### PR TITLE
feat(prompts): inject OpenSkills content into agent prompts

### DIFF
--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -63,7 +63,7 @@ export async function architectCommand({ task, config, logger, context, json }) 
   logger.info(`Architect (${architectRole.provider}) starting...`);
 
   const agent = createAgent(architectRole.provider, config, logger);
-  const prompt = buildArchitectPrompt({ task, researchContext: context });
+  const prompt = await buildArchitectPrompt({ task, researchContext: context });
   const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
   const result = await agent.runTask({ prompt, onOutput, role: "architect" });
 

--- a/src/commands/code.js
+++ b/src/commands/code.js
@@ -17,7 +17,7 @@ export async function codeCommand({ task, config, logger }) {
       try { coderRules = await fs.readFile("coder-rules.md", "utf8"); } catch { /* no coder rules file */ }
     }
   }
-  const prompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology || "tdd" });
+  const prompt = await buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology || "tdd" });
   const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
   const result = await coder.runTask({ prompt, onOutput, role: "coder" });
   if (!result.ok) {

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -32,7 +32,7 @@ export async function reviewCommand({ task, config, logger, baseRef }) {
 
   const { rules } = await resolveReviewProfile({ mode: config.review_mode, projectDir: process.cwd() });
 
-  const prompt = buildReviewerPrompt({ task, diff, reviewRules: rules, mode: config.review_mode });
+  const prompt = await buildReviewerPrompt({ task, diff, reviewRules: rules, mode: config.review_mode });
   const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
   const result = await reviewer.reviewTask({ prompt, onOutput, role: "reviewer" });
   if (!result.ok) {

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -488,7 +488,7 @@ export async function handleCodeDirect(a, server, extra) {
       try { coderRules = await fs.readFile("coder-rules.md", "utf8"); } catch { /* no coder rules file */ }
     }
   }
-  const prompt = buildCoderPrompt({ task: a.task, coderRules, methodology: config.development?.methodology || "tdd" });
+  const prompt = await buildCoderPrompt({ task: a.task, coderRules, methodology: config.development?.methodology || "tdd" });
   sendTrackerLog(server, "coder", "running", coderRole.provider);
   runLog.logText(`[coder] agent launched, waiting for response...`);
   let result;
@@ -535,7 +535,7 @@ export async function handleReviewDirect(a, server, extra) {
   const diff = await generateDiff({ baseRef: resolvedBase });
   const { rules } = await resolveReviewProfile({ mode: config.review_mode, projectDir: process.cwd() });
 
-  const prompt = buildReviewerPrompt({ task: a.task, diff, reviewRules: rules, mode: config.review_mode });
+  const prompt = await buildReviewerPrompt({ task: a.task, diff, reviewRules: rules, mode: config.review_mode });
   sendTrackerLog(server, "reviewer", "running", reviewerRole.provider);
   runLog.logText(`[reviewer] agent launched, waiting for response...`);
   let result;

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -97,8 +97,8 @@ async function handleDryRun({ task, config, flags, emitter, pipelineFlags }) {
   const projectDir = config.projectDir || process.cwd();
   const { rules: reviewRules } = await resolveReviewProfile({ mode: config.review_mode, projectDir });
   const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
-  const coderPrompt = buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology, serenaEnabled: Boolean(config.serena?.enabled), rtkAvailable: Boolean(config.rtk?.available), productContext: config.productContext || null });
-  const reviewerPrompt = buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode, serenaEnabled: Boolean(config.serena?.enabled), rtkAvailable: Boolean(config.rtk?.available), productContext: config.productContext || null });
+  const coderPrompt = await buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology, serenaEnabled: Boolean(config.serena?.enabled), rtkAvailable: Boolean(config.rtk?.available), productContext: config.productContext || null });
+  const reviewerPrompt = await buildReviewerPrompt({ task, diff: "(dry-run: no diff)", reviewRules, mode: config.review_mode, serenaEnabled: Boolean(config.serena?.enabled), rtkAvailable: Boolean(config.rtk?.available), productContext: config.productContext || null });
 
   const summary = {
     dry_run: true,

--- a/src/prompts/architect.js
+++ b/src/prompts/architect.js
@@ -1,3 +1,5 @@
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
+
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
   "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
@@ -6,7 +8,7 @@ const SUBAGENT_PREAMBLE = [
 
 export const VALID_VERDICTS = new Set(["ready", "needs_clarification"]);
 
-export function buildArchitectPrompt({ task, instructions, researchContext = null, productContext = null }) {
+export async function buildArchitectPrompt({ task, instructions, researchContext = null, productContext = null, projectDir = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -40,6 +42,14 @@ export function buildArchitectPrompt({ task, instructions, researchContext = nul
   }
 
   sections.push(`## Task\n${task}`);
+
+  if (projectDir) {
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills);
+    if (skillSection) {
+      sections.push(skillSection);
+    }
+  }
 
   return sections.join("\n\n");
 }

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -1,4 +1,5 @@
 import { RTK_INSTRUCTIONS } from "./rtk-snippet.js";
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -31,7 +32,7 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, plan = null }) {
+export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, plan = null, projectDir = null }) {
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     `Task:\n${task}`,
@@ -81,6 +82,14 @@ export function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary =
 
   if (deferredContext) {
     sections.push(deferredContext);
+  }
+
+  if (projectDir) {
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills);
+    if (skillSection) {
+      sections.push(skillSection);
+    }
   }
 
   return sections.join("\n\n");

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -1,4 +1,5 @@
 import { RTK_INSTRUCTIONS } from "./rtk-snippet.js";
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -22,7 +23,7 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null }) {
+export async function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, projectDir = null }) {
   const truncatedDiff = diff.length > 12000 ? `${diff.slice(0, 12000)}\n\n[TRUNCATED]` : diff;
 
   const sections = [
@@ -52,6 +53,14 @@ export function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabl
     `Review rules:\n${reviewRules}`,
     `Git diff:\n${truncatedDiff}`
   );
+
+  if (projectDir) {
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills);
+    if (skillSection) {
+      sections.push(skillSection);
+    }
+  }
 
   return sections.join("\n\n");
 }

