### PR TITLE
feat(architect): persist ADRs (Nygard format) from architect tradeoffs

### DIFF
--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -91,6 +91,28 @@ export async function architectCommand({ task, config, logger, context, json }) 
     } else {
       console.log(result.output);
     }
+
+    // Persist ADRs from the architect's tradeoffs[] (v2.7.5). One ADR
+    // per tradeoff in Nygard format under `~/.kj/plans/_loose/adrs/`.
+    // Coder/reviewer in subsequent runs can pull the active ADRs into
+    // their prompt for context — done in a follow-up PR.
+    if (parsed?.architecture && config?.projectDir) {
+      try {
+        const { persistAdrsFromArchitecture } = await import("../plan/adr-generator.js");
+        const { adrs, paths } = await persistAdrsFromArchitecture({
+          projectDir: config.projectDir,
+          planId: null,                  // standalone architect → "_loose" bucket
+          architecture: parsed.architecture,
+        });
+        if (paths.length > 0) {
+          console.log(`\n${adrs.length} ADR${adrs.length === 1 ? "" : "s"} written:`);
+          for (const p of paths) console.log(`  - ${p}`);
+        }
+      } catch (err) {
+        logger.warn(`ADR write skipped: ${err.message}`);
+      }
+    }
+
     logger.info("Architect completed.");
     return { ok: true };
   });

