### PR TITLE
chore: bump version to v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate — without you babysitting every step.
+You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 
 ## What is Karajan?
 
@@ -30,7 +30,7 @@ Karajan is a local coding orchestrator. It runs on your machine, uses your exist
 
 It is not a hosted service. It is not a VS Code extension. It is a tool you install once and use from the terminal or as an MCP server inside your AI agent.
 
-The name comes from Herbert von Karajan — the conductor who believed that the best orchestras are made of great independent musicians who know exactly when to play and when to listen. Same idea here, applied to AI agents.
+The name comes from Herbert von Karajan, the conductor who believed that the best orchestras are made of great independent musicians who know exactly when to play and when to listen. Same idea, applied to AI agents.
 
 ## Why not just use Claude Code?
 
@@ -39,16 +39,16 @@ Claude Code is excellent. Use it for interactive, session-based coding.
 Use Karajan when you want:
 
 - **A repeatable, documented pipeline** that runs the same way every time
-- **TDD by default** — tests are written before implementation, not after
-- **SonarQube integration** — code quality gates as part of the flow, not an afterthought
-- **Solomon as pipeline boss** — every reviewer rejection is evaluated by a supervisor that decides if it's valid or just style noise
-- **Multi-provider routing** — Claude as coder, Codex as reviewer, or any combination
-- **Zero-config operation** — auto-detects test frameworks, starts SonarQube, simplifies pipeline for trivial tasks
-- **Composable role architecture** — define agent behaviors as plain markdown files that travel with your project
-- **Local-first** — your code, your keys, your machine, no data leaves unless you say so
-- **Zero API costs** — Karajan uses AI agent CLIs (Claude Code, Codex, Gemini CLI), not APIs. You pay your existing subscription (Claude Pro, ChatGPT Plus), not per-token API fees. No surprise bills.
+- **TDD by default.** Tests are written before implementation, not after
+- **SonarQube integration.** Code quality gates as part of the flow, not an afterthought
+- **Solomon as pipeline boss.** Every reviewer rejection is evaluated by a supervisor that decides if it's valid or just style noise
+- **Multi-provider routing.** Claude as coder, Codex as reviewer, or any combination
+- **Zero-config operation.** Auto-detects test frameworks, starts SonarQube, simplifies pipeline for trivial tasks
+- **Composable role architecture.** Agent behaviors defined as plain markdown files that travel with your project
+- **Local-first.** Your code, your keys, your machine. No data leaves unless you say so
+- **Zero API costs.** Karajan uses AI agent CLIs (Claude Code, Codex, Gemini CLI), not APIs. You pay your existing subscription (Claude Pro, ChatGPT Plus), not per-token API fees
 
-If Claude Code is a smart pair programmer, Karajan is the CI/CD pipeline for AI-assisted development. They work great together — Karajan is designed to be used as an MCP server inside Claude Code.
+If Claude Code is a smart pair programmer, Karajan is the CI/CD pipeline for AI-assisted development. They work great together: Karajan is designed to be used as an MCP server inside Claude Code.
 
 ## Install
 
@@ -62,7 +62,7 @@ That's it. No Docker required (SonarQube uses Docker, but Karajan auto-manages i
 
 Karajan installs **three commands**: `kj`, `kj-tail`, and `karajan-mcp`.
 
-### 1. CLI — Direct from terminal
+### 1. CLI: direct from terminal
 
 Run Karajan directly. You see the full pipeline output in real time.
 
