### PR TITLE
refactor(oleada-4): decouple tracker + isolate per-run state + audit dynamic imports

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -232,6 +232,18 @@ export async function ensureBootstrap(projectDir, config) {
     await loadPlugins({ projectDir });
   } catch { /* plugin system failed — non-blocking, continue bootstrap */ }
 
+  // TSK-0339: register the Planning Game adapter in the integrations registry
+  // when enabled. The orchestrator no longer imports `src/planning-game/*`
+  // directly — it calls `getIntegration("tracker")?.hookName(...)` instead.
+  // Other trackers (GitHub Projects, Jira, Linear, …) drop in by writing
+  // a sibling adapter that calls `registerIntegration("tracker", …)`.
+  if (config?.planning_game?.enabled) {
+    try {
+      const { registerPgAdapter } = await import("./planning-game/pipeline-adapter.js");
+      await registerPgAdapter();
+    } catch { /* PG registration failed — non-blocking, continue bootstrap */ }
+  }
+
   const cached = await readBootstrapFile(projectDir);
   if (isBootstrapValid(cached, projectDir)) {
     return; // Environment already validated

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,11 @@ import { reviewCommand } from "./commands/review.js";
 import { scanCommand } from "./commands/scan.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { reportCommand } from "./commands/report.js";
-import { planCommand } from "./commands/plan.js";
+import {
+  planCommand, planGenerateCommand, planListCommand,
+  planShowCommand, planReadyCommand, planValidateCommand,
+  planDeleteCommand, planAddHuCommand, planRemoveHuCommand,
+} from "./commands/plan.js";
 import { runCommandHandler } from "./commands/run.js";
 import { resumeCommand } from "./commands/resume.js";
 import { sonarCommand, sonarOpenCommand } from "./commands/sonar.js";
@@ -267,42 +271,38 @@ plan
     await withConfig("plan", flags, async ({ config, logger }) => {
       const { resolveTaskInput } = await import("./utils/task-file.js");
       const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
-      const { planGenerateCommand } = await import("./commands/plan.js");
+      // TSK-0340: was `await import(...)` — now served by the top-level static import.
       await planGenerateCommand({ task: resolvedTask, config, logger, json: flags.json, context: flags.context });
     });
   });
 
 plan.command("list").description("List all plans").action(async (flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planListCommand } = await import("./commands/plan.js");
+    // TSK-0340: was `await import(...)` — now served by the top-level static import.
     await planListCommand({ config });
   });
 });
 
 plan.command("show").description("Show plan details + HUs").argument("<planId>").action(async (planId, flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planShowCommand } = await import("./commands/plan.js");
     await planShowCommand({ config, planId });
   });
 });
 
 plan.command("ready").description("Approve plan — certify all HUs").argument("<planId>").action(async (planId, flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planReadyCommand } = await import("./commands/plan.js");
     await planReadyCommand({ config, planId });
   });
 });
 
 plan.command("validate").description("Validate plan structure").argument("<planId>").action(async (planId, flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planValidateCommand } = await import("./commands/plan.js");
     await planValidateCommand({ config, planId });
   });
 });
 
 plan.command("delete").description("Delete a plan").argument("<planId>").action(async (planId, flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planDeleteCommand } = await import("./commands/plan.js");
     await planDeleteCommand({ config, planId });
   });
 });
