### PR TITLE
feat(triage): classify taskType for policy-driven pipeline

### DIFF
--- a/src/prompts/triage.js
+++ b/src/prompts/triage.js
@@ -47,10 +47,10 @@ export function buildTriagePrompt({ task, instructions, availableRoles }) {
   );
 
   sections.push(
-    "Classify the task complexity, recommend only the necessary pipeline roles, and assess whether the task should be decomposed into smaller subtasks.",
+    "Classify the task complexity, determine its taskType, recommend only the necessary pipeline roles, and assess whether the task should be decomposed into smaller subtasks.",
     "Keep the reasoning short and practical.",
     "Return a single valid JSON object and nothing else.",
-    'JSON schema: {"level":"trivial|simple|medium|complex","roles":["planner|researcher|refactorer|reviewer|tester|security"],"reasoning":string,"shouldDecompose":boolean,"subtasks":string[]}'
+    'JSON schema: {"level":"trivial|simple|medium|complex","roles":["planner|researcher|refactorer|reviewer|tester|security"],"taskType":"sw|infra|doc|add-tests|refactor","reasoning":string,"shouldDecompose":boolean,"subtasks":string[]}'
   );
 
   sections.push(`## Task\n${task}`);

--- a/src/roles/triage-role.js
+++ b/src/roles/triage-role.js
@@ -1,9 +1,11 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { buildTriagePrompt } from "../prompts/triage.js";
+import { VALID_TASK_TYPES } from "../guards/policy-resolver.js";
 
 const VALID_LEVELS = new Set(["trivial", "simple", "medium", "complex"]);
 const VALID_ROLES = new Set(["planner", "researcher", "refactorer", "reviewer", "tester", "security"]);
+const FALLBACK_TASK_TYPE = "sw";
 
 function resolveProvider(config) {
   return (
@@ -74,6 +76,7 @@ export class TriageRole extends BaseRole {
             level: "medium",
             roles: ["reviewer"],
             reasoning: "Unstructured output, using safe defaults.",
+            taskType: FALLBACK_TASK_TYPE,
             provider,
             raw: result.output
           },
@@ -87,11 +90,13 @@ export class TriageRole extends BaseRole {
       const reasoning = String(parsed.reasoning || "").trim() || "No reasoning provided.";
       const shouldDecompose = Boolean(parsed.shouldDecompose);
       const subtasks = normalizeSubtasks(parsed.subtasks);
+      const taskType = VALID_TASK_TYPES.includes(parsed.taskType) ? parsed.taskType : FALLBACK_TASK_TYPE;
 
       const triageResult = {
         level,
         roles,
         reasoning,
+        taskType,
         provider
       };
 
@@ -116,6 +121,7 @@ export class TriageRole extends BaseRole {
           level: "medium",
           roles: ["reviewer"],
           reasoning: "Failed to parse triage output, using safe defaults.",
+          taskType: FALLBACK_TASK_TYPE,
           provider,
           raw: result.output
         },

--- a/templates/roles/triage.md
+++ b/templates/roles/triage.md
@@ -8,6 +8,7 @@ Return a single valid JSON object and nothing else:
 ```json
 {
   "level": "trivial|simple|medium|complex",
+  "taskType": "sw|infra|doc|add-tests|refactor",
   "roles": ["planner", "researcher", "refactorer", "reviewer", "tester", "security"],
   "reasoning": "brief practical justification",
   "shouldDecompose": false,
@@ -15,7 +16,14 @@ Return a single valid JSON object and nothing else:
 }
 ```
 
-## Classification guidance
+## Task type classification
+- `sw`: writing or modifying business logic, features, APIs, components, services.
+- `infra`: CI/CD, Docker, deploy scripts, build configuration, environment setup.
+- `doc`: documentation, README, CHANGELOG, comments-only changes.
+- `add-tests`: adding tests to existing code without changing functionality.
+- `refactor`: restructuring code without changing external behavior.
+
+## Complexity classification
 - `trivial`: tiny, low-risk, straightforward. Usually no extra roles.
 - `simple`: limited scope with low risk. Usually reviewer only.
 - `medium`: moderate scope/risk. Reviewer required; optional planner/researcher.

--- a/tests/triage-role.test.js
+++ b/tests/triage-role.test.js
@@ -181,6 +181,148 @@ describe("TriageRole", () => {
     expect(call.prompt).toContain("decomposed");
   });
 
+  it("parses taskType from triage output (sw)", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "medium",
+        roles: ["reviewer", "tester"],
+        reasoning: "Business logic task.",
+        taskType: "sw"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Implement user registration");
+
+    expect(output.result.taskType).toBe("sw");
+  });
+
+  it("parses taskType 'infra' for CI/CD tasks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "simple",
+        roles: ["reviewer"],
+        reasoning: "Infrastructure config.",
+        taskType: "infra"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Update Docker config");
+
+    expect(output.result.taskType).toBe("infra");
+  });
+
+  it("parses taskType 'doc' for documentation tasks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "trivial",
+        roles: ["reviewer"],
+        reasoning: "Documentation only.",
+        taskType: "doc"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Update README");
+
+    expect(output.result.taskType).toBe("doc");
+  });
+
+  it("parses taskType 'add-tests' for testing tasks", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "medium",
+        roles: ["reviewer"],
+        reasoning: "Adding tests to legacy code.",
+        taskType: "add-tests"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Add tests for auth module");
+
+    expect(output.result.taskType).toBe("add-tests");
+  });
+
+  it("parses taskType 'refactor'", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "medium",
+        roles: ["reviewer", "refactorer"],
+        reasoning: "Pure refactor.",
+        taskType: "refactor"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Refactor config module");
+
+    expect(output.result.taskType).toBe("refactor");
+  });
+
+  it("defaults taskType to 'sw' when LLM returns invalid taskType", async () => {
+    mockRunTask.mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        level: "medium",
+        roles: ["reviewer"],
+        reasoning: "Some task.",
+        taskType: "invalid-type"
+      }),
+      usage: { tokens_in: 100, tokens_out: 80, cost_usd: 0.001 }
+    });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Some task");
+
+    expect(output.result.taskType).toBe("sw");
+  });
+
+  it("defaults taskType to 'sw' when LLM omits taskType", async () => {
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Fix typo");
+
+    // Default mock has no taskType field
+    expect(output.result.taskType).toBe("sw");
+  });
+
+  it("defaults taskType to 'sw' in fallback (unparseable output)", async () => {
+    mockRunTask.mockResolvedValue({ ok: true, output: "not-json" });
+
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    const output = await role.run("Task");
+
+    expect(output.result.taskType).toBe("sw");
+  });
+
+  it("includes taskType in triage prompt schema", async () => {
+    const role = new TriageRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run("Some task");
+
+    const call = mockRunTask.mock.calls[0][0];
+    expect(call.prompt).toContain("taskType");
+  });
+
   it("emits role:start and role:end events", async () => {
     const events = [];
     emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));


### PR DESCRIPTION
## Summary
- Extend triage output with `taskType` field (sw, infra, doc, add-tests, refactor)
- Update triage prompt schema, template, and role validation
- Unknown/missing taskType defaults to `sw` (conservative fallback)
- 9 new tests covering all taskTypes, invalid values, omissions, and fallbacks

## Test plan
- [x] 112 test files, 1275 tests passing
- [x] All 5 taskTypes correctly parsed
- [x] Invalid/missing taskType defaults to sw
- [x] Fallback defaults include taskType
- [x] Prompt includes taskType in JSON schema

KJC-TSK-0125