### PR TITLE
feat: scripts for global branch protection and AI attribution guard

### DIFF
--- a/scripts/ai-attribution-guard.yml
+++ b/scripts/ai-attribution-guard.yml
@@ -1,0 +1,77 @@
+# AI Attribution Guard — GitHub Action
+#
+# Copy this file to .github/workflows/ai-attribution-guard.yml in any repo.
+# Blocks PRs that contain AI attribution comments or Co-Authored-By lines.
+# No dependencies, no Node.js required. Pure bash + grep.
+
+name: AI Attribution Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  scan:
+    name: Scan for AI attribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check PR diff for AI attribution
+        run: |
+          DIFF=$(git diff origin/${{ github.base_ref }}...HEAD \
+            -- ':!*.png' ':!*.jpg' ':!*.svg' ':!*.ico' \
+               ':!*.lock' ':!package-lock.json' ':!yarn.lock' \
+               ':!*.min.js' ':!*.min.css' \
+               ':!.githooks/*' \
+            | grep '^+' \
+            | grep -v '^+++' \
+            || true)
+
+          [ -z "$DIFF" ] && echo "No diff to scan" && exit 0
+
+          # Attribution patterns (not functional references like provider: "claude")
+          ATTR='(Generated|Created|Written|Made|Built|Authored|Assisted|Powered|Produced) (by|with|using|via) .*(Claude|Anthropic|OpenAI|ChatGPT|GPT-[0-9]|Copilot|Gemini|Cursor|Windsurf|Codeium)'
+          COAUTH='Co-Authored-By:.*\b(Claude|Anthropic|OpenAI|ChatGPT|Copilot|Gemini|Cursor|Windsurf|Codeium)\b'
+          COMMENT='(//|#|/\*|\*|<!--|--)\s*.*(Claude|Anthropic|OpenAI|ChatGPT|Copilot|Gemini).*(generated|assisted|helped|created|wrote|built|made)'
+
+          FOUND=""
+          for PAT in "$ATTR" "$COAUTH" "$COMMENT"; do
+            MATCH=$(echo "$DIFF" | grep -i -E "$PAT" || true)
+            [ -n "$MATCH" ] && FOUND="${FOUND}${MATCH}\n"
+          done
+
+          if [ -n "$FOUND" ]; then
+            echo "::error::AI attribution detected in PR diff"
+            echo -e "$FOUND"
+            echo ""
+            echo "Remove AI attribution comments/lines and push again."
+            exit 1
+          fi
+
+          echo "AI attribution guard: clean"
+
+      - name: Check commit messages
+        run: |
+          COMMITS=$(git log --format='%s%n%b' origin/${{ github.base_ref }}...HEAD)
+
+          COAUTH='Co-Authored-By:.*\b(Claude|Anthropic|OpenAI|ChatGPT|Copilot|Gemini|Cursor|Windsurf|Codeium)\b'
+          ATTR='(Generated|Created|Written|Built|Authored) (by|with|using) .*(Claude|Anthropic|OpenAI|ChatGPT|Copilot|Gemini|Cursor|Windsurf|Codeium)'
+
+          FOUND=""
+          for PAT in "$COAUTH" "$ATTR"; do
+            MATCH=$(echo "$COMMITS" | grep -i -E "$PAT" || true)
+            [ -n "$MATCH" ] && FOUND="${FOUND}${MATCH}\n"
+          done
+
+          if [ -n "$FOUND" ]; then
+            echo "::error::AI attribution detected in commit messages"
+            echo -e "$FOUND"
+            echo ""
+            echo "Amend commits to remove AI attribution and force-push."
+            exit 1
+          fi
+
+          echo "Commit messages: clean"

