### PR TITLE
feat(roles): refactor Sonar as non-AI role extending BaseRole

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -14,9 +14,7 @@ import { validateReviewResult } from "./review/schema.js";
 import { evaluateTddPolicy } from "./review/tdd-policy.js";
 import { buildCoderPrompt } from "./prompts/coder.js";
 import { buildReviewerPrompt } from "./prompts/reviewer.js";
-import { getOpenIssues, getQualityGateStatus } from "./sonar/api.js";
-import { runSonarScan } from "./sonar/scanner.js";
-import { shouldBlockByProfile, summarizeIssues } from "./sonar/enforcer.js";
+import { SonarRole } from "./roles/sonar-role.js";
 import { resolveRole } from "./config.js";
 import { RepeatDetector } from "./repeat-detector.js";
 import { emitProgress, makeEvent } from "./utils/events.js";
@@ -394,7 +392,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       continue;
     }
 
-    // --- SonarQube ---
+    // --- SonarQube (via SonarRole) ---
     if (config.sonarqube.enabled) {
       logger.setContext({ iteration: i, stage: "sonar" });
       emitProgress(
@@ -404,46 +402,43 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         })
       );
 
-      const scan = await runSonarScan(config);
-      if (!scan.ok) {
+      const sonarRole = new SonarRole({ config, logger, emitter });
+      await sonarRole.init({ sessionId: session.id, iteration: i });
+      const sonarOutput = await sonarRole.run();
+      const { gateStatus, issues, openIssuesTotal, issuesSummary, blocking, projectKey } = sonarOutput.result;
+
+      if (!gateStatus && !sonarOutput.ok) {
         await markSessionStatus(session, "failed");
         emitProgress(
           emitter,
           makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
             status: "fail",
-            message: `Sonar scan failed: ${scan.stderr || scan.stdout}`
+            message: sonarOutput.summary
           })
         );
-        throw new Error(`Sonar scan failed: ${scan.stderr || scan.stdout}`);
+        throw new Error(sonarOutput.summary);
       }
 
-      const gate = await getQualityGateStatus(config, scan.projectKey);
-      const issues = await getOpenIssues(config, scan.projectKey);
-      session.last_sonar_summary = `QualityGate=${gate.status}; Open issues=${issues.total}; ${summarizeIssues(issues.issues)}`;
+      session.last_sonar_summary = sonarOutput.summary;
       await addCheckpoint(session, {
         stage: "sonar",
         iteration: i,
-        project_key: scan.projectKey,
-        quality_gate: gate.status,
-        open_issues: issues.total
-      });
-
-      const sonarBlocking = shouldBlockByProfile({
-        gateStatus: gate.status,
-        profile: config.sonarqube.enforcement_profile
+        project_key: projectKey,
+        quality_gate: gateStatus,
+        open_issues: openIssuesTotal
       });
 
       emitProgress(
         emitter,
         makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
-          status: sonarBlocking ? "fail" : "ok",
-          message: `Quality gate: ${gate.status}`,
-          detail: { projectKey: scan.projectKey, gateStatus: gate.status, openIssues: issues.total }
+          status: blocking ? "fail" : "ok",
+          message: `Quality gate: ${gateStatus}`,
+          detail: { projectKey, gateStatus, openIssues: openIssuesTotal }
         })
       );
 
-      if (sonarBlocking) {
-        repeatDetector.addIteration(issues.issues, []);
+      if (blocking) {
+        repeatDetector.addIteration(issues, []);
         const repeatState = repeatDetector.isStalled();
         if (repeatState.stalled) {
           const repeatCounts = repeatDetector.getRepeatCounts();
@@ -461,7 +456,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           return { approved: false, sessionId: session.id, reason: "stalled" };
         }
 
-        session.last_reviewer_feedback = `Sonar gate blocking (${gate.status}). Resolve critical findings first.`;
+        session.last_reviewer_feedback = `Sonar gate blocking (${gateStatus}). Resolve critical findings first.`;
         session.sonar_retry_count = (session.sonar_retry_count || 0) + 1;
         await saveSession(session);
         const maxSonarRetries = config.session.max_sonar_retries ?? config.session.fail_fast_repeats;
@@ -470,10 +465,10 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
             emitter,
             makeEvent("solomon:escalate", { ...eventBase, stage: "sonar" }, {
               message: `Sonar sub-loop limit reached (${session.sonar_retry_count}/${maxSonarRetries})`,
-              detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus: gate.status }
+              detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus }
             })
           );
