### PR TITLE
feat(discover): momtest mode for Mom Test questions (KJC-TSK-0119)

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -692,7 +692,7 @@ export async function handleToolCall(name, args, server, extra) {
     if (!a.task) {
       return failPayload("Missing required field: task");
     }
-    const validModes = ["gaps"];
+    const validModes = ["gaps", "momtest"];
     if (a.mode && !validModes.includes(a.mode)) {
       return failPayload(`Invalid mode "${a.mode}". Valid values: ${validModes.join(", ")}`);
     }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -232,7 +232,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to analyze for gaps" },
-        mode: { type: "string", enum: ["gaps"], description: "Discovery mode (default: gaps)" },
+        mode: { type: "string", enum: ["gaps", "momtest"], description: "Discovery mode: gaps (default) or momtest (Mom Test questions)" },
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
         pgProject: { type: "string", description: "Planning Game project ID. Required when pgTask is used." },

--- a/src/prompts/discover.js
+++ b/src/prompts/discover.js
@@ -4,7 +4,7 @@ const SUBAGENT_PREAMBLE = [
   "Do NOT use any MCP tools. Focus only on discovering gaps in the task specification."
 ].join(" ");
 
-export const DISCOVER_MODES = ["gaps"];
+export const DISCOVER_MODES = ["gaps", "momtest"];
 
 const VALID_VERDICTS = ["ready", "needs_validation"];
 const VALID_SEVERITIES = ["critical", "major", "minor"];
@@ -33,9 +33,37 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
     ].join("\n")
   );
 
+  if (mode === "momtest") {
+    sections.push(
+      "## Mom Test Rules",
+      [
+        "For each gap, generate questions that follow The Mom Test principles:",
+        "- ALWAYS ask about past behavior and real experiences, never hypothetical scenarios",
+        "- NEVER ask 'Would you...?', 'Do you think...?', 'Would it be useful if...?'",
+        "- ALWAYS ask 'When was the last time...?', 'How do you currently...?', 'What happened when...?'",
+        "- Ask about specifics, not generalities",
+        "- Each question must have a targetRole (who to ask) and rationale (why this matters)",
+        "",
+        "Examples of BAD questions (hypothetical/opinion):",
+        "  - 'Would you use this feature?' -> opinion, not data",
+        "  - 'Do you think users need this?' -> speculation",
+        "",
+        "Examples of GOOD questions (past behavior):",
+        "  - 'When was the last time you had to do X manually?' -> real experience",
+        "  - 'How are you currently handling Y?' -> current behavior",
+        "  - 'What happened the last time Z failed?' -> real consequence"
+      ].join("\n")
+    );
+  }
+
+  const baseSchema = '{"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}]';
+  const momtestSchema = mode === "momtest"
+    ? ',"momTestQuestions":[{"gapId":string,"question":string,"targetRole":string,"rationale":string}]'
+    : "";
+
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    'JSON schema: {"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}],"summary":string}'
+    `JSON schema: ${baseSchema}${momtestSchema},"summary":string}`
   );
 
   if (context) {
@@ -73,9 +101,20 @@ export function parseDiscoverOutput(raw) {
       suggestedQuestion: g.suggestedQuestion
     }));
 
+  const rawQuestions = Array.isArray(parsed.momTestQuestions) ? parsed.momTestQuestions : [];
+  const momTestQuestions = rawQuestions
+    .filter((q) => q && q.gapId && q.question && q.targetRole && q.rationale)
+    .map((q) => ({
+      gapId: q.gapId,
+      question: q.question,
+      targetRole: q.targetRole,
+      rationale: q.rationale
+    }));
+
   return {
     verdict,
     gaps,
+    momTestQuestions,
     summary: parsed.summary || ""
   };
 }

--- a/src/roles/discover-role.js
+++ b/src/roles/discover-role.js
@@ -10,10 +10,15 @@ function resolveProvider(config) {
   );
 }
 
