### PR TITLE
test(agents): add 105 unit tests for all agent implementations (#KJC-TSK-0177)

### DIFF
--- a/tests/agents/aider-agent.test.js
+++ b/tests/agents/aider-agent.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  roles: { coder: {}, reviewer: {} },
+  coder_options: {},
+  reviewer_options: {}
+};
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("AiderAgent", () => {
+  let runCommand;
+  let AiderAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+    const mod = await import("../../src/agents/aider-agent.js");
+    AiderAgent = mod.AiderAgent;
+  });
+
+  describe("--yes flag (non-interactive mode)", () => {
+    it("includes --yes flag for runTask", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "add tests", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--yes");
+    });
+
+    it("includes --yes flag for reviewTask", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--yes");
+    });
+
+    it("--yes appears before --message in args", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args.indexOf("--yes")).toBeLessThan(args.indexOf("--message"));
+    });
+  });
+
+  describe("--message flag with task prompt", () => {
+    it("includes --message flag followed by the task prompt", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "implement feature X", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      const msgIdx = args.indexOf("--message");
+      expect(msgIdx).toBeGreaterThanOrEqual(0);
+      expect(args[msgIdx + 1]).toBe("implement feature X");
+    });
+
+    it("passes prompt via --message for reviewTask too", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code quality", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--message");
+      expect(args).toContain("review code quality");
+    });
+  });
+
+  describe("exit code handling", () => {
+    it("returns ok: true on exit code 0", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "changes applied", stderr: "" });
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("changes applied");
+    });
+
+    it("returns ok: false on non-zero exit code", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "aider error" });
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "fail", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("aider error");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("model configuration", () => {
+    it("adds --model when configured", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "gpt-4o" }, reviewer: {} } };
+      const agent = new AiderAgent("aider", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("gpt-4o");
+    });
+
+    it("--model appears after --message in args", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "gpt-4o" }, reviewer: {} } };
+      const agent = new AiderAgent("aider", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args.indexOf("--model")).toBeGreaterThan(args.indexOf("--message"));
+    });
+
+    it("omits --model when not configured", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--model");
+    });
+  });
+
+  describe("no special stdin/env handling (unlike Claude)", () => {
+    it("does NOT set stdin to 'ignore'", async () => {
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.stdin).toBeUndefined();
+    });
+  });
+
+  describe("stdout/stderr mapping", () => {
+    it("maps stdout to output and stderr to error", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "result text", stderr: "warnings" });
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("result text");
+      expect(result.error).toBe("warnings");
+    });
+  });
+
+  describe("timeout and streaming passthrough", () => {
+    it("passes onOutput, silenceTimeoutMs, and timeout to runCommand", async () => {
+      const onOutput = vi.fn();
+      const agent = new AiderAgent("aider", baseConfig, logger);
+      await agent.runTask({
+        prompt: "test",
+        role: "coder",
+        onOutput,
+        silenceTimeoutMs: 25000,
+        timeoutMs: 80000
+      });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.onOutput).toBe(onOutput);
+      expect(opts.silenceTimeoutMs).toBe(25000);
+      expect(opts.timeout).toBe(80000);
+    });
+  });
+});

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  roles: { coder: {}, reviewer: {} },
+  coder_options: {},
+  reviewer_options: {}
+};
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("ClaudeAgent", () => {
+  let runCommand;
+  let ClaudeAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const mod = await import("../../src/agents/claude-agent.js");
+    ClaudeAgent = mod.ClaudeAgent;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDECODE;
+  });
+
+  describe("cleanExecaOpts() — CLAUDECODE env stripping", () => {
+    it("strips CLAUDECODE env var from subprocess options", async () => {
+      process.env.CLAUDECODE = "1";
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).toBeDefined();
+      expect(opts.env).not.toHaveProperty("CLAUDECODE");
+    });
+
+    it("preserves other env vars when stripping CLAUDECODE", async () => {
+      process.env.CLAUDECODE = "1";
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).toHaveProperty("PATH");
+    });
+
+    it("works when CLAUDECODE is not set (no crash)", async () => {
+      delete process.env.CLAUDECODE;
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).toBeDefined();
+      expect(opts.env).not.toHaveProperty("CLAUDECODE");
+    });
+
+    it("strips CLAUDECODE from reviewTask too", async () => {
+      process.env.CLAUDECODE = "1";
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).not.toHaveProperty("CLAUDECODE");
+    });
+  });
+
+  describe("cleanExecaOpts() — stdin handling", () => {
+    it("sets stdin to 'ignore' for runTask", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(runCommand.mock.calls[0][2].stdin).toBe("ignore");
+    });
+
+    it("sets stdin to 'ignore' for reviewTask", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      expect(runCommand.mock.calls[0][2].stdin).toBe("ignore");
+    });
+  });
+
+  describe("pickOutput() — stderr/stdout priority", () => {
+    it("returns stderr content when stdout is empty (Claude 2.x behavior)", async () => {
+      const stderrData = '{"type":"result","result":"task done"}';
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: stderrData });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("task done");
+    });
+
+    it("returns stdout content when stdout is available", async () => {
+      const stdoutData = '{"type":"result","result":"from stdout"}';
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: stdoutData, stderr: "other" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("from stdout");
+    });
+
+    it("returns empty string when both stdout and stderr are empty", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("");
+    });
+
+    it("pickOutput prefers stdout over stderr for reviewTask raw output", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "stdout-data", stderr: "stderr-data" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      expect(result.output).toBe("stdout-data");
+    });
+
+    it("reviewTask falls back to stderr when stdout is empty", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "stderr-only" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      expect(result.output).toBe("stderr-only");
+    });
+  });
+
+  describe("--allowedTools flag", () => {
+    it("includes --allowedTools with all 6 tools for runTask", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--allowedTools");
+      const toolsIdx = args.indexOf("--allowedTools");
+      const tools = args.slice(toolsIdx + 1).filter(a => !a.startsWith("-"));
+      expect(tools).toContain("Read");
+      expect(tools).toContain("Write");
+      expect(tools).toContain("Edit");
+      expect(tools).toContain("Bash");
+      expect(tools).toContain("Glob");
+      expect(tools).toContain("Grep");
+    });
+
+    it("includes --allowedTools for reviewTask", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--allowedTools");
+    });
+  });
+
+  describe("buildArgs — -p flag and output format", () => {
+    it("includes -p flag with the task prompt", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "implement feature X", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      const pIdx = args.indexOf("-p");
+      expect(pIdx).toBeGreaterThanOrEqual(0);
+      expect(args[pIdx + 1]).toBe("implement feature X");
+    });
+
+    it("uses --output-format json when no onOutput callback", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      const fmtIdx = args.indexOf("--output-format");
+      expect(fmtIdx).toBeGreaterThanOrEqual(0);
+      expect(args[fmtIdx + 1]).toBe("json");
+    });
+
+    it("uses --output-format stream-json when onOutput callback is provided", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder", onOutput: vi.fn() });
+
+      const args = runCommand.mock.calls[0][1];
+      const fmtIdx = args.indexOf("--output-format");
+      expect(fmtIdx).toBeGreaterThanOrEqual(0);
+      expect(args[fmtIdx + 1]).toBe("stream-json");
+    });
+
+    it("includes --verbose when streaming", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder", onOutput: vi.fn() });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--verbose");
+    });
+  });
+
+  describe("non-zero exit code handling", () => {
+    it("returns ok: false on non-zero exit code", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "fatal error" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "fail", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.error).toContain("fatal error");
+    });
+
+    it("returns ok: false for exit code 143 (killed)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 143, stdout: "", stderr: "killed" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "timeout", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(143);
+    });
+  });
+
+  describe("rate limit detection in stderr", () => {
+    it("rate limit message in stderr is present in error output", async () => {
+      const rateLimitMsg = "Rate limit exceeded. Please wait before retrying.";
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: rateLimitMsg });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Rate limit");
+    });
+
+    it("rate limit message in stderr is detectable via regex", async () => {
+      const rateLimitMsg = '{"error":"Rate limit exceeded","retryAfter":30}';
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: rateLimitMsg });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(/rate.?limit/i.test(result.error)).toBe(true);
+    });
+  });
+
+  describe("stream-json output parsing", () => {
+    it("extracts result text from NDJSON stream output", async () => {
+      const ndjson = [
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"working..."}]}}',
+        '{"type":"result","result":"final answer"}'
+      ].join("\n");
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: ndjson });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("final answer");
+    });
+
+    it("falls back to accumulating assistant text when no result message", async () => {
+      const ndjson = [
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hello "}]}}',
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"world"}]}}'
+      ].join("\n");
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: ndjson });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("hello world");
+    });
+
+    it("returns raw text when NDJSON parsing fails", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "plain text output" });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("plain text output");
+    });
+  });
+
+  describe("onOutput stream-json filter", () => {
+    it("wraps onOutput callback in a stream-json filter (not passed directly)", async () => {
+      const onOutput = vi.fn();
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder", onOutput });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.onOutput).toBeDefined();
+      expect(opts.onOutput).not.toBe(onOutput);
+    });
+
+    it("passes silenceTimeoutMs and timeout through to runCommand when streaming", async () => {
+      const onOutput = vi.fn();
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({
+        prompt: "test",
+        role: "coder",
+        onOutput,
+        silenceTimeoutMs: 30000,
+        timeoutMs: 120000
+      });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.silenceTimeoutMs).toBe(30000);
+      expect(opts.timeout).toBe(120000);
+    });
+  });
+
+  describe("model configuration", () => {
+    it("adds --model flag from roles config for coder", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "claude-opus-4-20250514" }, reviewer: {} } };
+      const agent = new ClaudeAgent("claude", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("claude-opus-4-20250514");
+    });
+
+    it("adds --model flag from roles config for reviewer", async () => {
+      const config = { ...baseConfig, roles: { coder: {}, reviewer: { model: "claude-sonnet-4-20250514" } } };
+      const agent = new ClaudeAgent("claude", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("claude-sonnet-4-20250514");
+    });
+
+    it("omits --model flag when no model is configured", async () => {
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--model");
+    });
+  });
+});

