### PR TITLE
feat(discover): wendel mode for adoption checklist (KJC-TSK-0120)

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -692,7 +692,7 @@ export async function handleToolCall(name, args, server, extra) {
     if (!a.task) {
       return failPayload("Missing required field: task");
     }
-    const validModes = ["gaps", "momtest"];
+    const validModes = ["gaps", "momtest", "wendel"];
     if (a.mode && !validModes.includes(a.mode)) {
       return failPayload(`Invalid mode "${a.mode}". Valid values: ${validModes.join(", ")}`);
     }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -232,7 +232,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to analyze for gaps" },
-        mode: { type: "string", enum: ["gaps", "momtest"], description: "Discovery mode: gaps (default) or momtest (Mom Test questions)" },
+        mode: { type: "string", enum: ["gaps", "momtest", "wendel"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), or wendel (behavior change checklist)" },
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
         pgProject: { type: "string", description: "Planning Game project ID. Required when pgTask is used." },

--- a/src/prompts/discover.js
+++ b/src/prompts/discover.js
@@ -4,10 +4,11 @@ const SUBAGENT_PREAMBLE = [
   "Do NOT use any MCP tools. Focus only on discovering gaps in the task specification."
 ].join(" ");
 
-export const DISCOVER_MODES = ["gaps", "momtest"];
+export const DISCOVER_MODES = ["gaps", "momtest", "wendel"];
 
 const VALID_VERDICTS = ["ready", "needs_validation"];
 const VALID_SEVERITIES = ["critical", "major", "minor"];
+const VALID_WENDEL_STATUSES = ["pass", "fail", "unknown", "not_applicable"];
 
 export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context = null }) {
   const sections = [SUBAGENT_PREAMBLE];
@@ -56,14 +57,36 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
     );
   }
 
+  if (mode === "wendel") {
+    sections.push(
+      "## Wendel Behavior Change Checklist",
+      [
+        "Evaluate whether the task implies a user behavior change. If it does, assess these 5 conditions:",
+        "",
+        "1. **CUE** — Is there a clear trigger that will prompt the user to take the new action?",
+        "2. **REACTION** — Will the user have a positive emotional reaction when they encounter the cue?",
+        "3. **EVALUATION** — Can the user quickly understand the value of the new behavior?",
+        "4. **ABILITY** — Does the user have the skill and resources to perform the new behavior?",
+        "5. **TIMING** — Is this the right moment to introduce this change?",
+        "",
+        "For each condition, set status to: pass, fail, unknown, or not_applicable",
+        "If the task does NOT imply behavior change (e.g., internal refactor, backend optimization), set ALL conditions to 'not_applicable'",
+        "If ANY condition is 'fail', set verdict to 'needs_validation'"
+      ].join("\n")
+    );
+  }
+
   const baseSchema = '{"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}]';
   const momtestSchema = mode === "momtest"
     ? ',"momTestQuestions":[{"gapId":string,"question":string,"targetRole":string,"rationale":string}]'
     : "";
+  const wendelSchema = mode === "wendel"
+    ? ',"wendelChecklist":[{"condition":"CUE|REACTION|EVALUATION|ABILITY|TIMING","status":"pass|fail|unknown|not_applicable","justification":string}]'
+    : "";
 
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    `JSON schema: ${baseSchema}${momtestSchema},"summary":string}`
+    `JSON schema: ${baseSchema}${momtestSchema}${wendelSchema},"summary":string}`
   );
 
   if (context) {
@@ -111,10 +134,22 @@ export function parseDiscoverOutput(raw) {
       rationale: q.rationale
     }));
 
+  const rawChecklist = Array.isArray(parsed.wendelChecklist) ? parsed.wendelChecklist : [];
+  const wendelChecklist = rawChecklist
+    .filter((c) => c && c.condition && c.justification && c.status)
+    .map((c) => ({
+      condition: c.condition,
+      status: VALID_WENDEL_STATUSES.includes(String(c.status).toLowerCase())
+        ? String(c.status).toLowerCase()
+        : "unknown",
+      justification: c.justification
+    }));
+
   return {
     verdict,
     gaps,
     momTestQuestions,
+    wendelChecklist,
     summary: parsed.summary || ""
   };
 }

