### PR TITLE
feat(checkpoint): auto-continue on recoverable stalls (rate limit/cooldown)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -381,6 +381,24 @@ function takeCheckpointSnapshot(session) {
   };
 }
 
+/**
+ * Determine if checkpoint should auto-continue without asking the user.
+ * Exported for testing.
+ */
+export function shouldAutoContinueCheckpoint(session, hasProgress) {
+  if (hasProgress) {
+    session._checkpoint_stall_count = 0;
+    return { autoContinue: true, reason: "progress_detected" };
+  }
+  const wasRateLimited = (session.standby_retry_count || 0) > 0;
+  const consecutiveStalls = (session._checkpoint_stall_count || 0) + 1;
+  session._checkpoint_stall_count = consecutiveStalls;
+  if (wasRateLimited && consecutiveStalls < 3) {
+    return { autoContinue: true, reason: "recoverable_stall" };
+  }
+  return { autoContinue: false, reason: consecutiveStalls >= 3 ? "max_stalls_reached" : "no_progress" };
+}
+
 async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpointAt, checkpointIntervalMs, elapsedMinutes, i, config, budgetTracker, stageResults, emitter, eventBase, session, budgetSummary, lastCheckpointSnapshot }) {
   if (checkpointDisabled || !askQuestion || (Date.now() - lastCheckpointAt) < checkpointIntervalMs) {
     return { action: "continue_loop", checkpointDisabled, lastCheckpointAt, lastCheckpointSnapshot };
@@ -389,22 +407,23 @@ async function handleCheckpoint({ checkpointDisabled, askQuestion, lastCheckpoin
   const elapsedStr = elapsedMinutes.toFixed(1);
   const stagesCompleted = Object.keys(stageResults).join(", ") || "none";
 
-  // Auto-continue if progress detected since last checkpoint
+  // Decide whether to auto-continue or ask the user
   const hasProgress = detectCheckpointProgress(session, lastCheckpointSnapshot);
   const newSnapshot = takeCheckpointSnapshot(session);
+  const decision = shouldAutoContinueCheckpoint(session, hasProgress);
 
-  if (hasProgress) {
+  if (decision.autoContinue) {
     emitProgress(
       emitter,
       makeEvent("session:checkpoint", { ...eventBase, iteration: i, stage: "checkpoint" }, {
-        message: `Checkpoint: progress detected, continuing (${elapsedStr} min elapsed)`,
-        detail: { elapsed_minutes: Number(elapsedStr), iterations_done: i - 1, stages: stagesCompleted, auto_continued: true, executorType: "system" }
+        message: `Checkpoint: ${decision.reason === "progress_detected" ? "progress detected" : "stall caused by rate limit/cooldown"}, auto-continuing (${elapsedStr} min elapsed)`,
+        detail: { elapsed_minutes: Number(elapsedStr), iterations_done: i - 1, stages: stagesCompleted, auto_continued: true, reason: decision.reason }
       })
     );
     return { action: "continue_loop", checkpointDisabled, lastCheckpointAt: Date.now(), lastCheckpointSnapshot: newSnapshot };
   }
 
-  // No progress — ask human
+  // No progress and not recoverable — ask human
   const iterInfo = `${i - 1}/${config.max_iterations} iterations completed`;
   const budgetInfo = budgetTracker.total().cost_usd > 0 ? ` | Budget: $${budgetTracker.total().cost_usd.toFixed(2)}` : "";
   const checkpointMsg = `Checkpoint — ${elapsedStr} min elapsed | ${iterInfo}${budgetInfo} | Stages completed: ${stagesCompleted}. No progress since last checkpoint. What would you like to do?`;

--- a/tests/smart-checkpoint.test.js
+++ b/tests/smart-checkpoint.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { shouldAutoContinueCheckpoint } from "../src/orchestrator.js";
+
+describe("shouldAutoContinueCheckpoint", () => {
+  it("auto-continues when progress is detected", () => {
+    const session = { standby_retry_count: 0, _checkpoint_stall_count: 2 };
+    const result = shouldAutoContinueCheckpoint(session, true);
+    expect(result.autoContinue).toBe(true);
+    expect(result.reason).toBe("progress_detected");
+    expect(session._checkpoint_stall_count).toBe(0);
+  });
+
+  it("auto-continues when stall was caused by rate limit (1st stall)", () => {
+    const session = { standby_retry_count: 2, _checkpoint_stall_count: 0 };
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(true);
+    expect(result.reason).toBe("recoverable_stall");
+    expect(session._checkpoint_stall_count).toBe(1);
+  });
+
+  it("auto-continues on 2nd consecutive rate-limit stall", () => {
+    const session = { standby_retry_count: 1, _checkpoint_stall_count: 1 };
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(true);
+    expect(result.reason).toBe("recoverable_stall");
+    expect(session._checkpoint_stall_count).toBe(2);
+  });
+
+  it("asks user on 3rd consecutive stall even with rate limit", () => {
+    const session = { standby_retry_count: 1, _checkpoint_stall_count: 2 };
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(false);
+    expect(result.reason).toBe("max_stalls_reached");
+  });
+
+  it("asks user when no progress and no rate limit", () => {
+    const session = { standby_retry_count: 0, _checkpoint_stall_count: 0 };
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(false);
+    expect(result.reason).toBe("no_progress");
+  });
+
+  it("resets stall counter when progress resumes", () => {
+    const session = { standby_retry_count: 0, _checkpoint_stall_count: 5 };
+    shouldAutoContinueCheckpoint(session, true);
+    expect(session._checkpoint_stall_count).toBe(0);
+    // Next stall without rate limit should ask
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(false);
+  });
+
+  it("handles missing session fields gracefully", () => {
+    const session = {};
+    const result = shouldAutoContinueCheckpoint(session, false);
+    expect(result.autoContinue).toBe(false);
+    expect(result.reason).toBe("no_progress");
+  });
+});


### PR DESCRIPTION
## Summary
- Checkpoint no longer asks the user when the stall was caused by rate limit or standby cooldown — it auto-continues
- After 2 consecutive stalls without progress, falls back to asking (real problem, not just cooldown)
- Stall counter resets when real progress is detected
- New exported `shouldAutoContinueCheckpoint()` function with 7 unit tests

## Test plan
- [x] 7/7 smart-checkpoint unit tests pass
- [x] 13/13 orchestrator-checkpoint integration tests pass
- [x] Verified logic: rate-limited session auto-continues, non-rate-limited session asks user

Fixes KJC-TSK-0264