### PR TITLE
fix(hu-sub-pipeline): plan is source of truth, reconcile stale on-disk batch

### DIFF
--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -301,6 +301,43 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
     };
   }
 
+  // Plan-driven runs: the plan JSON is the source of truth for HU
+  // statuses, NOT the on-disk hu-stories batch. Pre-fix, after a failed
+  // run left stories=['failed','blocked',…] on disk, manually resetting
+  // the plan back to all-certified did NOT clear the persisted batch.
+  // The next run loaded the stale disk batch, found zero `certified`
+  // stories, skipped the entire for-loop, and reported "All HUs
+  // completed successfully" for ZERO actual work — silently approving
+  // a run that never ran.
+  //
+  // Reconcile by overlaying the plan's authoritative status onto the
+  // persisted batch. We keep any in-flight context the disk batch may
+  // hold (worktree paths, partial refinement state) but trust the plan
+  // for what's runnable.
+  if (huReviewerResult.source?.plan === true && Array.isArray(huReviewerResult.stories)) {
+    const planById = new Map(huReviewerResult.stories.map((s) => [s.id, s]));
+    let reconciled = 0;
+    for (const persisted of batch.stories) {
+      const fromPlan = planById.get(persisted.id);
+      if (fromPlan && fromPlan.status !== persisted.status) {
+        persisted.status = fromPlan.status;
+        reconciled += 1;
+      }
+    }
+    // Stories present in the plan but missing from disk → append.
+    const persistedIds = new Set(batch.stories.map((s) => s.id));
+    for (const fromPlan of huReviewerResult.stories) {
+      if (!persistedIds.has(fromPlan.id)) {
+        batch.stories.push(fromPlan);
+        reconciled += 1;
+      }
+    }
+    if (reconciled > 0) {
+      logger.info(`HU sub-pipeline: reconciled ${reconciled} story status(es) from plan (disk batch was stale)`);
+      await saveHuBatch(batchSessionId, batch);
+    }
+  }
+
   const certifiedStories = batch.stories.filter(s => s.status === HU_STATUS.CERTIFIED);
   let orderedIds;
   try {

--- a/tests/hu-sub-pipeline.test.js
+++ b/tests/hu-sub-pipeline.test.js
@@ -266,6 +266,91 @@ describe("hu-sub-pipeline", () => {
     });
   });
 
