### PR TITLE
feat(cli): standalone commands for discover, triage, researcher, architect

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,10 @@ import { resumeCommand } from "./commands/resume.js";
 import { sonarCommand, sonarOpenCommand } from "./commands/sonar.js";
 import { rolesCommand } from "./commands/roles.js";
 import { agentsCommand } from "./commands/agents.js";
+import { discoverCommand } from "./commands/discover.js";
+import { triageCommand } from "./commands/triage.js";
+import { researcherCommand } from "./commands/researcher.js";
+import { architectCommand } from "./commands/architect.js";
 
 const PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
 const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
@@ -188,6 +192,59 @@ program
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
       await planCommand({ task, config, logger, json: flags.json, context: flags.context });
+    });
+  });
+
+program
+  .command("discover")
+  .description("Analyze task for gaps, ambiguities and missing info")
+  .argument("<task>")
+  .option("--mode <name>", "Discovery mode: gaps|momtest|wendel|classify|jtbd", "gaps")
+  .option("--discover <name>", "Override discover agent")
+  .option("--discover-model <name>", "Override discover model")
+  .option("--json", "Output raw JSON")
+  .action(async (task, flags) => {
+    await withConfig("discover", flags, async ({ config, logger }) => {
+      await discoverCommand({ task, config, logger, mode: flags.mode, json: flags.json });
+    });
+  });
+
+program
+  .command("triage")
+  .description("Classify task complexity and recommend pipeline roles")
+  .argument("<task>")
+  .option("--triage <name>", "Override triage agent")
+  .option("--triage-model <name>", "Override triage model")
+  .option("--json", "Output raw JSON")
+  .action(async (task, flags) => {
+    await withConfig("triage", flags, async ({ config, logger }) => {
+      await triageCommand({ task, config, logger, json: flags.json });
+    });
+  });
+
+program
+  .command("researcher")
+  .description("Research codebase for a task (files, patterns, constraints)")
+  .argument("<task>")
+  .option("--researcher <name>", "Override researcher agent")
+  .option("--researcher-model <name>", "Override researcher model")
+  .action(async (task, flags) => {
+    await withConfig("researcher", flags, async ({ config, logger }) => {
+      await researcherCommand({ task, config, logger });
+    });
+  });
+
+program
+  .command("architect")
+  .description("Design solution architecture (layers, patterns, contracts)")
+  .argument("<task>")
+  .option("--architect <name>", "Override architect agent")
+  .option("--architect-model <name>", "Override architect model")
+  .option("--context <text>", "Additional context (e.g. researcher output)")
+  .option("--json", "Output raw JSON")
+  .action(async (task, flags) => {
+    await withConfig("architect", flags, async ({ config, logger }) => {
+      await architectCommand({ task, config, logger, context: flags.context, json: flags.json });
     });
   });
 

