### PR TITLE
feat(guards): policy-resolver for taskType-driven pipeline gating

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -97,6 +97,7 @@ const DEFAULTS = {
       disabled_rules: ["javascript:S1116", "javascript:S3776"]
     }
   },
+  policies: {},
   serena: { enabled: false },
   planning_game: { enabled: false, project_id: null, codeveloper: null },
   becaria: { enabled: false, review_event: "becaria-review", comment_event: "becaria-comment", comment_prefix: true },
@@ -285,6 +286,7 @@ export function applyRunOverrides(config, flags) {
     out.development.methodology = methodology;
     out.development.require_test_changes = methodology === "tdd";
   }
+  if (flags.taskType) out.taskType = String(flags.taskType);
   if (flags.noSonar || flags.sonar === false) out.sonarqube.enabled = false;
   out.serena = out.serena || { enabled: false };
   if (flags.enableSerena !== undefined) out.serena.enabled = Boolean(flags.enableSerena);

--- a/src/guards/policy-resolver.js
+++ b/src/guards/policy-resolver.js
@@ -1,0 +1,37 @@
+export const VALID_TASK_TYPES = ["sw", "infra", "doc", "add-tests", "refactor"];
+
+export const DEFAULT_POLICIES = {
+  sw:        { tdd: true,  sonar: true,  reviewer: true, testsRequired: true  },
+  infra:     { tdd: false, sonar: false, reviewer: true, testsRequired: false },
+  doc:       { tdd: false, sonar: false, reviewer: true, testsRequired: false },
+  "add-tests": { tdd: false, sonar: true,  reviewer: true, testsRequired: true  },
+  refactor:  { tdd: true,  sonar: true,  reviewer: true, testsRequired: false },
+};
+
+const FALLBACK_TYPE = "sw";
+
+/**
+ * Resolve pipeline policies for a given taskType.
+ * Unknown / null / undefined taskType falls back to "sw" (conservative).
+ * configOverrides optionally merges over defaults per taskType.
+ */
+export function resolvePolicies(taskType, configOverrides) {
+  const resolvedType = VALID_TASK_TYPES.includes(taskType) ? taskType : FALLBACK_TYPE;
+  const base = { ...DEFAULT_POLICIES[resolvedType] };
+  const overrides = configOverrides?.[resolvedType];
+  if (overrides && typeof overrides === "object") {
+    Object.assign(base, overrides);
+  }
+  return base;
+}
+
+/**
+ * Resolve policies for a taskType and return a flat object with the resolved
+ * taskType plus all policy flags. This is the main entry point for the
+ * orchestrator to determine which pipeline stages to enable/disable.
+ */
+export function applyPolicies({ taskType, policies } = {}) {
+  const resolvedType = VALID_TASK_TYPES.includes(taskType) ? taskType : FALLBACK_TYPE;
+  const resolved = resolvePolicies(taskType, policies);
+  return { taskType: resolvedType, ...resolved };
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -22,6 +22,7 @@ import {
   incrementalPush
 } from "./git/automation.js";
 import { resolveRoleMdPath, loadFirstExisting } from "./roles/base-role.js";
+import { applyPolicies } from "./guards/policy-resolver.js";
 import { resolveReviewProfile } from "./review/profiles.js";
 import { CoderRole } from "./roles/coder-role.js";
 import { invokeSolomon } from "./orchestrator/solomon-escalation.js";
@@ -47,6 +48,10 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
   // --- Dry-run: return summary without executing anything ---
   if (flags.dryRun) {
+    const dryRunPolicies = applyPolicies({
+      taskType: flags.taskType || config.taskType || null,
+      policies: config.policies,
+    });
     const projectDir = config.projectDir || process.cwd();
     const { rules: reviewRules } = await resolveReviewProfile({ mode: config.review_mode, projectDir });
     const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
@@ -56,6 +61,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     const summary = {
       dry_run: true,
       task,
+      policies: dryRunPolicies,
       roles: {
         planner: plannerRole,
         coder: coderRole,
@@ -274,6 +280,32 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   if (flags.enableReviewer !== undefined) reviewerEnabled = Boolean(flags.enableReviewer);
   if (flags.enableTester !== undefined) testerEnabled = Boolean(flags.enableTester);
   if (flags.enableSecurity !== undefined) securityEnabled = Boolean(flags.enableSecurity);
+
+  // --- Policy resolver: gate stages by taskType ---
+  const resolvedPolicies = applyPolicies({
+    taskType: flags.taskType || config.taskType || null,
+    policies: config.policies,
+  });
+  session.resolved_policies = resolvedPolicies;
+
+  // Apply policy gates on shallow copies (never mutate the caller's config)
+  if (!resolvedPolicies.tdd) {
+    config = { ...config, development: { ...config.development, methodology: "standard", require_test_changes: false } };
+  }
+  if (!resolvedPolicies.sonar) {
+    config = { ...config, sonarqube: { ...config.sonarqube, enabled: false } };
+  }
+  if (!resolvedPolicies.reviewer) {
+    reviewerEnabled = false;
+  }
+
+  emitProgress(
+    emitter,
+    makeEvent("policies:resolved", eventBase, {
+      message: `Policies resolved for taskType="${resolvedPolicies.taskType}"`,
+      detail: resolvedPolicies
+    })
+  );
 
   // --- Researcher (pre-planning) ---
   let researchContext = null;

--- a/tests/guards/policy-resolver.test.js
+++ b/tests/guards/policy-resolver.test.js
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { resolvePolicies, applyPolicies, VALID_TASK_TYPES, DEFAULT_POLICIES } from "../../src/guards/policy-resolver.js";
+
+describe("policy-resolver", () => {
+  describe("VALID_TASK_TYPES", () => {
+    it("contains exactly the five expected task types", () => {
+      expect(VALID_TASK_TYPES).toEqual(["sw", "infra", "doc", "add-tests", "refactor"]);
+    });
+  });
+
+  describe("DEFAULT_POLICIES", () => {
+    it("has an entry for each valid task type", () => {
+      for (const t of VALID_TASK_TYPES) {
+        expect(DEFAULT_POLICIES).toHaveProperty(t);
+      }
+    });
+  });
+
+  describe("resolvePolicies – default mappings", () => {
+    it("sw → all true", () => {
+      expect(resolvePolicies("sw")).toEqual({ tdd: true, sonar: true, reviewer: true, testsRequired: true });
+    });
+
+    it("infra → only reviewer true", () => {
+      expect(resolvePolicies("infra")).toEqual({ tdd: false, sonar: false, reviewer: true, testsRequired: false });
+    });
+
+    it("doc → only reviewer true", () => {
+      expect(resolvePolicies("doc")).toEqual({ tdd: false, sonar: false, reviewer: true, testsRequired: false });
+    });
+
+    it("add-tests → sonar, reviewer, testsRequired true; tdd false", () => {
+      expect(resolvePolicies("add-tests")).toEqual({ tdd: false, sonar: true, reviewer: true, testsRequired: true });
+    });
+
+    it("refactor → tdd, sonar, reviewer true; testsRequired false", () => {
+      expect(resolvePolicies("refactor")).toEqual({ tdd: true, sonar: true, reviewer: true, testsRequired: false });
+    });
+  });
+
+  describe("resolvePolicies – unknown / null / undefined taskType defaults to sw", () => {
+    it("unknown string defaults to sw", () => {
+      expect(resolvePolicies("unknown")).toEqual(resolvePolicies("sw"));
+    });
+
+    it("null defaults to sw", () => {
+      expect(resolvePolicies(null)).toEqual(resolvePolicies("sw"));
+    });
+
+    it("undefined defaults to sw", () => {
+      expect(resolvePolicies(undefined)).toEqual(resolvePolicies("sw"));
+    });
+
+    it("empty string defaults to sw", () => {
+      expect(resolvePolicies("")).toEqual(resolvePolicies("sw"));
+    });
+  });
+
+  describe("resolvePolicies – configOverrides merging", () => {
+    it("overrides a single field for a task type", () => {
+      const result = resolvePolicies("sw", { sw: { tdd: false } });
+      expect(result).toEqual({ tdd: false, sonar: true, reviewer: true, testsRequired: true });
+    });
+
+    it("overrides multiple fields", () => {
+      const result = resolvePolicies("infra", { infra: { sonar: true, testsRequired: true } });
+      expect(result).toEqual({ tdd: false, sonar: true, reviewer: true, testsRequired: true });
+    });
+
+    it("ignores overrides for other task types", () => {
+      const result = resolvePolicies("doc", { sw: { tdd: false } });
+      expect(result).toEqual({ tdd: false, sonar: false, reviewer: true, testsRequired: false });
+    });
+
+    it("overrides apply to the resolved type when taskType is unknown", () => {
+      const result = resolvePolicies("bogus", { sw: { sonar: false } });
+      expect(result).toEqual({ tdd: true, sonar: false, reviewer: true, testsRequired: true });
+    });
+
+    it("empty overrides object has no effect", () => {
+      expect(resolvePolicies("sw", {})).toEqual(resolvePolicies("sw"));
+    });
+
+    it("null overrides has no effect", () => {
+      expect(resolvePolicies("sw", null)).toEqual(resolvePolicies("sw"));
+    });
+
+    it("undefined overrides has no effect", () => {
+      expect(resolvePolicies("sw", undefined)).toEqual(resolvePolicies("sw"));
+    });
+  });
+
+  describe("applyPolicies", () => {
+    it("returns resolved policies and the resolved taskType", () => {
+      const result = applyPolicies({ taskType: "doc", policies: {} });
+      expect(result).toEqual({
+        taskType: "doc",
+        tdd: false,
+        sonar: false,
+        reviewer: true,
+        testsRequired: false,
+      });
+    });
+
+    it("falls back to sw when taskType is null", () => {
+      const result = applyPolicies({ taskType: null, policies: {} });
+      expect(result.taskType).toBe("sw");
+      expect(result.tdd).toBe(true);
+      expect(result.sonar).toBe(true);
+    });
+
+    it("falls back to sw when taskType is undefined (not provided)", () => {
+      const result = applyPolicies({});
+      expect(result.taskType).toBe("sw");
+    });
+
+    it("applies config policy overrides", () => {
+      const result = applyPolicies({
+        taskType: "sw",
+        policies: { sw: { tdd: false } },
+      });
+      expect(result.tdd).toBe(false);
+      expect(result.sonar).toBe(true);
+    });
+
+    it("infra disables tdd, sonar, testsRequired", () => {
+      const result = applyPolicies({ taskType: "infra" });
+      expect(result.tdd).toBe(false);
+      expect(result.sonar).toBe(false);
+      expect(result.reviewer).toBe(true);
+      expect(result.testsRequired).toBe(false);
+    });
+
+    it("add-tests disables tdd but keeps sonar and testsRequired", () => {
+      const result = applyPolicies({ taskType: "add-tests" });
+      expect(result.tdd).toBe(false);
+      expect(result.sonar).toBe(true);
+      expect(result.testsRequired).toBe(true);
+    });
+
+    it("refactor enables tdd and sonar but not testsRequired", () => {
+      const result = applyPolicies({ taskType: "refactor" });
+      expect(result.tdd).toBe(true);
+      expect(result.sonar).toBe(true);
+      expect(result.testsRequired).toBe(false);
+    });
+  });
+
+  describe("resolvePolicies – does not mutate DEFAULT_POLICIES", () => {
+    it("overrides do not leak into DEFAULT_POLICIES", () => {
+      const before = { ...DEFAULT_POLICIES.sw };
+      resolvePolicies("sw", { sw: { tdd: false } });
+      expect(DEFAULT_POLICIES.sw).toEqual(before);
+    });
+  });
+});

--- a/tests/orchestrator-events.test.js
+++ b/tests/orchestrator-events.test.js
@@ -196,6 +196,7 @@ describe("orchestrator events", () => {
     expect(result.approved).toBe(true);
     expect(events).toEqual([
       "session:start",
+      "policies:resolved",
       "iteration:start",
       "coder:start",
       "coder:end",
@@ -530,6 +531,7 @@ describe("orchestrator events", () => {
     expect(result.approved).toBe(true);
     expect(events).toEqual([
       "session:start",
+      "policies:resolved",
       "planner:start",
       "planner:end",
       "iteration:start",
@@ -635,5 +637,72 @@ describe("orchestrator events", () => {
     expect(sessionEnd?.detail?.stages?.sonar?.issuesResolved).toBe(5);
     expect(sessionEnd?.detail?.git?.commits).toEqual([{ hash: "abc1234", message: "feat: auth hardening" }]);
     expect(sessionEnd?.detail?.git?.prUrl).toBe("https://github.com/org/repo/pull/9");
+  });
+
+  it("does not mutate caller config when policy gates disable TDD/Sonar (R-1)", async () => {
+    const emitter = new EventEmitter();
+
+    const config = {
+      coder: "codex",
+      reviewer: "claude",
+      review_mode: "standard",
+      max_iterations: 1,
+      review_rules: "./review-rules.md",
+      base_branch: "main",
+      taskType: "doc",
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: true, host: "http://localhost:9000" },
+      git: { auto_commit: false, auto_push: false, auto_pr: false },
+      session: { max_total_minutes: 120, fail_fast_repeats: 2 },
+      reviewer_options: { retries: 0, fallback_reviewer: null },
+      output: { log_level: "info" }
+    };
+
+    const logger = {
+      debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      setContext: vi.fn(), resetContext: vi.fn()
+    };
+
+    await runFlow({ task: "update docs", config, logger, flags: {}, emitter });
+
+    // The caller's config must remain untouched after runFlow
+    expect(config.development.methodology).toBe("tdd");
+    expect(config.development.require_test_changes).toBe(true);
+    expect(config.sonarqube.enabled).toBe(true);
+  });
+
+  it("honors config.taskType when flags.taskType is absent (R-1)", async () => {
+    const emitter = new EventEmitter();
+    const events = [];
+    emitter.on("progress", (e) => events.push(e));
+
+    const config = {
+      coder: "codex",
+      reviewer: "claude",
+      review_mode: "standard",
+      max_iterations: 1,
+      review_rules: "./review-rules.md",
+      base_branch: "main",
+      taskType: "doc",
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: true, host: "http://localhost:9000" },
+      git: { auto_commit: false, auto_push: false, auto_pr: false },
+      session: { max_total_minutes: 120, fail_fast_repeats: 2 },
+      reviewer_options: { retries: 0, fallback_reviewer: null },
+      output: { log_level: "info" }
+    };
+
+    const logger = {
+      debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      setContext: vi.fn(), resetContext: vi.fn()
+    };
+
+    await runFlow({ task: "update docs", config, logger, flags: {}, emitter });
+
+    const policyEvent = events.find((e) => e.type === "policies:resolved");
+    expect(policyEvent).toBeTruthy();
+    expect(policyEvent.detail.taskType).toBe("doc");
+    expect(policyEvent.detail.tdd).toBe(false);
+    expect(policyEvent.detail.sonar).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- New `src/guards/policy-resolver.js` module: maps taskType (sw, infra, doc, add-tests, refactor) to pipeline policies (tdd, sonar, reviewer, testsRequired) with config overrides support
- Integrated into orchestrator: applies policy gates without mutating caller config, emits `policies:resolved` event
- 26 unit tests + 2 integration tests (no-mutation guarantee + config.taskType precedence)

## Test plan
- [x] 112 test files, 1266 tests passing
- [x] Policy-resolver unit tests cover all taskTypes, fallback to sw, config overrides
- [x] Integration tests verify caller config immutability and taskType resolution

KJC-TSK-0126