-          const question = `SonarQube quality gate has failed ${session.sonar_retry_count} times (${gate.status}). What should we do?`;
+          const question = `SonarQube quality gate has failed ${session.sonar_retry_count} times (${gateStatus}). What should we do?`;
           if (askQuestion) {
             const answer = await askQuestion(question, { iteration: i, stage: "sonar" });
             if (answer) {
@@ -488,8 +483,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
             context: {
               iteration: i,
               stage: "sonar",
-              gateStatus: gate.status,
-              openIssues: issues.total,
+              gateStatus,
+              openIssues: openIssuesTotal,
               retryCount: session.sonar_retry_count
             }
           });

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -2,3 +2,4 @@ export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./b
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
 export { CommiterRole } from "./commiter-role.js";
+export { SonarRole } from "./sonar-role.js";

--- a/src/roles/sonar-role.js
+++ b/src/roles/sonar-role.js
@@ -1,0 +1,65 @@
+import { BaseRole } from "./base-role.js";
+import { runSonarScan } from "../sonar/scanner.js";
+import { getQualityGateStatus, getOpenIssues } from "../sonar/api.js";
+import { shouldBlockByProfile, summarizeIssues } from "../sonar/enforcer.js";
+
+function normalizeIssues(rawIssues) {
+  return rawIssues.map((issue) => ({
+    severity: issue.severity || "UNKNOWN",
+    type: issue.type || "UNKNOWN",
+    file: issue.component || "",
+    line: issue.line || 0,
+    rule: issue.rule || "",
+    message: issue.message || ""
+  }));
+}
+
+export class SonarRole extends BaseRole {
+  constructor({ config, logger, emitter = null }) {
+    super({ name: "sonar", config, logger, emitter });
+  }
+
+  async execute(_input) {
+    const scan = await runSonarScan(this.config);
+
+    if (!scan.ok) {
+      return {
+        ok: false,
+        result: {
+          projectKey: scan.projectKey || null,
+          gateStatus: null,
+          issues: [],
+          openIssuesTotal: 0,
+          issuesSummary: "",
+          blocking: false,
+          error: scan.stderr || scan.stdout || "Scan failed"
+        },
+        summary: `Sonar scan failed: ${scan.stderr || scan.stdout || "unknown error"}`
+      };
+    }
+
+    const gate = await getQualityGateStatus(this.config, scan.projectKey);
+    const openIssues = await getOpenIssues(this.config, scan.projectKey);
+    const issues = normalizeIssues(openIssues.issues || []);
+    const issuesSummary = summarizeIssues(openIssues.issues || []);
+
+    const profile = this.config.sonarqube?.enforcement_profile || "pragmatic";
+    const blocking = shouldBlockByProfile({
+      gateStatus: gate.status,
+      profile
+    });
+
+    return {
+      ok: !blocking,
+      result: {
+        projectKey: scan.projectKey,
+        gateStatus: gate.status,
+        issues,
+        openIssuesTotal: openIssues.total || 0,
+        issuesSummary,
+        blocking
+      },
+      summary: `Quality gate: ${gate.status}; Issues: ${openIssues.total || 0}${issuesSummary ? ` (${issuesSummary})` : ""}${blocking ? " [BLOCKING]" : ""}`
+    };
+  }
+}

