### PR TITLE
feat(ci): add darwin-x64 and SHA256 checksums to release workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write # needed to upload release assets
+  contents: write
 
 jobs:
   build:
@@ -18,7 +18,9 @@ jobs:
           - os: ubuntu-latest
             target: linux-x64
           - os: macos-latest
-            target: macos-arm64
+            target: darwin-arm64
+          - os: macos-13
+            target: darwin-x64
           - os: windows-latest
             target: win-x64
 
@@ -37,15 +39,12 @@ jobs:
       - name: Install project dependencies
         run: npm ci
 
-      # esbuild and postject are NOT in package.json devDependencies
-      # (to keep the core clean). Install them globally for the build.
       - name: Install build tools (esbuild + postject)
         run: npm install -g esbuild postject
 
       - name: Build SEA binary
         run: node scripts/build-sea.mjs
 
-      # Rename binary to include target platform
       - name: Rename binary (Linux/macOS)
         if: runner.os != 'Windows'
         run: mv dist/kj dist/kj-${{ matrix.target }}
@@ -54,14 +53,26 @@ jobs:
         if: runner.os == 'Windows'
         run: mv dist/kj.exe dist/kj-${{ matrix.target }}.exe
 
-      - name: Upload release asset (Linux/macOS)
+      - name: Generate SHA256 checksum (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: shasum -a 256 dist/kj-${{ matrix.target }} > dist/kj-${{ matrix.target }}.sha256
+
+      - name: Generate SHA256 checksum (Windows)
+        if: runner.os == 'Windows'
+        run: certutil -hashfile dist\kj-${{ matrix.target }}.exe SHA256 > dist\kj-${{ matrix.target }}.exe.sha256
+
+      - name: Upload release assets (Linux/macOS)
         if: runner.os != 'Windows'
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/kj-${{ matrix.target }}
+          files: |
+            dist/kj-${{ matrix.target }}
+            dist/kj-${{ matrix.target }}.sha256
 
-      - name: Upload release asset (Windows)
+      - name: Upload release assets (Windows)
         if: runner.os == 'Windows'
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/kj-${{ matrix.target }}.exe
+          files: |
+            dist/kj-${{ matrix.target }}.exe
+            dist/kj-${{ matrix.target }}.exe.sha256


### PR DESCRIPTION
## Summary
- Added macOS Intel (macos-13 / darwin-x64) build target
- Renamed macos target from `macos-arm64` to `darwin-arm64` for consistency
- Generate SHA256 checksum files for all platform binaries
- 4 platforms: linux-x64, darwin-arm64, darwin-x64, win-x64

## Test plan
- [x] Workflow syntax valid
- [x] Will test on next `git tag v1.57.1` push