### PR TITLE
feat(board): dependency graph view (SVG, vanilla, zero deps)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -445,6 +445,209 @@ async function renderBoard() {
   }
 }
 
+// ---- DAG view ----
+//
+// The kanban answers "what's the status of each HU"; the graph answers
+// "what depends on what, and what could run in parallel". It's a
+// leveled topological layout drawn as vanilla SVG — no Cytoscape /
+// D3 / Mermaid dependency because the board ships as a local
+// dashboard and every KB of JS saved is one less thing that can
+// mis-fetch behind a corporate proxy. The layout is basic but honest:
+// roots at the top, children below, siblings side-by-side, curved
+// bezier arrows. Good enough for plans up to ~30 HUs — beyond that
+// we'd want a real DAG library, but that's a problem for another day.
+
+const DAG_NODE_W = 170;
+const DAG_NODE_H = 62;
+const DAG_H_GAP = 28;
+const DAG_V_GAP = 72;
+const DAG_PAD = 32;
+
+/**
+ * Resolve `hu.blocked_by` HU-ids (e.g. "plan-xxx_001") to full story
+ * ids ("<project>::plan-xxx_001") so we can join by the board's row id.
+ * Ids that don't resolve are dropped silently — they usually signal a
+ * cross-plan dep which we don't render.
+ */
+function resolveBlockedBy(rawIds, storyIds) {
+  if (!Array.isArray(rawIds) || rawIds.length === 0) return [];
+  const resolved = [];
+  for (const raw of rawIds) {
+    const match = storyIds.find((id) => id.endsWith(`::${raw}`)) || (storyIds.includes(raw) ? raw : null);
+    if (match) resolved.push(match);
+  }
+  return resolved;
+}
+
+/**
+ * Assign each story a level = 1 + max(level of its deps). Roots get 0.
+ * Cycle-guarded with a visited set — KJ's planner shouldn't emit one
+ * but a hand-edited plan JSON might.
+ */
+function computeDagLevels(stories) {
+  const storyIds = stories.map((s) => s.id);
+  const byId = new Map();
+  for (const s of stories) {
+    const rawBlockedBy = s.blocked_by ? JSON.parse(s.blocked_by) : [];
+    byId.set(s.id, {
+      ...s,
+      resolvedBlockedBy: resolveBlockedBy(rawBlockedBy, storyIds),
+    });
+  }
+
+  const levels = new Map();
+  const visiting = new Set();
+  function levelOf(id) {
+    if (levels.has(id)) return levels.get(id);
+    if (visiting.has(id)) return 0;                // cycle → break
+    const s = byId.get(id);
+    if (!s || s.resolvedBlockedBy.length === 0) { levels.set(id, 0); return 0; }
+    visiting.add(id);
+    const l = 1 + Math.max(...s.resolvedBlockedBy.map(levelOf));
+    visiting.delete(id);
+    levels.set(id, l);
+    return l;
+  }
+  for (const id of byId.keys()) levelOf(id);
+
+  const byLevel = new Map();
+  for (const [id, lvl] of levels) {
+    if (!byLevel.has(lvl)) byLevel.set(lvl, []);
+    byLevel.get(lvl).push(id);
+  }
+
+  return { byId, levels, byLevel };
+}
+
+/**
+ * Render the graph view. If no project is selected we show a prompt
+ * — drawing every project's HUs in one DAG is visual garbage. If the
+ * current project has no stories or no blocked_by edges, we show a
+ * friendly empty state explaining what the view is for.
+ */
+async function renderGraph() {
+  const app = document.getElementById('app');
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading graph…</p></div>';
+
+  if (!selectedProject) {
+    app.innerHTML = renderEmptyState(
+      'Pick a project first',
+      'The dependency graph is per-project. Choose one in the dropdown above and I will draw its HU DAG.'
+    );
+    return;
+  }
+
+  try {
+    const stories = await api(`/api/projects/${encodeURIComponent(selectedProject)}/stories`);
+    if (stories.length === 0) {
+      app.innerHTML = renderEmptyState('No HUs in this project', 'Run kj plan to generate some.');
+      return;
+    }
+    // Preload initials so node labels can use short ids synchronously.
+    await resolveProjectMeta(selectedProject);
+    const projectDisplayName = projectNameCache[selectedProject] || humaniseProjectName(selectedProject);
+    const initials = projectInitialsCache[selectedProject] || 'kj';
+
+    const { byId, byLevel } = computeDagLevels(stories);
+    const maxLevel = Math.max(0, ...Array.from(byLevel.keys()));
+    const widestLevel = Math.max(0, ...Array.from(byLevel.values()).map((ids) => ids.length));
+    const width = widestLevel * (DAG_NODE_W + DAG_H_GAP) + DAG_PAD * 2;
+    const height = (maxLevel + 1) * (DAG_NODE_H + DAG_V_GAP) + DAG_PAD * 2;
+
+    // Assign x,y to each node. Within a level we distribute horizontally
+    // evenly; we make no effort to minimise edge crossings (the naive
+    // layout is fine for ~20 HUs, which is the realistic ceiling for a
+    // single plan).
+    const positions = new Map();
+    for (const [lvl, ids] of byLevel) {
+      const y = DAG_PAD + lvl * (DAG_NODE_H + DAG_V_GAP);
+      const rowW = ids.length * DAG_NODE_W + (ids.length - 1) * DAG_H_GAP;
+      const xStart = (width - rowW) / 2;
+      ids.forEach((id, i) => {
+        positions.set(id, { x: xStart + i * (DAG_NODE_W + DAG_H_GAP), y });
+      });
+    }
+
+    const edges = [];
+    for (const s of byId.values()) {
+      for (const parentId of s.resolvedBlockedBy) {
+        if (positions.has(parentId) && positions.has(s.id)) {
+          edges.push({ from: parentId, to: s.id });
+        }
+      }
+    }
+
+    const anyEdges = edges.length > 0;
+
+    const svg = `
+      <svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}"
+           xmlns="http://www.w3.org/2000/svg"
+           style="display:block;margin:0 auto;max-width:100%;overflow:visible">
+        <defs>
+          <marker id="dag-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+            <path d="M0,0 L7,4 L0,8 Z" fill="var(--text-muted)"/>
+          </marker>
+        </defs>
+        ${edges.map((e) => {
+          const p1 = positions.get(e.from);
+          const p2 = positions.get(e.to);
+          const x1 = p1.x + DAG_NODE_W / 2;
+          const y1 = p1.y + DAG_NODE_H;
+          const x2 = p2.x + DAG_NODE_W / 2;
+          const y2 = p2.y;
+          const cy = (y1 + y2) / 2;
+          return `<path d="M${x1},${y1} C${x1},${cy} ${x2},${cy} ${x2},${y2}"
+                        stroke="var(--text-muted)" stroke-width="1.5" fill="none"
+                        marker-end="url(#dag-arrow)" opacity="0.7"/>`;
+        }).join('')}
+        ${Array.from(byId.values()).map((s) => {
+          const p = positions.get(s.id);
+          const shortId = shortStoryId(s, initials);
+          const title = truncate(s.title || s.original_text || '', 26);
+          return `
+            <g transform="translate(${p.x},${p.y})"
+               class="dag-node status--${s.status}"
+               style="cursor:pointer"
+               onclick="showStoryDetail('${esc(s.id)}')">
+              <title>${esc(s.id)}</title>
+              <rect width="${DAG_NODE_W}" height="${DAG_NODE_H}" rx="6"
+                    fill="var(--bg-secondary)" stroke="var(--border)" stroke-width="1.2"/>
+              <rect width="4" height="${DAG_NODE_H}" rx="2" fill="currentColor"/>
+              <text x="12" y="20" font-size="11" font-weight="600" fill="var(--text)">
+                ${esc(shortId)}
+              </text>
+              <text x="${DAG_NODE_W - 10}" y="20" text-anchor="end" font-size="10"
+                    fill="var(--text-muted)">${esc(s.status)}</text>
+              <text x="12" y="40" font-size="10.5" fill="var(--text-muted)">
+                ${esc(title)}
+              </text>
+            </g>
+          `;
+        }).join('')}
+      </svg>
+    `;
+
+    app.innerHTML = `
+      <div class="section-header">
+        <span class="section-header__title">Dependency graph — ${esc(projectDisplayName)}</span>
+        <span class="section-header__count">${stories.length} HUs${anyEdges ? ` · ${edges.length} dep${edges.length === 1 ? '' : 's'}` : ' · no dependencies declared'}</span>
+      </div>
+      <div style="padding:8px;overflow:auto;max-height:calc(100vh - 140px)">
+        ${svg}
+      </div>
+      ${!anyEdges ? `
+        <div style="padding:14px 20px;color:var(--text-muted);font-size:0.85rem;max-width:720px;margin:12px auto">
+          No HU in this plan declares <code>blocked_by</code>, so the DAG degenerates to a row of isolated nodes.
+          Add dependencies via <code>kj plan</code> on generation or the modal <em>Edit</em> form
+          (blocked_by editing is on the roadmap).
+        </div>
+      ` : ''}
+    `;
+  } catch (err) {
+    app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading graph</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
+  }
+}
+
 /**
  * Renders a single kanban column.
  * @param {string} title
@@ -1243,6 +1446,7 @@ function render() {
     case 'dashboard': return renderDashboard();
     case 'board': return renderBoard();
     case 'sessions': return renderSessions();
+    case 'graph': return renderGraph();
     default: return renderDashboard();
   }
 }

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -21,6 +21,7 @@
     </div>
     <nav class="header__nav">
       <button class="nav-btn active" data-view="board">Board</button>
+      <button class="nav-btn" data-view="graph" title="Dependency graph of the selected project's HUs">Graph</button>
       <button class="nav-btn" data-view="dashboard">Dashboard</button>
       <button class="nav-btn" data-view="sessions">Sessions</button>
       <a class="nav-btn" href="/pipeline.html" title="Pipeline observability view (v2.7)">Pipeline</a>


### PR DESCRIPTION
## Summary

The kanban answers *\"what's the status of each HU\"*; the graph answers *\"what depends on what, and what could run in parallel\"*. This PR adds a **Graph** tab to the board that draws the HU DAG for the selected project.

### Layout

- Roots at the top (level 0), children below with level = max(level of deps) + 1.
- Siblings at the same level distributed horizontally.
- Curved bezier arrows parent → child.
- Cycle-guarded (KJ's planner shouldn't emit one, but a hand-edited plan JSON might — we don't want to infinite-recurse on render).

### Rendering

- **Pure vanilla SVG**, no Cytoscape / D3 / Mermaid dependency. The board ships as a local dashboard and every kB of JS saved is one less thing that can mis-fetch behind a corporate proxy.
- Node fill uses the existing \`status--\` CSS classes, so the palette matches the kanban columns 1:1.
- Clicking a node opens the existing story modal (\`window.showStoryDetail\` is already global).

### Limits of the naive layout (documented in code)

- No edge-crossing minimisation. Fine up to ~20 HUs; past that a real graph library earns its size.
- \`blocked_by\` pointing at a HU outside this plan / project is silently dropped — we don't draw cross-plan edges because the view is per-project.

### UX edge cases

- \"Pick a project first\" prompt when no project is selected (drawing every project's HUs in one DAG is visual garbage).
- Empty-state card when the plan has zero \`blocked_by\` edges — the DAG degenerates to a row of isolated nodes and we explain why.

## Closes the dogfooding punchlist

| PR | Fix |
|---|---|
| #484 | \`<dialog>\` replaces alert/confirm, clearer 404 msg |
| #485 | \"Run plan\" flow replaces the \"certified\" step + live sync |
| #486 | edit HU fields in place (title/scope/AC/task_type) |
| #487 | **this one** — DAG view |

## Tests

No new tests: the graph code is DOM + SVG only and the computed levels fall out of a small pure function. 87/87 hu-board + 3791/3791 parent unchanged.

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 87/87
- [x] \`npx vitest run tests/\` → 3791/3791
- [ ] Manual: after merge, \`kj board stop && kj board start\`, pick a project, click **Graph** → verify the DAG renders with arrows parent → child, clicking a node opens the story modal