### PR TITLE
test: add unit tests for CLI command handlers

### DIFF
--- a/tests/command-code.test.js
+++ b/tests/command-code.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/prompts/coder.js", () => ({
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("coder rules content")
+  }
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { coder: { provider: "codex" } },
+    coder_rules: "coder-rules.md",
+    development: { methodology: "tdd" },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/code", () => {
+  let createAgent, assertAgentsAvailable, buildCoderPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const prompts = await import("../src/prompts/coder.js");
+    buildCoderPrompt = prompts.buildCoderPrompt;
+    buildCoderPrompt.mockReturnValue("coder prompt");
+
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockResolvedValue("coder rules content");
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "done", exitCode: 0 })
+    });
+  });
+
+  it("asserts coder provider is available", async () => {
+    const { codeCommand } = await import("../src/commands/code.js");
+    await codeCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["codex"]);
+  });
+
+  it("creates agent with resolved provider", async () => {
+    const { codeCommand } = await import("../src/commands/code.js");
+    const config = makeConfig();
+    await codeCommand({ task: "add feature", config, logger: noopLogger });
+
+    expect(createAgent).toHaveBeenCalledWith("codex", config, noopLogger);
+  });
+
+  it("builds coder prompt with task and rules", async () => {
+    const { codeCommand } = await import("../src/commands/code.js");
+    await codeCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    expect(buildCoderPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      task: "add feature",
+      coderRules: "coder rules content",
+      methodology: "tdd"
+    }));
+  });
+
+  it("runs task with prompt and onOutput callback", async () => {
+    const { codeCommand } = await import("../src/commands/code.js");
+    await codeCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    const agent = createAgent.mock.results[0].value;
+    expect(agent.runTask).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "coder prompt",
+      role: "coder"
+    }));
+  });
+
+  it("throws when coder fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "syntax error", exitCode: 1 })
+    });
+
+    const { codeCommand } = await import("../src/commands/code.js");
+    await expect(
+      codeCommand({ task: "bad code", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("syntax error");
+  });
+
+  it("handles missing coder rules gracefully", async () => {
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockRejectedValue(new Error("ENOENT"));
+
+    const { codeCommand } = await import("../src/commands/code.js");
+    await codeCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    expect(buildCoderPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      coderRules: null
+    }));
+  });
+
+  it("logs completion on success", async () => {
+    const { codeCommand } = await import("../src/commands/code.js");
+    await codeCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    expect(noopLogger.info).toHaveBeenCalledWith(expect.stringContaining("completed"));
+  });
+});

--- a/tests/command-review.test.js
+++ b/tests/command-review.test.js
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  generateDiff: vi.fn().mockResolvedValue("diff --git a/file.js b/file.js\n+added line")
+}));
+
+vi.mock("../src/prompts/reviewer.js", () => ({
+  buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("review rules content")
+  }
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { reviewer: { provider: "claude" } },
+    reviewer_options: { fallback_reviewer: "codex" },
+    base_branch: "main",
+    review_rules: "review-rules.md",
+    review_mode: "standard",
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/review", () => {
+  let createAgent, assertAgentsAvailable, computeBaseRef, generateDiff, buildReviewerPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const diff = await import("../src/review/diff-generator.js");
+    computeBaseRef = diff.computeBaseRef;
+    generateDiff = diff.generateDiff;
+    computeBaseRef.mockResolvedValue("abc123");
+    generateDiff.mockResolvedValue("diff content");
+
+    const prompts = await import("../src/prompts/reviewer.js");
+    buildReviewerPrompt = prompts.buildReviewerPrompt;
+    buildReviewerPrompt.mockReturnValue("reviewer prompt");
+
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockResolvedValue("review rules content");
+
+    createAgent.mockReturnValue({
+      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: '{"approved": true}', exitCode: 0 })
+    });
+  });
+
+  it("asserts reviewer and fallback providers are available", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude", "codex"]);
+  });
+
+  it("creates agent with reviewer provider", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    const config = makeConfig();
+    await reviewCommand({ task: "review task", config, logger: noopLogger });
+
+    expect(createAgent).toHaveBeenCalledWith("claude", config, noopLogger);
+  });
+
+  it("computes base ref from config and override", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger, baseRef: "custom-ref" });
+
+    expect(computeBaseRef).toHaveBeenCalledWith({ baseBranch: "main", baseRef: "custom-ref" });
+  });
+
+  it("generates diff and builds reviewer prompt", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
+
+    expect(generateDiff).toHaveBeenCalledWith({ baseRef: "abc123" });
+    expect(buildReviewerPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      task: "review task",
+      diff: "diff content",
+      reviewRules: "review rules content",
+      mode: "standard"
+    }));
+  });
+
+  it("calls reviewTask with prompt and role", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
+
+    const agent = createAgent.mock.results[0].value;
+    expect(agent.reviewTask).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "reviewer prompt",
+      role: "reviewer"
+    }));
+  });
+
+  it("throws when reviewer fails", async () => {
+    createAgent.mockReturnValue({
+      reviewTask: vi.fn().mockResolvedValue({ ok: false, error: "review crashed", exitCode: 1 })
+    });
+
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await expect(
+      reviewCommand({ task: "bad review", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("review crashed");
+  });
+
+  it("uses fallback rules when review-rules.md is missing", async () => {
+    const fs = await import("node:fs/promises");
+    fs.default.readFile.mockRejectedValue(new Error("ENOENT"));
+
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
+
+    expect(buildReviewerPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      reviewRules: "Focus on critical issues only."
+    }));
+  });
+
+  it("logs completion on success", async () => {
+    const { reviewCommand } = await import("../src/commands/review.js");
+    await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
+
+    expect(noopLogger.info).toHaveBeenCalledWith(expect.stringContaining("completed"));
+  });
+});

