### PR TITLE
feat(cli+mcp): --task-file / taskFile + kj-tail waits for log

### DIFF
--- a/bin/kj-tail
+++ b/bin/kj-tail
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-VERSION="1.37.0"
+VERSION="1.38.0"
 
 # ── Colors ──────────────────────────────────────────────
 RED='\033[0;31m'
@@ -94,15 +94,42 @@ PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
 LOG_FILE="${PROJECT_DIR}/.kj/run.log"
 
 # ── Locate log ──────────────────────────────────────────
+# When the log does not exist yet, kj-tail stays open and polls until any
+# `kj` / `kj_*` invocation creates it. Exit with Ctrl-C. This used to be a
+# hard exit, which forced the user to time `kj-tail` start vs. the command;
+# too easy to miss early lines. Follow-mode and snapshot mode both get this.
 if [[ ! -f "$LOG_FILE" ]]; then
-  echo -e "${RED}No run log found at ${LOG_FILE}${RESET}"
+  if [[ "$FOLLOW" == "false" ]]; then
+    # Snapshot mode (-s): nothing to print, say so and exit cleanly.
+    echo -e "${YELLOW}No run log at ${LOG_FILE} yet.${RESET}"
+    echo ""
+    echo "The log is created when Karajan starts a pipeline — run any of:"
+    echo "  kj run \"...\"    kj audit    kj code    kj review    kj plan"
+    echo "  mcp__karajan-mcp__kj_run / kj_audit / kj_code / kj_review / kj_plan ..."
+    echo ""
+    exit 0
+  fi
+
+  echo -e "${YELLOW}Waiting for run log to appear at ${LOG_FILE}${RESET}"
+  echo -e "${DIM}(It is created the moment you run any kj command that invokes the orchestrator or a role.${RESET}"
+  echo -e "${DIM} Ctrl-C to stop waiting. Triggers: kj run/audit/code/review/plan/discover/triage/researcher/architect, or the same via MCP.)${RESET}"
   echo ""
-  echo "The run log is created when Karajan starts a pipeline."
-  echo "Make sure you're in the project directory, or pass it as argument:"
+  # Ensure parent dir exists so we can poll even on a fresh project
+  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+  # Poll every 500ms until the file shows up (low CPU, visible responsiveness).
+  # Cap at 4h (28800 ticks) to avoid infinite stuck monitors; after the cap we
+  # exit 0 so tmux/screen panes don't linger as errors.
+  tick=0
+  while [[ ! -f "$LOG_FILE" ]]; do
+    sleep 0.5
+    tick=$((tick + 1))
+    if (( tick >= 28800 )); then
+      echo -e "${YELLOW}Still no run log after 4h — exiting. Re-run kj-tail when ready.${RESET}"
+      exit 0
+    fi
+  done
+  echo -e "${GREEN}Log appeared — streaming...${RESET}"
   echo ""
-  echo "  kj-tail /path/to/project"
-  echo ""
-  exit 1
 fi
 
 # ── Filter & colorize ──────────────────────────────────

--- a/src/cli.js
+++ b/src/cli.js
@@ -76,7 +76,8 @@ program
 program
   .command("run")
   .description("Run coder+sonar+reviewer loop")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file to read from a .md file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md). Alternative to the positional task argument.")
   .option("--planner <name>")
   .option("--coder <name>")
   .option("--reviewer <name>")
@@ -138,32 +139,40 @@ program
   .option("-v, --verbose", "Show full agent output (stream-json, raw lines)")
   .action(async (task, flags) => {
     await withConfig("run", flags, async ({ config, logger }) => {
-      await runCommandHandler({ task, config, logger, flags });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await runCommandHandler({ task: resolvedTask, config, logger, flags });
     });
   });
 
 program
   .command("code")
   .description("Run only coder")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--coder <name>")
   .option("--coder-model <name>")
   .action(async (task, flags) => {
     await withConfig("code", flags, async ({ config, logger }) => {
-      await codeCommand({ task, config, logger });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await codeCommand({ task: resolvedTask, config, logger });
     });
   });
 
 program
   .command("review")
   .description("Run only reviewer")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--reviewer <name>")
   .option("--reviewer-model <name>")
   .option("--base-ref <ref>")
   .action(async (task, flags) => {
     await withConfig("review", flags, async ({ config, logger }) => {
-      await reviewCommand({ task, config, logger, baseRef: flags.baseRef });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await reviewCommand({ task: resolvedTask, config, logger, baseRef: flags.baseRef });
     });
   });
 
