### PR TITLE
feat(pipeline): mandatory triage + policy-resolver integration

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -44,7 +44,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   let testerEnabled = Boolean(config.pipeline?.tester?.enabled);
   let securityEnabled = Boolean(config.pipeline?.security?.enabled);
   let reviewerEnabled = config.pipeline?.reviewer?.enabled !== false;
-  const triageEnabled = Boolean(config.pipeline?.triage?.enabled);
+  // Triage is always mandatory — it classifies taskType for policy resolution
+  const triageEnabled = true;
 
   // --- Dry-run: return summary without executing anything ---
   if (flags.dryRun) {
@@ -282,8 +283,9 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   if (flags.enableSecurity !== undefined) securityEnabled = Boolean(flags.enableSecurity);
 
   // --- Policy resolver: gate stages by taskType ---
+  // Priority: explicit flag > config > triage classification > default (sw)
   const resolvedPolicies = applyPolicies({
-    taskType: flags.taskType || config.taskType || null,
+    taskType: flags.taskType || config.taskType || stageResults.triage?.taskType || null,
     policies: config.policies,
   });
   session.resolved_policies = resolvedPolicies;

--- a/src/orchestrator/pre-loop-stages.js
+++ b/src/orchestrator/pre-loop-stages.js
@@ -56,12 +56,14 @@ export async function runTriageStage({ config, logger, emitter, eventBase, sessi
   const recommendedRoles = new Set(triageOutput.result?.roles || []);
   const roleOverrides = {};
   if (triageOutput.ok) {
-    roleOverrides.plannerEnabled = recommendedRoles.has("planner");
-    roleOverrides.researcherEnabled = recommendedRoles.has("researcher");
-    roleOverrides.refactorerEnabled = recommendedRoles.has("refactorer");
-    roleOverrides.reviewerEnabled = recommendedRoles.has("reviewer");
-    roleOverrides.testerEnabled = recommendedRoles.has("tester");
-    roleOverrides.securityEnabled = recommendedRoles.has("security");
+    // Triage can activate roles, but cannot deactivate roles explicitly enabled in pipeline config
+    const p = config.pipeline || {};
+    roleOverrides.plannerEnabled = recommendedRoles.has("planner") || Boolean(p.planner?.enabled);
+    roleOverrides.researcherEnabled = recommendedRoles.has("researcher") || Boolean(p.researcher?.enabled);
+    roleOverrides.refactorerEnabled = recommendedRoles.has("refactorer") || Boolean(p.refactorer?.enabled);
+    roleOverrides.reviewerEnabled = recommendedRoles.has("reviewer") || Boolean(p.reviewer?.enabled);
+    roleOverrides.testerEnabled = recommendedRoles.has("tester") || Boolean(p.tester?.enabled);
+    roleOverrides.securityEnabled = recommendedRoles.has("security") || Boolean(p.security?.enabled);
   }
 
   const shouldDecompose = triageOutput.result?.shouldDecompose || false;
@@ -72,6 +74,7 @@ export async function runTriageStage({ config, logger, emitter, eventBase, sessi
     level: triageOutput.result?.level || null,
     roles: Array.from(recommendedRoles),
     reasoning: triageOutput.result?.reasoning || null,
+    taskType: triageOutput.result?.taskType || "sw",
     shouldDecompose,
     subtasks
   };

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -119,7 +119,7 @@ describe("kj_run smoke", () => {
   it("autostarts SonarQube and scans before review when sonar service is unavailable", async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
-    const reviewerAgent = { reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
+    const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
     createAgent.mockImplementation((name) => {
       if (name === "codex") return coderAgent;
       return reviewerAgent;
@@ -188,7 +188,7 @@ describe("kj_run smoke", () => {
   it("autostarts SonarQube and auto-authenticates when token is not configured", async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
-    const reviewerAgent = { reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
+    const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
     createAgent.mockImplementation((name) => {
       if (name === "codex") return coderAgent;
       return reviewerAgent;
@@ -266,7 +266,7 @@ describe("kj_run smoke", () => {
   it("runs configured coverage command before scan when enabled", async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
-    const reviewerAgent = { reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
+    const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK }) };
     createAgent.mockImplementation((name) => {
       if (name === "codex") return coderAgent;
       return reviewerAgent;

--- a/tests/orchestrator-budget.test.js
+++ b/tests/orchestrator-budget.test.js
@@ -112,6 +112,7 @@ describe("orchestrator budget integration", () => {
         };
       }
       return {
+        runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
         reviewTask: vi.fn().mockResolvedValue({
           ok: true,
           output: REVIEW_APPROVED,
@@ -217,6 +218,7 @@ describe("orchestrator budget integration", () => {
         };
       }
       return {
+        runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
         reviewTask: vi.fn().mockResolvedValue({
           ok: true,
           output: REVIEW_APPROVED

--- a/tests/orchestrator-checkpoint.test.js
+++ b/tests/orchestrator-checkpoint.test.js
@@ -45,7 +45,7 @@ vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
 }));
 
 vi.mock("../src/orchestrator/pre-loop-stages.js", () => ({
-  runTriageStage: vi.fn(),
+  runTriageStage: vi.fn().mockResolvedValue({ roleOverrides: {}, stageResult: { ok: true } }),
   runResearcherStage: vi.fn(),
   runPlannerStage: vi.fn()
 }));

--- a/tests/orchestrator-events.test.js
+++ b/tests/orchestrator-events.test.js
@@ -196,6 +196,8 @@ describe("orchestrator events", () => {
     expect(result.approved).toBe(true);
     expect(events).toEqual([
       "session:start",
+      "triage:start",
+      "triage:end",
       "policies:resolved",
       "iteration:start",
       "coder:start",
@@ -251,6 +253,7 @@ describe("orchestrator events", () => {
       runTask: vi.fn().mockResolvedValue({ ok: true, output: "" })
     };
     const reviewerAgent = {
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
       reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_OK })
     };
     createAgent.mockImplementation((name) => {
@@ -357,14 +360,15 @@ describe("orchestrator events", () => {
 
     await runFlow({ task: "test", config, logger, flags: {}, emitter });
 
-    const outputEvents = events.filter((e) => e.type === "agent:output");
-    expect(outputEvents.length).toBe(3);
-    expect(outputEvents[0].message).toBe("coder line 1");
-    expect(outputEvents[0].detail.agent).toBe("codex");
-    expect(outputEvents[0].stage).toBe("coder");
-    expect(outputEvents[2].message).toBe("reviewer line 1");
-    expect(outputEvents[2].detail.agent).toBe("claude");
-    expect(outputEvents[2].stage).toBe("reviewer");
+    const coderOutputEvents = events.filter((e) => e.type === "agent:output" && e.stage === "coder");
+    const reviewerOutputEvents = events.filter((e) => e.type === "agent:output" && e.stage === "reviewer");
+    expect(coderOutputEvents.length).toBe(2);
+    expect(coderOutputEvents[0].message).toBe("coder line 1");
+    expect(coderOutputEvents[0].detail.agent).toBe("codex");
+    expect(reviewerOutputEvents.length).toBe(1);
+    expect(reviewerOutputEvents[0].message).toBe("reviewer line 1");
+    expect(reviewerOutputEvents[0].detail.agent).toBe("claude");
+    expect(reviewerOutputEvents[0].stage).toBe("reviewer");
   });
 
   it("escalates to Solomon on TDD fail-fast and continues if Solomon resolves", async () => {
@@ -531,6 +535,8 @@ describe("orchestrator events", () => {
     expect(result.approved).toBe(true);
     expect(events).toEqual([
       "session:start",
+      "triage:start",
+      "triage:end",
       "policies:resolved",
       "planner:start",
       "planner:end",

--- a/tests/orchestrator-pg-integration.test.js
+++ b/tests/orchestrator-pg-integration.test.js
@@ -45,7 +45,7 @@ vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
 }));
 
 vi.mock("../src/orchestrator/pre-loop-stages.js", () => ({
-  runTriageStage: vi.fn(),
+  runTriageStage: vi.fn().mockResolvedValue({ roleOverrides: {}, stageResult: { ok: true } }),
   runResearcherStage: vi.fn(),
   runPlannerStage: vi.fn()
 }));

--- a/tests/orchestrator-repeat-detection.test.js
+++ b/tests/orchestrator-repeat-detection.test.js
@@ -154,7 +154,7 @@ describe("orchestrator repeat detection", () => {
   it("stalls when SonarQube issues repeat consecutively", async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
-    const reviewerAgent = { reviewTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
+    const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
     createAgent.mockImplementation((name) => (name === "codex" ? coderAgent : reviewerAgent));
 
     const { runSonarScan } = await import("../src/sonar/scanner.js");
@@ -207,7 +207,7 @@ describe("orchestrator repeat detection", () => {
   it("stalls when reviewer blocking issues repeat consecutively", async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
-    const reviewerAgent = { reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_BLOCKING }) };
+    const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_BLOCKING }) };
     createAgent.mockImplementation((name) => (name === "codex" ? coderAgent : reviewerAgent));
 
     const logger = {

--- a/tests/orchestrator-triage.test.js
+++ b/tests/orchestrator-triage.test.js
@@ -151,12 +151,12 @@ describe("orchestrator triage pipeline", () => {
     },
     pipeline: {
       triage: { enabled: true },
-      planner: { enabled: true },
-      refactorer: { enabled: true },
-      researcher: { enabled: true },
-      tester: { enabled: true },
-      security: { enabled: true },
-      reviewer: { enabled: true }
+      planner: { enabled: false },
+      refactorer: { enabled: false },
+      researcher: { enabled: false },
+      tester: { enabled: false },
+      security: { enabled: false },
+      reviewer: { enabled: false }
     },
     review_mode: "standard",
     max_iterations: 1,

--- a/tests/triage-stage.test.js
+++ b/tests/triage-stage.test.js
@@ -164,6 +164,55 @@ describe("runTriageStage", () => {
     expect(result.roleOverrides.securityEnabled).toBe(true);
   });
 
+  it("includes taskType in stage result", async () => {
+    triageRunMock.mockResolvedValue({
+      ok: true,
+      result: {
+        level: "simple",
+        roles: ["reviewer"],
+        reasoning: "Infra config.",
+        taskType: "infra"
+      },
+      usage: { tokens_in: 100, tokens_out: 80 }
+    });
+
+    const result = await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    expect(result.stageResult.taskType).toBe("infra");
+  });
+
+  it("defaults taskType to 'sw' when triage omits it", async () => {
+    // Default mock has no taskType
+    const result = await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    expect(result.stageResult.taskType).toBe("sw");
+  });
+
+  it("defaults taskType to 'sw' when triage fails", async () => {
+    triageRunMock.mockResolvedValue({
+      ok: false,
+      result: { error: "Agent failed" },
+      summary: "Triage failed",
+      usage: { tokens_in: 50, tokens_out: 20 }
+    });
+
+    const result = await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    expect(result.stageResult.taskType).toBe("sw");
+  });
+
   it("handles shouldDecompose in stage result", async () => {
     triageRunMock.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- Make triage mandatory: always runs to classify taskType for policy-driven pipeline gating
- Triage can activate roles but cannot deactivate roles explicitly enabled in pipeline config
- taskType from triage feeds into policy-resolver when no explicit `--taskType` flag is provided
- Priority chain: `flags.taskType` > `config.taskType` > `triage.taskType` > default (`sw`)
- Triage stage now includes `taskType` in its result

## Test plan
- [x] 112 test files, 1279 tests passing
- [x] 3 new triage-stage tests for taskType in result
- [x] Updated 8 test files for mandatory triage compatibility
- [x] Triage role overrides respect pipeline config (no unwanted deactivation)

KJC-TSK-0127