### PR TITLE
feat(board): live HU status sync + DOM-patching to kill the parpadeo

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -786,10 +786,10 @@ function renderKanbanColumn(title, cssClass, stories) {
   // mental map) but no body placeholder — "No stories" text on four
   // empty columns was noise on fresh plans.
   return `
-    <div class="kanban__column kanban__column--${cssClass}"${stories.length === 0 ? ' style="opacity:0.55"' : ''}>
+    <div class="kanban__column kanban__column--${cssClass}" data-column="${cssClass}"${stories.length === 0 ? ' style="opacity:0.55"' : ''}>
       <div class="kanban__column-header">
         <span class="kanban__column-title">${title}</span>
-        <span class="kanban__column-count">${stories.length}</span>
+        <span class="kanban__column-count" data-column-count>${stories.length}</span>
       </div>
       ${stories.map(renderStoryCard).join('')}
     </div>
@@ -827,7 +827,7 @@ function renderStoryCard(story) {
   const missingTestContract = testCount === 0 && ['pending', 'certified'].includes(story.status);
 
   return `
-    <div class="story-card" onclick="showStoryDetail('${esc(story.id)}')">
+    <div class="story-card" data-story-id="${esc(story.id)}" data-status="${esc(story.status || 'pending')}" onclick="showStoryDetail('${esc(story.id)}')">
       <div class="story-card__id" title="${esc(story.id)}">${esc(shortId)}</div>
       <div class="story-card__title">${esc(truncate(title, 100))}</div>
       <div class="story-card__meta" style="gap:10px">
@@ -2488,9 +2488,13 @@ function subscribeToServerEvents() {
       return;
     }
 
-    // Default: data changed somewhere; nudge the current view.
+    // Default: data changed somewhere. Try the targeted DOM patch
+    // first (no parpadeo, preserves scroll + hover state) and only
+    // fall back to a full re-render when the patch can't apply
+    // (different view, missing markers, etc.). This is the fix for
+    // the "todo el board parpadea cada vez que algo cambia" UX bug.
     if (sseRefreshTimer) clearTimeout(sseRefreshTimer);
-    sseRefreshTimer = setTimeout(() => refreshCurrentView(e.data), 150);
+    sseRefreshTimer = setTimeout(() => smartRefresh(payload), 150);
   });
   sseSource.addEventListener('error', () => {
     // EventSource handles reconnection. Nothing to do; browsers retry
@@ -2629,11 +2633,169 @@ async function refreshCurrentView(_rawEvent) {
   }
 }
 
-// Auto-refresh every 10 seconds (with sync to catch new batches)
+/**
+ * Smart refresh: pick the cheapest possible DOM update for the
+ * incoming SSE event. Today the server sends coarse-grained events
+ * (`{type: 'plan'|'batch'|'session'|'prompt'|...}`), so we route by
+ * type:
+ *
+ *   plan / batch on the board view  → patchBoardIncremental()
+ *   anything else                    → refreshCurrentView() (full re-render)
+ *
+ * The patch path preserves DOM nodes (no innerHTML rewrite, no
+ * scroll reset, no hover/focus loss) — this is what kills the
+ * "parpadeo" the user reported.
+ *
+ * @param {object|null} payload The parsed SSE payload, or null when
+ *   the event wasn't valid JSON. Coarse types still work (we just
+ *   degrade to a full re-render).
+ */
+async function smartRefresh(payload) {
+  const onBoard = currentView === 'board' && Boolean(selectedProject);
+  const isStoryRelated = payload && ['plan', 'batch'].includes(payload.type);
+  if (onBoard && isStoryRelated) {
+    const ok = await patchBoardIncremental();
+    if (ok) return;
+  }
+  await refreshCurrentView();
+}
+
+/**
+ * Targeted DOM patch for the Kanban board. Re-fetches the project's
+ * stories, diffs them against the cards already rendered, and only
+ * touches the affected nodes:
+ *
+ *   - status changed → move the card to the new column with a
+ *     subtle animation (no DOM recreation, listeners survive)
+ *   - new story      → render + insert into the right column
+ *   - story removed  → fade + remove
+ *   - column counts and the running badge are updated in place
+ *
+ * Returns false if the board's DOM markers aren't present (different
+ * view, error state, etc.) so smartRefresh can fall back to a full
+ * re-render.
+ *
+ * @returns {Promise<boolean>}
+ */
+async function patchBoardIncremental() {
+  const kanban = document.querySelector('.kanban');
+  if (!kanban) return false;          // not on the board view
+  const columns = {};
+  for (const col of kanban.querySelectorAll('.kanban__column')) {
+    const cls = col.dataset.column;
+    if (cls) columns[cls] = col;
+  }
+  if (!columns.pending || !columns.running) return false;
+
+  let stories;
+  try {
+    stories = await api(`/api/projects/${encodeURIComponent(selectedProject)}/stories`);
+  } catch { return false; }
+
+  // Re-derive the column → status mapping (kept in lockstep with
+  // renderBoard's `columns` object — change there, change here).
+  const statusToColumn = (status) => {
+    if (['pending', 'certified', 'needs_context', 'blocked'].includes(status)) return 'pending';
+    if (['coding', 'reviewing'].includes(status)) return 'running';
+    if (status === 'done') return 'done';
+    if (status === 'failed') return 'failed';
+    return 'pending';                  // safe default
+  };
+
+  const seen = new Set();
+  for (const story of stories) {
+    seen.add(story.id);
+    const targetCol = columns[statusToColumn(story.status)];
+    if (!targetCol) continue;
+    const existing = kanban.querySelector(`.story-card[data-story-id="${cssEscape(story.id)}"]`);
+    if (!existing) {
+      // New story — append to its column.
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = renderStoryCard(story).trim();
+      const node = wrapper.firstElementChild;
+      if (node) {
+        node.style.opacity = '0';
+        targetCol.appendChild(node);
+        requestAnimationFrame(() => { node.style.transition = 'opacity 200ms'; node.style.opacity = '1'; });
+      }
+      continue;
+    }
+    const previousStatus = existing.dataset.status;
+    if (previousStatus !== story.status) {
+      // Status changed — move the node + replace its inner content
+      // (counters, time-ago, status pill) without recreating the
+      // outer node so click handlers + transitions survive.
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = renderStoryCard(story).trim();
+      const fresh = wrapper.firstElementChild;
+      if (fresh) {
+        existing.innerHTML = fresh.innerHTML;
+        existing.dataset.status = story.status;
+        existing.setAttribute('onclick', fresh.getAttribute('onclick') || '');
+        if (existing.parentElement !== targetCol) {
+          existing.style.transition = 'opacity 150ms';
+          existing.style.opacity = '0.3';
+          setTimeout(() => {
+            targetCol.appendChild(existing);
+            requestAnimationFrame(() => { existing.style.opacity = '1'; });
+          }, 150);
+        }
+      }
+    } else {
+      // Same status — just refresh the inner block (counters / time
+      // ago / antipatterns may have changed) without moving.
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = renderStoryCard(story).trim();
+      const fresh = wrapper.firstElementChild;
+      if (fresh && fresh.innerHTML !== existing.innerHTML) {
+        existing.innerHTML = fresh.innerHTML;
+      }
+    }
+  }
+  // Cards that no longer exist on the server → remove with a fade.
+  for (const node of kanban.querySelectorAll('.story-card')) {
+    if (!seen.has(node.dataset.storyId)) {
+      node.style.transition = 'opacity 150ms';
+      node.style.opacity = '0';
+      setTimeout(() => node.remove(), 160);
+    }
+  }
+  // Recount each column + update the "N running" badge in the header.
+  for (const [cls, col] of Object.entries(columns)) {
+    const counter = col.querySelector('[data-column-count]');
+    if (counter) counter.textContent = String(col.querySelectorAll('.story-card').length);
+    col.style.opacity = col.querySelectorAll('.story-card').length === 0 ? '0.55' : '1';
+  }
+  const runningCount = columns.running.querySelectorAll('.story-card').length;
+  const runningBadge = document.querySelector('.section-header__badge');
+  if (runningBadge) {
+    if (runningCount > 0) {
+      runningBadge.textContent = `⚙ ${runningCount} running…`;
+      runningBadge.style.display = '';
+    } else {
+      runningBadge.style.display = 'none';
+    }
+  }
+  return true;
+}
+
+/**
+ * CSS.escape polyfill wrapper. Story IDs can contain "::" and other
+ * characters that break querySelector when interpolated raw.
+ */
+function cssEscape(str) {
+  return (window.CSS && CSS.escape) ? CSS.escape(str) : String(str).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}
+
+// Auto-refresh every 60 seconds as a SAFETY NET only — the board is
+// SSE-driven (push from server) so this should rarely fire. We keep
+// it at low frequency to recover from missed events on hibernation /
+// network blip without flickering the UI every 10s like before.
+// Uses smartRefresh too so it patches the DOM instead of full rerender.
 refreshInterval = setInterval(async () => {
   if (document.getElementById('modal-backdrop').classList.contains('hidden')) {
     await triggerSync();
     await populateProjectSelect();
-    render();
+    await smartRefresh(null);
   }
-}, 10000);
+}, 60_000);

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -38,7 +38,7 @@ import {
 import { resolveAddyosmaniSlugs } from "../../skills/addyosmani-role-map.js";
 import { saveSession } from "../../session/store.js";
 import {
-  setPreflight, setPreLoopContext, setPlanRef, setPlanSyncCallback,
+  setPreflight, setPreLoopContext, setPlanRef, setPlanSyncCallback, setLiveStatusUpdater,
   setAutoInstalledSkills, setSkillsRecommended, setAddyosmaniSkills,
 } from "../../session/mutators.js";
 import {
@@ -335,6 +335,20 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
             setPlanSyncCallback(session, async (subResult) => {
               syncResultsToPlan(loadedPlan, subResult);
               await savePlanToDisk(projectDir, loadedPlan);
+            });
+            // PR1 (live HU status): write the plan JSON on EVERY status
+            // change so the board's chokidar watcher fires per-HU and the
+            // Kanban columns reflect progress in real time. Without this
+            // the plan only updates at the end of the run and the board
+            // looks frozen during execution.
+            const { updateHuStatus: updateHuStatusFn } = await import("../../plan/plan-hu-ops.js");
+            setLiveStatusUpdater(session, async (huId, status) => {
+              try {
+                if (!updateHuStatusFn(loadedPlan, huId, status)) return;
+                await savePlanToDisk(projectDir, loadedPlan);
+              } catch (err) {
+                logger?.warn?.(`Live status update failed for ${huId}: ${err.message}`);
+              }
             });
             logger.info(`Plan ${flags.plan}: ${huBatch.certified} HUs ready for execution`);
             emitProgress(emitter, makeEvent("plan:hus-loaded", { ...eventBase, stage: "plan" }, {

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -389,7 +389,12 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
         emitter,
         eventBase: ctx.eventBase,
         logger,
-        config: ctx.config
+        config: ctx.config,
+        // PR1 (live HU status): forward the per-HU status updater so
+        // hu-sub-pipeline can patch the plan JSON on every transition,
+        // not only at the end of the run. The board's chokidar then
+        // fires per-HU and the Kanban columns update in real time.
+        onStatusChange: ctx.session?._liveStatusUpdater || null
       });
 
       emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -68,7 +68,15 @@ function buildHuTask(story) {
  * @param {object} params
  * @returns {Promise<{huId: string, approved: boolean, result?: object, error?: string, blockedDependents?: string[]}>}
  */
-async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath }) {
+async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null }) {
+  // PR1 (live HU status): every saveHuBatch should also notify the
+  // plan JSON so the board reflects state in real time. Defined as a
+  // local helper so we don't repeat the try/null-check boilerplate.
+  const notifyStatus = async (huId, status) => {
+    if (typeof onStatusChange !== "function") return;
+    try { await onStatusChange(huId, status); }
+    catch (err) { logger?.warn?.(`onStatusChange(${huId}, ${status}) failed: ${err.message}`); }
+  };
   const story = batch.stories.find(s => s.id === storyId);
 
   // --- Lazy refinement ---
@@ -114,6 +122,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
 
   updateStoryStatus(batch, story.id, HU_STATUS.CODING);
   await saveHuBatch(batchSessionId, batch);
+  await notifyStatus(story.id, HU_STATUS.CODING);
   emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
     message: `HU ${story.id} status → coding`,
     detail: { huId: story.id, status: HU_STATUS.CODING, timestamp: new Date().toISOString() }
@@ -126,6 +135,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     // --- Transition to reviewing (post-coder, pre-reviewer evaluation) ---
     updateStoryStatus(batch, story.id, HU_STATUS.REVIEWING);
     await saveHuBatch(batchSessionId, batch);
+    await notifyStatus(story.id, HU_STATUS.REVIEWING);
     emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
       message: `HU ${story.id} status → reviewing`,
       detail: { huId: story.id, status: HU_STATUS.REVIEWING, timestamp: new Date().toISOString() }
@@ -134,6 +144,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     if (approved) {
       updateStoryStatus(batch, story.id, HU_STATUS.DONE);
       await saveHuBatch(batchSessionId, batch);
+      await notifyStatus(story.id, HU_STATUS.DONE);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → done`,
         detail: { huId: story.id, status: HU_STATUS.DONE, timestamp: new Date().toISOString() }
@@ -147,6 +158,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     } else {
       updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
       await saveHuBatch(batchSessionId, batch);
+      await notifyStatus(story.id, HU_STATUS.FAILED);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → failed`,
         detail: { huId: story.id, status: HU_STATUS.FAILED, timestamp: new Date().toISOString() }
@@ -161,6 +173,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
   } catch (err) {
     updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
     await saveHuBatch(batchSessionId, batch);
+    await notifyStatus(story.id, HU_STATUS.FAILED);
     emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
       message: `HU ${story.id} status → failed`,
       detail: { huId: story.id, status: HU_STATUS.FAILED, timestamp: new Date().toISOString() }
@@ -187,7 +200,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
  * @param {object} params.logger - Logger instance
  * @returns {Promise<{approved: boolean, results: object[], blockedIds: string[]}>}
  */
-export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null }) {
+export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null, onStatusChange = null }) {
   const batchSessionId = huReviewerResult.batchSessionId;
   let batch;
   try {
@@ -235,13 +248,22 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
       // Single HU: run as before, no worktree needed
       const singleResult = await runSingleHu({
         storyId: runnableIds[0], batch, batchSessionId, runIterationFn,
-        emitter, eventBase, logger, config, results
+        emitter, eventBase, logger, config, results, onStatusChange
       });
       results.push(singleResult);
       if (!singleResult.approved) {
         allApproved = false;
         const newlyBlocked = blockDependents(batch, singleResult.huId);
         blockedIds.push(...newlyBlocked);
+        // PR1 (live HU status): notify the plan JSON of every newly
+        // BLOCKED HU so the board moves them into the blocked column
+        // without waiting for the run to finish.
+        if (typeof onStatusChange === "function") {
+          for (const blockedHuId of newlyBlocked) {
+            try { await onStatusChange(blockedHuId, HU_STATUS.BLOCKED); }
+            catch (err) { logger?.warn?.(`onStatusChange(${blockedHuId}, blocked) failed: ${err.message}`); }
+          }
+        }
       }
       await saveHuBatch(batchSessionId, batch);
     } else {
@@ -264,7 +286,8 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
         return runSingleHu({
           storyId, batch, batchSessionId, runIterationFn,
           emitter, eventBase, logger, config, results,
-          worktreePath: worktrees.get(storyId)
+          worktreePath: worktrees.get(storyId),
+          onStatusChange
         });
       });
 
