### PR TITLE
feat(init): interactive wizard with agent auto-detection

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -28,8 +28,11 @@ program.name("kj").description("Karajan Code CLI").version("0.1.0");
 program
   .command("init")
   .description("Initialize config, review rules and SonarQube")
-  .action(async () => {
-    await withConfig("init", {}, initCommand);
+  .option("--no-interactive", "Skip wizard, use defaults (for CI/scripts)")
+  .action(async (flags) => {
+    await withConfig("init", flags, async ({ config, logger }) => {
+      await initCommand({ logger, flags });
+    });
   });
 
 program

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,17 +1,10 @@
 import { runCommand } from "../utils/process.js";
-import { resolveBin } from "../agents/resolve-bin.js";
 import { exists } from "../utils/fs.js";
 import { getConfigPath } from "../config.js";
 import { isSonarReachable } from "../sonar/manager.js";
 import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
 import { ensureGitRepo } from "../utils/git.js";
-
-async function checkBinary(name, versionArg = "--version") {
-  const resolved = resolveBin(name);
-  const res = await runCommand(resolved, [versionArg]);
-  const version = (res.stdout || res.stderr || "").split("\n")[0].trim();
-  return { ok: res.exitCode === 0, version, path: resolved };
-}
+import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
 
 export async function runChecks({ config }) {
   const checks = [];
@@ -77,20 +70,14 @@ export async function runChecks({ config }) {
   });
 
   // 5. Agent CLIs
-  const agents = [
-    ["claude", "Install: npm install -g @anthropic-ai/claude-code"],
-    ["codex", "Install: npm install -g @openai/codex"],
-    ["gemini", "Install: npm install -g @anthropic-ai/gemini-code (or check Gemini CLI docs)"],
-    ["aider", "Install: pip install aider-chat"]
-  ];
-  for (const [agent, fixHint] of agents) {
-    const result = await checkBinary(agent);
+  for (const agent of KNOWN_AGENTS) {
+    const result = await checkBinary(agent.name);
     checks.push({
-      name: `agent:${agent}`,
-      label: `Agent: ${agent}`,
+      name: `agent:${agent.name}`,
+      label: `Agent: ${agent.name}`,
       ok: result.ok,
       detail: result.ok ? `${result.version} (${result.path})` : "Not found",
-      fix: result.ok ? null : fixHint
+      fix: result.ok ? null : `Install: ${agent.install}`
     });
   }
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,8 +5,88 @@ import { getConfigPath, loadConfig, writeConfig } from "../config.js";
 import { sonarUp, checkVmMaxMapCount } from "../sonar/manager.js";
 import { exists, ensureDir } from "../utils/fs.js";
 import { getKarajanHome } from "../utils/paths.js";
+import { detectAvailableAgents } from "../utils/agent-detect.js";
+import { createWizard, isTTY } from "../utils/wizard.js";
 
-export async function initCommand({ logger }) {
+async function runWizard(config, logger) {
+  const agents = await detectAvailableAgents();
+  const available = agents.filter((a) => a.available);
+  const unavailable = agents.filter((a) => !a.available);
+
+  logger.info("\n=== Karajan Code Setup Wizard ===\n");
+
+  if (available.length === 0) {
+    logger.warn("No AI agents detected. Install at least one:");
+    for (const agent of unavailable) {
+      logger.warn(`  ${agent.name}: ${agent.install}`);
+    }
+    logger.info("\nGenerating config with defaults (claude). You can change it later in kj.config.yml.\n");
+    return config;
+  }
+
+  logger.info("Detected agents:");
+  for (const agent of available) {
+    logger.info(`  OK   ${agent.name} (${agent.version})`);
+  }
+  for (const agent of unavailable) {
+    logger.info(`  MISS ${agent.name}`);
+  }
+  logger.info("");
+
+  if (available.length === 1) {
+    const only = available[0].name;
+    logger.info(`Only one agent available: ${only}. Using it for all roles.\n`);
+    config.coder = only;
+    config.reviewer = only;
+    config.roles.coder.provider = only;
+    config.roles.reviewer.provider = only;
+    return config;
+  }
+
+  const wizard = createWizard();
+  try {
+    const agentOptions = available.map((a) => ({
+      label: `${a.name} (${a.version})`,
+      value: a.name,
+      available: true
+    }));
+
+    const coder = await wizard.select("Select default CODER agent:", agentOptions);
+    config.coder = coder;
+    config.roles.coder.provider = coder;
+    logger.info(`  -> Coder: ${coder}`);
+
+    const reviewer = await wizard.select("Select default REVIEWER agent:", agentOptions);
+    config.reviewer = reviewer;
+    config.roles.reviewer.provider = reviewer;
+    logger.info(`  -> Reviewer: ${reviewer}`);
+
+    const enableTriage = await wizard.confirm("Enable triage (auto-classify task complexity)?", false);
+    config.pipeline.triage = config.pipeline.triage || {};
+    config.pipeline.triage.enabled = enableTriage;
+    logger.info(`  -> Triage: ${enableTriage ? "enabled" : "disabled"}`);
+
+    const enableSonar = await wizard.confirm("Enable SonarQube analysis?", true);
+    config.sonarqube.enabled = enableSonar;
+    logger.info(`  -> SonarQube: ${enableSonar ? "enabled" : "disabled"}`);
+
+    const methodology = await wizard.select("Development methodology:", [
+      { label: "TDD (test-driven development)", value: "tdd", available: true },
+      { label: "Standard (no TDD enforcement)", value: "standard", available: true }
+    ]);
+    config.development.methodology = methodology;
+    config.development.require_test_changes = methodology === "tdd";
+    logger.info(`  -> Methodology: ${methodology}`);
+
+    logger.info("");
+  } finally {
+    wizard.close();
+  }
+
+  return config;
+}
+
+export async function initCommand({ logger, flags = {} }) {
   const karajanHome = getKarajanHome();
   await ensureDir(karajanHome);
   logger.info(`Ensured ${karajanHome} exists`);
@@ -16,7 +96,27 @@ export async function initCommand({ logger }) {
   const coderRulesPath = path.resolve(process.cwd(), "coder-rules.md");
 
   const { config, exists: configExists } = await loadConfig();
-  if (!configExists) {
+  const interactive = flags.noInteractive !== true && isTTY();
+
+  if (configExists && interactive) {
+    const wizard = createWizard();
+    try {
+      const reconfigure = await wizard.confirm("Config already exists. Reconfigure?", false);
+      if (reconfigure) {
+        const updated = await runWizard(config, logger);
+        await writeConfig(configPath, updated);
+        logger.info(`Updated ${configPath}`);
+      } else {
+        logger.info("Keeping existing config.");
+      }
+    } finally {
+      wizard.close();
+    }
+  } else if (!configExists && interactive) {
+    const updated = await runWizard(config, logger);
+    await writeConfig(configPath, updated);
+    logger.info(`Created ${configPath}`);
+  } else if (!configExists) {
     await writeConfig(configPath, config);
     logger.info(`Created ${configPath}`);
   }
@@ -51,27 +151,31 @@ export async function initCommand({ logger }) {
     logger.info("Created coder-rules.md");
   }
 
-  const vmCheck = await checkVmMaxMapCount(os.platform());
-  if (!vmCheck.ok) {
-    logger.warn(`vm.max_map_count check failed: ${vmCheck.reason}`);
-    if (vmCheck.fix) {
-      logger.warn(`Fix: ${vmCheck.fix}`);
+  if (config.sonarqube?.enabled !== false) {
+    const vmCheck = await checkVmMaxMapCount(os.platform());
+    if (!vmCheck.ok) {
+      logger.warn(`vm.max_map_count check failed: ${vmCheck.reason}`);
+      if (vmCheck.fix) {
+        logger.warn(`Fix: ${vmCheck.fix}`);
+      }
     }
+
+    const sonar = await sonarUp();
+    if (sonar.exitCode !== 0) {
+      throw new Error(`Failed to start SonarQube: ${sonar.stderr || sonar.stdout}`);
+    }
+
+    logger.info("SonarQube container started");
+
+    logger.info("");
+    logger.info("To configure the SonarQube token:");
+    logger.info("  1. Open http://localhost:9000");
+    logger.info("  2. Log in (default credentials: admin / admin)");
+    logger.info("  3. Go to: My Account > Security > Generate Token");
+    logger.info("  4. Name: karajan-cli, Type: Global Analysis Token");
+    logger.info("  5. Set the token in ~/.karajan/kj.config.yml under sonarqube.token");
+    logger.info('     or export KJ_SONAR_TOKEN="<your-token>"');
+  } else {
+    logger.info("SonarQube disabled — skipping container setup.");
   }
-
-  const sonar = await sonarUp();
-  if (sonar.exitCode !== 0) {
-    throw new Error(`Failed to start SonarQube: ${sonar.stderr || sonar.stdout}`);
-  }
-
-  logger.info("SonarQube container started");
-
-  logger.info("");
-  logger.info("To configure the SonarQube token:");
-  logger.info("  1. Open http://localhost:9000");
-  logger.info("  2. Log in (default credentials: admin / admin)");
-  logger.info("  3. Go to: My Account > Security > Generate Token");
-  logger.info("  4. Name: karajan-cli, Type: Global Analysis Token");
-  logger.info("  5. Set the token in ~/.karajan/kj.config.yml under sonarqube.token");
-  logger.info("     or export KJ_SONAR_TOKEN=\"<your-token>\"");
 }

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -1,0 +1,32 @@
+import { runCommand } from "./process.js";
+import { resolveBin } from "../agents/resolve-bin.js";
+
+const KNOWN_AGENTS = [
+  { name: "claude", install: "npm install -g @anthropic-ai/claude-code" },
+  { name: "codex", install: "npm install -g @openai/codex" },
+  { name: "gemini", install: "npm install -g @anthropic-ai/gemini-code (or check Gemini CLI docs)" },
+  { name: "aider", install: "pip install aider-chat" }
+];
+
+export async function checkBinary(name, versionArg = "--version") {
+  const resolved = resolveBin(name);
+  const res = await runCommand(resolved, [versionArg]);
+  const version = (res.stdout || res.stderr || "").split("\n")[0].trim();
+  return { ok: res.exitCode === 0, version, path: resolved };
+}
+
+export async function detectAvailableAgents() {
+  const results = [];
+  for (const agent of KNOWN_AGENTS) {
+    const check = await checkBinary(agent.name);
+    results.push({
+      name: agent.name,
+      available: check.ok,
+      version: check.ok ? check.version : null,
+      install: agent.install
+    });
+  }
+  return results;
+}
+
+export { KNOWN_AGENTS };

--- a/src/utils/wizard.js
+++ b/src/utils/wizard.js
@@ -1,0 +1,41 @@
+import readline from "node:readline";
+
+export function createWizard(input = process.stdin, output = process.stdout) {
+  const rl = readline.createInterface({ input, output });
+
+  function ask(question) {
+    return new Promise((resolve) => {
+      rl.question(question, (answer) => resolve(answer.trim()));
+    });
+  }
+
+  async function confirm(question, defaultValue = true) {
+    const hint = defaultValue ? "[Y/n]" : "[y/N]";
+    const answer = await ask(`${question} ${hint} `);
+    if (answer === "") return defaultValue;
+    return /^y(es)?$/i.test(answer);
+  }
+
+  async function select(question, options) {
+    output.write(`${question}\n`);
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i];
+      const label = opt.available === false ? `${opt.label} (not installed)` : opt.label;
+      output.write(`  ${i + 1}) ${label}\n`);
+    }
+    const answer = await ask(`Choose [1-${options.length}]: `);
+    const idx = Number(answer) - 1;
+    if (idx >= 0 && idx < options.length) return options[idx].value;
+    return options[0].value;
+  }
+
+  function close() {
+    rl.close();
+  }
+
+  return { ask, confirm, select, close };
+}
+
+export function isTTY() {
+  return Boolean(process.stdin.isTTY);
+}

--- a/tests/agent-detect.test.js
+++ b/tests/agent-detect.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/bin/${name}`)
+}));
+
+describe("agent-detect", () => {
+  let checkBinary, detectAvailableAgents, KNOWN_AGENTS;
+  let runCommand;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ runCommand } = await import("../src/utils/process.js"));
+    ({ checkBinary, detectAvailableAgents, KNOWN_AGENTS } = await import("../src/utils/agent-detect.js"));
+  });
+
+  it("checkBinary returns ok=true when command succeeds", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "claude 1.0.0", stderr: "" });
+
+    const result = await checkBinary("claude");
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("claude 1.0.0");
+  });
+
+  it("checkBinary returns ok=false when command fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 127, stdout: "", stderr: "not found" });
+
+    const result = await checkBinary("codex");
+    expect(result.ok).toBe(false);
+  });
+
+  it("detectAvailableAgents checks all known agents", async () => {
+    runCommand.mockImplementation((_cmd, _args) => {
+      if (_cmd.includes("claude")) return Promise.resolve({ exitCode: 0, stdout: "claude 2.0", stderr: "" });
+      if (_cmd.includes("codex")) return Promise.resolve({ exitCode: 0, stdout: "codex 1.0", stderr: "" });
+      return Promise.resolve({ exitCode: 127, stdout: "", stderr: "" });
+    });
+
+    const agents = await detectAvailableAgents();
+    expect(agents).toHaveLength(KNOWN_AGENTS.length);
+
+    const claude = agents.find((a) => a.name === "claude");
+    expect(claude.available).toBe(true);
+    expect(claude.version).toBe("claude 2.0");
+
+    const gemini = agents.find((a) => a.name === "gemini");
+    expect(gemini.available).toBe(false);
+    expect(gemini.version).toBeNull();
+  });
+
+  it("KNOWN_AGENTS contains claude, codex, gemini, aider", () => {
+    const names = KNOWN_AGENTS.map((a) => a.name);
+    expect(names).toContain("claude");
+    expect(names).toContain("codex");
+    expect(names).toContain("gemini");
+    expect(names).toContain("aider");
+  });
+});

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/config.js", () => ({
+  getConfigPath: vi.fn().mockReturnValue("/fake/.karajan/kj.config.yml"),
+  loadConfig: vi.fn(),
+  writeConfig: vi.fn()
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  exists: vi.fn().mockResolvedValue(false),
+  ensureDir: vi.fn()
+}));
+
+vi.mock("../src/utils/paths.js", () => ({
+  getKarajanHome: vi.fn().mockReturnValue("/fake/.karajan"),
+  getSessionRoot: vi.fn().mockReturnValue("/fake/.karajan/sessions")
+}));
+
+vi.mock("../src/sonar/manager.js", () => ({
+  sonarUp: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
+  checkVmMaxMapCount: vi.fn().mockResolvedValue({ ok: true })
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(new Error("not found"))
+  }
+}));
+
+vi.mock("../src/utils/agent-detect.js", () => ({
+  detectAvailableAgents: vi.fn(),
+  checkBinary: vi.fn(),
+  KNOWN_AGENTS: [
+    { name: "claude", install: "npm i -g @anthropic-ai/claude-code" },
+    { name: "codex", install: "npm i -g @openai/codex" }
+  ]
+}));
+
+vi.mock("../src/utils/wizard.js", () => ({
+  createWizard: vi.fn(),
+  isTTY: vi.fn()
+}));
+
+describe("initCommand", () => {
+  let initCommand;
+  let loadConfig, writeConfig;
+  let detectAvailableAgents;
+  let createWizard, isTTY;
+
+  const logger = {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ loadConfig, writeConfig } = await import("../src/config.js"));
+    ({ detectAvailableAgents } = await import("../src/utils/agent-detect.js"));
+    ({ createWizard, isTTY } = await import("../src/utils/wizard.js"));
+    ({ initCommand } = await import("../src/commands/init.js"));
+  });
+
+  it("runs non-interactive mode when --no-interactive is set", async () => {
+    isTTY.mockReturnValue(true);
+    loadConfig.mockResolvedValue({
+      config: {
+        coder: "claude",
+        reviewer: "codex",
+        roles: { coder: {}, reviewer: {} },
+        pipeline: {},
+        sonarqube: { enabled: false },
+        development: { methodology: "tdd" }
+      },
+      exists: false
+    });
+
+    await initCommand({ logger, flags: { noInteractive: true } });
+
+    expect(writeConfig).toHaveBeenCalled();
+    expect(createWizard).not.toHaveBeenCalled();
+  });
+
+  it("runs non-interactive mode when stdin is not a TTY", async () => {
+    isTTY.mockReturnValue(false);
+    loadConfig.mockResolvedValue({
+      config: {
+        coder: "claude",
+        reviewer: "codex",
+        roles: { coder: {}, reviewer: {} },
+        pipeline: {},
+        sonarqube: { enabled: false },
+        development: { methodology: "tdd" }
+      },
+      exists: false
+    });
+
+    await initCommand({ logger, flags: {} });
+
+    expect(writeConfig).toHaveBeenCalled();
+    expect(createWizard).not.toHaveBeenCalled();
+  });
+
+  it("runs wizard when interactive and config does not exist", async () => {
+    isTTY.mockReturnValue(true);
+    const mockConfig = {
+      coder: "claude",
+      reviewer: "codex",
+      roles: { coder: { provider: null }, reviewer: { provider: null } },
+      pipeline: { triage: {} },
+      sonarqube: { enabled: true },
+      development: { methodology: "tdd", require_test_changes: true }
+    };
+    loadConfig.mockResolvedValue({ config: mockConfig, exists: false });
+
+    detectAvailableAgents.mockResolvedValue([
+      { name: "claude", available: true, version: "2.0.0", install: "" },
+      { name: "codex", available: true, version: "1.0.0", install: "" }
+    ]);
+
+    const mockWizard = {
+      ask: vi.fn(),
+      confirm: vi.fn().mockResolvedValue(false),
+      select: vi.fn()
+        .mockResolvedValueOnce("codex")  // coder
+        .mockResolvedValueOnce("claude") // reviewer
+        .mockResolvedValueOnce("tdd"),   // methodology
+      close: vi.fn()
+    };
+    createWizard.mockReturnValue(mockWizard);
+
+    await initCommand({ logger, flags: {} });
+
+    expect(detectAvailableAgents).toHaveBeenCalled();
+    expect(mockWizard.select).toHaveBeenCalledTimes(3);
+    expect(writeConfig).toHaveBeenCalled();
+    const writtenConfig = writeConfig.mock.calls[0][1];
+    expect(writtenConfig.coder).toBe("codex");
+    expect(writtenConfig.reviewer).toBe("claude");
+    mockWizard.close();
+  });
+
+  it("asks to reconfigure when config already exists", async () => {
+    isTTY.mockReturnValue(true);
+    loadConfig.mockResolvedValue({
+      config: {
+        coder: "claude",
+        reviewer: "codex",
+        roles: { coder: {}, reviewer: {} },
+        pipeline: {},
+        sonarqube: { enabled: false },
+        development: { methodology: "tdd" }
+      },
+      exists: true
+    });
+
+    const mockWizard = {
+      ask: vi.fn(),
+      confirm: vi.fn().mockResolvedValue(false),
+      select: vi.fn(),
+      close: vi.fn()
+    };
+    createWizard.mockReturnValue(mockWizard);
+
+    await initCommand({ logger, flags: {} });
+
+    expect(mockWizard.confirm).toHaveBeenCalledWith(
+      expect.stringContaining("Reconfigure"),
+      false
+    );
+  });
+
+  it("uses single agent for all roles when only one is available", async () => {
+    isTTY.mockReturnValue(true);
+    loadConfig.mockResolvedValue({
+      config: {
+        coder: "claude",
+        reviewer: "codex",
+        roles: { coder: { provider: null }, reviewer: { provider: null } },
+        pipeline: { triage: {} },
+        sonarqube: { enabled: false },
+        development: { methodology: "tdd" }
+      },
+      exists: false
+    });
+
+    detectAvailableAgents.mockResolvedValue([
+      { name: "claude", available: true, version: "2.0.0", install: "" },
+      { name: "codex", available: false, version: null, install: "npm i codex" }
+    ]);
+
+    const mockWizard = {
+      ask: vi.fn(),
+      confirm: vi.fn(),
+      select: vi.fn(),
+      close: vi.fn()
+    };
+    createWizard.mockReturnValue(mockWizard);
+
+    await initCommand({ logger, flags: {} });
+
+    const writtenConfig = writeConfig.mock.calls[0][1];
+    expect(writtenConfig.coder).toBe("claude");
+    expect(writtenConfig.reviewer).toBe("claude");
+    // No select calls needed when only one agent
+    expect(mockWizard.select).not.toHaveBeenCalled();
+  });
+});

--- a/tests/wizard.test.js
+++ b/tests/wizard.test.js
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import { Readable, Writable } from "node:stream";
+import { createWizard, isTTY } from "../src/utils/wizard.js";
+
+function makeInput(answers) {
+  const data = answers.join("\n") + "\n";
+  return Readable.from([data]);
+}
+
+function makeOutput() {
+  const chunks = [];
+  const writable = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    }
+  });
+  writable.getOutput = () => chunks.join("");
+  return writable;
+}
+
+describe("wizard", () => {
+  it("ask returns user input trimmed", async () => {
+    const input = makeInput(["  hello world  "]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const answer = await wizard.ask("What? ");
+    expect(answer).toBe("hello world");
+    wizard.close();
+  });
+
+  it("confirm returns true for 'y'", async () => {
+    const input = makeInput(["y"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const result = await wizard.confirm("Proceed?");
+    expect(result).toBe(true);
+    wizard.close();
+  });
+
+  it("confirm returns false for 'n'", async () => {
+    const input = makeInput(["n"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const result = await wizard.confirm("Proceed?");
+    expect(result).toBe(false);
+    wizard.close();
+  });
+
+  it("confirm uses default value on empty input", async () => {
+    const input = makeInput([""]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const result = await wizard.confirm("Proceed?", false);
+    expect(result).toBe(false);
+    wizard.close();
+  });
+
+  it("select returns chosen option value", async () => {
+    const input = makeInput(["2"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const options = [
+      { label: "Option A", value: "a", available: true },
+      { label: "Option B", value: "b", available: true }
+    ];
+    const result = await wizard.select("Pick:", options);
+    expect(result).toBe("b");
+
+    const text = output.getOutput();
+    expect(text).toContain("Option A");
+    expect(text).toContain("Option B");
+    wizard.close();
+  });
+
+  it("select shows (not installed) for unavailable options", async () => {
+    const input = makeInput(["1"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const options = [
+      { label: "claude", value: "claude", available: true },
+      { label: "gemini", value: "gemini", available: false }
+    ];
+    await wizard.select("Pick:", options);
+
+    const text = output.getOutput();
+    expect(text).toContain("gemini (not installed)");
+    expect(text).not.toContain("claude (not installed)");
+    wizard.close();
+  });
+
+  it("select defaults to first option on invalid input", async () => {
+    const input = makeInput(["99"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const options = [
+      { label: "A", value: "first", available: true },
+      { label: "B", value: "second", available: true }
+    ];
+    const result = await wizard.select("Pick:", options);
+    expect(result).toBe("first");
+    wizard.close();
+  });
+});
+
+describe("isTTY", () => {
+  it("returns a boolean", () => {
+    const result = isTTY();
+    expect(typeof result).toBe("boolean");
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-detect installed agents (claude, codex, gemini, aider) using shared `utils/agent-detect.js`
- Interactive wizard guides through: coder selection, reviewer selection, triage toggle, sonar toggle, methodology (TDD/standard)
- When only 1 agent available: skip selection, inform user, auto-assign to all roles
- When 0 agents available: warn and generate defaults
- `--no-interactive` flag for CI/scripts; auto-fallback when stdin is not a TTY
- Config reconfiguration prompt when `kj.config.yml` already exists
- SonarQube setup skipped when user disables it in wizard
- Extract `checkBinary` from doctor.js to shared module (DRY)
- 17 new tests (752 total)

## Test plan
- [x] All 752 tests pass
- [x] `checkBinary` and `detectAvailableAgents` correctly detect/miss agents
- [x] Wizard ask/confirm/select work with mock readline streams
- [x] Non-interactive mode skips wizard entirely
- [x] Non-TTY stdin auto-falls back to non-interactive
- [x] Single agent auto-assigns without prompting
- [x] Existing config prompts for reconfiguration

🤖 Generated with [Claude Code](https://claude.com/claude-code)