### PR TITLE
feat(budget): add per-model pricing for cost tracking

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -119,15 +119,40 @@ export function getConfigPath() {
   return path.join(getKarajanHome(), "kj.config.yml");
 }
 
+async function loadProjectPricingOverrides(projectDir = process.cwd()) {
+  const projectConfigPath = path.join(projectDir, ".karajan.yml");
+  if (!(await exists(projectConfigPath))) {
+    return null;
+  }
+
+  const raw = await fs.readFile(projectConfigPath, "utf8");
+  const parsed = yaml.load(raw) || {};
+  const pricing = parsed?.budget?.pricing;
+  if (!pricing || typeof pricing !== "object") {
+    return null;
+  }
+
+  return pricing;
+}
+
 export async function loadConfig() {
   const configPath = getConfigPath();
+  const projectPricing = await loadProjectPricingOverrides();
   if (!(await exists(configPath))) {
-    return { config: DEFAULTS, path: configPath, exists: false };
+    const baseDefaults = mergeDeep(DEFAULTS, {});
+    if (projectPricing) {
+      baseDefaults.budget = mergeDeep(baseDefaults.budget || {}, { pricing: projectPricing });
+    }
+    return { config: baseDefaults, path: configPath, exists: false };
   }
 
   const raw = await fs.readFile(configPath, "utf8");
   const parsed = yaml.load(raw) || {};
-  return { config: mergeDeep(DEFAULTS, parsed), path: configPath, exists: true };
+  const merged = mergeDeep(DEFAULTS, parsed);
+  if (projectPricing) {
+    merged.budget = mergeDeep(merged.budget || {}, { pricing: projectPricing });
+  }
+  return { config: merged, path: configPath, exists: true };
 }
 
 export async function writeConfig(configPath, config) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -93,7 +93,7 @@ function getRepeatThreshold(config) {
   return 2;
 }
 
-function extractUsageMetrics(result) {
+function extractUsageMetrics(result, defaultModel = null) {
   const usage = result?.usage || result?.metrics || {};
   const tokens_in =
     result?.tokens_in ??
@@ -111,10 +111,16 @@ function extractUsageMetrics(result) {
     result?.cost_usd ??
     usage?.cost_usd ??
     usage?.usd_cost ??
-    usage?.cost ??
-    0;
+    usage?.cost;
+  const model =
+    result?.model ??
+    usage?.model ??
+    usage?.model_name ??
+    usage?.model_id ??
+    defaultModel ??
+    null;
 
-  return { tokens_in, tokens_out, cost_usd };
+  return { tokens_in, tokens_out, cost_usd, model };
 }
 
 async function runReviewerWithFallback({ reviewerName, config, logger, prompt, session, iteration, onOutput, onAttemptResult }) {
@@ -301,7 +307,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const coder = createAgent(coderRole.provider, config, logger);
   const startedAt = Date.now();
   const eventBase = { sessionId: null, iteration: 0, stage: null, startedAt };
-  const budgetTracker = new BudgetTracker();
+  const budgetTracker = new BudgetTracker({ pricing: config?.budget?.pricing });
   const budgetLimit = Number(config?.max_budget_usd);
   const hasBudgetLimit = Number.isFinite(budgetLimit) && budgetLimit >= 0;
   const warnThresholdPct = Number(config?.budget?.warn_threshold_pct ?? 80);
@@ -310,8 +316,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     return budgetTracker.summary();
   }
 
-  function trackBudget({ role, provider, result }) {
-    const metrics = extractUsageMetrics(result);
+  function trackBudget({ role, provider, model, result }) {
+    const metrics = extractUsageMetrics(result, model);
     budgetTracker.record({ role, provider, ...metrics });
 
     if (!hasBudgetLimit) return;
@@ -387,6 +393,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     trackBudget({
       role: "researcher",
       provider: config?.roles?.researcher?.provider || coderRole.provider,
+      model: config?.roles?.researcher?.model || coderRole.model,
       result: researchOutput
     });
 
@@ -428,7 +435,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       plannerPromptParts.push("", "## Research findings", JSON.stringify(researchContext, null, 2));
     }
     const plannerResult = await planner.runTask({ prompt: plannerPromptParts.join("\n"), role: "planner" });
-    trackBudget({ role: "planner", provider: plannerRole.provider, result: plannerResult });
+    trackBudget({ role: "planner", provider: plannerRole.provider, model: plannerRole.model, result: plannerResult });
     if (!plannerResult.ok) {
       await markSessionStatus(session, "failed");
       const details = plannerResult.error || plannerResult.output || `exitCode=${plannerResult.exitCode ?? "unknown"}`;
@@ -534,7 +541,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       }));
     };
     const coderResult = await coder.runTask({ prompt: coderPrompt, onOutput: coderOnOutput, role: "coder" });
