### PR TITLE
fix(roles): robust JSON parsing in solomon, reviewer, impeccable, researcher

### DIFF
--- a/src/roles/impeccable-role.js
+++ b/src/roles/impeccable-role.js
@@ -1,6 +1,7 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { isDevToolsMcpAvailable, ensureWebPerfSkills } from "../webperf/devtools-detect.js";
+import { extractFirstJson } from "../utils/json-extract.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -35,10 +36,7 @@ function buildPrompt({ task, diff, instructions }) {
 }
 
 function parseImpeccableOutput(raw) {
-  const text = raw?.trim() || "";
-  const jsonMatch = /\{[\s\S]*\}/.exec(text);
-  if (!jsonMatch) return null;
-  return JSON.parse(jsonMatch[0]);
+  return extractFirstJson(raw);
 }
 
 function buildSummary(parsed) {

--- a/src/roles/researcher-role.js
+++ b/src/roles/researcher-role.js
@@ -1,5 +1,6 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { extractFirstJson } from "../utils/json-extract.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -34,10 +35,7 @@ function buildPrompt({ task, instructions }) {
 }
 
 function parseResearchOutput(raw) {
-  const text = raw?.trim() || "";
-  const jsonMatch = /\{[\s\S]*\}/.exec(text);
-  if (!jsonMatch) return null;
-  return JSON.parse(jsonMatch[0]);
+  return extractFirstJson(raw);
 }
 
 function buildSummary(parsed) {

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -1,6 +1,7 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { buildRtkInstructions } from "../prompts/rtk-snippet.js";
+import { extractFirstJson } from "../utils/json-extract.js";
 
 const MAX_DIFF_LENGTH = 12000;
 
@@ -65,12 +66,11 @@ function buildPrompt({ task, diff, reviewRules, reviewMode, instructions, rtkAva
 }
 
 function parseReviewOutput(raw) {
-  const text = raw?.trim() || "";
-  const jsonMatch = /\{[\s\S]*\}/.exec(text);
-  if (!jsonMatch) {
+  const parsed = extractFirstJson(raw);
+  if (!parsed) {
     throw new Error(`Failed to parse reviewer output: no JSON found`);
   }
-  return JSON.parse(jsonMatch[0]);
+  return parsed;
 }
 
 export class ReviewerRole extends BaseRole {

--- a/src/roles/solomon-role.js
+++ b/src/roles/solomon-role.js
@@ -1,5 +1,6 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { extractFirstJson } from "../utils/json-extract.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -98,10 +99,7 @@ function buildPrompt({ conflict, task, instructions }) {
 }
 
 function parseSolomonOutput(raw) {
-  const text = raw?.trim() || "";
-  const jsonMatch = /\{[\s\S]*\}/.exec(text);
-  if (!jsonMatch) return null;
-  return JSON.parse(jsonMatch[0]);
+  return extractFirstJson(raw);
 }
 
 function buildSummary(parsed) {


### PR DESCRIPTION
## Summary
- Solomon output parsing failed when LLM appended text after JSON (`Unexpected non-whitespace character after JSON at position 8119`)
- Root cause: greedy regex `\{[\s\S]*\}` captured trailing `}` from explanation text
- Fix: replaced with `extractFirstJson()` (bracket-depth parser from json-extract.js) in all 4 roles
- Same vulnerability existed in reviewer, impeccable, and researcher roles — fixed all

## Test plan
- [x] 26/26 solomon-role tests pass
- [x] 3/3 reviewer-parse-resilience tests pass
- [x] 6/6 domain-curator-role tests pass

Fixes KJC-BUG-0021