### PR TITLE
feat(mcp): graceful restart with marker file after npm update

### DIFF
--- a/src/mcp/orphan-guard.js
+++ b/src/mcp/orphan-guard.js
@@ -1,4 +1,9 @@
-import { readFileSync, watch } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync, watch, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const RESTART_MARKER_DIR = path.join(os.homedir(), ".kj");
+const RESTART_MARKER_PATH = path.join(RESTART_MARKER_DIR, ".mcp-restart");
 
 const DEFAULT_INTERVAL_MS = 5000;
 
@@ -69,14 +74,46 @@ export function setupMemoryWatchdog({
   return { timer };
 }
 
-export function setupVersionWatcher({ pkgPath, currentVersion, exitFn = () => process.exit(0) } = {}) {
+const DEFAULT_GRACE_MS = 2000;
+
+export function writeRestartMarker(version, markerPath = RESTART_MARKER_PATH) {
+  try {
+    mkdirSync(path.dirname(markerPath), { recursive: true });
+    writeFileSync(markerPath, version, "utf8");
+  } catch { /* best-effort */ }
+}
+
+export function readAndDeleteRestartMarker(markerPath = RESTART_MARKER_PATH) {
+  try {
+    if (!existsSync(markerPath)) return null;
+    const version = readFileSync(markerPath, "utf8").trim();
+    unlinkSync(markerPath);
+    return version || null;
+  } catch { /* ignore */ }
+  return null;
+}
+
+export function setupVersionWatcher({
+  pkgPath,
+  currentVersion,
+  gracePeriodMs = DEFAULT_GRACE_MS,
+  exitFn = () => process.exit(0),
+  markerPath = RESTART_MARKER_PATH
+} = {}) {
   if (!pkgPath) return null;
+
+  let _gracePeriodMs = gracePeriodMs;
 
   function checkVersion() {
     try {
       const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
       if (pkg.version !== currentVersion) {
-        exitFn();
+        const newVersion = pkg.version;
+        process.stderr.write(
+          `[karajan-mcp] Karajan MCP updated (v${currentVersion} → v${newVersion}). Restarting...\n`
+        );
+        writeRestartMarker(newVersion, markerPath);
+        setTimeout(() => exitFn(), _gracePeriodMs);
         return true;
       }
     } catch { /* ignore read errors */ }
@@ -90,5 +127,5 @@ export function setupVersionWatcher({ pkgPath, currentVersion, exitFn = () => pr
     });
   } catch { /* ignore watch errors */ }
 
-  return { watcher, checkVersion };
+  return { watcher, checkVersion, get gracePeriodMs() { return _gracePeriodMs; }, set gracePeriodMs(v) { _gracePeriodMs = v; } };
 }

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -50,7 +50,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
 });
 
 // --- Orphan process protection + version watcher ---
-import { setupOrphanGuard, setupVersionWatcher, setupMemoryWatchdog } from "./orphan-guard.js";
+import { setupOrphanGuard, setupVersionWatcher, setupMemoryWatchdog, readAndDeleteRestartMarker } from "./orphan-guard.js";
+
+// Check if this is a restart after update
+const restartedVersion = readAndDeleteRestartMarker();
+if (restartedVersion) {
+  process.stderr.write(`[karajan-mcp] MCP server restarted after update to v${restartedVersion}\n`);
+}
+
 setupOrphanGuard();
 setupVersionWatcher({ pkgPath: PKG_PATH, currentVersion: LOADED_VERSION });
 setupMemoryWatchdog();

