### PR TITLE
feat(hu): lazy HU planning, refine one at a time

### DIFF
--- a/src/hu/lazy-planner.js
+++ b/src/hu/lazy-planner.js
@@ -1,0 +1,104 @@
+/**
+ * Lazy HU Planner — refines HUs one at a time using context from completed HUs.
+ *
+ * Instead of fully planning all HUs upfront, only the first HU is decomposed
+ * with full acceptance criteria. Subsequent HUs are refined lazily before
+ * execution, incorporating learnings from previously completed HUs.
+ */
+import { createAgent } from "../agents/index.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on refining the user story."
+].join(" ");
+
+/**
+ * Build a prompt asking the AI to refine an HU based on context from completed HUs.
+ * @param {object} hu - The HU to refine (with at least id, original.text or certified.text).
+ * @param {Array<object>} completedHus - Array of completed HU results with summaries.
+ * @returns {string} The assembled refinement prompt.
+ */
+export function buildRefinementPrompt(hu, completedHus) {
+  const sections = [SUBAGENT_PREAMBLE];
+
+  sections.push("## HU Refinement");
+  sections.push(
+    "You are a senior product owner. Refine the following user story by adding or updating its acceptance criteria.",
+    "Use the context from previously completed HUs to make the criteria more precise and avoid redundant work."
+  );
+
+  if (completedHus.length > 0) {
+    sections.push("## Previously Completed HUs");
+    for (const completed of completedHus) {
+      const title = completed.certified?.title || completed.id;
+      const summary = completed.resultSummary || completed.certified?.text || completed.original?.text || "No summary available";
+      sections.push(`### ${completed.id} — ${title}\nResult: ${summary}`);
+    }
+  }
+
+  const huText = hu.certified?.text || hu.original?.text || `Implement HU ${hu.id}`;
+  sections.push(`## HU to Refine\n### ${hu.id}\n${huText}`);
+
+  sections.push(
+    "Return a single valid JSON object and nothing else.",
+    `JSON schema: {"id":string,"title":string,"text":string,"acceptanceCriteria":[string]}`,
+    "Rules:",
+    "- Keep the same HU id",
+    "- Refine the description to be more specific based on what was learned",
+    "- Add concrete, testable acceptance criteria",
+    "- Avoid repeating work already done in completed HUs",
+    "- The text field should be the full story description ready for implementation"
+  );
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Refine an HU using AI, incorporating context from completed HUs.
+ * @param {object} hu - The HU story object to refine.
+ * @param {Array<object>} completedHus - Completed HU stories with results.
+ * @param {object} config - Pipeline configuration.
+ * @param {object} logger - Logger instance.
+ * @returns {Promise<object>} Updated HU object with refined description and AC.
+ */
+export async function refineHuWithContext(hu, completedHus, config, logger) {
+  const provider = config?.roles?.hu_reviewer?.provider || config?.roles?.coder?.provider || "claude";
+  const prompt = buildRefinementPrompt(hu, completedHus);
+
+  logger.info(`Lazy planner: refining HU ${hu.id} with context from ${completedHus.length} completed HU(s)`);
+
+  const agent = createAgent(provider, config, logger);
+  let result;
+  try {
+    result = await agent.runTask({ prompt, role: "hu-reviewer" });
+  } catch (err) {
+    logger.warn(`Lazy planner: refinement failed for HU ${hu.id}: ${err.message}`);
+    return hu;
+  }
+
+  if (!result.ok) {
+    logger.warn(`Lazy planner: refinement returned not-ok for HU ${hu.id}`);
+    return hu;
+  }
+
+  const parsed = extractFirstJson(result.output);
+  if (!parsed || !parsed.text) {
+    logger.warn(`Lazy planner: could not parse refinement output for HU ${hu.id}`);
+    return hu;
+  }
+
+  // Update the HU with refined content
+  const refined = { ...hu };
+  refined.certified = {
+    ...(hu.certified || {}),
+    text: parsed.text,
+    title: parsed.title || hu.certified?.title || hu.id,
+    acceptanceCriteria: parsed.acceptanceCriteria || []
+  };
+  refined.needsRefinement = false;
+
+  logger.info(`Lazy planner: HU ${hu.id} refined successfully`);
+  return refined;
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -1426,7 +1426,8 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
         runIterationFn: async (huTask) => runIterationLoop(ctx, { task: huTask, askQuestion, emitter, logger }),
         emitter,
         eventBase: ctx.eventBase,
-        logger
+        logger,
+        config: ctx.config
       });
 
       emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -5,6 +5,7 @@
 import { topologicalSort } from "../hu/graph.js";
 import { updateStoryStatus, loadHuBatch, saveHuBatch, HU_STATUS } from "../hu/store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
