### PR TITLE
feat(orchestrator): integrate full ADR-001 pipeline with Solomon arbitration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,12 +11,19 @@ const DEFAULTS = {
     planner: { provider: null, model: null },
     coder: { provider: null, model: null },
     reviewer: { provider: null, model: null },
-    refactorer: { provider: null, model: null }
+    refactorer: { provider: null, model: null },
+    solomon: { provider: null, model: null },
+    researcher: { provider: null, model: null },
+    tester: { provider: null, model: null },
+    security: { provider: null, model: null }
   },
   pipeline: {
     planner: { enabled: false },
     refactorer: { enabled: false },
-    solomon: { enabled: false }
+    solomon: { enabled: false },
+    researcher: { enabled: false },
+    tester: { enabled: false },
+    security: { enabled: false }
   },
   review_mode: "standard",
   max_iterations: 5,
@@ -81,7 +88,9 @@ const DEFAULTS = {
     fail_fast_repeats: 2,
     repeat_detection_threshold: 2,
     max_sonar_retries: 3,
-    max_reviewer_retries: 3
+    max_reviewer_retries: 3,
+    max_tester_retries: 1,
+    max_security_retries: 1
   },
   failFast: {
     repeatThreshold: 2
@@ -139,6 +148,10 @@ export function applyRunOverrides(config, flags) {
   if (flags.reviewer) out.reviewer = flags.reviewer;
   if (flags.reviewer) out.roles.reviewer.provider = flags.reviewer;
   if (flags.refactorer) out.roles.refactorer.provider = flags.refactorer;
+  if (flags.solomon) out.roles.solomon.provider = flags.solomon;
+  if (flags.researcher) out.roles.researcher.provider = flags.researcher;
+  if (flags.tester) out.roles.tester.provider = flags.tester;
+  if (flags.security) out.roles.security.provider = flags.security;
   if (flags.plannerModel) out.roles.planner.model = String(flags.plannerModel);
   if (flags.coderModel) {
     out.roles.coder.model = String(flags.coderModel);
@@ -149,8 +162,13 @@ export function applyRunOverrides(config, flags) {
     out.reviewer_options.model = String(flags.reviewerModel);
   }
   if (flags.refactorerModel) out.roles.refactorer.model = String(flags.refactorerModel);
+  if (flags.solomonModel) out.roles.solomon.model = String(flags.solomonModel);
   if (flags.enablePlanner !== undefined) out.pipeline.planner.enabled = Boolean(flags.enablePlanner);
   if (flags.enableRefactorer !== undefined) out.pipeline.refactorer.enabled = Boolean(flags.enableRefactorer);
+  if (flags.enableSolomon !== undefined) out.pipeline.solomon.enabled = Boolean(flags.enableSolomon);
+  if (flags.enableResearcher !== undefined) out.pipeline.researcher.enabled = Boolean(flags.enableResearcher);
+  if (flags.enableTester !== undefined) out.pipeline.tester.enabled = Boolean(flags.enableTester);
+  if (flags.enableSecurity !== undefined) out.pipeline.security.enabled = Boolean(flags.enableSecurity);
   if (flags.mode) out.review_mode = flags.mode;
   if (flags.maxIterations) out.max_iterations = Number(flags.maxIterations);
   if (flags.maxIterationMinutes) out.session.max_iteration_minutes = Number(flags.maxIterationMinutes);
@@ -182,14 +200,14 @@ export function resolveRole(config, role) {
   let provider = roleConfig.provider ?? null;
   if (!provider && role === "coder") provider = legacyCoder;
   if (!provider && role === "reviewer") provider = legacyReviewer;
-  if (!provider && (role === "planner" || role === "refactorer")) {
+  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security")) {
     provider = roles.coder?.provider || legacyCoder;
   }
 
   let model = roleConfig.model ?? null;
   if (!model && role === "coder") model = config?.coder_options?.model ?? null;
   if (!model && role === "reviewer") model = config?.reviewer_options?.model ?? null;
-  if (!model && (role === "planner" || role === "refactorer")) {
+  if (!model && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security")) {
     model = config?.coder_options?.model ?? null;
   }
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -26,6 +26,10 @@ import {
   finalizeGitAutomation
 } from "./git/automation.js";
 import { resolveRoleMdPath, loadFirstExisting } from "./roles/base-role.js";
+import { ResearcherRole } from "./roles/researcher-role.js";
+import { TesterRole } from "./roles/tester-role.js";
+import { SecurityRole } from "./roles/security-role.js";
+import { SolomonRole } from "./roles/solomon-role.js";
 
 function getRepeatThreshold(config) {
   const raw =
@@ -69,6 +73,88 @@ async function runReviewerWithFallback({ reviewerName, config, logger, prompt, s
   return { result: null, attempts };
 }
 
+async function invokeSolomon({ config, logger, emitter, eventBase, stage, conflict, askQuestion, session, iteration }) {
+  const solomonEnabled = Boolean(config.pipeline?.solomon?.enabled);
+
+  if (!solomonEnabled) {
+    return escalateToHuman({ askQuestion, session, emitter, eventBase, stage, conflict, iteration });
+  }
+
+  emitProgress(
+    emitter,
+    makeEvent("solomon:start", { ...eventBase, stage: "solomon" }, {
+      message: `Solomon arbitrating ${stage} conflict`,
+      detail: { conflictStage: stage }
+    })
+  );
+
+  const solomon = new SolomonRole({ config, logger, emitter });
+  await solomon.init({ task: conflict.task || session.task, iteration });
+  const ruling = await solomon.run({ conflict });
+
+  emitProgress(
+    emitter,
+    makeEvent("solomon:end", { ...eventBase, stage: "solomon" }, {
+      message: `Solomon ruling: ${ruling.result?.ruling || "unknown"}`,
+      detail: ruling.result
+    })
+  );
+
+  await addCheckpoint(session, {
+    stage: "solomon",
+    iteration,
+    ruling: ruling.result?.ruling,
+    escalate: ruling.result?.escalate,
+    subtask: ruling.result?.subtask?.title || null
+  });
+
+  if (!ruling.ok) {
+    // escalate_human
+    return escalateToHuman({
+      askQuestion, session, emitter, eventBase, stage, iteration,
+      conflict: { ...conflict, solomonReason: ruling.result?.escalate_reason }
+    });
+  }
+
+  const r = ruling.result?.ruling;
+  if (r === "approve" || r === "approve_with_conditions") {
+    return { action: "continue", conditions: ruling.result?.conditions || [], ruling };
+  }
+
+  if (r === "create_subtask") {
+    return { action: "subtask", subtask: ruling.result?.subtask, ruling };
+  }
+
+  return { action: "continue", conditions: [], ruling };
+}
+
+async function escalateToHuman({ askQuestion, session, emitter, eventBase, stage, conflict, iteration }) {
+  const reason = conflict?.solomonReason || `${stage} conflict unresolved`;
+  const question = `${stage} conflict requires human intervention: ${reason}\nDetails: ${JSON.stringify(conflict?.history?.slice(-2) || [], null, 2)}\n\nHow should we proceed?`;
+
+  if (askQuestion) {
+    const answer = await askQuestion(question, { iteration, stage });
+    if (answer) {
+      return { action: "continue", humanGuidance: answer };
+    }
+  }
+
+  await pauseSession(session, {
+    question,
+    context: { iteration, stage, conflict }
+  });
+  emitProgress(
+    emitter,
+    makeEvent("question", { ...eventBase, stage }, {
+      status: "paused",
+      message: question,
+      detail: { question, sessionId: session.id }
+    })
+  );
+
+  return { action: "pause", question };
+}
+
 export async function runFlow({ task, config, logger, flags = {}, emitter = null, askQuestion = null }) {
   const plannerRole = resolveRole(config, "planner");
   const coderRole = resolveRole(config, "coder");
@@ -76,6 +162,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const refactorerRole = resolveRole(config, "refactorer");
   const plannerEnabled = Boolean(config.pipeline?.planner?.enabled);
   const refactorerEnabled = Boolean(config.pipeline?.refactorer?.enabled);
+  const researcherEnabled = Boolean(config.pipeline?.researcher?.enabled);
+  const testerEnabled = Boolean(config.pipeline?.tester?.enabled);
+  const securityEnabled = Boolean(config.pipeline?.security?.enabled);
 
   // --- Dry-run: return summary without executing anything ---
   if (flags.dryRun) {
@@ -97,14 +186,20 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       pipeline: {
         planner_enabled: plannerEnabled,
         refactorer_enabled: refactorerEnabled,
-        sonar_enabled: Boolean(config.sonarqube?.enabled)
+        sonar_enabled: Boolean(config.sonarqube?.enabled),
+        researcher_enabled: researcherEnabled,
+        tester_enabled: testerEnabled,
+        security_enabled: securityEnabled,
+        solomon_enabled: Boolean(config.pipeline?.solomon?.enabled)
       },
       limits: {
         max_iterations: config.max_iterations,
         max_iteration_minutes: config.session?.max_iteration_minutes,
         max_total_minutes: config.session?.max_total_minutes,
         max_sonar_retries: config.session?.max_sonar_retries,
-        max_reviewer_retries: config.session?.max_reviewer_retries
+        max_reviewer_retries: config.session?.max_reviewer_retries,
+        max_tester_retries: config.session?.max_tester_retries,
+        max_security_retries: config.session?.max_security_retries
       },
       prompts: {
         coder: coderPrompt,
@@ -160,6 +255,37 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     })
   );
 
+  // --- Researcher (pre-planning) ---
+  let researchContext = null;
+  if (researcherEnabled) {
+    logger.setContext({ iteration: 0, stage: "researcher" });
+    emitProgress(
+      emitter,
+      makeEvent("researcher:start", { ...eventBase, stage: "researcher" }, {
+        message: "Researcher investigating codebase"
+      })
+    );
+
+    const researcher = new ResearcherRole({ config, logger, emitter });
+    await researcher.init({ task });
+    const researchOutput = await researcher.run({ task });
+
+    await addCheckpoint(session, { stage: "researcher", iteration: 0, ok: researchOutput.ok });
+
+    emitProgress(
+      emitter,
+      makeEvent("researcher:end", { ...eventBase, stage: "researcher" }, {
+        status: researchOutput.ok ? "ok" : "fail",
+        message: researchOutput.ok ? "Research completed" : `Research failed: ${researchOutput.summary}`
+      })
+    );
+
+    if (researchOutput.ok) {
+      researchContext = researchOutput.result;
+    }
+  }
+
+  // --- Planner ---
   let plannedTask = task;
   if (plannerEnabled) {
     logger.setContext({ iteration: 0, stage: "planner" });
@@ -171,13 +297,16 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       })
     );
     const planner = createAgent(plannerRole.provider, config, logger);
-    const plannerPrompt = [
+    const plannerPromptParts = [
       "Create an implementation plan for this task.",
       "Return concise numbered steps focused on execution order and risk.",
       "",
       task
-    ].join("\n");
-    const plannerResult = await planner.runTask({ prompt: plannerPrompt, role: "planner" });
+    ];
+    if (researchContext) {
+      plannerPromptParts.push("", "## Research findings", JSON.stringify(researchContext, null, 2));
+    }
+    const plannerResult = await planner.runTask({ prompt: plannerPromptParts.join("\n"), role: "planner" });
     if (!plannerResult.ok) {
       await markSessionStatus(session, "failed");
       const details = plannerResult.error || plannerResult.output || `exitCode=${plannerResult.exitCode ?? "unknown"}`;
@@ -473,35 +602,32 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
               detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus: gate.status }
             })
           );
-          const question = `SonarQube quality gate has failed ${session.sonar_retry_count} times (${gate.status}). What should we do?`;
-          if (askQuestion) {
-            const answer = await askQuestion(question, { iteration: i, stage: "sonar" });
-            if (answer) {
-              session.last_reviewer_feedback += `\nUser guidance: ${answer}`;
-              session.sonar_retry_count = 0;
-              await saveSession(session);
-              continue;
-            }
-          }
-          await pauseSession(session, {
-            question,
-            context: {
-              iteration: i,
+
+          const solomonResult = await invokeSolomon({
+            config, logger, emitter, eventBase, stage: "sonar", askQuestion, session, iteration: i,
+            conflict: {
               stage: "sonar",
-              gateStatus: gate.status,
-              openIssues: issues.total,
-              retryCount: session.sonar_retry_count
+              task,
+              iterationCount: session.sonar_retry_count,
+              maxIterations: maxSonarRetries,
+              history: [{ agent: "sonar", feedback: session.last_sonar_summary }]
             }
           });
-          emitProgress(
-            emitter,
-            makeEvent("question", { ...eventBase, stage: "sonar" }, {
-              status: "paused",
-              message: question,
-              detail: { question, sessionId: session.id }
-            })
-          );
-          return { paused: true, sessionId: session.id, question, context: "sonar_fail_fast" };
+
+          if (solomonResult.action === "pause") {
+            return { paused: true, sessionId: session.id, question: solomonResult.question, context: "sonar_fail_fast" };
+          }
+          if (solomonResult.action === "continue") {
+            if (solomonResult.humanGuidance) {
+              session.last_reviewer_feedback += `\nUser guidance: ${solomonResult.humanGuidance}`;
+            }
+            session.sonar_retry_count = 0;
+            await saveSession(session);
+            continue;
+          }
+          if (solomonResult.action === "subtask") {
+            return { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "sonar_subtask" };
+          }
         }
         continue;
       }
@@ -635,6 +761,129 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
     if (review.approved) {
       session.reviewer_retry_count = 0;
+
+      // --- Post-loop stages: Tester → Security ---
+      const postLoopDiff = await generateDiff({ baseRef: session.session_start_sha });
+
+      // --- Tester ---
+      if (testerEnabled) {
+        logger.setContext({ iteration: i, stage: "tester" });
+        emitProgress(
+          emitter,
+          makeEvent("tester:start", { ...eventBase, stage: "tester" }, {
+            message: "Tester evaluating test quality"
+          })
+        );
+
+        const tester = new TesterRole({ config, logger, emitter });
+        await tester.init({ task, iteration: i });
+        const testerOutput = await tester.run({ task, diff: postLoopDiff });
+
+        await addCheckpoint(session, { stage: "tester", iteration: i, ok: testerOutput.ok });
+
+        emitProgress(
+          emitter,
+          makeEvent("tester:end", { ...eventBase, stage: "tester" }, {
+            status: testerOutput.ok ? "ok" : "fail",
+            message: testerOutput.ok ? "Tester passed" : `Tester: ${testerOutput.summary}`
+          })
+        );
+
+        if (!testerOutput.ok) {
+          const maxTesterRetries = config.session?.max_tester_retries ?? 1;
+          session.tester_retry_count = (session.tester_retry_count || 0) + 1;
+          await saveSession(session);
+
+          if (session.tester_retry_count >= maxTesterRetries) {
+            const solomonResult = await invokeSolomon({
+              config, logger, emitter, eventBase, stage: "tester", askQuestion, session, iteration: i,
+              conflict: {
+                stage: "tester",
+                task,
+                diff: postLoopDiff,
+                iterationCount: session.tester_retry_count,
+                maxIterations: maxTesterRetries,
+                history: [{ agent: "tester", feedback: testerOutput.summary }]
+              }
+            });
+
+            if (solomonResult.action === "pause") {
+              return { paused: true, sessionId: session.id, question: solomonResult.question, context: "tester_fail_fast" };
+            }
+            if (solomonResult.action === "subtask") {
+              return { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "tester_subtask" };
+            }
+            // continue = Solomon approved, proceed to next stage
+          } else {
+            session.last_reviewer_feedback = `Tester feedback: ${testerOutput.summary}`;
+            await saveSession(session);
+            continue;
+          }
+        } else {
+          session.tester_retry_count = 0;
+        }
+      }
+
+      // --- Security ---
+      if (securityEnabled) {
+        logger.setContext({ iteration: i, stage: "security" });
+        emitProgress(
+          emitter,
+          makeEvent("security:start", { ...eventBase, stage: "security" }, {
+            message: "Security auditing code"
+          })
+        );
+
+        const security = new SecurityRole({ config, logger, emitter });
+        await security.init({ task, iteration: i });
+        const securityOutput = await security.run({ task, diff: postLoopDiff });
+
+        await addCheckpoint(session, { stage: "security", iteration: i, ok: securityOutput.ok });
+
+        emitProgress(
+          emitter,
+          makeEvent("security:end", { ...eventBase, stage: "security" }, {
+            status: securityOutput.ok ? "ok" : "fail",
+            message: securityOutput.ok ? "Security audit passed" : `Security: ${securityOutput.summary}`
+          })
+        );
+
+        if (!securityOutput.ok) {
+          const maxSecurityRetries = config.session?.max_security_retries ?? 1;
+          session.security_retry_count = (session.security_retry_count || 0) + 1;
+          await saveSession(session);
+
+          if (session.security_retry_count >= maxSecurityRetries) {
+            const solomonResult = await invokeSolomon({
+              config, logger, emitter, eventBase, stage: "security", askQuestion, session, iteration: i,
+              conflict: {
+                stage: "security",
+                task,
+                diff: postLoopDiff,
+                iterationCount: session.security_retry_count,
+                maxIterations: maxSecurityRetries,
+                history: [{ agent: "security", feedback: securityOutput.summary }]
+              }
+            });
+
+            if (solomonResult.action === "pause") {
+              return { paused: true, sessionId: session.id, question: solomonResult.question, context: "security_fail_fast" };
+            }
+            if (solomonResult.action === "subtask") {
+              return { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "security_subtask" };
+            }
+            // continue = Solomon approved, proceed
+          } else {
+            session.last_reviewer_feedback = `Security feedback: ${securityOutput.summary}`;
+            await saveSession(session);
+            continue;
+          }
+        } else {
+          session.security_retry_count = 0;
+        }
+      }
+
+      // --- All post-loop checks passed → finalize ---
       const gitResult = await finalizeGitAutomation({ config, gitCtx, task, logger, session });
       await markSessionStatus(session, "approved");
       emitProgress(
@@ -662,34 +911,32 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           detail: { subloop: "reviewer", retryCount: session.reviewer_retry_count, limit: maxReviewerRetries }
         })
       );
-      const question = `Reviewer has rejected ${session.reviewer_retry_count} times with the same issues. Blocking issues:\n${session.last_reviewer_feedback}\n\nHow should we proceed?`;
-      if (askQuestion) {
-        const answer = await askQuestion(question, { iteration: i, stage: "reviewer" });
-        if (answer) {
-          session.last_reviewer_feedback += `\nUser guidance: ${answer}`;
-          session.reviewer_retry_count = 0;
-          await saveSession(session);
-          continue;
-        }
-      }
-      await pauseSession(session, {
-        question,
-        context: {
-          iteration: i,
+
+      const solomonResult = await invokeSolomon({
+        config, logger, emitter, eventBase, stage: "reviewer", askQuestion, session, iteration: i,
+        conflict: {
           stage: "reviewer",
-          lastFeedback: session.last_reviewer_feedback,
-          retryCount: session.reviewer_retry_count
+          task,
+          iterationCount: session.reviewer_retry_count,
+          maxIterations: maxReviewerRetries,
+          history: [{ agent: "reviewer", feedback: session.last_reviewer_feedback }]
         }
       });
-      emitProgress(
-        emitter,
-        makeEvent("question", { ...eventBase, stage: "reviewer" }, {
-          status: "paused",
-          message: question,
-          detail: { question, sessionId: session.id }
-        })
-      );
-      return { paused: true, sessionId: session.id, question, context: "reviewer_fail_fast" };
+
+      if (solomonResult.action === "pause") {
+        return { paused: true, sessionId: session.id, question: solomonResult.question, context: "reviewer_fail_fast" };
+      }
+      if (solomonResult.action === "continue") {
+        if (solomonResult.humanGuidance) {
+          session.last_reviewer_feedback += `\nUser guidance: ${solomonResult.humanGuidance}`;
+        }
+        session.reviewer_retry_count = 0;
+        await saveSession(session);
+        continue;
+      }
+      if (solomonResult.action === "subtask") {
+        return { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "reviewer_subtask" };
+      }
     }
   }
 
@@ -736,6 +983,8 @@ export async function resumeFlow({ sessionId, answer, config, logger, flags = {}
   session.repeated_issue_count = 0;
   session.sonar_retry_count = 0;
   session.reviewer_retry_count = 0;
+  session.tester_retry_count = 0;
+  session.security_retry_count = 0;
   session.last_sonar_issue_signature = null;
   session.sonar_repeat_count = 0;
   session.last_reviewer_issue_signature = null;

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -1,0 +1,60 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { buildCoderPrompt } from "../prompts/coder.js";
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.coder?.provider ||
+    config?.coder ||
+    "claude"
+  );
+}
+
+export class CoderRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "coder", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, reviewerFeedback, sonarSummary, onOutput } = typeof input === "string"
+      ? { task: input, reviewerFeedback: null, sonarSummary: null, onOutput: null }
+      : input || {};
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildCoderPrompt({
+      task: task || this.context?.task || "",
+      reviewerFeedback: reviewerFeedback || null,
+      sonarSummary: sonarSummary || null,
+      coderRules: this.instructions,
+      methodology: this.config?.development?.methodology || "tdd"
+    });
+
+    const coderArgs = { prompt, role: "coder" };
+    if (onOutput) coderArgs.onOutput = onOutput;
+
+    const result = await agent.runTask(coderArgs);
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Coder failed",
+          provider
+        },
+        summary: `Coder failed: ${result.error || result.output || "unknown error"}`
+      };
+    }
+
+    return {
+      ok: true,
+      result: {
+        output: result.output || "",
+        provider
+      },
+      summary: "Coder completed"
+    };
+  }
+}

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -2,3 +2,9 @@ export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./b
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
 export { CommiterRole } from "./commiter-role.js";
