### PR TITLE
feat(tester): Phase 3 of tests-first — gate-first tester, gherkin translation

### DIFF
--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -277,9 +277,53 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
               }));
 
               if (testResult.allPassed) {
-                logger.info(`HU ${story.id}: all acceptance tests PASSED — approved`);
-                await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
-                return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
+                // Phase 3 of tests-first (v2.7.5): the shell gate is green,
+                // but any Gherkin scenarios are still "pending" — they need
+                // the tester to translate them into real test files before
+                // we can call the HU done. If none are pending, approve
+                // immediately like before.
+                const pendingGherkinTests = (story.acceptance_tests || []).filter(
+                  (t) => t && typeof t === "object" && t.type === "gherkin"
+                );
+                if (pendingGherkinTests.length === 0) {
+                  logger.info(`HU ${story.id}: all shell acceptance tests PASSED, no Gherkin to translate — approved`);
+                  await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
+                  return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
+                }
+
+                // Shell tests passed; Gherkin needs translation. Invoke the
+                // tester with both so it writes code tests for the Gherkin,
+                // runs the suite, and returns verdict.
+                logger.info(`HU ${story.id}: shell gate passed, asking tester to translate ${pendingGherkinTests.length} Gherkin scenario(s)`);
+                const { runTesterStage } = await import("./post-loop-stages.js");
+                const shellResults = testResult.results.filter((r) => r.type !== "gherkin");
+                const testerOutcome = await runTesterStage({
+                  config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
+                  session: ctx.session, coderRole: ctx.coderRole, trackBudget: ctx.trackBudget,
+                  iteration: attempt, task: huTask, diff: null, askQuestion,
+                  pendingGherkinTests, shellTestResults: shellResults,
+                });
+                const testerStage = testerOutcome?.stageResult;
+                if (testerOutcome?.action !== "continue" && testerStage?.verdict === "pass") {
+                  logger.info(`HU ${story.id}: tester translated Gherkin and verdict=pass — approved`);
+                  await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
+                  return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
+                }
+
+                // Tester rejected (translated tests failed or coverage
+                // inadequate). Feed its diagnostic back to the coder for
+                // another iteration.
+                const failing = testerStage?.failing_scenarios?.join("\n- ") || testerStage?.summary || "tester rejected";
+                const diagnostic = [
+                  "Tester translated the Gherkin acceptance tests and some FAILED:",
+                  failing ? `- ${failing}` : "",
+                  "",
+                  "Fix the implementation so every scenario passes. Do NOT soften the scenarios.",
+                ].filter(Boolean).join("\n");
+                logger.warn(`HU ${story.id}: tester verdict=fail after Gherkin translation — sending back to coder`);
+                setReviewerFeedback(ctx.session, diagnostic);
+                ctx.plannedTask = `${huTask}\n\n--- GHERKIN TRANSLATION FAILURES ---\n${diagnostic}`;
+                continue;
               }
 
               // Brain diagnoses failures and sends concrete fix to coder

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -38,7 +38,7 @@ function isAgentFailure(output) {
  *
  * @returns {{ output, provider, attempts }}
  */
-async function runRoleWithFallback(RoleClass, { roleName, config, logger, emitter, eventBase, task, iteration, diff }) {
+async function runRoleWithFallback(RoleClass, { roleName, config, logger, emitter, eventBase, task, iteration, diff, pendingGherkinTests = null, shellTestResults = null }) {
   const chain = buildFallbackChain(config, roleName);
   const attempts = [];
 
@@ -54,7 +54,10 @@ async function runRoleWithFallback(RoleClass, { roleName, config, logger, emitte
     const start = Date.now();
     let output;
     try {
-      output = await role.run({ task, diff });
+      // Tests-first Phase 3: the tester role accepts optional extra
+      // inputs. Other roles ignore them harmlessly (they destructure
+      // only what they need from the input object).
+      output = await role.run({ task, diff, pendingGherkinTests, shellTestResults });
     } catch (err) {
       output = {
         ok: false,
@@ -94,7 +97,7 @@ async function runRoleWithFallback(RoleClass, { roleName, config, logger, emitte
   };
 }
 
-export async function runTesterStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, askQuestion }) {
+export async function runTesterStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, askQuestion, pendingGherkinTests = null, shellTestResults = null }) {
   logger.setContext({ iteration, stage: "tester" });
   emitProgress(
     emitter,
@@ -107,7 +110,15 @@ export async function runTesterStage({ config, logger, emitter, eventBase, sessi
   const testerStart = Date.now();
   const { output: testerOutput, provider, attempts } = await runRoleWithFallback(
     TesterRole,
-    { roleName: "tester", config, logger, emitter, eventBase, task, iteration, diff }
+    {
+      roleName: "tester", config, logger, emitter, eventBase, task, iteration, diff,
+      // Tests-first Phase 3 (v2.7.5): hand the tester the HU's pending
+      // Gherkin scenarios and the upstream shell-test results so it
+      // translates and reports accurately instead of re-running the
+      // gate or ignoring the behavioural spec.
+      pendingGherkinTests,
+      shellTestResults,
+    }
   );
   const totalDuration = Date.now() - testerStart;
 

--- a/src/roles/tester-role.js
+++ b/src/roles/tester-role.js
@@ -48,16 +48,26 @@ export class TesterRole extends AgentRole {
   }
 
   extractInput(input) {
-    if (typeof input === "string") return { task: input, diff: null, sonarIssues: null };
+    if (typeof input === "string") return { task: input, diff: null, sonarIssues: null, pendingGherkinTests: null, shellTestResults: null };
     return {
       task: input?.task || this.context?.task || "",
       diff: input?.diff || null,
       sonarIssues: input?.sonarIssues || null,
+      // Tests-first Phase 3 (v2.7.5): the tester now has two extra inputs.
+      //   - pendingGherkinTests: HU-declared Gherkin scenarios that need
+      //     translation into executable code tests in the project's
+      //     framework. The tester writes the test files and includes them
+      //     in the suite run before computing verdict.
+      //   - shellTestResults: results of running the HU's shell-type
+      //     acceptance_tests (already run upstream, passed at this point).
+      //     Passed for context so the tester doesn't re-run them redundantly.
+      pendingGherkinTests: input?.pendingGherkinTests || null,
+      shellTestResults: input?.shellTestResults || null,
       onOutput: input?.onOutput || null
     };
   }
 
-  async buildPrompt({ task, diff, sonarIssues }) {
+  async buildPrompt({ task, diff, sonarIssues, pendingGherkinTests, shellTestResults }) {
     const projectDir = this.config?.projectDir || process.cwd();
     const detection = await detectTestFramework(projectDir);
 
@@ -97,14 +107,65 @@ export class TesterRole extends AgentRole {
       );
     }
 
+    // Tests-first Phase 3 (v2.7.5): include the upstream shell-test results
+    // so the tester knows which part of the contract is already green.
+    if (Array.isArray(shellTestResults) && shellTestResults.length > 0) {
+      const passedCount = shellTestResults.filter((r) => r.passed).length;
+      sections.push(
+        "## Acceptance gate — shell tests",
+        `The HU's shell-type acceptance_tests already ran upstream: ${passedCount}/${shellTestResults.length} passed.`,
+        "Do NOT re-run them. Use the coverage/translation steps below to decide your verdict."
+      );
+    }
+
+    // Gherkin translation block — only when the HU carries Gherkin
+    // scenarios. Tester must produce real test files (in the detected
+    // framework's language) that encode Given/When/Then. This is how
+    // behaviour-level specs become enforceable.
+    if (Array.isArray(pendingGherkinTests) && pendingGherkinTests.length > 0) {
+      sections.push(
+        "## Gherkin acceptance tests to translate",
+        "These Gherkin scenarios are the HU's behavioural contract. They are NOT yet",
+        "executable — your job is to turn each one into a concrete test case in the",
+        "project's test framework, WRITE the test files, and INCLUDE them in the suite",
+        "run that determines your verdict.",
+        "",
+        "For each scenario below:",
+        "1. Pick the appropriate test file (use `target` hint if present; otherwise",
+        "   put the test next to the module it exercises).",
+        "2. Write a test that asserts the Given/When/Then as-is. Do NOT soften the",
+        "   assertion — if it's ambiguous, pick the stricter reading.",
+        "3. Make sure the test runs as part of the normal suite (no separate invocation).",
+        "",
+        "If ANY translated test fails on the current code, return verdict: \"fail\" with",
+        "a failing_scenarios array listing the scenarios that didn't pass. The coder",
+        "will iterate.",
+        ""
+      );
+      pendingGherkinTests.forEach((entry, i) => {
+        const content = typeof entry === "string" ? entry : entry?.content || "";
+        const target = entry && entry.file ? ` · target: \`${entry.file}\`` : "";
+        sections.push(
+          `### Scenario ${i + 1}${target}`,
+          "```gherkin",
+          content,
+          "```",
+          ""
+        );
+      });
+    }
+
     sections.push(
       "",
       "Return ONLY a single valid JSON object:",
-      '{"tests_pass":boolean,"coverage":{"overall":number,"services":number,"utilities":number},"missing_scenarios":[string],"quality_issues":[string],"verdict":"pass"|"fail"}',
+      '{"tests_pass":boolean,"coverage":{"overall":number,"services":number,"utilities":number},"missing_scenarios":[string],"quality_issues":[string],"failing_scenarios":[string],"translated_scenarios":[string],"verdict":"pass"|"fail"}',
       "",
       "- coverage.overall MUST be a real number from the test runner output, NOT an estimate",
       "- If coverage tool is not available, set coverage.overall to null (not 0, not a guess)",
       "- tests_pass must reflect whether the actual test run succeeded",
+      "- failing_scenarios: when Gherkin was given, list the scenarios your translated tests CAUGHT as failing",
+      "- translated_scenarios: when Gherkin was given, list the scenarios you successfully turned into passing tests",
+      "- verdict MUST be \"fail\" if any translated scenario still fails (even if coverage is green)",
       `## Task\n${task}`
     );
     if (diff) sections.push(`## Git diff\n${diff}`);
@@ -136,6 +197,9 @@ export class TesterRole extends AgentRole {
       coverage: parsed.coverage || {},
       missing_scenarios: parsed.missing_scenarios || [],
       quality_issues: parsed.quality_issues || [],
+      // Tests-first Phase 3: Gherkin translation outcomes.
+      failing_scenarios: Array.isArray(parsed.failing_scenarios) ? parsed.failing_scenarios : [],
+      translated_scenarios: Array.isArray(parsed.translated_scenarios) ? parsed.translated_scenarios : [],
       verdict,
       provider
     };
@@ -147,6 +211,8 @@ export class TesterRole extends AgentRole {
     const coverageStr = coverage.overall != null ? `${coverage.overall}%` : "not measured";
     const missingPart = parsed.missing_scenarios?.length ? `; ${parsed.missing_scenarios.length} missing scenario(s)` : "";
     const qualityPart = parsed.quality_issues?.length ? `; ${parsed.quality_issues.length} quality issue(s)` : "";
-    return `Verdict: ${verdict}; Coverage: ${coverageStr}${missingPart}${qualityPart}`;
+    const failingPart = parsed.failing_scenarios?.length ? `; ${parsed.failing_scenarios.length} failing scenario(s)` : "";
+    const translatedPart = parsed.translated_scenarios?.length ? `; ${parsed.translated_scenarios.length} scenario(s) translated` : "";
+    return `Verdict: ${verdict}; Coverage: ${coverageStr}${translatedPart}${failingPart}${missingPart}${qualityPart}`;
   }
 }

--- a/tests/tester-tests-first.test.js
+++ b/tests/tester-tests-first.test.js
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { TesterRole } from "../src/roles/tester-role.js";
+
+// Tests-first Phase 3 (v2.7.5): the tester role:
+//  - knows the upstream shell-test results so it doesn't re-run them,
+//  - receives pending Gherkin scenarios and is told to translate +
+//    run + report per-scenario verdicts.
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+async function build(input) {
+  const role = new TesterRole({
+    config: {
+      projectDir: process.cwd(),
+      roles: { tester: { provider: "claude" } },
+      coder: "claude",
+    },
+    logger,
+    emitter: { emit: vi.fn() },
+  });
+  await role.init({ task: input.task || "something" });
+  return role.buildPrompt(input);
+}
+
+describe("TesterRole.buildPrompt — Gherkin translation block", () => {
+  it("does not mention Gherkin when no pending scenarios are passed", async () => {
+    const { prompt } = await build({ task: "t", diff: null, sonarIssues: null, pendingGherkinTests: null });
+    expect(prompt).not.toMatch(/Gherkin acceptance tests to translate/);
+  });
+
+  it("emits the translation block when pending Gherkin scenarios are present", async () => {
+    const { prompt } = await build({
+      task: "implement login",
+      pendingGherkinTests: [
+        { type: "gherkin", content: "Given a logged-out user\nWhen they POST /login\nThen 200 response" },
+        { type: "gherkin", content: "Given expired session\nWhen they navigate to /dashboard\nThen redirect to /login", file: "tests/session.test.ts" },
+      ],
+    });
+    expect(prompt).toMatch(/## Gherkin acceptance tests to translate/);
+    expect(prompt).toMatch(/### Scenario 1/);
+    expect(prompt).toMatch(/### Scenario 2 · target: `tests\/session\.test\.ts`/);
+    expect(prompt).toMatch(/Given a logged-out user/);
+    expect(prompt).toMatch(/redirect to \/login/);
+  });
+
+  it("mentions shell-test results when provided so the tester does not re-run them", async () => {
+    const { prompt } = await build({
+      task: "t",
+      shellTestResults: [
+        { cmd: "echo ok", passed: true, type: "shell" },
+        { cmd: "true", passed: true, type: "shell" },
+      ],
+    });
+    expect(prompt).toMatch(/## Acceptance gate — shell tests/);
+    expect(prompt).toMatch(/2\/2 passed/);
+    expect(prompt).toMatch(/Do NOT re-run them/);
+  });
+
+  it("extends the JSON schema with failing_scenarios and translated_scenarios", async () => {
+    const { prompt } = await build({
+      task: "t",
+      pendingGherkinTests: [{ type: "gherkin", content: "G1" }],
+    });
+    expect(prompt).toMatch(/failing_scenarios/);
+    expect(prompt).toMatch(/translated_scenarios/);
+    expect(prompt).toMatch(/verdict MUST be "fail" if any translated scenario still fails/);
+  });
+});
+
+describe("TesterRole — result and summary", () => {
+  it("parses translated/failing scenarios into the success result", () => {
+    const role = new TesterRole({
+      config: { projectDir: process.cwd(), roles: { tester: { provider: "claude" } }, coder: "claude" },
+      logger,
+      emitter: { emit: vi.fn() },
+    });
+    const parsed = {
+      tests_pass: true,
+      coverage: { overall: 88 },
+      missing_scenarios: [],
+      quality_issues: [],
+      translated_scenarios: ["Logged out redirects", "Session expires"],
+      failing_scenarios: [],
+      verdict: "pass",
+    };
+    const out = role.buildSuccessResult(parsed, "claude");
+    expect(out.translated_scenarios).toEqual(["Logged out redirects", "Session expires"]);
+    expect(out.failing_scenarios).toEqual([]);
+  });
+
+  it("includes translated and failing counts in the summary line", () => {
+    const role = new TesterRole({
+      config: { projectDir: process.cwd(), roles: { tester: { provider: "claude" } }, coder: "claude" },
+      logger,
+      emitter: { emit: vi.fn() },
+    });
+    const summary = role.buildSummary({
+      tests_pass: false,
+      coverage: { overall: 62 },
+      translated_scenarios: ["A"],
+      failing_scenarios: ["B", "C"],
+      verdict: "fail",
+    });
+    expect(summary).toMatch(/Verdict: fail/);
+    expect(summary).toMatch(/1 scenario\(s\) translated/);
+    expect(summary).toMatch(/2 failing scenario\(s\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Final phase of the tests-first redesign (after #491 + #492). The old dynamic — *\"tester invents tests to match whatever got built\"* — is replaced with:

1. Coder writes code to satisfy the declared acceptance_tests (Phase 2).
2. \`runAcceptanceTests\` runs shell tests as the fail-fast gate.
3. If shell tests pass **AND** there are pending Gherkin scenarios, the tester role is invoked — its new job is to translate each Given/When/Then into a concrete test case in the project's framework, run it, and fail the verdict if any scenario still fails.
4. Only when shell + translated Gherkin tests all pass does the HU approve. Coverage / quality assessment happens in the same tester pass so we keep what the previous pipeline did.

### Tester role (\`src/roles/tester-role.js\`)

- Accepts \`pendingGherkinTests\` and \`shellTestResults\` inputs.
- Prompt gains a \"## Gherkin acceptance tests to translate\" section that lists each scenario (with optional target-file hint) and instructs: write tests in the detected framework, run them in the normal suite, don't soften assertions, return \`verdict: \"fail\"\` if any still fails.
- Response schema extended with \`translated_scenarios[]\` and \`failing_scenarios[]\`. Summary picks them up.

### Wire-through

- \`runTesterStage\` and \`runRoleWithFallback\` forward the new fields.
- \`flow-runner.js\` tests-first path: after shell gate passes, if Gherkin pending, invoke the tester; approve only on verdict=pass, otherwise loop coder with the failing-scenario diagnostic.

## Tests

6 new cases in \`tester-tests-first.test.js\`:
- Prompt omits translation block when no scenarios.
- Emits block when scenarios present, respects target-file hints.
- Surfaces upstream shell results (\"do NOT re-run them\").
- Extends JSON response schema with failing/translated arrays + verdict enforcement.
- buildSuccessResult / buildSummary handle the new fields.

3824 parent tests green.

## The trilogy summary

| PR | Phase | What |
|---|---|---|
| #491 | 1 | Planner emits structured acceptance_tests per HU |
| #492 | 2 | Coder prompt carries those tests from turn 1 |
| **this** | 3 | Tester runs them gate-first, translates Gherkin, verdict-enforces |

Closes the *\"tester validates, doesn't invent\"* gap raised during dogfooding.

## Test plan

- [x] \`npx vitest run tests/\` → 3824/3824
- [ ] Manual: \`kj plan <task>\` → verify per-HU structured acceptance_tests on the board
- [ ] Manual: \`kj plan ready <id>\` → refuses plan with tests-less HUs
- [ ] Manual: \`kj run --plan <id>\` → coder receives the tests in its prompt, tester enforces Gherkin before approving