### PR TITLE
feat(discover): DiscoverRole base + gaps mode (KJC-TSK-0117)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,8 @@ const DEFAULTS = {
     researcher: { provider: null, model: null },
     tester: { provider: null, model: null },
     security: { provider: null, model: null },
-    triage: { provider: null, model: null }
+    triage: { provider: null, model: null },
+    discover: { provider: null, model: null }
   },
   pipeline: {
     planner: { enabled: false },
@@ -25,7 +26,8 @@ const DEFAULTS = {
     researcher: { enabled: false },
     tester: { enabled: true },
     security: { enabled: true },
-    triage: { enabled: true }
+    triage: { enabled: true },
+    discover: { enabled: false }
   },
   review_mode: "standard",
   max_iterations: 5,
@@ -245,6 +247,9 @@ export function applyRunOverrides(config, flags) {
   if (flags.tester) out.roles.tester.provider = flags.tester;
   if (flags.security) out.roles.security.provider = flags.security;
   if (flags.triage) out.roles.triage.provider = flags.triage;
+  if (flags.discover) out.roles.discover.provider = flags.discover;
+  if (flags.discoverModel) out.roles.discover.model = String(flags.discoverModel);
+  if (flags.enableDiscover !== undefined) out.pipeline.discover.enabled = Boolean(flags.enableDiscover);
   if (flags.plannerModel) out.roles.planner.model = String(flags.plannerModel);
   if (flags.coderModel) {
     out.roles.coder.model = String(flags.coderModel);
@@ -318,14 +323,14 @@ export function resolveRole(config, role) {
   let provider = roleConfig.provider ?? null;
   if (!provider && role === "coder") provider = legacyCoder;
   if (!provider && role === "reviewer") provider = legacyReviewer;
-  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "triage")) {
+  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "triage" || role === "discover")) {
     provider = roles.coder?.provider || legacyCoder;
   }
 
   let model = roleConfig.model ?? null;
   if (!model && role === "coder") model = config?.coder_options?.model ?? null;
   if (!model && role === "reviewer") model = config?.reviewer_options?.model ?? null;
-  if (!model && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "triage")) {
+  if (!model && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "triage" || role === "discover")) {
     model = config?.coder_options?.model ?? null;
   }
 

--- a/src/prompts/discover.js
+++ b/src/prompts/discover.js
@@ -1,0 +1,81 @@
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on discovering gaps in the task specification."
+].join(" ");
+
+export const DISCOVER_MODES = ["gaps"];
+
+const VALID_VERDICTS = ["ready", "needs_validation"];
+const VALID_SEVERITIES = ["critical", "major", "minor"];
+
+export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context = null }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are a task discovery agent for Karajan Code, a multi-agent coding orchestrator.",
+    "Analyze the following task and identify gaps, ambiguities, missing information, and implicit assumptions."
+  );
+
+  sections.push(
+    "## Gap Detection Guidelines",
+    [
+      "- Look for missing acceptance criteria or requirements",
+      "- Identify implicit assumptions that need explicit confirmation",
+      "- Find ambiguities where multiple interpretations exist",
+      "- Check for contradictions between different parts of the spec",
+      "- Consider edge cases and error scenarios not addressed",
+      "- Classify each gap by severity: critical (blocks implementation), major (could cause rework), minor (reasonable default exists)"
+    ].join("\n")
+  );
+
+  sections.push(
+    "Return a single valid JSON object and nothing else.",
+    'JSON schema: {"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}],"summary":string}'
+  );
+
+  if (context) {
+    sections.push(`## Context\n${context}`);
+  }
+
+  sections.push(`## Task\n${task}`);
+
+  return sections.join("\n\n");
+}
+
+export function parseDiscoverOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return null;
+  }
+
+  const verdict = VALID_VERDICTS.includes(parsed.verdict) ? parsed.verdict : "ready";
+
+  const rawGaps = Array.isArray(parsed.gaps) ? parsed.gaps : [];
+  const gaps = rawGaps
+    .filter((g) => g && g.id && g.description && g.suggestedQuestion)
+    .map((g) => ({
+      id: g.id,
+      description: g.description,
+      severity: VALID_SEVERITIES.includes(String(g.severity).toLowerCase())
+        ? String(g.severity).toLowerCase()
+        : "major",
+      suggestedQuestion: g.suggestedQuestion
+    }));
+
+  return {
+    verdict,
+    gaps,
+    summary: parsed.summary || ""
+  };
+}