-    trackBudget({ role: "coder", provider: coderRole.provider, result: coderResult });
+    trackBudget({ role: "coder", provider: coderRole.provider, model: coderRole.model, result: coderResult });
 
     if (!coderResult.ok) {
       await markSessionStatus(session, "failed");
@@ -584,7 +591,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         onOutput: refactorerOnOutput,
         role: "refactorer"
       });
-      trackBudget({ role: "refactorer", provider: refactorerRole.provider, result: refactorResult });
+      trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refactorResult });
       if (!refactorResult.ok) {
         await markSessionStatus(session, "failed");
         const details = refactorResult.error || refactorResult.output || `exitCode=${refactorResult.exitCode ?? "unknown"}`;
@@ -828,7 +835,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       iteration: i,
       onOutput: reviewerOnOutput,
       onAttemptResult: ({ reviewer, result }) => {
-        trackBudget({ role: "reviewer", provider: reviewer, result });
+        trackBudget({ role: "reviewer", provider: reviewer, model: reviewerRole.model, result });
       }
     });
 
@@ -944,6 +951,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         trackBudget({
           role: "tester",
           provider: config?.roles?.tester?.provider || coderRole.provider,
+          model: config?.roles?.tester?.model || coderRole.model,
           result: testerOutput
         });
 
@@ -1009,6 +1017,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         trackBudget({
           role: "security",
           provider: config?.roles?.security?.provider || coderRole.provider,
+          model: config?.roles?.security?.model || coderRole.model,
           result: securityOutput
         });
 

