### PR TITLE
fix(process): detach stdin from all subprocesses to prevent hangs

### DIFF
--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -76,6 +76,10 @@ async function awaitWithTimeout(subprocess, timeout, getStdout) {
 
 export async function runCommand(command, args = [], options = {}) {
   const { timeout, onOutput, silenceTimeoutMs, partialOutputFlushMs, ...rest } = options;
+  // Always detach stdin: KJ subprocesses never need interactive input.
+  // Without this, a subprocess prompting for input (sonar credentials,
+  // agent approval, npm prompts) hangs forever since there is no TTY.
+  if (!rest.stdin) rest.stdin = "ignore";
   const subprocess = execa(command, args, { reject: false, ...rest });
 
   let stdoutAccum = "";


### PR DESCRIPTION
## Summary
- `runCommand` now passes `stdin: "ignore"` by default
- Previously only Claude agent had this. Codex, Gemini, Aider, OpenCode, and SonarQube scanner did not
- Any subprocess prompting for input (sonar credentials, npm prompts, agent approval) would hang forever
- Now the subprocess gets EOF immediately and fails fast with an error instead of hanging silently

## Test plan
- [x] 2690/2690 tests pass
- [x] Claude agent already used stdin:ignore (no change)
- [x] Other agents and sonar scanner now inherit it from runCommand