### PR TITLE
fix(security): secrets always block pipeline + coder must use .env

### DIFF
--- a/src/guards/output-guard.js
+++ b/src/guards/output-guard.js
@@ -10,13 +10,23 @@ const DESTRUCTIVE_PATTERNS = [
   { id: "format-disk", pattern: /mkfs\.|fdisk|dd\s+if=/, severity: "critical", message: "Disk format operation detected" },
 ];
 
-// Built-in credential patterns
+// Built-in credential patterns (ALL critical — secrets must NEVER be committed)
 const CREDENTIAL_PATTERNS = [
   { id: "aws-key", pattern: /AKIA[0-9A-Z]{16}/, severity: "critical", message: "AWS access key exposed" },
   { id: "private-key", pattern: /-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----/, severity: "critical", message: "Private key exposed" },
-  { id: "generic-secret", pattern: /(password|secret|token|api_key|apikey)\s*[:=]\s*["'][^"']{8,}["']/i, severity: "warning", message: "Potential secret/credential exposed" },
+  { id: "generic-secret", pattern: /(password|secret|token|api_key|apikey)\s*[:=]\s*["'][^"']{8,}["']/i, severity: "critical", message: "Hardcoded secret detected. Use .env file + process.env instead" },
   { id: "github-token", pattern: /gh[pousr]_[A-Za-z0-9_]{36,}/, severity: "critical", message: "GitHub token exposed" },
   { id: "npm-token", pattern: /npm_[A-Za-z0-9]{36,}/, severity: "critical", message: "npm token exposed" },
+  { id: "openai-key", pattern: /sk-[A-Za-z0-9]{20,}/, severity: "critical", message: "OpenAI API key exposed" },
+  { id: "anthropic-key", pattern: /sk-ant-[A-Za-z0-9_-]{20,}/, severity: "critical", message: "Anthropic API key exposed" },
+  { id: "stripe-key", pattern: /sk_live_[A-Za-z0-9]{20,}/, severity: "critical", message: "Stripe secret key exposed" },
+  { id: "stripe-test", pattern: /sk_test_[A-Za-z0-9]{20,}/, severity: "critical", message: "Stripe test key exposed. Use .env even for test keys" },
+  { id: "google-api-key", pattern: /AIza[A-Za-z0-9_-]{35}/, severity: "critical", message: "Google API key exposed" },
+  { id: "firebase-key", pattern: /"apiKey"\s*:\s*"AIza[A-Za-z0-9_-]{35}"/, severity: "critical", message: "Firebase API key hardcoded. Use .env file" },
+  { id: "slack-token", pattern: /xox[bpors]-[A-Za-z0-9-]{10,}/, severity: "critical", message: "Slack token exposed" },
+  { id: "jwt-secret", pattern: /jwt[_-]?secret\s*[:=]\s*["'][^"']{8,}["']/i, severity: "critical", message: "JWT secret hardcoded. Use .env file" },
+  { id: "database-url", pattern: /(mongodb|postgres|mysql|redis):\/\/[^"'\s]+:[^"'\s]+@/i, severity: "critical", message: "Database URL with credentials exposed. Use .env file" },
+  { id: "hardcoded-key-assignment", pattern: /(?:const|let|var)\s+\w*(?:key|secret|token|password)\w*\s*=\s*["'][A-Za-z0-9_-]{16,}["']/i, severity: "critical", message: "Hardcoded key in variable. Use process.env or .env file" },
 ];
 
 // Default protected files (block if these appear in added/modified lines)

--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -28,6 +28,15 @@ Before reporting done, verify that ALL parts of the task are addressed:
 - If you write tests first (TDD), the implementation MUST make those tests pass.
 - Do NOT commit code that doesn't compile or doesn't pass tests.
 
+## Secrets and environment variables
+
+- NEVER hardcode API keys, tokens, passwords, secrets, or credentials in source code. No exceptions, not even for public keys or test keys.
+- ALWAYS use environment variables via `process.env` (Node.js), `os.environ` (Python), or the equivalent for the project's language.
+- If the project needs API keys, create a `.env.example` file with placeholder values and add `.env` to `.gitignore`.
+- If `.gitignore` does not already include `.env`, add it.
+- If the task requires Firebase, Stripe, OpenAI, or any third-party API: use `.env` for the keys and document required variables in `.env.example` or README.
+- Database connection strings with credentials MUST use environment variables.
+
 ## File modification safety
 
 - NEVER overwrite existing files entirely. Always make targeted, minimal edits.

--- a/tests/output-guard.test.js
+++ b/tests/output-guard.test.js
@@ -104,14 +104,61 @@ describe("scanDiff", () => {
     expect(violation.severity).toBe("critical");
   });
 
-  it("detects generic secret pattern -> warning severity, pass still true", () => {
+  it("detects generic secret pattern -> critical severity, pass: false", () => {
     const diff = makeDiff("src/config.js", ['const password = "supersecretvalue123";'], ['// settings']);
     const result = scanDiff(diff);
 
     const violation = result.violations.find(v => v.id === "generic-secret");
     expect(violation).toBeDefined();
-    expect(violation.severity).toBe("warning");
-    // warnings alone do not block
+    expect(violation.severity).toBe("critical");
+    expect(result.pass).toBe(false);
+  });
+
+  it("detects OpenAI API key", () => {
+    const diff = makeDiff("src/ai.js", ['const key = "sk-abc123def456ghi789jkl012mno345pqr678"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "openai-key")).toBe(true);
+  });
+
+  it("detects Anthropic API key", () => {
+    const diff = makeDiff("src/ai.js", ['const key = "sk-ant-abc123def456ghi789jkl012mno"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "anthropic-key")).toBe(true);
+  });
+
+  it("detects Google API key", () => {
+    const diff = makeDiff("src/maps.js", ['const key = "AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "google-api-key")).toBe(true);
+  });
+
+  it("detects Firebase config with hardcoded key", () => {
+    const diff = makeDiff("src/firebase.js", ['"apiKey": "AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "firebase-key")).toBe(true);
+  });
+
+  it("detects database URL with credentials", () => {
+    const diff = makeDiff("src/db.js", ['const url = "mongodb://admin:secretpass@localhost:27017/mydb"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "database-url")).toBe(true);
+  });
+
+  it("detects hardcoded key in variable assignment", () => {
+    const diff = makeDiff("src/config.js", ['const apiKey = "abcdef1234567890abcdef"'], []);
+    const result = scanDiff(diff);
+    expect(result.pass).toBe(false);
+    expect(result.violations.some(v => v.id === "hardcoded-key-assignment")).toBe(true);
+  });
+
+  it("allows process.env usage (no false positive)", () => {
+    const diff = makeDiff("src/config.js", ['const apiKey = process.env.API_KEY'], []);
+    const result = scanDiff(diff);
     expect(result.pass).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- All credential patterns upgraded from warning to **critical** (blocking)
- 10 new patterns: OpenAI, Anthropic, Stripe, Google, Firebase, Slack, JWT, database URLs, hardcoded key assignments
- Coder template: mandatory .env usage, .env.example creation, .gitignore check
- 7 new tests

## Test plan
- [x] 170 files, 2149 tests pass
- [ ] CI green