### PR TITLE
fix(diff): handle empty repo in computeBaseRef

### DIFF
--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -19,14 +19,16 @@ function run(command, args, ...rest) {
 export async function computeBaseRef({ baseBranch = "main", baseRef = null }) {
   if (baseRef) return baseRef;
   const mergeBase = await run("git", ["merge-base", "HEAD", `origin/${baseBranch}`]);
-  if (mergeBase.exitCode !== 0) {
-    const fallback = await run("git", ["rev-parse", "HEAD~1"]);
-    if (fallback.exitCode !== 0) {
-      throw new Error("Could not compute diff base reference");
-    }
-    return fallback.stdout.trim();
-  }
-  return mergeBase.stdout.trim();
+  if (mergeBase.exitCode === 0) return mergeBase.stdout.trim();
+
+  const fallback = await run("git", ["rev-parse", "HEAD~1"]);
+  if (fallback.exitCode === 0) return fallback.stdout.trim();
+
+  // Empty repo (zero commits): diff against the empty tree
+  const emptyTree = await run("git", ["hash-object", "-t", "tree", "/dev/null"]);
+  if (emptyTree.exitCode === 0) return emptyTree.stdout.trim();
+
+  throw new Error("Could not compute diff base reference");
 }
 
 export async function generateDiff({ baseRef, stageNewFiles = false }) {

--- a/tests/diff-generator.test.js
+++ b/tests/diff-generator.test.js
@@ -5,10 +5,52 @@ vi.mock("../src/utils/process.js", () => ({
 }));
 
 const { runCommand } = await import("../src/utils/process.js");
-const { generateDiff, getUntrackedFiles } = await import("../src/review/diff-generator.js");
+const { computeBaseRef, generateDiff, getUntrackedFiles } = await import("../src/review/diff-generator.js");
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("computeBaseRef", () => {
+  it("returns explicit baseRef when provided", async () => {
+    const ref = await computeBaseRef({ baseRef: "abc123" });
+    expect(ref).toBe("abc123");
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns merge-base when available", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "def456\n", stderr: "" });
+    const ref = await computeBaseRef({ baseBranch: "main" });
+    expect(ref).toBe("def456");
+    expect(runCommand).toHaveBeenCalledWith("git", ["merge-base", "HEAD", "origin/main"]);
+  });
+
+  it("falls back to HEAD~1 when merge-base fails", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "not a git repo" })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "aaa111\n", stderr: "" });
+    const ref = await computeBaseRef({ baseBranch: "main" });
+    expect(ref).toBe("aaa111");
+    expect(runCommand).toHaveBeenCalledWith("git", ["rev-parse", "HEAD~1"]);
+  });
+
+  it("returns empty tree hash when repo has zero commits", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "merge-base fail" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "HEAD~1 fail" })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "4b825dc642cb6eb9a060e54bf899d15363da7461\n", stderr: "" });
+    const ref = await computeBaseRef({ baseBranch: "main" });
+    expect(ref).toBe("4b825dc642cb6eb9a060e54bf899d15363da7461");
+    expect(runCommand).toHaveBeenCalledWith("git", ["hash-object", "-t", "tree", "/dev/null"]);
+  });
+
+  it("throws when all strategies fail", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "merge-base fail" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "HEAD~1 fail" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "hash-object fail" });
+    await expect(computeBaseRef({ baseBranch: "main" })).rejects.toThrow("Could not compute diff base reference");
+  });
 });
 
 describe("generateDiff", () => {


### PR DESCRIPTION
## Summary
- `computeBaseRef` crashed with "Could not compute diff base reference" on repos with zero commits
- Now falls back to git's empty tree hash (`git hash-object -t tree /dev/null`) so diffs show all files as new additions
- Added 5 tests for `computeBaseRef` covering all strategies (explicit ref, merge-base, HEAD~1, empty tree, all-fail)

## Test plan
- [x] 9/9 diff-generator tests pass
- [x] Verified on empty repo: returns `4b825dc642cb6eb9a060e54bf899d15363da7461`

Fixes KJC-BUG-0019