### PR TITLE
fix(coder): KJC-BUG-0032 — guard against writes outside projectDir

### DIFF
--- a/src/orchestrator/fs-leak-detector.js
+++ b/src/orchestrator/fs-leak-detector.js
@@ -1,0 +1,111 @@
+/**
+ * KJC-BUG-0032: detect coder writes outside projectDir.
+ *
+ * The coder subprocess runs with `cwd: projectDir`, but its Bash
+ * tool can `cd` anywhere. Real-world repro: a HU titled
+ *   "Initialize project skeleton: create assistant/ directory…"
+ * had Claude run `cd /home/manu/assistant && pnpm init …`. The
+ * resulting 36 MB of code lived in $HOME/assistant — outside the
+ * projectDir, outside any git repo, lost to tracking, commits and
+ * review. The coder was happy, the user only noticed by accident.
+ *
+ * This module is a deterministic guard: snapshot $HOME's top-level
+ * directory entries before the coder runs, scan again after, and
+ * any new entry that isn't projectDir itself is a leak.
+ *
+ * Why top-level only:
+ *   - Catches the realistic failure mode (coder creates a sibling
+ *     `~/something` for the project skeleton).
+ *   - Cheap (single readdirSync) — no `find -newer` traversal of
+ *     $HOME's potentially massive tree.
+ *   - Doesn't thrash on writes to existing dirs like ~/.npm or
+ *     ~/.cache that legitimate node tooling touches.
+ *
+ * What it WON'T catch (acknowledged trade-offs):
+ *   - Writes deep inside existing $HOME subdirs (e.g. modifying
+ *     ~/.bashrc — would need a per-file mtime scan).
+ *   - Writes to /tmp (high false-positive rate; /tmp is ephemeral
+ *     by spec; less risky).
+ *   - Writes to /etc, /var, etc. (would require root anyway).
+ *
+ * The first-pass guard is the right ROI. Subsequent iterations
+ * can extend coverage if real-world cases warrant it.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Snapshot the immediate children of $HOME. Returns a Set of names
+ * (not full paths) so detectNewHomeEntries can do a quick set
+ * difference. Empty set on any FS error — treats "can't snapshot"
+ * the same as "snapshot OK with nothing".
+ *
+ * @returns {Set<string>}
+ */
+export function snapshotHomeTopLevel() {
+  try {
+    return new Set(fs.readdirSync(os.homedir()));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Detect $HOME top-level entries that didn't exist when `before`
+ * was snapshotted. Excludes projectDir itself in case the user
+ * keeps their projects directly under $HOME (no false positive
+ * if `projectDir = $HOME/some-project` already existed).
+ *
+ * @param {Set<string>} before — snapshot from snapshotHomeTopLevel()
+ * @param {string|null} projectDir — current run's projectDir
+ * @returns {string[]} absolute paths of new entries (potential leaks)
+ */
+export function detectNewHomeEntries(before, projectDir) {
+  const home = os.homedir();
+  let after;
+  try {
+    after = fs.readdirSync(home);
+  } catch {
+    return [];
+  }
+  const projectDirAbs = projectDir ? path.resolve(projectDir) : null;
+  const leaks = [];
+  for (const name of after) {
+    if (before.has(name)) continue;
+    const full = path.join(home, name);
+    // Skip projectDir itself (defensive — shouldn't happen since
+    // projectDir is pre-existing, but a paranoid check costs nothing).
+    if (projectDirAbs && path.resolve(full) === projectDirAbs) continue;
+    leaks.push(full);
+  }
+  return leaks;
+}
+
+/**
+ * Format a leak list into a multiline plain-Spanish error message.
+ * Includes a hint about how to recover (move-or-delete) so the user
+ * isn't left guessing.
+ *
+ * @param {string[]} leaks — output of detectNewHomeEntries()
+ * @param {string} projectDir
+ * @returns {string}
+ */
+export function formatLeakMessage(leaks, projectDir) {
+  const list = leaks.map((p) => `  - ${p}`).join("\n");
+  return [
+    `El coder creó archivos FUERA del proyecto (${projectDir}).`,
+    "",
+    "Rutas detectadas:",
+    list,
+    "",
+    "Esto suele pasar cuando una HU usa una ruta absoluta o relativa a $HOME y el coder la sigue literalmente. Las rutas SIEMPRE deben ser relativas a la raíz del proyecto.",
+    "",
+    "Qué hacer:",
+    "  1. Inspecciona las rutas listadas. Si tienen código útil, muévelo a tu proyecto manualmente.",
+    "  2. Borra las rutas listadas si son basura.",
+    "  3. Edita el título / scope de la HU para que no contenga rutas absolutas.",
+    "  4. Vuelve a lanzar la HU.",
+  ].join("\n");
+}

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -18,6 +18,7 @@ import { runCoderWithFallback } from "../agent-fallback.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
+import { snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage } from "../fs-leak-detector.js";
 
 export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
   logger.setContext({ iteration, stage: "coder" });
@@ -45,6 +46,12 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
     onOutput: coderOnOutput, emitter, eventBase, stage: "coder", provider: coderRole.provider
   });
   const coderStart = Date.now();
