### PR TITLE
feat: PG auto-status (In Progress / To Validate) in runFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-03-07
+
+### Added
+- **Planning Game auto-status in `runFlow`**: when `pgTaskId` is provided, Karajan now automatically marks the PG card as "In Progress" (with `startDate`, `developer: BecarIA`) at session start, and "To Validate" (with `endDate`, `commits`) on approved completion. Works from both CLI and MCP — no duplicate logic needed
+- 6 new tests for PG integration (1090 total)
+
+### Changed
+- **CLI `run.js` simplified**: PG card fetch and completion update logic moved to `runFlow` (was duplicated in CLI handler)
+
 ## [1.10.0] - 2026-03-07
 
 ### Added
@@ -234,7 +243,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: GitHub Actions workflow with validation and PR annotations
 - **716+ unit tests** with Vitest
 
-[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/manufosela/karajan-code/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/manufosela/karajan-code/compare/v1.9.6...v1.10.0
 [1.9.6]: https://github.com/manufosela/karajan-code/compare/v1.9.4...v1.9.6
 [1.9.3]: https://github.com/manufosela/karajan-code/compare/v1.9.2...v1.9.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "hasInstallScript": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,7 +4,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { createActivityLog } from "../activity-log.js";
 import { printHeader, printEvent } from "../utils/display.js";
 import { resolveRole } from "../config.js";
-import { parseCardId, buildTaskFromCard, buildCompletionUpdates } from "../planning-game/adapter.js";
+import { parseCardId } from "../planning-game/adapter.js";
 
 export async function runCommandHandler({ task, config, logger, flags }) {
   const requiredProviders = [
@@ -22,24 +22,10 @@ export async function runCommandHandler({ task, config, logger, flags }) {
   if (config.pipeline?.security?.enabled) requiredProviders.push(resolveRole(config, "security").provider);
   await assertAgentsAvailable(requiredProviders);
 
-  // --- Planning Game: resolve card context ---
+  // --- Planning Game: resolve card ID ---
   const pgCardId = flags?.pgTask || parseCardId(task);
   const pgProject = flags?.pgProject || config.planning_game?.project_id || null;
-  let pgCard = null;
-  let enrichedTask = task;
-
-  if (pgCardId && pgProject && config.planning_game?.enabled !== false) {
-    try {
-      const { fetchCard, updateCard } = await import("../planning-game/client.js");
-      pgCard = await fetchCard({ projectId: pgProject, cardId: pgCardId });
-      if (pgCard) {
-        enrichedTask = buildTaskFromCard(pgCard);
-        logger.info(`Planning Game: loaded card ${pgCardId} from project ${pgProject}`);
-      }
-    } catch (err) {
-      logger.warn(`Planning Game: could not load card ${pgCardId}: ${err.message}`);
-    }
-  }
+  const enrichedTask = task;
 
   const jsonMode = flags?.json;
 
@@ -65,25 +51,7 @@ export async function runCommandHandler({ task, config, logger, flags }) {
     printHeader({ task: enrichedTask, config });
   }
 
-  const startDate = new Date().toISOString();
   const result = await runFlow({ task: enrichedTask, config, logger, flags, emitter, pgTaskId: pgCardId || null, pgProject: pgProject || null });
-
-  // --- Planning Game: update card on completion ---
-  if (pgCard && pgProject && result?.approved) {
-    try {
-      const { updateCard } = await import("../planning-game/client.js");
-      const updates = buildCompletionUpdates({
-        approved: true,
-        commits: result.git?.commits || [],
-        startDate,
-        codeveloper: config.planning_game?.codeveloper || null
-      });
-      await updateCard({ projectId: pgProject, cardId: pgCardId, firebaseId: pgCard.firebaseId, updates });
-      logger.info(`Planning Game: updated ${pgCardId} to "${updates.status}"`);
-    } catch (err) {
-      logger.warn(`Planning Game: could not update card ${pgCardId}: ${err.message}`);
-    }
-  }
 
   if (jsonMode) {
     console.log(JSON.stringify(result, null, 2));

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -157,6 +157,32 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
   eventBase.sessionId = session.id;
 
+  // --- Planning Game: mark card as In Progress ---
+  let pgCard = null;
+  if (pgTaskId && pgProject && config.planning_game?.enabled !== false) {
+    try {
+      const { fetchCard, updateCard } = await import("./planning-game/client.js");
+      pgCard = await fetchCard({ projectId: pgProject, cardId: pgTaskId });
+      if (pgCard && pgCard.status !== "In Progress") {
+        await updateCard({
+          projectId: pgProject,
+          cardId: pgTaskId,
+          firebaseId: pgCard.firebaseId,
+          updates: {
+            status: "In Progress",
+            startDate: new Date().toISOString(),
+            developer: "dev_016",
+            codeveloper: config.planning_game?.codeveloper || null
+          }
+        });
+        logger.info(`Planning Game: ${pgTaskId} → In Progress`);
+      }
+    } catch (err) {
+      logger.warn(`Planning Game: could not update ${pgTaskId}: ${err.message}`);
+    }
+  }
+  session.pg_card = pgCard || null;
+
   emitProgress(
     emitter,
     makeEvent("session:start", eventBase, {
@@ -493,6 +519,30 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       }
       session.budget = budgetSummary();
       await markSessionStatus(session, "approved");
+
+      // --- Planning Game: mark card as To Validate ---
+      if (pgCard && pgProject) {
+        try {
+          const { updateCard } = await import("./planning-game/client.js");
+          const { buildCompletionUpdates } = await import("./planning-game/adapter.js");
+          const pgUpdates = buildCompletionUpdates({
+            approved: true,
+            commits: gitResult?.commits || [],
+            startDate: session.pg_card?.startDate || session.created_at,
+            codeveloper: config.planning_game?.codeveloper || null
+          });
+          await updateCard({
+            projectId: pgProject,
+            cardId: session.pg_task_id,
+            firebaseId: pgCard.firebaseId,
+            updates: pgUpdates
+          });
+          logger.info(`Planning Game: ${session.pg_task_id} → To Validate`);
+        } catch (err) {
+          logger.warn(`Planning Game: could not update ${session.pg_task_id} on completion: ${err.message}`);
+        }
+      }
+
       emitProgress(
         emitter,
         makeEvent("session:end", { ...eventBase, stage: "done" }, {

--- a/tests/orchestrator-pg-integration.test.js
+++ b/tests/orchestrator-pg-integration.test.js
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/session-store.js", () => ({
+  createSession: vi.fn(async (init) => ({ id: "sess-1", created_at: "2026-03-07T00:00:00Z", checkpoints: [], ...init })),
+  loadSession: vi.fn(),
+  markSessionStatus: vi.fn(async () => {}),
+  resumeSessionWithAnswer: vi.fn(),
+  saveSession: vi.fn(async () => {}),
+  addCheckpoint: vi.fn(async () => {})
+}));
+
+vi.mock("../src/review/diff-generator.js", () => ({
+  computeBaseRef: vi.fn(async () => "abc123"),
+  generateDiff: vi.fn(async () => "diff content")
+}));
+
+vi.mock("../src/roles/base-role.js", () => ({
+  resolveRoleMdPath: vi.fn(() => []),
+  loadFirstExisting: vi.fn(async () => null)
+}));
+
+vi.mock("../src/review/profiles.js", () => ({
+  resolveReviewProfile: vi.fn(async () => ({ rules: "" }))
+}));
+
+vi.mock("../src/roles/coder-role.js", () => ({
+  CoderRole: class {
+    constructor() {}
+    async init() {}
+  }
+}));
+
+vi.mock("../src/git/automation.js", () => ({
+  prepareGitAutomation: vi.fn(async () => ({ enabled: false })),
+  finalizeGitAutomation: vi.fn(async () => ({ commits: [{ hash: "abc", message: "feat: done" }] }))
+}));
+
+vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
+  invokeSolomon: vi.fn()
+}));
+
+vi.mock("../src/orchestrator/pre-loop-stages.js", () => ({
+  runTriageStage: vi.fn(),
+  runResearcherStage: vi.fn(),
+  runPlannerStage: vi.fn()
+}));
+
+vi.mock("../src/orchestrator/iteration-stages.js", () => ({
+  runCoderStage: vi.fn(),
+  runRefactorerStage: vi.fn(),
+  runTddCheckStage: vi.fn(),
+  runSonarStage: vi.fn(),
+  runReviewerStage: vi.fn()
+}));
+
+vi.mock("../src/orchestrator/post-loop-stages.js", () => ({
+  runTesterStage: vi.fn(),
+  runSecurityStage: vi.fn()
+}));
+
+const mockFetchCard = vi.fn();
+const mockUpdateCard = vi.fn();
+
+vi.mock("../src/planning-game/client.js", () => ({
+  fetchCard: (...args) => mockFetchCard(...args),
+  updateCard: (...args) => mockUpdateCard(...args)
+}));
+
+const { runFlow } = await import("../src/orchestrator.js");
+const { runCoderStage, runTddCheckStage, runReviewerStage } = await import("../src/orchestrator/iteration-stages.js");
+
+function makeConfig(overrides = {}) {
+  return {
+    coder: "claude",
+    reviewer: "codex",
+    roles: {
+      planner: { provider: null, model: null },
+      coder: { provider: "claude", model: null },
+      reviewer: { provider: "codex", model: null },
+      refactorer: { provider: null, model: null },
+      solomon: { provider: null, model: null },
+      researcher: { provider: null, model: null },
+      tester: { provider: null, model: null },
+      security: { provider: null, model: null },
+      triage: { provider: null, model: null }
+    },
+    pipeline: {
+      planner: { enabled: false },
+      refactorer: { enabled: false },
+      solomon: { enabled: false },
+      researcher: { enabled: false },
+      tester: { enabled: false },
+      security: { enabled: false },
+      triage: { enabled: false },
+      reviewer: { enabled: false }
+    },
+    review_mode: "standard",
+    max_iterations: 1,
+    max_budget_usd: null,
+    base_branch: "main",
+    coder_options: { model: null },
+    reviewer_options: { model: null, fallback_reviewer: "codex" },
+    development: { methodology: "standard", require_test_changes: false },
+    sonarqube: { enabled: false },
+    serena: { enabled: false },
+    planning_game: { enabled: true, codeveloper: "dev_001" },
+    git: { auto_commit: false, auto_push: false, auto_pr: false },
+    output: { report_dir: "./.reviews", log_level: "info" },
+    budget: { warn_threshold_pct: 80 },
+    model_selection: { enabled: false },
+    session: {
+      max_iteration_minutes: 30,
+      max_total_minutes: 120,
+      checkpoint_interval_minutes: 999,
+      fail_fast_repeats: 2,
+      repeat_detection_threshold: 2,
+      max_sonar_retries: 3,
+      max_reviewer_retries: 3,
+      max_tester_retries: 1,
+      max_security_retries: 1,
+      expiry_days: 30
+    },
+    failFast: { repeatThreshold: 2 },
+    ...overrides
+  };
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("Planning Game integration in runFlow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runCoderStage.mockResolvedValue({ action: "ok" });
+    runTddCheckStage.mockResolvedValue({ action: "ok" });
+    runReviewerStage.mockResolvedValue({ action: "ok", review: { approved: true, blocking_issues: [], summary: "ok", confidence: 1 } });
+    mockFetchCard.mockResolvedValue({
+      cardId: "KJC-TSK-0099",
+      firebaseId: "-Oabc123",
+      title: "Test task",
+      status: "To Do"
+    });
+    mockUpdateCard.mockResolvedValue({ message: "ok" });
+  });
+
+  it("marks PG card as In Progress at session start", async () => {
+    await runFlow({
+      task: "Fix bug",
+      config: makeConfig(),
+      logger,
+      pgTaskId: "KJC-TSK-0099",
+      pgProject: "Karajan Code"
+    });
+
+    expect(mockFetchCard).toHaveBeenCalledWith({
+      projectId: "Karajan Code",
+      cardId: "KJC-TSK-0099"
+    });
+
+    const inProgressCall = mockUpdateCard.mock.calls.find(
+      (call) => call[0]?.updates?.status === "In Progress"
+    );
+    expect(inProgressCall).toBeDefined();
+    expect(inProgressCall[0].updates.developer).toBe("dev_016");
+    expect(inProgressCall[0].updates.codeveloper).toBe("dev_001");
+    expect(inProgressCall[0].updates.startDate).toBeDefined();
+  });
+
+  it("marks PG card as To Validate on approved completion", async () => {
+    await runFlow({
+      task: "Fix bug",
+      config: makeConfig(),
+      logger,
+      pgTaskId: "KJC-TSK-0099",
+      pgProject: "Karajan Code"
+    });
+
+    const toValidateCall = mockUpdateCard.mock.calls.find(
+      (call) => call[0]?.updates?.status === "To Validate"
+    );
+    expect(toValidateCall).toBeDefined();
+    expect(toValidateCall[0].updates.developer).toBe("dev_016");
+    expect(toValidateCall[0].updates.endDate).toBeDefined();
+  });
+
+  it("skips PG card already In Progress", async () => {
+    mockFetchCard.mockResolvedValue({
+      cardId: "KJC-TSK-0099",
+      firebaseId: "-Oabc123",
+      title: "Test task",
+      status: "In Progress"
+    });
+
+    await runFlow({
+      task: "Fix bug",
+      config: makeConfig(),
+      logger,
+      pgTaskId: "KJC-TSK-0099",
+      pgProject: "Karajan Code"
+    });
+
+    // Should NOT call updateCard with "In Progress" (already there)
+    const inProgressCall = mockUpdateCard.mock.calls.find(
+      (call) => call[0]?.updates?.status === "In Progress"
+    );
+    expect(inProgressCall).toBeUndefined();
+  });
+
+  it("does not touch PG when planning_game is disabled", async () => {
+    const config = makeConfig({ planning_game: { enabled: false } });
+
+    await runFlow({
+      task: "Fix bug",
+      config,
+      logger,
+      pgTaskId: "KJC-TSK-0099",
+      pgProject: "Karajan Code"
+    });
+
+    expect(mockFetchCard).not.toHaveBeenCalled();
+    expect(mockUpdateCard).not.toHaveBeenCalled();
+  });
+
+  it("does not touch PG when no pgTaskId provided", async () => {
+    await runFlow({
+      task: "Fix bug",
+      config: makeConfig(),
+      logger
+    });
+
+    expect(mockFetchCard).not.toHaveBeenCalled();
+  });
+
+  it("handles PG errors gracefully without failing the run", async () => {
+    mockFetchCard.mockRejectedValue(new Error("PG unavailable"));
+
+    const result = await runFlow({
+      task: "Fix bug",
+      config: makeConfig(),
+      logger,
+      pgTaskId: "KJC-TSK-0099",
+      pgProject: "Karajan Code"
+    });
+
+    expect(result.approved).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("PG unavailable")
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- runFlow auto-marks PG card as **In Progress** at session start (with startDate, developer=BecarIA, codeveloper)
- runFlow auto-marks PG card as **To Validate** on approved completion (with endDate, commits)
- Centralized in orchestrator — works from both CLI and MCP
- Removed duplicate PG logic from CLI `run.js`

## Test plan
- [x] 1090 tests passing (6 new for PG integration)
- [x] Tests cover: In Progress on start, To Validate on completion, skip if already In Progress, disabled PG, no pgTaskId, PG errors handled gracefully

KJC-TSK-0002