### PR TITLE
chore: bump version to v1.59.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "1.58.2",
+  "version": "1.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "1.58.2",
+      "version": "1.59.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.58.2",
+  "version": "1.59.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
Version bump to v1.59.0. Changes since v1.58.2:

### New features
- Native HTTP proxy layer (17 PRs #319-#334): context compression, response interception, prompt injection, progress monitoring
- Project bootstrapping: auto git init + handle empty repos (#340)
- Smart checkpoint: auto-continue on rate limit/cooldown stalls (#339)
- Policy guard: reject pipeline bypass in resume answers (#338)
- Clean CLI output: suppress internal events in quiet mode (#341)
- Configurable session/log cleanup (#341)

### Fixes
- computeBaseRef empty repo crash (#335)
- npm audit vulnerabilities (#336)
- Sonar token exposure in ps aux (#337)

## Test plan
- [x] All CI checks pass