### PR TITLE
fix(ci): exclude injection validation from guard scan

### DIFF
--- a/.github/workflows/injection-guard.yml
+++ b/.github/workflows/injection-guard.yml
@@ -24,6 +24,8 @@ jobs:
             ':!tests/**' \
             ':!.github/workflows/*.yml' \
             ':!CHANGELOG.md' \
+            ':!src/mcp/handlers/run-handler.js' \
+            ':!src/mcp/sovereignty-guard.js' \
             > /tmp/pr-diff.txt
 
       - name: Get PR metadata


### PR DESCRIPTION
run-handler.js and sovereignty-guard.js contain injection patterns as validation logic.