### PR TITLE
chore: bump version to v1.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- Bump version to v1.24.0 for impeccable design auditor role release

## Changes in v1.24.0
- New `impeccable` pipeline role: automated UI/UX quality gate (PR #119)
- Frontend detection in triage and intent classifier
- `--enable-impeccable` CLI flag, `enableImpeccable` MCP parameter