### PR TITLE
feat(report): chronological trace per pipeline stage

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -131,6 +131,8 @@ program
   .option("--list", "List session ids")
   .option("--session-id <id>", "Show report for a specific session ID")
   .option("--format <type>", "Output format: text|json", "text")
+  .option("--trace", "Show chronological trace of all pipeline stages")
+  .option("--currency <code>", "Display costs in currency: usd|eur", "usd")
   .action(async (flags) => {
     await reportCommand(flags);
   });

--- a/src/commands/report.js
+++ b/src/commands/report.js
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { exists } from "../utils/fs.js";
 import { getSessionRoot } from "../utils/paths.js";
+import { loadConfig } from "../config.js";
 
 function parseBudgetFromActivityLog(logText) {
   if (!logText) {
@@ -132,6 +133,8 @@ async function buildReport(dir, sessionId) {
   const budget = parseBudgetFromActivityLog(activityLog);
   const commits = summarizeCommits(session, checkpoints);
 
+  const budgetTrace = Array.isArray(session.budget?.trace) ? session.budget.trace : [];
+
   return {
     session_id: session.id,
     task_description: session.task || "",
@@ -143,6 +146,7 @@ async function buildReport(dir, sessionId) {
       resolved: sonar.resolved
     },
     budget_consumed: budget,
+    budget_trace: budgetTrace,
     commits_generated: commits,
     status: session.status || "unknown"
   };
@@ -191,7 +195,105 @@ function printTextReport(report) {
   console.log(commitsText);
 }
 
-export async function reportCommand({ list = false, sessionId = null, format = "text" }) {
+function formatDuration(ms) {
+  if (ms === null || ms === undefined) return "-";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainSeconds = (seconds % 60).toFixed(0);
+  return `${minutes}m${remainSeconds}s`;
+}
+
+function padRight(str, len) {
+  const s = String(str);
+  return s.length >= len ? s : s + " ".repeat(len - s.length);
+}
+
+function padLeft(str, len) {
+  const s = String(str);
+  return s.length >= len ? s : " ".repeat(len - s.length) + s;
+}
+
+function convertCost(costUsd, currency, exchangeRate) {
+  if (currency === "eur") return costUsd * exchangeRate;
+  return costUsd;
+}
+
+function formatCost(cost, currency) {
+  const symbol = currency === "eur" ? "\u20AC" : "$";
+  return `${symbol}${cost.toFixed(4)}`;
+}
+
+function printTraceTable(trace, { currency = "usd", exchangeRate = 0.92 } = {}) {
+  if (!trace || trace.length === 0) {
+    console.log("No trace data available.");
+    return;
+  }
+
+  const currencyLabel = currency.toUpperCase();
+
+  const headers = ["#", "Stage", "Provider", "Duration", "Tokens In", "Tokens Out", `Cost ${currencyLabel}`];
+  const rows = trace.map((entry) => {
+    const cost = convertCost(entry.cost_usd, currency, exchangeRate);
+    return [
+      String(entry.index ?? "-"),
+      entry.role,
+      entry.provider || "-",
+      formatDuration(entry.duration_ms),
+      String(entry.tokens_in),
+      String(entry.tokens_out),
+      formatCost(cost, currency)
+    ];
+  });
+
+  const totals = trace.reduce(
+    (acc, entry) => {
+      acc.tokens_in += entry.tokens_in;
+      acc.tokens_out += entry.tokens_out;
+      acc.cost += entry.cost_usd;
+      acc.duration += entry.duration_ms ?? 0;
+      return acc;
+    },
+    { tokens_in: 0, tokens_out: 0, cost: 0, duration: 0 }
+  );
+
+  const totalRow = [
+    "",
+    "TOTAL",
+    "",
+    formatDuration(totals.duration),
+    String(totals.tokens_in),
+    String(totals.tokens_out),
+    formatCost(convertCost(totals.cost, currency, exchangeRate), currency)
+  ];
+
+  const allRows = [headers, ...rows, totalRow];
+  const colWidths = headers.map((_, colIdx) =>
+    Math.max(...allRows.map((row) => String(row[colIdx]).length))
+  );
+
+  const rightAligned = new Set([0, 3, 4, 5, 6]);
+  function formatRow(row) {
+    return row
+      .map((cell, idx) =>
+        rightAligned.has(idx)
+          ? padLeft(cell, colWidths[idx])
+          : padRight(cell, colWidths[idx])
+      )
+      .join("  ");
+  }
+
+  console.log(formatRow(headers));
+  console.log(colWidths.map((w) => "-".repeat(w)).join("  "));
+  for (const row of rows) {
+    console.log(formatRow(row));
+  }
+  console.log(colWidths.map((w) => "-".repeat(w)).join("  "));
+  console.log(formatRow(totalRow));
+}
+
+export async function reportCommand({ list = false, sessionId = null, format = "text", trace = false, currency = "usd" }) {
   const dir = getSessionRoot();
   if (!(await exists(dir))) {
     console.log("No reports yet");
@@ -220,5 +322,19 @@ export async function reportCommand({ list = false, sessionId = null, format = "
     return;
   }
 
+  if (trace) {
+    const { config } = await loadConfig();
+    const cur = currency?.toLowerCase() || config?.budget?.currency || "usd";
+    const rate = config?.budget?.exchange_rate_eur ?? 0.92;
+    console.log(`Session: ${report.session_id}`);
+    console.log(`Status: ${report.status}`);
+    console.log(`Task: ${report.task_description || "N/A"}`);
+    console.log("");
+    printTraceTable(report.budget_trace, { currency: cur, exchangeRate: rate });
+    return;
+  }
+
   printTextReport(report);
 }
+
+export { formatDuration, convertCost, formatCost, printTraceTable, buildReport };

--- a/src/config.js
+++ b/src/config.js
@@ -102,7 +102,9 @@ const DEFAULTS = {
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info" },
   budget: {
-    warn_threshold_pct: 80
+    warn_threshold_pct: 80,
+    currency: "usd",
+    exchange_rate_eur: 0.92
   },
   session: {
     max_iteration_minutes: 15,

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -199,6 +199,8 @@ export async function handleToolCall(name, args, server, extra) {
     if (a.list) commandArgs.push("--list");
     if (a.sessionId) commandArgs.push("--session-id", String(a.sessionId));
     if (a.format) commandArgs.push("--format", String(a.format));
+    if (a.trace) commandArgs.push("--trace");
+    if (a.currency) commandArgs.push("--currency", String(a.currency));
     return runKjCommand({
       command: "report",
       commandArgs,

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -108,13 +108,15 @@ export const tools = [
   },
   {
     name: "kj_report",
-    description: "Read latest or list session reports",
+    description: "Read latest or list session reports. Use trace=true for chronological stage-by-stage breakdown with timing and token usage.",
     inputSchema: {
       type: "object",
       properties: {
         list: { type: "boolean" },
         sessionId: { type: "string" },
         format: { type: "string", enum: ["text", "json"] },
+        trace: { type: "boolean", description: "Show chronological trace of all pipeline stages" },
+        currency: { type: "string", enum: ["usd", "eur"], description: "Display costs in this currency" },
         kjHome: { type: "string" }
       }
     }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -318,12 +318,15 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const warnThresholdPct = Number(config?.budget?.warn_threshold_pct ?? 80);
 
   function budgetSummary() {
-    return budgetTracker.summary();
+    const s = budgetTracker.summary();
+    s.trace = budgetTracker.trace();
+    return s;
   }
 
-  function trackBudget({ role, provider, model, result }) {
+  let stageCounter = 0;
+  function trackBudget({ role, provider, model, result, duration_ms }) {
     const metrics = extractUsageMetrics(result, model);
-    budgetTracker.record({ role, provider, ...metrics });
+    budgetTracker.record({ role, provider, ...metrics, duration_ms, stage_index: stageCounter++ });
 
     if (!hasBudgetLimit) return;
     const totalCost = budgetTracker.total().cost_usd;
@@ -392,12 +395,14 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
     const triage = new TriageRole({ config, logger, emitter });
     await triage.init({ task, sessionId: session.id, iteration: 0 });
+    const triageStart = Date.now();
     const triageOutput = await triage.run({ task });
     trackBudget({
       role: "triage",
       provider: config?.roles?.triage?.provider || coderRole.provider,
       model: config?.roles?.triage?.model || coderRole.model,
-      result: triageOutput
+      result: triageOutput,
+      duration_ms: Date.now() - triageStart
     });
 
     await addCheckpoint(session, { stage: "triage", iteration: 0, ok: triageOutput.ok });
@@ -456,12 +461,14 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
     const researcher = new ResearcherRole({ config, logger, emitter });
     await researcher.init({ task });
+    const researchStart = Date.now();
     const researchOutput = await researcher.run({ task });
     trackBudget({
       role: "researcher",
       provider: config?.roles?.researcher?.provider || coderRole.provider,
       model: config?.roles?.researcher?.model || coderRole.model,
-      result: researchOutput
+      result: researchOutput,
+      duration_ms: Date.now() - researchStart
     });
 
     await addCheckpoint(session, { stage: "researcher", iteration: 0, ok: researchOutput.ok });
@@ -492,6 +499,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       })
     );
     const planner = createAgent(plannerRole.provider, config, logger);
+    const plannerStart = Date.now();
     const plannerPromptParts = [
       "Create an implementation plan for this task.",
       "Return concise numbered steps focused on execution order and risk.",
@@ -502,7 +510,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       plannerPromptParts.push("", "## Research findings", JSON.stringify(researchContext, null, 2));
     }
     const plannerResult = await planner.runTask({ prompt: plannerPromptParts.join("\n"), role: "planner" });
-    trackBudget({ role: "planner", provider: plannerRole.provider, model: plannerRole.model, result: plannerResult });
+    trackBudget({ role: "planner", provider: plannerRole.provider, model: plannerRole.model, result: plannerResult, duration_ms: Date.now() - plannerStart });
     if (!plannerResult.ok) {
       await markSessionStatus(session, "failed");
       const details = plannerResult.error || plannerResult.output || `exitCode=${plannerResult.exitCode ?? "unknown"}`;
@@ -608,8 +616,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         detail: { stream, agent: coderRole.provider }
       }));
     };
+    const coderStart = Date.now();
     const coderResult = await coder.runTask({ prompt: coderPrompt, onOutput: coderOnOutput, role: "coder" });
-    trackBudget({ role: "coder", provider: coderRole.provider, model: coderRole.model, result: coderResult });
+    trackBudget({ role: "coder", provider: coderRole.provider, model: coderRole.model, result: coderResult, duration_ms: Date.now() - coderStart });
 
     if (!coderResult.ok) {
       await markSessionStatus(session, "failed");
@@ -654,12 +663,13 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           detail: { stream, agent: refactorerRole.provider }
         }));
       };
+      const refactorerStart = Date.now();
       const refactorResult = await refactorer.runTask({
         prompt: refactorPrompt,
         onOutput: refactorerOnOutput,
         role: "refactorer"
       });
-      trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refactorResult });
+      trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refactorResult, duration_ms: Date.now() - refactorerStart });
       if (!refactorResult.ok) {
         await markSessionStatus(session, "failed");
         const details = refactorResult.error || refactorResult.output || `exitCode=${refactorResult.exitCode ?? "unknown"}`;
@@ -757,8 +767,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
       const sonarRole = new SonarRole({ config, logger, emitter });
       await sonarRole.init({ iteration: i });
+      const sonarStart = Date.now();
       const sonarOutput = await sonarRole.run();
-      trackBudget({ role: "sonar", provider: "sonar", result: sonarOutput });
+      trackBudget({ role: "sonar", provider: "sonar", result: sonarOutput, duration_ms: Date.now() - sonarStart });
       const sonarResult = sonarOutput.result;
 
       if (!sonarResult.gateStatus && sonarResult.error) {
@@ -902,6 +913,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
           detail: { stream, agent: reviewerRole.provider }
         }));
       };
