### PR TITLE
feat(review): implement custom review profiles with mode-specific templates

### DIFF
--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -1,9 +1,9 @@
-import fs from "node:fs/promises";
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { computeBaseRef, generateDiff } from "../review/diff-generator.js";
 import { buildReviewerPrompt } from "../prompts/reviewer.js";
 import { resolveRole } from "../config.js";
+import { resolveReviewProfile } from "../review/profiles.js";
 
 export async function reviewCommand({ task, config, logger, baseRef }) {
   const reviewerRole = resolveRole(config, "reviewer");
@@ -12,12 +12,7 @@ export async function reviewCommand({ task, config, logger, baseRef }) {
   const reviewer = createAgent(reviewerRole.provider, config, logger);
   const resolvedBase = await computeBaseRef({ baseBranch: config.base_branch, baseRef });
   const diff = await generateDiff({ baseRef: resolvedBase });
-  let rules = "Focus on critical issues only.";
-  try {
-    rules = await fs.readFile(config.review_rules, "utf8");
-  } catch {
-    // no-op
-  }
+  const { rules } = await resolveReviewProfile({ mode: config.review_mode, projectDir: process.cwd() });
 
   const prompt = buildReviewerPrompt({ task, diff, reviewRules: rules, mode: config.review_mode });
   const onOutput = ({ line }) => process.stdout.write(`${line}\n`);

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -24,6 +24,7 @@ import {
   finalizeGitAutomation
 } from "./git/automation.js";
 import { resolveRoleMdPath, loadFirstExisting } from "./roles/base-role.js";
+import { resolveReviewProfile } from "./review/profiles.js";
 import { ResearcherRole } from "./roles/researcher-role.js";
 import { TesterRole } from "./roles/tester-role.js";
 import { SecurityRole } from "./roles/security-role.js";
@@ -167,7 +168,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   // --- Dry-run: return summary without executing anything ---
   if (flags.dryRun) {
     const projectDir = config.projectDir || process.cwd();
-    const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir)) || "";
+    const { rules: reviewRules } = await resolveReviewProfile({ mode: config.review_mode, projectDir });
     const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
     const coderPrompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology });
     const reviewerPrompt = buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode });
@@ -336,7 +337,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const gitCtx = await prepareGitAutomation({ config, task, logger, session });
 
   const projectDir = config.projectDir || process.cwd();
-  const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir)) || "Focus on critical issues only.";
+  const { rules: reviewRules } = await resolveReviewProfile({ mode: config.review_mode, projectDir });
   const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
 
   for (let i = 1; i <= config.max_iterations; i += 1) {

--- a/src/review/profiles.js
+++ b/src/review/profiles.js
@@ -1,0 +1,66 @@
+/**
+ * Review profile resolver.
+ * Loads mode-specific reviewer instructions with fallback chain:
+ *   1. Project-level / user-level / built-in reviewer-{mode}.md
+ *   2. Project-level / user-level / built-in reviewer.md
+ *   3. Hardcoded default
+ */
+
+import path from "node:path";
+import { loadFirstExisting } from "../roles/base-role.js";
+import { getKarajanHome } from "../utils/paths.js";
+
+const KNOWN_MODES = ["paranoid", "strict", "standard", "relaxed"];
+
+const DEFAULT_RULES = "Focus on critical issues: security vulnerabilities, logic errors, and broken tests.";
+
+function buildCandidates(fileName, projectDir) {
+  const candidates = [];
+
+  if (projectDir) {
+    candidates.push(path.join(projectDir, ".karajan", "roles", fileName));
+  }
+
+  candidates.push(path.join(getKarajanHome(), "roles", fileName));
+
+  const builtIn = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    "..",
+    "..",
+    "templates",
+    "roles",
+    fileName
+  );
+  candidates.push(builtIn);
+
+  return candidates;
+}
+
+export async function resolveReviewProfile({ mode = "standard", projectDir } = {}) {
+  // Known modes: try mode-specific file first, then base reviewer.md
+  if (KNOWN_MODES.includes(mode)) {
+    const modePaths = buildCandidates(`reviewer-${mode}.md`, projectDir);
+    const modeRules = await loadFirstExisting(modePaths);
+    if (modeRules) {
+      return { mode, rules: modeRules };
+    }
+
+    // Fallback to base reviewer.md
+    const basePaths = buildCandidates("reviewer.md", projectDir);
+    const baseRules = await loadFirstExisting(basePaths);
+    if (baseRules) {
+      return { mode, rules: baseRules };
+    }
+
+    return { mode, rules: DEFAULT_RULES };
+  }
+
+  // Custom/unknown modes: only check base reviewer.md
+  const basePaths = buildCandidates("reviewer.md", projectDir);
+  const baseRules = await loadFirstExisting(basePaths);
+  if (baseRules) {
+    return { mode, rules: baseRules };
+  }
+
+  return { mode, rules: DEFAULT_RULES };
+}

