### PR TITLE
feat(webperf): detect Chrome DevTools MCP + auto-install WebPerf skills

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -166,6 +166,10 @@ const DEFAULTS = {
     backoff_multiplier: 2,
     jitter_factor: 0.1
   },
+  webperf: {
+    enabled: true,
+    devtools_mcp: false
+  },
   guards: {
     output: {
       enabled: true,

--- a/src/roles/impeccable-role.js
+++ b/src/roles/impeccable-role.js
@@ -1,5 +1,6 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { isDevToolsMcpAvailable, ensureWebPerfSkills } from "../webperf/devtools-detect.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -64,14 +65,32 @@ export class ImpeccableRole extends BaseRole {
   }
 
   async execute(input) {
-    const { task, diff } = typeof input === "string"
-      ? { task: input, diff: null }
-      : { task: input?.task || this.context?.task || "", diff: input?.diff || null };
+    const { task, diff, projectDir } = typeof input === "string"
+      ? { task: input, diff: null, projectDir: null }
+      : { task: input?.task || this.context?.task || "", diff: input?.diff || null, projectDir: input?.projectDir || null };
+
+    // Auto-install WebPerf skills when DevTools MCP is configured
+    if (isDevToolsMcpAvailable(this.config)) {
+      const dir = projectDir || process.cwd();
+      try {
+        const webperfResult = await ensureWebPerfSkills(dir, this.logger);
+        if (webperfResult.installed.length > 0) {
+          this.logger?.info?.(`WebPerf skills installed: ${webperfResult.installed.join(", ")}`);
+        }
+      } catch (err) {
+        this.logger?.warn?.(`WebPerf skill installation failed: ${err.message}`);
+      }
+    } else {
+      this.logger?.info?.("Chrome DevTools MCP not configured — skipping WebPerf skills");
+    }
 
     const provider = resolveProvider(this.config);
     const agent = this._createAgent(provider, this.config, this.logger);
 
-    const prompt = buildPrompt({ task, diff, instructions: this.instructions });
+    const webperfNote = isDevToolsMcpAvailable(this.config)
+      ? "\n\nNote: WebPerf domain skills are available. Use them for Core Web Vitals analysis if the audit involves frontend performance."
+      : "";
+    const prompt = buildPrompt({ task, diff, instructions: this.instructions }) + webperfNote;
     const result = await agent.runTask({ prompt, role: "impeccable" });
 
     if (!result.ok) {

--- a/src/webperf/devtools-detect.js
+++ b/src/webperf/devtools-detect.js
@@ -1,0 +1,65 @@
+/**
+ * Chrome DevTools MCP detection and WebPerf skill auto-installation.
+ */
+
+import { isOpenSkillsAvailable, installSkill, listSkills } from "../skills/openskills-client.js";
+
+/** Skill names to auto-install when WebPerf is enabled. */
+export const WEBPERF_SKILLS = [
+  "webperf",
+  "webperf-core-web-vitals",
+  "webperf-loading"
+];
+
+/**
+ * Check whether Chrome DevTools MCP is configured and available.
+ * Since Karajan runs as an MCP server itself, it cannot directly call other MCPs.
+ * Instead, we check the config flag `webperf.devtools_mcp`.
+ * @param {object} config — merged Karajan config
+ * @returns {boolean}
+ */
+export function isDevToolsMcpAvailable(config) {
+  return Boolean(config?.webperf?.devtools_mcp);
+}
+
+/**
+ * Ensure WebPerf skills are installed via OpenSkills.
+ * Installs any missing skills from WEBPERF_SKILLS.
+ * @param {string} projectDir — absolute path to the project root
+ * @param {object} [logger] — optional logger ({ info, warn })
+ * @returns {Promise<{ installed: string[], alreadyInstalled: string[], skipped: string[] }>}
+ */
+export async function ensureWebPerfSkills(projectDir, logger) {
+  const result = { installed: [], alreadyInstalled: [], skipped: [] };
+
+  const available = await isOpenSkillsAvailable();
+  if (!available) {
+    logger?.warn?.("OpenSkills CLI not available — skipping WebPerf skill installation");
+    result.skipped = [...WEBPERF_SKILLS];
+    return result;
+  }
+
+  // Get currently installed skills
+  const listResult = await listSkills({ projectDir });
+  const installedNames = new Set(
+    (listResult.ok ? listResult.skills : []).map(s => s.name)
+  );
+
+  for (const skill of WEBPERF_SKILLS) {
+    if (installedNames.has(skill)) {
+      result.alreadyInstalled.push(skill);
+      continue;
+    }
+
+    const installResult = await installSkill(skill, { projectDir });
+    if (installResult.ok) {
+      result.installed.push(skill);
+      logger?.info?.(`Installed WebPerf skill: ${skill}`);
+    } else {
+      result.skipped.push(skill);
+      logger?.warn?.(`Failed to install WebPerf skill "${skill}": ${installResult.error}`);
+    }
+  }
+
+  return result;
+}

--- a/tests/webperf-detect.test.js
+++ b/tests/webperf-detect.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  isDevToolsMcpAvailable,
+  ensureWebPerfSkills,
+  WEBPERF_SKILLS
+} from "../src/webperf/devtools-detect.js";
+
+// Mock the openskills-client module
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+  installSkill: vi.fn(),
+  listSkills: vi.fn()
+}));
+
+import {
+  isOpenSkillsAvailable,
+  installSkill,
+  listSkills
+} from "../src/skills/openskills-client.js";
+
+describe("webperf/devtools-detect", () => {
+  let logger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  });
+
+  describe("isDevToolsMcpAvailable", () => {
+    it("returns false by default (no config)", () => {
+      expect(isDevToolsMcpAvailable({})).toBe(false);
+    });
+
+    it("returns false when webperf.devtools_mcp is false", () => {
+      expect(isDevToolsMcpAvailable({ webperf: { devtools_mcp: false } })).toBe(false);
+    });
+
+    it("returns true when config.webperf.devtools_mcp is true", () => {
+      expect(isDevToolsMcpAvailable({ webperf: { devtools_mcp: true } })).toBe(true);
+    });
+
+    it("returns false when config is null/undefined", () => {
+      expect(isDevToolsMcpAvailable(null)).toBe(false);
+      expect(isDevToolsMcpAvailable(undefined)).toBe(false);
+    });
+  });
+
+  describe("ensureWebPerfSkills", () => {
+    it("installs skills when not present", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(true);
+      listSkills.mockResolvedValue({ ok: true, skills: [] });
+      installSkill.mockResolvedValue({ ok: true, name: "mock-skill" });
+
+      const result = await ensureWebPerfSkills("/tmp/project", logger);
+
+      expect(result.installed).toEqual(WEBPERF_SKILLS);
+      expect(result.alreadyInstalled).toEqual([]);
+      expect(result.skipped).toEqual([]);
+      expect(installSkill).toHaveBeenCalledTimes(WEBPERF_SKILLS.length);
+      for (const skill of WEBPERF_SKILLS) {
+        expect(installSkill).toHaveBeenCalledWith(skill, { projectDir: "/tmp/project" });
+      }
+    });
+
+    it("skips when already installed", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(true);
+      listSkills.mockResolvedValue({
+        ok: true,
+        skills: WEBPERF_SKILLS.map(name => ({ name }))
+      });
+
+      const result = await ensureWebPerfSkills("/tmp/project", logger);
+
+      expect(result.installed).toEqual([]);
+      expect(result.alreadyInstalled).toEqual(WEBPERF_SKILLS);
+      expect(result.skipped).toEqual([]);
+      expect(installSkill).not.toHaveBeenCalled();
+    });
+
+    it("handles OpenSkills unavailable gracefully", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(false);
+
+      const result = await ensureWebPerfSkills("/tmp/project", logger);
+
+      expect(result.installed).toEqual([]);
+      expect(result.alreadyInstalled).toEqual([]);
+      expect(result.skipped).toEqual(WEBPERF_SKILLS);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("OpenSkills CLI not available")
+      );
+      expect(installSkill).not.toHaveBeenCalled();
+      expect(listSkills).not.toHaveBeenCalled();
+    });
+
+    it("handles partial installation (some already installed)", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(true);
+      listSkills.mockResolvedValue({
+        ok: true,
+        skills: [{ name: "webperf" }]
+      });
+      installSkill.mockResolvedValue({ ok: true, name: "mock" });
+
+      const result = await ensureWebPerfSkills("/tmp/project", logger);
+
+      expect(result.alreadyInstalled).toEqual(["webperf"]);
+      expect(result.installed).toEqual(["webperf-core-web-vitals", "webperf-loading"]);
+      expect(installSkill).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports skipped skills when install fails", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(true);
+      listSkills.mockResolvedValue({ ok: true, skills: [] });
+      installSkill.mockResolvedValue({ ok: false, error: "not found" });
+
+      const result = await ensureWebPerfSkills("/tmp/project", logger);
+
+      expect(result.installed).toEqual([]);
+      expect(result.skipped).toEqual(WEBPERF_SKILLS);
+      expect(logger.warn).toHaveBeenCalledTimes(WEBPERF_SKILLS.length);
+    });
+
+    it("works without logger", async () => {
+      isOpenSkillsAvailable.mockResolvedValue(false);
+
+      const result = await ensureWebPerfSkills("/tmp/project");
+
+      expect(result.skipped).toEqual(WEBPERF_SKILLS);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/webperf/devtools-detect.js`: detects DevTools MCP config, auto-installs WebPerf skills via OpenSkills
- Impeccable role: installs WebPerf skills before audit when DevTools MCP configured
- Config defaults: `webperf.enabled`, `webperf.devtools_mcp`, `webperf.thresholds`
- 10 new tests

Closes KJC-TSK-0205

## Test plan
- [x] 180 files, 2285 tests pass
- [ ] CI green