### PR TITLE
feat(board): run-plan flow, live plan sync, richer cards

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -369,11 +369,25 @@ async function renderBoard() {
       ? (projectNameCache[selectedProject] || humaniseProjectName(selectedProject))
       : '';
 
+    // Kanban status → column mapping. The plan schema recognises seven
+    // statuses (pending/certified/coding/reviewing/done/failed/blocked/
+    // needs_context) but the user only cares about four lanes:
+    //   - Pending: anything generated but not running yet (including the
+    //     legacy intermediate "certified" state, which is a no-op from
+    //     the user's perspective — "I said it's ok to run but kj hasn't
+    //     started yet").
+    //   - Running: actively being processed by the pipeline.
+    //   - Done:    pipeline approved.
+    //   - Failed:  pipeline rejected.
+    // Empty lanes are hidden so the board doesn't fill with sad empty
+    // columns when a run is purely green.
     const columns = {
-      pending: stories.filter((s) => s.status === 'pending'),
-      needs_context: stories.filter((s) => s.status === 'needs_context'),
-      certified: stories.filter((s) => s.status === 'certified'),
+      pending: stories.filter((s) =>
+        ['pending', 'certified', 'needs_context', 'blocked'].includes(s.status)
+      ),
+      running: stories.filter((s) => ['coding', 'reviewing'].includes(s.status)),
       done: stories.filter((s) => s.status === 'done'),
+      failed: stories.filter((s) => s.status === 'failed'),
     };
 
     if (stories.length === 0) {
@@ -381,35 +395,49 @@ async function renderBoard() {
       return;
     }
 
-    // Show "Mark all certified" bulk action only when a project is in focus
-    // AND at least one HU is still pending. Outside a project the action is
-    // ambiguous (which plan?) and irrelevant when nothing would change.
-    const pendingCount = columns.pending.length;
-    const canMarkReady = Boolean(selectedProject) && pendingCount > 0;
+    // "Run plan" bulk action: visible when a project is selected AND at
+    // least one HU is still awaiting execution AND nothing's currently
+    // running (to avoid accidentally launching a second pipeline over a
+    // live one). Replaces the old "Mark as certified" button — the
+    // intermediate "certified" state was noise from the user's POV.
+    const awaitingCount = columns.pending.length;
+    const runningCount = columns.running.length;
+    const canRun = Boolean(selectedProject) && awaitingCount > 0 && runningCount === 0;
+    const isRunning = runningCount > 0;
+
+    const visibleColumns = [
+      { title: 'Pending', cls: 'pending', rows: columns.pending },
+      { title: 'Running', cls: 'running', rows: columns.running },
+      { title: 'Done', cls: 'done', rows: columns.done },
+      { title: 'Failed', cls: 'failed', rows: columns.failed },
+    ].filter((c) => c.rows.length > 0 || c.title === 'Pending');
 
     app.innerHTML = `
       <div class="section-header">
         <span class="section-header__title" title="${selectedProject ? esc(selectedProject) : ''}">Story Board${selectedProject ? ` - ${esc(projectDisplayName)}` : ''}</span>
         <span class="section-header__count">${stories.length} stories</span>
-        ${canMarkReady ? `
-          <button class="control-btn" id="mark-project-ready"
-                  style="margin-left:auto;padding:6px 12px;font-size:0.85rem;background:var(--color-green);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;"
-                  title="Certify every pending HU of this project — equivalent to 'kj plan ready'">
-            Mark ${pendingCount} pending HU${pendingCount === 1 ? '' : 's'} as certified
+        ${isRunning ? `
+          <span class="section-header__badge"
+                style="margin-left:auto;padding:4px 10px;font-size:0.8rem;background:var(--color-yellow,#eab308);color:#000;border-radius:var(--radius-sm);font-weight:600;">
+            ⚙ ${runningCount} running…
+          </span>
+        ` : ''}
+        ${canRun ? `
+          <button class="control-btn" id="run-plan-btn"
+                  style="margin-left:auto;padding:6px 14px;font-size:0.9rem;background:var(--color-green);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;"
+                  title="Launch kj run --plan over every plan in this project">
+            ▶ Run plan (${awaitingCount} HU${awaitingCount === 1 ? '' : 's'})
           </button>
         ` : ''}
       </div>
       <div class="kanban">
-        ${renderKanbanColumn('Pending', 'pending', columns.pending)}
-        ${renderKanbanColumn('Needs Context', 'needs-context', columns.needs_context)}
-        ${renderKanbanColumn('Certified', 'certified', columns.certified)}
-        ${renderKanbanColumn('Done', 'done', columns.done)}
+        ${visibleColumns.map((c) => renderKanbanColumn(c.title, c.cls, c.rows)).join('')}
       </div>
     `;
 
-    if (canMarkReady) {
-      document.getElementById('mark-project-ready').addEventListener('click', async () => {
-        await markProjectReady(selectedProject);
+    if (canRun) {
+      document.getElementById('run-plan-btn').addEventListener('click', async () => {
+        await runProject(selectedProject);
       });
     }
   } catch (err) {
@@ -445,22 +473,41 @@ function renderKanbanColumn(title, cssClass, stories) {
 function renderStoryCard(story) {
   const title = story.title || story.original_text || story.id;
   const antipatterns = story.antipatterns ? JSON.parse(story.antipatterns) : [];
-  const acCount = story.acceptance_criteria ? JSON.parse(story.acceptance_criteria).length : 0;
+  // Prefer denormalised counters stamped at sync time; fall back to
+  // parsing the JSON blob for pre-migration rows so the card still shows
+  // the AC count without a board DB nuke.
+  const acCount = typeof story.ac_count === 'number'
+    ? story.ac_count
+    : (story.acceptance_criteria ? JSON.parse(story.acceptance_criteria).length : 0);
+  const testCount = typeof story.test_count === 'number' ? story.test_count : 0;
+  const blockedBy = story.blocked_by ? JSON.parse(story.blocked_by) : [];
   const initials = projectInitialsCache[story.project_id] || 'kj';
   const shortId = shortStoryId(story, initials);
+
+  // Human-readable dep list: `lao-001, lao-003` instead of the raw HU ids.
+  const shortDep = (depId) => {
+    const m = /_(\d+)(?!.*\d)/.exec(depId);
+    return `${initials}-${m ? m[1] : '?'}`;
+  };
 
   return `
     <div class="story-card" onclick="showStoryDetail('${esc(story.id)}')">
       <div class="story-card__id" title="${esc(story.id)}">${esc(shortId)}</div>
       <div class="story-card__title">${esc(truncate(title, 100))}</div>
-      <div class="story-card__meta">
+      <div class="story-card__meta" style="gap:10px">
+        ${acCount > 0 ? `<span title="${acCount} acceptance criteria">📋 ${acCount} AC${acCount === 1 ? '' : 's'}</span>` : ''}
+        ${testCount > 0 ? `<span title="${testCount} acceptance tests">🧪 ${testCount} test${testCount === 1 ? '' : 's'}</span>` : ''}
         ${story.quality_total !== null ? `
-          <span class="story-card__score ${scoreClass(story.quality_total)}">
-            Score: ${story.quality_total}/60 ${qualityBar(story.quality_total)}
+          <span class="story-card__score ${scoreClass(story.quality_total)}" title="INVEST score">
+            ${story.quality_total}/60 ${qualityBar(story.quality_total)}
           </span>
         ` : ''}
-        ${acCount > 0 ? `<span class="story-card__ac">AC: ${acCount} criteria${story.ac_format ? ` (${esc(story.ac_format)})` : ''}</span>` : ''}
       </div>
+      ${blockedBy.length > 0 ? `
+        <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--text-muted)" title="This HU waits on: ${esc(blockedBy.join(', '))}">
+          ⏳ waits for: ${blockedBy.map((d) => esc(shortDep(d))).join(', ')}
+        </div>
+      ` : ''}
       ${antipatterns.length > 0 ? `<div class="story-card__antipattern">${antipatterns.map((a) => esc(a)).join(', ')}</div>` : ''}
       <div class="story-card__meta" style="margin-top:6px">
         <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
@@ -552,109 +599,29 @@ function renderEmptyState(title, text) {
   `;
 }
 
-// ---- Story status mutations ----
+// ---- Plan execution ----
+//
+// The board delegates execution to the CLI via `POST /api/projects/:id/run`.
+// There's no more intermediate "certify" step: the user reviews HUs
+// (editing inline if needed — see edit-in-place PR), and when happy
+// clicks "Run plan", which spawns `kj run --plan <id>` as a detached
+// child on the server. Status updates flow back through the plan JSON
+// watcher without any manual refresh.
+//
+// We still expose a per-HU status PATCH endpoint for corrective moves
+// (e.g. retry a failed HU manually), but it's no longer the primary
+// action on the card.
 
 /**
- * Render the status-action toolbar inside the story modal. The CLI speaks
- * three statuses — pending / certified / done — and so do we. The "Certify"
- * button is the primary action: it's what the user's here to do after
- * reviewing the HU. We only show buttons for transitions that actually
- * make sense from the current status, so the UI never offers a no-op.
- * @param {object} story
- * @returns {string}
- */
-function renderStoryStatusActions(story) {
-  if (!story || !story.id) return '';
-  const status = String(story.status || 'pending');
-  const buttons = [];
-  if (status === 'pending' || status === 'needs_context') {
-    buttons.push(`<button class="control-btn" data-action="certify" style="background:var(--color-green);color:#fff;border:none;padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Certify</button>`);
-  }
-  if (status === 'certified') {
-    buttons.push(`<button class="control-btn" data-action="uncertify" style="background:var(--bg-secondary);border:1px solid var(--border);padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Back to pending</button>`);
-    buttons.push(`<button class="control-btn" data-action="done" style="background:var(--color-blue,#3b82f6);color:#fff;border:none;padding:6px 14px;border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem">Mark done</button>`);
-  }
-  if (buttons.length === 0) return '';
-
-  // Inline-binder: we attach the click handlers from inside the modal
-  // after the innerHTML paint by hooking into the existing onclick flow.
-  // Doing this with setTimeout(0) avoids racing the DOM insertion.
-  setTimeout(() => {
-    document.querySelectorAll('.modal__status-actions [data-action]').forEach((btn) => {
-      btn.addEventListener('click', async () => {
-        const action = btn.dataset.action;
-        const next = action === 'certify' ? 'certified'
-          : action === 'uncertify' ? 'pending'
-          : action === 'done' ? 'done'
-          : null;
-        if (!next) return;
-        await patchStoryStatus(story.id, next);
-      });
-    });
-  }, 0);
-
-  return `<div class="modal__status-actions" style="display:flex;gap:8px;padding:12px 0;border-bottom:1px solid var(--border);margin-bottom:12px">${buttons.join('')}</div>`;
-}
-
-/**
- * Change one HU's status. Re-renders the board on success; closes the
- * modal so the user can confirm the move visually. On error we leave the
- * modal open and surface the message inline.
- * @param {string} storyId
- * @param {string} status
- */
-async function patchStoryStatus(storyId, status) {
-  try {
-    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status }),
-    });
-    if (!res.ok) {
-      // 404 from Express itself (no matching route) vs 404 from our
-      // handler (story not found) — if the endpoint simply isn't wired
-      // up, the server is probably still on a pre-v2.7.5 build. The
-      // generic message here was "Could not update status: HTTP 404",
-      // which was technically correct but useless. Be explicit.
-      if (res.status === 404) {
-        await showError(
-          'The board server does not recognise the PATCH endpoint.\n\n'
-          + 'This usually means the board process is still running a pre-v2.7.5 build. '
-          + 'Restart it with:\n\n'
-          + '    kj board stop && kj board start\n\n'
-          + 'Then reload this page.',
-          { title: 'Board out of date' }
-        );
-        return;
-      }
-      if (res.status === 409) {
-        await showError(
-          'This story is not backed by a plan file (legacy row from before '
-          + 'plan_id stamping). Re-run `kj plan` to re-import it.',
-          { title: 'Cannot certify legacy row' }
-        );
-        return;
-      }
-      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
-      await showError(msg, { title: 'Could not update status' });
-      return;
-    }
-    closeModal();
-    await renderBoard();
-  } catch (err) {
-    await showError(err.message, { title: 'Could not update status' });
-  }
-}
-
-/**
- * Bulk-certify every pending HU of the currently selected project. Hits
- * the server endpoint that mirrors `kj plan ready`, so the source-of-truth
- * plan JSON is rewritten before the board re-renders.
+ * Launch the pipeline over every plan of a project. Returns when the
+ * spawn ack is received — not when the run completes. Live progress is
+ * reflected automatically by the plans-dir watcher on the server, so
+ * the board re-renders without us having to poll.
  * @param {string} projectId
  */
