### PR TITLE
feat(planner): enforce spec_section + acceptance_tests in CLI prompt

### DIFF
--- a/src/plan/spec-detector.js
+++ b/src/plan/spec-detector.js
@@ -1,0 +1,61 @@
+/**
+ * Detect numbered/sectioned headings in a task description so the
+ * planner prompt can demand `spec_section` per HU instead of leaving
+ * it as a soft "preferred" hint that LLMs ignore.
+ *
+ * Recognises three common shapes (kept intentionally narrow — false
+ * positives turn the planner prompt into noise):
+ *
+ *   ## 1. Overview              → section "1",   title "Overview"
+ *   ### 2.1 add                 → section "2.1", title "add"
+ *   ## §5 Initial Scope         → section "5",   title "Initial Scope"
+ *
+ * The matcher is anchored to markdown heading lines (`^#+`) so prose
+ * mentions of a number ("see version 4.2") never trigger detection.
+ *
+ * Returns `{ hasSpec, sections, sectionList }`:
+ *   - `hasSpec`     boolean — true when at least one heading matched.
+ *                   Prompt builders use this to switch language from
+ *                   "preferred" to "MUST".
+ *   - `sections`    string[] — bare section refs, dedup, in document
+ *                   order. e.g. ["1", "2", "2.1", "2.2", "3"].
+ *   - `sectionList` Array<{section, title}> — full list with titles
+ *                   so the prompt can echo the checklist back at the
+ *                   LLM. Keeps order, dedup by section ref.
+ *
+ * @param {string} text
+ * @returns {{ hasSpec: boolean, sections: string[], sectionList: Array<{section: string, title: string}> }}
+ */
+export function detectSpecSections(text) {
+  const empty = { hasSpec: false, sections: [], sectionList: [] };
+  if (!text || typeof text !== "string") return empty;
+
+  // Anchored to heading lines. Two regex shapes — numbered sections
+  // and §-prefixed sections — are both common in the wild.
+  //
+  //   ^#{1,6}\s*               ← markdown heading marker (any depth)
+  //   §?\s*                    ← optional "§"
+  //   (\d+(?:\.\d+){0,4})      ← section number, up to 5 levels deep
+  //   [.)]?\s+                 ← optional trailing "." or ")", then space
+  //   (.+?)\s*$                ← title (lazy, trim trailing whitespace)
+  const headingRe = /^#{1,6}\s*§?\s*(\d+(?:\.\d+){0,4})[.)]?\s+(.+?)\s*$/;
+
+  const seen = new Set();
+  const sectionList = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    const m = headingRe.exec(line);
+    if (!m) continue;
+    const section = m[1];
+    if (seen.has(section)) continue;
+    seen.add(section);
+    sectionList.push({ section, title: m[2].trim() });
+  }
+
+  if (sectionList.length === 0) return empty;
+  return {
+    hasSpec: true,
+    sections: sectionList.map((s) => s.section),
+    sectionList,
+  };
+}

--- a/src/prompts/planner.js
+++ b/src/prompts/planner.js
@@ -1,3 +1,5 @@
+import { detectSpecSections } from "../plan/spec-detector.js";
+
 function extractStepText(line) {
   const numberedStep = /^\d+[).:-]\s*(.+)$/.exec(line);
   if (numberedStep) return numberedStep[1].trim();
@@ -64,7 +66,68 @@ function formatArchitectContext(architectContext) {
   return lines.length > 1 ? lines.join("\n") : null;
 }
 
