### PR TITLE
feat(plan): plan reviewer pass — closed-checklist, no scope creep

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -293,6 +293,7 @@ plan
   // focused synthesizer pass to fill them in. Disable with these
   // flags only if you explicitly want a fast / sketch plan.
   .option("--no-tests-synth", "Skip the tests-synthesizer pass that fills in missing acceptance_tests")
+  .option("--no-plan-review", "Skip the high-level plan reviewer pass (gaps / deps / overlap / order)")
   .option("--quick", "Sketch mode — skip every quality pass after the initial planner call")
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
@@ -300,7 +301,11 @@ plan
       const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
       await planGenerateCommand({
         task: resolvedTask, config, logger, json: flags.json, context: flags.context,
-        flags: { noTestsSynth: flags.testsSynth === false, quick: Boolean(flags.quick) },
+        flags: {
+          noTestsSynth: flags.testsSynth === false,
+          noPlanReview: flags.planReview === false,
+          quick: Boolean(flags.quick),
+        },
       });
     });
   });

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -200,6 +200,37 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     );
   }
 
+  // Plan reviewer pass (PR D). Asks five closed-ended questions
+  // about the just-generated plan: missing HUs, missing deps, scope
+  // overlap, parallelisable groups, order issues. Output is purely
+  // advisory — we surface the findings to the user and they decide
+  // whether to apply them. Skipped when --no-plan-review or --quick.
+  const skipReview = Boolean(flags?.noPlanReview || flags?.quick);
+  if (plan.hus.length > 0 && !skipReview) {
+    runLog.logText("[planner] running plan reviewer pass");
+    progress.onOutput?.({ line: "Reviewing the plan for gaps / overlaps / order issues", kind: "text" });
+    const { reviewPlan, findingsCount } = await import("../plan/plan-reviewer.js");
+    const review = await reviewPlan({
+      agent: planner,
+      task,
+      hus: plan.hus,
+      onOutput: progress.onOutput,
+      silenceTimeoutMs,
+      timeoutMs,
+    });
+    if (review.ok) {
+      plan.review = review.findings;
+      const count = findingsCount(review.findings);
+      runLog.logText(
+        count > 0
+          ? `[planner] reviewer surfaced ${count} item(s): ${review.findings.summary || "(see plan.review for details)"}`
+          : `[planner] reviewer found nothing actionable: ${review.findings.summary || "OK"}`
+      );
+    } else {
+      runLog.logText(`[planner] reviewer pass failed (non-blocking): ${review.error}`);
+    }
+  }
+
   const planId = await savePlan(projectDir, plan);
   const { plansDir } = await import("../plan/plan-store.js");
   const path = await import("node:path");
@@ -229,6 +260,23 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   // Now we just say: inspect, then run. The board is the recommended UI.
   console.log(`\nPlan saved: ${planId} (${plan.hus.length} HUs, status: ${plan.status})`);
   console.log(`         → ${planPath}`);
+  // Reviewer findings: print a short summary so the user knows
+  // at-a-glance whether the plan needs attention. Full details live
+  // in `plan.review` and `kj plan show <id>` renders them.
+  if (plan.review) {
+    const r = plan.review;
+    const counts = [
+      r.missing_hus?.length ? `${r.missing_hus.length} missing HU(s)` : null,
+      r.missing_dependencies?.length ? `${r.missing_dependencies.length} missing dep(s)` : null,
+      r.scope_overlaps?.length ? `${r.scope_overlaps.length} overlap(s)` : null,
+      r.order_issues?.length ? `${r.order_issues.length} order issue(s)` : null,
+    ].filter(Boolean);
+    if (counts.length === 0) {
+      console.log(`Reviewer: ✓ ${r.summary || "no issues"}`);
+    } else {
+      console.log(`Reviewer flagged: ${counts.join(", ")} — see \`kj plan show ${planId}\``);
+    }
+  }
   console.log("");
   console.log(`Inspect: kj plan show ${planId}`);
   console.log(`Run:     kj run --plan ${planId} "${task.slice(0, 40)}..."`);
