### PR TITLE
feat: add kj sonar open command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ import { reportCommand } from "./commands/report.js";
 import { planCommand } from "./commands/plan.js";
 import { runCommandHandler } from "./commands/run.js";
 import { resumeCommand } from "./commands/resume.js";
-import { sonarCommand } from "./commands/sonar.js";
+import { sonarCommand, sonarOpenCommand } from "./commands/sonar.js";
 
 async function withConfig(commandName, flags, fn) {
   const { config } = await loadConfig();
@@ -152,6 +152,18 @@ sonar.command("status").action(async () => sonarCommand({ action: "status" }));
 sonar.command("start").action(async () => sonarCommand({ action: "start" }));
 sonar.command("stop").action(async () => sonarCommand({ action: "stop" }));
 sonar.command("logs").action(async () => sonarCommand({ action: "logs" }));
+sonar
+  .command("open")
+  .description("Open SonarQube dashboard in the browser")
+  .action(async () => {
+    const { config } = await loadConfig();
+    const result = await sonarOpenCommand({ config });
+    if (!result.ok) {
+      console.error(result.error);
+      process.exit(1);
+    }
+    console.log(`Opened ${result.url}`);
+  });
 
 program.parseAsync().catch((error) => {
   console.error(error.message);

--- a/src/commands/sonar.js
+++ b/src/commands/sonar.js
@@ -1,4 +1,33 @@
-import { sonarDown, sonarLogs, sonarStatus, sonarUp } from "../sonar/manager.js";
+import os from "node:os";
+import { sonarDown, sonarLogs, sonarStatus, sonarUp, isSonarReachable } from "../sonar/manager.js";
+import { resolveSonarProjectKey } from "../sonar/project-key.js";
+import { runCommand } from "../utils/process.js";
+
+function openBrowserCmd() {
+  const platform = os.platform();
+  if (platform === "darwin") return "open";
+  if (platform === "win32") return "start";
+  return "xdg-open";
+}
+
+export async function sonarOpenCommand({ config }) {
+  const host = config?.sonarqube?.host || "http://localhost:9000";
+
+  if (!(await isSonarReachable(host))) {
+    return { ok: false, error: `SonarQube is not reachable at ${host}. Run 'kj sonar start' first.` };
+  }
+
+  let projectKey;
+  try {
+    projectKey = await resolveSonarProjectKey(config);
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+
+  const url = `${host}/dashboard?id=${projectKey}`;
+  await runCommand(openBrowserCmd(), [url]);
+  return { ok: true, url };
+}
 
 export async function sonarCommand({ action }) {
   if (action === "start") {

--- a/src/sonar/manager.js
+++ b/src/sonar/manager.js
@@ -39,7 +39,7 @@ export async function ensureComposeFile() {
   return COMPOSE_PATH;
 }
 
-async function isSonarReachable(host) {
+export async function isSonarReachable(host) {
   const res = await runCommand("curl", ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", `${host}/api/system/status`]);
   return res.exitCode === 0 && res.stdout.trim().startsWith("2");
 }

--- a/tests/sonar-open.test.js
+++ b/tests/sonar-open.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/sonar/manager.js", () => ({
+  isSonarReachable: vi.fn()
+}));
+
+vi.mock("../src/sonar/project-key.js", () => ({
+  resolveSonarProjectKey: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  loadConfig: vi.fn()
+}));
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" })
+}));
+
+describe("sonarOpenCommand", () => {
+  let sonarOpenCommand;
+  let isSonarReachable;
+  let resolveSonarProjectKey;
+  let loadConfig;
+  let runCommand;
+
+  const baseConfig = {
+    sonarqube: { host: "http://localhost:9000", project_key: null }
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const managerMod = await import("../src/sonar/manager.js");
+    isSonarReachable = managerMod.isSonarReachable;
+
+    const pkMod = await import("../src/sonar/project-key.js");
+    resolveSonarProjectKey = pkMod.resolveSonarProjectKey;
+
+    const configMod = await import("../src/config.js");
+    loadConfig = configMod.loadConfig;
+    loadConfig.mockResolvedValue({ config: baseConfig });
+
+    const procMod = await import("../src/utils/process.js");
+    runCommand = procMod.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    const mod = await import("../src/commands/sonar.js");
+    sonarOpenCommand = mod.sonarOpenCommand;
+  });
+
+  it("returns dashboard URL when SonarQube is reachable", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    resolveSonarProjectKey.mockResolvedValue("kj-my-project-abc123");
+
+    const result = await sonarOpenCommand({ config: baseConfig });
+
+    expect(result.ok).toBe(true);
+    expect(result.url).toBe("http://localhost:9000/dashboard?id=kj-my-project-abc123");
+    expect(runCommand).toHaveBeenCalled();
+  });
+
+  it("uses config host for the URL", async () => {
+    const config = { sonarqube: { host: "http://sonar.example.com:9000" } };
+    isSonarReachable.mockResolvedValue(true);
+    resolveSonarProjectKey.mockResolvedValue("my-project");
+
+    const result = await sonarOpenCommand({ config });
+
+    expect(result.url).toBe("http://sonar.example.com:9000/dashboard?id=my-project");
+  });
+
+  it("returns error when SonarQube is not reachable", async () => {
+    isSonarReachable.mockResolvedValue(false);
+
+    const result = await sonarOpenCommand({ config: baseConfig });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not reachable|no está disponible/i);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns error when project key resolution fails", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    resolveSonarProjectKey.mockRejectedValue(new Error("Missing git remote"));
+
+    const result = await sonarOpenCommand({ config: baseConfig });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Missing git remote/);
+  });
+
+  it("defaults host to localhost:9000 when not configured", async () => {
+    const config = { sonarqube: {} };
+    isSonarReachable.mockResolvedValue(true);
+    resolveSonarProjectKey.mockResolvedValue("kj-test");
+
+    const result = await sonarOpenCommand({ config });
+
+    expect(result.url).toBe("http://localhost:9000/dashboard?id=kj-test");
+    expect(isSonarReachable).toHaveBeenCalledWith("http://localhost:9000");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `kj sonar open` subcommand that opens the SonarQube dashboard in the default browser
- Checks SonarQube reachability before attempting to open; shows error suggesting `kj sonar start` if unavailable
- Resolves project key automatically from config/git remote
- Cross-platform browser opening (xdg-open / open / start)
- Export `isSonarReachable` from `sonar/manager.js` for reuse

## Test plan
- [x] 5 new tests in `tests/sonar-open.test.js`
- [x] All 200 tests pass with no regressions