### PR TITLE
feat(skills): surface skill-source decisions in summary.md + kj-tail

### DIFF
--- a/bin/kj-tail
+++ b/bin/kj-tail
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-VERSION="1.36.0"
+VERSION="1.37.0"
 
 # ── Colors ──────────────────────────────────────────────
 RED='\033[0;31m'
@@ -245,6 +245,17 @@ filter_line() {
   # Preflight
   if [[ "$clean" == *"[preflight"* ]] || [[ "$clean" == *"Preflight"* ]]; then
     echo -e "${prefix}${GRAY}  ├─ ⚙️  ${clean}${RESET}"
+    return
+  fi
+
+  # Skills (addyosmani catalog + OpenSkills marketplace)
+  if [[ "$clean" == *"[skills:"* ]] || [[ "$clean" == *"[skills]"* ]]; then
+    # Highlight failures/unavailability in yellow, successes in magenta
+    if [[ "$clean" == *"unavailable"* ]] || [[ "$clean" == *"would have used"* ]]; then
+      echo -e "${prefix}${YELLOW}  ├─ 🎯 ${clean}${RESET}"
+    else
+      echo -e "${prefix}${MAGENTA}  ├─ 🎯 ${clean}${RESET}"
+    fi
     return
   fi
 

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -452,6 +452,14 @@ async function finalizeApprovedSession({ config, gitCtx, task, logger, session, 
         finishedAt: new Date().toISOString(),
         brainDecisions: Array.isArray(session.brainDecisions) ? session.brainDecisions.length : 0,
         solomonInvocations: Array.isArray(session.solomonRulings) ? session.solomonRulings.length : 0,
+        // KJC-TSK-0327: surface skill-source decisions in the summary so the
+        // post-mortem shows which process skills (addyosmani) and stack skills
+        // (OpenSkills) actually shaped the role prompts.
+        skills: {
+          addyosmani: session.addyosmaniSkills,
+          installed: session.autoInstalledSkills,
+          recommended: session.skillsRecommended,
+        },
       }, { logger });
       logger.info(`Session journal written to ${journalDir}`);
     } catch (err) {

--- a/src/session/journal/summary-writer.js
+++ b/src/session/journal/summary-writer.js
@@ -26,6 +26,10 @@ import path from "node:path";
  * @property {string} [finishedAt]                 - ISO timestamp (optional)
  * @property {number} [solomonInvocations]
  * @property {number} [brainDecisions]
+ * @property {Object} [skills]                        - skill sources used this session (KJC-TSK-0327)
+ * @property {Object} [skills.addyosmani]             - { available, action, resolvedSlugs, reason }
+ * @property {string[]} [skills.installed]            - OpenSkills installed this run (session.autoInstalledSkills)
+ * @property {string[]} [skills.recommended]          - wouldHaveUsed when OpenSkills CLI missing
  */
 
 function esc(text) {
@@ -103,6 +107,48 @@ function renderBreakdownByRole(breakdown) {
   return ["| Role | Tokens | Cost |", "|---|---|---|", ...rows].join("\n");
 }
 
+/**
+ * Render the Skills section: which process skills (addyosmani) were resolved
+ * for the task, which OpenSkills were installed, and which skills would have
+ * helped but couldn't be installed (graceful-degradation path).
+ *
+ * Returns null when no skill activity happened (no addyosmani, no installs,
+ * no recommendations) so the section is elided.
+ */
+function renderSkills(skills) {
+  if (!skills || typeof skills !== "object") return null;
+  const addy = skills.addyosmani;
+  const installed = Array.isArray(skills.installed) ? skills.installed : [];
+  const recommended = Array.isArray(skills.recommended) ? skills.recommended : [];
+
+  const hasAddy = addy && (addy.available === true || addy.available === false);
+  if (!hasAddy && installed.length === 0 && recommended.length === 0) return null;
+
+  const lines = [];
+
+  if (hasAddy) {
+    if (addy.available) {
+      const action = addy.action || "ready";
+      const slugs = Array.isArray(addy.resolvedSlugs) ? addy.resolvedSlugs : [];
+      lines.push(`- **addyosmani/agent-skills** (process, 1st source): ${esc(action)}` +
+        (slugs.length > 0 ? ` — resolved slugs: ${slugs.map((s) => `\`${esc(s)}\``).join(", ")}` : " — no role/task-specific slugs resolved"));
+    } else {
+      const reason = addy.reason ? ` — ${esc(addy.reason)}` : "";
+      lines.push(`- **addyosmani/agent-skills**: unavailable${reason}`);
+    }
+  }
+
+  if (installed.length > 0) {
+    lines.push(`- **OpenSkills installed**: ${installed.map((s) => `\`${esc(s)}\``).join(", ")}`);
+  }
+
+  if (recommended.length > 0) {
+    lines.push(`- **OpenSkills recommended** (CLI missing, would-have-used): ${recommended.map((s) => `\`${esc(s)}\``).join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
 function renderJournalLinks(files) {
   if (!Array.isArray(files) || files.length === 0) return "_No additional journal files._";
   return files.map((f) => `- [${esc(f)}](./${f})`).join("\n");
@@ -144,6 +190,11 @@ export function buildSummaryMarkdown(input) {
   const breakdown = renderBreakdownByRole(input.budget?.breakdown_by_role);
   if (breakdown) {
     sections.push("", "## Budget breakdown (by role)", "", breakdown);
+  }
+
+  const skillsSection = renderSkills(input.skills);
+  if (skillsSection) {
+    sections.push("", "## Skills Used", "", skillsSection);
   }
 
   sections.push("", "## Commits", "", renderCommits(input.commits));

--- a/tests/session/summary-writer.test.js
+++ b/tests/session/summary-writer.test.js
@@ -130,6 +130,79 @@ describe("session/journal/summary-writer — buildSummaryMarkdown", () => {
     expect(md).not.toContain(longSummary);
   });
 
+  describe("Skills section (KJC-TSK-0327)", () => {
+    it("omits the Skills section entirely when no skills activity happened", () => {
+      const md = buildSummaryMarkdown(sample()); // no `skills` field
+      expect(md).not.toContain("## Skills Used");
+    });
+
+    it("renders addyosmani resolved slugs when catalog is available", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          addyosmani: {
+            available: true,
+            action: "pulled",
+            resolvedSlugs: ["test-driven-development", "code-review-and-quality"],
+          },
+        },
+      }));
+      expect(md).toContain("## Skills Used");
+      expect(md).toContain("**addyosmani/agent-skills** (process, 1st source): pulled");
+      expect(md).toContain("`test-driven-development`");
+      expect(md).toContain("`code-review-and-quality`");
+    });
+
+    it("reports addyosmani as unavailable with the reason when git/network failed", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          addyosmani: { available: false, reason: "git not available" },
+        },
+      }));
+      expect(md).toContain("**addyosmani/agent-skills**: unavailable — git not available");
+    });
+
+    it("lists OpenSkills that were actually installed this run", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          installed: ["vitest-patterns", "owasp-top-10"],
+        },
+      }));
+      expect(md).toContain("## Skills Used");
+      expect(md).toContain("**OpenSkills installed**: `vitest-patterns`, `owasp-top-10`");
+    });
+
+    it("lists recommended OpenSkills when the CLI was missing (would-have-used)", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          recommended: ["astro", "react"],
+        },
+      }));
+      expect(md).toContain("**OpenSkills recommended** (CLI missing, would-have-used): `astro`, `react`");
+    });
+
+    it("combines all three sources when present together", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          addyosmani: { available: true, action: "fresh", resolvedSlugs: ["security-and-hardening"] },
+          installed: ["prisma"],
+          recommended: ["nextjs"],
+        },
+      }));
+      expect(md).toContain("addyosmani/agent-skills");
+      expect(md).toContain("OpenSkills installed");
+      expect(md).toContain("OpenSkills recommended");
+    });
+
+    it("handles addyosmani with empty resolvedSlugs (no role/task-specific match)", () => {
+      const md = buildSummaryMarkdown(sample({
+        skills: {
+          addyosmani: { available: true, action: "fresh", resolvedSlugs: [] },
+        },
+      }));
+      expect(md).toContain("no role/task-specific slugs resolved");
+    });
+  });
+
   it("escapes pipe chars in commit messages + task text (table safety)", () => {
     const md = buildSummaryMarkdown(sample({
       task: "a|b|c",


### PR DESCRIPTION
## Why

Today, when Karajan runs, you cannot easily see which skills shaped the role prompts. Events `skills:addyosmani-ready` / `skills:auto-install` land in `.kj/run.log` but without styling in `kj-tail`, and the persistent `summary.md` never mentions skills at all. The user asking "¿muestra los skills que decide usar?" exposed the gap.

## What

### 1. `summary.md` → new "Skills Used" section

```markdown
## Skills Used

- **addyosmani/agent-skills** (process, 1st source): pulled — resolved slugs: `test-driven-development`, `code-review-and-quality`
- **OpenSkills installed**: `vitest-patterns`, `owasp-top-10`
- **OpenSkills recommended** (CLI missing, would-have-used): `astro`
```

Elided when no skill activity happens (e.g. `skills.mode: none`). Shown even for partial-failure paths — if git is missing, the summary reports `addyosmani/agent-skills: unavailable — git not available` so the post-mortem is honest about what didn't happen.

Data path: `flow-runner.js` now passes `{ addyosmani, installed, recommended }` from `session.*` into `writeSummaryJournalV2`. Zero runtime cost; the fields already existed on `session`.

### 2. `kj-tail` v1.37.0 → 🎯 skills filter

- Magenta 🎯 for `ready` / `auto-install` (success path)
- Yellow 🎯 for `unavailable` / `would have used` (graceful degradation)

Smoke-tested with a crafted `.kj/run.log`:

```
├─ 🎯 [skills:addyosmani-ready] [skills] addyosmani/agent-skills cloned — 21 slug(s) available, 3 relevant to task
├─ 🎯 [skills:auto-install] [skills] Auto-installed 2 skill(s): vitest-patterns, owasp-top-10
├─ 🎯 [skills:addyosmani-unavailable] [skills] addyosmani/agent-skills catalog unavailable: git not available
```

## Tests

- **7 new vitest cases** in `tests/session/summary-writer.test.js` covering: section elision when empty, addyosmani available + action + slugs, addyosmani unavailable + reason, installed OpenSkills, recommended OpenSkills, combined sources, empty resolvedSlugs edge case.
- Full suite: **3 679 tests across 285 files passing.** Lint clean.

## Test plan
- [ ] Kick off a real `kj run` with tester+reviewer enabled, confirm `summary.md` shows the addyosmani slugs that were resolved for each role's prompt.
- [ ] Run `kj-tail -v` in parallel and confirm 🎯 lines appear with the right color.

Refs: KJC-TSK-0327 (addyosmani integration) — visibility follow-up