### PR TITLE
refactor: centralize SonarQube config resolution

### DIFF
--- a/src/orchestrator/preflight-checks.js
+++ b/src/orchestrator/preflight-checks.js
@@ -13,11 +13,11 @@ import { checkBinary } from "../utils/agent-detect.js";
 import { isSonarReachable, sonarUp } from "../sonar/manager.js";
 import { runCommand } from "../utils/process.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
-import { loadSonarCredentials } from "../sonar/credentials.js";
-
-function normalizeApiHost(rawHost) {
-  return String(rawHost || "http://localhost:9000").replace(/host\.docker\.internal/g, "localhost");
-}
+import {
+  resolveSonarHost,
+  resolveSonarToken,
+  resolveSonarCredentials,
+} from "../sonar/config-resolver.js";
 
 function parseJsonSafe(text) {
   try {
@@ -60,10 +60,10 @@ async function checkSonarReachable(host) {
 }
 
 async function checkSonarAuth(config) {
-  const host = normalizeApiHost(config.sonarqube?.host);
+  const host = resolveSonarHost(config.sonarqube?.host);
 
   // Check explicit token first
-  const explicitToken = process.env.KJ_SONAR_TOKEN || process.env.SONAR_TOKEN || config.sonarqube?.token;
+  const explicitToken = resolveSonarToken(config);
   if (explicitToken) {
     // Validate the token works
     const res = await runCommand("curl", [
@@ -77,20 +77,14 @@ async function checkSonarAuth(config) {
     }
   }
 
-  // Try admin credentials: env vars → config → ~/.karajan/sonar-credentials.json (NO default admin/admin)
-  const fileCreds = await loadSonarCredentials() || {};
-  const adminUser = process.env.KJ_SONAR_ADMIN_USER || config.sonarqube?.admin_user || fileCreds.user;
-  const candidates = [
-    process.env.KJ_SONAR_ADMIN_PASSWORD,
-    config.sonarqube?.admin_password,
-    fileCreds.password
-  ].filter(Boolean);
+  // Try admin credentials via centralized resolver
+  const { user: adminUser, passwords } = await resolveSonarCredentials(config);
 
-  if (!adminUser || candidates.length === 0) {
+  if (!adminUser || passwords.length === 0) {
     return { name: "sonar-auth", ok: false, detail: "No Sonar token or admin credentials configured. Set KJ_SONAR_TOKEN, configure sonarqube.token in kj.config.yml, or save credentials in ~/.karajan/sonar-credentials.json." };
   }
 
-  for (const password of [...new Set(candidates)]) {
+  for (const password of passwords) {
     const validateRes = await runCommand("curl", [
       "-sS", "-u", `${adminUser}:${password}`,
       `${host}/api/authentication/validate`
@@ -151,7 +145,7 @@ async function checkSecurityAgent(config) {
 export async function runPreflightChecks({ config, logger, emitter, eventBase, resolvedPolicies, securityEnabled }) {
   const sonarEnabled = Boolean(config.sonarqube?.enabled) && resolvedPolicies.sonar !== false;
   const isExternalSonar = Boolean(config.sonarqube?.external);
-  const sonarHost = normalizeApiHost(config.sonarqube?.host);
+  const sonarHost = resolveSonarHost(config.sonarqube?.host);
 
   const result = {
     ok: true,

--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -1,6 +1,7 @@
 import { runCommand } from "../utils/process.js";
 import { withRetry } from "../utils/retry.js";
 import { resolveSonarProjectKey } from "./project-key.js";
+import { resolveSonarToken } from "./config-resolver.js";
 
 export class SonarApiError extends Error {
   constructor(message, { url, httpStatus, hint } = {}) {
@@ -13,7 +14,7 @@ export class SonarApiError extends Error {
 }
 
 function tokenFromConfig(config) {
-  return process.env.KJ_SONAR_TOKEN || config.sonarqube.token || "";
+  return resolveSonarToken(config) || "";
 }
 
 function parseHttpResponse(stdout) {

--- a/src/sonar/config-resolver.js
+++ b/src/sonar/config-resolver.js
@@ -1,0 +1,69 @@
+/**
+ * Centralized SonarQube configuration resolution.
+ *
+ * Single source of truth for host URL, token, and admin credentials.
+ * Consumers: scanner.js, preflight-checks.js, api.js.
+ */
+
+import { loadSonarCredentials } from "./credentials.js";
+
+const DEFAULT_HOST = "http://localhost:9000";
+
+/**
+ * Normalize SonarQube host URL for API calls (replace Docker-internal hostname).
+ * @param {string|undefined} rawHost - Raw host from config or env
+ * @returns {string} Normalized host URL without trailing slash
+ */
+export function resolveSonarHost(rawHost) {
+  const host = String(rawHost || DEFAULT_HOST)
+    .replace(/host\.docker\.internal/g, "localhost")
+    .replace(/\/+$/, "");
+  return host;
+}
+
+/**
+ * Resolve SonarQube auth token from (in priority order):
+ *   1. KJ_SONAR_TOKEN env var
+ *   2. config.sonarqube.token
+ *   3. SONAR_TOKEN env var
+ *
+ * @param {object} [config={}] - Karajan config object
+ * @returns {string|null} Token string or null if none found
+ */
+export function resolveSonarToken(config = {}) {
+  const token =
+    process.env.KJ_SONAR_TOKEN ||
+    config.sonarqube?.token ||
+    process.env.SONAR_TOKEN ||
+    null;
+  return token || null;
+}
+
+/**
+ * Resolve SonarQube admin credentials from (in priority order):
+ *   1. Env vars: KJ_SONAR_ADMIN_USER / KJ_SONAR_ADMIN_PASSWORD
+ *   2. Config: sonarqube.admin_user / sonarqube.admin_password
+ *   3. Credentials file: ~/.karajan/sonar-credentials.json
+ *
+ * Returns all candidate passwords (de-duped) so callers can try each.
+ *
+ * @param {object} [config={}] - Karajan config object
+ * @returns {Promise<{ user: string|null, passwords: string[] }>}
+ */
+export async function resolveSonarCredentials(config = {}) {
+  const fileCreds = (await loadSonarCredentials()) || {};
+
+  const user =
+    process.env.KJ_SONAR_ADMIN_USER ||
+    config.sonarqube?.admin_user ||
+    fileCreds.user ||
+    null;
+
+  const candidates = [
+    process.env.KJ_SONAR_ADMIN_PASSWORD,
+    config.sonarqube?.admin_password,
+    fileCreds.password,
+  ].filter(Boolean);
+
+  return { user, passwords: [...new Set(candidates)] };
+}

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -4,7 +4,11 @@ import path from "node:path";
 import { runCommand } from "../utils/process.js";
 import { sonarUp } from "./manager.js";
 import { resolveSonarProjectKey } from "./project-key.js";
-import { loadSonarCredentials } from "./credentials.js";
+import {
+  resolveSonarHost,
+  resolveSonarToken as resolveToken,
+  resolveSonarCredentials,
+} from "./config-resolver.js";
 
 export function buildScannerOpts(projectKey, scanner = {}) {
   const opts = [`-Dsonar.projectKey=${projectKey}`];
@@ -48,10 +52,6 @@ function parseJsonSafe(text) {
   } catch {
     return null;
   }
-}
-
-function normalizeApiHost(rawHost) {
-  return String(rawHost || "http://localhost:9000").replaceAll("host.docker.internal", "localhost");
 }
 
 async function validateAdminCredentials(host, user, password) {
@@ -133,22 +133,14 @@ async function maybeRunCoverage(config) {
   return checkLcovExists(lcovPath, blockOnFailure, run.stdout || "");
 }
 
-async function resolveSonarToken(config, apiHost) {
-  const explicitToken = process.env.KJ_SONAR_TOKEN || process.env.SONAR_TOKEN || config.sonarqube.token;
+async function resolveSonarTokenWithFallback(config, apiHost) {
+  const explicitToken = resolveToken(config);
   if (explicitToken) return explicitToken;
 
-  // Resolve admin credentials from: env vars → config → ~/.karajan/sonar-credentials.json
-  const fileCreds = await loadSonarCredentials() || {};
-  const adminUser = process.env.KJ_SONAR_ADMIN_USER || config.sonarqube.admin_user || fileCreds.user;
-  const candidates = [
-    process.env.KJ_SONAR_ADMIN_PASSWORD,
-    config.sonarqube.admin_password,
-    fileCreds.password
-  ].filter(Boolean);
+  const { user: adminUser, passwords } = await resolveSonarCredentials(config);
+  if (!adminUser || passwords.length === 0) return null;
 
-  if (!adminUser || candidates.length === 0) return null;
-
-  for (const password of new Set(candidates)) {
+  for (const password of passwords) {
     const valid = await validateAdminCredentials(apiHost, adminUser, password);
     if (!valid) continue;
     const token = await generateUserToken(apiHost, adminUser, password);
@@ -205,7 +197,7 @@ export async function runSonarScan(config, projectKey = null) {
     ? Number(sonarConfig.timeouts.scanner_ms)
     : 15 * 60 * 1000;
   const sonarNetwork = sonarConfig.network || "karajan_sonar_net";
-  const apiHost = normalizeApiHost(rawHost);
+  const apiHost = resolveSonarHost(rawHost);
   const isLocalHost = /localhost|127\.0\.0\.1/.test(rawHost);
   const host = isLocalHost ? rawHost.replaceAll(/localhost|127\.0\.0\.1/g, "host.docker.internal") : rawHost;
 
@@ -219,7 +211,7 @@ export async function runSonarScan(config, projectKey = null) {
     };
   }
   await ensureSonarProjectProperties();
-  const token = await resolveSonarToken(config, apiHost);
+  const token = await resolveSonarTokenWithFallback(config, apiHost);
   if (!token) {
     return {
       ok: false,

--- a/tests/sonar-config-resolver.test.js
+++ b/tests/sonar-config-resolver.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Mock credentials.js before importing the module under test
+vi.mock("../src/sonar/credentials.js", () => ({
+  loadSonarCredentials: vi.fn().mockResolvedValue({ user: null, password: null }),
+}));
+
+import {
+  resolveSonarHost,
+  resolveSonarToken,
+  resolveSonarCredentials,
+} from "../src/sonar/config-resolver.js";
+import { loadSonarCredentials } from "../src/sonar/credentials.js";
+
+describe("resolveSonarHost", () => {
+  it("returns default host when no input", () => {
+    expect(resolveSonarHost()).toBe("http://localhost:9000");
+    expect(resolveSonarHost(undefined)).toBe("http://localhost:9000");
+    expect(resolveSonarHost("")).toBe("http://localhost:9000");
+  });
+
+  it("replaces host.docker.internal with localhost", () => {
+    expect(resolveSonarHost("http://host.docker.internal:9000")).toBe("http://localhost:9000");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(resolveSonarHost("http://localhost:9000/")).toBe("http://localhost:9000");
+    expect(resolveSonarHost("http://localhost:9000///")).toBe("http://localhost:9000");
+  });
+
+  it("preserves external hosts", () => {
+    expect(resolveSonarHost("https://sonar.example.com")).toBe("https://sonar.example.com");
+  });
+});
+
+describe("resolveSonarToken", () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.KJ_SONAR_TOKEN = process.env.KJ_SONAR_TOKEN;
+    savedEnv.SONAR_TOKEN = process.env.SONAR_TOKEN;
+    delete process.env.KJ_SONAR_TOKEN;
+    delete process.env.SONAR_TOKEN;
+  });
+
+  afterEach(() => {
+    if (savedEnv.KJ_SONAR_TOKEN !== undefined) process.env.KJ_SONAR_TOKEN = savedEnv.KJ_SONAR_TOKEN;
+    else delete process.env.KJ_SONAR_TOKEN;
+    if (savedEnv.SONAR_TOKEN !== undefined) process.env.SONAR_TOKEN = savedEnv.SONAR_TOKEN;
+    else delete process.env.SONAR_TOKEN;
+  });
+
+  it("returns KJ_SONAR_TOKEN env var with highest priority", () => {
+    process.env.KJ_SONAR_TOKEN = "env-kj-token";
+    process.env.SONAR_TOKEN = "env-sonar-token";
+    const config = { sonarqube: { token: "config-token" } };
+    expect(resolveSonarToken(config)).toBe("env-kj-token");
+  });
+
+  it("returns config sonarqube.token as second priority", () => {
+    process.env.SONAR_TOKEN = "env-sonar-token";
+    const config = { sonarqube: { token: "config-token" } };
+    expect(resolveSonarToken(config)).toBe("config-token");
+  });
+
+  it("returns SONAR_TOKEN env var as third priority", () => {
+    process.env.SONAR_TOKEN = "env-sonar-token";
+    expect(resolveSonarToken({})).toBe("env-sonar-token");
+  });
+
+  it("returns null when no token available", () => {
+    expect(resolveSonarToken({})).toBeNull();
+    expect(resolveSonarToken()).toBeNull();
+  });
+});
+
+describe("resolveSonarCredentials", () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    savedEnv.KJ_SONAR_ADMIN_USER = process.env.KJ_SONAR_ADMIN_USER;
+    savedEnv.KJ_SONAR_ADMIN_PASSWORD = process.env.KJ_SONAR_ADMIN_PASSWORD;
+    delete process.env.KJ_SONAR_ADMIN_USER;
+    delete process.env.KJ_SONAR_ADMIN_PASSWORD;
+    loadSonarCredentials.mockResolvedValue({ user: null, password: null });
+  });
+
+  afterEach(() => {
+    if (savedEnv.KJ_SONAR_ADMIN_USER !== undefined) process.env.KJ_SONAR_ADMIN_USER = savedEnv.KJ_SONAR_ADMIN_USER;
+    else delete process.env.KJ_SONAR_ADMIN_USER;
+    if (savedEnv.KJ_SONAR_ADMIN_PASSWORD !== undefined) process.env.KJ_SONAR_ADMIN_PASSWORD = savedEnv.KJ_SONAR_ADMIN_PASSWORD;
+    else delete process.env.KJ_SONAR_ADMIN_PASSWORD;
+  });
+
+  it("resolves user and password from env vars", async () => {
+    process.env.KJ_SONAR_ADMIN_USER = "env-user";
+    process.env.KJ_SONAR_ADMIN_PASSWORD = "env-pass";
+    const result = await resolveSonarCredentials({});
+    expect(result.user).toBe("env-user");
+    expect(result.passwords).toEqual(["env-pass"]);
+  });
+
+  it("resolves from config as second priority", async () => {
+    const config = { sonarqube: { admin_user: "cfg-user", admin_password: "cfg-pass" } };
+    const result = await resolveSonarCredentials(config);
+    expect(result.user).toBe("cfg-user");
+    expect(result.passwords).toEqual(["cfg-pass"]);
+  });
+
+  it("resolves from credentials file as last priority", async () => {
+    loadSonarCredentials.mockResolvedValue({ user: "file-user", password: "file-pass" });
+    const result = await resolveSonarCredentials({});
+    expect(result.user).toBe("file-user");
+    expect(result.passwords).toEqual(["file-pass"]);
+  });
+
+  it("deduplicates passwords across sources", async () => {
+    process.env.KJ_SONAR_ADMIN_PASSWORD = "same-pass";
+    const config = { sonarqube: { admin_password: "same-pass" } };
+    loadSonarCredentials.mockResolvedValue({ user: null, password: "same-pass" });
+    const result = await resolveSonarCredentials(config);
+    expect(result.passwords).toEqual(["same-pass"]);
+  });
+
+  it("collects multiple unique passwords in order", async () => {
+    process.env.KJ_SONAR_ADMIN_USER = "user";
+    process.env.KJ_SONAR_ADMIN_PASSWORD = "env-pass";
+    const config = { sonarqube: { admin_password: "cfg-pass" } };
+    loadSonarCredentials.mockResolvedValue({ user: null, password: "file-pass" });
+    const result = await resolveSonarCredentials(config);
+    expect(result.passwords).toEqual(["env-pass", "cfg-pass", "file-pass"]);
+  });
+
+  it("returns null user and empty passwords when nothing configured", async () => {
+    const result = await resolveSonarCredentials({});
+    expect(result.user).toBeNull();
+    expect(result.passwords).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes KJC-TSK-0216. Single config-resolver.js for host, token, credentials. 14 new tests.