### PR TITLE
fix(orchestrator): tester verdict propagation + sonar state wiring + kj run --plan reads task

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -28,6 +28,7 @@ import { researcherCommand } from "./commands/researcher.js";
 import { architectCommand } from "./commands/architect.js";
 import { auditCommand } from "./commands/audit.js";
 import { boardCommand } from "./commands/board.js";
+import { loadPlan } from "./plan/plan-store.js";
 import { undoCommand } from "./commands/undo.js";
 import { statusCommand } from "./commands/status.js";
 import { cleanCommand } from "./commands/clean.js";
@@ -150,8 +151,24 @@ program
   .option("-v, --verbose", "Show full agent output (stream-json, raw lines)")
   .action(async (task, flags) => {
     await withConfig("run", flags, async ({ config, logger }) => {
+      // If `--plan <id>` was passed and the user didn't provide a task
+      // argument or --task-file, fall back to the task embedded in the
+      // plan JSON. The whole point of `kj plan generate` is that the
+      // task is captured once and re-used; forcing the user to repeat
+      // --task-file on every run is friction with no upside.
+      let effectiveTask = task;
+      if (!task && !flags.taskFile && flags.plan) {
+        // config.projectDir is only populated post-init; before runFlow
+        // it can still be undefined. Plans are stored under cwd, so
+        // that's the correct fallback for the lookup.
+        const projectDir = config.projectDir || process.cwd();
+        const plan = await loadPlan(projectDir, flags.plan);
+        if (plan?.task && String(plan.task).trim()) {
+          effectiveTask = plan.task;
+        }
+      }
       const { resolveTaskInput } = await import("./utils/task-file.js");
-      const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+      const resolvedTask = await resolveTaskInput({ task: effectiveTask, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
       await runCommandHandler({ task: resolvedTask, config, logger, flags });
     });
   });

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -144,6 +144,16 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
               const sonarResult = await runSonarStage({
                 config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
                 session: ctx.session, trackBudget: ctx.trackBudget, iteration: attempt,
+                // sonarState is required: runSonarStage reads/writes
+                // .issuesInitial / .issuesFinal on it. Forgetting this
+                // surfaces as `Cannot read properties of undefined
+                // (reading 'issuesInitial')` and the catch below swallows
+                // it as "sonar stage failed (non-blocking)" — the gate
+                // never actually runs for the HU, every iteration burns
+                // budget for nothing. Mirrors iteration-loop.js.
+                sonarState: ctx.sonarState,
+                repeatDetector: ctx.repeatDetector,
+                budgetSummary: ctx.budgetSummary,
                 askQuestion, brainCtx: ctx.brainCtx
               });
               if (sonarResult?.action === "continue") {

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -167,7 +167,22 @@ export async function runTesterStage({ config, logger, emitter, eventBase, sessi
   }
 
   resetRetryCount(session, "tester");
-  return { action: "ok", stageResult: { ok: true, summary: testerOutput.summary || "All tests passed" } };
+  // Propagate the full tester result (verdict, failing_scenarios,
+  // translated_scenarios, coverage…) — not just {ok, summary}. Callers
+  // in the HU sub-pipeline read `stageResult.verdict === "pass"` to
+  // decide approve-vs-feedback when Gherkin translation is involved;
+  // dropping the verdict here forced every Gherkin-bearing HU into the
+  // "fail" branch even when the tester explicitly returned pass, which
+  // burned all max_iterations and broke the FASE-2 test-diet run.
+  return {
+    action: "ok",
+    stageResult: {
+      ...testerOutput.result,
+      ok: true,
+      summary: testerOutput.summary || "All tests passed",
+      provider: testerProvider,
+    },
+  };
 }
 
 export async function runSecurityStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, askQuestion, brainCtx }) {

--- a/src/orchestrator/stages/sonar-stage.js
+++ b/src/orchestrator/stages/sonar-stage.js
@@ -123,6 +123,20 @@ async function handleSonarBlocking({ sonarResult, config, logger, emitter, event
 }
 
 export async function runSonarStage({ config, logger, emitter, eventBase, session, trackBudget, iteration, repeatDetector, budgetSummary, sonarState, askQuestion, task, brainCtx }) {
+  // Required-input guards. Without these, the bug class that broke the
+  // FASE-2 run on 2026-04-29 (run-hu-batch.js called runSonarStage
+  // without sonarState) is silent: the stage threw `Cannot read
+  // properties of undefined (reading 'issuesInitial')` later, the HU
+  // sub-pipeline's catch swallowed it as "non-blocking", and the
+  // Sonar gate effectively never ran. Failing fast here surfaces the
+  // missing wiring at the first iteration so any new caller fixes it
+  // before burning budget.
+  if (!sonarState || typeof sonarState !== "object") {
+    throw new Error("runSonarStage: `sonarState` is required (object with issuesInitial/issuesFinal slots — usually ctx.sonarState).");
+  }
+  if (!session) {
+    throw new Error("runSonarStage: `session` is required.");
+  }
   logger.setContext({ iteration, stage: "sonar" });
   emitProgress(
     emitter,

--- a/tests/iteration-stages-unit.test.js
+++ b/tests/iteration-stages-unit.test.js
@@ -385,6 +385,34 @@ describe("iteration-stages: runSonarStage", () => {
     // Solomon mock returns { action: "continue" }, so sonar stage continues
     expect(result.action).toBe("continue");
   });
+
+  it("throws a clear error when called without sonarState (regression: silent run-hu-batch wiring bug)", async () => {
+    // Pre-fix, run-hu-batch.js called runSonarStage without sonarState.
+    // The stage didn't notice until line 300 (`sonarState.issuesInitial`)
+    // and threw `Cannot read properties of undefined`. Higher up, the
+    // HU sub-pipeline's catch logged it as "non-blocking" and the gate
+    // never actually evaluated — every iteration burned budget against
+    // a Sonar that, from the orchestrator's POV, hadn't run. Failing
+    // fast at the function boundary surfaces the missing wiring on the
+    // first call so any new caller fixes it before launching agents.
+    await expect(runSonarStage({
+      config: makeConfig(), logger, emitter, eventBase,
+      session: makeSession(), trackBudget, iteration: 1,
+      repeatDetector, budgetSummary,
+      // sonarState intentionally omitted
+      askQuestion: null, task: "do X",
+    })).rejects.toThrow(/sonarState.*required/i);
+  });
+
+  it("throws a clear error when called without session (defense-in-depth for the same wiring class)", async () => {
+    const sonarState = { issuesInitial: null, issuesFinal: null };
+    await expect(runSonarStage({
+      config: makeConfig(), logger, emitter, eventBase,
+      // session intentionally omitted
+      trackBudget, iteration: 1,
+      repeatDetector, budgetSummary, sonarState, askQuestion: null, task: "do X",
+    })).rejects.toThrow(/session.*required/i);
+  });
 });
 
 describe("iteration-stages: runReviewerStage", () => {

--- a/tests/orchestrator-post-loop.test.js
+++ b/tests/orchestrator-post-loop.test.js
@@ -90,6 +90,45 @@ describe("post-loop-stages", () => {
       expect(result.action).toBe("continue");
       expect(result.stageResult.summary).toBe("Tests failing");
     });
+
+    it("propagates verdict + failing_scenarios + translated_scenarios on the OK path (regression: FASE-2 run blocker)", async () => {
+      // Pre-fix, the OK return shape was just { ok, summary } — losing the
+      // verdict, failing_scenarios, translated_scenarios that the role
+      // produced. Callers in run-hu-batch.js read `stageResult.verdict`
+      // to decide approve-vs-feedback when Gherkin translation is in
+      // play; with the verdict undefined every Gherkin-bearing HU fell
+      // into the "fail" branch and burned all max_iterations on a tester
+      // that had actually passed. This pins the propagation so the
+      // mismatch can't come back.
+      testerRunMock.mockResolvedValueOnce({
+        ok: true,
+        summary: "Verdict: pass; Coverage: 78.7%; 1 scenario(s) translated",
+        result: {
+          verdict: "pass",
+          tests_pass: true,
+          coverage: { overall: 78.7 },
+          translated_scenarios: ["scenario A"],
+          failing_scenarios: [],
+          missing_scenarios: ["scenario B (deferred)"],
+        },
+      });
+      const session = { id: "s1", task: "t", checkpoints: [], tester_retry_count: 0 };
+
+      const result = await runTesterStage({
+        config: { session: {} }, logger, emitter, eventBase, session,
+        coderRole, trackBudget, iteration: 1, task: "t", diff: "diff",
+        pendingGherkinTests: [{ content: "Given … When … Then …" }],
+      });
+
+      expect(result.action).toBe("ok");
+      expect(result.stageResult.ok).toBe(true);
+      expect(result.stageResult.verdict).toBe("pass");
+      expect(result.stageResult.failing_scenarios).toEqual([]);
+      expect(result.stageResult.translated_scenarios).toEqual(["scenario A"]);
+      expect(result.stageResult.coverage).toEqual({ overall: 78.7 });
+      // summary is still set for compatibility with non-Gherkin callers.
+      expect(result.stageResult.summary).toContain("Coverage");
+    });
   });
 
   describe("runSecurityStage", () => {


### PR DESCRIPTION
## Summary

Three runtime bugs that together broke the FASE-2 test-diet run on 2026-04-29: every Gherkin-bearing HU exhausted \`max_iterations\` on a tester that had actually passed, while the Sonar quality gate effectively never ran.

## What was broken

### 1. \`runTesterStage\` dropped \`verdict\` on the OK return shape

When the tester passed, \`runTesterStage\` returned only \`{ ok, summary }\` — losing \`verdict\` / \`failing_scenarios\` / \`translated_scenarios\` from the role's output. The HU sub-pipeline reads \`stageResult.verdict === "pass"\` to decide approve-vs-feedback when Gherkin translation is in play; with verdict undefined, every Gherkin HU fell into the "fail" branch even when the tester explicitly returned pass. The diagnostic fed back to the coder ("scenario X failed: …") then echoed the tester's own pass-summary because \`failing_scenarios\` was also undefined.

### 2. \`run-hu-batch.js\` called \`runSonarStage\` without \`sonarState\`

The HU sub-pipeline path forgot \`sonarState\` (and \`repeatDetector\` / \`budgetSummary\`). The stage didn't notice until line 300 and threw \`Cannot read properties of undefined (reading 'issuesInitial')\`. The sub-pipeline's catch swallowed it as "sonar stage failed (non-blocking)" — the gate effectively never ran; iterations burned budget against a Sonar that hadn't started.

### 3. \`kj run --plan <id>\` required \`--task-file\` even though the plan stored the task

Friction in the dogfood loop. Plans persist the task at generation; the run command should reuse it.

## What this PR adds

| File | Change |
|---|---|
| \`src/orchestrator/post-loop-stages.js\` | Spread \`testerOutput.result\` into the OK stageResult so verdict + Gherkin fields survive. |
| \`src/orchestrator/drivers/run-hu-batch.js\` | Pass \`sonarState\` / \`repeatDetector\` / \`budgetSummary\` from \`ctx\`. |
| \`src/orchestrator/stages/sonar-stage.js\` | Required-input guards for \`sonarState\` / \`session\`. Fails at the function boundary instead of dying 130 lines deep. |
| \`src/cli.js\` | \`kj run --plan\` falls back to \`plan.task\` when no positional task / \`--task-file\` was given. |

## Regression pins

| Test | Why |
|---|---|
| \`tests/orchestrator-post-loop.test.js\` :: "propagates verdict + failing_scenarios + translated_scenarios on the OK path" | Verdict propagation. |
| \`tests/iteration-stages-unit.test.js\` :: "throws a clear error when called without sonarState" | Forces every future caller to wire it. |
| \`tests/iteration-stages-unit.test.js\` :: "throws a clear error when called without session" | Same defense-in-depth class. |

## Test plan

- [x] \`npx vitest run\` — 4082/4082
- [x] Manual: \`kj run --plan <id>\` (no \`--task-file\`) loads the plan's task.
- [x] Manual: a Gherkin-bearing HU now approves on first iteration when the tester returns pass.