### PR TITLE
feat(sonar): SonarCloud as complementary quality gate

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -97,6 +97,8 @@ program
   .option("--methodology <name>")
   .option("--no-auto-rebase")
   .option("--no-sonar")
+  .option("--enable-sonarcloud", "Enable SonarCloud scan (complementary to SonarQube)")
+  .option("--no-sonarcloud")
   .option("--checkpoint-interval <n>", "Minutes between interactive checkpoints (default: 5)")
   .option("--pg-task <cardId>", "Planning Game card ID (e.g., KJC-TSK-0042)")
   .option("--pg-project <projectId>", "Planning Game project ID")

--- a/src/config.js
+++ b/src/config.js
@@ -101,6 +101,18 @@ const DEFAULTS = {
       disabled_rules: ["javascript:S1116", "javascript:S3776"]
     }
   },
+  sonarcloud: {
+    enabled: false,
+    organization: null,
+    token: null,
+    project_key: null,
+    host: "https://sonarcloud.io",
+    scanner: {
+      sources: "src,public,lib",
+      exclusions: "**/node_modules/**,**/dist/**,**/build/**,**/*.min.js",
+      test_inclusions: "**/*.test.js,**/*.spec.js,**/tests/**,**/__tests__/**"
+    }
+  },
   policies: {},
   serena: { enabled: false },
   planning_game: { enabled: false, project_id: null, codeveloper: null },
