### PR TITLE
fix(cli): no raw JSON in CLI output, idle heartbeat with rotating phrases

### DIFF
--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -167,36 +167,105 @@ function summarizeToolCall(name, input = {}) {
   }
 }
 
-function createStreamJsonFilter(onOutput) {
+/**
+ * Translate a Claude stream-json event into a human-readable summary.
+ *
+ * Returns a `{ line, kind }` object for the cli-progress reporter to
+ * display, OR `null` to suppress (the event is structural noise).
+ *
+ * Whitelist semantics on purpose: pre-v2.7.5 the filter ONLY recognised
+ * `assistant` + `result` and forwarded everything else as raw JSON,
+ * which dumped 6 KB of `system/init` + `rate_limit_event` to the user
+ * on every `kj plan`. Now we recognise every event type Claude can
+ * emit and either condense it to one line or drop it. Unknown types
+ * are dropped silently unless DEBUG_KJ_AGENT is set.
+ */
+export function translateStreamJsonEvent(obj) {
+  switch (obj.type) {
+    case "system": {
+      // The init frame announces session id + model. Useful as a single
+      // status line on first connect; the rate_limit subtype on a
+      // healthy session is pure noise — suppress.
+      if (obj.subtype === "init") {
+        const model = typeof obj.model === "string" ? obj.model : "?";
+        return { line: `Claude session ready (model: ${model.replace(/\[.*\]/, "")})`, kind: "text" };
+      }
+      return null;
+    }
+    case "rate_limit_event": {
+      const status = obj.rate_limit_info?.status;
+      // Only surface when actually throttled — "allowed" is the happy
+      // path and surfaces every few seconds during normal runs.
+      if (status && status !== "allowed") {
+        return { line: `Rate limit: ${status}`, kind: "text" };
+      }
+      return null;
+    }
+    case "user": {
+      // Echoes of the previous tool's output coming back into the
+      // conversation. Adding a line per echo would double the noise of
+      // the corresponding tool_use line, which we already render.
+      return null;
+    }
+    case "assistant": {
+      const content = obj.message?.content;
+      if (!Array.isArray(content)) return null;
+      // Each content block becomes a separate line — we return them
+      // through the caller's emit-many path below.
+      return { _multi: true, blocks: content };
+    }
+    case "result": {
+      const summary = typeof obj.result === "string"
+        ? obj.result.split("\n")[0].slice(0, 120)
+        : "result received";
+      return { line: `done: ${summary}` };
+    }
+    default: {
+      if (process.env.DEBUG_KJ_AGENT) {
+        return { line: `[debug] unknown event: ${obj.type}` };
+      }
+      return null;
+    }
+  }
+}
+
+export function createStreamJsonFilter(onOutput) {
   if (!onOutput) return null;
   return ({ stream, line }) => {
+    let obj;
     try {
-      const obj = JSON.parse(line);
-      // Forward assistant content
-      if (obj.type === "assistant" && obj.message?.content) {
-        for (const block of obj.message.content) {
-          if (block.type === "text" && block.text) {
-            // Only emit first line of text for brevity
-            const firstLine = block.text.split("\n")[0].trim().slice(0, 120);
-            if (firstLine) onOutput({ stream, line: firstLine, kind: "text" });
-          } else if (block.type === "tool_use") {
-            onOutput({ stream, line: summarizeToolCall(block.name, block.input), kind: "tool" });
-          } else if (block.type === "thinking" && block.thinking) {
-            onOutput({ stream, line: `thinking: ${block.thinking.slice(0, 80).replace(/\s+/g, " ")}…`, kind: "thinking" });
-          }
+      obj = JSON.parse(line);
+    } catch {
+      // Not JSON — forward verbatim ONLY if it's short and not a partial
+      // JSON chunk (some agents print stderr diagnostics through the
+      // same channel). Anything that smells like JSON-debris gets
+      // dropped to keep the CLI clean.
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith("{") && !trimmed.startsWith("[") && trimmed.length < 200) {
+        onOutput({ stream, line: trimmed });
+      }
+      return;
+    }
+
+    const summary = translateStreamJsonEvent(obj);
+    if (!summary) return;
+
+    // Multi-block assistant payload: one line per content block.
+    if (summary._multi) {
+      for (const block of summary.blocks) {
+        if (block.type === "text" && block.text) {
+          const firstLine = block.text.split("\n")[0].trim().slice(0, 120);
+          if (firstLine) onOutput({ stream, line: firstLine, kind: "text" });
+        } else if (block.type === "tool_use") {
+          onOutput({ stream, line: summarizeToolCall(block.name, block.input), kind: "tool" });
+        } else if (block.type === "thinking" && block.thinking) {
+          onOutput({ stream, line: `thinking: ${block.thinking.slice(0, 80).replace(/\s+/g, " ")}…`, kind: "thinking" });
         }
-        return;
       }
-      // Forward result
-      if (obj.type === "result") {
-        const summary = typeof obj.result === "string"
-          ? obj.result.split("\n")[0].slice(0, 120)
-          : "result received";
-        onOutput({ stream, line: `done: ${summary}` });
-        return;
-      }
-    } catch { /* not JSON, forward raw */ }
-    onOutput({ stream, line });
+      return;
+    }
+
+    onOutput({ stream, line: summary.line, kind: summary.kind });
   };
 }
 

--- a/src/utils/cli-progress.js
+++ b/src/utils/cli-progress.js
@@ -41,7 +41,33 @@ const ICONS = {
   tool: "▸",      // ▸ right-pointing small triangle
   text: "·",      // · middle dot
   thinking: "…",  // …
+  heartbeat: "⠿", // braille dots — distinct from real activity icons
 };
+
+/**
+ * Rotating idle messages so the user knows the process is alive without
+ * the same string repeating every minute. Picked at random each tick;
+ * the previous one is held back so two ticks in a row never duplicate.
+ */
+const HEARTBEAT_LINES = [
+  "still working…",
+  "thinking through it…",
+  "wading through tokens…",
+  "asking the model nicely…",
+  "crunching the spec…",
+  "burning down the prompt…",
+  "kneading the context window…",
+  "still here, give me a sec…",
+  "the LLM is doing LLM things…",
+  "drafting, redrafting…",
+];
+
+/**
+ * Default cadence for the idle heartbeat. ~45s is short enough to feel
+ * responsive on a quiet planner run (Claude can think for 1-2 min on a
+ * complex spec) without spamming every few seconds.
+ */
+const DEFAULT_HEARTBEAT_MS = 45_000;
 
 /**
  * @typedef {Object} CliProgressReporter
@@ -55,10 +81,18 @@ const ICONS = {
  *                                   Default: "agent".
  * @param {NodeJS.WriteStream} [opts.stream]  - output destination. Default: process.stderr.
  * @param {boolean} [opts.quiet]   - when true, nothing is printed (useful for --json mode).
+ * @param {number}  [opts.heartbeatMs] - silent interval before printing an
+ *   "alive" line. Defaults to 45 s. Set to 0 to disable the heartbeat
+ *   (useful in tests).
  * @returns {CliProgressReporter}
  */
 export function createCliProgressReporter(opts = {}) {
-  const { role = "agent", stream = process.stderr, quiet = false } = opts;
+  const {
+    role = "agent",
+    stream = process.stderr,
+    quiet = false,
+    heartbeatMs = DEFAULT_HEARTBEAT_MS,
+  } = opts;
 
   if (quiet) {
     return { onOutput: () => {}, finish: () => {} };
@@ -67,6 +101,37 @@ export function createCliProgressReporter(opts = {}) {
   const startedAt = Date.now();
   stream.write(`[${role}] starting...\n`);
 
+  // Idle heartbeat: a periodic timer that prints a varied "still alive"
+  // line whenever the agent goes quiet for longer than `heartbeatMs`.
+  // Reset on every real onOutput so heavy chatter doesn't trigger the
+  // duplicate. Always elapses to a different message than last time so
+  // two consecutive ticks never read the same.
+  let lastActivityAt = Date.now();
+  let lastHeartbeatIdx = -1;
+  let heartbeatTimer = null;
+
+  function pickHeartbeatLine() {
+    let idx;
+    do {
+      idx = Math.floor(Math.random() * HEARTBEAT_LINES.length);
+    } while (idx === lastHeartbeatIdx && HEARTBEAT_LINES.length > 1);
+    lastHeartbeatIdx = idx;
+    return HEARTBEAT_LINES[idx];
+  }
+
+  function tick() {
+    const idleFor = Date.now() - lastActivityAt;
+    if (idleFor < heartbeatMs) return;        // real activity reset us
+    const elapsed = Math.round((Date.now() - startedAt) / 1000);
+    stream.write(`  ${ICONS.heartbeat} ${pickHeartbeatLine()} (${elapsed}s)\n`);
+    lastActivityAt = Date.now();              // collapse next ticks
+  }
+
+  if (heartbeatMs > 0) {
+    heartbeatTimer = setInterval(tick, heartbeatMs);
+    if (typeof heartbeatTimer.unref === "function") heartbeatTimer.unref();
+  }
+
   const onOutput = (event) => {
     if (!event || typeof event !== "object") return;
     const raw = typeof event.line === "string" ? event.line : "";
@@ -74,6 +139,7 @@ export function createCliProgressReporter(opts = {}) {
     // Strip trailing newline — we re-add our own.
     const line = raw.replace(/\s+$/, "");
     if (!line) return;
+    lastActivityAt = Date.now();
     const icon = ICONS[event.kind] || ICONS.text;
     stream.write(`  ${icon} ${line}\n`);
   };
@@ -82,6 +148,10 @@ export function createCliProgressReporter(opts = {}) {
    * @param {string} [outcome]  default "done". Use "failed", "stopped", "timeout" etc.
    */
   const finish = (outcome = "done") => {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
     const ms = Date.now() - startedAt;
     const s = (ms / 1000).toFixed(1);
     stream.write(`[${role}] ${outcome} (${s}s)\n`);

--- a/tests/claude-stream-filter.test.js
+++ b/tests/claude-stream-filter.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { translateStreamJsonEvent, createStreamJsonFilter } from "../src/agents/claude-agent.js";
+
+// Pre-v2.7.5 the filter only recognised assistant/result and dumped
+// everything else as raw JSON to the user — including the giant
+// `system/init` line and every `rate_limit_event`. These tests pin
+// the behaviour down so the noise can't come back.
+
+describe("translateStreamJsonEvent", () => {
+  it("condenses system/init into a one-line model announcement", () => {
+    const out = translateStreamJsonEvent({
+      type: "system",
+      subtype: "init",
+      model: "claude-opus-4-7",
+      tools: ["a", "b"],
+      session_id: "abc",
+    });
+    expect(out).toEqual({ line: "Claude session ready (model: claude-opus-4-7)", kind: "text" });
+  });
+
+  it("strips bracketed model suffixes (e.g. [1m])", () => {
+    const out = translateStreamJsonEvent({ type: "system", subtype: "init", model: "claude-opus-4-7[1m]" });
+    expect(out.line).toBe("Claude session ready (model: claude-opus-4-7)");
+  });
+
+  it("suppresses healthy rate_limit_event (status: allowed)", () => {
+    expect(
+      translateStreamJsonEvent({ type: "rate_limit_event", rate_limit_info: { status: "allowed" } })
+    ).toBeNull();
+  });
+
+  it("surfaces actual rate-limit warnings", () => {
+    const out = translateStreamJsonEvent({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "throttled" },
+    });
+    expect(out).toEqual({ line: "Rate limit: throttled", kind: "text" });
+  });
+
+  it("suppresses 'user' echoes (tool_result feedback)", () => {
+    expect(translateStreamJsonEvent({ type: "user", message: { content: [] } })).toBeNull();
+  });
+
+  it("returns multi-block for assistant payloads", () => {
+    const out = translateStreamJsonEvent({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "hello" }] },
+    });
+    expect(out._multi).toBe(true);
+    expect(out.blocks).toHaveLength(1);
+  });
+
+  it("renders result as a one-liner", () => {
+    const out = translateStreamJsonEvent({ type: "result", result: "everything is fine\nmore lines" });
+    expect(out).toEqual({ line: "done: everything is fine" });
+  });
+
+  it("drops unknown event types silently when DEBUG_KJ_AGENT is unset", () => {
+    delete process.env.DEBUG_KJ_AGENT;
+    expect(translateStreamJsonEvent({ type: "some_future_event", foo: 1 })).toBeNull();
+  });
+});
+
+describe("createStreamJsonFilter", () => {
+  it("forwards nothing for system/init's noise (just the friendly line)", () => {
+    const sink = vi.fn();
+    const filter = createStreamJsonFilter(sink);
+    filter({
+      stream: "stdout",
+      line: JSON.stringify({
+        type: "system",
+        subtype: "init",
+        model: "claude-opus-4-7",
+        tools: Array.from({ length: 200 }, (_, i) => `tool_${i}`),
+        mcp_servers: Array.from({ length: 50 }, (_, i) => ({ name: `s${i}`, status: "connected" })),
+      }),
+    });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0].line).toMatch(/Claude session ready/);
+    // Critically: the giant raw JSON must not appear anywhere.
+    const allLines = sink.mock.calls.map((c) => c[0].line).join("\n");
+    expect(allLines).not.toContain("mcp_servers");
+    expect(allLines).not.toContain('"type":"system"');
+  });
+
+  it("emits one onOutput per assistant content block", () => {
+    const sink = vi.fn();
+    const filter = createStreamJsonFilter(sink);
+    filter({
+      stream: "stdout",
+      line: JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Reading SPEC.md\nthen analyzing" },
+            { type: "tool_use", name: "Read", input: { file_path: "/x/SPEC.md" } },
+          ],
+        },
+      }),
+    });
+    expect(sink).toHaveBeenCalledTimes(2);
+    expect(sink.mock.calls[0][0].kind).toBe("text");
+    expect(sink.mock.calls[0][0].line).toBe("Reading SPEC.md");   // first line only
+    expect(sink.mock.calls[1][0].kind).toBe("tool");
+  });
+
+  it("drops malformed JSON-shaped lines instead of echoing them", () => {
+    const sink = vi.fn();
+    const filter = createStreamJsonFilter(sink);
+    filter({ stream: "stdout", line: '{"truncated":true,"incom' });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it("forwards short non-JSON diagnostic lines (e.g. stderr leaks)", () => {
+    const sink = vi.fn();
+    const filter = createStreamJsonFilter(sink);
+    filter({ stream: "stderr", line: "warning: deprecated --foo flag" });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0].line).toBe("warning: deprecated --foo flag");
+  });
+
+  it("returns null when onOutput is null (no-op)", () => {
+    expect(createStreamJsonFilter(null)).toBeNull();
+  });
+});

