### PR TITLE
fix(tdd): include untracked files in TDD policy + Solomon escalation

### DIFF
--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -3,7 +3,7 @@ import { CoderRole } from "../roles/coder-role.js";
 import { RefactorerRole } from "../roles/refactorer-role.js";
 import { SonarRole } from "../roles/sonar-role.js";
 import { addCheckpoint, markSessionStatus, saveSession, pauseSession } from "../session-store.js";
-import { generateDiff } from "../review/diff-generator.js";
+import { generateDiff, getUntrackedFiles } from "../review/diff-generator.js";
 import { evaluateTddPolicy } from "../review/tdd-policy.js";
 import { validateReviewResult } from "../review/schema.js";
 import { filterReviewScope, buildDeferredContext } from "../review/scope-filter.js";
@@ -198,7 +198,8 @@ export async function runRefactorerStage({ refactorerRole, config, logger, emitt
 export async function runTddCheckStage({ config, logger, emitter, eventBase, session, trackBudget, iteration, askQuestion }) {
   logger.setContext({ iteration, stage: "tdd" });
   const tddDiff = await generateDiff({ baseRef: session.session_start_sha });
-  const tddEval = evaluateTddPolicy(tddDiff, config.development);
+  const untrackedFiles = await getUntrackedFiles();
+  const tddEval = evaluateTddPolicy(tddDiff, config.development, untrackedFiles);
   await addCheckpoint(session, {
     stage: "tdd-policy",
     iteration,
@@ -227,34 +228,42 @@ export async function runTddCheckStage({ config, logger, emitter, eventBase, ses
     session.repeated_issue_count += 1;
     await saveSession(session);
     if (session.repeated_issue_count >= config.session.fail_fast_repeats) {
-      const question = `TDD policy has failed ${session.repeated_issue_count} times. The coder is not creating tests. How should we proceed? Issue: ${tddEval.reason}`;
-      if (askQuestion) {
-        const answer = await askQuestion(question, { iteration, stage: "tdd" });
-        if (answer) {
-          session.last_reviewer_feedback += `\nUser guidance: ${answer}`;
-          session.repeated_issue_count = 0;
-          await saveSession(session);
-          return { action: "continue" };
-        }
-      }
-      await pauseSession(session, {
-        question,
-        context: {
-          iteration,
-          stage: "tdd",
-          lastFeedback: tddEval.message,
-          repeatedCount: session.repeated_issue_count
-        }
-      });
       emitProgress(
         emitter,
-        makeEvent("question", { ...eventBase, stage: "tdd" }, {
-          status: "paused",
-          message: question,
-          detail: { question, sessionId: session.id }
+        makeEvent("solomon:escalate", { ...eventBase, stage: "tdd" }, {
+          message: `TDD sub-loop limit reached (${session.repeated_issue_count}/${config.session.fail_fast_repeats})`,
+          detail: { subloop: "tdd", retryCount: session.repeated_issue_count, reason: tddEval.reason }
         })
       );
-      return { action: "pause", result: { paused: true, sessionId: session.id, question, context: "tdd_fail_fast" } };
+
+      const solomonResult = await invokeSolomon({
+        config, logger, emitter, eventBase, stage: "tdd", askQuestion, session, iteration,
+        conflict: {
+          stage: "tdd",
+          task: session.task,
+          iterationCount: session.repeated_issue_count,
+          maxIterations: config.session.fail_fast_repeats,
+          reason: tddEval.reason,
+          sourceFiles: tddEval.sourceFiles,
+          testFiles: tddEval.testFiles,
+          history: [{ agent: "tdd-policy", feedback: tddEval.message }]
+        }
+      });
+
+      if (solomonResult.action === "pause") {
+        return { action: "pause", result: { paused: true, sessionId: session.id, question: solomonResult.question, context: "tdd_fail_fast" } };
+      }
+      if (solomonResult.action === "continue") {
+        if (solomonResult.humanGuidance) {
+          session.last_reviewer_feedback += `\nUser guidance: ${solomonResult.humanGuidance}`;
+        }
+        session.repeated_issue_count = 0;
+        await saveSession(session);
+        return { action: "continue" };
+      }
+      if (solomonResult.action === "subtask") {
+        return { action: "pause", result: { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "tdd_subtask" } };
+      }
     }
     return { action: "continue" };
   }

--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -20,3 +20,9 @@ export async function generateDiff({ baseRef }) {
   }
   return result.stdout;
 }
+
+export async function getUntrackedFiles() {
+  const result = await runCommand("git", ["ls-files", "--others", "--exclude-standard"]);
+  if (result.exitCode !== 0) return [];
+  return result.stdout.trim().split("\n").filter(Boolean);
+}

--- a/src/review/tdd-policy.js
+++ b/src/review/tdd-policy.js
@@ -19,13 +19,15 @@ function isSourceFile(file, extensions = []) {
   return extensions.some((ext) => file.endsWith(ext));
 }
 
-export function evaluateTddPolicy(diff, developmentConfig = {}) {
+export function evaluateTddPolicy(diff, developmentConfig = {}, untrackedFiles = []) {
   const requireTestChanges = developmentConfig.require_test_changes !== false;
   const patterns = developmentConfig.test_file_patterns || ["/tests/", "/__tests__/", ".test.", ".spec."];
   const extensions =
     developmentConfig.source_file_extensions || [".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".java", ".rb", ".php", ".cs"];
 
-  const files = extractChangedFiles(diff);
+  const diffFiles = extractChangedFiles(diff);
+  const extra = Array.isArray(untrackedFiles) ? untrackedFiles : [];
+  const files = [...new Set([...diffFiles, ...extra])];
   const sourceFiles = files.filter((f) => isSourceFile(f, extensions) && !isTestFile(f, patterns));
   const testFiles = files.filter((f) => isTestFile(f, patterns));
 

--- a/tests/checkpoint-provider-model.test.js
+++ b/tests/checkpoint-provider-model.test.js
@@ -92,6 +92,7 @@ vi.mock("../src/prompts/planner.js", () => ({
 }));
 
 vi.mock("../src/review/diff-generator.js", () => ({
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/command-review.test.js
+++ b/tests/command-review.test.js
@@ -16,6 +16,7 @@ vi.mock("../src/config.js", () => ({
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff --git a/file.js b/file.js\n+added line")
 }));
 

--- a/tests/diff-generator.test.js
+++ b/tests/diff-generator.test.js
@@ -5,7 +5,7 @@ vi.mock("../src/utils/process.js", () => ({
 }));
 
 const { runCommand } = await import("../src/utils/process.js");
-const { generateDiff } = await import("../src/review/diff-generator.js");
+const { generateDiff, getUntrackedFiles } = await import("../src/review/diff-generator.js");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -18,5 +18,39 @@ describe("generateDiff", () => {
     await generateDiff({ baseRef: "abc123" });
 
     expect(runCommand).toHaveBeenCalledWith("git", ["diff", "abc123"]);
+  });
+});
+
+describe("getUntrackedFiles", () => {
+  it("returns list of untracked files excluding gitignored", async () => {
+    runCommand.mockResolvedValue({
+      exitCode: 0,
+      stdout: "src/guards/policy-resolver.js\ntests/guards/policy-resolver.test.js\n",
+      stderr: ""
+    });
+
+    const files = await getUntrackedFiles();
+
+    expect(runCommand).toHaveBeenCalledWith("git", ["ls-files", "--others", "--exclude-standard"]);
+    expect(files).toEqual([
+      "src/guards/policy-resolver.js",
+      "tests/guards/policy-resolver.test.js"
+    ]);
+  });
+
+  it("returns empty array when no untracked files", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    const files = await getUntrackedFiles();
+
+    expect(files).toEqual([]);
+  });
+
+  it("returns empty array when command fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error" });
+
+    const files = await getUntrackedFiles();
+
+    expect(files).toEqual([]);
   });
 });

--- a/tests/dry-run.test.js
+++ b/tests/dry-run.test.js
@@ -20,6 +20,7 @@ vi.mock("../src/session-store.js", () => ({
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -45,6 +45,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -88,6 +88,7 @@ vi.mock("../src/review/parser.js", () => ({
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/orchestrator-budget.test.js
+++ b/tests/orchestrator-budget.test.js
@@ -51,6 +51,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff")
 }));
 

--- a/tests/orchestrator-checkpoint.test.js
+++ b/tests/orchestrator-checkpoint.test.js
@@ -15,6 +15,7 @@ vi.mock("../src/session-store.js", () => ({
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn(async () => "abc123"),
+  getUntrackedFiles: vi.fn(async () => []),
   generateDiff: vi.fn(async () => "diff content")
 }));
 

--- a/tests/orchestrator-events.test.js
+++ b/tests/orchestrator-events.test.js
@@ -49,6 +49,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 
@@ -64,6 +65,10 @@ vi.mock("../src/review/tdd-policy.js", () => ({
     testFiles: ["a.test.js"],
     message: "OK"
   })
+}));
+
+vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
+  invokeSolomon: vi.fn().mockResolvedValue({ action: "continue", humanGuidance: "Proceed" })
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
@@ -361,8 +366,9 @@ describe("orchestrator events", () => {
     expect(outputEvents[2].stage).toBe("reviewer");
   });
 
-  it("calls askQuestion on fail-fast and continues if answer provided", async () => {
+  it("escalates to Solomon on TDD fail-fast and continues if Solomon resolves", async () => {
     const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
+    const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
     let tddCallCount = 0;
     evaluateTddPolicy.mockImplementation(() => {
       tddCallCount += 1;
@@ -371,8 +377,9 @@ describe("orchestrator events", () => {
       }
       return { ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" };
     });
+    invokeSolomon.mockResolvedValue({ action: "continue", humanGuidance: "Coder should create test files first" });
 
-    const askQuestion = vi.fn().mockResolvedValue("Skip tests for now");
+    const askQuestion = vi.fn();
 
     const config = {
       coder: "codex",
@@ -386,6 +393,7 @@ describe("orchestrator events", () => {
       git: { auto_commit: false, auto_push: false, auto_pr: false },
       session: { max_total_minutes: 120, fail_fast_repeats: 2 },
       reviewer_options: { retries: 0, fallback_reviewer: null },
+      pipeline: { solomon: { enabled: true } },
       output: { log_level: "info" }
     };
 
@@ -397,16 +405,19 @@ describe("orchestrator events", () => {
     const emitter = new EventEmitter();
     const result = await runFlow({ task: "test", config, logger, flags: {}, emitter, askQuestion });
 
-    expect(askQuestion).toHaveBeenCalledTimes(1);
-    expect(askQuestion.mock.calls[0][0]).toContain("TDD policy has failed");
+    expect(invokeSolomon).toHaveBeenCalledWith(expect.objectContaining({
+      conflict: expect.objectContaining({ stage: "tdd" })
+    }));
     expect(result.approved).toBe(true);
   });
 
-  it("falls back to pause when askQuestion returns null", async () => {
+  it("falls back to pause when Solomon cannot resolve TDD conflict", async () => {
     const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
+    const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
     evaluateTddPolicy.mockReturnValue({
       ok: false, reason: "no tests", sourceFiles: ["a.js"], testFiles: [], message: "No tests found"
     });
+    invokeSolomon.mockResolvedValue({ action: "pause", question: "TDD conflict unresolved — needs human input" });
 
     const askQuestion = vi.fn().mockResolvedValue(null);
 
@@ -422,6 +433,7 @@ describe("orchestrator events", () => {
       git: { auto_commit: false, auto_push: false, auto_pr: false },
       session: { max_total_minutes: 120, fail_fast_repeats: 2 },
       reviewer_options: { retries: 0, fallback_reviewer: null },
+      pipeline: { solomon: { enabled: true } },
       output: { log_level: "info" }
     };
 
@@ -433,7 +445,9 @@ describe("orchestrator events", () => {
     const emitter = new EventEmitter();
     const result = await runFlow({ task: "test", config, logger, flags: {}, emitter, askQuestion });
 
-    expect(askQuestion).toHaveBeenCalledTimes(1);
+    expect(invokeSolomon).toHaveBeenCalledWith(expect.objectContaining({
+      conflict: expect.objectContaining({ stage: "tdd" })
+    }));
     expect(result.paused).toBe(true);
   });
 

--- a/tests/orchestrator-iteration.test.js
+++ b/tests/orchestrator-iteration.test.js
@@ -35,6 +35,7 @@ vi.mock("../src/utils/events.js", () => ({
 }));
 
 vi.mock("../src/review/diff-generator.js", () => ({
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 
@@ -171,16 +172,22 @@ describe("iteration-stages", () => {
       expect(result.action).toBe("continue");
     });
 
-    it("returns pause when TDD fails repeatedly without askQuestion", async () => {
+    it("returns pause when TDD fails repeatedly and Solomon escalates to pause", async () => {
       const { evaluateTddPolicy } = await import("../src/review/tdd-policy.js");
       evaluateTddPolicy.mockReturnValue({ ok: false, reason: "no tests", message: "Missing", sourceFiles: ["a.js"], testFiles: [] });
 
-      const session = { id: "s1", session_start_sha: "abc", checkpoints: [], repeated_issue_count: 1 };
-      const config = { development: {}, session: { fail_fast_repeats: 2 } };
+      const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
+      invokeSolomon.mockResolvedValue({ action: "pause", question: "TDD stalled — needs human input" });
+
+      const session = { id: "s1", session_start_sha: "abc", checkpoints: [], repeated_issue_count: 1, task: "test task" };
+      const config = { development: {}, session: { fail_fast_repeats: 2 }, pipeline: { solomon: { enabled: true } } };
 
       const result = await runTddCheckStage({ config, logger, emitter, eventBase, session, trackBudget, iteration: 1, askQuestion: null });
       expect(result.action).toBe("pause");
       expect(result.result.paused).toBe(true);
+      expect(invokeSolomon).toHaveBeenCalledWith(expect.objectContaining({
+        conflict: expect.objectContaining({ stage: "tdd" })
+      }));
     });
   });
 

--- a/tests/orchestrator-pg-integration.test.js
+++ b/tests/orchestrator-pg-integration.test.js
@@ -15,6 +15,7 @@ vi.mock("../src/session-store.js", () => ({
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn(async () => "abc123"),
+  getUntrackedFiles: vi.fn(async () => []),
   generateDiff: vi.fn(async () => "diff content")
 }));
 

--- a/tests/orchestrator-repeat-detection.test.js
+++ b/tests/orchestrator-repeat-detection.test.js
@@ -44,6 +44,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/orchestrator-triage.test.js
+++ b/tests/orchestrator-triage.test.js
@@ -101,6 +101,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff")
 }));
 

--- a/tests/rate-limit-stages.test.js
+++ b/tests/rate-limit-stages.test.js
@@ -33,6 +33,7 @@ vi.mock("../src/utils/events.js", () => ({
 }));
 
 vi.mock("../src/review/diff-generator.js", () => ({
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/reviewer-parse-resilience.test.js
+++ b/tests/reviewer-parse-resilience.test.js
@@ -40,6 +40,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -40,6 +40,7 @@ vi.mock("../src/session-store.js", () => {
 
 vi.mock("../src/review/diff-generator.js", () => ({
   computeBaseRef: vi.fn().mockResolvedValue("abc123"),
+  getUntrackedFiles: vi.fn().mockResolvedValue([]),
   generateDiff: vi.fn().mockResolvedValue("diff content")
 }));
 

--- a/tests/tdd-policy.test.js
+++ b/tests/tdd-policy.test.js
@@ -44,4 +44,83 @@ describe("evaluateTddPolicy", () => {
     expect(out.ok).toBe(true);
     expect(out.reason).toBe("no_source_changes");
   });
+
+  describe("untracked files support", () => {
+    it("passes when source is only in diff but tests are untracked (new files)", () => {
+      const diff = [
+        "diff --git a/src/config.js b/src/config.js",
+        "index 111..222 100644",
+        "--- a/src/config.js",
+        "+++ b/src/config.js"
+      ].join("\n");
+
+      const untrackedFiles = [
+        "src/guards/policy-resolver.js",
+        "tests/guards/policy-resolver.test.js"
+      ];
+
+      const out = evaluateTddPolicy(diff, { require_test_changes: true }, untrackedFiles);
+      expect(out.ok).toBe(true);
+      expect(out.reason).toBe("tests_present");
+      expect(out.testFiles).toContain("tests/guards/policy-resolver.test.js");
+      expect(out.sourceFiles).toContain("src/guards/policy-resolver.js");
+    });
+
+    it("fails when untracked files are all source with no tests", () => {
+      const diff = "";
+      const untrackedFiles = [
+        "src/guards/policy-resolver.js",
+        "src/guards/utils.js"
+      ];
+
+      const out = evaluateTddPolicy(diff, { require_test_changes: true }, untrackedFiles);
+      expect(out.ok).toBe(false);
+      expect(out.reason).toBe("source_changes_without_tests");
+    });
+
+    it("passes when all untracked files are tests (add-tests scenario)", () => {
+      const diff = "";
+      const untrackedFiles = [
+        "tests/guards/policy-resolver.test.js",
+        "tests/guards/utils.test.js"
+      ];
+
+      const out = evaluateTddPolicy(diff, { require_test_changes: true }, untrackedFiles);
+      expect(out.ok).toBe(true);
+      expect(out.reason).toBe("no_source_changes");
+    });
+
+    it("merges diff files and untracked files without duplicates", () => {
+      const diff = [
+        "diff --git a/src/config.js b/src/config.js",
+        "index 111..222 100644",
+        "--- a/src/config.js",
+        "+++ b/src/config.js"
+      ].join("\n");
+
+      const untrackedFiles = [
+        "src/config.js",
+        "tests/config.test.js"
+      ];
+
+      const out = evaluateTddPolicy(diff, { require_test_changes: true }, untrackedFiles);
+      expect(out.ok).toBe(true);
+      expect(out.sourceFiles.filter(f => f === "src/config.js")).toHaveLength(1);
+    });
+
+    it("handles empty/undefined untrackedFiles gracefully", () => {
+      const diff = [
+        "diff --git a/src/auth.js b/src/auth.js",
+        "index 111..222 100644",
+        "--- a/src/auth.js",
+        "+++ b/src/auth.js"
+      ].join("\n");
+
+      const out1 = evaluateTddPolicy(diff, { require_test_changes: true }, []);
+      expect(out1.ok).toBe(false);
+
+      const out2 = evaluateTddPolicy(diff, { require_test_changes: true }, undefined);
+      expect(out2.ok).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Root cause fix**: `generateDiff()` used `git diff` which ignores untracked (new) files. The TDD policy never saw test files created by the coder, causing false violations on every task that creates new files.
- **Solomon escalation**: TDD fail-fast now escalates to Solomon (like sonar and reviewer do) instead of pausing directly to the host, preventing the host from seeking workarounds.

## Changes
- `src/review/diff-generator.js`: Add `getUntrackedFiles()` using `git ls-files --others --exclude-standard`
- `src/review/tdd-policy.js`: Accept `untrackedFiles` parameter, merge with diff files via `Set` for deduplication
- `src/orchestrator/iteration-stages.js`: Pass untracked files to TDD check + replace `pauseSession` with `invokeSolomon()`
- 17 test files updated with `getUntrackedFiles` mock + 2 tests rewritten for Solomon flow

## Test plan
- [x] 1238 tests passing (111 test files)
- [x] New tests cover: untracked source+test files, untracked source only, untracked tests only, deduplication, empty/undefined handling
- [x] Existing TDD policy tests still pass
- [x] Solomon escalation tests verify conflict context includes `stage: "tdd"`