### PR TITLE
feat(domain): auto-detect project context + --domain parameter

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -127,6 +127,7 @@ program
   .option("--smart-models", "Enable smart model selection based on triage complexity")
   .option("--no-smart-models", "Disable smart model selection")
   .option("--design", "Activate design refactoring mode (impeccable role applies design changes)")
+  .option("--domain <text-or-path>", "Domain knowledge: inline text or path to .md file")
   .option("--dry-run", "Show what would be executed without running anything")
   .option("--json", "Output JSON only (no styled display)")
   .option("-q, --quiet", "Show only stage status lines, suppress raw agent output (default)")

--- a/src/domains/domain-loader.js
+++ b/src/domains/domain-loader.js
@@ -5,8 +5,8 @@
  * Project-local domains override user-global domains by directory name.
  */
 
-import { readdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readdir, readFile, mkdir, writeFile, stat } from "node:fs/promises";
+import { join, isAbsolute } from "node:path";
 import yaml from "js-yaml";
 import { getKarajanHome } from "../utils/paths.js";
 
@@ -104,7 +104,51 @@ function parseSections(content) {
 }
 
 /**
+ * Auto-detect project context files (README.md, CLAUDE.md) as lightweight domains.
+ * Used as fallback when no explicit .karajan/domains/ are configured.
+ *
+ * @param {string} projectDir — absolute path to project root
+ * @returns {Promise<DomainFile[]>}
+ */
+export async function autoDetectDomains(projectDir) {
+  if (!projectDir) return [];
+
+  const candidates = ["README.md", "CLAUDE.md", "docs/README.md"];
+  const detected = [];
+
+  for (const rel of candidates) {
+    const filePath = join(projectDir, rel);
+    let content;
+    try {
+      content = await readFile(filePath, "utf-8");
+    } catch { continue; }
+
+    if (!content || content.trim().length < 20) continue;
+
+    // Truncate to first 4000 chars to avoid bloating context
+    const trimmed = content.length > 4000 ? content.slice(0, 4000) + "\n\n[...truncated]" : content;
+
+    detected.push({
+      name: `auto:${rel}`,
+      description: `Auto-detected from ${rel}`,
+      tags: [],
+      version: "0.0.0",
+      author: "",
+      visibility: "private",
+      sources: [{ type: "auto-detect", note: rel }],
+      content: trimmed,
+      sections: parseSections(trimmed),
+      filePath,
+      origin: "auto-detect"
+    });
+  }
+
+  return detected;
+}
+
+/**
  * Load all domains from project-local and user-global directories.
+ * Falls back to auto-detecting README.md/CLAUDE.md when no explicit domains found.
  * Project-local domains override user-global domains when directory names match.
  *
  * @param {string|null} projectDir — absolute path to project root (null = user-global only)
@@ -119,7 +163,6 @@ export async function loadDomains(projectDir) {
   const projectDomains = projectDomainDir ? await scanDomainDir(projectDomainDir, "project") : [];
 
   // Build a map keyed by directory name for merge.
-  // We track by directory name (not domain name) because the override is by directory.
   const merged = new Map();
 
   for (const { dirName, domain } of userDomains) {
@@ -129,7 +172,14 @@ export async function loadDomains(projectDir) {
     merged.set(dirName, domain); // project overrides user
   }
 
-  return Array.from(merged.values());
+  const explicit = Array.from(merged.values());
+
+  // Fallback: auto-detect README.md, CLAUDE.md when no explicit domains found
+  if (explicit.length === 0 && projectDir) {
+    return autoDetectDomains(projectDir);
+  }
+
+  return explicit;
 }
 
 /**
@@ -161,4 +211,35 @@ async function scanDomainDir(dir, origin) {
   }
 
   return results;
+}
+
+/**
+ * Persist an inline domain (text or file path) to .karajan/domains/inline/DOMAIN.md.
+ * If domainInput is a path to an existing .md file, reads its content.
+ * Otherwise treats it as inline text.
+ *
+ * @param {string} domainInput — inline text or absolute path to a .md file
+ * @param {string} projectDir — project root
+ */
+export async function persistInlineDomain(domainInput, projectDir) {
+  if (!domainInput || !projectDir) return;
+
+  let content = domainInput;
+
+  // If it looks like a file path, try to read it
+  if (isAbsolute(domainInput) && domainInput.endsWith(".md")) {
+    try {
+      const s = await stat(domainInput);
+      if (s.isFile()) {
+        content = await readFile(domainInput, "utf-8");
+      }
+    } catch { /* treat as inline text */ }
+  }
+
+  const domainDir = join(projectDir, ".karajan", "domains", "inline");
+  await mkdir(domainDir, { recursive: true });
+
+  const domainFile = join(domainDir, DOMAIN_FILE);
+  const wrapped = `---\nname: inline-domain\ndescription: Domain knowledge provided via --domain parameter\ntags: []\nversion: "0.0.0"\n---\n\n${content}\n`;
+  await writeFile(domainFile, wrapped, "utf-8");
 }