+      const reviewerStart = Date.now();
       const reviewerExec = await runReviewerWithFallback({
         reviewerName: reviewerRole.provider,
         config,
@@ -911,7 +923,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         iteration: i,
         onOutput: reviewerOnOutput,
         onAttemptResult: ({ reviewer, result }) => {
-          trackBudget({ role: "reviewer", provider: reviewer, model: reviewerRole.model, result });
+          trackBudget({ role: "reviewer", provider: reviewer, model: reviewerRole.model, result, duration_ms: Date.now() - reviewerStart });
         }
       });
 
@@ -1023,12 +1035,14 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
         const tester = new TesterRole({ config, logger, emitter });
         await tester.init({ task, iteration: i });
+        const testerStart = Date.now();
         const testerOutput = await tester.run({ task, diff: postLoopDiff });
         trackBudget({
           role: "tester",
           provider: config?.roles?.tester?.provider || coderRole.provider,
           model: config?.roles?.tester?.model || coderRole.model,
-          result: testerOutput
+          result: testerOutput,
+          duration_ms: Date.now() - testerStart
         });
 
         await addCheckpoint(session, { stage: "tester", iteration: i, ok: testerOutput.ok });
@@ -1089,12 +1103,14 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
         const security = new SecurityRole({ config, logger, emitter });
         await security.init({ task, iteration: i });