@@ -283,6 +306,15 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
           allApproved = false;
           const newlyBlocked = blockDependents(batch, res.huId);
           blockedIds.push(...newlyBlocked);
+          // PR1 (live HU status): same as the single-HU path — push
+          // BLOCKED transitions to the plan JSON immediately so the
+          // board shows them moving to the blocked column live.
+          if (typeof onStatusChange === "function") {
+            for (const blockedHuId of newlyBlocked) {
+              try { await onStatusChange(blockedHuId, HU_STATUS.BLOCKED); }
+              catch (err) { logger?.warn?.(`onStatusChange(${blockedHuId}, blocked) failed: ${err.message}`); }
+            }
+          }
           // Clean up failed worktree
           if (worktrees.has(res.huId)) {
             try { await removeWorktree(projectDir, res.huId); } catch { /* ignore */ }

--- a/src/session/mutators.js
+++ b/src/session/mutators.js
@@ -210,6 +210,23 @@ export function setPlanSyncCallback(session, fn) {
   session._syncResultsToPlan = fn;
 }
 
+/**
+ * Live status updater: invoked by hu-sub-pipeline after every status
+ * change so the plan JSON gets the new status immediately, not only at
+ * the end of the run. Without this, the board reads an unchanged plan
+ * file during execution and the columns appear frozen until the run
+ * completes (the bug we're fixing in PR1).
+ *
+ * Signature: async (huId, status) => void
+ */
+export function setLiveStatusUpdater(session, fn) {
+  session._liveStatusUpdater = fn;
+}
+
+export function getLiveStatusUpdater(session) {
+  return session._liveStatusUpdater || null;
+}
+
 // --- Skills ---------------------------------------------------------------
 
 export function setAddyosmaniSkills(session, payload) {


### PR DESCRIPTION
## Two bugs, one PR (they're the same UX problem)

### Bug 1: HU columns frozen during run-plan
Click ▶ Run plan from the board → every HU stays in 'pending' until the run finishes. Hard-refresh shows them still in 'pending'. Root cause: \`hu-sub-pipeline\` writes statuses to \`~/.karajan/hu/<sessionId>/batch.json\` but the board reads from \`~/.kj/plans/<slug>/<planId>.json\`, which is only synced at the END via \`syncResultsToPlan\`. The plan file is stale during execution.

**Fix**: new \`setLiveStatusUpdater(session, fn)\` mutator. \`pre-loop.js\` wires a closure that calls \`updateHuStatus(loadedPlan, huId, status)\` + \`savePlanToDisk\` on every transition. \`flow-runner\` forwards it to \`runHuSubPipeline\` as \`onStatusChange\`. \`hu-sub-pipeline\` calls it after every \`saveHuBatch()\` for \`CODING / REVIEWING / DONE / FAILED / BLOCKED\` (both the single-HU and parallel-batch paths).

### Bug 2: Parpadeo on every SSE event
\`app.innerHTML = ...\` re-renders the entire \`<div id=\"app\">\` on every SSE event AND every 10s. Visual flicker, scroll reset, lost hover/focus state.

**Fix**: targeted DOM patching.
- Story cards carry \`data-story-id\` + \`data-status\`.
- Kanban columns carry \`data-column\` + \`data-column-count\`.
- New \`patchBoardIncremental()\` diffs API stories against rendered cards: status changes move the existing DOM node between columns (no recreation, listeners survive), new stories fade in, removed stories fade out, counters and the running badge update in place.
- New \`smartRefresh()\` routes SSE events: \`board\` view + \`plan|batch\` event → patch path; everything else → \`refreshCurrentView()\` (full re-render fallback).
- 10s polling lowered to 60s, also routed through \`smartRefresh\`.

## Test plan

- [x] Parent vitest: 3989 / 3989 passing.
- [x] hu-board vitest: 125 / 125 passing.
- [ ] Manual: launch \`▶ Run plan\` and watch HU cards move from \`Pending\` → \`Running\` → \`Done\` live, no flicker.