### PR TITLE
fix(resume): apply session overrides on kj_resume (#KJC-BUG-0009)

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -827,6 +827,7 @@ async function handleResume(a, server, extra) {
   if (!a.sessionId) {
     return failPayload("Missing required field: sessionId");
   }
+  applySessionOverrides(a, ["coder", "reviewer", "tester", "security", "solomon", "enableTester", "enableSecurity", "enableImpeccable"]);
   return handleResumeDirect(a, server, extra);
 }
 


### PR DESCRIPTION
## Summary
- Fix enableTester/enableSecurity/enableImpeccable being ignored on kj_resume
- Add missing applySessionOverrides() call in handleResume()

## Root cause
handleRun() calls applySessionOverrides() at L846 but handleResume() was missing it.
Session overrides from preflight were lost on resume.

## Test plan
- [x] 62 MCP handler tests pass
- [x] Full suite 1586 tests pass