### PR TITLE
fix(board): drop the "🧪 1 test" chip from story cards

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -716,7 +716,11 @@ function renderStoryCard(story) {
       <div class="story-card__title">${esc(truncate(title, 100))}</div>
       <div class="story-card__meta" style="gap:10px">
         ${acCount > 0 ? `<span title="${acCount} acceptance criteria">📋 ${acCount} AC${acCount === 1 ? '' : 's'}</span>` : ''}
-        ${testCount > 0 ? `<span title="${testCount} acceptance tests">🧪 ${testCount} test${testCount === 1 ? '' : 's'}</span>` : ''}
+        ${/* The test count chip was misleading: `kj plan` stamps one
+           placeholder test ("npx vitest run …") on every HU, so the
+           card always read "🧪 1 test" regardless of what the HU
+           actually needed. The modal still shows the Acceptance Tests
+           section for anyone who wants to inspect what will run. */ ''}
         ${story.quality_total !== null ? `
           <span class="story-card__score ${scoreClass(story.quality_total)}" title="INVEST score">
             ${story.quality_total}/60 ${qualityBar(story.quality_total)}


### PR DESCRIPTION
## Summary

The chip on story cards was misleading: \`kj plan\` stamps a single placeholder (\`npx vitest run 2>&1; test \$? -eq 0 && echo PASS || echo FAIL\`) on every HU, so the card always read *\"🧪 1 test\"* regardless of what the HU actually needed. That's a project-suite gate, not a per-HU assertion — meaningless as card metadata.

The modal still shows the Acceptance Tests section for anyone who wants to inspect what will run. The card now shows only the AC count (when non-zero) and the INVEST score (when present), both of which ARE genuinely per-HU.

## Tests

No test changes — card rendering is DOM-only and the existing suites already cover sync + count persistence. 101/101 board + 3791/3791 parent unchanged.

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 101/101
- [ ] Manual: after \`kj board stop && kj board start\`, cards no longer show \"🧪 1 test\"; open a HU → modal's Acceptance Tests section still lists the \`npx vitest run …\` placeholder