### PR TITLE
feat(mcp): standalone kj_triage, kj_researcher, kj_architect tools

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -469,6 +469,138 @@ export async function handleDiscoverDirect(a, server, extra) {
   return { ok: true, ...result.result, summary: result.summary };
 }
 
+export async function handleTriageDirect(a, server, extra) {
+  const config = await buildConfig(a, "triage");
+  const logger = createLogger(config.output.log_level, "mcp");
+
+  const triageRole = resolveRole(config, "triage");
+  await assertAgentsAvailable([triageRole.provider]);
+
+  const projectDir = await resolveProjectDir(server);
+  const runLog = createRunLog(projectDir);
+  runLog.logText(`[kj_triage] started`);
+  const emitter = buildDirectEmitter(server, runLog, extra);
+  const eventBase = { sessionId: null, iteration: 0, startedAt: Date.now() };
+  const onOutput = ({ stream, line }) => {
+    emitter.emit("progress", { type: "agent:output", stage: "triage", message: line, detail: { stream, agent: triageRole.provider } });
+  };
+  const stallDetector = createStallDetector({
+    onOutput, emitter, eventBase, stage: "triage", provider: triageRole.provider
+  });
+
+  const { TriageRole } = await import("../roles/triage-role.js");
+  const triage = new TriageRole({ config, logger, emitter });
+  await triage.init({ task: a.task });
+
+  sendTrackerLog(server, "triage", "running", triageRole.provider);
+  runLog.logText(`[triage] agent launched, waiting for response...`);
+  let result;
+  try {
+    result = await triage.run({ task: a.task, onOutput: stallDetector.onOutput });
+  } finally {
+    stallDetector.stop();
+    const stats = stallDetector.stats();
+    runLog.logText(`[triage] finished — lines=${stats.lineCount}, bytes=${stats.bytesReceived}, elapsed=${Math.round(stats.elapsedMs / 1000)}s`);
+    runLog.close();
+  }
+
+  if (!result.ok) {
+    sendTrackerLog(server, "triage", "failed");
+    throw new Error(result.result?.error || result.summary || "Triage failed");
+  }
+
+  sendTrackerLog(server, "triage", "done");
+  return { ok: true, ...result.result, summary: result.summary };
+}
+
+export async function handleResearcherDirect(a, server, extra) {
+  const config = await buildConfig(a, "researcher");
+  const logger = createLogger(config.output.log_level, "mcp");
+
+  const researcherRole = resolveRole(config, "researcher");
+  await assertAgentsAvailable([researcherRole.provider]);
+
+  const projectDir = await resolveProjectDir(server);
+  const runLog = createRunLog(projectDir);
+  runLog.logText(`[kj_researcher] started`);
+  const emitter = buildDirectEmitter(server, runLog, extra);
+  const eventBase = { sessionId: null, iteration: 0, startedAt: Date.now() };
+  const onOutput = ({ stream, line }) => {
+    emitter.emit("progress", { type: "agent:output", stage: "researcher", message: line, detail: { stream, agent: researcherRole.provider } });
+  };
+  const stallDetector = createStallDetector({
+    onOutput, emitter, eventBase, stage: "researcher", provider: researcherRole.provider
+  });
+
+  const { ResearcherRole } = await import("../roles/researcher-role.js");
+  const researcher = new ResearcherRole({ config, logger, emitter });
+  await researcher.init({ task: a.task });
+
+  sendTrackerLog(server, "researcher", "running", researcherRole.provider);
+  runLog.logText(`[researcher] agent launched, waiting for response...`);
+  let result;
+  try {
+    result = await researcher.run({ task: a.task, onOutput: stallDetector.onOutput });
+  } finally {
+    stallDetector.stop();
+    const stats = stallDetector.stats();
+    runLog.logText(`[researcher] finished — lines=${stats.lineCount}, bytes=${stats.bytesReceived}, elapsed=${Math.round(stats.elapsedMs / 1000)}s`);
+    runLog.close();
+  }
+
+  if (!result.ok) {
+    sendTrackerLog(server, "researcher", "failed");
+    throw new Error(result.result?.error || result.summary || "Researcher failed");
+  }
+
+  sendTrackerLog(server, "researcher", "done");
+  return { ok: true, ...result.result, summary: result.summary };
+}
+
+export async function handleArchitectDirect(a, server, extra) {
+  const config = await buildConfig(a, "architect");
+  const logger = createLogger(config.output.log_level, "mcp");
+
+  const architectRole = resolveRole(config, "architect");
+  await assertAgentsAvailable([architectRole.provider]);
+
+  const projectDir = await resolveProjectDir(server);
+  const runLog = createRunLog(projectDir);
+  runLog.logText(`[kj_architect] started`);
+  const emitter = buildDirectEmitter(server, runLog, extra);
+  const eventBase = { sessionId: null, iteration: 0, startedAt: Date.now() };
+  const onOutput = ({ stream, line }) => {
+    emitter.emit("progress", { type: "agent:output", stage: "architect", message: line, detail: { stream, agent: architectRole.provider } });
+  };
+  const stallDetector = createStallDetector({
+    onOutput, emitter, eventBase, stage: "architect", provider: architectRole.provider
+  });
+
+  const { ArchitectRole } = await import("../roles/architect-role.js");
+  const architect = new ArchitectRole({ config, logger, emitter });
+  await architect.init({ task: a.task });
+
+  sendTrackerLog(server, "architect", "running", architectRole.provider);
+  runLog.logText(`[architect] agent launched, waiting for response...`);
+  let result;
+  try {
+    result = await architect.run({ task: a.task, researchContext: a.context || null, onOutput: stallDetector.onOutput });
+  } finally {
+    stallDetector.stop();
+    const stats = stallDetector.stats();
+    runLog.logText(`[architect] finished — lines=${stats.lineCount}, bytes=${stats.bytesReceived}, elapsed=${Math.round(stats.elapsedMs / 1000)}s`);
+    runLog.close();
+  }
+
+  if (!result.ok) {
+    sendTrackerLog(server, "architect", "failed");
+    throw new Error(result.result?.error || result.summary || "Architect failed");
+  }
+
+  sendTrackerLog(server, "architect", "done");
+  return { ok: true, ...result.result, summary: result.summary };
+}
+
 /* ── Preflight helpers ─────────────────────────────────────────────── */
 
 const AGENT_ROLES = new Set(["coder", "reviewer", "tester", "security", "solomon"]);
