### PR TITLE
feat(sonar): auto-manage SonarQube without user intervention

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -900,7 +900,9 @@ async function runQualityGateStages({ config, logger, emitter, eventBase, sessio
   if (tddResult.action === "pause") return { action: "return", result: tddResult.result };
   if (tddResult.action === "continue") return { action: "continue" };
 
-  if (config.sonarqube.enabled) {
+  const skipSonarForTaskType = new Set(["infra", "doc"]);
+  const effectiveTaskType = session.resolved_policies?.taskType || null;
+  if (config.sonarqube.enabled && !skipSonarForTaskType.has(effectiveTaskType)) {
     const sonarResult = await runSonarStage({
       config, logger, emitter, eventBase, session, trackBudget, iteration: i,
       repeatDetector, budgetSummary, sonarState, askQuestion, task

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -341,6 +341,23 @@ async function handleSonarRetryLimit({ config, logger, emitter, eventBase, sessi
 }
 
 async function handleSonarBlocking({ sonarResult, config, logger, emitter, eventBase, session, iteration, repeatDetector, budgetSummary, askQuestion, task }) {
+  // If the ONLY quality gate failure is coverage, treat as non-blocking warning
+  if (sonarResult.conditions) {
+    const failedConditions = sonarResult.conditions.filter(c => c.status === "ERROR");
+    const onlyCoverage = failedConditions.length > 0 && failedConditions.every(c =>
+      c.metricKey === "new_coverage" || c.metricKey === "coverage"
+    );
+    if (onlyCoverage) {
+      logger.warn("Quality gate failed on coverage only — treating as advisory (code quality is clean)");
+      emitProgress(emitter, makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
+        status: "warn",
+        message: "Quality gate: coverage below threshold (advisory — code quality is clean)"
+      }));
+      session.last_reviewer_feedback = null;
+      return { action: "ok", stageResult: { gateStatus: "WARN_COVERAGE", advisory: true } };
+    }
+  }
+
   repeatDetector.addIteration(sonarResult.issues, []);
   const repeatState = repeatDetector.isStalled();
   if (repeatState.stalled) {
@@ -368,6 +385,39 @@ export async function runSonarStage({ config, logger, emitter, eventBase, sessio
       message: "SonarQube scanning"
     })
   );
+
+  // Auto-manage SonarQube: ensure it is reachable before scanning
+  const { sonarUp, isSonarReachable } = await import("../sonar/manager.js");
+  const sonarHost = config.sonarqube?.host || "http://localhost:9000";
+
+  if (!await isSonarReachable(sonarHost)) {
+    logger.info("SonarQube not reachable, attempting to start...");
+    emitProgress(emitter, makeEvent("sonar:start", { ...eventBase, stage: "sonar" }, { message: "Starting SonarQube Docker..." }));
+
+    const upResult = await sonarUp(sonarHost);
+    if (upResult.exitCode !== 0) {
+      logger.warn(`SonarQube could not be started: ${upResult.stderr || upResult.stdout}`);
+      emitProgress(emitter, makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
+        status: "skip",
+        message: "SonarQube not available — install Docker and run 'kj sonar start' to enable static analysis"
+      }));
+      return { action: "ok", stageResult: { gateStatus: "SKIPPED", reason: "SonarQube not available" } };
+    }
+
+    let ready = false;
+    for (let attempt = 0; attempt < 12; attempt++) {
+      await new Promise(r => setTimeout(r, 5000));
+      if (await isSonarReachable(sonarHost)) { ready = true; break; }
+    }
+    if (!ready) {
+      logger.warn("SonarQube started but not ready after 60s");
+      emitProgress(emitter, makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
+        status: "skip", message: "SonarQube started but not ready — will retry next iteration"
+      }));
+      return { action: "ok", stageResult: { gateStatus: "PENDING", reason: "SonarQube starting up" } };
+    }
+    logger.info("SonarQube is ready");
+  }
 
   const sonarRole = new SonarRole({ config, logger, emitter });
   await sonarRole.init({ iteration });

--- a/src/roles/sonar-role.js
+++ b/src/roles/sonar-role.js
@@ -54,6 +54,7 @@ export class SonarRole extends BaseRole {
       result: {
         projectKey: scan.projectKey,
         gateStatus: gate.status,
+        conditions: gate.conditions || [],
         issues,
         openIssuesTotal: openIssues.total || 0,
         issuesSummary,

--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -72,9 +72,9 @@ export async function getQualityGateStatus(config, projectKey = null) {
 
   try {
     const parsed = JSON.parse(body);
-    return { ok: true, status: parsed.projectStatus?.status || "ERROR", raw: parsed };
+    return { ok: true, status: parsed.projectStatus?.status || "ERROR", conditions: parsed.projectStatus?.conditions || [], raw: parsed };
   } catch {
-    return { ok: false, status: "ERROR", raw: body };
+    return { ok: false, status: "ERROR", conditions: [], raw: body };
   }
 }
 

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
 import { runCommand } from "../utils/process.js";
 import { sonarUp } from "./manager.js";
 import { resolveSonarProjectKey } from "./project-key.js";
@@ -151,6 +153,33 @@ async function resolveSonarToken(config, apiHost) {
   return null;
 }
 
+export async function ensureSonarProjectProperties(cwd = process.cwd()) {
+  const propsPath = path.join(cwd, "sonar-project.properties");
+  try {
+    await fsPromises.access(propsPath);
+    return; // already exists
+  } catch {
+    // Auto-generate based on project structure
+    let pkg = {};
+    try {
+      const raw = await fsPromises.readFile(path.join(cwd, "package.json"), "utf8");
+      pkg = JSON.parse(raw);
+    } catch {
+      // no package.json or invalid JSON — use defaults
+    }
+    const projectKey = (pkg.name || path.basename(cwd)).replace(/[^a-zA-Z0-9_.-]/g, "_");
+    const props = [
+      `sonar.projectKey=${projectKey}`,
+      `sonar.projectName=${pkg.name || path.basename(cwd)}`,
+      `sonar.sources=src`,
+      `sonar.tests=tests`,
+      `sonar.javascript.lcov.reportPaths=coverage/lcov.info`,
+      `sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**`,
+    ].join("\n");
+    await fsPromises.writeFile(propsPath, props + "\n", "utf8");
+  }
+}
+
 export async function runSonarScan(config, projectKey = null) {
   let effectiveProjectKey;
   try {
@@ -184,6 +213,7 @@ export async function runSonarScan(config, projectKey = null) {
       exitCode: start.exitCode
     };
   }
+  await ensureSonarProjectProperties();
   const token = await resolveSonarToken(config, apiHost);
   if (!token) {
     return {

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -98,12 +98,14 @@ vi.mock("node:fs/promises", () => ({
   default: {
     readFile: vi.fn().mockResolvedValue("review rules"),
     writeFile: vi.fn().mockResolvedValue(undefined),
-    mkdir: vi.fn().mockResolvedValue(undefined)
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn().mockResolvedValue(undefined)
   }
 }));
 
 vi.mock("../src/sonar/manager.js", () => ({
-  sonarUp: vi.fn()
+  sonarUp: vi.fn(),
+  isSonarReachable: vi.fn().mockResolvedValue(true)
 }));
 
 vi.mock("../src/utils/process.js", () => ({


### PR DESCRIPTION
## Summary
- Auto-start SonarQube Docker if not running (wait up to 60s for ready)
- Auto-generate `sonar-project.properties` if missing (from package.json)
- Coverage-only quality gate failure = advisory warning (non-blocking when code is clean)
- Skip sonar for infra/doc task types automatically
- Quality gate conditions passed through for intelligent failure detection

## Test plan
- [x] 131 test files, 1586 tests pass
- [x] Smoke test updated with new mocks