### PR TITLE
feat(solomon): autonomous decisions — no unnecessary human interruption

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -313,22 +313,60 @@ async function tryBecariaComment({ config, session, logger, agent, body }) {
   } catch { /* non-blocking */ }
 }
 
-async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpointAt, checkpointIntervalMs, elapsedMinutes, i, config, budgetTracker, stageResults, emitter, eventBase, session, budgetSummary }) {
+function detectCheckpointProgress(session, lastCheckpointSnapshot) {
+  if (!lastCheckpointSnapshot) return true; // First checkpoint — assume progress
+  const currentIteration = session.reviewer_retry_count ?? 0;
+  const currentStages = Object.keys(session.resolved_policies || {}).length;
+  const currentCheckpoints = (session.checkpoints || []).length;
+
+  const iterationAdvanced = currentIteration !== lastCheckpointSnapshot.iteration;
+  const stagesChanged = currentStages !== lastCheckpointSnapshot.stagesCount;
+  const checkpointsChanged = currentCheckpoints !== lastCheckpointSnapshot.checkpointsCount;
+
+  return iterationAdvanced || stagesChanged || checkpointsChanged;
+}
+
+function takeCheckpointSnapshot(session) {
+  return {
+    iteration: session.reviewer_retry_count ?? 0,
+    stagesCount: Object.keys(session.resolved_policies || {}).length,
+    checkpointsCount: (session.checkpoints || []).length
+  };
+}
+
+async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpointAt, checkpointIntervalMs, elapsedMinutes, i, config, budgetTracker, stageResults, emitter, eventBase, session, budgetSummary, lastCheckpointSnapshot }) {
   if (checkpointDisabled || !askQuestion || (Date.now() - lastCheckpointAt) < checkpointIntervalMs) {
-    return { action: "continue_loop", checkpointDisabled, lastCheckpointAt };
+    return { action: "continue_loop", checkpointDisabled, lastCheckpointAt, lastCheckpointSnapshot };
   }
 
   const elapsedStr = elapsedMinutes.toFixed(1);
+  const stagesCompleted = Object.keys(stageResults).join(", ") || "none";
+
+  // Auto-continue if progress detected since last checkpoint
+  const hasProgress = detectCheckpointProgress(session, lastCheckpointSnapshot);
+  const newSnapshot = takeCheckpointSnapshot(session);
+
+  if (hasProgress) {
+    emitProgress(
+      emitter,
+      makeEvent("session:checkpoint", { ...eventBase, iteration: i, stage: "checkpoint" }, {
+        message: `Checkpoint: progress detected, continuing (${elapsedStr} min elapsed)`,
+        detail: { elapsed_minutes: Number(elapsedStr), iterations_done: i - 1, stages: stagesCompleted, auto_continued: true }
+      })
+    );
+    return { action: "continue_loop", checkpointDisabled, lastCheckpointAt: Date.now(), lastCheckpointSnapshot: newSnapshot };
+  }
+
+  // No progress — ask human
   const iterInfo = `${i - 1}/${config.max_iterations} iterations completed`;
   const budgetInfo = budgetTracker.total().cost_usd > 0 ? ` | Budget: $${budgetTracker.total().cost_usd.toFixed(2)}` : "";
-  const stagesCompleted = Object.keys(stageResults).join(", ") || "none";
-  const checkpointMsg = `Checkpoint — ${elapsedStr} min elapsed | ${iterInfo}${budgetInfo} | Stages completed: ${stagesCompleted}. What would you like to do?`;
+  const checkpointMsg = `Checkpoint — ${elapsedStr} min elapsed | ${iterInfo}${budgetInfo} | Stages completed: ${stagesCompleted}. No progress since last checkpoint. What would you like to do?`;
 
   emitProgress(
     emitter,
     makeEvent("session:checkpoint", { ...eventBase, iteration: i, stage: "checkpoint" }, {
-      message: `Interactive checkpoint at ${elapsedStr} min`,
-      detail: { elapsed_minutes: Number(elapsedStr), iterations_done: i - 1, stages: stagesCompleted }
+      message: `Interactive checkpoint at ${elapsedStr} min (stalled)`,
+      detail: { elapsed_minutes: Number(elapsedStr), iterations_done: i - 1, stages: stagesCompleted, auto_continued: false }
     })
   );
 
@@ -354,7 +392,9 @@ async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpoin
     return { action: "stop", result: { approved: false, sessionId: session.id, reason: "user_stopped", elapsed_minutes: Number(elapsedStr) } };
   }
 