--- a/src/roles/discover-role.js
+++ b/src/roles/discover-role.js
@@ -1,0 +1,97 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { buildDiscoverPrompt, parseDiscoverOutput } from "../prompts/discover.js";
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.discover?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function buildSummary(parsed) {
+  const count = parsed.gaps?.length || 0;
+  if (count === 0) return "Discovery complete: task is ready";
+  return `Discovery complete: ${count} gap${count !== 1 ? "s" : ""} found (verdict: ${parsed.verdict})`;
+}
+
+export class DiscoverRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "discover", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const task = typeof input === "string"
+      ? input
+      : input?.task || this.context?.task || "";
+    const onOutput = typeof input === "string" ? null : input?.onOutput || null;
+    const mode = (typeof input === "object" ? input?.mode : null) || "gaps";
+    const context = typeof input === "object" ? input?.context || null : null;
+
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildDiscoverPrompt({ task, instructions: this.instructions, mode, context });
+    const runArgs = { prompt, role: "discover" };
+    if (onOutput) runArgs.onOutput = onOutput;
+    const result = await agent.runTask(runArgs);
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: {
+          error: result.error || result.output || "Discovery failed",
+          provider,
+          mode
+        },
+        summary: `Discovery failed: ${result.error || "unknown error"}`,
+        usage: result.usage
+      };
+    }
+
+    try {
+      const parsed = parseDiscoverOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: true,
+          result: {
+            verdict: "ready",
+            gaps: [],
+            mode,
+            raw: result.output,
+            provider
+          },
+          summary: "Discovery complete (unstructured output)",
+          usage: result.usage
+        };
+      }
+
+      return {
+        ok: true,
+        result: {
+          verdict: parsed.verdict,
+          gaps: parsed.gaps,
+          mode,
+          provider
+        },
+        summary: buildSummary(parsed),
+        usage: result.usage
+      };
+    } catch {
+      return {
+        ok: true,
+        result: {
+          verdict: "ready",
+          gaps: [],
+          mode,
+          raw: result.output,
+          provider
+        },
+        summary: "Discovery complete (unstructured output)",
+        usage: result.usage
+      };
+    }
+  }
+}

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -10,3 +10,4 @@ export { TriageRole } from "./triage-role.js";
 export { TesterRole } from "./tester-role.js";
 export { SecurityRole } from "./security-role.js";
 export { SolomonRole } from "./solomon-role.js";
+export { DiscoverRole } from "./discover-role.js";

