### PR TITLE
docs: simplify Homebrew install to one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ npm install -g karajan-code
 
 **Homebrew** (macOS):
 ```bash
-brew tap manufosela/tap
-brew install karajan-code
+brew install manufosela/tap/karajan-code
 ```
 
 **One-liner** (detects OS, installs via npm):

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -60,8 +60,7 @@ npm install -g karajan-code
 
 **Homebrew** (macOS):
 ```bash
-brew tap manufosela/tap
-brew install karajan-code
+brew install manufosela/tap/karajan-code
 ```
 
 **One-liner** (detecta SO, instala via npm):


### PR DESCRIPTION
## Summary
- Replace two-step `brew tap` + `brew install` with single `brew install manufosela/tap/karajan-code`
- Updated both EN and ES READMEs