### PR TITLE
chore: bump version to v1.57.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.57.1] - 2026-03-31
+
+### Added
+- **SEA binary build**: standalone binary via `node scripts/build-sea.mjs`. No Node.js required to run
+- **Release workflow**: GitHub Actions builds binaries for linux-x64, darwin-arm64, darwin-x64, win-x64 with SHA256 checksums on every tag
+
+### Fixed
+- **YAML duplicate keys**: config loader now tolerates duplicated keys in user config files (#300)
+
 ## [1.57.0] - 2026-03-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
SEA binary build, release workflow, YAML duplicate keys fix