### PR TITLE
fix: show tokens in budget updates + TDD SKIP on empty diff

### DIFF
--- a/src/review/tdd-policy.js
+++ b/src/review/tdd-policy.js
@@ -2,7 +2,8 @@ function extractChangedFiles(diff) {
   const files = new Set();
   const lines = String(diff || "").split("\n");
   for (const line of lines) {
-    if (!line.startsWith("diff --git ")) continue;
+    // Support both git diff and snapshot diff formats
+    if (!line.startsWith("diff --git ") && !line.startsWith("diff --snapshot ")) continue;
     const parts = line.split(" ");
     const b = parts[3] || "";
     if (b.startsWith("b/")) files.add(b.slice(2));
@@ -49,7 +50,8 @@ export function evaluateTddPolicy(diff, developmentConfig = {}, untrackedFiles =
   }
 
   if (sourceFiles.length === 0) {
-    return { ok: true, reason: "no_source_changes", sourceFiles, testFiles };
+    const reason = files.length === 0 ? "no_diff_available" : "no_source_changes";
+    return { ok: true, reason, sourceFiles, testFiles };
   }
 
   if (testFiles.length === 0) {

--- a/src/utils/display.js
+++ b/src/utils/display.js
@@ -337,6 +337,10 @@ const EVENT_HANDLERS = {
 
   "tdd:result": (event, icon) => {
     const tdd = event.detail || {};
+    if (tdd.reason === "no_diff_available") {
+      console.log(`  \u251c\u2500 ${icon} TDD policy: ${ANSI.yellow}SKIP${ANSI.reset} ${ANSI.dim}(no diff available)${ANSI.reset}`);
+      return;
+    }
     const label = tdd.ok ? `${ANSI.green}PASS${ANSI.reset}` : `${ANSI.red}FAIL${ANSI.reset}`;
     const files = tdd.sourceFiles === undefined ? "" : ` (${tdd.sourceFiles} src, ${tdd.testFiles} test)`;
     const executor = formatExecutor(event.detail);
@@ -449,9 +453,13 @@ const EVENT_HANDLERS = {
       console.log(`  \u251c\u2500 ${icon} Budget: ${ANSI.dim}N/A (provider does not report usage)${ANSI.reset}`);
       return;
     }
+    const tokenStr = totalTokens > 0 ? `${totalTokens.toLocaleString()} tokens` : "";
+    const costStr = `$${total.toFixed(2)}`;
     const color = budgetColor(max, pct, warn);
-    if (Number.isFinite(max) && max >= 0) {
-      console.log(`  \u251c\u2500 ${icon} Budget: ${color}$${total.toFixed(2)} / $${max.toFixed(2)} (${pct.toFixed(1)}%)${ANSI.reset}`);
+    if (Number.isFinite(max) && max > 0) {
+      console.log(`  \u251c\u2500 ${icon} Budget: ${color}${costStr} / $${max.toFixed(2)} (${pct.toFixed(1)}%)${ANSI.reset}${tokenStr ? `  ${ANSI.dim}${tokenStr}${ANSI.reset}` : ""}`);
+    } else if (total > 0 || totalTokens > 0) {
+      console.log(`  \u251c\u2500 ${icon} Budget: ${color}${costStr}${ANSI.reset}${tokenStr ? `  ${ANSI.dim}${tokenStr}${ANSI.reset}` : ""}`);
     }
   },
 


### PR DESCRIPTION
## Summary
- Budget updates now show tokens: `💸 Budget: $0.55  7,200 tokens`
- Budget shown even without max_budget_usd configured
- TDD shows SKIP (yellow) instead of false PASS when no diff available
- TDD file extraction supports snapshot diff format

## Test plan
- [x] 13/13 tdd-policy tests pass
- [x] 7/7 cli-welcome tests pass