### PR TITLE
chore: bump version to v1.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "1.59.0",
+      "version": "1.59.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "1.59.0",
+  "version": "1.59.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Changes since v1.59.0
- feat: ASCII art banner with brand colors and robot mascot (#343, #344)
- feat: Domain Curator auto-detect README/CLAUDE.md + --domain parameter (#346)
- fix: Proxy ECONNREFUSED for claude-agent + sanitize error output (#345)
- fix: Robust JSON parsing in solomon/reviewer/impeccable/researcher (#347)