### PR TITLE
feat(types): @typedef Conflict + document Brain⇄Solomon invariant (TSK-0326)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,7 +74,7 @@ The main pipeline lives in `src/orchestrator.js` (~1400 LOC) and calls functions
 | `hu-sub-pipeline.js` | HU batch processing with dependency graph |
 | `acceptance-runner.js` | **v2.4**: Executes HU `acceptance_tests` shell commands after each coder iteration; captures exact pass/fail output for Brain diagnostics |
 | `auto-generator.js` | **v2.1**: Converts triage subtasks into a certified HU batch with setup HU and per-HU `task_type` classification |
-| `solomon-escalation.js` | Solomon invocation with conflict context and previous rulings |
+| `solomon-escalation.js` | Solomon invocation with `Conflict` payload (see `src/types/solomon.js`) and previous rulings. **Invariant: called only by Brain or by the orchestrator on Brain's behalf — never from stages or rules. The v2.3.0 audit fixed 21 violations of this rule.** |
 | `solomon-rules.js` | Deterministic rules engine (stale detection, scope guard, deps alerts) |
 | `preflight-checks.js` | Environment validation before pipeline starts |
 | `agent-fallback.js` | Fallback routing when primary coder fails |

--- a/docs/es/ARCHITECTURE.md
+++ b/docs/es/ARCHITECTURE.md
@@ -74,7 +74,7 @@ El pipeline principal vive en `src/orchestrator.js` (~1400 LOC) y llama a funcio
 | `hu-sub-pipeline.js` | Procesamiento de batches de HU con grafo de dependencias |
 | `acceptance-runner.js` | **v2.4**: Ejecuta los comandos shell `acceptance_tests` de cada HU tras cada iteración del coder; captura la salida exacta pasa/falla para diagnósticos de Brain |
 | `auto-generator.js` | **v2.1**: Convierte los subtasks de triage en un batch certificado de HUs con HU de setup y clasificación `task_type` por HU |
-| `solomon-escalation.js` | Invocación de Solomon con contexto de conflicto y rulings previos |
+| `solomon-escalation.js` | Invocación de Solomon con payload `Conflict` (ver `src/types/solomon.js`) y rulings previos. **Invariante: solo lo llama Brain o el orquestador por cuenta de Brain — NUNCA desde stages ni rules. La auditoría v2.3.0 corrigió 21 violaciones de esta regla.** |
 | `solomon-rules.js` | Motor de reglas determinísticas (detección de stale, scope guard, alertas de deps) |
 | `preflight-checks.js` | Validación del entorno antes de arrancar el pipeline |
 | `agent-fallback.js` | Enrutamiento de fallback cuando el coder principal falla |

--- a/src/brain/solomon-consult.js
+++ b/src/brain/solomon-consult.js
@@ -8,6 +8,14 @@
  *
  * This is intentionally conservative. A future iteration can make Solomon a
  * binding arbiter for routing (like it is for pipeline-control decisions).
