### PR TITLE
test: add tests for utilities (git.js, paths.js, fs.js, display.js)

### DIFF
--- a/tests/utils-display.test.js
+++ b/tests/utils-display.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { formatElapsed, printHeader, printEvent } from "../src/utils/display.js";
+
+describe("utils/display", () => {
+  describe("formatElapsed", () => {
+    it("formats 0ms as 00:00", () => {
+      expect(formatElapsed(0)).toBe("00:00");
+    });
+
+    it("formats undefined as 00:00", () => {
+      expect(formatElapsed(undefined)).toBe("00:00");
+    });
+
+    it("formats 90 seconds as 01:30", () => {
+      expect(formatElapsed(90000)).toBe("01:30");
+    });
+
+    it("formats 5 seconds as 00:05", () => {
+      expect(formatElapsed(5000)).toBe("00:05");
+    });
+
+    it("formats 600 seconds as 10:00", () => {
+      expect(formatElapsed(600000)).toBe("10:00");
+    });
+
+    it("pads single digit minutes and seconds", () => {
+      expect(formatElapsed(65000)).toBe("01:05");
+    });
+  });
+
+  describe("printHeader", () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    it("prints task, coder, reviewer, max iterations and timeout", () => {
+      printHeader({
+        task: "Fix auth bug",
+        config: {
+          coder: "codex",
+          reviewer: "claude",
+          roles: { coder: { provider: "codex" }, reviewer: { provider: "claude" } },
+          max_iterations: 5,
+          session: { max_total_minutes: 120 }
+        }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Fix auth bug");
+      expect(output).toContain("codex");
+      expect(output).toContain("claude");
+      expect(output).toContain("5");
+      expect(output).toContain("120");
+    });
+  });
+
+  describe("printEvent", () => {
+    let spy;
+
+    beforeEach(() => {
+      spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    it("prints iteration start with iteration number", () => {
+      printEvent({ type: "iteration:start", detail: { iteration: 2, maxIterations: 5 }, elapsed: 30000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Iteration 2/5");
+    });
+
+    it("prints coder start with provider name", () => {
+      printEvent({ type: "coder:start", detail: { coder: "codex" } });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Coder");
+      expect(output).toContain("codex");
+    });
+
+    it("prints reviewer approved", () => {
+      printEvent({ type: "reviewer:end", detail: { approved: true }, elapsed: 5000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("APPROVED");
+    });
+
+    it("prints reviewer rejected with blocking count", () => {
+      printEvent({
+        type: "reviewer:end",
+        detail: { approved: false, blockingCount: 3, issues: ["Issue A", "Issue B"] }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("REJECTED");
+      expect(output).toContain("3 blocking");
+      expect(output).toContain("Issue A");
+    });
+
+    it("prints sonar gate status", () => {
+      printEvent({ type: "sonar:end", status: "ok", detail: { gateStatus: "OK" }, elapsed: 2000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Quality gate");
+      expect(output).toContain("OK");
+    });
+
+    it("prints question event with pause message", () => {
+      printEvent({ type: "question", detail: { question: "Should I proceed?" }, sessionId: "s_123" });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Paused");
+      expect(output).toContain("Should I proceed?");
+      expect(output).toContain("s_123");
+    });
+
+    it("prints default fallback for unknown event types", () => {
+      printEvent({ type: "custom:event", message: "Something happened", elapsed: 1000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Something happened");
+    });
+  });
+});

--- a/tests/utils-fs.test.js
+++ b/tests/utils-fs.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import path from "node:path";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn()
+  }
+}));
+
+describe("utils/fs", () => {
+  let ensureDir, exists, resolveFromCwd, fsMock;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    fsMock = (await import("node:fs/promises")).default;
+    const mod = await import("../src/utils/fs.js");
+    ensureDir = mod.ensureDir;
+    exists = mod.exists;
+    resolveFromCwd = mod.resolveFromCwd;
+  });
+
+  describe("ensureDir", () => {
+    it("calls fs.mkdir with recursive: true", async () => {
+      await ensureDir("/some/dir");
+      expect(fsMock.mkdir).toHaveBeenCalledWith("/some/dir", { recursive: true });
+    });
+  });
+
+  describe("exists", () => {
+    it("returns true when file is accessible", async () => {
+      fsMock.access.mockResolvedValue(undefined);
+      expect(await exists("/some/file")).toBe(true);
+    });
+
+    it("returns false when access throws", async () => {
+      fsMock.access.mockRejectedValue(new Error("ENOENT"));
+      expect(await exists("/missing/file")).toBe(false);
+    });
+  });
+
+  describe("resolveFromCwd", () => {
+    it("resolves relative path from cwd", () => {
+      const result = resolveFromCwd("src", "index.js");
+      expect(result).toBe(path.resolve(process.cwd(), "src", "index.js"));
+    });
+
+    it("returns absolute path for absolute input", () => {
+      const result = resolveFromCwd("/abs/path");
+      expect(result).toBe("/abs/path");
+    });
+  });
+});

--- a/tests/utils-git.test.js
+++ b/tests/utils-git.test.js
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+describe("utils/git", () => {
+  let git, runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const processMod = await import("../src/utils/process.js");
+    runCommand = processMod.runCommand;
+    git = await import("../src/utils/git.js");
+  });
+
+  describe("ensureGitRepo", () => {
+    it("returns true inside a git repo", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "true\n", stderr: "" });
+
+      expect(await git.ensureGitRepo()).toBe(true);
+      expect(runCommand).toHaveBeenCalledWith("git", ["rev-parse", "--is-inside-work-tree"]);
+    });
+
+    it("returns false outside a git repo", async () => {
+      runCommand.mockResolvedValue({ exitCode: 128, stdout: "", stderr: "not a git repo" });
+
+      expect(await git.ensureGitRepo()).toBe(false);
+    });
+  });
+
+  describe("currentBranch", () => {
+    it("returns the current branch name", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "feat/test\n", stderr: "" });
+
+      expect(await git.currentBranch()).toBe("feat/test");
+    });
+
+    it("throws on git failure", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error" });
+
+      await expect(git.currentBranch()).rejects.toThrow("git rev-parse");
+    });
+  });
+
+  describe("fetchBase", () => {
+    it("fetches the base branch from origin", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+      await git.fetchBase("main");
+      expect(runCommand).toHaveBeenCalledWith("git", ["fetch", "origin", "main"], expect.anything());
+    });
+  });
+
+  describe("buildBranchName", () => {
+    it("builds a branch name from prefix and task", () => {
+      const name = git.buildBranchName("feat/", "Add login feature");
+
+      expect(name).toMatch(/^feat\/add-login-feature-/);
+      // Contains ISO timestamp portion
+      expect(name).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}$/);
+    });
+
+    it("slugifies special characters", () => {
+      const name = git.buildBranchName("fix/", "Bug #42: fix & deploy!");
+
+      expect(name).toMatch(/^fix\/bug-42-fix-deploy-/);
+    });
+
+    it("uses 'task' fallback for empty task", () => {
+      const name = git.buildBranchName("feat/", "");
+
+      expect(name).toMatch(/^feat\/task-/);
+    });
+
+    it("truncates long task slugs to 40 chars", () => {
+      const longTask = "a".repeat(100);
+      const name = git.buildBranchName("feat/", longTask);
+      const slug = name.replace(/^feat\//, "").replace(/-\d{4}.*$/, "");
+
+      expect(slug.length).toBeLessThanOrEqual(40);
+    });
+  });
+
+  describe("hasChanges", () => {
+    it("returns true when there are changes", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "M file.js\n", stderr: "" });
+
+      expect(await git.hasChanges()).toBe(true);
+    });
+
+    it("returns false when clean", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+      expect(await git.hasChanges()).toBe(false);
+    });
+  });
+
+  describe("commitAll", () => {
+    it("stages and commits when there are changes", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })  // git add -A
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "M file.js", stderr: "" })  // git status --porcelain
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });  // git commit
+
+      const result = await git.commitAll("test commit");
+
+      expect(result.committed).toBe(true);
+      expect(runCommand).toHaveBeenCalledWith("git", ["add", "-A"], expect.anything());
+      expect(runCommand).toHaveBeenCalledWith("git", ["commit", "-m", "test commit"], expect.anything());
+    });
+
+    it("skips commit when no changes after staging", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })  // git add -A
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });  // git status --porcelain (empty)
+
+      const result = await git.commitAll("test commit");
+
+      expect(result.committed).toBe(false);
+    });
+  });
+
+  describe("pushBranch", () => {
+    it("pushes branch to origin with -u flag", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+      await git.pushBranch("feat/test");
+      expect(runCommand).toHaveBeenCalledWith("git", ["push", "-u", "origin", "feat/test"], expect.anything());
+    });
+  });
+
+  describe("createPullRequest", () => {
+    it("creates PR via gh CLI", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "https://github.com/repo/pull/1\n", stderr: "" });
+
+      const url = await git.createPullRequest({
+        baseBranch: "main",
+        branch: "feat/test",
+        title: "Test PR",
+        body: "Description"
+      });
+
+      expect(url).toBe("https://github.com/repo/pull/1");
+      expect(runCommand).toHaveBeenCalledWith(
+        "gh",
+        ["pr", "create", "--base", "main", "--head", "feat/test", "--title", "Test PR", "--body", "Description"]
+      );
+    });
+
+    it("throws on gh failure", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "auth error" });
+
+      await expect(
+        git.createPullRequest({ baseBranch: "main", branch: "feat/test", title: "T", body: "B" })
+      ).rejects.toThrow("gh");
+    });
+  });
+
+  describe("syncBaseBranch", () => {
+    it("returns synced=true, rebased=false when already in sync", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+
+      const result = await git.syncBaseBranch({ baseBranch: "main", autoRebase: false });
+      expect(result).toEqual({ synced: true, rebased: false });
+    });
+
+    it("rebases when behind and autoRebase=true", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" })  // rev-parse main
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "def456\n", stderr: "" })  // rev-parse origin/main
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });  // rebase
+
+      const result = await git.syncBaseBranch({ baseBranch: "main", autoRebase: true });
+      expect(result).toEqual({ synced: true, rebased: true });
+    });
+
+    it("throws when behind and autoRebase=false", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "def456\n", stderr: "" });
+
+      await expect(git.syncBaseBranch({ baseBranch: "main", autoRebase: false })).rejects.toThrow("behind");
+    });
+  });
+});

