### PR TITLE
fix(mcp): resolve project dir from explicit param, not install path (#KJC-BUG-0012)

### DIFF
--- a/src/mcp/run-kj.js
+++ b/src/mcp/run-kj.js
@@ -76,11 +76,14 @@ export async function runKjCommand({ command, commandArgs = [], options = {}, en
 
   const timeout = options.timeoutMs ? Number(options.timeoutMs) : undefined;
 
-  const result = await execa("node", args, {
+  const execOpts = {
     env: runEnv,
     reject: false,
     timeout
-  });
+  };
+  if (options.projectDir) execOpts.cwd = options.projectDir;
+
+  const result = await execa("node", args, execOpts);
 
   const ok = result.exitCode === 0;
   const payload = {

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -25,20 +25,37 @@ import { currentBranch } from "../utils/git.js";
 import { isPreflightAcked, ackPreflight, getSessionOverrides } from "./preflight.js";
 
 /**
- * Resolve the user's project directory via MCP roots.
- * Falls back to process.cwd() if roots are not available.
+ * Resolve the user's project directory.
+ * Priority: 1) explicit projectDir param, 2) MCP roots, 3) error with instructions.
  */
-async function resolveProjectDir(server) {
+async function resolveProjectDir(server, explicitProjectDir) {
+  // 1. Explicit projectDir from tool parameter — always wins
+  if (explicitProjectDir) return explicitProjectDir;
+
+  // 2. MCP roots (host-provided workspace directory)
   try {
     const { roots } = await server.listRoots();
     if (roots?.length > 0) {
       const uri = roots[0].uri;
-      // MCP roots use file:// URIs
       if (uri.startsWith("file://")) return new URL(uri).pathname;
       return uri;
     }
   } catch { /* client may not support roots */ }
-  return process.cwd();
+
+  // 3. Check if process.cwd() looks like a real project (has package.json or .git)
+  const cwd = process.cwd();
+  try {
+    const hasGit = await fs.access(`${cwd}/.git`).then(() => true).catch(() => false);
+    const hasPkg = await fs.access(`${cwd}/package.json`).then(() => true).catch(() => false);
+    if (hasGit || hasPkg) return cwd;
+  } catch { /* ignore */ }
+
+  // 4. No valid project directory — fail with clear instructions
+  throw new Error(
+    `Cannot determine project directory. The MCP server is running from "${cwd}" which does not appear to be your project. ` +
+    `Fix: pass the "projectDir" parameter with the absolute path to your project (e.g., projectDir: "/home/user/my-project"), ` +
+    `or run "kj init" inside your project directory.`
+  );
 }
 
 export function asObject(value) {
@@ -260,7 +277,7 @@ export async function handleRunDirect(a, server, extra) {
   if (config.pipeline?.security?.enabled) requiredProviders.push(resolveRole(config, "security").provider);
   await assertAgentsAvailable(requiredProviders);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_run] started — task="${a.task.slice(0, 80)}..."`);
 
@@ -293,7 +310,7 @@ export async function handleResumeDirect(a, server, extra) {
   const config = await buildConfig(a);
   const logger = createLogger(config.output.log_level, "mcp");
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_resume] started — session="${a.sessionId}"`);
 
@@ -349,7 +366,7 @@ export async function handlePlanDirect(a, server, extra) {
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
     ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
@@ -416,7 +433,7 @@ export async function handleCodeDirect(a, server, extra) {
   const coderRole = resolveRole(config, "coder");
   await assertAgentsAvailable([coderRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_code] started — provider=${coderRole.provider}`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -465,7 +482,7 @@ export async function handleReviewDirect(a, server, extra) {
   const reviewerRole = resolveRole(config, "reviewer");
   await assertAgentsAvailable([reviewerRole.provider, config.reviewer_options?.fallback_reviewer]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_review] started — provider=${reviewerRole.provider}`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -512,7 +529,7 @@ export async function handleDiscoverDirect(a, server, extra) {
   const discoverRole = resolveRole(config, "discover");
   await assertAgentsAvailable([discoverRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_discover] started — mode=${a.mode || "gaps"}`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -565,7 +582,7 @@ export async function handleTriageDirect(a, server, extra) {
   const triageRole = resolveRole(config, "triage");
   await assertAgentsAvailable([triageRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_triage] started`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -609,7 +626,7 @@ export async function handleResearcherDirect(a, server, extra) {
   const researcherRole = resolveRole(config, "researcher");
   await assertAgentsAvailable([researcherRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_researcher] started`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -653,7 +670,7 @@ export async function handleArchitectDirect(a, server, extra) {
   const architectRole = resolveRole(config, "architect");
   await assertAgentsAvailable([architectRole.provider]);
 
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_architect] started`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -780,7 +797,7 @@ function buildReportArgs(a) {
 
 async function handleStatus(a, server) {
   const maxLines = a.lines || 50;
-  const projectDir = await resolveProjectDir(server);
+  const projectDir = await resolveProjectDir(server, a.projectDir);
   return readRunLog(projectDir, maxLines);
 }
 

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -53,6 +53,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description for the coder (can include a Planning Game card ID like KJC-TSK-0042)" },
+        projectDir: { type: "string", description: "Absolute path to the project directory. Required when KJ MCP server runs from a different directory than the target project." },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as task context and updates card status on completion." },
         pgProject: { type: "string", description: "Planning Game project ID (e.g., 'Karajan Code'). Required when pgTask is used." },
         planner: { type: "string" },
@@ -112,6 +113,7 @@ export const tools = [
       properties: {
         sessionId: { type: "string", description: "Session ID to resume" },
         answer: { type: "string", description: "Answer to the question that caused the pause" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -185,6 +187,7 @@ export const tools = [
         task: { type: "string" },
         coder: { type: "string" },
         coderModel: { type: "string" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -200,6 +203,7 @@ export const tools = [
         reviewer: { type: "string" },
         reviewerModel: { type: "string" },
         baseRef: { type: "string" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -226,6 +230,7 @@ export const tools = [
         plannerModel: { type: "string" },
         coder: { type: "string", description: "Legacy alias for planner" },
         coderModel: { type: "string", description: "Legacy alias for plannerModel" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -242,6 +247,7 @@ export const tools = [
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
         pgProject: { type: "string", description: "Planning Game project ID. Required when pgTask is used." },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -254,6 +260,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to classify" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -266,6 +273,7 @@ export const tools = [
       required: ["task"],
       properties: {
         task: { type: "string", description: "Task description to research" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }
@@ -279,6 +287,7 @@ export const tools = [
       properties: {
         task: { type: "string", description: "Task description to architect" },
         context: { type: "string", description: "Additional context (e.g., researcher output)" },
+        projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
     }

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -97,7 +97,9 @@ vi.mock("../src/review/profiles.js", () => ({
 }));
 
 vi.mock("node:fs/promises", () => ({
-  default: { readFile: vi.fn().mockResolvedValue("coder rules content") }
+  default: { readFile: vi.fn().mockResolvedValue("coder rules content"), access: vi.fn().mockResolvedValue(undefined) },
+  readFile: vi.fn().mockResolvedValue("coder rules content"),
+  access: vi.fn().mockResolvedValue(undefined)
 }));
 
 vi.mock("../src/utils/git.js", () => ({


### PR DESCRIPTION
## Summary
- All MCP tools now accept `projectDir` parameter
- Resolution: explicit param > MCP roots > cwd (if valid project) > error with instructions
- No silent fallback — fails with clear fix instructions if project dir cannot be determined
- Subprocess CLI runs with correct cwd

## Root cause
resolveProjectDir() fell back to process.cwd() which was karajan-code's install dir, not the user's project.

## Test plan
- [x] 137 files, 1688 tests pass