--- a/tests/command-run.test.js
+++ b/tests/command-run.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/orchestrator.js", () => ({
+  runFlow: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/activity-log.js", () => ({
+  createActivityLog: vi.fn(() => ({
+    write: vi.fn(),
+    writeEvent: vi.fn()
+  }))
+}));
+
+vi.mock("../src/utils/display.js", () => ({
+  printHeader: vi.fn(),
+  printEvent: vi.fn()
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: {
+      coder: { provider: "codex" },
+      reviewer: { provider: "claude" },
+      planner: { provider: null },
+      refactorer: { provider: null }
+    },
+    pipeline: { planner: { enabled: false }, refactorer: { enabled: false } },
+    reviewer_options: { fallback_reviewer: "codex" },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+  setContext: vi.fn(), onLog: vi.fn()
+};
+
+describe("commands/run", () => {
+  let runFlow, assertAgentsAvailable, printHeader, printEvent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const orch = await import("../src/orchestrator.js");
+    runFlow = orch.runFlow;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const display = await import("../src/utils/display.js");
+    printHeader = display.printHeader;
+    printEvent = display.printEvent;
+
+    runFlow.mockResolvedValue({ approved: true, sessionId: "s1" });
+  });
+
+  it("calls assertAgentsAvailable with required providers", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    await runCommandHandler({ task: "test task", config, logger: noopLogger, flags: {} });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(
+      expect.arrayContaining(["codex", "claude"])
+    );
+  });
+
+  it("includes planner provider when planner is enabled", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig({
+      pipeline: { planner: { enabled: true }, refactorer: { enabled: false } },
+      roles: {
+        coder: { provider: "codex" },
+        reviewer: { provider: "claude" },
+        planner: { provider: "claude" },
+        refactorer: { provider: null }
+      }
+    });
+    await runCommandHandler({ task: "test task", config, logger: noopLogger, flags: {} });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(
+      expect.arrayContaining(["claude"])
+    );
+  });
+
+  it("calls runFlow with task, config, logger, flags, and emitter", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    await runCommandHandler({ task: "do something", config, logger: noopLogger, flags: { dryRun: true } });
+
+    expect(runFlow).toHaveBeenCalledWith(expect.objectContaining({
+      task: "do something",
+      config,
+      logger: noopLogger,
+      flags: { dryRun: true }
+    }));
+  });
+
+  it("prints header and events in normal mode", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    await runCommandHandler({ task: "test", config, logger: noopLogger, flags: {} });
+
+    expect(printHeader).toHaveBeenCalledWith({ task: "test", config });
+  });
+
+  it("does not print header in json mode", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runCommandHandler({ task: "test", config, logger: noopLogger, flags: { json: true } });
+
+    expect(printHeader).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("outputs JSON result in json mode", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    runFlow.mockResolvedValue({ approved: true, sessionId: "s1" });
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runCommandHandler({ task: "test", config, logger: noopLogger, flags: { json: true } });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("approved"));
+    consoleSpy.mockRestore();
+  });
+
+  it("propagates runFlow errors", async () => {
+    const { runCommandHandler } = await import("../src/commands/run.js");
+    const config = makeConfig();
+    runFlow.mockRejectedValue(new Error("orchestrator failed"));
+
+    await expect(
+      runCommandHandler({ task: "test", config, logger: noopLogger, flags: {} })
+    ).rejects.toThrow("orchestrator failed");
+  });
+});