--- a/tests/agents/codex-agent.test.js
+++ b/tests/agents/codex-agent.test.js
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  roles: { coder: {}, reviewer: {} },
+  coder_options: {},
+  reviewer_options: {}
+};
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("CodexAgent", () => {
+  let runCommand;
+  let CodexAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+    const mod = await import("../../src/agents/codex-agent.js");
+    CodexAgent = mod.CodexAgent;
+  });
+
+  describe("buildArgs — exec command structure", () => {
+    it("starts args with 'exec' subcommand", async () => {
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("exec");
+    });
+
+    it("ends args with '-' to read prompt from stdin", async () => {
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[args.length - 1]).toBe("-");
+    });
+
+    it("passes task prompt via input option (stdin)", async () => {
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({ prompt: "implement feature", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.input).toBe("implement feature");
+    });
+  });
+
+  describe("--full-auto flag", () => {
+    it("adds --full-auto when auto_approve is enabled for coder", async () => {
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(runCommand.mock.calls[0][1]).toContain("--full-auto");
+    });
+
+    it("does NOT add --full-auto when auto_approve is false", async () => {
+      const config = { ...baseConfig, coder_options: { auto_approve: false } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(runCommand.mock.calls[0][1]).not.toContain("--full-auto");
+    });
+
+    it("does NOT add --full-auto for reviewer role (even if auto_approve is on)", async () => {
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      expect(runCommand.mock.calls[0][1]).not.toContain("--full-auto");
+    });
+
+    it("does NOT add --full-auto when coder_options is missing", async () => {
+      const config = { roles: { coder: {}, reviewer: {} } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(runCommand.mock.calls[0][1]).not.toContain("--full-auto");
+    });
+  });
+
+  describe("exit code handling", () => {
+    it("returns ok: true on exit code 0", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "success", stderr: "" });
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("success");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("returns ok: false on non-zero exit code", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "command failed" });
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "fail", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("command failed");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("returns ok: false for exit code 143 (killed)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 143, stdout: "partial", stderr: "killed" });
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "timeout", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(143);
+    });
+  });
+
+  describe("model configuration", () => {
+    it("adds --model flag when model is configured for coder", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "o3" }, reviewer: {} } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("o3");
+    });
+
+    it("adds --model flag for reviewer when configured", async () => {
+      const config = { ...baseConfig, roles: { coder: {}, reviewer: { model: "o4-mini" } } };
+      const agent = new CodexAgent("codex", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("o4-mini");
+    });
+
+    it("omits --model flag when no model is configured", async () => {
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--model");
+    });
+  });
+
+  describe("reviewTask structure", () => {
+    it("uses exec subcommand with stdin for review too", async () => {
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("exec");
+      expect(args[args.length - 1]).toBe("-");
+      expect(runCommand.mock.calls[0][2].input).toBe("review code");
+    });
+
+    it("returns stdout as output and stderr as error", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "review result", stderr: "warnings" });
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      const result = await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      expect(result.output).toBe("review result");
+      expect(result.error).toBe("warnings");
+    });
+  });
+
+  describe("timeout and streaming options passthrough", () => {
+    it("passes onOutput, silenceTimeoutMs, and timeout to runCommand", async () => {
+      const onOutput = vi.fn();
+      const agent = new CodexAgent("codex", baseConfig, logger);
+      await agent.runTask({
+        prompt: "test",
+        role: "coder",
+        onOutput,
+        silenceTimeoutMs: 20000,
+        timeoutMs: 60000
+      });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.onOutput).toBe(onOutput);
+      expect(opts.silenceTimeoutMs).toBe(20000);
+      expect(opts.timeout).toBe(60000);
+    });
+  });
+});

