### PR TITLE
fix(board): keep 4 columns visible, show tests in modal, live run log

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -405,12 +405,16 @@ async function renderBoard() {
     const canRun = Boolean(selectedProject) && awaitingCount > 0 && runningCount === 0;
     const isRunning = runningCount > 0;
 
+    // Always show the four canonical lanes so the user has a mental
+    // map of the flow, even when every HU is still in Pending. Empty
+    // columns render their header (with count=0) but suppress the "No
+    // stories" placeholder inside so they don't steal visual space.
     const visibleColumns = [
       { title: 'Pending', cls: 'pending', rows: columns.pending },
       { title: 'Running', cls: 'running', rows: columns.running },
       { title: 'Done', cls: 'done', rows: columns.done },
       { title: 'Failed', cls: 'failed', rows: columns.failed },
-    ].filter((c) => c.rows.length > 0 || c.title === 'Pending');
+    ];
 
     app.innerHTML = `
       <div class="section-header">
@@ -421,6 +425,13 @@ async function renderBoard() {
                 style="margin-left:auto;padding:4px 10px;font-size:0.8rem;background:var(--color-yellow,#eab308);color:#000;border-radius:var(--radius-sm);font-weight:600;">
             ⚙ ${runningCount} running…
           </span>
+        ` : ''}
+        ${lastLaunchedPlanId ? `
+          <button class="control-btn" id="view-log-btn"
+                  style="${isRunning ? '' : 'margin-left:auto;'}padding:6px 12px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;"
+                  title="Tail the detached kj run log in a dialog">
+            📜 View log
+          </button>
         ` : ''}
         ${canRun ? `
           <button class="control-btn" id="run-plan-btn"
@@ -439,6 +450,10 @@ async function renderBoard() {
       document.getElementById('run-plan-btn').addEventListener('click', async () => {
         await runProject(selectedProject);
       });
+    }
+    const viewLogBtn = document.getElementById('view-log-btn');
+    if (viewLogBtn && lastLaunchedPlanId) {
+      viewLogBtn.addEventListener('click', () => openLogViewer(lastLaunchedPlanId));
     }
   } catch (err) {
     app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading board</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
@@ -656,14 +671,16 @@ async function renderGraph() {
  * @returns {string}
  */
 function renderKanbanColumn(title, cssClass, stories) {
+  // Empty lanes render the header (so the user keeps the 4-column
+  // mental map) but no body placeholder — "No stories" text on four
+  // empty columns was noise on fresh plans.
   return `
-    <div class="kanban__column kanban__column--${cssClass}">
+    <div class="kanban__column kanban__column--${cssClass}"${stories.length === 0 ? ' style="opacity:0.55"' : ''}>
       <div class="kanban__column-header">
         <span class="kanban__column-title">${title}</span>
         <span class="kanban__column-count">${stories.length}</span>
       </div>
       ${stories.map(renderStoryCard).join('')}
-      ${stories.length === 0 ? '<div style="text-align:center;color:var(--text-muted);font-size:0.8rem;padding:20px">No stories</div>' : ''}
     </div>
   `;
 }
@@ -709,6 +726,10 @@ function renderStoryCard(story) {
       ${blockedBy.length > 0 ? `
         <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--text-muted)" title="This HU waits on: ${esc(blockedBy.join(', '))}">
           ⏳ waits for: ${blockedBy.map((d) => esc(shortDep(d))).join(', ')}
