### PR TITLE
fix(claude-agent): --verbose for stream-json (Claude Code v2.1.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-03-10
+
+### Fixed
+- **Claude subprocess incompatible with Claude Code v2.1.71**: `--print` combined with `--output-format stream-json` now requires `--verbose` flag. Added `--verbose` to both `runTask` (streaming) and `reviewTask` in `ClaudeAgent`
+
 ## [1.13.0] - 2026-03-08
 
 ### Added
@@ -291,7 +296,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: GitHub Actions workflow with validation and PR annotations
 - **716+ unit tests** with Vitest
 
-[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.13.1...HEAD
+[1.13.1]: https://github.com/manufosela/karajan-code/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/manufosela/karajan-code/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/manufosela/karajan-code/compare/v1.11.1...v1.12.0
+[1.11.1]: https://github.com/manufosela/karajan-code/compare/v1.11.0...v1.11.1
+[1.11.0]: https://github.com/manufosela/karajan-code/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/manufosela/karajan-code/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/manufosela/karajan-code/compare/v1.9.6...v1.10.0
 [1.9.6]: https://github.com/manufosela/karajan-code/compare/v1.9.4...v1.9.6

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,6 +124,10 @@ function pickOutput(res) {
 }
 ```
 
+4. **`--verbose` required with `stream-json`** (v2.1.71+): Claude Code now requires `--verbose` when combining `--print` with `--output-format stream-json`. Without it, the subprocess exits with an error.
+
+**Fix** (v1.13.1): Karajan adds `--verbose` alongside `--output-format stream-json` in both `runTask` and `reviewTask`.
+
 **Verify manually**:
 ```bash
 # Hangs (inherits env + stdin):
@@ -131,6 +135,9 @@ claude -p "Reply PONG" --output-format json
 
 # Works (clean env, no stdin, read stderr):
 env -u CLAUDECODE claude -p "Reply PONG" --output-format json < /dev/null 2>&1
+
+# For stream-json (requires --verbose since Claude Code v2.1.71):
+env -u CLAUDECODE claude -p "Reply PONG" --output-format stream-json --verbose < /dev/null 2>&1
 ```
 
 > This only affects Claude Code 2.x as a subprocess. Other agents (Codex, Gemini, Aider) are unaffected.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -120,7 +120,7 @@ export class ClaudeAgent extends BaseAgent {
 
     // Use stream-json when onOutput is provided to get real-time feedback
     if (task.onOutput) {
-      args.push("--output-format", "stream-json");
+      args.push("--output-format", "stream-json", "--verbose");
       const streamFilter = createStreamJsonFilter(task.onOutput);
       const res = await runCommand(resolveBin("claude"), args, cleanExecaOpts({
         onOutput: streamFilter,
@@ -141,7 +141,7 @@ export class ClaudeAgent extends BaseAgent {
   }
 
   async reviewTask(task) {
-    const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS, "--output-format", "stream-json"];
+    const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS, "--output-format", "stream-json", "--verbose"];
     const model = this.getRoleModel(task.role || "reviewer");
     if (model) args.push("--model", model);
     const res = await runCommand(resolveBin("claude"), args, cleanExecaOpts({

--- a/tests/agents-implementations.test.js
+++ b/tests/agents-implementations.test.js
@@ -53,7 +53,7 @@ describe("Agent implementations", () => {
       expect(args).toContain("opus");
     });
 
-    it("reviews task with --output-format stream-json", async () => {
+    it("reviews task with --output-format stream-json and --verbose", async () => {
       const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
       const agent = new ClaudeAgent("claude", baseConfig, logger);
       await agent.reviewTask({ prompt: "review code", role: "reviewer" });
@@ -61,6 +61,7 @@ describe("Agent implementations", () => {
       const args = runCommand.mock.calls[0][1];
       expect(args).toContain("--output-format");
       expect(args).toContain("stream-json");
+      expect(args).toContain("--verbose");
     });
 
     it("returns ok=false on non-zero exit with error from stderr", async () => {
@@ -74,7 +75,7 @@ describe("Agent implementations", () => {
       expect(result.error).toContain("error detail");
     });
 
-    it("uses stream-json and wraps onOutput when callback is provided", async () => {
+    it("uses stream-json with --verbose and wraps onOutput when callback is provided", async () => {
       const { ClaudeAgent } = await import("../src/agents/claude-agent.js");
       const agent = new ClaudeAgent("claude", baseConfig, logger);
       const onOutput = vi.fn();
@@ -83,6 +84,7 @@ describe("Agent implementations", () => {
       const args = runCommand.mock.calls[0][1];
       expect(args).toContain("--output-format");
       expect(args).toContain("stream-json");
+      expect(args).toContain("--verbose");
       // The onOutput is wrapped in a stream-json filter, not passed directly
       expect(runCommand.mock.calls[0][2]).toHaveProperty("onOutput");
       expect(runCommand.mock.calls[0][2].onOutput).not.toBe(onOutput);


### PR DESCRIPTION
## Summary
- Claude Code v2.1.71 requires `--verbose` when combining `--print` with `--output-format=stream-json`
- Added `--verbose` flag to `runTask` (streaming) and `reviewTask` in `ClaudeAgent`
- Updated tests, changelog, troubleshooting docs, and bumped version to 1.13.1

## Test plan
- [x] 18 agent implementation tests pass (including 2 updated assertions for `--verbose`)
- [ ] Manual `kj_run` with Claude Code v2.1.71 to confirm stream-json works

Fixes KJC-BUG-0006