### PR TITLE
feat(journal): executive summary.md with stages table + budget breakdown + journal links (KJC-TSK-0289)

### DIFF
--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -432,12 +432,26 @@ async function finalizeApprovedSession({ config, gitCtx, task, logger, session, 
       if (decisionsResult.written) journalFiles.push("decisions.md");
       if (hasTree) journalFiles.push("tree.txt");
 
-      await writeSummaryJournal(journalDir, {
-        task: session.task, result: "APPROVED", sessionId: session.id,
-        iterations: i, durationMs: Date.now() - (session._startedAt || Date.now()),
-        budget: budgetSummary(), stages: stageResults,
-        commits: gitResult?.commits || [], files: journalFiles
-      });
+      // KJC-TSK-0289: use the richer summary writer (stages table, budget
+      // breakdown, brain/solomon counts, typed links to other journal files).
+      const { writeSummaryJournal: writeSummaryJournalV2 } =
+        await import("./session/journal/summary-writer.js");
+      const startedAt = session._startedAt ? new Date(session._startedAt).toISOString() : undefined;
+      await writeSummaryJournalV2(journalDir, {
+        task: session.task,
+        result: "APPROVED",
+        sessionId: session.id,
+        iterations: i,
+        durationMs: Date.now() - (session._startedAt || Date.now()),
+        budget: budgetSummary(),
+        stages: stageResults,
+        commits: gitResult?.commits || [],
+        files: journalFiles,
+        startedAt,
+        finishedAt: new Date().toISOString(),
+        brainDecisions: Array.isArray(session.brainDecisions) ? session.brainDecisions.length : 0,
+        solomonInvocations: Array.isArray(session.solomonRulings) ? session.solomonRulings.length : 0,
+      }, { logger });
       logger.info(`Session journal written to ${journalDir}`);
     } catch (err) {
       logger.warn(`Journal write failed (non-blocking): ${err.message}`);

--- a/src/session/journal/summary-writer.js
+++ b/src/session/journal/summary-writer.js
@@ -1,0 +1,176 @@
+/**
+ * Executive session summary (`summary.md`) — the entry point to the journal
+ * directory. Pulls together every useful signal from the session into a
+ * single scannable Markdown page with links to the rest of the journal.
+ *
+ * Acceptance criterion (KJC-TSK-0289):
+ *   summary.md contains: task, result (approved/rejected/paused), iterations,
+ *   duration, budget, stages + status, list of journal files, commits.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * @typedef {Object} SummaryInput
+ * @property {string} sessionId
+ * @property {string} task
+ * @property {"APPROVED"|"REJECTED"|"PAUSED"|"FAILED"|string} result
+ * @property {number} iterations
+ * @property {number} durationMs
+ * @property {{ total_cost_usd?: number, total_tokens?: number, breakdown_by_role?: Object }} [budget]
+ * @property {Record<string, { ok?: boolean, summary?: string }>} [stages]
+ * @property {Array<{ hash?: string, message?: string, date?: string, author?: string }>} [commits]
+ * @property {string[]} [files]                    - names of other journal files in the same dir
+ * @property {string} [startedAt]                  - ISO timestamp (optional, auto-derived if absent)
+ * @property {string} [finishedAt]                 - ISO timestamp (optional)
+ * @property {number} [solomonInvocations]
+ * @property {number} [brainDecisions]
+ */
+
+function esc(text) {
+  return String(text ?? "").replace(/\|/g, "\\|");
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return `${m}m ${rs}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return `${h}h ${rm}m ${rs}s`;
+}
+
+function formatBudget(budget) {
+  if (!budget) return "—";
+  const cost = Number(budget.total_cost_usd ?? 0);
+  const tokens = Number(budget.total_tokens ?? 0);
+  const costStr = `$${cost.toFixed(2)}`;
+  const tokStr = tokens > 0 ? `${tokens.toLocaleString("en-US")} tokens` : "—";
+  return `${costStr} · ${tokStr}`;
+}
+
+function resultBadge(result) {
+  const r = String(result || "").toUpperCase();
+  const map = {
+    APPROVED: "✅ APPROVED",
+    REJECTED: "❌ REJECTED",
+    PAUSED: "⏸ PAUSED",
+    FAILED: "❌ FAILED",
+  };
+  return map[r] || r;
+}
+
+function renderStagesTable(stages) {
+  if (!stages || Object.keys(stages).length === 0) return "_No stages recorded._";
+  const header = "| Stage | Status | Summary |\n|---|---|---|";
+  const rows = Object.entries(stages).map(([name, stageResult]) => {
+    const ok = stageResult?.ok !== false;
+    const status = ok ? "✅ pass" : "❌ fail";
+    const summary = esc(stageResult?.summary || "").slice(0, 120);
+    return `| \`${esc(name)}\` | ${status} | ${summary} |`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+function renderCommits(commits) {
+  if (!Array.isArray(commits) || commits.length === 0) return "_No commits in this session._";
+  return commits
+    .map((c) => {
+      const hash = (c.hash || "").slice(0, 7) || "?";
+      return `- \`${hash}\` ${esc(c.message || "(no message)")}`;
+    })
+    .join("\n");
+}
+
+function renderBreakdownByRole(breakdown) {
+  if (!breakdown || typeof breakdown !== "object") return null;
+  const entries = Object.entries(breakdown)
+    .map(([role, m]) => ({
+      role,
+      tokens: Number(m?.total_tokens || 0),
+      cost: Number(m?.total_cost_usd || 0),
+    }))
+    .filter((e) => e.tokens > 0 || e.cost > 0);
+  if (entries.length === 0) return null;
+  const rows = entries
+    .sort((a, b) => b.cost - a.cost)
+    .map((e) => `| \`${esc(e.role)}\` | ${e.tokens.toLocaleString("en-US")} | $${e.cost.toFixed(4)} |`);
+  return ["| Role | Tokens | Cost |", "|---|---|---|", ...rows].join("\n");
+}
+
+function renderJournalLinks(files) {
+  if (!Array.isArray(files) || files.length === 0) return "_No additional journal files._";
+  return files.map((f) => `- [${esc(f)}](./${f})`).join("\n");
+}
+
+/**
+ * Build the summary.md content.
+ *
+ * @param {SummaryInput} input
+ * @returns {string}
+ */
+export function buildSummaryMarkdown(input) {
+  const sessionId = input.sessionId || "(unknown)";
+  const result = resultBadge(input.result);
+  const startedAt = input.startedAt || "(unknown)";
+  const finishedAt = input.finishedAt || new Date().toISOString();
+
+  const sections = [
+    `# Session summary — ${sessionId}`,
+    "",
+    `- **Result**: ${result}`,
+    `- **Task**: ${esc(input.task || "(no task)")}`,
+    `- **Iterations**: ${input.iterations ?? 0}`,
+    `- **Duration**: ${formatDuration(input.durationMs)}`,
+    `- **Budget**: ${formatBudget(input.budget)}`,
+    `- **Started**: ${startedAt}`,
+    `- **Finished**: ${finishedAt}`,
+  ];
+
+  if (Number.isFinite(input.brainDecisions) && input.brainDecisions > 0) {
+    sections.push(`- **Brain decisions**: ${input.brainDecisions}`);
+  }
+  if (Number.isFinite(input.solomonInvocations) && input.solomonInvocations > 0) {
+    sections.push(`- **Solomon invocations**: ${input.solomonInvocations}`);
+  }
+
+  sections.push("", "---", "", "## Stages", "", renderStagesTable(input.stages));
+
+  const breakdown = renderBreakdownByRole(input.budget?.breakdown_by_role);
+  if (breakdown) {
+    sections.push("", "## Budget breakdown (by role)", "", breakdown);
+  }
+
+  sections.push("", "## Commits", "", renderCommits(input.commits));
+
+  sections.push("", "## Journal files", "", renderJournalLinks(input.files));
+
+  return sections.join("\n") + "\n";
+}
+
+/**
+ * Write summary.md to the given journal directory. Always writes (the file
+ * is the entry point; even a barebones session should have one).
+ *
+ * @param {string} journalDir
+ * @param {SummaryInput} input
+ * @param {{ logger?: Object }} [options]
+ * @returns {Promise<{ written: boolean, path: string|null }>}
+ */
+export async function writeSummaryJournal(journalDir, input, options = {}) {
+  const filePath = path.join(journalDir, "summary.md");
+  try {
+    await fs.mkdir(journalDir, { recursive: true });
+    await fs.writeFile(filePath, buildSummaryMarkdown(input), "utf8");
+    options.logger?.info?.(`Wrote session summary: ${filePath}`);
+    return { written: true, path: filePath };
+  } catch (err) {
+    options.logger?.warn?.(`Failed to write session summary (non-blocking): ${err.message}`);
+    return { written: false, path: null };
+  }
+}

--- a/tests/session/summary-writer.test.js
+++ b/tests/session/summary-writer.test.js
@@ -1,0 +1,170 @@
+import { describe, expect, it, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  buildSummaryMarkdown,
+  writeSummaryJournal,
+} from "../../src/session/journal/summary-writer.js";
+
+function sample(overrides = {}) {
+  return {
+    sessionId: "s-test",
+    task: "implement auth",
+    result: "APPROVED",
+    iterations: 3,
+    durationMs: 125_000,
+    budget: {
+      total_cost_usd: 0.42,
+      total_tokens: 54321,
+      breakdown_by_role: {
+        coder: { total_tokens: 30000, total_cost_usd: 0.25 },
+        reviewer: { total_tokens: 24321, total_cost_usd: 0.17 },
+      },
+    },
+    stages: {
+      triage: { ok: true, summary: "medium / sw" },
+      coder: { ok: true, summary: "3 files modified" },
+      reviewer: { ok: true, summary: "approved" },
+    },
+    commits: [
+      { hash: "abc1234567", message: "feat: add login" },
+      { hash: "def4567", message: "test: login e2e" },
+    ],
+    files: ["iterations.md", "decisions.md", "tree.txt"],
+    startedAt: "2026-04-19T12:00:00.000Z",
+    finishedAt: "2026-04-19T12:02:05.000Z",
+    brainDecisions: 2,
+    solomonInvocations: 1,
+    ...overrides,
+  };
+}
+
+describe("session/journal/summary-writer — buildSummaryMarkdown", () => {
+  it("includes the required AC fields: task, result, iterations, duration, budget, stages, files, commits", () => {
+    const md = buildSummaryMarkdown(sample());
+    expect(md).toContain("# Session summary — s-test");
+    expect(md).toContain("**Task**: implement auth");
+    expect(md).toContain("**Result**: ✅ APPROVED");
+    expect(md).toContain("**Iterations**: 3");
+    expect(md).toContain("**Duration**: 2m 5s");
+    expect(md).toContain("**Budget**: $0.42 · 54,321 tokens");
+    expect(md).toContain("## Stages");
+    expect(md).toContain("`coder`");
+    expect(md).toContain("3 files modified");
+    expect(md).toContain("## Commits");
+    expect(md).toContain("`abc1234`");
+    expect(md).toContain("## Journal files");
+    expect(md).toContain("[iterations.md](./iterations.md)");
+    expect(md).toContain("[decisions.md](./decisions.md)");
+    expect(md).toContain("[tree.txt](./tree.txt)");
+  });
+
+  it("renders stages as a Markdown table with pass/fail badges", () => {
+    const md = buildSummaryMarkdown(sample({
+      stages: {
+        coder: { ok: true, summary: "ok" },
+        reviewer: { ok: false, summary: "found blockers" },
+      },
+    }));
+    expect(md).toContain("| Stage | Status | Summary |");
+    expect(md).toContain("| `coder` | ✅ pass | ok |");
+    expect(md).toContain("| `reviewer` | ❌ fail | found blockers |");
+  });
+
+  it("renders budget breakdown table when per-role data present", () => {
+    const md = buildSummaryMarkdown(sample());
+    expect(md).toContain("## Budget breakdown (by role)");
+    expect(md).toContain("| Role | Tokens | Cost |");
+    expect(md).toContain("`coder`");
+    expect(md).toContain("$0.2500");
+  });
+
+  it("omits budget breakdown section when all roles have 0 usage", () => {
+    const md = buildSummaryMarkdown(sample({
+      budget: { total_cost_usd: 0, total_tokens: 0, breakdown_by_role: { coder: { total_tokens: 0, total_cost_usd: 0 } } },
+    }));
+    expect(md).not.toContain("## Budget breakdown");
+  });
+
+  it("shows placeholder text when no stages, commits, or files", () => {
+    const md = buildSummaryMarkdown(sample({ stages: {}, commits: [], files: [] }));
+    expect(md).toContain("_No stages recorded._");
+    expect(md).toContain("_No commits in this session._");
+    expect(md).toContain("_No additional journal files._");
+  });
+
+  it("formats REJECTED and PAUSED results with appropriate badges", () => {
+    const md1 = buildSummaryMarkdown(sample({ result: "REJECTED" }));
+    expect(md1).toContain("❌ REJECTED");
+    const md2 = buildSummaryMarkdown(sample({ result: "PAUSED" }));
+    expect(md2).toContain("⏸ PAUSED");
+  });
+
+  it("formats durations > 1h as h+m+s", () => {
+    const md = buildSummaryMarkdown(sample({ durationMs: 3_725_000 })); // 1h 2m 5s
+    expect(md).toContain("1h 2m 5s");
+  });
+
+  it("formats durations < 1s as ms", () => {
+    const md = buildSummaryMarkdown(sample({ durationMs: 450 }));
+    expect(md).toContain("450ms");
+  });
+
+  it("includes Brain/Solomon counts only when > 0", () => {
+    const with0 = buildSummaryMarkdown(sample({ brainDecisions: 0, solomonInvocations: 0 }));
+    expect(with0).not.toContain("Brain decisions");
+    expect(with0).not.toContain("Solomon invocations");
+    const with2 = buildSummaryMarkdown(sample({ brainDecisions: 4, solomonInvocations: 2 }));
+    expect(with2).toContain("**Brain decisions**: 4");
+    expect(with2).toContain("**Solomon invocations**: 2");
+  });
+
+  it("truncates very long stage summaries to 120 chars in the table", () => {
+    const longSummary = "x".repeat(300);
+    const md = buildSummaryMarkdown(sample({
+      stages: { coder: { ok: true, summary: longSummary } },
+    }));
+    // Row exists, but the summary isn't 300 chars long verbatim.
+    expect(md).toContain("`coder`");
+    expect(md).not.toContain(longSummary);
+  });
+
+  it("escapes pipe chars in commit messages + task text (table safety)", () => {
+    const md = buildSummaryMarkdown(sample({
+      task: "a|b|c",
+      commits: [{ hash: "xxx", message: "fix | something" }],
+    }));
+    expect(md).toContain("a\\|b\\|c");
+    expect(md).toContain("fix \\| something");
+  });
+});
+
+describe("session/journal/summary-writer — writeSummaryJournal", () => {
+  const cleanups = [];
+
+  afterEach(async () => {
+    for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+    cleanups.length = 0;
+  });
+
+  it("writes summary.md to the given journal directory", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-summary-"));
+    cleanups.push(tmp);
+    const result = await writeSummaryJournal(tmp, sample());
+    expect(result.written).toBe(true);
+    expect(result.path).toBe(path.join(tmp, "summary.md"));
+    const content = await fs.readFile(result.path, "utf8");
+    expect(content).toContain("# Session summary — s-test");
+  });
+
+  it("returns written:false when the directory cannot be written to", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-summary-ro-"));
+    cleanups.push(tmp);
+    await fs.writeFile(path.join(tmp, "blocker"), "file");
+    const badDir = path.join(tmp, "blocker", "under-a-file");
+    const result = await writeSummaryJournal(badDir, sample());
+    expect(result.written).toBe(false);
+    expect(result.path).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes KJC-TSK-0289 (epic KJC-PCS-0032 session journal).

Replaces the basic generateSummary() renderer with a richer summary writer that makes `.reviews/{sessionId}/summary.md` a proper entry point to the journal.

## What's new in summary.md
- **Result badge**: ✅ APPROVED / ❌ REJECTED / ⏸ PAUSED / ❌ FAILED.
- **Brain decisions + Solomon invocations counters** (only shown when > 0) — surfaces routing activity that was previously invisible.
- **Stages table** (Markdown) with pass/fail badges and summary per stage.
- **Budget breakdown by role** (when roles have non-zero usage): tokens and cost per role, sorted by cost.
- **Commits** list with short hashes.
- **Journal files** section linking to iterations.md, decisions.md, tree.txt from the same directory.
- **Start/Finish timestamps** for audit.
- **Duration formatting** handles ms / s / m+s / h+m+s.
- Pipe-char escaping so tables stay valid when text contains `|`.

## Changes
- `src/session/journal/summary-writer.js`: pure `buildSummaryMarkdown` + I/O `writeSummaryJournal`.
- `src/orchestrator.js`: at session:end uses the new writer with brainDecisions/solomonInvocations counts derived from session state (already captured in TSK-0322 and TSK-0287).
- 13 new tests covering shape, stage table rendering, budget breakdown presence/absence, result badges, duration formats, truncation, pipe escaping, fs error handling.

## Commits
1. feat(journal): summary-writer with rich stages table + budget breakdown + journal links
2. feat(orchestrator): use summary-writer for richer executive session summary

## Test plan
- [x] `npx vitest run` → 3517 tests pass (+13 new)
- [ ] Smoke test: real kj run → verify .reviews/{sessionId}/summary.md has the rich shape and links to siblings.