+export { CoderRole } from "./coder-role.js";
+export { SonarRole } from "./sonar-role.js";
+export { ResearcherRole } from "./researcher-role.js";
+export { TesterRole } from "./tester-role.js";
+export { SecurityRole } from "./security-role.js";
+export { SolomonRole } from "./solomon-role.js";

--- a/src/roles/researcher-role.js
+++ b/src/roles/researcher-role.js
@@ -1,0 +1,134 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on researching the codebase."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.researcher?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function buildPrompt({ task, instructions }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "Investigate the codebase for the following task.",
+    "Identify affected files, patterns, constraints, prior decisions, risks, and test coverage.",
+    "Return a single valid JSON object with your findings and nothing else.",
+    'JSON schema: {"affected_files":[string],"patterns":[string],"constraints":[string],"prior_decisions":[string],"risks":[string],"test_coverage":string}'
+  );
+
+  sections.push(`## Task\n${task}`);
+
+  return sections.join("\n\n");
+}
+
+function parseResearchOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+function buildSummary(parsed) {
+  const files = parsed.affected_files?.length || 0;
+  const risks = parsed.risks?.length || 0;
+  const patterns = parsed.patterns?.length || 0;
+  const parts = [];
+  if (files) parts.push(`${files} file${files !== 1 ? "s" : ""}`);
+  if (risks) parts.push(`${risks} risk${risks !== 1 ? "s" : ""}`);
+  if (patterns) parts.push(`${patterns} pattern${patterns !== 1 ? "s" : ""}`);
+  return parts.length
+    ? `Research complete: ${parts.join(", ")} identified`
+    : "Research complete";
+}
+
+export class ResearcherRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "researcher", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const task = typeof input === "string"
+      ? input
+      : input?.task || this.context?.task || "";
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({ task, instructions: this.instructions });
+    const result = await agent.runTask({ prompt, role: "researcher" });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Researcher failed",
+          provider
+        },
+        summary: `Researcher failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseResearchOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: true,
+          result: {
+            affected_files: [],
+            patterns: [],
+            constraints: [],
+            prior_decisions: [],
+            risks: [],
+            test_coverage: "",
+            raw: result.output,
+            provider
+          },
+          summary: "Research complete (unstructured output)"
+        };
+      }
+
+      return {
+        ok: true,
+        result: {
+          affected_files: parsed.affected_files || [],
+          patterns: parsed.patterns || [],
+          constraints: parsed.constraints || [],
+          prior_decisions: parsed.prior_decisions || [],
+          risks: parsed.risks || [],
+          test_coverage: parsed.test_coverage || "",
+          provider
+        },
+        summary: buildSummary(parsed)
+      };
+    } catch {
+      return {
+        ok: true,
+        result: {
+          affected_files: [],
+          patterns: [],
+          constraints: [],
+          prior_decisions: [],
+          risks: [],
+          test_coverage: "",
+          raw: result.output,
+          provider
+        },
+        summary: "Research complete (unstructured output)"
+      };
+    }
+  }
+}

--- a/src/roles/security-role.js
+++ b/src/roles/security-role.js
@@ -1,0 +1,128 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on auditing code for security vulnerabilities."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.security?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function buildPrompt({ task, diff, instructions }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are a security auditor. Analyze the code changes for vulnerabilities.",
+    "Check for: OWASP top 10, exposed secrets/API keys, hardcoded credentials, command injection, XSS, SQL injection, path traversal, prototype pollution, insecure dependencies.",
+    "Return a single valid JSON object with your findings and nothing else.",
+    'JSON schema: {"vulnerabilities":[{"severity":"critical|high|medium|low","category":string,"file":string,"line":number,"description":string,"fix_suggestion":string}],"verdict":"pass"|"fail"}'
+  );
+
+  sections.push(`## Task\n${task}`);
+
+  if (diff) {
+    sections.push(`## Git diff to audit\n${diff}`);
+  }
+
+  return sections.join("\n\n");
+}
+
+function parseSecurityOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+function buildSummary(parsed) {
+  const vulns = parsed.vulnerabilities || [];
+  if (vulns.length === 0) {
+    return `Verdict: ${parsed.verdict || "pass"}; No vulnerabilities found`;
+  }
+
+  const bySeverity = {};
+  for (const v of vulns) {
+    const sev = v.severity || "unknown";
+    bySeverity[sev] = (bySeverity[sev] || 0) + 1;
+  }
+
+  const parts = Object.entries(bySeverity)
+    .sort(([a], [b]) => {
+      const order = { critical: 0, high: 1, medium: 2, low: 3 };
+      return (order[a] ?? 4) - (order[b] ?? 4);
+    })
+    .map(([sev, count]) => `${count} ${sev}`);
+
+  return `Verdict: ${parsed.verdict || "fail"}; ${parts.join(", ")}`;
+}
+
+export class SecurityRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "security", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, diff } = typeof input === "string"
+      ? { task: input, diff: null }
+      : { task: input?.task || this.context?.task || "", diff: input?.diff || null };
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({ task, diff, instructions: this.instructions });
+    const result = await agent.runTask({ prompt, role: "security" });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Security audit failed",
+          provider
+        },
+        summary: `Security audit failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseSecurityOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: false,
+          result: { error: "Failed to parse security output: no JSON found", provider },
+          summary: "Security output parse error: no JSON found"
+        };
+      }
+
+      const verdict = parsed.verdict || (parsed.vulnerabilities?.length ? "fail" : "pass");
+      const ok = verdict === "pass";
+
+      return {
+        ok,
+        result: {
+          vulnerabilities: parsed.vulnerabilities || [],
+          verdict,
+          provider
+        },
+        summary: buildSummary({ ...parsed, verdict })
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        result: { error: `Failed to parse security output: ${err.message}`, provider },
+        summary: `Security output parse error: ${err.message}`
+      };
+    }
+  }
+}

--- a/src/roles/solomon-role.js
+++ b/src/roles/solomon-role.js
@@ -1,0 +1,199 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on resolving the conflict between agents."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.solomon?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function formatHistory(history) {
+  if (!history || history.length === 0) return "No previous interactions recorded.";
+
+  return history
+    .map((entry, i) => {
+      const agent = entry.agent || "unknown";
+      const feedback = entry.feedback || entry.message || "(no feedback)";
+      return `### Interaction ${i + 1} [${agent}]\n${feedback}`;
+    })
+    .join("\n\n");
+}
+
+function buildPrompt({ conflict, task, instructions }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are Solomon, the conflict resolver in a multi-role AI pipeline.",
+    "You are activated when agents cannot reach agreement after their iteration limit."
+  );
+
+  sections.push(
+    "## Decision hierarchy",
+    "Security > Correctness > Tests > Architecture > Maintainability > Style",
+    "- Green tests are sacred. Never dismiss a failing test.",
+    "- Style preferences NEVER block approval.",
+    "- Hardcoded values that will come from DB later are acceptable (contextual false positive).",
+    "- Sonar INFO/MINOR issues are always dismissable.",
+    "- Sonar BLOCKER/CRITICAL must be fixed unless they are proven false positives."
+  );
+
+  sections.push(
+    "## Classification rules",
+    "For each issue, classify as:",
+    "1. **critical** (security, correctness, tests broken) — action: must_fix",
+    "2. **important** (architecture, maintainability) — action: should_fix",
+    "3. **style** (naming, formatting, preferences, false positives) — action: dismiss"
+  );
+
+  sections.push(
+    "## Your decision options",
+    '1. **approve** — All pending issues are style/false positives. Pipeline continues.',
+    '2. **approve_with_conditions** — Important issues exist but are fixable. Give exact instructions to Coder for one more attempt.',
+    '3. **escalate_human** — Critical issues that cannot be resolved, ambiguous requirements, architecture decisions, or business logic decisions.',
+    '4. **create_subtask** — A prerequisite task must be completed first to resolve the conflict. The current task will pause, the subtask runs, then the current task resumes.'
+  );
+
+  sections.push(
+    "Return a single valid JSON object with your ruling and nothing else.",
+    'JSON schema: {"ruling":"approve"|"approve_with_conditions"|"escalate_human"|"create_subtask","classification":[{"issue":string,"category":"critical"|"important"|"style","action":"must_fix"|"should_fix"|"dismiss"}],"conditions":[string],"dismissed":[string],"escalate":boolean,"escalate_reason":string|null,"subtask":{"title":string,"description":string,"reason":string}|null}'
+  );
+
+  const stage = conflict?.stage || "unknown";
+  const iterationCount = conflict?.iterationCount ?? "?";
+  const maxIterations = conflict?.maxIterations ?? "?";
+
+  sections.push(
+    `## Conflict context`,
+    `Stage: ${stage}`,
+    `Iterations exhausted: ${iterationCount}/${maxIterations}`
+  );
+
+  if (task) {
+    sections.push(`## Original task\n${task}`);
+  }
+
+  if (conflict?.diff) {
+    sections.push(`## Current diff\n${conflict.diff}`);
+  }
+
+  sections.push(`## Agent interaction history\n${formatHistory(conflict?.history)}`);
+
+  return sections.join("\n\n");
+}
+
+function parseSolomonOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+function buildSummary(parsed) {
+  const ruling = parsed.ruling || "unknown";
+  const conditions = parsed.conditions || [];
+  const dismissed = parsed.dismissed || [];
+  const subtask = parsed.subtask || null;
+
+  if (ruling === "approve") {
+    const parts = ["Approved"];
+    if (dismissed.length > 0) parts.push(`${dismissed.length} dismissed`);
+    return parts.join("; ");
+  }
+
+  if (ruling === "approve_with_conditions") {
+    const parts = [`Approved with ${conditions.length} condition${conditions.length !== 1 ? "s" : ""}`];
+    if (dismissed.length > 0) parts.push(`${dismissed.length} dismissed`);
+    return parts.join("; ");
+  }
+
+  if (ruling === "escalate_human") {
+    return `Escalated to human: ${parsed.escalate_reason || "ambiguous conflict"}`;
+  }
+
+  if (ruling === "create_subtask") {
+    return `Subtask created: ${subtask?.title || "unnamed subtask"}`;
+  }
+
+  return `Solomon ruling: ${ruling}`;
+}
+
+export class SolomonRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "solomon", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const conflict = input?.conflict || {};
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({
+      conflict,
+      task: this.context?.task || "",
+      instructions: this.instructions
+    });
+
+    const result = await agent.runTask({ prompt, role: "solomon" });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Solomon arbitration failed",
+          provider
+        },
+        summary: `Solomon failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseSolomonOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: false,
+          result: { error: "Failed to parse Solomon output: no JSON found", provider },
+          summary: "Solomon output parse error: no JSON found"
+        };
+      }
+
+      const ruling = parsed.ruling || "approve";
+      const escalate = Boolean(parsed.escalate);
+      const ok = ruling !== "escalate_human";
+
+      return {
+        ok,
+        result: {
+          ruling,
+          classification: parsed.classification || [],
+          conditions: parsed.conditions || [],
+          dismissed: parsed.dismissed || [],
+          escalate,
+          escalate_reason: parsed.escalate_reason || null,
+          subtask: parsed.subtask || null,
+          provider
+        },
+        summary: buildSummary(parsed)
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        result: { error: `Failed to parse Solomon output: ${err.message}`, provider },
+        summary: `Solomon output parse error: ${err.message}`
+      };
+    }
+  }
+}

--- a/src/roles/sonar-role.js
+++ b/src/roles/sonar-role.js
@@ -1,0 +1,65 @@
+import { BaseRole } from "./base-role.js";
+import { runSonarScan } from "../sonar/scanner.js";
+import { getQualityGateStatus, getOpenIssues } from "../sonar/api.js";
+import { shouldBlockByProfile, summarizeIssues } from "../sonar/enforcer.js";
+
+function normalizeIssues(rawIssues) {
+  return rawIssues.map((issue) => ({
+    severity: issue.severity || "UNKNOWN",
+    type: issue.type || "UNKNOWN",
+    file: issue.component || "",
+    line: issue.line || 0,
+    rule: issue.rule || "",
+    message: issue.message || ""
+  }));
+}
+
+export class SonarRole extends BaseRole {
+  constructor({ config, logger, emitter = null }) {
+    super({ name: "sonar", config, logger, emitter });
+  }
+
+  async execute(_input) {
+    const scan = await runSonarScan(this.config);
+
+    if (!scan.ok) {
+      return {
+        ok: false,
+        result: {
+          projectKey: scan.projectKey || null,
+          gateStatus: null,
+          issues: [],
+          openIssuesTotal: 0,
+          issuesSummary: "",
+          blocking: false,
+          error: scan.stderr || scan.stdout || "Scan failed"
+        },
+        summary: `Sonar scan failed: ${scan.stderr || scan.stdout || "unknown error"}`
+      };
+    }
+
+    const gate = await getQualityGateStatus(this.config, scan.projectKey);
+    const openIssues = await getOpenIssues(this.config, scan.projectKey);
+    const issues = normalizeIssues(openIssues.issues || []);
+    const issuesSummary = summarizeIssues(openIssues.issues || []);
+
+    const profile = this.config.sonarqube?.enforcement_profile || "pragmatic";
+    const blocking = shouldBlockByProfile({
+      gateStatus: gate.status,
+      profile
+    });
+
+    return {
+      ok: !blocking,
+      result: {
+        projectKey: scan.projectKey,
+        gateStatus: gate.status,
+        issues,
+        openIssuesTotal: openIssues.total || 0,
+        issuesSummary,
+        blocking
+      },
+      summary: `Quality gate: ${gate.status}; Issues: ${openIssues.total || 0}${issuesSummary ? ` (${issuesSummary})` : ""}${blocking ? " [BLOCKING]" : ""}`
+    };
+  }
+}

--- a/src/roles/tester-role.js
+++ b/src/roles/tester-role.js
@@ -1,0 +1,114 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on evaluating test quality."
+].join(" ");
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.tester?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function buildPrompt({ task, diff, sonarIssues, instructions }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are a test quality gate. You do NOT write tests — you evaluate them.",
+    "Run the test suite, check coverage, identify missing scenarios, and evaluate assertion quality.",
+    "Return a single valid JSON object with your findings and nothing else.",
+    'JSON schema: {"tests_pass":boolean,"coverage":{"overall":number,"services":number,"utilities":number},"missing_scenarios":[string],"quality_issues":[string],"verdict":"pass"|"fail"}'
+  );
+
+  sections.push(`## Task\n${task}`);
+
+  if (diff) {
+    sections.push(`## Git diff\n${diff}`);
+  }
+
+  if (sonarIssues) {
+    sections.push(`## Sonar test issues\n${sonarIssues}`);
+  }
+
+  return sections.join("\n\n");
+}
+
+function parseTesterOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+  return JSON.parse(jsonMatch[0]);
+}
+
+export class TesterRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "tester", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, diff, sonarIssues } = typeof input === "string"
+      ? { task: input, diff: null, sonarIssues: null }
+      : { task: input?.task || this.context?.task || "", diff: input?.diff || null, sonarIssues: input?.sonarIssues || null };
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildPrompt({ task, diff, sonarIssues, instructions: this.instructions });
+    const result = await agent.runTask({ prompt, role: "tester" });
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Tester failed",
+          provider
+        },
+        summary: `Tester failed: ${result.error || "unknown error"}`
+      };
+    }
+
+    try {
+      const parsed = parseTesterOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: false,
+          result: { error: "Failed to parse tester output: no JSON found", provider },
+          summary: "Tester output parse error: no JSON found"
+        };
+      }
+
+      const verdict = parsed.verdict || (parsed.tests_pass ? "pass" : "fail");
+      const ok = verdict === "pass";
+      const coverage = parsed.coverage || {};
+
+      return {
+        ok,
+        result: {
+          tests_pass: Boolean(parsed.tests_pass),
+          coverage,
+          missing_scenarios: parsed.missing_scenarios || [],
+          quality_issues: parsed.quality_issues || [],
+          verdict,
+          provider
+        },
+        summary: `Verdict: ${verdict}; Coverage: ${coverage.overall ?? "?"}%${parsed.missing_scenarios?.length ? `; ${parsed.missing_scenarios.length} missing scenario(s)` : ""}${parsed.quality_issues?.length ? `; ${parsed.quality_issues.length} quality issue(s)` : ""}`
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        result: { error: `Failed to parse tester output: ${err.message}`, provider },
+        summary: `Tester output parse error: ${err.message}`
+      };
+    }
+  }
+}

