### PR TITLE
feat(skills): Karajan skills as Claude Code slash commands

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -204,6 +204,56 @@ async function scaffoldBecariaGateway(config, flags, logger) {
   logger.info("  4. Push the workflow files and enable 'kj run --enable-becaria'");
 }
 
+async function installSkills(logger, interactive) {
+  const projectDir = process.cwd();
+  const commandsDir = path.join(projectDir, ".claude", "commands");
+  const skillsTemplateDir = path.resolve(import.meta.dirname, "../../templates/skills");
+
+  let doInstall = true;
+  if (interactive) {
+    const wizard = createWizard();
+    try {
+      doInstall = await wizard.confirm("Install Karajan skills as slash commands (/kj-code, /kj-review, etc.)?", true);
+    } finally {
+      wizard.close();
+    }
+  }
+
+  if (!doInstall) {
+    logger.info("Skills installation skipped.");
+    return;
+  }
+
+  await ensureDir(commandsDir);
+
+  let installed = 0;
+  try {
+    const files = await fs.readdir(skillsTemplateDir);
+    for (const file of files) {
+      if (!file.endsWith(".md")) continue;
+      const src = path.join(skillsTemplateDir, file);
+      const dest = path.join(commandsDir, file);
+      if (await exists(dest)) {
+        logger.info(`  ${file} already exists — skipping`);
+        continue;
+      }
+      const content = await fs.readFile(src, "utf8");
+      await fs.writeFile(dest, content, "utf8");
+      installed += 1;
+    }
+  } catch (err) {
+    logger.warn(`Could not install skills: ${err.message}`);
+    return;
+  }
+
+  if (installed > 0) {
+    logger.info(`Installed ${installed} Karajan skill(s) in .claude/commands/`);
+    logger.info("Available as slash commands: /kj-run, /kj-code, /kj-review, /kj-test, /kj-security, /kj-discover, /kj-architect, /kj-sonar");
+  } else {
+    logger.info("All skills already installed.");
+  }
+}
+
 export async function initCommand({ logger, flags = {} }) {
   const karajanHome = getKarajanHome();
   await ensureDir(karajanHome);
@@ -219,6 +269,7 @@ export async function initCommand({ logger, flags = {} }) {
   await handleConfigSetup({ config, configExists, interactive, configPath, logger });
   await ensureReviewRules(reviewRulesPath, logger);
   await ensureCoderRules(coderRulesPath, logger);
+  await installSkills(logger, interactive);
   await setupSonarQube(config, logger);
   await scaffoldBecariaGateway(config, flags, logger);
 }

--- a/templates/skills/kj-architect.md
+++ b/templates/skills/kj-architect.md
@@ -1,0 +1,45 @@
+# kj-architect — Architecture Design
+
+Analyze the task and propose an architecture before implementation.
+
+## Your task
+
+$ARGUMENTS
+
+## Steps
+
+1. Read the task and understand the requirements
+2. Explore the existing codebase structure (`ls`, `find`, read key files)
+3. Identify the appropriate architectural approach
+4. Propose a design with tradeoffs
+
+## What to deliver
+
+### Architecture overview
+- Architecture type (layered, hexagonal, event-driven, etc.)
+- Key components/layers and their responsibilities
+- Data flow between components
+
+### API contracts (if applicable)
+- Endpoints with method, path, request/response schema
+- Error handling strategy
+
+### Data model changes (if applicable)
+- New entities/collections
+- Modified fields
+- Migration strategy
+
+### Tradeoffs
+- For each design decision: what was chosen, why, and what alternatives were considered
+- Constraints that influenced the design
+
+### Clarification questions
+- Any ambiguities that could affect the architecture
+- Decisions that need stakeholder input
+
+## Constraints
+
+- Follow existing patterns in the codebase — don't introduce a new architecture without justification
+- Keep it simple — the right amount of complexity is the minimum needed
+- Consider testability in every design decision
+- Do NOT start coding — this is design only

--- a/templates/skills/kj-code.md
+++ b/templates/skills/kj-code.md
@@ -1,0 +1,51 @@
+# kj-code — Coder with Guardrails
+
+Implement the task with TDD methodology and built-in quality checks.
+
+## Your task
+
+$ARGUMENTS
+
+## Methodology
+
+1. **Tests first**: Write or update tests BEFORE implementation
+2. **Implement**: Write minimal, focused code to pass the tests
+3. **Verify**: Run the test suite (`npm test` or project equivalent)
+4. **Check diff**: Run `git diff` and verify ONLY intended lines changed
+
+## Guardrails (MANDATORY)
+
+After writing code, verify ALL of these before reporting done:
+
+### Security check
+- [ ] No hardcoded credentials, API keys, or secrets in the diff
+- [ ] No `eval()`, `innerHTML` with user input, or SQL string concatenation
+- [ ] User input is validated/sanitized at system boundaries
+
+### Destructive operation check
+- [ ] No `rm -rf /`, `DROP TABLE`, `git push --force`, or similar in the diff
+- [ ] No `fs.rmSync` or `fs.rm` on paths derived from user input
+- [ ] No `process.exit()` in library code
+
+### Performance check
+- [ ] No synchronous file I/O (`readFileSync`, `writeFileSync`) in request handlers
+- [ ] No `document.write()` or layout thrashing patterns
+- [ ] No unbounded loops or missing pagination
+
+### TDD check
+- [ ] Source changes have corresponding test changes
+- [ ] Tests actually run and pass
+
+## File modification safety
+
+- NEVER overwrite existing files entirely — make targeted edits
+- After each edit, verify with `git diff` that ONLY intended lines changed
+- If unintended changes detected, revert immediately with `git checkout -- <file>`
+
+## Completeness check
+
+Before reporting done:
+- Re-read the task description
+- Check every requirement is addressed
+- Run the test suite
+- Verify no regressions

--- a/templates/skills/kj-discover.md
+++ b/templates/skills/kj-discover.md
@@ -1,0 +1,24 @@
+# kj-discover — Gap Detection
+
+Analyze the task for gaps, ambiguities, and missing information BEFORE coding.
+
+## Your task
+
+$ARGUMENTS
+
+## What to do
+
+1. Read the task description carefully
+2. Identify gaps: missing requirements, implicit assumptions, ambiguities, contradictions
+3. Classify each gap: **critical** (blocks implementation), **major** (risks rework), **minor** (reasonable default exists)
+4. For each gap, suggest a specific question to resolve it
+5. Give a verdict: **ready** (no gaps) or **needs_validation** (gaps found)
+
+## Output
+
+Present findings clearly:
+- List each gap with severity and suggested question
+- Give your verdict at the end
+- If ready, say so and suggest proceeding to implementation
+
+Do NOT start coding. This is analysis only.

--- a/templates/skills/kj-review.md
+++ b/templates/skills/kj-review.md
@@ -1,0 +1,47 @@
+# kj-review — Code Review with Quality Gates
+
+Review the current changes against task requirements and quality standards.
+
+## Your task
+
+Review the changes in the current branch: $ARGUMENTS
+
+## Steps
+
+1. Run `git diff main...HEAD` (or appropriate base branch) to see all changes
+2. Review each changed file against the priorities below
+3. Report findings clearly
+
+## Review priorities (in order)
+
+1. **Security** — vulnerabilities, exposed secrets, injection vectors
+2. **Correctness** — logic errors, edge cases, broken tests
+3. **Tests** — adequate coverage, meaningful assertions
+4. **Architecture** — patterns, maintainability, SOLID principles
+5. **Style** — naming, formatting (only flag if egregious)
+
+## Scope constraint
+
+- **ONLY review files present in the diff** — do not flag issues in untouched files
+- Out-of-scope issues go as suggestions, never as blocking
+
+## Guardrails (auto-check)
+
+Flag as BLOCKING if any of these are detected in the diff:
+- [ ] Hardcoded credentials, API keys, or secrets
+- [ ] Entire file replaced (massive deletions + additions instead of targeted edits)
+- [ ] `eval()`, `innerHTML` with user input, SQL string concatenation
+- [ ] Missing test changes when source files changed (TDD violation)
+- [ ] `rm -rf`, `DROP TABLE`, `git push --force` or similar destructive operations
+
+## Output
+
+For each issue found:
+- **File and line** where the issue is
+- **Severity**: critical / major / minor
+- **Description**: what's wrong
+- **Suggested fix**: how to fix it
+
+End with a clear verdict:
+- **APPROVED** — no blocking issues found
+- **REQUEST_CHANGES** — blocking issues listed above must be fixed

--- a/templates/skills/kj-run.md
+++ b/templates/skills/kj-run.md
@@ -1,0 +1,69 @@
+# kj-run — Full Pipeline (Skills Mode)
+
+Execute the complete Karajan pipeline as sequential skills.
+
+## Your task
+
+$ARGUMENTS
+
+## Pipeline steps (execute in order)
+
+### Step 1 — Discover (optional but recommended)
+Analyze the task for gaps before coding:
+- Identify missing requirements, ambiguities, contradictions
+- If critical gaps found, STOP and ask the user before proceeding
+- If ready, continue
+
+### Step 2 — Code (with guardrails)
+Implement the task:
+1. **Tests first** (TDD): write/update tests before implementation
+2. **Implement**: minimal, focused code to fulfill the task
+3. **Verify**: run the test suite
+4. **Security check**: no hardcoded secrets, no injection vectors, no destructive ops in the diff
+5. **Diff check**: run `git diff` and verify only intended lines changed
+6. If any guardrail fails, fix before proceeding
+
+### Step 3 — Review (self-review)
+Review your own changes against quality standards:
+1. Run `git diff main...HEAD` (or base branch)
+2. Check: security, correctness, tests, architecture, style (in that order)
+3. Flag blocking issues:
+   - Hardcoded credentials or secrets
+   - Entire files overwritten instead of targeted edits
+   - Missing tests for new code
+   - SQL injection, XSS, command injection
+   - Destructive operations
+4. If blocking issues found, fix them and re-review
+5. If clean, proceed
+
+### Step 4 — Test audit
+Verify test quality:
+1. Every changed source file has corresponding tests
+2. Run `npm test` (or equivalent) — all must pass
+3. No skipped tests for changed code
+4. If tests fail, fix before proceeding
+
+### Step 5 — Security scan
+Quick security audit on the diff:
+1. Scan for OWASP top 10 in changed files
+2. Check for leaked secrets, injection vectors, missing auth
+3. If critical/high findings, fix before proceeding
+
+### Step 6 — Sonar (if available)
+If SonarQube is running (`docker ps | grep sonarqube`):
+1. Run `npx @sonar/scan`
+2. Check quality gate
+3. Fix blockers and critical issues
+
+### Step 7 — Commit
+If all steps pass:
+1. Stage changed files: `git add <specific files>`
+2. Commit with conventional commit message: `feat:`, `fix:`, `refactor:`, etc.
+3. Do NOT push unless the user explicitly asks
+
+## Important rules
+
+- **Never skip steps** — execute all applicable steps in order
+- **Fix before proceeding** — if a step finds issues, fix them before moving to the next
+- **Report progress** — after each step, briefly state what was done and the result
+- **Stop on critical** — if a critical security or correctness issue can't be fixed, stop and report

--- a/templates/skills/kj-security.md
+++ b/templates/skills/kj-security.md
@@ -1,0 +1,49 @@
+# kj-security — Security Audit
+
+Perform a security audit on the current changes.
+
+## Your task
+
+$ARGUMENTS
+
+## Steps
+
+1. Run `git diff main...HEAD` to see all changes
+2. Scan for each vulnerability category below
+3. Report findings with severity and remediation
+
+## Vulnerability categories
+
+### Critical
+- [ ] Hardcoded secrets (API keys, passwords, tokens, connection strings)
+- [ ] SQL injection (string concatenation in queries)
+- [ ] Command injection (`exec`, `spawn` with unsanitized input)
+- [ ] Path traversal (file operations with user-controlled paths)
+
+### High
+- [ ] XSS (Cross-Site Scripting) — `innerHTML`, `dangerouslySetInnerHTML` with user input
+- [ ] Missing authentication/authorization checks on new endpoints
+- [ ] Insecure deserialization
+- [ ] SSRF (Server-Side Request Forgery) — fetch/request with user-controlled URLs
+
+### Medium
+- [ ] Missing input validation at system boundaries
+- [ ] Verbose error messages that leak internal details
+- [ ] Missing CSRF protection on state-changing endpoints
+- [ ] Insecure random number generation for security purposes
+
+### Low
+- [ ] Missing security headers
+- [ ] Dependencies with known vulnerabilities (check `npm audit`)
+- [ ] Console.log with sensitive data
+
+## Output
+
+For each finding:
+- **Severity**: critical / high / medium / low
+- **File and line**: where the issue is
+- **Category**: which vulnerability type
+- **Description**: what's wrong
+- **Remediation**: specific fix
+
+End with a summary: total findings by severity, and whether the code is safe to ship.

--- a/templates/skills/kj-sonar.md
+++ b/templates/skills/kj-sonar.md
@@ -1,0 +1,41 @@
+# kj-sonar — Static Analysis
+
+Run SonarQube/SonarCloud analysis and fix any issues found.
+
+## Your task
+
+$ARGUMENTS
+
+## Steps
+
+1. Check if SonarQube is running: `docker ps | grep sonarqube`
+2. If running, execute scan:
+   ```bash
+   npx @sonar/scan -Dsonar.host.url=http://localhost:9000 -Dsonar.projectKey=<project-key>
+   ```
+3. Check quality gate status:
+   ```bash
+   curl -s -u admin:admin "http://localhost:9000/api/qualitygates/project_status?projectKey=<project-key>"
+   ```
+4. List issues:
+   ```bash
+   curl -s -u admin:admin "http://localhost:9000/api/issues/search?projectKeys=<project-key>&statuses=OPEN&ps=50"
+   ```
+
+## If SonarQube is not available
+
+Perform manual static analysis checks:
+- [ ] Cognitive complexity — functions over 15 should be refactored
+- [ ] Duplicated code blocks (3+ lines repeated)
+- [ ] Unused imports and variables
+- [ ] Empty catch blocks without comments
+- [ ] Nested ternary operations
+- [ ] `console.log` left in production code
+
+## Output
+
+Report:
+- Quality gate status (passed/failed)
+- Issues found by severity (blocker, critical, major, minor)
+- For each issue: file, line, rule, and suggested fix
+- Fix critical and blocker issues before proceeding

--- a/templates/skills/kj-test.md
+++ b/templates/skills/kj-test.md
@@ -1,0 +1,40 @@
+# kj-test — Test Quality Audit
+
+Evaluate test coverage and quality for the current changes.
+
+## Your task
+
+$ARGUMENTS
+
+## Steps
+
+1. Run `git diff main...HEAD` to identify changed source files
+2. For each changed source file, find the corresponding test file
+3. Run the test suite and check results
+4. Evaluate test quality
+
+## Checks
+
+### Coverage
+- [ ] Every changed source file has a corresponding test file
+- [ ] New functions/methods have at least one test
+- [ ] Edge cases are covered (null, empty, boundary values)
+
+### Quality
+- [ ] Tests have meaningful assertions (not just "no error thrown")
+- [ ] Test descriptions clearly state what is being tested
+- [ ] No tests that always pass (e.g., empty test body, `expect(true).toBe(true)`)
+- [ ] Mocks are minimal — prefer real implementations where feasible
+
+### Execution
+- [ ] Run `npm test` (or project equivalent) and report results
+- [ ] All tests pass
+- [ ] No skipped tests (`.skip`) for the changed code
+
+## Output
+
+Report:
+- Test files found/missing for each changed source file
+- Test execution results (pass/fail count)
+- Quality issues found
+- Suggestions for improving coverage


### PR DESCRIPTION
## Summary
Adds 8 Karajan skills that install as Claude Code slash commands in `.claude/commands/`. Each skill is a self-contained prompt with built-in guardrails — no MCP server needed.

**Skills:**
| Command | Role | Description |
|---------|------|-------------|
| `/kj-run` | Full pipeline | Sequential: discover → code → review → test → security → sonar → commit |
| `/kj-code` | Coder | TDD + guardrails (security, destructive ops, performance, diff check) |
| `/kj-review` | Reviewer | Quality review with auto-blocking rules |
| `/kj-test` | Tester | Test coverage and quality audit |
| `/kj-security` | Security | OWASP top 10 scan on diff |
| `/kj-discover` | Discover | Gap detection before coding |
| `/kj-architect` | Architect | Architecture design before implementation |
| `/kj-sonar` | Sonar | SonarQube scan or manual static analysis |

**Two modes coexist:**
- **Skills mode**: simpler, single AI, no MCP — guardrails are in the prompts
- **Orchestrator mode**: multi-agent, MCP server, subprocess — full pipeline control

**Installation:** `kj init` now asks whether to install skills. Skills are copied to `.claude/commands/` and become available as slash commands.

## Test plan
- [x] Full suite: 130 files, 1577 tests pass
- [ ] Manual: run `kj init` and verify skills installed, test `/kj-review` in Claude Code