--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -1,0 +1,90 @@
+import { createAgent } from "../agents/index.js";
+import { assertAgentsAvailable } from "../agents/availability.js";
+import { resolveRole } from "../config.js";
+import { buildArchitectPrompt, parseArchitectOutput } from "../prompts/architect.js";
+
+function formatArchitect(result) {
+  const lines = [];
+  lines.push(`## Architecture Design`);
+  lines.push(`**Verdict:** ${result.verdict || "unknown"}`, "");
+
+  const arch = result.architecture;
+  if (arch) {
+    if (arch.type) lines.push(`**Type:** ${arch.type}`, "");
+
+    if (arch.layers?.length) {
+      lines.push("### Layers");
+      for (const l of arch.layers) {
+        if (typeof l === "string") {
+          lines.push(`- ${l}`);
+        } else {
+          lines.push(`- **${l.name}**: ${l.responsibility || ""}`);
+        }
+      }
+      lines.push("");
+    }
+
+    if (arch.patterns?.length) {
+      lines.push("### Patterns");
+      for (const p of arch.patterns) lines.push(`- ${p}`);
+      lines.push("");
+    }
+
+    if (arch.tradeoffs?.length) {
+      lines.push("### Tradeoffs");
+      for (const t of arch.tradeoffs) {
+        lines.push(`- **${t.decision}**: ${t.rationale || ""}`);
+        if (t.alternatives?.length) lines.push(`  Alternatives: ${t.alternatives.join(", ")}`);
+      }
+      lines.push("");
+    }
+
+    if (arch.apiContracts?.length) {
+      lines.push("### API Contracts");
+      for (const c of arch.apiContracts) {
+        lines.push(`- \`${c.method || "GET"} ${c.endpoint}\``);
+      }
+      lines.push("");
+    }
+  }
+
+  if (result.questions?.length) {
+    lines.push("### Clarification Questions");
+    for (const q of result.questions) {
+      lines.push(`- ${q.question || q}`);
+    }
+    lines.push("");
+  }
+
+  if (result.summary) lines.push(`---\n${result.summary}`);
+  return lines.join("\n");
+}
+
+export async function architectCommand({ task, config, logger, context, json }) {
+  const architectRole = resolveRole(config, "architect");
+  await assertAgentsAvailable([architectRole.provider]);
+  logger.info(`Architect (${architectRole.provider}) starting...`);
+
+  const agent = createAgent(architectRole.provider, config, logger);
+  const prompt = buildArchitectPrompt({ task, researchContext: context });
+  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
+  const result = await agent.runTask({ prompt, onOutput, role: "architect" });
+
+  if (!result.ok) {
+    throw new Error(result.error || result.output || "Architect failed");
+  }
+
+  const parsed = parseArchitectOutput(result.output);
+
+  if (json) {
+    console.log(JSON.stringify(parsed || result.output, null, 2));
+    return;
+  }
+
+  if (parsed?.verdict) {
+    console.log(formatArchitect(parsed));
+  } else {
+    console.log(result.output);
+  }
+  logger.info("Architect completed.");
+}

--- a/src/commands/discover.js
+++ b/src/commands/discover.js
@@ -1,0 +1,87 @@
+import { createAgent } from "../agents/index.js";
+import { assertAgentsAvailable } from "../agents/availability.js";
+import { resolveRole } from "../config.js";
+import { buildDiscoverPrompt, parseDiscoverOutput } from "../prompts/discover.js";
+import { parseMaybeJsonString } from "../review/parser.js";
+
+function formatDiscover(result, mode) {
+  const lines = [];
+  lines.push(`## Discovery (${mode})`);
+  lines.push(`**Verdict:** ${result.verdict || "unknown"}`, "");
+
+  if (result.gaps?.length) {
+    lines.push("## Gaps");
+    for (const g of result.gaps) {
+      const sev = g.severity ? ` [${g.severity}]` : "";
+      lines.push(`- ${g.description || g}${sev}`);
+      if (g.suggestedQuestion) lines.push(`  → ${g.suggestedQuestion}`);
+    }
+    lines.push("");
+  }
+
+  if (result.momTestQuestions?.length) {
+    lines.push("## Mom Test Questions");
+    for (const q of result.momTestQuestions) {
+      lines.push(`- ${q.question || q}`);
+      if (q.rationale) lines.push(`  _${q.rationale}_`);
+    }
+    lines.push("");
+  }
+
+  if (result.wendelChecklist?.length) {
+    lines.push("## Wendel Checklist");
+    for (const w of result.wendelChecklist) {
+      const icon = w.status === "pass" ? "✓" : w.status === "fail" ? "✗" : "?";
+      lines.push(`- [${icon}] ${w.condition}: ${w.justification || ""}`);
+    }
+    lines.push("");
+  }
+
+  if (result.classification) {
+    lines.push("## Classification");
+    lines.push(`- Type: ${result.classification.type}`);
+    if (result.classification.adoptionRisk) lines.push(`- Adoption risk: ${result.classification.adoptionRisk}`);
+    if (result.classification.frictionEstimate) lines.push(`- Friction: ${result.classification.frictionEstimate}`);
+    lines.push("");
+  }
+
+  if (result.jtbds?.length) {
+    lines.push("## Jobs-to-be-Done");
+    for (const j of result.jtbds) {
+      lines.push(`- **${j.id || ""}**: ${j.functional || j}`);
+    }
+    lines.push("");
+  }
+
+  if (result.summary) lines.push(`---\n${result.summary}`);
+  return lines.join("\n");
+}
+
+export async function discoverCommand({ task, config, logger, mode, json }) {
+  const discoverRole = resolveRole(config, "discover");
+  await assertAgentsAvailable([discoverRole.provider]);
+  logger.info(`Discover (${discoverRole.provider}) starting — mode: ${mode || "gaps"}...`);
+
+  const agent = createAgent(discoverRole.provider, config, logger);
+  const prompt = buildDiscoverPrompt({ task, mode: mode || "gaps" });
+  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
+  const result = await agent.runTask({ prompt, onOutput, role: "discover" });
+
+  if (!result.ok) {
+    throw new Error(result.error || result.output || "Discover failed");
+  }
+
+  const parsed = parseDiscoverOutput(result.output);
+
+  if (json) {
+    console.log(JSON.stringify(parsed || result.output, null, 2));
+    return;
+  }
+
+  if (parsed?.verdict) {
+    console.log(formatDiscover(parsed, mode || "gaps"));
+  } else {
+    console.log(result.output);
+  }
+  logger.info("Discover completed.");
+}

