### PR TITLE
docs: update READMEs for v1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ kj-tail --help           # Full options
 
 ┌─ Terminal 2: kj-tail ────────────────────────────────────────────────────────┐
 │                                                                              │
-│  kj-tail v1.37.0 — .kj/run.log                                              │
+│  kj-tail v1.38.0 — .kj/run.log                                              │
 │                                                                              │
 │  ├─ 📋 Triage: medium (sw) — enabling researcher, architect, planner         │
 │  ├─ ⚙️ Preflight passed — all checks OK                                     │
@@ -205,7 +205,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 
 | Role | What it does | Default |
 |------|-------------|---------|
-| **hu-reviewer** | Certifies user stories before coding (6 dimensions, 7 antipatterns) | Off |
+| **hu-reviewer** | Certifies user stories before coding (6 dimensions, 7 antipatterns) | Auto (medium/complex) |
 | **triage** | Classifies complexity, activates roles, auto-simplifies for trivial tasks | **On** |
 | **discover** | Detects gaps in requirements (Mom Test, Wendel, JTBD) | Off |
 | **architect** | Designs solution architecture before planning | Off |
@@ -274,6 +274,7 @@ Karajan auto-detects and auto-configures everything it can:
 - **Pipeline complexity**: Triage classifies task → trivial tasks skip reviewer loop
 - **Provider outages**: Retries on 500/502/503/504 with backoff (same as rate limits)
 - **Coverage**: Coverage-only quality gate failures treated as advisory
+- **HU Manager**: Complex tasks auto-decompose into formal user stories with dependencies. Each HU runs as its own sub-pipeline with state tracking visible in the HU Board
 
 No per-project configuration required. If you want to customize, config is layered: session > project > global.
 
@@ -298,7 +299,7 @@ Not nostalgia, not stubbornness. I've been using JavaScript since 1997, when Bre
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-npm test              # Run 2044 tests with Vitest
+npm test              # Run 2093 tests with Vitest
 npm run validate      # Lint + test
 ```
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -140,7 +140,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 
 | Rol | Que hace | Por defecto |
 |-----|----------|-------------|
-| **hu-reviewer** | Certifica historias de usuario antes de codificar (6 dimensiones, 7 antipatrones) | Off |
+| **hu-reviewer** | Certifica historias de usuario antes de codificar (6 dimensiones, 7 antipatrones) | Auto (media/compleja) |
 | **triage** | Clasifica complejidad, activa roles, auto-simplifica para tareas triviales | **On** |
 | **discover** | Detecta huecos en requisitos (Mom Test, Wendel, JTBD) | Off |
 | **architect** | Disena la arquitectura de la solucion antes de planificar | Off |
@@ -209,6 +209,7 @@ Karajan auto-detecta y auto-configura todo lo que puede:
 - **Complejidad del pipeline**: Triage clasifica la tarea, las triviales saltan el loop del reviewer
 - **Caidas de proveedor**: Reintentos en 500/502/503/504 con backoff (igual que rate limits)
 - **Cobertura**: Fallos de quality gate solo por cobertura se tratan como advisory
+- **HU Manager**: Las tareas complejas se descomponen automaticamente en historias de usuario formales con dependencias. Cada HU se ejecuta como su propio sub-pipeline con seguimiento de estado visible en el HU Board
 
 Sin configuracion por proyecto requerida. Si quieres personalizar, la config se apila: sesion > proyecto > global.
 
@@ -233,7 +234,7 @@ No es nostalgia ni cabezonería. Es que llevo usando JavaScript desde 1997, cuan
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-npm test              # Ejecutar 2044 tests con Vitest
+npm test              # Ejecutar 2093 tests con Vitest
 npm run validate      # Lint + test
 ```
 


### PR DESCRIPTION
## Summary
- hu-reviewer default: Off → Auto (medium/complex)
- Zero-config: added HU Manager bullet
- Test count: 2044 → 2093
- kj-tail version: v1.37.0 → v1.38.0

## Test plan
- [ ] CI green