### PR TITLE
feat(cli): update available notification

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -25,8 +25,13 @@ import { architectCommand } from "./commands/architect.js";
 import { auditCommand } from "./commands/audit.js";
 import { boardCommand } from "./commands/board.js";
 
+import { printUpdateNotice } from "./utils/update-check.js";
+
 const PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
 const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
+
+// Non-blocking update check (runs in background, prints after command output)
+printUpdateNotice(PKG_VERSION).catch(() => {});
 
 async function withConfig(commandName, flags, fn) {
   const { config } = await loadConfig();

--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getKarajanHome } from "./paths.js";
+
+const CACHE_FILE = "update-check.json";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PACKAGE_NAME = "karajan-code";
+
+/**
+ * Check npm for a newer version. Non-blocking, cached for 24h.
+ * Returns { updateAvailable, latest, current } or null if check fails/cached.
+ */
+export async function checkForUpdate(currentVersion) {
+  try {
+    const cachePath = path.join(getKarajanHome(), CACHE_FILE);
+
+    // Check cache first
+    try {
+      const raw = await fs.readFile(cachePath, "utf8");
+      const cache = JSON.parse(raw);
+      if (cache.checkedAt && Date.now() - cache.checkedAt < CACHE_TTL_MS) {
+        if (!cache.latest || cache.latest === currentVersion) return null;
+        return { updateAvailable: true, latest: cache.latest, current: currentVersion };
+      }
+    } catch { /* no cache or expired */ }
+
+    // Fetch from npm (timeout 3s, don't block)
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
+      signal: controller.signal,
+      headers: { "Accept": "application/json" },
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) return null;
+    const data = await res.json();
+    const latest = data.version;
+
+    // Save cache
+    await fs.mkdir(getKarajanHome(), { recursive: true });
+    await fs.writeFile(cachePath, JSON.stringify({ latest, checkedAt: Date.now() }), "utf8");
+
+    if (latest === currentVersion) return null;
+    if (compareVersions(latest, currentVersion) > 0) {
+      return { updateAvailable: true, latest, current: currentVersion };
+    }
+    return null;
+  } catch {
+    return null; // Network error, offline, etc. Never block.
+  }
+}
+
+/**
+ * Print update notice if available. Call at CLI startup, non-blocking.
+ */
+export async function printUpdateNotice(currentVersion) {
+  const result = await checkForUpdate(currentVersion);
+  if (result?.updateAvailable) {
+    console.log(`\n  Update available: v${result.current} → v${result.latest}`);
+    console.log(`  Run: npm install -g ${PACKAGE_NAME}\n`);
+  }
+}
+
+/** Simple semver compare: returns >0 if a > b, <0 if a < b, 0 if equal */
+function compareVersions(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
+}

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkForUpdate } from "../src/utils/update-check.js";
+import fs from "node:fs/promises";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+  },
+}));
+
+describe("update-check", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fs.readFile.mockRejectedValue(new Error("no cache"));
+    fs.writeFile.mockResolvedValue();
+    fs.mkdir.mockResolvedValue();
+    global.fetch = vi.fn();
+  });
+
+  it("returns null when npm returns same version", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "1.38.2" }),
+    });
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toBeNull();
+  });
+
+  it("returns update info when npm has newer version", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "1.39.0" }),
+    });
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toEqual({
+      updateAvailable: true,
+      latest: "1.39.0",
+      current: "1.38.2",
+    });
+  });
+
+  it("returns null when npm version is older", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "1.37.0" }),
+    });
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch fails (offline)", async () => {
+    global.fetch.mockRejectedValue(new Error("network error"));
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when npm returns non-200", async () => {
+    global.fetch.mockResolvedValue({ ok: false });
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toBeNull();
+  });
+
+  it("uses cache when fresh (no fetch)", async () => {
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({ latest: "1.40.0", checkedAt: Date.now() })
+    );
+    const result = await checkForUpdate("1.38.2");
+    expect(result).toEqual({
+      updateAvailable: true,
+      latest: "1.40.0",
+      current: "1.38.2",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores expired cache and fetches", async () => {
+    fs.readFile.mockResolvedValue(
+      JSON.stringify({ latest: "1.40.0", checkedAt: Date.now() - 25 * 60 * 60 * 1000 })
+    );
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "1.41.0" }),
+    });
+    const result = await checkForUpdate("1.38.2");
+    expect(result.latest).toBe("1.41.0");
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it("saves cache after successful fetch", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "1.39.0" }),
+    });
+    await checkForUpdate("1.38.2");
+    expect(fs.writeFile).toHaveBeenCalled();
+    const written = JSON.parse(fs.writeFile.mock.calls[0][1]);
+    expect(written.latest).toBe("1.39.0");
+    expect(written.checkedAt).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/utils/update-check.js`: fetches npm registry, compares versions, caches 24h
- CLI runs check at startup (fire-and-forget, never blocks)
- 8 tests: newer/same/older version, cache fresh/expired, offline, save cache

## Test plan
- [x] 171 files, 2157 tests pass
- [ ] CI green