### PR TITLE
feat(types): central JSDoc typedefs for core entities (KJC-TSK-0317)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "((command -v rg >/dev/null 2>&1 && rg --files src tests | rg '\\.js$') || find src tests -type f -name '*.js') | while IFS= read -r f; do node --check \"$f\"; done",
+    "typecheck": "npx -p typescript@5 tsc --noEmit -p tsconfig.json",
     "validate": "npm run lint && npm test",
     "mcp": "node src/mcp/server.js"
   },

--- a/src/agents/base-agent.js
+++ b/src/agents/base-agent.js
@@ -1,3 +1,12 @@
+/**
+ * Base class for provider-specific agent adapters (claude, codex, gemini, ...).
+ * Every concrete agent must implement runTask() and may override reviewTask().
+ *
+ * @typedef {import("../types/config.js").KarajanConfig} KarajanConfig
+ * @typedef {import("../types/stage.js").Logger} Logger
+ * @typedef {import("../types/agent.js").AgentResult} AgentResult
+ */
+
 const MODEL_NOT_SUPPORTED_PATTERNS = [
   /model.{0,30}is not supported/i,
   /model.{0,30}not available/i,
@@ -8,20 +17,39 @@ const MODEL_NOT_SUPPORTED_PATTERNS = [
 ];
 
 export class BaseAgent {
+  /**
+   * @param {string} name                    - agent slug (claude|codex|gemini|aider|opencode)
+   * @param {KarajanConfig} config
+   * @param {Logger} logger
+   */
   constructor(name, config, logger) {
     this.name = name;
     this.config = config;
     this.logger = logger;
   }
 
+  /**
+   * Execute a coding/agentic task. Subclasses MUST override.
+   * @param {string|Object} _task
+   * @returns {Promise<AgentResult>}
+   */
   async runTask(_task) {
     throw new Error("runTask not implemented");
   }
 
+  /**
+   * Execute a review task. Subclasses MAY override for different behaviour.
+   * @param {string|Object} _task
+   * @returns {Promise<AgentResult>}
+   */
   async reviewTask(_task) {
     throw new Error("reviewTask not implemented");
   }
 
+  /**
+   * @param {string} role
+   * @returns {string|null}
+   */
   getRoleModel(role) {
     const roleModel = this.config?.roles?.[role]?.model;
     if (roleModel) return roleModel;
@@ -29,11 +57,21 @@ export class BaseAgent {
     return this.config?.coder_options?.model || null;
   }
 
+  /**
+   * @param {string} role
+   * @returns {boolean}
+   */
   isAutoApproveEnabled(role) {
     if (role === "reviewer") return false;
     return Boolean(this.config?.coder_options?.auto_approve);
   }
 
+  /**
+   * Heuristic: does the agent's error look like "model not supported"?
+   * Used by the retry/fallback path.
+   * @param {Partial<AgentResult>} result
+   * @returns {boolean}
+   */
   isModelNotSupportedError(result) {
     const text = [result?.error, result?.output, result?.stderr, result?.stdout]
       .filter(Boolean).join("\n");

--- a/src/guards/policy-resolver.js
+++ b/src/guards/policy-resolver.js
@@ -1,3 +1,11 @@
+/**
+ * Policy resolution: map task type + config toggles to concrete pipeline
+ * flags (TDD, Sonar, reviewer retries, tests required, coder required, ...).
+ *
+ * @typedef {import("../types/policy.js").ResolvedPolicies} ResolvedPolicies
+ * @typedef {import("../types/config.js").KarajanConfig} KarajanConfig
+ */
+
 export const VALID_TASK_TYPES = new Set(["sw", "infra", "doc", "add-tests", "refactor", "audit", "analysis", "no-code"]);
 
 export const DEFAULT_POLICIES = {

--- a/src/hu/store.js
+++ b/src/hu/store.js
@@ -1,3 +1,12 @@
+/**
+ * HU (Historia de Usuario / User Story) storage. Persists HU batches and
+ * their stories to the session directory.
+ *
+ * @typedef {import("../types/hu.js").HUStory} HUStory
+ * @typedef {import("../types/hu.js").HUBatch} HUBatch
+ * @typedef {import("../types/hu.js").HUStatus} HUStatus
+ */
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { execFile } from "node:child_process";

--- a/src/orchestrator/pipeline-context.js
+++ b/src/orchestrator/pipeline-context.js
@@ -1,8 +1,25 @@
 /**
  * Shared context object for pipeline execution.
  * Replaces destructured parameter objects across orchestrator functions.
+ *
+ * @typedef {import("../types/config.js").KarajanConfig} KarajanConfig
+ * @typedef {import("../types/session.js").Session} Session
+ * @typedef {import("../types/stage.js").Logger} Logger
+ * @typedef {import("../types/stage.js").Emitter} Emitter
+ * @typedef {import("../types/stage.js").EventBase} EventBase
+ * @typedef {import("../types/config.js").PipelineFlags} PipelineFlags
+ * @typedef {import("../types/stage.js").StageContext} StageContext
  */
 export class PipelineContext {
+  /**
+   * @param {Object} args
+   * @param {KarajanConfig} args.config
+   * @param {Session} args.session
+   * @param {Logger} args.logger
+   * @param {Emitter|null} args.emitter
+   * @param {string} args.task
+   * @param {Object} [args.flags]
+   */
   constructor({ config, session, logger, emitter, task, flags = {} }) {
     this.config = config;
     this.session = session;

--- a/src/types/agent.js
+++ b/src/types/agent.js
@@ -1,0 +1,55 @@
+/**
+ * Agent result / response typedefs. Every provider agent (claude, codex,
+ * gemini, opencode, aider) returns a shape that's a superset of AgentResult.
+ *
+ * AgentResponse<T> is the generic wrapper used when a caller has parsed
+ * the raw output into a structured payload of type T.
+ */
+
+/**
+ * Raw agent result as returned by agent.runTask() / agent.reviewTask().
+ *
+ * @typedef {Object} AgentResult
+ * @property {boolean} ok                       - whether the call succeeded
+ * @property {string} [output]                  - raw stdout / response text
+ * @property {string} [summary]                 - short human summary
+ * @property {Object} [result]                  - structured result (stage-specific)
+ * @property {string} [error]
+ * @property {string} [stderr]
+ * @property {string} [stdout]
+ * @property {number} [exitCode]
+ * @property {AgentUsage} [usage]
+ * @property {string} [provider]
+ * @property {string} [model]
+ */
+
+/**
+ * Token/cost reporting shape. Fields optional because not all providers
+ * report all metrics.
+ *
+ * @typedef {Object} AgentUsage
+ * @property {number} [input_tokens]
+ * @property {number} [output_tokens]
+ * @property {number} [cached_tokens]
+ * @property {number} [total_tokens]
+ * @property {number} [cost_usd]
+ */
+
+/**
+ * Generic agent response — AgentResult whose `result` field is typed.
+ *
+ * Example:
+ *   /** @type {import("../types/agent.js").AgentResponse<import("./review-result.js").ReviewResult>} *\/
+ *
+ * @template T
+ * @typedef {Object} AgentResponse
+ * @property {boolean} ok
+ * @property {T} [result]
+ * @property {string} [output]
+ * @property {string} [summary]
+ * @property {string} [error]
+ * @property {AgentUsage} [usage]
+ * @property {string} [provider]
+ */
+
+export {};

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -1,0 +1,114 @@
+/**
+ * Karajan configuration typedefs. Mirrors the shape produced by loadConfig()
+ * and consumed throughout the orchestrator. Optional fields are intentional
+ * — users may set them in kj.config.yml without every field being required.
+ */
+
+/**
+ * @typedef {Object} RoleConfig
+ * @property {string} [provider]    - claude | codex | gemini | opencode | aider | anthropic | openai | google
+ * @property {string} [model]       - provider-specific model identifier
+ */
+
+/**
+ * @typedef {Object} PipelineToggle
+ * @property {boolean} [enabled]
+ */
+
+/**
+ * @typedef {Object} PipelineFlags
+ * @property {boolean} [coderEnabled]
+ * @property {boolean} [reviewerEnabled]
+ * @property {boolean} [plannerEnabled]
+ * @property {boolean} [researcherEnabled]
+ * @property {boolean} [architectEnabled]
+ * @property {boolean} [refactorerEnabled]
+ * @property {boolean} [testerEnabled]
+ * @property {boolean} [securityEnabled]
+ * @property {boolean} [impeccableEnabled]
+ * @property {boolean} [triageEnabled]
+ * @property {boolean} [discoverEnabled]
+ * @property {boolean} [huReviewerEnabled]
+ * @property {boolean} [coderRequired]
+ */
+
+/**
+ * @typedef {Object} GitConfig
+ * @property {boolean} [auto_commit]
+ * @property {boolean} [auto_push]
+ * @property {boolean} [auto_pr]
+ * @property {boolean} [auto_rebase]
+ * @property {string} [branch_prefix]
+ */
+
+/**
+ * @typedef {Object} SonarConfig
+ * @property {boolean} [enabled]
+ * @property {string} [host]
+ * @property {string} [token]
+ * @property {boolean} [external]
+ * @property {string} [enforcement_profile]
+ */
+
+/**
+ * @typedef {Object} BudgetConfig
+ * @property {Object} [pricing]
+ * @property {number} [warn_threshold_pct]
+ */
+
+/**
+ * @typedef {Object} BrainDecisorConfig
+ * @property {boolean} [enabled]
+ * @property {number} [maxDecisions]
+ */
+
+/**
+ * @typedef {Object} BrainConfig
+ * @property {boolean} [enabled]
+ * @property {string} [provider]
+ * @property {boolean} [bypass_solomon_on_correctness]
+ * @property {number} [max_consecutive_verification_failures]
+ * @property {BrainDecisorConfig} [decisor]
+ */
+
+/**
+ * @typedef {Object} SkillsConfig
+ * @property {boolean} [enabled]
+ * @property {"auto"|"regex"|"semantic"|"none"} [mode]
+ */
+
+/**
+ * @typedef {Object} PreflightConfig
+ * @property {boolean} [extended]
+ */
+
+/**
+ * Full Karajan configuration shape as resolved by loadConfig() +
+ * applyRunOverrides(). Not every field is always present; consumers should
+ * defensively read via `config.x?.y`.
+ *
+ * @typedef {Object} KarajanConfig
+ * @property {string} [coder]                   - legacy agent name (claude, codex, ...)
+ * @property {string} [reviewer]                - legacy agent name
+ * @property {Object.<string, RoleConfig>} [roles]
+ * @property {Object.<string, PipelineToggle>} [pipeline]
+ * @property {string} [review_mode]             - standard | strict | paranoid | relaxed
+ * @property {string} [review_rules]            - path to review rules .md
+ * @property {number} [max_iterations]
+ * @property {number} [max_budget_usd]
+ * @property {BudgetConfig} [budget]
+ * @property {SonarConfig} [sonarqube]
+ * @property {GitConfig} [git]
+ * @property {string} [base_branch]
+ * @property {Object} [session]                 - timeouts etc
+ * @property {Object} [output]                  - log level, report dir
+ * @property {Object} [development]             - methodology, require_test_changes
+ * @property {BrainConfig} [brain]
+ * @property {SkillsConfig} [skills]
+ * @property {PreflightConfig} [preflight]
+ * @property {string} [projectDir]              - absolute path, set at runtime
+ * @property {string} [productContext]          - runtime-loaded
+ * @property {string} [domainContext]           - runtime-loaded
+ */
+
+export {};

--- a/src/types/hu.js
+++ b/src/types/hu.js
@@ -1,0 +1,47 @@
+/**
+ * HU (Historia de Usuario) typedefs. An HU is a user story that the
+ * pipeline can decompose into, certify via hu-reviewer, then run as a
+ * sub-pipeline.
+ */
+
+/**
+ * @typedef {"pending"|"planned"|"in_progress"|"done"|"rejected"|"blocked"|"failed"} HUStatus
+ */
+
+/**
+ * @typedef {Object} HUAcceptanceCriterion
+ * @property {string} [given]
+ * @property {string} [when]
+ * @property {string} [then]
+ * @property {string} [raw]                     - plain-text AC if not Gherkin
+ */
+
+/**
+ * @typedef {Object} HUStory
+ * @property {string} id                        - stable slug per batch
+ * @property {string} title
+ * @property {string} [role]                    - "Como ..."
+ * @property {string} [goal]                    - "Quiero ..."
+ * @property {string} [benefit]                 - "Para ..."
+ * @property {HUAcceptanceCriterion[]} [acceptanceCriteria]
+ * @property {HUStatus} [status]
+ * @property {string} [assignee]
+ * @property {string[]} [dependencies]          - ids of HUs that must be done first
+ * @property {Object} [certification]           - hu-reviewer verdict
+ * @property {Object} [session]                 - sub-pipeline session metadata when it runs
+ */
+
+/**
+ * A batch is the ordered collection of HUs produced by the auto-generator
+ * or loaded from a YAML file.
+ *
+ * @typedef {Object} HUBatch
+ * @property {string} id                        - typically the parent sessionId
+ * @property {string} [task]                    - original task text
+ * @property {HUStory[]} stories
+ * @property {string} [created_at]
+ * @property {string} [updated_at]
+ * @property {Object} [board]                   - HU Board metadata (port, URL)
+ */
+
+export {};

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,0 +1,34 @@
+/**
+ * Central JSDoc typedef registry. Import typedefs via:
+ *
+ *   /** @typedef {import("../types/index.js").KarajanConfig} KarajanConfig *\/
+ *
+ * This module re-exports every type so consumers have a single import path.
+ * The actual typedef bodies live in the focused files under src/types/.
+ *
+ * Intentionally a runtime-empty module: it only carries JSDoc annotations,
+ * nothing to execute.
+ */
+
+/**
+ * @typedef {import("./config.js").KarajanConfig} KarajanConfig
+ * @typedef {import("./config.js").RoleConfig} RoleConfig
+ * @typedef {import("./config.js").PipelineFlags} PipelineFlags
+ *
+ * @typedef {import("./session.js").Session} Session
+ * @typedef {import("./session.js").Checkpoint} Checkpoint
+ *
+ * @typedef {import("./stage.js").StageContext} StageContext
+ * @typedef {import("./stage.js").StageResult} StageResult
+ *
+ * @typedef {import("./agent.js").AgentResult} AgentResult
+ * @typedef {import("./agent.js").AgentResponse} AgentResponse
+ *
+ * @typedef {import("./hu.js").HUStory} HUStory
+ * @typedef {import("./hu.js").HUBatch} HUBatch
+ *
+ * @typedef {import("./policy.js").ResolvedPolicies} ResolvedPolicies
+ * @typedef {import("./policy.js").QualityGateResult} QualityGateResult
+ */
+
+export {};

--- a/src/types/policy.js
+++ b/src/types/policy.js
@@ -1,0 +1,43 @@
+/**
+ * Policy + quality-gate typedefs. Policies are resolved once per session
+ * from config + task type; quality gates are the outputs of each gate
+ * (sonar, perf, tests, review).
+ */
+
+/**
+ * @typedef {Object} ResolvedPolicies
+ * @property {boolean} [tdd]                    - whether TDD is enforced
+ * @property {boolean} [sonar]                  - Sonar gate enabled
+ * @property {boolean} [tests]                  - tester gate enabled
+ * @property {boolean} [security]               - security audit enabled
+ * @property {boolean} [reviewer]               - reviewer gate enabled
+ * @property {boolean} [planner]                - planner enabled
+ * @property {boolean} [researcher]             - researcher enabled
+ * @property {boolean} [architect]              - architect enabled
+ * @property {boolean} [refactorer]             - refactorer enabled
+ * @property {boolean} [impeccable]             - impeccable audit enabled
+ * @property {boolean} [triage]                 - triage enabled
+ * @property {boolean} [discover]               - discover phase enabled
+ * @property {boolean} [hu_reviewer]            - HU certification enabled
+ * @property {number} [reviewer_retries]
+ * @property {number} [tester_retries]
+ * @property {string} [reason]                  - why these policies (task type + config chain)
+ */
+
+/**
+ * Result of a quality gate evaluation — Sonar, perf, tester, reviewer, etc.
+ *
+ * @typedef {Object} QualityGateResult
+ * @property {boolean} ok                       - did the gate pass
+ * @property {"OK"|"FAIL"|"WARN"|"ERROR"} gateStatus
+ * @property {string} [summary]
+ * @property {Object[]} [blocking_issues]       - for reviewer/security gates
+ * @property {number} [openIssues]              - sonar
+ * @property {number} [issuesInitial]
+ * @property {number} [issuesFinal]
+ * @property {number} [issuesResolved]
+ * @property {string} [provider]                - which agent produced the verdict (when relevant)
+ * @property {Object} [details]                 - gate-specific payload
+ */
+
+export {};

--- a/src/types/session.js
+++ b/src/types/session.js
@@ -1,0 +1,74 @@
+/**
+ * Session state typedefs. The session is a mutable object that accumulates
+ * state throughout a kj run and is persisted to ~/.karajan/sessions/<id>/.
+ */
+
+/**
+ * @typedef {Object} Checkpoint
+ * @property {string} [at]                   - ISO timestamp
+ * @property {string} [stage]
+ * @property {number} [iteration]
+ * @property {string} [conflictStage]
+ * @property {string} [ruling]
+ * @property {string} [alternativeAgent]
+ * @property {string} [waitUntil]
+ * @property {string[]} [conditions]
+ * @property {boolean} [escalate]
+ * @property {string} [error]
+ * @property {string|null} [subtask]
+ */
+
+/**
+ * @typedef {Object} SolomonRulingRecord
+ * @property {string} at                     - ISO timestamp
+ * @property {string} stage
+ * @property {string} trigger
+ * @property {Object} conflict
+ * @property {string} ruling                 - approve | approve_with_conditions | escalate_human | create_subtask | ...
+ * @property {string} [reasoning]
+ * @property {string[]} [conditions]
+ * @property {string|null} [alternativeAgent]
+ * @property {string} [result]
+ */
+
+/**
+ * @typedef {Object} BrainDecisionRecord
+ * @property {number} seq
+ * @property {string} at
+ * @property {string} intent                 - "<taskType>:<level>"
+ * @property {string[]} rolesOn
+ * @property {string} confidence             - low | medium | high
+ * @property {string} rationale
+ * @property {string[]} appliedOverrides
+ */
+
+/**
+ * @typedef {Object} RtkSavings
+ * @property {number} [callCount]
+ * @property {number} [estimatedTokensSaved]
+ * @property {number} [savedPct]
+ * @property {number} [originalBytes]
+ * @property {number} [rtkBytes]
+ */
+
+/**
+ * @typedef {Object} Session
+ * @property {string} id                     - session id
+ * @property {string} task                   - user's task text
+ * @property {"running"|"paused"|"approved"|"rejected"|"failed"} status
+ * @property {string} created_at             - ISO timestamp
+ * @property {string} updated_at
+ * @property {Checkpoint[]} [checkpoints]
+ * @property {SolomonRulingRecord[]} [solomonRulings]     - KJC-TSK-0287
+ * @property {BrainDecisionRecord[]} [brainDecisions]     - KJC-TSK-0322
+ * @property {string[]} [skillsRecommended]               - wouldHaveUsed when openskills missing
+ * @property {string[]} [autoInstalledSkills]
+ * @property {RtkSavings} [rtk_savings]
+ * @property {string} [session_start_sha]
+ * @property {string} [_journalDir]                       - runtime journal path
+ * @property {string[]} [_journalIterations]              - rendered iteration markdown
+ * @property {string[]} [_journalFiles]
+ * @property {Object} [budget]                            - final budget summary snapshot
+ */
+
+export {};

--- a/src/types/stage.js
+++ b/src/types/stage.js
@@ -1,0 +1,68 @@
+/**
+ * Stage context + stage result typedefs. A StageContext is the bundle of
+ * orchestration state every stage function receives; a StageResult is what
+ * they return for downstream stages to consume.
+ */
+
+/**
+ * @typedef {Object} Logger
+ * @property {(msg: string, ...rest: any[]) => void} info
+ * @property {(msg: string, ...rest: any[]) => void} warn
+ * @property {(msg: string, ...rest: any[]) => void} error
+ * @property {(msg: string, ...rest: any[]) => void} [debug]
+ */
+
+/**
+ * @typedef {Object} Emitter
+ * @property {(event: string, data?: any) => void} emit
+ */
+
+/**
+ * Shape of `eventBase` propagated to every emitted event for correlation.
+ *
+ * @typedef {Object} EventBase
+ * @property {string} sessionId
+ * @property {number} iteration
+ * @property {string|null} stage
+ * @property {number} startedAt                  - epoch ms
+ */
+
+/**
+ * The context every pipeline stage consumes. Most stages pick a subset with
+ * destructuring. Listed here so consumers can import a single type instead
+ * of re-declaring ad-hoc objects.
+ *
+ * @typedef {Object} StageContext
+ * @property {import("./config.js").KarajanConfig} config
+ * @property {import("./session.js").Session} session
+ * @property {Logger} logger
+ * @property {Emitter|null} emitter
+ * @property {EventBase} eventBase
+ * @property {Function} [trackBudget]
+ * @property {Function} [budgetSummary]
+ * @property {import("./config.js").PipelineFlags} [pipelineFlags]
+ * @property {Object} [coderRole]                - CoderRole instance
+ * @property {Object} [reviewerRole]
+ * @property {Object} [brainCtx]
+ * @property {Function} [askQuestion]
+ * @property {Object} [stageResults]             - accumulated results from prior stages
+ * @property {string} [task]
+ * @property {string|null} [pgTaskId]
+ * @property {string|null} [pgProject]
+ * @property {Object} [flags]                    - CLI/call-time flags
+ */
+
+/**
+ * The structured return of most stage helpers. Stages are allowed to return
+ * shape-specific additions on top of these common fields.
+ *
+ * @typedef {Object} StageResult
+ * @property {boolean} ok
+ * @property {string} [summary]
+ * @property {Object} [result]                   - stage-specific payload
+ * @property {string} [action]                   - "return" | "retry" | "continue" | "skip" | ...
+ * @property {Object} [stageResult]              - alternate nested result shape used by some stages
+ * @property {string} [provider]
+ */
+
+export {};

--- a/tests/types.test.js
+++ b/tests/types.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Typedef modules are runtime-empty — they only carry JSDoc annotations.
+ * This test verifies that they load without syntax errors so an accidental
+ * typo in the JSDoc comment block doesn't crash consumers.
+ */
+
+describe("src/types/ — JSDoc typedef modules load cleanly", () => {
+  const modules = [
+    "../src/types/index.js",
+    "../src/types/config.js",
+    "../src/types/session.js",
+    "../src/types/stage.js",
+    "../src/types/agent.js",
+    "../src/types/hu.js",
+    "../src/types/policy.js",
+  ];
+
+  for (const specifier of modules) {
+    it(`imports ${specifier} without error`, async () => {
+      const mod = await import(specifier);
+      // Every file exports an empty {} — just verify it's an object namespace.
+      expect(mod).toBeTypeOf("object");
+    });
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Opt-in type-check for Karajan's JSDoc typedefs. Not enforced in CI; developers run `npm run typecheck` locally. Strict mode is OFF on purpose — we're detecting new drift against the typedefs in src/types/, not retrofitting the whole codebase.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "noImplicitThis": false,
+    "alwaysStrict": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": []
+  },
+  "include": [
+    "src/types/**/*.js",
+    "src/orchestrator/pipeline-context.js",
+    "src/agents/base-agent.js",
+    "src/hu/store.js",
+    "src/guards/policy-resolver.js",
+    "src/budget/comparison.js",
+    "src/brain/decisor.js",
+    "src/brain/decision-tracker.js",
+    "src/brain/solomon-consult.js",
+    "src/session/journal/**/*.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "packages",
+    "dist",
+    "coverage",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Closes KJC-TSK-0317 (epic KJC-PCS-0027 Codebase Health). Implements the bootstrap phase of strict JSDoc typing without migrating to TypeScript (per docs/why-vanilla-js.md).

Closes #363
References #377

## What this adds

### src/types/ — single source of truth
Central typedef files for the entities that flow across the orchestrator:

- `config.js` — `KarajanConfig`, `RoleConfig`, `PipelineFlags`, sub-configs (sonar/git/brain/skills/preflight).
- `session.js` — `Session`, `Checkpoint`, `SolomonRulingRecord`, `BrainDecisionRecord`, `RtkSavings`.
- `stage.js` — `StageContext`, `StageResult`, `Logger`, `Emitter`, `EventBase`.
- `agent.js` — `AgentResult`, `AgentResponse<T>`, `AgentUsage`.
- `hu.js` — `HUStory`, `HUBatch`, `HUStatus`, `HUAcceptanceCriterion`.
- `policy.js` — `ResolvedPolicies`, `QualityGateResult`.
- `index.js` — re-exports everything for a single import path.

All files are runtime-empty (only JSDoc annotations). Consumers import via `/** @typedef {import("../types/index.js").KarajanConfig} KarajanConfig *\/`.

### Consumer wiring
Four critical consumers now import + use the typedefs:
- `src/orchestrator/pipeline-context.js` — `PipelineContext` constructor typed.
- `src/agents/base-agent.js` — every method typed with `AgentResult` return.
- `src/hu/store.js` — file header imports HU types.
- `src/guards/policy-resolver.js` — file header imports policy types.

### Typecheck opt-in
- `tsconfig.json` scoped to the annotated files (NOT the whole codebase — strict mode OFF).
- `npm run typecheck` runs `tsc --noEmit -p tsconfig.json`.
- NOT wired into CI yet — developers can opt in locally; future PRs may tighten.

## Scope
This is the bootstrap commit — establishes the types and the typecheck tooling. Annotating every `@param Object` across the 270+ source files is out of scope for this card and can be a follow-up (opportunistic, file-by-file).

## Commits
1. feat(types): central JSDoc typedefs for config, session, stage, agent, hu, policy
2. refactor(types): pipeline-context, base-agent, hu/store, policy-resolver import central typedefs
3. build(typecheck): opt-in tsconfig.json + npm run typecheck for src/types/ drift detection

## Test plan
- [x] `npx vitest run` → 3560 tests pass (+7 new for typedef module load)
- [ ] `npm run typecheck` locally to validate scoped files parse under tsc --checkJs