### PR TITLE
feat(mcp): kj_suggest tool for host AI observations

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -26,6 +26,7 @@ import { currentBranch } from "../utils/git.js";
 import { isPreflightAcked, ackPreflight, getSessionOverrides } from "./preflight.js";
 import { ensureBootstrap } from "../bootstrap.js";
 import { validateSovereignty } from "./sovereignty-guard.js";
+import { handleSuggestion } from "./suggest-handler.js";
 
 /**
  * Resolve the user's project directory.
@@ -977,6 +978,17 @@ async function handleScan(a, server) {
   return runKjCommand({ command: "scan", options: a });
 }
 
+async function handleSuggest(a) {
+  if (!a.suggestion) {
+    return failPayload("Missing required field: suggestion");
+  }
+  return handleSuggestion({
+    suggestion: a.suggestion,
+    context: a.context || null,
+    projectDir: a.projectDir || null
+  });
+}
+
 /* ── Handler dispatch map ─────────────────────────────────────────── */
 
 const toolHandlers = {
@@ -1000,7 +1012,8 @@ const toolHandlers = {
   kj_architect:   (a, server, extra) => handleArchitect(a, server, extra),
   kj_audit:       (a, server, extra) => handleAudit(a, server, extra),
   kj_board:       (a) => handleBoard(a),
-  kj_hu:          (a, server) => handleHu(a, server)
+  kj_hu:          (a, server) => handleHu(a, server),
+  kj_suggest:     (a) => handleSuggest(a)
 };
 
 export async function handleToolCall(name, args, server, extra) {

--- a/src/mcp/suggest-handler.js
+++ b/src/mcp/suggest-handler.js
@@ -1,0 +1,91 @@
+/**
+ * Handler for kj_suggest MCP tool.
+ * Allows the host AI to propose observations to Solomon without override power.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getSessionRoot } from "../utils/paths.js";
+
+/**
+ * Find the most recent running session for a given projectDir.
+ * If projectDir is not provided, returns the most recent running session overall.
+ */
+async function findActiveSession(projectDir) {
+  const sessionRoot = getSessionRoot();
+  let entries;
+  try {
+    entries = await fs.readdir(sessionRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort();
+  // Walk backwards (most recent first)
+  for (let i = dirs.length - 1; i >= 0; i--) {
+    try {
+      const raw = await fs.readFile(path.join(sessionRoot, dirs[i], "session.json"), "utf8");
+      const session = JSON.parse(raw);
+      if (session.status !== "running") continue;
+      if (projectDir && session.projectDir && session.projectDir !== projectDir) continue;
+      return session;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Handle a suggestion from the host AI.
+ * Logs it to the active session's suggestions array for Solomon to evaluate.
+ *
+ * @param {object} params
+ * @param {string} params.suggestion - The observation or proposal
+ * @param {string} [params.context] - Additional context
+ * @param {string} [params.projectDir] - Project directory to scope session lookup
+ * @returns {Promise<object>} Result with accepted status and message
+ */
+export async function handleSuggestion({ suggestion, context, projectDir }) {
+  if (!suggestion || typeof suggestion !== "string" || suggestion.trim() === "") {
+    return {
+      accepted: false,
+      reason: "Suggestion text is required and must be a non-empty string."
+    };
+  }
+
+  const session = await findActiveSession(projectDir);
+
+  if (!session) {
+    return {
+      accepted: false,
+      reason: "No active pipeline session. Suggestions are only evaluated during pipeline execution."
+    };
+  }
+
+  // Initialize suggestions array if not present
+  if (!Array.isArray(session.suggestions)) {
+    session.suggestions = [];
+  }
+
+  const entry = {
+    suggestion: suggestion.trim(),
+    context: context || null,
+    timestamp: new Date().toISOString()
+  };
+
+  session.suggestions.push(entry);
+
+  // Persist the updated session
+  const sessionRoot = getSessionRoot();
+  const sessionFile = path.join(sessionRoot, session.id, "session.json");
+  session.updated_at = new Date().toISOString();
+  await fs.writeFile(sessionFile, JSON.stringify(session, null, 2), "utf8");
+
+  return {
+    accepted: true,
+    status: "logged",
+    sessionId: session.id,
+    message: "Suggestion logged for Solomon evaluation in next iteration. Solomon will decide whether to act on it."
+  };
+}

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -334,5 +334,18 @@ export const tools = [
         projectDir: { type: "string", description: "Project directory (defaults to cwd)" }
       }
     }
+  },
+  {
+    name: "kj_suggest",
+    description: "Propose an observation or suggestion to Karajan's Solomon engine. Solomon will evaluate it and decide whether to accept, reject, or ask the human. You CANNOT override pipeline decisions through this tool, only propose.",
+    inputSchema: {
+      type: "object",
+      required: ["suggestion"],
+      properties: {
+        suggestion: { type: "string", description: "What you observed or want to propose" },
+        context: { type: "string", description: "Additional context (current HU, iteration, etc.)" },
+        projectDir: { type: "string", description: "Project directory" }
+      }
+    }
   }
 ];

--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -1,5 +1,5 @@
 import { SolomonRole } from "../roles/solomon-role.js";
-import { addCheckpoint, pauseSession } from "../session-store.js";
+import { addCheckpoint, pauseSession, saveSession } from "../session-store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 
 /**
@@ -80,17 +80,31 @@ export async function invokeSolomon({ config, logger, emitter, eventBase, stage,
     })
   );
 
+  // Collect pending suggestions from the session for Solomon's context
+  const pendingSuggestions = Array.isArray(session.suggestions) && session.suggestions.length > 0
+    ? session.suggestions.slice()
+    : null;
+
   const solomon = new SolomonRole({ config, logger, emitter });
   await solomon.init({ task: conflict.task || session.task, iteration });
   let ruling;
   try {
-    ruling = await solomon.run({ conflict });
+    const conflictWithSuggestions = pendingSuggestions
+      ? { ...conflict, hostSuggestions: pendingSuggestions }
+      : conflict;
+    ruling = await solomon.run({ conflict: conflictWithSuggestions });
   } catch (err) {
     logger.warn(`Solomon threw: ${err.message}`);
     return escalateToHuman({
       askQuestion, session, emitter, eventBase, stage, iteration,
       conflict: { ...conflict, solomonReason: `Solomon error: ${err.message}` }
     });
+  }
+
+  // Clear processed suggestions from session
+  if (pendingSuggestions) {
+    session.suggestions = [];
+    try { await saveSession(session); } catch { /* best-effort */ }
   }
 
   const solomonError = ruling.result?.error;

--- a/tests/kj-suggest.test.js
+++ b/tests/kj-suggest.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// We need to mock getSessionRoot before importing the handler
+const TEST_SESSION_ROOT = path.join(os.tmpdir(), `kj-suggest-test-${Date.now()}`);
+
+vi.mock("../src/utils/paths.js", () => ({
+  getSessionRoot: () => TEST_SESSION_ROOT
+}));
+
+const { handleSuggestion } = await import("../src/mcp/suggest-handler.js");
+
+async function createTestSession(id, data = {}) {
+  const dir = path.join(TEST_SESSION_ROOT, id);
+  await fs.mkdir(dir, { recursive: true });
+  const session = {
+    id,
+    status: "running",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    checkpoints: [],
+    ...data
+  };
+  await fs.writeFile(path.join(dir, "session.json"), JSON.stringify(session, null, 2), "utf8");
+  return session;
+}
+
+async function readTestSession(id) {
+  const raw = await fs.readFile(path.join(TEST_SESSION_ROOT, id, "session.json"), "utf8");
+  return JSON.parse(raw);
+}
+
+describe("kj_suggest", () => {
+  beforeEach(async () => {
+    await fs.mkdir(TEST_SESSION_ROOT, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(TEST_SESSION_ROOT, { recursive: true, force: true });
+  });
+
+  it("returns rejection when no active session exists", async () => {
+    const result = await handleSuggestion({ suggestion: "Consider using a cache here" });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toMatch(/no active pipeline session/i);
+  });
+
+  it("logs suggestion when active session exists", async () => {
+    await createTestSession("s_2026-01-01T00-00-00-000Z");
+
+    const result = await handleSuggestion({ suggestion: "The test coverage seems low" });
+
+    expect(result.accepted).toBe(true);
+    expect(result.status).toBe("logged");
+    expect(result.sessionId).toBe("s_2026-01-01T00-00-00-000Z");
+    expect(result.message).toMatch(/solomon/i);
+  });
+
+  it("stores suggestion in session.suggestions array", async () => {
+    await createTestSession("s_2026-01-02T00-00-00-000Z");
+
+    await handleSuggestion({
+      suggestion: "Add error handling for network failures",
+      context: "iteration 3, coder stage"
+    });
+
+    const session = await readTestSession("s_2026-01-02T00-00-00-000Z");
+    expect(session.suggestions).toHaveLength(1);
+    expect(session.suggestions[0].suggestion).toBe("Add error handling for network failures");
+    expect(session.suggestions[0].context).toBe("iteration 3, coder stage");
+    expect(session.suggestions[0].timestamp).toBeDefined();
+  });
+
+  it("accumulates multiple suggestions", async () => {
+    await createTestSession("s_2026-01-03T00-00-00-000Z");
+
+    await handleSuggestion({ suggestion: "First observation" });
+    await handleSuggestion({ suggestion: "Second observation" });
+    await handleSuggestion({ suggestion: "Third observation" });
+
+    const session = await readTestSession("s_2026-01-03T00-00-00-000Z");
+    expect(session.suggestions).toHaveLength(3);
+    expect(session.suggestions[0].suggestion).toBe("First observation");
+    expect(session.suggestions[1].suggestion).toBe("Second observation");
+    expect(session.suggestions[2].suggestion).toBe("Third observation");
+  });
+
+  it("tool description mentions it cannot override decisions", async () => {
+    const { tools } = await import("../src/mcp/tools.js");
+    const suggestTool = tools.find(t => t.name === "kj_suggest");
+
+    expect(suggestTool).toBeDefined();
+    expect(suggestTool.description).toMatch(/cannot override/i);
+  });
+
+  it("rejects empty suggestion text", async () => {
+    await createTestSession("s_2026-01-04T00-00-00-000Z");
+
+    const result = await handleSuggestion({ suggestion: "" });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toMatch(/required/i);
+  });
+
+  it("ignores non-running sessions", async () => {
+    await createTestSession("s_2026-01-05T00-00-00-000Z", { status: "completed" });
+
+    const result = await handleSuggestion({ suggestion: "Something" });
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toMatch(/no active pipeline session/i);
+  });
+
+  it("scopes session lookup by projectDir", async () => {
+    await createTestSession("s_2026-01-06T00-00-00-000Z", {
+      status: "running",
+      projectDir: "/home/user/project-a"
+    });
+
+    // Looking for project-b should not find the session for project-a
+    const result = await handleSuggestion({
+      suggestion: "Something",
+      projectDir: "/home/user/project-b"
+    });
+
+    expect(result.accepted).toBe(false);
+  });
+});

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -89,7 +89,7 @@ describe("kj_architect handler validation", () => {
 });
 
 describe("MCP tools count", () => {
-  it("has 21 tools registered", () => {
-    expect(tools).toHaveLength(21);
+  it("has 22 tools registered", () => {
+    expect(tools).toHaveLength(22);
   });
 });


### PR DESCRIPTION
## Summary
- New `kj_suggest` MCP tool (22nd): host AI proposes observations to Solomon
- `suggest-handler.js`: finds active session, logs suggestion with timestamp
- Solomon reads `session.suggestions[]` in next evaluation, clears after processing
- Cannot override pipeline decisions, only propose
- 8 new tests (2165 total)

Closes KJC-TSK-0194

## Test plan
- [x] 172 files, 2165 tests pass
- [ ] CI green