### PR TITLE
KJC-TSK-0092: streaming robusto con CR y flush parcial

### DIFF
--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 
 export async function runCommand(command, args = [], options = {}) {
-  const { timeout, onOutput, silenceTimeoutMs, ...rest } = options;
+  const { timeout, onOutput, silenceTimeoutMs, partialOutputFlushMs, ...rest } = options;
   const subprocess = execa(command, args, {
     reject: false,
     ...rest
@@ -46,20 +46,45 @@ export async function runCommand(command, args = [], options = {}) {
     });
   }
 
+  let flushInterval = null;
   if (onOutput) {
-    const handler = (stream) => {
-      let partial = "";
+    const flushMs = Number(partialOutputFlushMs) > 0 ? Number(partialOutputFlushMs) : 2000;
+    const streams = {};
+    const makeHandler = (stream) => {
+      const state = { partial: "", dirty: false };
+      streams[stream] = state;
       return (chunk) => {
-        partial += chunk.toString();
-        const lines = partial.split("\n");
-        partial = lines.pop();
+        state.partial += chunk.toString();
+        const lines = state.partial.split(/\r\n|\n|\r/);
+        state.partial = lines.pop() ?? "";
+        state.dirty = state.partial.length > 0;
         for (const line of lines) {
           if (line) onOutput({ stream, line });
         }
       };
     };
-    if (subprocess.stdout) subprocess.stdout.on("data", handler("stdout"));
-    if (subprocess.stderr) subprocess.stderr.on("data", handler("stderr"));
+
+    const flushPartials = () => {
+      for (const [stream, state] of Object.entries(streams)) {
+        if (!state.dirty || !state.partial) continue;
+        onOutput({ stream, line: state.partial });
+        state.partial = "";
+        state.dirty = false;
+      }
+    };
+
+    if (subprocess.stdout) subprocess.stdout.on("data", makeHandler("stdout"));
+    if (subprocess.stderr) subprocess.stderr.on("data", makeHandler("stderr"));
+    flushInterval = setInterval(flushPartials, flushMs);
+    flushInterval.unref?.();
+
+    subprocess.finally(() => {
+      flushPartials();
+      if (flushInterval) {
+        clearInterval(flushInterval);
+        flushInterval = null;
+      }
+    });
   }
   armSilenceTimer();
 

--- a/tests/process-streaming.test.js
+++ b/tests/process-streaming.test.js
@@ -64,4 +64,30 @@ describe("runCommand onOutput streaming", () => {
     expect(result.timedOut).toBe(true);
     expect(result.stderr).toContain("without output");
   });
+
+  it("streams carriage-return output as line events", async () => {
+    const lines = [];
+    const result = await runCommand("bash", ["-c", "printf 'step1\\rstep2\\rstep3\\n'"], {
+      onOutput: ({ stream, line }) => lines.push({ stream, line })
+    });
+
+    expect(result.exitCode).toBe(0);
+    const stdoutLines = lines.filter((l) => l.stream === "stdout").map((l) => l.line);
+    expect(stdoutLines.some((l) => l.includes("step1"))).toBe(true);
+    expect(stdoutLines.some((l) => l.includes("step2"))).toBe(true);
+    expect(stdoutLines.some((l) => l.includes("step3"))).toBe(true);
+  });
+
+  it("flushes partial output when no newline arrives", async () => {
+    const lines = [];
+    const result = await runCommand("bash", ["-c", "printf 'partial'; sleep 0.2; printf ' done\\n'"], {
+      onOutput: ({ stream, line }) => lines.push({ stream, line }),
+      partialOutputFlushMs: 50
+    });
+
+    expect(result.exitCode).toBe(0);
+    const stdoutLines = lines.filter((l) => l.stream === "stdout").map((l) => l.line);
+    expect(stdoutLines.some((l) => l.includes("partial"))).toBe(true);
+    expect(result.stdout).toContain("partial done");
+  });
 });


### PR DESCRIPTION
## Summary\n- parse stdout/stderr lines using CR, LF and CRLF separators\n- flush partial stream buffers periodically when no newline arrives\n- keep full stdout/stderr accumulation unchanged\n\n## Testing\n- npx vitest run tests/process-streaming.test.js tests/agents-implementations.test.js tests/stall-detector.test.js\n\n## Planning Game\n- Card: KJC-TSK-0092