### PR TITLE
feat(doctor): preflight auto-remediator + kj doctor (KJC-TSK-0319)

### DIFF
--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -1,45 +1,26 @@
 import express from 'express';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createServer } from 'node:net';
 import { initDb, closeDb } from './db.js';
 import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
 import { authMiddleware } from './auth.js';
+import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = join(__dirname, '..', 'public');
 
 /**
- * Checks if a port is available.
- * @param {number} port
- * @returns {Promise<boolean>}
- */
-function isPortAvailable(port) {
-  return new Promise((resolve) => {
-    const server = createServer();
-    server.once('error', () => resolve(false));
-    server.once('listening', () => {
-      server.close();
-      resolve(true);
-    });
-    server.listen(port);
-  });
-}
-
-/**
- * Finds an available port starting from the given port.
+ * Finds an available port starting from the given port, logging each busy
+ * hop. Delegates to the shared util in src/utils/port-check.js.
  * @param {number} startPort
  * @param {number} maxAttempts
  * @returns {Promise<number>}
  */
-async function findAvailablePort(startPort, maxAttempts = 11) {
-  for (let i = 0; i < maxAttempts; i++) {
-    const port = startPort + i;
-    if (await isPortAvailable(port)) return port;
+function findAvailablePort(startPort, maxAttempts = 11) {
+  return findAvailablePortBase(startPort, maxAttempts, (port) => {
     console.log(`[server] Port ${port} is busy, trying ${port + 1}...`);
-  }
-  throw new Error(`No available port found between ${startPort} and ${startPort + maxAttempts - 1}`);
+  });
 }
 
 /**

--- a/src/checks/binaries.js
+++ b/src/checks/binaries.js
@@ -1,0 +1,123 @@
+/**
+ * Binary / CLI availability checks.
+ *
+ * Covers:
+ *   - Agent CLIs (claude, codex, gemini, aider, opencode)
+ *   - Core binaries (node, npm, git)
+ *   - Docker
+ *   - Serena MCP (optional)
+ *
+ * All binary checks use `strategy: "manual"` because auto-installing binaries
+ * is invasive and platform-specific. Exception: Serena is `"prompt"` (we know
+ * the install command and can offer to run it).
+ */
+
+import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
+import { runCommand } from "../utils/process.js";
+import { withDocLink } from "../utils/doc-links.js";
+import { STRATEGY } from "./types.js";
+
+/**
+ * Check the presence of a named agent CLI (claude/codex/gemini/aider).
+ */
+function createAgentCheck(agent) {
+  return {
+    name: `agent:${agent.name}`,
+    label: `Agent: ${agent.name}`,
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const result = await checkBinary(agent.name);
+      return {
+        ok: result.ok,
+        severity: "warn", // missing one agent CLI shouldn't block — user may not use it
+        detail: result.ok ? `${result.version} (${result.path})` : "Not found",
+        fix: result.ok ? undefined : withDocLink(`Install: ${agent.install}`, "agent_not_found"),
+      };
+    },
+  };
+}
+
+/**
+ * Check the presence of a core binary (node, npm, git).
+ */
+function createCoreBinaryCheck(bin) {
+  return {
+    name: bin,
+    label: bin,
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const result = await checkBinary(bin);
+      return {
+        ok: result.ok,
+        severity: "fail",
+        detail: result.ok ? result.version : "Not found",
+        fix: result.ok ? undefined : `Install ${bin} from its official website.`,
+      };
+    },
+  };
+}
+
+/**
+ * Docker check. Manual strategy (platform-dependent install).
+ */
+export function createDockerCheck() {
+  return {
+    name: "docker",
+    label: "Docker",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const docker = await checkBinary("docker", "--version");
+      return {
+        ok: docker.ok,
+        severity: "warn", // only required if Sonar enabled; soft-fail here
+        detail: docker.ok ? docker.version : "Not found",
+        fix: docker.ok ? undefined : withDocLink("Install Docker: https://docs.docker.com/get-docker/", "sonar_docker"),
+      };
+    },
+  };
+}
+
+/**
+ * Serena MCP (optional). Prompt strategy: we know how to install it.
+ */
+export function createSerenaCheck() {
+  return {
+    name: "serena",
+    label: "Serena MCP",
+    strategy: STRATEGY.MANUAL,
+    applies: (config) => config.serena?.enabled === true,
+    describe: "Install Serena via: uvx --from git+https://github.com/oraios/serena serena",
+    async detect() {
+      let ok = false;
+      try {
+        const res = await runCommand("serena", ["--version"]);
+        ok = res.exitCode === 0;
+      } catch {
+        ok = false;
+      }
+      return {
+        ok,
+        severity: "warn",
+        detail: ok ? "Available" : "Not found (prompts will still include Serena instructions)",
+        fix: ok ? undefined : "Install Serena: uvx --from git+https://github.com/oraios/serena serena --help",
+      };
+    },
+  };
+}
+
+/**
+ * Aggregate: all binary-related checks for the current config.
+ * @returns {import("./types.js").Check[]}
+ */
+export function getBinaryChecks() {
+  const checks = [];
+  for (const agent of KNOWN_AGENTS) {
+    checks.push(createAgentCheck(agent));
+  }
+  for (const bin of ["node", "npm", "git"]) {
+    checks.push(createCoreBinaryCheck(bin));
+  }
+  checks.push(createDockerCheck());
+  checks.push(createSerenaCheck());
+  return checks;
+}

--- a/src/checks/ci.js
+++ b/src/checks/ci.js
@@ -1,0 +1,105 @@
+/**
+ * CI infrastructure checks: required workflows, gh CLI, and GitHub secrets.
+ * Only applies when `config.ci.enabled === true`.
+ */
+
+import path from "node:path";
+import { exists } from "../utils/fs.js";
+import { runCommand } from "../utils/process.js";
+import { checkBinary } from "../utils/agent-detect.js";
+import { STRATEGY } from "./types.js";
+
+const REQUIRED_WORKFLOWS = ["kj-ci-gateway.yml", "automerge.yml", "houston-override.yml"];
+
+function ciEnabled(config) {
+  return config.ci?.enabled === true;
+}
+
+function createWorkflowCheck(workflow) {
+  return {
+    name: `ci:workflow:${workflow}`,
+    label: `CI workflow: ${workflow}`,
+    strategy: STRATEGY.MANUAL,
+    applies: ciEnabled,
+    async detect({ config }) {
+      const projectDir = config.projectDir || process.cwd();
+      const wfPath = path.join(projectDir, ".github", "workflows", workflow);
+      const wfExists = await exists(wfPath);
+      return {
+        ok: wfExists,
+        severity: "fail",
+        detail: wfExists ? "Found" : "Not found",
+        fix: wfExists
+          ? undefined
+          : `Run 'kj init --scaffold-ci' or copy from karajan-code/templates/workflows/${workflow}`,
+      };
+    },
+  };
+}
+
+export function createGhCliCheck() {
+  return {
+    name: "ci:gh",
+    label: "CI: gh CLI",
+    strategy: STRATEGY.MANUAL,
+    applies: ciEnabled,
+    async detect() {
+      const gh = await checkBinary("gh");
+      return {
+        ok: gh.ok,
+        severity: "fail",
+        detail: gh.ok ? gh.version : "Not found",
+        fix: gh.ok ? undefined : "Install GitHub CLI: https://cli.github.com/",
+      };
+    },
+  };
+}
+
+export function createGhSecretsCheck() {
+  return {
+    name: "ci:secrets",
+    label: "CI: GitHub secrets",
+    strategy: STRATEGY.MANUAL,
+    applies: ciEnabled,
+    async detect() {
+      try {
+        const { detectRepo } = await import("../ci/repo.js");
+        const repo = await detectRepo();
+        if (!repo) {
+          return { ok: true, severity: "info", detail: "No GitHub repo detected (skipped)" };
+        }
+        const res = await runCommand("gh", ["api", `repos/${repo}/actions/secrets`, "--jq", ".secrets[].name"]);
+        if (res.exitCode !== 0) {
+          return { ok: true, severity: "info", detail: "Cannot query secrets (gh unauthenticated?)" };
+        }
+        const names = new Set(res.stdout.split("\n").map((s) => s.trim()));
+        const hasAppId = names.has("KJ_CI_APP_ID");
+        const hasKey = names.has("KJ_CI_PRIVATE_KEY");
+        const secretsOk = hasAppId && hasKey;
+        const missing = [!hasAppId && "KJ_CI_APP_ID", !hasKey && "KJ_CI_PRIVATE_KEY"].filter(Boolean).join(" ");
+        return {
+          ok: secretsOk,
+          severity: "fail",
+          detail: secretsOk ? "KJ_CI_APP_ID + KJ_CI_PRIVATE_KEY found" : `Missing: ${missing}`,
+          fix: secretsOk ? undefined : "Add KJ_CI_APP_ID and KJ_CI_PRIVATE_KEY as GitHub repository secrets",
+        };
+      } catch {
+        return { ok: true, severity: "info", detail: "Cannot check secrets (unexpected error, skipped)" };
+      }
+    },
+  };
+}
+
+/**
+ * Aggregate of CI checks. Each check carries its own `applies` so the runner
+ * marks them SKIPPED when CI is disabled.
+ */
+export function getCiChecks() {
+  const checks = [];
+  for (const wf of REQUIRED_WORKFLOWS) {
+    checks.push(createWorkflowCheck(wf));
+  }
+  checks.push(createGhCliCheck());
+  checks.push(createGhSecretsCheck());
+  return checks;
+}

--- a/src/checks/config-files.js
+++ b/src/checks/config-files.js
@@ -1,0 +1,217 @@
+/**
+ * Config and rule-file checks.
+ *
+ * Covers:
+ *   - kj.config.yml existence (strategy: prompt — offer to run kj init)
+ *   - Review / coder rules discovery (strategy: none, informational)
+ *   - Agent config files: ~/.claude.json, ~/.codex/config.toml,
+ *     ~/.karajan/kj.config.yml (strategy: manual — structural fixes needed)
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { exists } from "../utils/fs.js";
+import { getConfigPath } from "../config.js";
+import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
+import { withDocLink } from "../utils/doc-links.js";
+import { STRATEGY } from "./types.js";
+
+/**
+ * kj.config.yml presence check.
+ */
+export function createConfigFileCheck() {
+  return {
+    name: "config",
+    label: "Config file",
+    strategy: STRATEGY.PROMPT,
+    describe: "Run 'kj init' to scaffold a default kj.config.yml",
+    async detect() {
+      const configPath = getConfigPath();
+      const configExists = await exists(configPath);
+      return {
+        ok: configExists,
+        severity: "fail",
+        detail: configExists ? configPath : "Not found",
+        fix: configExists ? undefined : withDocLink("Run 'kj init' to create the config file.", "config_missing"),
+      };
+    },
+  };
+}
+
+/**
+ * Review rules (.md) informational check.
+ */
+export function createReviewRulesCheck() {
+  return {
+    name: "review-rules",
+    label: "Reviewer rules (.md)",
+    strategy: STRATEGY.NONE,
+    async detect({ config }) {
+      const projectDir = config.projectDir || process.cwd();
+      const paths = resolveRoleMdPath("reviewer", projectDir);
+      const rules = await loadFirstExisting(paths);
+      return {
+        ok: true,
+        severity: "info",
+        detail: rules ? "Found" : "Not found (will use defaults)",
+      };
+    },
+  };
+}
+
+/**
+ * Coder rules (.md) informational check.
+ */
+export function createCoderRulesCheck() {
+  return {
+    name: "coder-rules",
+    label: "Coder rules (.md)",
+    strategy: STRATEGY.NONE,
+    async detect({ config }) {
+      const projectDir = config.projectDir || process.cwd();
+      const paths = resolveRoleMdPath("coder", projectDir);
+      const rules = await loadFirstExisting(paths);
+      return {
+        ok: true,
+        severity: "info",
+        detail: rules ? "Found" : "Not found (will use defaults)",
+      };
+    },
+  };
+}
+
+/**
+ * Detect duplicate TOML table headers (e.g. [mcp_servers."karajan-mcp"] twice).
+ */
+function findDuplicateTomlKeys(content) {
+  const tableHeaders = [];
+  const duplicates = [];
+  for (const line of content.split("\n")) {
+    const match = line.match(/^\s*\[([^\]]+)\]\s*$/);
+    if (match) {
+      const key = match[1].trim();
+      if (tableHeaders.includes(key)) {
+        duplicates.push(key);
+      } else {
+        tableHeaders.push(key);
+      }
+    }
+  }
+  return duplicates;
+}
+
+/**
+ * Claude config (~/.claude.json) validity.
+ */
+export function createClaudeConfigCheck() {
+  return {
+    name: "agent-config:claude",
+    label: "Agent config: claude (~/.claude.json)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const home = os.homedir();
+      const claudeJsonPath = path.join(home, ".claude.json");
+      try {
+        const raw = await fs.readFile(claudeJsonPath, "utf8");
+        JSON.parse(raw);
+        return { ok: true, severity: "info", detail: "Valid JSON" };
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          // Not configured: Claude may not be in use. Informational skip.
+          return { ok: true, severity: "info", detail: "Not present (skipped)" };
+        }
+        return {
+          ok: false,
+          severity: "warn",
+          detail: `Invalid JSON: ${err.message.split("\n")[0]}`,
+          fix: "Fix the JSON syntax in ~/.claude.json. Common issues: trailing commas, missing quotes.",
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Codex config (~/.codex/config.toml) validity.
+ */
+export function createCodexConfigCheck() {
+  return {
+    name: "agent-config:codex",
+    label: "Agent config: codex (~/.codex/config.toml)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const home = os.homedir();
+      const codexTomlPath = path.join(home, ".codex", "config.toml");
+      try {
+        const raw = await fs.readFile(codexTomlPath, "utf8");
+        const duplicates = findDuplicateTomlKeys(raw);
+        if (duplicates.length > 0) {
+          return {
+            ok: false,
+            severity: "warn",
+            detail: `Duplicate TOML keys: ${duplicates.join(", ")}`,
+            fix: `Remove duplicate entries in ~/.codex/config.toml: ${duplicates.join(", ")}`,
+          };
+        }
+        return { ok: true, severity: "info", detail: "Valid TOML (no duplicate keys)" };
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return { ok: true, severity: "info", detail: "Not present (skipped)" };
+        }
+        return {
+          ok: false,
+          severity: "warn",
+          detail: `Cannot read: ${err.message.split("\n")[0]}`,
+          fix: "Check file permissions on ~/.codex/config.toml",
+        };
+      }
+    },
+  };
+}
+
+/**
+ * KJ config (~/.karajan/kj.config.yml) YAML validity (separate from existence).
+ */
+export function createKjConfigYamlCheck() {
+  return {
+    name: "agent-config:karajan",
+    label: "Agent config: karajan (kj.config.yml)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const kjConfigPath = getConfigPath();
+      try {
+        const raw = await fs.readFile(kjConfigPath, "utf8");
+        const yaml = await import("js-yaml");
+        yaml.default.load(raw);
+        return { ok: true, severity: "info", detail: "Valid YAML" };
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          // Covered by createConfigFileCheck — don't duplicate the failure
+          return { ok: true, severity: "info", detail: "Not present (covered by config check)" };
+        }
+        return {
+          ok: false,
+          severity: "fail",
+          detail: `Invalid YAML: ${err.message.split("\n")[0]}`,
+          fix: `Fix YAML syntax in ${kjConfigPath}. Run 'kj init' to regenerate if needed.`,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Aggregate: all config-file-related checks.
+ * @returns {import("./types.js").Check[]}
+ */
+export function getConfigFileChecks() {
+  return [
+    createConfigFileCheck(),
+    createReviewRulesCheck(),
+    createCoderRulesCheck(),
+    createClaudeConfigCheck(),
+    createCodexConfigCheck(),
+    createKjConfigYamlCheck(),
+  ];
+}

--- a/src/checks/dir-setup.js
+++ b/src/checks/dir-setup.js
@@ -1,0 +1,63 @@
+/**
+ * Ensure ~/.karajan/ directory tree exists. Strategy: auto — creating
+ * directories under the user's home is non-invasive.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { STRATEGY } from "./types.js";
+
+const REQUIRED_DIRS = [
+  "", // ~/.karajan/
+  "sessions",
+  "skills-cache",
+  "logs",
+];
+
+export function createKarajanDirsCheck() {
+  return {
+    name: "karajan-dirs",
+    label: "~/.karajan directory tree",
+    strategy: STRATEGY.AUTO,
+    describe: "Create missing ~/.karajan subdirectories",
+    async detect() {
+      const home = os.homedir();
+      const root = path.join(home, ".karajan");
+      const missing = [];
+      for (const sub of REQUIRED_DIRS) {
+        const full = sub ? path.join(root, sub) : root;
+        try {
+          const stat = await fs.stat(full);
+          if (!stat.isDirectory()) missing.push(full);
+        } catch {
+          missing.push(full);
+        }
+      }
+      if (missing.length === 0) {
+        return { ok: true, severity: "info", detail: `All ${REQUIRED_DIRS.length} directories present under ${root}` };
+      }
+      return {
+        ok: false,
+        severity: "fail",
+        detail: `Missing: ${missing.map((m) => path.relative(home, m)).join(", ")}`,
+        fix: `mkdir -p ${missing.join(" ")}`,
+        extra: { missing },
+      };
+    },
+    async remediate({ extra }) {
+      const missing = extra?.missing || [];
+      for (const dir of missing) {
+        await fs.mkdir(dir, { recursive: true });
+      }
+      return {
+        fixed: true,
+        detail: `Created ${missing.length} director${missing.length === 1 ? "y" : "ies"} under ~/.karajan`,
+      };
+    },
+  };
+}
+
+export function getDirSetupChecks() {
+  return [createKarajanDirsCheck()];
+}

--- a/src/checks/mcp-health.js
+++ b/src/checks/mcp-health.js
@@ -1,0 +1,157 @@
+/**
+ * MCP server health checks.
+ *
+ * Karajan integrates with several MCP servers — karajan-mcp (stdio), Serena,
+ * Sonar MCP, Planning Game MCP, etc. This module verifies they respond to
+ * a minimal JSON-RPC `initialize` call within a short deadline.
+ *
+ * For stdio MCPs that Karajan spawns itself (karajan-mcp), a failed ping is
+ * auto-remediable by re-spawning. External MCPs (Serena) are warn-only.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { STRATEGY } from "./types.js";
+import { withTimeout, TimeoutError } from "../utils/with-timeout.js";
+import { checkBinary } from "../utils/agent-detect.js";
+
+const PING_TIMEOUT_MS = 3000;
+
+/**
+ * Send a JSON-RPC `initialize` to an MCP server over stdio and wait for
+ * any response. Kills the process immediately after.
+ *
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {Promise<{ok: boolean, detail: string}>}
+ */
+async function pingMcpStdio(command, args) {
+  const handshake = () =>
+    new Promise((resolve) => {
+      let child;
+      try {
+        child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+      } catch (err) {
+        resolve({ ok: false, detail: `spawn failed: ${err.message}` });
+        return;
+      }
+      let settled = false;
+      const finish = (ok, detail) => {
+        if (settled) return;
+        settled = true;
+        try {
+          child.kill();
+        } catch { /* already exited */ }
+        resolve({ ok, detail });
+      };
+      child.on("error", (err) => finish(false, `process error: ${err.message}`));
+      child.on("exit", (code) => {
+        if (!settled) finish(false, `exited with code ${code} before response`);
+      });
+      child.stdout.on("data", (buf) => {
+        const text = buf.toString();
+        // Any JSON-RPC response line counts as alive.
+        if (text.includes("\"jsonrpc\"") || text.includes("\"result\"") || text.includes("\"error\"")) {
+          finish(true, "Responded to initialize");
+        }
+      });
+      // Send initialize request
+      const req = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          clientInfo: { name: "kj-doctor", version: "1.0.0" },
+          capabilities: {},
+        },
+      });
+      try {
+        child.stdin.write(req + "\n");
+      } catch (err) {
+        finish(false, `stdin write failed: ${err.message}`);
+      }
+    });
+  try {
+    return await withTimeout(handshake(), PING_TIMEOUT_MS, "mcp-ping");
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      return { ok: false, detail: `No response within ${PING_TIMEOUT_MS}ms` };
+    }
+    return { ok: false, detail: err.message };
+  }
+}
+
+/**
+ * karajan-mcp health — stdio server bundled with this package.
+ * Strategy: auto (we can re-spawn it ourselves).
+ */
+export function createKarajanMcpCheck() {
+  return {
+    name: "mcp:karajan",
+    label: "MCP: karajan-mcp",
+    strategy: STRATEGY.AUTO,
+    describe: "Respawn karajan-mcp stdio process",
+    async detect() {
+      const binPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../bin/karajan-mcp.js");
+      const result = await pingMcpStdio(process.execPath, [binPath]);
+      return {
+        ok: result.ok,
+        severity: result.ok ? "info" : "warn",
+        detail: result.ok ? result.detail : `karajan-mcp did not respond: ${result.detail}`,
+        fix: result.ok ? undefined : "Re-run karajan-mcp via `node bin/karajan-mcp.js`",
+        extra: { binPath },
+      };
+    },
+    async remediate({ extra }) {
+      // Spawn once detached so the MCP client can pick it up for subsequent runs.
+      // This is idempotent: if one instance is already listening, another will
+      // coexist over a different pipe.
+      try {
+        spawn(process.execPath, [extra.binPath], { detached: true, stdio: "ignore" }).unref();
+        return { fixed: true, detail: "Re-spawned karajan-mcp in background" };
+      } catch (err) {
+        return { fixed: false, detail: `Failed to respawn: ${err.message}` };
+      }
+    },
+  };
+}
+
+/**
+ * Serena MCP — external tool the user installs themselves. Warn only when
+ * enabled in config. Strategy: manual (we don't manage its lifecycle).
+ */
+export function createSerenaMcpCheck() {
+  return {
+    name: "mcp:serena",
+    label: "MCP: serena",
+    strategy: STRATEGY.MANUAL,
+    applies: (config) => config?.serena?.enabled === true,
+    async detect() {
+      const bin = await checkBinary("serena");
+      if (!bin.ok) {
+        return {
+          ok: false,
+          severity: "warn",
+          detail: "serena binary not on PATH",
+          fix: "Install Serena: uvx --from git+https://github.com/oraios/serena serena",
+        };
+      }
+      const result = await pingMcpStdio("serena", ["start", "--mcp"]);
+      return {
+        ok: result.ok,
+        severity: result.ok ? "info" : "warn",
+        detail: result.ok ? "Serena responded to initialize" : `No response: ${result.detail}`,
+        fix: result.ok ? undefined : "Restart Serena manually and verify connectivity.",
+      };
+    },
+  };
+}
+
+/**
+ * Aggregate of MCP health checks. Only enabled servers run their ping.
+ */
+export function getMcpHealthChecks() {
+  return [createKarajanMcpCheck(), createSerenaMcpCheck()];
+}

