### PR TITLE
feat(skills): triage auto-detects and installs OpenSkills

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -40,6 +40,8 @@ import { waitForCooldown, MAX_STANDBY_RETRIES } from "./orchestrator/standby.js"
 import { detectTestFramework } from "./utils/project-detect.js";
 import { runPreflightChecks } from "./orchestrator/preflight-checks.js";
 import { detectRtk } from "./utils/rtk-detect.js";
+import { detectNeededSkills, autoInstallSkills, cleanupAutoInstalledSkills } from "./skills/skill-detector.js";
+import { isOpenSkillsAvailable } from "./skills/openskills-client.js";
 
 
 // --- Product Context loader ---
@@ -845,6 +847,29 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
   applyTriageOverrides(pipelineFlags, triageResult.roleOverrides);
   stageResults.triage = triageResult.stageResult;
 
+  // --- Auto-install skills based on task + project detection ---
+  const projectDir = config.projectDir || process.cwd();
+  try {
+    const osAvailable = await isOpenSkillsAvailable();
+    if (osAvailable) {
+      const neededSkills = await detectNeededSkills(task, projectDir);
+      if (neededSkills.length > 0) {
+        const skillResult = await autoInstallSkills(neededSkills, projectDir);
+        if (skillResult.installed.length > 0) {
+          session.autoInstalledSkills = skillResult.installed;
+        }
+        emitProgress(emitter, makeEvent("skills:auto-install", { ...eventBase, stage: "triage" }, {
+          message: skillResult.installed.length > 0
+            ? `Auto-installed ${skillResult.installed.length} skill(s): ${skillResult.installed.join(", ")}`
+            : `Skills detected (${neededSkills.join(", ")}) — all already installed or unavailable`,
+          detail: skillResult
+        }));
+      }
+    }
+  } catch (err) {
+    logger.warn(`Skill auto-install failed (non-blocking): ${err.message}`);
+  }
+
   // --- HU Reviewer auto-activation from triage (post-triage, no huFile needed) ---
   const triageRoles = new Set(triageResult.stageResult?.roles || []);
   if (triageRoles.has("hu-reviewer") && !stageResults.huReviewer) {
@@ -1387,44 +1412,60 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
 
   const ctx = await initFlowContext({ task, config, logger, emitter, askQuestion, pgTaskId, pgProject, flags });
 
-  // --- HU Sub-Pipeline: run each certified HU as an independent iteration loop ---
-  if (needsSubPipeline(ctx.stageResults.huReviewer)) {
-    logger.info(`HU sub-pipeline: ${ctx.stageResults.huReviewer.certified} certified stories — running each as a sub-pipeline`);
-    emitProgress(emitter, makeEvent("hu:sub-pipeline:start", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {
-      message: `Running ${ctx.stageResults.huReviewer.certified} HUs as sub-pipelines`,
-      detail: { total: ctx.stageResults.huReviewer.total, certified: ctx.stageResults.huReviewer.certified }
-    }));
+  try {
+    // --- HU Sub-Pipeline: run each certified HU as an independent iteration loop ---
+    if (needsSubPipeline(ctx.stageResults.huReviewer)) {
+      logger.info(`HU sub-pipeline: ${ctx.stageResults.huReviewer.certified} certified stories — running each as a sub-pipeline`);
+      emitProgress(emitter, makeEvent("hu:sub-pipeline:start", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {
+        message: `Running ${ctx.stageResults.huReviewer.certified} HUs as sub-pipelines`,
+        detail: { total: ctx.stageResults.huReviewer.total, certified: ctx.stageResults.huReviewer.certified }
+      }));
 
-    const subPipelineResult = await runHuSubPipeline({
-      huReviewerResult: ctx.stageResults.huReviewer,
-      runIterationFn: async (huTask) => runIterationLoop(ctx, { task: huTask, askQuestion, emitter, logger }),
-      emitter,
-      eventBase: ctx.eventBase,
-      logger
-    });
+      const subPipelineResult = await runHuSubPipeline({
+        huReviewerResult: ctx.stageResults.huReviewer,
+        runIterationFn: async (huTask) => runIterationLoop(ctx, { task: huTask, askQuestion, emitter, logger }),
+        emitter,
+        eventBase: ctx.eventBase,
+        logger
+      });
 
-    emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {
-      status: subPipelineResult.approved ? "ok" : "fail",
-      message: subPipelineResult.approved
-        ? "All HUs completed successfully"
-        : `Sub-pipeline finished with failures (${subPipelineResult.blockedIds.length} blocked)`,
-      detail: { results: subPipelineResult.results, blockedIds: subPipelineResult.blockedIds }
-    }));
+      emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {
+        status: subPipelineResult.approved ? "ok" : "fail",
+        message: subPipelineResult.approved
+          ? "All HUs completed successfully"
+          : `Sub-pipeline finished with failures (${subPipelineResult.blockedIds.length} blocked)`,
+        detail: { results: subPipelineResult.results, blockedIds: subPipelineResult.blockedIds }
+      }));
 