@@ -311,6 +359,53 @@ export async function planShowCommand({ config, planId }) {
     console.log(formatHuTable(plan.hus));
   } else {
     console.log("\nNo HUs defined. Add with: kj plan add-hu " + planId);
+  }
+
+  // Reviewer findings (PR D). When the planner ran with the plan
+  // reviewer pass enabled, plan.review carries advisory findings —
+  // missing HUs, missing deps, scope overlaps, parallelisable
+  // groups, order issues. Each section only renders when non-empty
+  // so a clean plan stays clean on screen.
+  if (plan.review) {
+    const r = plan.review;
+    const sections = [];
+    if (r.missing_hus?.length) {
+      sections.push(`### Missing HUs (${r.missing_hus.length})`);
+      for (const m of r.missing_hus) {
+        sections.push(`- §${m.spec_section}: ${m.rationale}`);
+      }
+    }
+    if (r.missing_dependencies?.length) {
+      sections.push(`\n### Missing dependencies (${r.missing_dependencies.length})`);
+      for (const d of r.missing_dependencies) {
+        sections.push(`- ${d.from} should depend on ${d.on} — ${d.rationale}`);
+      }
+    }
+    if (r.scope_overlaps?.length) {
+      sections.push(`\n### Scope overlaps (${r.scope_overlaps.length})`);
+      for (const o of r.scope_overlaps) {
+        sections.push(`- ${o.between.join(" ↔ ")}: ${o.rationale}`);
+      }
+    }
+    if (r.parallelisable_groups?.length) {
+      sections.push(`\n### Parallelisable groups (${r.parallelisable_groups.length})`);
+      for (const g of r.parallelisable_groups) {
+        sections.push(`- ${g.hus.join(" + ")}${g.rationale ? ` — ${g.rationale}` : ""}`);
+      }
+    }
+    if (r.order_issues?.length) {
+      sections.push(`\n### Order issues (${r.order_issues.length})`);
+      for (const o of r.order_issues) {
+        sections.push(`- ${o.hus.join(", ")} (${o.issue}): ${o.rationale}`);
+      }
+    }
+    if (sections.length > 0) {
+      console.log("\n## Reviewer findings");
+      if (r.summary) console.log(`_${r.summary}_\n`);
+      console.log(sections.join("\n"));
+    } else if (r.summary) {
+      console.log(`\n## Reviewer findings\n_${r.summary}_`);
+    }
   }
 }
 

