### PR TITLE
feat(cli): kj roles command to inspect pipeline templates

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ import { planCommand } from "./commands/plan.js";
 import { runCommandHandler } from "./commands/run.js";
 import { resumeCommand } from "./commands/resume.js";
 import { sonarCommand, sonarOpenCommand } from "./commands/sonar.js";
+import { rolesCommand } from "./commands/roles.js";
 
 async function withConfig(commandName, flags, fn) {
   const { config } = await loadConfig();
@@ -138,6 +139,15 @@ program
   .option("--currency <code>", "Display costs in currency: usd|eur", "usd")
   .action(async (flags) => {
     await reportCommand(flags);
+  });
+
+program
+  .command("roles [subcommand] [role]")
+  .description("List pipeline roles or show role template instructions")
+  .action(async (subcommand, role) => {
+    await withConfig("roles", {}, async ({ config }) => {
+      await rolesCommand({ config, subcommand: subcommand || "list", roleName: role });
+    });
   });
 
 program

--- a/src/commands/roles.js
+++ b/src/commands/roles.js
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
+import { resolveRole } from "../config.js";
+import { exists } from "../utils/fs.js";
+
+const PIPELINE_ROLES = [
+  { name: "triage", description: "Classifies task complexity and activates pipeline roles" },
+  { name: "researcher", description: "Investigates codebase before planning" },
+  { name: "planner", description: "Generates implementation plans" },
+  { name: "coder", description: "Writes code and tests (TDD)" },
+  { name: "refactorer", description: "Improves code clarity without changing behavior" },
+  { name: "sonar", description: "SonarQube static analysis" },
+  { name: "reviewer", description: "Code review with configurable strictness" },
+  { name: "tester", description: "Test quality gate and coverage checks" },
+  { name: "security", description: "OWASP security audit" },
+  { name: "solomon", description: "Conflict resolver between agents" },
+  { name: "commiter", description: "Git commit, push, and PR automation" }
+];
+
+const REVIEW_VARIANTS = ["reviewer-strict", "reviewer-relaxed", "reviewer-paranoid"];
+
+function isRoleEnabled(config, roleName) {
+  if (roleName === "coder" || roleName === "commiter" || roleName === "sonar") {
+    if (roleName === "sonar") return Boolean(config?.sonarqube?.enabled);
+    return true;
+  }
+  if (roleName === "reviewer") return config?.pipeline?.reviewer?.enabled !== false;
+  return Boolean(config?.pipeline?.[roleName]?.enabled);
+}
+
+export function listRoles(config) {
+  return PIPELINE_ROLES.map((role) => {
+    const resolved = resolveRole(config, role.name);
+    return {
+      name: role.name,
+      description: role.description,
+      provider: resolved.provider || "-",
+      model: resolved.model || "-",
+      enabled: isRoleEnabled(config, role.name)
+    };
+  });
+}
+
+export async function showRole(roleName, config) {
+  const projectDir = config?.projectDir || process.cwd();
+  const candidates = resolveRoleMdPath(roleName, projectDir);
+
+  const customPath = candidates[0];
+  const hasCustom = await exists(customPath);
+
+  const content = await loadFirstExisting(candidates);
+  if (!content) {
+    return { found: false, roleName, content: null, source: null, customPath: null };
+  }
+
+  let source = "built-in";
+  if (hasCustom) {
+    source = "custom";
+  } else if (candidates.length > 2) {
+    try {
+      await fs.readFile(candidates[1], "utf8");
+      source = "user";
+    } catch {
+      source = "built-in";
+    }
+  }
+
+  return {
+    found: true,
+    roleName,
+    content,
+    source,
+    customPath: hasCustom ? customPath : null
+  };
+}
+
+function printRoleList(roles) {
+  const nameWidth = Math.max(...roles.map((r) => r.name.length), 4);
+  const provWidth = Math.max(...roles.map((r) => r.provider.length), 8);
+
+  const header = `${"Role".padEnd(nameWidth)}  ${"Provider".padEnd(provWidth)}  Enabled  Description`;
+  console.log(header);
+  console.log("-".repeat(header.length));
+
+  for (const role of roles) {
+    const enabled = role.enabled ? "yes" : "no ";
+    console.log(
+      `${role.name.padEnd(nameWidth)}  ${role.provider.padEnd(provWidth)}  ${enabled.padEnd(7)}  ${role.description}`
+    );
+  }
+}
+
+export async function rolesCommand({ config, subcommand, roleName }) {
+  if (subcommand === "show" && roleName) {
+    const result = await showRole(roleName, config);
+    if (!result.found) {
+      console.log(`Role "${roleName}" not found.`);
+      console.log(`Available roles: ${PIPELINE_ROLES.map((r) => r.name).join(", ")}`);
+      console.log(`Review variants: ${REVIEW_VARIANTS.join(", ")}`);
+      return result;
+    }
+    if (result.source === "custom") {
+      console.log(`[custom override: ${result.customPath}]\n`);
+    }
+    console.log(result.content);
+    return result;
+  }
+
+  const roles = listRoles(config);
+  printRoleList(roles);
+  console.log(`\nReview variants: ${REVIEW_VARIANTS.join(", ")}`);
+  console.log('\nUse "kj roles show <role>" to view template instructions.');
+  return roles;
+}
+
+export { PIPELINE_ROLES, REVIEW_VARIANTS };

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -194,6 +194,17 @@ export async function handleToolCall(name, args, server, extra) {
     return runKjCommand({ command: "scan", options: a });
   }
 
+  if (name === "kj_roles") {
+    const action = a.action || "list";
+    const commandArgs = [action];
+    if (action === "show" && a.roleName) commandArgs.push(a.roleName);
+    return runKjCommand({
+      command: "roles",
+      commandArgs,
+      options: a
+    });
+  }
+
   if (name === "kj_report") {
     const commandArgs = [];
     if (a.list) commandArgs.push("--list");

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -122,6 +122,18 @@ export const tools = [
     }
   },
   {
+    name: "kj_roles",
+    description: "List pipeline roles or show the template instructions for a specific role. Use action='list' to see all roles with their provider and status. Use action='show' with roleName to read the .md template.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["list", "show"], description: "Action: list all roles or show a specific role template" },
+        roleName: { type: "string", description: "Role name to show (e.g. coder, reviewer, triage, reviewer-paranoid)" },
+        kjHome: { type: "string" }
+      }
+    }
+  },
+  {
     name: "kj_code",
     description: "Run coder-only mode",
     inputSchema: {

--- a/tests/command-roles.test.js
+++ b/tests/command-roles.test.js
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/roles/base-role.js", () => ({
+  resolveRoleMdPath: vi.fn(),
+  loadFirstExisting: vi.fn()
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  exists: vi.fn().mockResolvedValue(false),
+  ensureDir: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn(),
+  getConfigPath: vi.fn(),
+  loadConfig: vi.fn(),
+  applyRunOverrides: vi.fn(),
+  validateConfig: vi.fn()
+}));
+
+describe("roles command", () => {
+  let listRoles, showRole, rolesCommand, PIPELINE_ROLES, REVIEW_VARIANTS;
+  let resolveRole;
+  let resolveRoleMdPath, loadFirstExisting;
+  let exists;
+
+  const baseConfig = {
+    coder: "codex",
+    reviewer: "claude",
+    roles: {
+      coder: { provider: "codex", model: null },
+      reviewer: { provider: "claude", model: null },
+      planner: { provider: null, model: null }
+    },
+    pipeline: {
+      planner: { enabled: false },
+      refactorer: { enabled: false },
+      researcher: { enabled: false },
+      tester: { enabled: false },
+      security: { enabled: false },
+      triage: { enabled: true },
+      solomon: { enabled: false }
+    },
+    sonarqube: { enabled: true }
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ resolveRole } = await import("../src/config.js"));
+    ({ resolveRoleMdPath, loadFirstExisting } = await import("../src/roles/base-role.js"));
+    ({ exists } = await import("../src/utils/fs.js"));
+    ({ listRoles, showRole, rolesCommand, PIPELINE_ROLES, REVIEW_VARIANTS } = await import("../src/commands/roles.js"));
+  });
+
+  describe("PIPELINE_ROLES", () => {
+    it("contains all expected roles", () => {
+      const names = PIPELINE_ROLES.map((r) => r.name);
+      expect(names).toContain("coder");
+      expect(names).toContain("reviewer");
+      expect(names).toContain("triage");
+      expect(names).toContain("planner");
+      expect(names).toContain("sonar");
+      expect(names).toContain("solomon");
+      expect(names).toContain("commiter");
+      expect(names).toContain("tester");
+      expect(names).toContain("security");
+      expect(names).toContain("researcher");
+      expect(names).toContain("refactorer");
+    });
+  });
+
+  describe("REVIEW_VARIANTS", () => {
+    it("contains strict, relaxed, paranoid variants", () => {
+      expect(REVIEW_VARIANTS).toContain("reviewer-strict");
+      expect(REVIEW_VARIANTS).toContain("reviewer-relaxed");
+      expect(REVIEW_VARIANTS).toContain("reviewer-paranoid");
+    });
+  });
+
+  describe("listRoles", () => {
+    it("returns role list with provider and enabled status", () => {
+      resolveRole.mockImplementation((_config, role) => {
+        if (role === "coder") return { provider: "codex", model: null };
+        if (role === "reviewer") return { provider: "claude", model: null };
+        return { provider: null, model: null };
+      });
+
+      const roles = listRoles(baseConfig);
+      expect(roles).toHaveLength(PIPELINE_ROLES.length);
+
+      const coder = roles.find((r) => r.name === "coder");
+      expect(coder.provider).toBe("codex");
+      expect(coder.enabled).toBe(true);
+
+      const triage = roles.find((r) => r.name === "triage");
+      expect(triage.enabled).toBe(true);
+
+      const planner = roles.find((r) => r.name === "planner");
+      expect(planner.enabled).toBe(false);
+    });
+
+    it("shows sonar enabled based on sonarqube config", () => {
+      resolveRole.mockReturnValue({ provider: null, model: null });
+      const roles = listRoles(baseConfig);
+      const sonar = roles.find((r) => r.name === "sonar");
+      expect(sonar.enabled).toBe(true);
+
+      const disabledConfig = { ...baseConfig, sonarqube: { enabled: false } };
+      const roles2 = listRoles(disabledConfig);
+      const sonar2 = roles2.find((r) => r.name === "sonar");
+      expect(sonar2.enabled).toBe(false);
+    });
+  });
+
+  describe("showRole", () => {
+    it("returns content and source for built-in role", async () => {
+      resolveRoleMdPath.mockReturnValue(["/project/.karajan/roles/coder.md", "/home/.karajan/roles/coder.md", "/built-in/coder.md"]);
+      exists.mockResolvedValue(false);
+      loadFirstExisting.mockResolvedValue("# Coder Rules\nWrite code.");
+
+      const result = await showRole("coder", baseConfig);
+      expect(result.found).toBe(true);
+      expect(result.content).toContain("Coder Rules");
+      expect(result.source).toBe("built-in");
+      expect(result.customPath).toBeNull();
+    });
+
+    it("returns custom source when project override exists", async () => {
+      resolveRoleMdPath.mockReturnValue(["/project/.karajan/roles/coder.md", "/home/.karajan/roles/coder.md", "/built-in/coder.md"]);
+      exists.mockResolvedValue(true);
+      loadFirstExisting.mockResolvedValue("# Custom Coder");
+
+      const result = await showRole("coder", baseConfig);
+      expect(result.found).toBe(true);
+      expect(result.source).toBe("custom");
+      expect(result.customPath).toBe("/project/.karajan/roles/coder.md");
+    });
+
+    it("returns found=false when no template exists", async () => {
+      resolveRoleMdPath.mockReturnValue(["/a.md", "/b.md"]);
+      exists.mockResolvedValue(false);
+      loadFirstExisting.mockResolvedValue(null);
+
+      const result = await showRole("nonexistent", baseConfig);
+      expect(result.found).toBe(false);
+    });
+  });
+
+  describe("rolesCommand", () => {
+    it("prints role list when subcommand is list", async () => {
+      resolveRole.mockReturnValue({ provider: "codex", model: null });
+      const logs = [];
+      vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+      const result = await rolesCommand({ config: baseConfig, subcommand: "list" });
+      expect(Array.isArray(result)).toBe(true);
+      expect(logs.some((l) => l.includes("Role"))).toBe(true);
+      expect(logs.some((l) => l.includes("coder"))).toBe(true);
+      expect(logs.some((l) => l.includes('kj roles show'))).toBe(true);
+
+      console.log.mockRestore();
+    });
+
+    it("prints role template when subcommand is show", async () => {
+      resolveRoleMdPath.mockReturnValue(["/a.md", "/b.md", "/c.md"]);
+      exists.mockResolvedValue(false);
+      loadFirstExisting.mockResolvedValue("# Reviewer\nReview code carefully.");
+
+      const logs = [];
+      vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+      const result = await rolesCommand({ config: baseConfig, subcommand: "show", roleName: "reviewer" });
+      expect(result.found).toBe(true);
+      expect(logs.some((l) => l.includes("Reviewer"))).toBe(true);
+
+      console.log.mockRestore();
+    });
+
+    it("shows not found message for unknown role", async () => {
+      resolveRoleMdPath.mockReturnValue(["/a.md"]);
+      exists.mockResolvedValue(false);
+      loadFirstExisting.mockResolvedValue(null);
+
+      const logs = [];
+      vi.spyOn(console, "log").mockImplementation((...args) => logs.push(args.join(" ")));
+
+      const result = await rolesCommand({ config: baseConfig, subcommand: "show", roleName: "unknown" });
+      expect(result.found).toBe(false);
+      expect(logs.some((l) => l.includes("not found"))).toBe(true);
+
+      console.log.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `kj roles` command lists all 11 pipeline roles with provider, enabled status, and description
- `kj roles show <role>` displays the full .md template instructions (custom override → user config → built-in)
- Shows `[custom override: path]` header when project-level override is active
- Includes reviewer variants: `reviewer-strict`, `reviewer-relaxed`, `reviewer-paranoid`
- MCP `kj_roles` tool with `action=list|show` and `roleName` parameter
- 10 new tests (762 total)

## Test plan
- [x] All 762 tests pass
- [x] PIPELINE_ROLES contains all 11 expected roles
- [x] REVIEW_VARIANTS contains strict/relaxed/paranoid
- [x] listRoles returns correct provider and enabled status
- [x] showRole returns content with built-in/custom source detection
- [x] showRole returns found=false for unknown roles
- [x] rolesCommand prints formatted table for list
- [x] rolesCommand prints template content for show
- [x] rolesCommand shows "not found" for unknown roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)