### PR TITLE
refactor(sonar): make Sonar intrinsic to Karajan, kill the enabled toggle

### DIFF
--- a/src/checks/ports.js
+++ b/src/checks/ports.js
@@ -38,15 +38,13 @@ export function createSonarPortCheck() {
     name: "port:sonar",
     label: "SonarQube port",
     strategy: STRATEGY.MANUAL,
-    // Returns { applies, reason } so the runner shows WHY when skipped.
-    // Common cause of confusion: a global ~/.karajan/kj.config.yml with
-    // `sonarqube.enabled: false` silently disables every sonar check —
-    // the user thinks Karajan is broken, when it's just respecting their
-    // config.
+    // Since v2.7.4 Sonar is intrinsic to Karajan for code tasks, so the
+    // port check almost always applies. The only legitimate skip is when
+    // the user runs their own external Sonar instance (`external: true`),
+    // in which case the port is managed outside Karajan. The legacy
+    // `sonarqube.enabled` field is ignored (deprecation warning emitted
+    // at config load time — see emitConfigDeprecations in flow-runner.js).
     applies: (config) => {
-      if (config?.sonarqube?.enabled === false) {
-        return { applies: false, reason: "sonarqube.enabled is false in kj.config.yml — set true to enable Sonar (Karajan auto-starts the docker container)" };
-      }
       if (config?.sonarqube?.external === true) {
         return { applies: false, reason: "sonarqube.external is true — port managed outside Karajan" };
       }

--- a/src/config.js
+++ b/src/config.js
@@ -290,6 +290,20 @@ export async function loadConfig(projectDir) {
     throw new Error(`Invalid Karajan config:\n${formatConfigIssues(validation.issues)}`);
   }
 
+  // Deprecation tracking — `sonarqube.enabled` was a footgun: users would
+  // set it to `false` in their global ~/.karajan/kj.config.yml and then
+  // wonder why Sonar didn't run on a code task. Since v2.7.4 Sonar is
+  // intrinsic to Karajan for code tasks; the field is ignored. We surface
+  // a warning at run start (see emitConfigDeprecations in flow-runner.js)
+  // so users notice and clean up their config. Don't throw — keep
+  // back-compat so existing scripts keep working.
+  const userSetSonarEnabled = (globalConfig?.sonarqube?.enabled !== undefined)
+    || (projectConfig?.sonarqube?.enabled !== undefined);
+  if (userSetSonarEnabled) {
+    merged._deprecated = merged._deprecated || {};
+    merged._deprecated.sonarqubeEnabledKey = true;
+  }
+
   return { config: merged, path: configPath, exists: globalExists, hasProjectConfig: !!projectConfig };
 }
 
@@ -423,7 +437,16 @@ function applyOutputModeOverrides(out, flags) {
 
 function applyMiscOverrides(out, flags) {
   if (flags[AUTO_SIMPLIFY_FLAG] !== undefined) out.pipeline.auto_simplify = Boolean(flags[AUTO_SIMPLIFY_FLAG]);
-  if (flags.noSonar || flags.sonar === false) out.sonarqube.enabled = false;
+  // `--no-sonar` and `sonarqube.enabled: false` are deprecated since v2.7.4.
+  // Sonar is intrinsic to Karajan for code tasks (sw/refactor/add-tests) and
+  // skipped for non-code tasks (audit/doc/infra/analysis/no-code) by policy.
+  // The flag is still accepted to avoid breaking scripts; it now emits a
+  // warning at run start and is otherwise ignored. See preflight-checks.js
+  // and flow-runner.js for the actual gate (resolvedPolicies.sonar).
+  if (flags.noSonar || flags.sonar === false) {
+    out._deprecated = out._deprecated || {};
+    out._deprecated.noSonarFlag = true;
+  }
   out.sonarcloud = out.sonarcloud || {};
   if (flags.enableSonarcloud === true) out.sonarcloud.enabled = true;
   if (flags.noSonarcloud === true || flags.sonarcloud === false) out.sonarcloud.enabled = false;

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -726,6 +726,12 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
 
   let updatedConfig = resolvePipelinePolicies({ flags, config, stageResults, emitter, eventBase, session, pipelineFlags });
 
+  // Deprecation warnings recorded at config load time. Done here, after
+  // policies are resolved, so the message lands in context: if the user's
+  // legacy `sonarqube.enabled: false` is being ignored, this is the right
+  // moment for them to see it.
+  emitConfigDeprecations(updatedConfig, logger, emitter, eventBase);
+
   // --- Preflight environment checks ---
   const preflightResult = await runPreflightChecks({
     config: updatedConfig, logger, emitter, eventBase,
@@ -920,6 +926,46 @@ async function runPreLoopStages({ config, logger, emitter, eventBase, session, f
  * Setting skills.addyosmani.enabled = false, or removing "addyosmani" from
  * skills.sources, disables this step entirely (reverts to OpenSkills-only).
  */
+/**
+ * Print one-time deprecation warnings for config keys / CLI flags that
+ * Karajan no longer honours. Called once per run, after policy resolution
+ * so the message lands in context (the user sees what's being ignored
+ * RIGHT before the preflight that would have been affected).
+ *
+ * Currently surfaces:
+ *   - `sonarqube.enabled` set in user config → ignored since v2.7.4
+ *   - `--no-sonar` CLI flag → ignored since v2.7.4
+ */
+function emitConfigDeprecations(config, logger, emitter, eventBase) {
+  const dep = config?._deprecated;
+  if (!dep) return;
+
+  if (dep.sonarqubeEnabledKey) {
+    const m =
+      "DEPRECATED: `sonarqube.enabled` in kj.config.yml is ignored since v2.7.4. " +
+      "Sonar is intrinsic to Karajan for code tasks (sw/refactor/add-tests) and " +
+      "skipped for non-code tasks (audit/doc/infra/analysis/no-code) by policy. " +
+      "Remove the key from your config to silence this warning.";
+    logger.warn(m);
+    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
+      message: m,
+      detail: { key: "sonarqube.enabled", since: "v2.7.4" },
+    }));
+  }
+
+  if (dep.noSonarFlag) {
+    const m =
+      "DEPRECATED: `--no-sonar` flag is ignored since v2.7.4. Sonar runs for code " +
+      "tasks by policy. To skip Sonar on a one-off run, use a non-code task type " +
+      "(e.g. `--task-type doc`) or rely on Solomon's runtime override.";
+    logger.warn(m);
+    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
+      message: m,
+      detail: { flag: "--no-sonar", since: "v2.7.4" },
+    }));
+  }
+}
+
 async function ensureAddyosmaniSkills({ task, config, logger, session, emitter, eventBase }) {
   const skillsConfig = config?.skills || {};
   const sources = Array.isArray(skillsConfig.sources) ? skillsConfig.sources : ["addyosmani", "openskills", "local"];
@@ -1173,9 +1219,17 @@ async function runQualityGateStages({ config, logger, emitter, eventBase, sessio
   if (tddResult.action === "pause") return { action: "return", result: tddResult.result };
   if (tddResult.action === "continue") return { action: "continue" };
 
-  const skipSonarForTaskType = new Set(["infra", "doc", "no-code"]);
-  const effectiveTaskType = session.resolved_policies?.taskType || null;
-  if (config.sonarqube.enabled && !skipSonarForTaskType.has(effectiveTaskType)) {
+  // Sonar runs for code tasks per policy. Since v2.7.4 it is NOT
+  // toggleable via config — that's intrinsic to Karajan. The taskType
+  // policy (resolved_policies.sonar) is the single source of truth.
+  // Solomon may skip a single iteration via rule alerts; that's a
+  // runtime decision, not a config option.
+  //
+  // Test-only escape hatch: globalThis.__KJ_DISABLE_SONAR_STAGE forces
+  // the sonar stage off so tests don't have to spin up Docker. Set in
+  // tests/setup.js by default; production code never sees it.
+  const sonarStageDisabledForTest = globalThis.__KJ_DISABLE_SONAR_STAGE === true;
+  if (!sonarStageDisabledForTest && session.resolved_policies?.sonar !== false) {
     const sonarResult = await runSonarStage({
       config, logger, emitter, eventBase, session, trackBudget, iteration: i,
       repeatDetector, budgetSummary, sonarState, askQuestion, task, brainCtx

--- a/src/orchestrator/preflight-checks.js
+++ b/src/orchestrator/preflight-checks.js
@@ -168,7 +168,21 @@ async function checkSecurityAgent(config) {
  * @returns {{ ok: boolean, checks: object[], remediations: string[], configOverrides: object, warnings: string[], errors: object[] }}
  */
 export async function runPreflightChecks({ config, logger, emitter, eventBase, resolvedPolicies, securityEnabled }) {
-  const sonarEnabled = Boolean(config.sonarqube?.enabled) && resolvedPolicies.sonar !== false;
+  // Sonar is intrinsic to Karajan for code tasks (sw/refactor/add-tests).
+  // Since v2.7.4 it is NOT toggleable via `config.sonarqube.enabled` —
+  // that field is ignored (deprecation warning emitted at config load).
+  // The taskType policy (resolved_policies.sonar from DEFAULT_POLICIES in
+  // src/guards/policy-resolver.js) is the single source of truth: sw /
+  // refactor / add-tests run Sonar, audit / doc / infra / analysis /
+  // no-code skip it. Solomon may decide to skip a single iteration via
+  // rule alerts — that's a runtime decision, not a config option.
+  //
+  // Test-only escape hatch: globalThis.__KJ_DISABLE_SONAR_STAGE === true
+  // forces sonar OFF in preflight too, so tests that don't want sonar
+  // events in their expected sequence don't have to set up Docker mocks.
+  // Set in tests/setup.js by default; production code never sees it.
+  const sonarStageDisabledForTest = globalThis.__KJ_DISABLE_SONAR_STAGE === true;
+  const sonarEnabled = !sonarStageDisabledForTest && resolvedPolicies.sonar !== false;
   const isExternalSonar = Boolean(config.sonarqube?.external);
   const sonarHost = resolveSonarHost(config.sonarqube?.host);
 

--- a/tests/architecture/sonar-intrinsic.test.js
+++ b/tests/architecture/sonar-intrinsic.test.js
@@ -1,0 +1,148 @@
+/**
+ * Architecture regression guard — Sonar is INTRINSIC to Karajan, not a
+ * config toggle.
+ *
+ * The user's contract (set in v2.7.4): SonarQube quality gate is run for
+ * every code task (sw / refactor / add-tests) and skipped for non-code tasks
+ * (audit / doc / infra / analysis / no-code). The decision lives in
+ * `src/guards/policy-resolver.js::DEFAULT_POLICIES`. Users CANNOT disable
+ * Sonar via `sonarqube.enabled: false` or `--no-sonar` — those are accepted
+ * (back-compat) but ignored, with a deprecation warning.
+ *
+ * Rationale: a user running with `sonarqube.enabled: false` on a code task
+ * is doing a job Karajan refuses to call complete (no quality gate, no
+ * static analysis, no enforcement of the project's standards). That's not a
+ * use case Karajan supports. Solomon may decide to skip a single iteration
+ * via runtime rule alerts (legitimate — that's a runtime override based on
+ * evidence), but the user cannot pre-disable Sonar at config load time.
+ *
+ * If you find yourself wanting to remove these tests because they're "in
+ * the way", STOP. Read `src/orchestrator/preflight-checks.js`,
+ * `src/orchestrator/flow-runner.js::runQualityGateStages`, and
+ * `src/guards/policy-resolver.js`. Then open a discussion before changing
+ * the contract.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/agent-detect.js", () => ({
+  checkBinary: vi.fn().mockResolvedValue({ ok: true, version: "test" }),
+}));
+
+describe("architecture/sonar-intrinsic — Sonar is not a config toggle", () => {
+  describe("preflight (runPreflightChecks)", () => {
+    it("does NOT read config.sonarqube.enabled — only resolvedPolicies.sonar", async () => {
+      // Read the source and assert the guard is the policy, not the config.
+      // A textual assertion is uglier than mocking, but it's the only way to
+      // prevent a future PR from sneaking the config check back in by
+      // ANDing with `sonarqube.enabled` again.
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const url = await import("node:url");
+      const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
+      const text = await fs.readFile(
+        path.join(repoRoot, "src/orchestrator/preflight-checks.js"),
+        "utf8",
+      );
+      // Forbid the AND with config.sonarqube.enabled — that was the v2.7.3 bug.
+      expect(
+        text.match(/sonarqube\?\.enabled\)\s*&&\s*resolvedPolicies/i),
+        "Preflight must derive sonarEnabled from resolvedPolicies.sonar ONLY, not from config.sonarqube.enabled. " +
+          "Sonar is intrinsic to Karajan for code tasks since v2.7.4.",
+      ).toBeNull();
+      // Affirmative: the live expression must reference resolvedPolicies (the
+      // gate may include a test-only escape hatch like __KJ_DISABLE_SONAR_STAGE
+      // ANDed in, which is fine — what matters is that production code only
+      // looks at resolvedPolicies and never at config.sonarqube.enabled).
+      expect(text).toMatch(/resolvedPolicies\.sonar\s*!==\s*false/);
+    });
+  });
+
+  describe("flow-runner (runQualityGateStages)", () => {
+    it("gates the sonar stage on resolved_policies.sonar, not config.sonarqube.enabled", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const url = await import("node:url");
+      const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
+      const text = await fs.readFile(
+        path.join(repoRoot, "src/orchestrator/flow-runner.js"),
+        "utf8",
+      );
+      // Forbid: `if (config.sonarqube.enabled && ...) runSonarStage`
+      expect(
+        text.match(/config\.sonarqube\.enabled\s*&&[^\n]*runSonarStage/i),
+        "runSonarStage must be gated on session.resolved_policies.sonar, not config.sonarqube.enabled.",
+      ).toBeNull();
+      // Affirmative: must check resolved_policies in the gate.
+      expect(text).toMatch(/session\.resolved_policies\?\.sonar\s*!==\s*false[^\n]*\)\s*\{[\s\S]{0,600}runSonarStage/);
+    });
+  });
+
+  describe("flag handling", () => {
+    it("accepts --no-sonar but records it as deprecated (does NOT mutate sonarqube.enabled)", async () => {
+      const { applyRunOverrides } = await import("../../src/config.js");
+      const base = {
+        sonarqube: { enabled: true },
+        sonarcloud: { enabled: false },
+        development: {},
+        pipeline: {},
+        reviewer_options: {},
+        coder_options: {},
+        session: {},
+        git: {},
+      };
+      const out = applyRunOverrides(base, { noSonar: true });
+      // Old behaviour (v2.7.3 and earlier): `out.sonarqube.enabled === false`.
+      // New behaviour: enabled is unchanged, deprecation flag is set.
+      expect(out.sonarqube.enabled).toBe(true);
+      expect(out._deprecated?.noSonarFlag).toBe(true);
+    });
+
+    it("accepts sonar=false the same way (deprecated, ignored)", async () => {
+      const { applyRunOverrides } = await import("../../src/config.js");
+      const base = {
+        sonarqube: { enabled: true }, sonarcloud: { enabled: false },
+        development: {}, pipeline: {}, reviewer_options: {}, coder_options: {},
+        session: {}, git: {},
+      };
+      const out = applyRunOverrides(base, { sonar: false });
+      expect(out.sonarqube.enabled).toBe(true);
+      expect(out._deprecated?.noSonarFlag).toBe(true);
+    });
+  });
+
+  describe("config load", () => {
+    it("flags sonarqube.enabled in user config as deprecated", async () => {
+      // Direct unit-level check on the loadConfig logic. We don't actually
+      // load a file (avoids fs setup); instead we replicate the code path.
+      // This test is a guard: any change that drops the deprecation flag
+      // should fail it.
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const url = await import("node:url");
+      const repoRoot = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
+      const text = await fs.readFile(path.join(repoRoot, "src/config.js"), "utf8");
+      expect(text).toMatch(/userSetSonarEnabled/);
+      expect(text).toMatch(/sonarqubeEnabledKey/);
+      expect(text).toMatch(/_deprecated/);
+    });
+  });
+
+  describe("policy mapping (DEFAULT_POLICIES)", () => {
+    it("code task types DO require Sonar", async () => {
+      const { applyPolicies } = await import("../../src/guards/policy-resolver.js");
+      for (const codeType of ["sw", "refactor", "add-tests"]) {
+        const res = applyPolicies({ taskType: codeType, policies: {} });
+        expect(res.sonar, `taskType=${codeType} must require Sonar`).toBe(true);
+      }
+    });
+
+    it("non-code task types do NOT require Sonar", async () => {
+      const { applyPolicies } = await import("../../src/guards/policy-resolver.js");
+      for (const nonCodeType of ["audit", "doc", "infra", "analysis", "no-code"]) {
+        const res = applyPolicies({ taskType: nonCodeType, policies: {} });
+        expect(res.sonar, `taskType=${nonCodeType} must NOT require Sonar`).toBe(false);
+      }
+    });
+  });
+});

--- a/tests/checks/ports.test.js
+++ b/tests/checks/ports.test.js
@@ -50,19 +50,18 @@ describe("checks/ports", () => {
       expect(result.extra.port).toBe(9000);
     });
 
-    it("applies only when Sonar is enabled, and explains WHY when not", () => {
+    it("applies for any non-external config (Sonar is intrinsic since v2.7.4)", () => {
       const check = mod.createSonarPortCheck();
-      // Post-fix: applies() returns { applies, reason } when skipped so the
-      // user sees the cause instead of the opaque "Not applicable for current
-      // configuration" that confused users with `enabled: false` in their
-      // global ~/.karajan/kj.config.yml.
-      const disabled = check.applies({ sonarqube: { enabled: false } });
-      expect(disabled).toEqual({ applies: false, reason: expect.stringMatching(/sonarqube\.enabled is false/i) });
-
-      const external = check.applies({ sonarqube: { enabled: true, external: true } });
-      expect(external).toEqual({ applies: false, reason: expect.stringMatching(/external/i) });
-
+      // Post-v2.7.4: `sonarqube.enabled` is ignored — Sonar is intrinsic
+      // to Karajan for code tasks. The only legitimate skip is when the
+      // user runs their own external Sonar instance.
+      expect(check.applies({})).toBe(true);
+      expect(check.applies({ sonarqube: {} })).toBe(true);
+      expect(check.applies({ sonarqube: { enabled: false } })).toBe(true); // ignored!
       expect(check.applies({ sonarqube: { enabled: true } })).toBe(true);
+
+      const external = check.applies({ sonarqube: { external: true } });
+      expect(external).toEqual({ applies: false, reason: expect.stringMatching(/external/i) });
     });
   });
 

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -46,7 +46,11 @@ describe("applyRunOverrides", () => {
 
     expect(out.review_mode).toBe("paranoid");
     expect(out.base_branch).toBe("develop");
-    expect(out.sonarqube.enabled).toBe(false);
+    // Post-v2.7.4: --no-sonar no longer mutates sonarqube.enabled. Sonar is
+    // intrinsic to Karajan for code tasks; the flag is recorded as deprecated
+    // and surfaced as a warning at run start (see emitConfigDeprecations in
+    // flow-runner.js). The actual gate is resolvedPolicies.sonar.
+    expect(out._deprecated?.noSonarFlag).toBe(true);
     expect(out.session.max_iteration_minutes).toBe(1);
     expect(out.session.max_total_minutes).toBe(15);
     expect(out.reviewer_options.fallback_reviewer).toBe("gemini");

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 
 const REVIEW_OK = JSON.stringify({
@@ -140,9 +140,19 @@ vi.mock("../src/orchestrator/preflight-checks.js", () => ({
 }));
 
 describe("kj_run smoke", () => {
+  // This file legitimately exercises the Sonar stage. Opt out of the
+  // global test override (tests/setup.js sets __KJ_DISABLE_SONAR_STAGE=true
+  // by default so non-sonar tests don't hit the Docker stage).
+  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
+  });
+  // Restore the global default after this describe block finishes so it
+  // doesn't leak to other suites.
+  afterAll(() => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled;
   });
 
   it("autostarts SonarQube and scans before review when sonar service is unavailable", async () => {

--- a/tests/orchestrator-events.test.js
+++ b/tests/orchestrator-events.test.js
@@ -148,6 +148,17 @@ vi.mock("node:fs/promises", () => ({
   }
 }));
 
+// Helper for tests that genuinely exercise the Sonar stage. Toggles the
+// global __KJ_DISABLE_SONAR_STAGE off for the duration of the it() block
+// and restores it on completion. Tests that DON'T need Sonar (most of
+// this file) are unaffected — the global default from tests/setup.js
+// keeps Sonar disabled.
+async function withSonarStageEnabled(fn) {
+  const prev = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  globalThis.__KJ_DISABLE_SONAR_STAGE = false;
+  try { return await fn(); } finally { globalThis.__KJ_DISABLE_SONAR_STAGE = prev; }
+}
+
 describe("orchestrator events", () => {
   let runFlow;
 
@@ -316,7 +327,7 @@ describe("orchestrator events", () => {
     }
   });
 
-  it("runs sonar scan before reviewer when SonarQube is enabled", async () => {
+  it("runs sonar scan before reviewer when SonarQube is enabled", async () => withSonarStageEnabled(async () => {
     const { createAgent } = await import("../src/agents/index.js");
     const coderAgent = {
       runTask: vi.fn().mockResolvedValue({ ok: true, output: "" })
@@ -384,7 +395,7 @@ describe("orchestrator events", () => {
 
     const sonarEnd = events.find((e) => e.type === "sonar:end");
     expect(sonarEnd?.detail?.projectKey).toBe("kj-repo-123");
-  });
+  }));
 
   it("emits agent:output events from coder and reviewer", async () => {
     const { createAgent } = await import("../src/agents/index.js");
@@ -635,7 +646,7 @@ describe("orchestrator events", () => {
     expect(runTask).toHaveBeenCalledWith(expect.objectContaining({ role: "refactorer" }));
   });
 
-  it("emits session:end with planner plan, sonar issue resolution, and commit details", async () => {
+  it("emits session:end with planner plan, sonar issue resolution, and commit details", async () => withSonarStageEnabled(async () => {
     const emitter = new EventEmitter();
     const events = [];
     emitter.on("progress", (e) => events.push(e));
@@ -722,9 +733,9 @@ describe("orchestrator events", () => {
     expect(sessionEnd?.detail?.stages?.sonar?.issuesResolved).toBe(5);
     expect(sessionEnd?.detail?.git?.commits).toEqual([{ hash: "abc1234", message: "feat: auth hardening" }]);
     expect(sessionEnd?.detail?.git?.prUrl).toBe("https://github.com/org/repo/pull/9");
-  });
+  }));
 
-  it("does not mutate caller config when policy gates disable TDD/Sonar (R-1)", async () => {
+  it("does not mutate caller config when policy gates disable TDD/Sonar (R-1)", async () => withSonarStageEnabled(async () => {
     const emitter = new EventEmitter();
 
     const config = {
@@ -755,9 +766,9 @@ describe("orchestrator events", () => {
     expect(config.development.methodology).toBe("tdd");
     expect(config.development.require_test_changes).toBe(true);
     expect(config.sonarqube.enabled).toBe(true);
-  });
+  }));
 
-  it("honors config.taskType when flags.taskType is absent (R-1)", async () => {
+  it("honors config.taskType when flags.taskType is absent (R-1)", async () => withSonarStageEnabled(async () => {
     const emitter = new EventEmitter();
     const events = [];
     emitter.on("progress", (e) => events.push(e));
@@ -791,5 +802,5 @@ describe("orchestrator events", () => {
     expect(policyEvent.detail.taskType).toBe("doc");
     expect(policyEvent.detail.tdd).toBe(false);
     expect(policyEvent.detail.sonar).toBe(false);
-  });
+  }));
 });

--- a/tests/orchestrator-repeat-detection.test.js
+++ b/tests/orchestrator-repeat-detection.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const REVIEW_BLOCKING = JSON.stringify({
   approved: false,
@@ -145,8 +145,13 @@ vi.mock("node:fs/promises", () => ({
 
 describe("orchestrator repeat detection", () => {
   let runFlow;
+  // This file exercises the Sonar stage (sonar-issue repeat scenarios).
+  // Opt out of the global test override.
+  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  afterAll(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
 
   beforeEach(async () => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
 
     const { createAgent } = await import("../src/agents/index.js");

--- a/tests/preflight-checks.test.js
+++ b/tests/preflight-checks.test.js
@@ -70,8 +70,14 @@ describe("preflight-checks", () => {
   const emittedEvents = [];
 
   const savedEnv = { ...process.env };
+  // This file legitimately exercises the Sonar preflight (auto-start,
+  // reachability, token auth). Opt out of the global test override
+  // (tests/setup.js disables sonar by default for non-sonar tests).
+  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  afterEach(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
 
   beforeEach(async () => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
     delete process.env.SONAR_TOKEN;

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -44,3 +44,12 @@ globalThis.__KJ_DEFAULT_BRAIN_DECISOR = false;
 // `config.skills.addyosmani.enabled = true` explicitly (or rely on the direct
 // unit tests in tests/skills/addyosmani-*.test.js which mock git themselves).
 globalThis.__KJ_DEFAULT_ADDYOSMANI_ENABLED = false;
+
+// Disable the Sonar stage under Vitest. Sonar is intrinsic to Karajan in
+// production for code tasks (sw/refactor/add-tests) and the production
+// preflight auto-starts the Docker container. Forcing every test that touches
+// the flow runner to bring up SonarQube would be both slow (20-40 s warmup)
+// and brittle (requires Docker on the runner). Tests that specifically
+// exercise the sonar stage opt in by setting __KJ_DISABLE_SONAR_STAGE = false
+// in their own setup, or mock runSonarStage directly.
+globalThis.__KJ_DISABLE_SONAR_STAGE = true;

--- a/tests/sonar-token-flow.test.js
+++ b/tests/sonar-token-flow.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 
 // --- Mocks for preflight-checks ---
 
@@ -37,8 +37,13 @@ describe("[opt-in: sonar] sonar token resolution — preflight", () => {
   let runPreflightChecks;
   let checkBinary, isSonarReachable, sonarUp, runCommand, loadSonarCredentials;
   let logger, emitter, eventBase;
+  // Sonar preflight tests opt out of the global __KJ_DISABLE_SONAR_STAGE
+  // (set in tests/setup.js so non-sonar tests don't hit Docker).
+  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  afterEach(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
 
   beforeEach(async () => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
     delete process.env.SONAR_TOKEN;

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterAll, describe, expect, it, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { REVIEW_OK, REVIEW_REJECTED, makeConfig as makeBaseConfig, noopLogger } from "./fixtures/orchestrator-mocks.js";
 
@@ -141,8 +141,13 @@ vi.mock("node:fs/promises", () => ({
 
 describe("configurable sub-loop limits", () => {
   let runFlow;
+  // Sonar sub-loop tests genuinely exercise the sonar stage. Opt out of
+  // the global test override (tests/setup.js disables it by default).
+  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  afterAll(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
 
   beforeEach(async () => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
 
     const { createAgent } = await import("../src/agents/index.js");


### PR DESCRIPTION
## User feedback (verbatim)

> "Sonar debe usarse SI o SI si es una tarea de codigo. No puede haber una configuracion de Sonar true o false. Sonar no es discutible, como hacer TDD, es intrinseco a KJ. Otra cosa es que durante el proceso, Solomon decida saltarselo porque alguna regla asi lo indica."

## Architecture change

| | Before (v2.7.3) | After (this PR) |
|---|---|---|
| Code task (sw/refactor/add-tests) + `sonarqube.enabled: true` | ✅ Sonar runs | ✅ Sonar runs |
| Code task + `sonarqube.enabled: false` | ❌ Sonar skipped (the bug) | ✅ Sonar runs (config ignored, deprecation warning) |
| Non-code task (audit/doc/infra/...) | ✅ Skipped by policy | ✅ Skipped by policy |
| `--no-sonar` flag | Mutates `enabled = false` | Recorded as deprecated, ignored |
| Solomon runtime override | Already worked | Unchanged |

Sonar is now intrinsic to Karajan for code tasks, like TDD. The `sonarqube.enabled` config field and the `--no-sonar` flag are accepted (back-compat) but ignored, with a one-line deprecation warning emitted at run start.

## Why this matters

The user reported that `~/.karajan/kj.config.yml` had `sonarqube.enabled: false` set ages ago, so every code task ran with no quality gate, no static analysis, no enforcement. The opaque "Not applicable for current configuration" message in preflight made it impossible to spot. Sonar must be a contract, not a config knob.

## New architecture invariant

`tests/architecture/sonar-intrinsic.test.js` (5 cases) fails CI if any future change:

1. ANDs the preflight gate with `config.sonarqube?.enabled` (the v2.7.3 footgun).
2. Gates `runSonarStage` on `config.sonarqube.enabled` instead of `session.resolved_policies.sonar`.
3. Makes `--no-sonar` mutate `out.sonarqube.enabled` again.
4. Removes the deprecation tracking from `loadConfig`.
5. Changes the policy: code task types must require Sonar; non-code must skip it.

Read the test docstring before touching it.

## Test infrastructure

- `tests/setup.js` sets `__KJ_DISABLE_SONAR_STAGE = true` by default so non-sonar tests don't need to spin up Docker.
- 6 test files that legitimately exercise Sonar opt out per-test or per-describe via `globalThis.__KJ_DISABLE_SONAR_STAGE = false`. Consistent pattern across all of them. Same mechanism as `__KJ_DEFAULT_PREFLIGHT_EXTENDED`, `__KJ_DEFAULT_BRAIN_DECISOR`, etc.

## Tests

- 3 720 tests pass across 289 files. Lint clean.
- 5 new architectural cases.
- 1 rewritten test (`tests/checks/ports.test.js` — Sonar applies for any non-external config).
- 1 rewritten config test (`--no-sonar` records deprecation flag, doesn't mutate).
- 6 test files updated to opt-into the sonar stage where they need it.

## Test plan
- [ ] On a project with global `~/.karajan/kj.config.yml` containing `sonarqube.enabled: false`, run `kj run`. Expect a yellow `[config:deprecated]` warning at start, then full Sonar pipeline runs.
- [ ] `kj run --no-sonar "fix bug"`. Expect deprecation warning, Sonar still runs.
- [ ] `kj run --task-type doc "..."`. Expect Sonar SKIPPED (correct, by policy).