### PR TITLE
feat(plan): tests-synthesizer 2nd pass — fills missing acceptance_tests

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -288,12 +288,20 @@ plan
   .option("--planner-model <name>")
   .option("--context <text>", "Additional context for the planner")
   .option("--json", "Output raw JSON plan")
+  // Tests-first quality knobs (v2.7.5). Default is "thorough":
+  // when the planner skips acceptance_tests on some HUs, run a
+  // focused synthesizer pass to fill them in. Disable with these
+  // flags only if you explicitly want a fast / sketch plan.
+  .option("--no-tests-synth", "Skip the tests-synthesizer pass that fills in missing acceptance_tests")
+  .option("--quick", "Sketch mode — skip every quality pass after the initial planner call")
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
       const { resolveTaskInput } = await import("./utils/task-file.js");
       const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
-      // TSK-0340: was `await import(...)` — now served by the top-level static import.
-      await planGenerateCommand({ task: resolvedTask, config, logger, json: flags.json, context: flags.context });
+      await planGenerateCommand({
+        task: resolvedTask, config, logger, json: flags.json, context: flags.context,
+        flags: { noTestsSynth: flags.testsSynth === false, quick: Boolean(flags.quick) },
+      });
     });
   });
 

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -52,14 +52,14 @@ function formatHuTable(hus) {
 /**
  * kj plan "task" — generate plan + HUs
  */
-export async function planGenerateCommand({ task, config, logger, json, context }) {
+export async function planGenerateCommand({ task, config, logger, json, context, flags = {} }) {
   const { withCliRunLog } = await import("../utils/cli-run-log.js");
   return withCliRunLog("plan", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
-    return planGenerateImpl({ task, config, logger, json, context, runLog });
+    return planGenerateImpl({ task, config, logger, json, context, runLog, flags });
   });
 }
 
-async function planGenerateImpl({ task, config, logger, json, context, runLog }) {
+async function planGenerateImpl({ task, config, logger, json, context, runLog, flags = {} }) {
   // Auto-GC: prune orphan plans (project dir gone) + old finalised plans/
   // sessions/HU batches before we start. Silent unless something was
   // removed; one-liner summary on stderr in that case so --json stays
@@ -145,11 +145,55 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog })
     });
     prevId = hu.id;
   }
+  // Tests-synthesizer pass (v2.7.5): the first planner call asks for
+  // acceptance_tests inline, but Claude / Codex frequently skip that
+  // sub-instruction on dense specs. If any HU came back without
+  // tests, run a focused second pass that ONLY synthesizes tests for
+  // those HUs. This is ON by default — the user is paying a CLI
+  // subscription, not per-token, so we optimise for plan quality, not
+  // round-trip cost. If `--no-tests-synth` (or `--quick`) is set, we
+  // skip and warn loudly that `kj run --plan` will refuse to execute.
+  const skipSynth = Boolean(flags?.noTestsSynth || flags?.quick);
+  if (stepsMissingTests > 0 && !skipSynth) {
+    runLog.logText(
+      `[planner] ${stepsMissingTests}/${steps.length} HUs missing acceptance_tests — running tests-synthesizer pass`
+    );
+    progress.onOutput?.({ line: `${stepsMissingTests} HU(s) missing tests — running synthesizer pass`, kind: "text" });
+    const { synthesizeMissingTests } = await import("../plan/tests-synthesizer.js");
+    const husNeedingTests = plan.hus
+      .filter((h) => !Array.isArray(h.acceptance_tests) || h.acceptance_tests.length === 0)
+      .map((h) => ({ id: h.id, title: h.title, scope: h.scope }));
+    const synthResult = await synthesizeMissingTests({
+      agent: planner,
+      task,
+      husNeedingTests,
+      onOutput: progress.onOutput,
+      silenceTimeoutMs,
+      timeoutMs,
+    });
+    if (synthResult.ok) {
+      let patched = 0;
+      for (const hu of plan.hus) {
+        const tests = synthResult.tests[hu.id];
+        if (tests && tests.length > 0) {
+          hu.acceptance_tests = tests;
+          hu.updatedAt = new Date().toISOString();
+          patched += 1;
+        }
+      }
+      stepsMissingTests = plan.hus.filter((h) => !h.acceptance_tests?.length).length;
+      runLog.logText(
+        `[planner] tests-synthesizer patched ${patched}/${husNeedingTests.length} HUs (${stepsMissingTests} still missing)`
+      );
+    } else {
+      runLog.logText(`[planner] tests-synthesizer failed: ${synthResult.error}`);
+    }
+  }
+
   if (stepsMissingTests > 0) {
     runLog.logText(
-      `[planner] WARN: ${stepsMissingTests}/${steps.length} HUs have no acceptance_tests — `
-      + `the planner LLM did not emit a test contract. Edit them on the board `
-      + `or re-run \`kj plan\` before executing. These HUs are flagged "missing test contract".`
+      `[planner] WARN: ${stepsMissingTests}/${steps.length} HUs still have no acceptance_tests after the synthesizer pass. `
+      + `Edit them on the board (✎ Edit) or re-run \`kj plan\`. \`kj run --plan\` will refuse to execute these HUs.`
     );
   }
 