--- a/src/checks/node.js
+++ b/src/checks/node.js
@@ -1,0 +1,61 @@
+/**
+ * Node.js runtime version check. Requires Node >= 20 (minimum version that
+ * ships structuredClone, Array.prototype.findLast, AbortSignal.timeout, and
+ * stable fetch). Strategy: manual — we cannot auto-upgrade the runtime.
+ */
+
+import { STRATEGY } from "./types.js";
+
+export const MIN_NODE_MAJOR = 20;
+
+/**
+ * Accepts a version string in the form "v20.12.1" or "20.12.1" and returns
+ * an object { major, minor, patch } or null when the shape is invalid.
+ */
+export function parseNodeVersion(versionString) {
+  const str = String(versionString || "").trim();
+  const m = str.match(/^v?(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/**
+ * Create the Node version check. Accepts an optional override of the
+ * reported version (useful in tests).
+ *
+ * @param {{ version?: string }} [opts]
+ * @returns {import("./types.js").Check}
+ */
+export function createNodeVersionCheck(opts = {}) {
+  return {
+    name: "node-version",
+    label: "Node.js runtime",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const raw = opts.version ?? process.env.KJ_FORCE_NODE_VERSION ?? process.version;
+      const parsed = parseNodeVersion(raw);
+      if (!parsed) {
+        return {
+          ok: false,
+          severity: "fail",
+          detail: `Unrecognized Node version: ${raw}`,
+          fix: `Install Node ${MIN_NODE_MAJOR}+ from https://nodejs.org/ (current: ${raw}).`,
+        };
+      }
+      if (parsed.major < MIN_NODE_MAJOR) {
+        return {
+          ok: false,
+          severity: "fail",
+          detail: `Node ${raw} detected, requires >=${MIN_NODE_MAJOR}`,
+          fix: `Upgrade Node to ${MIN_NODE_MAJOR}+ (nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}, or brew upgrade node).`,
+          extra: { detected: parsed, required: MIN_NODE_MAJOR },
+        };
+      }
+      return { ok: true, severity: "info", detail: `${raw} (>= ${MIN_NODE_MAJOR} required)` };
+    },
+  };
+}
+
+export function getNodeChecks() {
+  return [createNodeVersionCheck()];
+}

--- a/src/checks/ports.js
+++ b/src/checks/ports.js
@@ -1,0 +1,110 @@
+/**
+ * Port availability checks for services Karajan controls.
+ *
+ *   - SonarQube port (default 9000): the Docker container binds a fixed port,
+ *     so if it's occupied by a non-Karajan process we cannot "move" it; we
+ *     report FAIL with the occupant PID/command to help the user stop the
+ *     conflicting process. Strategy: manual.
+ *
+ *   - HU Board port (default 4000): an in-process Node server we can rebind
+ *     to any free port in runtime overrides. Strategy: auto.
+ */
+
+import { isPortAvailable, findAvailablePort } from "../utils/port-check.js";
+import { getPortOccupant } from "../utils/port-occupant.js";
+import { STRATEGY } from "./types.js";
+
+const DEFAULT_SONAR_PORT = 9000;
+const DEFAULT_HU_BOARD_PORT = 4000;
+
+function extractPortFromHost(host, fallback) {
+  const m = String(host || "").match(/:(\d+)(?:\/|$)/);
+  return m ? Number(m[1]) : fallback;
+}
+
+/**
+ * Whether the occupant looks like the Karajan-managed Sonar container.
+ * Docker Desktop's proxy is typically `com.docker.backend` / `com.docker.vmnetd`
+ * on macOS and `docker-proxy` on Linux. We treat those as OK.
+ */
+function isKarajanSonarOccupant(occupant) {
+  if (!occupant?.command) return false;
+  const cmd = occupant.command.toLowerCase();
+  return cmd.includes("docker") || cmd.includes("sonar");
+}
+
+export function createSonarPortCheck() {
+  return {
+    name: "port:sonar",
+    label: "SonarQube port",
+    strategy: STRATEGY.MANUAL,
+    applies: (config) => config?.sonarqube?.enabled !== false,
+    async detect({ config }) {
+      const port = extractPortFromHost(config?.sonarqube?.host, DEFAULT_SONAR_PORT);
+      const free = await isPortAvailable(port);
+      if (free) {
+        return { ok: true, severity: "info", detail: `Port ${port} is free (Sonar container not yet running)` };
+      }
+      // Busy — is it our container?
+      const occupant = await getPortOccupant(port);
+      if (occupant && isKarajanSonarOccupant(occupant)) {
+        return {
+          ok: true,
+          severity: "info",
+          detail: `Port ${port} held by Karajan-managed Sonar (${occupant.command} PID ${occupant.pid})`,
+        };
+      }
+      const who = occupant
+        ? `${occupant.command || "unknown"} (PID ${occupant.pid ?? "?"})`
+        : "unknown process";
+      return {
+        ok: false,
+        severity: "fail",
+        detail: `Port ${port} occupied by ${who}`,
+        fix: `Stop the process holding port ${port} or change sonarqube.host in kj.config.yml.`,
+        extra: { port, occupant },
+      };
+    },
+  };
+}
+
+export function createHuBoardPortCheck() {
+  return {
+    name: "port:hu-board",
+    label: "HU Board port",
+    strategy: STRATEGY.AUTO,
+    applies: (config) => config?.hu_board?.enabled !== false,
+    describe: "Rebind HU Board to the next free port",
+    async detect({ config }) {
+      const port = config?.hu_board?.port || DEFAULT_HU_BOARD_PORT;
+      const free = await isPortAvailable(port);
+      if (free) {
+        return { ok: true, severity: "info", detail: `Port ${port} is free` };
+      }
+      const occupant = await getPortOccupant(port);
+      const who = occupant
+        ? `${occupant.command || "unknown"} (PID ${occupant.pid ?? "?"})`
+        : "unknown process";
+      return {
+        ok: false,
+        severity: "warn",
+        detail: `Port ${port} occupied by ${who}`,
+        fix: `Free port ${port} or set hu_board.port in kj.config.yml`,
+        extra: { port, occupant },
+      };
+    },
+    async remediate({ extra }) {
+      const start = (extra?.port ?? DEFAULT_HU_BOARD_PORT) + 1;
+      const found = await findAvailablePort(start, 20);
+      return {
+        fixed: true,
+        detail: `Rebound HU Board to port ${found} (in-memory override)`,
+        changes: { hu_board: { port: found } },
+      };
+    },
+  };
+}
+
+export function getPortChecks() {
+  return [createSonarPortCheck(), createHuBoardPortCheck()];
+}

--- a/src/checks/rtk.js
+++ b/src/checks/rtk.js
@@ -1,0 +1,36 @@
+/**
+ * RTK (Rust Token Killer) availability check. Manual strategy — installation
+ * depends on the host platform and is handled by getInstallCommand().
+ */
+
+import { runCommand } from "../utils/process.js";
+import { getInstallCommand } from "../utils/os-detect.js";
+import { withDocLink } from "../utils/doc-links.js";
+import { STRATEGY } from "./types.js";
+
+export function createRtkCheck() {
+  return {
+    name: "rtk",
+    label: "RTK (Rust Token Killer)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      try {
+        const res = await runCommand("rtk", ["--version"]);
+        if (res.exitCode === 0) {
+          return { ok: true, severity: "info", detail: `${res.stdout.trim()} — token savings active` };
+        }
+      } catch { /* not installed */ }
+      const installCmd = getInstallCommand("rtk");
+      return {
+        ok: false,
+        severity: "warn",
+        detail: "Not found — 60-90% token savings available",
+        fix: withDocLink(`Install: ${installCmd}`, "rtk_install"),
+      };
+    },
+  };
+}
+
+export function getRtkChecks() {
+  return [createRtkCheck()];
+}

--- a/src/checks/runner.js
+++ b/src/checks/runner.js
@@ -1,19 +1,30 @@
 /**
  * Check runner. Orchestrates the detect → remediate → re-verify phases for
- * a list of Check objects. Commit 1 implements only the detect phase (parallel
- * execution, applies filter, timeout-free for now). Later commits add
- * remediation, timeout wrapping, and re-verify.
+ * a list of Check objects.
  *
- * API contract intentionally leaves space for extension without breaking
- * consumers: options bag is always the last argument and backwards-compat
- * is preserved when unknown fields are added.
+ * Phase 1 (detect): executed in parallel with per-check timeout. Timeouts
+ * are reported as TIMEOUT status (WARN-level), never throw.
+ *
+ * Phase 2 (remediate): sequential, only for failures with strategy auto or
+ * prompt (and user consent for prompt). Skipped entirely when mode is
+ * "check-only". Each remediation has its own timeout (5s default, 60s for
+ * prompted actions like npm install).
+ *
+ * Phase 3 (re-verify): re-runs `detect` once for each check that was
+ * remediated, to confirm the fix actually worked. If re-verify fails, the
+ * status is FAIL (remediation lied).
+ *
+ * Runtime overrides returned by remediations are merged into `runReport.overrides`
+ * for consumers (e.g. preflight → orchestrator) to apply to the active session.
  */
 
 import { STATUS, STRATEGY } from "./types.js";