--- a/src/plan/plan-reviewer.js
+++ b/src/plan/plan-reviewer.js
@@ -1,0 +1,199 @@
+/**
+ * Plan reviewer — third pass after `kj plan` (PR D of the v2.7.5
+ * tests-first roadmap). Asks the planner LLM five concrete
+ * questions about the plan it just produced. Returns structured
+ * findings, NOT free-form prose.
+ *
+ * The questions are intentionally closed-ended:
+ *
+ *   1. **Missing HUs** — sections of the SPEC the plan doesn't cover.
+ *      (Catches "the planner forgot module X".)
+ *   2. **Missing dependencies** — pairs of HUs that should have a
+ *      `blocked_by` edge but don't.
+ *      (Catches "HU 4 needs the schema HU 2 produces".)
+ *   3. **Scope overlap** — pairs of HUs that touch the same scope.
+ *      (Catches "the planner split one piece of work into two HUs
+ *      that step on each other".)
+ *   4. **Parallelisable** — sets of HUs that have no inter-deps and
+ *      could run side-by-side.
+ *      (Surface for the user, not auto-applied — `kj run --plan`
+ *      runs serially today.)
+ *   5. **Order issues** — HUs whose `blocked_by` chain is wrong or
+ *      circular.
+ *
+ * The output is purely advisory. The reviewer NEVER edits the plan.
+ * It reports findings; the user decides whether to apply them via
+ * the board's edit modal or another `kj plan` pass.
+ *
+ * Free-form "could we add logging?" suggestions are explicitly out
+ * of scope to avoid scope-creep noise — see the prompt rules.
+ */
+
+import { extractFirstJson } from "../utils/json-extract.js";
+
+/**
+ * Build the focused review prompt. Exported for unit-testing the
+ * shape without an LLM in the loop.
+ *
+ * @param {object} args
+ * @param {string} args.task
+ * @param {Array<object>} args.hus
+ * @returns {string}
+ */
+export function buildReviewerPrompt({ task, hus }) {
+  const huSummary = hus.map((h, i) => {
+    const deps = Array.isArray(h.blocked_by) && h.blocked_by.length > 0
+      ? ` ← blocked_by: ${h.blocked_by.join(", ")}`
+      : "";
+    const spec = h.spec_section ? ` [§${h.spec_section}]` : "";
+    return `${i + 1}. ${h.id}${spec}: ${h.title || "(untitled)"}${deps}\n   scope: ${h.scope || "(none)"}`;
+  }).join("\n\n");
+
+  return [
+    "You previously generated an implementation plan for the task below.",
+    "Your ONLY job in this call is to review it against five specific questions.",
+    "DO NOT propose new features, logging, monitoring, refactors, or anything",
+    "beyond what the SPEC explicitly requires. We're checking the plan for",
+    "completeness and correctness — NOT improving its scope.",
+    "",
+    "Output MUST be a JSON object with this exact shape:",
+    "",
+    "```json",
+    "{",
+    '  "missing_hus": [',
+    '    { "spec_section": "<section ref or short description>", "rationale": "<why it should exist>" }',
+    "  ],",
+    '  "missing_dependencies": [',
+    '    { "from": "<huId that should depend on>", "on": "<huId>", "rationale": "<why>" }',
+    "  ],",
+    '  "scope_overlaps": [',
+    '    { "between": ["<huId>", "<huId>"], "rationale": "<why they overlap>" }',
+    "  ],",
+    '  "parallelisable_groups": [',
+    '    { "his": ["<huId>", "<huId>"], "rationale": "<why these can run side-by-side>" }',
+    "  ],",
+    '  "order_issues": [',
+    '    { "hus": ["<huId>"], "issue": "<wrong order | circular | other>", "rationale": "<why>" }',
+    "  ],",
+    '  "summary": "<one sentence overall verdict>"',
+    "}",
+    "```",
+    "",
+    "Rules:",
+    "- Each array can be empty if there's nothing to flag for that question.",
+    "- Reference HUs by their EXACT id from the list below.",
+    "- Suggest at MOST 5 entries per array — only the most important ones.",
+    "- DO NOT propose tests / acceptance criteria — those are handled by other roles.",
+    "- DO NOT suggest renames / cosmetic changes — only structural issues.",
+    "- Return ONLY the JSON — no prose, no markdown fences around it.",
+    "",
+    "## Original Task",
+    task,
+    "",
+    "## Plan to review",
+    "",
+    huSummary,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Run the focused review pass.
+ *
+ * Pure-function side: parses the LLM JSON and normalises the shape
+ * (missing arrays default to `[]`, summary defaults to `""`). Junk
+ * entries (missing required fields) are dropped silently.
+ *
+ * @param {object} args
+ * @param {object} args.agent
+ * @param {string} args.task
+ * @param {Array<object>} args.hus
+ * @param {Function} [args.onOutput]
+ * @param {number} [args.silenceTimeoutMs]
+ * @param {number} [args.timeoutMs]
+ * @returns {Promise<{ ok: boolean, findings?: object, error?: string }>}
+ */
+export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs, timeoutMs }) {
+  if (!Array.isArray(hus) || hus.length === 0) {
+    return { ok: true, findings: emptyFindings("Plan has no HUs to review.") };
+  }
+  const prompt = buildReviewerPrompt({ task, hus });
+  const runArgs = { prompt, role: "planner" };
+  if (onOutput) runArgs.onOutput = onOutput;
+  if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
+  if (timeoutMs) runArgs.timeoutMs = timeoutMs;
+
+  const result = await agent.runTask(runArgs);
+  if (!result.ok) {
+    return { ok: false, error: result.error || "reviewer agent failed" };
+  }
+  const parsed = extractFirstJson(result.output || "");
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "reviewer returned no JSON object" };
+  }
+  return { ok: true, findings: normaliseFindings(parsed) };
+}
+
+function emptyFindings(summary) {
+  return {
+    missing_hus: [],
+    missing_dependencies: [],
+    scope_overlaps: [],
+    parallelisable_groups: [],
+    order_issues: [],
+    summary: summary || "",
+  };
+}
+
+/**
+ * Coerce the raw LLM payload into the canonical shape. Each list is
+ * filtered to keep only entries with the required fields populated.
+ * @param {object} raw
+ */
+function normaliseFindings(raw) {
+  const f = emptyFindings(typeof raw.summary === "string" ? raw.summary : "");
+  if (Array.isArray(raw.missing_hus)) {
+    f.missing_hus = raw.missing_hus
+      .filter((m) => m && (m.spec_section || m.section || m.title) && m.rationale)
+      .map((m) => ({
+        spec_section: String(m.spec_section || m.section || m.title),
+        rationale: String(m.rationale),
+      }));
+  }
+  if (Array.isArray(raw.missing_dependencies)) {
+    f.missing_dependencies = raw.missing_dependencies
+      .filter((d) => d && d.from && d.on && d.rationale)
+      .map((d) => ({ from: String(d.from), on: String(d.on), rationale: String(d.rationale) }));
+  }
+  if (Array.isArray(raw.scope_overlaps)) {
+    f.scope_overlaps = raw.scope_overlaps
+      .filter((o) => o && Array.isArray(o.between) && o.between.length >= 2 && o.rationale)
+      .map((o) => ({ between: o.between.map(String), rationale: String(o.rationale) }));
+  }
+  if (Array.isArray(raw.parallelisable_groups)) {
+    f.parallelisable_groups = raw.parallelisable_groups
+      .filter((g) => g && Array.isArray(g.hus) && g.hus.length >= 2)
+      .map((g) => ({ hus: g.hus.map(String), rationale: g.rationale ? String(g.rationale) : "" }));
+  }
+  if (Array.isArray(raw.order_issues)) {
+    f.order_issues = raw.order_issues
+      .filter((o) => o && Array.isArray(o.hus) && o.hus.length >= 1 && o.issue)
+      .map((o) => ({ hus: o.hus.map(String), issue: String(o.issue), rationale: o.rationale ? String(o.rationale) : "" }));
+  }
+  return f;
+}
+
+/**
+ * Flatten findings into a count of actionable items (for the CLI
+ * banner: "Reviewer found 3 issues.").
+ */
+export function findingsCount(findings) {
+  if (!findings) return 0;
+  return (
+    (findings.missing_hus?.length || 0)
+    + (findings.missing_dependencies?.length || 0)
+    + (findings.scope_overlaps?.length || 0)
+    + (findings.order_issues?.length || 0)
+    // parallelisable_groups is informational, not an issue.
+  );
+}