--- a/src/roles/discover-role.js
+++ b/src/roles/discover-role.js
@@ -12,11 +12,17 @@ function resolveProvider(config) {
 
 function buildSummary(parsed, mode) {
   const gapCount = parsed.gaps?.length || 0;
-  if (gapCount === 0) return "Discovery complete: task is ready";
-  const parts = [`${gapCount} gap${gapCount !== 1 ? "s" : ""} found`];
+  if (gapCount === 0 && mode !== "wendel") return "Discovery complete: task is ready";
+  const parts = [];
+  if (gapCount > 0) parts.push(`${gapCount} gap${gapCount !== 1 ? "s" : ""} found`);
   if (mode === "momtest") {
     const qCount = parsed.momTestQuestions?.length || 0;
     if (qCount > 0) parts.push(`${qCount} Mom Test question${qCount !== 1 ? "s" : ""}`);
+  }
+  if (mode === "wendel") {
+    const failCount = (parsed.wendelChecklist || []).filter(c => c.status === "fail").length;
+    if (failCount > 0) parts.push(`${failCount} Wendel condition${failCount !== 1 ? "s" : ""} failed`);
+    else if (gapCount === 0) return "Discovery complete: task is ready";
   }
   return `Discovery complete: ${parts.join(", ")} (verdict: ${parsed.verdict})`;
 }
@@ -81,6 +87,9 @@ export class DiscoverRole extends BaseRole {
       };
       if (mode === "momtest") {
         resultObj.momTestQuestions = parsed.momTestQuestions || [];
+      }
+      if (mode === "wendel") {
+        resultObj.wendelChecklist = parsed.wendelChecklist || [];
       }
 
       return {

--- a/templates/roles/discover.md
+++ b/templates/roles/discover.md
@@ -60,7 +60,7 @@ When running in **momtest** mode, for each gap generate questions following The 
 | "Do you think users need dark mode?" | "How many support tickets mentioned readability issues?" |
 | "Would it be useful to have X?" | "How are you currently handling X?" |
 
-### Mom Test Output Schema (additional fields)
+### Mom Test Output Schema (additional fields for momtest mode)
 
 ```json
 {
@@ -70,6 +70,41 @@ When running in **momtest** mode, for each gap generate questions following The 
       "question": "Past-behavior question to validate this gap",
       "targetRole": "Who should answer (end-user, developer, PM, etc.)",
       "rationale": "Why this question matters for the gap"
+    }
+  ]
+}
+```
+
+## Wendel Mode
+
+When running in **wendel** mode, evaluate whether the task implies a **user behavior change** and assess 5 adoption conditions:
+
+| Condition | Question |
+|-----------|----------|
+| **CUE** | Is there a clear trigger that will prompt the user to take the new action? |
+| **REACTION** | Will the user have a positive emotional reaction when encountering the cue? |
+| **EVALUATION** | Can the user quickly understand the value of the new behavior? |
+| **ABILITY** | Does the user have the skill and resources to perform the new behavior? |
+| **TIMING** | Is this the right moment to introduce this change? |
+
+### Status Values
+
+- **pass**: Condition is clearly met based on the task specification
+- **fail**: Condition is NOT met — adoption risk identified
+- **unknown**: Not enough information to evaluate
+- **not_applicable**: Task does not imply user behavior change (e.g., refactor, backend optimization)
+
+If the task does NOT imply behavior change, set ALL conditions to `not_applicable` and verdict to `ready`.
+
+### Wendel Output Schema (additional fields for wendel mode)
+
+```json
+{
+  "wendelChecklist": [
+    {
+      "condition": "CUE|REACTION|EVALUATION|ABILITY|TIMING",
+      "status": "pass|fail|unknown|not_applicable",
+      "justification": "Why this condition passes or fails"
     }
   ]
 }

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -267,6 +267,79 @@ describe("DiscoverRole", () => {
       expect(result.result.momTestQuestions).toEqual([]);
     });
 
+    it("returns wendelChecklist in wendel mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "No CUE defined", severity: "critical", suggestedQuestion: "q" }],
+        wendelChecklist: [
+          { condition: "CUE", status: "fail", justification: "No trigger point" },
+          { condition: "REACTION", status: "pass", justification: "Users want this" },
+          { condition: "EVALUATION", status: "pass", justification: "Easy to evaluate" },
+          { condition: "ABILITY", status: "pass", justification: "No new skills needed" },
+          { condition: "TIMING", status: "pass", justification: "Good timing" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Add notification bell" });
+      const result = await role.run({ task: "Add notification bell", mode: "wendel" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.mode).toBe("wendel");
+      expect(result.result.wendelChecklist).toHaveLength(5);
+      expect(result.result.wendelChecklist[0].condition).toBe("CUE");
+      expect(result.result.wendelChecklist[0].status).toBe("fail");
+    });
+
+    it("returns not_applicable wendel checklist for non-behavior tasks", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        wendelChecklist: [
+          { condition: "CUE", status: "not_applicable", justification: "Internal refactor" },
+          { condition: "REACTION", status: "not_applicable", justification: "Internal refactor" },
+          { condition: "EVALUATION", status: "not_applicable", justification: "Internal refactor" },
+          { condition: "ABILITY", status: "not_applicable", justification: "Internal refactor" },
+          { condition: "TIMING", status: "not_applicable", justification: "Internal refactor" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Refactor database module" });
+      const result = await role.run({ task: "Refactor database module", mode: "wendel" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.verdict).toBe("ready");
+      expect(result.result.wendelChecklist.every(c => c.status === "not_applicable")).toBe(true);
+    });
+
+    it("includes wendel fail count in summary", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "x", severity: "major", suggestedQuestion: "q" }],
+        wendelChecklist: [
+          { condition: "CUE", status: "fail", justification: "No trigger" },
+          { condition: "REACTION", status: "fail", justification: "No motivation" },
+          { condition: "EVALUATION", status: "pass", justification: "ok" },
+          { condition: "ABILITY", status: "pass", justification: "ok" },
+          { condition: "TIMING", status: "pass", justification: "ok" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "wendel" });
+
+      expect(result.summary).toContain("2");
+      expect(result.summary).toMatch(/fail/i);
+    });
+
     it("includes momTestQuestions count in summary for momtest mode", async () => {
       const agentOutput = JSON.stringify({
         verdict: "needs_validation",

--- a/tests/prompt-discover.test.js
+++ b/tests/prompt-discover.test.js
@@ -66,6 +66,29 @@ describe("buildDiscoverPrompt — momtest mode", () => {
   });
 });
 
+describe("buildDiscoverPrompt — wendel mode", () => {
+  it("includes Wendel Checklist when mode is wendel", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "wendel" });
+    expect(prompt).toContain("Wendel");
+    expect(prompt).toContain("CUE");
+    expect(prompt).toContain("REACTION");
+    expect(prompt).toContain("EVALUATION");
+    expect(prompt).toContain("ABILITY");
+    expect(prompt).toContain("TIMING");
+  });
+
+  it("includes wendelChecklist in JSON schema for wendel mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "wendel" });
+    expect(prompt).toContain("wendelChecklist");
+    expect(prompt).toContain("pass");
+  });
+
+  it("does not include Wendel in gaps mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "gaps" });
+    expect(prompt).not.toContain("Wendel");
+  });
+});
+
 describe("DISCOVER_MODES", () => {
   it("exports gaps as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("gaps");
@@ -73,6 +96,10 @@ describe("DISCOVER_MODES", () => {
 
   it("exports momtest as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("momtest");
+  });
+
+  it("exports wendel as a valid mode", () => {
+    expect(DISCOVER_MODES).toContain("wendel");
   });
 });
 
@@ -175,6 +202,68 @@ describe("parseDiscoverOutput", () => {
     const raw = JSON.stringify({ verdict: "ready", gaps: [] });
     const parsed = parseDiscoverOutput(raw);
     expect(parsed.momTestQuestions).toEqual([]);
+  });
+
+  it("parses wendelChecklist from output", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [],
+      wendelChecklist: [
+        { condition: "CUE", status: "pass", justification: "Clear trigger exists" },
+        { condition: "REACTION", status: "fail", justification: "No motivation identified" },
+        { condition: "EVALUATION", status: "unknown", justification: "Not enough info" },
+        { condition: "ABILITY", status: "pass", justification: "Users have the skill" },
+        { condition: "TIMING", status: "not_applicable", justification: "Internal tool" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.wendelChecklist).toHaveLength(5);
+    expect(parsed.wendelChecklist[0].condition).toBe("CUE");
+    expect(parsed.wendelChecklist[1].status).toBe("fail");
+  });
+
+  it("returns empty wendelChecklist when not present", () => {
+    const raw = JSON.stringify({ verdict: "ready", gaps: [] });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.wendelChecklist).toEqual([]);
+  });
+
+  it("normalizes wendel status to valid values", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      wendelChecklist: [
+        { condition: "CUE", status: "PASS", justification: "ok" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.wendelChecklist[0].status).toBe("pass");
+  });
+
+  it("defaults invalid wendel status to unknown", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      wendelChecklist: [
+        { condition: "CUE", status: "invalid_status", justification: "ok" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.wendelChecklist[0].status).toBe("unknown");
+  });
+
+  it("filters wendelChecklist items missing required fields", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      wendelChecklist: [
+        { condition: "CUE", status: "pass", justification: "ok" },
+        { condition: "REACTION" },
+        { status: "fail" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.wendelChecklist).toHaveLength(1);
   });
 
   it("filters momTestQuestions missing required fields", () => {


### PR DESCRIPTION
## Summary
- Extends DiscoverRole with **wendel** mode for behavior change adoption validation
- Evaluates 5 conditions: CUE, REACTION, EVALUATION, ABILITY, TIMING
- Each condition rated as pass/fail/unknown/not_applicable with justification
- Non-behavior tasks get all conditions as not_applicable with verdict=ready
- Parser normalizes status values and filters incomplete entries

## Test plan
- [x] 12 new tests: prompt wendel sections, parser wendelChecklist, role wendel mode, summary
- [x] Full suite: 1342 tests passing across 115 files