### PR TITLE
feat(skills): addyosmani/agent-skills as first-source process catalog (KJC-TSK-0327)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -138,6 +138,70 @@ kj skills clear-cache   # force re-install on next session
 The TTL is currently 7 days and is not user-configurable in v1. The cache
 stores metadata only — it never holds skill content itself.
 
+## addyosmani/agent-skills (process skills — **first source**)
+
+Since v2.7, Karajan also consults the [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills)
+catalog **before** OpenSkills. The two providers are orthogonal:
+
+| Provider | What it covers | Example slugs |
+|----------|----------------|---------------|
+| `addyosmani` (first) | Lifecycle / process skills, per role | `test-driven-development`, `code-review-and-quality`, `security-and-hardening`, `performance-optimization`, `git-workflow-and-versioning` |
+| `openskills` | Stack / framework skills | `astro`, `react`, `prisma`, `vitest-patterns`, `owasp-top-10` |
+| `local` | Project-specific skills under `.claude/skills/` | any slug you define |
+
+### Bootstrap
+
+On the first run with `skills.addyosmani.enabled: true` (default), Karajan
+shallow-clones the upstream repo into `~/.karajan/agent-skills/`. Subsequent
+runs re-use the local copy and refresh it with `git pull` after
+`skills.addyosmani.refreshDays` (default: **7 days**). When `git` is missing or
+the network is unreachable, the step degrades silently and the pipeline keeps
+running with OpenSkills only.
+
+### Role → slug mapping
+
+The role map in `src/skills/addyosmani-role-map.js` wires each Karajan role to
+its canonical workflows:
+
+| Role | addyosmani slugs |
+|------|------------------|
+| `coder` | `incremental-implementation`, `source-driven-development`, `context-engineering`, `debugging-and-error-recovery` |
+| `reviewer` | `code-review-and-quality`, `code-simplification` |
+| `tester` | `test-driven-development`, `browser-testing-with-devtools` |
+| `security` | `security-and-hardening` |
+| `architect` | `spec-driven-development`, `api-and-interface-design`, `planning-and-task-breakdown` |
+| `planner` | `planning-and-task-breakdown`, `spec-driven-development` |
+| `impeccable` | `frontend-ui-engineering` |
+| `refactorer` | `code-simplification`, `debugging-and-error-recovery` |
+
+Task-text triggers add slugs on top. For example, any task mentioning
+"performance" or "Core Web Vitals" pulls `performance-optimization`; "git" or
+"semver" pulls `git-workflow-and-versioning`; "CI/CD" pulls
+`ci-cd-and-automation`.
+
+### Configuration
+
+```yaml
+# ~/.karajan/kj.config.yml
+skills:
+  mode: auto
+  sources: [addyosmani, openskills, local]   # first match wins per source
+  addyosmani:
+    enabled: true
+    refreshDays: 7
+    repoUrl: https://github.com/addyosmani/agent-skills.git
+```
+
+To disable the addyosmani source, remove it from `sources` **or** set
+`skills.addyosmani.enabled: false`.
+
+### CLI
+
+```bash
+kj skills sync-addyosmani    # force git pull + report slug count
+kj skills list-addyosmani    # enumerate slugs with their descriptions
+```
+
 ## Testing behavior locally
 
 ```bash

--- a/src/cli.js
+++ b/src/cli.js
@@ -217,7 +217,7 @@ program
 
 program
   .command("skills [action]")
-  .description("Manage the local OpenSkills cache (actions: list | clear-cache)")
+  .description("Manage the skill cache (actions: list | clear-cache | sync-addyosmani | list-addyosmani)")
   .action(async (action) => {
     const { skillsCommand } = await import("./commands/skills.js");
     const exitCode = await skillsCommand({ action: action || "list" });

--- a/src/commands/skills.js
+++ b/src/commands/skills.js
@@ -1,12 +1,15 @@
 /**
- * `kj skills` — manage the local OpenSkills cache.
+ * `kj skills` — manage the local OpenSkills cache and the addyosmani catalog.
  *
  * Subcommands:
- *   - list         : print cached skills with their age and freshness.
- *   - clear-cache  : delete all cached metadata (forces re-install on next session).
+ *   - list                  : print cached OpenSkills with their age and freshness.
+ *   - clear-cache           : delete all cached metadata (forces re-install on next session).
+ *   - sync-addyosmani       : force a git pull of addyosmani/agent-skills.
+ *   - list-addyosmani       : enumerate slugs available in the cached catalog.
  */
 
 import { listCached, clearCache, getCacheRoot, DEFAULT_TTL_MS } from "../skills/skills-cache.js";
+import { refreshIfStale, listAvailableSlugs, getCatalogRoot, loadSkillBySlug } from "../skills/addyosmani-catalog.js";
 
 function humanAge(cachedAt) {
   const ms = Date.now() - Date.parse(cachedAt);
@@ -22,8 +25,12 @@ export async function skillsCommand({ action = "list" } = {}) {
       return listAction();
     case "clear-cache":
       return clearAction();
+    case "sync-addyosmani":
+      return syncAddyosmaniAction();
+    case "list-addyosmani":
+      return listAddyosmaniAction();
     default:
-      console.error(`Unknown action: ${action}. Use: list | clear-cache`);
+      console.error(`Unknown action: ${action}. Use: list | clear-cache | sync-addyosmani | list-addyosmani`);
       return 1;
   }
 }
@@ -45,5 +52,35 @@ async function listAction() {
 async function clearAction() {
   const { removed } = await clearCache();
   console.log(`Cleared ${removed} cached skill${removed === 1 ? "" : "s"} from ${getCacheRoot()}`);
+  return 0;
+}
+
+async function syncAddyosmaniAction() {
+  console.log("Syncing addyosmani/agent-skills catalog...");
+  const logger = { warn: (m) => console.warn(`  warn: ${m}`), info: (m) => console.log(`  ${m}`) };
+  const result = await refreshIfStale({ force: true, logger });
+  if (!result.ok) {
+    console.error(`Sync failed: ${result.error || result.action}`);
+    return 1;
+  }
+  const slugs = await listAvailableSlugs();
+  console.log(`${result.action === "cloned" ? "Cloned" : "Pulled"} at ${getCatalogRoot()}`);
+  console.log(`Available slugs: ${slugs.length}`);
+  return 0;
+}
+
+async function listAddyosmaniAction() {
+  const slugs = await listAvailableSlugs();
+  if (slugs.length === 0) {
+    console.log(`No addyosmani catalog found at ${getCatalogRoot()}`);
+    console.log("Run `kj skills sync-addyosmani` to bootstrap it.");
+    return 0;
+  }
+  console.log(`addyosmani/agent-skills catalog at ${getCatalogRoot()}\n${slugs.length} slug(s):\n`);
+  for (const slug of slugs) {
+    const skill = await loadSkillBySlug(slug);
+    const desc = skill?.description ? ` — ${skill.description.slice(0, 100)}${skill.description.length > 100 ? "..." : ""}` : "";
+    console.log(`  ${slug}${desc}`);
+  }
   return 0;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -141,6 +141,15 @@ const DEFAULTS = {
   policies: {},
   serena: { enabled: false },
   planning_game: { enabled: false, project_id: null, codeveloper: null },
+  skills: {
+    mode: "auto",
+    sources: ["addyosmani", "openskills", "local"],
+    addyosmani: {
+      enabled: true,
+      refreshDays: 7,
+      repoUrl: "https://github.com/addyosmani/agent-skills.git"
+    }
+  },
   ci: { enabled: false, review_event: "kj-review", comment_event: "kj-comment", comment_prefix: true },
   git: { auto_commit: false, auto_push: false, auto_pr: false, auto_rebase: true, branch_prefix: "feat/" },
   output: { report_dir: "./.reviews", log_level: "info", quiet: true },

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -152,6 +152,30 @@ const Budget = v.optional(v.looseObject({
 }));
 
 /**
+ * skills.addyosmani subtree (KJC-TSK-0327). Governs the addyosmani/agent-skills
+ * catalog provider: enabled flag, refresh TTL and repo URL.
+ */
+const SkillsAddyosmani = v.looseObject({
+  enabled: v.optional(v.boolean()),
+  refreshDays: v.optional(v.pipe(
+    v.number(),
+    v.minValue(0, "skills.addyosmani.refreshDays must be >= 0")
+  )),
+  repoUrl: v.optional(v.string()),
+});
+
+/**
+ * skills.* subtree. `sources` controls which providers Karajan consults and in
+ * what order (addyosmani → openskills → local by default). `mode` is the
+ * existing regex/semantic/auto/none knob from semantic-detector.js.
+ */
+const Skills = v.optional(v.looseObject({
+  mode: v.optional(v.picklist(["auto", "regex", "semantic", "none"], "skills.mode must be one of: auto | regex | semantic | none")),
+  sources: v.optional(v.array(v.string())),
+  addyosmani: v.optional(SkillsAddyosmani),
+}));
+
+/**
  * Main config schema. `looseObject` lets every consumer that reads an
  * undeclared key keep working while the schema catches the bugs we care
  * about.
@@ -181,6 +205,7 @@ export const ConfigSchema = v.looseObject({
   hu_language: v.optional(v.string()),
   policies: v.optional(v.record(v.string(), v.unknown())),
   telemetry: v.optional(v.boolean()),
+  skills: Skills,
 });
 
 /**

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -39,6 +39,8 @@ import { setRunner as setGitRunner } from "../utils/git.js";
 import { detectNeededSkills, autoInstallSkills, cleanupAutoInstalledSkills } from "../skills/skill-detector.js";
 import { isOpenSkillsAvailable } from "../skills/openskills-client.js";
 import { refineSkillsSemantically, resolveSkillsMode } from "../skills/semantic-detector.js";
+import { refreshIfStale as refreshAddyosmaniCatalog, listAvailableSlugs as listAddyosmaniSlugs } from "../skills/addyosmani-catalog.js";
+import { resolveAddyosmaniSlugs } from "../skills/addyosmani-role-map.js";
 
 // Extracted modules
 import {
@@ -832,6 +834,20 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
       // User explicitly opted out. Skip detection entirely.
       return { plannedTask, updatedConfig };
     }
+
+    // FIRST source: addyosmani/agent-skills (process skills per role).
+    // This runs BEFORE OpenSkills detection because process skills are the
+    // canonical workflows (TDD, code-review, security, performance...) that
+    // should shape every role's prompt; stack skills come second.
+    await ensureAddyosmaniSkills({
+      task: plannedTask,
+      config: updatedConfig,
+      logger,
+      session,
+      emitter,
+      eventBase,
+    });
+
     let neededSkills = skillsMode === "semantic"
       ? []
       : await detectNeededSkills(plannedTask, skillProjectDir);
@@ -877,6 +893,80 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
   }
 
   return { plannedTask, updatedConfig };
+}
+
+/**
+ * Ensure the addyosmani/agent-skills catalog is present and fresh, then
+ * resolve which upstream slugs are relevant for the current task. The
+ * resolved slugs are stored on `session.addyosmaniSkills` so downstream
+ * prompt builders can inject them ahead of OpenSkills-detected stack skills.
+ *
+ * Config surface (all optional, sensible defaults):
+ *   skills:
+ *     sources: ["addyosmani", "openskills", "local"]  # default
+ *     addyosmani:
+ *       enabled: true
+ *       refreshDays: 7
+ *       repoUrl: "https://github.com/addyosmani/agent-skills.git"
+ *
+ * Setting skills.addyosmani.enabled = false, or removing "addyosmani" from
+ * skills.sources, disables this step entirely (reverts to OpenSkills-only).
+ */
+async function ensureAddyosmaniSkills({ task, config, logger, session, emitter, eventBase }) {
+  const skillsConfig = config?.skills || {};
+  const sources = Array.isArray(skillsConfig.sources) ? skillsConfig.sources : ["addyosmani", "openskills", "local"];
+  const addyConfig = skillsConfig.addyosmani || {};
+  // Test harness override: tests/setup.js sets __KJ_DEFAULT_ADDYOSMANI_ENABLED
+  // to false so orchestrator tests don't spawn git. Tests that need the real
+  // catalog opt in by setting config.skills.addyosmani.enabled = true.
+  const globalDefault = globalThis.__KJ_DEFAULT_ADDYOSMANI_ENABLED;
+  const enabledFromConfig = addyConfig.enabled === true
+    || (addyConfig.enabled !== false && globalDefault !== false);
+  const enabled = enabledFromConfig && sources.includes("addyosmani");
+  if (!enabled) return;
+
+  const refreshDays = Number.isFinite(addyConfig.refreshDays) ? addyConfig.refreshDays : 7;
+  const refreshMs = Math.max(0, refreshDays) * 24 * 60 * 60 * 1000;
+
+  try {
+    const refreshResult = await refreshAddyosmaniCatalog({
+      refreshMs,
+      repoUrl: addyConfig.repoUrl,
+      logger,
+    });
+
+    if (!refreshResult.ok) {
+      session.addyosmaniSkills = { available: false, reason: refreshResult.error || "refresh failed" };
+      emitProgress(emitter, makeEvent("skills:addyosmani-unavailable", { ...eventBase, stage: "skills" }, {
+        message: `addyosmani/agent-skills catalog unavailable: ${refreshResult.error || refreshResult.action}`,
+        detail: { action: refreshResult.action, hint: "Install git to enable process skills from addyosmani/agent-skills" },
+      }));
+      return;
+    }
+
+    const available = new Set(await listAddyosmaniSlugs());
+    const resolved = resolveAddyosmaniSlugs({ role: null, task }); // role resolution happens per-stage later
+    const valid = resolved.filter((slug) => available.has(slug));
+
+    session.addyosmaniSkills = {
+      available: true,
+      action: refreshResult.action,
+      resolvedSlugs: valid,
+      allAvailable: Array.from(available),
+    };
+
+    emitProgress(emitter, makeEvent("skills:addyosmani-ready", { ...eventBase, stage: "skills" }, {
+      message: `addyosmani/agent-skills ${refreshResult.action} — ${available.size} slug(s) available, ${valid.length} relevant to task`,
+      detail: {
+        action: refreshResult.action,
+        relevantSlugs: valid,
+        availableCount: available.size,
+      },
+    }));
+  } catch (err) {
+    logger.warn(`addyosmani catalog step failed (non-blocking): ${err.message}`);
+    session.addyosmaniSkills = { available: false, reason: err.message };
+  }
 }
 
 /**

--- a/src/skills/addyosmani-catalog.js
+++ b/src/skills/addyosmani-catalog.js
@@ -1,0 +1,293 @@
+/**
+ * addyosmani/agent-skills catalog provider (KJC-TSK-0327).
+ *
+ * Fetches and caches the addyosmani/agent-skills repository (20+ process
+ * skills: TDD, code-review, security, performance, git-workflow, debugging,
+ * CI/CD, docs, spec-driven, planning...) and exposes them as a first-class
+ * skill source for Karajan's pipeline.
+ *
+ * This catalog is ORTHOGONAL to the OpenSkills marketplace (which hosts stack
+ * skills like astro, react, prisma, python-data). Together they cover:
+ *   - addyosmani    → lifecycle/process skills mapped per role
+ *   - OpenSkills    → stack/framework skills detected from task + deps
+ *   - local skills  → project-specific skills under .claude/skills
+ *
+ * Lifecycle:
+ *   1. ensureCatalog()      – clone (depth=1) on first use
+ *   2. refreshIfStale()     – git pull when older than TTL (default 7d)
+ *   3. loadSkillBySlug()    – read /skills/<slug>/SKILL.md from disk
+ *   4. listAvailableSlugs() – enumerate the /skills/ directory
+ *
+ * Degradation contract: when git is missing, the network is unreachable, or
+ * the catalog directory is malformed, every exported function returns safe
+ * empty values and logs a warning. The pipeline NEVER blocks on this module.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runCommand } from "../utils/process.js";
+import { getKarajanHome } from "../utils/paths.js";
+
+const REPO_URL = "https://github.com/addyosmani/agent-skills.git";
+const CATALOG_DIR_NAME = "agent-skills";
+const SKILLS_SUBDIR = "skills";
+const SKILL_FILE = "SKILL.md";
+const DEFAULT_REFRESH_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const META_FILENAME = ".karajan-catalog-meta.json";
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+/**
+ * Absolute path to the cached catalog inside ~/.karajan/.
+ * @returns {string}
+ */
+export function getCatalogRoot() {
+  return path.join(getKarajanHome(), CATALOG_DIR_NAME);
+}
+
+function getSkillsRoot() {
+  return path.join(getCatalogRoot(), SKILLS_SUBDIR);
+}
+
+function getMetaPath() {
+  return path.join(getCatalogRoot(), META_FILENAME);
+}
+
+async function pathExists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readMeta() {
+  try {
+    const raw = await fs.readFile(getMetaPath(), "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeMeta(meta) {
+  await fs.mkdir(getCatalogRoot(), { recursive: true });
+  await fs.writeFile(getMetaPath(), JSON.stringify(meta, null, 2), "utf8");
+}
+
+/**
+ * Check whether `git` is on PATH. Cached per-process.
+ * @returns {Promise<boolean>}
+ */
+let _gitAvailable = null;
+export async function isGitAvailable() {
+  if (_gitAvailable !== null) return _gitAvailable;
+  try {
+    const result = await runCommand("git", ["--version"], { timeout: 5_000 });
+    _gitAvailable = result.exitCode === 0;
+  } catch {
+    _gitAvailable = false;
+  }
+  return _gitAvailable;
+}
+
+// Internal: reset the cached probe (tests use this to re-evaluate git presence).
+export function __resetGitProbe() {
+  _gitAvailable = null;
+}
+
+/**
+ * Clone the addyosmani/agent-skills repo (shallow) if it does not already
+ * exist locally. No-op when it is already present.
+ *
+ * @param {{ repoUrl?: string, logger?: object }} [opts]
+ * @returns {Promise<{ok: boolean, path?: string, error?: string, skipped?: boolean}>}
+ */
+export async function ensureCatalog(opts = {}) {
+  const { repoUrl = REPO_URL, logger } = opts;
+  const root = getCatalogRoot();
+
+  if (await pathExists(path.join(root, ".git"))) {
+    return { ok: true, path: root, skipped: true };
+  }
+
+  if (!(await isGitAvailable())) {
+    logger?.warn?.("addyosmani-catalog: git not available — skipping catalog bootstrap");
+    return { ok: false, error: "git not available" };
+  }
+
+  await fs.mkdir(path.dirname(root), { recursive: true });
+
+  const result = await runCommand(
+    "git",
+    ["clone", "--depth", "1", repoUrl, root],
+    { timeout: 120_000 }
+  );
+
+  if (result.exitCode !== 0) {
+    const stderr = (result.stderr || "").trim();
+    logger?.warn?.(`addyosmani-catalog: clone failed — ${stderr}`);
+    return { ok: false, error: stderr || `clone failed (exit ${result.exitCode})` };
+  }
+
+  await writeMeta({
+    repoUrl,
+    clonedAt: new Date().toISOString(),
+    lastPullAt: new Date().toISOString(),
+  });
+
+  return { ok: true, path: root };
+}
+
+/**
+ * Refresh the catalog via `git pull` when the cached copy is older than
+ * `refreshMs`. When the catalog does not exist yet, delegates to
+ * ensureCatalog().
+ *
+ * @param {{ refreshMs?: number, repoUrl?: string, force?: boolean, logger?: object }} [opts]
+ * @returns {Promise<{ok: boolean, action: "cloned"|"pulled"|"fresh"|"skipped", error?: string}>}
+ */
+export async function refreshIfStale(opts = {}) {
+  const { refreshMs = DEFAULT_REFRESH_MS, repoUrl = REPO_URL, force = false, logger } = opts;
+  const root = getCatalogRoot();
+
+  if (!(await pathExists(path.join(root, ".git")))) {
+    const cloneResult = await ensureCatalog({ repoUrl, logger });
+    return cloneResult.ok
+      ? { ok: true, action: "cloned" }
+      : { ok: false, action: "skipped", error: cloneResult.error };
+  }
+
+  const meta = await readMeta();
+  const lastPull = meta?.lastPullAt ? Date.parse(meta.lastPullAt) : 0;
+  const age = Date.now() - (Number.isFinite(lastPull) ? lastPull : 0);
+  if (!force && age < refreshMs) {
+    return { ok: true, action: "fresh" };
+  }
+
+  if (!(await isGitAvailable())) {
+    logger?.warn?.("addyosmani-catalog: git unavailable — using stale cache");
+    return { ok: true, action: "skipped" };
+  }
+
+  const result = await runCommand(
+    "git",
+    ["-C", root, "pull", "--ff-only", "--depth", "1"],
+    { timeout: 60_000 }
+  );
+
+  if (result.exitCode !== 0) {
+    const stderr = (result.stderr || "").trim();
+    logger?.warn?.(`addyosmani-catalog: git pull failed — ${stderr} (keeping stale cache)`);
+    return { ok: false, action: "skipped", error: stderr };
+  }
+
+  await writeMeta({
+    ...(meta || {}),
+    repoUrl,
+    lastPullAt: new Date().toISOString(),
+  });
+
+  return { ok: true, action: "pulled" };
+}
+
+/**
+ * Parse YAML frontmatter for name + description (we intentionally avoid a
+ * YAML dep — a tiny regex is enough for the fields we care about and stays
+ * compatible with addyosmani's SKILL.md format).
+ *
+ * @param {string} raw
+ * @returns {{name: string|null, description: string|null, body: string}}
+ */
+export function parseFrontmatter(raw) {
+  if (!raw) return { name: null, description: null, body: "" };
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) {
+    return { name: null, description: null, body: raw };
+  }
+  const frontmatter = match[1];
+  const body = match[2] || "";
+
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+  return {
+    name: nameMatch ? stripQuotes(nameMatch[1]) : null,
+    description: descMatch ? stripQuotes(descMatch[1]) : null,
+    body,
+  };
+}
+
+function stripQuotes(value) {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"'))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * Enumerate available skill slugs under /skills/.
+ *
+ * @returns {Promise<string[]>}
+ */
+export async function listAvailableSlugs() {
+  const root = getSkillsRoot();
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => !name.startsWith("."))
+    .sort();
+}
+
+/**
+ * Load a skill by its slug. Returns null when the slug is not present or the
+ * SKILL.md file is missing/unreadable.
+ *
+ * @param {string} slug
+ * @returns {Promise<{slug: string, name: string, description: string|null, content: string, path: string}|null>}
+ */
+export async function loadSkillBySlug(slug) {
+  if (!slug || typeof slug !== "string") return null;
+  const safeSlug = slug.trim().replace(/[^A-Za-z0-9._-]/g, "");
+  if (!safeSlug) return null;
+
+  const skillPath = path.join(getSkillsRoot(), safeSlug, SKILL_FILE);
+  let raw;
+  try {
+    raw = await fs.readFile(skillPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const parsed = parseFrontmatter(raw);
+  return {
+    slug: safeSlug,
+    name: parsed.name || safeSlug,
+    description: parsed.description,
+    content: raw,
+    path: skillPath,
+  };
+}
+
+/**
+ * Load multiple skills by slug in parallel. Silently drops missing entries.
+ *
+ * @param {string[]} slugs
+ * @returns {Promise<Array<{slug: string, name: string, description: string|null, content: string, path: string}>>}
+ */
+export async function loadSkillsBySlugs(slugs = []) {
+  if (!Array.isArray(slugs) || slugs.length === 0) return [];
+  const results = await Promise.all(slugs.map((s) => loadSkillBySlug(s)));
+  return results.filter(Boolean);
+}
+
+export { DEFAULT_REFRESH_MS, REPO_URL };

--- a/src/skills/addyosmani-role-map.js
+++ b/src/skills/addyosmani-role-map.js
@@ -1,0 +1,133 @@
+/**
+ * Role → addyosmani/agent-skills slug mapping (KJC-TSK-0327).
+ *
+ * The addyosmani catalog is process-oriented (not stack-oriented), so the
+ * natural keying is by Karajan role: reviewer wants code-review workflows,
+ * tester wants TDD, security wants hardening, etc.
+ *
+ * Task-text triggers complement the role map: e.g. a task that mentions
+ * "performance" or "Core Web Vitals" pulls in performance-optimization,
+ * regardless of which role is running.
+ *
+ * Every slug listed here MUST exist in the upstream repo at:
+ *   https://github.com/addyosmani/agent-skills/tree/main/skills/<slug>
+ * If upstream renames or removes a slug, loadSkillBySlug() degrades silently
+ * (returns null) and the pipeline continues without blocking.
+ */
+
+/**
+ * Role → array of upstream slugs.
+ * Keep slugs lowercase-hyphenated, matching addyosmani's directory names.
+ */
+export const ROLE_TO_ADDYOSMANI_SLUGS = {
+  // The coder role benefits from broad process context: how to iterate,
+  // how to engineer context, and how to debug when things break.
+  coder: [
+    "incremental-implementation",
+    "source-driven-development",
+    "context-engineering",
+    "debugging-and-error-recovery",
+  ],
+
+  // Reviewer wants the review + simplification workflows.
+  reviewer: [
+    "code-review-and-quality",
+    "code-simplification",
+  ],
+
+  // Tester focuses on TDD and browser verification.
+  tester: [
+    "test-driven-development",
+    "browser-testing-with-devtools",
+  ],
+
+  // Security role uses the dedicated hardening workflow.
+  security: [
+    "security-and-hardening",
+  ],
+
+  // Architect covers spec-driven, API design and planning skills.
+  architect: [
+    "spec-driven-development",
+    "api-and-interface-design",
+    "planning-and-task-breakdown",
+  ],
+
+  // Planner overlaps with architect but leans on task breakdown and spec.
+  planner: [
+    "planning-and-task-breakdown",
+    "spec-driven-development",
+  ],
+
+  // Researcher / discover benefit from the idea-refine workflow.
+  researcher: [
+    "idea-refine",
+  ],
+  discover: [
+    "idea-refine",
+  ],
+
+  // Impeccable (UI/UX audit) uses the frontend engineering workflow.
+  impeccable: [
+    "frontend-ui-engineering",
+  ],
+
+  // Refactorer uses simplification and debugging workflows.
+  refactorer: [
+    "code-simplification",
+    "debugging-and-error-recovery",
+  ],
+};
+
+/**
+ * Task-text patterns → addyosmani slug. These are applied in addition to the
+ * role map, so a reviewer task that mentions "performance" also pulls in the
+ * performance-optimization skill.
+ */
+export const TASK_PATTERN_TO_SLUG = [
+  { pattern: /\bperformance\b|\bcore\s+web\s+vitals\b|\blcp\b|\bcls\b|\binp\b/i, slug: "performance-optimization" },
+  { pattern: /\bsecurity\b|\bhardening\b|\bauth(entication|orization)?\b|\bxss\b|\bcsrf\b|\binjection\b/i, slug: "security-and-hardening" },
+  { pattern: /\btdd\b|\btest[- ]driven\b/i, slug: "test-driven-development" },
+  { pattern: /\bfrontend\b|\bui\b|\bux\b|\bcss\b|\bresponsive\b/i, slug: "frontend-ui-engineering" },
+  { pattern: /\bapi\b|\bendpoint\b|\binterface\s+design\b|\bopenapi\b|\brest\b|\bgraphql\b/i, slug: "api-and-interface-design" },
+  { pattern: /\bci\b|\bcd\b|\bci\/cd\b|\bpipeline\b|\bgithub\s+actions\b|\bworkflow\b/i, slug: "ci-cd-and-automation" },
+  { pattern: /\bgit\b|\bcommit\b|\bbranch\b|\bmerge\b|\bversioning\b|\bsemver\b/i, slug: "git-workflow-and-versioning" },
+  { pattern: /\bdebug\b|\berror\s+recovery\b|\bstack\s+trace\b/i, slug: "debugging-and-error-recovery" },
+  { pattern: /\bdeprecat|\bmigrat/i, slug: "deprecation-and-migration" },
+  { pattern: /\bdocs?\b|\badr\b|\breadme\b|\bdocumentation\b/i, slug: "documentation-and-adrs" },
+  { pattern: /\brelease\b|\blaunch\b|\bship\b/i, slug: "shipping-and-launch" },
+  { pattern: /\bspec\b|\bspecification\b|\bprd\b/i, slug: "spec-driven-development" },
+  { pattern: /\bidea\b|\brefine\b|\bdiscover/i, slug: "idea-refine" },
+  { pattern: /\bbrowser\s+test|\bdevtools\b|\bchrome\s+devtools\b/i, slug: "browser-testing-with-devtools" },
+];
+
+/**
+ * Resolve the set of addyosmani slugs that apply to a given (role, task)
+ * tuple. Returns a deduped array preserving role-first ordering (so role
+ * skills appear before task-inferred ones in the prompt).
+ *
+ * @param {{role?: string|null, task?: string|null}} args
+ * @returns {string[]}
+ */
+export function resolveAddyosmaniSlugs({ role = null, task = null } = {}) {
+  const out = [];
+  const seen = new Set();
+
+  const push = (slug) => {
+    if (!slug || seen.has(slug)) return;
+    seen.add(slug);
+    out.push(slug);
+  };
+
+  if (role && ROLE_TO_ADDYOSMANI_SLUGS[role]) {
+    for (const slug of ROLE_TO_ADDYOSMANI_SLUGS[role]) push(slug);
+  }
+
+  if (task && typeof task === "string") {
+    for (const { pattern, slug } of TASK_PATTERN_TO_SLUG) {
+      if (pattern.test(task)) push(slug);
+    }
+  }
+
+  return out;
+}

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -36,3 +36,11 @@ globalThis.__KJ_DEFAULT_SKILLS_MODE = "regex";
 // override those flags per its decision logic. Tests that exercise Brain
 // routing opt in via `config.brain.decisor.enabled = true` explicitly.
 globalThis.__KJ_DEFAULT_BRAIN_DECISOR = false;
+
+// Default the addyosmani/agent-skills catalog OFF under Vitest. Many
+// orchestrator tests assert exact event/command sequences; the catalog step
+// would add a git probe + skills:addyosmani-ready event that they don't
+// expect. Tests that exercise the catalog opt in via
+// `config.skills.addyosmani.enabled = true` explicitly (or rely on the direct
+// unit tests in tests/skills/addyosmani-*.test.js which mock git themselves).
+globalThis.__KJ_DEFAULT_ADDYOSMANI_ENABLED = false;

--- a/tests/skills/addyosmani-catalog.test.js
+++ b/tests/skills/addyosmani-catalog.test.js
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+let originalKarajanHome;
+
+vi.mock("../../src/utils/paths.js", () => ({
+  getKarajanHome: vi.fn(() => originalKarajanHome),
+  getSessionRoot: vi.fn(() => path.join(originalKarajanHome, "sessions")),
+}));
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
+
+describe("skills/addyosmani-catalog", () => {
+  let tmpHome;
+  let mod;
+  let runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-addyo-test-"));
+    originalKarajanHome = tmpHome;
+    const paths = await import("../../src/utils/paths.js");
+    paths.getKarajanHome.mockReturnValue(tmpHome);
+    ({ runCommand } = await import("../../src/utils/process.js"));
+    mod = await import("../../src/skills/addyosmani-catalog.js");
+    mod.__resetGitProbe();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpHome, { recursive: true, force: true }).catch(() => {});
+  });
+
+  describe("parseFrontmatter", () => {
+    it("extracts name and description from YAML frontmatter", () => {
+      const raw = [
+        "---",
+        "name: test-driven-development",
+        "description: Drives development with tests. Use when implementing logic.",
+        "---",
+        "",
+        "# Test-Driven Development",
+        "body content here",
+      ].join("\n");
+
+      const parsed = mod.parseFrontmatter(raw);
+      expect(parsed.name).toBe("test-driven-development");
+      expect(parsed.description).toContain("Drives development with tests");
+      expect(parsed.body).toContain("# Test-Driven Development");
+    });
+
+    it("strips surrounding quotes from values", () => {
+      const raw = '---\nname: "quoted-name"\ndescription: \'single-quoted\'\n---\nbody';
+      const parsed = mod.parseFrontmatter(raw);
+      expect(parsed.name).toBe("quoted-name");
+      expect(parsed.description).toBe("single-quoted");
+    });
+
+    it("returns nulls and full body when no frontmatter present", () => {
+      const raw = "# Just a heading\nNo frontmatter here.";
+      const parsed = mod.parseFrontmatter(raw);
+      expect(parsed.name).toBeNull();
+      expect(parsed.description).toBeNull();
+      expect(parsed.body).toBe(raw);
+    });
+
+    it("returns all-null on empty input", () => {
+      const parsed = mod.parseFrontmatter("");
+      expect(parsed.name).toBeNull();
+      expect(parsed.description).toBeNull();
+      expect(parsed.body).toBe("");
+    });
+  });
+
+  describe("isGitAvailable", () => {
+    it("returns true when git --version exits 0", async () => {
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version 2.40.0", stderr: "" });
+      expect(await mod.isGitAvailable()).toBe(true);
+    });
+
+    it("returns false when git --version fails", async () => {
+      runCommand.mockRejectedValueOnce(new Error("command not found"));
+      expect(await mod.isGitAvailable()).toBe(false);
+    });
+
+    it("caches the result across calls", async () => {
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version 2.40", stderr: "" });
+      await mod.isGitAvailable();
+      await mod.isGitAvailable();
+      expect(runCommand).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("listAvailableSlugs", () => {
+    it("returns [] when catalog directory does not exist", async () => {
+      expect(await mod.listAvailableSlugs()).toEqual([]);
+    });
+
+    it("lists subdirectories of /skills/ sorted alphabetically", async () => {
+      const skillsRoot = path.join(mod.getCatalogRoot(), "skills");
+      await fs.mkdir(path.join(skillsRoot, "test-driven-development"), { recursive: true });
+      await fs.mkdir(path.join(skillsRoot, "code-review-and-quality"), { recursive: true });
+      await fs.mkdir(path.join(skillsRoot, "security-and-hardening"), { recursive: true });
+      // hidden dir must be excluded
+      await fs.mkdir(path.join(skillsRoot, ".git"), { recursive: true });
+
+      const slugs = await mod.listAvailableSlugs();
+      expect(slugs).toEqual([
+        "code-review-and-quality",
+        "security-and-hardening",
+        "test-driven-development",
+      ]);
+    });
+  });
+
+  describe("loadSkillBySlug", () => {
+    it("returns null for missing slug", async () => {
+      expect(await mod.loadSkillBySlug("nonexistent")).toBeNull();
+    });
+
+    it("returns null for invalid slug input", async () => {
+      expect(await mod.loadSkillBySlug("")).toBeNull();
+      expect(await mod.loadSkillBySlug(null)).toBeNull();
+      expect(await mod.loadSkillBySlug(undefined)).toBeNull();
+    });
+
+    it("loads SKILL.md and parses frontmatter", async () => {
+      const slug = "test-driven-development";
+      const dir = path.join(mod.getCatalogRoot(), "skills", slug);
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "SKILL.md"),
+        "---\nname: test-driven-development\ndescription: Drives dev with tests\n---\n# Body"
+      );
+
+      const skill = await mod.loadSkillBySlug(slug);
+      expect(skill).not.toBeNull();
+      expect(skill.slug).toBe(slug);
+      expect(skill.name).toBe("test-driven-development");
+      expect(skill.description).toBe("Drives dev with tests");
+      expect(skill.content).toContain("# Body");
+    });
+
+    it("rejects path traversal in slug", async () => {
+      expect(await mod.loadSkillBySlug("../../etc/passwd")).toBeNull();
+    });
+  });
+
+  describe("ensureCatalog", () => {
+    it("is a no-op when .git exists already", async () => {
+      await fs.mkdir(path.join(mod.getCatalogRoot(), ".git"), { recursive: true });
+      const result = await mod.ensureCatalog();
+      expect(result.ok).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns ok: false when git is not available", async () => {
+      runCommand.mockRejectedValueOnce(new Error("not found"));
+      const result = await mod.ensureCatalog();
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/git not available/i);
+    });
+
+    it("runs git clone when catalog does not exist and writes meta.json", async () => {
+      // 1st call: git --version → ok ; 2nd call: git clone → ok
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+      const result = await mod.ensureCatalog();
+      expect(result.ok).toBe(true);
+      expect(runCommand).toHaveBeenCalledTimes(2);
+      expect(runCommand).toHaveBeenLastCalledWith(
+        "git",
+        expect.arrayContaining(["clone", "--depth", "1"]),
+        expect.objectContaining({ timeout: expect.any(Number) })
+      );
+
+      const metaPath = path.join(mod.getCatalogRoot(), ".karajan-catalog-meta.json");
+      const meta = JSON.parse(await fs.readFile(metaPath, "utf8"));
+      expect(meta.repoUrl).toBeTruthy();
+      expect(typeof meta.clonedAt).toBe("string");
+      expect(typeof meta.lastPullAt).toBe("string");
+    });
+
+    it("surfaces clone failures without throwing", async () => {
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 128, stdout: "", stderr: "fatal: network down" });
+
+      const result = await mod.ensureCatalog();
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("network down");
+    });
+  });
+
+  describe("refreshIfStale", () => {
+    async function seedCatalog({ lastPullAgoMs = 0 } = {}) {
+      await fs.mkdir(path.join(mod.getCatalogRoot(), ".git"), { recursive: true });
+      const meta = {
+        repoUrl: "https://github.com/addyosmani/agent-skills.git",
+        clonedAt: new Date(Date.now() - lastPullAgoMs).toISOString(),
+        lastPullAt: new Date(Date.now() - lastPullAgoMs).toISOString(),
+      };
+      await fs.writeFile(
+        path.join(mod.getCatalogRoot(), ".karajan-catalog-meta.json"),
+        JSON.stringify(meta)
+      );
+    }
+
+    it("returns 'fresh' when cache is within TTL", async () => {
+      await seedCatalog({ lastPullAgoMs: 60 * 1000 }); // 1 min ago
+      const result = await mod.refreshIfStale({ refreshMs: 7 * 24 * 60 * 60 * 1000 });
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe("fresh");
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("pulls when cache is older than TTL", async () => {
+      await seedCatalog({ lastPullAgoMs: 8 * 24 * 60 * 60 * 1000 });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+      const result = await mod.refreshIfStale({ refreshMs: 7 * 24 * 60 * 60 * 1000 });
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe("pulled");
+    });
+
+    it("force:true bypasses TTL check and always pulls", async () => {
+      await seedCatalog({ lastPullAgoMs: 60 * 1000 });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+      const result = await mod.refreshIfStale({ force: true });
+      expect(result.action).toBe("pulled");
+    });
+
+    it("degrades to 'skipped' without error when git pull fails", async () => {
+      await seedCatalog({ lastPullAgoMs: 8 * 24 * 60 * 60 * 1000 });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "conflict" });
+
+      const result = await mod.refreshIfStale({ refreshMs: 0 });
+      expect(result.ok).toBe(false);
+      expect(result.action).toBe("skipped");
+    });
+
+    it("delegates to ensureCatalog when catalog is absent", async () => {
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+      const result = await mod.refreshIfStale();
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe("cloned");
+    });
+  });
+});

--- a/tests/skills/addyosmani-role-map.test.js
+++ b/tests/skills/addyosmani-role-map.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAddyosmaniSlugs,
+  ROLE_TO_ADDYOSMANI_SLUGS,
+  TASK_PATTERN_TO_SLUG,
+} from "../../src/skills/addyosmani-role-map.js";
+
+describe("skills/addyosmani-role-map", () => {
+  describe("resolveAddyosmaniSlugs", () => {
+    it("returns [] when no role and no task is given", () => {
+      expect(resolveAddyosmaniSlugs({})).toEqual([]);
+    });
+
+    it("maps tester role to TDD + browser testing slugs", () => {
+      const slugs = resolveAddyosmaniSlugs({ role: "tester" });
+      expect(slugs).toContain("test-driven-development");
+      expect(slugs).toContain("browser-testing-with-devtools");
+    });
+
+    it("maps reviewer role to review + simplification slugs", () => {
+      const slugs = resolveAddyosmaniSlugs({ role: "reviewer" });
+      expect(slugs).toContain("code-review-and-quality");
+      expect(slugs).toContain("code-simplification");
+    });
+
+    it("maps security role to hardening slug", () => {
+      expect(resolveAddyosmaniSlugs({ role: "security" })).toContain("security-and-hardening");
+    });
+
+    it("maps architect role to spec/API/planning slugs", () => {
+      const slugs = resolveAddyosmaniSlugs({ role: "architect" });
+      expect(slugs).toContain("spec-driven-development");
+      expect(slugs).toContain("api-and-interface-design");
+      expect(slugs).toContain("planning-and-task-breakdown");
+    });
+
+    it("returns [] for unknown role with no task", () => {
+      expect(resolveAddyosmaniSlugs({ role: "unknown-role" })).toEqual([]);
+    });
+
+    it("infers performance-optimization from task text", () => {
+      const slugs = resolveAddyosmaniSlugs({ task: "Improve Core Web Vitals and LCP on landing" });
+      expect(slugs).toContain("performance-optimization");
+    });
+
+    it("infers security-and-hardening from task keywords", () => {
+      const slugs = resolveAddyosmaniSlugs({ task: "Fix XSS in user form" });
+      expect(slugs).toContain("security-and-hardening");
+    });
+
+    it("combines role slugs first, then task slugs (role-first ordering)", () => {
+      const slugs = resolveAddyosmaniSlugs({
+        role: "reviewer",
+        task: "Optimize performance of API endpoints",
+      });
+      expect(slugs[0]).toBe("code-review-and-quality");
+      expect(slugs[1]).toBe("code-simplification");
+      expect(slugs).toContain("performance-optimization");
+      expect(slugs).toContain("api-and-interface-design");
+    });
+
+    it("dedupes when role and task suggest the same slug", () => {
+      const slugs = resolveAddyosmaniSlugs({
+        role: "tester",
+        task: "Use TDD to add coverage",
+      });
+      const tddHits = slugs.filter((s) => s === "test-driven-development");
+      expect(tddHits).toHaveLength(1);
+    });
+
+    it("ignores non-string task input", () => {
+      const slugs = resolveAddyosmaniSlugs({ role: "tester", task: 42 });
+      expect(slugs).toEqual(["test-driven-development", "browser-testing-with-devtools"]);
+    });
+  });
+
+  describe("role catalog integrity", () => {
+    it("every known Karajan role has at least one addyosmani slug mapped", () => {
+      const roles = ["coder", "reviewer", "tester", "security", "architect", "planner", "impeccable", "refactorer"];
+      for (const role of roles) {
+        expect(ROLE_TO_ADDYOSMANI_SLUGS[role], `role ${role}`).toBeDefined();
+        expect(ROLE_TO_ADDYOSMANI_SLUGS[role].length).toBeGreaterThan(0);
+      }
+    });
+
+    it("slugs are lowercase-hyphenated (marketplace convention)", () => {
+      const allSlugs = new Set();
+      for (const list of Object.values(ROLE_TO_ADDYOSMANI_SLUGS)) {
+        for (const s of list) allSlugs.add(s);
+      }
+      for (const { slug } of TASK_PATTERN_TO_SLUG) allSlugs.add(slug);
+
+      for (const slug of allSlugs) {
+        expect(slug, `slug "${slug}"`).toMatch(/^[a-z][a-z0-9-]*$/);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Integrates **addyosmani/agent-skills** as a first-class skill source that runs **before** OpenSkills.
- Providers are orthogonal: addyosmani = lifecycle/process per role; OpenSkills = stack/framework; local = project-specific.
- Shallow-clone to `~/.karajan/agent-skills/`, weekly `git pull` refresh, silent degradation when git is missing.
- Role→slug map (tester→TDD, reviewer→code-review, security→hardening, architect→spec/API, etc.) + task-text triggers.
- New config (`skills.sources`, `skills.addyosmani.*`) and CLI (`kj skills sync-addyosmani`, `kj skills list-addyosmani`).

## Key files
- `src/skills/addyosmani-catalog.js` — provider (clone/pull/load/parse frontmatter, graceful degradation)
- `src/skills/addyosmani-role-map.js` — role→slug mapping + task-text inference
- `src/orchestrator/flow-runner.js` — `ensureAddyosmaniSkills()` step runs before OpenSkills auto-install
- `src/config.js` + `src/config/schema.js` — defaults + Valibot schema for new `skills.*` subtree
- `src/commands/skills.js` + `src/cli.js` — two new subcommands

## Tests
- 35 new cases across `tests/skills/addyosmani-catalog.test.js` + `tests/skills/addyosmani-role-map.test.js`.
- `tests/setup.js` default-disables the catalog under Vitest so orchestrator event-sequence tests don't regress.
- Full suite: **3672/3672 tests pass across 285 files.** Lint clean.

## Test plan
- [ ] `kj skills sync-addyosmani` clones the repo on a fresh machine
- [ ] `kj skills list-addyosmani` shows all 21 slugs with descriptions
- [ ] Running `kj run "add TDD coverage for module X"` includes `test-driven-development` slug in the tester prompt before OpenSkills vitest-patterns
- [ ] Setting `skills.addyosmani.enabled: false` in `kj.config.yml` reverts to pre-existing behavior
- [ ] Uninstalling git still lets the pipeline complete (warn emitted, no block)

Refs: KJC-TSK-0327