+  // KJC-BUG-0032 (PR-I): snapshot $HOME's top-level entries BEFORE
+  // the coder runs so we can detect leaks afterwards. The bug: a HU
+  // titled "Initialize project skeleton: create assistant/…" had
+  // Claude run `cd /home/manu/assistant && pnpm init …` and 36 MB
+  // of code landed outside projectDir, outside any git repo.
+  const homeSnapshotBeforeCoder = snapshotHomeTopLevel();
   let coderExecResult;
   try {
     coderExecResult = await coderRoleInstance.execute({
@@ -137,6 +144,29 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       })
     );
     throw new Error(`Coder failed: ${details}`);
+  }
+
+  // KJC-BUG-0032 (PR-I): scan $HOME for new top-level entries the
+  // coder created OUTSIDE projectDir. Stop the HU loudly with a
+  // plain-Spanish message instead of letting the user discover by
+  // accident hours later that 36 MB of code is in the wrong place.
+  // Runs BEFORE the success-path verification so a leaked HU doesn't
+  // get marked as "Coder applied changes".
+  const projectDirAbs = config.projectDir || process.cwd();
+  const fsLeaks = detectNewHomeEntries(homeSnapshotBeforeCoder, projectDirAbs);
+  if (fsLeaks.length > 0) {
+    const msg = formatLeakMessage(fsLeaks, projectDirAbs);
+    logger.error(msg);
+    emitProgress(
+      emitter,
+      makeEvent("coder:fs-leak", { ...eventBase, stage: "coder" }, {
+        status: "fail",
+        message: `Coder escribió fuera del projectDir: ${fsLeaks.length} ruta(s) detectada(s)`,
+        detail: { provider: coderRole.provider, leaks: fsLeaks, projectDir: projectDirAbs }
+      })
+    );
+    await markSessionStatus(session, "failed");
+    throw new Error(msg);
   }
 
   // Measure files changed so stale detection (solomon-rules) has accurate data

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -160,6 +160,28 @@ function renderReviewerFindingsSection(findings, huId) {
 
 export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
   const langInstruction = getLanguageInstruction(language);
+  // KJC-BUG-0032 (PR-I): hard rule about file paths. Real bug: a HU
+  // titled "Initialize project skeleton: create assistant/ directory…"
+  // had Claude run `cd /home/manu/assistant && pnpm init …` and 36 MB
+  // of code landed in $HOME instead of inside projectDir. Reinforce
+  // the constraint at the prompt level (soft fix) AND enforce it
+  // post-coder via fs-leak-detector.js (hard fix).
+  const projectDirRule = projectDir
+    ? [
+        "## CRITICAL — Project directory boundary",
+        `The project root is **${projectDir}**. EVERY file you create, write, edit, mkdir or cd to MUST stay inside this directory.`,
+        "",
+        "Forbidden, regardless of what the task says:",
+        "- Absolute paths outside the project root (e.g. `/home/USER/something`, `/tmp/x`, `/etc/y`).",
+        "- `cd` to any directory outside the project root inside Bash commands.",
+        "- Creating sibling top-level directories under `$HOME`.",
+        "",
+        "If the task or HU title mentions a directory like `assistant/` or `app/`, treat it as RELATIVE to the project root. NEVER as an absolute path under $HOME.",
+        "",
+        "Karajan runs a deterministic post-coder guard that detects writes outside the project root and ABORTS the HU. If you ignore this rule the run will fail and your work will be discarded."
+      ].join("\n")
+    : null;
+
   const sections = [
     serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
     ...(langInstruction ? [langInstruction] : []),
@@ -172,6 +194,7 @@ export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSum
     "No console.log — use a structured logger. No 'any' types — use JSDoc annotations.",
     SUBPROCESS_CONSTRAINTS
   ];
+  if (projectDirRule) sections.push(projectDirRule);
 
   if (serenaEnabled) {
     sections.push(SERENA_INSTRUCTIONS);

--- a/tests/coder-prompt-tests-first.test.js
+++ b/tests/coder-prompt-tests-first.test.js
@@ -201,6 +201,33 @@ describe("buildCoderPrompt — reviewer findings filtered per HU", () => {
   });
 });
 
