### PR TITLE
feat(discover): classify mode START/STOP/DIFFERENT (KJC-TSK-0121)

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -692,7 +692,7 @@ export async function handleToolCall(name, args, server, extra) {
     if (!a.task) {
       return failPayload("Missing required field: task");
     }
-    const validModes = ["gaps", "momtest", "wendel"];
+    const validModes = ["gaps", "momtest", "wendel", "classify"];
     if (a.mode && !validModes.includes(a.mode)) {
       return failPayload(`Invalid mode "${a.mode}". Valid values: ${validModes.join(", ")}`);
     }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -232,7 +232,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to analyze for gaps" },
-        mode: { type: "string", enum: ["gaps", "momtest", "wendel"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), or wendel (behavior change checklist)" },
+        mode: { type: "string", enum: ["gaps", "momtest", "wendel", "classify"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), wendel (behavior change checklist), or classify (START/STOP/DIFFERENT)" },
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
         pgProject: { type: "string", description: "Planning Game project ID. Required when pgTask is used." },

--- a/src/prompts/discover.js
+++ b/src/prompts/discover.js
@@ -4,11 +4,13 @@ const SUBAGENT_PREAMBLE = [
   "Do NOT use any MCP tools. Focus only on discovering gaps in the task specification."
 ].join(" ");
 
-export const DISCOVER_MODES = ["gaps", "momtest", "wendel"];
+export const DISCOVER_MODES = ["gaps", "momtest", "wendel", "classify"];
 
 const VALID_VERDICTS = ["ready", "needs_validation"];
 const VALID_SEVERITIES = ["critical", "major", "minor"];
 const VALID_WENDEL_STATUSES = ["pass", "fail", "unknown", "not_applicable"];
+const VALID_CLASSIFY_TYPES = ["START", "STOP", "DIFFERENT", "not_applicable"];
+const VALID_ADOPTION_RISKS = ["none", "low", "medium", "high"];
 
 export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context = null }) {
   const sections = [SUBAGENT_PREAMBLE];
@@ -76,6 +78,24 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
     );
   }
 
+  if (mode === "classify") {
+    sections.push(
+      "## Behavior Change Classification",
+      [
+        "Classify the task by its impact on user behavior:",
+        "",
+        "- **START**: User must adopt a completely new behavior or workflow",
+        "- **STOP**: User must stop doing something they currently do (highest resistance risk)",
+        "- **DIFFERENT**: User must do something they already do, but differently",
+        "- **not_applicable**: Task has no user behavior impact (internal refactor, backend, infra)",
+        "",
+        "Assess adoption risk: none (no user impact), low, medium, high",
+        "STOP changes carry the highest risk of resistance — always flag them",
+        "Provide a frictionEstimate explaining the expected friction"
+      ].join("\n")
+    );
+  }
+
   const baseSchema = '{"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}]';
   const momtestSchema = mode === "momtest"
     ? ',"momTestQuestions":[{"gapId":string,"question":string,"targetRole":string,"rationale":string}]'
@@ -83,10 +103,13 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
   const wendelSchema = mode === "wendel"
     ? ',"wendelChecklist":[{"condition":"CUE|REACTION|EVALUATION|ABILITY|TIMING","status":"pass|fail|unknown|not_applicable","justification":string}]'
     : "";
+  const classifySchema = mode === "classify"
+    ? ',"classification":{"type":"START|STOP|DIFFERENT|not_applicable","adoptionRisk":"none|low|medium|high","frictionEstimate":string}'
+    : "";
 
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    `JSON schema: ${baseSchema}${momtestSchema}${wendelSchema},"summary":string}`
+    `JSON schema: ${baseSchema}${momtestSchema}${wendelSchema}${classifySchema},"summary":string}`
   );
 
   if (context) {
@@ -145,11 +168,25 @@ export function parseDiscoverOutput(raw) {
       justification: c.justification
     }));
 
