### PR TITLE
feat(board): interactive story status changes + bulk mark-plan-ready

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -381,10 +381,23 @@ async function renderBoard() {
       return;
     }
 
+    // Show "Mark all certified" bulk action only when a project is in focus
+    // AND at least one HU is still pending. Outside a project the action is
+    // ambiguous (which plan?) and irrelevant when nothing would change.
+    const pendingCount = columns.pending.length;
+    const canMarkReady = Boolean(selectedProject) && pendingCount > 0;
+
     app.innerHTML = `
       <div class="section-header">
         <span class="section-header__title" title="${selectedProject ? esc(selectedProject) : ''}">Story Board${selectedProject ? ` - ${esc(projectDisplayName)}` : ''}</span>
         <span class="section-header__count">${stories.length} stories</span>
+        ${canMarkReady ? `
+          <button class="control-btn" id="mark-project-ready"
+                  style="margin-left:auto;padding:6px 12px;font-size:0.85rem;background:var(--color-green);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;"
+                  title="Certify every pending HU of this project — equivalent to 'kj plan ready'">
+            Mark ${pendingCount} pending HU${pendingCount === 1 ? '' : 's'} as certified
+          </button>
+        ` : ''}
       </div>
       <div class="kanban">
         ${renderKanbanColumn('Pending', 'pending', columns.pending)}
@@ -393,6 +406,12 @@ async function renderBoard() {
         ${renderKanbanColumn('Done', 'done', columns.done)}
       </div>
     `;
+
+    if (canMarkReady) {
+      document.getElementById('mark-project-ready').addEventListener('click', async () => {
+        await markProjectReady(selectedProject);
+      });
+    }
   } catch (err) {
     app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading board</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
   }
@@ -533,6 +552,100 @@ function renderEmptyState(title, text) {
   `;
 }
 
+// ---- Story status mutations ----
+
+/**
+ * Render the status-action toolbar inside the story modal. The CLI speaks
+ * three statuses — pending / certified / done — and so do we. The "Certify"
+ * button is the primary action: it's what the user's here to do after
+ * reviewing the HU. We only show buttons for transitions that actually
+ * make sense from the current status, so the UI never offers a no-op.
+ * @param {object} story
+ * @returns {string}
+ */
+function renderStoryStatusActions(story) {
+  if (!story || !story.id) return '';
+  const status = String(story.status || 'pending');
+  const buttons = [];
+  if (status === 'pending' || status === 'needs_context') {
+    buttons.push(`<button class="control-btn" data-action="certify" style="background:var(--color-green);color:#fff;border:none;padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Certify</button>`);
+  }
+  if (status === 'certified') {
+    buttons.push(`<button class="control-btn" data-action="uncertify" style="background:var(--bg-secondary);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Back to pending</button>`);
+    buttons.push(`<button class="control-btn" data-action="done" style="background:var(--color-blue,#3b82f6);color:#fff;border:none;padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Mark done</button>`);
+  }
+  if (buttons.length === 0) return '';
+
+  // Inline-binder: we attach the click handlers from inside the modal
+  // after the innerHTML paint by hooking into the existing onclick flow.
+  // Doing this with setTimeout(0) avoids racing the DOM insertion.
+  setTimeout(() => {
+    document.querySelectorAll('.modal__status-actions [data-action]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const action = btn.dataset.action;
+        const next = action === 'certify' ? 'certified'
+          : action === 'uncertify' ? 'pending'
+          : action === 'done' ? 'done'
+          : null;
+        if (!next) return;
+        await patchStoryStatus(story.id, next);
+      });
+    });
+  }, 0);
+
+  return `<div class="modal__status-actions" style="display:flex;gap:8px;padding:12px 0;border-bottom:1px solid var(--border);margin-bottom:12px">${buttons.join('')}</div>`;
+}
+
+/**
+ * Change one HU's status. Re-renders the board on success; closes the
+ * modal so the user can confirm the move visually. On error we leave the
+ * modal open and surface the message inline.
+ * @param {string} storyId
+ * @param {string} status
+ */
+async function patchStoryStatus(storyId, status) {
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      alert(`Could not update status: ${msg}`);
+      return;
+    }
+    closeModal();
+    await renderBoard();
+  } catch (err) {
+    alert(`Could not update status: ${err.message}`);
+  }
+}
+
+/**
+ * Bulk-certify every pending HU of the currently selected project. Hits
+ * the server endpoint that mirrors `kj plan ready`, so the source-of-truth
+ * plan JSON is rewritten before the board re-renders.
+ * @param {string} projectId
+ */
+async function markProjectReady(projectId) {
+  try {
+    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/ready`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      alert(`Could not mark project ready: ${msg}`);
+      return;
+    }
+    await renderBoard();
+  } catch (err) {
+    alert(`Could not mark project ready: ${err.message}`);
+  }
+}
+
 // ---- Detail Modals ----
 
 /**
@@ -565,6 +678,8 @@ async function showStoryDetail(storyId) {
         </div>
         <button class="modal__close" onclick="closeModal()">&times;</button>
       </div>
+
+      ${renderStoryStatusActions(story)}
 
       <div class="modal__section">
         <div class="modal__section-title">Original Text</div>

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -95,6 +95,13 @@ export function initDb() {
     CREATE INDEX IF NOT EXISTS idx_context_story ON context_requests(story_id);
   `);
 
+  // --- Migrations ---
+  // plan_id: lets PATCH /api/stories/:id + POST /api/plans/:planId/ready
+  // locate the source-of-truth plan JSON at ~/.kj/plans/<slug>/<planId>.json.
+  // ALTER is idempotent on restart because we swallow the dup-column error.
+  try { db.exec('ALTER TABLE stories ADD COLUMN plan_id TEXT'); } catch { /* already migrated */ }
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
+
   return db;
 }
 
