### PR TITLE
feat(board): edit HU fields in place from the modal

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -682,6 +682,11 @@ async function showStoryDetail(storyId) {
 
     const dimLabels = ['Independent', 'Negotiable', 'Valuable', 'Estimable', 'Small', 'Testable'];
 
+    // Edit-in-place is gated on plan-backed stories: legacy rows
+    // (plan_id null) have no source-of-truth file to write to, so PATCH
+    // would 409 anyway.
+    const canEdit = ['pending', 'certified', 'needs_context', 'blocked'].includes(story.status);
+
     content.innerHTML = `
       <div class="modal__header">
         <div>
@@ -689,7 +694,16 @@ async function showStoryDetail(storyId) {
           <div class="modal__subtitle" style="font-size:0.75rem;color:var(--text-muted);font-family:monospace;margin-top:2px">${esc(story.id)}</div>
           <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
         </div>
-        <button class="modal__close" onclick="closeModal()">&times;</button>
+        <div style="display:flex;align-items:center;gap:8px">
+          ${canEdit ? `
+            <button id="edit-hu-btn" class="control-btn"
+                    style="padding:6px 12px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem"
+                    title="Edit title, scope, task type, and acceptance criteria">
+              ✎ Edit
+            </button>
+          ` : ''}
+          <button class="modal__close" onclick="closeModal()">&times;</button>
+        </div>
       </div>
 
 
@@ -783,8 +797,169 @@ async function showStoryDetail(storyId) {
         </div>
       </details>
     `;
+
+    // Wire the Edit button — stays within the modal so we don't flash
+    // a re-fetch; the edit form overwrites innerHTML in place.
+    const editBtn = document.getElementById('edit-hu-btn');
+    if (editBtn) editBtn.addEventListener('click', () => renderStoryEditForm(story));
   } catch (err) {
     content.innerHTML = `<div class="modal__header"><div class="modal__title">Error</div><button class="modal__close" onclick="closeModal()">&times;</button></div><p>${esc(err.message)}</p>`;
+  }
+}
+
+/**
+ * Swap the story modal into an inline edit form. Accepts the full story
+ * record that `showStoryDetail` just rendered so we don't re-fetch —
+ * the user's intent is "edit what I'm looking at".
+ *
+ * Cancel restores the read-only view via `showStoryDetail`; Save posts a
+ * PATCH and, on success, re-opens in read-only with the refreshed row.
+ *
+ * @param {object} story
+ */
+function renderStoryEditForm(story) {
+  const content = document.getElementById('modal-content');
+  const initials = projectInitialsCache[story.project_id] || 'kj';
+  const shortId = shortStoryId(story, initials);
+
+  const rawAc = story.acceptance_criteria ? JSON.parse(story.acceptance_criteria) : [];
+  // Represent AC as text: plain strings go verbatim, Gherkin objects
+  // collapse to "Given … | When … | Then …". On save we parse back —
+  // if the line matches the pattern we treat it as Gherkin, otherwise
+  // a free-form string.
+  const acInitial = rawAc
+    .map((c) => typeof c === 'string' ? c : (c.given ? `Given ${c.given} | When ${c.when} | Then ${c.then}` : JSON.stringify(c)))
+    .join('\n');
+
+  const scopeInitial = story.original_text || story.certified_want || '';
+  const TASK_TYPES = ['sw', 'infra', 'doc', 'add-tests', 'refactor'];
+
+  content.innerHTML = `
+    <div class="modal__header">
+      <div>
+        <div class="modal__title" title="${esc(story.id)}">${esc(shortId)} <span style="font-size:0.75rem;color:var(--text-muted);font-weight:normal">(editing)</span></div>
+        <div class="modal__subtitle" style="font-size:0.75rem;color:var(--text-muted);font-family:monospace;margin-top:2px">${esc(story.id)}</div>
+      </div>
+      <button class="modal__close" onclick="closeModal()">&times;</button>
+    </div>
+
+    <form id="hu-edit-form" onsubmit="return false" style="display:flex;flex-direction:column;gap:14px;padding:8px 0">
+      <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+        <span style="color:var(--text-muted)">Title</span>
+        <input type="text" id="edit-title" value="${esc(story.title || '')}"
+               style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-size:0.95rem"
+               maxlength="200" required>
+      </label>
+
+      <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+        <span style="color:var(--text-muted)">Scope</span>
+        <textarea id="edit-scope" rows="4"
+                  style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-family:inherit;font-size:0.9rem;line-height:1.5;resize:vertical">${esc(scopeInitial)}</textarea>
+      </label>
+
+      <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+        <span style="color:var(--text-muted)">Task type</span>
+        <select id="edit-task-type"
+                style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-size:0.9rem">
+          ${TASK_TYPES.map((t) => `<option value="${t}">${t}</option>`).join('')}
+        </select>
+      </label>
+
+      <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+        <span style="color:var(--text-muted)">
+          Acceptance criteria — one per line.
+          Gherkin: <code>Given X | When Y | Then Z</code>
+        </span>
+        <textarea id="edit-ac" rows="6"
+                  style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-family:var(--font-mono, monospace);font-size:0.85rem;line-height:1.5;resize:vertical">${esc(acInitial)}</textarea>
+      </label>
+
+      <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px;padding-top:12px;border-top:1px solid var(--border)">
+        <button type="button" id="edit-cancel" class="control-btn"
+                style="padding:6px 14px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
+          Cancel
+        </button>
+        <button type="button" id="edit-save" class="control-btn"
+                style="padding:6px 14px;border:none;background:var(--color-green);color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600">
+          Save
+        </button>
+      </div>
+    </form>
+  `;
+
+  document.getElementById('edit-cancel').addEventListener('click', () => showStoryDetail(story.id));
+  document.getElementById('edit-save').addEventListener('click', () => saveStoryEdits(story));
+}
+
+/**
+ * Collect the form values, compute the diff against the story as it
+ * was on modal open, and PATCH only the changed fields. Empty diff is
+ * a no-op (close out of edit mode without an API call).
+ * @param {object} story
+ */
+async function saveStoryEdits(story) {
+  const title = document.getElementById('edit-title').value.trim();
+  const scope = document.getElementById('edit-scope').value;
+  const taskType = document.getElementById('edit-task-type').value;
+  const acRaw = document.getElementById('edit-ac').value;
+
+  if (!title) {
+    await showError('Title cannot be empty.', { title: 'Invalid input' });
+    return;
+  }
+
+  // Parse AC: one per line; a line with "Given X | When Y | Then Z"
+  // (case-insensitive) becomes Gherkin; everything else stays a string.
+  // Blank lines are dropped.
+  const acceptance_criteria = acRaw.split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const m = /^Given\s+(.*?)\s*\|\s*When\s+(.*?)\s*\|\s*Then\s+(.*)$/i.exec(line);
+      if (m) return { given: m[1].trim(), when: m[2].trim(), then: m[3].trim() };
+      return line;
+    });
+
+  // Diff against the original so we don't send untouched fields and
+  // let the server's COALESCE keep existing values.
+  const patch = {};
+  const originalScope = story.original_text || story.certified_want || '';
+  if (title !== (story.title || '')) patch.title = title;
+  if (scope !== originalScope) patch.scope = scope;
+  if (taskType && taskType !== 'sw') patch.task_type = taskType;
+  const prevAcStr = story.acceptance_criteria || '[]';
+  const nextAcStr = JSON.stringify(acceptance_criteria);
+  if (nextAcStr !== prevAcStr) patch.acceptance_criteria = acceptance_criteria;
+
+  if (Object.keys(patch).length === 0) {
+    showStoryDetail(story.id);
+    return;
+  }
+
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(story.id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) {
+      if (res.status === 404) {
+        await showError(
+          'The board server does not recognise the extended PATCH endpoint.\n\n'
+          + 'Restart it to pick up v2.7.5+:\n\n'
+          + '    kj board stop && kj board start',
+          { title: 'Board out of date' }
+        );
+        return;
+      }
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'Could not save HU' });
+      return;
+    }
+    await renderBoard();               // card shows new title/counts
+    await showStoryDetail(story.id);   // reopen modal with fresh data
+  } catch (err) {
+    await showError(err.message, { title: 'Could not save HU' });
   }
 }
 

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -19,7 +19,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { updateHuStatus, certifyAllHus } from '../../../src/plan/plan-hu-ops.js';
+import { updateHuStatus, certifyAllHus, updateHu } from '../../../src/plan/plan-hu-ops.js';
 import { syncPlanFile } from './sync.js';
 
 // Repo root → so we can spawn `node <repo>/src/cli.js run ...` without
