### PR TITLE
fix(flow): preflight/init failures bail clean, no Solomon escalation

### DIFF
--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -107,28 +107,33 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
   try {
     ctx = await initFlowContext({ task, config, logger, emitter, askQuestion, pgTaskId, pgProject, flags });
   } catch (initError) {
-    // Pre-loop stage failure → Solomon decides
-    logger.warn(`Init/pre-loop error — escalating to Solomon: ${initError.message}`);
-    // tempSession needs `checkpoints` because invokeSolomon → addCheckpoint
-    // pushes into it. Pre-v2.7.4 this lacked the array and crashed with
-    // "Cannot read properties of undefined (reading 'push')" the moment
-    // Solomon was consulted on a preflight failure.
-    const tempSession = { id: "init-error", task, status: "failed", checkpoints: [] };
-    const solomonResult = await invokeSolomon({
-      config, logger, emitter, eventBase: { sessionId: "init-error", iteration: 0, stage: "init", startedAt: Date.now() },
-      stage: "init_error", askQuestion, session: tempSession, iteration: 0,
-      conflict: {
-        stage: "init_error",
-        task,
-        iterationCount: 0,
-        maxIterations: config.max_iterations || 5,
-        history: [{ agent: "pipeline", feedback: `Initialization failed: ${initError.message}` }]
-      }
-    });
-    if (solomonResult.action === "pause") {
-      return { paused: true, sessionId: "init-error", question: solomonResult.question, context: "init_error" };
-    }
-    throw initError; // Solomon couldn't resolve — propagate
+    // Pre-loop / preflight failures are CONFIG problems, not pipeline
+    // disputes. Pre-v2.7.5 we escalated them to Solomon, which:
+    //   1. Spent tokens on something an LLM can't actually fix (e.g.
+    //      "port 9000 occupied", "docker not installed", "node version
+    //      too old"). Solomon's job is to mediate between coder and
+    //      reviewer, not to rewrite the user's environment.
+    //   2. Often failed to parse its own output ("Failed to parse
+    //      Solomon output: no JSON found") and then asked the user a
+    //      garbled multi-line "Conflict: init_error" prompt — useless
+    //      when the run was launched by the board's ▶ Run plan with
+    //      stdio=ignore, since there's nobody to answer it.
+    //
+    // New behaviour: print the error verbatim with the actionable fix
+    // (the preflight check already attached one), emit init_error
+    // through the event channel for tooling, and bail with a non-zero
+    // exit. The user gets one clear message and a fix; nothing tries to
+    // be cleverer than that.
+    logger.error(`Initialization failed: ${initError.message}`);
+    if (initError.fix) logger.error(`  Fix: ${initError.fix}`);
+    emitProgress(emitter, makeEvent("init:failed", {
+      sessionId: "init-error", iteration: 0, stage: "init", startedAt: Date.now()
+    }, {
+      status: "fail",
+      message: `Initialization failed: ${initError.message}`,
+      detail: { error: initError.message, fix: initError.fix || null }
+    }));
+    throw initError;
   }
 
   try {

--- a/tests/flow-init-error-no-solomon.test.js
+++ b/tests/flow-init-error-no-solomon.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Regression for v2.7.5: a preflight / init failure must NOT escalate
+// to Solomon. Solomon's job is to mediate coder/reviewer disputes, not
+// to ask an LLM what to do about "port 9000 occupied". Pre-patch we
+// invoked Solomon, which often failed to parse its own output and
+// surfaced a garbled "Conflict: init_error" prompt — useless when the
+// run is non-interactive (board's ▶ Run plan spawns with stdio=ignore).
+
+const initFlowContext = vi.fn();
+const invokeSolomon = vi.fn();
+
+vi.mock("../src/orchestrator/drivers/init-context.js", () => ({
+  initFlowContext: (...args) => initFlowContext(...args),
+}));
+vi.mock("../src/orchestrator/solomon-escalation.js", () => ({
+  invokeSolomon: (...args) => invokeSolomon(...args),
+}));
+// Heavy modules pulled in transitively by flow-runner — stub the
+// surface to keep the test focused on the init-error branch.
+vi.mock("../src/orchestrator/drivers/iteration-loop.js", () => ({
+  runIterationLoop: vi.fn(),
+  runCoderAndRefactorerStages: vi.fn(),
+  runGuardStages: vi.fn(),
+  runStageWithStandby: vi.fn(),
+}));
+vi.mock("../src/utils/garbage-collector.js", () => ({
+  runAutoGC: vi.fn().mockResolvedValue({ removed: [], errors: [] }),
+  summarizeGC: vi.fn().mockReturnValue(null),
+}));
+
+beforeEach(() => {
+  initFlowContext.mockReset();
+  invokeSolomon.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("flow-runner: preflight/init failures fail-fast", () => {
+  it("does NOT call invokeSolomon when initFlowContext throws", async () => {
+    const initError = new Error("Preflight FAILED — port 9000 occupied by unknown process");
+    initError.fix = "Stop the conflicting process or use sonarqube.host in kj.config.yml";
+    initFlowContext.mockRejectedValue(initError);
+
+    const { runFlow } = await import("../src/orchestrator/flow-runner.js");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+    const emitter = { emit: vi.fn() };
+
+    await expect(
+      runFlow({ task: "do thing", config: {}, logger, emitter, askQuestion: vi.fn(), flags: {} })
+    ).rejects.toThrow(/port 9000 occupied/);
+
+    expect(invokeSolomon).not.toHaveBeenCalled();
+  });
+
+  it("emits an init:failed event with the error message and the fix hint", async () => {
+    const initError = new Error("Docker not installed");
+    initError.fix = "Install Docker: https://docs.docker.com/get-docker/";
+    initFlowContext.mockRejectedValue(initError);
+
+    const { runFlow } = await import("../src/orchestrator/flow-runner.js");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+    const emitter = { emit: vi.fn() };
+
+    await expect(
+      runFlow({ task: "do thing", config: {}, logger, emitter, askQuestion: vi.fn(), flags: {} })
+    ).rejects.toThrow();
+
+    // The error + fix go to the logger as plain text…
+    const errorCalls = logger.error.mock.calls.map((c) => c[0]).join(" | ");
+    expect(errorCalls).toMatch(/Docker not installed/);
+    expect(errorCalls).toMatch(/Install Docker/);
+
+    // …and the structured event carries the same data for the board /
+    // SSE consumers downstream.
+    const initFailedEvent = emitter.emit.mock.calls.find(
+      ([eventName, payload]) => eventName === "progress" && payload?.type === "init:failed"
+    );
+    expect(initFailedEvent).toBeDefined();
+    expect(initFailedEvent[1].detail).toMatchObject({
+      error: "Docker not installed",
+      fix: "Install Docker: https://docs.docker.com/get-docker/",
+    });
+  });
+
+  it("an init error with no fix hint still reports cleanly (no crash)", async () => {
+    initFlowContext.mockRejectedValue(new Error("something exploded"));
+
+    const { runFlow } = await import("../src/orchestrator/flow-runner.js");
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+    const emitter = { emit: vi.fn() };
+
+    await expect(
+      runFlow({ task: "x", config: {}, logger, emitter, askQuestion: vi.fn(), flags: {} })
+    ).rejects.toThrow(/something exploded/);
+
+    expect(invokeSolomon).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Reported on the v2.7.5 dogfooding: a SonarQube port collision turned into a multi-step Solomon dialog that ended with a \`❓ Conflict: init_error\` prompt the board user couldn't even answer (\`stdio=ignore\`). The chain:

    Init/pre-loop error — escalating to Solomon: Preflight FAILED …
    Solomon execution failed: Failed to parse Solomon output: no JSON
    ❓ --- Conflict: init_error ---
    > Your response (or 'stop' to exit):    ← hangs forever

Two things wrong:
1. Solomon's job is to mediate coder/reviewer disputes, not to ask an LLM what to do about \"port 9000 occupied\" or \"Docker not installed\". An LLM cannot fix the user's environment.
2. Solomon often failed to parse its own response on these inputs and surfaced a useless prompt nobody could answer in a non-interactive run.

**Fix in \`src/orchestrator/flow-runner.js\`**: when \`initFlowContext\` throws, log the message + the attached \`fix\` hint (preflight already attaches one), emit an \`init:failed\` progress event for tooling, and re-throw. No Solomon, no prompt, no hang.

## Tests

\`tests/flow-init-error-no-solomon.test.js\` (3 cases):
- invokeSolomon is never called on init failure
- structured \`init:failed\` event carries \`{ error, fix }\`
- a fix-less error still fails cleanly

3875 parent tests green.

## Companion

PR #498 (sonar auto-discovery) eliminated the most common cause of init_error in the first place. Together: the user never sees an init-error rabbit hole.

## Test plan

- [x] \`npx vitest run tests/\` → 3875/3875
- [ ] Manual: a missing dependency (e.g. \`docker\` not installed) prints one error line + the install hint, then exits 1 — no Solomon ceremony