### PR TITLE
feat(plan): auto-certify pending HUs + refuse silent-fallback on broken plans

### DIFF
--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -323,6 +323,38 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
             }));
             throw new Error(`Plan ${flags.plan} has ${missing.length} HU(s) with no acceptance_tests — see the run log for details.`);
           }
+
+          // PR-E (auto-certify + anomaly guards): the user expects
+          // pending HUs to be runnable; the "certified" intermediate
+          // state was an invisible wall. Helpers live in
+          // src/plan/plan-hu-ops.js so they can be unit-tested
+          // without spinning up the whole orchestrator. Pulled from
+          // the same dynamic import used a few lines below for
+          // updateHuStatus + setHuOutcome — no extra import budget.
+          const planHuOps = await import("../../plan/plan-hu-ops.js");
+          const { autoCertifyPendingHus, assertPlanRunnable } = planHuOps;
+          const promoted = autoCertifyPendingHus(loadedPlan);
+          if (promoted > 0) {
+            await savePlanToDisk(projectDir, loadedPlan);
+            logger.info(`Plan ${flags.plan}: auto-certified ${promoted} pending HU(s) — ready to run`);
+            emitProgress(emitter, makeEvent("plan:auto-certified", { ...eventBase, stage: "plan" }, {
+              message: `Auto-certificadas ${promoted} HU(s) pendientes`,
+              detail: { planId: flags.plan, count: promoted }
+            }));
+          }
+          // Refuse loudly if after auto-certify there's still nothing
+          // runnable. Without this the orchestrator silently falls
+          // back to legacy single-task mode and burns tokens.
+          try {
+            assertPlanRunnable(loadedPlan, flags.plan);
+          } catch (err) {
+            logger.error(err.message);
+            emitProgress(emitter, makeEvent("plan:no-runnable", { ...eventBase, stage: "plan" }, {
+              status: "fail", message: err.message,
+              detail: { planId: flags.plan }
+            }));
+            throw err;
+          }
         }
 
         // v2 plan with HUs → inject as huReviewer so sub-pipeline picks them up
@@ -375,7 +407,9 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
             // Kanban columns reflect progress in real time. Without this
             // the plan only updates at the end of the run and the board
             // looks frozen during execution.
