### PR TITLE
feat(hu): lightweight HU history records for every pipeline run

### DIFF
--- a/src/hu/store.js
+++ b/src/hu/store.js
@@ -151,3 +151,45 @@ export function answerContextRequest(batch, storyId, answer) {
   story.updated_at = new Date().toISOString();
   return story;
 }
+
+/**
+ * Create a lightweight history record for a pipeline run.
+ * Stores a minimal single-HU batch in the same hu-stories directory
+ * so the HU Board can pick it up alongside full batches.
+ * @param {string} sessionId - The session identifier.
+ * @param {{task: string, result: string, approved: boolean, summary?: string, timestamp?: string}} data
+ * @returns {Promise<object>} The created batch object.
+ */
+export async function createHistoryRecord(sessionId, { task, result, approved, summary, timestamp }) {
+  const ts = timestamp || new Date().toISOString();
+  const dir = path.join(getHuDir(), sessionId);
+  await fs.mkdir(dir, { recursive: true });
+
+  const batch = {
+    session_id: sessionId,
+    created_at: ts,
+    stories: [
+      {
+        id: `HU-hist-${sessionId}`,
+        status: approved ? "certified" : "failed",
+        original: { text: task },
+        blocked_by: [],
+        certified: approved ? { summary: summary || result } : null,
+        quality: null,
+        context_requests: [],
+        created_at: ts,
+        updated_at: ts
+      }
+    ],
+    history: {
+      task,
+      result,
+      approved,
+      summary: summary || null,
+      timestamp: ts
+    }
+  };
+
+  await fs.writeFile(path.join(dir, "batch.json"), JSON.stringify(batch, null, 2));
+  return batch;
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1301,6 +1301,22 @@ async function runSingleIteration(ctx) {
   return { action: "next" };
 }
 
+async function writeHistoryRecord({ sessionId, task, result, logger }) {
+  try {
+    const { createHistoryRecord } = await import("./hu/store.js");
+    const approved = Boolean(result?.approved);
+    const summary = result?.review?.summary || result?.reason || null;
+    await createHistoryRecord(sessionId, {
+      task,
+      result: JSON.stringify(result),
+      approved,
+      summary
+    });
+  } catch (err) {
+    logger.warn(`HU history record failed (non-blocking): ${err.message}`);
+  }
+}
+
 export async function runFlow({ task, config, logger, flags = {}, emitter = null, askQuestion = null, pgTaskId = null, pgProject = null }) {
   const pipelineFlags = resolvePipelineFlags(config);
 
@@ -1324,7 +1340,10 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
       checkpointDisabled, askQuestion, lastCheckpointAt, checkpointIntervalMs, elapsedMinutes,
       i, config: ctx.config, budgetTracker: ctx.budgetTracker, stageResults: ctx.stageResults, emitter, eventBase: ctx.eventBase, session: ctx.session, budgetSummary: ctx.budgetSummary, lastCheckpointSnapshot
     });
-    if (cpResult.action === "stop") return cpResult.result;
+    if (cpResult.action === "stop") {
+      await writeHistoryRecord({ sessionId: ctx.session.id, task, result: cpResult.result, logger });
+      return cpResult.result;
+    }
     checkpointDisabled = cpResult.checkpointDisabled;
     lastCheckpointAt = cpResult.lastCheckpointAt;
     if (cpResult.lastCheckpointSnapshot !== undefined) lastCheckpointSnapshot = cpResult.lastCheckpointSnapshot;
@@ -1336,11 +1355,16 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
     ctx.iteration = i;
 
     const iterResult = await runSingleIteration(ctx);
-    if (iterResult.action === "return") return iterResult.result;
+    if (iterResult.action === "return") {
+      await writeHistoryRecord({ sessionId: ctx.session.id, task, result: iterResult.result, logger });
+      return iterResult.result;
+    }
     if (iterResult.action === "retry") { i -= 1; }
   }
 