--- a/src/commands/researcher.js
+++ b/src/commands/researcher.js
@@ -1,0 +1,40 @@
+import { createAgent } from "../agents/index.js";
+import { assertAgentsAvailable } from "../agents/availability.js";
+import { resolveRole } from "../config.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on researching the codebase."
+].join(" ");
+
+function buildResearchPrompt(task) {
+  return [
+    SUBAGENT_PREAMBLE,
+    "Investigate the codebase for the following task.",
+    "Identify affected files, patterns, constraints, prior decisions, risks, and test coverage.",
+    "Return a single valid JSON object with your findings and nothing else.",
+    '{"affected_files":[string],"patterns":[string],"constraints":[string],"prior_decisions":[string],"risks":[string],"test_coverage":string}',
+    `## Task\n${task}`
+  ].join("\n\n");
+}
+
+export async function researcherCommand({ task, config, logger }) {
+  const researcherRole = resolveRole(config, "researcher");
+  await assertAgentsAvailable([researcherRole.provider]);
+  logger.info(`Researcher (${researcherRole.provider}) starting...`);
+
+  const agent = createAgent(researcherRole.provider, config, logger);
+  const prompt = buildResearchPrompt(task);
+  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
+  const result = await agent.runTask({ prompt, onOutput, role: "researcher" });
+
+  if (!result.ok) {
+    throw new Error(result.error || result.output || "Researcher failed");
+  }
+
+  if (result.output) {
+    console.log(result.output);
+  }
+  logger.info("Researcher completed.");
+}