-function buildSummary(parsed) {
-  const count = parsed.gaps?.length || 0;
-  if (count === 0) return "Discovery complete: task is ready";
-  return `Discovery complete: ${count} gap${count !== 1 ? "s" : ""} found (verdict: ${parsed.verdict})`;
+function buildSummary(parsed, mode) {
+  const gapCount = parsed.gaps?.length || 0;
+  if (gapCount === 0) return "Discovery complete: task is ready";
+  const parts = [`${gapCount} gap${gapCount !== 1 ? "s" : ""} found`];
+  if (mode === "momtest") {
+    const qCount = parsed.momTestQuestions?.length || 0;
+    if (qCount > 0) parts.push(`${qCount} Mom Test question${qCount !== 1 ? "s" : ""}`);
+  }
+  return `Discovery complete: ${parts.join(", ")} (verdict: ${parsed.verdict})`;
 }
 
 export class DiscoverRole extends BaseRole {
@@ -68,15 +73,20 @@ export class DiscoverRole extends BaseRole {
         };
       }
 
+      const resultObj = {
+        verdict: parsed.verdict,
+        gaps: parsed.gaps,
+        mode,
+        provider
+      };
+      if (mode === "momtest") {
+        resultObj.momTestQuestions = parsed.momTestQuestions || [];
+      }
+
       return {
         ok: true,
-        result: {
-          verdict: parsed.verdict,
-          gaps: parsed.gaps,
-          mode,
-          provider
-        },
-        summary: buildSummary(parsed),
+        result: resultObj,
+        summary: buildSummary(parsed, mode),
         usage: result.usage
       };
     } catch {

--- a/templates/roles/discover.md
+++ b/templates/roles/discover.md
@@ -43,3 +43,34 @@ Return a single valid JSON object and nothing else.
 ```
 
 If the task is well-defined with no gaps, return `verdict: "ready"` with an empty `gaps` array.
+
+## Mom Test Mode
+
+When running in **momtest** mode, for each gap generate questions following The Mom Test principles:
+
+- Ask about **past behavior** and real experiences, never hypothetical scenarios
+- Ask about **specifics**, not generalities
+- Focus on what people **actually do**, not what they say they would do
+
+### Good vs Bad Questions
+
+| Bad (hypothetical/opinion) | Good (past behavior) |
+|---|---|
+| "Would you use a notification system?" | "When was the last time you missed an important update?" |
+| "Do you think users need dark mode?" | "How many support tickets mentioned readability issues?" |
+| "Would it be useful to have X?" | "How are you currently handling X?" |
+
+### Mom Test Output Schema (additional fields)
+
+```json
+{
+  "momTestQuestions": [
+    {
+      "gapId": "gap-1",
+      "question": "Past-behavior question to validate this gap",
+      "targetRole": "Who should answer (end-user, developer, PM, etc.)",
+      "rationale": "Why this question matters for the gap"
+    }
+  ]
+}
+```

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -233,6 +233,60 @@ describe("DiscoverRole", () => {
       expect(prompt).toContain("context task");
     });
 
+    it("returns momTestQuestions in momtest mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "Missing auth", severity: "critical", suggestedQuestion: "q" }],
+        momTestQuestions: [
+          { gapId: "g1", question: "When was the last time you had to log in?", targetRole: "end-user", rationale: "Validates auth need" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Add auth" });
+      const result = await role.run({ task: "Add auth", mode: "momtest" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.mode).toBe("momtest");
+      expect(result.result.momTestQuestions).toHaveLength(1);
+      expect(result.result.momTestQuestions[0].gapId).toBe("g1");
+      expect(result.result.momTestQuestions[0].targetRole).toBe("end-user");
+    });
+
+    it("returns empty momTestQuestions when verdict is ready in momtest mode", async () => {
+      const agentOutput = JSON.stringify({ verdict: "ready", gaps: [] });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "momtest" });
+
+      expect(result.result.momTestQuestions).toEqual([]);
+    });
+
+    it("includes momTestQuestions count in summary for momtest mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "x", severity: "major", suggestedQuestion: "q" }],
+        momTestQuestions: [
+          { gapId: "g1", question: "q1", targetRole: "dev", rationale: "r" },
+          { gapId: "g1", question: "q2", targetRole: "pm", rationale: "r" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "momtest" });
+
+      expect(result.summary).toContain("2");
+      expect(result.summary).toMatch(/question/i);
+    });
+
     it("forwards usage from agent result", async () => {
       const mockAgent = makeMockAgent({
         ok: true,

--- a/tests/prompt-discover.test.js
+++ b/tests/prompt-discover.test.js
@@ -47,9 +47,32 @@ describe("buildDiscoverPrompt", () => {
   });
 });
 
+describe("buildDiscoverPrompt — momtest mode", () => {
+  it("includes Mom Test rules when mode is momtest", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "momtest" });
+    expect(prompt).toContain("Mom Test");
+    expect(prompt).toContain("past behavior");
+  });
+
+  it("includes momTestQuestions in JSON schema for momtest mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "momtest" });
+    expect(prompt).toContain("momTestQuestions");
+    expect(prompt).toContain("targetRole");
+  });
+
+  it("does not include Mom Test rules in gaps mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "gaps" });
+    expect(prompt).not.toContain("Mom Test");
+  });
+});
+
 describe("DISCOVER_MODES", () => {
   it("exports gaps as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("gaps");
+  });
+
+  it("exports momtest as a valid mode", () => {
+    expect(DISCOVER_MODES).toContain("momtest");
   });
 });
 
@@ -132,5 +155,39 @@ describe("parseDiscoverOutput", () => {
     const parsed = parseDiscoverOutput(raw);
     expect(parsed.gaps).toHaveLength(1);
     expect(parsed.gaps[0].id).toBe("g1");
+  });
+
+  it("parses momTestQuestions from output", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [{ id: "g1", description: "Missing auth", severity: "critical", suggestedQuestion: "q" }],
+      momTestQuestions: [
+        { gapId: "g1", question: "When was the last time you logged in manually?", targetRole: "end-user", rationale: "Validates if auth is actually needed" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.momTestQuestions).toHaveLength(1);
+    expect(parsed.momTestQuestions[0].gapId).toBe("g1");
+    expect(parsed.momTestQuestions[0].targetRole).toBe("end-user");
+  });
+
+  it("returns empty momTestQuestions when not present", () => {
+    const raw = JSON.stringify({ verdict: "ready", gaps: [] });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.momTestQuestions).toEqual([]);
+  });
+
+  it("filters momTestQuestions missing required fields", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [{ id: "g1", description: "x", severity: "major", suggestedQuestion: "q" }],
+      momTestQuestions: [
+        { gapId: "g1", question: "Valid question?", targetRole: "dev", rationale: "reason" },
+        { gapId: "g1" },
+        { question: "No gapId" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.momTestQuestions).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Extends DiscoverRole with **momtest** mode that generates past-behavior questions (The Mom Test) for each detected gap
- Questions always ask about real experiences, never hypothetical scenarios
- Each question includes `gapId`, `question`, `targetRole`, and `rationale`
- Parser validates and filters momTestQuestions with required field checks
- Template updated with good/bad question examples and Mom Test rules

## Test plan
- [x] 10 new tests: prompt builder momtest sections, parser momTestQuestions, role momtest mode, summary
- [x] Full suite: 1330 tests passing across 115 files