### PR TITLE
feat: add kj update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-03-03
+
+### Added
+- **`kj update` CLI command**: checks npm for the latest version and runs `npm install -g karajan-code@latest` to self-update
+
 ## [1.9.0] - 2026-03-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -187,6 +187,29 @@ program
     });
   });
 
+program
+  .command("update")
+  .description("Update karajan-code to the latest version from npm")
+  .action(async () => {
+    const { execaCommand } = await import("execa");
+    console.log(`Current version: ${PKG_VERSION}`);
+    console.log("Checking for updates...");
+    try {
+      const { stdout } = await execaCommand("npm view karajan-code version");
+      const latest = stdout.trim();
+      if (latest === PKG_VERSION) {
+        console.log(`Already on the latest version (${PKG_VERSION}).`);
+        return;
+      }
+      console.log(`Updating ${PKG_VERSION} → ${latest}...`);
+      await execaCommand("npm install -g karajan-code@latest", { stdio: "inherit" });
+      console.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
+    } catch (err) {
+      console.error(`Update failed: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 const sonar = program.command("sonar").description("Manage SonarQube container");
 sonar.command("status").action(async () => sonarCommand({ action: "status" }));
 sonar.command("start").action(async () => sonarCommand({ action: "start" }));


### PR DESCRIPTION
## Summary
- Adds `kj update` CLI command that checks npm for latest version and self-updates via `npm install -g karajan-code@latest`
- Shows current vs latest version, skips if already up to date
- Bumps version to 1.9.1

## Test plan
- [x] 1053 tests passing
- [ ] Manual: run `kj update` and verify it checks npm and updates