-  return parseCheckpointAnswer({ trimmedAnswer, checkpointDisabled, config });
+  const parsed = parseCheckpointAnswer({ trimmedAnswer, checkpointDisabled, config });
+  parsed.lastCheckpointSnapshot = newSnapshot;
+  return parsed;
 }
 
 function parseCheckpointAnswer({ trimmedAnswer, checkpointDisabled, config }) {
@@ -1159,6 +1199,7 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   const checkpointIntervalMs = (ctx.config.session.checkpoint_interval_minutes ?? 5) * 60 * 1000;
   let lastCheckpointAt = Date.now();
   let checkpointDisabled = false;
+  let lastCheckpointSnapshot = null;
 
   let i = 0;
   while (i < ctx.config.max_iterations) {
@@ -1167,11 +1208,12 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
     const cpResult = await handleCheckpoint({
       checkpointDisabled, askQuestion, lastCheckpointAt, checkpointIntervalMs, elapsedMinutes,
-      i, config: ctx.config, budgetTracker: ctx.budgetTracker, stageResults: ctx.stageResults, emitter, eventBase: ctx.eventBase, session: ctx.session, budgetSummary: ctx.budgetSummary
+      i, config: ctx.config, budgetTracker: ctx.budgetTracker, stageResults: ctx.stageResults, emitter, eventBase: ctx.eventBase, session: ctx.session, budgetSummary: ctx.budgetSummary, lastCheckpointSnapshot
     });
     if (cpResult.action === "stop") return cpResult.result;
     checkpointDisabled = cpResult.checkpointDisabled;
     lastCheckpointAt = cpResult.lastCheckpointAt;
+    if (cpResult.lastCheckpointSnapshot !== undefined) lastCheckpointSnapshot = cpResult.lastCheckpointSnapshot;
 
     await checkSessionTimeout({ askQuestion, elapsedMinutes, config: ctx.config, session: ctx.session, emitter, eventBase: ctx.eventBase, i, budgetSummary: ctx.budgetSummary });
     await checkBudgetExceeded({ budgetTracker: ctx.budgetTracker, config: ctx.config, session: ctx.session, emitter, eventBase: ctx.eventBase, i, budgetLimit: ctx.budgetLimit, budgetSummary: ctx.budgetSummary });

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -134,36 +134,18 @@ export async function runTesterStage({ config, logger, emitter, eventBase, sessi
   );
 
   if (!testerOutput.ok) {
-    const maxTesterRetries = config.session?.max_tester_retries ?? 1;
-    session.tester_retry_count = (session.tester_retry_count || 0) + 1;
-    await saveSession(session);
-
-    if (session.tester_retry_count >= maxTesterRetries) {
-      const solomonResult = await invokeSolomon({
-        config, logger, emitter, eventBase, stage: "tester", askQuestion, session, iteration,
-        conflict: {
-          stage: "tester",
-          task,
-          diff,
-          iterationCount: session.tester_retry_count,
-          maxIterations: maxTesterRetries,
-          history: [{ agent: "tester", feedback: testerOutput.summary }]
-        }
-      });
-
-      if (solomonResult.action === "pause") {
-        return { action: "pause", result: { paused: true, sessionId: session.id, question: solomonResult.question, context: "tester_fail_fast" } };
-      }
-      if (solomonResult.action === "subtask") {
-        return { action: "pause", result: { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "tester_subtask" } };
-      }
-      // Solomon approved — proceed to next stage
-      return { action: "ok" };
-    }
-
-    session.last_reviewer_feedback = `Tester feedback: ${testerOutput.summary}`;
-    await saveSession(session);
-    return { action: "continue" };
+    // Tester findings are advisory when reviewer already approved.
+    // Auto-continue with a warning — no human escalation needed.
+    logger.warn(`Tester failed (advisory): ${testerOutput.summary}`);
+    emitProgress(
+      emitter,
+      makeEvent("tester:auto-continue", { ...eventBase, stage: "tester" }, {
+        status: "warn",
+        message: `Tester issues are advisory (reviewer approved), continuing: ${testerOutput.summary}`,
+        detail: { summary: testerOutput.summary, auto_continued: true }
+      })
+    );
+    return { action: "ok", stageResult: { ok: false, summary: testerOutput.summary || "Tester issues (advisory)", auto_continued: true } };
   }
 
   session.tester_retry_count = 0;
@@ -212,36 +194,46 @@ export async function runSecurityStage({ config, logger, emitter, eventBase, ses
   );
 
   if (!securityOutput.ok) {
-    const maxSecurityRetries = config.session?.max_security_retries ?? 1;
-    session.security_retry_count = (session.security_retry_count || 0) + 1;
-    await saveSession(session);
+    // Check if the security finding is critical (SQL injection, RCE, auth bypass, etc.)
+    const summary = (securityOutput.summary || "").toLowerCase();
+    const criticalPatterns = ["injection", "rce", "remote code", "auth bypass", "authentication bypass", "privilege escalation", "credentials exposed", "secret", "critical vulnerability"];
+    const isCritical = criticalPatterns.some((p) => summary.includes(p));
 
-    if (session.security_retry_count >= maxSecurityRetries) {
+    if (isCritical) {
+      // Critical security issue — escalate to Solomon/human
+      logger.warn(`Critical security finding — escalating: ${securityOutput.summary}`);
       const solomonResult = await invokeSolomon({
         config, logger, emitter, eventBase, stage: "security", askQuestion, session, iteration,
         conflict: {
           stage: "security",
           task,
           diff,
-          iterationCount: session.security_retry_count,
-          maxIterations: maxSecurityRetries,
+          iterationCount: 1,
+          maxIterations: 1,
           history: [{ agent: "security", feedback: securityOutput.summary }]
         }
       });
 
       if (solomonResult.action === "pause") {
-        return { action: "pause", result: { paused: true, sessionId: session.id, question: solomonResult.question, context: "security_fail_fast" } };
+        return { action: "pause", result: { paused: true, sessionId: session.id, question: solomonResult.question, context: "security_critical" } };
       }
       if (solomonResult.action === "subtask") {
         return { action: "pause", result: { paused: true, sessionId: session.id, subtask: solomonResult.subtask, context: "security_subtask" } };
       }
-      // Solomon approved — proceed
       return { action: "ok" };
     }
 
-    session.last_reviewer_feedback = `Security feedback: ${securityOutput.summary}`;
-    await saveSession(session);
-    return { action: "continue" };
+    // Non-critical security findings are advisory when reviewer already approved.
+    logger.warn(`Security failed (advisory): ${securityOutput.summary}`);
+    emitProgress(
+      emitter,
+      makeEvent("security:auto-continue", { ...eventBase, stage: "security" }, {
+        status: "warn",
+        message: `Security issues are advisory (reviewer approved), continuing: ${securityOutput.summary}`,
+        detail: { summary: securityOutput.summary, auto_continued: true }
+      })
+    );
+    return { action: "ok", stageResult: { ok: false, summary: securityOutput.summary || "Security issues (advisory)", auto_continued: true } };
   }
 
   session.security_retry_count = 0;

--- a/src/utils/budget.js
+++ b/src/utils/budget.js
@@ -121,6 +121,10 @@ export class BudgetTracker {
     return this.total().cost_usd > n;
   }
 
+  hasUsageData() {
+    return this.entries.length > 0 && (this.total().tokens_in > 0 || this.total().tokens_out > 0 || this.total().cost_usd > 0);
+  }
+
   summary() {
     const totals = this.total();
     const byRole = {};
@@ -133,7 +137,8 @@ export class BudgetTracker {
       total_tokens: totals.tokens_in + totals.tokens_out,
       total_cost_usd: totals.cost_usd,
       breakdown_by_role: byRole,
-      entries: [...this.entries]
+      entries: [...this.entries],
+      usage_available: this.hasUsageData()
     };
   }
 

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -221,6 +221,10 @@ function printSessionGit(git) {
 
 function printSessionBudget(budget) {
   if (!budget) return;
+  if (budget.usage_available === false || (budget.total_tokens === 0 && budget.total_cost_usd === 0 && Object.keys(budget.breakdown_by_role || {}).length > 0)) {
+    console.log(`  ${ANSI.dim}\ud83d\udcb0 Budget: N/A (provider does not report usage)${ANSI.reset}`);
+    return;
+  }
   console.log(`  ${ANSI.dim}\ud83d\udcb0 Total tokens: ${budget.total_tokens ?? 0}${ANSI.reset}`);
   console.log(`  ${ANSI.dim}\ud83d\udcb0 Total cost: $${Number(budget.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`);
   for (const [role, metrics] of Object.entries(budget.breakdown_by_role || {})) {
@@ -376,9 +380,15 @@ const EVENT_HANDLERS = {
 
   "budget:update": (event, icon) => {
     const total = Number(event.detail?.total_cost_usd || 0);
+    const totalTokens = Number(event.detail?.total_tokens || 0);
     const max = Number(event.detail?.max_budget_usd);
     const pct = Number(event.detail?.pct_used ?? 0);
     const warn = Number(event.detail?.warn_threshold_pct ?? 80);
+    const hasEntries = (event.detail?.entries?.length ?? 0) > 0 || Object.keys(event.detail?.breakdown_by_role || {}).length > 0;
+    if (hasEntries && totalTokens === 0 && total === 0) {
+      console.log(`  \u251c\u2500 ${icon} Budget: ${ANSI.dim}N/A (provider does not report usage)${ANSI.reset}`);
+      return;
+    }
     const color = budgetColor(max, pct, warn);
     if (Number.isFinite(max) && max >= 0) {
       console.log(`  \u251c\u2500 ${icon} Budget: ${color}$${total.toFixed(2)} / $${max.toFixed(2)} (${pct.toFixed(1)}%)${ANSI.reset}`);


### PR DESCRIPTION
## Summary
- Checkpoints auto-continue if progress detected, only ask on stall
- Tester failures advisory after reviewer approval
- Security auto-continues non-critical, escalates critical only
- Budget: "N/A (provider does not report usage)" instead of "$0.00"

## Test plan
- [x] 151 files, 1860 tests pass