### PR TITLE
feat(roles): refactor Coder to BaseRole pattern

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -14,6 +14,7 @@ import { validateReviewResult } from "./review/schema.js";
 import { evaluateTddPolicy } from "./review/tdd-policy.js";
 import { buildCoderPrompt } from "./prompts/coder.js";
 import { buildReviewerPrompt } from "./prompts/reviewer.js";
+import { CoderRole } from "./roles/coder-role.js";
 import { getOpenIssues, getQualityGateStatus } from "./sonar/api.js";
 import { runSonarScan } from "./sonar/scanner.js";
 import { shouldBlockByProfile, summarizeIssues } from "./sonar/enforcer.js";
@@ -125,7 +126,6 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   }
 
   const repeatDetector = new RepeatDetector({ threshold: getRepeatThreshold(config) });
-  const coder = createAgent(coderRole.provider, config, logger);
   const startedAt = Date.now();
   const eventBase = { sessionId: null, iteration: 0, stage: null, startedAt };
 
@@ -205,7 +205,6 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
   const projectDir = config.projectDir || process.cwd();
   const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir)) || "Focus on critical issues only.";
-  const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
 
   for (let i = 1; i <= config.max_iterations; i += 1) {
     const elapsedMinutes = (Date.now() - startedAt) / 60000;
@@ -236,7 +235,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
     logger.info(`Iteration ${i}/${config.max_iterations}`);
 
-    // --- Coder ---
+    // --- Coder (via CoderRole) ---
     logger.setContext({ iteration: i, stage: "coder" });
     emitProgress(
       emitter,
@@ -246,24 +245,24 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       })
     );
 
-    const coderPrompt = buildCoderPrompt({
-      task: plannedTask,
-      reviewerFeedback: session.last_reviewer_feedback,
-      sonarSummary: session.last_sonar_summary,
-      coderRules,
-      methodology: config.development?.methodology || "tdd"
-    });
     const coderOnOutput = ({ stream, line }) => {
       emitProgress(emitter, makeEvent("agent:output", { ...eventBase, stage: "coder" }, {
         message: line,
         detail: { stream, agent: coderRole.provider }
       }));
     };
-    const coderResult = await coder.runTask({ prompt: coderPrompt, onOutput: coderOnOutput, role: "coder" });
+    const coderRoleInstance = new CoderRole({ config, logger, emitter });
+    await coderRoleInstance.init({ sessionId: session.id, iteration: i, task: plannedTask });
+    const coderResult = await coderRoleInstance.run({
+      task: plannedTask,
+      reviewerFeedback: session.last_reviewer_feedback,
+      sonarSummary: session.last_sonar_summary,
+      onOutput: coderOnOutput
+    });
 
     if (!coderResult.ok) {
       await markSessionStatus(session, "failed");
-      const details = coderResult.error || coderResult.output || `exitCode=${coderResult.exitCode ?? "unknown"}`;
+      const details = coderResult.result?.error || coderResult.summary || "unknown error";
       emitProgress(
         emitter,
         makeEvent("coder:end", { ...eventBase, stage: "coder" }, {

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -1,0 +1,60 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { buildCoderPrompt } from "../prompts/coder.js";
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.coder?.provider ||
+    config?.coder ||
+    "claude"
+  );
+}
+
+export class CoderRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "coder", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, reviewerFeedback, sonarSummary, onOutput } = typeof input === "string"
+      ? { task: input, reviewerFeedback: null, sonarSummary: null, onOutput: null }
+      : input || {};
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildCoderPrompt({
+      task: task || this.context?.task || "",
+      reviewerFeedback: reviewerFeedback || null,
+      sonarSummary: sonarSummary || null,
+      coderRules: this.instructions,
+      methodology: this.config?.development?.methodology || "tdd"
+    });
+
+    const coderArgs = { prompt, role: "coder" };
+    if (onOutput) coderArgs.onOutput = onOutput;
+
+    const result = await agent.runTask(coderArgs);
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Coder failed",
+          provider
+        },
+        summary: `Coder failed: ${result.error || result.output || "unknown error"}`
+      };
+    }
+
+    return {
+      ok: true,
+      result: {
+        output: result.output || "",
+        provider
+      },
+      summary: "Coder completed"
+    };
+  }
+}

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -2,3 +2,4 @@ export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./b
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
 export { CommiterRole } from "./commiter-role.js";
