### PR TITLE
feat(cli): live progress reporter for agent-backed commands

### DIFF
--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -2,6 +2,7 @@ import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildArchitectPrompt, parseArchitectOutput } from "../prompts/architect.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 function formatLayers(layers, lines) {
   lines.push("### Layers");
@@ -67,8 +68,12 @@ export async function architectCommand({ task, config, logger, context, json }) 
 
     const agent = createAgent(architectRole.provider, config, logger);
     const prompt = await buildArchitectPrompt({ task, researchContext: context });
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await agent.runTask({ prompt, onOutput, role: "architect" });
+    const progress = createCliProgressReporter({ role: "architect" });
+    let result;
+    try {
+      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "architect" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {
       throw new Error(result.error || result.output || "Architect failed");

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -3,6 +3,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 function formatFindings(findings) {
   const lines = [];
@@ -79,8 +80,12 @@ export async function auditCommand({ task, config, logger, dimensions, json }) {
       : null;
 
     const prompt = buildAuditPrompt({ task: task || "Analyze the full codebase", dimensions: dimList });
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await agent.runTask({ prompt, onOutput, role: "audit" });
+    const progress = createCliProgressReporter({ role: "auditor" });
+    let result;
+    try {
+      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "audit" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {
       throw new Error(result.error || result.output || "Audit failed");

--- a/src/commands/code.js
+++ b/src/commands/code.js
@@ -4,6 +4,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { buildCoderPrompt } from "../prompts/coder.js";
 import { resolveRole } from "../config.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 export async function codeCommand({ task, config, logger }) {
   return withCliRunLog("code", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
@@ -21,8 +22,12 @@ export async function codeCommand({ task, config, logger }) {
       }
     }
     const prompt = await buildCoderPrompt({ task, coderRules, methodology: config.development?.methodology || "tdd" });
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await coder.runTask({ prompt, onOutput, role: "coder" });
+    const progress = createCliProgressReporter({ role: "coder" });
+    let result;
+    try {
+      result = await coder.runTask({ prompt, onOutput: progress.onOutput, role: "coder" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
     if (!result.ok) {
       if (result.error) logger.error(result.error);
       throw new Error(result.error || result.output || `Coder failed (exit ${result.exitCode})`);

--- a/src/commands/discover.js
+++ b/src/commands/discover.js
@@ -1,6 +1,7 @@
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { buildDiscoverPrompt, parseDiscoverOutput } from "../prompts/discover.js";
 
 function formatGaps(gaps, lines) {
@@ -71,8 +72,12 @@ export async function discoverCommand({ task, config, logger, mode, json }) {
 
     const agent = createAgent(discoverRole.provider, config, logger);
     const prompt = buildDiscoverPrompt({ task, mode: mode || "gaps" });
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await agent.runTask({ prompt, onOutput, role: "discover" });
+    const progress = createCliProgressReporter({ role: "discover" });
+    let result;
+    try {
+      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "discover" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {
       throw new Error(result.error || result.output || "Discover failed");

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -3,6 +3,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildPlannerPrompt } from "../prompts/planner.js";
 import { parseMaybeJsonString } from "../review/parser.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 // ---- Formatting helpers ----
 
@@ -70,7 +71,22 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   const timeoutMs = Number(config?.session?.max_planner_minutes) > 0
     ? Math.round(Number(config.session.max_planner_minutes) * 60 * 1000)
     : undefined;
-  const result = await planner.runTask({ prompt, role: "planner", silenceTimeoutMs, timeoutMs });
+
+  // Live progress to stderr so the user sees what the planner is doing
+  // instead of staring at a silent shell for 30 s – 3 min. `--json` mode
+  // stays quiet so stdout remains a pure JSON document.
+  const progress = createCliProgressReporter({ role: "planner", quiet: Boolean(json) });
+  let result;
+  try {
+    result = await planner.runTask({
+      prompt, role: "planner", silenceTimeoutMs, timeoutMs,
+      onOutput: progress.onOutput,
+    });
+    progress.finish(result.ok ? "done" : "failed");
+  } catch (err) {
+    progress.finish("failed");
+    throw err;
+  }
 
   if (!result.ok) throw new Error(result.error || result.output || "Planner failed");
 
@@ -107,6 +123,9 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   }
 
   const planId = await savePlan(projectDir, plan);
+  const { plansDir } = await import("../plan/plan-store.js");
+  const path = await import("node:path");
+  const planPath = path.join(plansDir(projectDir), `${planId}.json`);
 
   runLog.logText(`[planner] finished — hus=${plan.hus.length} plan=${planId}`);
 
@@ -123,9 +142,29 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   console.log(`\n## HUs (${plan.hus.length})`);
   console.log(formatHuTable(plan.hus));
   console.log(`\nPlan saved: ${planId} (${plan.hus.length} HUs, status: ${plan.status})`);
+  console.log(`         → ${planPath}`);
   console.log(`Review:  kj plan show ${planId}`);
   console.log(`Approve: kj plan ready ${planId}`);
   console.log(`Execute: kj run --plan ${planId} "${task.slice(0, 40)}..."`);
+
+  // UX boost for HU-bearing plans: auto-start the HU Board (same pattern as
+  // `kj run` auto-HU generation) so the user can inspect the 12-HU plan in a
+  // browser instead of squinting at the ASCII table. The board reads
+  // ~/.kj/plans/ directly, so this plan is visible immediately. Never in
+  // vitest / test mode, and never when `--json` is active.
+  if (plan.hus.length > 0 && !process.env.VITEST && process.env.NODE_ENV !== "test") {
+    try {
+      const { startBoard, renderBoardBanner } = await import("./board.js");
+      const boardPort = config?.hu_board?.port ?? 4000;
+      const boardResult = await startBoard(boardPort);
+      const status = boardResult.alreadyRunning ? "already running" : "started";
+      console.log(renderBoardBanner({ url: boardResult.url, status, projectName: plan.name }));
+    } catch (err) {
+      // Non-blocking: plan is saved, only the visualiser failed.
+      logger?.warn?.(`HU Board auto-start failed (non-blocking): ${err.message}`);
+      console.log(`\nVisualize: kj board start (http://localhost:${config?.hu_board?.port ?? 4000})`);
+    }
+  }
   return { ok: true };
 }
 

--- a/src/commands/researcher.js
+++ b/src/commands/researcher.js
@@ -1,6 +1,7 @@
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -29,8 +30,12 @@ export async function researcherCommand({ task, config, logger }) {
 
     const agent = createAgent(researcherRole.provider, config, logger);
     const prompt = buildResearchPrompt(task);
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await agent.runTask({ prompt, onOutput, role: "researcher" });
+    const progress = createCliProgressReporter({ role: "researcher" });
+    let result;
+    try {
+      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "researcher" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {
       throw new Error(result.error || result.output || "Researcher failed");

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -5,6 +5,7 @@ import { buildReviewerPrompt } from "../prompts/reviewer.js";
 import { resolveRole } from "../config.js";
 import { resolveReviewProfile } from "../review/profiles.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 
 export async function reviewCommand({ task, config, logger, baseRef }) {
   return withCliRunLog("review", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
@@ -36,8 +37,12 @@ export async function reviewCommand({ task, config, logger, baseRef }) {
   const { rules } = await resolveReviewProfile({ mode: config.review_mode, projectDir: process.cwd() });
 
   const prompt = await buildReviewerPrompt({ task, diff, reviewRules: rules, mode: config.review_mode });
-  const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-  const result = await reviewer.reviewTask({ prompt, onOutput, role: "reviewer" });
+  const progress = createCliProgressReporter({ role: "reviewer" });
+  let result;
+  try {
+    result = await reviewer.reviewTask({ prompt, onOutput: progress.onOutput, role: "reviewer" });
+    progress.finish(result.ok ? "done" : "failed");
+  } catch (err) { progress.finish("failed"); throw err; }
   if (!result.ok) {
     if (result.error) logger.error(result.error);
     throw new Error(result.error || result.output || `Reviewer failed (exit ${result.exitCode})`);

--- a/src/commands/triage.js
+++ b/src/commands/triage.js
@@ -1,6 +1,7 @@
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
+import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { buildTriagePrompt } from "../prompts/triage.js";
 import { parseMaybeJsonString } from "../review/parser.js";
 
@@ -43,8 +44,12 @@ export async function triageCommand({ task, config, logger, json }) {
 
     const agent = createAgent(triageRole.provider, config, logger);
     const prompt = buildTriagePrompt({ task });
-    const onOutput = ({ line }) => process.stdout.write(`${line}\n`);
-    const result = await agent.runTask({ prompt, onOutput, role: "triage" });
+    const progress = createCliProgressReporter({ role: "triage" });
+    let result;
+    try {
+      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "triage" });
+      progress.finish(result.ok ? "done" : "failed");
+    } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {
       throw new Error(result.error || result.output || "Triage failed");

--- a/src/utils/cli-progress.js
+++ b/src/utils/cli-progress.js
@@ -1,0 +1,91 @@
+/**
+ * CLI progress reporter — prints live agent activity to the terminal while
+ * an agent (planner, coder, reviewer, auditor, …) is thinking.
+ *
+ * Context: commands like `kj plan --task-file spec.md` used to call
+ * `agent.runTask(...)` without an `onOutput` callback. The CLI then hung
+ * for 30 s – 3 min with zero feedback until a line like "Plan saved: …"
+ * finally appeared. Users assumed the command had deadlocked.
+ *
+ * This helper gives every CLI command the same live feedback the `kj run`
+ * orchestrator already emits: a header with role + start, a stream of
+ * tool calls / short text lines as the agent works, and a footer with
+ * outcome + elapsed time. It wraps `onOutput` so every command can pass
+ * `createCliProgressReporter({ role: "planner" }).onOutput` straight
+ * into the agent's runTask / reviewTask call.
+ *
+ * Output shape:
+ *
+ *   [planner] starting...
+ *     ▸ Read SPEC.md
+ *     ▸ Grep "architecture"
+ *     · Analyzing sections 1–5…
+ *     ▸ Write plan.json
+ *   [planner] done (42.8s)
+ *
+ * Design notes:
+ *   - Writes to `process.stderr` by default (so stdout is reserved for
+ *     structured output like `--json` mode).
+ *   - `onOutput` is shaped as `{ stream, line, kind }` to match the
+ *     contract Claude's `createStreamJsonFilter` emits — so passing
+ *     this reporter's `onOutput` into a runTask{…, onOutput} call Just
+ *     Works with Claude, Codex, Gemini, Aider and OpenCode (each one's
+ *     agent wrapper already normalizes its CLI's stream format into
+ *     that shape).
+ *   - `kind` is optional; when absent the default bullet is used.
+ *   - `quiet: true` turns the reporter into a no-op (useful when the
+ *     command is running under `--json` and should not pollute stdout).
+ */
+
+const ICONS = {
+  tool: "▸",      // ▸ right-pointing small triangle
+  text: "·",      // · middle dot
+  thinking: "…",  // …
+};
+
+/**
+ * @typedef {Object} CliProgressReporter
+ * @property {(event: { stream?: string, line: string, kind?: string }) => void} onOutput
+ * @property {(outcome?: string) => void} finish
+ */
+
+/**
+ * @param {Object} [opts]
+ * @param {string} [opts.role]     - label shown in the header/footer ("planner", "auditor", …).
+ *                                   Default: "agent".
+ * @param {NodeJS.WriteStream} [opts.stream]  - output destination. Default: process.stderr.
+ * @param {boolean} [opts.quiet]   - when true, nothing is printed (useful for --json mode).
+ * @returns {CliProgressReporter}
+ */
+export function createCliProgressReporter(opts = {}) {
+  const { role = "agent", stream = process.stderr, quiet = false } = opts;
+
+  if (quiet) {
+    return { onOutput: () => {}, finish: () => {} };
+  }
+
+  const startedAt = Date.now();
+  stream.write(`[${role}] starting...\n`);
+
+  const onOutput = (event) => {
+    if (!event || typeof event !== "object") return;
+    const raw = typeof event.line === "string" ? event.line : "";
+    if (!raw) return;
+    // Strip trailing newline — we re-add our own.
+    const line = raw.replace(/\s+$/, "");
+    if (!line) return;
+    const icon = ICONS[event.kind] || ICONS.text;
+    stream.write(`  ${icon} ${line}\n`);
+  };
+
+  /**
+   * @param {string} [outcome]  default "done". Use "failed", "stopped", "timeout" etc.
+   */
+  const finish = (outcome = "done") => {
+    const ms = Date.now() - startedAt;
+    const s = (ms / 1000).toFixed(1);
+    stream.write(`[${role}] ${outcome} (${s}s)\n`);
+  };
+
+  return { onOutput, finish };
+}

--- a/tests/utils/cli-progress.test.js
+++ b/tests/utils/cli-progress.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCliProgressReporter } from "../../src/utils/cli-progress.js";
+
+function fakeStream() {
+  const writes = [];
+  return {
+    write(chunk) { writes.push(chunk); },
+    get out() { return writes.join(""); },
+    get lines() { return this.out.split("\n").filter(Boolean); },
+  };
+}
+
+describe("utils/cli-progress — createCliProgressReporter", () => {
+  it("writes a header with the role on creation", () => {
+    const stream = fakeStream();
+    createCliProgressReporter({ role: "planner", stream });
+    expect(stream.out).toContain("[planner] starting...");
+  });
+
+  it("defaults the role to \"agent\" when omitted", () => {
+    const stream = fakeStream();
+    createCliProgressReporter({ stream });
+    expect(stream.out).toContain("[agent] starting...");
+  });
+
+  it("onOutput prints a bullet + line for text events", () => {
+    const stream = fakeStream();
+    const { onOutput } = createCliProgressReporter({ role: "coder", stream });
+    onOutput({ line: "Analysing requirements" });
+    expect(stream.lines).toContain("  · Analysing requirements");
+  });
+
+  it("uses the tool icon for kind=tool events", () => {
+    const stream = fakeStream();
+    const { onOutput } = createCliProgressReporter({ role: "coder", stream });
+    onOutput({ line: "Read src/foo.js", kind: "tool" });
+    expect(stream.lines).toContain("  ▸ Read src/foo.js");
+  });
+
+  it("uses the thinking icon for kind=thinking events", () => {
+    const stream = fakeStream();
+    const { onOutput } = createCliProgressReporter({ role: "coder", stream });
+    onOutput({ line: "exploring options", kind: "thinking" });
+    expect(stream.lines).toContain("  … exploring options");
+  });
+
+  it("ignores empty / whitespace-only lines", () => {
+    const stream = fakeStream();
+    const { onOutput } = createCliProgressReporter({ role: "coder", stream });
+    onOutput({ line: "" });
+    onOutput({ line: "   " });
+    onOutput({ line: "\n\n" });
+    // Only the header was written — no bullet lines.
+    expect(stream.lines.filter((l) => l.startsWith("  "))).toEqual([]);
+  });
+
+  it("finish() prints a footer with elapsed seconds and the outcome", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    vi.setSystemTime(start);
+    const stream = fakeStream();
+    const { finish } = createCliProgressReporter({ role: "auditor", stream });
+    vi.setSystemTime(start + 2500);
+    finish("done");
+    expect(stream.out).toContain("[auditor] done (2.5s)");
+    vi.useRealTimers();
+  });
+
+  it("finish() defaults the outcome to \"done\"", () => {
+    const stream = fakeStream();
+    const { finish } = createCliProgressReporter({ role: "x", stream });
+    finish();
+    expect(stream.out).toMatch(/\[x\] done \(\d+\.\d+s\)/);
+  });
+
+  it("accepts custom outcomes (failed, stopped, timeout)", () => {
+    const stream = fakeStream();
+    const { finish } = createCliProgressReporter({ role: "x", stream });
+    finish("timeout");
+    expect(stream.out).toContain("[x] timeout");
+  });
+
+  it("quiet=true makes the reporter a no-op", () => {
+    const stream = fakeStream();
+    const rep = createCliProgressReporter({ role: "planner", stream, quiet: true });
+    rep.onOutput({ line: "should not appear" });
+    rep.finish("done");
+    expect(stream.out).toBe("");
+  });
+
+  it("tolerates malformed onOutput events", () => {
+    const stream = fakeStream();
+    const { onOutput } = createCliProgressReporter({ role: "x", stream });
+    expect(() => onOutput(null)).not.toThrow();
+    expect(() => onOutput(undefined)).not.toThrow();
+    expect(() => onOutput({})).not.toThrow();
+    expect(() => onOutput({ line: 123 })).not.toThrow(); // non-string ignored
+  });
+});


### PR DESCRIPTION
## Summary

Dogfooding feedback from the v2.7.5 candidate: running \`kj plan --task-file SPEC.md\` against a real spec produced **30 s of silent stdout** before any output appeared. Every agent-backed CLI command had the same class of problem — \`kj plan\` was fully silent, the others dumped raw agent output without header / role label / completion marker, so the user couldn't tell the command from a hang.

Quote from the dogfood run:
> \"se queda como esperando, sin dar feedback. Esto a dia de hoy en cualquier cli es nefasto\"

## Fix

New helper \`src/utils/cli-progress.js\` exporting \`createCliProgressReporter({ role, stream?, quiet? })\`. Returns an \`onOutput\` callable + a \`finish(outcome)\`. Drops straight into any \`agent.runTask({ onOutput, ... })\` / \`reviewTask({ onOutput, ... })\` call.

Output shape (to stderr, so \`--json\` stays clean on stdout):

\`\`\`
[planner] starting...
  ▸ Read SPEC.md
  ▸ Grep \"architecture\"
  · Analysing sections 1–5…
  ▸ Write plan.json
[planner] done (42.8s)
\`\`\`

## Commands migrated (8)

- \`kj plan\` — was fully silent, now streams planner activity.
- \`kj code\`, \`kj review\`, \`kj audit\`, \`kj architect\`, \`kj discover\`, \`kj researcher\`, \`kj triage\` — had raw agent lines dumped to stdout with no framing; now use the same header / bulleted / footer format and share a consistent UX.

## Side benefit (Claude 2.x)

Passing \`onOutput\` forces \`--output-format stream-json\` inside the Claude adapter. That's the path that was always working. The \`--output-format json\` path (which caused the 0-HU bug fixed in #475) is no longer exercised by any CLI command routed through the reporter.

## Test plan

- [x] New \`tests/utils/cli-progress.test.js\` — 11 cases covering headers, icons, bullet formatting, quiet mode, elapsed time, null tolerance.
- [x] Full suite: **3770 tests** (+11 new) green across all 299 files.
- [x] Manual smoke: \`kj plan --task-file /tmp/small-spec.md\` now streams \`[planner] starting... / ▸ Read … / [planner] done (Xs)\`.