### PR TITLE
feat(mcp): memory watchdog to prevent OOM crashes

### DIFF
--- a/src/mcp/orphan-guard.js
+++ b/src/mcp/orphan-guard.js
@@ -22,6 +22,53 @@ export function setupOrphanGuard({ intervalMs = DEFAULT_INTERVAL_MS, exitFn = ()
   return { timer, parentPid };
 }
 
+const DEFAULT_MEMORY_CHECK_MS = 30_000;
+const DEFAULT_WARN_HEAP_MB = 512;
+const DEFAULT_CRITICAL_HEAP_MB = 768;
+
+export function setupMemoryWatchdog({
+  intervalMs = DEFAULT_MEMORY_CHECK_MS,
+  warnHeapMb = DEFAULT_WARN_HEAP_MB,
+  criticalHeapMb = DEFAULT_CRITICAL_HEAP_MB,
+  onWarn = null,
+  onCritical = null,
+  exitFn = () => process.exit(1)
+} = {}) {
+  const warnBytes = warnHeapMb * 1024 * 1024;
+  const criticalBytes = criticalHeapMb * 1024 * 1024;
+  let warned = false;
+
+  const timer = setInterval(() => {
+    const { heapUsed, rss } = process.memoryUsage();
+
+    if (heapUsed >= criticalBytes) {
+      if (global.gc) {
+        try { global.gc(); } catch { /* --expose-gc not set */ }
+        const after = process.memoryUsage().heapUsed;
+        if (after < criticalBytes) return; // GC freed enough
+      }
+      const msg = `Memory critical: heap ${(heapUsed / 1024 / 1024).toFixed(0)}MB / rss ${(rss / 1024 / 1024).toFixed(0)}MB — exiting to prevent OOM`;
+      if (onCritical) onCritical(msg);
+      else process.stderr.write(`[karajan-mcp] ${msg}\n`);
+      clearInterval(timer);
+      exitFn();
+      return;
+    }
+
+    if (heapUsed >= warnBytes && !warned) {
+      warned = true;
+      const msg = `Memory warning: heap ${(heapUsed / 1024 / 1024).toFixed(0)}MB / rss ${(rss / 1024 / 1024).toFixed(0)}MB (critical at ${criticalHeapMb}MB)`;
+      if (onWarn) onWarn(msg);
+      else process.stderr.write(`[karajan-mcp] ${msg}\n`);
+    } else if (heapUsed < warnBytes) {
+      warned = false;
+    }
+  }, intervalMs);
+  timer.unref();
+
+  return { timer };
+}
+
 export function setupVersionWatcher({ pkgPath, currentVersion, exitFn = () => process.exit(0) } = {}) {
   if (!pkgPath) return null;
 

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -50,9 +50,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
 });
 
 // --- Orphan process protection + version watcher ---
-import { setupOrphanGuard, setupVersionWatcher } from "./orphan-guard.js";
+import { setupOrphanGuard, setupVersionWatcher, setupMemoryWatchdog } from "./orphan-guard.js";
 setupOrphanGuard();
 setupVersionWatcher({ pkgPath: PKG_PATH, currentVersion: LOADED_VERSION });
+setupMemoryWatchdog();
 
 const transport = new StdioServerTransport();
 await mcpServer.connect(transport);