--- a/tests/utils-paths.test.js
+++ b/tests/utils-paths.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import os from "node:os";
+
+describe("utils/paths", () => {
+  const originalEnv = process.env.KJ_HOME;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.KJ_HOME = originalEnv;
+    } else {
+      delete process.env.KJ_HOME;
+    }
+    vi.resetModules();
+  });
+
+  describe("getKarajanHome", () => {
+    it("returns ~/.karajan by default", async () => {
+      delete process.env.KJ_HOME;
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      expect(getKarajanHome()).toBe(path.join(os.homedir(), ".karajan"));
+    });
+
+    it("returns $KJ_HOME when set", async () => {
+      process.env.KJ_HOME = "/custom/kj";
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      expect(getKarajanHome()).toBe(path.resolve("/custom/kj"));
+    });
+
+    it("resolves relative $KJ_HOME to absolute", async () => {
+      process.env.KJ_HOME = "relative/path";
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      expect(path.isAbsolute(getKarajanHome())).toBe(true);
+    });
+  });
+
+  describe("getSessionRoot", () => {
+    it("returns sessions dir under karajan home", async () => {
+      delete process.env.KJ_HOME;
+      const { getSessionRoot } = await import("../src/utils/paths.js");
+      expect(getSessionRoot()).toBe(path.join(os.homedir(), ".karajan", "sessions"));
+    });
+  });
+
+  describe("getSonarComposePath", () => {
+    it("returns docker-compose path under karajan home", async () => {
+      delete process.env.KJ_HOME;
+      const { getSonarComposePath } = await import("../src/utils/paths.js");
+      expect(getSonarComposePath()).toBe(path.join(os.homedir(), ".karajan", "docker-compose.sonar.yml"));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 43 new unit tests for 4 utility modules that had no test coverage
- **paths.js** (5 tests): `getKarajanHome` with/without `$KJ_HOME`, relative path resolution, `getSessionRoot`, `getSonarComposePath`
- **fs.js** (5 tests): `ensureDir` recursive mkdir, `exists` accessible/missing files, `resolveFromCwd`
- **display.js** (14 tests): `formatElapsed` edge cases, `printHeader` output, `printEvent` for all event types (iteration, coder, reviewer, sonar, question, default)
- **git.js** (19 tests): `ensureGitRepo`, `currentBranch`, `fetchBase`, `buildBranchName` slugification/truncation, `hasChanges`, `commitAll` with/without changes, `pushBranch`, `createPullRequest`, `syncBaseBranch` sync/rebase/error
- Total: 275 tests across 40 files

## Test plan
- [x] All 43 new tests pass
- [x] Full suite (275 tests) green
- [x] Mocks used for fs, process/runCommand; pure function tests need no mocks