+ *
+ * Architectural invariant: this module is the ONLY sanctioned path from
+ * Brain to Solomon for routing concerns. Stages / rules / agents must not
+ * bypass Brain to reach Solomon directly — see the note on `invokeSolomon`
+ * in `src/orchestrator/solomon-escalation.js` and docs/ARCHITECTURE.md.
+ *
+ * @typedef {import("../types/solomon.js").Conflict} Conflict
+ * @typedef {import("../types/solomon.js").SolomonResult} SolomonResult
  */
 
 /**
@@ -17,7 +25,7 @@
  * @param {import("./decisor.js").Decision} args.decision
  * @param {Object} args.triage
  * @param {string} args.task
- * @returns {Object} conflict
+ * @returns {Conflict} conflict
  */
 export function buildRoutingConflict({ decision, triage, task }) {
   return {

--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -4,6 +4,23 @@ import { emitProgress, makeEvent } from "../utils/events.js";
 import { msg, getLang } from "../utils/messages.js";
 
 /**
+ * @typedef {import("../types/solomon.js").Conflict} Conflict
+ * @typedef {import("../types/solomon.js").SolomonResult} SolomonResult
+ */
+
+/**
+ * Architectural invariant (DO NOT BREAK):
+ * `invokeSolomon` MUST NOT be called directly from stages, rules or agent
+ * code. The only callers should be:
+ *   - Karajan Brain (via `src/brain/solomon-consult.js`)
+ *   - The orchestrator's escalation path (`src/orchestrator/flow-runner.js`)
+ *     on behalf of Brain.
+ * The v2.3.0 audit fixed 21 violations of this rule. Keeping Solomon behind
+ * Brain is what the "Brain-as-gateway, Solomon-as-judge" architecture
+ * depends on — see docs/ARCHITECTURE.md §Brain/Solomon.
+ */
+
+/**
  * Build a human-readable escalation message from raw Solomon conflict data.
  * Replaces the raw JSON dump with structured, plain-text output.
  *
@@ -81,6 +98,23 @@ function extractSolomonHistory(session) {
     }));
 }
 
+/**
+ * Consult Solomon (or fall back to human escalation) for a given conflict.
+ * See the Conflict typedef for the shape of the `conflict` argument and
+ * the invariant above for who is allowed to call this.
+ *
+ * @param {Object}    params
+ * @param {Object}    params.config
+ * @param {Object}    params.logger
+ * @param {Object}    [params.emitter]
+ * @param {Object}    [params.eventBase]
+ * @param {string}    params.stage
+ * @param {Conflict}  params.conflict
+ * @param {Function}  [params.askQuestion]
+ * @param {Object}    [params.session]
+ * @param {number}    [params.iteration]
+ * @returns {Promise<SolomonResult>}
+ */
 export async function invokeSolomon({ config, logger, emitter, eventBase, stage, conflict, askQuestion, session, iteration }) {
   const solomonEnabled = Boolean(config.pipeline?.solomon?.enabled);
 

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -29,6 +29,10 @@
  *
  * @typedef {import("./policy.js").ResolvedPolicies} ResolvedPolicies
  * @typedef {import("./policy.js").QualityGateResult} QualityGateResult
+ *
+ * @typedef {import("./solomon.js").Conflict} SolomonConflict
+ * @typedef {import("./solomon.js").ConflictHistoryEntry} SolomonConflictHistoryEntry
+ * @typedef {import("./solomon.js").SolomonResult} SolomonResult
  */
 
 export {};

--- a/src/types/solomon.js
+++ b/src/types/solomon.js
@@ -1,0 +1,87 @@
+/**
+ * Typedefs for Solomon — the AI judge consulted by Brain on genuine dilemmas.
+ *
+ * Architectural invariant (enforced by convention, see docs/ARCHITECTURE.md):
+ *   Solomon is **NEVER** invoked directly from stages, rules or roles.
+ *   The only legitimate entry points are:
+ *     - `src/brain/solomon-consult.js#consultSolomonForRouting`
+ *     - `src/orchestrator/solomon-escalation.js#invokeSolomon`
+ *   Both are called by Brain (or by the orchestrator on Brain's behalf).
+ *   The v2.3.0 audit fixed 21 violations where stages bypassed Brain and
+ *   called Solomon directly. Don't reintroduce that pattern.
+ *
+ * This module is runtime-empty — it only carries JSDoc annotations.
+ *
+ * @module types/solomon
+ */
+
+/**
+ * A single turn of feedback attributed to a pipeline agent. Used to build
+ * `Conflict.history` when Brain escalates a decision to Solomon.
+ *
+ * @typedef {Object} ConflictHistoryEntry
+ * @property {string} agent     - slug of the agent that produced the feedback
+ *                                (e.g. "reviewer", "sonar", "tester",
+ *                                "coder_rate_limit").
+ * @property {string} feedback  - raw textual feedback to be weighted by Solomon.
+ */
+
+/**
+ * The bundle of context Brain hands to Solomon when it cannot decide on its
+ * own. Solomon reads only this object + the stage + task; it never sees
+ * session internals beyond what is packed here.
+ *
+ * Historical shape: this matches the argument already used by
+ * `invokeSolomon({ ..., conflict })` — the typedef formalizes the contract
+ * so future drift is caught by `npm run typecheck`.
+ *
+ * @typedef {Object} Conflict
+ * @property {string} stage
+ *           Pipeline stage that triggered escalation (e.g. "reviewer",
+ *           "sonar", "tester", "init_error", "coder_rate_limit").
+ * @property {string} task
+ *           Original user task (denormalized so Solomon sees what the user
+ *           actually asked for, not just the stage context).
+ * @property {number} iterationCount
+ *           Current iteration number inside the escalating sub-loop.
+ * @property {number} maxIterations
+ *           Configured cap for that sub-loop (reviewer retries, tester
+ *           retries, full pipeline iterations, etc.). Hitting this cap is
+ *           the canonical trigger for Solomon consultation.
+ * @property {string|null} [cooldownUntil]
+ *           ISO timestamp for rate-limit / standby escalations. Null when
+ *           the conflict is not a rate-limit.
+ * @property {number|null} [cooldownMs]
+ *           Remaining cooldown in milliseconds. Null outside rate-limit
+ *           escalations.
+ * @property {ConflictHistoryEntry[]} history
+ *           Ordered list of agent feedback Solomon should weigh. Most
+ *           recent last. Must be non-empty — Solomon should always see at
+ *           least one piece of evidence.
+ */
+
+/**
+ * Solomon's ruling on a `Conflict`. Returned by `invokeSolomon()` and
+ * consumed by the orchestrator to decide what happens next.
+ *
+ * @typedef {Object} SolomonResult
+ * @property {"continue"|"pause"|"subtask"} action
+ *           - `continue`: retry the sub-loop with optional `humanGuidance`
+ *             appended to the next feedback round.
+ *           - `pause`: stop the pipeline and surface a question to the
+ *             human operator (`SolomonResult.question`).
+ *           - `subtask`: bifurcate into a named sub-task defined in
+ *             `SolomonResult.subtask`.
+ * @property {string} [rationale]         - human-readable reasoning for the
+ *                                          chosen action. Logged to the
+ *                                          decisions journal.
+ * @property {string} [humanGuidance]     - text to merge into the next
+ *                                          coder/reviewer prompt when
+ *                                          action === "continue".
+ * @property {string} [question]          - prompt shown to the human when
+ *                                          action === "pause".
+ * @property {Object} [subtask]           - sub-task descriptor when
+ *                                          action === "subtask".
+ */
+
+export {};

--- a/tests/types/solomon-typedef.test.js
+++ b/tests/types/solomon-typedef.test.js
@@ -1,0 +1,95 @@
+/**
+ * TSK-0326 — smoke test for src/types/solomon.js + the Brain⇄Solomon invariant.
+ *
+ * The typedef module is runtime-empty (it only carries JSDoc). The test
+ * guarantees:
+ *   1. The module is loadable (no syntax errors in the JSDoc comments).
+ *   2. src/orchestrator/solomon-escalation.js and src/brain/solomon-consult.js
+ *      reference the typedef via JSDoc `import("../types/solomon.js")`.
+ *   3. src/orchestrator/solomon-escalation.js carries the architectural
+ *      invariant note ("only Brain / the orchestrator may call invokeSolomon").
+ *   4. docs/ARCHITECTURE.md (EN + ES) mentions the same invariant so the rule
+ *      is visible outside the source file.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../..");
+
+describe("src/types/solomon.js — Conflict typedef registry (TSK-0326)", () => {
+  it("module loads without side effects", async () => {
+    const mod = await import("../../src/types/solomon.js");
+    // Runtime-empty: the only export is the default `export {}` sentinel.
+    expect(Object.keys(mod)).toEqual([]);
+  });
+
+  it("defines @typedef Conflict with the documented fields", async () => {
+    const src = await fs.readFile(path.join(ROOT, "src/types/solomon.js"), "utf8");
+    expect(src).toContain("@typedef {Object} Conflict");
+    for (const field of [
+      "stage",
+      "task",
+      "iterationCount",
+      "maxIterations",
+      "cooldownUntil",
+      "cooldownMs",
+      "history",
+    ]) {
+      expect(src).toContain(`@property`);
+      expect(src).toContain(field);
+    }
+  });
+
+  it("defines ConflictHistoryEntry and SolomonResult typedefs", async () => {
+    const src = await fs.readFile(path.join(ROOT, "src/types/solomon.js"), "utf8");
+    expect(src).toContain("@typedef {Object} ConflictHistoryEntry");
+    expect(src).toContain("@typedef {Object} SolomonResult");
+  });
+
+  it("is re-exported from src/types/index.js", async () => {
+    const src = await fs.readFile(path.join(ROOT, "src/types/index.js"), "utf8");
+    expect(src).toMatch(/import\("\.\/solomon\.js"\)\.Conflict/);
+    expect(src).toMatch(/import\("\.\/solomon\.js"\)\.SolomonResult/);
+  });
+});
+
+describe("Brain⇄Solomon invariant is documented where it matters", () => {
+  it("solomon-escalation.js uses the Conflict typedef via JSDoc import", async () => {
+    const src = await fs.readFile(
+      path.join(ROOT, "src/orchestrator/solomon-escalation.js"),
+      "utf8"
+    );
+    expect(src).toMatch(/import\("\.\.\/types\/solomon\.js"\)\.Conflict/);
+  });
+
+  it("solomon-escalation.js carries the 'only Brain may invoke' note", async () => {
+    const src = await fs.readFile(
+      path.join(ROOT, "src/orchestrator/solomon-escalation.js"),
+      "utf8"
+    );
+    expect(src).toMatch(/MUST NOT be called directly from stages/i);
+    expect(src).toMatch(/Brain-as-gateway|on behalf of Brain/);
+  });
+
+  it("solomon-consult.js imports the Conflict + SolomonResult typedefs", async () => {
+    const src = await fs.readFile(
+      path.join(ROOT, "src/brain/solomon-consult.js"),
+      "utf8"
+    );
+    expect(src).toMatch(/import\("\.\.\/types\/solomon\.js"\)\.Conflict/);
+    expect(src).toMatch(/import\("\.\.\/types\/solomon\.js"\)\.SolomonResult/);
+  });
+
+  it("ARCHITECTURE.md (EN) documents the invariant", async () => {
+    const src = await fs.readFile(path.join(ROOT, "docs/ARCHITECTURE.md"), "utf8");
+    expect(src).toMatch(/never from stages or rules/i);
+    expect(src).toMatch(/21 violations/);
+  });
+
+  it("ARCHITECTURE.md (ES) documents the invariant", async () => {
+    const src = await fs.readFile(path.join(ROOT, "docs/es/ARCHITECTURE.md"), "utf8");
+    expect(src).toMatch(/NUNCA desde stages/);
+    expect(src).toMatch(/21 violaciones/);
+  });
+});


### PR DESCRIPTION
## Summary

Formalizes the Brain⇄Solomon contract that v2.3.0 fixed in code but never wrote down. Adds a central `@typedef Conflict` + `SolomonResult` and makes explicit — in source and in ARCHITECTURE.md — that `invokeSolomon` must only be called by Brain (or by the orchestrator on Brain's behalf).

Scope-check: this is the **reduced** tarea following the analysis of the A2A / KAP proposal — no new protocol, no multi-voter redesign. Just naming the existing contract so it's checkable and visible.

## What's new

- **`src/types/solomon.js`** — new typedef module (runtime-empty). Defines:
  - `Conflict` — the escalation payload: stage, task, iterationCount, maxIterations, cooldownUntil?, cooldownMs?, history.
  - `ConflictHistoryEntry` — the `{ agent, feedback }` shape.
  - `SolomonResult` — the `{ action, rationale, humanGuidance?, question?, subtask? }` ruling.
- **`src/types/index.js`** — re-exports `SolomonConflict` / `SolomonResult` from the central registry.
- **`src/orchestrator/solomon-escalation.js`** — JSDoc `import(\"../types/solomon.js\")`, typed `invokeSolomon` parameters + return, and the \"only Brain may invoke\" invariant note at the top of the file with a pointer to the v2.3.0 audit.
- **`src/brain/solomon-consult.js`** — imports `Conflict` + `SolomonResult`; `buildRoutingConflict` returns `Conflict`.
- **`docs/ARCHITECTURE.md` + `docs/es/ARCHITECTURE.md`** — the `solomon-escalation.js` row now carries the invariant explicitly (with the 21-violations-fixed-in-v2.3.0 reference).

## Deliberately NOT included

- ❌ No \"KAP\" (Karajan Agent Protocol) or A2A-style redesign. Karajan is sequential pipeline, not a proposal-voting council.
- ❌ No new runtime behaviour. The `Conflict` shape matches the argument `invokeSolomon` already receives.
- ❌ No new dependency. Pure JSDoc typedefs + docs.

## Tests

9 new in `tests/types/solomon-typedef.test.js`:

- Module loads cleanly (runtime-empty, no exports).
- `Conflict` carries all documented fields.
- `ConflictHistoryEntry` + `SolomonResult` typedefs present.
- Typedef re-exported from `src/types/index.js`.
- `solomon-escalation.js` + `solomon-consult.js` import the typedef via JSDoc.
- `solomon-escalation.js` carries the invariant note.
- `ARCHITECTURE.md` EN + ES reference the invariant and the v2.3.0 audit.

Full suite: **3 647 tests / 284 files green**.

Closes KJC-TSK-0326.