### PR TITLE
feat(plan): Phase 1 of tests-first — planner emits structured acceptance_tests

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -710,28 +710,34 @@ function renderStoryCard(story) {
     return `${initials}-${m ? m[1] : '?'}`;
   };
 
+  // Tests-first flag: a HU with zero acceptance_tests has no contract
+  // for the coder, so `Run plan` will refuse to execute it. Surface
+  // this on the card so the user edits the HU before trying to run.
+  const missingTestContract = testCount === 0 && ['pending', 'certified'].includes(story.status);
+
   return `
     <div class="story-card" onclick="showStoryDetail('${esc(story.id)}')">
       <div class="story-card__id" title="${esc(story.id)}">${esc(shortId)}</div>
       <div class="story-card__title">${esc(truncate(title, 100))}</div>
       <div class="story-card__meta" style="gap:10px">
         ${acCount > 0 ? `<span title="${acCount} acceptance criteria">📋 ${acCount} AC${acCount === 1 ? '' : 's'}</span>` : ''}
-        ${/* The test count chip was misleading: `kj plan` stamps one
-           placeholder test ("npx vitest run …") on every HU, so the
-           card always read "🧪 1 test" regardless of what the HU
-           actually needed. The modal still shows the Acceptance Tests
-           section for anyone who wants to inspect what will run. */ ''}
+        ${testCount > 0 ? `<span title="${testCount} acceptance tests declared">✅ ${testCount} test${testCount === 1 ? '' : 's'}</span>` : ''}
         ${story.quality_total !== null ? `
           <span class="story-card__score ${scoreClass(story.quality_total)}" title="INVEST score">
             ${story.quality_total}/60 ${qualityBar(story.quality_total)}
           </span>
         ` : ''}
       </div>
+      ${missingTestContract ? `
+        <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--color-yellow,#eab308);font-weight:600" title="This HU has no acceptance_tests declared — Run plan will reject it until you add at least one.">
+          ⚠ missing test contract
+        </div>
+      ` : ''}
       ${blockedBy.length > 0 ? `
         <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--text-muted)" title="This HU waits on: ${esc(blockedBy.join(', '))}">
           ⏳ waits for: ${blockedBy.map((d) => esc(shortDep(d))).join(', ')}
         </div>
-      ` : (story.status === 'pending' || story.status === 'certified') ? `
+      ` : (story.status === 'pending' || story.status === 'certified') && !missingTestContract ? `
         <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--color-green)" title="No dependencies — runs first on the next 'Run plan'">
           🟢 ready to run
         </div>
