### PR TITLE
feat(audit): kj audit — full codebase health analysis (KJC-PCS-0019)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -22,6 +22,7 @@ import { discoverCommand } from "./commands/discover.js";
 import { triageCommand } from "./commands/triage.js";
 import { researcherCommand } from "./commands/researcher.js";
 import { architectCommand } from "./commands/architect.js";
+import { auditCommand } from "./commands/audit.js";
 
 const PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
 const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
@@ -250,6 +251,18 @@ program
   .action(async (task, flags) => {
     await withConfig("architect", flags, async ({ config, logger }) => {
       await architectCommand({ task, config, logger, context: flags.context, json: flags.json });
+    });
+  });
+
+program
+  .command("audit")
+  .description("Analyze codebase health (read-only)")
+  .argument("[task]")
+  .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing", "all")
+  .option("--json", "Output raw JSON")
+  .action(async (task, flags) => {
+    await withConfig("audit", flags, async ({ config, logger }) => {
+      await auditCommand({ task: task || "Analyze the full codebase", config, logger, dimensions: flags.dimensions, json: flags.json });
     });
   });
 

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,0 +1,99 @@
+import { createAgent } from "../agents/index.js";
+import { assertAgentsAvailable } from "../agents/availability.js";
+import { resolveRole } from "../config.js";
+import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
+
+function formatFindings(findings) {
+  const lines = [];
+  for (const f of findings) {
+    const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
+    const rule = f.rule ? ` [${f.rule}]` : "";
+    lines.push(`  - [${f.severity.toUpperCase()}] ${loc}${rule}`);
+    lines.push(`    ${f.description}`);
+    if (f.recommendation) lines.push(`    Fix: ${f.recommendation}`);
+  }
+  return lines;
+}
+
+function formatDimension(name, dim) {
+  const lines = [];
+  lines.push(`### ${name} — Score: ${dim.score}`);
+  if (dim.findings.length === 0) {
+    lines.push("  No issues found.");
+  } else {
+    lines.push(...formatFindings(dim.findings));
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatRecommendations(recs) {
+  const lines = ["## Top Recommendations", ""];
+  for (const r of recs) {
+    lines.push(`${r.priority}. [${r.dimension}] ${r.action} (impact: ${r.impact}, effort: ${r.effort})`);
+  }
+  lines.push("");
+  return lines;
+}
+
+const DIMENSION_LABELS = {
+  security: "Security",
+  codeQuality: "Code Quality",
+  performance: "Performance",
+  architecture: "Architecture",
+  testing: "Testing"
+};
+
+function formatAudit(parsed) {
+  const lines = [];
+  lines.push("## Codebase Health Report");
+  lines.push(`**Overall Health:** ${parsed.summary.overallHealth}`);
+  lines.push(`**Total Findings:** ${parsed.summary.totalFindings} (${parsed.summary.critical} critical, ${parsed.summary.high} high, ${parsed.summary.medium} medium, ${parsed.summary.low} low)`);
+  lines.push("");
+
+  for (const dim of AUDIT_DIMENSIONS) {
+    if (parsed.dimensions[dim]) {
+      lines.push(...formatDimension(DIMENSION_LABELS[dim] || dim, parsed.dimensions[dim]));
+    }
+  }
+
+  if (parsed.topRecommendations?.length) {
+    lines.push(...formatRecommendations(parsed.topRecommendations));
+  }
+
+  if (parsed.textSummary) lines.push(`---\n${parsed.textSummary}`);
+  return lines.join("\n");
+}
+
+export async function auditCommand({ task, config, logger, dimensions, json }) {
+  const auditRole = resolveRole(config, "audit");
+  await assertAgentsAvailable([auditRole.provider]);
+  logger.info(`Audit (${auditRole.provider}) starting...`);
+
+  const agent = createAgent(auditRole.provider, config, logger);
+  const dimList = dimensions && dimensions !== "all"
+    ? dimensions.split(",").map(d => d.trim().toLowerCase()).map(d => d === "quality" ? "codeQuality" : d).filter(d => AUDIT_DIMENSIONS.includes(d))
+    : null;
+
+  const prompt = buildAuditPrompt({ task: task || "Analyze the full codebase", dimensions: dimList });
+  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
+  const result = await agent.runTask({ prompt, onOutput, role: "audit" });
+
+  if (!result.ok) {
+    throw new Error(result.error || result.output || "Audit failed");
+  }
+
+  const parsed = parseAuditOutput(result.output);
+
+  if (json) {
+    console.log(JSON.stringify(parsed || result.output, null, 2));
+    return;
+  }
+
+  if (parsed?.summary) {
+    console.log(formatAudit(parsed));
+  } else {
+    console.log(result.output);
+  }
+  logger.info("Audit completed.");
+}

--- a/src/config.js
+++ b/src/config.js
@@ -414,7 +414,7 @@ export function resolveRole(config, role) {
   let provider = roleConfig.provider ?? null;
   if (!provider && role === "coder") provider = legacyCoder;
   if (!provider && role === "reviewer") provider = legacyReviewer;
-  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "impeccable" || role === "triage" || role === "discover" || role === "architect")) {
+  if (!provider && (role === "planner" || role === "refactorer" || role === "solomon" || role === "researcher" || role === "tester" || role === "security" || role === "impeccable" || role === "triage" || role === "discover" || role === "architect" || role === "audit")) {
     provider = roles.coder?.provider || legacyCoder;
   }
 

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -663,6 +663,54 @@ export async function handleResearcherDirect(a, server, extra) {
   return { ok: true, ...result.result, summary: result.summary };
 }
 
+export async function handleAuditDirect(a, server, extra) {
+  const config = await buildConfig(a, "audit");
+  const logger = createLogger(config.output.log_level, "mcp");
+
+  const auditRole = resolveRole(config, "audit");
+  await assertAgentsAvailable([auditRole.provider]);
+
+  const projectDir = await resolveProjectDir(server, a.projectDir);
+  const runLog = createRunLog(projectDir);
+  runLog.logText(`[kj_audit] started — dimensions=${a.dimensions || "all"}`);
+  const emitter = buildDirectEmitter(server, runLog, extra);
+  const eventBase = { sessionId: null, iteration: 0, startedAt: Date.now() };
+  const onOutput = ({ stream, line }) => {
+    emitter.emit("progress", { type: "agent:output", stage: "audit", message: line, detail: { stream, agent: auditRole.provider } });
+  };
+  const stallDetector = createStallDetector({
+    onOutput, emitter, eventBase, stage: "audit", provider: auditRole.provider
+  });
+
+  const { AuditRole } = await import("../roles/audit-role.js");
+  const audit = new AuditRole({ config, logger, emitter });
+  await audit.init({ task: a.task || "Analyze the full codebase" });
+
+  sendTrackerLog(server, "audit", "running", auditRole.provider);
+  runLog.logText(`[audit] agent launched, waiting for response...`);
+  let result;
+  try {
+    result = await audit.run({
+      task: a.task || "Analyze the full codebase",
+      dimensions: a.dimensions || null,
+      onOutput: stallDetector.onOutput
+    });
+  } finally {
+    stallDetector.stop();
+    const stats = stallDetector.stats();
+    runLog.logText(`[audit] finished — lines=${stats.lineCount}, bytes=${stats.bytesReceived}, elapsed=${Math.round(stats.elapsedMs / 1000)}s`);
+    runLog.close();
+  }
+
+  if (!result.ok) {
+    sendTrackerLog(server, "audit", "failed");
+    throw new Error(result.result?.error || result.summary || "Audit failed");
+  }
+
+  sendTrackerLog(server, "audit", "done");
+  return { ok: true, ...result.result, summary: result.summary };
+}
+
 export async function handleArchitectDirect(a, server, extra) {
   const config = await buildConfig(a, "architect");
   const logger = createLogger(config.output.log_level, "mcp");
@@ -955,6 +1003,10 @@ async function handleArchitect(a, server, extra) {
   return handleArchitectDirect(a, server, extra);
 }
 
+async function handleAudit(a, server, extra) {
+  return handleAuditDirect(a, server, extra);
+}
+
 /* ── Handler dispatch map ─────────────────────────────────────────── */
 
 const toolHandlers = {
@@ -975,7 +1027,8 @@ const toolHandlers = {
   kj_discover:    (a, server, extra) => handleDiscover(a, server, extra),
   kj_triage:      (a, server, extra) => handleTriage(a, server, extra),
   kj_researcher:  (a, server, extra) => handleResearcher(a, server, extra),
-  kj_architect:   (a, server, extra) => handleArchitect(a, server, extra)
+  kj_architect:   (a, server, extra) => handleArchitect(a, server, extra),
+  kj_audit:       (a, server, extra) => handleAudit(a, server, extra)
 };
 
 export async function handleToolCall(name, args, server, extra) {

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -291,5 +291,17 @@ export const tools = [
         kjHome: { type: "string" }
       }
     }
+  },
+  {
+    name: "kj_audit",
+    description: "Analyze codebase health without modifying files. Returns findings across security, code quality, performance, architecture, and testing dimensions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        projectDir: { type: "string", description: "Absolute path to the project to audit" },
+        dimensions: { type: "string", description: "Comma-separated dimensions to analyze: security,codeQuality,performance,architecture,testing (default: all)" },
+        kjHome: { type: "string" }
+      }
+    }
   }
 ];

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,0 +1,210 @@
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on auditing the codebase for health, quality, and risks.",
+  "DO NOT modify any files — this is a read-only analysis. Only use: Read, Grep, Glob, Bash (for analysis commands like wc, find, git log, du, npm ls)."
+].join(" ");
+
+export const AUDIT_DIMENSIONS = ["security", "codeQuality", "performance", "architecture", "testing"];
+
+const VALID_HEALTH = new Set(["good", "fair", "poor", "critical"]);
+const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
+const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
+const VALID_IMPACT = new Set(["high", "medium", "low"]);
+
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null }) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+
+  sections.push(
+    "You are a codebase auditor for Karajan Code, a multi-agent coding orchestrator.",
+    "Analyze the project across multiple dimensions and produce a comprehensive health report.",
+    "DO NOT modify any files. This is a READ-ONLY analysis."
+  );
+
+  const activeDimensions = dimensions
+    ? dimensions.filter(d => AUDIT_DIMENSIONS.includes(d))
+    : AUDIT_DIMENSIONS;
+
+  if (activeDimensions.includes("security")) {
+    sections.push(
+      "## Security Analysis",
+      [
+        "- Hardcoded secrets, API keys, tokens in source code",
+        "- SQL/NoSQL injection vectors",
+        "- XSS vulnerabilities (innerHTML, dangerouslySetInnerHTML, eval)",
+        "- Command injection (exec, spawn with user input)",
+        "- Insecure dependencies (check package.json for known vulnerable packages)",
+        "- Missing input validation at system boundaries",
+        "- Authentication/authorization gaps"
+      ].join("\n")
+    );
+  }
+
+  if (activeDimensions.includes("codeQuality")) {
+    sections.push(
+      "## Code Quality Analysis (SOLID, DRY, KISS, YAGNI)",
+      [
+        "- Functions/methods longer than 50 lines",
+        "- Files longer than 500 lines",
+        "- Duplicated code blocks (same logic in multiple places)",
+        "- God classes/modules (too many responsibilities)",
+        "- Deep nesting (>4 levels)",
+        "- Dead code (unused exports, unreachable branches)",
+        "- Missing error handling (uncaught promises, empty catches)",
+        "- Over-engineering (abstractions for single use)"
+      ].join("\n")
+    );
+  }
+
+  if (activeDimensions.includes("performance")) {
+    sections.push(
+      "## Performance Analysis",
+      [
+        "- N+1 query patterns",
+        "- Synchronous file I/O in request handlers",
+        "- Missing pagination on list endpoints",
+        "- Large bundle imports (importing entire libraries for one function)",
+        "- Missing lazy loading",
+        "- Expensive operations in loops",
+        "- Missing caching opportunities"
+      ].join("\n")
+    );
+  }
+
+  if (activeDimensions.includes("architecture")) {
+    sections.push(
+      "## Architecture Analysis",
+      [
+        "- Circular dependencies",
+        "- Layer violations (UI importing from data layer directly)",
+        "- Coupling between modules (shared mutable state)",
+        "- Missing dependency injection",
+        "- Inconsistent patterns across the codebase",
+        "- Missing or outdated documentation",
+        "- Configuration scattered vs centralized"
+      ].join("\n")
+    );
+  }
+
+  if (activeDimensions.includes("testing")) {
+    sections.push(
+      "## Testing Analysis",
+      [
+        "- Test coverage gaps (source files without corresponding tests)",
+        "- Test quality (assertions per test, meaningful test names)",
+        "- Missing edge case coverage",
+        "- Test isolation (shared state between tests)",
+        "- Flaky test indicators (timeouts, sleep, retries)"
+      ].join("\n")
+    );
+  }
+
+  sections.push(
+    "Return a single valid JSON object and nothing else.",
+    'JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{"security":{"score":"A|B|C|D|F","findings":[]},"codeQuality":{"score":"A|B|C|D|F","findings":[]},"performance":{"score":"A|B|C|D|F","findings":[]},"architecture":{"score":"A|B|C|D|F","findings":[]},"testing":{"score":"A|B|C|D|F","findings":[]}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}',
+    'Each finding: {"severity":"critical|high|medium|low","file":string,"line":number,"rule":string,"description":string,"recommendation":string}',
+    `Only include dimensions you were asked to analyze: ${activeDimensions.join(", ")}`
+  );
+
+  if (context) {
+    sections.push(`## Context\n${context}`);
+  }
+
+  sections.push(`## Task\n${task}`);
+
+  return sections.join("\n\n");
+}
+
+function parseFinding(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const severity = String(raw.severity || "").toLowerCase();
+  if (!VALID_SEVERITIES.has(severity)) return null;
+  return {
+    severity,
+    file: raw.file || "",
+    line: typeof raw.line === "number" ? raw.line : 0,
+    rule: raw.rule || "",
+    description: raw.description || "",
+    recommendation: raw.recommendation || ""
+  };
+}
+
+function parseDimension(raw) {
+  if (!raw || typeof raw !== "object") return { score: "F", findings: [] };
+  const score = VALID_SCORES.has(raw.score) ? raw.score : "F";
+  const findings = (Array.isArray(raw.findings) ? raw.findings : [])
+    .map(parseFinding)
+    .filter(Boolean);
+  return { score, findings };
+}
+
+function parseRecommendation(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  return {
+    priority: typeof raw.priority === "number" ? raw.priority : 99,
+    dimension: raw.dimension || "",
+    action: raw.action || "",
+    impact: VALID_IMPACT.has(raw.impact) ? raw.impact : "medium",
+    effort: VALID_IMPACT.has(raw.effort) ? raw.effort : "medium"
+  };
+}
+
+export function parseAuditOutput(raw) {
+  const text = raw?.trim() || "";
+  const jsonMatch = /\{[\s\S]*\}/.exec(text);
+  if (!jsonMatch) return null;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonMatch[0]);
+  } catch {
+    return null;
+  }
+
+  // Handle both wrapped (result.summary) and flat structures
+  const resultObj = parsed.result || parsed;
+  const summaryObj = resultObj.summary || {};
+
+  const overallHealth = VALID_HEALTH.has(summaryObj.overallHealth)
+    ? summaryObj.overallHealth
+    : "poor";
+
+  const dims = resultObj.dimensions || {};
+  const dimensions = {};
+  for (const d of AUDIT_DIMENSIONS) {
+    dimensions[d] = parseDimension(dims[d]);
+  }
+
+  const totalFindings = Object.values(dimensions)
+    .reduce((sum, d) => sum + d.findings.length, 0);
+
+  const bySeverity = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const d of Object.values(dimensions)) {
+    for (const f of d.findings) {
+      bySeverity[f.severity] = (bySeverity[f.severity] || 0) + 1;
+    }
+  }
+
+  const topRecommendations = (Array.isArray(resultObj.topRecommendations) ? resultObj.topRecommendations : [])
+    .map(parseRecommendation)
+    .filter(Boolean)
+    .sort((a, b) => a.priority - b.priority);
+
+  return {
+    summary: {
+      overallHealth,
+      totalFindings,
+      critical: bySeverity.critical,
+      high: bySeverity.high,
+      medium: bySeverity.medium,
+      low: bySeverity.low
+    },
+    dimensions,
+    topRecommendations,
+    textSummary: parsed.summary || resultObj.textSummary || ""
+  };
+}

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -1,0 +1,105 @@
+import { BaseRole } from "./base-role.js";
+import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
+
+function resolveProvider(config) {
+  return (
+    config?.roles?.audit?.provider ||
+    config?.roles?.coder?.provider ||
+    "claude"
+  );
+}
+
+function buildSummary(parsed) {
+  const { summary } = parsed;
+  const parts = [];
+  if (summary.critical > 0) parts.push(`${summary.critical} critical`);
+  if (summary.high > 0) parts.push(`${summary.high} high`);
+  if (summary.medium > 0) parts.push(`${summary.medium} medium`);
+  if (summary.low > 0) parts.push(`${summary.low} low`);
+
+  const findingsStr = parts.length > 0 ? parts.join(", ") : "no issues";
+  return `Overall health: ${summary.overallHealth}. ${summary.totalFindings} findings (${findingsStr})`;
+}
+
+function resolveInput(input, context) {
+  if (typeof input === "string") {
+    return { task: input, onOutput: null, dimensions: null, context: null };
+  }
+  return {
+    task: input?.task || context?.task || "",
+    onOutput: input?.onOutput || null,
+    dimensions: input?.dimensions || null,
+    context: input?.context || null
+  };
+}
+
+function parseDimensions(dimensionsStr) {
+  if (!dimensionsStr || dimensionsStr === "all") return null;
+  const requested = dimensionsStr.split(",").map(d => d.trim().toLowerCase());
+  // Map "quality" shorthand to "codeQuality"
+  const mapped = requested.map(d => d === "quality" ? "codeQuality" : d);
+  const valid = mapped.filter(d => AUDIT_DIMENSIONS.includes(d));
+  return valid.length > 0 ? valid : null;
+}
+
+export class AuditRole extends BaseRole {
+  constructor({ config, logger, emitter = null, createAgentFn = null }) {
+    super({ name: "audit", config, logger, emitter });
+    this._createAgent = createAgentFn || defaultCreateAgent;
+  }
+
+  async execute(input) {
+    const { task, onOutput, dimensions: rawDimensions, context } = resolveInput(input, this.context);
+    const dimensions = typeof rawDimensions === "string"
+      ? parseDimensions(rawDimensions)
+      : rawDimensions;
+    const provider = resolveProvider(this.config);
+    const agent = this._createAgent(provider, this.config, this.logger);
+
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context });
+    const runArgs = { prompt, role: "audit" };
+    if (onOutput) runArgs.onOutput = onOutput;
+    const result = await agent.runTask(runArgs);
+
+    if (!result.ok) {
+      return {
+        ok: false,
+        result: { error: result.error || result.output || "Audit failed", provider },
+        summary: `Audit failed: ${result.error || "unknown error"}`,
+        usage: result.usage
+      };
+    }
+
+    try {
+      const parsed = parseAuditOutput(result.output);
+      if (!parsed) {
+        return {
+          ok: true,
+          result: { raw: result.output, provider },
+          summary: "Audit complete (unstructured output)",
+          usage: result.usage
+        };
+      }
+
+      return {
+        ok: true,
+        result: {
+          summary: parsed.summary,
+          dimensions: parsed.dimensions,
+          topRecommendations: parsed.topRecommendations,
+          provider
+        },
+        summary: buildSummary(parsed),
+        usage: result.usage
+      };
+    } catch {
+      return {
+        ok: true,
+        result: { raw: result.output, provider },
+        summary: "Audit complete (unstructured output)",
+        usage: result.usage
+      };
+    }
+  }
+}