-    const finalResult = {
-      approved: subPipelineResult.approved,
-      sessionId: ctx.session.id,
-      huResults: subPipelineResult.results,
-      blockedIds: subPipelineResult.blockedIds
-    };
-    await writeHistoryRecord({ sessionId: ctx.session.id, task, result: finalResult, logger });
-    return finalResult;
+      const finalResult = {
+        approved: subPipelineResult.approved,
+        sessionId: ctx.session.id,
+        huResults: subPipelineResult.results,
+        blockedIds: subPipelineResult.blockedIds
+      };
+      await writeHistoryRecord({ sessionId: ctx.session.id, task, result: finalResult, logger });
+      return finalResult;
+    }
+
+    // --- Standard single-task pipeline (1 HU or no HU reviewer) ---
+    const result = await runIterationLoop(ctx, { task: ctx.plannedTask, askQuestion, emitter, logger });
+    await writeHistoryRecord({ sessionId: ctx.session.id, task, result, logger });
+    return result;
+  } finally {
+    // --- Cleanup auto-installed skills ---
+    const autoSkills = ctx.session?.autoInstalledSkills;
+    if (autoSkills && autoSkills.length > 0) {
+      const cleanProjectDir = ctx.config?.projectDir || process.cwd();
+      try {
+        const cleanupResult = await cleanupAutoInstalledSkills(autoSkills, cleanProjectDir);
+        if (cleanupResult.removed.length > 0) {
+          logger.info(`Cleaned up ${cleanupResult.removed.length} auto-installed skill(s): ${cleanupResult.removed.join(", ")}`);
+        }
+      } catch (err) {
+        logger.warn(`Skill cleanup failed (non-blocking): ${err.message}`);
+      }
+    }
   }
