### PR TITLE
feat(board): kj.config.yml editor modal — settings without a terminal

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -2349,6 +2349,108 @@ function handleRoute() {
 // viewer (re-uses openLogViewer's tail loop, just pointed at the
 // new generic /api/runs/:commandId/log endpoint).
 
+// PR5: kj.config.yml editor modal
+//
+// Goal: a non-technical user opens the modal, picks "Sonnet siempre"
+// from a dropdown, hits "Guardar", and the next `kj run` is cheap.
+// No yml editing, no terminal trip.
+//
+// Each EDITABLE_FIELDS entry the backend exposes becomes one form
+// row. `select` → <select>, `boolean` → <input type=checkbox>,
+// `number` → <input type=number min/max>. Help text under each
+// label as a small grey paragraph.
+async function showConfigEditor() {
+  let cfg;
+  try {
+    const r = await fetch('/api/config');
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    cfg = await r.json();
+  } catch (err) {
+    await showError(`No se pudo leer la configuración: ${err.message}`, { title: 'Configuración' });
+    return;
+  }
+  const dlg = document.getElementById('app-dialog') || ensureDialog();
+  const renderField = (f) => {
+    const id = `cfg-field-${f.key}`;
+    let input = '';
+    if (f.type === 'select') {
+      input = `<select id="${id}" data-key="${esc(f.key)}" style="width:100%;padding:6px 8px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);">
+        ${f.options.map((o) => `<option value="${esc(o)}"${o === f.value ? ' selected' : ''}>${esc(o)}</option>`).join('')}
+      </select>`;
+    } else if (f.type === 'boolean') {
+      input = `<label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+        <input type="checkbox" id="${id}" data-key="${esc(f.key)}"${f.value ? ' checked' : ''} style="cursor:pointer;">
+        <span style="font-size:0.85rem;color:var(--text-muted);">${f.value ? 'activado' : 'desactivado'}</span>
+      </label>`;
+    } else if (f.type === 'number') {
+      input = `<input type="number" id="${id}" data-key="${esc(f.key)}" value="${esc(String(f.value))}"${f.min != null ? ` min="${f.min}"` : ''}${f.max != null ? ` max="${f.max}"` : ''} style="width:120px;padding:6px 8px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);">`;
+    }
+    return `
+      <div style="margin-bottom:14px;">
+        <label for="${id}" style="display:block;font-weight:600;color:var(--text);font-size:0.88rem;margin-bottom:4px;">${esc(f.label)}</label>
+        ${input}
+        ${f.help ? `<p style="margin:4px 0 0;font-size:0.75rem;color:var(--text-muted);">${esc(f.help)}</p>` : ''}
+      </div>
+    `;
+  };
+  dlg.innerHTML = `
+    <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;gap:10px;">
+      <span style="font-size:1.2rem;">⚙</span>
+      <span>Configuración de Karajan</span>
+      <span style="margin-left:auto;font-family:var(--font-mono,monospace);font-size:0.75rem;color:var(--text-muted);">${esc(cfg.path || '')}</span>
+    </div>
+    <div style="padding:14px 18px;max-height:65vh;overflow:auto;">
+      ${cfg.fields.map(renderField).join('')}
+      <p style="margin:14px 0 0;font-size:0.75rem;color:var(--text-muted);">
+        Los cambios se guardan en <code>kj.config.yml</code> de forma atómica (con copia de seguridad <code>.bak</code>).
+        El próximo <code>kj run</code> los aplicará — no hace falta reiniciar el board.
+      </p>
+    </div>
+    <div style="padding:12px 18px;border-top:1px solid var(--border);display:flex;gap:8px;justify-content:flex-end;">
+      <button id="config-cancel" style="padding:8px 16px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;">Cancelar</button>
+      <button id="config-save" style="padding:8px 16px;background:var(--color-green);border:none;color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;">Guardar</button>
+    </div>
+  `;
+  if (typeof dlg.showModal === 'function' && !dlg.open) dlg.showModal();
+  dlg.querySelector('#config-cancel')?.addEventListener('click', () => { try { dlg.close(); } catch { /* ignore */ } }, { once: true });
+  dlg.querySelector('#config-save')?.addEventListener('click', async () => {
+    // Build the patch from the form, comparing against initial values
+    // so we only send what changed.
+    const patch = {};
+    for (const f of cfg.fields) {
+      const el = dlg.querySelector(`[data-key="${f.key}"]`);
+      if (!el) continue;
+      let v;
+      if (f.type === 'boolean') v = el.checked;
+      else if (f.type === 'number') v = Number(el.value);
+      else v = el.value;
+      if (v !== f.value) patch[f.key] = v;
+    }
+    if (Object.keys(patch).length === 0) {
+      try { dlg.close(); } catch { /* ignore */ }
+      return;
+    }
+    try {
+      const r = await fetch('/api/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ patch }),
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        const msg = body?.details?.errors?.length
+          ? body.details.errors.join('\n')
+          : (body.error || `HTTP ${r.status}`);
+        await showError(msg, { title: 'No se pudo guardar' });
+        return;
+      }
+      try { dlg.close(); } catch { /* ignore */ }
+    } catch (err) {
+      await showError(err.message || String(err), { title: 'Error guardando configuración' });
+    }
+  }, { once: true });
+}
+
 async function showCommandLauncher() {
   const dlg = ensureDialog();
   // Per-command field schemas — kept in the client because each
@@ -2557,6 +2659,14 @@ document.getElementById('sync-btn').addEventListener('click', async () => {
 // dropping to a terminal. Output streams to the existing log panel.
 document.getElementById('commands-btn').addEventListener('click', () => {
   showCommandLauncher();
+});
+
+// PR5: Settings button — opens the kj.config.yml editor modal.
+// User picks coder/reviewer providers, model strategy, iteration
+// caps, etc. in plain Spanish. Save writes the yml atomically;
+// next `kj run` picks up the new config (no restart needed).
+document.getElementById('config-btn').addEventListener('click', () => {
+  showConfigEditor();
 });
 
 // Restart button — respawn the board server in place. The page's

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -29,6 +29,7 @@
         <option value="">All Projects</option>
       </select>
       <div class="header__controls">
+        <button class="control-btn" id="config-btn" title="Configurar Karajan (modelos, agentes, tope de iteraciones, …)">⚙</button>
         <button class="control-btn" id="commands-btn" title="Launch a Karajan CLI command (kj plan, kj architect, kj clean…)">⚡</button>
         <button class="control-btn" id="restart-btn" title="Restart the HU Board server (preserves URL, the page reconnects automatically)">🔁</button>
         <button class="control-btn" id="sync-btn" title="Re-scan disk for new batches">🔄</button>

--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -1,0 +1,285 @@
+/**
+ * Read / write the global Karajan config (~/.karajan/kj.config.yml)
+ * from the board.
+ *
+ * The board is a Node Express server that the user already has
+ * running, so it's the natural place to expose a "settings" page —
+ * no extra terminal trip, no risk of malformed YAML, plain Spanish
+ * labels for non-technical users.
+ *
+ * Design notes:
+ *
+ * - The yml may contain dozens of fields (legacy, advanced, future
+ *   experiments). The board only EXPOSES + EDITS a small whitelist
+ *   that maps to the labels the UI shows. Everything else is read,
+ *   preserved verbatim, and written back unchanged. So a power
+ *   user editing the file by hand never loses keys when they later
+ *   touch the modal.
+ *
+ * - Writes go through a tmp-file + atomic rename so a partial
+ *   write never leaves the user with a corrupt yml.
+ *
+ * - A `.bak` copy is kept of the previous content so the user can
+ *   recover from a botched save outside the modal (rare but
+ *   irrecoverable otherwise).
+ *
+ * - VITEST aware: when KJ_HOME is set we honour it (every test
+ *   harness uses tmp dirs already). When not set we use
+ *   `~/.karajan/kj.config.yml` like the rest of Karajan does.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, renameSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import yaml from 'js-yaml';
+
+function configPath() {
+  // Same path the parent uses (src/utils/paths.js::getKarajanHome).
+  // We can't import the parent helper from the hu-board package
+  // without inflating the module graph, so we duplicate the small
+  // path-resolution logic here. Keep them in lockstep.
+  if (process.env.KJ_HOME) return join(process.env.KJ_HOME, 'kj.config.yml');
+  return join(homedir(), '.karajan', 'kj.config.yml');
+}
+
+function backupPath() { return `${configPath()}.bak`; }
+
+/**
+ * Whitelist of fields the board's modal exposes. Everything else
+ * stays untouched in the yml. Each entry says where in the yml the
+ * field lives (`path`) and how to render it for the UI (`type`,
+ * `label`, `options` for selects).
+ *
+ * The path is a dotted notation we resolve manually (so we never
+ * need to take a runtime dep on lodash for `_.get`/`_.set`).
+ */
+export const EDITABLE_FIELDS = [
+  {
+    key: 'coder',
+    path: 'coder',
+    type: 'select',
+    label: 'Agente para el rol "coder"',
+    help: 'Quién escribe el código. Claude es el más fiable, Codex es más rápido.',
+    options: ['claude', 'codex', 'gemini', 'aider'],
+    default: 'claude',
+  },
+  {
+    key: 'reviewer',
+    path: 'reviewer',
+    type: 'select',
+    label: 'Agente para el rol "reviewer"',
+    help: 'Quién revisa el código del coder. Conviene que sea un agente distinto al coder para detectar errores.',
+    options: ['claude', 'codex', 'gemini', 'aider'],
+    default: 'codex',
+  },
+  {
+    key: 'modelMode',
+    path: '_modelMode_virtual',
+    type: 'select',
+    label: 'Estrategia de modelos',
+    help: 'Auto = Karajan elige el modelo según la complejidad (haiku/sonnet/opus). Sonnet siempre = barato, ideal para pruebas. Opus siempre = caro, máxima calidad.',
+    options: ['auto', 'sonnet', 'opus'],
+    default: 'auto',
+    // Virtual field: doesn't map 1:1 to a yml key. Translate when
+    // reading + writing (see readConfig + writeConfigPatch).
+  },
+  {
+    key: 'maxIterationMinutes',
+    path: 'session.max_iteration_minutes',
+    type: 'number',
+    label: 'Tope de minutos por iteración',
+    help: 'Si una iteración (coder + reviewer) supera este tiempo, Karajan la corta y Solomon decide qué hacer.',
+    min: 1,
+    max: 120,
+    default: 30,
+  },
+  {
+    key: 'maxTotalMinutes',
+    path: 'session.max_total_minutes',
+    type: 'number',
+    label: 'Tope de minutos total por sesión',
+    help: 'Tope absoluto del wall-clock de la sesión. Si se llega aquí, Karajan para aunque queden HUs.',
+    min: 5,
+    max: 480,
+    default: 120,
+  },
+  {
+    key: 'sonarEnabled',
+    path: 'sonarqube.enabled',
+    type: 'boolean',
+    label: 'Activar análisis SonarQube',
+    help: 'Pasa el código por SonarQube y bloquea si el quality gate falla. Requiere SonarQube corriendo.',
+    default: false,
+  },
+];
+
+const ROLES_FOR_MODEL_MODE = [
+  'planner', 'architect', 'coder', 'reviewer', 'triage',
+  'researcher', 'tester', 'security', 'refactorer', 'impeccable'
+];
+
+function getDeep(obj, path) {
+  if (!obj || !path) return undefined;
+  const parts = path.split('.');
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}
+
+function setDeep(obj, path, value) {
+  const parts = path.split('.');
+  const last = parts.pop();
+  let cur = obj;
+  for (const p of parts) {
+    if (cur[p] == null || typeof cur[p] !== 'object') cur[p] = {};
+    cur = cur[p];
+  }
+  cur[last] = value;
+}
+
+function deleteDeep(obj, path) {
+  const parts = path.split('.');
+  const last = parts.pop();
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return;
+    cur = cur[p];
+  }
+  if (cur && typeof cur === 'object') delete cur[last];
+}
+
+/**
+ * Derive the virtual `modelMode` from the actual yml shape. Looks at
+ * roles.<role>.model: if every editable role pins the same model,
+ * that's the mode. Otherwise "auto" (the default — Karajan's
+ * smart-select picks per role).
+ */
+function deriveModelMode(parsed) {
+  const roles = parsed?.roles;
+  if (!roles || typeof roles !== 'object') return 'auto';
+  const seen = new Set();
+  for (const r of ROLES_FOR_MODEL_MODE) {
+    const m = roles[r]?.model;
+    if (m) seen.add(String(m).toLowerCase());
+  }
+  if (seen.size === 1) {
+    const only = [...seen][0];
+    if (only === 'sonnet' || only === 'opus') return only;
+  }
+  return 'auto';
+}
+
+/**
+ * Apply the virtual `modelMode` back to the yml: 'auto' deletes the
+ * roles.<r>.model overrides; 'sonnet' / 'opus' set them on every
+ * editable role. Other yml keys are left alone.
+ */
+function applyModelMode(parsed, mode) {
+  if (!parsed.roles) parsed.roles = {};
+  if (mode === 'auto') {
+    for (const r of ROLES_FOR_MODEL_MODE) {
+      if (parsed.roles[r]?.model) delete parsed.roles[r].model;
+      if (parsed.roles[r] && Object.keys(parsed.roles[r]).length === 0) delete parsed.roles[r];
+    }
+    if (Object.keys(parsed.roles).length === 0) delete parsed.roles;
+    return;
+  }
+  for (const r of ROLES_FOR_MODEL_MODE) {
+    if (!parsed.roles[r] || typeof parsed.roles[r] !== 'object') parsed.roles[r] = {};
+    parsed.roles[r].model = mode;
+  }
+}
+
+/**
+ * Read the current config + flatten it into the shape the UI wants:
+ *   {
+ *     path: "/abs/path",
+ *     fields: [{ key, label, help, type, options?, value, default }],
+ *     raw: <full parsed yml>          // power-user inspection
+ *   }
+ *
+ * Returns sane defaults when the file doesn't exist yet.
+ */
+export function readConfig() {
+  const p = configPath();
+  let parsed = {};
+  let exists = false;
+  if (existsSync(p)) {
+    try {
+      parsed = yaml.load(readFileSync(p, 'utf8'), { json: true }) || {};
+      exists = true;
+    } catch (err) {
+      throw new Error(`No se pudo parsear ${p}: ${err.message}`);
+    }
+  }
+  const fields = EDITABLE_FIELDS.map((f) => {
+    let value;
+    if (f.key === 'modelMode') value = deriveModelMode(parsed);
+    else value = getDeep(parsed, f.path);
+    if (value === undefined) value = f.default;
+    return { ...f, value };
+  });
+  return { path: p, exists, fields, raw: parsed };
+}
+
+/**
+ * Apply a patch (subset of EDITABLE_FIELDS keys → new values) to the
+ * yml. Validates each field; refuses unknown keys. Writes via tmp +
+ * rename; keeps a .bak.
+ *
+ * @returns {{ path: string, written: boolean, applied: object[], errors: string[] }}
+ */
+export function writeConfigPatch(patch) {
+  if (!patch || typeof patch !== 'object') {
+    return { path: configPath(), written: false, applied: [], errors: ['patch debe ser un objeto'] };
+  }
+  // Read current state (or empty if file doesn't exist yet).
+  const p = configPath();
+  let parsed = {};
+  if (existsSync(p)) {
+    try { parsed = yaml.load(readFileSync(p, 'utf8'), { json: true }) || {}; }
+    catch (err) { return { path: p, written: false, applied: [], errors: [`No se pudo parsear el yml actual: ${err.message}`] }; }
+  }
+  const errors = [];
+  const applied = [];
+  for (const [key, val] of Object.entries(patch)) {
+    const field = EDITABLE_FIELDS.find((f) => f.key === key);
+    if (!field) { errors.push(`Campo desconocido: ${key}`); continue; }
+
+    if (field.type === 'select' && !field.options.includes(val)) {
+      errors.push(`${key}: valor inválido "${val}". Permitidos: ${field.options.join(', ')}`);
+      continue;
+    }
+    if (field.type === 'number') {
+      const n = Number(val);
+      if (!Number.isFinite(n)) { errors.push(`${key}: debe ser un número`); continue; }
+      if (field.min != null && n < field.min) { errors.push(`${key}: mínimo ${field.min}`); continue; }
+      if (field.max != null && n > field.max) { errors.push(`${key}: máximo ${field.max}`); continue; }
+    }
+    if (field.type === 'boolean' && typeof val !== 'boolean') {
+      errors.push(`${key}: debe ser true o false`);
+      continue;
+    }
+
+    if (field.key === 'modelMode') applyModelMode(parsed, val);
+    else setDeep(parsed, field.path, field.type === 'number' ? Number(val) : val);
+    applied.push({ key, value: val });
+  }
+  if (errors.length > 0) return { path: p, written: false, applied, errors };
+
+  // Write atomically: serialize → write to .tmp → rename. Backup the
+  // existing file first so the user can recover.
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (existsSync(p)) { try { copyFileSync(p, backupPath()); } catch { /* best-effort */ } }
+  const dump = yaml.dump(parsed, { lineWidth: 120 });
+  // mkstemp would be nicer but we want to stay in the same dir for
+  // a guaranteed-atomic rename across the same filesystem.
+  const tmpFile = join(dir, `.kj.config.yml.${process.pid}.${Date.now()}.tmp`);
+  writeFileSync(tmpFile, dump, 'utf8');
+  renameSync(tmpFile, p);
+  return { path: p, written: true, applied, errors: [] };
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -21,6 +21,7 @@ import { setHuStatus, setHuFields, markPlanReady, runPlan } from '../plan-mutati
 import { subscribe as subscribeEvents } from '../event-bus.js';
 import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
+import { readConfig, writeConfigPatch } from '../config-yaml.js';
 
 const router = Router();
 
@@ -606,6 +607,39 @@ router.post('/projects/:id/run', (req, res) => {
     }
     const launched = results.filter((r) => r.ok).length;
     res.json({ launched, total: planIds.length, results });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/config — read the editable subset of ~/.karajan/kj.config.yml.
+ * Powers the board's settings modal; non-editable keys in the yml are
+ * left untouched on PUT (see writeConfigPatch's whitelist semantics).
+ */
+router.get('/config', (_req, res) => {
+  try {
+    const data = readConfig();
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * PUT /api/config — apply a patch to the yml. Body is `{ patch: { key: value } }`
+ * with the keys defined in EDITABLE_FIELDS. Unknown keys are 400'd; type
+ * errors are 400'd; validation errors are 400'd. Writes are atomic
+ * (tmp + rename) and a `.bak` is kept of the previous content.
+ */
+router.put('/config', (req, res) => {
+  try {
+    const patch = req.body?.patch;
+    const result = writeConfigPatch(patch);
+    if (!result.written) {
+      return res.status(400).json({ error: 'No se pudo guardar la configuración', details: result });
+    }
+    res.json(result);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/config-yaml.test.js
+++ b/packages/hu-board/tests/config-yaml.test.js
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import yaml from 'js-yaml';
+import { readConfig, writeConfigPatch, EDITABLE_FIELDS } from '../src/config-yaml.js';
+
+let tmpHome;
+let savedKjHome;
+
+beforeEach(() => {
+  tmpHome = join(tmpdir(), `kj-cfg-${process.pid}-${Date.now()}`);
+  mkdirSync(tmpHome, { recursive: true });
+  savedKjHome = process.env.KJ_HOME;
+  process.env.KJ_HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (savedKjHome === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = savedKjHome;
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function writeYml(content) {
+  writeFileSync(join(tmpHome, 'kj.config.yml'), content, 'utf8');
+}
+function readYmlBack() {
+  return yaml.load(readFileSync(join(tmpHome, 'kj.config.yml'), 'utf8'), { json: true });
+}
+
+describe('readConfig', () => {
+  it('returns sensible defaults when the file does not exist yet', () => {
+    const cfg = readConfig();
+    expect(cfg.exists).toBe(false);
+    expect(cfg.fields.length).toBe(EDITABLE_FIELDS.length);
+    const coder = cfg.fields.find(f => f.key === 'coder');
+    expect(coder.value).toBe('claude');     // default
+  });
+
+  it('reads existing values from the yml', () => {
+    writeYml('coder: codex\nreviewer: claude\nsession:\n  max_iteration_minutes: 5\n');
+    const cfg = readConfig();
+    expect(cfg.exists).toBe(true);
+    expect(cfg.fields.find(f => f.key === 'coder').value).toBe('codex');
+    expect(cfg.fields.find(f => f.key === 'reviewer').value).toBe('claude');
+    expect(cfg.fields.find(f => f.key === 'maxIterationMinutes').value).toBe(5);
+  });
+
+  it('derives modelMode=auto when no roles.<r>.model is set', () => {
+    writeYml('coder: claude\n');
+    const cfg = readConfig();
+    expect(cfg.fields.find(f => f.key === 'modelMode').value).toBe('auto');
+  });
+
+  it('derives modelMode=sonnet when every role pins sonnet', () => {
+    writeYml(`coder: claude\nroles:\n  coder: { model: sonnet }\n  reviewer: { model: sonnet }\n  planner: { model: sonnet }\n  architect: { model: sonnet }\n  triage: { model: sonnet }\n  researcher: { model: sonnet }\n  tester: { model: sonnet }\n  security: { model: sonnet }\n  refactorer: { model: sonnet }\n  impeccable: { model: sonnet }\n`);
+    const cfg = readConfig();
+    expect(cfg.fields.find(f => f.key === 'modelMode').value).toBe('sonnet');
+  });
+});
+
+describe('writeConfigPatch', () => {
+  it('writes a fresh yml when the file does not exist', () => {
+    const r = writeConfigPatch({ coder: 'codex', maxIterationMinutes: 10 });
+    expect(r.written).toBe(true);
+    expect(r.errors).toEqual([]);
+    const yml = readYmlBack();
+    expect(yml.coder).toBe('codex');
+    expect(yml.session.max_iteration_minutes).toBe(10);
+  });
+
+  it('preserves unrelated keys (whitelist semantics)', () => {
+    writeYml('coder: claude\nbecaria:\n  enabled: true\n  custom_field: kept\n');
+    const r = writeConfigPatch({ coder: 'codex' });
+    expect(r.written).toBe(true);
+    const yml = readYmlBack();
+    expect(yml.coder).toBe('codex');
+    expect(yml.becaria).toEqual({ enabled: true, custom_field: 'kept' });
+  });
+
+  it('rejects unknown keys', () => {
+    const r = writeConfigPatch({ doesNotExist: 'foo' });
+    expect(r.written).toBe(false);
+    expect(r.errors[0]).toMatch(/Campo desconocido/);
+  });
+
+  it('rejects out-of-range numbers', () => {
+    const r = writeConfigPatch({ maxIterationMinutes: 9999 });
+    expect(r.written).toBe(false);
+    expect(r.errors[0]).toMatch(/máximo/);
+  });
+
+  it('rejects invalid select values', () => {
+    const r = writeConfigPatch({ coder: 'gpt-99' });
+    expect(r.written).toBe(false);
+    expect(r.errors[0]).toMatch(/Permitidos/);
+  });
+
+  it('modelMode=sonnet pins every editable role to sonnet', () => {
+    const r = writeConfigPatch({ modelMode: 'sonnet' });
+    expect(r.written).toBe(true);
+    const yml = readYmlBack();
+    expect(yml.roles.coder.model).toBe('sonnet');
+    expect(yml.roles.reviewer.model).toBe('sonnet');
+    expect(yml.roles.planner.model).toBe('sonnet');
+  });
+
+  it('modelMode=auto removes the role.model overrides without nuking other role keys', () => {
+    writeYml(`coder: claude\nroles:\n  coder: { model: sonnet, provider: claude }\n  reviewer: { model: sonnet }\n`);
+    const r = writeConfigPatch({ modelMode: 'auto' });
+    expect(r.written).toBe(true);
+    const yml = readYmlBack();
+    expect(yml.roles.coder.model).toBeUndefined();
+    expect(yml.roles.coder.provider).toBe('claude');     // preserved
+    // Empty role objects get cleaned up
+    expect(yml.roles.reviewer).toBeUndefined();
+  });
+
+  it('keeps a .bak file when overwriting', () => {
+    writeYml('coder: claude\n');
+    writeConfigPatch({ coder: 'codex' });
+    expect(existsSync(join(tmpHome, 'kj.config.yml.bak'))).toBe(true);
+    expect(readFileSync(join(tmpHome, 'kj.config.yml.bak'), 'utf8')).toMatch(/coder: claude/);
+  });
+
+  it('is atomic (no partial write on validation error)', () => {
+    writeYml('coder: claude\n');
+    const r = writeConfigPatch({ coder: 'codex', doesNotExist: 'foo' });
+    expect(r.written).toBe(false);
+    // Original file untouched.
+    expect(readFileSync(join(tmpHome, 'kj.config.yml'), 'utf8')).toMatch(/coder: claude/);
+  });
+});


### PR DESCRIPTION
## Why

User feedback: \"y desde el board del proyecto, poder configurar ese yml, todas las opciones, mediante un modal. Al tener un server corriendo, podemos lanzar tareas de node que escriban en el yml y cargarlo cuando se lance kj. ¿Es posible no?\"

Yes — the board IS that node server.

## Three pieces

### 1. \`packages/hu-board/src/config-yaml.js\` (new)
- \`readConfig()\` returns the editable subset for the UI plus the full parsed yml.
- \`writeConfigPatch(patch)\` validates → backs up → atomic-rename writes. **Whitelist semantics**: only \`EDITABLE_FIELDS\` keys are touched; unrelated yml keys (\`becaria\`, \`sonarqube.*\`, custom power-user fields) are preserved verbatim.
- Atomic write: tmp file + rename. Backup at \`kj.config.yml.bak\`.

### 2. \`GET\` / \`PUT /api/config\`
- \`GET\` returns \`{ path, exists, fields[], raw }\`.
- \`PUT\` accepts \`{ patch: { key: value } }\` → validates each → writes → returns \`{ written, applied[], errors[] }\`.

### 3. ⚙ button in the header → plain-Spanish modal

Fields exposed (each with help text):
- **Estrategia de modelos**: auto | sonnet | opus (virtual field — toggles \`roles.<role>.model\` under the hood)
- **Coder / Reviewer por defecto**: claude / codex / gemini / aider
- **Tope minutos por iteración** / **total**
- **Activar SonarQube**

Save button only sends what changed. Karajan reads the yml on every \`kj run\` so no restart is needed.

## Test plan

- [x] 13 new cases for \`readConfig\` + \`writeConfigPatch\` (defaults, whitelist preservation, unknown key rejection, range validation, modelMode round-trip, \`.bak\` file, atomic write on error).
- [x] Parent vitest: 3989 / 3989.
- [x] Board vitest: 138 / 138.