### PR TITLE
feat(board): per-HU outcome + plan rollup + summary indicators

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -446,6 +446,7 @@ async function renderBoard() {
           Comprobando estado del proyecto…
         </div>
       </div>
+      <div id="plan-rollup-banner"></div>
       <div class="kanban">
         ${visibleColumns.map((c) => renderKanbanColumn(c.title, c.cls, c.rows)).join('')}
       </div>
@@ -467,6 +468,10 @@ async function renderBoard() {
     // it without blocking the initial paint. Replaces a placeholder
     // div in-place (no full re-render).
     renderPreflightPanel(selectedProject).catch(() => {});
+    // PR3: render the plan-level rollup banner if any plan in this
+    // project has a stamped outcome. Non-blocking — if it fails the
+    // user just doesn't see the banner.
+    renderPlanRollup(selectedProject).catch(() => {});
     const viewLogBtn = document.getElementById('view-log-btn');
     if (viewLogBtn && lastOpenedLog) {
       viewLogBtn.addEventListener('click', () => openGenericLogPanel({
@@ -874,8 +879,38 @@ function renderStoryCard(story) {
       <div class="story-card__meta" style="margin-top:6px">
         <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
         <span class="story-card__time">${timeAgo(story.updated_at)}</span>
+        ${renderOutcomeChip(story.outcome)}
       </div>
     </div>
+  `;
+}
+
+/**
+ * PR3: render the per-HU outcome chip (📄 ver resumen) when an
+ * outcome is stamped. Click → opens the outcome modal with the
+ * full breakdown (iterations, duration, commits, blockers, summary).
+ *
+ * The outcome arrives as a JSON-stringified blob from the SQLite
+ * `outcome` column or as a raw object when the API returns the
+ * parsed plan. Tolerate both shapes.
+ *
+ * @param {string|object|null} outcome
+ * @returns {string} HTML
+ */
+function renderOutcomeChip(outcome) {
+  if (!outcome) return '';
+  let parsed;
+  try { parsed = typeof outcome === 'string' ? JSON.parse(outcome) : outcome; }
+  catch { return ''; }
+  if (!parsed || typeof parsed !== 'object') return '';
+  const summary = parsed.summary || `Resultado: ${parsed.status || 'desconocido'}`;
+  return `
+    <span class="story-card__outcome-chip"
+          style="margin-left:auto;padding:2px 8px;font-size:0.7rem;background:var(--bg-primary);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer;color:var(--text-muted);"
+          title="${esc(summary)}"
+          onclick="event.stopPropagation(); showOutcomeModal('${esc(JSON.stringify(parsed).replace(/'/g, '&#39;'))}');">
+      📄 resumen
+    </span>
   `;
 }
 
@@ -1154,6 +1189,117 @@ async function confirmRunWithPreflight(projectId) {
     proceed?.addEventListener('click', () => close(true), { once: true });
     dlg.addEventListener('close', () => resolve(false), { once: true });
   });
+}
+
+// ---- PR3: outcome modal + plan rollup banner ----
+//
+// Surfaces the per-HU + plan-level execution outcome the orchestrator
+// stamps on the plan JSON. Plain Spanish, no jargon, designed for a
+// non-technical user reviewing what happened during the run.
+
+/**
+ * Open the outcome detail modal for a single HU. The chip on each
+ * card calls this with the JSON-stringified outcome (escaped for the
+ * inline onclick attribute) — we parse and render the breakdown.
+ *
+ * Exposed on `window` because it's invoked from the inline onclick
+ * attribute renderOutcomeChip writes.
+ */
+window.showOutcomeModal = function showOutcomeModal(escapedJson) {
+  let outcome;
+  try { outcome = JSON.parse(String(escapedJson).replace(/&#39;/g, "'")); }
+  catch { return; }
+  const dlg = document.getElementById('app-dialog') || ensureDialog();
+  const status = outcome.status || 'desconocido';
+  const headerColor = status === 'done' ? 'var(--color-green)'
+    : status === 'failed' ? 'var(--color-red,#ef4444)'
+    : 'var(--color-yellow,#eab308)';
+  const headerLabel = status === 'done' ? 'HU completada'
+    : status === 'failed' ? 'HU fallida'
+    : status === 'blocked' ? 'HU bloqueada'
+    : `HU · ${status}`;
+  const durationText = outcome.duration_ms != null ? formatDuration(outcome.duration_ms) : '—';
+  const blockersHtml = (outcome.blockers || []).length === 0 ? '' : `
+    <div style="margin-top:10px;">
+      <div style="font-weight:600;color:var(--color-red,#ef4444);font-size:0.85rem;">Problemas detectados</div>
+      <ul style="margin:4px 0 0 18px;padding:0;color:var(--text);">
+        ${outcome.blockers.map(b => `<li style="font-size:0.8rem;margin-top:4px;">${esc(b)}</li>`).join('')}
+      </ul>
+    </div>
+  `;
+  const commitsHtml = (outcome.commits || []).length === 0 ? '' : `
+    <div style="margin-top:10px;">
+      <div style="font-weight:600;color:var(--text);font-size:0.85rem;">Commits</div>
+      <ul style="margin:4px 0 0 18px;padding:0;color:var(--text-muted);">
+        ${outcome.commits.map(c => `<li style="font-family:var(--font-mono,monospace);font-size:0.78rem;">${esc(c)}</li>`).join('')}
+      </ul>
+    </div>
+  `;
+  dlg.innerHTML = `
+    <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;gap:10px;background:${headerColor};color:#000;">
+      <span style="font-size:1.2rem;">📄</span>
+      <span>${esc(headerLabel)}</span>
+    </div>
+    <div style="padding:14px 18px;max-height:65vh;overflow:auto;">
+      <p style="margin:0 0 10px;color:var(--text);">${esc(outcome.summary || '(sin resumen disponible)')}</p>
+      <div style="display:grid;grid-template-columns:repeat(auto-fill, minmax(180px, 1fr));gap:8px;font-size:0.8rem;">
+        <div><strong>Iteraciones</strong>: ${outcome.iterations ?? '—'}</div>
+        <div><strong>Duración</strong>: ${durationText}</div>
+        <div><strong>Rama</strong>: <span style="font-family:var(--font-mono,monospace)">${esc(outcome.branch || '—')}</span></div>
+        <div><strong>Pull Request</strong>: ${outcome.pr_url ? `<a href="${esc(outcome.pr_url)}" target="_blank" rel="noopener">abrir</a>` : '—'}</div>
+        <div><strong>Terminada</strong>: ${esc(outcome.finishedAt || '—')}</div>
+      </div>
+      ${blockersHtml}
+      ${commitsHtml}
+    </div>
+    <div style="padding:12px 18px;border-top:1px solid var(--border);display:flex;justify-content:flex-end;">
+      <button id="outcome-close" style="padding:8px 16px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;">Cerrar</button>
+    </div>
+  `;
+  if (typeof dlg.showModal === 'function' && !dlg.open) dlg.showModal();
+  dlg.querySelector('#outcome-close')?.addEventListener('click', () => { try { dlg.close(); } catch { /* ignore */ } }, { once: true });
+};
+
+/**
+ * Fetch + render the plan-level rollup banner. Shows X done / Y
+ * failed / Z blocked + total duration when at least one plan in the
+ * project has finished. Hidden otherwise.
+ */
+async function renderPlanRollup(projectId) {
+  const slot = document.getElementById('plan-rollup-banner');
+  if (!slot) return;
+  let data;
+  try {
+    const r = await fetch(`/api/projects/${encodeURIComponent(projectId)}/plans-outcome`);
+    if (!r.ok) return;
+    data = await r.json();
+  } catch { return; }
+  const finished = (data.plans || []).filter(p => p.outcome);
+  if (finished.length === 0) { slot.innerHTML = ''; return; }
+  // Aggregate the most recent plan first — non-tech user usually
+  // cares about "what happened just now", not historical sums.
+  finished.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
+  const recent = finished[0];
+  const o = recent.outcome;
+  const c = o.counts || {};
+  const summaryColor = o.status === 'done' ? 'var(--color-green)'
+    : o.status === 'failed' ? 'var(--color-red,#ef4444)'
+    : 'var(--color-yellow,#eab308)';
+  const headline = o.status === 'done' ? 'Plan finalizado correctamente'
+    : o.status === 'failed' ? 'Plan terminado con errores'
+    : 'Plan terminado parcialmente';
+  const durationText = o.duration_ms != null ? formatDuration(o.duration_ms) : '—';
+  slot.innerHTML = `
+    <div style="margin:8px 0;padding:10px 14px;background:var(--bg-primary);border:1px solid var(--border);border-left:4px solid ${summaryColor};border-radius:var(--radius-sm);font-size:0.85rem;display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
+      <span style="color:${summaryColor};font-weight:700;">${esc(headline)}</span>
+      <span style="color:var(--text-muted);">${esc(recent.name || recent.planId)}</span>
+      <span style="color:var(--text);">✓ ${c.done || 0} hechas</span>
+      ${c.failed ? `<span style="color:var(--color-red,#ef4444)">✗ ${c.failed} fallidas</span>` : ''}
+      ${c.blocked ? `<span style="color:var(--color-yellow,#eab308)">⏸ ${c.blocked} bloqueadas</span>` : ''}
+      <span style="color:var(--text-muted);">⏱ ${esc(durationText)}</span>
+      ${(o.prs || []).length > 0 ? `<span style="color:var(--text-muted);">${o.prs.length} PR(s):</span> ${o.prs.map(u => `<a href="${esc(u)}" target="_blank" rel="noopener" style="color:var(--color-green);">abrir</a>`).join(' · ')}` : ''}
+    </div>
+  `;
 }
 
 async function runProject(projectId) {

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -149,6 +149,14 @@ export function initDb() {
   // implements (e.g. "5.3" or "§5 Initial Scope"). Surfaces in the
   // card + modal so the user can trace HU → spec coverage.
   try { db.exec('ALTER TABLE stories ADD COLUMN spec_section TEXT'); } catch { /* already migrated */ }
+  // outcome (PR3): JSON blob with what actually happened during
+  // execution — iterations, duration, commits, branch, blockers,
+  // human summary. Stamped by hu-sub-pipeline at the end of each
+  // HU and ingested by syncPlanFile so the board can show the 📄
+  // indicator and detail modal without parsing the plan JSON
+  // again. Stored as TEXT (JSON.stringify'd) for simplicity —
+  // parsed on read by the UI.
+  try { db.exec('ALTER TABLE stories ADD COLUMN outcome TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   return db;
@@ -197,14 +205,14 @@ export function upsertStory(story) {
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
-      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section
+      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
-      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section
+      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -231,7 +239,8 @@ export function upsertStory(story) {
       blocked_by = COALESCE(@blocked_by, blocked_by),
       acceptance_tests = COALESCE(@acceptance_tests, acceptance_tests),
       plan_order = COALESCE(@plan_order, plan_order),
-      spec_section = COALESCE(@spec_section, spec_section)
+      spec_section = COALESCE(@spec_section, spec_section),
+      outcome = COALESCE(@outcome, outcome)
   `);
   stmt.run({
     id: story.id,
@@ -263,6 +272,7 @@ export function upsertStory(story) {
     acceptance_tests: story.acceptance_tests || null,
     plan_order: story.plan_order ?? null,
     spec_section: story.spec_section || null,
+    outcome: story.outcome || null,
   });
 }
 

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -130,6 +130,43 @@ router.get('/projects/:id/preflight', async (req, res) => {
 });
 
 /**
+ * GET /api/projects/:id/plans-outcome — Plan-level rollups (PR3).
+ *
+ * Reads every plan JSON for the project and returns the lightweight
+ * shape the board needs to render the "Plan finalizado · 8 done · 2
+ * failed · 15 min" banner. Plans that haven't finished yet have a
+ * null outcome — the front handles that by hiding the banner.
+ */
+router.get('/projects/:id/plans-outcome', (req, res) => {
+  try {
+    const projectId = req.params.id;
+    const plansBase = process.env.KJ_HOME
+      ? path.join(process.env.KJ_HOME, 'plans')
+      : path.join(process.env.HOME || '', '.kj', 'plans');
+    const plansDir = path.join(plansBase, projectId);
+    if (!fs.existsSync(plansDir)) return res.json({ projectId, plans: [] });
+    const out = [];
+    for (const f of fs.readdirSync(plansDir).filter(n => n.endsWith('.json'))) {
+      try {
+        const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
+        if (plan?.version !== 2) continue;
+        out.push({
+          planId: plan.planId,
+          name: plan.name || (plan.task ? plan.task.slice(0, 80) : plan.planId),
+          status: plan.status || 'draft',
+          updatedAt: plan.updatedAt || null,
+          outcome: plan.outcome || null,
+          huCount: Array.isArray(plan.hus) ? plan.hus.length : 0,
+        });
+      } catch { /* skip unreadable plan */ }
+    }
+    res.json({ projectId, plans: out });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
  * GET /api/projects/:id/stories - Stories for a project.
  */
 router.get('/projects/:id/stories', (req, res) => {

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -388,6 +388,11 @@ export function syncPlanFile(filePath) {
         plan_order: i,
         // Spec mapping (PR C): "implements §5.3" trace pointer.
         spec_section: typeof hu.spec_section === 'string' && hu.spec_section.trim() ? hu.spec_section.trim() : null,
+        // PR3: per-HU outcome (iterations, duration, commits,
+        // blockers, summary). Stored as a JSON string in SQLite —
+        // the front parses on read. Null until hu-sub-pipeline
+        // stamps it at the end of each HU.
+        outcome: hu.outcome ? JSON.stringify(hu.outcome) : null,
       });
     }
 

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -38,7 +38,7 @@ import {
 import { resolveAddyosmaniSlugs } from "../../skills/addyosmani-role-map.js";
 import { saveSession } from "../../session/store.js";
 import {
-  setPreflight, setPreLoopContext, setPlanRef, setPlanSyncCallback, setLiveStatusUpdater,
+  setPreflight, setPreLoopContext, setPlanRef, setPlanSyncCallback, setLiveStatusUpdater, setLiveOutcomeUpdater,
   setAutoInstalledSkills, setSkillsRecommended, setAddyosmaniSkills,
 } from "../../session/mutators.js";
 import {
@@ -341,13 +341,25 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
             // Kanban columns reflect progress in real time. Without this
             // the plan only updates at the end of the run and the board
             // looks frozen during execution.
-            const { updateHuStatus: updateHuStatusFn } = await import("../../plan/plan-hu-ops.js");
+            const { updateHuStatus: updateHuStatusFn, setHuOutcome: setHuOutcomeFn } = await import("../../plan/plan-hu-ops.js");
             setLiveStatusUpdater(session, async (huId, status) => {
               try {
                 if (!updateHuStatusFn(loadedPlan, huId, status)) return;
                 await savePlanToDisk(projectDir, loadedPlan);
               } catch (err) {
                 logger?.warn?.(`Live status update failed for ${huId}: ${err.message}`);
+              }
+            });
+            // PR3 (per-HU outcome): same pattern but for the rich
+            // outcome blob (iterations, duration, commits, summary…).
+            // Stamped once per HU at runSingleHu's exit so the board
+            // can show the 📄 indicator as soon as each HU finishes.
+            setLiveOutcomeUpdater(session, async (huId, outcome) => {
+              try {
+                if (!setHuOutcomeFn(loadedPlan, huId, outcome)) return;
+                await savePlanToDisk(projectDir, loadedPlan);
+              } catch (err) {
+                logger?.warn?.(`Live outcome update failed for ${huId}: ${err.message}`);
               }
             });
             logger.info(`Plan ${flags.plan}: ${huBatch.certified} HUs ready for execution`);

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -394,7 +394,10 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
         // hu-sub-pipeline can patch the plan JSON on every transition,
         // not only at the end of the run. The board's chokidar then
         // fires per-HU and the Kanban columns update in real time.
-        onStatusChange: ctx.session?._liveStatusUpdater || null
+        onStatusChange: ctx.session?._liveStatusUpdater || null,
+        // PR3 (per-HU outcome): same pattern, but for the rich
+        // outcome blob written ONCE per HU at the end of runSingleHu.
+        onOutcome: ctx.session?._liveOutcomeUpdater || null
       });
 
       emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -62,13 +62,66 @@ function buildHuTask(story) {
 }
 
 /**
+ * Build the per-HU outcome blob from whatever metadata the iteration
+ * loop returned. Tolerant by design — most fields are optional and we
+ * default to safe values so the board can render something useful
+ * even on weird failure modes (HU crashed before producing summary,
+ * runIterationFn missing the commits array, etc.).
+ *
+ * Plain-Spanish summary lives at the bottom of the priority order so
+ * we surface what the run actually said before falling back to
+ * generic phrases.
+ *
+ * @param {object} args
+ * @param {object} args.story
+ * @param {object} args.iterResult — whatever runIterationFn returned
+ * @param {string} args.status — HU_STATUS.* terminal value
+ * @param {number} args.startedAt — Date.now() when runSingleHu started
+ * @returns {object}
+ */
+function buildHuOutcome({ story, iterResult, status, startedAt }) {
+  const r = iterResult || {};
+  const git = r.git || {};
+  // Iterations are tracked in the standard pipeline as
+  // `result.iterations`, in the tests-first pipeline as the loop
+  // counter — fall back to whatever we can find.
+  const iterations = r.iterations ?? r.iteration ?? r.attempts ?? null;
+  const commits = Array.isArray(git.commits)
+    ? git.commits.map((c) => (typeof c === "string" ? c : c.hash || c.sha || "")).filter(Boolean)
+    : (Array.isArray(r.commits) ? r.commits : []);
+  const blockers = [];
+  if (r.error) blockers.push(String(r.error));
+  if (r.reason && r.reason !== "approved") blockers.push(String(r.reason));
+  if (Array.isArray(r.deferredIssues)) {
+    for (const d of r.deferredIssues) blockers.push(typeof d === "string" ? d : d.message || JSON.stringify(d));
+  }
+  // Plain-Spanish, one-or-two sentences.
+  let summary;
+  if (r.review?.summary) summary = String(r.review.summary);
+  else if (status === "done") summary = `HU completada${commits.length ? ` con ${commits.length} commit(s)` : ""}.`;
+  else if (status === "failed") summary = `HU falló${blockers.length ? `: ${blockers[0]}` : ""}.`;
+  else summary = `HU ${status}.`;
+  return {
+    status,
+    iterations: typeof iterations === "number" ? iterations : null,
+    duration_ms: typeof startedAt === "number" ? Date.now() - startedAt : null,
+    branch: r.branch || git.branch || null,
+    commits,
+    pr_url: r.pr_url || r.prUrl || git.pr_url || null,
+    blockers,
+    summary,
+    finishedAt: new Date().toISOString(),
+  };
+}
+
+/**
  * Execute a single HU through the coder→sonar→reviewer sub-pipeline.
  * Extracted to support both sequential and parallel execution paths.
  *
  * @param {object} params
  * @returns {Promise<{huId: string, approved: boolean, result?: object, error?: string, blockedDependents?: string[]}>}
  */
-async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null }) {
+async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null, onOutcome = null }) {
   // PR1 (live HU status): every saveHuBatch should also notify the
   // plan JSON so the board reflects state in real time. Defined as a
   // local helper so we don't repeat the try/null-check boilerplate.
@@ -77,6 +130,20 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     try { await onStatusChange(huId, status); }
     catch (err) { logger?.warn?.(`onStatusChange(${huId}, ${status}) failed: ${err.message}`); }
   };
+  // PR3 (per-HU outcome): single notification at the end of the HU
+  // with the rich outcome blob. Plan JSON gets it stamped before
+  // we return, so the board's chokidar fires once and the card
+  // shows its summary indicator.
+  const notifyOutcome = async (huId, outcome) => {
+    if (typeof onOutcome !== "function") return;
+    try { await onOutcome(huId, outcome); }
+    catch (err) { logger?.warn?.(`onOutcome(${huId}) failed: ${err.message}`); }
+  };
+
+  // PR3: capture the start time so duration can be reported in the
+  // outcome (wall-clock per HU is what the user needs in the board,
+  // not internal stage timings).
+  const huStartedAt = Date.now();
   const story = batch.stories.find(s => s.id === storyId);
 
   // --- Lazy refinement ---
@@ -145,6 +212,9 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
       updateStoryStatus(batch, story.id, HU_STATUS.DONE);
       await saveHuBatch(batchSessionId, batch);
       await notifyStatus(story.id, HU_STATUS.DONE);
+      // PR3: build + persist the per-HU outcome.
+      const okOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.DONE, startedAt: huStartedAt });
+      await notifyOutcome(story.id, okOutcome);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → done`,
         detail: { huId: story.id, status: HU_STATUS.DONE, timestamp: new Date().toISOString() }
@@ -152,13 +222,15 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
       emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
         status: "ok",
         message: `HU ${story.id} completed successfully`,
-        detail: { huId: story.id, approved: true }
+        detail: { huId: story.id, approved: true, outcome: okOutcome }
       }));
       return { huId: story.id, approved: true, result: iterResult };
     } else {
       updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
       await saveHuBatch(batchSessionId, batch);
       await notifyStatus(story.id, HU_STATUS.FAILED);
+      const failOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.FAILED, startedAt: huStartedAt });
+      await notifyOutcome(story.id, failOutcome);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → failed`,
         detail: { huId: story.id, status: HU_STATUS.FAILED, timestamp: new Date().toISOString() }
@@ -166,7 +238,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
       emitProgress(emitter, makeEvent("hu:end", { ...eventBase, stage: "hu-sub-pipeline" }, {
         status: "fail",
         message: `HU ${story.id} failed`,
-        detail: { huId: story.id, approved: false, reason: iterResult?.reason }
+        detail: { huId: story.id, approved: false, reason: iterResult?.reason, outcome: failOutcome }
       }));
       return { huId: story.id, approved: false, result: iterResult };
     }
@@ -174,6 +246,8 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
     await saveHuBatch(batchSessionId, batch);
     await notifyStatus(story.id, HU_STATUS.FAILED);
+    const errOutcome = buildHuOutcome({ story, iterResult: { error: err.message }, status: HU_STATUS.FAILED, startedAt: huStartedAt });
+    await notifyOutcome(story.id, errOutcome);
     emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
       message: `HU ${story.id} status → failed`,
       detail: { huId: story.id, status: HU_STATUS.FAILED, timestamp: new Date().toISOString() }
@@ -200,7 +274,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
  * @param {object} params.logger - Logger instance
  * @returns {Promise<{approved: boolean, results: object[], blockedIds: string[]}>}
  */
-export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null, onStatusChange = null }) {
+export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null, onStatusChange = null, onOutcome = null }) {
   const batchSessionId = huReviewerResult.batchSessionId;
   let batch;
   try {
@@ -248,7 +322,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
       // Single HU: run as before, no worktree needed
       const singleResult = await runSingleHu({
         storyId: runnableIds[0], batch, batchSessionId, runIterationFn,
-        emitter, eventBase, logger, config, results, onStatusChange
+        emitter, eventBase, logger, config, results, onStatusChange, onOutcome
       });
       results.push(singleResult);
       if (!singleResult.approved) {
@@ -287,7 +361,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
           storyId, batch, batchSessionId, runIterationFn,
           emitter, eventBase, logger, config, results,
           worktreePath: worktrees.get(storyId),
-          onStatusChange
+          onStatusChange, onOutcome
         });
       });
 