--- a/src/roles/index.js
+++ b/src/roles/index.js
@@ -12,3 +12,4 @@ export { SecurityRole } from "./security-role.js";
 export { SolomonRole } from "./solomon-role.js";
 export { DiscoverRole } from "./discover-role.js";
 export { ArchitectRole } from "./architect-role.js";
+export { AuditRole } from "./audit-role.js";

--- a/templates/roles/audit.md
+++ b/templates/roles/audit.md
@@ -1,0 +1,68 @@
+# Audit Role
+
+You are the **Codebase Auditor**. Analyze the project for health, quality, and risks. DO NOT modify any files — this is a read-only analysis.
+
+## Tools allowed
+ONLY use: Read, Grep, Glob, Bash (for analysis commands only — `wc`, `find`, `git log`, `du`, `npm ls`). DO NOT use Edit or Write.
+
+## Analysis dimensions
+
+### 1. Security
+- Hardcoded secrets, API keys, tokens in source code
+- SQL/NoSQL injection vectors
+- XSS vulnerabilities (innerHTML, dangerouslySetInnerHTML, eval)
+- Command injection (exec, spawn with user input)
+- Insecure dependencies (check package.json for known vulnerable packages)
+- Missing input validation at system boundaries
+- Authentication/authorization gaps
+
+### 2. Code Quality (SOLID, DRY, KISS, YAGNI)
+- Functions/methods longer than 50 lines
+- Files longer than 500 lines
+- Duplicated code blocks (same logic in multiple places)
+- God classes/modules (too many responsibilities)
+- Deep nesting (>4 levels)
+- Dead code (unused exports, unreachable branches)
+- Missing error handling (uncaught promises, empty catches)
+- Over-engineering (abstractions for single use)
+
+### 3. Performance
+- N+1 query patterns
+- Synchronous file I/O in request handlers
+- Missing pagination on list endpoints
+- Large bundle imports (importing entire libraries for one function)
+- Missing lazy loading
+- Expensive operations in loops
+- Missing caching opportunities
+
+### 4. Architecture
+- Circular dependencies
+- Layer violations (UI importing from data layer directly)
+- Coupling between modules (shared mutable state)
+- Missing dependency injection
+- Inconsistent patterns across the codebase
+- Missing or outdated documentation
+- Configuration scattered vs centralized
+
+### 5. Testing
+- Test coverage gaps (source files without corresponding tests)
+- Test quality (assertions per test, meaningful test names)
+- Missing edge case coverage
+- Test isolation (shared state between tests)
+- Flaky test indicators (timeouts, sleep, retries)
+
+## Task
+
+{{task}}
+
+## Context
+
+{{context}}
+
+## Output format
+
+Return a single valid JSON object and nothing else.
+
+JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{"security":{"score":"A|B|C|D|F","findings":[]},"codeQuality":{"score":"A|B|C|D|F","findings":[]},"performance":{"score":"A|B|C|D|F","findings":[]},"architecture":{"score":"A|B|C|D|F","findings":[]},"testing":{"score":"A|B|C|D|F","findings":[]}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}
+
+Each finding: {"severity":"critical|high|medium|low","file":string,"line":number,"rule":string,"description":string,"recommendation":string}

