### PR TITLE
feat(discover): jtbd mode for Jobs-to-be-Done (KJC-TSK-0122)

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -692,7 +692,7 @@ export async function handleToolCall(name, args, server, extra) {
     if (!a.task) {
       return failPayload("Missing required field: task");
     }
-    const validModes = ["gaps", "momtest", "wendel", "classify"];
+    const validModes = ["gaps", "momtest", "wendel", "classify", "jtbd"];
     if (a.mode && !validModes.includes(a.mode)) {
       return failPayload(`Invalid mode "${a.mode}". Valid values: ${validModes.join(", ")}`);
     }

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -232,7 +232,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to analyze for gaps" },
-        mode: { type: "string", enum: ["gaps", "momtest", "wendel", "classify"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), wendel (behavior change checklist), or classify (START/STOP/DIFFERENT)" },
+        mode: { type: "string", enum: ["gaps", "momtest", "wendel", "classify", "jtbd"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), wendel (behavior change checklist), classify (START/STOP/DIFFERENT), or jtbd (Jobs-to-be-Done)" },
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
         pgProject: { type: "string", description: "Planning Game project ID. Required when pgTask is used." },

--- a/src/prompts/discover.js
+++ b/src/prompts/discover.js
@@ -4,7 +4,7 @@ const SUBAGENT_PREAMBLE = [
   "Do NOT use any MCP tools. Focus only on discovering gaps in the task specification."
 ].join(" ");
 
-export const DISCOVER_MODES = ["gaps", "momtest", "wendel", "classify"];
+export const DISCOVER_MODES = ["gaps", "momtest", "wendel", "classify", "jtbd"];
 
 const VALID_VERDICTS = ["ready", "needs_validation"];
 const VALID_SEVERITIES = ["critical", "major", "minor"];
@@ -96,6 +96,25 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
     );
   }
 
+  if (mode === "jtbd") {
+    sections.push(
+      "## Jobs-to-be-Done Framework",
+      [
+        "Generate reinforced Jobs-to-be-Done from the task and any provided context (interview notes, field observations).",
+        "Each JTBD must include 5 layers:",
+        "",
+        "- **functional**: The practical job the user is trying to accomplish",
+        "- **emotionalPersonal**: How the user wants to feel personally",
+        "- **emotionalSocial**: How the user wants to be perceived by others",
+        "- **behaviorChange**: Type of change: START, STOP, DIFFERENT, or not_applicable",
+        "- **evidence**: Direct quotes or specific references from the context. If no context provided, set to 'not_available' and suggest what context is needed",
+        "",
+        "CRITICAL: evidence must contain real quotes or references from the provided context, NEVER invented assumptions",
+        "If no context is provided, mark evidence as 'not_available'"
+      ].join("\n")
+    );
+  }
+
   const baseSchema = '{"verdict":"ready|needs_validation","gaps":[{"id":string,"description":string,"severity":"critical|major|minor","suggestedQuestion":string}]';
   const momtestSchema = mode === "momtest"
     ? ',"momTestQuestions":[{"gapId":string,"question":string,"targetRole":string,"rationale":string}]'
@@ -106,10 +125,13 @@ export function buildDiscoverPrompt({ task, instructions, mode = "gaps", context
   const classifySchema = mode === "classify"
     ? ',"classification":{"type":"START|STOP|DIFFERENT|not_applicable","adoptionRisk":"none|low|medium|high","frictionEstimate":string}'
     : "";
+  const jtbdSchema = mode === "jtbd"
+    ? ',"jtbds":[{"id":string,"functional":string,"emotionalPersonal":string,"emotionalSocial":string,"behaviorChange":"START|STOP|DIFFERENT|not_applicable","evidence":string}]'
+    : "";
 
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    `JSON schema: ${baseSchema}${momtestSchema}${wendelSchema}${classifySchema},"summary":string}`
+    `JSON schema: ${baseSchema}${momtestSchema}${wendelSchema}${classifySchema}${jtbdSchema},"summary":string}`
   );
 
   if (context) {
@@ -168,6 +190,18 @@ export function parseDiscoverOutput(raw) {
       justification: c.justification
     }));
 
+  const rawJtbds = Array.isArray(parsed.jtbds) ? parsed.jtbds : [];
+  const jtbds = rawJtbds
+    .filter((j) => j && j.id && j.functional && j.emotionalPersonal && j.emotionalSocial && j.behaviorChange && j.evidence)
+    .map((j) => ({
+      id: j.id,
+      functional: j.functional,
+      emotionalPersonal: j.emotionalPersonal,
+      emotionalSocial: j.emotionalSocial,
+      behaviorChange: j.behaviorChange,
+      evidence: j.evidence
+    }));
+
   let classification = null;
   if (parsed.classification && typeof parsed.classification === "object") {
     const rawType = String(parsed.classification.type || "").toUpperCase();
@@ -187,6 +221,7 @@ export function parseDiscoverOutput(raw) {
     momTestQuestions,
     wendelChecklist,
     classification,
+    jtbds,
     summary: parsed.summary || ""
   };
 }

--- a/src/roles/discover-role.js
+++ b/src/roles/discover-role.js
@@ -12,7 +12,7 @@ function resolveProvider(config) {
 
 function buildSummary(parsed, mode) {
   const gapCount = parsed.gaps?.length || 0;
-  if (gapCount === 0 && mode !== "wendel") return "Discovery complete: task is ready";
+  if (gapCount === 0 && mode !== "wendel" && mode !== "jtbd") return "Discovery complete: task is ready";
   const parts = [];
   if (gapCount > 0) parts.push(`${gapCount} gap${gapCount !== 1 ? "s" : ""} found`);
   if (mode === "momtest") {
@@ -26,6 +26,11 @@ function buildSummary(parsed, mode) {
   }
   if (mode === "classify" && parsed.classification) {
     parts.push(`type: ${parsed.classification.type}, risk: ${parsed.classification.adoptionRisk}`);
+  }
+  if (mode === "jtbd") {
+    const jCount = parsed.jtbds?.length || 0;
+    if (jCount > 0) parts.push(`${jCount} JTBD${jCount !== 1 ? "s" : ""} generated`);
+    else if (gapCount === 0) return "Discovery complete: task is ready";
   }
   return `Discovery complete: ${parts.join(", ")} (verdict: ${parsed.verdict})`;
 }
@@ -96,6 +101,9 @@ export class DiscoverRole extends BaseRole {
       }
       if (mode === "classify") {
         resultObj.classification = parsed.classification || null;
+      }
+      if (mode === "jtbd") {
+        resultObj.jtbds = parsed.jtbds || [];
       }
 
       return {

--- a/templates/roles/discover.md
+++ b/templates/roles/discover.md
@@ -132,3 +132,36 @@ When running in **classify** mode, classify the task by its impact on user behav
   }
 }
 ```
+
+## JTBD Mode
+
+When running in **jtbd** mode, generate reinforced Jobs-to-be-Done from the task and provided context (interview notes, field observations).
+
+Each JTBD must include 5 layers:
+
+| Layer | Description |
+|-------|-------------|
+| **functional** | The practical job the user is trying to accomplish |
+| **emotionalPersonal** | How the user wants to feel personally |
+| **emotionalSocial** | How the user wants to be perceived by others |
+| **behaviorChange** | Type of change: START, STOP, DIFFERENT, or not_applicable |
+| **evidence** | Direct quotes or references from context. Set to `not_available` if no context provided |
+
+**CRITICAL**: The `evidence` field must contain real quotes or specific references from the provided context. Never invent assumptions.
+
+### JTBD Output Schema (additional fields for jtbd mode)
+
+```json
+{
+  "jtbds": [
+    {
+      "id": "jtbd-1",
+      "functional": "The practical job",
+      "emotionalPersonal": "How the user wants to feel",
+      "emotionalSocial": "How the user wants to be perceived",
+      "behaviorChange": "START|STOP|DIFFERENT|not_applicable",
+      "evidence": "Direct quote or 'not_available'"
+    }
+  ]
+}
+```

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -353,6 +353,75 @@ describe("DiscoverRole", () => {
       expect(result.result.classification.adoptionRisk).toBe("none");
     });
 
+    it("returns jtbds in jtbd mode", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        jtbds: [{
+          id: "jtbd-1",
+          functional: "Export data",
+          emotionalPersonal: "Feel productive",
+          emotionalSocial: "Impress team",
+          behaviorChange: "START",
+          evidence: "User: 'I spend 2h copying'"
+        }]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "Add export" });
+      const result = await role.run({ task: "Add export", mode: "jtbd" });
+
+      expect(result.ok).toBe(true);
+      expect(result.result.mode).toBe("jtbd");
+      expect(result.result.jtbds).toHaveLength(1);
+      expect(result.result.jtbds[0].functional).toBe("Export data");
+    });
+
+    it("returns empty jtbds when no context provided", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        jtbds: [{
+          id: "j1",
+          functional: "x",
+          emotionalPersonal: "y",
+          emotionalSocial: "z",
+          behaviorChange: "START",
+          evidence: "not_available"
+        }]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "jtbd" });
+
+      expect(result.result.jtbds[0].evidence).toBe("not_available");
+    });
+
+    it("includes jtbd count in summary", async () => {
+      const agentOutput = JSON.stringify({
+        verdict: "ready",
+        gaps: [],
+        jtbds: [
+          { id: "j1", functional: "a", emotionalPersonal: "b", emotionalSocial: "c", behaviorChange: "START", evidence: "e" },
+          { id: "j2", functional: "d", emotionalPersonal: "e", emotionalSocial: "f", behaviorChange: "DIFFERENT", evidence: "g" }
+        ]
+      });
+      const mockAgent = makeMockAgent({ ok: true, output: agentOutput });
+      const createAgentFn = () => mockAgent;
+
+      const role = new DiscoverRole({ config: makeConfig(), logger, createAgentFn });
+      await role.init({ task: "x" });
+      const result = await role.run({ task: "x", mode: "jtbd" });
+
+      expect(result.summary).toContain("2");
+      expect(result.summary).toMatch(/JTBD/i);
+    });
+
     it("includes classification in summary for classify mode", async () => {
       const agentOutput = JSON.stringify({
         verdict: "needs_validation",

--- a/tests/prompt-discover.test.js
+++ b/tests/prompt-discover.test.js
@@ -109,6 +109,28 @@ describe("buildDiscoverPrompt — classify mode", () => {
   });
 });
 
+describe("buildDiscoverPrompt — jtbd mode", () => {
+  it("includes JTBD framework when mode is jtbd", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "jtbd" });
+    expect(prompt).toContain("Jobs-to-be-Done");
+    expect(prompt).toContain("functional");
+    expect(prompt).toContain("emotionalPersonal");
+    expect(prompt).toContain("emotionalSocial");
+    expect(prompt).toContain("behaviorChange");
+    expect(prompt).toContain("evidence");
+  });
+
+  it("includes jtbds in JSON schema for jtbd mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "jtbd" });
+    expect(prompt).toContain("jtbds");
+  });
+
+  it("does not include JTBD in gaps mode", () => {
+    const prompt = buildDiscoverPrompt({ task: "x", mode: "gaps" });
+    expect(prompt).not.toContain("Jobs-to-be-Done");
+  });
+});
+
 describe("DISCOVER_MODES", () => {
   it("exports gaps as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("gaps");
@@ -124,6 +146,10 @@ describe("DISCOVER_MODES", () => {
 
   it("exports classify as a valid mode", () => {
     expect(DISCOVER_MODES).toContain("classify");
+  });
+
+  it("exports jtbd as a valid mode", () => {
+    expect(DISCOVER_MODES).toContain("jtbd");
   });
 });
 
@@ -351,6 +377,63 @@ describe("parseDiscoverOutput", () => {
     });
     const parsed = parseDiscoverOutput(raw);
     expect(parsed.wendelChecklist).toHaveLength(1);
+  });
+
+  it("parses jtbds from output", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      jtbds: [{
+        id: "jtbd-1",
+        functional: "Export data to CSV",
+        emotionalPersonal: "Feel in control of my data",
+        emotionalSocial: "Look competent in meetings",
+        behaviorChange: "START",
+        evidence: "User said: 'I spend 2 hours copying data manually'"
+      }]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.jtbds).toHaveLength(1);
+    expect(parsed.jtbds[0].id).toBe("jtbd-1");
+    expect(parsed.jtbds[0].functional).toBe("Export data to CSV");
+    expect(parsed.jtbds[0].evidence).toContain("copying data");
+  });
+
+  it("returns empty jtbds when not present", () => {
+    const raw = JSON.stringify({ verdict: "ready", gaps: [] });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.jtbds).toEqual([]);
+  });
+
+  it("filters jtbds missing required fields", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      jtbds: [
+        { id: "j1", functional: "x", emotionalPersonal: "y", emotionalSocial: "z", behaviorChange: "START", evidence: "data" },
+        { id: "j2", functional: "x" },
+        { emotionalPersonal: "missing id and functional" }
+      ]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.jtbds).toHaveLength(1);
+  });
+
+  it("handles not_available evidence", () => {
+    const raw = JSON.stringify({
+      verdict: "ready",
+      gaps: [],
+      jtbds: [{
+        id: "j1",
+        functional: "x",
+        emotionalPersonal: "y",
+        emotionalSocial: "z",
+        behaviorChange: "START",
+        evidence: "not_available"
+      }]
+    });
+    const parsed = parseDiscoverOutput(raw);
+    expect(parsed.jtbds[0].evidence).toBe("not_available");
   });
 
   it("filters momTestQuestions missing required fields", () => {


### PR DESCRIPTION
## Summary
- Extends DiscoverRole with **jtbd** mode for reinforced Jobs-to-be-Done generation
- 5 layers per JTBD: functional, emotionalPersonal, emotionalSocial, behaviorChange, evidence
- Evidence must come from provided context (interview notes); defaults to `not_available` without context
- Parser validates all 6 required fields per JTBD entry

## Test plan
- [x] 11 new tests: prompt jtbd sections, parser jtbds, role jtbd mode, summary, evidence handling
- [x] Full suite: 1366 tests passing across 115 files