--- a/tests/mcp-reconnect.test.js
+++ b/tests/mcp-reconnect.test.js
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, unlinkSync, rmSync } from "node:fs";
+
+// Use a temp directory for marker files to avoid polluting ~/.kj
+const TEST_MARKER_DIR = path.join(os.tmpdir(), "kj-reconnect-test-" + process.pid);
+const TEST_MARKER_PATH = path.join(TEST_MARKER_DIR, ".mcp-restart");
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+    writeFileSync: vi.fn(actual.writeFileSync),
+    unlinkSync: vi.fn(actual.unlinkSync),
+    existsSync: vi.fn(actual.existsSync),
+    mkdirSync: vi.fn(actual.mkdirSync),
+    watch: vi.fn(() => ({ close: vi.fn() }))
+  };
+});
+
+const fs = await import("node:fs");
+const { setupVersionWatcher, writeRestartMarker, readAndDeleteRestartMarker } = await import(
+  "../src/mcp/orphan-guard.js"
+);
+
+describe("MCP reconnect after npm update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("setupVersionWatcher grace period", () => {
+    it("delays exit by grace period when version changes", () => {
+      const exitFn = vi.fn();
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: "2.0.0" }));
+
+      const watcher = setupVersionWatcher({
+        pkgPath: "/fake/package.json",
+        currentVersion: "1.0.0",
+        gracePeriodMs: 2000,
+        exitFn,
+        markerPath: TEST_MARKER_PATH
+      });
+
+      const changed = watcher.checkVersion();
+      expect(changed).toBe(true);
+      // exitFn should NOT be called immediately
+      expect(exitFn).not.toHaveBeenCalled();
+
+      // After grace period, exitFn should be called
+      vi.advanceTimersByTime(2000);
+      expect(exitFn).toHaveBeenCalledOnce();
+    });
+
+    it("does not exit when version is unchanged", () => {
+      const exitFn = vi.fn();
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: "1.0.0" }));
+
+      const watcher = setupVersionWatcher({
+        pkgPath: "/fake/package.json",
+        currentVersion: "1.0.0",
+        gracePeriodMs: 2000,
+        exitFn,
+        markerPath: TEST_MARKER_PATH
+      });
+
+      const changed = watcher.checkVersion();
+      expect(changed).toBe(false);
+      vi.advanceTimersByTime(5000);
+      expect(exitFn).not.toHaveBeenCalled();
+    });
+
+    it("logs restart message to stderr when version changes", () => {
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const exitFn = vi.fn();
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: "2.0.0" }));
+
+      const watcher = setupVersionWatcher({
+        pkgPath: "/fake/package.json",
+        currentVersion: "1.0.0",
+        gracePeriodMs: 2000,
+        exitFn,
+        markerPath: TEST_MARKER_PATH
+      });
+
+      watcher.checkVersion();
+
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Karajan MCP updated (v1.0.0 → v2.0.0). Restarting...")
+      );
+      stderrSpy.mockRestore();
+    });
+  });
+
+  describe("writeRestartMarker", () => {
+    it("writes marker file with new version", () => {
+      fs.mkdirSync.mockImplementation(() => {});
+      fs.writeFileSync.mockImplementation(() => {});
+
+      writeRestartMarker("2.0.0", TEST_MARKER_PATH);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(
+        path.dirname(TEST_MARKER_PATH),
+        { recursive: true }
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        TEST_MARKER_PATH,
+        "2.0.0",
+        "utf8"
+      );
+    });
+
+    it("is called when version changes", () => {
+      const exitFn = vi.fn();
+      fs.readFileSync.mockReturnValue(JSON.stringify({ version: "2.0.0" }));
+      fs.mkdirSync.mockImplementation(() => {});
+      fs.writeFileSync.mockImplementation(() => {});
+
+      const watcher = setupVersionWatcher({
+        pkgPath: "/fake/package.json",
+        currentVersion: "1.0.0",
+        gracePeriodMs: 2000,
+        exitFn,
+        markerPath: TEST_MARKER_PATH
+      });
+
+      watcher.checkVersion();
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        TEST_MARKER_PATH,
+        "2.0.0",
+        "utf8"
+      );
+    });
+  });
+
+  describe("readAndDeleteRestartMarker", () => {
+    it("returns version and deletes marker when present", () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue("2.0.0");
+      fs.unlinkSync.mockImplementation(() => {});
+
+      const version = readAndDeleteRestartMarker(TEST_MARKER_PATH);
+
+      expect(version).toBe("2.0.0");
+      expect(fs.unlinkSync).toHaveBeenCalledWith(TEST_MARKER_PATH);
+    });
+
+    it("returns null when marker does not exist", () => {
+      fs.existsSync.mockReturnValue(false);
+
+      const version = readAndDeleteRestartMarker(TEST_MARKER_PATH);
+
+      expect(version).toBeNull();
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+
+    it("returns null on read errors", () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockImplementation(() => { throw new Error("EACCES"); });
+
+      const version = readAndDeleteRestartMarker(TEST_MARKER_PATH);
+
+      expect(version).toBeNull();
+    });
+
+    it("returns null for empty marker file", () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue("  ");
+      fs.unlinkSync.mockImplementation(() => {});
+
+      const version = readAndDeleteRestartMarker(TEST_MARKER_PATH);
+
+      expect(version).toBeNull();
+    });
+  });
+
+  describe("normal startup without marker", () => {
+    it("readAndDeleteRestartMarker returns null when no marker exists", () => {
+      fs.existsSync.mockReturnValue(false);
+
+      const version = readAndDeleteRestartMarker(TEST_MARKER_PATH);
+
+      expect(version).toBeNull();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/mcp-version-watcher.test.js
+++ b/tests/mcp-version-watcher.test.js
@@ -26,19 +26,25 @@ describe("setupVersionWatcher", () => {
     expect(result).toBeNull();
   });
 
-  it("checkVersion calls exitFn when version changes", () => {
+  it("checkVersion calls exitFn when version changes (after grace period)", () => {
+    vi.useFakeTimers();
     const exitFn = vi.fn();
     readFileSync.mockReturnValue(JSON.stringify({ version: "2.0.0" }));
 
-    const { checkVersion } = setupVersionWatcher({
+    const watcher = setupVersionWatcher({
       pkgPath: "/fake/package.json",
       currentVersion: "1.0.0",
+      gracePeriodMs: 2000,
       exitFn
     });
 
-    const changed = checkVersion();
+    const changed = watcher.checkVersion();
     expect(changed).toBe(true);
+    expect(exitFn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
     expect(exitFn).toHaveBeenCalledOnce();
+    vi.useRealTimers();
   });
 
   it("checkVersion does NOT call exitFn when version is the same", () => {


### PR DESCRIPTION
## Summary
- Enhanced `setupVersionWatcher` in orphan-guard.js with 2-second grace period before exit
- Added restart marker file (`~/.kj/.mcp-restart`) so the new MCP instance detects it was a planned restart
- Server startup reads and deletes marker, logs reconnection context
- 10 new tests covering grace period, marker lifecycle, and startup detection

## Test plan
- [x] `npm test` passes
- [x] Version watcher tests cover grace period and marker write
- [x] Reconnect tests cover marker read/delete and startup flow