### PR TITLE
fix(board): kj board start returns the prompt (was hanging the terminal)

### DIFF
--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -102,6 +102,12 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
     throw new Error("Failed to spawn HU Board server");
   }
   fs.writeFileSync(PID_FILE, String(child.pid));
+  // Detach for real: `detached: true` only sets up the new session;
+  // without `unref()` the parent's event loop still holds a reference
+  // to the child handle and `kj board start` hangs at the prompt
+  // instead of returning. Pair this with stdio:"ignore" (already set)
+  // to ensure the parent isn't waiting on any of the child's pipes.
+  child.unref();
   return { ok: true, alreadyRunning: false, pid: child.pid, url: buildBoardUrl(port, projectSlug), port };
 }
 

--- a/tests/board-start-detach.test.js
+++ b/tests/board-start-detach.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression for v2.7.5: `kj board start` was leaving the terminal
+// hanging because we spawned the child detached but never called
+// `child.unref()`. The parent's event loop kept a reference to the
+// child handle and never exited, so the prompt didn't return.
+//
+// We can't actually launch the board server in a unit test, so we
+// stub `child_process.spawn` and assert the spawn options + that
+// `unref()` was called on the returned child object.
+
+const unref = vi.fn();
+const child = { pid: 4242, on: vi.fn(), unref };
+const spawn = vi.fn(() => child);
+
+vi.mock("node:child_process", () => ({ spawn }));
+vi.mock("node:net", () => ({
+  default: {
+    createServer: () => ({
+      once: (event, cb) => {
+        if (event === "listening") setImmediate(cb);
+      },
+      listen: () => {},
+      close: (cb) => cb && cb(),
+    }),
+  },
+}));
+
+let tmpHome;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-board-start-"));
+  process.env.KJ_HOME = tmpHome;
+  unref.mockReset();
+  spawn.mockClear();
+  child.on.mockClear();
+  // The module captures KJ_HOME at load time (`const PID_FILE = ...`),
+  // so we must re-import it after each env tweak to pick up the new
+  // tmp dir.
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("startBoard — detaches properly", () => {
+  it("calls child.unref() so the parent process can exit", async () => {
+    const { startBoard } = await import("../src/commands/board.js");
+    await startBoard(4000);
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("spawns with detached:true and stdio:'ignore' (no parent pipe references)", async () => {
+    const { startBoard } = await import("../src/commands/board.js");
+    await startBoard(4000);
+    const opts = spawn.mock.calls[0][2];
+    expect(opts.detached).toBe(true);
+    expect(opts.stdio).toBe("ignore");
+  });
+
+  it("writes the PID file so subsequent kj board status / stop find the child", async () => {
+    const { startBoard } = await import("../src/commands/board.js");
+    const result = await startBoard(4000);
+    expect(result.pid).toBe(4242);
+    const pidPath = join(tmpHome, "hu-board.pid");
+    expect(existsSync(pidPath)).toBe(true);
+    expect(readFileSync(pidPath, "utf-8")).toBe("4242");
+  });
+});


### PR DESCRIPTION
## Summary

\`kj board start\` printed *\"HU Board started (PID …) at http://…\"* and then sat there; the terminal prompt never came back. \`kj board stop\` worked fine. The board server itself was running normally — only the parent CLI process refused to exit.

**Cause**: the spawn used \`detached: true\` + \`stdio: \"ignore\"\` but never called \`child.unref()\`. Without \`unref\`, the parent's event loop keeps a handle on the child and stays alive even though we have nothing to do. Standard \"fire-and-forget detached child\" recipe is **detached + stdio:ignore + unref** — we had two of three.

**Fix**: one line, \`child.unref()\` after the PID file write.

## Tests

\`tests/board-start-detach.test.js\` (3 cases): stubs \`child_process.spawn\` + \`node:net\` to exercise the spawn path without actually launching the board.
- Asserts \`child.unref()\` was called
- Asserts spawn options are detached-friendly (\`detached:true\`, \`stdio:'ignore'\`)
- Asserts PID file is written so subsequent \`kj board status / stop\` find the child

3884 parent tests green.

## Test plan

- [x] \`npx vitest run tests/\` → 3884/3884
- [ ] Manual: \`kj board stop && kj board start\` returns the prompt within ~100ms instead of hanging