--- a/tests/agents/create-agent.test.js
+++ b/tests/agents/create-agent.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAgent, getAvailableAgents, getAgentMeta, registerAgent } from "../../src/agents/index.js";
+import { ClaudeAgent } from "../../src/agents/claude-agent.js";
+import { CodexAgent } from "../../src/agents/codex-agent.js";
+import { GeminiAgent } from "../../src/agents/gemini-agent.js";
+import { AiderAgent } from "../../src/agents/aider-agent.js";
+import { OpenCodeAgent } from "../../src/agents/opencode-agent.js";
+import { BaseAgent } from "../../src/agents/base-agent.js";
+
+const config = { roles: {}, coder_options: {}, reviewer_options: {} };
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("createAgent factory", () => {
+  describe("creates correct agent instances", () => {
+    it("createAgent('claude') returns ClaudeAgent instance", () => {
+      const agent = createAgent("claude", config, logger);
+      expect(agent).toBeInstanceOf(ClaudeAgent);
+      expect(agent).toBeInstanceOf(BaseAgent);
+    });
+
+    it("createAgent('codex') returns CodexAgent instance", () => {
+      const agent = createAgent("codex", config, logger);
+      expect(agent).toBeInstanceOf(CodexAgent);
+      expect(agent).toBeInstanceOf(BaseAgent);
+    });
+
+    it("createAgent('gemini') returns GeminiAgent instance", () => {
+      const agent = createAgent("gemini", config, logger);
+      expect(agent).toBeInstanceOf(GeminiAgent);
+      expect(agent).toBeInstanceOf(BaseAgent);
+    });
+
+    it("createAgent('aider') returns AiderAgent instance", () => {
+      const agent = createAgent("aider", config, logger);
+      expect(agent).toBeInstanceOf(AiderAgent);
+      expect(agent).toBeInstanceOf(BaseAgent);
+    });
+
+    it("createAgent('opencode') returns OpenCodeAgent instance", () => {
+      const agent = createAgent("opencode", config, logger);
+      expect(agent).toBeInstanceOf(OpenCodeAgent);
+      expect(agent).toBeInstanceOf(BaseAgent);
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws for unknown agent name", () => {
+      expect(() => createAgent("unknown", config, logger)).toThrow("Unsupported agent: unknown");
+    });
+
+    it("throws for empty string agent name", () => {
+      expect(() => createAgent("", config, logger)).toThrow("Unsupported agent: ");
+    });
+
+    it("throws with descriptive message including the agent name", () => {
+      expect(() => createAgent("nonexistent", config, logger)).toThrow("nonexistent");
+    });
+  });
+
+  describe("passes config and logger to agent", () => {
+    it("created agent receives name, config, and logger", () => {
+      const agent = createAgent("claude", config, logger);
+      expect(agent.name).toBe("claude");
+      expect(agent.config).toBe(config);
+      expect(agent.logger).toBe(logger);
+    });
+  });
+
+  describe("getAvailableAgents", () => {
+    it("returns all 5 built-in agents", () => {
+      const agents = getAvailableAgents();
+      const names = agents.map(a => a.name);
+      expect(names).toContain("claude");
+      expect(names).toContain("codex");
+      expect(names).toContain("gemini");
+      expect(names).toContain("aider");
+      expect(names).toContain("opencode");
+    });
+
+    it("each agent entry includes AgentClass", () => {
+      const agents = getAvailableAgents();
+      for (const agent of agents) {
+        expect(agent.AgentClass).toBeDefined();
+        expect(agent.AgentClass.prototype).toBeInstanceOf(BaseAgent);
+      }
+    });
+
+    it("each built-in agent entry includes bin metadata", () => {
+      const agents = getAvailableAgents();
+      const builtIn = agents.filter(a => ["claude", "codex", "gemini", "aider", "opencode"].includes(a.name));
+      for (const agent of builtIn) {
+        expect(agent.bin).toBeDefined();
+        expect(typeof agent.bin).toBe("string");
+      }
+    });
+  });
+
+  describe("getAgentMeta", () => {
+    it("returns metadata for a registered agent", () => {
+      const meta = getAgentMeta("claude");
+      expect(meta).toBeDefined();
+      expect(meta.bin).toBe("claude");
+      expect(meta.installUrl).toContain("anthropic");
+    });
+
+    it("returns null for an unknown agent", () => {
+      const meta = getAgentMeta("nonexistent");
+      expect(meta).toBeNull();
+    });
+  });
+
+  describe("registerAgent", () => {
+    it("throws when name is empty", () => {
+      expect(() => registerAgent("", BaseAgent)).toThrow("Agent name must be a non-empty string");
+    });
+
+    it("throws when name is null", () => {
+      expect(() => registerAgent(null, BaseAgent)).toThrow("Agent name must be a non-empty string");
+    });
+
+    it("throws when name is a number", () => {
+      expect(() => registerAgent(42, BaseAgent)).toThrow("Agent name must be a non-empty string");
+    });
+  });
+});

