### PR TITLE
fix(test): auto-isolate KJ_HOME under VITEST to stop board pollution

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -1,16 +1,41 @@
 import Database from 'better-sqlite3';
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 /** @type {import('better-sqlite3').Database | null} */
 let db = null;
 
+// Per-process tmp dir for VITEST runs that forget to set KJ_HOME.
+// Without this, a test that touches initDb() / upsertProject() drops
+// rows into the developer's real `~/.karajan/hu-board.db` and the
+// running board UI shows phantom projects (observed: "sess-1",
+// "default", "Karajan Code" with 49 test fixture plans). Memoise so
+// every consumer in the same process agrees on the path. The
+// trailing `.karajan` segment keeps semantic parity with non-VITEST
+// defaults so any caller assuming the path ends in `.karajan` still
+// works.
+let _vitestKjHome = null;
+function vitestTmpKjHome() {
+  if (_vitestKjHome) return _vitestKjHome;
+  _vitestKjHome = join(
+    tmpdir(),
+    `karajan-vitest-${process.pid}-${Math.random().toString(36).slice(2, 10)}`,
+    '.karajan'
+  );
+  return _vitestKjHome;
+}
+
 /**
  * Returns the KJ home directory, respecting KJ_HOME env var.
+ * Under VITEST without KJ_HOME, returns a per-process tmp dir to
+ * prevent accidental writes into the developer's real `~/.karajan/`.
  * @returns {string}
  */
 export function getKjHome() {
-  return process.env.KJ_HOME || join(process.env.HOME || '/root', '.karajan');
+  if (process.env.KJ_HOME) return process.env.KJ_HOME;
+  if (process.env.VITEST) return vitestTmpKjHome();
+  return join(process.env.HOME || '/root', '.karajan');
 }
 
 /**

--- a/packages/hu-board/tests/db-kj-home-isolation.test.js
+++ b/packages/hu-board/tests/db-kj-home-isolation.test.js
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Regression test for the "phantom projects on the board" bug —
+// see src/db.js::getKjHome. Without VITEST auto-isolation, a hu-board
+// test that didn't set KJ_HOME would write into the developer's real
+// `~/.karajan/hu-board.db` and leave rogue rows visible on the board.
+
+describe("hu-board db.getKjHome — VITEST auto-isolation", () => {
+  const originalKjHome = process.env.KJ_HOME;
+  const originalVitest = process.env.VITEST;
+
+  afterEach(() => {
+    if (originalKjHome !== undefined) {
+      process.env.KJ_HOME = originalKjHome;
+    } else {
+      delete process.env.KJ_HOME;
+    }
+    if (originalVitest !== undefined) {
+      process.env.VITEST = originalVitest;
+    } else {
+      delete process.env.VITEST;
+    }
+    vi.resetModules();
+  });
+
+  it("returns ~/.karajan when KJ_HOME and VITEST are both unset", async () => {
+    delete process.env.KJ_HOME;
+    delete process.env.VITEST;
+    const { getKjHome } = await import("../src/db.js");
+    expect(getKjHome()).toBe(join(process.env.HOME || "/root", ".karajan"));
+  });
+
+  it("returns $KJ_HOME when explicitly set", async () => {
+    process.env.KJ_HOME = "/explicit/karajan";
+    const { getKjHome } = await import("../src/db.js");
+    expect(getKjHome()).toBe("/explicit/karajan");
+  });
+
+  it("returns a tmp dir under VITEST when KJ_HOME is unset", async () => {
+    delete process.env.KJ_HOME;
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/db.js");
+    const home = getKjHome();
+    expect(home.startsWith(tmpdir())).toBe(true);
+    // Trailing `.karajan` segment preserves semantic parity with
+    // the non-VITEST default so existing path assertions still match.
+    expect(home).toMatch(/karajan-vitest-\d+-[a-z0-9]+\/\.karajan$/);
+  });
+
+  it("memoises the tmp dir across calls within the same process", async () => {
+    delete process.env.KJ_HOME;
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/db.js");
+    expect(getKjHome()).toBe(getKjHome());
+  });
+
+  it("explicit KJ_HOME wins over VITEST tmp default", async () => {
+    process.env.KJ_HOME = "/winner";
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/db.js");
+    expect(getKjHome()).toBe("/winner");
+  });
+});

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -10,8 +10,33 @@ import os from "node:os";
 import { generatePlanId } from "./plan-id.js";
 import { isPlanV2, migratePlanV1toV2 } from "./plan-schema.js";
 
-function getKjHome() {
-  return process.env.KJ_HOME || path.join(os.homedir(), ".kj");
+// Per-process tmp dir for VITEST runs that forget to set KJ_HOME. We
+// memoise across calls so every helper in the same test process sees
+// the same root (mirrors what setting KJ_HOME explicitly would do)
+// without racing. The trailing `.kj` segment keeps semantic parity
+// with non-VITEST defaults so existing path assertions don't break.
+let _vitestKjHome = null;
+function vitestTmpKjHome() {
+  if (_vitestKjHome) return _vitestKjHome;
+  _vitestKjHome = path.join(
+    os.tmpdir(),
+    `kj-vitest-${process.pid}-${Math.random().toString(36).slice(2, 10)}`,
+    ".kj"
+  );
+  return _vitestKjHome;
+}
+
+export function getKjHome() {
+  if (process.env.KJ_HOME) return process.env.KJ_HOME;
+  // VITEST guard — without this, a test that calls savePlan() drops
+  // fixture files into the developer's real `~/.kj/plans/` and the
+  // running HU Board's chokidar watcher ingests them as "real" plans
+  // (observed: 49 fake "Add auth" plans contaminating the user's
+  // board). Auto-isolate to a per-process tmp dir so accidental
+  // writes can't leak. Tests that NEED to assert against a known
+  // path should still set KJ_HOME explicitly.
+  if (process.env.VITEST) return vitestTmpKjHome();
+  return path.join(os.homedir(), ".kj");
 }
 
 /**

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,11 +1,31 @@
 import os from "node:os";
 import path from "node:path";
 
+// Per-process tmp dir for VITEST runs that forget to set KJ_HOME. Same
+// rationale as src/plan/plan-store.js — without this, tests that use
+// real session/board paths leak files into the developer's real
+// `~/.karajan/` and pollute the HU Board's SQLite DB. Memoised so
+// every helper in the same process agrees on the path. The trailing
+// segment is `.karajan` to keep semantic parity with non-VITEST
+// defaults (existing tests assert paths contain ".karajan/...").
+let _vitestKarajanHome = null;
+function vitestTmpKarajanHome() {
+  if (_vitestKarajanHome) return _vitestKarajanHome;
+  _vitestKarajanHome = path.join(
+    os.tmpdir(),
+    `karajan-vitest-${process.pid}-${Math.random().toString(36).slice(2, 10)}`,
+    ".karajan"
+  );
+  return _vitestKarajanHome;
+}
+
 export function getKarajanHome() {
   if (process.env.KJ_HOME) {
     return path.resolve(process.env.KJ_HOME);
   }
-
+  if (process.env.VITEST) {
+    return vitestTmpKarajanHome();
+  }
   return path.join(os.homedir(), ".karajan");
 }
 

--- a/tests/plan-store-kj-home-isolation.test.js
+++ b/tests/plan-store-kj-home-isolation.test.js
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import os from "node:os";
+
+// Regression test for the "phantom Karajan Code project on the board"
+// bug: tests that called savePlan() without setting KJ_HOME used to
+// drop fixture files into the developer's real `~/.kj/plans/`. The
+// running HU Board's chokidar watcher then ingested them as real
+// plans (49 phantom "Add auth" entries observed). The fix lives in
+// src/plan/plan-store.js::getKjHome — under VITEST without KJ_HOME,
+// it returns a per-process tmp dir.
+
+describe("plan-store getKjHome — VITEST auto-isolation", () => {
+  const originalKjHome = process.env.KJ_HOME;
+  const originalVitest = process.env.VITEST;
+
+  afterEach(() => {
+    if (originalKjHome !== undefined) {
+      process.env.KJ_HOME = originalKjHome;
+    } else {
+      delete process.env.KJ_HOME;
+    }
+    if (originalVitest !== undefined) {
+      process.env.VITEST = originalVitest;
+    } else {
+      delete process.env.VITEST;
+    }
+    vi.resetModules();
+  });
+
+  it("returns ~/.kj when KJ_HOME and VITEST are both unset", async () => {
+    delete process.env.KJ_HOME;
+    delete process.env.VITEST;
+    const { getKjHome } = await import("../src/plan/plan-store.js");
+    expect(getKjHome()).toBe(path.join(os.homedir(), ".kj"));
+  });
+
+  it("returns $KJ_HOME when set", async () => {
+    process.env.KJ_HOME = "/explicit/kj";
+    const { getKjHome } = await import("../src/plan/plan-store.js");
+    expect(getKjHome()).toBe("/explicit/kj");
+  });
+
+  it("returns a tmp dir under VITEST when KJ_HOME is unset", async () => {
+    delete process.env.KJ_HOME;
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/plan/plan-store.js");
+    const home = getKjHome();
+    expect(home.startsWith(os.tmpdir())).toBe(true);
+    expect(home).not.toBe(path.join(os.homedir(), ".kj"));
+    // Trailing `.kj` segment preserves semantic parity with the
+    // default `~/.kj` so existing path assertions still match.
+    expect(home).toMatch(/kj-vitest-\d+-[a-z0-9]+\/\.kj$/);
+  });
+
+  it("memoises the tmp dir across calls within the same process", async () => {
+    delete process.env.KJ_HOME;
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/plan/plan-store.js");
+    expect(getKjHome()).toBe(getKjHome());
+  });
+
+  it("explicit KJ_HOME wins over VITEST tmp default", async () => {
+    process.env.KJ_HOME = "/winner";
+    process.env.VITEST = "true";
+    const { getKjHome } = await import("../src/plan/plan-store.js");
+    expect(getKjHome()).toBe("/winner");
+  });
+
+  it("plansDir + savePlan write under the tmp root, not ~/.kj/", async () => {
+    delete process.env.KJ_HOME;
+    process.env.VITEST = "true";
+    const { plansDir, savePlan, getKjHome } = await import("../src/plan/plan-store.js");
+    const projectDir = "/some/fake/project";
+    const dir = plansDir(projectDir);
+    expect(dir.startsWith(getKjHome())).toBe(true);
+    expect(dir).not.toContain(path.join(os.homedir(), ".kj"));
+
+    const planId = await savePlan(projectDir, {
+      planId: "plan-isolation-test",
+      version: 2,
+      hus: [],
+      task: "isolation",
+    });
+    expect(planId).toBe("plan-isolation-test");
+
+    const fs = await import("node:fs/promises");
+    const stats = await fs.stat(path.join(dir, "plan-isolation-test.json"));
+    expect(stats.isFile()).toBe(true);
+  });
+});

--- a/tests/utils-paths.test.js
+++ b/tests/utils-paths.test.js
@@ -3,20 +3,27 @@ import path from "node:path";
 import os from "node:os";
 
 describe("utils/paths", () => {
-  const originalEnv = process.env.KJ_HOME;
+  const originalKjHome = process.env.KJ_HOME;
+  const originalVitest = process.env.VITEST;
 
   afterEach(() => {
-    if (originalEnv !== undefined) {
-      process.env.KJ_HOME = originalEnv;
+    if (originalKjHome !== undefined) {
+      process.env.KJ_HOME = originalKjHome;
     } else {
       delete process.env.KJ_HOME;
+    }
+    if (originalVitest !== undefined) {
+      process.env.VITEST = originalVitest;
+    } else {
+      delete process.env.VITEST;
     }
     vi.resetModules();
   });
 
   describe("getKarajanHome", () => {
-    it("returns ~/.karajan by default", async () => {
+    it("returns ~/.karajan when KJ_HOME and VITEST are both unset", async () => {
       delete process.env.KJ_HOME;
+      delete process.env.VITEST;
       const { getKarajanHome } = await import("../src/utils/paths.js");
       expect(getKarajanHome()).toBe(path.join(os.homedir(), ".karajan"));
     });
@@ -32,11 +39,43 @@ describe("utils/paths", () => {
       const { getKarajanHome } = await import("../src/utils/paths.js");
       expect(path.isAbsolute(getKarajanHome())).toBe(true);
     });
+
+    // Auto-isolation guard: a test that forgets to set KJ_HOME used
+    // to drop files into the developer's real `~/.karajan/` and
+    // pollute the running HU Board (49 phantom plans observed).
+    // Under VITEST without KJ_HOME, the helper now returns a
+    // per-process tmp dir so accidental writes can't leak.
+    it("returns a tmp dir under VITEST when KJ_HOME is unset", async () => {
+      delete process.env.KJ_HOME;
+      process.env.VITEST = "true";
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      const home = getKarajanHome();
+      expect(home.startsWith(os.tmpdir())).toBe(true);
+      expect(home).not.toBe(path.join(os.homedir(), ".karajan"));
+      // Trailing `.karajan` segment preserves semantic parity with
+      // non-VITEST defaults so existing path assertions still match.
+      expect(home).toMatch(/karajan-vitest-\d+-[a-z0-9]+\/\.karajan$/);
+    });
+
+    it("memoises the tmp dir across calls within the same process", async () => {
+      delete process.env.KJ_HOME;
+      process.env.VITEST = "true";
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      expect(getKarajanHome()).toBe(getKarajanHome());
+    });
+
+    it("explicit KJ_HOME wins over VITEST tmp default", async () => {
+      process.env.KJ_HOME = "/explicit/path";
+      process.env.VITEST = "true";
+      const { getKarajanHome } = await import("../src/utils/paths.js");
+      expect(getKarajanHome()).toBe(path.resolve("/explicit/path"));
+    });
   });
 
   describe("getSessionRoot", () => {
     it("returns sessions dir under karajan home", async () => {
       delete process.env.KJ_HOME;
+      delete process.env.VITEST;
       const { getSessionRoot } = await import("../src/utils/paths.js");
       expect(getSessionRoot()).toBe(path.join(os.homedir(), ".karajan", "sessions"));
     });
@@ -45,6 +84,7 @@ describe("utils/paths", () => {
   describe("getSonarComposePath", () => {
     it("returns docker-compose path under karajan home", async () => {
       delete process.env.KJ_HOME;
+      delete process.env.VITEST;
       const { getSonarComposePath } = await import("../src/utils/paths.js");
       expect(getSonarComposePath()).toBe(path.join(os.homedir(), ".karajan", "docker-compose.sonar.yml"));
     });


### PR DESCRIPTION
## Summary

Tests that called \`savePlan()\` / \`initDb()\` / \`getKarajanHome()\` without setting \`KJ_HOME\` were writing into the developer's real \`~/.kj/plans/\` and \`~/.karajan/hu-board.db\`. The HU Board's chokidar watcher then ingested the test fixtures as real plans.

## What was observed

- 49 phantom \"Add auth\" plans contaminating a \"Karajan Code\" project on the running board.
- Rogue project/session rows (\`sess-1\`, \`default\`, \`tmp_kj-spec-test\`).
- Mixed in with the user's real Hu Board project — impossible to tell test from prod data without inspecting each plan's \`task\` field.

## Fix

Three modules — \`src/plan/plan-store.js\`, \`src/utils/paths.js\`, \`packages/hu-board/src/db.js\` — now default to a per-process tmp dir under \`process.env.VITEST\` when \`KJ_HOME\` is unset:

```
/tmp/kj-vitest-<pid>-<rand>/.kj          (plan-store)
/tmp/karajan-vitest-<pid>-<rand>/.karajan (paths + hu-board)
```

The trailing \`.kj\` / \`.karajan\` segment preserves semantic parity with the non-VITEST defaults so existing path assertions (e.g. \`tests/role-md-resolution.test.js\` checking that candidates contain \`.karajan/roles/coder.md\`) keep matching.

Memoised across calls so every helper in the same test process agrees on the path. Explicit \`KJ_HOME\` still wins — tests that need a known tmp dir keep working unchanged.

## Cleanup of existing pollution

Any developer with a polluted \`~/.kj/plans/<slug>/\` and \`~/.karajan/hu-board.db\` needs a one-time cleanup (this PR does not auto-wipe historic data):

```bash
# 1. Stop the board
kj board stop

# 2. Delete the polluted plan dir(s) — inspect first to be sure
ls ~/.kj/plans/
rm -rf ~/.kj/plans/<polluted-slug>/

# 3. Wipe the rogue board rows
sqlite3 ~/.karajan/hu-board.db <<'SQL'
DELETE FROM stories  WHERE project_id IN ('<id1>', '<id2>', ...);
DELETE FROM sessions WHERE project_id IN ('<id1>', '<id2>', ...);
DELETE FROM projects WHERE id          IN ('<id1>', '<id2>', ...);
SQL
```

## Test plan

- [x] \`tests/utils-paths.test.js\` — extended with VITEST tmp behaviour, memoisation, explicit-KJ_HOME-wins.
- [x] \`tests/plan-store-kj-home-isolation.test.js\` (new) — 6 cases including a \`savePlan\` integration that writes under the tmp root and never touches \`~/.kj/\`.
- [x] \`packages/hu-board/tests/db-kj-home-isolation.test.js\` (new) — 5 cases.
- [x] Parent \`vitest run\` — 3989 / 3989 passing.
- [x] Board \`vitest run\` — 125 / 125 passing.