--- a/src/utils/budget.js
+++ b/src/utils/budget.js
@@ -1,3 +1,5 @@
+import { calculateUsageCostUsd, DEFAULT_MODEL_PRICING, mergePricing } from "./pricing.js";
+
 function toSafeNumber(value) {
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return 0;
@@ -26,18 +28,30 @@ function addToBreakdown(map, key, entry) {
 }
 
 export class BudgetTracker {
-  constructor() {
+  constructor(options = {}) {
     this.entries = [];
+    this.pricing = mergePricing(DEFAULT_MODEL_PRICING, options.pricing || {});
   }
 
-  record({ role, provider, tokens_in, tokens_out, cost_usd } = {}) {
+  record({ role, provider, model, tokens_in, tokens_out, cost_usd } = {}) {
+    const safeTokensIn = toSafeNumber(tokens_in);
+    const safeTokensOut = toSafeNumber(tokens_out);
+    const hasExplicitCost = cost_usd !== undefined && cost_usd !== null && cost_usd !== "";
+    const modelName = model || provider || null;
+    const computedCost = calculateUsageCostUsd({
+      model: modelName,
+      tokens_in: safeTokensIn,
+      tokens_out: safeTokensOut,
+      pricing: this.pricing
+    });
     const entry = {
       role: role || "unknown",
       provider: provider || "unknown",
+      model: modelName,
       timestamp: new Date().toISOString(),
-      tokens_in: toSafeNumber(tokens_in),
-      tokens_out: toSafeNumber(tokens_out),
-      cost_usd: roundUsd(cost_usd)
+      tokens_in: safeTokensIn,
+      tokens_out: safeTokensOut,
+      cost_usd: roundUsd(hasExplicitCost ? cost_usd : computedCost)
     };
     this.entries.push(entry);
     return entry;

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -49,4 +49,29 @@ describe("BudgetTracker", () => {
     expect(summary.breakdown_by_role.coder.tokens_in).toBe(15);
     expect(summary.breakdown_by_role.reviewer.tokens_out).toBe(7);
   });
+
+  it("calculates cost from model pricing when cost_usd is missing", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", model: "codex/o4-mini", tokens_in: 2000000, tokens_out: 1000000 });
+
+    expect(tracker.total()).toEqual({
+      tokens_in: 2000000,
+      tokens_out: 1000000,
+      cost_usd: 7
+    });
+  });
+
+  it("prefers explicit cost_usd over calculated pricing", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", model: "codex/o4-mini", tokens_in: 2000000, tokens_out: 1000000, cost_usd: 0.99 });
+
+    expect(tracker.total().cost_usd).toBe(0.99);
+  });
+
+  it("supports pricing overrides through constructor options", () => {
+    const tracker = new BudgetTracker({ pricing: { "codex/o4-mini": { input_per_million: 2, output_per_million: 3 } } });
+    tracker.record({ role: "coder", provider: "codex", model: "codex/o4-mini", tokens_in: 500000, tokens_out: 500000 });
+
+    expect(tracker.total().cost_usd).toBe(2.5);
+  });
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,5 +1,20 @@
-import { describe, expect, it } from "vitest";
-import { applyRunOverrides, resolveRole, validateConfig } from "../src/config.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyRunOverrides, loadConfig, resolveRole, validateConfig } from "../src/config.js";
+
+const originalCwd = process.cwd();
+const originalKjHome = process.env.KJ_HOME;
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  if (originalKjHome === undefined) {
+    delete process.env.KJ_HOME;
+  } else {
+    process.env.KJ_HOME = originalKjHome;
+  }
+});
 
 describe("applyRunOverrides", () => {
   it("overrides review mode and base branch", () => {
@@ -117,5 +132,32 @@ describe("applyRunOverrides", () => {
     expect(() => validateConfig(config, "plan")).toThrow(
       "Missing provider for required role 'planner'. Set 'roles.planner.provider' or pass '--planner <name>'"
     );
+  });
+});
+
+describe("loadConfig", () => {
+  it("merges budget.pricing overrides from project .karajan.yml", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-config-"));
+    const kjHome = path.join(tmpDir, "home");
+    await fs.mkdir(kjHome, { recursive: true });
+    await fs.writeFile(
+      path.join(kjHome, "kj.config.yml"),
+      `budget:\n  pricing:\n    codex/o4-mini:\n      input_per_million: 1\n      output_per_million: 2\n`,
+      "utf8"
+    );
+    await fs.writeFile(
+      path.join(tmpDir, ".karajan.yml"),
+      `budget:\n  pricing:\n    codex/o4-mini:\n      output_per_million: 5\n`,
+      "utf8"
+    );
+
+    process.chdir(tmpDir);
+    process.env.KJ_HOME = kjHome;
+
+    const { config } = await loadConfig();
+    expect(config.budget.pricing["codex/o4-mini"]).toEqual({
+      input_per_million: 1,
+      output_per_million: 5
+    });
   });
 });

--- a/tests/orchestrator-budget.test.js
+++ b/tests/orchestrator-budget.test.js
@@ -194,4 +194,59 @@ describe("orchestrator budget integration", () => {
     expect(endEvent.detail.reason).toBe("budget_exceeded");
     expect(endEvent.detail.budget.total_cost_usd).toBe(0.2);
   });
+
+  it("auto-calculates cost when only tokens and model are reported", async () => {
+    const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
+    evaluateTddPolicy.mockReturnValue({
+      ok: true,
+      reason: "pass",
+      sourceFiles: ["a.js"],
+      testFiles: ["a.test.js"],
+      message: "OK"
+    });
+
+    createAgent.mockImplementation((name) => {
+      if (name === "codex") {
+        return {
+          runTask: vi.fn().mockResolvedValue({
+            ok: true,
+            output: "",
+            usage: { tokens_in: 1000000, tokens_out: 1000000, model: "codex/o4-mini" }
+          })
+        };
+      }
+      return {
+        reviewTask: vi.fn().mockResolvedValue({
+          ok: true,
+          output: REVIEW_APPROVED
+        })
+      };
+    });
+
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (event) => events.push(event));
+
+    const config = {
+      coder: "codex",
+      reviewer: "claude",
+      review_mode: "standard",
+      max_iterations: 1,
+      max_budget_usd: 5,
+      review_rules: "./review-rules.md",
+      base_branch: "main",
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: false },
+      git: { auto_commit: false, auto_push: false, auto_pr: false },
+      session: { max_total_minutes: 120, fail_fast_repeats: 2 },
+      reviewer_options: { retries: 0, fallback_reviewer: null },
+      output: { log_level: "info" }
+    };
+
+    const result = await runFlow({ task: "budget model pricing", config, logger, emitter });
+    expect(result.approved).toBe(true);
+
+    const endEvent = events.find((e) => e.type === "session:end");
+    expect(endEvent.detail.budget.total_cost_usd).toBe(5.5);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `DEFAULT_PRICING` table with input/output token costs per 1M tokens for major models
- Auto-calculate `cost_usd` when agents report `tokens_in`/`tokens_out` without cost
- Support pricing overrides via `.karajan.yml` `budget.pricing` section
- 16 tests covering budget, config, and orchestrator pricing integration

## Test plan
- [x] `npx vitest run tests/budget.test.js tests/config.test.js tests/orchestrator-budget.test.js` — 16 tests passing
- [ ] Manual: verify cost display in session summary with real agents

Closes KJC-TSK-0048