--- a/tests/agents/gemini-agent.test.js
+++ b/tests/agents/gemini-agent.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  roles: { coder: {}, reviewer: {} },
+  coder_options: {},
+  reviewer_options: {}
+};
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("GeminiAgent", () => {
+  let runCommand;
+  let GeminiAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "output", stderr: "" });
+    const mod = await import("../../src/agents/gemini-agent.js");
+    GeminiAgent = mod.GeminiAgent;
+  });
+
+  describe("buildArgs — -p flag", () => {
+    it("includes -p flag followed by the task prompt", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "build feature", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      const pIdx = args.indexOf("-p");
+      expect(pIdx).toBeGreaterThanOrEqual(0);
+      expect(args[pIdx + 1]).toBe("build feature");
+    });
+
+    it("uses -p for reviewTask too", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("-p");
+      expect(args).toContain("review code");
+    });
+  });
+
+  describe("output format", () => {
+    it("does NOT set --output-format for runTask (plain mode)", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--output-format");
+    });
+
+    it("sets --output-format json for reviewTask", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      const fmtIdx = args.indexOf("--output-format");
+      expect(fmtIdx).toBeGreaterThanOrEqual(0);
+      expect(args[fmtIdx + 1]).toBe("json");
+    });
+  });
+
+  describe("exit code handling", () => {
+    it("returns ok: true on exit code 0", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.output).toBe("done");
+    });
+
+    it("returns ok: false on non-zero exit code", async () => {
+      runCommand.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "crash" });
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.ok).toBe(false);
+      expect(result.exitCode).toBe(2);
+      expect(result.error).toBe("crash");
+    });
+  });
+
+  describe("model configuration", () => {
+    it("adds --model when configured for coder role", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "gemini-2.5-pro" }, reviewer: {} } };
+      const agent = new GeminiAgent("gemini", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("gemini-2.5-pro");
+    });
+
+    it("adds --model when configured for reviewer role", async () => {
+      const config = { ...baseConfig, roles: { coder: {}, reviewer: { model: "gemini-2.5-flash" } } };
+      const agent = new GeminiAgent("gemini", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("gemini-2.5-flash");
+    });
+
+    it("omits --model when no model configured", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--model");
+    });
+  });
+
+  describe("no special stdin/env handling (unlike Claude)", () => {
+    it("does NOT set stdin to 'ignore'", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.stdin).toBeUndefined();
+    });
+
+    it("does NOT strip env vars", async () => {
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).toBeUndefined();
+    });
+  });
+
+  describe("returns stdout/stderr directly (no pickOutput)", () => {
+    it("uses stdout as output, stderr as error", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "response", stderr: "warn" });
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("response");
+      expect(result.error).toBe("warn");
+    });
+  });
+
+  describe("timeout and streaming passthrough", () => {
+    it("passes onOutput, silenceTimeoutMs, and timeout to runCommand", async () => {
+      const onOutput = vi.fn();
+      const agent = new GeminiAgent("gemini", baseConfig, logger);
+      await agent.runTask({
+        prompt: "test",
+        role: "coder",
+        onOutput,
+        silenceTimeoutMs: 15000,
+        timeoutMs: 90000
+      });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.onOutput).toBe(onOutput);
+      expect(opts.silenceTimeoutMs).toBe(15000);
+      expect(opts.timeout).toBe(90000);
+    });
+  });
+});

