### PR TITLE
feat(roles): add ReviewerRole extending BaseRole

### DIFF
--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -1,2 +1,3 @@
 export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./base-role.js";
 export { PlannerRole } from "./planner-role.js";
+export { ReviewerRole } from "./reviewer-role.js";

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -1,0 +1,132 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const MAX_DIFF_LENGTH = 12000;
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on reviewing the code."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.reviewer?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function truncateDiff(diff) {
+  if (!diff) return "";
+  return diff.length > MAX_DIFF_LENGTH
+    ? `${diff.slice(0, MAX_DIFF_LENGTH)}\n\n[TRUNCATED]`
+    : diff;
+}
+
+function buildPrompt({ task, diff, reviewRules, reviewMode, instructions }) {
+  const sections = [];
+
+  sections.push(SUBAGENT_PREAMBLE);
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(`You are a code reviewer in ${reviewMode || "standard"} mode.`);
+  sections.push(
+    "Return only one valid JSON object and nothing else.",
+    'JSON schema:',
+    '{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}'
+  );
+
+  sections.push(`Task context:\n${task}`);
+
+  if (reviewRules) {
+    sections.push(`Review rules:\n${reviewRules}`);
+  }
+
+  sections.push(`Git diff:\n${truncateDiff(diff)}`);
+
+  return sections.join("\n\n");
+}
+
+function parseReviewOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(`Failed to parse reviewer output: no JSON found`);
+  }
+  return JSON.parse(jsonMatch[0]);
+}
+
+export class ReviewerRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "reviewer", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, diff, reviewRules, onOutput } = typeof input === "string"
+      ? { task: input, diff: "", reviewRules: null, onOutput: null }
+      : input;
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({
+      task: task || this.context?.task || "",
+      diff: diff || "",
+      reviewRules: reviewRules || null,
+      reviewMode: this.config?.review_mode || "standard",
+      instructions: this.instructions
+    });
+
+    const reviewArgs = { prompt, role: "reviewer" };
+    if (onOutput) reviewArgs.onOutput = onOutput;
+
+    const result = await agent.reviewTask(reviewArgs);
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Reviewer agent failed",
+          approved: false,
+          blocking_issues: []
+        },
+        summary: `Reviewer failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseReviewOutput(result.output);
+      const approved = Boolean(parsed.approved);
+      const blockingIssues = parsed.blocking_issues || [];
+
+      return {
+        ok: true,
+        result: {
+          approved,
+          blocking_issues: blockingIssues,
+          non_blocking_suggestions: parsed.non_blocking_suggestions || [],
+          confidence: parsed.confidence ?? null,
+          raw_summary: parsed.summary || ""
+        },
+        summary: approved
+          ? `Approved: ${parsed.summary || "no issues found"}`
+          : `Rejected: ${blockingIssues.length} blocking issue(s) — ${parsed.summary || ""}`
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        result: {
+          error: `Failed to parse reviewer output: ${err.message}`,
+          approved: false,
+          blocking_issues: []
+        },
+        summary: `Reviewer output parse error: ${err.message}`
+      };
+    }
+  }
+}

--- a/tests/reviewer-role.test.js
+++ b/tests/reviewer-role.test.js
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ReviewerRole } from "../src/roles/reviewer-role.js";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("ReviewerRole", () => {
+  let emitter;
+
+  beforeEach(() => {
+    emitter = new EventEmitter();
+  });
+
+  it("extends BaseRole and has name 'reviewer'", () => {
+    const role = new ReviewerRole({ config: {}, logger });
+    expect(role.name).toBe("reviewer");
+  });
+
+  it("returns approved review on successful execution", async () => {
+    const reviewJson = JSON.stringify({
+      approved: true,
+      blocking_issues: [],
+      non_blocking_suggestions: ["Consider adding JSDoc"],
+      summary: "Code looks good",
+      confidence: 0.95
+    });
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: reviewJson })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: { review_mode: "standard" }, logger, createAgentFn: createAgent });
+    await role.init({ task: "Add login" });
+    const output = await role.run({ task: "Add login", diff: "diff --git a/test" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.approved).toBe(true);
+    expect(output.result.blocking_issues).toHaveLength(0);
+  });
+
+  it("returns rejected review with blocking issues", async () => {
+    const reviewJson = JSON.stringify({
+      approved: false,
+      blocking_issues: [{ id: "1", severity: "critical", file: "src/x.js", line: 10, description: "SQL injection" }],
+      non_blocking_suggestions: [],
+      summary: "Critical security issue",
+      confidence: 0.9
+    });
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: reviewJson })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, createAgentFn: createAgent });
+    await role.init({ task: "Feature" });
+    const output = await role.run({ task: "Feature", diff: "diff content" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.approved).toBe(false);
+    expect(output.result.blocking_issues).toHaveLength(1);
+    expect(output.result.blocking_issues[0].severity).toBe("critical");
+  });
+
+  it("returns ok=false when agent fails entirely", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({ ok: false, error: "Agent crashed" })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, createAgentFn: createAgent });
+    await role.init({ task: "Task" });
+    const output = await role.run({ task: "Task", diff: "diff" });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent crashed");
+  });
+
+  it("returns ok=false when agent output is not valid JSON", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: "This is not JSON at all" })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, createAgentFn: createAgent });
+    await role.init({ task: "Task" });
+    const output = await role.run({ task: "Task", diff: "diff" });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("parse");
+  });
+
+  it("includes review rules and instructions in prompt", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "OK", confidence: 1 })
+      })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({
+      config: { review_rules: "No console.log in production" },
+      logger,
+      createAgentFn: createAgent
+    });
+    await role.init({ task: "Task" });
+    await role.run({ task: "Task", diff: "diff", reviewRules: "No console.log" });
+
+    const prompt = fakeAgent.reviewTask.mock.calls[0][0].prompt;
+    expect(prompt).toContain("No console.log");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "OK", confidence: 1 })
+      })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, emitter, createAgentFn: createAgent });
+    await role.init({ task: "Task", iteration: 2 });
+    await role.run({ task: "Task", diff: "diff" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("reviewer");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("resolves provider from config roles.reviewer", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "OK", confidence: 1 })
+      })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const config = { roles: { reviewer: { provider: "claude" } } };
+    const role = new ReviewerRole({ config, logger, createAgentFn: createAgent });
+    await role.init({ task: "Task" });
+    await role.run({ task: "Task", diff: "diff" });
+
+    expect(createAgent).toHaveBeenCalledWith("claude", config, logger);
+  });
+
+  it("report() returns structured reviewer report", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "All good", confidence: 0.95 })
+      })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, createAgentFn: createAgent });
+    await role.init({ task: "Task" });
+    await role.run({ task: "Task", diff: "diff" });
+
+    const report = role.report();
+    expect(report.role).toBe("reviewer");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toContain("Approved");
+  });
+
+  it("truncates large diffs", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "OK", confidence: 1 })
+      })
+    };
+    const createAgent = vi.fn().mockReturnValue(fakeAgent);
+
+    const role = new ReviewerRole({ config: {}, logger, createAgentFn: createAgent });
+    await role.init({ task: "Task" });
+    const largeDiff = "x".repeat(15000);
+    await role.run({ task: "Task", diff: largeDiff });
+
+    const prompt = fakeAgent.reviewTask.mock.calls[0][0].prompt;
+    expect(prompt).toContain("[TRUNCATED]");
+  });
+});


### PR DESCRIPTION
## Summary
- Implementa `ReviewerRole` extendiendo `BaseRole` con lifecycle estandarizado
- Construye prompt con preamble de sub-agente, truncado de diff (12K), review rules e instrucciones de `reviewer.md`
- Parsea salida JSON del agente y devuelve resultado estructurado: `approved`, `blocking_issues`, `suggestions`, `confidence`
- Gestiona errores de agente y errores de parseo como `ok: false`
- Re-exporta desde `src/roles/index.js`

## Test plan
- [x] 10 tests unitarios para ReviewerRole
- [x] Suite completa: 165 tests, 0 fallos
- [x] Verificar review aprobado y rechazado con blocking issues
- [x] Verificar manejo de output no-JSON
- [x] Verificar truncado de diffs grandes
- [x] Verificar emisión de eventos