### PR TITLE
feat: --design flag for frontend design refactoring

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -117,6 +117,7 @@ program
   .option("--no-auto-simplify", "Force full pipeline regardless of triage level")
   .option("--smart-models", "Enable smart model selection based on triage complexity")
   .option("--no-smart-models", "Disable smart model selection")
+  .option("--design", "Activate design refactoring mode (impeccable role applies design changes)")
   .option("--dry-run", "Show what would be executed without running anything")
   .option("--json", "Output JSON only (no styled display)")
   .option("-q, --quiet", "Show only stage status lines, suppress raw agent output (default)")

--- a/src/mcp/run-kj.js
+++ b/src/mcp/run-kj.js
@@ -43,6 +43,7 @@ export async function runKjCommand({ command, commandArgs = [], options = {}, en
   normalizeBoolFlag(options.enableTester, "--enable-tester", args);
   normalizeBoolFlag(options.enableSecurity, "--enable-security", args);
   normalizeBoolFlag(options.enableImpeccable, "--enable-impeccable", args);
+  normalizeBoolFlag(options.design, "--design", args);
   normalizeBoolFlag(options.enableTriage, "--enable-triage", args);
   normalizeBoolFlag(options.enableDiscover, "--enable-discover", args);
   normalizeBoolFlag(options.enableArchitect, "--enable-architect", args);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -100,6 +100,7 @@ export const tools = [
         taskType: { type: "string", enum: ["sw", "infra", "doc", "add-tests", "refactor"], description: "Explicit task type for policy resolution. Overrides triage classification." },
         quiet: { type: "boolean", description: "Suppress raw agent output lines, show only stage status (default: true). Set false for verbose output." },
         noSonar: { type: "boolean" },
+        design: { type: "boolean", description: "Activate design refactoring mode. Impeccable role applies design changes instead of just auditing." },
         enableSonarcloud: { type: "boolean", description: "Enable SonarCloud scan (complementary to SonarQube)" },
         kjHome: { type: "string" },
         sonarToken: { type: "string" },

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -262,6 +262,12 @@ function applyFlagOverrides(pipelineFlags, flags) {
   if (flags.enableTester !== undefined) pipelineFlags.testerEnabled = Boolean(flags.enableTester);
   if (flags.enableSecurity !== undefined) pipelineFlags.securityEnabled = Boolean(flags.enableSecurity);
   if (flags.enableImpeccable !== undefined) pipelineFlags.impeccableEnabled = Boolean(flags.enableImpeccable);
+
+  // --design flag: force-enable impeccable in refactoring mode
+  if (flags.design) {
+    pipelineFlags.impeccableEnabled = true;
+    pipelineFlags.impeccableMode = "refactoring";
+  }
 }
 
 function resolvePipelinePolicies({ flags, config, stageResults, emitter, eventBase, session, pipelineFlags }) {
@@ -1149,9 +1155,10 @@ async function runQualityGateStages({ config, logger, emitter, eventBase, sessio
 
   if (pipelineFlags?.impeccableEnabled) {
     const diff = await generateDiff({ baseRef: session.session_start_sha });
+    const impeccableMode = pipelineFlags?.impeccableMode || "audit";
     const impeccableResult = await runImpeccableStage({
       config, logger, emitter, eventBase, session, coderRole, trackBudget,
-      iteration: i, task, diff
+      iteration: i, task, diff, mode: impeccableMode
     });
     if (impeccableResult.stageResult) {
       stageResults.impeccable = impeccableResult.stageResult;

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -247,17 +247,21 @@ export async function runSecurityStage({ config, logger, emitter, eventBase, ses
   return { action: "ok", stageResult: { ok: true, summary: securityOutput.summary || "No vulnerabilities found" } };
 }
 
-export async function runImpeccableStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff }) {
+export async function runImpeccableStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, mode = "audit" }) {
   logger.setContext({ iteration, stage: "impeccable" });
+  const isRefactoring = mode === "refactoring";
+  const startMessage = isRefactoring
+    ? "Impeccable applying design refactoring"
+    : "Impeccable auditing frontend design quality";
   emitProgress(
     emitter,
     makeEvent("impeccable:start", { ...eventBase, stage: "impeccable" }, {
-      message: "Impeccable auditing frontend design quality",
-      detail: { provider: config?.roles?.impeccable?.provider || coderRole.provider, executorType: "agent" }
+      message: startMessage,
+      detail: { provider: config?.roles?.impeccable?.provider || coderRole.provider, executorType: "agent", mode }
     })
   );
 
-  const impeccable = new ImpeccableRole({ config, logger, emitter });
+  const impeccable = new ImpeccableRole({ config, logger, emitter, mode });
   await impeccable.init({ task, iteration });
   const impeccableStart = Date.now();
   let impeccableOutput;

--- a/src/roles/impeccable-role.js
+++ b/src/roles/impeccable-role.js
@@ -59,9 +59,11 @@ function buildSummary(parsed) {
 }
 
 export class ImpeccableRole extends BaseRole {
-  constructor({ config, logger, emitter = null, createAgentFn = null }) {
-    super({ name: "impeccable", config, logger, emitter });
+  constructor({ config, logger, emitter = null, createAgentFn = null, mode = "audit" }) {
+    const roleName = mode === "refactoring" ? "impeccable-design" : "impeccable";
+    super({ name: roleName, config, logger, emitter });
     this._createAgent = createAgentFn || defaultCreateAgent;
+    this.mode = mode;
   }
 
   async execute(input) {

--- a/templates/roles/impeccable-design.md
+++ b/templates/roles/impeccable-design.md
@@ -1,0 +1,87 @@
+# Impeccable Design (Refactoring Mode)
+
+You are refactoring the frontend design. Apply ALL of these improvements:
+
+## Scope constraint
+
+- **ONLY modify files present in the diff.** Do not touch files that were not changed.
+- If no frontend files (.html, .css, .astro, .jsx, .tsx, .vue, .svelte, .lit, .js with DOM manipulation) are in the diff, report APPROVED immediately with 0 issues.
+
+## Input
+
+- **Task**: {{task}}
+- **Diff**: {{diff}}
+- **Context**: {{context}}
+
+## Visual Hierarchy
+- Establish clear heading levels (size, weight, color)
+- Group related elements with consistent spacing
+- Use whitespace to separate sections
+
+## Spacing & Alignment
+- Consistent padding/margin using a spacing scale (4px, 8px, 16px, 24px, 32px)
+- Align elements to a grid
+- Remove arbitrary pixel values
+
+## Responsive
+- Mobile-first approach
+- Fluid layouts with relative units (rem, %, vw)
+- Breakpoints at 640px, 768px, 1024px, 1280px
+
+## Accessibility
+- Color contrast ratio >= 4.5:1 for text
+- All interactive elements keyboard-focusable
+- Labels on all form inputs
+- Alt text on all images
+
+## Micro-interactions
+- Hover/focus states on all interactive elements
+- Smooth transitions (150-300ms)
+- Loading states for async operations
+
+## Theming
+- CSS custom properties for colors, fonts, spacing
+- Dark mode support if applicable
+- Consistent color palette (max 5 primary colors)
+
+## Rules
+- Each fix must be minimal and targeted (Edit, not Write)
+- Only use Read, Edit, Grep, Glob, and Bash tools
+- Verify each fix with `git diff` to confirm only intended lines changed
+- Apply changes directly. Do not just list issues.
+
+## Report
+
+Output a strict JSON object:
+
+```json
+{
+  "ok": true,
+  "result": {
+    "verdict": "IMPROVED",
+    "issuesFound": 3,
+    "issuesFixed": 3,
+    "categories": {
+      "visualHierarchy": 0,
+      "spacing": 1,
+      "responsive": 1,
+      "a11y": 1,
+      "microInteractions": 0,
+      "theming": 0
+    },
+    "changes": [
+      {
+        "file": "src/components/Button.astro",
+        "issue": "Arbitrary padding values",
+        "fix": "Replaced with spacing scale (16px)",
+        "category": "spacing"
+      }
+    ]
+  },
+  "summary": "3 design issues found and fixed (1 spacing, 1 responsive, 1 a11y)"
+}
+```
+
+### Verdict rules
+- **APPROVED** — No frontend design issues found (issuesFound === 0)
+- **IMPROVED** — Issues were found and fixes were applied (issuesFixed > 0)

--- a/tests/design-flag.test.js
+++ b/tests/design-flag.test.js
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// --- Mocks for ImpeccableRole template loading ---
+vi.mock("../src/agents/index.js", () => ({
+  createAgent: vi.fn(() => ({
+    runTask: vi.fn(async () => ({
+      ok: true,
+      output: JSON.stringify({
+        ok: true,
+        result: { verdict: "APPROVED", issuesFound: 0, issuesFixed: 0, categories: {}, changes: [] },
+        summary: "No frontend design issues found"
+      })
+    }))
+  }))
+}));
+
+vi.mock("../src/webperf/devtools-detect.js", () => ({
+  isDevToolsMcpAvailable: vi.fn(() => false),
+  ensureWebPerfSkills: vi.fn(async () => ({ installed: [] }))
+}));
+
+describe("--design flag", () => {
+  describe("CLI flag definition", () => {
+    it("--design flag sets flags.design in CLI options", async () => {
+      // Commander parses --design as flags.design = true
+      const { Command } = await import("commander");
+      const program = new Command();
+      program
+        .command("run")
+        .argument("<task>")
+        .option("--design", "Activate design refactoring mode")
+        .action((task, flags) => {
+          expect(flags.design).toBe(true);
+        });
+
+      await program.parseAsync(["node", "kj", "run", "fix stuff", "--design"]);
+    });
+
+    it("without --design flag, flags.design is undefined", async () => {
+      const { Command } = await import("commander");
+      const program = new Command();
+      program
+        .command("run")
+        .argument("<task>")
+        .option("--design", "Activate design refactoring mode")
+        .action((task, flags) => {
+          expect(flags.design).toBeUndefined();
+        });
+
+      await program.parseAsync(["node", "kj", "run", "fix stuff"]);
+    });
+  });
+
+  describe("kj_run MCP tool schema", () => {
+    it("design parameter exists in kj_run tool schema", async () => {
+      const { tools } = await import("../src/mcp/tools.js");
+      const kjRun = tools.find((t) => t.name === "kj_run");
+      expect(kjRun).toBeDefined();
+      expect(kjRun.inputSchema.properties.design).toBeDefined();
+      expect(kjRun.inputSchema.properties.design.type).toBe("boolean");
+    });
+  });
+
+  describe("--design forces impeccable enabled", () => {
+    it("applyFlagOverrides enables impeccable and sets refactoring mode when design=true", () => {
+      // Replicate the applyFlagOverrides logic from orchestrator.js
+      const pipelineFlags = {
+        plannerEnabled: false,
+        refactorerEnabled: false,
+        researcherEnabled: false,
+        testerEnabled: false,
+        securityEnabled: false,
+        impeccableEnabled: false,
+        reviewerEnabled: true,
+        discoverEnabled: false,
+        architectEnabled: false
+      };
+
+      const flags = { design: true };
+
+      // Simulate applyFlagOverrides
+      if (flags.enableImpeccable !== undefined) pipelineFlags.impeccableEnabled = Boolean(flags.enableImpeccable);
+      if (flags.design) {
+        pipelineFlags.impeccableEnabled = true;
+        pipelineFlags.impeccableMode = "refactoring";
+      }
+
+      expect(pipelineFlags.impeccableEnabled).toBe(true);
+      expect(pipelineFlags.impeccableMode).toBe("refactoring");
+    });
+
+    it("without --design, impeccable stays disabled and no mode is set", () => {
+      const pipelineFlags = {
+        impeccableEnabled: false
+      };
+
+      const flags = {};
+
+      if (flags.enableImpeccable !== undefined) pipelineFlags.impeccableEnabled = Boolean(flags.enableImpeccable);
+      if (flags.design) {
+        pipelineFlags.impeccableEnabled = true;
+        pipelineFlags.impeccableMode = "refactoring";
+      }
+
+      expect(pipelineFlags.impeccableEnabled).toBe(false);
+      expect(pipelineFlags.impeccableMode).toBeUndefined();
+    });
+  });
+
+  describe("ImpeccableRole mode selects correct template", () => {
+    it("--design uses impeccable-design.md template (refactoring mode)", async () => {
+      const { ImpeccableRole } = await import("../src/roles/impeccable-role.js");
+
+      const role = new ImpeccableRole({
+        config: {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        mode: "refactoring"
+      });
+
+      // The role name determines which template file is loaded
+      expect(role.name).toBe("impeccable-design");
+      expect(role.mode).toBe("refactoring");
+    });
+
+    it("without --design, impeccable uses default template (audit mode)", async () => {
+      const { ImpeccableRole } = await import("../src/roles/impeccable-role.js");
+
+      const role = new ImpeccableRole({
+        config: {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+      });
+
+      expect(role.name).toBe("impeccable");
+      expect(role.mode).toBe("audit");
+    });
+
+    it("explicit mode=audit uses impeccable.md template", async () => {
+      const { ImpeccableRole } = await import("../src/roles/impeccable-role.js");
+
+      const role = new ImpeccableRole({
+        config: {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        mode: "audit"
+      });
+
+      expect(role.name).toBe("impeccable");
+      expect(role.mode).toBe("audit");
+    });
+  });
+
+  describe("MCP run-kj.js passes --design flag", () => {
+    it("design=true adds --design to CLI args", async () => {
+      // We test by importing and checking the normalizeBoolFlag pattern
+      // The run-kj.js file uses: normalizeBoolFlag(options.design, "--design", args)
+      const args = [];
+      const normalizeBoolFlag = (value, flagName, arr) => {
+        if (value === true) arr.push(flagName);
+      };
+
+      normalizeBoolFlag(true, "--design", args);
+      expect(args).toContain("--design");
+    });
+
+    it("design=undefined does not add --design to CLI args", () => {
+      const args = [];
+      const normalizeBoolFlag = (value, flagName, arr) => {
+        if (value === true) arr.push(flagName);
+      };
+
+      normalizeBoolFlag(undefined, "--design", args);
+      expect(args).not.toContain("--design");
+    });
+  });
+
+  describe("impeccable-design.md template exists", () => {
+    it("template file exists and contains refactoring instructions", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const { fileURLToPath } = await import("node:url");
+
+      const templatePath = path.resolve(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "templates",
+        "roles",
+        "impeccable-design.md"
+      );
+
+      const content = await fs.readFile(templatePath, "utf8");
+      expect(content).toContain("Refactoring Mode");
+      expect(content).toContain("Apply ALL of these improvements");
+      expect(content).toContain("Visual Hierarchy");
+      expect(content).toContain("Spacing & Alignment");
+      expect(content).toContain("Responsive");
+      expect(content).toContain("Accessibility");
+      expect(content).toContain("Micro-interactions");
+      expect(content).toContain("Theming");
+      expect(content).toContain("Apply changes directly");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `--design` flag on kj_run: activates impeccable in refactoring mode
- New `impeccable-design.md` template: hierarchy, spacing, responsive, a11y, animations, theming
- Coder APPLIES design changes instead of just reporting
- MCP: `design: true` parameter on kj_run
- 11 new tests

Closes KJC-TSK-0225

## Test plan
- [x] Tests pass
- [ ] CI green