### PR TITLE
fix(config): load config from global ~/.karajan instead of cwd

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import yaml from "js-yaml";
 import { ensureDir, exists } from "./utils/fs.js";
+import { getKarajanHome } from "./utils/paths.js";
 
 const DEFAULTS = {
   coder: "codex",
@@ -44,7 +45,7 @@ const DEFAULTS = {
   },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
-  session: { max_iteration_minutes: 5, max_total_minutes: 120, max_budget_usd: null, fail_fast_repeats: 2 }
+  session: { max_iteration_minutes: 15, max_total_minutes: 120, max_budget_usd: null, fail_fast_repeats: 2 }
 };
 
 function mergeDeep(base, override) {
@@ -61,12 +62,12 @@ function mergeDeep(base, override) {
   return output;
 }
 
-export function getConfigPath(cwd = process.cwd()) {
-  return path.join(cwd, "kj.config.yml");
+export function getConfigPath() {
+  return path.join(getKarajanHome(), "kj.config.yml");
 }
 
-export async function loadConfig(cwd = process.cwd()) {
-  const configPath = getConfigPath(cwd);
+export async function loadConfig() {
+  const configPath = getConfigPath();
   if (!(await exists(configPath))) {
     return { config: DEFAULTS, path: configPath, exists: false };
   }

--- a/templates/kj.config.yml
+++ b/templates/kj.config.yml
@@ -67,7 +67,7 @@ output:
 
 # Session limits
 session:
-  max_iteration_minutes: 5
+  max_iteration_minutes: 15
   max_total_minutes: 120
   max_budget_usd: null
   fail_fast_repeats: 2


### PR DESCRIPTION
## Summary
- Config se carga desde `~/.karajan/kj.config.yml` (global) en vez de buscar en el directorio actual
- Default `max_iteration_minutes` subido de 5 a 15 minutos
- Template actualizado

## Contexto
Cuando se ejecutaba `kj code` desde un proyecto sin `kj.config.yml`, usaba defaults con 5 min de timeout (insuficiente). La config debe ser global, no per-project.