### PR TITLE
feat(pipeline): host-as-coder — skip subprocess when host AI matches coder

### DIFF
--- a/src/agents/host-agent.js
+++ b/src/agents/host-agent.js
@@ -1,0 +1,38 @@
+/**
+ * Host Agent — delegates task execution to the MCP host AI via elicitation.
+ *
+ * Instead of spawning a subprocess, returns the prompt to the host AI
+ * (Claude, Codex, etc.) for direct execution. The host has full access
+ * to the codebase and tools — no subprocess overhead.
+ *
+ * Used when: the MCP host IS the same agent configured for a role.
+ */
+
+import { BaseAgent } from "./base-agent.js";
+
+export class HostAgent extends BaseAgent {
+  constructor(config, logger, { askHost }) {
+    super("host", config, logger);
+    this._askHost = askHost;
+  }
+
+  async runTask(task) {
+    const { prompt, onOutput } = task;
+
+    if (!this._askHost) {
+      return { ok: false, output: "", error: "Host agent has no askHost callback" };
+    }
+
+    if (onOutput) onOutput({ stream: "info", line: "[host-agent] Delegating to host AI..." });
+
+    const answer = await this._askHost(prompt);
+
+    if (!answer) {
+      return { ok: false, output: "", error: "Host AI declined or returned no response" };
+    }
+
+    if (onOutput) onOutput({ stream: "info", line: "[host-agent] Host AI completed task" });
+
+    return { ok: true, output: answer, exitCode: 0 };
+  }
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -978,7 +978,7 @@ async function initFlowContext({ task, config, logger, emitter, askQuestion, pgT
   const refactorerRole = resolveRole(config, "refactorer");
   const pipelineFlags = resolvePipelineFlags(config);
   const repeatDetector = new RepeatDetector({ threshold: getRepeatThreshold(config) });
-  const coderRoleInstance = new CoderRole({ config, logger, emitter, createAgentFn: createAgent });
+  const coderRoleInstance = new CoderRole({ config, logger, emitter, createAgentFn: createAgent, askHost: askQuestion });
   const startedAt = Date.now();
   const eventBase = { sessionId: null, iteration: 0, stage: null, startedAt };
   const { budgetTracker, budgetLimit, budgetSummary, trackBudget } = createBudgetManager({ config, emitter, eventBase });

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -1,6 +1,8 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { buildCoderPrompt } from "../prompts/coder.js";
+import { isHostAgent } from "../utils/agent-detect.js";
+import { HostAgent } from "../agents/host-agent.js";
 
 function resolveProvider(config) {
   return (
@@ -11,9 +13,10 @@ function resolveProvider(config) {
 }
 
 export class CoderRole extends BaseRole {
-  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+  constructor({ config, logger, emitter = null, createAgentFn = null, askHost = null }) {
     super({ name: "coder", config, logger, emitter });
     this._createAgent = createAgentFn || defaultCreateAgent;
+    this._askHost = askHost;
   }
 
   async execute(input) {
@@ -22,7 +25,14 @@ export class CoderRole extends BaseRole {
       : input || {};
 
     const provider = resolveProvider(this.config);
-    const agent = this._createAgent(provider, this.config, this.logger);
+    const useHost = this._askHost && isHostAgent(provider);
+    const agent = useHost
+      ? new HostAgent(this.config, this.logger, { askHost: this._askHost })
+      : this._createAgent(provider, this.config, this.logger);
+
+    if (useHost) {
+      this.logger.info(`Host-as-coder: delegating to host AI (skipping ${provider} subprocess)`);
+    }
 
     const prompt = buildCoderPrompt({
       task: task || this.context?.task || "",

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -30,4 +30,25 @@ export async function detectAvailableAgents() {
   return results;
 }
 
+/**
+ * Detect which AI agent is the current MCP host (if any).
+ * Returns the agent name ("claude", "codex", etc.) or null if not inside an agent.
+ */
+export function detectHostAgent() {
+  if (process.env.CLAUDECODE === "1" || process.env.CLAUDE_CODE === "1") return "claude";
+  if (process.env.CODEX_CLI === "1" || process.env.CODEX === "1") return "codex";
+  if (process.env.GEMINI_CLI === "1") return "gemini";
+  if (process.env.OPENCODE === "1") return "opencode";
+  return null;
+}
+
+/**
+ * Check if a given provider matches the current host agent.
+ * When true, we can skip subprocess spawning and delegate to the host.
+ */
+export function isHostAgent(provider) {
+  const host = detectHostAgent();
+  return host !== null && host === provider;
+}
+
 export { KNOWN_AGENTS };

--- a/tests/host-agent.test.js
+++ b/tests/host-agent.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HostAgent } from "../src/agents/host-agent.js";
+import { detectHostAgent, isHostAgent } from "../src/utils/agent-detect.js";
+
+describe("detectHostAgent", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("detects Claude as host", () => {
+    process.env.CLAUDECODE = "1";
+    expect(detectHostAgent()).toBe("claude");
+  });
+
+  it("detects Codex as host", () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE;
+    process.env.CODEX_CLI = "1";
+    expect(detectHostAgent()).toBe("codex");
+  });
+
+  it("returns null when no host detected", () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE;
+    delete process.env.CODEX_CLI;
+    delete process.env.CODEX;
+    delete process.env.GEMINI_CLI;
+    delete process.env.OPENCODE;
+    expect(detectHostAgent()).toBeNull();
+  });
+});
+
+describe("isHostAgent", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns true when provider matches host", () => {
+    process.env.CLAUDECODE = "1";
+    expect(isHostAgent("claude")).toBe(true);
+  });
+
+  it("returns false when provider differs from host", () => {
+    process.env.CLAUDECODE = "1";
+    expect(isHostAgent("codex")).toBe(false);
+  });
+
+  it("returns false when not inside any host", () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CLAUDE_CODE;
+    expect(isHostAgent("claude")).toBe(false);
+  });
+});
+
+describe("HostAgent", () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+  });
+
+  it("delegates prompt to askHost and returns result", async () => {
+    const askHost = vi.fn().mockResolvedValue("Code implemented successfully");
+    const agent = new HostAgent({}, logger, { askHost });
+
+    const result = await agent.runTask({ prompt: "Write a function", role: "coder" });
+
+    expect(askHost).toHaveBeenCalledWith("Write a function");
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("Code implemented successfully");
+  });
+
+  it("returns error when askHost returns null", async () => {
+    const askHost = vi.fn().mockResolvedValue(null);
+    const agent = new HostAgent({}, logger, { askHost });
+
+    const result = await agent.runTask({ prompt: "Write code" });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("declined");
+  });
+
+  it("returns error when no askHost callback", async () => {
+    const agent = new HostAgent({}, logger, { askHost: null });
+
+    const result = await agent.runTask({ prompt: "Write code" });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("no askHost");
+  });
+
+  it("calls onOutput callbacks when provided", async () => {
+    const askHost = vi.fn().mockResolvedValue("Done");
+    const onOutput = vi.fn();
+    const agent = new HostAgent({}, logger, { askHost });
+
+    await agent.runTask({ prompt: "Task", onOutput });
+
+    expect(onOutput).toHaveBeenCalledTimes(2);
+    expect(onOutput.mock.calls[0][0].line).toContain("Delegating");
+    expect(onOutput.mock.calls[1][0].line).toContain("completed");
+  });
+});


