### PR TITLE
feat(mcp): kj_skills tool for OpenSkills management

### DIFF
--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -989,6 +989,40 @@ async function handleSuggest(a) {
   });
 }
 
+async function handleSkills(a) {
+  const action = a.action;
+  if (!action) return failPayload("Missing required field: action");
+
+  const { isOpenSkillsAvailable, installSkill, removeSkill, listSkills, readSkill } =
+    await import("../skills/openskills-client.js");
+
+  const opts = { projectDir: a.projectDir || null };
+
+  switch (action) {
+    case "install": {
+      if (!a.source) return failPayload("Missing required field: source (required for install)");
+      const available = await isOpenSkillsAvailable();
+      if (!available) {
+        return failPayload("OpenSkills CLI is not available. Install it with: npm install -g openskills");
+      }
+      return installSkill(a.source, { ...opts, global: a.global || false });
+    }
+    case "remove": {
+      if (!a.name) return failPayload("Missing required field: name (required for remove)");
+      return removeSkill(a.name, opts);
+    }
+    case "list": {
+      return listSkills(opts);
+    }
+    case "read": {
+      if (!a.name) return failPayload("Missing required field: name (required for read)");
+      return readSkill(a.name, opts);
+    }
+    default:
+      return failPayload(`Unknown skills action: ${action}`);
+  }
+}
+
 /* ── Handler dispatch map ─────────────────────────────────────────── */
 
 const toolHandlers = {
@@ -1013,7 +1047,8 @@ const toolHandlers = {
   kj_audit:       (a, server, extra) => handleAudit(a, server, extra),
   kj_board:       (a) => handleBoard(a),
   kj_hu:          (a, server) => handleHu(a, server),
-  kj_suggest:     (a) => handleSuggest(a)
+  kj_suggest:     (a) => handleSuggest(a),
+  kj_skills:      (a) => handleSkills(a)
 };
 
 export async function handleToolCall(name, args, server, extra) {

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -347,5 +347,20 @@ export const tools = [
         projectDir: { type: "string", description: "Project directory" }
       }
     }
+  },
+  {
+    name: "kj_skills",
+    description: "Manage OpenSkills for domain-specific agent knowledge. Install skills from the marketplace or GitHub repos to give coders domain expertise.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["install", "remove", "list", "read"], description: "Action to perform" },
+        source: { type: "string", description: "Skill source: marketplace name, GitHub URL, or local path (for install)" },
+        name: { type: "string", description: "Skill name (for remove/read)" },
+        global: { type: "boolean", description: "Install globally (~/.agent/skills/) instead of project-local" },
+        projectDir: { type: "string", description: "Project directory" }
+      },
+      required: ["action"]
+    }
   }
 ];