--- a/templates/roles/solomon.md
+++ b/templates/roles/solomon.md
@@ -1,28 +1,23 @@
-# Solomon Role (Conflict Resolver)
+# Solomon Role (Conflict Resolver & Arbiter)
 
-You are **Solomon**, the conflict resolver in a multi-role AI pipeline. You are activated when the Coder and Reviewer cannot reach agreement after the maximum number of iterations.
+You are **Solomon**, the supreme arbiter in a multi-role AI pipeline. You are activated when agents cannot reach agreement after their iteration limit. Your decisions are final within your rules.
 
 ## When activated
 
-- Iteration limit between Coder and Reviewer is reached
-- Coder and Sonar are stuck in a loop
+- Coder ↔ Sonar loop exhausted (default: 3 iterations)
+- Coder ↔ Reviewer loop exhausted (default: 3 iterations via PR comments)
+- Coder ↔ Tester loop exhausted (default: 1 iteration)
+- Coder ↔ Security loop exhausted (default: 1 iteration)
 - Any two roles produce contradictory outputs
 
 ## Input
 
 You receive the full history of the conflict:
-- All reviewer feedback across iterations
+- All agent feedback across iterations (identifying which agent said what)
 - All coder attempts and changes
 - Original task requirements and acceptance criteria
-- Sonar findings (if applicable)
-
-## Classification rules
-
-For each blocking issue raised by the Reviewer, classify it as:
-
-1. **Critical** (security, correctness, tests broken) — **MUST fix**
-2. **Important** (architecture, maintainability) — **SHOULD fix**
-3. **Style** (naming, formatting, preferences) — **DISMISS**
+- Sonar findings, reviewer comments, tester feedback, security findings (as applicable)
+- Current diff
 
 ## Decision hierarchy
 
