### PR TITLE
fix(config): prevent coderModel flag from leaking into other roles

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -163,7 +163,6 @@ export function applyRunOverrides(config, flags) {
   if (flags.plannerModel) out.roles.planner.model = String(flags.plannerModel);
   if (flags.coderModel) {
     out.roles.coder.model = String(flags.coderModel);
-    out.coder_options.model = String(flags.coderModel);
   }
   if (flags.reviewerModel) {
     out.roles.reviewer.model = String(flags.reviewerModel);

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -84,6 +84,25 @@ describe("applyRunOverrides", () => {
     expect(out.roles.refactorer.model).toBe("ref-v2");
   });
 
+  it("does not leak coderModel override into planner model when plannerModel is not provided", () => {
+    const base = {
+      coder_options: { model: "legacy-coder-model" },
+      roles: {
+        planner: { provider: "claude", model: null },
+        coder: { provider: "codex", model: null },
+        reviewer: { provider: "claude", model: null },
+        refactorer: { provider: null, model: null }
+      }
+    };
+
+    const out = applyRunOverrides(base, {
+      coderModel: "code-v2"
+    });
+
+    expect(resolveRole(out, "coder").model).toBe("code-v2");
+    expect(resolveRole(out, "planner").model).toBe("legacy-coder-model");
+  });
+
   it("preserves legacy coder/reviewer provider fallback when roles block is absent", () => {
     const base = {
       coder: "gemini",


### PR DESCRIPTION
## Summary
- Remove `coder_options.model` mutation that caused cross-role model contamination when `--coder-model` was specified without `--planner-model`
- Add regression test verifying coderModel override does not leak into planner model

## Test plan
- [x] `npx vitest run tests/config.test.js` — 6 tests passing
- [ ] Manual: run `kj run --coder-model opus` and verify planner uses its default model

Closes KJC-TSK-0047