### PR TITLE
fix: replace test API keys with clearly fake values

### DIFF
--- a/tests/output-guard.test.js
+++ b/tests/output-guard.test.js
@@ -129,14 +129,14 @@ describe("scanDiff", () => {
   });
 
   it("detects Google API key", () => {
-    const diff = makeDiff("src/maps.js", ['const key = "AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q"'], []);
+    const diff = makeDiff("src/maps.js", ['const key = "AIzaTEST_FAKE_KEY_000000000000000000000"'], []);
     const result = scanDiff(diff);
     expect(result.pass).toBe(false);
     expect(result.violations.some(v => v.id === "google-api-key")).toBe(true);
   });
 
   it("detects Firebase config with hardcoded key", () => {
-    const diff = makeDiff("src/firebase.js", ['"apiKey": "AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q"'], []);
+    const diff = makeDiff("src/firebase.js", ['"apiKey": "AIzaTEST_FAKE_KEY_000000000000000000000"'], []);
     const result = scanDiff(diff);
     expect(result.pass).toBe(false);
     expect(result.violations.some(v => v.id === "firebase-key")).toBe(true);


### PR DESCRIPTION
GitGuardian flagged test strings that look like real Google API keys. Replaced with obviously fake patterns that still match the regex.