--- a/src/commands/triage.js
+++ b/src/commands/triage.js
@@ -1,0 +1,63 @@
+import { createAgent } from "../agents/index.js";
+import { assertAgentsAvailable } from "../agents/availability.js";
+import { resolveRole } from "../config.js";
+import { buildTriagePrompt } from "../prompts/triage.js";
+import { parseMaybeJsonString } from "../review/parser.js";
+
+function formatTriage(result) {
+  const lines = [];
+  lines.push(`## Triage Result`);
+  lines.push(`- **Level:** ${result.level || "unknown"}`);
+  if (result.taskType) lines.push(`- **Task type:** ${result.taskType}`);
+  if (result.reasoning) lines.push(`- **Reasoning:** ${result.reasoning}`);
+  lines.push("");
+
+  if (result.roles?.length) {
+    lines.push("### Recommended Roles");
+    for (const r of result.roles) {
+      lines.push(`- ${r}`);
+    }
+    lines.push("");
+  }
+
+  if (result.shouldDecompose) {
+    lines.push("### Decomposition Suggested");
+    if (result.subtasks?.length) {
+      for (const s of result.subtasks) {
+        lines.push(`- ${typeof s === "string" ? s : s.title || s}`);
+      }
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export async function triageCommand({ task, config, logger, json }) {
+  const triageRole = resolveRole(config, "triage");
+  await assertAgentsAvailable([triageRole.provider]);
+  logger.info(`Triage (${triageRole.provider}) starting...`);
+
+  const agent = createAgent(triageRole.provider, config, logger);
+  const prompt = buildTriagePrompt({ task });
+  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
+  const result = await agent.runTask({ prompt, onOutput, role: "triage" });
+
+  if (!result.ok) {
+    throw new Error(result.error || result.output || "Triage failed");
+  }
+
+  const parsed = parseMaybeJsonString(result.output);
+
+  if (json) {
+    console.log(JSON.stringify(parsed || result.output, null, 2));
+    return;
+  }
+
+  if (parsed?.level) {
+    console.log(formatTriage(parsed));
+  } else {
+    console.log(result.output);
+  }
+  logger.info("Triage completed.");
+}

--- a/tests/command-architect.test.js
+++ b/tests/command-architect.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/prompts/architect.js", () => ({
+  buildArchitectPrompt: vi.fn().mockReturnValue("architect prompt"),
+  parseArchitectOutput: vi.fn().mockReturnValue({
+    verdict: "ready",
+    architecture: { type: "layered", layers: ["domain", "application", "infrastructure"] },
+    summary: "Architecture designed"
+  })
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { architect: { provider: "claude" } },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/architect", () => {
+  let createAgent, assertAgentsAvailable, buildArchitectPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const prompts = await import("../src/prompts/architect.js");
+    buildArchitectPrompt = prompts.buildArchitectPrompt;
+    buildArchitectPrompt.mockReturnValue("architect prompt");
+    prompts.parseArchitectOutput.mockReturnValue({
+      verdict: "ready",
+      architecture: { type: "layered", layers: ["domain", "application", "infrastructure"] },
+      summary: "Architecture designed"
+    });
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"verdict":"ready"}', exitCode: 0 })
+    });
+  });
+
+  it("asserts architect provider is available", async () => {
+    const { architectCommand } = await import("../src/commands/architect.js");
+    await architectCommand({ task: "design auth system", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("builds prompt with task and context", async () => {
+    const { architectCommand } = await import("../src/commands/architect.js");
+    await architectCommand({ task: "design auth", config: makeConfig(), logger: noopLogger, context: "uses Firebase" });
+
+    expect(buildArchitectPrompt).toHaveBeenCalledWith({ task: "design auth", researchContext: "uses Firebase" });
+  });
+
+  it("throws when architect fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "design error", exitCode: 1 })
+    });
+
+    const { architectCommand } = await import("../src/commands/architect.js");
+    await expect(
+      architectCommand({ task: "bad task", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("design error");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { architectCommand } = await import("../src/commands/architect.js");
+    await architectCommand({ task: "design auth", config: makeConfig(), logger: noopLogger, json: true });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("ready"));
+    spy.mockRestore();
+  });
+});

--- a/tests/command-discover.test.js
+++ b/tests/command-discover.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/prompts/discover.js", () => ({
+  buildDiscoverPrompt: vi.fn().mockReturnValue("discover prompt"),
+  parseDiscoverOutput: vi.fn().mockReturnValue({
+    verdict: "needs_validation",
+    gaps: [{ description: "Missing DB schema", severity: "high" }],
+    summary: "1 gap found"
+  })
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { discover: { provider: "claude" } },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/discover", () => {
+  let createAgent, assertAgentsAvailable, buildDiscoverPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const prompts = await import("../src/prompts/discover.js");
+    buildDiscoverPrompt = prompts.buildDiscoverPrompt;
+    buildDiscoverPrompt.mockReturnValue("discover prompt");
+    prompts.parseDiscoverOutput.mockReturnValue({
+      verdict: "needs_validation",
+      gaps: [{ description: "Missing DB schema", severity: "high" }],
+      summary: "1 gap found"
+    });
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"verdict":"needs_validation"}', exitCode: 0 })
+    });
+  });
+
+  it("asserts discover provider is available", async () => {
+    const { discoverCommand } = await import("../src/commands/discover.js");
+    await discoverCommand({ task: "add login", config: makeConfig(), logger: noopLogger, mode: "gaps" });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("builds prompt with task and mode", async () => {
+    const { discoverCommand } = await import("../src/commands/discover.js");
+    await discoverCommand({ task: "add login", config: makeConfig(), logger: noopLogger, mode: "momtest" });
+
+    expect(buildDiscoverPrompt).toHaveBeenCalledWith({ task: "add login", mode: "momtest" });
+  });
+
+  it("defaults mode to gaps", async () => {
+    const { discoverCommand } = await import("../src/commands/discover.js");
+    await discoverCommand({ task: "add login", config: makeConfig(), logger: noopLogger });
+
+    expect(buildDiscoverPrompt).toHaveBeenCalledWith({ task: "add login", mode: "gaps" });
+  });
+
+  it("throws when discover fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "agent error", exitCode: 1 })
+    });
+
+    const { discoverCommand } = await import("../src/commands/discover.js");
+    await expect(
+      discoverCommand({ task: "bad task", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("agent error");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { discoverCommand } = await import("../src/commands/discover.js");
+    await discoverCommand({ task: "add login", config: makeConfig(), logger: noopLogger, json: true });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("needs_validation"));
+    spy.mockRestore();
+  });
+});