+export { CoderRole } from "./coder-role.js";

--- a/tests/coder-role.test.js
+++ b/tests/coder-role.test.js
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { CoderRole } = await import("../src/roles/coder-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("CoderRole", () => {
+  let emitter;
+  const config = {
+    roles: { coder: { provider: "claude", model: null } },
+    coder: "claude",
+    development: { methodology: "tdd" }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "Changes applied successfully",
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'coder'", () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("coder");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ task: "test" })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add login feature" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes prompt with task to agent", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add login feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Add login feature");
+    expect(callArgs.role).toBe("coder");
+  });
+
+  it("includes reviewer feedback in prompt when provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      task: "Fix bug",
+      reviewerFeedback: "Missing null check on line 42"
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Missing null check on line 42");
+  });
+
+  it("includes sonar summary in prompt when provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      task: "Fix sonar issues",
+      sonarSummary: "QualityGate=ERROR; CRITICAL: 2"
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("QualityGate=ERROR; CRITICAL: 2");
+  });
+
+  it("includes TDD methodology in prompt by default", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("TDD");
+  });
+
+  it("accepts string input as task shorthand", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Add login feature");
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Add login feature");
+  });
+
+  it("uses task from context when not provided in input", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Context task" });
+    await role.run({});
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Context task");
+  });
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Process timed out",
+      exitCode: 1
+    });
+
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add feature" });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Process timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  it("returns output from agent in result", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "Modified src/auth.js and added tests",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add auth" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.output).toBe("Modified src/auth.js and added tests");
+  });
+
+  it("forwards onOutput callback to agent", async () => {
+    const onOutput = vi.fn();
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature", onOutput });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.onOutput).toBe(onOutput);
+  });
+
+  it("does not pass onOutput when not provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.onOutput).toBeUndefined();
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new CoderRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run({ task: "Task" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("coder");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Agent binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new CoderRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run({ task: "Task" })).rejects.toThrow("Agent binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Agent binary not found");
+  });
+
+  it("report() returns structured coder report", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Build feature" });
+
+    const report = role.report();
+    expect(report.role).toBe("coder");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("resolves provider from config.roles.coder.provider", async () => {
+    const customConfig = {
+      roles: { coder: { provider: "codex", model: null } },
+      development: { methodology: "standard" }
+    };
+
+    const role = new CoderRole({ config: customConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("codex", customConfig, logger);
+  });
+
+  it("falls back to config.coder when roles.coder.provider is null", async () => {
+    const legacyConfig = {
+      roles: { coder: { provider: null } },
+      coder: "gemini",
+      development: { methodology: "tdd" }
+    };
+
+    const role = new CoderRole({ config: legacyConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", legacyConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {} };
+
+    const role = new CoderRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  it("works without emitter", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Task" });
+
+    expect(output.ok).toBe(true);
+  });
+
+  it("includes provider in result", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Task" });
+
+    expect(output.result.provider).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Summary
- Create `CoderRole` class extending `BaseRole` that wraps agent creation, prompt building (`buildCoderPrompt`), and execution
- CoderRole loads coder instructions from `templates/roles/coder.md` via BaseRole's `init()` lifecycle
- Update orchestrator to use `CoderRole` instead of direct `createAgent()` + `runTask()` calls
- Add 21 unit tests covering lifecycle, events, provider resolution, prompt construction, and error handling

## Test plan
- [x] All 479 tests pass (59 test files)
- [x] CoderRole unit tests verify BaseRole inheritance, lifecycle, events, provider fallback
- [x] Existing orchestrator tests (smoke, events, repeat detection, subloop limits) continue passing
- [x] Dry-run mode still works (uses buildCoderPrompt directly for preview)
- [x] No breaking changes to agent or prompt modules