@@ -74,7 +74,7 @@ kj audit "Full health analysis of this codebase"       # Read-only audit
 kj plan "Refactor the database layer"                  # Plan without coding
 ```
 
-### 2. MCP — Inside your AI agent
+### 2. MCP: inside your AI agent
 
 This is the primary use case. Karajan runs as an MCP server inside Claude Code, Codex, or Gemini. You ask your AI agent to do something, and it delegates the heavy lifting to Karajan's pipeline.
 
@@ -86,7 +86,7 @@ The MCP server auto-registers during `npm install`. Your AI agent sees 20 tools 
 
 **The problem**: when Karajan runs inside an AI agent, you lose visibility. The agent shows you the final result, but not the pipeline stages, iterations, or Solomon decisions happening in real time.
 
-### 3. kj-tail — Monitor from a separate terminal
+### 3. kj-tail: monitor from a separate terminal
 
 **This is the companion tool.** Open a second terminal in the **same project directory** where your AI agent is working, and run:
 
@@ -94,7 +94,7 @@ The MCP server auto-registers during `npm install`. Your AI agent sees 20 tools 
 kj-tail
 ```
 
-You'll see the live pipeline output — stages, results, iterations, errors — as they happen. Same view as running `kj run` directly.
+You'll see the live pipeline output (stages, results, iterations, errors) as they happen. Same view as running `kj run` directly.
 
 ```
 kj-tail                  # Follow pipeline in real time (default)
@@ -118,7 +118,7 @@ kj-tail --help           # Full options
 │    priority task         │    │  ├─ 📋 Triage: medium    │
 │                          │    │  ├─ 🔬 Researcher ✅     │
 │  (Claude calls kj_run   │    │  ├─ 🧠 Planner ✅        │
-│   via MCP — you see      │    │  ├─ 🔨 Coder ✅          │
+│   via MCP, you see       │    │  ├─ 🔨 Coder ✅          │
 │   only the final result) │    │  ├─ 🔍 Sonar: OK        │
 │                          │    │  ├─ 👁️ Reviewer ❌       │
 │                          │    │  ├─ ⚖️ Solomon: 2 cond.  │
@@ -129,7 +129,7 @@ kj-tail --help           # Full options
 └─────────────────────────┘    └─────────────────────────┘
 ```
 
-**Full pipeline example** — a complex task with all roles:
+**Full pipeline example**, a complex task with all roles:
 
 ```
 ┌─ Terminal 1 ─────────────────────────────────────────────────────────────────┐
@@ -154,7 +154,7 @@ kj-tail --help           # Full options
 
 ┌─ Terminal 2: kj-tail ────────────────────────────────────────────────────────┐
 │                                                                              │
-│  kj-tail v1.36.1 — .kj/run.log                                              │
+│  kj-tail v1.37.0 — .kj/run.log                                              │
 │                                                                              │
 │  ├─ 📋 Triage: medium (sw) — enabling researcher, architect, planner         │
 │  ├─ ⚙️ Preflight passed — all checks OK                                     │
@@ -193,7 +193,7 @@ kj-tail --help           # Full options
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
-[**▶ Watch the full pipeline demo**](https://karajancode.com#demo) — triage, architecture, TDD, SonarQube, code review, Solomon arbitration, security audit.
+[**Watch the full pipeline demo**](https://karajancode.com#demo): triage, architecture, TDD, SonarQube, code review, Solomon arbitration, security audit.
 
 ## The pipeline
 
@@ -217,7 +217,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 | **reviewer** | Code review with configurable strictness profiles | **Always on** |
 | **tester** | Test quality gate and coverage verification | **On** |
 | **security** | OWASP security audit | **On** |
-| **solomon** | Pipeline boss — evaluates every rejection, overrides style-only blocks | **On** |
+| **solomon** | Pipeline boss: evaluates every rejection, overrides style-only blocks | **On** |
 | **commiter** | Git commit, push, and PR automation after approval | Off |
 | **audit** | Read-only codebase health analysis (5 dimensions, A-F scores) | Standalone |
 
@@ -233,7 +233,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 
 Mix and match. Use Claude as coder and Codex as reviewer. Karajan auto-detects installed agents during `kj init`.
 
-## MCP server — 20 tools
+## MCP server (20 tools)
 
 After `npm install -g karajan-code`, the MCP server auto-registers in Claude and Codex. Manual config if needed:
 
@@ -251,7 +251,7 @@ Use `kj-tail` in a separate terminal to see what the pipeline is doing in real t
 
 ## The role architecture
 
-Every role in Karajan is defined by a markdown file — a plain document that describes how the agent should behave, what to check, and what good output looks like.
+Every role in Karajan is defined by a markdown file: a plain document that describes how the agent should behave, what to check, and what good output looks like.
 
 ```
 .karajan/roles/         # Project overrides (optional)
