### PR TITLE
feat(mcp): sovereignty guard rejects host AI pipeline manipulation

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -25,6 +25,7 @@ import { createRunLog, readRunLog } from "../utils/run-log.js";
 import { currentBranch } from "../utils/git.js";
 import { isPreflightAcked, ackPreflight, getSessionOverrides } from "./preflight.js";
 import { ensureBootstrap } from "../bootstrap.js";
+import { validateSovereignty } from "./sovereignty-guard.js";
 
 /**
  * Resolve the user's project directory.
@@ -823,6 +824,19 @@ async function handleRun(a, server, extra) {
       return failPayload(`Invalid taskType "${a.taskType}". Valid values: ${[...validTypes].join(", ")}`);
     }
   }
+
+  // Sovereignty guard: sanitise params and check for active sessions
+  const projectDir = await resolveProjectDir(server, a.projectDir);
+  const sovereignty = validateSovereignty(a, { projectDir });
+  if (sovereignty.error) {
+    return failPayload(sovereignty.error);
+  }
+  if (sovereignty.warnings.length > 0) {
+    const logger = createLogger("info", "mcp");
+    for (const w of sovereignty.warnings) logger.warn(`[sovereignty] ${w}`);
+  }
+  Object.assign(a, sovereignty.params);
+
   await runBootstrapGate(server, a);
   if (!isPreflightAcked()) {
     // Auto-acknowledge with defaults for autonomous operation

--- a/src/mcp/sovereignty-guard.js
+++ b/src/mcp/sovereignty-guard.js
@@ -1,0 +1,112 @@
+/**
+ * Sovereignty guard for MCP inputs.
+ *
+ * Validates kj_run parameters and rejects host-AI attempts to override
+ * pipeline decisions that Karajan makes internally (triage, hu-reviewer, etc.).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Parameters that the host AI is allowed to pass through without restriction. */
+const ALLOWED_PARAMS = new Set([
+  "task", "projectDir", "pgTask", "pgProject",
+  "planner", "coder", "reviewer", "refactorer",
+  "plannerModel", "coderModel", "reviewerModel", "refactorerModel",
+  "enablePlanner", "enableReviewer", "enableRefactorer", "enableResearcher",
+  "enableTester", "enableSecurity", "enableImpeccable",
+  "enableDiscover", "enableArchitect",
+  "architectModel", "huFile",
+  "enableSerena", "enableBecaria",
+  "reviewerFallback", "reviewerRetries",
+  "mode", "maxIterations", "maxIterationMinutes", "maxTotalMinutes",
+  "baseBranch", "baseRef", "methodology",
+  "autoCommit", "autoPush", "autoPr", "autoRebase", "branchPrefix",
+  "autoSimplify", "smartModels", "checkpointInterval",
+  "taskType", "quiet", "noSonar", "enableSonarcloud",
+  "kjHome", "sonarToken", "timeoutMs",
+  // Sovereign flags — validated below but still "known"
+  "enableTriage", "enableHuReviewer",
+]);
+
+const MIN_ITERATIONS = 1;
+const MAX_ITERATIONS = 10;
+const ACTIVE_SESSION_THRESHOLD_MS = 60_000;
+
+/**
+ * Check if a pipeline is already running for this project.
+ * Looks at .kj/run.log modification time.
+ *
+ * @param {string} projectDir - Project root directory
+ * @returns {{ active: boolean, message?: string }}
+ */
+export function checkActiveSession(projectDir) {
+  if (!projectDir) return { active: false };
+  const logPath = path.join(projectDir, ".kj", "run.log");
+  try {
+    const stat = fs.statSync(logPath);
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs < ACTIVE_SESSION_THRESHOLD_MS) {
+      return {
+        active: true,
+        message:
+          "A pipeline is already running for this project. " +
+          "Wait for it to complete or use kj_status to check progress.",
+      };
+    }
+  } catch {
+    // File doesn't exist or can't be read — no active session
+  }
+  return { active: false };
+}
+
+/**
+ * Validate and sanitise kj_run parameters.
+ *
+ * @param {Record<string, unknown>} params - Raw parameters from the MCP call
+ * @param {{ projectDir?: string }} context - Runtime context
+ * @returns {{ params: Record<string, unknown>, warnings: string[], error?: string }}
+ */
+export function validateSovereignty(params, context = {}) {
+  const warnings = [];
+  const sanitized = { ...params };
+
+  // 1. Strip unknown parameters
+  for (const key of Object.keys(sanitized)) {
+    if (!ALLOWED_PARAMS.has(key)) {
+      warnings.push(`Unknown parameter "${key}" stripped`);
+      delete sanitized[key];
+    }
+  }
+
+  // 2. Sovereign flags — pipeline decides, not the host AI
+  if (sanitized.enableHuReviewer === false) {
+    warnings.push("Pipeline decides hu-reviewer activation, ignoring override");
+    delete sanitized.enableHuReviewer;
+  }
+
+  if (sanitized.enableTriage === false) {
+    warnings.push("Triage is mandatory, ignoring override");
+    delete sanitized.enableTriage;
+  }
+
+  // 3. Clamp maxIterations to [1, 10]
+  if (sanitized.maxIterations !== undefined) {
+    const n = Number(sanitized.maxIterations);
+    if (!Number.isFinite(n) || n < MIN_ITERATIONS) {
+      warnings.push(`maxIterations ${sanitized.maxIterations} clamped to ${MIN_ITERATIONS}`);
+      sanitized.maxIterations = MIN_ITERATIONS;
+    } else if (n > MAX_ITERATIONS) {
+      warnings.push(`maxIterations ${sanitized.maxIterations} clamped to ${MAX_ITERATIONS}`);
+      sanitized.maxIterations = MAX_ITERATIONS;
+    }
+  }
+
+  // 4. Active session detection
+  const session = checkActiveSession(context.projectDir);
+  if (session.active) {
+    return { params: sanitized, warnings, error: session.message };
+  }
+
+  return { params: sanitized, warnings };
+}

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -110,6 +110,10 @@ vi.mock("../src/bootstrap.js", () => ({
   ensureBootstrap: vi.fn().mockResolvedValue(undefined)
 }));
 
