### PR TITLE
fix(ci): remove darwin-x64 target (macos-13 deprecated)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,8 +19,6 @@ jobs:
             target: linux-x64
           - os: macos-latest
             target: darwin-arm64
-          - os: macos-13
-            target: darwin-x64
           - os: windows-latest
             target: win-x64
 


### PR DESCRIPTION
Remove macos-13 runner (deprecated). darwin-arm64 covers modern Macs.