@@ -259,7 +259,7 @@ Every role in Karajan is defined by a markdown file — a plain document that de
 templates/roles/        # Built-in defaults (shipped with package)
 ```
 
-You can override any built-in role or create new ones. No code required. The agents read the role files and adapt their behavior. This means you can encode your team's conventions, domain rules, and quality standards — and every run of Karajan will apply them automatically.
+You can override any built-in role or create new ones. No code required. The agents read the role files and adapt their behavior. Encode your team's conventions, domain rules, and quality standards, and every run of Karajan applies them automatically.
 
 Use `kj roles show <role>` to inspect any template.
 
@@ -268,7 +268,8 @@ Use `kj roles show <role>` to inspect any template.
 Karajan auto-detects and auto-configures everything it can:
 
 - **TDD**: Detects test framework (vitest, jest, mocha) → auto-enables TDD
-- **Bootstrap gate**: Validates all prerequisites (git repo, remote, config, agents, SonarQube) before any tool runs. Fails hard with actionable fix instructions — never silently degrades
+- **Bootstrap gate**: Validates all prerequisites (git repo, remote, config, agents, SonarQube) before any tool runs. Fails hard with actionable fix instructions, never silently degrades
+- **Injection guard**: Scans diffs for prompt injection before AI review. Detects directive overrides, invisible Unicode, oversized comment payloads. Also runs as a GitHub Action on every PR
 - **SonarQube**: Auto-starts Docker container, generates config if missing
 - **Pipeline complexity**: Triage classifies task → trivial tasks skip reviewer loop
 - **Provider outages**: Retries on 500/502/503/504 with backoff (same as rate limits)
@@ -280,16 +281,16 @@ No per-project configuration required. If you want to customize, config is layer
 
 Because it should be.
 
-Karajan has **1966 tests** across 157 files. It runs on Node.js without a build step. You can read the source, understand it, fork it, and modify it without a TypeScript compiler between you and the code.
+Karajan has **2044 tests** across 161 files. It runs on Node.js without a build step. You can read the source, understand it, fork it, and modify it without a TypeScript compiler between you and the code.
 
-This is a deliberate choice, not a limitation. The tests are the type safety. The legibility is a feature. **55 releases in 26 days** — that velocity is possible precisely because vanilla JS with good tests lets you move fast without fear.
+This is a deliberate choice, not a limitation. The tests are the type safety. The legibility is a feature. 57 releases in 45 days. That velocity is possible precisely because vanilla JS with good tests lets you move fast without fear.
 
 ## Recommended companions
 
 | Tool | Why |
 |------|-----|
 | [**RTK**](https://github.com/rtk-ai/rtk) | Reduces token consumption by 60-90% on Bash command outputs |
-| [**Planning Game MCP**](https://github.com/AgenteIA-Geniova/planning-game-mcp) | Agile project management (tasks, sprints, estimation) — XP-native |
+| [**Planning Game MCP**](https://github.com/AgenteIA-Geniova/planning-game-mcp) | Agile project management (tasks, sprints, estimation), XP-native |
 | [**GitHub MCP**](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Create PRs, manage issues directly from the agent |
 | [**Chrome DevTools MCP**](https://github.com/anthropics/anthropic-quickstarts/tree/main/chrome-devtools-mcp) | Verify UI changes visually after frontend modifications |
 
@@ -299,11 +300,11 @@ This is a deliberate choice, not a limitation. The tests are the type safety. Th
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-npm test              # Run 1847 tests with Vitest
+npm test              # Run 2044 tests with Vitest
 npm run validate      # Lint + test
 ```
 
