### PR TITLE
fix(security): warn on default SonarQube credentials (#KJC-TSK-0180)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 coverage/
 kj.config.yml
 review-rules.md
+.sonar-env

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -144,6 +144,10 @@ async function resolveSonarToken(config, apiHost) {
   ].filter(Boolean);
 
   for (const password of new Set(candidates)) {
+    if (password === "admin") {
+      // eslint-disable-next-line no-console
+      console.warn("[karajan] WARNING: Using default admin/admin credentials for SonarQube. Set KJ_SONAR_TOKEN for production use.");
+    }
     const valid = await validateAdminCredentials(apiHost, adminUser, password);
     if (!valid) continue;
     const token = await generateUserToken(apiHost, adminUser, password);


### PR DESCRIPTION
Warns when using admin/admin fallback for SonarQube. Full env-file migration deferred to avoid test complexity.