### PR TITLE
feat(hu-board): /pipeline observability view + journal parser (TSK-0325)

### DIFF
--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -23,6 +23,7 @@
       <button class="nav-btn active" data-view="dashboard">Dashboard</button>
       <button class="nav-btn" data-view="board">Board</button>
       <button class="nav-btn" data-view="sessions">Sessions</button>
+      <a class="nav-btn" href="/pipeline.html" title="Pipeline observability view (v2.7)">Pipeline</a>
       <select class="project-select" id="project-select">
         <option value="">All Projects</option>
       </select>

--- a/packages/hu-board/public/pipeline.css
+++ b/packages/hu-board/public/pipeline.css
@@ -1,0 +1,132 @@
+/* Pipeline observability view (TSK-0325). */
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid #2a3a4e;
+  background: #0f1420;
+}
+.topbar h1 { font-size: 1.125rem; margin: 0; color: #e1e8f2; }
+.topbar .brand {
+  color: #7d9ebc;
+  text-decoration: none;
+  font-weight: 500;
+}
+.topbar .brand:hover { color: #e1e8f2; }
+
+.session-picker {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #94a4ac;
+}
+.session-picker select {
+  background: #1a2332;
+  color: #e1e8f2;
+  border: 1px solid #2a3a4e;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  min-width: 220px;
+}
+.session-picker button {
+  background: #1a2332;
+  color: #e1e8f2;
+  border: 1px solid #2a3a4e;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.session-picker button:hover { background: #2a3a4e; }
+
+main {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.role-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.role-card {
+  border: 1px solid #2a3a4e;
+  border-radius: 6px;
+  padding: 0.75rem;
+  background: #0f1420;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.role-card .name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: #e1e8f2;
+}
+.role-card .meta {
+  font-size: 0.75rem;
+  color: #7d9ebc;
+}
+.role-card[data-status="done"] { border-color: #4caf50; }
+.role-card[data-status="running"] { border-color: #f4b63f; }
+.role-card[data-status="error"] { border-color: #e74c3c; }
+.role-card[data-status="idle"] { opacity: 0.65; }
+
+.panel {
+  border: 1px solid #2a3a4e;
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  background: #0f1420;
+}
+.panel h2 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+  color: #e1e8f2;
+}
+.event-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 420px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.5rem;
+}
+.event-list li {
+  border-left: 2px solid #2a3a4e;
+  padding: 0.5rem 0.75rem;
+  background: #0a0e18;
+  border-radius: 3px;
+}
+.event-list li strong { color: #e1e8f2; display: block; margin-bottom: 0.25rem; }
+.event-list li pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-size: 0.8125rem;
+  color: #94a4ac;
+}
+
+.summary {
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 0.8125rem;
+  color: #94a4ac;
+  margin: 0;
+  max-height: 520px;
+  overflow-y: auto;
+}
+
+footer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: #7d9ebc;
+  padding: 0.75rem 1.5rem;
+  border-top: 1px solid #2a3a4e;
+}
+footer .sep { margin: 0 0.5rem; opacity: 0.5; }

--- a/packages/hu-board/public/pipeline.html
+++ b/packages/hu-board/public/pipeline.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Karajan — Pipeline Observability</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="/pipeline.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="/">← HU Board</a>
+      <h1>Pipeline Observability</h1>
+      <div class="session-picker">
+        <label for="sessionSelect">Session:</label>
+        <select id="sessionSelect" aria-label="Active session"></select>
+        <button id="refreshBtn" type="button" title="Refresh now">⟳</button>
+      </div>
+    </header>
+
+    <main>
+      <section id="roleGrid" class="role-grid" aria-label="Pipeline roles"></section>
+
+      <section class="panel">
+        <h2>Solomon arbitrations</h2>
+        <ol id="solomonList" class="event-list"></ol>
+      </section>
+
+      <section class="panel">
+        <h2>Iterations</h2>
+        <ol id="iterationList" class="event-list"></ol>
+      </section>
+
+      <section class="panel">
+        <h2>Summary</h2>
+        <pre id="summaryBlock" class="summary"></pre>
+      </section>
+    </main>
+
+    <footer>
+      <span id="lastRefresh">—</span>
+      <span class="sep">·</span>
+      <span>Auto-refresh every 2 s (click ⟳ to force)</span>
+    </footer>
+
+    <script src="/pipeline.js" type="module"></script>
+  </body>
+</html>

--- a/packages/hu-board/public/pipeline.js
+++ b/packages/hu-board/public/pipeline.js
@@ -1,0 +1,200 @@
+/**
+ * Pipeline observability client (TSK-0325).
+ *
+ * - Polls /api/pipeline/sessions for the session list (on refresh).
+ * - Polls /api/pipeline/sessions/:id every 2 s for the selected session.
+ * - Renders role cards, Solomon arbitrations, iteration log, summary.
+ *
+ * Zero dependencies, native fetch + DOM. Runs as ES module.
+ */
+
+const POLL_INTERVAL_MS = 2000;
+
+const els = {
+  sessionSelect: document.getElementById("sessionSelect"),
+  refreshBtn: document.getElementById("refreshBtn"),
+  roleGrid: document.getElementById("roleGrid"),
+  solomonList: document.getElementById("solomonList"),
+  iterationList: document.getElementById("iterationList"),
+  summaryBlock: document.getElementById("summaryBlock"),
+  lastRefresh: document.getElementById("lastRefresh"),
+};
+
+// Fixed set of pipeline roles we always render, even if the journal has not
+// mentioned them yet. Mirrors src/orchestrator/stages/ + src/roles/.
+const KNOWN_ROLES = [
+  "triage",
+  "discover",
+  "domain-curator",
+  "researcher",
+  "architect",
+  "planner",
+  "coder",
+  "refactorer",
+  "sonar",
+  "reviewer",
+  "tester",
+  "security",
+  "impeccable",
+  "audit",
+];
+
+let pollTimer = null;
+let currentSessionId = null;
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  }[c]));
+}
+
+async function api(path) {
+  const res = await fetch(path, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`${path} → ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Walk the iteration list and derive {status, lastIteration, retries} per
+ * role. A role is "done" if it appears in any iteration; "running" if it
+ * appears in the latest iteration and has no "error" marker; "error" if the
+ * body of its latest stage contains /error|failed/i.
+ */
+export function deriveRoleStatus(iterations) {
+  const summary = new Map();
+  iterations.forEach((it) => {
+    it.stages.forEach((stage) => {
+      const name = String(stage.name || "").toLowerCase();
+      const prev = summary.get(name) || { count: 0, lastIteration: 0, lastBody: "" };
+      prev.count += 1;
+      prev.lastIteration = Math.max(prev.lastIteration, it.number);
+      prev.lastBody = stage.body;
+      summary.set(name, prev);
+    });
+  });
+  return summary;
+}
+
+function renderRoleGrid(iterations) {
+  const status = deriveRoleStatus(iterations);
+  const latest = iterations.reduce((m, it) => Math.max(m, it.number), 0);
+  const rendered = new Set();
+  const cards = [];
+  const makeCard = (roleName) => {
+    const info = status.get(roleName.toLowerCase());
+    let state = "idle";
+    let meta = "not run yet";
+    if (info) {
+      const errored = /error|failed|✗|blocked/i.test(info.lastBody);
+      const isLatest = info.lastIteration === latest && latest > 0;
+      state = errored ? "error" : (isLatest ? "running" : "done");
+      meta = `iter #${info.lastIteration} · ${info.count} run${info.count > 1 ? "s" : ""}`;
+    }
+    rendered.add(roleName.toLowerCase());
+    return `<article class="role-card" data-status="${state}"><span class="name">${escapeHtml(roleName)}</span><span class="meta">${escapeHtml(meta)}</span></article>`;
+  };
+  for (const r of KNOWN_ROLES) cards.push(makeCard(r));
+  // Render any journal-observed role we did not know about (future roles).
+  for (const [name] of status) {
+    if (!rendered.has(name)) cards.push(makeCard(name));
+  }
+  els.roleGrid.innerHTML = cards.join("");
+}
+
+function renderSolomon(decisions) {
+  const solomon = decisions.filter((d) => /solomon/i.test(d.heading));
+  if (solomon.length === 0) {
+    els.solomonList.innerHTML = `<li><em>No Solomon arbitrations in this session yet.</em></li>`;
+    return;
+  }
+  els.solomonList.innerHTML = solomon
+    .map((s) => `<li><strong>${escapeHtml(s.heading)}</strong><pre>${escapeHtml(s.body)}</pre></li>`)
+    .join("");
+}
+
+function renderIterations(iterations) {
+  if (iterations.length === 0) {
+    els.iterationList.innerHTML = `<li><em>Session has not produced iterations yet.</em></li>`;
+    return;
+  }
+  els.iterationList.innerHTML = iterations
+    .slice()
+    .reverse() // latest on top
+    .map((it) => {
+      const stages = it.stages
+        .map((st) => `<div><strong>${escapeHtml(st.name)}</strong><pre>${escapeHtml(st.body)}</pre></div>`)
+        .join("");
+      const dur = it.duration ? ` — ${escapeHtml(it.duration)}` : "";
+      return `<li><strong>${escapeHtml(it.title)}${dur}</strong>${stages}</li>`;
+    })
+    .join("");
+}
+
+function renderSummary(summary) {
+  if (!summary) { els.summaryBlock.textContent = ""; return; }
+  const body = [summary.preamble, ...summary.sections.map((s) => `## ${s.heading}\n${s.body}`)]
+    .filter(Boolean).join("\n\n");
+  els.summaryBlock.textContent = body.trim() || "(empty summary.md)";
+}
+
+async function refreshOnce() {
+  if (!currentSessionId) return;
+  try {
+    const journal = await api(`/api/pipeline/sessions/${encodeURIComponent(currentSessionId)}`);
+    renderRoleGrid(journal.iterations);
+    renderSolomon(journal.decisions);
+    renderIterations(journal.iterations);
+    renderSummary(journal.summary);
+    els.lastRefresh.textContent = `Last refresh: ${new Date().toLocaleTimeString()}`;
+  } catch (err) {
+    els.lastRefresh.textContent = `Error: ${err.message}`;
+  }
+}
+
+async function loadSessions() {
+  const { sessions } = await api("/api/pipeline/sessions");
+  els.sessionSelect.innerHTML = sessions
+    .map((s) => `<option value="${escapeHtml(s.id)}">${escapeHtml(s.id)} (${new Date(s.mtime).toLocaleString()})</option>`)
+    .join("");
+  if (sessions.length > 0 && !currentSessionId) {
+    currentSessionId = sessions[0].id;
+  }
+  if (currentSessionId) {
+    els.sessionSelect.value = currentSessionId;
+  }
+}
+
+function startPolling() {
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = setInterval(refreshOnce, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+  if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+}
+
+els.sessionSelect.addEventListener("change", (e) => {
+  currentSessionId = e.target.value || null;
+  refreshOnce();
+});
+
+els.refreshBtn.addEventListener("click", async () => {
+  await loadSessions();
+  await refreshOnce();
+});
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) stopPolling();
+  else startPolling();
+});
+
+// Boot
+(async () => {
+  await loadSessions();
+  await refreshOnce();
+  startPolling();
+})();

