### PR TITLE
feat(planning-game): integrate Planning Game MCP in orchestrator

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -70,6 +70,8 @@ program
   .option("--methodology <name>")
   .option("--no-auto-rebase")
   .option("--no-sonar")
+  .option("--pg-task <cardId>", "Planning Game card ID (e.g., KJC-TSK-0042)")
+  .option("--pg-project <projectId>", "Planning Game project ID")
   .option("--dry-run", "Show what would be executed without running anything")
   .option("--json", "Output JSON only (no styled display)")
   .action(async (task, flags) => {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,6 +4,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { createActivityLog } from "../activity-log.js";
 import { printHeader, printEvent } from "../utils/display.js";
 import { resolveRole } from "../config.js";
+import { parseCardId, buildTaskFromCard, buildCompletionUpdates } from "../planning-game/adapter.js";
 
 export async function runCommandHandler({ task, config, logger, flags }) {
   const requiredProviders = [
@@ -15,13 +16,31 @@ export async function runCommandHandler({ task, config, logger, flags }) {
   if (config.pipeline?.refactorer?.enabled) requiredProviders.push(resolveRole(config, "refactorer").provider);
   await assertAgentsAvailable(requiredProviders);
 
+  // --- Planning Game: resolve card context ---
+  const pgCardId = flags?.pgTask || parseCardId(task);
+  const pgProject = flags?.pgProject || config.planning_game?.project_id || null;
+  let pgCard = null;
+  let enrichedTask = task;
+
+  if (pgCardId && pgProject && config.planning_game?.enabled !== false) {
+    try {
+      const { fetchCard, updateCard } = await import("../planning-game/client.js");
+      pgCard = await fetchCard({ projectId: pgProject, cardId: pgCardId });
+      if (pgCard) {
+        enrichedTask = buildTaskFromCard(pgCard);
+        logger.info(`Planning Game: loaded card ${pgCardId} from project ${pgProject}`);
+      }
+    } catch (err) {
+      logger.warn(`Planning Game: could not load card ${pgCardId}: ${err.message}`);
+    }
+  }
+
   const jsonMode = flags?.json;
 
   const emitter = new EventEmitter();
   let activityLog = null;
 
   emitter.on("progress", (event) => {
-    // Initialize activity log once we have a sessionId
     if (!activityLog && event.sessionId) {
       activityLog = createActivityLog(event.sessionId);
       logger.onLog((entry) => activityLog.write(entry));
@@ -37,10 +56,28 @@ export async function runCommandHandler({ task, config, logger, flags }) {
   });
 
   if (!jsonMode) {
-    printHeader({ task, config });
+    printHeader({ task: enrichedTask, config });
   }
 
-  const result = await runFlow({ task, config, logger, flags, emitter });
+  const startDate = new Date().toISOString();
+  const result = await runFlow({ task: enrichedTask, config, logger, flags, emitter });
+
+  // --- Planning Game: update card on completion ---
+  if (pgCard && pgProject && result?.approved) {
+    try {
+      const { updateCard } = await import("../planning-game/client.js");
+      const updates = buildCompletionUpdates({
+        approved: true,
+        commits: result.git?.commits || [],
+        startDate,
+        codeveloper: config.planning_game?.codeveloper || null
+      });
+      await updateCard({ projectId: pgProject, cardId: pgCardId, firebaseId: pgCard.firebaseId, updates });
+      logger.info(`Planning Game: updated ${pgCardId} to "${updates.status}"`);
+    } catch (err) {
+      logger.warn(`Planning Game: could not update card ${pgCardId}: ${err.message}`);
+    }
+  }
 
   if (jsonMode) {
     console.log(JSON.stringify(result, null, 2));

--- a/src/config.js
+++ b/src/config.js
@@ -79,6 +79,7 @@ const DEFAULTS = {
       disabled_rules: ["javascript:S1116", "javascript:S3776"]
     }
   },
+  planning_game: { enabled: false, project_id: null, codeveloper: null },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
   session: {
@@ -188,6 +189,9 @@ export function applyRunOverrides(config, flags) {
     out.development.require_test_changes = methodology === "tdd";
   }
   if (flags.noSonar || flags.sonar === false) out.sonarqube.enabled = false;
+  out.planning_game = out.planning_game || {};
+  if (flags.pgTask) out.planning_game.enabled = true;
+  if (flags.pgProject) out.planning_game.project_id = flags.pgProject;
   return out;
 }
 

--- a/src/mcp/run-kj.js
+++ b/src/mcp/run-kj.js
@@ -43,6 +43,8 @@ export async function runKjCommand({ command, commandArgs = [], options = {}, en
   normalizeBoolFlag(options.autoPr, "--auto-pr", args);
   if (options.autoRebase === false) args.push("--no-auto-rebase");
   normalizeBoolFlag(options.noSonar, "--no-sonar", args);
+  addOptionalValue(args, "--pg-task", options.pgTask);
+  addOptionalValue(args, "--pg-project", options.pgProject);
 
   const runEnv = {
     ...process.env,

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -52,7 +52,9 @@ export const tools = [
       type: "object",
       required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description for the coder" },
+        task: { type: "string", description: "Task description for the coder (can include a Planning Game card ID like KJC-TSK-0042)" },
+        pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as task context and updates card status on completion." },
+        pgProject: { type: "string", description: "Planning Game project ID (e.g., 'Karajan Code'). Required when pgTask is used." },
         planner: { type: "string" },
         coder: { type: "string" },
         reviewer: { type: "string" },

--- a/src/planning-game/adapter.js
+++ b/src/planning-game/adapter.js
@@ -1,0 +1,82 @@
+/**
+ * Planning Game MCP adapter.
+ * Handles card ID detection, task enrichment, and completion updates.
+ */
+
+const CARD_ID_PATTERN = /[A-Z0-9]{2,5}-(?:TSK|BUG|PCS|PRP|SPR|QA)-\d{4}/;
+
+export function parseCardId(text) {
+  if (!text) return null;
+  const match = String(text).match(CARD_ID_PATTERN);
+  return match ? match[0] : null;
+}
+
+export function buildTaskFromCard(card) {
+  const parts = [`## ${card.cardId}: ${card.title}`];
+
+  if (card.descriptionStructured?.length) {
+    parts.push("", "### User Story");
+    for (const s of card.descriptionStructured) {
+      parts.push(`- **Como** ${s.role}`);
+      parts.push(`  **Quiero** ${s.goal}`);
+      parts.push(`  **Para** ${s.benefit}`);
+    }
+  } else if (card.description) {
+    parts.push("", "### Description", card.description);
+  }
+
+  if (card.acceptanceCriteriaStructured?.length) {
+    parts.push("", "### Acceptance Criteria");
+    for (const ac of card.acceptanceCriteriaStructured) {
+      if (ac.given && ac.when && ac.then) {
+        parts.push(`- **Given** ${ac.given}`);
+        parts.push(`  **When** ${ac.when}`);
+        parts.push(`  **Then** ${ac.then}`);
+      } else if (ac.raw) {
+        parts.push(`- ${ac.raw}`);
+      }
+    }
+  } else if (card.acceptanceCriteria) {
+    parts.push("", "### Acceptance Criteria", card.acceptanceCriteria);
+  }
+
+  if (card.implementationPlan) {
+    const plan = card.implementationPlan;
+    parts.push("", "### Implementation Plan");
+    if (plan.approach) parts.push(`**Approach:** ${plan.approach}`);
+    if (plan.steps?.length) {
+      parts.push("**Steps:**");
+      for (const step of plan.steps) {
+        parts.push(`1. ${step.description}`);
+      }
+    }
+  }
+
+  return parts.join("\n");
+}
+
+export function buildCommitsPayload(gitLog) {
+  if (!gitLog || !gitLog.length) return [];
+  return gitLog.map((entry) => ({
+    hash: entry.hash,
+    message: entry.message,
+    date: entry.date,
+    author: entry.author
+  }));
+}
+
+export function buildCompletionUpdates({ approved, commits, startDate, codeveloper }) {
+  if (!approved) return {};
+
+  const updates = {
+    status: "To Validate",
+    endDate: new Date().toISOString(),
+    developer: "dev_016",
+    commits: commits || []
+  };
+
+  if (startDate) updates.startDate = startDate;
+  if (codeveloper) updates.codeveloper = codeveloper;
+
+  return updates;
+}

--- a/src/planning-game/client.js
+++ b/src/planning-game/client.js
@@ -1,0 +1,39 @@
+/**
+ * Planning Game MCP client.
+ * Communicates with Planning Game via HTTP API or MCP tool calls.
+ *
+ * When Karajan runs as an MCP server (kj_run), the caller (Claude Code)
+ * is expected to provide card data directly via pgTask/pgProject flags.
+ *
+ * This client provides standalone HTTP access for CLI usage (kj run --pg-task).
+ * Requires planning_game.api_url in config or PG_API_URL env var.
+ */
+
+const DEFAULT_API_URL = "http://localhost:3000/api";
+
+function getApiUrl() {
+  return process.env.PG_API_URL || DEFAULT_API_URL;
+}
+
+export async function fetchCard({ projectId, cardId }) {
+  const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/cards/${encodeURIComponent(cardId)}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Planning Game API error: ${response.status} ${response.statusText}`);
+  }
+  const data = await response.json();
+  return data.card || data;
+}
+
+export async function updateCard({ projectId, cardId, firebaseId, updates }) {
+  const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/cards/${encodeURIComponent(firebaseId)}`;
+  const response = await fetch(url, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ updates })
+  });
+  if (!response.ok) {
+    throw new Error(`Planning Game API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/tests/planning-game-adapter.test.js
+++ b/tests/planning-game-adapter.test.js
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  parseCardId,
+  buildTaskFromCard,
+  buildCommitsPayload,
+  buildCompletionUpdates
+} from "../src/planning-game/adapter.js";
+
+describe("planning-game/adapter", () => {
+  describe("parseCardId", () => {
+    it("extracts card ID from standard format", () => {
+      expect(parseCardId("KJC-TSK-0042")).toBe("KJC-TSK-0042");
+    });
+
+    it("extracts card ID embedded in text", () => {
+      expect(parseCardId("Implement KJC-TSK-0042 auth module")).toBe("KJC-TSK-0042");
+    });
+
+    it("extracts bug card ID", () => {
+      expect(parseCardId("PLN-BUG-0015")).toBe("PLN-BUG-0015");
+    });
+
+    it("extracts epic card ID", () => {
+      expect(parseCardId("EX2-PCS-0003")).toBe("EX2-PCS-0003");
+    });
+
+    it("returns null when no card ID found", () => {
+      expect(parseCardId("Just a regular task description")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(parseCardId("")).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(parseCardId(undefined)).toBeNull();
+    });
+
+    it("returns first card ID when multiple present", () => {
+      expect(parseCardId("KJC-TSK-0042 depends on KJC-TSK-0041")).toBe("KJC-TSK-0042");
+    });
+  });
+
+  describe("buildTaskFromCard", () => {
+    it("builds task string from card with structured description", () => {
+      const card = {
+        cardId: "KJC-TSK-0042",
+        title: "Implement auth module",
+        descriptionStructured: [
+          { role: "Como desarrollador", goal: "Quiero un módulo de auth", benefit: "Para seguridad" }
+        ],
+        acceptanceCriteriaStructured: [
+          { given: "Un usuario no autenticado", when: "Intenta acceder", then: "Se redirige a login" }
+        ]
+      };
+
+      const task = buildTaskFromCard(card);
+      expect(task).toContain("KJC-TSK-0042");
+      expect(task).toContain("Implement auth module");
+      expect(task).toContain("módulo de auth");
+      expect(task).toContain("usuario no autenticado");
+    });
+
+    it("builds task string from card with plain description", () => {
+      const card = {
+        cardId: "KJC-TSK-0001",
+        title: "Fix bug",
+        description: "There is a null pointer in auth.js",
+        acceptanceCriteria: "Auth should not crash"
+      };
+
+      const task = buildTaskFromCard(card);
+      expect(task).toContain("Fix bug");
+      expect(task).toContain("null pointer");
+      expect(task).toContain("Auth should not crash");
+    });
+
+    it("includes implementation plan if present", () => {
+      const card = {
+        cardId: "KJC-TSK-0010",
+        title: "Budget tracking",
+        description: "Implement budget tracking",
+        implementationPlan: {
+          approach: "Use token counter middleware",
+          steps: [
+            { description: "Add counter module" },
+            { description: "Integrate in orchestrator" }
+          ]
+        }
+      };
+
+      const task = buildTaskFromCard(card);
+      expect(task).toContain("token counter middleware");
+      expect(task).toContain("Add counter module");
+    });
+
+    it("handles minimal card with just title", () => {
+      const card = {
+        cardId: "KJC-TSK-0099",
+        title: "Simple task"
+      };
+
+      const task = buildTaskFromCard(card);
+      expect(task).toContain("KJC-TSK-0099");
+      expect(task).toContain("Simple task");
+    });
+  });
+
+  describe("buildCommitsPayload", () => {
+    it("builds commits array from git log lines", () => {
+      const gitLog = [
+        { hash: "abc1234", message: "feat: add auth", date: "2026-02-26T10:00:00Z", author: "dev@test.com" },
+        { hash: "def5678", message: "test: add auth tests", date: "2026-02-26T11:00:00Z", author: "dev@test.com" }
+      ];
+
+      const commits = buildCommitsPayload(gitLog);
+      expect(commits).toHaveLength(2);
+      expect(commits[0]).toEqual({
+        hash: "abc1234",
+        message: "feat: add auth",
+        date: "2026-02-26T10:00:00Z",
+        author: "dev@test.com"
+      });
+    });
+
+    it("returns empty array for null input", () => {
+      expect(buildCommitsPayload(null)).toEqual([]);
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(buildCommitsPayload([])).toEqual([]);
+    });
+  });
+
+  describe("buildCompletionUpdates", () => {
+    it("builds update payload for successful completion", () => {
+      const updates = buildCompletionUpdates({
+        approved: true,
+        commits: [{ hash: "abc", message: "feat: done", date: "2026-02-26T12:00:00Z", author: "dev@test.com" }],
+        startDate: "2026-02-26T10:00:00Z"
+      });
+
+      expect(updates.status).toBe("To Validate");
+      expect(updates.endDate).toBeTruthy();
+      expect(updates.commits).toHaveLength(1);
+      expect(updates.developer).toBe("dev_016");
+    });
+
+    it("does not change status for failed runs", () => {
+      const updates = buildCompletionUpdates({
+        approved: false,
+        commits: [],
+        startDate: "2026-02-26T10:00:00Z"
+      });
+
+      expect(updates.status).toBeUndefined();
+      expect(updates.endDate).toBeUndefined();
+    });
+
+    it("includes codeveloper when provided", () => {
+      const updates = buildCompletionUpdates({
+        approved: true,
+        commits: [{ hash: "abc", message: "feat: done", date: "2026-02-26T12:00:00Z", author: "dev@test.com" }],
+        startDate: "2026-02-26T10:00:00Z",
+        codeveloper: "dev_001"
+      });
+
+      expect(updates.codeveloper).toBe("dev_001");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/planning-game/adapter.js`: parse card IDs (`KJC-TSK-0042`), build enriched task from card data (user stories, acceptance criteria, implementation plan), build completion payloads
- New `src/planning-game/client.js`: HTTP client for standalone CLI usage (Planning Game API)
- `commands/run.js`: auto-detects card ID in task text or via `--pg-task`, fetches card context before running, updates card to "To Validate" on approval
- `config.js`: new `planning_game` section (`enabled`, `project_id`, `codeveloper`); auto-enables when `--pg-task` flag used
- `mcp/tools.js`: `kj_run` extended with `pgTask` and `pgProject` parameters
- `cli.js`: `--pg-task <cardId>` and `--pg-project <projectId>` flags
- `mcp/run-kj.js`: forwards new flags to CLI subprocess
- 18 new tests for adapter (parseCardId, buildTaskFromCard, buildCommitsPayload, buildCompletionUpdates)
- 618 tests passing across 65 files

## Test plan
- [x] 18 adapter unit tests: card ID parsing, task enrichment, commit payload, completion updates
- [x] Full suite: 618 tests, 65 files, all green
- [ ] Integration test with real Planning Game MCP instance