### PR TITLE
KJC-TSK-0091: heartbeat y guardarraíles de silencio para planner

### DIFF
--- a/src/agents/aider-agent.js
+++ b/src/agents/aider-agent.js
@@ -8,7 +8,10 @@ export class AiderAgent extends BaseAgent {
     const args = ["--yes", "--message", task.prompt];
     const model = this.getRoleModel(role);
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("aider"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("aider"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 
@@ -17,7 +20,10 @@ export class AiderAgent extends BaseAgent {
     const args = ["--yes", "--message", task.prompt];
     const model = this.getRoleModel(role);
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("aider"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("aider"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 }

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -81,7 +81,10 @@ export class ClaudeAgent extends BaseAgent {
     if (task.onOutput) {
       args.push("--output-format", "stream-json");
       const streamFilter = createStreamJsonFilter(task.onOutput);
-      const res = await runCommand(resolveBin("claude"), args, { onOutput: streamFilter });
+      const res = await runCommand(resolveBin("claude"), args, {
+        onOutput: streamFilter,
+        silenceTimeoutMs: task.silenceTimeoutMs
+      });
       const output = extractTextFromStreamJson(res.stdout);
       return { ok: res.exitCode === 0, output, error: res.stderr, exitCode: res.exitCode };
     }
@@ -94,7 +97,10 @@ export class ClaudeAgent extends BaseAgent {
     const args = ["-p", task.prompt, "--output-format", "json"];
     const model = this.getRoleModel(task.role || "reviewer");
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("claude"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("claude"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 }

--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -10,7 +10,10 @@ export class CodexAgent extends BaseAgent {
     if (model) args.push("--model", model);
     if (this.isAutoApproveEnabled(role)) args.push("--full-auto");
     args.push(task.prompt);
-    const res = await runCommand(resolveBin("codex"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("codex"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 
@@ -19,7 +22,10 @@ export class CodexAgent extends BaseAgent {
     const model = this.getRoleModel(task.role || "reviewer");
     if (model) args.push("--model", model);
     args.push(task.prompt);
-    const res = await runCommand(resolveBin("codex"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("codex"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 }

--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -8,7 +8,10 @@ export class GeminiAgent extends BaseAgent {
     const args = ["-p", task.prompt];
     const model = this.getRoleModel(role);
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("gemini"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("gemini"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 
@@ -17,7 +20,10 @@ export class GeminiAgent extends BaseAgent {
     const args = ["-p", task.prompt, "--output-format", "json"];
     const model = this.getRoleModel(role);
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("gemini"), args, { onOutput: task.onOutput });
+    const res = await runCommand(resolveBin("gemini"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs
+    });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -115,6 +115,7 @@ const DEFAULTS = {
     max_iteration_minutes: 30,
     max_total_minutes: 120,
     checkpoint_interval_minutes: 5,
+    max_agent_silence_minutes: 20,
     fail_fast_repeats: 2,
     repeat_detection_threshold: 2,
     max_sonar_retries: 3,

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -247,11 +247,19 @@ export async function handlePlanDirect(a, server, extra) {
 
   const planner = createAgent(plannerRole.provider, config, logger);
   const prompt = buildPlannerPrompt({ task: a.task, context: a.context });
+  const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
+    ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
+    : undefined;
   sendTrackerLog(server, "planner", "running", plannerRole.provider);
   runLog.logText(`[planner] agent launched, waiting for response...`);
   let result;
   try {
-    result = await planner.runTask({ prompt, role: "planner", onOutput: stallDetector.onOutput });
+    result = await planner.runTask({
+      prompt,
+      role: "planner",
+      onOutput: stallDetector.onOutput,
+      silenceTimeoutMs
+    });
   } finally {
     stallDetector.stop();
     const stats = stallDetector.stats();

--- a/src/roles/planner-role.js
+++ b/src/roles/planner-role.js
@@ -9,6 +9,12 @@ function resolveProvider(config) {
   );
 }
 
+function resolvePlannerSilenceTimeoutMs(config) {
+  const minutes = Number(config?.session?.max_agent_silence_minutes);
+  if (!Number.isFinite(minutes) || minutes <= 0) return null;
+  return Math.round(minutes * 60 * 1000);
+}
+
 function buildPrompt({ task, instructions, research, triageDecomposition }) {
   const sections = [];
 
@@ -78,6 +84,8 @@ export class PlannerRole extends BaseRole {
 
     const runArgs = { prompt, role: "planner" };
     if (onOutput) runArgs.onOutput = onOutput;
+    const silenceTimeoutMs = resolvePlannerSilenceTimeoutMs(this.config);
+    if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
     const result = await agent.runTask(runArgs);
 
     if (!result.ok) {

--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 
 export async function runCommand(command, args = [], options = {}) {
-  const { timeout, onOutput, ...rest } = options;
+  const { timeout, onOutput, silenceTimeoutMs, ...rest } = options;
   const subprocess = execa(command, args, {
     reject: false,
     ...rest
@@ -9,15 +9,40 @@ export async function runCommand(command, args = [], options = {}) {
 
   let stdoutAccum = "";
   let stderrAccum = "";
+  let outputSilenceTimer = null;
+  let silenceTimedOut = false;
+
+  function clearSilenceTimer() {
+    if (outputSilenceTimer) {
+      clearTimeout(outputSilenceTimer);
+      outputSilenceTimer = null;
+    }
+  }
+
+  function armSilenceTimer() {
+    const ms = Number(silenceTimeoutMs);
+    if (!Number.isFinite(ms) || ms <= 0 || silenceTimedOut) return;
+    clearSilenceTimer();
+    outputSilenceTimer = setTimeout(() => {
+      silenceTimedOut = true;
+      try {
+        subprocess.kill("SIGKILL", { forceKillAfterDelay: 1000 });
+      } catch {
+        // no-op
+      }
+    }, ms);
+  }
 
   if (subprocess.stdout) {
     subprocess.stdout.on("data", (chunk) => {
       stdoutAccum += chunk.toString();
+      armSilenceTimer();
     });
   }
   if (subprocess.stderr) {
     subprocess.stderr.on("data", (chunk) => {
       stderrAccum += chunk.toString();
+      armSilenceTimer();
     });
   }
 
@@ -36,10 +61,21 @@ export async function runCommand(command, args = [], options = {}) {
     if (subprocess.stdout) subprocess.stdout.on("data", handler("stdout"));
     if (subprocess.stderr) subprocess.stderr.on("data", handler("stderr"));
   }
+  armSilenceTimer();
 
   try {
     if (!timeout) {
       const result = await subprocess;
+      clearSilenceTimer();
+      if (silenceTimedOut) {
+        return {
+          exitCode: 143,
+          stdout: stdoutAccum,
+          stderr: `Command killed after ${Number(silenceTimeoutMs)}ms without output`,
+          timedOut: true,
+          signal: "SIGKILL"
+        };
+      }
       return enrichResult(result, stdoutAccum, stderrAccum);
     }
 
@@ -63,8 +99,28 @@ export async function runCommand(command, args = [], options = {}) {
 
     const result = await Promise.race([subprocess, timeoutResult]);
     if (timer) clearTimeout(timer);
+    clearSilenceTimer();
+    if (silenceTimedOut) {
+      return {
+        exitCode: 143,
+        stdout: stdoutAccum,
+        stderr: `Command killed after ${Number(silenceTimeoutMs)}ms without output`,
+        timedOut: true,
+        signal: "SIGKILL"
+      };
+    }
     return enrichResult(result, stdoutAccum, stderrAccum);
   } catch (error) {
+    clearSilenceTimer();
+    if (silenceTimedOut) {
+      return {
+        exitCode: 143,
+        stdout: error?.stdout || stdoutAccum,
+        stderr: `Command killed after ${Number(silenceTimeoutMs)}ms without output`,
+        timedOut: true,
+        signal: error?.signal || "SIGKILL"
+      };
+    }
     const details = [
       error?.shortMessage,
       error?.originalMessage,

--- a/src/utils/stall-detector.js
+++ b/src/utils/stall-detector.js
@@ -15,6 +15,7 @@ import { emitProgress, makeEvent } from "./events.js";
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;   // heartbeat every 30s
 const DEFAULT_STALL_TIMEOUT_MS      = 120_000;  // warn after 2min silence
 const DEFAULT_CRITICAL_TIMEOUT_MS   = 300_000;  // critical after 5min silence
+const DEFAULT_STALL_REPEAT_MS       = 60_000;   // repeat stall notices every 60s
 
 export function createStallDetector({
   onOutput,
@@ -24,23 +25,30 @@ export function createStallDetector({
   provider,
   heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS,
   stallTimeoutMs      = DEFAULT_STALL_TIMEOUT_MS,
-  criticalTimeoutMs   = DEFAULT_CRITICAL_TIMEOUT_MS
+  criticalTimeoutMs   = DEFAULT_CRITICAL_TIMEOUT_MS,
+  stallRepeatMs       = DEFAULT_STALL_REPEAT_MS,
+  maxSilenceMs        = null,
+  onMaxSilence        = null
 }) {
   let lastActivityAt = Date.now();
   let lineCount = 0;
   let bytesReceived = 0;
-  let stallWarned = false;
-  let criticalWarned = false;
   let heartbeatTimer = null;
   const startedAt = Date.now();
+  let lastStallWarnAt = 0;
+  let lastCriticalWarnAt = 0;
+  let maxSilenceTriggered = false;
 
   function emitHeartbeat() {
     const now = Date.now();
     const silenceMs = now - lastActivityAt;
     const elapsedMs = now - startedAt;
+    const shouldWarn = silenceMs >= stallTimeoutMs;
+    const shouldCritical = silenceMs >= criticalTimeoutMs;
+    const repeatWindow = Math.max(1000, Number(stallRepeatMs) || DEFAULT_STALL_REPEAT_MS);
 
-    if (silenceMs >= criticalTimeoutMs && !criticalWarned) {
-      criticalWarned = true;
+    if (shouldCritical && (now - lastCriticalWarnAt >= repeatWindow)) {
+      lastCriticalWarnAt = now;
       emitProgress(emitter, makeEvent("agent:stall", { ...eventBase, stage }, {
         status: "critical",
         message: `Agent ${provider} unresponsive for ${Math.round(silenceMs / 1000)}s — may be hung`,
@@ -53,8 +61,8 @@ export function createStallDetector({
           severity: "critical"
         }
       }));
-    } else if (silenceMs >= stallTimeoutMs && !stallWarned) {
-      stallWarned = true;
+    } else if (shouldWarn && (now - lastStallWarnAt >= repeatWindow)) {
+      lastStallWarnAt = now;
       emitProgress(emitter, makeEvent("agent:stall", { ...eventBase, stage }, {
         status: "warning",
         message: `Agent ${provider} silent for ${Math.round(silenceMs / 1000)}s — still waiting`,
@@ -67,20 +75,49 @@ export function createStallDetector({
           severity: "warning"
         }
       }));
-    } else if (silenceMs < stallTimeoutMs) {
-      // Reset warning flags when activity resumes
-      stallWarned = false;
-      criticalWarned = false;
+    }
 
-      emitProgress(emitter, makeEvent("agent:heartbeat", { ...eventBase, stage }, {
-        message: `Agent ${provider} active — ${lineCount} lines, ${Math.round(elapsedMs / 1000)}s elapsed`,
+    emitProgress(emitter, makeEvent("agent:heartbeat", { ...eventBase, stage }, {
+      message: silenceMs < stallTimeoutMs
+        ? `Agent ${provider} active — ${lineCount} lines, ${Math.round(elapsedMs / 1000)}s elapsed`
+        : `Agent ${provider} waiting — silent ${Math.round(silenceMs / 1000)}s, ${Math.round(elapsedMs / 1000)}s elapsed`,
+      detail: {
+        provider,
+        elapsedMs,
+        silenceMs,
+        lineCount,
+        bytesReceived,
+        status: silenceMs < stallTimeoutMs ? "active" : "waiting"
+      }
+    }));
+
+    const hardLimit = Number(maxSilenceMs);
+    if (!maxSilenceTriggered && Number.isFinite(hardLimit) && hardLimit > 0 && silenceMs >= hardLimit) {
+      maxSilenceTriggered = true;
+      emitProgress(emitter, makeEvent("agent:stall", { ...eventBase, stage }, {
+        status: "fail",
+        message: `Agent ${provider} exceeded max silence (${Math.round(hardLimit / 1000)}s)`,
         detail: {
           provider,
+          silenceMs,
           elapsedMs,
           lineCount,
-          bytesReceived
+          bytesReceived,
+          severity: "fatal",
+          maxSilenceMs: hardLimit
         }
       }));
+      if (typeof onMaxSilence === "function") {
+        onMaxSilence({
+          provider,
+          stage,
+          silenceMs,
+          elapsedMs,
+          lineCount,
+          bytesReceived,
+          maxSilenceMs: hardLimit
+        });
+      }
     }
   }
 
@@ -91,10 +128,6 @@ export function createStallDetector({
     lastActivityAt = Date.now();
     lineCount++;
     bytesReceived += data.line?.length || 0;
-
-    // Reset stall flags on new activity
-    stallWarned = false;
-    criticalWarned = false;
 
     // Forward to the original callback
     if (onOutput) {

--- a/tests/process-streaming.test.js
+++ b/tests/process-streaming.test.js
@@ -54,4 +54,14 @@ describe("runCommand onOutput streaming", () => {
       expect(l.line).not.toBe("");
     }
   });
+
+  it("kills command when silence timeout is exceeded", async () => {
+    const result = await runCommand("bash", ["-c", "sleep 1; echo late"], {
+      silenceTimeoutMs: 50
+    });
+
+    expect(result.exitCode).toBe(143);
+    expect(result.timedOut).toBe(true);
+    expect(result.stderr).toContain("without output");
+  });
 });

--- a/tests/stall-detector.test.js
+++ b/tests/stall-detector.test.js
@@ -64,6 +64,21 @@ describe("createStallDetector", () => {
     detector.stop();
   });
 
+  it("emits heartbeat events while waiting in silence", () => {
+    const detector = createStallDetector({
+      onOutput: null, emitter, eventBase: makeEventBase(), stage: "planner", provider: "claude",
+      heartbeatIntervalMs: 1000, stallTimeoutMs: 2000, criticalTimeoutMs: 5000
+    });
+
+    vi.advanceTimersByTime(3000);
+
+    const heartbeats = events.filter(e => e.type === "agent:heartbeat");
+    expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+    expect(heartbeats[heartbeats.length - 1].detail.status).toBe("waiting");
+
+    detector.stop();
+  });
+
   it("emits stall warning after stallTimeoutMs of silence", () => {
     const detector = createStallDetector({
       onOutput: null, emitter, eventBase: makeEventBase(), stage: "planner", provider: "gemini",
@@ -94,6 +109,20 @@ describe("createStallDetector", () => {
     const critical = stalls.filter(e => e.detail.severity === "critical");
     expect(critical.length).toBeGreaterThanOrEqual(1);
     expect(critical[0].message).toContain("unresponsive");
+
+    detector.stop();
+  });
+
+  it("repeats stall warnings during prolonged silence", () => {
+    const detector = createStallDetector({
+      onOutput: null, emitter, eventBase: makeEventBase(), stage: "planner", provider: "gemini",
+      heartbeatIntervalMs: 1000, stallTimeoutMs: 2000, criticalTimeoutMs: 10000, stallRepeatMs: 1000
+    });
+
+    vi.advanceTimersByTime(6000);
+
+    const warningStalls = events.filter(e => e.type === "agent:stall" && e.detail.severity === "warning");
+    expect(warningStalls.length).toBeGreaterThanOrEqual(2);
 
     detector.stop();
   });


### PR DESCRIPTION
## Summary\n- add periodic heartbeat visibility during silent agent windows\n- add repeated stall warnings and fatal max-silence signal\n- enforce planner silence timeout via agent command options\n\n## Testing\n- npx vitest run tests/stall-detector.test.js tests/process-streaming.test.js tests/planner-role.test.js tests/mcp-server-handlers.test.js tests/agents-implementations.test.js tests/config.test.js\n\n## Planning Game\n- Card: KJC-TSK-0091