### PR TITLE
feat(gc): automatic garbage collector + kj clean command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -30,6 +30,7 @@ import { auditCommand } from "./commands/audit.js";
 import { boardCommand } from "./commands/board.js";
 import { undoCommand } from "./commands/undo.js";
 import { statusCommand } from "./commands/status.js";
+import { cleanCommand } from "./commands/clean.js";
 
 import { printUpdateNotice } from "./utils/update-check.js";
 import { printWelcomeScreen } from "./utils/welcome.js";
@@ -253,6 +254,24 @@ program
   .action(async (subcommand, role, provider, flags) => {
     await withConfig("agents", {}, async ({ config }) => {
       await agentsCommand({ config, subcommand: subcommand || "list", role, provider, global: flags.global });
+    });
+  });
+
+program
+  .command("clean")
+  .description("Garbage-collect stale plans, sessions and HU batches (dry-run by default)")
+  .option("--yes", "Actually delete — without this flag, only prints what would be removed")
+  .option("--plan-days <n>", "Keep finalised plans (approved/rejected/executed) for N days (default: 30)")
+  .option("--draft-days <n>", "Keep draft plans for N days (default: 60)")
+  .option("--session-days <n>", "Keep finalised sessions for N days (default: 7)")
+  .option("--hu-days <n>", "Keep HU story batches for N days (default: 14)")
+  .action(async (flags) => {
+    await cleanCommand({
+      yes: Boolean(flags.yes),
+      planDays: flags.planDays ? Number(flags.planDays) : undefined,
+      draftDays: flags.draftDays ? Number(flags.draftDays) : undefined,
+      sessionDays: flags.sessionDays ? Number(flags.sessionDays) : undefined,
+      huDays: flags.huDays ? Number(flags.huDays) : undefined,
     });
   });
 

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -1,0 +1,70 @@
+/**
+ * `kj clean` — manual garbage collector.
+ *
+ * Shows or deletes accumulated state under `~/.kj/plans/` and
+ * `~/.karajan/` (sessions, HU story batches). Dry-run by default so
+ * the user can eyeball the plan before committing to it.
+ *
+ * Usage:
+ *   kj clean                         # dry-run, shows what would be removed
+ *   kj clean --yes                   # actually delete
+ *   kj clean --plan-days 60          # keep finalised plans for 60 days instead of 30
+ *   kj clean --draft-days 90         # keep drafts for 90 days instead of 60
+ *   kj clean --session-days 14       # keep finalised sessions for 14 days instead of 7
+ *   kj clean --hu-days 30            # keep HU batches for 30 days instead of 14
+ *
+ * The auto-GC that runs at the start of every `kj run` / `kj plan`
+ * uses the same retention defaults; tweaking them here lets the user
+ * sweep more or less aggressively without editing config.
+ */
+
+import { runManualGC, summarizeGC } from "../utils/garbage-collector.js";
+
+/**
+ * @param {Object} opts
+ * @param {boolean} [opts.yes=false]           - when false, dry-run only
+ * @param {number}  [opts.planDays=30]
+ * @param {number}  [opts.draftDays=60]
+ * @param {number}  [opts.sessionDays=7]
+ * @param {number}  [opts.huDays=14]
+ * @param {Object}  [opts.logger]
+ */
+export async function cleanCommand(opts = {}) {
+  const dryRun = !opts.yes;
+  const result = await runManualGC({
+    planRetentionDays: opts.planDays,
+    draftRetentionDays: opts.draftDays,
+    sessionRetentionDays: opts.sessionDays,
+    huRetentionDays: opts.huDays,
+    dryRun,
+  });
+
+  if (!result.removed.length) {
+    console.log("[clean] nothing to clean — ~/.kj/ and ~/.karajan/ are tidy.");
+    return { ok: true, removed: 0 };
+  }
+
+  const verb = dryRun ? "would remove" : "removed";
+  console.log(`[clean] ${verb} ${result.removed.length} item(s):`);
+  for (const r of result.removed) {
+    console.log(`  - ${r.kind.padEnd(10)} ${r.path}`);
+    console.log(`                 ${r.reason}`);
+  }
+
+  const kb = Math.round(result.bytesFreed / 1024);
+  if (kb) console.log(`[clean] ${verb} ${kb} KiB total`);
+
+  if (result.errors.length) {
+    console.log(`[clean] ${result.errors.length} error(s) (non-blocking):`);
+    for (const e of result.errors) console.log(`  - ${e.path}: ${e.error}`);
+  }
+
+  if (dryRun) {
+    console.log("");
+    console.log("[clean] DRY-RUN — no files touched. Re-run with --yes to actually delete.");
+  } else {
+    console.log(summarizeGC(result));
+  }
+
+  return { ok: true, removed: result.removed.length, bytesFreed: result.bytesFreed };
+}

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -4,6 +4,7 @@ import { resolveRole } from "../config.js";
 import { buildPlannerPrompt } from "../prompts/planner.js";
 import { parseMaybeJsonString } from "../review/parser.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