--- a/packages/hu-board/src/journal-parser.js
+++ b/packages/hu-board/src/journal-parser.js
@@ -1,0 +1,180 @@
+/**
+ * Journal parser — reads `.reviews/<sessionId>/` artefacts produced by Karajan's
+ * session journal writers (decisions.md, iterations.md, summary.md, tree.txt)
+ * and exposes them as structured JSON for the /pipeline dashboard.
+ *
+ * Scope: zero new runtime dependencies. Uses only node:fs + node:path.
+ * Poll-friendly: every call re-reads from disk so the UI can refresh by
+ * hitting the API endpoint on an interval (1-2 s). No WebSocket, no SSE —
+ * keeps the surface minimal (TSK-0325).
+ *
+ * Input layout (as written by src/session/journal/*):
+ *
+ *   <projectDir>/.reviews/<sessionId>/
+ *     ├─ decisions.md     — Brain / Solomon / standby / checkpoint decisions
+ *     ├─ iterations.md    — per-iteration coder/reviewer/sonar/solomon detail
+ *     ├─ summary.md       — executive view: stages, budget, links
+ *     └─ tree.txt         — directory-grouped file status
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve the directory where session journals live. Honours KJ_PROJECT_DIR
+ * for the common "hu-board runs in a different process from the pipeline"
+ * case; otherwise falls back to the current working directory.
+ */
+export function getProjectDir() {
+  return process.env.KJ_PROJECT_DIR || process.cwd();
+}
+
+/**
+ * Resolve the `.reviews/` directory under the active project dir.
+ */
+export function getReviewsDir() {
+  return path.join(getProjectDir(), ".reviews");
+}
+
+/**
+ * List available sessions. Each entry points at a `.reviews/<sessionId>/`
+ * directory that has been produced by Karajan's journal writers.
+ *
+ * @returns {Array<{id: string, journalPath: string, mtimeMs: number}>}
+ */
+export function listSessions() {
+  const reviewsDir = getReviewsDir();
+  if (!fs.existsSync(reviewsDir)) return [];
+  const entries = fs.readdirSync(reviewsDir, { withFileTypes: true });
+  const sessions = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = path.join(reviewsDir, entry.name);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = fs.statSync(dir).mtimeMs;
+    } catch { /* stat failed — skip this entry */ }
+    sessions.push({ id: entry.name, journalPath: dir, mtimeMs });
+  }
+  // Most recent first — what the UI wants by default.
+  sessions.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return sessions;
+}
+
+/**
+ * Split a markdown doc into `## Heading` blocks. Keeps the heading name
+ * and the body under it.
+ * @param {string} md
+ * @returns {Array<{heading: string, body: string}>}
+ */
+export function splitByHeading(md, level = 2) {
+  if (!md) return [];
+  const prefix = "#".repeat(level) + " ";
+  const lines = md.split(/\r?\n/);
+  const blocks = [];
+  let current = null;
+  for (const line of lines) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix + "# ")) {
+      if (current) blocks.push(current);
+      current = { heading: line.slice(prefix.length).trim(), body: "" };
+    } else if (current) {
+      current.body += (current.body ? "\n" : "") + line;
+    }
+  }
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+/**
+ * Parse iterations.md into a list of iteration objects. The journal writer
+ * (src/session/journal/iteration-logger.js) produces `## Iteration N`
+ * sections, each with `### Stage` sub-blocks (Coder, Reviewer, Sonar, …).
+ *
+ * @param {string} md
+ * @returns {Array<{number: number, title: string, duration?: string, stages: Array<{name: string, body: string}>}>}
+ */
+export function parseIterations(md) {
+  return splitByHeading(md, 2).map((block) => {
+    const match = block.heading.match(/Iteration\s+(\d+)/i);
+    const number = match ? Number(match[1]) : 0;
+    const durationMatch = block.body.match(/\*\*Duration\*\*:\s*([^\n]+)/i);
+    const duration = durationMatch ? durationMatch[1].trim() : null;
+    const stages = splitByHeading(block.body, 3).map((s) => ({
+      name: s.heading,
+      body: s.body.trim(),
+    }));
+    return { number, title: block.heading, duration, stages };
+  });
+}
+
+/**
+ * Parse decisions.md into structured records. The writer uses
+ * `## <timestamp> — <decisionType>` headings; fall back to a flat list
+ * when the format drifts.
+ *
+ * @param {string} md
+ * @returns {Array<{heading: string, body: string}>}
+ */
+export function parseDecisions(md) {
+  return splitByHeading(md, 2).map((b) => ({
+    heading: b.heading,
+    body: b.body.trim(),
+  }));
+}
+
+/**
+ * Parse summary.md into { preamble, sections }. The preamble is anything
+ * before the first `## Heading`.
+ *
+ * @param {string} md
+ * @returns {{preamble: string, sections: Array<{heading: string, body: string}>}}
+ */
+export function parseSummary(md) {
+  const sections = splitByHeading(md, 2);
+  const firstHeadingIdx = md.indexOf("## ");
+  const preamble = firstHeadingIdx === -1 ? md.trim() : md.slice(0, firstHeadingIdx).trim();
+  return { preamble, sections };
+}
+
+/**
+ * Read a file defensively — returns null when missing, the content when
+ * present. Lets `readJournal` return a consistent shape even when the
+ * pipeline wrote some artefacts but not others.
+ */
+function readIfExists(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read + parse the four journal artefacts for a given session. Always
+ * returns an object with the same keys so the client has predictable
+ * defaults.
+ *
+ * @param {string} sessionId
+ */
+export function readJournal(sessionId) {
+  const dir = path.join(getReviewsDir(), sessionId);
+  const iterationsRaw = readIfExists(path.join(dir, "iterations.md"));
+  const decisionsRaw = readIfExists(path.join(dir, "decisions.md"));
+  const summaryRaw = readIfExists(path.join(dir, "summary.md"));
+  const treeRaw = readIfExists(path.join(dir, "tree.txt"));
+  return {
+    id: sessionId,
+    journalPath: dir,
+    exists: fs.existsSync(dir),
+    iterations: iterationsRaw ? parseIterations(iterationsRaw) : [],
+    decisions: decisionsRaw ? parseDecisions(decisionsRaw) : [],
+    summary: summaryRaw ? parseSummary(summaryRaw) : { preamble: "", sections: [] },
+    tree: treeRaw || "",
+    raw: {
+      iterations: iterationsRaw,
+      decisions: decisionsRaw,
+      summary: summaryRaw,
+      tree: treeRaw,
+    },
+  };
+}

--- a/packages/hu-board/src/routes/pipeline.js
+++ b/packages/hu-board/src/routes/pipeline.js
@@ -1,0 +1,45 @@
+/**
+ * /api/pipeline/* — routes backing the pipeline observability view
+ * (TSK-0325). Reads the session journal on every request; the UI polls
+ * this endpoint every 1-2 s. No WebSocket, no SSE — polling keeps the
+ * surface minimal and test-friendly.
+ */
+
+import { Router } from "express";
+import { listSessions, readJournal } from "../journal-parser.js";
+
+const router = Router();
+
+/**
+ * GET /api/pipeline/sessions
+ * List every session with a journal directory. Most recent first.
+ */
+router.get("/sessions", (_req, res) => {
+  try {
+    const sessions = listSessions().map((s) => ({
+      id: s.id,
+      mtime: new Date(s.mtimeMs).toISOString(),
+    }));
+    res.json({ sessions });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/pipeline/sessions/:id
+ * Full parsed journal for a given session.
+ */
+router.get("/sessions/:id", (req, res) => {
+  try {
+    const journal = readJournal(req.params.id);
+    if (!journal.exists) {
+      return res.status(404).json({ error: `session "${req.params.id}" not found` });
+    }
+    res.json(journal);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { initDb, closeDb } from './db.js';
 import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
+import pipelineRoutes from './routes/pipeline.js';
 import { authMiddleware } from './auth.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
@@ -53,6 +54,7 @@ async function main() {
   app.use(express.json());
   app.use(express.static(PUBLIC_DIR));
   app.use('/api', authMiddleware(), apiRoutes);
+  app.use('/api/pipeline', authMiddleware(), pipelineRoutes);
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {

--- a/packages/hu-board/tests/journal-parser.test.js
+++ b/packages/hu-board/tests/journal-parser.test.js
@@ -1,0 +1,129 @@
+/**
+ * TSK-0325 — tests for the journal parser backing the /pipeline view.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+let tmpDir;
+let parser;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "hu-board-journal-"));
+  process.env.KJ_PROJECT_DIR = tmpDir;
+  parser = await import("../src/journal-parser.js");
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_PROJECT_DIR;
+});
+
+function stage(name, body) { return `### ${name}\n${body}\n`; }
+
+function writeSession(id, files) {
+  const dir = join(tmpDir, ".reviews", id);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(join(dir, name), content, "utf8");
+  }
+  return dir;
+}
+
+describe("journal-parser.listSessions", () => {
+  it("returns an empty list when .reviews/ does not exist", () => {
+    const fresh = mkdtempSync(join(tmpdir(), "hu-board-journal-empty-"));
+    process.env.KJ_PROJECT_DIR = fresh;
+    expect(parser.listSessions()).toEqual([]);
+    rmSync(fresh, { recursive: true, force: true });
+    process.env.KJ_PROJECT_DIR = tmpDir;
+  });
+
+  it("lists only directories under .reviews/", () => {
+    writeSession("sess-a", { "iterations.md": "# Iterations\n" });
+    writeSession("sess-b", { "iterations.md": "# Iterations\n" });
+    fs.writeFileSync(join(tmpDir, ".reviews", "stray.txt"), "ignored", "utf8");
+    const ids = parser.listSessions().map((s) => s.id).sort();
+    expect(ids).toContain("sess-a");
+    expect(ids).toContain("sess-b");
+    expect(ids).not.toContain("stray.txt");
+  });
+});
+
+describe("journal-parser.splitByHeading", () => {
+  it("splits on the given level", () => {
+    const md = "# doc\n\n## one\nbody1\n\n## two\nbody2\n";
+    const blocks = parser.splitByHeading(md, 2);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].heading).toBe("one");
+    expect(blocks[0].body.trim()).toBe("body1");
+    expect(blocks[1].heading).toBe("two");
+  });
+
+  it("returns empty array for missing content", () => {
+    expect(parser.splitByHeading("", 2)).toEqual([]);
+    expect(parser.splitByHeading(null, 2)).toEqual([]);
+  });
+});
+
+describe("journal-parser.parseIterations", () => {
+  it("extracts iteration number + stages", () => {
+    const md = [
+      "# Iterations",
+      "",
+      "## Iteration 1",
+      "**Duration**: 1m2s",
+      "",
+      stage("Coder", "added function foo"),
+      stage("Reviewer", "Approved"),
+      "",
+      "## Iteration 2",
+      "**Duration**: 45s",
+      stage("Coder", "fixed typo"),
+    ].join("\n");
+    const its = parser.parseIterations(md);
+    expect(its).toHaveLength(2);
+    expect(its[0].number).toBe(1);
+    expect(its[0].duration).toBe("1m2s");
+    expect(its[0].stages.map((s) => s.name)).toEqual(["Coder", "Reviewer"]);
+    expect(its[1].stages[0].body).toContain("fixed typo");
+  });
+});
+
+describe("journal-parser.parseDecisions", () => {
+  it("returns a flat list of heading/body pairs", () => {
+    const md = "# Decisions\n\n## 10:00 — Solomon consult\nbody\n\n## 10:02 — Brain route\nbody2\n";
+    const out = parser.parseDecisions(md);
+    expect(out).toHaveLength(2);
+    expect(out[0].heading).toContain("Solomon");
+  });
+});
+
+describe("journal-parser.parseSummary", () => {
+  it("separates preamble and sections", () => {
+    const md = "intro line\n\n## Stages\nstage body\n";
+    const out = parser.parseSummary(md);
+    expect(out.preamble).toBe("intro line");
+    expect(out.sections).toHaveLength(1);
+    expect(out.sections[0].heading).toBe("Stages");
+  });
+});
+
+describe("journal-parser.readJournal", () => {
+  it("returns a stable shape even when files are missing", () => {
+    writeSession("sess-partial", { "iterations.md": "# Iterations\n## Iteration 1\n### Coder\ndone\n" });
+    const out = parser.readJournal("sess-partial");
+    expect(out.exists).toBe(true);
+    expect(out.iterations).toHaveLength(1);
+    expect(out.decisions).toEqual([]);
+    expect(out.summary).toEqual({ preamble: "", sections: [] });
+    expect(out.tree).toBe("");
+  });
+
+  it("returns exists=false for unknown sessions", () => {
+    const out = parser.readJournal("nope-nope-nope");
+    expect(out.exists).toBe(false);
+  });
+});

--- a/packages/hu-board/tests/pipeline-route.test.js
+++ b/packages/hu-board/tests/pipeline-route.test.js
@@ -1,0 +1,76 @@
+/**
+ * TSK-0325 — integration tests for the /api/pipeline/* routes.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+let tmpDir;
+let app;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "hu-board-pipeline-"));
+  process.env.KJ_PROJECT_DIR = tmpDir;
+
+  // Seed a journal directory
+  const reviewsDir = join(tmpDir, ".reviews", "demo-session");
+  fs.mkdirSync(reviewsDir, { recursive: true });
+  fs.writeFileSync(
+    join(reviewsDir, "iterations.md"),
+    "# Iterations\n\n## Iteration 1\n**Duration**: 1m\n### Coder\ndone\n### Reviewer\nApproved\n",
+    "utf8"
+  );
+  fs.writeFileSync(
+    join(reviewsDir, "decisions.md"),
+    "# Decisions\n\n## Solomon consult\nused Solomon\n",
+    "utf8"
+  );
+  fs.writeFileSync(
+    join(reviewsDir, "summary.md"),
+    "Session overview.\n\n## Stages\ntable here\n",
+    "utf8"
+  );
+  fs.writeFileSync(join(reviewsDir, "tree.txt"), "src/\n  foo.js\n", "utf8");
+
+  const { default: pipelineRoutes } = await import("../src/routes/pipeline.js");
+  app = express();
+  app.use("/api/pipeline", pipelineRoutes);
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_PROJECT_DIR;
+});
+
+describe("GET /api/pipeline/sessions", () => {
+  it("returns 200 and a sessions array", async () => {
+    const res = await request(app).get("/api/pipeline/sessions");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.sessions)).toBe(true);
+    expect(res.body.sessions.map((s) => s.id)).toContain("demo-session");
+    expect(res.body.sessions[0]).toHaveProperty("mtime");
+  });
+});
+
+describe("GET /api/pipeline/sessions/:id", () => {
+  it("returns the full parsed journal", async () => {
+    const res = await request(app).get("/api/pipeline/sessions/demo-session");
+    expect(res.status).toBe(200);
+    expect(res.body.exists).toBe(true);
+    expect(res.body.iterations).toHaveLength(1);
+    expect(res.body.iterations[0].stages.map((s) => s.name)).toContain("Coder");
+    expect(res.body.decisions[0].heading).toContain("Solomon");
+    expect(res.body.summary.sections[0].heading).toBe("Stages");
+    expect(res.body.tree).toContain("src/");
+  });
+
+  it("returns 404 for unknown sessions", async () => {
+    const res = await request(app).get("/api/pipeline/sessions/not-a-real-session");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'session "not-a-real-session" not found' });
+  });
+});

--- a/packages/hu-board/vitest.config.js
+++ b/packages/hu-board/vitest.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+// Local config for the hu-board package. The root `vitest.config.js`
+// excludes `packages/**` and expects a repo-wide `tests/setup.js` that
+// does not apply here — this config scopes vitest to the hu-board tree
+// and omits that setup file.
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.js"],
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

Extends `packages/hu-board` with a **pipeline observability view** that reads the per-session journal written by v2.6's journal suite (`decisions.md`, `iterations.md`, `summary.md`, `tree.txt` under `.reviews/<id>/`) and renders it as a live dashboard in a vanilla-JS page.

Addresses the reformulated proposal from the improvements analysis: not a new WS server, not a new UI framework, just extend the Express server already running at `:4000` and poll the journal files every 2 s.

## What's new

### Server side

- **`packages/hu-board/src/journal-parser.js`** — zero-dep parser.
  - `listSessions()` walks `<projectDir>/.reviews/` (honours `KJ_PROJECT_DIR`, falls back to `cwd`).
  - `readJournal(id)` returns a stable shape `{ iterations, decisions, summary, tree, raw, exists }` even when some files are missing.
  - `parseIterations`, `parseDecisions`, `parseSummary`, `splitByHeading` — pure functions, easy to test.
- **`packages/hu-board/src/routes/pipeline.js`**:
  - `GET /api/pipeline/sessions` → `{ sessions: [{ id, mtime }] }` newest first.
  - `GET /api/pipeline/sessions/:id` → full parsed journal (404 when unknown).
- **`packages/hu-board/src/server.js`**: mounts `pipelineRoutes` at `/api/pipeline`.

### Client side (vanilla ES module)

- **`packages/hu-board/public/pipeline.html` + `.css` + `.js`** — session selector, **role grid** (14 known roles + any new role observed in the journal, each with `idle / running / done / error` state), Solomon arbitrations panel, iterations log (latest on top), summary panel. Polls every 2 s; pauses when the tab is hidden; manual refresh button available.
- **`packages/hu-board/public/index.html`** gets a `Pipeline` nav link.

### Tooling

- **`packages/hu-board/vitest.config.js`** — local scope. The root `vitest.config.js` excludes `packages/**` and points at a setup file that does not apply here, so tests were unrunnable from the package. New local config fixes that.

## Explicit scope discipline

Per the TSK-0325 AC:

- ✅ Vanilla HTML/CSS/ES-module JS. No React / Vue / D3 / `ws` / `socket.io`.
- ✅ Polling (1-2 s), not WebSocket. Server tests are plain `supertest`.
- ✅ Zero new runtime dependencies — only Express + existing devDeps (`vitest`, `supertest`).
- ✅ Session replay is \"open /pipeline for a finished session\" — same endpoint, same rendering.
- ✅ Rendered roles mirror `src/orchestrator/stages/` + `src/roles/` — future roles auto-appear.

## Tests

12 new across two files:

- `tests/journal-parser.test.js` — `listSessions` empty + populated, `splitByHeading` happy + edge, `parseIterations` number+duration+stages, `parseDecisions` list shape, `parseSummary` preamble + sections, `readJournal` stable shape + 404.
- `tests/pipeline-route.test.js` — `GET /sessions` shape, `GET /sessions/:id` full journal, 404 for unknown.

Root suite unaffected: **3 647 tests / 284 files green** (last run from this branch before push).

Closes KJC-TSK-0325.