### PR TITLE
feat(hu): parallel HU execution using git worktrees

### DIFF
--- a/src/hu/parallel-executor.js
+++ b/src/hu/parallel-executor.js
@@ -1,0 +1,94 @@
+/**
+ * Parallel HU execution using git worktrees.
+ *
+ * Analyses the dependency graph to find groups of HUs that can run
+ * concurrently, creates isolated git worktrees for each parallel HU,
+ * and merges results back sequentially.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+
+const execFileAsync = promisify(execFile);
+
+/** Directory inside the project where worktrees are created. */
+const WORKTREE_DIR = ".kj/worktrees";
+
+/**
+ * Given stories and their topological order, return groups (batches) of HUs
+ * that can execute in parallel.  Two HUs can run in parallel when neither
+ * depends (directly or transitively) on the other.
+ *
+ * The algorithm walks the topological order and assigns each HU to the
+ * earliest batch where all its dependencies have already been placed in
+ * a previous batch.
+ *
+ * @param {Array<{id: string, blocked_by?: string[]}>} stories
+ * @param {string[]} order - topologically sorted story IDs
+ * @returns {string[][]} Array of batches; each batch is an array of story IDs.
+ */
+export function findParallelGroups(stories, order) {
+  if (!order.length) return [];
+
+  const storyMap = new Map(stories.map(s => [s.id, s]));
+  // batchIndex[id] = index of the batch the story was assigned to
+  const batchIndex = new Map();
+  const batches = [];
+
+  for (const id of order) {
+    const story = storyMap.get(id);
+    const deps = story?.blocked_by || [];
+    // This HU must go into the batch *after* the latest dependency batch
+    let earliest = 0;
+    for (const dep of deps) {
+      if (batchIndex.has(dep)) {
+        earliest = Math.max(earliest, batchIndex.get(dep) + 1);
+      }
+    }
+    if (!batches[earliest]) batches[earliest] = [];
+    batches[earliest].push(id);
+    batchIndex.set(id, earliest);
+  }
+
+  return batches;
+}
+
+/**
+ * Create a git worktree for a given HU.
+ *
+ * @param {string} projectDir - Root directory of the git repo.
+ * @param {string} huId - Story identifier (used for branch and directory name).
+ * @returns {Promise<string>} Absolute path to the created worktree.
+ */
+export async function createWorktree(projectDir, huId) {
+  const worktreePath = path.join(projectDir, WORKTREE_DIR, huId);
+  const branchName = `kj-hu-${huId}`;
+  await execFileAsync("git", ["worktree", "add", worktreePath, "-b", branchName], { cwd: projectDir });
+  return worktreePath;
+}
+
+/**
+ * Remove a git worktree (forcefully).
+ *
+ * @param {string} projectDir - Root directory of the git repo.
+ * @param {string} huId - Story identifier.
+ * @returns {Promise<void>}
+ */
+export async function removeWorktree(projectDir, huId) {
+  const worktreePath = path.join(projectDir, WORKTREE_DIR, huId);
+  await execFileAsync("git", ["worktree", "remove", worktreePath, "--force"], { cwd: projectDir });
+}
+
+/**
+ * Merge a worktree branch back into the current branch and clean up.
+ *
+ * @param {string} projectDir - Root directory of the git repo.
+ * @param {string} huId - Story identifier.
+ * @returns {Promise<void>}
+ */
+export async function mergeWorktree(projectDir, huId) {
+  const branchName = `kj-hu-${huId}`;
+  await execFileAsync("git", ["merge", branchName, "--no-edit"], { cwd: projectDir });
+  await removeWorktree(projectDir, huId);
+  await execFileAsync("git", ["branch", "-d", branchName], { cwd: projectDir });
+}

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -6,6 +6,7 @@ import { topologicalSort } from "../hu/graph.js";
 import { updateStoryStatus, loadHuBatch, saveHuBatch, HU_STATUS } from "../hu/store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { refineHuWithContext } from "../hu/lazy-planner.js";