--- a/src/plan/plan-executor.js
+++ b/src/plan/plan-executor.js
@@ -5,7 +5,7 @@
  */
 
 import { isPlanV2 } from "./plan-schema.js";
-import { updateHuStatus } from "./plan-hu-ops.js";
+import { updateHuStatus, computePlanOutcome, setPlanOutcome } from "./plan-hu-ops.js";
 
 /**
  * Convert a v2 plan's HUs into the stageResults.huReviewer format
@@ -76,4 +76,12 @@ export function syncResultsToPlan(plan, subPipelineResult) {
   const anyFailed = plan.hus.some(h => h.status === "failed");
   plan.status = allDone ? "done" : anyFailed ? "failed" : "running";
   plan.updatedAt = new Date().toISOString();
+
+  // PR3: stamp the plan-level rollup so the board can show the
+  // "Plan finalizado · X done · Y failed · Z blocked · D min" banner
+  // without recomputing it on every render. Built from the per-HU
+  // outcomes that hu-sub-pipeline already wrote on the way through.
+  const duration_ms = subPipelineResult.duration_ms ?? null;
+  const rollup = computePlanOutcome(plan, { duration_ms });
+  setPlanOutcome(plan, rollup);
 }

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -100,6 +100,107 @@ export function updateHuStatus(plan, huId, status) {
 }
 
 /**
+ * Stamp the per-HU outcome — what actually happened during execution.
+ * Written ONCE per HU, at the end of runSingleHu in hu-sub-pipeline.
+ * Consumed by the board to render the per-HU summary indicator and
+ * by `kj report` for retrospective inspection.
+ *
+ * Shape (every field optional except status + finishedAt):
+ *   {
+ *     status:       "done" | "failed" | "blocked",
+ *     iterations:   number,        // how many coder→reviewer rounds
+ *     duration_ms:  number,        // wall-clock for this HU
+ *     branch:       string|null,   // git branch the coder used
+ *     commits:      string[],      // SHA list captured during the run
+ *     pr_url:       string|null,
+ *     blockers:     string[],      // why it failed/was blocked, plain
+ *     summary:      string,        // 1-2 sentence human summary
+ *     finishedAt:   ISO timestamp
+ *   }
+ *
+ * @returns {boolean} true if the HU was found and the outcome stored
+ */
+export function setHuOutcome(plan, huId, outcome) {
+  const hu = plan.hus.find(h => h.id === huId);
+  if (!hu) return false;
+  hu.outcome = {
+    status: outcome.status || hu.status || null,
+    iterations: outcome.iterations ?? null,
+    duration_ms: outcome.duration_ms ?? null,
+    branch: outcome.branch ?? null,
+    commits: Array.isArray(outcome.commits) ? outcome.commits : [],
+    pr_url: outcome.pr_url ?? null,
+    blockers: Array.isArray(outcome.blockers) ? outcome.blockers : [],
+    summary: outcome.summary || "",
+    finishedAt: outcome.finishedAt || new Date().toISOString(),
+  };
+  hu.updatedAt = new Date().toISOString();
+  plan.updatedAt = new Date().toISOString();
+  return true;
+}
+
+/**
+ * Stamp the plan-level rollup once every HU has finished. Built from
+ * the per-HU outcomes so the board can show "Plan finished · 8 done
+ * · 2 failed · 1 blocked · 15 min" in one banner.
+ *
+ *   {
+ *     status:       "done" | "partial" | "failed",
+ *     total:        number,
+ *     counts:       { done, failed, blocked, pending },
+ *     duration_ms:  number,
+ *     prs:          string[],            // unique pr_url across HUs
+ *     blockers:     string[],            // dedup'd blockers
+ *     finishedAt:   ISO timestamp,
+ *   }
+ */
+export function setPlanOutcome(plan, outcome) {
+  plan.outcome = {
+    status: outcome.status || "partial",
+    total: outcome.total ?? (plan.hus?.length || 0),
+    counts: outcome.counts || { done: 0, failed: 0, blocked: 0, pending: 0 },
+    duration_ms: outcome.duration_ms ?? null,
+    prs: Array.isArray(outcome.prs) ? [...new Set(outcome.prs.filter(Boolean))] : [],
+    blockers: Array.isArray(outcome.blockers) ? [...new Set(outcome.blockers.filter(Boolean))] : [],
+    finishedAt: outcome.finishedAt || new Date().toISOString(),
+  };
+  plan.updatedAt = new Date().toISOString();
+}
+
+/**
+ * Compute the rollup from the per-HU outcomes already stamped on the
+ * plan. Invoked by syncResultsToPlan in plan-executor when the run
+ * ends so the caller doesn't have to assemble the counts by hand.
+ */
+export function computePlanOutcome(plan, { duration_ms = null } = {}) {
+  const hus = plan.hus || [];
+  const counts = { done: 0, failed: 0, blocked: 0, pending: 0 };
+  const prs = [];
+  const blockers = [];
+  for (const hu of hus) {
+    const status = hu.outcome?.status || hu.status || "pending";
+    if (counts[status] !== undefined) counts[status] += 1;
+    else counts.pending += 1;
+    if (hu.outcome?.pr_url) prs.push(hu.outcome.pr_url);
+    if (Array.isArray(hu.outcome?.blockers)) blockers.push(...hu.outcome.blockers);
+  }
+  let status = "done";
+  if (counts.failed > 0 || counts.blocked > 0) status = counts.done > 0 ? "partial" : "failed";
+  if (counts.done === 0 && counts.failed === 0 && counts.blocked === 0) status = "pending";
+  return {
+    status,
+    total: hus.length,
+    counts,
+    duration_ms,
+    // Dedupe at the rollup boundary — same PR / blocker reported by
+    // multiple HUs is noise in the banner.
+    prs: [...new Set(prs.filter(Boolean))],
+    blockers: [...new Set(blockers.filter(Boolean))],
+    finishedAt: new Date().toISOString(),
+  };
+}
+
+/**
  * Mark all pending HUs as certified (ready to execute).
  * Sets plan status to "ready".
  * @returns {number} count of certified HUs

--- a/src/session/mutators.js
+++ b/src/session/mutators.js
@@ -227,6 +227,22 @@ export function getLiveStatusUpdater(session) {
   return session._liveStatusUpdater || null;
 }
 
+/**
+ * Live outcome updater (PR3): invoked by hu-sub-pipeline after each
+ * HU's runSingleHu finishes. The plan JSON gets the per-HU outcome
+ * stamped immediately so the board can show a "📄 ver resumen"
+ * indicator next to each card without waiting for the run to end.
+ *
+ * Signature: async (huId, outcome) => void
+ */
+export function setLiveOutcomeUpdater(session, fn) {
+  session._liveOutcomeUpdater = fn;
+}
+
+export function getLiveOutcomeUpdater(session) {
+  return session._liveOutcomeUpdater || null;
+}
+
 // --- Skills ---------------------------------------------------------------
 
 export function setAddyosmaniSkills(session, payload) {

--- a/tests/plan-hu-outcome.test.js
+++ b/tests/plan-hu-outcome.test.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  setHuOutcome, setPlanOutcome, computePlanOutcome, addHu, updateHuStatus,
+} from "../src/plan/plan-hu-ops.js";
+import { createPlanV2 } from "../src/plan/plan-schema.js";
+
+function makePlan() {
+  const p = createPlanV2("test task");
+  addHu(p, { title: "h1" });
+  addHu(p, { title: "h2" });
+  addHu(p, { title: "h3" });
+  return p;
+}
+
+describe("setHuOutcome", () => {
+  it("stamps the outcome blob with safe defaults for missing fields", () => {
+    const plan = makePlan();
+    const ok = setHuOutcome(plan, plan.hus[0].id, {
+      status: "done",
+      summary: "Implementé add(a,b).",
+    });
+    expect(ok).toBe(true);
+    const o = plan.hus[0].outcome;
+    expect(o.status).toBe("done");
+    expect(o.summary).toBe("Implementé add(a,b).");
+    expect(o.commits).toEqual([]);
+    expect(o.blockers).toEqual([]);
+    expect(o.iterations).toBeNull();
+    expect(o.duration_ms).toBeNull();
+    expect(o.finishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("preserves arrays passed in", () => {
+    const plan = makePlan();
+    setHuOutcome(plan, plan.hus[0].id, {
+      status: "failed",
+      commits: ["abc123", "def456"],
+      blockers: ["sonar gate failed", "tests missing"],
+      iterations: 3,
+      duration_ms: 124000,
+      branch: "feat/x",
+      pr_url: "https://github.com/x/y/pull/1",
+      summary: "fail",
+    });
+    const o = plan.hus[0].outcome;
+    expect(o.commits).toEqual(["abc123", "def456"]);
+    expect(o.blockers).toEqual(["sonar gate failed", "tests missing"]);
+    expect(o.iterations).toBe(3);
+    expect(o.duration_ms).toBe(124000);
+    expect(o.branch).toBe("feat/x");
+    expect(o.pr_url).toBe("https://github.com/x/y/pull/1");
+  });
+
+  it("returns false when the HU id is unknown", () => {
+    const plan = makePlan();
+    expect(setHuOutcome(plan, "no-such-hu", { status: "done" })).toBe(false);
+  });
+});
+
+describe("computePlanOutcome", () => {
+  it("counts statuses and dedupes prs + blockers", () => {
+    const plan = makePlan();
+    setHuOutcome(plan, plan.hus[0].id, { status: "done", pr_url: "https://x/pull/1" });
+    setHuOutcome(plan, plan.hus[1].id, { status: "failed", blockers: ["sonar fail"], pr_url: "https://x/pull/2" });
+    setHuOutcome(plan, plan.hus[2].id, { status: "failed", blockers: ["sonar fail", "tests missing"] });
+    updateHuStatus(plan, plan.hus[0].id, "done");
+    updateHuStatus(plan, plan.hus[1].id, "failed");
+    updateHuStatus(plan, plan.hus[2].id, "failed");
+
+    const r = computePlanOutcome(plan, { duration_ms: 950000 });
+    expect(r.total).toBe(3);
+    expect(r.counts).toEqual({ done: 1, failed: 2, blocked: 0, pending: 0 });
+    expect(r.status).toBe("partial");
+    expect(r.duration_ms).toBe(950000);
+    expect(r.prs).toEqual(["https://x/pull/1", "https://x/pull/2"]);
+    expect(r.blockers).toEqual(["sonar fail", "tests missing"]);
+    expect(r.finishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("returns status=done when every HU is done", () => {
+    const plan = makePlan();
+    for (const hu of plan.hus) {
+      updateHuStatus(plan, hu.id, "done");
+      setHuOutcome(plan, hu.id, { status: "done" });
+    }
+    const r = computePlanOutcome(plan);
+    expect(r.status).toBe("done");
+    expect(r.counts).toEqual({ done: 3, failed: 0, blocked: 0, pending: 0 });
+  });
+
+  it("returns status=failed when none are done", () => {
+    const plan = makePlan();
+    for (const hu of plan.hus) {
+      updateHuStatus(plan, hu.id, "failed");
+      setHuOutcome(plan, hu.id, { status: "failed" });
+    }
+    const r = computePlanOutcome(plan);
+    expect(r.status).toBe("failed");
+  });
+
+  it("returns status=pending when no HU has terminal status yet", () => {
+    const plan = makePlan();
+    const r = computePlanOutcome(plan);
+    expect(r.status).toBe("pending");
+  });
+});
+
+describe("setPlanOutcome", () => {
+  it("stamps the rollup blob with sensible defaults", () => {
+    const plan = makePlan();
+    setPlanOutcome(plan, { status: "done", total: 3, counts: { done: 3, failed: 0, blocked: 0, pending: 0 } });
+    expect(plan.outcome.status).toBe("done");
+    expect(plan.outcome.total).toBe(3);
+    expect(plan.outcome.prs).toEqual([]);
+    expect(plan.outcome.blockers).toEqual([]);
+    expect(plan.outcome.finishedAt).toMatch(/^\d{4}/);
+    expect(plan.updatedAt).toMatch(/^\d{4}/);
+  });
+
+  it("dedupes prs + blockers passed in", () => {
+    const plan = makePlan();
+    setPlanOutcome(plan, {
+      status: "partial", total: 3,
+      prs: ["a", "b", "a", "", null],
+      blockers: ["x", "y", "x"],
+    });
+    expect(plan.outcome.prs).toEqual(["a", "b"]);
+    expect(plan.outcome.blockers).toEqual(["x", "y"]);
+  });
+});


### PR DESCRIPTION
## Why

User feedback after a failed run: \"ya ha terminado el run, pero no tengo ni idea de lo que ha ocurrido. Veo que ha fallado sonar, pero no sé si ha commiteado, si se ha saltado alguna regla…\"

Three coupled changes that close the visibility gap.

## 1. Per-HU \`outcome\` blob on the plan JSON

Stamped at the end of every \`runSingleHu\` in \`hu-sub-pipeline\`:

\`\`\`json
{
  \"status\": \"done|failed|blocked\",
  \"iterations\": 3,
  \"duration_ms\": 124000,
  \"branch\": \"feat/PLN-TSK-0042-…\",
  \"commits\": [\"abc123\", \"def456\"],
  \"pr_url\": null,
  \"blockers\": [\"sonar gate failed\"],
  \"summary\": \"Implementé add(a,b). Tests pasan.\",
  \"finishedAt\": \"2026-04-26T…\"
}
\`\`\`

Helpers in \`plan-hu-ops.js\`: \`setHuOutcome\`, \`setPlanOutcome\`, \`computePlanOutcome\` (rollup with dedup).

Wiring mirrors PR1: \`setLiveOutcomeUpdater()\` mutator → \`pre-loop\` registers a closure → \`flow-runner\` forwards as \`onOutcome\` → \`hu-sub-pipeline\` calls it after every notifyStatus.

## 2. Plan-level rollup at end of run

\`syncResultsToPlan\` now also calls \`setPlanOutcome(plan, computePlanOutcome(plan, …))\` so the plan JSON carries \`{ status, counts, duration_ms, prs[], blockers[], finishedAt }\`.

## 3. Board surfaces both, plain Spanish, no jargon

- SQLite stories table gets an \`outcome\` TEXT column. \`syncPlanFile\` passes it through.
- New \`GET /api/projects/:id/plans-outcome\` returns plan-level rollups (reads plan JSONs directly).
- Each story card grows a \"📄 resumen\" chip when outcome is present. Click → modal with status-coloured header, iterations/duration/branch/PR/finished, \"Problemas detectados\" section, \"Commits\" section.
- Above the kanban, a coloured banner shows the most recent plan outcome: \"Plan finalizado correctamente\" / \"…con errores\" / \"…parcialmente\", with ✓ N hechas · ✗ N fallidas · ⏸ N bloqueadas · ⏱ duration · PR links.

## Test plan

- [x] 9 new cases for \`plan-hu-ops\` (defaults, arrays, unknown HU, counts, dedup, status edges).
- [x] Parent vitest: 3998/3998.
- [x] Board vitest: 125/125.
- [ ] Manual: launch a run with intentional failure → verify each HU shows the chip after finishing, modal opens with details, banner appears at top of kanban.