--- a/tests/command-researcher.test.js
+++ b/tests/command-researcher.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { researcher: { provider: "claude" } },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/researcher", () => {
+  let createAgent, assertAgentsAvailable;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"affected_files":["src/foo.js"]}', exitCode: 0 })
+    });
+  });
+
+  it("asserts researcher provider is available", async () => {
+    const { researcherCommand } = await import("../src/commands/researcher.js");
+    await researcherCommand({ task: "investigate auth", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("runs task with researcher role", async () => {
+    const { researcherCommand } = await import("../src/commands/researcher.js");
+    await researcherCommand({ task: "investigate auth", config: makeConfig(), logger: noopLogger });
+
+    const agent = createAgent.mock.results[0].value;
+    expect(agent.runTask).toHaveBeenCalledWith(expect.objectContaining({
+      role: "researcher"
+    }));
+  });
+
+  it("throws when researcher fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "research error", exitCode: 1 })
+    });
+
+    const { researcherCommand } = await import("../src/commands/researcher.js");
+    await expect(
+      researcherCommand({ task: "bad task", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("research error");
+  });
+
+  it("outputs result on success", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { researcherCommand } = await import("../src/commands/researcher.js");
+    await researcherCommand({ task: "investigate auth", config: makeConfig(), logger: noopLogger });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("affected_files"));
+    spy.mockRestore();
+  });
+});

--- a/tests/command-triage.test.js
+++ b/tests/command-triage.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/prompts/triage.js", () => ({
+  buildTriagePrompt: vi.fn().mockReturnValue("triage prompt")
+}));
+
+vi.mock("../src/review/parser.js", () => ({
+  parseMaybeJsonString: vi.fn().mockReturnValue({
+    level: "medium",
+    taskType: "sw",
+    roles: ["reviewer", "tester"],
+    reasoning: "Moderate complexity task"
+  })
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { triage: { provider: "claude" } },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/triage", () => {
+  let createAgent, assertAgentsAvailable;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"level":"medium"}', exitCode: 0 })
+    });
+  });
+
+  it("asserts triage provider is available", async () => {
+    const { triageCommand } = await import("../src/commands/triage.js");
+    await triageCommand({ task: "add feature", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("throws when triage fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "triage error", exitCode: 1 })
+    });
+
+    const { triageCommand } = await import("../src/commands/triage.js");
+    await expect(
+      triageCommand({ task: "bad task", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("triage error");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { triageCommand } = await import("../src/commands/triage.js");
+    await triageCommand({ task: "add feature", config: makeConfig(), logger: noopLogger, json: true });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("medium"));
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `kj discover`, `kj triage`, `kj researcher`, `kj architect` as clean standalone CLI commands
- Replaces the need for `kj run --enable-discover` / `--enable-architect` for standalone usage
- Each command follows the same pattern as existing `kj code`, `kj review`, `kj plan`
- The `--enable-*` flags remain available for pipeline integration via `kj run`

## New commands
| Command | Description | Key flags |
|---------|-------------|-----------|
| `kj discover "task"` | Analyze task for gaps/ambiguities | `--mode gaps\|momtest\|wendel\|classify\|jtbd`, `--json` |
| `kj triage "task"` | Classify complexity, recommend roles | `--json` |
| `kj researcher "task"` | Research codebase (files, patterns, risks) | |
| `kj architect "task"` | Design solution architecture | `--context`, `--json` |

## Test plan
- [x] 16 new tests for all 4 commands (command-discover, command-triage, command-researcher, command-architect)
- [x] Full suite: 1532 tests passing
- [x] `kj --help` shows all 4 new commands