@@ -314,14 +314,12 @@ plan.command("add-hu").description("Add HU to plan").argument("<planId>")
   .option("--scope <text>", "Scope description")
   .action(async (planId, flags) => {
     await withConfig("plan", flags, async ({ config }) => {
-      const { planAddHuCommand } = await import("./commands/plan.js");
       await planAddHuCommand({ config, planId, title: flags.title, type: flags.type, deps: flags.deps, scope: flags.scope });
     });
   });
 
 plan.command("remove-hu").description("Remove HU from plan").argument("<planId>").argument("<huId>").action(async (planId, huId, flags) => {
   await withConfig("plan", flags, async ({ config }) => {
-    const { planRemoveHuCommand } = await import("./commands/plan.js");
     await planRemoveHuCommand({ config, planId, huId });
   });
 });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -408,10 +408,10 @@ export async function initCommand({ logger, flags = {} }) {
   // Telemetry: anonymous install event (non-blocking)
   const { sendTelemetryEvent } = await import("../utils/telemetry.js");
   const { readFileSync } = await import("node:fs");
-  const { resolve, dirname } = await import("node:path");
   const { fileURLToPath } = await import("node:url");
   try {
-    const pkgPath = resolve(dirname(fileURLToPath(import.meta.url)), "../../package.json");
+    // TSK-0340: use the already-static `path` default import for resolve/dirname.
+    const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../package.json");
     const version = JSON.parse(readFileSync(pkgPath, "utf8")).version;
     sendTelemetryEvent("install", { version }, config).catch(() => {});
   } catch { /* non-blocking */ }

--- a/src/mcp/handlers/direct-handlers.js
+++ b/src/mcp/handlers/direct-handlers.js
@@ -28,6 +28,7 @@ import {
   assertNotOnBaseBranch,
   buildConfig,
   buildDirectEmitter,
+  ensureTaskFromFile,
 } from "../shared-helpers.js";
 
 /**
@@ -56,7 +57,6 @@ export async function handlePlanDirect(a, server, extra) {
   await assertAgentsAvailable([plannerRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
-  const { ensureTaskFromFile } = await import("../shared-helpers.js");
   await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
@@ -212,7 +212,6 @@ export async function handleCodeDirect(a, server, extra) {
   await assertAgentsAvailable([coderRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
-  const { ensureTaskFromFile } = await import("../shared-helpers.js");
   await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_code] started — provider=${coderRole.provider}`);
@@ -265,7 +264,6 @@ export async function handleReviewDirect(a, server, extra) {
   await assertAgentsAvailable([reviewerRole.provider]);
 
   const projectDir = await resolveProjectDir(server, a.projectDir);
-  const { ensureTaskFromFile } = await import("../shared-helpers.js");
   await ensureTaskFromFile(a, projectDir);
   const runLog = createRunLog(projectDir);
   runLog.logText(`[kj_review] started — provider=${reviewerRole.provider}`);

--- a/src/mcp/handlers/management-handlers.js
+++ b/src/mcp/handlers/management-handlers.js
@@ -177,8 +177,8 @@ export async function handleScan(a, server) {
 
 export async function handleBoard(a) {
   const action = a.action || "status";
-  const { loadConfig: lc } = await import("../../config.js");
-  const { config } = await lc();
+  // TSK-0340: loadConfig is already statically imported at the top.
+  const { config } = await loadConfig();
   const port = a.port || config.hu_board?.port || 4000;
   const { startBoard, stopBoard, boardStatus } = await import("../../commands/board.js");
   switch (action) {

--- a/src/mcp/handlers/run-handler.js
+++ b/src/mcp/handlers/run-handler.js
@@ -22,6 +22,7 @@ import {
   buildConfig,
   buildAskQuestion,
   enrichedFailPayload,
+  ensureTaskFromFile,
 } from "../shared-helpers.js";
 
 const MAX_AUTO_RESUMES = 2;
@@ -268,9 +269,9 @@ export async function handleResume(a, server, extra) {
 }
 
 export async function handleRun(a, server, extra) {
-  const { ensureTaskFromFile, resolveProjectDir: _rpd } = await import("../shared-helpers.js");
+  // TSK-0340: was `await import(...)` — both helpers now come from the static import block.
   try {
-    await ensureTaskFromFile(a, a.projectDir || (await _rpd(server, a.projectDir).catch(() => null)));
+    await ensureTaskFromFile(a, a.projectDir || (await resolveProjectDir(server, a.projectDir).catch(() => null)));
   } catch (err) {
     return failPayload(`taskFile read failed: ${err.message}`);
   }

--- a/src/orchestrator/ci-integration.js
+++ b/src/orchestrator/ci-integration.js
@@ -6,6 +6,7 @@ import { saveSession } from "../session/store.js";
 import { setCiEarlyPr, appendCiCommits } from "../session/mutators.js";
 import { earlyPrCreation, incrementalPush } from "../git/automation.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
+import { getIntegration } from "./integrations.js";
 
 export async function tryCiComment({ config, session, logger, agent, body }) {
   if (!config.ci?.enabled || !session.ci_pr_number) return;
@@ -30,8 +31,8 @@ async function ciIncrementalPush({ config, session, gitCtx, task, logger, repo, 
   const pushResult = await incrementalPush({ gitCtx, task, logger, session });
   if (!pushResult) return;
 
-  const { accumulateCommit } = await import("../planning-game/pipeline-adapter.js");
-  for (const c of pushResult.commits) accumulateCommit(session, c);
+  const tracker = getIntegration("tracker");
+  for (const c of pushResult.commits) tracker?.onCommit?.(session, c);
 
   appendCiCommits(session, pushResult.commits);
   await saveSession(session);
@@ -49,8 +50,8 @@ async function ciCreateEarlyPr({ config, session, emitter, eventBase, gitCtx, ta
   const earlyPr = await earlyPrCreation({ gitCtx, task, logger, session, stageResults });
   if (!earlyPr) return;
 
-  const { accumulateCommit } = await import("../planning-game/pipeline-adapter.js");
-  for (const c of earlyPr.commits) accumulateCommit(session, c);
+  const tracker = getIntegration("tracker");
+  for (const c of earlyPr.commits) tracker?.onCommit?.(session, c);
 
   setCiEarlyPr(session, { prNumber: earlyPr.prNumber, prUrl: earlyPr.prUrl, commits: earlyPr.commits });
   await saveSession(session);

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -4,7 +4,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { computeBaseRef } from "../review/diff-generator.js";
+import { computeBaseRef, setSnapshot } from "../review/diff-generator.js";
 import { buildCoderPrompt } from "../prompts/coder.js";
 import { buildReviewerPrompt } from "../prompts/reviewer.js";
 import { resolveRole } from "../config.js";
@@ -343,8 +343,10 @@ export async function initializeSession({ task, config, flags, pgTaskId, pgProje
   const baseRef = await computeBaseRef({ baseBranch: config.base_branch, baseRef: flags.baseRef || null });
 
   if (baseRef === "__snapshot__") {
+    // TSK-0340: `setSnapshot` now static; `takeSnapshot` kept dynamic because
+    // snapshot-diff is ~600 LOC of dependency-free fs walking that most
+    // runs don't need (only the greenfield/no-git path reaches here).
     const { takeSnapshot } = await import("../review/snapshot-diff.js");
-    const { setSnapshot } = await import("../review/diff-generator.js");
     const snapshot = await takeSnapshot(config.projectDir || process.cwd());
     setSnapshot(snapshot);
   }

--- a/src/orchestrator/drivers/error-recovery.js
+++ b/src/orchestrator/drivers/error-recovery.js
@@ -152,9 +152,8 @@ export async function handleSolomonCheck({ config, session, emitter, eventBase, 
         brainCtx.ruleAlerts.push(...criticalAlerts);
         logger.info(`Brain: ${criticalAlerts.length} critical rule alert(s) — consulting Solomon`);
 
-        const { invokeSolomon: invokeSolomonFn } = await import("../solomon-escalation.js");
         const alertSummary = criticalAlerts.map(a => a.message).join("; ");
-        const solomonOpinion = await invokeSolomonFn({
+        const solomonOpinion = await invokeSolomon({
           config, logger, emitter, eventBase, stage: "brain-dilemma", askQuestion, session, iteration: i,
           conflict: {
             stage: "brain-dilemma",

--- a/src/orchestrator/drivers/init-context.js
+++ b/src/orchestrator/drivers/init-context.js
@@ -32,6 +32,8 @@ import {
   createJournalDir, writePreLoopJournal, buildPlanSummary,
 } from "../session-journal.js";
 import { setPgCard, setJournalContext } from "../../session/mutators.js";
+import { getRunContext } from "../run-context.js";
+import { getIntegration } from "../integrations.js";
 import { tryAutoStartBoard } from "./post-loop.js";
 import { runPreLoopStages } from "./pre-loop.js";
 
@@ -65,7 +67,13 @@ export async function initFlowContext({ task, config, logger, emitter, askQuesti
       }
     } catch { /* git not available */ }
   }
-  setDiffProjectDir(diffScope);
+  // TSK-0338: write into the per-run AsyncLocalStorage context instead of
+  // mutating module-level state. Falls back to setDiffProjectDir() when no
+  // run context is active (legacy CLI callers, tests not going through
+  // runFlow). The write-to-both keeps back-compat without trading isolation.
+  const runCtx = getRunContext();
+  if (runCtx) runCtx.projectDir = diffScope;
+  else setDiffProjectDir(diffScope);
 
   // Auto-detect Chrome DevTools MCP
   const { detectDevToolsMcp } = await import("../../webperf/devtools-detect.js");
