### PR TITLE
docs(roles): Flow alias JSDoc for BaseRole + AgentRole (TSK-0324)

### DIFF
--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -3,6 +3,15 @@
  * Handles the common execute() flow: resolve provider → create agent → call LLM → parse output.
  * Subclasses override hooks (buildPrompt, parseOutput, buildSuccessResult, buildSummary)
  * instead of reimplementing the full execute() boilerplate.
+ *
+ * Conceptual mapping: `AgentRole` is a Karajan Role that delegates to an AI CLI
+ * subprocess (not to a provider HTTP API). From the outside it plays the same
+ * role as a Genkit Flow — named unit of work with a prompt and a parsed output —
+ * but every invocation spawns a fresh `execa` subprocess (claude, codex, gemini,
+ * aider, opencode) and the state lives in Karajan's session store, not in a
+ * provider-side conversation. See `docs/COMPARISON.md`.
+ *
+ * @alias Flow — similar to Genkit Flow but executed over subprocess CLIs, not API calls.
  */
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";

--- a/src/roles/base-role.js
+++ b/src/roles/base-role.js
@@ -49,6 +49,23 @@ async function loadFirstExisting(paths) {
   return null;
 }
 
+/**
+ * Base class for every pipeline role (coder, reviewer, planner, refactorer,
+ * researcher, architect, triage, discover, tester, security, impeccable,
+ * hu-reviewer, audit, solomon, commiter, karajan-brain, domain-curator).
+ *
+ * Conceptual mapping for developers coming from other ecosystems:
+ * `BaseRole` (and every subclass) is Karajan's equivalent of a **Flow** in the
+ * Genkit sense — a named, composable unit of work with a prompt, an invocation
+ * and a parsed output. The important difference: a Karajan Role executes over
+ * a **subprocess CLI** (`claude`, `codex`, `gemini`, `aider`, `opencode`), not
+ * by calling an HTTP provider API. No PTY, no long-lived session — each run
+ * is a fresh subprocess with state on disk under `~/.karajan/sessions/`.
+ *
+ * See `docs/COMPARISON.md` for the full positioning.
+ *
+ * @alias Flow — similar to Genkit Flow but executed over subprocess CLIs, not API calls.
+ */
 export class BaseRole {
   constructor({ name, config, logger, emitter = null }) {
     if (!name) throw new Error("Role name is required");


### PR DESCRIPTION
## Summary

Adds an `@alias Flow` JSDoc note to `BaseRole` and `AgentRole` so developers coming from Genkit / LangChain have a clean mental bridge to Karajan's Role concept.

Part of the **Positioning epic** (`KJC-PCS-0039`), immediate follow-up to [#450 (COMPARISON.md)](https://github.com/manufosela/karajan-code/pull/450).

## Wording

Explicit about the distinction:

> \"similar to Genkit Flow but executed over subprocess CLIs, not API calls\"

Both `BaseRole` and `AgentRole` get a paragraph explaining the subprocess-vs-API-call difference and a pointer to `docs/COMPARISON.md`.

## Deliberately NOT added

Per the positioning analysis, these alias candidates were **rejected**:

- ❌ `Solomon → Arbitrator` — Solomon is an AI judge consulted by Brain on dilemmas, not a tie-breaker between parallel proposals.
- ❌ `Domain Curator → Context Manager` — Domain Curator synthesizes codebase-specific domain knowledge, not generic conversation memory.

Forcing those aliases would MISLEAD developers about the actual behavior and is a worse outcome than no alias.

## No runtime change

Pure JSDoc. Suite unchanged, lint green.

Closes KJC-TSK-0324.