### PR TITLE
feat(skills): OpenSkills fase 2 — multi-role + semantic + cache + fallback (KJC-TSK-0321)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,154 @@
+# OpenSkills integration
+
+Karajan auto-injects domain-specific skills into role prompts so each AI agent
+has the right context for the task at hand. This page documents how detection
+works, how skills are routed to roles, how the cache behaves, and how to
+customize the behavior.
+
+## How detection works
+
+When `kj run` starts, Karajan inspects the task text and the project files to
+decide which skills to install. Detection runs in one of four modes:
+
+| Mode | Behavior |
+|---|---|
+| `auto` (default) | Regex + semantic. Regex scans files and task text; the classifier agent (triage/planner/coder provider, whichever is configured) then suggests additional skills from a curated catalog. |
+| `regex` | Regex-only. Fast and offline; no classifier call. |
+| `semantic` | Classifier-only. Useful when the project has no obvious markers (empty greenfield) but the task description implies a stack. |
+| `none` | Skill detection and installation are disabled entirely. |
+
+Set the mode via:
+
+```bash
+kj run "task" --skills-mode=regex
+```
+
+Or in `~/.karajan/kj.config.yml`:
+
+```yaml
+skills:
+  mode: auto
+```
+
+### Regex signals
+
+The detector recognizes these stacks out of the box:
+
+| Stack | Signal |
+|---|---|
+| Astro / Next / React / Vue / Svelte / Angular | `package.json` dependency |
+| Express / Fastify / NestJS | `package.json` dependency |
+| Java / Kotlin | `pom.xml`, `build.gradle`, `build.gradle.kts` |
+| Go | `go.mod` |
+| Rust | `Cargo.toml` |
+| Ruby | `Gemfile` |
+| PHP | `composer.json`, `phpunit.xml` |
+| Python | `pyproject.toml`, `requirements.txt`, `setup.py` |
+| Python data (pandas/numpy/scipy) | requirements / pyproject contains the package |
+| Python ML (torch/tensorflow/scikit-learn) | requirements / pyproject contains the package |
+| .NET | `*.csproj` or `*.sln` anywhere under `projectDir` (bounded walk) |
+| Databases (SQL) | `*.sql` files, `schema.prisma`, `migrations/` or `db/migrate/` directories |
+| Prisma | `*.prisma` files or `@prisma/client` dep |
+| Jupyter / data | `*.ipynb` files |
+| Test frameworks | `vitest`, `jest`, `@playwright/test`, `cypress` in `package.json`; `pytest` in Python deps |
+| Elixir / Erlang | `mix.exs`, `rebar.config` |
+
+Additionally, the task text is scanned with word-boundary regexes for common
+stack mentions (e.g. "add a SQL query" → `sql-analysis`, "CSS tweak" →
+`frontend-design`).
+
+### Semantic refinement
+
+In `auto` and `semantic` modes, the triage classifier is shown:
+
+- The task text.
+- Skills already detected by regex.
+- A curated catalog of skill names.
+
+It is asked to pick up to 5 additional skills that would meaningfully help.
+Catalog-only answers: the classifier cannot invent skills. If the classifier
+is unreachable (no provider configured, missing API key, transient error),
+detection silently degrades to regex-only and the session continues.
+
+## Role → skill filtering
+
+Not every skill helps every role. Karajan applies role-specific filters so a
+reviewer doesn't receive `pytest-patterns` and a tester doesn't receive
+`owasp-top-10`:
+
+| Role | Filter |
+|---|---|
+| `coder` | No filter — receives every detected skill |
+| `reviewer` | Matches `code-review`, `security`, `lint`, `style`, `antipatterns`, `owasp`; allows `sql-analysis` |
+| `architect` | Broad — receives everything EXCEPT test-framework patterns |
+| `tester` | Matches `test`, `pytest`, `vitest`, `jest`, `playwright`, `cypress` |
+| `security` | Matches `security`, `owasp`, `sast` |
+| `planner` | Broad — same policy as architect |
+| `solomon` | Matches `security`, `code-review` |
+
+See `src/skills/skill-loader.js` → `ROLE_SKILL_PATTERNS` for the authoritative
+config.
+
+## Claude dedup (Agent Skills)
+
+When the active provider is Anthropic (Claude Sonnet 4.5+), Karajan does NOT
+inline the full contents of `SKILL.md` in the prompt. Claude can load Agent
+Skills natively; duplicating the content in the prompt wastes tokens and risks
+drifting from the canonical source. Instead, the prompt section is a
+reference list like:
+
+```
+## Domain Skills
+
+Skills available natively via your Agent Skills capability: react-patterns,
+sql-analysis, owasp-top-10.
+```
+
+For other providers (OpenAI, Google, OpenCode, ...), the full `SKILL.md` body
+is included inline as before.
+
+## Fallback when the CLI is missing
+
+If `npx openskills` isn't available in the current PATH, Karajan:
+
+1. Still runs detection.
+2. Emits a `skills:unavailable` progress event with a list of `wouldHaveUsed`
+   skills for the final report.
+3. Logs a warning suggesting `npm install -g openskills`.
+4. Continues the pipeline without skills — nothing blocks.
+
+The session report surfaces the `wouldHaveUsed` list as a recommendation so
+users can opt into the benefit in future sessions.
+
+## Local cache (`~/.karajan/skills-cache/`)
+
+After a successful install, Karajan records the skill's install time in
+`~/.karajan/skills-cache/<skill>/meta.json`. On the next session, if the
+recorded install is newer than 7 days, Karajan skips the `npx openskills
+install` call and treats the skill as already installed. This saves 10–30s
+per skill per session.
+
+Inspect and manage the cache:
+
+```bash
+kj skills list          # show cached skills with fresh/stale flag
+kj skills clear-cache   # force re-install on next session
+```
+
+The TTL is currently 7 days and is not user-configurable in v1. The cache
+stores metadata only — it never holds skill content itself.
+
+## Testing behavior locally
+
+```bash
+kj run "dummy task" --skills-mode=regex --dry-run
+```
+
+Combined with `kj doctor` to verify `openskills` CLI availability:
+
+```bash
+kj doctor --verbose  # verifies skill CLI + preflight + ports + tokens
+```
+
+Set `skills.enabled: false` in `kj.config.yml` to turn off all skill
+detection at the config level (equivalent to `--skills-mode=none`).

--- a/src/cli.js
+++ b/src/cli.js
@@ -212,6 +212,15 @@ program
   });
 
 program