--- a/tests/cli-progress.test.js
+++ b/tests/cli-progress.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createCliProgressReporter } from "../src/utils/cli-progress.js";
+
+// Minimal Writable-like mock so we can assert what hits stderr.
+function makeStream() {
+  const chunks = [];
+  return {
+    chunks,
+    write: (s) => { chunks.push(s); return true; },
+    text: () => chunks.join(""),
+  };
+}
+
+describe("createCliProgressReporter", () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it("emits a starting header and a footer with elapsed time", () => {
+    const stream = makeStream();
+    const r = createCliProgressReporter({ role: "planner", stream, heartbeatMs: 0 });
+    r.finish();
+    const out = stream.text();
+    expect(out).toMatch(/^\[planner\] starting\.\.\./);
+    expect(out).toMatch(/\[planner\] done \(\d+\.\ds\)\n$/);
+  });
+
+  it("renders one line per onOutput with the kind-appropriate icon", () => {
+    const stream = makeStream();
+    const r = createCliProgressReporter({ role: "planner", stream, heartbeatMs: 0 });
+    r.onOutput({ line: "Read SPEC.md", kind: "tool" });
+    r.onOutput({ line: "Analyzing", kind: "text" });
+    r.onOutput({ line: "thinking: deciding…", kind: "thinking" });
+    r.finish();
+    expect(stream.text()).toMatch(/▸ Read SPEC\.md/);
+    expect(stream.text()).toMatch(/· Analyzing/);
+    expect(stream.text()).toMatch(/… thinking: deciding…/);
+  });
+
+  it("ignores empty / non-string lines instead of printing blank rows", () => {
+    const stream = makeStream();
+    const r = createCliProgressReporter({ role: "p", stream, heartbeatMs: 0 });
+    r.onOutput({ line: "" });
+    r.onOutput({ line: null });
+    r.onOutput({});
+    r.onOutput({ line: "  \n  " });
+    r.finish();
+    // Header + footer only — nothing else.
+    const lines = stream.text().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(2);
+  });
+
+  it("quiet mode is a total no-op (used by --json)", () => {
+    const stream = makeStream();
+    const r = createCliProgressReporter({ role: "p", stream, quiet: true });
+    r.onOutput({ line: "anything" });
+    r.finish();
+    expect(stream.text()).toBe("");
+  });
+
+  describe("idle heartbeat", () => {
+    it("prints a 'still working' line after heartbeatMs of silence", () => {
+      const stream = makeStream();
+      const r = createCliProgressReporter({ role: "p", stream, heartbeatMs: 1000 });
+      vi.advanceTimersByTime(1100);
+      const out = stream.text();
+      // braille icon + a non-empty line + parenthesised seconds elapsed
+      expect(out).toMatch(/⠿ .+ \(\d+s\)/);
+      r.finish();
+    });
+
+    it("real onOutput resets the idle clock so chatter does not double up", () => {
+      const stream = makeStream();
+      const r = createCliProgressReporter({ role: "p", stream, heartbeatMs: 1000 });
+      vi.advanceTimersByTime(900);
+      r.onOutput({ line: "real activity", kind: "tool" });
+      vi.advanceTimersByTime(900);
+      // Total elapsed: 1.8s, but the activity at 900ms reset the
+      // counter, so silence is only 900ms — under the 1000ms threshold.
+      expect(stream.text()).not.toMatch(/⠿/);
+      r.finish();
+    });
+
+    it("varies the heartbeat phrase between consecutive ticks", () => {
+      const stream = makeStream();
+      const r = createCliProgressReporter({ role: "p", stream, heartbeatMs: 100 });
+      // Force several ticks back-to-back.
+      vi.advanceTimersByTime(150);
+      vi.advanceTimersByTime(150);
+      vi.advanceTimersByTime(150);
+      const lines = stream.text().split("\n").filter((l) => l.includes("⠿"));
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      // Strip the elapsed-seconds suffix and assert no two adjacent
+      // messages are identical.
+      const messages = lines.map((l) => l.replace(/\s*\(\d+s\)\s*$/, ""));
+      for (let i = 1; i < messages.length; i += 1) {
+        expect(messages[i]).not.toBe(messages[i - 1]);
+      }
+      r.finish();
+    });
+
+    it("finish() clears the heartbeat timer", () => {
+      const stream = makeStream();
+      const r = createCliProgressReporter({ role: "p", stream, heartbeatMs: 100 });
+      r.finish();
+      vi.advanceTimersByTime(500);
+      // No ⠿ heartbeat line should appear after finish.
+      expect(stream.text()).not.toMatch(/⠿/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two related UX defects raised during the v2.7.5 planner dogfooding:

### 1. Giant raw JSON dump on \`kj plan\`

\`createStreamJsonFilter\` only recognised \`assistant\` and \`result\` events. Everything else — \`system/init\` (thousands of chars listing every tool, MCP server, slash command, agent), \`rate_limit_event\` (one per few seconds during normal runs), \`user\` echoes — fell through and was forwarded literally. Six-KB of unreadable JSON appeared on the first line of every plan.

Filter is now whitelist-based via \`translateStreamJsonEvent\`:

- \`system/init\` → \"Claude session ready (model: <name>)\" (one line)
- \`rate_limit_event\` → suppressed when \`status: allowed\`, surfaced only on real throttling
- \`user\` echoes → suppressed (the matching tool_use line already shows)
- \`assistant\` text/tool_use/thinking → unchanged
- \`result\` → \"done: <first 120 chars>\"
- Unknown types → silent unless \`DEBUG_KJ_AGENT=1\`
- Lines smelling like JSON-debris (start with \`{\` / \`[\`, ≥200 chars) → dropped, not echoed

### 2. Long silent stretches with no liveness signal

Claude can think for 1-2 min on complex specs. The CLI showed nothing in between events, so users thought it had hung.

\`createCliProgressReporter\` gets an **idle heartbeat**: every 45 s of silence (configurable via \`heartbeatMs\`, \`0\` disables) it prints one of ten varied lines — \"still working…\", \"wading through tokens…\", \"asking the model nicely…\", etc. Two consecutive ticks never use the same phrase. Real activity resets the timer. Timer is unrefed and cleared on \`finish()\`.

## Tests

- \`tests/cli-progress.test.js\` (8): header/footer, icons by kind, blank-line filter, quiet mode, heartbeat tick on silence, activity resets clock, phrase varies between ticks, finish clears timer
- \`tests/claude-stream-filter.test.js\` (13): every event type translated/suppressed, multi-block fan-out, malformed JSON dropped, short stderr leaks forwarded

3845 parent tests green.

## Test plan

- [x] \`npx vitest run tests/\` → 3845/3845
- [ ] Manual: \`kj plan <spec>\` no longer dumps system/init JSON; if Claude thinks for >45s, a varied \"still working\" line appears