+        const securityStart = Date.now();
         const securityOutput = await security.run({ task, diff: postLoopDiff });
         trackBudget({
           role: "security",
           provider: config?.roles?.security?.provider || coderRole.provider,
           model: config?.roles?.security?.model || coderRole.model,
-          result: securityOutput
+          result: securityOutput,
+          duration_ms: Date.now() - securityStart
         });
 
         await addCheckpoint(session, { stage: "security", iteration: i, ok: securityOutput.ok });
@@ -1148,6 +1164,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       if (stageResults.planner?.ok) {
         stageResults.planner.completedSteps = [...(stageResults.planner.steps || [])];
       }
+      session.budget = budgetSummary();
       await markSessionStatus(session, "approved");
       emitProgress(
         emitter,
@@ -1203,6 +1220,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     }
   }
 
+  session.budget = budgetSummary();
   await markSessionStatus(session, "failed");
   emitProgress(
     emitter,

--- a/src/utils/budget.js
+++ b/src/utils/budget.js
@@ -33,7 +33,7 @@ export class BudgetTracker {
     this.pricing = mergePricing(DEFAULT_MODEL_PRICING, options.pricing || {});
   }
 
-  record({ role, provider, model, tokens_in, tokens_out, cost_usd } = {}) {
+  record({ role, provider, model, tokens_in, tokens_out, cost_usd, duration_ms, stage_index } = {}) {
     const safeTokensIn = toSafeNumber(tokens_in);
     const safeTokensOut = toSafeNumber(tokens_out);
     const hasExplicitCost = cost_usd !== undefined && cost_usd !== null && cost_usd !== "";
@@ -53,6 +53,12 @@ export class BudgetTracker {
       tokens_out: safeTokensOut,
       cost_usd: roundUsd(hasExplicitCost ? cost_usd : computedCost)
     };
+    if (duration_ms !== undefined && duration_ms !== null) {
+      entry.duration_ms = toSafeNumber(duration_ms);
+    }
+    if (stage_index !== undefined && stage_index !== null) {
+      entry.stage_index = Number(stage_index);
+    }
     this.entries.push(entry);
     return entry;
   }
@@ -99,5 +105,19 @@ export class BudgetTracker {
       breakdown_by_role: byRole,
       entries: [...this.entries]
     };
+  }
+
+  trace() {
+    return this.entries.map((entry, index) => ({
+      index: entry.stage_index ?? index,
+      role: entry.role,
+      provider: entry.provider,
+      model: entry.model,
+      timestamp: entry.timestamp,
+      duration_ms: entry.duration_ms ?? null,
+      tokens_in: entry.tokens_in,
+      tokens_out: entry.tokens_out,
+      cost_usd: entry.cost_usd
+    }));
   }
 }