--- a/templates/roles/discover.md
+++ b/templates/roles/discover.md
@@ -1,0 +1,45 @@
+# Discover Role
+
+You are the **Discover** role in a multi-role AI pipeline.
+
+Your job is to analyze a task description, ticket, or brief and identify **gaps** — missing information, implicit assumptions, ambiguities, and contradictions that could cause unnecessary iterations during implementation.
+
+## Responsibilities
+
+- Detect missing requirements or acceptance criteria
+- Identify implicit assumptions that need explicit confirmation
+- Find ambiguities where multiple interpretations are possible
+- Spot contradictions between different parts of the specification
+- Suggest specific questions that would resolve each gap
+
+## Severity Classification
+
+- **critical**: Blocks implementation entirely — cannot proceed without this information
+- **major**: Could lead to significant rework if assumed incorrectly
+- **minor**: Nice to clarify but a reasonable default exists
+
+## Verdict
+
+- **ready**: The task is well-defined and can proceed to implementation without further clarification
+- **needs_validation**: One or more gaps were found that should be resolved before implementation
+
+## Output format
+
+Return a single valid JSON object and nothing else.
+
+```json
+{
+  "verdict": "ready|needs_validation",
+  "gaps": [
+    {
+      "id": "gap-1",
+      "description": "What information is missing or ambiguous",
+      "severity": "critical|major|minor",
+      "suggestedQuestion": "A specific question to resolve this gap"
+    }
+  ],
+  "summary": "Brief human-readable summary of findings"
+}
+```
+
+If the task is well-defined with no gaps, return `verdict: "ready"` with an empty `gaps` array.

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DiscoverRole } from "../src/roles/discover-role.js";
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: {
+      discover: { provider: "claude", model: null },
+      coder: { provider: "claude", model: null },
+      ...overrides.roles
+    },
+    pipeline: {
+      discover: { enabled: true },
+      ...overrides.pipeline
+    }
+  };
+}
+
+function makeMockAgent(output) {
+  return {
+    runTask: vi.fn().mockResolvedValue(output)
+  };
+}
+
+describe("DiscoverRole", () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = makeLogger();
+  });
+
+  it("extends BaseRole with name 'discover'", () => {
+    const role = new DiscoverRole({ config: makeConfig(), logger });
+    expect(role.name).toBe("discover");
+  });
+
+  describe("execute() — gaps mode", () => {
+    it("returns verdict=ready when no gaps found", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        summary: "Task is well defined"
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Add login page" });
+      const result = await role.run({ task: "Add login page" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.verdict).toBe("ready");
+      expect(result.result.gaps).toEqual([]);
+    });
+
+    it("returns verdict=needs_validation with gaps when found", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [
+          { id: "gap-1", description: "Missing auth spec", severity: "critical", suggestedQuestion: "Which auth provider?" },
+          { id: "gap-2", description: "No error handling spec", severity: "minor", suggestedQuestion: "What on failure?" }
+        ],
+        summary: "2 gaps found"
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Implement auth system" });
+      const result = await role.run({ task: "Implement auth system" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.verdict).toBe("needs_validation");
+      expect(result.result.gaps).toHaveLength(2);
+      expect(result.result.gaps[0].id).toBe("gap-1");
+      expect(result.result.gaps[0].severity).toBe("critical");
+      expect(result.result.gaps[1].severity).toBe("minor");
+    });
+
+    it("handles agent failure gracefully", async () => {
+      const mockAgent = makeMockAgent({ ok: false, error: "Agent crashed" });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.ok).toBe(false);
+      expect(result.result.error).toContain("crashed");
+    });
+
+    it("handles unstructured (non-JSON) output gracefully", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: "I found some issues but no JSON" });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.verdict).toBe("ready");
+      expect(result.result.gaps).toEqual([]);
+      expect(result.result.raw).toBeDefined();
+    });
+
+    it("handles malformed JSON gracefully", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: "{not valid json at all}" });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.verdict).toBe("ready");
+      expect(result.result.gaps).toEqual([]);
+      expect(result.result.raw).toBeDefined();
+    });
+
+    it("passes onOutput callback to agent", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+      const onOutput = vi.fn();
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      await role.run({ task: "x", onOutput });
+
+      const runArgs = mockAgent.runTask.mock.calls[0][0];
+      expect(runArgs.onOutput).toBe(onOutput);
+    });
+
+    it("uses discover provider from config", async () => {
+      const config = makeConfig({ roles: { discover: { provider: "gemini", model: null }, coder: { provider: "claude", model: null } } });
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = vi.fn().mockReturnValue(mockAgent);
+
+      const role = new DiscoverRole({ config, logger, createAgentFn });
+      await role.init({ task: "x" });
+      await role.run({ task: "x" });
+
+      expect(createAgentFn).toHaveBeenCalledWith("gemini", config, logger);
+    });
+
+    it("falls back to coder provider if discover provider not set", async () => {
+      const config = makeConfig({ roles: { discover: { provider: null, model: null }, coder: { provider: "aider", model: null } } });
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = vi.fn().mockReturnValue(mockAgent);
+
+      const role = new DiscoverRole({ config, logger, createAgentFn });
+      await role.init({ task: "x" });
+      await role.run({ task: "x" });
+
+      expect(createAgentFn).toHaveBeenCalledWith("aider", config, logger);
+    });
+
+    it("includes mode in result", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "gaps" });
+
+      expect(result.result.mode).toBe("gaps");
+    });
+
+    it("defaults mode to gaps", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.result.mode).toBe("gaps");
+    });
+
+    it("includes provider in result", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.result.provider).toBe("claude");
+    });
+
+    it("builds summary with gap count", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [
+          { id: "g1", description: "Missing spec", severity: "critical", suggestedQuestion: "q" },
+          { id: "g2", description: "Unclear scope", severity: "major", suggestedQuestion: "q" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.summary).toContain("2");
+      expect(result.summary).toContain("gap");
+    });
+
+    it("accepts task as string input", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "test task" });
+      const result = await role.run("test task");
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("uses context task as fallback", async () => {
+      const mockAgent = makeMockAgent({ ok: true, output: JSON.stringify({ verdict: "ready", gaps: [] }) });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "context task" });
+      const result = await role.run({});
+
+      expect(result.ok).toBe(true);
+      const prompt = mockAgent.runTask.mock.calls[0][0].prompt;
+      expect(prompt).toContain("context task");
+    });
+
+    it("forwards usage from agent result", async () => {
+      const mockAgent = makeMockAgent({
+        ok: true,
+        output: JSON.stringify({ verdict: "ready", gaps: [] }),
+        usage: { input_tokens: 100, output_tokens: 50 }
+      });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x" });
+
+      expect(result.usage).toEqual({ input_tokens: 100, output_tokens: 50 });
+    });
+  });
+});