+  let classification = null;
+  if (parsed.classification && typeof parsed.classification === "object") {
+    const rawType = String(parsed.classification.type || "").toUpperCase();
+    const type = rawType === "NOT_APPLICABLE" ? "not_applicable"
+      : VALID_CLASSIFY_TYPES.includes(rawType) ? rawType : "not_applicable";
+    const rawRisk = String(parsed.classification.adoptionRisk || "").toLowerCase();
+    classification = {
+      type,
+      adoptionRisk: VALID_ADOPTION_RISKS.includes(rawRisk) ? rawRisk : "medium",
+      frictionEstimate: parsed.classification.frictionEstimate || ""
+    };
+  }
+
   return {
     verdict,
     gaps,
     momTestQuestions,
     wendelChecklist,
+    classification,
     summary: parsed.summary || ""
   };
 }

--- a/src/roles/discover-role.js
+++ b/src/roles/discover-role.js
@@ -24,6 +24,9 @@ function buildSummary(parsed, mode) {
     if (failCount > 0) parts.push(`${failCount} Wendel condition${failCount !== 1 ? "s" : ""} failed`);
     else if (gapCount === 0) return "Discovery complete: task is ready";
   }
+  if (mode === "classify" && parsed.classification) {
+    parts.push(`type: ${parsed.classification.type}, risk: ${parsed.classification.adoptionRisk}`);
+  }
   return `Discovery complete: ${parts.join(", ")} (verdict: ${parsed.verdict})`;
 }
 
