### PR TITLE
fix(process): don't force stdin=ignore when input is provided

### DIFF
--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -76,10 +76,9 @@ async function awaitWithTimeout(subprocess, timeout, getStdout) {
 
 export async function runCommand(command, args = [], options = {}) {
   const { timeout, onOutput, silenceTimeoutMs, partialOutputFlushMs, ...rest } = options;
-  // Always detach stdin: KJ subprocesses never need interactive input.
-  // Without this, a subprocess prompting for input (sonar credentials,
-  // agent approval, npm prompts) hangs forever since there is no TTY.
-  if (!rest.stdin) rest.stdin = "ignore";
+  // Detach stdin unless the caller provides input (e.g. Codex uses input: prompt).
+  // Without this, a subprocess prompting for input hangs forever since there is no TTY.
+  if (!rest.stdin && !rest.input) rest.stdin = "ignore";
   const subprocess = execa(command, args, { reject: false, ...rest });
 
   let stdoutAccum = "";


### PR DESCRIPTION
## Summary
Codex uses execa's `input` option to pipe the prompt via stdin. The global `stdin="ignore"` default in `runCommand` was overriding this, causing Codex to fail with "The stdin option must not include ignore".

Fix: skip `stdin="ignore"` when `input` is present in options.

## Test plan
- [x] 36/36 agents-contract tests pass