### PR TITLE
test: add tests for prompt builders (coder.js, reviewer.js)

### DIFF
--- a/tests/prompt-coder.test.js
+++ b/tests/prompt-coder.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { buildCoderPrompt } from "../src/prompts/coder.js";
+
+describe("buildCoderPrompt", () => {
+  it("includes task and default TDD instructions", () => {
+    const result = buildCoderPrompt({ task: "Add login feature" });
+
+    expect(result).toContain("Task:\nAdd login feature");
+    expect(result).toContain("Default development policy: TDD");
+    expect(result).toContain("Add or update failing tests first");
+    expect(result).toContain("Implement minimal code to make tests pass");
+    expect(result).toContain("Refactor safely while keeping tests green");
+  });
+
+  it("includes subagent preamble", () => {
+    const result = buildCoderPrompt({ task: "Fix bug" });
+
+    expect(result).toContain("You are running as a Karajan sub-agent");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
+
+  it("omits TDD instructions when methodology is not tdd", () => {
+    const result = buildCoderPrompt({ task: "Fix bug", methodology: "standard" });
+
+    expect(result).not.toContain("Default development policy: TDD");
+    expect(result).toContain("Task:\nFix bug");
+  });
+
+  it("includes coder rules when provided", () => {
+    const result = buildCoderPrompt({
+      task: "Refactor module",
+      coderRules: "Always use arrow functions"
+    });
+
+    expect(result).toContain("Coder rules (MUST follow):\nAlways use arrow functions");
+  });
+
+  it("includes sonar summary when provided", () => {
+    const result = buildCoderPrompt({
+      task: "Fix issues",
+      sonarSummary: "3 blocker issues found in auth.js"
+    });
+
+    expect(result).toContain("Sonar summary:\n3 blocker issues found in auth.js");
+  });
+
+  it("includes reviewer feedback when provided", () => {
+    const result = buildCoderPrompt({
+      task: "Update API",
+      reviewerFeedback: "Missing input validation on POST /users"
+    });
+
+    expect(result).toContain("Reviewer blocking feedback:\nMissing input validation on POST /users");
+  });
+
+  it("includes all optional sections together", () => {
+    const result = buildCoderPrompt({
+      task: "Complete rewrite",
+      coderRules: "Follow SOLID",
+      sonarSummary: "2 critical issues",
+      reviewerFeedback: "Tests missing for edge case",
+      methodology: "tdd"
+    });
+
+    expect(result).toContain("Task:\nComplete rewrite");
+    expect(result).toContain("Coder rules (MUST follow):\nFollow SOLID");
+    expect(result).toContain("Default development policy: TDD");
+    expect(result).toContain("Sonar summary:\n2 critical issues");
+    expect(result).toContain("Reviewer blocking feedback:\nTests missing for edge case");
+  });
+
+  it("sections are separated by double newlines", () => {
+    const result = buildCoderPrompt({
+      task: "Test task",
+      sonarSummary: "issue",
+      reviewerFeedback: "feedback"
+    });
+
+    const sections = result.split("\n\n");
+    expect(sections.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("omits null/undefined optional sections", () => {
+    const result = buildCoderPrompt({
+      task: "Simple task",
+      coderRules: null,
+      sonarSummary: undefined,
+      reviewerFeedback: null
+    });
+
+    expect(result).not.toContain("Coder rules");
+    expect(result).not.toContain("Sonar summary");
+    expect(result).not.toContain("Reviewer blocking feedback");
+  });
+});

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { buildReviewerPrompt } from "../src/prompts/reviewer.js";
+
+describe("buildReviewerPrompt", () => {
+  const baseArgs = {
+    task: "Add login feature",
+    diff: "diff --git a/src/auth.js\n+export function login() {}",
+    reviewRules: "Check for security issues",
+    mode: "standard"
+  };
+
+  it("includes subagent preamble", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("You are running as a Karajan sub-agent");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
+
+  it("includes review mode", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("You are a code reviewer in standard mode");
+  });
+
+  it("includes JSON schema instruction", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("Return only one valid JSON object and nothing else");
+    expect(result).toContain('"approved":boolean');
+    expect(result).toContain('"blocking_issues"');
+    expect(result).toContain('"non_blocking_suggestions"');
+    expect(result).toContain('"summary":string');
+    expect(result).toContain('"confidence":number');
+  });
+
+  it("includes task context", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("Task context:\nAdd login feature");
+  });
+
+  it("includes review rules", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("Review rules:\nCheck for security issues");
+  });
+
+  it("includes git diff", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).toContain("Git diff:\ndiff --git a/src/auth.js");
+  });
+
+  it("truncates diff larger than 12KB", () => {
+    const largeDiff = "x".repeat(15000);
+    const result = buildReviewerPrompt({ ...baseArgs, diff: largeDiff });
+
+    expect(result).toContain("[TRUNCATED]");
+    expect(result).not.toContain("x".repeat(15000));
+    // Truncated portion should be 12000 chars
+    const diffSection = result.split("Git diff:\n")[1];
+    expect(diffSection).toContain("x".repeat(12000));
+  });
+
+  it("does not truncate diff at exactly 12KB", () => {
+    const exactDiff = "y".repeat(12000);
+    const result = buildReviewerPrompt({ ...baseArgs, diff: exactDiff });
+
+    expect(result).not.toContain("[TRUNCATED]");
+    expect(result).toContain("y".repeat(12000));
+  });
+
+  it("does not truncate diff smaller than 12KB", () => {
+    const smallDiff = "z".repeat(5000);
+    const result = buildReviewerPrompt({ ...baseArgs, diff: smallDiff });
+
+    expect(result).not.toContain("[TRUNCATED]");
+    expect(result).toContain("z".repeat(5000));
+  });
+
+  it("supports different review modes", () => {
+    const paranoid = buildReviewerPrompt({ ...baseArgs, mode: "paranoid" });
+    const relaxed = buildReviewerPrompt({ ...baseArgs, mode: "relaxed" });
+
+    expect(paranoid).toContain("You are a code reviewer in paranoid mode");
+    expect(relaxed).toContain("You are a code reviewer in relaxed mode");
+  });
+
+  it("sections are separated by double newlines", () => {
+    const result = buildReviewerPrompt(baseArgs);
+    const sections = result.split("\n\n");
+
+    // preamble, mode, JSON instruction, schema, task, rules, diff = at least 7
+    expect(sections.length).toBeGreaterThanOrEqual(7);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 9 tests for `buildCoderPrompt`: TDD/standard methodology, optional sections (coderRules, sonarSummary, reviewerFeedback), subagent preamble, section separation
- Add 11 tests for `buildReviewerPrompt`: review modes (standard, paranoid, relaxed), diff truncation at 12KB boundary, JSON schema instruction, task/rules/diff inclusion, section separation
- Total test coverage: 232 tests across 36 files

## Test plan
- [x] All 20 new tests pass
- [x] Full suite (232 tests) green
- [x] No mocks needed — pure functions