### PR TITLE
fix(agents): parse Claude 2.x --output-format json array payload

### DIFF
--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -72,10 +72,10 @@ function collectAssistantText(obj) {
  * Returns an object with tokens_in, tokens_out, cost_usd, model or null if not found.
  */
 function extractUsageFromStreamJson(raw) {
-  const lines = (raw || "").split("\n").filter(Boolean);
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const obj = tryParseJson(lines[i]);
-    if (!obj || obj.type !== "result") continue;
+  const events = parseClaudeEvents(raw);
+  for (let i = events.length - 1; i >= 0; i--) {
+    const obj = events[i];
+    if (obj.type !== "result") continue;
 
     const tokens_in = obj.usage?.input_tokens ?? 0;
     const tokens_out = obj.usage?.output_tokens ?? 0;
@@ -89,25 +89,54 @@ function extractUsageFromStreamJson(raw) {
 }
 
 /**
- * Extract the final text result from stream-json NDJSON output.
- * Each line is a JSON object. We collect assistant text content from
- * "result" messages and fall back to accumulating "content_block_delta" text.
+ * Normalize Claude's output payload to a flat array of event objects.
+ *
+ * Claude 2.x supports two on-disk shapes depending on the output-format flag:
+ *
+ *   --output-format stream-json → NDJSON, one event JSON per line
+ *   --output-format json        → a single JSON array with every event
+ *
+ * The legacy path assumed NDJSON and silently dropped the `json` variant
+ * (split("\n") returned one unparseable "line" containing the whole array,
+ * extract returned empty, caller fell back to the raw string — which made
+ * `kj plan` save the whole stream as `approach` with zero HUs). Handle both
+ * shapes here so callers see a uniform list of events regardless of flag.
+ */
+function parseClaudeEvents(raw) {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) return [];
+  // `--output-format json` → single JSON array.
+  if (trimmed.startsWith("[")) {
+    try {
+      const arr = JSON.parse(trimmed);
+      if (Array.isArray(arr)) return arr.filter((o) => o && typeof o === "object");
+    } catch { /* fall through to NDJSON */ }
+  }
+  // `--output-format stream-json` → NDJSON, one event per line.
+  const events = [];
+  for (const line of trimmed.split("\n")) {
+    const obj = tryParseJson(line);
+    if (obj && typeof obj === "object") events.push(obj);
+  }
+  return events;
+}
+
+/**
+ * Extract the final text result from Claude's output (either stream-json
+ * NDJSON or single-array json — see parseClaudeEvents). We look for the
+ * `result` message first (holds the final text); if missing, concatenate
+ * every assistant text block encountered.
  */
 function extractTextFromStreamJson(raw) {
-  const lines = (raw || "").split("\n").filter(Boolean);
-  // Try to find a "result" message with the final text
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const obj = tryParseJson(lines[i]);
-    if (!obj) continue;
-    const result = extractResultText(obj);
+  const events = parseClaudeEvents(raw);
+  // Walk from the end — the final `result` event is the last one.
+  for (let i = events.length - 1; i >= 0; i--) {
+    const result = extractResultText(events[i]);
     if (result) return result;
   }
-  // Fallback: accumulate all assistant text deltas
+  // Fallback: accumulate every assistant text block in order.
   const parts = [];
-  for (const line of lines) {
-    const obj = tryParseJson(line);
-    if (obj) parts.push(...collectAssistantText(obj));
-  }
+  for (const obj of events) parts.push(...collectAssistantText(obj));
   return parts.join("") || raw;
 }
 

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -287,6 +287,38 @@ describe("ClaudeAgent", () => {
 
       expect(result.output).toBe("plain text output");
     });
+
+    it("extracts result text from a JSON array payload (`--output-format json`)", async () => {
+      // Claude 2.x with --output-format json emits one JSON array containing every
+      // event on a single line. The previous `split('\n')` strategy returned nothing
+      // useful from this shape, which made `kj plan` save the whole array as the
+      // plan's `approach` field and skip HU generation entirely. The regression is
+      // captured here.
+      const arrayPayload = JSON.stringify([
+        { type: "system", subtype: "init", session_id: "abc" },
+        { type: "assistant", message: { content: [{ type: "text", text: "thinking…" }] } },
+        { type: "result", result: "final plan text" },
+      ]);
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: arrayPayload });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("final plan text");
+    });
+
+    it("accumulates assistant text from a JSON array when no result event is present", async () => {
+      const arrayPayload = JSON.stringify([
+        { type: "assistant", message: { content: [{ type: "text", text: "step1 " }] } },
+        { type: "assistant", message: { content: [{ type: "text", text: "step2" }] } },
+      ]);
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: arrayPayload });
+
+      const agent = new ClaudeAgent("claude", baseConfig, logger);
+      const result = await agent.runTask({ prompt: "test", role: "coder" });
+
+      expect(result.output).toBe("step1 step2");
+    });
   });
 
   describe("onOutput stream-json filter", () => {


### PR DESCRIPTION
## Summary

Claude 2.x emits either NDJSON (with `--output-format stream-json`) or a single JSON array (with `--output-format json`). `extractTextFromStreamJson` and `extractUsageFromStreamJson` both assumed NDJSON and called `split(\"\n\")`, which returned one unparseable line containing the whole array. The result text was never extracted and the caller fell back to the raw stream as \`output\`.

## User-visible symptom

Reported during dogfooding of the v2.7.5 candidate. \`kj plan --task-file spec.md\` saved the raw 36 KB array as \`plan.approach\` and produced **zero HUs** because \`parsed.steps\` was \`undefined\` on the first event (\`{\"type\":\"system\",\"subtype\":\"init\",...}\`).

## Fix

New \`parseClaudeEvents(raw)\` helper normalizes both shapes into a flat event array. Both extract functions route through it.

## Test plan

- [x] Two new regression cases in \`tests/agents/claude-agent.test.js\` — JSON-array shape with and without a final \`result\` event.
- [x] Full suite: 3759 tests (+2) passing.
- [x] Verified against the actual captured output from the user's failed \`kj plan\` run — the 11.6 KB result text is now extracted instead of the 36 KB raw array.