--- a/src/roles/architect-role.js
+++ b/src/roles/architect-role.js
@@ -59,7 +59,7 @@ export class ArchitectRole extends BaseRole {
     const provider = resolveProvider(this.config);
     const agent = this._createAgent(provider, this.config, this.logger);
 
-    const prompt = buildArchitectPrompt({ task, instructions: this.instructions, researchContext, productContext: this.config?.productContext || null });
+    const prompt = await buildArchitectPrompt({ task, instructions: this.instructions, researchContext, productContext: this.config?.productContext || null });
     const runArgs = { prompt, role: "architect" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -34,7 +34,7 @@ export class CoderRole extends BaseRole {
       this.logger.info(`Host-as-coder: delegating to host AI (skipping ${provider} subprocess)`);
     }
 
-    const prompt = buildCoderPrompt({
+    const prompt = await buildCoderPrompt({
       task: task || this.context?.task || "",
       reviewerFeedback: reviewerFeedback || null,
       sonarSummary: sonarSummary || null,

--- a/src/skills/skill-loader.js
+++ b/src/skills/skill-loader.js
@@ -1,0 +1,58 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const SKILL_DIRS = [".agent/skills", ".claude/skills"];
+const SKILL_FILE = "SKILL.md";
+
+/**
+ * Scans known skill directories for SKILL.md files.
+ * @param {string} projectDir — absolute path to the project root
+ * @returns {Promise<Array<{name: string, content: string}>>}
+ */
+export async function loadAvailableSkills(projectDir) {
+  const skills = [];
+
+  for (const rel of SKILL_DIRS) {
+    const dir = join(projectDir, rel);
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue; // directory does not exist — skip
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillPath = join(dir, entry.name, SKILL_FILE);
+      try {
+        const content = await readFile(skillPath, "utf-8");
+        skills.push({ name: entry.name, content });
+      } catch {
+        // no SKILL.md in this subdirectory — skip
+      }
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Builds a prompt section from loaded skills.
+ * @param {Array<{name: string, content: string}>} skills
+ * @returns {string} prompt section or empty string
+ */
+export function buildSkillSection(skills) {
+  if (!skills || skills.length === 0) return "";
+
+  const header = [
+    "## Domain Skills",
+    "",
+    "The following domain-specific knowledge is available for this task:"
+  ].join("\n");
+
+  const blocks = skills.map(
+    (s) => `### ${s.name}\n${s.content}`
+  );
+
+  return [header, ...blocks].join("\n\n");
+}

--- a/tests/product-context.test.js
+++ b/tests/product-context.test.js
@@ -65,24 +65,24 @@ describe("loadProductContext", () => {
 describe("productContext injection into prompts", () => {
   const productContext = "We build dental treatment planning software for orthodontists.";
 
-  it("buildCoderPrompt includes productContext when provided", () => {
-    const result = buildCoderPrompt({ task: "Add login", productContext });
+  it("buildCoderPrompt includes productContext when provided", async () => {
+    const result = await buildCoderPrompt({ task: "Add login", productContext });
     expect(result).toContain("## Product Context");
     expect(result).toContain(productContext);
   });
 
-  it("buildCoderPrompt omits productContext when null", () => {
-    const result = buildCoderPrompt({ task: "Add login", productContext: null });
+  it("buildCoderPrompt omits productContext when null", async () => {
+    const result = await buildCoderPrompt({ task: "Add login", productContext: null });
     expect(result).not.toContain("## Product Context");
   });
 
-  it("buildCoderPrompt omits productContext by default", () => {
-    const result = buildCoderPrompt({ task: "Add login" });
+  it("buildCoderPrompt omits productContext by default", async () => {
+    const result = await buildCoderPrompt({ task: "Add login" });
     expect(result).not.toContain("## Product Context");
   });
 
-  it("buildReviewerPrompt includes productContext when provided", () => {
-    const result = buildReviewerPrompt({
+  it("buildReviewerPrompt includes productContext when provided", async () => {
+    const result = await buildReviewerPrompt({
       task: "Add login",
       diff: "some diff",
       reviewRules: "rules",
@@ -93,8 +93,8 @@ describe("productContext injection into prompts", () => {
     expect(result).toContain(productContext);
   });
 
-  it("buildReviewerPrompt omits productContext when null", () => {
-    const result = buildReviewerPrompt({
+  it("buildReviewerPrompt omits productContext when null", async () => {
+    const result = await buildReviewerPrompt({
       task: "Add login",
       diff: "some diff",
       reviewRules: "rules",
@@ -103,7 +103,7 @@ describe("productContext injection into prompts", () => {
     expect(result).not.toContain("## Product Context");
   });
 
-  it("buildHuReviewerPrompt includes productContext when provided", () => {
+  it("buildHuReviewerPrompt includes productContext when provided", async () => {
     const result = buildHuReviewerPrompt({
       stories: [{ id: "HU-001", text: "As a doctor..." }],
       instructions: null,
@@ -113,7 +113,7 @@ describe("productContext injection into prompts", () => {
     expect(result).toContain(productContext);
   });
 
-  it("buildHuReviewerPrompt omits productContext when null", () => {
+  it("buildHuReviewerPrompt omits productContext when null", async () => {
     const result = buildHuReviewerPrompt({
       stories: [{ id: "HU-001", text: "As a doctor..." }],
       instructions: null
@@ -121,8 +121,8 @@ describe("productContext injection into prompts", () => {
     expect(result).not.toContain("## Product Context");
   });
 
-  it("buildArchitectPrompt includes productContext when provided", () => {
-    const result = buildArchitectPrompt({
+  it("buildArchitectPrompt includes productContext when provided", async () => {
+    const result = await buildArchitectPrompt({
       task: "Design auth system",
       instructions: null,
       productContext
@@ -131,15 +131,15 @@ describe("productContext injection into prompts", () => {
     expect(result).toContain(productContext);
   });
 
-  it("buildArchitectPrompt omits productContext when null", () => {
-    const result = buildArchitectPrompt({
+  it("buildArchitectPrompt omits productContext when null", async () => {
+    const result = await buildArchitectPrompt({
       task: "Design auth system",
       instructions: null
     });
     expect(result).not.toContain("## Product Context");
   });
 
-  it("buildPlannerPrompt includes productContext when provided", () => {
+  it("buildPlannerPrompt includes productContext when provided", async () => {
     const result = buildPlannerPrompt({
       task: "Implement caching",
       context: null,
@@ -150,7 +150,7 @@ describe("productContext injection into prompts", () => {
     expect(result).toContain(productContext);
   });
 
-  it("buildPlannerPrompt omits productContext when null", () => {
+  it("buildPlannerPrompt omits productContext when null", async () => {
     const result = buildPlannerPrompt({
       task: "Implement caching",
       context: null,

--- a/tests/prompt-architect.test.js
+++ b/tests/prompt-architect.test.js
@@ -2,30 +2,30 @@ import { describe, it, expect } from "vitest";
 import { buildArchitectPrompt, parseArchitectOutput, VALID_VERDICTS } from "../src/prompts/architect.js";
 
 describe("buildArchitectPrompt", () => {
-  it("returns a string containing the task", () => {
-    const prompt = buildArchitectPrompt({ task: "Design auth system" });
+  it("returns a string containing the task", async () => {
+    const prompt = await buildArchitectPrompt({ task: "Design auth system" });
     expect(prompt).toContain("Design auth system");
   });
 
-  it("includes sub-agent preamble", () => {
-    const prompt = buildArchitectPrompt({ task: "x" });
+  it("includes sub-agent preamble", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x" });
     expect(prompt).toContain("Karajan sub-agent");
     expect(prompt).toContain("Do NOT use any MCP tools");
   });
 
-  it("includes instructions when provided", () => {
-    const prompt = buildArchitectPrompt({ task: "x", instructions: "Custom architect instructions" });
+  it("includes instructions when provided", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x", instructions: "Custom architect instructions" });
     expect(prompt).toContain("Custom architect instructions");
   });
 
-  it("omits instructions section when null", () => {
-    const prompt = buildArchitectPrompt({ task: "x", instructions: null });
+  it("omits instructions section when null", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x", instructions: null });
     expect(typeof prompt).toBe("string");
     expect(prompt.length).toBeGreaterThan(0);
   });
 
-  it("includes JSON schema with architecture fields", () => {
-    const prompt = buildArchitectPrompt({ task: "x" });
+  it("includes JSON schema with architecture fields", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x" });
     expect(prompt).toContain("verdict");
     expect(prompt).toContain("architecture");
     expect(prompt).toContain("layers");
@@ -38,28 +38,28 @@ describe("buildArchitectPrompt", () => {
     expect(prompt).toContain("summary");
   });
 
-  it("includes research context when provided", () => {
-    const prompt = buildArchitectPrompt({ task: "x", researchContext: "Files: src/auth.js" });
+  it("includes research context when provided", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x", researchContext: "Files: src/auth.js" });
     expect(prompt).toContain("Files: src/auth.js");
   });
 
-  it("omits research context section when not provided", () => {
-    const prompt = buildArchitectPrompt({ task: "x" });
+  it("omits research context section when not provided", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x" });
     expect(prompt).not.toContain("## Research Context");
   });
 
-  it("includes architecture role description", () => {
-    const prompt = buildArchitectPrompt({ task: "x" });
+  it("includes architecture role description", async () => {
+    const prompt = await buildArchitectPrompt({ task: "x" });
     expect(prompt).toContain("architect");
   });
 });
 
 describe("VALID_VERDICTS", () => {
-  it("includes ready", () => {
+  it("includes ready", async () => {
     expect(VALID_VERDICTS).toContain("ready");
   });
 
-  it("includes needs_clarification", () => {
+  it("includes needs_clarification", async () => {
     expect(VALID_VERDICTS).toContain("needs_clarification");
   });
 });
@@ -80,7 +80,7 @@ describe("parseArchitectOutput", () => {
     summary: "Well-defined auth architecture"
   };
 
-  it("parses valid JSON output", () => {
+  it("parses valid JSON output", async () => {
     const parsed = parseArchitectOutput(JSON.stringify(validOutput));
     expect(parsed).not.toBeNull();
     expect(parsed.verdict).toBe("ready");
@@ -95,7 +95,7 @@ describe("parseArchitectOutput", () => {
     expect(parsed.summary).toBe("Well-defined auth architecture");
   });
 
-  it("parses JSON embedded in markdown code blocks", () => {
+  it("parses JSON embedded in markdown code blocks", async () => {
     const raw = `Here is my analysis:\n\`\`\`json\n${JSON.stringify(validOutput)}\n\`\`\`\nDone.`;
     const parsed = parseArchitectOutput(raw);
     expect(parsed).not.toBeNull();
@@ -103,33 +103,33 @@ describe("parseArchitectOutput", () => {
     expect(parsed.architecture.type).toBe("layered");
   });
 
-  it("returns null for non-JSON output", () => {
+  it("returns null for non-JSON output", async () => {
     expect(parseArchitectOutput("no json here")).toBeNull();
   });
 
-  it("returns null for empty/null input", () => {
+  it("returns null for empty/null input", async () => {
     expect(parseArchitectOutput("")).toBeNull();
     expect(parseArchitectOutput(null)).toBeNull();
     expect(parseArchitectOutput(undefined)).toBeNull();
   });
 
-  it("returns null for invalid JSON", () => {
+  it("returns null for invalid JSON", async () => {
     expect(parseArchitectOutput("{invalid json}")).toBeNull();
   });
 
-  it("normalizes verdict to valid values", () => {
+  it("normalizes verdict to valid values", async () => {
     const raw = JSON.stringify({ ...validOutput, verdict: "ready" });
     const parsed = parseArchitectOutput(raw);
     expect(VALID_VERDICTS).toContain(parsed.verdict);
   });
 
-  it("defaults invalid verdict to needs_clarification", () => {
+  it("defaults invalid verdict to needs_clarification", async () => {
     const raw = JSON.stringify({ ...validOutput, verdict: "unknown_verdict" });
     const parsed = parseArchitectOutput(raw);
     expect(parsed.verdict).toBe("needs_clarification");
   });
 
-  it("defaults missing architecture to empty structure", () => {
+  it("defaults missing architecture to empty structure", async () => {
     const raw = JSON.stringify({ verdict: "ready", questions: [], summary: "ok" });
     const parsed = parseArchitectOutput(raw);
     expect(parsed.architecture.type).toBe("");
@@ -141,19 +141,19 @@ describe("parseArchitectOutput", () => {
     expect(parsed.architecture.tradeoffs).toEqual([]);
   });
 
-  it("defaults missing questions to empty array", () => {
+  it("defaults missing questions to empty array", async () => {
     const raw = JSON.stringify({ verdict: "ready", architecture: validOutput.architecture, summary: "ok" });
     const parsed = parseArchitectOutput(raw);
     expect(parsed.questions).toEqual([]);
   });
 
-  it("defaults missing summary to empty string", () => {
+  it("defaults missing summary to empty string", async () => {
     const raw = JSON.stringify({ verdict: "ready", architecture: validOutput.architecture, questions: [] });
     const parsed = parseArchitectOutput(raw);
     expect(parsed.summary).toBe("");
   });
 
-  it("filters non-string items from arrays", () => {
+  it("filters non-string items from arrays", async () => {
     const raw = JSON.stringify({
       verdict: "ready",
       architecture: {
@@ -178,7 +178,7 @@ describe("parseArchitectOutput", () => {
     expect(parsed.questions).toEqual(["Is this right?"]);
   });
 
-  it("parses needs_clarification verdict with questions", () => {
+  it("parses needs_clarification verdict with questions", async () => {
     const raw = JSON.stringify({
       verdict: "needs_clarification",
       architecture: validOutput.architecture,
@@ -191,7 +191,7 @@ describe("parseArchitectOutput", () => {
     expect(parsed.questions[0]).toBe("Which auth provider to use?");
   });
 
-  it("handles architecture with partial fields", () => {
+  it("handles architecture with partial fields", async () => {
     const raw = JSON.stringify({
       verdict: "ready",
       architecture: { type: "microservices", layers: ["api"] },
@@ -205,7 +205,7 @@ describe("parseArchitectOutput", () => {
     expect(parsed.architecture.dataModel.entities).toEqual([]);
   });
 
-  it("handles dataModel without entities", () => {
+  it("handles dataModel without entities", async () => {
     const raw = JSON.stringify({
       verdict: "ready",
       architecture: { type: "x", dataModel: {} },

--- a/tests/prompt-coder.test.js
+++ b/tests/prompt-coder.test.js
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { buildCoderPrompt } from "../src/prompts/coder.js";
 
 describe("buildCoderPrompt", () => {
-  it("includes task and default TDD instructions", () => {
-    const result = buildCoderPrompt({ task: "Add login feature" });
+  it("includes task and default TDD instructions", async () => {
+    const result = await buildCoderPrompt({ task: "Add login feature" });
 
     expect(result).toContain("Task:\nAdd login feature");
     expect(result).toContain("Default development policy: TDD");
@@ -12,22 +12,22 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("Refactor safely while keeping tests green");
   });
 
-  it("includes subagent preamble", () => {
-    const result = buildCoderPrompt({ task: "Fix bug" });
+  it("includes subagent preamble", async () => {
+    const result = await buildCoderPrompt({ task: "Fix bug" });
 
     expect(result).toContain("You are running as a Karajan sub-agent");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("omits TDD instructions when methodology is not tdd", () => {
-    const result = buildCoderPrompt({ task: "Fix bug", methodology: "standard" });
+  it("omits TDD instructions when methodology is not tdd", async () => {
+    const result = await buildCoderPrompt({ task: "Fix bug", methodology: "standard" });
 
     expect(result).not.toContain("Default development policy: TDD");
     expect(result).toContain("Task:\nFix bug");
   });
 
-  it("includes coder rules when provided", () => {
-    const result = buildCoderPrompt({
+  it("includes coder rules when provided", async () => {
+    const result = await buildCoderPrompt({
       task: "Refactor module",
       coderRules: "Always use arrow functions"
     });
@@ -35,8 +35,8 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("Coder rules (MUST follow):\nAlways use arrow functions");
   });
 
-  it("includes sonar summary when provided", () => {
-    const result = buildCoderPrompt({
+  it("includes sonar summary when provided", async () => {
+    const result = await buildCoderPrompt({
       task: "Fix issues",
       sonarSummary: "3 blocker issues found in auth.js"
     });
@@ -44,8 +44,8 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("Sonar summary:\n3 blocker issues found in auth.js");
   });
 
-  it("includes reviewer feedback when provided", () => {
-    const result = buildCoderPrompt({
+  it("includes reviewer feedback when provided", async () => {
+    const result = await buildCoderPrompt({
       task: "Update API",
       reviewerFeedback: "Missing input validation on POST /users"
     });
@@ -53,8 +53,8 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("Reviewer blocking feedback:\nMissing input validation on POST /users");
   });
 
-  it("includes all optional sections together", () => {
-    const result = buildCoderPrompt({
+  it("includes all optional sections together", async () => {
+    const result = await buildCoderPrompt({
       task: "Complete rewrite",
       coderRules: "Follow SOLID",
       sonarSummary: "2 critical issues",
@@ -69,8 +69,8 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("Reviewer blocking feedback:\nTests missing for edge case");
   });
 
-  it("sections are separated by double newlines", () => {
-    const result = buildCoderPrompt({
+  it("sections are separated by double newlines", async () => {
+    const result = await buildCoderPrompt({
       task: "Test task",
       sonarSummary: "issue",
       reviewerFeedback: "feedback"
@@ -80,8 +80,8 @@ describe("buildCoderPrompt", () => {
     expect(sections.length).toBeGreaterThanOrEqual(5);
   });
 
-  it("omits null/undefined optional sections", () => {
-    const result = buildCoderPrompt({
+  it("omits null/undefined optional sections", async () => {
+    const result = await buildCoderPrompt({
       task: "Simple task",
       coderRules: null,
       sonarSummary: undefined,
@@ -93,8 +93,8 @@ describe("buildCoderPrompt", () => {
     expect(result).not.toContain("Reviewer blocking feedback");
   });
 
-  it("includes Serena instructions when serenaEnabled is true", () => {
-    const result = buildCoderPrompt({ task: "Navigate code", serenaEnabled: true });
+  it("includes Serena instructions when serenaEnabled is true", async () => {
+    const result = await buildCoderPrompt({ task: "Navigate code", serenaEnabled: true });
 
     expect(result).toContain("Serena MCP");
     expect(result).toContain("find_symbol");
@@ -103,31 +103,31 @@ describe("buildCoderPrompt", () => {
     expect(result).not.toContain("Do NOT use any MCP tools");
   });
 
-  it("does not include Serena instructions by default", () => {
-    const result = buildCoderPrompt({ task: "Normal task" });
+  it("does not include Serena instructions by default", async () => {
+    const result = await buildCoderPrompt({ task: "Normal task" });
 
     expect(result).not.toContain("Serena MCP");
     expect(result).not.toContain("find_symbol");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("does not include Serena when serenaEnabled is false", () => {
-    const result = buildCoderPrompt({ task: "Normal task", serenaEnabled: false });
+  it("does not include Serena when serenaEnabled is false", async () => {
+    const result = await buildCoderPrompt({ task: "Normal task", serenaEnabled: false });
 
     expect(result).not.toContain("Serena MCP");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("includes subprocess constraints about non-interactive execution", () => {
-    const result = buildCoderPrompt({ task: "Init project" });
+  it("includes subprocess constraints about non-interactive execution", async () => {
+    const result = await buildCoderPrompt({ task: "Init project" });
 
     expect(result).toContain("non-interactive subprocess");
     expect(result).toContain("--yes");
     expect(result).toContain("will hang forever");
   });
 
-  it("includes RTK instructions when rtkAvailable is true", () => {
-    const result = buildCoderPrompt({ task: "Fix tests", rtkAvailable: true });
+  it("includes RTK instructions when rtkAvailable is true", async () => {
+    const result = await buildCoderPrompt({ task: "Fix tests", rtkAvailable: true });
 
     expect(result).toContain("Token Optimization (RTK detected)");
     expect(result).toContain("rtk git status");
@@ -135,15 +135,15 @@ describe("buildCoderPrompt", () => {
     expect(result).toContain("does NOT apply to non-Bash tools");
   });
 
-  it("does not include RTK instructions by default", () => {
-    const result = buildCoderPrompt({ task: "Normal task" });
+  it("does not include RTK instructions by default", async () => {
+    const result = await buildCoderPrompt({ task: "Normal task" });
 
     expect(result).not.toContain("RTK");
     expect(result).not.toContain("Token Optimization");
   });
 
-  it("does not include RTK instructions when rtkAvailable is false", () => {
-    const result = buildCoderPrompt({ task: "Normal task", rtkAvailable: false });
+  it("does not include RTK instructions when rtkAvailable is false", async () => {
+    const result = await buildCoderPrompt({ task: "Normal task", rtkAvailable: false });
 
     expect(result).not.toContain("RTK");
     expect(result).not.toContain("Token Optimization");

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -9,21 +9,21 @@ describe("buildReviewerPrompt", () => {
     mode: "standard"
   };
 
-  it("includes subagent preamble", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes subagent preamble", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("You are running as a Karajan sub-agent");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("includes review mode", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes review mode", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("You are a code reviewer in standard mode");
   });
 
-  it("includes JSON schema instruction", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes JSON schema instruction", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("Return only one valid JSON object and nothing else");
     expect(result).toContain('"approved":boolean');
@@ -33,27 +33,27 @@ describe("buildReviewerPrompt", () => {
     expect(result).toContain('"confidence":number');
   });
 
-  it("includes task context", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes task context", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("Task context:\nAdd login feature");
   });
 
-  it("includes review rules", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes review rules", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("Review rules:\nCheck for security issues");
   });
 
-  it("includes git diff", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("includes git diff", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).toContain("Git diff:\ndiff --git a/src/auth.js");
   });
 
-  it("truncates diff larger than 12KB", () => {
+  it("truncates diff larger than 12KB", async () => {
     const largeDiff = "x".repeat(15000);
-    const result = buildReviewerPrompt({ ...baseArgs, diff: largeDiff });
+    const result = await buildReviewerPrompt({ ...baseArgs, diff: largeDiff });
 
     expect(result).toContain("[TRUNCATED]");
     expect(result).not.toContain("x".repeat(15000));
@@ -62,40 +62,40 @@ describe("buildReviewerPrompt", () => {
     expect(diffSection).toContain("x".repeat(12000));
   });
 
-  it("does not truncate diff at exactly 12KB", () => {
+  it("does not truncate diff at exactly 12KB", async () => {
     const exactDiff = "y".repeat(12000);
-    const result = buildReviewerPrompt({ ...baseArgs, diff: exactDiff });
+    const result = await buildReviewerPrompt({ ...baseArgs, diff: exactDiff });
 
     expect(result).not.toContain("[TRUNCATED]");
     expect(result).toContain("y".repeat(12000));
   });
 
-  it("does not truncate diff smaller than 12KB", () => {
+  it("does not truncate diff smaller than 12KB", async () => {
     const smallDiff = "z".repeat(5000);
-    const result = buildReviewerPrompt({ ...baseArgs, diff: smallDiff });
+    const result = await buildReviewerPrompt({ ...baseArgs, diff: smallDiff });
 
     expect(result).not.toContain("[TRUNCATED]");
     expect(result).toContain("z".repeat(5000));
   });
 
-  it("supports different review modes", () => {
-    const paranoid = buildReviewerPrompt({ ...baseArgs, mode: "paranoid" });
-    const relaxed = buildReviewerPrompt({ ...baseArgs, mode: "relaxed" });
+  it("supports different review modes", async () => {
+    const paranoid = await buildReviewerPrompt({ ...baseArgs, mode: "paranoid" });
+    const relaxed = await buildReviewerPrompt({ ...baseArgs, mode: "relaxed" });
 
     expect(paranoid).toContain("You are a code reviewer in paranoid mode");
     expect(relaxed).toContain("You are a code reviewer in relaxed mode");
   });
 
-  it("sections are separated by double newlines", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("sections are separated by double newlines", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
     const sections = result.split("\n\n");
 
     // preamble, mode, JSON instruction, schema, task, rules, diff = at least 7
     expect(sections.length).toBeGreaterThanOrEqual(7);
   });
 
-  it("includes Serena instructions when serenaEnabled is true", () => {
-    const result = buildReviewerPrompt({ ...baseArgs, serenaEnabled: true });
+  it("includes Serena instructions when serenaEnabled is true", async () => {
+    const result = await buildReviewerPrompt({ ...baseArgs, serenaEnabled: true });
 
     expect(result).toContain("Serena MCP");
     expect(result).toContain("find_symbol");
@@ -103,23 +103,23 @@ describe("buildReviewerPrompt", () => {
     expect(result).not.toContain("Do NOT use any MCP tools");
   });
 
-  it("does not include Serena instructions by default", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("does not include Serena instructions by default", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).not.toContain("Serena MCP");
     expect(result).not.toContain("find_symbol");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("does not include Serena when serenaEnabled is false", () => {
-    const result = buildReviewerPrompt({ ...baseArgs, serenaEnabled: false });
+  it("does not include Serena when serenaEnabled is false", async () => {
+    const result = await buildReviewerPrompt({ ...baseArgs, serenaEnabled: false });
 
     expect(result).not.toContain("Serena MCP");
     expect(result).toContain("Do NOT use any MCP tools");
   });
 
-  it("includes RTK instructions when rtkAvailable is true", () => {
-    const result = buildReviewerPrompt({ ...baseArgs, rtkAvailable: true });
+  it("includes RTK instructions when rtkAvailable is true", async () => {
+    const result = await buildReviewerPrompt({ ...baseArgs, rtkAvailable: true });
 
     expect(result).toContain("Token Optimization (RTK detected)");
     expect(result).toContain("rtk git status");
@@ -127,15 +127,15 @@ describe("buildReviewerPrompt", () => {
     expect(result).toContain("does NOT apply to non-Bash tools");
   });
 
-  it("does not include RTK instructions by default", () => {
-    const result = buildReviewerPrompt(baseArgs);
+  it("does not include RTK instructions by default", async () => {
+    const result = await buildReviewerPrompt(baseArgs);
 
     expect(result).not.toContain("RTK");
     expect(result).not.toContain("Token Optimization");
   });
 
-  it("does not include RTK instructions when rtkAvailable is false", () => {
-    const result = buildReviewerPrompt({ ...baseArgs, rtkAvailable: false });
+  it("does not include RTK instructions when rtkAvailable is false", async () => {
+    const result = await buildReviewerPrompt({ ...baseArgs, rtkAvailable: false });
 
     expect(result).not.toContain("RTK");
     expect(result).not.toContain("Token Optimization");

--- a/tests/skill-injection.test.js
+++ b/tests/skill-injection.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn()
+}));
+
+const { readdir, readFile } = await import("node:fs/promises");
+const { loadAvailableSkills, buildSkillSection } = await import("../src/skills/skill-loader.js");
+
+describe("skill-loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("loadAvailableSkills", () => {
+    it("returns empty array when no skills directories exist", async () => {
+      readdir.mockRejectedValue(new Error("ENOENT"));
+      const result = await loadAvailableSkills("/project");
+      expect(result).toEqual([]);
+    });
+
+    it("reads SKILL.md from .agent/skills/ subdirectories", async () => {
+      readdir.mockImplementation(async (dir) => {
+        if (dir === "/project/.agent/skills") {
+          return [{ name: "react", isDirectory: () => true }];
+        }
+        throw new Error("ENOENT");
+      });
+      readFile.mockResolvedValue("React best practices content");
+
+      const result = await loadAvailableSkills("/project");
+
+      expect(result).toEqual([{ name: "react", content: "React best practices content" }]);
+      expect(readFile).toHaveBeenCalledWith(
+        "/project/.agent/skills/react/SKILL.md",
+        "utf-8"
+      );
+    });
+
+    it("reads SKILL.md from .claude/skills/ subdirectories", async () => {
+      readdir.mockImplementation(async (dir) => {
+        if (dir === "/project/.claude/skills") {
+          return [{ name: "testing", isDirectory: () => true }];
+        }
+        throw new Error("ENOENT");
+      });
+      readFile.mockResolvedValue("Testing guidelines");
+
+      const result = await loadAvailableSkills("/project");
+
+      expect(result).toEqual([{ name: "testing", content: "Testing guidelines" }]);
+    });
+
+    it("reads from both directories and merges results", async () => {
+      readdir.mockImplementation(async (dir) => {
+        if (dir === "/project/.agent/skills") {
+          return [{ name: "react", isDirectory: () => true }];
+        }
+        if (dir === "/project/.claude/skills") {
+          return [{ name: "testing", isDirectory: () => true }];
+        }
+        throw new Error("ENOENT");
+      });
+      readFile.mockImplementation(async (path) => {
+        if (path.includes("react")) return "React content";
+        if (path.includes("testing")) return "Testing content";
+        throw new Error("ENOENT");
+      });
+
+      const result = await loadAvailableSkills("/project");
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ name: "react", content: "React content" });
+      expect(result[1]).toEqual({ name: "testing", content: "Testing content" });
+    });
+
+    it("skips entries that are not directories", async () => {
+      readdir.mockImplementation(async (dir) => {
+        if (dir === "/project/.agent/skills") {
+          return [
+            { name: "README.md", isDirectory: () => false },
+            { name: "react", isDirectory: () => true }
+          ];
+        }
+        throw new Error("ENOENT");
+      });
+      readFile.mockResolvedValue("React content");
+
+      const result = await loadAvailableSkills("/project");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("react");
+    });
+
+    it("skips subdirectories without SKILL.md", async () => {
+      readdir.mockImplementation(async (dir) => {
+        if (dir === "/project/.agent/skills") {
+          return [{ name: "empty-skill", isDirectory: () => true }];
+        }
+        throw new Error("ENOENT");
+      });
+      readFile.mockRejectedValue(new Error("ENOENT"));
+
+      const result = await loadAvailableSkills("/project");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("buildSkillSection", () => {
+    it("returns empty string for empty array", () => {
+      expect(buildSkillSection([])).toBe("");
+    });
+
+    it("returns empty string for null/undefined", () => {
+      expect(buildSkillSection(null)).toBe("");
+      expect(buildSkillSection(undefined)).toBe("");
+    });
+
+    it("builds section for one skill", () => {
+      const section = buildSkillSection([{ name: "react", content: "React rules" }]);
+
+      expect(section).toContain("## Domain Skills");
+      expect(section).toContain("### react");
+      expect(section).toContain("React rules");
+    });
+
+    it("builds section for multiple skills in order", () => {
+      const section = buildSkillSection([
+        { name: "react", content: "React rules" },
+        { name: "testing", content: "Test guidelines" }
+      ]);
+
+      expect(section).toContain("### react");
+      expect(section).toContain("### testing");
+      const reactIdx = section.indexOf("### react");
+      const testIdx = section.indexOf("### testing");
+      expect(reactIdx).toBeLessThan(testIdx);
+    });
+  });
+});
+
+describe("skill injection into prompts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("coder prompt unchanged when no skills directory exists", async () => {
+    readdir.mockRejectedValue(new Error("ENOENT"));
+
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    const prompt = await buildCoderPrompt({ task: "Do something", projectDir: "/project" });
+
+    expect(prompt).toContain("Do something");
+    expect(prompt).not.toContain("Domain Skills");
+  });
+
+  it("coder prompt includes skill content when skills exist", async () => {
+    readdir.mockImplementation(async (dir) => {
+      if (dir === "/project/.agent/skills") {
+        return [{ name: "react", isDirectory: () => true }];
+      }
+      throw new Error("ENOENT");
+    });
+    readFile.mockResolvedValue("Use functional components");
+
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    const prompt = await buildCoderPrompt({ task: "Build UI", projectDir: "/project" });
+
+    expect(prompt).toContain("## Domain Skills");
+    expect(prompt).toContain("### react");
+    expect(prompt).toContain("Use functional components");
+  });
+
+  it("reviewer prompt includes skill content when skills exist", async () => {
+    readdir.mockImplementation(async (dir) => {
+      if (dir === "/project/.agent/skills") {
+        return [{ name: "security", isDirectory: () => true }];
+      }
+      throw new Error("ENOENT");
+    });
+    readFile.mockResolvedValue("Always validate input");
+
+    const { buildReviewerPrompt } = await import("../src/prompts/reviewer.js");
+    const prompt = await buildReviewerPrompt({
+      task: "Review code",
+      diff: "some diff",
+      reviewRules: "be strict",
+      mode: "standard",
+      projectDir: "/project"
+    });
+
+    expect(prompt).toContain("## Domain Skills");
+    expect(prompt).toContain("### security");
+    expect(prompt).toContain("Always validate input");
+  });
+
+  it("architect prompt includes skill content when skills exist", async () => {
+    readdir.mockImplementation(async (dir) => {
+      if (dir === "/project/.agent/skills") {
+        return [{ name: "aws", isDirectory: () => true }];
+      }
+      throw new Error("ENOENT");
+    });
+    readFile.mockResolvedValue("Use Lambda for compute");
+
+    const { buildArchitectPrompt } = await import("../src/prompts/architect.js");
+    const prompt = await buildArchitectPrompt({
+      task: "Design infra",
+      instructions: "Follow best practices",
+      projectDir: "/project"
+    });
+
+    expect(prompt).toContain("## Domain Skills");
+    expect(prompt).toContain("### aws");
+    expect(prompt).toContain("Use Lambda for compute");
+  });
+
+  it("prompts unchanged when projectDir is null", async () => {
+    const { buildCoderPrompt } = await import("../src/prompts/coder.js");
+    const prompt = await buildCoderPrompt({ task: "Do something" });
+
+    expect(prompt).toContain("Do something");
+    expect(prompt).not.toContain("Domain Skills");
+    expect(readdir).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/skills/skill-loader.js`: loads skills from `.agent/skills/` and `.claude/skills/`
- Prompt builders (coder, reviewer, architect) now async, inject skill content when available
- Backward compatible: no skills = no change
- 15 new tests (2219 total)

Closes KJC-TSK-0198

## Test plan
- [x] 175 files, 2219 tests pass
- [ ] CI green