### PR TITLE
feat(display): runner UI for all pipeline roles

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -255,6 +255,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     })
   );
 
+  // Accumulate stage results for final summary
+  const stageResults = {};
+
   // --- Researcher (pre-planning) ---
   let researchContext = null;
   if (researcherEnabled) {
@@ -280,6 +283,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       })
     );
 
+    stageResults.researcher = { ok: researchOutput.ok, summary: researchOutput.summary || null };
     if (researchOutput.ok) {
       researchContext = researchOutput.result;
     }
@@ -322,6 +326,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     if (plannerResult.output?.trim()) {
       plannedTask = `${task}\n\nExecution plan:\n${plannerResult.output.trim()}`;
     }
+    stageResults.planner = { ok: true };
     emitProgress(
       emitter,
       makeEvent("planner:end", { ...eventBase, stage: "planner" }, {
@@ -634,6 +639,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
       // Sonar passed — reset retry counter
       session.sonar_retry_count = 0;
+      stageResults.sonar = { gateStatus: gate.status, openIssues: issues.total };
     }
 
     // --- Reviewer ---
@@ -821,6 +827,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           }
         } else {
           session.tester_retry_count = 0;
+          stageResults.tester = { ok: true, summary: testerOutput.summary || "All tests passed" };
         }
       }
 
@@ -880,6 +887,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           }
         } else {
           session.security_retry_count = 0;
+          stageResults.security = { ok: true, summary: securityOutput.summary || "No vulnerabilities found" };
         }
       }
 
@@ -890,7 +898,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         emitter,
         makeEvent("session:end", { ...eventBase, stage: "done" }, {
           message: "Session approved",
-          detail: { approved: true, git: gitResult }
+          detail: { approved: true, iterations: i, stages: stageResults, git: gitResult }
         })
       );
       return { approved: true, sessionId: session.id, review, git: gitResult };
