### PR TITLE
feat(board): route interactive prompts to a board modal (no more hangs)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -2090,9 +2090,28 @@ function subscribeToServerEvents() {
   if (sseSource) sseSource.close();
   sseSource = new EventSource('/api/events');
   sseSource.addEventListener('message', (e) => {
-    // Debounce burst updates — chokidar fires fast on a single
-    // plan JSON rewrite (plan.hus → stories → plan again). We
-    // don't need to patch the DOM ten times in 20ms.
+    // Try to parse the event as a typed payload. Prompt events drive
+    // the prompt modal; everything else just nudges a re-render.
+    let payload;
+    try { payload = JSON.parse(e.data); } catch { payload = null; }
+
+    if (payload?.type === 'prompt' && payload.promptId) {
+      // A non-interactive runner is asking for input — pop the modal
+      // immediately. fetch the full prompt body from the API so we
+      // don't depend on the SSE event carrying every field.
+      fetch(`/api/prompts`).then(r => r.ok ? r.json() : []).then((list) => {
+        const match = list.find((p) => p.promptId === payload.promptId);
+        if (match) showPromptModal(match);
+      }).catch(() => {});
+      return;
+    }
+    if (payload?.type === 'prompt-resolved' && payload.promptId) {
+      // Runner read its answer file — close the modal if it's still open.
+      closePromptModalIfMatches(payload.promptId);
+      return;
+    }
+
+    // Default: data changed somewhere; nudge the current view.
     if (sseRefreshTimer) clearTimeout(sseRefreshTimer);
     sseRefreshTimer = setTimeout(() => refreshCurrentView(e.data), 150);
   });
@@ -2100,6 +2119,109 @@ function subscribeToServerEvents() {
     // EventSource handles reconnection. Nothing to do; browsers retry
     // the `retry:` value we sent on open.
   });
