### PR TITLE
feat(board): launch a single HU from the per-card ▶ button

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -842,9 +842,26 @@ function renderStoryCard(story) {
   // this on the card so the user edits the HU before trying to run.
   const missingTestContract = testCount === 0 && ['pending', 'certified'].includes(story.status);
 
+  // PR4: per-HU ▶ Run button. Visible when:
+  //   - the HU is certified or failed (re-run after fixing) AND
+  //   - it has at least one acceptance test (otherwise the run
+  //     would refuse) AND
+  //   - it isn't currently coding/reviewing.
+  const canRunHu = ['certified', 'failed', 'pending'].includes(story.status)
+    && testCount > 0
+    && !['coding', 'reviewing'].includes(story.status);
+
   return `
     <div class="story-card" data-story-id="${esc(story.id)}" data-status="${esc(story.status || 'pending')}" onclick="showStoryDetail('${esc(story.id)}')">
-      <div class="story-card__id" title="${esc(story.id)}">${esc(shortId)}</div>
+      <div class="story-card__id" title="${esc(story.id)}">
+        ${esc(shortId)}
+        ${canRunHu ? `
+          <button class="story-card__run-btn"
+                  style="float:right;padding:1px 6px;font-size:0.7rem;background:var(--color-green);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;"
+                  title="Lanzar solo esta HU"
+                  onclick="event.stopPropagation(); window.runSingleHuFromCard('${esc(story.id)}', '${esc(title.replace(/'/g, '&#39;'))}');">▶</button>
+        ` : ''}
+      </div>
       <div class="story-card__title">${esc(truncate(title, 100))}</div>
       <div class="story-card__meta" style="gap:10px">
         ${acCount > 0 ? `<span title="${acCount} acceptance criteria">📋 ${acCount} AC${acCount === 1 ? '' : 's'}</span>` : ''}
@@ -1155,6 +1172,47 @@ async function confirmRunWithPreflight(projectId) {
     dlg.addEventListener('close', () => resolve(false), { once: true });
   });
 }
+/**
+ * PR4: launch a single HU from the per-card ▶ button. Confirms with
+ * the user (so an accidental click doesn't kick a run) and POSTs to
+ * the new /api/hus/:huId/run endpoint, which resolves the planId
+ * server-side from the SQLite row.
+ *
+ * Exposed on `window` because the inline onclick on the card calls it.
+ */
+window.runSingleHuFromCard = async function runSingleHuFromCard(huId, title) {
+  const friendlyTitle = (title || huId).replace(/&#39;/g, "'");
+  const ok = await showConfirm(
+    `¿Lanzar solo esta HU?\n\n${friendlyTitle}\n\nKarajan ejecutará únicamente esta HU; las demás del plan no se tocarán.`,
+    { title: 'Lanzar HU individual', okLabel: 'Lanzar', cancelLabel: 'Cancelar' }
+  );
+  if (!ok) return;
+  try {
+    const res = await fetch(`/api/hus/${encodeURIComponent(huId)}/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudo lanzar la HU' });
+      return;
+    }
+    const body = await res.json();
+    // Surface the log path so the user can tail it from the View log button.
+    if (body.logPath) {
+      lastOpenedLog = {
+        id: `hu-${huId}`,
+        label: `HU ${huId}`,
+        tailUrl: (offset) => `/api/runs/${encodeURIComponent(`hu-${huId}`)}/log?offset=${offset || 0}`,
+      };
+    }
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo al lanzar la HU' });
+  }
+};
 
 async function runProject(projectId) {
   try {

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -204,7 +204,7 @@ export function markPlanReady({ planId, projectId }) {
  * @param {string} [args.taskOverride] - optional custom task string
  * @returns {{ ok: true, pid: number, logPath: string } | { ok: false, error: string }}
  */
-export function runPlan({ planId, projectId, taskOverride } = {}) {
+export function runPlan({ planId, projectId, taskOverride, huIds = null } = {}) {
   const filePath = findPlanFilePath(planId, projectId);
   if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
 
@@ -222,17 +222,37 @@ export function runPlan({ planId, projectId, taskOverride } = {}) {
     };
   }
 
+  // PR4: when huIds is set, validate they exist before spawning so
+  // we surface "unknown HU" as an HTTP 400 instead of letting the
+  // CLI fail mid-startup with a less obvious message.
+  let huFlag = null;
+  if (Array.isArray(huIds) && huIds.length > 0) {
+    const validIds = new Set(plan.hus.map((h) => h.id));
+    const unknown = huIds.filter((id) => !validIds.has(id));
+    if (unknown.length > 0) {
+      return { ok: false, error: `unknown HU id(s) in plan ${planId}: ${unknown.join(', ')}` };
+    }
+    huFlag = huIds.join(',');
+  }
+
   const runsDir = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-board-runs');
   mkdirSync(runsDir, { recursive: true });
-  const logPath = join(runsDir, `${planId}.log`);
+  // PR4: when running a single HU, suffix the log with the HU id so
+  // a subsequent full-plan run doesn't overwrite the per-HU log.
+  const logName = huFlag
+    ? `${planId}--hu-${huIds.join('-').replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 60)}.log`
+    : `${planId}.log`;
+  const logPath = join(runsDir, logName);
 
   const task = taskOverride || plan.task || `run plan ${planId}`;
-  const args = [KJ_CLI, 'run', '--plan', planId, task];
+  const args = [KJ_CLI, 'run', '--plan', planId];
+  if (huFlag) args.push('--hu', huFlag);
+  args.push(task);
 
   // Escape hatch for tests — hard-kill the spawn so vitest doesn't boot
   // the full orchestrator. The shape of the response is what we assert.
   if (process.env.KJ_RUN_SPAWN_MODE === 'echo') {
-    return { ok: true, pid: 0, logPath, argv: [process.execPath, ...args], projectDir };
+    return { ok: true, pid: 0, logPath, argv: [process.execPath, ...args], projectDir, huIds: huIds || null };
   }
 
   const out = openSync(logPath, 'a');

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -573,12 +573,63 @@ router.get('/plans/:planId/log', (req, res) => {
  */
 router.post('/plans/:planId/run', (req, res) => {
   try {
-    const { projectId, task } = req.body || {};
-    const result = runPlan({ planId: req.params.planId, projectId, taskOverride: task });
-    if (!result.ok) return res.status(404).json({ error: result.error });
+    const { projectId, task, huIds } = req.body || {};
+    // PR4: callers may pass `huIds: ["hu_x_001"]` to scope the run
+    // to a single HU (or comma-separated subset). When omitted, the
+    // whole plan runs as before.
+    const result = runPlan({
+      planId: req.params.planId,
+      projectId,
+      taskOverride: task,
+      huIds: Array.isArray(huIds) ? huIds : null,
+    });
+    if (!result.ok) {
+      // 404 for "plan not found" (preserves the contract the existing
+      // test asserts on), 400 for validation errors (unknown HU id,
+      // missing projectDir, etc.).
+      const code = /^plan not found/.test(result.error) ? 404 : 400;
+      return res.status(code).json({ error: result.error });
+    }
     res.json({
       launched: true,
       planId: req.params.planId,
+      pid: result.pid,
+      logPath: result.logPath,
+      huIds: Array.isArray(huIds) && huIds.length > 0 ? huIds : null,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/hus/:huId/run — PR4: launch a single HU (or, when the
+ * caller passes additional ids in body.extraHuIds, a small bundle).
+ *
+ * The HU's plan is resolved from the SQLite stories table so the
+ * front doesn't have to know the planId — it only needs the story
+ * id from the card.
+ */
+router.post('/hus/:huId/run', (req, res) => {
+  try {
+    const huId = req.params.huId;
+    const row = getStoryRow(huId);
+    if (!row) return res.status(404).json({ error: `unknown HU: ${huId}` });
+    if (!row.plan_id) return res.status(400).json({ error: `HU ${huId} is not backed by a plan (legacy row)` });
+
+    // Story id on disk uses just the HU local id (hu_<plan>_NNN),
+    // not the "<projectId>::<huId>" composite the board persists.
+    // Strip the prefix back off before forwarding to runPlan.
+    const planLocalHuId = huId.includes('::') ? huId.split('::').pop() : huId;
+    const extraIds = Array.isArray(req.body?.extraHuIds) ? req.body.extraHuIds.map((x) => (x.includes('::') ? x.split('::').pop() : x)) : [];
+    const huIds = [planLocalHuId, ...extraIds];
+
+    const result = runPlan({ planId: row.plan_id, projectId: row.project_id, huIds });
+    if (!result.ok) return res.status(400).json({ error: result.error });
+    res.json({
+      launched: true,
+      planId: row.plan_id,
+      huIds,
       pid: result.pid,
       logPath: result.logPath,
     });

--- a/packages/hu-board/tests/run-single-hu.test.js
+++ b/packages/hu-board/tests/run-single-hu.test.js
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpKj;
+let savedPlansDir;
+let savedSpawnMode;
+
+beforeEach(() => {
+  tmpKj = join(tmpdir(), `kj-runhu-${process.pid}-${Date.now()}`);
+  // plan-mutations.js::plansRoot prefers KJ_PLANS_DIR over KJ_HOME, and
+  // vitest.config.js sets KJ_PLANS_DIR globally to a placeholder. Override
+  // it here so findPlanFilePath sees our fixture.
+  const plansDir = join(tmpKj, 'plans');
+  mkdirSync(join(plansDir, 'proj1'), { recursive: true });
+
+  writeFileSync(join(plansDir, 'proj1', 'plan-X.json'), JSON.stringify({
+    planId: 'plan-X',
+    version: 2,
+    projectDir: '/some/proj',
+    task: 'do stuff',
+    status: 'ready',
+    hus: [
+      { id: 'hu_plan-X_001', title: 'h1', status: 'certified' },
+      { id: 'hu_plan-X_002', title: 'h2', status: 'certified' },
+      { id: 'hu_plan-X_003', title: 'h3', status: 'certified' },
+    ],
+  }));
+
+  savedPlansDir = process.env.KJ_PLANS_DIR;
+  process.env.KJ_PLANS_DIR = plansDir;
+  savedSpawnMode = process.env.KJ_RUN_SPAWN_MODE;
+  process.env.KJ_RUN_SPAWN_MODE = 'echo';     // never actually spawn
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (savedPlansDir === undefined) delete process.env.KJ_PLANS_DIR;
+  else process.env.KJ_PLANS_DIR = savedPlansDir;
+  if (savedSpawnMode === undefined) delete process.env.KJ_RUN_SPAWN_MODE;
+  else process.env.KJ_RUN_SPAWN_MODE = savedSpawnMode;
+  try { rmSync(tmpKj, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('runPlan with huIds (PR4)', () => {
+  it('returns the same shape when no huIds is set (back-compat)', async () => {
+    const { runPlan } = await import('../src/plan-mutations.js');
+    const r = runPlan({ planId: 'plan-X', projectId: 'proj1' });
+    expect(r.ok).toBe(true);
+    expect(r.argv).toBeDefined();
+    expect(r.argv.join(' ')).toMatch(/--plan plan-X/);
+    expect(r.argv.join(' ')).not.toMatch(/--hu/);
+    expect(r.huIds).toBeNull();
+  });
+
+  it('appends --hu <ids> to the spawn argv when huIds is passed', async () => {
+    const { runPlan } = await import('../src/plan-mutations.js');
+    const r = runPlan({ planId: 'plan-X', projectId: 'proj1', huIds: ['hu_plan-X_002'] });
+    expect(r.ok).toBe(true);
+    expect(r.argv.join(' ')).toMatch(/--plan plan-X --hu hu_plan-X_002/);
+    expect(r.huIds).toEqual(['hu_plan-X_002']);
+  });
+
+  it('joins multiple huIds with comma', async () => {
+    const { runPlan } = await import('../src/plan-mutations.js');
+    const r = runPlan({ planId: 'plan-X', projectId: 'proj1', huIds: ['hu_plan-X_001', 'hu_plan-X_003'] });
+    expect(r.ok).toBe(true);
+    expect(r.argv.join(' ')).toMatch(/--hu hu_plan-X_001,hu_plan-X_003/);
+  });
+
+  it('rejects huIds that do not exist on the plan', async () => {
+    const { runPlan } = await import('../src/plan-mutations.js');
+    const r = runPlan({ planId: 'plan-X', projectId: 'proj1', huIds: ['nope_001', 'hu_plan-X_002'] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/unknown HU/);
+  });
+
+  it('uses a per-HU log filename so a full-plan run does not overwrite it', async () => {
+    const { runPlan } = await import('../src/plan-mutations.js');
+    const single = runPlan({ planId: 'plan-X', projectId: 'proj1', huIds: ['hu_plan-X_002'] });
+    const full   = runPlan({ planId: 'plan-X', projectId: 'proj1' });
+    expect(single.logPath).not.toBe(full.logPath);
+    expect(single.logPath).toMatch(/plan-X--hu-hu_plan-X_002\.log$/);
+    expect(full.logPath).toMatch(/plan-X\.log$/);
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -102,6 +102,11 @@ program
   .option("--enable-discover")
   .option("--enable-architect")
   .option("--plan <planId>", "Plan ID from kj plan. Loads persisted plan context and skips researcher/architect/planner.")
+  // PR4: launch a single HU (or comma-separated list) instead of the
+  // entire plan. The board uses this for the per-HU ▶ button so the
+  // user can re-run only a failed HU without restarting the whole
+  // plan. Requires --plan to also be set.
+  .option("--hu <huIds>", "Comma-separated HU IDs to run. When set, the plan's other HUs are skipped. Requires --plan.")
   .option("--enable-hu-reviewer")
   .option("--hu-file <path>", "YAML file with HU stories to certify before coding")
   .option("--enable-serena")

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -328,6 +328,40 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
         // v2 plan with HUs → inject as huReviewer so sub-pipeline picks them up
         if (isPlanV2(loadedPlan) && loadedPlan.hus?.length > 0) {
           const huBatch = planToHuBatch(loadedPlan);
+          // PR4: --hu <ids> filters the batch to only the requested
+          // stories, marking the rest as already-done so the sub-
+          // pipeline skips them. The board's per-HU ▶ button uses
+          // this to re-run a single failed HU without restarting
+          // the whole plan.
+          if (huBatch.ok && flags.hu) {
+            const requested = String(flags.hu).split(",").map((s) => s.trim()).filter(Boolean);
+            if (requested.length === 0) {
+              logger.warn(`--hu was empty after parsing — falling back to running every certified HU`);
+            } else {
+              const requestedSet = new Set(requested);
+              const found = huBatch.stories.filter((s) => requestedSet.has(s.id));
+              const missing = requested.filter((id) => !huBatch.stories.some((s) => s.id === id));
+              if (missing.length > 0) {
+                logger.warn(`--hu: ignored ${missing.length} unknown HU id(s): ${missing.join(", ")}`);
+              }
+              if (found.length === 0) {
+                throw new Error(`--hu: none of the requested HU id(s) exist in plan ${flags.plan}: ${requested.join(", ")}`);
+              }
+              // Stories not in `requested` get status=done so the sub-
+              // pipeline filter (`status === certified`) skips them.
+              // We don't touch the plan JSON itself — this is a
+              // run-time filter only.
+              for (const story of huBatch.stories) {
+                if (!requestedSet.has(story.id)) story.status = "done";
+              }
+              huBatch.certified = found.length;
+              logger.info(`Plan ${flags.plan}: --hu filter active — ${found.length}/${huBatch.total} HU(s) will run (${found.map((s) => s.id).join(", ")})`);
+              emitProgress(emitter, makeEvent("plan:hu-filter", { ...eventBase, stage: "plan" }, {
+                message: `--hu filter: ${found.length} HU(s) selected, ${huBatch.total - found.length} skipped`,
+                detail: { planId: flags.plan, requested, ignored: missing, willRun: found.map((s) => s.id) }
+              }));
+            }
+          }
           if (huBatch.ok) {
             stageResults.huReviewer = huBatch;
             // Store plan reference so we can sync results back after execution


### PR DESCRIPTION
## Why

User feedback: \"también podría poder lanzarse las tareas 'ready to run' de manera individual, desde la propia HU, y no tener que hacer todo el run plan entero\".

## Three pieces

### 1. CLI: \`kj run --plan <id> --hu <huIds>\`

New flag accepting a comma-separated list. \`pre-loop\` flips every story whose id isn't in the requested set to \`status=done\` inside the in-memory batch so the sub-pipeline skips them. Validates ids exist; throws on completely unknown ids; warns + skips partial unknowns. Emits a \`plan:hu-filter\` progress event.

### 2. Board: \`POST /api/hus/:huId/run\`

Resolves the planId from SQLite so the front never needs to know it. Optional \`body.extraHuIds\` to bundle a small subset.

### 3. Frontend: per-card ▶ button

Visible when status ∈ {certified, failed, pending} AND \`test_count > 0\` AND not currently coding/reviewing. Click → plain-Spanish confirm modal → POST → board re-renders.

## Back-compat

\`runPlan({ planId, projectId, taskOverride })\` keeps working unchanged. The new \`huIds\` param defaults to null. Log filename stays \`<planId>.log\` for full-plan runs and gets \`<planId>--hu-<id>.log\` when scoped so the per-HU log can't overwrite the full one.

## Test plan

- [x] 5 new cases for \`runPlan\` (back-compat shape, single HU, multi-HU, unknown id rejection, log uniqueness).
- [x] Parent vitest: 3989 / 3989.
- [x] Board vitest: 130 / 130.