### PR TITLE
feat(board): launch kj commands from the board UI + restart endpoint

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1047,13 +1047,35 @@ function ansiToHtml(text) {
 }
 
 /**
- * Open (or refocus) the run-log panel for the given plan. If a panel
- * is already up for the same planId, just bring it to the front; if
- * for a different one, swap content + reset offset.
+ * Open (or refocus) the run-log panel for the given plan. Thin shim
+ * over `openGenericLogPanel` — the original entry point used for
+ * `kj run --plan` runs that the Run-plan button kicks off.
  */
 function openLogViewer(planId) {
+  return openGenericLogPanel({
+    id: planId,
+    label: 'Run log',
+    tailUrl: (offset) => `/api/plans/${encodeURIComponent(planId)}/log?offset=${offset}`,
+  });
+}
+
+/**
+ * Generic floating log panel anchored bottom-right. Used by:
+ *   - openLogViewer(planId)         → /api/plans/:planId/log
+ *   - openCommandLogViewer(cmd, id) → /api/runs/:commandId/log
+ *
+ * The only thing that changes between callers is the tail URL +
+ * the label; the window controls (min/max/close), polling, and ANSI
+ * rendering are identical.
+ *
+ * @param {object} args
+ * @param {string} args.id        - opaque id (planId or commandId), shown in header
+ * @param {string} args.label     - "Run log", "kj plan", …
+ * @param {(offset:number)=>string} args.tailUrl - returns the URL to GET each tick
+ */
+function openGenericLogPanel({ id, label, tailUrl }) {
   // Tearing down the previous panel cleanly avoids two timers running
-  // when the user clicks "Run plan" twice quickly.
+  // when the user opens a second log while the first is still tailing.
   if (logPollTimer) { clearTimeout(logPollTimer); logPollTimer = null; }
   if (logViewerState.panel && logViewerState.panel.parentNode) {
     logViewerState.panel.remove();
@@ -1084,10 +1106,10 @@ function openLogViewer(planId) {
                    border-bottom:1px solid var(--border);
                    user-select:none;flex-shrink:0">
       <div style="display:flex;align-items:baseline;gap:10px;min-width:0">
-        <strong style="color:var(--text)">Run log</strong>
+        <strong style="color:var(--text)">${esc(label)}</strong>
         <span style="font-family:var(--font-mono, monospace);font-size:0.78rem;
                      color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;
-                     white-space:nowrap">${esc(planId)}</span>
+                     white-space:nowrap">${esc(id)}</span>
       </div>
       <div style="display:flex;align-items:center;gap:6px;flex-shrink:0">
         <span id="log-status" style="font-size:0.75rem;color:var(--text-muted);margin-right:8px">connecting…</span>
@@ -1112,7 +1134,7 @@ function openLogViewer(planId) {
   `;
 
   document.body.appendChild(panel);
-  logViewerState = { planId, panel, offset: 0, isMax: false, isMin: false };
+  logViewerState = { planId: id, panel, offset: 0, isMax: false, isMin: false };
 
   const bodyEl = panel.querySelector('#log-body');
   const statusEl = panel.querySelector('#log-status');
@@ -1175,7 +1197,7 @@ function openLogViewer(planId) {
   async function tick() {
     if (!logViewerState.panel) return;        // user closed
     try {
-      const res = await fetch(`/api/plans/${encodeURIComponent(planId)}/log?offset=${logViewerState.offset}`);
+      const res = await fetch(tailUrl(logViewerState.offset));
       if (!res.ok) {
         statusEl.textContent = `error: HTTP ${res.status}`;
         logPollTimer = setTimeout(tick, 4000);
@@ -1993,6 +2015,191 @@ function handleRoute() {
   render();
 }
 
+// ---- Command launcher modal ----
+//
+// Opens a small form inside the existing <dialog> singleton with a
+// command picker (plan / architect / clean) and the appropriate
+// fields per command. Submit POSTs to /api/commands/:command, the
+// server spawns a detached `kj` child, and we open the existing log
+// viewer (re-uses openLogViewer's tail loop, just pointed at the
+// new generic /api/runs/:commandId/log endpoint).
+
+async function showCommandLauncher() {
+  const dlg = ensureDialog();
+  // Per-command field schemas — kept in the client because each
+  // command has different inputs and the modal renders accordingly.
+  const SCHEMAS = {
+    plan: {
+      label: '📋 kj plan',
+      help: 'Generate an implementation plan with HUs. Paste the task text OR a file path.',
+      fields: [
+        { name: 'taskFile', label: 'SPEC file path (absolute)', type: 'text', placeholder: '/home/me/project/SPEC.md' },
+        { name: 'task', label: 'OR paste task text directly', type: 'textarea', rows: 6 },
+        { name: 'context', label: 'Extra context (optional)', type: 'text' },
+        { name: 'projectDir', label: 'Project directory (optional, defaults to board\'s cwd)', type: 'text' },
+        { name: 'quick', label: '--quick (skip synth + reviewer)', type: 'checkbox' },
+      ],
+    },
+    architect: {
+      label: '🏛 kj architect',
+      help: 'Design an architecture and persist ADRs. Same input as kj plan.',
+      fields: [
+        { name: 'taskFile', label: 'SPEC file path (absolute)', type: 'text', placeholder: '/home/me/project/SPEC.md' },
+        { name: 'task', label: 'OR paste task text directly', type: 'textarea', rows: 6 },
+        { name: 'context', label: 'Extra context (optional)', type: 'text' },
+        { name: 'projectDir', label: 'Project directory (optional)', type: 'text' },
+      ],
+    },
+    clean: {
+      label: '🧹 kj clean',
+      help: 'Garbage-collect plans / sessions / batches. --nuke wipes everything including the board DB.',
+      fields: [
+        { name: 'dryRun', label: '--dry-run (just report)', type: 'checkbox' },
+        { name: 'nuke', label: '⚠ --nuke (delete everything, including this board\'s DB)', type: 'checkbox' },
+      ],
+    },
+  };
+
+  let active = 'plan';
+  const renderForm = () => {
+    const s = SCHEMAS[active];
+    const fields = s.fields.map((f) => {
+      const id = `cmd-field-${f.name}`;
+      if (f.type === 'textarea') {
+        return `
+          <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+            <span style="color:var(--text-muted)">${esc(f.label)}</span>
+            <textarea id="${id}" rows="${f.rows || 4}" placeholder="${esc(f.placeholder || '')}"
+                      style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-family:inherit;font-size:0.9rem;line-height:1.45;resize:vertical"></textarea>
+          </label>`;
+      }
+      if (f.type === 'checkbox') {
+        return `
+          <label style="display:flex;align-items:center;gap:8px;font-size:0.85rem">
+            <input type="checkbox" id="${id}">
+            <span>${esc(f.label)}</span>
+          </label>`;
+      }
+      return `
+        <label style="display:flex;flex-direction:column;gap:4px;font-size:0.85rem">
+          <span style="color:var(--text-muted)">${esc(f.label)}</span>
+          <input type="text" id="${id}" placeholder="${esc(f.placeholder || '')}"
+                 style="padding:8px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);font-size:0.9rem">
+        </label>`;
+    }).join('');
+
+    dlg.innerHTML = `
+      <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;justify-content:space-between;gap:10px">
+        <span>⚡ Run a Karajan command</span>
+        <button id="cmd-close" type="button" class="control-btn"
+                style="padding:4px 10px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
+          ✕
+        </button>
+      </div>
+      <div style="padding:12px 18px;display:flex;gap:8px;border-bottom:1px solid var(--border)">
+        ${Object.entries(SCHEMAS).map(([key, s]) => `
+          <button type="button" data-cmd="${key}"
+                  style="padding:6px 12px;border:1px solid var(--border);
+                         background:${key === active ? 'var(--color-green)' : 'var(--bg-primary)'};
+                         color:${key === active ? '#fff' : 'var(--text)'};
+                         border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem;font-weight:${key === active ? '600' : '400'}">
+            ${esc(s.label)}
+          </button>
+        `).join('')}
+      </div>
+      <form id="cmd-form" onsubmit="return false"
+            style="padding:14px 18px;display:flex;flex-direction:column;gap:12px;min-width:540px;max-width:80vw">
+        <div style="font-size:0.8rem;color:var(--text-muted)">${esc(SCHEMAS[active].help)}</div>
+        ${fields}
+        <div style="display:flex;justify-content:flex-end;gap:8px;padding-top:8px;border-top:1px solid var(--border)">
+          <button type="button" id="cmd-cancel" class="control-btn"
+                  style="padding:6px 14px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
+            Cancel
+          </button>
+          <button type="button" id="cmd-submit" class="control-btn"
+                  style="padding:6px 14px;border:none;background:var(--color-green);color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600">
+            Run
+          </button>
+        </div>
+      </form>
+    `;
+
+    dlg.querySelectorAll('[data-cmd]').forEach((btn) => {
+      btn.addEventListener('click', () => { active = btn.dataset.cmd; renderForm(); });
+    });
+    dlg.querySelector('#cmd-close').addEventListener('click', () => dlg.close());
+    dlg.querySelector('#cmd-cancel').addEventListener('click', () => dlg.close());
+    dlg.querySelector('#cmd-submit').addEventListener('click', () => submitCommand(active));
+  };
+
+  async function submitCommand(command) {
+    const s = SCHEMAS[command];
+    const body = {};
+    for (const f of s.fields) {
+      const el = document.getElementById(`cmd-field-${f.name}`);
+      if (!el) continue;
+      if (f.type === 'checkbox') body[f.name] = el.checked;
+      else {
+        const v = (el.value || '').trim();
+        if (v) body[f.name] = v;
+      }
+    }
+    // plan / architect: at least one of taskFile or task is required.
+    if ((command === 'plan' || command === 'architect') && !body.taskFile && !body.task) {
+      await showError('Provide either a SPEC file path or paste the task text.', { title: 'Missing input' });
+      return;
+    }
+    if (command === 'clean' && body.nuke) {
+      const ok = await showConfirm(
+        '`kj clean --nuke` will delete EVERY plan / session / batch + wipe the HU Board DB. Cannot be undone.',
+        { title: 'Confirm --nuke', okLabel: 'Wipe everything', destructive: true }
+      );
+      if (!ok) return;
+    }
+
+    let res, payload;
+    try {
+      res = await fetch(`/api/commands/${encodeURIComponent(command)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      payload = await res.json().catch(() => ({}));
+    } catch (err) {
+      await showError(err.message, { title: 'Could not launch command' });
+      return;
+    }
+    if (!res.ok) {
+      await showError(payload.error || `HTTP ${res.status}`, { title: 'Command rejected' });
+      return;
+    }
+
+    dlg.close();
+    if (payload.commandId) openCommandLogViewer(command, payload.commandId);
+  }
+
+  renderForm();
+  dlg.showModal();
+}
+
+/**
+ * Open the run-log panel pointed at a /api/runs/<commandId>/log
+ * tail. Reuses the same panel UI as openLogViewer() for plans —
+ * just swaps the URL it polls.
+ */
+function openCommandLogViewer(commandLabel, commandId) {
+  // We piggyback on openLogViewer by faking a planId-shaped argument.
+  // Simpler than duplicating the whole panel; the only difference is
+  // the polled URL, which we hijack via fetch interception per call.
+  // Cleaner approach: extract a generic openLogViewer({ id, label,
+  // tailUrl }) helper. Done in this PR.
+  openGenericLogPanel({
+    id: commandId,
+    label: `kj ${commandLabel}`,
+    tailUrl: (offset) => `/api/runs/${encodeURIComponent(commandId)}/log?offset=${offset}`,
+  });
+}
+
 // ---- Initialization ----
 
 // Nav button clicks
@@ -2019,6 +2226,29 @@ document.getElementById('sync-btn').addEventListener('click', async () => {
   } catch { /* ignore */ }
   btn.textContent = '🔄';
   btn.disabled = false;
+});
+
+// Commands button — opens the launcher modal so the user can run
+// `kj plan`, `kj architect`, `kj clean` (and more later) without
+// dropping to a terminal. Output streams to the existing log panel.
+document.getElementById('commands-btn').addEventListener('click', () => {
+  showCommandLauncher();
+});
+
+// Restart button — respawn the board server in place. The page's
+// EventSource auto-reconnects so the user sees a brief "connecting…"
+// blip and the board comes back live.
+document.getElementById('restart-btn').addEventListener('click', async () => {
+  const ok = await showConfirm(
+    'Restart the HU Board server now? The page will reconnect automatically.',
+    { title: 'Restart board', okLabel: 'Restart' }
+  );
+  if (!ok) return;
+  try {
+    await fetch('/api/board/restart', { method: 'POST' });
+  } catch { /* the server is going down; the catch is expected */ }
+  // Give the new server a beat to bind, then reload the page.
+  setTimeout(() => window.location.reload(), 1200);
 });
 
 // Delete project (cascade) — delegated handler on the dashboard grid

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -29,6 +29,8 @@
         <option value="">All Projects</option>
       </select>
       <div class="header__controls">
+        <button class="control-btn" id="commands-btn" title="Launch a Karajan CLI command (kj plan, kj architect, kj clean…)">⚡</button>
+        <button class="control-btn" id="restart-btn" title="Restart the HU Board server (preserves URL, the page reconnects automatically)">🔁</button>
         <button class="control-btn" id="sync-btn" title="Re-scan disk for new batches">🔄</button>
       </div>
     </nav>

--- a/packages/hu-board/src/command-runner.js
+++ b/packages/hu-board/src/command-runner.js
@@ -1,0 +1,134 @@
+/**
+ * Generic Karajan-CLI launcher used by the board's "Commands" panel.
+ * Wraps the same spawn-detached-with-log pattern that `runPlan`
+ * already uses (see plan-mutations.js), but covers the broader set
+ * of commands the user wants to trigger from the UI: plan,
+ * architect, clean, etc.
+ *
+ * Security: the command name is matched against an explicit
+ * whitelist. Free-form arg arrays are NOT allowed — each command
+ * builds its argv from a typed schema. This keeps a curious browser
+ * client from doing `node cli.js -e "rm -rf /"` via a crafted POST.
+ *
+ * Output: each command writes to `~/.karajan/hu-board-runs/
+ * cmd-<commandId>.log`, which the existing `/api/plans/:planId/log`
+ * endpoint can tail (we generalise it to take a log id, not just a
+ * planId, in routes/api.js).
+ */
+
+import { mkdirSync, openSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+
+// Repo root → so we can spawn `node <repo>/src/cli.js …` regardless
+// of whether `kj` is on $PATH for the board process.
+const REPO_ROOT = (() => {
+  const here = dirname(fileURLToPath(import.meta.url));     // packages/hu-board/src
+  return join(here, "..", "..", "..");                       // → repo root
+})();
+const KJ_CLI = join(REPO_ROOT, "src", "cli.js");
+
+/**
+ * Resolve the runs directory the board already uses for plan logs.
+ * Falls back to ~/.karajan/hu-board-runs/ when KJ_HOME is unset.
+ */
+function runsDir() {
+  return join(process.env.KJ_HOME || join(homedir(), ".karajan"), "hu-board-runs");
+}
+
+/**
+ * Whitelist + argv builders. Each entry maps a logical command name
+ * (`plan`, `architect`, `clean`) to a function that turns the
+ * board-side input into a CLI argv. Adding a new command means: add
+ * an entry here and an entry in the board UI's `COMMANDS` table.
+ *
+ * Why typed builders instead of a generic args array: the browser
+ * client can't smuggle arbitrary flags. Anything that's not in the
+ * whitelist is rejected with 400.
+ *
+ * Each builder returns `{ args, projectDir? }`. `projectDir` is the
+ * cwd the spawn should use (defaults to the board's cwd).
+ */
+const COMMAND_BUILDERS = {
+  plan: (input) => {
+    const args = ["plan"];
+    if (input.taskFile) args.push("--task-file", String(input.taskFile));
+    if (input.context) args.push("--context", String(input.context));
+    if (input.quick) args.push("--quick");
+    if (input.noTestsSynth) args.push("--no-tests-synth");
+    if (input.noPlanReview) args.push("--no-plan-review");
+    // Positional task goes last when no --task-file was given.
+    if (!input.taskFile && input.task) args.push(String(input.task));
+    return { args, projectDir: input.projectDir };
+  },
+  architect: (input) => {
+    const args = ["architect"];
+    if (input.taskFile) args.push("--task-file", String(input.taskFile));
+    if (input.context) args.push("--context", String(input.context));
+    if (!input.taskFile && input.task) args.push(String(input.task));
+    return { args, projectDir: input.projectDir };
+  },
+  clean: (input) => {
+    const args = ["clean", "--yes"];      // never prompt; UI confirms ahead
+    if (input.nuke) args.push("--nuke");
+    if (input.dryRun) args.push("--dry-run");
+    return { args };
+  },
+};
+
+/**
+ * Spawn the requested CLI command as a detached child. Returns
+ * `{ ok, commandId, pid, logPath, argv }` so the caller can offer
+ * the log to the user via the existing log viewer.
+ *
+ * Test seam: `KJ_RUN_SPAWN_MODE=echo` short-circuits the spawn so
+ * vitest doesn't actually boot the orchestrator.
+ *
+ * @param {object} args
+ * @param {string} args.command  - one of the COMMAND_BUILDERS keys
+ * @param {object} [args.input]
+ * @returns {{ ok: boolean, commandId?: string, pid?: number,
+ *             logPath?: string, argv?: string[], error?: string }}
+ */
+export function runKjCommand({ command, input = {} } = {}) {
+  const build = COMMAND_BUILDERS[command];
+  if (!build) {
+    return { ok: false, error: `Unsupported command: ${command}. Allowed: ${Object.keys(COMMAND_BUILDERS).join(", ")}` };
+  }
+
+  let built;
+  try {
+    built = build(input);
+  } catch (err) {
+    return { ok: false, error: `Bad input for "${command}": ${err.message}` };
+  }
+
+  const dir = runsDir();
+  mkdirSync(dir, { recursive: true });
+  const commandId = `cmd-${command}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+  const logPath = join(dir, `${commandId}.log`);
+  const argv = [KJ_CLI, ...built.args];
+
+  if (process.env.KJ_RUN_SPAWN_MODE === "echo") {
+    return { ok: true, commandId, pid: 0, logPath, argv: [process.execPath, ...argv] };
+  }
+
+  const out = openSync(logPath, "a");
+  const err = openSync(logPath, "a");
+  const child = spawn(process.execPath, argv, {
+    cwd: built.projectDir || process.cwd(),
+    detached: true,
+    stdio: ["ignore", out, err],
+    env: { ...process.env, CLAUDECODE: undefined },
+  });
+  child.unref();
+  return { ok: true, commandId, pid: child.pid ?? 0, logPath };
+}
+
+/** Test helper: list of command names exposed. */
+export function listSupportedCommands() {
+  return Object.keys(COMMAND_BUILDERS);
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawn as spawnChild } from 'node:child_process';
 import {
   getDashboardStats,
   getProjects,
@@ -18,6 +19,7 @@ import {
 import { fullScan } from '../sync.js';
 import { setHuStatus, setHuFields, markPlanReady, runPlan } from '../plan-mutations.js';
 import { subscribe as subscribeEvents } from '../event-bus.js';
+import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 
 const router = Router();
 
@@ -556,6 +558,115 @@ router.post('/projects/:id/run', (req, res) => {
     }
     const launched = results.filter((r) => r.ok).length;
     res.json({ launched, total: planIds.length, results });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/commands - List the kj commands the board can launch.
+ * The UI uses this to render the Actions panel without hardcoding
+ * the command list on the client.
+ */
+router.get('/commands', (_req, res) => {
+  res.json({ commands: listSupportedCommands() });
+});
+
+/**
+ * POST /api/commands/:command - Spawn a kj <command> as a detached
+ * child. Body fields depend on the command (see command-runner.js
+ * for the per-command input schema). Returns a commandId the client
+ * can pass to GET /api/runs/:commandId/log to tail the output.
+ *
+ * The board never executes free-form arg arrays — the command name
+ * must be in the whitelist and each command builds its argv from a
+ * typed schema. Anything outside that fails 400.
+ */
+router.post('/commands/:command', (req, res) => {
+  try {
+    const result = runKjCommand({ command: req.params.command, input: req.body || {} });
+    if (!result.ok) return res.status(400).json({ error: result.error });
+    res.json({
+      ok: true,
+      commandId: result.commandId,
+      pid: result.pid,
+      logPath: result.logPath,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/runs/:commandId/log - Generalisation of the per-plan log
+ * tail. The original `/api/plans/:planId/log` reads
+ * `<runsDir>/<planId>.log`; this one reads `<runsDir>/<commandId>.log`
+ * where `commandId` is what `/api/commands/:command` returned.
+ *
+ * Same offset semantics + 1 MiB cap as the plans endpoint.
+ */
+router.get('/runs/:commandId/log', (req, res) => {
+  try {
+    const runsDir = path.join(getKjHome(), 'hu-board-runs');
+    const logPath = path.join(runsDir, `${req.params.commandId}.log`);
+    if (!fs.existsSync(logPath)) {
+      return res.json({ exists: false, size: 0, content: '' });
+    }
+    const stat = fs.statSync(logPath);
+    const offset = Math.max(0, Math.min(stat.size, Number(req.query.offset) || 0));
+    const MAX_READ = 1024 * 1024;
+    const length = Math.min(MAX_READ, stat.size - offset);
+    let content = '';
+    if (length > 0) {
+      const fd = fs.openSync(logPath, 'r');
+      try {
+        const buf = Buffer.alloc(length);
+        fs.readSync(fd, buf, 0, length, offset);
+        content = buf.toString('utf-8');
+      } finally {
+        fs.closeSync(fd);
+      }
+    }
+    res.json({ exists: true, size: stat.size, content });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/board/restart - Respawn the board server in place. The
+ * server can't truly restart itself (it'd kill its own process), so
+ * we use the detached-child + parent-exit pattern: spawn a copy with
+ * the same argv + cwd + env, unref it, ack the client, then exit
+ * after a 250 ms delay so the response actually flushes.
+ *
+ * The new server overwrites the PID file and bindes the same port
+ * (or the next free one if the old one hasn't released yet — handled
+ * by the existing find-available-port logic in startBoard).
+ *
+ * The browser tab's EventSource auto-reconnects, so the user sees a
+ * brief blip and the board comes back live.
+ */
+router.post('/board/restart', (_req, res) => {
+  // Tests / programmatic callers can short-circuit the actual self-
+  // exec via env so the suite doesn't have its node process killed
+  // mid-test by a misfire.
+  if (process.env.KJ_BOARD_RESTART_MODE === 'echo') {
+    return res.json({ ok: true, restartingInMs: 0, mode: 'echo' });
+  }
+  try {
+    res.json({ ok: true, restartingInMs: 250 });
+    setTimeout(() => {
+      try {
+        const child = spawnChild(
+          process.execPath,
+          process.argv.slice(1),
+          { cwd: process.cwd(), detached: true, stdio: 'ignore', env: process.env }
+        );
+        child.unref();
+      } catch { /* if respawn fails, the user can `kj board start` manually */ }
+      process.exit(0);
+    }, 250);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/command-runner.test.js
+++ b/packages/hu-board/tests/command-runner.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+let tmpHome;
+let app;
+let dbMod;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "hu-board-cmd-"));
+  process.env.KJ_HOME = tmpHome;
+  // Echo mode short-circuits the actual `kj` spawn so the test doesn't
+  // boot the orchestrator.
+  process.env.KJ_RUN_SPAWN_MODE = "echo";
+
+  dbMod = await import("../src/db.js");
+  dbMod.initDb();
+  const { default: apiRoutes } = await import("../src/routes/api.js");
+  app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+});
+
+afterEach(() => {
+  delete process.env.KJ_RUN_SPAWN_MODE;
+  dbMod.closeDb();
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("GET /api/commands", () => {
+  it("lists the supported kj commands the board can launch", async () => {
+    const res = await request(app).get("/api/commands");
+    expect(res.status).toBe(200);
+    expect(res.body.commands).toEqual(expect.arrayContaining(["plan", "architect", "clean"]));
+  });
+});
+
+describe("POST /api/commands/:command", () => {
+  it("rejects an unknown command name with 400", async () => {
+    const res = await request(app).post("/api/commands/sudo").send({ task: "rm -rf /" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Unsupported command/);
+  });
+
+  it("plan: builds argv with the positional task when no taskFile is given", async () => {
+    const { runKjCommand } = await import("../src/command-runner.js");
+    const result = runKjCommand({ command: "plan", input: { task: "build login" } });
+    expect(result.ok).toBe(true);
+    expect(result.argv.some((a) => a === "build login")).toBe(true);
+    expect(result.argv).toContain("plan");
+  });
+
+  it("plan: passes --task-file when provided AND drops the positional task", async () => {
+    const { runKjCommand } = await import("../src/command-runner.js");
+    const result = runKjCommand({ command: "plan", input: { taskFile: "/tmp/SPEC.md", task: "ignored" } });
+    expect(result.ok).toBe(true);
+    const idx = result.argv.indexOf("--task-file");
+    expect(idx).toBeGreaterThan(-1);
+    expect(result.argv[idx + 1]).toBe("/tmp/SPEC.md");
+    expect(result.argv).not.toContain("ignored");
+  });
+
+  it("plan: forwards --quick / --no-tests-synth / --no-plan-review flags", async () => {
+    const { runKjCommand } = await import("../src/command-runner.js");
+    const result = runKjCommand({ command: "plan", input: { taskFile: "/tmp/x.md", quick: true, noTestsSynth: true, noPlanReview: true } });
+    expect(result.argv).toEqual(expect.arrayContaining(["--quick", "--no-tests-synth", "--no-plan-review"]));
+  });
+
+  it("clean: always passes --yes and conditionally --nuke", async () => {
+    const { runKjCommand } = await import("../src/command-runner.js");
+    const noNuke = runKjCommand({ command: "clean", input: {} });
+    expect(noNuke.argv).toContain("--yes");
+    expect(noNuke.argv).not.toContain("--nuke");
+
+    const nuked = runKjCommand({ command: "clean", input: { nuke: true } });
+    expect(nuked.argv).toContain("--nuke");
+  });
+
+  it("returns commandId + logPath the client can tail", async () => {
+    const res = await request(app).post("/api/commands/plan").send({ task: "do thing" });
+    expect(res.status).toBe(200);
+    expect(res.body.commandId).toMatch(/^cmd-plan-/);
+    expect(res.body.logPath).toMatch(/hu-board-runs\/cmd-plan-.+\.log$/);
+  });
+});
+
+describe("GET /api/runs/:commandId/log", () => {
+  it("returns exists:false when the log file hasn't been created yet", async () => {
+    const res = await request(app).get("/api/runs/cmd-nope-1/log");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exists: false, size: 0, content: "" });
+  });
+
+  it("tails the log by offset like the per-plan endpoint does", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const dir = path.join(tmpHome, "hu-board-runs");
+    fs.mkdirSync(dir, { recursive: true });
+    const logPath = path.join(dir, "cmd-x-1.log");
+    fs.writeFileSync(logPath, "hello\nworld\n");
+    const full = await request(app).get("/api/runs/cmd-x-1/log");
+    expect(full.body.content).toBe("hello\nworld\n");
+    fs.writeFileSync(logPath, "hello\nworld\n!!!\n");
+    const delta = await request(app).get("/api/runs/cmd-x-1/log").query({ offset: 12 });
+    expect(delta.body.content).toBe("!!!\n");
+  });
+});
+
+describe("POST /api/board/restart", () => {
+  it("acks immediately in echo mode without killing the test process", async () => {
+    process.env.KJ_BOARD_RESTART_MODE = "echo";
+    const res = await request(app).post("/api/board/restart");
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe("echo");
+    delete process.env.KJ_BOARD_RESTART_MODE;
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of \"commands in the UI\". Today, kicking off \`kj plan\`, \`kj architect\` or \`kj clean\` requires dropping to a terminal even when the board is open. This PR exposes those three as buttons in the board header (⚡ icon → modal), reusing the existing log-panel infra so output streams in place. Also adds a 🔁 restart button.

### Server (\`packages/hu-board/src/\`)

- **\`command-runner.js\`** (new) — whitelist + per-command argv builder (NO free-form args from the browser). Spawns \`node <repo>/src/cli.js <command> …\` detached, redirects to \`~/.karajan/hu-board-runs/cmd-<id>.log\`. \`KJ_RUN_SPAWN_MODE=echo\` short-circuits for tests.
- **\`routes/api.js\`** new endpoints:
  - \`GET  /api/commands\` — list whitelisted commands
  - \`POST /api/commands/:command\` — spawn → returns \`{ commandId, logPath }\`
  - \`GET  /api/runs/:commandId/log\` — generic log tail (mirrors \`/api/plans/:planId/log\`)
  - \`POST /api/board/restart\` — respawn-self pattern: spawn new server with same argv/cwd/env, unref, exit after 250 ms so the ack flushes. \`KJ_BOARD_RESTART_MODE=echo\` for tests.

### Board UI

- New header buttons: ⚡ (commands), 🔁 (restart)
- **\`showCommandLauncher()\`** — tabbed modal with per-command schemas (plan / architect / clean). Renders the right fields per command. Validates \"taskFile OR task\" for plan/architect; demands extra confirm on \`--nuke\`. Submit → POST → opens log viewer.
- **Refactor**: existing log panel split into \`openGenericLogPanel({ id, label, tailUrl })\`. \`openLogViewer(planId)\` is a thin shim now. New \`openCommandLogViewer(label, commandId)\` mirrors it.
- **Restart**: confirm → POST → \`setTimeout 1.2 s\` → \`location.reload()\`. EventSource auto-reconnects.

## Tests

\`packages/hu-board/tests/command-runner.test.js\` (10): list endpoint, unknown command rejected, plan argv builder edges, clean argv (\`--yes\` always, \`--nuke\` conditional), response shape, generic log tail offsets, restart echo mode.

3933 parent + 119 board tests green.

## Follow-ups

- Phase 2: research / triage / review / run-without-plan
- File path picker (HTML \`<input type=\"file\">\` can't browse host paths; either keep text input or add \`/api/fs/list\` + mini-browser). Defer until concrete pain.

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 119/119
- [x] \`npx vitest run tests/\` → 3933/3933
- [ ] Manual: ⚡ on the header → modal opens → run \`kj plan\` over a SPEC, log streams; 🔁 → board restarts and page reconnects