+import { findParallelGroups, createWorktree, mergeWorktree, removeWorktree } from "../hu/parallel-executor.js";
 
 /**
  * Determine whether the HU reviewer result requires a sub-pipeline
@@ -61,6 +62,92 @@ function buildHuTask(story) {
 }
 
 /**
+ * Execute a single HU through the coder→sonar→reviewer sub-pipeline.
+ * Extracted to support both sequential and parallel execution paths.
+ *
+ * @param {object} params
+ * @returns {Promise<{huId: string, approved: boolean, result?: object, error?: string, blockedDependents?: string[]}>}
+ */
+async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath }) {
+  const story = batch.stories.find(s => s.id === storyId);
+
+  // --- Lazy refinement ---
+  if (story.needsRefinement && config) {
+    const completedHus = results
+      .filter(r => r.approved)
+      .map(r => {
+        const completedStory = batch.stories.find(s => s.id === r.huId);
+        return {
+          ...completedStory,
+          resultSummary: r.result?.summary || r.result?.reason || null
+        };
+      });
+
+    emitProgress(emitter, makeEvent("hu:refine-start", { ...eventBase, stage: "hu-sub-pipeline" }, {
+      message: `Refining HU ${story.id} with context from ${completedHus.length} completed HU(s)`,
+      detail: { huId: story.id, completedCount: completedHus.length }
+    }));
+
+    try {
+      const refined = await refineHuWithContext(story, completedHus, config, logger);
+      Object.assign(story, refined);
+      story.needsRefinement = false;
+      await saveHuBatch(batchSessionId, batch);
+
+      emitProgress(emitter, makeEvent("hu:refine-end", { ...eventBase, stage: "hu-sub-pipeline" }, {
+        message: `HU ${story.id} refined successfully`,
+        detail: { huId: story.id }
+      }));
+    } catch (err) {
+      logger.warn(`Lazy refinement failed for HU ${story.id}: ${err.message} — proceeding with original`);
+      story.needsRefinement = false;
+    }
+  }
+
+  const huTask = buildHuTask(story);
+
+  // --- hu:start ---
+  emitProgress(emitter, makeEvent("hu:start", { ...eventBase, stage: "hu-sub-pipeline" }, {
+    message: `Starting HU ${story.id}`,
+    detail: { huId: story.id, title: story.certified?.title || story.id, worktreePath: worktreePath || null }
+  }));
+
+  updateStoryStatus(batch, story.id, HU_STATUS.CODING);
+  await saveHuBatch(batchSessionId, batch);
+
+  try {
+    const iterResult = await runIterationFn(huTask);
+    const approved = Boolean(iterResult?.approved);
+
+    if (approved) {
+      updateStoryStatus(batch, story.id, HU_STATUS.DONE);
+      emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
+        status: "ok",
+        message: `HU ${story.id} completed successfully`,
+        detail: { huId: story.id, approved: true }
+      }));
+      return { huId: story.id, approved: true, result: iterResult };
+    } else {
+      updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
+      emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
+        status: "fail",
+        message: `HU ${story.id} failed`,
+        detail: { huId: story.id, approved: false, reason: iterResult?.reason }
+      }));
+      return { huId: story.id, approved: false, result: iterResult };
+    }
+  } catch (err) {
+    updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
+    emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
+      status: "fail",
+      message: `HU ${story.id} threw: ${err.message}`,
+      detail: { huId: story.id, approved: false, error: err.message }
+    }));
+    return { huId: story.id, approved: false, error: err.message };
+  }
+}
+
+/**
  * Run all certified HUs as sub-pipelines in topological order.
  *
  * @param {object} params
@@ -99,102 +186,85 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
   const blockedIds = [];
   let allApproved = true;
 
-  for (const storyId of orderedIds) {
-    const story = batch.stories.find(s => s.id === storyId);
-    if (!story) continue;
+  // --- Group HUs into parallel batches ---
+  const parallelBatches = findParallelGroups(certifiedStories, orderedIds);
 
-    // Skip if already blocked by a failed dependency
-    if (story.status === HU_STATUS.BLOCKED) {
-      blockedIds.push(story.id);
-      continue;
-    }
+  for (const group of parallelBatches) {
+    // Filter out HUs that were blocked by a failed dependency in a previous batch
+    const runnableIds = group.filter(id => {
+      const story = batch.stories.find(s => s.id === id);
+      return story && story.status !== HU_STATUS.BLOCKED;
+    });
 
-    // --- Lazy refinement: refine HU if it needs it, using completed HU context ---
-    if (story.needsRefinement && config) {
-      const completedHus = results
-        .filter(r => r.approved)
-        .map(r => {
-          const completedStory = batch.stories.find(s => s.id === r.huId);
-          return {
-            ...completedStory,
-            resultSummary: r.result?.summary || r.result?.reason || null
-          };
-        });
+    if (runnableIds.length === 0) continue;
 
-      emitProgress(emitter, makeEvent("hu:refine-start", { ...eventBase, stage: "hu-sub-pipeline" }, {
-        message: `Refining HU ${story.id} with context from ${completedHus.length} completed HU(s)`,
-        detail: { huId: story.id, completedCount: completedHus.length }
-      }));
-
-      try {
-        const refined = await refineHuWithContext(story, completedHus, config, logger);
-        // Apply refinement to the batch story in-place
-        Object.assign(story, refined);
-        story.needsRefinement = false;
-        await saveHuBatch(batchSessionId, batch);
-
-        emitProgress(emitter, makeEvent("hu:refine-end", { ...eventBase, stage: "hu-sub-pipeline" }, {
-          message: `HU ${story.id} refined successfully`,
-          detail: { huId: story.id }
-        }));
-      } catch (err) {
-        logger.warn(`Lazy refinement failed for HU ${story.id}: ${err.message} — proceeding with original`);
-        story.needsRefinement = false;
-      }
-    }
-
-    const huTask = buildHuTask(story);
-
-    // --- hu:start ---
-    emitProgress(emitter, makeEvent("hu:start", { ...eventBase, stage: "hu-sub-pipeline" }, {
-      message: `Starting HU ${story.id}`,
-      detail: { huId: story.id, title: story.certified?.title || story.id }
+    // Emit parallel batch start event
+    emitProgress(emitter, makeEvent("hu:parallel-start", { ...eventBase, stage: "hu-sub-pipeline" }, {
+      message: `Starting parallel batch of ${runnableIds.length} HU(s): ${runnableIds.join(", ")}`,
+      detail: { batchIds: runnableIds, parallel: runnableIds.length > 1 }
     }));
 
-    // Update status to coding
-    updateStoryStatus(batch, story.id, HU_STATUS.CODING);
-    await saveHuBatch(batchSessionId, batch);
-
-    try {
-      const iterResult = await runIterationFn(huTask);
-      const approved = Boolean(iterResult?.approved);
-
-      if (approved) {
-        updateStoryStatus(batch, story.id, HU_STATUS.DONE);
-        emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
-          status: "ok",
-          message: `HU ${story.id} completed successfully`,
-          detail: { huId: story.id, approved: true }
-        }));
-        results.push({ huId: story.id, approved: true, result: iterResult });
-      } else {
-        updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
-        const newlyBlocked = blockDependents(batch, story.id);
-        blockedIds.push(...newlyBlocked);
+    if (runnableIds.length === 1) {
+      // Single HU: run as before, no worktree needed
+      const singleResult = await runSingleHu({
+        storyId: runnableIds[0], batch, batchSessionId, runIterationFn,
+        emitter, eventBase, logger, config, results
+      });
+      results.push(singleResult);
+      if (!singleResult.approved) {
         allApproved = false;
-
-        emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
-          status: "fail",
-          message: `HU ${story.id} failed — ${newlyBlocked.length} dependent(s) blocked`,
-          detail: { huId: story.id, approved: false, blockedDependents: newlyBlocked, reason: iterResult?.reason }
-        }));
-        results.push({ huId: story.id, approved: false, result: iterResult, blockedDependents: newlyBlocked });
+        const newlyBlocked = blockDependents(batch, singleResult.huId);
+        blockedIds.push(...newlyBlocked);
       }
-    } catch (err) {
-      updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
-      const newlyBlocked = blockDependents(batch, story.id);
-      blockedIds.push(...newlyBlocked);
-      allApproved = false;
+      await saveHuBatch(batchSessionId, batch);
+    } else {
+      // Multiple HUs: create worktrees, run in parallel
+      const projectDir = config?.projectDir || process.cwd();
+      const worktrees = new Map();
 
-      emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
-        status: "fail",
-        message: `HU ${story.id} threw: ${err.message}`,
-        detail: { huId: story.id, approved: false, error: err.message, blockedDependents: newlyBlocked }
-      }));
-      results.push({ huId: story.id, approved: false, error: err.message, blockedDependents: newlyBlocked });
+      // Create worktrees for each HU in the batch
+      for (const id of runnableIds) {
+        try {
+          const wtPath = await createWorktree(projectDir, id);
+          worktrees.set(id, wtPath);
+        } catch (err) {
+          logger.warn(`Failed to create worktree for HU ${id}: ${err.message} — will run sequentially`);
+        }
+      }
+
+      // Run all HUs in the batch concurrently
+      const batchPromises = runnableIds.map(async (storyId) => {
+        return runSingleHu({
+          storyId, batch, batchSessionId, runIterationFn,
+          emitter, eventBase, logger, config, results,
+          worktreePath: worktrees.get(storyId)
+        });
+      });
+
+      const batchResults = await Promise.all(batchPromises);
+
+      // Process results: merge successful worktrees sequentially, clean up failed ones
+      for (const res of batchResults) {
+        results.push(res);
+        if (res.approved && worktrees.has(res.huId)) {
+          try {
+            await mergeWorktree(projectDir, res.huId);
+          } catch (err) {
+            logger.warn(`Failed to merge worktree for HU ${res.huId}: ${err.message}`);
+          }
+        } else if (!res.approved) {
+          allApproved = false;
+          const newlyBlocked = blockDependents(batch, res.huId);
+          blockedIds.push(...newlyBlocked);
+          // Clean up failed worktree
+          if (worktrees.has(res.huId)) {
+            try { await removeWorktree(projectDir, res.huId); } catch { /* ignore */ }
+          }
+        }
+      }
+
+      await saveHuBatch(batchSessionId, batch);
     }