+  .command("skills [action]")
+  .description("Manage the local OpenSkills cache (actions: list | clear-cache)")
+  .action(async (action) => {
+    const { skillsCommand } = await import("./commands/skills.js");
+    const exitCode = await skillsCommand({ action: action || "list" });
+    if (Number.isInteger(exitCode)) process.exit(exitCode);
+  });
+
+program
   .command("roles [subcommand] [role]")
   .description("List pipeline roles or show role template instructions")
   .action(async (subcommand, role) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -128,6 +128,7 @@ program
   .option("--no-smart-models", "Disable smart model selection")
   .option("--design", "Activate design refactoring mode (impeccable role applies design changes)")
   .option("--domain <text-or-path>", "Domain knowledge: inline text or path to .md file")
+  .option("--skills-mode <mode>", "Skill detection mode: auto|regex|semantic|none (default: auto)")
   .option("--dry-run", "Show what would be executed without running anything")
   .option("--json", "Output JSON only (no styled display)")
   .option("-q, --quiet", "Show only stage status lines, suppress raw agent output (default)")

--- a/src/commands/skills.js
+++ b/src/commands/skills.js
@@ -1,0 +1,49 @@
+/**
+ * `kj skills` — manage the local OpenSkills cache.
+ *
+ * Subcommands:
+ *   - list         : print cached skills with their age and freshness.
+ *   - clear-cache  : delete all cached metadata (forces re-install on next session).
+ */
+
+import { listCached, clearCache, getCacheRoot, DEFAULT_TTL_MS } from "../skills/skills-cache.js";
+
+function humanAge(cachedAt) {
+  const ms = Date.now() - Date.parse(cachedAt);
+  if (!Number.isFinite(ms) || ms < 0) return "unknown";
+  const days = ms / (24 * 60 * 60 * 1000);
+  if (days < 1) return `${Math.max(1, Math.round(ms / (60 * 60 * 1000)))}h ago`;
+  return `${days.toFixed(1)}d ago`;
+}
+
+export async function skillsCommand({ action = "list" } = {}) {
+  switch (action) {
+    case "list":
+      return listAction();
+    case "clear-cache":
+      return clearAction();
+    default:
+      console.error(`Unknown action: ${action}. Use: list | clear-cache`);
+      return 1;
+  }
+}
+
+async function listAction() {
+  const cache = await listCached();
+  if (cache.length === 0) {
+    console.log(`No cached skills at ${getCacheRoot()}`);
+    return 0;
+  }
+  console.log(`Cached skills (TTL ${Math.round(DEFAULT_TTL_MS / 86400000)}d) at ${getCacheRoot()}:\n`);
+  for (const entry of cache) {
+    const flag = entry.fresh ? "FRESH" : "STALE";
+    console.log(`  ${flag}  ${entry.name}  (${humanAge(entry.cachedAt)})`);
+  }
+  return 0;
+}
+
+async function clearAction() {
+  const { removed } = await clearCache();
+  console.log(`Cleared ${removed} cached skill${removed === 1 ? "" : "s"} from ${getCacheRoot()}`);
+  return 0;
+}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -38,6 +38,7 @@ import { setRunner as setDiffRunner, setProjectDir as setDiffProjectDir } from "
 import { setRunner as setGitRunner } from "./utils/git.js";
 import { detectNeededSkills, autoInstallSkills, cleanupAutoInstalledSkills } from "./skills/skill-detector.js";
 import { isOpenSkillsAvailable } from "./skills/openskills-client.js";
+import { refineSkillsSemantically, resolveSkillsMode } from "./skills/semantic-detector.js";
 
 // Extracted modules
 import {
@@ -730,7 +731,28 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
   // actual install is skipped inside autoInstallSkills when unavailable.
   const skillProjectDir = updatedConfig.projectDir || process.cwd();
   try {
-    const neededSkills = await detectNeededSkills(plannedTask, skillProjectDir);
+    const skillsMode = resolveSkillsMode(updatedConfig, flags);
+    if (skillsMode === "none") {
+      // User explicitly opted out. Skip detection entirely.
+      return { plannedTask, updatedConfig };
+    }
+    let neededSkills = skillsMode === "semantic"
+      ? []
+      : await detectNeededSkills(plannedTask, skillProjectDir);
+    // Semantic mode augments regex detection with a classifier call.
+    // "auto" = regex always + semantic when budget allows (v1: always when mode=auto and classifier reachable).
+    if (skillsMode === "auto" || skillsMode === "semantic") {
+      const extra = await refineSkillsSemantically({
+        task: plannedTask,
+        alreadyDetected: neededSkills,
+        config: updatedConfig,
+        logger,
+      });
+      if (extra.length > 0) {
+        logger.info(`Semantic skill detection added: ${extra.join(", ")}`);
+        neededSkills = Array.from(new Set([...neededSkills, ...extra]));
+      }
+    }
     if (neededSkills.length > 0) {
       const skillResult = await autoInstallSkills(neededSkills, skillProjectDir);
       if (skillResult.installed.length > 0) {

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -724,23 +724,35 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
   // Runs AFTER triage and planner so that the planned task text (which includes
   // planner output like implementation steps) is available for keyword detection.
   // This ensures greenfield projects with no package.json still get correct skills.
+  //
+  // Detection runs UNCONDITIONALLY — even when the openskills CLI is missing —
+  // so the session report can recommend which skills would have been used. The
+  // actual install is skipped inside autoInstallSkills when unavailable.
   const skillProjectDir = updatedConfig.projectDir || process.cwd();
   try {
-    const osAvailable = await isOpenSkillsAvailable();
-    if (osAvailable) {
-      const neededSkills = await detectNeededSkills(plannedTask, skillProjectDir);
-      if (neededSkills.length > 0) {
-        const skillResult = await autoInstallSkills(neededSkills, skillProjectDir);
-        if (skillResult.installed.length > 0) {
-          session.autoInstalledSkills = skillResult.installed;
-        }
-        emitProgress(emitter, makeEvent("skills:auto-install", { ...eventBase, stage: "skills" }, {
-          message: skillResult.installed.length > 0
-            ? `Auto-installed ${skillResult.installed.length} skill(s): ${skillResult.installed.join(", ")}`
-            : `Skills detected (${neededSkills.join(", ")}) — all already installed or unavailable`,
-          detail: skillResult
+    const neededSkills = await detectNeededSkills(plannedTask, skillProjectDir);
+    if (neededSkills.length > 0) {
+      const skillResult = await autoInstallSkills(neededSkills, skillProjectDir);
+      if (skillResult.installed.length > 0) {
+        session.autoInstalledSkills = skillResult.installed;
+      }
+      if (skillResult.osAvailable === false && skillResult.wouldHaveUsed.length > 0) {
+        session.skillsRecommended = skillResult.wouldHaveUsed;
+        logger.warn(`OpenSkills CLI not available — would have used: ${skillResult.wouldHaveUsed.join(", ")}. Install openskills globally to auto-inject them next time.`);
+        emitProgress(emitter, makeEvent("skills:unavailable", { ...eventBase, stage: "skills" }, {
+          message: `OpenSkills CLI not available — would have used: ${skillResult.wouldHaveUsed.join(", ")}`,
+          detail: {
+            wouldHaveUsed: skillResult.wouldHaveUsed,
+            hint: "Install openskills globally: npm install -g openskills",
+          },
         }));
       }
+      emitProgress(emitter, makeEvent("skills:auto-install", { ...eventBase, stage: "skills" }, {
+        message: skillResult.installed.length > 0
+          ? `Auto-installed ${skillResult.installed.length} skill(s): ${skillResult.installed.join(", ")}`
+          : `Skills detected (${neededSkills.join(", ")}) — all already installed or unavailable`,
+        detail: skillResult,
+      }));
     }
   } catch (err) {
     logger.warn(`Skill auto-install failed (non-blocking): ${err.message}`);

--- a/src/prompts/architect.js
+++ b/src/prompts/architect.js
@@ -51,7 +51,7 @@ export async function buildArchitectPrompt({ task, instructions, researchContext
 
   if (projectDir) {
     const skills = await loadAvailableSkills(projectDir);
-    const skillSection = buildSkillSection(skills, { provider });
+    const skillSection = buildSkillSection(skills, { provider, role: "architect" });
     if (skillSection) {
       sections.push(skillSection);
     }

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -64,7 +64,7 @@ export async function buildReviewerPrompt({ task, diff, reviewRules, mode, seren
 
   if (projectDir) {
     const skills = await loadAvailableSkills(projectDir);
-    const skillSection = buildSkillSection(skills, { provider });
+    const skillSection = buildSkillSection(skills, { provider, role: "reviewer" });
     if (skillSection) {
       sections.push(skillSection);
     }

--- a/src/roles/security-role.js
+++ b/src/roles/security-role.js
@@ -1,5 +1,6 @@
 import { AgentRole } from "./agent-role.js";
 import { extractFirstJson } from "../utils/json-extract.js";
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -23,6 +24,17 @@ export class SecurityRole extends AgentRole {
       `## Task\n${task}`
     );
     if (diff) sections.push(`## Git diff to audit\n${diff}`);
+
+    // Inject security-relevant skills (owasp-*, security-*, sast-*) filtered
+    // by role=security.
+    const projectDir = this.config?.projectDir || process.cwd();
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills, {
+      provider: this._resolvedProvider || (typeof this.resolveProvider === "function" ? this.resolveProvider() : null),
+      role: "security",
+    });
+    if (skillSection) sections.push(skillSection);
+
     return { prompt: sections.join("\n\n") };
   }
 

--- a/src/roles/tester-role.js
+++ b/src/roles/tester-role.js
@@ -1,6 +1,7 @@
 import { AgentRole } from "./agent-role.js";
 import { extractFirstJson } from "../utils/json-extract.js";
 import { detectTestFramework } from "../utils/project-detect.js";
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -108,6 +109,16 @@ export class TesterRole extends AgentRole {
     );
     if (diff) sections.push(`## Git diff\n${diff}`);
     if (sonarIssues) sections.push(`## Sonar test issues\n${sonarIssues}`);
+
+    // Inject test-relevant skills (filtered by role=tester to only include
+    // testing patterns like pytest-patterns, vitest-patterns, etc.)
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills, {
+      provider: this._resolvedProvider || (typeof this.resolveProvider === "function" ? this.resolveProvider() : null),
+      role: "tester",
+    });
+    if (skillSection) sections.push(skillSection);
+
     return { prompt: sections.join("\n\n") };
   }
 

--- a/src/skills/semantic-detector.js
+++ b/src/skills/semantic-detector.js
@@ -1,0 +1,147 @@
+/**
+ * Semantic skill detection using the triage classifier.
+ *
+ * The regex-based detector (skill-detector.js) is fast but shallow: it only
+ * catches dependencies that name themselves explicitly. A task like
+ * "add a feature flag system" might benefit from an "a/b-testing" skill
+ * that regex cannot guess without an exhaustive keyword list.
+ *
+ * Semantic mode asks the classifier agent to pick skills from a known
+ * catalog given the task text and the skills already detected by regex.
+ * The catalog is intentionally small and curated — we don't hit the
+ * openskills.cc marketplace API (not available). If the classifier is
+ * unavailable (missing provider / missing API key), we return [] and the
+ * pipeline keeps working with the regex-only result.
+ */
+
+import { createAgent } from "../agents/index.js";
+import { resolveRole } from "../config.js";
+
+/**
+ * Curated catalog of skills the classifier is allowed to suggest. Keeping
+ * this small prevents the model from hallucinating non-existent skills and
+ * bounds the tokens spent on the prompt.
+ */
+export const SEMANTIC_CATALOG = [
+  "astro", "nextjs", "react", "vue", "svelte", "angular",
+  "express", "fastify", "nestjs",
+  "java", "kotlin", "go", "rust", "ruby", "php", "dotnet", "elixir",
+  "python", "python-data", "python-ml", "pytest-patterns",
+  "django", "flask", "fastapi",
+  "sql-analysis", "prisma", "mongodb",
+  "owasp-top-10", "security-checklist",
+  "java-code-review", "python-code-review",
+  "frontend-design", "csv-transform", "data-report",
+  "vitest-patterns", "jest-patterns", "playwright-patterns", "cypress-patterns",
+];
+
+const PROMPT = (task, catalog, alreadyDetected) => `You are a classifier that picks which domain skills would help solve a task.
+
+Task:
+"""${task}"""
+
+Already detected skills (do NOT repeat, but consider the task context they imply):
+${alreadyDetected.length > 0 ? alreadyDetected.join(", ") : "(none)"}
+
+From this exact catalog, output a JSON array with the names of 0 to 5 additional skills that would meaningfully help. Output ONLY the JSON array, no prose.
+
+Catalog (pick strict matches only):
+${catalog.join(", ")}
+
+Rules:
+- Only names from the catalog. Do NOT invent.
+- Prefer precision over recall: empty array is a valid answer when nothing fits.
+- Do NOT include already-detected skills.
+- Respond with a single JSON array, e.g. ["python-data","sql-analysis"]
+`;
+
+function tryParseArray(raw) {
+  if (!raw) return [];
+  try {
+    const m = String(raw).match(/\[[^\]]*\]/);
+    if (!m) return [];
+    const parsed = JSON.parse(m[0]);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s) => typeof s === "string");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Ask the classifier for additional skills.
+ *
+ * @param {Object} args
+ * @param {string} args.task
+ * @param {string[]} args.alreadyDetected
+ * @param {Object} args.config - Karajan config
+ * @param {Object} [args.logger]
+ * @returns {Promise<string[]>}
+ */
+export async function refineSkillsSemantically({ task, alreadyDetected = [], config, logger }) {
+  if (!task || typeof task !== "string") return [];
+  let provider;
+  try {
+    provider = resolveRole(config, "triage")?.provider
+      || resolveRole(config, "planner")?.provider
+      || resolveRole(config, "coder")?.provider;
+  } catch {
+    provider = null;
+  }
+  if (!provider) {
+    logger?.debug?.("semantic-detector: no classifier provider — skipping");
+    return [];
+  }
+
+  let agent;
+  try {
+    agent = createAgent(provider, config, logger);
+  } catch (err) {
+    logger?.debug?.(`semantic-detector: classifier unavailable (${err.message}) — skipping`);
+    return [];
+  }
+  if (!agent || typeof agent.runTask !== "function") {
+    logger?.debug?.("semantic-detector: classifier agent has no runTask() — skipping");
+    return [];
+  }
+
+  const prompt = PROMPT(task, SEMANTIC_CATALOG, alreadyDetected);
+  let res;
+  try {
+    res = await agent.runTask(prompt, { timeoutMs: 30_000 });
+  } catch (err) {
+    logger?.warn?.(`semantic-detector: classifier call failed (${err.message}) — skipping`);
+    return [];
+  }
+  if (!res?.ok) {
+    logger?.debug?.("semantic-detector: classifier returned not-ok — skipping");
+    return [];
+  }
+
+  const suggested = tryParseArray(res.output || res.result?.raw || "");
+  const allowed = new Set(SEMANTIC_CATALOG);
+  const alreadySet = new Set(alreadyDetected.map((s) => s.toLowerCase()));
+  return suggested
+    .map((s) => String(s).trim())
+    .filter((s) => s && allowed.has(s) && !alreadySet.has(s.toLowerCase()))
+    .slice(0, 5);
+}
+
+/**
+ * Resolve the effective skills mode from config + flags.
+ * Precedence: flags.skillsMode > config.skills.mode > globalThis default > "auto".
+ *
+ * The global default lets the test harness opt out of semantic detection
+ * without each orchestrator test having to mock this module (tests/setup.js
+ * sets globalThis.__KJ_DEFAULT_SKILLS_MODE = "regex").
+ *
+ * @param {Object} config
+ * @param {Object} [flags]
+ * @returns {"auto"|"regex"|"semantic"|"none"}
+ */
+export function resolveSkillsMode(config, flags = {}) {
+  const defaultMode = globalThis.__KJ_DEFAULT_SKILLS_MODE || "auto";
+  const candidate = flags.skillsMode ?? config?.skills?.mode ?? defaultMode;
+  const valid = new Set(["auto", "regex", "semantic", "none"]);
+  return valid.has(candidate) ? candidate : "auto";
+}

--- a/src/skills/skill-detector.js
+++ b/src/skills/skill-detector.js
@@ -284,12 +284,25 @@ async function collectExtensionMarkers(projectDir, maxDepth, needed) {
 
 /**
  * Auto-install needed skills that are not yet installed.
+ *
+ * When the `openskills` CLI is not available, this function degrades
+ * gracefully: it returns `osAvailable: false` and `wouldHaveUsed` with the
+ * list of skills that would have been installed if the CLI had been present.
+ * Callers (e.g. the orchestrator) can surface this info in the session
+ * report without blocking execution.
+ *
  * @param {string[]} neededSkills - Skill names to ensure are installed.
  * @param {string} projectDir - Absolute path to project root.
- * @returns {Promise<{installed: string[], failed: string[], alreadyInstalled: string[]}>}
+ * @returns {Promise<{
+ *   installed: string[],
+ *   failed: string[],
+ *   alreadyInstalled: string[],
+ *   wouldHaveUsed: string[],
+ *   osAvailable: boolean
+ * }>}
  */
 export async function autoInstallSkills(neededSkills, projectDir) {
-  const result = { installed: [], failed: [], alreadyInstalled: [] };
+  const result = { installed: [], failed: [], alreadyInstalled: [], wouldHaveUsed: [], osAvailable: true };
 
   if (!neededSkills || neededSkills.length === 0) {
     return result;
@@ -302,7 +315,10 @@ export async function autoInstallSkills(neededSkills, projectDir) {
   // Check if OpenSkills is available
   const osAvailable = await isOpenSkillsAvailable();
   if (!osAvailable) {
-    // All skills count as "failed" silently — caller should check osAvailable separately
+    result.osAvailable = false;
+    // Report what we would have installed so the session report can surface
+    // the recommendation — "install openskills globally to enable: X, Y, Z".
+    result.wouldHaveUsed = neededSkills.filter((s) => !existingNames.has(s.toLowerCase()));
     return result;
   }
 

--- a/src/skills/skill-detector.js
+++ b/src/skills/skill-detector.js
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { loadAvailableSkills } from "./skill-loader.js";
 import { isOpenSkillsAvailable, installSkill, removeSkill } from "./openskills-client.js";
+import { isFresh as isCacheFresh, recordInstall as recordSkillInstall } from "./skills-cache.js";
 
 /**
  * Known frameworks detectable from package.json dependencies.
@@ -328,10 +329,21 @@ export async function autoInstallSkills(neededSkills, projectDir) {
       continue;
     }
 
+    // Cache short-circuit: if we installed this skill in the last 7 days,
+    // assume it's still good and skip the `npx openskills install` call
+    // (which can take 10-30s). Running sessions can opt out by clearing
+    // the cache with `kj skills clear-cache`.
+    if (await isCacheFresh(skillName)) {
+      result.alreadyInstalled.push(skillName);
+      continue;
+    }
+
     try {
       const installResult = await installSkill(skillName, { projectDir });
       if (installResult.ok) {
-        result.installed.push(installResult.name || skillName);
+        const installedName = installResult.name || skillName;
+        result.installed.push(installedName);
+        await recordSkillInstall(installedName, { source: skillName }).catch(() => {});
       } else {
         result.failed.push(skillName);
       }

--- a/src/skills/skill-detector.js
+++ b/src/skills/skill-detector.js
@@ -23,6 +23,39 @@ const PKG_JSON_FRAMEWORKS = {
   express: "express",
   fastify: "fastify",
   "@nestjs/core": "nestjs",
+  // DB / ORM
+  prisma: "prisma",
+  "@prisma/client": "prisma",
+  knex: "sql-analysis",
+  sequelize: "sql-analysis",
+  typeorm: "sql-analysis",
+  mongoose: "mongodb",
+  "better-sqlite3": "sql-analysis",
+  // Testing
+  vitest: "vitest-patterns",
+  jest: "jest-patterns",
+  "@playwright/test": "playwright-patterns",
+  cypress: "cypress-patterns",
+};
+
+/**
+ * Python dependency names (from requirements.txt or pyproject.toml) mapping
+ * to their canonical skill.
+ */
+const PYTHON_DEPS = {
+  pandas: "python-data",
+  numpy: "python-data",
+  scipy: "python-data",
+  "scikit-learn": "python-ml",
+  sklearn: "python-ml",
+  tensorflow: "python-ml",
+  torch: "python-ml",
+  pytorch: "python-ml",
+  pytest: "pytest-patterns",
+  django: "python-django",
+  flask: "python-flask",
+  fastapi: "python-fastapi",
+  sqlalchemy: "sql-analysis",
 };
 
 /**
@@ -36,13 +69,43 @@ const LANGUAGE_FILE_MARKERS = [
   { file: "go.mod", skill: "go" },
   { file: "Cargo.toml", skill: "rust" },
   { file: "pyproject.toml", skill: "python" },
+  { file: "requirements.txt", skill: "python" },
   { file: "setup.py", skill: "python" },
   { file: "Gemfile", skill: "ruby" },
   { file: "pubspec.yaml", skill: "flutter" },
   { file: "Package.swift", skill: "swift" },
   { file: "phpunit.xml", skill: "php" },
   { file: "composer.json", skill: "php" },
+  { file: "mix.exs", skill: "elixir" },
+  { file: "rebar.config", skill: "erlang" },
 ];
+
+/**
+ * File EXTENSIONS whose presence anywhere under projectDir adds a skill.
+ * Uses a shallow-recursive glob with a cutoff to avoid walking node_modules.
+ */
+const EXTENSION_MARKERS = [
+  { ext: ".csproj", skill: "dotnet" },
+  { ext: ".sln", skill: "dotnet" },
+  { ext: ".ipynb", skill: "python-data" },
+  { ext: ".prisma", skill: "prisma" },
+];
+
+/**
+ * Files detected as "SQL / database schema" when they exist at repo root.
+ * Used in addition to EXTENSION_MARKERS for *.sql anywhere in the repo.
+ */
+const SQL_MARKER_FILES = [
+  "schema.sql",
+  "schema.prisma",
+  "migrations",
+  "db/migrate",
+];
+
+const DIRECTORIES_TO_SKIP = new Set([
+  "node_modules", ".git", ".kj", ".karajan", "dist", "build", ".next", "out",
+  "target", ".venv", "venv", "__pycache__", ".vitest-cache", "coverage",
+]);
 
 /**
  * Patterns to detect framework/skill mentions in the task text.
@@ -91,14 +154,21 @@ const TASK_TEXT_PATTERNS = [
 
 /**
  * Analyze the task and project to determine what skills might be needed.
+ *
  * @param {string} task - The task description text.
  * @param {string} projectDir - Absolute path to project root.
+ * @param {{ includeExtensions?: boolean, maxDepth?: number }} [options]
+ *   - includeExtensions: scan for file extensions (.csproj, .ipynb, .sql...)
+ *     that signal a stack. Default true. Disable to avoid the shallow walk
+ *     in very large repos or in tests.
+ *   - maxDepth: bound the walk (default 3 directories deep).
  * @returns {Promise<string[]>} Array of unique skill names to search for.
  */
-export async function detectNeededSkills(task, projectDir) {
+export async function detectNeededSkills(task, projectDir, options = {}) {
+  const { includeExtensions = true, maxDepth = 3 } = options;
   const needed = new Set();
 
-  // 1. Scan package.json for known frameworks
+  // 1. Scan package.json for known frameworks and JS-ecosystem deps
   if (projectDir) {
     try {
       const pkgRaw = await fs.readFile(path.join(projectDir, "package.json"), "utf8");
@@ -111,16 +181,32 @@ export async function detectNeededSkills(task, projectDir) {
       }
     } catch { /* no package.json or parse error — skip */ }
 
-    // 2. Check for language markers
+    // 2. Language marker files at repo root
     for (const marker of LANGUAGE_FILE_MARKERS) {
       try {
         await fs.access(path.join(projectDir, marker.file));
         needed.add(marker.skill);
       } catch { /* file not found — skip */ }
     }
+
+    // 3. Python deps from requirements.txt / pyproject.toml
+    await collectPythonDeps(projectDir, needed);
+
+    // 4. File extension markers (.csproj, .ipynb, .prisma, *.sql)
+    if (includeExtensions) {
+      await collectExtensionMarkers(projectDir, maxDepth, needed);
+    }
+
+    // 5. SQL / DB schema markers at well-known paths
+    for (const candidate of SQL_MARKER_FILES) {
+      try {
+        await fs.access(path.join(projectDir, candidate));
+        needed.add("sql-analysis");
+      } catch { /* skip */ }
+    }
   }
 
-  // 3. Check task text for framework mentions
+  // 6. Task text patterns
   if (task) {
     for (const { pattern, skill } of TASK_TEXT_PATTERNS) {
       if (pattern.test(task)) {
@@ -130,6 +216,70 @@ export async function detectNeededSkills(task, projectDir) {
   }
 
   return Array.from(needed);
+}
+
+async function collectPythonDeps(projectDir, needed) {
+  // requirements.txt — each non-comment line is "name==ver" or "name>=ver"
+  try {
+    const raw = await fs.readFile(path.join(projectDir, "requirements.txt"), "utf8");
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim().split("#")[0].trim();
+      if (!trimmed) continue;
+      const name = trimmed.split(/[<>=!~\[\s]/)[0].toLowerCase();
+      const skill = PYTHON_DEPS[name];
+      if (skill) needed.add(skill);
+    }
+  } catch { /* no requirements.txt */ }
+
+  // pyproject.toml — simple heuristic scan for dependency names. A full TOML
+  // parse would need a dep; we just look for quoted names, which is fine.
+  try {
+    const raw = await fs.readFile(path.join(projectDir, "pyproject.toml"), "utf8");
+    const lower = raw.toLowerCase();
+    for (const [name, skill] of Object.entries(PYTHON_DEPS)) {
+      if (lower.includes(`"${name}"`) || lower.includes(`'${name}'`)) {
+        needed.add(skill);
+      }
+    }
+  } catch { /* no pyproject.toml */ }
+}
+
+async function collectExtensionMarkers(projectDir, maxDepth, needed) {
+  // Build a lookup by extension for fast decisions.
+  const byExt = new Map(EXTENSION_MARKERS.map((m) => [m.ext, m.skill]));
+  const extensions = new Set(byExt.keys());
+  extensions.add(".sql");
+  let sqlFound = false;
+
+  async function walk(dir, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (DIRECTORIES_TO_SKIP.has(entry.name)) continue;
+        if (entry.name.startsWith(".")) continue;
+        await walk(path.join(dir, entry.name), depth + 1);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!extensions.has(ext)) continue;
+      if (ext === ".sql") {
+        sqlFound = true;
+        continue;
+      }
+      const skill = byExt.get(ext);
+      if (skill) needed.add(skill);
+    }
+  }
+
+  await walk(projectDir, 0);
+  if (sqlFound) needed.add("sql-analysis");
 }
 
 /**

--- a/src/skills/skill-loader.js
+++ b/src/skills/skill-loader.js
@@ -79,20 +79,109 @@ export async function loadAvailableSkills(projectDir, options = {}) {
  * For every other provider, the full SKILL.md body is inlined (previous
  * behaviour preserved).
  *
+ * When `role` is supplied, skills are filtered to those relevant to the role
+ * (e.g. a reviewer only sees `*-code-review`, `*-security-*`, and general
+ * patterns; see ROLE_SKILL_PATTERNS). Setting role to null/undefined keeps
+ * the legacy behavior of injecting every skill (useful for the coder role,
+ * which benefits from broad context).
+ *
  * @param {Array<{name: string, content: string}>} skills
- * @param {{ provider?: string }} [options]
+ * @param {{ provider?: string, role?: string }} [options]
  * @returns {string} prompt section or empty string
  */
 export function buildSkillSection(skills, options = {}) {
   if (!skills || skills.length === 0) return "";
 
+  const filtered = options.role ? filterSkillsForRole(skills, options.role) : skills;
+  if (filtered.length === 0) return "";
+
   const providerSlug = normalize(options.provider);
 
   if (providerSlug === "anthropic") {
-    return buildReferenceSection(skills);
+    return buildReferenceSection(filtered);
   }
 
-  return buildInlineSection(skills);
+  return buildInlineSection(filtered);
+}
+
+/**
+ * Role → substring patterns that skills must match to be included. A skill
+ * matches the role if its name contains ANY of the role's patterns OR if it
+ * appears in the role's explicit allowlist. Coder is omitted on purpose: it
+ * receives everything.
+ *
+ * The patterns target the skill NAMING convention shipped by openskills.cc
+ * where skills are typically named like `react-patterns`, `java-code-review`,
+ * `pytest-patterns`, `owasp-top-10`, etc.
+ */
+/**
+ * Role → filter config.
+ *
+ * Two modes:
+ *   - `includes` present: skill name must contain ANY include AND NOT contain
+ *     any exclude. `allow` bypasses both checks (explicit allowlist by name).
+ *   - `includes` absent (or empty) + `excludes` present: skill passes unless
+ *     its name contains an exclude pattern. This is the "accept broad, trim
+ *     obvious mismatches" mode used by architect.
+ */
+const ROLE_SKILL_PATTERNS = {
+  reviewer: {
+    includes: ["code-review", "security", "lint", "style", "antipatterns", "owasp"],
+    excludes: [],
+    allow: ["sql-analysis"],
+  },
+  architect: {
+    // Architect sees everything except test-framework patterns. Architecture
+    // decisions touch every domain, so keep the filter permissive.
+    includes: null,
+    excludes: ["pytest", "vitest", "jest", "playwright", "cypress"],
+    allow: [],
+  },
+  tester: {
+    includes: ["test", "pytest", "vitest", "jest", "playwright", "cypress"],
+    excludes: [],
+    allow: [],
+  },
+  security: {
+    includes: ["security", "owasp", "sast"],
+    excludes: [],
+    allow: [],
+  },
+  planner: {
+    // Planner gets broad stack context except test frameworks.
+    includes: null,
+    excludes: ["pytest", "vitest", "jest", "playwright", "cypress"],
+    allow: [],
+  },
+  solomon: {
+    includes: ["security", "code-review"],
+    excludes: [],
+    allow: [],
+  },
+};
+
+/**
+ * Filter skills for a given role using the ROLE_SKILL_PATTERNS map. Unknown
+ * roles get ALL skills (conservative default for the coder role and any
+ * future addition). Matching is case-insensitive substring.
+ *
+ * @param {Array<{name: string}>} skills
+ * @param {string} role
+ * @returns {Array} filtered array
+ */
+export function filterSkillsForRole(skills, role) {
+  const cfg = ROLE_SKILL_PATTERNS[role];
+  if (!cfg) return skills; // unknown role (e.g. coder) → no filter
+  const includes = Array.isArray(cfg.includes) ? cfg.includes.map((s) => s.toLowerCase()) : null;
+  const excludes = (cfg.excludes || []).map((s) => s.toLowerCase());
+  const allow = new Set((cfg.allow || []).map((s) => s.toLowerCase()));
+  return skills.filter((s) => {
+    const name = (s.name || "").toLowerCase();
+    if (allow.has(name)) return true;
+    if (excludes.some((pat) => name.includes(pat))) return false;
+    if (!includes || includes.length === 0) return true; // exclude-only mode
+    return includes.some((pat) => name.includes(pat));
+  });
 }
 
 function buildInlineSection(skills) {

--- a/src/skills/skills-cache.js
+++ b/src/skills/skills-cache.js
@@ -1,0 +1,128 @@
+/**
+ * Local cache for installed OpenSkills, backed by `~/.karajan/skills-cache/`.
+ *
+ * The cache records WHEN each skill was last installed so we can skip
+ * redundant `npx openskills install X` calls during the 7-day TTL window
+ * (each call can take 10-30s even when the skill is already present).
+ *
+ * This is intentionally simple: one directory per skill name with a
+ * `meta.json` describing the last install time. Skill content is NOT copied
+ * to the cache — OpenSkills owns the real content on disk; we only track
+ * freshness.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getKarajanHome } from "../utils/paths.js";
+
+const CACHE_DIR_NAME = "skills-cache";
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export function getCacheRoot() {
+  return path.join(getKarajanHome(), CACHE_DIR_NAME);
+}
+
+function sanitize(name) {
+  // Allow safe skill name characters, replace everything else with "_".
+  return String(name || "").replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function metaPath(name) {
+  return path.join(getCacheRoot(), sanitize(name), "meta.json");
+}
+
+/**
+ * Read cached metadata for a skill. Returns null if missing or unreadable.
+ * @param {string} name
+ * @returns {Promise<{cachedAt: string, source?: string}|null>}
+ */
+export async function getCachedMeta(name) {
+  if (!name) return null;
+  try {
+    const raw = await fs.readFile(metaPath(name), "utf8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.cachedAt !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True iff the skill was cached more recently than `ttlMs` ago.
+ * @param {string} name
+ * @param {number} [ttlMs=DEFAULT_TTL_MS]
+ * @returns {Promise<boolean>}
+ */
+export async function isFresh(name, ttlMs = DEFAULT_TTL_MS) {
+  const meta = await getCachedMeta(name);
+  if (!meta) return false;
+  const cachedTime = Date.parse(meta.cachedAt);
+  if (Number.isNaN(cachedTime)) return false;
+  return Date.now() - cachedTime < ttlMs;
+}
+
+/**
+ * Record that a skill was just (re-)installed. Creates the cache subdir if
+ * needed.
+ * @param {string} name
+ * @param {{ source?: string }} [opts]
+ * @returns {Promise<void>}
+ */
+export async function recordInstall(name, opts = {}) {
+  if (!name) return;
+  const dir = path.join(getCacheRoot(), sanitize(name));
+  await fs.mkdir(dir, { recursive: true });
+  const meta = {
+    name,
+    cachedAt: new Date().toISOString(),
+    ...(opts.source ? { source: opts.source } : {}),
+  };
+  await fs.writeFile(path.join(dir, "meta.json"), JSON.stringify(meta, null, 2), "utf8");
+}
+
+/**
+ * Remove all cached skill metadata (does not touch real installed skills,
+ * only clears the freshness tracker).
+ * @returns {Promise<{removed: number}>}
+ */
+export async function clearCache() {
+  const root = getCacheRoot();
+  let removed = 0;
+  try {
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      await fs.rm(path.join(root, entry.name), { recursive: true, force: true });
+      removed++;
+    }
+  } catch { /* cache dir does not exist — nothing to clear */ }
+  return { removed };
+}
+
+/**
+ * List cached skill names with their cachedAt timestamp, sorted oldest first.
+ * @returns {Promise<Array<{name: string, cachedAt: string, fresh: boolean}>>}
+ */
+export async function listCached(ttlMs = DEFAULT_TTL_MS) {
+  const root = getCacheRoot();
+  const out = [];
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const meta = await getCachedMeta(entry.name);
+    if (!meta) continue;
+    const cachedTime = Date.parse(meta.cachedAt);
+    const fresh = !Number.isNaN(cachedTime) && (Date.now() - cachedTime < ttlMs);
+    out.push({ name: meta.name || entry.name, cachedAt: meta.cachedAt, fresh });
+  }
+  out.sort((a, b) => a.cachedAt.localeCompare(b.cachedAt));
+  return out;
+}
+
+export { DEFAULT_TTL_MS };

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -24,3 +24,9 @@ process.env.GOOGLE_API_KEY ??= "sk-test-google";
 process.env.OPENCODE_API_KEY ??= "sk-test-opencode";
 
 globalThis.__KJ_DEFAULT_PREFLIGHT_EXTENDED = false;
+
+// Default skills mode to "regex" under Vitest so orchestrator tests that do
+// not mock the semantic detector don't spawn classifier agents and skew
+// agent-invocation assertions. Tests that exercise the semantic path set
+// `flags.skillsMode = "auto"` or `config.skills.mode = "semantic"` explicitly.
+globalThis.__KJ_DEFAULT_SKILLS_MODE = "regex";

--- a/tests/skills/cache.test.js
+++ b/tests/skills/cache.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let originalKarajanHome;
+
+vi.mock("../../src/utils/paths.js", () => ({
+  getKarajanHome: vi.fn(() => originalKarajanHome),
+  getSessionRoot: vi.fn(() => path.join(originalKarajanHome, "sessions")),
+}));
+
+describe("skills/skills-cache", () => {
+  let getCachedMeta, isFresh, recordInstall, clearCache, listCached, getCacheRoot, DEFAULT_TTL_MS;
+  let tmpHome;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-cache-test-"));
+    originalKarajanHome = tmpHome;
+    const paths = await import("../../src/utils/paths.js");
+    paths.getKarajanHome.mockReturnValue(tmpHome);
+    ({ getCachedMeta, isFresh, recordInstall, clearCache, listCached, getCacheRoot, DEFAULT_TTL_MS } = await import("../../src/skills/skills-cache.js"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("getCachedMeta returns null when skill is not cached", async () => {
+    expect(await getCachedMeta("nonexistent")).toBeNull();
+  });
+
+  it("recordInstall writes meta.json and getCachedMeta reads it back", async () => {
+    await recordInstall("java-code-review", { source: "java-code-review" });
+    const meta = await getCachedMeta("java-code-review");
+    expect(meta).toBeTruthy();
+    expect(meta.name).toBe("java-code-review");
+    expect(meta.source).toBe("java-code-review");
+    expect(typeof meta.cachedAt).toBe("string");
+  });
+
+  it("isFresh is true right after recordInstall", async () => {
+    await recordInstall("react-patterns");
+    expect(await isFresh("react-patterns")).toBe(true);
+  });
+
+  it("isFresh is false when the TTL has elapsed", async () => {
+    await recordInstall("react-patterns");
+    // Simulate 8 days elapsed by rewriting the meta file
+    const metaFile = path.join(getCacheRoot(), "react-patterns", "meta.json");
+    const old = JSON.parse(await fs.readFile(metaFile, "utf8"));
+    old.cachedAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    await fs.writeFile(metaFile, JSON.stringify(old));
+    expect(await isFresh("react-patterns")).toBe(false);
+  });
+
+  it("isFresh respects a custom TTL", async () => {
+    await recordInstall("react-patterns");
+    // TTL=0 forces "always stale"; the delta since cachedAt is never < 0.
+    expect(await isFresh("react-patterns", 0)).toBe(false);
+    expect(await isFresh("react-patterns", 60_000)).toBe(true);
+  });
+
+  it("clearCache empties the cache directory", async () => {
+    await recordInstall("a");
+    await recordInstall("b");
+    const before = await listCached();
+    expect(before).toHaveLength(2);
+
+    const { removed } = await clearCache();
+    expect(removed).toBe(2);
+
+    const after = await listCached();
+    expect(after).toHaveLength(0);
+  });
+
+  it("listCached sorts oldest first and flags fresh/stale", async () => {
+    await recordInstall("old-skill");
+    const metaFile = path.join(getCacheRoot(), "old-skill", "meta.json");
+    const staleMeta = JSON.parse(await fs.readFile(metaFile, "utf8"));
+    staleMeta.cachedAt = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    await fs.writeFile(metaFile, JSON.stringify(staleMeta));
+
+    await recordInstall("new-skill");
+
+    const list = await listCached();
+    expect(list).toHaveLength(2);
+    expect(list[0].name).toBe("old-skill");
+    expect(list[0].fresh).toBe(false);
+    expect(list[1].name).toBe("new-skill");
+    expect(list[1].fresh).toBe(true);
+  });
+
+  it("sanitizes skill names for directory paths (no shell-sensitive chars)", async () => {
+    await recordInstall("weird/name with spaces");
+    const entries = await fs.readdir(getCacheRoot());
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).not.toContain("/");
+    expect(entries[0]).not.toContain(" ");
+  });
+
+  it("DEFAULT_TTL_MS is 7 days", () => {
+    expect(DEFAULT_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/tests/skills/fallback.test.js
+++ b/tests/skills/fallback.test.js
@@ -10,6 +10,11 @@ vi.mock("../../src/skills/skill-loader.js", () => ({
   loadAvailableSkills: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("../../src/skills/skills-cache.js", () => ({
+  isFresh: vi.fn().mockResolvedValue(false),
+  recordInstall: vi.fn().mockResolvedValue(undefined),
+}));
+
 describe("skills/fallback — graceful degradation when openskills CLI is missing", () => {
   let autoInstallSkills, client;
 
@@ -19,6 +24,9 @@ describe("skills/fallback — graceful degradation when openskills CLI is missin
     client = await import("../../src/skills/openskills-client.js");
     const loader = await import("../../src/skills/skill-loader.js");
     loader.loadAvailableSkills.mockResolvedValue([]);
+    const cache = await import("../../src/skills/skills-cache.js");
+    cache.isFresh.mockResolvedValue(false);
+    cache.recordInstall.mockResolvedValue(undefined);
   });
 
   it("returns osAvailable:false and wouldHaveUsed when CLI is missing", async () => {

--- a/tests/skills/fallback.test.js
+++ b/tests/skills/fallback.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+  installSkill: vi.fn(),
+  removeSkill: vi.fn(),
+}));
+
+vi.mock("../../src/skills/skill-loader.js", () => ({
+  loadAvailableSkills: vi.fn().mockResolvedValue([]),
+}));
+
+describe("skills/fallback — graceful degradation when openskills CLI is missing", () => {
+  let autoInstallSkills, client;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ autoInstallSkills } = await import("../../src/skills/skill-detector.js"));
+    client = await import("../../src/skills/openskills-client.js");
+    const loader = await import("../../src/skills/skill-loader.js");
+    loader.loadAvailableSkills.mockResolvedValue([]);
+  });
+
+  it("returns osAvailable:false and wouldHaveUsed when CLI is missing", async () => {
+    client.isOpenSkillsAvailable.mockResolvedValue(false);
+
+    const result = await autoInstallSkills(["java", "pytest-patterns"], "/proj");
+
+    expect(result.osAvailable).toBe(false);
+    expect(result.wouldHaveUsed).toEqual(["java", "pytest-patterns"]);
+    expect(result.installed).toEqual([]);
+    expect(client.installSkill).not.toHaveBeenCalled();
+  });
+
+  it("does NOT report already-installed skills as wouldHaveUsed", async () => {
+    client.isOpenSkillsAvailable.mockResolvedValue(false);
+    const loader = await import("../../src/skills/skill-loader.js");
+    loader.loadAvailableSkills.mockResolvedValue([{ name: "java", content: "" }]);
+
+    const result = await autoInstallSkills(["java", "pytest-patterns"], "/proj");
+
+    expect(result.osAvailable).toBe(false);
+    expect(result.wouldHaveUsed).toEqual(["pytest-patterns"]);
+  });
+
+  it("returns osAvailable:true and installs normally when CLI is present", async () => {
+    client.isOpenSkillsAvailable.mockResolvedValue(true);
+    client.installSkill.mockResolvedValue({ ok: true, name: "java" });
+
+    const result = await autoInstallSkills(["java"], "/proj");
+
+    expect(result.osAvailable).toBe(true);
+    expect(result.wouldHaveUsed).toEqual([]);
+    expect(result.installed).toEqual(["java"]);
+    expect(client.installSkill).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing and returns osAvailable:true when neededSkills is empty", async () => {
+    const result = await autoInstallSkills([], "/proj");
+
+    expect(result.installed).toEqual([]);
+    expect(result.wouldHaveUsed).toEqual([]);
+    expect(result.osAvailable).toBe(true);
+    expect(client.isOpenSkillsAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/tests/skills/integration.test.js
+++ b/tests/skills/integration.test.js
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+vi.mock("../../src/skills/openskills-client.js", () => ({
+  isOpenSkillsAvailable: vi.fn(),
+  installSkill: vi.fn(),
+  removeSkill: vi.fn(),
+}));
+
+vi.mock("../../src/skills/skill-loader.js", async () => {
+  const actual = await vi.importActual("../../src/skills/skill-loader.js");
+  return {
+    ...actual,
+    loadAvailableSkills: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("../../src/skills/skills-cache.js", () => ({
+  isFresh: vi.fn().mockResolvedValue(false),
+  recordInstall: vi.fn().mockResolvedValue(undefined),
+}));
+
+/**
+ * End-to-end(-ish) integration: detectNeededSkills + autoInstallSkills +
+ * buildSkillSection, wired together with the role filter and Claude dedup.
+ * Covers the full "detect → install → inject into role prompt" pipeline.
+ */
+
+async function mkTmpProject() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "kj-skills-integ-"));
+}
+
+describe("skills integration — detect → install → inject", () => {
+  const cleanups = [];
+  let detectNeededSkills, autoInstallSkills;
+  let buildSkillSection, filterSkillsForRole;
+  let client;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ detectNeededSkills, autoInstallSkills } = await import("../../src/skills/skill-detector.js"));
+    ({ buildSkillSection, filterSkillsForRole } = await import("../../src/skills/skill-loader.js"));
+    client = await import("../../src/skills/openskills-client.js");
+    const loader = await import("../../src/skills/skill-loader.js");
+    loader.loadAvailableSkills.mockResolvedValue([]);
+    const cache = await import("../../src/skills/skills-cache.js");
+    cache.isFresh.mockResolvedValue(false);
+    cache.recordInstall.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+    cleanups.length = 0;
+  });
+
+  it("Python project with pandas + pytest → installs python-data + pytest-patterns; reviewer gets neither", async () => {
+    const dir = await mkTmpProject();
+    cleanups.push(dir);
+    await fs.writeFile(path.join(dir, "requirements.txt"), "pandas==2.2.0\npytest==8.0.0\n");
+
+    client.isOpenSkillsAvailable.mockResolvedValue(true);
+    client.installSkill.mockImplementation(async (name) => ({ ok: true, name }));
+
+    const detected = await detectNeededSkills("clean the data and write tests", dir);
+    expect(detected).toContain("python-data");
+    expect(detected).toContain("pytest-patterns");
+
+    const installed = await autoInstallSkills(detected, dir);
+    expect(installed.installed).toContain("python-data");
+    expect(installed.installed).toContain("pytest-patterns");
+
+    // Reviewer filter: neither pytest-patterns nor python-data should reach the reviewer.
+    const skills = installed.installed.map((n) => ({ name: n, content: `skill ${n}` }));
+    const reviewerOnly = filterSkillsForRole(skills, "reviewer");
+    expect(reviewerOnly.map((s) => s.name)).not.toContain("python-data");
+    expect(reviewerOnly.map((s) => s.name)).not.toContain("pytest-patterns");
+  });
+
+  it("Java project with pom.xml → coder sees java, reviewer sees java-code-review only when it exists in skills catalog", async () => {
+    const dir = await mkTmpProject();
+    cleanups.push(dir);
+    await fs.writeFile(path.join(dir, "pom.xml"), "<project/>");
+
+    const detected = await detectNeededSkills("refactor the service layer", dir);
+    expect(detected).toContain("java");
+
+    // The coder gets the java skill; reviewer filter keeps only *-code-review.
+    const skills = [
+      { name: "java", content: "java general" },
+      { name: "java-code-review", content: "java code review" },
+    ];
+    const coderView = filterSkillsForRole(skills, "coder");
+    const reviewerView = filterSkillsForRole(skills, "reviewer");
+    expect(coderView.map((s) => s.name)).toEqual(["java", "java-code-review"]);
+    expect(reviewerView.map((s) => s.name)).toEqual(["java-code-review"]);
+  });
+
+  it("Claude provider dedups skill content in reviewer prompt", async () => {
+    const skills = [
+      { name: "java-code-review", content: "Long java review checklist...\n- null handling\n- etc" },
+      { name: "owasp-top-10", content: "OWASP top 10 details..." },
+    ];
+    const section = buildSkillSection(skills, { role: "reviewer", provider: "claude" });
+    expect(section).toContain("java-code-review");
+    expect(section).toContain("owasp-top-10");
+    expect(section).not.toContain("Long java review checklist");
+    expect(section).toContain("Agent Skills capability");
+  });
+
+  it("OpenSkills CLI missing → installed is empty, wouldHaveUsed is populated", async () => {
+    const dir = await mkTmpProject();
+    cleanups.push(dir);
+    await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ dependencies: { astro: "^4.0.0" } }));
+
+    client.isOpenSkillsAvailable.mockResolvedValue(false);
+
+    const detected = await detectNeededSkills("build a landing", dir);
+    expect(detected).toContain("astro");
+
+    const result = await autoInstallSkills(detected, dir);
+    expect(result.osAvailable).toBe(false);
+    expect(result.installed).toEqual([]);
+    expect(result.wouldHaveUsed).toContain("astro");
+  });
+
+  it("Empty task + empty project → no skills detected, no install attempted", async () => {
+    const dir = await mkTmpProject();
+    cleanups.push(dir);
+    const detected = await detectNeededSkills("", dir);
+    expect(detected).toEqual([]);
+
+    const result = await autoInstallSkills(detected, dir);
+    expect(result.installed).toEqual([]);
+    expect(result.wouldHaveUsed).toEqual([]);
+    expect(client.isOpenSkillsAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/tests/skills/role-filter.test.js
+++ b/tests/skills/role-filter.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { buildSkillSection, filterSkillsForRole } from "../../src/skills/skill-loader.js";
+
+const SAMPLE_SKILLS = [
+  { name: "react-patterns", content: "react" },
+  { name: "java-code-review", content: "java code review" },
+  { name: "java-security-checks", content: "java security" },
+  { name: "pytest-patterns", content: "pytest" },
+  { name: "sql-analysis", content: "sql" },
+  { name: "prisma", content: "prisma" },
+  { name: "owasp-top-10", content: "owasp" },
+  { name: "python-data", content: "pandas" },
+];
+
+describe("skills/role-filter — filterSkillsForRole", () => {
+  describe("reviewer", () => {
+    it("includes *-code-review + security + sql-analysis allowlist, excludes irrelevant patterns", () => {
+      const names = filterSkillsForRole(SAMPLE_SKILLS, "reviewer").map((s) => s.name);
+      expect(names).toContain("java-code-review");
+      expect(names).toContain("java-security-checks");
+      expect(names).toContain("owasp-top-10");
+      expect(names).toContain("sql-analysis");
+      expect(names).not.toContain("react-patterns");
+      expect(names).not.toContain("pytest-patterns");
+      expect(names).not.toContain("python-data");
+    });
+  });
+
+  describe("architect", () => {
+    it("accepts broad context (anything except test-framework patterns)", () => {
+      const names = filterSkillsForRole(SAMPLE_SKILLS, "architect").map((s) => s.name);
+      // Architecture touches everything: patterns, databases, cloud, security...
+      expect(names).toContain("react-patterns");
+      expect(names).toContain("sql-analysis");
+      expect(names).toContain("prisma");
+      expect(names).toContain("owasp-top-10");
+      expect(names).toContain("python-data");
+      // But NOT test frameworks — those belong to the tester role.
+      expect(names).not.toContain("pytest-patterns");
+    });
+  });
+
+  describe("tester", () => {
+    it("includes *-test/pytest/vitest/jest/playwright patterns only", () => {
+      const extended = [
+        ...SAMPLE_SKILLS,
+        { name: "vitest-patterns", content: "" },
+        { name: "jest-patterns", content: "" },
+        { name: "playwright-patterns", content: "" },
+      ];
+      const names = filterSkillsForRole(extended, "tester").map((s) => s.name);
+      expect(names).toContain("pytest-patterns");
+      expect(names).toContain("vitest-patterns");
+      expect(names).toContain("jest-patterns");
+      expect(names).toContain("playwright-patterns");
+      expect(names).not.toContain("react-patterns");
+      expect(names).not.toContain("sql-analysis");
+    });
+  });
+
+  describe("security", () => {
+    it("includes only *-security / owasp / sast", () => {
+      const names = filterSkillsForRole(SAMPLE_SKILLS, "security").map((s) => s.name);
+      expect(names).toContain("java-security-checks");
+      expect(names).toContain("owasp-top-10");
+      expect(names).not.toContain("pytest-patterns");
+      expect(names).not.toContain("react-patterns");
+    });
+  });
+
+  describe("coder (unknown role) returns everything", () => {
+    it("passes all skills through unchanged", () => {
+      const names = filterSkillsForRole(SAMPLE_SKILLS, "coder").map((s) => s.name);
+      expect(names).toHaveLength(SAMPLE_SKILLS.length);
+    });
+
+    it("returns all when role is null/undefined", () => {
+      expect(filterSkillsForRole(SAMPLE_SKILLS, undefined)).toHaveLength(SAMPLE_SKILLS.length);
+      expect(filterSkillsForRole(SAMPLE_SKILLS, null)).toHaveLength(SAMPLE_SKILLS.length);
+    });
+  });
+});
+
+describe("skills/role-filter — buildSkillSection applies filter", () => {
+  it("filters before rendering when role is given", () => {
+    const section = buildSkillSection(SAMPLE_SKILLS, { role: "reviewer" });
+    expect(section).toContain("java-code-review");
+    expect(section).not.toContain("react-patterns");
+  });
+
+  it("returns empty string when no skill matches the role filter", () => {
+    const onlyReactSkills = [{ name: "react-patterns", content: "react" }];
+    const section = buildSkillSection(onlyReactSkills, { role: "tester" });
+    expect(section).toBe("");
+  });
+
+  it("anthropic + role applies both filter and reference-mode dedup", () => {
+    const section = buildSkillSection(SAMPLE_SKILLS, { role: "reviewer", provider: "claude" });
+    expect(section).toContain("Agent Skills capability");
+    expect(section).toContain("java-code-review");
+    expect(section).not.toContain("java code review"); // content not inlined
+    expect(section).not.toContain("react-patterns"); // filtered out
+  });
+});

--- a/tests/skills/semantic.test.js
+++ b/tests/skills/semantic.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/agents/index.js", () => ({
+  createAgent: vi.fn(),
+}));
+
+vi.mock("../../src/config.js", () => ({
+  resolveRole: vi.fn(),
+}));
+
+describe("skills/semantic-detector", () => {
+  let refineSkillsSemantically, resolveSkillsMode, SEMANTIC_CATALOG;
+  let createAgent, resolveRole;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ refineSkillsSemantically, resolveSkillsMode, SEMANTIC_CATALOG } =
+      await import("../../src/skills/semantic-detector.js"));
+    ({ createAgent } = await import("../../src/agents/index.js"));
+    ({ resolveRole } = await import("../../src/config.js"));
+  });
+
+  describe("resolveSkillsMode", () => {
+    it("defaults to auto in production (global override absent)", () => {
+      const saved = globalThis.__KJ_DEFAULT_SKILLS_MODE;
+      delete globalThis.__KJ_DEFAULT_SKILLS_MODE;
+      try {
+        expect(resolveSkillsMode({})).toBe("auto");
+        expect(resolveSkillsMode({}, {})).toBe("auto");
+      } finally {
+        if (saved !== undefined) globalThis.__KJ_DEFAULT_SKILLS_MODE = saved;
+      }
+    });
+
+    it("respects globalThis.__KJ_DEFAULT_SKILLS_MODE (test harness override)", () => {
+      // Our tests/setup.js sets this to "regex". Assert that it propagates.
+      expect(resolveSkillsMode({})).toBe("regex");
+    });
+
+    it("reads from flags.skillsMode first", () => {
+      expect(resolveSkillsMode({ skills: { mode: "none" } }, { skillsMode: "semantic" })).toBe("semantic");
+    });
+
+    it("falls back to config.skills.mode", () => {
+      expect(resolveSkillsMode({ skills: { mode: "regex" } })).toBe("regex");
+    });
+
+    it("clamps unknown values to auto", () => {
+      expect(resolveSkillsMode({}, { skillsMode: "bogus" })).toBe("auto");
+    });
+
+    it("accepts all 4 documented modes", () => {
+      for (const mode of ["auto", "regex", "semantic", "none"]) {
+        expect(resolveSkillsMode({}, { skillsMode: mode })).toBe(mode);
+      }
+    });
+  });
+
+  describe("refineSkillsSemantically", () => {
+    it("returns [] when no triage/planner provider is configured", async () => {
+      resolveRole.mockReturnValue({ provider: null });
+      const logger = { debug: vi.fn() };
+      const out = await refineSkillsSemantically({ task: "build X", config: {}, logger });
+      expect(out).toEqual([]);
+      expect(createAgent).not.toHaveBeenCalled();
+    });
+
+    it("returns [] when the agent fails to create", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockImplementation(() => { throw new Error("no API key"); });
+      const logger = { debug: vi.fn() };
+      const out = await refineSkillsSemantically({ task: "build X", config: {}, logger });
+      expect(out).toEqual([]);
+    });
+
+    it("returns [] when agent.runTask returns not-ok", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockReturnValue({
+        runTask: vi.fn().mockResolvedValue({ ok: false }),
+      });
+      const logger = { debug: vi.fn() };
+      const out = await refineSkillsSemantically({ task: "x", config: {}, logger });
+      expect(out).toEqual([]);
+    });
+
+    it("returns parsed skills, filtered to the catalog and excluding already-detected", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockReturnValue({
+        runTask: vi.fn().mockResolvedValue({
+          ok: true,
+          output: '["sql-analysis","hallucinated-skill","owasp-top-10","prisma"]',
+        }),
+      });
+      const out = await refineSkillsSemantically({
+        task: "add migration tracking",
+        alreadyDetected: ["prisma"],
+        config: {},
+        logger: { debug: vi.fn(), warn: vi.fn() },
+      });
+      expect(out).toContain("sql-analysis");
+      expect(out).toContain("owasp-top-10");
+      expect(out).not.toContain("hallucinated-skill"); // not in catalog
+      expect(out).not.toContain("prisma"); // already detected
+    });
+
+    it("limits results to 5 suggestions", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockReturnValue({
+        runTask: vi.fn().mockResolvedValue({
+          ok: true,
+          output: JSON.stringify(SEMANTIC_CATALOG.slice(0, 10)),
+        }),
+      });
+      const out = await refineSkillsSemantically({ task: "x", config: {}, logger: { debug: vi.fn() } });
+      expect(out.length).toBeLessThanOrEqual(5);
+    });
+
+    it("returns [] on malformed classifier output", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockReturnValue({
+        runTask: vi.fn().mockResolvedValue({ ok: true, output: "nope, no JSON here" }),
+      });
+      const out = await refineSkillsSemantically({ task: "x", config: {}, logger: { debug: vi.fn() } });
+      expect(out).toEqual([]);
+    });
+
+    it("returns [] on classifier throw", async () => {
+      resolveRole.mockImplementation((_, role) => role === "triage" ? { provider: "claude" } : { provider: null });
+      createAgent.mockReturnValue({
+        runTask: vi.fn().mockRejectedValue(new Error("network")),
+      });
+      const logger = { warn: vi.fn(), debug: vi.fn() };
+      const out = await refineSkillsSemantically({ task: "x", config: {}, logger });
+      expect(out).toEqual([]);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it("returns [] when task is empty", async () => {
+      const out = await refineSkillsSemantically({ task: "", config: {} });
+      expect(out).toEqual([]);
+      expect(createAgent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/skills/skill-detector-extended.test.js
+++ b/tests/skills/skill-detector-extended.test.js
@@ -1,0 +1,199 @@
+import { describe, expect, it, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { detectNeededSkills } from "../../src/skills/skill-detector.js";
+
+async function mkTmpProject() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "kj-detector-ext-"));
+}
+
+describe("skills/skill-detector — extended detection", () => {
+  const cleanups = [];
+
+  afterEach(async () => {
+    for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+    cleanups.length = 0;
+  });
+
+  describe(".NET", () => {
+    it("detects dotnet when a .csproj file exists", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "App.csproj"), "<Project/>");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("dotnet");
+    });
+
+    it("detects dotnet when a .sln file exists", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "MyApp.sln"), "Solution");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("dotnet");
+    });
+  });
+
+  describe("Python deps", () => {
+    it("detects python-data when pandas is in requirements.txt", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "requirements.txt"), "pandas==2.2.0\nnumpy>=1.24\n# scipy commented\n");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("python-data");
+    });
+
+    it("detects python-ml when torch is in pyproject.toml", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "pyproject.toml"), '[project]\ndependencies = ["torch", "pandas"]\n');
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("python-ml");
+      expect(skills).toContain("python-data");
+    });
+
+    it("detects pytest-patterns when pytest is in requirements.txt", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "requirements.txt"), "pytest==8.0.0\n");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("pytest-patterns");
+    });
+
+    it("skips commented-out deps in requirements.txt", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "requirements.txt"), "# pandas==2.2.0\n");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).not.toContain("python-data");
+    });
+  });
+
+  describe("Data / ML", () => {
+    it("detects python-data when a .ipynb file exists in the repo", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "analysis.ipynb"), '{"cells": []}');
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("python-data");
+    });
+
+    it("finds notebooks in nested directories up to maxDepth", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.mkdir(path.join(dir, "notebooks"));
+      await fs.writeFile(path.join(dir, "notebooks", "nb.ipynb"), "{}");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("python-data");
+    });
+
+    it("ignores node_modules during extension walk", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.mkdir(path.join(dir, "node_modules", "pkg"), { recursive: true });
+      await fs.writeFile(path.join(dir, "node_modules", "pkg", "fixture.ipynb"), "{}");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).not.toContain("python-data");
+    });
+  });
+
+  describe("Databases", () => {
+    it("detects sql-analysis when any .sql file exists in the repo", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.mkdir(path.join(dir, "db"));
+      await fs.writeFile(path.join(dir, "db", "schema.sql"), "CREATE TABLE users ();");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("sql-analysis");
+    });
+
+    it("detects prisma when schema.prisma exists", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "schema.prisma"), "generator client {}");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("prisma");
+    });
+
+    it("detects sql-analysis via migrations directory", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.mkdir(path.join(dir, "migrations"));
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("sql-analysis");
+    });
+  });
+
+  describe("Testing frameworks via package.json", () => {
+    it("detects playwright-patterns when @playwright/test is a dep", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({
+        devDependencies: { "@playwright/test": "^1.40.0" }
+      }));
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("playwright-patterns");
+    });
+
+    it("detects vitest-patterns when vitest is a dep", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({
+        devDependencies: { vitest: "^1.0.0" }
+      }));
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("vitest-patterns");
+    });
+  });
+
+  describe("Extension walk bounds", () => {
+    it("respects maxDepth option", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      // Put the marker file 4 levels deep
+      const deep = path.join(dir, "a", "b", "c", "d");
+      await fs.mkdir(deep, { recursive: true });
+      await fs.writeFile(path.join(deep, "App.csproj"), "<Project/>");
+      const defaultDepthSkills = await detectNeededSkills("", dir); // default 3
+      expect(defaultDepthSkills).not.toContain("dotnet");
+      const deeperSkills = await detectNeededSkills("", dir, { maxDepth: 5 });
+      expect(deeperSkills).toContain("dotnet");
+    });
+
+    it("can disable the extension walk entirely", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "App.csproj"), "<Project/>");
+      const skills = await detectNeededSkills("", dir, { includeExtensions: false });
+      expect(skills).not.toContain("dotnet");
+    });
+  });
+
+  describe("Backwards compat", () => {
+    it("still detects astro via package.json and reacts to frontend text", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({
+        dependencies: { astro: "^4.0.0" }
+      }));
+      const skills = await detectNeededSkills("build a landing page CSS", dir);
+      expect(skills).toContain("astro");
+      expect(skills).toContain("frontend-design");
+    });
+
+    it("still detects java via pom.xml", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      await fs.writeFile(path.join(dir, "pom.xml"), "<project/>");
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toContain("java");
+    });
+
+    it("returns empty array when no signals and no task text", async () => {
+      const dir = await mkTmpProject();
+      cleanups.push(dir);
+      const skills = await detectNeededSkills("", dir);
+      expect(skills).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes KJC-TSK-0321. Last of the 3 hojas unblocking the Brain decisor (KJC-TSK-0322) — all blockers (D, B, C) now closed.

## What this does

### Extended detection
- Adds .NET (*.csproj, *.sln), Python data/ML (pandas, numpy, torch, scikit-learn, pytest) via requirements.txt + pyproject.toml, SQL (*.sql anywhere + schema.prisma + migrations/), Prisma, Jupyter (*.ipynb), JS test frameworks (vitest, jest, playwright, cypress).
- Bounded recursive walk (maxDepth=3) skipping node_modules, .git, venv, etc.
- New options: { includeExtensions, maxDepth } on detectNeededSkills.

### Role-specific filtering
- buildSkillSection(skills, { provider, role }) filters skills per role:
  - coder: no filter (broad context)
  - reviewer: code-review + security + lint + style + sql-analysis
  - architect/planner: broad except test frameworks
  - tester: only test-framework patterns
  - security: only *-security / owasp / sast
- tester-role.js and security-role.js now inject their filtered skill section.

### Graceful fallback + report
- autoInstallSkills returns { osAvailable, wouldHaveUsed } when `npx openskills` is missing.
- Orchestrator emits a dedicated `skills:unavailable` event with the recommendation list, so the session report surfaces what would have been used.
- Pipeline never blocks on missing CLI.

### Local cache with 7-day TTL
- ~/.karajan/skills-cache/<skill>/meta.json records install time.
- autoInstallSkills skips `npx openskills install` when cache is fresh (saves 10-30s per skill).
- New subcommand: `kj skills list` / `kj skills clear-cache`.

### Semantic mode
- New --skills-mode=auto|regex|semantic|none flag; config.skills.mode also supported.
- Semantic mode uses the triage classifier to refine regex detection from a curated catalog (28 skills). Graceful degradation when classifier unavailable.
- auto (default in production) = regex + semantic.

### Docs
- docs/skills.md documents all modes, role mapping, cache behavior, Claude dedup.

## Commits
1. feat(skills): extended detection — .NET, Python deps, data/ML, DB/prisma, test frameworks
2. feat(skills): role-specific skill filtering
3. feat(skills): graceful fallback + wouldHaveUsed report
4. feat(skills): ~/.karajan/skills-cache with 7-day TTL + kj skills subcommand
5. feat(skills): --skills-mode flag + semantic classifier detection
6. docs(skills): document modes, role filter, cache, Claude dedup + integration tests

## Test plan
- [x] npx vitest run → 3404 tests pass (263 files, +159 new)
- [x] Extended detection: 19 unit tests covering all new stacks
- [x] Role filter: 13 assertions across 5 roles
- [x] Cache: 9 tests covering TTL, fresh/stale, sanitization
- [x] Semantic: 13 tests covering all failure modes + catalog filtering
- [x] Integration: 5 end-to-end scenarios (detect → install → inject)
- [ ] Smoke test kj run with --skills-mode=semantic on a Java project