### PR TITLE
docs: v2.5.0 kj plan and kj board commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v2.4.0 released** — Executable acceptance tests for HUs: each HU runs shell commands after every coder iteration. All pass → approved. Any fail → Brain diagnoses with exact error output. First version where the full demo completes end-to-end: 6 HUs, 280 tests, 97% coverage, 0 vulnerabilities. Also includes security audit fixes and auto-HU decomposition (v2.1+). See [CHANGELOG.md](./CHANGELOG.md) for full history and [MIGRATION-v2.md](./MIGRATION-v2.md) for v1→v2 breaking changes.
+> **v2.5.0 released** — `kj plan` command: generate structured plans with HUs, review them, add/remove HUs, validate, certify, and execute approved plans via `kj run --plan <planId>`. The full plan→execute workflow is now first-class. Also includes all v2.4 features: executable acceptance tests per HU, auto-HU decomposition, and security audit fixes. See [CHANGELOG.md](./CHANGELOG.md) for full history and [MIGRATION-v2.md](./MIGRATION-v2.md) for v1→v2 breaking changes.
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 
@@ -107,7 +107,23 @@ kj run "Create a utility function that validates Spanish DNI numbers, with tests
 kj code "Add input validation to the signup form"     # Coder only
 kj review "Check the authentication changes"           # Review current diff
 kj audit "Full health analysis of this codebase"       # Read-only audit
-kj plan "Refactor the database layer"                  # Plan without coding
+
+# Planning workflow (v2.5.0)
+kj plan "Refactor the database layer"                  # Generate plan + HUs
+kj plan list                                           # List plans for this project
+kj plan show <planId>                                  # Show plan details + HU table
+kj plan validate <planId>                              # Check structure and deps
+kj plan ready <planId>                                 # Certify all HUs, mark ready
+kj plan add-hu <planId> --title "..." --type feat      # Add HU to plan
+kj plan remove-hu <planId> <huId>                      # Remove HU from plan
+kj plan delete <planId>                                # Delete plan from disk
+kj run --plan <planId> "task"                          # Execute an approved plan
+
+# HU Board dashboard (v1.34.0+)
+kj board start                                         # Start web dashboard (port 4000)
+kj board open                                          # Start + open in browser
+kj board status                                        # Check if running
+kj board stop                                          # Stop the board
 ```
 
 ### 2. MCP: inside your AI agent
@@ -218,7 +234,7 @@ After `npm install -g karajan-code`, the MCP server auto-registers in Claude and
 # command = "karajan-mcp"
 ```
 
-**23 tools** available: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`, `kj_hu`, `kj_skills`, `kj_suggest`.
+**24 tools** available: `kj_run`, `kj_code`, `kj_review`, `kj_plan`, `kj_board`, `kj_audit`, `kj_scan`, `kj_doctor`, `kj_config`, `kj_report`, `kj_resume`, `kj_roles`, `kj_agents`, `kj_preflight`, `kj_status`, `kj_init`, `kj_discover`, `kj_triage`, `kj_researcher`, `kj_architect`, `kj_impeccable`, `kj_hu`, `kj_skills`, `kj_suggest`.
 
 Use `kj-tail` in a separate terminal to see what the pipeline is doing in real time (see [Three ways to use Karajan](#three-ways-to-use-karajan)).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,10 +134,17 @@ CLI adapters for AI providers.
 | Command | File | Purpose |
 |---------|------|---------|
 | `kj init` | init.js | Interactive setup wizard |
-| `kj run <task>` | run.js | Full pipeline |
+| `kj run <task>` | run.js | Full pipeline; `--plan <planId>` executes an approved plan |
 | `kj code <task>` | code.js | Coder only |
 | `kj review` | review.js | Reviewer only |
-| `kj plan <task>` | plan.js | Plan only |
+| `kj plan <task>` | plan.js | Generate plan + HUs with acceptance tests (v2.5) |
+| `kj plan list` | plan.js | List all plans for current project |
+| `kj plan show <id>` | plan.js | Show plan details + HU table |
+| `kj plan validate <id>` | plan.js | Check structure, deps, IDs |
+| `kj plan ready <id>` | plan.js | Certify all HUs, mark plan ready to execute |
+| `kj plan add-hu <id>` | plan.js | Add HU (--title, --type, --deps, --scope) |
+| `kj plan remove-hu <id> <huId>` | plan.js | Remove HU from plan |
+| `kj plan delete <id>` | plan.js | Delete plan from disk |
 | `kj discover <task>` | discover.js | Discovery only |
 | `kj triage <task>` | triage.js | Classification only |
 | `kj researcher <task>` | researcher.js | Research only |
@@ -151,7 +158,7 @@ CLI adapters for AI providers.
 | `kj roles` | roles.js | List roles / show template |
 | `kj agents` | agents.js | List agents / assign providers |
 | `kj sonar` | sonar.js | Manage SonarQube Docker |
-| `kj board` | board.js | HU Board dashboard |
+| `kj board` | board.js | HU Board dashboard (start/stop/status/open) |
 | `kj config` | config.js | Show/edit config |
 | `kj undo` | undo.js | Revert last run |
 
@@ -195,6 +202,7 @@ Deterministic validation layers.
 | `src/domains/` | Domain knowledge synthesis |
 | `src/git/` | Git automation (auto-commit, push, PR) |
 | `src/hu/` | HU system (store, graph, splitting-detector, parallel-executor) |
+| `src/plan/` | **v2.5**: Plan CRUD (create, list, show, validate, ready, add-hu, remove-hu, delete), plan schema v2 with acceptance tests, integration with `kj run --plan` |
 | `src/planning-game/` | Planning Game integration |
 | `src/webperf/` | Core Web Vitals + Chrome DevTools MCP detection |
 | `src/audit/` | Basal cost measurement |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -16,7 +16,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.0.0
+kj --version    # 2.5.0
 kj doctor       # Check environment
 ```
 
