### PR TITLE
feat(roles): add BaseRole abstraction with standardized lifecycle

### DIFF
--- a/src/roles/base-role.js
+++ b/src/roles/base-role.js
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getKarajanHome } from "../utils/paths.js";
+
+const ROLE_EVENTS = {
+  START: "role:start",
+  END: "role:end",
+  ERROR: "role:error"
+};
+
+function resolveRoleMdPath(roleName, projectDir) {
+  const fileName = `${roleName}.md`;
+  const candidates = [];
+
+  if (projectDir) {
+    candidates.push(path.join(projectDir, ".karajan", "roles", fileName));
+  }
+
+  candidates.push(path.join(getKarajanHome(), "roles", fileName));
+
+  const builtIn = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    "..",
+    "..",
+    "templates",
+    "roles",
+    fileName
+  );
+  candidates.push(builtIn);
+
+  return candidates;
+}
+
+async function loadFirstExisting(paths) {
+  for (const p of paths) {
+    try {
+      return await fs.readFile(p, "utf8");
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export class BaseRole {
+  constructor({ name, config, logger, emitter = null }) {
+    if (!name) throw new Error("Role name is required");
+    this.name = name;
+    this.config = config || {};
+    this.logger = logger;
+    this.emitter = emitter;
+    this.instructions = null;
+    this._initialized = false;
+    this._startTime = null;
+    this._output = null;
+  }
+
+  async init(context = {}) {
+    this.context = context;
+    const projectDir = this.config.projectDir || process.cwd();
+    const paths = resolveRoleMdPath(this.name, projectDir);
+    this.instructions = await loadFirstExisting(paths);
+    this._initialized = true;
+  }
+
+  async execute(_input) {
+    throw new Error(`${this.name}: execute() not implemented`);
+  }
+
+  report() {
+    return {
+      role: this.name,
+      ok: this._output?.ok ?? false,
+      result: this._output?.result ?? null,
+      summary: this._output?.summary ?? "",
+      timestamp: new Date().toISOString()
+    };
+  }
+
+  validate(output) {
+    if (!output) return { valid: false, reason: "Output is null or undefined" };
+    if (typeof output.ok !== "boolean") return { valid: false, reason: "Output.ok must be a boolean" };
+    return { valid: true, reason: "" };
+  }
+
+  async run(input) {
+    this._ensureInitialized();
+    this._startTime = Date.now();
+    this._emitEvent(ROLE_EVENTS.START, { input });
+
+    try {
+      const output = await this.execute(input);
+      this._output = output;
+
+      const validation = this.validate(output);
+      if (!validation.valid) {
+        throw new Error(`${this.name} output validation failed: ${validation.reason}`);
+      }
+
+      this._emitEvent(ROLE_EVENTS.END, { output: this.report() });
+      return output;
+    } catch (error) {
+      this._emitEvent(ROLE_EVENTS.ERROR, { error: error.message });
+      throw error;
+    }
+  }
+
+  _ensureInitialized() {
+    if (!this._initialized) {
+      throw new Error(`${this.name}: init() must be called before run()`);
+    }
+  }
+
+  _emitEvent(type, detail = {}) {
+    if (!this.emitter) return;
+    this.emitter.emit(type, {
+      role: this.name,
+      iteration: this.context?.iteration ?? 0,
+      sessionId: this.context?.sessionId ?? null,
+      elapsed: this._startTime ? Date.now() - this._startTime : 0,
+      timestamp: new Date().toISOString(),
+      ...detail
+    });
+  }
+}
+
+export { ROLE_EVENTS };

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -1,0 +1,1 @@
+export { BaseRole, ROLE_EVENTS } from "./base-role.js";

--- a/tests/base-role.test.js
+++ b/tests/base-role.test.js
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { BaseRole, ROLE_EVENTS } from "../src/roles/base-role.js";
+
+class TestRole extends BaseRole {
+  async execute(input) {
+    return { ok: true, result: { echo: input }, summary: "Test done" };
+  }
+}
+
+class FailingRole extends BaseRole {
+  async execute() {
+    throw new Error("Something broke");
+  }
+}
+
+class BadOutputRole extends BaseRole {
+  async execute() {
+    return { notOk: true };
+  }
+}
+
+describe("BaseRole", () => {
+  let emitter;
+  let logger;
+
+  beforeEach(() => {
+    emitter = new EventEmitter();
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+  });
+
+  it("throws if execute() is not implemented", async () => {
+    const role = new BaseRole({ name: "abstract", config: {}, logger });
+    await role.init();
+    await expect(role.run("test")).rejects.toThrow("execute() not implemented");
+  });
+
+  it("throws if run() called before init()", async () => {
+    const role = new TestRole({ name: "test", config: {}, logger });
+    await expect(role.run("input")).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("throws if name is missing", () => {
+    expect(() => new BaseRole({ config: {}, logger })).toThrow("Role name is required");
+  });
+
+  it("executes a role and returns output", async () => {
+    const role = new TestRole({ name: "test", config: {}, logger, emitter });
+    await role.init({ sessionId: "s1", iteration: 1 });
+    const output = await role.run("hello");
+    expect(output.ok).toBe(true);
+    expect(output.result.echo).toBe("hello");
+    expect(output.summary).toBe("Test done");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new TestRole({ name: "test", config: {}, logger, emitter });
+    await role.init({ sessionId: "s1", iteration: 2 });
+    await role.run("input");
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("test");
+    expect(events[0].iteration).toBe(2);
+    expect(events[1].type).toBe("end");
+    expect(events[1].role).toBe("test");
+  });
+
+  it("emits role:error on execute failure", async () => {
+    const errors = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => errors.push(e));
+
+    const role = new FailingRole({ name: "failing", config: {}, logger, emitter });
+    await role.init();
+    await expect(role.run("input")).rejects.toThrow("Something broke");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].role).toBe("failing");
+    expect(errors[0].error).toBe("Something broke");
+  });
+
+  it("emits role:error on validation failure", async () => {
+    const errors = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => errors.push(e));
+
+    const role = new BadOutputRole({ name: "bad", config: {}, logger, emitter });
+    await role.init();
+    await expect(role.run("input")).rejects.toThrow("output validation failed");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].error).toContain("Output.ok must be a boolean");
+  });
+
+  it("generates a report after successful execution", async () => {
+    const role = new TestRole({ name: "reporter", config: {}, logger });
+    await role.init();
+    await role.run("data");
+
+    const report = role.report();
+    expect(report.role).toBe("reporter");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBe("Test done");
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("validate() accepts valid output", () => {
+    const role = new BaseRole({ name: "v", config: {}, logger });
+    expect(role.validate({ ok: true }).valid).toBe(true);
+    expect(role.validate({ ok: false }).valid).toBe(true);
+  });
+
+  it("validate() rejects null output", () => {
+    const role = new BaseRole({ name: "v", config: {}, logger });
+    expect(role.validate(null).valid).toBe(false);
+  });
+
+  it("validate() rejects output without ok boolean", () => {
+    const role = new BaseRole({ name: "v", config: {}, logger });
+    expect(role.validate({ ok: "yes" }).valid).toBe(false);
+  });
+
+  it("works without emitter (no events, no crash)", async () => {
+    const role = new TestRole({ name: "silent", config: {}, logger });
+    await role.init();
+    const output = await role.run("data");
+    expect(output.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implementa la clase `BaseRole` (ADR-001) con lifecycle estandarizado: `init()` → `execute()` → `run()` → `report()` → `validate()`
- Resolución de ficheros `.md` de instrucciones por rol con orden: proyecto > usuario > built-in
- Emisión de eventos estándar (`role:start`, `role:end`, `role:error`) via EventEmitter
- Validación de output (requiere `ok: boolean`)
- 12 tests cubriendo todos los paths del lifecycle

## Test plan
- [x] Tests unitarios para BaseRole (12 tests)
- [x] Suite completa pasa (127 tests, 0 fallos)
- [x] Verificar que `execute()` no implementado lanza error
- [x] Verificar guard de `init()` antes de `run()`
- [x] Verificar emisión correcta de eventos start/end/error
- [x] Verificar validación de output