+import { withTimeout, TimeoutError } from "../utils/with-timeout.js";
+
+const DEFAULT_DETECT_TIMEOUT_MS = 5000;
+const DEFAULT_REMEDIATE_TIMEOUT_MS = 60000;
 
 /**
- * Execute a list of checks and return a structured report.
- *
  * @param {import("./types.js").Check[]} checks
  * @param {{ config: Object }} ctx
  * @param {{
@@ -21,82 +32,168 @@ import { STATUS, STRATEGY } from "./types.js";
  *   yes?: boolean,
  *   onConfirm?: (describe: string) => Promise<boolean>,
  *   timeoutMs?: number,
+ *   remediateTimeoutMs?: number,
  *   signal?: AbortSignal,
  *   logger?: { info: Function, warn: Function, error: Function }
  * }} [options]
  * @returns {Promise<import("./types.js").RunReport>}
  */
 export async function runChecks(checks, ctx, options = {}) {
+  const {
+    mode = "fix",
+    yes = false,
+    onConfirm = defaultOnConfirm,
+    timeoutMs = DEFAULT_DETECT_TIMEOUT_MS,
+    remediateTimeoutMs = DEFAULT_REMEDIATE_TIMEOUT_MS,
+    signal,
+    logger = silentLogger(),
+  } = options;
+
   const { config } = ctx;
   const startTotal = Date.now();
+  const entries = [];
+  const overrides = {};
 
-  const reports = [];
-
-  // Build applicable checks (skipped checks get a SKIPPED report).
-  const applicable = [];
+  // Build applicable entries (skipped checks noted up front).
   for (const check of checks) {
     if (typeof check.applies === "function" && !check.applies(config)) {
-      reports.push({
-        name: check.name,
-        label: check.label,
+      entries.push({
+        check,
         status: STATUS.SKIPPED,
-        strategy: check.strategy,
         detail: "Not applicable for current configuration",
         runMs: 0,
+        detectResult: null,
+        remediated: false,
       });
-      continue;
+    } else {
+      entries.push({ check, status: null, detail: null, runMs: 0, detectResult: null, remediated: false });
     }
-    applicable.push(check);
   }
 
-  // Phase 1: detect in parallel.
-  const detections = await Promise.all(
-    applicable.map(async (check) => {
+  // Phase 1: detect in parallel with timeout.
+  const detectBase = Date.now();
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.status === STATUS.SKIPPED) return;
       const start = Date.now();
       try {
-        const result = await check.detect({ config });
-        return { check, result, runMs: Date.now() - start, error: null };
+        const result = await withTimeout(entry.check.detect({ config, signal }), timeoutMs, entry.check.name);
+        entry.detectResult = result;
+        entry.runMs = Date.now() - start;
+        entry.status = resolveStatusFromDetect(entry.check, result);
+        entry.detail = result.detail;
       } catch (err) {
-        return {
-          check,
-          result: { ok: false, severity: "fail", detail: `Detection error: ${err.message}` },
-          runMs: Date.now() - start,
-          error: err,
-        };
+        entry.runMs = Date.now() - start;
+        if (err instanceof TimeoutError) {
+          entry.detectResult = { ok: false, severity: "warn", detail: `Timeout after ${timeoutMs}ms` };
+          entry.status = STATUS.TIMEOUT;
+          entry.detail = entry.detectResult.detail;
+        } else {
+          entry.detectResult = { ok: false, severity: "fail", detail: `Detection error: ${err.message}` };
+          entry.status = STATUS.FAIL;
+          entry.detail = entry.detectResult.detail;
+        }
       }
     })
   );
+  logger.info?.(`Detect phase done in ${Date.now() - detectBase}ms`);
 
-  // Build reports. Remediation will be added in commit 4.
-  for (const { check, result, runMs } of detections) {
-    const status = resolveStatus(check, result);
-    reports.push({
-      name: check.name,
-      label: check.label,
-      status,
-      strategy: check.strategy,
-      detail: result.detail,
-      fix: result.fix,
-      runMs,
-    });
+  // Phase 2: remediate sequentially (only in "fix" mode, only failing checks).
+  if (mode !== "check-only") {
+    for (const entry of entries) {
+      if (!shouldAttemptRemediation(entry)) continue;
+      const { check, detectResult } = entry;
+      if (check.strategy === STRATEGY.PROMPT && !yes) {
+        const approved = await onConfirm(check.describe || `Fix: ${check.name}`);
+        if (!approved) {
+          logger.info?.(`User declined remediation for ${check.name}`);
+          continue;
+        }
+      }
+      const start = Date.now();
+      try {
+        const rem = await withTimeout(
+          check.remediate({ config, extra: detectResult.extra, signal, logger }),
+          remediateTimeoutMs,
+          `${check.name}:remediate`
+        );
+        entry.remediated = rem.fixed === true;
+        entry.runMs += Date.now() - start;
+        if (rem.fixed) {
+          if (rem.changes) mergeOverrides(overrides, rem.changes);
+          entry.detail = rem.detail;
+          entry.status = STATUS.FIXED;
+        } else {
+          entry.detail = rem.detail || entry.detail;
+          entry.status = STATUS.FAIL;
+        }
+      } catch (err) {
+        entry.runMs += Date.now() - start;
+        const msg = err instanceof TimeoutError ? `Remediation timeout after ${remediateTimeoutMs}ms` : `Remediation error: ${err.message}`;
+        entry.detail = msg;
+        entry.status = STATUS.FAIL;
+        logger.warn?.(`Remediation failed for ${check.name}: ${msg}`);
+      }
+    }
+
+    // Phase 3: re-verify fixed checks.
+    await Promise.all(
+      entries.filter((e) => e.remediated).map(async (entry) => {
+        const start = Date.now();
+        try {
+          const result = await withTimeout(entry.check.detect({ config, signal }), timeoutMs, `${entry.check.name}:reverify`);
+          entry.runMs += Date.now() - start;
+          if (!result.ok) {
+            entry.status = STATUS.FAIL;
+            entry.detail = `${entry.detail} (but re-verify failed: ${result.detail})`;
+          }
+        } catch (err) {
+          entry.runMs += Date.now() - start;
+          entry.status = STATUS.FAIL;
+          entry.detail = `${entry.detail} (re-verify error: ${err.message})`;
+        }
+      })
+    );
   }
+
+  // Flatten into reports.
+  const reports = entries.map((e) => ({
+    name: e.check.name,
+    label: e.check.label,
+    status: e.status,
+    strategy: e.check.strategy,
+    detail: e.detail ?? "",
+    fix: e.detectResult?.fix,
+    runMs: e.runMs,
+  }));
 
   const summary = summarize(reports);
 
   return {
     checks: reports,
-    overrides: {},
+    overrides,
     totalMs: Date.now() - startTotal,
     summary,
   };
 }
 
-function resolveStatus(check, result) {
+function shouldAttemptRemediation(entry) {
+  if (entry.status === STATUS.SKIPPED) return false;
+  if (entry.status === STATUS.OK) return false;
+  if (entry.status === STATUS.TIMEOUT) return false; // don't remediate when detect itself timed out
+  const { check, detectResult } = entry;
+  if (!check.remediate || !detectResult) return false;
+  if (check.strategy === STRATEGY.MANUAL || check.strategy === STRATEGY.NONE) return false;
+  // Soft failures (WARN) with PROMPT strategy: don't nag the user for optional issues.
+  if (entry.status === STATUS.WARN && check.strategy === STRATEGY.PROMPT) return false;
+  return true;
+}
+
+function resolveStatusFromDetect(check, result) {
   if (result.ok) return STATUS.OK;
   const severity = result.severity || "fail";
   if (severity === "warn") return STATUS.WARN;
-  if (severity === "info") return STATUS.OK; // info always OK
-  // strategy "none" checks should never fail; treat as WARN defensively
+  if (severity === "info") return STATUS.OK; // info is always non-failing
   if (check.strategy === STRATEGY.NONE) return STATUS.WARN;
   return STATUS.FAIL;
 }
@@ -111,8 +208,32 @@ function summarize(reports) {
 }
 
 /**
- * Flatten a RunReport into the legacy doctor.js shape for backwards compat
- * with existing tests and consumers that still expect {name,label,ok,detail,fix}.
+ * Deep-merge (shallow for now, one level deep) remediation changes into overrides.
+ * Remediation outputs like { hu_board: { port: 4007 } } should not overwrite a
+ * sibling key { hu_board: { enabled: true } } that a prior check set.
+ */
+function mergeOverrides(target, source) {
+  for (const [key, value] of Object.entries(source)) {
+    if (value && typeof value === "object" && !Array.isArray(value) && typeof target[key] === "object") {
+      Object.assign(target[key], value);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+function defaultOnConfirm() {
+  // Non-interactive by default: refuse prompts unless the caller supplies a real handler.
+  return Promise.resolve(false);
+}
+
+function silentLogger() {
+  return { info() {}, warn() {}, error() {} };
+}
+
+/**
+ * Flatten a RunReport into the legacy doctor.js shape.
+ * OK/FIXED/SKIPPED → ok:true. WARN/FAIL/TIMEOUT → ok:false.
  */
 export function toLegacyShape(runReport) {
   return runReport.checks.map((c) => ({

--- a/src/checks/runner.js
+++ b/src/checks/runner.js
@@ -1,0 +1,125 @@
+/**
+ * Check runner. Orchestrates the detect → remediate → re-verify phases for
+ * a list of Check objects. Commit 1 implements only the detect phase (parallel
+ * execution, applies filter, timeout-free for now). Later commits add
+ * remediation, timeout wrapping, and re-verify.
+ *
+ * API contract intentionally leaves space for extension without breaking
+ * consumers: options bag is always the last argument and backwards-compat
+ * is preserved when unknown fields are added.
+ */
+
+import { STATUS, STRATEGY } from "./types.js";
+
+/**
+ * Execute a list of checks and return a structured report.
+ *
+ * @param {import("./types.js").Check[]} checks
+ * @param {{ config: Object }} ctx
+ * @param {{
+ *   mode?: "fix"|"check-only",
+ *   yes?: boolean,
+ *   onConfirm?: (describe: string) => Promise<boolean>,
+ *   timeoutMs?: number,
+ *   signal?: AbortSignal,
+ *   logger?: { info: Function, warn: Function, error: Function }
+ * }} [options]
+ * @returns {Promise<import("./types.js").RunReport>}
+ */
+export async function runChecks(checks, ctx, options = {}) {
+  const { config } = ctx;
+  const startTotal = Date.now();
+
+  const reports = [];
+
+  // Build applicable checks (skipped checks get a SKIPPED report).
+  const applicable = [];
+  for (const check of checks) {
+    if (typeof check.applies === "function" && !check.applies(config)) {
+      reports.push({
+        name: check.name,
+        label: check.label,
+        status: STATUS.SKIPPED,
+        strategy: check.strategy,
+        detail: "Not applicable for current configuration",
+        runMs: 0,
+      });
+      continue;
+    }
+    applicable.push(check);
+  }
+
+  // Phase 1: detect in parallel.
+  const detections = await Promise.all(
+    applicable.map(async (check) => {
+      const start = Date.now();
+      try {
+        const result = await check.detect({ config });
+        return { check, result, runMs: Date.now() - start, error: null };
+      } catch (err) {
+        return {
+          check,
+          result: { ok: false, severity: "fail", detail: `Detection error: ${err.message}` },
+          runMs: Date.now() - start,
+          error: err,
+        };
+      }
+    })
+  );
+
+  // Build reports. Remediation will be added in commit 4.
+  for (const { check, result, runMs } of detections) {
+    const status = resolveStatus(check, result);
+    reports.push({
+      name: check.name,
+      label: check.label,
+      status,
+      strategy: check.strategy,
+      detail: result.detail,
+      fix: result.fix,
+      runMs,
+    });
+  }
+
+  const summary = summarize(reports);
+
+  return {
+    checks: reports,
+    overrides: {},
+    totalMs: Date.now() - startTotal,
+    summary,
+  };
+}
+
+function resolveStatus(check, result) {
+  if (result.ok) return STATUS.OK;
+  const severity = result.severity || "fail";
+  if (severity === "warn") return STATUS.WARN;
+  if (severity === "info") return STATUS.OK; // info always OK
+  // strategy "none" checks should never fail; treat as WARN defensively
+  if (check.strategy === STRATEGY.NONE) return STATUS.WARN;
+  return STATUS.FAIL;
+}
+
+function summarize(reports) {
+  const summary = { ok: 0, fixed: 0, warn: 0, fail: 0, skipped: 0, timeout: 0 };
+  for (const r of reports) {
+    const k = r.status.toLowerCase();
+    if (k in summary) summary[k]++;
+  }
+  return summary;
+}
+
+/**
+ * Flatten a RunReport into the legacy doctor.js shape for backwards compat
+ * with existing tests and consumers that still expect {name,label,ok,detail,fix}.
+ */
+export function toLegacyShape(runReport) {
+  return runReport.checks.map((c) => ({
+    name: c.name,
+    label: c.label,
+    ok: c.status === STATUS.OK || c.status === STATUS.FIXED || c.status === STATUS.SKIPPED,
+    detail: c.detail,
+    fix: c.fix ?? null,
+  }));
+}

--- a/src/checks/runner.js
+++ b/src/checks/runner.js
@@ -136,12 +136,16 @@ export async function runChecks(checks, ctx, options = {}) {
       }
     }
 
-    // Phase 3: re-verify fixed checks.
+    // Phase 3: re-verify fixed checks using the config merged with any
+    // runtime overrides applied by remediations. Without this merge, a check
+    // that rebinds to a new port (override) would re-verify against the old
+    // config and wrongly report failure.
+    const verifyConfig = mergeConfigAndOverrides(config, overrides);
     await Promise.all(
       entries.filter((e) => e.remediated).map(async (entry) => {
         const start = Date.now();
         try {
-          const result = await withTimeout(entry.check.detect({ config, signal }), timeoutMs, `${entry.check.name}:reverify`);
+          const result = await withTimeout(entry.check.detect({ config: verifyConfig, signal }), timeoutMs, `${entry.check.name}:reverify`);
           entry.runMs += Date.now() - start;
           if (!result.ok) {
             entry.status = STATUS.FAIL;
@@ -220,6 +224,23 @@ function mergeOverrides(target, source) {
       target[key] = value;
     }
   }
+}
+
+/**
+ * Produce a shallow-merged copy of config + overrides used during re-verify.
+ * Does not mutate the original config.
+ */
+function mergeConfigAndOverrides(config, overrides) {
+  if (!overrides || Object.keys(overrides).length === 0) return config;
+  const merged = { ...config };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value && typeof value === "object" && !Array.isArray(value) && typeof config[key] === "object") {
+      merged[key] = { ...config[key], ...value };
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
 }
 
 function defaultOnConfirm() {

--- a/src/checks/skills.js
+++ b/src/checks/skills.js
@@ -1,0 +1,49 @@
+/**
+ * OpenSkills CLI availability check. Only runs when skills are enabled.
+ * Strategy: prompt — we can offer to run `npm install -g openskills`,
+ * but global installs are invasive enough that they need user consent.
+ */
+
+import { isOpenSkillsAvailable } from "../skills/openskills-client.js";
+import { runCommand } from "../utils/process.js";
+import { STRATEGY } from "./types.js";
+
+export function skillsEnabled(config) {
+  return config?.skills?.enabled !== false;
+}
+
+export function createOpenSkillsCheck() {
+  return {
+    name: "openskills",
+    label: "OpenSkills CLI",
+    strategy: STRATEGY.PROMPT,
+    applies: skillsEnabled,
+    describe: "Install OpenSkills globally: npm install -g openskills",
+    async detect() {
+      const available = await isOpenSkillsAvailable();
+      if (available) {
+        return { ok: true, severity: "info", detail: "Available via `npx openskills`" };
+      }
+      return {
+        ok: false,
+        severity: "warn", // skills enabled but missing → degrade gracefully
+        detail: "`npx openskills` not available — skill injection will be skipped",
+        fix: "Install OpenSkills: npm install -g openskills",
+      };
+    },
+    async remediate() {
+      const res = await runCommand("npm", ["install", "-g", "openskills"], { timeout: 60000 });
+      if (res.exitCode === 0) {
+        return { fixed: true, detail: "Installed openskills globally via npm" };
+      }
+      return {
+        fixed: false,
+        detail: `npm install -g openskills failed (exit ${res.exitCode}): ${res.stderr.split("\n")[0]}`,
+      };
+    },
+  };
+}
+
+export function getSkillsChecks() {
+  return [createOpenSkillsCheck()];
+}

--- a/src/checks/sonar.js
+++ b/src/checks/sonar.js
@@ -1,0 +1,67 @@
+/**
+ * SonarQube reachability + auth checks.
+ *
+ * Auto-remediation strategy (preserving existing behavior from
+ * preflight-checks.js): if Sonar is not reachable, try `sonarUp()` which
+ * starts the Docker container, then poll for readiness. If auth fails but
+ * admin credentials exist, generate a fresh token and persist it.
+ */
+
+import { isSonarReachable } from "../sonar/manager.js";
+import { STRATEGY } from "./types.js";
+import { withDocLink } from "../utils/doc-links.js";
+
+/**
+ * Whether Sonar is enabled in the active config.
+ */
+function sonarEnabled(config) {
+  return config.sonarqube?.enabled !== false;
+}
+
+function sonarHost(config) {
+  return config.sonarqube?.host || "http://localhost:9000";
+}
+
+/**
+ * Informative check: Sonar enabled/disabled status.
+ * Produces an OK result with disabled description when Sonar is off.
+ */
+export function createSonarStatusCheck() {
+  return {
+    name: "sonarqube",
+    label: "SonarQube",
+    strategy: STRATEGY.NONE,
+    async detect({ config }) {
+      const host = sonarHost(config);
+      if (!sonarEnabled(config)) {
+        return { ok: true, severity: "info", detail: "Disabled in config" };
+      }
+      let reachable = false;
+      try {
+        reachable = await isSonarReachable(host);
+      } catch {
+        reachable = false;
+      }
+      return {
+        ok: reachable,
+        severity: "fail",
+        detail: reachable ? `Reachable at ${host}` : `Not reachable at ${host}`,
+        fix: reachable
+          ? undefined
+          : withDocLink(
+              "Run 'kj sonar start' or 'docker start karajan-sonarqube'. Use --no-sonar to skip.",
+              "sonar_docker"
+            ),
+        extra: { host, reachable },
+      };
+    },
+  };
+}
+
+/**
+ * All Sonar-related checks. Keeps just the status check for commit 1;
+ * auth + auto-remediation are layered in commit 3.
+ */
+export function getSonarChecks() {
+  return [createSonarStatusCheck()];
+}

--- a/src/checks/system.js
+++ b/src/checks/system.js
@@ -1,0 +1,53 @@
+/**
+ * Miscellaneous system-level checks: Karajan version, git repo presence.
+ * Kept in a dedicated module so they're easy to find and extend.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { ensureGitRepo } from "../utils/git.js";
+import { STRATEGY } from "./types.js";
+
+function getPackageVersion() {
+  const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
+  return JSON.parse(readFileSync(pkgPath, "utf8")).version;
+}
+
+export function createKarajanVersionCheck() {
+  return {
+    name: "karajan",
+    label: "Karajan Code",
+    strategy: STRATEGY.NONE,
+    async detect() {
+      const version = getPackageVersion();
+      return { ok: true, severity: "info", detail: `v${version}` };
+    },
+  };
+}
+
+export function createGitRepoCheck() {
+  return {
+    name: "git",
+    label: "Git repository",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      let gitOk = false;
+      try {
+        gitOk = await ensureGitRepo();
+      } catch {
+        gitOk = false;
+      }
+      return {
+        ok: gitOk,
+        severity: "fail",
+        detail: gitOk ? "Inside a git repository" : "Not a git repository",
+        fix: gitOk ? undefined : "Run 'git init' or navigate to a git-managed project.",
+      };
+    },
+  };
+}
+
+export function getSystemChecks() {
+  return [createKarajanVersionCheck(), createGitRepoCheck()];
+}

--- a/src/checks/tokens.js
+++ b/src/checks/tokens.js
@@ -1,0 +1,96 @@
+/**
+ * API token availability checks.
+ *
+ * Provider tokens (ANTHROPIC_API_KEY / OPENAI_API_KEY / ...) are LAZY:
+ * we only check them for providers that are actually used by at least one
+ * active role in the current config.
+ *
+ * Strategy:
+ *   - Required providers with no key → FAIL, strategy manual (we can't
+ *     fetch an API key for the user). Fix hint includes the how-to URL.
+ *   - Optional providers (opencode, aider) without key → WARN.
+ *   - GH_TOKEN is checked when git.auto_pr=true, strategy prompt (we can
+ *     launch `gh auth login` with user approval).
+ */
+
+import { checkBinary } from "../utils/agent-detect.js";
+import { getRequiredProviderEnvs, hasEnvVar } from "../utils/provider-env.js";
+import { STRATEGY } from "./types.js";
+
+/**
+ * A single provider env check. One is created per active provider.
+ */
+function createProviderTokenCheck(entry) {
+  return {
+    name: `token:${entry.provider}`,
+    label: `API token: ${entry.provider}`,
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const ok = hasEnvVar(entry);
+      if (ok) {
+        return { ok: true, severity: "info", detail: `${entry.envVars[0]} is set` };
+      }
+      return {
+        ok: false,
+        severity: entry.optional ? "warn" : "fail",
+        detail: `${entry.envVars.join(" / ")} not set`,
+        fix: `Get an API key at ${entry.howToGetUrl} and export ${entry.envVars[0]}=...`,
+        extra: { provider: entry.provider, envVars: entry.envVars, howToGetUrl: entry.howToGetUrl },
+      };
+    },
+  };
+}
+
+/**
+ * GH token check + auto-remediation via `gh auth login` when it's installed.
+ */
+function createGhTokenCheck() {
+  return {
+    name: "token:gh",
+    label: "GitHub token (for auto_pr)",
+    strategy: STRATEGY.PROMPT,
+    applies: (config) => config?.git?.auto_pr === true,
+    describe: "Run 'gh auth login' to authenticate with GitHub",
+    async detect() {
+      const envOk = !!process.env.GH_TOKEN || !!process.env.GITHUB_TOKEN;
+      if (envOk) {
+        return { ok: true, severity: "info", detail: "GH_TOKEN or GITHUB_TOKEN is set" };
+      }
+      // If `gh` is installed and authenticated, it manages its own token.
+      const gh = await checkBinary("gh");
+      if (!gh.ok) {
+        return {
+          ok: false,
+          severity: "fail",
+          detail: "No GH_TOKEN/GITHUB_TOKEN and `gh` CLI not installed",
+          fix: "Install GitHub CLI (https://cli.github.com) or export GH_TOKEN=...",
+          extra: { hasGh: false },
+        };
+      }
+      return {
+        ok: false,
+        severity: "fail",
+        detail: "No GH_TOKEN/GITHUB_TOKEN; `gh` is installed but auth status unknown",
+        fix: "Run 'gh auth login' or export GH_TOKEN=...",
+        extra: { hasGh: true },
+      };
+    },
+    // remediate() intentionally omitted: launching `gh auth login` requires an
+    // interactive terminal session. The runner's prompt strategy will point
+    // the user to the command and exit with FAIL in non-TTY contexts.
+  };
+}
+
+/**
+ * Build the list of token checks for the active config. Each active provider
+ * gets one, plus conditional GH token when auto_pr is on.
+ *
+ * @param {Object} config
+ * @returns {import("./types.js").Check[]}
+ */
+export function getTokenChecks(config) {
+  const required = getRequiredProviderEnvs(config);
+  const checks = required.map(createProviderTokenCheck);
+  checks.push(createGhTokenCheck());
+  return checks;
+}

--- a/src/checks/types.js
+++ b/src/checks/types.js
@@ -1,0 +1,105 @@
+/**
+ * Shared check schema for doctor/preflight subsystem.
+ *
+ * A Check describes an environment requirement (binary present, port free,
+ * token configured, MCP reachable...). Each check can optionally remediate
+ * itself when it fails, using one of 4 strategies:
+ *
+ *   - "auto"   → fix without asking. Use for non-invasive, reversible changes
+ *                (in-memory runtime overrides, starting existing services,
+ *                creating files under ~/.karajan/, etc.)
+ *   - "prompt" → ask user before fixing. Use for invasive changes that touch
+ *                the user's system outside Karajan's scope (global npm install,
+ *                writing kj.config.yml, `gh auth login`, etc.)
+ *   - "manual" → cannot auto-fix, only report a hint (Node runtime upgrade,
+ *                missing Docker, missing API key with no admin creds)
+ *   - "none"   → informational check, always OK (Karajan version, feature
+ *                disabled by config)
+ */
+
+/**
+ * @typedef {Object} CheckResult
+ * @property {boolean} ok                        - true if check passes
+ * @property {"fail"|"warn"|"info"} [severity]   - relevant when !ok; default "fail"
+ * @property {string} detail                     - human-readable status
+ * @property {string} [fix]                      - remediation hint shown when manual or user declines
+ * @property {Object} [extra]                    - structured data consumed by remediate (e.g. occupant PID, host, roles)
+ */
+
+/**
+ * @typedef {Object} RemediationContext
+ * @property {Object} config                     - resolved Karajan config
+ * @property {AbortSignal} [signal]              - cancellation
+ * @property {Object} extra                      - check's CheckResult.extra
+ * @property {Object} logger                     - logger instance
+ */
+
+/**
+ * @typedef {Object} RemediationResult
+ * @property {boolean} fixed                     - true if remediation succeeded
+ * @property {string} detail                     - what was done, human-readable
+ * @property {Object} [changes]                  - runtime config overrides to merge into the active session
+ */
+
+/**
+ * @typedef {Object} Check
+ * @property {string} name                       - slug, unique across all checks (e.g. "node-version")
+ * @property {string} label                      - human label (e.g. "Node.js runtime")
+ * @property {"auto"|"prompt"|"manual"|"none"} strategy
+ * @property {(ctx: { config: Object }) => Promise<CheckResult>} detect
+ * @property {(ctx: RemediationContext) => Promise<RemediationResult>} [remediate]
+ * @property {string} [describe]                 - shown to user when strategy is "prompt"
+ * @property {(config: Object) => boolean} [applies]  - if false, check is SKIPPED (lazy evaluation). Default: always applies.
+ */
+
+/**
+ * @typedef {Object} CheckReport
+ * @property {string} name
+ * @property {string} label
+ * @property {"OK"|"FIXED"|"WARN"|"FAIL"|"SKIPPED"|"TIMEOUT"} status
+ * @property {"auto"|"prompt"|"manual"|"none"} strategy
+ * @property {string} detail                     - detect detail or remediate detail when FIXED
+ * @property {string} [fix]                      - remediation hint for FAIL/WARN
+ * @property {number} runMs                      - total time (detect + remediate + re-verify)
+ * @property {boolean} [cached]                  - future: served from cache
+ */
+
+/**
+ * @typedef {Object} RunReport
+ * @property {CheckReport[]} checks
+ * @property {Object} overrides                  - merged runtime overrides from auto-remediations
+ * @property {number} totalMs
+ * @property {{ ok: number, fixed: number, warn: number, fail: number, skipped: number, timeout: number }} summary
+ */
+
+/**
+ * Status constants.
+ */
+export const STATUS = Object.freeze({
+  OK: "OK",
+  FIXED: "FIXED",
+  WARN: "WARN",
+  FAIL: "FAIL",
+  SKIPPED: "SKIPPED",
+  TIMEOUT: "TIMEOUT",
+});
+
+export const STRATEGY = Object.freeze({
+  AUTO: "auto",
+  PROMPT: "prompt",
+  MANUAL: "manual",
+  NONE: "none",
+});
+
+export const SEVERITY = Object.freeze({
+  FAIL: "fail",
+  WARN: "warn",
+  INFO: "info",
+});
+
+/**
+ * Whether the final status blocks the pipeline (for preflight).
+ */
+export function isBlocking(status) {
+  return status === STATUS.FAIL || status === STATUS.TIMEOUT;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -172,9 +172,22 @@ program
 
 program
   .command("doctor")
-  .description("Check environment requirements")
-  .action(async () => {
-    await withConfig("doctor", {}, doctorCommand);
+  .description("Check environment requirements and auto-remediate when possible")
+  .option("--check-only", "Detect issues without applying fixes")
+  .option("-y, --yes", "Auto-confirm prompts for invasive remediations (CI mode)")
+  .option("--json", "Emit machine-readable JSON instead of human output")
+  .option("--verbose", "Include fix hints and timing for every check")
+  .action(async (flags) => {
+    const exitCode = await withConfig("doctor", {}, (ctx) =>
+      doctorCommand({
+        ...ctx,
+        checkOnly: !!flags.checkOnly,
+        yes: !!flags.yes,
+        json: !!flags.json,
+        verbose: !!flags.verbose,
+      })
+    );
+    if (Number.isInteger(exitCode)) process.exit(exitCode);
   });
 
 program

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -13,18 +13,30 @@ import { getBinaryChecks } from "../checks/binaries.js";
 import { getSonarChecks } from "../checks/sonar.js";
 import { getCiChecks } from "../checks/ci.js";
 import { getRtkChecks } from "../checks/rtk.js";
+import { getNodeChecks } from "../checks/node.js";
+import { getPortChecks } from "../checks/ports.js";
+import { getTokenChecks } from "../checks/tokens.js";
+import { getMcpHealthChecks } from "../checks/mcp-health.js";
+import { getSkillsChecks } from "../checks/skills.js";
+import { getDirSetupChecks } from "../checks/dir-setup.js";
 
 /**
  * Build the list of Check objects applicable to the current config.
  * @param {Object} config
  * @returns {import("../checks/types.js").Check[]}
  */
-function buildChecks() {
+function buildChecks(config) {
   return [
     ...getSystemChecks(),
+    ...getNodeChecks(),
+    ...getDirSetupChecks(),
     ...getConfigFileChecks(),
     ...getBinaryChecks(),
     ...getSonarChecks(),
+    ...getPortChecks(),
+    ...getTokenChecks(config),
+    ...getMcpHealthChecks(),
+    ...getSkillsChecks(),
     ...getCiChecks(),
     ...getRtkChecks(),
   ];
@@ -40,7 +52,7 @@ function buildChecks() {
  * @returns {Promise<Array<{ name: string, label: string, ok: boolean, detail: string, fix: string|null }>>}
  */
 export async function runChecks({ config }) {
-  const checks = buildChecks();
+  const checks = buildChecks(config);
   const report = await runCheckPipeline(checks, { config });
   return toLegacyShape(report);
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,376 +1,56 @@
-import { readFileSync } from "node:fs";
-import fs from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import os from "node:os";
-import path from "node:path";
-import { runCommand } from "../utils/process.js";
-import { exists } from "../utils/fs.js";
-import { getConfigPath } from "../config.js";
-import { isSonarReachable } from "../sonar/manager.js";
-import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
-import { ensureGitRepo } from "../utils/git.js";
-import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
-import { getInstallCommand } from "../utils/os-detect.js";
-import { withDocLink } from "../utils/doc-links.js";
+/**
+ * `kj doctor` command. Runs the unified check runner and prints a
+ * human-readable report.
+ *
+ * Internal helpers have been extracted to src/checks/* modules during
+ * KJC-TSK-0319. This file remains the thin CLI adapter.
+ */
 
+import { runChecks as runCheckPipeline, toLegacyShape } from "../checks/runner.js";
+import { getSystemChecks } from "../checks/system.js";
+import { getConfigFileChecks } from "../checks/config-files.js";
+import { getBinaryChecks } from "../checks/binaries.js";
+import { getSonarChecks } from "../checks/sonar.js";
+import { getCiChecks } from "../checks/ci.js";
+import { getRtkChecks } from "../checks/rtk.js";
 
-function getPackageVersion() {
-  const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
-  return JSON.parse(readFileSync(pkgPath, "utf8")).version;
-}
-
-function checkKarajanVersion() {
-  const version = getPackageVersion();
-  return {
-    name: "karajan",
-    label: "Karajan Code",
-    ok: true,
-    detail: `v${version}`,
-    fix: null
-  };
-}
-
-async function checkConfigFile() {
-  const configPath = getConfigPath();
-  const configExists = await exists(configPath);
-  return {
-    name: "config",
-    label: "Config file",
-    ok: configExists,
-    detail: configExists ? configPath : "Not found",
-    fix: configExists ? null : withDocLink("Run 'kj init' to create the config file.", "config_missing")
-  };
-}
-
-async function checkGitRepo() {
-  let gitOk = false;
-  try {
-    gitOk = await ensureGitRepo();
-  } catch { /* git check failed */
-    gitOk = false;
-  }
-  return {
-    name: "git",
-    label: "Git repository",
-    ok: gitOk,
-    detail: gitOk ? "Inside a git repository" : "Not a git repository",
-    fix: gitOk ? null : "Run 'git init' or navigate to a git-managed project."
-  };
-}
-
-async function checkDocker() {
-  const docker = await checkBinary("docker", "--version");
-  return {
-    name: "docker",
-    label: "Docker",
-    ok: docker.ok,
-    detail: docker.ok ? docker.version : "Not found",
-    fix: docker.ok ? null : withDocLink("Install Docker: https://docs.docker.com/get-docker/", "sonar_docker")
-  };
-}
-
-function sonarDetail(config, sonarOk, sonarHost) {
-  if (config.sonarqube?.enabled === false) return "Disabled in config";
-  if (sonarOk) return `Reachable at ${sonarHost}`;
-  return `Not reachable at ${sonarHost}`;
-}
-
-async function checkSonarQube(config) {
-  const sonarHost = config.sonarqube?.host || "http://localhost:9000";
-  let sonarOk = false;
-  if (config.sonarqube?.enabled !== false) {
-    try {
-      sonarOk = await isSonarReachable(sonarHost);
-    } catch { /* sonar check failed */
-      sonarOk = false;
-    }
-  }
-  const isOkOrDisabled = sonarOk || config.sonarqube?.enabled === false;
-  return {
-    name: "sonarqube",
-    label: "SonarQube",
-    ok: isOkOrDisabled,
-    detail: sonarDetail(config, sonarOk, sonarHost),
-    fix: isOkOrDisabled
-      ? null
-      : withDocLink("Run 'kj sonar start' or 'docker start karajan-sonarqube'. Use --no-sonar to skip.", "sonar_docker")
-  };
-}
-
-async function checkAgentCLIs() {
-  const checks = [];
-  for (const agent of KNOWN_AGENTS) {
-    const result = await checkBinary(agent.name);
-    checks.push({
-      name: `agent:${agent.name}`,
-      label: `Agent: ${agent.name}`,
-      ok: result.ok,
-      detail: result.ok ? `${result.version} (${result.path})` : "Not found",
-      fix: result.ok ? null : withDocLink(`Install: ${agent.install}`, "agent_not_found")
-    });
-  }
-  return checks;
-}
-
-async function checkCoreBinaries() {
-  const checks = [];
-  for (const bin of ["node", "npm", "git"]) {
-    const result = await checkBinary(bin);
-    checks.push({
-      name: bin,
-      label: bin,
-      ok: result.ok,
-      detail: result.ok ? result.version : "Not found",
-      fix: result.ok ? null : `Install ${bin} from its official website.`
-    });
-  }
-  return checks;
-}
-
-async function checkSerena() {
-  let serenaOk = false;
-  try {
-    const serenaCheck = await runCommand("serena", ["--version"]);
-    serenaOk = serenaCheck.exitCode === 0;
-  } catch { /* serena not installed */
-    serenaOk = false;
-  }
-  return {
-    name: "serena",
-    label: "Serena MCP",
-    ok: serenaOk,
-    detail: serenaOk ? "Available" : "Not found (prompts will still include Serena instructions)",
-    fix: serenaOk ? null : "Install Serena: uvx --from git+https://github.com/oraios/serena serena --help"
-  };
-}
-
-async function checkCiWorkflows(projectDir) {
-  const checks = [];
-  const workflowDir = path.join(projectDir, ".github", "workflows");
-  const requiredWorkflows = ["kj-ci-gateway.yml", "automerge.yml", "houston-override.yml"];
-  for (const wf of requiredWorkflows) {
-    const wfPath = path.join(workflowDir, wf);
-    const wfExists = await exists(wfPath);
-    checks.push({
-      name: `ci:workflow:${wf}`,
-      label: `CI workflow: ${wf}`,
-      ok: wfExists,
-      detail: wfExists ? "Found" : "Not found",
-      fix: wfExists ? null : `Run 'kj init --scaffold-ci' or copy from karajan-code/templates/workflows/${wf}`
-    });
-  }
-  return checks;
-}
-
-async function checkCiSecrets() {
-  try {
-    const { detectRepo } = await import("../ci/repo.js");
-    const repo = await detectRepo();
-    if (!repo) return null;
-
-    const secretsRes = await runCommand("gh", ["api", `repos/${repo}/actions/secrets`, "--jq", ".secrets[].name"]);
-    if (secretsRes.exitCode !== 0) return null;
-
-    const names = new Set(secretsRes.stdout.split("\n").map((s) => s.trim()));
-    const hasAppId = names.has("KJ_CI_APP_ID");
-    const hasKey = names.has("KJ_CI_PRIVATE_KEY");
-    const secretsOk = hasAppId && hasKey;
-    const missing = [!hasAppId && "KJ_CI_APP_ID", !hasKey && "KJ_CI_PRIVATE_KEY"].filter(Boolean).join(" ");
-    return {
-      name: "ci:secrets",
-      label: "CI: GitHub secrets",
-      ok: secretsOk,
-      detail: secretsOk ? "KJ_CI_APP_ID + KJ_CI_PRIVATE_KEY found" : `Missing: ${missing}`,
-      fix: secretsOk ? null : "Add KJ_CI_APP_ID and KJ_CI_PRIVATE_KEY as GitHub repository secrets"
-    };
-  } catch { /* GitHub API error */
-    return null;
-  }
-}
-
-async function checkCiInfra(config) {
-  const checks = [];
-  const projectDir = config.projectDir || process.cwd();
-
-  checks.push(...await checkCiWorkflows(projectDir));
-
-  const ghCheck = await checkBinary("gh");
-  checks.push({
-    name: "ci:gh",
-    label: "CI: gh CLI",
-    ok: ghCheck.ok,
-    detail: ghCheck.ok ? ghCheck.version : "Not found",
-    fix: ghCheck.ok ? null : "Install GitHub CLI: https://cli.github.com/"
-  });
-
-  const secretsCheck = await checkCiSecrets();
-  if (secretsCheck) checks.push(secretsCheck);
-
-  return checks;
-}
-
-async function checkRtk() {
-  const installCmd = getInstallCommand("rtk");
-  try {
-    const res = await runCommand("rtk", ["--version"]);
-    if (res.exitCode === 0) {
-      return { name: "rtk", label: "RTK (Rust Token Killer)", ok: true, detail: `${res.stdout.trim()} — token savings active`, fix: null };
-    }
-  } catch { /* not installed */ }
-  return {
-    name: "rtk",
-    label: "RTK (Rust Token Killer)",
-    ok: false,
-    detail: "Not found — 60-90% token savings available",
-    fix: withDocLink(`Install: ${installCmd}`, "rtk_install")
-  };
-}
-
-async function checkRuleFiles(config) {
-  const projectDir = config.projectDir || process.cwd();
-  const reviewRules = await loadFirstExisting(resolveRoleMdPath("reviewer", projectDir));
-  const coderRules = await loadFirstExisting(resolveRoleMdPath("coder", projectDir));
+/**
+ * Build the list of Check objects applicable to the current config.
+ * @param {Object} config
+ * @returns {import("../checks/types.js").Check[]}
+ */
+function buildChecks() {
   return [
-    {
-      name: "review-rules",
-      label: "Reviewer rules (.md)",
-      ok: Boolean(reviewRules),
-      detail: reviewRules ? "Found" : "Not found (will use defaults)",
-      fix: null
-    },
-    {
-      name: "coder-rules",
-      label: "Coder rules (.md)",
-      ok: Boolean(coderRules),
-      detail: coderRules ? "Found" : "Not found (will use defaults)",
-      fix: null
-    }
+    ...getSystemChecks(),
+    ...getConfigFileChecks(),
+    ...getBinaryChecks(),
+    ...getSonarChecks(),
+    ...getCiChecks(),
+    ...getRtkChecks(),
   ];
 }
 
 /**
- * Detect duplicate TOML table headers (e.g. [mcp_servers."karajan-mcp"] appearing twice).
- * Full TOML parsing would require a dependency — this catches the most common config error.
+ * Run all environment checks and return results in the legacy shape expected
+ * by existing consumers: `{ name, label, ok, detail, fix }`.
+ *
+ * Kept public so tools and tests can consume the raw list without CLI output.
+ *
+ * @param {{ config: Object }} args
+ * @returns {Promise<Array<{ name: string, label: string, ok: boolean, detail: string, fix: string|null }>>}
  */
-function findDuplicateTomlKeys(content) {
-  const tableHeaders = [];
-  const duplicates = [];
-  for (const line of content.split("\n")) {
-    const match = line.match(/^\s*\[([^\]]+)\]\s*$/);
-    if (match) {
-      const key = match[1].trim();
-      if (tableHeaders.includes(key)) {
-        duplicates.push(key);
-      } else {
-        tableHeaders.push(key);
-      }
-    }
-  }
-  return duplicates;
-}
-
-async function checkAgentConfigs() {
-  const checks = [];
-  const home = os.homedir();
-
-  // Claude: ~/.claude.json
-  const claudeJsonPath = path.join(home, ".claude.json");
-  try {
-    const raw = await fs.readFile(claudeJsonPath, "utf8");
-    JSON.parse(raw);
-    checks.push({ name: "agent-config:claude", label: "Agent config: claude (~/.claude.json)", ok: true, detail: "Valid JSON", fix: null });
-  } catch (err) {
-    if (err.code === "ENOENT") {
-      // File doesn't exist — not an error, Claude may not be configured
-    } else {
-      checks.push({
-        name: "agent-config:claude",
-        label: "Agent config: claude (~/.claude.json)",
-        ok: false,
-        detail: `Invalid JSON: ${err.message.split("\n")[0]}`,
-        fix: "Fix the JSON syntax in ~/.claude.json. Common issues: trailing commas, missing quotes."
-      });
-    }
-  }
-
-  // Codex: ~/.codex/config.toml
-  const codexTomlPath = path.join(home, ".codex", "config.toml");
-  try {
-    const raw = await fs.readFile(codexTomlPath, "utf8");
-    const duplicates = findDuplicateTomlKeys(raw);
-    if (duplicates.length > 0) {
-      checks.push({
-        name: "agent-config:codex",
-        label: "Agent config: codex (~/.codex/config.toml)",
-        ok: false,
-        detail: `Duplicate TOML keys: ${duplicates.join(", ")}`,
-        fix: `Remove duplicate entries in ~/.codex/config.toml: ${duplicates.join(", ")}`
-      });
-    } else {
-      checks.push({ name: "agent-config:codex", label: "Agent config: codex (~/.codex/config.toml)", ok: true, detail: "Valid TOML (no duplicate keys)", fix: null });
-    }
-  } catch (err) {
-    if (err.code !== "ENOENT") {
-      checks.push({
-        name: "agent-config:codex",
-        label: "Agent config: codex (~/.codex/config.toml)",
-        ok: false,
-        detail: `Cannot read: ${err.message.split("\n")[0]}`,
-        fix: "Check file permissions on ~/.codex/config.toml"
-      });
-    }
-  }
-
-  // KJ config: ~/.karajan/kj.config.yml (validate YAML)
-  const kjConfigPath = getConfigPath();
-  try {
-    const raw = await fs.readFile(kjConfigPath, "utf8");
-    const yaml = await import("js-yaml");
-    yaml.default.load(raw);
-    checks.push({ name: "agent-config:karajan", label: "Agent config: karajan (kj.config.yml)", ok: true, detail: "Valid YAML", fix: null });
-  } catch (err) {
-    if (err.code !== "ENOENT") {
-      checks.push({
-        name: "agent-config:karajan",
-        label: "Agent config: karajan (kj.config.yml)",
-        ok: false,
-        detail: `Invalid YAML: ${err.message.split("\n")[0]}`,
-        fix: `Fix YAML syntax in ${kjConfigPath}. Run 'kj init' to regenerate if needed.`
-      });
-    }
-  }
-
-  return checks;
-}
-
 export async function runChecks({ config }) {
-  const checks = [];
-
-  checks.push(
-    checkKarajanVersion(),
-    await checkConfigFile(),
-    await checkGitRepo(),
-    await checkDocker(),
-    await checkSonarQube(config),
-    ...await checkAgentCLIs(),
-    ...await checkCoreBinaries()
-  );
-
-  if (config.serena?.enabled) {
-    checks.push(await checkSerena());
-  }
-
-  if (config.ci?.enabled) {
-    checks.push(...await checkCiInfra(config));
-  }
-
-  checks.push(...await checkAgentConfigs());
-  checks.push(...await checkRuleFiles(config));
-  checks.push(await checkRtk());
-
-  return checks;
+  const checks = buildChecks();
+  const report = await runCheckPipeline(checks, { config });
+  return toLegacyShape(report);
 }
 
+/**
+ * `kj doctor` CLI entrypoint. Prints each check's status and any fix hints.
+ * Returns the flattened check list for programmatic consumption.
+ *
+ * @param {{ config: Object }} args
+ */
 export async function doctorCommand({ config }) {
   const checks = await runChecks({ config });
 

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -1,12 +1,19 @@
 /**
  * `kj doctor` command. Runs the unified check runner and prints a
- * human-readable report.
+ * human-readable report by default. Supports flags:
  *
- * Internal helpers have been extracted to src/checks/* modules during
- * KJC-TSK-0319. This file remains the thin CLI adapter.
+ *   --check-only   : only detect, do not apply fixes
+ *   --yes / -y     : auto-confirm prompts for invasive remediations (CI mode)
+ *   --json         : emit machine-readable JSON to stdout
+ *   --verbose      : include fix hints and timing per check
+ *
+ * Exit code is 1 whenever any check ends with FAIL (including remediation
+ * failures). WARN, OK, FIXED, SKIPPED and TIMEOUT do not fail the command.
  */
 
+import readline from "node:readline";
 import { runChecks as runCheckPipeline, toLegacyShape } from "../checks/runner.js";
+import { STATUS } from "../checks/types.js";
 import { getSystemChecks } from "../checks/system.js";
 import { getConfigFileChecks } from "../checks/config-files.js";
 import { getBinaryChecks } from "../checks/binaries.js";
@@ -43,43 +50,112 @@ function buildChecks(config) {
 }
 
 /**
- * Run all environment checks and return results in the legacy shape expected
- * by existing consumers: `{ name, label, ok, detail, fix }`.
+ * Interactive terminal confirmation. Returns false when stdin is not a TTY
+ * so non-interactive contexts don't hang forever.
  *
- * Kept public so tools and tests can consume the raw list without CLI output.
+ * @param {string} describe
+ * @returns {Promise<boolean>}
+ */
+function confirmViaTty(describe) {
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) {
+      resolve(false);
+      return;
+    }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`? ${describe} [y/N] `, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+/**
+ * Run the full doctor pipeline without CLI formatting. Consumers that need
+ * the raw report (preflight, status command) should use this.
+ *
+ * @param {{ config: Object, checkOnly?: boolean, yes?: boolean, onConfirm?: Function, logger?: Object }} args
+ * @returns {Promise<import("../checks/types.js").RunReport>}
+ */
+export async function runDoctor({ config, checkOnly = false, yes = false, onConfirm, logger }) {
+  const checks = buildChecks(config);
+  return runCheckPipeline(checks, { config }, {
+    mode: checkOnly ? "check-only" : "fix",
+    yes,
+    onConfirm: onConfirm ?? confirmViaTty,
+    logger,
+  });
+}
+
+/**
+ * Legacy shape (backwards-compat for callers that still expect
+ * {name,label,ok,detail,fix}). Kept public because tests and the CI gate
+ * still rely on it.
  *
  * @param {{ config: Object }} args
- * @returns {Promise<Array<{ name: string, label: string, ok: boolean, detail: string, fix: string|null }>>}
  */
 export async function runChecks({ config }) {
-  const checks = buildChecks(config);
-  const report = await runCheckPipeline(checks, { config });
+  const report = await runDoctor({ config });
   return toLegacyShape(report);
 }
 
 /**
- * `kj doctor` CLI entrypoint. Prints each check's status and any fix hints.
- * Returns the flattened check list for programmatic consumption.
+ * `kj doctor` CLI entrypoint. Returns the exit code (0 OK, 1 when FAIL).
  *
- * @param {{ config: Object }} args
+ * @param {{ config: Object, checkOnly?: boolean, yes?: boolean, json?: boolean, verbose?: boolean }} args
+ * @returns {Promise<number>}
  */
-export async function doctorCommand({ config }) {
-  const checks = await runChecks({ config });
+export async function doctorCommand({ config, checkOnly = false, yes = false, json = false, verbose = false }) {
+  const report = await runDoctor({ config, checkOnly, yes });
 
-  for (const check of checks) {
-    const icon = check.ok ? "OK  " : "MISS";
-    console.log(`${icon} ${check.label}: ${check.detail}`);
-    if (check.fix) {
+  if (json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printHuman(report, { verbose });
+  }
+
+  return hasBlockingFailure(report) ? 1 : 0;
+}
+
+function hasBlockingFailure(report) {
+  return report.checks.some((c) => c.status === STATUS.FAIL || c.status === STATUS.TIMEOUT);
+}
+
+function statusIcon(status) {
+  switch (status) {
+    case STATUS.OK: return "OK   ";
+    case STATUS.FIXED: return "FIXED";
+    case STATUS.WARN: return "WARN ";
+    case STATUS.FAIL: return "FAIL ";
+    case STATUS.SKIPPED: return "SKIP ";
+    case STATUS.TIMEOUT: return "TIME ";
+    default: return "?    ";
+  }
+}
+
+function printHuman(report, { verbose }) {
+  for (const check of report.checks) {
+    console.log(`${statusIcon(check.status)} ${check.label}: ${check.detail}`);
+    if (check.fix && (check.status === STATUS.FAIL || check.status === STATUS.WARN || verbose)) {
       console.log(`     -> ${check.fix}`);
+    }
+    if (verbose) {
+      console.log(`     (${check.runMs}ms, strategy=${check.strategy})`);
     }
   }
 
-  const failures = checks.filter((c) => !c.ok && c.fix);
-  if (failures.length === 0) {
-    console.log("\nAll checks passed.");
+  const s = report.summary;
+  const total = s.ok + s.fixed + s.warn + s.fail + s.skipped + s.timeout;
+  console.log();
+  if (s.fail === 0 && s.timeout === 0) {
+    const label = s.fixed > 0 ? `All checks passed (${s.fixed} auto-fixed)` : "All checks passed.";
+    console.log(label);
   } else {
-    console.log(`\n${failures.length} issue(s) found.`);
+    console.log(
+      `${s.fail + s.timeout} issue(s) found, ${s.fixed} auto-fixed, ${s.warn} warnings, ${s.skipped} skipped out of ${total}.`
+    );
   }
-
-  return checks;
+  if (Object.keys(report.overrides).length > 0) {
+    console.log(`Runtime overrides applied: ${JSON.stringify(report.overrides)}`);
+  }
 }

--- a/src/mcp/handlers/management-handlers.js
+++ b/src/mcp/handlers/management-handlers.js
@@ -157,8 +157,13 @@ export function handleInit(a) {
   return runKjCommand({ command: "init", options: a });
 }
 
-export function handleDoctor(a) {
-  return runKjCommand({ command: "doctor", options: a });
+export function handleDoctor(a = {}) {
+  const commandArgs = [];
+  if (a.checkOnly) commandArgs.push("--check-only");
+  if (a.yes) commandArgs.push("--yes");
+  if (a.json) commandArgs.push("--json");
+  if (a.verbose) commandArgs.push("--verbose");
+  return runKjCommand({ command: "doctor", commandArgs, options: a });
 }
 
 export function handleConfig(a) {

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -12,12 +12,16 @@ export const tools = [
   },
   {
     name: "kj_doctor",
-    description: "Check system dependencies and agent CLIs",
+    description: "Check system dependencies, agent CLIs, ports, tokens and MCP health — auto-remediates when possible",
     inputSchema: {
       type: "object",
       properties: {
         kjHome: { type: "string" },
-        timeoutMs: { type: "number" }
+        timeoutMs: { type: "number" },
+        checkOnly: { type: "boolean", description: "Detect only, do not apply fixes" },
+        yes: { type: "boolean", description: "Auto-confirm prompts for invasive remediations" },
+        json: { type: "boolean", description: "Emit machine-readable JSON output" },
+        verbose: { type: "boolean", description: "Include fix hints and timing per check" }
       }
     }
   },

--- a/src/orchestrator/preflight-checks.js
+++ b/src/orchestrator/preflight-checks.js
@@ -22,6 +22,14 @@ import {
 } from "../sonar/config-resolver.js";
 import { saveSonarToken } from "../sonar/credentials.js";
 import { withDocLink } from "../utils/doc-links.js";
+import { runChecks as runCheckPipeline } from "../checks/runner.js";
+import { STATUS } from "../checks/types.js";
+import { getNodeChecks } from "../checks/node.js";
+import { getDirSetupChecks } from "../checks/dir-setup.js";
+import { getPortChecks } from "../checks/ports.js";
+import { getTokenChecks } from "../checks/tokens.js";
+import { getMcpHealthChecks } from "../checks/mcp-health.js";
+import { getSkillsChecks } from "../checks/skills.js";
 
 function parseJsonSafe(text) {
   try {
@@ -173,9 +181,14 @@ export async function runPreflightChecks({ config, logger, emitter, eventBase, r
     errors: [],
   };
 
-  // Short-circuit: nothing to check
-  if (!sonarEnabled && !securityEnabled) {
-    logger.info("Preflight: skipped (no sonar, no security)");
+  // Resolve extended preflight opt-in early so the short-circuit below can see it.
+  const extendedDefault = globalThis.__KJ_DEFAULT_PREFLIGHT_EXTENDED ?? true;
+  const extendedEnabled = config?.preflight?.extended ?? extendedDefault;
+
+  // Preserve legacy short-circuit: if nothing at all needs checking, skip
+  // emitting the whole preflight bracket.
+  if (!sonarEnabled && !securityEnabled && !extendedEnabled) {
+    logger.info("Preflight: skipped (no sonar, no security, extended disabled)");
     emitProgress(emitter, makeEvent("preflight:end", { ...eventBase, stage: "preflight" }, {
       message: "Preflight skipped (no checks needed)",
       detail: { ...result, executorType: "local" }
@@ -185,7 +198,7 @@ export async function runPreflightChecks({ config, logger, emitter, eventBase, r
 
   emitProgress(emitter, makeEvent("preflight:start", { ...eventBase, stage: "preflight" }, {
     message: "Running preflight environment checks",
-    detail: { sonarEnabled, securityEnabled, executorType: "local" }
+    detail: { sonarEnabled, securityEnabled, extendedEnabled, executorType: "local" }
   }));
 
   // --- 1. Docker (only if sonar enabled and not external) ---
@@ -288,6 +301,15 @@ export async function runPreflightChecks({ config, logger, emitter, eventBase, r
     }
   }
 
+  // --- 5. Complementary doctor-style checks (Node version, ports, tokens, MCP
+  //         health, ~/.karajan dirs, openskills). These are auto-remediated
+  //         with yes:true because preflight runs non-interactively inside kj run.
+  //         Opt-out via `config.preflight.extended: false`. Defaults to true
+  //         in production; the test harness (tests/setup.js) defaults it off.
+  if (extendedEnabled) {
+    await runExtendedPreflight({ config, result, emitter, eventBase, logger });
+  }
+
   const hasErrors = result.errors.length > 0;
   const hasWarnings = result.warnings.length > 0;
   const preflightLang = getLang(config);
@@ -302,4 +324,56 @@ export async function runPreflightChecks({ config, logger, emitter, eventBase, r
   }));
 
   return result;
+}
+
+/**
+ * Run the doctor-style complementary checks and merge their outcomes into
+ * the existing preflight result shape. Runs with yes:true (non-interactive)
+ * and auto-remediation enabled. FAIL/TIMEOUT are appended to errors (blocking),
+ * WARN are appended to warnings (non-blocking), FIXED status is recorded as a
+ * remediation, and runtime overrides from auto-fixes are merged into
+ * configOverrides.
+ */
+async function runExtendedPreflight({ config, result, emitter, eventBase, logger }) {
+  const checks = [
+    ...getNodeChecks(),
+    ...getDirSetupChecks(),
+    ...getPortChecks(),
+    ...getTokenChecks(config),
+    ...getMcpHealthChecks(),
+    ...getSkillsChecks(),
+  ];
+  let report;
+  try {
+    report = await runCheckPipeline(checks, { config }, { mode: "fix", yes: true, timeoutMs: 3000, logger });
+  } catch (err) {
+    logger.warn(`Preflight: extended checks failed to run (${err.message})`);
+    return;
+  }
+
+  for (const c of report.checks) {
+    result.checks.push({ name: c.name, ok: c.status === STATUS.OK || c.status === STATUS.FIXED || c.status === STATUS.SKIPPED, detail: c.detail });
+    const eventStatus = c.status === STATUS.FAIL || c.status === STATUS.TIMEOUT
+      ? "fail"
+      : c.status === STATUS.WARN
+        ? "warn"
+        : "ok";
+    emitProgress(emitter, makeEvent("preflight:check", { ...eventBase, stage: "preflight" }, {
+      status: eventStatus,
+      message: `${c.label}: ${c.detail}`,
+      detail: { name: c.name, status: c.status, detail: c.detail, fix: c.fix }
+    }));
+    if (c.status === STATUS.FIXED) {
+      result.remediations.push(`${c.label}: ${c.detail}`);
+    } else if (c.status === STATUS.FAIL || c.status === STATUS.TIMEOUT) {
+      result.ok = false;
+      result.errors.push({ check: c.name, message: `${c.label}: ${c.detail}`, fix: c.fix });
+    } else if (c.status === STATUS.WARN) {
+      result.warnings.push(`${c.label}: ${c.detail}`);
+    }
+  }
+
+  if (report.overrides && Object.keys(report.overrides).length > 0) {
+    Object.assign(result.configOverrides, report.overrides);
+  }
 }

--- a/src/utils/port-check.js
+++ b/src/utils/port-check.js
@@ -1,0 +1,45 @@
+/**
+ * TCP port availability helpers.
+ *
+ * Originally lived in packages/hu-board/src/server.js. Moved here so the
+ * doctor/preflight subsystem (src/checks/) and hu-board share a single
+ * implementation.
+ */
+
+import { createServer } from "node:net";
+
+/**
+ * Check whether a TCP port is available to bind on localhost.
+ *
+ * @param {number} port
+ * @returns {Promise<boolean>}
+ */
+export function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close();
+      resolve(true);
+    });
+    server.listen(port);
+  });
+}
+
+/**
+ * Find the first available port starting from `startPort`.
+ *
+ * @param {number} startPort       - first port to try
+ * @param {number} [maxAttempts=11] - how many consecutive ports to probe
+ * @param {(port: number) => void} [onBusy] - called for each busy port seen
+ * @returns {Promise<number>}      - resolves with the first free port found
+ * @throws {Error} if no port is free within the range
+ */
+export async function findAvailablePort(startPort, maxAttempts = 11, onBusy) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = startPort + i;
+    if (await isPortAvailable(port)) return port;
+    if (onBusy) onBusy(port);
+  }
+  throw new Error(`No available port found between ${startPort} and ${startPort + maxAttempts - 1}`);
+}

--- a/src/utils/port-occupant.js
+++ b/src/utils/port-occupant.js
@@ -1,0 +1,95 @@
+/**
+ * Detect which process is holding a TCP port. Cross-platform best-effort:
+ *   - Linux/macOS: try `lsof -iTCP:PORT -sTCP:LISTEN -n -P -Fpcn` (parsable),
+ *     fall back to `ss -tlnp` for Linux-only pid detection.
+ *   - Windows: `netstat -ano` + `tasklist` to resolve image name.
+ *
+ * Returns null if the port is free or we cannot determine the occupant.
+ * Never throws — designed to enrich diagnostic messages, not to gate logic.
+ */
+
+import { runCommand } from "./process.js";
+
+/**
+ * @typedef {Object} PortOccupant
+ * @property {number} port
+ * @property {number|null} pid
+ * @property {string|null} command      - process name ("karajan-sonarqube", "node", etc.)
+ * @property {string} raw               - raw tool output for debugging
+ */
+
+/**
+ * @param {number} port
+ * @returns {Promise<PortOccupant|null>}
+ */
+export async function getPortOccupant(port) {
+  if (process.platform === "win32") {
+    return detectWindows(port);
+  }
+  const byLsof = await detectLsof(port);
+  if (byLsof) return byLsof;
+  return detectSs(port);
+}
+
+async function detectLsof(port) {
+  try {
+    const res = await runCommand("lsof", [
+      `-iTCP:${port}`,
+      "-sTCP:LISTEN",
+      "-n",
+      "-P",
+      "-Fpcn",
+    ]);
+    if (res.exitCode !== 0 || !res.stdout.trim()) return null;
+    // Format: lines starting with p<pid>, c<command>, n<name>
+    const lines = res.stdout.split("\n").filter(Boolean);
+    let pid = null;
+    let command = null;
+    for (const line of lines) {
+      if (line.startsWith("p")) pid = Number(line.slice(1)) || null;
+      else if (line.startsWith("c")) command = line.slice(1) || null;
+    }
+    return { port, pid, command, raw: res.stdout };
+  } catch {
+    return null;
+  }
+}
+
+async function detectSs(port) {
+  try {
+    const res = await runCommand("ss", ["-tlnpH", `sport = :${port}`]);
+    if (res.exitCode !== 0 || !res.stdout.trim()) return null;
+    // Example line: LISTEN 0 511 0.0.0.0:4000 0.0.0.0:* users:(("node",pid=12345,fd=20))
+    const match = res.stdout.match(/users:\(\("([^"]+)",pid=(\d+)/);
+    if (!match) return null;
+    return { port, pid: Number(match[2]), command: match[1], raw: res.stdout };
+  } catch {
+    return null;
+  }
+}
+
+async function detectWindows(port) {
+  try {
+    const netstat = await runCommand("netstat", ["-ano"]);
+    if (netstat.exitCode !== 0) return null;
+    const line = netstat.stdout
+      .split(/\r?\n/)
+      .find((l) => l.match(new RegExp(`:${port}\\s+.*LISTENING`)));
+    if (!line) return null;
+    const parts = line.trim().split(/\s+/);
+    const pid = Number(parts[parts.length - 1]) || null;
+    if (!pid) return { port, pid: null, command: null, raw: line };
+    const tasklist = await runCommand("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"]);
+    const command = parseTasklist(tasklist.stdout);
+    return { port, pid, command, raw: `${line}\n${tasklist.stdout}` };
+  } catch {
+    return null;
+  }
+}
+
+function parseTasklist(stdout) {
+  const line = stdout.split(/\r?\n/).find(Boolean);
+  if (!line) return null;
+  const match = line.match(/^"([^"]+)"/);
+  return match ? match[1] : null;
+}

--- a/src/utils/provider-env.js
+++ b/src/utils/provider-env.js
@@ -1,0 +1,116 @@
+/**
+ * Mapping of AI provider → required environment variable(s), plus helpers to
+ * determine which ones are actually needed by the current active config.
+ *
+ * The Check subsystem uses this to validate tokens LAZILY: we only demand an
+ * API key when a role is configured to use the provider behind it. Providers
+ * that run fully locally (e.g. opencode via a self-hosted proxy) are marked
+ * `optional: true` and only warn if their key is missing.
+ */
+
+/**
+ * @typedef {Object} ProviderEnv
+ * @property {string} provider
+ * @property {string[]} envVars     - env var names that would satisfy the check (first match wins)
+ * @property {string} howToGetUrl   - user-facing URL to obtain a key
+ * @property {boolean} optional     - warn vs fail when missing
+ */
+
+/** @type {Record<string, ProviderEnv>} */
+export const PROVIDER_ENV = Object.freeze({
+  anthropic: {
+    provider: "anthropic",
+    envVars: ["ANTHROPIC_API_KEY"],
+    howToGetUrl: "https://console.anthropic.com/settings/keys",
+    optional: false,
+  },
+  openai: {
+    provider: "openai",
+    envVars: ["OPENAI_API_KEY"],
+    howToGetUrl: "https://platform.openai.com/api-keys",
+    optional: false,
+  },
+  google: {
+    provider: "google",
+    envVars: ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    howToGetUrl: "https://aistudio.google.com/app/apikey",
+    optional: false,
+  },
+  opencode: {
+    provider: "opencode",
+    envVars: ["OPENCODE_API_KEY"],
+    howToGetUrl: "https://opencode.ai/docs",
+    optional: true, // local/self-hosted — may not need an API key
+  },
+  aider: {
+    provider: "aider",
+    envVars: ["AIDER_API_KEY"],
+    howToGetUrl: "https://aider.chat/docs/usage.html",
+    optional: true,
+  },
+});
+
+/**
+ * Returns true if any of the env vars for a provider is set non-empty.
+ * @param {ProviderEnv} entry
+ */
+export function hasEnvVar(entry) {
+  return entry.envVars.some((name) => {
+    const v = process.env[name];
+    return typeof v === "string" && v.trim().length > 0;
+  });
+}
+
+/**
+ * Walk the active config and collect the set of providers currently in use
+ * by at least one role.
+ *
+ * @param {Object} config - Karajan config (loaded)
+ * @returns {Set<string>} - set of provider slugs (e.g. "anthropic", "openai")
+ */
+export function collectActiveProviders(config) {
+  const providers = new Set();
+  const roles = config?.roles || {};
+  for (const [, roleCfg] of Object.entries(roles)) {
+    const provider = roleCfg?.provider;
+    if (typeof provider === "string" && provider.trim().length > 0) {
+      providers.add(provider);
+    }
+  }
+  // Also include top-level default coder/reviewer if set (legacy shape).
+  if (config?.coder) providers.add(config.coder);
+  if (config?.reviewer) providers.add(config.reviewer);
+  return providers;
+}
+
+/**
+ * Map active providers to the env vars we must validate.
+ *
+ * @param {Object} config
+ * @returns {ProviderEnv[]}
+ */
+export function getRequiredProviderEnvs(config) {
+  const active = collectActiveProviders(config);
+  const required = [];
+  for (const providerSlug of active) {
+    // Some configs store agent names (claude, codex, gemini) rather than
+    // canonical provider names. Map them.
+    const canonical = normalizeProvider(providerSlug);
+    const entry = PROVIDER_ENV[canonical];
+    if (entry) required.push(entry);
+  }
+  return required;
+}
+
+/**
+ * Normalize CLI/agent name to canonical provider slug.
+ */
+export function normalizeProvider(name) {
+  const lc = String(name || "").toLowerCase();
+  if (lc === "claude" || lc === "anthropic") return "anthropic";
+  if (lc === "codex" || lc === "openai") return "openai";
+  if (lc === "gemini" || lc === "google") return "google";
+  if (lc === "opencode") return "opencode";
+  if (lc === "aider") return "aider";
+  return lc;
+}

--- a/src/utils/with-timeout.js
+++ b/src/utils/with-timeout.js
@@ -1,0 +1,42 @@
+/**
+ * Timeout wrapper for arbitrary promises.
+ *
+ * Produces a new Promise that resolves with the original value if the
+ * underlying promise settles within `ms`, or rejects with a TimeoutError if
+ * it doesn't. Intended for wrapping individual checks in the doctor/preflight
+ * runner so a slow HTTP probe cannot hang the whole pipeline.
+ *
+ * The original promise keeps running after timeout (we cannot cancel it
+ * without cooperation). Callers should avoid calling `withTimeout` on
+ * side-effectful operations they need to be sure completed.
+ */
+
+export class TimeoutError extends Error {
+  constructor(label, ms) {
+    super(`Timeout after ${ms}ms${label ? ` (${label})` : ""}`);
+    this.name = "TimeoutError";
+    this.timeoutMs = ms;
+    this.label = label;
+  }
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} ms
+ * @param {string} [label] - for error messages / logs
+ * @returns {Promise<T>}
+ */
+export function withTimeout(promise, ms, label) {
+  if (!Number.isFinite(ms) || ms <= 0) return promise;
+
+  let timerId;
+  const timeout = new Promise((_resolve, reject) => {
+    timerId = setTimeout(() => reject(new TimeoutError(label, ms)), ms);
+    if (timerId && typeof timerId.unref === "function") timerId.unref();
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timerId) clearTimeout(timerId);
+  });
+}

--- a/tests/checks/auto-remediation-e2e.test.js
+++ b/tests/checks/auto-remediation-e2e.test.js
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { STATUS } from "../../src/checks/types.js";
+
+/**
+ * End-to-end coverage of the auto-remediation flow: each realistic scenario
+ * listed in the implementation plan of KJC-TSK-0319 gets an assertion so we
+ * catch regressions in the detect → remediate → re-verify pipeline.
+ */
+
+vi.mock("../../src/utils/port-check.js", () => ({
+  isPortAvailable: vi.fn(),
+  findAvailablePort: vi.fn(),
+}));
+vi.mock("../../src/utils/port-occupant.js", () => ({
+  getPortOccupant: vi.fn(),
+}));
+vi.mock("../../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+}));
+vi.mock("node:fs/promises", () => ({
+  default: {
+    stat: vi.fn(),
+    mkdir: vi.fn(),
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+  },
+}));
+vi.mock("node:child_process", () => {
+  const { EventEmitter } = require("node:events");
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    }),
+  };
+});
+
+describe("auto-remediation end-to-end", () => {
+  let runChecks, portCheck, portOcc, fsPromises;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ runChecks } = await import("../../src/checks/runner.js"));
+    portCheck = await import("../../src/utils/port-check.js");
+    portOcc = await import("../../src/utils/port-occupant.js");
+    fsPromises = (await import("node:fs/promises")).default;
+  });
+
+  describe("HU Board port rebind", () => {
+    it("port 4000 occupied → auto-fixes by finding next free port and applying override", async () => {
+      portCheck.isPortAvailable.mockImplementation(async (port) => port !== 4000);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 4000, pid: 99, command: "node", raw: "" });
+      portCheck.findAvailablePort.mockResolvedValue(4007);
+
+      const { createHuBoardPortCheck } = await import("../../src/checks/ports.js");
+      const report = await runChecks([createHuBoardPortCheck()], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.FIXED);
+      expect(report.overrides).toEqual({ hu_board: { port: 4007 } });
+    });
+  });
+
+  describe("~/.karajan directory tree", () => {
+    it("missing dirs → auto-created and re-verify succeeds", async () => {
+      // First call (detect): dirs missing. Second call (re-verify): dirs exist.
+      let detectCall = 0;
+      fsPromises.stat.mockImplementation(async () => {
+        detectCall++;
+        if (detectCall <= 4) {
+          const err = new Error("ENOENT");
+          err.code = "ENOENT";
+          throw err;
+        }
+        return { isDirectory: () => true };
+      });
+      fsPromises.mkdir.mockResolvedValue(undefined);
+
+      const { createKarajanDirsCheck } = await import("../../src/checks/dir-setup.js");
+      const report = await runChecks([createKarajanDirsCheck()], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.FIXED);
+      expect(fsPromises.mkdir).toHaveBeenCalled();
+    });
+
+    it("remediation runs but re-verify still sees missing dirs → FAIL", async () => {
+      // Always missing, even after remediate (e.g. permission denied, silent fail).
+      fsPromises.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      fsPromises.mkdir.mockResolvedValue(undefined);
+
+      const { createKarajanDirsCheck } = await import("../../src/checks/dir-setup.js");
+      const report = await runChecks([createKarajanDirsCheck()], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].detail).toContain("re-verify failed");
+    });
+  });
+
+  describe("SonarQube port (manual)", () => {
+    it("port 9000 held by Karajan docker → OK without remediation", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(false);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 9000, pid: 1, command: "docker-proxy", raw: "" });
+
+      const { createSonarPortCheck } = await import("../../src/checks/ports.js");
+      const report = await runChecks([createSonarPortCheck()], {
+        config: { sonarqube: { enabled: true, host: "http://localhost:9000" } },
+      });
+
+      expect(report.checks[0].status).toBe(STATUS.OK);
+    });
+
+    it("port 9000 held by unrelated process → FAIL with occupant detail", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(false);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 9000, pid: 9876, command: "java", raw: "" });
+
+      const { createSonarPortCheck } = await import("../../src/checks/ports.js");
+      const report = await runChecks([createSonarPortCheck()], {
+        config: { sonarqube: { enabled: true, host: "http://localhost:9000" } },
+      });
+
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].detail).toContain("java");
+      expect(report.checks[0].detail).toContain("9876");
+    });
+  });
+
+  describe("Node version manual-only", () => {
+    it("Node 18 → FAIL with upgrade hint, remediation not attempted", async () => {
+      const { createNodeVersionCheck } = await import("../../src/checks/node.js");
+      const check = createNodeVersionCheck({ version: "v18.17.0" });
+      const report = await runChecks([check], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].fix).toContain("nvm install");
+    });
+
+    it("Node 22 → OK", async () => {
+      const { createNodeVersionCheck } = await import("../../src/checks/node.js");
+      const check = createNodeVersionCheck({ version: "v22.0.0" });
+      const report = await runChecks([check], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.OK);
+    });
+  });
+
+  describe("Tokens (manual)", () => {
+    const savedEnv = { ...process.env };
+
+    afterEach(() => {
+      for (const k of Object.keys(process.env)) delete process.env[k];
+      for (const [k, v] of Object.entries(savedEnv)) process.env[k] = v;
+    });
+
+    it("ANTHROPIC_API_KEY missing with active anthropic role → FAIL", async () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      const { getTokenChecks } = await import("../../src/checks/tokens.js");
+      const checks = getTokenChecks({ roles: { coder: { provider: "claude" } } });
+      const anth = checks.find((c) => c.name === "token:anthropic");
+      const report = await runChecks([anth], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].fix).toContain("console.anthropic.com");
+    });
+  });
+
+  describe("OpenSkills CLI", () => {
+    it("missing + skills disabled → SKIPPED", async () => {
+      const { createOpenSkillsCheck } = await import("../../src/checks/skills.js");
+      const check = createOpenSkillsCheck();
+      const report = await runChecks([check], { config: { skills: { enabled: false } } });
+
+      expect(report.checks[0].status).toBe(STATUS.SKIPPED);
+    });
+
+    it("missing with skills enabled → WARN (soft failure, no nag)", async () => {
+      const skillsClient = await import("../../src/skills/openskills-client.js");
+      skillsClient.isOpenSkillsAvailable.mockResolvedValue(false);
+
+      const { createOpenSkillsCheck } = await import("../../src/checks/skills.js");
+      const report = await runChecks([createOpenSkillsCheck()], { config: {} });
+
+      expect(report.checks[0].status).toBe(STATUS.WARN);
+    });
+  });
+
+  describe("check-only mode", () => {
+    it("does not apply any remediation even when auto fixes are available", async () => {
+      fsPromises.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      fsPromises.mkdir.mockResolvedValue(undefined);
+
+      const { createKarajanDirsCheck } = await import("../../src/checks/dir-setup.js");
+      const report = await runChecks([createKarajanDirsCheck()], { config: {} }, { mode: "check-only" });
+
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(fsPromises.mkdir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("timeouts", () => {
+    it("slow detect → TIMEOUT, not FAIL", async () => {
+      const slowCheck = {
+        name: "slow",
+        label: "Slow check",
+        strategy: "auto",
+        detect: () => new Promise(() => {}),
+        remediate: vi.fn(),
+      };
+      const report = await runChecks([slowCheck], { config: {} }, { timeoutMs: 25 });
+      expect(report.checks[0].status).toBe(STATUS.TIMEOUT);
+      expect(slowCheck.remediate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/checks/dir-setup.test.js
+++ b/tests/checks/dir-setup.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    stat: vi.fn(),
+    mkdir: vi.fn(),
+  },
+}));
+
+describe("checks/dir-setup", () => {
+  let mod, fs;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mod = await import("../../src/checks/dir-setup.js");
+    fs = (await import("node:fs/promises")).default;
+  });
+
+  it("passes when all dirs exist", async () => {
+    fs.stat.mockResolvedValue({ isDirectory: () => true });
+    const check = mod.createKarajanDirsCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports missing directories and remediate creates them", async () => {
+    fs.stat.mockImplementation(async (p) => {
+      if (p.endsWith("sessions") || p.endsWith("logs")) {
+        const err = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return { isDirectory: () => true };
+    });
+    const check = mod.createKarajanDirsCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.extra.missing.length).toBe(2);
+
+    fs.mkdir.mockResolvedValue(undefined);
+    const rem = await check.remediate({ extra: result.extra });
+    expect(rem.fixed).toBe(true);
+    expect(fs.mkdir).toHaveBeenCalledTimes(2);
+    expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining("sessions"), { recursive: true });
+    expect(fs.mkdir).toHaveBeenCalledWith(expect.stringContaining("logs"), { recursive: true });
+  });
+
+  it("is marked auto strategy", () => {
+    expect(mod.createKarajanDirsCheck().strategy).toBe("auto");
+  });
+});

--- a/tests/checks/mcp-health.test.js
+++ b/tests/checks/mcp-health.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+const mockSpawn = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args) => mockSpawn(...args),
+}));
+
+vi.mock("../../src/utils/agent-detect.js", () => ({
+  checkBinary: vi.fn(),
+}));
+
+/**
+ * Produce a fake child process that emits a JSON-RPC response after a tick.
+ */
+function fakeChild(options = {}) {
+  const child = new EventEmitter();
+  child.stdin = { write: vi.fn() };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.unref = vi.fn();
+  setImmediate(() => {
+    if (options.response) {
+      child.stdout.emit("data", Buffer.from(options.response));
+    } else if (options.errorOnExit !== undefined) {
+      child.emit("exit", options.errorOnExit);
+    } else if (options.errorOnSpawn) {
+      child.emit("error", options.errorOnSpawn);
+    }
+  });
+  return child;
+}
+
+describe("checks/mcp-health", () => {
+  let mod;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mod = await import("../../src/checks/mcp-health.js");
+  });
+
+  it("karajan-mcp OK when it responds with JSON-RPC result", async () => {
+    mockSpawn.mockImplementation(() =>
+      fakeChild({ response: '{"jsonrpc":"2.0","id":1,"result":{}}\n' })
+    );
+    const check = mod.createKarajanMcpCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("karajan-mcp WARN when the process exits before responding", async () => {
+    mockSpawn.mockImplementation(() => fakeChild({ errorOnExit: 2 }));
+    const check = mod.createKarajanMcpCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("warn");
+  });
+
+  it("karajan-mcp WARN on spawn error", async () => {
+    mockSpawn.mockImplementation(() => {
+      const c = fakeChild();
+      setImmediate(() => c.emit("error", new Error("ENOENT")));
+      return c;
+    });
+    const check = mod.createKarajanMcpCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("warn");
+  });
+
+  it("karajan-mcp remediate re-spawns detached", async () => {
+    const detachedChild = fakeChild();
+    mockSpawn.mockImplementation(() => detachedChild);
+    const check = mod.createKarajanMcpCheck();
+    const rem = await check.remediate({ extra: { binPath: "/x/bin" } });
+    expect(rem.fixed).toBe(true);
+    expect(detachedChild.unref).toHaveBeenCalled();
+  });
+
+  it("serena check applies only when serena is enabled", () => {
+    const check = mod.createSerenaMcpCheck();
+    expect(check.applies({})).toBe(false);
+    expect(check.applies({ serena: { enabled: false } })).toBe(false);
+    expect(check.applies({ serena: { enabled: true } })).toBe(true);
+  });
+});

--- a/tests/checks/node.test.js
+++ b/tests/checks/node.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createNodeVersionCheck, parseNodeVersion, MIN_NODE_MAJOR } from "../../src/checks/node.js";
+
+describe("checks/node-version", () => {
+  it("parseNodeVersion accepts v-prefixed and bare versions", () => {
+    expect(parseNodeVersion("v20.12.1")).toEqual({ major: 20, minor: 12, patch: 1 });
+    expect(parseNodeVersion("22.0.0")).toEqual({ major: 22, minor: 0, patch: 0 });
+    expect(parseNodeVersion("invalid")).toBeNull();
+    expect(parseNodeVersion("")).toBeNull();
+  });
+
+  it("passes for current supported major", async () => {
+    const check = createNodeVersionCheck({ version: `v${MIN_NODE_MAJOR}.0.0` });
+    const result = await check.detect({ config: {} });
+    expect(result.ok).toBe(true);
+  });
+
+  it("fails for Node older than the required major", async () => {
+    const check = createNodeVersionCheck({ version: "v18.17.0" });
+    const result = await check.detect({ config: {} });
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("fail");
+    expect(result.fix).toContain("nvm install");
+    expect(result.extra.detected.major).toBe(18);
+  });
+
+  it("fails cleanly for an unparseable version", async () => {
+    const check = createNodeVersionCheck({ version: "garbage" });
+    const result = await check.detect({ config: {} });
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("Unrecognized");
+  });
+
+  it("is marked manual (cannot auto-fix runtime)", () => {
+    expect(createNodeVersionCheck().strategy).toBe("manual");
+  });
+});

--- a/tests/checks/ports.test.js
+++ b/tests/checks/ports.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/port-check.js", () => ({
+  isPortAvailable: vi.fn(),
+  findAvailablePort: vi.fn(),
+}));
+
+vi.mock("../../src/utils/port-occupant.js", () => ({
+  getPortOccupant: vi.fn(),
+}));
+
+describe("checks/ports", () => {
+  let mod, portCheck, portOcc;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mod = await import("../../src/checks/ports.js");
+    portCheck = await import("../../src/utils/port-check.js");
+    portOcc = await import("../../src/utils/port-occupant.js");
+  });
+
+  describe("sonar port", () => {
+    const config = { sonarqube: { enabled: true, host: "http://localhost:9000" } };
+
+    it("OK when free", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(true);
+      const check = mod.createSonarPortCheck();
+      const result = await check.detect({ config });
+      expect(result.ok).toBe(true);
+    });
+
+    it("OK when held by docker/sonar itself", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(false);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 9000, pid: 123, command: "docker-proxy", raw: "" });
+      const check = mod.createSonarPortCheck();
+      const result = await check.detect({ config });
+      expect(result.ok).toBe(true);
+      expect(result.detail).toContain("Karajan-managed");
+    });
+
+    it("FAIL with occupant details when held by other process", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(false);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 9000, pid: 999, command: "java", raw: "" });
+      const check = mod.createSonarPortCheck();
+      const result = await check.detect({ config });
+      expect(result.ok).toBe(false);
+      expect(result.severity).toBe("fail");
+      expect(result.detail).toContain("java");
+      expect(result.detail).toContain("999");
+      expect(result.extra.port).toBe(9000);
+    });
+
+    it("applies only when Sonar is enabled", () => {
+      const check = mod.createSonarPortCheck();
+      expect(check.applies({ sonarqube: { enabled: false } })).toBe(false);
+      expect(check.applies({ sonarqube: { enabled: true } })).toBe(true);
+    });
+  });
+
+  describe("hu-board port", () => {
+    it("OK when free", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(true);
+      const check = mod.createHuBoardPortCheck();
+      const result = await check.detect({ config: {} });
+      expect(result.ok).toBe(true);
+    });
+
+    it("WARN when busy, and remediate finds next free port", async () => {
+      portCheck.isPortAvailable.mockResolvedValue(false);
+      portOcc.getPortOccupant.mockResolvedValue({ port: 4000, pid: 456, command: "node", raw: "" });
+      portCheck.findAvailablePort.mockResolvedValue(4007);
+      const check = mod.createHuBoardPortCheck();
+      const detect = await check.detect({ config: {} });
+      expect(detect.ok).toBe(false);
+      expect(detect.severity).toBe("warn");
+      const rem = await check.remediate({ extra: detect.extra });
+      expect(rem.fixed).toBe(true);
+      expect(rem.changes.hu_board.port).toBe(4007);
+      expect(portCheck.findAvailablePort).toHaveBeenCalledWith(4001, 20);
+    });
+  });
+});

