### PR TITLE
fix: reviewer now sees new files created by coder (git add before diff)

### DIFF
--- a/src/orchestrator/iteration-stages.js
+++ b/src/orchestrator/iteration-stages.js
@@ -685,7 +685,7 @@ async function fetchReviewDiff(session, logger) {
     logger.info(`Reviewer reading PR diff #${session.becaria_pr_number}`);
     return diff;
   }
-  return generateDiff({ baseRef: session.session_start_sha });
+  return generateDiff({ baseRef: session.session_start_sha, stageNewFiles: true });
 }
 
 export async function runReviewerStage({ reviewerRole, config, logger, emitter, eventBase, session, trackBudget, iteration, reviewRules, task, repeatDetector, budgetSummary, askQuestion }) {

--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -13,8 +13,12 @@ export async function computeBaseRef({ baseBranch = "main", baseRef = null }) {
   return mergeBase.stdout.trim();
 }
 
-export async function generateDiff({ baseRef }) {
-  const result = await runCommand("git", ["diff", `${baseRef}`]);
+export async function generateDiff({ baseRef, stageNewFiles = false }) {
+  // Stage untracked files so they appear in the diff (coder creates files but doesn't git add)
+  if (stageNewFiles) {
+    await runCommand("git", ["add", "-A"]);
+  }
+  const result = await runCommand("git", ["diff", stageNewFiles ? "--cached" : "", `${baseRef}`].filter(Boolean));
   if (result.exitCode !== 0) {
     throw new Error(`git diff failed: ${result.stderr || result.stdout}`);
   }


### PR DESCRIPTION
## Summary
- `generateDiff()` now accepts `stageNewFiles` option
- When `stageNewFiles: true`, runs `git add -A` before diff and uses `--cached` to include staged changes
- `fetchReviewDiff()` passes `stageNewFiles: true` so all coder-created files appear in the reviewer diff
- Fixes the real-world bug where scaffold tasks loop forever because reviewer can't see new files

## Test plan
- [x] 170 files, 2149 tests pass
- [ ] CI green