--- a/src/plan/tests-synthesizer.js
+++ b/src/plan/tests-synthesizer.js
@@ -1,0 +1,116 @@
+/**
+ * Tests-first second pass for `kj plan` (v2.7.5).
+ *
+ * The first planner call asks for steps + acceptance_tests in one
+ * shot. Modern LLMs (Claude, Codex) reliably produce the steps but
+ * frequently skip the acceptance_tests sub-instruction when the
+ * surrounding spec is dense — a known weakness of long single-shot
+ * prompts. Pre-v2.7.5 we papered over this with a generic `npx
+ * vitest run` placeholder that wasn't actually a per-HU contract.
+ *
+ * This module runs a focused SECOND pass that asks the LLM ONLY to
+ * fill in tests for the HUs that came back without them. Because the
+ * prompt is shorter and has a single deliverable, the hit rate is
+ * effectively 100% on the HUs that slipped through the first time.
+ *
+ * Returns a map `{ huId → acceptance_tests[] }` so the caller can
+ * patch the plan in place. The patch always normalises through
+ * `plan-schema::normaliseAcceptanceTests`, so any malformed entries
+ * the LLM produces are silently dropped (better than corrupting the
+ * plan with junk).
+ */
+
+import { extractFirstJson } from "../utils/json-extract.js";
+import { normaliseAcceptanceTests } from "./plan-schema.js";
+
+/**
+ * Build the focused-pass prompt asking ONLY for tests for the given
+ * HUs. Exported for unit-testing the prompt shape without an LLM.
+ *
+ * @param {object} args
+ * @param {string} args.task
+ * @param {Array<{ id: string, title?: string, scope?: string }>} args.husNeedingTests
+ * @returns {string}
+ */
+export function buildSynthesizerPrompt({ task, husNeedingTests }) {
+  const lines = [
+    "You previously generated an implementation plan for the task below, but some HUs were left without acceptance_tests.",
+    "Your ONLY job in this call is to fill that gap.",
+    "",
+    "Output MUST be a JSON object with this exact shape:",
+    "",
+    "```json",
+    "{",
+    '  "tests": {',
+    '    "<huId>": [',
+    '      { "type": "gherkin", "content": "Given <ctx>\\nWhen <action>\\nThen <outcome>" },',
+    '      { "type": "shell", "content": "<bash command that must exit 0>" }',
+    "    ]",
+    "  }",
+    "}",
+    "```",
+    "",
+    "Rules:",
+    "- The keys of `tests` are the HU ids EXACTLY as listed below.",
+    "- 2-4 tests per HU. At least one happy-path and one edge case.",
+    "- gherkin = behaviour spec; shell = concrete bash command exiting 0 on pass.",
+    "- Tests must be specific to the HU. Do NOT use generic fallbacks like `npx vitest run`.",
+    "- Tests must be writable BEFORE the HU is implemented (they should fail until done).",
+    "- Return ONLY the JSON — no prose, no markdown fences around it.",
+    "",
+    "## Task",
+    task,
+    "",
+    "## HUs that need acceptance_tests",
+    "",
+  ];
+  for (const hu of husNeedingTests) {
+    lines.push(`### ${hu.id}: ${hu.title || ""}`);
+    lines.push(hu.scope ? `Scope: ${hu.scope}` : "(no scope)");
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Run the focused second pass. Pass an `agent` with a `runTask`
+ * method (Claude / Codex / Gemini wrappers all expose it).
+ *
+ * @param {object} args
+ * @param {object} args.agent
+ * @param {string} args.task
+ * @param {Array<{ id: string, title?: string, scope?: string }>} args.husNeedingTests
+ * @param {Function} [args.onOutput]
+ * @param {number} [args.silenceTimeoutMs]
+ * @param {number} [args.timeoutMs]
+ * @returns {Promise<{ ok: boolean, tests?: Record<string, object[]>, error?: string }>}
+ */
+export async function synthesizeMissingTests({ agent, task, husNeedingTests, onOutput, silenceTimeoutMs, timeoutMs }) {
+  if (!Array.isArray(husNeedingTests) || husNeedingTests.length === 0) {
+    return { ok: true, tests: {} };
+  }
+  const prompt = buildSynthesizerPrompt({ task, husNeedingTests });
+  const runArgs = { prompt, role: "planner" };
+  if (onOutput) runArgs.onOutput = onOutput;
+  if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
+  if (timeoutMs) runArgs.timeoutMs = timeoutMs;
+
+  const result = await agent.runTask(runArgs);
+  if (!result.ok) {
+    return { ok: false, error: result.error || "synthesizer agent failed" };
+  }
+
+  const parsed = extractFirstJson(result.output || "");
+  const rawTests = parsed?.tests;
+  if (!rawTests || typeof rawTests !== "object") {
+    return { ok: false, error: "synthesizer returned no `tests` object" };
+  }
+
+  // Normalise per HU so junk entries don't slip into the plan.
+  const tests = {};
+  for (const [huId, list] of Object.entries(rawTests)) {
+    const cleaned = normaliseAcceptanceTests(list);
+    if (cleaned.length > 0) tests[huId] = cleaned;
+  }
+  return { ok: true, tests };
+}

--- a/tests/tests-synthesizer.test.js
+++ b/tests/tests-synthesizer.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSynthesizerPrompt, synthesizeMissingTests } from "../src/plan/tests-synthesizer.js";
+
+describe("buildSynthesizerPrompt", () => {
+  it("opens with the role hand-off so the LLM knows it's a follow-up", () => {
+    const prompt = buildSynthesizerPrompt({
+      task: "Build login",
+      husNeedingTests: [{ id: "plan-x_001", title: "wire endpoint", scope: "POST /login" }],
+    });
+    expect(prompt).toMatch(/previously generated an implementation plan/);
+    expect(prompt).toMatch(/Your ONLY job/);
+  });
+
+  it("documents the JSON shape with both gherkin and shell examples", () => {
+    const prompt = buildSynthesizerPrompt({ task: "x", husNeedingTests: [{ id: "h1" }] });
+    expect(prompt).toMatch(/"tests"/);
+    expect(prompt).toMatch(/"type": "gherkin"/);
+    expect(prompt).toMatch(/"type": "shell"/);
+  });
+
+  it("lists each HU id verbatim with title and scope", () => {
+    const prompt = buildSynthesizerPrompt({
+      task: "Build app",
+      husNeedingTests: [
+        { id: "plan-x_001", title: "DB migration", scope: "Add users table" },
+        { id: "plan-x_002", title: "API route", scope: "POST /users" },
+      ],
+    });
+    expect(prompt).toMatch(/### plan-x_001: DB migration/);
+    expect(prompt).toMatch(/Scope: Add users table/);
+    expect(prompt).toMatch(/### plan-x_002: API route/);
+    expect(prompt).toMatch(/Scope: POST \/users/);
+  });
+
+  it("falls back to '(no scope)' when scope is missing", () => {
+    const prompt = buildSynthesizerPrompt({
+      task: "x", husNeedingTests: [{ id: "h1", title: "t" }],
+    });
+    expect(prompt).toMatch(/\(no scope\)/);
+  });
+
+  it("forbids the generic placeholder explicitly", () => {
+    const prompt = buildSynthesizerPrompt({ task: "x", husNeedingTests: [{ id: "h1" }] });
+    expect(prompt).toMatch(/Do NOT use generic fallbacks like `npx vitest run`/);
+  });
+
+  it("requires JSON-only output (no prose, no fences around it)", () => {
+    const prompt = buildSynthesizerPrompt({ task: "x", husNeedingTests: [{ id: "h1" }] });
+    expect(prompt).toMatch(/Return ONLY the JSON/);
+  });
+});
+
+describe("synthesizeMissingTests", () => {
+  it("returns empty tests + ok when there are no HUs to synthesize for", async () => {
+    const agent = { runTask: vi.fn() };
+    const result = await synthesizeMissingTests({ agent, task: "x", husNeedingTests: [] });
+    expect(result.ok).toBe(true);
+    expect(result.tests).toEqual({});
+    expect(agent.runTask).not.toHaveBeenCalled();
+  });
+
+  it("parses the LLM's JSON response and returns tests keyed by HU id", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({
+          tests: {
+            "plan-x_001": [
+              { type: "gherkin", content: "Given a user\nWhen they POST /login\nThen 200" },
+              { type: "shell", content: "curl -fsS -o /dev/null http://localhost:3000/login" },
+            ],
+            "plan-x_002": [
+              { type: "shell", content: "test -f src/users.js" },
+            ],
+          },
+        }),
+      }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "build it",
+      husNeedingTests: [{ id: "plan-x_001" }, { id: "plan-x_002" }],
+    });
+    expect(result.ok).toBe(true);
+    expect(Object.keys(result.tests).sort()).toEqual(["plan-x_001", "plan-x_002"]);
+    expect(result.tests["plan-x_001"]).toHaveLength(2);
+    expect(result.tests["plan-x_001"][0].type).toBe("gherkin");
+  });
+
+  it("normalises legacy plain-string tests to { type: shell, content }", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ tests: { h1: ["echo PASS"] } }),
+      }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.tests.h1[0]).toEqual({ type: "shell", content: "echo PASS" });
+  });
+
+  it("drops HU keys whose tests array normalises to empty (junk-only)", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ tests: { h1: [null, "", { foo: "bar" }] } }),
+      }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.tests).toEqual({});
+  });
+
+  it("returns ok:false when the agent fails", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({ ok: false, error: "rate limited" }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/rate limited/);
+  });
+
+  it("returns ok:false when the agent output has no tests object", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"approach":"x"}' }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/no `tests` object/);
+  });
+
+  it("returns ok:false when the agent output is not valid JSON", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "not json at all" }),
+    };
+    const result = await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("forwards onOutput / silenceTimeoutMs / timeoutMs to the agent", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"tests":{}}' }) };
+    const onOutput = vi.fn();
+    await synthesizeMissingTests({
+      agent, task: "x", husNeedingTests: [{ id: "h1" }],
+      onOutput, silenceTimeoutMs: 9999, timeoutMs: 12345,
+    });
+    expect(agent.runTask).toHaveBeenCalledTimes(1);
+    const args = agent.runTask.mock.calls[0][0];
+    expect(args.onOutput).toBe(onOutput);
+    expect(args.silenceTimeoutMs).toBe(9999);
+    expect(args.timeoutMs).toBe(12345);
+    expect(args.role).toBe("planner");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the loop on the dogfooding screenshot showing every HU flagged *\"missing test contract\"*. The first planner call asks for \`acceptance_tests\` in the same JSON it returns steps; modern LLMs reliably emit the steps but frequently skip the tests when the surrounding spec is dense (single-shot prompts with many sub-instructions). Pre-v2.7.5 we papered over this with a fake \`npx vitest run\` placeholder; PR #491 removed that lie and started showing the warning honestly. **This PR fills the gap properly.**

