### PR TITLE
fix(hu-board): session→project fallback + release v2.6.1 (BUG-0028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-04-20
+
+### Fixed
+
+- **hu-board: session.json without a matching auto-batch is no longer dropped** (KJC-BUG-0028). Previously `syncSessionFile` bailed with `if (!projectId) return;` when a session had no batch and no `project_id`, and it never called `upsertProject` even when `project_id` was present. Result: running `kj run "task"` without HU decomposition produced a session that was invisible on the board. Now `syncSessionFile` upserts the project row in that order: `auto-<sessionId>` → `data.project_id` → `default` (bucket `"Orphan sessions"`). Restores the two regressed tests in `packages/hu-board/tests/sync.test.js`.
+- **hu-board: `fullScan` plans directory is now isolated for tests**. The scan of v2 plans previously hardcoded `~/.kj/plans/` via `homedir()`, so running the test suite flooded the output with entries from the developer's real machine. `KJ_PLANS_DIR` now overrides that path; the hu-board vitest config sets it to a non-existent placeholder so tests never read real plans.
+
+### Infrastructure
+
+- `packages/hu-board/vitest.config.js` sets `env.KJ_PLANS_DIR` for all test runs.
+
 ## [2.6.0] - 2026-04-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -167,13 +167,36 @@ function syncSessionFile(filePath) {
     const data = JSON.parse(raw);
     const sessionId = data.id || basename(join(filePath, '..'));
 
-    // Sessions NEVER create projects. Only batches (hu-stories/) create projects.
-    // The session attaches to the batch's project if one exists, otherwise it's
-    // invisible in the board (correct for runs without HU decomposition).
+    // Resolve which project this session belongs to:
+    //   1. If a plan / HU batch already created `auto-<sessionId>`, reuse it
+    //      so plan-based runs group with their HU batch.
+    //   2. Otherwise fall back to the session's declared `project_id`.
+    //   3. Otherwise bucket the session under "default" so orphan runs
+    //      (e.g. `kj run "task"` without HU decomposition) still show up on
+    //      the board instead of disappearing silently. Fix for KJC-BUG-0028.
     const autoProjectId = `auto-${sessionId}`;
     const db = getDb();
     const existingBatch = db.prepare('SELECT id FROM projects WHERE id = ?').get(autoProjectId);
-    const projectId = existingBatch ? autoProjectId : (data.project_id || null);
+    let projectId;
+    if (existingBatch) {
+      projectId = autoProjectId;
+    } else if (data.project_id) {
+      projectId = data.project_id;
+    } else {
+      projectId = 'default';
+    }
+
+    // Ensure the project row exists. Skip when an auto-batch owns it already
+    // (that row was written by syncStoryFile with richer metadata and we do
+    // not want to overwrite name/total_stories).
+    if (!existingBatch) {
+      upsertProject({
+        id: projectId,
+        name: projectId === 'default' ? 'Orphan sessions' : projectId,
+        last_activity: data.updated_at || data.created_at || new Date().toISOString(),
+        total_stories: 0,
+      });
+    }
 
     // Calculate iterations from checkpoints
     const checkpoints = data.checkpoints || [];
@@ -193,9 +216,8 @@ function syncSessionFile(filePath) {
       }
     }
 
-    // No upsertProject — sessions don't create projects.
-
-    if (!projectId) return; // No batch project to attach to → skip session
+    // Project row was created above (unless an auto-batch owns it); the
+    // session always has a project to attach to now.
 
     upsertSession({
       id: sessionId,
@@ -311,8 +333,9 @@ export function fullScan() {
     }
   }
 
-  // Scan v2 plans (from kj plan → ~/.kj/plans/)
-  const kjDir = join(homedir(), '.kj', 'plans');
+  // Scan v2 plans (from kj plan → ~/.kj/plans/). Honours KJ_PLANS_DIR for
+  // test isolation; falls back to the default location in production.
+  const kjDir = process.env.KJ_PLANS_DIR || join(homedir(), '.kj', 'plans');
   if (existsSync(kjDir)) {
     const projectDirs = readdirSync(kjDir);
     for (const projDir of projectDirs) {

--- a/packages/hu-board/vitest.config.js
+++ b/packages/hu-board/vitest.config.js
@@ -9,5 +9,11 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.js"],
     testTimeout: 15000,
+    // Isolate sync.js from the developer's real ~/.kj/plans/ so tests
+    // don't drown in real data. tests can still override KJ_PLANS_DIR
+    // for scenarios that need to seed plans.
+    env: {
+      KJ_PLANS_DIR: "/tmp/.kj-plans-hu-board-test-placeholder",
+    },
   },
 });


### PR DESCRIPTION
## Summary

Fixes two pre-existing failures in `packages/hu-board/tests/sync.test.js` that exposed a real regression: a `session.json` without a matching auto-batch was silently dropped, so `kj run \"task\"` without HU decomposition produced sessions that never appeared on the HU Board.

Ships as **v2.6.1** (patch) since there is no behaviour change beyond the fix + test isolation.

## Bug (KJC-BUG-0028)

- `syncSessionFile` bailed early with `if (!projectId) return;` whenever no `auto-<sessionId>` project existed and the session had no `project_id`.
- Even when `project_id` was present, the function never called `upsertProject`, so the project row did not exist and the session had nothing to attach to.
- Consequence: orphan sessions disappeared.

## Fix (`packages/hu-board/src/sync.js`)

- Resolve `projectId` with a clean fallback chain:
  1. `auto-<sessionId>` if the batch already exists.
  2. `data.project_id` if present.
  3. `\"default\"` bucket, named `\"Orphan sessions\"`.
- `upsertProject` is called when we had to synthesize the project; auto-batch case is left alone so its richer metadata (name, total_stories) is preserved.
- The `if (!projectId) return;` guard is gone.

## Test isolation (BONUS)

`fullScan` used to scan `~/.kj/plans/` via `homedir()` regardless of `KJ_HOME`, so running the hu-board test suite drowned the output in real plan data from the developer's machine. Now it honours `KJ_PLANS_DIR`, and `packages/hu-board/vitest.config.js` sets it to a placeholder so tests are properly isolated.

## Release

- `package.json` `2.6.0` → `2.6.1`
- `CHANGELOG.md`: new `[2.6.1] - 2026-04-20` section (Fixed + Infrastructure).

## Verification

- Root suite: **3 647 tests / 284 files green** (unchanged).
- hu-board local suite: **61 tests / 6 files green** (was 59 passing + 2 failing before this PR).

Closes KJC-BUG-0028.