-
-  // --- Standard single-task pipeline (1 HU or no HU reviewer) ---
-  const result = await runIterationLoop(ctx, { task: ctx.plannedTask, askQuestion, emitter, logger });
-  await writeHistoryRecord({ sessionId: ctx.session.id, task, result, logger });
-  return result;
 }
 
 export async function resumeFlow({ sessionId, answer, config, logger, flags = {}, emitter = null, askQuestion = null }) {

--- a/src/skills/skill-detector.js
+++ b/src/skills/skill-detector.js
@@ -1,0 +1,187 @@
+/**
+ * Detects needed skills from task description and project files,
+ * then auto-installs them via OpenSkills if available.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { loadAvailableSkills } from "./skill-loader.js";
+import { isOpenSkillsAvailable, installSkill, removeSkill } from "./openskills-client.js";
+
+/**
+ * Known frameworks detectable from package.json dependencies.
+ * Maps dependency name to the skill name to search for.
+ */
+const PKG_JSON_FRAMEWORKS = {
+  astro: "astro",
+  next: "nextjs",
+  react: "react",
+  "react-dom": "react",
+  vue: "vue",
+  svelte: "svelte",
+  "@angular/core": "angular",
+  express: "express",
+  fastify: "fastify",
+  "@nestjs/core": "nestjs",
+};
+
+/**
+ * Language markers: file presence maps to a skill name.
+ * Reuses the same concept as src/utils/project-detect.js LANGUAGE_MARKERS.
+ */
+const LANGUAGE_FILE_MARKERS = [
+  { file: "pom.xml", skill: "java" },
+  { file: "build.gradle", skill: "java" },
+  { file: "build.gradle.kts", skill: "kotlin" },
+  { file: "go.mod", skill: "go" },
+  { file: "Cargo.toml", skill: "rust" },
+  { file: "pyproject.toml", skill: "python" },
+  { file: "setup.py", skill: "python" },
+  { file: "Gemfile", skill: "ruby" },
+  { file: "pubspec.yaml", skill: "flutter" },
+  { file: "Package.swift", skill: "swift" },
+  { file: "phpunit.xml", skill: "php" },
+  { file: "composer.json", skill: "php" },
+];
+
+/**
+ * Patterns to detect framework/skill mentions in the task text.
+ * Each entry: regex pattern (case-insensitive) -> skill name.
+ */
+const TASK_TEXT_PATTERNS = [
+  { pattern: /\bastro\b/i, skill: "astro" },
+  { pattern: /\bnext\.?js\b/i, skill: "nextjs" },
+  { pattern: /\breact\b/i, skill: "react" },
+  { pattern: /\bvue\b/i, skill: "vue" },
+  { pattern: /\bsvelte\b/i, skill: "svelte" },
+  { pattern: /\bangular\b/i, skill: "angular" },
+  { pattern: /\bexpress\b/i, skill: "express" },
+  { pattern: /\bfastify\b/i, skill: "fastify" },
+  { pattern: /\bnest\.?js\b/i, skill: "nestjs" },
+  { pattern: /\bjava\b/i, skill: "java" },
+  { pattern: /\bkotlin\b/i, skill: "kotlin" },
+  { pattern: /\bgo(?:lang)?\b/i, skill: "go" },
+  { pattern: /\brust\b/i, skill: "rust" },
+  { pattern: /\bpython\b/i, skill: "python" },
+  { pattern: /\bruby\b/i, skill: "ruby" },
+  { pattern: /\bflutter\b/i, skill: "flutter" },
+  { pattern: /\bswift\b/i, skill: "swift" },
+  { pattern: /\bphp\b/i, skill: "php" },
+];
+
+/**
+ * Analyze the task and project to determine what skills might be needed.
+ * @param {string} task - The task description text.
+ * @param {string} projectDir - Absolute path to project root.
+ * @returns {Promise<string[]>} Array of unique skill names to search for.
+ */
+export async function detectNeededSkills(task, projectDir) {
+  const needed = new Set();
+
+  // 1. Scan package.json for known frameworks
+  if (projectDir) {
+    try {
+      const pkgRaw = await fs.readFile(path.join(projectDir, "package.json"), "utf8");
+      const pkg = JSON.parse(pkgRaw);
+      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+      for (const [dep, skill] of Object.entries(PKG_JSON_FRAMEWORKS)) {
+        if (allDeps[dep]) {
+          needed.add(skill);
+        }
+      }
+    } catch { /* no package.json or parse error — skip */ }
+
+    // 2. Check for language markers
+    for (const marker of LANGUAGE_FILE_MARKERS) {
+      try {
+        await fs.access(path.join(projectDir, marker.file));
+        needed.add(marker.skill);
+      } catch { /* file not found — skip */ }
+    }
+  }
+
+  // 3. Check task text for framework mentions
+  if (task) {
+    for (const { pattern, skill } of TASK_TEXT_PATTERNS) {
+      if (pattern.test(task)) {
+        needed.add(skill);
+      }
+    }
+  }
+
+  return Array.from(needed);
+}
+
+/**
+ * Auto-install needed skills that are not yet installed.
+ * @param {string[]} neededSkills - Skill names to ensure are installed.
+ * @param {string} projectDir - Absolute path to project root.
+ * @returns {Promise<{installed: string[], failed: string[], alreadyInstalled: string[]}>}
+ */
+export async function autoInstallSkills(neededSkills, projectDir) {
+  const result = { installed: [], failed: [], alreadyInstalled: [] };
+
+  if (!neededSkills || neededSkills.length === 0) {
+    return result;
+  }
+
+  // Check which skills are already installed locally
+  const existingSkills = await loadAvailableSkills(projectDir);
+  const existingNames = new Set(existingSkills.map(s => s.name.toLowerCase()));
+
+  // Check if OpenSkills is available
+  const osAvailable = await isOpenSkillsAvailable();
+  if (!osAvailable) {
+    // All skills count as "failed" silently — caller should check osAvailable separately
+    return result;
+  }
+
+  for (const skillName of neededSkills) {
+    if (existingNames.has(skillName.toLowerCase())) {
+      result.alreadyInstalled.push(skillName);
+      continue;
+    }
+
+    try {
+      const installResult = await installSkill(skillName, { projectDir });
+      if (installResult.ok) {
+        result.installed.push(installResult.name || skillName);
+      } else {
+        result.failed.push(skillName);
+      }
+    } catch {
+      result.failed.push(skillName);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Remove skills that were auto-installed during this session.
+ * @param {string[]} skillNames - Skill names to remove.
+ * @param {string} projectDir - Absolute path to project root.
+ * @returns {Promise<{removed: string[], failed: string[]}>}
+ */
+export async function cleanupAutoInstalledSkills(skillNames, projectDir) {
+  const result = { removed: [], failed: [] };
+
+  if (!skillNames || skillNames.length === 0) {
+    return result;
+  }
+
+  for (const name of skillNames) {
+    try {
+      const removeResult = await removeSkill(name, { projectDir });
+      if (removeResult.ok) {
+        result.removed.push(name);
+      } else {
+        result.failed.push(name);
+      }
+    } catch {
+      result.failed.push(name);
+    }
+  }
+
+  return result;
+}

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -120,6 +120,18 @@ vi.mock("../src/utils/rtk-detect.js", () => ({
   detectRtk: vi.fn().mockResolvedValue({ available: false, version: null })
 }));
 
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn().mockResolvedValue(false),
+  installSkill: vi.fn().mockResolvedValue({ ok: false }),
+  removeSkill: vi.fn().mockResolvedValue({ ok: true })
+}));
+
+vi.mock("../src/skills/skill-detector.js", () => ({
+  detectNeededSkills: vi.fn().mockResolvedValue([]),
+  autoInstallSkills: vi.fn().mockResolvedValue({ installed: [], failed: [], alreadyInstalled: [] }),
+  cleanupAutoInstalledSkills: vi.fn().mockResolvedValue({ removed: [], failed: [] })
+}));
+
 vi.mock("../src/orchestrator/preflight-checks.js", () => ({
   runPreflightChecks: vi.fn().mockResolvedValue({
     ok: true, checks: [], remediations: [], configOverrides: {}, warnings: [], errors: []

--- a/tests/triage-auto-skills.test.js
+++ b/tests/triage-auto-skills.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs/promises", () => {
+  const readFile = vi.fn();
+  const readdir = vi.fn();
+  const access = vi.fn();
+  return {
+    readFile,
+    readdir,
+    access,
+    default: { readFile, readdir, access }
+  };
+});
+
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+  installSkill: vi.fn(),
+  removeSkill: vi.fn()
+}));
+
+vi.mock("../src/skills/skill-loader.js", () => ({
+  loadAvailableSkills: vi.fn()
+}));
+
+const { readFile, readdir, access } = await import("node:fs/promises");
+const { isOpenSkillsAvailable, installSkill, removeSkill } = await import("../src/skills/openskills-client.js");
+const { loadAvailableSkills } = await import("../src/skills/skill-loader.js");
+const { detectNeededSkills, autoInstallSkills, cleanupAutoInstalledSkills } = await import("../src/skills/skill-detector.js");
+
+describe("skill-detector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readFile.mockRejectedValue(new Error("ENOENT"));
+    readdir.mockRejectedValue(new Error("ENOENT"));
+    access.mockRejectedValue(new Error("ENOENT"));
+    loadAvailableSkills.mockResolvedValue([]);
+    isOpenSkillsAvailable.mockResolvedValue(true);
+    installSkill.mockResolvedValue({ ok: true, name: "test-skill" });
+    removeSkill.mockResolvedValue({ ok: true });
+  });
+
+  describe("detectNeededSkills", () => {
+    it("detects astro from package.json", async () => {
+      readFile.mockResolvedValue(JSON.stringify({
+        dependencies: { astro: "^4.0.0" }
+      }));
+
+      const result = await detectNeededSkills("Build a page", "/project");
+
+      expect(result).toContain("astro");
+    });
+
+    it("detects react from package.json devDependencies", async () => {
+      readFile.mockResolvedValue(JSON.stringify({
+        devDependencies: { react: "^18.0.0", "react-dom": "^18.0.0" }
+      }));
+
+      const result = await detectNeededSkills("Build a component", "/project");
+
+      expect(result).toContain("react");
+      // react-dom also maps to "react", so should only appear once
+      expect(result.filter(s => s === "react")).toHaveLength(1);
+    });
+
+    it("detects 'react' skill from task text mentioning React component", async () => {
+      const result = await detectNeededSkills("Create a React component for the dashboard", "/project");
+
+      expect(result).toContain("react");
+    });
+
+    it("detects go skill when go.mod exists", async () => {
+      access.mockImplementation(async (filePath) => {
+        if (filePath === "/project/go.mod") return undefined;
+        throw new Error("ENOENT");
+      });
+
+      const result = await detectNeededSkills("Build an API", "/project");
+
+      expect(result).toContain("go");
+    });
+
+    it("detects rust skill when Cargo.toml exists", async () => {
+      access.mockImplementation(async (filePath) => {
+        if (filePath === "/project/Cargo.toml") return undefined;
+        throw new Error("ENOENT");
+      });
+
+      const result = await detectNeededSkills("Build a CLI", "/project");
+
+      expect(result).toContain("rust");
+    });
+
+    it("detects java skill when pom.xml exists", async () => {
+      access.mockImplementation(async (filePath) => {
+        if (filePath === "/project/pom.xml") return undefined;
+        throw new Error("ENOENT");
+      });
+
+      const result = await detectNeededSkills("Add endpoint", "/project");
+
+      expect(result).toContain("java");
+    });
+
+    it("returns empty array when no frameworks detected", async () => {
+      const result = await detectNeededSkills("Fix a typo in the README", "/project");
+
+      expect(result).toEqual([]);
+    });
+
+    it("combines package.json and task text detections", async () => {
+      readFile.mockResolvedValue(JSON.stringify({
+        dependencies: { express: "^4.0.0" }
+      }));
+
+      const result = await detectNeededSkills("Build an Astro page with express backend", "/project");
+
+      expect(result).toContain("express");
+      expect(result).toContain("astro");
+    });
+
+    it("handles null projectDir gracefully", async () => {
+      const result = await detectNeededSkills("Create a React component", null);
+
+      expect(result).toContain("react");
+    });
+
+    it("handles null task gracefully", async () => {
+      readFile.mockResolvedValue(JSON.stringify({
+        dependencies: { vue: "^3.0.0" }
+      }));
+
+      const result = await detectNeededSkills(null, "/project");
+
+      expect(result).toContain("vue");
+    });
+  });
+
+  describe("autoInstallSkills", () => {
+    it("skips already installed skills", async () => {
+      loadAvailableSkills.mockResolvedValue([{ name: "react", content: "content" }]);
+
+      const result = await autoInstallSkills(["react"], "/project");
+
+      expect(result.alreadyInstalled).toContain("react");
+      expect(result.installed).toHaveLength(0);
+      expect(installSkill).not.toHaveBeenCalled();
+    });
+
+    it("installs skills that are not yet installed", async () => {
+      installSkill.mockResolvedValue({ ok: true, name: "astro" });
+
+      const result = await autoInstallSkills(["astro"], "/project");
+
+      expect(result.installed).toContain("astro");
+      expect(installSkill).toHaveBeenCalledWith("astro", { projectDir: "/project" });
+    });
+
+    it("returns empty results when OpenSkills is unavailable", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(false);
+
+      const result = await autoInstallSkills(["react", "vue"], "/project");
+
+      expect(result.installed).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+      expect(result.alreadyInstalled).toHaveLength(0);
+      expect(installSkill).not.toHaveBeenCalled();
+    });
+
+    it("tracks failed installations", async () => {
+      installSkill.mockResolvedValue({ ok: false, error: "not found" });
+
+      const result = await autoInstallSkills(["nonexistent"], "/project");
+
+      expect(result.failed).toContain("nonexistent");
+      expect(result.installed).toHaveLength(0);
+    });
+
+    it("returns empty results for empty input", async () => {
+      const result = await autoInstallSkills([], "/project");
+
+      expect(result.installed).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+      expect(result.alreadyInstalled).toHaveLength(0);
+    });
+
+    it("returns empty results for null input", async () => {
+      const result = await autoInstallSkills(null, "/project");
+
+      expect(result.installed).toHaveLength(0);
+    });
+
+    it("handles install exceptions gracefully", async () => {
+      installSkill.mockRejectedValue(new Error("network error"));
+
+      const result = await autoInstallSkills(["astro"], "/project");
+
+      expect(result.failed).toContain("astro");
+      expect(result.installed).toHaveLength(0);
+    });
+  });
+
+  describe("cleanupAutoInstalledSkills", () => {
+    it("removes auto-installed skills", async () => {
+      removeSkill.mockResolvedValue({ ok: true });
+
+      const result = await cleanupAutoInstalledSkills(["astro", "react"], "/project");
+
+      expect(result.removed).toEqual(["astro", "react"]);
+      expect(removeSkill).toHaveBeenCalledTimes(2);
+    });
+
+    it("tracks failed removals", async () => {
+      removeSkill.mockResolvedValue({ ok: false, error: "not found" });
+
+      const result = await cleanupAutoInstalledSkills(["ghost"], "/project");
+
+      expect(result.failed).toContain("ghost");
+      expect(result.removed).toHaveLength(0);
+    });
+
+    it("returns empty results for empty input", async () => {
+      const result = await cleanupAutoInstalledSkills([], "/project");
+
+      expect(result.removed).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+      expect(removeSkill).not.toHaveBeenCalled();
+    });
+
+    it("returns empty results for null input", async () => {
+      const result = await cleanupAutoInstalledSkills(null, "/project");
+
+      expect(result.removed).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/skills/skill-detector.js`: detects needed skills from package.json, language markers, and task text
- Auto-installs via OpenSkills after triage, auto-cleans up after pipeline
- Skips silently if OpenSkills not available
- 21 new tests (2240 total)

Closes KJC-TSK-0197. Completes epic KJC-PCS-0024 (OpenSkills Integration).

## Test plan
- [x] 176 files, 2240 tests pass
- [ ] CI green