--- a/tests/agents/opencode-agent.test.js
+++ b/tests/agents/opencode-agent.test.js
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = {
+  roles: { coder: {}, reviewer: {} },
+  coder_options: {},
+  reviewer_options: {}
+};
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe("OpenCodeAgent", () => {
+  let runCommand;
+  let OpenCodeAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+    const mod = await import("../../src/agents/opencode-agent.js");
+    OpenCodeAgent = mod.OpenCodeAgent;
+  });
+
+  describe("basic construction", () => {
+    it("stores name, config, and logger", () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      expect(agent.name).toBe("opencode");
+      expect(agent.config).toBe(baseConfig);
+      expect(agent.logger).toBe(logger);
+    });
+  });
+
+  describe("runTask args", () => {
+    it("starts with 'run' subcommand", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("run");
+    });
+
+    it("puts the prompt as the last argument", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "implement feature", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[args.length - 1]).toBe("implement feature");
+    });
+
+    it("does NOT use stdin for prompt (unlike Codex)", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.input).toBeUndefined();
+    });
+  });
+
+  describe("reviewTask args", () => {
+    it("starts with 'run' subcommand for review too", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review code", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[0]).toBe("run");
+    });
+
+    it("includes --format json for reviewTask", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--format");
+      expect(args).toContain("json");
+    });
+
+    it("does NOT include --format json for runTask", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--format");
+    });
+
+    it("puts prompt as last argument in reviewTask", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.reviewTask({ prompt: "review this", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[args.length - 1]).toBe("review this");
+    });
+  });
+
+  describe("model configuration", () => {
+    it("adds --model when configured for coder role", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "anthropic/claude-3-5-sonnet" }, reviewer: {} } };
+      const agent = new OpenCodeAgent("opencode", config, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("anthropic/claude-3-5-sonnet");
+    });
+
+    it("adds --model when configured for reviewer role", async () => {
+      const config = { ...baseConfig, roles: { coder: {}, reviewer: { model: "openai/gpt-4o" } } };
+      const agent = new OpenCodeAgent("opencode", config, logger);
+      await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--model");
+      expect(args).toContain("openai/gpt-4o");
+    });
+
+    it("--model appears before prompt in args", async () => {
+      const config = { ...baseConfig, roles: { coder: { model: "test-model" }, reviewer: {} } };
+      const agent = new OpenCodeAgent("opencode", config, logger);
+      await agent.runTask({ prompt: "do work", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args.indexOf("--model")).toBeLessThan(args.indexOf("do work"));
+    });
+
+    it("omits --model when not configured", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args).not.toContain("--model");
+    });
+  });
+
+  describe("exit code handling", () => {
+    it("returns ok: true on exit code 0", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "success", stderr: "" });
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result).toEqual({ ok: true, output: "success", error: "", exitCode: 0 });
+    });
+
+    it("returns ok: false on non-zero exit code", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error" });
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "fail", role: "coder" });
+
+      expect(result).toEqual({ ok: false, output: "", error: "error", exitCode: 1 });
+    });
+  });
+
+  describe("no special stdin/env handling", () => {
+    it("does NOT set stdin to 'ignore'", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.stdin).toBeUndefined();
+    });
+
+    it("does NOT strip env vars", async () => {
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({ prompt: "test", role: "coder" });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.env).toBeUndefined();
+    });
+  });
+
+  describe("timeout and streaming passthrough", () => {
+    it("passes onOutput, silenceTimeoutMs, and timeout to runCommand", async () => {
+      const onOutput = vi.fn();
+      const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+      await agent.runTask({
+        prompt: "test",
+        role: "coder",
+        onOutput,
+        silenceTimeoutMs: 10000,
+        timeoutMs: 50000
+      });
+
+      const opts = runCommand.mock.calls[0][2];
+      expect(opts.onOutput).toBe(onOutput);
+      expect(opts.silenceTimeoutMs).toBe(10000);
+      expect(opts.timeout).toBe(50000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
105 new tests covering all 5 agent implementations and the factory.
Focus on subprocess workarounds, edge cases, and error handling.

## Test plan
- [x] 145 files, 1807 tests pass (+105 new)