### PR TITLE
feat(serena): optional Serena MCP for token efficiency

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -60,6 +60,7 @@ program
   .option("--enable-tester")
   .option("--enable-security")
   .option("--enable-triage")
+  .option("--enable-serena")
   .option("--mode <name>")
   .option("--max-iterations <n>")
   .option("--max-iteration-minutes <n>")

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -106,7 +106,25 @@ export async function runChecks({ config }) {
     });
   }
 
-  // 7. Review rules / Coder rules
+  // 7. Serena MCP
+  if (config.serena?.enabled) {
+    let serenaOk = false;
+    try {
+      const serenaCheck = await runCommand("serena", ["--version"]);
+      serenaOk = serenaCheck.exitCode === 0;
+    } catch {
+      serenaOk = false;
+    }
+    checks.push({
+      name: "serena",
+      label: "Serena MCP",
+      ok: serenaOk,
+      detail: serenaOk ? "Available" : "Not found (prompts will still include Serena instructions)",
+      fix: serenaOk ? null : "Install Serena: uvx --from git+https://github.com/oraios/serena serena --help"
+    });
+  }
+
+  // 8. Review rules / Coder rules
   const projectDir = config.projectDir || process.cwd();
   const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir));
   const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));

--- a/src/config.js
+++ b/src/config.js
@@ -97,6 +97,7 @@ const DEFAULTS = {
       disabled_rules: ["javascript:S1116", "javascript:S3776"]
     }
   },
+  serena: { enabled: false },
   planning_game: { enabled: false, project_id: null, codeveloper: null },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
@@ -243,6 +244,8 @@ export function applyRunOverrides(config, flags) {
     out.development.require_test_changes = methodology === "tdd";
   }
   if (flags.noSonar || flags.sonar === false) out.sonarqube.enabled = false;
+  out.serena = out.serena || { enabled: false };
+  if (flags.enableSerena !== undefined) out.serena.enabled = Boolean(flags.enableSerena);
   out.planning_game = out.planning_game || {};
   if (flags.pgTask) out.planning_game.enabled = true;
   if (flags.pgProject) out.planning_game.project_id = flags.pgProject;

