### PR TITLE
KJC-TSK-0093: telemetría y diagnóstico de stalls en kj_plan

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -62,6 +62,18 @@ export function classifyError(error) {
   const msg = error?.message || String(error);
   const lower = msg.toLowerCase();
 
+  if (
+    lower.includes("without output")
+    || lower.includes("silent for")
+    || lower.includes("unresponsive")
+    || lower.includes("exceeded max silence")
+  ) {
+    return {
+      category: "agent_stall",
+      suggestion: "Agent output stalled. Check live details with kj_status, then retry with a smaller prompt or increase session.max_agent_silence_minutes if needed."
+    };
+  }
+
   if (lower.includes("sonar") && (lower.includes("connect") || lower.includes("econnrefused") || lower.includes("not available") || lower.includes("not running"))) {
     return {
       category: "sonar_unavailable",
@@ -235,7 +247,12 @@ export async function handlePlanDirect(a, server, extra) {
 
   const projectDir = await resolveProjectDir(server);
   const runLog = createRunLog(projectDir);
-  runLog.logText(`[kj_plan] started — provider=${plannerRole.provider}`);
+  const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
+    ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
+    : undefined;
+  runLog.logText(
+    `[kj_plan] started — provider=${plannerRole.provider}, max_silence=${silenceTimeoutMs ? `${Math.round(silenceTimeoutMs / 1000)}s` : "disabled"}`
+  );
   const emitter = buildDirectEmitter(server, runLog);
   const eventBase = { sessionId: null, iteration: 0, startedAt: Date.now() };
   const onOutput = ({ stream, line }) => {
@@ -247,12 +264,10 @@ export async function handlePlanDirect(a, server, extra) {
 
   const planner = createAgent(plannerRole.provider, config, logger);
   const prompt = buildPlannerPrompt({ task: a.task, context: a.context });
-  const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
-    ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
-    : undefined;
   sendTrackerLog(server, "planner", "running", plannerRole.provider);
   runLog.logText(`[planner] agent launched, waiting for response...`);
   let result;
+  let plannerStats = null;
   try {
     result = await planner.runTask({
       prompt,
@@ -262,14 +277,20 @@ export async function handlePlanDirect(a, server, extra) {
     });
   } finally {
     stallDetector.stop();
-    const stats = stallDetector.stats();
-    runLog.logText(`[planner] finished — lines=${stats.lineCount}, bytes=${stats.bytesReceived}, elapsed=${Math.round(stats.elapsedMs / 1000)}s`);
+    plannerStats = stallDetector.stats();
+    runLog.logText(
+      `[planner] finished — lines=${plannerStats.lineCount}, bytes=${plannerStats.bytesReceived}, elapsed=${Math.round(plannerStats.elapsedMs / 1000)}s`
+    );
     runLog.close();
   }
 
   if (!result.ok) {
     sendTrackerLog(server, "planner", "failed");
-    throw new Error(result.error || result.output || "Planner failed");
+    const baseError = result.error || result.output || "Planner failed";
+    const statsSuffix = plannerStats
+      ? ` [lines=${plannerStats.lineCount}, bytes=${plannerStats.bytesReceived}, elapsed=${Math.round(plannerStats.elapsedMs / 1000)}s]`
+      : "";
+    throw new Error(`${baseError}${statsSuffix}`);
   }
 
   sendTrackerLog(server, "planner", "done");

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -207,6 +207,12 @@ describe("mcp/server-handlers", () => {
       expect(result.category).toBe("timeout");
     });
 
+    it("classifies stalled agent errors", () => {
+      const result = classifyError(new Error("Command killed after 1200000ms without output"));
+      expect(result.category).toBe("agent_stall");
+      expect(result.suggestion).toContain("kj_status");
+    });
+
     it("classifies git errors", () => {
       const result = classifyError(new Error("not a git repository"));
       expect(result.category).toBe("git_error");
@@ -480,6 +486,16 @@ describe("mcp/server-handlers", () => {
 
       expect(sendTrackerLog).toHaveBeenCalledWith(mockServer, "planner", "running", expect.any(String));
       expect(sendTrackerLog).toHaveBeenCalledWith(mockServer, "planner", "done");
+    });
+
+    it("kj_plan failure includes runtime stats in the error message", async () => {
+      createAgent.mockReturnValueOnce({
+        runTask: vi.fn().mockResolvedValue({ ok: false, error: "Command killed after 1200000ms without output" })
+      });
+
+      await expect(handlePlanDirect({ task: "Plan feature" }, mockServer, {}))
+        .rejects.toThrow(/without output.*lines=/i);
+      expect(sendTrackerLog).toHaveBeenCalledWith(mockServer, "planner", "failed");
     });
   });
 });


### PR DESCRIPTION
## Summary\n- classify silent/no-output failures as agent_stall with actionable guidance\n- include max silence configuration in kj_plan run log start line\n- append runtime stats (lines/bytes/elapsed) to kj_plan failure errors\n\n## Testing\n- npx vitest run tests/mcp-server-handlers.test.js tests/mcp-error-handling.test.js tests/stall-detector.test.js\n\n## Planning Game\n- Card: KJC-TSK-0093