### PR TITLE
fix(board): sync accepts v2.7.5 structured tests {type, content, file?}

### DIFF
--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -332,11 +332,21 @@ export function syncPlanFile(filePath) {
       // DO count as 1 test each. But empty strings / null entries
       // (which show up in half-baked plans) must not inflate the
       // badge to "🧪 1 test" on a HU that effectively has none.
+      // Drop empty entries but accept BOTH legacy shapes and the
+      // v2.7.5 structured form. The original anti-junk filter only
+      // knew the legacy shape (`name|title|description|given|gherkin|
+      // scope`) and silently nuked every test produced by the
+      // tests-synthesizer (which emits `{type, content, file?}`),
+      // leaving every HU flagged "missing test contract" on the
+      // board even though the plan JSON had 4 tests apiece.
       const testList = (Array.isArray(hu.acceptance_tests) ? hu.acceptance_tests : [])
         .filter((t) => {
           if (!t) return false;
           if (typeof t === 'string') return t.trim().length > 0;
-          // objects: require some identifying field
+          if (typeof t !== 'object') return false;
+          // v2.7.5 structured form — primary shape going forward.
+          if (typeof t.content === 'string' && t.content.trim().length > 0) return true;
+          // Legacy shapes kept for back-compat with hand-edited plans.
           return Boolean(t.name || t.title || t.description || t.given || t.gherkin || t.scope);
         });
       const blockedByList = Array.isArray(hu.blocked_by) ? hu.blocked_by : [];

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -470,6 +470,37 @@ describe('empty acceptance_tests entries must not inflate test_count', () => {
     const row = dbMod.getStoriesByProject(PROJECT_ID).find((s) => s.id.endsWith('_901'));
     expect(row.test_count).toBe(2);
   });
+
+  // Regression for the v2.7.5 dogfooding hit: the synthesizer (PR #502)
+  // emits `{ type: "shell" | "gherkin", content: "..." }`. The original
+  // anti-junk filter only knew the legacy shape (name/title/given/…)
+  // and rejected every structured entry, leaving test_count = 0 on
+  // the board even though the plan JSON had 4 tests apiece.
+  it('keeps v2.7.5 structured form { type, content, file? } from the synthesizer', () => {
+    writePlanToDisk({
+      hus: [
+        {
+          id: `${PLAN_ID}_902`,
+          title: 'structured',
+          status: 'pending',
+          acceptance_criteria: [],
+          acceptance_tests: [
+            { type: 'shell', content: 'npx vitest run path/to/spec.test.ts' },
+            { type: 'gherkin', content: 'Given x\nWhen y\nThen z' },
+            { type: 'shell', content: 'tsc --noEmit', file: 'tsconfig.json' },
+            { type: 'shell', content: '   ' },              // empty content → drop
+            { type: 'shell' },                               // no content    → drop
+          ],
+          blocked_by: [],
+          createdAt: 'a', updatedAt: 'a',
+        },
+      ],
+    });
+    syncMod.syncPlanFile(planPath());
+    const row = dbMod.getStoriesByProject(PROJECT_ID).find((s) => s.id.endsWith('_902'));
+    expect(row.test_count).toBe(3);
+    expect(row.acceptance_tests).not.toBeNull();
+  });
 });
 
 describe('acceptance_tests stamping', () => {


### PR DESCRIPTION
## Summary

User report: \`kj plan\` ran the synthesizer and patched all 11 HUs with 4 acceptance_tests each (verified in the plan JSON). The board kept flagging every card as *\"⚠ missing test contract\"*.

**Root cause**: when PR #489 added the anti-junk filter to \`syncPlanFile\`, it only knew the legacy test shapes:

    name | title | description | given | gherkin | scope

Two PRs later (#491) the planner started emitting the v2.7.5 structured shape:

    { type: \"shell\" | \"gherkin\", content: \"...\", file?: \"...\" }

The structured form has none of the legacy keys, so the filter rejected every entry → \`testList = []\` → \`test_count = 0\` → board sees no tests. **The plan JSON itself was fine; only the board's SQLite cache was wrong.**

## Fix

Extend the filter to ALSO accept entries with a non-empty \`content\` string (the canonical v2.7.5 form). Legacy shapes still work for back-compat with hand-edited plans.

## Tests

Regression case in \`plan-mutations.test.js\`: 5 entries (3 valid shell+gherkin, 1 empty content, 1 missing content) → \`test_count = 3\`, \`acceptance_tests != null\`.

3939 parent + 120 board green.

## Test plan

- [x] \`npx vitest run packages/hu-board/\` → 120/120
- [x] \`npx vitest run tests/\` → 3939/3939
- [ ] Manual: \`kj board stop && kj board start\`, hit /api/sync — board now shows ✅ N tests on each card instead of ⚠ missing