### PR TITLE
feat: intelligent reviewer mediation with deferred issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-03-07
+
+### Added
+- **Intelligent reviewer mediation**: when the reviewer flags out-of-scope issues (files not in the diff), the scope filter auto-defers them instead of blocking the pipeline. Deferred issues are tracked as technical debt in the session and injected into the coder prompt as context
+- **Deferred issues tracking**: out-of-scope reviewer concerns are stored in `session.deferred_issues` with structured metadata (file, severity, description, suggested_fix). Returned in `deferredIssues` field of the session result for follow-up task creation
+- **Solomon mediation on reviewer stall**: when `RepeatDetector` detects a stalled reviewer (same issues repeated), Solomon now arbitrates before stopping — can override, continue with guidance, or create subtask. Falls back to pause only if Solomon can't resolve
+- **Solomon rule: reviewer_overreach**: new rule detects when the reviewer consistently flags out-of-scope issues that get auto-demoted by the scope filter
+- **Deferred context in coder prompt**: the coder receives a "Deferred reviewer concerns" section listing tracked tech debt, so it can naturally address issues if its changes touch the relevant areas
+- 4 new tests for scope filter and deferred context (1196 total)
+
 ## [1.11.1] - 2026-03-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -152,7 +152,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     last_sonar_issue_signature: null,
     sonar_repeat_count: 0,
     last_reviewer_issue_signature: null,
-    reviewer_repeat_count: 0
+    reviewer_repeat_count: 0,
+    deferred_issues: []
   };
   if (pgTaskId) sessionInit.pg_task_id = pgTaskId;
   if (pgProject) sessionInit.pg_project_id = pgProject;
@@ -496,7 +497,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     if (reviewerEnabled) {
       const reviewerResult = await runReviewerStage({
         reviewerRole, config, logger, emitter, eventBase, session, trackBudget,
-        iteration: i, reviewRules, task, repeatDetector, budgetSummary
+        iteration: i, reviewRules, task, repeatDetector, budgetSummary, askQuestion
       });
       if (reviewerResult.action === "pause") {
         return reviewerResult.result;
@@ -649,14 +650,17 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         }
       }
 
+      const deferredIssues = session.deferred_issues || [];
       emitProgress(
         emitter,
         makeEvent("session:end", { ...eventBase, stage: "done" }, {
-          message: "Session approved",
-          detail: { approved: true, iterations: i, stages: stageResults, git: gitResult, budget: budgetSummary() }
+          message: deferredIssues.length > 0
+            ? `Session approved (${deferredIssues.length} deferred issue(s) tracked as tech debt)`
+            : "Session approved",
+          detail: { approved: true, iterations: i, stages: stageResults, git: gitResult, budget: budgetSummary(), deferredIssues }
         })
       );
-      return { approved: true, sessionId: session.id, review, git: gitResult };
+      return { approved: true, sessionId: session.id, review, git: gitResult, deferredIssues };
     }
 
     session.last_reviewer_feedback = review.blocking_issues

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -6,6 +6,7 @@ import { addCheckpoint, markSessionStatus, saveSession, pauseSession } from "../
 import { generateDiff } from "../review/diff-generator.js";
 import { evaluateTddPolicy } from "../review/tdd-policy.js";
 import { validateReviewResult } from "../review/schema.js";
+import { filterReviewScope, buildDeferredContext } from "../review/scope-filter.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { runReviewerWithFallback } from "./reviewer-fallback.js";
 import { runCoderWithFallback } from "./agent-fallback.js";
@@ -39,6 +40,7 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       task: plannedTask,
       reviewerFeedback: session.last_reviewer_feedback,
       sonarSummary: session.last_sonar_summary,
