### PR TITLE
fix(config): resolve provider from provider/model format

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -469,6 +469,13 @@ const CODER_INHERITED_ROLES = new Set([
 
 function resolveProvider(roleConfig, role, roles, legacyCoder, legacyReviewer) {
   if (roleConfig.provider) return roleConfig.provider;
+
+  // If model has "provider/model" format (e.g. "gemini/pro"), extract the provider
+  if (roleConfig.model && roleConfig.model.includes("/")) {
+    const inferredProvider = roleConfig.model.split("/")[0].toLowerCase();
+    if (AGENT_MODEL_SIGNATURES[inferredProvider]) return inferredProvider;
+  }
+
   if (role === "coder") return legacyCoder;
   if (role === "reviewer") return legacyReviewer;
   if (CODER_INHERITED_ROLES.has(role)) return roles.coder?.provider || legacyCoder;
@@ -476,7 +483,13 @@ function resolveProvider(roleConfig, role, roles, legacyCoder, legacyReviewer) {
 }
 
 function resolveModel(roleConfig, role, config) {
-  if (roleConfig.model) return { model: roleConfig.model, inherited: false };
+  if (roleConfig.model) {
+    // Strip "provider/" prefix from models like "gemini/pro" → "pro"
+    const model = roleConfig.model.includes("/")
+      ? roleConfig.model.split("/").slice(1).join("/")
+      : roleConfig.model;
+    return { model, inherited: false };
+  }
   if (role === "coder") return { model: config?.coder_options?.model ?? null, inherited: false };
   if (role === "reviewer") return { model: config?.reviewer_options?.model ?? null, inherited: false };
   if (CODER_INHERITED_ROLES.has(role)) {
@@ -495,8 +508,8 @@ export function resolveRole(config, role) {
   const provider = resolveProvider(roleConfig, role, roles, legacyCoder, legacyReviewer);
   let { model, inherited: modelIsInherited } = resolveModel(roleConfig, role, config);
 
-  // Drop inherited model if incompatible with the resolved provider
-  if (modelIsInherited && provider && model && !isModelCompatible(provider, model)) {
+  // Drop model if incompatible with the resolved provider (inherited or explicit)
+  if (provider && model && !isModelCompatible(provider, model)) {
     model = null;
   }
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -131,6 +131,32 @@ describe("applyRunOverrides", () => {
     expect(resolveRole(out, "reviewer").provider).toBe("aider");
   });
 
+  it("infers provider from provider/model format in model field", () => {
+    const config = {
+      roles: {
+        reviewer: { model: "gemini/pro" },
+        coder: { provider: "claude" }
+      }
+    };
+    const out = applyRunOverrides(config, {});
+    // provider inferred from "gemini/pro" → "gemini"
+    expect(resolveRole(out, "reviewer").provider).toBe("gemini");
+    // model stripped to just "pro"
+    expect(resolveRole(out, "reviewer").model).toBe("pro");
+  });
+
+  it("drops incompatible explicit model (e.g. gemini model on claude provider)", () => {
+    const config = {
+      roles: {
+        reviewer: { provider: "claude", model: "gemini-2.5-pro" }
+      }
+    };
+    const out = applyRunOverrides(config, {});
+    expect(resolveRole(out, "reviewer").provider).toBe("claude");
+    // model dropped because gemini model is incompatible with claude provider
+    expect(resolveRole(out, "reviewer").model).toBeNull();
+  });
+
   it("keeps default budget warning threshold when not overridden", () => {
     const out = applyRunOverrides({}, {});
     expect(out.budget.warn_threshold_pct).toBe(80);


### PR DESCRIPTION
## Summary
- When model is `gemini/pro`, infer provider=gemini and strip prefix (model=`pro`)
- Drop incompatible explicit models (not just inherited ones)
- Fixes: `claude -p --model gemini/pro` when user meant to use Gemini CLI

## Test plan
- [x] 2690/2690 tests pass
- [x] New tests: provider inference from `gemini/pro`, incompatible model drop