### PR TITLE
fix(pipeline): catch tester/security exceptions to prevent unhandled pause

### DIFF
--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -16,7 +16,13 @@ export async function runTesterStage({ config, logger, emitter, eventBase, sessi
   const tester = new TesterRole({ config, logger, emitter });
   await tester.init({ task, iteration });
   const testerStart = Date.now();
-  const testerOutput = await tester.run({ task, diff });
+  let testerOutput;
+  try {
+    testerOutput = await tester.run({ task, diff });
+  } catch (err) {
+    logger.warn(`Tester threw: ${err.message}`);
+    testerOutput = { ok: false, summary: `Tester error: ${err.message}`, result: { error: err.message } };
+  }
   trackBudget({
     role: "tester",
     provider: config?.roles?.tester?.provider || coderRole.provider,
@@ -90,7 +96,13 @@ export async function runSecurityStage({ config, logger, emitter, eventBase, ses
   const security = new SecurityRole({ config, logger, emitter });
   await security.init({ task, iteration });
   const securityStart = Date.now();
-  const securityOutput = await security.run({ task, diff });
+  let securityOutput;
+  try {
+    securityOutput = await security.run({ task, diff });
+  } catch (err) {
+    logger.warn(`Security threw: ${err.message}`);
+    securityOutput = { ok: false, summary: `Security error: ${err.message}`, result: { error: err.message } };
+  }
   trackBudget({
     role: "security",
     provider: config?.roles?.security?.provider || coderRole.provider,


### PR DESCRIPTION
## Summary
- Wrap `tester.run()` and `security.run()` in try-catch in `post-loop-stages.js`
- Exceptions (e.g. JSON parse errors from tester output) are now converted to `{ok: false}` results
- This allows the normal retry → Solomon escalation flow instead of bubbling up as an unhandled exception that pauses the session

## Root cause
When the tester agent returns output containing `{...}` that isn't valid JSON, `JSON.parse()` throws. Without try-catch in `runTesterStage()`, the exception propagated through the entire orchestration pipeline to the MCP server, causing an unexpected session pause.

## Test plan
- [x] `orchestrator-post-loop.test.js` — 6 tests pass
- [x] `tester-role.test.js` — 20 tests pass
- [x] `security-role.test.js` — 21 tests pass
- [x] Full suite: 128 files, 1559 tests pass