### PR TITLE
feat: implement --dry-run mode for kj run

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -70,6 +70,7 @@ program
   .option("--methodology <name>")
   .option("--no-auto-rebase")
   .option("--no-sonar")
+  .option("--dry-run", "Show what would be executed without running anything")
   .option("--json", "Output JSON only (no styled display)")
   .action(async (task, flags) => {
     await withConfig("run", flags, async ({ config, logger }) => {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -74,9 +74,57 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const coderRole = resolveRole(config, "coder");
   const reviewerRole = resolveRole(config, "reviewer");
   const refactorerRole = resolveRole(config, "refactorer");
-  const repeatDetector = new RepeatDetector({ threshold: getRepeatThreshold(config) });
   const plannerEnabled = Boolean(config.pipeline?.planner?.enabled);
   const refactorerEnabled = Boolean(config.pipeline?.refactorer?.enabled);
+
+  // --- Dry-run: return summary without executing anything ---
+  if (flags.dryRun) {
+    const projectDir = config.projectDir || process.cwd();
+    const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir)) || "";
+    const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
+    const coderPrompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology });
+    const reviewerPrompt = buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode });
+
+    const summary = {
+      dry_run: true,
+      task,
+      roles: {
+        planner: plannerRole,
+        coder: coderRole,
+        reviewer: reviewerRole,
+        refactorer: refactorerRole
+      },
+      pipeline: {
+        planner_enabled: plannerEnabled,
+        refactorer_enabled: refactorerEnabled,
+        sonar_enabled: Boolean(config.sonarqube?.enabled)
+      },
+      limits: {
+        max_iterations: config.max_iterations,
+        max_iteration_minutes: config.session?.max_iteration_minutes,
+        max_total_minutes: config.session?.max_total_minutes,
+        max_sonar_retries: config.session?.max_sonar_retries,
+        max_reviewer_retries: config.session?.max_reviewer_retries
+      },
+      prompts: {
+        coder: coderPrompt,
+        reviewer: reviewerPrompt
+      },
+      git: config.git
+    };
+
+    emitProgress(
+      emitter,
+      makeEvent("dry-run:summary", { sessionId: null, iteration: 0, stage: "dry-run", startedAt: Date.now() }, {
+        message: "Dry-run complete — no changes made",
+        detail: summary
+      })
+    );
+
+    return summary;
+  }
+
+  const repeatDetector = new RepeatDetector({ threshold: getRepeatThreshold(config) });
   const coder = createAgent(coderRole.provider, config, logger);
   const startedAt = Date.now();
   const eventBase = { sessionId: null, iteration: 0, stage: null, startedAt };