--- a/tests/checks/runner.test.js
+++ b/tests/checks/runner.test.js
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import { runChecks, toLegacyShape } from "../../src/checks/runner.js";
+import { STATUS, STRATEGY } from "../../src/checks/types.js";
+
+function makeCheck(overrides = {}) {
+  return {
+    name: "test-check",
+    label: "Test",
+    strategy: STRATEGY.AUTO,
+    detect: vi.fn(async () => ({ ok: true, severity: "info", detail: "OK" })),
+    ...overrides,
+  };
+}
+
+describe("checks/runner", () => {
+  describe("detect phase", () => {
+    it("runs detect in parallel and returns OK status for passing checks", async () => {
+      const c1 = makeCheck({ name: "a" });
+      const c2 = makeCheck({ name: "b" });
+      const report = await runChecks([c1, c2], { config: {} });
+      expect(report.checks).toHaveLength(2);
+      expect(report.summary.ok).toBe(2);
+      expect(c1.detect).toHaveBeenCalledOnce();
+      expect(c2.detect).toHaveBeenCalledOnce();
+    });
+
+    it("marks checks as SKIPPED when applies returns false", async () => {
+      const c = makeCheck({ applies: () => false });
+      const report = await runChecks([c], { config: {} });
+      expect(report.checks[0].status).toBe(STATUS.SKIPPED);
+      expect(c.detect).not.toHaveBeenCalled();
+    });
+
+    it("catches thrown errors in detect and marks as FAIL", async () => {
+      const c = makeCheck({
+        detect: vi.fn(async () => {
+          throw new Error("boom");
+        }),
+      });
+      const report = await runChecks([c], { config: {} });
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].detail).toContain("boom");
+    });
+
+    it("marks slow detects as TIMEOUT", async () => {
+      const c = makeCheck({
+        detect: () => new Promise(() => {}),
+      });
+      const report = await runChecks([c], { config: {} }, { timeoutMs: 25 });
+      expect(report.checks[0].status).toBe(STATUS.TIMEOUT);
+    });
+
+    it("WARN + AUTO still remediates (non-invasive fixes apply even for soft failures)", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "warn", detail: "soft" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "fixed" })),
+      });
+      c.detect.mockImplementationOnce(async () => ({ ok: false, severity: "warn", detail: "soft" }))
+        .mockImplementation(async () => ({ ok: true, severity: "info", detail: "ok" }));
+      const report = await runChecks([c], { config: {} });
+      expect(c.remediate).toHaveBeenCalled();
+      expect(report.checks[0].status).toBe(STATUS.FIXED);
+    });
+  });
+
+  describe("remediate phase", () => {
+    it("FIXED when remediate succeeds and re-verify passes", async () => {
+      let detectCall = 0;
+      const c = makeCheck({
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => {
+          detectCall++;
+          return detectCall === 1
+            ? { ok: false, severity: "fail", detail: "busy" }
+            : { ok: true, severity: "info", detail: "ok" };
+        }),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "remedied" })),
+      });
+      const report = await runChecks([c], { config: {} });
+      expect(report.checks[0].status).toBe(STATUS.FIXED);
+      expect(c.remediate).toHaveBeenCalledOnce();
+      expect(c.detect).toHaveBeenCalledTimes(2); // detect + re-verify
+    });
+
+    it("FAIL when remediate returns fixed:false", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "busy" })),
+        remediate: vi.fn(async () => ({ fixed: false, detail: "could not" })),
+      });
+      const report = await runChecks([c], { config: {} });
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].detail).toBe("could not");
+    });
+
+    it("FAIL when remediation succeeds but re-verify still fails", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "busy" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "did something" })),
+      });
+      const report = await runChecks([c], { config: {} });
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+      expect(report.checks[0].detail).toContain("re-verify failed");
+    });
+
+    it("does not remediate manual-strategy checks", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.MANUAL,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "missing" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "nope" })),
+      });
+      const report = await runChecks([c], { config: {} });
+      expect(c.remediate).not.toHaveBeenCalled();
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+    });
+
+    it("merges remediation `changes` into runReport.overrides (deep-merge)", async () => {
+      const c1 = makeCheck({
+        name: "c1",
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "busy" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "done", changes: { hu_board: { port: 4007 } } })),
+      });
+      const c2 = makeCheck({
+        name: "c2",
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "busy" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "done", changes: { hu_board: { host: "0.0.0.0" } } })),
+      });
+      // Make both re-verifies pass
+      c1.detect.mockImplementationOnce(async () => ({ ok: false, severity: "fail", detail: "busy" }))
+        .mockImplementation(async () => ({ ok: true, severity: "info", detail: "ok" }));
+      c2.detect.mockImplementationOnce(async () => ({ ok: false, severity: "fail", detail: "busy" }))
+        .mockImplementation(async () => ({ ok: true, severity: "info", detail: "ok" }));
+      const report = await runChecks([c1, c2], { config: {} });
+      expect(report.overrides.hu_board).toEqual({ port: 4007, host: "0.0.0.0" });
+    });
+
+    it("respects check-only mode (no remediation attempted)", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.AUTO,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "busy" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "would fix" })),
+      });
+      const report = await runChecks([c], { config: {} }, { mode: "check-only" });
+      expect(c.remediate).not.toHaveBeenCalled();
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+    });
+
+    it("WARN + PROMPT does not nag the user (soft failures don't prompt)", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.PROMPT,
+        describe: "Install X",
+        detect: vi.fn(async () => ({ ok: false, severity: "warn", detail: "missing" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "installed" })),
+      });
+      const onConfirm = vi.fn(async () => false);
+      const report = await runChecks([c], { config: {} }, { onConfirm });
+      expect(c.remediate).not.toHaveBeenCalled();
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(report.checks[0].status).toBe(STATUS.WARN);
+    });
+
+    it("FAIL + PROMPT declined by user stays FAIL (remediate not called)", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.PROMPT,
+        describe: "Install X",
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "missing" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "installed" })),
+      });
+      const onConfirm = vi.fn(async () => false);
+      const report = await runChecks([c], { config: {} }, { onConfirm });
+      expect(onConfirm).toHaveBeenCalledOnce();
+      expect(c.remediate).not.toHaveBeenCalled();
+      expect(report.checks[0].status).toBe(STATUS.FAIL);
+    });
+
+    it("PROMPT-strategy FAIL check auto-confirmed by yes:true calls remediate", async () => {
+      const c = makeCheck({
+        strategy: STRATEGY.PROMPT,
+        detect: vi.fn(async () => ({ ok: false, severity: "fail", detail: "missing" })),
+        remediate: vi.fn(async () => ({ fixed: true, detail: "installed" })),
+      });
+      c.detect.mockImplementationOnce(async () => ({ ok: false, severity: "fail", detail: "missing" }))
+        .mockImplementation(async () => ({ ok: true, severity: "info", detail: "ok" }));
+      const report = await runChecks([c], { config: {} }, { yes: true });
+      expect(c.remediate).toHaveBeenCalledOnce();
+      expect(report.checks[0].status).toBe(STATUS.FIXED);
+    });
+  });
+
+  describe("toLegacyShape", () => {
+    it("maps FIXED/OK/SKIPPED to ok:true", async () => {
+      const report = { checks: [
+        { name: "a", label: "A", status: STATUS.OK, detail: "" },
+        { name: "b", label: "B", status: STATUS.FIXED, detail: "" },
+        { name: "c", label: "C", status: STATUS.SKIPPED, detail: "" },
+      ] };
+      const legacy = toLegacyShape(report);
+      expect(legacy.every((c) => c.ok)).toBe(true);
+    });
+
+    it("maps FAIL/WARN/TIMEOUT to ok:false", async () => {
+      const report = { checks: [
+        { name: "a", label: "A", status: STATUS.FAIL, detail: "" },
+        { name: "b", label: "B", status: STATUS.WARN, detail: "" },
+        { name: "c", label: "C", status: STATUS.TIMEOUT, detail: "" },
+      ] };
+      const legacy = toLegacyShape(report);
+      expect(legacy.every((c) => !c.ok)).toBe(true);
+    });
+  });
+});

