### PR TITLE
feat(audit): lean audit measuring basal cost

### DIFF
--- a/src/audit/basal-cost.js
+++ b/src/audit/basal-cost.js
@@ -1,0 +1,190 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFile, execFileSync } from "node:child_process";
+import { getKarajanHome } from "../utils/paths.js";
+
+const SOURCE_EXTENSIONS = new Set([
+  ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".tsx", ".jsx",
+  ".py", ".rb", ".go", ".rs", ".java", ".kt", ".swift", ".c", ".cpp", ".h",
+  ".vue", ".svelte", ".astro", ".php", ".cs", ".sh"
+]);
+
+const EXCLUDE_DIRS = new Set([
+  "node_modules", ".git", "dist", "build", "coverage", ".next",
+  ".nuxt", ".output", "__pycache__", ".cache", ".parcel-cache"
+]);
+
+function slugify(projectDir) {
+  return path.basename(projectDir).replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function walkSourceFiles(dir) {
+  // Use git ls-files for speed (instant vs recursive walk)
+  try {
+    const output = execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], { cwd: dir, encoding: "utf8", timeout: 5000 });
+    return output.trim().split("\n")
+      .filter(f => f && SOURCE_EXTENSIONS.has(path.extname(f)) && !EXCLUDE_DIRS.has(f.split("/")[0]))
+      .map(f => path.join(dir, f));
+  } catch {
+    // Fallback to recursive walk if not a git repo
+    const files = [];
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return files;
+    }
+    for (const entry of entries) {
+      if (EXCLUDE_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...walkSourceFiles(full));
+      } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        files.push(full);
+      }
+    }
+    return files;
+  }
+}
+
+function countLines(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    return content.split("\n").length;
+  } catch {
+    return 0;
+  }
+}
+
+function countDependencies(projectDir) {
+  const pkgPath = path.join(projectDir, "package.json");
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    const deps = Object.keys(pkg.dependencies || {});
+    const devDeps = Object.keys(pkg.devDependencies || {});
+    return { dependencies: deps.length, devDependencies: devDeps.length, total: deps.length + devDeps.length };
+  } catch {
+    return { dependencies: 0, devDependencies: 0, total: 0 };
+  }
+}
+
+function runDepcheck(projectDir) {
+  return new Promise((resolve) => {
+    execFile("npx", ["depcheck", "--json"], { cwd: projectDir, timeout: 30000 }, (err, stdout) => {
+      if (err && !stdout) {
+        resolve({ unused: [], note: "depcheck not available or failed" });
+        return;
+      }
+      try {
+        const result = JSON.parse(stdout);
+        const unused = [
+          ...(result.dependencies || []),
+          ...(result.devDependencies || [])
+        ];
+        resolve({ unused });
+      } catch {
+        resolve({ unused: [], note: "depcheck output not parseable" });
+      }
+    });
+  });
+}
+
+function findDeadExports(sourceFiles) {
+  const exportMap = new Map(); // file -> [exportName]
+  const importedNames = new Set();
+
+  const exportRe = /export\s+(?:default\s+)?(?:function|class|const|let|var|async\s+function)\s+(\w+)/g;
+  const namedExportRe = /export\s*\{([^}]+)\}/g;
+  const importRe = /import\s+\{([^}]+)\}\s+from/g;
+  const defaultImportRe = /import\s+(\w+)\s+from/g;
+
+  for (const file of sourceFiles) {
+    let content;
+    try {
+      content = fs.readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+
+    const exports = [];
+    for (const match of content.matchAll(exportRe)) {
+      exports.push(match[1]);
+    }
+    for (const match of content.matchAll(namedExportRe)) {
+      const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/).pop().trim());
+      exports.push(...names);
+    }
+    if (exports.length > 0) {
+      exportMap.set(file, exports);
+    }
+
+    for (const match of content.matchAll(importRe)) {
+      const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/)[0].trim());
+      for (const name of names) importedNames.add(name);
+    }
+    for (const match of content.matchAll(defaultImportRe)) {
+      importedNames.add(match[1]);
+    }
+  }
+
+  const dead = [];
+  for (const [file, exports] of exportMap) {
+    for (const name of exports) {
+      if (!importedNames.has(name)) {
+        dead.push({ file, name });
+      }
+    }
+  }
+  return dead;
+}
+
+export async function measureBasalCost(projectDir) {
+  const sourceFiles = walkSourceFiles(projectDir);
+  let totalLines = 0;
+  for (const f of sourceFiles) {
+    totalLines += countLines(f);
+  }
+
+  const depInfo = countDependencies(projectDir);
+  const depcheck = await runDepcheck(projectDir);
+  const deadExports = findDeadExports(sourceFiles);
+
+  return {
+    totalLines,
+    totalFiles: sourceFiles.length,
+    dependencies: depInfo,
+    unusedDependencies: depcheck,
+    deadExports
+  };
+}
+
+function auditDir() {
+  return path.join(getKarajanHome(), "audits");
+}
+
+export function loadPreviousAudit(projectDir) {
+  const file = path.join(auditDir(), slugify(projectDir), "latest.json");
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function saveAuditSnapshot(projectDir, metrics) {
+  const dir = path.join(auditDir(), slugify(projectDir));
+  fs.mkdirSync(dir, { recursive: true });
+  const snapshot = { ...metrics, timestamp: new Date().toISOString() };
+  fs.writeFileSync(path.join(dir, "latest.json"), JSON.stringify(snapshot, null, 2));
+  return snapshot;
+}
+
+export function computeGrowthDelta(current, previous) {
+  if (!previous) return null;
+  return {
+    lines: current.totalLines - previous.totalLines,
+    files: current.totalFiles - previous.totalFiles,
+    deps: current.dependencies.total - (previous.dependencies?.total ?? 0),
+    since: previous.timestamp || null
+  };
+}

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -14,7 +14,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -111,6 +111,40 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     'Each finding: {"severity":"critical|high|medium|low","file":string,"line":number,"rule":string,"description":string,"recommendation":string}',
     `Only include dimensions you were asked to analyze: ${activeDimensions.join(", ")}`
   );
