### PR TITLE
feat(agents): add OpenCode as 5th coding agent

### DIFF
--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -2,6 +2,7 @@ import { ClaudeAgent } from "./claude-agent.js";
 import { CodexAgent } from "./codex-agent.js";
 import { GeminiAgent } from "./gemini-agent.js";
 import { AiderAgent } from "./aider-agent.js";
+import { OpenCodeAgent } from "./opencode-agent.js";
 
 const agentRegistry = new Map();
 
@@ -38,3 +39,4 @@ registerAgent("claude", ClaudeAgent, { bin: "claude", installUrl: "https://docs.
 registerAgent("codex", CodexAgent, { bin: "codex", installUrl: "https://developers.openai.com/codex/cli" });
 registerAgent("gemini", GeminiAgent, { bin: "gemini", installUrl: "https://github.com/google-gemini/gemini-cli" });
 registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.chat/docs/install.html" });
+registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });

--- a/src/agents/model-registry.js
+++ b/src/agents/model-registry.js
@@ -60,3 +60,4 @@ registerModel("gemini", { provider: "google", pricing: { input_per_million: 1.25
 registerModel("gemini/pro", { provider: "google", pricing: { input_per_million: 1.25, output_per_million: 5 } });
 registerModel("gemini/flash", { provider: "google", pricing: { input_per_million: 0.075, output_per_million: 0.3 } });
 registerModel("aider", { provider: "aider", pricing: { input_per_million: 3, output_per_million: 15 } });
+registerModel("opencode", { provider: "opencode", pricing: { input_per_million: 0, output_per_million: 0 } });

--- a/src/agents/opencode-agent.js
+++ b/src/agents/opencode-agent.js
@@ -1,0 +1,33 @@
+import { BaseAgent } from "./base-agent.js";
+import { runCommand } from "../utils/process.js";
+import { resolveBin } from "./resolve-bin.js";
+
+export class OpenCodeAgent extends BaseAgent {
+  async runTask(task) {
+    const role = task.role || "coder";
+    const args = ["run"];
+    const model = this.getRoleModel(role);
+    if (model) args.push("--model", model);
+    args.push(task.prompt);
+    const res = await runCommand(resolveBin("opencode"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs
+    });
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+  }
+
+  async reviewTask(task) {
+    const role = task.role || "reviewer";
+    const args = ["run", "--format", "json"];
+    const model = this.getRoleModel(role);
+    if (model) args.push("--model", model);
+    args.push(task.prompt);
+    const res = await runCommand(resolveBin("opencode"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs
+    });
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+  }
+}

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -5,7 +5,8 @@ const KNOWN_AGENTS = [
   { name: "claude", install: "npm install -g @anthropic-ai/claude-code" },
   { name: "codex", install: "npm install -g @openai/codex" },
   { name: "gemini", install: "npm install -g @anthropic-ai/gemini-code (or check Gemini CLI docs)" },
-  { name: "aider", install: "pip install aider-chat" }
+  { name: "aider", install: "pip install aider-chat" },
+  { name: "opencode", install: "curl -fsSL https://opencode.ai/install | bash (or see https://opencode.ai)" }
 ];
 
 export async function checkBinary(name, versionArg = "--version") {

--- a/tests/agents-contract.test.js
+++ b/tests/agents-contract.test.js
@@ -11,8 +11,8 @@ const logger = { info() {}, warn() {}, error() {}, debug() {} };
 describe("agent contract tests", () => {
   const agents = getAvailableAgents();
 
-  it("has at least 4 registered agents", () => {
-    expect(agents.length).toBeGreaterThanOrEqual(4);
+  it("has at least 5 registered agents", () => {
+    expect(agents.length).toBeGreaterThanOrEqual(5);
   });
 
   describe.each(agents.map((a) => [a.name]))("%s", (name) => {

--- a/tests/agents-implementations.test.js
+++ b/tests/agents-implementations.test.js
@@ -205,4 +205,46 @@ describe("Agent implementations", () => {
       expect(args).toContain("gpt-4-turbo");
     });
   });
+
+  describe("OpenCodeAgent", () => {
+    it("runs task with opencode run and prompt as argument", async () => {
+      const { OpenCodeAgent } = await import("../src/agents/opencode-agent.js");
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("run");
+      expect(args[args.length - 1]).toBe("fix bug");
+    });
+
+    it("adds --model flag when configured", async () => {
+      const { OpenCodeAgent } = await import("../src/agents/opencode-agent.js");
+      const config = { ...baseConfig, roles: { coder: { model: "anthropic/claude-3-5-sonnet" }, reviewer: {} } };
+      const agent = new OpenCodeAgent("opencode", config, logger);
+      await agent.runTask({ prompt: "work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("anthropic/claude-3-5-sonnet");
+    });
+
+    it("reviews with --format json", async () => {
+      const { OpenCodeAgent } = await import("../src/agents/opencode-agent.js");
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--format");
+      expect(args).toContain("json");
+    });
+
+    it("returns structured result", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "warn" });
+      const { OpenCodeAgent } = await import("../src/agents/opencode-agent.js");
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "work", role: "coder" });
+
+      expect(result).toEqual({ ok: true, output: "done", error: "warn", exitCode: 0 });
+    });
+  });
 });


### PR DESCRIPTION
Register opencode agent with CLI syntax `opencode run [--model] [--format json] "prompt"`, multi-provider pricing at 0, and detection support.