### PR TITLE
feat(mcp): resilient run with auto-resume on failure

### DIFF
--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -3,56 +3,53 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildArchitectPrompt, parseArchitectOutput } from "../prompts/architect.js";
 
+function formatLayers(layers, lines) {
+  lines.push("### Layers");
+  for (const l of layers) {
+    lines.push(typeof l === "string" ? `- ${l}` : `- **${l.name}**: ${l.responsibility || ""}`);
+  }
+  lines.push("");
+}
+
+function formatTradeoffs(tradeoffs, lines) {
+  lines.push("### Tradeoffs");
+  for (const t of tradeoffs) {
+    lines.push(`- **${t.decision}**: ${t.rationale || ""}`);
+    if (t.alternatives?.length) lines.push(`  Alternatives: ${t.alternatives.join(", ")}`);
+  }
+  lines.push("");
+}
+
+function formatApiContracts(contracts, lines) {
+  lines.push("### API Contracts");
+  for (const c of contracts) {
+    lines.push(`- \`${c.method || "GET"} ${c.endpoint}\``);
+  }
+  lines.push("");
+}
+
+function formatArchitecture(arch, lines) {
+  if (arch.type) lines.push(`**Type:** ${arch.type}`, "");
+  if (arch.layers?.length) formatLayers(arch.layers, lines);
+  if (arch.patterns?.length) {
+    lines.push("### Patterns");
+    for (const p of arch.patterns) lines.push(`- ${p}`);
+    lines.push("");
+  }
+  if (arch.tradeoffs?.length) formatTradeoffs(arch.tradeoffs, lines);
+  if (arch.apiContracts?.length) formatApiContracts(arch.apiContracts, lines);
+}
+
 function formatArchitect(result) {
   const lines = [];
   lines.push(`## Architecture Design`);
   lines.push(`**Verdict:** ${result.verdict || "unknown"}`, "");
 
-  const arch = result.architecture;
-  if (arch) {
-    if (arch.type) lines.push(`**Type:** ${arch.type}`, "");
-
-    if (arch.layers?.length) {
-      lines.push("### Layers");
-      for (const l of arch.layers) {
-        if (typeof l === "string") {
-          lines.push(`- ${l}`);
-        } else {
-          lines.push(`- **${l.name}**: ${l.responsibility || ""}`);
-        }
-      }
-      lines.push("");
-    }
-
-    if (arch.patterns?.length) {
-      lines.push("### Patterns");
-      for (const p of arch.patterns) lines.push(`- ${p}`);
-      lines.push("");
-    }
-
-    if (arch.tradeoffs?.length) {
-      lines.push("### Tradeoffs");
-      for (const t of arch.tradeoffs) {
-        lines.push(`- **${t.decision}**: ${t.rationale || ""}`);
-        if (t.alternatives?.length) lines.push(`  Alternatives: ${t.alternatives.join(", ")}`);
-      }
-      lines.push("");
-    }
-
-    if (arch.apiContracts?.length) {
-      lines.push("### API Contracts");
-      for (const c of arch.apiContracts) {
-        lines.push(`- \`${c.method || "GET"} ${c.endpoint}\``);
-      }
-      lines.push("");
-    }
-  }
+  if (result.architecture) formatArchitecture(result.architecture, lines);
 
   if (result.questions?.length) {
     lines.push("### Clarification Questions");
-    for (const q of result.questions) {
-      lines.push(`- ${q.question || q}`);
-    }
+    for (const q of result.questions) lines.push(`- ${q.question || q}`);
     lines.push("");
   }
 

--- a/src/commands/discover.js
+++ b/src/commands/discover.js
@@ -2,57 +2,61 @@ import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildDiscoverPrompt, parseDiscoverOutput } from "../prompts/discover.js";
-import { parseMaybeJsonString } from "../review/parser.js";
+
+function formatGaps(gaps, lines) {
+  lines.push("## Gaps");
+  for (const g of gaps) {
+    const sev = g.severity ? ` [${g.severity}]` : "";
+    lines.push(`- ${g.description || g}${sev}`);
+    if (g.suggestedQuestion) lines.push(`  → ${g.suggestedQuestion}`);
+  }
+  lines.push("");
+}
+
+function formatMomTest(questions, lines) {
+  lines.push("## Mom Test Questions");
+  for (const q of questions) {
+    lines.push(`- ${q.question || q}`);
+    if (q.rationale) lines.push(`  _${q.rationale}_`);
+  }
+  lines.push("");
+}
+
+function formatWendel(checklist, lines) {
+  lines.push("## Wendel Checklist");
+  for (const w of checklist) {
+    const icon = w.status === "pass" ? "✓" : w.status === "fail" ? "✗" : "?";
+    lines.push(`- [${icon}] ${w.condition}: ${w.justification || ""}`);
+  }
+  lines.push("");
+}
+
+function formatClassification(classification, lines) {
+  lines.push("## Classification");
+  lines.push(`- Type: ${classification.type}`);
+  if (classification.adoptionRisk) lines.push(`- Adoption risk: ${classification.adoptionRisk}`);
+  if (classification.frictionEstimate) lines.push(`- Friction: ${classification.frictionEstimate}`);
+  lines.push("");
+}
+
+function formatJtbds(jtbds, lines) {
+  lines.push("## Jobs-to-be-Done");
+  for (const j of jtbds) {
+    lines.push(`- **${j.id || ""}**: ${j.functional || j}`);
+  }
+  lines.push("");
+}
 
 function formatDiscover(result, mode) {
   const lines = [];
   lines.push(`## Discovery (${mode})`);
   lines.push(`**Verdict:** ${result.verdict || "unknown"}`, "");
 
-  if (result.gaps?.length) {
-    lines.push("## Gaps");
-    for (const g of result.gaps) {
-      const sev = g.severity ? ` [${g.severity}]` : "";
-      lines.push(`- ${g.description || g}${sev}`);
-      if (g.suggestedQuestion) lines.push(`  → ${g.suggestedQuestion}`);
-    }
-    lines.push("");
-  }
-
-  if (result.momTestQuestions?.length) {
-    lines.push("## Mom Test Questions");
-    for (const q of result.momTestQuestions) {
-      lines.push(`- ${q.question || q}`);
-      if (q.rationale) lines.push(`  _${q.rationale}_`);
-    }
-    lines.push("");
-  }
-
-  if (result.wendelChecklist?.length) {
-    lines.push("## Wendel Checklist");
-    for (const w of result.wendelChecklist) {
-      const icon = w.status === "pass" ? "✓" : w.status === "fail" ? "✗" : "?";
-      lines.push(`- [${icon}] ${w.condition}: ${w.justification || ""}`);
-    }
-    lines.push("");
-  }
-
-  if (result.classification) {
-    lines.push("## Classification");
-    lines.push(`- Type: ${result.classification.type}`);
-    if (result.classification.adoptionRisk) lines.push(`- Adoption risk: ${result.classification.adoptionRisk}`);
-    if (result.classification.frictionEstimate) lines.push(`- Friction: ${result.classification.frictionEstimate}`);
-    lines.push("");
-  }
-
-  if (result.jtbds?.length) {
-    lines.push("## Jobs-to-be-Done");
-    for (const j of result.jtbds) {
-      lines.push(`- **${j.id || ""}**: ${j.functional || j}`);
-    }
-    lines.push("");
-  }
-
+  if (result.gaps?.length) formatGaps(result.gaps, lines);
+  if (result.momTestQuestions?.length) formatMomTest(result.momTestQuestions, lines);
+  if (result.wendelChecklist?.length) formatWendel(result.wendelChecklist, lines);
+  if (result.classification) formatClassification(result.classification, lines);
+  if (result.jtbds?.length) formatJtbds(result.jtbds, lines);
   if (result.summary) lines.push(`---\n${result.summary}`);
   return lines.join("\n");
 }