--- a/templates/roles/reviewer-paranoid.md
+++ b/templates/roles/reviewer-paranoid.md
@@ -1,0 +1,38 @@
+# Reviewer Role — Paranoid Mode
+
+You are the **Reviewer** in paranoid mode. Every change is suspect until proven safe. Be extremely thorough.
+
+## Review priorities (in order)
+
+1. **Security** — treat every input as hostile; check for injection, SSRF, path traversal, prototype pollution, secret leaks
+2. **Correctness** — trace every code path; verify edge cases, null/undefined, integer overflow, race conditions
+3. **Tests** — demand high coverage; reject if critical paths lack assertions
+4. **Data integrity** — validate schemas, migrations, backwards compatibility
+5. **Architecture** — coupling, abstraction leaks, violation of established patterns
+6. **Style** — flag inconsistencies that could hide bugs
+
+## Rules
+
+- **Default to rejection.** Approve only when you are highly confident there are zero risks.
+- Flag any file that was entirely replaced (not surgically edited) as BLOCKING.
+- Flag missing error handling as BLOCKING.
+- Flag missing input validation as BLOCKING.
+- Require explicit tests for every new public function.
+- If confidence < 0.85, reject and explain what you cannot verify.
+- Style issues are BLOCKING only when they obscure logic (ambiguous names, deeply nested ternaries).
+
+## Output format
+
+Return a strict JSON object:
+```json
+{
+  "ok": true,
+  "result": {
+    "approved": boolean,
+    "blocking_issues": [],
+    "non_blocking_suggestions": [],
+    "confidence": number,
+    "summary": "string"
+  }
+}
+```

--- a/templates/roles/reviewer-relaxed.md
+++ b/templates/roles/reviewer-relaxed.md
@@ -1,0 +1,34 @@
+# Reviewer Role — Relaxed Mode
+
+You are the **Reviewer** in relaxed mode. Focus only on what truly matters.
+
+## Review priorities (in order)
+
+1. **Security** — only critical vulnerabilities (secrets in code, SQL injection, XSS)
+2. **Correctness** — only clear logic errors that would break functionality
+3. **Tests** — only flag if zero tests exist for critical new logic
+
+## Rules
+
+- Only block on critical security vulnerabilities or clear correctness bugs.
+- Architecture, style, and naming issues are NEVER blocking.
+- Missing tests are non-blocking unless the change is in a critical path.
+- Trust the developer's intent; suggest improvements as non-blocking only.
+- Confidence threshold: reject only if < 0.60.
+- Prefer approving with suggestions over rejecting.
+
+## Output format
+
+Return a strict JSON object:
+```json
+{
+  "ok": true,
+  "result": {
+    "approved": boolean,
+    "blocking_issues": [],
+    "non_blocking_suggestions": [],
+    "confidence": number,
+    "summary": "string"
+  }
+}
+```