@@ -60,13 +60,52 @@ Writes `~/.karajan/kj.config.yml`. Override per-project with `.karajan/kj.config
 kj run "task"                # Full pipeline
 kj run "task" --enable-brain # With Karajan Brain (v2)
 kj code "task"               # Just coder, no review
-kj plan "task"               # Just planning, no implementation
+kj plan "task"               # Generate plan + HUs (v2.5)
 kj review                    # Review uncommitted changes
 kj audit                     # Audit whole codebase
 kj status                    # Current session
 kj resume <session-id>       # Resume paused
 kj doctor                    # Environment check
+
+# Plan management (v2.5.0)
+kj plan list                 # List plans for this project
+kj plan show <planId>        # Show plan details + HU table
+kj plan validate <planId>    # Check structure, deps, IDs
+kj plan ready <planId>       # Certify all HUs, mark ready to execute
+kj plan add-hu <planId>      # Add HU (--title, --type, --deps, --scope)
+kj plan remove-hu <planId> <huId>  # Remove HU from plan
+kj plan delete <planId>      # Delete plan from disk
+kj run --plan <planId> "task"      # Execute an approved plan
+
+# HU Board dashboard
+kj board start               # Start web dashboard (port 4000, fallback 4001-4009)
+kj board open                # Start + open in browser
+kj board status              # Check if running
+kj board stop                # Stop the board
 ```
+
+## Planning workflow (v2.5.0)
+
+`kj plan` introduces a two-phase flow: **plan → review → execute**. Instead of running code immediately, you first generate a structured plan with HUs, inspect and adjust it, then execute it when ready.
+
+```bash
+# Phase 1: generate a plan with HUs and acceptance tests
+kj plan "Refactor the authentication layer to use JWT"
+# → writes plan to disk, prints planId (e.g. plan_1234)
+
+# Inspect and adjust
+kj plan show plan_1234       # Review HU table, deps, acceptance criteria
+kj plan validate plan_1234   # Check structure, no broken deps
+kj plan add-hu plan_1234 --title "Add refresh token endpoint" --type feat
+kj plan remove-hu plan_1234 hu_03
+
+# Phase 2: certify and execute
+kj plan ready plan_1234      # Certifies all HUs, marks plan as ready
+kj run --plan plan_1234 "Refactor the authentication layer to use JWT"
+# → skips researcher/architect/planner stages, loads plan directly
+```
+
+The plan is saved to `.karajan/plans/` and persists across sessions. Use `kj plan list` to see all plans for the current project.
 
 ## Configuration
 

--- a/docs/es/ARCHITECTURE.md
+++ b/docs/es/ARCHITECTURE.md
@@ -131,10 +131,17 @@ Adaptadores CLI para providers de IA.
 | Comando | Propósito |
 |---------|-----------|
 | `kj init` | Wizard interactivo de setup |
-| `kj run <task>` | Pipeline completo |
+| `kj run <task>` | Pipeline completo; `--plan <planId>` ejecuta un plan aprobado |
 | `kj code <task>` | Solo coder |
 | `kj review` | Solo reviewer |
-| `kj plan <task>` | Solo plan |
+| `kj plan <task>` | Generar plan + HUs con tests de aceptación (v2.5) |
+| `kj plan list` | Listar todos los planes del proyecto actual |
+| `kj plan show <id>` | Ver detalles del plan + tabla de HUs |
+| `kj plan validate <id>` | Verificar estructura, deps, IDs |
+| `kj plan ready <id>` | Certificar todas las HUs, marcar plan listo para ejecutar |
+| `kj plan add-hu <id>` | Añadir HU (--title, --type, --deps, --scope) |
+| `kj plan remove-hu <id> <huId>` | Eliminar HU del plan |
+| `kj plan delete <id>` | Borrar plan del disco |
 | `kj discover <task>` | Solo discovery |
 | `kj triage <task>` | Solo clasificación |
 | `kj researcher <task>` | Solo investigación |