--- a/src/config.js
+++ b/src/config.js
@@ -141,6 +141,7 @@ const DEFAULTS = {
     max_reviewer_retries: 3,
     max_tester_retries: 1,
     max_security_retries: 1,
+    max_auto_resumes: 2,
     expiry_days: 30
   },
   failFast: {

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -171,6 +171,69 @@ export function buildAskQuestion(server) {
   };
 }
 
+const MAX_AUTO_RESUMES = 2;
+const NON_RECOVERABLE_CATEGORIES = new Set([
+  "config_error", "auth_error", "agent_missing", "branch_error", "git_error"
+]);
+
+async function attemptAutoResume({ err, config, logger, emitter, askQuestion, runLog }) {
+  const { category } = classifyError(err);
+  if (NON_RECOVERABLE_CATEGORIES.has(category)) return null;
+
+  // Find session ID from most recent session file
+  const { loadMostRecentSession } = await import("../session-store.js");
+  let session;
+  try {
+    session = await loadMostRecentSession();
+  } catch {
+    return null;
+  }
+  if (!session || !["failed", "stopped"].includes(session.status)) return null;
+
+  const maxRetries = config.session?.max_auto_resumes ?? MAX_AUTO_RESUMES;
+  const autoResumeCount = session.auto_resume_count || 0;
+  if (autoResumeCount >= maxRetries) {
+    runLog.logText(`[resilient] auto-resume limit reached (${maxRetries}), giving up`);
+    return null;
+  }
+
+  runLog.logText(`[resilient] run failed (${category}), auto-resuming (${autoResumeCount + 1}/${maxRetries})...`);
+  emitter.emit("progress", {
+    type: "resilient:auto_resume",
+    attempt: autoResumeCount + 1,
+    maxRetries,
+    errorCategory: category,
+    sessionId: session.id
+  });
+
+  // Increment counter and save before resuming
+  const { saveSession } = await import("../session-store.js");
+  session.auto_resume_count = autoResumeCount + 1;
+  await saveSession(session);
+
+  try {
+    const result = await resumeFlow({
+      sessionId: session.id,
+      config,
+      logger,
+      flags: {},
+      emitter,
+      askQuestion
+    });
+    const ok = !result.paused && (result.approved !== false);
+    runLog.logText(`[resilient] auto-resume ${ok ? "succeeded" : "finished"} — ok=${ok}`);
+    return { ok, ...result, autoResumed: true, autoResumeAttempt: autoResumeCount + 1 };
+  } catch (error) {
+    // Recursive: try again if still within limits
+    const nestedResult = await attemptAutoResume({
+      err: error, config, logger, emitter, askQuestion, runLog
+    });
+    if (nestedResult) return nestedResult;
+    runLog.logText(`[resilient] auto-resume failed: ${error.message}`);
+    return null;
+  }
+}
+
 export async function handleRunDirect(a, server, extra) {
   const config = await buildConfig(a);
   await assertNotOnBaseBranch(config);
@@ -209,6 +272,12 @@ export async function handleRunDirect(a, server, extra) {
     const result = await runFlow({ task: a.task, config, logger, flags: a, emitter, askQuestion, pgTaskId, pgProject });
     runLog.logText(`[kj_run] finished — ok=${!result.paused && (result.approved !== false)}`);
     return { ok: !result.paused && (result.approved !== false), ...result };
+  } catch (err) {
+    const autoResumeResult = await attemptAutoResume({
+      err, config, logger, emitter, askQuestion, runLog, progressNotifier, extra
+    });
+    if (autoResumeResult) return autoResumeResult;
+    throw err;
   } finally {
     runLog.close();
   }

--- a/src/session-store.js
+++ b/src/session-store.js
@@ -63,6 +63,24 @@ export async function pauseSession(session, { question, context: pauseContext })
   await saveSession(session);
 }
 
