### PR TITLE
docs: add community templates (CoC, contributing, issue/PR)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Something broke or behaves unexpectedly
+labels: bug
+---
+
+**Karajan version:**
+
+**Command executed:**
+
+**Output obtained:**
+
+**Expected output:**
+
+**OS and Node version:**
+
+---
+
+**Versión de Karajan:**
+
+**Comando ejecutado:**
+
+**Salida obtenida:**
+
+**Salida esperada:**
+
+**SO y versión de Node:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest something that would make Karajan more useful
+labels: enhancement
+---
+
+**What problem does this solve?**
+
+**How would you solve it?**
+
+**Alternatives you considered:**
+
+---
+
+**¿Qué problema resuelve?**
+
+**¿Cómo lo resolverías?**
+
+**Alternativas que consideraste:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What this PR solves
+
+## How to test it
+
+## Tests added or modified
+
+## Notes for the reviewer
+
+**PRs without tests will not be merged unless there is a justified exceptional reason.**
+
+---
+
+## Qué resuelve este PR
+
+## Cómo probarlo
+
+## Tests añadidos o modificados
+
+## Notas para el revisor
+
+**Los PRs sin tests no se mergean salvo causa excepcional justificada.**

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This is a small project built by one person in the open. Contributions, questions and honest criticism are welcome. Personal attacks, harassment or passive-aggressive behavior are not.
+
+Keep discussions technical. Disagree with ideas, not with people. If you open an issue or a PR, explain what and why. If someone else does, read before reacting.
+
+There is no formal pledge to sign, no training to complete. Just show up in good faith and treat others the way you would in a room where everyone can hear you.
+
+If someone breaks these simple rules the issue or PR gets closed immediately, no warnings, no debate. Repeat offenders get blocked. Life is too short.
+
+---
+
+# Código de Conducta
+
+Este es un proyecto pequeño, construido por una persona y publicado en abierto. Las contribuciones, preguntas y críticas honestas son bienvenidas. Los ataques personales, el acoso o la agresividad pasiva no tienen sitio aquí.
+
+Mantén las discusiones en el plano técnico. Discrepa con las ideas, no con las personas. Si abres un issue o un PR, explica el qué y el porqué. Si lo abre otro, lee antes de contestar.
+
+No hay ningún compromiso formal que firmar ni formación que completar. Solo hace falta buena fe y tratar a los demás como lo harías en una sala donde todo el mundo te escucha.
+
+Si alguien se salta estas reglas tan sencillas, el issue o PR se cierra en el acto, sin avisos ni discusiones. Los reincidentes se bloquean. La vida es demasiado corta.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Reporting bugs
+
+Open an issue with the exact command you ran, the output you got, and the output you expected. Without those three things the bug cannot be reproduced and the issue will be closed.
+
+## Proposing features
+
+Open a Discussion first, not a PR. Explain what you need and why. Building something nobody asked for and then discovering it does not fit the project is frustrating for everyone. Talk first, code later.
+
+## Opening a pull request
+
+Branch from main. Include tests or the PR will not be reviewed. Write a short description of what the PR solves and why you chose this approach. Keep changes focused.
+
+This project is written in vanilla JavaScript with JSDoc annotations. It will stay that way. PRs that introduce TypeScript, transpilation steps or type-system dependencies will be closed.
+
+## Response time
+
+Issues and PRs are reviewed within a few days. If a week passes with no reply, a friendly reminder comment is perfectly fine.
+
+---
+
+# Contribuir
+
+## Reportar bugs
+
+Abre un issue con el comando exacto que ejecutaste, la salida que obtuviste y la salida que esperabas. Sin esas tres cosas el bug no se puede reproducir y el issue se cerrará.
+
+## Proponer funcionalidades
+
+Abre una Discussion primero, no un PR. Explica qué necesitas y por qué. Construir algo que nadie pidió para descubrir después que no encaja en el proyecto es frustrante para todos. Primero hablar, luego codear.
+
+## Abrir un pull request
+
+Crea rama desde main. Incluye tests o el PR no será revisado. Escribe una descripción corta de qué resuelve el PR y por qué elegiste ese enfoque. Mantén los cambios acotados.
+
+Este proyecto está escrito en JavaScript vanilla con anotaciones JSDoc. Va a seguir así. Los PRs que introduzcan TypeScript, pasos de transpilación o dependencias del sistema de tipos se cerrarán.
+
+## Tiempo de respuesta
+
+Los issues y PRs se revisan en pocos días. Si pasa una semana sin respuesta, un comentario recordatorio es bienvenido sin problema.


### PR DESCRIPTION
## Summary
- CODE_OF_CONDUCT.md — bilingual EN/ES, direct tone, no Contributor Covenant copy-paste
- CONTRIBUTING.md — bug reports, feature proposals, PR guidelines, response time
- Issue templates: bug report + feature request (bilingual, minimal fields)
- PR template: what/how/tests/notes + firm line on tests requirement

## Test plan
- [ ] Verify templates render correctly on GitHub (New Issue, New PR)