### PR TITLE
feat(cli): ASCII art banner with brand colors and robot mascot

### DIFF
--- a/src/utils/banner.js
+++ b/src/utils/banner.js
@@ -1,0 +1,79 @@
+/**
+ * Karajan Code ASCII banner with brand colors.
+ *
+ * Brand palette:
+ *   #AACCEE  steel blue (primary text)
+ *   #88CC88  green (accents, robot eyes)
+ *   #464000  dark olive
+ *   #444411  charcoal (secondary text)
+ */
+
+const C = {
+  blue:    "\x1b[38;2;170;204;238m",  // #AACCEE
+  green:   "\x1b[38;2;100;190;100m",  // green accents
+  gray:    "\x1b[38;2;140;140;140m",  // borders/dim
+  white:   "\x1b[38;2;220;220;220m",  // bright text
+  olive:   "\x1b[38;2;70;64;0m",      // #464000
+  charcoal:"\x1b[38;2;100;100;80m",   // #444411 approx
+  bold:    "\x1b[1m",
+  dim:     "\x1b[2m",
+  reset:   "\x1b[0m"
+};
+
+// Robot mascot (conductor with visor, bowtie, baton)
+const MASCOT = [
+  `${C.gray}    ╭──────────╮`,
+  `${C.gray}    │ ${C.green}~╷${C.gray}    ${C.green}╷${C.gray}  │`,
+  `${C.gray}    │  ${C.green}v${C.gray}     ${C.green}│${C.gray}  ├${C.charcoal}──`,
+  `${C.gray}    ╰──────────╯${C.charcoal} /`,
+  `${C.gray}       ╭─${C.white}⋈${C.gray}─╮  ${C.charcoal}/`,
+  `${C.gray}       ╰────╯`,
+];
+
+// "KARAJAN" in compact block letters
+const TITLE = [
+  `${C.bold}${C.blue}╦╔═ ╔═╗ ╦═╗ ╔═╗   ╦ ╔═╗ ╔╗╔`,
+  `${C.bold}${C.blue}╠╩╗ ╠═╣ ╠╦╝ ╠═╣   ║ ╠═╣ ║║║`,
+  `${C.bold}${C.blue}╩ ╩ ╩ ╩ ╩╚═ ╩ ╩ ╚╝  ╩ ╩ ╝╚╝`,
+];
+
+/**
+ * Print the Karajan Code ASCII banner.
+ * @param {string} version - Package version to display
+ * @param {object} [opts] - Options
+ * @param {boolean} [opts.compact] - Skip mascot, show only text
+ * @param {boolean} [opts.force] - Print even without TTY
+ */
+export function printBanner(version, opts = {}) {
+  if (!opts.force && !process.stdout.isTTY) return; // skip in pipes/non-interactive
+
+  console.log();
+
+  if (!opts.compact) {
+    // Combine mascot (left) + title (right)
+    const pad = "  ";
+    const mascotWidth = 22; // visual width of mascot lines
+
+    for (let i = 0; i < Math.max(MASCOT.length, TITLE.length + 2); i++) {
+      const left = i < MASCOT.length ? MASCOT[i] : " ".repeat(mascotWidth);
+      const titleIdx = i - 1; // offset title down 1 line
+      let right = "";
+      if (titleIdx >= 0 && titleIdx < TITLE.length) {
+        right = `${pad}${TITLE[titleIdx]}`;
+      } else if (titleIdx === TITLE.length) {
+        right = `${pad}${C.white}${C.bold}        C O D E${C.reset}  ${C.dim}v${version}${C.reset}`;
+      } else if (titleIdx === TITLE.length + 1) {
+        right = `${pad}${C.charcoal}  multiagent coding orchestrator${C.reset}`;
+      }
+      console.log(`${left}${C.reset}${right}${C.reset}`);
+    }
+  } else {
+    // Compact: just title + version
+    for (const line of TITLE) {
+      console.log(`  ${line}${C.reset}`);
+    }
+    console.log(`  ${C.white}${C.bold}        C O D E${C.reset}  ${C.dim}v${version}${C.reset}`);
+  }
+
+  console.log();
+}

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { printBanner } from "./banner.js";
 
 // TODO: i18n display messages
 const DISPLAY_PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
@@ -83,9 +84,7 @@ const BAR = `${ANSI.dim}\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u
 
 export function printHeader({ task, config }) {
   const version = DISPLAY_VERSION;
-  console.log(BAR);
-  console.log(`${ANSI.bold}${ANSI.cyan}\u25b6 Karajan Code v${version}${ANSI.reset}`);
-  console.log(BAR);
+  printBanner(version);
   console.log(`${ANSI.bold}Task:${ANSI.reset} ${task}`);
   console.log(
     `${ANSI.bold}Coder:${ANSI.reset} ${config.roles?.coder?.provider || config.coder} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Reviewer:${ANSI.reset} ${config.roles?.reviewer?.provider || config.reviewer}`

--- a/src/utils/welcome.js
+++ b/src/utils/welcome.js
@@ -1,3 +1,5 @@
+import { printBanner } from "./banner.js";
+
 const A = {
   reset:   "\x1b[0m",
   bold:    "\x1b[1m",
@@ -6,8 +8,6 @@ const A = {
   green:   "\x1b[32m",
   yellow:  "\x1b[33m",
 };
-
-const BAR = `${A.dim}${"─".repeat(44)}${A.reset}`;
 
 const QUICK_START = [
   ["kj run <task>",  "Run the full coder+reviewer pipeline"],
@@ -24,12 +24,7 @@ const QUICK_START = [
  * @param {object} [opts.config]  - Loaded KJ config (optional, shows configured agents)
  */
 export function printWelcomeScreen({ version, config = null }) {
-  console.log();
-  console.log(BAR);
-  console.log(`  ${A.bold}${A.cyan}▶ Karajan Code${A.reset}  ${A.dim}v${version}${A.reset}`);
-  console.log(`  ${A.dim}AI-powered coding pipeline${A.reset}`);
-  console.log(BAR);
-  console.log();
+  printBanner(version, { force: true });
 
   if (config) {
     const coder    = config.roles?.coder?.provider    || config.coder    || "claude";


### PR DESCRIPTION
## Summary
- New `src/utils/banner.js` module — importable from any CLI command
- Robot conductor ASCII art (visor, bowtie, baton) with brand colors (#AACCEE, #88CC88)
- KARAJAN block letters + "C O D E" + version + tagline
- Integrated in `printHeader` (kj run) and `printWelcomeScreen` (kj without args)
- Respects TTY — hidden in pipes/non-interactive, `force` option for welcome screen

## Test plan
- [x] 7/7 cli-welcome tests pass
- [x] Full test suite passes (3108/3108)

Fixes KJC-TSK-0267