-  return handleMaxIterationsReached({ session: ctx.session, budgetSummary: ctx.budgetSummary, emitter, eventBase: ctx.eventBase, config: ctx.config, stageResults: ctx.stageResults, logger, askQuestion, task });
+  const maxIterResult = await handleMaxIterationsReached({ session: ctx.session, budgetSummary: ctx.budgetSummary, emitter, eventBase: ctx.eventBase, config: ctx.config, stageResults: ctx.stageResults, logger, askQuestion, task });
+  await writeHistoryRecord({ sessionId: ctx.session.id, task, result: maxIterResult, logger });
+  return maxIterResult;
 }
 
 export async function resumeFlow({ sessionId, answer, config, logger, flags = {}, emitter = null, askQuestion = null }) {

--- a/tests/hu-history-records.test.js
+++ b/tests/hu-history-records.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// Mock getKarajanHome to use a temp directory
+let tmpDir;
+vi.mock("../src/utils/paths.js", () => ({
+  getKarajanHome: () => tmpDir
+}));
+
+describe("HU history records", () => {
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-hu-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("pipeline completion creates a history record in hu/store", async () => {
+    const { createHistoryRecord } = await import("../src/hu/store.js");
+    const sessionId = "test-session-001";
+    const batch = await createHistoryRecord(sessionId, {
+      task: "Add login button",
+      result: "completed",
+      approved: true,
+      summary: "Login button added successfully"
+    });
+
+    // Verify the file was written
+    const filePath = path.join(tmpDir, "hu-stories", sessionId, "batch.json");
+    const raw = await fs.readFile(filePath, "utf8");
+    const loaded = JSON.parse(raw);
+
+    expect(loaded.session_id).toBe(sessionId);
+    expect(loaded.stories).toHaveLength(1);
+    expect(loaded.history).toBeDefined();
+    expect(batch).toEqual(loaded);
+  });
+
+  it("history record contains task, result, approved status, and timestamp", async () => {
+    const { createHistoryRecord } = await import("../src/hu/store.js");
+    const ts = "2026-03-26T10:00:00.000Z";
+    const batch = await createHistoryRecord("sess-002", {
+      task: "Fix authentication bug",
+      result: "bug fixed",
+      approved: true,
+      summary: "Auth flow corrected",
+      timestamp: ts
+    });
+
+    expect(batch.history.task).toBe("Fix authentication bug");
+    expect(batch.history.result).toBe("bug fixed");
+    expect(batch.history.approved).toBe(true);
+    expect(batch.history.timestamp).toBe(ts);
+    expect(batch.created_at).toBe(ts);
+    expect(batch.stories[0].created_at).toBe(ts);
+    expect(batch.stories[0].updated_at).toBe(ts);
+  });
+
+  it("failed pipelines also create a history record with approved: false", async () => {
+    const { createHistoryRecord } = await import("../src/hu/store.js");
+    const batch = await createHistoryRecord("sess-fail-003", {
+      task: "Refactor database layer",
+      result: "max_iterations reached",
+      approved: false,
+      summary: "Could not complete within iteration budget"
+    });
+
+    expect(batch.history.approved).toBe(false);
+    expect(batch.stories[0].status).toBe("failed");
+    expect(batch.stories[0].certified).toBeNull();
+
+    // Verify file exists on disk
+    const filePath = path.join(tmpDir, "hu-stories", "sess-fail-003", "batch.json");
+    const raw = await fs.readFile(filePath, "utf8");
+    const loaded = JSON.parse(raw);
+    expect(loaded.history.approved).toBe(false);
+    expect(loaded.stories[0].status).toBe("failed");
+  });
+
+  it("history record format is compatible with HU Board sync (same shape as batch.json)", async () => {
+    const { createHistoryRecord, loadHuBatch } = await import("../src/hu/store.js");
+    const sessionId = "sess-compat-004";
+
+    await createHistoryRecord(sessionId, {
+      task: "Update API endpoint",
+      result: "done",
+      approved: true,
+      summary: "Endpoint updated"
+    });
+
+    // loadHuBatch should be able to load the history record
+    const loaded = await loadHuBatch(sessionId);
+    expect(loaded.session_id).toBe(sessionId);
+    expect(loaded.created_at).toBeDefined();
+    expect(Array.isArray(loaded.stories)).toBe(true);
+    expect(loaded.stories.length).toBeGreaterThan(0);
+
+    // Each story has the same shape as a regular batch story
+    const story = loaded.stories[0];
+    expect(story).toHaveProperty("id");
+    expect(story).toHaveProperty("status");
+    expect(story).toHaveProperty("original");
+    expect(story.original).toHaveProperty("text");
+    expect(story).toHaveProperty("blocked_by");
+    expect(Array.isArray(story.blocked_by)).toBe(true);
+    expect(story).toHaveProperty("certified");
+    expect(story).toHaveProperty("quality");
+    expect(story).toHaveProperty("context_requests");
+    expect(Array.isArray(story.context_requests)).toBe(true);
+    expect(story).toHaveProperty("created_at");
+    expect(story).toHaveProperty("updated_at");
+  });
+});


### PR DESCRIPTION
## Summary
- Every pipeline run (simple or complex) now creates a history record in `hu/store.js`
- Records stored in `~/.kj/hu-stories/<sessionId>/batch.json`, compatible with HU Board sync
- Approved runs get `status: "certified"`, failed get `status: "failed"`
- Lazy dynamic import to avoid startup overhead
- Non-blocking: errors are caught and logged as warnings
- 4 new tests

Closes KJC-TSK-0187

## Test plan
- [x] 162 files, 2048 tests pass
- [ ] CI green