@@ -30,31 +25,82 @@ For each blocking issue raised by the Reviewer, classify it as:
 Security > Correctness > Tests > Architecture > Maintainability > Style
 ```
 
-- Green tests are sacred. Never dismiss a failing test.
-- Style preferences NEVER block approval.
-- If the Reviewer's feedback is purely stylistic, approve the code.
+- **Green tests are sacred.** Never dismiss a failing test.
+- **Style preferences NEVER block approval.**
+- **Contextual false positives are valid.** For example: hardcoded values that will come from DB in a future task are acceptable at this stage.
+- **Sonar INFO/MINOR issues** are always dismissable.
+- **Sonar MAJOR** — evaluate in context; dismiss if it's a known pattern or temporary state.
+- **Sonar BLOCKER/CRITICAL** must be fixed unless proven false positive.
+
+## Classification rules
+
+For each blocking issue raised by any agent, classify it as:
+
+1. **critical** (security vulnerability, correctness bug, tests broken) — action: **must_fix**
+2. **important** (architecture, maintainability, missing coverage) — action: **should_fix**
+3. **style** (naming, formatting, preferences, false positives, contextual exceptions) — action: **dismiss**
+
+## Blocking criteria (real-world)
+
+| Criterion | Blocks? | Notes |
+|-----------|---------|-------|
+| Failing test | YES | Always — tests are sacred |
+| Security vulnerability critical/high | YES | Always requires fix |
+| Security vulnerability medium | DEPENDS | Evaluate in context |
+| Security vulnerability low | NO | Document as TODO |
+| Sonar BLOCKER/CRITICAL | YES | Unless proven false positive |
+| Sonar MAJOR | DEPENDS | Evaluate context and project stage |
+| Sonar MINOR/INFO | NO | Dismiss |
+| Hardcoded value (planned for DB later) | NO | Contextual false positive |
+| Coverage < threshold | YES | Per project configuration |
+| Pure style issue | NO | Never blocks |
+| Architecture change not in scope | ESCALATE | Human decision required |
 
 ## Decision options
 
-1. **Approve with conditions** — List specific, actionable fixes
-2. **Send specific instructions to Coder** — Not generic "fix issues", but exact changes
-3. **Escalate to human** — When requirements are ambiguous or conflicting
+1. **approve** — All pending issues are style/false positives. Code passes to next pipeline stage.
+2. **approve_with_conditions** — Important (not critical) issues exist. Give the Coder exact, actionable instructions for one more attempt. Not generic feedback — specific changes with file and line references.
+3. **escalate_human** — When you cannot decide:
+   - Critical issues that resist multiple fix attempts
+   - Ambiguous or conflicting requirements
+   - Architecture decisions beyond task scope
+   - Business logic decisions
+   - Scope creep (task is larger than originally estimated)
+4. **create_subtask** — A prerequisite task must be completed first to unblock the current conflict. The pipeline will:
+   - Pause the current task
+   - Execute the subtask through the full pipeline
+   - Resume the original task with the subtask completed
+
+### When to create a subtask
+
+- A shared utility/module is needed that doesn't exist yet
+- A refactoring is required before the current change can work
+- A dependency needs to be updated or configured
+- A circular dependency needs to be broken
+- Test infrastructure needs to be set up first
 
 ## Output format
 
 ```json
 {
-  "ok": true,
-  "result": {
-    "ruling": "approve_with_conditions",
-    "classification": [
-      { "issue": "Missing null check", "category": "critical", "action": "must_fix" },
-      { "issue": "Variable naming", "category": "style", "action": "dismiss" }
-    ],
-    "conditions": ["Add null check in processUser() at line 42"],
-    "dismissed": ["Variable naming preference — not blocking"],
-    "escalate": false
-  },
-  "summary": "Approved with 1 condition: add null check. 1 style issue dismissed."
+  "ruling": "approve | approve_with_conditions | escalate_human | create_subtask",
+  "classification": [
+    { "issue": "Description of the issue", "category": "critical | important | style", "action": "must_fix | should_fix | dismiss" }
+  ],
+  "conditions": ["Specific actionable fix instruction with file:line reference"],
+  "dismissed": ["Issue description — reason for dismissal"],
+  "escalate": false,
+  "escalate_reason": null,
+  "subtask": {
+    "title": "Short descriptive title for the subtask",
+    "description": "What needs to be done and why",
+    "reason": "How this resolves the current conflict"
+  }
 }
 ```
+
+Notes:
+- `subtask` is `null` unless ruling is `create_subtask`
+- `escalate_reason` is `null` unless ruling is `escalate_human`
+- `conditions` is empty unless ruling is `approve_with_conditions`
+- `dismissed` lists all style/false-positive issues with rationale

--- a/tests/coder-role.test.js
+++ b/tests/coder-role.test.js
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { CoderRole } = await import("../src/roles/coder-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("CoderRole", () => {
+  let emitter;
+  const config = {
+    roles: { coder: { provider: "claude", model: null } },
+    coder: "claude",
+    development: { methodology: "tdd" }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "Changes applied successfully",
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'coder'", () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("coder");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ task: "test" })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add login feature" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes prompt with task to agent", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add login feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Add login feature");
+    expect(callArgs.role).toBe("coder");
+  });
+
+  it("includes reviewer feedback in prompt when provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      task: "Fix bug",
+      reviewerFeedback: "Missing null check on line 42"
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Missing null check on line 42");
+  });
+
+  it("includes sonar summary in prompt when provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      task: "Fix sonar issues",
+      sonarSummary: "QualityGate=ERROR; CRITICAL: 2"
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("QualityGate=ERROR; CRITICAL: 2");
+  });
+
+  it("includes TDD methodology in prompt by default", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("TDD");
+  });
+
+  it("accepts string input as task shorthand", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Add login feature");
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Add login feature");
+  });
+
+  it("uses task from context when not provided in input", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Context task" });
+    await role.run({});
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Context task");
+  });
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Process timed out",
+      exitCode: 1
+    });
+
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add feature" });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Process timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  it("returns output from agent in result", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "Modified src/auth.js and added tests",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Add auth" });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.output).toBe("Modified src/auth.js and added tests");
+  });
+
+  it("forwards onOutput callback to agent", async () => {
+    const onOutput = vi.fn();
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature", onOutput });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.onOutput).toBe(onOutput);
+  });
+
+  it("does not pass onOutput when not provided", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.onOutput).toBeUndefined();
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new CoderRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run({ task: "Task" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("coder");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Agent binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new CoderRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run({ task: "Task" })).rejects.toThrow("Agent binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Agent binary not found");
+  });
+
+  it("report() returns structured coder report", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Build feature" });
+
+    const report = role.report();
+    expect(report.role).toBe("coder");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("resolves provider from config.roles.coder.provider", async () => {
+    const customConfig = {
+      roles: { coder: { provider: "codex", model: null } },
+      development: { methodology: "standard" }
+    };
+
+    const role = new CoderRole({ config: customConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("codex", customConfig, logger);
+  });
+
+  it("falls back to config.coder when roles.coder.provider is null", async () => {
+    const legacyConfig = {
+      roles: { coder: { provider: null } },
+      coder: "gemini",
+      development: { methodology: "tdd" }
+    };
+
+    const role = new CoderRole({ config: legacyConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", legacyConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {} };
+
+    const role = new CoderRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  it("works without emitter", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Task" });
+
+    expect(output.ok).toBe(true);
+  });
+
+  it("includes provider in result", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Task" });
+
+    expect(output.result.provider).toBe("claude");
+  });
+});

--- a/tests/researcher-role.test.js
+++ b/tests/researcher-role.test.js
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { ResearcherRole } = await import("../src/roles/researcher-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const sampleResearchOutput = JSON.stringify({
+  affected_files: ["src/auth.js", "tests/auth.test.js"],
+  patterns: ["Factory pattern for agents", "ES modules"],
+  constraints: ["Must keep backward compatibility"],
+  prior_decisions: ["ADR-001 defines role-based architecture"],
+  risks: ["Changing auth may break session handling"],
+  test_coverage: "80% coverage on auth module"
+});
+
+describe("ResearcherRole", () => {
+  let emitter;
+  const config = {
+    roles: { researcher: { provider: "claude", model: null }, coder: { provider: "claude" } },
+    development: {}
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: sampleResearchOutput,
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'researcher'", () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("researcher");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run("task")).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Implement login feature");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes task in prompt to agent", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Add authentication module");
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Add authentication module");
+    expect(callArgs.role).toBe("researcher");
+  });
+
+  it("accepts string input as task shorthand", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Investigate codebase");
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Investigate codebase");
+  });
+
+  it("accepts object input with task field", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Investigate auth" });
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Investigate auth");
+  });
+
+  it("uses task from context when not provided in input", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Context task" });
+    await role.run({});
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Context task");
+  });
+
+  it("parses JSON output from agent into structured result", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Investigate auth");
+
+    expect(output.result.affected_files).toEqual(["src/auth.js", "tests/auth.test.js"]);
+    expect(output.result.patterns).toEqual(["Factory pattern for agents", "ES modules"]);
+    expect(output.result.constraints).toEqual(["Must keep backward compatibility"]);
+    expect(output.result.prior_decisions).toEqual(["ADR-001 defines role-based architecture"]);
+    expect(output.result.risks).toEqual(["Changing auth may break session handling"]);
+    expect(output.result.test_coverage).toBe("80% coverage on auth module");
+  });
+
+  it("handles JSON embedded in markdown code blocks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: `Here is my research:\n\`\`\`json\n${sampleResearchOutput}\n\`\`\`\nDone.`,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.affected_files).toEqual(["src/auth.js", "tests/auth.test.js"]);
+  });
+
+  it("returns ok=true with raw output when JSON parse fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "No JSON here, just plain text research findings about the codebase.",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.raw).toContain("plain text research");
+    expect(output.result.affected_files).toEqual([]);
+  });
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Agent timed out",
+      exitCode: 1
+    });
+
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  it("includes provider in result", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.result.provider).toBe("claude");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new ResearcherRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run("Task");
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("researcher");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new ResearcherRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run("Task")).rejects.toThrow("Binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Binary not found");
+  });
+
+  it("report() returns structured researcher report", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Investigate");
+
+    const report = role.report();
+    expect(report.role).toBe("researcher");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("resolves provider from config.roles.researcher.provider", async () => {
+    const customConfig = {
+      roles: { researcher: { provider: "codex" } },
+      development: {}
+    };
+
+    const role = new ResearcherRole({ config: customConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("codex", customConfig, logger);
+  });
+
+  it("falls back to coder provider when researcher provider is null", async () => {
+    const fallbackConfig = {
+      roles: { researcher: { provider: null }, coder: { provider: "gemini" } },
+      development: {}
+    };
+
+    const role = new ResearcherRole({ config: fallbackConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", fallbackConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {} };
+
+    const role = new ResearcherRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  it("works without emitter", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.ok).toBe(true);
+  });
+
+  it("generates meaningful summary from parsed research", async () => {
+    const role = new ResearcherRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.summary).toContain("2 files");
+    expect(output.summary).toContain("1 risk");
+  });
+});

--- a/tests/security-role.test.js
+++ b/tests/security-role.test.js
@@ -1,0 +1,314 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { SecurityRole } = await import("../src/roles/security-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const samplePassOutput = JSON.stringify({
+  vulnerabilities: [],
+  verdict: "pass"
+});
+
+const sampleFailOutput = JSON.stringify({
+  vulnerabilities: [
+    {
+      severity: "critical",
+      category: "injection",
+      file: "src/api/handler.js",
+      line: 42,
+      description: "User input passed directly to shell command",
+      fix_suggestion: "Use parameterized execution or sanitize input"
+    },
+    {
+      severity: "high",
+      category: "secrets",
+      file: "src/config.js",
+      line: 10,
+      description: "Hardcoded API key",
+      fix_suggestion: "Use environment variable"
+    }
+  ],
+  verdict: "fail"
+});
+
+describe("SecurityRole", () => {
+  let emitter;
+  const config = {
+    roles: { security: { provider: "claude", model: null }, coder: { provider: "claude" } },
+    development: {}
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: samplePassOutput,
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'security'", () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("security");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ task: "audit" })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Audit auth module", diff: "some diff" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes task and diff in prompt to agent", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Audit changes", diff: "diff --git a/src/api.js" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Audit changes");
+    expect(callArgs.prompt).toContain("diff --git a/src/api.js");
+    expect(callArgs.role).toBe("security");
+  });
+
+  it("accepts string input as task shorthand", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit code for vulnerabilities");
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Audit code for vulnerabilities");
+  });
+
+  it("uses task from context when not provided", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Context task" });
+    await role.run({});
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Context task");
+  });
+
+  it("returns ok=true when verdict is pass", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.verdict).toBe("pass");
+    expect(output.result.vulnerabilities).toHaveLength(0);
+  });
+
+  it("returns ok=false when verdict is fail", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: sampleFailOutput,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(false);
+    expect(output.result.verdict).toBe("fail");
+    expect(output.result.vulnerabilities).toHaveLength(2);
+  });
+
+  it("parses vulnerabilities with full structure", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: sampleFailOutput,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    const vuln = output.result.vulnerabilities[0];
+    expect(vuln.severity).toBe("critical");
+    expect(vuln.category).toBe("injection");
+    expect(vuln.file).toBe("src/api/handler.js");
+    expect(vuln.line).toBe(42);
+    expect(vuln.description).toContain("shell command");
+    expect(vuln.fix_suggestion).toContain("sanitize");
+  });
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Agent timed out",
+      exitCode: 1
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  it("handles JSON embedded in markdown code blocks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: `Results:\n\`\`\`json\n${samplePassOutput}\n\`\`\``,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.verdict).toBe("pass");
+  });
+
+  it("returns ok=false with parse error when JSON is invalid", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "No vulnerabilities found in plain text.",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("parse error");
+  });
+
+  it("includes provider in result", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.result.provider).toBe("claude");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new SecurityRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run("Audit");
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("security");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new SecurityRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run("Audit")).rejects.toThrow("Binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Binary not found");
+  });
+
+  it("report() returns structured security report", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Audit");
+
+    const report = role.report();
+    expect(report.role).toBe("security");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("resolves provider from config.roles.security.provider", async () => {
+    const customConfig = {
+      roles: { security: { provider: "codex" } },
+      development: {}
+    };
+
+    const role = new SecurityRole({ config: customConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Audit");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("codex", customConfig, logger);
+  });
+
+  it("falls back to coder provider when security provider is null", async () => {
+    const fallbackConfig = {
+      roles: { security: { provider: null }, coder: { provider: "gemini" } },
+      development: {}
+    };
+
+    const role = new SecurityRole({ config: fallbackConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Audit");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", fallbackConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {} };
+
+    const role = new SecurityRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Audit");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  it("generates meaningful summary with vulnerability counts", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: sampleFailOutput,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.summary).toContain("fail");
+    expect(output.summary).toContain("1 critical");
+    expect(output.summary).toContain("1 high");
+  });
+
+  it("works without emitter", async () => {
+    const role = new SecurityRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Audit");
+
+    expect(output.ok).toBe(true);
+  });
+});

--- a/tests/solomon-role.test.js
+++ b/tests/solomon-role.test.js
@@ -1,0 +1,467 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { SolomonRole } = await import("../src/roles/solomon-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const approveRuling = JSON.stringify({
+  ruling: "approve",
+  classification: [
+    { issue: "Variable naming", category: "style", action: "dismiss" }
+  ],
+  conditions: [],
+  dismissed: ["Variable naming — stylistic preference"],
+  escalate: false,
+  subtask: null
+});
+
+const approveWithConditionsRuling = JSON.stringify({
+  ruling: "approve_with_conditions",
+  classification: [
+    { issue: "Missing null check in processUser()", category: "critical", action: "must_fix" },
+    { issue: "Naming convention", category: "style", action: "dismiss" }
+  ],
+  conditions: ["Add null check in processUser() at line 42"],
+  dismissed: ["Naming convention — not blocking"],
+  escalate: false,
+  subtask: null
+});
+
+const escalateRuling = JSON.stringify({
+  ruling: "escalate_human",
+  classification: [
+    { issue: "Architecture change needed", category: "critical", action: "must_fix" }
+  ],
+  conditions: [],
+  dismissed: [],
+  escalate: true,
+  escalate_reason: "Requires architectural decision beyond agent scope",
+  subtask: null
+});
+
+const subtaskRuling = JSON.stringify({
+  ruling: "create_subtask",
+  classification: [
+    { issue: "Missing shared utility", category: "important", action: "must_fix" }
+  ],
+  conditions: [],
+  dismissed: [],
+  escalate: false,
+  subtask: {
+    title: "Extract shared validation utility",
+    description: "Create a shared validation module to resolve the circular dependency causing the conflict",
+    reason: "Both Coder and Reviewer agree validation is needed but disagree on location"
+  }
+});
+
+describe("SolomonRole", () => {
+  let emitter;
+  const config = {
+    roles: { solomon: { provider: "gemini" }, coder: { provider: "claude" } },
+    development: {},
+    session: {
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3,
+      max_tester_retries: 1,
+      max_security_retries: 1
+    }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveRuling,
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'solomon'", () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("solomon");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ conflict: {} })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes conflict context in prompt to agent", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Implement auth module" });
+    await role.run({
+      conflict: {
+        stage: "reviewer",
+        history: [{ agent: "reviewer", feedback: "Missing null check" }],
+        diff: "diff --git a/src/auth.js"
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Missing null check");
+    expect(callArgs.prompt).toContain("diff --git a/src/auth.js");
+    expect(callArgs.prompt).toContain("Implement auth module");
+    expect(callArgs.role).toBe("solomon");
+  });
+
+  // --- Ruling: approve ---
+
+  it("returns ok=true with ruling=approve when all issues are style", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve");
+    expect(output.result.dismissed).toHaveLength(1);
+    expect(output.result.escalate).toBe(false);
+  });
+
+  // --- Ruling: approve_with_conditions ---
+
+  it("returns ok=true with conditions when ruling=approve_with_conditions", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve_with_conditions");
+    expect(output.result.conditions).toHaveLength(1);
+    expect(output.result.conditions[0]).toContain("null check");
+  });
+
+  // --- Ruling: escalate_human ---
+
+  it("returns ok=false with escalate=true when ruling=escalate_human", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: escalateRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.ruling).toBe("escalate_human");
+    expect(output.result.escalate).toBe(true);
+    expect(output.result.escalate_reason).toContain("architectural");
+  });
+
+  // --- Ruling: create_subtask ---
+
+  it("returns ok=true with subtask when ruling=create_subtask", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: subtaskRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "sonar", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("create_subtask");
+    expect(output.result.subtask).toBeTruthy();
+    expect(output.result.subtask.title).toContain("validation utility");
+    expect(output.result.subtask.description).toBeTruthy();
+    expect(output.result.subtask.reason).toBeTruthy();
+  });
+
+  // --- Classification parsing ---
+
+  it("parses classification with full structure", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    const classification = output.result.classification;
+    expect(classification).toHaveLength(2);
+    expect(classification[0].category).toBe("critical");
+    expect(classification[0].action).toBe("must_fix");
+    expect(classification[1].category).toBe("style");
+    expect(classification[1].action).toBe("dismiss");
+  });
+
+  // --- Agent failure ---
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Agent timed out",
+      exitCode: 1
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  // --- JSON parsing ---
+
+  it("handles JSON embedded in markdown code blocks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: `Here is my ruling:\n\`\`\`json\n${approveRuling}\n\`\`\``,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+    expect(output.result.ruling).toBe("approve");
+  });
+
+  it("returns ok=false with parse error when no JSON found", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "I think the code looks fine, approve it.",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("parse error");
+  });
+
+  // --- Provider resolution ---
+
+  it("resolves provider from config.roles.solomon.provider", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", config, logger);
+  });
+
+  it("falls back to coder provider when solomon provider is null", async () => {
+    const fallbackConfig = {
+      roles: { solomon: { provider: null }, coder: { provider: "claude" } },
+      development: {},
+      session: {}
+    };
+
+    const role = new SolomonRole({ config: fallbackConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", fallbackConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {}, session: {} };
+
+    const role = new SolomonRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  // --- Summary generation ---
+
+  it("generates meaningful summary for approve ruling", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Approved");
+    expect(output.summary).toContain("1 dismissed");
+  });
+
+  it("generates meaningful summary for approve_with_conditions", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: approveWithConditionsRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Approved with 1 condition");
+    expect(output.summary).toContain("1 dismissed");
+  });
+
+  it("generates summary for escalate ruling", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: escalateRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.summary).toContain("Escalated to human");
+  });
+
+  it("generates summary for create_subtask ruling", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: subtaskRuling,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "sonar", history: [] } });
+
+    expect(output.summary).toContain("Subtask created");
+    expect(output.summary).toContain("validation utility");
+  });
+
+  // --- Events ---
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new SolomonRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("solomon");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new SolomonRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run({ conflict: { stage: "reviewer", history: [] } })).rejects.toThrow("Binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Binary not found");
+  });
+
+  // --- report() ---
+
+  it("report() returns structured solomon report", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    const report = role.report();
+    expect(report.role).toBe("solomon");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  // --- Works without emitter ---
+
+  it("works without emitter", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ conflict: { stage: "reviewer", history: [] } });
+
+    expect(output.ok).toBe(true);
+  });
+
+  // --- Conflict stage in prompt ---
+
+  it("includes conflict stage in prompt", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      conflict: {
+        stage: "sonar",
+        history: [{ agent: "sonar", feedback: "BLOCKER: SQL injection" }]
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("sonar");
+    expect(callArgs.prompt).toContain("SQL injection");
+  });
+
+  // --- Includes iteration limits context ---
+
+  it("includes iteration config context in prompt", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      conflict: {
+        stage: "reviewer",
+        iterationCount: 3,
+        maxIterations: 3,
+        history: []
+      }
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("3");
+  });
+
+  // --- Handles missing conflict gracefully ---
+
+  it("handles missing conflict input gracefully", async () => {
+    const role = new SolomonRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({});
+
+    expect(output.ok).toBe(true);
+    expect(mockRunTask).toHaveBeenCalled();
+  });
+});

