### PR TITLE
fix(diff): git-free snapshot diff for projects without git

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -199,6 +199,15 @@ function createBudgetManager({ config, emitter, eventBase }) {
 
 async function initializeSession({ task, config, flags, pgTaskId, pgProject }) {
   const baseRef = await computeBaseRef({ baseBranch: config.base_branch, baseRef: flags.baseRef || null });
+
+  // Take filesystem snapshot for git-free diff fallback
+  if (baseRef === "__snapshot__") {
+    const { takeSnapshot } = await import("./review/snapshot-diff.js");
+    const { setSnapshot } = await import("./review/diff-generator.js");
+    const snapshot = await takeSnapshot(config.projectDir || process.cwd());
+    setSnapshot(snapshot);
+  }
+
   const sessionInit = {
     task,
     config_snapshot: config,

--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -1,7 +1,20 @@
 import { runCommand } from "../utils/process.js";
+import { generateSnapshotDiff } from "./snapshot-diff.js";
 
 /** @type {((command: string, args?: string[], options?: object) => Promise<object>)|null} */
 let _runner = null;
+
+/** @type {Map<string, string>|null} — pre-coder filesystem snapshot for git-free diff */
+let _snapshot = null;
+
+/**
+ * Store a filesystem snapshot for git-free diff fallback.
+ * Call before the coder runs. If git is available, this is unused.
+ * @param {Map<string, string>} snapshot
+ */
+export function setSnapshot(snapshot) {
+  _snapshot = snapshot;
+}
 
 /**
  * Inject an RTK-aware runner so all git operations in this module benefit from token savings.
@@ -18,29 +31,46 @@ function run(command, args, ...rest) {
 
 export async function computeBaseRef({ baseBranch = "main", baseRef = null }) {
   if (baseRef) return baseRef;
-  const mergeBase = await run("git", ["merge-base", "HEAD", `origin/${baseBranch}`]);
-  if (mergeBase.exitCode === 0) return mergeBase.stdout.trim();
 
-  const fallback = await run("git", ["rev-parse", "HEAD~1"]);
-  if (fallback.exitCode === 0) return fallback.stdout.trim();
+  try {
+    const mergeBase = await run("git", ["merge-base", "HEAD", `origin/${baseBranch}`]);
+    if (mergeBase.exitCode === 0) return mergeBase.stdout.trim();
 
-  // Empty repo (zero commits): diff against the empty tree
-  const emptyTree = await run("git", ["hash-object", "-t", "tree", "/dev/null"]);
-  if (emptyTree.exitCode === 0) return emptyTree.stdout.trim();
+    const fallback = await run("git", ["rev-parse", "HEAD~1"]);
+    if (fallback.exitCode === 0) return fallback.stdout.trim();
 
-  throw new Error("Could not compute diff base reference");
+    // Empty repo (zero commits): diff against the empty tree
+    const emptyTree = await run("git", ["hash-object", "-t", "tree", "/dev/null"]);
+    if (emptyTree.exitCode === 0) return emptyTree.stdout.trim();
+  } catch { /* git not available */ }
+
+  // No git or all strategies failed — return sentinel for snapshot-based diff
+  return "__snapshot__";
 }
 
-export async function generateDiff({ baseRef, stageNewFiles = false }) {
-  // Stage untracked files so they appear in the diff (coder creates files but doesn't git add)
-  if (stageNewFiles) {
-    await run("git", ["add", "-A"]);
+export async function generateDiff({ baseRef, stageNewFiles = false, projectDir = null }) {
+  // Try git diff first
+  try {
+    if (stageNewFiles) {
+      await run("git", ["add", "-A"]);
+    }
+    const result = await run("git", ["diff", stageNewFiles ? "--cached" : "", `${baseRef}`].filter(Boolean));
+    if (result.exitCode === 0) {
+      return result.stdout;
+    }
+  } catch { /* git not available or failed */ }
+
+  // Fallback: snapshot-based diff (no git needed)
+  if (_snapshot) {
+    const dir = projectDir || process.cwd();
+    return generateSnapshotDiff(_snapshot, null, dir);
   }
-  const result = await run("git", ["diff", stageNewFiles ? "--cached" : "", `${baseRef}`].filter(Boolean));
-  if (result.exitCode !== 0) {
-    throw new Error(`git diff failed: ${result.stderr || result.stdout}`);
-  }
-  return result.stdout;
+
+  // No git and no snapshot — generate diff of all files as new
+  const dir = projectDir || process.cwd();
+  const { takeSnapshot } = await import("./snapshot-diff.js");
+  const emptySnapshot = new Map();
+  return generateSnapshotDiff(emptySnapshot, null, dir);
 }
 
 export async function getUntrackedFiles() {

--- a/src/review/snapshot-diff.js
+++ b/src/review/snapshot-diff.js
@@ -1,0 +1,122 @@
+/**
+ * Git-free diff generation using filesystem snapshots.
+ *
+ * Takes a snapshot of project files (path → content hash), then compares
+ * a later snapshot to generate a unified diff. Works on any OS, no git needed.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { createHash } from "node:crypto";
+
+const DEFAULT_IGNORE = new Set([
+  "node_modules", ".git", ".kj", ".karajan", "dist", "build",
+  ".next", ".nuxt", ".svelte-kit", "__pycache__", ".venv",
+  "coverage", ".nyc_output", ".reviews"
+]);
+
+const MAX_FILE_SIZE = 512 * 1024; // 512KB — skip large files
+
+/**
+ * Scan a directory recursively and return a Map of relative path → content hash.
+ * @param {string} rootDir
+ * @returns {Promise<Map<string, string>>} path → sha256 hash
+ */
+export async function takeSnapshot(rootDir) {
+  const snapshot = new Map();
+  await scanDir(rootDir, rootDir, snapshot);
+  return snapshot;
+}
+
+async function scanDir(dir, rootDir, snapshot) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch { return; }
+
+  for (const entry of entries) {
+    if (DEFAULT_IGNORE.has(entry.name) || entry.name.startsWith(".")) continue;
+
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await scanDir(fullPath, rootDir, snapshot);
+    } else if (entry.isFile()) {
+      try {
+        const s = await stat(fullPath);
+        if (s.size > MAX_FILE_SIZE) continue;
+        const content = await readFile(fullPath);
+        const hash = createHash("sha256").update(content).digest("hex");
+        snapshot.set(relative(rootDir, fullPath), hash);
+      } catch { /* skip unreadable files */ }
+    }
+  }
+}
+
+/**
+ * Compare two snapshots and generate a unified diff string.
+ * @param {Map<string, string>} before — snapshot before coder
+ * @param {Map<string, string>|null} after — snapshot after coder (null = read from disk)
+ * @param {string} rootDir — project root (for reading file contents)
+ * @returns {Promise<string>} unified diff text
+ */
+export async function generateSnapshotDiff(before, after, rootDir) {
+  if (!after) {
+    after = await takeSnapshot(rootDir);
+  }
+
+  const lines = [];
+
+  // New files (in after but not before)
+  for (const [path, hash] of after) {
+    if (!before.has(path)) {
+      const content = await safeRead(join(rootDir, path));
+      if (content !== null) {
+        lines.push(`diff --snapshot a/${path} b/${path}`);
+        lines.push("new file");
+        lines.push(`--- /dev/null`);
+        lines.push(`+++ b/${path}`);
+        for (const line of content.split("\n")) {
+          lines.push(`+${line}`);
+        }
+        lines.push("");
+      }
+    }
+  }
+
+  // Modified files (in both, different hash)
+  for (const [path, hash] of after) {
+    if (before.has(path) && before.get(path) !== hash) {
+      const content = await safeRead(join(rootDir, path));
+      if (content !== null) {
+        lines.push(`diff --snapshot a/${path} b/${path}`);
+        lines.push("modified file");
+        lines.push(`--- a/${path}`);
+        lines.push(`+++ b/${path}`);
+        // Show full new content (we don't have the old content)
+        for (const line of content.split("\n")) {
+          lines.push(`+${line}`);
+        }
+        lines.push("");
+      }
+    }
+  }
+
+  // Deleted files (in before but not after)
+  for (const [path] of before) {
+    if (!after.has(path)) {
+      lines.push(`diff --snapshot a/${path} b/${path}`);
+      lines.push("deleted file");
+      lines.push(`--- a/${path}`);
+      lines.push(`+++ /dev/null`);
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function safeRead(filePath) {
+  try {
+    return await readFile(filePath, "utf-8");
+  } catch { return null; }
+}

--- a/tests/diff-generator.test.js
+++ b/tests/diff-generator.test.js
@@ -44,12 +44,13 @@ describe("computeBaseRef", () => {
     expect(runCommand).toHaveBeenCalledWith("git", ["hash-object", "-t", "tree", "/dev/null"]);
   });
 
-  it("throws when all strategies fail", async () => {
+  it("returns __snapshot__ sentinel when all git strategies fail", async () => {
     runCommand
       .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "merge-base fail" })
       .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "HEAD~1 fail" })
       .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "hash-object fail" });
-    await expect(computeBaseRef({ baseBranch: "main" })).rejects.toThrow("Could not compute diff base reference");
+    const ref = await computeBaseRef({ baseBranch: "main" });
+    expect(ref).toBe("__snapshot__");
   });
 });
 

