### PR TITLE
feat: detect CLI agent rate limits and pause session

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -255,11 +255,17 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     logger.info(`Iteration ${i}/${config.max_iterations}`);
 
     // --- Coder ---
-    await runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i });
+    const coderResult = await runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i });
+    if (coderResult?.action === "pause") {
+      return coderResult.result;
+    }
 
     // --- Refactorer ---
     if (refactorerEnabled) {
-      await runRefactorerStage({ refactorerRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i });
+      const refResult = await runRefactorerStage({ refactorerRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i });
+      if (refResult?.action === "pause") {
+        return refResult.result;
+      }
     }
 
     // --- TDD Policy ---
@@ -302,6 +308,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         reviewerRole, config, logger, emitter, eventBase, session, trackBudget,
         iteration: i, reviewRules, task, repeatDetector, budgetSummary
       });
+      if (reviewerResult.action === "pause") {
+        return reviewerResult.result;
+      }
       review = reviewerResult.review;
       if (reviewerResult.stalled) {
         return reviewerResult.stalledResult;

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -8,6 +8,7 @@ import { validateReviewResult } from "../review/schema.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { runReviewerWithFallback } from "./reviewer-fallback.js";
 import { invokeSolomon } from "./solomon-escalation.js";
+import { detectRateLimit } from "../utils/rate-limit-detector.js";
 
 export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration }) {
   logger.setContext({ iteration, stage: "coder" });
@@ -35,8 +36,30 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
   trackBudget({ role: "coder", provider: coderRole.provider, model: coderRole.model, result: coderExecResult.result, duration_ms: Date.now() - coderStart });
 
   if (!coderExecResult.ok) {
-    await markSessionStatus(session, "failed");
     const details = coderExecResult.result?.error || coderExecResult.summary || "unknown error";
+    const rateLimitCheck = detectRateLimit({
+      stderr: coderExecResult.result?.error || "",
+      stdout: coderExecResult.result?.output || ""
+    });
+
+    if (rateLimitCheck.isRateLimit) {
+      const question = `Agent ${coderRole.provider} hit a rate limit: ${rateLimitCheck.message}. Session paused until the token window resets.`;
+      await pauseSession(session, {
+        question,
+        context: { iteration, stage: "coder", reason: "rate_limit", agent: coderRole.provider, detail: rateLimitCheck.message }
+      });
+      emitProgress(
+        emitter,
+        makeEvent("coder:rate_limit", { ...eventBase, stage: "coder" }, {
+          status: "paused",
+          message: question,
+          detail: { agent: coderRole.provider, rateLimitMessage: rateLimitCheck.message, sessionId: session.id }
+        })
+      );
+      return { action: "pause", result: { paused: true, sessionId: session.id, question, context: "rate_limit" } };
+    }
+
+    await markSessionStatus(session, "failed");
     emitProgress(
       emitter,
       makeEvent("coder:end", { ...eventBase, stage: "coder" }, {
@@ -71,8 +94,30 @@ export async function runRefactorerStage({ refactorerRole, config, logger, emitt
   const refResult = await refRole.execute(plannedTask);
   trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refResult.result, duration_ms: Date.now() - refactorerStart });
   if (!refResult.ok) {
-    await markSessionStatus(session, "failed");
     const details = refResult.result?.error || refResult.summary || "unknown error";
+    const rateLimitCheck = detectRateLimit({
+      stderr: refResult.result?.error || "",
+      stdout: refResult.result?.output || ""
+    });
+
+    if (rateLimitCheck.isRateLimit) {
+      const question = `Agent ${refactorerRole.provider} hit a rate limit: ${rateLimitCheck.message}. Session paused until the token window resets.`;
+      await pauseSession(session, {
+        question,
+        context: { iteration, stage: "refactorer", reason: "rate_limit", agent: refactorerRole.provider, detail: rateLimitCheck.message }
+      });
+      emitProgress(
+        emitter,
+        makeEvent("refactorer:rate_limit", { ...eventBase, stage: "refactorer" }, {
+          status: "paused",
+          message: question,
+          detail: { agent: refactorerRole.provider, rateLimitMessage: rateLimitCheck.message, sessionId: session.id }
+        })
+      );
+      return { action: "pause", result: { paused: true, sessionId: session.id, question, context: "rate_limit" } };
+    }
+
+    await markSessionStatus(session, "failed");
     emitProgress(
       emitter,
       makeEvent("refactorer:end", { ...eventBase, stage: "refactorer" }, {
@@ -318,12 +363,35 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
   });
 
   if (!reviewerExec.execResult || !reviewerExec.execResult.ok) {
-    await markSessionStatus(session, "failed");
     const lastAttempt = reviewerExec.attempts.at(-1);
     const details =
       lastAttempt?.result?.error ||
       lastAttempt?.execResult?.summary ||
       `reviewer=${lastAttempt?.reviewer || "unknown"}`;
+
+    const rateLimitCheck = detectRateLimit({
+      stderr: lastAttempt?.result?.error || "",
+      stdout: lastAttempt?.result?.output || ""
+    });
+
+    if (rateLimitCheck.isRateLimit) {
+      const question = `Reviewer ${reviewerRole.provider} hit a rate limit: ${rateLimitCheck.message}. Session paused until the token window resets.`;
+      await pauseSession(session, {
+        question,
+        context: { iteration, stage: "reviewer", reason: "rate_limit", agent: reviewerRole.provider, detail: rateLimitCheck.message }
+      });
+      emitProgress(
+        emitter,
+        makeEvent("reviewer:rate_limit", { ...eventBase, stage: "reviewer" }, {
+          status: "paused",
+          message: question,
+          detail: { agent: reviewerRole.provider, rateLimitMessage: rateLimitCheck.message, sessionId: session.id }
+        })
+      );
+      return { action: "pause", result: { paused: true, sessionId: session.id, question, context: "rate_limit" } };
+    }
+
+    await markSessionStatus(session, "failed");
     emitProgress(
       emitter,
       makeEvent("reviewer:end", { ...eventBase, stage: "reviewer" }, {

--- a/src/utils/rate-limit-detector.js
+++ b/src/utils/rate-limit-detector.js
@@ -1,0 +1,43 @@
+/**
+ * Detects rate limit / usage cap messages from CLI agent output.
+ * Returns { isRateLimit, agent, message } where agent is the best guess
+ * of which CLI triggered it (or "unknown").
+ */
+
+const RATE_LIMIT_PATTERNS = [
+  // Claude CLI
+  { pattern: /usage limit/i, agent: "claude" },
+  { pattern: /plan's usage limit/i, agent: "claude" },
+  { pattern: /Claude Pro usage limit/i, agent: "claude" },
+
+  // OpenAI / Codex CLI
+  { pattern: /exceeded your current quota/i, agent: "codex" },
+
+  // Gemini CLI
+  { pattern: /resource exhausted/i, agent: "gemini" },
+  { pattern: /quota exceeded/i, agent: "gemini" },
+
+  // Generic (match any agent)
+  { pattern: /rate limit/i, agent: "unknown" },
+  { pattern: /token limit reached/i, agent: "unknown" },
+  { pattern: /\b429\b/, agent: "unknown" },
+  { pattern: /too many requests/i, agent: "unknown" },
+  { pattern: /throttl/i, agent: "unknown" },
+];
+
+export function detectRateLimit({ stderr = "", stdout = "" }) {
+  const combined = `${stderr}\n${stdout}`;
+
+  for (const { pattern, agent } of RATE_LIMIT_PATTERNS) {
+    if (pattern.test(combined)) {
+      const matchedLine = combined.split("\n").find((l) => pattern.test(l)) || combined.trim();
+      return {
+        isRateLimit: true,
+        agent,
+        message: matchedLine.trim()
+      };
+    }
+  }
+
+  return { isRateLimit: false, agent: "", message: "" };
+}

--- a/tests/rate-limit-detector.test.js
+++ b/tests/rate-limit-detector.test.js
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { detectRateLimit } from "../src/utils/rate-limit-detector.js";
+
+describe("detectRateLimit", () => {
+  describe("Claude CLI rate limit patterns", () => {
+    it("detects Claude usage limit message", () => {
+      const result = detectRateLimit({
+        stderr: "You've exceeded your usage limit. Please wait until 3:00 PM to continue.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+      expect(result.agent).toBe("claude");
+    });
+
+    it("detects Claude token cap message", () => {
+      const result = detectRateLimit({
+        stderr: "",
+        stdout: "Rate limit reached. Try again in 2 hours."
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects Claude plan limit message", () => {
+      const result = detectRateLimit({
+        stderr: "You have reached your plan's usage limit for this period.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects Claude Pro limit message", () => {
+      const result = detectRateLimit({
+        stderr: "Claude Pro usage limit exceeded. Resets at 2026-03-01T15:00:00Z.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+  });
+
+  describe("Codex CLI rate limit patterns", () => {
+    it("detects Codex rate limit message", () => {
+      const result = detectRateLimit({
+        stderr: "Rate limit exceeded. Please try again later.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects OpenAI quota exceeded", () => {
+      const result = detectRateLimit({
+        stderr: "Error: You exceeded your current quota, please check your plan and billing details.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+  });
+
+  describe("Gemini CLI rate limit patterns", () => {
+    it("detects Gemini rate limit from stderr", () => {
+      const result = detectRateLimit({
+        stderr: "Resource exhausted: quota exceeded for the model.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects Gemini 429 error", () => {
+      const result = detectRateLimit({
+        stderr: "Error 429: Too many requests. Please retry after a moment.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+  });
+
+  describe("Aider rate limit patterns", () => {
+    it("detects Aider rate limit message", () => {
+      const result = detectRateLimit({
+        stderr: "Rate limit error from provider. Waiting to retry...",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects Aider token limit message", () => {
+      const result = detectRateLimit({
+        stderr: "",
+        stdout: "Token limit reached for the current session."
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+  });
+
+  describe("generic rate limit patterns", () => {
+    it("detects HTTP 429 status code mention", () => {
+      const result = detectRateLimit({
+        stderr: "HTTP error: 429 Too Many Requests",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+
+    it("detects throttled/throttling messages", () => {
+      const result = detectRateLimit({
+        stderr: "Request throttled. Please wait before retrying.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+    });
+  });
+
+  describe("non-rate-limit errors", () => {
+    it("returns false for regular errors", () => {
+      const result = detectRateLimit({
+        stderr: "Error: file not found",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(false);
+    });
+
+    it("returns false for syntax errors", () => {
+      const result = detectRateLimit({
+        stderr: "SyntaxError: Unexpected token",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(false);
+    });
+
+    it("returns false for empty output", () => {
+      const result = detectRateLimit({ stderr: "", stdout: "" });
+      expect(result.isRateLimit).toBe(false);
+    });
+
+    it("returns false for timeout errors", () => {
+      const result = detectRateLimit({
+        stderr: "Command timed out after 300000ms",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(false);
+    });
+
+    it("returns false for permission errors", () => {
+      const result = detectRateLimit({
+        stderr: "Error: EACCES: permission denied",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(false);
+    });
+  });
+
+  describe("return value structure", () => {
+    it("returns message with context when rate limit detected", () => {
+      const result = detectRateLimit({
+        stderr: "Rate limit exceeded. Try again in 5 minutes.",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(true);
+      expect(result.message).toBeTruthy();
+      expect(typeof result.message).toBe("string");
+    });
+
+    it("returns empty message when no rate limit", () => {
+      const result = detectRateLimit({
+        stderr: "Some other error",
+        stdout: ""
+      });
+      expect(result.isRateLimit).toBe(false);
+      expect(result.message).toBe("");
+    });
+  });
+});

--- a/tests/rate-limit-stages.test.js
+++ b/tests/rate-limit-stages.test.js
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const coderExecuteMock = vi.fn();
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/roles/refactorer-role.js", () => ({
+  RefactorerRole: class {
+    async init() {}
+    async execute() { return { ok: true, result: {} }; }
+  }
+}));
+
+vi.mock("../src/roles/sonar-role.js", () => ({
+  SonarRole: class {
+    async init() {}
+    async run() { return { ok: true, result: {} }; }
+  }
+}));
+
+vi.mock("../src/session-store.js", () => ({
+  addCheckpoint: vi.fn(async () => {}),
+  markSessionStatus: vi.fn(async () => {}),
+  saveSession: vi.fn(async () => {}),
+  pauseSession: vi.fn(async () => {})
+}));
+
+vi.mock("../src/utils/events.js", () => ({
+  emitProgress: vi.fn(),
+  makeEvent: vi.fn((type, base, payload) => ({ type, ...base, ...payload }))
+}));
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  generateDiff: vi.fn().mockResolvedValue("diff content")
+}));
+
+vi.mock("../src/review/tdd-policy.js", () => ({
+  evaluateTddPolicy: vi.fn().mockReturnValue({ ok: true })
+}));
+
+vi.mock("../src/review/schema.js", () => ({
+  validateReviewResult: vi.fn((r) => r)
+}));
+
+vi.mock("../src/orchestrator/reviewer-fallback.js", () => ({
+  runReviewerWithFallback: vi.fn()
+}));
+
+vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
+  invokeSolomon: vi.fn()
+}));
+
+describe("rate-limit handling in iteration stages", () => {
+  const logger = {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    setContext: vi.fn(), resetContext: vi.fn()
+  };
+  const emitter = { emit: vi.fn() };
+  const eventBase = { sessionId: "s1", iteration: 1, stage: null, startedAt: Date.now() };
+  const trackBudget = vi.fn();
+
+  let runCoderStage, runReviewerStage, pauseSession;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    coderExecuteMock.mockResolvedValue({ ok: true, result: {} });
+
+    ({ runCoderStage, runReviewerStage } =
+      await import("../src/orchestrator/iteration-stages.js"));
+    ({ pauseSession } = await import("../src/session-store.js"));
+  });
+
+  describe("runCoderStage with rate limit", () => {
+    it("pauses session instead of throwing when coder hits rate limit", async () => {
+      coderExecuteMock.mockResolvedValueOnce({
+        ok: false,
+        result: {
+          error: "You've exceeded your usage limit. Please wait until 3:00 PM to continue.",
+          output: "",
+          exitCode: 1
+        },
+        summary: "usage limit"
+      });
+
+      const session = { id: "s1", task: "t", checkpoints: [], last_reviewer_feedback: null, last_sonar_summary: null };
+      const coderRoleInstance = { execute: coderExecuteMock };
+
+      const result = await runCoderStage({
+        coderRoleInstance,
+        coderRole: { provider: "claude", model: "m" },
+        config: {}, logger, emitter, eventBase, session,
+        plannedTask: "task", trackBudget, iteration: 1
+      });
+
+      expect(result).toBeDefined();
+      expect(result.action).toBe("pause");
+      expect(result.result.paused).toBe(true);
+      expect(result.result.context).toBe("rate_limit");
+      expect(pauseSession).toHaveBeenCalledWith(session, expect.objectContaining({
+        context: expect.objectContaining({ stage: "coder", reason: "rate_limit" })
+      }));
+    });
+
+    it("still throws for non-rate-limit errors", async () => {
+      coderExecuteMock.mockResolvedValueOnce({
+        ok: false,
+        result: { error: "Syntax error in file.js", output: "", exitCode: 1 },
+        summary: "syntax error"
+      });
+
+      const session = { id: "s1", task: "t", checkpoints: [], last_reviewer_feedback: null, last_sonar_summary: null };
+      const coderRoleInstance = { execute: coderExecuteMock };
+
+      await expect(
+        runCoderStage({
+          coderRoleInstance,
+          coderRole: { provider: "codex", model: null },
+          config: {}, logger, emitter, eventBase, session,
+          plannedTask: "t", trackBudget, iteration: 1
+        })
+      ).rejects.toThrow("Coder failed");
+    });
+
+    it("emits rate_limit event when pausing", async () => {
+      const { emitProgress } = await import("../src/utils/events.js");
+
+      coderExecuteMock.mockResolvedValueOnce({
+        ok: false,
+        result: {
+          error: "Rate limit exceeded. Please try again later.",
+          output: "",
+          exitCode: 1
+        }
+      });
+
+      const session = { id: "s1", task: "t", checkpoints: [], last_reviewer_feedback: null, last_sonar_summary: null };
+      const coderRoleInstance = { execute: coderExecuteMock };
+
+      await runCoderStage({
+        coderRoleInstance,
+        coderRole: { provider: "claude", model: "m" },
+        config: {}, logger, emitter, eventBase, session,
+        plannedTask: "task", trackBudget, iteration: 1
+      });
+
+      const rateLimitEvents = emitProgress.mock.calls.filter(
+        ([, evt]) => evt?.type === "coder:rate_limit"
+      );
+      expect(rateLimitEvents.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("runReviewerStage with rate limit", () => {
+    it("pauses session when reviewer hits rate limit", async () => {
+      const { runReviewerWithFallback } = await import("../src/orchestrator/reviewer-fallback.js");
+      runReviewerWithFallback.mockResolvedValue({
+        execResult: null,
+        attempts: [{
+          reviewer: "codex",
+          result: { error: "You exceeded your current quota, please check your plan." },
+          execResult: { ok: false, result: { error: "You exceeded your current quota, please check your plan." } }
+        }]
+      });
+
+      const session = { id: "s1", session_start_sha: "abc", checkpoints: [] };
+      const repeatDetector = { addIteration: vi.fn() };
+
+      const result = await runReviewerStage({
+        reviewerRole: { provider: "codex", model: null },
+        config: {}, logger, emitter, eventBase, session, trackBudget,
+        iteration: 1, reviewRules: "rules", task: "t",
+        repeatDetector, budgetSummary: vi.fn(() => ({ total_cost_usd: 0 }))
+      });
+
+      expect(result).toBeDefined();
+      expect(result.action).toBe("pause");
+      expect(result.result.context).toBe("rate_limit");
+      expect(pauseSession).toHaveBeenCalled();
+    });
+
+    it("still throws for non-rate-limit reviewer failures", async () => {
+      const { runReviewerWithFallback } = await import("../src/orchestrator/reviewer-fallback.js");
+      runReviewerWithFallback.mockResolvedValue({
+        execResult: null,
+        attempts: [{
+          reviewer: "claude",
+          result: { error: "Connection refused" }
+        }]
+      });
+
+      const session = { id: "s1", session_start_sha: "abc", checkpoints: [] };
+      const repeatDetector = { addIteration: vi.fn() };
+
+      await expect(
+        runReviewerStage({
+          reviewerRole: { provider: "claude", model: null },
+          config: {}, logger, emitter, eventBase, session, trackBudget,
+          iteration: 1, reviewRules: "rules", task: "t",
+          repeatDetector, budgetSummary: vi.fn(() => ({ total_cost_usd: 0 }))
+        })
+      ).rejects.toThrow("Reviewer failed");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/utils/rate-limit-detector.js` with pattern matching for rate limit messages from Claude, Codex, Gemini, and Aider CLI agents
- Modify `runCoderStage`, `runRefactorerStage`, and `runReviewerStage` in `iteration-stages.js` to detect rate limits and pause the session instead of marking it as failed
- Update `orchestrator.js` to handle the new `{ action: "pause" }` return from coder/refactorer/reviewer stages
- Users can resume paused sessions with `kj resume --session <id>` once the token window resets

## Test plan
- [x] 19 unit tests for `rate-limit-detector.js` covering all agent patterns and edge cases
- [x] 5 integration tests for rate limit handling in iteration stages (coder pause, reviewer pause, non-rate-limit errors still throw)
- [x] Full test suite passes (89 files, 923 tests, 0 failures)

Closes KJC-TSK-0079