+        </div>
+      ` : (story.status === 'pending' || story.status === 'certified') ? `
+        <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--color-green)" title="No dependencies — runs first on the next 'Run plan'">
+          🟢 ready to run
         </div>
       ` : ''}
       ${antipatterns.length > 0 ? `<div class="story-card__antipattern">${antipatterns.map((a) => esc(a)).join(', ')}</div>` : ''}
@@ -822,6 +843,11 @@ function renderEmptyState(title, text) {
  * the board re-renders without us having to poll.
  * @param {string} projectId
  */
+// Track the most recently launched planId so the "View log" button in
+// the section header can re-open the viewer without the user hunting
+// through plan ids.
+let lastLaunchedPlanId = null;
+
 async function runProject(projectId) {
   try {
     const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/run`, {
@@ -850,16 +876,121 @@ async function runProject(projectId) {
     // for the watcher debounce.
     await fetch('/api/sync', { method: 'POST' }).catch(() => {});
     await renderBoard();
-    await showError(
-      `Pipeline launched for ${body.launched}/${body.total} plan(s).\n\n`
-      + 'The HUs will transition through coding → reviewing → done as '
-      + 'kj runs them. Refresh is automatic once the watcher picks up '
-      + 'each status change.',
-      { title: 'Run started' }
-    );
+
+    // Remember the first successful planId so the section header can
+    // offer a "View log" button without the user having to re-launch.
+    const firstOk = (body.results || []).find((r) => r.ok);
+    if (firstOk && firstOk.planId) {
+      lastLaunchedPlanId = firstOk.planId;
+      // Open the log viewer straight away — the user's mental model is
+      // "I clicked Run, I want to see what's happening", not "I clicked
+      // Run, now where do I look".
+      openLogViewer(firstOk.planId);
+    } else {
+      await showError(
+        `Pipeline launched for ${body.launched}/${body.total} plan(s) but `
+        + 'no planId came back, so there\'s no log to show.',
+        { title: 'Run started' }
+      );
+    }
   } catch (err) {
     await showError(err.message, { title: 'Could not launch run' });
   }
+}
+
+// ---- Run log viewer ----
+//
+// `kj run --plan` is spawned as a detached child on the server side;
+// stdout+stderr land in ~/.karajan/hu-board-runs/<planId>.log. The
+// browser polls GET /api/plans/:planId/log?offset=<last-seen-size>
+// every 2s and appends the delta into a <pre>. Polling stops when the
+// dialog closes.
+
+let logPollTimer = null;
+
+function openLogViewer(planId) {
+  if (logPollTimer) { clearTimeout(logPollTimer); logPollTimer = null; }
+
+  const dlg = ensureDialog();
+  dlg.innerHTML = `
+    <div style="padding:12px 18px;border-bottom:1px solid var(--border);
+                display:flex;justify-content:space-between;align-items:center;gap:10px">
+      <div style="font-weight:600">
+        Run log
+        <span style="font-family:var(--font-mono, monospace);font-size:0.8rem;
+                     color:var(--text-muted);margin-left:8px">${esc(planId)}</span>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center">
+        <span id="log-status" style="font-size:0.75rem;color:var(--text-muted)">connecting…</span>
+        <button id="log-close" class="control-btn"
+                style="padding:4px 12px;border:1px solid var(--border);
+                       background:var(--bg-primary);color:var(--text);
+                       border-radius:var(--radius-sm);cursor:pointer">
+          Close
+        </button>
+      </div>
+    </div>
+    <pre id="log-body"
+         style="margin:0;padding:14px 18px;max-height:60vh;min-height:240px;
+                min-width:640px;max-width:80vw;overflow:auto;
+                font-family:var(--font-mono, monospace);font-size:0.8rem;
+                line-height:1.45;background:#0b0b0c;color:#e6e6e6;
+                white-space:pre-wrap;word-break:break-word"></pre>
+    <div style="padding:10px 18px;border-top:1px solid var(--border);
+                font-size:0.75rem;color:var(--text-muted)">
+      The run keeps going in the background even if you close this. Re-open anytime.
+    </div>
+  `;
+
+  let offset = 0;
+  const bodyEl = dlg.querySelector('#log-body');
+  const statusEl = dlg.querySelector('#log-status');
+
+  const stopPolling = () => {
+    if (logPollTimer) { clearTimeout(logPollTimer); logPollTimer = null; }
+  };
+  const cleanup = () => {
+    stopPolling();
+    dlg.removeEventListener('close', cleanup);
+  };
+
+  dlg.querySelector('#log-close').addEventListener('click', () => {
+    cleanup();
+    if (dlg.open) dlg.close();
+  });
+  dlg.addEventListener('close', cleanup);
+
+  async function tick() {
+    try {
+      const res = await fetch(`/api/plans/${encodeURIComponent(planId)}/log?offset=${offset}`);
+      if (!res.ok) {
+        statusEl.textContent = `error: HTTP ${res.status}`;
+        logPollTimer = setTimeout(tick, 4000);
+        return;
+      }
+      const body = await res.json();
+      if (!body.exists) {
+        statusEl.textContent = 'waiting for run to start…';
+      } else {
+        if (body.content) {
+          // Auto-scroll if the user was already at the bottom before
+          // this append; otherwise keep their scroll position so they
+          // can read older lines without fighting the tail.
+          const atBottom = bodyEl.scrollTop + bodyEl.clientHeight >= bodyEl.scrollHeight - 8;
+          bodyEl.textContent += body.content;
+          if (atBottom) bodyEl.scrollTop = bodyEl.scrollHeight;
+        }
+        offset = body.size;
+        statusEl.textContent = `${(body.size / 1024).toFixed(1)} KB — live`;
+      }
+    } catch (err) {
+      statusEl.textContent = `error: ${err.message}`;
+    }
+    logPollTimer = setTimeout(tick, 2000);
+  }
+
+  dlg.showModal();
+  tick();
 }
 
 // ---- Detail Modals ----
