### PR TITLE
fix(solomon): detect and escalate reviewer style-only blocks (#KJC-BUG-0010)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -534,12 +534,12 @@ async function handleBecariaEarlyPrOrPush({ becariaEnabled, config, session, emi
   }
 }
 
-async function handleSolomonCheck({ config, session, emitter, eventBase, logger, task, i, askQuestion, becariaEnabled }) {
+async function handleSolomonCheck({ config, session, emitter, eventBase, logger, task, i, askQuestion, becariaEnabled, blockingIssues }) {
   if (config.pipeline?.solomon?.enabled === false) return { action: "continue" };
 
   try {
     const { evaluateRules, buildRulesContext } = await import("./orchestrator/solomon-rules.js");
-    const rulesContext = await buildRulesContext({ session, task, iteration: i });
+    const rulesContext = await buildRulesContext({ session, task, iteration: i, blockingIssues });
     const rulesResult = evaluateRules(rulesContext, config.solomon?.rules);
 
     if (rulesResult.alerts.length > 0) {
@@ -1100,7 +1100,7 @@ async function runSingleIteration(ctx) {
   }));
   session.standby_retry_count = 0;
 
-  const solomonResult = await handleSolomonCheck({ config, session, emitter, eventBase, logger, task, i, askQuestion, becariaEnabled });
+  const solomonResult = await handleSolomonCheck({ config, session, emitter, eventBase, logger, task, i, askQuestion, becariaEnabled, blockingIssues: review?.blocking_issues });
   if (solomonResult.action === "pause") return { action: "return", result: solomonResult.result };
 
   await handleBecariaReviewDispatch({ becariaEnabled, config, session, review, i, logger });

--- a/src/orchestrator/solomon-rules.js
+++ b/src/orchestrator/solomon-rules.js
@@ -8,7 +8,8 @@ const DEFAULT_RULES = {
   max_stale_iterations: 3,
   no_new_dependencies_without_task: true,
   scope_guard: true,
-  reviewer_overreach: true
+  reviewer_overreach: true,
+  reviewer_style_block: true
 };
 
 export function evaluateRules(context, rulesConfig = {}) {
@@ -71,6 +72,25 @@ export function evaluateRules(context, rulesConfig = {}) {
     });
   }
 
+  // Rule 6: Reviewer style-only block — all blocking issues are style/naming/formatting, not security/correctness
+  if (rules.reviewer_style_block && context.blockingIssues?.length > 0) {
+    const styleKeywords = /\b(naming|name|rename|style|format|formatting|indent|spacing|camelCase|snake_case|convention|cosmetic|readability|comment|jsdoc|documentation|whitespace|semicolon|quotes|trailing)\b/i;
+    const styleSeverities = new Set(["low", "minor"]);
+    const allStyle = context.blockingIssues.every(issue => {
+      const desc = issue.description || "";
+      const sev = (issue.severity || "").toLowerCase();
+      return styleSeverities.has(sev) || styleKeywords.test(desc);
+    });
+    if (allStyle) {
+      alerts.push({
+        rule: "reviewer_style_block",
+        severity: "critical",
+        message: `Reviewer blocked on ${context.blockingIssues.length} style-only issue(s). Style preferences should not block approval — escalating to Solomon mediation.`,
+        detail: { issueCount: context.blockingIssues.length, issues: context.blockingIssues.map(i => i.description) }
+      });
+    }
+  }
+
   return {
     alerts,
     hasCritical: alerts.some(a => a.severity === "critical"),
@@ -81,7 +101,7 @@ export function evaluateRules(context, rulesConfig = {}) {
 /**
  * Build context for rules evaluation from git diff and session state.
  */
-export async function buildRulesContext({ session, task, iteration }) {
+export async function buildRulesContext({ session, task, iteration, blockingIssues }) {
   const context = {
     task,
     iteration,
@@ -90,7 +110,8 @@ export async function buildRulesContext({ session, task, iteration }) {
     newDependencies: [],
     outOfScopeFiles: [],
     reviewerDemotedCount: 0,
-    reviewerAutoApproved: false
+    reviewerAutoApproved: false,
+    blockingIssues: blockingIssues || []
   };
 
   // Count reviewer scope-filter demotions from session checkpoints


### PR DESCRIPTION
## Summary
- Add Solomon Rule 6: `reviewer_style_block` — detects when ALL reviewer blocking issues are style/naming/formatting only
- When triggered, escalates to Solomon mediation instead of letting the reviewer block indefinitely
- Style detection via severity (low/minor) and keyword matching (naming, format, convention, etc.)
- Passes reviewer `blockingIssues` to Solomon rules context for analysis

## Root cause
Solomon only detected "reviewer overreach" via scope-filter demotions (out-of-scope files). Style issues on changed files were never flagged as overreach because they're technically in-scope. Solomon never intervened.

## Test plan
- [x] 14 Solomon rules tests pass
- [x] Full suite 1586 tests pass
- [x] No regressions