--- a/tests/checks/skills.test.js
+++ b/tests/checks/skills.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+}));
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
+
+describe("checks/skills", () => {
+  let mod, client, proc;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    mod = await import("../../src/checks/skills.js");
+    client = await import("../../src/skills/openskills-client.js");
+    proc = await import("../../src/utils/process.js");
+  });
+
+  it("passes when openskills CLI is available", async () => {
+    client.isOpenSkillsAvailable.mockResolvedValue(true);
+    const check = mod.createOpenSkillsCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("warns (not fail) when openskills CLI is missing", async () => {
+    client.isOpenSkillsAvailable.mockResolvedValue(false);
+    const check = mod.createOpenSkillsCheck();
+    const result = await check.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("warn");
+    expect(result.fix).toContain("npm install -g openskills");
+  });
+
+  it("remediate reports success when npm install exits 0", async () => {
+    proc.runCommand.mockResolvedValue({ exitCode: 0, stdout: "added 5 packages", stderr: "" });
+    const check = mod.createOpenSkillsCheck();
+    const rem = await check.remediate({});
+    expect(rem.fixed).toBe(true);
+    expect(proc.runCommand).toHaveBeenCalledWith("npm", ["install", "-g", "openskills"], expect.anything());
+  });
+
+  it("remediate reports failure when npm install errors", async () => {
+    proc.runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "EACCES: permission denied" });
+    const check = mod.createOpenSkillsCheck();
+    const rem = await check.remediate({});
+    expect(rem.fixed).toBe(false);
+    expect(rem.detail).toContain("EACCES");
+  });
+
+  it("applies only when skills are enabled", () => {
+    const check = mod.createOpenSkillsCheck();
+    expect(check.applies({})).toBe(true); // default enabled
+    expect(check.applies({ skills: { enabled: false } })).toBe(false);
+    expect(check.applies({ skills: { enabled: true } })).toBe(true);
+  });
+});