--- a/tests/plan-reviewer.test.js
+++ b/tests/plan-reviewer.test.js
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildReviewerPrompt, reviewPlan, findingsCount } from "../src/plan/plan-reviewer.js";
+
+describe("buildReviewerPrompt", () => {
+  it("constrains the LLM to five closed-ended questions, no free-form suggestions", () => {
+    const p = buildReviewerPrompt({
+      task: "build it",
+      hus: [{ id: "h1", title: "do x", scope: "x scope", blocked_by: [] }],
+    });
+    expect(p).toMatch(/missing_hus/);
+    expect(p).toMatch(/missing_dependencies/);
+    expect(p).toMatch(/scope_overlaps/);
+    expect(p).toMatch(/parallelisable_groups/);
+    expect(p).toMatch(/order_issues/);
+    // Anti-scope-creep nudges
+    expect(p).toMatch(/DO NOT propose new features/i);
+    expect(p).toMatch(/DO NOT propose tests/i);
+    expect(p).toMatch(/DO NOT suggest renames/i);
+  });
+
+  it("renders each HU with id + title + scope + blocked_by + spec_section", () => {
+    const p = buildReviewerPrompt({
+      task: "x",
+      hus: [
+        { id: "h1", title: "first", scope: "do x", blocked_by: [], spec_section: "1.1" },
+        { id: "h2", title: "second", scope: "do y", blocked_by: ["h1"] },
+      ],
+    });
+    expect(p).toMatch(/h1 \[§1\.1\]: first/);
+    expect(p).toMatch(/scope: do x/);
+    expect(p).toMatch(/h2: second ← blocked_by: h1/);
+  });
+
+  it("requires JSON-only output", () => {
+    const p = buildReviewerPrompt({ task: "x", hus: [{ id: "h1" }] });
+    expect(p).toMatch(/Return ONLY the JSON/);
+  });
+
+  it("caps suggestions at 5 per array to keep findings actionable", () => {
+    const p = buildReviewerPrompt({ task: "x", hus: [{ id: "h1" }] });
+    expect(p).toMatch(/at MOST 5 entries per array/);
+  });
+});
+
+describe("reviewPlan", () => {
+  it("short-circuits when there are no HUs to review", async () => {
+    const agent = { runTask: vi.fn() };
+    const result = await reviewPlan({ agent, task: "x", hus: [] });
+    expect(result.ok).toBe(true);
+    expect(result.findings.summary).toMatch(/no HUs to review/i);
+    expect(agent.runTask).not.toHaveBeenCalled();
+  });
+
+  it("parses the LLM's structured response into normalised findings", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({
+          missing_hus: [{ spec_section: "5.4", rationale: "calendar sync not covered" }],
+          missing_dependencies: [{ from: "h3", on: "h2", rationale: "h3 reads schema h2 creates" }],
+          scope_overlaps: [{ between: ["h4", "h5"], rationale: "both touch the file mover" }],
+          parallelisable_groups: [{ hus: ["h6", "h7"], rationale: "no shared deps" }],
+          order_issues: [{ hus: ["h8"], issue: "wrong order", rationale: "depends on h9 but listed before it" }],
+          summary: "Looks solid; 1 missing HU, 1 dep gap.",
+        }),
+      }),
+    };
+    const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
+    expect(result.ok).toBe(true);
+    expect(result.findings.missing_hus).toHaveLength(1);
+    expect(result.findings.missing_hus[0].spec_section).toBe("5.4");
+    expect(result.findings.missing_dependencies[0].from).toBe("h3");
+    expect(result.findings.scope_overlaps[0].between).toEqual(["h4", "h5"]);
+    expect(result.findings.parallelisable_groups[0].hus).toEqual(["h6", "h7"]);
+    expect(result.findings.order_issues[0].issue).toBe("wrong order");
+    expect(result.findings.summary).toMatch(/Looks solid/);
+  });
+
+  it("filters out malformed entries (missing required fields)", async () => {
+    const agent = {
+      runTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({
+          missing_hus: [
+            { spec_section: "5.4", rationale: "ok" },
+            { rationale: "no section" },             // dropped
+            { spec_section: "5.5" },                  // dropped (no rationale)
+          ],
+          missing_dependencies: [
+            { from: "h1", on: "h2", rationale: "ok" },
+            { from: "h3" },                           // dropped
+          ],
+          scope_overlaps: [
+            { between: ["h1", "h2"], rationale: "ok" },
+            { between: ["only-one"], rationale: "single-element" },  // dropped
+          ],
+          order_issues: [
+            { hus: [], issue: "x" },                  // dropped (no hus)
+            { hus: ["h1"], issue: "ok" },
+          ],
+          parallelisable_groups: [
+            { hus: ["h1", "h2"] },
+            { hus: ["alone"] },                       // dropped
+          ],
+        }),
+      }),
+    };
+    const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
+    expect(result.findings.missing_hus).toHaveLength(1);
+    expect(result.findings.missing_dependencies).toHaveLength(1);
+    expect(result.findings.scope_overlaps).toHaveLength(1);
+    expect(result.findings.order_issues).toHaveLength(1);
+    expect(result.findings.parallelisable_groups).toHaveLength(1);
+  });
+
+  it("returns ok:false on agent failure", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: false, error: "rate limited" }) };
+    const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/rate limited/);
+  });
+
+  it("returns ok:false on non-JSON output", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "free-form prose" }) };
+    const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
+    expect(result.ok).toBe(false);
+  });
+
+  it("forwards onOutput / silenceTimeoutMs / timeoutMs to the agent", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "{}" }) };
+    const onOutput = vi.fn();
+    await reviewPlan({
+      agent, task: "x", hus: [{ id: "h1" }],
+      onOutput, silenceTimeoutMs: 9999, timeoutMs: 12345,
+    });
+    const args = agent.runTask.mock.calls[0][0];
+    expect(args.onOutput).toBe(onOutput);
+    expect(args.silenceTimeoutMs).toBe(9999);
+    expect(args.timeoutMs).toBe(12345);
+  });
+});
+
+describe("findingsCount", () => {
+  it("sums up actionable items only (parallelisable_groups is informational, not counted)", () => {
+    expect(findingsCount({
+      missing_hus: [1, 2],
+      missing_dependencies: [1],
+      scope_overlaps: [1, 2, 3],
+      order_issues: [1],
+      parallelisable_groups: [1, 2, 3, 4, 5],     // ignored
+    })).toBe(7);
+  });
+
+  it("returns 0 for empty / null findings", () => {
+    expect(findingsCount(null)).toBe(0);
+    expect(findingsCount({})).toBe(0);
+    expect(findingsCount({ missing_hus: [] })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

PR D of the multi-step planning roadmap. After the planner + tests-synthesizer passes, run a third focused pass that asks the LLM **five specific questions** about the plan it just produced, with strong anti-scope-creep nudges:

1. **Missing HUs** — sections of the SPEC the plan doesn't cover
2. **Missing deps** — pairs of HUs that should have a \`blocked_by\` edge
3. **Scope overlap** — HUs that touch the same scope and might fight
4. **Parallelisable** — HUs with no inter-deps that could run together
5. **Order issues** — wrong / circular \`blocked_by\` chains

The output is **purely advisory**. The reviewer never edits the plan. It surfaces findings; the user decides whether to apply them via the board's edit modal or another \`kj plan\` pass.

**Anti-scope-creep rules** spelled out in the prompt: NO new features, NO logging proposals, NO renames, NO test suggestions (the synthesizer handles those), MAX 5 entries per array.

### Module: \`src/plan/plan-reviewer.js\`

- \`buildReviewerPrompt\` exported for prompt-shape testing without an LLM
- \`reviewPlan\` runs the pass; short-circuits on 0 HUs; normalises findings (drops malformed entries silently)
- \`findingsCount\` totals actionable items (parallelisable_groups intentionally excluded — informational)

### Wiring: \`src/commands/plan.js\`

After the synthesizer pass, findings stamped on \`plan.review\`. \`Plan saved …\` line gets a one-line reviewer summary:
- \`Reviewer: ✓ no issues\` when clean
- \`Reviewer flagged: 3 missing HU(s), 1 missing dep(s) — see \`kj plan show <id>\`\` otherwise

\`kj plan show <id>\` renders the full findings as a markdown section with subsections per non-empty array.

### CLI: \`src/cli.js\`

New flag \`--no-plan-review\` mirroring the existing \`--no-tests-synth\`. \`--quick\` skips both. Defaults run the full quality pipeline.

## Tests

\`tests/plan-reviewer.test.js\` (12): prompt structure (5 questions + anti-creep + JSON-only + cap + HU metadata), reviewPlan happy path + malformed filter + agent-failure + non-JSON + arg forwarding, findingsCount sums + null-safe.

3933 parent tests green.

## Roadmap

| | Scope | Status |
|---|---|---|
| A | Tests synthesizer | ✅ #502 |
| B | ADRs from Architect | ✅ #503 |
| C | Spec mapping | ✅ #504 |
| **D** | **Plan reviewer** | **this** |
| E | Rate-limit pause/resume coverage | follow-up |
| F | Wire ADRs + spec_section + reviewer findings into coder/reviewer prompt | follow-up |

## Test plan

- [x] \`npx vitest run tests/\` → 3933/3933
- [ ] Manual: \`kj plan\` over a SPEC.md → reviewer flags missing HUs / deps if any → \`kj plan show\` renders the findings section