@@ -946,7 +954,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     makeEvent("session:end", { ...eventBase, stage: "done" }, {
       status: "fail",
       message: "Max iterations reached",
-      detail: { approved: false, reason: "max_iterations" }
+      detail: { approved: false, reason: "max_iterations", iterations: config.max_iterations, stages: stageResults }
     })
   );
   return { approved: false, sessionId: session.id, reason: "max_iterations" };

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -15,6 +15,8 @@ const ICONS = {
   "session:start": "\u25b6",
   "planner:start": "\ud83e\udde0",
   "planner:end": "\ud83e\udde0",
+  "researcher:start": "\ud83d\udd2c",
+  "researcher:end": "\ud83d\udd2c",
   "iteration:start": "\u25b6",
   "coder:start": "\ud83d\udd28",
   "coder:end": "\ud83d\udd28",
@@ -25,6 +27,13 @@ const ICONS = {
   "sonar:end": "\ud83d\udd0d",
   "reviewer:start": "\ud83d\udc41\ufe0f",
   "reviewer:end": "\ud83d\udc41\ufe0f",
+  "tester:start": "\ud83e\uddea",
+  "tester:end": "\ud83e\uddea",
+  "security:start": "\ud83d\udd12",
+  "security:end": "\ud83d\udd12",
+  "solomon:start": "\u2696\ufe0f",
+  "solomon:end": "\u2696\ufe0f",
+  "solomon:escalate": "\u26a0\ufe0f",
   "iteration:end": "\u23f1\ufe0f",
   "session:end": "\ud83c\udfc1",
   question: "\u2753"
@@ -58,6 +67,18 @@ export function printHeader({ task, config }) {
   console.log(
     `${ANSI.bold}Max iterations:${ANSI.reset} ${config.max_iterations} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Timeout:${ANSI.reset} ${config.session.max_total_minutes}min`
   );
+
+  const pipeline = config.pipeline || {};
+  const activeRoles = [];
+  if (pipeline.planner?.enabled) activeRoles.push(`Planner (${config.roles?.planner?.provider || "?"})`);
+  if (pipeline.researcher?.enabled) activeRoles.push(`Researcher (${config.roles?.researcher?.provider || "?"})`);
+  if (pipeline.tester?.enabled) activeRoles.push("Tester");
+  if (pipeline.security?.enabled) activeRoles.push("Security");
+  if (pipeline.solomon?.enabled) activeRoles.push(`Solomon (${config.roles?.solomon?.provider || "?"})`);
+  if (activeRoles.length > 0) {
+    console.log(`${ANSI.bold}Pipeline:${ANSI.reset} ${activeRoles.join(` ${ANSI.dim}|${ANSI.reset} `)}`);
+  }
+
   console.log(BAR);
   console.log();
 }
@@ -109,6 +130,14 @@ export function printEvent(event) {
       break;
     }
 
+    case "researcher:start":
+      console.log(`  \u251c\u2500 ${icon} Researcher (${event.detail?.researcher || "?"}) investigating...`);
+      break;
+
+    case "researcher:end":
+      console.log(`  \u251c\u2500 ${status} Researcher completed  ${elapsed}`);
+      break;
+
     case "sonar:start":
       console.log(`  \u251c\u2500 ${icon} SonarQube scanning...`);
       break;
@@ -140,6 +169,74 @@ export function printEvent(event) {
       break;
     }
 
+    case "tester:start":
+      console.log(`  \u251c\u2500 ${icon} Tester evaluating...`);
+      break;
+
+    case "tester:end": {
+      const testerOk = event.detail?.ok !== false;
+      if (testerOk) {
+        console.log(`  \u251c\u2500 ${ANSI.green}\u2705 Tester: passed${ANSI.reset}  ${elapsed}`);
+      } else {
+        const testerSummary = event.detail?.summary || "issues found";
+        console.log(`  \u251c\u2500 ${ANSI.red}\u274c Tester: ${testerSummary}${ANSI.reset}  ${elapsed}`);
+      }
+      break;
+    }
+
+    case "security:start":
+      console.log(`  \u251c\u2500 ${icon} Security auditing...`);
+      break;
+
+    case "security:end": {
+      const secOk = event.detail?.ok !== false;
+      if (secOk) {
+        console.log(`  \u251c\u2500 ${ANSI.green}\u2705 Security: passed${ANSI.reset}  ${elapsed}`);
+      } else {
+        const secSummary = event.detail?.summary || "vulnerabilities found";
+        console.log(`  \u251c\u2500 ${ANSI.red}\u274c Security: ${secSummary}${ANSI.reset}  ${elapsed}`);
+      }
+      break;
+    }
+
+    case "solomon:start":
+      console.log(`  \u251c\u2500 ${icon} Solomon arbitrating ${event.detail?.conflictStage || "?"} conflict...`);
+      break;
+
+    case "solomon:end": {
+      const ruling = event.detail?.ruling || "unknown";
+      const rulingUpper = ruling.toUpperCase().replace(/_/g, " ");
+      if (ruling === "approve") {
+        const dismissedCount = event.detail?.dismissed?.length || 0;
+        console.log(`  \u251c\u2500 ${ANSI.green}\u2696\ufe0f Solomon: APPROVE${dismissedCount > 0 ? ` (${dismissedCount} dismissed)` : ""}${ANSI.reset}  ${elapsed}`);
+      } else if (ruling === "approve_with_conditions") {
+        const condCount = event.detail?.conditions?.length || 0;
+        console.log(`  \u251c\u2500 ${ANSI.yellow}\u2696\ufe0f Solomon: ${condCount} condition${condCount !== 1 ? "s" : ""}${ANSI.reset}  ${elapsed}`);
+        if (event.detail?.conditions) {
+          for (const cond of event.detail.conditions) {
+            console.log(`  \u2502   ${ANSI.dim}${cond}${ANSI.reset}`);
+          }
+        }
+      } else if (ruling === "escalate_human") {
+        const reason = event.detail?.escalate_reason || "unknown reason";
+        console.log(`  \u251c\u2500 ${ANSI.red}\u2696\ufe0f Solomon: ESCALATE \u2014 ${reason}${ANSI.reset}  ${elapsed}`);
+      } else if (ruling === "create_subtask") {
+        const subtaskTitle = event.detail?.subtask?.title || "untitled";
+        console.log(`  \u251c\u2500 ${ANSI.magenta}\u2696\ufe0f Solomon: SUBTASK \u2014 ${subtaskTitle}${ANSI.reset}  ${elapsed}`);
+      } else {
+        console.log(`  \u251c\u2500 \u2696\ufe0f Solomon: ${rulingUpper}  ${elapsed}`);
+      }
+      break;
+    }
+
+    case "solomon:escalate": {
+      const subloop = event.detail?.subloop || "?";
+      const retryCount = event.detail?.retryCount || 0;
+      const limit = event.detail?.limit || "?";
+      console.log(`  \u251c\u2500 ${icon} ${subloop} sub-loop limit reached (${retryCount}/${limit}), invoking Solomon...`);
+      break;
+    }
+
     case "iteration:end":
       console.log(`  \u2514\u2500 ${icon} Duration: ${formatElapsed(event.detail?.duration)}  ${elapsed}`);
       break;
@@ -150,6 +247,33 @@ export function printEvent(event) {
         ? `${ANSI.bold}${ANSI.green}APPROVED${ANSI.reset}`
         : `${ANSI.bold}${ANSI.red}${event.detail?.reason || "FAILED"}${ANSI.reset}`;
       console.log(`${icon} Result: ${resultLabel}  ${elapsed}`);
+
+      const stages = event.detail?.stages;
+      if (stages) {
+        if (stages.researcher?.summary) {
+          console.log(`  ${ANSI.dim}\ud83d\udd2c Research: ${stages.researcher.summary}${ANSI.reset}`);
+        }
+        if (stages.tester?.summary) {
+          console.log(`  ${ANSI.dim}\ud83e\uddea Tester: ${stages.tester.summary}${ANSI.reset}`);
+        }
+        if (stages.security?.summary) {
+          console.log(`  ${ANSI.dim}\ud83d\udd12 Security: ${stages.security.summary}${ANSI.reset}`);
+        }
+        if (stages.sonar) {
+          const gateLabel = stages.sonar.gateStatus === "OK" ? ANSI.green : ANSI.red;
+          console.log(`  ${ANSI.dim}\ud83d\udd0d Sonar: ${gateLabel}${stages.sonar.gateStatus}${ANSI.reset}${ANSI.dim} (${stages.sonar.openIssues ?? 0} issues)${ANSI.reset}`);
+        }
+      }
+
+      const git = event.detail?.git;
+      if (git?.branch) {
+        const parts = [`branch: ${git.branch}`];
+        if (git.committed) parts.push("committed");
+        if (git.pushed) parts.push("pushed");
+        if (git.pr) parts.push(`PR: ${git.pr}`);
+        console.log(`  ${ANSI.dim}\ud83d\udcce Git: ${parts.join(", ")}${ANSI.reset}`);
+      }
+
       console.log(`${ANSI.dim}Session: ${event.sessionId}${ANSI.reset}`);
       break;
     }

--- a/tests/utils-display.test.js
+++ b/tests/utils-display.test.js
@@ -120,5 +120,251 @@ describe("utils/display", () => {
       const output = spy.mock.calls.map((c) => c[0]).join("\n");
       expect(output).toContain("Something happened");
     });
+
+    // --- Researcher events ---
+
+    it("prints researcher start", () => {
+      printEvent({ type: "researcher:start", detail: { researcher: "claude" } });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Researcher");
+      expect(output).toContain("claude");
+    });
+
+    it("prints researcher end with status ok", () => {
+      printEvent({ type: "researcher:end", status: "ok", elapsed: 8000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Researcher");
+      expect(output).toContain("completed");
+    });
+
+    // --- Tester events ---
+
+    it("prints tester start", () => {
+      printEvent({ type: "tester:start", detail: {} });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Tester");
+    });
+
+    it("prints tester end passed", () => {
+      printEvent({ type: "tester:end", status: "ok", detail: { ok: true }, elapsed: 5000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Tester");
+      expect(output).toContain("passed");
+    });
+
+    it("prints tester end failed with summary", () => {
+      printEvent({ type: "tester:end", status: "fail", detail: { ok: false, summary: "3 tests failing" }, elapsed: 5000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Tester");
+      expect(output).toContain("3 tests failing");
+    });
+
+    // --- Security events ---
+
+    it("prints security start", () => {
+      printEvent({ type: "security:start", detail: {} });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Security");
+    });
+
+    it("prints security end passed", () => {
+      printEvent({ type: "security:end", status: "ok", detail: { ok: true }, elapsed: 4000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Security");
+      expect(output).toContain("passed");
+    });
+
+    it("prints security end failed", () => {
+      printEvent({ type: "security:end", status: "fail", detail: { ok: false, summary: "SQL injection found" }, elapsed: 4000 });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Security");
+      expect(output).toContain("SQL injection found");
+    });
+
+    // --- Solomon events ---
+
+    it("prints solomon start with conflict stage", () => {
+      printEvent({ type: "solomon:start", detail: { conflictStage: "reviewer" } });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Solomon");
+      expect(output).toContain("reviewer");
+    });
+
+    it("prints solomon end with approve ruling", () => {
+      printEvent({
+        type: "solomon:end",
+        detail: {
+          ruling: "approve",
+          dismissed: ["Style issue — preference"],
+          conditions: []
+        },
+        elapsed: 3000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Solomon");
+      expect(output).toContain("APPROVE");
+      expect(output).toContain("1 dismissed");
+    });
+
+    it("prints solomon end with approve_with_conditions ruling", () => {
+      printEvent({
+        type: "solomon:end",
+        detail: {
+          ruling: "approve_with_conditions",
+          conditions: ["Fix null check at auth.js:42"],
+          dismissed: []
+        },
+        elapsed: 3000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Solomon");
+      expect(output).toContain("1 condition");
+      expect(output).toContain("Fix null check at auth.js:42");
+    });
+
+    it("prints solomon end with escalate_human ruling", () => {
+      printEvent({
+        type: "solomon:end",
+        detail: {
+          ruling: "escalate_human",
+          escalate_reason: "Architecture decision beyond scope"
+        },
+        elapsed: 3000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Solomon");
+      expect(output).toContain("ESCALATE");
+      expect(output).toContain("Architecture decision beyond scope");
+    });
+
+    it("prints solomon end with create_subtask ruling", () => {
+      printEvent({
+        type: "solomon:end",
+        detail: {
+          ruling: "create_subtask",
+          subtask: { title: "Extract shared validation", description: "Create shared module" }
+        },
+        elapsed: 3000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Solomon");
+      expect(output).toContain("SUBTASK");
+      expect(output).toContain("Extract shared validation");
+    });
+
+    it("prints solomon escalate event (sub-loop limit)", () => {
+      printEvent({
+        type: "solomon:escalate",
+        detail: { subloop: "sonar", retryCount: 3, limit: 3, gateStatus: "ERROR" }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("sonar");
+      expect(output).toContain("3/3");
+    });
+
+    // --- Enhanced session:end with full summary ---
+
+    it("prints session end with comprehensive summary when approved", () => {
+      printEvent({
+        type: "session:end",
+        detail: {
+          approved: true,
+          iterations: 2,
+          stages: {
+            researcher: { ok: true, summary: "Found 3 relevant patterns" },
+            planner: { ok: true },
+            sonar: { gateStatus: "OK", openIssues: 0 },
+            tester: { ok: true, summary: "All tests passed" },
+            security: { ok: true, summary: "No vulnerabilities found" }
+          },
+          git: { committed: true, branch: "feat/auth-fix", pushed: true }
+        },
+        elapsed: 120000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("APPROVED");
+      expect(output).toContain("02:00");
+    });
+
+    it("prints session end with pipeline summary lines", () => {
+      printEvent({
+        type: "session:end",
+        detail: {
+          approved: true,
+          iterations: 3,
+          stages: {
+            researcher: { ok: true, summary: "Analyzed 5 files" },
+            tester: { ok: true, summary: "12 tests passed" },
+            security: { ok: true, summary: "Clean" }
+          },
+          git: { committed: true, branch: "feat/task-42" }
+        },
+        elapsed: 180000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("APPROVED");
+      expect(output).toContain("Analyzed 5 files");
+      expect(output).toContain("12 tests passed");
+    });
+
+    it("prints session end failed with reason", () => {
+      printEvent({
+        type: "session:end",
+        detail: { approved: false, reason: "max_iterations", iterations: 5 },
+        elapsed: 300000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("max_iterations");
+    });
+
+    // --- Enhanced header ---
+
+    it("printHeader shows active pipeline roles", () => {
+      printHeader({
+        task: "Add login feature",
+        config: {
+          coder: "codex",
+          reviewer: "claude",
+          roles: {
+            coder: { provider: "codex" },
+            reviewer: { provider: "claude" },
+            planner: { provider: "claude" },
+            solomon: { provider: "gemini" }
+          },
+          pipeline: {
+            planner: { enabled: true },
+            researcher: { enabled: false },
+            tester: { enabled: true },
+            security: { enabled: true },
+            solomon: { enabled: true }
+          },
+          max_iterations: 5,
+          session: { max_total_minutes: 120 }
+        }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Planner");
+      expect(output).toContain("Tester");
+      expect(output).toContain("Security");
+      expect(output).toContain("Solomon");
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `printEvent()` handlers for `researcher`, `tester`, `security`, and `solomon` events (start/end/escalate)
- Solomon display shows ruling type (approve, conditions, escalate, subtask) with details
- Enhanced `session:end` with per-stage summaries (research findings, tester results, security audit, sonar gate, git info)
- `printHeader()` now shows active pipeline roles (Planner, Researcher, Tester, Security, Solomon)
- Orchestrator accumulates `stageResults` and passes them to final `session:end` event
- 16 new tests (32 total in display suite), 600 tests passing across 64 files

## Test plan
- [x] All 32 display tests pass including 16 new event type tests
- [x] Full suite: 600 tests, 64 files, all green
- [ ] Manual verification with `kj run` showing new event formatting