### PR TITLE
feat(journal): persist decisions.md with Solomon rulings + Brain decisions (KJC-TSK-0287)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -420,12 +420,16 @@ async function finalizeApprovedSession({ config, gitCtx, task, logger, session, 
   if (journalDir) {
     try {
       await writeIterationsJournal(journalDir, session._journalIterations || []);
-      await writeDecisionsJournal(journalDir, session._journalDecisions || []);
+      // decisions.md: writes only when Solomon was invoked (AC of KJC-TSK-0287).
+      // Pulls structured data from session.solomonRulings + session.brainDecisions.
+      const { writeDecisionsJournal: writeDecisionsJournalV2 } =
+        await import("./session/journal/decisions-writer.js");
+      const decisionsResult = await writeDecisionsJournalV2(session, { journalDir, logger });
       const hasTree = await writeTreeJournal(journalDir, session.session_start_sha);
 
       const journalFiles = [...(session._journalFiles || [])];
       if (session._journalIterations?.length) journalFiles.push("iterations.md");
-      if (session._journalDecisions?.length) journalFiles.push("decisions.md");
+      if (decisionsResult.written) journalFiles.push("decisions.md");
       if (hasTree) journalFiles.push("tree.txt");
 
       await writeSummaryJournal(journalDir, {

--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -156,6 +156,27 @@ export async function invokeSolomon({ config, logger, emitter, eventBase, stage,
     subtask: ruling.result?.subtask?.title || null
   });
 
+  // Record the ruling for the session journal (decisions.md). Lazy-import so
+  // this module stays free of journal-specific deps for callers that don't
+  // need them.
+  try {
+    const { recordSolomonRuling } = await import("../session/journal/decisions-writer.js");
+    recordSolomonRuling(session, {
+      stage: conflict?.stage || stage,
+      trigger: conflict?.reason || conflict?.summary || "solomon invoked",
+      conflict: {
+        task: conflict?.task,
+        reason: conflict?.reason,
+        summary: conflict?.summary,
+        iterationCount: conflict?.iterationCount,
+      },
+      ruling: ruling.result?.ruling || (ruling.ok ? "continue" : "escalate_human"),
+      reasoning: ruling.result?.reasoning || ruling.summary || "",
+      conditions: ruling.result?.conditions || [],
+      alternativeAgent: ruling.result?.alternativeAgent || null,
+    });
+  } catch { /* best-effort, don't break the pipeline on a journal hiccup */ }
+
   if (!ruling.ok) {
     const reason = ruling.result?.escalate_reason || solomonError || ruling.summary;
     return escalateToHuman({

--- a/src/session/journal/decisions-writer.js
+++ b/src/session/journal/decisions-writer.js
@@ -146,19 +146,24 @@ export function buildDecisionsMarkdown(session) {
 }
 
 /**
- * Persist decisions.md to the session directory. No-op when there are no
- * Solomon rulings.
+ * Persist decisions.md to the session's journal directory. No-op when there
+ * are no Solomon rulings (per acceptance criteria).
+ *
+ * Path resolution (first match wins):
+ *   1. options.journalDir       — direct path to the session journal directory
+ *   2. options.sessionRoot + id — combines with session.id
+ *   3. getSessionRoot() + id    — default Karajan session root
  *
  * @param {Object} session
- * @param {{ sessionRoot?: string, logger?: Object }} [options]
+ * @param {{ journalDir?: string, sessionRoot?: string, logger?: Object }} [options]
  * @returns {Promise<{ written: boolean, path: string|null }>}
  */
 export async function writeDecisionsJournal(session, options = {}) {
   const content = buildDecisionsMarkdown(session);
   if (content === null) return { written: false, path: null };
 
-  const sessionRoot = options.sessionRoot || getSessionRoot();
-  const sessionDir = path.join(sessionRoot, session.id);
+  const sessionDir = options.journalDir
+    || path.join(options.sessionRoot || getSessionRoot(), session.id);
   const filePath = path.join(sessionDir, "decisions.md");
   try {
     await fs.mkdir(sessionDir, { recursive: true });

--- a/src/session/journal/decisions-writer.js
+++ b/src/session/journal/decisions-writer.js
@@ -1,0 +1,195 @@
+/**
+ * Build a human-readable `decisions.md` journal file summarizing every
+ * Solomon ruling and Brain decision made during a session.
+ *
+ * Acceptance criterion (KJC-TSK-0287):
+ *   - Given Solomon was invoked at least once → decisions.md is written with
+ *     timestamp, trigger, conflict context, ruling (action + reasoning),
+ *     and resulting actions for every invocation.
+ *   - Given Solomon was NOT invoked → decisions.md is NOT created.
+ *
+ * Brain routing decisions (from KJC-TSK-0322) are appended as a secondary
+ * section when present, since they share the same "decisions" semantics.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getSessionRoot } from "../../utils/paths.js";
+
+/**
+ * @typedef {Object} SolomonRuling
+ * @property {string} at                         - ISO timestamp
+ * @property {string} stage                      - conflict stage (reviewer, brain-routing, ...)
+ * @property {string} trigger                    - short reason the invocation was triggered
+ * @property {Object} conflict                   - conflict context (task, reason, summary)
+ * @property {string} ruling                     - approve / continue / escalate_human / create_subtask / ...
+ * @property {string} [reasoning]
+ * @property {string[]} [conditions]
+ * @property {string} [alternativeAgent]
+ * @property {string} [result]                   - what the orchestrator did with the ruling
+ */
+
+/**
+ * @typedef {Object} BrainDecisionRecord
+ * @property {number} seq
+ * @property {string} at
+ * @property {string} intent
+ * @property {string[]} rolesOn
+ * @property {string} confidence
+ * @property {string} rationale
+ * @property {string[]} appliedOverrides
+ */
+
+function esc(text) {
+  return String(text ?? "").replace(/\|/g, "\\|");
+}
+
+function formatConditions(conditions) {
+  if (!Array.isArray(conditions) || conditions.length === 0) return "—";
+  return conditions.map((c) => `- ${esc(c)}`).join("\n");
+}
+
+function formatConflict(conflict) {
+  if (!conflict) return "—";
+  const parts = [];
+  if (conflict.task) parts.push(`**Task**: ${esc(conflict.task.slice(0, 200))}${conflict.task.length > 200 ? "…" : ""}`);
+  if (conflict.reason) parts.push(`**Reason**: ${esc(conflict.reason)}`);
+  if (conflict.summary) parts.push(`**Summary**: ${esc(conflict.summary)}`);
+  return parts.length > 0 ? parts.join("\n") : "—";
+}
+
+/**
+ * Render a Solomon ruling as a Markdown subsection.
+ * @param {SolomonRuling} ruling
+ * @param {number} index
+ * @returns {string}
+ */
+function renderRuling(ruling, index) {
+  const at = ruling.at || "(unknown timestamp)";
+  const header = `### ${index + 1}. Solomon @ ${at} — ${esc(ruling.ruling || "unknown")}`;
+  const lines = [
+    header,
+    "",
+    `- **Stage**: ${esc(ruling.stage || "?")}`,
+    `- **Trigger**: ${esc(ruling.trigger || "?")}`,
+    `- **Ruling**: \`${esc(ruling.ruling || "?")}\``,
+  ];
+  if (ruling.alternativeAgent) lines.push(`- **Alternative agent**: ${esc(ruling.alternativeAgent)}`);
+  if (ruling.result) lines.push(`- **Applied result**: ${esc(ruling.result)}`);
+  lines.push("");
+  if (ruling.reasoning) {
+    lines.push("**Reasoning:**", "");
+    lines.push(ruling.reasoning.trim(), "");
+  }
+  if (ruling.conditions?.length) {
+    lines.push("**Conditions:**", "");
+    lines.push(formatConditions(ruling.conditions), "");
+  }
+  lines.push("**Conflict context:**", "");
+  lines.push(formatConflict(ruling.conflict), "");
+  return lines.join("\n");
+}
+
+function renderBrainDecision(decision, index) {
+  return [
+    `### ${index + 1}. Brain @ ${decision.at} — ${esc(decision.intent)}`,
+    "",
+    `- **Confidence**: ${esc(decision.confidence)}`,
+    `- **Roles on**: ${(decision.rolesOn || []).map(esc).join(", ") || "—"}`,
+    `- **Overrides applied**: ${(decision.appliedOverrides || []).map(esc).join(", ") || "—"}`,
+    "",
+    `> ${esc(decision.rationale || "")}`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Build the Markdown content for a session. Returns `null` if no Solomon
+ * rulings are present (per acceptance criteria — no Solomon, no file).
+ *
+ * @param {Object} session
+ * @returns {string|null}
+ */
+export function buildDecisionsMarkdown(session) {
+  const rulings = Array.isArray(session?.solomonRulings) ? session.solomonRulings : [];
+  const brainDecisions = Array.isArray(session?.brainDecisions) ? session.brainDecisions : [];
+
+  // AC: no Solomon invocation → do not generate the file.
+  if (rulings.length === 0) return null;
+
+  const sessionId = session?.id || "(unknown)";
+  const header = [
+    `# Session decisions — ${sessionId}`,
+    "",
+    `_Generated at ${new Date().toISOString()}._`,
+    "",
+    `This journal records every decision the pipeline delegated to Solomon, plus Brain routing decisions for cross-reference.`,
+    "",
+    "## Summary",
+    "",
+    `- Solomon invocations: **${rulings.length}**`,
+    `- Brain routing decisions: **${brainDecisions.length}**`,
+    "",
+    "---",
+    "",
+    "## Solomon rulings",
+    "",
+  ].join("\n");
+
+  const solomonSection = rulings.map((r, i) => renderRuling(r, i)).join("\n---\n\n");
+
+  const brainSection = brainDecisions.length > 0
+    ? "\n---\n\n## Brain routing decisions\n\n" + brainDecisions.map((d, i) => renderBrainDecision(d, i)).join("\n")
+    : "";
+
+  return header + solomonSection + brainSection + "\n";
+}
+
+/**
+ * Persist decisions.md to the session directory. No-op when there are no
+ * Solomon rulings.
+ *
+ * @param {Object} session
+ * @param {{ sessionRoot?: string, logger?: Object }} [options]
+ * @returns {Promise<{ written: boolean, path: string|null }>}
+ */
+export async function writeDecisionsJournal(session, options = {}) {
+  const content = buildDecisionsMarkdown(session);
+  if (content === null) return { written: false, path: null };
+
+  const sessionRoot = options.sessionRoot || getSessionRoot();
+  const sessionDir = path.join(sessionRoot, session.id);
+  const filePath = path.join(sessionDir, "decisions.md");
+  try {
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(filePath, content, "utf8");
+    options.logger?.info?.(`Wrote decisions journal: ${filePath}`);
+    return { written: true, path: filePath };
+  } catch (err) {
+    options.logger?.warn?.(`Failed to write decisions journal (non-blocking): ${err.message}`);
+    return { written: false, path: null };
+  }
+}
+
+/**
+ * Append a Solomon ruling to session.solomonRulings. Creates the array if
+ * absent. Callers (invokeSolomon) pass the structured record.
+ *
+ * @param {Object} session
+ * @param {SolomonRuling} record
+ */
+export function recordSolomonRuling(session, record) {
+  if (!session) return;
+  if (!Array.isArray(session.solomonRulings)) session.solomonRulings = [];
+  session.solomonRulings.push({
+    at: record.at || new Date().toISOString(),
+    stage: record.stage || "unknown",
+    trigger: record.trigger || "",
+    conflict: record.conflict || {},
+    ruling: record.ruling || "unknown",
+    reasoning: record.reasoning || "",
+    conditions: Array.isArray(record.conditions) ? [...record.conditions] : [],
+    alternativeAgent: record.alternativeAgent || null,
+    result: record.result || "",
+  });
+}

--- a/tests/session/decisions-journal-integration.test.js
+++ b/tests/session/decisions-journal-integration.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  writeDecisionsJournal,
+  buildDecisionsMarkdown,
+  recordSolomonRuling,
+} from "../../src/session/journal/decisions-writer.js";
+
+/**
+ * Integration scenarios for the decisions.md journal:
+ *   - session with 0 Solomon invocations → no file
+ *   - session with 1 invocation → file exists with expected shape
+ *   - Brain decisions are appended when present
+ *   - integrates with options.journalDir (the path used by the existing
+ *     session-journal infrastructure)
+ */
+
+describe("decisions journal integration", () => {
+  const cleanups = [];
+
+  afterEach(async () => {
+    for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+    cleanups.length = 0;
+  });
+
+  async function mkTmpDir() {
+    const d = await fs.mkdtemp(path.join(os.tmpdir(), "kj-journal-integ-"));
+    cleanups.push(d);
+    return d;
+  }
+
+  it("AC: session where Solomon was NOT invoked → decisions.md is NOT created", async () => {
+    const journalDir = await mkTmpDir();
+    const session = {
+      id: "s-no-solomon",
+      solomonRulings: [], // explicit empty
+      brainDecisions: [
+        { seq: 1, at: "2026-04-19T11:00:00.000Z", intent: "sw:simple", rolesOn: ["coder"], confidence: "high", rationale: "r", appliedOverrides: [] }
+      ],
+    };
+    const result = await writeDecisionsJournal(session, { journalDir });
+    expect(result.written).toBe(false);
+    const files = await fs.readdir(journalDir);
+    expect(files).not.toContain("decisions.md");
+  });
+
+  it("AC: session where Solomon was invoked once → decisions.md exists with expected fields", async () => {
+    const journalDir = await mkTmpDir();
+    const session = { id: "s-with-solomon" };
+    recordSolomonRuling(session, {
+      stage: "reviewer",
+      trigger: "reviewer retry exhausted",
+      conflict: { task: "add rate limiter", reason: "style-only blocker", summary: "3 iterations" },
+      ruling: "approve_with_conditions",
+      reasoning: "Stylistic objections don't block correctness.",
+      conditions: ["open follow-up for naming"],
+    });
+    const result = await writeDecisionsJournal(session, { journalDir });
+    expect(result.written).toBe(true);
+    const content = await fs.readFile(result.path, "utf8");
+    expect(content).toContain("# Session decisions — s-with-solomon");
+    expect(content).toContain("Solomon invocations: **1**");
+    expect(content).toContain("approve_with_conditions");
+    expect(content).toContain("**Stage**: reviewer");
+    expect(content).toContain("**Trigger**: reviewer retry exhausted");
+    expect(content).toContain("Stylistic objections don't block correctness.");
+    expect(content).toContain("- open follow-up for naming");
+  });
+
+  it("multi-ruling session: each ruling is rendered as its own subsection separated by ---", async () => {
+    const session = { id: "s-multi" };
+    recordSolomonRuling(session, { stage: "reviewer", trigger: "first", conflict: { reason: "a" }, ruling: "approve", reasoning: "reason-1" });
+    recordSolomonRuling(session, { stage: "coder", trigger: "second", conflict: { reason: "b" }, ruling: "escalate_human", reasoning: "reason-2" });
+    const md = buildDecisionsMarkdown(session);
+    expect(md).toContain("Solomon invocations: **2**");
+    expect(md).toContain("reason-1");
+    expect(md).toContain("reason-2");
+    expect(md.split("\n---\n\n").length).toBeGreaterThanOrEqual(3); // header --- + between rulings
+  });
+
+  it("session with both Solomon rulings and Brain decisions includes both sections", async () => {
+    const journalDir = await mkTmpDir();
+    const session = {
+      id: "s-both",
+      brainDecisions: [
+        { seq: 1, at: "2026-04-19T10:00:00.000Z", intent: "refactor:medium", rolesOn: ["coder", "reviewer", "refactorer"], confidence: "high", rationale: "level=medium | taskType=refactor", appliedOverrides: [] }
+      ],
+    };
+    recordSolomonRuling(session, { stage: "reviewer", trigger: "retry", conflict: { reason: "style" }, ruling: "approve", reasoning: "style-only" });
+    const result = await writeDecisionsJournal(session, { journalDir });
+    const content = await fs.readFile(result.path, "utf8");
+    expect(content).toContain("## Solomon rulings");
+    expect(content).toContain("## Brain routing decisions");
+    expect(content).toContain("refactor:medium");
+  });
+
+  it("falls back gracefully when the journal directory is not writable", async () => {
+    const session = { id: "s-ro" };
+    recordSolomonRuling(session, { stage: "reviewer", trigger: "x", conflict: {}, ruling: "approve", reasoning: "y" });
+    const tmp = await mkTmpDir();
+    // Path under an existing file is not usable as a directory.
+    await fs.writeFile(path.join(tmp, "blocker"), "stub");
+    const badDir = path.join(tmp, "blocker", "under-a-file");
+    const logger = { info: () => {}, warn: () => {} };
+    const result = await writeDecisionsJournal(session, { journalDir: badDir, logger });
+    expect(result.written).toBe(false);
+    expect(result.path).toBeNull();
+  });
+});

--- a/tests/session/decisions-writer.test.js
+++ b/tests/session/decisions-writer.test.js
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  buildDecisionsMarkdown,
+  writeDecisionsJournal,
+  recordSolomonRuling,
+} from "../../src/session/journal/decisions-writer.js";
+
+function sampleRuling(overrides = {}) {
+  return {
+    at: "2026-04-19T11:00:00.000Z",
+    stage: "reviewer",
+    trigger: "reviewer retry exhausted",
+    conflict: { task: "add X", reason: "style-only", summary: "3 iterations, same blocker" },
+    ruling: "approve_with_conditions",
+    reasoning: "The blocker is stylistic; code is correct. Ship with a follow-up task.",
+    conditions: ["create follow-up task for naming"],
+    alternativeAgent: null,
+    result: "pipeline continued with conditions",
+    ...overrides,
+  };
+}
+
+describe("session/journal/decisions-writer — buildDecisionsMarkdown", () => {
+  it("returns null when there are NO Solomon rulings (AC: file not generated)", () => {
+    const md = buildDecisionsMarkdown({ id: "s1", solomonRulings: [], brainDecisions: [{ seq: 1, at: "x", intent: "sw:simple", rolesOn: [], confidence: "high", rationale: "" }] });
+    expect(md).toBeNull();
+  });
+
+  it("returns null when session has no solomonRulings field at all", () => {
+    expect(buildDecisionsMarkdown({ id: "s1" })).toBeNull();
+    expect(buildDecisionsMarkdown({})).toBeNull();
+  });
+
+  it("renders a Solomon ruling with all standard fields", () => {
+    const md = buildDecisionsMarkdown({ id: "s-test", solomonRulings: [sampleRuling()] });
+    expect(md).toContain("# Session decisions — s-test");
+    expect(md).toContain("## Solomon rulings");
+    expect(md).toContain("Solomon @ 2026-04-19T11:00:00.000Z");
+    expect(md).toContain("approve_with_conditions");
+    expect(md).toContain("**Stage**: reviewer");
+    expect(md).toContain("**Trigger**: reviewer retry exhausted");
+    expect(md).toContain("style-only");
+    expect(md).toContain("pipeline continued with conditions");
+    expect(md).toContain("- create follow-up task for naming");
+  });
+
+  it("includes Brain routing section when brainDecisions are present", () => {
+    const md = buildDecisionsMarkdown({
+      id: "s2",
+      solomonRulings: [sampleRuling()],
+      brainDecisions: [{
+        seq: 1,
+        at: "2026-04-19T10:55:00.000Z",
+        intent: "refactor:medium",
+        rolesOn: ["coder", "reviewer", "tester", "refactorer"],
+        confidence: "high",
+        rationale: "level=medium | taskType=refactor",
+        appliedOverrides: [],
+      }],
+    });
+    expect(md).toContain("## Brain routing decisions");
+    expect(md).toContain("Brain @ 2026-04-19T10:55:00.000Z — refactor:medium");
+    expect(md).toContain("coder, reviewer, tester, refactorer");
+  });
+
+  it("omits the Brain section when brainDecisions is empty", () => {
+    const md = buildDecisionsMarkdown({ id: "s3", solomonRulings: [sampleRuling()] });
+    expect(md).not.toContain("## Brain routing decisions");
+  });
+
+  it("summary counts match actual list lengths", () => {
+    const md = buildDecisionsMarkdown({
+      id: "s4",
+      solomonRulings: [sampleRuling(), sampleRuling({ at: "x2" })],
+      brainDecisions: [
+        { seq: 1, at: "x", intent: "sw:simple", rolesOn: [], confidence: "high", rationale: "r", appliedOverrides: [] },
+      ],
+    });
+    expect(md).toContain("Solomon invocations: **2**");
+    expect(md).toContain("Brain routing decisions: **1**");
+  });
+
+  it("escapes pipe characters to not break Markdown tables when they appear in text", () => {
+    const ruling = sampleRuling({ conflict: { reason: "a|b|c" } });
+    const md = buildDecisionsMarkdown({ id: "s5", solomonRulings: [ruling] });
+    expect(md).toContain("a\\|b\\|c");
+  });
+
+  it("truncates very long task text to 200 chars + ellipsis", () => {
+    // A 3000-char task → the markdown still shows only the first 200 chars + "…".
+    const longTask = "abc".repeat(1000); // 3000 chars
+    const ruling = sampleRuling({ conflict: { task: longTask } });
+    const md = buildDecisionsMarkdown({ id: "s6", solomonRulings: [ruling] });
+    expect(md).toContain("…");
+    // The task itself does NOT appear verbatim in the output.
+    expect(md).not.toContain(longTask);
+  });
+});
+
+describe("session/journal/decisions-writer — writeDecisionsJournal", () => {
+  const cleanups = [];
+
+  afterEach(async () => {
+    for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+    cleanups.length = 0;
+  });
+
+  it("returns { written: false, path: null } when no Solomon rulings", async () => {
+    const result = await writeDecisionsJournal({ id: "s-empty", solomonRulings: [] });
+    expect(result.written).toBe(false);
+    expect(result.path).toBeNull();
+  });
+
+  it("writes decisions.md inside the session directory when there are rulings", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-journal-"));
+    cleanups.push(tmp);
+    const result = await writeDecisionsJournal(
+      { id: "abc", solomonRulings: [sampleRuling()] },
+      { sessionRoot: tmp }
+    );
+    expect(result.written).toBe(true);
+    expect(result.path).toBe(path.join(tmp, "abc", "decisions.md"));
+    const content = await fs.readFile(result.path, "utf8");
+    expect(content).toContain("# Session decisions — abc");
+  });
+
+  it("returns written:false when fs write fails (non-blocking)", async () => {
+    // Create a read-only temp directory by chmod, then target a subdir there.
+    // This is faster than relying on /proc or Windows paths.
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-journal-ro-"));
+    cleanups.push(tmp);
+    // Make a path that's definitively unusable: a file masquerading as a dir.
+    await fs.writeFile(path.join(tmp, "blocker"), "file");
+    const badRoot = path.join(tmp, "blocker", "under-a-file");
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const result = await writeDecisionsJournal(
+      { id: "x", solomonRulings: [sampleRuling()] },
+      { sessionRoot: badRoot, logger }
+    );
+    expect(result.written).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  }, 10000);
+});
+
+describe("session/journal/decisions-writer — recordSolomonRuling", () => {
+  it("creates session.solomonRulings on first call", () => {
+    const session = {};
+    recordSolomonRuling(session, sampleRuling());
+    expect(session.solomonRulings).toHaveLength(1);
+    expect(session.solomonRulings[0].ruling).toBe("approve_with_conditions");
+  });
+
+  it("appends to an existing array", () => {
+    const session = { solomonRulings: [sampleRuling()] };
+    recordSolomonRuling(session, sampleRuling({ ruling: "escalate_human" }));
+    expect(session.solomonRulings).toHaveLength(2);
+    expect(session.solomonRulings[1].ruling).toBe("escalate_human");
+  });
+
+  it("auto-fills timestamp when not provided", () => {
+    const session = {};
+    recordSolomonRuling(session, { stage: "x", ruling: "approve" });
+    expect(session.solomonRulings[0].at).toBeTruthy();
+    expect(Date.parse(session.solomonRulings[0].at)).not.toBeNaN();
+  });
+
+  it("deep-copies conditions so later mutations don't leak", () => {
+    const session = {};
+    const conditions = ["a"];
+    recordSolomonRuling(session, { ...sampleRuling(), conditions });
+    conditions.push("b");
+    expect(session.solomonRulings[0].conditions).toEqual(["a"]);
+  });
+
+  it("is a no-op on null session (defensive)", () => {
+    expect(() => recordSolomonRuling(null, sampleRuling())).not.toThrow();
+  });
+});

--- a/tests/session/ruling-capture.test.js
+++ b/tests/session/ruling-capture.test.js
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * Focused test: after invokeSolomon() produces a ruling, session.solomonRulings
+ * must contain a journal-ready record. We mock SolomonRole to return a fixed
+ * ruling and assert the capture contract.
+ */
+
+const solomonRun = vi.fn();
+
+vi.mock("../../src/roles/solomon-role.js", () => ({
+  SolomonRole: class {
+    constructor() {}
+    async init() {}
+    async run(input) { return solomonRun(input); }
+  },
+}));
+
+vi.mock("../../src/session-store.js", () => ({
+  addCheckpoint: vi.fn().mockResolvedValue(undefined),
+  saveSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../src/utils/events.js", () => ({
+  emitProgress: vi.fn(),
+  makeEvent: vi.fn((type, base, detail) => ({ type, ...base, detail })),
+}));
+
+describe("solomon invocation → session.solomonRulings capture", () => {
+  let invokeSolomon;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ invokeSolomon } = await import("../../src/orchestrator/solomon-escalation.js"));
+  });
+
+  it("appends a ruling record when Solomon returns approve", async () => {
+    solomonRun.mockResolvedValue({
+      ok: true,
+      result: {
+        ruling: "approve",
+        reasoning: "Issues are stylistic, not functional.",
+        conditions: [],
+      },
+      summary: "Solomon approve",
+    });
+    const session = { id: "s1", checkpoints: [] };
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const config = { pipeline: { solomon: { enabled: true } }, roles: { solomon: { provider: "gemini" } } };
+    const conflict = { task: "do X", stage: "reviewer", reason: "retry exhausted", summary: "3 iterations" };
+    await invokeSolomon({ config, logger, emitter: null, eventBase: {}, stage: "reviewer", conflict, askQuestion: null, session, iteration: 2 });
+    expect(session.solomonRulings).toHaveLength(1);
+    expect(session.solomonRulings[0]).toMatchObject({
+      stage: "reviewer",
+      trigger: expect.stringContaining("retry exhausted"),
+      ruling: "approve",
+      reasoning: expect.stringContaining("stylistic"),
+    });
+  });
+
+  it("records approve_with_conditions including the conditions array", async () => {
+    solomonRun.mockResolvedValue({
+      ok: true,
+      result: {
+        ruling: "approve_with_conditions",
+        reasoning: "Ship with follow-up.",
+        conditions: ["create follow-up for naming"],
+      },
+    });
+    const session = { id: "s2", checkpoints: [] };
+    const config = { pipeline: { solomon: { enabled: true } }, roles: { solomon: { provider: "gemini" } } };
+    await invokeSolomon({
+      config, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, emitter: null, eventBase: {},
+      stage: "reviewer",
+      conflict: { task: "x", stage: "reviewer", reason: "retry exhausted" },
+      askQuestion: null, session, iteration: 0,
+    });
+    expect(session.solomonRulings[0].ruling).toBe("approve_with_conditions");
+    expect(session.solomonRulings[0].conditions).toEqual(["create follow-up for naming"]);
+  });
+
+  it("appends multiple rulings when invokeSolomon is called more than once", async () => {
+    solomonRun.mockResolvedValueOnce({ ok: true, result: { ruling: "approve", reasoning: "r1" } });
+    solomonRun.mockResolvedValueOnce({ ok: true, result: { ruling: "create_subtask", reasoning: "r2", subtask: { title: "follow-up" } } });
+    const session = { id: "s3", checkpoints: [] };
+    const config = { pipeline: { solomon: { enabled: true } }, roles: { solomon: { provider: "gemini" } } };
+    const base = { config, logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }, emitter: null, eventBase: {}, askQuestion: null, session };
+    await invokeSolomon({ ...base, stage: "reviewer", conflict: { stage: "reviewer", reason: "first" }, iteration: 0 });
+    await invokeSolomon({ ...base, stage: "coder", conflict: { stage: "coder", reason: "second" }, iteration: 1 });
+    expect(session.solomonRulings).toHaveLength(2);
+    expect(session.solomonRulings[0].ruling).toBe("approve");
+    expect(session.solomonRulings[1].ruling).toBe("create_subtask");
+  });
+});


### PR DESCRIPTION
Closes KJC-TSK-0287 (epic KJC-PCS-0032 session journal). Natural follow-up to the Brain decisor (#437) — the Brain decisions already recorded in session state are now persisted to disk alongside Solomon rulings.

## What this does

At session end, when Solomon has been invoked at least once, Karajan writes `decisions.md` inside the session's journal directory (`.reviews/{sessionId}/`). The file contains:
- Summary: count of Solomon invocations + Brain routing decisions.
- Solomon rulings section: for each invocation — timestamp, stage, trigger, ruling verdict (approve / approve_with_conditions / escalate_human / create_subtask), reasoning, conditions, alternative agent, and the orchestrator's applied result.
- Brain routing section (when present): each routing decision with intent, rolesOn, confidence, applied overrides, and rationale.

When Solomon was NOT invoked in the session, the file is NOT created (matches the acceptance criterion).

## Changes
- `src/session/journal/decisions-writer.js`: pure `buildDecisionsMarkdown` + I/O `writeDecisionsJournal` + `recordSolomonRuling` helper.
- `src/orchestrator/solomon-escalation.js`: after every ruling, appends a structured record to `session.solomonRulings`.
- `src/orchestrator.js`: replaces the empty legacy `writeDecisionsJournal(journalDir, [])` call with the new writer consuming session state.
- 24 new tests (unit + integration) cover the no-Solomon → no-file invariant, multi-ruling rendering, Brain section merge, fallback on unwritable journal dirs, and deep-copy on recording.

## Commits
1. feat(journal): decisions-writer module with buildDecisionsMarkdown + writeDecisionsJournal
2. feat(orchestrator): capture Solomon rulings in session.solomonRulings for journaling
3. feat(orchestrator): wire decisions-writer into session:end (writes when Solomon invoked)

## Test plan
- [x] `npx vitest run` → 3487 tests pass (270 files, +24 new)
- [ ] Smoke test: run kj run on a task that triggers Solomon (TDD fail-fast / rate limit) → .reviews/{sessionId}/decisions.md appears with the invocation.