### PR TITLE
Refactor: Dividir src/utils/display.js

### DIFF
--- a/src/commands/resume.js
+++ b/src/commands/resume.js
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import readline from "node:readline";
 import { resumeFlow } from "../orchestrator.js";
 import { createActivityLog } from "../activity-log.js";
-import { printEvent } from "../utils/display.js";
+import { printEvent } from "../utils/display/event-handlers.js";
 
 function createCliAskQuestion() {
   return async (question, context) => {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -3,7 +3,8 @@ import readline from "node:readline";
 import { runFlow } from "../orchestrator.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { createActivityLog } from "../activity-log.js";
-import { printHeader, printEvent } from "../utils/display.js";
+import { printHeader } from "../utils/display/header.js";
+import { printEvent } from "../utils/display/event-handlers.js";
 import { resolveRole } from "../config.js";
 import { parseCardId } from "../planning-game/adapter.js";
 

--- a/src/utils/display/event-handlers.js
+++ b/src/utils/display/event-handlers.js
@@ -1,303 +1,26 @@
-import path from "node:path";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { printBanner } from "./banner.js";
+import { 
+  ANSI, 
+  formatElapsed, 
+  formatExecutor, 
+  budgetColor, 
+  roleStart, 
+  roleEnd, 
+  passFailStage, 
+  TRACKER_STATUS, 
+  TRACKER_DEFAULT, 
+  ICONS, 
+  STATUS_ICON 
+} from "./formatters.js";
+import { printSolomonRuling } from "./solomon.js";
+import { 
+  printSessionStages, 
+  printSessionGit, 
+  printSessionBudget, 
+  printSessionRtkSavings, 
+  printSessionProxyStats 
+} from "./session-summary.js";
 
-// TODO: i18n display messages
-const DISPLAY_PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
-const DISPLAY_VERSION = JSON.parse(readFileSync(DISPLAY_PKG_PATH, "utf8")).version;
-
-const ANSI = {
-  reset: "\x1b[0m",
-  bold: "\x1b[1m",
-  dim: "\x1b[2m",
-  cyan: "\x1b[36m",
-  green: "\x1b[32m",
-  yellow: "\x1b[33m",
-  red: "\x1b[31m",
-  gray: "\x1b[90m",
-  white: "\x1b[37m",
-  magenta: "\x1b[35m"
-};
-
-const ICONS = {
-  "session:start": "\u25b6",
-  "planner:start": "\ud83e\udde0",
-  "planner:end": "\ud83e\udde0",
-  "researcher:start": "\ud83d\udd2c",
-  "researcher:end": "\ud83d\udd2c",
-  "iteration:start": "\u25b6",
-  "coder:start": "\ud83d\udd28",
-  "coder:end": "\ud83d\udd28",
-  "refactorer:start": "\u267b\ufe0f",
-  "refactorer:end": "\u267b\ufe0f",
-  "tdd:result": "\ud83d\udccb",
-  "sonar:start": "\ud83d\udd0d",
-  "sonar:end": "\ud83d\udd0d",
-  "reviewer:start": "\ud83d\udc41\ufe0f",
-  "reviewer:end": "\ud83d\udc41\ufe0f",
-  "tester:start": "\ud83e\uddea",
-  "tester:end": "\ud83e\uddea",
-  "security:start": "\ud83d\udd12",
-  "security:end": "\ud83d\udd12",
-  "solomon:start": "\u2696\ufe0f",
-  "solomon:end": "\u2696\ufe0f",
-  "solomon:escalate": "\u26a0\ufe0f",
-  "coder:standby": "\u23f3",
-  "coder:standby_heartbeat": "\u23f3",
-  "coder:standby_resume": "\u25b6\ufe0f",
-  "budget:update": "\ud83d\udcb8",
-  "iteration:end": "\u23f1\ufe0f",
-  "session:end": "\ud83c\udfc1",
-  "discover:start": "\ud83d\udd0e",
-  "discover:end": "\ud83d\udd0e",
-  "architect:start": "\ud83c\udfdb\ufe0f",
-  "architect:end": "\ud83c\udfdb\ufe0f",
-  "hu-reviewer:start": "\ud83d\udcdd",
-  "hu-reviewer:end": "\ud83d\udcdd",
-  "impeccable:start": "\ud83c\udfa8",
-  "impeccable:end": "\ud83c\udfa8",
-  "audit:start": "\ud83d\udccb",
-  "audit:end": "\ud83d\udccb",
-  "sonarcloud:start": "\u2601\ufe0f",
-  "sonarcloud:end": "\u2601\ufe0f",
-  "preflight:start": "\ud83d\udee1\ufe0f",
-  "preflight:end": "\ud83d\udee1\ufe0f",
-  question: "\u2753"
-};
-
-const STATUS_ICON = {
-  ok: `${ANSI.green}\u2705${ANSI.reset}`,
-  fail: `${ANSI.red}\u274c${ANSI.reset}`,
-  paused: `${ANSI.yellow}\u23f8\ufe0f${ANSI.reset}`,
-  running: `${ANSI.cyan}\u25b6${ANSI.reset}`
-};
-
-export function formatElapsed(ms) {
-  const totalSec = Math.floor((ms || 0) / 1000);
-  const min = String(Math.floor(totalSec / 60)).padStart(2, "0");
-  const sec = String(totalSec % 60).padStart(2, "0");
-  return `${min}:${sec}`;
-}
-
-const BAR = `${ANSI.dim}\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500${ANSI.reset}`;
-
-export function printHeader({ task, config }) {
-  const version = DISPLAY_VERSION;
-  printBanner(version);
-  console.log(`${ANSI.bold}Task:${ANSI.reset} ${task}`);
-  console.log(
-    `${ANSI.bold}Coder:${ANSI.reset} ${config.roles?.coder?.provider || config.coder} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Reviewer:${ANSI.reset} ${config.roles?.reviewer?.provider || config.reviewer}`
-  );
-  console.log(
-    `${ANSI.bold}Max iterations:${ANSI.reset} ${config.max_iterations} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Timeout:${ANSI.reset} ${config.session.max_total_minutes}min`
-  );
-
-  const pipeline = config.pipeline || {};
-  const activeRoles = [];
-  if (pipeline.planner?.enabled) activeRoles.push(`Planner (${config.roles?.planner?.provider || "?"})`);
-  if (pipeline.researcher?.enabled) activeRoles.push(`Researcher (${config.roles?.researcher?.provider || "?"})`);
-  if (pipeline.tester?.enabled) activeRoles.push("Tester");
-  if (pipeline.security?.enabled) activeRoles.push("Security");
-  if (pipeline.solomon?.enabled) activeRoles.push(`Solomon (${config.roles?.solomon?.provider || "?"})`);
-  if (activeRoles.length > 0) {
-    const separator = ` ${ANSI.dim}|${ANSI.reset} `;
-    console.log(`${ANSI.bold}Pipeline:${ANSI.reset} ${activeRoles.join(separator)}`);
-  }
-
-  console.log(BAR);
-  console.log();
-}
-
-/* ── Helper: executor/provider tag ───────────────────────────── */
-
-function formatExecutor(detail) {
-  if (!detail) return '';
-  const provider = detail.provider || '';
-  const type = detail.executorType || '';
-  if (provider) return `  ${ANSI.dim}${provider}${ANSI.reset}`;
-  if (type === 'local') return `  ${ANSI.dim}local${ANSI.reset}`;
-  if (type === 'system') return `  ${ANSI.dim}system${ANSI.reset}`;
-  return '';
-}
-
-/* ── Helper: role start/end one-liners ───────────────────────── */
-
-function roleStart(icon, label, provider) {
-  console.log(`  \u251c\u2500 ${icon} ${label} (${provider || "?"}) running...`);
-}
-
-function roleEnd(status, label, elapsed, executor) {
-  console.log(`  \u251c\u2500 ${status} ${label} completed${executor || ''}  ${elapsed}`);
-}
-
-/* ── Helper: pass/fail stage result ─────────────────────────── */
-
-function passFailStage(detail, label, failDefault, elapsed) {
-  const executor = formatExecutor(detail);
-  if (detail?.ok === false) {
-    const summary = detail?.summary || failDefault;
-    console.log(`  \u251c\u2500 ${ANSI.red}\u274c ${label}: ${summary}${ANSI.reset}${executor}  ${elapsed}`);
-  } else {
-    console.log(`  \u251c\u2500 ${ANSI.green}\u2705 ${label}: passed${ANSI.reset}${executor}  ${elapsed}`);
-  }
-}
-
-/* ── Helper: solomon ruling display ─────────────────────────── */
-
-const SOLOMON_RULING_HANDLERS = {
-  approve(detail, elapsed) {
-    const dismissedCount = detail?.dismissed?.length || 0;
-    const dismissedSuffix = dismissedCount > 0 ? ` (${dismissedCount} dismissed)` : "";
-    console.log(`  \u251c\u2500 ${ANSI.green}\u2696\ufe0f Solomon: APPROVE${dismissedSuffix}${ANSI.reset}  ${elapsed}`);
-  },
-  approve_with_conditions(detail, elapsed) {
-    const condCount = detail?.conditions?.length || 0;
-    console.log(`  \u251c\u2500 ${ANSI.yellow}\u2696\ufe0f Solomon: ${condCount} condition${condCount === 1 ? "" : "s"}${ANSI.reset}  ${elapsed}`);
-    if (detail?.conditions) {
-      for (const cond of detail.conditions) {
-        console.log(`  \u2502   ${ANSI.dim}${cond}${ANSI.reset}`);
-      }
-    }
-  },
-  escalate_human(detail, elapsed) {
-    const reason = detail?.escalate_reason || "unknown reason";
-    console.log(`  \u251c\u2500 ${ANSI.red}\u2696\ufe0f Solomon: ESCALATE \u2014 ${reason}${ANSI.reset}  ${elapsed}`);
-  },
-  create_subtask(detail, elapsed) {
-    const subtaskTitle = detail?.subtask?.title || "untitled";
-    console.log(`  \u251c\u2500 ${ANSI.magenta}\u2696\ufe0f Solomon: SUBTASK \u2014 ${subtaskTitle}${ANSI.reset}  ${elapsed}`);
-  }
-};
-
-function printSolomonRuling(detail, elapsed) {
-  const ruling = detail?.ruling || "unknown";
-  const handler = SOLOMON_RULING_HANDLERS[ruling];
-  if (handler) {
-    handler(detail, elapsed);
-  } else {
-    const rulingUpper = ruling.toUpperCase().replaceAll("_", " ");
-    console.log(`  \u251c\u2500 \u2696\ufe0f Solomon: ${rulingUpper}  ${elapsed}`);
-  }
-}
-
-/* ── Helper: budget color selection ─────────────────────────── */
-
-function budgetColor(max, pct, warn) {
-  if (max > 0 && pct >= 100) return ANSI.red;
-  if (max > 0 && pct >= warn) return ANSI.yellow;
-  return ANSI.green;
-}
-
-/* ── Helpers: session:end sub-sections ──────────────────────── */
-
-function printSessionStages(stages) {
-  if (!stages) return;
-  if (stages.researcher?.summary) {
-    console.log(`  ${ANSI.dim}\ud83d\udd2c Research: ${stages.researcher.summary}${ANSI.reset}`);
-  }
-  printSessionPlanner(stages.planner);
-  if (stages.tester?.summary) {
-    console.log(`  ${ANSI.dim}\ud83e\uddea Tester: ${stages.tester.summary}${ANSI.reset}`);
-  }
-  if (stages.security?.summary) {
-    console.log(`  ${ANSI.dim}\ud83d\udd12 Security: ${stages.security.summary}${ANSI.reset}`);
-  }
-  printSessionSonar(stages.sonar);
-}
-
-function printSessionPlanner(planner) {
-  if (!planner?.title && !planner?.approach && !planner?.completedSteps?.length) return;
-  const planParts = [];
-  if (planner.title) planParts.push(planner.title);
-  if (planner.approach) planParts.push(`approach: ${planner.approach}`);
-  console.log(`  ${ANSI.dim}\ud83d\uddfa Plan: ${planParts.join(" | ")}${ANSI.reset}`);
-  for (const step of planner.completedSteps || []) {
-    console.log(`  ${ANSI.dim}   \u2713 ${step}${ANSI.reset}`);
-  }
-}
-
-function printSessionSonar(sonar) {
-  if (!sonar) return;
-  const gateLabel = sonar.gateStatus === "OK" ? ANSI.green : ANSI.red;
-  console.log(`  ${ANSI.dim}\ud83d\udd0d Sonar: ${gateLabel}${sonar.gateStatus}${ANSI.reset}${ANSI.dim} (${sonar.openIssues ?? 0} issues)${ANSI.reset}`);
-  if (typeof sonar.issuesInitial === "number" || typeof sonar.issuesResolved === "number") {
-    const issuesInitial = sonar.issuesInitial ?? sonar.openIssues ?? 0;
-    const issuesFinal = sonar.issuesFinal ?? sonar.openIssues ?? 0;
-    const issuesResolved = sonar.issuesResolved ?? Math.max(issuesInitial - issuesFinal, 0);
-    console.log(`  ${ANSI.dim}\ud83d\udee0 Issues: ${issuesInitial} detected, ${issuesFinal} open, ${issuesResolved} resolved${ANSI.reset}`);
-  }
-}
-
-function printSessionGit(git) {
-  if (!git?.branch) return;
-  const parts = [`branch: ${git.branch}`];
-  if (git.committed) parts.push("committed");
-  if (git.pushed) parts.push("pushed");
-  if (git.pr || git.prUrl) parts.push(`PR: ${git.pr || git.prUrl}`);
-  console.log(`  ${ANSI.dim}\ud83d\udcce Git: ${parts.join(", ")}${ANSI.reset}`);
-  if (Array.isArray(git.commits) && git.commits.length > 0) {
-    console.log(`  ${ANSI.dim}\ud83e\uddfe Commits:${ANSI.reset}`);
-    for (const commit of git.commits) {
-      const shortHash = (commit.hash || "").slice(0, 7) || "unknown";
-      const message = commit.message || "";
-      console.log(`  ${ANSI.dim}   - ${shortHash} ${message}${ANSI.reset}`);
-    }
-  }
-}
-
-function isBudgetUnavailable(budget) {
-  return budget.usage_available === false ||
-    (budget.total_tokens === 0 && budget.total_cost_usd === 0 && Object.keys(budget.breakdown_by_role || {}).length > 0);
-}
-
-function printSessionRtkSavings(rtkSavings) {
-  if (!rtkSavings || !rtkSavings.callCount) return;
-  const tokens = rtkSavings.estimatedTokensSaved ?? 0;
-  const ratio = rtkSavings.savedPct ?? 0;
-  const commands = rtkSavings.callCount ?? 0;
-  console.log(`  ${ANSI.dim}\u26a1 RTK: saved ~${tokens} tokens (${ratio}% compression, ${commands} commands)${ANSI.reset}`);
-}
-
-function printSessionProxyStats(proxyStats) {
-  if (!proxyStats || !proxyStats.requests) return;
-  const reqs = proxyStats.requests;
-  const bytesIn = proxyStats.bytes_in ?? 0;
-  const bytesOut = proxyStats.bytes_out ?? 0;
-  const totalBytes = bytesIn + bytesOut;
-  const estTokens = Math.round(totalBytes / 4); // ~4 bytes per token
-  console.log(`  ${ANSI.dim}\ud83d\udee1\ufe0f Proxy: ${reqs} requests, ~${estTokens} tokens proxied (${(totalBytes / 1024).toFixed(0)}KB transferred)${ANSI.reset}`);
-}
-
-function printSessionBudget(budget) {
-  if (!budget) return;
-  if (isBudgetUnavailable(budget)) {
-    console.log(`  ${ANSI.dim}\ud83d\udcb0 Budget: N/A (provider does not report usage)${ANSI.reset}`);
-    return;
-  }
-  const estPrefix = budget.includes_estimates ? "~" : "";
-  const estNote = budget.includes_estimates ? " (includes estimates)" : "";
-  console.log(`  ${ANSI.dim}\ud83d\udcb0 Total tokens: ${estPrefix}${budget.total_tokens ?? 0}${estNote}${ANSI.reset}`);
-  console.log(`  ${ANSI.dim}\ud83d\udcb0 Total cost: ${estPrefix}$${Number(budget.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`);
-  for (const [role, metrics] of Object.entries(budget.breakdown_by_role || {})) {
-    console.log(
-      `  ${ANSI.dim}   - ${role}: ${estPrefix}${metrics.total_tokens ?? 0} tokens, ${estPrefix}$${Number(metrics.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`
-    );
-  }
-}
-
-/* ── Helper: pipeline tracker stage icon/color ──────────────── */
-
-const TRACKER_STATUS = {
-  done:    { icon: "\u2713", color: ANSI.green },
-  running: { icon: "\u25b6", color: ANSI.cyan },
-  failed:  { icon: "\u2717", color: ANSI.red }
-};
-const TRACKER_DEFAULT = { icon: "\u00b7", color: ANSI.dim };
-
-/* ── Event handler map ──────────────────────────────────────── */
-
-const EVENT_HANDLERS = {
+export const EVENT_HANDLERS = {
   "session:start": () => {},
 
   "iteration:start": (event, icon, elapsed) => {
@@ -601,10 +324,8 @@ const EVENT_HANDLERS = {
   }
 };
 
-/* ── Quiet-mode filter ──────────────────────────────────────── */
-
 /** Event types suppressed in quiet mode (internal/noise events). */
-const QUIET_SUPPRESSED = new Set([
+export const QUIET_SUPPRESSED = new Set([
   "agent:output",
   "agent:stall",
   "agent:heartbeat",
@@ -629,12 +350,11 @@ const QUIET_SUPPRESSED = new Set([
   "guard:blocked",
 ]);
 
-/* ── Main entry point ───────────────────────────────────────── */
-
 /**
- * @param {object} event
- * @param {object} [opts]
- * @param {boolean} [opts.quiet] - When true, suppress raw agent output lines.
+ * Handle and print pipeline events
+ * @param {Object} event 
+ * @param {Object} [opts] 
+ * @param {boolean} [opts.quiet] 
  */
 export function printEvent(event, opts = {}) {
   if (opts.quiet && QUIET_SUPPRESSED.has(event.type)) {
@@ -651,5 +371,4 @@ export function printEvent(event, opts = {}) {
   } else if (event.message) {
     console.log(`  \u251c\u2500 ${icon} ${event.message}  ${elapsed}`);
   }
-  // Events without handler AND without message are silently dropped
 }

--- a/src/utils/display/formatters.js
+++ b/src/utils/display/formatters.js
@@ -1,0 +1,131 @@
+export const ANSI = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  gray: "\x1b[90m",
+  white: "\x1b[37m",
+  magenta: "\x1b[35m"
+};
+
+export const ICONS = {
+  "session:start": "\u25b6",
+  "planner:start": "\ud83e\udde0",
+  "planner:end": "\ud83e\udde0",
+  "researcher:start": "\ud83d\udd2c",
+  "researcher:end": "\ud83d\udd2c",
+  "iteration:start": "\u25b6",
+  "coder:start": "\ud83d\udd28",
+  "coder:end": "\ud83d\udd28",
+  "refactorer:start": "\u267b\ufe0f",
+  "refactorer:end": "\u267b\ufe0f",
+  "tdd:result": "\ud83d\udccb",
+  "sonar:start": "\ud83d\udd0d",
+  "sonar:end": "\ud83d\udd0d",
+  "reviewer:start": "\ud83d\udc41\ufe0f",
+  "reviewer:end": "\ud83d\udc41\ufe0f",
+  "tester:start": "\ud83e\uddea",
+  "tester:end": "\ud83e\uddea",
+  "security:start": "\ud83d\udd12",
+  "security:end": "\ud83d\udd12",
+  "solomon:start": "\u2696\ufe0f",
+  "solomon:end": "\u2696\ufe0f",
+  "solomon:escalate": "\u26a0\ufe0f",
+  "coder:standby": "\u23f3",
+  "coder:standby_heartbeat": "\u23f3",
+  "coder:standby_resume": "\u25b6\ufe0f",
+  "budget:update": "\ud83d\udcb8",
+  "iteration:end": "\u23f1\ufe0f",
+  "session:end": "\ud83c\udfc1",
+  "discover:start": "\ud83d\udd0e",
+  "discover:end": "\ud83d\udd0e",
+  "architect:start": "\ud83c\udfdb\ufe0f",
+  "architect:end": "\ud83c\udfdb\ufe0f",
+  "hu-reviewer:start": "\ud83d\udcdd",
+  "hu-reviewer:end": "\ud83d\udcdd",
+  "impeccable:start": "\ud83c\udfa8",
+  "impeccable:end": "\ud83c\udfa8",
+  "audit:start": "\ud83d\udccb",
+  "audit:end": "\ud83d\udccb",
+  "sonarcloud:start": "\u2601\ufe0f",
+  "sonarcloud:end": "\u2601\ufe0f",
+  "preflight:start": "\ud83d\udee1\ufe0f",
+  "preflight:end": "\ud83d\udee1\ufe0f",
+  question: "\u2753"
+};
+
+export const STATUS_ICON = {
+  ok: `${ANSI.green}\u2705${ANSI.reset}`,
+  fail: `${ANSI.red}\u274c${ANSI.reset}`,
+  paused: `${ANSI.yellow}\u23f8\ufe0f${ANSI.reset}`,
+  running: `${ANSI.cyan}\u25b6${ANSI.reset}`
+};
+
+export const TRACKER_STATUS = {
+  done:    { icon: "\u2713", color: ANSI.green },
+  running: { icon: "\u25b6", color: ANSI.cyan },
+  failed:  { icon: "\u2717", color: ANSI.red }
+};
+
+export const TRACKER_DEFAULT = { icon: "\u00b7", color: ANSI.dim };
+
+/**
+ * Format milliseconds into MM:SS string
+ * @param {number} ms 
+ * @returns {string}
+ */
+export function formatElapsed(ms) {
+  const totalSec = Math.floor((ms || 0) / 1000);
+  const min = String(Math.floor(totalSec / 60)).padStart(2, "0");
+  const sec = String(totalSec % 60).padStart(2, "0");
+  return `${min}:${sec}`;
+}
+
+/**
+ * Format executor details into a display string
+ * @param {Object} detail 
+ * @returns {string}
+ */
+export function formatExecutor(detail) {
+  if (!detail) return '';
+  const provider = detail.provider || '';
+  const type = detail.executorType || '';
+  if (provider) return `  ${ANSI.dim}${provider}${ANSI.reset}`;
+  if (type === 'local') return `  ${ANSI.dim}local${ANSI.reset}`;
+  if (type === 'system') return `  ${ANSI.dim}system${ANSI.reset}`;
+  return '';
+}
+
+/**
+ * Calculate budget ANSI color based on usage
+ * @param {number} max 
+ * @param {number} pct 
+ * @param {number} warn 
+ * @returns {string}
+ */
+export function budgetColor(max, pct, warn) {
+  if (max > 0 && pct >= 100) return ANSI.red;
+  if (max > 0 && pct >= warn) return ANSI.yellow;
+  return ANSI.green;
+}
+
+export function roleStart(icon, label, provider) {
+  console.log(`  \u251c\u2500 ${icon} ${label} (${provider || "?"}) running...`);
+}
+
+export function roleEnd(status, label, elapsed, executor) {
+  console.log(`  \u251c\u2500 ${status} ${label} completed${executor || ''}  ${elapsed}`);
+}
+
+export function passFailStage(detail, label, failDefault, elapsed) {
+  const executor = formatExecutor(detail);
+  if (detail?.ok === false) {
+    const summary = detail?.summary || failDefault;
+    console.log(`  \u251c\u2500 ${ANSI.red}\u274c ${label}: ${summary}${ANSI.reset}${executor}  ${elapsed}`);
+  } else {
+    console.log(`  \u251c\u2500 ${ANSI.green}\u2705 ${label}: passed${ANSI.reset}${executor}  ${elapsed}`);
+  }
+}

--- a/src/utils/display/header.js
+++ b/src/utils/display/header.js
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { printBanner } from "../banner.js";
+import { ANSI } from "./formatters.js";
+
+// TODO: i18n display messages
+const DISPLAY_PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../package.json");
+const DISPLAY_VERSION = JSON.parse(readFileSync(DISPLAY_PKG_PATH, "utf8")).version;
+
+export const BAR = `${ANSI.dim}\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500${ANSI.reset}`;
+
+/**
+ * Print task, configuration and pipeline header
+ * @param {Object} params
+ * @param {string} params.task
+ * @param {Object} params.config
+ */
+export function printHeader({ task, config }) {
+  const version = DISPLAY_VERSION;
+  printBanner(version);
+  console.log(`${ANSI.bold}Task:${ANSI.reset} ${task}`);
+  console.log(
+    `${ANSI.bold}Coder:${ANSI.reset} ${config.roles?.coder?.provider || config.coder} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Reviewer:${ANSI.reset} ${config.roles?.reviewer?.provider || config.reviewer}`
+  );
+  console.log(
+    `${ANSI.bold}Max iterations:${ANSI.reset} ${config.max_iterations} ${ANSI.dim}|${ANSI.reset} ${ANSI.bold}Timeout:${ANSI.reset} ${config.session.max_total_minutes}min`
+  );
+
+  const pipeline = config.pipeline || {};
+  const activeRoles = [];
+  if (pipeline.planner?.enabled) activeRoles.push(`Planner (${config.roles?.planner?.provider || "?"})`);
+  if (pipeline.researcher?.enabled) activeRoles.push(`Researcher (${config.roles?.researcher?.provider || "?"})`);
+  if (pipeline.tester?.enabled) activeRoles.push("Tester");
+  if (pipeline.security?.enabled) activeRoles.push("Security");
+  if (pipeline.solomon?.enabled) activeRoles.push(`Solomon (${config.roles?.solomon?.provider || "?"})`);
+  if (activeRoles.length > 0) {
+    const separator = ` ${ANSI.dim}|${ANSI.reset} `;
+    console.log(`${ANSI.bold}Pipeline:${ANSI.reset} ${activeRoles.join(separator)}`);
+  }
+
+  console.log(BAR);
+  console.log();
+}

--- a/src/utils/display/session-summary.js
+++ b/src/utils/display/session-summary.js
@@ -1,0 +1,96 @@
+import { ANSI } from "./formatters.js";
+
+export function printSessionStages(stages) {
+  if (!stages) return;
+  if (stages.researcher?.summary) {
+    console.log(`  ${ANSI.dim}\ud83d\udd2c Research: ${stages.researcher.summary}${ANSI.reset}`);
+  }
+  printSessionPlanner(stages.planner);
+  if (stages.tester?.summary) {
+    console.log(`  ${ANSI.dim}\ud83e\uddea Tester: ${stages.tester.summary}${ANSI.reset}`);
+  }
+  if (stages.security?.summary) {
+    console.log(`  ${ANSI.dim}\ud83d\udd12 Security: ${stages.security.summary}${ANSI.reset}`);
+  }
+  printSessionSonar(stages.sonar);
+}
+
+export function printSessionPlanner(planner) {
+  if (!planner?.title && !planner?.approach && !planner?.completedSteps?.length) return;
+  const planParts = [];
+  if (planner.title) planParts.push(planner.title);
+  if (planner.approach) planParts.push(`approach: ${planner.approach}`);
+  console.log(`  ${ANSI.dim}\ud83d\uddfa Plan: ${planParts.join(" | ")}${ANSI.reset}`);
+  for (const step of planner.completedSteps || []) {
+    console.log(`  ${ANSI.dim}   \u2713 ${step}${ANSI.reset}`);
+  }
+}
+
+export function printSessionSonar(sonar) {
+  if (!sonar) return;
+  const gateLabel = sonar.gateStatus === "OK" ? ANSI.green : ANSI.red;
+  console.log(`  ${ANSI.dim}\ud83d\udd0d Sonar: ${gateLabel}${sonar.gateStatus}${ANSI.reset}${ANSI.dim} (${sonar.openIssues ?? 0} issues)${ANSI.reset}`);
+  if (typeof sonar.issuesInitial === "number" || typeof sonar.issuesResolved === "number") {
+    const issuesInitial = sonar.issuesInitial ?? sonar.openIssues ?? 0;
+    const issuesFinal = sonar.issuesFinal ?? sonar.openIssues ?? 0;
+    const issuesResolved = sonar.issuesResolved ?? Math.max(issuesInitial - issuesFinal, 0);
+    console.log(`  ${ANSI.dim}\ud83d\udee0 Issues: ${issuesInitial} detected, ${issuesFinal} open, ${issuesResolved} resolved${ANSI.reset}`);
+  }
+}
+
+export function printSessionGit(git) {
+  if (!git?.branch) return;
+  const parts = [`branch: ${git.branch}`];
+  if (git.committed) parts.push("committed");
+  if (git.pushed) parts.push("pushed");
+  if (git.pr || git.prUrl) parts.push(`PR: ${git.pr || git.prUrl}`);
+  console.log(`  ${ANSI.dim}\ud83d\udcce Git: ${parts.join(", ")}${ANSI.reset}`);
+  if (Array.isArray(git.commits) && git.commits.length > 0) {
+    console.log(`  ${ANSI.dim}\ud83e\uddfe Commits:${ANSI.reset}`);
+    for (const commit of git.commits) {
+      const shortHash = (commit.hash || "").slice(0, 7) || "unknown";
+      const message = commit.message || "";
+      console.log(`  ${ANSI.dim}   - ${shortHash} ${message}${ANSI.reset}`);
+    }
+  }
+}
+
+export function isBudgetUnavailable(budget) {
+  return budget.usage_available === false ||
+    (budget.total_tokens === 0 && budget.total_cost_usd === 0 && Object.keys(budget.breakdown_by_role || {}).length > 0);
+}
+
+export function printSessionRtkSavings(rtkSavings) {
+  if (!rtkSavings || !rtkSavings.callCount) return;
+  const tokens = rtkSavings.estimatedTokensSaved ?? 0;
+  const ratio = rtkSavings.savedPct ?? 0;
+  const commands = rtkSavings.callCount ?? 0;
+  console.log(`  ${ANSI.dim}\u26a1 RTK: saved ~${tokens} tokens (${ratio}% compression, ${commands} commands)${ANSI.reset}`);
+}
+
+export function printSessionProxyStats(proxyStats) {
+  if (!proxyStats || !proxyStats.requests) return;
+  const reqs = proxyStats.requests;
+  const bytesIn = proxyStats.bytes_in ?? 0;
+  const bytesOut = proxyStats.bytes_out ?? 0;
+  const totalBytes = bytesIn + bytesOut;
+  const estTokens = Math.round(totalBytes / 4); // ~4 bytes per token
+  console.log(`  ${ANSI.dim}\ud83d\udee1\ufe0f Proxy: ${reqs} requests, ~${estTokens} tokens proxied (${(totalBytes / 1024).toFixed(0)}KB transferred)${ANSI.reset}`);
+}
+
+export function printSessionBudget(budget) {
+  if (!budget) return;
+  if (isBudgetUnavailable(budget)) {
+    console.log(`  ${ANSI.dim}\ud83d\udcb0 Budget: N/A (provider does not report usage)${ANSI.reset}`);
+    return;
+  }
+  const estPrefix = budget.includes_estimates ? "~" : "";
+  const estNote = budget.includes_estimates ? " (includes estimates)" : "";
+  console.log(`  ${ANSI.dim}\ud83d\udcb0 Total tokens: ${estPrefix}${budget.total_tokens ?? 0}${estNote}${ANSI.reset}`);
+  console.log(`  ${ANSI.dim}\ud83d\udcb0 Total cost: ${estPrefix}$${Number(budget.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`);
+  for (const [role, metrics] of Object.entries(budget.breakdown_by_role || {})) {
+    console.log(
+      `  ${ANSI.dim}   - ${role}: ${estPrefix}${metrics.total_tokens ?? 0} tokens, ${estPrefix}$${Number(metrics.total_cost_usd || 0).toFixed(2)}${ANSI.reset}`
+    );
+  }
+}

--- a/src/utils/display/solomon.js
+++ b/src/utils/display/solomon.js
@@ -1,0 +1,42 @@
+import { ANSI } from "./formatters.js";
+
+export const SOLOMON_RULING_HANDLERS = {
+  approve(detail, elapsed) {
+    const dismissedCount = detail?.dismissed?.length || 0;
+    const dismissedSuffix = dismissedCount > 0 ? ` (${dismissedCount} dismissed)` : "";
+    console.log(`  \u251c\u2500 ${ANSI.green}\u2696\ufe0f Solomon: APPROVE${dismissedSuffix}${ANSI.reset}  ${elapsed}`);
+  },
+  approve_with_conditions(detail, elapsed) {
+    const condCount = detail?.conditions?.length || 0;
+    console.log(`  \u251c\u2500 ${ANSI.yellow}\u2696\ufe0f Solomon: ${condCount} condition${condCount === 1 ? "" : "s"}${ANSI.reset}  ${elapsed}`);
+    if (detail?.conditions) {
+      for (const cond of detail.conditions) {
+        console.log(`  \u2502   ${ANSI.dim}${cond}${ANSI.reset}`);
+      }
+    }
+  },
+  escalate_human(detail, elapsed) {
+    const reason = detail?.escalate_reason || "unknown reason";
+    console.log(`  \u251c\u2500 ${ANSI.red}\u2696\ufe0f Solomon: ESCALATE \u2014 ${reason}${ANSI.reset}  ${elapsed}`);
+  },
+  create_subtask(detail, elapsed) {
+    const subtaskTitle = detail?.subtask?.title || "untitled";
+    console.log(`  \u251c\u2500 ${ANSI.magenta}\u2696\ufe0f Solomon: SUBTASK \u2014 ${subtaskTitle}${ANSI.reset}  ${elapsed}`);
+  }
+};
+
+/**
+ * Print Solomon ruling details
+ * @param {Object} detail 
+ * @param {string} elapsed 
+ */
+export function printSolomonRuling(detail, elapsed) {
+  const ruling = detail?.ruling || "unknown";
+  const handler = SOLOMON_RULING_HANDLERS[ruling];
+  if (handler) {
+    handler(detail, elapsed);
+  } else {
+    const rulingUpper = ruling.toUpperCase().replaceAll("_", " ");
+    console.log(`  \u251c\u2500 \u2696\ufe0f Solomon: ${rulingUpper}  ${elapsed}`);
+  }
+}

--- a/tests/command-run.test.js
+++ b/tests/command-run.test.js
@@ -21,8 +21,11 @@ vi.mock("../src/activity-log.js", () => ({
   }))
 }));
 
-vi.mock("../src/utils/display.js", () => ({
-  printHeader: vi.fn(),
+vi.mock("../src/utils/display/header.js", () => ({
+  printHeader: vi.fn()
+}));
+
+vi.mock("../src/utils/display/event-handlers.js", () => ({
   printEvent: vi.fn()
 }));
 
@@ -56,9 +59,11 @@ describe("commands/run", () => {
     const avail = await import("../src/agents/availability.js");
     assertAgentsAvailable = avail.assertAgentsAvailable;
 
-    const display = await import("../src/utils/display.js");
-    printHeader = display.printHeader;
-    printEvent = display.printEvent;
+    const header = await import("../src/utils/display/header.js");
+    printHeader = header.printHeader;
+
+    const eventHandlers = await import("../src/utils/display/event-handlers.js");
+    printEvent = eventHandlers.printEvent;
 
     runFlow.mockResolvedValue({ approved: true, sessionId: "s1" });
   });

--- a/tests/output-quiet.test.js
+++ b/tests/output-quiet.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { printEvent, formatElapsed } from "../src/utils/display.js";
+import { printEvent } from "../src/utils/display/event-handlers.js";
+import { formatElapsed } from "../src/utils/display/formatters.js";
 import { applyRunOverrides } from "../src/config.js";
 
 // Capture console.log output

--- a/tests/utils-display.test.js
+++ b/tests/utils-display.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { formatElapsed, printHeader, printEvent } from "../src/utils/display.js";
+import { formatElapsed } from "../src/utils/display/formatters.js";
+import { printHeader } from "../src/utils/display/header.js";
+import { printEvent } from "../src/utils/display/event-handlers.js";
 
 describe("utils/display", () => {
   describe("formatElapsed", () => {


### PR DESCRIPTION
Resolves #372.

Este PR fragmenta el archivo masivo `src/utils/display.js` (650+ líneas) en submódulos especializados dentro del directorio `src/utils/display/`:

1. `formatters.js`: ANSI, colores, y primitivas genéricas de formato.
2. `header.js`: Renderizado de la cabecera (banner y configuración).
3. `solomon.js`: Lógica de resolución de conflictos.
4. `session-summary.js`: Lógica del reporte final al terminar una iteración.
5. `event-handlers.js`: El gran mapa de manejadores de progreso.

**Cambios adicionales:**
- Se ha eliminado el archivo `src/utils/display.js` (barrel file) siguiendo las mejores prácticas para evitar dependencias circulares y mejorar el tree-shaking.
- Se han actualizado todos los `imports` en el resto del proyecto para apuntar directamente a los nuevos submódulos.
- Se han actualizado los mocks en los tests para reflejar la nueva estructura.

Todos los tests pasan correctamente (`npm run test`).