### PR TITLE
chore: release prep - package metadata, CHANGELOG, SECURITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `package.json` metadata for npm publish (repository, keywords, engines, author, license, files)
+- `SECURITY.md` with vulnerability reporting policy
+- `CHANGELOG.md`
+- Pre-commit hook blocking LLM attribution in commits (`.githooks/pre-commit`)
+
+## [0.2.0] - 2026-02-27
+
+### Added
+- Per-model pricing table for accurate budget tracking in USD (#49)
+- `kj report` command with session export and `--format json` (#50)
+- Model selection flags `--coder-model`, `--reviewer-model`, `--planner-model` per role (#45)
+- Planning-game client with timeout, network error, and JSON parse handling (#46)
+- `buildTaskPrompt` and `updateCardOnCompletion` in planning-game adapter (#46)
+- Configurable SonarQube settings: container name, volumes, network, timeouts (#47)
+- Support for external SonarQube with `sonarqube.external=true` (#47)
+- `RefactorerRole` export and template verification (#48)
+
+### Fixed
+- `coderModel` flag no longer leaks into other roles' model selection (#45)
+
+## [0.1.0] - 2026-02-24
+
+### Added
+- **Core orchestrator**: coder -> sonar -> reviewer loop with configurable iterations
+- **CLI commands**: `init`, `config`, `run`, `code`, `review`, `scan`, `doctor`, `plan`, `resume`, `sonar`
+- **4 AI agents**: Claude, Codex, Gemini, Aider with auto-detection
+- **10 pipeline roles**: Planner, Coder, Refactorer, Reviewer, Tester, Security, Researcher, Sonar, Solomon, Commiter
+- **BaseRole abstraction** with standardized lifecycle (init -> execute -> report)
+- **Role .md templates** with custom instruction support per project
+- **SonarQube integration**: Docker management, quality gates, enforcement profiles
+- **TDD-by-default** methodology with test change enforcement
+- **Review profiles**: standard, strict, paranoid, relaxed, custom
+- **Budget tracking**: token and cost tracking per session
+- **Planning Game MCP integration**: task context and completion updates
+- **MCP server** with 10 tools and real-time progress notifications
+- **Session management**: pause/resume, fail-fast detection, activity logging
+- **Git automation**: auto-commit, auto-push, auto-PR, auto-rebase
+- **Streaming output**: real-time agent output in CLI and MCP
+- **Solomon arbitration**: conflict resolution between AI agents
+- **Interactive installer**: one-command setup with multi-instance support
+- **CI/CD**: GitHub Actions workflow with validation and PR annotations
+- **716+ unit tests** with Vitest
+
+[Unreleased]: https://github.com/manufosela/karajan-code/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/manufosela/karajan-code/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/manufosela/karajan-code/releases/tag/v0.1.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in karajan-code, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. Email **mjfosela@gmail.com** with the subject line: `[SECURITY] karajan-code vulnerability report`
+2. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment** within 48 hours
+- **Assessment** within 7 days
+- **Fix or mitigation** within 30 days for confirmed vulnerabilities
+- Credit in the release notes (unless you prefer anonymity)
+
+### Scope
+
+The following are in scope:
+- Command injection via task descriptions or config values
+- Arbitrary file read/write outside the project directory
+- Credential leakage (API keys, tokens) in logs or reports
+- MCP server vulnerabilities (unauthorized tool execution)
+
+The following are out of scope:
+- Vulnerabilities in third-party AI CLIs (claude, codex, gemini, aider)
+- SonarQube Docker container security (report to SonarSource)
+- Denial of service via resource exhaustion (long-running tasks)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,38 @@
 {
   "name": "karajan-code",
   "version": "0.2.0",
-  "description": "Local multi-agent coding orchestrator",
+  "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
+  "license": "MIT",
+  "author": "Manu Fosela <mjfosela@gmail.com>",
+  "homepage": "https://github.com/manufosela/karajan-code#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manufosela/karajan-code.git"
+  },
+  "bugs": {
+    "url": "https://github.com/manufosela/karajan-code/issues"
+  },
+  "keywords": [
+    "ai",
+    "orchestrator",
+    "code-review",
+    "tdd",
+    "sonarqube",
+    "multi-agent",
+    "mcp",
+    "cli"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "src/",
+    "templates/",
+    "scripts/",
+    "LICENSE",
+    "README.md"
+  ],
   "bin": {
     "kj": "./src/cli.js",
     "karajan-mcp": "./src/mcp/server.js"


### PR DESCRIPTION
## Summary
- Complete `package.json` with repository, keywords, engines, author, license, files for npm publish
- Add `CHANGELOG.md` with v0.1.0 and v0.2.0 history (Keep a Changelog format)
- Add `SECURITY.md` with vulnerability reporting policy

## Test plan
- [x] `npm publish --dry-run` passes with correct tarball contents
- [x] All existing tests still pass (716 tests)

Closes KJC-TSK-0049, KJC-TSK-0050, KJC-TSK-0051