+
+  // On boot, also fetch any prompts that were already pending before
+  // this tab connected (we missed their SSE add-event).
+  fetch('/api/prompts').then((r) => r.ok ? r.json() : []).then((list) => {
+    for (const p of list) showPromptModal(p);
+  }).catch(() => {});
+}
+
+// ---- Prompt modal ----
+//
+// The runner publishes a prompt JSON file when it needs an answer
+// (Solomon escalations, max-iterations decisions, anything wired to
+// askQuestion) and there's no TTY to ask through. The board surfaces
+// the prompt as a modal dialog with a text input. When the user
+// answers, we POST back; the runner sees the answer file and
+// resolves.
+
+let activePromptId = null;
+
+function showPromptModal(prompt) {
+  if (!prompt?.promptId) return;
+  if (activePromptId === prompt.promptId) return;
+  activePromptId = prompt.promptId;
+  const dlg = ensureDialog();
+  const ctxBlock = prompt.context
+    ? `<details style="margin-top:8px">
+         <summary style="cursor:pointer;color:var(--text-muted);font-size:0.85rem">Context</summary>
+         <pre style="white-space:pre-wrap;font-size:0.78rem;background:var(--bg-primary);padding:8px;border-radius:var(--radius-sm);overflow:auto;max-height:240px">${esc(JSON.stringify(prompt.context, null, 2))}</pre>
+       </details>`
+    : '';
+  dlg.innerHTML = `
+    <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:10px">
+      <span>❓ Karajan needs an answer</span>
+      ${prompt.sessionId ? `<span style="font-family:var(--font-mono, monospace);font-size:0.75rem;color:var(--text-muted)">${esc(prompt.sessionId)}</span>` : ''}
+    </div>
+    <div style="padding:14px 18px">
+      <div style="white-space:pre-wrap;font-size:0.95rem;line-height:1.55">${esc(prompt.question)}</div>
+      ${ctxBlock}
+      <textarea id="prompt-answer" rows="3"
+                placeholder="Type your answer (or 'stop' to abort the run)"
+                style="margin-top:12px;width:100%;padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-family:inherit;font-size:0.9rem;line-height:1.5;resize:vertical;box-sizing:border-box"></textarea>
+    </div>
+    <div style="display:flex;justify-content:space-between;align-items:center;padding:10px 18px;border-top:1px solid var(--border);gap:8px">
+      <span style="font-size:0.75rem;color:var(--text-muted)">
+        The runner is blocked waiting for this answer. Closing the dialog without answering aborts the prompt (run stops).
+      </span>
+      <div style="display:flex;gap:8px">
+        <button id="prompt-stop" type="button" class="control-btn"
+                style="padding:6px 14px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
+          Stop
+        </button>
+        <button id="prompt-send" type="button" class="control-btn"
+                style="padding:6px 14px;border:none;background:var(--color-green);color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600">
+          Send
+        </button>
+      </div>
+    </div>
+  `;
+
+  const send = async (rawAnswer) => {
+    const answer = String(rawAnswer ?? '');
+    try {
+      await fetch(`/api/prompts/${encodeURIComponent(prompt.promptId)}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answer }),
+      });
+    } catch (err) {
+      await showError(`Could not deliver answer: ${err.message}`, { title: 'Prompt delivery failed' });
+      return;
+    }
+    activePromptId = null;
+    if (dlg.open) dlg.close();
+  };
+
+  dlg.querySelector('#prompt-send').addEventListener('click', () => {
+    send(dlg.querySelector('#prompt-answer').value.trim());
+  });
+  dlg.querySelector('#prompt-stop').addEventListener('click', () => send('stop'));
+
+  // Esc / backdrop click also count as Stop so the user can't accidentally
+  // leave the runner blocked.
+  dlg.addEventListener('close', () => {
+    if (activePromptId === prompt.promptId) {
+      activePromptId = null;
+      // Best-effort stop; ignore errors if the runner already moved on.
+      fetch(`/api/prompts/${encodeURIComponent(prompt.promptId)}/answer`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answer: 'stop' }),
+      }).catch(() => {});
+    }
+  }, { once: true });
+
+  dlg.showModal();
+  setTimeout(() => dlg.querySelector('#prompt-answer')?.focus(), 50);
+}
+
+function closePromptModalIfMatches(promptId) {
+  if (activePromptId !== promptId) return;
+  activePromptId = null;
+  const dlg = document.getElementById('app-dialog');
+  if (dlg && dlg.open) dlg.close();
 }
 
 /**

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -348,6 +348,70 @@ router.post('/projects/:id/ready', (req, res) => {
 });
 
 /**
+ * Resolve the prompts directory the runner writes RPC packets to.
+ * Same convention as src/utils/board-prompt-bridge.js on the runner.
+ */
+function promptsDir() {
+  return path.join(getKjHome(), 'prompts');
+}
+
+/**
+ * GET /api/prompts - List currently pending prompts. The runner is
+ * blocked on each one waiting for an answer; the board reads this on
+ * boot to surface modals for prompts that were already pending when
+ * the page loaded (the SSE event fires only on new arrivals).
+ */
+router.get('/prompts', (_req, res) => {
+  try {
+    const dir = promptsDir();
+    if (!fs.existsSync(dir)) return res.json([]);
+    const entries = fs.readdirSync(dir);
+    const result = [];
+    for (const name of entries) {
+      if (!name.endsWith('.json') || name.endsWith('.answer.json')) continue;
+      try {
+        const raw = fs.readFileSync(path.join(dir, name), 'utf-8');
+        result.push(JSON.parse(raw));
+      } catch { /* malformed — skip */ }
+    }
+    result.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/prompts/:promptId/answer - Body { answer }. Writes a
+ * sibling .answer.json the runner is polling for. The runner reads
+ * it, deletes both files, and resolves askQuestion. An answer of
+ * "stop" tells the runner to abort the session.
+ */
+router.post('/prompts/:promptId/answer', (req, res) => {
+  try {
+    const { answer } = req.body || {};
+    if (typeof answer !== 'string') {
+      return res.status(400).json({ error: 'Body must contain an "answer" string' });
+    }
+    const dir = promptsDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const promptPath = path.join(dir, `${req.params.promptId}.json`);
+    if (!fs.existsSync(promptPath)) {
+      return res.status(404).json({ error: `Prompt not found: ${req.params.promptId}` });
+    }
+    const answerPath = path.join(dir, `${req.params.promptId}.answer.json`);
+    fs.writeFileSync(
+      answerPath,
+      JSON.stringify({ answer, answeredAt: new Date().toISOString() }, null, 2),
+      'utf-8'
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
  * GET /api/events - Server-Sent Events stream for live board updates.
  *
  * Replaces the old "sync → full page re-render" dance. The chokidar

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -449,6 +449,7 @@ export function startWatcher() {
   const kjHome = getKjHome();
   const storiesGlob = join(kjHome, 'hu-stories', '*', 'batch.json');
   const sessionsGlob = join(kjHome, 'sessions', '*', 'session.json');
+  const promptsGlob = join(kjHome, 'prompts', '*.json');
   // Plans live under KJ_PLANS_DIR or ~/.kj/plans/, NOT under ~/.karajan/ —
   // the two homes are separate (KJ runs off ~/.kj, the board off
   // ~/.karajan). Without this glob, HU statuses flipped to coding / done
@@ -458,27 +459,49 @@ export function startWatcher() {
   const plansRoot = process.env.KJ_PLANS_DIR || join(homedir(), '.kj', 'plans');
   const plansGlob = join(plansRoot, '*', 'plan-*.json');
 
-  const watcher = watch([storiesGlob, sessionsGlob, plansGlob], {
+  const watcher = watch([storiesGlob, sessionsGlob, plansGlob, promptsGlob], {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
   });
 
-  const syncByPath = (p) => {
+  const syncByPath = (p, eventName) => {
     if (p.includes('hu-stories')) syncStoryFile(p);
     else if (p.includes('sessions')) syncSessionFile(p);
     else if (p.includes(`${plansRoot}${plansRoot.endsWith('/') ? '' : '/'}`) || p.includes('/plans/')) {
       syncPlanFile(p);
+    } else if (p.includes('/prompts/')) {
+      // Prompt files are RPC packets the runner writes when it needs
+      // an answer (Solomon escalation, etc.) — see board-prompt-bridge.js.
+      // The board's API exposes a /api/prompts list; here we just emit
+      // a bus event so connected SSE clients pop the modal immediately
+      // instead of waiting on the next render cycle.
+      if (p.endsWith('.answer.json')) return;     // ignore our own writes
+      try {
+        const raw = readFileSync(p, 'utf-8');
+        const data = JSON.parse(raw);
+        publishEvent({ type: 'prompt', event: eventName, promptId: data.promptId, sessionId: data.sessionId, question: data.question });
+      } catch { /* malformed prompt file — ignore */ }
     }
   };
 
   watcher.on('add', (p) => {
     console.log(`[watcher] New file: ${p}`);
-    syncByPath(p);
+    syncByPath(p, 'add');
   });
 
   watcher.on('change', (p) => {
     console.log(`[watcher] Changed: ${p}`);
-    syncByPath(p);
+    syncByPath(p, 'change');
+  });
+
+  // The runner deletes prompt files once the answer arrives. Surface
+  // those deletions as `prompt:resolved` events so already-open modals
+  // can close themselves without polling.
+  watcher.on('unlink', (p) => {
+    if (p.includes('/prompts/') && p.endsWith('.json') && !p.endsWith('.answer.json')) {
+      const m = /([^/]+)\.json$/.exec(p);
+      if (m) publishEvent({ type: 'prompt-resolved', promptId: m[1] });
+    }
   });
 
   console.log(`[watcher] Watching ${kjHome} + ${plansRoot} for changes`);

--- a/packages/hu-board/tests/prompts-api.test.js
+++ b/packages/hu-board/tests/prompts-api.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+let tmp;
+let app;
+let dbMod;
+
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "hu-board-prompts-"));
+  process.env.KJ_HOME = tmp;
+  dbMod = await import("../src/db.js");
+  dbMod.initDb();
+  const { default: apiRoutes } = await import("../src/routes/api.js");
+  app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+});
+
+afterEach(() => {
+  dbMod.closeDb();
+  rmSync(tmp, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("GET /api/prompts", () => {
+  it("returns [] when no prompts dir exists", async () => {
+    const res = await request(app).get("/api/prompts");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns the pending prompts sorted by createdAt", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "prompt-2.json"), JSON.stringify({
+      promptId: "prompt-2", sessionId: "s", question: "second?", createdAt: "2026-04-25T11:00:00Z",
+    }));
+    writeFileSync(join(dir, "prompt-1.json"), JSON.stringify({
+      promptId: "prompt-1", sessionId: "s", question: "first?", createdAt: "2026-04-25T10:00:00Z",
+    }));
+    const res = await request(app).get("/api/prompts");
+    expect(res.status).toBe(200);
+    expect(res.body.map((p) => p.promptId)).toEqual(["prompt-1", "prompt-2"]);
+  });
+
+  it("ignores answer.json files (they're not pending prompts)", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "prompt-x.answer.json"), JSON.stringify({ answer: "x" }));
+    const res = await request(app).get("/api/prompts");
+    expect(res.body).toEqual([]);
+  });
+
+  it("skips malformed prompt files instead of 500ing", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "good.json"), JSON.stringify({ promptId: "good", question: "?" }));
+    writeFileSync(join(dir, "bad.json"), "not json {{{");
+    const res = await request(app).get("/api/prompts");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].promptId).toBe("good");
+  });
+});
+
+describe("POST /api/prompts/:promptId/answer", () => {
+  it("returns 404 when the prompt doesn't exist", async () => {
+    const res = await request(app).post("/api/prompts/nope/answer").send({ answer: "x" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when the body has no answer string", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "prompt-x.json"), JSON.stringify({ promptId: "prompt-x", question: "?" }));
+    const res = await request(app).post("/api/prompts/prompt-x/answer").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("writes a sibling .answer.json the runner can pick up", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "prompt-x.json"), JSON.stringify({ promptId: "prompt-x", question: "?" }));
+
+    const res = await request(app).post("/api/prompts/prompt-x/answer").send({ answer: "yes please" });
+    expect(res.status).toBe(200);
+
+    const answerPath = join(dir, "prompt-x.answer.json");
+    expect(existsSync(answerPath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(answerPath, "utf-8"));
+    expect(parsed.answer).toBe("yes please");
+    expect(typeof parsed.answeredAt).toBe("string");
+  });
+
+  it("accepts the literal string 'stop' as a valid answer (signals abort)", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    writeFileSync(join(dir, "prompt-x.json"), JSON.stringify({ promptId: "prompt-x", question: "?" }));
+    const res = await request(app).post("/api/prompts/prompt-x/answer").send({ answer: "stop" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/commands/resume.js
+++ b/src/commands/resume.js
@@ -4,22 +4,29 @@ import { resumeFlow } from "../orchestrator.js";
 import { createActivityLog } from "../activity-log.js";
 import { printEvent } from "../utils/display/event-handlers.js";
 
-function createCliAskQuestion() {
+function createCliAskQuestion(opts = {}) {
+  const { sessionId = null } = opts;
   return async (question, context) => {
-    // Mirror the run.js detection: refuse to hang on a TTY-less stdin.
-    // Same rationale (board's Run-plan button spawns with stdio=ignore).
+    // Mirror the run.js logic: route to the board via the file-based
+    // bridge when there's no TTY; otherwise prompt the local terminal.
     const stdinReadable = process.stdin && process.stdin.readable !== false;
     const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
     if (!isInteractive) {
+      const { askThroughBoard } = await import("../utils/board-prompt-bridge.js");
       console.log(`\n\u2753 ${question}`);
       if (context?.detail) {
         console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
       }
       console.log(
-        "\n[non-interactive] No TTY available \u2014 cannot prompt for an answer.\n"
-        + "  Re-run `kj resume <sessionId>` from a terminal to answer."
+        "\n[non-interactive] Routing the prompt to the HU Board.\n"
+        + "  Open http://localhost:4000 \u2014 a modal will appear asking for your answer."
       );
-      return null;
+      try {
+        return await askThroughBoard({ sessionId, question, context });
+      } catch (err) {
+        console.log(`\n[prompt-bridge] ${err.message} \u2014 stopping the session.`);
+        return null;
+      }
     }
 
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -9,30 +9,35 @@ import { printEvent } from "../utils/display/event-handlers.js";
 import { resolveRole } from "../config.js";
 import { parseCardId } from "../planning-game/adapter.js";
 
-function createCliAskQuestion() {
+function createCliAskQuestion(opts = {}) {
+  const { sessionId = null } = opts;
   return async (question, context) => {
-    // No TTY (e.g. spawned by the board's "\u25b6 Run plan" with stdio=ignore)
-    // means readline.question() would hang forever waiting for input
-    // that can never arrive. Detect and abort cleanly with a message
-    // the user can see in the run log instead of leaving the process
-    // wedged. Once we add prompt-routing through the board UI (planned
-    // follow-up), we'll replace this fallback with that path.
+    // Two paths:
+    //   - Interactive TTY: prompt via readline (the developer's terminal).
+    //   - No TTY (board's \u25b6 Run plan with stdio=ignore, CI, etc.): publish
+    //     the prompt through the file-based bridge so the HU Board can
+    //     surface it as a modal. The runner blocks on the bridge until
+    //     the user answers (or times out / kills the run). Pre-v2.7.5
+    //     this path just bailed; now the question actually gets answered.
     const stdinReadable = process.stdin && process.stdin.readable !== false;
     const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
     if (!isInteractive) {
+      const { askThroughBoard } = await import("../utils/board-prompt-bridge.js");
       console.log(`\n\u2753 ${question}`);
       if (context?.detail) {
         console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
       }
       console.log(
-        "\n[non-interactive] No TTY available \u2014 cannot prompt for an answer.\n"
-        + "  This run was likely launched by the board's \u25b6 Run plan button or another\n"
-        + "  detached process (stdio=ignore). The session is being stopped instead\n"
-        + "  of hanging forever.\n"
-        + "  To answer the prompt, re-run the command in a terminal:\n"
-        + "    kj resume <sessionId>"
+        "\n[non-interactive] Routing the prompt to the HU Board.\n"
+        + "  Open http://localhost:4000 \u2014 a modal will appear asking for your answer.\n"
+        + "  This process is now waiting; closing the board does NOT cancel the run."
       );
-      return null;
+      try {
+        return await askThroughBoard({ sessionId, question, context });
+      } catch (err) {
+        console.log(`\n[prompt-bridge] ${err.message} \u2014 stopping the session.`);
+        return null;
+      }
     }
 
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/src/utils/board-prompt-bridge.js
+++ b/src/utils/board-prompt-bridge.js
@@ -1,0 +1,109 @@
+/**
+ * File-based RPC between a non-interactive Karajan run and the HU
+ * Board. When the runner needs an answer to a question (Solomon
+ * escalation, max-iterations resolution, anything wired to
+ * askQuestion) and stdin is unavailable (the board's ▶ Run plan
+ * spawns with stdio=ignore), it writes a prompt JSON to a known
+ * directory and polls for an "answer" sibling file. The board's
+ * chokidar watcher sees the prompt and surfaces it as a modal; the
+ * user's answer is POSTed back, written as the answer file, and the
+ * runner picks it up and resolves.
+ *
+ * Why files instead of a socket / SSE-back-channel:
+ *   - Zero new server in the runner. A detached child has no listening
+ *     port; opening one would mean discovery + auth + cleanup.
+ *   - Survives a runner restart: if the user kills + resumes, the
+ *     pending prompt is still on disk and the board can re-show it.
+ *   - The board already watches `~/.karajan/`; one more glob is cheap.
+ *
+ * Layout:
+ *   $KJ_HOME/prompts/<promptId>.json         - { sessionId, question, context, createdAt }
+ *   $KJ_HOME/prompts/<promptId>.answer.json  - { answer, answeredAt }    (written by board)
+ *
+ * The bridge owns the lifecycle: write the prompt, poll until the
+ * answer arrives, delete BOTH files, return the answer string (or
+ * null when the user picked "stop"). Aborts cleanly on signal or on
+ * a configurable timeout (default 30 min — long enough for a coffee).
+ */
+
+import { mkdir, writeFile, readFile, unlink, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+const POLL_INTERVAL_MS = 500;
+const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;          // 30 min
+
+function getPromptsDir() {
+  const home = process.env.KJ_HOME || join(homedir(), ".karajan");
+  return join(home, "prompts");
+}
+
+function exists(path) {
+  return stat(path).then(() => true, () => false);
+}
+
+/**
+ * Publish a prompt + wait for the answer. Returns the answer string,
+ * `null` when the user explicitly picked "stop", or rejects on
+ * timeout / abort.
+ *
+ * @param {object} args
+ * @param {string} args.sessionId
+ * @param {string} args.question
+ * @param {object} [args.context]   - serialised verbatim into the prompt JSON
+ * @param {number} [args.timeoutMs]
+ * @param {AbortSignal} [args.signal]
+ * @param {object} [args.logger]    - { info, warn } — optional, for breadcrumbs
+ * @returns {Promise<string|null>}
+ */
+export async function askThroughBoard({ sessionId, question, context = null, timeoutMs = DEFAULT_TIMEOUT_MS, signal = null, logger = null } = {}) {
+  if (!question) throw new Error("askThroughBoard: question is required");
+
+  const dir = getPromptsDir();
+  await mkdir(dir, { recursive: true });
+
+  const promptId = `prompt-${Date.now()}-${randomUUID().slice(0, 8)}`;
+  const promptPath = join(dir, `${promptId}.json`);
+  const answerPath = join(dir, `${promptId}.answer.json`);
+
+  const payload = {
+    promptId,
+    sessionId: sessionId || null,
+    question,
+    context: context || null,
+    createdAt: new Date().toISOString(),
+  };
+  await writeFile(promptPath, JSON.stringify(payload, null, 2), "utf-8");
+  logger?.info?.(`[prompt-bridge] published ${promptId} — waiting for answer via the board`);
+
+  const startedAt = Date.now();
+  try {
+    while (true) {
+      if (signal?.aborted) throw new Error("askThroughBoard: aborted");
+      if (Date.now() - startedAt > timeoutMs) {
+        throw new Error(`askThroughBoard: timed out after ${Math.round(timeoutMs / 1000)}s waiting for answer to ${promptId}`);
+      }
+      if (await exists(answerPath)) {
+        const raw = await readFile(answerPath, "utf-8");
+        let answer;
+        try { ({ answer } = JSON.parse(raw)); } catch { answer = null; }
+        await unlink(answerPath).catch(() => {});
+        await unlink(promptPath).catch(() => {});
+        if (typeof answer === "string" && answer.trim().toLowerCase() === "stop") return null;
+        return typeof answer === "string" ? answer.trim() : null;
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+  } catch (err) {
+    // Best-effort cleanup of the prompt file on error so it doesn't
+    // get stuck pending on the board forever.
+    await unlink(promptPath).catch(() => {});
+    throw err;
+  }
+}
+
+/** Test seam — exposes the resolved prompts dir for assertions. */
+export function _getPromptsDirForTests() {
+  return getPromptsDir();
+}

--- a/tests/board-prompt-bridge.test.js
+++ b/tests/board-prompt-bridge.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { askThroughBoard, _getPromptsDirForTests } from "../src/utils/board-prompt-bridge.js";
+
+let tmp;
+let savedHome;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kj-prompt-bridge-"));
+  savedHome = process.env.KJ_HOME;
+  process.env.KJ_HOME = tmp;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = savedHome;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("askThroughBoard", () => {
+  it("writes a prompt JSON, waits, and resolves with the answer when an answer file appears", async () => {
+    const promptsDir = _getPromptsDirForTests();
+    expect(promptsDir).toContain(tmp);
+
+    // Race: kick off the bridge, then write the answer file 50ms later.
+    const future = askThroughBoard({
+      sessionId: "sess-1", question: "Pick A or B", context: { iteration: 3 }, timeoutMs: 5000,
+    });
+
+    setTimeout(() => {
+      const files = readdirSync(promptsDir).filter((f) => !f.endsWith(".answer.json"));
+      const promptFile = files[0];
+      const promptId = promptFile.replace(/\.json$/, "");
+      writeFileSync(
+        join(promptsDir, `${promptId}.answer.json`),
+        JSON.stringify({ answer: "A", answeredAt: new Date().toISOString() }),
+        "utf-8"
+      );
+    }, 80);
+
+    const result = await future;
+    expect(result).toBe("A");
+    // Both files cleaned up.
+    const remaining = readdirSync(promptsDir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("returns null when the user answers 'stop' (case-insensitive, trimmed)", async () => {
+    const promptsDir = _getPromptsDirForTests();
+    const future = askThroughBoard({ sessionId: "s", question: "?", timeoutMs: 5000 });
+    setTimeout(() => {
+      const promptFile = readdirSync(promptsDir).find((f) => !f.endsWith(".answer.json"));
+      const id = promptFile.replace(/\.json$/, "");
+      writeFileSync(join(promptsDir, `${id}.answer.json`), JSON.stringify({ answer: "  STOP  " }));
+    }, 50);
+    const result = await future;
+    expect(result).toBeNull();
+  });
+
+  it("times out cleanly if no answer arrives, leaving no prompt file behind", async () => {
+    const promptsDir = _getPromptsDirForTests();
+    await expect(
+      askThroughBoard({ sessionId: "s", question: "?", timeoutMs: 200 })
+    ).rejects.toThrow(/timed out/);
+    // Best-effort cleanup means the prompt file is gone after timeout.
+    expect(readdirSync(promptsDir)).toEqual([]);
+  });
+
+  it("aborts when the AbortSignal fires", async () => {
+    const ctrl = new AbortController();
+    const promptsDir = _getPromptsDirForTests();
+    const future = askThroughBoard({ sessionId: "s", question: "?", timeoutMs: 5000, signal: ctrl.signal });
+    setTimeout(() => ctrl.abort(), 100);
+    await expect(future).rejects.toThrow(/aborted/);
+    expect(readdirSync(promptsDir)).toEqual([]);
+  });
+
+  it("publishes a JSON file with sessionId / question / context / createdAt", async () => {
+    const promptsDir = _getPromptsDirForTests();
+    let snapshot = null;
+    const future = askThroughBoard({
+      sessionId: "abc", question: "Why?", context: { extra: 1 }, timeoutMs: 5000,
+    });
+    setTimeout(() => {
+      const promptFile = readdirSync(promptsDir).find((f) => !f.endsWith(".answer.json"));
+      const id = promptFile.replace(/\.json$/, "");
+      // Snapshot the prompt JSON BEFORE writing the answer (the bridge
+      // deletes the prompt on answer pickup).
+      const fs = require("node:fs");
+      snapshot = JSON.parse(fs.readFileSync(join(promptsDir, promptFile), "utf-8"));
+      writeFileSync(join(promptsDir, `${id}.answer.json`), JSON.stringify({ answer: "ok" }));
+    }, 50);
+    const ans = await future;
+    expect(ans).toBe("ok");
+    expect(snapshot).toMatchObject({
+      sessionId: "abc",
+      question: "Why?",
+      context: { extra: 1 },
+    });
+    expect(snapshot.promptId).toMatch(/^prompt-/);
+    expect(typeof snapshot.createdAt).toBe("string");
+  });
+
+  it("rejects when question is missing", async () => {
+    await expect(askThroughBoard({})).rejects.toThrow(/question is required/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the loop on the dogfooding complaint: when the board's ▶ Run plan button spawns \`kj run --plan\` with \`stdio: 'ignore'\`, any \`askQuestion()\` call (Solomon escalation, max-iter, human conflict) used to hang on a stdin nobody could write to. PR #497 made it abort instead — this PR makes it actually **ASK the user via a modal on the board**.

## Architecture: file-based RPC

The runner writes the prompt as JSON at \`\$KJ_HOME/prompts/<promptId>.json\` and polls every 500 ms for a sibling \`<promptId>.answer.json\`. The board's chokidar watcher sees the prompt → fetches it → pops a modal. User answers → POST → server writes the answer file → runner reads, deletes both, resolves \`askQuestion()\`.

Files instead of a socket because:
- A detached child has no listening port (would mean discovery + auth + cleanup)
- Survives a runner restart: pending prompts stay on disk
- Board's chokidar already watches \`~/.karajan/\`

## Files

- **\`src/utils/board-prompt-bridge.js\`** — \`askThroughBoard({ sessionId, question, context, timeoutMs, signal })\`. 30-min default timeout, AbortSignal, cleans up on every exit path. Returns null on \"stop\" answer; throws on timeout / abort.
- **\`src/commands/run.js\` + \`resume.js\`** — \`createCliAskQuestion\` flips to the bridge when stdin is not a TTY (was: print error + return null).
- **\`packages/hu-board/src/sync.js\`** — chokidar watches \`\$KJ_HOME/prompts/*.json\`; publishes \`{ type: 'prompt', … }\` on add and \`{ type: 'prompt-resolved' }\` on unlink.
- **\`packages/hu-board/src/routes/api.js\`** — \`GET /api/prompts\` (list pending) + \`POST /api/prompts/:promptId/answer\`.
- **\`packages/hu-board/public/app.js\`** — SSE listener routes \`prompt\` events to \`showPromptModal\`. On boot, fetches \`/api/prompts\` so prompts pending before page-load still surface. Modal: question + collapsible context + textarea + Send / Stop. Esc / backdrop close = Stop (best-effort, can never leave the runner blocked). \`prompt-resolved\` closes the modal in case the runner timed out / was killed externally.

## Tests

- **\`tests/board-prompt-bridge.test.js\`** (6): publish + answer round-trip, \"stop\" → null, timeout cleanup, abort, payload shape, missing-question rejected.
- **\`packages/hu-board/tests/prompts-api.test.js\`** (8): GET sorting, ignore \`.answer.json\`, malformed-file tolerated, POST 404 / 400 / happy path, \"stop\" accepted.

3881 parent + 109 board tests green.

## Trio with #498 + #499

| PR | Fix |
|---|---|
| #498 | Sonar auto-discovery (the most common cause of init_error) |
| #499 | Init errors fail-fast, no Solomon ceremony |
| **this** | When a genuine prompt is needed, it surfaces on the board instead of into the void |

User never sees init/preflight rabbit holes, and interactive prompts now actually get answered.

## Test plan

- [x] \`npx vitest run tests/\` → 3881/3881
- [x] \`npx vitest run packages/hu-board/\` → 109/109
- [ ] Manual: \`kj board stop && kj board start\`, \`kj run --plan\` from the board, force a Solomon escalation → modal pops on the board with the question, type answer → run continues