+
+  if (basalCost) {
+    const lines = [
+      "## Basal Cost",
+      `- Total source lines: ${basalCost.totalLines}`,
+      `- Total source files: ${basalCost.totalFiles}`,
+      `- Dependencies: ${basalCost.dependencies?.total ?? 0} (${basalCost.dependencies?.dependencies ?? 0} prod + ${basalCost.dependencies?.devDependencies ?? 0} dev)`
+    ];
+    if (basalCost.unusedDependencies?.unused?.length > 0) {
+      lines.push(`- Unused dependencies: ${basalCost.unusedDependencies.unused.join(", ")}`);
+    } else if (basalCost.unusedDependencies?.note) {
+      lines.push(`- Unused dependencies: ${basalCost.unusedDependencies.note}`);
+    }
+    if (basalCost.deadExports?.length > 0) {
+      lines.push(`- Dead exports (exported but never imported): ${basalCost.deadExports.length}`);
+      for (const de of basalCost.deadExports.slice(0, 20)) {
+        lines.push(`  - ${de.name} in ${de.file}`);
+      }
+      if (basalCost.deadExports.length > 20) {
+        lines.push(`  - ... and ${basalCost.deadExports.length - 20} more`);
+      }
+    }
+    if (growthDelta) {
+      lines.push("");
+      lines.push("### Growth since last audit");
+      lines.push(`- Lines: ${growthDelta.lines >= 0 ? "+" : ""}${growthDelta.lines}`);
+      lines.push(`- Files: ${growthDelta.files >= 0 ? "+" : ""}${growthDelta.files}`);
+      lines.push(`- Dependencies: ${growthDelta.deps >= 0 ? "+" : ""}${growthDelta.deps}`);
+      if (growthDelta.since) lines.push(`- Since: ${growthDelta.since}`);
+    }
+    lines.push("");
+    lines.push("Flag if basal cost is growing faster than feature delivery. Recommend elimination of unused code and dependencies.");
+    sections.push(lines.join("\n"));
+  }
 
   if (context) {
     sections.push(`## Context\n${context}`);

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -1,6 +1,7 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
+import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDelta } from "../audit/basal-cost.js";
 
 function resolveProvider(config) {
   return (
@@ -57,7 +58,18 @@ export class AuditRole extends BaseRole {
     const provider = resolveProvider(this.config);
     const agent = this._createAgent(provider, this.config, this.logger);
 
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context });
+    const projectDir = this.config?.projectDir || process.cwd();
+    let basalCost = null;
+    let growthDelta = null;
+    try {
+      basalCost = await measureBasalCost(projectDir);
+      const previous = loadPreviousAudit(projectDir);
+      growthDelta = computeGrowthDelta(basalCost, previous);
+    } catch {
+      // basal cost is best-effort, don't fail the audit
+    }
+
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);
@@ -82,12 +94,18 @@ export class AuditRole extends BaseRole {
         };
       }
 
