### PR TITLE
fix(pipeline): remove silent fallbacks for TDD, reviewer, and git

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1004,13 +1004,7 @@ async function initFlowContext({ task, config, logger, emitter, askQuestion, pgT
   const { plannedTask } = preLoopResult;
   const updatedConfig = preLoopResult.updatedConfig;
 
-  let gitCtx;
-  try {
-    gitCtx = await prepareGitAutomation({ config: updatedConfig, task, logger, session });
-  } catch (err) {
-    logger.warn(`Git automation setup failed: ${err.message}`);
-    gitCtx = { enabled: false };
-  }
+  const gitCtx = await prepareGitAutomation({ config: updatedConfig, task, logger, session });
   const projectDir = updatedConfig.projectDir || process.cwd();
   const { rules: reviewRules } = await resolveReviewProfile({ mode: updatedConfig.review_mode, projectDir });
   await coderRoleInstance.init();

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -262,7 +262,7 @@ export async function runTddCheckStage({ config, logger, emitter, eventBase, ses
     untrackedFiles = await getUntrackedFiles();
   } catch (err) {
     logger.warn(`TDD diff generation failed: ${err.message}`);
-    return { action: "ok", stageResult: { ok: true, summary: `TDD check skipped: ${err.message}` } };
+    return { action: "continue", stageResult: { ok: false, summary: `TDD check failed: ${err.message}` } };
   }
   const tddEval = evaluateTddPolicy(tddDiff, config.development, untrackedFiles);
   await addCheckpoint(session, {
@@ -573,7 +573,7 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
     diff = await fetchReviewDiff(session, logger);
   } catch (err) {
     logger.warn(`Review diff generation failed: ${err.message}`);
-    return { approved: true, blocking_issues: [], non_blocking_suggestions: [], summary: `Reviewer skipped: diff error — ${err.message}`, confidence: 0 };
+    return { approved: false, blocking_issues: [{ description: `Diff generation failed: ${err.message}` }], non_blocking_suggestions: [], summary: `Reviewer failed: cannot generate diff — ${err.message}`, confidence: 0 };
   }
   const reviewerOnOutput = ({ stream, line }) => {
     emitProgress(emitter, makeEvent("agent:output", { ...eventBase, stage: "reviewer" }, {


### PR DESCRIPTION
## Summary
Fixes 3 silent fallbacks introduced in #108 that swallowed errors instead of reporting them:

- **TDD check**: was returning `ok: true` (skip) on diff error → now returns `ok: false` with `action: "continue"` so the coder gets feedback
- **Reviewer diff**: was auto-approving (`approved: true`) when diff generation failed → now returns `approved: false` with a blocking issue
- **Git automation**: was silently disabling git (`enabled: false`) on error → reverted to original behavior: exception propagates and session fails with a clear error

## Principle
If something fails, it FAILS and INFORMS. No silent degradation.

## Test plan
- [x] Full suite: 128 files, 1559 tests pass