--- a/src/mcp/run-kj.js
+++ b/src/mcp/run-kj.js
@@ -43,6 +43,7 @@ export async function runKjCommand({ command, commandArgs = [], options = {}, en
   normalizeBoolFlag(options.enableTester, "--enable-tester", args);
   normalizeBoolFlag(options.enableSecurity, "--enable-security", args);
   normalizeBoolFlag(options.enableTriage, "--enable-triage", args);
+  normalizeBoolFlag(options.enableSerena, "--enable-serena", args);
   normalizeBoolFlag(options.autoCommit, "--auto-commit", args);
   normalizeBoolFlag(options.autoPush, "--auto-push", args);
   normalizeBoolFlag(options.autoPr, "--auto-pr", args);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -70,6 +70,7 @@ export const tools = [
         enableTester: { type: "boolean" },
         enableSecurity: { type: "boolean" },
         enableTriage: { type: "boolean" },
+        enableSerena: { type: "boolean" },
         reviewerFallback: { type: "string" },
         reviewerRetries: { type: "number" },
         mode: { type: "string" },

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -258,8 +258,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     const projectDir = config.projectDir || process.cwd();
     const { rules: reviewRules } = await resolveReviewProfile({ mode: config.review_mode, projectDir });
     const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
-    const coderPrompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology });
-    const reviewerPrompt = buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode });
+    const coderPrompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology, serenaEnabled: Boolean(config.serena?.enabled) });
+    const reviewerPrompt = buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode, serenaEnabled: Boolean(config.serena?.enabled) });
 
     const summary = {
       dry_run: true,
@@ -599,7 +599,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       reviewerFeedback: session.last_reviewer_feedback,
       sonarSummary: session.last_sonar_summary,
       coderRules,
-      methodology: config.development?.methodology || "tdd"
+      methodology: config.development?.methodology || "tdd",
+      serenaEnabled: Boolean(config.serena?.enabled)
     });
     const coderOnOutput = ({ stream, line }) => {
       emitProgress(emitter, makeEvent("agent:output", { ...eventBase, stage: "coder" }, {
@@ -892,7 +893,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         task,
         diff,
         reviewRules,
-        mode: config.review_mode
+        mode: config.review_mode,
+        serenaEnabled: Boolean(config.serena?.enabled)
       });
       const reviewerOnOutput = ({ stream, line }) => {
         emitProgress(emitter, makeEvent("agent:output", { ...eventBase, stage: "reviewer" }, {

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -4,13 +4,34 @@ const SUBAGENT_PREAMBLE = [
   "Execute the task directly. Do NOT use any MCP tools. Focus only on coding."
 ].join(" ");
 
-export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd" }) {
+const SUBAGENT_PREAMBLE_SERENA = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Execute the task directly. Focus only on coding."
+].join(" ");
+
+const SERENA_INSTRUCTIONS = [
+  "## Serena MCP — symbol-level code navigation",
+  "You have access to Serena MCP tools for efficient code navigation.",
+  "Prefer these over reading entire files to save tokens:",
+  "- `find_symbol(name)` — locate a function, class, or variable definition",
+  "- `find_referencing_symbols(name)` — find all code that references a symbol",
+  "- `insert_after_symbol(name, code)` — insert code precisely after a symbol",
+  "Use Serena for understanding existing code structure before making changes.",
+  "Fall back to reading files only when Serena tools are not sufficient."
+].join("\n");
+
+export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false }) {
   const sections = [
-    SUBAGENT_PREAMBLE,
+    serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     `Task:\n${task}`,
     "Implement directly in the repository.",
     "Keep changes minimal and production-ready."
   ];
+
+  if (serenaEnabled) {
+    sections.push(SERENA_INSTRUCTIONS);
+  }
 
   if (coderRules) {
     sections.push(`Coder rules (MUST follow):\n${coderRules}`);

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -4,17 +4,42 @@ const SUBAGENT_PREAMBLE = [
   "Do NOT use any MCP tools. Focus only on reviewing the code."
 ].join(" ");
 
-export function buildReviewerPrompt({ task, diff, reviewRules, mode }) {
+const SUBAGENT_PREAMBLE_SERENA = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Focus only on reviewing the code."
+].join(" ");
+
+const SERENA_INSTRUCTIONS = [
+  "## Serena MCP — symbol-level code navigation",
+  "You have access to Serena MCP tools for efficient code review.",
+  "Use these to verify context without reading entire files:",
+  "- `find_symbol(name)` — locate a function, class, or variable definition",
+  "- `find_referencing_symbols(name)` — find all callers/references of a symbol",
+  "Use Serena to check how changed symbols are used across the codebase.",
+  "Fall back to reading files only when Serena tools are not sufficient."
+].join("\n");
+
+export function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false }) {
   const truncatedDiff = diff.length > 12000 ? `${diff.slice(0, 12000)}\n\n[TRUNCATED]` : diff;
 
-  return [
-    SUBAGENT_PREAMBLE,
+  const sections = [
+    serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     `You are a code reviewer in ${mode} mode.`,
     "Return only one valid JSON object and nothing else.",
     "JSON schema:",
-    '{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}',
+    '{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}'
+  ];
+
+  if (serenaEnabled) {
+    sections.push(SERENA_INSTRUCTIONS);
+  }
+
+  sections.push(
     `Task context:\n${task}`,
     `Review rules:\n${reviewRules}`,
     `Git diff:\n${truncatedDiff}`
-  ].join("\n\n");
+  );
+
+  return sections.join("\n\n");
 }

--- a/tests/prompt-coder.test.js
+++ b/tests/prompt-coder.test.js
@@ -92,4 +92,29 @@ describe("buildCoderPrompt", () => {
     expect(result).not.toContain("Sonar summary");
     expect(result).not.toContain("Reviewer blocking feedback");
   });
+
+  it("includes Serena instructions when serenaEnabled is true", () => {
+    const result = buildCoderPrompt({ task: "Navigate code", serenaEnabled: true });
+
+    expect(result).toContain("Serena MCP");
+    expect(result).toContain("find_symbol");
+    expect(result).toContain("find_referencing_symbols");
+    expect(result).toContain("insert_after_symbol");
+    expect(result).not.toContain("Do NOT use any MCP tools");
+  });
+
+  it("does not include Serena instructions by default", () => {
+    const result = buildCoderPrompt({ task: "Normal task" });
+
+    expect(result).not.toContain("Serena MCP");
+    expect(result).not.toContain("find_symbol");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
+
+  it("does not include Serena when serenaEnabled is false", () => {
+    const result = buildCoderPrompt({ task: "Normal task", serenaEnabled: false });
+
+    expect(result).not.toContain("Serena MCP");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
 });

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -93,4 +93,28 @@ describe("buildReviewerPrompt", () => {
     // preamble, mode, JSON instruction, schema, task, rules, diff = at least 7
     expect(sections.length).toBeGreaterThanOrEqual(7);
   });
+
+  it("includes Serena instructions when serenaEnabled is true", () => {
+    const result = buildReviewerPrompt({ ...baseArgs, serenaEnabled: true });
+
+    expect(result).toContain("Serena MCP");
+    expect(result).toContain("find_symbol");
+    expect(result).toContain("find_referencing_symbols");
+    expect(result).not.toContain("Do NOT use any MCP tools");
+  });
+
+  it("does not include Serena instructions by default", () => {
+    const result = buildReviewerPrompt(baseArgs);
+
+    expect(result).not.toContain("Serena MCP");
+    expect(result).not.toContain("find_symbol");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
+
+  it("does not include Serena when serenaEnabled is false", () => {
+    const result = buildReviewerPrompt({ ...baseArgs, serenaEnabled: false });
+
+    expect(result).not.toContain("Serena MCP");
+    expect(result).toContain("Do NOT use any MCP tools");
+  });
 });


### PR DESCRIPTION
## Summary
- Add optional Serena MCP integration (`serena.enabled`) that injects symbol-level navigation instructions into coder and reviewer prompts
- When enabled, prompts suggest using `find_symbol`, `find_referencing_symbols`, and `insert_after_symbol` instead of reading entire files
- `kj_doctor` checks Serena availability when enabled
- Zero behavioral change when disabled (default)

## Changes
- `src/config.js` — `serena: { enabled: false }` in DEFAULTS, `enableSerena` flag support
- `src/prompts/coder.js` — conditional Serena instructions, relaxed MCP preamble when Serena active
- `src/prompts/reviewer.js` — conditional Serena instructions for review context
- `src/orchestrator.js` — pass `serenaEnabled` to prompt builders
- `src/commands/doctor.js` — Serena availability check
- `src/cli.js` / `src/mcp/tools.js` / `src/mcp/run-kj.js` — `--enable-serena` / `enableSerena`

## Test plan
- [x] 3 new coder prompt tests (Serena on/off/default)
- [x] 3 new reviewer prompt tests (Serena on/off/default)
- [x] All 721 tests passing (20 existing prompt tests unaffected)