--- a/src/mcp/sovereignty-guard.js
+++ b/src/mcp/sovereignty-guard.js
@@ -24,7 +24,7 @@ const ALLOWED_PARAMS = new Set([
   "autoCommit", "autoPush", "autoPr", "autoRebase", "branchPrefix",
   "autoSimplify", "smartModels", "checkpointInterval",
   "taskType", "quiet", "noSonar", "enableSonarcloud",
-  "kjHome", "sonarToken", "timeoutMs",
+  "kjHome", "sonarToken", "timeoutMs", "domain",
   // Sovereign flags — validated below but still "known"
   "enableTriage", "enableHuReviewer",
 ]);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -104,7 +104,8 @@ export const tools = [
         enableSonarcloud: { type: "boolean", description: "Enable SonarCloud scan (complementary to SonarQube)" },
         kjHome: { type: "string" },
         sonarToken: { type: "string" },
-        timeoutMs: { type: "number" }
+        timeoutMs: { type: "number" },
+        domain: { type: "string", description: "Domain knowledge: inline text describing the project domain, or absolute path to a .md file. Auto-saved to .karajan/domains/ for the curator." }
       }
     }
   },

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -35,6 +35,7 @@ import { msg, getLang } from "./utils/messages.js";
 import { PipelineContext } from "./orchestrator/pipeline-context.js";
 import { runTriageStage, runResearcherStage, runArchitectStage, runPlannerStage, runDiscoverStage, runHuReviewerStage } from "./orchestrator/pre-loop-stages.js";
 import { runDomainCuratorStage } from "./orchestrator/stages/domain-curator-stage.js";
+import { persistInlineDomain } from "./domains/domain-loader.js";
 import { runCoderStage, runRefactorerStage, runTddCheckStage, runSonarStage, runSonarCloudStage, runReviewerStage } from "./orchestrator/iteration-stages.js";
 import { runTesterStage, runSecurityStage, runImpeccableStage, runFinalAuditStage } from "./orchestrator/post-loop-stages.js";
 import { needsSubPipeline, runHuSubPipeline } from "./orchestrator/hu-sub-pipeline.js";
@@ -938,6 +939,15 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
     }
   } catch (err) {
     logger.warn(`Skill auto-install failed (non-blocking): ${err.message}`);
+  }
+
+  // --- Persist inline domain if provided via --domain flag ---
+  if (flags?.domain) {
+    try {
+      await persistInlineDomain(flags.domain, config.projectDir || process.cwd());
+    } catch (err) {
+      logger.warn(`Failed to persist inline domain: ${err.message}`);
+    }
   }
 
   // --- Domain Curator (after triage + skill auto-install, before planning phases) ---