-async function markProjectReady(projectId) {
+async function runProject(projectId) {
   try {
-    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/ready`, {
+    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
@@ -662,7 +629,7 @@ async function markProjectReady(projectId) {
     if (!res.ok) {
       if (res.status === 404) {
         await showError(
-          'The board server does not recognise the "mark ready" endpoint.\n\n'
+          'The board server does not recognise the "run" endpoint.\n\n'
           + 'Most likely cause: the board process is running a pre-v2.7.5 build. '
           + 'Restart it with:\n\n'
           + '    kj board stop && kj board start',
@@ -671,12 +638,24 @@ async function markProjectReady(projectId) {
         return;
       }
       const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
-      await showError(msg, { title: 'Could not mark project ready' });
+      await showError(msg, { title: 'Could not launch run' });
       return;
     }
+    const body = await res.json();
+    // Best-effort: a chokidar tick may still be in flight, so fetch
+    // once explicitly to surface the "running" state without waiting
+    // for the watcher debounce.
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
     await renderBoard();
+    await showError(
+      `Pipeline launched for ${body.launched}/${body.total} plan(s).\n\n`
+      + 'The HUs will transition through coding → reviewing → done as '
+      + 'kj runs them. Refresh is automatic once the watcher picks up '
+      + 'each status change.',
+      { title: 'Run started' }
+    );
   } catch (err) {
-    await showError(err.message, { title: 'Could not mark project ready' });
+    await showError(err.message, { title: 'Could not launch run' });
   }
 }
 
@@ -713,7 +692,6 @@ async function showStoryDetail(storyId) {
         <button class="modal__close" onclick="closeModal()">&times;</button>
       </div>
 
-      ${renderStoryStatusActions(story)}
 
       <div class="modal__section">
         <div class="modal__section-title">Original Text</div>
@@ -792,14 +770,18 @@ async function showStoryDetail(storyId) {
         </div>
       ` : ''}
 
-      <div class="modal__section">
-        <div class="modal__section-title">Metadata</div>
-        <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(story.project_id)}</div>
-        <div class="modal__field"><span class="modal__field-label">Session:</span> ${esc(story.session_id || '--')}</div>
-        <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(story.created_at || '--')}</div>
-        <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(story.updated_at || '--')}</div>
-        ${story.certified_at ? `<div class="modal__field"><span class="modal__field-label">Certified at:</span> ${esc(story.certified_at)}</div>` : ''}
-      </div>
+      <details class="modal__section" style="margin-top:8px">
+        <summary style="cursor:pointer;font-weight:600;font-size:0.85rem;color:var(--text-muted);padding:6px 0">
+          Metadata
+        </summary>
+        <div style="padding-top:6px">
+          <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(story.project_id)}</div>
+          <div class="modal__field"><span class="modal__field-label">Session:</span> ${esc(story.session_id || '--')}</div>
+          <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(story.created_at || '--')}</div>
+          <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(story.updated_at || '--')}</div>
+          ${story.certified_at ? `<div class="modal__field"><span class="modal__field-label">Certified at:</span> ${esc(story.certified_at)}</div>` : ''}
+        </div>
+      </details>
     `;
   } catch (err) {
     content.innerHTML = `<div class="modal__header"><div class="modal__title">Error</div><button class="modal__close" onclick="closeModal()">&times;</button></div><p>${esc(err.message)}</p>`;
@@ -904,12 +886,16 @@ async function showSessionDetail(sessionId) {
         </div>
       ` : ''}
 