--- a/templates/roles/reviewer-strict.md
+++ b/templates/roles/reviewer-strict.md
@@ -1,0 +1,37 @@
+# Reviewer Role — Strict Mode
+
+You are the **Reviewer** in strict mode. High standards, but practical.
+
+## Review priorities (in order)
+
+1. **Security** — vulnerabilities, exposed secrets, injection vectors
+2. **Correctness** — logic errors, edge cases, broken tests
+3. **Tests** — adequate coverage for changed code, meaningful assertions
+4. **Architecture** — patterns, maintainability, SOLID principles
+5. **Style** — naming, formatting (flag if inconsistent with codebase)
+
+## Rules
+
+- Block on any security issue, regardless of severity.
+- Block on logic errors that could reach production.
+- Block if test coverage for new code is insufficient.
+- Require error handling for external calls (network, filesystem, user input).
+- Flag file overwrites (massive deletions + additions) as BLOCKING.
+- Style issues are non-blocking unless they create ambiguity.
+- Confidence threshold: reject if < 0.80.
+
+## Output format
+
+Return a strict JSON object:
+```json
+{
+  "ok": true,
+  "result": {
+    "approved": boolean,
+    "blocking_issues": [],
+    "non_blocking_suggestions": [],
+    "confidence": number,
+    "summary": "string"
+  }
+}
+```

--- a/tests/command-review.test.js
+++ b/tests/command-review.test.js
@@ -23,10 +23,8 @@ vi.mock("../src/prompts/reviewer.js", () => ({
   buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
 }));
 
