### PR TITLE
feat: improve kj doctor with comprehensive checks and fix suggestions

### DIFF
--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,34 +1,150 @@
 import { runCommand } from "../utils/process.js";
 import { resolveBin } from "../agents/resolve-bin.js";
+import { exists } from "../utils/fs.js";
+import { getConfigPath } from "../config.js";
+import { isSonarReachable } from "../sonar/manager.js";
+import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
+import { ensureGitRepo } from "../utils/git.js";
 
 async function checkBinary(name, versionArg = "--version") {
   const resolved = resolveBin(name);
   const res = await runCommand(resolved, [versionArg]);
-  return { ok: res.exitCode === 0, output: res.stdout || res.stderr, path: resolved };
+  const version = (res.stdout || res.stderr || "").split("\n")[0].trim();
+  return { ok: res.exitCode === 0, version, path: resolved };
+}
+
+export async function runChecks({ config }) {
+  const checks = [];
+
+  // 1. Config file
+  const configPath = getConfigPath();
+  const configExists = await exists(configPath);
+  checks.push({
+    name: "config",
+    label: "Config file",
+    ok: configExists,
+    detail: configExists ? configPath : "Not found",
+    fix: configExists ? null : "Run 'kj init' to create the config file."
+  });
+
+  // 2. Git repository
+  let gitOk = false;
+  try {
+    gitOk = await ensureGitRepo();
+  } catch {
+    gitOk = false;
+  }
+  checks.push({
+    name: "git",
+    label: "Git repository",
+    ok: gitOk,
+    detail: gitOk ? "Inside a git repository" : "Not a git repository",
+    fix: gitOk ? null : "Run 'git init' or navigate to a git-managed project."
+  });
+
+  // 3. Docker
+  const docker = await checkBinary("docker", "--version");
+  checks.push({
+    name: "docker",
+    label: "Docker",
+    ok: docker.ok,
+    detail: docker.ok ? docker.version : "Not found",
+    fix: docker.ok ? null : "Install Docker: https://docs.docker.com/get-docker/"
+  });
+
+  // 4. SonarQube reachability
+  const sonarHost = config.sonarqube?.host || "http://localhost:9000";
+  let sonarOk = false;
+  if (config.sonarqube?.enabled !== false) {
+    try {
+      sonarOk = await isSonarReachable(sonarHost);
+    } catch {
+      sonarOk = false;
+    }
+  }
+  checks.push({
+    name: "sonarqube",
+    label: "SonarQube",
+    ok: sonarOk || config.sonarqube?.enabled === false,
+    detail: config.sonarqube?.enabled === false
+      ? "Disabled in config"
+      : sonarOk
+        ? `Reachable at ${sonarHost}`
+        : `Not reachable at ${sonarHost}`,
+    fix: sonarOk || config.sonarqube?.enabled === false
+      ? null
+      : "Run 'kj sonar start' or 'docker start karajan-sonarqube'. Use --no-sonar to skip."
+  });
+
+  // 5. Agent CLIs
+  const agents = [
+    ["claude", "Install: npm install -g @anthropic-ai/claude-code"],
+    ["codex", "Install: npm install -g @openai/codex"],
+    ["gemini", "Install: npm install -g @anthropic-ai/gemini-code (or check Gemini CLI docs)"],
+    ["aider", "Install: pip install aider-chat"]
+  ];
+  for (const [agent, fixHint] of agents) {
+    const result = await checkBinary(agent);
+    checks.push({
+      name: `agent:${agent}`,
+      label: `Agent: ${agent}`,
+      ok: result.ok,
+      detail: result.ok ? `${result.version} (${result.path})` : "Not found",
+      fix: result.ok ? null : fixHint
+    });
+  }
+
+  // 6. Core binaries
+  for (const bin of ["node", "npm", "git"]) {
+    const result = await checkBinary(bin);
+    checks.push({
+      name: bin,
+      label: bin,
+      ok: result.ok,
+      detail: result.ok ? result.version : "Not found",
+      fix: result.ok ? null : `Install ${bin} from its official website.`
+    });
+  }
+
+  // 7. Review rules / Coder rules
+  const projectDir = config.projectDir || process.cwd();
+  const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir));
+  const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
+  checks.push({
+    name: "review-rules",
+    label: "Reviewer rules (.md)",
+    ok: Boolean(reviewRules),
+    detail: reviewRules ? "Found" : "Not found (will use defaults)",
+    fix: null
+  });
+  checks.push({
+    name: "coder-rules",
+    label: "Coder rules (.md)",
+    ok: Boolean(coderRules),
+    detail: coderRules ? "Found" : "Not found (will use defaults)",
+    fix: null
+  });
+
+  return checks;
 }
 
 export async function doctorCommand({ config }) {
-  const binaries = [
-    ["node"],
-    ["npm"],
-    ["git"],
-    ["docker"],
-    ["claude"],
-    ["codex"],
-    ["gemini"],
-    ["aider"]
-  ];
+  const checks = await runChecks({ config });
 
-  const results = [];
-  for (const [binary] of binaries) {
-    results.push([binary, await checkBinary(binary)]);
+  for (const check of checks) {
+    const icon = check.ok ? "OK  " : "MISS";
+    console.log(`${icon} ${check.label}: ${check.detail}`);
+    if (check.fix) {
+      console.log(`     -> ${check.fix}`);
+    }
   }
 
-  for (const [binary, result] of results) {
-    const output = (result.output || "").split("\n")[0];
-    console.log(`${result.ok ? "OK" : "MISS"} ${binary}: ${output} (${result.path})`);
+  const failures = checks.filter((c) => !c.ok && c.fix);
+  if (failures.length === 0) {
+    console.log("\nAll checks passed.");
+  } else {
+    console.log(`\n${failures.length} issue(s) found.`);
   }
 
-  console.log(`Review mode: ${config.review_mode}`);
-  console.log(`Sonar profile: ${config.sonarqube.enforcement_profile}`);
+  return checks;
 }

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/bin/${name}`)
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  exists: vi.fn(),
+  ensureDir: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  getConfigPath: vi.fn().mockReturnValue("/home/user/.karajan/kj.config.yml"),
+  loadConfig: vi.fn(),
+  applyRunOverrides: vi.fn(),
+  validateConfig: vi.fn(),
+  resolveRole: vi.fn()
+}));
+
+vi.mock("../src/sonar/manager.js", () => ({
+  isSonarReachable: vi.fn()
+}));
+
+vi.mock("../src/roles/base-role.js", () => ({
+  resolveRoleMdPath: vi.fn().mockReturnValue(["/fake/reviewer.md"]),
+  loadFirstExisting: vi.fn()
+}));
+
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn()
+}));
+
+const baseConfig = {
+  review_mode: "standard",
+  sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" }
+};
+
+describe("doctor", () => {
+  let runChecks, doctorCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { runCommand } = await import("../src/utils/process.js");
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+
+    const { exists } = await import("../src/utils/fs.js");
+    exists.mockResolvedValue(true);
+
+    const { isSonarReachable } = await import("../src/sonar/manager.js");
+    isSonarReachable.mockResolvedValue(true);
+
+    const { ensureGitRepo } = await import("../src/utils/git.js");
+    ensureGitRepo.mockResolvedValue(true);
+
+    const { loadFirstExisting } = await import("../src/roles/base-role.js");
+    loadFirstExisting.mockResolvedValue("rules content");
+
+    const mod = await import("../src/commands/doctor.js");
+    runChecks = mod.runChecks;
+    doctorCommand = mod.doctorCommand;
+  });
+
+  describe("runChecks", () => {
+    it("returns an array of check results", async () => {
+      const checks = await runChecks({ config: baseConfig });
+      expect(Array.isArray(checks)).toBe(true);
+      expect(checks.length).toBeGreaterThan(5);
+    });
+
+    it("includes config, git, docker, sonarqube, agents, and rules checks", async () => {
+      const checks = await runChecks({ config: baseConfig });
+      const names = checks.map((c) => c.name);
+
+      expect(names).toContain("config");
+      expect(names).toContain("git");
+      expect(names).toContain("docker");
+      expect(names).toContain("sonarqube");
+      expect(names).toContain("agent:claude");
+      expect(names).toContain("agent:codex");
+      expect(names).toContain("agent:gemini");
+      expect(names).toContain("agent:aider");
+      expect(names).toContain("review-rules");
+      expect(names).toContain("coder-rules");
+    });
+
+    it("marks config as OK when file exists", async () => {
+      const checks = await runChecks({ config: baseConfig });
+      const configCheck = checks.find((c) => c.name === "config");
+      expect(configCheck.ok).toBe(true);
+    });
+
+    it("marks config as MISS when file does not exist", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false);
+
+      const checks = await runChecks({ config: baseConfig });
+      const configCheck = checks.find((c) => c.name === "config");
+      expect(configCheck.ok).toBe(false);
+      expect(configCheck.fix).toContain("kj init");
+    });
+
+    it("marks git as MISS when not in a repo", async () => {
+      const { ensureGitRepo } = await import("../src/utils/git.js");
+      ensureGitRepo.mockResolvedValue(false);
+
+      const checks = await runChecks({ config: baseConfig });
+      const gitCheck = checks.find((c) => c.name === "git");
+      expect(gitCheck.ok).toBe(false);
+      expect(gitCheck.fix).toContain("git init");
+    });
+
+    it("marks sonar as OK when disabled in config", async () => {
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+      isSonarReachable.mockResolvedValue(false);
+
+      const config = { ...baseConfig, sonarqube: { ...baseConfig.sonarqube, enabled: false } };
+      const checks = await runChecks({ config });
+      const sonarCheck = checks.find((c) => c.name === "sonarqube");
+      expect(sonarCheck.ok).toBe(true);
+      expect(sonarCheck.detail).toContain("Disabled");
+    });
+
+    it("marks sonar as MISS when not reachable", async () => {
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+      isSonarReachable.mockResolvedValue(false);
+
+      const checks = await runChecks({ config: baseConfig });
+      const sonarCheck = checks.find((c) => c.name === "sonarqube");
+      expect(sonarCheck.ok).toBe(false);
+      expect(sonarCheck.fix).toContain("kj sonar start");
+    });
+
+    it("marks agent as MISS when binary not found", async () => {
+      const { runCommand } = await import("../src/utils/process.js");
+      // Make only claude fail
+      runCommand.mockImplementation((cmd) => {
+        if (cmd.includes("claude")) {
+          return Promise.resolve({ exitCode: 1, stdout: "", stderr: "not found" });
+        }
+        return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+      });
+
+      const checks = await runChecks({ config: baseConfig });
+      const claudeCheck = checks.find((c) => c.name === "agent:claude");
+      expect(claudeCheck.ok).toBe(false);
+      expect(claudeCheck.fix).toContain("npm install");
+    });
+
+    it("each check has name, label, ok, detail fields", async () => {
+      const checks = await runChecks({ config: baseConfig });
+      for (const check of checks) {
+        expect(check).toHaveProperty("name");
+        expect(check).toHaveProperty("label");
+        expect(typeof check.ok).toBe("boolean");
+        expect(check).toHaveProperty("detail");
+      }
+    });
+  });
+
+  describe("doctorCommand", () => {
+    it("returns check results", async () => {
+      const checks = await doctorCommand({ config: baseConfig });
+      expect(Array.isArray(checks)).toBe(true);
+    });
+
+    it("prints fix suggestions for failed checks", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false);
+
+      await doctorCommand({ config: baseConfig });
+
+      const output = console.log.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("->");
+      expect(output).toContain("kj init");
+    });
+
+    it("prints 'All checks passed' when everything is OK", async () => {
+      await doctorCommand({ config: baseConfig });
+
+      const output = console.log.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("All checks passed");
+    });
+
+    it("prints issue count when there are failures", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false);
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+      isSonarReachable.mockResolvedValue(false);
+
+      await doctorCommand({ config: baseConfig });
+
+      const output = console.log.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toMatch(/\d+ issue/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrite `kj doctor` with structured check results covering all key dependencies
- Checks: config file, git repo, Docker, SonarQube reachability, agent CLIs (claude, codex, gemini, aider), core binaries (node, npm, git), reviewer/coder rules (.md)
- Each failed check shows a specific fix suggestion (e.g., `Run 'kj init'`, `Run 'kj sonar start'`, `npm install -g ...`)
- SonarQube disabled in config correctly shows "Disabled" instead of failing
- Export `runChecks()` for programmatic use (MCP integration, testing)
- 13 new tests covering all check types, pass/fail scenarios, fix suggestions, and output formatting

## Test plan
- [x] All 340 tests pass across 45 files
- [x] Config missing → fix suggestion with `kj init`
- [x] Git not a repo → fix with `git init`
- [x] SonarQube unreachable → fix with `kj sonar start`
- [x] SonarQube disabled → shows "Disabled" (OK)
- [x] Agent binary missing → shows install command
- [x] All checks pass → "All checks passed" message