### PR DESCRIPTION
## Summary
When the MCP host AI is the same agent configured as coder (e.g., Claude Code calling kj_run with coder=claude), Karajan now delegates the coder prompt directly to the host via MCP elicitation instead of spawning a subprocess.

**How it works:**
- `detectHostAgent()` checks env vars (CLAUDECODE, CODEX_CLI, GEMINI_CLI, OPENCODE) to identify the host
- `isHostAgent(provider)` compares host with the configured coder provider
- When they match: `HostAgent` sends the prompt via `askQuestion` (MCP elicitation)
- When they don't match: subprocess spawned as before (unchanged)

**Examples:**
| Host | Coder config | Behavior |
|------|-------------|----------|
| Claude Code | coder: claude | Host-as-coder (no subprocess) |
| Claude Code | coder: codex | Spawns codex subprocess |
| Codex | coder: codex | Host-as-coder (no subprocess) |
| CLI terminal | coder: claude | Spawns claude subprocess |

**What stays the same:**
- All guardrails still run: guards, sonar, TDD, reviewer, solomon
- Other roles (reviewer, tester, security) still spawn subprocesses
- CLI mode unchanged — always spawns

## Test plan
- [x] `host-agent.test.js` — 10 tests (detection, delegation, error handling)
- [x] `coder-role.test.js` — 21 tests pass (no regression)
- [x] Full suite: 130 files, 1575 tests pass