### PR TITLE
chore: bump version to v1.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Security fixes: npm audit (5 vulns), SonarQube default credentials warning