--- a/tests/checks/tokens.test.js
+++ b/tests/checks/tokens.test.js
@@ -14,6 +14,8 @@ describe("checks/tokens", () => {
     delete process.env.OPENAI_API_KEY;
     delete process.env.GEMINI_API_KEY;
     delete process.env.GOOGLE_API_KEY;
+    delete process.env.OPENCODE_API_KEY;
+    delete process.env.AIDER_API_KEY;
     delete process.env.GH_TOKEN;
     delete process.env.GITHUB_TOKEN;
     mod = await import("../../src/checks/tokens.js");

--- a/tests/checks/tokens.test.js
+++ b/tests/checks/tokens.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../../src/utils/agent-detect.js", () => ({
+  checkBinary: vi.fn(),
+}));
+
+describe("checks/tokens", () => {
+  let mod, agentDetect;
+  const savedEnv = { ...process.env };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.GH_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    mod = await import("../../src/checks/tokens.js");
+    agentDetect = await import("../../src/utils/agent-detect.js");
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    for (const [k, v] of Object.entries(savedEnv)) process.env[k] = v;
+  });
+
+  it("emits one check per active provider", () => {
+    const checks = mod.getTokenChecks({
+      roles: { coder: { provider: "claude" }, reviewer: { provider: "openai" } },
+    });
+    const names = checks.map((c) => c.name);
+    expect(names).toContain("token:anthropic");
+    expect(names).toContain("token:openai");
+    expect(names).toContain("token:gh"); // always present
+  });
+
+  it("skips inactive providers", () => {
+    const checks = mod.getTokenChecks({ roles: { coder: { provider: "claude" } } });
+    const names = checks.map((c) => c.name);
+    expect(names).not.toContain("token:openai");
+  });
+
+  it("provider check passes when env var is set", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-xxx";
+    const checks = mod.getTokenChecks({ roles: { coder: { provider: "claude" } } });
+    const anth = checks.find((c) => c.name === "token:anthropic");
+    const result = await anth.detect({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("provider check fails with helpful fix when env var missing", async () => {
+    const checks = mod.getTokenChecks({ roles: { coder: { provider: "claude" } } });
+    const anth = checks.find((c) => c.name === "token:anthropic");
+    const result = await anth.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("fail");
+    expect(result.fix).toContain("console.anthropic.com");
+    expect(result.fix).toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("optional providers warn instead of fail", async () => {
+    const checks = mod.getTokenChecks({ roles: { coder: { provider: "opencode" } } });
+    const oc = checks.find((c) => c.name === "token:opencode");
+    const result = await oc.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.severity).toBe("warn");
+  });
+
+  it("gh token check applies only when auto_pr is on", () => {
+    const checks = mod.getTokenChecks({ roles: { coder: { provider: "claude" } } });
+    const gh = checks.find((c) => c.name === "token:gh");
+    expect(gh.applies({ git: { auto_pr: true } })).toBe(true);
+    expect(gh.applies({ git: { auto_pr: false } })).toBe(false);
+    expect(gh.applies({})).toBe(false);
+  });
+
+  it("gh token: OK when GH_TOKEN set", async () => {
+    process.env.GH_TOKEN = "ghp_xxx";
+    const checks = mod.getTokenChecks({});
+    const gh = checks.find((c) => c.name === "token:gh");
+    const result = await gh.detect({});
+    expect(result.ok).toBe(true);
+  });
+
+  it("gh token: FAIL with 'install gh' hint when CLI missing", async () => {
+    agentDetect.checkBinary.mockResolvedValue({ ok: false });
+    const checks = mod.getTokenChecks({});
+    const gh = checks.find((c) => c.name === "token:gh");
+    const result = await gh.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.fix).toContain("cli.github.com");
+  });
+
+  it("gh token: FAIL with 'gh auth login' hint when CLI present", async () => {
+    agentDetect.checkBinary.mockResolvedValue({ ok: true, version: "2.50.0" });
+    const checks = mod.getTokenChecks({});
+    const gh = checks.find((c) => c.name === "token:gh");
+    const result = await gh.detect({});
+    expect(result.ok).toBe(false);
+    expect(result.fix).toContain("gh auth login");
+  });
+});

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -37,8 +37,43 @@ vi.mock("../src/utils/git.js", () => ({
 vi.mock("node:fs/promises", () => ({
   default: {
     readFile: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
-    access: vi.fn().mockResolvedValue(undefined)
+    access: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ isDirectory: () => true }),
+    mkdir: vi.fn().mockResolvedValue(undefined)
   }
+}));
+
+// Stub spawn so mcp-health check doesn't actually fork `node bin/karajan-mcp.js`
+// during unit runs. A minimal fake emits a JSON-RPC result so the check passes.
+vi.mock("node:child_process", () => {
+  const { EventEmitter } = require("node:events");
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n'));
+      });
+      return child;
+    })
+  };
+});
+
+vi.mock("../src/utils/port-check.js", () => ({
+  isPortAvailable: vi.fn().mockResolvedValue(true),
+  findAvailablePort: vi.fn().mockResolvedValue(4001)
+}));
+
+vi.mock("../src/utils/port-occupant.js", () => ({
+  getPortOccupant: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn().mockResolvedValue(true)
 }));
 
 const baseConfig = {
@@ -71,6 +106,26 @@ describe("doctor", () => {
     // Agent config files: simulate ENOENT (not found) so checks are skipped
     const fsPromises = await import("node:fs/promises");
     fsPromises.default.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    fsPromises.default.stat.mockResolvedValue({ isDirectory: () => true });
+
+    const { isPortAvailable } = await import("../src/utils/port-check.js");
+    isPortAvailable.mockResolvedValue(true);
+
+    const { isOpenSkillsAvailable } = await import("../src/skills/openskills-client.js");
+    isOpenSkillsAvailable.mockResolvedValue(true);
+
+    const cp = await import("node:child_process");
+    cp.spawn.mockImplementation(() => {
+      const { EventEmitter } = require("node:events");
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    });
 
     const mod = await import("../src/commands/doctor.js");
     runChecks = mod.runChecks;

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -230,9 +230,9 @@ describe("doctor", () => {
   });
 
   describe("doctorCommand", () => {
-    it("returns check results", async () => {
-      const checks = await doctorCommand({ config: baseConfig });
-      expect(Array.isArray(checks)).toBe(true);
+    it("returns 0 when all checks pass", async () => {
+      const exitCode = await doctorCommand({ config: baseConfig });
+      expect(exitCode).toBe(0);
     });
 
     it("prints fix suggestions for failed checks", async () => {
@@ -263,6 +263,51 @@ describe("doctor", () => {
 
       const output = console.log.mock.calls.map((c) => c[0]).join("\n");
       expect(output).toMatch(/\d+ issue/);
+    });
+
+    it("returns 1 when any check fails", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false);
+      const { isSonarReachable } = await import("../src/sonar/manager.js");
+      isSonarReachable.mockResolvedValue(false);
+
+      const exitCode = await doctorCommand({ config: baseConfig });
+      expect(exitCode).toBe(1);
+    });
+
+    it("emits JSON when --json flag is set", async () => {
+      await doctorCommand({ config: baseConfig, json: true });
+
+      const calls = console.log.mock.calls.map((c) => c[0]);
+      // JSON output prints a single blob; parse it to validate shape.
+      const jsonCall = calls.find((c) => typeof c === "string" && c.trim().startsWith("{"));
+      expect(jsonCall).toBeTruthy();
+      const parsed = JSON.parse(jsonCall);
+      expect(parsed).toHaveProperty("checks");
+      expect(parsed).toHaveProperty("summary");
+      expect(parsed).toHaveProperty("overrides");
+    });
+
+    it("verbose mode prints fix hints and runMs per check", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false);
+
+      await doctorCommand({ config: baseConfig, verbose: true });
+
+      const output = console.log.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("ms, strategy=");
+    });
+
+    it("check-only mode does not invoke any remediate function", async () => {
+      const { exists } = await import("../src/utils/fs.js");
+      exists.mockResolvedValue(false); // force failures
+
+      const exitCode = await doctorCommand({ config: baseConfig, checkOnly: true });
+      // still 1 because no fixes applied
+      expect(exitCode).toBe(1);
+      // and no "FIXED" label in output
+      const output = console.log.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).not.toMatch(/\bFIXED\b/);
     });
   });
 });

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 /**
  * E2E integration test: kj init → produces valid config → kj doctor reports all OK.
@@ -17,9 +17,46 @@ vi.mock("node:fs/promises", () => ({
     appendFile: vi.fn(async (p, content) => {
       const existing = writtenFiles.get(p) || "";
       writtenFiles.set(p, existing + content);
-    })
+    }),
+    // dir-setup check stats the home dir tree; treat all as existing dirs.
+    stat: vi.fn().mockResolvedValue({ isDirectory: () => true }),
+    mkdir: vi.fn().mockResolvedValue(undefined)
   }
 }));
+
+// dir-setup uses os.homedir() + path.join. Don't need to mock those.
+// But the default vi.resetAllMocks in beforeEach wipes the stat mock;
+// we restore it there below.
+
+// Additional mocks for the new doctor checks (commit 3 of KJC-TSK-0319):
+vi.mock("../src/utils/port-check.js", () => ({
+  isPortAvailable: vi.fn().mockResolvedValue(true),
+  findAvailablePort: vi.fn().mockResolvedValue(4001)
+}));
+
+vi.mock("../src/utils/port-occupant.js", () => ({
+  getPortOccupant: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock("node:child_process", () => {
+  const { EventEmitter } = require("node:events");
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    })
+  };
+});
 
 vi.mock("../src/utils/fs.js", () => ({
   exists: vi.fn(async (p) => writtenFiles.has(p)),
@@ -89,9 +126,16 @@ describe("installer E2E: init → doctor", () => {
     debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()
   };
 
+  const savedEnv = { ...process.env };
+
   beforeEach(async () => {
     vi.resetAllMocks();
     writtenFiles.clear();
+
+    // Token checks require the env vars of active providers to be set.
+    // The test uses providers claude (anthropic) and codex (openai).
+    process.env.ANTHROPIC_API_KEY = "sk-test-installer";
+    process.env.OPENAI_API_KEY = "sk-test-installer";
 
     // Re-setup mocks cleared by resetAllMocks
     const { exists, ensureDir } = await import("../src/utils/fs.js");
@@ -120,10 +164,35 @@ describe("installer E2E: init → doctor", () => {
 
     const fsPromises = (await import("node:fs/promises")).default;
     fsPromises.writeFile.mockImplementation(async (p, content) => { writtenFiles.set(p, content); });
+    fsPromises.stat.mockResolvedValue({ isDirectory: () => true });
+    fsPromises.mkdir.mockResolvedValue(undefined);
+
+    // Re-setup mocks introduced by commit 3 of KJC-TSK-0319
+    const { isPortAvailable } = await import("../src/utils/port-check.js");
+    isPortAvailable.mockResolvedValue(true);
+    const { isOpenSkillsAvailable } = await import("../src/skills/openskills-client.js");
+    isOpenSkillsAvailable.mockResolvedValue(true);
+    const cp = await import("node:child_process");
+    cp.spawn.mockImplementation(() => {
+      const { EventEmitter } = require("node:events");
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    });
     fsPromises.readFile.mockImplementation(async (p) => {
       if (writtenFiles.has(p)) return writtenFiles.get(p);
       throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     });
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    for (const [k, v] of Object.entries(savedEnv)) process.env[k] = v;
   });
 
   it("init creates config that passes doctor checks", async () => {

--- a/tests/mcp-server-handlers.test.js
+++ b/tests/mcp-server-handlers.test.js
@@ -386,7 +386,16 @@ describe("mcp/server-handlers", () => {
 
     it("routes kj_doctor to runKjCommand", async () => {
       await handleToolCall("kj_doctor", {}, mockServer, {});
-      expect(runKjCommand).toHaveBeenCalledWith({ command: "doctor", options: {} });
+      expect(runKjCommand).toHaveBeenCalledWith({ command: "doctor", commandArgs: [], options: {} });
+    });
+
+    it("forwards kj_doctor flags as CLI args", async () => {
+      await handleToolCall("kj_doctor", { checkOnly: true, yes: true, json: true, verbose: true }, mockServer, {});
+      expect(runKjCommand).toHaveBeenCalledWith({
+        command: "doctor",
+        commandArgs: ["--check-only", "--yes", "--json", "--verbose"],
+        options: { checkOnly: true, yes: true, json: true, verbose: true },
+      });
     });
 
     it("routes kj_config with json flag", async () => {
@@ -594,7 +603,7 @@ describe("mcp/server-handlers", () => {
 
     it("handles undefined args", async () => {
       await handleToolCall("kj_doctor", undefined, mockServer, {});
-      expect(runKjCommand).toHaveBeenCalledWith({ command: "doctor", options: {} });
+      expect(runKjCommand).toHaveBeenCalledWith({ command: "doctor", commandArgs: [], options: {} });
     });
   });
 

--- a/tests/preflight-checks.test.js
+++ b/tests/preflight-checks.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../src/utils/agent-detect.js", () => ({
   checkBinary: vi.fn()
@@ -21,11 +21,55 @@ vi.mock("../src/sonar/credentials.js", () => ({
   loadSonarCredentials: vi.fn().mockResolvedValue({ user: "admin", password: "testpass" })
 }));
 
+// Commit 6 of KJC-TSK-0319: preflight now also runs doctor-style extended
+// checks. Stub their IO so the existing tests keep their Sonar/security
+// focus without accidentally failing on unrelated environment issues.
+vi.mock("../src/utils/port-check.js", () => ({
+  isPortAvailable: vi.fn().mockResolvedValue(true),
+  findAvailablePort: vi.fn().mockResolvedValue(4001)
+}));
+
+vi.mock("../src/utils/port-occupant.js", () => ({
+  getPortOccupant: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock("../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn().mockResolvedValue(true)
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    stat: vi.fn().mockResolvedValue({ isDirectory: () => true }),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    access: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
+vi.mock("node:child_process", () => {
+  const { EventEmitter } = require("node:events");
+  return {
+    spawn: vi.fn(() => {
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    })
+  };
+});
+
 describe("preflight-checks", () => {
   let runPreflightChecks;
   let checkBinary, isSonarReachable, sonarUp, runCommand;
   let logger, emitter, eventBase;
   const emittedEvents = [];
+
+  const savedEnv = { ...process.env };
 
   beforeEach(async () => {
     vi.resetAllMocks();
@@ -33,6 +77,9 @@ describe("preflight-checks", () => {
     delete process.env.SONAR_TOKEN;
     delete process.env.KJ_SONAR_ADMIN_USER;
     delete process.env.KJ_SONAR_ADMIN_PASSWORD;
+
+    // Satisfy the token check for active providers used by makeConfig().
+    process.env.ANTHROPIC_API_KEY = "sk-test-preflight";
 
     emittedEvents.length = 0;
 
@@ -53,8 +100,40 @@ describe("preflight-checks", () => {
     emitter = { emit: vi.fn((_event, data) => emittedEvents.push(data)) };
     eventBase = { sessionId: "test-session", iteration: 0, stage: null, startedAt: Date.now() };
 
+    // Restore default happy-path mocks for the extended checks (they were
+    // reset by vi.resetAllMocks).
+    const portCheck = await import("../src/utils/port-check.js");
+    portCheck.isPortAvailable.mockResolvedValue(true);
+    portCheck.findAvailablePort.mockResolvedValue(4001);
+
+    const skillsClient = await import("../src/skills/openskills-client.js");
+    skillsClient.isOpenSkillsAvailable.mockResolvedValue(true);
+
+    const fsPromises = (await import("node:fs/promises")).default;
+    fsPromises.stat.mockResolvedValue({ isDirectory: () => true });
+    fsPromises.mkdir.mockResolvedValue(undefined);
+    fsPromises.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    const cp = await import("node:child_process");
+    cp.spawn.mockImplementation(() => {
+      const { EventEmitter } = require("node:events");
+      const child = new EventEmitter();
+      child.stdin = { write: vi.fn() };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = vi.fn();
+      child.unref = vi.fn();
+      setImmediate(() => child.stdout.emit("data", Buffer.from('{"jsonrpc":"2.0","id":1,"result":{}}\n')));
+      return child;
+    });
+
     const mod = await import("../src/orchestrator/preflight-checks.js");
     runPreflightChecks = mod.runPreflightChecks;
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    for (const [k, v] of Object.entries(savedEnv)) process.env[k] = v;
   });
 
   function makeConfig(overrides = {}) {
@@ -62,11 +141,15 @@ describe("preflight-checks", () => {
       sonarqube: { enabled: true, host: "http://localhost:9000", ...overrides.sonarqube },
       roles: { security: { provider: "claude" }, coder: { provider: "claude" }, ...overrides.roles },
       coder: "claude",
+      // The test suite globally defaults extended preflight OFF (see
+      // tests/setup.js). The preflight-checks test explicitly wants the
+      // extended checks to run so we can assert their behavior.
+      preflight: { extended: true, ...overrides.preflight },
       ...overrides,
     };
   }
 
-  it("skips all checks when sonar and security are both disabled", async () => {
+  it("runs only extended (doctor-style) checks when sonar and security are both disabled", async () => {
     const config = makeConfig({ sonarqube: { enabled: false } });
     const result = await runPreflightChecks({
       config, logger, emitter, eventBase,
@@ -74,7 +157,13 @@ describe("preflight-checks", () => {
       securityEnabled: false,
     });
     expect(result.ok).toBe(true);
-    expect(result.checks).toHaveLength(0);
+    // No Sonar/docker/security entries, but extended checks are still present.
+    const names = result.checks.map((c) => c.name);
+    expect(names).not.toContain("docker");
+    expect(names).not.toContain("sonar-reachable");
+    expect(names).not.toContain("security-agent");
+    expect(names).toContain("node-version");
+    // Happy-path default mocks should keep things green.
     expect(result.warnings).toHaveLength(0);
   });
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,26 @@
+/**
+ * Global Vitest setup. Applied to every test file via vitest.config.js
+ * `setupFiles`.
+ *
+ * Two effects:
+ *
+ * 1) Preload API-key env vars so the token checks in the extended preflight
+ *    don't fail for providers that orchestrator tests happen to reference
+ *    (claude, codex, gemini…) without caring about real credentials.
+ *    Individual tests that want to assert missing-key behavior can
+ *    `delete process.env.XXX` in their own setup.
+ *
+ * 2) Default the extended preflight to OFF under Vitest. Orchestrator tests
+ *    don't mock the new IO surfaces (port-check, fs.stat, spawn, openskills
+ *    CLI) so running extended preflight against a real machine causes flaky
+ *    failures. Tests that explicitly exercise the extended preflight set
+ *    `config.preflight.extended: true` or override the global.
+ */
+
+process.env.ANTHROPIC_API_KEY ??= "sk-test-anthropic";
+process.env.OPENAI_API_KEY ??= "sk-test-openai";
+process.env.GEMINI_API_KEY ??= "sk-test-gemini";
+process.env.GOOGLE_API_KEY ??= "sk-test-google";
+process.env.OPENCODE_API_KEY ??= "sk-test-opencode";
+
+globalThis.__KJ_DEFAULT_PREFLIGHT_EXTENDED = false;