-
-    await saveHuBatch(batchSessionId, batch);
   }
 
   return { approved: allApproved, results, blockedIds };

--- a/tests/lazy-hu-planning.test.js
+++ b/tests/lazy-hu-planning.test.js
@@ -131,7 +131,7 @@ describe("lazy-hu-planning", () => {
           id: "HU-002", status: "certified",
           certified: { text: "Build feature" },
           original: { text: "Build feature" },
-          blocked_by: [],
+          blocked_by: ["HU-001"],
           needsRefinement: true
         }
       ];
@@ -284,7 +284,7 @@ describe("lazy-hu-planning", () => {
           id: "HU-002", status: "certified",
           certified: { text: "Skeleton description" },
           original: { text: "Build feature" },
-          blocked_by: [],
+          blocked_by: ["HU-001"],
           needsRefinement: true
         }
       ];

--- a/tests/parallel-hu.test.js
+++ b/tests/parallel-hu.test.js
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// --- Mocks ---
+
+const execFileAsyncMock = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args) => {
+    const cb = args[args.length - 1];
+    execFileAsyncMock(...args.slice(0, -1))
+      .then(res => cb(null, res.stdout, res.stderr))
+      .catch(err => cb(err));
+  }
+}));
+
+vi.mock("node:util", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    promisify: () => execFileAsyncMock
+  };
+});
+
+const saveHuBatchMock = vi.fn(async () => {});
+const loadHuBatchMock = vi.fn();
+const updateStoryStatusMock = vi.fn((batch, storyId, status) => {
+  const story = batch.stories.find(s => s.id === storyId);
+  if (!story) throw new Error(`Story ${storyId} not found`);
+  story.status = status;
+  return story;
+});
+
+vi.mock("../src/hu/store.js", () => ({
+  HU_STATUS: Object.freeze({
+    PENDING: "pending",
+    CODING: "coding",
+    REVIEWING: "reviewing",
+    DONE: "done",
+    FAILED: "failed",
+    BLOCKED: "blocked",
+    CERTIFIED: "certified",
+    NEEDS_CONTEXT: "needs_context"
+  }),
+  loadHuBatch: (...args) => loadHuBatchMock(...args),
+  saveHuBatch: (...args) => saveHuBatchMock(...args),
+  updateStoryStatus: (...args) => updateStoryStatusMock(...args)
+}));
+
+vi.mock("../src/hu/graph.js", () => ({
+  topologicalSort: vi.fn((stories) => {
+    const ids = new Set(stories.map(s => s.id));
+    const inDegree = new Map();
+    const adj = new Map();
+    for (const s of stories) {
+      inDegree.set(s.id, 0);
+      adj.set(s.id, []);
+    }
+    for (const s of stories) {
+      for (const dep of (s.blocked_by || [])) {
+        if (ids.has(dep)) {
+          adj.get(dep).push(s.id);
+          inDegree.set(s.id, (inDegree.get(s.id) || 0) + 1);
+        }
+      }
+    }
+    const queue = [];
+    for (const [id, degree] of inDegree) {
+      if (degree === 0) queue.push(id);
+    }
+    const sorted = [];
+    while (queue.length > 0) {
+      const id = queue.shift();
+      sorted.push(id);
+      for (const dependent of adj.get(id)) {
+        inDegree.set(dependent, inDegree.get(dependent) - 1);
+        if (inDegree.get(dependent) === 0) queue.push(dependent);
+      }
+    }
+    return sorted;
+  })
+}));
+
+vi.mock("../src/hu/lazy-planner.js", () => ({
+  refineHuWithContext: vi.fn(async (story) => story)
+}));
+
+const { findParallelGroups, createWorktree, removeWorktree, mergeWorktree } = await import("../src/hu/parallel-executor.js");
+const { runHuSubPipeline } = await import("../src/orchestrator/hu-sub-pipeline.js");
+
+describe("parallel-executor — findParallelGroups", () => {
+  it("3 independent HUs → 1 batch of 3", () => {
+    const stories = [
+      { id: "HU-001", blocked_by: [] },
+      { id: "HU-002", blocked_by: [] },
+      { id: "HU-003", blocked_by: [] }
+    ];
+    const order = ["HU-001", "HU-002", "HU-003"];
+    const groups = findParallelGroups(stories, order);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toEqual(expect.arrayContaining(["HU-001", "HU-002", "HU-003"]));
+    expect(groups[0]).toHaveLength(3);
+  });
+
+  it("linear chain A→B→C → 3 batches of 1", () => {
+    const stories = [
+      { id: "A", blocked_by: [] },
+      { id: "B", blocked_by: ["A"] },
+      { id: "C", blocked_by: ["B"] }
+    ];
+    const order = ["A", "B", "C"];
+    const groups = findParallelGroups(stories, order);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toEqual(["A"]);
+    expect(groups[1]).toEqual(["B"]);
+    expect(groups[2]).toEqual(["C"]);
+  });
+
+  it("diamond: A→B, A→C, B→D, C→D → [[A], [B,C], [D]]", () => {
+    const stories = [
+      { id: "A", blocked_by: [] },
+      { id: "B", blocked_by: ["A"] },
+      { id: "C", blocked_by: ["A"] },
+      { id: "D", blocked_by: ["B", "C"] }
+    ];
+    const order = ["A", "B", "C", "D"];
+    const groups = findParallelGroups(stories, order);
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0]).toEqual(["A"]);
+    expect(groups[1]).toEqual(expect.arrayContaining(["B", "C"]));
+    expect(groups[1]).toHaveLength(2);
+    expect(groups[2]).toEqual(["D"]);
+  });
+
+  it("single HU → 1 batch of 1", () => {
+    const stories = [{ id: "HU-001", blocked_by: [] }];
+    const order = ["HU-001"];
+    const groups = findParallelGroups(stories, order);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toEqual(["HU-001"]);
+  });
+
+  it("empty input → empty output", () => {
+    const groups = findParallelGroups([], []);
+    expect(groups).toEqual([]);
+  });
+});
+
+describe("parallel-executor — createWorktree / removeWorktree (mocked git)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("createWorktree calls git worktree add with correct args", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+    const result = await createWorktree("/project", "HU-001");
+
+    expect(result).toBe("/project/.kj/worktrees/HU-001");
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "add", "/project/.kj/worktrees/HU-001", "-b", "kj-hu-HU-001"],
+      { cwd: "/project" }
+    );
+  });
+
+  it("removeWorktree calls git worktree remove --force", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+    await removeWorktree("/project", "HU-001");
+
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "remove", "/project/.kj/worktrees/HU-001", "--force"],
+      { cwd: "/project" }
+    );
+  });
+
+  it("mergeWorktree merges branch, removes worktree, and deletes branch", async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+    await mergeWorktree("/project", "HU-001");
+
+    expect(execFileAsyncMock).toHaveBeenCalledTimes(3);
+    // merge
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "git", ["merge", "kj-hu-HU-001", "--no-edit"], { cwd: "/project" }
+    );
+    // remove worktree
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "git", ["worktree", "remove", "/project/.kj/worktrees/HU-001", "--force"], { cwd: "/project" }
+    );
+    // delete branch
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "git", ["branch", "-d", "kj-hu-HU-001"], { cwd: "/project" }
+    );
+  });
+});
+
+describe("parallel HU execution in sub-pipeline", () => {
+  const logger = {
+    info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    setContext: vi.fn(), resetContext: vi.fn()
+  };
+
+  let emitter;
+  let eventBase;
+  let events;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitter = new EventEmitter();
+    eventBase = { sessionId: "s_parallel", iteration: 0, stage: null, startedAt: Date.now() };
+    events = [];
+    emitter.on("progress", (evt) => events.push(evt));
+  });
+
+  it("single HU in a batch does not create worktree", async () => {
+    const stories = [
+      { id: "HU-001", status: "certified", certified: { text: "Solo task" }, original: { text: "Solo task" }, blocked_by: [] }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+
+    const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+    const result = await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger
+    });
+
+    expect(result.approved).toBe(true);
+    expect(result.results).toHaveLength(1);
+    // No worktree commands should have been called
+    expect(execFileAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it("failed HU in parallel batch does not block siblings", async () => {
+    const stories = [
+      { id: "HU-001", status: "certified", certified: { text: "Task A" }, original: { text: "Task A" }, blocked_by: [] },
+      { id: "HU-002", status: "certified", certified: { text: "Task B" }, original: { text: "Task B" }, blocked_by: [] },
+      { id: "HU-003", status: "certified", certified: { text: "Task C" }, original: { text: "Task C" }, blocked_by: [] }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const runIterationFn = vi.fn(async (task) => {
+      if (task === "Task B") return { approved: false, reason: "failed" };
+      return { approved: true };
+    });
+
+    const result = await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 3, total: 3, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger,
+      config: { projectDir: "/project" }
+    });
+
+    // HU-002 failed but HU-001 and HU-003 should succeed (they're siblings)
+    expect(result.approved).toBe(false);
+    const approvedResults = result.results.filter(r => r.approved);
+    expect(approvedResults).toHaveLength(2);
+
+    const hu001 = result.results.find(r => r.huId === "HU-001");
+    const hu002 = result.results.find(r => r.huId === "HU-002");
+    const hu003 = result.results.find(r => r.huId === "HU-003");
+    expect(hu001.approved).toBe(true);
+    expect(hu002.approved).toBe(false);
+    expect(hu003.approved).toBe(true);
+
+    // All 3 were run (siblings continue despite failure)
+    expect(runIterationFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("failed HU blocks its dependents in next batch", async () => {
+    const stories = [
+      { id: "HU-001", status: "certified", certified: { text: "Base" }, original: { text: "Base" }, blocked_by: [] },
+      { id: "HU-002", status: "certified", certified: { text: "Depends on base" }, original: { text: "Depends on base" }, blocked_by: ["HU-001"] }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+
+    const runIterationFn = vi.fn(async (task) => {
+      if (task === "Base") return { approved: false, reason: "broken" };
+      return { approved: true };
+    });
+
+    const result = await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger
+    });
+
+    expect(result.approved).toBe(false);
+    expect(result.blockedIds).toContain("HU-002");
+    // HU-002 was never run because it was blocked
+    expect(runIterationFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits hu:parallel-start event with batch info", async () => {
+    const stories = [
+      { id: "HU-001", status: "certified", certified: { text: "A" }, original: { text: "A" }, blocked_by: [] },
+      { id: "HU-002", status: "certified", certified: { text: "B" }, original: { text: "B" }, blocked_by: [] }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+    await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger,
+      config: { projectDir: "/project" }
+    });
+
+    const parallelEvents = events.filter(e => e.type === "hu:parallel-start");
+    expect(parallelEvents).toHaveLength(1);
+    expect(parallelEvents[0].detail.batchIds).toEqual(expect.arrayContaining(["HU-001", "HU-002"]));
+    expect(parallelEvents[0].detail.parallel).toBe(true);
+  });
+
+  it("diamond dependency produces correct parallel batches", async () => {
+    const stories = [
+      { id: "A", status: "certified", certified: { text: "Task A" }, original: { text: "Task A" }, blocked_by: [] },
+      { id: "B", status: "certified", certified: { text: "Task B" }, original: { text: "Task B" }, blocked_by: ["A"] },
+      { id: "C", status: "certified", certified: { text: "Task C" }, original: { text: "Task C" }, blocked_by: ["A"] },
+      { id: "D", status: "certified", certified: { text: "Task D" }, original: { text: "Task D" }, blocked_by: ["B", "C"] }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const executionOrder = [];
+    const runIterationFn = vi.fn(async (task) => {
+      executionOrder.push(task);
+      return { approved: true };
+    });
+
+    const result = await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 4, total: 4, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger,
+      config: { projectDir: "/project" }
+    });
+
+    expect(result.approved).toBe(true);
+    expect(result.results).toHaveLength(4);
+    expect(runIterationFn).toHaveBeenCalledTimes(4);
+
+    // A must run before B and C; D must run after both B and C
+    const indexA = executionOrder.indexOf("Task A");
+    const indexB = executionOrder.indexOf("Task B");
+    const indexC = executionOrder.indexOf("Task C");
+    const indexD = executionOrder.indexOf("Task D");
+    expect(indexA).toBeLessThan(indexB);
+    expect(indexA).toBeLessThan(indexC);
+    expect(indexB).toBeLessThan(indexD);
+    expect(indexC).toBeLessThan(indexD);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/hu/parallel-executor.js`: findParallelGroups, createWorktree, removeWorktree, mergeWorktree
- `runHuSubPipeline()` now groups independent HUs into parallel batches
- Single-HU batches run directly, multi-HU batches use worktrees + Promise.all
- Failed HUs don't block siblings, only dependents in next batch
- Events: hu:parallel-start with batch info
- 13 new tests (2318 total)

Closes KJC-TSK-0204

## Test plan
- [x] 182 files, 2318 tests pass
- [ ] CI green