--- a/scripts/install-guard-all-repos.sh
+++ b/scripts/install-guard-all-repos.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Installs the AI Attribution Guard workflow in all repos of a GitHub user.
+# Requires: gh CLI authenticated with admin/push permissions.
+#
+# Usage:
+#   ./scripts/install-guard-all-repos.sh              # dry-run
+#   ./scripts/install-guard-all-repos.sh --apply       # install in all repos
+#
+# What it does:
+#   - Creates .github/workflows/ai-attribution-guard.yml in each repo
+#   - Skips repos that already have the file
+#   - Skips archived repos
+
+set -euo pipefail
+
+OWNER="${GH_OWNER:-manufosela}"
+APPLY=false
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKFLOW_FILE="$SCRIPT_DIR/ai-attribution-guard.yml"
+
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY=true
+fi
+
+if [[ ! -f "$WORKFLOW_FILE" ]]; then
+  echo "ERROR: $WORKFLOW_FILE not found"
+  exit 1
+fi
+
+CONTENT=$(base64 -w 0 "$WORKFLOW_FILE")
+
+echo "=== Install AI Attribution Guard in all repos of $OWNER ==="
+echo ""
+
+if [[ "$APPLY" == false ]]; then
+  echo "  DRY RUN mode. Use --apply to actually install."
+  echo ""
+fi
+
+REPOS=$(gh repo list "$OWNER" --limit 500 --json name,isArchived \
+  --jq '.[] | select(.isArchived == false) | .name')
+
+TOTAL=0
+INSTALLED=0
+SKIPPED=0
+FAILED=0
+
+while read -r REPO; do
+  [ -z "$REPO" ] && continue
+  TOTAL=$((TOTAL + 1))
+
+  # Check if workflow already exists
+  EXISTS=$(gh api "repos/$OWNER/$REPO/contents/.github/workflows/ai-attribution-guard.yml" --jq '.sha' 2>/dev/null || echo "")
+
+  if [[ -n "$EXISTS" ]]; then
+    echo "  SKIP  $REPO — workflow already exists"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  if [[ "$APPLY" == false ]]; then
+    echo "  WOULD $REPO"
+    continue
+  fi
+
+  if gh api "repos/$OWNER/$REPO/contents/.github/workflows/ai-attribution-guard.yml" -X PUT \
+    -f message="chore: add AI attribution guard workflow" \
+    -f content="$CONTENT" \
+    --jq '.commit.sha' 2>/dev/null; then
+    echo "  OK    $REPO"
+    INSTALLED=$((INSTALLED + 1))
+  else
+    echo "  FAIL  $REPO — check permissions"
+    FAILED=$((FAILED + 1))
+  fi
+
+done <<< "$REPOS"
+
+echo ""
+echo "=== Summary ==="
+echo "  Total:     $TOTAL"
+echo "  Installed: $INSTALLED"
+echo "  Skipped:   $SKIPPED"
+echo "  Failed:    $FAILED"

--- a/scripts/protect-all-repos.sh
+++ b/scripts/protect-all-repos.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Configures branch protection on all repos of a GitHub user.
+# Requires: gh CLI authenticated with admin permissions.
+#
+# Usage:
+#   ./scripts/protect-all-repos.sh              # dry-run (shows what it would do)
+#   ./scripts/protect-all-repos.sh --apply      # apply protection rules
+#
+# What it does:
+#   - Require PRs before merging (no direct push to default branch)
+#   - Block force push
+#   - Block branch deletion
+#
+# Skips repos where branch protection is already configured.
+
+set -euo pipefail
+
+OWNER="${GH_OWNER:-manufosela}"
+APPLY=false
+
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY=true
+fi
+
+echo "=== Branch Protection for all repos of $OWNER ==="
+echo ""
+
+if [[ "$APPLY" == false ]]; then
+  echo "  DRY RUN mode. Use --apply to actually configure."
+  echo ""
+fi
+
+REPOS=$(gh repo list "$OWNER" --limit 500 --json name,defaultBranchRef,isArchived \
+  --jq '.[] | select(.isArchived == false) | "\(.name)\t\(.defaultBranchRef.name // "main")"')
+
+TOTAL=0
+PROTECTED=0
+SKIPPED=0
+FAILED=0
+
+while IFS=$'\t' read -r REPO BRANCH; do
+  TOTAL=$((TOTAL + 1))
+
+  # Check if already protected
+  STATUS=$(gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection" --jq '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null || echo "none")
+
+  if [[ "$STATUS" != "none" ]]; then
+    echo "  SKIP  $REPO ($BRANCH) — already protected"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  if [[ "$APPLY" == false ]]; then
+    echo "  WOULD $REPO ($BRANCH)"
+    continue
+  fi
+
+  # Apply protection
+  if gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection" -X PUT \
+    --input - <<EOF 2>/dev/null; then
+{
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 0,
+    "dismiss_stale_reviews": false
+  },
+  "enforce_admins": false,
+  "required_status_checks": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+    echo "  OK    $REPO ($BRANCH)"
+    PROTECTED=$((PROTECTED + 1))
+  else
+    echo "  FAIL  $REPO ($BRANCH) — check permissions"
+    FAILED=$((FAILED + 1))
+  fi
+
+done <<< "$REPOS"
+
+echo ""
+echo "=== Summary ==="
+echo "  Total:     $TOTAL"
+echo "  Protected: $PROTECTED"
+echo "  Skipped:   $SKIPPED"
+echo "  Failed:    $FAILED"


### PR DESCRIPTION
## Summary
- `scripts/protect-all-repos.sh`: configures branch protection (require PR, no force push) on all 238+ GitHub repos. Dry-run by default.
- `scripts/install-guard-all-repos.sh`: installs AI attribution guard workflow in all repos. Dry-run by default.
- `scripts/ai-attribution-guard.yml`: standalone workflow (no deps) that blocks PRs with AI attribution. Copy to any repo.

## Test plan
- [x] Dry-run on 238 repos: all already protected and guarded
- [x] Scripts handle errors, skip archived repos, skip already-configured repos