@@ -140,13 +147,13 @@ export function upsertStory(story) {
       certified_as, certified_want, certified_so_that,
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
-      created_at, updated_at, certified_at
+      created_at, updated_at, certified_at, plan_id
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
-      @created_at, @updated_at, @certified_at
+      @created_at, @updated_at, @certified_at, @plan_id
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -166,7 +173,8 @@ export function upsertStory(story) {
       ac_format = COALESCE(@ac_format, ac_format),
       acceptance_criteria = COALESCE(@acceptance_criteria, acceptance_criteria),
       updated_at = @updated_at,
-      certified_at = COALESCE(@certified_at, certified_at)
+      certified_at = COALESCE(@certified_at, certified_at),
+      plan_id = COALESCE(@plan_id, plan_id)
   `);
   stmt.run({
     id: story.id,
@@ -191,7 +199,51 @@ export function upsertStory(story) {
     created_at: story.created_at || new Date().toISOString(),
     updated_at: story.updated_at || new Date().toISOString(),
     certified_at: story.certified_at || null,
+    plan_id: story.plan_id || null,
   });
+}
+
+/**
+ * Look up a story row (minimal fields used by the mutation endpoints).
+ * @param {string} storyId
+ * @returns {{ id: string, project_id: string, plan_id: string|null, status: string }|null}
+ */
+export function getStoryRow(storyId) {
+  const row = getDb()
+    .prepare('SELECT id, project_id, plan_id, status FROM stories WHERE id = ?')
+    .get(storyId);
+  return row || null;
+}
+
+/**
+ * Update a single story's status (in-memory — the source-of-truth plan
+ * JSON is mutated separately by the caller before or after this write).
+ * @param {string} storyId
+ * @param {string} status
+ * @returns {boolean} true if a row was updated
+ */
+export function updateStoryStatus(storyId, status) {
+  const res = getDb()
+    .prepare('UPDATE stories SET status = ?, updated_at = ? WHERE id = ?')
+    .run(status, new Date().toISOString(), storyId);
+  return res.changes > 0;
+}
+
+/**
+ * List every distinct `plan_id` stamped on the stories of a given project.
+ * Used by "mark plan ready" so the board can act on each plan of a project
+ * without making the user pick one.
+ * @param {string} projectId
+ * @returns {string[]}
+ */
+export function listPlanIdsForProject(projectId) {
+  return getDb()
+    .prepare(`
+      SELECT DISTINCT plan_id FROM stories
+      WHERE project_id = ? AND plan_id IS NOT NULL
+    `)
+    .all(projectId)
+    .map((r) => r.plan_id);
 }
 
 /**

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -1,0 +1,140 @@
+/**
+ * Server-side mutations for plan HUs triggered from the board UI.
+ *
+ * The source of truth is the plan JSON at `~/.kj/plans/<slug>/<planId>.json`.
+ * Every mutation in this module follows the same protocol:
+ *
+ *   1. Load the plan JSON from disk.
+ *   2. Mutate it in-memory using the helpers from `src/plan/plan-hu-ops.js`
+ *      (so CLI `kj plan ready` and board "Mark ready" stay in lock-step).
+ *   3. Write the JSON back.
+ *   4. Re-sync the plan into SQLite via `syncPlanFile` so the board
+ *      reflects the change on the next render without a manual refresh.
+ *
+ * Steps 2-4 must share a single on-disk write: we never ack the mutation to
+ * the UI without persisting it, otherwise a reload would silently revert.
+ */
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { updateHuStatus, certifyAllHus } from '../../../src/plan/plan-hu-ops.js';
+import { syncPlanFile } from './sync.js';
+
+/**
+ * Root directory where `kj plan` writes `<slug>/<planId>.json`. Honours
+ * `KJ_PLANS_DIR` (tests) then `KJ_HOME/plans` (power users) then
+ * `~/.kj/plans/` (default) — same precedence as `sync.js::fullScan`.
+ */
+function plansRoot() {
+  if (process.env.KJ_PLANS_DIR) return process.env.KJ_PLANS_DIR;
+  if (process.env.KJ_HOME) return join(process.env.KJ_HOME, 'plans');
+  return join(homedir(), '.kj', 'plans');
+}
+
+/**
+ * Locate `<planId>.json` on disk. If `projectId` is known we go straight
+ * to that subdir; otherwise we fall back to scanning every project dir
+ * (costly, only used when the HU row pre-dates the `plan_id` migration
+ * and we have nothing else to go on).
+ *
+ * @param {string} planId
+ * @param {string|undefined} projectId
+ * @returns {string|null}
+ */
+export function findPlanFilePath(planId, projectId) {
+  const root = plansRoot();
+  if (!existsSync(root)) return null;
+  const fileName = `${planId}.json`;
+  if (projectId) {
+    const direct = join(root, projectId, fileName);
+    if (existsSync(direct)) return direct;
+  }
+  // Fall back to a scan so legacy rows without plan_id still work.
+  let dirs;
+  try { dirs = readdirSync(root); } catch { return null; }
+  for (const d of dirs) {
+    const candidate = join(root, d, fileName);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Load + validate a plan file in one step. Callers pass the on-disk path
+ * returned by `findPlanFilePath`.
+ * @param {string} filePath
+ */
+function readPlan(filePath) {
+  const raw = readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function writePlan(filePath, plan) {
+  writeFileSync(filePath, JSON.stringify(plan, null, 2), 'utf-8');
+}
+
+/**
+ * Change a single HU's status inside its plan JSON and re-sync into
+ * SQLite. Returns the new status, so callers can 200-reply with the
+ * committed value (not a shadow copy that might differ from disk).
+ *
+ * Valid statuses mirror the CLI: pending, certified, done. Anything else
+ * is rejected up the stack — we don't silently coerce.
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} args.huId
+ * @param {string} args.status - new status
+ * @param {string} [args.projectId] - optional hint to avoid the scan
+ * @returns {{ ok: true, status: string, planStatus: string } | { ok: false, error: string }}
+ */
+export function setHuStatus({ planId, huId, status, projectId }) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+
+  const plan = readPlan(filePath);
+  if (!Array.isArray(plan.hus)) return { ok: false, error: 'plan has no hus[]' };
+
+  const existed = updateHuStatus(plan, huId, status);
+  if (!existed) return { ok: false, error: `hu not found: ${huId}` };
+
+  // When every remaining HU is certified, auto-advance the plan status
+  // to "ready" so the CLI hint `kj run --plan <id>` matches reality.
+  // Conversely, downgrading the last certified HU back to pending must
+  // roll the plan back to "draft" — otherwise `kj run` would refuse to
+  // reload a supposedly-ready plan whose HUs disagree.
+  if (plan.hus.every((h) => h.status === 'certified' || h.status === 'done')) {
+    plan.status = 'ready';
+  } else if (plan.hus.some((h) => h.status === 'pending')) {
+    plan.status = 'draft';
+  }
+
+  writePlan(filePath, plan);
+  syncPlanFile(filePath);
+  return { ok: true, status, planStatus: plan.status };
+}
+
+/**
+ * Bulk certify: equivalent to `kj plan ready <planId>` over HTTP. Flips
+ * every pending HU to certified and sets `plan.status = "ready"`. No-op
+ * on already-ready plans (idempotent, returns count=0).
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} [args.projectId]
+ * @returns {{ ok: true, count: number, planStatus: string } | { ok: false, error: string }}
+ */
+export function markPlanReady({ planId, projectId }) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+
+  const plan = readPlan(filePath);
+  if (!Array.isArray(plan.hus) || plan.hus.length === 0) {
+    return { ok: false, error: 'plan has no hus[]' };
+  }
+
+  const count = certifyAllHus(plan);
+  writePlan(filePath, plan);
+  syncPlanFile(filePath);
+  return { ok: true, count, planStatus: plan.status };
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -12,8 +12,11 @@ import {
   deleteStory,
   deleteSession,
   getKjHome,
+  getStoryRow,
+  listPlanIdsForProject,
 } from '../db.js';
 import { fullScan } from '../sync.js';
+import { setHuStatus, markPlanReady } from '../plan-mutations.js';
 
 const router = Router();
 
@@ -197,6 +200,101 @@ router.delete('/sessions/:id', (req, res) => {
     const ok = deleteSession(req.params.id);
     if (!ok) return res.status(404).json({ error: 'Session not found' });
     res.json({ deleted: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * PATCH /api/stories/:id - Change a single HU's status.
+ *
+ * The row id on the board is `${projectId}::${huId}` — we split it here to
+ * feed the underlying plan-mutation helper. The source-of-truth plan JSON
+ * is rewritten first, then re-synced into SQLite, so a reload renders the
+ * committed state and never a stale view.
+ *
+ * Body: { status: "pending" | "certified" | "done" }
+ * Returns 400 on unknown status, 404 when the story / plan can't be found.
+ */
+const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'needs_context']);
+
+router.patch('/stories/:id', (req, res) => {
+  try {
+    const { status } = req.body || {};
+    if (!status || !ALLOWED_STORY_STATUSES.has(status)) {
+      return res.status(400).json({
+        error: `status must be one of: ${[...ALLOWED_STORY_STATUSES].join(', ')}`,
+      });
+    }
+    const row = getStoryRow(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Story not found' });
+    if (!row.plan_id) {
+      // HU came from a pre-migration batch.json or a non-plan source —
+      // refuse to mutate because we have no source-of-truth file to
+      // write to. The client should fall back to "delete + re-sync"
+      // for those rows.
+      return res.status(409).json({
+        error: 'Story is not backed by a plan file (legacy row). Re-run `kj plan` to re-import it.',
+      });
+    }
+    const huId = req.params.id.includes('::')
+      ? req.params.id.split('::').slice(1).join('::')
+      : req.params.id;
+    const result = setHuStatus({
+      planId: row.plan_id,
+      huId,
+      status,
+      projectId: row.project_id,
+    });
+    if (!result.ok) return res.status(404).json({ error: result.error });
+    res.json({ updated: true, id: req.params.id, status: result.status, planStatus: result.planStatus });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/plans/:planId/ready - Bulk-certify every pending HU of a plan.
+ * Equivalent to the CLI `kj plan ready <planId>`. Body is optional — if the
+ * client knows the projectId we use it as a fast path, otherwise we fall
+ * back to scanning the plans dir.
+ */
+router.post('/plans/:planId/ready', (req, res) => {
+  try {
+    const { projectId } = req.body || {};
+    const result = markPlanReady({ planId: req.params.planId, projectId });
+    if (!result.ok) return res.status(404).json({ error: result.error });
+    res.json({ ready: true, planId: req.params.planId, count: result.count, planStatus: result.planStatus });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/projects/:id/ready - Sugar: mark every plan of a project ready
+ * in one call. Lets the board expose a single "Mark all certified" button
+ * per project view without the UI having to enumerate plan ids first.
+ */
+router.post('/projects/:id/ready', (req, res) => {
+  try {
+    const planIds = listPlanIdsForProject(req.params.id);
+    if (planIds.length === 0) {
+      return res.status(404).json({ error: 'No plan-backed stories for this project' });
+    }
+    const results = [];
+    for (const planId of planIds) {
+      const r = markPlanReady({ planId, projectId: req.params.id });
+      results.push({ planId, ...r });
+    }
+    const totalCertified = results
+      .filter((r) => r.ok)
+      .reduce((acc, r) => acc + r.count, 0);
+    res.json({
+      ready: true,
+      projectId: req.params.id,
+      plans: results,
+      totalCertified,
+    });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -289,7 +289,7 @@ function syncSessionFile(filePath) {
  * Sync a v2 plan file (with embedded HUs) to SQLite.
  * Plans are the authoritative source — replaces hu-stories for plan-based runs.
  */
-function syncPlanFile(filePath) {
+export function syncPlanFile(filePath) {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const data = JSON.parse(raw);
@@ -345,6 +345,9 @@ function syncPlanFile(filePath) {
         created_at: hu.createdAt,
         updated_at: hu.updatedAt,
         certified_at: null,
+        // Stamp plan_id so the PATCH / mark-ready endpoints can locate
+        // the source plan JSON without walking the plans dir.
+        plan_id: data.planId,
       });
     }
 

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+
+// Tests for the new write endpoints that back the HU Board's "Certify" /
+// "Mark ready" buttons:
+//   - PATCH  /api/stories/:id
+//   - POST   /api/plans/:planId/ready
+//   - POST   /api/projects/:id/ready
+//
+// Every mutation must update the plan JSON on disk FIRST, then re-sync the
+// SQLite row — otherwise a page reload would silently revert the change.
+// Each test reloads the plan file to assert that the disk reflects the
+// ack'd state (not just the cache).
+
+let tmpHome;
+let tmpPlansDir;
+let app;
+let dbMod;
+let planMutationsMod;
+let syncMod;
+
+const PROJECT_ID = 'home_manu_ws_ai_demo-project';
+const PLAN_ID = 'plan-20260424101010-abcd';
+
+function planPath() {
+  return join(tmpPlansDir, PROJECT_ID, `${PLAN_ID}.json`);
+}
+
+function writePlanToDisk(overrides = {}) {
+  mkdirSync(join(tmpPlansDir, PROJECT_ID), { recursive: true });
+  const plan = {
+    planId: PLAN_ID,
+    version: 2,
+    status: 'draft',
+    projectDir: '/home/manu/ws/ai/demo-project',
+    task: 'build thing',
+    name: 'demo plan',
+    createdAt: '2026-04-24T10:10:10Z',
+    updatedAt: '2026-04-24T10:10:10Z',
+    hus: [
+      { id: `${PLAN_ID}_001`, title: 'hu one', status: 'pending', acceptance_criteria: [], createdAt: '2026-04-24T10:10:10Z', updatedAt: '2026-04-24T10:10:10Z' },
+      { id: `${PLAN_ID}_002`, title: 'hu two', status: 'pending', acceptance_criteria: [], createdAt: '2026-04-24T10:10:10Z', updatedAt: '2026-04-24T10:10:10Z' },
+      { id: `${PLAN_ID}_003`, title: 'hu three', status: 'pending', acceptance_criteria: [], createdAt: '2026-04-24T10:10:10Z', updatedAt: '2026-04-24T10:10:10Z' },
+    ],
+    ...overrides,
+  };
+  writeFileSync(planPath(), JSON.stringify(plan, null, 2), 'utf-8');
+  return plan;
+}
+
+function readPlanFromDisk() {
+  return JSON.parse(readFileSync(planPath(), 'utf-8'));
+}
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'hu-board-mut-'));
+  tmpPlansDir = mkdtempSync(join(tmpdir(), 'hu-board-plans-'));
+  process.env.KJ_HOME = tmpHome;
+  process.env.KJ_PLANS_DIR = tmpPlansDir;
+
+  // Modules are imported once across the suite; `initDb()` swaps the
+  // underlying SQLite handle to one rooted in the per-test tmpHome, and
+  // `closeDb()` in afterEach tears it down — so each test gets a clean
+  // board + plans root without the cache-busting import tricks vitest
+  // refuses to evaluate.
+  dbMod = await import('../src/db.js');
+  planMutationsMod = await import('../src/plan-mutations.js');
+  syncMod = await import('../src/sync.js');
+  const { default: apiRoutes } = await import('../src/routes/api.js');
+
+  dbMod.initDb();
+
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRoutes);
+
+  // Seed: write plan → sync → board sees 3 pending HUs.
+  writePlanToDisk();
+  syncMod.syncPlanFile(planPath());
+});
+
+afterEach(() => {
+  dbMod.closeDb();
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(tmpPlansDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+});
+
+describe('PATCH /api/stories/:id', () => {
+  it('certifies a pending HU and writes the new status to the plan JSON', async () => {
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ status: 'certified' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('certified');
+
+    const diskPlan = readPlanFromDisk();
+    const hu = diskPlan.hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.status).toBe('certified');
+  });
+
+  it('auto-advances plan.status to ready when every HU ends up certified', async () => {
+    for (const n of ['001', '002', '003']) {
+      await request(app)
+        .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_${n}`)}`)
+        .send({ status: 'certified' });
+    }
+    const diskPlan = readPlanFromDisk();
+    expect(diskPlan.status).toBe('ready');
+  });
+
+  it('rolls plan.status back to draft when a certified HU is downgraded', async () => {
+    // First make the plan ready...
+    for (const n of ['001', '002', '003']) {
+      await request(app)
+        .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_${n}`)}`)
+        .send({ status: 'certified' });
+    }
+    expect(readPlanFromDisk().status).toBe('ready');
+    // ...then uncertify one.
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_002`)}`)
+      .send({ status: 'pending' });
+    expect(res.status).toBe(200);
+    expect(readPlanFromDisk().status).toBe('draft');
+  });
+
+  it('rejects an unknown status with 400 and does not touch disk', async () => {
+    const before = JSON.stringify(readPlanFromDisk());
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_001`)}`)
+      .send({ status: 'reticulating-splines' });
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(readPlanFromDisk())).toBe(before);
+  });
+
+  it('returns 404 for an unknown story id', async () => {
+    const res = await request(app)
+      .patch('/api/stories/nope')
+      .send({ status: 'certified' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/plans/:planId/ready', () => {
+  it('certifies every pending HU and flips the plan to ready', async () => {
+    const res = await request(app)
+      .post(`/api/plans/${PLAN_ID}/ready`)
+      .send({ projectId: PROJECT_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+    expect(res.body.planStatus).toBe('ready');
+
+    const diskPlan = readPlanFromDisk();
+    expect(diskPlan.status).toBe('ready');
+    expect(diskPlan.hus.every((h) => h.status === 'certified')).toBe(true);
+  });
+
+  it('works without a projectId hint by falling back to a plans-dir scan', async () => {
+    const res = await request(app).post(`/api/plans/${PLAN_ID}/ready`).send({});
+    expect(res.status).toBe(200);
+    expect(res.body.count).toBe(3);
+  });
+
+  it('returns 404 for an unknown planId', async () => {
+    const res = await request(app).post('/api/plans/plan-ghost/ready').send({});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/projects/:id/ready', () => {
+  it('bulk-certifies every plan of a project', async () => {
+    const res = await request(app)
+      .post(`/api/projects/${encodeURIComponent(PROJECT_ID)}/ready`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.totalCertified).toBe(3);
+    expect(readPlanFromDisk().status).toBe('ready');
+  });
+
+  it('returns 404 when the project has no plan-backed stories', async () => {
+    dbMod.upsertProject({ id: 'bare-project', name: 'Bare' });
+    dbMod.upsertStory({ id: 'bare-project::hu-x', project_id: 'bare-project', status: 'pending' });
+    const res = await request(app)
+      .post(`/api/projects/${encodeURIComponent('bare-project')}/ready`)
+      .send({});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('plan_id stamping via syncPlanFile', () => {
+  it('persists plan_id on every story row so PATCH can find the file', () => {
+    const row = dbMod.getStoryRow(`${PROJECT_ID}::${PLAN_ID}_001`);
+    expect(row).not.toBeNull();
+    expect(row.plan_id).toBe(PLAN_ID);
+    expect(row.project_id).toBe(PROJECT_ID);
+  });
+
+  it('listPlanIdsForProject returns distinct plan ids', () => {
+    const ids = dbMod.listPlanIdsForProject(PROJECT_ID);
+    expect(ids).toEqual([PLAN_ID]);
+  });
+});


### PR DESCRIPTION
## Summary

Until this PR the HU Board was read-only for story status — you could view / open / delete HUs but had to drop to \`kj plan ready <planId>\` on the CLI to certify. Dogfooding v2.7.5 made that painful (\"I see the HUs but I can't interact beyond opening them\").

This wires up the full write path end-to-end:

- **PATCH /api/stories/:id** \`{ status }\` — per-HU status change (pending / certified / done / needs_context). Rewrites the source-of-truth plan JSON at \`~/.kj/plans/<slug>/<planId>.json\` FIRST, then re-syncs SQLite, so a page reload never reverts the change. Auto-advances \`plan.status\` to \`ready\` once every HU is certified, rolls it back to \`draft\` when a certified HU is downgraded.
- **POST /api/plans/:planId/ready** — bulk certify, equivalent to \`kj plan ready <planId>\`. Idempotent.
- **POST /api/projects/:id/ready** — sugar over every plan of a project so the UI can expose a single \"Mark all certified\" button without enumerating plan ids first.

## UI

- Story modal gets a status action row (\"Certify\" / \"Back to pending\" / \"Mark done\") that only shows transitions that make sense from the current state.
- Project view gets a green \"Mark N pending HUs as certified\" button in the section header, visible only when scoped to a project AND at least one pending HU remains.

## Schema

Idempotent ALTER-TABLE migration adds a nullable \`plan_id\` column to \`stories\` so PATCH can find the source plan file without scanning the plans dir. Legacy rows without \`plan_id\` return 409 (\"not backed by a plan file — re-run \`kj plan\`\") instead of being silently lost.

## Tests

12 new in \`packages/hu-board/tests/plan-mutations.test.js\`:
- PATCH certifies, persists to disk, handles unknown statuses / stories.
- Plan status auto-advances ready ↔ draft as HUs change.
- POST /plans/:planId/ready with and without projectId hint.
- POST /projects/:id/ready returns 404 on bare projects.
- \`plan_id\` stamping via \`syncPlanFile\`.

73/73 hu-board tests + 3791/3791 parent suite all green.

## Test plan

- [x] vitest run packages/hu-board/ → 73/73
- [x] vitest run tests/ → 3791/3791
- [ ] Manual: open board on a \`kj plan\` output → click Certify → HU moves column → re-run \`kj plan show <id>\` → status is \"certified\" on disk