### PR TITLE
feat: auto-fallback to available agent on rate limit

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -71,6 +71,7 @@ program
   .option("--max-total-minutes <n>")
   .option("--base-branch <name>")
   .option("--base-ref <ref>")
+  .option("--coder-fallback <name>")
   .option("--reviewer-fallback <name>")
   .option("--reviewer-retries <n>")
   .option("--auto-commit")

--- a/src/config.js
+++ b/src/config.js
@@ -33,7 +33,7 @@ const DEFAULTS = {
   review_rules: "./review-rules.md",
   coder_rules: "./coder-rules.md",
   base_branch: "main",
-  coder_options: { model: null, auto_approve: true },
+  coder_options: { model: null, auto_approve: true, fallback_coder: null },
   reviewer_options: {
     output_format: "json",
     require_schema: true,
@@ -240,6 +240,7 @@ export function applyRunOverrides(config, flags) {
   if (flags.maxIterationMinutes) out.session.max_iteration_minutes = Number(flags.maxIterationMinutes);
   if (flags.maxTotalMinutes) out.session.max_total_minutes = Number(flags.maxTotalMinutes);
   if (flags.baseBranch) out.base_branch = flags.baseBranch;
+  if (flags.coderFallback) out.coder_options.fallback_coder = flags.coderFallback;
   if (flags.reviewerFallback) out.reviewer_options.fallback_reviewer = flags.reviewerFallback;
   if (flags.reviewerRetries !== undefined) out.reviewer_options.retries = Number(flags.reviewerRetries);
   if (flags.autoCommit !== undefined) out.git.auto_commit = Boolean(flags.autoCommit);

--- a/src/orchestrator/agent-fallback.js
+++ b/src/orchestrator/agent-fallback.js
@@ -1,0 +1,83 @@
+import { createAgent } from "../agents/index.js";
+import { addCheckpoint } from "../session-store.js";
+import { detectRateLimit } from "../utils/rate-limit-detector.js";
+
+/**
+ * Run a coder-like role with fallback on rate limit.
+ * Tries the primary agent first. If it fails with a rate limit,
+ * switches to the fallback agent (if configured).
+ * Non-rate-limit failures stop immediately (no fallback).
+ *
+ * Returns { execResult, attempts, allRateLimited }
+ */
+export async function runCoderWithFallback({
+  coderName,
+  fallbackCoder,
+  config,
+  logger,
+  emitter,
+  RoleClass,
+  roleInput,
+  session,
+  iteration,
+  onAttemptResult
+}) {
+  const candidates = [coderName];
+  if (fallbackCoder && fallbackCoder !== coderName) {
+    candidates.push(fallbackCoder);
+  }
+
+  const attempts = [];
+  let allRateLimited = true;
+
+  for (const name of candidates) {
+    const agentConfig = {
+      ...config,
+      roles: { ...config.roles, coder: { ...config.roles?.coder, provider: name } }
+    };
+
+    const role = new RoleClass({ config: agentConfig, logger, emitter, createAgentFn: createAgent });
+    await role.init();
+
+    const execResult = await role.execute(roleInput);
+
+    if (onAttemptResult) {
+      await onAttemptResult({ coder: name, result: execResult.result });
+    }
+
+    const rateLimited = !execResult.ok && detectRateLimit({
+      stderr: execResult.result?.error || "",
+      stdout: execResult.result?.output || ""
+    }).isRateLimit;
+
+    attempts.push({
+      coder: name,
+      ok: execResult.ok,
+      rateLimited,
+      result: execResult.result,
+      execResult
+    });
+
+    await addCheckpoint(session, {
+      stage: "coder-attempt",
+      iteration,
+      coder: name,
+      ok: execResult.ok,
+      rateLimited
+    });
+
+    if (execResult.ok) {
+      return { execResult, attempts, allRateLimited: false };
+    }
+
+    // Only fallback on rate limit errors
+    if (!rateLimited) {
+      allRateLimited = false;
+      return { execResult: null, attempts, allRateLimited: false };
+    }
+
+    logger.warn(`Agent ${name} hit rate limit, trying fallback...`);
+  }
+
+  return { execResult: null, attempts, allRateLimited };
+}

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -1,4 +1,5 @@
 import { createAgent } from "../agents/index.js";
+import { CoderRole } from "../roles/coder-role.js";
 import { RefactorerRole } from "../roles/refactorer-role.js";
 import { SonarRole } from "../roles/sonar-role.js";
 import { addCheckpoint, markSessionStatus, saveSession, pauseSession } from "../session-store.js";
@@ -7,6 +8,7 @@ import { evaluateTddPolicy } from "../review/tdd-policy.js";
 import { validateReviewResult } from "../review/schema.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { runReviewerWithFallback } from "./reviewer-fallback.js";
+import { runCoderWithFallback } from "./agent-fallback.js";
 import { invokeSolomon } from "./solomon-escalation.js";
 import { detectRateLimit } from "../utils/rate-limit-detector.js";
 
@@ -43,6 +45,46 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
     });
 
     if (rateLimitCheck.isRateLimit) {
+      // Try fallback agent if configured
+      const fallbackCoder = config.coder_options?.fallback_coder;
+      if (fallbackCoder && fallbackCoder !== coderRole.provider) {
+        logger.warn(`Coder ${coderRole.provider} hit rate limit, falling back to ${fallbackCoder}`);
+        emitProgress(
+          emitter,
+          makeEvent("coder:fallback", { ...eventBase, stage: "coder" }, {
+            message: `Coder ${coderRole.provider} rate-limited, switching to ${fallbackCoder}`,
+            detail: { primary: coderRole.provider, fallback: fallbackCoder }
+          })
+        );
+
+        const fallbackResult = await runCoderWithFallback({
+          coderName: fallbackCoder,
+          fallbackCoder: null,
+          config,
+          logger,
+          emitter,
+          RoleClass: CoderRole,
+          roleInput: { task: plannedTask, reviewerFeedback: session.last_reviewer_feedback, sonarSummary: session.last_sonar_summary, onOutput: coderOnOutput },
+          session,
+          iteration,
+          onAttemptResult: ({ coder, result }) => {
+            trackBudget({ role: "coder", provider: coder, model: coderRole.model, result, duration_ms: Date.now() - coderStart });
+          }
+        });
+
+        if (fallbackResult.execResult?.ok) {
+          await addCheckpoint(session, { stage: "coder", iteration, note: `Coder completed via fallback (${fallbackCoder})` });
+          emitProgress(
+            emitter,
+            makeEvent("coder:end", { ...eventBase, stage: "coder" }, {
+              message: `Coder completed (fallback: ${fallbackCoder})`
+            })
+          );
+          return;
+        }
+      }
+
+      // No fallback or fallback also failed — pause
       const question = `Agent ${coderRole.provider} hit a rate limit: ${rateLimitCheck.message}. Session paused until the token window resets.`;
       await pauseSession(session, {
         question,

--- a/tests/agent-fallback.test.js
+++ b/tests/agent-fallback.test.js
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => ({
+  addCheckpoint: vi.fn(async () => {}),
+  pauseSession: vi.fn(async () => {})
+}));
+
+describe("runCoderWithFallback", () => {
+  let runCoderWithFallback, addCheckpoint;
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+  const emitter = { emit: vi.fn() };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ runCoderWithFallback } = await import("../src/orchestrator/agent-fallback.js"));
+    ({ addCheckpoint } = await import("../src/session-store.js"));
+  });
+
+  it("returns success on first attempt when primary agent succeeds", async () => {
+    const executeMock = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { output: "done", error: "", exitCode: 0, provider: "claude" },
+      summary: "Coder completed"
+    });
+
+    const RoleClass = class {
+      constructor() { this.execute = executeMock; }
+      async init() {}
+    };
+
+    const result = await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: "codex",
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1
+    });
+
+    expect(result.execResult.ok).toBe(true);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].coder).toBe("claude");
+  });
+
+  it("falls back to secondary agent when primary hits rate limit", async () => {
+    const primaryExec = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { output: "", error: "You've exceeded your usage limit. Please wait.", exitCode: 1 },
+      summary: "rate limit"
+    });
+    const fallbackExec = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { output: "done by fallback", error: "", exitCode: 0, provider: "codex" },
+      summary: "Coder completed"
+    });
+
+    let callCount = 0;
+    const RoleClass = class {
+      constructor() {
+        callCount++;
+        this.execute = callCount === 1 ? primaryExec : fallbackExec;
+      }
+      async init() {}
+    };
+
+    const result = await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: "codex",
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1
+    });
+
+    expect(result.execResult.ok).toBe(true);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts[0].coder).toBe("claude");
+    expect(result.attempts[0].ok).toBe(false);
+    expect(result.attempts[0].rateLimited).toBe(true);
+    expect(result.attempts[1].coder).toBe("codex");
+    expect(result.attempts[1].ok).toBe(true);
+  });
+
+  it("returns null execResult when all agents fail with rate limits", async () => {
+    const failExec = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { output: "", error: "Rate limit exceeded", exitCode: 1 },
+      summary: "rate limit"
+    });
+
+    const RoleClass = class {
+      constructor() { this.execute = failExec; }
+      async init() {}
+    };
+
+    const result = await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: "codex",
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1
+    });
+
+    expect(result.execResult).toBeNull();
+    expect(result.attempts).toHaveLength(2);
+    expect(result.allRateLimited).toBe(true);
+  });
+
+  it("does not fallback on non-rate-limit errors", async () => {
+    const failExec = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { output: "", error: "Syntax error in file.js", exitCode: 1 },
+      summary: "syntax error"
+    });
+
+    const RoleClass = class {
+      constructor() { this.execute = failExec; }
+      async init() {}
+    };
+
+    const result = await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: "codex",
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1
+    });
+
+    expect(result.execResult).toBeNull();
+    expect(result.attempts).toHaveLength(1);
+    expect(result.allRateLimited).toBe(false);
+  });
+
+  it("works without fallback configured (fallbackCoder is null)", async () => {
+    const failExec = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { output: "", error: "Rate limit exceeded", exitCode: 1 },
+      summary: "rate limit"
+    });
+
+    const RoleClass = class {
+      constructor() { this.execute = failExec; }
+      async init() {}
+    };
+
+    const result = await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: null,
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1
+    });
+
+    expect(result.execResult).toBeNull();
+    expect(result.attempts).toHaveLength(1);
+    expect(result.allRateLimited).toBe(true);
+  });
+
+  it("tracks checkpoints for each attempt", async () => {
+    const failExec = vi.fn().mockResolvedValue({
+      ok: false,
+      result: { output: "", error: "Usage limit reached", exitCode: 1 },
+      summary: "limit"
+    });
+    const successExec = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { output: "ok", error: "", exitCode: 0 },
+      summary: "done"
+    });
+
+    let callCount = 0;
+    const RoleClass = class {
+      constructor() {
+        callCount++;
+        this.execute = callCount === 1 ? failExec : successExec;
+      }
+      async init() {}
+    };
+
+    await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: "codex",
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 2
+    });
+
+    expect(addCheckpoint).toHaveBeenCalledTimes(2);
+    expect(addCheckpoint).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ stage: "coder-attempt", coder: "claude", iteration: 2, ok: false })
+    );
+    expect(addCheckpoint).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ stage: "coder-attempt", coder: "codex", iteration: 2, ok: true })
+    );
+  });
+
+  it("calls onAttemptResult callback for each attempt", async () => {
+    const onAttemptResult = vi.fn();
+    const executeMock = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { output: "done", error: "", exitCode: 0 },
+      summary: "done"
+    });
+
+    const RoleClass = class {
+      constructor() { this.execute = executeMock; }
+      async init() {}
+    };
+
+    await runCoderWithFallback({
+      coderName: "claude",
+      fallbackCoder: null,
+      config: { roles: { coder: { provider: "claude" } }, session: { max_iteration_minutes: 5 } },
+      logger, emitter,
+      RoleClass,
+      roleInput: { task: "test" },
+      session: { id: "s1", checkpoints: [] },
+      iteration: 1,
+      onAttemptResult
+    });
+
+    expect(onAttemptResult).toHaveBeenCalledWith(expect.objectContaining({ coder: "claude" }));
+  });
+});


### PR DESCRIPTION
## Summary
- When the primary coder agent hits a rate limit, Karajan automatically switches to a configured fallback agent (`--coder-fallback` / `coder_options.fallback_coder`)
- Only rate-limit errors trigger fallback; other failures stop immediately (no masking real bugs)
- If all agents are rate-limited, the session pauses for manual `kj resume`
- New `runCoderWithFallback` utility with checkpoint tracking for each attempt

## Changes
- `src/orchestrator/agent-fallback.js` — new fallback orchestration utility
- `src/config.js` — `fallback_coder` default + `applyRunOverrides` support
- `src/cli.js` — `--coder-fallback <name>` CLI flag
- `src/orchestrator/iteration-stages.js` — integrated fallback into `runCoderStage`
- `tests/agent-fallback.test.js` — 7 unit tests

## Test plan
- [x] All 930 tests pass (90 test files)
- [x] Primary agent succeeds → no fallback triggered
- [x] Primary hits rate limit → fallback agent runs
- [x] Both agents rate-limited → session pauses
- [x] Non-rate-limit errors → no fallback, immediate stop
- [x] No fallback configured → session pauses on rate limit
- [x] Checkpoints tracked for each attempt
- [x] onAttemptResult callback fires per attempt