### PR TITLE
feat(roles): export RefactorerRole and verify template

### DIFF
--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -1,6 +1,7 @@
 export { BaseRole, ROLE_EVENTS, resolveRoleMdPath, loadFirstExisting } from "./base-role.js";
 export { PlannerRole } from "./planner-role.js";
 export { ReviewerRole } from "./reviewer-role.js";
+export { RefactorerRole } from "./refactorer-role.js";
 export { CommiterRole } from "./commiter-role.js";
 export { CoderRole } from "./coder-role.js";
 export { SonarRole } from "./sonar-role.js";

--- a/tests/role-md-resolution.test.js
+++ b/tests/role-md-resolution.test.js
@@ -87,7 +87,7 @@ describe("Role .md file resolution", () => {
 });
 
 describe("Built-in role templates exist", () => {
-  const roles = ["coder", "reviewer", "researcher", "planner", "tester", "security", "commiter", "solomon", "karajan", "sonar"];
+  const roles = ["coder", "reviewer", "refactorer", "researcher", "planner", "tester", "security", "commiter", "solomon", "karajan", "sonar"];
 
   for (const roleName of roles) {
     it(`templates/roles/${roleName}.md exists and is non-empty`, async () => {


### PR DESCRIPTION
## Summary
- Export `RefactorerRole` from `src/roles/index.js` (class already existed but was not exported)
- Add `refactorer` to built-in template existence test

## Test plan
- [x] `npx vitest run` — 691 tests passing
- [x] `templates/roles/refactorer.md` template exists and is non-empty

Closes KJC-TSK-0045