+import { refineHuWithContext } from "../hu/lazy-planner.js";
 
 /**
  * Determine whether the HU reviewer result requires a sub-pipeline
@@ -72,7 +73,7 @@ function buildHuTask(story) {
  * @param {object} params.logger - Logger instance
  * @returns {Promise<{approved: boolean, results: object[], blockedIds: string[]}>}
  */
-export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger }) {
+export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null }) {
   const batchSessionId = huReviewerResult.batchSessionId;
   let batch;
   try {
@@ -106,6 +107,40 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
     if (story.status === HU_STATUS.BLOCKED) {
       blockedIds.push(story.id);
       continue;
+    }
+
+    // --- Lazy refinement: refine HU if it needs it, using completed HU context ---
+    if (story.needsRefinement && config) {
+      const completedHus = results
+        .filter(r => r.approved)
+        .map(r => {
+          const completedStory = batch.stories.find(s => s.id === r.huId);
+          return {
+            ...completedStory,
+            resultSummary: r.result?.summary || r.result?.reason || null
+          };
+        });
+
+      emitProgress(emitter, makeEvent("hu:refine-start", { ...eventBase, stage: "hu-sub-pipeline" }, {
+        message: `Refining HU ${story.id} with context from ${completedHus.length} completed HU(s)`,
+        detail: { huId: story.id, completedCount: completedHus.length }
+      }));
+
+      try {
+        const refined = await refineHuWithContext(story, completedHus, config, logger);
+        // Apply refinement to the batch story in-place
+        Object.assign(story, refined);
+        story.needsRefinement = false;
+        await saveHuBatch(batchSessionId, batch);
+
+        emitProgress(emitter, makeEvent("hu:refine-end", { ...eventBase, stage: "hu-sub-pipeline" }, {
+          message: `HU ${story.id} refined successfully`,
+          detail: { huId: story.id }
+        }));
+      } catch (err) {
+        logger.warn(`Lazy refinement failed for HU ${story.id}: ${err.message} — proceeding with original`);
+        story.needsRefinement = false;
+      }
     }
 
     const huTask = buildHuTask(story);

--- a/src/orchestrator/pre-loop-stages.js
+++ b/src/orchestrator/pre-loop-stages.js
@@ -646,11 +646,17 @@ export async function runHuReviewerStage({ config, logger, emitter, eventBase, s
       config, logger, emitter, eventBase, session, coderRole, trackBudget
     });
     if (decomposed && decomposed.length > 1) {
-      stories = decomposed.map(hu => ({
-        id: hu.id,
-        text: `As a ${hu.role}, I want to ${hu.goal}, so that ${hu.benefit}\n\nTitle: ${hu.title}\nAcceptance Criteria:\n${hu.acceptanceCriteria.map(ac => `- ${ac}`).join("\n")}`,
-        blocked_by: hu.dependsOn || []
-      }));
+      stories = decomposed.map((hu, idx) => {
+        const isFirst = idx === 0;
+        const fullText = `As a ${hu.role}, I want to ${hu.goal}, so that ${hu.benefit}\n\nTitle: ${hu.title}\nAcceptance Criteria:\n${hu.acceptanceCriteria.map(ac => `- ${ac}`).join("\n")}`;
+        const skeletonText = `As a ${hu.role}, I want to ${hu.goal}, so that ${hu.benefit}\n\nTitle: ${hu.title}`;
+        return {
+          id: hu.id,
+          text: isFirst ? fullText : skeletonText,
+          blocked_by: hu.dependsOn || [],
+          needsRefinement: !isFirst
+        };
+      });
     } else {
       stories = [{ id: "HU-AUTO-001", text: session.task }];
     }

--- a/tests/lazy-hu-planning.test.js
+++ b/tests/lazy-hu-planning.test.js
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// --- Mocks ---
+
+const saveHuBatchMock = vi.fn(async () => {});
+const loadHuBatchMock = vi.fn();
+const updateStoryStatusMock = vi.fn((batch, storyId, status) => {
+  const story = batch.stories.find(s => s.id === storyId);
+  if (!story) throw new Error(`Story ${storyId} not found`);
+  story.status = status;
+  return story;
+});
+
+vi.mock("../src/hu/store.js", () => ({
+  HU_STATUS: Object.freeze({
+    PENDING: "pending",
+    CODING: "coding",
+    REVIEWING: "reviewing",
+    DONE: "done",
+    FAILED: "failed",
+    BLOCKED: "blocked",
+    CERTIFIED: "certified",
+    NEEDS_CONTEXT: "needs_context"
+  }),
+  loadHuBatch: (...args) => loadHuBatchMock(...args),
+  saveHuBatch: (...args) => saveHuBatchMock(...args),
+  updateStoryStatus: (...args) => updateStoryStatusMock(...args)
+}));
+
+vi.mock("../src/hu/graph.js", () => ({
+  topologicalSort: vi.fn((stories) => stories.map(s => s.id))
+}));
+
+const refineHuWithContextMock = vi.fn();
+
+vi.mock("../src/hu/lazy-planner.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    refineHuWithContext: (...args) => refineHuWithContextMock(...args),
+  };
+});
+
+const { runHuSubPipeline } = await import("../src/orchestrator/hu-sub-pipeline.js");
+const { buildRefinementPrompt } = await import("../src/hu/lazy-planner.js");
+
+describe("lazy-hu-planning", () => {
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    setContext: vi.fn(), resetContext: vi.fn()
+  };
+
+  let emitter;
+  let eventBase;
+  let events;
+
+  const config = {
+    roles: {
+      hu_reviewer: { provider: "claude" },
+      coder: { provider: "claude" }
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitter = new EventEmitter();
+    eventBase = { sessionId: "s_lazy_test", iteration: 0, stage: null, startedAt: Date.now() };
+    events = [];
+    emitter.on("progress", (evt) => events.push(evt));
+  });
+
+  describe("first HU has full AC, second has needsRefinement: true", () => {
+    it("first HU is not refined, second HU triggers refinement", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "Setup base\n\nAcceptance Criteria:\n- Base is set up" },
+          original: { text: "Setup base" },
+          blocked_by: [],
+          needsRefinement: false
+        },
+        {
+          id: "HU-002", status: "certified",
+          certified: { text: "Build feature" },
+          original: { text: "Build feature" },
+          blocked_by: [],
+          needsRefinement: true
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      refineHuWithContextMock.mockResolvedValue({
+        ...stories[1],
+        certified: { text: "Build feature with refined AC", title: "Build feature", acceptanceCriteria: ["Feature works"] },
+        needsRefinement: false
+      });
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger,
+        config
+      });
+
+      // refineHuWithContext should only be called for HU-002 (needsRefinement: true)
+      expect(refineHuWithContextMock).toHaveBeenCalledTimes(1);
+      expect(refineHuWithContextMock.mock.calls[0][0].id).toBe("HU-002");
+    });
+  });
+
+  describe("refineHuWithContext includes completed HU results in prompt", () => {
+    it("passes completed HU data to refinement function", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "Setup base", title: "Setup" },
+          original: { text: "Setup base" },
+          blocked_by: [],
+          needsRefinement: false
+        },
+        {
+          id: "HU-002", status: "certified",
+          certified: { text: "Build feature" },
+          original: { text: "Build feature" },
+          blocked_by: [],
+          needsRefinement: true
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      refineHuWithContextMock.mockImplementation(async (hu) => ({
+        ...hu,
+        certified: { text: "Refined feature", acceptanceCriteria: ["Works"] },
+        needsRefinement: false
+      }));
+
+      const runIterationFn = vi.fn(async () => ({ approved: true, summary: "Completed successfully" }));
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger,
+        config
+      });
+
+      // The second call to refineHuWithContext should include completed HU-001 in completedHus
+      const completedHusArg = refineHuWithContextMock.mock.calls[0][1];
+      expect(completedHusArg).toHaveLength(1);
+      expect(completedHusArg[0].id).toBe("HU-001");
+    });
+  });
+
+  describe("buildRefinementPrompt contains previous HU summaries", () => {
+    it("includes completed HU details in the prompt", () => {
+      const hu = {
+        id: "HU-002",
+        original: { text: "Build feature X" },
+        certified: { text: "Build feature X" }
+      };
+
+      const completedHus = [
+        {
+          id: "HU-001",
+          certified: { text: "Setup base config", title: "Setup Base" },
+          original: { text: "Setup base" },
+          resultSummary: "Base configuration completed with all defaults"
+        }
+      ];
+
+      const prompt = buildRefinementPrompt(hu, completedHus);
+
+      expect(prompt).toContain("HU-001");
+      expect(prompt).toContain("Setup Base");
+      expect(prompt).toContain("Base configuration completed with all defaults");
+      expect(prompt).toContain("HU-002");
+      expect(prompt).toContain("Build feature X");
+      expect(prompt).toContain("Previously Completed HUs");
+    });
+
+    it("generates prompt without completed HUs section when none provided", () => {
+      const hu = {
+        id: "HU-001",
+        original: { text: "First story" },
+        certified: null
+      };
+
+      const prompt = buildRefinementPrompt(hu, []);
+
+      expect(prompt).toContain("HU-001");
+      expect(prompt).toContain("First story");
+      expect(prompt).not.toContain("Previously Completed HUs");
+    });
+  });
+
+  describe("single HU task: no refinement needed", () => {
+    it("does not call refineHuWithContext for a single HU without needsRefinement", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "Single task" },
+          original: { text: "Single task" },
+          blocked_by: [],
+          needsRefinement: false
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger,
+        config
+      });
+
+      expect(refineHuWithContextMock).not.toHaveBeenCalled();
+      expect(runIterationFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call refineHuWithContext when config is null", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "Task" },
+          original: { text: "Task" },
+          blocked_by: [],
+          needsRefinement: true
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger
+        // config omitted — defaults to null
+      });
+
+      expect(refineHuWithContextMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("refinement updates the HU in the batch", () => {
+    it("after refinement, the coder receives the refined task description", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "Setup base" },
+          original: { text: "Setup base" },
+          blocked_by: [],
+          needsRefinement: false
+        },
+        {
+          id: "HU-002", status: "certified",
+          certified: { text: "Skeleton description" },
+          original: { text: "Build feature" },
+          blocked_by: [],
+          needsRefinement: true
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      refineHuWithContextMock.mockImplementation(async (hu) => ({
+        ...hu,
+        certified: { text: "Fully refined feature description with detailed AC", title: "Feature" },
+        needsRefinement: false
+      }));
+
+      const tasksReceived = [];
+      const runIterationFn = vi.fn(async (task) => {
+        tasksReceived.push(task);
+        return { approved: true };
+      });
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger,
+        config
+      });
+
+      // First HU gets original text, second gets refined text
+      expect(tasksReceived[0]).toBe("Setup base");
+      expect(tasksReceived[1]).toBe("Fully refined feature description with detailed AC");
+
+      // Batch should have been saved after refinement (extra save)
+      // Saves: HU-001 coding, HU-001 done, HU-002 refinement, HU-002 coding, HU-002 done = 5
+      expect(saveHuBatchMock.mock.calls.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it("emits hu:refine-start and hu:refine-end events", async () => {
+      const stories = [
+        {
+          id: "HU-001", status: "certified",
+          certified: { text: "First" },
+          original: { text: "First" },
+          blocked_by: [],
+          needsRefinement: false
+        },
+        {
+          id: "HU-002", status: "certified",
+          certified: { text: "Second" },
+          original: { text: "Second" },
+          blocked_by: [],
+          needsRefinement: true
+        }
+      ];
+
+      const batch = { session_id: "hu-s_lazy_test", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      refineHuWithContextMock.mockImplementation(async (hu) => ({
+        ...hu,
+        certified: { text: "Refined" },
+        needsRefinement: false
+      }));
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      await runHuSubPipeline({
+        huReviewerResult: {
+          ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_lazy_test"
+        },
+        runIterationFn,
+        emitter,
+        eventBase,
+        logger,
+        config
+      });
+
+      const refineStartEvents = events.filter(e => e.type === "hu:refine-start");
+      const refineEndEvents = events.filter(e => e.type === "hu:refine-end");
+
+      expect(refineStartEvents).toHaveLength(1);
+      expect(refineStartEvents[0].detail.huId).toBe("HU-002");
+      expect(refineEndEvents).toHaveLength(1);
+      expect(refineEndEvents[0].detail.huId).toBe("HU-002");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/hu/lazy-planner.js`: refines HUs with context from completed ones
- First HU keeps full AC, subsequent get `needsRefinement: true`
- Before each HU executes, AI refines it using results from previous HUs
- Events: `hu:refine-start`, `hu:refine-end`
- 8 new tests (2248 total)

Closes KJC-TSK-0196

## Test plan
- [x] 177 files, 2248 tests pass
- [ ] CI green