+export async function loadMostRecentSession() {
+  let entries;
+  try {
+    entries = await fs.readdir(SESSION_ROOT, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort();
+  for (let i = dirs.length - 1; i >= 0; i--) {
+    try {
+      return await loadSession(dirs[i]);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
 export async function resumeSessionWithAnswer(sessionId, answer) {
   const session = await loadSession(sessionId);
   if (session.status !== "paused") {

--- a/tests/resilient-run.test.js
+++ b/tests/resilient-run.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { classifyError } from "../src/mcp/server-handlers.js";
+
+vi.mock("../src/session-store.js", () => ({
+  loadMostRecentSession: vi.fn(),
+  saveSession: vi.fn(),
+  createSession: vi.fn().mockResolvedValue({ id: "s_test", status: "running", checkpoints: [] }),
+  loadSession: vi.fn(),
+  markSessionStatus: vi.fn(),
+  addCheckpoint: vi.fn(),
+  pauseSession: vi.fn(),
+  resumeSessionWithAnswer: vi.fn()
+}));
+
+describe("resilient run — error classification", () => {
+  it("classifies config errors as non-recoverable", () => {
+    const { category } = classifyError(new Error("Config missing required field"));
+    expect(category).toBe("config_error");
+  });
+
+  it("classifies auth errors as non-recoverable", () => {
+    const { category } = classifyError(new Error("401 Unauthorized"));
+    expect(category).toBe("auth_error");
+  });
+
+  it("classifies agent missing as non-recoverable", () => {
+    const { category } = classifyError(new Error("missing provider claude not found"));
+    expect(category).toBe("agent_missing");
+  });
+
+  it("classifies branch error as non-recoverable", () => {
+    const { category } = classifyError(new Error("You are on the base branch"));
+    expect(category).toBe("branch_error");
+  });
+
+  it("classifies timeouts as recoverable", () => {
+    const { category } = classifyError(new Error("Session timed out"));
+    expect(category).toBe("timeout");
+  });
+
+  it("classifies stalls as recoverable", () => {
+    const { category } = classifyError(new Error("Agent without output for 5 minutes"));
+    expect(category).toBe("agent_stall");
+  });
+
+  it("classifies unknown errors as recoverable", () => {
+    const { category } = classifyError(new Error("Something unexpected happened"));
+    expect(category).toBe("unknown");
+  });
+});
+
+describe("resilient run — loadMostRecentSession", () => {
+  let loadMostRecentSession;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const mod = await import("../src/session-store.js");
+    loadMostRecentSession = mod.loadMostRecentSession;
+  });
+
+  it("returns null when no sessions exist", async () => {
+    loadMostRecentSession.mockResolvedValue(null);
+    const session = await loadMostRecentSession();
+    expect(session).toBeNull();
+  });
+
+  it("returns most recent session", async () => {
+    const mockSession = { id: "s_2026-03-14", status: "failed", auto_resume_count: 0 };
+    loadMostRecentSession.mockResolvedValue(mockSession);
+    const session = await loadMostRecentSession();
+    expect(session.status).toBe("failed");
+  });
+});
+
+describe("resilient run — auto-resume limits", () => {
+  it("max_auto_resumes defaults to 2 in loaded config", async () => {
+    const { loadConfig } = await import("../src/config.js");
+    const { config } = await loadConfig("/tmp/nonexistent-project");
+    expect(config.session.max_auto_resumes).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- When `kj_run` fails with a recoverable error, the MCP server auto-resumes the session (up to 2 retries by default)
- Non-recoverable errors (config, auth, missing agent, wrong branch) skip auto-resume and fail immediately
- Configurable via `session.max_auto_resumes` in `kj.config.yml`
- New `loadMostRecentSession()` in session-store for finding the failed session
- Progress event `resilient:auto_resume` emitted for visibility
- Result includes `autoResumed: true` and `autoResumeAttempt` when auto-resumed

## Test plan
- [x] `resilient-run.test.js` — 10 tests (error classification, session loading, config defaults)
- [x] Full suite: 128 files, 1559 tests pass
- [ ] Manual: trigger a timeout/stall during `kj_run` and verify auto-resume kicks in