### PR TITLE
refactor(orchestrator): use SonarRole as pipeline participant

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -14,10 +14,8 @@ import { validateReviewResult } from "./review/schema.js";
 import { evaluateTddPolicy } from "./review/tdd-policy.js";
 import { buildCoderPrompt } from "./prompts/coder.js";
 import { buildReviewerPrompt } from "./prompts/reviewer.js";
-import { getOpenIssues, getQualityGateStatus } from "./sonar/api.js";
-import { runSonarScan } from "./sonar/scanner.js";
-import { shouldBlockByProfile, summarizeIssues } from "./sonar/enforcer.js";
 import { resolveRole } from "./config.js";
+import { SonarRole } from "./roles/sonar-role.js";
 import { RepeatDetector } from "./repeat-detector.js";
 import { emitProgress, makeEvent } from "./utils/events.js";
 import {
@@ -528,7 +526,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       continue;
     }
 
-    // --- SonarQube ---
+    // --- SonarQube (via SonarRole) ---
     if (config.sonarqube.enabled) {
       logger.setContext({ iteration: i, stage: "sonar" });
       emitProgress(
@@ -538,46 +536,43 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         })
       );
 
-      const scan = await runSonarScan(config);
-      if (!scan.ok) {
+      const sonarRole = new SonarRole({ config, logger, emitter });
+      await sonarRole.init({ iteration: i });
+      const sonarOutput = await sonarRole.run();
+      const sonarResult = sonarOutput.result;
+
+      if (!sonarResult.gateStatus && sonarResult.error) {
         await markSessionStatus(session, "failed");
         emitProgress(
           emitter,
           makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
             status: "fail",
-            message: `Sonar scan failed: ${scan.stderr || scan.stdout}`
+            message: `Sonar scan failed: ${sonarResult.error}`
           })
         );
-        throw new Error(`Sonar scan failed: ${scan.stderr || scan.stdout}`);
+        throw new Error(`Sonar scan failed: ${sonarResult.error}`);
       }
 
-      const gate = await getQualityGateStatus(config, scan.projectKey);
-      const issues = await getOpenIssues(config, scan.projectKey);
-      session.last_sonar_summary = `QualityGate=${gate.status}; Open issues=${issues.total}; ${summarizeIssues(issues.issues)}`;
+      session.last_sonar_summary = sonarOutput.summary;
       await addCheckpoint(session, {
         stage: "sonar",
         iteration: i,
-        project_key: scan.projectKey,
-        quality_gate: gate.status,
-        open_issues: issues.total
-      });
-
-      const sonarBlocking = shouldBlockByProfile({
-        gateStatus: gate.status,
-        profile: config.sonarqube.enforcement_profile
+        project_key: sonarResult.projectKey,
+        quality_gate: sonarResult.gateStatus,
+        open_issues: sonarResult.openIssuesTotal
       });
 
       emitProgress(
         emitter,
         makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
-          status: sonarBlocking ? "fail" : "ok",
-          message: `Quality gate: ${gate.status}`,
-          detail: { projectKey: scan.projectKey, gateStatus: gate.status, openIssues: issues.total }
+          status: sonarResult.blocking ? "fail" : "ok",
+          message: `Quality gate: ${sonarResult.gateStatus}`,
+          detail: { projectKey: sonarResult.projectKey, gateStatus: sonarResult.gateStatus, openIssues: sonarResult.openIssuesTotal }
         })
       );
 
-      if (sonarBlocking) {
-        repeatDetector.addIteration(issues.issues, []);
+      if (sonarResult.blocking) {
+        repeatDetector.addIteration(sonarResult.issues, []);
         const repeatState = repeatDetector.isStalled();
         if (repeatState.stalled) {
           const repeatCounts = repeatDetector.getRepeatCounts();
@@ -595,7 +590,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           return { approved: false, sessionId: session.id, reason: "stalled" };
         }
 
-        session.last_reviewer_feedback = `Sonar gate blocking (${gate.status}). Resolve critical findings first.`;
+        session.last_reviewer_feedback = `Sonar gate blocking (${sonarResult.gateStatus}). Resolve critical findings first.`;
         session.sonar_retry_count = (session.sonar_retry_count || 0) + 1;
         await saveSession(session);
         const maxSonarRetries = config.session.max_sonar_retries ?? config.session.fail_fast_repeats;
@@ -604,7 +599,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
             emitter,
             makeEvent("solomon:escalate", { ...eventBase, stage: "sonar" }, {
               message: `Sonar sub-loop limit reached (${session.sonar_retry_count}/${maxSonarRetries})`,
-              detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus: gate.status }
+              detail: { subloop: "sonar", retryCount: session.sonar_retry_count, limit: maxSonarRetries, gateStatus: sonarResult.gateStatus }
             })
           );
 
@@ -639,7 +634,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
       // Sonar passed — reset retry counter
       session.sonar_retry_count = 0;
-      stageResults.sonar = { gateStatus: gate.status, openIssues: issues.total };
+      stageResults.sonar = { gateStatus: sonarResult.gateStatus, openIssues: sonarResult.openIssuesTotal };
     }
 
     // --- Reviewer ---


### PR DESCRIPTION
## Summary
- Replace 5 direct sonar module imports (`runSonarScan`, `getQualityGateStatus`, `getOpenIssues`, `shouldBlockByProfile`, `summarizeIssues`) with single `SonarRole` import
- Orchestrator now uses `SonarRole.init()` → `SonarRole.run()` following the same lifecycle as all other roles
- SonarRole internally calls the same underlying modules, so all existing orchestrator test mocks continue to work
- Net result: -27 lines, +22 lines (cleaner, consistent role-based pipeline)

## Test plan
- [x] All 600 tests pass across 64 files (including all orchestrator sonar tests)
- [x] sonar-role.test.js (15 tests) validates SonarRole behavior directly
- [x] orchestrator-events, subloop-limits, repeat-detection tests verify integration