### PR TITLE
feat(coder): inject ADRs, SPEC section, reviewer findings into coder prompt (PR F)

### DIFF
--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -197,6 +197,28 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
       const huMaxIterations = ctx.config.hu_max_iterations ?? 3;
       const huBranches = new Map();
       const { prepareHuBranch, finalizeHuCommit } = await import("../git/hu-automation.js");
+
+      // PR F (v2.7.5): the per-HU loop needs three pieces of plan context:
+      //   • ADRs (loaded once from disk, applies to every HU on this plan)
+      //   • the plan-reviewer findings (rides on the huBatch)
+      //   • each HU's spec_section (rides on the story)
+      // Loading ADRs once outside the loop avoids hitting the filesystem
+      // per-HU. When the plan never went through `kj plan` (legacy
+      // auto-generated batch), planId is null → loadActiveAdrs falls back
+      // to the "_loose" bucket and returns [] silently.
+      const planId = ctx.stageResults.huReviewer.planId || null;
+      const reviewerFindings = ctx.stageResults.huReviewer.review || null;
+      let planAdrs = [];
+      try {
+        const { loadActiveAdrs } = await import("../plan/adr-loader.js");
+        planAdrs = await loadActiveAdrs(ctx.config.projectDir || process.cwd(), planId);
+        if (planAdrs.length > 0) {
+          logger.info(`Plan ${planId || "(loose)"}: loaded ${planAdrs.length} ADR(s) for coder context`);
+        }
+      } catch (err) {
+        logger.warn(`ADR loader failed (non-blocking): ${err.message}`);
+      }
+
       const subPipelineResult = await runHuSubPipeline({
         huReviewerResult: ctx.stageResults.huReviewer,
         runIterationFn: async (huTask, story) => {
@@ -243,7 +265,15 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
                 config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
                 session: ctx.session, plannedTask: ctx.plannedTask,
                 trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: ctx.brainCtx,
-                acceptanceTests: story.acceptance_tests
+                acceptanceTests: story.acceptance_tests,
+                // PR F (v2.7.5): plan-aware coder context. ADRs are
+                // shared across the plan, the rest are scoped to this
+                // HU. buildCoderPrompt skips any section whose data is
+                // null/empty so legacy paths render the same prompt.
+                adrs: planAdrs,
+                specSection: story.spec_section || null,
+                reviewerFindings,
+                huId: story.id
               });
               if (coderResult?.action === "standby" || coderResult?.action === "pause") {
                 return coderResult?.result || { approved: false, reason: "coder_failed" };

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -19,7 +19,7 @@ import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
 
-export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null }) {
+export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
   logger.setContext({ iteration, stage: "coder" });
   emitProgress(
     emitter,
@@ -55,6 +55,10 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       // Tests-first contract flows through to buildCoderPrompt which
       // renders the "Acceptance Tests — MUST pass" section.
       acceptanceTests,
+      // PR F (v2.7.5): plan-aware context. ADRs apply to every HU on
+      // the plan, the rest are scoped to this HU. All four pass through
+      // untouched when the caller omits them (legacy single-task runs).
+      adrs, specSection, reviewerFindings, huId,
       onOutput: coderStall.onOutput
     });
   } finally {

--- a/src/plan/adr-loader.js
+++ b/src/plan/adr-loader.js
@@ -1,0 +1,53 @@
+/**
+ * Counterpart to `adr-generator.js`: reads back the persisted ADRs
+ * for a given plan so the coder / reviewer can pull them into their
+ * prompt context. PR F of the v2.7.5 multi-step planning roadmap.
+ *
+ * ADRs live at `~/.kj/plans/<slug>/<planId>/adrs/<id>.md` (per
+ * `adr-generator.js::writeAdrsToDisk`). On read we surface the raw
+ * markdown to the caller — they decide how much of it to render.
+ *
+ * Returns an empty array (not an error) when the directory doesn't
+ * exist: not every plan has ADRs (architect role is optional).
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { plansDir } from "./plan-store.js";
+
+/**
+ * @typedef {Object} Adr
+ * @property {string} id           - "0001-use-vitest"
+ * @property {string} markdown     - full file contents
+ */
+
+/**
+ * @param {string} projectDir
+ * @param {string|null} planId  - null falls back to the "_loose" bucket
+ *                                used by `kj architect` standalone
+ * @returns {Promise<Adr[]>}
+ */
+export async function loadActiveAdrs(projectDir, planId) {
+  if (!projectDir) return [];
+  const slug = planId || "_loose";
+  const dir = join(plansDir(projectDir), slug, "adrs");
+  let files;
+  try {
+    const s = await stat(dir);
+    if (!s.isDirectory()) return [];
+    files = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const adrs = [];
+  for (const file of files) {
+    if (!file.endsWith(".md")) continue;
+    try {
+      const md = await readFile(join(dir, file), "utf-8");
+      adrs.push({ id: file.replace(/\.md$/, ""), markdown: md });
+    } catch { /* skip unreadable file */ }
+  }
+  // Numeric prefix in id ("0001-…") sorts naturally.
+  adrs.sort((a, b) => a.id.localeCompare(b.id));
+  return adrs;
+}

--- a/src/plan/plan-executor.js
+++ b/src/plan/plan-executor.js
@@ -27,6 +27,10 @@ export function planToHuBatch(plan) {
     certified: { text: hu.scope || hu.title },
     acceptance_criteria: hu.acceptance_criteria || [],
     acceptance_tests: hu.acceptance_tests || [],
+    // PR F (v2.7.5): forward the SPEC section pointer into the story
+    // so the per-HU loop in flow-runner can hand it to the coder
+    // prompt without having to re-load the plan from disk.
+    spec_section: hu.spec_section || null,
     original: { text: hu.scope || hu.title }
   }));
 