+/**
+ * Render the SPEC-section guidance block for the planner.
+ *
+ * Two modes:
+ *   • the task contains numbered headings (`## 1.`, `### 2.1`, `§5`) →
+ *     spec_section becomes a HARD requirement and the detected
+ *     sections are echoed back as a checklist. LLMs (Sonnet, Codex)
+ *     consistently skipped the soft "preferred" wording, so the only
+ *     reliable lever is to (a) escalate the rule to MUST and (b) hand
+ *     them the literal list of section refs they're allowed to cite.
+ *   • no numbered headings detected → spec_section stays optional
+ *     and the prompt simply explains the field for completeness.
+ */
+function renderSpecSectionRules(specInfo) {
+  if (!specInfo.hasSpec) {
+    return [
+      "### `spec_section` (optional)",
+      "The task does not look like a structured SPEC, so this field may be `null`. If you do cite a section, use a short ref like `\"5.3\"` or `\"§5 Initial Scope\"`.",
+    ].join("\n");
+  }
+  const checklist = specInfo.sectionList
+    .map(({ section, title }) => `  - "${section}" — ${title}`)
+    .join("\n");
+  return [
+    "### `spec_section` (REQUIRED — the task is a structured SPEC)",
+    `Detected ${specInfo.sections.length} numbered SPEC heading(s) in the task. Every \`step\` MUST set \`spec_section\` to one of the refs below — string, exactly as listed. NEVER \`null\`, NEVER omitted, NEVER a free-form paraphrase.`,
+    "",
+    "Allowed values:",
+    checklist,
+    "",
+    "If a step covers multiple sections, pick the most specific one (e.g. prefer `\"2.1\"` over `\"2\"`). If a step does not map to any section, refactor the step so it does — the SPEC is the source of truth for what work belongs in this plan.",
+  ].join("\n");
+}
+
+/**
+ * Render the acceptance_tests guidance block — same contract as
+ * planner-role.js (the orchestrator path) so both entry points
+ * produce comparable plans.
+ */
+function renderAcceptanceTestsRules() {
+  return [
+    "### `acceptance_tests` (REQUIRED — at least one test per step)",
+    "Each step MUST include 2-4 executable tests. Mix `gherkin` (observable behaviour) and `shell` (concrete commands that exit 0).",
+    "",
+    "Shape:",
+    "```json",
+    '"acceptance_tests": [',
+    '  { "type": "gherkin", "content": "Given <ctx>\\nWhen <action>\\nThen <outcome>" },',
+    '  { "type": "shell",   "content": "<bash command that exits 0 on success>" }',
+    "]",
+    "```",
+    "",
+    "Rules:",
+    "- Tests are written BEFORE the step is implemented — they should fail until the step is done, pass afterwards.",
+    "- Cover at least one happy path and one edge case / failure mode.",
+    "- Do NOT use the placeholder `\"npx vitest run\"` — every test must assert something specific to the step.",
+  ].join("\n");
+}
+
 export function buildPlannerPrompt({ task, context, architectContext, productContext = null, domainContext = null }) {
+  const specInfo = detectSpecSections(task);
+
   const parts = [
     "You are an expert software architect. Create an implementation plan for the following task.",
     "",
@@ -93,10 +156,24 @@ export function buildPlannerPrompt({ task, context, architectContext, productCon
   parts.push(
     "## Output format",
     "Respond with a JSON object containing:",
-    "- `approach`: A concise paragraph describing the overall strategy",
-    "- `steps`: An array of objects, each with `description` (what to do) and `commit` (conventional commit message). Each step should correspond to a single commit.",
-    "- `risks`: An array of strings describing potential risks or challenges",
-    "- `outOfScope`: An array of strings listing what is explicitly NOT included",
+    "- `approach`: A concise paragraph describing the overall strategy.",
+    "- `steps`: An array of step objects (see shape below). Each step = one commit.",
+    "- `risks`: An array of strings describing potential risks or challenges.",
+    "- `outOfScope`: An array of strings listing what is explicitly NOT included.",
+    "",
+    "Each step in `steps` has this shape:",
+    "```json",
+    "{",
+    '  "description": "<what this step achieves, one sentence>",',
+    '  "commit": "<conventional commit message>",',
+    '  "spec_section": "<see rules below>",',
+    '  "acceptance_tests": [ /* see rules below */ ]',
+    "}",
+    "```",
+    "",
+    renderSpecSectionRules(specInfo),
+    "",
+    renderAcceptanceTestsRules(),
     "",
     "Respond ONLY with valid JSON, no markdown fences or extra text."
   );

--- a/tests/prompt-planner.test.js
+++ b/tests/prompt-planner.test.js
@@ -79,4 +79,67 @@ describe("prompts/planner buildPlannerPrompt", () => {
     expect(prompt).not.toContain("Layers:");
     expect(prompt).not.toContain("Patterns:");
   });
+
+  // PR F follow-up (v2.7.5): the CLI planner prompt must demand
+  // spec_section + acceptance_tests structured output the same way
+  // planner-role.js does in the orchestrator path. Earlier the CLI
+  // path silently dropped both, leaving plan.js parsing fields the
+  // LLM was never asked to produce.
+
+  describe("acceptance_tests guidance", () => {
+    it("requires acceptance_tests with structured shape on every step", () => {
+      const prompt = buildPlannerPrompt({ task: "Add caching" });
+      expect(prompt).toMatch(/`acceptance_tests`.*REQUIRED/);
+      expect(prompt).toContain('"type": "gherkin"');
+      expect(prompt).toContain('"type": "shell"');
+    });
+
+    it("forbids the placeholder npx vitest run", () => {
+      const prompt = buildPlannerPrompt({ task: "Add caching" });
+      expect(prompt).toMatch(/Do NOT use the placeholder.*npx vitest run/);
+    });
+  });
+
+  describe("spec_section guidance — unstructured task", () => {
+    it("marks spec_section as optional when task has no numbered headings", () => {
+      const prompt = buildPlannerPrompt({ task: "Fix login bug — the cookie is not being cleared." });
+      expect(prompt).toMatch(/`spec_section`.*optional/);
+      expect(prompt).not.toMatch(/`spec_section`.*REQUIRED/);
+    });
+  });
+
+  describe("spec_section guidance — structured SPEC", () => {
+    const SPEC = [
+      "# Tiny Math Library — SPEC",
+      "## 1. Overview",
+      "blah",
+      "## 2. Functions",
+      "### 2.1 add",
+      "blah",
+      "### 2.2 multiply",
+      "blah",
+      "## 3. Test contract",
+      "blah",
+    ].join("\n");
+
+    it("escalates spec_section to REQUIRED when numbered headings are present", () => {
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toMatch(/`spec_section`.*REQUIRED/);
+      expect(prompt).toContain("Detected 5 numbered SPEC heading(s)");
+    });
+
+    it("echoes the detected sections back as a checklist the LLM must pick from", () => {
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toContain('"1" — Overview');
+      expect(prompt).toContain('"2" — Functions');
+      expect(prompt).toContain('"2.1" — add');
+      expect(prompt).toContain('"2.2" — multiply');
+      expect(prompt).toContain('"3" — Test contract');
+    });
+
+    it("forbids null / omitted / paraphrased spec_section values", () => {
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toMatch(/NEVER `null`, NEVER omitted, NEVER a free-form paraphrase/);
+    });
+  });
 });

--- a/tests/spec-detector.test.js
+++ b/tests/spec-detector.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { detectSpecSections } from "../src/plan/spec-detector.js";
+
+describe("detectSpecSections", () => {
+  it("returns hasSpec=false for empty/null input", () => {
+    expect(detectSpecSections("")).toEqual({ hasSpec: false, sections: [], sectionList: [] });
+    expect(detectSpecSections(null)).toEqual({ hasSpec: false, sections: [], sectionList: [] });
+    expect(detectSpecSections(undefined)).toEqual({ hasSpec: false, sections: [], sectionList: [] });
+  });
+
+  it("returns hasSpec=false for plain prose without numbered headings", () => {
+    const text = "Add a logout button to the header. It should clear the session cookie.";
+    expect(detectSpecSections(text)).toEqual({ hasSpec: false, sections: [], sectionList: [] });
+  });
+
+  it("detects numbered ## headings with trailing dot", () => {
+    const text = "# Tiny Lib\n\n## 1. Overview\nblah\n\n## 2. Functions\nblah";
+    const r = detectSpecSections(text);
+    expect(r.hasSpec).toBe(true);
+    expect(r.sections).toEqual(["1", "2"]);
+    expect(r.sectionList).toEqual([
+      { section: "1", title: "Overview" },
+      { section: "2", title: "Functions" },
+    ]);
+  });
+
+  it("detects nested ### headings up to 5 levels deep", () => {
+    const text = [
+      "## 2. Functions",
+      "### 2.1 add",
+      "### 2.2 multiply",
+      "#### 2.2.1 edge cases",
+    ].join("\n");
+    const r = detectSpecSections(text);
+    expect(r.sections).toEqual(["2", "2.1", "2.2", "2.2.1"]);
+    expect(r.sectionList[2]).toEqual({ section: "2.2", title: "multiply" });
+  });
+
+  it("recognises §-prefixed headings", () => {
+    const text = "## §5 Initial Scope\ncontent\n## §5.1 First Milestone";
+    const r = detectSpecSections(text);
+    expect(r.sections).toEqual(["5", "5.1"]);
+    expect(r.sectionList[1]).toEqual({ section: "5.1", title: "First Milestone" });
+  });
+
+  it("ignores prose mentions of section refs", () => {
+    const text = [
+      "Implement v4.2 of the API.",
+      "Reference: see section 7.3 for details.",
+      "## 1. Overview",
+      "We need to ship 1.0.",
+    ].join("\n");
+    const r = detectSpecSections(text);
+    expect(r.sections).toEqual(["1"]);
+  });
+
+  it("dedupes repeated section refs in document order", () => {
+    const text = "## 1. First\n## 1. Duplicate ref\n## 2. Second";
+    const r = detectSpecSections(text);
+    expect(r.sections).toEqual(["1", "2"]);
+    expect(r.sectionList[0].title).toBe("First");
+  });
+
+  it("handles ) instead of . as separator", () => {
+    const text = "## 3) Setup\nblah";
+    const r = detectSpecSections(text);
+    expect(r.sections).toEqual(["3"]);
+    expect(r.sectionList[0].title).toBe("Setup");
+  });
+
+  it("ignores bullet-style numbering (not headings)", () => {
+    const text = "1. first item\n2. second item";
+    expect(detectSpecSections(text).hasSpec).toBe(false);
+  });
+
+  it("trims trailing whitespace from titles", () => {
+    const text = "## 1. Overview   \n";
+    expect(detectSpecSections(text).sectionList[0].title).toBe("Overview");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR F (#512). The CLI `kj plan generate` path uses `src/prompts/planner.js::buildPlannerPrompt`, which never asked the LLM for `spec_section` or `acceptance_tests` — yet `commands/plan.js` was parsing both. Result: Sonnet and Codex silently dropped them, every HU got `spec_section: null`, and PR F's coder-prompt SPEC-reference section never rendered in real runs.

## What changed

### `src/plan/spec-detector.js` (new)
Detects numbered / §-prefixed headings in the task text — `## 1.`, `### 2.1`, `## §5` — and returns a checklist the prompt can echo back to the LLM. Anchored to markdown heading lines so prose mentions of \"version 4.2\" or \"section 7.3\" never trigger.

### `src/prompts/planner.js`
- Always demands `acceptance_tests` on every step (same contract as `planner-role.js` in the orchestrator path — both entry points now produce comparable plans).
- `spec_section` switches between two modes based on the detector:
  - **structured SPEC detected** → REQUIRED, with a literal allowed-values checklist and \"NEVER `null`, NEVER omitted, NEVER a free-form paraphrase\".
  - **unstructured task** → optional, with a brief format hint.

## Verified end-to-end

Real `kj plan generate` over a tiny `SPEC.md` with §1 / §2 / §2.1 / §2.2 / §3 now yields plans where every HU has its `spec_section` filled in correctly. PR F's coder-prompt SPEC-reference section now actually fires in production.

## Test plan

- [x] 10 new tests for `detectSpecSections` (empty input, prose, numbered/`§` headings, nested levels, dedup, prose-mention rejection, bullet-not-heading, whitespace).
- [x] 8 new tests for `buildPlannerPrompt` (acceptance_tests requirement, no-placeholder rule, optional vs required spec_section, allowed-values checklist).
- [x] Full vitest suite: 3980 / 3980 passing.