@@ -122,6 +122,38 @@ export function setHuStatus({ planId, huId, status, projectId }) {
   writePlan(filePath, plan);
   syncPlanFile(filePath);
   return { ok: true, status, planStatus: plan.status };
+}
+
+/**
+ * Edit one HU's user-facing fields in place. Whitelist mirrors
+ * `updateHu` in plan-hu-ops so the CLI and the board stay in lock-step:
+ * title, task_type, scope, acceptance_criteria, acceptance_tests,
+ * blocked_by. Unknown keys are silently ignored.
+ *
+ * The caller passes a `patch` object with whichever subset of fields
+ * the user actually changed — pushing the whole HU every time would
+ * make optimistic concurrency harder to add later.
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} args.huId
+ * @param {object} args.patch
+ * @param {string} [args.projectId]
+ * @returns {{ ok: true, hu: object } | { ok: false, error: string }}
+ */
+export function setHuFields({ planId, huId, patch, projectId }) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+
+  const plan = readPlan(filePath);
+  if (!Array.isArray(plan.hus)) return { ok: false, error: 'plan has no hus[]' };
+
+  const updated = updateHu(plan, huId, patch || {});
+  if (!updated) return { ok: false, error: `hu not found: ${huId}` };
+
+  writePlan(filePath, plan);
+  syncPlanFile(filePath);
+  return { ok: true, hu: updated };
 }
 
 /**

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -16,7 +16,7 @@ import {
   listPlanIdsForProject,
 } from '../db.js';
 import { fullScan } from '../sync.js';
-import { setHuStatus, markPlanReady, runPlan } from '../plan-mutations.js';
+import { setHuStatus, setHuFields, markPlanReady, runPlan } from '../plan-mutations.js';
 
 const router = Router();
 
@@ -206,33 +206,56 @@ router.delete('/sessions/:id', (req, res) => {
 });
 
 /**
- * PATCH /api/stories/:id - Change a single HU's status.
+ * PATCH /api/stories/:id - Edit a single HU.
  *
- * The row id on the board is `${projectId}::${huId}` — we split it here to
- * feed the underlying plan-mutation helper. The source-of-truth plan JSON
- * is rewritten first, then re-synced into SQLite, so a reload renders the
- * committed state and never a stale view.
+ * Accepts two shapes in the same call (both optional, either or both
+ * can be present):
  *
- * Body: { status: "pending" | "certified" | "done" }
- * Returns 400 on unknown status, 404 when the story / plan can't be found.
+ *   { status: "pending" | "certified" | "done" | "needs_context" }
+ *     → changes the lifecycle state (original PATCH semantics).
+ *
+ *   { title?, scope?, task_type?, acceptance_criteria?,
+ *     acceptance_tests?, blocked_by? }
+ *     → edits the user-facing fields in place. Whitelist mirrors
+ *     plan-hu-ops::updateHu so CLI and board stay aligned.
+ *
+ * When both are present we apply status last — the status change
+ * transitions the plan lifecycle and can rewrite plan.status, whereas
+ * field edits are local to the HU and should never fight the status
+ * auto-promotion.
+ *
+ * The row id on the board is `${projectId}::${huId}` — split here to
+ * feed the plan-mutation helpers. The source-of-truth plan JSON is
+ * rewritten before we ack, then re-synced into SQLite, so a reload
+ * renders the committed state.
  */
 const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'needs_context']);
