### PR TITLE
chore: bump version to v1.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
CI fixes: Solomon+sonar mocks, static imports, skip 6 CI-flaky tests