### PR TITLE
feat: configurable sub-loop limits with solomon:escalate

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,8 @@ const DEFAULTS = {
   },
   pipeline: {
     planner: { enabled: false },
-    refactorer: { enabled: false }
+    refactorer: { enabled: false },
+    solomon: { enabled: false }
   },
   review_mode: "standard",
   max_iterations: 5,
@@ -73,7 +74,18 @@ const DEFAULTS = {
   },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
-  session: { max_iteration_minutes: 15, max_total_minutes: 120, max_budget_usd: null, fail_fast_repeats: 2 }
+  session: {
+    max_iteration_minutes: 15,
+    max_total_minutes: 120,
+    max_budget_usd: null,
+    fail_fast_repeats: 2,
+    repeat_detection_threshold: 2,
+    max_sonar_retries: 3,
+    max_reviewer_retries: 3
+  },
+  failFast: {
+    repeatThreshold: 2
+  }
 };
 
 function mergeDeep(base, override) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -89,6 +89,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     session_start_sha: baseRef,
     last_reviewer_feedback: null,
     repeated_issue_count: 0,
+    sonar_retry_count: 0,
+    reviewer_retry_count: 0,
     last_sonar_issue_signature: null,
     sonar_repeat_count: 0,
     last_reviewer_issue_signature: null,
@@ -412,15 +414,23 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         }
 
         session.last_reviewer_feedback = `Sonar gate blocking (${gate.status}). Resolve critical findings first.`;
-        session.repeated_issue_count += 1;
+        session.sonar_retry_count = (session.sonar_retry_count || 0) + 1;
         await saveSession(session);
-        if (session.repeated_issue_count >= config.session.fail_fast_repeats) {
-          const question = `SonarQube quality gate has failed ${session.repeated_issue_count} times (${gate.status}). What should we do?`;
+        const maxSonarRetries = config.session.max_sonar_retries ?? config.session.fail_fast_repeats;
+        if (session.sonar_retry_count >= maxSonarRetries) {
+          emitProgress(
+            emitter,
+            makeEvent("solomon:escalate", { ...eventBase, stage: "sonar" }, {
+              message: `Sonar sub-loop limit reached (${session.sonar_retry_count}/${maxSonarRetries})`,
+              detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus: gate.status }
+            })
+          );
+          const question = `SonarQube quality gate has failed ${session.sonar_retry_count} times (${gate.status}). What should we do?`;
           if (askQuestion) {
             const answer = await askQuestion(question, { iteration: i, stage: "sonar" });
             if (answer) {
               session.last_reviewer_feedback += `\nUser guidance: ${answer}`;
-              session.repeated_issue_count = 0;
+              session.sonar_retry_count = 0;
               await saveSession(session);
               continue;
             }
@@ -432,7 +442,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
               stage: "sonar",
               gateStatus: gate.status,
               openIssues: issues.total,
-              repeatedCount: session.repeated_issue_count
+              retryCount: session.sonar_retry_count
             }
           });
           emitProgress(
@@ -447,6 +457,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         }
         continue;
       }
+
+      // Sonar passed — reset retry counter
+      session.sonar_retry_count = 0;
     }
 
     // --- Reviewer ---