@@ -90,6 +93,9 @@ export class DiscoverRole extends BaseRole {
       }
       if (mode === "wendel") {
         resultObj.wendelChecklist = parsed.wendelChecklist || [];
+      }
+      if (mode === "classify") {
+        resultObj.classification = parsed.classification || null;
       }
 
       return {

--- a/templates/roles/discover.md
+++ b/templates/roles/discover.md
@@ -109,3 +109,26 @@ If the task does NOT imply behavior change, set ALL conditions to `not_applicabl
   ]
 }
 ```
+
+## Classify Mode
+
+When running in **classify** mode, classify the task by its impact on user behavior:
+
+| Type | Description | Risk Level |
+|------|-------------|------------|
+| **START** | User must adopt a completely new behavior or workflow | Medium-High |
+| **STOP** | User must stop doing something they currently do | **Highest** resistance risk |
+| **DIFFERENT** | User must do something they already do, but differently | Low-Medium |
+| **not_applicable** | No user behavior impact (internal refactor, backend, infra) | None |
+
+### Classify Output Schema (additional fields for classify mode)
+
+```json
+{
+  "classification": {
+    "type": "START|STOP|DIFFERENT|not_applicable",
+    "adoptionRisk": "none|low|medium|high",
+    "frictionEstimate": "Description of expected friction"
+  }
+}
+```

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -317,6 +317,59 @@ describe("DiscoverRole", () => {
       expect(result.result.wendelChecklist.every(c => c.status === "not_applicable")).toBe(true);
     });
 
+    it("returns classification in classify mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "x", severity: "major", suggestedQuestion: "q" }],
+        classification: { type: "STOP", adoptionRisk: "high", frictionEstimate: "Removing existing workflow" }
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Remove legacy export" });
+      const result = await role.run({ task: "Remove legacy export", mode: "classify" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.mode).toBe("classify");
+      expect(result.result.classification.type).toBe("STOP");
+      expect(result.result.classification.adoptionRisk).toBe("high");
+    });
+
+    it("returns not_applicable classification for technical tasks", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        classification: { type: "not_applicable", adoptionRisk: "none", frictionEstimate: "No user impact" }
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Refactor DB module" });
+      const result = await role.run({ task: "Refactor DB module", mode: "classify" });
+
+      expect(result.result.classification.type).toBe("not_applicable");
+      expect(result.result.classification.adoptionRisk).toBe("none");
+    });
+
+    it("includes classification in summary for classify mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "needs_validation",
+        gaps: [{ id: "g1", description: "x", severity: "major", suggestedQuestion: "q" }],
+        classification: { type: "STOP", adoptionRisk: "high", frictionEstimate: "x" }
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "classify" });
+
+      expect(result.summary).toContain("STOP");
+      expect(result.summary).toContain("high");
+    });
+
     it("includes wendel fail count in summary", async () => {
       const agentOutput = JSON.stringify({
         verdict: "needs_validation",

--- a/tests/prompt-discover.test.js
+++ b/tests/prompt-discover.test.js
@@ -89,6 +89,26 @@ describe("buildDiscoverPrompt — wendel mode", () => {
   });
 });
 
+describe("buildDiscoverPrompt — classify mode", () => {
+  it("includes START/STOP/DIFFERENT classification when mode is classify", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "classify" });
+    expect(prompt).toContain("START");
+    expect(prompt).toContain("STOP");
+    expect(prompt).toContain("DIFFERENT");
+  });
+
+  it("includes classification in JSON schema for classify mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "classify" });
+    expect(prompt).toContain("classification");
+    expect(prompt).toContain("adoptionRisk");
+  });
+
+  it("does not include classification in gaps mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "gaps" });
+    expect(prompt).not.toContain("adoptionRisk");
+  });
+});
+
 describe("DISCOVER_MODES", () => {
   it("exports gaps as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("gaps");
@@ -100,6 +120,10 @@ describe("DISCOVER_MODES", () => {
 
   it("exports wendel as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("wendel");
+  });
+
+  it("exports classify as a valid mode", () => {
+    expect(DISCOVER_MODES).toContain("classify");
   });
 });
 
@@ -250,6 +274,69 @@ describe("parseDiscoverOutput", () => {
     });
     const parsed = parseDiscoverOutput(raw);
     expect(parsed.wendelChecklist[0].status).toBe("unknown");
+  });
+
+  it("parses classification from output", () => {
+    const raw = JSON.stringify({
+      verdict: "needs_validation",
+      gaps: [],
+      classification: {
+        type: "START",
+        adoptionRisk: "medium",
+        frictionEstimate: "Users need to learn a new workflow"
+      }
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification).toBeDefined();
+    expect(parsed.classification.type).toBe("START");
+    expect(parsed.classification.adoptionRisk).toBe("medium");
+    expect(parsed.classification.frictionEstimate).toBe("Users need to learn a new workflow");
+  });
+
+  it("returns null classification when not present", () => {
+    const raw = JSON.stringify({ verdict: "ready", gaps: [] });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification).toBeNull();
+  });
+
+  it("normalizes classification type to uppercase", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      classification: { type: "stop", adoptionRisk: "high", frictionEstimate: "x" }
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification.type).toBe("STOP");
+  });
+
+  it("defaults invalid classification type to not_applicable", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      classification: { type: "INVALID", adoptionRisk: "low", frictionEstimate: "x" }
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification.type).toBe("not_applicable");
+  });
+
+  it("normalizes adoptionRisk to valid values", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      classification: { type: "START", adoptionRisk: "HIGH", frictionEstimate: "x" }
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification.adoptionRisk).toBe("high");
+  });
+
+  it("defaults invalid adoptionRisk to medium", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      classification: { type: "START", adoptionRisk: "extreme", frictionEstimate: "x" }
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.classification.adoptionRisk).toBe("medium");
   });
 
   it("filters wendelChecklist items missing required fields", () => {


### PR DESCRIPTION
## Summary
- Extends DiscoverRole with **classify** mode for behavior change categorization
- Classifies tasks as START (new behavior), STOP (remove behavior), DIFFERENT (change behavior), or not_applicable
- Includes adoptionRisk (none/low/medium/high) and frictionEstimate
- Parser normalizes type to uppercase and risk to lowercase with defaults

## Test plan
- [x] 13 new tests: prompt classify sections, parser classification, role classify mode, summary
- [x] Full suite: 1355 tests passing across 115 files