### PR TITLE
feat: add plugin loader for custom agents

### DIFF
--- a/src/plugins/loader.js
+++ b/src/plugins/loader.js
@@ -1,0 +1,67 @@
+/**
+ * Plugin loader: discovers and loads plugins from .karajan/plugins/ directories.
+ *
+ * Plugins are JS files that export a `register(api)` function.
+ * The `api` object provides: registerAgent, registerModel.
+ *
+ * Discovery order (all are loaded, not first-wins):
+ *   1. <project>/.karajan/plugins/*.js
+ *   2. ~/.karajan/plugins/*.js
+ */
+
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { getKarajanHome } from "../utils/paths.js";
+import { registerAgent } from "../agents/index.js";
+
+async function listPluginFiles(dir) {
+  try {
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith(".js"))
+      .map((e) => path.join(dir, e.name));
+  } catch {
+    return [];
+  }
+}
+
+async function loadPlugin(filePath, api, logger) {
+  try {
+    const mod = await import(pathToFileURL(filePath).href);
+    const registerFn = mod.register || mod.default?.register;
+    if (typeof registerFn !== "function") {
+      logger?.warn?.(`Plugin ${filePath}: no register() export found, skipping`);
+      return null;
+    }
+    const meta = registerFn(api);
+    const name = meta?.name || path.basename(filePath, ".js");
+    logger?.debug?.(`Plugin loaded: ${name} (${filePath})`);
+    return { name, path: filePath, meta };
+  } catch (error) {
+    logger?.warn?.(`Plugin ${filePath} failed to load: ${error.message}`);
+    return null;
+  }
+}
+
+export async function loadPlugins({ projectDir, logger } = {}) {
+  const dirs = [];
+
+  if (projectDir) {
+    dirs.push(path.join(projectDir, ".karajan", "plugins"));
+  }
+  dirs.push(path.join(getKarajanHome(), "plugins"));
+
+  const api = { registerAgent };
+
+  const loaded = [];
+  for (const dir of dirs) {
+    const files = await listPluginFiles(dir);
+    for (const file of files) {
+      const result = await loadPlugin(file, api, logger);
+      if (result) loaded.push(result);
+    }
+  }
+
+  return loaded;
+}

--- a/tests/plugin-loader.test.js
+++ b/tests/plugin-loader.test.js
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+
+describe("plugin loader", () => {
+  let tmpDir;
+  let loadPlugins;
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-plugin-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writePlugin(dir, name, content) {
+    const pluginDir = path.join(dir, ".karajan", "plugins");
+    await fs.mkdir(pluginDir, { recursive: true });
+    const filePath = path.join(pluginDir, `${name}.js`);
+    await fs.writeFile(filePath, content, "utf8");
+    return filePath;
+  }
+
+  it("loads plugin from project .karajan/plugins/", async () => {
+    await writePlugin(tmpDir, "my-agent", `
+      export function register({ registerAgent }) {
+        class FakeAgent {
+          async runTask() { return { ok: true, output: "", error: "", exitCode: 0 }; }
+          async reviewTask() { return { ok: true, output: "", error: "", exitCode: 0 }; }
+        }
+        registerAgent("fake-test-agent", FakeAgent, { bin: "fake" });
+        return { name: "my-agent" };
+      }
+    `);
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: tmpDir, logger });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("my-agent");
+  });
+
+  it("skips files without register() export", async () => {
+    await writePlugin(tmpDir, "no-register", `export const foo = "bar";`);
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: tmpDir, logger });
+
+    expect(result).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no register()"));
+  });
+
+  it("handles plugin load errors gracefully", async () => {
+    await writePlugin(tmpDir, "broken", `throw new Error("broken plugin");`);
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: tmpDir, logger });
+
+    expect(result).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to load"));
+  });
+
+  it("returns empty array when no plugin directories exist", async () => {
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: path.join(tmpDir, "nonexistent"), logger });
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips non-js files", async () => {
+    const pluginDir = path.join(tmpDir, ".karajan", "plugins");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(path.join(pluginDir, "readme.txt"), "not a plugin", "utf8");
+    await fs.writeFile(path.join(pluginDir, "data.json"), "{}", "utf8");
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: tmpDir, logger });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("uses filename as plugin name when register returns no name", async () => {
+    await writePlugin(tmpDir, "unnamed-plugin", `
+      export function register() {
+        return {};
+      }
+    `);
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    const result = await lp({ projectDir: tmpDir, logger });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("unnamed-plugin");
+  });
+
+  it("provides registerAgent in the plugin API", async () => {
+    let apiReceived = null;
+    await writePlugin(tmpDir, "api-check", `
+      export function register(api) {
+        globalThis.__kjPluginApiCheck = api;
+        return { name: "api-check" };
+      }
+    `);
+
+    const { loadPlugins: lp } = await import("../src/plugins/loader.js");
+    await lp({ projectDir: tmpDir, logger });
+
+    const api = globalThis.__kjPluginApiCheck;
+    expect(typeof api.registerAgent).toBe("function");
+    delete globalThis.__kjPluginApiCheck;
+  });
+});


### PR DESCRIPTION
## Summary
- Add plugin discovery system that scans `.karajan/plugins/` directories (project-local and global `~/.karajan/plugins/`)
- Plugins are JS files exporting a `register(api)` function that receives `{ registerAgent }` 
- Fail-safe loading: broken plugins are skipped with warnings, never crash the system
- 7 new unit tests covering: loading, error handling, API injection, file filtering

## Test plan
- [x] All 891 tests pass (including 7 new plugin loader tests)
- [x] Plugin loader discovers JS files in .karajan/plugins/ directories
- [x] Broken plugins are skipped gracefully with warning logs
- [x] Non-JS files are ignored
- [x] registerAgent API is correctly exposed to plugins