+      if (basalCost) {
+        try { saveAuditSnapshot(projectDir, basalCost); } catch { /* best-effort */ }
+      }
+
       return {
         ok: true,
         result: {
           summary: parsed.summary,
           dimensions: parsed.dimensions,
           topRecommendations: parsed.topRecommendations,
+          basalCost: basalCost || undefined,
+          growthDelta: growthDelta || undefined,
           provider
         },
         summary: buildSummary(parsed),

--- a/tests/lean-audit.test.js
+++ b/tests/lean-audit.test.js
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  measureBasalCost,
+  loadPreviousAudit,
+  saveAuditSnapshot,
+  computeGrowthDelta
+} from "../src/audit/basal-cost.js";
+
+let tmpDir;
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "kj-lean-audit-"));
+}
+
+beforeEach(() => {
+  tmpDir = makeTmpDir();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("measureBasalCost", () => {
+  it("counts lines and files", async () => {
+    const src = path.join(tmpDir, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, "a.js"), "const a = 1;\nconst b = 2;\n");
+    fs.writeFileSync(path.join(src, "b.js"), "export default 42;\n");
+
+    const metrics = await measureBasalCost(tmpDir);
+
+    expect(metrics.totalFiles).toBe(2);
+    expect(metrics.totalLines).toBeGreaterThanOrEqual(4);
+  });
+
+  it("excludes node_modules", async () => {
+    const src = path.join(tmpDir, "src");
+    const nm = path.join(tmpDir, "node_modules", "pkg");
+    fs.mkdirSync(src);
+    fs.mkdirSync(nm, { recursive: true });
+    fs.writeFileSync(path.join(src, "a.js"), "1\n2\n3\n");
+    fs.writeFileSync(path.join(nm, "x.js"), "should be excluded\n");
+
+    const metrics = await measureBasalCost(tmpDir);
+
+    expect(metrics.totalFiles).toBe(1);
+  });
+
+  it("counts dependencies from package.json", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({
+        dependencies: { foo: "^1.0.0", bar: "^2.0.0" },
+        devDependencies: { baz: "^3.0.0" }
+      })
+    );
+
+    const metrics = await measureBasalCost(tmpDir);
+
+    expect(metrics.dependencies.dependencies).toBe(2);
+    expect(metrics.dependencies.devDependencies).toBe(1);
+    expect(metrics.dependencies.total).toBe(3);
+  });
+
+  it("returns zero deps when no package.json", async () => {
+    const metrics = await measureBasalCost(tmpDir);
+
+    expect(metrics.dependencies.total).toBe(0);
+  });
+});
+
+describe("loadPreviousAudit", () => {
+  it("returns null when no previous audit", () => {
+    const originalEnv = process.env.KJ_HOME;
+    process.env.KJ_HOME = path.join(tmpDir, ".karajan");
+    try {
+      const result = loadPreviousAudit("/fake/project");
+      expect(result).toBeNull();
+    } finally {
+      if (originalEnv === undefined) delete process.env.KJ_HOME;
+      else process.env.KJ_HOME = originalEnv;
+    }
+  });
+});
+
+describe("saveAuditSnapshot + loadPreviousAudit roundtrip", () => {
+  it("saves and loads audit snapshot", () => {
+    const originalEnv = process.env.KJ_HOME;
+    process.env.KJ_HOME = path.join(tmpDir, ".karajan");
+    try {
+      const projectDir = "/fake/my-project";
+      const metrics = {
+        totalLines: 500,
+        totalFiles: 20,
+        dependencies: { dependencies: 5, devDependencies: 3, total: 8 },
+        unusedDependencies: { unused: ["lodash"] },
+        deadExports: []
+      };
+
+      const saved = saveAuditSnapshot(projectDir, metrics);
+      expect(saved.timestamp).toBeDefined();
+      expect(saved.totalLines).toBe(500);
+
+      const loaded = loadPreviousAudit(projectDir);
+      expect(loaded).not.toBeNull();
+      expect(loaded.totalLines).toBe(500);
+      expect(loaded.totalFiles).toBe(20);
+      expect(loaded.dependencies.total).toBe(8);
+      expect(loaded.timestamp).toBe(saved.timestamp);
+    } finally {
+      if (originalEnv === undefined) delete process.env.KJ_HOME;
+      else process.env.KJ_HOME = originalEnv;
+    }
+  });
+});
+
+describe("computeGrowthDelta", () => {
+  it("calculates correct deltas", () => {
+    const current = {
+      totalLines: 600,
+      totalFiles: 25,
+      dependencies: { total: 10 }
+    };
+    const previous = {
+      totalLines: 500,
+      totalFiles: 20,
+      dependencies: { total: 8 },
+      timestamp: "2026-01-01T00:00:00.000Z"
+    };
+
+    const delta = computeGrowthDelta(current, previous);
+
+    expect(delta.lines).toBe(100);
+    expect(delta.files).toBe(5);
+    expect(delta.deps).toBe(2);
+    expect(delta.since).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("returns null with no previous audit", () => {
+    const current = {
+      totalLines: 600,
+      totalFiles: 25,
+      dependencies: { total: 10 }
+    };
+
+    const delta = computeGrowthDelta(current, null);
+
+    expect(delta).toBeNull();
+  });
+
+  it("handles negative deltas", () => {
+    const current = {
+      totalLines: 400,
+      totalFiles: 15,
+      dependencies: { total: 5 }
+    };
+    const previous = {
+      totalLines: 500,
+      totalFiles: 20,
+      dependencies: { total: 8 },
+      timestamp: "2026-01-01T00:00:00.000Z"
+    };
+
+    const delta = computeGrowthDelta(current, previous);
+
+    expect(delta.lines).toBe(-100);
+    expect(delta.files).toBe(-5);
+    expect(delta.deps).toBe(-3);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
       "node_modules/**",
       "packages/**",
       ".claude/**"
-    ]
+    ],
+    testTimeout: 30000
   }
 });


### PR DESCRIPTION
## Summary
- New `src/audit/basal-cost.js`: measures total lines, files, deps, unused deps (depcheck), dead exports
- Saves audit snapshots to `~/.karajan/audits/`, computes growth delta between audits
- Audit prompt includes basal cost section with growth trends
- 9 new tests

Closes KJC-TSK-0195. Completes epic KJC-PCS-0023 (Lean Software Practices).

## Test plan
- [x] All tests pass individually (concurrent timeout on slow machines)
- [ ] CI green