### PR TITLE
refactor: sync I/O → async in basal-cost.js and store.js

### DIFF
--- a/src/audit/basal-cost.js
+++ b/src/audit/basal-cost.js
@@ -1,7 +1,10 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { getKarajanHome } from "../utils/paths.js";
+
+const execFileAsync = promisify(execFile);
 
 const SOURCE_EXTENSIONS = new Set([
   ".js", ".mjs", ".cjs", ".ts", ".mts", ".cts", ".tsx", ".jsx",
@@ -18,11 +21,11 @@ function slugify(projectDir) {
   return path.basename(projectDir).replace(/[^a-zA-Z0-9_-]/g, "_");
 }
 
-function walkSourceFiles(dir) {
+async function walkSourceFiles(dir) {
   // Use git ls-files for speed (instant vs recursive walk)
   try {
-    const output = execFileSync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], { cwd: dir, encoding: "utf8", timeout: 5000 });
-    return output.trim().split("\n")
+    const { stdout } = await execFileAsync("git", ["ls-files", "--cached", "--others", "--exclude-standard"], { cwd: dir, encoding: "utf8", timeout: 5000 });
+    return stdout.trim().split("\n")
       .filter(f => f && SOURCE_EXTENSIONS.has(path.extname(f)) && !EXCLUDE_DIRS.has(f.split("/")[0]))
       .map(f => path.join(dir, f));
   } catch {
@@ -30,15 +33,15 @@ function walkSourceFiles(dir) {
     const files = [];
     let entries;
     try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch { /* directory not readable */
       return files;
     }
     for (const entry of entries) {
       if (EXCLUDE_DIRS.has(entry.name)) continue;
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        files.push(...walkSourceFiles(full));
+        files.push(...await walkSourceFiles(full));
       } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
         files.push(full);
       }
@@ -47,19 +50,19 @@ function walkSourceFiles(dir) {
   }
 }
 
-function countLines(filePath) {
+async function countLines(filePath) {
   try {
-    const content = fs.readFileSync(filePath, "utf8");
+    const content = await fs.readFile(filePath, "utf8");
     return content.split("\n").length;
   } catch {
     return 0;
   }
 }
 
-function countDependencies(projectDir) {
+async function countDependencies(projectDir) {
   const pkgPath = path.join(projectDir, "package.json");
   try {
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    const pkg = JSON.parse(await fs.readFile(pkgPath, "utf8"));
     const deps = Object.keys(pkg.dependencies || {});
     const devDeps = Object.keys(pkg.devDependencies || {});
     return { dependencies: deps.length, devDependencies: devDeps.length, total: deps.length + devDeps.length };
@@ -89,7 +92,7 @@ function runDepcheck(projectDir) {
   });
 }
 
-function findDeadExports(sourceFiles) {
+async function findDeadExports(sourceFiles) {
   const exportMap = new Map(); // file -> [exportName]
   const importedNames = new Set();
 
@@ -101,7 +104,7 @@ function findDeadExports(sourceFiles) {
   for (const file of sourceFiles) {
     let content;
     try {
-      content = fs.readFileSync(file, "utf8");
+      content = await fs.readFile(file, "utf8");
     } catch {
       continue;
     }
@@ -139,15 +142,15 @@ function findDeadExports(sourceFiles) {
 }
 
 export async function measureBasalCost(projectDir) {
-  const sourceFiles = walkSourceFiles(projectDir);
+  const sourceFiles = await walkSourceFiles(projectDir);
   let totalLines = 0;
   for (const f of sourceFiles) {
-    totalLines += countLines(f);
+    totalLines += await countLines(f);
   }
 
-  const depInfo = countDependencies(projectDir);
+  const depInfo = await countDependencies(projectDir);
   const depcheck = await runDepcheck(projectDir);
-  const deadExports = findDeadExports(sourceFiles);
+  const deadExports = await findDeadExports(sourceFiles);
 
   return {
     totalLines,
@@ -162,20 +165,20 @@ function auditDir() {
   return path.join(getKarajanHome(), "audits");
 }
 
-export function loadPreviousAudit(projectDir) {
+export async function loadPreviousAudit(projectDir) {
   const file = path.join(auditDir(), slugify(projectDir), "latest.json");
   try {
-    return JSON.parse(fs.readFileSync(file, "utf8"));
+    return JSON.parse(await fs.readFile(file, "utf8"));
   } catch {
     return null;
   }
 }
 
-export function saveAuditSnapshot(projectDir, metrics) {
+export async function saveAuditSnapshot(projectDir, metrics) {
   const dir = path.join(auditDir(), slugify(projectDir));
-  fs.mkdirSync(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true });
   const snapshot = { ...metrics, timestamp: new Date().toISOString() };
-  fs.writeFileSync(path.join(dir, "latest.json"), JSON.stringify(snapshot, null, 2));
+  await fs.writeFile(path.join(dir, "latest.json"), JSON.stringify(snapshot, null, 2));
   return snapshot;
 }
 

--- a/src/hu/store.js
+++ b/src/hu/store.js
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 import { getKarajanHome } from "../utils/paths.js";
 
 // FUTURE: hu-storage adapter for PG/Trello/etc — currently local files only
@@ -237,13 +240,14 @@ export function addSplittingMetadata(batch, huId, metadata) {
 /**
  * Detect project info from the given directory.
  * @param {string} cwd - Directory to detect project from.
- * @returns {{ name: string, remoteUrl: string|null }}
+ * @returns {Promise<{ name: string, remoteUrl: string|null }>}
  */
-export function detectProject(cwd) {
+export async function detectProject(cwd) {
   const name = path.basename(cwd);
   let remoteUrl = null;
   try {
-    remoteUrl = execSync("git remote get-url origin", { cwd, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    const { stdout } = await execFileAsync("git", ["remote", "get-url", "origin"], { cwd, encoding: "utf8" });
+    remoteUrl = stdout.trim();
   } catch { /* not a git repo or no remote */ }
   return { name, remoteUrl };
 }

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -63,7 +63,7 @@ export class AuditRole extends BaseRole {
     let growthDelta = null;
     try {
       basalCost = await measureBasalCost(projectDir);
-      const previous = loadPreviousAudit(projectDir);
+      const previous = await loadPreviousAudit(projectDir);
       growthDelta = computeGrowthDelta(basalCost, previous);
     } catch {
       // basal cost is best-effort, don't fail the audit
@@ -95,7 +95,7 @@ export class AuditRole extends BaseRole {
       }
 
       if (basalCost) {
-        try { saveAuditSnapshot(projectDir, basalCost); } catch { /* best-effort */ }
+        try { await saveAuditSnapshot(projectDir, basalCost); } catch { /* best-effort */ }
       }
 
       return {

--- a/tests/kj-hu-tool.test.js
+++ b/tests/kj-hu-tool.test.js
@@ -126,7 +126,7 @@ describe("kj_hu tool", () => {
 
   it("project detection from directory name works", async () => {
     const { detectProject } = await import("../src/hu/store.js");
-    const result = detectProject(projectDir);
+    const result = await detectProject(projectDir);
     expect(result.name).toBe("my-test-project");
     // No git repo in temp dir, so remoteUrl should be null
     expect(result.remoteUrl).toBeNull();

--- a/tests/lean-audit.test.js
+++ b/tests/lean-audit.test.js
@@ -73,11 +73,11 @@ describe("measureBasalCost", () => {
 });
 
 describe("loadPreviousAudit", () => {
-  it("returns null when no previous audit", () => {
+  it("returns null when no previous audit", async () => {
     const originalEnv = process.env.KJ_HOME;
     process.env.KJ_HOME = path.join(tmpDir, ".karajan");
     try {
-      const result = loadPreviousAudit("/fake/project");
+      const result = await loadPreviousAudit("/fake/project");
       expect(result).toBeNull();
     } finally {
       if (originalEnv === undefined) delete process.env.KJ_HOME;
@@ -87,7 +87,7 @@ describe("loadPreviousAudit", () => {
 });
 
 describe("saveAuditSnapshot + loadPreviousAudit roundtrip", () => {
-  it("saves and loads audit snapshot", () => {
+  it("saves and loads audit snapshot", async () => {
     const originalEnv = process.env.KJ_HOME;
     process.env.KJ_HOME = path.join(tmpDir, ".karajan");
     try {
@@ -100,11 +100,11 @@ describe("saveAuditSnapshot + loadPreviousAudit roundtrip", () => {
         deadExports: []
       };
 
-      const saved = saveAuditSnapshot(projectDir, metrics);
+      const saved = await saveAuditSnapshot(projectDir, metrics);
       expect(saved.timestamp).toBeDefined();
       expect(saved.totalLines).toBe(500);
 
-      const loaded = loadPreviousAudit(projectDir);
+      const loaded = await loadPreviousAudit(projectDir);
       expect(loaded).not.toBeNull();
       expect(loaded.totalLines).toBe(500);
       expect(loaded.totalFiles).toBe(20);


### PR DESCRIPTION
Closes KJC-TSK-0215. All fs sync ops replaced with async. 2388 tests pass.