### PR TITLE
feat(config): Valibot schema validation + falsy CLI override fixes (TSK-0318)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.0",
+        "valibot": "^1.3.1"
       },
       "bin": {
         "karajan-mcp": "bin/karajan-mcp.js",
@@ -3244,6 +3245,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "valibot": "^1.3.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,11 @@ import path from "node:path";
 import yaml from "js-yaml";
 import { ensureDir, exists } from "./utils/fs.js";
 import { getKarajanHome } from "./utils/paths.js";
+import { safeParseConfig, formatConfigIssues } from "./config/schema.js";
+
+/**
+ * @typedef {import("./config/schema.js").KarajanConfig} KarajanConfig
+ */
 
 const DEFAULTS = {
   coder: "claude",
@@ -266,6 +271,16 @@ export async function loadConfig(projectDir) {
     merged.budget = mergeDeep(merged.budget || {}, { pricing: projectPricing });
   }
 
+  // KJC-TSK-0318 — schema-validate the merged config so invalid values
+  // (review_mode typos, max_iterations=0, out-of-range ports) surface at
+  // load time with a clear error instead of crashing deep inside the
+  // orchestrator. safeParse + explicit error prefix keeps the message
+  // actionable.
+  const validation = safeParseConfig(merged);
+  if (!validation.success) {
+    throw new Error(`Invalid Karajan config:\n${formatConfigIssues(validation.issues)}`);
+  }
+
   return { config: merged, path: configPath, exists: globalExists, hasProjectConfig: !!projectConfig };
 }
 
@@ -303,10 +318,13 @@ const PIPELINE_ENABLE_FLAGS = [
 
 const AUTO_SIMPLIFY_FLAG = "autoSimplify";
 
-// Scalar flags: [flagName, setter] — truthy check
+// Scalar flags: [flagName, setter] — truthy check.
+// Note: max_iterations was previously here but `0` was silently ignored
+// (truthy check skipped it). It now lives in UNDEF_CHECK_FLAGS so
+// `--max-iterations 0` reaches the schema validator and errors cleanly
+// instead of falling through to the default (KJC-TSK-0318).
 const SCALAR_FLAGS = [
   ["mode", (out, v) => { out.review_mode = v; }],
-  ["maxIterations", (out, v) => { out.max_iterations = Number(v); }],
   ["maxIterationMinutes", (out, v) => { out.session.max_iteration_minutes = Number(v); }],
   ["maxTotalMinutes", (out, v) => { out.session.max_total_minutes = Number(v); }],
   ["checkpointInterval", (out, v) => { out.session.checkpoint_interval_minutes = Number(v); }],
@@ -317,8 +335,11 @@ const SCALAR_FLAGS = [
   ["branchPrefix", (out, v) => { out.git.branch_prefix = String(v); }]
 ];
 
-// Boolean/undefined-check flags: [flagName, setter] — !== undefined check
+// Boolean/undefined-check flags: [flagName, setter] — !== undefined check.
+// These preserve falsy values (false, 0) so --no-rebase correctly sets
+// auto_rebase=false and --reviewer-retries 0 correctly disables retries.
 const UNDEF_CHECK_FLAGS = [
+  ["maxIterations", (out, v) => { out.max_iterations = Number(v); }],
   ["reviewerRetries", (out, v) => { out.reviewer_options.retries = Number(v); }],
   ["autoCommit", (out, v) => { out.git.auto_commit = Boolean(v); }],
   ["autoPush", (out, v) => { out.git.auto_push = Boolean(v); }],
@@ -430,6 +451,14 @@ export function applyRunOverrides(config, flags) {
   applyCiOverride(out, flags);
   applyMiscOverrides(out, flags);
   applyOutputModeOverrides(out, flags);
+
+  // KJC-TSK-0318 — re-run schema validation after overrides so CLI flags
+  // that would produce an invalid config (e.g. --max-iterations 0) fail
+  // fast with the same clear message loadConfig would have produced.
+  const validation = safeParseConfig(out);
+  if (!validation.success) {
+    throw new Error(`Invalid Karajan config after CLI overrides:\n${formatConfigIssues(validation.issues)}`);
+  }
 
   return out;
 }

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -1,0 +1,222 @@
+/**
+ * Central Valibot schema for Karajan's configuration surface (KJC-TSK-0318).
+ *
+ * Origin: this schema is based on Jorge del Casar's original work in PR #379
+ * (closed). The full 650-line mirror-of-DEFAULTS approach he proposed drifted
+ * heavily against `main` by the time it was reviewed, so this file takes the
+ * same intent — validating Karajan config at load time with Valibot — but
+ * narrows the scope to the handful of fields where validation actually
+ * catches real bugs (review_mode, methodology, max_iterations, percentage
+ * budgets, port numbers). Everything else is defined with `v.looseObject` /
+ * `v.unknown()` so existing consumers who touch undeclared keys keep working.
+ *
+ * The runtime DEFAULTS object still lives in src/config.js — it is the source
+ * of truth for default values. This schema exists to reject invalid input
+ * early (e.g. `max_iterations: 0`, `review_mode: "yolo"`) with a clear error,
+ * and to give downstream consumers a typed handle via `KarajanConfig`.
+ *
+ * @typedef {import("valibot").InferOutput<typeof ConfigSchema>} KarajanConfig
+ */
+
+import * as v from "valibot";
+
+/**
+ * Positive integer (>= 1). Used where 0 / negative would be a clear bug
+ * (max_iterations, port, most timeout knobs when they gate the loop itself).
+ */
+const PositiveInt = v.pipe(
+  v.number("must be a number"),
+  v.integer("must be an integer"),
+  v.minValue(1, "must be >= 1")
+);
+
+/**
+ * Non-negative integer (>= 0). Used for retry counts where 0 is a valid
+ * "don't retry" signal.
+ */
+const NonNegativeInt = v.pipe(
+  v.number("must be a number"),
+  v.integer("must be an integer"),
+  v.minValue(0, "must be >= 0")
+);
+
+/**
+ * review_mode picklist — anything outside this set is a typo.
+ */
+const ReviewMode = v.picklist(
+  ["paranoid", "strict", "standard", "relaxed", "custom"],
+  "review_mode must be one of: paranoid | strict | standard | relaxed | custom"
+);
+
+const Methodology = v.picklist(
+  ["tdd", "standard"],
+  "development.methodology must be one of: tdd | standard"
+);
+
+/**
+ * Role entry — provider + model, both nullable. Extra keys allowed.
+ */
+const RoleEntry = v.looseObject({
+  provider: v.optional(v.nullable(v.string())),
+  model: v.optional(v.nullable(v.string())),
+});
+
+const RolesMap = v.optional(v.looseObject({
+  planner: v.optional(RoleEntry),
+  coder: v.optional(RoleEntry),
+  reviewer: v.optional(RoleEntry),
+  refactorer: v.optional(RoleEntry),
+  solomon: v.optional(RoleEntry),
+  researcher: v.optional(RoleEntry),
+  tester: v.optional(RoleEntry),
+  security: v.optional(RoleEntry),
+  impeccable: v.optional(RoleEntry),
+  triage: v.optional(RoleEntry),
+  discover: v.optional(RoleEntry),
+  architect: v.optional(RoleEntry),
+  hu_reviewer: v.optional(RoleEntry),
+}));
+
+const PipelineEntry = v.looseObject({
+  enabled: v.optional(v.boolean()),
+});
+
+const PipelineMap = v.optional(v.looseObject({
+  planner: v.optional(PipelineEntry),
+  refactorer: v.optional(PipelineEntry),
+  solomon: v.optional(PipelineEntry),
+  researcher: v.optional(PipelineEntry),
+  tester: v.optional(PipelineEntry),
+  security: v.optional(PipelineEntry),
+  impeccable: v.optional(PipelineEntry),
+  triage: v.optional(PipelineEntry),
+  discover: v.optional(PipelineEntry),
+  architect: v.optional(PipelineEntry),
+  hu_reviewer: v.optional(PipelineEntry),
+  auto_simplify: v.optional(v.boolean()),
+}));
+
+const Development = v.optional(v.looseObject({
+  methodology: v.optional(Methodology),
+  require_test_changes: v.optional(v.boolean()),
+  test_file_patterns: v.optional(v.array(v.string())),
+  source_file_extensions: v.optional(v.array(v.string())),
+}));
+
+const Git = v.optional(v.looseObject({
+  auto_commit: v.optional(v.boolean()),
+  auto_push: v.optional(v.boolean()),
+  auto_pr: v.optional(v.boolean()),
+  auto_rebase: v.optional(v.boolean()),
+  branch_prefix: v.optional(v.string()),
+}));
+
+const ReviewerOptions = v.optional(v.looseObject({
+  output_format: v.optional(v.string()),
+  require_schema: v.optional(v.boolean()),
+  model: v.optional(v.nullable(v.string())),
+  deterministic: v.optional(v.boolean()),
+  retries: v.optional(NonNegativeInt, 1),
+  fallback_reviewer: v.optional(v.nullable(v.string())),
+}));
+
+const CoderOptions = v.optional(v.looseObject({
+  model: v.optional(v.nullable(v.string())),
+  auto_approve: v.optional(v.boolean()),
+  fallback_coder: v.optional(v.nullable(v.string())),
+}));
+
+const HuBoard = v.optional(v.looseObject({
+  enabled: v.optional(v.boolean()),
+  port: v.optional(v.pipe(
+    v.number("hu_board.port must be a number"),
+    v.integer(),
+    v.minValue(1, "hu_board.port must be >= 1"),
+    v.maxValue(65535, "hu_board.port must be <= 65535")
+  )),
+  auto_start: v.optional(v.boolean()),
+}));
+
+/**
+ * Budget warn threshold: 0-100 percent. Anything outside is nonsense.
+ */
+const Budget = v.optional(v.looseObject({
+  warn_threshold_pct: v.optional(v.pipe(
+    v.number(),
+    v.minValue(0, "budget.warn_threshold_pct must be 0-100"),
+    v.maxValue(100, "budget.warn_threshold_pct must be 0-100")
+  )),
+  currency: v.optional(v.string()),
+  exchange_rate_eur: v.optional(v.number()),
+  pricing: v.optional(v.unknown()),
+}));
+
+/**
+ * Main config schema. `looseObject` lets every consumer that reads an
+ * undeclared key keep working while the schema catches the bugs we care
+ * about.
+ */
+export const ConfigSchema = v.looseObject({
+  coder: v.optional(v.string()),
+  reviewer: v.optional(v.string()),
+  roles: RolesMap,
+  pipeline: PipelineMap,
+  review_mode: v.optional(ReviewMode),
+  max_iterations: v.optional(PositiveInt, 5),
+  hu_max_iterations: v.optional(PositiveInt, 3),
+  max_budget_usd: v.optional(v.nullable(v.pipe(
+    v.number(),
+    v.minValue(0, "max_budget_usd must be >= 0")
+  ))),
+  review_rules: v.optional(v.string()),
+  coder_rules: v.optional(v.string()),
+  base_branch: v.optional(v.string()),
+  coder_options: CoderOptions,
+  reviewer_options: ReviewerOptions,
+  development: Development,
+  git: Git,
+  hu_board: HuBoard,
+  budget: Budget,
+  language: v.optional(v.string()),
+  hu_language: v.optional(v.string()),
+  policies: v.optional(v.record(v.string(), v.unknown())),
+  telemetry: v.optional(v.boolean()),
+});
+
+/**
+ * Parse a raw merged config against the schema. Returns the normalized
+ * config or throws a Valibot ValiError. Call sites should wrap this in a
+ * try/catch that re-throws with a friendlier prefix.
+ *
+ * @param {unknown} input
+ * @returns {KarajanConfig}
+ */
+export function parseConfig(input) {
+  return v.parse(ConfigSchema, input);
+}
+
+/**
+ * Safe variant — returns { success, data } | { success: false, issues } so
+ * callers can decide how to report errors without catching ValiError.
+ * @param {unknown} input
+ */
+export function safeParseConfig(input) {
+  const result = v.safeParse(ConfigSchema, input);
+  if (result.success) return { success: true, data: result.output };
+  return {
+    success: false,
+    issues: result.issues.map(i => ({
+      path: (i.path || []).map(p => p.key).join("."),
+      message: i.message,
+    })),
+  };
+}
+
+/**
+ * Aggregate Valibot issues into a single readable string. Used by loadConfig
+ * to produce actionable error messages instead of the default ValiError dump.
+ * @param {Array<{path: string, message: string}>} issues
+ */
+export function formatConfigIssues(issues) {
+  return issues.map(i => (i.path ? `${i.path}: ${i.message}` : i.message)).join("\n");
+}

--- a/tests/config-schema.test.js
+++ b/tests/config-schema.test.js
@@ -1,0 +1,182 @@
+/**
+ * TSK-0318 — Valibot schema validation for Karajan config.
+ * Covers schema parse, CLI falsy-override handling, and the known bugs from
+ * issue #367 (--no-rebase, --reviewer-retries 0, --max-iterations 0).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ConfigSchema,
+  parseConfig,
+  safeParseConfig,
+  formatConfigIssues,
+} from "../src/config/schema.js";
+import { applyRunOverrides } from "../src/config.js";
+import * as v from "valibot";
+
+describe("config schema — parse", () => {
+  it("accepts an empty object (all fields optional / looseObject)", () => {
+    const out = parseConfig({});
+    // The schema supplies defaults for max_iterations / hu_max_iterations;
+    // every other field remains absent.
+    expect(out.max_iterations).toBe(5);
+    expect(out.hu_max_iterations).toBe(3);
+  });
+
+  it("accepts a realistic Karajan config and passes through unknown keys", () => {
+    const input = {
+      coder: "claude",
+      reviewer: "codex",
+      review_mode: "standard",
+      max_iterations: 5,
+      development: { methodology: "tdd", require_test_changes: true },
+      // looseObject → unknown keys survive parse
+      experimental_feature: { foo: 42 },
+      guards: { output: { enabled: true } },
+    };
+    const out = parseConfig(input);
+    expect(out.experimental_feature).toEqual({ foo: 42 });
+    expect(out.review_mode).toBe("standard");
+  });
+
+  it("rejects unknown review_mode with a readable message", () => {
+    const res = safeParseConfig({ review_mode: "yolo" });
+    expect(res.success).toBe(false);
+    expect(res.issues[0].path).toBe("review_mode");
+    expect(res.issues[0].message).toMatch(/review_mode must be one of/);
+  });
+
+  it("rejects max_iterations <= 0", () => {
+    const zero = safeParseConfig({ max_iterations: 0 });
+    const neg = safeParseConfig({ max_iterations: -3 });
+    expect(zero.success).toBe(false);
+    expect(neg.success).toBe(false);
+    expect(zero.issues[0].path).toBe("max_iterations");
+    expect(zero.issues[0].message).toMatch(/>= 1/);
+  });
+
+  it("rejects non-integer max_iterations", () => {
+    const res = safeParseConfig({ max_iterations: 3.5 });
+    expect(res.success).toBe(false);
+    expect(res.issues[0].message).toMatch(/integer/);
+  });
+
+  it("rejects invalid development.methodology but preserves others", () => {
+    const res = safeParseConfig({ development: { methodology: "cowboy" } });
+    expect(res.success).toBe(false);
+    expect(res.issues[0].path).toBe("development.methodology");
+    expect(res.issues[0].message).toMatch(/tdd \| standard/);
+  });
+
+  it("accepts reviewer_options.retries = 0 (valid 'no retries' signal)", () => {
+    const out = parseConfig({ reviewer_options: { retries: 0 } });
+    expect(out.reviewer_options.retries).toBe(0);
+  });
+
+  it("rejects hu_board.port out of range", () => {
+    const high = safeParseConfig({ hu_board: { port: 70000 } });
+    const low = safeParseConfig({ hu_board: { port: 0 } });
+    expect(high.success).toBe(false);
+    expect(low.success).toBe(false);
+    expect(high.issues[0].path).toBe("hu_board.port");
+  });
+
+  it("rejects budget.warn_threshold_pct outside 0-100", () => {
+    const tooHigh = safeParseConfig({ budget: { warn_threshold_pct: 150 } });
+    const tooLow = safeParseConfig({ budget: { warn_threshold_pct: -10 } });
+    expect(tooHigh.success).toBe(false);
+    expect(tooLow.success).toBe(false);
+  });
+
+  it("rejects negative max_budget_usd but accepts null and positive", () => {
+    expect(safeParseConfig({ max_budget_usd: null }).success).toBe(true);
+    expect(safeParseConfig({ max_budget_usd: 50 }).success).toBe(true);
+    expect(safeParseConfig({ max_budget_usd: -5 }).success).toBe(false);
+  });
+
+  it("parseConfig throws a ValiError on invalid input", () => {
+    expect(() => parseConfig({ review_mode: "yolo" })).toThrow(v.ValiError);
+  });
+
+  it("formatConfigIssues joins path + message per line", () => {
+    const res = safeParseConfig({ review_mode: "yolo", max_iterations: 0 });
+    const formatted = formatConfigIssues(res.issues);
+    expect(formatted).toMatch(/review_mode:/);
+    expect(formatted).toMatch(/max_iterations:/);
+  });
+});
+
+describe("applyRunOverrides — falsy handling regressions from #367", () => {
+  /** Minimal valid baseline config for exercising overrides. */
+  function baseline() {
+    return {
+      coder: "claude",
+      reviewer: "codex",
+      review_mode: "standard",
+      max_iterations: 5,
+      base_branch: "main",
+      sonarqube: { enabled: true },
+      session: { max_iteration_minutes: 20, max_total_minutes: 120 },
+      reviewer_options: { retries: 1, fallback_reviewer: "codex" },
+      development: { methodology: "tdd", require_test_changes: true },
+      git: {
+        auto_commit: false, auto_push: false, auto_pr: false,
+        auto_rebase: true, branch_prefix: "feat/"
+      },
+      coder_options: { auto_approve: true },
+      roles: {
+        planner: { provider: null, model: null },
+        coder: { provider: null, model: null },
+        reviewer: { provider: null, model: null },
+        refactorer: { provider: null, model: null },
+        solomon: { provider: null, model: null },
+        researcher: { provider: null, model: null },
+        tester: { provider: null, model: null },
+        security: { provider: null, model: null },
+        impeccable: { provider: null, model: null },
+        triage: { provider: null, model: null },
+        discover: { provider: null, model: null },
+        architect: { provider: null, model: null },
+        hu_reviewer: { provider: null, model: null },
+      },
+      pipeline: {
+        planner: { enabled: false }, refactorer: { enabled: false },
+        solomon: { enabled: true }, researcher: { enabled: false },
+        tester: { enabled: true }, security: { enabled: true },
+        impeccable: { enabled: false }, triage: { enabled: true },
+        discover: { enabled: false }, architect: { enabled: false },
+        hu_reviewer: { enabled: false },
+      },
+      serena: { enabled: false },
+    };
+  }
+
+  it("--no-rebase → git.auto_rebase=false (was the #367 regression)", () => {
+    const out = applyRunOverrides(baseline(), { autoRebase: false });
+    expect(out.git.auto_rebase).toBe(false);
+  });
+
+  it("--reviewer-retries 0 → reviewer_options.retries=0 (was silently lost)", () => {
+    const out = applyRunOverrides(baseline(), { reviewerRetries: 0 });
+    expect(out.reviewer_options.retries).toBe(0);
+  });
+
+  it("--max-iterations 0 → throws clear schema error instead of silent fallback", () => {
+    expect(() => applyRunOverrides(baseline(), { maxIterations: 0 }))
+      .toThrow(/max_iterations[\s\S]*>= 1/);
+  });
+
+  it("--max-iterations 3 still works (positive integer override)", () => {
+    const out = applyRunOverrides(baseline(), { maxIterations: 3 });
+    expect(out.max_iterations).toBe(3);
+  });
+
+  it("omitting autoRebase keeps the existing value (backward compat)", () => {
+    const out = applyRunOverrides(baseline(), {});
+    expect(out.git.auto_rebase).toBe(true);
+  });
+
+  it("invalid mode via CLI flag errors with schema message", () => {
+    expect(() => applyRunOverrides(baseline(), { mode: "yolo" }))
+      .toThrow(/review_mode must be one of/);
+  });
+});


### PR DESCRIPTION
## Summary

Revives the Valibot-based config validation from Jorge del Casar's closed PR #379 and lands it on current `main`, plus the falsy-override fixes from issue #367 (`--no-rebase`, `--reviewer-retries 0`, `--max-iterations 0`). The 650-line mirror-of-DEFAULTS approach Jorge proposed had drifted too far against `main` to rebase cleanly; this PR keeps the same intent — schema-validate config at load time — but narrows the scope to fields where validation catches real bugs.

### What's new

- **`src/config/schema.js`** — Valibot `ConfigSchema` covering the invariants that matter (review_mode picklist, methodology picklist, positive `max_iterations`, non-negative `reviewer_options.retries`, `hu_board.port` range, `budget.warn_threshold_pct` 0-100, non-negative `max_budget_usd`). Everything else goes through `v.looseObject` / `v.unknown()` so existing consumers keep working while main evolves. Exports `KarajanConfig` via `v.InferOutput<typeof ConfigSchema>`.
- **`loadConfig`** now calls `safeParseConfig(merged)` and throws `Invalid Karajan config: <issues>` instead of silently carrying bad values deeper into the pipeline.
- **`applyRunOverrides`** re-validates after CLI flags are applied so `--max-iterations 0` fails fast with the same clear message.

### Fixes for #367 (falsy CLI overrides)

- `maxIterations` moved from `SCALAR_FLAGS` (truthy check — dropped `0`) to `UNDEF_CHECK_FLAGS` (`!== undefined` check). `--max-iterations 0` now errors via the schema.
- `--no-rebase` correctly sets `git.auto_rebase = false`.
- `--reviewer-retries 0` correctly sets `reviewer_options.retries = 0`.

### Tests

18 new in `tests/config-schema.test.js`:

- **Schema parse**: empty input applies defaults; realistic config passes through unknown keys; rejections for unknown review_mode, `max_iterations <= 0` / non-integer, invalid methodology, `hu_board.port` out of range, `warn_threshold_pct` outside 0-100, negative `max_budget_usd`; `retries = 0` accepted; `parseConfig` throws ValiError; `formatConfigIssues` shape.
- **applyRunOverrides**: `--no-rebase` sets false, `--reviewer-retries 0` sticks at 0, `--max-iterations 0` throws a readable error, `--max-iterations 3` still works, missing flag keeps the existing value, invalid `--mode` errors.

Full suite: **3 622 tests / 281 files green**.

### Scope

Does not attempt to rewrite every branch of `applyRunOverrides` into the declarative mapping Jorge proposed — that was out of reach without a bigger refactor and is not part of the ACs. The schema is the public-facing validation surface; the procedural override path remains, now guarded.

Closes #363
Closes #367

Co-authored-by: Jorge del Casar <jorge.casar@gmail.com>