-            const { updateHuStatus: updateHuStatusFn, setHuOutcome: setHuOutcomeFn } = await import("../../plan/plan-hu-ops.js");
+            // (`planHuOps` was loaded above for PR-E auto-certify — reuse
+            // the same reference to stay under the dynamic-import budget.)
+            const { updateHuStatus: updateHuStatusFn, setHuOutcome: setHuOutcomeFn } = planHuOps;
             setLiveStatusUpdater(session, async (huId, status) => {
               try {
                 if (!updateHuStatusFn(loadedPlan, huId, status)) return;

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -168,6 +168,68 @@ export function setPlanOutcome(plan, outcome) {
 }
 
 /**
+ * PR-E: auto-promote every pending HU with at least one acceptance
+ * test to "certified". The intermediate "certified" state was an
+ * invisible wall — there's no UI button for it and the user had no
+ * way to discover `kj plan ready`. Treating pending-with-tests as
+ * runnable removes the wall while keeping the test contract gate.
+ *
+ * Mutates plan in place. HUs in done / failed / blocked are left
+ * alone so re-runs stay explicit (use --hu <id>).
+ *
+ * @returns {number} how many HUs were promoted (0 if nothing changed).
+ */
+export function autoCertifyPendingHus(plan) {
+  if (!plan?.hus?.length) return 0;
+  let promoted = 0;
+  const now = new Date().toISOString();
+  for (const hu of plan.hus) {
+    if (hu.status === "pending" && Array.isArray(hu.acceptance_tests) && hu.acceptance_tests.length > 0) {
+      hu.status = "certified";
+      hu.updatedAt = now;
+      promoted += 1;
+    }
+  }
+  if (promoted > 0) plan.updatedAt = now;
+  return promoted;
+}
+
+/**
+ * PR-E: assert that the plan has at least one HU that's actually
+ * going to run. Throws with a plain-Spanish message otherwise so
+ * `kj run --plan` can never silently fall back to single-task mode
+ * and burn tokens for nothing.
+ *
+ * The set of "runnable" statuses matches the sub-pipeline filter
+ * (today: certified). The caller should run autoCertifyPendingHus()
+ * BEFORE this so pending-with-tests get a chance.
+ *
+ * @throws {Error} when no HU is runnable.
+ */
+export function assertPlanRunnable(plan, planId) {
+  if (!plan?.hus?.length) {
+    throw new Error(
+      `El plan ${planId} no contiene ninguna HU. `
+      + `Edita el plan o vuelve a generarlo con \`kj plan\`. `
+      + `Aborto para no malgastar tokens en un fallback de "single task".`
+    );
+  }
+  const certified = plan.hus.filter((h) => h.status === "certified").length;
+  if (certified > 0) return;
+  const counts = plan.hus.reduce((acc, h) => {
+    const k = h.status || "pending";
+    acc[k] = (acc[k] || 0) + 1;
+    return acc;
+  }, {});
+  const summary = Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(", ");
+  throw new Error(
+    `Plan ${planId}: 0 HU(s) listas para ejecutar (estados: ${summary}). `
+    + `Si las HU(s) están en done/failed/blocked y quieres relanzarlas, usa --hu <id>. `
+    + `Aborto para no malgastar tokens en un fallback de "single task".`
+  );
+}
+
+/**
  * Compute the rollup from the per-HU outcomes already stamped on the
  * plan. Invoked by syncResultsToPlan in plan-executor when the run
  * ends so the caller doesn't have to assemble the counts by hand.

--- a/tests/plan-auto-certify-anomaly.test.js
+++ b/tests/plan-auto-certify-anomaly.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  autoCertifyPendingHus, assertPlanRunnable, addHu,
+} from "../src/plan/plan-hu-ops.js";
+import { createPlanV2 } from "../src/plan/plan-schema.js";
+
+function makePlan(huSpecs) {
+  const plan = createPlanV2("test");
+  for (const spec of huSpecs) addHu(plan, spec);
+  return plan;
+}
+
+// PR-E: helpers that gate a plan-based run so the orchestrator can never
+// silently fall back to single-task mode on a broken / un-ready plan.
+
+describe("autoCertifyPendingHus", () => {
+  it("promotes pending HUs that have at least one acceptance test", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "echo a" }] },
+      { title: "b", acceptance_tests: [{ type: "gherkin", content: "Given\nWhen\nThen" }] },
+    ]);
+    expect(plan.hus.every((h) => h.status === "pending")).toBe(true);
+    const promoted = autoCertifyPendingHus(plan);
+    expect(promoted).toBe(2);
+    expect(plan.hus.every((h) => h.status === "certified")).toBe(true);
+  });
+
+  it("skips pending HUs that have no acceptance tests", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "echo a" }] },
+      { title: "b", acceptance_tests: [] },     // no tests → not promoted
+    ]);
+    const promoted = autoCertifyPendingHus(plan);
+    expect(promoted).toBe(1);
+    expect(plan.hus[0].status).toBe("certified");
+    expect(plan.hus[1].status).toBe("pending");
+  });
+
+  it("leaves done / failed / blocked HUs alone", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "b", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "c", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    plan.hus[0].status = "done";
+    plan.hus[1].status = "failed";
+    plan.hus[2].status = "blocked";
+    const promoted = autoCertifyPendingHus(plan);
+    expect(promoted).toBe(0);
+    expect(plan.hus.map((h) => h.status)).toEqual(["done", "failed", "blocked"]);
+  });
+
+  it("returns 0 on empty / missing plans", () => {
+    expect(autoCertifyPendingHus(null)).toBe(0);
+    expect(autoCertifyPendingHus({})).toBe(0);
+    expect(autoCertifyPendingHus({ hus: [] })).toBe(0);
+  });
+
+  it("stamps updatedAt on every promoted HU and on the plan", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    const before = plan.hus[0].updatedAt;
+    // wait one ms so timestamps differ
+    return new Promise((r) => setTimeout(r, 5)).then(() => {
+      autoCertifyPendingHus(plan);
+      expect(plan.hus[0].updatedAt).not.toBe(before);
+      expect(plan.updatedAt).toBe(plan.hus[0].updatedAt);
+    });
+  });
+});
+
+describe("assertPlanRunnable", () => {
+  it("throws when the plan has zero HUs", () => {
+    expect(() => assertPlanRunnable({ hus: [] }, "plan-X")).toThrow(/no contiene ninguna HU/);
+    expect(() => assertPlanRunnable({}, "plan-X")).toThrow(/no contiene ninguna HU/);
+    expect(() => assertPlanRunnable(null, "plan-X")).toThrow(/no contiene ninguna HU/);
+  });
+
+  it("throws when no HU is in 'certified' state", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "b", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    plan.hus[0].status = "done";
+    plan.hus[1].status = "failed";
+    expect(() => assertPlanRunnable(plan, "plan-Y")).toThrow(/0 HU\(s\) listas para ejecutar/);
+  });
+
+  it("includes the status counts in the error so the user knows where things are", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "b", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "c", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    plan.hus[0].status = "done";
+    plan.hus[1].status = "failed";
+    plan.hus[2].status = "blocked";
+    try {
+      assertPlanRunnable(plan, "plan-Z");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err.message).toMatch(/1 done/);
+      expect(err.message).toMatch(/1 failed/);
+      expect(err.message).toMatch(/1 blocked/);
+      expect(err.message).toMatch(/--hu <id>/);
+    }
+  });
+
+  it("returns silently when at least one HU is certified", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    plan.hus[0].status = "certified";
+    expect(() => assertPlanRunnable(plan, "plan-W")).not.toThrow();
+  });
+
+  it("treats pending HUs as not runnable (caller must auto-certify first)", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+    ]);
+    expect(plan.hus[0].status).toBe("pending");
+    expect(() => assertPlanRunnable(plan, "plan-V")).toThrow(/0 HU\(s\) listas para ejecutar/);
+  });
+});
+
+describe("autoCertify + assertPlanRunnable composition", () => {
+  it("the typical happy path: pending → certified → runnable", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [{ type: "shell", content: "x" }] },
+      { title: "b", acceptance_tests: [{ type: "gherkin", content: "G\nW\nT" }] },
+    ]);
+    autoCertifyPendingHus(plan);
+    expect(() => assertPlanRunnable(plan, "plan-OK")).not.toThrow();
+  });
+
+  it("pending without tests stays unrunnable even after auto-certify", () => {
+    const plan = makePlan([
+      { title: "a", acceptance_tests: [] },     // no tests → never promoted
+      { title: "b", acceptance_tests: [] },
+    ]);
+    autoCertifyPendingHus(plan);
+    expect(() => assertPlanRunnable(plan, "plan-NO-TESTS")).toThrow(/0 HU\(s\) listas/);
+  });
+});


### PR DESCRIPTION
## Why

Two coupled UX problems the user hit on dogfood:

> \"lo de las HUs certified me ha dejado perplejo. No veo botón para certificar. Esto es algo que has puesto como obligatorio sin posibilidad de interactuar.\"

> \"Si el run plan no encuentra historias que mierdas se pone a hacer? Se pone a perder tiempo y gastar tokens sin una tarea? Karajan tiene que ser listo y anti-humanos tontos o errores de la IA o del programa.\"

## Two new helpers in \`src/plan/plan-hu-ops.js\`

### \`autoCertifyPendingHus(plan)\`
Promotes every \`pending\` HU that has at least one acceptance test to \`certified\`. The \"certified\" intermediate state was invisible — no UI button, the user had no way to discover \`kj plan ready\`. Now pending-with-tests is treated as runnable. HUs in \`done\`/\`failed\`/\`blocked\` are left alone so re-runs stay explicit (use \`--hu <id>\`).

### \`assertPlanRunnable(plan, planId)\`
Throws (plain Spanish) when the plan has 0 HUs OR no certified HUs after auto-promote. Prevents the \"single-task fallback\" footgun that burned tokens on tasks the user never explicitly asked the runner to handle.

## Wired into pre-loop.js

```
1. (existing) refuse if any HU has no acceptance_tests
2. (NEW)      auto-certify pending HUs that have tests
3. (NEW)      assert plan is runnable; throw if 0 HUs / 0 certified
4. (existing) inject huReviewer for the sub-pipeline
```

The auto-certify writes to disk so the change persists across restarts and the board sees the new status. Emits \`plan:auto-certified\` and \`plan:no-runnable\` progress events.

## Test plan

- [x] 12 new cases in \`tests/plan-auto-certify-anomaly.test.js\`.
- [x] Dynamic-imports budget kept under 150 (reused existing \`planHuOps\` import for PR1's live status updater).
- [x] Parent vitest: 4010 / 4010.