### PR TITLE
fix(board+gc): scoped-project URL, zombie-session sweep, ready-plan GC

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -3,11 +3,27 @@
  * Vanilla JS single-page app with hash-based routing.
  */
 
+/**
+ * Scoped-project mode: when the server serves `/p/<slug>`, the UI boots
+ * pre-filtered to that project. Multi-project affordances (project
+ * dropdown, Sessions tab, Pipeline link, Dashboard card grid) are hidden
+ * because they make no sense here. Driven by dogfood feedback: the user
+ * wanted one board per project, not a global view with 2 000 stories.
+ */
+const SCOPED_PREFIX = '/p/';
+const scopedProjectSlug = window.location.pathname.startsWith(SCOPED_PREFIX)
+  ? decodeURIComponent(window.location.pathname.slice(SCOPED_PREFIX.length)).replace(/\/+$/, '')
+  : null;
+
+if (scopedProjectSlug) {
+  document.body.classList.add('scoped-mode');
+}
+
 /** @type {string} Current view */
-let currentView = 'dashboard';
+let currentView = scopedProjectSlug ? 'board' : 'dashboard';
 
 /** @type {string} Selected project ID (empty = all) */
-let selectedProject = '';
+let selectedProject = scopedProjectSlug || '';
 
 /** @type {number | null} Auto-refresh interval ID */
 let refreshInterval = null;
