### PR TITLE
feat: add kj config --edit interactive editing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -36,6 +36,7 @@ program
   .command("config")
   .description("Show current config")
   .option("--json", "Show as JSON")
+  .option("--edit", "Open config in $EDITOR for editing")
   .action(async (flags) => {
     await configCommand(flags);
   });

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,13 +1,74 @@
-import { loadConfig } from "../config.js";
+import fs from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import yaml from "js-yaml";
+import { loadConfig, validateConfig, getConfigPath, writeConfig } from "../config.js";
+import { ensureDir } from "../utils/fs.js";
+import path from "node:path";
 
-export async function configCommand({ json = false }) {
-  const { config, path, exists } = await loadConfig();
-  if (json) {
-    console.log(JSON.stringify({ path, exists, config }, null, 2));
+function resolveEditor() {
+  const raw = process.env.VISUAL || process.env.EDITOR || "vi";
+  const parts = raw.split(/\s+/);
+  return { cmd: parts[0], args: parts.slice(1) };
+}
+
+export async function editConfigOnce(configPath) {
+  const { cmd, args } = resolveEditor();
+  const result = spawnSync(cmd, [...args, configPath], { stdio: "inherit" });
+
+  if (result.status !== 0) {
+    return { ok: false, error: `Editor exited with code ${result.status}` };
+  }
+
+  let raw;
+  try {
+    raw = await fs.readFile(configPath, "utf8");
+  } catch (err) {
+    return { ok: false, error: `Could not read config: ${err.message}` };
+  }
+
+  let parsed;
+  try {
+    parsed = yaml.load(raw);
+  } catch (err) {
+    return { ok: false, error: `Invalid YAML: ${err.message}` };
+  }
+
+  try {
+    validateConfig(parsed || {});
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+
+  return { ok: true, config: parsed };
+}
+
+export async function configCommand({ json = false, edit = false }) {
+  if (edit) {
+    const configPath = getConfigPath();
+    await ensureDir(path.dirname(configPath));
+    const { exists: configExists } = await loadConfig();
+    if (!configExists) {
+      const { config: defaults } = await loadConfig();
+      await writeConfig(configPath, defaults);
+    }
+
+    const result = await editConfigOnce(configPath);
+    if (result.ok) {
+      console.log("Configuration saved and validated.");
+    } else {
+      console.error(`Validation error: ${result.error}`);
+      process.exitCode = 1;
+    }
     return;
   }
 
-  console.log(`Config path: ${path}`);
+  const { config, path: cfgPath, exists } = await loadConfig();
+  if (json) {
+    console.log(JSON.stringify({ path: cfgPath, exists, config }, null, 2));
+    return;
+  }
+
+  console.log(`Config path: ${cfgPath}`);
   console.log(`Exists: ${exists}`);
   console.log(JSON.stringify(config, null, 2));
 }

--- a/tests/config-edit.test.js
+++ b/tests/config-edit.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import yaml from "js-yaml";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0 }))
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  ensureDir: vi.fn(),
+  exists: vi.fn().mockResolvedValue(true)
+}));
+
+describe("editConfigOnce", () => {
+  let editConfigOnce;
+  let fs;
+  let spawnSync;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const fsMod = await import("node:fs/promises");
+    fs = fsMod.default;
+
+    const cpMod = await import("node:child_process");
+    spawnSync = cpMod.spawnSync;
+    spawnSync.mockReturnValue({ status: 0 });
+
+    const mod = await import("../src/commands/config.js");
+    editConfigOnce = mod.editConfigOnce;
+  });
+
+  it("opens editor and returns ok when config is valid", async () => {
+    const validYaml = yaml.dump({
+      coder: "claude",
+      reviewer: "codex",
+      review_mode: "standard",
+      max_iterations: 5,
+      development: { methodology: "tdd" }
+    });
+    fs.readFile.mockResolvedValue(validYaml);
+
+    const result = await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+    expect(result.config).toBeTruthy();
+  });
+
+  it("uses VISUAL env var first for editor", async () => {
+    const orig = { VISUAL: process.env.VISUAL, EDITOR: process.env.EDITOR };
+    process.env.VISUAL = "code --wait";
+    process.env.EDITOR = "nano";
+
+    fs.readFile.mockResolvedValue(yaml.dump({ coder: "claude", reviewer: "codex", review_mode: "standard", development: { methodology: "tdd" } }));
+
+    await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "code",
+      expect.arrayContaining(["--wait", "/tmp/kj.config.yml"]),
+      expect.any(Object)
+    );
+
+    process.env.VISUAL = orig.VISUAL;
+    process.env.EDITOR = orig.EDITOR;
+  });
+
+  it("falls back to EDITOR when VISUAL is not set", async () => {
+    const orig = { VISUAL: process.env.VISUAL, EDITOR: process.env.EDITOR };
+    delete process.env.VISUAL;
+    process.env.EDITOR = "nano";
+
+    fs.readFile.mockResolvedValue(yaml.dump({ coder: "claude", reviewer: "codex", review_mode: "standard", development: { methodology: "tdd" } }));
+
+    await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "nano",
+      ["/tmp/kj.config.yml"],
+      expect.any(Object)
+    );
+
+    process.env.VISUAL = orig.VISUAL;
+    process.env.EDITOR = orig.EDITOR;
+  });
+
+  it("returns error when editor exits with non-zero", async () => {
+    spawnSync.mockReturnValue({ status: 1 });
+
+    const result = await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/editor exited/i);
+  });
+
+  it("returns error when YAML is invalid", async () => {
+    fs.readFile.mockResolvedValue("invalid: yaml: [broken");
+
+    const result = await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/YAML/i);
+  });
+
+  it("returns error when config validation fails", async () => {
+    const invalidConfig = yaml.dump({
+      coder: "claude",
+      reviewer: "codex",
+      review_mode: "invalid_mode",
+      development: { methodology: "tdd" }
+    });
+    fs.readFile.mockResolvedValue(invalidConfig);
+
+    const result = await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/review_mode/i);
+  });
+
+  it("returns error when saved file cannot be read", async () => {
+    fs.readFile.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await editConfigOnce("/tmp/kj.config.yml");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ENOENT/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--edit` flag to `kj config` command that opens `kj.config.yml` in `$VISUAL`/`$EDITOR`/`vi`
- After saving, validates YAML syntax and config schema (review_mode, methodology, etc.)
- Reports validation errors with non-zero exit code
- Creates default config file if none exists before opening editor
- Handles editors with args (e.g. `code --wait`)

## Test plan
- [x] 7 new tests in `tests/config-edit.test.js` covering:
  - Valid config round-trip
  - `$VISUAL` priority over `$EDITOR`
  - `$EDITOR` fallback
  - Editor non-zero exit handling
  - Invalid YAML detection
  - Config validation failure (bad review_mode)
  - File read error handling
- [x] All 207 tests pass with no regressions