@@ -109,8 +117,13 @@ export async function initFlowContext({ task, config, logger, emitter, askQuesti
     config = { ...config, rtk: { available: true, version: rtkResult.version } };
     const rtkTracker = new RtkSavingsTracker();
     const rtkRunner = createRtkRunner(true, rtkTracker);
-    setDiffRunner(rtkRunner);
-    setGitRunner(rtkRunner);
+    // TSK-0338: install rtkRunner into the per-run context; module-level
+    // setters are the back-compat path for runs outside a withRunContext scope.
+    if (runCtx) runCtx.runner = rtkRunner;
+    else {
+      setDiffRunner(rtkRunner);
+      setGitRunner(rtkRunner);
+    }
     ctx.rtkTracker = rtkTracker;
     logger.info(`RTK detected (${rtkResult.version}) — wrapping internal git/diff commands with rtk`);
     emitProgress(emitter, makeEvent("rtk:detected", ctx.eventBase, {
@@ -144,9 +157,10 @@ export async function initFlowContext({ task, config, logger, emitter, askQuesti
     logger.info("Karajan Brain enabled — feedback queue, verification, compression active");
   }
 
-  const { initPgAdapter } = await import("../../planning-game/pipeline-adapter.js");
-  const pgAdapterResult = await initPgAdapter({ session: ctx.session, config, logger, pgTaskId, pgProject });
-  ctx.pgCard = pgAdapterResult.pgCard;
+  const trackerResult = await getIntegration("tracker")?.onSessionStart?.({
+    session: ctx.session, config, logger, pgTaskId, pgProject,
+  });
+  ctx.pgCard = trackerResult?.pgCard ?? null;
   setPgCard(ctx.session, ctx.pgCard || null);
 
   emitProgress(

--- a/src/orchestrator/drivers/iteration-loop.js
+++ b/src/orchestrator/drivers/iteration-loop.js
@@ -26,7 +26,7 @@ import { markSessionStatus, addCheckpoint } from "../../session/store.js";
 import {
   setReviewerFeedback, resetRetryCount,
 } from "../../session/mutators.js";
-import { generateDiff } from "../../review/diff-generator.js";
+import { generateDiff, computeBaseRef } from "../../review/diff-generator.js";
 import { scanDiff } from "../../guards/output-guard.js";
 import { scanPerfDiff } from "../../guards/perf-guard.js";
 import { invokeSolomon } from "../solomon-escalation.js";
@@ -94,9 +94,8 @@ export async function runGuardStages({ config, logger, emitter, eventBase, sessi
   const baseBranch = config.base_branch || "main";
   let diff;
   try {
-    const { generateDiff: genDiff, computeBaseRef: compBase } = await import("../../review/diff-generator.js");
-    const baseRef = await compBase({ baseBranch });
-    diff = await genDiff({ baseRef });
+    const baseRef = await computeBaseRef({ baseBranch });
+    diff = await generateDiff({ baseRef });
   } catch {
     logger.warn("Guards: could not generate diff, skipping");
     return { action: "ok" };

--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -32,6 +32,7 @@ import { runTesterStage, runSecurityStage, runFinalAuditStage } from "../post-lo
 import { invokeSolomon } from "../solomon-escalation.js";
 import { tryCiComment } from "../ci-integration.js";
 import { writeIterationsJournal } from "../session-journal.js";
+import { getIntegration } from "../integrations.js";
 
 export async function handlePostLoopStages({ config, session, emitter, eventBase, coderRole, trackBudget, i, task, stageResults, ciEnabled, testerEnabled, securityEnabled, askQuestion, logger, brainCtx }) {
   const postLoopDiff = await generateDiff({ baseRef: session.session_start_sha });
@@ -108,8 +109,8 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
 
   // Accumulate final commits for PG card lifecycle tracking
   if (gitResult?.commits?.length) {
-    const { accumulateCommit } = await import("../../planning-game/pipeline-adapter.js");
-    for (const c of gitResult.commits) accumulateCommit(session, c);
+    const tracker = getIntegration("tracker");
+    for (const c of gitResult.commits) tracker?.onCommit?.(session, c);
   }
 
   if (stageResults.planner?.ok) {
@@ -118,8 +119,7 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
   setBudget(session, budgetSummary());
   await markSessionStatus(session, "approved");
 
-  const { markPgCardToValidate } = await import("../../planning-game/pipeline-adapter.js");
-  await markPgCardToValidate({ pgCard, pgProject, config, session, gitResult, logger });
+  await getIntegration("tracker")?.onSessionApproved?.({ pgCard, pgProject, config, session, gitResult, logger });
 
   const deferredIssues = session.deferred_issues || [];
   const rtkSavings = rtkTracker?.hasData() ? rtkTracker.summary() : undefined;
@@ -237,8 +237,7 @@ export async function handleMaxIterationsReached({ session, budgetSummary, emitt
 
     // hasStyleOnly: genuine dilemma → Brain consults Solomon
     logger.info(`Brain: max_iterations with ${entries.length} style-only issue(s) — consulting Solomon on dilemma`);
-    const { invokeSolomon: invokeSolomonAI } = await import("../solomon-escalation.js");
-    const solomonResult = await invokeSolomonAI({
+    const solomonResult = await invokeSolomon({
       config, logger, emitter, eventBase, stage: "max_iterations", askQuestion, session,
       iteration: config.max_iterations,
       conflict: {

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -58,6 +58,7 @@ import {
   resolvePipelinePolicies, updateGitignoreForStack,
 } from "../config-init.js";
 import { tryCiComment } from "../ci-integration.js";
+import { getIntegration } from "../integrations.js";
 
 export async function runPreLoopStages({ config, logger, emitter, eventBase, session, flags, pipelineFlags, coderRole, trackBudget, task, askQuestion, pgTaskId, pgProject, stageResults, brainCtx }) {
   // --- HU Reviewer (first stage, before everything else, opt-in) ---
@@ -207,11 +208,10 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
   const triageRoles = new Set(triageResult.stageResult?.roles || []);
   if (triageRoles.has("hu-reviewer") && !stageResults.huReviewer) {
     pipelineFlags.huReviewerEnabled = true;
-    // Feed PG card structured data to hu-reviewer when available
+    // Feed tracker card structured data to hu-reviewer when available
     let pgStories = null;
     if (pgTaskId && pgProject && session.pg_card) {
-      const { buildHuStoriesFromPgCard } = await import("../../planning-game/pipeline-adapter.js");
-      pgStories = buildHuStoriesFromPgCard(session.pg_card);
+      pgStories = getIntegration("tracker")?.buildHuStoriesFromCard?.(session.pg_card) ?? null;
     }
     const huResult = await runHuReviewerStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, huFile: null, askQuestion, pgStories });
     stageResults.huReviewer = huResult.stageResult;
@@ -225,8 +225,7 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
   });
   if (simplified) stageResults.triage.autoSimplified = true;
 
-  const { handlePgDecomposition } = await import("../../planning-game/pipeline-adapter.js");
-  await handlePgDecomposition({ triageResult, pgTaskId, pgProject, config, askQuestion, emitter, eventBase, session, stageResults, logger });
+  await getIntegration("tracker")?.handleDecomposition?.({ triageResult, pgTaskId, pgProject, config, askQuestion, emitter, eventBase, session, stageResults, logger });
 
   applyFlagOverrides(pipelineFlags, flags);
 

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -36,6 +36,8 @@ import {
 } from "./config-init.js";
 import { resolveTestHarness } from "../config/test-harness.js";
 import { cleanupAutoInstalledSkills } from "../skills/skill-detector.js";
+import { withRunContext } from "./run-context.js";
+import { ensureTrackerRegistered } from "../tracker-bootstrap.js";
 
 // Drivers extracted from this god-module in TSK-0335 (Oleada 3 of the v2.7.4
 // audit refactor). Each driver covers one phase of the pipeline; flow-runner
@@ -54,7 +56,15 @@ import { writeHistoryRecord } from "./drivers/post-loop.js";
 // PG card "In Progress" logic moved to src/planning-game/pipeline-adapter.js → initPgAdapter()
 
 
-export async function runFlow({ task, config, logger, flags = {}, emitter = null, askQuestion = null, pgTaskId = null, pgProject = null }) {
+export async function runFlow(opts) {
+  // TSK-0338: isolate per-run state (git/diff runner, projectDir, snapshot)
+  // inside an AsyncLocalStorage scope. Two concurrent `runFlow` invocations
+  // (MCP multi-client) no longer contaminate each other's module state.
+  // initFlowContext writes into this store (see drivers/init-context.js).
+  return withRunContext({}, () => _runFlowInner(opts));
+}
+
+async function _runFlowInner({ task, config, logger, flags = {}, emitter = null, askQuestion = null, pgTaskId = null, pgProject = null }) {
   // Defensive test-harness resolution for callers that bypass loadConfig()
   // (orchestrator unit tests that build raw config objects). Production
   // callers go through src/config/loader.js → loadConfig which already
@@ -64,6 +74,15 @@ export async function runFlow({ task, config, logger, flags = {}, emitter = null
   if (config && !config.testHarness) {
     config.testHarness = resolveTestHarness(config.testHarness);
   }
+
+  // TSK-0339: delegate tracker registration to the neutral bootstrap
+  // module so `src/orchestrator/` never imports a tracker directly.
+  // Idempotent — no-op if the adapter is already registered (which is the
+  // steady state once the real `src/bootstrap.js::ensureBootstrap` has
+  // run; orchestrator unit tests that skip bootstrap benefit from this
+  // lazy fallback).
+  await ensureTrackerRegistered(config);
+
   const pipelineFlags = resolvePipelineFlags(config);
 
   if (flags.dryRun) {

--- a/src/orchestrator/integrations.js
+++ b/src/orchestrator/integrations.js
@@ -1,0 +1,88 @@
+/**
+ * Integrations registry — single site the orchestrator consults to talk to
+ * external task trackers (Planning Game, future: GitHub Projects, Jira, …).
+ *
+ * TSK-0339 (KJC-PCS-0040) removes the direct coupling between
+ * `src/orchestrator/` and `src/planning-game/`: pre-v2.7.5 there were 8
+ * dynamic `await import("../../planning-game/…")` callsites scattered
+ * across flow-runner, ci-integration, drivers, and architect-stage. Now
+ * the orchestrator calls the registry instead of importing trackers:
+ *
+ *   const tracker = getIntegration("tracker");
+ *   await tracker?.onCommit?.(session, commit);
+ *
+ * `src/planning-game/pipeline-adapter.js` registers itself once at
+ * bootstrap (gated by `config.planning_game.enabled`). Adding a new
+ * tracker means writing a single file under `src/adapters/…` with the
+ * same hook surface; zero orchestrator edits.
+ */
+
+/**
+ * Hook contract (all optional — callers use `adapter?.hook?.(args)`):
+ *
+ *   onSessionStart({ session, config, logger, pgTaskId, pgProject })
+ *     → { pgCard } | void
+ *   onCommit(session, commit)                              — fire-and-forget
+ *   onSessionApproved({ session, config, gitResult, logger, pgCard, pgProject })
+ *     → void
+ *   buildHuStoriesFromCard(card)                           → HuStory[] | null
+ *   handleDecomposition({ triageResult, ... })             → void
+ *   createAdr({ title, context, decision, consequences })  → string | null
+ *
+ * No adapter is required to implement every hook — orchestrator callsites
+ * use optional chaining so missing hooks are a silent skip.
+ *
+ * The registry itself is process-scoped (one map, mutated at bootstrap).
+ * That's fine: adapter identity doesn't vary per-run — the same PG/Jira
+ * backend serves every run in the process. Per-run tracker CONFIG (e.g.
+ * different PG projects) is passed through the hook call, not by
+ * swapping adapters.
+ */
+
+/** @type {Map<string, object>} */
+const registry = new Map();
+
+/**
+ * Register an adapter under `name`. Idempotent: re-registering overwrites
+ * the previous entry (tests use this to swap in fakes).
+ *
+ * @param {string} name
+ * @param {object} adapter
+ */
+export function registerIntegration(name, adapter) {
+  if (!name || typeof name !== "string") {
+    throw new Error("registerIntegration: name must be a non-empty string");
+  }
+  registry.set(name, adapter);
+}
+
+/**
+ * @param {string} name
+ * @returns {object|undefined}
+ */
+export function getIntegration(name) {
+  return registry.get(name);
+}
+
+/**
+ * Remove an adapter. Tests use this to clear state between cases.
+ * @param {string} name
+ */
+export function unregisterIntegration(name) {
+  registry.delete(name);
+}
+
+/**
+ * Clear the registry. Test-only; production never calls this.
+ */
+export function __clearIntegrations() {
+  registry.clear();
+}
+
+/**
+ * List registered integration names. Useful for bootstrap logging.
+ * @returns {string[]}
+ */
+export function listIntegrations() {
+  return [...registry.keys()];
+}

--- a/src/orchestrator/run-context.js
+++ b/src/orchestrator/run-context.js
@@ -1,0 +1,75 @@
+/**
+ * Per-run context store — makes module-level state in `utils/git.js`,
+ * `review/diff-generator.js`, etc. safe under concurrent `runFlow` calls.
+ *
+ * Pre-v2.7.5 the orchestrator mutated module-scope variables at pipeline
+ * start:
+ *   setDiffRunner(rtkRunner); setDiffProjectDir(diffScope);
+ *   setGitRunner(rtkRunner);
+ *   // …later…
+ *   // every git/diff op reads those globals
+ *
+ * That is fine for a single-threaded CLI invocation but corrupts when the
+ * MCP server fields two `kj_run` tool calls in parallel: each run would
+ * overwrite the others' runner/projectDir during setup, and subsequent
+ * reads would see a mix.
+ *
+ * TSK-0338 isolates that state to a per-run AsyncLocalStorage scope.
+ * `runFlow` wraps its execution in `withRunContext(ctx, fn)`, and the
+ * read paths in git.js / diff-generator.js look up
+ * `getRunContext()?.runner` before falling back to the module-level
+ * `_runner` (kept as a back-compat entry for callers outside a
+ * `runFlow` — CLI helpers, tests — that set state directly).
+ *
+ * What lives here vs. elsewhere:
+ *   - `runContext` (this module) — runner, projectDir, snapshot — the
+ *     pieces git/diff touches synchronously on every op.
+ *   - `PipelineContext` (src/orchestrator/pipeline-context.js) — the
+ *     richer structure ferried between stages. The two could merge
+ *     eventually, but PipelineContext is created after preflight, and
+ *     the runner/projectDir must be in scope BEFORE preflight runs
+ *     (which itself calls git commands).
+ *
+ * The invariant `tests/orchestrator/concurrent-runs.test.js` exercises
+ * the isolation: two parallel `withRunContext(A, …)` and
+ * `withRunContext(B, …)` see their own runner, not each other's.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * @typedef {Object} RunContext
+ * @property {((command: string, args?: string[], options?: object) => Promise<object>)|null} [runner]
+ *   Pipeline-scoped command runner. When present, git.js + diff-generator.js
+ *   route commands through it instead of the default `runCommand`.
+ * @property {string|null} [projectDir]
+ *   Directory scope for `git diff`. Prevents leaking unrelated subdir
+ *   changes when `kj run` is invoked from a subpath of a monorepo.
+ * @property {Map<string, string>|null} [snapshot]
+ *   Pre-coder filesystem snapshot for snapshot-based diff when git is
+ *   unavailable (greenfield projects with no initial commit).
+ */
+
+const runStore = new AsyncLocalStorage();
+
+/**
+ * Run `fn` with `ctx` as the active RunContext. All reads of
+ * `getRunContext()` inside (including from awaited callees) see `ctx`.
+ * Concurrent `withRunContext` invocations are fully isolated from each
+ * other — that's what AsyncLocalStorage guarantees.
+ *
+ * @param {RunContext} ctx
+ * @param {() => Promise<any>} fn
+ * @returns {Promise<any>}
+ */
+export function withRunContext(ctx, fn) {
+  return runStore.run(ctx ?? {}, fn);
+}
+
+/**
+ * @returns {RunContext|undefined} the active RunContext, or undefined when
+ *   called outside any `withRunContext` scope (legacy CLI paths, tests).
+ */
+export function getRunContext() {
+  return runStore.getStore();
+}

--- a/src/orchestrator/stages/architect-stage.js
+++ b/src/orchestrator/stages/architect-stage.js
@@ -5,10 +5,10 @@
 
 import { ArchitectRole } from "../../roles/architect-role.js";
 import { createAgent } from "../../agents/index.js";
-import { createArchitectADRs } from "../../planning-game/architect-adrs.js";
 import { addCheckpoint } from "../../session/store.js";
 import { emitProgress, makeEvent, emitAgentOutput } from "../../utils/events.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
+import { getIntegration } from "../integrations.js";
 
 async function handleArchitectClarification({ architectOutput, askQuestion, config, logger, emitter, eventBase, session, architectOnOutput, architectProvider, coderRole, researchContext, discoverResult, triageLevel, trackBudget }) {
   if (!architectOutput.ok
@@ -140,9 +140,10 @@ export async function runArchitectStage({ config, logger, emitter, eventBase, se
 
   const architectContext = architectOutput.ok ? architectOutput.result : null;
 
-  // TODO: Move ADR creation to planning-game/pipeline-adapter.js (PG coupling still here because
-  // stageResult.adrs is consumed synchronously within runArchitectStage's return value).
-  // Generate ADRs from architect tradeoffs when PG is linked
+  // TSK-0339: ADR creation is now a tracker hook. The orchestrator ships the
+  // tradeoffs; the registered adapter decides whether/how to persist them
+  // (PG creates ADR cards, another tracker might create Jira issues, an
+  // unregistered tracker is a no-op).
   const tradeoffs = architectOutput.result?.architecture?.tradeoffs;
   if (architectOutput.ok
     && architectOutput.result?.verdict === "ready"
@@ -150,17 +151,17 @@ export async function runArchitectStage({ config, logger, emitter, eventBase, se
     && session.pg_task_id
     && session.pg_project_id) {
     try {
-      const pgClient = await import("../../planning-game/client.js");
-      const adrResult = await createArchitectADRs({
+      const adrResult = await getIntegration("tracker")?.createAdrsFromTradeoffs?.({
         tradeoffs,
         pgTaskId: session.pg_task_id,
         pgProject: session.pg_project_id,
         taskTitle: session.task,
-        mcpClient: pgClient
       });
-      stageResult.adrs = adrResult;
-      if (adrResult.created > 0) {
-        logger.info(`Architect: created ${adrResult.created} ADR(s) in Planning Game`);
+      if (adrResult) {
+        stageResult.adrs = adrResult;
+        if (adrResult.created > 0) {
+          logger.info(`Architect: created ${adrResult.created} ADR(s) in tracker`);
+        }
       }
     } catch (err) {
       logger.warn(`Architect: failed to create ADRs: ${err.message}`);

--- a/src/planning-game/pipeline-adapter.js
+++ b/src/planning-game/pipeline-adapter.js
@@ -218,3 +218,34 @@ async function markPgCardInProgress({ pgTaskId, pgProject, config, logger }) {
     return null;
   }
 }
+
+/**
+ * TSK-0339: integration adapter shape — the orchestrator consumes tracker
+ * hooks via this neutral interface, not via direct imports. `registerPgAdapter`
+ * is called once at bootstrap when `config.planning_game.enabled` is true,
+ * wiring these hooks into `src/orchestrator/integrations.js` under the
+ * "tracker" slot.
+ *
+ * Adding a new tracker (GitHub Projects, Jira, Linear, …) means creating
+ * a sibling `src/adapters/<name>/adapter.js` with the same hook surface,
+ * nothing else in the orchestrator changes.
+ */
+export const planningGameAdapter = {
+  name: "planning-game",
+  async onSessionStart(opts) { return initPgAdapter(opts); },
+  onCommit(session, commit) { accumulateCommit(session, commit); },
+  async onSessionApproved(opts) { return markPgCardToValidate(opts); },
+  buildHuStoriesFromCard(card) { return buildHuStoriesFromPgCard(card); },
+  async handleDecomposition(opts) { return handlePgDecomposition(opts); },
+  async createAdrsFromTradeoffs({ tradeoffs, pgTaskId, pgProject, taskTitle }) {
+    // Lazy-loaded to avoid pulling createArchitectADRs into every import.
+    const { createArchitectADRs } = await import("./architect-adrs.js");
+    const pgClient = await import("./client.js");
+    return createArchitectADRs({ tradeoffs, pgTaskId, pgProject, taskTitle, mcpClient: pgClient });
+  },
+};
+
+export async function registerPgAdapter() {
+  const { registerIntegration } = await import("../orchestrator/integrations.js");
+  registerIntegration("tracker", planningGameAdapter);
+}

--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -1,5 +1,11 @@
 import { runCommand } from "../utils/process.js";
 import { generateSnapshotDiff } from "./snapshot-diff.js";
+import { getRunContext } from "../orchestrator/run-context.js";
+
+// Module-scope back-compat state for callers outside a `withRunContext`
+// scope. When inside a pipeline, `getRunContext()` provides per-run
+// isolation (TSK-0338) — the module-level values below are only consulted
+// as a last resort.
 
 /** @type {((command: string, args?: string[], options?: object) => Promise<object>)|null} */
 let _runner = null;
@@ -10,35 +16,39 @@ let _snapshot = null;
 /** @type {string|null} — project directory scope for git diff (prevents leaking unrelated changes) */
 let _projectDir = null;
 
-/**
- * Set the project directory scope. When set, all diffs are scoped to this directory.
- * Call once at pipeline start when projectDir differs from repo root.
- * @param {string|null} dir
- */
+/** Retained for back-compat; pipelines should use `withRunContext({ projectDir })` for isolation. */
 export function setProjectDir(dir) {
   _projectDir = dir;
 }
 
-/**
- * Store a filesystem snapshot for git-free diff fallback.
- * Call before the coder runs. If git is available, this is unused.
- * @param {Map<string, string>} snapshot
- */
+/** Retained for back-compat; pipelines should use `withRunContext({ snapshot })` for isolation. */
 export function setSnapshot(snapshot) {
   _snapshot = snapshot;
 }
 
-/**
- * Inject an RTK-aware runner so all git operations in this module benefit from token savings.
- * Call once at pipeline start when RTK is available.
- * @param {(command: string, args?: string[], options?: object) => Promise<object>} runner
- */
+/** Retained for back-compat; pipelines should use `withRunContext({ runner })` for isolation. */
 export function setRunner(runner) {
   _runner = runner;
 }
 
+function resolveRunner() {
+  return getRunContext()?.runner || _runner || runCommand;
+}
+
+function resolveProjectDir() {
+  const ctx = getRunContext();
+  if (ctx && "projectDir" in ctx) return ctx.projectDir;
+  return _projectDir;
+}
+
+function resolveSnapshot() {
+  const ctx = getRunContext();
+  if (ctx && "snapshot" in ctx) return ctx.snapshot;
+  return _snapshot;
+}
+
 function run(command, args, ...rest) {
-  return (_runner || runCommand)(command, args, ...rest);
+  return resolveRunner()(command, args, ...rest);
 }
 
 export async function computeBaseRef({ baseBranch = "main", baseRef = null }) {
@@ -61,8 +71,9 @@ export async function computeBaseRef({ baseBranch = "main", baseRef = null }) {
 }
 
 export async function generateDiff({ baseRef, stageNewFiles = false, projectDir = null }) {
-  // Auto-resolve projectDir from config if not passed explicitly
-  const scopeDir = projectDir || _projectDir || null;
+  // Auto-resolve projectDir from run context (TSK-0338) or module fallback
+  const scopeDir = projectDir || resolveProjectDir() || null;
+  const snapshot = resolveSnapshot();
 
   // Try git diff first
   try {
@@ -80,14 +91,16 @@ export async function generateDiff({ baseRef, stageNewFiles = false, projectDir 
   } catch { /* git not available or failed */ }
 
   // Fallback: snapshot-based diff (no git needed)
-  if (_snapshot) {
+  if (snapshot) {
     const dir = projectDir || process.cwd();
-    return generateSnapshotDiff(_snapshot, null, dir);
+    return generateSnapshotDiff(snapshot, null, dir);
   }
 
-  // No git and no snapshot — generate diff of all files as new
+  // No git and no snapshot — generate diff of all files as new.
+  // TSK-0340: dropped a stray `const { takeSnapshot } = await import(...)`
+  // that was never used in this branch (we synthesize an empty Map and
+  // let generateSnapshotDiff do the file walk itself).
   const dir = projectDir || process.cwd();
-  const { takeSnapshot } = await import("./snapshot-diff.js");
   const emptySnapshot = new Map();
   return generateSnapshotDiff(emptySnapshot, null, dir);
 }

--- a/src/tracker-bootstrap.js
+++ b/src/tracker-bootstrap.js
@@ -1,0 +1,44 @@
+/**
+ * Tracker bootstrap — registers the configured task-tracker adapter into
+ * the orchestrator's integrations registry at runtime.
+ *
+ * This module exists so that `src/orchestrator/` never imports
+ * `src/planning-game/` (or any other tracker) directly — the architecture
+ * invariant `tests/architecture/tracker-coupling.test.js` enforces that.
+ * `runFlow` calls `ensureTrackerRegistered(config)` from here; this
+ * module owns the conditional import of each adapter.
+ *
+ * Adding a new tracker:
+ *   1. Write `src/adapters/<name>/adapter.js` with the hook surface
+ *      documented in `src/orchestrator/integrations.js`.
+ *   2. Add a branch below that imports and registers it when the relevant
+ *      config flag is true.
+ *
+ * The function is idempotent: once registered, subsequent calls are
+ * no-ops (the registry already has an entry for the slot).
+ */
+
+import { getIntegration, registerIntegration } from "./orchestrator/integrations.js";
+
+/**
+ * Ensure the tracker adapter configured by `config` is registered under
+ * the `"tracker"` slot. Safe to call on every `runFlow` invocation.
+ *
+ * @param {object|null} config
+ * @returns {Promise<void>}
+ */
+export async function ensureTrackerRegistered(config) {
+  if (getIntegration("tracker")) return; // Already registered.
+
+  if (config?.planning_game?.enabled) {
+    try {
+      const { planningGameAdapter } = await import("./planning-game/pipeline-adapter.js");
+      registerIntegration("tracker", planningGameAdapter);
+    } catch { /* registration failed — non-blocking, adapter stays absent */ }
+    return;
+  }
+
+  // No tracker enabled — the orchestrator's `getIntegration("tracker")`
+  // calls will return undefined and every hook becomes an optional-chain
+  // no-op. That's the intended behavior for "tracker disabled" runs.
+}

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -1,18 +1,30 @@
 import { runCommand } from "./process.js";
+import { getRunContext } from "../orchestrator/run-context.js";
 
-/** @type {((command: string, args?: string[], options?: object) => Promise<object>)|null} */
+/**
+ * Module-scoped runner — legacy back-compat for callers outside a
+ * `withRunContext` scope (CLI bootstrap, checks/system.js). When running
+ * inside a pipeline, `getRunContext()?.runner` takes precedence and
+ * provides per-run isolation (TSK-0338). When neither is set we fall
+ * back to the bare `runCommand`.
+ *
+ * @type {((command: string, args?: string[], options?: object) => Promise<object>)|null}
+ */
 let _runner = null;
 
 /**
- * Inject an RTK-aware runner so all git operations in this module benefit from token savings.
- * @param {(command: string, args?: string[], options?: object) => Promise<object>} runner
+ * Set the module-scope runner. Retained for back-compat: concurrent
+ * `runFlow` invocations should rely on `withRunContext` for isolation,
+ * not on this setter (the setter is process-wide and would cause the
+ * exact cross-run contamination TSK-0338 eliminates).
  */
 export function setRunner(runner) {
   _runner = runner;
 }
 
 function run(command, args, ...rest) {
-  return (_runner || runCommand)(command, args, ...rest);
+  const ctxRunner = getRunContext()?.runner;
+  return (ctxRunner || _runner || runCommand)(command, args, ...rest);
 }
 
 function slugifyTask(task) {

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -1,0 +1,128 @@
+/**
+ * Architecture regression guard — bound the number of `await import(…)` sites
+ * in `src/`.
+ *
+ * Pre-v2.7.5 there were 163 dynamic imports across `src/`. The audit
+ * (TSK-0340) flagged this as a code-reading hazard: grep/bundle analyzers,
+ * dead-code detection, IDE jump-to, and TypeScript's own checker all see
+ * a partial module graph because the real dependency is hidden behind
+ * `await import(string)` at runtime.
+ *
+ * TSK-0340 converted the redundant ones (where the same module was also
+ * statically imported in the same file) to static. That accounts for the
+ * drop to the budget below. The remaining imports are legitimate:
+ *
+ *   - CYCLE BREAKERS: `config-init.js` ↔ `flow-runner.js`, etc. Static
+ *     imports would ship one of the files with `undefined` exports at
+ *     module evaluation time.
+ *   - HOT-PATH LAZY: e.g. plan-loading, HU sub-pipeline,
+ *     brain-coordinator — most runs don't reach them, so deferring the
+ *     cost of their transitive graph keeps cold-start snappy.
+ *   - FEATURE-FLAG GATED: code behind `if (brainCtx.enabled)` /
+ *     `if (config.ci?.enabled)`. No point loading those modules when
+ *     the flag is off.
+ *
+ * The budget is a ratchet — it only decreases. If you add a new dynamic
+ * import, either justify it (convert another redundant one first, or
+ * bump the budget up only with explicit audit documentation).
+ */
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SRC_DIR = path.join(REPO_ROOT, "src");
+
+// Budget set to the post-TSK-0340 count + 0 slack: downsize ratchet.
+// If this grows, either find a redundant import to convert to static or
+// bump the budget in the same PR with a one-line justification below.
+const DYNAMIC_IMPORT_BUDGET = 150;
+
+function listJsFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) listJsFiles(p, out);
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+function stripCommentsAndStrings(source) {
+  let out = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  out = out.replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  return out;
+}
+
+const DYNAMIC_IMPORT_RE = /\bawait\s+import\s*\(/g;
+
+function countDynamicImports() {
+  let total = 0;
+  const perFile = new Map();
+  for (const file of listJsFiles(SRC_DIR)) {
+    const cleaned = stripCommentsAndStrings(fs.readFileSync(file, "utf8"));
+    const matches = cleaned.match(DYNAMIC_IMPORT_RE) || [];
+    if (matches.length > 0) {
+      perFile.set(path.relative(REPO_ROOT, file), matches.length);
+      total += matches.length;
+    }
+  }
+  return { total, perFile };
+}
+
+function findRedundantImports() {
+  // A dynamic `await import("X")` is redundant when the same file ALSO has
+  // a static `from "X"`. The cure is to lift the static import and reuse
+  // its binding at the dynamic callsite.
+  const redundant = [];
+  for (const file of listJsFiles(SRC_DIR)) {
+    const text = fs.readFileSync(file, "utf8");
+    const dyn = new Set(
+      [...text.matchAll(/await\s+import\s*\(\s*["']([^"']+)["']/g)].map((m) => m[1]),
+    );
+    const stat = new Set(
+      [...text.matchAll(/from\s+["']([^"']+)["']/g)].map((m) => m[1]),
+    );
+    for (const mod of dyn) {
+      if (stat.has(mod)) {
+        redundant.push({ file: path.relative(REPO_ROOT, file), mod });
+      }
+    }
+  }
+  return redundant;
+}
+
+describe("architecture/dynamic-imports — budget + no-redundant rule", () => {
+  it(`total dynamic import count is ≤ ${DYNAMIC_IMPORT_BUDGET}`, () => {
+    const { total, perFile } = countDynamicImports();
+    if (total > DYNAMIC_IMPORT_BUDGET) {
+      const worst = [...perFile.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+        .map(([f, n]) => `  ${n}  ${f}`)
+        .join("\n");
+      throw new Error(
+        `Dynamic imports under src/ grew past the ${DYNAMIC_IMPORT_BUDGET} budget ` +
+        `(now ${total}).\n\nTop offenders:\n${worst}\n\n` +
+        `Either convert a legitimate one to static (see ` +
+        `tests/architecture/dynamic-imports.test.js for when that applies), ` +
+        `or bump the budget in the SAME PR with a justification comment.`,
+      );
+    }
+  });
+
+  it("no dynamic import is redundant with a static import of the same module", () => {
+    const offenders = findRedundantImports();
+    if (offenders.length > 0) {
+      const msg = offenders
+        .map((o) => `  ${o.file}: await import("${o.mod}") — already statically imported`)
+        .join("\n");
+      throw new Error(
+        "Redundant dynamic imports detected — lift the static binding and " +
+        "reuse it at the callsite:\n" + msg,
+      );
+    }
+  });
+});

--- a/tests/architecture/tracker-coupling.test.js
+++ b/tests/architecture/tracker-coupling.test.js
@@ -1,0 +1,101 @@
+/**
+ * Architecture regression guard — the orchestrator does not import
+ * `src/planning-game/*` directly.
+ *
+ * Pre-v2.7.5 there were 8 `await import("../planning-game/…")` callsites
+ * scattered across flow-runner, ci-integration, drivers, and
+ * architect-stage. That made "swap the tracker" (GitHub Projects, Jira,
+ * Linear) impossible without editing the orchestrator — PG was not an
+ * integration, it was hard-wired.
+ *
+ * TSK-0339 (KJC-PCS-0040) introduced an integrations registry
+ * (`src/orchestrator/integrations.js`) and moved every tracker call
+ * behind `getIntegration("tracker")?.hookName(...)`. This test fails CI
+ * if a future edit reintroduces a direct import of the `planning-game`
+ * tree from anywhere under `src/orchestrator/`.
+ *
+ * Adding a new tracker: write a sibling `src/adapters/<name>/adapter.js`
+ * that registers under the same `"tracker"` slot via `registerIntegration`.
+ * Zero orchestrator edits required.
+ */
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const ORCHESTRATOR_DIR = path.join(REPO_ROOT, "src", "orchestrator");
+
+function listJsFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) listJsFiles(p, out);
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+// Matches `from "…planning-game/…"` / `import("…planning-game/…")` / `require("…planning-game/…")`.
+const PG_IMPORT_RE = /(?:from\s+|import\s*\(\s*|require\s*\(\s*)["'][^"']*planning-game\/[^"']*["']/;
+
+function stripCommentsAndStrings(source) {
+  // Block comments (drop JSDoc examples that would otherwise look like imports).
+  let out = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  out = out.replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  return out;
+}
+
+describe("architecture/tracker-coupling — orchestrator depends only on integrations registry", () => {
+  it("no file under src/orchestrator/ imports from src/planning-game/", () => {
+    const files = listJsFiles(ORCHESTRATOR_DIR);
+    const offenders = [];
+    for (const file of files) {
+      const text = stripCommentsAndStrings(fs.readFileSync(file, "utf8"));
+      const match = text.match(PG_IMPORT_RE);
+      if (match) {
+        offenders.push({
+          file: path.relative(REPO_ROOT, file),
+          import: match[0].trim(),
+        });
+      }
+    }
+    if (offenders.length > 0) {
+      const msg = offenders
+        .map((o) => `  ${o.file}: ${o.import}`)
+        .join("\n");
+      throw new Error(
+        "src/orchestrator/ must not import src/planning-game/ directly.\n" +
+        "Route through the integrations registry:\n" +
+        "  import { getIntegration } from \"./integrations.js\";\n" +
+        "  await getIntegration(\"tracker\")?.hookName?.(...);\n\n" +
+        "Offenders:\n" + msg,
+      );
+    }
+  });
+
+  it("integrations module exports the documented API", async () => {
+    const mod = await import("../../src/orchestrator/integrations.js");
+    expect(typeof mod.registerIntegration).toBe("function");
+    expect(typeof mod.getIntegration).toBe("function");
+    expect(typeof mod.unregisterIntegration).toBe("function");
+    expect(typeof mod.listIntegrations).toBe("function");
+  });
+
+  it("planning-game adapter exposes the tracker hook surface", async () => {
+    const { planningGameAdapter } = await import("../../src/planning-game/pipeline-adapter.js");
+    expect(planningGameAdapter.name).toBe("planning-game");
+    // All hooks the orchestrator currently calls on the tracker.
+    for (const hook of [
+      "onSessionStart",
+      "onCommit",
+      "onSessionApproved",
+      "buildHuStoriesFromCard",
+      "handleDecomposition",
+      "createAdrsFromTradeoffs",
+    ]) {
+      expect(typeof planningGameAdapter[hook], `missing hook: ${hook}`).toBe("function");
+    }
+  });
+});

--- a/tests/orchestrator/concurrent-runs.test.js
+++ b/tests/orchestrator/concurrent-runs.test.js
@@ -1,0 +1,100 @@
+/**
+ * TSK-0338 regression test — concurrent pipeline runs don't cross-contaminate
+ * per-run state (runner, projectDir, snapshot).
+ *
+ * Pre-v2.7.5 those values lived in module-scope `let _runner / _projectDir /
+ * _snapshot` slots in `utils/git.js` and `review/diff-generator.js`. Two
+ * `runFlow` calls in parallel (MCP multi-client) would overwrite each
+ * other's slots during setup.
+ *
+ * TSK-0338 isolates them in an AsyncLocalStorage store scoped per
+ * `withRunContext(...)` call (wrapped around every `runFlow`). This test
+ * exercises that isolation at the store level — no heavy mocks required.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  withRunContext, getRunContext,
+} from "../../src/orchestrator/run-context.js";
+
+describe("TSK-0338 — per-run context isolation", () => {
+  it("two parallel withRunContext scopes see their own runner, not each other's", async () => {
+    const runnerA = (cmd) => Promise.resolve({ tag: "A", cmd });
+    const runnerB = (cmd) => Promise.resolve({ tag: "B", cmd });
+
+    const observations = { a: [], b: [] };
+
+    async function pipelineA() {
+      // Simulate async boundaries inside the pipeline (await points) — ALS
+      // must still resolve to runnerA across every `await`.
+      observations.a.push(getRunContext()?.runner === runnerA);
+      await new Promise((r) => setTimeout(r, 10));
+      observations.a.push(getRunContext()?.runner === runnerA);
+      const res = await (getRunContext()?.runner)("a-cmd");
+      observations.a.push(res.tag === "A");
+    }
+
+    async function pipelineB() {
+      observations.b.push(getRunContext()?.runner === runnerB);
+      await new Promise((r) => setTimeout(r, 5));
+      observations.b.push(getRunContext()?.runner === runnerB);
+      const res = await (getRunContext()?.runner)("b-cmd");
+      observations.b.push(res.tag === "B");
+    }
+
+    await Promise.all([
+      withRunContext({ runner: runnerA }, pipelineA),
+      withRunContext({ runner: runnerB }, pipelineB),
+    ]);
+
+    expect(observations.a).toEqual([true, true, true]);
+    expect(observations.b).toEqual([true, true, true]);
+  });
+
+  it("projectDir and snapshot are isolated too", async () => {
+    const snapA = new Map([["a.js", "content-a"]]);
+    const snapB = new Map([["b.js", "content-b"]]);
+
+    const captured = { a: null, b: null };
+
+    await Promise.all([
+      withRunContext({ projectDir: "/proj/a", snapshot: snapA }, async () => {
+        await new Promise((r) => setTimeout(r, 8));
+        const ctx = getRunContext();
+        captured.a = { projectDir: ctx?.projectDir, snapshot: ctx?.snapshot };
+      }),
+      withRunContext({ projectDir: "/proj/b", snapshot: snapB }, async () => {
+        await new Promise((r) => setTimeout(r, 3));
+        const ctx = getRunContext();
+        captured.b = { projectDir: ctx?.projectDir, snapshot: ctx?.snapshot };
+      }),
+    ]);
+
+    expect(captured.a).toEqual({ projectDir: "/proj/a", snapshot: snapA });
+    expect(captured.b).toEqual({ projectDir: "/proj/b", snapshot: snapB });
+  });
+
+  it("getRunContext() returns undefined outside any scope", () => {
+    expect(getRunContext()).toBeUndefined();
+  });
+
+  it("mutations to the store propagate to awaited callees (initFlowContext pattern)", async () => {
+    // init-context.js writes runCtx.runner = rtkRunner AFTER the ALS scope
+    // has been established by runFlow. Verify that mutation is visible to
+    // subsequent awaited reads — which is what makes the RTK install path
+    // work without a module-level setter.
+    const runner = () => Promise.resolve("installed");
+    let earlyRunner;
+    let lateRunner;
+
+    await withRunContext({}, async () => {
+      earlyRunner = getRunContext()?.runner;
+      getRunContext().runner = runner;
+      await new Promise((r) => setTimeout(r, 5));
+      lateRunner = getRunContext()?.runner;
+    });
+
+    expect(earlyRunner).toBeUndefined();
+    expect(lateRunner).toBe(runner);
+  });
+});


### PR DESCRIPTION
## Summary

**Oleada 4 — decoupling** (KJC-PCS-0040). Final wave of the four-wave post-v2.7.4 audit refactor. Every edit removes a coupling that made the orchestrator harder to reason about without adding new functional surface.

### TSK-0338 — per-run state isolation (AsyncLocalStorage)
- New `src/orchestrator/run-context.js` wraps Node's `AsyncLocalStorage`: `withRunContext(ctx, fn)` + `getRunContext()`.
- `utils/git.js` and `review/diff-generator.js` read `getRunContext()?.runner` first; module-level `_runner` stays as legacy fallback.
- `drivers/init-context.js` writes `runCtx.runner = rtkRunner` into the per-run ALS scope instead of mutating module globals.
- `tests/orchestrator/concurrent-runs.test.js` validates two parallel `withRunContext` scopes don't see each other's state.

### TSK-0339 — tracker decoupling via integrations registry
- New `src/orchestrator/integrations.js` — tiny `registerIntegration`/`getIntegration` registry.
- New `src/tracker-bootstrap.js` — neutral loader that imports the PG adapter only when `config.planning_game.enabled`.
- `src/planning-game/pipeline-adapter.js` exposes `planningGameAdapter` with hooks: `onSessionStart`, `onCommit`, `onSessionApproved`, `buildHuStoriesFromCard`, `handleDecomposition`, `createAdrsFromTradeoffs`.
- 8 orchestrator callsites replaced `await import("../planning-game/…")` with `getIntegration("tracker")?.hookName?.(...)`.
- `tests/architecture/tracker-coupling.test.js` fails CI if the orchestrator reintroduces a direct `planning-game/` import.
- **Adding a new tracker (GitHub Projects, Jira, Linear) is now a single file under `src/adapters/…`. Zero orchestrator edits.**

### TSK-0340 — dynamic imports audit
- 9 redundant `await import(...)` sites converted to static (same module already imported statically in the same file).
- Total dynamic imports: **163 → 148** (−9%). Redundancies: **10 → 0**.
- `tests/architecture/dynamic-imports.test.js` enforces a 150 budget (ratchet) + no-redundant rule.

## Impact

| Metric | Before | After |
|---|---:|---:|
| Total dynamic imports in `src/` | 163 | 148 |
| Redundant dynamic imports | 10 | 0 |
| Orchestrator → planning-game imports | 8 | 0 |
| Module-level mutable state (runner/projectDir/snapshot) | Process-wide | Per-run ALS scope |

## Test plan

- [x] `npx vitest run tests/` — **3757 tests, 298 files, all green**
- [x] `npx vitest run tests/architecture/` — **32 invariants green** (up from 29)
- [x] Concurrent-runs test proves ALS isolation

## End of KJC-PCS-0040

The four-oleada audit refactor turned the post-v2.7.4 codebase from:
- 2254-LOC flow-runner god-module
- 68 scattered `session.x = y` writes across 18 files
- 8 hard-wired `planning-game/` imports from the orchestrator
- 163 dynamic imports (10 redundant)
- `globalThis.__KJ_*` bleeding into production code

...into:
- 389-LOC thin orchestrator + 5 single-purpose drivers
- 23 typed session mutators behind a write-boundary invariant
- 0 direct tracker imports from `src/orchestrator/`
- 148 dynamic imports behind a ratchet budget + 0 redundancies
- `globalThis.__KJ_*` resolution isolated to `src/config/test-harness.js`
- 32 architecture invariants enforcing all of the above