--- a/tests/sonar-role.test.js
+++ b/tests/sonar-role.test.js
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+vi.mock("../src/sonar/scanner.js", () => ({
+  runSonarScan: vi.fn()
+}));
+
+vi.mock("../src/sonar/api.js", () => ({
+  getQualityGateStatus: vi.fn(),
+  getOpenIssues: vi.fn()
+}));
+
+vi.mock("../src/sonar/enforcer.js", () => ({
+  shouldBlockByProfile: vi.fn(),
+  summarizeIssues: vi.fn()
+}));
+
+const { SonarRole } = await import("../src/roles/sonar-role.js");
+const { runSonarScan } = await import("../src/sonar/scanner.js");
+const { getQualityGateStatus, getOpenIssues } = await import("../src/sonar/api.js");
+const { shouldBlockByProfile, summarizeIssues } = await import("../src/sonar/enforcer.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const sampleIssues = [
+  { severity: "CRITICAL", type: "BUG", component: "src/foo.js", line: 10, rule: "js:S1234", message: "Null pointer" },
+  { severity: "MAJOR", type: "CODE_SMELL", component: "src/bar.js", line: 25, rule: "js:S5678", message: "Unused var" }
+];
+
+describe("SonarRole", () => {
+  let emitter;
+  const config = {
+    sonarqube: {
+      enabled: true,
+      enforcement_profile: "pragmatic"
+    }
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    runSonarScan.mockResolvedValue({
+      ok: true,
+      projectKey: "kj-test-project",
+      stdout: "Analysis complete",
+      stderr: "",
+      exitCode: 0
+    });
+
+    getQualityGateStatus.mockResolvedValue({
+      ok: true,
+      status: "OK",
+      raw: {}
+    });
+
+    getOpenIssues.mockResolvedValue({
+      total: 0,
+      issues: [],
+      raw: {}
+    });
+
+    shouldBlockByProfile.mockReturnValue(false);
+    summarizeIssues.mockReturnValue("");
+  });
+
+  it("extends BaseRole and has name 'sonar'", () => {
+    const role = new SonarRole({ config, logger });
+    expect(role.name).toBe("sonar");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new SonarRole({ config, logger });
+    await expect(role.run()).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("executes scan, quality gate, and issues on run", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(runSonarScan).toHaveBeenCalledWith(config);
+    expect(getQualityGateStatus).toHaveBeenCalledWith(config, "kj-test-project");
+    expect(getOpenIssues).toHaveBeenCalledWith(config, "kj-test-project");
+    expect(output.ok).toBe(true);
+  });
+
+  it("returns ok=true when quality gate passes", async () => {
+    shouldBlockByProfile.mockReturnValue(false);
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(true);
+    expect(output.result.gateStatus).toBe("OK");
+    expect(output.result.blocking).toBe(false);
+  });
+
+  it("returns ok=false when quality gate blocks", async () => {
+    getQualityGateStatus.mockResolvedValue({ ok: true, status: "ERROR", raw: {} });
+    shouldBlockByProfile.mockReturnValue(true);
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(false);
+    expect(output.result.gateStatus).toBe("ERROR");
+    expect(output.result.blocking).toBe(true);
+  });
+
+  it("returns ok=false when scan fails", async () => {
+    runSonarScan.mockResolvedValue({
+      ok: false,
+      projectKey: null,
+      stdout: "",
+      stderr: "Docker not running",
+      exitCode: 1
+    });
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("scan failed");
+    expect(getQualityGateStatus).not.toHaveBeenCalled();
+  });
+
+  it("includes issues classified by severity in output", async () => {
+    getOpenIssues.mockResolvedValue({ total: 2, issues: sampleIssues, raw: {} });
+    summarizeIssues.mockReturnValue("CRITICAL: 1, MAJOR: 1");
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.issues).toHaveLength(2);
+    expect(output.result.issues[0]).toEqual({
+      severity: "CRITICAL",
+      type: "BUG",
+      file: "src/foo.js",
+      line: 10,
+      rule: "js:S1234",
+      message: "Null pointer"
+    });
+    expect(output.result.issues[1]).toEqual({
+      severity: "MAJOR",
+      type: "CODE_SMELL",
+      file: "src/bar.js",
+      line: 25,
+      rule: "js:S5678",
+      message: "Unused var"
+    });
+  });
+
+  it("calls shouldBlockByProfile with correct profile", async () => {
+    const customConfig = {
+      sonarqube: { enabled: true, enforcement_profile: "paranoid" }
+    };
+    const role = new SonarRole({ config: customConfig, logger });
+    await role.init({});
+    await role.run();
+
+    expect(shouldBlockByProfile).toHaveBeenCalledWith({
+      gateStatus: "OK",
+      profile: "paranoid"
+    });
+  });
+
+  it("includes issuesSummary from summarizeIssues", async () => {
+    getOpenIssues.mockResolvedValue({ total: 3, issues: sampleIssues, raw: {} });
+    summarizeIssues.mockReturnValue("CRITICAL: 1, MAJOR: 2");
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.issuesSummary).toBe("CRITICAL: 1, MAJOR: 2");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new SonarRole({ config, logger, emitter });
+    await role.init({ iteration: 1 });
+    await role.run();
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("sonar");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when scan throws", async () => {
+    runSonarScan.mockRejectedValue(new Error("Docker daemon not running"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new SonarRole({ config, logger, emitter });
+    await role.init({});
+    await expect(role.run()).rejects.toThrow("Docker daemon not running");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Docker daemon not running");
+  });
+
+  it("report() returns structured sonar report", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    await role.run();
+
+    const report = role.report();
+    expect(report.role).toBe("sonar");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("includes projectKey in result", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.projectKey).toBe("kj-test-project");
+  });
+
+  it("includes openIssuesTotal in result", async () => {
+    getOpenIssues.mockResolvedValue({ total: 5, issues: sampleIssues, raw: {} });
+
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.result.openIssuesTotal).toBe(5);
+  });
+
+  it("works without emitter", async () => {
+    const role = new SonarRole({ config, logger });
+    await role.init({});
+    const output = await role.run();
+
+    expect(output.ok).toBe(true);
+  });
+
+  it("does not require createAgentFn (non-AI role)", () => {
+    const role = new SonarRole({ config, logger });
+    expect(role).toBeDefined();
+    expect(role.name).toBe("sonar");
+  });
+});