@@ -879,6 +1010,7 @@ async function showStoryDetail(storyId) {
     const story = await api(`/api/stories/${encodeURIComponent(storyId)}`);
     const antipatterns = story.antipatterns ? JSON.parse(story.antipatterns) : [];
     const ac = story.acceptance_criteria ? JSON.parse(story.acceptance_criteria) : [];
+    const tests = story.acceptance_tests ? JSON.parse(story.acceptance_tests) : [];
     const ctxRequests = story.context_requests || [];
     const initials = await resolveProjectInitials(story.project_id);
     const shortId = shortStoryId(story, initials);
@@ -970,6 +1102,38 @@ async function showStoryDetail(storyId) {
               if (typeof c === 'string') return `<li class="modal__ac-item">${esc(c)}</li>`;
               if (c.given) return `<li class="modal__ac-item"><code>Given</code> ${esc(c.given)}<br><code>When</code> ${esc(c.when)}<br><code>Then</code> ${esc(c.then)}</li>`;
               return `<li class="modal__ac-item">${esc(JSON.stringify(c))}</li>`;
+            }).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${tests.length > 0 ? `
+        <div class="modal__section">
+          <div class="modal__section-title">Acceptance Tests (${tests.length})</div>
+          <ul class="modal__ac-list">
+            ${tests.map((t) => {
+              if (typeof t === 'string') return `<li class="modal__ac-item">${esc(t)}</li>`;
+              const label = t.name || t.title || t.id || '';
+              const desc = t.description || t.scope || '';
+              const given = t.given || (t.gherkin && t.gherkin.given);
+              if (given) {
+                const when = t.when || (t.gherkin && t.gherkin.when);
+                const then = t.then || (t.gherkin && t.gherkin.then);
+                return `<li class="modal__ac-item">
+                  ${label ? `<strong>${esc(label)}</strong><br>` : ''}
+                  <code>Given</code> ${esc(given)}<br>
+                  <code>When</code> ${esc(when || '')}<br>
+                  <code>Then</code> ${esc(then || '')}
+                </li>`;
+              }
+              if (label || desc) {
+                return `<li class="modal__ac-item">
+                  ${label ? `<strong>${esc(label)}</strong>` : ''}
+                  ${label && desc ? '<br>' : ''}
+                  ${desc ? esc(desc) : ''}
+                </li>`;
+              }
+              return `<li class="modal__ac-item"><code>${esc(JSON.stringify(t))}</code></li>`;
             }).join('')}
           </ul>
         </div>

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -109,6 +109,11 @@ export function initDb() {
   try { db.exec('ALTER TABLE stories ADD COLUMN ac_count INTEGER'); } catch { /* already migrated */ }
   try { db.exec('ALTER TABLE stories ADD COLUMN test_count INTEGER'); } catch { /* already migrated */ }
   try { db.exec('ALTER TABLE stories ADD COLUMN blocked_by TEXT'); } catch { /* already migrated */ }
+  // acceptance_tests is the raw JSON of `hu.acceptance_tests` — the
+  // plan stores each test as either a plain string or an object with
+  // { name, description, given/when/then, ... }. The modal renders
+  // the list; the card just shows the count (test_count above).
+  try { db.exec('ALTER TABLE stories ADD COLUMN acceptance_tests TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   return db;
@@ -157,14 +162,14 @@ export function upsertStory(story) {
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
-      ac_count, test_count, blocked_by
+      ac_count, test_count, blocked_by, acceptance_tests
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
-      @ac_count, @test_count, @blocked_by
+      @ac_count, @test_count, @blocked_by, @acceptance_tests
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -188,7 +193,8 @@ export function upsertStory(story) {
       plan_id = COALESCE(@plan_id, plan_id),
       ac_count = COALESCE(@ac_count, ac_count),
       test_count = COALESCE(@test_count, test_count),
-      blocked_by = COALESCE(@blocked_by, blocked_by)
+      blocked_by = COALESCE(@blocked_by, blocked_by),
+      acceptance_tests = COALESCE(@acceptance_tests, acceptance_tests)
   `);
   stmt.run({
     id: story.id,
@@ -217,6 +223,7 @@ export function upsertStory(story) {
     ac_count: story.ac_count ?? null,
     test_count: story.test_count ?? null,
     blocked_by: story.blocked_by || null,
+    acceptance_tests: story.acceptance_tests || null,
   });
 }
 

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -347,6 +347,52 @@ router.post('/projects/:id/ready', (req, res) => {
 });
 
 /**
+ * GET /api/plans/:planId/log - Tail the detached run's log file.
+ *
+ * Accepts ?offset=N so a polling UI can request only the new bytes
+ * since last read (the "tail -f" UX without SSE). Returns:
+ *
+ *   { content: string, size: number, exists: boolean }
+ *
+ * - `exists` is false when the run hasn't started yet (the log path is
+ *   deterministic, so we know where to look).
+ * - `size` is the current file length; clients pass `offset=size` next
+ *   time to get only the delta.
+ *
+ * Path is the same one that `runPlan` wrote to:
+ *   ~/.karajan/hu-board-runs/<planId>.log (honours KJ_HOME in tests).
+ */
+router.get('/plans/:planId/log', (req, res) => {
+  try {
+    const runsDir = path.join(getKjHome(), 'hu-board-runs');
+    const logPath = path.join(runsDir, `${req.params.planId}.log`);
+    if (!fs.existsSync(logPath)) {
+      return res.json({ exists: false, size: 0, content: '' });
+    }
+    const stat = fs.statSync(logPath);
+    const offset = Math.max(0, Math.min(stat.size, Number(req.query.offset) || 0));
+    // Cap per-request read to 1 MiB so a huge log can't blow up the
+    // response. The client will keep polling and catch up.
+    const MAX_READ = 1024 * 1024;
+    const length = Math.min(MAX_READ, stat.size - offset);
+    let content = '';
+    if (length > 0) {
+      const fd = fs.openSync(logPath, 'r');
+      try {
+        const buf = Buffer.alloc(length);
+        fs.readSync(fd, buf, 0, length, offset);
+        content = buf.toString('utf-8');
+      } finally {
+        fs.closeSync(fd);
+      }
+    }
+    res.json({ exists: true, size: stat.size, content });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
  * POST /api/plans/:planId/run - Launch `kj run --plan <planId>` as a
  * detached child. This is the "Run plan" button's endpoint — the board
  * no longer requires the user to drop to a terminal to kick off the

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -354,6 +354,10 @@ export function syncPlanFile(filePath) {
         ac_count: acList.length,
         test_count: testList.length,
         blocked_by: blockedByList.length > 0 ? JSON.stringify(blockedByList) : null,
+        // Full test list goes to SQLite too so the modal can show
+        // "🧪 2 tests" next to the list. Pre-patch the card showed
+        // test_count but the modal had nothing to render.
+        acceptance_tests: testList.length > 0 ? JSON.stringify(testList) : null,
       });
     }
 

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -366,6 +366,79 @@ describe('POST /api/plans/:planId/run', () => {
   });
 });
 
