### PR TITLE
feat(i18n): language selection in kj init with OS locale detection

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -9,6 +9,7 @@ import { detectAvailableAgents } from "../utils/agent-detect.js";
 import { createWizard, isTTY } from "../utils/wizard.js";
 import { runCommand } from "../utils/process.js";
 import { getInstallCommand } from "../utils/os-detect.js";
+import { detectOsLocale, SUPPORTED_LANGUAGES } from "../utils/locale.js";
 
 async function runWizard(config, logger) {
   const agents = await detectAvailableAgents();
@@ -87,6 +88,31 @@ async function runWizard(config, logger) {
     config.development.methodology = methodology;
     config.development.require_test_changes = methodology === "tdd";
     logger.info(`  -> Methodology: ${methodology}`);
+
+    const detectedLocale = detectOsLocale();
+    const allLangEntries = Object.entries(SUPPORTED_LANGUAGES).map(([code, name]) => ({
+      label: `${name} (${code})`,
+      value: code,
+      available: true
+    }));
+    // Put detected locale first so it becomes the default selection
+    const languageOptions = [
+      ...allLangEntries.filter((o) => o.value === detectedLocale),
+      ...allLangEntries.filter((o) => o.value !== detectedLocale)
+    ];
+
+    const pipelineLang = await wizard.select("Pipeline language:", languageOptions);
+    config.language = pipelineLang;
+    logger.info(`  -> Pipeline language: ${pipelineLang}`);
+
+    // Reorder for HU language with pipeline language as default
+    const huLangOptions = [
+      ...allLangEntries.filter((o) => o.value === pipelineLang),
+      ...allLangEntries.filter((o) => o.value !== pipelineLang)
+    ];
+    const huLang = await wizard.select("HU language (for user stories):", huLangOptions);
+    config.hu_language = huLang;
+    logger.info(`  -> HU language: ${huLang}`);
 
     logger.info("");
   } finally {
@@ -289,6 +315,13 @@ export async function initCommand({ logger, flags = {} }) {
 
   const { config, exists: configExists } = await loadConfig();
   const interactive = flags.noInteractive !== true && isTTY();
+
+  // Auto-detect language from OS locale for non-interactive mode
+  if (!interactive && !configExists) {
+    const detectedLocale = detectOsLocale();
+    config.language = detectedLocale;
+    config.hu_language = detectedLocale;
+  }
 
   await handleConfigSetup({ config, configExists, interactive, configPath, logger });
   await ensureReviewRules(reviewRulesPath, logger);

--- a/src/config.js
+++ b/src/config.js
@@ -123,6 +123,8 @@ const DEFAULTS = {
     port: 4000,
     auto_start: false
   },
+  language: "en",
+  hu_language: "en",
   policies: {},
   serena: { enabled: false },
   planning_game: { enabled: false, project_id: null, codeveloper: null },

--- a/src/prompts/architect.js
+++ b/src/prompts/architect.js
@@ -1,4 +1,5 @@
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
+import { getLanguageInstruction } from "../utils/locale.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -8,8 +9,9 @@ const SUBAGENT_PREAMBLE = [
 
 export const VALID_VERDICTS = new Set(["ready", "needs_clarification"]);
 
-export async function buildArchitectPrompt({ task, instructions, researchContext = null, productContext = null, projectDir = null }) {
-  const sections = [SUBAGENT_PREAMBLE];
+export async function buildArchitectPrompt({ task, instructions, researchContext = null, productContext = null, projectDir = null, language = "en" }) {
+  const langInstruction = getLanguageInstruction(language);
+  const sections = [SUBAGENT_PREAMBLE, ...(langInstruction ? [langInstruction] : [])];
 
   if (instructions) {
     sections.push(instructions);

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -1,5 +1,6 @@
 import { RTK_INSTRUCTIONS } from "./rtk-snippet.js";
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
+import { getLanguageInstruction } from "../utils/locale.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -32,9 +33,11 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, plan = null, projectDir = null }) {
+export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, plan = null, projectDir = null, language = "en" }) {
+  const langInstruction = getLanguageInstruction(language);
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
+    ...(langInstruction ? [langInstruction] : []),
     `Task:\n${task}`,
     "Implement directly in the repository.",
     "Keep changes minimal and production-ready.",

--- a/src/prompts/hu-reviewer.js
+++ b/src/prompts/hu-reviewer.js
@@ -1,4 +1,5 @@
 import { extractFirstJson } from "../utils/json-extract.js";
+import { getLanguageInstruction } from "../utils/locale.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -21,8 +22,9 @@ const DIMENSION_KEYS = [
  * @param {{stories: Array<{id: string, text: string}>, instructions: string|null, context?: string|null}} params
  * @returns {string} The assembled prompt.
  */
-export function buildHuReviewerPrompt({ stories, instructions, context = null, productContext = null }) {
-  const sections = [SUBAGENT_PREAMBLE];
+export function buildHuReviewerPrompt({ stories, instructions, context = null, productContext = null, hu_language = "en" }) {
+  const langInstruction = getLanguageInstruction(hu_language);
+  const sections = [SUBAGENT_PREAMBLE, ...(langInstruction ? [langInstruction] : [])];
 
   if (instructions) {
     sections.push(instructions);

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -1,5 +1,6 @@
 import { RTK_INSTRUCTIONS } from "./rtk-snippet.js";
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
+import { getLanguageInstruction } from "../utils/locale.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -23,11 +24,13 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export async function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, projectDir = null }) {
+export async function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, projectDir = null, language = "en" }) {
   const truncatedDiff = diff.length > 12000 ? `${diff.slice(0, 12000)}\n\n[TRUNCATED]` : diff;
 
+  const langInstruction = getLanguageInstruction(language);
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
+    ...(langInstruction ? [langInstruction] : []),
     `You are a code reviewer in ${mode} mode.`,
     "CRITICAL SCOPE RULE: Only review changes that are part of the diff below. Do NOT flag issues in unchanged code, missing features planned for future tasks, or improvements outside the scope of this task. If the diff is correct for what the task asks, approve it — even if the broader codebase has other issues.",
     "Only block approval for issues IN THE DIFF that are bugs, security vulnerabilities, or clear violations of the review rules.",

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+// TODO: i18n display messages
 const DISPLAY_PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
 const DISPLAY_VERSION = JSON.parse(readFileSync(DISPLAY_PKG_PATH, "utf8")).version;
 

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -1,0 +1,59 @@
+/**
+ * OS locale detection and language instruction generation for i18n support.
+ */
+
+export const SUPPORTED_LANGUAGES = {
+  en: "English",
+  es: "Español"
+};
+
+const LANG_ENV_VARS = ["LANG", "LANGUAGE", "LC_ALL", "LC_MESSAGES"];
+
+/**
+ * Detect the 2-letter language code from OS environment variables.
+ * Checks LANG, LANGUAGE, LC_ALL, LC_MESSAGES in order.
+ * @returns {string} 2-letter language code (e.g. "en", "es")
+ */
+export function detectOsLocale() {
+  for (const envVar of LANG_ENV_VARS) {
+    const value = process.env[envVar];
+    if (value) {
+      const code = extractLangCode(value);
+      if (code) return code;
+    }
+  }
+  return "en";
+}
+
+/**
+ * Extract a 2-letter language code from a locale string.
+ * Handles formats like "es_ES.UTF-8", "en_US", "es", "C.UTF-8".
+ * @param {string} locale
+ * @returns {string|null}
+ */
+function extractLangCode(locale) {
+  const trimmed = locale.trim();
+  if (!trimmed || trimmed === "C" || trimmed === "POSIX") return null;
+  // Match first 2 lowercase letters before _, ., or end
+  const match = /^([a-z]{2})(?:[_.\-]|$)/i.exec(trimmed);
+  if (match) return match[1].toLowerCase();
+  return null;
+}
+
+/**
+ * Get a prompt instruction string for the given language.
+ * Returns empty string for English (agents default to English).
+ * @param {string} lang - 2-letter language code
+ * @returns {string}
+ */
+export function getLanguageInstruction(lang) {
+  if (!lang || lang === "en") return "";
+  const languageName = SUPPORTED_LANGUAGES[lang];
+  if (lang === "es") {
+    return "IMPORTANT: Respond in Spanish. All output, explanations, and feedback must be in Spanish.";
+  }
+  if (languageName) {
+    return `IMPORTANT: Respond in ${languageName}. All output must be in ${languageName}.`;
+  }
+  return `IMPORTANT: Respond in ${lang}. All output must be in ${lang}.`;
+}

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { detectOsLocale, getLanguageInstruction, SUPPORTED_LANGUAGES } from "../src/utils/locale.js";
+import { buildCoderPrompt } from "../src/prompts/coder.js";
+import { buildHuReviewerPrompt } from "../src/prompts/hu-reviewer.js";
+
+describe("locale detection", () => {
+  const originalEnv = {};
+
+  beforeEach(() => {
+    for (const key of ["LANG", "LANGUAGE", "LC_ALL", "LC_MESSAGES"]) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ["LANG", "LANGUAGE", "LC_ALL", "LC_MESSAGES"]) {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("returns 'es' when LANG=es_ES.UTF-8", () => {
+    process.env.LANG = "es_ES.UTF-8";
+    expect(detectOsLocale()).toBe("es");
+  });
+
+  it("returns 'en' when LANG=en_US.UTF-8", () => {
+    process.env.LANG = "en_US.UTF-8";
+    expect(detectOsLocale()).toBe("en");
+  });
+
+  it("returns 'en' as default when no env vars set", () => {
+    expect(detectOsLocale()).toBe("en");
+  });
+
+  it("falls back to LANGUAGE when LANG is not set", () => {
+    process.env.LANGUAGE = "fr_FR.UTF-8";
+    expect(detectOsLocale()).toBe("fr");
+  });
+
+  it("falls back to LC_ALL when LANG and LANGUAGE are not set", () => {
+    process.env.LC_ALL = "de_DE.UTF-8";
+    expect(detectOsLocale()).toBe("de");
+  });
+
+  it("skips C and POSIX locales", () => {
+    process.env.LANG = "C";
+    process.env.LANGUAGE = "POSIX";
+    process.env.LC_ALL = "es_ES";
+    expect(detectOsLocale()).toBe("es");
+  });
+});
+
+describe("getLanguageInstruction", () => {
+  it("returns empty string for 'en'", () => {
+    expect(getLanguageInstruction("en")).toBe("");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(getLanguageInstruction(null)).toBe("");
+    expect(getLanguageInstruction(undefined)).toBe("");
+  });
+
+  it("returns Spanish instruction for 'es'", () => {
+    const instruction = getLanguageInstruction("es");
+    expect(instruction).toContain("Spanish");
+    expect(instruction).toMatch(/^IMPORTANT:/);
+  });
+
+  it("returns generic instruction for unsupported language", () => {
+    const instruction = getLanguageInstruction("ja");
+    expect(instruction).toContain("ja");
+    expect(instruction).toMatch(/^IMPORTANT:/);
+  });
+});
+
+describe("SUPPORTED_LANGUAGES", () => {
+  it("includes en and es", () => {
+    expect(SUPPORTED_LANGUAGES.en).toBe("English");
+    expect(SUPPORTED_LANGUAGES.es).toBe("Español");
+  });
+});
+
+describe("config defaults include language", () => {
+  it("loadConfig returns language and hu_language", async () => {
+    const { loadConfig } = await import("../src/config.js");
+    const { config } = await loadConfig();
+    expect(config).toHaveProperty("language");
+    expect(config).toHaveProperty("hu_language");
+  });
+});
+
+describe("coder prompt includes language instruction", () => {
+  it("includes Spanish instruction when language is 'es'", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "Fix the bug",
+      language: "es"
+    });
+    expect(prompt).toContain("IMPORTANT: Respond in Spanish");
+  });
+
+  it("does not include language instruction when language is 'en'", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "Fix the bug",
+      language: "en"
+    });
+    expect(prompt).not.toContain("IMPORTANT: Respond in");
+  });
+
+  it("does not include language instruction when language is omitted", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "Fix the bug"
+    });
+    expect(prompt).not.toContain("IMPORTANT: Respond in");
+  });
+});
+
+describe("HU reviewer uses hu_language, not language", () => {
+  it("includes Spanish instruction when hu_language is 'es'", () => {
+    const prompt = buildHuReviewerPrompt({
+      stories: [{ id: "HU-001", text: "As a user..." }],
+      instructions: null,
+      hu_language: "es"
+    });
+    expect(prompt).toContain("IMPORTANT: Respond in Spanish");
+  });
+
+  it("does not include language instruction when hu_language is 'en'", () => {
+    const prompt = buildHuReviewerPrompt({
+      stories: [{ id: "HU-001", text: "As a user..." }],
+      instructions: null,
+      hu_language: "en"
+    });
+    expect(prompt).not.toContain("IMPORTANT: Respond in");
+  });
+
+  it("defaults to English when hu_language is omitted", () => {
+    const prompt = buildHuReviewerPrompt({
+      stories: [{ id: "HU-001", text: "As a user..." }],
+      instructions: null
+    });
+    expect(prompt).not.toContain("IMPORTANT: Respond in");
+  });
+});

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -123,7 +123,9 @@ describe("initCommand", () => {
       select: vi.fn()
         .mockResolvedValueOnce("codex")  // coder
         .mockResolvedValueOnce("claude") // reviewer
-        .mockResolvedValueOnce("tdd"),   // methodology
+        .mockResolvedValueOnce("tdd")    // methodology
+        .mockResolvedValueOnce("en")     // pipeline language
+        .mockResolvedValueOnce("en"),    // HU language
       close: vi.fn()
     };
     createWizard.mockReturnValue(mockWizard);
@@ -131,11 +133,13 @@ describe("initCommand", () => {
     await initCommand({ logger, flags: {} });
 
     expect(detectAvailableAgents).toHaveBeenCalled();
-    expect(mockWizard.select).toHaveBeenCalledTimes(3);
+    expect(mockWizard.select).toHaveBeenCalledTimes(5);
     expect(writeConfig).toHaveBeenCalled();
     const writtenConfig = writeConfig.mock.calls[0][1];
     expect(writtenConfig.coder).toBe("codex");
     expect(writtenConfig.reviewer).toBe("claude");
+    expect(writtenConfig.language).toBe("en");
+    expect(writtenConfig.hu_language).toBe("en");
     mockWizard.close();
   });
 


### PR DESCRIPTION
## Summary
- New `src/utils/locale.js`: OS locale detection, language instruction for prompts
- `kj init`: asks pipeline language + HU language (defaults to OS locale)
- Coder/reviewer/architect prompts inject language instruction when not English
- HU reviewer uses separate hu_language config
- Config defaults: language + hu_language
- 18 new tests (2275 total)

Closes KJC-TSK-0191

## Test plan
- [x] 179 files, 2275 tests pass
- [ ] CI green