### PR TITLE
feat: v1.10.0 — kj_agents, checkpoint resilience, subprocess constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-03-07
+
+### Added
+- **`kj_agents` MCP tool and CLI command**: list or change AI agent assignments per role on the fly. `kj_agents set coder gemini` persists to `kj.config.yml` — no restart needed, next `kj_run`/`kj_code` picks it up immediately
+- **`kj doctor` version display**: first line now shows Karajan Code version (`OK   Karajan Code: v1.10.0`)
+- **Subprocess constraints in coder prompt**: tells the coder it runs non-interactively (no stdin/TTY), must use `--yes`/`--no-input` flags for CLI wizards, and report clearly if a task cannot be done non-interactively
+- 10 new tests (1084 total)
+
+### Fixed
+- **Checkpoint null response no longer kills sessions**: when `elicitInput` fails or the AI agent returns null/empty, the session now continues for 5 more minutes instead of stopping. Only an explicit "4" or "stop" triggers a session stop
+- **`kj_resume` accepts stopped and failed sessions**: previously only "paused" sessions could be resumed. Now stopped (checkpoint) and failed (timeout/max-iterations) sessions can be re-run with `kj_resume`
+
 ## [1.9.6] - 2026-03-06
 
 ### Fixed
@@ -222,7 +234,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: GitHub Actions workflow with validation and PR annotations
 - **716+ unit tests** with Vitest
 