--- a/tests/sonar-role.test.js
+++ b/tests/sonar-role.test.js
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn()
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn(),
+  getOpenIssues: vi.fn()
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  shouldBlockByProfile: vi.fn(),
+  summarizeIssues: vi.fn()
+}));
+
+const { SonarRole } = await import("../src/roles/sonar-role.js");
+const { runSonarScan } = await import("../src/sonar/scanner.js");
+const { getQualityGateStatus, getOpenIssues } = await import("../src/sonar/api.js");
+const { shouldBlockByProfile, summarizeIssues } = await import("../src/sonar/enforcer.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const sampleIssues = [
+  { severity: "CRITICAL", type: "BUG", component: "src/foo.js", line: 10, rule: "js:S1234", message: "Null pointer" },
+  { severity: "MAJOR", type: "CODE_SMELL", component: "src/bar.js", line: 25, rule: "js:S5678", message: "Unused var" }
+];
+
+describe("SonarRole", () => {
+  let emitter;
+  const config = {
+    sonarqube: {
+      enabled: true,
+      enforcement_profile: "pragmatic"
+    }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    runSonarScan.mockResolvedValue({
+      ok: true,
+      projectKey: "kj-test-project",
+      stdout: "Analysis complete",
+      stderr: "",
+      exitCode: 0
+    });
+
+    getQualityGateStatus.mockResolvedValue({
+      ok: true,
+      status: "OK",
+      raw: {}
+    });
+
+    getOpenIssues.mockResolvedValue({
+      total: 0,
+      issues: [],
+      raw: {}
+    });
+
+    shouldBlockByProfile.mockReturnValue(false);
+    summarizeIssues.mockReturnValue("");
+  });
+
+  it("extends BaseRole and has name 'sonar'", () => {
+    const role = new SonarRole({ config, logger });
+    expect(role.name).toBe("sonar");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new SonarRole({ config, logger });
+    await expect(role.run()).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("executes scan, quality gate, and issues on run", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(runSonarScan).toHaveBeenCalledWith(config);
+    expect(getQualityGateStatus).toHaveBeenCalledWith(config, "kj-test-project");
+    expect(getOpenIssues).toHaveBeenCalledWith(config, "kj-test-project");
+    expect(output.ok).toBe(true);
+  });
+
+  it("returns ok=true when quality gate passes", async () => {
+    shouldBlockByProfile.mockReturnValue(false);
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(true);
+    expect(output.result.gateStatus).toBe("OK");
+    expect(output.result.blocking).toBe(false);
+  });
+
+  it("returns ok=false when quality gate blocks", async () => {
+    getQualityGateStatus.mockResolvedValue({ ok: true, status: "ERROR", raw: {} });
+    shouldBlockByProfile.mockReturnValue(true);
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(false);
+    expect(output.result.gateStatus).toBe("ERROR");
+    expect(output.result.blocking).toBe(true);
+  });
+
+  it("returns ok=false when scan fails", async () => {
+    runSonarScan.mockResolvedValue({
+      ok: false,
+      projectKey: null,
+      stdout: "",
+      stderr: "Docker not running",
+      exitCode: 1
+    });
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("scan failed");
+    expect(getQualityGateStatus).not.toHaveBeenCalled();
+  });
+
+  it("includes issues classified by severity in output", async () => {
+    getOpenIssues.mockResolvedValue({ total: 2, issues: sampleIssues, raw: {} });
+    summarizeIssues.mockReturnValue("CRITICAL: 1, MAJOR: 1");
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.issues).toHaveLength(2);
+    expect(output.result.issues[0]).toEqual({
+      severity: "CRITICAL",
+      type: "BUG",
+      file: "src/foo.js",
+      line: 10,
+      rule: "js:S1234",
+      message: "Null pointer"
+    });
+    expect(output.result.issues[1]).toEqual({
+      severity: "MAJOR",
+      type: "CODE_SMELL",
+      file: "src/bar.js",
+      line: 25,
+      rule: "js:S5678",
+      message: "Unused var"
+    });
+  });
+
+  it("calls shouldBlockByProfile with correct profile", async () => {
+    const customConfig = {
+      sonarqube: { enabled: true, enforcement_profile: "paranoid" }
+    };
+    const role = new SonarRole({ config: customConfig, logger });
+    await role.init({});
+    await role.run();
+
+    expect(shouldBlockByProfile).toHaveBeenCalledWith({
+      gateStatus: "OK",
+      profile: "paranoid"
+    });
+  });
+
+  it("includes issuesSummary from summarizeIssues", async () => {
+    getOpenIssues.mockResolvedValue({ total: 3, issues: sampleIssues, raw: {} });
+    summarizeIssues.mockReturnValue("CRITICAL: 1, MAJOR: 2");
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.issuesSummary).toBe("CRITICAL: 1, MAJOR: 2");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new SonarRole({ config, logger, emitter });
+    await role.init({ iteration: 1 });
+    await role.run();
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("sonar");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when scan throws", async () => {
+    runSonarScan.mockRejectedValue(new Error("Docker daemon not running"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new SonarRole({ config, logger, emitter });
+    await role.init({});
+    await expect(role.run()).rejects.toThrow("Docker daemon not running");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Docker daemon not running");
+  });
+
+  it("report() returns structured sonar report", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    await role.run();
+
+    const report = role.report();
+    expect(report.role).toBe("sonar");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("includes projectKey in result", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.projectKey).toBe("kj-test-project");
+  });
+
+  it("includes openIssuesTotal in result", async () => {
+    getOpenIssues.mockResolvedValue({ total: 5, issues: sampleIssues, raw: {} });
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.openIssuesTotal).toBe(5);
+  });
+
+  it("works without emitter", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(true);
+  });
+
+  it("does not require createAgentFn (non-AI role)", () => {
+    const role = new SonarRole({ config, logger });
+    expect(role).toBeDefined();
+    expect(role.name).toBe("sonar");
+  });
+});


### PR DESCRIPTION
## Summary
- Create `SonarRole` class extending `BaseRole` that wraps existing sonar scanner/api/enforcer modules
- Standardize Sonar participation in the pipeline with lifecycle (init → run → report) and events (role:start, role:end, role:error)
- Update orchestrator to use `SonarRole` instead of direct sonar module imports
- Add 16 unit tests covering lifecycle, events, output structure, and issue classification

## Test plan
- [x] All 474 tests pass (59 test files)
- [x] SonarRole unit tests verify BaseRole inheritance, lifecycle, events, output format
- [x] Existing orchestrator tests (sonar stalling, events, subloop limits) continue passing
- [x] No breaking changes to sonar module internals (scanner, api, enforcer unchanged)