-Issues and pull requests welcome. If something doesn't work as documented, [open an issue](https://github.com/manufosela/karajan-code/issues) — that's the most useful contribution at this stage.
+Issues and pull requests welcome. If something doesn't work as documented, [open an issue](https://github.com/manufosela/karajan-code/issues). That's the most useful contribution at this stage.
 
 ## Links
 
@@ -315,4 +316,4 @@ Issues and pull requests welcome. If something doesn't work as documented, [open
 
 ---
 
-Built by [@manufosela](https://github.com/manufosela) — Head of Engineering at Geniova Technologies, co-organizer of NodeJS Madrid, author of [Liderazgo Afectivo](https://www.amazon.es/dp/B0D7F4C8KC). 90+ npm packages published.
+Built by [@manufosela](https://github.com/manufosela). Head of Engineering at Geniova Technologies, co-organizer of NodeJS Madrid, author of [Liderazgo Afectivo](https://www.amazon.es/dp/B0D7F4C8KC). 90+ npm packages published.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -23,39 +23,40 @@
 
 ## Que es Karajan Code?
 
-Karajan Code (`kj`) orquesta multiples agentes de IA a traves de un pipeline automatizado: generacion de codigo, analisis estatico, revision de codigo, testing y auditorias de seguridad — todo en un solo comando.
+Karajan Code (`kj`) orquesta multiples agentes de IA a traves de un pipeline automatizado: generacion de codigo, analisis estatico, revision de codigo, testing y auditorias de seguridad. Todo en un solo comando.
 
 En lugar de ejecutar un agente de IA y revisar manualmente su output, `kj` encadena agentes con quality gates. El coder escribe codigo, SonarQube lo analiza, el reviewer lo revisa, y si hay problemas, el coder recibe otra oportunidad. Este bucle se repite hasta que el codigo es aprobado o se alcanza el limite de iteraciones.
 
 **Caracteristicas principales:**
 - **Pipeline multi-agente** con 11 roles configurables
 - **5 agentes de IA soportados**: Claude, Codex, Gemini, Aider, OpenCode
-- **Servidor MCP** con 20 herramientas — usa `kj` desde Claude, Codex o cualquier host compatible con MCP sin salir de tu agente. [Ver configuracion MCP](#servidor-mcp)
-- **Bootstrap obligatorio** — valida prerequisitos del entorno (git, remote, config, agentes, SonarQube) antes de cada ejecucion. Si algo falta, para con instrucciones claras
-- **TDD obligatorio** — se exigen cambios en tests cuando se modifican ficheros fuente
-- **Integracion con SonarQube** — analisis estatico con quality gates (requiere [Docker](#requisitos))
-- **Perfiles de revision** — standard, strict, relaxed, paranoid
-- **Tracking de presupuesto** — monitorizacion de tokens y costes por sesion con `--trace`
-- **Automatizacion Git** — auto-commit, auto-push, auto-PR tras aprobacion
-- **Gestion de sesiones** — pausa/reanudacion con deteccion fail-fast y limpieza automatica de sesiones expiradas
-- **Sistema de plugins** — extiende con agentes custom via `.karajan/plugins/`
-- **Checkpoints interactivos** — en lugar de matar tareas largas, pausa cada 5 minutos con un informe de progreso y te deja decidir: continuar, parar o ajustar el tiempo
-- **Descomposicion de tareas** — triage detecta cuando una tarea debe dividirse y recomienda subtareas; con integracion Planning Game, crea cards vinculadas con bloqueo secuencial
-- **Retry con backoff** — recuperacion automatica ante errores transitorios de API (429, 5xx) con backoff exponencial y jitter
-- **Pipeline stage tracker** — vista de progreso acumulativo durante `kj_run` mostrando que stages estan completadas, en ejecucion o pendientes — tanto en CLI como via eventos MCP para renderizado en tiempo real en el host
-- **Guardarrailes de observabilidad del planner** — telemetria continua de heartbeat/stall, proteccion configurable por silencio maximo (`session.max_agent_silence_minutes`) y limite duro de ejecucion (`session.max_planner_minutes`) para evitar bloqueos prolongados en `kj_plan`/planner
-- **Standby por rate-limit** — cuando un agente alcanza limites de uso, Karajan parsea el tiempo de espera, espera con backoff exponencial y reanuda automaticamente en vez de fallar
-- **Preflight handshake** — `kj_preflight` requiere confirmacion humana de la configuracion de agentes antes de ejecutar, previniendo que la IA cambie asignaciones silenciosamente
-- **Config de 3 niveles** — sesion > proyecto > global con scoping de `kj_agents`
-- **Mediacion inteligente del reviewer** — el scope filter difiere automaticamente issues del reviewer fuera de scope (ficheros no presentes en el diff) como deuda tecnica rastreada en vez de bloquear; Solomon media reviews estancados; el contexto diferido se inyecta en el prompt del coder
-- **Integracion con Planning Game** — combina opcionalmente con [Planning Game](https://github.com/AgenteIA-Geniova/planning-game) para gestion agil de proyectos (tareas, sprints, estimacion) — como Jira, pero open-source y nativo XP
+- **Servidor MCP** con 20 herramientas. Usa `kj` desde Claude, Codex o cualquier host compatible con MCP sin salir de tu agente. [Ver configuracion MCP](#servidor-mcp)
+- **Bootstrap obligatorio.** Valida prerequisitos del entorno (git, remote, config, agentes, SonarQube) antes de cada ejecucion. Si algo falta, para con instrucciones claras
+- **Guardia anti-inyeccion.** Escanea diffs antes de pasarlos a la IA: detecta directivas de override, Unicode invisible y payloads ocultos en comentarios. Tambien como GitHub Action en cada PR
+- **TDD obligatorio.** Se exigen cambios en tests cuando se modifican ficheros fuente
+- **Integracion con SonarQube.** Analisis estatico con quality gates (requiere [Docker](#requisitos))
+- **Perfiles de revision.** standard, strict, relaxed, paranoid
+- **Tracking de presupuesto.** Monitorizacion de tokens y costes por sesion con `--trace`
+- **Automatizacion Git.** Auto-commit, auto-push, auto-PR tras aprobacion
+- **Gestion de sesiones.** Pausa/reanudacion con deteccion fail-fast y limpieza automatica de sesiones expiradas
+- **Sistema de plugins.** Extiende con agentes custom via `.karajan/plugins/`
+- **Checkpoints interactivos.** En lugar de matar tareas largas, pausa cada 5 minutos con un informe de progreso y te deja decidir: continuar, parar o ajustar el tiempo
+- **Descomposicion de tareas.** Triage detecta cuando una tarea debe dividirse y recomienda subtareas; con integracion Planning Game, crea cards vinculadas con bloqueo secuencial
+- **Retry con backoff.** Recuperacion automatica ante errores transitorios de API (429, 5xx) con backoff exponencial y jitter
+- **Pipeline stage tracker.** Vista de progreso acumulativo durante `kj_run` mostrando que stages estan completadas, en ejecucion o pendientes, tanto en CLI como via eventos MCP para renderizado en tiempo real en el host
+- **Guardarrailes de observabilidad del planner.** Telemetria continua de heartbeat/stall, proteccion configurable por silencio maximo (`session.max_agent_silence_minutes`) y limite duro de ejecucion (`session.max_planner_minutes`) para evitar bloqueos prolongados en `kj_plan`/planner
+- **Standby por rate-limit.** Cuando un agente alcanza limites de uso, Karajan parsea el tiempo de espera, espera con backoff exponencial y reanuda automaticamente en vez de fallar
+- **Preflight handshake.** `kj_preflight` requiere confirmacion humana de la configuracion de agentes antes de ejecutar, previniendo que la IA cambie asignaciones silenciosamente
+- **Config de 3 niveles.** Sesion > proyecto > global con scoping de `kj_agents`
+- **Mediacion inteligente del reviewer.** El scope filter difiere automaticamente issues del reviewer fuera de scope (ficheros no presentes en el diff) como deuda tecnica rastreada en vez de bloquear; Solomon media reviews estancados; el contexto diferido se inyecta en el prompt del coder
+- **Integracion con Planning Game.** Combina opcionalmente con [Planning Game](https://github.com/AgenteIA-Geniova/planning-game) para gestion agil de proyectos (tareas, sprints, estimacion). Como Jira, pero open-source y nativo XP
 
-> **Mejor con MCP** — Karajan Code esta disenado para usarse como servidor MCP dentro de tu agente de IA (Claude, Codex, etc.). El agente envia tareas a `kj_run`, recibe notificaciones de progreso en tiempo real, y obtiene resultados estructurados — sin copiar y pegar.
+> **Mejor con MCP.** Karajan Code esta disenado para usarse como servidor MCP dentro de tu agente de IA (Claude, Codex, etc.). El agente envia tareas a `kj_run`, recibe notificaciones de progreso en tiempo real, y obtiene resultados estructurados. Sin copiar y pegar.
 
 ## Requisitos
 
 - **Node.js** >= 18
-- **Docker** — necesario para el analisis estatico con SonarQube. Si no tienes Docker o no necesitas SonarQube, desactivalo con `--no-sonar` o `sonarqube.enabled: false` en la config
+- **Docker** (necesario para SonarQube). Si no lo necesitas, desactivalo con `--no-sonar` o `sonarqube.enabled: false`
 - Al menos un agente de IA instalado: Claude, Codex, Gemini o Aider
 
 ## Pipeline
@@ -66,7 +67,7 @@ triage? ─> researcher? ─> planner? ─> coder ─> refactorer? ─> sonar? �
 
 | Rol | Descripcion | Por defecto |
 |-----|-------------|-------------|
-| **triage** | Director de pipeline — analiza la complejidad y activa roles dinamicamente | **On** |
+| **triage** | Director de pipeline: analiza la complejidad y activa roles dinamicamente | **On** |
 | **researcher** | Investiga el contexto del codebase antes de planificar | Off |
 | **planner** | Genera planes de implementacion estructurados | Off |
 | **coder** | Escribe codigo y tests siguiendo metodologia TDD | **Siempre activo** |
@@ -75,7 +76,7 @@ triage? ─> researcher? ─> planner? ─> coder ─> refactorer? ─> sonar? �
 | **reviewer** | Revision de codigo con perfiles de exigencia configurables | **Siempre activo** |
 | **tester** | Quality gate de tests y verificacion de cobertura | **On** |
 | **security** | Auditoria de seguridad OWASP | **On** |
-| **solomon** | Supervisor de sesion — monitoriza salud de iteraciones con 5 reglas (incl. reviewer overreach), media reviews estancados, escala ante anomalias | **On** |
+| **solomon** | Supervisor de sesion: monitoriza salud de iteraciones con 5 reglas (incl. reviewer overreach), media reviews estancados, escala ante anomalias | **On** |
 | **commiter** | Automatizacion de git commit, push y PR tras aprobacion | Off |
 
 Los roles marcados con `?` son opcionales y se pueden activar por ejecucion o via config.
@@ -133,7 +134,7 @@ Guias completas: [`docs/multi-instance.md`](multi-instance.md) | [`docs/install-
 
 Karajan instala **tres comandos**: `kj`, `kj-tail` y `karajan-mcp`.
 
-### 1. CLI — Directamente desde terminal
+### 1. CLI: directamente desde terminal
 
 ```bash
 kj run "Implementar autenticacion de usuario con JWT"
@@ -142,7 +143,7 @@ kj review "Revisar los cambios de autenticacion"
 kj plan "Refactorizar la capa de base de datos"
 ```
 
-### 2. MCP — Dentro de tu agente de IA
+### 2. MCP: dentro de tu agente de IA
 
 El caso de uso principal. Karajan corre como servidor MCP dentro de Claude Code, Codex o Gemini. El agente tiene acceso a 20 herramientas (`kj_run`, `kj_code`, `kj_review`, etc.) y delega el trabajo pesado al pipeline de Karajan.
 
@@ -152,7 +153,7 @@ Tu → Claude Code → kj_run (via MCP) → triage → coder → sonar → revie
 
 **El problema**: cuando Karajan corre dentro de un agente de IA, pierdes visibilidad. El agente te muestra el resultado final, pero no las etapas del pipeline, iteraciones o decisiones de Solomon en tiempo real.
 
-### 3. kj-tail — Monitorizar desde otro terminal
+### 3. kj-tail: monitorizar desde otro terminal
 
 **La herramienta companera.** Abre un segundo terminal en el **mismo directorio del proyecto** donde esta trabajando tu agente de IA:
 
@@ -160,7 +161,7 @@ Tu → Claude Code → kj_run (via MCP) → triage → coder → sonar → revie
 kj-tail
 ```
 
-Veras la salida del pipeline en vivo — etapas, resultados, iteraciones, errores — tal como ocurren.
+Veras la salida del pipeline en vivo (etapas, resultados, iteraciones, errores) tal como ocurren.
 
 ```bash
 kj-tail                  # Seguir pipeline en tiempo real (por defecto)
@@ -185,7 +186,7 @@ kj-tail --help           # Todas las opciones
 │    prioritaria            │    │  ├─ 🔬 Researcher ✅      │
 │                           │    │  ├─ 🧠 Planner ✅         │
 │  (Claude llama a kj_run   │    │  ├─ 🔨 Coder ✅           │
-│   via MCP — solo ves      │    │  ├─ 🔍 Sonar: OK         │
+│   via MCP, solo ves       │    │  ├─ 🔍 Sonar: OK         │
 │   el resultado final)     │    │  ├─ 👁️ Reviewer ❌        │
 │                           │    │  ├─ ⚖️ Solomon: 2 cond.   │
 │                           │    │  ├─ 🔨 Coder (iter 2) ✅  │
@@ -195,7 +196,7 @@ kj-tail --help           # Todas las opciones
 └──────────────────────────┘    └──────────────────────────┘
 ```
 
-**Ejemplo con pipeline completo** — tarea compleja con todos los roles:
+**Ejemplo con pipeline completo**, tarea compleja con todos los roles:
 
 ```
 ┌─ Terminal 1 ─────────────────────────────────────────────────────────────────┐
@@ -221,7 +222,7 @@ kj-tail --help           # Todas las opciones
 
 ┌─ Terminal 2: kj-tail ────────────────────────────────────────────────────────┐
 │                                                                              │
-│  kj-tail v1.36.1 — .kj/run.log                                              │
+│  kj-tail v1.37.0 — .kj/run.log                                              │
 │                                                                              │
 │  ├─ 📋 Triage: medium (sw) — activando researcher, architect, planner        │
 │  ├─ ⚙️ Preflight passed — all checks OK                                     │
@@ -332,7 +333,7 @@ Cada rol tiene un template `.md` con instrucciones que el agente de IA sigue. Lo
 
 Usa `kj roles show <rol>` para inspeccionar cualquier template. Crea un override de proyecto para personalizar el comportamiento por proyecto.
 
-**Variantes de revision**: `reviewer-strict`, `reviewer-relaxed`, `reviewer-paranoid` — seleccionables via flag `--mode` o config `review_mode`.
+**Variantes de revision**: `reviewer-strict`, `reviewer-relaxed`, `reviewer-paranoid`, seleccionables via flag `--mode` o config `review_mode`.
 
 ## Contribuir
 
@@ -340,7 +341,7 @@ Usa `kj roles show <rol>` para inspeccionar cualquier template. Crea un override
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-npm test              # Ejecutar 1040+ tests con Vitest
+npm test              # Ejecutar 2044 tests con Vitest
 npm run test:watch    # Modo watch
 npm run validate      # Lint + test
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.36.1",
+  "version": "1.37.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- Bump version to v1.37.0
- README: add injection guard to zero-config features, update test counts (2044/161), update release count (57/45d)
- README.es: same updates in Spanish

## Test plan
- [ ] CI passes