### PR TITLE
fix(pipeline): treat provider 500/5xx as transient — retry instead of fail (#KJC-BUG-0011)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -485,10 +485,18 @@ async function handleStandbyResult({ stageResult, session, emitter, eventBase, i
   }
 
   const standbyRetries = session.standby_retry_count || 0;
+  const isOutage = stageResult.standbyInfo.isProviderOutage;
+  const pauseReason = isOutage
+    ? `Provider outage (${stageResult.standbyInfo.message || "5xx/connection error"}) — retried ${standbyRetries} times. This is NOT a KJ or code problem.`
+    : `Rate limit standby exhausted after ${standbyRetries} retries. Agent: ${stageResult.standbyInfo.agent}`;
+
   if (standbyRetries >= MAX_STANDBY_RETRIES) {
+    session.last_reviewer_feedback = isOutage
+      ? "IMPORTANT: The previous interruption was caused by a provider outage (API 500 error), NOT by a problem in your code or in Karajan. Continue from where you left off."
+      : session.last_reviewer_feedback;
     await pauseSession(session, {
-      question: `Rate limit standby exhausted after ${standbyRetries} retries. Agent: ${stageResult.standbyInfo.agent}`,
-      context: { iteration: i, stage, reason: "standby_exhausted" }
+      question: pauseReason,
+      context: { iteration: i, stage, reason: isOutage ? "provider_outage" : "standby_exhausted" }
     });
     emitProgress(emitter, makeEvent(`${stage}:rate_limit`, { ...eventBase, stage }, {
       status: "paused",

--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -100,9 +100,10 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
         action: "standby",
         standbyInfo: {
           agent: coderRole.provider,
-          cooldownMs: rateLimitCheck.cooldownMs,
+          cooldownMs: rateLimitCheck.cooldownMs || (rateLimitCheck.isProviderOutage ? 30000 : null),
           cooldownUntil: rateLimitCheck.cooldownUntil,
-          message: rateLimitCheck.message
+          message: rateLimitCheck.message,
+          isProviderOutage: rateLimitCheck.isProviderOutage || false
         }
       };
     }
@@ -169,9 +170,10 @@ export async function runRefactorerStage({ refactorerRole, config, logger, emitt
         action: "standby",
         standbyInfo: {
           agent: refactorerRole.provider,
-          cooldownMs: rateLimitCheck.cooldownMs,
+          cooldownMs: rateLimitCheck.cooldownMs || (rateLimitCheck.isProviderOutage ? 30000 : null),
           cooldownUntil: rateLimitCheck.cooldownUntil,
-          message: rateLimitCheck.message
+          message: rateLimitCheck.message,
+          isProviderOutage: rateLimitCheck.isProviderOutage || false
         }
       };
     }
@@ -738,9 +740,10 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
         action: "standby",
         standbyInfo: {
           agent: reviewerRole.provider,
-          cooldownMs: rateLimitCheck.cooldownMs,
+          cooldownMs: rateLimitCheck.cooldownMs || (rateLimitCheck.isProviderOutage ? 30000 : null),
           cooldownUntil: rateLimitCheck.cooldownUntil,
-          message: rateLimitCheck.message
+          message: rateLimitCheck.message,
+          isProviderOutage: rateLimitCheck.isProviderOutage || false
         }
       };
     }

--- a/src/utils/rate-limit-detector.js
+++ b/src/utils/rate-limit-detector.js
@@ -77,22 +77,35 @@ const RATE_LIMIT_PATTERNS = [
   { pattern: /resource exhausted/i, agent: "gemini" },
   { pattern: /quota exceeded/i, agent: "gemini" },
 
-  // Generic (match any agent)
+  // Generic rate limits (match any agent)
   { pattern: /rate limit/i, agent: "unknown" },
   { pattern: /token limit reached/i, agent: "unknown" },
   { pattern: /\b429\b/, agent: "unknown" },
   { pattern: /too many requests/i, agent: "unknown" },
   { pattern: /throttl/i, agent: "unknown" },
+
+  // Provider outages / transient errors (treat like rate limits → retry)
+  { pattern: /\b500\b.*(?:internal server error|error)/i, agent: "unknown" },
+  { pattern: /\b502\b|bad gateway/i, agent: "unknown" },
+  { pattern: /\b503\b|service unavailable/i, agent: "unknown" },
+  { pattern: /\b504\b|gateway timeout/i, agent: "unknown" },
+  { pattern: /overloaded/i, agent: "unknown" },
+  { pattern: /ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket hang up/i, agent: "unknown" },
+  { pattern: /network error|fetch failed/i, agent: "unknown" },
 ];
 
 export function detectRateLimit({ stderr = "", stdout = "" }) {
   const combined = `${stderr}\n${stdout}`;
 
+  const PROVIDER_OUTAGE_PATTERNS = /\b50[0-4]\b|bad gateway|service unavailable|gateway timeout|overloaded|ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket hang up|network error|fetch failed/i;
+
   for (const { pattern, agent } of RATE_LIMIT_PATTERNS) {
     if (pattern.test(combined)) {
       const matchedLine = combined.split("\n").find((l) => pattern.test(l)) || combined.trim();
+      const isProviderOutage = PROVIDER_OUTAGE_PATTERNS.test(matchedLine);
       return {
         isRateLimit: true,
+        isProviderOutage,
         agent,
         message: matchedLine.trim(),
         ...parseCooldown(matchedLine)
@@ -100,5 +113,5 @@ export function detectRateLimit({ stderr = "", stdout = "" }) {
     }
   }
 
-  return { isRateLimit: false, agent: "", message: "", cooldownUntil: null, cooldownMs: null };
+  return { isRateLimit: false, isProviderOutage: false, agent: "", message: "", cooldownUntil: null, cooldownMs: null };
 }


### PR DESCRIPTION
## Summary
- Provider 500/502/503/504 + connection errors now trigger standby+retry (like 429)
- 30s default cooldown for outages
- On resume, coder gets explicit context: "provider outage, not your code"

## Root cause
Only 429/rate-limit patterns triggered standby. 500 errors marked session as failed immediately.

## Test plan
- [x] 134 files, 1659 tests pass