### PR TITLE
feat(plan): implement complete kj plan command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -131,9 +131,11 @@ program
   .argument("<task>")
   .option("--planner <name>")
   .option("--planner-model <name>")
+  .option("--context <text>", "Additional context for the planner")
+  .option("--json", "Output raw JSON plan")
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
-      await planCommand({ task, config, logger });
+      await planCommand({ task, config, logger, json: flags.json, context: flags.context });
     });
   });
 

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -1,15 +1,67 @@
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
+import { buildPlannerPrompt } from "../prompts/planner.js";
+import { parseMaybeJsonString } from "../review/parser.js";
 
-export async function planCommand({ task, config, logger }) {
+function formatPlan(plan) {
+  const lines = [];
+
+  if (plan.approach) {
+    lines.push("## Approach", plan.approach, "");
+  }
+
+  if (plan.steps?.length) {
+    lines.push("## Steps");
+    for (let i = 0; i < plan.steps.length; i++) {
+      const step = plan.steps[i];
+      const commit = step.commit ? ` → \`${step.commit}\`` : "";
+      lines.push(`${i + 1}. ${step.description}${commit}`);
+    }
+    lines.push("");
+  }
+
+  if (plan.risks?.length) {
+    lines.push("## Risks");
+    for (const risk of plan.risks) {
+      lines.push(`- ${risk}`);
+    }
+    lines.push("");
+  }
+
+  if (plan.outOfScope?.length) {
+    lines.push("## Out of scope");
+    for (const item of plan.outOfScope) {
+      lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export async function planCommand({ task, config, logger, json, context }) {
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);
+
   const planner = createAgent(plannerRole.provider, config, logger);
-  const prompt = `Create an implementation plan for this task:\n\n${task}\n\nOutput concise numbered steps.`;
+  const prompt = buildPlannerPrompt({ task, context });
   const result = await planner.runTask({ prompt, role: "planner" });
+
   if (!result.ok) {
     throw new Error(result.error || result.output || "Planner failed");
   }
-  console.log(result.output);
+
+  const parsed = parseMaybeJsonString(result.output);
+
+  if (json) {
+    console.log(JSON.stringify(parsed || result.output, null, 2));
+    return;
+  }
+
+  if (parsed && parsed.approach) {
+    console.log(formatPlan(parsed));
+  } else {
+    console.log(result.output);
+  }
 }

--- a/src/prompts/planner.js
+++ b/src/prompts/planner.js
@@ -1,0 +1,26 @@
+export function buildPlannerPrompt({ task, context }) {
+  const parts = [
+    "You are an expert software architect. Create an implementation plan for the following task.",
+    "",
+    "## Task",
+    task,
+    ""
+  ];
+
+  if (context) {
+    parts.push("## Context", context, "");
+  }
+
+  parts.push(
+    "## Output format",
+    "Respond with a JSON object containing:",
+    "- `approach`: A concise paragraph describing the overall strategy",
+    "- `steps`: An array of objects, each with `description` (what to do) and `commit` (conventional commit message). Each step should correspond to a single commit.",
+    "- `risks`: An array of strings describing potential risks or challenges",
+    "- `outOfScope`: An array of strings listing what is explicitly NOT included",
+    "",
+    "Respond ONLY with valid JSON, no markdown fences or extra text."
+  );
+
+  return parts.join("\n");
+}

--- a/tests/command-plan.test.js
+++ b/tests/command-plan.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || "claude"
+  }))
+}));
+
+vi.mock("../src/prompts/planner.js", () => ({
+  buildPlannerPrompt: vi.fn().mockReturnValue("planner prompt")
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { planner: { provider: "claude" } },
+    session: { max_iteration_minutes: 10 },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+const validPlan = JSON.stringify({
+  approach: "Use modular design",
+  steps: [
+    { description: "Create database schema", commit: "feat: add user schema" },
+    { description: "Add API endpoints", commit: "feat: add auth endpoints" }
+  ],
+  risks: ["Token expiration handling"],
+  outOfScope: ["OAuth2 support"]
+});
+
+describe("commands/plan", () => {
+  let createAgent, assertAgentsAvailable, buildPlannerPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const prompts = await import("../src/prompts/planner.js");
+    buildPlannerPrompt = prompts.buildPlannerPrompt;
+    buildPlannerPrompt.mockReturnValue("planner prompt");
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: validPlan, exitCode: 0 })
+    });
+  });
+
+  it("asserts planner agent is available", async () => {
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    consoleSpy.mockRestore();
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("builds planner prompt with task", async () => {
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    consoleSpy.mockRestore();
+
+    expect(buildPlannerPrompt).toHaveBeenCalledWith(expect.objectContaining({
+      task: "Add auth"
+    }));
+  });
+
+  it("calls agent runTask with prompt and planner role", async () => {
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    consoleSpy.mockRestore();
+
+    const agent = createAgent.mock.results[0].value;
+    expect(agent.runTask).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "planner prompt",
+      role: "planner"
+    }));
+  });
+
+  it("prints formatted plan on success", async () => {
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("modular design");
+    expect(output).toContain("database schema");
+    consoleSpy.mockRestore();
+  });
+
+  it("outputs raw JSON in json mode", async () => {
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger, json: true });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain('"approach"');
+    consoleSpy.mockRestore();
+  });
+
+  it("throws when planner agent fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "planner crashed", exitCode: 1 })
+    });
+
+    const { planCommand } = await import("../src/commands/plan.js");
+    await expect(
+      planCommand({ task: "Bad plan", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("planner crashed");
+  });
+
+  it("handles non-JSON output gracefully", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "Plain text plan:\n1. Do this\n2. Do that", exitCode: 0 })
+    });
+
+    const { planCommand } = await import("../src/commands/plan.js");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planCommand({ task: "Add feature", config: makeConfig(), logger: noopLogger });
+
+    const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("Do this");
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/prompt-planner.test.js
+++ b/tests/prompt-planner.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildPlannerPrompt } from "../src/prompts/planner.js";
+
+describe("prompts/planner buildPlannerPrompt", () => {
+  it("includes the task in the prompt", () => {
+    const prompt = buildPlannerPrompt({ task: "Add user authentication" });
+    expect(prompt).toContain("Add user authentication");
+  });
+
+  it("requests JSON output with required fields", () => {
+    const prompt = buildPlannerPrompt({ task: "Refactor DB layer" });
+    expect(prompt).toContain("approach");
+    expect(prompt).toContain("steps");
+    expect(prompt).toContain("risks");
+    expect(prompt).toContain("outOfScope");
+  });
+
+  it("includes context when provided", () => {
+    const prompt = buildPlannerPrompt({
+      task: "Add caching",
+      context: "We use Redis in production"
+    });
+    expect(prompt).toContain("Redis");
+  });
+
+  it("works without optional context", () => {
+    const prompt = buildPlannerPrompt({ task: "Simple fix" });
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(50);
+  });
+
+  it("requests each step to be a single commit", () => {
+    const prompt = buildPlannerPrompt({ task: "Big refactor" });
+    expect(prompt.toLowerCase()).toContain("commit");
+  });
+
+  it("asks for structured JSON format", () => {
+    const prompt = buildPlannerPrompt({ task: "Add feature" });
+    expect(prompt).toContain("JSON");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/prompts/planner.js` with structured prompt that requests JSON output (approach, steps, risks, outOfScope)
- Rewrite `src/commands/plan.js` to parse JSON agent output and format it for display
- Add `--json` flag for raw JSON output and `--context` flag for additional context
- Each step maps to a single conventional commit message
- Gracefully handles non-JSON agent output by displaying raw text

## Test plan
- [ ] Verify CI passes on Node 20.x and 22.x
- [ ] All 438 tests pass (425 existing + 13 new)
- [ ] Test `kj plan "Add auth"` produces formatted plan
- [ ] Test `kj plan "Add auth" --json` produces raw JSON