+import { runAutoGC, summarizeGC } from "../utils/garbage-collector.js";
 
 // ---- Formatting helpers ----
 
@@ -59,6 +60,20 @@ export async function planGenerateCommand({ task, config, logger, json, context 
 }
 
 async function planGenerateImpl({ task, config, logger, json, context, runLog }) {
+  // Auto-GC: prune orphan plans (project dir gone) + old finalised plans/
+  // sessions/HU batches before we start. Silent unless something was
+  // removed; one-liner summary on stderr in that case so --json stays
+  // untouched. Skipped in test env.
+  if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
+    try {
+      const gcResult = await runAutoGC();
+      const line = summarizeGC(gcResult);
+      if (line && !json) process.stderr.write(`${line}\n`);
+    } catch (err) {
+      logger?.warn?.(`Auto-GC failed (non-blocking): ${err.message}`);
+    }
+  }
+
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);
   runLog.logText(`[planner] provider=${plannerRole.provider}`);

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -83,6 +83,20 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
   // lazy fallback).
   await ensureTrackerRegistered(config);
 
+  // Auto-GC: prune orphan plans and old finalised state so `~/.kj/` and
+  // `~/.karajan/` don't accumulate forever. Silent unless something was
+  // removed; stderr one-liner on cleanup. Skipped in test env.
+  if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
+    try {
+      const { runAutoGC, summarizeGC } = await import("../utils/garbage-collector.js");
+      const gcResult = await runAutoGC();
+      const summary = summarizeGC(gcResult);
+      if (summary) process.stderr.write(`${summary}\n`);
+    } catch (err) {
+      logger?.warn?.(`Auto-GC failed (non-blocking): ${err.message}`);
+    }
+  }
+
   const pipelineFlags = resolvePipelineFlags(config);
 
   if (flags.dryRun) {

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -40,6 +40,11 @@ export async function savePlan(projectDir, planResult) {
   if (isPlanV2(planResult)) {
     const filePath = path.join(dir, `${planResult.planId}.json`);
     planResult.updatedAt = new Date().toISOString();
+    // TSK-0341 / garbage-collector: stamp the absolute projectDir on every
+    // plan so the GC can check `fs.exists(projectDir)` reliably. Reverse-
+    // engineering it from the slug is lossy (underscores in the original
+    // name collide with underscores introduced by slash-substitution).
+    if (!planResult.projectDir && projectDir) planResult.projectDir = projectDir;
     await fs.writeFile(filePath, JSON.stringify(planResult, null, 2), "utf8");
     return planResult.planId;
   }

--- a/src/utils/garbage-collector.js
+++ b/src/utils/garbage-collector.js
@@ -1,0 +1,293 @@
+/**
+ * Karajan garbage collector — keeps `~/.kj/` and `~/.karajan/` from
+ * accumulating dead state across runs.
+ *
+ * Dogfood motivation: after ~1 year the user's `~/.kj/plans/` had 2 464
+ * plans in `home_manu_ws_npm-packages_karajan-code/` plus 35 plans from
+ * worktrees that no longer exist. Same story for `~/.karajan/sessions/`
+ * and `hu-stories/`. None ever got cleaned because no command did it.
+ */
+
+/**
+ * Two entry points:
+ *   - `runAutoGC(opts)` — silent, called at the top of every `kj run`
+ *     and `kj plan`. Prints a single one-liner ONLY when something was
+ *     removed.
+ *   - `runManualGC(opts)` — backs `kj clean`. Caller decides `dryRun`;
+ *     returns the full `{ removed, bytesFreed, errors }` record.
+ *
+ * Retention policy (all adjustable via opts):
+ *   • Plans whose stamped `projectDir` no longer exists → delete.
+ *   • Plans with final status (approved/rejected/executed) older than
+ *     `planRetentionDays` (30) → delete.
+ *   • Draft plans older than `draftRetentionDays` (60) → delete.
+ *   • Finalised sessions older than `sessionRetentionDays` (7) → delete.
+ *   • HU story batches older than `huRetentionDays` (14) → delete.
+ *
+ * Failures are NEVER fatal — every op is try/catch and non-blocking.
+ * Tested against an isolated tmp KJ_HOME so production data is safe.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const FINAL_PLAN_STATUSES = new Set(["approved", "rejected", "executed", "completed"]);
+const FINAL_SESSION_STATUSES = new Set(["approved", "failed", "stopped", "rejected", "completed"]);
+
+function getKjHome() {
+  return process.env.KJ_HOME || path.join(os.homedir(), ".kj");
+}
+
+function getKarajanHome() {
+  return process.env.KARAJAN_HOME || path.join(os.homedir(), ".karajan");
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @typedef {Object} GCOptions
+ * @property {number} [planRetentionDays=30]
+ * @property {number} [draftRetentionDays=60]
+ * @property {number} [sessionRetentionDays=7]
+ * @property {number} [huRetentionDays=14]
+ * @property {boolean} [dryRun=false]   - only report what would be removed
+ * @property {Date}    [now]            - clock injection for tests
+ */
+
+/**
+ * @typedef {Object} GCResult
+ * @property {Array<{path: string, reason: string, kind: string, bytes?: number}>} removed
+ * @property {number} bytesFreed
+ * @property {Array<{path: string, error: string}>} errors
+ */
+
+async function tryReadJson(file) {
+  try {
+    const txt = await fs.readFile(file, "utf8");
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+async function tryStat(p) {
+  try { return await fs.stat(p); } catch { return null; }
+}
+
+async function exists(p) {
+  return Boolean(await tryStat(p));
+}
+
+async function listDir(dir) {
+  try { return await fs.readdir(dir, { withFileTypes: true }); } catch { return []; }
+}
+
+async function unlinkOrRm(p, dryRun) {
+  if (dryRun) return;
+  try {
+    const st = await fs.stat(p);
+    if (st.isDirectory()) await fs.rm(p, { recursive: true, force: true });
+    else await fs.unlink(p);
+  } catch { /* best-effort */ }
+}
+
+function ageInDays(stat, now) {
+  return (now.getTime() - stat.mtimeMs) / DAY_MS;
+}
+
+// Slugs are lossy — we CAN'T recover a path from one because `_` in
+// the slug could have come from either `/` in the path or a literal
+// `_` in a directory name (e.g. `ws_ai` vs `ws/ai`). That's why plans
+// saved via `savePlan()` now stamp their absolute `projectDir`; the GC
+// reads it from there. Legacy plans without the field fall back to
+// age-only retention — never marked as orphans on the way up.
+
+async function gcPlans(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const plansRoot = path.join(getKjHome(), "plans");
+  if (!(await exists(plansRoot))) return result;
+
+  for (const projEntry of await listDir(plansRoot)) {
+    if (!projEntry.isDirectory()) continue;
+    const projDir = path.join(plansRoot, projEntry.name);
+
+    let removedCountInDir = 0;
+    let totalCountInDir = 0;
+
+    for (const planEntry of await listDir(projDir)) {
+      if (!planEntry.isFile() || !planEntry.name.endsWith(".json")) continue;
+      totalCountInDir += 1;
+      const filePath = path.join(projDir, planEntry.name);
+      const stat = await tryStat(filePath);
+      if (!stat) continue;
+
+      const data = await tryReadJson(filePath);
+      const status = data?.status || "draft";
+      const storedDir = typeof data?.projectDir === "string" ? data.projectDir : null;
+      const days = ageInDays(stat, now);
+
+      let reason = null;
+      // Orphan check: only when the plan stamped its origin projectDir.
+      // Plans older than the savePlan-stamping change don't have it, so
+      // we refuse to guess and just apply age-based retention.
+      if (storedDir && !(await exists(storedDir))) {
+        reason = "orphaned (project dir no longer exists)";
+      } else if (FINAL_PLAN_STATUSES.has(status) && days > opts.planRetentionDays) {
+        reason = `${status} plan older than ${opts.planRetentionDays}d (${Math.round(days)}d)`;
+      } else if (status === "draft" && days > opts.draftRetentionDays) {
+        reason = `stale draft older than ${opts.draftRetentionDays}d (${Math.round(days)}d)`;
+      }
+
+      if (reason) {
+        try {
+          await unlinkOrRm(filePath, opts.dryRun);
+          result.removed.push({ path: filePath, reason, kind: "plan", bytes: stat.size });
+          result.bytesFreed += stat.size;
+          removedCountInDir += 1;
+        } catch (err) {
+          result.errors.push({ path: filePath, error: err.message });
+        }
+      }
+    }
+
+    // If we just emptied the project dir, remove it too.
+    if (removedCountInDir === totalCountInDir && totalCountInDir > 0) {
+      try {
+        await unlinkOrRm(projDir, opts.dryRun);
+      } catch { /* ignore */ }
+    }
+  }
+  return result;
+}
+
+async function gcSessions(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const sessionsRoot = path.join(getKarajanHome(), "sessions");
+  if (!(await exists(sessionsRoot))) return result;
+
+  for (const sessEntry of await listDir(sessionsRoot)) {
+    if (!sessEntry.isDirectory()) continue;
+    const sessDir = path.join(sessionsRoot, sessEntry.name);
+    const sessionFile = path.join(sessDir, "session.json");
+    const stat = await tryStat(sessDir);
+    if (!stat) continue;
+
+    const data = await tryReadJson(sessionFile);
+    const status = data?.status;
+    if (!status || !FINAL_SESSION_STATUSES.has(status)) continue;
+
+    const days = ageInDays(stat, now);
+    if (days <= opts.sessionRetentionDays) continue;
+
+    try {
+      await unlinkOrRm(sessDir, opts.dryRun);
+      result.removed.push({
+        path: sessDir,
+        reason: `${status} session older than ${opts.sessionRetentionDays}d (${Math.round(days)}d)`,
+        kind: "session",
+      });
+    } catch (err) {
+      result.errors.push({ path: sessDir, error: err.message });
+    }
+  }
+  return result;
+}
+
+async function gcHuStories(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const huRoot = path.join(getKarajanHome(), "hu-stories");
+  if (!(await exists(huRoot))) return result;
+
+  for (const batchEntry of await listDir(huRoot)) {
+    if (!batchEntry.isDirectory()) continue;
+    const batchDir = path.join(huRoot, batchEntry.name);
+    const stat = await tryStat(batchDir);
+    if (!stat) continue;
+
+    const days = ageInDays(stat, now);
+    if (days <= opts.huRetentionDays) continue;
+
+    try {
+      await unlinkOrRm(batchDir, opts.dryRun);
+      result.removed.push({
+        path: batchDir,
+        reason: `HU batch older than ${opts.huRetentionDays}d (${Math.round(days)}d)`,
+        kind: "hu-batch",
+      });
+    } catch (err) {
+      result.errors.push({ path: batchDir, error: err.message });
+    }
+  }
+  return result;
+}
+
+function mergeResults(...parts) {
+  const out = { removed: [], bytesFreed: 0, errors: [] };
+  for (const r of parts) {
+    out.removed.push(...r.removed);
+    out.bytesFreed += r.bytesFreed;
+    out.errors.push(...r.errors);
+  }
+  return out;
+}
+
+function defaultOpts(opts = {}) {
+  return {
+    planRetentionDays: opts.planRetentionDays ?? 30,
+    draftRetentionDays: opts.draftRetentionDays ?? 60,
+    sessionRetentionDays: opts.sessionRetentionDays ?? 7,
+    huRetentionDays: opts.huRetentionDays ?? 14,
+    dryRun: Boolean(opts.dryRun),
+    now: opts.now || new Date(),
+  };
+}
+
+/**
+ * Manual GC — backs `kj clean`. Caller decides dryRun via opts.
+ *
+ * @param {GCOptions} [opts]
+ * @returns {Promise<GCResult>}
+ */
+export async function runManualGC(opts = {}) {
+  const o = defaultOpts(opts);
+  return mergeResults(
+    await gcPlans(o),
+    await gcSessions(o),
+    await gcHuStories(o),
+  );
+}
+
+/**
+ * Auto GC — silent, called at the top of `kj run` / `kj plan`. Always
+ * destructive (dryRun ignored). Returns the same result so the caller
+ * can print a one-liner summary if anything was removed.
+ *
+ * @param {Omit<GCOptions, 'dryRun'>} [opts]
+ * @returns {Promise<GCResult>}
+ */
+export async function runAutoGC(opts = {}) {
+  return runManualGC({ ...opts, dryRun: false });
+}
+
+/**
+ * Format a GC result as a single human-readable line. Used by the
+ * silent auto-GC path so the user only sees one line in the rare case
+ * something was actually cleaned.
+ *
+ * @param {GCResult} result
+ * @returns {string|null}    null when nothing was removed
+ */
+export function summarizeGC(result) {
+  if (!result.removed.length) return null;
+  const byKind = {};
+  for (const r of result.removed) {
+    byKind[r.kind] = (byKind[r.kind] || 0) + 1;
+  }
+  const parts = Object.entries(byKind).map(([k, n]) => `${n} ${k}${n === 1 ? "" : "s"}`);
+  const kb = Math.round(result.bytesFreed / 1024);
+  return `[gc] removed ${parts.join(", ")}${kb ? ` (${kb} KiB)` : ""}`;
+}

--- a/tests/utils/garbage-collector.test.js
+++ b/tests/utils/garbage-collector.test.js
@@ -1,0 +1,230 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  runManualGC, runAutoGC, summarizeGC,
+} from "../../src/utils/garbage-collector.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+let tmpKj;
+let tmpKarajan;
+let savedKJ;
+let savedKARAJAN;
+
+async function mkdirp(p) { await fs.mkdir(p, { recursive: true }); }
+
+async function writePlan(projectSlug, planId, { status = "draft", mtime, projectDir } = {}) {
+  const dir = path.join(tmpKj, "plans", projectSlug);
+  await mkdirp(dir);
+  const filePath = path.join(dir, `${planId}.json`);
+  const payload = { planId, status, version: 2 };
+  if (projectDir !== undefined) payload.projectDir = projectDir;
+  await fs.writeFile(filePath, JSON.stringify(payload));
+  if (mtime) await fs.utimes(filePath, mtime, mtime);
+  return filePath;
+}
+
+async function writeSession(id, { status = "approved", mtime } = {}) {
+  const dir = path.join(tmpKarajan, "sessions", id);
+  await mkdirp(dir);
+  const file = path.join(dir, "session.json");
+  await fs.writeFile(file, JSON.stringify({ id, status }));
+  if (mtime) {
+    await fs.utimes(file, mtime, mtime);
+    await fs.utimes(dir, mtime, mtime);
+  }
+  return dir;
+}
+
+async function writeHuBatch(id, { mtime } = {}) {
+  const dir = path.join(tmpKarajan, "hu-stories", id);
+  await mkdirp(dir);
+  const file = path.join(dir, "batch.json");
+  await fs.writeFile(file, JSON.stringify({ session_id: id }));
+  if (mtime) {
+    await fs.utimes(file, mtime, mtime);
+    await fs.utimes(dir, mtime, mtime);
+  }
+  return dir;
+}
+
+beforeEach(async () => {
+  tmpKj = await fs.mkdtemp(path.join(os.tmpdir(), "kj-gc-"));
+  tmpKarajan = await fs.mkdtemp(path.join(os.tmpdir(), "karajan-gc-"));
+  savedKJ = process.env.KJ_HOME;
+  savedKARAJAN = process.env.KARAJAN_HOME;
+  process.env.KJ_HOME = tmpKj;
+  process.env.KARAJAN_HOME = tmpKarajan;
+});
+
+afterEach(async () => {
+  if (savedKJ === undefined) delete process.env.KJ_HOME; else process.env.KJ_HOME = savedKJ;
+  if (savedKARAJAN === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = savedKARAJAN;
+  await fs.rm(tmpKj, { recursive: true, force: true });
+  await fs.rm(tmpKarajan, { recursive: true, force: true });
+});
+
+describe("garbage-collector — plans", () => {
+  it("removes plans whose stamped projectDir no longer exists (orphans)", async () => {
+    const orphanPlan = await writePlan("x", "plan-orphan", {
+      projectDir: "/definitely/does/not/exist/anywhere",
+    });
+    const keptPlan = await writePlan("tmp", "plan-alive", {
+      projectDir: "/tmp",
+    });
+
+    const result = await runManualGC({ dryRun: false });
+
+    const removedPaths = result.removed.map((r) => r.path);
+    expect(removedPaths).toContain(orphanPlan);
+    expect(removedPaths).not.toContain(keptPlan);
+  });
+
+  it("does NOT treat legacy plans without projectDir as orphans (conservative)", async () => {
+    // Pre-TSK-0341 plans don't stamp projectDir. GC must fall back to
+    // age-only retention instead of deleting them as "orphans".
+    const legacy = await writePlan("whatever", "plan-legacy", {
+      status: "draft",
+      // mtime is "now" so draftRetentionDays (60d) doesn't kick in.
+    });
+
+    const result = await runManualGC({ dryRun: false });
+
+    expect(result.removed.map((r) => r.path)).not.toContain(legacy);
+    const stat = await fs.stat(legacy);
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("removes finalised plans older than planRetentionDays", async () => {
+    const oldApproved = await writePlan("tmp", "plan-old", {
+      status: "approved",
+      mtime: new Date(Date.now() - 40 * DAY),
+    });
+    const youngApproved = await writePlan("tmp", "plan-recent", {
+      status: "approved",
+      mtime: new Date(Date.now() - 5 * DAY),
+    });
+
+    const result = await runManualGC({ planRetentionDays: 30, dryRun: false });
+
+    const paths = result.removed.map((r) => r.path);
+    expect(paths).toContain(oldApproved);
+    expect(paths).not.toContain(youngApproved);
+  });
+
+  it("removes stale drafts past draftRetentionDays", async () => {
+    const stale = await writePlan("tmp", "plan-stale-draft", {
+      status: "draft",
+      mtime: new Date(Date.now() - 90 * DAY),
+    });
+    const fresh = await writePlan("tmp", "plan-fresh-draft", {
+      status: "draft",
+      mtime: new Date(Date.now() - 10 * DAY),
+    });
+
+    const result = await runManualGC({ draftRetentionDays: 60, dryRun: false });
+
+    const paths = result.removed.map((r) => r.path);
+    expect(paths).toContain(stale);
+    expect(paths).not.toContain(fresh);
+  });
+
+  it("dry-run reports what would be removed but doesn't touch disk", async () => {
+    const orphan = await writePlan("x", "plan-to-keep-on-disk", {
+      projectDir: "/definitely/does/not/exist",
+    });
+
+    const result = await runManualGC({ dryRun: true });
+
+    expect(result.removed.some((r) => r.path === orphan)).toBe(true);
+    // File still there.
+    const stat = await fs.stat(orphan);
+    expect(stat.isFile()).toBe(true);
+  });
+});
+
+describe("garbage-collector — sessions", () => {
+  it("removes finalised sessions older than sessionRetentionDays", async () => {
+    const oldApproved = await writeSession("sess-old", {
+      status: "approved",
+      mtime: new Date(Date.now() - 20 * DAY),
+    });
+    const recentApproved = await writeSession("sess-recent", {
+      status: "approved",
+      mtime: new Date(Date.now() - 2 * DAY),
+    });
+    const runningNotFinal = await writeSession("sess-running", {
+      status: "running",
+      mtime: new Date(Date.now() - 100 * DAY),
+    });
+
+    const result = await runManualGC({ sessionRetentionDays: 7, dryRun: false });
+
+    const paths = result.removed.map((r) => r.path);
+    expect(paths).toContain(oldApproved);
+    expect(paths).not.toContain(recentApproved);
+    // Running is never touched, no matter how old.
+    expect(paths).not.toContain(runningNotFinal);
+  });
+});
+
+describe("garbage-collector — HU story batches", () => {
+  it("removes HU batches older than huRetentionDays", async () => {
+    const oldBatch = await writeHuBatch("batch-old", {
+      mtime: new Date(Date.now() - 30 * DAY),
+    });
+    const recentBatch = await writeHuBatch("batch-recent", {
+      mtime: new Date(Date.now() - 5 * DAY),
+    });
+
+    const result = await runManualGC({ huRetentionDays: 14, dryRun: false });
+
+    const paths = result.removed.map((r) => r.path);
+    expect(paths).toContain(oldBatch);
+    expect(paths).not.toContain(recentBatch);
+  });
+});
+
+describe("garbage-collector — summary + autoGC", () => {
+  it("runAutoGC is runManualGC with dryRun=false", async () => {
+    const orphan = await writePlan("x", "plan-auto", {
+      projectDir: "/definitely/does/not/exist",
+    });
+
+    const result = await runAutoGC();
+
+    expect(result.removed.some((r) => r.path === orphan)).toBe(true);
+    await expect(fs.stat(orphan)).rejects.toThrow();
+  });
+
+  it("summarizeGC returns null when nothing was removed", () => {
+    expect(summarizeGC({ removed: [], bytesFreed: 0, errors: [] })).toBeNull();
+  });
+
+  it("summarizeGC groups by kind and reports kib when bytes>0", () => {
+    const line = summarizeGC({
+      removed: [
+        { kind: "plan", bytes: 2048 },
+        { kind: "plan", bytes: 1024 },
+        { kind: "session" },
+      ],
+      bytesFreed: 3072,
+      errors: [],
+    });
+    expect(line).toContain("2 plans");
+    expect(line).toContain("1 session");
+    expect(line).toMatch(/\d+ KiB/);
+  });
+
+  it("never throws on missing ~/.kj/ or ~/.karajan/", async () => {
+    await fs.rm(tmpKj, { recursive: true, force: true });
+    await fs.rm(tmpKarajan, { recursive: true, force: true });
+
+    const result = await runManualGC({ dryRun: false });
+
+    expect(result.removed).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Dogfooding feedback from v2.7.5 candidate:

> \"Ya me he encontrado mucha basura generada por karajan, que no van a ningún lado, no hay un garbage colector\"

The user's \`~/.kj/plans/\` had **2 464 plans** sitting in \`home_manu_ws_npm-packages_karajan-code/\` plus 35 plans from git worktrees that no longer exist. None of it ever got cleaned because no command did it.

## What lands

### Auto-GC (silent)
\`kj run\` and \`kj plan\` now run a silent pre-flight GC pass. Prints a single \`[gc] removed …\` line to stderr **only** when something was removed.

Retention windows:
- plans with status approved/rejected/executed → 30 days
- plans with status draft → 60 days
- sessions with status approved/failed/stopped/rejected → 7 days
- HU story batches → 14 days
- plans whose stamped \`projectDir\` no longer exists → removed always

Never in tests. Never fatal — failures logged as non-blocking warnings.

### \`kj clean\` command (explicit)
Dry-run by default; \`--yes\` actually deletes. Per-kind day knobs:

\`\`\`
kj clean                           # dry-run, show what would be removed
kj clean --yes                     # delete
kj clean --draft-days 7 --yes      # aggressive draft sweep
\`\`\`

### Plan stamping
\`savePlan()\` now writes the absolute \`projectDir\` inside each plan JSON. The GC reads it for the orphan check — reverse-engineering the path from the slug is lossy (\`ws_ai\` vs \`ws/ai\` collide). Legacy plans without the field are **never** marked orphan; they fall back to age-only retention so no false positives on old data.

## Test plan

- [x] \`tests/utils/garbage-collector.test.js\` — 11 cases: orphan detection, legacy-plan conservative handling, per-status retention, session retention, HU batch retention, dry-run preservation, empty-home tolerance, summarizeGC formatting.
- [x] Full suite: **3781 tests** (+11 new) / 300 files green.
- [x] Smoke: \`node src/cli.js clean\` on the dogfood machine detects 3 stale HU batches. With \`--draft-days 7\` it identifies 1 359 stale karajan-code dogfooding drafts.