### PR TITLE
feat(roles): implement CommiterRole for git operations

### DIFF
--- a/src/roles/commiter-role.js
+++ b/src/roles/commiter-role.js
@@ -1,0 +1,94 @@
+import { BaseRole } from "./base-role.js";
+import {
+  ensureGitRepo,
+  currentBranch,
+  fetchBase,
+  ensureBranchUpToDateWithBase,
+  hasChanges,
+  commitAll,
+  pushBranch,
+  createPullRequest,
+  revParse
+} from "../utils/git.js";
+
+function buildCommitMessage(task) {
+  const clean = String(task || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  const prefix = "feat: ";
+  const maxBody = 72 - prefix.length;
+  return `${prefix}${clean.slice(0, maxBody) || "update"}`;
+}
+
+function buildPrTitle(task) {
+  const clean = String(task || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return clean.slice(0, 70) || "Karajan update";
+}
+
+export class CommiterRole extends BaseRole {
+  constructor({ config, logger, emitter = null }) {
+    super({ name: "commiter", config, logger, emitter });
+  }
+
+  async execute(input) {
+    const { task, commitMessage, push = false, createPr = false } = input || {};
+
+    const isRepo = await ensureGitRepo();
+    if (!isRepo) {
+      return {
+        ok: false,
+        result: { error: "Current directory is not a git repository" },
+        summary: "Commiter failed: not a git repo"
+      };
+    }
+
+    const branch = await currentBranch();
+    const changes = await hasChanges();
+
+    if (!changes) {
+      return {
+        ok: true,
+        result: { branch, committed: false, commitHash: null, prUrl: null },
+        summary: "No changes to commit"
+      };
+    }
+
+    const msg = commitMessage || buildCommitMessage(task);
+    await commitAll(msg);
+    const commitHash = await revParse("HEAD");
+
+    if (push) {
+      const baseBranch = this.config.base_branch || "main";
+      await fetchBase(baseBranch);
+      await ensureBranchUpToDateWithBase({
+        branch,
+        baseBranch,
+        autoRebase: true
+      });
+      await pushBranch(branch);
+    }
+
+    let prUrl = null;
+    if (push && createPr) {
+      const baseBranch = this.config.base_branch || "main";
+      prUrl = await createPullRequest({
+        baseBranch,
+        branch,
+        title: buildPrTitle(task),
+        body: `Task: ${task || "N/A"}`
+      });
+    }
+
+    const parts = [`Committed on ${branch}`];
+    if (push) parts.push("pushed");
+    if (prUrl) parts.push(`PR: ${prUrl}`);
+
+    return {
+      ok: true,
+      result: { branch, committed: true, commitHash, prUrl },
+      summary: parts.join(", ")
+    };
+  }
+}

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -1,3 +1,4 @@
 export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./base-role.js";
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
+export { CommiterRole } from "./commiter-role.js";

--- a/tests/commiter-role.test.js
+++ b/tests/commiter-role.test.js
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+// Mock git utilities before importing CommiterRole
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn(),
+  currentBranch: vi.fn(),
+  fetchBase: vi.fn(),
+  syncBaseBranch: vi.fn(),
+  ensureBranchUpToDateWithBase: vi.fn(),
+  createBranch: vi.fn(),
+  buildBranchName: vi.fn(),
+  hasChanges: vi.fn(),
+  commitAll: vi.fn(),
+  pushBranch: vi.fn(),
+  createPullRequest: vi.fn(),
+  revParse: vi.fn()
+}));
+
+const { CommiterRole } = await import("../src/roles/commiter-role.js");
+const git = await import("../src/utils/git.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("CommiterRole", () => {
+  let emitter;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    // Defaults: we're in a git repo with changes
+    git.ensureGitRepo.mockResolvedValue(true);
+    git.hasChanges.mockResolvedValue(true);
+    git.currentBranch.mockResolvedValue("feat/my-branch");
+    git.commitAll.mockResolvedValue({ committed: true });
+    git.pushBranch.mockResolvedValue(undefined);
+    git.createPullRequest.mockResolvedValue("https://github.com/org/repo/pull/42");
+    git.fetchBase.mockResolvedValue(undefined);
+    git.ensureBranchUpToDateWithBase.mockResolvedValue({ upToDate: true, rebased: false });
+    git.revParse.mockResolvedValue("abc1234");
+  });
+
+  it("extends BaseRole and has name 'commiter'", () => {
+    const role = new CommiterRole({ config: {}, logger });
+    expect(role.name).toBe("commiter");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new CommiterRole({ config: {}, logger });
+    await expect(role.run({})).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("commits changes with conventional commit message", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({ task: "Add user authentication" });
+    const output = await role.run({ task: "Add user authentication" });
+
+    expect(output.ok).toBe(true);
+    expect(git.commitAll).toHaveBeenCalled();
+    const commitMsg = git.commitAll.mock.calls[0][0];
+    expect(commitMsg.length).toBeLessThanOrEqual(72);
+  });
+
+  it("uses provided commitMessage from input", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({ task: "Fix login" });
+    await role.run({ task: "Fix login", commitMessage: "fix: resolve login null pointer" });
+
+    expect(git.commitAll).toHaveBeenCalledWith("fix: resolve login null pointer");
+  });
+
+  it("generates commit message from task when not provided", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({ task: "Add widget feature" });
+    await role.run({ task: "Add widget feature" });
+
+    const commitMsg = git.commitAll.mock.calls[0][0];
+    expect(commitMsg).toMatch(/^feat: /);
+    expect(commitMsg).toContain("Add widget feature");
+  });
+
+  it("pushes branch when push is true", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Add feature", push: true });
+
+    expect(git.pushBranch).toHaveBeenCalledWith("feat/my-branch");
+  });
+
+  it("does NOT push branch when push is false", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Add feature", push: false });
+
+    expect(git.pushBranch).not.toHaveBeenCalled();
+  });
+
+  it("creates PR when createPr is true", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    const output = await role.run({ task: "Add feature", push: true, createPr: true });
+
+    expect(git.createPullRequest).toHaveBeenCalled();
+    expect(output.result.prUrl).toBe("https://github.com/org/repo/pull/42");
+  });
+
+  it("does NOT create PR when createPr is false", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Add feature", push: true, createPr: false });
+
+    expect(git.createPullRequest).not.toHaveBeenCalled();
+  });
+
+  it("returns ok=false when not in a git repo", async () => {
+    git.ensureGitRepo.mockResolvedValue(false);
+
+    const role = new CommiterRole({ config: {}, logger });
+    await role.init({});
+    const output = await role.run({ task: "Fix bug" });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("git");
+  });
+
+  it("returns ok=true with committed=false when no changes", async () => {
+    git.hasChanges.mockResolvedValue(false);
+
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    const output = await role.run({ task: "No changes" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.committed).toBe(false);
+    expect(git.commitAll).not.toHaveBeenCalled();
+  });
+
+  it("rebases before push when baseBranch configured", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Feature", push: true });
+
+    expect(git.fetchBase).toHaveBeenCalledWith("main");
+    expect(git.ensureBranchUpToDateWithBase).toHaveBeenCalled();
+  });
+
+  it("returns result with branch and commit hash", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    const output = await role.run({ task: "Add feature" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.branch).toBe("feat/my-branch");
+    expect(output.result.commitHash).toBe("abc1234");
+    expect(output.result.committed).toBe(true);
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger, emitter });
+    await role.init({ task: "Task", iteration: 1 });
+    await role.run({ task: "Task" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("commiter");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when git operation fails", async () => {
+    git.commitAll.mockRejectedValue(new Error("git commit failed: merge conflict"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger, emitter });
+    await role.init({ task: "Task" });
+    await expect(role.run({ task: "Task" })).rejects.toThrow("git commit failed");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("git commit failed");
+  });
+
+  it("report() returns structured commiter report", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Build feature" });
+
+    const report = role.report();
+    expect(report.role).toBe("commiter");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+  });
+
+  it("truncates long commit messages to 72 chars", async () => {
+    const longTask = "A".repeat(100);
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: longTask });
+
+    const commitMsg = git.commitAll.mock.calls[0][0];
+    expect(commitMsg.length).toBeLessThanOrEqual(72);
+  });
+
+  it("PR title and body are generated from task", async () => {
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await role.run({ task: "Add user profile page", push: true, createPr: true });
+
+    const prCall = git.createPullRequest.mock.calls[0][0];
+    expect(prCall.title).toContain("Add user profile page");
+    expect(prCall.baseBranch).toBe("main");
+    expect(prCall.branch).toBe("feat/my-branch");
+    expect(prCall.body).toBeTruthy();
+  });
+
+  it("handles push failure gracefully", async () => {
+    git.pushBranch.mockRejectedValue(new Error("push rejected: non-fast-forward"));
+
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await expect(role.run({ task: "Feature", push: true })).rejects.toThrow("push rejected");
+  });
+
+  it("handles PR creation failure gracefully", async () => {
+    git.createPullRequest.mockRejectedValue(new Error("gh: not found"));
+
+    const role = new CommiterRole({ config: { base_branch: "main" }, logger });
+    await role.init({});
+    await expect(role.run({ task: "Feature", push: true, createPr: true })).rejects.toThrow("gh: not found");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `CommiterRole` extending `BaseRole` with standardized lifecycle for git operations
- Handles commits with Conventional Commits format, push, rebase-before-push, and PR creation
- Commit messages auto-generated from task or accept custom messages, capped at 72 chars
- Exports `CommiterRole` from `src/roles/index.js`

## Test plan
- [x] 20 unit tests covering all CommiterRole functionality
- [x] Commit message generation and truncation
- [x] Push and PR creation flows
- [x] Error handling (not a git repo, no changes, push failure, PR failure)
- [x] Event emission (role:start, role:end, role:error)
- [x] All 458 existing tests pass