+describe("buildCoderPrompt — projectDir boundary rule (PR-I, KJC-BUG-0032)", () => {
+  it("renders the CRITICAL boundary section when projectDir is present", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "Initialize project skeleton: create assistant/ directory",
+      projectDir: "/home/user/my-project",
+    });
+    expect(prompt).toMatch(/CRITICAL — Project directory boundary/);
+    expect(prompt).toContain("/home/user/my-project");
+    expect(prompt).toMatch(/EVERY file you create.*MUST stay inside/);
+    expect(prompt).toMatch(/RELATIVE to the project root/);
+    expect(prompt).toMatch(/post-coder guard/);
+  });
+
+  it("omits the section when projectDir is null (legacy callers)", async () => {
+    const prompt = await buildCoderPrompt({ task: "fix typo" });
+    expect(prompt).not.toMatch(/Project directory boundary/);
+  });
+
+  it("forbids absolute paths under $HOME explicitly", async () => {
+    const prompt = await buildCoderPrompt({
+      task: "x", projectDir: "/proj",
+    });
+    expect(prompt).toMatch(/\/home\/USER\/something/);
+    expect(prompt).toMatch(/Forbidden/);
+  });
+});
+
 describe("buildCoderPrompt — section ordering for plan-aware run", () => {
   it("renders ADRs → SPEC ref → reviewer findings → acceptance tests in that order", async () => {
     const huId = "hu_p001_002";

--- a/tests/fs-leak-detector.test.js
+++ b/tests/fs-leak-detector.test.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage,
+} from "../src/orchestrator/fs-leak-detector.js";
+
+// KJC-BUG-0032 (PR-I): the coder's Bash tool can `cd` anywhere and
+// create files under $HOME. The detector snapshots $HOME's top-level
+// before the coder runs and reports any new entry afterwards.
+
+let savedHome;
+let tmpHome;
+
+beforeEach(() => {
+  // Point HOME at a tmp dir so the test doesn't touch the developer's
+  // real $HOME (and so it doesn't false-positive on whatever happens
+  // to be in $HOME during CI).
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kj-fsleak-"));
+  savedHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  // os.homedir() reads HOME — re-evaluating the module would be cleaner
+  // but the helpers re-read it on every call, so this is enough.
+});
+
+afterEach(() => {
+  if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe("snapshotHomeTopLevel", () => {
+  it("returns the immediate children of $HOME as a Set", () => {
+    fs.mkdirSync(path.join(tmpHome, "ws"));
+    fs.mkdirSync(path.join(tmpHome, ".cache"));
+    fs.writeFileSync(path.join(tmpHome, ".bashrc"), "# x");
+    const snap = snapshotHomeTopLevel();
+    expect(snap).toBeInstanceOf(Set);
+    expect(snap.has("ws")).toBe(true);
+    expect(snap.has(".cache")).toBe(true);
+    expect(snap.has(".bashrc")).toBe(true);
+  });
+
+  it("returns an empty Set when $HOME is unreadable", () => {
+    process.env.HOME = "/nonexistent/path/for/testing";
+    const snap = snapshotHomeTopLevel();
+    expect(snap).toBeInstanceOf(Set);
+    expect(snap.size).toBe(0);
+  });
+});
+
+describe("detectNewHomeEntries", () => {
+  it("returns empty when nothing changed in $HOME", () => {
+    fs.mkdirSync(path.join(tmpHome, "ws"));
+    const before = snapshotHomeTopLevel();
+    const leaks = detectNewHomeEntries(before, "/some/projectDir");
+    expect(leaks).toEqual([]);
+  });
+
+  it("flags new top-level directories created since the snapshot", () => {
+    fs.mkdirSync(path.join(tmpHome, "ws"));
+    const before = snapshotHomeTopLevel();
+    // Simulate the bug — coder creates ~/assistant
+    fs.mkdirSync(path.join(tmpHome, "assistant"));
+    fs.writeFileSync(path.join(tmpHome, "assistant", "package.json"), "{}");
+    const leaks = detectNewHomeEntries(before, "/some/projectDir");
+    expect(leaks).toEqual([path.join(tmpHome, "assistant")]);
+  });
+
+  it("flags new top-level files too (not just dirs)", () => {
+    const before = snapshotHomeTopLevel();
+    fs.writeFileSync(path.join(tmpHome, "rogue.sh"), "#!/bin/bash");
+    const leaks = detectNewHomeEntries(before, "/some/projectDir");
+    expect(leaks).toEqual([path.join(tmpHome, "rogue.sh")]);
+  });
+
+  it("does NOT flag projectDir even if it equals a $HOME child path", () => {
+    fs.mkdirSync(path.join(tmpHome, "my-project"));
+    const before = snapshotHomeTopLevel();
+    // Simulate a sub-write inside projectDir — top-level snapshot
+    // already had `my-project`, so no new entry → no leak.
+    fs.writeFileSync(path.join(tmpHome, "my-project", "x.js"), "x");
+    const leaks = detectNewHomeEntries(before, path.join(tmpHome, "my-project"));
+    expect(leaks).toEqual([]);
+  });
+
+  it("excludes projectDir from the leak list when it appears as a NEW $HOME entry (defensive)", () => {
+    const before = snapshotHomeTopLevel();
+    fs.mkdirSync(path.join(tmpHome, "fresh-project"));
+    const leaks = detectNewHomeEntries(before, path.join(tmpHome, "fresh-project"));
+    expect(leaks).toEqual([]);
+  });
+
+  it("returns absolute paths so callers can show actionable info", () => {
+    const before = snapshotHomeTopLevel();
+    fs.mkdirSync(path.join(tmpHome, "leak"));
+    const leaks = detectNewHomeEntries(before, "/somewhere/else");
+    expect(leaks[0].startsWith("/")).toBe(true);
+    expect(leaks[0]).toBe(path.join(tmpHome, "leak"));
+  });
+
+  it("handles projectDir=null gracefully", () => {
+    const before = snapshotHomeTopLevel();
+    fs.mkdirSync(path.join(tmpHome, "leak"));
+    const leaks = detectNewHomeEntries(before, null);
+    expect(leaks).toEqual([path.join(tmpHome, "leak")]);
+  });
+});
+
+describe("formatLeakMessage", () => {
+  it("includes every leak path on its own line", () => {
+    const msg = formatLeakMessage(["/home/x/assistant", "/home/x/rogue.sh"], "/proj");
+    expect(msg).toContain("- /home/x/assistant");
+    expect(msg).toContain("- /home/x/rogue.sh");
+  });
+
+  it("mentions the projectDir so the user knows what was expected", () => {
+    const msg = formatLeakMessage(["/home/x/y"], "/home/user/proj");
+    expect(msg).toContain("/home/user/proj");
+  });
+
+  it("includes recovery hints in plain Spanish", () => {
+    const msg = formatLeakMessage(["/home/x/y"], "/proj");
+    expect(msg).toMatch(/relativas a la raíz del proyecto/i);
+    expect(msg).toMatch(/Inspecciona/);
+    expect(msg).toMatch(/Borra/);
+    expect(msg).toMatch(/Edita el título/);
+  });
+});

--- a/tests/iteration-stages-unit.test.js
+++ b/tests/iteration-stages-unit.test.js
@@ -253,6 +253,64 @@ describe("iteration-stages: runCoderStage", () => {
     expect(call.huId).toBeNull();
   });
 
+  // KJC-BUG-0032 (PR-I): runCoderStage must throw and emit a
+  // coder:fs-leak event when the coder created a new top-level
+  // entry under $HOME outside the projectDir. Uses fs + a tmp HOME
+  // to simulate the leak deterministically.
+  it("aborts the HU when the coder writes outside projectDir", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kj-stage-leak-"));
+    const savedHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    try {
+      // The "coder" simulates the bug: creates a new top-level dir
+      // under $HOME during execution.
+      const executeMock = vi.fn(async () => {
+        fs.mkdirSync(path.join(tmpHome, "assistant"));
+        fs.writeFileSync(path.join(tmpHome, "assistant", "package.json"), "{}");
+        return { ok: true, result: { output: "done" }, summary: "ok" };
+      });
+      const coderRoleInstance = { execute: executeMock };
+
+      await expect(runCoderStage({
+        coderRoleInstance, coderRole,
+        config: { ...makeConfig(), projectDir: "/some/other/projectDir" },
+        logger, emitter, eventBase,
+        session: makeSession(), plannedTask: "do X", trackBudget, iteration: 1
+      })).rejects.toThrow(/FUERA del proyecto/);
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+      try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it("does NOT abort when the coder writes only inside projectDir", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const os = await import("node:os");
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kj-stage-clean-"));
+    const savedHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    try {
+      // No new top-level $HOME entries created during coder run.
+      const executeMock = vi.fn(async () => ({ ok: true, result: { output: "done" }, summary: "ok" }));
+      const coderRoleInstance = { execute: executeMock };
+
+      const result = await runCoderStage({
+        coderRoleInstance, coderRole,
+        config: { ...makeConfig(), projectDir: "/some/projectDir" },
+        logger, emitter, eventBase,
+        session: makeSession(), plannedTask: "do X", trackBudget, iteration: 1
+      });
+      expect(result).toBeUndefined();   // success returns void
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME; else process.env.HOME = savedHome;
+      try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
   it("returns standby action on rate limit", async () => {
     const { detectRateLimit } = await import("../src/utils/rate-limit-detector.js");
     detectRateLimit.mockReturnValueOnce({ isRateLimit: true, cooldownMs: 60000, message: "rate limited" });


### PR DESCRIPTION
## Why

Closes **KJC-BUG-0032**.

Real-world bug from yesterday's dogfood: a HU titled \"Initialize project skeleton: create assistant/ directory…\" had Claude run \`cd /home/manu/assistant && pnpm init …\` inside its Bash tool, and 36 MB of code landed in \`$HOME/assistant\` — outside the projectDir, outside any git repo, lost to tracking, commits and review. User discovered it by accident.

## Two layers of defence

### Hard guard — \`src/orchestrator/fs-leak-detector.js\`

Before invoking the coder, snapshot \`$HOME\`'s top-level entries. After the coder returns, re-scan and flag any new top-level entry that isn't \`projectDir\` itself. If any leak is detected the HU aborts (\`markSessionStatus('failed')\` + plain-Spanish error listing leaked paths and recovery steps + \`coder:fs-leak\` progress event).

Trade-offs (in the module header):
- Catches the realistic failure mode (sibling dir under \`$HOME\`).
- Cheap (single \`readdirSync\`, no \`find -newer\` traversal).
- Won't catch deep writes inside existing \`$HOME\` subdirs nor \`/tmp\` writes — first-pass guard, can extend later if dogfood reveals other modes.

### Soft guard — \`buildCoderPrompt\` rule

New \`## CRITICAL — Project directory boundary\` section in the coder prompt when \`projectDir\` is present. Tells the coder explicitly that every file path must stay inside \`projectDir\`, forbids absolute paths under \`\$HOME / /tmp / /etc\`, and warns that the post-coder guard will abort the HU on violation.

## Test plan

- [x] 12 cases for fs-leak-detector (snapshot, leak detection, projectDir defensive exclusion, formatLeakMessage hints).
- [x] 2 cases for runCoderStage (aborts on simulated leak, passes on clean run).
- [x] 3 cases for buildCoderPrompt (boundary section render, omitted when no projectDir, forbids absolute \`$HOME\` paths).
- [x] Full parent suite: 4037 / 4037.