+const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by'];
 
 router.patch('/stories/:id', (req, res) => {
   try {
-    const { status } = req.body || {};
-    if (!status || !ALLOWED_STORY_STATUSES.has(status)) {
+    const body = req.body || {};
+    const hasStatus = Object.prototype.hasOwnProperty.call(body, 'status');
+    const fieldPatch = {};
+    for (const k of EDITABLE_HU_FIELDS) {
+      if (Object.prototype.hasOwnProperty.call(body, k)) fieldPatch[k] = body[k];
+    }
+    const hasFieldEdit = Object.keys(fieldPatch).length > 0;
+
+    if (!hasStatus && !hasFieldEdit) {
+      return res.status(400).json({
+        error: `Body must include status or one of: ${EDITABLE_HU_FIELDS.join(', ')}`,
+      });
+    }
+    if (hasStatus && !ALLOWED_STORY_STATUSES.has(body.status)) {
       return res.status(400).json({
         error: `status must be one of: ${[...ALLOWED_STORY_STATUSES].join(', ')}`,
       });
     }
+
     const row = getStoryRow(req.params.id);
     if (!row) return res.status(404).json({ error: 'Story not found' });
     if (!row.plan_id) {
-      // HU came from a pre-migration batch.json or a non-plan source —
-      // refuse to mutate because we have no source-of-truth file to
-      // write to. The client should fall back to "delete + re-sync"
-      // for those rows.
       return res.status(409).json({
         error: 'Story is not backed by a plan file (legacy row). Re-run `kj plan` to re-import it.',
       });
@@ -240,14 +263,37 @@ router.patch('/stories/:id', (req, res) => {
     const huId = req.params.id.includes('::')
       ? req.params.id.split('::').slice(1).join('::')
       : req.params.id;
-    const result = setHuStatus({
-      planId: row.plan_id,
-      huId,
-      status,
-      projectId: row.project_id,
+
+    let updatedHu;
+    if (hasFieldEdit) {
+      const fieldResult = setHuFields({
+        planId: row.plan_id,
+        huId,
+        patch: fieldPatch,
+        projectId: row.project_id,
+      });
+      if (!fieldResult.ok) return res.status(404).json({ error: fieldResult.error });
+      updatedHu = fieldResult.hu;
+    }
+
+    let statusResult;
+    if (hasStatus) {
+      statusResult = setHuStatus({
+        planId: row.plan_id,
+        huId,
+        status: body.status,
+        projectId: row.project_id,
+      });
+      if (!statusResult.ok) return res.status(404).json({ error: statusResult.error });
+    }
+
+    res.json({
+      updated: true,
+      id: req.params.id,
+      status: statusResult ? statusResult.status : undefined,
+      planStatus: statusResult ? statusResult.planStatus : undefined,
+      hu: updatedHu,
     });
-    if (!result.ok) return res.status(404).json({ error: result.error });
-    res.json({ updated: true, id: req.params.id, status: result.status, planStatus: result.planStatus });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -268,6 +268,69 @@ describe('denormalised ac_count / test_count / blocked_by on story rows', () => 
   });
 });
 
+describe('PATCH /api/stories/:id - field edits (title, scope, task_type, acceptance_criteria)', () => {
+  const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+
+  it('edits the title and persists to the plan JSON', async () => {
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ title: 'renamed via board' });
+    expect(res.status).toBe(200);
+    expect(res.body.hu.title).toBe('renamed via board');
+    const plan = readPlanFromDisk();
+    expect(plan.hus.find((h) => h.id === `${PLAN_ID}_001`).title).toBe('renamed via board');
+  });
+
+  it('edits the scope', async () => {
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ scope: 'new scope here' });
+    expect(res.status).toBe(200);
+    expect(readPlanFromDisk().hus[0].scope).toBe('new scope here');
+  });
+
+  it('changes task_type', async () => {
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ task_type: 'refactor' });
+    expect(res.status).toBe(200);
+    expect(readPlanFromDisk().hus[0].task_type).toBe('refactor');
+  });
+
+  it('rewrites acceptance_criteria as a list of strings or Gherkin objects', async () => {
+    const newAc = [
+      'raw string criterion',
+      { given: 'user logs in', when: 'they visit /', then: 'dashboard is shown' },
+    ];
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ acceptance_criteria: newAc });
+    expect(res.status).toBe(200);
+    expect(readPlanFromDisk().hus[0].acceptance_criteria).toEqual(newAc);
+  });
+
+  it('allows combining a status change with field edits in one PATCH', async () => {
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ title: 'combined edit', status: 'certified' });
+    expect(res.status).toBe(200);
+    const plan = readPlanFromDisk();
+    const hu = plan.hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.title).toBe('combined edit');
+    expect(hu.status).toBe('certified');
+  });
+
+  it('ignores unknown fields', async () => {
+    const before = JSON.stringify(readPlanFromDisk());
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ irrelevant: 'x' });
+    // No status + no whitelisted field → 400.
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(readPlanFromDisk())).toBe(before);
+  });
+});
+
 describe('POST /api/plans/:planId/run', () => {
   it('returns the pid + log path + resolved argv in echo mode', async () => {
     const res = await request(app)


### PR DESCRIPTION
## Summary

User's workflow is \"if I don't agree with a HU, I edit it — I don't want to drop to the CLI\". Before this PR the modal was read-only and the only way to reshape a HU was \`kj plan remove-hu\` + \`add-hu\`, forcing a full rewrite.

### Extended \`PATCH /api/stories/:id\`

Accepts the status-change body AND a field-edit body in the same call:

    { status?, title?, scope?, task_type?,
      acceptance_criteria?, acceptance_tests?, blocked_by? }

Whitelist mirrors \`plan-hu-ops.js::updateHu\` so CLI and board stay in lock-step. Field edits apply first; status last — so plan-status auto-promotion (draft ↔ ready) doesn't fight a field edit. Empty body returns 400. Unknown fields silently dropped.

### Modal edit mode

An ✎ Edit button appears in the story modal header when the HU is in a non-terminal state (pending / certified / needs_context / blocked). Click flips the modal into a form with:

- **Title** (required, max 200 chars)
- **Scope** (textarea)
- **Task type** (select: sw, infra, doc, add-tests, refactor)
- **Acceptance criteria** (textarea, one per line; \`Given X | When Y | Then Z\` parses as Gherkin on save, otherwise kept as string)

Cancel restores the read-only view; Save diffs the form against the original story, PATCHes only changed fields, and re-opens the modal refreshed. No API call when nothing changed.

## Tests

26 mutation tests (was 20). New cases:
- title / scope / task_type edits persist to the plan JSON
- acceptance_criteria rewrite supports strings + Gherkin objects
- combined status + field edit in one PATCH
- empty body (no status, no whitelisted field) returns 400

87/87 hu-board + 3791/3791 parent green.

## Not in this PR

- Editing \`blocked_by\` (needs checkbox-of-siblings UI; deferred)
- DAG view (PR #4)

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 87/87
- [x] \`npx vitest run tests/\` → 3791/3791
- [ ] Manual: after merge, \`kj board stop && kj board start\`, open a HU, click ✎ Edit, change title, save, verify the plan JSON on disk got the new title