@@ -1111,37 +1117,42 @@ async function showStoryDetail(storyId) {
         </div>
       ` : ''}
 
-      ${tests.length > 0 ? `
+      ${tests.length === 0 ? `
+        <div class="modal__section" style="border:1px solid var(--color-yellow,#eab308);background:rgba(234,179,8,0.08);padding:10px 12px;border-radius:var(--radius-sm)">
+          <div class="modal__section-title" style="color:var(--color-yellow,#eab308)">⚠ Missing test contract</div>
+          <div style="font-size:0.85rem;line-height:1.5;margin-top:4px">
+            This HU has no acceptance_tests declared. The tests-first pipeline (v2.7.5)
+            refuses to run HUs without an executable contract. Click ✎ Edit above and
+            add at least one test — a <code>shell</code> command that exits 0 on pass,
+            or a <code>gherkin</code> Given/When/Then spec.
+          </div>
+        </div>
+      ` : `
         <div class="modal__section">
           <div class="modal__section-title">Acceptance Tests (${tests.length})</div>
           <ul class="modal__ac-list">
             ${tests.map((t) => {
-              if (typeof t === 'string') return `<li class="modal__ac-item">${esc(t)}</li>`;
-              const label = t.name || t.title || t.id || '';
-              const desc = t.description || t.scope || '';
-              const given = t.given || (t.gherkin && t.gherkin.given);
-              if (given) {
-                const when = t.when || (t.gherkin && t.gherkin.when);
-                const then = t.then || (t.gherkin && t.gherkin.then);
-                return `<li class="modal__ac-item">
-                  ${label ? `<strong>${esc(label)}</strong><br>` : ''}
-                  <code>Given</code> ${esc(given)}<br>
-                  <code>When</code> ${esc(when || '')}<br>
-                  <code>Then</code> ${esc(then || '')}
-                </li>`;
+              // Legacy form: plain string — render as shell.
+              if (typeof t === 'string') {
+                return `<li class="modal__ac-item"><span style="font-size:0.7rem;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;margin-right:8px">shell</span><code>${esc(t)}</code></li>`;
               }
-              if (label || desc) {
-                return `<li class="modal__ac-item">
-                  ${label ? `<strong>${esc(label)}</strong>` : ''}
-                  ${label && desc ? '<br>' : ''}
-                  ${desc ? esc(desc) : ''}
-                </li>`;
+              // v2.7.5 structured form: { type, content, file? }
+              if (t && typeof t === 'object' && typeof t.content === 'string') {
+                const type = t.type === 'gherkin' ? 'gherkin' : 'shell';
+                const badgeColor = type === 'gherkin' ? 'var(--color-blue,#3b82f6)' : 'var(--text-muted)';
+                const fileBit = t.file ? ` <span style="color:var(--text-muted);font-size:0.75rem;margin-left:8px">→ ${esc(t.file)}</span>` : '';
+                if (type === 'gherkin') {
+                  return `<li class="modal__ac-item"><span style="font-size:0.7rem;color:${badgeColor};text-transform:uppercase;letter-spacing:0.5px;margin-right:8px">gherkin</span>${fileBit}<pre style="white-space:pre-wrap;margin:4px 0 0 0;font-family:inherit;font-size:0.9rem;line-height:1.5">${esc(t.content)}</pre></li>`;
+                }
+                return `<li class="modal__ac-item"><span style="font-size:0.7rem;color:${badgeColor};text-transform:uppercase;letter-spacing:0.5px;margin-right:8px">shell</span>${fileBit}<code>${esc(t.content)}</code></li>`;
               }
+              // Fallback for anything else: show the raw JSON so the user
+              // can diagnose malformed entries.
               return `<li class="modal__ac-item"><code>${esc(JSON.stringify(t))}</code></li>`;
             }).join('')}
           </ul>
         </div>
-      ` : ''}
+      `}
 
       ${ctxRequests.length > 0 ? `
         <div class="modal__section">
@@ -1202,6 +1213,24 @@ function renderStoryEditForm(story) {
     .map((c) => typeof c === 'string' ? c : (c.given ? `Given ${c.given} | When ${c.when} | Then ${c.then}` : JSON.stringify(c)))
     .join('\n');
 
+  // Tests-first editor: one block per test with a type selector
+  // (shell | gherkin), the content textarea, optional file path, and
+  // a remove button. Save collects them into the structured v2.7.5
+  // array shape. Plain strings in the existing data are treated as
+  // legacy shell tests and auto-upgraded to the structured form.
+  const rawTests = story.acceptance_tests ? JSON.parse(story.acceptance_tests) : [];
+  const testsInitial = rawTests.map((t) => {
+    if (typeof t === 'string') return { type: 'shell', content: t, file: '' };
+    if (t && typeof t === 'object') {
+      return {
+        type: t.type === 'gherkin' ? 'gherkin' : 'shell',
+        content: typeof t.content === 'string' ? t.content : JSON.stringify(t),
+        file: typeof t.file === 'string' ? t.file : '',
+      };
+    }
+    return { type: 'shell', content: String(t ?? ''), file: '' };
+  });
+
   const scopeInitial = story.original_text || story.certified_want || '';
   const TASK_TYPES = ['sw', 'infra', 'doc', 'add-tests', 'refactor'];
 
@@ -1245,6 +1274,17 @@ function renderStoryEditForm(story) {
                   style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-family:var(--font-mono, monospace);font-size:0.85rem;line-height:1.5;resize:vertical">${esc(acInitial)}</textarea>
       </label>
 
+      <fieldset style="border:1px solid var(--border);border-radius:var(--radius-sm);padding:10px 12px;margin:0">
+        <legend style="color:var(--text-muted);font-size:0.85rem;padding:0 6px">
+          Acceptance tests — the contract the coder must satisfy
+        </legend>
+        <div id="edit-tests-list" style="display:flex;flex-direction:column;gap:8px"></div>
+        <button type="button" id="edit-tests-add"
+                style="margin-top:8px;padding:4px 10px;font-size:0.8rem;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer">
+          + Add test
+        </button>
+      </fieldset>
+
       <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px;padding-top:12px;border-top:1px solid var(--border)">
         <button type="button" id="edit-cancel" class="control-btn"
                 style="padding:6px 14px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
@@ -1258,8 +1298,62 @@ function renderStoryEditForm(story) {
     </form>
   `;
 
+  // Tests editor state + renderers. Kept on the function scope (not
+  // on window) so reopening the form gives a fresh copy.
+  let testRows = [...testsInitial];
+  const listEl = document.getElementById('edit-tests-list');
+
+  function renderTestsEditor() {
+    listEl.innerHTML = testRows.map((t, i) => `
+      <div class="edit-test-row" data-idx="${i}"
+           style="display:grid;grid-template-columns:auto 1fr auto;gap:6px;align-items:start;padding:8px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg-primary)">
+        <select data-field="type"
+                style="padding:4px 6px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text);border-radius:var(--radius-sm);font-size:0.8rem">
+          <option value="shell"${t.type === 'shell' ? ' selected' : ''}>shell</option>
+          <option value="gherkin"${t.type === 'gherkin' ? ' selected' : ''}>gherkin</option>
+        </select>
+        <div style="display:flex;flex-direction:column;gap:4px">
+          <textarea data-field="content" rows="${t.type === 'gherkin' ? 3 : 2}"
+                    placeholder="${t.type === 'gherkin' ? 'Given …\\nWhen …\\nThen …' : 'npx vitest run test/foo.test.js'}"
+                    style="padding:6px 8px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text);border-radius:var(--radius-sm);font-family:var(--font-mono, monospace);font-size:0.82rem;line-height:1.4;resize:vertical">${esc(t.content)}</textarea>
+          <input type="text" data-field="file" placeholder="Optional: file path (e.g. tests/login.test.ts)" value="${esc(t.file || '')}"
+                 style="padding:4px 8px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text);border-radius:var(--radius-sm);font-family:var(--font-mono, monospace);font-size:0.75rem">
+        </div>
+        <button type="button" data-field="remove" title="Remove this test"
+                style="align-self:start;padding:4px 8px;background:transparent;border:1px solid var(--border);color:var(--text-muted);border-radius:var(--radius-sm);cursor:pointer;font-size:0.8rem">✕</button>
+      </div>
+    `).join('');
+
+    // Bind the edit events. We re-bind on every render — cheap, and
+    // keeps the state → DOM mapping simple.
+    listEl.querySelectorAll('.edit-test-row').forEach((row) => {
+      const idx = Number(row.dataset.idx);
+      row.querySelector('[data-field="type"]').addEventListener('change', (e) => {
+        testRows[idx].type = e.target.value;
+        renderTestsEditor();            // re-render so placeholder updates
+      });
+      row.querySelector('[data-field="content"]').addEventListener('input', (e) => {
+        testRows[idx].content = e.target.value;
+      });
+      row.querySelector('[data-field="file"]').addEventListener('input', (e) => {
+        testRows[idx].file = e.target.value;
+      });
+      row.querySelector('[data-field="remove"]').addEventListener('click', () => {
+        testRows.splice(idx, 1);
+        renderTestsEditor();
+      });
+    });
+  }
+
+  renderTestsEditor();
+
+  document.getElementById('edit-tests-add').addEventListener('click', () => {
+    testRows.push({ type: 'shell', content: '', file: '' });
+    renderTestsEditor();
+  });
+
   document.getElementById('edit-cancel').addEventListener('click', () => showStoryDetail(story.id));
-  document.getElementById('edit-save').addEventListener('click', () => saveStoryEdits(story));
+  document.getElementById('edit-save').addEventListener('click', () => saveStoryEdits(story, () => testRows));
 }
 
 /**
@@ -1268,7 +1362,7 @@ function renderStoryEditForm(story) {
  * a no-op (close out of edit mode without an API call).
  * @param {object} story
  */
-async function saveStoryEdits(story) {
+async function saveStoryEdits(story, getTestRows) {
   const title = document.getElementById('edit-title').value.trim();
   const scope = document.getElementById('edit-scope').value;
   const taskType = document.getElementById('edit-task-type').value;
@@ -1291,6 +1385,18 @@ async function saveStoryEdits(story) {
       return line;
     });
 
+  // Collect the structured acceptance_tests from the editor state,
+  // dropping rows the user left empty.
+  const testRows = typeof getTestRows === 'function' ? getTestRows() : [];
+  const acceptance_tests = testRows
+    .map((t) => ({
+      type: t.type === 'gherkin' ? 'gherkin' : 'shell',
+      content: (t.content || '').trim(),
+      file: (t.file || '').trim(),
+    }))
+    .filter((t) => t.content.length > 0)
+    .map((t) => (t.file ? t : { type: t.type, content: t.content }));
+
   // Diff against the original so we don't send untouched fields and
   // let the server's COALESCE keep existing values.
   const patch = {};
@@ -1301,6 +1407,9 @@ async function saveStoryEdits(story) {
   const prevAcStr = story.acceptance_criteria || '[]';
   const nextAcStr = JSON.stringify(acceptance_criteria);
   if (nextAcStr !== prevAcStr) patch.acceptance_criteria = acceptance_criteria;
+  const prevTestsStr = story.acceptance_tests || '[]';
+  const nextTestsStr = JSON.stringify(acceptance_tests);
+  if (nextTestsStr !== prevTestsStr) patch.acceptance_tests = acceptance_tests;
 
   if (Object.keys(patch).length === 0) {
     showStoryDetail(story.id);

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -120,21 +120,37 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   plan.risks = parsed?.risks || [];
   plan.outOfScope = parsed?.outOfScope || [];
 
-  // Convert planner steps → HUs
+  // Convert planner steps → HUs, carrying the structured acceptance_tests
+  // the LLM was asked to emit. If the LLM fell back to legacy behaviour
+  // (omitted tests or returned an empty array) we DO NOT inject a fake
+  // suite-wide placeholder — that was the pre-v2.7.5 lie. Instead we
+  // stamp `acceptance_tests: []` and the board / CLI flag the HU as
+  // "missing test contract" so the user can either regenerate or edit
+  // the tests manually before executing.
+  const { normaliseAcceptanceTests } = await import("../plan/plan-schema.js");
   const steps = parsed?.steps || [];
   let prevId = null;
+  let stepsMissingTests = 0;
   for (const step of steps) {
     const desc = typeof step === "string" ? step : step.description || step.title || JSON.stringify(step);
+    const rawTests = typeof step === "object" ? step.acceptance_tests : null;
+    const tests = normaliseAcceptanceTests(rawTests);
+    if (tests.length === 0) stepsMissingTests += 1;
     const hu = addHu(plan, {
       title: desc.slice(0, 80),
       task_type: classifyTaskType(desc),
       scope: desc,
       blocked_by: prevId ? [prevId] : [],
-      acceptance_tests: [
-        "npx vitest run 2>&1; test $? -eq 0 && echo PASS || echo FAIL"
-      ]
+      acceptance_tests: tests,
     });
     prevId = hu.id;
+  }
+  if (stepsMissingTests > 0) {
+    runLog.logText(
+      `[planner] WARN: ${stepsMissingTests}/${steps.length} HUs have no acceptance_tests — `
+      + `the planner LLM did not emit a test contract. Edit them on the board `
+      + `or re-run \`kj plan\` before executing. These HUs are flagged "missing test contract".`
+    );
   }
 
   const planId = await savePlan(projectDir, plan);
@@ -264,6 +280,21 @@ export async function planReadyCommand({ config, planId }) {
 
   if (plan.hus.length === 0) {
     console.error("Cannot approve a plan with 0 HUs.");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Tests-first gate: refuse to certify HUs that have no acceptance_tests.
+  // A "ready" plan must have an executable test contract per HU, otherwise
+  // the coder has nothing to aim for. Flag each offender, then bail so the
+  // user can edit the plan (board ✎ Edit or `kj plan add-hu`) and retry.
+  const missing = plan.hus.filter((h) => !Array.isArray(h.acceptance_tests) || h.acceptance_tests.length === 0);
+  if (missing.length > 0) {
+    console.error(`Cannot mark ready: ${missing.length}/${plan.hus.length} HU(s) have no acceptance_tests:`);
+    for (const h of missing) console.error(`  - ${h.id}  ${(h.title || "").slice(0, 60)}`);
+    console.error("");
+    console.error("Tests-first flow requires a test contract per HU. Edit each HU on the board");
+    console.error("(http://localhost:4000) via the ✎ Edit button, or re-run `kj plan` to regenerate.");
     process.exitCode = 1;
     return;
   }

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -9,6 +9,53 @@ import { generatePlanId, generateHuId } from "./plan-id.js";
 const VALID_PLAN_STATUSES = new Set(["draft", "ready", "running", "done", "failed"]);
 const VALID_HU_STATUSES = new Set(["pending", "certified", "coding", "reviewing", "done", "failed", "blocked"]);
 const VALID_TASK_TYPES = new Set(["sw", "infra", "doc", "add-tests", "refactor", "nocode"]);
+const VALID_TEST_TYPES = new Set(["shell", "gherkin"]);
+
+/**
+ * Structured acceptance-test shape introduced in v2.7.5 (tests-first):
+ *
+ *   { type: "shell",   content: "<bash command>", file?: "<optional path>" }
+ *   { type: "gherkin", content: "Given …\nWhen …\nThen …", file?: "<optional path>" }
+ *
+ * Legacy entries (plain strings) are accepted by validatePlan and get
+ * normalised to `{ type: "shell", content: <string> }` at read time by
+ * `normaliseAcceptanceTest`. New plans MUST emit the structured form.
+ *
+ * Why two types: shell tests are executable as-is (a bash command that
+ * exits 0 on pass); gherkin tests are human-readable specs that the
+ * tester role translates into real code tests during `kj run` — they
+ * are the contract the coder is expected to satisfy.
+ *
+ * @param {unknown} entry
+ * @returns {{ type: string, content: string, file?: string } | null}
+ */
+export function normaliseAcceptanceTest(entry) {
+  if (entry == null) return null;
+  if (typeof entry === "string") {
+    const trimmed = entry.trim();
+    if (!trimmed) return null;
+    return { type: "shell", content: trimmed };
+  }
+  if (typeof entry === "object" && typeof entry.content === "string") {
+    const content = entry.content.trim();
+    if (!content) return null;
+    const type = VALID_TEST_TYPES.has(entry.type) ? entry.type : "shell";
+    const out = { type, content };
+    if (typeof entry.file === "string" && entry.file.trim()) out.file = entry.file.trim();
+    return out;
+  }
+  return null;
+}
+
+/**
+ * Normalise an array of raw acceptance_tests, dropping empties.
+ * @param {unknown[]} list
+ * @returns {{ type: string, content: string, file?: string }[]}
+ */
+export function normaliseAcceptanceTests(list) {
+  if (!Array.isArray(list)) return [];
+  return list.map(normaliseAcceptanceTest).filter(Boolean);
+}
 
 /**
  * Check if a plan uses v2 schema (has version field + hus array).
@@ -98,6 +145,27 @@ export function validatePlan(plan) {
     if (!hu.title) errors.push(`HU ${hu.id}: missing title`);
     if (!VALID_HU_STATUSES.has(hu.status)) errors.push(`HU ${hu.id}: invalid status ${hu.status}`);
     if (hu.task_type && !VALID_TASK_TYPES.has(hu.task_type)) errors.push(`HU ${hu.id}: invalid task_type ${hu.task_type}`);
+    // acceptance_tests: may be absent (legacy) or an array of either
+    // plain strings (legacy shell) or { type, content, file? } objects.
+    if (hu.acceptance_tests !== undefined) {
+      if (!Array.isArray(hu.acceptance_tests)) {
+        errors.push(`HU ${hu.id}: acceptance_tests must be an array`);
+      } else {
+        hu.acceptance_tests.forEach((entry, idx) => {
+          if (typeof entry === "string") return; // legacy form — OK
+          if (!entry || typeof entry !== "object") {
+            errors.push(`HU ${hu.id}: acceptance_tests[${idx}] must be a string or { type, content } object`);
+            return;
+          }
+          if (entry.type && !VALID_TEST_TYPES.has(entry.type)) {
+            errors.push(`HU ${hu.id}: acceptance_tests[${idx}].type must be one of ${[...VALID_TEST_TYPES].join("|")}`);
+          }
+          if (typeof entry.content !== "string" || !entry.content.trim()) {
+            errors.push(`HU ${hu.id}: acceptance_tests[${idx}].content must be a non-empty string`);
+          }
+        });
+      }
+    }
     // Check blocked_by references exist
     for (const dep of hu.blocked_by || []) {
       if (!huIds.has(dep) && !(plan.hus || []).some(h => h.id === dep)) {

--- a/src/roles/planner-role.js
+++ b/src/roles/planner-role.js
@@ -65,7 +65,45 @@ export class PlannerRole extends AgentRole {
 
     const sections = [];
     if (this.instructions) sections.push(this.instructions, "");
-    sections.push("Create an implementation plan for this task.", "Return concise numbered steps focused on execution order and risk.", "");
+    // Tests-first planning (v2.7.5):
+    // The planner MUST emit structured acceptance tests for every step.
+    // These are the contract the coder is handed (phase 2 of the
+    // tests-first flow); the tester role later runs them as the
+    // pass/fail gate. Without them the coder has no executable spec.
+    sections.push(
+      "Create an implementation plan for this task as structured JSON.",
+      "",
+      "Output MUST be a JSON object with this exact shape:",
+      "",
+      "```json",
+      "{",
+      '  "approach": "<2-3 sentence high-level plan>",',
+      '  "risks": ["<risk 1>", "<risk 2>"],',
+      '  "outOfScope": ["<excluded item>"],',
+      '  "steps": [',
+      "    {",
+      '      "description": "<what this step achieves, one sentence>",',
+      '      "acceptance_tests": [',
+      '        { "type": "gherkin", "content": "Given <ctx>\\nWhen <action>\\nThen <outcome>" },',
+      '        { "type": "shell", "content": "<bash command that must exit 0>" }',
+      "      ]",
+      "    }",
+      "  ]",
+      "}",
+      "```",
+      "",
+      "Rules for acceptance_tests (CRITICAL — this is the contract the coder must satisfy):",
+      '- EVERY step MUST have at least one acceptance_test. No empty arrays.',
+      '- "gherkin" tests describe observable behaviour in natural language. Use them for end-to-end or user-facing assertions.',
+      '- "shell" tests are bash commands that exit 0 on success. Use them for concrete verifications (file exists, lint passes, specific exit code, HTTP status).',
+      '- Write tests BEFORE the step is implemented — they should fail until the step is done, pass afterwards.',
+      '- Prefer 2-4 tests per step: one happy-path, at least one edge case / failure path.',
+      '- Do NOT use the generic fallback "npx vitest run" (pre-v2.7.5 placeholder). Each test must assert something specific to the step.',
+      "",
+      "Steps must be ordered so that each depends only on previous steps (the first step has no prerequisites).",
+      "Return ONLY the JSON — no prose, no markdown fences around it.",
+      ""
+    );
     if (this.config?.productContext) sections.push("## Product Context", this.config.productContext, "");
     if (this.config?.domainContext) sections.push("## Domain Context", this.config.domainContext, "");
     appendDecompositionSection(sections, triageDecomposition);

--- a/tests/plan-ready-tests-first-gate.test.js
+++ b/tests/plan-ready-tests-first-gate.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { planReadyCommand } from "../src/commands/plan.js";
+import { createPlanV2 } from "../src/plan/plan-schema.js";
+import { addHu } from "../src/plan/plan-hu-ops.js";
+import { savePlan } from "../src/plan/plan-store.js";
+
+// Tests-first gate (v2.7.5): `kj plan ready <planId>` refuses to mark
+// a plan as ready unless every HU has at least one acceptance_test.
+// Without this, the coder would get handed HUs with no contract and
+// we'd be back to "pipeline guesses what passes".
+
+let tmpKjHome;
+let savedKjHome;
+let savedExitCode;
+let projectDir;
+let consoleErrorSpy;
+
+beforeEach(async () => {
+  tmpKjHome = await fs.mkdtemp(path.join(os.tmpdir(), "plan-ready-gate-"));
+  savedKjHome = process.env.KJ_HOME;
+  process.env.KJ_HOME = tmpKjHome;
+  projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "project-"));
+  savedExitCode = process.exitCode;
+  process.exitCode = 0;
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  consoleErrorSpy.mockRestore();
+  process.exitCode = savedExitCode;
+  if (savedKjHome === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = savedKjHome;
+  await fs.rm(tmpKjHome, { recursive: true, force: true });
+  await fs.rm(projectDir, { recursive: true, force: true });
+});
+
+async function writePlan(hus) {
+  const plan = createPlanV2("a task");
+  for (const hu of hus) addHu(plan, hu);
+  const planId = await savePlan(projectDir, plan);
+  return planId;
+}
+
+describe("planReadyCommand — tests-first gate", () => {
+  it("refuses to mark ready when a HU has no acceptance_tests", async () => {
+    const planId = await writePlan([
+      {
+        title: "with tests",
+        scope: "ok",
+        acceptance_tests: [{ type: "shell", content: "echo ok" }],
+      },
+      {
+        title: "without tests",
+        scope: "uh oh",
+        acceptance_tests: [],
+      },
+    ]);
+
+    await planReadyCommand({ config: { projectDir }, planId });
+
+    expect(process.exitCode).toBe(1);
+    const stderr = consoleErrorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(stderr).toContain("1/2 HU(s) have no acceptance_tests");
+    expect(stderr).toContain("without tests");
+  });
+
+  it("allows marking ready when every HU has at least one test", async () => {
+    const planId = await writePlan([
+      { title: "a", scope: "s", acceptance_tests: [{ type: "shell", content: "echo a" }] },
+      { title: "b", scope: "s", acceptance_tests: [{ type: "gherkin", content: "Given x\nWhen y\nThen z" }] },
+    ]);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await planReadyCommand({ config: { projectDir }, planId });
+    expect(process.exitCode).toBe(0);
+    const stdout = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(stdout).toContain("HUs certified");
+    logSpy.mockRestore();
+  });
+
+  it("refuses when HU has acceptance_tests: undefined (legacy pre-v2.7.5 plans)", async () => {
+    const plan = createPlanV2("legacy");
+    plan.hus.push({
+      id: "plan-legacy_001",
+      title: "from old planner",
+      status: "pending",
+      blocked_by: [],
+      // no acceptance_tests at all
+    });
+    const planId = await savePlan(projectDir, plan);
+
+    await planReadyCommand({ config: { projectDir }, planId });
+
+    expect(process.exitCode).toBe(1);
+    const stderr = consoleErrorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(stderr).toContain("no acceptance_tests");
+  });
+});

--- a/tests/plan-tests-first.test.js
+++ b/tests/plan-tests-first.test.js
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  normaliseAcceptanceTest,
+  normaliseAcceptanceTests,
+  createPlanV2,
+  validatePlan,
+} from "../src/plan/plan-schema.js";
+import { addHu } from "../src/plan/plan-hu-ops.js";
+
+// Tests-first schema (v2.7.5): planner now emits a structured
+// { type: "shell"|"gherkin", content, file? } per test, and the legacy
+// plain-string form is still accepted for backwards compatibility.
+
+describe("normaliseAcceptanceTest", () => {
+  it("upgrades a legacy plain string to { type: shell }", () => {
+    expect(normaliseAcceptanceTest("npx vitest run")).toEqual({
+      type: "shell",
+      content: "npx vitest run",
+    });
+  });
+
+  it("keeps explicit shell objects as-is", () => {
+    expect(normaliseAcceptanceTest({ type: "shell", content: "ls /tmp" })).toEqual({
+      type: "shell",
+      content: "ls /tmp",
+    });
+  });
+
+  it("keeps gherkin objects and trims content", () => {
+    expect(
+      normaliseAcceptanceTest({ type: "gherkin", content: "  Given x\nWhen y\nThen z  " })
+    ).toEqual({ type: "gherkin", content: "Given x\nWhen y\nThen z" });
+  });
+
+  it("includes file when provided and non-empty", () => {
+    expect(
+      normaliseAcceptanceTest({ type: "shell", content: "tsc --noEmit", file: "tsconfig.json" })
+    ).toEqual({ type: "shell", content: "tsc --noEmit", file: "tsconfig.json" });
+  });
+
+  it("drops empty / whitespace-only / missing-content entries", () => {
+    expect(normaliseAcceptanceTest("")).toBeNull();
+    expect(normaliseAcceptanceTest("   ")).toBeNull();
+    expect(normaliseAcceptanceTest(null)).toBeNull();
+    expect(normaliseAcceptanceTest(undefined)).toBeNull();
+    expect(normaliseAcceptanceTest({ type: "shell", content: "" })).toBeNull();
+    expect(normaliseAcceptanceTest({ foo: "bar" })).toBeNull();
+  });
+
+  it("defaults unknown test types to shell (no silent data loss)", () => {
+    expect(
+      normaliseAcceptanceTest({ type: "python", content: "pytest" })
+    ).toEqual({ type: "shell", content: "pytest" });
+  });
+});
+
+describe("normaliseAcceptanceTests", () => {
+  it("returns [] for a non-array", () => {
+    expect(normaliseAcceptanceTests(null)).toEqual([]);
+    expect(normaliseAcceptanceTests("string")).toEqual([]);
+    expect(normaliseAcceptanceTests(undefined)).toEqual([]);
+  });
+
+  it("filters out empties and keeps valid entries in order", () => {
+    const result = normaliseAcceptanceTests([
+      "echo PASS",
+      { type: "gherkin", content: "Given x\nWhen y\nThen z" },
+      "",
+      null,
+      { foo: "bar" },
+      { type: "shell", content: "tsc --noEmit", file: "tsconfig.json" },
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ type: "shell", content: "echo PASS" });
+    expect(result[1]).toEqual({ type: "gherkin", content: "Given x\nWhen y\nThen z" });
+    expect(result[2]).toEqual({ type: "shell", content: "tsc --noEmit", file: "tsconfig.json" });
+  });
+});
+
+describe("validatePlan — acceptance_tests validation", () => {
+  it("accepts a plan with structured shell + gherkin tests", () => {
+    const plan = createPlanV2("build it");
+    addHu(plan, {
+      title: "write thing",
+      scope: "do the thing",
+      acceptance_tests: [
+        { type: "shell", content: "tsc --noEmit" },
+        { type: "gherkin", content: "Given x\nWhen y\nThen z" },
+      ],
+    });
+    expect(validatePlan(plan).valid).toBe(true);
+  });
+
+  it("accepts legacy plain-string acceptance_tests (backward compat)", () => {
+    const plan = createPlanV2("build it");
+    addHu(plan, {
+      title: "legacy",
+      scope: "old-style",
+      acceptance_tests: ["npx vitest run"],
+    });
+    expect(validatePlan(plan).valid).toBe(true);
+  });
+
+  it("rejects tests with invalid type", () => {
+    const plan = createPlanV2("build it");
+    addHu(plan, {
+      title: "bad",
+      scope: "scope",
+      acceptance_tests: [{ type: "python", content: "pytest" }],
+    });
+    const result = validatePlan(plan);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("acceptance_tests[0].type"))).toBe(true);
+  });
+
+  it("rejects tests whose content is missing or blank", () => {
+    const plan = createPlanV2("build it");
+    addHu(plan, {
+      title: "empty",
+      scope: "scope",
+      acceptance_tests: [{ type: "shell", content: "" }, { type: "gherkin", content: "   " }],
+    });
+    const result = validatePlan(plan);
+    expect(result.valid).toBe(false);
+    expect(result.errors.filter((e) => e.includes(".content")).length).toBe(2);
+  });
+
+  it("rejects acceptance_tests that isn't an array", () => {
+    const plan = createPlanV2("build it");
+    plan.hus.push({
+      id: "plan-x_001",
+      title: "bad",
+      status: "pending",
+      acceptance_tests: "not-an-array",
+      blocked_by: [],
+    });
+    const result = validatePlan(plan);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("must be an array"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of a three-phase shift from *\"tester invents tests for whatever got built\"* to *\"planner declares the contract, coder satisfies it, tester validates + covers gaps\"*.

### Schema (\`src/plan/plan-schema.js\`)
- New \`normaliseAcceptanceTest\` / \`normaliseAcceptanceTests\` promote legacy plain strings to \`{ type: \"shell\", content }\`, while accepting the structured \`{ type: \"shell\" | \"gherkin\", content, file? }\`. Unknown types default to \`shell\`.
- \`validatePlan\` rejects non-array / unknown type / empty content.

### Planner (\`src/roles/planner-role.js\`)
- Prompt now demands \`{ approach, risks, outOfScope, steps: [{ description, acceptance_tests: [...] }] }\`.
- Rules enforced: every step ≥1 test, gherkin for behaviour / shell for exit-code assertions, no generic \`npx vitest run\` fallback, 2-4 tests per step with at least one edge case.

### Plan command (\`src/commands/plan.js\`)
- Reads \`step.acceptance_tests\` from the LLM output and persists them as-is.
- When the LLM omits tests for a step, the HU is saved with \`acceptance_tests: []\` and a warning goes to the run log — **no fake fallback**, that was the old bug.
- \`planReadyCommand\` refuses to certify a plan with any HU missing tests. Prints each offender and points the user to ✎ Edit on the board.

### Board
- Card: yellow ⚠ *\"missing test contract\"* badge on tests-less HUs.
- Modal: warning box when empty, typed list with \`shell\`/\`gherkin\` badges and optional \`file\` hint when present.
- Edit form: one fieldset row per test (type select, content textarea, file input, remove); ➕ Add test button. Save sends the structured array.

## Tests

- 11 new cases in \`plan-tests-first.test.js\` (schema + validatePlan).
- 3 new cases in \`plan-ready-tests-first-gate.test.js\` (\`kj plan ready\` gate).
- 3807 parent + 101 board tests green.

## Roadmap

- **Phase 2** (next PR): coder prompt receives the declared tests and is told to make them pass.
- **Phase 3** (after that): tester runs them gate-first and only adds coverage if the contract passes.

## Test plan

- [x] \`npx vitest run tests/\` → 3807/3807
- [x] \`npx vitest run packages/hu-board/\` → 101/101
- [ ] Manual: after merge, \`kj plan <task>\`, verify the plan JSON has structured \`acceptance_tests\` per HU
- [ ] Manual: \`kj plan ready <id>\` fails on a plan with any tests-less HU, succeeds after adding tests via the board's Edit form