### PR TITLE
fix(board): orphan-proof + project name comes from plan.name

### DIFF
--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -212,9 +212,14 @@ function syncSessionFile(filePath) {
     //   1. If a plan / HU batch already created `auto-<sessionId>`, reuse it
     //      so plan-based runs group with their HU batch.
     //   2. Otherwise fall back to the session's declared `project_id`.
-    //   3. Otherwise bucket the session under "default" so orphan runs
-    //      (e.g. `kj run "task"` without HU decomposition) still show up on
-    //      the board instead of disappearing silently. Fix for KJC-BUG-0028.
+    //   3. Otherwise → REJECT. Orphan sessions (no project_id and no batch)
+    //      USED to be promoted to a fake "Orphan sessions" project, which
+    //      violated the user's invariant: "Si se crea proyecto y se crean
+    //      hus se asocian a proyecto. ES IMPOSIBLE QUE [no exista esa
+    //      asociación]". Now we skip them entirely. The fix for the source
+    //      (kj run always stamps project_id derived from cwd) lives in
+    //      PR-F; this is the safety net so a leftover orphan can never
+    //      again appear as a phantom project on the board.
     const autoProjectId = `auto-${sessionId}`;
     const db = getDb();
     const existingBatch = db.prepare('SELECT id FROM projects WHERE id = ?').get(autoProjectId);
@@ -224,7 +229,9 @@ function syncSessionFile(filePath) {
     } else if (data.project_id) {
       projectId = data.project_id;
     } else {
-      projectId = 'default';
+      // Orphan: log + skip. Never promote to "default".
+      console.warn(`[sync] Session ${sessionId} has no project_id and no matching batch — skipping (orphan). File: ${filePath}`);
+      return;
     }
 
     // Ensure the project row exists. Skip when an auto-batch owns it already
@@ -233,7 +240,7 @@ function syncSessionFile(filePath) {
     if (!existingBatch) {
       upsertProject({
         id: projectId,
-        name: projectId === 'default' ? 'Orphan sessions' : projectId,
+        name: projectId,
         last_activity: data.updated_at || data.created_at || new Date().toISOString(),
         total_stories: 0,
       });
@@ -308,14 +315,20 @@ export function syncPlanFile(filePath) {
     const projectId = data.projectDir
       ? deriveProjectIdFromDir(data.projectDir)
       : data.planId;
-    // Human-friendly project name: basename("/…/linux-assistant-orchestrator")
-    // becomes "Linux Assistant Orchestrator". Uses `titleCaseBasename` (not
-    // `slugToTitle`) because the stopwords list there is tuned for free-text
-    // goals and would strip meaningful words like "tool" or "system" from a
-    // directory name. Falls back to the plan's declared name or task.
-    const projectName = data.projectDir
-      ? titleCaseBasename(basename(data.projectDir))
-      : (data.name || slugToTitle(data.task || '') || projectId);
+    // Human-friendly project name resolution order (most-specific first):
+    //   1. plan.name explicitly set by the user / planner ("Linux Assistant
+    //      Orchestrator" — preserved across renames done from the board).
+    //   2. titleCaseBasename(projectDir) — derived from the cwd of the
+    //      original kj plan invocation. NOTE: this is the SUBCARPETA of the
+    //      projectDir, NOT necessarily where the work happens. If the user
+    //      ran `kj plan` from inside `…/karajan-code/packages/hu-board/`
+    //      with a SPEC about "Linux Assistant", the basename here would
+    //      misleadingly say "Hu Board" — that's why plan.name wins.
+    //   3. slugToTitle of the task / projectId as a last resort.
+    const projectName = data.name
+      || (data.projectDir ? titleCaseBasename(basename(data.projectDir)) : null)
+      || slugToTitle(data.task || '')
+      || projectId;
 
     upsertProject({
       id: projectId,

--- a/packages/hu-board/tests/sync-orphan.test.js
+++ b/packages/hu-board/tests/sync-orphan.test.js
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpHome;
+let savedKjHome;
+let savedPlansDir;
+let consoleSpy;
+
+beforeEach(() => {
+  tmpHome = join(tmpdir(), `kj-orphan-${process.pid}-${Date.now()}`);
+  mkdirSync(join(tmpHome, 'sessions'), { recursive: true });
+  mkdirSync(join(tmpHome, 'hu-stories'), { recursive: true });
+  mkdirSync(join(tmpHome, 'plans'), { recursive: true });
+
+  savedKjHome = process.env.KJ_HOME;
+  savedPlansDir = process.env.KJ_PLANS_DIR;
+  process.env.KJ_HOME = tmpHome;
+  process.env.KJ_PLANS_DIR = join(tmpHome, 'plans');
+  consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (savedKjHome === undefined) delete process.env.KJ_HOME; else process.env.KJ_HOME = savedKjHome;
+  if (savedPlansDir === undefined) delete process.env.KJ_PLANS_DIR; else process.env.KJ_PLANS_DIR = savedPlansDir;
+  consoleSpy?.mockRestore();
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('sync.js — orphan-proof (PR-B)', () => {
+  it('skips a session.json without project_id and no matching batch', async () => {
+    const dir = join(tmpHome, 'sessions', 'sess-orphan');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'session.json'), JSON.stringify({
+      id: 'sess-orphan',
+      task: 'whatever',
+      status: 'running',
+      project_id: null,
+    }));
+    const { initDb, getDb } = await import('../src/db.js');
+    initDb();
+    const { fullScan } = await import('../src/sync.js');
+    fullScan();
+    const projects = getDb().prepare('SELECT id FROM projects').all();
+    expect(projects.find(p => p.id === 'default')).toBeUndefined();
+    expect(projects.find(p => p.id === 'sess-orphan')).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(/orphan/i));
+  });
+
+  it('still ingests a session.json when project_id is present', async () => {
+    const dir = join(tmpHome, 'sessions', 'sess-good');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'session.json'), JSON.stringify({
+      id: 'sess-good',
+      task: 'good task',
+      status: 'approved',
+      project_id: 'my-project',
+    }));
+    const { initDb, getDb } = await import('../src/db.js');
+    initDb();
+    const { fullScan } = await import('../src/sync.js');
+    fullScan();
+    const proj = getDb().prepare('SELECT id, name FROM projects WHERE id = ?').get('my-project');
+    expect(proj).toBeDefined();
+    expect(proj.id).toBe('my-project');
+  });
+
+  it('attaches a session to its auto-batch project when the batch session id starts with auto-', async () => {
+    // Pre-create the auto-batch under hu-stories/ so syncStoryFile registers
+    // the project. The session's id matches so syncSessionFile picks it up.
+    const huDir = join(tmpHome, 'hu-stories', 'auto-sess-paired');
+    mkdirSync(huDir, { recursive: true });
+    writeFileSync(join(huDir, 'batch.json'), JSON.stringify({
+      session_id: 'auto-sess-paired',
+      stories: [{ id: 'HU-1', status: 'pending', original: { text: 'hello' } }],
+    }));
+    const sessDir = join(tmpHome, 'sessions', 'auto-sess-paired');
+    mkdirSync(sessDir, { recursive: true });
+    writeFileSync(join(sessDir, 'session.json'), JSON.stringify({
+      id: 'auto-sess-paired', task: 'paired', status: 'running', project_id: null,
+    }));
+    const { initDb, getDb } = await import('../src/db.js');
+    initDb();
+    const { fullScan } = await import('../src/sync.js');
+    fullScan();
+    // The auto-batch project should exist; the orphan-skip logic must NOT
+    // have rejected the session (because the batch project covers it).
+    const projects = getDb().prepare('SELECT id FROM projects').all();
+    expect(projects.find(p => p.id === 'auto-sess-paired')).toBeDefined();
+  });
+});
+
+describe('sync.js — plan name preference (PR-B)', () => {
+  it('prefers plan.name over titleCaseBasename(projectDir)', async () => {
+    const projDir = join(tmpHome, 'plans', 'home_user_misleading-folder');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, 'plan-A.json'), JSON.stringify({
+      planId: 'plan-A',
+      version: 2,
+      name: 'My Real Project Name',
+      projectDir: '/home/user/misleading-folder',
+      task: 'do stuff',
+      status: 'draft',
+      hus: [{ id: 'hu_plan-A_001', title: 'h1', status: 'pending' }],
+    }));
+    const { initDb, getDb } = await import('../src/db.js');
+    initDb();
+    const { fullScan } = await import('../src/sync.js');
+    fullScan();
+    const proj = getDb().prepare("SELECT name FROM projects WHERE id = 'home_user_misleading-folder'").get();
+    expect(proj.name).toBe('My Real Project Name');
+  });
+
+  it('falls back to titleCaseBasename when plan.name is missing', async () => {
+    const projDir = join(tmpHome, 'plans', 'home_user_some-tool');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, 'plan-B.json'), JSON.stringify({
+      planId: 'plan-B',
+      version: 2,
+      projectDir: '/home/user/some-tool',
+      task: 'do stuff',
+      status: 'draft',
+      hus: [{ id: 'hu_plan-B_001', title: 'h1', status: 'pending' }],
+    }));
+    const { initDb, getDb } = await import('../src/db.js');
+    initDb();
+    const { fullScan } = await import('../src/sync.js');
+    fullScan();
+    const proj = getDb().prepare("SELECT name FROM projects WHERE id = 'home_user_some-tool'").get();
+    expect(proj.name).toBe('Some Tool');
+  });
+});