@@ -566,6 +579,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     );
 
     if (review.approved) {
+      session.reviewer_retry_count = 0;
       const gitResult = await finalizeGitAutomation({ config, gitCtx, task, logger, session });
       await markSessionStatus(session, "approved");
       emitProgress(
@@ -581,16 +595,24 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     session.last_reviewer_feedback = review.blocking_issues
       .map((x) => `${x.id || "ISSUE"}: ${x.description || "Missing description"}`)
       .join("\n");
-    session.repeated_issue_count += 1;
+    session.reviewer_retry_count = (session.reviewer_retry_count || 0) + 1;
     await saveSession(session);
 
-    if (session.repeated_issue_count >= config.session.fail_fast_repeats) {
-      const question = `Reviewer has rejected ${session.repeated_issue_count} times with the same issues. Blocking issues:\n${session.last_reviewer_feedback}\n\nHow should we proceed?`;
+    const maxReviewerRetries = config.session.max_reviewer_retries ?? config.session.fail_fast_repeats;
+    if (session.reviewer_retry_count >= maxReviewerRetries) {
+      emitProgress(
+        emitter,
+        makeEvent("solomon:escalate", { ...eventBase, stage: "reviewer" }, {
+          message: `Reviewer sub-loop limit reached (${session.reviewer_retry_count}/${maxReviewerRetries})`,
+          detail: { subloop: "reviewer", retryCount: session.reviewer_retry_count, limit: maxReviewerRetries }
+        })
+      );
+      const question = `Reviewer has rejected ${session.reviewer_retry_count} times with the same issues. Blocking issues:\n${session.last_reviewer_feedback}\n\nHow should we proceed?`;
       if (askQuestion) {
         const answer = await askQuestion(question, { iteration: i, stage: "reviewer" });
         if (answer) {
           session.last_reviewer_feedback += `\nUser guidance: ${answer}`;
-          session.repeated_issue_count = 0;
+          session.reviewer_retry_count = 0;
           await saveSession(session);
           continue;
         }
@@ -601,7 +623,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           iteration: i,
           stage: "reviewer",
           lastFeedback: session.last_reviewer_feedback,
-          repeatedCount: session.repeated_issue_count
+          retryCount: session.reviewer_retry_count
         }
       });
       emitProgress(
@@ -657,6 +679,8 @@ export async function resumeFlow({ sessionId, answer, config, logger, flags = {}
     session.last_reviewer_feedback = `Previous feedback: ${session.paused_state.context.lastFeedback}\nUser guidance: ${answer}`;
   }
   session.repeated_issue_count = 0;
+  session.sonar_retry_count = 0;
+  session.reviewer_retry_count = 0;
   session.last_sonar_issue_signature = null;
   session.sonar_repeat_count = 0;
   session.last_reviewer_issue_signature = null;

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -1,0 +1,285 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+const REVIEW_REJECTED = JSON.stringify({
+  approved: false,
+  blocking_issues: [{ id: "B1", severity: "high", description: "Bug found" }],
+  non_blocking_suggestions: [],
+  summary: "Rejected",
+  confidence: 0.9
+});
+
+const REVIEW_OK = JSON.stringify({
+  approved: true,
+  blocking_issues: [],
+  non_blocking_suggestions: [],
+  summary: "OK",
+  confidence: 0.9
+});
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => {
+  let session = null;
+  return {
+    createSession: vi.fn(async (initial) => {
+      session = { id: "s_test", status: "running", checkpoints: [], ...initial };
+      return session;
+    }),
+    saveSession: vi.fn(async () => {}),
+    loadSession: vi.fn(async () => session),
+    addCheckpoint: vi.fn(async (s, cp) => { s.checkpoints.push(cp); }),
+    markSessionStatus: vi.fn(async (s, status) => { s.status = status; }),
+    pauseSession: vi.fn(async (s, data) => { s.status = "paused"; s.paused_state = data; }),
+    resumeSessionWithAnswer: vi.fn(async () => session)
+  };
+});
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  generateDiff: vi.fn().mockResolvedValue("diff content")
+}));
+
+vi.mock("../src/review/schema.js", () => ({
+  validateReviewResult: vi.fn((r) => r)
+}));
+
+vi.mock("../src/review/tdd-policy.js", () => ({
+  evaluateTddPolicy: vi.fn().mockReturnValue({ ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" })
+}));
+
+vi.mock("../src/prompts/coder.js", () => ({
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+}));
+
+vi.mock("../src/prompts/reviewer.js", () => ({
+  buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn().mockResolvedValue({ status: "ERROR" }),
+  getOpenIssues: vi.fn().mockResolvedValue({ total: 2, issues: [{ key: "i1" }] })
+}));
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn().mockResolvedValue({ ok: true, projectKey: "test-key" })
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  shouldBlockByProfile: vi.fn().mockReturnValue(true),
+  summarizeIssues: vi.fn().mockReturnValue("2 issues")
+}));
+
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn().mockResolvedValue(true),
+  currentBranch: vi.fn().mockResolvedValue("feat/test"),
+  fetchBase: vi.fn(),
+  syncBaseBranch: vi.fn(),
+  ensureBranchUpToDateWithBase: vi.fn(),
+  createBranch: vi.fn(),
+  buildBranchName: vi.fn().mockReturnValue("feat/test"),
+  commitAll: vi.fn().mockResolvedValue({ committed: true }),
+  pushBranch: vi.fn(),
+  createPullRequest: vi.fn()
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("role instructions"),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    coder: "codex",
+    reviewer: "claude",
+    review_mode: "standard",
+    max_iterations: 10,
+    base_branch: "main",
+    roles: {
+      planner: { provider: null },
+      coder: { provider: "codex" },
+      reviewer: { provider: "claude" },
+      refactorer: { provider: null }
+    },
+    pipeline: { planner: { enabled: false }, refactorer: { enabled: false }, solomon: { enabled: false } },
+    coder_options: { auto_approve: true },
+    reviewer_options: { retries: 0 },
+    development: { methodology: "tdd", require_test_changes: true },
+    sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" },
+    git: { auto_commit: false, auto_push: false, auto_pr: false },
+    session: {
+      max_iteration_minutes: 15,
+      max_total_minutes: 120,
+      fail_fast_repeats: 2,
+      repeat_detection_threshold: 99,
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3,
+      ...overrides
+    },
+    failFast: { repeatThreshold: 99 },
+    output: { log_level: "error" }
+  };
+}
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+describe("configurable sub-loop limits", () => {
+  let runFlow;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK })
+    });
+
+    const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
+    evaluateTddPolicy.mockReturnValue({ ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" });
+
+    const { computeBaseRef, generateDiff } = await import("../src/review/diff-generator.js");
+    computeBaseRef.mockResolvedValue("abc123");
+    generateDiff.mockResolvedValue("diff content");
+
+    const { validateReviewResult } = await import("../src/review/schema.js");
+    validateReviewResult.mockImplementation((r) => r);
+
+    const { runSonarScan } = await import("../src/sonar/scanner.js");
+    runSonarScan.mockResolvedValue({ ok: true, projectKey: "test-key" });
+
+    const { getQualityGateStatus, getOpenIssues } = await import("../src/sonar/api.js");
+    getQualityGateStatus.mockResolvedValue({ status: "ERROR" });
+    getOpenIssues.mockResolvedValue({ total: 2, issues: [{ key: "i1" }] });
+
+    const { shouldBlockByProfile, summarizeIssues } = await import("../src/sonar/enforcer.js");
+    shouldBlockByProfile.mockReturnValue(true);
+    summarizeIssues.mockReturnValue("2 issues");
+
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    buildCoderPrompt.mockReturnValue("coder prompt");
+
+    const { buildReviewerPrompt } = await import("../src/prompts/reviewer.js");
+    buildReviewerPrompt.mockReturnValue("reviewer prompt");
+
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockResolvedValue("role instructions");
+
+    const mod = await import("../src/orchestrator.js");
+    runFlow = mod.runFlow;
+  });
+
+  it("emits solomon:escalate when sonar sub-loop limit is reached", async () => {
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig({ max_sonar_retries: 2 });
+
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
+    expect(solomonEvents.length).toBe(1);
+    expect(solomonEvents[0].detail.subloop).toBe("sonar");
+    expect(solomonEvents[0].detail.retryCount).toBe(2);
+    expect(solomonEvents[0].detail.limit).toBe(2);
+    expect(result.paused).toBe(true);
+    expect(result.context).toBe("sonar_fail_fast");
+  });
+
+  it("sonar retries respect max_sonar_retries independently from fail_fast_repeats", async () => {
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    // max_sonar_retries=3, fail_fast_repeats=2 — sonar should use 3, not 2
+    const config = makeConfig({ max_sonar_retries: 3, fail_fast_repeats: 2 });
+
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
+    expect(solomonEvents[0].detail.retryCount).toBe(3);
+    expect(solomonEvents[0].detail.limit).toBe(3);
+  });
+
+  it("emits solomon:escalate when reviewer sub-loop limit is reached", async () => {
+    // Make sonar pass, reviewer reject
+    const { shouldBlockByProfile } = await import("../src/sonar/enforcer.js");
+    shouldBlockByProfile.mockReturnValue(false);
+
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_REJECTED })
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig({ max_reviewer_retries: 2 });
+
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
+    expect(solomonEvents.length).toBe(1);
+    expect(solomonEvents[0].detail.subloop).toBe("reviewer");
+    expect(solomonEvents[0].detail.retryCount).toBe(2);
+    expect(result.paused).toBe(true);
+    expect(result.context).toBe("reviewer_fail_fast");
+  });
+
+  it("reviewer retries respect max_reviewer_retries independently", async () => {
+    const { shouldBlockByProfile } = await import("../src/sonar/enforcer.js");
+    shouldBlockByProfile.mockReturnValue(false);
+
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_REJECTED })
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig({ max_reviewer_retries: 4, fail_fast_repeats: 2 });
+
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
+    expect(solomonEvents[0].detail.retryCount).toBe(4);
+    expect(solomonEvents[0].detail.limit).toBe(4);
+  });
+
+  it("sonar counter resets when sonar passes after failures", async () => {
+    const { shouldBlockByProfile } = await import("../src/sonar/enforcer.js");
+    // Sonar blocks on iter 1, passes on iter 2
+    let sonarCallCount = 0;
+    shouldBlockByProfile.mockImplementation(() => {
+      sonarCallCount += 1;
+      return sonarCallCount <= 1;
+    });
+
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK })
+    });
+
+    const { validateReviewResult } = await import("../src/review/schema.js");
+    validateReviewResult.mockImplementation((r) => r);
+
+    const config = makeConfig({ max_sonar_retries: 3 });
+
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger });
+
+    // Should succeed: sonar blocked once, then passed, reviewer approved
+    expect(result.approved).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Split shared `repeated_issue_count` into independent `sonar_retry_count` and `reviewer_retry_count` with separate configurable limits (`session.max_sonar_retries`, `session.max_reviewer_retries`)
- Emit `solomon:escalate` progress event when a sub-loop limit is reached, providing a hook for the future Solomon arbitration role (KJC-TSK-0033)
- Counters reset when respective stage passes (sonar passes → reset sonar counter, reviewer approves → reset reviewer counter)
- Add `pipeline.solomon.enabled` config field (defaults to `false`)
- TDD retry tracking unchanged (uses existing `repeated_issue_count` / `fail_fast_repeats`)

## Config changes
```yaml
session:
  max_sonar_retries: 3      # Independent sonar sub-loop limit
  max_reviewer_retries: 3   # Independent reviewer sub-loop limit
pipeline:
  solomon:
    enabled: false           # Hook for future Solomon role
```

## Test plan
- [x] 5 new tests in `tests/subloop-limits.test.js`:
  - solomon:escalate emitted on sonar limit
  - sonar retries independent from fail_fast_repeats
  - solomon:escalate emitted on reviewer limit
  - reviewer retries independent from fail_fast_repeats
  - sonar counter resets after sonar passes
- [x] All 212 tests pass with no regressions