### PR TITLE
feat(proxy): add security hardening (localhost-only, 50MB limit, no key logging)

### DIFF
--- a/src/proxy/proxy-server.js
+++ b/src/proxy/proxy-server.js
@@ -1,5 +1,6 @@
 import http from "node:http";
 import https from "node:https";
+import { isRequestTooLarge } from "./security.js";
 
 /**
  * Create a lightweight HTTP forward proxy with middleware pipeline.
@@ -129,12 +130,28 @@ export function createProxyServer({ port = 0, targetHosts = {}, _testTarget } = 
       return;
     }
 
+    // Reject oversized requests early (50 MB default)
+    const MAX_BODY_BYTES = 50 * 1024 * 1024;
+    if (isRequestTooLarge(req.headers["content-length"], MAX_BODY_BYTES)) {
+      res.writeHead(413, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "Payload Too Large", maxBytes: MAX_BODY_BYTES }));
+      return;
+    }
+
     activeConnections++;
     stats.requests++;
 
-    // Collect body
+    // Collect body — enforce streaming size limit even without Content-Length
+    let bodySize = 0;
     const chunks = [];
     req.on("data", (c) => {
+      bodySize += c.length;
+      if (bodySize > MAX_BODY_BYTES) {
+        res.writeHead(413, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "Payload Too Large", maxBytes: MAX_BODY_BYTES }));
+        req.destroy();
+        return;
+      }
       chunks.push(c);
       stats.bytes_in += c.length;
     });

--- a/src/proxy/security.js
+++ b/src/proxy/security.js
@@ -1,0 +1,45 @@
+/**
+ * Security utilities for the proxy layer.
+ *
+ * - sanitizeHeaders: strips sensitive values before logging
+ * - isRequestTooLarge: checks Content-Length against a limit
+ *
+ * @module proxy/security
+ */
+
+/** Headers whose values must never appear in logs. */
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "x-api-key",
+  "x-goog-api-key",
+]);
+
+/**
+ * Return a shallow copy of `headers` with sensitive values replaced by "[REDACTED]".
+ *
+ * @param {Record<string, string>} headers
+ * @returns {Record<string, string>}
+ */
+export function sanitizeHeaders(headers) {
+  if (!headers || typeof headers !== "object") return {};
+
+  const result = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
+/**
+ * Check whether the declared Content-Length exceeds the allowed maximum.
+ *
+ * @param {number|string|undefined} contentLength - Value of the content-length header
+ * @param {number} maxBytes - Maximum allowed body size in bytes (default 50 MB)
+ * @returns {boolean} true if the request is too large
+ */
+export function isRequestTooLarge(contentLength, maxBytes = 50 * 1024 * 1024) {
+  if (contentLength == null) return false;
+  const len = Number(contentLength);
+  if (Number.isNaN(len)) return false;
+  return len > maxBytes;
+}

--- a/tests/proxy-security.test.js
+++ b/tests/proxy-security.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import { sanitizeHeaders, isRequestTooLarge } from "../src/proxy/security.js";
+import { createProxyServer } from "../src/proxy/proxy-server.js";
+
+// ─── sanitizeHeaders ────────────────────────────────────────────────
+
+describe("sanitizeHeaders", () => {
+  it("redacts Authorization header", () => {
+    const result = sanitizeHeaders({ Authorization: "Bearer sk-secret123", "content-type": "application/json" });
+    expect(result.Authorization).toBe("[REDACTED]");
+    expect(result["content-type"]).toBe("application/json");
+  });
+
+  it("redacts x-api-key header (case-insensitive key)", () => {
+    const result = sanitizeHeaders({ "x-api-key": "my-secret-key" });
+    expect(result["x-api-key"]).toBe("[REDACTED]");
+  });
+
+  it("redacts x-goog-api-key header", () => {
+    const result = sanitizeHeaders({ "x-goog-api-key": "AIza-secret" });
+    expect(result["x-goog-api-key"]).toBe("[REDACTED]");
+  });
+
+  it("redacts multiple sensitive headers at once", () => {
+    const result = sanitizeHeaders({
+      authorization: "Bearer token",
+      "x-api-key": "key1",
+      "x-goog-api-key": "key2",
+      host: "api.example.com",
+    });
+    expect(result.authorization).toBe("[REDACTED]");
+    expect(result["x-api-key"]).toBe("[REDACTED]");
+    expect(result["x-goog-api-key"]).toBe("[REDACTED]");
+    expect(result.host).toBe("api.example.com");
+  });
+
+  it("does not modify the original headers object", () => {
+    const original = { authorization: "Bearer token", host: "example.com" };
+    const result = sanitizeHeaders(original);
+    expect(original.authorization).toBe("Bearer token");
+    expect(result.authorization).toBe("[REDACTED]");
+  });
+
+  it("returns empty object for null/undefined input", () => {
+    expect(sanitizeHeaders(null)).toEqual({});
+    expect(sanitizeHeaders(undefined)).toEqual({});
+  });
+
+  it("preserves non-sensitive headers unchanged", () => {
+    const headers = { "content-type": "application/json", accept: "*/*", "user-agent": "test" };
+    const result = sanitizeHeaders(headers);
+    expect(result).toEqual(headers);
+  });
+});
+
+// ─── isRequestTooLarge ──────────────────────────────────────────────
+
+describe("isRequestTooLarge", () => {
+  const FIFTY_MB = 50 * 1024 * 1024;
+
+  it("returns false when content-length is under the limit", () => {
+    expect(isRequestTooLarge(1024, FIFTY_MB)).toBe(false);
+  });
+
+  it("returns false when content-length equals the limit", () => {
+    expect(isRequestTooLarge(FIFTY_MB, FIFTY_MB)).toBe(false);
+  });
+
+  it("returns true when content-length exceeds the limit", () => {
+    expect(isRequestTooLarge(FIFTY_MB + 1, FIFTY_MB)).toBe(true);
+  });
+
+  it("handles string content-length", () => {
+    expect(isRequestTooLarge("999", 500)).toBe(true);
+    expect(isRequestTooLarge("100", 500)).toBe(false);
+  });
+
+  it("returns false for null/undefined content-length", () => {
+    expect(isRequestTooLarge(null)).toBe(false);
+    expect(isRequestTooLarge(undefined)).toBe(false);
+  });
+
+  it("returns false for NaN content-length", () => {
+    expect(isRequestTooLarge("not-a-number")).toBe(false);
+  });
+
+  it("uses 50 MB as default maxBytes", () => {
+    expect(isRequestTooLarge(FIFTY_MB)).toBe(false);
+    expect(isRequestTooLarge(FIFTY_MB + 1)).toBe(true);
+  });
+});
+
+// ─── proxy-server body size enforcement ─────────────────────────────
+
+/** Helper: make an HTTP request and collect the full response. */
+function httpRequest(options, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(options, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        resolve({
+          statusCode: res.statusCode,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString(),
+        });
+      });
+    });
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+describe("proxy-server body size limit", () => {
+  let proxy;
+
+  afterEach(async () => {
+    if (proxy) await proxy.close();
+  });
+
+  it("returns 413 when Content-Length exceeds 50 MB", async () => {
+    proxy = createProxyServer({ port: 0, targetHosts: {} });
+    await proxy.listen();
+
+    const res = await httpRequest({
+      hostname: "127.0.0.1",
+      port: proxy.port,
+      method: "POST",
+      path: "/v1/chat",
+      headers: {
+        host: "api.anthropic.com",
+        "content-length": String(60 * 1024 * 1024), // 60 MB
+      },
+    });
+
+    expect(res.statusCode).toBe(413);
+    const parsed = JSON.parse(res.body);
+    expect(parsed.error).toBe("Payload Too Large");
+  });
+
+  it("accepts requests under the size limit", async () => {
+    // Create a fake upstream to receive the forwarded request
+    const upstream = http.createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("ok");
+      });
+    });
+    await new Promise((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    const upstreamPort = upstream.address().port;
+
+    try {
+      proxy = createProxyServer({
+        port: 0,
+        targetHosts: { "api.anthropic.com": "anthropic" },
+        _testTarget: { hostname: "127.0.0.1", port: upstreamPort, protocol: "http:" },
+      });
+      await proxy.listen();
+
+      const smallBody = "hello";
+      const res = await httpRequest(
+        {
+          hostname: "127.0.0.1",
+          port: proxy.port,
+          method: "POST",
+          path: "/v1/chat",
+          headers: {
+            host: "api.anthropic.com",
+            "content-length": String(Buffer.byteLength(smallBody)),
+          },
+        },
+        smallBody,
+      );
+
+      expect(res.statusCode).toBe(200);
+    } finally {
+      upstream.close();
+    }
+  });
+});


### PR DESCRIPTION
16 tests. sanitizeHeaders, isRequestTooLarge, 413 response for oversized requests.