### PR TITLE
feat(sonar): extract hardcoded SonarQube values to config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -49,6 +49,21 @@ const DEFAULTS = {
   sonarqube: {
     enabled: true,
     host: "http://localhost:9000",
+    external: false,
+    container_name: "karajan-sonarqube",
+    network: "karajan_sonar_net",
+    volumes: {
+      data: "karajan_sonar_data",
+      logs: "karajan_sonar_logs",
+      extensions: "karajan_sonar_extensions"
+    },
+    timeouts: {
+      healthcheck_seconds: 5,
+      compose_up_ms: 300000,
+      compose_control_ms: 120000,
+      logs_ms: 30000,
+      scanner_ms: 900000
+    },
     token: null,
     project_key: null,
     admin_user: "admin",

--- a/src/sonar/manager.js
+++ b/src/sonar/manager.js
@@ -7,67 +7,116 @@ import { loadConfig } from "../config.js";
 const KARAJAN_HOME = getKarajanHome();
 const COMPOSE_PATH = getSonarComposePath();
 
-const composeTemplate = `services:
+function normalizeSonarConfig(sonarqube = {}) {
+  const timeouts = sonarqube.timeouts || {};
+  return {
+    host: sonarqube.host || "http://localhost:9000",
+    external: sonarqube.external === true,
+    containerName: sonarqube.container_name || "karajan-sonarqube",
+    network: sonarqube.network || "karajan_sonar_net",
+    volumes: {
+      data: sonarqube?.volumes?.data || "karajan_sonar_data",
+      logs: sonarqube?.volumes?.logs || "karajan_sonar_logs",
+      extensions: sonarqube?.volumes?.extensions || "karajan_sonar_extensions"
+    },
+    timeouts: {
+      healthcheckSeconds: Number(timeouts.healthcheck_seconds) > 0 ? Number(timeouts.healthcheck_seconds) : 5,
+      composeUpMs: Number(timeouts.compose_up_ms) > 0 ? Number(timeouts.compose_up_ms) : 5 * 60 * 1000,
+      composeControlMs: Number(timeouts.compose_control_ms) > 0 ? Number(timeouts.compose_control_ms) : 2 * 60 * 1000,
+      logsMs: Number(timeouts.logs_ms) > 0 ? Number(timeouts.logs_ms) : 30 * 1000
+    }
+  };
+}
+
+function buildComposeTemplate(sonarConfig) {
+  return `services:
   sonarqube:
     image: sonarqube:community
-    container_name: karajan-sonarqube
+    container_name: ${sonarConfig.containerName}
     ports:
       - "9000:9000"
     volumes:
-      - karajan_sonar_data:/opt/sonarqube/data
-      - karajan_sonar_logs:/opt/sonarqube/logs
-      - karajan_sonar_extensions:/opt/sonarqube/extensions
+      - ${sonarConfig.volumes.data}:/opt/sonarqube/data
+      - ${sonarConfig.volumes.logs}:/opt/sonarqube/logs
+      - ${sonarConfig.volumes.extensions}:/opt/sonarqube/extensions
     environment:
       - SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true
     networks:
-      - karajan_sonar_net
+      - ${sonarConfig.network}
     restart: unless-stopped
 
 volumes:
-  karajan_sonar_data:
-  karajan_sonar_logs:
-  karajan_sonar_extensions:
+  ${sonarConfig.volumes.data}:
+  ${sonarConfig.volumes.logs}:
+  ${sonarConfig.volumes.extensions}:
 
 networks:
-  karajan_sonar_net:
-    name: karajan_sonar_net
+  ${sonarConfig.network}:
+    name: ${sonarConfig.network}
 `;
+}
 
-export async function ensureComposeFile() {
+export async function ensureComposeFile(sonarqube = null) {
+  const sonarConfig = sonarqube ? normalizeSonarConfig(sonarqube) : normalizeSonarConfig((await loadConfig()).config.sonarqube);
+  const composeTemplate = buildComposeTemplate(sonarConfig);
   await ensureDir(KARAJAN_HOME);
   await fs.writeFile(COMPOSE_PATH, composeTemplate, "utf8");
   return COMPOSE_PATH;
 }
 
-export async function isSonarReachable(host) {
-  const res = await runCommand("curl", ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", `${host}/api/system/status`]);
+export async function isSonarReachable(host, healthcheckSeconds = 5) {
+  const timeout = Number(healthcheckSeconds) > 0 ? String(Number(healthcheckSeconds)) : "5";
+  const res = await runCommand("curl", ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", timeout, `${host}/api/system/status`]);
   return res.exitCode === 0 && res.stdout.trim().startsWith("2");
 }
 
 export async function sonarUp(hostOverride = null) {
   const { config } = await loadConfig();
-  const host = hostOverride || config.sonarqube.host || "http://localhost:9000";
+  const sonarConfig = normalizeSonarConfig(config.sonarqube);
+  const host = hostOverride || sonarConfig.host;
 
-  if (await isSonarReachable(host)) {
+  if (await isSonarReachable(host, sonarConfig.timeouts.healthcheckSeconds)) {
     return { exitCode: 0, stdout: `SonarQube already reachable at ${host}, skipping container start.`, stderr: "" };
   }
 
-  const compose = await ensureComposeFile();
-  return runCommand("docker", ["compose", "-f", compose, "up", "-d"]);
+  if (sonarConfig.external) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `Configured external SonarQube is not reachable at ${host}.`
+    };
+  }
+
+  const compose = await ensureComposeFile(config.sonarqube);
+  return runCommand("docker", ["compose", "-f", compose, "up", "-d"], { timeout: sonarConfig.timeouts.composeUpMs });
 }
 
 export async function sonarDown() {
-  const compose = await ensureComposeFile();
-  return runCommand("docker", ["compose", "-f", compose, "stop"]);
+  const { config } = await loadConfig();
+  const sonarConfig = normalizeSonarConfig(config.sonarqube);
+  if (sonarConfig.external) {
+    return { exitCode: 0, stdout: "sonarqube.external=true, skipping Docker stop.", stderr: "" };
+  }
+  const compose = await ensureComposeFile(config.sonarqube);
+  return runCommand("docker", ["compose", "-f", compose, "stop"], { timeout: sonarConfig.timeouts.composeControlMs });
 }
 
 export async function sonarStatus() {
-  const containerRes = await runCommand("docker", ["ps", "--filter", "name=karajan-sonarqube", "--format", "{{.Status}}"]);
+  const { config } = await loadConfig();
+  const sonarConfig = normalizeSonarConfig(config.sonarqube);
+  const host = sonarConfig.host;
+
+  if (sonarConfig.external) {
+    if (await isSonarReachable(host, sonarConfig.timeouts.healthcheckSeconds)) {
+      return { exitCode: 0, stdout: `external SonarQube running at ${host}`, stderr: "" };
+    }
+    return { exitCode: 1, stdout: "", stderr: `external SonarQube is not reachable at ${host}` };
+  }
+
+  const containerRes = await runCommand("docker", ["ps", "--filter", `name=${sonarConfig.containerName}`, "--format", "{{.Status}}"]);
   if (containerRes.stdout?.trim()) return containerRes;
 
-  const { config } = await loadConfig();
-  const host = config.sonarqube.host || "http://localhost:9000";
-  if (await isSonarReachable(host)) {
+  if (await isSonarReachable(host, sonarConfig.timeouts.healthcheckSeconds)) {
     return { exitCode: 0, stdout: `external SonarQube running at ${host}`, stderr: "" };
   }
 
@@ -75,7 +124,12 @@ export async function sonarStatus() {
 }
 
 export async function sonarLogs() {
-  return runCommand("docker", ["logs", "--tail", "100", "karajan-sonarqube"]);
+  const { config } = await loadConfig();
+  const sonarConfig = normalizeSonarConfig(config.sonarqube);
+  if (sonarConfig.external) {
+    return { exitCode: 1, stdout: "", stderr: "sonarqube.external=true, Docker logs are not available." };
+  }
+  return runCommand("docker", ["logs", "--tail", "100", sonarConfig.containerName], { timeout: sonarConfig.timeouts.logsMs });
 }
 
 const MIN_MAP_COUNT = 262144;

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -195,7 +195,13 @@ export async function runSonarScan(config, projectKey = null) {
       exitCode: 1
     };
   }
-  const rawHost = config.sonarqube.host;
+  const sonarConfig = config?.sonarqube || {};
+  const rawHost = sonarConfig.host || "http://localhost:9000";
+  const isExternalSonar = sonarConfig.external === true;
+  const scannerTimeout = Number(sonarConfig?.timeouts?.scanner_ms) > 0
+    ? Number(sonarConfig.timeouts.scanner_ms)
+    : 15 * 60 * 1000;
+  const sonarNetwork = sonarConfig.network || "karajan_sonar_net";
   const apiHost = normalizeApiHost(rawHost);
   const isLocalHost = /localhost|127\.0\.0\.1/.test(rawHost);
   const host = isLocalHost ? rawHost.replace(/localhost|127\.0\.0\.1/g, "host.docker.internal") : rawHost;
@@ -230,7 +236,7 @@ export async function runSonarScan(config, projectKey = null) {
     };
   }
   const scannerConfig = normalizeScannerConfig({
-    ...config.sonarqube.scanner,
+    ...sonarConfig.scanner,
     ...coverage.scannerPatch
   });
 
@@ -239,7 +245,8 @@ export async function runSonarScan(config, projectKey = null) {
     "--rm",
     "-v",
     `${process.cwd()}:/usr/src`,
-    ...(isLocalHost ? ["--add-host", "host.docker.internal:host-gateway"] : ["--network", "karajan_sonar_net"]),
+    ...(isLocalHost ? ["--add-host", "host.docker.internal:host-gateway"] : []),
+    ...(!isLocalHost && !isExternalSonar ? ["--network", sonarNetwork] : []),
     "-e",
     `SONAR_HOST_URL=${host}`,
     "-e",
@@ -249,7 +256,7 @@ export async function runSonarScan(config, projectKey = null) {
     "sonarsource/sonar-scanner-cli"
   ];
 
-  const result = await runCommand("docker", args, { timeout: 15 * 60 * 1000 });
+  const result = await runCommand("docker", args, { timeout: scannerTimeout });
   return {
     ok: result.exitCode === 0,
     projectKey: effectiveProjectKey,

--- a/tests/sonar-manager.test.js
+++ b/tests/sonar-manager.test.js
@@ -20,8 +20,15 @@ const { runCommand } = await import("../src/utils/process.js");
 const { loadConfig } = await import("../src/config.js");
 const { sonarUp, sonarStatus, sonarDown, ensureComposeFile } = await import("../src/sonar/manager.js");
 
-function mockConfig(host = "http://localhost:9000") {
-  loadConfig.mockResolvedValue({ config: { sonarqube: { host } } });
+function mockConfig(host = "http://localhost:9000", extraSonar = {}) {
+  loadConfig.mockResolvedValue({
+    config: {
+      sonarqube: {
+        host,
+        ...extraSonar
+      }
+    }
+  });
 }
 
 function mockCurlReachable() {
@@ -76,10 +83,33 @@ describe("sonarUp", () => {
     expect(curlCall[1]).toContain("http://sonar.internal:9000/api/system/status");
     expect(result.stdout).toContain("sonar.internal:9000");
   });
+
+  it("uses configured healthcheck timeout", async () => {
+    mockConfig("http://localhost:9000", { timeouts: { healthcheck_seconds: 12 } });
+    mockCurlReachable();
+
+    await sonarUp();
+
+    const curlCall = runCommand.mock.calls.find(([cmd]) => cmd === "curl");
+    expect(curlCall[1]).toContain("--max-time");
+    expect(curlCall[1]).toContain("12");
+  });
+
+  it("does not start docker when sonarqube.external is true", async () => {
+    mockConfig("http://sonar.internal:9000", { external: true });
+    mockCurlReachable();
+
+    const result = await sonarUp();
+
+    expect(result.exitCode).toBe(0);
+    const dockerCalls = runCommand.mock.calls.filter(([cmd]) => cmd === "docker");
+    expect(dockerCalls).toHaveLength(0);
+  });
 });
 
 describe("sonarStatus", () => {
   it("returns container status when karajan-sonarqube is running", async () => {
+    mockConfig();
     runCommand.mockResolvedValue({ exitCode: 0, stdout: "Up 2 hours", stderr: "" });
 
     const result = await sonarStatus();
@@ -113,6 +143,15 @@ describe("sonarStatus", () => {
 
     expect(result.stdout).toBe("");
   });
+
+  it("uses configured container_name", async () => {
+    mockConfig("http://localhost:9000", { container_name: "custom-sonarqube" });
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "Up 2 hours", stderr: "" });
+
+    await sonarStatus();
+
+    expect(runCommand.mock.calls[0][1]).toContain("name=custom-sonarqube");
+  });
 });
 
 describe("sonarDown", () => {
@@ -132,5 +171,30 @@ describe("ensureComposeFile", () => {
     const result = await ensureComposeFile();
     expect(typeof result).toBe("string");
     expect(result).toContain("docker-compose.sonar.yml");
+  });
+
+  it("writes configured container name, network and volumes into compose file", async () => {
+    const fs = await import("node:fs/promises");
+    mockConfig("http://localhost:9000", {
+      container_name: "sonar-custom",
+      network: "sonar_custom_net",
+      volumes: {
+        data: "sonar_custom_data",
+        logs: "sonar_custom_logs",
+        extensions: "sonar_custom_extensions"
+      }
+    });
+
+    await ensureComposeFile();
+
+    const writeCall = fs.default.writeFile.mock.calls[0];
+    const content = writeCall[1];
+    expect(content).toContain("container_name: sonar-custom");
+    expect(content).toContain("- sonar_custom_data:/opt/sonarqube/data");
+    expect(content).toContain("- sonar_custom_logs:/opt/sonarqube/logs");
+    expect(content).toContain("- sonar_custom_extensions:/opt/sonarqube/extensions");
+    expect(content).toContain("- sonar_custom_net");
+    expect(content).toContain("sonar_custom_net:");
+    expect(content).toContain("name: sonar_custom_net");
   });
 });

--- a/tests/sonar-scanner-run.test.js
+++ b/tests/sonar-scanner-run.test.js
@@ -282,4 +282,47 @@ describe("runSonarScan", () => {
     const scannerEnv = runCommand.mock.calls[0][1].find((x) => x.startsWith("SONAR_SCANNER_OPTS="));
     expect(scannerEnv).toContain("-Dsonar.javascript.lcov.reportPaths=package.json");
   });
+
+  it("uses configured Sonar network and scanner timeout", async () => {
+    const config = {
+      sonarqube: {
+        host: "http://sonar.internal:9000",
+        token: "token-123",
+        network: "custom_sonar_net",
+        timeouts: {
+          scanner_ms: 123456
+        },
+        scanner: { sources: "src" }
+      }
+    };
+    sonarUp.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+
+    const result = await runSonarScan(config, "my-key");
+
+    expect(result.ok).toBe(true);
+    expect(runCommand.mock.calls[0][1]).toContain("--network");
+    expect(runCommand.mock.calls[0][1]).toContain("custom_sonar_net");
+    expect(runCommand.mock.calls[0][2]).toEqual({ timeout: 123456 });
+  });
+
+  it("does not force custom docker network when sonarqube.external=true", async () => {
+    const config = {
+      sonarqube: {
+        host: "http://sonar.external:9000",
+        token: "token-123",
+        external: true,
+        network: "custom_sonar_net",
+        scanner: { sources: "src" }
+      }
+    };
+    sonarUp.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+
+    const result = await runSonarScan(config, "my-key");
+
+    expect(result.ok).toBe(true);
+    expect(runCommand.mock.calls[0][1]).not.toContain("--network");
+    expect(runCommand.mock.calls[0][1]).not.toContain("custom_sonar_net");
+  });
 });


### PR DESCRIPTION
## Summary
- Extract hardcoded SonarQube container name, volumes, network, and timeouts into `.karajan.yml` config
- Support `sonarqube.external=true` with host URL to skip Docker management and connect to external instances
- 37 sonar-related tests passing

## Test plan
- [x] `npx vitest run tests/sonar-*.test.js` — 37 tests passing
- [ ] Manual: test with custom container_name in .karajan.yml
- [ ] Manual: test with sonarqube.external=true pointing to remote SonarQube

Closes KJC-TSK-0044