### PR TITLE
docs: make SECURITY.md bilingual

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,3 +41,49 @@ The following are out of scope:
 - Vulnerabilities in third-party AI CLIs (claude, codex, gemini, aider)
 - SonarQube Docker container security (report to SonarSource)
 - Denial of service via resource exhaustion (long-running tasks)
+
+---
+
+# Politica de Seguridad
+
+## Versiones Soportadas
+
+| Version | Soportada          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reportar una Vulnerabilidad
+
+Si descubres una vulnerabilidad de seguridad en karajan-code, reportala de forma responsable.
+
+**NO abras un issue publico en GitHub para vulnerabilidades de seguridad.**
+
+### Como Reportar
+
+1. Envia un email a **mjfosela@gmail.com** con el asunto: `[SECURITY] karajan-code vulnerability report`
+2. Incluye:
+   - Descripcion de la vulnerabilidad
+   - Pasos para reproducirla
+   - Impacto potencial
+   - Solucion sugerida (si la tienes)
+
+### Que Esperar
+
+- **Confirmacion** en 48 horas
+- **Evaluacion** en 7 dias
+- **Correccion o mitigacion** en 30 dias para vulnerabilidades confirmadas
+- Credito en las release notes (salvo que prefieras anonimato)
+
+### Alcance
+
+Dentro del alcance:
+- Inyeccion de comandos via descripciones de tareas o valores de configuracion
+- Lectura/escritura arbitraria de ficheros fuera del directorio del proyecto
+- Fuga de credenciales (API keys, tokens) en logs o informes
+- Vulnerabilidades del servidor MCP (ejecucion no autorizada de herramientas)
+
+Fuera del alcance:
+- Vulnerabilidades en CLIs de IA de terceros (claude, codex, gemini, aider)
+- Seguridad del contenedor Docker de SonarQube (reportar a SonarSource)
+- Denegacion de servicio por agotamiento de recursos (tareas de larga duracion)


### PR DESCRIPTION
## Summary
- Added Spanish translation below the English version, separated by horizontal rule
- Same format as CODE_OF_CONDUCT.md and CONTRIBUTING.md

## Test plan
- [ ] CI green