### PR TITLE
feat(mcp): expose kj_clean tool with dry-run / nuke / retention knobs

### DIFF
--- a/src/mcp/handlers/management-handlers.js
+++ b/src/mcp/handlers/management-handlers.js
@@ -201,6 +201,50 @@ export async function handleUndo(a, server) {
   }
 }
 
+/**
+ * Garbage-collect stale Karajan state. Routed here (not through the
+ * generic `runKjCommand`) because the user needs a structured result
+ * payload: MCP clients (Claude Desktop, Cursor, …) render lists, not
+ * ANSI-styled stdout. Shared implementation lives in
+ * `src/utils/garbage-collector.js` so CLI and MCP stay in sync.
+ */
+export async function handleClean(a) {
+  const { runManualGC, nukeBoardDb, summarizeGC } = await import("../../utils/garbage-collector.js");
+
+  const dryRun = !a?.yes;
+  const retention = a?.nuke
+    ? { planRetentionDays: 0, draftRetentionDays: 0, sessionRetentionDays: 0, huRetentionDays: 0 }
+    : {
+      planRetentionDays: a?.planDays,
+      draftRetentionDays: a?.draftDays,
+      sessionRetentionDays: a?.sessionDays,
+      huRetentionDays: a?.huDays,
+    };
+
+  const result = await runManualGC({ ...retention, dryRun });
+  if (a?.nuke) {
+    const boardResult = await nukeBoardDb({ dryRun });
+    result.removed.push(...boardResult.removed);
+    result.bytesFreed += boardResult.bytesFreed;
+    result.errors.push(...boardResult.errors);
+  }
+
+  const byKind = {};
+  for (const r of result.removed) byKind[r.kind] = (byKind[r.kind] || 0) + 1;
+
+  return {
+    ok: true,
+    dryRun,
+    nuke: Boolean(a?.nuke),
+    removed: result.removed.length,
+    bytesFreed: result.bytesFreed,
+    breakdown: byKind,
+    items: result.removed.map((r) => ({ path: r.path, kind: r.kind, reason: r.reason })),
+    errors: result.errors,
+    summary: summarizeGC(result) || "[clean] nothing to clean — ~/.kj/ and ~/.karajan/ are tidy.",
+  };
+}
+
 export async function buildPreflightRequiredResponse(toolName) {
   const { config } = await loadConfig();
   const { listAgents } = await import("../../commands/agents.js");

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -22,7 +22,7 @@ export {
 // ── Sub-module re-exports ────────────────────────────────────────────
 export { handleRunDirect, handleResumeDirect, validateResumeAnswer, handleRun, handleResume } from "./handlers/run-handler.js";
 export { handlePlanDirect, handleCodeDirect, handleReviewDirect, handleDiscoverDirect, handleTriageDirect, handleResearcherDirect, handleAuditDirect, handleArchitectDirect, handleCode, handleReview, handlePlan, handleDiscover, handleTriage, handleResearcher, handleArchitect, handleAudit } from "./handlers/direct-handlers.js";
-export { handleStatus, handleAgents, handlePreflight, handleRoles, handleReport, handleInit, handleDoctor, handleConfig, handleScan, handleBoard, handleUndo, buildPreflightRequiredResponse } from "./handlers/management-handlers.js";
+export { handleStatus, handleAgents, handlePreflight, handleRoles, handleReport, handleInit, handleDoctor, handleConfig, handleScan, handleBoard, handleUndo, handleClean, buildPreflightRequiredResponse } from "./handlers/management-handlers.js";
 export { handleHu, handleSkills, handleSuggest } from "./handlers/hu-handlers.js";
 
 // ── Handler dispatch ─────────────────────────────────────────────────
@@ -36,7 +36,7 @@ import {
 import {
   handleStatus, handleAgents, handlePreflight, handleRoles,
   handleReport, handleInit, handleDoctor, handleConfig,
-  handleScan, handleBoard, handleUndo
+  handleScan, handleBoard, handleUndo, handleClean
 } from "./handlers/management-handlers.js";
 import { handleHu, handleSkills, handleSuggest } from "./handlers/hu-handlers.js";
 
@@ -66,7 +66,8 @@ export async function handleToolCall(name, args, server, extra) {
     kj_hu:          (a, server) => handleHu(a, server),
     kj_suggest:     (a) => handleSuggest(a),
     kj_skills:      (a) => handleSkills(a),
-    kj_undo:        (a, server) => handleUndo(a, server)
+    kj_undo:        (a, server) => handleUndo(a, server),
+    kj_clean:       (a) => handleClean(a),
   }[name];
   if (handler) {
     return handler(a, server, extra);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -385,5 +385,20 @@ export const tools = [
         projectDir: { type: "string", description: "Absolute path to the project directory" }
       }
     }
+  },
+  {
+    name: "kj_clean",
+    description: "Garbage-collect stale Karajan state: orphan plans (project dir no longer exists), finalised plans/sessions past their retention window, and HU story batches. Dry-run by default; pass yes=true to actually delete. Use nuke=true to wipe everything (retention=0 on every bucket + drop the HU board SQLite DB).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        yes: { type: "boolean", description: "If true, actually delete. Default false (dry-run: returns the list of items that would be removed without touching disk)." },
+        nuke: { type: "boolean", description: "If true, retention=0 on every bucket + wipe the HU board DB (stops the board first if running). The \"I want it all gone right now\" button." },
+        planDays: { type: "number", description: "Keep finalised plans (approved/rejected/executed) for this many days. Default: 30." },
+        draftDays: { type: "number", description: "Keep draft plans for this many days. Default: 60." },
+        sessionDays: { type: "number", description: "Keep finalised sessions for this many days. Default: 7." },
+        huDays: { type: "number", description: "Keep HU story batches for this many days. Default: 14." }
+      }
+    }
   }
 ];

