### PR TITLE
feat(report): implement kj report with session export

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -123,6 +123,8 @@ program
   .command("report")
   .description("Show latest session report")
   .option("--list", "List session ids")
+  .option("--session-id <id>", "Show report for a specific session ID")
+  .option("--format <type>", "Output format: text|json", "text")
   .action(async (flags) => {
     await reportCommand(flags);
   });

--- a/src/commands/report.js
+++ b/src/commands/report.js
@@ -1,8 +1,197 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { exists } from "../utils/fs.js";
 import { getSessionRoot } from "../utils/paths.js";
 
-export async function reportCommand({ list = false }) {
+function parseBudgetFromActivityLog(logText) {
+  if (!logText) {
+    return { consumed_usd: null, limit_usd: null };
+  }
+
+  const regex = /Budget:\s*\$([0-9]+(?:\.[0-9]+)?)\s*\/\s*\$([0-9]+(?:\.[0-9]+)?)/g;
+  let match;
+  let last = null;
+  while ((match = regex.exec(logText)) !== null) {
+    last = match;
+  }
+
+  if (!last) {
+    return { consumed_usd: null, limit_usd: null };
+  }
+
+  return {
+    consumed_usd: Number(last[1]),
+    limit_usd: Number(last[2])
+  };
+}
+
+function summarizeIterations(checkpoints = []) {
+  const byIteration = new Map();
+  for (const checkpoint of checkpoints) {
+    const iteration = Number(checkpoint?.iteration);
+    if (!Number.isFinite(iteration) || iteration <= 0) continue;
+
+    if (!byIteration.has(iteration)) {
+      byIteration.set(iteration, {
+        iteration,
+        coder_runs: 0,
+        reviewer_attempts: 0,
+        reviewer_approved: null
+      });
+    }
+
+    const item = byIteration.get(iteration);
+    if (checkpoint.stage === "coder") {
+      item.coder_runs += 1;
+    } else if (checkpoint.stage === "reviewer-attempt") {
+      item.reviewer_attempts += 1;
+    } else if (checkpoint.stage === "reviewer") {
+      item.reviewer_approved = Boolean(checkpoint.approved);
+    }
+  }
+
+  return [...byIteration.values()].sort((a, b) => a.iteration - b.iteration);
+}
+
+function summarizePlan(checkpoints = []) {
+  const stages = checkpoints
+    .map((checkpoint) => checkpoint.stage)
+    .filter((stage) => typeof stage === "string" && stage.length > 0);
+
+  const uniqueOrdered = [];
+  for (const stage of stages) {
+    if (uniqueOrdered[uniqueOrdered.length - 1] !== stage) {
+      uniqueOrdered.push(stage);
+    }
+  }
+
+  return uniqueOrdered;
+}
+
+function summarizeSonar(checkpoints = []) {
+  const sonarPoints = checkpoints
+    .filter((checkpoint) => checkpoint.stage === "sonar" && typeof checkpoint.open_issues === "number")
+    .map((checkpoint) => checkpoint.open_issues);
+
+  if (sonarPoints.length === 0) {
+    return { initial: null, final: null, resolved: 0 };
+  }
+
+  const initial = sonarPoints[0];
+  const final = sonarPoints[sonarPoints.length - 1];
+  return {
+    initial,
+    final,
+    resolved: Math.max(initial - final, 0)
+  };
+}
+
+function summarizeCommits(session, checkpoints = []) {
+  const idsFromSession = Array.isArray(session?.git?.commits)
+    ? session.git.commits.filter((item) => typeof item === "string" && item.length > 0)
+    : [];
+
+  const idsFromCheckpoints = checkpoints
+    .filter((checkpoint) => checkpoint.stage === "git-commit" && checkpoint.committed && checkpoint.commit)
+    .map((checkpoint) => checkpoint.commit)
+    .filter((item) => typeof item === "string" && item.length > 0);
+
+  const ids = [...new Set([...idsFromSession, ...idsFromCheckpoints])];
+  if (ids.length > 0) {
+    return { count: ids.length, ids };
+  }
+
+  const committedCount = checkpoints.filter(
+    (checkpoint) => checkpoint.stage === "git-commit" && checkpoint.committed
+  ).length;
+
+  return { count: committedCount, ids: [] };
+}
+
+async function readActivityLog(sessionDir) {
+  const file = path.join(sessionDir, "activity.log");
+  if (!(await exists(file))) {
+    return "";
+  }
+
+  return fs.readFile(file, "utf8");
+}
+
+async function buildReport(dir, sessionId) {
+  const sessionDir = path.join(dir, sessionId);
+  const sessionFile = path.join(sessionDir, "session.json");
+  if (!(await exists(sessionFile))) {
+    throw new Error(`Session not found: ${sessionId}`);
+  }
+  const content = await fs.readFile(sessionFile, "utf8");
+  const session = JSON.parse(content);
+  const checkpoints = Array.isArray(session.checkpoints) ? session.checkpoints : [];
+  const activityLog = await readActivityLog(sessionDir);
+
+  const sonar = summarizeSonar(checkpoints);
+  const budget = parseBudgetFromActivityLog(activityLog);
+  const commits = summarizeCommits(session, checkpoints);
+
+  return {
+    session_id: session.id,
+    task_description: session.task || "",
+    plan_executed: summarizePlan(checkpoints),
+    iterations: summarizeIterations(checkpoints),
+    sonar_issues_resolved: {
+      initial_open_issues: sonar.initial,
+      final_open_issues: sonar.final,
+      resolved: sonar.resolved
+    },
+    budget_consumed: budget,
+    commits_generated: commits,
+    status: session.status || "unknown"
+  };
+}
+
+function printTextReport(report) {
+  const budgetText =
+    typeof report.budget_consumed?.consumed_usd === "number"
+      ? `$${report.budget_consumed.consumed_usd.toFixed(2)}${
+          typeof report.budget_consumed?.limit_usd === "number"
+            ? ` / $${report.budget_consumed.limit_usd.toFixed(2)}`
+            : ""
+        }`
+      : "N/A";
+
+  const planText = report.plan_executed.length > 0 ? report.plan_executed.join(" -> ") : "N/A";
+  const iterationText =
+    report.iterations.length > 0
+      ? report.iterations
+          .map(
+            (item) =>
+              `#${item.iteration} coder=${item.coder_runs} reviewer_attempts=${item.reviewer_attempts} approved=${item.reviewer_approved}`
+          )
+          .join("\n")
+      : "N/A";
+  const commitsText =
+    report.commits_generated.ids.length > 0
+      ? `${report.commits_generated.count} (${report.commits_generated.ids.join(", ")})`
+      : String(report.commits_generated.count);
+
+  console.log(`Session: ${report.session_id}`);
+  console.log(`Status: ${report.status}`);
+  console.log("Task Description:");
+  console.log(report.task_description || "N/A");
+  console.log("Plan Executed:");
+  console.log(planText);
+  console.log("Iterations (Coder/Reviewer):");
+  console.log(iterationText);
+  console.log("Sonar Issues Resolved:");
+  console.log(
+    `initial=${report.sonar_issues_resolved.initial_open_issues ?? "N/A"} final=${report.sonar_issues_resolved.final_open_issues ?? "N/A"} resolved=${report.sonar_issues_resolved.resolved}`
+  );
+  console.log("Budget Consumed:");
+  console.log(budgetText);
+  console.log("Commits Generated:");
+  console.log(commitsText);
+}
+
+export async function reportCommand({ list = false, sessionId = null, format = "text" }) {
   const dir = getSessionRoot();
   if (!(await exists(dir))) {
     console.log("No reports yet");
@@ -15,12 +204,21 @@ export async function reportCommand({ list = false }) {
     return;
   }
 
-  const last = entries.sort().at(-1);
-  if (!last) {
+  const ids = [...entries].sort();
+  const selectedSessionId = sessionId || ids.at(-1);
+  if (!selectedSessionId) {
     console.log("No reports yet");
     return;
   }
+  if (sessionId && !ids.includes(sessionId)) {
+    throw new Error(`Session not found: ${sessionId}`);
+  }
 
-  const content = await fs.readFile(path.join(dir, last, "session.json"), "utf8");
-  console.log(content);
+  const report = await buildReport(dir, selectedSessionId);
+  if (format === "json") {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  printTextReport(report);
 }

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -189,9 +189,13 @@ export async function handleToolCall(name, args, server, extra) {
   }
 
   if (name === "kj_report") {
+    const commandArgs = [];
+    if (a.list) commandArgs.push("--list");
+    if (a.sessionId) commandArgs.push("--session-id", String(a.sessionId));
+    if (a.format) commandArgs.push("--format", String(a.format));
     return runKjCommand({
       command: "report",
-      commandArgs: a.list ? ["--list"] : [],
+      commandArgs,
       options: a
     });
   }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -107,6 +107,8 @@ export const tools = [
       type: "object",
       properties: {
         list: { type: "boolean" },
+        sessionId: { type: "string" },
+        format: { type: "string", enum: ["text", "json"] },
         kjHome: { type: "string" }
       }
     }

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -289,6 +289,15 @@ describe("mcp/server-handlers", () => {
       });
     });
 
+    it("routes kj_report with sessionId and json format", async () => {
+      await handleToolCall("kj_report", { sessionId: "s_123", format: "json" }, mockServer, {});
+      expect(runKjCommand).toHaveBeenCalledWith({
+        command: "report",
+        commandArgs: ["--session-id", "s_123", "--format", "json"],
+        options: { sessionId: "s_123", format: "json" }
+      });
+    });
+
     it("routes kj_code with task arg", async () => {
       await handleToolCall("kj_code", { task: "Fix bug" }, mockServer, {});
       expect(runKjCommand).toHaveBeenCalledWith({

--- a/tests/mcp-tools-schema.test.js
+++ b/tests/mcp-tools-schema.test.js
@@ -9,4 +9,12 @@ describe("MCP tools schema", () => {
     expect(planTool.inputSchema?.properties?.coder?.type).toBe("string");
     expect(planTool.inputSchema?.properties?.coderModel?.type).toBe("string");
   });
+
+  it("exposes sessionId and format fields for kj_report", () => {
+    const reportTool = tools.find((tool) => tool.name === "kj_report");
+
+    expect(reportTool).toBeDefined();
+    expect(reportTool.inputSchema?.properties?.sessionId?.type).toBe("string");
+    expect(reportTool.inputSchema?.properties?.format?.enum).toEqual(["text", "json"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `kj report` command that generates full session reports
- Report includes: task, plan, iterations (coder/reviewer), sonar issues, budget consumed, commits
- Support `--format json` for machine-readable output
- Register `kj_report` in MCP tools with schema and handler

## Test plan
- [x] MCP schema and handler tests passing
- [ ] Manual: `kj report` after a completed session
- [ ] Manual: `kj report --format json --session-id <id>`

Closes KJC-TSK-0046