### PR TITLE
chore: bump version to v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.21.2",
+  "version": "1.22.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- #111: resilient kj_resume — handle crash mid-resume
- #112: memory watchdog to prevent OOM crashes
- #113: host-as-coder — skip subprocess when host AI matches coder