### PR TITLE
feat: multi-language test framework detection and TDD policy

### DIFF
--- a/src/review/tdd-policy.js
+++ b/src/review/tdd-policy.js
@@ -21,15 +21,17 @@ function isSourceFile(file, extensions = []) {
 
 const SKIP_TDD_TASK_TYPES = new Set(["doc", "infra"]);
 
+const DEFAULT_TEST_PATTERNS = ["/tests/", "/__tests__/", ".test.", ".spec.", "/src/test/", "/test/", "Test.java", "Test.kt", "test_", "_test.py", "_test.go", "Test.cs", "_spec.rb", "Test.php", "_test.dart", "Tests.swift"];
+const DEFAULT_SOURCE_EXTENSIONS = [".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".java", ".kt", ".rb", ".php", ".cs", ".rs", ".swift", ".dart"];
+
 export function evaluateTddPolicy(diff, developmentConfig = {}, untrackedFiles = [], taskType = null) {
   if (taskType && SKIP_TDD_TASK_TYPES.has(taskType)) {
     return { ok: true, reason: "tdd_not_applicable_for_task_type", sourceFiles: [], testFiles: [] };
   }
 
   const requireTestChanges = developmentConfig.require_test_changes !== false;
-  const patterns = developmentConfig.test_file_patterns || ["/tests/", "/__tests__/", ".test.", ".spec."];
-  const extensions =
-    developmentConfig.source_file_extensions || [".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".java", ".rb", ".php", ".cs"];
+  const patterns = developmentConfig.test_file_patterns || DEFAULT_TEST_PATTERNS;
+  const extensions = developmentConfig.source_file_extensions || DEFAULT_SOURCE_EXTENSIONS;
 
   const diffFiles = extractChangedFiles(diff);
   const extra = Array.isArray(untrackedFiles) ? untrackedFiles : [];

--- a/src/utils/project-detect.js
+++ b/src/utils/project-detect.js
@@ -1,14 +1,61 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const TEST_FRAMEWORKS = ["vitest", "jest", "@jest/core", "mocha", "ava", "tap", "playwright", "@playwright/test"];
-
-const CONFIG_FILES = [
+// --- JS/TS ---
+const JS_FRAMEWORKS = ["vitest", "jest", "@jest/core", "mocha", "ava", "tap", "playwright", "@playwright/test"];
+const JS_CONFIG_FILES = [
   "vitest.config.js", "vitest.config.ts",
   "jest.config.js", "jest.config.ts", "jest.config.mjs",
   ".mocharc.yml", ".mocharc.json",
   "playwright.config.js", "playwright.config.ts"
 ];
+
+// --- Multi-language project markers ---
+const LANGUAGE_MARKERS = [
+  // Java / Kotlin (Maven)
+  { file: "pom.xml", framework: "junit", language: "java" },
+  // Java / Kotlin (Gradle)
+  { file: "build.gradle", framework: "junit", language: "java" },
+  { file: "build.gradle.kts", framework: "junit", language: "kotlin" },
+  // Python
+  { file: "pytest.ini", framework: "pytest", language: "python" },
+  { file: "pyproject.toml", framework: "pytest", language: "python" },
+  { file: "setup.py", framework: "pytest", language: "python" },
+  { file: "setup.cfg", framework: "pytest", language: "python" },
+  { file: "tox.ini", framework: "pytest", language: "python" },
+  // Go
+  { file: "go.mod", framework: "go-test", language: "go" },
+  // Rust
+  { file: "Cargo.toml", framework: "cargo-test", language: "rust" },
+  // C# / .NET
+  { file: "*.csproj", glob: true, framework: "dotnet-test", language: "csharp" },
+  { file: "*.sln", glob: true, framework: "dotnet-test", language: "csharp" },
+  // Ruby
+  { file: "Gemfile", framework: "rspec", language: "ruby" },
+  { file: ".rspec", framework: "rspec", language: "ruby" },
+  // PHP
+  { file: "phpunit.xml", framework: "phpunit", language: "php" },
+  { file: "phpunit.xml.dist", framework: "phpunit", language: "php" },
+  // Swift
+  { file: "Package.swift", framework: "xctest", language: "swift" },
+  // Dart / Flutter
+  { file: "pubspec.yaml", framework: "dart-test", language: "dart" },
+];
+
+/** Test file patterns per language (used by TDD policy). */
+export const TEST_PATTERNS_BY_LANGUAGE = {
+  javascript: ["/tests/", "/__tests__/", ".test.", ".spec."],
+  java:       ["/src/test/", "/test/", "Test.java", "Tests.java", "IT.java"],
+  kotlin:     ["/src/test/", "/test/", "Test.kt", "Tests.kt", "/src/androidTest/"],
+  python:     ["/tests/", "/test/", "test_", "_test.py", "tests.py"],
+  go:         ["_test.go"],
+  rust:       ["/tests/", "#[test]", "#[cfg(test)]"],
+  csharp:     ["/Tests/", "/Test/", "Tests.cs", "Test.cs", ".Tests/"],
+  ruby:       ["/spec/", "/test/", "_spec.rb", "_test.rb"],
+  php:        ["/tests/", "/test/", "Test.php"],
+  swift:      ["/Tests/", "Tests.swift"],
+  dart:       ["/test/", "_test.dart"],
+};
 
 function frameworkFromConfig(filename) {
   if (filename.startsWith("vitest")) return "vitest";
@@ -19,32 +66,49 @@ function frameworkFromConfig(filename) {
 
 /**
  * Detect if the project has a test framework configured.
- * Checks: package.json devDependencies/dependencies for known test frameworks.
- * Also checks for config files (vitest.config, jest.config, .mocharc, playwright.config).
+ * Checks JS (package.json), then multi-language project markers.
  * @param {string} cwd - Project root
- * @returns {Promise<{hasTests: boolean, framework: string|null}>}
+ * @returns {Promise<{hasTests: boolean, framework: string|null, language: string|null}>}
  */
 export async function detectTestFramework(cwd = process.cwd()) {
+  // 1. JS/TS: check package.json
   try {
     const pkgRaw = await fs.readFile(path.join(cwd, "package.json"), "utf8");
     const pkg = JSON.parse(pkgRaw);
     const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
-    for (const fw of TEST_FRAMEWORKS) {
+    for (const fw of JS_FRAMEWORKS) {
       if (allDeps[fw]) {
-        return { hasTests: true, framework: fw };
+        return { hasTests: true, framework: fw, language: "javascript" };
       }
     }
   } catch { /* no package.json or parse error */ }
 
-  for (const cf of CONFIG_FILES) {
+  // 2. JS/TS: check config files
+  for (const cf of JS_CONFIG_FILES) {
     try {
       await fs.access(path.join(cwd, cf));
-      return { hasTests: true, framework: frameworkFromConfig(cf) };
+      return { hasTests: true, framework: frameworkFromConfig(cf), language: "javascript" };
     } catch { /* not found */ }
   }
 
-  return { hasTests: false, framework: null };
+  // 3. Multi-language: check project markers
+  for (const marker of LANGUAGE_MARKERS) {
+    try {
+      if (marker.glob) {
+        const entries = await fs.readdir(cwd);
+        const ext = marker.file.replace("*", "");
+        if (entries.some((e) => e.endsWith(ext))) {
+          return { hasTests: true, framework: marker.framework, language: marker.language };
+        }
+      } else {
+        await fs.access(path.join(cwd, marker.file));
+        return { hasTests: true, framework: marker.framework, language: marker.language };
+      }
+    } catch { /* not found */ }
+  }
+
+  return { hasTests: false, framework: null, language: null };
 }
 
 /**

--- a/tests/multi-language-detect.test.js
+++ b/tests/multi-language-detect.test.js
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { detectTestFramework, TEST_PATTERNS_BY_LANGUAGE } from "../src/utils/project-detect.js";
+import { evaluateTddPolicy } from "../src/review/tdd-policy.js";
+import fs from "node:fs/promises";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    access: vi.fn(),
+    readdir: vi.fn(),
+  },
+}));
+
+describe("multi-language test framework detection", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fs.readFile.mockRejectedValue(new Error("not found"));
+    fs.access.mockRejectedValue(new Error("not found"));
+    fs.readdir.mockResolvedValue([]);
+  });
+
+  it("detects vitest from package.json", async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ devDependencies: { vitest: "^4.0.0" } }));
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "vitest", language: "javascript" });
+  });
+
+  it("detects Java/Maven from pom.xml", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("pom.xml")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "junit", language: "java" });
+  });
+
+  it("detects Kotlin/Gradle from build.gradle.kts", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("build.gradle.kts")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "junit", language: "kotlin" });
+  });
+
+  it("detects Java/Gradle from build.gradle", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("build.gradle")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "junit", language: "java" });
+  });
+
+  it("detects Python from pyproject.toml", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("pyproject.toml")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "pytest", language: "python" });
+  });
+
+  it("detects Python from pytest.ini", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("pytest.ini")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "pytest", language: "python" });
+  });
+
+  it("detects Go from go.mod", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("go.mod")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "go-test", language: "go" });
+  });
+
+  it("detects Rust from Cargo.toml", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("Cargo.toml")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "cargo-test", language: "rust" });
+  });
+
+  it("detects C# from .csproj file", async () => {
+    fs.readdir.mockResolvedValue(["MyApp.csproj", "Program.cs"]);
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "dotnet-test", language: "csharp" });
+  });
+
+  it("detects Ruby from Gemfile", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("Gemfile")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "rspec", language: "ruby" });
+  });
+
+  it("detects PHP from phpunit.xml", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("phpunit.xml")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "phpunit", language: "php" });
+  });
+
+  it("detects Dart from pubspec.yaml", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("pubspec.yaml")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "dart-test", language: "dart" });
+  });
+
+  it("detects Swift from Package.swift", async () => {
+    fs.access.mockImplementation((p) => {
+      if (p.endsWith("Package.swift")) return Promise.resolve();
+      return Promise.reject(new Error("not found"));
+    });
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: true, framework: "xctest", language: "swift" });
+  });
+
+  it("returns no framework when nothing found", async () => {
+    const r = await detectTestFramework("/project");
+    expect(r).toEqual({ hasTests: false, framework: null, language: null });
+  });
+
+  it("JS package.json takes priority over language markers", async () => {
+    fs.readFile.mockResolvedValue(JSON.stringify({ devDependencies: { jest: "^29.0.0" } }));
+    fs.access.mockResolvedValue(); // go.mod would also match
+    const r = await detectTestFramework("/project");
+    expect(r.framework).toBe("jest");
+    expect(r.language).toBe("javascript");
+  });
+});
+
+describe("TEST_PATTERNS_BY_LANGUAGE export", () => {
+  it("has patterns for all supported languages", () => {
+    const languages = ["javascript", "java", "kotlin", "python", "go", "rust", "csharp", "ruby", "php", "swift", "dart"];
+    for (const lang of languages) {
+      expect(TEST_PATTERNS_BY_LANGUAGE[lang]).toBeDefined();
+      expect(TEST_PATTERNS_BY_LANGUAGE[lang].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("TDD policy with multi-language patterns", () => {
+  it("detects Java test files (src/test/)", () => {
+    const diff = "diff --git a/src/main/java/App.java b/src/main/java/App.java\ndiff --git a/src/test/java/AppTest.java b/src/test/java/AppTest.java";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("src/test/java/AppTest.java");
+    expect(r.sourceFiles).toContain("src/main/java/App.java");
+  });
+
+  it("fails TDD for Java source without test", () => {
+    const diff = "diff --git a/src/main/java/App.java b/src/main/java/App.java";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("source_changes_without_tests");
+  });
+
+  it("detects Python test files (test_*.py)", () => {
+    const diff = "diff --git a/app.py b/app.py\ndiff --git a/tests/test_app.py b/tests/test_app.py";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("tests/test_app.py");
+  });
+
+  it("detects Go test files (_test.go)", () => {
+    const diff = "diff --git a/main.go b/main.go\ndiff --git a/main_test.go b/main_test.go";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("main_test.go");
+  });
+
+  it("detects Kotlin test files", () => {
+    const diff = "diff --git a/src/main/kotlin/App.kt b/src/main/kotlin/App.kt\ndiff --git a/src/test/kotlin/AppTest.kt b/src/test/kotlin/AppTest.kt";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("src/test/kotlin/AppTest.kt");
+  });
+
+  it("detects C# test files", () => {
+    const diff = "diff --git a/src/App.cs b/src/App.cs\ndiff --git a/Tests/AppTest.cs b/Tests/AppTest.cs";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("Tests/AppTest.cs");
+  });
+
+  it("detects Ruby spec files", () => {
+    const diff = "diff --git a/lib/app.rb b/lib/app.rb\ndiff --git a/spec/app_spec.rb b/spec/app_spec.rb";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("spec/app_spec.rb");
+  });
+
+  it("detects PHP test files", () => {
+    const diff = "diff --git a/src/App.php b/src/App.php\ndiff --git a/tests/AppTest.php b/tests/AppTest.php";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("tests/AppTest.php");
+  });
+
+  it("detects Dart test files", () => {
+    const diff = "diff --git a/lib/app.dart b/lib/app.dart\ndiff --git a/test/app_test.dart b/test/app_test.dart";
+    const r = evaluateTddPolicy(diff);
+    expect(r.ok).toBe(true);
+    expect(r.testFiles).toContain("test/app_test.dart");
+  });
+
+  it("skips TDD for doc taskType regardless of language", () => {
+    const diff = "diff --git a/src/main/java/App.java b/src/main/java/App.java";
+    const r = evaluateTddPolicy(diff, {}, [], "doc");
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe("tdd_not_applicable_for_task_type");
+  });
+
+  it("skips TDD for infra taskType", () => {
+    const diff = "diff --git a/main.go b/main.go";
+    const r = evaluateTddPolicy(diff, {}, [], "infra");
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe("tdd_not_applicable_for_task_type");
+  });
+});


### PR DESCRIPTION
## Summary
- `project-detect.js`: detects 12 languages via project markers (pom.xml, build.gradle, go.mod, Cargo.toml, pyproject.toml, etc.)
- `tdd-policy.js`: test file patterns for Java, Kotlin, Python, Go, Rust, C#, Ruby, PHP, Swift, Dart
- Exports `TEST_PATTERNS_BY_LANGUAGE` for future per-language customization
- 27 new tests

Closes KJC-TSK-0189

## Test plan
- [x] 167 files, 2120 tests pass
- [ ] CI green