### PR TITLE
fix(cli): banner adapts to URL length, drop confusing "Approve" step

### DIFF
--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -98,8 +98,6 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
   });
   // Swallow spawn errors so an HU Board failure never crashes the pipeline.
   child.on("error", () => { /* non-blocking — caller logs via tryAutoStartBoard catch */ });
-  child.unref();
-
   if (!child.pid) {
     throw new Error("Failed to spawn HU Board server");
   }
@@ -110,22 +108,22 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
 export async function stopBoard() {
   const pid = readPid();
   if (!pid || !isProcessAlive(pid)) {
-    try { fs.unlinkSync(PID_FILE); } catch { /* ignore */ }
+    fs.rmSync(PID_FILE, { force: true });
     return { ok: true, wasRunning: false };
   }
 
   try {
     process.kill(pid, "SIGTERM");
   } catch { /* process already dead */
-    // already dead
   }
-  try { fs.unlinkSync(PID_FILE); } catch { /* ignore */ }
+  fs.rmSync(PID_FILE, { force: true });
   return { ok: true, wasRunning: true, pid };
 }
 
 export async function boardStatus(port = 4000) {
   const pid = readPid();
   const running = pid !== null && isProcessAlive(pid);
+
   return {
     ok: true,
     running,
@@ -134,27 +132,46 @@ export async function boardStatus(port = 4000) {
   };
 }
 
+// Strip ANSI escapes so we can measure the actual on-screen width of a
+// styled string. Used to size the rules around the banner content.
+const ANSI_RE = /\[[0-9;]*m/g;
+const visibleWidth = (s) => s.replace(ANSI_RE, "").length;
+
 /**
- * Render a highlighted cyan box with the HU Board URL + optional project name.
- * Centralizes the banner used by both the init-time auto-start (flow-runner.js)
- * and the post-planner auto-HU generation safety net so they stay in sync.
+ * Render a HU Board announcement framed by two horizontal rules of EQUAL
+ * length. Pre-v2.7.5 we used a fixed 50-char rounded box drawn with
+ * corners + verticals — fine when the URL fit, but a project slug
+ * pushed past the right wall and the box looked broken. The user's
+ * verdict: "looks worse than no box at all when it overflows".
+ *
+ * New rule: just an over-and-under rule sized to the longest visible
+ * content line. No left/right verticals, no fixed width. Always tidy.
  *
  * @param {Object} params
  * @param {string} params.url           - "http://localhost:4000"
  * @param {string} params.status        - "started" | "already running"
  * @param {string} [params.projectName] - optional project label
- * @returns {string} ANSI-escaped box ready for console.log
+ * @returns {string} ANSI-coloured banner ready for console.log
  */
 export function renderBoardBanner({ url, status, projectName }) {
-  const title = projectName ? `  Project: \u001b[1m${projectName}\u001b[0m` : null;
-  const lines = [
-    "",
-    "\u001b[36m\u256d\u2500 HU Board \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e",
-    `\u001b[36m\u2502\u001b[0m  \u001b[1m${status}\u001b[0m  \u001b[4m${url}\u001b[0m`,
-  ];
-  if (title) lines.push(`\u001b[36m\u2502\u001b[0m${title}`);
-  lines.push("\u001b[36m\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f\u001b[0m", "");
-  return lines.join("\n");
+  const cyan = (s) => `[36m${s}[0m`;
+  const bold = (s) => `[1m${s}[0m`;
+  const underline = (s) => `[4m${s}[0m`;
+
+  const heading = `  ${bold("HU Board")} · ${status}  →  ${underline(url)}`;
+  const content = [heading];
+  if (projectName) content.push(`  Project: ${bold(projectName)}`);
+
+  // Width = widest visible content line + 2-cell padding. Cap at the
+  // terminal width so a silly-long URL doesn't draw a 200-char rule.
+  const termWidth = (process.stdout.columns && process.stdout.columns > 20)
+    ? process.stdout.columns
+    : 100;
+  const longest = Math.max(...content.map(visibleWidth));
+  const ruleWidth = Math.min(longest + 2, termWidth);
+  const rule = cyan("─".repeat(ruleWidth));
+
+  return ["", rule, ...content, rule, ""].join("\n");
 }
 
 export async function boardCommand({ action = "start", port = 4000, logger }) {

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -172,11 +172,20 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
   }
   console.log(`\n## HUs (${plan.hus.length})`);
   console.log(formatHuTable(plan.hus));
+  // Tell the user what just happened and what their two real options are.
+  // Pre-v2.7.5 we printed Review / Approve / Execute as three lines, which
+  // confused everyone:
+  //   - "Review" sounded like an action; `kj plan show` is read-only.
+  //   - "Approve" exposed the internal `kj plan ready` gate that the board
+  //     workflow now bypasses (the board's "Run plan" button calls
+  //     `kj run --plan` directly and the tests-first gate is enforced there).
+  // Now we just say: inspect, then run. The board is the recommended UI.
   console.log(`\nPlan saved: ${planId} (${plan.hus.length} HUs, status: ${plan.status})`);
   console.log(`         → ${planPath}`);
-  console.log(`Review:  kj plan show ${planId}`);
-  console.log(`Approve: kj plan ready ${planId}`);
-  console.log(`Execute: kj run --plan ${planId} "${task.slice(0, 40)}..."`);
+  console.log("");
+  console.log(`Inspect: kj plan show ${planId}`);
+  console.log(`Run:     kj run --plan ${planId} "${task.slice(0, 40)}..."`);
+  console.log(`         (or click ▶ Run plan on the board, if running)`);
 
   // UX boost for HU-bearing plans: auto-start the HU Board (same pattern as
   // `kj run` auto-HU generation) so the user can inspect the 12-HU plan in a
@@ -302,7 +311,7 @@ export async function planReadyCommand({ config, planId }) {
   const count = certifyAllHus(plan);
   await savePlan(projectDir, plan);
   console.log(`✅ ${count} HUs certified. Plan status: ready`);
-  console.log(`Execute: kj run --plan ${planId} "${(plan.task || "").slice(0, 40)}..."`);
+  console.log(`Run: kj run --plan ${planId} "${(plan.task || "").slice(0, 40)}..."`);
 }
 
 /**

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -297,6 +297,34 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
         stageResults.architect = { ok: true, summary: "Loaded from persisted plan", fromPlan: flags.plan };
         stageResults.planner = { ok: true, summary: "Loaded from persisted plan", fromPlan: flags.plan };
 
+        // Tests-first gate (v2.7.5): refuse to run a plan when any HU has
+        // no acceptance_tests. Mirrors the gate in `kj plan ready` so the
+        // CLI path and the board's "▶ Run plan" button (which spawns
+        // `kj run --plan` directly, bypassing `kj plan ready`) both
+        // enforce the same contract. Without this, the board could
+        // launch a run on a plan whose HUs the planner-LLM forgot to
+        // declare tests for, and the coder would have nothing to satisfy.
+        if (isPlanV2(loadedPlan) && Array.isArray(loadedPlan.hus)) {
+          const missing = loadedPlan.hus.filter(
+            (h) => !Array.isArray(h.acceptance_tests) || h.acceptance_tests.length === 0
+          );
+          if (missing.length > 0) {
+            const offenders = missing.map((h) => `  - ${h.id}  ${(h.title || "").slice(0, 60)}`).join("\n");
+            const msg =
+              `Refusing to run plan ${flags.plan}: ${missing.length}/${loadedPlan.hus.length} HU(s) have no acceptance_tests.\n`
+              + `${offenders}\n\n`
+              + "Tests-first flow requires a test contract per HU. Edit each HU on the board\n"
+              + "(http://localhost:4000) via the ✎ Edit button, or re-run `kj plan` to regenerate.";
+            logger.error(msg);
+            emitProgress(emitter, makeEvent("plan:tests-missing", { ...eventBase, stage: "plan" }, {
+              status: "fail",
+              message: `Plan ${flags.plan}: ${missing.length} HU(s) missing acceptance_tests`,
+              detail: { planId: flags.plan, missingHuIds: missing.map((h) => h.id) }
+            }));
+            throw new Error(`Plan ${flags.plan} has ${missing.length} HU(s) with no acceptance_tests — see the run log for details.`);
+          }
+        }
+
         // v2 plan with HUs → inject as huReviewer so sub-pipeline picks them up
         if (isPlanV2(loadedPlan) && loadedPlan.hus?.length > 0) {
           const huBatch = planToHuBatch(loadedPlan);

--- a/tests/board-banner-shape.test.js
+++ b/tests/board-banner-shape.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { renderBoardBanner } from "../src/commands/board.js";
+
+// Strip ANSI escapes so we can measure the actual rendered width of a
+// banner line.
+const ANSI_RE = /\[[0-9;]*m/g;
+const visible = (s) => s.replace(ANSI_RE, "");
+
+describe("renderBoardBanner", () => {
+  it("renders top + bottom rules of EQUAL length around the content", () => {
+    const out = renderBoardBanner({
+      url: "http://localhost:4000",
+      status: "started",
+      projectName: "Demo",
+    });
+    const lines = out.split("\n").filter(Boolean);
+    // 1 top rule + 2 content lines (heading + project) + 1 bottom rule
+    expect(lines.length).toBe(4);
+
+    const ruleChar = "─";
+    const isRule = (l) => visible(l).split("").every((c) => c === ruleChar);
+
+    const topVisible = visible(lines[0]);
+    const bottomVisible = visible(lines[lines.length - 1]);
+    expect(isRule(lines[0])).toBe(true);
+    expect(isRule(lines[lines.length - 1])).toBe(true);
+    expect(topVisible.length).toBe(bottomVisible.length);
+  });
+
+  it("rules width matches the longest content line (or terminal width, whichever is smaller)", () => {
+    const url = "http://localhost:4000/p/very-long-project-slug-that-might-exceed-old-50-char-box";
+    const out = renderBoardBanner({ url, status: "started", projectName: "Demo" });
+    const lines = out.split("\n").filter(Boolean);
+    const maxContentWidth = Math.max(
+      ...lines.slice(1, -1).map((l) => visible(l).length)
+    );
+    const ruleWidth = visible(lines[0]).length;
+    const termWidth = (process.stdout.columns && process.stdout.columns > 20)
+      ? process.stdout.columns
+      : 100;
+    // Either fits (rule >= content) or got capped at terminal width to
+    // avoid a rule that wraps onto two lines.
+    if (maxContentWidth + 2 <= termWidth) {
+      expect(ruleWidth).toBeGreaterThanOrEqual(maxContentWidth);
+      expect(ruleWidth).toBeLessThanOrEqual(maxContentWidth + 4);
+    } else {
+      expect(ruleWidth).toBe(termWidth);
+    }
+  });
+
+  it("never draws a fixed-width 50-char box (the old broken layout)", () => {
+    const out = renderBoardBanner({
+      url: "http://localhost:4000/p/home_manu_ws_ai_linux-assistant-orchestrator",
+      status: "started",
+      projectName: "Linux Assistant Orchestrator",
+    });
+    expect(out).not.toMatch(/╭/);
+    expect(out).not.toMatch(/╰/);
+    expect(out).not.toMatch(/│/);
+    expect(out).not.toMatch(/╮/);
+    expect(out).not.toMatch(/╯/);
+  });
+
+  it("omits the project line when projectName is falsy", () => {
+    const out = renderBoardBanner({ url: "http://x/", status: "started" });
+    expect(out).not.toMatch(/Project:/);
+  });
+
+  it("includes both status and url visibly in the heading", () => {
+    const out = renderBoardBanner({
+      url: "http://localhost:4321/",
+      status: "already running",
+    });
+    expect(visible(out)).toMatch(/HU Board · already running/);
+    expect(visible(out)).toMatch(/http:\/\/localhost:4321\//);
+  });
+});


### PR DESCRIPTION
## Summary

Two UX defects raised on the v2.7.5 dogfooding output:

### 1. HU Board banner overflows on long URLs

Pre-patch the banner used a fixed 50-char rounded box. Looked fine on \`http://localhost:4000\`, looked broken when the project slug pushed the URL past 50 chars — the right wall collapsed.

Replaced with **two equal-length rules above and below the content**. Width = longest visible content line + 2-cell padding, capped at terminal width so a long URL doesn't draw a rule that wraps. ANSI escapes stripped before measuring so styling never inflates the rule.

**Before:**
\`\`\`
╭─ HU Board ──────────────────────────────────────╮
│  started  http://localhost:4000/p/very-long-project-slug-here
│  Project: Some Project Name
╰──────────────────────────────────────╯
\`\`\`

**After:**
\`\`\`
────────────────────────────────────────────────────────────────────
  HU Board · started  →  http://localhost:4000/p/very-long-project-slug-here
  Project: Some Project Name
────────────────────────────────────────────────────────────────────
\`\`\`

### 2. \"Review / Approve / Execute\" is confusing

\`kj plan\` printed:

    Review:  kj plan show <id>
    Approve: kj plan ready <id>
    Execute: kj run --plan <id> ...

- *\"Review\"* implied an action; \`kj plan show\` is read-only
- *\"Approve\"* exposed the internal \`kj plan ready\` gate that the board flow doesn't use (the **▶ Run plan** button calls \`kj run --plan\` directly)

Now we say **Inspect + Run** plus a hint about the board button. The board flow is the recommended UI; the CLI gate is still there for those who want it.

### Bonus: tests-first gate also on \`kj run --plan\`

Pre-patch, the gate refusing HUs without \`acceptance_tests\` lived ONLY in \`kj plan ready\`. The board's Run-plan button skips that command, so a plan whose LLM forgot tests for some HU could still be launched, handing the coder a contract-less HU.

Added the same gate at the start of \`kj run --plan\` (\`pre-loop.js\`): load the plan, count HUs missing tests, abort with the detailed offender list. CLI and board now enforce identically.

## Tests

5 new cases in \`board-banner-shape.test.js\`: equal-length rules, width-vs-content invariant + terminal cap, no fixed-width box, no Project line when missing, status+url visibility.

3850 parent tests green.

## Test plan

- [x] \`npx vitest run tests/\` → 3850/3850
- [ ] Manual: \`kj plan <task>\` shows \"Inspect / Run\" instead of \"Review / Approve / Execute\"
- [ ] Manual: HU Board banner — same width top + bottom regardless of project slug length
- [ ] Manual: \`kj run --plan <id>\` over a plan with a tests-less HU aborts cleanly with the offender list