### PR TITLE
feat(board): SSE live updates, topological order, test count fix

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1731,7 +1731,69 @@ window.selectProject = selectProject;
 triggerSync().then(() => {
   populateProjectSelect();
   handleRoute();
+  subscribeToServerEvents();
 });
+
+// ---- Server-push updates ----
+//
+// The board gets a one-way stream of events from the server via
+// Server-Sent Events; each event hints at what changed (plan file,
+// session, batch). On receipt we refresh the current view in a way
+// that preserves scroll position and any open modal. Full-page
+// re-render is no longer on the table — clicking around doesn't
+// reset your scroll anymore.
+//
+// EventSource auto-reconnects on drop, so we don't manage lifecycle
+// ourselves. The status line below the header flashes briefly on
+// each update so the user can see the data is live.
+
+let sseSource = null;
+let sseRefreshTimer = null;
+
+function subscribeToServerEvents() {
+  if (typeof EventSource === 'undefined') return;   // ancient browser
+  if (sseSource) sseSource.close();
+  sseSource = new EventSource('/api/events');
+  sseSource.addEventListener('message', (e) => {
+    // Debounce burst updates — chokidar fires fast on a single
+    // plan JSON rewrite (plan.hus → stories → plan again). We
+    // don't need to patch the DOM ten times in 20ms.
+    if (sseRefreshTimer) clearTimeout(sseRefreshTimer);
+    sseRefreshTimer = setTimeout(() => refreshCurrentView(e.data), 150);
+  });
+  sseSource.addEventListener('error', () => {
+    // EventSource handles reconnection. Nothing to do; browsers retry
+    // the `retry:` value we sent on open.
+  });
+}
+
+/**
+ * Refresh the current SPA view without touching scroll position or
+ * any modal state. The heavy lifting already lives in renderBoard /
+ * renderGraph / renderSessions; this just re-calls them while the
+ * scroll offset is pinned, so the visual effect is "the card
+ * status updated in place".
+ * @param {string} _rawEvent unused for now — we could branch on
+ *   event type later to patch only the touched card, but a full
+ *   re-render with scroll preservation is already invisible to
+ *   the user and a lot simpler to reason about.
+ */
+async function refreshCurrentView(_rawEvent) {
+  const app = document.getElementById('app');
+  const scrollTop = app?.scrollTop ?? 0;
+  const scrollLeft = app?.scrollLeft ?? 0;
+  // Modal is in a separate DOM branch (#modal-backdrop) so render()
+  // never touches it — we don't need to save its state.
+  try {
+    await render();
+  } finally {
+    const fresh = document.getElementById('app');
+    if (fresh) {
+      fresh.scrollTop = scrollTop;
+      fresh.scrollLeft = scrollLeft;
+    }
+  }
+}
 
 // Auto-refresh every 10 seconds (with sync to catch new batches)
 refreshInterval = setInterval(async () => {

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -114,6 +114,12 @@ export function initDb() {
   // { name, description, given/when/then, ... }. The modal renders
   // the list; the card just shows the count (test_count above).
   try { db.exec('ALTER TABLE stories ADD COLUMN acceptance_tests TEXT'); } catch { /* already migrated */ }
+  // plan_order is the index of the HU in `plan.hus[]` as the planner
+  // emitted it. The planner's output is already topological (it calls
+  // addHu with `blocked_by: [prevId]`), so sorting the board by this
+  // column puts roots first and dependents last — matching what
+  // `kj run --plan` will actually execute.
+  try { db.exec('ALTER TABLE stories ADD COLUMN plan_order INTEGER'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   return db;
@@ -162,14 +168,14 @@ export function upsertStory(story) {
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
-      ac_count, test_count, blocked_by, acceptance_tests
+      ac_count, test_count, blocked_by, acceptance_tests, plan_order
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
-      @ac_count, @test_count, @blocked_by, @acceptance_tests
+      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -194,7 +200,8 @@ export function upsertStory(story) {
       ac_count = COALESCE(@ac_count, ac_count),
       test_count = COALESCE(@test_count, test_count),
       blocked_by = COALESCE(@blocked_by, blocked_by),
-      acceptance_tests = COALESCE(@acceptance_tests, acceptance_tests)
+      acceptance_tests = COALESCE(@acceptance_tests, acceptance_tests),
+      plan_order = COALESCE(@plan_order, plan_order)
   `);
   stmt.run({
     id: story.id,
@@ -224,6 +231,7 @@ export function upsertStory(story) {
     test_count: story.test_count ?? null,
     blocked_by: story.blocked_by || null,
     acceptance_tests: story.acceptance_tests || null,
+    plan_order: story.plan_order ?? null,
   });
 }
 
@@ -339,9 +347,16 @@ export function getProjects() {
  * @param {string} projectId
  * @returns {Array<object>}
  */
+/**
+ * Fetch all stories of a project ordered by plan_order ASC (roots first,
+ * dependents last — matches what `kj run --plan` will actually execute)
+ * and falling back to updated_at DESC for legacy rows that never had
+ * plan_order stamped.
+ */
 export function getStoriesByProject(projectId) {
   return getDb().prepare(`
-    SELECT * FROM stories WHERE project_id = ? ORDER BY updated_at DESC
+    SELECT * FROM stories WHERE project_id = ?
+    ORDER BY plan_order IS NULL, plan_order ASC, updated_at DESC
   `).all(projectId);
 }
 

--- a/packages/hu-board/src/event-bus.js
+++ b/packages/hu-board/src/event-bus.js
@@ -1,0 +1,58 @@
+/**
+ * Tiny pub/sub used to push sync-related events to connected SSE
+ * clients. The chokidar watcher calls `publish(event)` whenever a plan
+ * / session / batch file changes; the SSE endpoint subscribes each
+ * connected response and writes the JSON-encoded event as a message.
+ *
+ * No external dependency on purpose — `events.EventEmitter` would work
+ * but would make testing the endpoint awkward (we need deterministic
+ * subscribe/publish semantics for the integration tests in
+ * sse.test.js). The contract is:
+ *
+ *   subscribe(fn)   → returns an unsubscribe function
+ *   publish(event)  → calls every current subscriber once
+ *   subscriberCount → how many listeners are live (tests only)
+ *
+ * Events are plain JSON objects. Callers pick the shape:
+ *
+ *   { type: 'plan',    planId, projectId }   — a plan JSON was synced
+ *   { type: 'session', sessionId, projectId }— a session JSON was synced
+ *   { type: 'story',   storyId, projectId }  — a single HU row mutated
+ *
+ * The board's client treats these as hints: the usual response is to
+ * re-fetch the affected project's stories and patch the kanban in
+ * place, so no full page reload is ever required.
+ */
+
+const subscribers = new Set();
+
+/**
+ * @param {(event: object) => void} fn
+ * @returns {() => void} unsubscribe
+ */
+export function subscribe(fn) {
+  subscribers.add(fn);
+  return () => { subscribers.delete(fn); };
+}
+
+/**
+ * @param {object} event
+ */
+export function publish(event) {
+  for (const fn of subscribers) {
+    try { fn(event); } catch (err) {
+      // A broken subscriber must not take the bus down. Log and move on.
+      console.error('[event-bus] subscriber threw:', err.message);
+    }
+  }
+}
+
+/** @returns {number} */
+export function subscriberCount() {
+  return subscribers.size;
+}
+
+/** Test helper — drops every subscriber. */
+export function _resetForTests() {
+  subscribers.clear();
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -17,6 +17,7 @@ import {
 } from '../db.js';
 import { fullScan } from '../sync.js';
 import { setHuStatus, setHuFields, markPlanReady, runPlan } from '../plan-mutations.js';
+import { subscribe as subscribeEvents } from '../event-bus.js';
 
 const router = Router();
 
@@ -344,6 +345,57 @@ router.post('/projects/:id/ready', (req, res) => {
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+/**
+ * GET /api/events - Server-Sent Events stream for live board updates.
+ *
+ * Replaces the old "sync → full page re-render" dance. The chokidar
+ * watcher publishes a small event on every sync (plan/session/batch);
+ * this endpoint pipes those events to every connected client. The
+ * client patches the affected card in place, so scroll position and
+ * any open modal survive the update.
+ *
+ * The connection stays open for the life of the tab. Browsers
+ * auto-reconnect on socket drop — we send a keep-alive comment every
+ * 25s so intermediate proxies don't kill the idle socket.
+ */
+router.get('/events', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    // Disable Express compression on this route — SSE must be a raw
+    // stream, gzip buffers and breaks the "push on every event" model.
+    'X-Accel-Buffering': 'no',
+  });
+  res.flushHeaders?.();
+  // Initial hello so the client knows the stream is open. Useful for
+  // the integration test too: the EventSource-equivalent supertest
+  // client can wait on the first line.
+  res.write('retry: 2000\n');
+  res.write('event: hello\ndata: {"ok":true}\n\n');
+
+  const send = (event) => {
+    try {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    } catch {
+      // Client gone — the close handler will clean up shortly.
+    }
+  };
+  const unsubscribe = subscribeEvents(send);
+
+  // 25s is well under the default 60-90s idle timeout of every sane
+  // reverse proxy, but high enough that it doesn't spam the log.
+  const keepAlive = setInterval(() => {
+    try { res.write(': keep-alive\n\n'); } catch { /* ignore */ }
+  }, 25000);
+
+  req.on('close', () => {
+    clearInterval(keepAlive);
+    unsubscribe();
+    res.end?.();
+  });
 });
 
 /**

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -10,6 +10,7 @@ import {
   insertContextRequest,
   getDb,
 } from './db.js';
+import { publish as publishEvent } from './event-bus.js';
 
 /**
  * Derive a human-readable project name from batch data.
@@ -176,6 +177,7 @@ function syncStoryFile(filePath) {
     }
 
     console.log(`[sync] Synced stories from ${basename(join(filePath, '..'))}: ${(data.stories || []).length} stories`);
+    publishEvent({ type: 'batch', projectId, path: filePath });
   } catch (err) {
     console.error(`[sync] Error syncing story file ${filePath}:`, err.message);
   }
@@ -277,6 +279,7 @@ function syncSessionFile(filePath) {
     });
 
     console.log(`[sync] Synced session ${sessionId}: status=${data.status}, iterations=${maxIteration}`);
+    publishEvent({ type: 'session', projectId, sessionId });
   } catch (err) {
     console.error(`[sync] Error syncing session file ${filePath}:`, err.message);
   }
@@ -321,9 +324,21 @@ export function syncPlanFile(filePath) {
       total_stories: data.hus.length,
     });
 
-    for (const hu of data.hus) {
+    for (let i = 0; i < data.hus.length; i += 1) {
+      const hu = data.hus[i];
       const acList = Array.isArray(hu.acceptance_criteria) ? hu.acceptance_criteria : [];
-      const testList = Array.isArray(hu.acceptance_tests) ? hu.acceptance_tests : [];
+      // Only count tests that carry real content. `kj plan` stamps a
+      // placeholder like `["npx vitest run ..."]` on every HU — those
+      // DO count as 1 test each. But empty strings / null entries
+      // (which show up in half-baked plans) must not inflate the
+      // badge to "🧪 1 test" on a HU that effectively has none.
+      const testList = (Array.isArray(hu.acceptance_tests) ? hu.acceptance_tests : [])
+        .filter((t) => {
+          if (!t) return false;
+          if (typeof t === 'string') return t.trim().length > 0;
+          // objects: require some identifying field
+          return Boolean(t.name || t.title || t.description || t.given || t.gherkin || t.scope);
+        });
       const blockedByList = Array.isArray(hu.blocked_by) ? hu.blocked_by : [];
       const acText = acList.length > 0 ? JSON.stringify(acList) : null;
 
@@ -358,10 +373,14 @@ export function syncPlanFile(filePath) {
         // "🧪 2 tests" next to the list. Pre-patch the card showed
         // test_count but the modal had nothing to render.
         acceptance_tests: testList.length > 0 ? JSON.stringify(testList) : null,
+        // Index in plan.hus[] — used by getStoriesByProject to order
+        // cards topologically (roots first, dependents last).
+        plan_order: i,
       });
     }
 
     console.log(`[sync] Plan ${projectId}: ${data.hus.length} HUs (${projectName})`);
+    publishEvent({ type: 'plan', projectId, planId: data.planId });
   } catch (err) {
     console.error(`[sync] Failed to sync plan ${filePath}: ${err.message}`);
   }

--- a/packages/hu-board/tests/event-bus.test.js
+++ b/packages/hu-board/tests/event-bus.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { subscribe, publish, subscriberCount, _resetForTests } from '../src/event-bus.js';
+
+describe('event-bus', () => {
+  beforeEach(() => { _resetForTests(); });
+
+  it('fan-outs each publish to every subscriber', () => {
+    const seenA = [];
+    const seenB = [];
+    subscribe((e) => seenA.push(e));
+    subscribe((e) => seenB.push(e));
+
+    publish({ type: 'plan', planId: 'p1' });
+    publish({ type: 'session', sessionId: 's1' });
+
+    expect(seenA).toHaveLength(2);
+    expect(seenB).toHaveLength(2);
+    expect(seenA[0]).toEqual({ type: 'plan', planId: 'p1' });
+  });
+
+  it('unsubscribe stops delivery without affecting the other subscribers', () => {
+    const a = [];
+    const b = [];
+    const unsubA = subscribe((e) => a.push(e));
+    subscribe((e) => b.push(e));
+
+    publish({ type: 'plan' });
+    unsubA();
+    publish({ type: 'session' });
+
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(2);
+  });
+
+  it('a subscriber throwing does not take the bus down', () => {
+    const seen = [];
+    subscribe(() => { throw new Error('boom'); });
+    subscribe((e) => seen.push(e));
+
+    publish({ type: 'plan' });
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it('subscriberCount reflects live listeners', () => {
+    expect(subscriberCount()).toBe(0);
+    const unsub = subscribe(() => {});
+    expect(subscriberCount()).toBe(1);
+    unsub();
+    expect(subscriberCount()).toBe(0);
+  });
+});

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -410,6 +410,68 @@ describe('GET /api/plans/:planId/log', () => {
   });
 });
 
+describe('plan_order topological stamping', () => {
+  it('stamps plan_order = index in plan.hus[] so cards sort roots-first', () => {
+    writePlanToDisk({
+      hus: [
+        { id: `${PLAN_ID}_001`, title: 'root', status: 'pending', acceptance_criteria: [], blocked_by: [], createdAt: 'a', updatedAt: 'a' },
+        { id: `${PLAN_ID}_002`, title: 'mid',  status: 'pending', acceptance_criteria: [], blocked_by: [`${PLAN_ID}_001`], createdAt: 'b', updatedAt: 'b' },
+        { id: `${PLAN_ID}_003`, title: 'leaf', status: 'pending', acceptance_criteria: [], blocked_by: [`${PLAN_ID}_002`], createdAt: 'c', updatedAt: 'c' },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const stories = dbMod.getStoriesByProject(PROJECT_ID);
+    // getStoriesByProject orders by plan_order ASC, so roots first,
+    // then their dependents — matching kj run --plan's topo sort.
+    expect(stories[0].id).toBe(`${PROJECT_ID}::${PLAN_ID}_001`);
+    expect(stories[1].id).toBe(`${PROJECT_ID}::${PLAN_ID}_002`);
+    expect(stories[2].id).toBe(`${PROJECT_ID}::${PLAN_ID}_003`);
+    expect(stories[0].plan_order).toBe(0);
+    expect(stories[2].plan_order).toBe(2);
+  });
+});
+
+describe('empty acceptance_tests entries must not inflate test_count', () => {
+  it('ignores null, empty strings, and structureless objects', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_900`,
+          title: 'noise',
+          status: 'pending',
+          acceptance_criteria: [],
+          acceptance_tests: ['', null, { foo: 'bar' }, '   ', {}],
+          blocked_by: [],
+          createdAt: 'a', updatedAt: 'a',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const row = dbMod.getStoriesByProject(PROJECT_ID).find((s) => s.id.endsWith('_900'));
+    expect(row.test_count).toBe(0);
+    expect(row.acceptance_tests).toBeNull();
+  });
+
+  it('keeps real string tests and Gherkin objects', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_901`,
+          title: 'real',
+          status: 'pending',
+          acceptance_criteria: [],
+          acceptance_tests: ['npx vitest', { given: 'x', when: 'y', then: 'z' }, ''],
+          blocked_by: [],
+          createdAt: 'a', updatedAt: 'a',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const row = dbMod.getStoriesByProject(PROJECT_ID).find((s) => s.id.endsWith('_901'));
+    expect(row.test_count).toBe(2);
+  });
+});
+
 describe('acceptance_tests stamping', () => {
   it('persists acceptance_tests JSON on the story row so the modal can render the list', () => {
     writePlanToDisk({

--- a/packages/hu-board/tests/sse.test.js
+++ b/packages/hu-board/tests/sse.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import express from 'express';
+import http from 'node:http';
+
+// Integration test for GET /api/events. We exercise the endpoint with
+// a raw HTTP client instead of supertest because supertest buffers
+// the response until it ends, and SSE streams don't end — we need to
+// read chunks as they arrive.
+
+let tmpDir;
+let server;
+let port;
+let dbMod;
+let busMod;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-sse-'));
+  process.env.KJ_HOME = tmpDir;
+
+  dbMod = await import('../src/db.js');
+  dbMod.initDb();
+  busMod = await import('../src/event-bus.js');
+  busMod._resetForTests();
+
+  const { default: apiRoutes } = await import('../src/routes/api.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api', apiRoutes);
+
+  await new Promise((resolve) => {
+    server = app.listen(0, () => {
+      port = server.address().port;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  await new Promise((r) => server.close(r));
+  dbMod.closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+/**
+ * Open a raw HTTP request to /api/events and resolve once we've
+ * collected `want` full SSE messages (each "\n\n"-terminated). Kills
+ * the socket after, so the server's close handler fires.
+ */
+function collectSseMessages(want, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const req = http.get({ host: 'localhost', port, path: '/api/events' }, (res) => {
+      let buf = '';
+      const frames = [];
+      const timer = setTimeout(() => {
+        req.destroy();
+        reject(new Error(`timed out after ${frames.length}/${want} frames`));
+      }, timeoutMs);
+      res.on('data', (chunk) => {
+        buf += chunk.toString('utf-8');
+        let idx;
+        while ((idx = buf.indexOf('\n\n')) !== -1) {
+          frames.push(buf.slice(0, idx));
+          buf = buf.slice(idx + 2);
+          if (frames.length >= want) {
+            clearTimeout(timer);
+            req.destroy();
+            resolve(frames);
+            return;
+          }
+        }
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+  });
+}
+
+describe('GET /api/events', () => {
+  it('sends a hello frame immediately on connect', async () => {
+    const [hello] = await collectSseMessages(1);
+    expect(hello).toContain('event: hello');
+    expect(hello).toContain('data: {"ok":true}');
+  });
+
+  it('streams a published bus event to the connected client', async () => {
+    // Kick the bus on the next tick so the client is already subscribed.
+    setTimeout(() => busMod.publish({ type: 'plan', planId: 'p1', projectId: 'proj' }), 50);
+    const frames = await collectSseMessages(2);
+    const dataFrame = frames.find((f) => f.startsWith('data:'));
+    expect(dataFrame).toBeDefined();
+    const payload = JSON.parse(dataFrame.replace(/^data:\s*/, ''));
+    expect(payload).toEqual({ type: 'plan', planId: 'p1', projectId: 'proj' });
+  });
+
+  it('unsubscribes on connection close', async () => {
+    expect(busMod.subscriberCount()).toBe(0);
+    const frames = await collectSseMessages(1);
+    expect(frames[0]).toContain('hello');
+    // The socket was destroyed inside collectSseMessages; the server's
+    // `req.on('close', …)` fires on the next macrotask. Poll up to
+    // 500ms (10 × 50ms) so we don't race the close handler on slow
+    // CI runners.
+    for (let i = 0; i < 10 && busMod.subscriberCount() !== 0; i += 1) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(busMod.subscriberCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Three distinct issues raised immediately after #488:

### 1. HUs were listed in reverse-dependency order

\`getStoriesByProject\` was \`ORDER BY updated_at DESC\`, so whichever HU got rewritten last floated to the top. Roots ended at the bottom; dependents at the top — the opposite of what \`kj run --plan\` actually executes.

**Fix**: stamp \`plan_order\` (index in \`plan.hus[]\`) at sync time and \`ORDER BY plan_order ASC, updated_at DESC\`. Since the planner's output is already topological (each \`addHu\` sets \`blocked_by: [prevId]\`), cards now match execution order exactly.

### 2. \"Feels like the 90s — reloads lose scroll and close open modals\"

Full SSE plumbing:

- **\`packages/hu-board/src/event-bus.js\`** — 60-LOC pub/sub with fan-out, throw-isolation, unsubscribe.
- **\`GET /api/events\`** — long-lived SSE stream. \`hello\` frame on connect, 25 s keep-alives, one frame per bus event, clean unsubscribe on \`req.close\`.
- **\`sync.js\`** publishes after every successful plan / session / batch sync.
- **Client**: \`EventSource\` debounces bursts (150 ms) and calls \`refreshCurrentView()\` which saves \`#app.scrollTop\`, re-invokes \`render()\`, then restores. Modal lives in a separate DOM branch so open details stay open.

### 3. \"🧪 1 test on every HU even without any\"

Two causes:

- \`kj plan\` really does stamp one acceptance_tests placeholder per HU (\`\"npx vitest run …\"\`), so that 1 is honest. It's a project-suite gate, not a per-HU assertion. Documented in the chat — no code change.
- Half-baked plans with \`[null, '', {}]\` inflated the count anyway. Fixed in syncPlanFile with a filter that keeps strings with non-empty \`trim()\` and objects with at least one identifying field.

## Tests

Two new suites + cases added to the existing mutation file:

- \`event-bus.test.js\` — 4 cases (fan-out, unsubscribe, throw isolation, subscriberCount)
- \`sse.test.js\` — 3 cases over a raw \`http\` client (supertest can't read SSE as a stream; it buffers until end)
- plan_order topological ordering
- filter for empty acceptance_tests entries

101/101 hu-board + 3791/3791 parent green.

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 101/101
- [x] \`npx vitest run tests/\` → 3791/3791
- [ ] Manual: \`kj board stop && kj board start\`; open board; scroll; trigger a plan sync — scroll stays put, open modal stays open
- [ ] Manual: HU 001 (root) renders above HU 002 (depends on 001)