--- a/tests/utils-port-check.test.js
+++ b/tests/utils-port-check.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { createServer } from "node:net";
+import { isPortAvailable, findAvailablePort } from "../src/utils/port-check.js";
+
+describe("utils/port-check", () => {
+  const openServers = [];
+
+  afterEach(async () => {
+    for (const s of openServers) {
+      await new Promise((resolve) => s.close(resolve));
+    }
+    openServers.length = 0;
+  });
+
+  async function occupy(port) {
+    return new Promise((resolve, reject) => {
+      const s = createServer();
+      s.once("error", reject);
+      s.listen(port, () => {
+        openServers.push(s);
+        resolve(s);
+      });
+    });
+  }
+
+  it("reports a free port as available", async () => {
+    // Pick a port likely free by asking the OS; then verify it's available.
+    const probe = await new Promise((resolve, reject) => {
+      const s = createServer();
+      s.once("error", reject);
+      s.listen(0, () => {
+        const { port } = s.address();
+        s.close(() => resolve(port));
+      });
+    });
+    expect(await isPortAvailable(probe)).toBe(true);
+  });
+
+  it("reports a busy port as unavailable", async () => {
+    const server = await occupy(0);
+    const { port } = server.address();
+    expect(await isPortAvailable(port)).toBe(false);
+  });
+
+  it("findAvailablePort returns the same port when free", async () => {
+    const probe = await new Promise((resolve) => {
+      const s = createServer();
+      s.listen(0, () => {
+        const { port } = s.address();
+        s.close(() => resolve(port));
+      });
+    });
+    expect(await findAvailablePort(probe)).toBe(probe);
+  });
+
+  it("findAvailablePort skips busy ports and returns next free", async () => {
+    // Occupy two consecutive ports
+    const s1 = await occupy(0);
+    const port = s1.address().port;
+    const s2 = await occupy(port + 1).catch(() => null);
+    const onBusy = [];
+    const found = await findAvailablePort(port, 10, (p) => onBusy.push(p));
+    expect(found).toBeGreaterThan(port);
+    expect(onBusy).toContain(port);
+    if (s2) expect(onBusy).toContain(port + 1);
+  });
+
+  it("findAvailablePort throws when no port is free in the range", async () => {
+    const s = await occupy(0);
+    const port = s.address().port;
+    await expect(findAvailablePort(port, 1)).rejects.toThrow(/No available port/);
+  });
+});

