### PR TITLE
fix(mcp): truncate kj_status lines to prevent overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/src/utils/run-log.js
+++ b/src/utils/run-log.js
@@ -183,13 +183,15 @@ export function readRunLog(projectDir, maxLines = 50) {
     const total = lines.length;
     const shown = lines.slice(-maxLines);
     const status = parseRunStatus(lines);
+    const MAX_LINE_CHARS = 2000;
+    const truncated = shown.map(l => l.length > MAX_LINE_CHARS ? l.slice(0, MAX_LINE_CHARS) + "… [truncated]" : l);
     return {
       ok: true,
       path: logPath,
       totalLines: total,
       status,
-      lines: shown,
-      summary: shown.join("\n")
+      lines: truncated,
+      summary: truncated.join("\n")
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- Truncate each run-log line to 2000 chars max in `kj_status` output
- Prevents MCP result overflow when agent output lines are very long (157K+ chars observed)
- Lines exceeding limit show `… [truncated]` suffix

## Test plan
- [x] `run-log.test.js` — 14 tests pass
- [ ] Manual: run `kj_status` on a session with large agent output, verify no overflow