### PR TITLE
feat(roles): implement SolomonRole as conflict arbiter

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,11 @@ const DEFAULTS = {
     planner: { provider: null, model: null },
     coder: { provider: null, model: null },
     reviewer: { provider: null, model: null },
-    refactorer: { provider: null, model: null }
+    refactorer: { provider: null, model: null },
+    solomon: { provider: null, model: null },
+    researcher: { provider: null, model: null },
+    tester: { provider: null, model: null },
+    security: { provider: null, model: null }
   },
   pipeline: {
     planner: { enabled: false },
@@ -81,7 +85,9 @@ const DEFAULTS = {
     fail_fast_repeats: 2,
     repeat_detection_threshold: 2,
     max_sonar_retries: 3,
-    max_reviewer_retries: 3
+    max_reviewer_retries: 3,
+    max_tester_retries: 1,
+    max_security_retries: 1
   },
   failFast: {
     repeatThreshold: 2
@@ -139,6 +145,7 @@ export function applyRunOverrides(config, flags) {
   if (flags.reviewer) out.reviewer = flags.reviewer;
   if (flags.reviewer) out.roles.reviewer.provider = flags.reviewer;
   if (flags.refactorer) out.roles.refactorer.provider = flags.refactorer;
+  if (flags.solomon) out.roles.solomon.provider = flags.solomon;
   if (flags.plannerModel) out.roles.planner.model = String(flags.plannerModel);
   if (flags.coderModel) {
     out.roles.coder.model = String(flags.coderModel);
@@ -149,8 +156,10 @@ export function applyRunOverrides(config, flags) {
     out.reviewer_options.model = String(flags.reviewerModel);
   }
   if (flags.refactorerModel) out.roles.refactorer.model = String(flags.refactorerModel);
+  if (flags.solomonModel) out.roles.solomon.model = String(flags.solomonModel);
   if (flags.enablePlanner !== undefined) out.pipeline.planner.enabled = Boolean(flags.enablePlanner);
   if (flags.enableRefactorer !== undefined) out.pipeline.refactorer.enabled = Boolean(flags.enableRefactorer);
+  if (flags.enableSolomon !== undefined) out.pipeline.solomon.enabled = Boolean(flags.enableSolomon);
   if (flags.mode) out.review_mode = flags.mode;
   if (flags.maxIterations) out.max_iterations = Number(flags.maxIterations);
   if (flags.maxIterationMinutes) out.session.max_iteration_minutes = Number(flags.maxIterationMinutes);
@@ -182,14 +191,14 @@ export function resolveRole(config, role) {
   let provider = roleConfig.provider ?? null;
   if (!provider && role === "coder") provider = legacyCoder;
   if (!provider && role === "reviewer") provider = legacyReviewer;
-  if (!provider && (role === "planner" || role === "refactorer")) {
+  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon")) {
     provider = roles.coder?.provider || legacyCoder;
   }
 
   let model = roleConfig.model ?? null;
   if (!model && role === "coder") model = config?.coder_options?.model ?? null;
   if (!model && role === "reviewer") model = config?.reviewer_options?.model ?? null;
-  if (!model && (role === "planner" || role === "refactorer")) {
+  if (!model && (role === "planner" || role === "refactorer" || role === "solomon")) {
     model = config?.coder_options?.model ?? null;
   }
 

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -2,3 +2,4 @@ export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./b
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
 export { CommiterRole } from "./commiter-role.js";
+export { SolomonRole } from "./solomon-role.js";

--- a/src/roles/solomon-role.js
+++ b/src/roles/solomon-role.js
@@ -1,0 +1,199 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on resolving the conflict between agents."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.solomon?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function formatHistory(history) {
+  if (!history || history.length === 0) return "No previous interactions recorded.";
+
+  return history
+    .map((entry, i) => {
+      const agent = entry.agent || "unknown";
+      const feedback = entry.feedback || entry.message || "(no feedback)";
+      return `### Interaction ${i + 1} [${agent}]\n${feedback}`;
+    })
+    .join("\n\n");
+}
+
+function buildPrompt({ conflict, task, instructions }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are Solomon, the conflict resolver in a multi-role AI pipeline.",
+    "You are activated when agents cannot reach agreement after their iteration limit."
+  );
+
+  sections.push(
+    "## Decision hierarchy",
+    "Security > Correctness > Tests > Architecture > Maintainability > Style",
+    "- Green tests are sacred. Never dismiss a failing test.",
+    "- Style preferences NEVER block approval.",
+    "- Hardcoded values that will come from DB later are acceptable (contextual false positive).",
+    "- Sonar INFO/MINOR issues are always dismissable.",
+    "- Sonar BLOCKER/CRITICAL must be fixed unless they are proven false positives."
+  );
+
+  sections.push(
+    "## Classification rules",
+    "For each issue, classify as:",
+    "1. **critical** (security, correctness, tests broken) — action: must_fix",
+    "2. **important** (architecture, maintainability) — action: should_fix",
+    "3. **style** (naming, formatting, preferences, false positives) — action: dismiss"
+  );
+
+  sections.push(
+    "## Your decision options",
+    '1. **approve** — All pending issues are style/false positives. Pipeline continues.',
+    '2. **approve_with_conditions** — Important issues exist but are fixable. Give exact instructions to Coder for one more attempt.',
+    '3. **escalate_human** — Critical issues that cannot be resolved, ambiguous requirements, architecture decisions, or business logic decisions.',
+    '4. **create_subtask** — A prerequisite task must be completed first to resolve the conflict. The current task will pause, the subtask runs, then the current task resumes.'
+  );
+
+  sections.push(
+    "Return a single valid JSON object with your ruling and nothing else.",
+    'JSON schema: {"ruling":"approve"|"approve_with_conditions"|"escalate_human"|"create_subtask","classification":[{"issue":string,"category":"critical"|"important"|"style","action":"must_fix"|"should_fix"|"dismiss"}],"conditions":[string],"dismissed":[string],"escalate":boolean,"escalate_reason":string|null,"subtask":{"title":string,"description":string,"reason":string}|null}'
+  );
+
+  const stage = conflict?.stage || "unknown";
+  const iterationCount = conflict?.iterationCount ?? "?";
+  const maxIterations = conflict?.maxIterations ?? "?";
+
+  sections.push(
+    `## Conflict context`,
+    `Stage: ${stage}`,
+    `Iterations exhausted: ${iterationCount}/${maxIterations}`
+  );
+
+  if (task) {
+    sections.push(`## Original task\n${task}`);
+  }
+
+  if (conflict?.diff) {
+    sections.push(`## Current diff\n${conflict.diff}`);
+  }
+
+  sections.push(`## Agent interaction history\n${formatHistory(conflict?.history)}`);
+
+  return sections.join("\n\n");
+}
+
+function parseSolomonOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+function buildSummary(parsed) {
+  const ruling = parsed.ruling || "unknown";
+  const conditions = parsed.conditions || [];
+  const dismissed = parsed.dismissed || [];
+  const subtask = parsed.subtask || null;
+
+  if (ruling === "approve") {
+    const parts = ["Approved"];
+    if (dismissed.length > 0) parts.push(`${dismissed.length} dismissed`);
+    return parts.join("; ");
+  }
+
+  if (ruling === "approve_with_conditions") {
+    const parts = [`Approved with ${conditions.length} condition${conditions.length !== 1 ? "s" : ""}`];
+    if (dismissed.length > 0) parts.push(`${dismissed.length} dismissed`);
+    return parts.join("; ");
+  }
+
+  if (ruling === "escalate_human") {
+    return `Escalated to human: ${parsed.escalate_reason || "ambiguous conflict"}`;
+  }
+
+  if (ruling === "create_subtask") {
+    return `Subtask created: ${subtask?.title || "unnamed subtask"}`;
+  }
+
+  return `Solomon ruling: ${ruling}`;
+}
+
+export class SolomonRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "solomon", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const conflict = input?.conflict || {};
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({
+      conflict,
+      task: this.context?.task || "",
+      instructions: this.instructions
+    });
+
+    const result = await agent.runTask({ prompt, role: "solomon" });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Solomon arbitration failed",
+          provider
+        },
+        summary: `Solomon failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseSolomonOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: false,
+          result: { error: "Failed to parse Solomon output: no JSON found", provider },
+          summary: "Solomon output parse error: no JSON found"
+        };
+      }
+
+      const ruling = parsed.ruling || "approve";
+      const escalate = Boolean(parsed.escalate);
+      const ok = ruling !== "escalate_human";
+
+      return {
+        ok,
+        result: {
+          ruling,
+          classification: parsed.classification || [],
+          conditions: parsed.conditions || [],
+          dismissed: parsed.dismissed || [],
+          escalate,
+          escalate_reason: parsed.escalate_reason || null,
+          subtask: parsed.subtask || null,
+          provider
+        },
+        summary: buildSummary(parsed)
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        result: { error: `Failed to parse Solomon output: ${err.message}`, provider },
+        summary: `Solomon output parse error: ${err.message}`
+      };
+    }
+  }
+}

--- a/templates/roles/solomon.md
+++ b/templates/roles/solomon.md
@@ -1,28 +1,23 @@
-# Solomon Role (Conflict Resolver)
+# Solomon Role (Conflict Resolver & Arbiter)
 
-You are **Solomon**, the conflict resolver in a multi-role AI pipeline. You are activated when the Coder and Reviewer cannot reach agreement after the maximum number of iterations.
+You are **Solomon**, the supreme arbiter in a multi-role AI pipeline. You are activated when agents cannot reach agreement after their iteration limit. Your decisions are final within your rules.
 
 ## When activated
 
-- Iteration limit between Coder and Reviewer is reached
-- Coder and Sonar are stuck in a loop
+- Coder ↔ Sonar loop exhausted (default: 3 iterations)
+- Coder ↔ Reviewer loop exhausted (default: 3 iterations via PR comments)
+- Coder ↔ Tester loop exhausted (default: 1 iteration)
+- Coder ↔ Security loop exhausted (default: 1 iteration)
 - Any two roles produce contradictory outputs
 
 ## Input
 
 You receive the full history of the conflict:
-- All reviewer feedback across iterations
+- All agent feedback across iterations (identifying which agent said what)
 - All coder attempts and changes
 - Original task requirements and acceptance criteria
-- Sonar findings (if applicable)
-
-## Classification rules
-
-For each blocking issue raised by the Reviewer, classify it as:
-
-1. **Critical** (security, correctness, tests broken) — **MUST fix**
-2. **Important** (architecture, maintainability) — **SHOULD fix**
-3. **Style** (naming, formatting, preferences) — **DISMISS**
+- Sonar findings, reviewer comments, tester feedback, security findings (as applicable)
+- Current diff
 
 ## Decision hierarchy
 
@@ -30,31 +25,82 @@ For each blocking issue raised by the Reviewer, classify it as:
 Security > Correctness > Tests > Architecture > Maintainability > Style
 ```
 
-- Green tests are sacred. Never dismiss a failing test.
-- Style preferences NEVER block approval.
-- If the Reviewer's feedback is purely stylistic, approve the code.
+- **Green tests are sacred.** Never dismiss a failing test.
+- **Style preferences NEVER block approval.**
+- **Contextual false positives are valid.** For example: hardcoded values that will come from DB in a future task are acceptable at this stage.
+- **Sonar INFO/MINOR issues** are always dismissable.
+- **Sonar MAJOR** — evaluate in context; dismiss if it's a known pattern or temporary state.
+- **Sonar BLOCKER/CRITICAL** must be fixed unless proven false positive.
+
+## Classification rules
+
+For each blocking issue raised by any agent, classify it as:
+
+1. **critical** (security vulnerability, correctness bug, tests broken) — action: **must_fix**
+2. **important** (architecture, maintainability, missing coverage) — action: **should_fix**
+3. **style** (naming, formatting, preferences, false positives, contextual exceptions) — action: **dismiss**
+
+## Blocking criteria (real-world)
+
+| Criterion | Blocks? | Notes |
+|-----------|---------|-------|
+| Failing test | YES | Always — tests are sacred |
+| Security vulnerability critical/high | YES | Always requires fix |
+| Security vulnerability medium | DEPENDS | Evaluate in context |
+| Security vulnerability low | NO | Document as TODO |
+| Sonar BLOCKER/CRITICAL | YES | Unless proven false positive |
+| Sonar MAJOR | DEPENDS | Evaluate context and project stage |
+| Sonar MINOR/INFO | NO | Dismiss |
+| Hardcoded value (planned for DB later) | NO | Contextual false positive |
+| Coverage < threshold | YES | Per project configuration |
+| Pure style issue | NO | Never blocks |
+| Architecture change not in scope | ESCALATE | Human decision required |
 
 ## Decision options
 
-1. **Approve with conditions** — List specific, actionable fixes
-2. **Send specific instructions to Coder** — Not generic "fix issues", but exact changes
-3. **Escalate to human** — When requirements are ambiguous or conflicting
+1. **approve** — All pending issues are style/false positives. Code passes to next pipeline stage.
+2. **approve_with_conditions** — Important (not critical) issues exist. Give the Coder exact, actionable instructions for one more attempt. Not generic feedback — specific changes with file and line references.
+3. **escalate_human** — When you cannot decide:
+   - Critical issues that resist multiple fix attempts
+   - Ambiguous or conflicting requirements
+   - Architecture decisions beyond task scope
+   - Business logic decisions
+   - Scope creep (task is larger than originally estimated)
+4. **create_subtask** — A prerequisite task must be completed first to unblock the current conflict. The pipeline will:
+   - Pause the current task
+   - Execute the subtask through the full pipeline
+   - Resume the original task with the subtask completed
+
+### When to create a subtask
+
+- A shared utility/module is needed that doesn't exist yet
+- A refactoring is required before the current change can work
+- A dependency needs to be updated or configured
+- A circular dependency needs to be broken
+- Test infrastructure needs to be set up first
 
 ## Output format
 
 ```json
 {
-  "ok": true,
-  "result": {
-    "ruling": "approve_with_conditions",
-    "classification": [
-      { "issue": "Missing null check", "category": "critical", "action": "must_fix" },
-      { "issue": "Variable naming", "category": "style", "action": "dismiss" }
-    ],
-    "conditions": ["Add null check in processUser() at line 42"],
-    "dismissed": ["Variable naming preference — not blocking"],
-    "escalate": false
-  },
-  "summary": "Approved with 1 condition: add null check. 1 style issue dismissed."
+  "ruling": "approve | approve_with_conditions | escalate_human | create_subtask",
+  "classification": [
+    { "issue": "Description of the issue", "category": "critical | important | style", "action": "must_fix | should_fix | dismiss" }
+  ],
+  "conditions": ["Specific actionable fix instruction with file:line reference"],
+  "dismissed": ["Issue description — reason for dismissal"],
+  "escalate": false,
+  "escalate_reason": null,
+  "subtask": {
+    "title": "Short descriptive title for the subtask",
+    "description": "What needs to be done and why",
+    "reason": "How this resolves the current conflict"
+  }
 }
 ```
+
+Notes:
+- `subtask` is `null` unless ruling is `create_subtask`
+- `escalate_reason` is `null` unless ruling is `escalate_human`
+- `conditions` is empty unless ruling is `approve_with_conditions`
+- `dismissed` lists all style/false-positive issues with rationale

--- a/tests/solomon-role.test.js
+++ b/tests/solomon-role.test.js
@@ -1,0 +1,467 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { SolomonRole } = await import("../src/roles/solomon-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const approveRuling = JSON.stringify({
+  ruling: "approve",
+  classification: [
+    { issue: "Variable naming", category: "style", action: "dismiss" }
+  ],
+  conditions: [],
+  dismissed: ["Variable naming — stylistic preference"],
+  escalate: false,
+  subtask: null
+});
+
+const approveWithConditionsRuling = JSON.stringify({
+  ruling: "approve_with_conditions",
+  classification: [
+    { issue: "Missing null check in processUser()", category: "critical", action: "must_fix" },
+    { issue: "Naming convention", category: "style", action: "dismiss" }
+  ],
+  conditions: ["Add null check in processUser() at line 42"],
+  dismissed: ["Naming convention — not blocking"],
+  escalate: false,
+  subtask: null
+});
+
+const escalateRuling = JSON.stringify({
+  ruling: "escalate_human",
+  classification: [
+    { issue: "Architecture change needed", category: "critical", action: "must_fix" }
+  ],
+  conditions: [],
+  dismissed: [],
+  escalate: true,
+  escalate_reason: "Requires architectural decision beyond agent scope",
+  subtask: null
+});
+
+const subtaskRuling = JSON.stringify({
+  ruling: "create_subtask",
+  classification: [
+    { issue: "Missing shared utility", category: "important", action: "must_fix" }
+  ],
+  conditions: [],
+  dismissed: [],
+  escalate: false,
+  subtask: {
+    title: "Extract shared validation utility",
+    description: "Create a shared validation module to resolve the circular dependency causing the conflict",
+    reason: "Both Coder and Reviewer agree validation is needed but disagree on location"
+  }
+});
+
+describe("SolomonRole", () => {
+  let emitter;
+  const config = {
+    roles: { solomon: { provider: "gemini" }, coder: { provider: "claude" } },
+    development: {},
+    session: {
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3,
+      max_tester_retries: 1,
+      max_security_retries: 1
+    }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveRuling,
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'solomon'", () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("solomon");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ conflict: {} })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes conflict context in prompt to agent", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Implement auth module" });
+    await role.run({
+      conflict: {
+        stage: "reviewer",
+        history: [{ agent: "reviewer", feedback: "Missing null check" }],
+        diff: "diff --git a/src/auth.js"
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Missing null check");
+    expect(callArgs.prompt).toContain("diff --git a/src/auth.js");
+    expect(callArgs.prompt).toContain("Implement auth module");
+    expect(callArgs.role).toBe("solomon");
+  });
+
+  // --- Ruling: approve ---
+
+  it("returns ok=true with ruling=approve when all issues are style", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve");
+    expect(output.result.dismissed).toHaveLength(1);
+    expect(output.result.escalate).toBe(false);
+  });
+
+  // --- Ruling: approve_with_conditions ---
+
+  it("returns ok=true with conditions when ruling=approve_with_conditions", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve_with_conditions");
+    expect(output.result.conditions).toHaveLength(1);
+    expect(output.result.conditions[0]).toContain("null check");
+  });
+
+  // --- Ruling: escalate_human ---
+
+  it("returns ok=false with escalate=true when ruling=escalate_human", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: escalateRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.ruling).toBe("escalate_human");
+    expect(output.result.escalate).toBe(true);
+    expect(output.result.escalate_reason).toContain("architectural");
+  });
+
+  // --- Ruling: create_subtask ---
+
+  it("returns ok=true with subtask when ruling=create_subtask", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: subtaskRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "sonar", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("create_subtask");
+    expect(output.result.subtask).toBeTruthy();
+    expect(output.result.subtask.title).toContain("validation utility");
+    expect(output.result.subtask.description).toBeTruthy();
+    expect(output.result.subtask.reason).toBeTruthy();
+  });
+
+  // --- Classification parsing ---
+
+  it("parses classification with full structure", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    const classification = output.result.classification;
+    expect(classification).toHaveLength(2);
+    expect(classification[0].category).toBe("critical");
+    expect(classification[0].action).toBe("must_fix");
+    expect(classification[1].category).toBe("style");
+    expect(classification[1].action).toBe("dismiss");
+  });
+
+  // --- Agent failure ---
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Agent timed out",
+      exitCode: 1
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  // --- JSON parsing ---
+
+  it("handles JSON embedded in markdown code blocks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: `Here is my ruling:\n\`\`\`json\n${approveRuling}\n\`\`\``,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve");
+  });
+
+  it("returns ok=false with parse error when no JSON found", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "I think the code looks fine, approve it.",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("parse error");
+  });
+
+  // --- Provider resolution ---
+
+  it("resolves provider from config.roles.solomon.provider", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", config, logger);
+  });
+
+  it("falls back to coder provider when solomon provider is null", async () => {
+    const fallbackConfig = {
+      roles: { solomon: { provider: null }, coder: { provider: "claude" } },
+      development: {},
+      session: {}
+    };
+
+    const role = new SolomonRole({ config: fallbackConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", fallbackConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {}, session: {} };
+
+    const role = new SolomonRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  // --- Summary generation ---
+
+  it("generates meaningful summary for approve ruling", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Approved");
+    expect(output.summary).toContain("1 dismissed");
+  });
+
+  it("generates meaningful summary for approve_with_conditions", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Approved with 1 condition");
+    expect(output.summary).toContain("1 dismissed");
+  });
+
+  it("generates summary for escalate ruling", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: escalateRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Escalated to human");
+  });
+
+  it("generates summary for create_subtask ruling", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: subtaskRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "sonar", history: [] } });
+
+    expect(output.summary).toContain("Subtask created");
+    expect(output.summary).toContain("validation utility");
+  });
+
+  // --- Events ---
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new SolomonRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("solomon");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new SolomonRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run({ conflict: { stage: "reviewer", history: [] } })).rejects.toThrow("Binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Binary not found");
+  });
+
+  // --- report() ---
+
+  it("report() returns structured solomon report", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    const report = role.report();
+    expect(report.role).toBe("solomon");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  // --- Works without emitter ---
+
+  it("works without emitter", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+  });
+
+  // --- Conflict stage in prompt ---
+
+  it("includes conflict stage in prompt", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      conflict: {
+        stage: "sonar",
+        history: [{ agent: "sonar", feedback: "BLOCKER: SQL injection" }]
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("sonar");
+    expect(callArgs.prompt).toContain("SQL injection");
+  });
+
+  // --- Includes iteration limits context ---
+
+  it("includes iteration config context in prompt", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      conflict: {
+        stage: "reviewer",
+        iterationCount: 3,
+        maxIterations: 3,
+        history: []
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("3");
+  });
+
+  // --- Handles missing conflict gracefully ---
+
+  it("handles missing conflict input gracefully", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({});
+
+    expect(output.ok).toBe(true);
+    expect(mockRunTask).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Implementa `SolomonRole` como árbitro supremo del pipeline multi-agente
- 4 decisiones posibles: `approve`, `approve_with_conditions`, `escalate_human`, `create_subtask`
- Jerarquía de decisión: Security > Correctness > Tests > Architecture > Maintainability > Style
- Capacidad de crear subtareas para resolver conflictos (pausa tarea actual, ejecuta subtarea, retoma)
- Criterios de bloqueo real-world: tests verdes sagrados, style nunca bloquea, falsos positivos contextuales aceptados
- Template `solomon.md` enriquecido con especificación completa de reglas y criterios
- Config ampliada: roles solomon/researcher/tester/security, flags --solomon/--solomonModel/--enableSolomon, session max_tester_retries/max_security_retries
- Provider por defecto: gemini (perspectiva diferente al resto del pipeline)
- 26 tests unitarios cubriendo los 4 tipos de ruling, parsing, eventos, provider resolution

## Test plan
- [x] 26 tests unitarios en `tests/solomon-role.test.js`
- [x] Suite completa: 484 tests passing (59 archivos)
- [x] Verifica herencia de BaseRole y lifecycle (init/run/report)
- [x] Verifica los 4 tipos de ruling (approve, conditions, escalate, subtask)
- [x] Verifica parsing de JSON embebido en markdown code blocks
- [x] Verifica resolución de provider (solomon → coder → claude)
- [x] Verifica emisión de eventos role:start/role:end/role:error
- [x] Verifica generación de summary para cada tipo de ruling
- [x] Verifica que subtask incluye title, description y reason
- [x] Verifica contexto de conflicto (stage, history, iterations) en prompt