--- a/tests/tester-role.test.js
+++ b/tests/tester-role.test.js
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { ROLE_EVENTS } from "../src/roles/base-role.js";
+
+const mockRunTask = vi.fn();
+const mockCreateAgent = vi.fn(() => ({ runTask: mockRunTask }));
+
+const { TesterRole } = await import("../src/roles/tester-role.js");
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+const samplePassOutput = JSON.stringify({
+  tests_pass: true,
+  coverage: { overall: 85, services: 82, utilities: 91 },
+  missing_scenarios: ["Error handling for network timeout not tested"],
+  quality_issues: [],
+  verdict: "pass"
+});
+
+const sampleFailOutput = JSON.stringify({
+  tests_pass: false,
+  coverage: { overall: 60, services: 55, utilities: 70 },
+  missing_scenarios: ["Auth module has no tests"],
+  quality_issues: ["Tests use shared mutable state in describe block"],
+  verdict: "fail"
+});
+
+describe("TesterRole", () => {
+  let emitter;
+  const config = {
+    roles: { tester: { provider: "claude", model: null }, coder: { provider: "claude" } },
+    development: {}
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    emitter = new EventEmitter();
+
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: samplePassOutput,
+      error: "",
+      exitCode: 0
+    });
+  });
+
+  it("extends BaseRole and has name 'tester'", () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    expect(role.name).toBe("tester");
+  });
+
+  it("requires init() before run()", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await expect(role.run({ task: "test" })).rejects.toThrow("init() must be called before run()");
+  });
+
+  it("creates agent and calls runTask on execute", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run({ task: "Evaluate tests for auth module" });
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", config, logger);
+    expect(mockRunTask).toHaveBeenCalled();
+    expect(output.ok).toBe(true);
+  });
+
+  it("passes task and diff in prompt to agent", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Evaluate auth tests", diff: "diff --git a/src/auth.js" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Evaluate auth tests");
+    expect(callArgs.prompt).toContain("diff --git a/src/auth.js");
+    expect(callArgs.role).toBe("tester");
+  });
+
+  it("accepts string input as task shorthand", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check test quality");
+
+    expect(output.ok).toBe(true);
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Check test quality");
+  });
+
+  it("uses task from context when not provided", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({ task: "Context task" });
+    await role.run({});
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("Context task");
+  });
+
+  it("parses JSON output with passing verdict", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.tests_pass).toBe(true);
+    expect(output.result.verdict).toBe("pass");
+    expect(output.result.coverage).toEqual({ overall: 85, services: 82, utilities: 91 });
+    expect(output.result.missing_scenarios).toHaveLength(1);
+    expect(output.result.quality_issues).toHaveLength(0);
+  });
+
+  it("returns ok=false when verdict is fail", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: sampleFailOutput,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.ok).toBe(false);
+    expect(output.result.tests_pass).toBe(false);
+    expect(output.result.verdict).toBe("fail");
+    expect(output.result.coverage.overall).toBe(60);
+    expect(output.result.quality_issues).toHaveLength(1);
+  });
+
+  it("returns ok=false when agent fails", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: false,
+      output: "",
+      error: "Agent timed out",
+      exitCode: 1
+    });
+
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.ok).toBe(false);
+    expect(output.result.error).toContain("Agent timed out");
+    expect(output.summary).toContain("failed");
+  });
+
+  it("handles JSON embedded in markdown code blocks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: `Here are the results:\n\`\`\`json\n${samplePassOutput}\n\`\`\``,
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.ok).toBe(true);
+    expect(output.result.tests_pass).toBe(true);
+  });
+
+  it("returns ok=false with parse error when JSON is invalid", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: "No JSON here, just plain text about tests.",
+      error: "",
+      exitCode: 0
+    });
+
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.ok).toBe(false);
+    expect(output.summary).toContain("parse error");
+  });
+
+  it("includes sonar issues in prompt when provided", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({
+      task: "Check tests",
+      sonarIssues: "MAJOR: Test file has code smell on line 15"
+    });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.prompt).toContain("MAJOR: Test file has code smell on line 15");
+  });
+
+  it("includes provider in result", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Check tests");
+
+    expect(output.result.provider).toBe("claude");
+  });
+
+  it("emits role:start and role:end events", async () => {
+    const events = [];
+    emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));
+    emitter.on(ROLE_EVENTS.END, (e) => events.push({ type: "end", ...e }));
+
+    const role = new TesterRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({ iteration: 1 });
+    await role.run("Check tests");
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("start");
+    expect(events[0].role).toBe("tester");
+    expect(events[1].type).toBe("end");
+  });
+
+  it("emits role:error when agent throws", async () => {
+    mockRunTask.mockRejectedValue(new Error("Binary not found"));
+
+    const events = [];
+    emitter.on(ROLE_EVENTS.ERROR, (e) => events.push(e));
+
+    const role = new TesterRole({ config, logger, emitter, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await expect(role.run("Check tests")).rejects.toThrow("Binary not found");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error).toContain("Binary not found");
+  });
+
+  it("report() returns structured tester report", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Check tests");
+
+    const report = role.report();
+    expect(report.role).toBe("tester");
+    expect(report.ok).toBe(true);
+    expect(report.summary).toBeTruthy();
+    expect(report.timestamp).toBeTruthy();
+  });
+
+  it("resolves provider from config.roles.tester.provider", async () => {
+    const customConfig = {
+      roles: { tester: { provider: "codex" } },
+      development: {}
+    };
+
+    const role = new TesterRole({ config: customConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("codex", customConfig, logger);
+  });
+
+  it("falls back to coder provider when tester provider is null", async () => {
+    const fallbackConfig = {
+      roles: { tester: { provider: null }, coder: { provider: "gemini" } },
+      development: {}
+    };
+
+    const role = new TesterRole({ config: fallbackConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("gemini", fallbackConfig, logger);
+  });
+
+  it("defaults to 'claude' when no provider configured", async () => {
+    const minConfig = { roles: {}, development: {} };
+
+    const role = new TesterRole({ config: minConfig, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Task");
+
+    expect(mockCreateAgent).toHaveBeenCalledWith("claude", minConfig, logger);
+  });
+
+  it("generates meaningful summary from parsed result", async () => {
+    const role = new TesterRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.summary).toContain("pass");
+    expect(output.summary).toContain("85%");
+  });
+});


### PR DESCRIPTION
## Summary
- Refactoriza el orquestador para implementar el pipeline completo del ADR-001
- Pipeline: Researcher → Planner → [Coder ↔ Sonar ↔ Reviewer] → Tester → Security → Commiter
- Solomon como árbitro cuando se agotan iteraciones en cualquier sub-loop (sonar, reviewer, tester, security)
- Solomon puede: aprobar, aprobar con condiciones, escalar al humano, o crear subtareas
- Todos los roles (CoderRole, SonarRole, ResearcherRole, TesterRole, SecurityRole, SolomonRole) integrados
- Config expandida: pipeline flags para researcher/tester/security/solomon, CLI overrides, iteration limits configurables
- Contexto compartido: research findings se pasan al planner, feedback acumulado entre roles
- Backward compatible: todos los tests existentes del orchestrator siguen pasando sin cambios

## Cambios principales
- `src/orchestrator.js`: Añade Researcher (pre-planner), Tester y Security (post-loop), Solomon (arbitraje en todos los sub-loops)
- `src/config.js`: Nuevos roles, pipeline flags, session limits (max_tester_retries, max_security_retries)
- `src/roles/`: 6 nuevos roles (coder, sonar, researcher, tester, security, solomon) + index actualizado
- `templates/roles/solomon.md`: Especificación completa con criterios de bloqueo y jerarquía de decisión

## Test plan
- [x] 582 tests passing (64 archivos)
- [x] Tests existentes del orchestrator no modificados y pasando (events, repeat-detection, subloop-limits, dry-run)
- [x] Tests unitarios de cada rol individual (coder 21, sonar 16, researcher 20, tester 20, security 21, solomon 26)
- [x] Verifica pipeline sequence con researcher y planner habilitados
- [x] Verifica dry-run con info de nuevos roles
- [x] Verifica escalado a Solomon en sub-loops de sonar, reviewer, tester y security