+describe('GET /api/plans/:planId/log', () => {
+  it('returns exists:false when the log file does not exist yet', async () => {
+    const res = await request(app).get(`/api/plans/${PLAN_ID}/log`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exists: false, size: 0, content: '' });
+  });
+
+  it('tails the log from a given offset', async () => {
+    // Seed a fake log file at the path `runPlan` would write to.
+    const runsDir = join(tmpHome, 'hu-board-runs');
+    mkdirSync(runsDir, { recursive: true });
+    const logPath = join(runsDir, `${PLAN_ID}.log`);
+    writeFileSync(logPath, 'first chunk\nsecond chunk\n', 'utf-8');
+
+    const firstBytes = Buffer.byteLength('first chunk\nsecond chunk\n');
+    const full = await request(app).get(`/api/plans/${PLAN_ID}/log`);
+    expect(full.status).toBe(200);
+    expect(full.body.exists).toBe(true);
+    expect(full.body.size).toBe(firstBytes);
+    expect(full.body.content).toBe('first chunk\nsecond chunk\n');
+
+    // Append more, read only delta.
+    writeFileSync(logPath, 'first chunk\nsecond chunk\nthird chunk\n', 'utf-8');
+    const totalBytes = Buffer.byteLength('first chunk\nsecond chunk\nthird chunk\n');
+    const delta = await request(app)
+      .get(`/api/plans/${PLAN_ID}/log`)
+      .query({ offset: firstBytes });
+    expect(delta.body.content).toBe('third chunk\n');
+    expect(delta.body.size).toBe(totalBytes);
+  });
+
+  it('clamps a too-large offset to the file size', async () => {
+    const runsDir = join(tmpHome, 'hu-board-runs');
+    mkdirSync(runsDir, { recursive: true });
+    writeFileSync(join(runsDir, `${PLAN_ID}.log`), 'hello\n', 'utf-8');
+
+    const res = await request(app)
+      .get(`/api/plans/${PLAN_ID}/log`)
+      .query({ offset: 9999 });
+    expect(res.status).toBe(200);
+    expect(res.body.content).toBe('');
+  });
+});
+
+describe('acceptance_tests stamping', () => {
+  it('persists acceptance_tests JSON on the story row so the modal can render the list', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_500`,
+          title: 'with tests',
+          status: 'pending',
+          acceptance_criteria: [],
+          acceptance_tests: [
+            'it should do the thing',
+            { given: 'x', when: 'y', then: 'z' },
+          ],
+          blocked_by: [],
+          createdAt: '2026-04-24T10:10:10Z',
+          updatedAt: '2026-04-24T10:10:10Z',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const stories = dbMod.getStoriesByProject(PROJECT_ID);
+    const row = stories.find((s) => s.id.endsWith('_500'));
+    expect(row.test_count).toBe(2);
+    const tests = JSON.parse(row.acceptance_tests);
+    expect(tests[0]).toBe('it should do the thing');
+    expect(tests[1].given).toBe('x');
+  });
+});
+
 describe('POST /api/projects/:id/run', () => {
   it('launches every plan of the project', async () => {
     const res = await request(app)


### PR DESCRIPTION
## Summary

Four follow-up fixes on the dogfooding punchlist that landed straight after PR #487:

### 1. "Ya no hay columnas"

The previous render hid empty lanes, so a fresh plan (everything in Pending) looked like a single list. **Now all four headers (Pending / Running / Done / Failed) render with their counts**; empty lanes drop to 55% opacity instead of showing a "No stories" placeholder.

### 2. "¿El orden mostrado = orden de ejecución?"

No. \`kj run --plan\` does a topological sort on \`blocked_by\` before executing. Surfaced visually: cards with no unresolved deps get a **🟢 ready to run** badge (mirrors the existing ⏳ "waits for…" tag on blocked HUs). Scanning the board now tells the user which HUs will fire first.

### 3. "1 test on the card, but the modal shows nothing"

Real bug: the sync pipeline counted \`acceptance_tests\` but never persisted the list. Added:
- Idempotent \`ALTER TABLE stories ADD COLUMN acceptance_tests TEXT\`
- \`syncPlanFile\` stamps the JSON
- Modal renders a new **"Acceptance Tests (N)"** section accepting strings, Gherkin triples, or free-form \`{ name, description }\`

### 4. "¿El botón Run plan abre una terminal?"

No — detached child, output to \`~/.karajan/hu-board-runs/<planId>.log\`. Replaced the previous \"Run started\" info dialog with a **live log viewer**:

- New endpoint \`GET /api/plans/:planId/log?offset=N\` serves current size + new bytes since last read (clamped to 1 MiB per request). Returns \`exists:false\` cleanly when the run hasn't created the file yet.
- Client polls every 2s into a styled \`<dialog>\` with smart auto-scroll (only when already at bottom — we don't fight manual scroll-up). Polling stops on close.
- A **📜 View log** button in the section header lets the user re-open the viewer after closing.

## Tests

30 mutation tests (was 26). New coverage:
- \`/api/plans/:planId/log\` — exists:false path, tail-by-offset, clamped over-size offset
- \`acceptance_tests\` JSON persisted on the story row at sync time, parses back into strings and Gherkin triples

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 91/91
- [x] \`npx vitest run tests/\` → 3791 (3 flaky-timeouts on first full batch run; all pass individually)
- [ ] Manual: \`kj board stop && kj board start\`, open a project with zero certified HUs — kanban shows 4 columns (Pending full, others at 55% opacity); open a HU — modal shows Acceptance Tests if any; click Run plan — log viewer opens and tails live