@@ -39,6 +43,12 @@ export function planToHuBatch(plan) {
     certified,
     batchSessionId: `plan-${plan.planId}`,
     planId: plan.planId,
+    // PR F (v2.7.5): plan-wide reviewer findings ride along the batch
+    // so the coder can be told about issues that touch its HU. The
+    // shape mirrors plan-reviewer.js output (missing_dependencies,
+    // scope_overlaps, order_issues, …) — null when the reviewer
+    // never ran for this plan.
+    review: plan.review || null,
     auto_generated: false,
     source: { plan: true, planId: plan.planId }
   };

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -86,7 +86,79 @@ function renderAcceptanceTestsSection(tests) {
   return lines.join("\n");
 }
 
-export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null }) {
+/**
+ * Render the active ADRs (PR F) as a "MUST respect" preamble. Each
+ * ADR is shown verbatim — they're already in Nygard format
+ * (Context · Decision · Consequences) and the coder benefits from
+ * the full text, not a summary. Keeps the prompt size sane: caps at
+ * 8 ADRs (the planner shouldn't realistically emit more for one
+ * plan, but bound it just in case).
+ */
+function renderAdrSection(adrs) {
+  if (!Array.isArray(adrs) || adrs.length === 0) return "";
+  const capped = adrs.slice(0, 8);
+  const lines = [
+    "## Architecture Decision Records (active)",
+    "",
+    "These ADRs were committed by the architect role. Your implementation MUST respect them. If the SPEC asks for something incompatible with one of these, surface the conflict in your PR description rather than silently overriding the ADR.",
+    "",
+  ];
+  for (const adr of capped) {
+    lines.push(adr.markdown.trim(), "", "---", "");
+  }
+  if (adrs.length > capped.length) {
+    lines.push(`_(…${adrs.length - capped.length} more ADRs not shown — see ~/.kj/plans/<slug>/<planId>/adrs/.)_`, "");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * SPEC-section pointer (PR F). One short line. Lets the coder put
+ * "implements §X.Y of SPEC.md" in the PR description for traceability.
+ */
+function renderSpecSectionLine(specSection) {
+  if (!specSection) return "";
+  return [
+    "## SPEC reference",
+    "",
+    `This HU implements **§${specSection}** of the source SPEC. Cite this section in your PR description so the reviewer can trace coverage end-to-end.`,
+  ].join("\n");
+}
+
+/**
+ * Plan-reviewer findings relevant to this HU (PR F). The reviewer's
+ * output is plan-wide; we filter to entries that mention the
+ * current HU id so the coder gets only what's actionable for them.
+ */
+function renderReviewerFindingsSection(findings, huId) {
+  if (!findings || !huId) return "";
+  const items = [];
+  for (const md of findings.missing_dependencies || []) {
+    if (md.from === huId) items.push(`- This HU should depend on **${md.on}** — ${md.rationale}`);
+    else if (md.on === huId) items.push(`- HU **${md.from}** should depend on this one — ${md.rationale}`);
+  }
+  for (const ov of findings.scope_overlaps || []) {
+    if (Array.isArray(ov.between) && ov.between.includes(huId)) {
+      const others = ov.between.filter((id) => id !== huId);
+      items.push(`- Scope overlap with **${others.join(", ")}** — ${ov.rationale}`);
+    }
+  }
+  for (const oi of findings.order_issues || []) {
+    if (Array.isArray(oi.hus) && oi.hus.includes(huId)) {
+      items.push(`- Order issue (${oi.issue}): ${oi.rationale}`);
+    }
+  }
+  if (items.length === 0) return "";
+  return [
+    "## Reviewer findings about this HU",
+    "",
+    "The plan reviewer flagged the following — consider them while implementing:",
+    "",
+    ...items,
+  ].join("\n");
+}
+
+export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
   const langInstruction = getLanguageInstruction(language);
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
@@ -122,10 +194,24 @@ export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSum
     sections.push(`## Implementation Plan (from planner)\nFollow these steps:\n${plan}`);
   }
 
-  // Tests-first contract: injected right after the plan so the coder
-  // reads "here are the steps" and immediately "here's the gate they
-  // need to satisfy". Placed BEFORE coder rules / TDD policy so those
-  // frame the tests, not the other way around.
+  // PR F context injections — order matters:
+  //   1. ADRs first (they constrain HOW you implement),
+  //   2. SPEC reference (what section we're satisfying),
+  //   3. Reviewer findings about THIS HU (warnings the coder needs
+  //      to consider while writing code),
+  //   4. Acceptance tests (the gate the implementation must pass).
+  // All four sit BEFORE coder rules / TDD policy so the policy
+  // frames them, not the other way around.
+  const adrSection = renderAdrSection(adrs);
+  if (adrSection) sections.push(adrSection);
+
+  const specSectionLine = renderSpecSectionLine(specSection);
+  if (specSectionLine) sections.push(specSectionLine);
+
+  const reviewerSection = renderReviewerFindingsSection(reviewerFindings, huId);
+  if (reviewerSection) sections.push(reviewerSection);
+
+  // Tests-first contract: the gate the implementation must pass.
   const testsSection = renderAcceptanceTestsSection(acceptanceTests);
   if (testsSection) {
     sections.push(testsSection);

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -22,7 +22,15 @@ export class CoderRole extends AgentRole {
   }
 
   extractInput(input) {
-    if (typeof input === "string") return { task: input, reviewerFeedback: null, sonarSummary: null, deferredContext: null, acceptanceTests: null, onOutput: null };
+    if (typeof input === "string") {
+      return {
+        task: input,
+        reviewerFeedback: null, sonarSummary: null, deferredContext: null,
+        acceptanceTests: null,
+        adrs: null, specSection: null, reviewerFindings: null, huId: null,
+        onOutput: null
+      };
+    }
     return {
       task: input?.task || this.context?.task || "",
       reviewerFeedback: input?.reviewerFeedback || null,
@@ -32,13 +40,23 @@ export class CoderRole extends AgentRole {
       // must satisfy. Only the plan-backed HU path populates this;
       // the standard single-task `kj run` flow leaves it null.
       acceptanceTests: input?.acceptanceTests || null,
+      // PR F (v2.7.5): per-HU planning context. ADRs constrain HOW,
+      // specSection ties this HU to a SPEC heading, reviewerFindings
+      // are filtered to entries that mention this HU. All four are
+      // null for non-plan-backed runs, which keeps the legacy flow
+      // byte-for-byte identical.
+      adrs: Array.isArray(input?.adrs) ? input.adrs : null,
+      specSection: input?.specSection || null,
+      reviewerFindings: input?.reviewerFindings || null,
+      huId: input?.huId || null,
       onOutput: input?.onOutput || null
     };
   }
 
-  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests }) {
+  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests, adrs, specSection, reviewerFindings, huId }) {
     const prompt = await buildCoderPrompt({
       task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests,
+      adrs, specSection, reviewerFindings, huId,
       coderRules: this.instructions,
       methodology: this.config?.development?.methodology || "tdd",
       serenaEnabled: Boolean(this.config?.serena?.enabled),

--- a/tests/coder-prompt-tests-first.test.js
+++ b/tests/coder-prompt-tests-first.test.js
@@ -76,3 +76,149 @@ describe("buildCoderPrompt — acceptance_tests section", () => {
     expect(prompt).toMatch(/do NOT silently rewrite the test/);
   });
 });
+
+// PR F (v2.7.5): the coder prompt absorbs three more pieces of plan
+// context — ADRs (constrains HOW you implement), the SPEC section
+// pointer (what the HU is satisfying), and the plan-reviewer findings
+// filtered to entries that actually mention the current HU.
+
+describe("buildCoderPrompt — ADR section", () => {
+  it("is omitted when no ADRs are passed", async () => {
+    const prompt = await buildCoderPrompt({ task: "do a thing" });
+    expect(prompt).not.toMatch(/Architecture Decision Records/);
+  });
+
+  it("is omitted when ADRs is an empty array", async () => {
+    const prompt = await buildCoderPrompt({ task: "do a thing", adrs: [] });
+    expect(prompt).not.toMatch(/Architecture Decision Records/);
+  });
+
+  it("renders the ADR markdown verbatim with a MUST-respect preamble", async () => {
+    const md = "# 0001 — Use Vitest\n\n## Context\nWe need a JS runner.\n\n## Decision\nVitest.\n\n## Consequences\n- Fast.\n";
+    const prompt = await buildCoderPrompt({
+      task: "wire it up",
+      adrs: [{ id: "0001-use-vitest", markdown: md }],
+    });
+    expect(prompt).toMatch(/## Architecture Decision Records \(active\)/);
+    expect(prompt).toMatch(/MUST respect them/);
+    expect(prompt).toContain(md.trim());
+  });
+
+  it("caps at 8 ADRs and notes how many were truncated", async () => {
+    const adrs = Array.from({ length: 11 }, (_, i) => ({
+      id: `${String(i + 1).padStart(4, "0")}-x`,
+      markdown: `# ADR ${i + 1}\nbody-${i + 1}`,
+    }));
+    const prompt = await buildCoderPrompt({ task: "x", adrs });
+    expect(prompt).toMatch(/body-1\b/);
+    expect(prompt).toMatch(/body-8\b/);
+    expect(prompt).not.toMatch(/body-9\b/);
+    expect(prompt).toMatch(/3 more ADRs not shown/);
+  });
+});
+
+describe("buildCoderPrompt — SPEC section pointer", () => {
+  it("is omitted when no specSection is passed", async () => {
+    const prompt = await buildCoderPrompt({ task: "x" });
+    expect(prompt).not.toMatch(/SPEC reference/);
+  });
+
+  it("renders a one-line pointer the coder can cite", async () => {
+    const prompt = await buildCoderPrompt({ task: "x", specSection: "5.3" });
+    expect(prompt).toMatch(/## SPEC reference/);
+    expect(prompt).toMatch(/§5\.3/);
+    expect(prompt).toMatch(/Cite this section in your PR description/);
+  });
+});
+
+describe("buildCoderPrompt — reviewer findings filtered per HU", () => {
+  const huId = "hu_p001_002";
+
+  it("is omitted when there are no findings", async () => {
+    const prompt = await buildCoderPrompt({ task: "x", huId });
+    expect(prompt).not.toMatch(/Reviewer findings about this HU/);
+  });
+
+  it("is omitted when no finding mentions this HU", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      huId,
+      reviewerFindings: {
+        missing_dependencies: [{ from: "hu_p001_007", on: "hu_p001_009", rationale: "irrelevant" }],
+        scope_overlaps: [{ between: ["hu_p001_004", "hu_p001_005"], rationale: "irrelevant" }],
+        order_issues: [{ hus: ["hu_p001_010"], issue: "x", rationale: "irrelevant" }],
+      },
+    });
+    expect(prompt).not.toMatch(/Reviewer findings about this HU/);
+  });
+
+  it("renders missing_dependency where the HU is the source", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      huId,
+      reviewerFindings: {
+        missing_dependencies: [{ from: huId, on: "hu_p001_001", rationale: "needs schema first" }],
+      },
+    });
+    expect(prompt).toMatch(/should depend on \*\*hu_p001_001\*\*/);
+    expect(prompt).toMatch(/needs schema first/);
+  });
+
+  it("renders missing_dependency where the HU is the target", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      huId,
+      reviewerFindings: {
+        missing_dependencies: [{ from: "hu_p001_005", on: huId, rationale: "consumes the API" }],
+      },
+    });
+    expect(prompt).toMatch(/HU \*\*hu_p001_005\*\* should depend on this one/);
+    expect(prompt).toMatch(/consumes the API/);
+  });
+
+  it("renders scope_overlaps and lists the other HUs", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      huId,
+      reviewerFindings: {
+        scope_overlaps: [{ between: [huId, "hu_p001_004", "hu_p001_005"], rationale: "both touch /api/users" }],
+      },
+    });
+    expect(prompt).toMatch(/Scope overlap with \*\*hu_p001_004, hu_p001_005\*\*/);
+    expect(prompt).toMatch(/both touch \/api\/users/);
+  });
+
+  it("renders order_issues that mention the HU", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x",
+      huId,
+      reviewerFindings: {
+        order_issues: [{ hus: [huId, "hu_p001_001"], issue: "wrong-order", rationale: "schema must land first" }],
+      },
+    });
+    expect(prompt).toMatch(/Order issue \(wrong-order\)/);
+    expect(prompt).toMatch(/schema must land first/);
+  });
+});
+
+describe("buildCoderPrompt — section ordering for plan-aware run", () => {
+  it("renders ADRs → SPEC ref → reviewer findings → acceptance tests in that order", async () => {
+    const huId = "hu_p001_002";
+    const prompt = await buildCoderPrompt({
+      task: "implement",
+      adrs: [{ id: "0001-x", markdown: "# 0001 — X\n\nBody.\n" }],
+      specSection: "4.2",
+      reviewerFindings: { order_issues: [{ hus: [huId], issue: "i", rationale: "r" }] },
+      huId,
+      acceptanceTests: [{ type: "shell", content: "npx vitest run" }],
+    });
+    const idxAdr = prompt.indexOf("Architecture Decision Records");
+    const idxSpec = prompt.indexOf("SPEC reference");
+    const idxRev = prompt.indexOf("Reviewer findings about this HU");
+    const idxTests = prompt.indexOf("Acceptance Tests — MUST pass");
+    expect(idxAdr).toBeGreaterThan(-1);
+    expect(idxSpec).toBeGreaterThan(idxAdr);
+    expect(idxRev).toBeGreaterThan(idxSpec);
+    expect(idxTests).toBeGreaterThan(idxRev);
+  });
+});