+      deferredContext: buildDeferredContext(session.deferred_issues),
       onOutput: coderStall.onOutput
     });
   } finally {
@@ -390,7 +392,7 @@ export async function runSonarStage({ config, logger, emitter, eventBase, sessio
   return { action: "ok", stageResult };
 }
 
-export async function runReviewerStage({ reviewerRole, config, logger, emitter, eventBase, session, trackBudget, iteration, reviewRules, task, repeatDetector, budgetSummary }) {
+export async function runReviewerStage({ reviewerRole, config, logger, emitter, eventBase, session, trackBudget, iteration, reviewRules, task, repeatDetector, budgetSummary, askQuestion }) {
   logger.setContext({ iteration, stage: "reviewer" });
   emitProgress(
     emitter,
@@ -489,6 +491,39 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
       confidence: 0
     };
   }
+  // --- Scope filter: auto-defer out-of-scope blocking issues ---
+  const { review: filteredReview, demoted, deferred, allDemoted } = filterReviewScope(review, diff);
+  review = filteredReview;
+
+  if (demoted.length > 0) {
+    logger.info(`Scope filter: deferred ${demoted.length} out-of-scope issue(s)${allDemoted ? " — auto-approved" : ""}`);
+
+    // Accumulate deferred issues in session for tracking
+    if (!session.deferred_issues) session.deferred_issues = [];
+    session.deferred_issues.push(...deferred);
+    await saveSession(session);
+
+    emitProgress(
+      emitter,
+      makeEvent("reviewer:scope_filter", { ...eventBase, stage: "reviewer" }, {
+        message: `Scope filter deferred ${demoted.length} out-of-scope issue(s)`,
+        detail: {
+          demotedCount: demoted.length,
+          autoApproved: allDemoted,
+          totalDeferred: session.deferred_issues.length,
+          deferred: deferred.map(d => ({ file: d.file, id: d.id, description: d.description }))
+        }
+      })
+    );
+    await addCheckpoint(session, {
+      stage: "reviewer-scope-filter",
+      iteration,
+      demoted_count: demoted.length,
+      auto_approved: allDemoted,
+      total_deferred: session.deferred_issues.length
+    });
+  }
+
   await addCheckpoint(session, {
     stage: "reviewer",
     iteration,
@@ -518,8 +553,50 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
     const repeatState = repeatDetector.isStalled();
     if (repeatState.stalled) {
       const repeatCounts = repeatDetector.getRepeatCounts();
+
+      // --- Solomon mediation for stalled reviewer ---
+      // Instead of immediately stopping, let Solomon arbitrate
+      logger.warn(`Reviewer stalled (${repeatCounts.reviewer} repeats). Invoking Solomon mediation.`);
+      emitProgress(
+        emitter,
+        makeEvent("solomon:escalate", { ...eventBase, stage: "reviewer" }, {
+          message: `Reviewer stalled — Solomon mediating`,
+          detail: { repeats: repeatCounts.reviewer, reason: repeatState.reason }
+        })
+      );
+
+      const solomonResult = await invokeSolomon({
+        config, logger, emitter, eventBase, stage: "reviewer", askQuestion, session, iteration,
+        conflict: {
+          stage: "reviewer",
+          task,
+          iterationCount: repeatCounts.reviewer,
+          maxIterations: config.session?.fail_fast_repeats ?? 2,
+          stalledReason: repeatState.reason,
+          blockingIssues: review.blocking_issues,
+          history: [{ agent: "reviewer", feedback: review.blocking_issues.map(x => x.description).join("; ") }]
+        }
+      });
+
+      if (solomonResult.action === "pause") {
+        await markSessionStatus(session, "stalled");
+        return { review, stalled: true, stalledResult: { paused: true, sessionId: session.id, question: solomonResult.question, context: "reviewer_stalled" } };
+      }
+      if (solomonResult.action === "continue") {
+        // Solomon says continue — reset repeat detector for reviewer
+        repeatDetector.reviewer = { lastHash: null, repeatCount: 0 };
+        if (solomonResult.humanGuidance) {
+          session.last_reviewer_feedback = `Solomon/user guidance: ${solomonResult.humanGuidance}`;
+          await saveSession(session);
+        }
+        return { review };
+      }
+      if (solomonResult.action === "subtask") {
+        return { review, stalled: true, stalledResult: { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "reviewer_subtask" } };
+      }
+
+      // Fallback: original stall behavior
       const message = `Manual intervention required: reviewer issues repeated ${repeatCounts.reviewer} times.`;
-      logger.warn(message);
       await markSessionStatus(session, "stalled");
       emitProgress(
         emitter,

--- a/src/orchestrator/solomon-rules.js
+++ b/src/orchestrator/solomon-rules.js
@@ -7,7 +7,8 @@ const DEFAULT_RULES = {
   max_files_per_iteration: 10,
   max_stale_iterations: 3,
   no_new_dependencies_without_task: true,
-  scope_guard: true
+  scope_guard: true,
+  reviewer_overreach: true
 };
 
 export function evaluateRules(context, rulesConfig = {}) {
@@ -59,6 +60,17 @@ export function evaluateRules(context, rulesConfig = {}) {
     });
   }
 
+  // Rule 5: Reviewer overreach — reviewer consistently flags out-of-scope issues
+  if (rules.reviewer_overreach && context.reviewerDemotedCount > 0) {
+    const severity = context.reviewerDemotedCount >= 3 ? "critical" : "warn";
+    alerts.push({
+      rule: "reviewer_overreach",
+      severity,
+      message: `Reviewer flagged ${context.reviewerDemotedCount} out-of-scope issue(s) that were auto-demoted by scope filter.`,
+      detail: { demotedCount: context.reviewerDemotedCount, autoApproved: context.reviewerAutoApproved || false }
+    });
+  }
+
   return {
     alerts,
     hasCritical: alerts.some(a => a.severity === "critical"),
@@ -76,8 +88,19 @@ export async function buildRulesContext({ session, task, iteration }) {
     filesChanged: 0,
     staleIterations: 0,
     newDependencies: [],
-    outOfScopeFiles: []
+    outOfScopeFiles: [],
+    reviewerDemotedCount: 0,
+    reviewerAutoApproved: false
   };
+
+  // Count reviewer scope-filter demotions from session checkpoints
+  const scopeFilterCheckpoints = (session.checkpoints || [])
+    .filter(cp => cp.stage === "reviewer-scope-filter");
+  if (scopeFilterCheckpoints.length > 0) {
+    const latest = scopeFilterCheckpoints.at(-1);
+    context.reviewerDemotedCount = latest.demoted_count || 0;
+    context.reviewerAutoApproved = latest.auto_approved || false;
+  }
 
   // Count files changed via git
   try {

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -29,7 +29,7 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false }) {
+export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, deferredContext = null }) {
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     `Task:\n${task}`,
@@ -63,6 +63,10 @@ export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary =
 
   if (reviewerFeedback) {
     sections.push(`Reviewer blocking feedback:\n${reviewerFeedback}`);
+  }
+
+  if (deferredContext) {
+    sections.push(deferredContext);
   }
 
   return sections.join("\n\n");

--- a/src/review/scope-filter.js
+++ b/src/review/scope-filter.js
@@ -1,0 +1,152 @@
+/**
+ * Scope filter — auto-defers reviewer blocking issues that reference
+ * files NOT present in the diff.  This prevents reviewer scope drift
+ * (flagging missing features, unchanged code, future tasks) from
+ * stalling the pipeline.
+ *
+ * Deferred issues are NOT forgotten — they are tracked in the session
+ * as technical debt that should be resolved in future iterations or
+ * follow-up tasks.  The coder and planner receive context about what
+ * was deferred and why.
+ */
+
+/**
+ * Extract the set of changed file paths from a unified diff string.
+ */
+export function extractDiffFiles(diff) {
+  const files = new Set();
+  for (const line of (diff || "").split("\n")) {
+    // Match "+++ b/path" lines in unified diff
+    const m = line.match(/^\+\+\+ b\/(.+)/);
+    if (m) files.add(m[1]);
+  }
+  return files;
+}
+
+/**
+ * Determine whether a blocking issue is within scope of the diff.
+ *
+ * An issue is considered IN scope when:
+ * - It has no `file` field (general concern about the diff)
+ * - Its `file` matches one of the changed files (exact or suffix match)
+ * - It references a pattern present in the diff content itself
+ *
+ * An issue is OUT of scope when:
+ * - It explicitly references a file NOT in the diff
+ */
+export function isIssueInScope(issue, diffFiles, diffContent) {
+  const file = (issue.file || "").trim();
+
+  // No file specified — the reviewer is commenting on the diff generally
+  if (!file) return true;
+
+  // Direct match
+  if (diffFiles.has(file)) return true;
+
+  // Suffix match (reviewer might use full path vs relative)
+  for (const df of diffFiles) {
+    if (df.endsWith(file) || file.endsWith(df)) return true;
+  }
+
+  // Check if the file path appears anywhere in the diff content
+  // (covers cases where the file is referenced in imports/requires)
+  if (diffContent && diffContent.includes(file)) return true;
+
+  return false;
+}
+
+/**
+ * Filter a review result, demoting out-of-scope blocking issues to
+ * non-blocking suggestions.
+ *
+ * Returns { review, demoted, allDemoted } where:
+ * - review: the filtered review (may flip approved to true)
+ * - demoted: array of issues that were demoted
+ * - allDemoted: true if ALL blocking issues were out of scope
+ */
+export function filterReviewScope(review, diff) {
+  if (!review || review.approved) {
+    return { review, demoted: [], allDemoted: false };
+  }
+
+  const diffFiles = extractDiffFiles(diff);
+
+  // If we can't parse diff files, don't filter (safety)
+  if (diffFiles.size === 0) {
+    return { review, demoted: [], allDemoted: false };
+  }
+
+  const inScope = [];
+  const demoted = [];
+
+  for (const issue of review.blocking_issues || []) {
+    if (isIssueInScope(issue, diffFiles, diff)) {
+      inScope.push(issue);
+    } else {
+      demoted.push(issue);
+    }
+  }
+
+  if (demoted.length === 0) {
+    return { review, demoted: [], allDemoted: false };
+  }
+
+  const demotedSuggestions = demoted.map(
+    (issue) => `[auto-demoted] ${issue.file || "unknown"}: ${issue.description || issue.id || "no description"}`
+  );
+
+  const filtered = {
+    ...review,
+    blocking_issues: inScope,
+    non_blocking_suggestions: [
+      ...(review.non_blocking_suggestions || []),
+      ...demotedSuggestions
+    ]
+  };
+
+  // If no in-scope blocking issues remain, auto-approve
+  const allDemoted = inScope.length === 0;
+  if (allDemoted) {
+    filtered.approved = true;
+    filtered.summary = `${review.summary || ""} [Auto-approved: ${demoted.length} out-of-scope issue(s) demoted to suggestions]`.trim();
+  }
+
+  // Build structured deferred issues for session tracking
+  const deferred = demoted.map((issue) => ({
+    id: issue.id || null,
+    file: issue.file || null,
+    severity: issue.severity || "medium",
+    description: issue.description || "no description",
+    suggested_fix: issue.suggested_fix || null,
+    deferred_at: new Date().toISOString(),
+    reason: "out_of_scope"
+  }));
+
+  return { review: filtered, demoted, deferred, allDemoted };
+}
+
+/**
+ * Build a human-readable summary of deferred issues for injection
+ * into coder/planner prompts so they are aware of the tech debt.
+ */
+export function buildDeferredContext(deferredIssues) {
+  if (!deferredIssues?.length) return "";
+
+  const lines = [
+    "## Deferred reviewer concerns (technical debt)",
+    "The following issues were flagged by the reviewer but deferred because they are outside the current diff scope.",
+    "You do NOT need to fix them now, but be aware of them:",
+    ""
+  ];
+
+  for (const issue of deferredIssues) {
+    const file = issue.file ? `\`${issue.file}\`` : "general";
+    const fix = issue.suggested_fix ? ` — Suggestion: ${issue.suggested_fix}` : "";
+    lines.push(`- [${issue.severity}] ${file}: ${issue.description}${fix}`);
+  }
+
+  lines.push("");
+  lines.push("If your current changes naturally address any of these, great. Otherwise, they will be tracked for future resolution.");
+
+  return lines.join("\n");
+}

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -17,8 +17,8 @@ export class CoderRole extends BaseRole {
   }
 
   async execute(input) {
-    const { task, reviewerFeedback, sonarSummary, onOutput } = typeof input === "string"
-      ? { task: input, reviewerFeedback: null, sonarSummary: null, onOutput: null }
+    const { task, reviewerFeedback, sonarSummary, deferredContext, onOutput } = typeof input === "string"
+      ? { task: input, reviewerFeedback: null, sonarSummary: null, deferredContext: null, onOutput: null }
       : input || {};
 
     const provider = resolveProvider(this.config);
@@ -28,6 +28,7 @@ export class CoderRole extends BaseRole {
       task: task || this.context?.task || "",
       reviewerFeedback: reviewerFeedback || null,
       sonarSummary: sonarSummary || null,
+      deferredContext: deferredContext || null,
       coderRules: this.instructions,
       methodology: this.config?.development?.methodology || "tdd",
       serenaEnabled: Boolean(this.config?.serena?.enabled)

--- a/tests/orchestrator-iteration.test.js
+++ b/tests/orchestrator-iteration.test.js
@@ -282,8 +282,9 @@ describe("iteration-stages", () => {
       ).rejects.toThrow("Reviewer failed");
     });
 
-    it("returns stalled when reviewer issues repeat", async () => {
+    it("returns stalled when reviewer issues repeat and Solomon pauses", async () => {
       const { runReviewerWithFallback } = await import("../src/orchestrator/reviewer-fallback.js");
+      const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
       runReviewerWithFallback.mockResolvedValue({
         execResult: {
           ok: true,
@@ -291,12 +292,14 @@ describe("iteration-stages", () => {
         },
         attempts: []
       });
+      invokeSolomon.mockResolvedValue({ action: "pause", question: "Stalled" });
 
       const session = { id: "s1", session_start_sha: "abc", checkpoints: [] };
       const repeatDetector = {
         addIteration: vi.fn(),
         isStalled: vi.fn(() => ({ stalled: true, reason: "reviewer_repeat" })),
-        getRepeatCounts: vi.fn(() => ({ reviewer: 3 }))
+        getRepeatCounts: vi.fn(() => ({ reviewer: 3 })),
+        reviewer: { lastHash: null, repeatCount: 3 }
       };
 
       const result = await runReviewerStage({
@@ -307,7 +310,7 @@ describe("iteration-stages", () => {
       });
 
       expect(result.stalled).toBe(true);
-      expect(result.stalledResult.reason).toBe("stalled");
+      expect(result.stalledResult.context).toBe("reviewer_stalled");
     });
   });
 });

--- a/tests/orchestrator-repeat-detection.test.js
+++ b/tests/orchestrator-repeat-detection.test.js
@@ -69,6 +69,10 @@ vi.mock("../src/prompts/reviewer.js", () => ({
   buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt")
 }));
 
+vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
+  invokeSolomon: vi.fn().mockResolvedValue({ action: "pause", question: "Reviewer stalled" })
+}));
+
 vi.mock("../src/sonar/api.js", () => ({
   getQualityGateStatus: vi.fn(),
   getOpenIssues: vi.fn()
@@ -138,6 +142,9 @@ describe("orchestrator repeat detection", () => {
 
     const fs = await import("node:fs/promises");
     fs.default.readFile.mockResolvedValue("review rules");
+
+    const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
+    invokeSolomon.mockResolvedValue({ action: "pause", question: "Reviewer stalled" });
 
     const mod = await import("../src/orchestrator.js");
     runFlow = mod.runFlow;
@@ -230,9 +237,9 @@ describe("orchestrator repeat detection", () => {
 
     const { markSessionStatus } = await import("../src/session-store.js");
     expect(markSessionStatus).toHaveBeenCalledWith(expect.any(Object), "stalled");
-    expect(result.approved).toBe(false);
-    expect(result.reason).toBe("stalled");
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Manual intervention"));
+    expect(result.paused).toBe(true);
+    expect(result.context).toBe("reviewer_stalled");
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Reviewer stalled"));
     expect(reviewerAgent.reviewTask).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/scope-filter.test.js
+++ b/tests/scope-filter.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import { extractDiffFiles, isIssueInScope, filterReviewScope, buildDeferredContext } from "../src/review/scope-filter.js";
+
+const SAMPLE_DIFF = `diff --git a/src/foo.js b/src/foo.js
+--- a/src/foo.js
++++ b/src/foo.js
+@@ -1,3 +1,4 @@
+ const a = 1;
++const b = 2;
+ export { a };
+diff --git a/src/bar.js b/src/bar.js
+--- a/src/bar.js
++++ b/src/bar.js
+@@ -1,2 +1,3 @@
+ export function bar() {}
++export function baz() {}
+`;
+
+describe("extractDiffFiles", () => {
+  it("extracts file paths from unified diff", () => {
+    const files = extractDiffFiles(SAMPLE_DIFF);
+    expect(files).toEqual(new Set(["src/foo.js", "src/bar.js"]));
+  });
+
+  it("returns empty set for empty diff", () => {
+    expect(extractDiffFiles("")).toEqual(new Set());
+    expect(extractDiffFiles(null)).toEqual(new Set());
+  });
+});
+
+describe("isIssueInScope", () => {
+  const diffFiles = new Set(["src/foo.js", "src/bar.js"]);
+
+  it("returns true when issue has no file", () => {
+    expect(isIssueInScope({ description: "general issue" }, diffFiles, SAMPLE_DIFF)).toBe(true);
+  });
+
+  it("returns true when issue file is in diff", () => {
+    expect(isIssueInScope({ file: "src/foo.js" }, diffFiles, SAMPLE_DIFF)).toBe(true);
+  });
+
+  it("returns false when issue file is NOT in diff", () => {
+    expect(isIssueInScope({ file: "src/missing.js" }, diffFiles, "")).toBe(false);
+  });
+
+  it("handles suffix matching", () => {
+    expect(isIssueInScope({ file: "foo.js" }, diffFiles, "")).toBe(true);
+  });
+
+  it("returns true when file appears in diff content", () => {
+    const diff = SAMPLE_DIFF + '\nimport { helper } from "./utils/helper.js";';
+    expect(isIssueInScope({ file: "utils/helper.js" }, diffFiles, diff)).toBe(true);
+  });
+});
+
+describe("filterReviewScope", () => {
+  it("returns unchanged review when already approved", () => {
+    const review = { approved: true, blocking_issues: [], non_blocking_suggestions: [] };
+    const result = filterReviewScope(review, SAMPLE_DIFF);
+    expect(result.demoted).toEqual([]);
+    expect(result.review.approved).toBe(true);
+  });
+
+  it("demotes out-of-scope blocking issues", () => {
+    const review = {
+      approved: false,
+      blocking_issues: [
+        { id: "1", file: "src/foo.js", description: "in scope issue" },
+        { id: "2", file: "src/unrelated.js", description: "out of scope issue" }
+      ],
+      non_blocking_suggestions: [],
+      summary: "Review"
+    };
+    const result = filterReviewScope(review, SAMPLE_DIFF);
+    expect(result.demoted).toHaveLength(1);
+    expect(result.demoted[0].id).toBe("2");
+    expect(result.review.blocking_issues).toHaveLength(1);
+    expect(result.review.blocking_issues[0].id).toBe("1");
+    expect(result.review.approved).toBe(false);
+    expect(result.allDemoted).toBe(false);
+  });
+
+  it("auto-approves when ALL blocking issues are out of scope", () => {
+    const review = {
+      approved: false,
+      blocking_issues: [
+        { id: "1", file: "firestore.rules", description: "missing rules" },
+        { id: "2", file: "pages/admin.js", description: "missing page" }
+      ],
+      non_blocking_suggestions: ["existing suggestion"],
+      summary: "Rejected"
+    };
+    const result = filterReviewScope(review, SAMPLE_DIFF);
+    expect(result.demoted).toHaveLength(2);
+    expect(result.deferred).toHaveLength(2);
+    expect(result.allDemoted).toBe(true);
+    expect(result.review.approved).toBe(true);
+    expect(result.review.blocking_issues).toHaveLength(0);
+    expect(result.review.non_blocking_suggestions).toHaveLength(3);
+  });
+
+  it("produces structured deferred issues with metadata", () => {
+    const review = {
+      approved: false,
+      blocking_issues: [
+        { id: "1", file: "firestore.rules", severity: "high", description: "missing rules", suggested_fix: "add rules" }
+      ],
+      non_blocking_suggestions: []
+    };
+    const result = filterReviewScope(review, SAMPLE_DIFF);
+    expect(result.deferred).toHaveLength(1);
+    const d = result.deferred[0];
+    expect(d.file).toBe("firestore.rules");
+    expect(d.severity).toBe("high");
+    expect(d.description).toBe("missing rules");
+    expect(d.suggested_fix).toBe("add rules");
+    expect(d.reason).toBe("out_of_scope");
+    expect(d.deferred_at).toBeTruthy();
+  });
+
+  it("does not filter when diff is empty", () => {
+    const review = {
+      approved: false,
+      blocking_issues: [{ id: "1", file: "src/x.js", description: "issue" }],
+      non_blocking_suggestions: []
+    };
+    const result = filterReviewScope(review, "");
+    expect(result.demoted).toEqual([]);
+    expect(result.review.approved).toBe(false);
+  });
+
+  it("keeps issues without file field as in-scope", () => {
+    const review = {
+      approved: false,
+      blocking_issues: [
+        { id: "1", description: "general architecture concern" },
+        { id: "2", file: "src/nonexistent.js", description: "out of scope" }
+      ],
+      non_blocking_suggestions: []
+    };
+    const result = filterReviewScope(review, SAMPLE_DIFF);
+    expect(result.review.blocking_issues).toHaveLength(1);
+    expect(result.review.blocking_issues[0].id).toBe("1");
+    expect(result.demoted).toHaveLength(1);
+  });
+});
+
+describe("buildDeferredContext", () => {
+  it("returns empty string for no deferred issues", () => {
+    expect(buildDeferredContext([])).toBe("");
+    expect(buildDeferredContext(null)).toBe("");
+  });
+
+  it("builds readable context with deferred issues", () => {
+    const deferred = [
+      { file: "firestore.rules", severity: "high", description: "missing security rules", suggested_fix: "add rules file" },
+      { file: null, severity: "medium", description: "no error handling" }
+    ];
+    const context = buildDeferredContext(deferred);
+    expect(context).toContain("Deferred reviewer concerns");
+    expect(context).toContain("technical debt");
+    expect(context).toContain("`firestore.rules`");
+    expect(context).toContain("missing security rules");
+    expect(context).toContain("Suggestion: add rules file");
+    expect(context).toContain("no error handling");
+    expect(context).toContain("tracked for future resolution");
+  });
+
+  it("shows general for issues without file", () => {
+    const deferred = [{ severity: "low", description: "minor concern" }];
+    const context = buildDeferredContext(deferred);
+    expect(context).toContain("general: minor concern");
+  });
+});


### PR DESCRIPTION
## Summary
- **Scope filter**: auto-defers reviewer blocking issues that reference files NOT in the diff, instead of stalling the pipeline
- **Deferred issues tracking**: out-of-scope concerns stored in session as structured tech debt, injected into coder prompt as awareness context
- **Solomon mediation on stall**: when reviewer issues repeat, Solomon arbitrates before stopping — can override, continue, or create subtask
- **Solomon rule**: new `reviewer_overreach` rule detects consistent out-of-scope flagging

## Test plan
- [x] 1196 tests pass (16 new for scope filter + deferred context)
- [x] Lint clean
- [ ] Manual: run `kj_run` with a reviewer that flags out-of-scope files → should auto-defer and approve
- [ ] Manual: force reviewer stall → Solomon should mediate instead of stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)