### PR TITLE
fix(board): Board is the landing view everywhere, not Dashboard

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -19,8 +19,15 @@ if (scopedProjectSlug) {
   document.body.classList.add('scoped-mode');
 }
 
-/** @type {string} Current view */
-let currentView = scopedProjectSlug ? 'board' : 'dashboard';
+/**
+ * Current view — Board is the default everywhere, not just in scoped mode.
+ * Dogfood quote: "Board vista por defecto. Dashboard es algo extra que a
+ * priori no me interesa, pq me interesan los proyectos." The Kanban is
+ * the thing the user wants to see first; Dashboard stays accessible via
+ * its nav button for the (rare) multi-project overview case but is never
+ * the landing view.
+ */
+let currentView = 'board';
 
 /** @type {string} Selected project ID (empty = all) */
 let selectedProject = scopedProjectSlug || '';
@@ -712,11 +719,13 @@ async function populateProjectSelect() {
  * Parses the hash route and renders.
  */
 function handleRoute() {
-  const hash = window.location.hash.slice(1) || 'dashboard';
+  // Board-first: the default landing view is always the Kanban. Dashboard
+  // is only shown when the user explicitly navigates to `#dashboard`.
+  const hash = window.location.hash.slice(1) || 'board';
   const parts = hash.split('/');
   // In scoped mode the project is locked — the hash controls the view
   // only. `board/<slug>` becomes `board` and the slug stays fixed.
-  currentView = parts[0] || (scopedProjectSlug ? 'board' : 'dashboard');
+  currentView = parts[0] || 'board';
   selectedProject = scopedProjectSlug || parts[1] || '';
 
   document.querySelectorAll('.nav-btn').forEach((btn) => {

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -20,8 +20,8 @@
       </div>
     </div>
     <nav class="header__nav">
-      <button class="nav-btn active" data-view="dashboard">Dashboard</button>
-      <button class="nav-btn" data-view="board">Board</button>
+      <button class="nav-btn active" data-view="board">Board</button>
+      <button class="nav-btn" data-view="dashboard">Dashboard</button>
       <button class="nav-btn" data-view="sessions">Sessions</button>
       <a class="nav-btn" href="/pipeline.html" title="Pipeline observability view (v2.7)">Pipeline</a>
       <select class="project-select" id="project-select">


### PR DESCRIPTION
## Summary

Dogfood quote: \"**BOARD vista por defecto. Dashboard es algo extra que a priori no me interesa, pq me interesa el proyecto.**\"

Pre-patch the board booted into Dashboard (multi-project card grid). That was fine when the board was global with ~1 project per dev, but with per-project scoping (#480) the Kanban is what the user actually cares about — Dashboard just wastes a click.

## What lands

- \`app.js\` \`currentView\` defaults to \`'board'\` unconditionally.
- \`app.js::handleRoute\` falls back to \`'board'\` on empty hash.
- \`index.html\` navbar marks Board as \`active\` on load; Dashboard moved to second position.

Dashboard stays reachable via its nav button for the rare cases where the multi-project overview is useful — it just is no longer the landing page.

## Test plan

- [x] 3 791 tests / 301 files green.
- [x] Manual: both \`http://localhost:4000/\` and \`http://localhost:4000/p/<slug>\` now land on the Kanban.