--- a/tests/mcp-clean-handler.test.js
+++ b/tests/mcp-clean-handler.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { handleClean } from "../src/mcp/handlers/management-handlers.js";
+
+let tmpKj;
+let tmpKarajan;
+let saved;
+
+async function write(p, content = "x") {
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, content);
+}
+
+beforeEach(async () => {
+  tmpKj = await fs.mkdtemp(path.join(os.tmpdir(), "kj-mcp-clean-"));
+  tmpKarajan = await fs.mkdtemp(path.join(os.tmpdir(), "karajan-mcp-clean-"));
+  saved = { KJ: process.env.KJ_HOME, KARAJAN: process.env.KARAJAN_HOME };
+  process.env.KJ_HOME = tmpKj;
+  process.env.KARAJAN_HOME = tmpKarajan;
+});
+
+afterEach(async () => {
+  if (saved.KJ === undefined) delete process.env.KJ_HOME; else process.env.KJ_HOME = saved.KJ;
+  if (saved.KARAJAN === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = saved.KARAJAN;
+  await fs.rm(tmpKj, { recursive: true, force: true });
+  await fs.rm(tmpKarajan, { recursive: true, force: true });
+});
+
+describe("MCP handleClean", () => {
+  it("defaults to dry-run (returns items without deleting anything)", async () => {
+    const planFile = path.join(tmpKj, "plans", "x", "plan-orphan.json");
+    await write(planFile, JSON.stringify({
+      planId: "plan-orphan",
+      version: 2,
+      status: "draft",
+      projectDir: "/definitely/does/not/exist",
+    }));
+
+    const result = await handleClean({});
+
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.removed).toBe(1);
+    expect(result.items[0].path).toBe(planFile);
+    // File still on disk because dryRun.
+    const stat = await fs.stat(planFile);
+    expect(stat.isFile()).toBe(true);
+  });
+
+  it("yes=true actually deletes", async () => {
+    const planFile = path.join(tmpKj, "plans", "x", "plan-orphan.json");
+    await write(planFile, JSON.stringify({
+      planId: "plan-orphan",
+      version: 2,
+      status: "draft",
+      projectDir: "/definitely/does/not/exist",
+    }));
+
+    const result = await handleClean({ yes: true });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.removed).toBe(1);
+    await expect(fs.stat(planFile)).rejects.toThrow();
+  });
+
+  it("nuke=true drops the HU board DB in addition to retention=0 sweeps", async () => {
+    await write(path.join(tmpKarajan, "hu-board.db"), "fake");
+    await write(path.join(tmpKarajan, "hu-board.db-wal"), "fake");
+
+    const result = await handleClean({ yes: true, nuke: true });
+
+    expect(result.nuke).toBe(true);
+    expect(result.removed).toBeGreaterThanOrEqual(2);
+    await expect(fs.stat(path.join(tmpKarajan, "hu-board.db"))).rejects.toThrow();
+    await expect(fs.stat(path.join(tmpKarajan, "hu-board.db-wal"))).rejects.toThrow();
+  });
+
+  it("returns a tidy summary when nothing to clean", async () => {
+    const result = await handleClean({});
+    expect(result.removed).toBe(0);
+    expect(result.summary).toMatch(/tidy/);
+  });
+
+  it("exposes a per-kind breakdown for MCP client rendering", async () => {
+    const p1 = path.join(tmpKj, "plans", "a", "plan-1.json");
+    const p2 = path.join(tmpKj, "plans", "b", "plan-2.json");
+    await write(p1, JSON.stringify({ planId: "p1", version: 2, projectDir: "/nope-1" }));
+    await write(p2, JSON.stringify({ planId: "p2", version: 2, projectDir: "/nope-2" }));
+
+    const result = await handleClean({ yes: true });
+
+    expect(result.breakdown).toEqual({ plan: 2 });
+    expect(result.bytesFreed).toBeGreaterThan(0);
+  });
+});

