### PR TITLE
feat(hu-board): complete HU Board dashboard

### DIFF
--- a/packages/hu-board/Dockerfile
+++ b/packages/hu-board/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --production
+COPY src/ src/
+COPY public/ public/
+ENV PORT=4000
+ENV KJ_HOME=/data
+EXPOSE 4000
+CMD ["node", "src/server.js"]

--- a/packages/hu-board/README.md
+++ b/packages/hu-board/README.md
@@ -1,0 +1,69 @@
+# Karajan HU Board
+
+A web dashboard that visualizes all HU (User Story) stories managed by Karajan Code. Reads from `~/.karajan/hu-stories/` and `~/.karajan/sessions/`, groups by project, and provides a read-only kanban board with quality metrics and session timelines.
+
+## Quick Start
+
+### Without Docker
+
+```bash
+cd packages/hu-board
+npm install
+npm start
+# Open http://localhost:4000
+```
+
+### With Docker
+
+```bash
+cd packages/hu-board
+docker compose up -d
+# Open http://localhost:4000
+```
+
+### Development (auto-reload)
+
+```bash
+npm run dev
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `4000` | Server port (auto-detects next available if busy) |
+| `KJ_HOME` | `~/.karajan` | Path to Karajan data directory |
+
+You can also use `--port` flag:
+
+```bash
+node src/server.js --port 5000
+```
+
+## Architecture
+
+- **Backend**: Node.js + Express serving REST API + static files
+- **Frontend**: Vanilla JS single-page app with hash-based routing
+- **Database**: SQLite (via `better-sqlite3`) at `$KJ_HOME/hu-board.db`
+- **Sync**: Chokidar watches JSON files and syncs to SQLite in real-time
+
+The SQLite database is a read index over the JSON source files. If deleted, it rebuilds automatically on next startup.
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/dashboard` | Global statistics |
+| GET | `/api/projects` | List all projects with counts |
+| GET | `/api/projects/:id` | Project detail |
+| GET | `/api/projects/:id/stories` | Stories for a project |
+| GET | `/api/stories/:id` | Story detail with quality, AC, context requests |
+| GET | `/api/projects/:id/sessions` | Sessions for a project |
+| GET | `/api/sessions` | All sessions |
+| GET | `/api/sessions/:id` | Session detail with timeline |
+
+## Views
+
+1. **Dashboard** - Global stats cards + project overview grid
+2. **Board** - Kanban columns (Pending / Needs Context / Certified / Done)
+3. **Sessions** - Timeline of Karajan pipeline sessions with stages and duration

--- a/packages/hu-board/docker-compose.yml
+++ b/packages/hu-board/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  hu-board:
+    build: .
+    ports:
+      - "${HU_BOARD_PORT:-4000}:4000"
+    volumes:
+      - ${KJ_HOME:-~/.karajan}:/data
+    environment:
+      - KJ_HOME=/data
+    restart: unless-stopped

--- a/packages/hu-board/package-lock.json
+++ b/packages/hu-board/package-lock.json
@@ -1,0 +1,1284 @@
+{
+  "name": "@karajan/hu-board",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@karajan/hu-board",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "^11.0.0",
+        "chokidar": "^4.0.0",
+        "express": "^5.1.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@karajan/hu-board",
+  "version": "1.0.0",
+  "description": "HU Story Board dashboard for Karajan Code",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node --watch src/server.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0",
+    "chokidar": "^4.0.0",
+    "express": "^5.1.0"
+  }
+}

