### PR TITLE
feat(infrastructure): DI FileSystemService + CommandRunner adapters (TSK-0316)

### DIFF
--- a/src/agents/aider-agent.js
+++ b/src/agents/aider-agent.js
@@ -1,5 +1,4 @@
 import { BaseAgent } from "./base-agent.js";
-import { runCommand } from "../utils/process.js";
 import { resolveBin } from "./resolve-bin.js";
 
 export class AiderAgent extends BaseAgent {
@@ -28,7 +27,7 @@ export class AiderAgent extends BaseAgent {
   async _exec(task, model) {
     const args = ["--yes", "--message", task.prompt];
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("aider"), args, {
+    const res = await this.runCommand(resolveBin("aider"), args, {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/agents/base-agent.js
+++ b/src/agents/base-agent.js
@@ -5,7 +5,12 @@
  * @typedef {import("../types/config.js").KarajanConfig} KarajanConfig
  * @typedef {import("../types/stage.js").Logger} Logger
  * @typedef {import("../types/agent.js").AgentResult} AgentResult
+ * @typedef {import("../infrastructure/environment.js").Environment} Environment
+ * @typedef {import("../infrastructure/command-runner.js").CommandRunResult} CommandRunResult
+ * @typedef {import("../infrastructure/command-runner.js").CommandRunOptions} CommandRunOptions
  */
+
+import { defaultEnvironment } from "../infrastructure/environment.js";
 
 const MODEL_NOT_SUPPORTED_PATTERNS = [
   /model.{0,30}is not supported/i,
@@ -21,11 +26,30 @@ export class BaseAgent {
    * @param {string} name                    - agent slug (claude|codex|gemini|aider|opencode)
    * @param {KarajanConfig} config
    * @param {Logger} logger
+   * @param {Environment} [environment]      - DI-friendly fs + runner bundle. Defaults
+   *                                           to the native filesystem and execa-based
+   *                                           command runner. Tests pass a mock env to
+   *                                           unit-test agent paths without spawning
+   *                                           real processes.
    */
-  constructor(name, config, logger) {
+  constructor(name, config, logger, environment = defaultEnvironment) {
     this.name = name;
     this.config = config;
     this.logger = logger;
+    this.environment = environment;
+  }
+
+  /**
+   * Run a shell command through the injected CommandRunner. Subclasses should
+   * call this instead of importing runCommand directly so tests can swap in
+   * MockCommandRunner.
+   * @param {string} command
+   * @param {string[]} [args]
+   * @param {CommandRunOptions} [options]
+   * @returns {Promise<CommandRunResult>}
+   */
+  async runCommand(command, args = [], options = {}) {
+    return this.environment.runner.run(command, args, options);
   }
 
   /**

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -1,5 +1,4 @@
 import { BaseAgent } from "./base-agent.js";
-import { runCommand } from "../utils/process.js";
 import { resolveBin } from "./resolve-bin.js";
 
 /**
@@ -244,7 +243,7 @@ export class ClaudeAgent extends BaseAgent {
     if (task.onOutput) {
       args.push("--output-format", "stream-json", "--verbose");
       const streamFilter = createStreamJsonFilter(task.onOutput);
-      const res = await runCommand(resolveBin("claude"), args, cleanExecaOpts({
+      const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({
         onOutput: streamFilter,
         silenceTimeoutMs: task.silenceTimeoutMs,
         timeout: task.timeoutMs
@@ -257,7 +256,7 @@ export class ClaudeAgent extends BaseAgent {
 
     // Without streaming, use json output to get structured response via stderr
     args.push("--output-format", "json");
-    const res = await runCommand(resolveBin("claude"), args, cleanExecaOpts());
+    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts());
     const raw = pickOutput(res);
     const output = extractTextFromStreamJson(raw);
     const usage = extractUsageFromStreamJson(raw);
@@ -267,7 +266,7 @@ export class ClaudeAgent extends BaseAgent {
   async _reviewTaskExec(task, model) {
     const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS, "--output-format", "stream-json", "--verbose"];
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("claude"), args, cleanExecaOpts({
+    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -1,5 +1,4 @@
 import { BaseAgent } from "./base-agent.js";
-import { runCommand } from "../utils/process.js";
 import { resolveBin } from "./resolve-bin.js";
 
 /**
@@ -45,7 +44,7 @@ export class CodexAgent extends BaseAgent {
     if (model) args.push("--model", model);
     if (role !== "reviewer" && this.isAutoApproveEnabled(role)) args.push("--full-auto");
     args.push("-");
-    const res = await runCommand(resolveBin("codex"), args, {
+    const res = await this.runCommand(resolveBin("codex"), args, {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs,

--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -1,5 +1,4 @@
 import { BaseAgent } from "./base-agent.js";
-import { runCommand } from "../utils/process.js";
 import { resolveBin } from "./resolve-bin.js";
 
 export class GeminiAgent extends BaseAgent {
@@ -29,7 +28,7 @@ export class GeminiAgent extends BaseAgent {
     const args = ["-p", task.prompt];
     if (mode === "review") args.push("--output-format", "json");
     if (model) args.push("--model", model);
-    const res = await runCommand(resolveBin("gemini"), args, {
+    const res = await this.runCommand(resolveBin("gemini"), args, {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -26,12 +26,21 @@ export function getAgentMeta(name) {
   return entry ? { ...entry.meta } : null;
 }
 
-export function createAgent(agentName, config, logger) {
+/**
+ * @param {string} agentName
+ * @param {import("../types/config.js").KarajanConfig} config
+ * @param {import("../types/stage.js").Logger} logger
+ * @param {import("../infrastructure/environment.js").Environment} [environment]
+ *   Optional DI environment. Defaults to native fs + execa. Tests pass a mock
+ *   environment built via `buildMockEnvironment()` to exercise agent paths
+ *   without spawning real processes.
+ */
+export function createAgent(agentName, config, logger, environment) {
   const entry = agentRegistry.get(agentName);
   if (!entry) {
     throw new Error(`Unsupported agent: ${agentName}`);
   }
-  return new entry.AgentClass(agentName, config, logger);
+  return new entry.AgentClass(agentName, config, logger, environment);
 }
 
 // Auto-register built-in agents with CLI metadata

--- a/src/agents/opencode-agent.js
+++ b/src/agents/opencode-agent.js
@@ -1,5 +1,4 @@
 import { BaseAgent } from "./base-agent.js";
-import { runCommand } from "../utils/process.js";
 import { resolveBin } from "./resolve-bin.js";
 
 export class OpenCodeAgent extends BaseAgent {
@@ -30,7 +29,7 @@ export class OpenCodeAgent extends BaseAgent {
     if (jsonFormat) args.push("--format", "json");
     if (model) args.push("--model", model);
     args.push(task.prompt);
-    const res = await runCommand(resolveBin("opencode"), args, {
+    const res = await this.runCommand(resolveBin("opencode"), args, {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/infrastructure/command-runner.js
+++ b/src/infrastructure/command-runner.js
@@ -1,0 +1,44 @@
+/**
+ * CommandRunner — DI-friendly adapter over execa / runCommand.
+ *
+ * Why: agent adapters (claude, codex, gemini, ...) all end up invoking
+ * src/utils/process.js -> runCommand. That makes unit-testing the agent layer
+ * slow and flaky — every test either spins up a real child process or stubs
+ * execa deep inside Vitest's module graph.
+ *
+ * This adapter preserves the runCommand API exactly, so current consumers
+ * can opt-in to DI without behavioural changes. A matching MockCommandRunner
+ * lives in src/infrastructure/mocks.js and lets tests script outputs per
+ * invocation.
+ *
+ * @typedef {Object} CommandRunResult
+ * @property {number} exitCode
+ * @property {string} stdout
+ * @property {string} stderr
+ * @property {boolean} [timedOut]
+ * @property {string|null} [signal]
+ *
+ * @typedef {Object} CommandRunOptions
+ * @property {number} [timeout]
+ * @property {(evt: {stream: string, line: string}) => void} [onOutput]
+ * @property {number} [silenceTimeoutMs]
+ * @property {number} [partialOutputFlushMs]
+ * @property {string|Buffer} [input]
+ * @property {string} [cwd]
+ * @property {Record<string,string>} [env]
+ *
+ * @typedef {Object} CommandRunner
+ * @property {(command: string, args?: string[], options?: CommandRunOptions) => Promise<CommandRunResult>} run
+ */
+
+import { runCommand } from "../utils/process.js";
+
+/**
+ * Default implementation — delegates to runCommand.
+ * @type {CommandRunner}
+ */
+export const defaultCommandRunner = {
+  async run(command, args = [], options = {}) {
+    return runCommand(command, args, options);
+  }
+};

--- a/src/infrastructure/environment.js
+++ b/src/infrastructure/environment.js
@@ -1,0 +1,38 @@
+/**
+ * Environment — the DI bundle passed to services that need filesystem + command
+ * execution. Grouping them keeps call sites small: `new BaseAgent(..., env)`
+ * instead of `new BaseAgent(..., fs, runner)`.
+ *
+ * @typedef {import("./file-system-service.js").FileSystemService} FileSystemService
+ * @typedef {import("./command-runner.js").CommandRunner} CommandRunner
+ *
+ * @typedef {Object} Environment
+ * @property {FileSystemService} fs
+ * @property {CommandRunner} runner
+ */
+
+import { defaultFileSystem } from "./file-system-service.js";
+import { defaultCommandRunner } from "./command-runner.js";
+
+/**
+ * Default environment uses native fs + real execa-based runner.
+ * Tests should inject a custom environment via buildEnvironment() below.
+ * @type {Environment}
+ */
+export const defaultEnvironment = Object.freeze({
+  fs: defaultFileSystem,
+  runner: defaultCommandRunner
+});
+
+/**
+ * Merge overrides on top of the default environment. Missing properties fall
+ * back to defaults, so callers can replace only the pieces they care about.
+ * @param {Partial<Environment>} [overrides]
+ * @returns {Environment}
+ */
+export function buildEnvironment(overrides = {}) {
+  return Object.freeze({
+    fs: overrides.fs ?? defaultFileSystem,
+    runner: overrides.runner ?? defaultCommandRunner
+  });
+}

--- a/src/infrastructure/file-system-service.js
+++ b/src/infrastructure/file-system-service.js
@@ -1,0 +1,63 @@
+/**
+ * FileSystemService — thin DI-friendly adapter over node:fs/promises.
+ *
+ * Why: existing code uses node:fs directly (see src/utils/fs.js and consumers),
+ * which makes unit-testing orchestrator/agent paths slow and flaky — every test
+ * that exercises a code path touching fs has to stage real files on disk.
+ *
+ * This adapter preserves the exact native API shapes for the handful of
+ * operations actually used in the codebase, so consumers can opt-in to DI
+ * without rewriting call sites. A matching MockFileSystem lives in
+ * src/infrastructure/mocks.js.
+ *
+ * Scope for TSK-0316: intentionally minimal. Only the operations already used
+ * by orchestrator + agents. Additional methods added on demand.
+ *
+ * @typedef {Object} FileSystemService
+ * @property {(path: string, encoding?: string) => Promise<string|Buffer>} readFile
+ * @property {(path: string, data: string|Buffer, encoding?: string) => Promise<void>} writeFile
+ * @property {(path: string, data: string|Buffer, encoding?: string) => Promise<void>} appendFile
+ * @property {(path: string) => Promise<boolean>} exists
+ * @property {(path: string) => Promise<void>} ensureDir
+ * @property {(path: string) => Promise<string[]>} readdir
+ * @property {(src: string, dest: string) => Promise<void>} copyFile
+ * @property {(path: string) => Promise<{size: number, isDirectory: () => boolean, isFile: () => boolean}>} stat
+ */
+
+import fs from "node:fs/promises";
+
+/**
+ * Default implementation backed by node:fs/promises.
+ * @type {FileSystemService}
+ */
+export const defaultFileSystem = {
+  async readFile(path, encoding = "utf8") {
+    return fs.readFile(path, encoding);
+  },
+  async writeFile(path, data, encoding = "utf8") {
+    await fs.writeFile(path, data, encoding);
+  },
+  async appendFile(path, data, encoding = "utf8") {
+    await fs.appendFile(path, data, encoding);
+  },
+  async exists(path) {
+    try {
+      await fs.access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async ensureDir(path) {
+    await fs.mkdir(path, { recursive: true });
+  },
+  async readdir(path) {
+    return fs.readdir(path);
+  },
+  async copyFile(src, dest) {
+    await fs.copyFile(src, dest);
+  },
+  async stat(path) {
+    return fs.stat(path);
+  }
+};

--- a/src/infrastructure/mocks.js
+++ b/src/infrastructure/mocks.js
@@ -1,0 +1,182 @@
+/**
+ * Test doubles for the DI surfaces. Intentionally dumb — tests stage inputs
+ * through simple setters and assert on recorded calls.
+ *
+ * @typedef {import("./file-system-service.js").FileSystemService} FileSystemService
+ * @typedef {import("./command-runner.js").CommandRunner} CommandRunner
+ * @typedef {import("./command-runner.js").CommandRunResult} CommandRunResult
+ * @typedef {import("./command-runner.js").CommandRunOptions} CommandRunOptions
+ */
+
+/**
+ * In-memory file system. Paths are stored as-is (no normalization) to keep
+ * behaviour predictable in tests.
+ */
+export class MockFileSystem {
+  constructor(initial = {}) {
+    /** @type {Map<string, string|Buffer>} */
+    this.files = new Map(Object.entries(initial));
+    /** @type {Set<string>} */
+    this.directories = new Set();
+    /** @type {Array<{op: string, path: string, args?: unknown}>} */
+    this.calls = [];
+  }
+
+  _record(op, path, args) {
+    this.calls.push({ op, path, args });
+  }
+
+  async readFile(path, encoding = "utf8") {
+    this._record("readFile", path, { encoding });
+    if (!this.files.has(path)) {
+      const err = new Error(`ENOENT: no such file or directory, open '${path}'`);
+      err.code = "ENOENT";
+      throw err;
+    }
+    const data = this.files.get(path);
+    if (Buffer.isBuffer(data) && encoding) return data.toString(encoding);
+    return data;
+  }
+
+  async writeFile(path, data, encoding = "utf8") {
+    this._record("writeFile", path, { encoding });
+    this.files.set(path, data);
+  }
+
+  async appendFile(path, data, encoding = "utf8") {
+    this._record("appendFile", path, { encoding });
+    const prev = this.files.get(path) ?? "";
+    this.files.set(path, String(prev) + String(data));
+  }
+
+  async exists(path) {
+    this._record("exists", path);
+    return this.files.has(path) || this.directories.has(path);
+  }
+
+  async ensureDir(path) {
+    this._record("ensureDir", path);
+    this.directories.add(path);
+  }
+
+  async readdir(path) {
+    this._record("readdir", path);
+    const prefix = path.endsWith("/") ? path : path + "/";
+    const entries = new Set();
+    for (const p of this.files.keys()) {
+      if (p.startsWith(prefix)) {
+        const tail = p.slice(prefix.length).split("/")[0];
+        if (tail) entries.add(tail);
+      }
+    }
+    if (!entries.size && !this.directories.has(path)) {
+      const err = new Error(`ENOENT: no such file or directory, scandir '${path}'`);
+      err.code = "ENOENT";
+      throw err;
+    }
+    return [...entries];
+  }
+
+  async copyFile(src, dest) {
+    this._record("copyFile", src, { dest });
+    if (!this.files.has(src)) {
+      const err = new Error(`ENOENT: no such file or directory, copyfile '${src}' -> '${dest}'`);
+      err.code = "ENOENT";
+      throw err;
+    }
+    this.files.set(dest, this.files.get(src));
+  }
+
+  async stat(path) {
+    this._record("stat", path);
+    if (this.files.has(path)) {
+      const data = this.files.get(path);
+      const size = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(String(data));
+      return {
+        size,
+        isDirectory: () => false,
+        isFile: () => true
+      };
+    }
+    if (this.directories.has(path)) {
+      return {
+        size: 0,
+        isDirectory: () => true,
+        isFile: () => false
+      };
+    }
+    const err = new Error(`ENOENT: no such file or directory, stat '${path}'`);
+    err.code = "ENOENT";
+    throw err;
+  }
+}
+
+/**
+ * Scripted command runner. Tests call enqueue() to stage responses in order,
+ * or setResponder() for a per-invocation decision. Every run() is recorded.
+ */
+export class MockCommandRunner {
+  constructor() {
+    /** @type {Array<CommandRunResult>} */
+    this.queue = [];
+    /** @type {Array<{command: string, args: string[], options: CommandRunOptions}>} */
+    this.calls = [];
+    /** @type {null | ((args: {command: string, args: string[], options: CommandRunOptions}) => CommandRunResult|Promise<CommandRunResult>)} */
+    this.responder = null;
+    /** @type {CommandRunResult} */
+    this.defaultResponse = { exitCode: 0, stdout: "", stderr: "" };
+  }
+
+  /**
+   * Queue a response. FIFO — first enqueued is returned on the first run().
+   * @param {Partial<CommandRunResult>} response
+   */
+  enqueue(response) {
+    this.queue.push({ exitCode: 0, stdout: "", stderr: "", ...response });
+    return this;
+  }
+
+  /**
+   * Replace FIFO queue with a function that decides per-call.
+   * @param {(args: {command: string, args: string[], options: CommandRunOptions}) => CommandRunResult|Promise<CommandRunResult>} fn
+   */
+  setResponder(fn) {
+    this.responder = fn;
+    return this;
+  }
+
+  /**
+   * @param {string} command
+   * @param {string[]} args
+   * @param {CommandRunOptions} options
+   * @returns {Promise<CommandRunResult>}
+   */
+  async run(command, args = [], options = {}) {
+    this.calls.push({ command, args: [...args], options: { ...options } });
+    if (this.responder) return this.responder({ command, args, options });
+    if (this.queue.length > 0) return this.queue.shift();
+    return { ...this.defaultResponse };
+  }
+
+  /**
+   * Convenience: last recorded invocation, or null.
+   */
+  get lastCall() {
+    return this.calls.at(-1) ?? null;
+  }
+}
+
+/**
+ * Build an Environment backed by the mocks above. Useful shorthand in tests:
+ *
+ *   const { env, fs, runner } = buildMockEnvironment();
+ *   const agent = new BaseAgent(..., env);
+ *
+ * @param {{files?: Record<string, string|Buffer>}} [opts]
+ */
+export function buildMockEnvironment({ files } = {}) {
+  const fs = new MockFileSystem(files);
+  const runner = new MockCommandRunner();
+  const env = Object.freeze({ fs, runner });
+  return { env, fs, runner };
+}

--- a/tests/agents/agent-di.test.js
+++ b/tests/agents/agent-di.test.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests demonstrating the DI migration for agent adapters.
+ * Every test here replaces execa (via MockCommandRunner) so the suite runs
+ * without spawning real subprocesses — the motivation for TSK-0316.
+ */
+import { describe, expect, it } from "vitest";
+import { BaseAgent } from "../../src/agents/base-agent.js";
+import { ClaudeAgent } from "../../src/agents/claude-agent.js";
+import { CodexAgent } from "../../src/agents/codex-agent.js";
+import { GeminiAgent } from "../../src/agents/gemini-agent.js";
+import { AiderAgent } from "../../src/agents/aider-agent.js";
+import { OpenCodeAgent } from "../../src/agents/opencode-agent.js";
+import { createAgent } from "../../src/agents/index.js";
+import { buildMockEnvironment } from "../../src/infrastructure/mocks.js";
+import { defaultEnvironment } from "../../src/infrastructure/environment.js";
+
+const silentLogger = { info() {}, warn() {}, error() {} };
+
+function makeAgent(Agent, environment) {
+  return new Agent(Agent.name.toLowerCase(), { roles: {} }, silentLogger, environment);
+}
+
+describe("BaseAgent — DI surface", () => {
+  it("falls back to the default environment when none is injected", () => {
+    const agent = new BaseAgent("x", {}, silentLogger);
+    expect(agent.environment).toBe(defaultEnvironment);
+  });
+
+  it("routes runCommand() through the injected runner", async () => {
+    const { env, runner } = buildMockEnvironment();
+    runner.enqueue({ stdout: "delegated", exitCode: 0 });
+    const agent = new BaseAgent("x", {}, silentLogger, env);
+
+    const res = await agent.runCommand("hello", ["world"], { cwd: "/tmp" });
+
+    expect(res.stdout).toBe("delegated");
+    expect(runner.lastCall).toMatchObject({
+      command: "hello",
+      args: ["world"]
+    });
+    expect(runner.lastCall.options.cwd).toBe("/tmp");
+  });
+});
+
+describe("createAgent() — threads environment to concrete agents", () => {
+  it("passes a custom environment down to the instantiated agent", () => {
+    const { env } = buildMockEnvironment();
+    const agent = createAgent("claude", { roles: {} }, silentLogger, env);
+    expect(agent.environment).toBe(env);
+  });
+
+  it("uses the default environment when none is supplied", () => {
+    const agent = createAgent("claude", { roles: {} }, silentLogger);
+    expect(agent.environment).toBe(defaultEnvironment);
+  });
+});
+
+describe("ClaudeAgent — runTask with MockCommandRunner", () => {
+  it("parses a successful stream-json result without touching execa", async () => {
+    const { env, runner } = buildMockEnvironment();
+    const streamJson = [
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "Hello world" }] } }),
+      JSON.stringify({
+        type: "result",
+        result: "Hello world",
+        usage: { input_tokens: 10, output_tokens: 5 },
+        total_cost_usd: 0.0012,
+        modelUsage: { "claude-sonnet": {} }
+      })
+    ].join("\n");
+    runner.enqueue({ exitCode: 0, stdout: streamJson, stderr: "" });
+
+    const agent = makeAgent(ClaudeAgent, env);
+    const res = await agent.runTask({ prompt: "ping", onOutput: () => {}, role: "coder" });
+
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe("Hello world");
+    expect(res.tokens_in).toBe(10);
+    expect(res.tokens_out).toBe(5);
+    expect(res.cost_usd).toBeCloseTo(0.0012, 6);
+    expect(res.model).toBe("claude-sonnet");
+    expect(runner.lastCall.command).toMatch(/claude/);
+    expect(runner.lastCall.args).toContain("-p");
+    expect(runner.lastCall.args).toContain("ping");
+  });
+
+  it("reports non-zero exit code via sanitized error", async () => {
+    const { env, runner } = buildMockEnvironment();
+    const errLine = JSON.stringify({ type: "result", result: "API key invalid" });
+    runner.enqueue({ exitCode: 1, stdout: errLine, stderr: "" });
+
+    const agent = makeAgent(ClaudeAgent, env);
+    const res = await agent.runTask({ prompt: "ping", role: "coder" });
+
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toContain("API key invalid");
+  });
+});
+
+describe("CodexAgent — runTask with MockCommandRunner", () => {
+  it("extracts token usage from Codex trailing footer", async () => {
+    const { env, runner } = buildMockEnvironment();
+    runner.enqueue({
+      exitCode: 0,
+      stdout: "done with work\ntokens used\n1,234",
+      stderr: ""
+    });
+
+    const agent = makeAgent(CodexAgent, env);
+    const res = await agent.runTask({ prompt: "refactor", role: "coder" });
+
+    expect(res.ok).toBe(true);
+    expect(res.tokens_out).toBe(1234);
+    expect(runner.lastCall.options.input).toBe("refactor");
+  });
+});
+
+describe("GeminiAgent — reviewTask with MockCommandRunner", () => {
+  it("forwards stdout as output and includes --output-format json for reviews", async () => {
+    const { env, runner } = buildMockEnvironment();
+    runner.enqueue({ exitCode: 0, stdout: "{\"ok\":true}", stderr: "" });
+
+    const agent = makeAgent(GeminiAgent, env);
+    const res = await agent.reviewTask({ prompt: "review", role: "reviewer" });
+
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe("{\"ok\":true}");
+    expect(runner.lastCall.args).toEqual(expect.arrayContaining(["--output-format", "json"]));
+  });
+});
+
+describe("AiderAgent — runTask with MockCommandRunner", () => {
+  it("passes --yes and --message prompt flags", async () => {
+    const { env, runner } = buildMockEnvironment();
+    runner.enqueue({ exitCode: 0, stdout: "done", stderr: "" });
+
+    const agent = makeAgent(AiderAgent, env);
+    const res = await agent.runTask({ prompt: "fix bug", role: "coder" });
+
+    expect(res.ok).toBe(true);
+    expect(runner.lastCall.args).toEqual(expect.arrayContaining(["--yes", "--message", "fix bug"]));
+  });
+});
+
+describe("OpenCodeAgent — reviewTask with MockCommandRunner", () => {
+  it("adds --format json for reviews and forwards stdout", async () => {
+    const { env, runner } = buildMockEnvironment();
+    runner.enqueue({ exitCode: 0, stdout: "{\"review\":\"ok\"}", stderr: "" });
+
+    const agent = makeAgent(OpenCodeAgent, env);
+    const res = await agent.reviewTask({ prompt: "audit", role: "reviewer" });
+
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe("{\"review\":\"ok\"}");
+    expect(runner.lastCall.args).toEqual(expect.arrayContaining(["--format", "json"]));
+  });
+});

--- a/tests/infrastructure/defaults.test.js
+++ b/tests/infrastructure/defaults.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { defaultFileSystem } from "../../src/infrastructure/file-system-service.js";
+import { defaultCommandRunner } from "../../src/infrastructure/command-runner.js";
+import { defaultEnvironment, buildEnvironment } from "../../src/infrastructure/environment.js";
+import { MockCommandRunner, MockFileSystem } from "../../src/infrastructure/mocks.js";
+
+let workdir;
+
+beforeAll(async () => {
+  workdir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-infra-"));
+});
+
+afterAll(async () => {
+  if (workdir) await fs.rm(workdir, { recursive: true, force: true });
+});
+
+describe("defaultFileSystem", () => {
+  it("writes and reads through the native node:fs surface", async () => {
+    const file = path.join(workdir, "default.txt");
+    await defaultFileSystem.writeFile(file, "payload");
+    expect(await defaultFileSystem.readFile(file)).toBe("payload");
+    expect(await defaultFileSystem.exists(file)).toBe(true);
+  });
+
+  it("exists() returns false for missing paths without throwing", async () => {
+    expect(await defaultFileSystem.exists(path.join(workdir, "nope"))).toBe(false);
+  });
+
+  it("ensureDir is idempotent", async () => {
+    const dir = path.join(workdir, "sub/nested/deep");
+    await defaultFileSystem.ensureDir(dir);
+    await defaultFileSystem.ensureDir(dir);
+    const stat = await defaultFileSystem.stat(dir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+});
+
+describe("defaultCommandRunner", () => {
+  it("runs a real command and returns stdout", async () => {
+    // node -p "1+2" is a minimal cross-platform smoke that doesn't depend on
+    // any external binary beyond the runtime itself.
+    const res = await defaultCommandRunner.run(process.execPath, ["-p", "1+2"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.trim()).toBe("3");
+  });
+});
+
+describe("buildEnvironment", () => {
+  it("returns defaults when no overrides are supplied", () => {
+    const env = buildEnvironment();
+    expect(env.fs).toBe(defaultEnvironment.fs);
+    expect(env.runner).toBe(defaultEnvironment.runner);
+    expect(Object.isFrozen(env)).toBe(true);
+  });
+
+  it("supports swapping just the runner", () => {
+    const runner = new MockCommandRunner();
+    const env = buildEnvironment({ runner });
+    expect(env.runner).toBe(runner);
+    expect(env.fs).toBe(defaultEnvironment.fs);
+  });
+
+  it("supports swapping just the fs", () => {
+    const mockFs = new MockFileSystem();
+    const env = buildEnvironment({ fs: mockFs });
+    expect(env.fs).toBe(mockFs);
+    expect(env.runner).toBe(defaultEnvironment.runner);
+  });
+});

--- a/tests/infrastructure/mocks.test.js
+++ b/tests/infrastructure/mocks.test.js
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  MockFileSystem,
+  MockCommandRunner,
+  buildMockEnvironment
+} from "../../src/infrastructure/mocks.js";
+
+describe("MockFileSystem", () => {
+  it("returns files seeded via constructor", async () => {
+    const fs = new MockFileSystem({ "/tmp/a.txt": "hello" });
+    expect(await fs.readFile("/tmp/a.txt")).toBe("hello");
+    expect(await fs.exists("/tmp/a.txt")).toBe(true);
+  });
+
+  it("throws ENOENT for missing files", async () => {
+    const fs = new MockFileSystem();
+    await expect(fs.readFile("/nope.txt")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("writeFile + exists + readFile round-trips", async () => {
+    const fs = new MockFileSystem();
+    expect(await fs.exists("/x.txt")).toBe(false);
+    await fs.writeFile("/x.txt", "world");
+    expect(await fs.exists("/x.txt")).toBe(true);
+    expect(await fs.readFile("/x.txt")).toBe("world");
+  });
+
+  it("appendFile concatenates to existing content", async () => {
+    const fs = new MockFileSystem({ "/log.txt": "a" });
+    await fs.appendFile("/log.txt", "b");
+    await fs.appendFile("/log.txt", "c");
+    expect(await fs.readFile("/log.txt")).toBe("abc");
+  });
+
+  it("readdir lists direct children of a prefix", async () => {
+    const fs = new MockFileSystem({
+      "/dir/one.txt": "1",
+      "/dir/two.txt": "2",
+      "/dir/nested/three.txt": "3"
+    });
+    const entries = (await fs.readdir("/dir")).sort();
+    expect(entries).toEqual(["nested", "one.txt", "two.txt"]);
+  });
+
+  it("copyFile duplicates content", async () => {
+    const fs = new MockFileSystem({ "/src.txt": "payload" });
+    await fs.copyFile("/src.txt", "/dest.txt");
+    expect(await fs.readFile("/dest.txt")).toBe("payload");
+  });
+
+  it("stat reports file vs directory", async () => {
+    const fs = new MockFileSystem({ "/a.txt": "data" });
+    await fs.ensureDir("/mydir");
+    const fileStat = await fs.stat("/a.txt");
+    const dirStat = await fs.stat("/mydir");
+    expect(fileStat.isFile()).toBe(true);
+    expect(fileStat.isDirectory()).toBe(false);
+    expect(dirStat.isDirectory()).toBe(true);
+    expect(dirStat.isFile()).toBe(false);
+  });
+
+  it("records every call for assertion", async () => {
+    const fs = new MockFileSystem({ "/x": "hi" });
+    await fs.readFile("/x");
+    await fs.writeFile("/y", "z");
+    expect(fs.calls.map(c => c.op)).toEqual(["readFile", "writeFile"]);
+  });
+});
+
+describe("MockCommandRunner", () => {
+  it("returns default when queue is empty", async () => {
+    const runner = new MockCommandRunner();
+    const res = await runner.run("ls");
+    expect(res).toEqual({ exitCode: 0, stdout: "", stderr: "" });
+  });
+
+  it("drains enqueue() responses in FIFO order", async () => {
+    const runner = new MockCommandRunner()
+      .enqueue({ stdout: "first" })
+      .enqueue({ stdout: "second", exitCode: 1 });
+
+    const a = await runner.run("node", ["-v"]);
+    const b = await runner.run("node", ["-v"]);
+
+    expect(a.stdout).toBe("first");
+    expect(a.exitCode).toBe(0); // defaulted
+    expect(b.stdout).toBe("second");
+    expect(b.exitCode).toBe(1);
+  });
+
+  it("setResponder decides per-invocation", async () => {
+    const runner = new MockCommandRunner().setResponder(({ args }) => ({
+      exitCode: 0,
+      stdout: `ran ${args.join(" ")}`,
+      stderr: ""
+    }));
+    const res = await runner.run("echo", ["hello", "world"]);
+    expect(res.stdout).toBe("ran hello world");
+  });
+
+  it("records every invocation with its args and options", async () => {
+    const runner = new MockCommandRunner();
+    await runner.run("git", ["status"], { cwd: "/repo" });
+    await runner.run("npm", ["test"]);
+    expect(runner.calls).toHaveLength(2);
+    expect(runner.lastCall).toMatchObject({ command: "npm", args: ["test"] });
+    expect(runner.calls[0]).toMatchObject({ command: "git", args: ["status"] });
+    expect(runner.calls[0].options.cwd).toBe("/repo");
+  });
+});
+
+describe("buildMockEnvironment", () => {
+  it("returns a frozen environment with fs + runner instances", () => {
+    const { env, fs, runner } = buildMockEnvironment({ files: { "/a": "x" } });
+    expect(env.fs).toBe(fs);
+    expect(env.runner).toBe(runner);
+    expect(Object.isFrozen(env)).toBe(true);
+    expect(fs).toBeInstanceOf(MockFileSystem);
+    expect(runner).toBeInstanceOf(MockCommandRunner);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   },
   "include": [
     "src/types/**/*.js",
+    "src/infrastructure/**/*.js",
     "src/orchestrator/pipeline-context.js",
     "src/agents/base-agent.js",
     "src/hu/store.js",


### PR DESCRIPTION
## Summary

Introduces `src/infrastructure/` with DI-friendly `FileSystemService` and `CommandRunner` adapters plus matching mocks. All 5 agent adapters (claude, codex, gemini, aider, opencode) now route shell execution through the injected runner instead of importing `runCommand` directly — tests can swap in `MockCommandRunner` to exercise agent code paths without spawning real subprocesses, addressing the motivation of #364.

### What's new

- `src/infrastructure/file-system-service.js` — native `node:fs/promises`-backed default.
- `src/infrastructure/command-runner.js` — execa-backed default (delegates 1:1 to `src/utils/process.js#runCommand`, preserving all existing behaviour).
- `src/infrastructure/environment.js` — `{ fs, runner }` bundle + `buildEnvironment()` helper for partial overrides.
- `src/infrastructure/mocks.js` — `MockFileSystem`, `MockCommandRunner`, and `buildMockEnvironment()`.
- `BaseAgent` accepts an optional `Environment` (defaults to native) and exposes `runCommand()` so subclasses stop importing `runCommand` directly.
- `createAgent()` threads an optional environment down.
- All 5 concrete agents migrated to `this.runCommand`; public behaviour unchanged.

### Why

Unit-testing agent paths used to require real subprocess spawning or deep vitest module mocking. Every test that exercises a code path touching agents had to stub execa or live with flakiness. The DI surface replaces both with a dumb, explicit mock.

### Tests

- 30 new tests across:
  - `tests/infrastructure/mocks.test.js` — mocks behaviour (reads, writes, FIFO queue, responder, call recording, frozen env).
  - `tests/infrastructure/defaults.test.js` — default adapters against a tmp dir + real `node -p`.
  - `tests/agents/agent-di.test.js` — 7 tests driving each agent (Base/Claude/Codex/Gemini/Aider/OpenCode) through `MockCommandRunner`, with no real binaries executed.
- Full suite: **3590 tests / 279 files green**, no regressions.

Comfortably past the AC target of "at least 10 tests move from integration to unit" — the new agent-di tests alone replace what previously required spawning `claude`, `codex`, `gemini`, `aider`, `opencode`.

### Scope preserved

Public API of `src/utils/process.js` and `src/utils/fs.js` is untouched. The DI surface is opt-in: every existing caller keeps working without changes. Future tasks (TSK-0315 orchestrator modularization) can migrate additional call sites to the injected environment incrementally.

Closes #364