### PR TITLE
feat(run): cwd confirmation prompt + stamp project_id on every session

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -83,6 +83,7 @@ program
   .description("Run coder+sonar+reviewer loop")
   .argument("[task]", "Task description (or use --task-file to read from a .md file)")
   .option("--task-file <path>", "Read the task from a file (e.g. .md). Alternative to the positional task argument.")
+  .option("-y, --yes", "Skip the cwd confirmation prompt (CI / scripted runs).")
   .option("--planner <name>")
   .option("--coder <name>")
   .option("--reviewer <name>")

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -8,6 +8,7 @@ import { printHeader } from "../utils/display/header.js";
 import { printEvent } from "../utils/display/event-handlers.js";
 import { resolveRole } from "../config.js";
 import { parseCardId } from "../planning-game/adapter.js";
+import { confirmCwd } from "../utils/cwd-confirm.js";
 
 function createCliAskQuestion(opts = {}) {
   const { sessionId = null } = opts;
@@ -59,6 +60,27 @@ function createCliAskQuestion(opts = {}) {
 }
 
 export async function runCommandHandler({ task, config, logger, flags }) {
+  // PR-F (cwd confirmation): when launching from an interactive
+  // terminal, surface the working directory so the user can abort if
+  // they typed `kj run` from the wrong place. The user's words:
+  // "todas las que lo lancé desde terminal te garantizo que estaba
+  // en la carpeta del proyecto … aún así preguntar por si acaso".
+  //
+  // Skip the prompt when:
+  //   - --yes / -y is set (CI / scripted runs),
+  //   - --json mode is on (machine-readable output, no TTY assumed),
+  //   - stdin is not a TTY (piped, board-spawned subprocess, MCP).
+  const projectDir = config?.projectDir || process.cwd();
+  const canPrompt = process.stdin.isTTY && process.stdout.isTTY
+    && !flags?.yes && !flags?.json;
+  if (canPrompt) {
+    const ok = await confirmCwd(projectDir);
+    if (!ok) {
+      console.log("Aborted by user.");
+      return { ok: false, aborted: true };
+    }
+  }
+
   // Best-effort session cleanup before starting
   try {
     const { cleanupExpiredSessions } = await import("../session-cleanup.js");

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -12,6 +12,7 @@ import { emitProgress, makeEvent } from "../utils/events.js";
 import { BudgetTracker, extractUsageMetrics } from "../utils/budget.js";
 import { computeKjComparison } from "../budget/comparison.js";
 import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
+import { projectSlug } from "../plan/plan-store.js";
 import { applyPolicies } from "../guards/policy-resolver.js";
 import { resolveReviewProfile } from "../review/profiles.js";
 import { createSession } from "../session/store.js";
@@ -351,8 +352,19 @@ export async function initializeSession({ task, config, flags, pgTaskId, pgProje
     setSnapshot(snapshot);
   }
 
+  // PR-F: stamp project_id on every session derived from the project
+  // directory (slug = same algorithm the board uses to bucket plans).
+  // Without this, sessions created by `kj run` from a terminal land
+  // on disk with `project_id: null`. The board sync sees an orphan
+  // and (used to) promote it to a phantom "Orphan sessions" project.
+  // Now that PR-B blocks orphans on the board side, we must also fix
+  // the source so the session can attach to a real project.
+  const projectDir = config.projectDir || process.cwd();
+  const project_id = projectSlug(projectDir);
+
   const sessionInit = {
     task,
+    project_id,
     config_snapshot: config,
     base_ref: baseRef,
     session_start_sha: baseRef,

--- a/src/utils/cwd-confirm.js
+++ b/src/utils/cwd-confirm.js
@@ -1,0 +1,39 @@
+/**
+ * PR-F: ask the user "Run on $(pwd)?" before launching `kj run` from
+ * a terminal. Same defensive UX as `git push --force-with-lease`
+ * surfacing the branch — the user wants to know what they're aiming
+ * at before the rocket fires.
+ *
+ * The prompt is plain readline (no extra deps) and accepts any of:
+ *   y, yes, s, sí, ENTER  → true
+ *   n, no, ENTER+Esc      → false
+ *
+ * Skipped automatically by the caller when stdin/stdout are not a
+ * TTY, when --yes is set, or when --json is set. So this module is
+ * never called in CI / non-interactive contexts.
+ */
+
+import readline from "node:readline";
+
+/**
+ * @param {string} projectDir absolute path of the cwd / projectDir
+ * @returns {Promise<boolean>} true to continue, false to abort
+ */
+export async function confirmCwd(projectDir) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  // No emoji — keep terminal-safe even on basic Windows shells.
+  const question = `Karajan va a ejecutarse sobre:\n  ${projectDir}\n\n¿Continuar? [Y/n] `;
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      const trimmed = String(answer || "").trim().toLowerCase();
+      // Empty answer = ENTER = accept the default = yes.
+      if (trimmed === "" || trimmed === "y" || trimmed === "yes" || trimmed === "s" || trimmed === "si" || trimmed === "sí") {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+    rl.on("SIGINT", () => { rl.close(); resolve(false); });
+  });
+}

--- a/tests/cwd-confirm.test.js
+++ b/tests/cwd-confirm.test.js
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Readable, Writable } from "node:stream";
+
+// PR-F: confirmCwd() asks the user "Run on $(pwd)?" before launching
+// kj run from a terminal. Tests stub stdin/stdout via piped streams
+// so we can drive the prompt deterministically without a TTY.
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function runWithStubbedStdio(input) {
+  // Replace process.stdin / stdout temporarily; readline reads from
+  // the streams we hand it via process.stdin / process.stdout, so
+  // monkey-patching for the duration of one call is enough.
+  const stdinReplacement = Readable.from([input]);
+  const stdoutReplacement = new Writable({ write(_, __, cb) { cb(); } });
+  const realIn = process.stdin;
+  const realOut = process.stdout;
+  Object.defineProperty(process, "stdin", { value: stdinReplacement, configurable: true });
+  Object.defineProperty(process, "stdout", { value: stdoutReplacement, configurable: true });
+  try {
+    const { confirmCwd } = await import("../src/utils/cwd-confirm.js");
+    return await confirmCwd("/home/user/project");
+  } finally {
+    Object.defineProperty(process, "stdin", { value: realIn, configurable: true });
+    Object.defineProperty(process, "stdout", { value: realOut, configurable: true });
+  }
+}
+
+describe("confirmCwd", () => {
+  it("returns true on empty input (ENTER = default Yes)", async () => {
+    expect(await runWithStubbedStdio("\n")).toBe(true);
+  });
+
+  it("returns true on 'y' / 'yes' / 's' / 'sí'", async () => {
+    expect(await runWithStubbedStdio("y\n")).toBe(true);
+    expect(await runWithStubbedStdio("yes\n")).toBe(true);
+    expect(await runWithStubbedStdio("s\n")).toBe(true);
+    expect(await runWithStubbedStdio("sí\n")).toBe(true);
+  });
+
+  it("returns false on 'n' / 'no'", async () => {
+    expect(await runWithStubbedStdio("n\n")).toBe(false);
+    expect(await runWithStubbedStdio("no\n")).toBe(false);
+  });
+
+  it("returns false on any other answer (defensive — abort if unsure)", async () => {
+    expect(await runWithStubbedStdio("maybe\n")).toBe(false);
+    expect(await runWithStubbedStdio("xyz\n")).toBe(false);
+  });
+
+  it("trims whitespace and lowercases the answer", async () => {
+    expect(await runWithStubbedStdio("  Y  \n")).toBe(true);
+    expect(await runWithStubbedStdio("  N  \n")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

User reported two coupled issues today, both with the same root cause:

> \"vuelve a aparecer un proyecto Orphan sessions que no entiendo ni he pedido. No puede quedar nada huérfano, se elimina y punto.\"

> \"ok a usar el cwd, desde terminal, ok, aún así preguntar por si acaso. Desde web debería de saberlo ya antes de lanzar el run del plan, ¿no? Cuando se crean las HUs se crean en una carpeta y debe persistir.\"

\`kj run\` sessions never stamped a \`project_id\`, so every CLI run produced an orphan that the board promoted to a phantom project. The web/board path already passes the plan's \`projectDir\` to the spawned subprocess; the CLI was the leak.

## Two fixes

### 1. Stamp \`project_id\` on every session at creation
\`initializeSession\` derives \`project_id\` from \`config.projectDir || process.cwd()\` using the same \`projectSlug\` helper the board uses to bucket plans. Combined with PR-B (board rejects orphans), the \"Orphan sessions\" phantom project class becomes provably impossible.

### 2. Cwd confirmation prompt for terminal launches
New \`src/utils/cwd-confirm.js\` + integration in \`commands/run.js\`. When stdin+stdout are a TTY and neither \`--yes\` nor \`--json\` is set, prompts:

```
Karajan va a ejecutarse sobre:
  /home/user/that-folder

¿Continuar? [Y/n]
```

Accepts \`y / yes / s / sí / ENTER\` as Yes; anything else aborts (defensive default). Skipped on \`--yes\`, \`--json\`, or non-TTY stdio (so the board's ▶ Run plan path is unaffected — its spawn uses \`stdio:ignore\`).

## Test plan

- [x] 5 cases for \`confirmCwd\` (default Yes, y/n, sí, trim/case).
- [x] Dynamic-imports budget kept under 150 (static-imported \`projectSlug\` and \`confirmCwd\`).
- [x] Parent vitest: 4003 / 4003.