### PR TITLE
fix: auto-close MCP server when parent process dies

### DIFF
--- a/src/mcp/orphan-guard.js
+++ b/src/mcp/orphan-guard.js
@@ -1,0 +1,21 @@
+const DEFAULT_INTERVAL_MS = 5000;
+
+export function setupOrphanGuard({ intervalMs = DEFAULT_INTERVAL_MS, exitFn = () => process.exit(0) } = {}) {
+  const parentPid = process.ppid;
+
+  const timer = setInterval(() => {
+    try {
+      process.kill(parentPid, 0);
+    } catch {
+      clearInterval(timer);
+      exitFn();
+    }
+  }, intervalMs);
+  timer.unref();
+
+  process.stdin.on("end", exitFn);
+  process.stdin.on("close", exitFn);
+  process.on("SIGHUP", exitFn);
+
+  return { timer, parentPid };
+}

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -33,5 +33,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
   }
 });
 
+// --- Orphan process protection ---
+import { setupOrphanGuard } from "./orphan-guard.js";
+setupOrphanGuard();
+
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/tests/mcp-orphan-guard.test.js
+++ b/tests/mcp-orphan-guard.test.js
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+describe("orphan-guard", () => {
+  let originalPpid;
+  let originalStdin;
+  let fakeStdin;
+  let exitFn;
+
+  beforeEach(() => {
+    originalPpid = process.ppid;
+    originalStdin = process.stdin;
+    fakeStdin = new EventEmitter();
+    Object.defineProperty(process, "stdin", { value: fakeStdin, writable: true, configurable: true });
+    exitFn = vi.fn();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "stdin", { value: originalStdin, writable: true, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("calls exitFn when parent pid is dead", async () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => { throw new Error("ESRCH"); });
+
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const { timer } = setupOrphanGuard({ intervalMs: 100, exitFn });
+
+    vi.advanceTimersByTime(100);
+    expect(exitFn).toHaveBeenCalledTimes(1);
+
+    clearInterval(timer);
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("does not call exitFn when parent pid is alive", async () => {
+    vi.useFakeTimers();
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const { timer } = setupOrphanGuard({ intervalMs: 100, exitFn });
+
+    vi.advanceTimersByTime(300);
+    expect(exitFn).not.toHaveBeenCalled();
+
+    clearInterval(timer);
+    killSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("calls exitFn when stdin emits 'end'", async () => {
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const { timer } = setupOrphanGuard({ intervalMs: 60000, exitFn });
+
+    fakeStdin.emit("end");
+    expect(exitFn).toHaveBeenCalledTimes(1);
+
+    clearInterval(timer);
+  });
+
+  it("calls exitFn when stdin emits 'close'", async () => {
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const { timer } = setupOrphanGuard({ intervalMs: 60000, exitFn });
+
+    fakeStdin.emit("close");
+    expect(exitFn).toHaveBeenCalledTimes(1);
+
+    clearInterval(timer);
+  });
+
+  it("calls exitFn on SIGHUP", async () => {
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const { timer } = setupOrphanGuard({ intervalMs: 60000, exitFn });
+
+    process.emit("SIGHUP");
+    expect(exitFn).toHaveBeenCalledTimes(1);
+
+    clearInterval(timer);
+  });
+
+  it("returns parentPid and timer handle", async () => {
+    const { setupOrphanGuard } = await import("../src/mcp/orphan-guard.js");
+    const result = setupOrphanGuard({ intervalMs: 60000, exitFn });
+
+    expect(result.parentPid).toBe(process.ppid);
+    expect(result.timer).toBeDefined();
+
+    clearInterval(result.timer);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds orphan process protection to the MCP server via `src/mcp/orphan-guard.js`
- Monitors parent PID every 5s and exits if parent dies
- Listens for stdin `end`/`close` events and `SIGHUP` signal
- Prevents accumulation of zombie node processes when Claude Code sessions end

## Test plan
- [x] 6 unit tests covering all exit triggers (parent death, stdin end/close, SIGHUP)
- [x] All 856 tests pass with no regressions

Closes KJC-TSK-0078

🤖 Generated with [Claude Code](https://claude.com/claude-code)