--- a/tests/report-trace.test.js
+++ b/tests/report-trace.test.js
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+import { BudgetTracker } from "../src/utils/budget.js";
+import { formatDuration, convertCost, formatCost, printTraceTable } from "../src/commands/report.js";
+
+describe("BudgetTracker trace()", () => {
+  it("returns entries with stage_index and duration_ms", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "triage", provider: "codex", tokens_in: 100, tokens_out: 50, cost_usd: 0.1, duration_ms: 1200, stage_index: 0 });
+    tracker.record({ role: "coder", provider: "codex", tokens_in: 5000, tokens_out: 2000, cost_usd: 1.5, duration_ms: 45000, stage_index: 1 });
+    tracker.record({ role: "reviewer", provider: "claude", tokens_in: 3000, tokens_out: 800, cost_usd: 0.8, duration_ms: 12000, stage_index: 2 });
+
+    const trace = tracker.trace();
+    expect(trace).toHaveLength(3);
+    expect(trace[0]).toEqual({
+      index: 0,
+      role: "triage",
+      provider: "codex",
+      model: "codex",
+      timestamp: expect.any(String),
+      duration_ms: 1200,
+      tokens_in: 100,
+      tokens_out: 50,
+      cost_usd: 0.1
+    });
+    expect(trace[1].index).toBe(1);
+    expect(trace[1].role).toBe("coder");
+    expect(trace[1].duration_ms).toBe(45000);
+    expect(trace[2].index).toBe(2);
+    expect(trace[2].role).toBe("reviewer");
+  });
+
+  it("uses entry index as fallback when stage_index is not set", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "codex", tokens_in: 100, tokens_out: 50, cost_usd: 0.1 });
+    tracker.record({ role: "reviewer", provider: "claude", tokens_in: 200, tokens_out: 100, cost_usd: 0.2 });
+
+    const trace = tracker.trace();
+    expect(trace[0].index).toBe(0);
+    expect(trace[1].index).toBe(1);
+    expect(trace[0].duration_ms).toBeNull();
+  });
+
+  it("returns empty array when no entries recorded", () => {
+    const tracker = new BudgetTracker();
+    expect(tracker.trace()).toEqual([]);
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats milliseconds", () => {
+    expect(formatDuration(500)).toBe("500ms");
+  });
+
+  it("formats seconds", () => {
+    expect(formatDuration(3500)).toBe("3.5s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(125000)).toBe("2m5s");
+  });
+
+  it("returns dash for null/undefined", () => {
+    expect(formatDuration(null)).toBe("-");
+    expect(formatDuration(undefined)).toBe("-");
+  });
+});
+
+describe("convertCost", () => {
+  it("returns USD as-is", () => {
+    expect(convertCost(1.5, "usd", 0.92)).toBe(1.5);
+  });
+
+  it("converts to EUR with exchange rate", () => {
+    expect(convertCost(1.0, "eur", 0.92)).toBeCloseTo(0.92, 6);
+  });
+});
+
+describe("formatCost", () => {
+  it("formats USD with dollar sign", () => {
+    expect(formatCost(1.5, "usd")).toBe("$1.5000");
+  });
+
+  it("formats EUR with euro sign", () => {
+    expect(formatCost(0.92, "eur")).toBe("\u20AC0.9200");
+  });
+});
+
+describe("printTraceTable", () => {
+  it("prints table with headers, rows, and totals", () => {
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+    const trace = [
+      { index: 0, role: "coder", provider: "codex", model: "codex", timestamp: "2026-01-01T00:00:00Z", duration_ms: 30000, tokens_in: 1000, tokens_out: 500, cost_usd: 0.5 },
+      { index: 1, role: "reviewer", provider: "claude", model: "claude", timestamp: "2026-01-01T00:01:00Z", duration_ms: 15000, tokens_in: 800, tokens_out: 200, cost_usd: 0.3 }
+    ];
+
+    printTraceTable(trace, { currency: "usd", exchangeRate: 0.92 });
+
+    expect(logs[0]).toContain("#");
+    expect(logs[0]).toContain("Stage");
+    expect(logs[0]).toContain("Provider");
+    expect(logs[0]).toContain("Duration");
+    expect(logs[0]).toContain("Tokens In");
+    expect(logs[0]).toContain("Cost USD");
+
+    // Data rows
+    expect(logs[2]).toContain("coder");
+    expect(logs[2]).toContain("codex");
+    expect(logs[2]).toContain("30.0s");
+    expect(logs[3]).toContain("reviewer");
+    expect(logs[3]).toContain("claude");
+    expect(logs[3]).toContain("15.0s");
+
+    // Total row
+    const totalRow = logs[logs.length - 1];
+    expect(totalRow).toContain("TOTAL");
+    expect(totalRow).toContain("1800");
+    expect(totalRow).toContain("700");
+    expect(totalRow).toContain("$0.8000");
+
+    console.log.mockRestore();
+  });
+
+  it("prints EUR costs when currency is eur", () => {
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+    const trace = [
+      { index: 0, role: "coder", provider: "codex", model: "codex", timestamp: "2026-01-01T00:00:00Z", duration_ms: 10000, tokens_in: 1000, tokens_out: 500, cost_usd: 1.0 }
+    ];
+
+    printTraceTable(trace, { currency: "eur", exchangeRate: 0.92 });
+
+    expect(logs[0]).toContain("Cost EUR");
+
+    const dataRow = logs[2];
+    expect(dataRow).toContain("\u20AC0.9200");
+
+    console.log.mockRestore();
+  });
+
+  it("handles empty trace", () => {
+    const logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+    printTraceTable([], { currency: "usd", exchangeRate: 0.92 });
+    expect(logs[0]).toContain("No trace data available");
+
+    console.log.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `BudgetTracker` with `duration_ms`, `stage_index`, and `trace()` method
- Record start/end timestamps for every pipeline stage in orchestrator (triage, researcher, planner, coder, refactorer, sonar, reviewer, tester, security)
- Save budget trace to session.json for offline report access
- Add `--trace` flag to `kj report` for formatted chronological table with #, Stage, Provider, Duration, Tokens In/Out, Cost
- Add `--currency eur` flag with configurable `budget.exchange_rate_eur` for EUR conversion
- CLI + MCP support (`kj_report` tool updated with `trace` and `currency` params)
- 14 new tests (735 total)

## Test plan
- [x] All 735 tests pass
- [x] BudgetTracker.trace() returns entries with stage_index and duration_ms
- [x] formatDuration handles ms, seconds, minutes
- [x] convertCost and formatCost handle USD/EUR
- [x] printTraceTable renders headers, data rows, separator, totals
- [x] Empty trace shows "No trace data available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)