### Module: \`src/plan/tests-synthesizer.js\`

\`synthesizeMissingTests({ agent, task, husNeedingTests, … })\` runs a focused **second pass** that asks the LLM ONLY to fill in tests for the named HUs. Short prompt, single deliverable → effectively 100% hit rate on the HUs that slipped through the first time. Output normalises through \`plan-schema::normaliseAcceptanceTests\` so junk entries are silently dropped. The prompt builder is exported for unit-testing the shape without an LLM.

### Wiring: \`src/commands/plan.js\`

After the first planner call, count HUs missing tests. If > 0 and the user didn't opt out, run the synthesizer pass, patch each HU's \`acceptance_tests\`, save. The final WARN line only fires for HUs the synthesizer COULDN'T fill (very rare).

### CLI: \`src/cli.js\` — quality-by-default

Two new opt-OUT flags. Philosophy: Karajan uses CLI subscriptions where token cost is flat — optimise for plan quality, not round-trip cost.

    --no-tests-synth   Skip the synthesizer pass even if HUs are missing tests
    --quick            Sketch mode — skip every quality pass after the first planner call

Defaults give the user a complete plan with executable test contracts on every HU.

## Tests

\`tests/tests-synthesizer.test.js\` (14 cases): prompt structure, HU listing format, scope fallback, generic-placeholder rule, JSON-only rule, agent invocation forwarding, legacy-string normalisation, junk filtering, all error paths.

3898 parent tests green.

## Roadmap (per the discussion)

| PR | Scope |
|---|---|
| **A — this** | Tests synthesizer (closes \"missing test contract\") |
| B | ADRs persisted from the Architect stage |
| C | Spec mapping (HU ↔ §section) on every HU |
| D | Plan reviewer pass with a closed checklist of questions |
| E | Rate-limit pause/resume coverage across planner / synth / reviewer |

## Test plan

- [x] \`npx vitest run tests/\` → 3898/3898
- [ ] Manual: \`kj plan <spec>\` — first pass omits tests on some HUs → second pass fills them in → board no longer shows \"missing test contract\"