### PR TITLE
feat(board): rename project from the header pencil button

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -419,6 +419,12 @@ async function renderBoard() {
     app.innerHTML = `
       <div class="section-header">
         <span class="section-header__title" title="${selectedProject ? esc(selectedProject) : ''}">Story Board${selectedProject ? ` - ${esc(projectDisplayName)}` : ''}</span>
+        ${selectedProject ? `
+          <button class="control-btn project-rename-btn"
+                  style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-size:0.9rem;padding:2px 6px;"
+                  title="Renombrar este proyecto"
+                  onclick="event.stopPropagation(); window.renameProjectModal('${esc(selectedProject)}', '${esc(projectDisplayName.replace(/'/g, '&#39;'))}');">✎</button>
+        ` : ''}
         <span class="section-header__count">${stories.length} stories</span>
         ${isRunning ? `
           <span class="section-header__badge"
@@ -1263,6 +1269,74 @@ window.runSingleHuFromCard = async function runSingleHuFromCard(huId, title) {
  * Exposed on `window` because it's invoked from the inline onclick
  * attribute renderOutcomeChip writes.
  */
+/**
+ * PR-G: rename a project from the header ✎ button. Opens a small
+ * dialog with the current name pre-filled, validates length, PUTs
+ * to /api/projects/:id/name, and re-renders the board so the new
+ * name shows up everywhere (header, dropdown, picker).
+ *
+ * Exposed on `window` because the inline onclick attribute on the
+ * pencil button calls it.
+ */
+window.renameProjectModal = function renameProjectModal(projectId, currentName) {
+  const dlg = document.getElementById('app-dialog') || ensureDialog();
+  const safeCurrent = String(currentName || '').replace(/&#39;/g, "'");
+  dlg.innerHTML = `
+    <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;gap:10px;">
+      <span style="font-size:1.1rem;">✎</span>
+      <span>Renombrar proyecto</span>
+    </div>
+    <div style="padding:14px 18px;">
+      <label for="rename-input" style="display:block;font-size:0.85rem;color:var(--text);margin-bottom:6px;">
+        Nombre del proyecto
+      </label>
+      <input type="text" id="rename-input" value="${esc(safeCurrent)}" maxlength="120"
+             style="width:100%;padding:8px 10px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);font-size:0.95rem;" />
+      <p style="margin:8px 0 0;font-size:0.75rem;color:var(--text-muted);">
+        Se actualizará el campo <code>name</code> en cada plan JSON de este proyecto y la fila en la base de datos del board.
+      </p>
+      <p id="rename-error" style="margin:8px 0 0;font-size:0.78rem;color:var(--color-red,#ef4444);display:none;"></p>
+    </div>
+    <div style="padding:12px 18px;border-top:1px solid var(--border);display:flex;gap:8px;justify-content:flex-end;">
+      <button id="rename-cancel" style="padding:8px 16px;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;">Cancelar</button>
+      <button id="rename-save"   style="padding:8px 16px;background:var(--color-green);border:none;color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;">Guardar</button>
+    </div>
+  `;
+  if (typeof dlg.showModal === 'function' && !dlg.open) dlg.showModal();
+  const input = dlg.querySelector('#rename-input');
+  const errorEl = dlg.querySelector('#rename-error');
+  input?.focus();
+  input?.select();
+  dlg.querySelector('#rename-cancel')?.addEventListener('click', () => { try { dlg.close(); } catch { /* ignore */ } }, { once: true });
+  dlg.querySelector('#rename-save')?.addEventListener('click', async () => {
+    const newName = input?.value?.trim() || '';
+    if (!newName) { errorEl.style.display = 'block'; errorEl.textContent = 'El nombre no puede estar vacío.'; return; }
+    if (newName === safeCurrent) { try { dlg.close(); } catch { /* ignore */ } return; }
+    try {
+      const r = await fetch(`/api/projects/${encodeURIComponent(projectId)}/name`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}));
+        errorEl.style.display = 'block';
+        errorEl.textContent = body?.error || `HTTP ${r.status}`;
+        return;
+      }
+      // Update the cached display name + refresh the board so the
+      // header, dropdown and project picker all show the new value.
+      projectNameCache[projectId] = newName;
+      try { dlg.close(); } catch { /* ignore */ }
+      await populateProjectSelect();
+      await renderBoard();
+    } catch (err) {
+      errorEl.style.display = 'block';
+      errorEl.textContent = err.message || String(err);
+    }
+  }, { once: true });
+};
+
 window.showOutcomeModal = function showOutcomeModal(escapedJson) {
   let outcome;
   try { outcome = JSON.parse(String(escapedJson).replace(/&#39;/g, "'")); }

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -21,6 +21,7 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { updateHuStatus, certifyAllHus, updateHu } from '../../../src/plan/plan-hu-ops.js';
 import { syncPlanFile } from './sync.js';
+import { getDb } from './db.js';
 
 // Repo root → so we can spawn `node <repo>/src/cli.js run ...` without
 // depending on `kj` being in $PATH of the board process.
@@ -166,6 +167,65 @@ export function setHuFields({ planId, huId, patch, projectId }) {
  * @param {string} [args.projectId]
  * @returns {{ ok: true, count: number, planStatus: string } | { ok: false, error: string }}
  */
+/**
+ * PR-G: rename a project from the board.
+ *
+ * "Project" on the board is just a row in the projects table that
+ * groups stories. The source of truth for the human-readable name
+ * is `plan.name` inside each plan JSON for that project (PR-B made
+ * sync.js prefer it over the cwd basename). So a rename has to:
+ *
+ *   1. Update plan.name on every plan JSON belonging to this project,
+ *      so the next sync doesn't clobber the rename back to the
+ *      basename derivation.
+ *   2. Update the projects.name column directly so the UI updates
+ *      without waiting for a full re-scan.
+ *
+ * Validates name length (1–120) and rejects empty/whitespace-only.
+ *
+ * @returns {{ ok: true, name, plansUpdated } | { ok: false, error }}
+ */
+export function renameProject({ projectId, name }) {
+  const trimmed = String(name || '').trim();
+  if (!trimmed) return { ok: false, error: 'El nombre no puede estar vacío.' };
+  if (trimmed.length > 120) return { ok: false, error: 'El nombre no puede superar los 120 caracteres.' };
+
+  const root = plansRoot();
+  let plansUpdated = 0;
+  if (existsSync(root)) {
+    const projDir = join(root, projectId);
+    if (existsSync(projDir)) {
+      let files;
+      try { files = readdirSync(projDir); } catch { files = []; }
+      for (const f of files) {
+        if (!f.endsWith('.json')) continue;
+        const filePath = join(projDir, f);
+        try {
+          const plan = readPlan(filePath);
+          plan.name = trimmed;
+          plan.updatedAt = new Date().toISOString();
+          writePlan(filePath, plan);
+          plansUpdated += 1;
+        } catch { /* skip unreadable plan */ }
+      }
+    }
+  }
+
+  // Update the project row directly so the UI reflects the new name
+  // without waiting for the chokidar watcher to fire on the plan
+  // edits above.
+  try {
+    const stmt = getDb().prepare('UPDATE projects SET name = ? WHERE id = ?');
+    const res = stmt.run(trimmed, projectId);
+    if (res.changes === 0 && plansUpdated === 0) {
+      return { ok: false, error: `Proyecto no encontrado: ${projectId}` };
+    }
+  } catch (err) {
+    return { ok: false, error: `Error actualizando la base de datos: ${err.message}` };
+  }
+  return { ok: true, name: trimmed, plansUpdated };
+}
+
 export function markPlanReady({ planId, projectId }) {
   const filePath = findPlanFilePath(planId, projectId);
   if (!filePath) return { ok: false, error: `plan not found: ${planId}` };

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -17,7 +17,7 @@ import {
   listPlanIdsForProject,
 } from '../db.js';
 import { fullScan } from '../sync.js';
-import { setHuStatus, setHuFields, markPlanReady, runPlan } from '../plan-mutations.js';
+import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject } from '../plan-mutations.js';
 import { subscribe as subscribeEvents } from '../event-bus.js';
 import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
@@ -78,6 +78,26 @@ router.get('/projects/:id', (req, res) => {
     const project = projects.find((p) => p.id === req.params.id);
     if (!project) return res.status(404).json({ error: 'Project not found' });
     res.json(project);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * PUT /api/projects/:id/name — PR-G: rename a project.
+ *
+ * Updates plan.name on every plan JSON belonging to the project AND
+ * the projects.name column directly so the UI reflects the new name
+ * on the next render. Body: { name: "Linux Assistant Orchestrator" }.
+ */
+router.put('/projects/:id/name', (req, res) => {
+  try {
+    const result = renameProject({ projectId: req.params.id, name: req.body?.name });
+    if (!result.ok) {
+      const code = /no encontrado/i.test(result.error) ? 404 : 400;
+      return res.status(code).json({ error: result.error });
+    }
+    res.json(result);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/rename-project.test.js
+++ b/packages/hu-board/tests/rename-project.test.js
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpKj;
+let savedKjHome;
+let savedPlansDir;
+
+beforeEach(() => {
+  tmpKj = join(tmpdir(), `kj-rename-${process.pid}-${Date.now()}`);
+  mkdirSync(join(tmpKj, 'plans', 'proj-X'), { recursive: true });
+  // Two plan JSONs in this project so we can verify renameProject
+  // updates ALL of them.
+  writeFileSync(join(tmpKj, 'plans', 'proj-X', 'plan-1.json'), JSON.stringify({
+    planId: 'plan-1', version: 2, projectDir: '/x', task: 't',
+    name: 'Old Name', status: 'draft',
+    hus: [{ id: 'hu_plan-1_001', title: 'h', status: 'pending' }],
+  }));
+  writeFileSync(join(tmpKj, 'plans', 'proj-X', 'plan-2.json'), JSON.stringify({
+    planId: 'plan-2', version: 2, projectDir: '/x', task: 't',
+    name: 'Old Name', status: 'draft',
+    hus: [{ id: 'hu_plan-2_001', title: 'h', status: 'pending' }],
+  }));
+  savedKjHome = process.env.KJ_HOME;
+  savedPlansDir = process.env.KJ_PLANS_DIR;
+  process.env.KJ_HOME = tmpKj;
+  process.env.KJ_PLANS_DIR = join(tmpKj, 'plans');
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (savedKjHome === undefined) delete process.env.KJ_HOME; else process.env.KJ_HOME = savedKjHome;
+  if (savedPlansDir === undefined) delete process.env.KJ_PLANS_DIR; else process.env.KJ_PLANS_DIR = savedPlansDir;
+  try { rmSync(tmpKj, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('renameProject (PR-G)', () => {
+  it('updates plan.name on EVERY plan JSON belonging to the project', async () => {
+    const { initDb, upsertProject } = await import('../src/db.js');
+    initDb();
+    upsertProject({ id: 'proj-X', name: 'Old Name', total_stories: 0 });
+    const { renameProject } = await import('../src/plan-mutations.js');
+
+    const r = renameProject({ projectId: 'proj-X', name: 'Brand New Name' });
+    expect(r.ok).toBe(true);
+    expect(r.name).toBe('Brand New Name');
+    expect(r.plansUpdated).toBe(2);
+
+    const p1 = JSON.parse(readFileSync(join(tmpKj, 'plans', 'proj-X', 'plan-1.json'), 'utf8'));
+    const p2 = JSON.parse(readFileSync(join(tmpKj, 'plans', 'proj-X', 'plan-2.json'), 'utf8'));
+    expect(p1.name).toBe('Brand New Name');
+    expect(p2.name).toBe('Brand New Name');
+  });
+
+  it('updates the SQLite project row directly', async () => {
+    const { initDb, upsertProject, getDb } = await import('../src/db.js');
+    initDb();
+    upsertProject({ id: 'proj-X', name: 'Old Name', total_stories: 0 });
+    const { renameProject } = await import('../src/plan-mutations.js');
+    renameProject({ projectId: 'proj-X', name: 'New' });
+    const row = getDb().prepare('SELECT name FROM projects WHERE id = ?').get('proj-X');
+    expect(row.name).toBe('New');
+  });
+
+  it('rejects empty / whitespace-only names', async () => {
+    const { initDb } = await import('../src/db.js');
+    initDb();
+    const { renameProject } = await import('../src/plan-mutations.js');
+    expect(renameProject({ projectId: 'proj-X', name: '' }).ok).toBe(false);
+    expect(renameProject({ projectId: 'proj-X', name: '   ' }).ok).toBe(false);
+    expect(renameProject({ projectId: 'proj-X', name: null }).ok).toBe(false);
+  });
+
+  it('rejects names longer than 120 characters', async () => {
+    const { initDb } = await import('../src/db.js');
+    initDb();
+    const { renameProject } = await import('../src/plan-mutations.js');
+    const long = 'x'.repeat(121);
+    const r = renameProject({ projectId: 'proj-X', name: long });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/120/);
+  });
+
+  it('returns 404-equivalent error when no plans + no SQLite row exist for the project', async () => {
+    const { initDb } = await import('../src/db.js');
+    initDb();
+    const { renameProject } = await import('../src/plan-mutations.js');
+    // No plans dir for this project + no SQLite row → not found.
+    const r = renameProject({ projectId: 'no-such-project', name: 'X' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no encontrado/i);
+  });
+
+  it('trims surrounding whitespace before saving', async () => {
+    const { initDb, upsertProject } = await import('../src/db.js');
+    initDb();
+    upsertProject({ id: 'proj-X', name: 'Old', total_stories: 0 });
+    const { renameProject } = await import('../src/plan-mutations.js');
+    const r = renameProject({ projectId: 'proj-X', name: '   Padded   ' });
+    expect(r.ok).toBe(true);
+    expect(r.name).toBe('Padded');
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #521 which made \`plan.name\` the source of truth for the project display name. Without a way to edit it from the board, the user was stuck with whatever the planner/cwd derivation produced.

## Three pieces

### 1. \`renameProject({ projectId, name })\` in \`plan-mutations.js\`
Updates \`plan.name\` on every plan JSON belonging to the project AND the \`projects.name\` column in SQLite directly. Rejects empty, whitespace-only, and >120-char names with plain-Spanish errors.

### 2. \`PUT /api/projects/:id/name\` route
Body: \`{ name: \"Linux Assistant Orchestrator\" }\`. 400 on validation error, 404 when neither plan dir nor SQLite row exists.

### 3. ✎ pencil next to the project name in the board header
Click → small dialog with the current name pre-selected. Save PUTs to the API; on success refreshes header, dropdown and project picker.

## Test plan

- [x] 6 cases for \`renameProject\` (multi-plan update, SQLite row, empty rejection, length limit, project-not-found, whitespace trim).
- [x] Parent vitest: 4015 / 4015.
- [x] Board vitest: 163 / 163.