@@ -347,6 +359,9 @@ function applyBecariaOverride(out, flags) {
 
 function applyMiscOverrides(out, flags) {
   if (flags.noSonar || flags.sonar === false) out.sonarqube.enabled = false;
+  out.sonarcloud = out.sonarcloud || {};
+  if (flags.enableSonarcloud === true) out.sonarcloud.enabled = true;
+  if (flags.noSonarcloud === true || flags.sonarcloud === false) out.sonarcloud.enabled = false;
 
   out.planning_game = out.planning_game || {};
   if (flags.pgTask) out.planning_game.enabled = true;

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -93,6 +93,7 @@ export const tools = [
         checkpointInterval: { type: "number", description: "Minutes between interactive checkpoints (default: 5). Set 0 to disable." },
         taskType: { type: "string", enum: ["sw", "infra", "doc", "add-tests", "refactor"], description: "Explicit task type for policy resolution. Overrides triage classification." },
         noSonar: { type: "boolean" },
+        enableSonarcloud: { type: "boolean", description: "Enable SonarCloud scan (complementary to SonarQube)" },
         kjHome: { type: "string" },
         sonarToken: { type: "string" },
         timeoutMs: { type: "number" }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -30,7 +30,7 @@ import { resolveReviewProfile } from "./review/profiles.js";
 import { CoderRole } from "./roles/coder-role.js";
 import { invokeSolomon } from "./orchestrator/solomon-escalation.js";
 import { runTriageStage, runResearcherStage, runArchitectStage, runPlannerStage, runDiscoverStage } from "./orchestrator/pre-loop-stages.js";
-import { runCoderStage, runRefactorerStage, runTddCheckStage, runSonarStage, runReviewerStage } from "./orchestrator/iteration-stages.js";
+import { runCoderStage, runRefactorerStage, runTddCheckStage, runSonarStage, runSonarCloudStage, runReviewerStage } from "./orchestrator/iteration-stages.js";
 import { runTesterStage, runSecurityStage } from "./orchestrator/post-loop-stages.js";
 import { waitForCooldown, MAX_STANDBY_RETRIES } from "./orchestrator/standby.js";
 
@@ -907,6 +907,15 @@ async function runQualityGateStages({ config, logger, emitter, eventBase, sessio
     if (sonarResult.stageResult) {
       stageResults.sonar = sonarResult.stageResult;
       await tryBecariaComment({ config, session, logger, agent: "Sonar", body: `SonarQube scan: ${sonarResult.stageResult.summary || "completed"}` });
+    }
+  }
+
+  if (config.sonarcloud?.enabled) {
+    const cloudResult = await runSonarCloudStage({
+      config, logger, emitter, eventBase, session, trackBudget, iteration: i
+    });
+    if (cloudResult.stageResult) {
+      stageResults.sonarcloud = cloudResult.stageResult;
     }
   }
 

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -427,6 +427,47 @@ export async function runSonarStage({ config, logger, emitter, eventBase, sessio
   return { action: "ok", stageResult };
 }
 
+export async function runSonarCloudStage({ config, logger, emitter, eventBase, session, trackBudget, iteration }) {
+  logger.setContext({ iteration, stage: "sonarcloud" });
+  emitProgress(
+    emitter,
+    makeEvent("sonarcloud:start", { ...eventBase, stage: "sonarcloud" }, {
+      message: "SonarCloud scanning"
+    })
+  );
+
+  const { runSonarCloudScan } = await import("../sonar/cloud-scanner.js");
+  const scanStart = Date.now();
+  const result = await runSonarCloudScan(config);
+  trackBudget({ role: "sonarcloud", provider: "sonarcloud", result: { ok: result.ok }, duration_ms: Date.now() - scanStart });
+
+  await addCheckpoint(session, {
+    stage: "sonarcloud",
+    iteration,
+    project_key: result.projectKey,
+    exitCode: result.exitCode,
+    provider: "sonarcloud",
+    model: null
+  });
+
+  const status = result.ok ? "ok" : "warn";
+  const message = result.ok
+    ? `SonarCloud scan passed (project: ${result.projectKey})`
+    : `SonarCloud scan issue: ${(result.stderr || "").slice(0, 200)}`;
+
+  emitProgress(
+    emitter,
+    makeEvent("sonarcloud:end", { ...eventBase, stage: "sonarcloud" }, {
+      status,
+      message,
+      detail: { projectKey: result.projectKey, exitCode: result.exitCode }
+    })
+  );
+
+  // SonarCloud is advisory — never blocks the pipeline
+  return { action: "ok", stageResult: { ok: result.ok, projectKey: result.projectKey, message } };
+}
+
 async function handleReviewerStalledSolomon({ review, repeatCounts, repeatState, config, logger, emitter, eventBase, session, iteration, task, askQuestion, budgetSummary, repeatDetector }) {
   logger.warn(`Reviewer stalled (${repeatCounts.reviewer} repeats). Invoking Solomon mediation.`);
   emitProgress(

--- a/src/sonar/cloud-scanner.js
+++ b/src/sonar/cloud-scanner.js
@@ -1,0 +1,76 @@
+import { runCommand } from "../utils/process.js";
+import { resolveSonarProjectKey } from "./project-key.js";
+
+function buildCloudScannerArgs(projectKey, config) {
+  const sc = config.sonarcloud || {};
+  const scanner = sc.scanner || {};
+  const host = sc.host || "https://sonarcloud.io";
+  const token = process.env.KJ_SONARCLOUD_TOKEN || sc.token;
+  const organization = process.env.KJ_SONARCLOUD_ORG || sc.organization;
+
+  const args = [
+    `-Dsonar.host.url=${host}`,
+    `-Dsonar.projectKey=${projectKey}`
+  ];
+
+  if (token) args.push(`-Dsonar.token=${token}`);
+  if (organization) args.push(`-Dsonar.organization=${organization}`);
+  if (scanner.sources) args.push(`-Dsonar.sources=${scanner.sources}`);
+  if (scanner.exclusions) args.push(`-Dsonar.exclusions=${scanner.exclusions}`);
+  if (scanner.test_inclusions) args.push(`-Dsonar.test.inclusions=${scanner.test_inclusions}`);
+
+  return args;
+}
+
+export async function runSonarCloudScan(config, projectKey = null) {
+  const sc = config.sonarcloud || {};
+  const token = process.env.KJ_SONARCLOUD_TOKEN || sc.token;
+  const organization = sc.organization || process.env.KJ_SONARCLOUD_ORG;
+
+  if (!token) {
+    return {
+      ok: false,
+      projectKey: null,
+      stdout: "",
+      stderr: "SonarCloud token not configured. Set sonarcloud.token in kj.config.yml or KJ_SONARCLOUD_TOKEN env var.",
+      exitCode: 1
+    };
+  }
+
+  if (!organization) {
+    return {
+      ok: false,
+      projectKey: null,
+      stdout: "",
+      stderr: "SonarCloud organization not configured. Set sonarcloud.organization in kj.config.yml or KJ_SONARCLOUD_ORG env var.",
+      exitCode: 1
+    };
+  }
+
+  let effectiveProjectKey;
+  try {
+    effectiveProjectKey = projectKey || sc.project_key || await resolveSonarProjectKey(config, { projectKey });
+  } catch (error) {
+    return {
+      ok: false,
+      projectKey: null,
+      stdout: "",
+      stderr: error?.message || String(error),
+      exitCode: 1
+    };
+  }
+
+  const scannerTimeout = 15 * 60 * 1000;
+  const args = buildCloudScannerArgs(effectiveProjectKey, config);
+
+  // Use npx @sonar/scan (no Docker needed)
+  const result = await runCommand("npx", ["@sonar/scan", ...args], { timeout: scannerTimeout });
+
+  return {
+    ok: result.exitCode === 0,
+    projectKey: effectiveProjectKey,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode
+  };
+}

--- a/tests/sonarcloud-scanner.test.js
+++ b/tests/sonarcloud-scanner.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/sonar/project-key.js", () => ({
+  resolveSonarProjectKey: vi.fn().mockResolvedValue("test-project")
+}));
+
+describe("runSonarCloudScan", () => {
+  let runCommand;
+  const savedEnv = {};
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    savedEnv.KJ_SONARCLOUD_TOKEN = process.env.KJ_SONARCLOUD_TOKEN;
+    savedEnv.KJ_SONARCLOUD_ORG = process.env.KJ_SONARCLOUD_ORG;
+    delete process.env.KJ_SONARCLOUD_TOKEN;
+    delete process.env.KJ_SONARCLOUD_ORG;
+
+    const proc = await import("../src/utils/process.js");
+    runCommand = proc.runCommand;
+  });
+
+  afterEach(() => {
+    if (savedEnv.KJ_SONARCLOUD_TOKEN !== undefined) process.env.KJ_SONARCLOUD_TOKEN = savedEnv.KJ_SONARCLOUD_TOKEN;
+    else delete process.env.KJ_SONARCLOUD_TOKEN;
+    if (savedEnv.KJ_SONARCLOUD_ORG !== undefined) process.env.KJ_SONARCLOUD_ORG = savedEnv.KJ_SONARCLOUD_ORG;
+    else delete process.env.KJ_SONARCLOUD_ORG;
+  });
+
+  it("fails when token is missing", async () => {
+    const { runSonarCloudScan } = await import("../src/sonar/cloud-scanner.js");
+    const result = await runSonarCloudScan({ sonarcloud: { organization: "org" } });
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("token");
+  });
+
+  it("fails when organization is missing", async () => {
+    const { runSonarCloudScan } = await import("../src/sonar/cloud-scanner.js");
+    const result = await runSonarCloudScan({ sonarcloud: { token: "sqc_xxx" } });
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("organization");
+  });
+
+  it("runs npx @sonar/scan with correct args", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+
+    const { runSonarCloudScan } = await import("../src/sonar/cloud-scanner.js");
+    const result = await runSonarCloudScan({
+      sonarcloud: {
+        token: "sqc_test",
+        organization: "myorg",
+        project_key: "my-project",
+        scanner: { sources: "src" }
+      }
+    });
+
+    expect(result.ok).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith(
+      "npx",
+      expect.arrayContaining([
+        "@sonar/scan",
+        "-Dsonar.host.url=https://sonarcloud.io",
+        "-Dsonar.projectKey=my-project",
+        "-Dsonar.token=sqc_test",
+        "-Dsonar.organization=myorg"
+      ]),
+      expect.any(Object)
+    );
+  });
+
+  it("uses env vars for token and org", async () => {
+    process.env.KJ_SONARCLOUD_TOKEN = "env_token";
+    process.env.KJ_SONARCLOUD_ORG = "env_org";
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "ok", stderr: "" });
+
+    const { runSonarCloudScan } = await import("../src/sonar/cloud-scanner.js");
+    const result = await runSonarCloudScan({ sonarcloud: { project_key: "proj" } });
+
+    expect(result.ok).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith(
+      "npx",
+      expect.arrayContaining(["-Dsonar.token=env_token", "-Dsonar.organization=env_org"]),
+      expect.any(Object)
+    );
+  });
+
+  it("returns failure when scan exits non-zero", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "scan failed" });
+
+    const { runSonarCloudScan } = await import("../src/sonar/cloud-scanner.js");
+    const result = await runSonarCloudScan({
+      sonarcloud: { token: "sqc_test", organization: "myorg", project_key: "proj" }
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add SonarCloud support as a **complement** to SonarQube (both can run together)
- SonarCloud uses `npx @sonar/scan` (no Docker required)
- Advisory mode: reports results but never blocks the pipeline
- Runs after SonarQube in the quality gate stage

## Configuration
```yaml
sonarcloud:
  enabled: true
  organization: "myorg"
  token: "sqc_xxx"
  project_key: "my-project"
```

Or via env vars: `KJ_SONARCLOUD_TOKEN`, `KJ_SONARCLOUD_ORG`

## CLI / MCP
- `kj run "task" --enable-sonarcloud`
- `kj_run({ task: "...", enableSonarcloud: true })`

## Test plan
- [x] 5 new tests: token/org validation, scanner args, env vars, failure handling
- [x] Full suite: 1549 tests passing