### PR TITLE
fix: make reviewer output parsing resilient instead of crashing

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -512,20 +512,27 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       throw new Error(`Reviewer failed: ${details}`);
     }
 
-    const parsed = parseJsonOutput(reviewerExec.result.output);
-    if (!parsed) {
-      await markSessionStatus(session, "failed");
-      emitProgress(
-        emitter,
-        makeEvent("reviewer:end", { ...eventBase, stage: "reviewer" }, {
-          status: "fail",
-          message: "Reviewer output is not valid JSON"
-        })
-      );
-      throw new Error("Reviewer output is not valid JSON");
+    let review;
+    try {
+      const parsed = parseJsonOutput(reviewerExec.result.output);
+      if (!parsed) {
+        throw new Error("Reviewer output is not valid JSON");
+      }
+      review = validateReviewResult(parsed);
+    } catch (parseErr) {
+      logger.warn(`Reviewer output parse/validation failed: ${parseErr.message}`);
+      review = {
+        approved: false,
+        blocking_issues: [{
+          id: "PARSE_ERROR",
+          severity: "high",
+          description: `Reviewer output could not be parsed: ${parseErr.message}`
+        }],
+        non_blocking_suggestions: [],
+        summary: `Parse error: ${parseErr.message}`,
+        confidence: 0
+      };
     }
-
-    const review = validateReviewResult(parsed);
     await addCheckpoint(session, {
       stage: "reviewer",
       iteration: i,

--- a/tests/review-schema.test.js
+++ b/tests/review-schema.test.js
@@ -2,26 +2,117 @@ import { describe, expect, it } from "vitest";
 import { validateReviewResult } from "../src/review/schema.js";
 
 describe("validateReviewResult", () => {
-  it("accepts valid shape", () => {
+  it("accepts valid complete shape", () => {
     const output = validateReviewResult({
       approved: false,
       blocking_issues: [{ id: "A", description: "Issue" }],
-      non_blocking_suggestions: [],
-      summary: "x",
+      non_blocking_suggestions: ["Consider refactoring"],
+      summary: "Needs work",
       confidence: 0.8
     });
 
     expect(output.approved).toBe(false);
     expect(output.blocking_issues).toHaveLength(1);
+    expect(output.non_blocking_suggestions).toEqual(["Consider refactoring"]);
+    expect(output.summary).toBe("Needs work");
+    expect(output.confidence).toBe(0.8);
   });
 
-  it("rejects approved with blockers", () => {
+  it("accepts approved=true with empty blocking_issues", () => {
+    const output = validateReviewResult({
+      approved: true,
+      blocking_issues: [],
+      summary: "All good"
+    });
+
+    expect(output.approved).toBe(true);
+  });
+
+  it("throws for null input", () => {
+    expect(() => validateReviewResult(null)).toThrow("must be a JSON object");
+  });
+
+  it("throws for undefined input", () => {
+    expect(() => validateReviewResult(undefined)).toThrow("must be a JSON object");
+  });
+
+  it("throws for non-object input", () => {
+    expect(() => validateReviewResult("string")).toThrow("must be a JSON object");
+    expect(() => validateReviewResult(42)).toThrow("must be a JSON object");
+  });
+
+  it("throws when approved is missing", () => {
+    expect(() =>
+      validateReviewResult({ blocking_issues: [] })
+    ).toThrow("missing boolean field: approved");
+  });
+
+  it("throws when approved is not boolean", () => {
+    expect(() =>
+      validateReviewResult({ approved: "yes", blocking_issues: [] })
+    ).toThrow("missing boolean field: approved");
+  });
+
+  it("throws when blocking_issues is missing", () => {
+    expect(() =>
+      validateReviewResult({ approved: false })
+    ).toThrow("missing array field: blocking_issues");
+  });
+
+  it("throws when blocking_issues is not an array", () => {
+    expect(() =>
+      validateReviewResult({ approved: false, blocking_issues: "none" })
+    ).toThrow("missing array field: blocking_issues");
+  });
+
+  it("defaults non_blocking_suggestions to empty array", () => {
+    const output = validateReviewResult({
+      approved: false,
+      blocking_issues: [{ id: "A" }]
+    });
+
+    expect(output.non_blocking_suggestions).toEqual([]);
+  });
+
+  it("defaults summary to empty string", () => {
+    const output = validateReviewResult({
+      approved: false,
+      blocking_issues: [{ id: "A" }]
+    });
+
+    expect(output.summary).toBe("");
+  });
+
+  it("defaults confidence to 0.5", () => {
+    const output = validateReviewResult({
+      approved: false,
+      blocking_issues: [{ id: "A" }]
+    });
+
+    expect(output.confidence).toBe(0.5);
+  });
+
+  it("rejects approved=true with blocking issues", () => {
     expect(() =>
       validateReviewResult({
         approved: true,
         blocking_issues: [{ id: "A" }],
         non_blocking_suggestions: []
       })
-    ).toThrow();
+    ).toThrow("approved=true with blocking issues");
+  });
+
+  it("preserves existing optional fields when present", () => {
+    const output = validateReviewResult({
+      approved: false,
+      blocking_issues: [{ id: "B" }],
+      non_blocking_suggestions: ["Suggestion"],
+      summary: "Review summary",
+      confidence: 0.95
+    });
+
+    expect(output.non_blocking_suggestions).toEqual(["Suggestion"]);
+    expect(output.summary).toBe("Review summary");
+    expect(output.confidence).toBe(0.95);
   });
 });

--- a/tests/reviewer-parse-resilience.test.js
+++ b/tests/reviewer-parse-resilience.test.js
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => {
+  let session = null;
+  return {
+    createSession: vi.fn(async (initial) => {
+      session = { id: "s_test", status: "running", checkpoints: [], ...initial };
+      return session;
+    }),
+    saveSession: vi.fn(async () => {}),
+    loadSession: vi.fn(async () => session),
+    addCheckpoint: vi.fn(async (s, cp) => { s.checkpoints.push(cp); }),
+    markSessionStatus: vi.fn(async (s, status) => { s.status = status; }),
+    pauseSession: vi.fn(async (s, data) => { s.status = "paused"; s.paused_state = data; }),
+    resumeSessionWithAnswer: vi.fn(async () => session)
+  };
+});
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  generateDiff: vi.fn().mockResolvedValue("diff content")
+}));
+
+vi.mock("../src/review/schema.js", () => ({
+  validateReviewResult: vi.fn((r) => r)
+}));
+
+vi.mock("../src/review/tdd-policy.js", () => ({
+  evaluateTddPolicy: vi.fn().mockReturnValue({ ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" })
+}));
+
+vi.mock("../src/prompts/coder.js", () => ({
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+}));
+
+vi.mock("../src/prompts/reviewer.js", () => ({
+  buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn().mockResolvedValue({ status: "OK" }),
+  getOpenIssues: vi.fn().mockResolvedValue({ total: 0, issues: [] })
+}));
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn().mockResolvedValue({ ok: true, projectKey: "test-key" })
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  shouldBlockByProfile: vi.fn().mockReturnValue(false),
+  summarizeIssues: vi.fn().mockReturnValue("")
+}));
+
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn().mockResolvedValue(true),
+  currentBranch: vi.fn().mockResolvedValue("feat/test"),
+  fetchBase: vi.fn(),
+  syncBaseBranch: vi.fn(),
+  ensureBranchUpToDateWithBase: vi.fn(),
+  createBranch: vi.fn(),
+  buildBranchName: vi.fn().mockReturnValue("feat/test"),
+  commitAll: vi.fn().mockResolvedValue({ committed: true }),
+  pushBranch: vi.fn(),
+  createPullRequest: vi.fn()
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("role instructions"),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+const REVIEW_OK = JSON.stringify({
+  approved: true,
+  blocking_issues: [],
+  non_blocking_suggestions: [],
+  summary: "OK",
+  confidence: 0.9
+});
+
+function makeConfig(overrides = {}) {
+  return {
+    coder: "codex",
+    reviewer: "claude",
+    review_mode: "standard",
+    max_iterations: 10,
+    base_branch: "main",
+    roles: {
+      planner: { provider: null },
+      coder: { provider: "codex" },
+      reviewer: { provider: "claude" },
+      refactorer: { provider: null }
+    },
+    pipeline: { planner: { enabled: false }, refactorer: { enabled: false }, solomon: { enabled: false } },
+    coder_options: { auto_approve: true },
+    reviewer_options: { retries: 0 },
+    development: { methodology: "tdd", require_test_changes: true },
+    sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" },
+    git: { auto_commit: false, auto_push: false, auto_pr: false },
+    session: {
+      max_iteration_minutes: 15,
+      max_total_minutes: 120,
+      fail_fast_repeats: 2,
+      repeat_detection_threshold: 99,
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3,
+      ...overrides
+    },
+    failFast: { repeatThreshold: 99 },
+    output: { log_level: "error" }
+  };
+}
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+describe("reviewer parse resilience", () => {
+  let runFlow;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
+    evaluateTddPolicy.mockReturnValue({ ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" });
+
+    const { computeBaseRef, generateDiff } = await import("../src/review/diff-generator.js");
+    computeBaseRef.mockResolvedValue("abc123");
+    generateDiff.mockResolvedValue("diff content");
+
+    const { runSonarScan } = await import("../src/sonar/scanner.js");
+    runSonarScan.mockResolvedValue({ ok: true, projectKey: "test-key" });
+
+    const { getQualityGateStatus, getOpenIssues } = await import("../src/sonar/api.js");
+    getQualityGateStatus.mockResolvedValue({ status: "OK" });
+    getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+
+    const { shouldBlockByProfile } = await import("../src/sonar/enforcer.js");
+    shouldBlockByProfile.mockReturnValue(false);
+
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    buildCoderPrompt.mockReturnValue("coder prompt");
+
+    const { buildReviewerPrompt } = await import("../src/prompts/reviewer.js");
+    buildReviewerPrompt.mockReturnValue("reviewer prompt");
+
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockResolvedValue("role instructions");
+
+    const { validateReviewResult } = await import("../src/review/schema.js");
+    validateReviewResult.mockImplementation((r) => r);
+
+    const mod = await import("../src/orchestrator.js");
+    runFlow = mod.runFlow;
+  });
+
+  it("does not crash when reviewer returns non-JSON — treats as rejected iteration", async () => {
+    let reviewerCallCount = 0;
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockImplementation(() => {
+        reviewerCallCount += 1;
+        if (reviewerCallCount === 1) {
+          // First attempt: garbage output
+          return { ok: true, output: "This is not JSON at all!" };
+        }
+        // Second attempt: valid JSON
+        return { ok: true, output: REVIEW_OK };
+      })
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig({ max_iterations: 3 });
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    // Should not crash — should eventually approve on second iteration
+    expect(result.approved).toBe(true);
+    expect(reviewerCallCount).toBe(2);
+
+    // First reviewer:end should show parse failure
+    const reviewerEndEvents = events.filter((e) => e.type === "reviewer:end");
+    expect(reviewerEndEvents.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("includes PARSE_ERROR blocking issue when reviewer output is garbage", async () => {
+    const { createAgent } = await import("../src/agents/index.js");
+    let reviewerCallCount = 0;
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockImplementation(() => {
+        reviewerCallCount += 1;
+        if (reviewerCallCount === 1) {
+          return { ok: true, output: "garbage output" };
+        }
+        return { ok: true, output: REVIEW_OK };
+      })
+    });
+
+    const { validateReviewResult } = await import("../src/review/schema.js");
+    validateReviewResult.mockImplementation((r) => {
+      // Real validation for the second call
+      if (r.approved !== undefined) return r;
+      throw new Error("bad shape");
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig({ max_iterations: 3 });
+    await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    // The first reviewer:end should contain the parse error info
+    const firstReviewerEnd = events.find(
+      (e) => e.type === "reviewer:end" && e.detail?.issues?.some((i) => i.includes("PARSE_ERROR"))
+    );
+    expect(firstReviewerEnd).toBeTruthy();
+  });
+
+  it("does not crash when validateReviewResult throws", async () => {
+    const { createAgent } = await import("../src/agents/index.js");
+    let reviewerCallCount = 0;
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockImplementation(() => {
+        reviewerCallCount += 1;
+        if (reviewerCallCount === 1) {
+          // Valid JSON but missing required field
+          return { ok: true, output: JSON.stringify({ approved: "not-boolean", blocking_issues: [] }) };
+        }
+        return { ok: true, output: REVIEW_OK };
+      })
+    });
+
+    const { validateReviewResult } = await import("../src/review/schema.js");
+    validateReviewResult.mockImplementation((r) => {
+      if (typeof r.approved !== "boolean") {
+        throw new Error("Reviewer output missing boolean field: approved");
+      }
+      return r;
+    });
+
+    const emitter = new EventEmitter();
+    const config = makeConfig({ max_iterations: 3 });
+    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+
+    // Should recover on second iteration
+    expect(result.approved).toBe(true);
+    expect(reviewerCallCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Orchestrator no longer crashes when reviewer returns non-JSON or invalid output
- Parse/validation errors are caught and converted to rejected iterations with a `PARSE_ERROR` blocking issue, allowing the coder to retry
- Expanded `review-schema.test.js` from 2 to 14 tests (null, non-object, missing required fields, optional field defaults, logical contradiction)
- Added 3 new resilience integration tests: garbage output recovery, PARSE_ERROR emission, validateReviewResult throw recovery

## Test plan
- [x] All 290 tests pass across 41 files
- [x] Garbage reviewer output → treated as rejection, coder retries next iteration
- [x] validateReviewResult throw → same graceful handling
- [x] Schema validation covers all paths (null, string, missing approved/blocking_issues, defaults)