### PR TITLE
fix(board): kj board stop now actually stops the board (3-step fallback)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -647,6 +647,22 @@ router.get('/runs/:commandId/log', (req, res) => {
  * The browser tab's EventSource auto-reconnects, so the user sees a
  * brief blip and the board comes back live.
  */
+/**
+ * POST /api/board/shutdown - Tell the server to exit cleanly. Used
+ * by `kj board stop` as a fallback when the PID file is missing or
+ * stale (typical after the user has been hot-pulling Karajan and
+ * the running server is from a build that didn't write the PID
+ * file). The body of the response is sent before we exit, then a
+ * 250 ms delay to let the response flush, then process.exit(0).
+ */
+router.post('/board/shutdown', (_req, res) => {
+  if (process.env.KJ_BOARD_RESTART_MODE === 'echo') {
+    return res.json({ ok: true, mode: 'echo' });
+  }
+  res.json({ ok: true, shuttingDownInMs: 250 });
+  setTimeout(() => process.exit(0), 250);
+});
+
 router.post('/board/restart', (_req, res) => {
   // Tests / programmatic callers can short-circuit the actual self-
   // exec via env so the suite doesn't have its node process killed

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -4,6 +4,7 @@ import path from "node:path";
 import net from "node:net";
 import { spawn } from "node:child_process";
 import { getKarajanHome } from "../utils/paths.js";
+import { getPortOccupant } from "../utils/port-occupant.js";
 
 const BOARD_DIR = path.resolve(import.meta.dirname, "../../packages/hu-board");
 const PID_FILE = path.join(getKarajanHome(), "hu-board.pid");
@@ -148,19 +149,66 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
   return { ok: true, alreadyRunning: false, pid: child.pid, url: buildBoardUrl(port, projectSlug), port };
 }
 
-export async function stopBoard() {
+export async function stopBoard(opts = {}) {
+  const { port = 4000 } = opts;
+  // Path 1: live PID in the file → straight SIGTERM. Pre-v2.7.5
+  // this was the only path; if the file was missing or stale (e.g.
+  // user ran a board built before the server-writes-own-PID fix in
+  // PR #508) we'd return "wasn't running" while the ghost server
+  // happily kept serving requests. The fallbacks below close that gap.
   const pid = readPid();
-  if (!pid || !isProcessAlive(pid)) {
+  if (pid && isProcessAlive(pid)) {
+    try { process.kill(pid, "SIGTERM"); } catch { /* race with dying process */ }
     fs.rmSync(PID_FILE, { force: true });
-    return { ok: true, wasRunning: false };
-  }
-
-  try {
-    process.kill(pid, "SIGTERM");
-  } catch { /* process already dead */
+    return { ok: true, wasRunning: true, pid, via: "pidfile" };
   }
   fs.rmSync(PID_FILE, { force: true });
-  return { ok: true, wasRunning: true, pid };
+
+  // Path 2: HTTP-ask the server to exit cleanly. Works for any
+  // running server that has the /api/board/shutdown endpoint —
+  // even when there's no PID file, no process tree to walk, etc.
+  const shutdownUrl = `/api/board/shutdown`;
+  const shutdownOk = await postBoardShutdown(port, shutdownUrl);
+  if (shutdownOk) {
+    return { ok: true, wasRunning: true, pid: null, via: "api" };
+  }
+
+  // Path 3: there's something on the port and the API didn't take it
+  // down. Find its PID via lsof / ss / netstat and SIGTERM it.
+  // Works against truly old servers that don't have the shutdown
+  // endpoint, with the cost of one extra subprocess call.
+  try {
+    const occupant = await getPortOccupant(port);
+    if (occupant?.pid) {
+      try { process.kill(occupant.pid, "SIGTERM"); } catch { /* gone */ }
+      return { ok: true, wasRunning: true, pid: occupant.pid, via: "port-occupant" };
+    }
+  } catch { /* lsof not installed etc — fall through */ }
+
+  return { ok: true, wasRunning: false };
+}
+
+/**
+ * Best-effort POST to the board's shutdown endpoint. Returns true
+ * when the server acks (and is presumably exiting); false on any
+ * error so the caller falls through to the next strategy.
+ */
+function postBoardShutdown(port, urlPath, timeoutMs = 750) {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: urlPath, method: 'POST', timeout: timeoutMs,
+        headers: { 'Content-Type': 'application/json', 'Content-Length': '2' } },
+      (res) => {
+        const ok = res.statusCode >= 200 && res.statusCode < 400;
+        res.resume();
+        resolve(ok);
+      }
+    );
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.write('{}');
+    req.end();
+  });
 }
 
 export async function boardStatus(port = 4000) {
@@ -229,9 +277,11 @@ export async function boardCommand({ action = "start", port = 4000, logger }) {
       return result;
     }
     case "stop": {
-      const result = await stopBoard();
+      const result = await stopBoard({ port });
       if (result.wasRunning) {
-        logger.info(`HU Board stopped (PID ${result.pid})`);
+        const pidPart = result.pid ? ` (PID ${result.pid})` : "";
+        const viaPart = result.via && result.via !== "pidfile" ? ` [via ${result.via}]` : "";
+        logger.info(`HU Board stopped${pidPart}${viaPart}`);
       } else {
         logger.info("HU Board was not running");
       }

--- a/tests/board-stop-fallback.test.js
+++ b/tests/board-stop-fallback.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression for the user's report: `kj board stop` returned
+// "wasn't running" while a board was clearly serving requests on
+// localhost:4000. Cause: the running server was built before the
+// server-writes-own-PID fix (PR #508), so the PID file was either
+// missing or pointing at a long-dead process. The CLI's PID-only
+// stop path declared victory and walked away from the ghost.
+//
+// New stopBoard tries three strategies in order:
+//   1. PID file (existing behaviour)
+//   2. POST /api/board/shutdown (works against any modern server)
+//   3. getPortOccupant + SIGTERM (for old servers without the API)
+
+const httpRequest = vi.fn();
+vi.mock("node:http", () => ({
+  default: { request: (...args) => httpRequest(...args) },
+}));
+
+const portOccupant = vi.fn();
+vi.mock("../src/utils/port-occupant.js", () => ({
+  getPortOccupant: (...args) => portOccupant(...args),
+}));
+
+let tmpHome;
+const originalKill = process.kill;
+let killCalls;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-board-stop-"));
+  process.env.KJ_HOME = tmpHome;
+  httpRequest.mockReset();
+  portOccupant.mockReset();
+  vi.resetModules();
+  killCalls = [];
+  // Stub process.kill globally so SIGTERM paths don't actually fire
+  // in the test runner (signal 0 is still allowed for liveness probe).
+  process.kill = (pid, sig) => {
+    killCalls.push({ pid, sig });
+    if (sig === 0) {
+      // Probe-mode: throw ESRCH to signal "no such process" unless
+      // the test sets ALIVE_PIDS.
+      if (!global.__alivePids?.has(pid)) {
+        const e = new Error("kill ESRCH");
+        e.code = "ESRCH";
+        throw e;
+      }
+      return true;
+    }
+    return true;
+  };
+});
+
+afterEach(() => {
+  process.kill = originalKill;
+  delete global.__alivePids;
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+function mockHttpReply(status) {
+  httpRequest.mockImplementation((_opts, cb) => {
+    const fakeRes = { statusCode: status, resume: () => {} };
+    setImmediate(() => cb(fakeRes));
+    return { on: () => {}, end: () => {}, write: () => {}, destroy: () => {} };
+  });
+}
+
+function mockHttpError() {
+  httpRequest.mockImplementation(() => {
+    const handlers = {};
+    setImmediate(() => handlers.error?.(new Error("ECONNREFUSED")));
+    return {
+      on: (ev, cb) => { handlers[ev] = cb; },
+      end: () => {},
+      write: () => {},
+      destroy: () => {},
+    };
+  });
+}
+
+describe("stopBoard — three-step fallback", () => {
+  it("strategy 1: live PID in the file → SIGTERM via PID, reports via:pidfile", async () => {
+    writeFileSync(join(tmpHome, "hu-board.pid"), "12345");
+    global.__alivePids = new Set([12345]);
+    const { stopBoard } = await import("../src/commands/board.js");
+    const result = await stopBoard({ port: 4000 });
+    expect(result).toMatchObject({ wasRunning: true, pid: 12345, via: "pidfile" });
+    expect(killCalls.some((c) => c.pid === 12345 && c.sig === "SIGTERM")).toBe(true);
+  });
+
+  it("strategy 2: stale PID file → API shutdown succeeds, reports via:api", async () => {
+    writeFileSync(join(tmpHome, "hu-board.pid"), "99999");
+    // 99999 is NOT in __alivePids → isProcessAlive returns false → fall through
+    mockHttpReply(200);
+    const { stopBoard } = await import("../src/commands/board.js");
+    const result = await stopBoard({ port: 4000 });
+    expect(result).toMatchObject({ wasRunning: true, via: "api" });
+  });
+
+  it("strategy 2: PID file missing entirely → API shutdown still works", async () => {
+    mockHttpReply(200);
+    const { stopBoard } = await import("../src/commands/board.js");
+    const result = await stopBoard({ port: 4000 });
+    expect(result.via).toBe("api");
+  });
+
+  it("strategy 3: API endpoint unavailable (old build) → port-occupant SIGTERM, reports via:port-occupant", async () => {
+    mockHttpError();
+    portOccupant.mockResolvedValue({ port: 4000, pid: 7777, command: "node", raw: "" });
+    const { stopBoard } = await import("../src/commands/board.js");
+    const result = await stopBoard({ port: 4000 });
+    expect(result).toMatchObject({ wasRunning: true, pid: 7777, via: "port-occupant" });
+    expect(killCalls.some((c) => c.pid === 7777 && c.sig === "SIGTERM")).toBe(true);
+  });
+
+  it("nothing running anywhere → wasRunning:false, no kill calls", async () => {
+    mockHttpError();
+    portOccupant.mockResolvedValue(null);
+    const { stopBoard } = await import("../src/commands/board.js");
+    const result = await stopBoard({ port: 4000 });
+    expect(result).toEqual({ ok: true, wasRunning: false });
+    expect(killCalls.filter((c) => c.sig === "SIGTERM")).toHaveLength(0);
+  });
+
+  it("API succeeds preempts the port-occupant fallback (no double-kill)", async () => {
+    mockHttpReply(200);
+    portOccupant.mockResolvedValue({ port: 4000, pid: 8888, command: "node", raw: "" });
+    const { stopBoard } = await import("../src/commands/board.js");
+    await stopBoard({ port: 4000 });
+    expect(killCalls.filter((c) => c.sig === "SIGTERM")).toHaveLength(0);
+    expect(portOccupant).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

User reported: ran \`kj board stop\`, the board kept serving on \`localhost:4000\`. **Cause**: the running server was built before PR #508's *\"server writes its own PID\"* fix. The PID file was missing or pointing at a long-dead process. The CLI's PID-only stop path declared *\"wasn't running\"* and walked away from the ghost server.

\`stopBoard\` now tries **three strategies in order**:

| # | Strategy | When it works |
|---|---|---|
| 1 | PID file → SIGTERM | Standard happy path |
| 2 | POST \`/api/board/shutdown\` | Modern server, missing/stale PID file |
| 3 | \`getPortOccupant\` + SIGTERM | Truly old server with no shutdown endpoint |

Each path reports \`via: \"pidfile\" | \"api\" | \"port-occupant\"\` so the CLI can show *\"HU Board stopped (PID 7777) [via port-occupant]\"* when a fallback fired — useful diagnostic for ghost-server cases.

Also adds \`POST /api/board/shutdown\` to the API surface. Same \`KJ_BOARD_RESTART_MODE=echo\` test seam as the existing \`/restart\`.

\`boardCommand\` passes the configured port to \`stopBoard\` so the API + port-occupant probes hit the right one.

## Tests

\`tests/board-stop-fallback.test.js\` (6): each strategy in isolation; \"API success preempts port-occupant\" (no double-kill); \"nothing running anywhere → wasRunning:false\". Stubs \`node:http\` + \`getPortOccupant\` for hermetic execution.

3939 parent + 119 board green.

## Test plan

- [x] \`npx vitest run tests/\` → 3939/3939
- [x] \`npx vitest run packages/hu-board/\` → 119/119
- [ ] Manual: kill PID file → \`kj board stop\` → server still goes down (via API) → curl 4000 → ECONNREFUSED
- [ ] Manual: against a pre-#508 ghost server → \`kj board stop\` → goes down (via port-occupant) → log says \`[via port-occupant]\`