--- a/tests/dry-run.test.js
+++ b/tests/dry-run.test.js
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => ({
+  createSession: vi.fn(async (initial) => ({
+    id: "s_dry", status: "running", checkpoints: [], ...initial
+  })),
+  saveSession: vi.fn(async () => {}),
+  loadSession: vi.fn(async () => null),
+  addCheckpoint: vi.fn(async () => {}),
+  markSessionStatus: vi.fn(async () => {}),
+  pauseSession: vi.fn(async () => {}),
+  resumeSessionWithAnswer: vi.fn(async () => null)
+}));
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  generateDiff: vi.fn().mockResolvedValue("diff content")
+}));
+
+vi.mock("../src/review/schema.js", () => ({
+  validateReviewResult: vi.fn((r) => r)
+}));
+
+vi.mock("../src/review/tdd-policy.js", () => ({
+  evaluateTddPolicy: vi.fn().mockReturnValue({ ok: true })
+}));
+
+vi.mock("../src/prompts/coder.js", () => ({
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt content")
+}));
+
+vi.mock("../src/prompts/reviewer.js", () => ({
+  buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt content")
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn().mockResolvedValue({ status: "OK" }),
+  getOpenIssues: vi.fn().mockResolvedValue({ total: 0, issues: [] })
+}));
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn().mockResolvedValue({ ok: true, projectKey: "test-key" })
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  shouldBlockByProfile: vi.fn().mockReturnValue(false),
+  summarizeIssues: vi.fn().mockReturnValue("")
+}));
+
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn().mockResolvedValue(true),
+  currentBranch: vi.fn().mockResolvedValue("feat/test"),
+  fetchBase: vi.fn(),
+  syncBaseBranch: vi.fn(),
+  ensureBranchUpToDateWithBase: vi.fn(),
+  createBranch: vi.fn(),
+  buildBranchName: vi.fn().mockReturnValue("feat/test"),
+  commitAll: vi.fn().mockResolvedValue({ committed: true }),
+  pushBranch: vi.fn(),
+  createPullRequest: vi.fn()
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("role instructions"),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    coder: "codex",
+    reviewer: "claude",
+    review_mode: "standard",
+    max_iterations: 5,
+    base_branch: "main",
+    roles: {
+      planner: { provider: null },
+      coder: { provider: "codex" },
+      reviewer: { provider: "claude" },
+      refactorer: { provider: null }
+    },
+    pipeline: { planner: { enabled: false }, refactorer: { enabled: false }, solomon: { enabled: false } },
+    coder_options: { auto_approve: true },
+    reviewer_options: { retries: 0, fallback_reviewer: "codex" },
+    development: { methodology: "tdd", require_test_changes: true },
+    sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" },
+    git: { auto_commit: false, auto_push: false, auto_pr: false },
+    session: {
+      max_iteration_minutes: 15,
+      max_total_minutes: 120,
+      fail_fast_repeats: 2,
+      repeat_detection_threshold: 2,
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3
+    },
+    failFast: { repeatThreshold: 2 },
+    output: { log_level: "error" },
+    ...overrides
+  };
+}
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+describe("dry-run mode", () => {
+  let runFlow;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const { createAgent } = await import("../src/agents/index.js");
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: "{}" })
+    });
+
+    const { computeBaseRef } = await import("../src/review/diff-generator.js");
+    computeBaseRef.mockResolvedValue("abc123");
+
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    buildCoderPrompt.mockReturnValue("coder prompt content");
+
+    const { buildReviewerPrompt } = await import("../src/prompts/reviewer.js");
+    buildReviewerPrompt.mockReturnValue("reviewer prompt content");
+
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockResolvedValue("role instructions");
+
+    const mod = await import("../src/orchestrator.js");
+    runFlow = mod.runFlow;
+  });
+
+  it("returns dry_run=true without executing agents", async () => {
+    const { createAgent } = await import("../src/agents/index.js");
+
+    const config = makeConfig();
+    const result = await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(result.dry_run).toBe(true);
+    // Agents should never be called
+    const agent = createAgent.mock.results[0]?.value;
+    if (agent) {
+      expect(agent.runTask).not.toHaveBeenCalled();
+      expect(agent.reviewTask).not.toHaveBeenCalled();
+    }
+  });
+
+  it("includes resolved roles in dry-run output", async () => {
+    const config = makeConfig();
+    const result = await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(result.roles.coder.provider).toBe("codex");
+    expect(result.roles.reviewer.provider).toBe("claude");
+  });
+
+  it("includes pipeline configuration", async () => {
+    const config = makeConfig();
+    const result = await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(result.pipeline).toBeDefined();
+    expect(result.pipeline.planner_enabled).toBe(false);
+    expect(result.pipeline.refactorer_enabled).toBe(false);
+    expect(result.pipeline.sonar_enabled).toBe(true);
+  });
+
+  it("includes session limits", async () => {
+    const config = makeConfig();
+    const result = await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(result.limits.max_iterations).toBe(5);
+    expect(result.limits.max_total_minutes).toBe(120);
+  });
+
+  it("includes sample prompts", async () => {
+    const config = makeConfig();
+    const result = await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(result.prompts.coder).toBeTruthy();
+    expect(result.prompts.reviewer).toBeTruthy();
+  });
+
+  it("does not create a session store entry", async () => {
+    const { createSession } = await import("../src/session-store.js");
+
+    const config = makeConfig();
+    await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it("does not run sonar scan", async () => {
+    const { runSonarScan } = await import("../src/sonar/scanner.js");
+
+    const config = makeConfig();
+    await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    });
+
+    expect(runSonarScan).not.toHaveBeenCalled();
+  });
+
+  it("emits a dry-run progress event", async () => {
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = makeConfig();
+    await runFlow({
+      task: "Add login",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true },
+      emitter
+    });
+
+    const dryRunEvent = events.find((e) => e.type === "dry-run:summary");
+    expect(dryRunEvent).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to `kj run` that shows what would be executed without making any changes
- Returns resolved roles (planner, coder, reviewer, refactorer), pipeline config (planner/refactorer/sonar enabled), session limits, sample prompts (coder + reviewer), and git settings
- No sessions created, no agents executed, no sonar scans, no files modified
- Emits `dry-run:summary` progress event for display/logging
- 8 new tests covering all aspects of dry-run output and side-effect prevention

## Test plan
- [x] All 311 tests pass across 43 files
- [x] `--dry-run` returns `dry_run: true` with complete config summary
- [x] No `createSession`, `createAgent.runTask`, `runSonarScan` calls in dry-run mode
- [x] Progress event emitted for UI integration