--- a/src/skills/openskills-client.js
+++ b/src/skills/openskills-client.js
@@ -1,0 +1,157 @@
+/**
+ * OpenSkills CLI client.
+ * Wraps `npx openskills` commands for installing, removing, listing, and reading skills.
+ */
+
+import { runCommand } from "../utils/process.js";
+
+const NPX = "npx";
+const PKG = "openskills";
+
+function buildCwd(projectDir) {
+  return projectDir || process.cwd();
+}
+
+/**
+ * Check whether the openskills CLI is available.
+ * @returns {Promise<boolean>}
+ */
+export async function isOpenSkillsAvailable() {
+  try {
+    const result = await runCommand(NPX, [PKG, "--version"], {
+      timeout: 15_000
+    });
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install a skill from a marketplace name, GitHub URL, or local path.
+ * @param {string} source - Skill source identifier.
+ * @param {object} opts
+ * @param {string} [opts.projectDir] - Working directory.
+ * @param {boolean} [opts.global] - Install globally (~/.agent/skills/).
+ * @returns {Promise<{ok: boolean, name?: string, error?: string}>}
+ */
+export async function installSkill(source, { projectDir, global: isGlobal } = {}) {
+  if (!source) {
+    return { ok: false, error: "source is required for install" };
+  }
+
+  const args = [PKG, "install", source];
+  if (isGlobal) args.push("--global");
+
+  const result = await runCommand(NPX, args, {
+    cwd: buildCwd(projectDir),
+    timeout: 60_000
+  });
+
+  if (result.exitCode !== 0) {
+    const stderr = (result.stderr || "").trim();
+    return { ok: false, error: stderr || `install failed (exit ${result.exitCode})` };
+  }
+
+  // Try to extract the skill name from stdout
+  const output = (result.stdout || "").trim();
+  const nameMatch = output.match(/installed\s+(?:skill\s+)?["']?([^\s"']+)["']?/i)
+    || output.match(/([^\s/]+)\s*$/);
+  const name = nameMatch ? nameMatch[1] : source;
+
+  return { ok: true, name };
+}
+
+/**
+ * Remove an installed skill by name.
+ * @param {string} name - Skill name.
+ * @param {object} opts
+ * @param {string} [opts.projectDir] - Working directory.
+ * @returns {Promise<{ok: boolean, error?: string}>}
+ */
+export async function removeSkill(name, { projectDir } = {}) {
+  if (!name) {
+    return { ok: false, error: "name is required for remove" };
+  }
+
+  const result = await runCommand(NPX, [PKG, "remove", name], {
+    cwd: buildCwd(projectDir),
+    timeout: 30_000
+  });
+
+  if (result.exitCode !== 0) {
+    const stderr = (result.stderr || "").trim();
+    return { ok: false, error: stderr || `remove failed (exit ${result.exitCode})` };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * List installed skills.
+ * @param {object} opts
+ * @param {string} [opts.projectDir] - Working directory.
+ * @returns {Promise<{ok: boolean, skills?: Array<{name: string, source?: string, scope?: string}>, error?: string}>}
+ */
+export async function listSkills({ projectDir } = {}) {
+  const result = await runCommand(NPX, [PKG, "list", "--json"], {
+    cwd: buildCwd(projectDir),
+    timeout: 30_000
+  });
+
+  if (result.exitCode !== 0) {
+    // Fallback: try without --json
+    const fallback = await runCommand(NPX, [PKG, "list"], {
+      cwd: buildCwd(projectDir),
+      timeout: 30_000
+    });
+
+    if (fallback.exitCode !== 0) {
+      const stderr = (fallback.stderr || "").trim();
+      return { ok: false, error: stderr || `list failed (exit ${fallback.exitCode})` };
+    }
+
+    // Parse text output: each line is a skill name
+    const lines = (fallback.stdout || "").split("\n").map(l => l.trim()).filter(Boolean);
+    const skills = lines.map(line => ({ name: line }));
+    return { ok: true, skills };
+  }
+
+  // Parse JSON output
+  const stdout = (result.stdout || "").trim();
+  try {
+    const parsed = JSON.parse(stdout);
+    const skills = Array.isArray(parsed) ? parsed : (parsed.skills || []);
+    return { ok: true, skills };
+  } catch {
+    // If JSON parse fails, treat as text
+    const lines = stdout.split("\n").map(l => l.trim()).filter(Boolean);
+    const skills = lines.map(line => ({ name: line }));
+    return { ok: true, skills };
+  }
+}
+
+/**
+ * Read a skill's content by name.
+ * @param {string} name - Skill name.
+ * @param {object} opts
+ * @param {string} [opts.projectDir] - Working directory.
+ * @returns {Promise<{ok: boolean, content?: string, error?: string}>}
+ */
+export async function readSkill(name, { projectDir } = {}) {
+  if (!name) {
+    return { ok: false, error: "name is required for read" };
+  }
+
+  const result = await runCommand(NPX, [PKG, "read", name], {
+    cwd: buildCwd(projectDir),
+    timeout: 30_000
+  });
+
+  if (result.exitCode !== 0) {
+    const stderr = (result.stderr || "").trim();
+    return { ok: false, error: stderr || `read failed (exit ${result.exitCode})` };
+  }
+
+  return { ok: true, content: (result.stdout || "").trim() };
+}

--- a/tests/kj-skills.test.js
+++ b/tests/kj-skills.test.js
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+const { runCommand } = await import("../src/utils/process.js");
+const {
+  isOpenSkillsAvailable,
+  installSkill,
+  removeSkill,
+  listSkills,
+  readSkill
+} = await import("../src/skills/openskills-client.js");
+
+describe("openskills-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("isOpenSkillsAvailable", () => {
+    it("returns true when npx openskills --version succeeds", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "1.0.0", stderr: "" });
+      const result = await isOpenSkillsAvailable();
+      expect(result).toBe(true);
+      expect(runCommand).toHaveBeenCalledWith("npx", ["openskills", "--version"], expect.objectContaining({ timeout: 15_000 }));
+    });
+
+    it("returns false when npx openskills --version fails", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "not found" });
+      const result = await isOpenSkillsAvailable();
+      expect(result).toBe(false);
+    });
+
+    it("returns false when runCommand throws", async () => {
+      runCommand.mockRejectedValue(new Error("ENOENT"));
+      const result = await isOpenSkillsAvailable();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("installSkill", () => {
+    it("returns success with skill name on successful install", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: 'installed skill "react-patterns"',
+        stderr: ""
+      });
+
+      const result = await installSkill("react-patterns", { projectDir: "/tmp/proj" });
+      expect(result).toEqual({ ok: true, name: "react-patterns" });
+      expect(runCommand).toHaveBeenCalledWith(
+        "npx",
+        ["openskills", "install", "react-patterns"],
+        expect.objectContaining({ cwd: "/tmp/proj" })
+      );
+    });
+
+    it("passes --global flag when global is true", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "installed my-skill", stderr: "" });
+
+      await installSkill("my-skill", { global: true });
+      expect(runCommand).toHaveBeenCalledWith(
+        "npx",
+        ["openskills", "install", "my-skill", "--global"],
+        expect.any(Object)
+      );
+    });
+
+    it("returns error when source is missing", async () => {
+      const result = await installSkill(null);
+      expect(result).toEqual({ ok: false, error: "source is required for install" });
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns error when install command fails", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 1,
+        stdout: "",
+        stderr: "skill not found in marketplace"
+      });
+
+      const result = await installSkill("nonexistent-skill");
+      expect(result).toEqual({ ok: false, error: "skill not found in marketplace" });
+    });
+  });
+
+  describe("removeSkill", () => {
+    it("returns success on removal", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "removed", stderr: "" });
+
+      const result = await removeSkill("old-skill", { projectDir: "/tmp/proj" });
+      expect(result).toEqual({ ok: true });
+      expect(runCommand).toHaveBeenCalledWith(
+        "npx",
+        ["openskills", "remove", "old-skill"],
+        expect.objectContaining({ cwd: "/tmp/proj" })
+      );
+    });
+
+    it("returns error when name is missing", async () => {
+      const result = await removeSkill(null);
+      expect(result).toEqual({ ok: false, error: "name is required for remove" });
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns error when remove fails", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "skill not installed" });
+      const result = await removeSkill("missing-skill");
+      expect(result).toEqual({ ok: false, error: "skill not installed" });
+    });
+  });
+
+  describe("listSkills", () => {
+    it("returns parsed JSON skill list", async () => {
+      const skills = [
+        { name: "react-patterns", source: "marketplace", scope: "project" },
+        { name: "node-security", source: "github:user/repo", scope: "global" }
+      ];
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: JSON.stringify(skills),
+        stderr: ""
+      });
+
+      const result = await listSkills({ projectDir: "/tmp/proj" });
+      expect(result).toEqual({ ok: true, skills });
+    });
+
+    it("falls back to text parsing when --json fails", async () => {
+      // First call (--json) fails
+      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "unknown flag" });
+      // Second call (text) succeeds
+      runCommand.mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: "react-patterns\nnode-security\n",
+        stderr: ""
+      });
+
+      const result = await listSkills();
+      expect(result).toEqual({
+        ok: true,
+        skills: [{ name: "react-patterns" }, { name: "node-security" }]
+      });
+    });
+
+    it("returns error when both list attempts fail", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "openskills not found" });
+
+      const result = await listSkills();
+      expect(result).toEqual({ ok: false, error: "openskills not found" });
+    });
+  });
+
+  describe("readSkill", () => {
+    it("returns skill content", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "# React Patterns\nUse hooks for state management...",
+        stderr: ""
+      });
+
+      const result = await readSkill("react-patterns", { projectDir: "/tmp/proj" });
+      expect(result).toEqual({
+        ok: true,
+        content: "# React Patterns\nUse hooks for state management..."
+      });
+    });
+
+    it("returns error when name is missing", async () => {
+      const result = await readSkill(null);
+      expect(result).toEqual({ ok: false, error: "name is required for read" });
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns error when read fails", async () => {
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "skill not found" });
+      const result = await readSkill("nonexistent");
+      expect(result).toEqual({ ok: false, error: "skill not found" });
+    });
+  });
+});
+
+const { handleToolCall } = await import("../src/mcp/server-handlers.js");
+
+describe("kj_skills handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error when action is missing", async () => {
+    const result = await handleToolCall("kj_skills", {}, null, null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("action");
+  });
+
+  it("returns error when source is missing for install", async () => {
+    // isOpenSkillsAvailable check runs first — make it succeed
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "1.0.0", stderr: "" });
+    const result = await handleToolCall("kj_skills", { action: "install" }, null, null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("source");
+  });
+
+  it("returns error when openskills is unavailable for install", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "not found" });
+    const result = await handleToolCall("kj_skills", { action: "install", source: "my-skill" }, null, null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("OpenSkills CLI is not available");
+  });
+
+  it("returns error when name is missing for remove", async () => {
+    const result = await handleToolCall("kj_skills", { action: "remove" }, null, null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("name");
+  });
+
+  it("returns error for unknown action", async () => {
+    const result = await handleToolCall("kj_skills", { action: "unknown" }, null, null);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Unknown skills action");
+  });
+});

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -89,7 +89,7 @@ describe("kj_architect handler validation", () => {
 });
 
 describe("MCP tools count", () => {
-  it("has 22 tools registered", () => {
-    expect(tools).toHaveLength(22);
+  it("has 23 tools registered", () => {
+    expect(tools).toHaveLength(23);
   });
 });


### PR DESCRIPTION
## Summary
- New `src/skills/openskills-client.js`: wraps `npx openskills` CLI (install, remove, list, read, availability check)
- New `kj_skills` MCP tool (23rd): install/remove/list/read OpenSkills
- 21 new tests

Closes KJC-TSK-0199

## Test plan
- [x] 174 files, 2204 tests pass (excluding TSK-0198 tests that depend on prompt changes not yet merged)
- [ ] CI green