### PR TITLE
fix(board): server writes own PID + HTTP-probe before spawning + nuke skip

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -426,10 +426,10 @@ async function renderBoard() {
             ⚙ ${runningCount} running…
           </span>
         ` : ''}
-        ${lastLaunchedPlanId ? `
+        ${lastOpenedLog ? `
           <button class="control-btn" id="view-log-btn"
                   style="${isRunning ? '' : 'margin-left:auto;'}padding:6px 12px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;"
-                  title="Tail the detached kj run log in a dialog">
+                  title="Re-open the log of the most recent run/command">
             📜 View log
           </button>
         ` : ''}
@@ -452,8 +452,12 @@ async function renderBoard() {
       });
     }
     const viewLogBtn = document.getElementById('view-log-btn');
-    if (viewLogBtn && lastLaunchedPlanId) {
-      viewLogBtn.addEventListener('click', () => openLogViewer(lastLaunchedPlanId));
+    if (viewLogBtn && lastOpenedLog) {
+      viewLogBtn.addEventListener('click', () => openGenericLogPanel({
+        id: lastOpenedLog.id,
+        label: lastOpenedLog.label,
+        tailUrl: lastOpenedLog.tailUrl,
+      }));
     }
   } catch (err) {
     app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading board</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
@@ -859,6 +863,13 @@ function renderEmptyState(title, text) {
 // through plan ids.
 let lastLaunchedPlanId = null;
 
+// Generalised across plan runs AND ⚡ launcher commands: the ▶ Run
+// plan button populates this with the run's logPath, and the
+// command launcher does the same with its own commandId. The 📜
+// View log button in the section header reads from here so it
+// re-opens whichever was most recently launched.
+let lastOpenedLog = null;     // { id, label, tailUrl(offset) }
+
 async function runProject(projectId) {
   try {
     const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/run`, {
@@ -893,6 +904,11 @@ async function runProject(projectId) {
     const firstOk = (body.results || []).find((r) => r.ok);
     if (firstOk && firstOk.planId) {
       lastLaunchedPlanId = firstOk.planId;
+      lastOpenedLog = {
+        id: firstOk.planId,
+        label: 'Run log',
+        tailUrl: (offset) => `/api/plans/${encodeURIComponent(firstOk.planId)}/log?offset=${offset}`,
+      };
       // Open the log viewer straight away — the user's mental model is
       // "I clicked Run, I want to see what's happening", not "I clicked
       // Run, now where do I look".
@@ -2211,16 +2227,15 @@ async function showCommandLauncher() {
  * just swaps the URL it polls.
  */
 function openCommandLogViewer(commandLabel, commandId) {
-  // We piggyback on openLogViewer by faking a planId-shaped argument.
-  // Simpler than duplicating the whole panel; the only difference is
-  // the polled URL, which we hijack via fetch interception per call.
-  // Cleaner approach: extract a generic openLogViewer({ id, label,
-  // tailUrl }) helper. Done in this PR.
-  openGenericLogPanel({
+  const args = {
     id: commandId,
     label: `kj ${commandLabel}`,
     tailUrl: (offset) => `/api/runs/${encodeURIComponent(commandId)}/log?offset=${offset}`,
-  });
+  };
+  // Remember it so the section header's 📜 View log button can
+  // re-open this same log after the user closes the panel.
+  lastOpenedLog = args;
+  openGenericLogPanel(args);
 }
 
 // ---- Initialization ----

--- a/packages/hu-board/src/command-runner.js
+++ b/packages/hu-board/src/command-runner.js
@@ -122,7 +122,11 @@ export function runKjCommand({ command, input = {} } = {}) {
     cwd: built.projectDir || process.cwd(),
     detached: true,
     stdio: ["ignore", out, err],
-    env: { ...process.env, CLAUDECODE: undefined },
+    // KJ_INSIDE_BOARD: lets `kj clean --nuke` skip SIGTERMing the
+    // board (it'd kill the page the user is looking at). Other
+    // future "is this run hosted by the board" branches can read
+    // the same flag.
+    env: { ...process.env, CLAUDECODE: undefined, KJ_INSIDE_BOARD: "1" },
   });
   child.unref();
   return { ok: true, commandId, pid: child.pid ?? 0, logPath };

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -1,12 +1,26 @@
 import express from 'express';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { initDb, closeDb } from './db.js';
 import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
 import pipelineRoutes from './routes/pipeline.js';
 import { authMiddleware } from './auth.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
+
+/**
+ * Path to the PID file the CLI's `kj board start` / `kj board stop`
+ * also use. Pre-v2.7.5 this was written ONLY by the CLI launcher,
+ * so a self-respawn (the 🔁 button on the board) left a stale PID
+ * pointing at a dead process — and the next `kj plan` saw that, gave
+ * up on the existing board, and spawned a new one on port 4001.
+ *
+ * Now the server writes its own PID on every start so both the CLI
+ * launch and the in-place restart keep the file accurate.
+ */
+const PID_FILE = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-board.pid');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = join(__dirname, '..', 'public');
@@ -66,8 +80,20 @@ async function main() {
   const port = await findAvailablePort(desiredPort);
 
   const server = app.listen(port, () => {
+    // Write the PID file so the CLI's `kj board status / stop` and
+    // the next `kj plan`'s startBoard() check find this server. The
+    // file used to be written only by `kj board start`'s launcher,
+    // which meant the 🔁 self-respawn left a stale PID and the next
+    // auto-start spawned a duplicate board on the next free port.
+    try {
+      mkdirSync(dirname(PID_FILE), { recursive: true });
+      writeFileSync(PID_FILE, String(process.pid), 'utf8');
+    } catch (err) {
+      console.warn(`[server] could not write PID file: ${err.message}`);
+    }
     console.log(`\n  Karajan HU Board`);
     console.log(`  -----------------`);
+    console.log(`  PID:        ${process.pid}`);
     console.log(`  Running at: http://localhost:${port}`);
     console.log(`  Data dir:   ${process.env.KJ_HOME || '~/.karajan'}\n`);
   });
@@ -77,6 +103,9 @@ async function main() {
     console.log('\n[server] Shutting down...');
     watcher.close();
     closeDb();
+    // Best-effort PID file cleanup on graceful exit. If we crash the
+    // file stays — the CLI's `isProcessAlive` check handles that.
+    try { rmSync(PID_FILE, { force: true }); } catch { /* ignore */ }
     server.close(() => process.exit(0));
   };
 

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import http from "node:http";
 import path from "node:path";
 import net from "node:net";
 import { spawn } from "node:child_process";
@@ -23,6 +24,27 @@ function isProcessAlive(pid) {
   } catch { /* process does not exist */
     return false;
   }
+}
+
+/**
+ * HTTP-probe the board's /api/dashboard. Returns true when it
+ * responds with 2xx within ~750ms. Used as a fallback when the PID
+ * file is missing/stale to detect "board is up, just untracked".
+ */
+async function isBoardReachable(port, timeoutMs = 750) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/api/dashboard', method: 'GET', timeout: timeoutMs },
+      (res) => {
+        const ok = res.statusCode >= 200 && res.statusCode < 500;
+        res.resume();   // drain
+        resolve(ok);
+      }
+    );
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.end();
+  });
 }
 
 /**
@@ -74,6 +96,21 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
       ok: true,
       alreadyRunning: true,
       pid: existingPid,
+      url: buildBoardUrl(desiredPort, projectSlug),
+    };
+  }
+
+  // Belt-and-suspenders (v2.7.5 fix): even if the PID file is missing
+  // or stale, HTTP-probe the configured port before spawning. If
+  // /api/dashboard responds, a board is already there — reuse it. The
+  // pre-fix scenario: 🔁 self-restart didn't update the PID file
+  // (now fixed), so a `kj plan` afterwards saw a stale PID, spawned
+  // a duplicate board on port 4001, and confused the user.
+  if (await isBoardReachable(desiredPort)) {
+    return {
+      ok: true,
+      alreadyRunning: true,
+      pid: existingPid || null,
       url: buildBoardUrl(desiredPort, projectSlug),
     };
   }

--- a/src/utils/garbage-collector.js
+++ b/src/utils/garbage-collector.js
@@ -307,11 +307,18 @@ export async function nukeBoardDb(opts = {}) {
   const dryRun = Boolean(opts.dryRun);
   const kHome = getKarajanHome();
 
-  // Stop the board if we find a live pidfile.
+  // Stop the board if we find a live pidfile — UNLESS we're being
+  // invoked from inside the board itself (the user clicked ⚡ →
+  // `kj clean --nuke` in the launcher). In that case killing the
+  // board would kill the page they're looking at, mid-confirm.
+  // command-runner.js sets KJ_INSIDE_BOARD=1 on every spawn so we
+  // can detect this. The nuke still wipes the DB; the board picks
+  // up the empty DB on its next chokidar tick.
+  const insideBoard = process.env.KJ_INSIDE_BOARD === "1";
   const pidFile = path.join(kHome, "hu-board.pid");
   try {
     const pid = Number.parseInt(await fs.readFile(pidFile, "utf8"), 10);
-    if (!dryRun && Number.isFinite(pid)) {
+    if (!dryRun && Number.isFinite(pid) && !insideBoard) {
       try { process.kill(pid, 0); process.kill(pid, "SIGTERM"); } catch { /* already dead */ }
     }
   } catch { /* no pidfile */ }

