### PR TITLE
refactor(hu-reviewer): extract splitting detection into phase module

### DIFF
--- a/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
+++ b/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
@@ -1,0 +1,130 @@
+/**
+ * HU Reviewer phase: detect splittable HUs and apply the split.
+ *
+ * Extracted from `runHuReviewerStage` in PR-M (audit follow-up,
+ * KJC-PCS-0033). Was 78 LOC inlined inside the 311-LOC parent
+ * function — moving it brings the stage closer to a clean
+ * load → split → evaluate → return shape.
+ *
+ * For each pending HU in the batch:
+ *
+ *   1. Run the deterministic indicator detector
+ *      (src/hu/splitting-detector.js). If no indicators, skip.
+ *   2. Pick the first heuristic that matches; ask the LLM for a
+ *      split proposal. Retry with other heuristics on failure.
+ *   3. In autonomous mode (askQuestion=null) the proposal is
+ *      auto-accepted. In interactive mode the FDE confirms.
+ *   4. Replace the original story with the proposed sub-HUs in
+ *      the batch and persist.
+ *
+ * Behaviour identical to the inlined version — only the container
+ * changes. The closure variables (batch, askQuestion, config,
+ * logger, emitter, eventBase, batchSessionId) become explicit
+ * function parameters.
+ */
+
+import { saveHuBatch, updateStoryStatus } from "../../../hu/store.js";
+import { emitProgress, makeEvent } from "../../../utils/events.js";
+import { detectIndicators, selectHeuristic } from "../../../hu/splitting-detector.js";
+import { generateSplitProposal, formatSplitProposalForFDE, buildSplitDependencies } from "../../../hu/splitting-generator.js";
+
+/**
+ * Build a fresh sub-HU story object from a proposal entry. Same
+ * shape the inlined code produced; centralised to avoid the
+ * autonomous + interactive paths drifting apart.
+ */
+function buildSubHuStory(sub) {
+  const text = `${sub.title}\n\n${sub.text}\n\nAcceptance Criteria:\n${(sub.acceptanceCriteria || []).map((ac) => `- ${ac}`).join("\n")}`;
+  const now = new Date().toISOString();
+  return {
+    id: sub.id,
+    status: "pending",
+    original: { text },
+    blocked_by: sub.blocked_by || [],
+    certified: null,
+    quality: null,
+    context_requests: [],
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/**
+ * Replace `story` in `batch.stories` with the expanded sub-HUs and
+ * emit the `hu-reviewer:split-accepted` event.
+ */
+function applySplit({ batch, story, proposal, heuristic, source, eventBase, emitter }) {
+  const updatedSubHUs = buildSplitDependencies(proposal.subHUs, story);
+  const storyIndex = batch.stories.findIndex((s) => s.id === story.id);
+  const newStories = updatedSubHUs.map(buildSubHuStory);
+  batch.stories.splice(storyIndex, 1, ...newStories);
+  emitProgress(emitter, makeEvent("hu-reviewer:split-accepted", { ...eventBase, stage: "hu-reviewer" }, {
+    message: `${source} accepted split of ${story.id} into ${updatedSubHUs.length} sub-HUs`,
+    detail: { originalId: story.id, subHUs: updatedSubHUs.map((s) => s.id), heuristic }
+  }));
+}
+
+/**
+ * @param {object} args
+ * @param {object} args.batch              — HU batch (mutated in place)
+ * @param {string} args.batchSessionId     — for saveHuBatch persistence
+ * @param {Function|null} args.askQuestion — interactive prompt (null = auto-accept)
+ * @param {object} args.config
+ * @param {object} args.logger
+ * @param {object} args.emitter
+ * @param {object} args.eventBase
+ */
+export async function detectAndApplySplits({ batch, batchSessionId, askQuestion, config, logger, emitter, eventBase }) {
+  const storiesToSplit = [...batch.stories].filter((s) => s.status === "pending");
+  for (const story of storiesToSplit) {
+    const indicators = detectIndicators(story.original.text);
+    if (indicators.length === 0) continue;
+
+    let heuristic = selectHeuristic(indicators);
+    if (!heuristic) continue;
+
+    const triedHeuristics = [];
+    let splitAccepted = false;
+
+    while (heuristic && !splitAccepted) {
+      const proposal = await generateSplitProposal(
+        { id: story.id, text: story.original.text },
+        heuristic, config, logger
+      );
+
+      if (!proposal) {
+        triedHeuristics.push(heuristic);
+        heuristic = selectHeuristic(indicators, triedHeuristics);
+        continue;
+      }
+
+      if (!askQuestion) {
+        // Autonomous mode: auto-accept the split.
+        applySplit({ batch, story, proposal, heuristic, source: "Auto", eventBase, emitter });
+        splitAccepted = true;
+      } else {
+        // Interactive mode: ask FDE for confirmation.
+        const formatted = formatSplitProposalForFDE(proposal);
+        const question = `Split proposed for ${story.id}:\n${formatted}\nAccept? (yes/no/try another)`;
+        emitProgress(emitter, makeEvent("hu-reviewer:split-proposal", { ...eventBase, stage: "hu-reviewer" }, {
+          message: `Split proposal for ${story.id} using heuristic: ${heuristic}`,
+          detail: { originalId: story.id, heuristic, subHUCount: proposal.subHUs.length }
+        }));
+        const answer = await askQuestion(question, { iteration: 0, stage: "hu-reviewer" });
+        if (!answer || answer.toLowerCase().startsWith("yes")) {
+          applySplit({ batch, story, proposal, heuristic, source: "FDE", eventBase, emitter });
+          splitAccepted = true;
+        } else if (answer.toLowerCase().includes("try") || answer.toLowerCase().startsWith("no")) {
+          triedHeuristics.push(heuristic);
+          heuristic = selectHeuristic(indicators, triedHeuristics);
+          if (!heuristic) {
+            updateStoryStatus(batch, story.id, "needs_context");
+          }
+          continue;
+        }
+      }
+      break;
+    }
+    await saveHuBatch(batchSessionId, batch);
+  }
+}

--- a/src/orchestrator/stages/hu-reviewer-stage.js
+++ b/src/orchestrator/stages/hu-reviewer-stage.js
@@ -12,8 +12,7 @@ import { buildDecompositionPrompt, parseDecompositionOutput } from "../../prompt
 import { createStallDetector } from "../../utils/stall-detector.js";
 import { createHuBatch, loadHuBatch, saveHuBatch, updateStoryStatus, updateStoryQuality, updateStoryCertified, addContextRequest, answerContextRequest } from "../../hu/store.js";
 import { topologicalSort } from "../../hu/graph.js";
-import { detectIndicators, selectHeuristic } from "../../hu/splitting-detector.js";
-import { generateSplitProposal, formatSplitProposalForFDE, buildSplitDependencies } from "../../hu/splitting-generator.js";
+import { detectAndApplySplits } from "./hu-reviewer-phases/detect-and-apply-splits.js";
 
 /**
  * Use an AI agent to decompose a complex task into multiple formal HUs.
@@ -239,83 +238,11 @@ export async function runHuReviewerStage({ config, logger, emitter, eventBase, s
     batch = await createHuBatch(batchSessionId, stories);
   }
 
-  // --- Splitting detection: check each pending HU for split indicators before 6D evaluation ---
-  const storiesToSplit = [...batch.stories].filter(s => s.status === "pending");
-  for (const story of storiesToSplit) {
-    const indicators = detectIndicators(story.original.text);
-    if (indicators.length === 0) continue;
+  // --- Splitting detection: extracted to hu-reviewer-phases/detect-and-apply-splits.js (PR-M) ---
+  await detectAndApplySplits({
+    batch, batchSessionId, askQuestion, config, logger, emitter, eventBase,
+  });
 
-    let heuristic = selectHeuristic(indicators);
-    if (!heuristic) continue;
-
-    const triedHeuristics = [];
-    let splitAccepted = false;
-
-    while (heuristic && !splitAccepted) {
-      const proposal = await generateSplitProposal(
-        { id: story.id, text: story.original.text },
-        heuristic, config, logger
-      );
-
-      if (!proposal) {
-        triedHeuristics.push(heuristic);
-        heuristic = selectHeuristic(indicators, triedHeuristics);
-        continue;
-      }
-
-      if (!askQuestion) {
-        // Autonomous mode: auto-accept the split
-        const updatedSubHUs = buildSplitDependencies(proposal.subHUs, story);
-        const storyIndex = batch.stories.findIndex(s => s.id === story.id);
-        const newStories = updatedSubHUs.map(sub => ({
-          id: sub.id, status: "pending",
-          original: { text: `${sub.title}\n\n${sub.text}\n\nAcceptance Criteria:\n${(sub.acceptanceCriteria || []).map(ac => `- ${ac}`).join("\n")}` },
-          blocked_by: sub.blocked_by || [], certified: null, quality: null,
-          context_requests: [], created_at: new Date().toISOString(), updated_at: new Date().toISOString()
-        }));
-        batch.stories.splice(storyIndex, 1, ...newStories);
-        splitAccepted = true;
-        emitProgress(emitter, makeEvent("hu-reviewer:split-accepted", { ...eventBase, stage: "hu-reviewer" }, {
-          message: `Auto-accepted split of ${story.id} into ${updatedSubHUs.length} sub-HUs`,
-          detail: { originalId: story.id, subHUs: updatedSubHUs.map(s => s.id), heuristic }
-        }));
-      } else {
-        // Interactive mode: ask FDE for confirmation
-        const formatted = formatSplitProposalForFDE(proposal);
-        const question = `Split proposed for ${story.id}:\n${formatted}\nAccept? (yes/no/try another)`;
-        emitProgress(emitter, makeEvent("hu-reviewer:split-proposal", { ...eventBase, stage: "hu-reviewer" }, {
-          message: `Split proposal for ${story.id} using heuristic: ${heuristic}`,
-          detail: { originalId: story.id, heuristic, subHUCount: proposal.subHUs.length }
-        }));
-        const answer = await askQuestion(question, { iteration: 0, stage: "hu-reviewer" });
-        if (!answer || answer.toLowerCase().startsWith("yes")) {
-          const updatedSubHUs = buildSplitDependencies(proposal.subHUs, story);
-          const storyIndex = batch.stories.findIndex(s => s.id === story.id);
-          const newStories = updatedSubHUs.map(sub => ({
-            id: sub.id, status: "pending",
-            original: { text: `${sub.title}\n\n${sub.text}\n\nAcceptance Criteria:\n${(sub.acceptanceCriteria || []).map(ac => `- ${ac}`).join("\n")}` },
-            blocked_by: sub.blocked_by || [], certified: null, quality: null,
-            context_requests: [], created_at: new Date().toISOString(), updated_at: new Date().toISOString()
-          }));
-          batch.stories.splice(storyIndex, 1, ...newStories);
-          splitAccepted = true;
-          emitProgress(emitter, makeEvent("hu-reviewer:split-accepted", { ...eventBase, stage: "hu-reviewer" }, {
-            message: `FDE accepted split of ${story.id} into ${updatedSubHUs.length} sub-HUs`,
-            detail: { originalId: story.id, subHUs: updatedSubHUs.map(s => s.id), heuristic }
-          }));
-        } else if (answer.toLowerCase().includes("try") || answer.toLowerCase().startsWith("no")) {
-          triedHeuristics.push(heuristic);
-          heuristic = selectHeuristic(indicators, triedHeuristics);
-          if (!heuristic) {
-            updateStoryStatus(batch, story.id, "needs_context");
-          }
-          continue;
-        }
-      }
-      break;
-    }
-    await saveHuBatch(batchSessionId, batch);
-  }
 
   // --- Evaluate loop (re-evaluate entire batch until all certified or needs_context with no askQuestion) ---
   const huReviewerOnOutput = ({ stream, line }) => {


### PR DESCRIPTION
## Summary

Audit follow-up — third (and last) of the HIGH god-functions flagged by \`kj audit\` (KJC-PCS-0033).

\`runHuReviewerStage\` was a 311-LOC function doing four jobs:

1. load stories (YAML / PG card / AI decomposition)
2. **detect splittable HUs and apply the split** ← extracted
3. evaluate + certify loop
4. topological sort + return

Step 2 was 78 LOC of nested control flow (per-story heuristic selection loop + autonomous vs interactive modes + LLM-retry loop), with significant code duplication between the autonomous and interactive accept-paths. Extracting it isolates a coherent unit and lets the parent function read as the four-stage pipeline above.

## Changes

- New file \`src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js\` (130 LOC including header doc) exporting \`detectAndApplySplits({ batch, batchSessionId, askQuestion, config, logger, emitter, eventBase })\`.
- Two helpers inside the phase to kill duplication between the auto and FDE paths:
  - \`buildSubHuStory(sub)\` — canonical story object shape
  - \`applySplit({...})\` — splice in the new sub-HUs + emit \`hu-reviewer:split-accepted\`
- \`hu-reviewer-stage.js\` reduced 311 → 239 LOC (function), 397 → 394 (file). Drops 5 now-unused imports (\`detectIndicators\`, \`selectHeuristic\`, \`generateSplitProposal\`, \`formatSplitProposalForFDE\`, \`buildSplitDependencies\`) — all moved with the logic.

## Behaviour

**Identical.** Same heuristic priority order, same autonomous-vs-FDE branching, same persistence (\`saveHuBatch\` per story), same emitted events (\`hu-reviewer:split-proposal\`, \`hu-reviewer:split-accepted\`).

## Series

Final HIGH god-function refactor of the audit series:

| PR | Function | Before | After | Δ |
|---|---|---|---|---|
| #530 (PR-K) | \`runPreLoopStages\` | 496 | 318 | -36% |
| #531 (PR-L) | \`_runFlowInner\` | 399 | 162 | -59% |
| this (PR-M) | \`runHuReviewerStage\` | 311 | 239 | -23% |

## Test plan

- [x] \`npx vitest run\` — 4037/4037 green
- [x] \`tests/architecture/dynamic-imports.test.js\` — budget unchanged (≤150)
- [x] No new ESLint/lint warnings
- [ ] CI green