--- a/tests/memory-watchdog.test.js
+++ b/tests/memory-watchdog.test.js
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setupMemoryWatchdog } from "../src/mcp/orphan-guard.js";
+
+describe("memory-watchdog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns a timer handle", () => {
+    const { timer } = setupMemoryWatchdog({ intervalMs: 60000 });
+    expect(timer).toBeDefined();
+    clearInterval(timer);
+  });
+
+  it("calls onWarn when heap exceeds warning threshold", () => {
+    vi.useFakeTimers();
+    const onWarn = vi.fn();
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      heapUsed: 600 * 1024 * 1024, // 600MB
+      rss: 800 * 1024 * 1024,
+      heapTotal: 1024 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const { timer } = setupMemoryWatchdog({ intervalMs: 100, warnHeapMb: 512, criticalHeapMb: 768, onWarn });
+    vi.advanceTimersByTime(100);
+
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(onWarn.mock.calls[0][0]).toContain("Memory warning");
+
+    clearInterval(timer);
+  });
+
+  it("does not warn when heap is below threshold", () => {
+    vi.useFakeTimers();
+    const onWarn = vi.fn();
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      heapUsed: 100 * 1024 * 1024, // 100MB
+      rss: 200 * 1024 * 1024,
+      heapTotal: 1024 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const { timer } = setupMemoryWatchdog({ intervalMs: 100, warnHeapMb: 512, onWarn });
+    vi.advanceTimersByTime(300);
+
+    expect(onWarn).not.toHaveBeenCalled();
+
+    clearInterval(timer);
+  });
+
+  it("calls exitFn when heap exceeds critical threshold", () => {
+    vi.useFakeTimers();
+    const exitFn = vi.fn();
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      heapUsed: 800 * 1024 * 1024, // 800MB
+      rss: 1024 * 1024 * 1024,
+      heapTotal: 1024 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const onCritical = vi.fn();
+    const { timer } = setupMemoryWatchdog({ intervalMs: 100, criticalHeapMb: 768, exitFn, onCritical });
+    vi.advanceTimersByTime(100);
+
+    expect(exitFn).toHaveBeenCalledTimes(1);
+    expect(onCritical).toHaveBeenCalledTimes(1);
+
+    clearInterval(timer);
+  });
+
+  it("resets warn flag when heap drops below threshold", () => {
+    vi.useFakeTimers();
+    const onWarn = vi.fn();
+    const memSpy = vi.spyOn(process, "memoryUsage");
+
+    // First tick: above warn
+    memSpy.mockReturnValue({ heapUsed: 600 * 1024 * 1024, rss: 800 * 1024 * 1024, heapTotal: 1024 * 1024 * 1024, external: 0, arrayBuffers: 0 });
+    const { timer } = setupMemoryWatchdog({ intervalMs: 100, warnHeapMb: 512, criticalHeapMb: 1024, onWarn });
+    vi.advanceTimersByTime(100);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+
+    // Second tick: still above — should NOT warn again
+    vi.advanceTimersByTime(100);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+
+    // Third tick: drops below
+    memSpy.mockReturnValue({ heapUsed: 100 * 1024 * 1024, rss: 200 * 1024 * 1024, heapTotal: 1024 * 1024 * 1024, external: 0, arrayBuffers: 0 });
+    vi.advanceTimersByTime(100);
+
+    // Fourth tick: above again — should warn again
+    memSpy.mockReturnValue({ heapUsed: 600 * 1024 * 1024, rss: 800 * 1024 * 1024, heapTotal: 1024 * 1024 * 1024, external: 0, arrayBuffers: 0 });
+    vi.advanceTimersByTime(100);
+    expect(onWarn).toHaveBeenCalledTimes(2);
+
+    clearInterval(timer);
+  });
+
+  it("attempts GC before exiting on critical", () => {
+    vi.useFakeTimers();
+    const exitFn = vi.fn();
+    const gcFn = vi.fn();
+    global.gc = gcFn;
+
+    // GC doesn't help — still above critical after
+    vi.spyOn(process, "memoryUsage").mockReturnValue({
+      heapUsed: 800 * 1024 * 1024,
+      rss: 1024 * 1024 * 1024,
+      heapTotal: 1024 * 1024 * 1024,
+      external: 0,
+      arrayBuffers: 0
+    });
+
+    const onCritical = vi.fn();
+    const { timer } = setupMemoryWatchdog({ intervalMs: 100, criticalHeapMb: 768, exitFn, onCritical });
+    vi.advanceTimersByTime(100);
+
+    expect(gcFn).toHaveBeenCalled();
+    expect(exitFn).toHaveBeenCalled();
+
+    clearInterval(timer);
+    delete global.gc;
+  });
+});


### PR DESCRIPTION
## Summary
Adds a memory watchdog to the MCP server that monitors heap usage every 30 seconds:

- **Warning** at 512MB heap: logs to stderr, emits once per spike
- **Critical** at 768MB heap: attempts `global.gc()` if available, exits gracefully if still above threshold
- Warning resets when memory drops back below threshold (no spam)
- Configurable thresholds and callbacks
- Same pattern as orphan guard and version watcher — `timer.unref()` so it doesn't keep the process alive

## Why
Long kj_run sessions with multiple iterations spawn agent subprocesses that consume memory. Without this, Node.js OOMs silently and the MCP connection drops with no explanation.

## Test plan
- [x] `memory-watchdog.test.js` — 6 tests (warn, critical, GC attempt, reset, no false positive)
- [x] Full suite: 129 files, 1565 tests pass