### PR TITLE
docs: fix repo docs for v1.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-=======
+## [1.38.1] - 2026-03-28
+
+### Added
+- **`kj_hu` MCP tool** (21st tool): create, update, list, get HUs manually in the board. Auto-creates project from directory name + git remote (#208)
+- **Multi-language TDD**: detects test frameworks for 12 languages (Java/JUnit, Python/pytest, Go, Rust/cargo, C#/.NET, Ruby/RSpec, PHP/PHPUnit, Swift/XCTest, Dart). TDD enforcement works for all languages, not just JS (#207)
+- **MCP sovereignty**: tool descriptions explicitly instruct host AIs to pass tasks as-is without grouping, reordering, or overriding pipeline decisions (#210)
+- 35 new tests (2142 total across 170 files)
+
+### Fixed
+- **Solomon messages**: escalation messages are now human-readable structured text instead of raw JSON. Shows reviewer feedback, Solomon decision, and clear options (#209)
+- **Sonar token**: actionable error with 3 fix options when token is missing, instead of silently disabling sonar (#211)
+
 ## [1.38.0] - 2026-03-26
 
 ### Added
@@ -48,7 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Propagate Solomon error details to escalation and activity log
 
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 ## [1.36.0] - 2026-03-25
 
 ### Added
@@ -452,15 +461,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD**: GitHub Actions workflow with validation and PR annotations
 - **716+ unit tests** with Vitest
 
-<<<<<<< HEAD
-[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.35.0...HEAD
-=======
-[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.38.0...HEAD
+[Unreleased]: https://github.com/manufosela/karajan-code/compare/v1.38.1...HEAD
+[1.38.1]: https://github.com/manufosela/karajan-code/compare/v1.38.0...v1.38.1
 [1.38.0]: https://github.com/manufosela/karajan-code/compare/v1.37.0...v1.38.0
 [1.37.0]: https://github.com/manufosela/karajan-code/compare/v1.36.1...v1.37.0
 [1.36.1]: https://github.com/manufosela/karajan-code/compare/v1.36.0...v1.36.1
 [1.36.0]: https://github.com/manufosela/karajan-code/compare/v1.35.0...v1.36.0
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 [1.35.0]: https://github.com/manufosela/karajan-code/compare/v1.34.4...v1.35.0
 [1.34.4]: https://github.com/manufosela/karajan-code/compare/v1.34.3...v1.34.4
 [1.34.3]: https://github.com/manufosela/karajan-code/compare/v1.34.2...v1.34.3

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This is the primary use case. Karajan runs as an MCP server inside Claude Code, 
 You → Claude Code → kj_run (via MCP) → triage → coder → sonar → reviewer → tester → security
 ```
 
-The MCP server auto-registers during `npm install`. Your AI agent sees 20 tools (`kj_run`, `kj_code`, `kj_review`, etc.) and uses them as needed.
+The MCP server auto-registers during `npm install`. Your AI agent sees 21 tools (`kj_run`, `kj_code`, `kj_review`, etc.) and uses them as needed.
 
 **The problem**: when Karajan runs inside an AI agent, you lose visibility. The agent shows you the final result, but not the pipeline stages, iterations, or Solomon decisions happening in real time.
 
@@ -154,7 +154,7 @@ kj-tail --help           # Full options
 
 ┌─ Terminal 2: kj-tail ────────────────────────────────────────────────────────┐
 │                                                                              │
-│  kj-tail v1.38.0 — .kj/run.log                                              │
+│  kj-tail v1.38.1 — .kj/run.log                                              │
 │                                                                              │
 │  ├─ 📋 Triage: medium (sw) — enabling researcher, architect, planner         │
 │  ├─ ⚙️ Preflight passed — all checks OK                                     │
@@ -233,7 +233,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 
 Mix and match. Use Claude as coder and Codex as reviewer. Karajan auto-detects installed agents during `kj init`.
 
-## MCP server (20 tools)
+## MCP server (21 tools)
 
 After `npm install -g karajan-code`, the MCP server auto-registers in Claude and Codex. Manual config if needed:
 
@@ -245,7 +245,7 @@ After `npm install -g karajan-code`, the MCP server auto-registers in Claude and
 # command = "karajan-mcp"
 ```
 
-**20 tools** available: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`.
+**21 tools** available: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`, `kj_hu`.
 
 Use `kj-tail` in a separate terminal to see what the pipeline is doing in real time (see [Three ways to use Karajan](#three-ways-to-use-karajan)).
 
@@ -267,7 +267,7 @@ Use `kj roles show <role>` to inspect any template.
 
 Karajan auto-detects and auto-configures everything it can:
 
-- **TDD**: Detects test framework (vitest, jest, mocha) → auto-enables TDD
+- **TDD**: Detects test framework for 12 languages (vitest, jest, JUnit, pytest, go test, cargo test, and more). Auto-enables TDD for code tasks, skips for doc/infra
 - **Bootstrap gate**: Validates all prerequisites (git repo, remote, config, agents, SonarQube) before any tool runs. Fails hard with actionable fix instructions, never silently degrades
 - **Injection guard**: Scans diffs for prompt injection before AI review. Detects directive overrides, invisible Unicode, oversized comment payloads. Also runs as a GitHub Action on every PR
 - **SonarQube**: Auto-starts Docker container, generates config if missing
@@ -299,7 +299,7 @@ Not nostalgia, not stubbornness. I've been using JavaScript since 1997, when Bre
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-npm test              # Run 2093 tests with Vitest
+npm test              # Run 2142 tests with Vitest
 npm run validate      # Lint + test
 ```
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,151 +1,27 @@
 <p align="center">
-<<<<<<< HEAD
-  <img src="karajan-code-logo-small.png" alt="Karajan Code" width="200">
-=======
   <img src="karajan-code-logo-small.png" alt="Karajan Code" width="180">
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 </p>
 
 <h1 align="center">Karajan Code</h1>
 
 <p align="center">
-<<<<<<< HEAD
-  Orquestador local multi-agente con TDD, SonarQube y revision de codigo automatizada.
-=======
   Orquestador local multi-agente. TDD-first, basado en MCP, JavaScript vanilla.
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/karajan-code"><img src="https://img.shields.io/npm/v/karajan-code.svg" alt="npm version"></a>
-<<<<<<< HEAD
-=======
   <a href="https://www.npmjs.com/package/karajan-code"><img src="https://img.shields.io/npm/dw/karajan-code.svg" alt="npm downloads"></a>
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
   <a href="https://github.com/manufosela/karajan-code/actions"><img src="https://github.com/manufosela/karajan-code/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg" alt="Node.js"></a>
 </p>
 
 <p align="center">
-<<<<<<< HEAD
-  <a href="../README.md">Read in English</a>
-=======
   <a href="../README.md">Read in English</a> · <a href="https://karajancode.com">Documentacion</a>
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 </p>
 
 ---
 
-<<<<<<< HEAD
-## Que es Karajan Code?
-
-Karajan Code (`kj`) orquesta multiples agentes de IA a traves de un pipeline automatizado: generacion de codigo, analisis estatico, revision de codigo, testing y auditorias de seguridad — todo en un solo comando.
-
-En lugar de ejecutar un agente de IA y revisar manualmente su output, `kj` encadena agentes con quality gates. El coder escribe codigo, SonarQube lo analiza, el reviewer lo revisa, y si hay problemas, el coder recibe otra oportunidad. Este bucle se repite hasta que el codigo es aprobado o se alcanza el limite de iteraciones.
-
-**Caracteristicas principales:**
-- **Pipeline multi-agente** con 11 roles configurables
-- **5 agentes de IA soportados**: Claude, Codex, Gemini, Aider, OpenCode
-- **Servidor MCP** con 20 herramientas — usa `kj` desde Claude, Codex o cualquier host compatible con MCP sin salir de tu agente. [Ver configuracion MCP](#servidor-mcp)
-- **Bootstrap obligatorio** — valida prerequisitos del entorno (git, remote, config, agentes, SonarQube) antes de cada ejecucion. Si algo falta, para con instrucciones claras
-- **TDD obligatorio** — se exigen cambios en tests cuando se modifican ficheros fuente
-- **Integracion con SonarQube** — analisis estatico con quality gates (requiere [Docker](#requisitos))
-- **Perfiles de revision** — standard, strict, relaxed, paranoid
-- **Tracking de presupuesto** — monitorizacion de tokens y costes por sesion con `--trace`
-- **Automatizacion Git** — auto-commit, auto-push, auto-PR tras aprobacion
-- **Gestion de sesiones** — pausa/reanudacion con deteccion fail-fast y limpieza automatica de sesiones expiradas
-- **Sistema de plugins** — extiende con agentes custom via `.karajan/plugins/`
-- **Checkpoints interactivos** — en lugar de matar tareas largas, pausa cada 5 minutos con un informe de progreso y te deja decidir: continuar, parar o ajustar el tiempo
-- **Descomposicion de tareas** — triage detecta cuando una tarea debe dividirse y recomienda subtareas; con integracion Planning Game, crea cards vinculadas con bloqueo secuencial
-- **Retry con backoff** — recuperacion automatica ante errores transitorios de API (429, 5xx) con backoff exponencial y jitter
-- **Pipeline stage tracker** — vista de progreso acumulativo durante `kj_run` mostrando que stages estan completadas, en ejecucion o pendientes — tanto en CLI como via eventos MCP para renderizado en tiempo real en el host
-- **Guardarrailes de observabilidad del planner** — telemetria continua de heartbeat/stall, proteccion configurable por silencio maximo (`session.max_agent_silence_minutes`) y limite duro de ejecucion (`session.max_planner_minutes`) para evitar bloqueos prolongados en `kj_plan`/planner
-- **Standby por rate-limit** — cuando un agente alcanza limites de uso, Karajan parsea el tiempo de espera, espera con backoff exponencial y reanuda automaticamente en vez de fallar
-- **Preflight handshake** — `kj_preflight` requiere confirmacion humana de la configuracion de agentes antes de ejecutar, previniendo que la IA cambie asignaciones silenciosamente
-- **Config de 3 niveles** — sesion > proyecto > global con scoping de `kj_agents`
-- **Mediacion inteligente del reviewer** — el scope filter difiere automaticamente issues del reviewer fuera de scope (ficheros no presentes en el diff) como deuda tecnica rastreada en vez de bloquear; Solomon media reviews estancados; el contexto diferido se inyecta en el prompt del coder
-- **Integracion con Planning Game** — combina opcionalmente con [Planning Game](https://github.com/AgenteIA-Geniova/planning-game) para gestion agil de proyectos (tareas, sprints, estimacion) — como Jira, pero open-source y nativo XP
-
-> **Mejor con MCP** — Karajan Code esta disenado para usarse como servidor MCP dentro de tu agente de IA (Claude, Codex, etc.). El agente envia tareas a `kj_run`, recibe notificaciones de progreso en tiempo real, y obtiene resultados estructurados — sin copiar y pegar.
-
-## Requisitos
-
-- **Node.js** >= 18
-- **Docker** — necesario para el analisis estatico con SonarQube. Si no tienes Docker o no necesitas SonarQube, desactivalo con `--no-sonar` o `sonarqube.enabled: false` en la config
-- Al menos un agente de IA instalado: Claude, Codex, Gemini o Aider
-
-## Pipeline
-
-```
-triage? ─> researcher? ─> planner? ─> coder ─> refactorer? ─> sonar? ─> reviewer ─> tester? ─> security? ─> commiter?
-```
-
-| Rol | Descripcion | Por defecto |
-|-----|-------------|-------------|
-| **triage** | Director de pipeline — analiza la complejidad y activa roles dinamicamente | **On** |
-| **researcher** | Investiga el contexto del codebase antes de planificar | Off |
-| **planner** | Genera planes de implementacion estructurados | Off |
-| **coder** | Escribe codigo y tests siguiendo metodologia TDD | **Siempre activo** |
-| **refactorer** | Mejora la claridad del codigo sin cambiar comportamiento | Off |
-| **sonar** | Ejecuta analisis estatico SonarQube y quality gates | On (si configurado) |
-| **reviewer** | Revision de codigo con perfiles de exigencia configurables | **Siempre activo** |
-| **tester** | Quality gate de tests y verificacion de cobertura | **On** |
-| **security** | Auditoria de seguridad OWASP | **On** |
-| **solomon** | Supervisor de sesion — monitoriza salud de iteraciones con 5 reglas (incl. reviewer overreach), media reviews estancados, escala ante anomalias | **On** |
-| **commiter** | Automatizacion de git commit, push y PR tras aprobacion | Off |
-
-Los roles marcados con `?` son opcionales y se pueden activar por ejecucion o via config.
-
-## Instalacion
-
-### Desde npm (recomendado)
-
-```bash
-npm install -g karajan-code
-kj init
-```
-
-### Desde codigo fuente
-
-```bash
-git clone https://github.com/manufosela/karajan-code.git
-cd karajan-code
-./scripts/install.sh
-```
-
-### Setup no interactivo (CI/automatizacion)
-
-```bash
-./scripts/install.sh \
-  --non-interactive \
-  --kj-home /ruta/a/.karajan \
-  --sonar-host http://localhost:9000 \
-  --sonar-token "$KJ_SONAR_TOKEN" \
-  --coder claude \
-  --reviewer codex \
-  --run-doctor true
-```
-
-### Setup multi-instancia
-
-Guias completas: [`docs/multi-instance.md`](multi-instance.md) | [`docs/install-two-instances.md`](install-two-instances.md)
-
-```bash
-./scripts/setup-multi-instance.sh
-```
-
-## Agentes soportados
-
-| Agente | CLI | Instalacion |
-|--------|-----|-------------|
-| **Claude** | `claude` | `npm install -g @anthropic-ai/claude-code` |
-| **Codex** | `codex` | `npm install -g @openai/codex` |
-| **Gemini** | `gemini` | Ver [Gemini CLI docs](https://github.com/google-gemini/gemini-cli) |
-| **Aider** | `aider` | `pipx install aider-chat` (o `pip3 install aider-chat`) |
-
-`kj init` auto-detecta los agentes instalados. Si solo hay uno disponible, se asigna a todos los roles automaticamente.
-=======
 Tu describes lo que quieres construir. Karajan orquesta multiples agentes de IA para planificarlo, implementarlo, testearlo, revisarlo con SonarQube e iterar. Sin que tengas que supervisar cada paso.
 
 ## Que es Karajan?
@@ -162,6 +38,7 @@ Claude Code es excelente. Usalo para codificacion interactiva basada en sesiones
 
 Usa Karajan cuando quieras:
 
+- **Un pipeline repetible y documentado** que corre igual cada vez
 - **TDD por defecto.** Los tests se escriben antes de la implementacion, no despues
 - **Integracion con SonarQube.** Quality gates como parte del flujo, no como algo secundario
 - **Solomon como jefe del pipeline.** Cada rechazo del reviewer es evaluado por un supervisor que decide si es valido o solo ruido de estilo
@@ -171,7 +48,7 @@ Usa Karajan cuando quieras:
 - **Local-first.** Tu codigo, tus claves, tu maquina. Ningun dato sale salvo que tu lo digas
 - **Zero costes de API.** Karajan usa CLIs de agentes de IA (Claude Code, Codex, Gemini CLI), no APIs. Pagas tu suscripcion existente (Claude Pro, ChatGPT Plus), no tarifas por token
 
-Si Claude Code es un programador de pares inteligente, Karajan es el pipeline CI/CD para desarrollo asistido por IA. Funcionan genial juntos: Karajan esta disenado para usarse como servidor MCP dentro de Claude Code.
+Si Claude Code es un programador de pares inteligente, Karajan es el pipeline CI/CD para desarrollo asistido por IA. Funcionan genial juntos: Karajan esta diseñado para usarse como servidor MCP dentro de Claude Code.
 
 ## Instalacion
 
@@ -180,26 +57,11 @@ npm install -g karajan-code
 ```
 
 Eso es todo. No requiere Docker (SonarQube usa Docker, pero Karajan lo gestiona automaticamente). Sin ficheros de configuracion que copiar. `kj init` auto-detecta tus agentes instalados.
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 
 ## Tres formas de usar Karajan
 
 Karajan instala **tres comandos**: `kj`, `kj-tail` y `karajan-mcp`.
 
-<<<<<<< HEAD
-### 1. CLI — Directamente desde terminal
-
-```bash
-kj run "Implementar autenticacion de usuario con JWT"
-kj code "Anadir validacion de inputs al formulario de registro"
-kj review "Revisar los cambios de autenticacion"
-kj plan "Refactorizar la capa de base de datos"
-```
-
-### 2. MCP — Dentro de tu agente de IA
-
-El caso de uso principal. Karajan corre como servidor MCP dentro de Claude Code, Codex o Gemini. El agente tiene acceso a 20 herramientas (`kj_run`, `kj_code`, `kj_review`, etc.) y delega el trabajo pesado al pipeline de Karajan.
-=======
 ### 1. CLI: directamente desde terminal
 
 Ejecuta Karajan directamente. Ves la salida completa del pipeline en tiempo real.
@@ -215,41 +77,26 @@ kj plan "Refactorizar la capa de base de datos"                     # Planificar
 ### 2. MCP: dentro de tu agente de IA
 
 Este es el caso de uso principal. Karajan corre como servidor MCP dentro de Claude Code, Codex o Gemini. Le pides algo a tu agente de IA y el delega el trabajo pesado al pipeline de Karajan.
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 
 ```
 Tu → Claude Code → kj_run (via MCP) → triage → coder → sonar → reviewer → tester → security
 ```
 
-<<<<<<< HEAD
-**El problema**: cuando Karajan corre dentro de un agente de IA, pierdes visibilidad. El agente te muestra el resultado final, pero no las etapas del pipeline, iteraciones o decisiones de Solomon en tiempo real.
-
-### 3. kj-tail — Monitorizar desde otro terminal
-
-**La herramienta companera.** Abre un segundo terminal en el **mismo directorio del proyecto** donde esta trabajando tu agente de IA:
-=======
-El servidor MCP se auto-registra durante `npm install`. Tu agente de IA ve 20 herramientas (`kj_run`, `kj_code`, `kj_review`, etc.) y las usa segun necesite.
+El servidor MCP se auto-registra durante `npm install`. Tu agente de IA ve 21 herramientas (`kj_run`, `kj_code`, `kj_review`, `kj_hu`, etc.) y las usa segun necesite.
 
 **El problema**: cuando Karajan corre dentro de un agente de IA, pierdes visibilidad. El agente te muestra el resultado final, pero no las etapas del pipeline, iteraciones o decisiones de Solomon en tiempo real.
 
 ### 3. kj-tail: monitorizar desde otro terminal
 
 **La herramienta compañera.** Abre un segundo terminal en el **mismo directorio del proyecto** donde esta trabajando tu agente de IA:
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 
 ```bash
 kj-tail
 ```
 
-<<<<<<< HEAD
-Veras la salida del pipeline en vivo — etapas, resultados, iteraciones, errores — tal como ocurren.
-
-```bash
-=======
 Veras la salida del pipeline en vivo (etapas, resultados, iteraciones, errores) tal como ocurren. La misma vista que ejecutar `kj run` directamente.
 
 ```
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 kj-tail                  # Seguir pipeline en tiempo real (por defecto)
 kj-tail -v               # Verbose: incluir heartbeats de agente y presupuesto
 kj-tail -t               # Mostrar timestamps
@@ -260,172 +107,6 @@ kj-tail --help           # Todas las opciones
 
 > **Importante**: `kj-tail` debe ejecutarse desde el mismo directorio donde el agente de IA esta trabajando. Lee `<proyecto>/.kj/run.log`, que se crea cuando Karajan arranca un pipeline via MCP.
 
-**Flujo tipico:**
-
-```
-┌──────────────────────────┐    ┌──────────────────────────┐
-│  Terminal 1               │    │  Terminal 2               │
-│                           │    │                           │
-│  $ claude                 │    │  $ kj-tail                │
-│  > implementa la          │    │                           │
-│    siguiente tarea        │    │  ├─ 📋 Triage: medium     │
-│    prioritaria            │    │  ├─ 🔬 Researcher ✅      │
-│                           │    │  ├─ 🧠 Planner ✅         │
-│  (Claude llama a kj_run   │    │  ├─ 🔨 Coder ✅           │
-<<<<<<< HEAD
-│   via MCP — solo ves      │    │  ├─ 🔍 Sonar: OK         │
-=======
-│   via MCP, solo ves       │    │  ├─ 🔍 Sonar: OK         │
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
-│   el resultado final)     │    │  ├─ 👁️ Reviewer ❌        │
-│                           │    │  ├─ ⚖️ Solomon: 2 cond.   │
-│                           │    │  ├─ 🔨 Coder (iter 2) ✅  │
-│                           │    │  ├─ ✅ Review: APPROVED    │
-│                           │    │  ├─ 🧪 Tester: passed     │
-│                           │    │  └─ 🏁 Result: APPROVED   │
-└──────────────────────────┘    └──────────────────────────┘
-```
-
-<<<<<<< HEAD
-**Ejemplo con pipeline completo** — tarea compleja con todos los roles:
-
-```
-┌─ Terminal 1 ─────────────────────────────────────────────────────────────────┐
-│                                                                              │
-│  $ claude                                                                    │
-│                                                                              │
-│  > Construye una API REST para un sistema de reservas. Requisitos:           │
-│  > - Express + TypeScript con validacion Zod en cada endpoint                │
-│  > - Endpoints: POST /bookings, GET /bookings/:id,                           │
-│  >   PATCH /bookings/:id/cancel                                              │
-│  > - Una reserva tiene: id, guestName, roomType (standard|suite|penthouse),  │
-│  >   checkIn, checkOut, status (confirmed|cancelled)                         │
-│  > - Validar: checkOut posterior a checkIn, sin fechas pasadas,              │
-│  >   roomType debe ser un valor valido del enum                              │
-│  > - Cancelar devuelve 409 si ya esta cancelada                              │
-│  > - Usa TDD. Ejecutalo con Karajan con architect y planner activos,         │
-│  >   modo paranoid. Coder claude, reviewer codex.                            │
-│                                                                              │
-│  Claude llama a kj_run via MCP con:                                          │
-│    --enable-architect --enable-researcher --enable-planner --mode paranoid    │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-
-┌─ Terminal 2: kj-tail ────────────────────────────────────────────────────────┐
-│                                                                              │
-│  kj-tail v1.36.1 — .kj/run.log                                              │
-│                                                                              │
-│  ├─ 📋 Triage: medium (sw) — activando researcher, architect, planner        │
-│  ├─ ⚙️ Preflight passed — all checks OK                                     │
-│  ├─ 🔬 Researcher: 8 ficheros, 3 patrones, 5 restricciones                  │
-│  ├─ 🏗️ Architect: diseno 3 capas (routes → service → validators)            │
-│  ├─ 🧠 Planner: 6 pasos — tests primero, luego rutas, servicio, validadores │
-│  │                                                                           │
-│  ▶ Iteracion 1/5                                                             │
-│  ├─ 🔨 Coder (claude): 3 endpoints + 18 tests                               │
-│  ├─ 📋 TDD: PASS (3 src, 2 test)                                            │
-│  ├─ 🔍 Sonar: Quality gate OK                                               │
-│  ├─ 👁️ Reviewer (codex): REJECTED (2 blocking)                              │
-│  │   "Falta 404 para GET booking inexistente"                                │
-│  │   "Endpoint cancel sin test de idempotencia"                              │
-│  ├─ ⚖️ Solomon: approve_with_conditions (2 condiciones)                     │
-│  │   "Anadir respuesta 404 y test para GET /bookings/:id con id desconocido" │
-│  │   "Anadir test: cancelar reserva ya cancelada devuelve 409, no 500"       │
-│  │                                                                           │
-│  ▶ Iteracion 2/5                                                             │
-│  ├─ 🔨 Coder (claude): corregido — 22 tests                                 │
-│  ├─ 📋 TDD: PASS                                                            │
-│  ├─ 🔍 Sonar: OK                                                            │
-│  ├─ 👁️ Reviewer (codex): APPROVED                                           │
-│  ├─ 🧪 Tester: passed — cobertura 94%, 22 tests                             │
-│  ├─ 🔒 Security: passed — 0 criticos, 1 bajo (helmet recomendado)           │
-│  ├─ 📊 Audit: CERTIFIED (3 advertencias)                                    │
-│  │                                                                           │
-│  🏁 Resultado: APPROVED                                                      │
-│     🔬 Investigacion: 8 ficheros, 3 patrones                                 │
-│     🗺 Plan: 6 pasos (tests primero)                                         │
-│     🧪 Cobertura: 94%, 22 tests                                              │
-│     🔒 Seguridad: OK                                                         │
-│     🔍 Sonar: OK                                                             │
-│     💰 Presupuesto: $0.42 (claude: $0.38, codex: $0.04)                      │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-## Comandos CLI
-
-Consulta la [documentacion completa de comandos](../README.md#cli-commands) en el README principal (ingles). Resumen:
-
-| Comando | Descripcion |
-|---------|-------------|
-| `kj init` | Wizard interactivo de configuracion |
-| `kj run <task>` | Pipeline completo: coder → sonar → reviewer |
-| `kj code <task>` | Solo coder (sin revision) |
-| `kj review <task>` | Solo reviewer (sobre diff actual) |
-| `kj plan <task>` | Generar plan de implementacion |
-| `kj scan` | Ejecutar analisis SonarQube |
-| `kj doctor` | Verificar entorno (git, Docker, agentes, SonarQube) |
-| `kj config` | Mostrar configuracion actual |
-| `kj report` | Informes de sesion con tracking de presupuesto |
-| `kj resume <id>` | Reanudar sesion pausada |
-| `kj roles` | Inspeccionar roles y templates del pipeline |
-| `kj sonar` | Gestionar contenedor Docker de SonarQube |
-
-## Servidor MCP
-
-Karajan Code expone un servidor MCP para integracion con cualquier host compatible (Claude, Codex, agentes custom).
-
-Tras `npm install -g karajan-code`, el servidor MCP se auto-registra en las configs de Claude y Codex. Config manual:
-
-```json
-{
-  "mcpServers": {
-    "karajan-mcp": {
-      "command": "karajan-mcp"
-    }
-  }
-}
-```
-
-### Herramientas MCP
-
-| Herramienta | Descripcion |
-|-------------|-------------|
-| `kj_init` | Inicializar config y SonarQube |
-| `kj_doctor` | Verificar dependencias del sistema |
-| `kj_config` | Mostrar configuracion |
-| `kj_scan` | Ejecutar analisis SonarQube |
-| `kj_run` | Ejecutar pipeline completo (con notificaciones de progreso en tiempo real) |
-| `kj_resume` | Reanudar sesion pausada |
-| `kj_report` | Leer informes de sesion (soporta `--trace`) |
-| `kj_roles` | Listar roles o mostrar templates |
-| `kj_code` | Modo solo coder |
-| `kj_review` | Modo solo reviewer |
-| `kj_plan` | Generar plan de implementacion con telemetria heartbeat/stall y diagnostico mas claro |
-
-### MCPs complementarios recomendados
-
-Karajan Code funciona perfectamente solo, pero combinarlo con estos servidores MCP le da a tu agente un entorno de desarrollo completo:
-
-| MCP | Para que | Caso de uso |
-|-----|----------|-------------|
-| [**Planning Game MCP**](https://github.com/AgenteIA-Geniova/planning-game-mcp) | Puente MCP para [Planning Game](https://github.com/AgenteIA-Geniova/planning-game), gestor agil open-source (tareas, sprints, estimacion, XP). Solo necesario si usas Planning Game | `kj_run` con `--pg-task` obtiene contexto completo de la tarea y actualiza el estado al completar |
-| [**GitHub MCP**](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Crear PRs, gestionar issues, leer repos desde el agente | Combinar con `--auto-push` para flujo completo: codigo → revision → push → PR |
-| [**Serena**](https://github.com/oramasearch/serena) | Navegacion a nivel de simbolo (find references, go-to-definition) para proyectos JS/TS | Activar con `--enable-serena` para inyectar contexto de simbolos en prompts de coder/reviewer |
-| [**Chrome DevTools MCP**](https://github.com/anthropics/anthropic-quickstarts/tree/main/chrome-devtools-mcp) | Automatizacion de navegador, screenshots, inspeccion de consola/red | Verificar cambios de UI visualmente tras modificar codigo frontend |
-
-## Templates de roles
-
-Cada rol tiene un template `.md` con instrucciones que el agente de IA sigue. Los templates se resuelven en orden de prioridad:
-
-1. **Override de proyecto**: `.karajan/roles/<rol>.md` (en la raiz del proyecto)
-2. **Override de usuario**: `$KJ_HOME/roles/<rol>.md`
-3. **Built-in**: `templates/roles/<rol>.md` (incluido en el paquete)
-
-Usa `kj roles show <rol>` para inspeccionar cualquier template. Crea un override de proyecto para personalizar el comportamiento por proyecto.
-
-**Variantes de revision**: `reviewer-strict`, `reviewer-relaxed`, `reviewer-paranoid` — seleccionables via flag `--mode` o config `review_mode`.
-=======
 [**Ver la demo completa del pipeline**](https://karajancode.com#demo): triage, arquitectura, TDD, SonarQube, code review, arbitraje de Solomon, auditoria de seguridad.
 
 ## El pipeline
@@ -441,7 +122,7 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 | **hu-reviewer** | Certifica historias de usuario antes de codificar (6 dimensiones, 7 antipatrones) | Auto (media/compleja) |
 | **triage** | Clasifica complejidad, activa roles, auto-simplifica para tareas triviales | **On** |
 | **discover** | Detecta huecos en requisitos (Mom Test, Wendel, JTBD) | Off |
-| **architect** | Disena la arquitectura de la solucion antes de planificar | Off |
+| **architect** | Diseña la arquitectura de la solucion antes de planificar | Off |
 | **planner** | Genera planes de implementacion estructurados | Off |
 | **coder** | Escribe codigo y tests siguiendo metodologia TDD | **Siempre on** |
 | **refactorer** | Mejora la claridad del codigo sin cambiar comportamiento | Off |
@@ -466,19 +147,19 @@ hu-reviewer? → triage → discover? → architect? → planner? → coder → 
 
 Mezcla y combina. Usa Claude como coder y Codex como reviewer. Karajan auto-detecta agentes instalados durante `kj init`.
 
-## Servidor MCP (20 herramientas)
+## Servidor MCP (21 herramientas)
 
 Tras `npm install -g karajan-code`, el servidor MCP se auto-registra en Claude y Codex. Config manual si es necesario:
 
 ```bash
-# Claude: anadir a ~/.claude.json → "mcpServers":
+# Claude: añadir a ~/.claude.json → "mcpServers":
 # { "karajan-mcp": { "command": "karajan-mcp" } }
 
-# Codex: anadir a ~/.codex/config.toml → [mcp_servers."karajan-mcp"]
+# Codex: añadir a ~/.codex/config.toml → [mcp_servers."karajan-mcp"]
 # command = "karajan-mcp"
 ```
 
-**20 herramientas** disponibles: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`.
+**21 herramientas** disponibles: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`, `kj_hu`.
 
 Usa `kj-tail` en un terminal separado para ver lo que el pipeline esta haciendo en tiempo real (ver [Tres formas de usar Karajan](#tres-formas-de-usar-karajan)).
 
@@ -500,7 +181,7 @@ Usa `kj roles show <rol>` para inspeccionar cualquier template.
 
 Karajan auto-detecta y auto-configura todo lo que puede:
 
-- **TDD**: Detecta framework de tests (vitest, jest, mocha) y auto-activa TDD
+- **TDD**: Detecta framework de tests para 12 lenguajes (vitest, jest, JUnit, pytest, go test, cargo test, y mas). Auto-activa TDD para tareas de codigo, lo salta para doc/infra
 - **Bootstrap gate**: Valida todos los prerequisitos (repo git, remote, config, agentes, SonarQube) antes de ejecutar. Falla con instrucciones claras, nunca degrada silenciosamente
 - **Injection guard**: Escanea diffs en busca de prompt injection antes del review de IA. Detecta directivas de override, Unicode invisible, payloads en comentarios sobredimensionados. Tambien como GitHub Action en cada PR
 - **SonarQube**: Auto-arranca contenedor Docker, genera config si falta
@@ -511,11 +192,11 @@ Karajan auto-detecta y auto-configura todo lo que puede:
 
 Sin configuracion por proyecto requerida. Si quieres personalizar, la config se apila: sesion > proyecto > global.
 
-## Por qué JavaScript vanilla?
+## Por que JavaScript vanilla?
 
-No es nostalgia ni cabezonería. Es que llevo usando JavaScript desde 1997, cuando Brendan Eich lo creó en una semana y nos cambió la vida a los que hacíamos webs. Conozco sus tripas, sus bugs, sus rarezas. Y sé que quien conoce JS de verdad convierte esos bugs en features. TypeScript existe para que developers acostumbrados a lenguajes fuertemente tipados no entren en pánico al ver JS. Respeto eso. Pero yo no lo necesito. Los tests son mi seguridad de tipos. JSDoc y un buen IDE son mi intellisense. Y no tener un compilador entre el código y yo es lo que me permite moverme a 57 releases en 45 días sin miedo.
+No es nostalgia ni cabezoneria. Es que llevo usando JavaScript desde 1997, cuando Brendan Eich lo creo en una semana y nos cambio la vida a los que haciamos webs. Conozco sus tripas, sus bugs, sus rarezas. Y se que quien conoce JS de verdad convierte esos bugs en features. TypeScript existe para que developers acostumbrados a lenguajes fuertemente tipados no entren en panico al ver JS. Respeto eso. Pero yo no lo necesito. Los tests son mi seguridad de tipos. JSDoc y un buen IDE son mi intellisense. Y no tener un compilador entre el codigo y yo es lo que me permite moverme a 57 releases en 45 dias sin miedo.
 
-[Por qué JavaScript vanilla: la versión larga](why-vanilla-js.md)
+[Por que JavaScript vanilla: la version larga](why-vanilla-js.md)
 
 ## Compañeros recomendados
 
@@ -525,7 +206,6 @@ No es nostalgia ni cabezonería. Es que llevo usando JavaScript desde 1997, cuan
 | [**Planning Game MCP**](https://github.com/AgenteIA-Geniova/planning-game-mcp) | Gestion agil de proyectos (tareas, sprints, estimacion), nativo XP |
 | [**GitHub MCP**](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | Crear PRs, gestionar issues directamente desde el agente |
 | [**Chrome DevTools MCP**](https://github.com/anthropics/anthropic-quickstarts/tree/main/chrome-devtools-mcp) | Verificar cambios de UI visualmente tras modificar frontend |
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 
 ## Contribuir
 
@@ -533,32 +213,15 @@ No es nostalgia ni cabezonería. Es que llevo usando JavaScript desde 1997, cuan
 git clone https://github.com/manufosela/karajan-code.git
 cd karajan-code
 npm install
-<<<<<<< HEAD
-npm test              # Ejecutar 1040+ tests con Vitest
-npm run test:watch    # Modo watch
-npm run validate      # Lint + test
-```
-
-- Tests: [Vitest](https://vitest.dev/)
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`)
-- PRs: un solo proposito por PR, < 300 lineas cambiadas
-=======
-npm test              # Ejecutar 2093 tests con Vitest
+npm test              # Ejecutar 2142 tests con Vitest
 npm run validate      # Lint + test
 ```
 
 Issues y pull requests bienvenidos. Si algo no funciona como esta documentado, [abre un issue](https://github.com/manufosela/karajan-code/issues). Es la contribucion mas util en esta fase.
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920
 
 ## Enlaces
 
 - [Web](https://karajancode.com) (tambien [kj-code.com](https://kj-code.com))
-<<<<<<< HEAD
-- [Changelog](../CHANGELOG.md)
-- [Politica de seguridad](../SECURITY.md)
-- [Licencia (AGPL-3.0)](../LICENSE)
-- [Issues](https://github.com/manufosela/karajan-code/issues)
-=======
 - [Documentacion completa](https://karajancode.com/docs/)
 - [Changelog](../CHANGELOG.md)
 - [Politica de seguridad](../SECURITY.md)
@@ -567,4 +230,3 @@ Issues y pull requests bienvenidos. Si algo no funciona como esta documentado, [
 ---
 
 Construido por [@manufosela](https://github.com/manufosela). Head of Engineering en Geniova Technologies, co-organizador de NodeJS Madrid, autor de [Liderazgo Afectivo](https://www.liderazgoafectivo.com). 90+ paquetes npm publicados.
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920


### PR DESCRIPTION
## Summary
- README.md: 21 tools, 2142 tests, kj_hu in tool list, multi-language TDD, v1.38.1
- docs/README.es.md: full rewrite (had 36 unresolved merge conflict markers)
- CHANGELOG.md: resolved 2 merge conflicts, added v1.38.1 section

## Test plan
- [ ] CI green