### PR TITLE
fix(tests): Solomon mock continue for iterating tests

### DIFF
--- a/tests/orchestrator-events.test.js
+++ b/tests/orchestrator-events.test.js
@@ -171,7 +171,7 @@ describe("orchestrator events", () => {
     fs.default.readFile.mockResolvedValue("review rules");
 
     const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
-    invokeSolomon.mockResolvedValue({ action: "pause", question: "Solomon escalated" });
+    invokeSolomon.mockResolvedValue({ action: "continue", humanGuidance: "Proceed" });
 
     const { sonarUp, isSonarReachable } = await import("../src/sonar/manager.js");
     sonarUp.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });

--- a/tests/orchestrator-repeat-detection.test.js
+++ b/tests/orchestrator-repeat-detection.test.js
@@ -71,7 +71,7 @@ vi.mock("../src/prompts/reviewer.js", () => ({
 }));
 
 vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
-  invokeSolomon: vi.fn().mockResolvedValue({ action: "pause", question: "Reviewer stalled" }),
+  invokeSolomon: vi.fn().mockResolvedValue({ action: "continue", humanGuidance: "Proceed" }),
   escalateToHuman: vi.fn().mockResolvedValue({ action: "pause", question: "Human needed" })
 }));
 
@@ -159,7 +159,7 @@ describe("orchestrator repeat detection", () => {
     fs.default.readFile.mockResolvedValue("review rules");
 
     const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
-    invokeSolomon.mockResolvedValue({ action: "pause", question: "Reviewer stalled" });
+    invokeSolomon.mockResolvedValue({ action: "continue", humanGuidance: "Proceed" });
 
     const { sonarUp, isSonarReachable } = await import("../src/sonar/manager.js");
     sonarUp.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
@@ -223,6 +223,9 @@ describe("orchestrator repeat detection", () => {
   });
 
   it("stalls when reviewer blocking issues repeat consecutively", async () => {
+    const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
+    invokeSolomon.mockResolvedValue({ action: "pause", question: "Reviewer stalled" });
+
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }) };
     const reviewerAgent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }), reviewTask: vi.fn().mockResolvedValue({ ok: true, output: REVIEW_BLOCKING }) };

--- a/tests/orchestrator-triage.test.js
+++ b/tests/orchestrator-triage.test.js
@@ -135,7 +135,7 @@ vi.mock("../src/git/automation.js", () => ({
 }));
 
 vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
-  invokeSolomon: vi.fn().mockResolvedValue({ action: "pause", question: "Solomon escalated" }),
+  invokeSolomon: vi.fn().mockResolvedValue({ action: "continue", humanGuidance: "Proceed" }),
   escalateToHuman: vi.fn().mockResolvedValue({ action: "pause", question: "Human needed" })
 }));
 
@@ -215,7 +215,7 @@ describe("orchestrator triage pipeline", () => {
       message: "OK"
     });
     const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
-    invokeSolomon.mockResolvedValue({ action: "pause", question: "Solomon escalated" });
+    invokeSolomon.mockResolvedValue({ action: "continue", humanGuidance: "Proceed" });
   });
 
   it("trivial task runs only coder + sonar (without reviewer)", async () => {

--- a/tests/reviewer-parse-resilience.test.js
+++ b/tests/reviewer-parse-resilience.test.js
@@ -93,7 +93,7 @@ vi.mock("../src/utils/git.js", () => ({
 }));
 
 vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
-  invokeSolomon: vi.fn().mockResolvedValue({ action: "pause", question: "Solomon escalated" }),
+  invokeSolomon: vi.fn().mockResolvedValue({ action: "continue", humanGuidance: "Proceed" }),
   escalateToHuman: vi.fn().mockResolvedValue({ action: "pause", question: "Human needed" })
 }));
 
@@ -118,7 +118,7 @@ describe("reviewer parse resilience", () => {
     await reapplyDefaultMocks();
 
     const { invokeSolomon } = await import("../src/orchestrator/solomon-escalation.js");
-    invokeSolomon.mockResolvedValue({ action: "pause", question: "Solomon escalated" });
+    invokeSolomon.mockResolvedValue({ action: "continue", humanGuidance: "Proceed" });
 
     const { sonarUp, isSonarReachable } = await import("../src/sonar/manager.js");
     sonarUp.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });


### PR DESCRIPTION
## Summary
- Changed Solomon mock default from `{ action: "pause" }` to `{ action: "continue" }` in 4 test files where tests expect the pipeline to iterate normally after reviewer rejection
- Added explicit `{ action: "pause" }` override in the repeat-detection reviewer-stall test that specifically verifies Solomon pause behavior
- Files changed: `orchestrator-events`, `orchestrator-repeat-detection`, `orchestrator-triage`, `reviewer-parse-resilience`

## Test plan
- [x] All 145 test files pass (1805 tests, 2 skipped)
- [x] Solomon-specific tests (subloop-limits, orchestrator-post-loop) unchanged and still pass