-      <div class="modal__section">
-        <div class="modal__section-title">Metadata</div>
-        <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(session.project_id)}</div>
-        <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(session.created_at || '--')}</div>
-        <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(session.updated_at || '--')}</div>
-      </div>
+      <details class="modal__section" style="margin-top:8px">
+        <summary style="cursor:pointer;font-weight:600;font-size:0.85rem;color:var(--text-muted);padding:6px 0">
+          Metadata
+        </summary>
+        <div style="padding-top:6px">
+          <div class="modal__field"><span class="modal__field-label">Project:</span> ${esc(session.project_id)}</div>
+          <div class="modal__field"><span class="modal__field-label">Created:</span> ${esc(session.created_at || '--')}</div>
+          <div class="modal__field"><span class="modal__field-label">Updated:</span> ${esc(session.updated_at || '--')}</div>
+        </div>
+      </details>
     `;
   } catch (err) {
     content.innerHTML = `<div class="modal__header"><div class="modal__title">Error</div><button class="modal__close" onclick="closeModal()">&times;</button></div><p>${esc(err.message)}</p>`;

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -96,10 +96,19 @@ export function initDb() {
   `);
 
   // --- Migrations ---
-  // plan_id: lets PATCH /api/stories/:id + POST /api/plans/:planId/ready
-  // locate the source-of-truth plan JSON at ~/.kj/plans/<slug>/<planId>.json.
-  // ALTER is idempotent on restart because we swallow the dup-column error.
+  // Each ALTER is idempotent on restart — we swallow the duplicate-column
+  // error so adding one over time doesn't force a board DB nuke.
+  //
+  // plan_id:       lets the mutation endpoints locate the source-of-truth plan
+  //                JSON at ~/.kj/plans/<slug>/<planId>.json without a scan.
+  // ac_count:      number of acceptance criteria, surfaced on the card.
+  // test_count:    number of acceptance_tests, surfaced on the card.
+  // blocked_by:    denormalised JSON array of HU ids this story waits on,
+  //                so the card can render `⏳ waits for: lao-001` inline.
   try { db.exec('ALTER TABLE stories ADD COLUMN plan_id TEXT'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN ac_count INTEGER'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN test_count INTEGER'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN blocked_by TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   return db;
@@ -147,13 +156,15 @@ export function upsertStory(story) {
       certified_as, certified_want, certified_so_that,
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
-      created_at, updated_at, certified_at, plan_id
+      created_at, updated_at, certified_at, plan_id,
+      ac_count, test_count, blocked_by
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
-      @created_at, @updated_at, @certified_at, @plan_id
+      @created_at, @updated_at, @certified_at, @plan_id,
+      @ac_count, @test_count, @blocked_by
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -174,7 +185,10 @@ export function upsertStory(story) {
       acceptance_criteria = COALESCE(@acceptance_criteria, acceptance_criteria),
       updated_at = @updated_at,
       certified_at = COALESCE(@certified_at, certified_at),
-      plan_id = COALESCE(@plan_id, plan_id)
+      plan_id = COALESCE(@plan_id, plan_id),
+      ac_count = COALESCE(@ac_count, ac_count),
+      test_count = COALESCE(@test_count, test_count),
+      blocked_by = COALESCE(@blocked_by, blocked_by)
   `);
   stmt.run({
     id: story.id,
@@ -200,6 +214,9 @@ export function upsertStory(story) {
     updated_at: story.updated_at || new Date().toISOString(),
     certified_at: story.certified_at || null,
     plan_id: story.plan_id || null,
+    ac_count: story.ac_count ?? null,
+    test_count: story.test_count ?? null,
+    blocked_by: story.blocked_by || null,
   });
 }
 

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -14,11 +14,21 @@
  * Steps 2-4 must share a single on-disk write: we never ack the mutation to
  * the UI without persisting it, otherwise a reload would silently revert.
  */
-import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, openSync } from 'node:fs';
+import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { updateHuStatus, certifyAllHus } from '../../../src/plan/plan-hu-ops.js';
 import { syncPlanFile } from './sync.js';
+
+// Repo root → so we can spawn `node <repo>/src/cli.js run ...` without
+// depending on `kj` being in $PATH of the board process.
+const REPO_ROOT = (() => {
+  const here = dirname(fileURLToPath(import.meta.url));       // packages/hu-board/src
+  return join(here, '..', '..', '..');                         // → repo root
+})();
+const KJ_CLI = join(REPO_ROOT, 'src', 'cli.js');
 
 /**
  * Root directory where `kj plan` writes `<slug>/<planId>.json`. Honours
@@ -137,4 +147,72 @@ export function markPlanReady({ planId, projectId }) {
   writePlan(filePath, plan);
   syncPlanFile(filePath);
   return { ok: true, count, planStatus: plan.status };
+}
+
+/**
+ * Launch `kj run --plan <planId>` as a detached child. This is the
+ * "Run plan" button's server-side handler: the board no longer asks the
+ * user to drop to the terminal to kick off execution.
+ *
+ * We spawn against the repo's own CLI (`node <repo>/src/cli.js`) instead
+ * of a `kj` binary on $PATH — the board is always shipped with the repo
+ * that hosts it, so that entry point is guaranteed to exist. Tests set
+ * `KJ_RUN_SPAWN_MODE=echo` to replace the spawn with a no-op that just
+ * returns a fake pid, so we can assert payload shape without booting the
+ * whole orchestrator inside vitest.
+ *
+ * Output is redirected to `~/.karajan/hu-board-runs/<planId>.log` so the
+ * board can tail it later if we wire up a live log viewer — for now it's
+ * just a durable trail. stdin is `ignore` (coder subprocess requirement
+ * documented in CLAUDE.md).
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} [args.projectId]
+ * @param {string} [args.taskOverride] - optional custom task string
+ * @returns {{ ok: true, pid: number, logPath: string } | { ok: false, error: string }}
+ */
+export function runPlan({ planId, projectId, taskOverride } = {}) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+
+  const plan = readPlan(filePath);
+  if (!Array.isArray(plan.hus) || plan.hus.length === 0) {
+    return { ok: false, error: 'plan has no hus[]' };
+  }
+  const projectDir = plan.projectDir;
+  if (!projectDir) {
+    return {
+      ok: false,
+      error:
+        'plan has no projectDir stamped — re-run `kj plan` to regenerate it, '
+        + 'then try again (plans pre-v2.7.4 did not persist the dir).',
+    };
+  }
+
+  const runsDir = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-board-runs');
+  mkdirSync(runsDir, { recursive: true });
+  const logPath = join(runsDir, `${planId}.log`);
+
+  const task = taskOverride || plan.task || `run plan ${planId}`;
+  const args = [KJ_CLI, 'run', '--plan', planId, task];
+
+  // Escape hatch for tests — hard-kill the spawn so vitest doesn't boot
+  // the full orchestrator. The shape of the response is what we assert.
+  if (process.env.KJ_RUN_SPAWN_MODE === 'echo') {
+    return { ok: true, pid: 0, logPath, argv: [process.execPath, ...args], projectDir };
+  }
+
+  const out = openSync(logPath, 'a');
+  const err = openSync(logPath, 'a');
+  const child = spawn(process.execPath, args, {
+    cwd: projectDir,
+    detached: true,
+    stdio: ['ignore', out, err],
+    // Strip CLAUDECODE so the Claude agent subprocess trick in
+    // claude-agent.js doesn't misbehave (documented in CLAUDE.md).
+    env: { ...process.env, CLAUDECODE: undefined },
+  });
+  child.unref();
+  return { ok: true, pid: child.pid ?? 0, logPath };
 }

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -16,7 +16,7 @@ import {
   listPlanIdsForProject,
 } from '../db.js';
 import { fullScan } from '../sync.js';
-import { setHuStatus, markPlanReady } from '../plan-mutations.js';
+import { setHuStatus, markPlanReady, runPlan } from '../plan-mutations.js';
 
 const router = Router();
 
@@ -295,6 +295,59 @@ router.post('/projects/:id/ready', (req, res) => {
       plans: results,
       totalCertified,
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/plans/:planId/run - Launch `kj run --plan <planId>` as a
+ * detached child. This is the "Run plan" button's endpoint — the board
+ * no longer requires the user to drop to a terminal to kick off the
+ * pipeline.
+ *
+ * Body: { projectId?: string, task?: string } — both optional. projectId
+ * makes the plan-file lookup O(1); task overrides plan.task as the
+ * pipeline's headline description.
+ *
+ * Returns the child's pid + the log path so a future "tail this run"
+ * viewer can attach.
+ */
+router.post('/plans/:planId/run', (req, res) => {
+  try {
+    const { projectId, task } = req.body || {};
+    const result = runPlan({ planId: req.params.planId, projectId, taskOverride: task });
+    if (!result.ok) return res.status(404).json({ error: result.error });
+    res.json({
+      launched: true,
+      planId: req.params.planId,
+      pid: result.pid,
+      logPath: result.logPath,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/projects/:id/run - Sugar: launch every plan of a project. For
+ * the common case where each project has exactly one active plan this
+ * behaves the same as POST /plans/:planId/run; with multiple plans it
+ * kicks each one in its own detached child.
+ */
+router.post('/projects/:id/run', (req, res) => {
+  try {
+    const planIds = listPlanIdsForProject(req.params.id);
+    if (planIds.length === 0) {
+      return res.status(404).json({ error: 'No plan-backed stories for this project' });
+    }
+    const results = [];
+    for (const planId of planIds) {
+      const r = runPlan({ planId, projectId: req.params.id });
+      results.push({ planId, ...r });
+    }
+    const launched = results.filter((r) => r.ok).length;
+    res.json({ launched, total: planIds.length, results });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -322,9 +322,10 @@ export function syncPlanFile(filePath) {
     });
 
     for (const hu of data.hus) {
-      const acText = Array.isArray(hu.acceptance_criteria)
-        ? JSON.stringify(hu.acceptance_criteria)
-        : null;
+      const acList = Array.isArray(hu.acceptance_criteria) ? hu.acceptance_criteria : [];
+      const testList = Array.isArray(hu.acceptance_tests) ? hu.acceptance_tests : [];
+      const blockedByList = Array.isArray(hu.blocked_by) ? hu.blocked_by : [];
+      const acText = acList.length > 0 ? JSON.stringify(acList) : null;
 
       upsertStory({
         id: `${projectId}::${hu.id}`,
@@ -348,6 +349,11 @@ export function syncPlanFile(filePath) {
         // Stamp plan_id so the PATCH / mark-ready endpoints can locate
         // the source plan JSON without walking the plans dir.
         plan_id: data.planId,
+        // Denormalised counters + deps so the card renders "3 ACs ·
+        // 2 tests · waits for lao-001" without every client parsing JSON.
+        ac_count: acList.length,
+        test_count: testList.length,
+        blocked_by: blockedByList.length > 0 ? JSON.stringify(blockedByList) : null,
       });
     }
 
@@ -420,24 +426,38 @@ export function startWatcher() {
   const kjHome = getKjHome();
   const storiesGlob = join(kjHome, 'hu-stories', '*', 'batch.json');
   const sessionsGlob = join(kjHome, 'sessions', '*', 'session.json');
+  // Plans live under KJ_PLANS_DIR or ~/.kj/plans/, NOT under ~/.karajan/ —
+  // the two homes are separate (KJ runs off ~/.kj, the board off
+  // ~/.karajan). Without this glob, HU statuses flipped to coding / done
+  // by `kj run --plan` never reached the board until the user clicked
+  // the manual 🔄 sync — exactly the "silent, feels dead" UX we wanted
+  // to avoid.
+  const plansRoot = process.env.KJ_PLANS_DIR || join(homedir(), '.kj', 'plans');
+  const plansGlob = join(plansRoot, '*', 'plan-*.json');
 
-  const watcher = watch([storiesGlob, sessionsGlob], {
+  const watcher = watch([storiesGlob, sessionsGlob, plansGlob], {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
   });
 
-  watcher.on('add', (path) => {
-    console.log(`[watcher] New file: ${path}`);
-    if (path.includes('hu-stories')) syncStoryFile(path);
-    else if (path.includes('sessions')) syncSessionFile(path);
+  const syncByPath = (p) => {
+    if (p.includes('hu-stories')) syncStoryFile(p);
+    else if (p.includes('sessions')) syncSessionFile(p);
+    else if (p.includes(`${plansRoot}${plansRoot.endsWith('/') ? '' : '/'}`) || p.includes('/plans/')) {
+      syncPlanFile(p);
+    }
+  };
+
+  watcher.on('add', (p) => {
+    console.log(`[watcher] New file: ${p}`);
+    syncByPath(p);
   });
 
-  watcher.on('change', (path) => {
-    console.log(`[watcher] Changed: ${path}`);
-    if (path.includes('hu-stories')) syncStoryFile(path);
-    else if (path.includes('sessions')) syncSessionFile(path);
+  watcher.on('change', (p) => {
+    console.log(`[watcher] Changed: ${p}`);
+    syncByPath(p);
   });
 
-  console.log(`[watcher] Watching ${kjHome} for changes`);
+  console.log(`[watcher] Watching ${kjHome} + ${plansRoot} for changes`);
   return watcher;
 }

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -61,6 +61,10 @@ beforeEach(async () => {
   tmpPlansDir = mkdtempSync(join(tmpdir(), 'hu-board-plans-'));
   process.env.KJ_HOME = tmpHome;
   process.env.KJ_PLANS_DIR = tmpPlansDir;
+  // Don't actually spawn the orchestrator — "echo" mode short-circuits
+  // runPlan so we can assert the payload shape without booting kj run
+  // inside vitest.
+  process.env.KJ_RUN_SPAWN_MODE = 'echo';
 
   // Modules are imported once across the suite; `initDb()` swaps the
   // underlying SQLite handle to one rooted in the per-test tmpHome, and
@@ -84,6 +88,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  delete process.env.KJ_RUN_SPAWN_MODE;
   dbMod.closeDb();
   rmSync(tmpHome, { recursive: true, force: true });
   rmSync(tmpPlansDir, { recursive: true, force: true });
@@ -207,5 +212,113 @@ describe('plan_id stamping via syncPlanFile', () => {
   it('listPlanIdsForProject returns distinct plan ids', () => {
     const ids = dbMod.listPlanIdsForProject(PROJECT_ID);
     expect(ids).toEqual([PLAN_ID]);
+  });
+});
+
+describe('denormalised ac_count / test_count / blocked_by on story rows', () => {
+  it('stamps ac_count and test_count from the plan JSON', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_010`,
+          title: 'rich hu',
+          status: 'pending',
+          acceptance_criteria: [{ given: 'g', when: 'w', then: 't' }, 'another'],
+          acceptance_tests: ['t1', 't2', 't3'],
+          blocked_by: [],
+          createdAt: '2026-04-24T10:10:10Z',
+          updatedAt: '2026-04-24T10:10:10Z',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const stories = dbMod.getStoriesByProject(PROJECT_ID);
+    const row = stories.find((s) => s.id.endsWith('_010'));
+    expect(row.ac_count).toBe(2);
+    expect(row.test_count).toBe(3);
+  });
+
+  it('stamps blocked_by as a JSON array of HU ids', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_100`,
+          title: 'root',
+          status: 'pending',
+          acceptance_criteria: [],
+          blocked_by: [],
+          createdAt: '2026-04-24T10:10:10Z', updatedAt: '2026-04-24T10:10:10Z',
+        },
+        {
+          id: `${PLAN_ID}_200`,
+          title: 'child',
+          status: 'pending',
+          acceptance_criteria: [],
+          blocked_by: [`${PLAN_ID}_100`],
+          createdAt: '2026-04-24T10:10:10Z', updatedAt: '2026-04-24T10:10:10Z',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const stories = dbMod.getStoriesByProject(PROJECT_ID);
+    const child = stories.find((s) => s.id.endsWith('_200'));
+    expect(JSON.parse(child.blocked_by)).toEqual([`${PLAN_ID}_100`]);
+    const root = stories.find((s) => s.id.endsWith('_100'));
+    expect(root.blocked_by).toBeNull();
+  });
+});
+
+describe('POST /api/plans/:planId/run', () => {
+  it('returns the pid + log path + resolved argv in echo mode', async () => {
+    const res = await request(app)
+      .post(`/api/plans/${PLAN_ID}/run`)
+      .send({ projectId: PROJECT_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.launched).toBe(true);
+    expect(res.body.planId).toBe(PLAN_ID);
+    expect(res.body.logPath).toMatch(/hu-board-runs\/.+\.log$/);
+  });
+
+  it('respects taskOverride when provided', () => {
+    const result = planMutationsMod.runPlan({
+      planId: PLAN_ID,
+      projectId: PROJECT_ID,
+      taskOverride: 'custom goal here',
+    });
+    expect(result.ok).toBe(true);
+    expect(result.argv[result.argv.length - 1]).toBe('custom goal here');
+  });
+
+  it('returns 404 for an unknown plan', async () => {
+    const res = await request(app).post('/api/plans/plan-nope/run').send({});
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses to run plans without projectDir (legacy pre-v2.7.4)', () => {
+    // Strip projectDir from the existing plan and rewrite it.
+    writePlanToDisk({ projectDir: undefined });
+    const result = planMutationsMod.runPlan({ planId: PLAN_ID, projectId: PROJECT_ID });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/projectDir/);
+  });
+});
+
+describe('POST /api/projects/:id/run', () => {
+  it('launches every plan of the project', async () => {
+    const res = await request(app)
+      .post(`/api/projects/${encodeURIComponent(PROJECT_ID)}/run`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.launched).toBe(1);
+    expect(res.body.total).toBe(1);
+  });
+
+  it('returns 404 when the project has no plan-backed stories', async () => {
+    dbMod.upsertProject({ id: 'bare-project', name: 'Bare' });
+    dbMod.upsertStory({ id: 'bare-project::hu-x', project_id: 'bare-project', status: 'pending' });
+    const res = await request(app)
+      .post(`/api/projects/${encodeURIComponent('bare-project')}/run`)
+      .send({});
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

Dogfooding v2.7.5 exposed that the \"certify → then run\" two-step was confusing. The user's mental model is *\"I delegate to KJ — if I don't like a HU, I edit it; otherwise I hit Run\"*. This PR delivers that.

### Flow redesign

| Before | After |
|---|---|
| 4 columns: Pending / Needs Context / Certified / Done | 4 columns: **Pending / Running / Done / Failed** (empty ones hidden) |
| Green button: \"Mark N pending HUs as certified\" | Green button: **▶ Run plan (N HUs)** |
| No live update during \`kj run\` | Watcher now tracks \`~/.kj/plans/\` too |
| Running / failed HUs invisible | First-class lanes |

While a run is live, the green Run button is replaced by a yellow \`⚙ N running…\` badge to prevent accidentally launching a second pipeline.

### Run endpoint

\`POST /api/plans/:planId/run\` and \`POST /api/projects/:id/run\` spawn \`node <repo>/src/cli.js run --plan <id> <task>\` as a detached child, redirecting output to \`~/.karajan/hu-board-runs/<planId>.log\`. \`KJ_RUN_SPAWN_MODE=echo\` short-circuits in tests. Refuses to launch plans without a \`projectDir\` stamp (legacy pre-v2.7.4) instead of corrupting the spawn.

### Richer cards

Idempotent ALTER-TABLE migrations add \`ac_count\`, \`test_count\`, \`blocked_by\` to \`stories\`. Denormalised at sync time so every card renders:

    📋 3 ACs · 🧪 2 tests · ⏳ waits for: lao-001

Modal metadata (Project/Session/Created/Updated/etc.) now wraps in \`<details>\` — collapsed by default to reclaim vertical space.

## Tests

20 mutation tests (was 12). Added coverage for:
- \`runPlan\` payload shape (pid, logPath, argv), echo mode
- 404 on unknown plan
- refusal when \`projectDir\` is missing
- project-level bulk run
- \`ac_count\` / \`test_count\` / \`blocked_by\` stamping at sync time

81/81 hu-board + 3791/3791 parent suite green.

## Not in this PR (follow-ups)

- **PR #3**: edit-in-place HU fields from the modal (title/scope/AC/task_type/blocked_by)
- **PR #4**: DAG view of \`blocked_by\` dependencies

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 81/81
- [x] \`npx vitest run tests/\` → 3791/3791
- [ ] Manual: after merge, \`kj board stop && kj board start\`, run \`kj plan\`, check cards show AC/tests counts + dependencies
- [ ] Manual: click **Run plan** on a fresh plan → HUs move Pending → Running → Done without a page refresh