-vi.mock("node:fs/promises", () => ({
-  default: {
-    readFile: vi.fn().mockResolvedValue("review rules content")
-  }
+vi.mock("../src/review/profiles.js", () => ({
+  resolveReviewProfile: vi.fn().mockResolvedValue({ mode: "standard", rules: "review rules content" })
 }));
 
 function makeConfig(overrides = {}) {
@@ -66,8 +64,8 @@ describe("commands/review", () => {
     buildReviewerPrompt = prompts.buildReviewerPrompt;
     buildReviewerPrompt.mockReturnValue("reviewer prompt");
 
-    const fs = await import("node:fs/promises");
-    fs.default.readFile.mockResolvedValue("review rules content");
+    const profiles = await import("../src/review/profiles.js");
+    profiles.resolveReviewProfile.mockResolvedValue({ mode: "standard", rules: "review rules content" });
 
     createAgent.mockReturnValue({
       reviewTask: vi.fn().mockResolvedValue({ ok: true, output: '{"approved": true}', exitCode: 0 })
@@ -131,15 +129,18 @@ describe("commands/review", () => {
     ).rejects.toThrow("review crashed");
   });
 
-  it("uses fallback rules when review-rules.md is missing", async () => {
-    const fs = await import("node:fs/promises");
-    fs.default.readFile.mockRejectedValue(new Error("ENOENT"));
+  it("uses fallback rules when no profile files found", async () => {
+    const profiles = await import("../src/review/profiles.js");
+    profiles.resolveReviewProfile.mockResolvedValue({
+      mode: "standard",
+      rules: "Focus on critical issues: security vulnerabilities, logic errors, and broken tests."
+    });
 
     const { reviewCommand } = await import("../src/commands/review.js");
     await reviewCommand({ task: "review task", config: makeConfig(), logger: noopLogger });
 
     expect(buildReviewerPrompt).toHaveBeenCalledWith(expect.objectContaining({
-      reviewRules: "Focus on critical issues only."
+      reviewRules: "Focus on critical issues: security vulnerabilities, logic errors, and broken tests."
     }));
   });
 

--- a/tests/review-profiles.test.js
+++ b/tests/review-profiles.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import path from "node:path";
+
+vi.mock("../src/roles/base-role.js", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    loadFirstExisting: vi.fn()
+  };
+});
+
+const { resolveReviewProfile } = await import("../src/review/profiles.js");
+const { loadFirstExisting } = await import("../src/roles/base-role.js");
+
+describe("review/profiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("resolveReviewProfile", () => {
+    it("returns mode-specific rules when file exists", async () => {
+      loadFirstExisting.mockImplementation((paths) => {
+        const modeFile = paths.find((p) => p.includes("reviewer-paranoid"));
+        if (modeFile) return "Paranoid rules content";
+        return null;
+      });
+
+      const result = await resolveReviewProfile({ mode: "paranoid", projectDir: "/project" });
+      expect(result.rules).toContain("Paranoid rules content");
+      expect(result.mode).toBe("paranoid");
+    });
+
+    it("falls back to base reviewer.md when mode file not found", async () => {
+      loadFirstExisting
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce("Base reviewer rules");
+
+      const result = await resolveReviewProfile({ mode: "standard", projectDir: "/project" });
+      expect(result.rules).toContain("Base reviewer rules");
+      expect(result.mode).toBe("standard");
+    });
+
+    it("returns default fallback when no files found", async () => {
+      loadFirstExisting.mockResolvedValue(null);
+
+      const result = await resolveReviewProfile({ mode: "standard", projectDir: "/project" });
+      expect(result.rules).toContain("critical issues");
+      expect(result.mode).toBe("standard");
+    });
+
+    it("resolves paranoid profile", async () => {
+      loadFirstExisting.mockImplementation((paths) => {
+        if (paths.some((p) => p.includes("reviewer-paranoid"))) return "paranoid content";
+        return null;
+      });
+
+      const result = await resolveReviewProfile({ mode: "paranoid", projectDir: "/project" });
+      expect(result.rules).toBe("paranoid content");
+    });
+
+    it("resolves strict profile", async () => {
+      loadFirstExisting.mockImplementation((paths) => {
+        if (paths.some((p) => p.includes("reviewer-strict"))) return "strict content";
+        return null;
+      });
+
+      const result = await resolveReviewProfile({ mode: "strict", projectDir: "/project" });
+      expect(result.rules).toBe("strict content");
+    });
+
+    it("resolves relaxed profile", async () => {
+      loadFirstExisting.mockImplementation((paths) => {
+        if (paths.some((p) => p.includes("reviewer-relaxed"))) return "relaxed content";
+        return null;
+      });
+
+      const result = await resolveReviewProfile({ mode: "relaxed", projectDir: "/project" });
+      expect(result.rules).toBe("relaxed content");
+    });
+
+    it("custom mode only checks base reviewer.md", async () => {
+      loadFirstExisting.mockResolvedValueOnce("custom rules from project");
+
+      const result = await resolveReviewProfile({ mode: "custom", projectDir: "/project" });
+      expect(result.rules).toBe("custom rules from project");
+      expect(result.mode).toBe("custom");
+    });
+
+    it("standard mode resolves built-in template when no overrides", async () => {
+      loadFirstExisting.mockImplementation((paths) => {
+        const builtin = paths.find((p) => p.includes("templates/roles/reviewer.md"));
+        if (builtin) return "Built-in reviewer template";
+        return null;
+      });
+
+      const result = await resolveReviewProfile({ mode: "standard", projectDir: "/project" });
+      expect(result.rules).toContain("Built-in reviewer template");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `resolveReviewProfile()` in `src/review/profiles.js` with fallback chain: mode-specific template (`reviewer-{mode}.md`) → base `reviewer.md` → hardcoded default
- Create three mode-specific reviewer templates: `reviewer-paranoid.md` (default-reject, high confidence threshold), `reviewer-strict.md` (high standards, practical), `reviewer-relaxed.md` (minimal blocking)
- Integrate profile resolution into orchestrator (dry-run + main loop) and `commands/review.js`, replacing direct `fs.readFile` / `loadFirstExisting` calls

## Test plan
- [x] 8 unit tests for `resolveReviewProfile` covering all modes and fallback scenarios
- [x] Updated `command-review.test.js` to use profile mock instead of fs mock
- [x] Full suite: 668 tests passing (67 files)