### PR TITLE
feat(plan): kj plan generate prompts for the project name

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -301,6 +301,8 @@ plan
   .option("--no-tests-synth", "Skip the tests-synthesizer pass that fills in missing acceptance_tests")
   .option("--no-plan-review", "Skip the high-level plan reviewer pass (gaps / deps / overlap / order)")
   .option("--quick", "Sketch mode — skip every quality pass after the initial planner call")
+  .option("-y, --yes", "Skip the project-name prompt (use the auto-derived default).")
+  .option("--no-interactive", "Force non-interactive mode (no prompts, use defaults).")
   .action(async (task, flags) => {
     await withConfig("plan", flags, async ({ config, logger }) => {
       const { resolveTaskInput } = await import("./utils/task-file.js");
@@ -311,6 +313,8 @@ plan
           noTestsSynth: flags.testsSynth === false,
           noPlanReview: flags.planReview === false,
           quick: Boolean(flags.quick),
+          yes: Boolean(flags.yes),
+          interactive: flags.interactive,
         },
       });
     });

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -5,6 +5,7 @@ import { buildPlannerPrompt } from "../prompts/planner.js";
 import { parseMaybeJsonString } from "../review/parser.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAutoGC, summarizeGC } from "../utils/garbage-collector.js";
+import { promptProjectName } from "../utils/prompt-project-name.js";
 
 // ---- Formatting helpers ----
 
@@ -115,7 +116,15 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
 
   const projectDir = config.projectDir || process.cwd();
   const plan = createPlanV2(task);
-  plan.name = deriveProjectName(task);
+  // PR-H: deduce a default name from the task content (which the LLM
+  // saw and condensed), then ask the user to confirm or override.
+  // Skip the prompt on non-interactive runs (--json, --yes, board-
+  // spawned subprocesses with stdio:ignore) so CI / automation
+  // doesn't hang waiting on a TTY.
+  const defaultName = deriveProjectName(task);
+  const canPrompt = process.stdin.isTTY && process.stdout.isTTY
+    && !json && !flags?.yes && flags?.interactive !== false;
+  plan.name = canPrompt ? await promptProjectName(defaultName) : defaultName;
   plan.approach = parsed?.approach || (typeof parsed === "string" ? parsed : (typeof result.output === "string" ? result.output : null));
   plan.risks = parsed?.risks || [];
   plan.outOfScope = parsed?.outOfScope || [];

--- a/src/utils/prompt-project-name.js
+++ b/src/utils/prompt-project-name.js
@@ -1,0 +1,35 @@
+/**
+ * PR-H: ask the user "Nombre del proyecto?" before saving a plan.
+ *
+ * The user's words: "El nombre del board debería de deducirse del
+ * cwd o del nombre del plan, pero no darlo por hecho, preguntar al
+ * usuario siempre, por si quiere cambiarlo."
+ *
+ * Pre-fills the prompt with the suggested name (derived from the
+ * task / cwd) so accepting the default is one ENTER away. Returns
+ * the trimmed answer; falls back to the default when the user just
+ * hits ENTER (empty input).
+ *
+ * Caller is responsible for skipping this when stdin/stdout are not
+ * a TTY, when --yes is set, or when --json is set.
+ */
+
+import readline from "node:readline";
+
+/**
+ * @param {string} defaultName — pre-filled suggestion shown in [brackets]
+ * @returns {Promise<string>} the user's answer (defaults to defaultName)
+ */
+export async function promptProjectName(defaultName) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const fallback = String(defaultName || "").trim();
+  const hint = fallback ? ` [${fallback}]` : "";
+  return new Promise((resolve) => {
+    rl.question(`Nombre del proyecto${hint}: `, (answer) => {
+      rl.close();
+      const trimmed = String(answer || "").trim();
+      resolve(trimmed || fallback);
+    });
+    rl.on("SIGINT", () => { rl.close(); resolve(fallback); });
+  });
+}

--- a/tests/prompt-project-name.test.js
+++ b/tests/prompt-project-name.test.js
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Readable, Writable } from "node:stream";
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+async function runWithStubbedStdio(input, defaultName) {
+  const stdinReplacement = Readable.from([input]);
+  const stdoutReplacement = new Writable({ write(_, __, cb) { cb(); } });
+  const realIn = process.stdin;
+  const realOut = process.stdout;
+  Object.defineProperty(process, "stdin", { value: stdinReplacement, configurable: true });
+  Object.defineProperty(process, "stdout", { value: stdoutReplacement, configurable: true });
+  try {
+    const { promptProjectName } = await import("../src/utils/prompt-project-name.js");
+    return await promptProjectName(defaultName);
+  } finally {
+    Object.defineProperty(process, "stdin", { value: realIn, configurable: true });
+    Object.defineProperty(process, "stdout", { value: realOut, configurable: true });
+  }
+}
+
+describe("promptProjectName", () => {
+  it("returns the default when the user just hits ENTER", async () => {
+    expect(await runWithStubbedStdio("\n", "Linux Assistant")).toBe("Linux Assistant");
+  });
+
+  it("returns the user's typed answer when non-empty", async () => {
+    expect(await runWithStubbedStdio("Mi Proyecto Mejor\n", "default")).toBe("Mi Proyecto Mejor");
+  });
+
+  it("trims surrounding whitespace from the user's answer", async () => {
+    expect(await runWithStubbedStdio("   spaced   \n", "default")).toBe("spaced");
+  });
+
+  it("uses an empty fallback when the default is empty/null", async () => {
+    expect(await runWithStubbedStdio("\n", null)).toBe("");
+    expect(await runWithStubbedStdio("\n", "")).toBe("");
+    expect(await runWithStubbedStdio("\n", undefined)).toBe("");
+  });
+
+  it("trims the default before using it", async () => {
+    expect(await runWithStubbedStdio("\n", "  Padded  ")).toBe("Padded");
+  });
+});


### PR DESCRIPTION
## Why

User feedback: \"el nombre del board debería de deducirse del cwd o del nombre del plan, pero no darlo por hecho, preguntar al usuario siempre, por si quiere cambiarlo.\"

## How

After the planner produces the plan, prompt:

```
Nombre del proyecto [Linux Assistant]:
```

The bracketed default is the auto-derived name from the task content. Empty answer (just ENTER) keeps the default; any other input wins. Trims surrounding whitespace.

Skipped automatically when:
- \`--json\` (machine-readable output)
- \`--yes\` / \`-y\` (CI / scripted)
- \`--no-interactive\` (explicit opt-out)
- stdin/stdout not a TTY (board-spawned subprocess, MCP)

So the board's \`kj plan\` flow is unchanged (\`stdio:ignore\` on spawn).

Pairs with #526 (rename from the board): the user picks a name once at plan-creation and can edit later from the header pencil.

## Test plan

- [x] 5 cases for \`promptProjectName\` (default ENTER, typed answer, trim, empty fallback, default trim).
- [x] Parent vitest: 4020 / 4020.
- [x] Dynamic-imports budget within 150.