--- a/tests/snapshot-diff.test.js
+++ b/tests/snapshot-diff.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { takeSnapshot, generateSnapshotDiff } from "../src/review/snapshot-diff.js";
+
+let testDir;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "kj-snap-"));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe("takeSnapshot", () => {
+  it("captures file hashes", async () => {
+    await writeFile(join(testDir, "hello.js"), "console.log('hello');");
+    const snap = await takeSnapshot(testDir);
+    expect(snap.size).toBe(1);
+    expect(snap.has("hello.js")).toBe(true);
+  });
+
+  it("ignores node_modules", async () => {
+    await mkdir(join(testDir, "node_modules"), { recursive: true });
+    await writeFile(join(testDir, "node_modules", "dep.js"), "module");
+    await writeFile(join(testDir, "app.js"), "app");
+    const snap = await takeSnapshot(testDir);
+    expect(snap.size).toBe(1);
+    expect(snap.has("app.js")).toBe(true);
+  });
+
+  it("scans subdirectories", async () => {
+    await mkdir(join(testDir, "src"), { recursive: true });
+    await writeFile(join(testDir, "src", "index.js"), "export default {};");
+    const snap = await takeSnapshot(testDir);
+    expect(snap.has("src/index.js")).toBe(true);
+  });
+});
+
+describe("generateSnapshotDiff", () => {
+  it("detects new files", async () => {
+    const before = new Map();
+    await writeFile(join(testDir, "new.js"), "const x = 1;");
+    const diff = await generateSnapshotDiff(before, null, testDir);
+    expect(diff).toContain("new file");
+    expect(diff).toContain("+const x = 1;");
+    expect(diff).toContain("b/new.js");
+  });
+
+  it("detects modified files", async () => {
+    await writeFile(join(testDir, "mod.js"), "original");
+    const before = await takeSnapshot(testDir);
+    await writeFile(join(testDir, "mod.js"), "modified");
+    const diff = await generateSnapshotDiff(before, null, testDir);
+    expect(diff).toContain("modified file");
+    expect(diff).toContain("+modified");
+  });
+
+  it("detects deleted files", async () => {
+    await writeFile(join(testDir, "del.js"), "to delete");
+    const before = await takeSnapshot(testDir);
+    await rm(join(testDir, "del.js"));
+    const diff = await generateSnapshotDiff(before, null, testDir);
+    expect(diff).toContain("deleted file");
+    expect(diff).toContain("a/del.js");
+  });
+
+  it("returns empty for no changes", async () => {
+    await writeFile(join(testDir, "same.js"), "unchanged");
+    const before = await takeSnapshot(testDir);
+    const diff = await generateSnapshotDiff(before, null, testDir);
+    expect(diff.trim()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- New `snapshot-diff.js`: pure Node.js filesystem diff using SHA-256 content hashing
- Works on any OS, no git/diff/external tools needed
- When git fails, `computeBaseRef` returns sentinel instead of throwing
- `generateDiff` falls back to snapshot diff automatically
- Orchestrator takes filesystem snapshot before coder runs when no git available
- 7 new tests for snapshot-diff, all diff-generator tests updated

## Test plan
- [x] 7/7 snapshot-diff tests pass
- [x] 9/9 diff-generator tests pass (updated for fallback behavior)

Fixes KJC-BUG-0022