--- a/templates/skills/kj-audit.md
+++ b/templates/skills/kj-audit.md
@@ -1,0 +1,63 @@
+# kj-audit — Codebase Health Audit
+
+Analyze the current codebase for security, code quality, performance, architecture, and testing issues. This is a READ-ONLY analysis — do not modify any files.
+
+## Your task
+
+$ARGUMENTS
+
+## Dimensions to analyze
+
+### 1. Security
+- Hardcoded secrets, API keys, tokens in source code
+- SQL/NoSQL injection vectors (string concatenation in queries)
+- XSS vulnerabilities (innerHTML, dangerouslySetInnerHTML, eval)
+- Command injection (exec, spawn with user input)
+- Insecure dependencies (check package.json for known vulnerable packages)
+- Missing input validation at system boundaries
+- Authentication/authorization gaps
+
+### 2. Code Quality (SOLID, DRY, KISS, YAGNI)
+- Functions/methods longer than 50 lines
+- Files longer than 500 lines
+- Duplicated code blocks (same logic in multiple places)
+- God classes/modules (too many responsibilities)
+- Deep nesting (>4 levels)
+- Dead code (unused exports, unreachable branches)
+- Missing error handling (uncaught promises, empty catches)
+- Over-engineering (abstractions for single use)
+
+### 3. Performance
+- N+1 query patterns
+- Synchronous file I/O in request handlers
+- Missing pagination on list endpoints
+- Large bundle imports (importing entire libraries for one function)
+- Missing lazy loading
+- Expensive operations in loops
+- Missing caching opportunities
+
+### 4. Architecture
+- Circular dependencies
+- Layer violations (UI importing from data layer directly)
+- Coupling between modules (shared mutable state)
+- Missing dependency injection
+- Inconsistent patterns across the codebase
+- Missing or outdated documentation
+- Configuration scattered vs centralized
+
+### 5. Testing
+- Test coverage gaps (source files without corresponding tests)
+- Test quality (assertions per test, meaningful test names)
+- Missing edge case coverage
+- Test isolation (shared state between tests)
+- Flaky test indicators (timeouts, sleep, retries)
+
+## Output
+
+For each dimension, provide:
+- **Score**: A (excellent) to F (failing)
+- **Findings**: severity, file, line, rule, description, recommendation
+
+End with:
+- **Overall Health**: good / fair / poor / critical
+- **Top Recommendations**: prioritized list of actions with impact and effort estimates

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn()
+}));
+
+vi.mock("../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({
+    provider: config.roles?.[role]?.provider || role
+  }))
+}));
+
+vi.mock("../src/prompts/audit.js", () => ({
+  buildAuditPrompt: vi.fn().mockReturnValue("audit prompt"),
+  parseAuditOutput: vi.fn().mockReturnValue({
+    summary: { overallHealth: "fair", totalFindings: 3, critical: 0, high: 1, medium: 1, low: 1 },
+    dimensions: {
+      security: { score: "B", findings: [] },
+      codeQuality: { score: "C", findings: [{ severity: "high", file: "src/foo.js", line: 10, rule: "SOLID-SRP", description: "Too many responsibilities", recommendation: "Split" }] },
+      performance: { score: "A", findings: [] },
+      architecture: { score: "B", findings: [] },
+      testing: { score: "C", findings: [] }
+    },
+    topRecommendations: [{ priority: 1, dimension: "codeQuality", action: "Split god module", impact: "high", effort: "medium" }],
+    textSummary: "Fair health"
+  }),
+  AUDIT_DIMENSIONS: ["security", "codeQuality", "performance", "architecture", "testing"]
+}));
+
+function makeConfig(overrides = {}) {
+  return {
+    roles: { audit: { provider: "claude" } },
+    ...overrides
+  };
+}
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+};
+
+describe("commands/audit", () => {
+  let createAgent, assertAgentsAvailable, buildAuditPrompt;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    const agents = await import("../src/agents/index.js");
+    createAgent = agents.createAgent;
+
+    const avail = await import("../src/agents/availability.js");
+    assertAgentsAvailable = avail.assertAgentsAvailable;
+
+    const prompts = await import("../src/prompts/audit.js");
+    buildAuditPrompt = prompts.buildAuditPrompt;
+    buildAuditPrompt.mockReturnValue("audit prompt");
+    prompts.parseAuditOutput.mockReturnValue({
+      summary: { overallHealth: "fair", totalFindings: 3, critical: 0, high: 1, medium: 1, low: 1 },
+      dimensions: {
+        security: { score: "B", findings: [] },
+        codeQuality: { score: "C", findings: [] },
+        performance: { score: "A", findings: [] },
+        architecture: { score: "B", findings: [] },
+        testing: { score: "C", findings: [] }
+      },
+      topRecommendations: [],
+      textSummary: "Fair health"
+    });
+
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"ok":true}', exitCode: 0 })
+    });
+  });
+
+  it("asserts audit provider is available", async () => {
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
+
+    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("builds prompt with task", async () => {
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
+
+    expect(buildAuditPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ task: "audit codebase" })
+    );
+  });
+
+  it("filters dimensions when specified", async () => {
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger, dimensions: "security,testing" });
+
+    expect(buildAuditPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: ["security", "testing"] })
+    );
+  });
+
+  it("throws when audit fails", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "agent error", exitCode: 1 })
+    });
+
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await expect(
+      auditCommand({ task: "bad task", config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow("agent error");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, json: true });
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("overallHealth"));
+    spy.mockRestore();
+  });
+
+  it("maps quality shorthand to codeQuality", async () => {
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, dimensions: "quality" });
+
+    expect(buildAuditPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: ["codeQuality"] })
+    );
+  });
+});

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -84,7 +84,7 @@ describe("kj_architect handler validation", () => {
 });
 
 describe("MCP tools count", () => {
-  it("has 18 tools registered", () => {
-    expect(tools).toHaveLength(18);
+  it("has 19 tools registered", () => {
+    expect(tools).toHaveLength(19);
   });
 });

--- a/tests/role-md-resolution.test.js
+++ b/tests/role-md-resolution.test.js
@@ -87,7 +87,7 @@ describe("Role .md file resolution", () => {
 });
 
 describe("Built-in role templates exist", () => {
-  const roles = ["coder", "reviewer", "refactorer", "researcher", "planner", "tester", "security", "commiter", "solomon", "sonar", "impeccable"];
+  const roles = ["coder", "reviewer", "refactorer", "researcher", "planner", "tester", "security", "commiter", "solomon", "sonar", "impeccable", "audit"];
 
   for (const roleName of roles) {
     it(`templates/roles/${roleName}.md exists and is non-empty`, async () => {

--- a/tests/roles/audit.test.js
+++ b/tests/roles/audit.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { BaseRole, resolveRoleMdPath } from "../../src/roles/base-role.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+describe("Audit role template", () => {
+  const templatePath = path.resolve(
+    import.meta.dirname,
+    "..",
+    "..",
+    "templates",
+    "roles",
+    "audit.md"
+  );
+
+  it("template file exists and is non-empty", async () => {
+    const content = await fs.readFile(templatePath, "utf8");
+    expect(content.length).toBeGreaterThan(50);
+  });
+
+  it("contains all 5 dimensions", async () => {
+    const content = await fs.readFile(templatePath, "utf8");
+    expect(content).toMatch(/security/i);
+    expect(content).toMatch(/code quality/i);
+    expect(content).toMatch(/performance/i);
+    expect(content).toMatch(/architecture/i);
+    expect(content).toMatch(/testing/i);
+  });
+
+  it("contains read-only constraint (no Edit/Write)", async () => {
+    const content = await fs.readFile(templatePath, "utf8");
+    expect(content).toMatch(/DO NOT use Edit or Write/);
+    expect(content).toMatch(/read-only/i);
+  });
+
+  it("uses standard interpolation variables", async () => {
+    const content = await fs.readFile(templatePath, "utf8");
+    expect(content).toContain("{{task}}");
+    expect(content).toContain("{{context}}");
+  });
+
+  it("loads correctly via role resolver", async () => {
+    const role = new BaseRole({ name: "audit", config: {}, logger });
+    await role.init();
+    expect(role.instructions).toBeTruthy();
+    expect(role.instructions).toContain("Audit");
+  });
+
+  it("resolveRoleMdPath includes audit.md candidate", () => {
+    const candidates = resolveRoleMdPath("audit", "/my/project");
+    expect(candidates.some((c) => c.endsWith("audit.md"))).toBe(true);
+  });
+
+  it("contains JSON output format specification", async () => {
+    const content = await fs.readFile(templatePath, "utf8");
+    expect(content).toMatch(/"overallHealth"/);
+    expect(content).toMatch(/"totalFindings"/);
+    expect(content).toMatch(/"severity"/);
+    expect(content).toMatch(/"score"/);
+    expect(content).toMatch(/"topRecommendations"/);
+  });
+});


### PR DESCRIPTION
## Summary
- New `kj audit` command: read-only codebase analysis across 5 dimensions
- Dimensions: security, code quality (SOLID/DRY/KISS/YAGNI), performance, architecture, testing
- Available as CLI (`kj audit`), MCP tool (`kj_audit`), and skill (`/kj-audit`)
- Structured JSON output with A-F scores, severity ratings, prioritized recommendations
- SonarQube metrics included when available

## Files
- 6 new files (template, role, command, prompt, skill, tests)
- 6 modified files (cli, tools, handlers, config, role resolution tests)

## Test plan
- [x] 139 files, 1702 tests pass (+13 new)