-[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.9.3...HEAD
+[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/manufosela/karajan-code/compare/v1.9.6...v1.10.0
+[1.9.6]: https://github.com/manufosela/karajan-code/compare/v1.9.4...v1.9.6
 [1.9.3]: https://github.com/manufosela/karajan-code/compare/v1.9.2...v1.9.3
 [1.9.2]: https://github.com/manufosela/karajan-code/compare/v1.9.1...v1.9.2
 [1.8.0]: https://github.com/manufosela/karajan-code/compare/v1.7.0...v1.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "1.9.6",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "1.9.6",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.9.6",
+  "version": "1.10.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,6 +17,7 @@ import { runCommandHandler } from "./commands/run.js";
 import { resumeCommand } from "./commands/resume.js";
 import { sonarCommand, sonarOpenCommand } from "./commands/sonar.js";
 import { rolesCommand } from "./commands/roles.js";
+import { agentsCommand } from "./commands/agents.js";
 
 const PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
 const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
@@ -158,6 +159,15 @@ program
   .action(async (subcommand, role) => {
     await withConfig("roles", {}, async ({ config }) => {
       await rolesCommand({ config, subcommand: subcommand || "list", roleName: role });
+    });
+  });
+
+program
+  .command("agents [subcommand] [role] [provider]")
+  .description("List or change AI agent assignments per role (e.g. kj agents set coder gemini)")
+  .action(async (subcommand, role, provider) => {
+    await withConfig("agents", {}, async ({ config }) => {
+      await agentsCommand({ config, subcommand: subcommand || "list", role, provider });
     });
   });
 

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -1,0 +1,68 @@
+import { loadConfig, writeConfig, getConfigPath, resolveRole } from "../config.js";
+import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
+
+const ASSIGNABLE_ROLES = [
+  "coder", "reviewer", "planner", "refactorer", "triage",
+  "researcher", "tester", "security", "solomon"
+];
+
+const VALID_PROVIDERS = KNOWN_AGENTS.map((a) => a.name);
+
+export function listAgents(config) {
+  return ASSIGNABLE_ROLES.map((role) => {
+    const resolved = resolveRole(config, role);
+    return {
+      role,
+      provider: resolved.provider || "-",
+      model: resolved.model || "-"
+    };
+  });
+}
+
+export async function setAgent(role, provider) {
+  if (!ASSIGNABLE_ROLES.includes(role)) {
+    throw new Error(`Unknown role "${role}". Valid roles: ${ASSIGNABLE_ROLES.join(", ")}`);
+  }
+  if (!VALID_PROVIDERS.includes(provider)) {
+    const bin = await checkBinary(provider);
+    if (!bin.ok) {
+      throw new Error(`Provider "${provider}" not found. Available: ${VALID_PROVIDERS.join(", ")}`);
+    }
+  }
+
+  const { config } = await loadConfig();
+  config.roles = config.roles || {};
+  config.roles[role] = config.roles[role] || {};
+  config.roles[role].provider = provider;
+
+  const configPath = getConfigPath();
+  await writeConfig(configPath, config);
+
+  return { role, provider, configPath };
+}
+
+export async function agentsCommand({ config, subcommand, role, provider }) {
+  if (subcommand === "set") {
+    if (!role || !provider) {
+      console.log("Usage: kj agents set <role> <provider>");
+      console.log(`Roles: ${ASSIGNABLE_ROLES.join(", ")}`);
+      console.log(`Providers: ${VALID_PROVIDERS.join(", ")}`);
+      return;
+    }
+    const result = await setAgent(role, provider);
+    console.log(`Set ${result.role} -> ${result.provider} (saved to ${result.configPath})`);
+    return result;
+  }
+
+  const agents = listAgents(config);
+  const roleWidth = Math.max(...agents.map((a) => a.role.length), 4);
+  const provWidth = Math.max(...agents.map((a) => a.provider.length), 8);
+  console.log(`${"Role".padEnd(roleWidth)}  ${"Provider".padEnd(provWidth)}  Model`);
+  console.log("-".repeat(roleWidth + provWidth + 10));
+  for (const a of agents) {
+    console.log(`${a.role.padEnd(roleWidth)}  ${a.provider.padEnd(provWidth)}  ${a.model}`);
+  }
+  return agents;
+}
+
+export { ASSIGNABLE_ROLES, VALID_PROVIDERS };

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { runCommand } from "../utils/process.js";
 import { exists } from "../utils/fs.js";
 import { getConfigPath } from "../config.js";
@@ -6,8 +9,23 @@ import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
 import { ensureGitRepo } from "../utils/git.js";
 import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
 
+function getPackageVersion() {
+  const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
+  return JSON.parse(readFileSync(pkgPath, "utf8")).version;
+}
+
 export async function runChecks({ config }) {
   const checks = [];
+
+  // 0. Karajan version
+  const version = getPackageVersion();
+  checks.push({
+    name: "karajan",
+    label: "Karajan Code",
+    ok: true,
+    detail: `v${version}`,
+    fix: null
+  });
 
   // 1. Config file
   const configPath = getConfigPath();

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -442,6 +442,21 @@ export async function handleToolCall(name, args, server, extra) {
     return runKjCommand({ command: "doctor", options: a });
   }
 
+  if (name === "kj_agents") {
+    const action = a.action || "list";
+    if (action === "set") {
+      if (!a.role || !a.provider) {
+        return failPayload("Missing required fields: role and provider");
+      }
+      const { setAgent } = await import("../commands/agents.js");
+      const result = await setAgent(a.role, a.provider);
+      return { ok: true, ...result, message: `${result.role} now uses ${result.provider}` };
+    }
+    const config = await buildConfig(a);
+    const { listAgents } = await import("../commands/agents.js");
+    return { ok: true, agents: listAgents(config) };
+  }
+
   if (name === "kj_config") {
     return runKjCommand({
       command: "config",

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -97,7 +97,7 @@ export const tools = [
   {
     name: "kj_resume",
     description:
-      "Resume a paused session by ID. Provide an answer to the question that caused the pause. Sends real-time progress notifications via MCP logging.",
+      "Resume a paused, stopped, or failed session by ID. For paused sessions, provide an answer. For stopped/failed sessions, re-runs the flow from scratch. Sends real-time progress notifications via MCP logging.",
     inputSchema: {
       type: "object",
       required: ["sessionId"],
@@ -132,6 +132,19 @@ export const tools = [
       properties: {
         action: { type: "string", enum: ["list", "show"], description: "Action: list all roles or show a specific role template" },
         roleName: { type: "string", description: "Role name to show (e.g. coder, reviewer, triage, reviewer-paranoid)" },
+        kjHome: { type: "string" }
+      }
+    }
+  },
+  {
+    name: "kj_agents",
+    description: "List or change which AI agent (provider) is assigned to each pipeline role. Use action='list' to see current assignments. Use action='set' with role and provider to change it persistently (writes to kj.config.yml, no restart needed).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["list", "set"], description: "Action: list current agents or set a role's provider" },
+        role: { type: "string", description: "Role to change (e.g. coder, reviewer, planner, triage)" },
+        provider: { type: "string", description: "New provider to assign (e.g. claude, codex, gemini, aider)" },
         kjHome: { type: "string" }
       }
     }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -295,7 +295,13 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
       await addCheckpoint(session, { stage: "interactive-checkpoint", elapsed_minutes: Number(elapsedStr), answer });
 
-      if (!answer || answer.trim() === "4" || answer.trim().toLowerCase().startsWith("stop")) {
+      // Explicit stop: only when the user clearly chose option 4 or typed "stop".
+      // A null/empty answer (e.g. elicitInput failure, AI timeout) defaults to
+      // "continue 5 more minutes" so the session is not killed accidentally.
+      const trimmedAnswer = (answer || "").trim();
+      const isExplicitStop = trimmedAnswer === "4" || trimmedAnswer.toLowerCase().startsWith("stop");
+
+      if (isExplicitStop) {
         await markSessionStatus(session, "stopped");
         emitProgress(
           emitter,
@@ -308,12 +314,15 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         return { approved: false, sessionId: session.id, reason: "user_stopped", elapsed_minutes: Number(elapsedStr) };
       }
 
-      if (answer.trim() === "2" || answer.trim().toLowerCase().startsWith("continue until")) {
+      // No answer or unrecognized → default to continue 5 more minutes
+      if (!trimmedAnswer) {
+        lastCheckpointAt = Date.now();
+      } else if (trimmedAnswer === "2" || trimmedAnswer.toLowerCase().startsWith("continue until")) {
         checkpointDisabled = true;
-      } else if (answer.trim() === "1" || answer.trim().toLowerCase().includes("5 m")) {
+      } else if (trimmedAnswer === "1" || trimmedAnswer.toLowerCase().includes("5 m")) {
         lastCheckpointAt = Date.now();
       } else {
-        const customMinutes = parseInt(answer.trim().replace(/\D/g, ""), 10);
+        const customMinutes = parseInt(trimmedAnswer.replace(/\D/g, ""), 10);
         if (customMinutes > 0) {
           lastCheckpointAt = Date.now();
           config.session.checkpoint_interval_minutes = customMinutes;
@@ -561,9 +570,18 @@ export async function resumeFlow({ sessionId, answer, config, logger, flags = {}
     return session;
   }
 
-  if (session.status !== "running") {
-    logger.info(`Session ${sessionId} has status ${session.status}`);
+  // Allow resuming "stopped" sessions (checkpoint stop) and "failed" sessions
+  const resumableStatuses = ["running", "stopped", "failed"];
+  if (!resumableStatuses.includes(session.status)) {
+    logger.info(`Session ${sessionId} has status ${session.status} — not resumable`);
     return session;
+  }
+
+  // Mark as running again for stopped/failed sessions
+  if (session.status !== "running") {
+    logger.info(`Resuming ${session.status} session ${sessionId}`);
+    session.status = "running";
+    await saveSession(session);
   }
 
   // Session was paused and now resumed with answer - re-run the flow

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -10,6 +10,14 @@ const SUBAGENT_PREAMBLE_SERENA = [
   "Execute the task directly. Focus only on coding."
 ].join(" ");
 
+const SUBPROCESS_CONSTRAINTS = [
+  "## Environment constraints",
+  "You run as a non-interactive subprocess (no stdin, no TTY).",
+  "- If the task requires a CLI wizard or interactive init (e.g. `create-react-app`, `pnpm create astro`, `npm init`), ALWAYS use non-interactive flags: `--yes`, `--no-input`, `--template <name>`, `--defaults`, etc.",
+  "- Never run a command that waits for user input — it will hang forever.",
+  "- If a task absolutely cannot be done non-interactively, say so explicitly instead of hanging."
+].join("\n");
+
 const SERENA_INSTRUCTIONS = [
   "## Serena MCP — symbol-level code navigation",
   "You have access to Serena MCP tools for efficient code navigation.",
@@ -26,7 +34,8 @@ export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary =
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     `Task:\n${task}`,
     "Implement directly in the repository.",
-    "Keep changes minimal and production-ready."
+    "Keep changes minimal and production-ready.",
+    SUBPROCESS_CONSTRAINTS
   ];
 
   if (serenaEnabled) {

--- a/tests/agents-command.test.js
+++ b/tests/agents-command.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/config.js", () => ({
+  loadConfig: vi.fn(),
+  writeConfig: vi.fn(),
+  getConfigPath: vi.fn(() => "/home/user/.karajan/kj.config.yml"),
+  resolveRole: vi.fn((config, role) => {
+    const roles = config?.roles || {};
+    return {
+      provider: roles[role]?.provider || "claude",
+      model: roles[role]?.model || null
+    };
+  })
+}));
+
+vi.mock("../src/utils/agent-detect.js", () => ({
+  checkBinary: vi.fn(async () => ({ ok: false })),
+  KNOWN_AGENTS: [
+    { name: "claude", install: "npm i -g @anthropic-ai/claude-code" },
+    { name: "codex", install: "npm i -g @openai/codex" },
+    { name: "gemini", install: "npm i -g @anthropic-ai/gemini" },
+    { name: "aider", install: "pip install aider-chat" }
+  ]
+}));
+
+const { listAgents, setAgent } = await import("../src/commands/agents.js");
+const { loadConfig, writeConfig, getConfigPath } = await import("../src/config.js");
+
+describe("agents command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listAgents", () => {
+    it("lists all assignable roles with their providers", () => {
+      const config = {
+        roles: {
+          coder: { provider: "claude", model: "opus" },
+          reviewer: { provider: "codex", model: null }
+        }
+      };
+      const agents = listAgents(config);
+
+      expect(agents.length).toBe(9);
+      expect(agents.find((a) => a.role === "coder").provider).toBe("claude");
+      expect(agents.find((a) => a.role === "reviewer").provider).toBe("codex");
+    });
+
+    it("shows - for roles without explicit provider", () => {
+      const config = { roles: {} };
+      // resolveRole mock returns "claude" by default
+      const agents = listAgents(config);
+      expect(agents.every((a) => a.provider)).toBe(true);
+    });
+  });
+
+  describe("setAgent", () => {
+    it("updates role provider in config and writes to disk", async () => {
+      loadConfig.mockResolvedValue({
+        config: { roles: { coder: { provider: "claude" } } }
+      });
+      writeConfig.mockResolvedValue(undefined);
+
+      const result = await setAgent("coder", "gemini");
+
+      expect(result.role).toBe("coder");
+      expect(result.provider).toBe("gemini");
+      expect(writeConfig).toHaveBeenCalledWith(
+        "/home/user/.karajan/kj.config.yml",
+        expect.objectContaining({
+          roles: expect.objectContaining({
+            coder: expect.objectContaining({ provider: "gemini" })
+          })
+        })
+      );
+    });
+
+    it("throws for unknown role", async () => {
+      await expect(setAgent("unknown", "claude")).rejects.toThrow("Unknown role");
+    });
+
+    it("throws for unknown provider not found as binary", async () => {
+      await expect(setAgent("coder", "nonexistent")).rejects.toThrow("not found");
+    });
+
+    it("creates role entry if it does not exist", async () => {
+      loadConfig.mockResolvedValue({
+        config: { roles: {} }
+      });
+      writeConfig.mockResolvedValue(undefined);
+
+      const result = await setAgent("planner", "codex");
+
+      expect(result.provider).toBe("codex");
+      expect(writeConfig).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          roles: expect.objectContaining({
+            planner: { provider: "codex" }
+          })
+        })
+      );
+    });
+  });
+});

--- a/tests/orchestrator-checkpoint.test.js
+++ b/tests/orchestrator-checkpoint.test.js
@@ -62,8 +62,8 @@ vi.mock("../src/orchestrator/post-loop-stages.js", () => ({
   runSecurityStage: vi.fn()
 }));
 
-const { runFlow } = await import("../src/orchestrator.js");
-const { addCheckpoint, markSessionStatus } = await import("../src/session-store.js");
+const { runFlow, resumeFlow } = await import("../src/orchestrator.js");
+const { addCheckpoint, markSessionStatus, loadSession, saveSession } = await import("../src/session-store.js");
 const { runCoderStage, runTddCheckStage, runReviewerStage } = await import("../src/orchestrator/iteration-stages.js");
 const { emitProgress } = await import("../src/utils/events.js");
 
@@ -202,13 +202,14 @@ describe("interactive checkpoint system", () => {
     expect(result.reason).toBe("user_stopped");
   });
 
-  it("stops when askQuestion returns null (e.g., declined elicit)", async () => {
+  it("continues when askQuestion returns null (default to 5 more minutes)", async () => {
     const askQuestion = vi.fn().mockResolvedValue(null);
-    const config = makeConfig();
+    const config = makeConfig({ max_iterations: 1 });
 
     const result = await runFlow({ task: "Fix bug", config, logger, askQuestion });
 
-    expect(result.reason).toBe("user_stopped");
+    // null response defaults to "continue 5 more minutes" instead of stopping
+    expect(result.approved).toBe(true);
   });
 
   it("emits session:checkpoint event", async () => {
@@ -288,5 +289,77 @@ describe("interactive checkpoint system", () => {
     // Should NOT throw — hard timeout is disabled when askQuestion is available
     const result = await runFlow({ task: "Fix bug", config, logger, askQuestion });
     expect(result.approved).toBe(true);
+  });
+});
+
+describe("resumeFlow from stopped/failed sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runCoderStage.mockResolvedValue({ action: "ok" });
+    runTddCheckStage.mockResolvedValue({ action: "ok" });
+    runReviewerStage.mockResolvedValue({ action: "ok", review: { approved: true, blocking_issues: [], summary: "ok", confidence: 1 } });
+  });
+
+  it("resumes a stopped session by re-running the flow", async () => {
+    const stoppedSession = {
+      id: "sess-stopped",
+      status: "stopped",
+      task: "Fix bug",
+      config_snapshot: makeConfig({ max_iterations: 1 }),
+      checkpoints: []
+    };
+    loadSession.mockResolvedValue(stoppedSession);
+    saveSession.mockResolvedValue(undefined);
+
+    const result = await resumeFlow({
+      sessionId: "sess-stopped",
+      config: makeConfig({ max_iterations: 1 }),
+      logger
+    });
+
+    // Session should be marked running before re-running
+    expect(saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "running" })
+    );
+    expect(result.approved).toBe(true);
+  });
+
+  it("resumes a failed session by re-running the flow", async () => {
+    const failedSession = {
+      id: "sess-failed",
+      status: "failed",
+      task: "Fix bug",
+      config_snapshot: makeConfig({ max_iterations: 1 }),
+      checkpoints: []
+    };
+    loadSession.mockResolvedValue(failedSession);
+    saveSession.mockResolvedValue(undefined);
+
+    const result = await resumeFlow({
+      sessionId: "sess-failed",
+      config: makeConfig({ max_iterations: 1 }),
+      logger
+    });
+
+    expect(result.approved).toBe(true);
+  });
+
+  it("rejects resuming an approved (completed) session", async () => {
+    const approvedSession = {
+      id: "sess-approved",
+      status: "approved",
+      task: "Fix bug",
+      checkpoints: []
+    };
+    loadSession.mockResolvedValue(approvedSession);
+
+    const result = await resumeFlow({
+      sessionId: "sess-approved",
+      config: makeConfig(),
+      logger
+    });
+
+    // Should return the session as-is, not re-run
+    expect(result.status).toBe("approved");
   });
 });

--- a/tests/prompt-coder.test.js
+++ b/tests/prompt-coder.test.js
@@ -117,4 +117,12 @@ describe("buildCoderPrompt", () => {
     expect(result).not.toContain("Serena MCP");
     expect(result).toContain("Do NOT use any MCP tools");
   });
+
+  it("includes subprocess constraints about non-interactive execution", () => {
+    const result = buildCoderPrompt({ task: "Init project" });
+
+    expect(result).toContain("non-interactive subprocess");
+    expect(result).toContain("--yes");
+    expect(result).toContain("will hang forever");
+  });
 });


### PR DESCRIPTION
## Summary
- **`kj_agents` MCP tool + CLI**: list/set AI agent per role on the fly (`kj_agents set coder gemini`), persists to config, no restart needed
- **Checkpoint resilience**: null/empty `elicitInput` response defaults to "continue 5 min" instead of killing the session
- **`kj_resume` expanded**: now accepts stopped and failed sessions, not just paused
- **Subprocess constraints**: coder prompt tells the agent it's non-interactive — use `--yes`/`--no-input` flags or report inability
- **`kj doctor` version**: shows Karajan version as first check line

## Test plan
- [x] 1084 tests passing (10 new)
- [x] `kj_agents` list/set tested
- [x] Checkpoint null → continue tested
- [x] resumeFlow stopped/failed tested
- [x] Subprocess constraints in prompt tested

KJC-TSK-0002