### PR TITLE
test: add unit tests for agent implementations

### DIFF
--- a/tests/agents-availability.test.js
+++ b/tests/agents-availability.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => name)
+}));
+
+describe("agents/availability", () => {
+  let runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../src/utils/process.js");
+    runCommand = proc.runCommand;
+  });
+
+  it("does not throw when all agents are available", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+    await expect(assertAgentsAvailable(["claude", "codex"])).resolves.toBeUndefined();
+  });
+
+  it("throws with descriptive error when agent is missing", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+
+    await expect(assertAgentsAvailable(["claude"])).rejects.toThrow(/Missing required AI CLIs/);
+  });
+
+  it("includes install URL in error message", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+
+    try {
+      await assertAgentsAvailable(["codex"]);
+    } catch (e) {
+      expect(e.message).toContain("codex");
+      expect(e.message).toContain("Install:");
+    }
+  });
+
+  it("deduplicates agent names", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+    await assertAgentsAvailable(["claude", "claude", "claude"]);
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips null and undefined entries", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+    await assertAgentsAvailable([null, undefined, "claude"]);
+
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips unknown agent names gracefully", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+    await expect(assertAgentsAvailable(["unknown-agent"])).resolves.toBeUndefined();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("reports multiple missing agents", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1 });
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+
+    try {
+      await assertAgentsAvailable(["claude", "codex"]);
+    } catch (e) {
+      expect(e.message).toContain("claude");
+      expect(e.message).toContain("codex");
+    }
+  });
+
+  it("does not throw for empty array", async () => {
+    const { assertAgentsAvailable } = await import("../src/agents/availability.js");
+    await expect(assertAgentsAvailable([])).resolves.toBeUndefined();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+});

--- a/tests/agents-base.test.js
+++ b/tests/agents-base.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { BaseAgent } from "../src/agents/base-agent.js";
+
+describe("BaseAgent", () => {
+  const config = {
+    roles: {
+      coder: { provider: "codex", model: "gpt-4o" },
+      reviewer: { provider: "claude", model: "sonnet" }
+    },
+    coder_options: { auto_approve: true, model: "fallback-coder-model" },
+    reviewer_options: { model: "fallback-reviewer-model" }
+  };
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+  it("stores name, config, and logger", () => {
+    const agent = new BaseAgent("test", config, logger);
+    expect(agent.name).toBe("test");
+    expect(agent.config).toBe(config);
+    expect(agent.logger).toBe(logger);
+  });
+
+  it("runTask throws not implemented", async () => {
+    const agent = new BaseAgent("test", config, logger);
+    await expect(agent.runTask({})).rejects.toThrow("not implemented");
+  });
+
+  it("reviewTask throws not implemented", async () => {
+    const agent = new BaseAgent("test", config, logger);
+    await expect(agent.reviewTask({})).rejects.toThrow("not implemented");
+  });
+
+  describe("getRoleModel", () => {
+    it("returns role-specific model from config.roles", () => {
+      const agent = new BaseAgent("test", config, logger);
+      expect(agent.getRoleModel("coder")).toBe("gpt-4o");
+      expect(agent.getRoleModel("reviewer")).toBe("sonnet");
+    });
+
+    it("falls back to reviewer_options.model for reviewer role", () => {
+      const agent = new BaseAgent("test", { ...config, roles: {} }, logger);
+      expect(agent.getRoleModel("reviewer")).toBe("fallback-reviewer-model");
+    });
+
+    it("falls back to coder_options.model for coder role", () => {
+      const agent = new BaseAgent("test", { ...config, roles: {} }, logger);
+      expect(agent.getRoleModel("coder")).toBe("fallback-coder-model");
+    });
+
+    it("returns null when no model configured", () => {
+      const agent = new BaseAgent("test", {}, logger);
+      expect(agent.getRoleModel("coder")).toBeNull();
+    });
+  });
+
+  describe("isAutoApproveEnabled", () => {
+    it("returns true for coder when auto_approve is set", () => {
+      const agent = new BaseAgent("test", config, logger);
+      expect(agent.isAutoApproveEnabled("coder")).toBe(true);
+    });
+
+    it("always returns false for reviewer role", () => {
+      const agent = new BaseAgent("test", config, logger);
+      expect(agent.isAutoApproveEnabled("reviewer")).toBe(false);
+    });
+
+    it("returns false when auto_approve is not set", () => {
+      const agent = new BaseAgent("test", { coder_options: {} }, logger);
+      expect(agent.isAutoApproveEnabled("coder")).toBe(false);
+    });
+  });
+});

