### PR TITLE
fix(codex): add --skip-git-repo-check for non-git projects

### DIFF
--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -42,7 +42,7 @@ export class CodexAgent extends BaseAgent {
   }
 
   async _exec(task, model, role) {
-    const args = ["exec"];
+    const args = ["exec", "--skip-git-repo-check"];
     if (model) args.push("--model", model);
     if (role !== "reviewer" && this.isAutoApproveEnabled(role)) args.push("--full-auto");
     args.push("-");


### PR DESCRIPTION
Codex CLI fails with 'Not inside a trusted directory' when running in projects without git. Adds --skip-git-repo-check flag.