--- a/src/plan/adr-generator.js
+++ b/src/plan/adr-generator.js
@@ -1,0 +1,170 @@
+/**
+ * Architecture Decision Records (ADRs) — distill the architect role's
+ * tradeoffs[] output into the canonical "Context · Decision ·
+ * Consequences · Status" markdown format.
+ *
+ * Why ADRs as a first-class artifact (v2.7.5):
+ *   - The architect already analyses the task and produces a
+ *     `tradeoffs[]` list with `{ decision, rationale, alternatives }`.
+ *     That data is exactly what an ADR captures, just unformatted.
+ *   - An ADR persists the WHY of an architectural choice. Coder and
+ *     reviewer in the next `kj run` can pull the active ADRs into
+ *     their prompt for context.
+ *   - It's also a deliverable in its own right — projects benefit
+ *     from a `docs/adr/` history regardless of Karajan.
+ *
+ * Storage: per-plan under `~/.kj/plans/<slug>/adrs/<adr-id>.md` (so
+ * an ADR's lifecycle matches its plan's). When the orchestrator runs
+ * a plan, the coder gets the ADRs as context. When a plan is removed
+ * (`kj plan delete`) the ADRs go with it.
+ *
+ * Format follows Michael Nygard's classic structure (the most widely
+ * adopted in the industry, used by GitHub, Spotify, AWS docs, etc.).
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { plansDir } from "./plan-store.js";
+
+const VALID_ADR_STATUSES = new Set(["proposed", "accepted", "deprecated", "superseded"]);
+
+/**
+ * Slugify a decision title into a filesystem-safe ADR id fragment.
+ * "Use SQLite for plan storage" → "use-sqlite-for-plan-storage".
+ */
+function slugifyTitle(title) {
+  return String(title || "")
+    .toLowerCase()
+    // Decompose accents (NFD) then strip combining marks so "versión"
+    // → "version", keeping the ADR id ASCII-only and filesystem-safe.
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80) || "untitled";
+}
+
+/**
+ * Turn the architect's `architecture.tradeoffs[]` into an array of
+ * ADR objects. Each tradeoff carries `{ decision, rationale,
+ * alternatives }`; we map them to the four ADR sections plus
+ * metadata.
+ *
+ * Numbering: 1-based, zero-padded to 4 digits ("0001-…"). Stable per
+ * call — callers should treat `id` as opaque (filename) and `number`
+ * as ordinal.
+ *
+ * @param {object} architecture - parsed architect output
+ * @param {object} [opts]
+ * @param {string} [opts.status] - default "accepted" (architect runs imply the decision is taken)
+ * @returns {Array<{ number: number, id: string, title: string, status: string,
+ *                   context: string, decision: string, consequences: string,
+ *                   alternatives: string[] }>}
+ */
+export function extractAdrsFromArchitecture(architecture, opts = {}) {
+  const tradeoffs = Array.isArray(architecture?.tradeoffs) ? architecture.tradeoffs : [];
+  const status = VALID_ADR_STATUSES.has(opts.status) ? opts.status : "accepted";
+  const adrs = [];
+  let n = 0;
+  for (const t of tradeoffs) {
+    if (!t || (typeof t !== "object" && typeof t !== "string")) continue;
+    const title = typeof t === "string" ? t : (t.decision || t.title || "");
+    if (!title.trim()) continue;
+    n += 1;
+    const number = n;
+    const slug = slugifyTitle(title);
+    const id = `${String(number).padStart(4, "0")}-${slug}`;
+    adrs.push({
+      number,
+      id,
+      title: title.trim(),
+      status,
+      context: typeof t === "object" && t.context ? String(t.context) : "",
+      decision: typeof t === "object" && t.decision ? String(t.decision) : title.trim(),
+      consequences: typeof t === "object" && t.rationale ? String(t.rationale) : "",
+      alternatives: typeof t === "object" && Array.isArray(t.alternatives) ? t.alternatives.map(String) : [],
+    });
+  }
+  return adrs;
+}
+
+/**
+ * Render an ADR to markdown using Nygard's format. Newline-stable so
+ * tests can do exact-match assertions.
+ *
+ * @param {object} adr
+ * @param {object} [opts]
+ * @param {Date} [opts.date]
+ * @returns {string}
+ */
+export function renderAdrMarkdown(adr, opts = {}) {
+  const date = (opts.date || new Date()).toISOString().slice(0, 10);   // YYYY-MM-DD
+  const lines = [
+    `# ${String(adr.number).padStart(4, "0")}. ${adr.title}`,
+    "",
+    `**Status:** ${adr.status}  `,
+    `**Date:** ${date}  `,
+    "",
+    "## Context",
+    "",
+    adr.context || "_(architect role did not provide an explicit context — see Decision below.)_",
+    "",
+    "## Decision",
+    "",
+    adr.decision,
+    "",
+  ];
+  if (adr.alternatives?.length > 0) {
+    lines.push("**Alternatives considered:**");
+    lines.push("");
+    for (const alt of adr.alternatives) lines.push(`- ${alt}`);
+    lines.push("");
+  }
+  lines.push(
+    "## Consequences",
+    "",
+    adr.consequences || "_(no consequences captured by the architect role.)_",
+    ""
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Write the ADRs to disk under the plan's adrs/ directory. Returns
+ * the list of absolute paths written so callers can surface them in
+ * the CLI output.
+ *
+ * @param {object} args
+ * @param {string} args.projectDir
+ * @param {string} args.planId        - used to scope ADRs to a plan; falls
+ *                                      back to "_loose" when this came
+ *                                      from `kj architect` standalone
+ * @param {Array} args.adrs           - output of extractAdrsFromArchitecture
+ * @returns {Promise<string[]>} absolute paths written
+ */
+export async function writeAdrsToDisk({ projectDir, planId, adrs }) {
+  if (!Array.isArray(adrs) || adrs.length === 0) return [];
+  if (!projectDir) throw new Error("writeAdrsToDisk: projectDir is required");
+  const planSlug = planId || "_loose";
+  const dir = join(plansDir(projectDir), planSlug, "adrs");
+  await mkdir(dir, { recursive: true });
+  const paths = [];
+  for (const adr of adrs) {
+    const filePath = join(dir, `${adr.id}.md`);
+    await writeFile(filePath, renderAdrMarkdown(adr), "utf-8");
+    paths.push(filePath);
+  }
+  return paths;
+}
+
+/**
+ * Convenience: extract + write in one call. Used by `kj architect`
+ * and (later) the orchestrator's architect stage.
+ */
+export async function persistAdrsFromArchitecture({ projectDir, planId, architecture }) {
+  const adrs = extractAdrsFromArchitecture(architecture);
+  const paths = await writeAdrsToDisk({ projectDir, planId, adrs });
+  return { adrs, paths };
+}

--- a/tests/adr-generator.test.js
+++ b/tests/adr-generator.test.js
@@ -1,0 +1,210 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  extractAdrsFromArchitecture,
+  renderAdrMarkdown,
+  writeAdrsToDisk,
+  persistAdrsFromArchitecture,
+} from "../src/plan/adr-generator.js";
+
+let tmpHome;
+let tmpProject;
+let savedHome;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-adr-"));
+  tmpProject = mkdtempSync(join(tmpdir(), "kj-adr-project-"));
+  savedHome = process.env.KJ_HOME;
+  process.env.KJ_HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = savedHome;
+  rmSync(tmpHome, { recursive: true, force: true });
+  rmSync(tmpProject, { recursive: true, force: true });
+});
+
+describe("extractAdrsFromArchitecture", () => {
+  it("returns [] when there are no tradeoffs", () => {
+    expect(extractAdrsFromArchitecture({})).toEqual([]);
+    expect(extractAdrsFromArchitecture({ tradeoffs: [] })).toEqual([]);
+    expect(extractAdrsFromArchitecture(null)).toEqual([]);
+  });
+
+  it("creates one ADR per tradeoff with 4-digit zero-padded ids", () => {
+    const adrs = extractAdrsFromArchitecture({
+      tradeoffs: [
+        { decision: "Use SQLite for storage", rationale: "Zero-config, file-based" },
+        { decision: "Use Express 5 for HTTP" },
+      ],
+    });
+    expect(adrs).toHaveLength(2);
+    expect(adrs[0].id).toBe("0001-use-sqlite-for-storage");
+    expect(adrs[1].id).toBe("0002-use-express-5-for-http");
+    expect(adrs[0].number).toBe(1);
+    expect(adrs[1].number).toBe(2);
+  });
+
+  it("default status is 'accepted' (architect ran → decision is taken)", () => {
+    const [adr] = extractAdrsFromArchitecture({ tradeoffs: [{ decision: "x" }] });
+    expect(adr.status).toBe("accepted");
+  });
+
+  it("respects the status override when provided + valid", () => {
+    const [adr] = extractAdrsFromArchitecture(
+      { tradeoffs: [{ decision: "x" }] },
+      { status: "proposed" }
+    );
+    expect(adr.status).toBe("proposed");
+  });
+
+  it("rejects invalid status overrides and falls back to 'accepted'", () => {
+    const [adr] = extractAdrsFromArchitecture(
+      { tradeoffs: [{ decision: "x" }] },
+      { status: "invalid-status" }
+    );
+    expect(adr.status).toBe("accepted");
+  });
+
+  it("captures alternatives when the architect provides them", () => {
+    const [adr] = extractAdrsFromArchitecture({
+      tradeoffs: [{ decision: "Use Vitest", rationale: "Fast", alternatives: ["Jest", "Mocha"] }],
+    });
+    expect(adr.alternatives).toEqual(["Jest", "Mocha"]);
+  });
+
+  it("accepts plain-string tradeoffs (degraded shape)", () => {
+    const [adr] = extractAdrsFromArchitecture({ tradeoffs: ["Use HTTP/2"] });
+    expect(adr.title).toBe("Use HTTP/2");
+    expect(adr.decision).toBe("Use HTTP/2");
+  });
+
+  it("skips empty / whitespace-only tradeoffs without bumping the number", () => {
+    const adrs = extractAdrsFromArchitecture({
+      tradeoffs: [
+        { decision: "  " },
+        "",
+        null,
+        { decision: "Real one" },
+      ],
+    });
+    expect(adrs).toHaveLength(1);
+    expect(adrs[0].number).toBe(1);
+  });
+
+  it("slugifies titles with non-ASCII characters cleanly", () => {
+    const [adr] = extractAdrsFromArchitecture({
+      tradeoffs: [{ decision: "Usar PostgreSQL — versión 16" }],
+    });
+    expect(adr.id).toMatch(/^0001-/);
+    expect(adr.id).not.toMatch(/[^a-z0-9-]/);
+  });
+});
+
+describe("renderAdrMarkdown", () => {
+  it("uses the canonical Nygard format with a header, Status/Date, Context, Decision, Consequences", () => {
+    const md = renderAdrMarkdown({
+      number: 7, id: "0007-x", title: "Use SQLite", status: "accepted",
+      context: "We need plan storage.", decision: "Use SQLite.",
+      consequences: "No external DB.", alternatives: [],
+    }, { date: new Date("2026-04-25T00:00:00Z") });
+    expect(md).toMatch(/^# 0007\. Use SQLite\n/);
+    expect(md).toMatch(/\*\*Status:\*\* accepted/);
+    expect(md).toMatch(/\*\*Date:\*\* 2026-04-25/);
+    expect(md).toMatch(/## Context\n\nWe need plan storage\./);
+    expect(md).toMatch(/## Decision\n\nUse SQLite\./);
+    expect(md).toMatch(/## Consequences\n\nNo external DB\./);
+  });
+
+  it("renders an Alternatives section as a bullet list when present", () => {
+    const md = renderAdrMarkdown({
+      number: 1, id: "x", title: "t", status: "accepted",
+      decision: "d", context: "c", consequences: "cons",
+      alternatives: ["A", "B", "C"],
+    });
+    expect(md).toMatch(/\*\*Alternatives considered:\*\*\n\n- A\n- B\n- C/);
+  });
+
+  it("falls back to placeholder text when context / consequences are missing", () => {
+    const md = renderAdrMarkdown({
+      number: 1, id: "x", title: "t", status: "accepted", decision: "d",
+    });
+    expect(md).toMatch(/_\(architect role did not provide an explicit context/);
+    expect(md).toMatch(/_\(no consequences captured by the architect role\.\)_/);
+  });
+});
+
+describe("writeAdrsToDisk", () => {
+  it("creates the adrs/ subdir under the plan dir and writes one file per ADR", async () => {
+    const adrs = [
+      { number: 1, id: "0001-a", title: "A", status: "accepted", decision: "d1", context: "c", consequences: "x", alternatives: [] },
+      { number: 2, id: "0002-b", title: "B", status: "accepted", decision: "d2", context: "c", consequences: "x", alternatives: [] },
+    ];
+    const paths = await writeAdrsToDisk({
+      projectDir: tmpProject,
+      planId: "plan-test",
+      adrs,
+    });
+    expect(paths).toHaveLength(2);
+    for (const p of paths) {
+      expect(existsSync(p)).toBe(true);
+      expect(p).toMatch(/\/plans\/[^/]+\/plan-test\/adrs\/000[12]-[ab]\.md$/);
+      expect(readFileSync(p, "utf-8")).toMatch(/# 000[12]\./);
+    }
+  });
+
+  it("uses the '_loose' bucket when planId is missing (kj architect standalone)", async () => {
+    const adrs = [{ number: 1, id: "0001-x", title: "X", status: "accepted", decision: "d", context: "", consequences: "", alternatives: [] }];
+    const [filePath] = await writeAdrsToDisk({
+      projectDir: tmpProject,
+      planId: null,
+      adrs,
+    });
+    expect(filePath).toMatch(/\/_loose\/adrs\/0001-x\.md$/);
+  });
+
+  it("returns [] without touching disk when adrs is empty", async () => {
+    const paths = await writeAdrsToDisk({ projectDir: tmpProject, planId: "p", adrs: [] });
+    expect(paths).toEqual([]);
+  });
+
+  it("requires a projectDir", async () => {
+    await expect(
+      writeAdrsToDisk({ projectDir: "", planId: "p", adrs: [{ number: 1, id: "x", title: "t", status: "accepted", decision: "d", context: "", consequences: "", alternatives: [] }] })
+    ).rejects.toThrow(/projectDir is required/);
+  });
+});
+
+describe("persistAdrsFromArchitecture (extract + write)", () => {
+  it("end-to-end: tradeoffs[] → markdown files on disk", async () => {
+    const result = await persistAdrsFromArchitecture({
+      projectDir: tmpProject,
+      planId: null,
+      architecture: {
+        tradeoffs: [
+          { decision: "Pick Vitest", rationale: "Fast + ESM-native", alternatives: ["Jest"] },
+          { decision: "Use chokidar for watching", rationale: "Cross-platform" },
+        ],
+      },
+    });
+    expect(result.adrs).toHaveLength(2);
+    expect(result.paths).toHaveLength(2);
+    const dir = result.paths[0].replace(/\/[^/]+$/, "");
+    const files = readdirSync(dir).sort();
+    expect(files).toEqual(["0001-pick-vitest.md", "0002-use-chokidar-for-watching.md"]);
+    const md = readFileSync(result.paths[0], "utf-8");
+    expect(md).toMatch(/Fast \+ ESM-native/);
+  });
+
+  it("end-to-end with no tradeoffs: returns empty arrays without writing", async () => {
+    const result = await persistAdrsFromArchitecture({
+      projectDir: tmpProject,
+      planId: "p",
+      architecture: { tradeoffs: [] },
+    });
+    expect(result).toEqual({ adrs: [], paths: [] });
+  });
+});


### PR DESCRIPTION
## Summary

PR B of the multi-step planning roadmap. The architect role already produces a \`tradeoffs[]\` list with \`{ decision, rationale, alternatives }\` — exactly what an ADR captures, just unformatted. This PR distills that into proper ADR files on disk so:

1. The user gets a \`docs/adr\`-style history they can read / commit
2. Coder + reviewer in subsequent runs can pull the active ADRs into their prompt for context (wired in a follow-up PR)
3. ADRs scope to the plan they came from — \`kj plan delete\` will clean them up alongside the plan JSON

### Module: \`src/plan/adr-generator.js\`

- **\`extractAdrsFromArchitecture(architecture, opts)\`** — turns tradeoffs[] into ADR objects with 4-digit zero-padded ids (\`0001-use-vitest\`). Default status \`accepted\`. Accepts plain-string tradeoffs as a degraded-shape fallback. Skips empty entries without bumping the number.
- **\`renderAdrMarkdown(adr, opts)\`** — Nygard format (the de-facto industry standard): header, Status + Date, Context, Decision (+ Alternatives when present), Consequences. Falls back to italic placeholder text rather than dropping a section.
- **\`writeAdrsToDisk\`** — writes under \`~/.kj/plans/<slug>/<planId>/adrs/<adr-id>.md\`. Uses \`_loose\` bucket when \`planId\` is null (\`kj architect\` standalone).
- **\`persistAdrsFromArchitecture\`** — convenience: extract + write in one call.

Slugify is ASCII-only via NFD-decompose + strip-combining-marks so *\"Usar PostgreSQL — versión 16\"* becomes \`0001-usar-postgresql-version-16\` (filesystem-safe everywhere).

### Wiring: \`src/commands/architect.js\`

After the architect call succeeds, persist ADRs and surface paths in the CLI output. Failures warn but don't abort.

## Tests

\`tests/adr-generator.test.js\` (18) — empty/null, numbering/padding/slug, default+override+invalid status, alternatives, string-fallback, whitespace-skip, ASCII-only slug, markdown sections + bullets + placeholders, disk write per-plan + \`_loose\`, projectDir requirement, end-to-end.

3916 parent tests green.

## Roadmap

| | Scope | Status |
|---|---|---|
| A | Tests synthesizer | ✅ #502 |
| **B** | **ADRs from Architect** | **this** |
| C | Spec mapping (HU ↔ §section) | next |
| D | Plan reviewer (closed checklist) | next |
| E | Rate-limit pause/resume coverage | follow-up |
| F | Wire ADRs into coder/reviewer prompt context | follow-up |

## Test plan

- [x] \`npx vitest run tests/\` → 3916/3916
- [ ] Manual: \`kj architect <task>\` produces \`~/.kj/plans/<slug>/_loose/adrs/0001-…md\` with Nygard-format markdown