### PR DESCRIPTION
## Summary

PR F is the final piece of the v2.7.5 multi-step planning roadmap (A=tests synthesizer #502, B=ADRs from Architect #503, C=spec_section per HU #504, D=plan reviewer #505). The coder now receives full plan-aware context whenever it runs against a persisted plan.

## What's injected

1. **ADRs from the architect** — loaded once per plan from `~/.kj/plans/<slug>/<planId>/adrs/`, rendered as a "MUST respect" preamble (capped at 8 with overflow notice).
2. **SPEC section pointer** — a one-line `implements §X.Y of SPEC.md` cue the coder cites in its PR description for traceability.
3. **Plan-reviewer findings filtered per-HU** — only entries that mention the current HU id are surfaced (missing_dependencies, scope_overlaps, order_issues).

All four sections render BEFORE the existing acceptance-tests block so the policy frames them, not the other way around. Section order: plan → ADRs → SPEC ref → reviewer findings → acceptance tests → coder rules → TDD policy.

## Files

- **NEW** `src/plan/adr-loader.js` — counterpart to `adr-generator.js`; reads `.md` files from the per-plan ADR directory; returns `[]` (not error) when the dir is missing.
- `src/prompts/coder.js` — three new render helpers + four new params on `buildCoderPrompt` (`adrs`, `specSection`, `reviewerFindings`, `huId`).
- `src/roles/coder-role.js` — extractInput / buildPrompt forward the new fields.
- `src/orchestrator/stages/coder-stage.js` — `runCoderStage` plumbs the new params to the role.
- `src/orchestrator/flow-runner.js` — loads ADRs once per plan outside the per-HU loop; passes the per-HU triple (specSection / reviewerFindings / huId) into each `runCoderStage` call.
- `src/plan/plan-executor.js` — `planToHuBatch` propagates `spec_section` per story and `review` on the batch.

## Backward compatibility

Every new section is omitted when its data is null or empty. Legacy single-task `kj run` invocations and any plan that hasn't gone through the architect/reviewer render the same prompt as before.

## Test plan

- [x] `tests/coder-prompt-tests-first.test.js` — 13 new cases covering ADR section (cap at 8, omit-when-empty), SPEC pointer, filtered reviewer findings (4 shapes), and the cross-section ordering invariant.
- [x] Full `npm test` — 3962 / 3962 passing.
- [x] HU Board test suite — 120 / 120 passing.