--- a/tests/command-scan.test.js
+++ b/tests/command-scan.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn()
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn(),
+  getOpenIssues: vi.fn()
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  summarizeIssues: vi.fn()
+}));
+
+function makeConfig() {
+  return {
+    sonarqube: { enabled: true, host: "http://localhost:9000" }
+  };
+}
+
+describe("commands/scan", () => {
+  let runSonarScan, getQualityGateStatus, getOpenIssues, summarizeIssues;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const scanner = await import("../src/sonar/scanner.js");
+    runSonarScan = scanner.runSonarScan;
+
+    const api = await import("../src/sonar/api.js");
+    getQualityGateStatus = api.getQualityGateStatus;
+    getOpenIssues = api.getOpenIssues;
+
+    const enforcer = await import("../src/sonar/enforcer.js");
+    summarizeIssues = enforcer.summarizeIssues;
+
+    runSonarScan.mockResolvedValue({ ok: true, projectKey: "my-project" });
+    getQualityGateStatus.mockResolvedValue({ status: "OK" });
+    getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+    summarizeIssues.mockReturnValue("");
+  });
+
+  it("runs sonar scan with config", async () => {
+    const { scanCommand } = await import("../src/commands/scan.js");
+    const config = makeConfig();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await scanCommand({ config });
+    consoleSpy.mockRestore();
+
+    expect(runSonarScan).toHaveBeenCalledWith(config);
+  });
+
+  it("queries quality gate and issues after scan", async () => {
+    const { scanCommand } = await import("../src/commands/scan.js");
+    const config = makeConfig();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await scanCommand({ config });
+    consoleSpy.mockRestore();
+
+    expect(getQualityGateStatus).toHaveBeenCalledWith(config, "my-project");
+    expect(getOpenIssues).toHaveBeenCalledWith(config, "my-project");
+  });
+
+  it("prints project key, quality gate status, and issue count", async () => {
+    const { scanCommand } = await import("../src/commands/scan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await scanCommand({ config: makeConfig() });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("my-project");
+    expect(output).toContain("OK");
+    expect(output).toContain("0");
+    consoleSpy.mockRestore();
+  });
+
+  it("summarizes issues by severity", async () => {
+    getOpenIssues.mockResolvedValue({ total: 3, issues: [{ severity: "MAJOR" }] });
+    summarizeIssues.mockReturnValue("MAJOR: 3");
+
+    const { scanCommand } = await import("../src/commands/scan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await scanCommand({ config: makeConfig() });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("MAJOR: 3");
+    consoleSpy.mockRestore();
+  });
+
+  it("throws when scan fails", async () => {
+    runSonarScan.mockResolvedValue({ ok: false, stderr: "connection refused" });
+
+    const { scanCommand } = await import("../src/commands/scan.js");
+    await expect(scanCommand({ config: makeConfig() })).rejects.toThrow("scan failed");
+  });
+
+  it("does not query issues when scan fails", async () => {
+    runSonarScan.mockResolvedValue({ ok: false, stderr: "timeout" });
+
+    const { scanCommand } = await import("../src/commands/scan.js");
+    try {
+      await scanCommand({ config: makeConfig() });
+    } catch { /* expected */ }
+
+    expect(getQualityGateStatus).not.toHaveBeenCalled();
+    expect(getOpenIssues).not.toHaveBeenCalled();
+  });
+
+  it("prints 'none' when no issues by severity", async () => {
+    summarizeIssues.mockReturnValue("");
+
+    const { scanCommand } = await import("../src/commands/scan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await scanCommand({ config: makeConfig() });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("none");
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 29 unit tests covering the 4 main CLI command handlers: `run`, `code`, `review`, `scan`
- All dependencies mocked (agents, orchestrator, sonar, diff-generator, prompts)
- Tests cover: happy path, error propagation, json mode, missing rules fallback, scan failures

## Test plan
- [ ] Verify CI passes on Node 20.x and 22.x
- [ ] All 386 tests pass (357 existing + 29 new)