### PR TITLE
fix(i18n): pipeline messages respect configured language

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -31,6 +31,7 @@ import { classifyIntent } from "./guards/intent-guard.js";
 import { resolveReviewProfile } from "./review/profiles.js";
 import { CoderRole } from "./roles/coder-role.js";
 import { invokeSolomon } from "./orchestrator/solomon-escalation.js";
+import { msg, getLang } from "./utils/messages.js";
 import { PipelineContext } from "./orchestrator/pipeline-context.js";
 import { runTriageStage, runResearcherStage, runArchitectStage, runPlannerStage, runDiscoverStage, runHuReviewerStage } from "./orchestrator/pre-loop-stages.js";
 import { runCoderStage, runRefactorerStage, runTddCheckStage, runSonarStage, runSonarCloudStage, runReviewerStage } from "./orchestrator/iteration-stages.js";
@@ -402,8 +403,9 @@ async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpoin
     })
   );
 
+  const lang = getLang(config);
   const answer = await askQuestion(
-    `${checkpointMsg}\n\n1 = Continue 5 more minutes\n2 = Continue until done (no more checkpoints)\n3 = Continue for N minutes (type the number of minutes)\n4 = Stop now\n\nType 1, 2, 3, or 4:`
+    `${checkpointMsg}\n\n${msg("checkpoint_options", lang)}`
   );
 
   await addCheckpoint(session, { stage: "interactive-checkpoint", elapsed_minutes: Number(elapsedStr), answer });
