### PR TITLE
feat(init): cross-platform SonarQube setup improvements

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -333,16 +333,16 @@ async function ensureSonarQube(kjHome, nonInteractive) {
 
   // Check if sonarqube container is already running
   const ps = await run("docker", ["ps", "--format", "{{.Names}}"]);
-  if (ps.stdout.split("\n").some((n) => n.trim() === "sonarqube")) {
+  if (ps.stdout.split("\n").some((n) => n.trim() === "karajan-sonarqube")) {
     console.log("SonarQube already running at " + sonarUrl);
     return true;
   }
 
   // Check if container exists but is stopped
   const psAll = await run("docker", ["ps", "-a", "--format", "{{.Names}}"]);
-  if (psAll.stdout.split("\n").some((n) => n.trim() === "sonarqube")) {
+  if (psAll.stdout.split("\n").some((n) => n.trim() === "karajan-sonarqube")) {
     console.log("SonarQube container exists but stopped, starting...");
-    const start = await run("docker", ["start", "sonarqube-db", "sonarqube"]);
+    const start = await run("docker", ["start", "karajan-sonarqube"]);
     if (start.exitCode === 0) {
       console.log("SonarQube started at " + sonarUrl);
       return true;
@@ -361,6 +361,18 @@ async function ensureSonarQube(kjHome, nonInteractive) {
     } catch {
       console.log("docker-compose.sonar.yml template not found, skipping Docker setup.");
       return false;
+    }
+  }
+
+  // Check vm.max_map_count on Linux/WSL2 (required by Elasticsearch in SonarQube)
+  if (os.platform() === "linux") {
+    const sysctl = await run("sysctl", ["vm.max_map_count"]);
+    const match = sysctl.stdout?.match(/=\s*(\d+)/);
+    const current = match ? Number(match[1]) : 0;
+    if (current < 262144) {
+      console.log(`\nvm.max_map_count = ${current} (needs >= 262144 for SonarQube)`);
+      console.log("Fix with: sudo sysctl -w vm.max_map_count=262144");
+      console.log("Persist: echo 'vm.max_map_count=262144' | sudo tee -a /etc/sysctl.conf\n");
     }
   }
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,10 +1,16 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { getConfigPath, loadConfig, writeConfig } from "../config.js";
-import { sonarUp } from "../sonar/manager.js";
-import { exists } from "../utils/fs.js";
+import { sonarUp, checkVmMaxMapCount } from "../sonar/manager.js";
+import { exists, ensureDir } from "../utils/fs.js";
+import { getKarajanHome } from "../utils/paths.js";
 
 export async function initCommand({ logger }) {
+  const karajanHome = getKarajanHome();
+  await ensureDir(karajanHome);
+  logger.info(`Ensured ${karajanHome} exists`);
+
   const configPath = getConfigPath();
   const reviewRulesPath = path.resolve(process.cwd(), "review-rules.md");
   const coderRulesPath = path.resolve(process.cwd(), "coder-rules.md");
@@ -45,10 +51,27 @@ export async function initCommand({ logger }) {
     logger.info("Created coder-rules.md");
   }
 
+  const vmCheck = await checkVmMaxMapCount(os.platform());
+  if (!vmCheck.ok) {
+    logger.warn(`vm.max_map_count check failed: ${vmCheck.reason}`);
+    if (vmCheck.fix) {
+      logger.warn(`Fix: ${vmCheck.fix}`);
+    }
+  }
+
   const sonar = await sonarUp();
   if (sonar.exitCode !== 0) {
     throw new Error(`Failed to start SonarQube: ${sonar.stderr || sonar.stdout}`);
   }
 
   logger.info("SonarQube container started");
+
+  logger.info("");
+  logger.info("To configure the SonarQube token:");
+  logger.info("  1. Open http://localhost:9000");
+  logger.info("  2. Log in (default credentials: admin / admin)");
+  logger.info("  3. Go to: My Account > Security > Generate Token");
+  logger.info("  4. Name: karajan-cli, Type: Global Analysis Token");
+  logger.info("  5. Set the token in ~/.karajan/kj.config.yml under sonarqube.token");
+  logger.info("     or export KJ_SONAR_TOKEN=\"<your-token>\"");
 }

--- a/src/sonar/manager.js
+++ b/src/sonar/manager.js
@@ -77,3 +77,33 @@ export async function sonarStatus() {
 export async function sonarLogs() {
   return runCommand("docker", ["logs", "--tail", "100", "karajan-sonarqube"]);
 }
+
+const MIN_MAP_COUNT = 262144;
+
+export async function checkVmMaxMapCount(platform) {
+  if (platform === "darwin" || platform === "win32") {
+    return { ok: true, reason: "vm.max_map_count check not required on this platform" };
+  }
+
+  const res = await runCommand("sysctl", ["vm.max_map_count"]);
+  if (res.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: "Could not read vm.max_map_count",
+      fix: `sudo sysctl -w vm.max_map_count=${MIN_MAP_COUNT}`
+    };
+  }
+
+  const match = res.stdout.match(/=\s*(\d+)/);
+  const current = match ? Number(match[1]) : 0;
+
+  if (current >= MIN_MAP_COUNT) {
+    return { ok: true, reason: `vm.max_map_count = ${current}` };
+  }
+
+  return {
+    ok: false,
+    reason: `vm.max_map_count = ${current} (needs >= ${MIN_MAP_COUNT})`,
+    fix: `sudo sysctl -w vm.max_map_count=${MIN_MAP_COUNT} && echo "vm.max_map_count=${MIN_MAP_COUNT}" | sudo tee -a /etc/sysctl.conf`
+  };
+}

--- a/templates/docker-compose.sonar.yml
+++ b/templates/docker-compose.sonar.yml
@@ -12,7 +12,7 @@
 services:
   sonarqube:
     image: sonarqube:community
-    container_name: sonarqube
+    container_name: karajan-sonarqube
     depends_on:
       sonarqube-db:
         condition: service_healthy
@@ -33,7 +33,7 @@ services:
 
   sonarqube-db:
     image: postgres:17
-    container_name: sonarqube-db
+    container_name: karajan-sonarqube-db
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U sonar"]
       interval: 10s

--- a/tests/install-cross-platform.test.js
+++ b/tests/install-cross-platform.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import os from "node:os";
+
+/**
+ * Tests for cross-platform consistency in install.js helper functions.
+ * We test the exported/extractable logic without running the full installer.
+ */
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue(""),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
+    copyFile: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+describe("install cross-platform helpers", () => {
+  describe("container name consistency", () => {
+    it("install.js template docker-compose uses karajan-sonarqube", async () => {
+      const fs = await import("node:fs/promises");
+      // Read the template file
+      const templatePath = `${process.cwd()}/templates/docker-compose.sonar.yml`;
+      // Reset mock to actually read the file
+      const { readFileSync } = await import("node:fs");
+      const content = readFileSync(templatePath, "utf8");
+      // The template currently uses "sonarqube" - after fix it should use "karajan-sonarqube"
+      expect(content).toContain("container_name:");
+    });
+
+    it("manager.js compose template uses karajan-sonarqube", async () => {
+      const managerPath = `${process.cwd()}/src/sonar/manager.js`;
+      const { readFileSync } = await import("node:fs");
+      const content = readFileSync(managerPath, "utf8");
+      expect(content).toContain("karajan-sonarqube");
+    });
+  });
+
+  describe("shell profile detection", () => {
+    it("handles both .bashrc and .zshrc paths", () => {
+      const home = os.homedir();
+      const profiles = [
+        `${home}/.bashrc`,
+        `${home}/.zshrc`
+      ];
+      // Both should be valid file paths
+      for (const p of profiles) {
+        expect(p).toMatch(/\.(bashrc|zshrc)$/);
+      }
+    });
+  });
+
+  describe("SonarQube token instructions", () => {
+    it("install.js contains clear manual token instructions", async () => {
+      const { readFileSync } = await import("node:fs");
+      const content = readFileSync(`${process.cwd()}/scripts/install.js`, "utf8");
+      expect(content).toContain("My Account");
+      expect(content).toContain("Security");
+      expect(content).toContain("Generate Token");
+      expect(content).toContain("Global Analysis Token");
+    });
+  });
+});

--- a/tests/sonar-manager-init.test.js
+++ b/tests/sonar-manager-init.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  ensureDir: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  loadConfig: vi.fn().mockResolvedValue({
+    config: { sonarqube: { host: "http://localhost:9000" } }
+  })
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockResolvedValue("")
+  }
+}));
+
+describe("sonar/manager cross-platform", () => {
+  let runCommand, ensureDir;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../src/utils/process.js");
+    runCommand = proc.runCommand;
+
+    const fsUtils = await import("../src/utils/fs.js");
+    ensureDir = fsUtils.ensureDir;
+
+    const { loadConfig } = await import("../src/config.js");
+    loadConfig.mockResolvedValue({
+      config: { sonarqube: { host: "http://localhost:9000" } }
+    });
+  });
+
+  describe("ensureComposeFile", () => {
+    it("creates KJ_HOME directory and writes compose file", async () => {
+      const fs = await import("node:fs/promises");
+      const { ensureComposeFile } = await import("../src/sonar/manager.js");
+
+      await ensureComposeFile();
+
+      expect(ensureDir).toHaveBeenCalled();
+      expect(fs.default.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining("docker-compose.sonar.yml"),
+        expect.stringContaining("karajan-sonarqube"),
+        "utf8"
+      );
+    });
+
+    it("compose template uses karajan-sonarqube container name", async () => {
+      const fs = await import("node:fs/promises");
+      const { ensureComposeFile } = await import("../src/sonar/manager.js");
+
+      await ensureComposeFile();
+
+      const writeCall = fs.default.writeFile.mock.calls[0];
+      const content = writeCall[1];
+      expect(content).toContain("container_name: karajan-sonarqube");
+      expect(content).not.toContain("container_name: sonarqube\n");
+    });
+  });
+
+  describe("isSonarReachable", () => {
+    it("returns true when curl gets 2xx status", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "200" });
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+
+      const result = await isSonarReachable("http://localhost:9000");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when curl fails", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "" });
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+
+      const result = await isSonarReachable("http://localhost:9000");
+      expect(result).toBe(false);
+    });
+
+    it("returns false on non-2xx status", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "503" });
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+
+      const result = await isSonarReachable("http://localhost:9000");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("sonarUp", () => {
+    it("skips start when SonarQube is already reachable", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "200" });
+      const { sonarUp } = await import("../src/sonar/manager.js");
+
+      const result = await sonarUp("http://localhost:9000");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("already reachable");
+    });
+
+    it("starts container when SonarQube is not reachable", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 1, stdout: "" })  // isSonarReachable
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });  // docker compose up
+
+      const { sonarUp } = await import("../src/sonar/manager.js");
+      const result = await sonarUp("http://localhost:9000");
+
+      expect(result.exitCode).toBe(0);
+      const dockerCall = runCommand.mock.calls[1];
+      expect(dockerCall[0]).toBe("docker");
+      expect(dockerCall[1]).toContain("up");
+    });
+  });
+
+  describe("sonarStatus", () => {
+    it("checks karajan-sonarqube container name", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "Up 2 hours" });
+      const { sonarStatus } = await import("../src/sonar/manager.js");
+
+      await sonarStatus();
+
+      const psCall = runCommand.mock.calls[0];
+      expect(psCall[1]).toContain("name=karajan-sonarqube");
+    });
+  });
+
+  describe("sonarLogs", () => {
+    it("reads logs from karajan-sonarqube container", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "log line" });
+      const { sonarLogs } = await import("../src/sonar/manager.js");
+
+      await sonarLogs();
+
+      const logsCall = runCommand.mock.calls[0];
+      expect(logsCall[1]).toContain("karajan-sonarqube");
+    });
+  });
+
+  describe("checkVmMaxMapCount", () => {
+    it("returns ok on macOS (darwin)", async () => {
+      const { checkVmMaxMapCount } = await import("../src/sonar/manager.js");
+      const result = await checkVmMaxMapCount("darwin");
+      expect(result.ok).toBe(true);
+      expect(result.reason).toContain("not required");
+    });
+
+    it("returns ok when vm.max_map_count is sufficient on Linux", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "vm.max_map_count = 262144" });
+      const { checkVmMaxMapCount } = await import("../src/sonar/manager.js");
+
+      const result = await checkVmMaxMapCount("linux");
+      expect(result.ok).toBe(true);
+    });
+
+    it("returns not ok when vm.max_map_count is too low on Linux", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "vm.max_map_count = 65530" });
+      const { checkVmMaxMapCount } = await import("../src/sonar/manager.js");
+
+      const result = await checkVmMaxMapCount("linux");
+      expect(result.ok).toBe(false);
+      expect(result.fix).toContain("sysctl");
+    });
+
+    it("returns not ok when sysctl fails on Linux", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "" });
+      const { checkVmMaxMapCount } = await import("../src/sonar/manager.js");
+
+      const result = await checkVmMaxMapCount("linux");
+      expect(result.ok).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Unify Docker container names to `karajan-sonarqube` across `manager.js`, `install.js`, and the compose template (was inconsistent: `sonarqube` vs `karajan-sonarqube`)
- Add `vm.max_map_count` check for Linux/WSL2 in both `kj init` and the installer script — warns with fix instructions if below 262144
- Ensure `~/.karajan/` directory is created during `kj init` before writing config
- Add clear SonarQube token setup instructions to `kj init` output

## Test plan
- [ ] Verify CI passes (lint + tests on Node 20.x and 22.x)
- [ ] Test `kj init` on Linux/WSL2 — should warn about vm.max_map_count if too low
- [ ] Test `kj init` on macOS — should skip vm.max_map_count check
- [ ] Verify container name consistency: `docker ps --filter name=karajan-sonarqube`