--- a/tests/agents-implementations.test.js
+++ b/tests/agents-implementations.test.js
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  session: { max_iteration_minutes: 10 },
+  roles: { coder: { model: null }, reviewer: { model: null } },
+  coder_options: { auto_approve: false },
+  reviewer_options: {}
+};
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("Agent implementations", () => {
+  let runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "output", stderr: "" });
+  });
+
+  describe("ClaudeAgent", () => {
+    it("runs task with claude -p and prompt", async () => {
+      const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+      expect(runCommand).toHaveBeenCalledWith(
+        "/usr/local/bin/claude",
+        ["-p", "fix bug"],
+        expect.objectContaining({ timeout: 600000 })
+      );
+    });
+
+    it("adds --model flag when model is configured", async () => {
+      const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
+      const config = { ...baseConfig, roles: { coder: { model: "opus" }, reviewer: {} } };
+      const agent = new ClaudeAgent("claude", config, logger);
+      await agent.runTask({ prompt: "fix", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("opus");
+    });
+
+    it("reviews task with --output-format json", async () => {
+      const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--output-format");
+      expect(args).toContain("json");
+    });
+
+    it("returns ok=false on non-zero exit", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error" });
+      const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "fail", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toBe("error");
+    });
+
+    it("passes onOutput callback to runCommand", async () => {
+      const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const onOutput = vi.fn();
+      await agent.runTask({ prompt: "work", role: "coder", onOutput });
+
+      expect(runCommand).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ onOutput })
+      );
+    });
+  });
+
+  describe("CodexAgent", () => {
+    it("runs task with codex exec and prompt as last arg", async () => {
+      const { CodexAgent } = await import("../src/agents/codex-agent.js");
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({ prompt: "add tests", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("exec");
+      expect(args[args.length - 1]).toBe("add tests");
+    });
+
+    it("adds --full-auto when auto_approve is enabled", async () => {
+      const { CodexAgent } = await import("../src/agents/codex-agent.js");
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--full-auto");
+    });
+
+    it("does not add --full-auto for reviewer role", async () => {
+      const { CodexAgent } = await import("../src/agents/codex-agent.js");
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--full-auto");
+    });
+
+    it("adds --model flag when configured", async () => {
+      const { CodexAgent } = await import("../src/agents/codex-agent.js");
+      const config = { ...baseConfig, roles: { coder: { model: "o3-mini" }, reviewer: {} } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("o3-mini");
+    });
+
+    it("returns structured result", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "warn" });
+      const { CodexAgent } = await import("../src/agents/codex-agent.js");
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "work", role: "coder" });
+
+      expect(result).toEqual({ ok: true, output: "done", error: "warn", exitCode: 0 });
+    });
+  });
+
+  describe("GeminiAgent", () => {
+    it("runs task with gemini -p and prompt", async () => {
+      const { GeminiAgent } = await import("../src/agents/gemini-agent.js");
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "refactor", role: "coder" });
+
+      expect(runCommand).toHaveBeenCalledWith(
+        "/usr/local/bin/gemini",
+        ["-p", "refactor"],
+        expect.objectContaining({ timeout: 600000 })
+      );
+    });
+
+    it("reviews with --output-format json", async () => {
+      const { GeminiAgent } = await import("../src/agents/gemini-agent.js");
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--output-format");
+      expect(args).toContain("json");
+    });
+
+    it("adds model when configured", async () => {
+      const { GeminiAgent } = await import("../src/agents/gemini-agent.js");
+      const config = { ...baseConfig, roles: { coder: { model: "gemini-2.5-pro" }, reviewer: {} } };
+      const agent = new GeminiAgent("gemini", config, logger);
+      await agent.runTask({ prompt: "work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("gemini-2.5-pro");
+    });
+  });
+
+  describe("AiderAgent", () => {
+    it("runs task with aider --yes --message", async () => {
+      const { AiderAgent } = await import("../src/agents/aider-agent.js");
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "fix issue", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--yes");
+      expect(args).toContain("--message");
+      expect(args).toContain("fix issue");
+    });
+
+    it("reviews with same --yes --message pattern", async () => {
+      const { AiderAgent } = await import("../src/agents/aider-agent.js");
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--yes");
+      expect(args).toContain("--message");
+      expect(args).toContain("review code");
+    });
+
+    it("adds model when configured", async () => {
+      const { AiderAgent } = await import("../src/agents/aider-agent.js");
+      const config = { ...baseConfig, roles: { coder: { model: "gpt-4-turbo" }, reviewer: {} } };
+      const agent = new AiderAgent("aider", config, logger);
+      await agent.runTask({ prompt: "work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("gpt-4-turbo");
+    });
+  });
+});

--- a/tests/agents-index.test.js
+++ b/tests/agents-index.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAgent } from "../src/agents/index.js";
+import { ClaudeAgent } from "../src/agents/claude-agent.js";
+import { CodexAgent } from "../src/agents/codex-agent.js";
+import { GeminiAgent } from "../src/agents/gemini-agent.js";
+import { AiderAgent } from "../src/agents/aider-agent.js";
+
+const config = { session: { max_iteration_minutes: 5 } };
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("agents/index createAgent", () => {
+  it("creates ClaudeAgent for 'claude'", () => {
+    const agent = createAgent("claude", config, logger);
+    expect(agent).toBeInstanceOf(ClaudeAgent);
+  });
+
+  it("creates CodexAgent for 'codex'", () => {
+    const agent = createAgent("codex", config, logger);
+    expect(agent).toBeInstanceOf(CodexAgent);
+  });
+
+  it("creates GeminiAgent for 'gemini'", () => {
+    const agent = createAgent("gemini", config, logger);
+    expect(agent).toBeInstanceOf(GeminiAgent);
+  });
+
+  it("creates AiderAgent for 'aider'", () => {
+    const agent = createAgent("aider", config, logger);
+    expect(agent).toBeInstanceOf(AiderAgent);
+  });
+
+  it("throws for unsupported agent name", () => {
+    expect(() => createAgent("gpt5", config, logger)).toThrow("Unsupported agent: gpt5");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 39 unit tests covering all agent modules: BaseAgent, Claude, Codex, Gemini, Aider, availability, and factory
- All subprocess calls mocked via `runCommand` and `resolveBin`
- Tests verify: command construction, model flags, auto-approve logic, output format, error propagation, missing agent detection with install URLs

## Test plan
- [ ] Verify CI passes on Node 20.x and 22.x
- [ ] All 425 tests pass (386 existing + 39 new)