@@ -1292,11 +1294,13 @@ async function runSingleIteration(ctx) {
 
   const reviewerRetryCount = session.reviewer_retry_count || 0;
   const maxReviewerRetries = config.session.max_reviewer_retries ?? config.session.fail_fast_repeats;
+  const iterLang = getLang(config);
+  const iterMsg = msg("pipeline_iteration", iterLang, { current: i, max: config.max_iterations });
   emitProgress(emitter, makeEvent("iteration:start", { ...eventBase, stage: "iteration" }, {
-    message: `Iteration ${i}/${config.max_iterations}`,
+    message: iterMsg,
     detail: { iteration: i, maxIterations: config.max_iterations, reviewerRetryCount, maxReviewerRetries }
   }));
-  logger.info(`Iteration ${i}/${config.max_iterations}`);
+  logger.info(iterMsg);
 
   const crResult = await runCoderAndRefactorerStages({
     coderRoleInstance: ctx.coderRoleInstance, coderRole: ctx.coderRole, refactorerRole: ctx.refactorerRole,

--- a/src/orchestrator/preflight-checks.js
+++ b/src/orchestrator/preflight-checks.js
@@ -13,6 +13,7 @@ import { checkBinary } from "../utils/agent-detect.js";
 import { isSonarReachable, sonarUp } from "../sonar/manager.js";
 import { runCommand } from "../utils/process.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
+import { msg, getLang } from "../utils/messages.js";
 import {
   resolveSonarHost,
   resolveSonarToken,
@@ -273,13 +274,14 @@ export async function runPreflightChecks({ config, logger, emitter, eventBase, r
 
   const hasErrors = result.errors.length > 0;
   const hasWarnings = result.warnings.length > 0;
+  const preflightLang = getLang(config);
   emitProgress(emitter, makeEvent("preflight:end", { ...eventBase, stage: "preflight" }, {
     status: hasErrors ? "fail" : hasWarnings ? "warn" : "ok",
     message: hasErrors
       ? `Preflight FAILED — ${result.errors.length} blocking issue(s)`
       : hasWarnings
         ? `Preflight completed with ${result.warnings.length} warning(s)`
-        : "Preflight passed — all checks OK",
+        : msg("preflight_passed", preflightLang),
     detail: { ...result, executorType: "local" }
   }));
 

--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -1,6 +1,7 @@
 import { SolomonRole } from "../roles/solomon-role.js";
 import { addCheckpoint, pauseSession, saveSession } from "../session-store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
+import { msg, getLang } from "../utils/messages.js";
 
 /**
  * Build a human-readable escalation message from raw Solomon conflict data.
@@ -14,15 +15,16 @@ export function formatEscalationMessage(solomonResult, session) {
   const stage = solomonResult?.stage || "unknown";
   const solomonReason = solomonResult?.solomonReason || null;
   const history = solomonResult?.history || [];
+  const lang = getLang(session?.config_snapshot);
 
   const lines = [];
-  lines.push(`--- Conflict: ${stage} ---`);
+  lines.push(msg("solomon_conflict", lang, { stage }));
   lines.push("");
 
   // Extract reviewer/agent feedback from history
   const feedbackEntries = history.filter(entry => entry && typeof entry === "object");
   if (feedbackEntries.length > 0) {
-    lines.push("Reviewer feedback:");
+    lines.push(msg("solomon_feedback", lang));
     for (const entry of feedbackEntries) {
       const agent = entry.agent || "unknown";
       const feedback = entry.feedback || "No feedback provided";
@@ -42,7 +44,7 @@ export function formatEscalationMessage(solomonResult, session) {
 
   // Solomon's reason (if it tried and failed)
   if (solomonReason) {
-    lines.push(`Solomon could not resolve the conflict: ${solomonReason}`);
+    lines.push(`${msg("solomon_reason", lang)} ${solomonReason}`);
     lines.push("");
   }
 
@@ -50,16 +52,13 @@ export function formatEscalationMessage(solomonResult, session) {
   const iterationCount = solomonResult?.iterationCount;
   const maxIterations = solomonResult?.maxIterations;
   if (iterationCount !== undefined && maxIterations !== undefined) {
-    lines.push(`Iterations: ${iterationCount}/${maxIterations}`);
+    lines.push(msg("pipeline_iteration", lang, { current: iterationCount, max: maxIterations }));
     lines.push("");
   }
 
-  lines.push("Options:");
-  lines.push("  1. Accept coder's work as-is");
-  lines.push("  2. Retry with reviewer's feedback");
-  lines.push("  3. Stop the session");
+  lines.push(msg("solomon_options", lang));
   lines.push("");
-  lines.push("How should we proceed?");
+  lines.push(msg("solomon_proceed", lang));
 
   return lines.join("\n");
 }

--- a/src/planning-game/decomposition.js
+++ b/src/planning-game/decomposition.js
@@ -4,6 +4,8 @@
  * recommends decomposition and user accepts.
  */
 
+import { msg } from "../utils/messages.js";
+
 export async function createDecompositionSubtasks({
   client,
   projectId,
@@ -66,9 +68,9 @@ export async function createDecompositionSubtasks({
   return created;
 }
 
-export function buildDecompositionQuestion(subtasks, parentCardId) {
+export function buildDecompositionQuestion(subtasks, parentCardId, lang = "en") {
   const lines = [
-    `Triage recommends decomposing this task into ${subtasks.length} subtasks:`,
+    msg("triage_decompose", lang, { count: subtasks.length }),
     ""
   ];
   for (let i = 0; i < subtasks.length; i++) {
@@ -76,14 +78,10 @@ export function buildDecompositionQuestion(subtasks, parentCardId) {
   }
   lines.push(
     "",
-    `Parent card: ${parentCardId}. Each subtask will block the next one (sequential chain).`,
+    msg("triage_create_cards", lang, { cardId: parentCardId }),
+    msg("triage_sequential", lang),
     "",
-    "What should we do?",
-    "1 = Accept and create the subtasks",
-    "2 = Reject and continue without decomposing",
-    "3 = Modify (write your proposal)",
-    "",
-    "Type 1, 2, or 3:"
+    msg("triage_reply", lang)
   );
   return lines.join("\n");
 }

--- a/src/planning-game/pipeline-adapter.js
+++ b/src/planning-game/pipeline-adapter.js
@@ -13,6 +13,7 @@
 
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { addCheckpoint, saveSession } from "../session-store.js";
+import { getLang } from "../utils/messages.js";
 
 /**
  * Attach the PG adapter to a pipeline emitter.
@@ -54,7 +55,8 @@ export async function handlePgDecomposition({ triageResult, pgTaskId, pgProject,
     const { buildDecompositionQuestion, createDecompositionSubtasks } = await import("./decomposition.js");
     const { createCard, relateCards, fetchCard } = await import("./client.js");
 
-    const question = buildDecompositionQuestion(triageResult.stageResult.subtasks, pgTaskId);
+    const lang = getLang(config);
+    const question = buildDecompositionQuestion(triageResult.stageResult.subtasks, pgTaskId, lang);
     const answer = await askQuestion(question);
 
     const normalizedAnswer = (answer || "").trim().toLowerCase();

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -1,0 +1,61 @@
+/**
+ * Centralized message catalog for pipeline UI strings.
+ * Supports i18n by resolving messages for the configured language.
+ * Falls back to English when a key or language is missing.
+ */
+
+const MESSAGES = {
+  en: {
+    triage_decompose: "Triage recommends decomposing this task into {count} subtasks:",
+    triage_create_cards: "Create these as linked cards in Planning Game (parent: {cardId})?",
+    triage_sequential: "Each subtask will block the next one (sequential chain).",
+    triage_reply: "Reply: yes / no",
+    solomon_conflict: "--- Conflict: {stage} ---",
+    solomon_feedback: "Reviewer feedback:",
+    solomon_reason: "Solomon could not resolve the conflict:",
+    solomon_options: "Options:\n  1. Accept coder's work as-is\n  2. Retry with reviewer's feedback\n  3. Stop the session",
+    solomon_proceed: "How should we proceed?",
+    checkpoint_continue: "Continue for {minutes} more minutes?",
+    checkpoint_options: "1. Continue 5 more minutes\n2. Continue until done (no more checkpoints)\n3. Continue for N minutes (reply with the number)\n4. Stop now",
+    preflight_passed: "Preflight passed — all checks OK",
+    pipeline_iteration: "Iteration {current}/{max}",
+  },
+  es: {
+    triage_decompose: "Triage recomienda descomponer esta tarea en {count} subtareas:",
+    triage_create_cards: "¿Crear estas como cards vinculadas en Planning Game (padre: {cardId})?",
+    triage_sequential: "Cada subtarea bloqueará la siguiente (cadena secuencial).",
+    triage_reply: "Responde: sí / no",
+    solomon_conflict: "--- Conflicto: {stage} ---",
+    solomon_feedback: "Feedback del reviewer:",
+    solomon_reason: "Solomon no pudo resolver el conflicto:",
+    solomon_options: "Opciones:\n  1. Aceptar el trabajo del coder tal cual\n  2. Reintentar con el feedback del reviewer\n  3. Parar la sesión",
+    solomon_proceed: "¿Cómo procedemos?",
+    checkpoint_continue: "¿Continuar {minutes} minutos más?",
+    checkpoint_options: "1. Continuar (5 min)\n2. Continuar hasta terminar\n3. Tiempo personalizado\n4. Parar",
+    preflight_passed: "Preflight superado — todas las comprobaciones OK",
+    pipeline_iteration: "Iteración {current}/{max}",
+  }
+};
+
+/**
+ * Resolve a message template by key and language, interpolating parameters.
+ * Falls back to English, then to the raw key if not found.
+ *
+ * @param {string} key - Message key (e.g. "solomon_conflict")
+ * @param {string} [lang="en"] - 2-letter language code
+ * @param {object} [params={}] - Interpolation values (e.g. {stage: "reviewer"})
+ * @returns {string}
+ */
+export function msg(key, lang = "en", params = {}) {
+  const template = MESSAGES[lang]?.[key] || MESSAGES.en[key] || key;
+  return template.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+}
+
+/**
+ * Extract the language code from a Karajan config object.
+ * @param {object} [config] - Karajan config
+ * @returns {string} 2-letter language code
+ */
+export function getLang(config) {
+  return config?.language || "en";
+}

--- a/tests/i18n-messages.test.js
+++ b/tests/i18n-messages.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { msg, getLang } from "../src/utils/messages.js";
+
+describe("msg()", () => {
+  it("returns Spanish message with interpolation", () => {
+    const result = msg("triage_decompose", "es", { count: 5 });
+    expect(result).toBe("Triage recomienda descomponer esta tarea en 5 subtareas:");
+  });
+
+  it("returns English message with interpolation", () => {
+    const result = msg("triage_decompose", "en", { count: 5 });
+    expect(result).toBe("Triage recommends decomposing this task into 5 subtasks:");
+  });
+
+  it("falls back to English when language is missing", () => {
+    const result = msg("solomon_feedback", "fr");
+    expect(result).toBe("Reviewer feedback:");
+  });
+
+  it("returns key as fallback for unknown keys", () => {
+    const result = msg("unknown_key", "es");
+    expect(result).toBe("unknown_key");
+  });
+
+  it("preserves unreplaced placeholders", () => {
+    const result = msg("solomon_conflict", "en", {});
+    expect(result).toBe("--- Conflict: {stage} ---");
+  });
+
+  it("interpolates Solomon conflict with stage param", () => {
+    expect(msg("solomon_conflict", "es", { stage: "reviewer" })).toBe("--- Conflicto: reviewer ---");
+  });
+
+  it("interpolates pipeline_iteration", () => {
+    expect(msg("pipeline_iteration", "es", { current: 2, max: 5 })).toBe("Iteración 2/5");
+    expect(msg("pipeline_iteration", "en", { current: 2, max: 5 })).toBe("Iteration 2/5");
+  });
+
+  it("defaults to English when lang is undefined", () => {
+    const result = msg("preflight_passed");
+    expect(result).toBe("Preflight passed — all checks OK");
+  });
+
+  it("returns checkpoint_options in Spanish", () => {
+    const result = msg("checkpoint_options", "es");
+    expect(result).toContain("Continuar");
+    expect(result).toContain("Parar");
+  });
+});
+
+describe("getLang()", () => {
+  it("returns configured language", () => {
+    expect(getLang({ language: "es" })).toBe("es");
+  });
+
+  it("returns 'en' when language is not set", () => {
+    expect(getLang({ })).toBe("en");
+  });
+
+  it("returns 'en' when config is null", () => {
+    expect(getLang(null)).toBe("en");
+  });
+
+  it("returns 'en' when config is undefined", () => {
+    expect(getLang(undefined)).toBe("en");
+  });
+
+  it("returns 'en' when config has no language field", () => {
+    expect(getLang({ someOther: "value" })).toBe("en");
+  });
+});

--- a/tests/solomon-messages.test.js
+++ b/tests/solomon-messages.test.js
@@ -19,7 +19,7 @@ describe("formatEscalationMessage", () => {
     expect(result).toContain("Reviewer feedback:");
     expect(result).toContain("[reviewer] R-1: The change only deletes code without replacing it");
     expect(result).toContain("Solomon could not resolve the conflict: Solomon error: timeout");
-    expect(result).toContain("Iterations: 3/3");
+    expect(result).toContain("Iteration 3/3");
     expect(result).toContain("1. Accept coder's work as-is");
     expect(result).toContain("2. Retry with reviewer's feedback");
     expect(result).toContain("3. Stop the session");
@@ -138,7 +138,7 @@ describe("formatEscalationMessage", () => {
 
     const result = formatEscalationMessage(conflict);
 
-    expect(result).toContain("Iterations: 5/10");
+    expect(result).toContain("Iteration 5/10");
   });
 
   it("omits iteration context when not provided", () => {
@@ -149,6 +149,6 @@ describe("formatEscalationMessage", () => {
 
     const result = formatEscalationMessage(conflict);
 
-    expect(result).not.toContain("Iterations:");
+    expect(result).not.toContain("Iteration ");
   });
 });


### PR DESCRIPTION
## Summary
- New `src/utils/messages.js`: message catalog EN/ES with `msg(key, lang, params)`
- Solomon, triage, checkpoints, preflight all use `msg()` instead of hardcoded English
- 14 new tests

Closes KJC-BUG-0014

## Test plan
- [x] Tests pass locally
- [ ] CI green