@@ -248,15 +257,18 @@ const plan = program.command("plan").description("Plan management (generate, rev
 plan
   .command("generate", { isDefault: true })
   .description("Generate implementation plan with HUs")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--planner <name>")
   .option("--planner-model <name>")
   .option("--context <text>", "Additional context for the planner")
   .option("--json", "Output raw JSON plan")
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
       const { planGenerateCommand } = await import("./commands/plan.js");
-      await planGenerateCommand({ task, config, logger, json: flags.json, context: flags.context });
+      await planGenerateCommand({ task: resolvedTask, config, logger, json: flags.json, context: flags.context });
     });
   });
 
@@ -317,65 +329,83 @@ plan.command("remove-hu").description("Remove HU from plan").argument("<planId>"
 program
   .command("discover")
   .description("Analyze task for gaps, ambiguities and missing info")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--mode <name>", "Discovery mode: gaps|momtest|wendel|classify|jtbd", "gaps")
   .option("--discover <name>", "Override discover agent")
   .option("--discover-model <name>", "Override discover model")
   .option("--json", "Output raw JSON")
   .action(async (task, flags) => {
     await withConfig("discover", flags, async ({ config, logger }) => {
-      await discoverCommand({ task, config, logger, mode: flags.mode, json: flags.json });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await discoverCommand({ task: resolvedTask, config, logger, mode: flags.mode, json: flags.json });
     });
   });
 
 program
   .command("triage")
   .description("Classify task complexity and recommend pipeline roles")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--triage <name>", "Override triage agent")
   .option("--triage-model <name>", "Override triage model")
   .option("--json", "Output raw JSON")
   .action(async (task, flags) => {
     await withConfig("triage", flags, async ({ config, logger }) => {
-      await triageCommand({ task, config, logger, json: flags.json });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await triageCommand({ task: resolvedTask, config, logger, json: flags.json });
     });
   });
 
 program
   .command("researcher")
   .description("Research codebase for a task (files, patterns, constraints)")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--researcher <name>", "Override researcher agent")
   .option("--researcher-model <name>", "Override researcher model")
   .action(async (task, flags) => {
     await withConfig("researcher", flags, async ({ config, logger }) => {
-      await researcherCommand({ task, config, logger });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await researcherCommand({ task: resolvedTask, config, logger });
     });
   });
 
 program
   .command("architect")
   .description("Design solution architecture (layers, patterns, contracts)")
-  .argument("<task>")
+  .argument("[task]", "Task description (or use --task-file)")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--architect <name>", "Override architect agent")
   .option("--architect-model <name>", "Override architect model")
   .option("--context <text>", "Additional context (e.g. researcher output)")
   .option("--json", "Output raw JSON")
   .action(async (task, flags) => {
     await withConfig("architect", flags, async ({ config, logger }) => {
-      await architectCommand({ task, config, logger, context: flags.context, json: flags.json });
+      const { resolveTaskInput } = await import("./utils/task-file.js");
+      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      await architectCommand({ task: resolvedTask, config, logger, context: flags.context, json: flags.json });
     });
   });
 
 program
   .command("audit")
   .description("Analyze codebase health (read-only)")
-  .argument("[task]")
+  .argument("[task]", "Task description. If absent, defaults to a full-codebase analysis. Use --task-file to point at a .md.")
+  .option("--task-file <path>", "Read the task from a file (e.g. .md)")
   .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing", "all")
   .option("--json", "Output raw JSON")
   .action(async (task, flags) => {
     await withConfig("audit", flags, async ({ config, logger }) => {
-      await auditCommand({ task: task || "Analyze the full codebase", config, logger, dimensions: flags.dimensions, json: flags.json });
+      let resolvedTask = task;
+      if (flags.taskFile) {
+        const { readTaskFile } = await import("./utils/task-file.js");
+        resolvedTask = await readTaskFile(flags.taskFile, { projectDir: config.projectDir });
+      }
+      await auditCommand({ task: resolvedTask || "Analyze the full codebase", config, logger, dimensions: flags.dimensions, json: flags.json });
     });
   });
 

--- a/src/mcp/direct-role-runner.js
+++ b/src/mcp/direct-role-runner.js
@@ -53,6 +53,18 @@ export async function runDirectRole({
   await assertAgentsAvailable([role.provider]);
 
   const projectDir = await resolveProjectDir(server, args.projectDir);
+
+  // Allow taskFile as alternative to inline task — works for every direct
+  // role (discover/triage/researcher/architect/audit/impeccable/...) without
+  // per-handler wiring. The mutation is in-place on the role's runInput /
+  // initContext since they are already built with `task: a.task`.
+  if ((!runInput?.task || runInput.task === undefined) && args.taskFile) {
+    const { readTaskFile } = await import("../utils/task-file.js");
+    const loaded = await readTaskFile(args.taskFile, { projectDir });
+    if (runInput) runInput.task = loaded;
+    if (initContext) initContext.task = loaded;
+    args.task = loaded;
+  }
   const runLog = createRunLog(projectDir);
   const startMsg = logStartMsg || `[kj_${effectiveStage}] started`;
   runLog.logText(startMsg);

--- a/src/mcp/handlers/direct-handlers.js
+++ b/src/mcp/handlers/direct-handlers.js
@@ -56,6 +56,8 @@ export async function handlePlanDirect(a, server, extra) {
   await assertAgentsAvailable([plannerRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
+  const { ensureTaskFromFile } = await import("../shared-helpers.js");
+  await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
     ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
@@ -210,6 +212,8 @@ export async function handleCodeDirect(a, server, extra) {
   await assertAgentsAvailable([coderRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
+  const { ensureTaskFromFile } = await import("../shared-helpers.js");
+  await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_code] started — provider=${coderRole.provider}`);
   const emitter = buildDirectEmitter(server, runLog, extra);
@@ -261,6 +265,8 @@ export async function handleReviewDirect(a, server, extra) {
   await assertAgentsAvailable([reviewerRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
+  const { ensureTaskFromFile } = await import("../shared-helpers.js");
+  await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_review] started — provider=${reviewerRole.provider}`);
   const emitter = buildDirectEmitter(server, runLog, extra);

--- a/src/mcp/handlers/run-handler.js
+++ b/src/mcp/handlers/run-handler.js
@@ -267,8 +267,14 @@ export async function handleResume(a, server, extra) {
 }
 
 export async function handleRun(a, server, extra) {
+  const { ensureTaskFromFile, resolveProjectDir: _rpd } = await import("../shared-helpers.js");
+  try {
+    await ensureTaskFromFile(a, a.projectDir || (await _rpd(server, a.projectDir).catch(() => null)));
+  } catch (err) {
+    return failPayload(`taskFile read failed: ${err.message}`);
+  }
   if (!a.task) {
-    return failPayload("Missing required field: task");
+    return failPayload("Missing required field: task (or pass taskFile with a .md path)");
   }
   if (a.taskType) {
     const validTypes = new Set(["sw", "infra", "doc", "add-tests", "refactor"]);

--- a/src/mcp/shared-helpers.js
+++ b/src/mcp/shared-helpers.js
@@ -21,6 +21,29 @@ export { classifyError } from "./error-classifiers.js";
  * Resolve the user's project directory.
  * Priority: 1) explicit projectDir param, 2) MCP roots, 3) error with instructions.
  */
+/**
+ * Resolve the `task` argument for MCP handlers. If the caller passed
+ * `a.taskFile` (instead of or in addition to `a.task`), read the file and
+ * set `a.task` to its trimmed content. When both are given, the explicit
+ * `a.task` wins (symmetric with CLI `resolveTaskInput`).
+ *
+ * Mutates `a` in place so downstream handlers keep reading `a.task`
+ * without any change. Returns `a` for convenience.
+ *
+ * @param {Object} a
+ * @param {string} [projectDir]  - used to resolve relative file paths
+ * @returns {Promise<Object>}    - the same `a`, with `a.task` filled in
+ */
+export async function ensureTaskFromFile(a, projectDir) {
+  if (!a) return a;
+  const hasTask = typeof a.task === "string" && a.task.trim().length > 0;
+  const hasFile = typeof a.taskFile === "string" && a.taskFile.trim().length > 0;
+  if (hasTask || !hasFile) return a;
+  const { readTaskFile } = await import("../utils/task-file.js");
+  a.task = await readTaskFile(a.taskFile, { projectDir });
+  return a;
+}
+
 export async function resolveProjectDir(server, explicitProjectDir) {
   if (explicitProjectDir) return explicitProjectDir;
 

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -54,9 +54,9 @@ export const tools = [
       "Run the full Karajan pipeline. IMPORTANT: Pass the user's task description exactly as they wrote it. Do NOT group, split, reorder, or modify tasks yourself. Karajan handles decomposition, role activation, iteration, and quality gates internally. Do NOT override pipeline parameters (enableHuReviewer, mode, methodology) unless the user explicitly requested it. If you have observations about the task, use kj_suggest instead.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description for the coder (can include a Planning Game card ID like KJC-TSK-0042)" },
+        task: { type: "string", description: "Task description for the coder (can include a Planning Game card ID like KJC-TSK-0042). Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md (or any text file) whose contents become the task description. Relative paths resolve against projectDir." },
         plan: { type: "string", description: "Plan ID from kj_plan. Loads persisted plan context and skips researcher/architect/planner stages." },
         projectDir: { type: "string", description: "Absolute path to the project directory. Required when KJ MCP server runs from a different directory than the target project." },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as task context and updates card status on completion." },
@@ -195,9 +195,9 @@ export const tools = [
     description: "Run coder-only mode. Pass the user's task exactly as described. Do NOT split or reinterpret the task.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string" },
+        task: { type: "string", description: "Task description. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         coder: { type: "string" },
         coderModel: { type: "string" },
         projectDir: { type: "string", description: "Absolute path to the project directory" },
@@ -210,9 +210,9 @@ export const tools = [
     description: "Run reviewer-only mode against current diff. Do NOT filter or pre-process the diff before passing it.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string" },
+        task: { type: "string", description: "Task description. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         reviewer: { type: "string" },
         reviewerModel: { type: "string" },
         baseRef: { type: "string" },
@@ -236,9 +236,9 @@ export const tools = [
     description: "Generate implementation plan for a task. Pass the task as the user described it. Karajan's planner decides the approach.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string" },
+        task: { type: "string", description: "Task description. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         planner: { type: "string" },
         plannerModel: { type: "string" },
         coder: { type: "string", description: "Legacy alias for planner" },
@@ -253,9 +253,9 @@ export const tools = [
     description: "Analyze a task for gaps, ambiguities, and missing information before execution. Returns a verdict (ready/needs_validation) with structured gap list. Can read task details from Planning Game if pgTask is provided.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description to analyze for gaps" },
+        task: { type: "string", description: "Task description to analyze for gaps. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         mode: { type: "string", enum: ["gaps", "momtest", "wendel", "classify", "jtbd"], description: "Discovery mode: gaps (default), momtest (Mom Test questions), wendel (behavior change checklist), classify (START/STOP/DIFFERENT), or jtbd (Jobs-to-be-Done)" },
         context: { type: "string", description: "Additional context for the analysis (e.g., research output)" },
         pgTask: { type: "string", description: "Planning Game card ID (e.g., KJC-TSK-0042). If provided, fetches full card details as additional context." },
@@ -270,9 +270,9 @@ export const tools = [
     description: "Classify task complexity and recommend which pipeline roles to activate. Returns level (trivial/simple/medium/complex), taskType, recommended roles, and optional decomposition.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description to classify" },
+        task: { type: "string", description: "Task description to classify. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
@@ -283,9 +283,9 @@ export const tools = [
     description: "Research the codebase for a task. Identifies affected files, patterns, constraints, prior decisions, risks, and test coverage.",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description to research" },
+        task: { type: "string", description: "Task description to research. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
       }
@@ -296,9 +296,9 @@ export const tools = [
     description: "Design solution architecture for a task. Returns layers, patterns, data model, API contracts, tradeoffs, and a verdict (ready/needs_clarification).",
     inputSchema: {
       type: "object",
-      required: ["task"],
       properties: {
-        task: { type: "string", description: "Task description to architect" },
+        task: { type: "string", description: "Task description to architect. Either `task` or `taskFile` is required." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file." },
         context: { type: "string", description: "Additional context (e.g., researcher output)" },
         projectDir: { type: "string", description: "Absolute path to the project directory" },
         kjHome: { type: "string" }
@@ -311,6 +311,8 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
+        task: { type: "string", description: "Optional focus for the audit. If absent (and no taskFile), defaults to a full-codebase analysis." },
+        taskFile: { type: "string", description: "Alternative to `task`: path to a .md/text file with the audit focus." },
         projectDir: { type: "string", description: "Absolute path to the project to audit" },
         dimensions: { type: "string", description: "Comma-separated dimensions to analyze: security,codeQuality,performance,architecture,testing (default: all)" },
         kjHome: { type: "string" }

--- a/src/utils/task-file.js
+++ b/src/utils/task-file.js
@@ -1,0 +1,109 @@
+/**
+ * Load a task description from a file (.md / .txt / .markdown / any plain text).
+ *
+ * Motivation: for anything beyond a one-line task, writing a `kj run "long
+ * multi-paragraph prompt ..."` becomes painful — escaping quotes, losing
+ * markdown formatting, no history. `kj run --task-file my-task.md` reads the
+ * file's contents and uses them as the task description. Same for `kj plan`,
+ * `kj audit`, `kj code`, and their MCP counterparts (via the `taskFile`
+ * argument).
+ *
+ * Behaviour:
+ *   - `taskFile` may be relative (resolved against `process.cwd()` by default,
+ *     or against `projectDir` if supplied) or absolute.
+ *   - Accepts any text file; markdown is the expected common case but we do
+ *     not require a specific extension.
+ *   - Trimmed of leading/trailing whitespace so agents don't get empty lines
+ *     around the task.
+ *   - `maxBytes` (default 256 KiB) guards against accidentally passing a huge
+ *     file (log dumps, PDFs). Agents choke on very long prompts anyway.
+ *   - Precedence with the positional `task` arg is decided by the caller:
+ *     this helper only loads, never merges. Convention used across commands:
+ *     when BOTH are provided, the positional task wins and the file is a
+ *     fallback — with a log warning so the user notices.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_TASK_FILE_MAX_BYTES = 256 * 1024;
+
+/**
+ * @param {string} filePath                - relative or absolute
+ * @param {Object} [opts]
+ * @param {string} [opts.projectDir]       - base dir for relative paths; defaults to process.cwd()
+ * @param {number} [opts.maxBytes]         - size cap; default 256 KiB
+ * @returns {Promise<string>}              - the trimmed file contents (task text)
+ * @throws                                 - Error with a user-readable message when the file is
+ *                                           missing, unreadable, empty, or over the size cap.
+ */
+export async function readTaskFile(filePath, opts = {}) {
+  if (!filePath || typeof filePath !== "string") {
+    throw new Error("readTaskFile: path must be a non-empty string");
+  }
+  const { projectDir, maxBytes = DEFAULT_TASK_FILE_MAX_BYTES } = opts;
+  const base = projectDir || process.cwd();
+  const resolved = path.isAbsolute(filePath) ? filePath : path.resolve(base, filePath);
+
+  let stat;
+  try {
+    stat = await fs.stat(resolved);
+  } catch (err) {
+    throw new Error(`Task file not found: ${resolved} (${err.code || err.message})`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`Task file is not a regular file: ${resolved}`);
+  }
+  if (stat.size > maxBytes) {
+    const kb = Math.round(stat.size / 1024);
+    const capKb = Math.round(maxBytes / 1024);
+    throw new Error(
+      `Task file is too large: ${resolved} (${kb} KiB > ${capKb} KiB cap). ` +
+      `Summarise the task or raise the limit with the caller's maxBytes option.`
+    );
+  }
+
+  const raw = await fs.readFile(resolved, "utf8");
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`Task file is empty (or whitespace-only): ${resolved}`);
+  }
+  return trimmed;
+}
+
+/**
+ * Resolve the task text a command should use, given both positional `task`
+ * and an optional `taskFile`. Single source of truth for precedence across
+ * CLI and MCP entry points.
+ *
+ * Rules:
+ *   - Neither provided → throw (caller decides the UX; typically propagates).
+ *   - Only `task` → returns it, untouched.
+ *   - Only `taskFile` → reads and returns it.
+ *   - Both → `task` wins; emits a warning through `logger.warn` (if given).
+ *
+ * @param {Object} args
+ * @param {string|undefined} args.task
+ * @param {string|undefined} args.taskFile
+ * @param {string} [args.projectDir]
+ * @param {Object} [args.logger]             - optional; uses `logger.warn(msg)` only
+ * @returns {Promise<string>}
+ */
+export async function resolveTaskInput({ task, taskFile, projectDir, logger } = {}) {
+  const hasTask = typeof task === "string" && task.trim().length > 0;
+  const hasFile = typeof taskFile === "string" && taskFile.trim().length > 0;
+
+  if (!hasTask && !hasFile) {
+    throw new Error("No task provided. Pass a task argument or --task-file <path>.");
+  }
+  if (hasTask && hasFile) {
+    logger?.warn?.(
+      `Both task and --task-file given; using the positional task and ignoring file: ${taskFile}`
+    );
+    return task.trim();
+  }
+  if (hasFile) {
+    return readTaskFile(taskFile, { projectDir });
+  }
+  return task.trim();
+}

--- a/tests/mcp-discover-tool.test.js
+++ b/tests/mcp-discover-tool.test.js
@@ -12,9 +12,15 @@ describe("kj_discover MCP tool schema", () => {
     expect(tool).toBeDefined();
   });
 
-  it("requires task parameter", () => {
+  it("accepts task or taskFile (either is valid)", () => {
     const tool = tools.find((t) => t.name === "kj_discover");
-    expect(tool.inputSchema.required).toContain("task");
+    // After KJC-TSK-0327 follow-up: `task` and `taskFile` are both optional
+    // in the schema; server-side validation enforces that at least one is
+    // present. Removing `required: ["task"]` lets clients pass taskFile alone.
+    expect(tool.inputSchema.required).toBeUndefined();
+    expect(tool.inputSchema.properties.task).toBeDefined();
+    expect(tool.inputSchema.properties.taskFile).toBeDefined();
+    expect(tool.inputSchema.properties.taskFile.type).toBe("string");
   });
 
   it("has mode as optional enum parameter", () => {

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -12,9 +12,11 @@ describe("kj_triage MCP tool schema", () => {
     expect(tool).toBeDefined();
   });
 
-  it("requires task parameter", () => {
+  it("accepts task or taskFile (either is valid)", () => {
     const tool = tools.find((t) => t.name === "kj_triage");
-    expect(tool.inputSchema.required).toContain("task");
+    expect(tool.inputSchema.required).toBeUndefined();
+    expect(tool.inputSchema.properties.task).toBeDefined();
+    expect(tool.inputSchema.properties.taskFile).toBeDefined();
   });
 
   it("has task as string property", () => {
@@ -29,9 +31,11 @@ describe("kj_researcher MCP tool schema", () => {
     expect(tool).toBeDefined();
   });
 
-  it("requires task parameter", () => {
+  it("accepts task or taskFile (either is valid)", () => {
     const tool = tools.find((t) => t.name === "kj_researcher");
-    expect(tool.inputSchema.required).toContain("task");
+    expect(tool.inputSchema.required).toBeUndefined();
+    expect(tool.inputSchema.properties.task).toBeDefined();
+    expect(tool.inputSchema.properties.taskFile).toBeDefined();
   });
 });
 
@@ -41,9 +45,11 @@ describe("kj_architect MCP tool schema", () => {
     expect(tool).toBeDefined();
   });
 
-  it("requires task parameter", () => {
+  it("accepts task or taskFile (either is valid)", () => {
     const tool = tools.find((t) => t.name === "kj_architect");
-    expect(tool.inputSchema.required).toContain("task");
+    expect(tool.inputSchema.required).toBeUndefined();
+    expect(tool.inputSchema.properties.task).toBeDefined();
+    expect(tool.inputSchema.properties.taskFile).toBeDefined();
   });
 
   it("has context as optional string", () => {

--- a/tests/utils/task-file.test.js
+++ b/tests/utils/task-file.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, it, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { readTaskFile, resolveTaskInput, DEFAULT_TASK_FILE_MAX_BYTES } from "../../src/utils/task-file.js";
+
+const cleanups = [];
+afterEach(async () => {
+  for (const p of cleanups) await fs.rm(p, { recursive: true, force: true }).catch(() => {});
+  cleanups.length = 0;
+});
+
+async function mkTmpDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-tf-"));
+  cleanups.push(dir);
+  return dir;
+}
+
+describe("utils/task-file — readTaskFile", () => {
+  it("reads a .md file and returns its trimmed content", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "task.md");
+    await fs.writeFile(file, "\n\n# Feature\n\nAdd a counter.\n\n");
+    const text = await readTaskFile(file);
+    expect(text).toBe("# Feature\n\nAdd a counter.");
+  });
+
+  it("resolves relative paths against projectDir", async () => {
+    const dir = await mkTmpDir();
+    await fs.writeFile(path.join(dir, "my-task.md"), "relative ok");
+    const text = await readTaskFile("my-task.md", { projectDir: dir });
+    expect(text).toBe("relative ok");
+  });
+
+  it("resolves relative paths against process.cwd() when no projectDir is given", async () => {
+    const dir = await mkTmpDir();
+    await fs.writeFile(path.join(dir, "t.md"), "cwd relative");
+    const prev = process.cwd();
+    process.chdir(dir);
+    try {
+      const text = await readTaskFile("t.md");
+      expect(text).toBe("cwd relative");
+    } finally {
+      process.chdir(prev);
+    }
+  });
+
+  it("throws a readable error when the file does not exist", async () => {
+    await expect(readTaskFile("/nope/nowhere/missing.md")).rejects.toThrow(/not found/i);
+  });
+
+  it("throws when the file is empty (or whitespace-only)", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "blank.md");
+    await fs.writeFile(file, "\n   \n\t\n");
+    await expect(readTaskFile(file)).rejects.toThrow(/empty/i);
+  });
+
+  it("throws when the file exceeds the maxBytes cap", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "huge.md");
+    await fs.writeFile(file, "x".repeat(200));
+    await expect(readTaskFile(file, { maxBytes: 100 })).rejects.toThrow(/too large/i);
+  });
+
+  it("rejects non-string paths", async () => {
+    await expect(readTaskFile("")).rejects.toThrow(/non-empty string/);
+    await expect(readTaskFile(null)).rejects.toThrow(/non-empty string/);
+  });
+
+  it("exposes DEFAULT_TASK_FILE_MAX_BYTES constant", () => {
+    expect(DEFAULT_TASK_FILE_MAX_BYTES).toBeGreaterThan(0);
+    expect(DEFAULT_TASK_FILE_MAX_BYTES).toBeLessThanOrEqual(1024 * 1024);
+  });
+});
+
+describe("utils/task-file — resolveTaskInput", () => {
+  it("returns the positional task untouched when only it is given", async () => {
+    const t = await resolveTaskInput({ task: "quick task" });
+    expect(t).toBe("quick task");
+  });
+
+  it("reads taskFile when only it is given", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "t.md");
+    await fs.writeFile(file, "from file");
+    const t = await resolveTaskInput({ taskFile: file });
+    expect(t).toBe("from file");
+  });
+
+  it("prefers positional task over taskFile when both are given (warns the user)", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "t.md");
+    await fs.writeFile(file, "from file");
+    const warnings = [];
+    const t = await resolveTaskInput({
+      task: "inline task",
+      taskFile: file,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(t).toBe("inline task");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/ignoring file/i);
+  });
+
+  it("throws when neither task nor taskFile is given", async () => {
+    await expect(resolveTaskInput({})).rejects.toThrow(/no task/i);
+  });
+
+  it("trims whitespace from the positional task", async () => {
+    const t = await resolveTaskInput({ task: "  padded task  \n" });
+    expect(t).toBe("padded task");
+  });
+
+  it("treats whitespace-only task as absent and falls through to taskFile", async () => {
+    const dir = await mkTmpDir();
+    const file = path.join(dir, "t.md");
+    await fs.writeFile(file, "from file");
+    const t = await resolveTaskInput({ task: "   \n  ", taskFile: file });
+    expect(t).toBe("from file");
+  });
+});


### PR DESCRIPTION
## What

Three dogfooding fixes:

### 1. Read task from a `.md` file — CLI and MCP

| Surface | Before | After |
|---------|--------|-------|
| CLI | `kj run "very long multi-paragraph prompt..."` (escaping hell) | `kj run --task-file my-task.md` or `kj run "short task"` |
| MCP | `kj_run({ task: "..." })` required inline | `kj_run({ taskFile: "path/to/spec.md" })` or `task: "..."` |

Wired into: `run`, `code`, `review`, `plan` (generate), `discover`, `triage`, `researcher`, `architect`, `audit`.

New helper `src/utils/task-file.js` does the heavy lifting: relative path resolution against projectDir/cwd, 256 KiB size cap, empty-file detection, trimming. Single precedence rule across CLI+MCP: positional `task` wins over `taskFile` when both given (warns the user). MCP side uses a thin `ensureTaskFromFile(a, projectDir)` helper that mutates `a.task` so handlers keep reading `a.task` with zero per-handler changes.

### 2. `kj-tail` waits for the log to appear

Before: `kj-tail` exited with a red error if `.kj/run.log` didn't exist yet. Users had to race the command and missed early lines.

After: `kj-tail` prints a yellow notice listing which commands trigger a log, ensures `.kj/` exists, polls every 500 ms, and streams as soon as the log appears. `-s` (snapshot) stays non-blocking.

### 3. Merged-branch cleanup

Removed 8 stale merged local branches + their 2 abandoned git worktrees (HU-002/003 left by earlier sub-pipelines). `git branch --merged main` is now empty.

## Tests

- **14 new vitest cases** in `tests/utils/task-file.test.js` covering readTaskFile + resolveTaskInput.
- Updated 4 existing MCP schema assertions (`requires task parameter` → `accepts task or taskFile`).
- Full suite: **3 702 tests across 287 files passing**. Lint clean.

## Test plan
- [ ] `echo "# Add counter component" > task.md && kj plan --task-file task.md` → reads file.
- [ ] `kj_plan` MCP tool invoked with `taskFile: "task.md"` produces the plan.
- [ ] Both `task` and `--task-file` given: positional wins, warning shown.
- [ ] Neither given: clear "no task" error.
- [ ] `kj-tail` in empty project waits; then `node bin/kj.js audit` in parallel → tail starts streaming.

Refs: dogfooding follow-up to KJC-TSK-0327