### PR TITLE
fix(board): project selector marks the active project, not 'All projects'

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -2510,14 +2510,34 @@ async function populateProjectSelect() {
   try {
     const projects = await api('/api/projects');
     const select = document.getElementById('project-select');
-    // Keep the "All Projects" option
-    select.innerHTML = '<option value="">All Projects</option>';
+    // Which project should appear pre-selected? Order:
+    //   1. scopedProjectSlug (URL is /p/<slug>)  — locked, never changes
+    //   2. selectedProject (route state, ej. #board/<slug>)
+    //   3. ""                                    — "All Projects"
+    // PR-D: the previous version cleared innerHTML and never marked
+    // any option as selected, so the dropdown showed "All Projects"
+    // even when scoped to one. handleRoute() set .value separately
+    // BUT the value was lost in the race because the matching option
+    // didn't exist yet when handleRoute ran. Setting .selected on
+    // the option directly avoids the race.
+    const desired = scopedProjectSlug || selectedProject || '';
+    select.innerHTML = '';
+    const all = document.createElement('option');
+    all.value = '';
+    all.textContent = 'All Projects';
+    if (desired === '') all.selected = true;
+    select.appendChild(all);
     for (const p of projects) {
       const opt = document.createElement('option');
       opt.value = p.id;
       opt.textContent = p.name || p.id;
+      if (p.id === desired) opt.selected = true;
       select.appendChild(opt);
     }
+    // Final guard: if `desired` did not match any rendered option
+    // (project not on the board yet), still set the value so
+    // handleRoute's expectation holds.
+    if (desired) select.value = desired;
   } catch {
     // Silently fail — project list will be empty
   }


### PR DESCRIPTION
## Why

User reported: "no muestra el proyecto actual seleccionado. Se muestra Hu Board, pero no está seleccionado."

## Root cause

`populateProjectSelect` cleared `innerHTML` and never marked any `<option>` as selected. `handleRoute` set `select.value = ...` but the matching option was created asynchronously inside populate; on boot the timing race left the dropdown showing "All Projects" even when scoped to one project.

## Fix

`populateProjectSelect` now reads `scopedProjectSlug + selectedProject` itself and applies `option.selected = true` to the matching `<option>` during construction. A final `select.value = desired` guards the case where the desired project isn't on the board yet.

## Test plan

- [x] Board vitest: 150 / 150 (no behaviour-test added — pure DOM UI).
- [ ] Manual: open `/p/<slug>` — header dropdown shows that slug as selected.