### PR TITLE
chore: release v1.16.0 — DiscoverRole + kj_discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-03-11
+
+### Added
+- **DiscoverRole**: new pre-execution validation role that analyzes tasks for gaps, ambiguities, and missing information before pipeline execution
+- **5 discovery modes**: `gaps` (default gap detection), `momtest` (Mom Test question generation), `wendel` (behavior change adoption checklist), `classify` (START/STOP/DIFFERENT classification), `jtbd` (Jobs-to-be-Done generation)
+- **`kj_discover` MCP tool**: standalone gap detection tool with mode, context, and Planning Game task integration
+- **Pipeline integration**: discover runs as opt-in pre-pipeline stage before triage (`--enable-discover` flag or `pipeline.discover.enabled` config)
+- **Non-blocking discovery**: discover failures log warnings and continue pipeline execution gracefully
+
 ## [1.15.0] - 2026-03-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- Bumps version to v1.16.0
- Updates CHANGELOG with all discover features from épica KJC-PCS-0010

## Changes in v1.16.0 (PRs #91-#97)
- **DiscoverRole**: pre-execution validation role with 5 modes
- **kj_discover MCP tool**: standalone gap detection
- **Pipeline integration**: opt-in pre-triage discover stage
- **Modes**: gaps, momtest, wendel, classify, jtbd

## Test plan
- [x] 1374 tests pass across 115 files