### PR TITLE
fix(solomon): human-readable escalation messages

### DIFF
--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -2,6 +2,68 @@ import { SolomonRole } from "../roles/solomon-role.js";
 import { addCheckpoint, pauseSession } from "../session-store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 
+/**
+ * Build a human-readable escalation message from raw Solomon conflict data.
+ * Replaces the raw JSON dump with structured, plain-text output.
+ *
+ * @param {object} solomonResult - The conflict object passed to escalateToHuman
+ * @param {object} [session]     - Current session (optional, used for extra context)
+ * @returns {string} Formatted message suitable for display to the user
+ */
+export function formatEscalationMessage(solomonResult, session) {
+  const stage = solomonResult?.stage || "unknown";
+  const solomonReason = solomonResult?.solomonReason || null;
+  const history = solomonResult?.history || [];
+
+  const lines = [];
+  lines.push(`--- Conflict: ${stage} ---`);
+  lines.push("");
+
+  // Extract reviewer/agent feedback from history
+  const feedbackEntries = history.filter(entry => entry && typeof entry === "object");
+  if (feedbackEntries.length > 0) {
+    lines.push("Reviewer feedback:");
+    for (const entry of feedbackEntries) {
+      const agent = entry.agent || "unknown";
+      const feedback = entry.feedback || "No feedback provided";
+      // Split multi-line feedback (e.g. "R-1: ...\nR-2: ...") into bullet points
+      const feedbackLines = String(feedback).split("\n").filter(l => l.trim());
+      if (feedbackLines.length === 1) {
+        lines.push(`  [${agent}] ${feedbackLines[0]}`);
+      } else {
+        lines.push(`  [${agent}]`);
+        for (const fl of feedbackLines) {
+          lines.push(`    - ${fl}`);
+        }
+      }
+    }
+    lines.push("");
+  }
+
+  // Solomon's reason (if it tried and failed)
+  if (solomonReason) {
+    lines.push(`Solomon could not resolve the conflict: ${solomonReason}`);
+    lines.push("");
+  }
+
+  // Iteration context
+  const iterationCount = solomonResult?.iterationCount;
+  const maxIterations = solomonResult?.maxIterations;
+  if (iterationCount !== undefined && maxIterations !== undefined) {
+    lines.push(`Iterations: ${iterationCount}/${maxIterations}`);
+    lines.push("");
+  }
+
+  lines.push("Options:");
+  lines.push("  1. Accept coder's work as-is");
+  lines.push("  2. Retry with reviewer's feedback");
+  lines.push("  3. Stop the session");
+  lines.push("");
+  lines.push("How should we proceed?");
+
+  return lines.join("\n");
+}
+
 export async function invokeSolomon({ config, logger, emitter, eventBase, stage, conflict, askQuestion, session, iteration }) {
   const solomonEnabled = Boolean(config.pipeline?.solomon?.enabled);
 
@@ -86,8 +148,7 @@ export async function invokeSolomon({ config, logger, emitter, eventBase, stage,
 }
 
 export async function escalateToHuman({ askQuestion, session, emitter, eventBase, stage, conflict, iteration }) {
-  const reason = conflict?.solomonReason || `${stage} conflict unresolved`;
-  const question = `${stage} conflict requires human intervention: ${reason}\nDetails: ${JSON.stringify(conflict?.history?.slice(-2) || [], null, 2)}\n\nHow should we proceed?`;
+  const question = formatEscalationMessage({ ...conflict, stage }, session);
 
   if (askQuestion) {
     const answer = await askQuestion(question, { iteration, stage });

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -452,7 +452,11 @@ const EVENT_HANDLERS = {
   question: (event, icon) => {
     console.log();
     console.log(`${ANSI.bold}${ANSI.yellow}${icon} Paused - question:${ANSI.reset}`);
-    console.log(`  ${event.detail?.question || event.message}`);
+    const questionText = event.detail?.question || event.message || "";
+    const questionLines = questionText.split("\n");
+    for (const line of questionLines) {
+      console.log(`  ${line}`);
+    }
     console.log(`${ANSI.dim}Resume with: kj resume ${event.sessionId} --answer "<response>"${ANSI.reset}`);
   },
 

--- a/tests/solomon-messages.test.js
+++ b/tests/solomon-messages.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { formatEscalationMessage } from "../src/orchestrator/solomon-escalation.js";
+
+describe("formatEscalationMessage", () => {
+  it("produces readable text from raw history", () => {
+    const conflict = {
+      stage: "reviewer",
+      solomonReason: "Solomon error: timeout",
+      history: [
+        { agent: "reviewer", feedback: "R-1: The change only deletes code without replacing it" }
+      ],
+      iterationCount: 3,
+      maxIterations: 3
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("Conflict: reviewer");
+    expect(result).toContain("Reviewer feedback:");
+    expect(result).toContain("[reviewer] R-1: The change only deletes code without replacing it");
+    expect(result).toContain("Solomon could not resolve the conflict: Solomon error: timeout");
+    expect(result).toContain("Iterations: 3/3");
+    expect(result).toContain("1. Accept coder's work as-is");
+    expect(result).toContain("2. Retry with reviewer's feedback");
+    expect(result).toContain("3. Stop the session");
+    expect(result).toContain("How should we proceed?");
+  });
+
+  it("does not contain JSON artifacts in the formatted output", () => {
+    const conflict = {
+      stage: "reviewer",
+      history: [
+        { agent: "reviewer", feedback: "R-1: Missing error handling\nR-2: No tests added" }
+      ]
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    // No JSON artifacts (curly braces, or JSON key syntax)
+    expect(result).not.toMatch(/[{}]/);
+    expect(result).not.toContain('"agent"');
+    expect(result).not.toContain('"feedback"');
+    expect(result).not.toContain("JSON");
+    expect(result).not.toContain("stringify");
+  });
+
+  it("lists multiple feedback entries clearly", () => {
+    const conflict = {
+      stage: "reviewer",
+      history: [
+        { agent: "reviewer", feedback: "R-1: Missing error handling" },
+        { agent: "coder", feedback: "Applied fix for R-1" },
+        { agent: "reviewer", feedback: "R-2: No tests for the new function" }
+      ]
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("[reviewer] R-1: Missing error handling");
+    expect(result).toContain("[coder] Applied fix for R-1");
+    expect(result).toContain("[reviewer] R-2: No tests for the new function");
+  });
+
+  it("handles multi-line feedback as bullet points", () => {
+    const conflict = {
+      stage: "reviewer",
+      history: [
+        { agent: "reviewer", feedback: "R-1: Missing error handling\nR-2: No tests added\nR-3: Unused import" }
+      ]
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("[reviewer]");
+    expect(result).toContain("- R-1: Missing error handling");
+    expect(result).toContain("- R-2: No tests added");
+    expect(result).toContain("- R-3: Unused import");
+  });
+
+  it("handles missing feedback fields gracefully", () => {
+    const conflict = {
+      stage: "max_iterations",
+      history: [
+        { agent: "pipeline" },
+        {},
+        null
+      ]
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("Conflict: max_iterations");
+    expect(result).toContain("[pipeline] No feedback provided");
+    expect(result).toContain("[unknown] No feedback provided");
+    expect(result).toContain("Options:");
+  });
+
+  it("handles empty conflict gracefully", () => {
+    const result = formatEscalationMessage({});
+
+    expect(result).toContain("Conflict: unknown");
+    expect(result).toContain("Options:");
+    expect(result).toContain("How should we proceed?");
+    // No reviewer feedback section when history is empty
+    expect(result).not.toContain("Reviewer feedback:");
+  });
+
+  it("handles null/undefined input gracefully", () => {
+    const resultNull = formatEscalationMessage(null);
+    expect(resultNull).toContain("Conflict: unknown");
+    expect(resultNull).toContain("Options:");
+
+    const resultUndefined = formatEscalationMessage(undefined);
+    expect(resultUndefined).toContain("Conflict: unknown");
+    expect(resultUndefined).toContain("Options:");
+  });
+
+  it("handles solomonReason without history", () => {
+    const conflict = {
+      stage: "reviewer",
+      solomonReason: "Solomon escalated to human",
+      history: []
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("Solomon could not resolve the conflict: Solomon escalated to human");
+    expect(result).not.toContain("Reviewer feedback:");
+  });
+
+  it("includes iteration context when provided", () => {
+    const conflict = {
+      stage: "reviewer",
+      iterationCount: 5,
+      maxIterations: 10,
+      history: []
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).toContain("Iterations: 5/10");
+  });
+
+  it("omits iteration context when not provided", () => {
+    const conflict = {
+      stage: "reviewer",
+      history: [{ agent: "reviewer", feedback: "some issue" }]
+    };
+
+    const result = formatEscalationMessage(conflict);
+
+    expect(result).not.toContain("Iterations:");
+  });
+});


### PR DESCRIPTION
## Summary
- `formatEscalationMessage()` converts raw conflict JSON into structured plain text
- Shows: what reviewer found, why Solomon couldn't resolve, clear options (1/2/3)
- Display renders multi-line messages with proper indentation
- 10 new tests

Closes KJC-BUG-0013

## Test plan
- [x] 169 files, 2138 tests pass
- [ ] CI green