+  describe("runHuSubPipeline — plan is source of truth, stale on-disk batch is reconciled", () => {
+    it("overlays plan statuses onto persisted batch when source is plan (regression: 'All HUs completed successfully' for zero work)", async () => {
+      // Pre-fix scenario, paraphrasing 2026-04-29 incident:
+      //   1. A previous run failed → on-disk batch.json had
+      //      stories=[{ status: 'failed' }, { status: 'blocked' }, …].
+      //   2. User reset the plan JSON manually (all HUs back to
+      //      'certified') and relaunched.
+      //   3. runHuSubPipeline loaded the STALE on-disk batch and ran
+      //      `batch.stories.filter(s => s.status === 'certified')` —
+      //      empty array. The for-loop never executed. allApproved
+      //      stayed true vacuously. The orchestrator emitted
+      //      "All HUs completed successfully" for ZERO work and
+      //      reported approved=true.
+      // The fix: when source.plan === true, the plan's HU statuses
+      // win over the persisted batch (the plan JSON is authoritative
+      // for plan-driven runs).
+      const persistedBatch = {
+        session_id: "plan-plan-X",
+        stories: [
+          { id: "HU-001", status: "failed",  original: { text: "1" }, blocked_by: [] },
+          { id: "HU-002", status: "blocked", original: { text: "2" }, blocked_by: ["HU-001"] },
+          { id: "HU-003", status: "blocked", original: { text: "3" }, blocked_by: ["HU-002"] },
+        ],
+      };
+      loadHuBatchMock.mockResolvedValue(persistedBatch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      const huReviewerResult = {
+        ok: true,
+        certified: 3,
+        total: 3,
+        // The plan JSON says all certified — this is the truth.
+        stories: [
+          { id: "HU-001", status: "certified", original: { text: "1" }, blocked_by: [] },
+          { id: "HU-002", status: "certified", original: { text: "2" }, blocked_by: ["HU-001"] },
+          { id: "HU-003", status: "certified", original: { text: "3" }, blocked_by: ["HU-002"] },
+        ],
+        batchSessionId: "plan-plan-X",
+        source: { plan: true, planId: "plan-X" },
+      };
+
+      const result = await runHuSubPipeline({
+        huReviewerResult, runIterationFn, emitter, eventBase, logger,
+      });
+
+      // Coder ran for every HU — not zero like the bug.
+      expect(runIterationFn).toHaveBeenCalledTimes(3);
+      expect(result.approved).toBe(true);
+      expect(result.results).toHaveLength(3);
+      // The reconciled batch was persisted back so subsequent reads
+      // don't re-encounter the stale state.
+      expect(saveHuBatchMock).toHaveBeenCalled();
+    });
+
+    it("does NOT touch the persisted batch when source is not plan (auto-HU runs)", async () => {
+      // Auto-generated HU runs (no plan) should keep the original
+      // behaviour — disk batch wins, no reconciliation.
+      const persistedBatch = {
+        session_id: "auto-s_X",
+        stories: [
+          { id: "HU-001", status: "certified", original: { text: "1" }, blocked_by: [] },
+        ],
+      };
+      loadHuBatchMock.mockResolvedValue(persistedBatch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+      const huReviewerResult = {
+        ok: true, certified: 1, total: 1,
+        stories: [{ id: "HU-001", status: "certified", original: { text: "1" }, blocked_by: [] }],
+        batchSessionId: "auto-s_X",
+        // No source.plan → reconciliation skipped.
+        auto_generated: true,
+      };
+
+      await runHuSubPipeline({
+        huReviewerResult, runIterationFn, emitter, eventBase, logger,
+      });
+      // No "reconciled" log line should fire.
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.stringMatching(/reconciled \d+ story status/),
+      );
+    });
+  });
+
   describe("runHuSubPipeline — failed HU blocks dependents", () => {
     it("when HU-001 fails, HU-002 (which depends on it) is blocked", async () => {
       const stories = [


### PR DESCRIPTION
## Summary

Yet another silent-failure bug uncovered by re-running the FASE-2 test diet on 2026-04-29: the orchestrator reported "All HUs completed successfully" for **zero actual work**.

## What was broken

1. A previous run failed → \`~/.karajan/hu-stories/<batchSessionId>/batch.json\` was persisted with \`stories=[{status:'failed'},{status:'blocked'},…]\`.
2. The user reset the plan JSON manually (all HUs back to \`certified\`) and relaunched.
3. \`runHuSubPipeline\` loaded the STALE on-disk batch and filtered \`s.status === "certified"\` — empty array.
4. The for-loop never executed. \`allApproved\` stayed \`true\` vacuously. The orchestrator emitted **"All HUs completed successfully"** for **ZERO** real work, reported \`approved=true\`, and returned to the shell as if the run had been a victory.

The plan JSON is the source of truth for plan-driven runs; the persisted hu-stories batch is a sync mirror, not authoritative. The sub-pipeline trusted the disk anyway.

## Fix

In \`runHuSubPipeline\`, when \`huReviewerResult.source?.plan === true\`, overlay the plan's authoritative status onto each persisted story before the for-loop runs. Append plan stories missing from disk. Save the reconciled batch so subsequent reads see fresh state.

Auto-HU runs (no plan) keep the original behaviour.

## Tests

| Test | Why |
|---|---|
| "overlays plan statuses onto persisted batch when source is plan" | Asserts coder ran 3 times for 3 stale-but-actually-certified HUs and \`saveHuBatch\` was called to persist the reconciled state. |
| "does NOT touch the persisted batch when source is not plan" | Pins the auto-HU path stays untouched. |

Full suite: 4084/4084.