### PR TITLE
feat(init): auto-add .kj/, .agent/, .scannerwork/ to project .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ review-rules.md
 # Claude Code local files (CLAUDE.md in root IS committed)
 .claude/
 
+# Agent skills (installed by kj_skills / OpenSkills)
+.agent/
+
 # SonarQube
 .scannerwork/
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -305,6 +305,35 @@ async function installSkills(logger, interactive) {
   }
 }
 
+const GITIGNORE_ENTRIES = [
+  { pattern: ".kj/", comment: "Karajan runtime (logs, worktrees)" },
+  { pattern: ".agent/", comment: "Agent skills (OpenSkills)" },
+  { pattern: ".scannerwork/", comment: "SonarQube scanner temp" },
+];
+
+async function ensureGitignoreEntries(projectDir, logger) {
+  const gitignorePath = path.join(projectDir, ".gitignore");
+  let content;
+  try {
+    content = await fs.readFile(gitignorePath, "utf8");
+  } catch {
+    // No .gitignore yet — will create one
+  }
+  if (!content) content = "";
+
+  const missing = GITIGNORE_ENTRIES.filter(e => !content.includes(e.pattern));
+  if (missing.length === 0) return;
+
+  const block = [
+    "",
+    "# Karajan Code",
+    ...missing.map(e => e.pattern)
+  ].join("\n") + "\n";
+
+  await fs.appendFile(gitignorePath, block, "utf8");
+  logger.info(`Added to .gitignore: ${missing.map(e => e.pattern).join(", ")}`);
+}
+
 export async function initCommand({ logger, flags = {} }) {
   const karajanHome = getKarajanHome();
   await ensureDir(karajanHome);
@@ -329,6 +358,7 @@ export async function initCommand({ logger, flags = {} }) {
   await handleConfigSetup({ config, configExists, interactive, configPath, logger });
   await ensureReviewRules(reviewRulesPath, logger);
   await ensureCoderRules(coderRulesPath, logger);
+  await ensureGitignoreEntries(process.cwd(), logger);
   await installSkills(logger, interactive);
 
   // Auto-detect project stack and preconfigure

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -24,7 +24,8 @@ vi.mock("../src/sonar/manager.js", () => ({
 vi.mock("node:fs/promises", () => ({
   default: {
     writeFile: vi.fn().mockResolvedValue(undefined),
-    readFile: vi.fn().mockRejectedValue(new Error("not found"))
+    readFile: vi.fn().mockRejectedValue(new Error("not found")),
+    appendFile: vi.fn().mockResolvedValue(undefined)
   }
 }));
 

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -13,6 +13,10 @@ vi.mock("node:fs/promises", () => ({
     readFile: vi.fn(async (p) => {
       if (writtenFiles.has(p)) return writtenFiles.get(p);
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }),
+    appendFile: vi.fn(async (p, content) => {
+      const existing = writtenFiles.get(p) || "";
+      writtenFiles.set(p, existing + content);
     })
   }
 }));


### PR DESCRIPTION
## Summary
- `kj init` now appends `.kj/`, `.agent/`, `.scannerwork/` to the project's `.gitignore` if missing
- Added `.agent/` to karajan-code's own `.gitignore`
- Idempotent: skips entries already present

## Test plan
- [x] 2690/2690 tests pass
- [x] init-wizard and installer-e2e tests updated with appendFile mock