### PR TITLE
feat(coder): Phase 2 of tests-first — coder prompt carries the declared tests

### DIFF
--- a/src/hu/acceptance-runner.js
+++ b/src/hu/acceptance-runner.js
@@ -37,35 +37,77 @@ async function runSingleTest(cmd, cwd, timeoutMs = 30000) {
 
 /**
  * Run all acceptance tests for an HU.
- * @param {string[]} tests - Array of shell commands
+ *
+ * Accepts two shapes:
+ *   - Legacy: plain string shell command.
+ *   - v2.7.5: { type: "shell" | "gherkin", content, file? }
+ *
+ * Shell entries execute immediately (exit code 0 = pass). Gherkin entries
+ * cannot be executed directly — that's Phase 3 of tests-first where the
+ * tester role translates them into real code tests. Until then, we report
+ * them as "pending" and skip rather than failing the whole gate.
+ *
+ * @param {Array<string|object>} tests - Array of shell commands OR structured entries
  * @param {string} cwd - Working directory
- * @returns {Promise<{allPassed: boolean, results: object[], summary: string, diagnostics: string|null}>}
+ * @returns {Promise<{allPassed: boolean, results: object[], summary: string, diagnostics: string|null, pending: number}>}
  */
 export async function runAcceptanceTests(tests, cwd) {
   if (!tests || tests.length === 0) {
-    return { allPassed: false, results: [], summary: "No acceptance tests defined", diagnostics: null };
+    return { allPassed: false, results: [], summary: "No acceptance tests defined", diagnostics: null, pending: 0 };
   }
 
   const results = [];
-  for (const cmd of tests) {
+  let pending = 0;
+  for (const entry of tests) {
+    let type = "shell";
+    let cmd;
+    if (typeof entry === "string") {
+      cmd = entry;
+    } else if (entry && typeof entry === "object" && typeof entry.content === "string") {
+      type = entry.type === "gherkin" ? "gherkin" : "shell";
+      cmd = entry.content;
+    } else {
+      results.push({ cmd: JSON.stringify(entry), passed: false, output: "Malformed acceptance_test entry", exitCode: -2, type: "invalid" });
+      continue;
+    }
+    if (type === "gherkin") {
+      // Gherkin entries need a translator (Phase 3). Mark them pending
+      // so the coder/tester sees they haven't been validated yet —
+      // better than silently passing (would lie) or hard-failing
+      // (would block the whole pipeline).
+      pending += 1;
+      results.push({
+        cmd,
+        passed: false,
+        output: "Gherkin test not yet executable (awaits tester translation — Phase 3)",
+        exitCode: 0,
+        type: "gherkin",
+        pending: true,
+      });
+      continue;
+    }
     const result = await runSingleTest(cmd, cwd);
-    results.push(result);
+    results.push({ ...result, type: "shell" });
   }
 
-  const passed = results.filter(r => r.passed);
-  const failed = results.filter(r => !r.passed);
+  const executedResults = results.filter((r) => !r.pending);
+  const passed = executedResults.filter((r) => r.passed);
+  const failed = executedResults.filter((r) => !r.passed);
   const allPassed = failed.length === 0;
 
-  const summary = `${passed.length}/${results.length} acceptance tests passed`;
+  const shellSummary = `${passed.length}/${executedResults.length} shell tests passed`;
+  const summary = pending > 0
+    ? `${shellSummary}, ${pending} gherkin test(s) pending translation`
+    : shellSummary;
 
   let diagnostics = null;
   if (!allPassed) {
-    diagnostics = failed.map(f =>
+    diagnostics = failed.map((f) =>
       `FAIL: ${f.cmd}\n  exit=${f.exitCode}\n  output: ${f.output.trim().split("\n").slice(-5).join("\n  ")}`
     ).join("\n\n");
   }
 
-  return { allPassed, results, summary, diagnostics };
+  return { allPassed, results, summary, diagnostics, pending };
 }
 
 /**

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -229,12 +229,16 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
                 detail: { iteration: attempt, maxIterations: ctx.config.max_iterations }
               }));
 
-              // Coder runs with the HU task + any diagnostic feedback from previous attempt
+              // Coder runs with the HU task + any diagnostic feedback from previous attempt.
+              // Phase 2 of tests-first (v2.7.5): also hand over the declared
+              // acceptance_tests so the coder has the contract from turn 1,
+              // not only after the first failed run.
               const coderResult = await runCoderStage({
                 coderRoleInstance: ctx.coderRoleInstance, coderRole: ctx.coderRole,
                 config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
                 session: ctx.session, plannedTask: ctx.plannedTask,
-                trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: ctx.brainCtx
+                trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: ctx.brainCtx,
+                acceptanceTests: story.acceptance_tests
               });
               if (coderResult?.action === "standby" || coderResult?.action === "pause") {
                 return coderResult?.result || { approved: false, reason: "coder_failed" };

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -19,7 +19,7 @@ import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
 
-export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx }) {
+export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null }) {
   logger.setContext({ iteration, stage: "coder" });
   emitProgress(
     emitter,
@@ -52,6 +52,9 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       reviewerFeedback,
       sonarSummary: session.last_sonar_summary,
       deferredContext: buildDeferredContext(session.deferred_issues),
+      // Tests-first contract flows through to buildCoderPrompt which
+      // renders the "Acceptance Tests — MUST pass" section.
+      acceptanceTests,
       onOutput: coderStall.onOutput
     });
   } finally {

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -33,7 +33,60 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null }) {
+/**
+ * Render structured acceptance_tests (v2.7.5) as a Markdown section the
+ * coder reads as its contract. Legacy plain-string entries and
+ * structured { type, content, file? } objects are both accepted.
+ *
+ * The layout is intentional:
+ *   - Gherkin blocks preserve their newlines so the coder sees the
+ *     Given/When/Then scenarios as-is.
+ *   - Shell blocks are fenced so the coder can copy-paste to verify.
+ *   - The header says "MUST pass" because this is the gate the tester
+ *     role runs (phase 3) and refuses to approve without.
+ *
+ * @param {Array} tests
+ * @returns {string}
+ */
+function renderAcceptanceTestsSection(tests) {
+  if (!Array.isArray(tests) || tests.length === 0) return "";
+  const lines = [
+    "## Acceptance Tests — MUST pass before the HU can be approved",
+    "",
+    "These are the concrete contract for this task. The tester stage will execute them as the pass/fail gate — if any one fails, the HU is rejected. Write your implementation so each test passes.",
+    "",
+  ];
+  tests.forEach((entry, i) => {
+    // Normalise: accept legacy strings and structured objects.
+    let type = "shell";
+    let content = "";
+    let file = null;
+    if (typeof entry === "string") {
+      content = entry;
+    } else if (entry && typeof entry === "object") {
+      type = entry.type === "gherkin" ? "gherkin" : "shell";
+      content = typeof entry.content === "string" ? entry.content : JSON.stringify(entry);
+      file = typeof entry.file === "string" && entry.file.trim() ? entry.file.trim() : null;
+    } else {
+      content = String(entry ?? "");
+    }
+    const heading = file
+      ? `### Test ${i + 1} · \`${type}\` · target: \`${file}\``
+      : `### Test ${i + 1} · \`${type}\``;
+    lines.push(heading);
+    if (type === "gherkin") {
+      lines.push("```gherkin", content, "```", "");
+    } else {
+      lines.push("```bash", content, "```", "");
+    }
+  });
+  lines.push(
+    "If a test is ambiguous, implement what makes it pass AND add the clarifying assertion to the PR description — do NOT silently rewrite the test."
+  );
+  return lines.join("\n");
+}
+
+export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null }) {
   const langInstruction = getLanguageInstruction(language);
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
@@ -67,6 +120,15 @@ export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSum
 
   if (plan) {
     sections.push(`## Implementation Plan (from planner)\nFollow these steps:\n${plan}`);
+  }
+
+  // Tests-first contract: injected right after the plan so the coder
+  // reads "here are the steps" and immediately "here's the gate they
+  // need to satisfy". Placed BEFORE coder rules / TDD policy so those
+  // frame the tests, not the other way around.
+  const testsSection = renderAcceptanceTestsSection(acceptanceTests);
+  if (testsSection) {
+    sections.push(testsSection);
   }
 
   if (coderRules) {

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -22,19 +22,23 @@ export class CoderRole extends AgentRole {
   }
 
   extractInput(input) {
-    if (typeof input === "string") return { task: input, reviewerFeedback: null, sonarSummary: null, deferredContext: null, onOutput: null };
+    if (typeof input === "string") return { task: input, reviewerFeedback: null, sonarSummary: null, deferredContext: null, acceptanceTests: null, onOutput: null };
     return {
       task: input?.task || this.context?.task || "",
       reviewerFeedback: input?.reviewerFeedback || null,
       sonarSummary: input?.sonarSummary || null,
       deferredContext: input?.deferredContext || null,
+      // Tests-first (v2.7.5): the coder reads these as the gate it
+      // must satisfy. Only the plan-backed HU path populates this;
+      // the standard single-task `kj run` flow leaves it null.
+      acceptanceTests: input?.acceptanceTests || null,
       onOutput: input?.onOutput || null
     };
   }
 
-  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext }) {
+  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests }) {
     const prompt = await buildCoderPrompt({
-      task, reviewerFeedback, sonarSummary, deferredContext,
+      task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests,
       coderRules: this.instructions,
       methodology: this.config?.development?.methodology || "tdd",
       serenaEnabled: Boolean(this.config?.serena?.enabled),

--- a/tests/acceptance-runner.test.js
+++ b/tests/acceptance-runner.test.js
@@ -29,6 +29,53 @@ describe("runAcceptanceTests", () => {
     expect(result.allPassed).toBe(false);
     expect(result.diagnostics).toContain("missing package");
   });
+
+  // Tests-first (v2.7.5): structured entries.
+  it("executes structured shell entries like plain strings", async () => {
+    const result = await runAcceptanceTests(
+      [{ type: "shell", content: "echo ok" }, { type: "shell", content: "true" }],
+      "/tmp"
+    );
+    expect(result.allPassed).toBe(true);
+    expect(result.pending).toBe(0);
+    expect(result.results.every((r) => r.type === "shell")).toBe(true);
+  });
+
+  it("marks gherkin entries as pending (not run, not failed) until the tester translates them", async () => {
+    const result = await runAcceptanceTests(
+      [
+        { type: "shell", content: "echo ok" },
+        { type: "gherkin", content: "Given x\nWhen y\nThen z" },
+      ],
+      "/tmp"
+    );
+    // The shell entry passes, the gherkin is pending — overall gate
+    // passes because all executable tests pass. The summary tells the
+    // user one gherkin is waiting for Phase 3 translation.
+    expect(result.allPassed).toBe(true);
+    expect(result.pending).toBe(1);
+    expect(result.summary).toContain("1 gherkin");
+    const gherkinEntry = result.results.find((r) => r.type === "gherkin");
+    expect(gherkinEntry.pending).toBe(true);
+  });
+
+  it("mixes legacy strings and structured entries seamlessly", async () => {
+    const result = await runAcceptanceTests(
+      ["echo legacy", { type: "shell", content: "echo structured" }],
+      "/tmp"
+    );
+    expect(result.allPassed).toBe(true);
+    expect(result.results.length).toBe(2);
+  });
+
+  it("flags malformed entries without crashing the whole gate", async () => {
+    const result = await runAcceptanceTests([{ foo: "bar" }, "true"], "/tmp");
+    const invalidEntry = result.results.find((r) => r.type === "invalid");
+    expect(invalidEntry).toBeDefined();
+    expect(invalidEntry.passed).toBe(false);
+    // The valid "true" command still ran successfully.
+    expect(result.results.some((r) => r.type === "shell" && r.passed)).toBe(true);
+  });
 });
 
 describe("buildDiagnosticPrompt", () => {

--- a/tests/coder-prompt-tests-first.test.js
+++ b/tests/coder-prompt-tests-first.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildCoderPrompt } from "../src/prompts/coder.js";
+
+// Tests-first Phase 2 (v2.7.5): the coder prompt carries the HU's
+// acceptance_tests so the coder knows the contract from turn 1, rather
+// than learning it after the first failed run.
+
+describe("buildCoderPrompt — acceptance_tests section", () => {
+  it("is omitted when no tests are passed", async () => {
+    const prompt = await buildCoderPrompt({ task: "do a thing" });
+    expect(prompt).not.toMatch(/Acceptance Tests/);
+  });
+
+  it("renders a shell test as a fenced bash block", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "implement login",
+      acceptanceTests: [{ type: "shell", content: "npx vitest run login.test.ts" }],
+    });
+    expect(prompt).toMatch(/## Acceptance Tests — MUST pass/);
+    expect(prompt).toMatch(/```bash\nnpx vitest run login\.test\.ts\n```/);
+  });
+
+  it("renders a gherkin test as a fenced gherkin block with preserved newlines", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "implement login",
+      acceptanceTests: [
+        { type: "gherkin", content: "Given a logged-out user\nWhen they POST /login with valid creds\nThen the response is 200 and sets a session cookie" },
+      ],
+    });
+    expect(prompt).toMatch(/```gherkin\nGiven a logged-out user\nWhen/);
+    expect(prompt).toMatch(/Then the response is 200 and sets a session cookie\n```/);
+  });
+
+  it("accepts legacy plain-string tests (backward compat)", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "legacy path",
+      acceptanceTests: ["npx vitest run"],
+    });
+    expect(prompt).toMatch(/```bash\nnpx vitest run\n```/);
+  });
+
+  it("includes the file hint when provided", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "targeted",
+      acceptanceTests: [
+        { type: "shell", content: "npx vitest run tests/auth.test.ts", file: "tests/auth.test.ts" },
+      ],
+    });
+    expect(prompt).toMatch(/target: `tests\/auth\.test\.ts`/);
+  });
+
+  it("numbers multiple tests and keeps their order", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "multi",
+      acceptanceTests: [
+        { type: "shell", content: "cmd-1" },
+        { type: "gherkin", content: "Given a\nWhen b\nThen c" },
+        { type: "shell", content: "cmd-3" },
+      ],
+    });
+    expect(prompt).toMatch(/### Test 1 · `shell`/);
+    expect(prompt).toMatch(/### Test 2 · `gherkin`/);
+    expect(prompt).toMatch(/### Test 3 · `shell`/);
+    const idx1 = prompt.indexOf("cmd-1");
+    const idx2 = prompt.indexOf("Given a");
+    const idx3 = prompt.indexOf("cmd-3");
+    expect(idx1).toBeLessThan(idx2);
+    expect(idx2).toBeLessThan(idx3);
+  });
+
+  it("nudges the coder to not silently rewrite ambiguous tests", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      acceptanceTests: [{ type: "shell", content: "cmd" }],
+    });
+    expect(prompt).toMatch(/do NOT silently rewrite the test/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the tests-first rollout (after #491). The coder now receives the HU's acceptance_tests from turn 1 as part of its prompt, so it writes code to satisfy the declared contract rather than waiting for the tester to invent something after the fact.

### Prompt (\`src/prompts/coder.js\`)

New \`renderAcceptanceTestsSection\` produces:

    ## Acceptance Tests — MUST pass before the HU can be approved
    These are the concrete contract …
    ### Test 1 · \`shell\`
    \`\`\`bash
    …
    \`\`\`
    ### Test 2 · \`gherkin\` · target: \`tests/auth.test.ts\`
    \`\`\`gherkin
    Given …
    When …
    Then …
    \`\`\`
    If a test is ambiguous, implement what makes it pass AND add the
    clarifying assertion to the PR description — do NOT silently
    rewrite the test.

- Accepts legacy plain strings (union type); shell → fenced bash; gherkin → fenced gherkin with newlines preserved
- Section omitted when \`acceptanceTests\` is null/empty so \`kj run\` flows without a plan are unaffected

### Wiring

- \`CoderRole.extractInput\` picks up \`acceptanceTests\`; \`buildPrompt\` forwards to \`buildCoderPrompt\`
- \`runCoderStage\` accepts \`acceptanceTests\` (default null) and passes to \`coderRoleInstance.execute\`
- \`flow-runner.js\` \`runIterationFn\` (tests-first path) passes \`story.acceptance_tests\` to \`runCoderStage\`

### Runner (\`src/hu/acceptance-runner.js\`)

- Accepts legacy strings AND structured \`{ type, content, file? }\` entries
- Shell → executed as before
- Gherkin → marked \`pending: true\` (not run, not failed) — needs Phase 3 tester translation to become executable
- \`summary\` surfaces pending counts so the user sees what isn't yet enforceable
- Malformed entries reported as invalid rather than crashing the gate

## Tests

- 7 cases in \`coder-prompt-tests-first.test.js\`: default omission, shell/gherkin rendering, legacy string, file hint, ordering, no-rewrite nudge
- 4 cases in \`acceptance-runner.test.js\`: structured shell, gherkin pending, mixed legacy+structured, malformed entry

3818 parent tests green.

## Test plan

- [x] \`npx vitest run tests/\` → 3818/3818
- [ ] Manual (Phase 3 required first for full flow): once Phase 3 ships, \`kj run --plan <id>\` sends the declared tests to the coder and enforces them

## Roadmap

- **Phase 3** (next PR): tester role runs the declared tests first as gate, adds coverage only if they pass, translates gherkin entries into code tests