--- a/tests/mcp-preloop-tools.test.js
+++ b/tests/mcp-preloop-tools.test.js
@@ -95,7 +95,9 @@ describe("kj_architect handler validation", () => {
 });
 
 describe("MCP tools count", () => {
-  it("has 24 tools registered", () => {
-    expect(tools).toHaveLength(24);
+  it("has 25 tools registered", () => {
+    // Expected surface grows as the CLI gains MCP-exposed commands.
+    // Post-v2.7.5: +kj_clean (garbage collector dogfood fallout).
+    expect(tools).toHaveLength(25);
   });
 });

--- a/tests/mcp-tools-schema.test.js
+++ b/tests/mcp-tools-schema.test.js
@@ -29,4 +29,21 @@ describe("MCP tools schema", () => {
     expect(reportTool.inputSchema?.properties?.sessionId?.type).toBe("string");
     expect(reportTool.inputSchema?.properties?.format?.enum).toEqual(["text", "json"]);
   });
+
+  it("exposes kj_clean with dry-run-by-default + nuke + retention knobs", () => {
+    // Garbage collector surfaced through MCP so Claude Desktop / Cursor can
+    // drive `kj clean` without shelling out. Dogfood feedback that motivated
+    // it: "quiero limpiar tooooodo lo que haya ahora mismo".
+    const cleanTool = tools.find((tool) => tool.name === "kj_clean");
+
+    expect(cleanTool).toBeDefined();
+    const props = cleanTool.inputSchema?.properties || {};
+    expect(props.yes?.type).toBe("boolean");
+    expect(props.nuke?.type).toBe("boolean");
+    for (const knob of ["planDays", "draftDays", "sessionDays", "huDays"]) {
+      expect(props[knob]?.type).toBe("number");
+    }
+    // Dry-run by default — no required fields.
+    expect(cleanTool.inputSchema?.required || []).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Dogfood feedback: \"El MCP debe actualizarse con los nuevos comandos y acciones posibles.\"

\`kj clean\` landed as a CLI command in #477 (auto-GC + manual sweep) and grew a \`--nuke\` flag in #478 (wipe the HU board DB). Until now the MCP surface was still the pre-v2.7.5 set of 24 tools — Claude Desktop / Cursor / Claude Code had no way to drive the garbage collector without shelling out.

## Surface

### \`kj_clean\` tool
\`\`\`json
{
  \"yes\":         { \"type\": \"boolean\" },      // false → dry-run (default)
  \"nuke\":        { \"type\": \"boolean\" },      // retention=0 + wipe board DB
  \"planDays\":    { \"type\": \"number\" },       // default 30
  \"draftDays\":   { \"type\": \"number\" },       // default 60
  \"sessionDays\": { \"type\": \"number\" },       // default 7
  \"huDays\":      { \"type\": \"number\" }        // default 14
}
\`\`\`

### Handler response
\`\`\`ts
{
  ok: true,
  dryRun: boolean,
  nuke: boolean,
  removed: number,
  bytesFreed: number,
  breakdown: Record<'plan'|'session'|'hu-batch'|'board', number>,
  items: Array<{ path, kind, reason }>,
  errors: Array<{ path, error }>,
  summary: string,
}
\`\`\`

Shared with CLI via \`runManualGC\` + \`nukeBoardDb\` so the two surfaces stay in lockstep — a retention change in one never drifts from the other.

## Test plan

- [x] \`tests/mcp-clean-handler.test.js\` (5 cases) — dry-run default, destructive \`yes=true\`, \`nuke=true\` board-DB wipe, tidy-home short-circuit, per-kind breakdown.
- [x] \`tests/mcp-tools-schema.test.js\` — schema contract for \`kj_clean\`.
- [x] \`tests/mcp-preloop-tools.test.js\` — tool count bumped 24 → 25 with justification comment.
- [x] Full suite: **3790 tests** (+6 new) / 301 files green.