### PR TITLE
fix: add explicit error handling to SonarQube API calls

### DIFF
--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -1,38 +1,78 @@
 import { runCommand } from "../utils/process.js";
 import { resolveSonarProjectKey } from "./project-key.js";
 
+export class SonarApiError extends Error {
+  constructor(message, { url, httpStatus, hint } = {}) {
+    super(message);
+    this.name = "SonarApiError";
+    this.url = url;
+    this.httpStatus = httpStatus;
+    this.hint = hint;
+  }
+}
+
 function tokenFromConfig(config) {
   return process.env.KJ_SONAR_TOKEN || config.sonarqube.token || "";
 }
 
-export async function getQualityGateStatus(config, projectKey = null) {
-  const effectiveProjectKey = await resolveSonarProjectKey(config, { projectKey });
+function parseHttpResponse(stdout) {
+  const lines = stdout.split("\n");
+  const httpCode = parseInt(lines.pop(), 10) || 0;
+  const body = lines.join("\n");
+  return { httpCode, body };
+}
+
+async function sonarFetch(config, urlPath) {
   const token = tokenFromConfig(config);
-  const url = `${config.sonarqube.host}/api/qualitygates/project_status?projectKey=${effectiveProjectKey}`;
-  const res = await runCommand("curl", ["-s", "-u", `${token}:`, url]);
+  const url = `${config.sonarqube.host}${urlPath}`;
+  const res = await runCommand("curl", ["-s", "-w", "\n%{http_code}", "-u", `${token}:`, url]);
+
   if (res.exitCode !== 0) {
-    return { ok: false, status: "ERROR", raw: res.stderr || res.stdout };
+    throw new SonarApiError(
+      `SonarQube is not reachable at ${config.sonarqube.host}. Check that SonarQube is running ('kj sonar start').`,
+      { url, hint: "Run 'kj sonar start' or verify Docker is running." }
+    );
   }
 
+  const { httpCode, body } = parseHttpResponse(res.stdout);
+
+  if (httpCode === 401) {
+    throw new SonarApiError(
+      `SonarQube authentication failed (HTTP 401). Token may be invalid or expired. Regenerate with 'kj init'.`,
+      { url, httpStatus: 401, hint: "Run 'kj init' to regenerate the SonarQube token." }
+    );
+  }
+
+  if (httpCode >= 400) {
+    throw new SonarApiError(
+      `SonarQube API returned HTTP ${httpCode} for ${url}.`,
+      { url, httpStatus: httpCode }
+    );
+  }
+
+  return body;
+}
+
+export async function getQualityGateStatus(config, projectKey = null) {
+  const effectiveProjectKey = await resolveSonarProjectKey(config, { projectKey });
+  const body = await sonarFetch(config, `/api/qualitygates/project_status?projectKey=${effectiveProjectKey}`);
+
   try {
-    const parsed = JSON.parse(res.stdout);
+    const parsed = JSON.parse(body);
     return { ok: true, status: parsed.projectStatus?.status || "ERROR", raw: parsed };
   } catch {
-    return { ok: false, status: "ERROR", raw: res.stdout };
+    return { ok: false, status: "ERROR", raw: body };
   }
 }
 
 export async function getOpenIssues(config, projectKey = null) {
   const effectiveProjectKey = await resolveSonarProjectKey(config, { projectKey });
-  const token = tokenFromConfig(config);
-  const url = `${config.sonarqube.host}/api/issues/search?projectKeys=${effectiveProjectKey}&statuses=OPEN`;
-  const res = await runCommand("curl", ["-s", "-u", `${token}:`, url]);
-  if (res.exitCode !== 0) return { total: 0, issues: [], raw: res.stderr || res.stdout };
+  const body = await sonarFetch(config, `/api/issues/search?projectKeys=${effectiveProjectKey}&statuses=OPEN`);
 
   try {
-    const parsed = JSON.parse(res.stdout);
+    const parsed = JSON.parse(body);
     return { total: parsed.total || 0, issues: parsed.issues || [], raw: parsed };
   } catch {
-    return { total: 0, issues: [], raw: res.stdout };
+    return { total: 0, issues: [], raw: body };
   }
 }

--- a/tests/sonar-api.test.js
+++ b/tests/sonar-api.test.js
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/sonar/project-key.js", () => ({
+  resolveSonarProjectKey: vi.fn().mockResolvedValue("my-project")
+}));
+
+describe("sonar/api", () => {
+  let getQualityGateStatus, getOpenIssues, runCommand;
+
+  const baseConfig = {
+    sonarqube: {
+      host: "http://localhost:9000",
+      token: "test-token"
+    }
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const processMod = await import("../src/utils/process.js");
+    runCommand = processMod.runCommand;
+    const { resolveSonarProjectKey } = await import("../src/sonar/project-key.js");
+    resolveSonarProjectKey.mockResolvedValue("my-project");
+    const api = await import("../src/sonar/api.js");
+    getQualityGateStatus = api.getQualityGateStatus;
+    getOpenIssues = api.getOpenIssues;
+  });
+
+  describe("getQualityGateStatus", () => {
+    it("returns gate status for successful response", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({ projectStatus: { status: "OK" } }) + "\n200",
+        stderr: ""
+      });
+
+      const result = await getQualityGateStatus(baseConfig);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe("OK");
+    });
+
+    it("returns ERROR status when gate fails", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({ projectStatus: { status: "ERROR" } }) + "\n200",
+        stderr: ""
+      });
+
+      const result = await getQualityGateStatus(baseConfig);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe("ERROR");
+    });
+
+    it("throws SonarApiError on connection failure (curl exit != 0)", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 7,
+        stdout: "",
+        stderr: "Failed to connect to localhost port 9000"
+      });
+
+      await expect(getQualityGateStatus(baseConfig)).rejects.toThrow(/not reachable/i);
+    });
+
+    it("throws SonarApiError with 401 hint on auth failure", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "Unauthorized\n401",
+        stderr: ""
+      });
+
+      await expect(getQualityGateStatus(baseConfig)).rejects.toThrow(/401/);
+      await expect(getQualityGateStatus(baseConfig)).rejects.toThrow(/token|auth/i);
+    });
+
+    it("throws SonarApiError on non-200 HTTP status", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "Not Found\n404",
+        stderr: ""
+      });
+
+      await expect(getQualityGateStatus(baseConfig)).rejects.toThrow(/404/);
+    });
+
+    it("throws on unparseable JSON body with 200 status", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "this is not json\n200",
+        stderr: ""
+      });
+
+      const result = await getQualityGateStatus(baseConfig);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe("ERROR");
+    });
+
+    it("includes URL in error for connection failures", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 7,
+        stdout: "",
+        stderr: "Connection refused"
+      });
+
+      await expect(getQualityGateStatus(baseConfig)).rejects.toThrow(/localhost:9000/);
+    });
+  });
+
+  describe("getOpenIssues", () => {
+    it("returns issues for successful response", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({ total: 2, issues: [{ key: "i1" }, { key: "i2" }] }) + "\n200",
+        stderr: ""
+      });
+
+      const result = await getOpenIssues(baseConfig);
+      expect(result.total).toBe(2);
+      expect(result.issues).toHaveLength(2);
+    });
+
+    it("returns empty issues for successful response with no issues", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({ total: 0, issues: [] }) + "\n200",
+        stderr: ""
+      });
+
+      const result = await getOpenIssues(baseConfig);
+      expect(result.total).toBe(0);
+      expect(result.issues).toEqual([]);
+    });
+
+    it("throws SonarApiError on connection failure", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 7,
+        stdout: "",
+        stderr: "Connection refused"
+      });
+
+      await expect(getOpenIssues(baseConfig)).rejects.toThrow(/not reachable/i);
+    });
+
+    it("throws SonarApiError on 401", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "Unauthorized\n401",
+        stderr: ""
+      });
+
+      await expect(getOpenIssues(baseConfig)).rejects.toThrow(/401/);
+    });
+
+    it("returns empty on unparseable JSON body with 200", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "not json\n200",
+        stderr: ""
+      });
+
+      const result = await getOpenIssues(baseConfig);
+      expect(result.total).toBe(0);
+      expect(result.issues).toEqual([]);
+    });
+
+    it("passes custom projectKey when provided", async () => {
+      const { resolveSonarProjectKey } = await import("../src/sonar/project-key.js");
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify({ total: 0, issues: [] }) + "\n200",
+        stderr: ""
+      });
+
+      await getOpenIssues(baseConfig, "custom-key");
+      expect(resolveSonarProjectKey).toHaveBeenCalledWith(baseConfig, { projectKey: "custom-key" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Introduce `SonarApiError` class with `url`, `httpStatus`, and `hint` fields for structured error reporting
- Use `curl -w "\n%{http_code}"` to capture HTTP status codes from SonarQube
- Connection failures (curl exit != 0) throw with URL and hint to run `kj sonar start`
- HTTP 401 throws with hint to regenerate token via `kj init`
- Other HTTP 4xx/5xx throw with status code and URL
- JSON parse failures on 200 responses degrade gracefully (return empty/error status)
- Add 13 new tests covering all error paths for both `getQualityGateStatus` and `getOpenIssues`

## Test plan
- [x] All 303 tests pass across 42 files
- [x] Connection failure → SonarApiError with host URL and hint
- [x] 401 auth failure → SonarApiError with token regeneration hint
- [x] 404 and other HTTP errors → SonarApiError with status code
- [x] Valid 200 responses parsed correctly
- [x] Unparseable 200 body → graceful degradation