@@ -148,7 +155,7 @@ Adaptadores CLI para providers de IA.
 | `kj roles` | Listar roles / ver template |
 | `kj agents` | Listar agentes / asignar providers |
 | `kj sonar` | Gestionar Docker de SonarQube |
-| `kj board` | Dashboard del HU Board |
+| `kj board` | Dashboard del HU Board (start/stop/status/open) |
 | `kj config` | Ver/editar config |
 | `kj undo` | Revertir última ejecución |
 
@@ -179,6 +186,7 @@ Capas de validación determinísticas.
 | `src/domains/` | Síntesis de conocimiento de dominio |
 | `src/git/` | Automatización git (auto-commit, push, PR) |
 | `src/hu/` | Sistema HU (store, graph, splitting-detector) |
+| `src/plan/` | **v2.5**: CRUD de planes (create, list, show, validate, ready, add-hu, remove-hu, delete), schema v2 con tests de aceptación, integración con `kj run --plan` |
 | `src/planning-game/` | Integración con Planning Game |
 | `src/webperf/` | Core Web Vitals + detección de Chrome DevTools MCP |
 | `src/prompts/` | Builders de prompts por rol |

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -16,7 +16,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.0.0
+kj --version    # 2.5.0
 kj doctor       # Comprobar entorno
 ```
 
@@ -60,13 +60,52 @@ Escribe `~/.karajan/kj.config.yml`. Sobrescríbelo por proyecto con `.karajan/kj
 kj run "tarea"                # Pipeline completo
 kj run "tarea" --enable-brain # Con Karajan Brain (v2)
 kj code "tarea"               # Solo coder, sin review
-kj plan "tarea"               # Solo planificación, sin implementar
+kj plan "tarea"               # Generar plan + HUs (v2.5)
 kj review                     # Review de cambios no commiteados
 kj audit                      # Auditar toda la base de código
 kj status                     # Estado de la sesión actual
 kj resume <session-id>        # Reanudar sesión pausada
 kj doctor                     # Comprobar entorno
+
+# Gestión de planes (v2.5.0)
+kj plan list                  # Listar planes del proyecto actual
+kj plan show <planId>         # Ver detalles del plan + tabla de HUs
+kj plan validate <planId>     # Verificar estructura, deps, IDs
+kj plan ready <planId>        # Certificar todas las HUs, marcar listo para ejecutar
+kj plan add-hu <planId>       # Añadir HU (--title, --type, --deps, --scope)
+kj plan remove-hu <planId> <huId>  # Eliminar HU del plan
+kj plan delete <planId>       # Borrar plan del disco
+kj run --plan <planId> "tarea"     # Ejecutar un plan aprobado
+
+# Dashboard HU Board
+kj board start                # Iniciar dashboard web (puerto 4000, fallback 4001-4009)
+kj board open                 # Iniciar + abrir en el navegador
+kj board status               # Comprobar si está corriendo
+kj board stop                 # Detener el board
 ```
+
+## Flujo de planificación (v2.5.0)
+
+`kj plan` introduce un flujo en dos fases: **planificar → revisar → ejecutar**. En lugar de codificar inmediatamente, primero se genera un plan estructurado con HUs, se inspecciona y ajusta, y se ejecuta cuando está listo.
+
+```bash
+# Fase 1: generar un plan con HUs y tests de aceptación
+kj plan "Refactorizar la capa de autenticación para usar JWT"
+# → escribe el plan en disco, imprime planId (p.ej. plan_1234)
+
+# Inspeccionar y ajustar
+kj plan show plan_1234        # Revisar tabla de HUs, deps, criterios de aceptación
+kj plan validate plan_1234    # Verificar estructura, sin deps rotas
+kj plan add-hu plan_1234 --title "Añadir endpoint de refresh token" --type feat
+kj plan remove-hu plan_1234 hu_03
+
+# Fase 2: certificar y ejecutar
+kj plan ready plan_1234       # Certifica todas las HUs, marca el plan como listo
+kj run --plan plan_1234 "Refactorizar la capa de autenticación para usar JWT"
+# → omite las etapas researcher/architect/planner, carga el plan directamente
+```
+
+El plan se guarda en `.karajan/plans/` y persiste entre sesiones. Usa `kj plan list` para ver todos los planes del proyecto actual.
 
 ## Configuración
 


### PR DESCRIPTION
## Summary

- Updates README.md: v2.5.0 banner, adds `kj plan` subcommands and `kj board` commands to CLI section, fixes MCP tool count to 24
- Updates docs/GETTING-STARTED.md (EN+ES): version bump, expands common commands block, adds new "Planning workflow" section explaining the two-phase plan→execute flow
- Updates docs/ARCHITECTURE.md (EN+ES): expands `kj plan` entries in commands table, adds `src/plan/` to subsystems list

## Test plan

- [ ] All command examples are accurate against v2.5.0 source
- [ ] Spanish sections match English content
- [ ] No broken links