--- a/tests/domain-autodetect.test.js
+++ b/tests/domain-autodetect.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn()
+}));
+
+vi.mock("../src/utils/paths.js", () => ({
+  getKarajanHome: vi.fn(() => "/home/user/.karajan")
+}));
+
+const { readdir, readFile, mkdir, writeFile, stat } = await import("node:fs/promises");
+const { autoDetectDomains, persistInlineDomain } = await import("../src/domains/domain-loader.js");
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  readdir.mockResolvedValue([]);
+});
+
+describe("autoDetectDomains", () => {
+  it("detects README.md as domain context", async () => {
+    readFile.mockImplementation((path) => {
+      if (path.endsWith("README.md") && !path.includes("docs")) {
+        return Promise.resolve("# My Project\n\nThis is a task management system with REST API.\n");
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const domains = await autoDetectDomains("/tmp/project");
+    expect(domains).toHaveLength(1);
+    expect(domains[0].name).toBe("auto:README.md");
+    expect(domains[0].content).toContain("task management");
+    expect(domains[0].origin).toBe("auto-detect");
+  });
+
+  it("detects both README.md and CLAUDE.md", async () => {
+    readFile.mockImplementation((path) => {
+      if (path.endsWith("README.md") && !path.includes("docs")) {
+        return Promise.resolve("# Project\n\nDescription here that is long enough to count.\n");
+      }
+      if (path.endsWith("CLAUDE.md")) {
+        return Promise.resolve("# Instructions\n\nUse TDD, run vitest, do not touch main branch.\n");
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const domains = await autoDetectDomains("/tmp/project");
+    expect(domains).toHaveLength(2);
+    expect(domains.map(d => d.name)).toEqual(["auto:README.md", "auto:CLAUDE.md"]);
+  });
+
+  it("skips files shorter than 20 chars", async () => {
+    readFile.mockImplementation((path) => {
+      if (path.endsWith("README.md")) return Promise.resolve("Short");
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const domains = await autoDetectDomains("/tmp/project");
+    expect(domains).toHaveLength(0);
+  });
+
+  it("truncates files over 4000 chars", async () => {
+    readFile.mockImplementation((path) => {
+      if (path.endsWith("README.md") && !path.includes("docs")) {
+        return Promise.resolve("x".repeat(5000));
+      }
+      return Promise.reject(new Error("ENOENT"));
+    });
+
+    const domains = await autoDetectDomains("/tmp/project");
+    expect(domains[0].content).toContain("[...truncated]");
+    expect(domains[0].content.length).toBeLessThan(4100);
+  });
+
+  it("returns empty for null projectDir", async () => {
+    const domains = await autoDetectDomains(null);
+    expect(domains).toHaveLength(0);
+  });
+});
+
+describe("persistInlineDomain", () => {
+  it("writes inline text to .karajan/domains/inline/DOMAIN.md", async () => {
+    mkdir.mockResolvedValue(undefined);
+    writeFile.mockResolvedValue(undefined);
+
+    await persistInlineDomain("This project is a dental platform", "/tmp/project");
+
+    expect(mkdir).toHaveBeenCalledWith(
+      expect.stringContaining(".karajan/domains/inline"),
+      { recursive: true }
+    );
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("DOMAIN.md"),
+      expect.stringContaining("dental platform"),
+      "utf-8"
+    );
+  });
+
+  it("reads content from .md file path", async () => {
+    stat.mockResolvedValue({ isFile: () => true });
+    readFile.mockResolvedValue("# Domain from file\n\nDetailed domain knowledge here.");
+    mkdir.mockResolvedValue(undefined);
+    writeFile.mockResolvedValue(undefined);
+
+    await persistInlineDomain("/path/to/domain.md", "/tmp/project");
+
+    expect(readFile).toHaveBeenCalledWith("/path/to/domain.md", "utf-8");
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("DOMAIN.md"),
+      expect.stringContaining("Domain from file"),
+      "utf-8"
+    );
+  });
+
+  it("treats non-existent file path as inline text", async () => {
+    stat.mockRejectedValue(new Error("ENOENT"));
+    mkdir.mockResolvedValue(undefined);
+    writeFile.mockResolvedValue(undefined);
+
+    await persistInlineDomain("/not/a/real/file.md", "/tmp/project");
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("DOMAIN.md"),
+      expect.stringContaining("/not/a/real/file.md"),
+      "utf-8"
+    );
+  });
+
+  it("does nothing with empty input", async () => {
+    await persistInlineDomain("", "/tmp/project");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/domain-loader.test.js
+++ b/tests/domain-loader.test.js
@@ -187,8 +187,9 @@ describe("loadDomains", () => {
     vi.clearAllMocks();
   });
 
-  it("returns empty array when no domain directories exist", async () => {
+  it("returns empty array when no domain directories and no auto-detect files exist", async () => {
     readdir.mockRejectedValue(new Error("ENOENT"));
+    readFile.mockRejectedValue(new Error("ENOENT"));
 
     const result = await loadDomains("/project");
 


### PR DESCRIPTION
## Summary
- Domain Curator auto-detects README.md, CLAUDE.md, docs/README.md as domain context when no explicit .karajan/domains/ configured
- New `--domain` parameter in kj_run (CLI + MCP): inline text or path to .md file, auto-persisted to .karajan/domains/inline/
- Files truncated at 4000 chars to avoid context bloat
- Works from Claude via MCP without human intervention

## Test plan
- [x] 9/9 domain-autodetect tests pass
- [x] 16/16 domain-loader tests pass (updated for auto-detect fallback)

Fixes KJC-TSK-0268