### PR TITLE
feat(budget): implement token and cost tracking per session

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,7 @@ const DEFAULTS = {
   },
   review_mode: "standard",
   max_iterations: 5,
+  max_budget_usd: null,
   review_rules: "./review-rules.md",
   coder_rules: "./coder-rules.md",
   base_branch: "main",
@@ -82,10 +83,12 @@ const DEFAULTS = {
   planning_game: { enabled: false, project_id: null, codeveloper: null },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
+  budget: {
+    warn_threshold_pct: 80
+  },
   session: {
     max_iteration_minutes: 15,
     max_total_minutes: 120,
-    max_budget_usd: null,
     fail_fast_repeats: 2,
     repeat_detection_threshold: 2,
     max_sonar_retries: 3,
@@ -140,6 +143,10 @@ export function applyRunOverrides(config, flags) {
   out.git = out.git || {};
   out.development = out.development || {};
   out.sonarqube = out.sonarqube || {};
+  if (out.max_budget_usd === undefined || out.max_budget_usd === null) {
+    out.max_budget_usd = out.session.max_budget_usd ?? null;
+  }
+  out.budget = mergeDeep(DEFAULTS.budget, out.budget || {});
   out.roles = mergeDeep(DEFAULTS.roles, out.roles || {});
   out.pipeline = mergeDeep(DEFAULTS.pipeline, out.pipeline || {});
 

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -18,6 +18,7 @@ import { resolveRole } from "./config.js";
 import { SonarRole } from "./roles/sonar-role.js";
 import { RepeatDetector } from "./repeat-detector.js";
 import { emitProgress, makeEvent } from "./utils/events.js";
+import { BudgetTracker } from "./utils/budget.js";
 import {
   commitMessageFromTask,
   prepareGitAutomation,
@@ -92,7 +93,31 @@ function getRepeatThreshold(config) {
   return 2;
 }
 
-async function runReviewerWithFallback({ reviewerName, config, logger, prompt, session, iteration, onOutput }) {
+function extractUsageMetrics(result) {
+  const usage = result?.usage || result?.metrics || {};
+  const tokens_in =
+    result?.tokens_in ??
+    usage?.tokens_in ??
+    usage?.input_tokens ??
+    usage?.prompt_tokens ??
+    0;
+  const tokens_out =
+    result?.tokens_out ??
+    usage?.tokens_out ??
+    usage?.output_tokens ??
+    usage?.completion_tokens ??
+    0;
+  const cost_usd =
+    result?.cost_usd ??
+    usage?.cost_usd ??
+    usage?.usd_cost ??
+    usage?.cost ??
+    0;
+
+  return { tokens_in, tokens_out, cost_usd };
+}
+
+async function runReviewerWithFallback({ reviewerName, config, logger, prompt, session, iteration, onOutput, onAttemptResult }) {
   const fallbackReviewer = config.reviewer_options?.fallback_reviewer;
   const retries = Math.max(0, Number(config.reviewer_options?.retries ?? 1));
   const candidates = [reviewerName];
@@ -105,6 +130,9 @@ async function runReviewerWithFallback({ reviewerName, config, logger, prompt, s
     const reviewer = createAgent(name, config, logger);
     for (let attempt = 1; attempt <= retries + 1; attempt += 1) {
       const result = await reviewer.reviewTask({ prompt, onOutput, role: "reviewer" });
+      if (onAttemptResult) {
+        await onAttemptResult({ reviewer: name, result });
+      }
       attempts.push({ reviewer: name, attempt, ok: result.ok, result });
       await addCheckpoint(session, {
         stage: "reviewer-attempt",
@@ -273,6 +301,38 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const coder = createAgent(coderRole.provider, config, logger);
   const startedAt = Date.now();
   const eventBase = { sessionId: null, iteration: 0, stage: null, startedAt };
+  const budgetTracker = new BudgetTracker();
+  const budgetLimit = Number(config?.max_budget_usd);
+  const hasBudgetLimit = Number.isFinite(budgetLimit) && budgetLimit >= 0;
+  const warnThresholdPct = Number(config?.budget?.warn_threshold_pct ?? 80);
+
+  function budgetSummary() {
+    return budgetTracker.summary();
+  }
+
+  function trackBudget({ role, provider, result }) {
+    const metrics = extractUsageMetrics(result);
+    budgetTracker.record({ role, provider, ...metrics });
+
+    if (!hasBudgetLimit) return;
+    const totalCost = budgetTracker.total().cost_usd;
+    const pctUsed = budgetLimit === 0 ? 100 : (totalCost / budgetLimit) * 100;
+    const status = totalCost > budgetLimit ? "fail" : pctUsed >= warnThresholdPct ? "paused" : "ok";
+    emitProgress(
+      emitter,
+      makeEvent("budget:update", { ...eventBase, stage: role }, {
+        status,
+        message: `Budget: $${totalCost.toFixed(2)} / $${budgetLimit.toFixed(2)}`,
+        detail: {
+          ...budgetSummary(),
+          max_budget_usd: budgetLimit,
+          warn_threshold_pct: warnThresholdPct,
+          pct_used: Number(pctUsed.toFixed(2)),
+          remaining_usd: budgetTracker.remaining(budgetLimit)
+        }
+      })
+    );
+  }
 
   const baseRef = await computeBaseRef({ baseBranch: config.base_branch, baseRef: flags.baseRef || null });
   const session = await createSession({
@@ -324,6 +384,11 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     const researcher = new ResearcherRole({ config, logger, emitter });
     await researcher.init({ task });
     const researchOutput = await researcher.run({ task });
+    trackBudget({
+      role: "researcher",
+      provider: config?.roles?.researcher?.provider || coderRole.provider,
+      result: researchOutput
+    });
 
     await addCheckpoint(session, { stage: "researcher", iteration: 0, ok: researchOutput.ok });
 
@@ -363,6 +428,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       plannerPromptParts.push("", "## Research findings", JSON.stringify(researchContext, null, 2));
     }
     const plannerResult = await planner.runTask({ prompt: plannerPromptParts.join("\n"), role: "planner" });
+    trackBudget({ role: "planner", provider: plannerRole.provider, result: plannerResult });
     if (!plannerResult.ok) {
       await markSessionStatus(session, "failed");
       const details = plannerResult.error || plannerResult.output || `exitCode=${plannerResult.exitCode ?? "unknown"}`;
@@ -409,10 +475,25 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         makeEvent("session:end", { ...eventBase, iteration: i, stage: "timeout" }, {
           status: "fail",
           message: "Session timed out",
-          detail: { approved: false, reason: "timeout" }
+          detail: { approved: false, reason: "timeout", budget: budgetSummary() }
         })
       );
       throw new Error("Session timed out");
+    }
+
+    if (budgetTracker.isOverBudget(config?.max_budget_usd)) {
+      await markSessionStatus(session, "failed");
+      const totalCost = budgetTracker.total().cost_usd;
+      const message = `Budget exceeded: $${totalCost.toFixed(2)} > $${budgetLimit.toFixed(2)}`;
+      emitProgress(
+        emitter,
+        makeEvent("session:end", { ...eventBase, iteration: i, stage: "budget" }, {
+          status: "fail",
+          message,
+          detail: { approved: false, reason: "budget_exceeded", budget: budgetSummary(), max_budget_usd: budgetLimit }
+        })
+      );
+      throw new Error(message);
     }
 
     eventBase.iteration = i;
@@ -453,6 +534,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       }));
     };
     const coderResult = await coder.runTask({ prompt: coderPrompt, onOutput: coderOnOutput, role: "coder" });
+    trackBudget({ role: "coder", provider: coderRole.provider, result: coderResult });
 
     if (!coderResult.ok) {
       await markSessionStatus(session, "failed");
@@ -502,6 +584,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         onOutput: refactorerOnOutput,
         role: "refactorer"
       });
+      trackBudget({ role: "refactorer", provider: refactorerRole.provider, result: refactorResult });
       if (!refactorResult.ok) {
         await markSessionStatus(session, "failed");
         const details = refactorResult.error || refactorResult.output || `exitCode=${refactorResult.exitCode ?? "unknown"}`;
@@ -600,6 +683,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       const sonarRole = new SonarRole({ config, logger, emitter });
       await sonarRole.init({ iteration: i });
       const sonarOutput = await sonarRole.run();
+      trackBudget({ role: "sonar", provider: "sonar", result: sonarOutput });
       const sonarResult = sonarOutput.result;
 
       if (!sonarResult.gateStatus && sonarResult.error) {
@@ -651,7 +735,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
             makeEvent("session:end", { ...eventBase, stage: "sonar" }, {
               status: "stalled",
               message,
-              detail: { reason: repeatState.reason, repeats: repeatCounts.sonar }
+              detail: { reason: repeatState.reason, repeats: repeatCounts.sonar, budget: budgetSummary() }
             })
           );
           return { approved: false, sessionId: session.id, reason: "stalled" };
@@ -742,7 +826,10 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       prompt: reviewerPrompt,
       session,
       iteration: i,
-      onOutput: reviewerOnOutput
+      onOutput: reviewerOnOutput,
+      onAttemptResult: ({ reviewer, result }) => {
+        trackBudget({ role: "reviewer", provider: reviewer, result });
+      }
     });
 
     if (!reviewerExec.result || !reviewerExec.result.ok) {
@@ -818,7 +905,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           makeEvent("session:end", { ...eventBase, stage: "reviewer" }, {
             status: "stalled",
             message,
-            detail: { reason: repeatState.reason, repeats: repeatCounts.reviewer }
+            detail: { reason: repeatState.reason, repeats: repeatCounts.reviewer, budget: budgetSummary() }
           })
         );
         return { approved: false, sessionId: session.id, reason: "stalled" };
@@ -854,6 +941,11 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         const tester = new TesterRole({ config, logger, emitter });
         await tester.init({ task, iteration: i });
         const testerOutput = await tester.run({ task, diff: postLoopDiff });
+        trackBudget({
+          role: "tester",
+          provider: config?.roles?.tester?.provider || coderRole.provider,
+          result: testerOutput
+        });
 
         await addCheckpoint(session, { stage: "tester", iteration: i, ok: testerOutput.ok });
 
@@ -914,6 +1006,11 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         const security = new SecurityRole({ config, logger, emitter });
         await security.init({ task, iteration: i });
         const securityOutput = await security.run({ task, diff: postLoopDiff });
+        trackBudget({
+          role: "security",
+          provider: config?.roles?.security?.provider || coderRole.provider,
+          result: securityOutput
+        });
 
         await addCheckpoint(session, { stage: "security", iteration: i, ok: securityOutput.ok });
 
@@ -971,7 +1068,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         emitter,
         makeEvent("session:end", { ...eventBase, stage: "done" }, {
           message: "Session approved",
-          detail: { approved: true, iterations: i, stages: stageResults, git: gitResult }
+          detail: { approved: true, iterations: i, stages: stageResults, git: gitResult, budget: budgetSummary() }
         })
       );
       return { approved: true, sessionId: session.id, review, git: gitResult };
@@ -1027,7 +1124,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     makeEvent("session:end", { ...eventBase, stage: "done" }, {
       status: "fail",
       message: "Max iterations reached",
-      detail: { approved: false, reason: "max_iterations", iterations: config.max_iterations, stages: stageResults }
+      detail: { approved: false, reason: "max_iterations", iterations: config.max_iterations, stages: stageResults, budget: budgetSummary() }
     })
   );
   return { approved: false, sessionId: session.id, reason: "max_iterations" };

--- a/src/utils/budget.js
+++ b/src/utils/budget.js
@@ -1,0 +1,89 @@
+function toSafeNumber(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
+function roundUsd(value) {
+  return Number(toSafeNumber(value).toFixed(6));
+}
+
+function normalizeLimit(limit) {
+  if (limit === null || limit === undefined || limit === "") return null;
+  const n = Number(limit);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+function addToBreakdown(map, key, entry) {
+  const current = map[key] || { tokens_in: 0, tokens_out: 0, total_tokens: 0, total_cost_usd: 0, count: 0 };
+  current.tokens_in += entry.tokens_in;
+  current.tokens_out += entry.tokens_out;
+  current.total_tokens += entry.tokens_in + entry.tokens_out;
+  current.total_cost_usd = roundUsd(current.total_cost_usd + entry.cost_usd);
+  current.count += 1;
+  map[key] = current;
+}
+
+export class BudgetTracker {
+  constructor() {
+    this.entries = [];
+  }
+
+  record({ role, provider, tokens_in, tokens_out, cost_usd } = {}) {
+    const entry = {
+      role: role || "unknown",
+      provider: provider || "unknown",
+      timestamp: new Date().toISOString(),
+      tokens_in: toSafeNumber(tokens_in),
+      tokens_out: toSafeNumber(tokens_out),
+      cost_usd: roundUsd(cost_usd)
+    };
+    this.entries.push(entry);
+    return entry;
+  }
+
+  total() {
+    let tokensIn = 0;
+    let tokensOut = 0;
+    let totalCost = 0;
+    for (const entry of this.entries) {
+      tokensIn += entry.tokens_in;
+      tokensOut += entry.tokens_out;
+      totalCost = roundUsd(totalCost + entry.cost_usd);
+    }
+    return {
+      tokens_in: tokensIn,
+      tokens_out: tokensOut,
+      cost_usd: totalCost
+    };
+  }
+
+  remaining(limit) {
+    const n = normalizeLimit(limit);
+    if (n === null) return Infinity;
+    return roundUsd(n - this.total().cost_usd);
+  }
+
+  isOverBudget(limit) {
+    const n = normalizeLimit(limit);
+    if (n === null) return false;
+    return this.total().cost_usd > n;
+  }
+
+  summary() {
+    const totals = this.total();
+    const byRole = {};
+
+    for (const entry of this.entries) {
+      addToBreakdown(byRole, entry.role, entry);
+    }
+
+    return {
+      total_tokens: totals.tokens_in + totals.tokens_out,
+      total_cost_usd: totals.cost_usd,
+      breakdown_by_role: byRole,
+      entries: [...this.entries]
+    };
+  }
+}

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -34,6 +34,7 @@ const ICONS = {
   "solomon:start": "\u2696\ufe0f",
   "solomon:end": "\u2696\ufe0f",
   "solomon:escalate": "\u26a0\ufe0f",
+  "budget:update": "\ud83d\udcb8",
   "iteration:end": "\u23f1\ufe0f",
   "session:end": "\ud83c\udfc1",
   question: "\u2753"
@@ -241,6 +242,18 @@ export function printEvent(event) {
       console.log(`  \u2514\u2500 ${icon} Duration: ${formatElapsed(event.detail?.duration)}  ${elapsed}`);
       break;
 
+    case "budget:update": {
+      const total = Number(event.detail?.total_cost_usd || 0);
+      const max = Number(event.detail?.max_budget_usd);
+      const pct = Number(event.detail?.pct_used ?? 0);
+      const warn = Number(event.detail?.warn_threshold_pct ?? 80);
+      const color = max > 0 && pct >= 100 ? ANSI.red : max > 0 && pct >= warn ? ANSI.yellow : ANSI.green;
+      if (Number.isFinite(max) && max >= 0) {
+        console.log(`  \u251c\u2500 ${icon} Budget: ${color}$${total.toFixed(2)} / $${max.toFixed(2)} (${pct.toFixed(1)}%)${ANSI.reset}`);
+      }
+      break;
+    }
+
     case "session:end": {
       console.log();
       const resultLabel = event.detail?.approved
@@ -293,6 +306,21 @@ export function printEvent(event) {
             const shortHash = (commit.hash || "").slice(0, 7) || "unknown";
             const message = commit.message || "";
             console.log(`  ${ANSI.dim}   - ${shortHash} ${message}${ANSI.reset}`);
+          }
+        }
+      }
+
+      const budget = event.detail?.budget;
+      if (budget) {
+        console.log(`  ${ANSI.dim}\ud83d\udcb0 Total tokens: ${budget.total_tokens ?? 0}${ANSI.reset}`);
+        console.log(`  ${ANSI.dim}\ud83d\udcb0 Total cost: $${Number(budget.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`);
+        const byRole = budget.breakdown_by_role || {};
+        const roles = Object.entries(byRole);
+        if (roles.length > 0) {
+          for (const [role, metrics] of roles) {
+            console.log(
+              `  ${ANSI.dim}   - ${role}: ${metrics.total_tokens ?? 0} tokens, $${Number(metrics.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`
+            );
           }
         }
       }

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { BudgetTracker } from "../src/utils/budget.js";
+
+describe("BudgetTracker", () => {
+  it("records entries and computes totals", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", tokens_in: 100, tokens_out: 250, cost_usd: 0.42 });
+    tracker.record({ role: "reviewer", provider: "claude", tokens_in: 40, tokens_out: 60, cost_usd: 0.18 });
+
+    expect(tracker.total()).toEqual({
+      tokens_in: 140,
+      tokens_out: 310,
+      cost_usd: 0.6
+    });
+  });
+
+  it("treats missing metrics as zero", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex" });
+
+    expect(tracker.total()).toEqual({
+      tokens_in: 0,
+      tokens_out: 0,
+      cost_usd: 0
+    });
+    expect(tracker.summary().entries).toHaveLength(1);
+  });
+
+  it("returns remaining budget and over-budget status", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", cost_usd: 1.25 });
+
+    expect(tracker.remaining(2)).toBeCloseTo(0.75, 8);
+    expect(tracker.isOverBudget(2)).toBe(false);
+    expect(tracker.isOverBudget(1)).toBe(true);
+    expect(tracker.isOverBudget(null)).toBe(false);
+  });
+
+  it("builds summary breakdown by role", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", tokens_in: 10, tokens_out: 20, cost_usd: 0.1 });
+    tracker.record({ role: "coder", provider: "codex", tokens_in: 5, tokens_out: 5, cost_usd: 0.05 });
+    tracker.record({ role: "reviewer", provider: "claude", tokens_in: 3, tokens_out: 7, cost_usd: 0.02 });
+
+    const summary = tracker.summary();
+    expect(summary.total_tokens).toBe(50);
+    expect(summary.total_cost_usd).toBe(0.17);
+    expect(summary.breakdown_by_role.coder.total_cost_usd).toBe(0.15);
+    expect(summary.breakdown_by_role.coder.tokens_in).toBe(15);
+    expect(summary.breakdown_by_role.reviewer.tokens_out).toBe(7);
+  });
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -97,6 +97,11 @@ describe("applyRunOverrides", () => {
     expect(resolveRole(out, "reviewer").provider).toBe("aider");
   });
 
+  it("keeps default budget warning threshold when not overridden", () => {
+    const out = applyRunOverrides({}, {});
+    expect(out.budget.warn_threshold_pct).toBe(80);
+  });
+
   it("returns actionable error when required role is not configured", () => {
     const config = {
       review_mode: "standard",

--- a/tests/orchestrator-budget.test.js
+++ b/tests/orchestrator-budget.test.js
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+const REVIEW_APPROVED = JSON.stringify({
+  approved: true,
+  blocking_issues: [],
+  non_blocking_suggestions: [],
+  summary: "OK",
+  confidence: 0.95
+});
+
+const REVIEW_REJECTED = JSON.stringify({
+  approved: false,
+  blocking_issues: [{ id: "B1", severity: "high", description: "Fix issue" }],
+  non_blocking_suggestions: [],
+  summary: "Needs fixes",
+  confidence: 0.9
+});
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => {
+  let session = null;
+  return {
+    createSession: vi.fn(async (initial) => {
+      session = {
+        id: "s_budget",
+        status: "running",
+        checkpoints: [],
+        ...initial
+      };
+      return session;
+    }),
+    saveSession: vi.fn(async () => {}),
+    loadSession: vi.fn(async () => session),
+    addCheckpoint: vi.fn(async (s, cp) => {
+      s.checkpoints.push(cp);
+    }),
+    markSessionStatus: vi.fn(async (s, status) => {
+      s.status = status;
+    }),
+    pauseSession: vi.fn(async (s, data) => {
+      s.status = "paused";
+      s.paused_state = data;
+    }),
+    resumeSessionWithAnswer: vi.fn(async () => session)
+  };
+});
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  generateDiff: vi.fn().mockResolvedValue("diff")
+}));
+
+vi.mock("../src/review/schema.js", () => ({
+  validateReviewResult: vi.fn((r) => r)
+}));
+
+vi.mock("../src/review/tdd-policy.js", () => ({
+  evaluateTddPolicy: vi.fn().mockReturnValue({
+    ok: true,
+    reason: "pass",
+    sourceFiles: ["a.js"],
+    testFiles: ["a.test.js"],
+    message: "OK"
+  })
+}));
+
+vi.mock("../src/prompts/coder.js", () => ({
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+}));
+
+vi.mock("../src/prompts/reviewer.js", () => ({
+  buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn().mockResolvedValue("rules"),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    mkdir: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+describe("orchestrator budget integration", () => {
+  let runFlow;
+  let createAgent;
+
+  const logger = {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    setContext: vi.fn(), resetContext: vi.fn()
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ runFlow } = await import("../src/orchestrator.js"));
+    ({ createAgent } = await import("../src/agents/index.js"));
+  });
+
+  it("adds budget summary to session:end when agent usage is reported", async () => {
+    createAgent.mockImplementation((name) => {
+      if (name === "codex") {
+        return {
+          runTask: vi.fn().mockResolvedValue({
+            ok: true,
+            output: "",
+            usage: { tokens_in: 100, tokens_out: 150, cost_usd: 0.35 }
+          })
+        };
+      }
+      return {
+        reviewTask: vi.fn().mockResolvedValue({
+          ok: true,
+          output: REVIEW_APPROVED,
+          tokens_in: 20,
+          tokens_out: 30,
+          cost_usd: 0.05
+        })
+      };
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (event) => events.push(event));
+
+    const config = {
+      coder: "codex",
+      reviewer: "claude",
+      review_mode: "standard",
+      max_iterations: 1,
+      max_budget_usd: 5,
+      review_rules: "./review-rules.md",
+      base_branch: "main",
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: false },
+      git: { auto_commit: false, auto_push: false, auto_pr: false },
+      session: { max_total_minutes: 120, fail_fast_repeats: 2 },
+      reviewer_options: { retries: 0, fallback_reviewer: null },
+      output: { log_level: "info" }
+    };
+
+    const result = await runFlow({ task: "budget task", config, logger, emitter });
+    expect(result.approved).toBe(true);
+
+    const endEvent = events.find((e) => e.type === "session:end");
+    expect(endEvent.detail.budget).toMatchObject({
+      total_tokens: 300,
+      total_cost_usd: 0.4
+    });
+    expect(endEvent.detail.budget.breakdown_by_role.coder.total_cost_usd).toBe(0.35);
+    expect(endEvent.detail.budget.breakdown_by_role.reviewer.total_tokens).toBe(50);
+  });
+
+  it("aborts when budget is exceeded before a new iteration starts", async () => {
+    createAgent.mockImplementation((name) => {
+      if (name === "codex") {
+        return {
+          runTask: vi.fn().mockResolvedValue({ ok: true, output: "" })
+        };
+      }
+      return {
+        runTask: vi.fn().mockResolvedValue({ ok: true, output: "plan", cost_usd: 0.2 }),
+        reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_REJECTED })
+      };
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (event) => events.push(event));
+
+    const config = {
+      coder: "codex",
+      reviewer: "claude",
+      roles: { planner: { provider: "claude" } },
+      pipeline: { planner: { enabled: true } },
+      review_mode: "standard",
+      max_iterations: 2,
+      max_budget_usd: 0.1,
+      review_rules: "./review-rules.md",
+      base_branch: "main",
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: false },
+      git: { auto_commit: false, auto_push: false, auto_pr: false },
+      session: { max_total_minutes: 120, fail_fast_repeats: 2 },
+      reviewer_options: { retries: 0, fallback_reviewer: null },
+      output: { log_level: "info" }
+    };
+
+    await expect(runFlow({ task: "budget limit", config, logger, emitter })).rejects.toThrow("Budget exceeded");
+
+    const endEvent = events.filter((e) => e.type === "session:end").at(-1);
+    expect(endEvent.detail.reason).toBe("budget_exceeded");
+    expect(endEvent.detail.budget.total_cost_usd).toBe(0.2);
+  });
+});

--- a/tests/utils-display.test.js
+++ b/tests/utils-display.test.js
@@ -367,6 +367,28 @@ describe("utils/display", () => {
       expect(output).toContain("pull/9");
     });
 
+    it("prints session end budget summary when available", () => {
+      printEvent({
+        type: "session:end",
+        detail: {
+          approved: true,
+          budget: {
+            total_tokens: 420,
+            total_cost_usd: 1.23,
+            breakdown_by_role: {
+              coder: { total_tokens: 300, total_cost_usd: 1, count: 2 },
+              reviewer: { total_tokens: 120, total_cost_usd: 0.23, count: 1 }
+            }
+          }
+        }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Total tokens");
+      expect(output).toContain("Total cost");
+      expect(output).toContain("coder");
+    });
+
     it("prints session end failed with reason", () => {
       printEvent({
         type: "session:end",
@@ -376,6 +398,18 @@ describe("utils/display", () => {
 
       const output = spy.mock.calls.map((c) => c[0]).join("\n");
       expect(output).toContain("max_iterations");
+    });
+
+    it("prints budget progress updates", () => {
+      printEvent({
+        type: "budget:update",
+        detail: { total_cost_usd: 0.6, max_budget_usd: 1, warn_threshold_pct: 80 }
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Budget");
+      expect(output).toContain("0.60");
+      expect(output).toContain("1.00");
     });
 
     // --- Enhanced header ---


### PR DESCRIPTION
## Summary
- New `BudgetTracker` class (`src/utils/budget.js`) to record token usage and cost per role/provider
- Orchestrator integration: tracks every role execution, enforces `max_budget_usd` limit with session abort
- Emits `budget:update` events with progress (cost, percentage, remaining)
- Displays budget summary in session:end output (total tokens, cost, breakdown by role)
- Config: `max_budget_usd` at top level + `budget.warn_threshold_pct` (default 80%)

## Test plan
- [x] `tests/budget.test.js` — BudgetTracker unit tests (record, total, isOverBudget, summary, breakdown)
- [x] `tests/orchestrator-budget.test.js` — Integration tests (budget in session:end, abort on budget exceeded)
- [x] `tests/utils-display.test.js` — Display formatting for budget data
- [x] `tests/config.test.js` — Config defaults for budget fields
- [x] Full suite: 677 tests passing