@@ -698,8 +714,10 @@ async function populateProjectSelect() {
 function handleRoute() {
   const hash = window.location.hash.slice(1) || 'dashboard';
   const parts = hash.split('/');
-  currentView = parts[0] || 'dashboard';
-  selectedProject = parts[1] || '';
+  // In scoped mode the project is locked — the hash controls the view
+  // only. `board/<slug>` becomes `board` and the slug stays fixed.
+  currentView = parts[0] || (scopedProjectSlug ? 'board' : 'dashboard');
+  selectedProject = scopedProjectSlug || parts[1] || '';
 
   document.querySelectorAll('.nav-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.view === currentView);

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -833,3 +833,16 @@ a:hover {
 ::-webkit-scrollbar-thumb:hover {
   background: var(--border-active);
 }
+
+/* ---- Scoped-project mode (URL: /p/<slug>) ---- */
+/* Hide multi-project affordances when the board is scoped to a single
+ * project — the page only makes sense as "this project's Kanban".
+ * Multi-project UX (the All Projects selector, the Sessions tab, the
+ * Pipeline page link) adds noise and broke the user's mental model
+ * during dogfooding. */
+body.scoped-mode .project-select,
+body.scoped-mode .nav-btn[data-view="sessions"],
+body.scoped-mode .nav-btn[data-view="dashboard"],
+body.scoped-mode .header__nav a[href="/pipeline.html"] {
+  display: none;
+}

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -52,11 +52,30 @@ async function findAvailablePort(desiredPort, maxTries = 10) {
   return null;
 }
 
-export async function startBoard(desiredPort = 4000) {
+/**
+ * Build the board URL. When `projectSlug` is provided, the URL points at
+ * the per-project view (`/p/<slug>`) so the caller's project shows up
+ * pre-filtered instead of "All projects".
+ * @param {number} port
+ * @param {string|null} [projectSlug]
+ * @returns {string}
+ */
+function buildBoardUrl(port, projectSlug) {
+  const base = `http://localhost:${port}`;
+  return projectSlug ? `${base}/p/${projectSlug}` : base;
+}
+
+export async function startBoard(desiredPort = 4000, opts = {}) {
+  const { projectSlug = null } = opts;
   const existingPid = readPid();
   if (existingPid && isProcessAlive(existingPid)) {
     // Trust the saved PID — port info comes from the PID file if present
-    return { ok: true, alreadyRunning: true, pid: existingPid, url: `http://localhost:${desiredPort}` };
+    return {
+      ok: true,
+      alreadyRunning: true,
+      pid: existingPid,
+      url: buildBoardUrl(desiredPort, projectSlug),
+    };
   }
 
   // Find a free port starting from desiredPort
@@ -85,7 +104,7 @@ export async function startBoard(desiredPort = 4000) {
     throw new Error("Failed to spawn HU Board server");
   }
   fs.writeFileSync(PID_FILE, String(child.pid));
-  return { ok: true, alreadyRunning: false, pid: child.pid, url: `http://localhost:${port}`, port };
+  return { ok: true, alreadyRunning: false, pid: child.pid, url: buildBoardUrl(port, projectSlug), port };
 }
 
 export async function stopBoard() {

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -170,8 +170,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   if (plan.hus.length > 0 && !process.env.VITEST && process.env.NODE_ENV !== "test") {
     try {
       const { startBoard, renderBoardBanner } = await import("./board.js");
+      const { projectSlug: slugFor } = await import("../plan/plan-store.js");
       const boardPort = config?.hu_board?.port ?? 4000;
-      const boardResult = await startBoard(boardPort);
+      // `projectSlug` scopes the board URL to this project's view
+      // (`/p/<slug>`) instead of the global "All projects" dashboard. The
+      // board UI hides multi-project chrome when it sees that prefix.
+      const boardResult = await startBoard(boardPort, { projectSlug: slugFor(projectDir) });
       const status = boardResult.alreadyRunning ? "already running" : "started";
       console.log(renderBoardBanner({ url: boardResult.url, status, projectName: plan.name }));
     } catch (err) {

--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -333,8 +333,12 @@ export async function tryAutoStartBoard(config, logger, emitter, eventBase) {
 
   try {
     const { startBoard, renderBoardBanner } = await import("../../commands/board.js");
+    const { projectSlug: slugFor } = await import("../../plan/plan-store.js");
     const boardPort = config.hu_board.port || 4000;
-    const boardResult = await startBoard(boardPort);
+    // Scope the board URL to the current run's project (`/p/<slug>`) so
+    // the user lands on a filtered view, not the global dashboard.
+    const slug = config.projectDir ? slugFor(config.projectDir) : null;
+    const boardResult = await startBoard(boardPort, { projectSlug: slug });
     const status = boardResult.alreadyRunning ? "already running" : "started";
     // Highlighted URL box — visible regardless of log level (matches the
     // post-planner auto-HU banner so the user gets the same signal either

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -14,7 +14,14 @@ function getKjHome() {
   return process.env.KJ_HOME || path.join(os.homedir(), ".kj");
 }
 
-function projectSlug(projectDir) {
+/**
+ * Deterministic slug for a project path — stable across plan-store writes,
+ * HU-board syncs and board URL routing. Keep in lockstep with
+ * `packages/hu-board/src/sync.js::deriveProjectIdFromDir`.
+ * @param {string} projectDir - absolute project path
+ * @returns {string}
+ */
+export function projectSlug(projectDir) {
   return projectDir
     .replace(/^\//, "")
     .replace(/[/\\]/g, "_")

--- a/src/utils/garbage-collector.js
+++ b/src/utils/garbage-collector.js
@@ -32,7 +32,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 
-const FINAL_PLAN_STATUSES = new Set(["approved", "rejected", "executed", "completed"]);
+const FINAL_PLAN_STATUSES = new Set([
+  // Terminal plan states the user explicitly opted into — retention applies.
+  "approved", "rejected", "executed", "completed", "ready",
+]);
+const KNOWN_PLAN_STATUSES = new Set([...FINAL_PLAN_STATUSES, "draft", "running"]);
 const FINAL_SESSION_STATUSES = new Set(["approved", "failed", "stopped", "rejected", "completed"]);
 
 function getKjHome() {
@@ -138,6 +142,10 @@ async function gcPlans(opts) {
         reason = `${status} plan older than ${opts.planRetentionDays}d (${Math.round(days)}d)`;
       } else if (status === "draft" && days > opts.draftRetentionDays) {
         reason = `stale draft older than ${opts.draftRetentionDays}d (${Math.round(days)}d)`;
+      } else if (!KNOWN_PLAN_STATUSES.has(status) && days > opts.draftRetentionDays) {
+        // Unknown status (corrupt/legacy/plan from a future version) —
+        // apply the draft window. Doing nothing would leak them forever.
+        reason = `plan with unknown status "${status}" older than ${opts.draftRetentionDays}d (${Math.round(days)}d)`;
       }
 
       if (reason) {
@@ -168,6 +176,14 @@ async function gcSessions(opts) {
   const sessionsRoot = path.join(getKarajanHome(), "sessions");
   if (!(await exists(sessionsRoot))) return result;
 
+  // Pipelines that get SIGKILL'd (power off, terminal closed, OOM…) leave
+  // their session.json stuck at status="running" forever. The original GC
+  // only reclaimed FINAL statuses and these zombies accumulated on the
+  // board. After `staleRunningDays` with no activity we assume the run is
+  // dead and sweep them. Default mirrors sessionRetentionDays so there is
+  // only one knob to reason about.
+  const staleRunningDays = opts.staleRunningDays ?? opts.sessionRetentionDays;
+
   for (const sessEntry of await listDir(sessionsRoot)) {
     if (!sessEntry.isDirectory()) continue;
     const sessDir = path.join(sessionsRoot, sessEntry.name);
@@ -177,18 +193,20 @@ async function gcSessions(opts) {
 
     const data = await tryReadJson(sessionFile);
     const status = data?.status;
-    if (!status || !FINAL_SESSION_STATUSES.has(status)) continue;
-
     const days = ageInDays(stat, now);
-    if (days <= opts.sessionRetentionDays) continue;
+
+    let reason = null;
+    if (status && FINAL_SESSION_STATUSES.has(status) && days > opts.sessionRetentionDays) {
+      reason = `${status} session older than ${opts.sessionRetentionDays}d (${Math.round(days)}d)`;
+    } else if ((!status || status === "running") && days > staleRunningDays) {
+      reason = `zombie ${status || "unknown-status"} session older than ${staleRunningDays}d (${Math.round(days)}d)`;
+    }
+
+    if (!reason) continue;
 
     try {
       await unlinkOrRm(sessDir, opts.dryRun);
-      result.removed.push({
-        path: sessDir,
-        reason: `${status} session older than ${opts.sessionRetentionDays}d (${Math.round(days)}d)`,
-        kind: "session",
-      });
+      result.removed.push({ path: sessDir, reason, kind: "session" });
     } catch (err) {
       result.errors.push({ path: sessDir, error: err.message });
     }

--- a/tests/utils/garbage-collector.test.js
+++ b/tests/utils/garbage-collector.test.js
@@ -155,18 +155,32 @@ describe("garbage-collector — sessions", () => {
       status: "approved",
       mtime: new Date(Date.now() - 2 * DAY),
     });
-    const runningNotFinal = await writeSession("sess-running", {
-      status: "running",
-      mtime: new Date(Date.now() - 100 * DAY),
-    });
 
     const result = await runManualGC({ sessionRetentionDays: 7, dryRun: false });
 
     const paths = result.removed.map((r) => r.path);
     expect(paths).toContain(oldApproved);
     expect(paths).not.toContain(recentApproved);
-    // Running is never touched, no matter how old.
-    expect(paths).not.toContain(runningNotFinal);
+  });
+
+  it("sweeps zombie running sessions older than staleRunningDays", async () => {
+    // Pipelines SIGKILL'd (power cut, terminal closed, OOM) leave stale
+    // running sessions that the old GC never reclaimed. Fix that.
+    const zombie = await writeSession("sess-zombie", {
+      status: "running",
+      mtime: new Date(Date.now() - 30 * DAY),
+    });
+    const activeRun = await writeSession("sess-active", {
+      status: "running",
+      mtime: new Date(Date.now() - 2 * DAY),
+    });
+
+    const result = await runManualGC({ sessionRetentionDays: 7, dryRun: false });
+
+    const paths = result.removed.map((r) => r.path);
+    expect(paths).toContain(zombie);
+    // Active run (within staleRunningDays) survives.
+    expect(paths).not.toContain(activeRun);
   });
 });
 


### PR DESCRIPTION
## Summary

Dogfood round 3 on v2.7.5 candidate. Post-nuke the user still saw 5 projects on the board when only 1 was expected. Plus a UX ask:

> \"No quiero 1 solo HuBoard, los huboard son independientes por proyecto. KJ los gestiona. Lo de All projects sobra, sessions y pipeline no entiendo qué significan.\"

## Three bugs + one UX redesign

### 1. Zombie running sessions never GC'd
Original logic only swept FINAL statuses (`approved`, `failed`, etc.). Pipelines SIGKILL'd (terminal close, OOM, power cut) left \`status: \"running\"\` forever. The user had 3 of these from 2 days ago.

**Fix**: new sweep for sessions older than \`staleRunningDays\` (default = \`sessionRetentionDays\`). Reason string tags them as \`zombie\`.

### 2. Unknown-status plans survived
`FINAL_PLAN_STATUSES` missed \`\"ready\"\` (a valid terminal state users opt into). And plans in truly unknown states (corrupt, future version) would leak forever.

**Fix**: \`FINAL_PLAN_STATUSES\` gains \`\"ready\"\`, new \`KNOWN_PLAN_STATUSES\` set makes unknown statuses fall under the draft window.

### 3. Board UI had no per-project view
Hard-wired multi-project: \"All Projects\" dropdown, Sessions tab, Pipeline link, big dashboard grid. No way to scope to the current project.

**Fix**: new URL shape \`/p/<slug>\` served by the existing SPA fallback.
- \`app.js\` detects the prefix, locks the project, boots in Kanban view.
- \`styles.css\` \`body.scoped-mode\` hides the project selector + Sessions + Pipeline + Dashboard nav buttons.
- \`kj plan\` and the post-\`kj run\` auto-start both use the scoped URL via \`projectSlug\` derived from \`projectDir\`.

## Live smoke

\`kj clean --nuke --yes\` on the dogfood box **after** this patch → sweeps 7 stale plans + 3 zombie sessions + 1 HU batch. Next \`kj plan\` opens \`http://localhost:4000/p/<slug>\` with exactly one project visible and no multi-project chrome.

## Test plan

- [x] New test: \`tests/utils/garbage-collector.test.js\` — \"sweeps zombie running sessions\". Old test renamed to reflect the split (finalised-only vs zombie-running).
- [x] **3 791 tests** / 301 files green.
- [x] Manual: opened \`http://localhost:4000/p/home_manu_ws_ai_linux-assistant-orchestrator\` — Kanban only, no dropdown, no Sessions, no Pipeline.