--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1,0 +1,736 @@
+/**
+ * Karajan HU Board - Frontend Application
+ * Vanilla JS single-page app with hash-based routing.
+ */
+
+/** @type {string} Current view */
+let currentView = 'dashboard';
+
+/** @type {string} Selected project ID (empty = all) */
+let selectedProject = '';
+
+/** @type {number | null} Auto-refresh interval ID */
+let refreshInterval = null;
+
+// ---- API Layer ----
+
+/**
+ * Fetches JSON from the API.
+ * @param {string} path - API path (e.g., '/api/dashboard')
+ * @returns {Promise<any>}
+ */
+async function api(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json();
+}
+
+// ---- Utility Functions ----
+
+/**
+ * Returns relative time string (e.g., "2 min ago").
+ * @param {string} dateStr - ISO date string
+ * @returns {string}
+ */
+function timeAgo(dateStr) {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Formats milliseconds to human readable duration.
+ * @param {number | null} ms
+ * @returns {string}
+ */
+function formatDuration(ms) {
+  if (!ms) return '--';
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${sec.toString().padStart(2, '0')}s`;
+}
+
+/**
+ * Returns a quality score CSS class based on value.
+ * @param {number | null} score
+ * @param {number} max
+ * @returns {string}
+ */
+function scoreClass(score, max = 60) {
+  if (score === null || score === undefined) return '';
+  const pct = score / max;
+  if (pct >= 0.7) return 'story-card__score--good';
+  if (pct >= 0.4) return 'story-card__score--ok';
+  return 'story-card__score--bad';
+}
+
+/**
+ * Generates quality bar HTML segments.
+ * @param {number | null} score
+ * @param {number} max
+ * @returns {string}
+ */
+function qualityBar(score, max = 60) {
+  if (score === null || score === undefined) return '';
+  const filled = Math.round((score / max) * 10);
+  let html = '<span class="quality-bar">';
+  for (let i = 0; i < 10; i++) {
+    html += `<span class="quality-bar__segment${i < filled ? ' quality-bar__segment--filled' : ''}"></span>`;
+  }
+  html += '</span>';
+  return html;
+}
+
+/**
+ * Escapes HTML entities.
+ * @param {string} str
+ * @returns {string}
+ */
+function esc(str) {
+  if (!str) return '';
+  const el = document.createElement('span');
+  el.textContent = str;
+  return el.innerHTML;
+}
+
+/**
+ * Truncates text to a max length.
+ * @param {string} text
+ * @param {number} max
+ * @returns {string}
+ */
+function truncate(text, max = 100) {
+  if (!text) return '';
+  return text.length > max ? text.slice(0, max) + '...' : text;
+}
+
+// ---- Render Functions ----
+
+/**
+ * Renders the dashboard view with global stats and project cards.
+ */
+async function renderDashboard() {
+  const app = document.getElementById('app');
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading dashboard...</p></div>';
+
+  try {
+    const [stats, projects] = await Promise.all([
+      api('/api/dashboard'),
+      api('/api/projects'),
+    ]);
+
+    const certPct = stats.total_stories > 0
+      ? Math.round((stats.certified_stories / stats.total_stories) * 100)
+      : 0;
+
+    app.innerHTML = `
+      <div class="stats-grid">
+        <div class="stat-card">
+          <div class="stat-card__value">${stats.total_stories}</div>
+          <div class="stat-card__label">Total Stories</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value stat-card__value--green">${stats.certified_stories} (${certPct}%)</div>
+          <div class="stat-card__label">Certified</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value stat-card__value--yellow">${stats.pending_stories}</div>
+          <div class="stat-card__label">Pending</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value stat-card__value--purple">${stats.avg_quality !== null ? stats.avg_quality + '/60' : '--'}</div>
+          <div class="stat-card__label">Avg Quality</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value">${stats.total_sessions}</div>
+          <div class="stat-card__label">Sessions</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value stat-card__value--green">${stats.approved_sessions}</div>
+          <div class="stat-card__label">Approved</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-card__value stat-card__value--purple">${stats.total_projects}</div>
+          <div class="stat-card__label">Projects</div>
+        </div>
+      </div>
+
+      <div class="section-header">
+        <span class="section-header__title">Projects</span>
+        <span class="section-header__count">${projects.length} projects</span>
+      </div>
+
+      ${projects.length === 0 ? renderEmptyState() : `
+        <div class="projects-grid">
+          ${projects.map((p) => `
+            <div class="project-card" onclick="selectProject('${esc(p.id)}')">
+              <div class="project-card__name">${esc(p.name || p.id)}</div>
+              <div class="project-card__stats">
+                <div class="project-card__stat">
+                  <div class="project-card__stat-value">${p.story_count || 0}</div>
+                  <div class="project-card__stat-label">Stories</div>
+                </div>
+                <div class="project-card__stat">
+                  <div class="project-card__stat-value">${p.certified_count || 0}</div>
+                  <div class="project-card__stat-label">Certified</div>
+                </div>
+                <div class="project-card__stat">
+                  <div class="project-card__stat-value">${p.session_count || 0}</div>
+                  <div class="project-card__stat-label">Sessions</div>
+                </div>
+              </div>
+              <div class="project-card__activity">Last activity: ${timeAgo(p.last_activity)}</div>
+            </div>
+          `).join('')}
+        </div>
+      `}
+    `;
+  } catch (err) {
+    app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading dashboard</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
+  }
+}
+
+/**
+ * Renders the kanban board view.
+ */
+async function renderBoard() {
+  const app = document.getElementById('app');
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading board...</p></div>';
+
+  try {
+    let stories;
+    if (selectedProject) {
+      stories = await api(`/api/projects/${encodeURIComponent(selectedProject)}/stories`);
+    } else {
+      // Get all stories from all projects
+      const projects = await api('/api/projects');
+      const allStories = await Promise.all(
+        projects.map((p) => api(`/api/projects/${encodeURIComponent(p.id)}/stories`))
+      );
+      stories = allStories.flat();
+    }
+
+    const columns = {
+      pending: stories.filter((s) => s.status === 'pending'),
+      needs_context: stories.filter((s) => s.status === 'needs_context'),
+      certified: stories.filter((s) => s.status === 'certified'),
+      done: stories.filter((s) => s.status === 'done'),
+    };
+
+    if (stories.length === 0) {
+      app.innerHTML = renderEmptyState();
+      return;
+    }
+
+    app.innerHTML = `
+      <div class="section-header">
+        <span class="section-header__title">Story Board${selectedProject ? ` - ${esc(selectedProject)}` : ''}</span>
+        <span class="section-header__count">${stories.length} stories</span>
+      </div>
+      <div class="kanban">
+        ${renderKanbanColumn('Pending', 'pending', columns.pending)}
+        ${renderKanbanColumn('Needs Context', 'needs-context', columns.needs_context)}
+        ${renderKanbanColumn('Certified', 'certified', columns.certified)}
+        ${renderKanbanColumn('Done', 'done', columns.done)}
+      </div>
+    `;
+  } catch (err) {
+    app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading board</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
+  }
+}
+
+/**
+ * Renders a single kanban column.
+ * @param {string} title
+ * @param {string} cssClass
+ * @param {Array<object>} stories
+ * @returns {string}
+ */
+function renderKanbanColumn(title, cssClass, stories) {
+  return `
+    <div class="kanban__column kanban__column--${cssClass}">
+      <div class="kanban__column-header">
+        <span class="kanban__column-title">${title}</span>
+        <span class="kanban__column-count">${stories.length}</span>
+      </div>
+      ${stories.map(renderStoryCard).join('')}
+      ${stories.length === 0 ? '<div style="text-align:center;color:var(--text-muted);font-size:0.8rem;padding:20px">No stories</div>' : ''}
+    </div>
+  `;
+}
+
+/**
+ * Renders a story card for the kanban board.
+ * @param {object} story
+ * @returns {string}
+ */
+function renderStoryCard(story) {
+  const title = story.title || story.original_text || story.id;
+  const antipatterns = story.antipatterns ? JSON.parse(story.antipatterns) : [];
+  const acCount = story.acceptance_criteria ? JSON.parse(story.acceptance_criteria).length : 0;
+
+  return `
+    <div class="story-card" onclick="showStoryDetail('${esc(story.id)}')">
+      <div class="story-card__id">${esc(story.id)}</div>
+      <div class="story-card__title">${esc(truncate(title, 100))}</div>
+      <div class="story-card__meta">
+        ${story.quality_total !== null ? `
+          <span class="story-card__score ${scoreClass(story.quality_total)}">
+            Score: ${story.quality_total}/60 ${qualityBar(story.quality_total)}
+          </span>
+        ` : ''}
+        ${acCount > 0 ? `<span class="story-card__ac">AC: ${acCount} criteria${story.ac_format ? ` (${esc(story.ac_format)})` : ''}</span>` : ''}
+      </div>
+      ${antipatterns.length > 0 ? `<div class="story-card__antipattern">${antipatterns.map((a) => esc(a)).join(', ')}</div>` : ''}
+      <div class="story-card__meta" style="margin-top:6px">
+        <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
+        <span class="story-card__time">${timeAgo(story.updated_at)}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Renders the sessions view.
+ */
+async function renderSessions() {
+  const app = document.getElementById('app');
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading sessions...</p></div>';
+
+  try {
+    let sessions;
+    if (selectedProject) {
+      sessions = await api(`/api/projects/${encodeURIComponent(selectedProject)}/sessions`);
+    } else {
+      sessions = await api('/api/sessions');
+    }
+
+    if (sessions.length === 0) {
+      app.innerHTML = `
+        <div class="section-header">
+          <span class="section-header__title">Sessions</span>
+          <span class="section-header__count">0 sessions</span>
+        </div>
+        ${renderEmptyState('No sessions found', 'KJ sessions will appear here when you run karajan.')}
+      `;
+      return;
+    }
+
+    app.innerHTML = `
+      <div class="section-header">
+        <span class="section-header__title">Sessions${selectedProject ? ` - ${esc(selectedProject)}` : ''}</span>
+        <span class="section-header__count">${sessions.length} sessions</span>
+      </div>
+      <div class="sessions-list">
+        ${sessions.map(renderSessionCard).join('')}
+      </div>
+    `;
+  } catch (err) {
+    app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading sessions</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
+  }
+}
+
+/**
+ * Renders a session card.
+ * @param {object} session
+ * @returns {string}
+ */
+function renderSessionCard(session) {
+  const stages = session.stages_completed ? JSON.parse(session.stages_completed) : [];
+
+  return `
+    <div class="session-card" onclick="showSessionDetail('${esc(session.id)}')">
+      <div class="session-card__header">
+        <span class="session-card__id">${esc(session.id)}</span>
+        <span class="session-card__status session-status--${session.status || 'unknown'}">${esc(session.status || 'unknown')}</span>
+      </div>
+      <div class="session-card__task">${esc(truncate(session.task, 150))}</div>
+      <div class="session-card__meta">
+        <span>Iterations: ${session.iterations || 0}</span>
+        <span>Duration: ${formatDuration(session.duration_ms)}</span>
+        <span>Stages: ${stages.join(', ') || '--'}</span>
+        <span>${timeAgo(session.created_at)}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Renders an empty state component.
+ * @param {string} title
+ * @param {string} text
+ * @returns {string}
+ */
+function renderEmptyState(title, text) {
+  return `
+    <div class="empty-state">
+      <div class="empty-state__icon">&#9744;</div>
+      <div class="empty-state__title">${title || 'No data yet'}</div>
+      <div class="empty-state__text">${text || 'HU stories and sessions will appear here as Karajan processes them.'}</div>
+      <div class="empty-state__path">~/.karajan/hu-stories/</div>
+    </div>
+  `;
+}
+
+// ---- Detail Modals ----
+
+/**
+ * Shows the story detail modal.
+ * @param {string} storyId
+ */
+async function showStoryDetail(storyId) {
+  const backdrop = document.getElementById('modal-backdrop');
+  const content = document.getElementById('modal-content');
+  backdrop.classList.remove('hidden');
+
+  content.innerHTML = '<div class="loading"><div class="loading__spinner"></div></div>';
+
+  try {
+    const story = await api(`/api/stories/${encodeURIComponent(storyId)}`);
+    const antipatterns = story.antipatterns ? JSON.parse(story.antipatterns) : [];
+    const ac = story.acceptance_criteria ? JSON.parse(story.acceptance_criteria) : [];
+    const ctxRequests = story.context_requests || [];
+
+    const dimLabels = ['Independent', 'Negotiable', 'Valuable', 'Estimable', 'Small', 'Testable'];
+
+    content.innerHTML = `
+      <div class="modal__header">
+        <div>
+          <div class="modal__title">${esc(story.id)}</div>
+          <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
+        </div>
+        <button class="modal__close" onclick="closeModal()">&times;</button>
+      </div>
+
+      <div class="modal__section">
+        <div class="modal__section-title">Original Text</div>
+        <div class="modal__field-value">${esc(story.original_text || 'N/A')}</div>
+      </div>
+
+      ${story.certified_as || story.certified_want || story.certified_so_that ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Certified Story</div>
+          <div class="modal__field">
+            <div class="modal__field-label">As a...</div>
+            <div class="modal__field-value">${esc(story.certified_as || '--')}</div>
+          </div>
+          <div class="modal__field">
+            <div class="modal__field-label">I want to...</div>
+            <div class="modal__field-value">${esc(story.certified_want || '--')}</div>
+          </div>
+          <div class="modal__field">
+            <div class="modal__field-label">So that...</div>
+            <div class="modal__field-value">${esc(story.certified_so_that || '--')}</div>
+          </div>
+        </div>
+      ` : ''}
+
+      ${story.quality_total !== null ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Quality Score: ${story.quality_total}/60</div>
+          <div class="modal__quality-grid">
+            ${[1, 2, 3, 4, 5, 6].map((d, i) => {
+              const val = story[`quality_d${d}`];
+              return `
+                <div class="modal__quality-dim">
+                  <div class="modal__quality-dim-label">${dimLabels[i]}</div>
+                  <div class="modal__quality-dim-value">${val !== null ? val + '/10' : '--'}</div>
+                </div>
+              `;
+            }).join('')}
+          </div>
+        </div>
+      ` : ''}
+
+      ${antipatterns.length > 0 ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Antipatterns</div>
+          ${antipatterns.map((a) => `<div class="story-card__antipattern" style="margin-bottom:4px">${esc(a)}</div>`).join('')}
+        </div>
+      ` : ''}
+
+      ${ac.length > 0 ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Acceptance Criteria${story.ac_format ? ` (${esc(story.ac_format)})` : ''}</div>
+          <ul class="modal__ac-list">
+            ${ac.map((c) => {
+              if (typeof c === 'string') return `<li class="modal__ac-item">${esc(c)}</li>`;
+              if (c.given) return `<li class="modal__ac-item"><code>Given</code> ${esc(c.given)}<br><code>When</code> ${esc(c.when)}<br><code>Then</code> ${esc(c.then)}</li>`;
+              return `<li class="modal__ac-item">${esc(JSON.stringify(c))}</li>`;
+            }).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${ctxRequests.length > 0 ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Context Requests (${ctxRequests.length})</div>
+          ${ctxRequests.map((cr) => `
+            <div style="background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-sm);padding:8px;margin-bottom:6px;">
+              <div style="font-size:0.8rem;color:var(--color-yellow);">${esc(cr.question || 'Fields needed: ' + (cr.fields_needed || ''))}</div>
+              ${cr.answer ? `<div style="font-size:0.8rem;color:var(--color-green);margin-top:4px;">${esc(cr.answer)}</div>` : ''}
+            </div>
+          `).join('')}
+        </div>
+      ` : ''}
+
+      <div class="modal__section">
+        <div class="modal__section-title">Metadata</div>
+        <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(story.project_id)}</div>
+        <div class="modal__field"><span class="modal__field-label">Session:</span> ${esc(story.session_id || '--')}</div>
+        <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(story.created_at || '--')}</div>
+        <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(story.updated_at || '--')}</div>
+        ${story.certified_at ? `<div class="modal__field"><span class="modal__field-label">Certified at:</span> ${esc(story.certified_at)}</div>` : ''}
+      </div>
+    `;
+  } catch (err) {
+    content.innerHTML = `<div class="modal__header"><div class="modal__title">Error</div><button class="modal__close" onclick="closeModal()">&times;</button></div><p>${esc(err.message)}</p>`;
+  }
+}
+
+/**
+ * Shows the session detail modal.
+ * @param {string} sessionId
+ */
+async function showSessionDetail(sessionId) {
+  const backdrop = document.getElementById('modal-backdrop');
+  const content = document.getElementById('modal-content');
+  backdrop.classList.remove('hidden');
+
+  content.innerHTML = '<div class="loading"><div class="loading__spinner"></div></div>';
+
+  try {
+    const session = await api(`/api/sessions/${encodeURIComponent(sessionId)}`);
+    const checkpoints = session.checkpoints || [];
+    const config = session.config_snapshot || {};
+    const budget = session.budget || {};
+    const startTime = session.created_at ? new Date(session.created_at).getTime() : 0;
+
+    content.innerHTML = `
+      <div class="modal__header">
+        <div>
+          <div class="modal__title">${esc(session.id)}</div>
+          <span class="session-card__status session-status--${session.status}">${esc(session.status)}</span>
+        </div>
+        <button class="modal__close" onclick="closeModal()">&times;</button>
+      </div>
+
+      <div class="modal__section">
+        <div class="modal__section-title">Task</div>
+        <div class="modal__field-value" style="font-size:0.85rem">${esc(session.task || 'N/A')}</div>
+      </div>
+
+      <div class="modal__section">
+        <div class="modal__section-title">Overview</div>
+        <div class="stats-grid" style="margin-bottom:0">
+          <div class="stat-card">
+            <div class="stat-card__value">${session.iterations || 0}</div>
+            <div class="stat-card__label">Iterations</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-card__value">${formatDuration(session.duration_ms)}</div>
+            <div class="stat-card__label">Duration</div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-card__value ${session.approved ? 'stat-card__value--green' : 'stat-card__value--yellow'}">${session.approved ? 'Yes' : 'No'}</div>
+            <div class="stat-card__label">Approved</div>
+          </div>
+        </div>
+      </div>
+
+      ${config.coder || config.reviewer ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Configuration</div>
+          <div style="font-family:var(--font-mono);font-size:0.8rem;color:var(--text-secondary)">
+            ${config.coder ? `Coder: ${esc(config.coder)}` : ''}
+            ${config.reviewer ? ` | Reviewer: ${esc(config.reviewer)}` : ''}
+          </div>
+        </div>
+      ` : ''}
+
+      ${checkpoints.length > 0 ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Timeline (${checkpoints.length} checkpoints)</div>
+          <div class="timeline">
+            ${checkpoints.map((cp) => {
+              const elapsed = cp.at && startTime ? formatDuration(new Date(cp.at).getTime() - startTime) : '';
+              const isOk = cp.ok === true || cp.approved === true;
+              const isFail = cp.ok === false || cp.approved === false;
+              const itemClass = isOk ? 'timeline__item--ok' : isFail ? 'timeline__item--fail' : 'timeline__item--info';
+
+              let detail = '';
+              if (cp.note) detail = cp.note;
+              else if (cp.approved !== undefined) detail = cp.approved ? 'APPROVED' : `REJECTED (${cp.blocking_issues || 0} issues)`;
+              else if (cp.reason) detail = cp.reason;
+              else if (cp.ok !== undefined) detail = cp.ok ? 'PASSED' : 'FAILED';
+              if (cp.provider) detail += ` [${cp.provider}]`;
+
+              return `
+                <div class="timeline__item ${itemClass}">
+                  <span class="timeline__time">${elapsed}</span>
+                  <div class="timeline__stage">[${esc(cp.stage)}] iter ${cp.iteration || 0}</div>
+                  <div class="timeline__detail">${esc(detail)}</div>
+                </div>
+              `;
+            }).join('')}
+          </div>
+        </div>
+      ` : ''}
+
+      ${budget.total_cost_usd !== undefined ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Budget</div>
+          <div style="font-family:var(--font-mono);font-size:0.8rem;color:var(--text-secondary)">
+            Tokens: ${budget.total_tokens || 0} | Cost: $${(budget.total_cost_usd || 0).toFixed(4)}
+          </div>
+        </div>
+      ` : ''}
+
+      <div class="modal__section">
+        <div class="modal__section-title">Metadata</div>
+        <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(session.project_id)}</div>
+        <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(session.created_at || '--')}</div>
+        <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(session.updated_at || '--')}</div>
+      </div>
+    `;
+  } catch (err) {
+    content.innerHTML = `<div class="modal__header"><div class="modal__title">Error</div><button class="modal__close" onclick="closeModal()">&times;</button></div><p>${esc(err.message)}</p>`;
+  }
+}
+
+/**
+ * Closes the modal.
+ */
+function closeModal() {
+  document.getElementById('modal-backdrop').classList.add('hidden');
+}
+
+// ---- Navigation ----
+
+/**
+ * Navigates to a specific view.
+ * @param {string} view - 'dashboard', 'board', or 'sessions'
+ */
+function navigate(view) {
+  currentView = view;
+  window.location.hash = selectedProject ? `${view}/${selectedProject}` : view;
+
+  // Update active nav button
+  document.querySelectorAll('.nav-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.view === view);
+  });
+
+  render();
+}
+
+/**
+ * Selects a project and navigates to the board view.
+ * @param {string} projectId
+ */
+function selectProject(projectId) {
+  selectedProject = projectId;
+  document.getElementById('project-select').value = projectId;
+  navigate('board');
+}
+
+/**
+ * Renders the current view.
+ */
+function render() {
+  switch (currentView) {
+    case 'dashboard': return renderDashboard();
+    case 'board': return renderBoard();
+    case 'sessions': return renderSessions();
+    default: return renderDashboard();
+  }
+}
+
+/**
+ * Populates the project selector dropdown.
+ */
+async function populateProjectSelect() {
+  try {
+    const projects = await api('/api/projects');
+    const select = document.getElementById('project-select');
+    // Keep the "All Projects" option
+    select.innerHTML = '<option value="">All Projects</option>';
+    for (const p of projects) {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      opt.textContent = p.name || p.id;
+      select.appendChild(opt);
+    }
+  } catch {
+    // Silently fail — project list will be empty
+  }
+}
+
+/**
+ * Parses the hash route and renders.
+ */
+function handleRoute() {
+  const hash = window.location.hash.slice(1) || 'dashboard';
+  const parts = hash.split('/');
+  currentView = parts[0] || 'dashboard';
+  selectedProject = parts[1] || '';
+
+  document.querySelectorAll('.nav-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.view === currentView);
+  });
+
+  document.getElementById('project-select').value = selectedProject;
+  render();
+}
+
+// ---- Initialization ----
+
+// Nav button clicks
+document.querySelectorAll('.nav-btn').forEach((btn) => {
+  btn.addEventListener('click', () => navigate(btn.dataset.view));
+});
+
+// Project selector
+document.getElementById('project-select').addEventListener('change', (e) => {
+  selectedProject = e.target.value;
+  window.location.hash = selectedProject ? `${currentView}/${selectedProject}` : currentView;
+  render();
+});
+
+// Modal close on backdrop click
+document.getElementById('modal-backdrop').addEventListener('click', (e) => {
+  if (e.target === e.currentTarget) closeModal();
+});
+
+// ESC to close modal
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeModal();
+});
+
+// Hash routing
+window.addEventListener('hashchange', handleRoute);
+
+// Make functions available globally for onclick handlers
+window.showStoryDetail = showStoryDetail;
+window.showSessionDetail = showSessionDetail;
+window.closeModal = closeModal;
+window.selectProject = selectProject;
+
+// Initial load
+populateProjectSelect();
+handleRoute();
+
+// Auto-refresh every 10 seconds
+refreshInterval = setInterval(() => {
+  if (document.getElementById('modal-backdrop').classList.contains('hidden')) {
+    render();
+  }
+}, 10000);

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Karajan HU Board</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='6' fill='%237c3aed'/><text x='16' y='22' text-anchor='middle' fill='white' font-size='16' font-family='sans-serif' font-weight='bold'>K</text></svg>">
+</head>
+<body>
+  <header class="header">
+    <div class="header__logo">
+      <svg viewBox="0 0 32 32" width="32" height="32">
+        <rect width="32" height="32" rx="6" fill="#7c3aed"/>
+        <text x="16" y="22" text-anchor="middle" fill="white" font-size="16" font-family="sans-serif" font-weight="bold">K</text>
+      </svg>
+      <div>
+        <div class="header__title">Karajan HU Board</div>
+        <div class="header__subtitle">story management dashboard</div>
+      </div>
+    </div>
+    <nav class="header__nav">
+      <button class="nav-btn active" data-view="dashboard">Dashboard</button>
+      <button class="nav-btn" data-view="board">Board</button>
+      <button class="nav-btn" data-view="sessions">Sessions</button>
+      <select class="project-select" id="project-select">
+        <option value="">All Projects</option>
+      </select>
+    </nav>
+  </header>
+
+  <main class="main" id="app">
+    <div class="loading">
+      <div class="loading__spinner"></div>
+      <p>Loading...</p>
+    </div>
+  </main>
+
+  <div class="modal-backdrop hidden" id="modal-backdrop">
+    <div class="modal" id="modal-content"></div>
+  </div>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -1,0 +1,779 @@
+/* ============================================
+   Karajan HU Board - Dark Theme
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+  --bg-primary: #0a0e1a;
+  --bg-card: #0f1425;
+  --bg-card-hover: #141a30;
+  --border: #1e2740;
+  --border-active: #2d3a5c;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent-purple: #7c3aed;
+  --accent-purple-dim: #6d28d9;
+  --accent-teal: #2dd4bf;
+  --accent-teal-dim: #14b8a6;
+  --color-green: #34d399;
+  --color-red: #f87171;
+  --color-yellow: #fbbf24;
+  --color-blue: #60a5fa;
+  --color-orange: #fb923c;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --radius: 8px;
+  --radius-sm: 4px;
+  --shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--accent-purple);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent-teal);
+}
+
+/* ---- Header ---- */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.header__logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header__logo svg {
+  width: 32px;
+  height: 32px;
+}
+
+.header__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.header__subtitle {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.header__nav {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.nav-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  transition: all 0.2s;
+}
+
+.nav-btn:hover,
+.nav-btn.active {
+  background: var(--accent-purple);
+  color: white;
+  border-color: var(--accent-purple);
+}
+
+.project-select {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.project-select:focus {
+  outline: none;
+  border-color: var(--accent-purple);
+}
+
+/* ---- Main Content ---- */
+.main {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+/* ---- Stats Grid ---- */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.stat-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  text-align: center;
+  transition: border-color 0.2s;
+}
+
+.stat-card:hover {
+  border-color: var(--border-active);
+}
+
+.stat-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent-teal);
+  font-family: var(--font-mono);
+}
+
+.stat-card__value--purple {
+  color: var(--accent-purple);
+}
+
+.stat-card__value--yellow {
+  color: var(--color-yellow);
+}
+
+.stat-card__value--green {
+  color: var(--color-green);
+}
+
+.stat-card__label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* ---- Section Headers ---- */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.section-header__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--accent-purple);
+}
+
+.section-header__count {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ---- Kanban Board ---- */
+.kanban {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.kanban__column {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  min-height: 200px;
+}
+
+.kanban__column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.kanban__column-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.kanban__column--pending .kanban__column-title { color: var(--color-yellow); }
+.kanban__column--certified .kanban__column-title { color: var(--accent-teal); }
+.kanban__column--needs-context .kanban__column-title { color: var(--color-red); }
+.kanban__column--done .kanban__column-title { color: var(--color-green); }
+
+.kanban__column-count {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-family: var(--font-mono);
+}
+
+/* ---- Story Card ---- */
+.story-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.story-card:hover {
+  border-color: var(--accent-purple);
+  background: var(--bg-card-hover);
+}
+
+.story-card__id {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.story-card__title {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.story-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.story-card__score {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+}
+
+.story-card__score--good { color: var(--color-green); }
+.story-card__score--ok { color: var(--color-yellow); }
+.story-card__score--bad { color: var(--color-red); }
+
+.quality-bar {
+  display: inline-flex;
+  gap: 1px;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
+.quality-bar__segment {
+  width: 6px;
+  height: 10px;
+  border-radius: 1px;
+  background: var(--border);
+}
+
+.quality-bar__segment--filled {
+  background: var(--accent-teal);
+}
+
+.story-card__ac {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.story-card__antipattern {
+  font-size: 0.7rem;
+  color: var(--color-orange);
+  margin-top: 4px;
+}
+
+.story-card__status {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.status--pending { background: rgba(251, 191, 36, 0.15); color: var(--color-yellow); }
+.status--certified { background: rgba(45, 212, 191, 0.15); color: var(--accent-teal); }
+.status--needs_context { background: rgba(248, 113, 113, 0.15); color: var(--color-red); }
+.status--done { background: rgba(52, 211, 153, 0.15); color: var(--color-green); }
+.status--coding { background: rgba(124, 58, 237, 0.15); color: var(--accent-purple); }
+
+.story-card__time {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+/* ---- Story Detail Modal ---- */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.modal-backdrop.hidden {
+  display: none;
+}
+
+.modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-width: 700px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 24px;
+  box-shadow: var(--shadow);
+}
+
+.modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.modal__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal__close {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.modal__close:hover {
+  color: var(--text-primary);
+}
+
+.modal__section {
+  margin-bottom: 16px;
+}
+
+.modal__section-title {
+  font-size: 0.8rem;
+  color: var(--accent-purple);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.modal__field {
+  margin-bottom: 8px;
+}
+
+.modal__field-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.modal__field-value {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.modal__quality-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.modal__quality-dim {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  text-align: center;
+}
+
+.modal__quality-dim-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.modal__quality-dim-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--accent-teal);
+}
+
+.modal__ac-list {
+  list-style: none;
+}
+
+.modal__ac-item {
+  background: var(--bg-primary);
+  border-left: 3px solid var(--accent-purple);
+  padding: 8px 12px;
+  margin-bottom: 6px;
+  font-size: 0.85rem;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.modal__ac-item code {
+  font-family: var(--font-mono);
+  color: var(--accent-teal);
+  font-size: 0.8rem;
+}
+
+/* ---- Sessions Timeline ---- */
+.sessions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.session-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.session-card:hover {
+  border-color: var(--accent-purple);
+}
+
+.session-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.session-card__id {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--accent-purple);
+}
+
+.session-card__status {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 3px;
+}
+
+.session-status--approved { background: rgba(52, 211, 153, 0.15); color: var(--color-green); }
+.session-status--failed { background: rgba(248, 113, 113, 0.15); color: var(--color-red); }
+.session-status--stopped { background: rgba(251, 191, 36, 0.15); color: var(--color-yellow); }
+.session-status--running { background: rgba(124, 58, 237, 0.15); color: var(--accent-purple); }
+
+.session-card__task {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.session-card__meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+/* ---- Session Detail Timeline ---- */
+.timeline {
+  position: relative;
+  padding-left: 24px;
+  margin: 16px 0;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+}
+
+.timeline__item {
+  position: relative;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.timeline__item::before {
+  content: '';
+  position: absolute;
+  left: -20px;
+  top: 14px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.timeline__item--ok::before { background: var(--color-green); }
+.timeline__item--fail::before { background: var(--color-red); }
+.timeline__item--info::before { background: var(--color-blue); }
+
+.timeline__stage {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--accent-purple);
+  font-weight: 500;
+}
+
+.timeline__detail {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.timeline__time {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  float: right;
+}
+
+/* ---- Projects Grid ---- */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.project-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.project-card:hover {
+  border-color: var(--accent-purple);
+  background: var(--bg-card-hover);
+}
+
+.project-card__name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent-purple);
+  margin-bottom: 8px;
+}
+
+.project-card__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.project-card__stat {
+  text-align: center;
+}
+
+.project-card__stat-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.project-card__stat-label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.project-card__activity {
+  margin-top: 8px;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+/* ---- Empty State ---- */
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-muted);
+}
+
+.empty-state__icon {
+  font-size: 3rem;
+  margin-bottom: 16px;
+  opacity: 0.4;
+}
+
+.empty-state__title {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+.empty-state__text {
+  font-size: 0.85rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.empty-state__path {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--accent-purple);
+  background: var(--bg-card);
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  display: inline-block;
+  margin-top: 8px;
+}
+
+/* ---- Loading ---- */
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--text-muted);
+}
+
+.loading__spinner {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent-purple);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .header__nav {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .kanban {
+    grid-template-columns: 1fr;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .modal {
+    margin: 8px;
+    max-height: 90vh;
+  }
+
+  .modal__quality-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .main {
+    padding: 16px;
+  }
+}
+
+/* ---- Scrollbar ---- */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-primary);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-active);
+}

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -1,0 +1,365 @@
+import Database from 'better-sqlite3';
+import { join } from 'node:path';
+import { mkdirSync } from 'node:fs';
+
+/** @type {import('better-sqlite3').Database | null} */
+let db = null;
+
+/**
+ * Returns the KJ home directory, respecting KJ_HOME env var.
+ * @returns {string}
+ */
+export function getKjHome() {
+  return process.env.KJ_HOME || join(process.env.HOME || '/root', '.karajan');
+}
+
+/**
+ * Initializes the SQLite database and creates tables if they don't exist.
+ * @returns {import('better-sqlite3').Database}
+ */
+export function initDb() {
+  const kjHome = getKjHome();
+  mkdirSync(kjHome, { recursive: true });
+
+  const dbPath = join(kjHome, 'hu-board.db');
+  db = new Database(dbPath);
+
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      first_seen TEXT,
+      last_activity TEXT,
+      total_stories INTEGER DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS stories (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      session_id TEXT,
+      status TEXT DEFAULT 'pending',
+      title TEXT,
+      original_text TEXT,
+      certified_as TEXT,
+      certified_want TEXT,
+      certified_so_that TEXT,
+      quality_total INTEGER,
+      quality_d1 INTEGER,
+      quality_d2 INTEGER,
+      quality_d3 INTEGER,
+      quality_d4 INTEGER,
+      quality_d5 INTEGER,
+      quality_d6 INTEGER,
+      antipatterns TEXT,
+      ac_format TEXT,
+      acceptance_criteria TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      certified_at TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      project_id TEXT,
+      task TEXT,
+      status TEXT,
+      created_at TEXT,
+      updated_at TEXT,
+      iterations INTEGER DEFAULT 0,
+      duration_ms INTEGER,
+      approved INTEGER DEFAULT 0,
+      commits TEXT,
+      stages_completed TEXT,
+      checkpoints TEXT,
+      llm_calls TEXT,
+      config_snapshot TEXT,
+      budget TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS context_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      story_id TEXT,
+      fields_needed TEXT,
+      question TEXT,
+      answer TEXT,
+      requested_at TEXT,
+      answered_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_stories_project ON stories(project_id);
+    CREATE INDEX IF NOT EXISTS idx_stories_status ON stories(status);
+    CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
+    CREATE INDEX IF NOT EXISTS idx_context_story ON context_requests(story_id);
+  `);
+
+  return db;
+}
+
+/**
+ * Returns the current database instance.
+ * @returns {import('better-sqlite3').Database}
+ */
+export function getDb() {
+  if (!db) throw new Error('Database not initialized. Call initDb() first.');
+  return db;
+}
+
+/**
+ * Inserts or updates a project record.
+ * @param {{ id: string, name?: string, first_seen?: string, last_activity?: string, total_stories?: number }} project
+ */
+export function upsertProject(project) {
+  const stmt = getDb().prepare(`
+    INSERT INTO projects (id, name, first_seen, last_activity, total_stories)
+    VALUES (@id, @name, @first_seen, @last_activity, @total_stories)
+    ON CONFLICT(id) DO UPDATE SET
+      name = COALESCE(@name, name),
+      last_activity = COALESCE(@last_activity, last_activity),
+      total_stories = COALESCE(@total_stories, total_stories)
+  `);
+  stmt.run({
+    id: project.id,
+    name: project.name || project.id,
+    first_seen: project.first_seen || new Date().toISOString(),
+    last_activity: project.last_activity || new Date().toISOString(),
+    total_stories: project.total_stories || 0,
+  });
+}
+
+/**
+ * Inserts or updates a story record.
+ * @param {object} story
+ */
+export function upsertStory(story) {
+  const stmt = getDb().prepare(`
+    INSERT INTO stories (
+      id, project_id, session_id, status, title, original_text,
+      certified_as, certified_want, certified_so_that,
+      quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
+      antipatterns, ac_format, acceptance_criteria,
+      created_at, updated_at, certified_at
+    ) VALUES (
+      @id, @project_id, @session_id, @status, @title, @original_text,
+      @certified_as, @certified_want, @certified_so_that,
+      @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
+      @antipatterns, @ac_format, @acceptance_criteria,
+      @created_at, @updated_at, @certified_at
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      status = @status,
+      title = COALESCE(@title, title),
+      original_text = COALESCE(@original_text, original_text),
+      certified_as = COALESCE(@certified_as, certified_as),
+      certified_want = COALESCE(@certified_want, certified_want),
+      certified_so_that = COALESCE(@certified_so_that, certified_so_that),
+      quality_total = COALESCE(@quality_total, quality_total),
+      quality_d1 = COALESCE(@quality_d1, quality_d1),
+      quality_d2 = COALESCE(@quality_d2, quality_d2),
+      quality_d3 = COALESCE(@quality_d3, quality_d3),
+      quality_d4 = COALESCE(@quality_d4, quality_d4),
+      quality_d5 = COALESCE(@quality_d5, quality_d5),
+      quality_d6 = COALESCE(@quality_d6, quality_d6),
+      antipatterns = COALESCE(@antipatterns, antipatterns),
+      ac_format = COALESCE(@ac_format, ac_format),
+      acceptance_criteria = COALESCE(@acceptance_criteria, acceptance_criteria),
+      updated_at = @updated_at,
+      certified_at = COALESCE(@certified_at, certified_at)
+  `);
+  stmt.run({
+    id: story.id,
+    project_id: story.project_id || 'default',
+    session_id: story.session_id || null,
+    status: story.status || 'pending',
+    title: story.title || null,
+    original_text: story.original_text || null,
+    certified_as: story.certified_as || null,
+    certified_want: story.certified_want || null,
+    certified_so_that: story.certified_so_that || null,
+    quality_total: story.quality_total ?? null,
+    quality_d1: story.quality_d1 ?? null,
+    quality_d2: story.quality_d2 ?? null,
+    quality_d3: story.quality_d3 ?? null,
+    quality_d4: story.quality_d4 ?? null,
+    quality_d5: story.quality_d5 ?? null,
+    quality_d6: story.quality_d6 ?? null,
+    antipatterns: story.antipatterns || null,
+    ac_format: story.ac_format || null,
+    acceptance_criteria: story.acceptance_criteria || null,
+    created_at: story.created_at || new Date().toISOString(),
+    updated_at: story.updated_at || new Date().toISOString(),
+    certified_at: story.certified_at || null,
+  });
+}
+
+/**
+ * Inserts or updates a session record.
+ * @param {object} session
+ */
+export function upsertSession(session) {
+  const stmt = getDb().prepare(`
+    INSERT INTO sessions (
+      id, project_id, task, status, created_at, updated_at,
+      iterations, duration_ms, approved, commits, stages_completed,
+      checkpoints, llm_calls, config_snapshot, budget
+    ) VALUES (
+      @id, @project_id, @task, @status, @created_at, @updated_at,
+      @iterations, @duration_ms, @approved, @commits, @stages_completed,
+      @checkpoints, @llm_calls, @config_snapshot, @budget
+    )
+    ON CONFLICT(id) DO UPDATE SET
+      status = @status,
+      task = COALESCE(@task, task),
+      updated_at = @updated_at,
+      iterations = COALESCE(@iterations, iterations),
+      duration_ms = COALESCE(@duration_ms, duration_ms),
+      approved = @approved,
+      commits = COALESCE(@commits, commits),
+      stages_completed = COALESCE(@stages_completed, stages_completed),
+      checkpoints = COALESCE(@checkpoints, checkpoints),
+      llm_calls = COALESCE(@llm_calls, llm_calls),
+      config_snapshot = COALESCE(@config_snapshot, config_snapshot),
+      budget = COALESCE(@budget, budget)
+  `);
+  stmt.run({
+    id: session.id,
+    project_id: session.project_id || 'default',
+    task: session.task || null,
+    status: session.status || 'unknown',
+    created_at: session.created_at || new Date().toISOString(),
+    updated_at: session.updated_at || new Date().toISOString(),
+    iterations: session.iterations ?? 0,
+    duration_ms: session.duration_ms ?? null,
+    approved: session.approved ? 1 : 0,
+    commits: session.commits || null,
+    stages_completed: session.stages_completed || null,
+    checkpoints: session.checkpoints || null,
+    llm_calls: session.llm_calls || null,
+    config_snapshot: session.config_snapshot || null,
+    budget: session.budget || null,
+  });
+}
+
+/**
+ * Returns all projects with aggregated stats.
+ * @returns {Array<object>}
+ */
+export function getProjects() {
+  return getDb().prepare(`
+    SELECT p.*,
+      (SELECT COUNT(*) FROM stories s WHERE s.project_id = p.id) AS story_count,
+      (SELECT COUNT(*) FROM stories s WHERE s.project_id = p.id AND s.status = 'certified') AS certified_count,
+      (SELECT COUNT(*) FROM stories s WHERE s.project_id = p.id AND s.status = 'pending') AS pending_count,
+      (SELECT COUNT(*) FROM sessions ss WHERE ss.project_id = p.id) AS session_count
+    FROM projects p
+    ORDER BY p.last_activity DESC
+  `).all();
+}
+
+/**
+ * Returns stories for a specific project.
+ * @param {string} projectId
+ * @returns {Array<object>}
+ */
+export function getStoriesByProject(projectId) {
+  return getDb().prepare(`
+    SELECT * FROM stories WHERE project_id = ? ORDER BY updated_at DESC
+  `).all(projectId);
+}
+
+/**
+ * Returns full story detail including context requests.
+ * @param {string} storyId
+ * @returns {object | null}
+ */
+export function getStoryDetail(storyId) {
+  const story = getDb().prepare('SELECT * FROM stories WHERE id = ?').get(storyId);
+  if (!story) return null;
+
+  const contextRequests = getDb().prepare(
+    'SELECT * FROM context_requests WHERE story_id = ? ORDER BY requested_at DESC'
+  ).all(storyId);
+
+  return { ...story, context_requests: contextRequests };
+}
+
+/**
+ * Returns sessions for a specific project.
+ * @param {string} projectId
+ * @returns {Array<object>}
+ */
+export function getSessionsByProject(projectId) {
+  return getDb().prepare(`
+    SELECT id, project_id, task, status, created_at, updated_at,
+           iterations, duration_ms, approved, stages_completed
+    FROM sessions WHERE project_id = ? ORDER BY created_at DESC
+  `).all(projectId);
+}
+
+/**
+ * Returns full session detail.
+ * @param {string} sessionId
+ * @returns {object | null}
+ */
+export function getSessionDetail(sessionId) {
+  return getDb().prepare('SELECT * FROM sessions WHERE id = ?').get(sessionId);
+}
+
+/**
+ * Returns global dashboard statistics.
+ * @returns {object}
+ */
+export function getDashboardStats() {
+  const db = getDb();
+  const totalStories = db.prepare('SELECT COUNT(*) AS count FROM stories').get().count;
+  const certifiedStories = db.prepare("SELECT COUNT(*) AS count FROM stories WHERE status = 'certified'").get().count;
+  const pendingStories = db.prepare("SELECT COUNT(*) AS count FROM stories WHERE status = 'pending'").get().count;
+  const doneStories = db.prepare("SELECT COUNT(*) AS count FROM stories WHERE status = 'done'").get().count;
+  const needsContextStories = db.prepare("SELECT COUNT(*) AS count FROM stories WHERE status = 'needs_context'").get().count;
+  const avgQuality = db.prepare('SELECT AVG(quality_total) AS avg FROM stories WHERE quality_total IS NOT NULL').get().avg;
+  const totalSessions = db.prepare('SELECT COUNT(*) AS count FROM sessions').get().count;
+  const approvedSessions = db.prepare('SELECT COUNT(*) AS count FROM sessions WHERE approved = 1').get().count;
+  const totalProjects = db.prepare('SELECT COUNT(*) AS count FROM projects').get().count;
+
+  return {
+    total_stories: totalStories,
+    certified_stories: certifiedStories,
+    pending_stories: pendingStories,
+    done_stories: doneStories,
+    needs_context_stories: needsContextStories,
+    avg_quality: avgQuality ? Math.round(avgQuality * 10) / 10 : null,
+    total_sessions: totalSessions,
+    approved_sessions: approvedSessions,
+    total_projects: totalProjects,
+  };
+}
+
+/**
+ * Inserts a context request for a story.
+ * @param {object} req
+ */
+export function insertContextRequest(req) {
+  getDb().prepare(`
+    INSERT INTO context_requests (story_id, fields_needed, question, answer, requested_at, answered_at)
+    VALUES (@story_id, @fields_needed, @question, @answer, @requested_at, @answered_at)
+  `).run({
+    story_id: req.story_id,
+    fields_needed: req.fields_needed || null,
+    question: req.question || null,
+    answer: req.answer || null,
+    requested_at: req.requested_at || new Date().toISOString(),
+    answered_at: req.answered_at || null,
+  });
+}
+
+/**
+ * Closes the database connection.
+ */
+export function closeDb() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1,0 +1,134 @@
+import { Router } from 'express';
+import {
+  getDashboardStats,
+  getProjects,
+  getStoriesByProject,
+  getStoryDetail,
+  getSessionsByProject,
+  getSessionDetail,
+} from '../db.js';
+
+const router = Router();
+
+/**
+ * GET /api/dashboard - Global dashboard statistics.
+ */
+router.get('/dashboard', (_req, res) => {
+  try {
+    const stats = getDashboardStats();
+    res.json(stats);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/projects - List all projects with story counts.
+ */
+router.get('/projects', (_req, res) => {
+  try {
+    const projects = getProjects();
+    res.json(projects);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/projects/:id - Project detail.
+ */
+router.get('/projects/:id', (req, res) => {
+  try {
+    const projects = getProjects();
+    const project = projects.find((p) => p.id === req.params.id);
+    if (!project) return res.status(404).json({ error: 'Project not found' });
+    res.json(project);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/projects/:id/stories - Stories for a project.
+ */
+router.get('/projects/:id/stories', (req, res) => {
+  try {
+    const stories = getStoriesByProject(req.params.id);
+    res.json(stories);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/stories/:id - Story detail with quality scores and context requests.
+ */
+router.get('/stories/:id', (req, res) => {
+  try {
+    const story = getStoryDetail(req.params.id);
+    if (!story) return res.status(404).json({ error: 'Story not found' });
+    res.json(story);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/projects/:id/sessions - Sessions for a project.
+ */
+router.get('/projects/:id/sessions', (req, res) => {
+  try {
+    const sessions = getSessionsByProject(req.params.id);
+    res.json(sessions);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/sessions/:id - Session detail with stages, commits, duration.
+ */
+router.get('/sessions/:id', (req, res) => {
+  try {
+    const session = getSessionDetail(req.params.id);
+    if (!session) return res.status(404).json({ error: 'Session not found' });
+    // Parse JSON fields for the response
+    const parsed = { ...session };
+    for (const field of ['checkpoints', 'llm_calls', 'config_snapshot', 'budget', 'commits', 'stages_completed']) {
+      if (parsed[field] && typeof parsed[field] === 'string') {
+        try { parsed[field] = JSON.parse(parsed[field]); } catch { /* keep as string */ }
+      }
+    }
+    res.json(parsed);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/sessions - All sessions across all projects.
+ */
+router.get('/sessions', (_req, res) => {
+  try {
+    const allProjects = getProjects();
+    const sessions = [];
+    for (const p of allProjects) {
+      sessions.push(...getSessionsByProject(p.id));
+    }
+    // Also get default project sessions
+    sessions.push(...getSessionsByProject('default'));
+    // Deduplicate
+    const seen = new Set();
+    const unique = sessions.filter((s) => {
+      if (seen.has(s.id)) return false;
+      seen.add(s.id);
+      return true;
+    });
+    unique.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+    res.json(unique);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -1,0 +1,106 @@
+import express from 'express';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:net';
+import { initDb, closeDb } from './db.js';
+import { fullScan, startWatcher } from './sync.js';
+import apiRoutes from './routes/api.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = join(__dirname, '..', 'public');
+
+/**
+ * Checks if a port is available.
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once('error', () => resolve(false));
+    server.once('listening', () => {
+      server.close();
+      resolve(true);
+    });
+    server.listen(port);
+  });
+}
+
+/**
+ * Finds an available port starting from the given port.
+ * @param {number} startPort
+ * @param {number} maxAttempts
+ * @returns {Promise<number>}
+ */
+async function findAvailablePort(startPort, maxAttempts = 11) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = startPort + i;
+    if (await isPortAvailable(port)) return port;
+    console.log(`[server] Port ${port} is busy, trying ${port + 1}...`);
+  }
+  throw new Error(`No available port found between ${startPort} and ${startPort + maxAttempts - 1}`);
+}
+
+/**
+ * Parses the desired port from env var or --port flag.
+ * @returns {number}
+ */
+function getDesiredPort() {
+  const portArg = process.argv.find((arg, i, arr) => arr[i - 1] === '--port');
+  if (portArg) return parseInt(portArg, 10);
+  return parseInt(process.env.PORT || '4000', 10);
+}
+
+/**
+ * Main entry point: initializes database, syncs data, and starts the server.
+ */
+async function main() {
+  // Initialize SQLite
+  console.log('[server] Initializing database...');
+  initDb();
+
+  // Full scan of existing files
+  console.log('[server] Running full scan of JSON files...');
+  fullScan();
+
+  // Start file watcher
+  const watcher = startWatcher();
+
+  // Create Express app
+  const app = express();
+  app.use(express.json());
+  app.use(express.static(PUBLIC_DIR));
+  app.use('/api', apiRoutes);
+
+  // SPA fallback: serve index.html for non-API, non-static routes
+  app.get('/{*splat}', (_req, res) => {
+    res.sendFile(join(PUBLIC_DIR, 'index.html'));
+  });
+
+  // Find available port
+  const desiredPort = getDesiredPort();
+  const port = await findAvailablePort(desiredPort);
+
+  const server = app.listen(port, () => {
+    console.log(`\n  Karajan HU Board`);
+    console.log(`  -----------------`);
+    console.log(`  Running at: http://localhost:${port}`);
+    console.log(`  Data dir:   ${process.env.KJ_HOME || '~/.karajan'}\n`);
+  });
+
+  // Graceful shutdown
+  const shutdown = () => {
+    console.log('\n[server] Shutting down...');
+    watcher.close();
+    closeDb();
+    server.close(() => process.exit(0));
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((err) => {
+  console.error('[server] Fatal error:', err);
+  process.exit(1);
+});

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -1,0 +1,222 @@
+import { watch } from 'chokidar';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import {
+  getKjHome,
+  upsertProject,
+  upsertStory,
+  upsertSession,
+  insertContextRequest,
+  getDb,
+} from './db.js';
+
+/**
+ * Parses a batch.json HU stories file and syncs to SQLite.
+ * @param {string} filePath - Absolute path to the batch.json file
+ */
+function syncStoryFile(filePath) {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    const sessionId = data.session_id || basename(join(filePath, '..'));
+    const projectId = data.project_id || sessionId;
+
+    upsertProject({
+      id: projectId,
+      name: data.project_name || projectId,
+      last_activity: data.created_at || new Date().toISOString(),
+      total_stories: (data.stories || []).length,
+    });
+
+    for (const story of data.stories || []) {
+      const certified = story.certified || {};
+      const quality = story.quality || {};
+      const dimensions = quality.dimensions || {};
+
+      upsertStory({
+        id: story.id,
+        project_id: projectId,
+        session_id: sessionId,
+        status: story.status || 'pending',
+        title: extractTitle(story),
+        original_text: story.original?.text || null,
+        certified_as: certified.as || null,
+        certified_want: certified.want || null,
+        certified_so_that: certified.so_that || null,
+        quality_total: quality.total ?? null,
+        quality_d1: dimensions.d1 ?? null,
+        quality_d2: dimensions.d2 ?? null,
+        quality_d3: dimensions.d3 ?? null,
+        quality_d4: dimensions.d4 ?? null,
+        quality_d5: dimensions.d5 ?? null,
+        quality_d6: dimensions.d6 ?? null,
+        antipatterns: quality.antipatterns ? JSON.stringify(quality.antipatterns) : null,
+        ac_format: story.acceptance_criteria?.format || null,
+        acceptance_criteria: story.acceptance_criteria?.criteria
+          ? JSON.stringify(story.acceptance_criteria.criteria)
+          : null,
+        created_at: story.created_at,
+        updated_at: story.updated_at,
+        certified_at: story.certified_at || null,
+      });
+
+      // Sync context requests
+      for (const ctx of story.context_requests || []) {
+        insertContextRequest({
+          story_id: story.id,
+          fields_needed: ctx.fields_needed ? JSON.stringify(ctx.fields_needed) : null,
+          question: ctx.question || null,
+          answer: ctx.answer || null,
+          requested_at: ctx.requested_at || null,
+          answered_at: ctx.answered_at || null,
+        });
+      }
+    }
+
+    console.log(`[sync] Synced stories from ${basename(join(filePath, '..'))}: ${(data.stories || []).length} stories`);
+  } catch (err) {
+    console.error(`[sync] Error syncing story file ${filePath}:`, err.message);
+  }
+}
+
+/**
+ * Extracts a short title from a story.
+ * @param {object} story
+ * @returns {string}
+ */
+function extractTitle(story) {
+  const text = story.original?.text || '';
+  if (story.certified?.want) {
+    return story.certified.want.slice(0, 120);
+  }
+  return text.slice(0, 120) || story.id;
+}
+
+/**
+ * Parses a session.json file and syncs to SQLite.
+ * @param {string} filePath - Absolute path to session.json
+ */
+function syncSessionFile(filePath) {
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    const sessionId = data.id || basename(join(filePath, '..'));
+    const projectId = data.project_id || 'default';
+
+    // Calculate iterations from checkpoints
+    const checkpoints = data.checkpoints || [];
+    const maxIteration = checkpoints.reduce((max, cp) => Math.max(max, cp.iteration || 0), 0);
+
+    // Calculate duration from first and last checkpoint
+    let durationMs = null;
+    if (data.created_at && data.updated_at) {
+      durationMs = new Date(data.updated_at).getTime() - new Date(data.created_at).getTime();
+    }
+
+    // Collect completed stages
+    const stagesSet = new Set();
+    for (const cp of checkpoints) {
+      if (cp.stage && !cp.stage.includes('attempt') && !cp.stage.includes('checkpoint')) {
+        stagesSet.add(cp.stage);
+      }
+    }
+
+    upsertProject({
+      id: projectId,
+      name: projectId,
+      last_activity: data.updated_at || data.created_at || new Date().toISOString(),
+    });
+
+    upsertSession({
+      id: sessionId,
+      project_id: projectId,
+      task: data.task || null,
+      status: data.status || 'unknown',
+      created_at: data.created_at,
+      updated_at: data.updated_at,
+      iterations: maxIteration,
+      duration_ms: durationMs,
+      approved: data.status === 'approved' ? 1 : 0,
+      commits: data.commits ? JSON.stringify(data.commits) : null,
+      stages_completed: JSON.stringify([...stagesSet]),
+      checkpoints: JSON.stringify(checkpoints),
+      llm_calls: data.llm_calls ? JSON.stringify(data.llm_calls) : null,
+      config_snapshot: data.config_snapshot ? JSON.stringify(data.config_snapshot) : null,
+      budget: data.budget ? JSON.stringify(data.budget) : null,
+    });
+
+    console.log(`[sync] Synced session ${sessionId}: status=${data.status}, iterations=${maxIteration}`);
+  } catch (err) {
+    console.error(`[sync] Error syncing session file ${filePath}:`, err.message);
+  }
+}
+
+/**
+ * Performs a full scan of all existing JSON files.
+ */
+export function fullScan() {
+  const kjHome = getKjHome();
+  const storiesDir = join(kjHome, 'hu-stories');
+  const sessionsDir = join(kjHome, 'sessions');
+
+  // Clear existing data for a clean rebuild
+  const db = getDb();
+  db.exec('DELETE FROM context_requests');
+  db.exec('DELETE FROM stories');
+  db.exec('DELETE FROM sessions');
+  db.exec('DELETE FROM projects');
+
+  // Scan stories
+  if (existsSync(storiesDir)) {
+    const dirs = readdirSync(storiesDir);
+    for (const dir of dirs) {
+      const batchPath = join(storiesDir, dir, 'batch.json');
+      if (existsSync(batchPath)) {
+        syncStoryFile(batchPath);
+      }
+    }
+  }
+
+  // Scan sessions
+  if (existsSync(sessionsDir)) {
+    const dirs = readdirSync(sessionsDir);
+    for (const dir of dirs) {
+      const sessionPath = join(sessionsDir, dir, 'session.json');
+      if (existsSync(sessionPath)) {
+        syncSessionFile(sessionPath);
+      }
+    }
+  }
+
+  console.log('[sync] Full scan completed');
+}
+
+/**
+ * Starts the file watcher for live sync.
+ * @returns {import('chokidar').FSWatcher}
+ */
+export function startWatcher() {
+  const kjHome = getKjHome();
+  const storiesGlob = join(kjHome, 'hu-stories', '*', 'batch.json');
+  const sessionsGlob = join(kjHome, 'sessions', '*', 'session.json');
+
+  const watcher = watch([storiesGlob, sessionsGlob], {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
+  });
+
+  watcher.on('add', (path) => {
+    console.log(`[watcher] New file: ${path}`);
+    if (path.includes('hu-stories')) syncStoryFile(path);
+    else if (path.includes('sessions')) syncSessionFile(path);
+  });
+
+  watcher.on('change', (path) => {
+    console.log(`[watcher] Changed: ${path}`);
+    if (path.includes('hu-stories')) syncStoryFile(path);
+    else if (path.includes('sessions')) syncSessionFile(path);
+  });
+
+  console.log(`[watcher] Watching ${kjHome} for changes`);
+  return watcher;
+}


### PR DESCRIPTION
## Summary
Full-stack web dashboard for visualizing Karajan HU stories and sessions.

- **Backend**: Express 5 + SQLite (better-sqlite3) + chokidar file watcher
- **Frontend**: Vanilla JS SPA — kanban board, session timeline, story detail modals
- **Data**: Reads JSON files from ~/.karajan/, SQLite as index (regenerable)
- **Multi-project**: Auto-discovers all projects, selector in header
- **Docker**: Single container, port 4000 (auto-detect), volume ~/.karajan/
- **Dark theme**: Matches KJ landing (purple/teal palette, Inter + JetBrains Mono)

## Features
- Dashboard with global stats (stories, certified %, avg quality)
- Kanban columns: Pending → Certified → Coding → Done
- Story cards with quality scores, antipatterns, AC format
- Session timeline with stage-by-stage breakdown
- Auto-refresh every 10 seconds
- 2387 lines, zero changes to root package

## Quick start
```bash
cd packages/hu-board && npm install && npm start
# Open http://localhost:4000 (or 4001 if busy)
```