@@ -662,6 +794,27 @@ async function handleDiscover(a, server, extra) {
   return handleDiscoverDirect(a, server, extra);
 }
 
+async function handleTriage(a, server, extra) {
+  if (!a.task) {
+    return failPayload("Missing required field: task");
+  }
+  return handleTriageDirect(a, server, extra);
+}
+
+async function handleResearcher(a, server, extra) {
+  if (!a.task) {
+    return failPayload("Missing required field: task");
+  }
+  return handleResearcherDirect(a, server, extra);
+}
+
+async function handleArchitect(a, server, extra) {
+  if (!a.task) {
+    return failPayload("Missing required field: task");
+  }
+  return handleArchitectDirect(a, server, extra);
+}
+
 /* ── Handler dispatch map ─────────────────────────────────────────── */
 
 const toolHandlers = {
@@ -679,7 +832,10 @@ const toolHandlers = {
   kj_code:      (a, server, extra) => handleCode(a, server, extra),
   kj_review:    (a, server, extra) => handleReview(a, server, extra),
   kj_plan:      (a, server, extra) => handlePlan(a, server, extra),
-  kj_discover:  (a, server, extra) => handleDiscover(a, server, extra)
+  kj_discover:    (a, server, extra) => handleDiscover(a, server, extra),
+  kj_triage:      (a, server, extra) => handleTriage(a, server, extra),
+  kj_researcher:  (a, server, extra) => handleResearcher(a, server, extra),
+  kj_architect:   (a, server, extra) => handleArchitect(a, server, extra)
 };
 
 export async function handleToolCall(name, args, server, extra) {

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -242,5 +242,42 @@ export const tools = [
         kjHome: { type: "string" }
       }
     }
+  },
+  {
+    name: "kj_triage",
+    description: "Classify task complexity and recommend which pipeline roles to activate. Returns level (trivial/simple/medium/complex), taskType, recommended roles, and optional decomposition.",
+    inputSchema: {
+      type: "object",
+      required: ["task"],
+      properties: {
+        task: { type: "string", description: "Task description to classify" },
+        kjHome: { type: "string" }
+      }
+    }
+  },
+  {
+    name: "kj_researcher",
+    description: "Research the codebase for a task. Identifies affected files, patterns, constraints, prior decisions, risks, and test coverage.",
+    inputSchema: {
+      type: "object",
+      required: ["task"],
+      properties: {
+        task: { type: "string", description: "Task description to research" },
+        kjHome: { type: "string" }
+      }
+    }
+  },
+  {
+    name: "kj_architect",
+    description: "Design solution architecture for a task. Returns layers, patterns, data model, API contracts, tradeoffs, and a verdict (ready/needs_clarification).",
+    inputSchema: {
+      type: "object",
+      required: ["task"],
+      properties: {
+        task: { type: "string", description: "Task description to architect" },
+        context: { type: "string", description: "Additional context (e.g., researcher output)" },
+        kjHome: { type: "string" }
+      }
+    }
   }
 ];

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tools } from "../src/mcp/tools.js";
+
+describe("kj_triage MCP tool schema", () => {
+  it("is registered in tools list", () => {
+    const tool = tools.find((t) => t.name === "kj_triage");
+    expect(tool).toBeDefined();
+  });
+
+  it("requires task parameter", () => {
+    const tool = tools.find((t) => t.name === "kj_triage");
+    expect(tool.inputSchema.required).toContain("task");
+  });
+
+  it("has task as string property", () => {
+    const tool = tools.find((t) => t.name === "kj_triage");
+    expect(tool.inputSchema.properties.task.type).toBe("string");
+  });
+});
+
+describe("kj_researcher MCP tool schema", () => {
+  it("is registered in tools list", () => {
+    const tool = tools.find((t) => t.name === "kj_researcher");
+    expect(tool).toBeDefined();
+  });
+
+  it("requires task parameter", () => {
+    const tool = tools.find((t) => t.name === "kj_researcher");
+    expect(tool.inputSchema.required).toContain("task");
+  });
+});
+
+describe("kj_architect MCP tool schema", () => {
+  it("is registered in tools list", () => {
+    const tool = tools.find((t) => t.name === "kj_architect");
+    expect(tool).toBeDefined();
+  });
+
+  it("requires task parameter", () => {
+    const tool = tools.find((t) => t.name === "kj_architect");
+    expect(tool.inputSchema.required).toContain("task");
+  });
+
+  it("has context as optional string", () => {
+    const tool = tools.find((t) => t.name === "kj_architect");
+    expect(tool.inputSchema.properties.context.type).toBe("string");
+  });
+});
+
+describe("kj_triage handler validation", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("returns error when task is missing", async () => {
+    const mod = await import("../src/mcp/server-handlers.js");
+    const mockServer = { sendLoggingMessage: vi.fn(), listRoots: vi.fn().mockResolvedValue({ roots: [] }) };
+    const result = await mod.handleToolCall("kj_triage", {}, mockServer);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("task");
+  });
+});
+
+describe("kj_researcher handler validation", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("returns error when task is missing", async () => {
+    const mod = await import("../src/mcp/server-handlers.js");
+    const mockServer = { sendLoggingMessage: vi.fn(), listRoots: vi.fn().mockResolvedValue({ roots: [] }) };
+    const result = await mod.handleToolCall("kj_researcher", {}, mockServer);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("task");
+  });
+});
+
+describe("kj_architect handler validation", () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it("returns error when task is missing", async () => {
+    const mod = await import("../src/mcp/server-handlers.js");
+    const mockServer = { sendLoggingMessage: vi.fn(), listRoots: vi.fn().mockResolvedValue({ roots: [] }) };
+    const result = await mod.handleToolCall("kj_architect", {}, mockServer);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("task");
+  });
+});
+
+describe("MCP tools count", () => {
+  it("has 18 tools registered", () => {
+    expect(tools).toHaveLength(18);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `kj_triage`, `kj_researcher`, `kj_architect` as standalone MCP tools (18 total)
- In-process execution with stall detection and progress streaming (same pattern as `kj_discover`)
- Input validation: all require `task`, `kj_architect` accepts optional `context`

## New MCP tools
| Tool | Description |
|------|-------------|
| `kj_triage` | Classify task complexity, recommend roles |
| `kj_researcher` | Research codebase (files, patterns, risks) |
| `kj_architect` | Design solution architecture |

## Test plan
- [x] 12 new tests: schema validation + handler input validation for all 3 tools
- [x] Tool count assertion: 18 tools
- [x] Full suite: 1544 tests passing