--- a/tests/utils-port-occupant.test.js
+++ b/tests/utils-port-occupant.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
+
+describe("utils/port-occupant", () => {
+  let getPortOccupant, runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ getPortOccupant } = await import("../src/utils/port-occupant.js"));
+    ({ runCommand } = await import("../src/utils/process.js"));
+  });
+
+  it("parses lsof -Fpcn output into pid + command", async () => {
+    if (process.platform === "win32") return; // skip on Windows
+    runCommand.mockResolvedValue({
+      exitCode: 0,
+      stdout: "p12345\ncnode\nn*:4000",
+      stderr: "",
+    });
+    const occ = await getPortOccupant(4000);
+    expect(occ).not.toBeNull();
+    expect(occ.pid).toBe(12345);
+    expect(occ.command).toBe("node");
+    expect(occ.port).toBe(4000);
+  });
+
+  it("returns null when lsof and ss both produce no output", async () => {
+    if (process.platform === "win32") return;
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    const occ = await getPortOccupant(4000);
+    expect(occ).toBeNull();
+  });
+
+  it("falls back to ss parsing when lsof returns nothing", async () => {
+    if (process.platform === "win32") return;
+    runCommand.mockImplementation((cmd) => {
+      if (cmd === "lsof") return Promise.resolve({ exitCode: 1, stdout: "", stderr: "" });
+      return Promise.resolve({
+        exitCode: 0,
+        stdout: 'LISTEN 0 511 0.0.0.0:4000 0.0.0.0:* users:(("node",pid=54321,fd=20))',
+        stderr: "",
+      });
+    });
+    const occ = await getPortOccupant(4000);
+    expect(occ).not.toBeNull();
+    expect(occ.pid).toBe(54321);
+    expect(occ.command).toBe("node");
+  });
+
+  it("never throws on unexpected errors (best-effort)", async () => {
+    if (process.platform === "win32") return;
+    runCommand.mockRejectedValue(new Error("boom"));
+    const occ = await getPortOccupant(4000);
+    expect(occ).toBeNull();
+  });
+});

--- a/tests/utils-provider-env.test.js
+++ b/tests/utils-provider-env.test.js
@@ -1,0 +1,116 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  PROVIDER_ENV,
+  hasEnvVar,
+  collectActiveProviders,
+  getRequiredProviderEnvs,
+  normalizeProvider,
+} from "../src/utils/provider-env.js";
+
+describe("utils/provider-env", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.OPENCODE_API_KEY;
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) delete process.env[k];
+    for (const [k, v] of Object.entries(savedEnv)) process.env[k] = v;
+  });
+
+  describe("normalizeProvider", () => {
+    it("maps CLI names to canonical provider slugs", () => {
+      expect(normalizeProvider("claude")).toBe("anthropic");
+      expect(normalizeProvider("codex")).toBe("openai");
+      expect(normalizeProvider("gemini")).toBe("google");
+      expect(normalizeProvider("opencode")).toBe("opencode");
+      expect(normalizeProvider("aider")).toBe("aider");
+    });
+
+    it("returns canonical names untouched", () => {
+      expect(normalizeProvider("anthropic")).toBe("anthropic");
+      expect(normalizeProvider("openai")).toBe("openai");
+      expect(normalizeProvider("google")).toBe("google");
+    });
+
+    it("handles empty/null input", () => {
+      expect(normalizeProvider(null)).toBe("");
+      expect(normalizeProvider(undefined)).toBe("");
+      expect(normalizeProvider("")).toBe("");
+    });
+  });
+
+  describe("hasEnvVar", () => {
+    it("returns true when any listed env var is non-empty", () => {
+      process.env.OPENAI_API_KEY = "sk-xxx";
+      expect(hasEnvVar(PROVIDER_ENV.openai)).toBe(true);
+    });
+
+    it("returns true when any of multiple fallback names is set", () => {
+      process.env.GOOGLE_API_KEY = "xxx";
+      expect(hasEnvVar(PROVIDER_ENV.google)).toBe(true);
+    });
+
+    it("returns false for missing", () => {
+      expect(hasEnvVar(PROVIDER_ENV.anthropic)).toBe(false);
+    });
+
+    it("returns false for whitespace-only value", () => {
+      process.env.ANTHROPIC_API_KEY = "   ";
+      expect(hasEnvVar(PROVIDER_ENV.anthropic)).toBe(false);
+    });
+  });
+
+  describe("collectActiveProviders", () => {
+    it("pulls providers from roles", () => {
+      const config = {
+        roles: {
+          coder: { provider: "anthropic" },
+          reviewer: { provider: "openai" },
+          planner: { provider: null },
+        },
+      };
+      const active = collectActiveProviders(config);
+      expect(active.has("anthropic")).toBe(true);
+      expect(active.has("openai")).toBe(true);
+      expect(active.size).toBe(2);
+    });
+
+    it("also includes top-level coder/reviewer", () => {
+      const config = { coder: "claude", reviewer: "codex", roles: {} };
+      const active = collectActiveProviders(config);
+      expect(active.has("claude")).toBe(true);
+      expect(active.has("codex")).toBe(true);
+    });
+
+    it("handles missing config gracefully", () => {
+      expect(collectActiveProviders({}).size).toBe(0);
+      expect(collectActiveProviders(null).size).toBe(0);
+    });
+  });
+
+  describe("getRequiredProviderEnvs", () => {
+    it("returns entries for each active provider", () => {
+      const config = {
+        roles: {
+          coder: { provider: "claude" },
+          reviewer: { provider: "gemini" },
+        },
+      };
+      const required = getRequiredProviderEnvs(config);
+      const slugs = required.map((r) => r.provider);
+      expect(slugs).toContain("anthropic");
+      expect(slugs).toContain("google");
+    });
+
+    it("skips unknown providers", () => {
+      const config = { roles: { coder: { provider: "unknown-model" } } };
+      expect(getRequiredProviderEnvs(config)).toHaveLength(0);
+    });
+  });
+});

--- a/tests/utils-with-timeout.test.js
+++ b/tests/utils-with-timeout.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { withTimeout, TimeoutError } from "../src/utils/with-timeout.js";
+
+describe("utils/with-timeout", () => {
+  it("resolves when the promise settles within the deadline", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 1000);
+    expect(result).toBe("ok");
+  });
+
+  it("rejects with TimeoutError when the deadline passes", async () => {
+    const slow = new Promise((resolve) => setTimeout(() => resolve("late"), 200));
+    await expect(withTimeout(slow, 30, "probe")).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("propagates the original rejection when it happens first", async () => {
+    const err = new Error("boom");
+    await expect(withTimeout(Promise.reject(err), 1000)).rejects.toBe(err);
+  });
+
+  it("returns the original promise when ms is 0 or negative", async () => {
+    const p = Promise.resolve("passthrough");
+    expect(await withTimeout(p, 0)).toBe("passthrough");
+    expect(await withTimeout(Promise.resolve("x"), -1)).toBe("x");
+  });
+
+  it("includes the label in the TimeoutError", async () => {
+    const slow = new Promise(() => {});
+    try {
+      await withTimeout(slow, 20, "mcp-ping");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TimeoutError);
+      expect(err.label).toBe("mcp-ping");
+      expect(err.timeoutMs).toBe(20);
+      expect(err.message).toContain("mcp-ping");
+    }
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
       ".kj/**",
       "demo/**"
     ],
+    setupFiles: ["./tests/setup.js"],
     testTimeout: 30000
   }
 });


### PR DESCRIPTION
Closes KJC-TSK-0319. Builds the foundation for the Brain decisor work (KJC-TSK-0322) by giving kj doctor and kj run preflight the ability to detect and actively remediate environment issues.

## What this does
- Every check now declares a `strategy: auto | prompt | manual | none`. The runner executes 3 phases: detect in parallel, remediate sequentially for FAILs, re-verify.
- Ports (HU Board) are rebound automatically. SonarQube auto-start preserved. ~/.karajan dirs auto-created. Token checks lazy per active provider. MCP karajan-mcp ping. OpenSkills CLI detection. Node version guard.
- kj doctor gets flags: --check-only, --yes, --json, --verbose. Exit 1 on FAIL.
- kj run preflight now calls runChecks internally (opt-in via config.preflight.extended, default on in production).

## Commits
1. refactor(checks): extract doctor.js internals to src/checks/ with remediation schema
2. feat(utils): port-check, provider-env, with-timeout, port-occupant helpers
3. feat(checks): node, ports, tokens, mcp-health, skills, dir-setup checks
4. feat(checks): runner with detect, remediate, re-verify phases
5. feat(doctor): --check-only, --yes, --json, --verbose flags and exit code on FAIL
6. refactor(preflight): consume runChecks pipeline for extended environment checks
7. test(checks): end-to-end coverage of auto-remediation scenarios

## Test plan
- [x] npx vitest run → 3225 tests pass (253 files, 92 new)
- [ ] Smoke test kj doctor on this machine
- [ ] Smoke test kj run with preflight auto-remediation (port rebind, dir creation)