--- a/tests/board-start-detach.test.js
+++ b/tests/board-start-detach.test.js
@@ -28,6 +28,24 @@ vi.mock("node:net", () => ({
     }),
   },
 }));
+// startBoard now HTTP-probes the configured port (`isBoardReachable`)
+// before spawning, as a fallback for stale/missing PID files. Stub
+// `node:http` so the probe immediately fails (i.e. "no board there"),
+// letting the spawn path proceed deterministically.
+vi.mock("node:http", () => {
+  return {
+    default: {
+      request: () => {
+        const handlers = {};
+        return {
+          on: (ev, cb) => { handlers[ev] = cb; },
+          end: () => { setImmediate(() => handlers.error?.(new Error("ECONNREFUSED"))); },
+          destroy: () => {},
+        };
+      },
+    },
+  };
+});
 
 let tmpHome;
 


### PR DESCRIPTION
## Summary

Fixes the user's report: clicked ⚡ → kj plan, output said the new board was on \`localhost:4001\` even though they'd launched it on 4000. **Cause**: the 🔁 self-restart spawned a new server but never updated the PID file (only \`kj board start\` wrote it), so a later auto-start saw a stale dead PID, gave up on reuse, and spawned a duplicate on the next free port (4001).

Also fixes two adjacent confusions:
- **\`kj clean --nuke\` from inside the board killed the board itself**, mid-modal-confirm, ending the page the user was looking at
- **The 📜 View log button** only surfaced after a kanban Run-plan click — not after the ⚡ launcher

## Four connected fixes

### 1. Server writes its own PID file

\`kj board start\` was the only writer of \`~/.karajan/hu-board.pid\`. After 🔁 restart the new server kept running but the PID file pointed at the dead old one. Now the server writes its own pid on \`listen()\` and removes it on graceful shutdown — both CLI launch and in-place restart keep the file accurate.

### 2. HTTP-probe before spawning (\`startBoard\`)

Belt-and-suspenders for stale-PID-file scenarios: before spawning, HTTP-ping \`/api/dashboard\`. If something responds 2xx, treat it as \"already running\" and return the existing URL. 750 ms timeout.

### 3. \`kj clean --nuke\` from inside the board no longer SIGTERMs the board

\`command-runner.js\` sets \`KJ_INSIDE_BOARD=1\` on every spawn. \`nukeBoardDb\` checks the var before sending SIGTERM. The DB still gets wiped; the board picks up the empty state on the next chokidar tick. Outside the board (plain \`kj clean --nuke\` from a terminal) the SIGTERM behaviour is unchanged.

### 4. 📜 View log surfaces command-launcher runs too

New \`lastOpenedLog\` (\`{id, label, tailUrl}\`) generic across plan-run and command-launcher flows. \`runProject()\` and \`openCommandLogViewer()\` both populate it; the section-header button re-opens whichever was last.

## Tests

\`tests/board-start-detach.test.js\` updated to stub \`node:http\` so the new \`isBoardReachable\` probe is deterministic. 3933 parent + 119 board green.

## Test plan

- [x] \`npx vitest run tests/\` → 3933/3933
- [x] \`npx vitest run packages/hu-board/\` → 119/119
- [ ] Manual: \`kj board start\` → 🔁 restart → ⚡ kj plan → auto-start reuses port 4000, no 4001 dupe
- [ ] Manual: ⚡ kj clean --nuke → board stays alive, DB wiped, page refreshes empty
- [ ] Manual: ⚡ kj plan → close log → 📜 View log button appears in board header → reopens log