### PR TITLE
feat(guards): policy guard for resume answer validation

### DIFF
--- a/src/guards/policy-guard.js
+++ b/src/guards/policy-guard.js
@@ -1,0 +1,90 @@
+/**
+ * Policy guard for kj_resume answers.
+ *
+ * Detects host-AI attempts to bypass pipeline policies (skip TDD, ignore
+ * reviewer, disable security, etc.) and rejects them with context-aware
+ * suggestions for valid alternatives.
+ */
+
+const BYPASS_PATTERNS = [
+  { regex: /\b(?:skip|omit|drop)\s+(?:the\s+)?(?:tests?|tdd|testing)\b/i, policy: "tdd" },
+  { regex: /\bdisable\s+(?:the\s+)?(?:tests?|tdd|testing)\b/i, policy: "tdd" },
+  { regex: /\b(?:don'?t|do\s+not|no\s+need\s+(?:for|to))\s+(?:run\s+)?tests?\b/i, policy: "tdd" },
+  { regex: /\bcontinue\s+without\s+test/i, policy: "tdd" },
+  { regex: /\bswitch\s+(?:to\s+)?(?:standard\s+)?methodology/i, policy: "tdd" },
+  { regex: /\bswitch\s+methodology/i, policy: "tdd" },
+  { regex: /\b(?:skip|ignore|bypass|disable)\s+(?:the\s+)?(?:review(?:er)?|code\s+review)\b/i, policy: "reviewer" },
+  { regex: /\b(?:approve|pass)\s+without\s+review/i, policy: "reviewer" },
+  { regex: /\bmark\s+as\s+approved\b/i, policy: "reviewer" },
+  { regex: /\bjust\s+ship\s+it/i, policy: "reviewer" },
+  { regex: /\bignore\s+(?:the\s+)?(?:review(?:er)?\s+)?feedback\b/i, policy: "reviewer" },
+  { regex: /\b(?:skip|ignore|bypass|disable)\s+(?:the\s+)?(?:sonar|sonarqube|quality\s+gate)/i, policy: "sonar" },
+  { regex: /\bignore\s+sonar\s+issues?\b/i, policy: "sonar" },
+  { regex: /\b(?:skip|ignore|bypass|disable)\s+(?:the\s+)?security(?:\s+checks?)?\b/i, policy: "security" },
+];
+
+const SUGGESTIONS_BY_POLICY = {
+  tdd: [
+    "Provide specific guidance for the coder on how to fix the failing tests",
+    "Describe the expected behavior so the coder can write correct tests",
+    "Suggest a different approach to implement the feature that is easier to test",
+  ],
+  reviewer: [
+    "Provide technical guidance to address the reviewer's feedback",
+    "Explain why the current approach is correct if you disagree with the review",
+    "Suggest alternative implementations that satisfy the reviewer's concerns",
+  ],
+  sonar: [
+    "Provide guidance on how to resolve the SonarQube issues",
+    "Explain the code changes needed to satisfy quality gate requirements",
+  ],
+  security: [
+    "Provide guidance on how to fix the security issues found",
+    "Explain the secure alternative for the flagged pattern",
+  ],
+};
+
+const CONTEXT_SUGGESTIONS = {
+  reviewer_fail_fast: [
+    "Provide specific technical guidance for the coder to address the reviewer's feedback",
+    "Suggest a different approach that resolves the reviewer's concerns",
+  ],
+  max_iterations: [
+    "Provide focused guidance to help the coder converge on a solution",
+    "Narrow the scope: specify exactly which file/function to change and how",
+    "Continue with additional iterations by choosing option 1 or 2",
+  ],
+  standby_exhausted: [
+    "Wait and retry — the provider may be temporarily overloaded",
+    "Continue to resume from where the pipeline left off",
+  ],
+};
+
+/**
+ * Validate a resume answer against pipeline policies.
+ *
+ * @param {string|null} answer - The resume answer from the host
+ * @param {string} [pauseContext] - The context of the pause (e.g. "reviewer_fail_fast")
+ * @returns {{ valid: boolean, reason?: string, suggestions?: string[] }}
+ */
+export function validatePolicyCompliance(answer, pauseContext) {
+  if (answer == null || answer === "") return { valid: true };
+  if (typeof answer !== "string") return { valid: true };
+
+  const text = answer.trim();
+  for (const { regex, policy } of BYPASS_PATTERNS) {
+    if (regex.test(text)) {
+      const suggestions = [
+        ...(CONTEXT_SUGGESTIONS[pauseContext] || []),
+        ...(SUGGESTIONS_BY_POLICY[policy] || []),
+      ];
+      return {
+        valid: false,
+        reason: `Pipeline policy "${policy}" cannot be bypassed. Provide technical guidance instead.`,
+        suggestions: [...new Set(suggestions)],
+      };
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/mcp/handlers/run-handler.js
+++ b/src/mcp/handlers/run-handler.js
@@ -8,6 +8,7 @@ import { runFlow, resumeFlow } from "../../orchestrator.js";
 import { loadConfig, applyRunOverrides, validateConfig, resolveRole } from "../../config.js";
 import { createLogger } from "../../utils/logger.js";
 import { assertAgentsAvailable } from "../../agents/availability.js";
+import { validatePolicyCompliance } from "../../guards/policy-guard.js";
 import { createRunLog } from "../../utils/run-log.js";
 import { buildProgressHandler, buildProgressNotifier, buildPipelineTracker } from "../progress.js";
 import { isPreflightAcked, ackPreflight, getSessionOverrides } from "../preflight.js";
@@ -203,7 +204,7 @@ const RESUME_INJECTION_PATTERNS = [
   /force\s+(approve|merge|push|commit)\b/i,
 ];
 
-export function validateResumeAnswer(answer) {
+export function validateResumeAnswer(answer, pauseContext) {
   if (answer == null || answer === "") return { valid: true, sanitized: answer ?? null };
   if (typeof answer !== "string") return { valid: true, sanitized: String(answer) };
   if (answer.length > RESUME_MAX_ANSWER_LENGTH) {
@@ -213,6 +214,14 @@ export function validateResumeAnswer(answer) {
     if (pattern.test(answer)) {
       return { valid: false, reason: "Answer rejected: matches guardrail bypass pattern" };
     }
+  }
+  // Policy compliance: reject attempts to bypass TDD, reviewer, security, etc.
+  const policy = validatePolicyCompliance(answer, pauseContext);
+  if (!policy.valid) {
+    const suggestionsText = policy.suggestions.length > 0
+      ? `\nValid alternatives:\n${policy.suggestions.map(s => `  - ${s}`).join("\n")}`
+      : "";
+    return { valid: false, reason: `${policy.reason}${suggestionsText}` };
   }
   return { valid: true, sanitized: answer.trim() };
 }
@@ -240,7 +249,15 @@ export async function handleResume(a, server, extra) {
   }
   await runBootstrapGate(server, a);
   if (a.answer) {
-    const validation = validateResumeAnswer(a.answer);
+    // Load session to get pause context for policy-aware validation
+    let pauseContext;
+    try {
+      const { loadSession } = await import("../../session-store.js");
+      const session = await loadSession(a.sessionId);
+      const ctx = session?.paused_state?.context;
+      pauseContext = typeof ctx === "string" ? ctx : ctx?.reason;
+    } catch { /* session read error — validate without context */ }
+    const validation = validateResumeAnswer(a.answer, pauseContext);
     if (!validation.valid) {
       return failPayload(`Resume answer rejected: ${validation.reason}`);
     }

--- a/tests/guards/policy-guard.test.js
+++ b/tests/guards/policy-guard.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { validatePolicyCompliance } from "../../src/guards/policy-guard.js";
+
+describe("validatePolicyCompliance", () => {
+  describe("bypass patterns", () => {
+    const bypassPhrases = [
+      "skip the tests",
+      "skip TDD",
+      "ignore the reviewer",
+      "ignore reviewer feedback",
+      "continue without tests",
+      "continue without testing",
+      "disable TDD",
+      "disable tests",
+      "switch to standard methodology",
+      "switch methodology to standard",
+      "don't run tests",
+      "no need for tests",
+      "approve without review",
+      "mark as approved",
+      "bypass the reviewer",
+      "just ship it without review",
+      "skip sonar",
+      "ignore sonar issues",
+      "disable security checks",
+      "skip security",
+    ];
+
+    for (const phrase of bypassPhrases) {
+      it(`rejects: "${phrase}"`, () => {
+        const result = validatePolicyCompliance(phrase);
+        expect(result.valid).toBe(false);
+        expect(result.reason).toBeTruthy();
+        expect(result.suggestions).toBeInstanceOf(Array);
+        expect(result.suggestions.length).toBeGreaterThan(0);
+      });
+    }
+  });
+
+  describe("valid answers", () => {
+    const validPhrases = [
+      "the coder should create test files first, then implement",
+      "focus on fixing the type error in line 42",
+      "try a different approach: use a Map instead of an object",
+      "1",
+      "2",
+      "continue",
+      "stop",
+      "the test expects a string but the function returns a number",
+      "add error handling for the null case",
+      "split the function into smaller units",
+    ];
+
+    for (const phrase of validPhrases) {
+      it(`accepts: "${phrase}"`, () => {
+        const result = validatePolicyCompliance(phrase);
+        expect(result.valid).toBe(true);
+      });
+    }
+  });
+
+  describe("context-aware suggestions", () => {
+    it("suggests TDD guidance for reviewer_fail_fast context", () => {
+      const result = validatePolicyCompliance("skip the tests", "reviewer_fail_fast");
+      expect(result.valid).toBe(false);
+      expect(result.suggestions.some(s => /guidance|feedback|approach/i.test(s))).toBe(true);
+    });
+
+    it("suggests alternatives for max_iterations context", () => {
+      const result = validatePolicyCompliance("ignore the reviewer", "max_iterations");
+      expect(result.valid).toBe(false);
+      expect(result.suggestions.some(s => /iteration|continue|guidance/i.test(s))).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("accepts null answer", () => {
+      const result = validatePolicyCompliance(null);
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts empty string", () => {
+      const result = validatePolicyCompliance("");
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts numeric choice", () => {
+      const result = validatePolicyCompliance("3");
+      expect(result.valid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/guards/policy-guard.js` module that detects attempts to bypass pipeline policies (skip TDD, ignore reviewer, disable security/sonar) in kj_resume answers
- Integrated into `validateResumeAnswer` in run-handler.js with pause context awareness
- Returns context-specific suggestions for valid alternatives (e.g. "provide technical guidance" instead of "skip tests")
- 35 new tests covering 20 bypass patterns, 10 valid answers, context-aware suggestions, and edge cases

## Test plan
- [x] 35/35 policy-guard tests pass
- [x] 36/36 anti-bypass-resume tests pass
- [x] 43/43 server-handlers-unit tests pass
- [x] 2/2 resume-config-snapshot tests pass

Fixes KJC-TSK-0124