--- a/tests/prompt-discover.test.js
+++ b/tests/prompt-discover.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { buildDiscoverPrompt, parseDiscoverOutput, DISCOVER_MODES } from "../src/prompts/discover.js";
+
+describe("buildDiscoverPrompt", () => {
+  it("returns a string containing the task", () => {
+    const prompt = buildDiscoverPrompt({ task: "Add login page" });
+    expect(prompt).toContain("Add login page");
+  });
+
+  it("includes sub-agent preamble", () => {
+    const prompt = buildDiscoverPrompt({ task: "x" });
+    expect(prompt).toContain("Karajan sub-agent");
+    expect(prompt).toContain("Do NOT use any MCP tools");
+  });
+
+  it("includes instructions when provided", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", instructions: "Custom discover instructions" });
+    expect(prompt).toContain("Custom discover instructions");
+  });
+
+  it("omits instructions section when null", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", instructions: null });
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it("includes JSON schema for gaps mode (default)", () => {
+    const prompt = buildDiscoverPrompt({ task: "x" });
+    expect(prompt).toContain("verdict");
+    expect(prompt).toContain("gaps");
+    expect(prompt).toContain("severity");
+  });
+
+  it("includes context when provided", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", context: "Some research context" });
+    expect(prompt).toContain("Some research context");
+  });
+
+  it("defaults to gaps mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x" });
+    expect(prompt).toContain("gaps");
+  });
+
+  it("accepts explicit mode parameter", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "gaps" });
+    expect(prompt).toContain("gaps");
+  });
+});
+
+describe("DISCOVER_MODES", () => {
+  it("exports gaps as a valid mode", () => {
+    expect(DISCOVER_MODES).toContain("gaps");
+  });
+});
+
+describe("parseDiscoverOutput", () => {
+  it("parses valid JSON with gaps", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [
+        { id: "gap-1", description: "Missing auth details", severity: "critical", suggestedQuestion: "How should auth work?" }
+      ],
+      summary: "1 gap found"
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed.verdict).toBe("needs_validation");
+    expect(parsed.gaps).toHaveLength(1);
+    expect(parsed.gaps[0].id).toBe("gap-1");
+    expect(parsed.gaps[0].severity).toBe("critical");
+  });
+
+  it("parses JSON embedded in markdown", () => {
+    const raw = `Here is my analysis:\n\`\`\`json\n${JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      summary: "Well defined"
+    })}\n\`\`\`\nDone.`;
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed.verdict).toBe("ready");
+    expect(parsed.gaps).toEqual([]);
+  });
+
+  it("returns null for non-JSON output", () => {
+    expect(parseDiscoverOutput("no json here")).toBeNull();
+  });
+
+  it("returns null for empty/null input", () => {
+    expect(parseDiscoverOutput("")).toBeNull();
+    expect(parseDiscoverOutput(null)).toBeNull();
+    expect(parseDiscoverOutput(undefined)).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseDiscoverOutput("{invalid json}")).toBeNull();
+  });
+
+  it("normalizes verdict to valid values", () => {
+    const raw = JSON.stringify({ verdict: "ready", gaps: [] });
+    const parsed = parseDiscoverOutput(raw);
+    expect(["ready", "needs_validation"]).toContain(parsed.verdict);
+  });
+
+  it("normalizes severity to valid values", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [{ id: "g1", description: "x", severity: "CRITICAL", suggestedQuestion: "q" }]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(["critical", "major", "minor"]).toContain(parsed.gaps[0].severity);
+  });
+
+  it("defaults severity to major for unknown values", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [{ id: "g1", description: "x", severity: "unknown_severity", suggestedQuestion: "q" }]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.gaps[0].severity).toBe("major");
+  });
+
+  it("filters out gaps missing required fields", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [
+        { id: "g1", description: "valid", severity: "major", suggestedQuestion: "q" },
+        { id: "g2" },
+        { description: "no id" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.gaps).toHaveLength(1);
+    expect(parsed.gaps[0].id).toBe("g1");
+  });
+});


### PR DESCRIPTION
## Summary
- New `DiscoverRole` extending `BaseRole` for pre-execution task validation
- Implements **gaps mode**: detects missing requirements, ambiguities, implicit assumptions, and contradictions in task specifications
- Returns `verdict: "ready"` or `verdict: "needs_validation"` with structured gap list (id, description, severity, suggestedQuestion)
- Prompt builder with JSON schema, parser with severity/verdict normalization, gap filtering
- Config defaults for `roles.discover` and `pipeline.discover`, provider resolution with coder fallback

## Test plan
- [x] 18 unit tests for prompt builder and parser (buildDiscoverPrompt, parseDiscoverOutput, DISCOVER_MODES)
- [x] 16 unit tests for DiscoverRole (happy path, agent failure, unstructured output, malformed JSON, provider resolution, mode/usage forwarding)
- [x] Full suite: 1313 tests passing across 114 files