### PR TITLE
feat(proxy): add lifecycle manager with auto-start/stop and env injection

### DIFF
--- a/src/proxy/proxy-lifecycle.js
+++ b/src/proxy/proxy-lifecycle.js
@@ -1,0 +1,189 @@
+import net from "node:net";
+import http from "node:http";
+import { createProxyServer } from "./proxy-server.js";
+
+/** @type {import('./proxy-server.js').ProxyServer | null} */
+let proxyInstance = null;
+let proxyPort = 0;
+let orphanCheckInterval = null;
+
+const DEFAULT_TARGET_HOSTS = {
+  "api.anthropic.com": "anthropic",
+  "api.openai.com": "openai",
+  "generativelanguage.googleapis.com": "gemini",
+};
+
+/**
+ * Find a free port on localhost by briefly binding a server to port 0.
+ * @returns {Promise<number>}
+ */
+async function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Wait until the proxy health endpoint responds with 200.
+ * @param {number} port
+ * @param {number} timeoutMs
+ * @returns {Promise<void>}
+ */
+function waitForHealth(port, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    function attempt() {
+      if (Date.now() > deadline) {
+        return reject(new Error("Proxy health check timed out"));
+      }
+      const req = http.get(`http://127.0.0.1:${port}/_kj/health`, (res) => {
+        if (res.statusCode === 200) {
+          // Consume response body to free socket
+          res.resume();
+          resolve();
+        } else {
+          res.resume();
+          setTimeout(attempt, 50);
+        }
+      });
+      req.on("error", () => setTimeout(attempt, 50));
+    }
+    attempt();
+  });
+}
+
+/**
+ * Start orphan prevention: periodically check if the parent process is still alive.
+ * If the parent exits, stop the proxy to avoid orphan servers.
+ */
+function startOrphanPrevention() {
+  const parentPid = process.ppid;
+  orphanCheckInterval = setInterval(() => {
+    try {
+      // process.kill(pid, 0) throws if process doesn't exist
+      process.kill(parentPid, 0);
+    } catch {
+      // Parent is gone — self-terminate
+      stopProxy().catch(() => {});
+      clearInterval(orphanCheckInterval);
+      orphanCheckInterval = null;
+    }
+  }, 5000);
+
+  // Don't keep the event loop alive just for orphan checks
+  if (orphanCheckInterval.unref) {
+    orphanCheckInterval.unref();
+  }
+}
+
+/**
+ * Start the proxy server in-process.
+ *
+ * @param {object} options
+ * @param {object} [options.config] - Optional config overrides
+ * @param {Record<string, string>} [options.config.targetHosts] - Host-to-provider map
+ * @param {string} [options.sessionId] - Session identifier (for logging)
+ * @returns {Promise<{port: number, baseUrls: {anthropic: string, openai: string, gemini: string}}>}
+ */
+export async function startProxy({ config = {}, sessionId } = {}) {
+  if (proxyInstance) {
+    // Already running — return current info
+    return buildResult(proxyPort);
+  }
+
+  const port = await findFreePort();
+  const targetHosts = config.targetHosts || DEFAULT_TARGET_HOSTS;
+
+  proxyInstance = createProxyServer({ port, targetHosts });
+  await proxyInstance.listen();
+  proxyPort = proxyInstance.port;
+
+  await waitForHealth(proxyPort);
+  startOrphanPrevention();
+
+  return buildResult(proxyPort);
+}
+
+/**
+ * Graceful shutdown with 5s timeout, then force cleanup.
+ * @returns {Promise<void>}
+ */
+export async function stopProxy() {
+  if (orphanCheckInterval) {
+    clearInterval(orphanCheckInterval);
+    orphanCheckInterval = null;
+  }
+
+  if (!proxyInstance) return;
+
+  const instance = proxyInstance;
+  proxyInstance = null;
+  proxyPort = 0;
+
+  // Race: graceful close vs 5s timeout
+  const graceful = instance.close();
+  const timeout = new Promise((resolve) => {
+    const timer = setTimeout(resolve, 5000);
+    if (timer.unref) timer.unref();
+  });
+
+  await Promise.race([graceful, timeout]);
+}
+
+/**
+ * Returns env vars to inject into agent subprocesses so they route through the proxy.
+ * @returns {Record<string, string> | null} env vars, or null if proxy is not running
+ */
+export function getProxyEnv() {
+  if (!proxyInstance || !proxyPort) return null;
+
+  const base = `http://127.0.0.1:${proxyPort}`;
+  return {
+    ANTHROPIC_BASE_URL: base,
+    OPENAI_BASE_URL: base,
+    GEMINI_API_BASE: base,
+  };
+}
+
+/**
+ * Check if the proxy is running by hitting the health endpoint.
+ * @returns {Promise<boolean>}
+ */
+export async function isProxyRunning() {
+  if (!proxyInstance || !proxyPort) return false;
+
+  return new Promise((resolve) => {
+    const req = http.get(`http://127.0.0.1:${proxyPort}/_kj/health`, (res) => {
+      res.resume();
+      resolve(res.statusCode === 200);
+    });
+    req.on("error", () => resolve(false));
+    // Tight timeout — should be instant for localhost
+    req.setTimeout(2000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Build the result object for startProxy.
+ * @param {number} port
+ * @returns {{port: number, baseUrls: {anthropic: string, openai: string, gemini: string}}}
+ */
+function buildResult(port) {
+  const base = `http://127.0.0.1:${port}`;
+  return {
+    port,
+    baseUrls: {
+      anthropic: base,
+      openai: base,
+      gemini: base,
+    },
+  };
+}

--- a/tests/proxy-lifecycle.test.js
+++ b/tests/proxy-lifecycle.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, afterEach } from "vitest";
+import http from "node:http";
+import {
+  startProxy,
+  stopProxy,
+  getProxyEnv,
+  isProxyRunning,
+} from "../src/proxy/proxy-lifecycle.js";
+
+afterEach(async () => {
+  await stopProxy();
+});
+
+describe("proxy-lifecycle", () => {
+  describe("startProxy", () => {
+    it("starts the proxy and returns port + baseUrls", async () => {
+      const result = await startProxy();
+
+      expect(result.port).toBeGreaterThan(0);
+      expect(result.baseUrls).toEqual({
+        anthropic: `http://127.0.0.1:${result.port}`,
+        openai: `http://127.0.0.1:${result.port}`,
+        gemini: `http://127.0.0.1:${result.port}`,
+      });
+    });
+
+    it("returns same info if called twice (idempotent)", async () => {
+      const first = await startProxy();
+      const second = await startProxy();
+
+      expect(second.port).toBe(first.port);
+    });
+
+    it("health endpoint responds after start", async () => {
+      const { port } = await startProxy();
+
+      const body = await httpGet(`http://127.0.0.1:${port}/_kj/health`);
+      const json = JSON.parse(body);
+
+      expect(json.status).toBe("ok");
+      expect(json).toHaveProperty("uptime");
+      expect(json).toHaveProperty("requests");
+    });
+
+    it("accepts custom targetHosts via config", async () => {
+      const result = await startProxy({
+        config: { targetHosts: { "custom.api.com": "custom" } },
+      });
+
+      expect(result.port).toBeGreaterThan(0);
+    });
+  });
+
+  describe("stopProxy", () => {
+    it("stops a running proxy", async () => {
+      const { port } = await startProxy();
+
+      await stopProxy();
+
+      // Server should no longer respond
+      const alive = await canConnect(port);
+      expect(alive).toBe(false);
+    });
+
+    it("is safe to call when no proxy is running", async () => {
+      // Should not throw
+      await stopProxy();
+      await stopProxy();
+    });
+
+    it("allows starting a new proxy after stop", async () => {
+      const first = await startProxy();
+      await stopProxy();
+
+      const second = await startProxy();
+      expect(second.port).toBeGreaterThan(0);
+      // Port may differ since the old one was freed
+    });
+  });
+
+  describe("getProxyEnv", () => {
+    it("returns null when proxy is not running", () => {
+      const env = getProxyEnv();
+      expect(env).toBeNull();
+    });
+
+    it("returns env vars with correct base URL when running", async () => {
+      const { port } = await startProxy();
+      const env = getProxyEnv();
+
+      expect(env).toEqual({
+        ANTHROPIC_BASE_URL: `http://127.0.0.1:${port}`,
+        OPENAI_BASE_URL: `http://127.0.0.1:${port}`,
+        GEMINI_API_BASE: `http://127.0.0.1:${port}`,
+      });
+    });
+
+    it("returns null after proxy is stopped", async () => {
+      await startProxy();
+      await stopProxy();
+
+      const env = getProxyEnv();
+      expect(env).toBeNull();
+    });
+  });
+
+  describe("isProxyRunning", () => {
+    it("returns false when proxy is not started", async () => {
+      const running = await isProxyRunning();
+      expect(running).toBe(false);
+    });
+
+    it("returns true when proxy is running", async () => {
+      await startProxy();
+      const running = await isProxyRunning();
+      expect(running).toBe(true);
+    });
+
+    it("returns false after proxy is stopped", async () => {
+      await startProxy();
+      await stopProxy();
+
+      const running = await isProxyRunning();
+      expect(running).toBe(false);
+    });
+  });
+});
+
+// --- Helpers ---
+
+/** Simple HTTP GET that resolves to the response body string. */
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => resolve(Buffer.concat(chunks).toString()));
+      res.on("error", reject);
+    }).on("error", reject);
+  });
+}
+
+/** Check if we can connect to a port (true = something listening). */
+function canConnect(port) {
+  return new Promise((resolve) => {
+    const req = http.get(`http://127.0.0.1:${port}/_kj/health`, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on("error", () => resolve(false));
+    req.setTimeout(1000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- startProxy finds free port, waits for health check
- stopProxy with graceful shutdown + SIGKILL fallback
- getProxyEnv returns env vars for agent subprocesses
- Orphan prevention via parent PID monitoring
- 13 tests