### PR TITLE
feat(pg): auto-track card lifecycle (In Progress, commits, To Validate)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -523,6 +523,10 @@ async function becariaIncrementalPush({ config, session, gitCtx, task, logger, r
   const pushResult = await incrementalPush({ gitCtx, task, logger, session });
   if (!pushResult) return;
 
+  // Accumulate commits for PG card lifecycle tracking
+  const { accumulateCommit } = await import("./planning-game/pipeline-adapter.js");
+  for (const c of pushResult.commits) accumulateCommit(session, c);
+
   session.becaria_commits = [...(session.becaria_commits ?? []), ...pushResult.commits];
   await saveSession(session);
 
@@ -538,6 +542,10 @@ async function becariaIncrementalPush({ config, session, gitCtx, task, logger, r
 async function becariaCreateEarlyPr({ config, session, emitter, eventBase, gitCtx, task, logger, stageResults, i, repo, dispatchComment }) {
   const earlyPr = await earlyPrCreation({ gitCtx, task, logger, session, stageResults });
   if (!earlyPr) return;
+
+  // Accumulate commits for PG card lifecycle tracking
+  const { accumulateCommit } = await import("./planning-game/pipeline-adapter.js");
+  for (const c of earlyPr.commits) accumulateCommit(session, c);
 
   session.becaria_pr_number = earlyPr.prNumber;
   session.becaria_pr_url = earlyPr.prUrl;
@@ -740,6 +748,13 @@ async function handlePostLoopStages({ config, session, emitter, eventBase, coder
 
 async function finalizeApprovedSession({ config, gitCtx, task, logger, session, stageResults, emitter, eventBase, budgetSummary, pgCard, pgProject, review, i }) {
   const gitResult = await finalizeGitAutomation({ config, gitCtx, task, logger, session, stageResults });
+
+  // Accumulate final commits for PG card lifecycle tracking
+  if (gitResult?.commits?.length) {
+    const { accumulateCommit } = await import("./planning-game/pipeline-adapter.js");
+    for (const c of gitResult.commits) accumulateCommit(session, c);
+  }
+
   if (stageResults.planner?.ok) {
     stageResults.planner.completedSteps = [...(stageResults.planner.steps ?? [])];
   }

--- a/src/planning-game/pipeline-adapter.js
+++ b/src/planning-game/pipeline-adapter.js
@@ -94,6 +94,7 @@ export async function handlePgDecomposition({ triageResult, pgTaskId, pgProject,
 
 /**
  * Mark PG card as "To Validate" on approved session completion.
+ * Merges commits from gitResult and session.pg_commits (accumulated during pipeline).
  */
 export async function markPgCardToValidate({ pgCard, pgProject, config, session, gitResult, logger }) {
   if (!pgCard || !pgProject) return;
@@ -101,9 +102,21 @@ export async function markPgCardToValidate({ pgCard, pgProject, config, session,
   try {
     const { updateCard } = await import("./client.js");
     const { buildCompletionUpdates } = await import("./adapter.js");
+
+    // Merge commits: session.pg_commits (accumulated) + gitResult.commits (final)
+    const accumulatedCommits = session.pg_commits || [];
+    const finalCommits = gitResult?.commits || [];
+    const seenHashes = new Set(accumulatedCommits.map(c => c.hash));
+    const mergedCommits = [...accumulatedCommits];
+    for (const c of finalCommits) {
+      if (!seenHashes.has(c.hash)) {
+        mergedCommits.push(c);
+      }
+    }
+
     const pgUpdates = buildCompletionUpdates({
       approved: true,
-      commits: gitResult?.commits || [],
+      commits: mergedCommits,
       startDate: session.pg_card?.startDate || session.created_at,
       codeveloper: config.planning_game?.codeveloper || null
     });
@@ -154,6 +167,25 @@ export function buildHuStoriesFromPgCard(pgCard) {
   const storyText = parts.join("\n");
 
   return [{ id: storyId, text: storyText }];
+}
+
+/**
+ * Accumulate a commit into the session's pg_commits array.
+ * Called after each successful commitAll during the iteration loop.
+ * Best-effort: never throws.
+ *
+ * @param {object} session - Pipeline session (mutated)
+ * @param {{ hash: string, message: string, date?: string, author?: string }} commitInfo
+ */
+export function accumulateCommit(session, commitInfo) {
+  if (!session || !commitInfo?.hash) return;
+  if (!session.pg_commits) session.pg_commits = [];
+  session.pg_commits.push({
+    hash: commitInfo.hash,
+    message: commitInfo.message || "",
+    date: commitInfo.date || new Date().toISOString(),
+    author: commitInfo.author || "BecarIA"
+  });
 }
 
 // --- Internal helpers ---

--- a/tests/pg-lifecycle.test.js
+++ b/tests/pg-lifecycle.test.js
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// --- Mocks for pipeline-adapter dependencies ---
+const mockFetchCard = vi.fn();
+const mockUpdateCard = vi.fn();
+
+vi.mock("../src/planning-game/client.js", () => ({
+  fetchCard: (...args) => mockFetchCard(...args),
+  updateCard: (...args) => mockUpdateCard(...args)
+}));
+
+const { initPgAdapter, markPgCardToValidate, accumulateCommit } = await import("../src/planning-game/pipeline-adapter.js");
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    planning_game: { enabled: true, codeveloper: "dev_042", ...overrides.planning_game },
+    ...overrides
+  };
+}
+
+describe("PG card lifecycle auto-tracking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- markCardInProgress via initPgAdapter ---
+
+  describe("initPgAdapter (markCardInProgress)", () => {
+    it("marks card as In Progress when pgTaskId is set and card is not In Progress", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123", status: "To Do" };
+      mockFetchCard.mockResolvedValue(pgCard);
+      mockUpdateCard.mockResolvedValue({});
+
+      const result = await initPgAdapter({
+        session: { id: "sess-1" },
+        config: makeConfig(),
+        logger: makeLogger(),
+        pgTaskId: "KJC-TSK-0210",
+        pgProject: "karajan-code"
+      });
+
+      expect(result.pgCard).toBeTruthy();
+      expect(mockFetchCard).toHaveBeenCalledWith({ projectId: "karajan-code", cardId: "KJC-TSK-0210" });
+      expect(mockUpdateCard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: "karajan-code",
+          cardId: "KJC-TSK-0210",
+          firebaseId: "fb-123",
+          updates: expect.objectContaining({
+            status: "In Progress",
+            developer: "dev_016",
+            codeveloper: "dev_042"
+          })
+        })
+      );
+      // startDate should be an ISO string
+      const updateCall = mockUpdateCard.mock.calls[0][0];
+      expect(updateCall.updates.startDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("does NOT call updateCard when pgTaskId is not set", async () => {
+      const result = await initPgAdapter({
+        session: { id: "sess-1" },
+        config: makeConfig(),
+        logger: makeLogger(),
+        pgTaskId: null,
+        pgProject: "karajan-code"
+      });
+
+      expect(result.pgCard).toBeNull();
+      expect(mockFetchCard).not.toHaveBeenCalled();
+      expect(mockUpdateCard).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent: skips update when card is already In Progress", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123", status: "In Progress" };
+      mockFetchCard.mockResolvedValue(pgCard);
+
+      const result = await initPgAdapter({
+        session: { id: "sess-1" },
+        config: makeConfig(),
+        logger: makeLogger(),
+        pgTaskId: "KJC-TSK-0210",
+        pgProject: "karajan-code"
+      });
+
+      expect(result.pgCard).toBeTruthy();
+      expect(mockFetchCard).toHaveBeenCalled();
+      expect(mockUpdateCard).not.toHaveBeenCalled();
+    });
+
+    it("does not block pipeline on PG error (best-effort)", async () => {
+      mockFetchCard.mockRejectedValue(new Error("PG API down"));
+
+      const logger = makeLogger();
+      const result = await initPgAdapter({
+        session: { id: "sess-1" },
+        config: makeConfig(),
+        logger,
+        pgTaskId: "KJC-TSK-0210",
+        pgProject: "karajan-code"
+      });
+
+      expect(result.pgCard).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("PG API down"));
+    });
+  });
+
+  // --- accumulateCommit ---
+
+  describe("accumulateCommit", () => {
+    it("accumulates commits in session.pg_commits", () => {
+      const session = { id: "sess-1" };
+
+      accumulateCommit(session, { hash: "abc123", message: "feat: first" });
+      accumulateCommit(session, { hash: "def456", message: "fix: second", date: "2026-03-30T12:00:00Z", author: "dev" });
+
+      expect(session.pg_commits).toHaveLength(2);
+      expect(session.pg_commits[0]).toEqual(expect.objectContaining({ hash: "abc123", message: "feat: first" }));
+      expect(session.pg_commits[1]).toEqual({ hash: "def456", message: "fix: second", date: "2026-03-30T12:00:00Z", author: "dev" });
+    });
+
+    it("initializes pg_commits array if not present", () => {
+      const session = { id: "sess-1" };
+      accumulateCommit(session, { hash: "aaa", message: "init" });
+      expect(session.pg_commits).toHaveLength(1);
+    });
+
+    it("no-ops when commitInfo is null or missing hash", () => {
+      const session = { id: "sess-1" };
+      accumulateCommit(session, null);
+      accumulateCommit(session, {});
+      accumulateCommit(session, { message: "no hash" });
+      expect(session.pg_commits).toBeUndefined();
+    });
+
+    it("no-ops when session is null", () => {
+      expect(() => accumulateCommit(null, { hash: "x", message: "y" })).not.toThrow();
+    });
+  });
+
+  // --- markPgCardToValidate ---
+
+  describe("markPgCardToValidate", () => {
+    it("marks card as To Validate with accumulated commits on approved pipeline", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123", status: "In Progress" };
+      mockUpdateCard.mockResolvedValue({});
+
+      const session = {
+        id: "sess-1",
+        pg_task_id: "KJC-TSK-0210",
+        pg_card: { startDate: "2026-03-30T10:00:00Z" },
+        pg_commits: [
+          { hash: "aaa", message: "feat: step 1", date: "2026-03-30T10:30:00Z", author: "BecarIA" }
+        ],
+        created_at: "2026-03-30T10:00:00Z"
+      };
+
+      await markPgCardToValidate({
+        pgCard,
+        pgProject: "karajan-code",
+        config: makeConfig(),
+        session,
+        gitResult: { commits: [{ hash: "bbb", message: "feat: final" }] },
+        logger: makeLogger()
+      });
+
+      expect(mockUpdateCard).toHaveBeenCalledOnce();
+      const updateCall = mockUpdateCard.mock.calls[0][0];
+      expect(updateCall.updates.status).toBe("To Validate");
+      expect(updateCall.updates.endDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      // Should have merged commits: aaa from pg_commits + bbb from gitResult
+      expect(updateCall.updates.commits).toHaveLength(2);
+      expect(updateCall.updates.commits[0].hash).toBe("aaa");
+      expect(updateCall.updates.commits[1].hash).toBe("bbb");
+    });
+
+    it("deduplicates commits by hash", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123" };
+      mockUpdateCard.mockResolvedValue({});
+
+      const session = {
+        id: "sess-1",
+        pg_task_id: "KJC-TSK-0210",
+        pg_card: {},
+        pg_commits: [
+          { hash: "aaa", message: "feat: same", date: "2026-03-30T10:30:00Z", author: "BecarIA" }
+        ],
+        created_at: "2026-03-30T10:00:00Z"
+      };
+
+      await markPgCardToValidate({
+        pgCard,
+        pgProject: "karajan-code",
+        config: makeConfig(),
+        session,
+        gitResult: { commits: [{ hash: "aaa", message: "feat: same" }] },
+        logger: makeLogger()
+      });
+
+      const updateCall = mockUpdateCard.mock.calls[0][0];
+      expect(updateCall.updates.commits).toHaveLength(1);
+    });
+
+    it("does NOT call updateCard when pgCard is null", async () => {
+      await markPgCardToValidate({
+        pgCard: null,
+        pgProject: "karajan-code",
+        config: makeConfig(),
+        session: { id: "sess-1", pg_task_id: "KJC-TSK-0210" },
+        gitResult: { commits: [] },
+        logger: makeLogger()
+      });
+
+      expect(mockUpdateCard).not.toHaveBeenCalled();
+    });
+
+    it("does not block pipeline on PG error (best-effort)", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123" };
+      mockUpdateCard.mockRejectedValue(new Error("PG timeout"));
+
+      const logger = makeLogger();
+      await markPgCardToValidate({
+        pgCard,
+        pgProject: "karajan-code",
+        config: makeConfig(),
+        session: { id: "sess-1", pg_task_id: "KJC-TSK-0210", pg_card: {}, created_at: "2026-03-30T10:00:00Z" },
+        gitResult: { commits: [] },
+        logger
+      });
+
+      // Should not throw, just warn
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("PG timeout"));
+    });
+
+    it("works when no pg_commits accumulated (uses gitResult only)", async () => {
+      const pgCard = { cardId: "KJC-TSK-0210", firebaseId: "fb-123" };
+      mockUpdateCard.mockResolvedValue({});
+
+      const session = {
+        id: "sess-1",
+        pg_task_id: "KJC-TSK-0210",
+        pg_card: {},
+        created_at: "2026-03-30T10:00:00Z"
+        // no pg_commits
+      };
+
+      await markPgCardToValidate({
+        pgCard,
+        pgProject: "karajan-code",
+        config: makeConfig(),
+        session,
+        gitResult: { commits: [{ hash: "ccc", message: "feat: only" }] },
+        logger: makeLogger()
+      });
+
+      const updateCall = mockUpdateCard.mock.calls[0][0];
+      expect(updateCall.updates.commits).toHaveLength(1);
+      expect(updateCall.updates.commits[0].hash).toBe("ccc");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `accumulateCommit()`: collects commits during pipeline in session.pg_commits
- `markPgCardToValidate()`: merges accumulated + final commits, deduplicates by hash
- Orchestrator calls accumulateCommit at each commit point
- All PG calls best-effort (don't block pipeline)
- 13 new tests (2388 total)

Closes KJC-TSK-0210. Completes epic KJC-PCS-0026.

## Test plan
- [x] 186 files, 2388 tests pass
- [ ] CI green