--- a/packages/hu-board/tests/sync.test.js
+++ b/packages/hu-board/tests/sync.test.js
@@ -194,7 +194,13 @@ describe('syncSessionFile via fullScan', () => {
     expect(() => sync.fullScan()).not.toThrow();
   });
 
-  it('defaults project_id to "default" when missing from session data', async () => {
+  it('rejects (does not ingest) sessions without project_id and no matching batch', async () => {
+    // PR-B (orphan-proof): the previous behaviour was to promote orphan
+    // sessions to a fake "default" / "Orphan sessions" project. The user
+    // declared that invariant unacceptable: "ES IMPOSIBLE QUE OCURRA. Si
+    // se crea proyecto y se crean hus se asocian a proyecto". sync.js now
+    // skips orphan session.json files entirely; the "default" project
+    // never appears.
     const { db, sync } = await setup();
 
     const sessionDir = join(tmpDir, 'sessions', 'sess-noproject');
@@ -211,9 +217,12 @@ describe('syncSessionFile via fullScan', () => {
 
     sync.fullScan();
 
+    // The orphan session must NOT have created a "default" project.
+    const allProjects = db.getProjects();
+    expect(allProjects.find((p) => p.id === 'default')).toBeUndefined();
+
+    // And the session itself must not have been ingested anywhere.
     const sessions = db.getSessionsByProject('default');
-    const found = sessions.find((s) => s.id === 'sess-noproject');
-    expect(found).toBeTruthy();
-    expect(found.project_id).toBe('default');
+    expect(sessions.find((s) => s.id === 'sess-noproject')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

Two coupled bugs reported during dogfood:

### 1. Phantom \"Orphan sessions\" project keeps reappearing

User: \"ES IMPOSIBLE QUE OCURRA. Si se crea proyecto y se crean hus se asocian a proyecto. Si se borra proyecto se borran hus.\"

Previous behaviour: a \`session.json\` without \`project_id\` (and without a matching auto-batch) was promoted to a fake \"default\" / \"Orphan sessions\" project. Invariant violated.

**Fix**: \`syncSessionFile\` skips such sessions entirely (logs warning, no DB write). The source of orphan sessions (\`kj run\` not stamping \`project_id\` from cwd) is fixed in PR-F; this is the safety net.

### 2. Project name derived from basename instead of plan.name

User ran \`kj plan generate\` from inside the \`hu-board\` subfolder with a Linux Assistant SPEC. The plan stamped \`projectDir\` to that subfolder. The board derived the project name from \`titleCaseBasename(projectDir)\` → \"Hu Board\", which had nothing to do with the actual content.

**Fix**: new resolution order is \`plan.name → titleCaseBasename(projectDir) → slugToTitle(task) → projectId\`. \`plan.name\` wins so renames done from the board (writing \`plan.name\`) survive across syncs.

## Test plan

- [x] 5 new cases in \`sync-orphan.test.js\` (orphan rejection, ingestion when project_id present, auto-batch attach, plan.name wins, basename fallback).
- [x] Legacy test asserting \"default\" promotion rewritten to assert new rejection behaviour.
- [x] Parent vitest: 3998 / 3998.
- [x] Board vitest: 155 / 155.