+vi.mock("../src/mcp/sovereignty-guard.js", () => ({
+  validateSovereignty: vi.fn((params) => ({ params: { ...params }, warnings: [] }))
+}));
+
 const {
   asObject,
   responseText,

--- a/tests/sovereignty-guard.test.js
+++ b/tests/sovereignty-guard.test.js
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { validateSovereignty, checkActiveSession } from "../src/mcp/sovereignty-guard.js";
+
+describe("sovereignty-guard", () => {
+  describe("validateSovereignty", () => {
+    it("strips enableHuReviewer:false with warning", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        enableHuReviewer: false,
+      });
+      expect(params.enableHuReviewer).toBeUndefined();
+      expect(warnings).toContain(
+        "Pipeline decides hu-reviewer activation, ignoring override"
+      );
+    });
+
+    it("keeps enableHuReviewer:true without warning", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        enableHuReviewer: true,
+      });
+      expect(params.enableHuReviewer).toBe(true);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("strips enableTriage:false with warning", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        enableTriage: false,
+      });
+      expect(params.enableTriage).toBeUndefined();
+      expect(warnings).toContain(
+        "Triage is mandatory, ignoring override"
+      );
+    });
+
+    it("keeps enableTriage:true without warning", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        enableTriage: true,
+      });
+      expect(params.enableTriage).toBe(true);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("allows mode:paranoid through", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        mode: "paranoid",
+      });
+      expect(params.mode).toBe("paranoid");
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("allows methodology:standard through", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        methodology: "standard",
+      });
+      expect(params.methodology).toBe("standard");
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("clamps maxIterations:0 to 1", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        maxIterations: 0,
+      });
+      expect(params.maxIterations).toBe(1);
+      expect(warnings.some((w) => w.includes("clamped to 1"))).toBe(true);
+    });
+
+    it("clamps maxIterations:100 to 10", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        maxIterations: 100,
+      });
+      expect(params.maxIterations).toBe(10);
+      expect(warnings.some((w) => w.includes("clamped to 10"))).toBe(true);
+    });
+
+    it("keeps maxIterations:5 as-is", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        maxIterations: 5,
+      });
+      expect(params.maxIterations).toBe(5);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("strips unknown parameters with warning", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        hackTheSystem: true,
+        injectPayload: "evil",
+      });
+      expect(params.hackTheSystem).toBeUndefined();
+      expect(params.injectPayload).toBeUndefined();
+      expect(warnings).toContain('Unknown parameter "hackTheSystem" stripped');
+      expect(warnings).toContain('Unknown parameter "injectPayload" stripped');
+    });
+
+    it("combines multiple violations", () => {
+      const { params, warnings } = validateSovereignty({
+        task: "do stuff",
+        enableTriage: false,
+        enableHuReviewer: false,
+        maxIterations: 999,
+        unknownFlag: true,
+      });
+      expect(params.enableTriage).toBeUndefined();
+      expect(params.enableHuReviewer).toBeUndefined();
+      expect(params.maxIterations).toBe(10);
+      expect(params.unknownFlag).toBeUndefined();
+      expect(warnings).toHaveLength(4);
+    });
+  });
+
+  describe("checkActiveSession", () => {
+    const tmpDir = path.join(process.cwd(), ".kj-test-sovereignty");
+    const kjDir = path.join(tmpDir, ".kj");
+    const logPath = path.join(kjDir, "run.log");
+
+    beforeEach(() => {
+      fs.mkdirSync(kjDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns active when run.log was modified recently", () => {
+      fs.writeFileSync(logPath, "running...");
+      // File was just written, so mtime is now — well within 60s
+      const result = checkActiveSession(tmpDir);
+      expect(result.active).toBe(true);
+      expect(result.message).toContain("already running");
+    });
+
+    it("returns inactive when run.log is stale", () => {
+      fs.writeFileSync(logPath, "done");
+      // Backdate the file by 2 minutes
+      const past = new Date(Date.now() - 120_000);
+      fs.utimesSync(logPath, past, past);
+      const result = checkActiveSession(tmpDir);
+      expect(result.active).toBe(false);
+    });
+
+    it("returns inactive when run.log does not exist", () => {
+      // No log file written
+      fs.rmSync(logPath, { force: true });
+      const result = checkActiveSession(tmpDir);
+      expect(result.active).toBe(false);
+    });
+
+    it("returns inactive when projectDir is falsy", () => {
+      const result = checkActiveSession(null);
+      expect(result.active).toBe(false);
+    });
+  });
+
+  describe("validateSovereignty with active session", () => {
+    const tmpDir = path.join(process.cwd(), ".kj-test-sovereignty-session");
+    const kjDir = path.join(tmpDir, ".kj");
+    const logPath = path.join(kjDir, "run.log");
+
+    beforeEach(() => {
+      fs.mkdirSync(kjDir, { recursive: true });
+      fs.writeFileSync(logPath, "running pipeline...");
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns error when active session detected", () => {
+      const result = validateSovereignty(
+        { task: "do stuff" },
+        { projectDir: tmpDir }
+      );
+      expect(result.error).toContain("already running");
+    });
+  });
+
+  describe("validateSovereignty without active session", () => {
+    it("allows execution when no projectDir is provided", () => {
+      const result = validateSovereignty({ task: "do stuff" });
+      expect(result.error).toBeUndefined();
+      expect(result.params.task).toBe("do stuff");
+    });
+
+    it("allows execution when run.log does not exist", () => {
+      const result = validateSovereignty(
+        { task: "do stuff" },
+        { projectDir: "/tmp/nonexistent-project-dir-12345" }
+      );
+      expect(result.error).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `sovereignty-guard.js`: validates kj_run params, strips overrides (enableHuReviewer, enableTriage), clamps maxIterations [1,10], strips unknown params
- Active session detection: blocks duplicate kj_run if pipeline already running
- 18 new tests (2175 total)

Closes KJC-TSK-0193

## Test plan
- [x] 172 files, 2175 tests pass
- [ ] CI green