### PR TITLE
fix(hu-sub-pipeline): reconcile FULL HU content from plan, not just status (#543)

### DIFF
--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -301,39 +301,71 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
     };
   }
 
-  // Plan-driven runs: the plan JSON is the source of truth for HU
-  // statuses, NOT the on-disk hu-stories batch. Pre-fix, after a failed
-  // run left stories=['failed','blocked',…] on disk, manually resetting
-  // the plan back to all-certified did NOT clear the persisted batch.
-  // The next run loaded the stale disk batch, found zero `certified`
-  // stories, skipped the entire for-loop, and reported "All HUs
-  // completed successfully" for ZERO actual work — silently approving
-  // a run that never ran.
+  // Plan-driven runs: the plan JSON is the source of truth for the
+  // ENTIRE HU, NOT just status, NOT the on-disk hu-stories batch.
   //
-  // Reconcile by overlaying the plan's authoritative status onto the
-  // persisted batch. We keep any in-flight context the disk batch may
-  // hold (worktree paths, partial refinement state) but trust the plan
-  // for what's runnable.
+  // PR #537 reconciled `status` and fixed the "All HUs completed
+  // successfully for zero work" bug. But status is only ONE field of
+  // the HU. The 2026-04-29 incident hit a different field — a user
+  // edited the plan JSON to fix a broken jq query inside the HU's
+  // `acceptance_tests`, but the persisted batch kept the broken
+  // version, so the acceptance runner used the broken test, the coder
+  // burned every iteration trying to make an irreparable test pass,
+  // and the HU failed.
+  //
+  // Treat the plan as authoritative for ALL content fields the user
+  // might edit between runs (acceptance_tests, title, scope,
+  // blocked_by, spec_section, original.text). In-flight runtime
+  // context that doesn't live in the plan (worktree path, refinement
+  // state, certification quality scores, context_requests) is
+  // preserved.
   if (huReviewerResult.source?.plan === true && Array.isArray(huReviewerResult.stories)) {
+    // Fields the plan owns. Anything NOT in this set is preserved
+    // from the persisted batch (in-flight runtime state).
+    const PLAN_OWNED_FIELDS = [
+      "status",
+      "title",
+      "scope",
+      "blocked_by",
+      "acceptance_tests",
+      "acceptance_criteria",
+      "spec_section",
+      "task_type",
+      "certified",   // canonical HU body
+      "original",    // original text reference
+    ];
     const planById = new Map(huReviewerResult.stories.map((s) => [s.id, s]));
-    let reconciled = 0;
+    let statusChanges = 0;
+    let contentChanges = 0;
     for (const persisted of batch.stories) {
       const fromPlan = planById.get(persisted.id);
-      if (fromPlan && fromPlan.status !== persisted.status) {
-        persisted.status = fromPlan.status;
-        reconciled += 1;
+      if (!fromPlan) continue;
+      for (const field of PLAN_OWNED_FIELDS) {
+        if (!(field in fromPlan)) continue;
+        const before = JSON.stringify(persisted[field]);
+        const after = JSON.stringify(fromPlan[field]);
+        if (before === after) continue;
+        persisted[field] = fromPlan[field];
+        if (field === "status") statusChanges += 1;
+        else contentChanges += 1;
       }
     }
     // Stories present in the plan but missing from disk → append.
     const persistedIds = new Set(batch.stories.map((s) => s.id));
+    let appended = 0;
     for (const fromPlan of huReviewerResult.stories) {
       if (!persistedIds.has(fromPlan.id)) {
         batch.stories.push(fromPlan);
-        reconciled += 1;
+        appended += 1;
       }
     }
-    if (reconciled > 0) {
-      logger.info(`HU sub-pipeline: reconciled ${reconciled} story status(es) from plan (disk batch was stale)`);
+    const totalChanges = statusChanges + contentChanges + appended;
+    if (totalChanges > 0) {
+      const parts = [];
+      if (statusChanges > 0) parts.push(`${statusChanges} status`);
+      if (contentChanges > 0) parts.push(`${contentChanges} content field(s)`);
+      if (appended > 0) parts.push(`${appended} appended`);
+      logger.info(`HU sub-pipeline: reconciled from plan — ${parts.join(", ")} (disk batch was stale)`);
       await saveHuBatch(batchSessionId, batch);
     }
   }

--- a/tests/hu-sub-pipeline.test.js
+++ b/tests/hu-sub-pipeline.test.js
@@ -346,8 +346,96 @@ describe("hu-sub-pipeline", () => {
       });
       // No "reconciled" log line should fire.
       expect(logger.info).not.toHaveBeenCalledWith(
-        expect.stringMatching(/reconciled \d+ story status/),
+        expect.stringMatching(/reconciled .* from plan/),
       );
+    });
+
+    it("overlays acceptance_tests from plan when persisted batch has stale tests (regression #543)", async () => {
+      // 2026-04-29 incident: planner emitted a buggy jq query in
+      // acceptance_tests, run failed, batch.json persisted the broken
+      // test, user manually fixed it in the plan JSON and relaunched —
+      // but acceptance_tests was NOT reconciled, only status was. The
+      // acceptance runner read the broken test from the persisted
+      // batch every iteration. Coder couldn't fix it (irreparable).
+      // HU 002 → failed → 7 dependents blocked.
+      const persistedBatch = {
+        session_id: "plan-plan-X",
+        stories: [
+          {
+            id: "HU-001",
+            status: "certified",
+            original: { text: "1" },
+            blocked_by: [],
+            acceptance_tests: [{ type: "shell", content: "jq -e 'BROKEN as $n | $n.foo == .bar' file.json" }],
+            title: "Stale title",
+          },
+        ],
+      };
+      loadHuBatchMock.mockResolvedValue(persistedBatch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+      const huReviewerResult = {
+        ok: true, certified: 1, total: 1,
+        stories: [{
+          id: "HU-001",
+          status: "certified",
+          original: { text: "1" },
+          blocked_by: [],
+          acceptance_tests: [{ type: "shell", content: "jq -e '.foo == .bar' file.json" }],  // FIXED
+          title: "Fixed title",
+        }],
+        batchSessionId: "plan-plan-X",
+        source: { plan: true, planId: "plan-X" },
+      };
+
+      await runHuSubPipeline({
+        huReviewerResult, runIterationFn, emitter, eventBase, logger,
+      });
+
+      // The persisted batch we passed in was MUTATED to carry the
+      // plan's acceptance_tests + title.
+      expect(persistedBatch.stories[0].acceptance_tests[0].content)
+        .toBe("jq -e '.foo == .bar' file.json");
+      expect(persistedBatch.stories[0].title).toBe("Fixed title");
+      // Reconciled state was saved back to disk.
+      expect(saveHuBatchMock).toHaveBeenCalled();
+      // Log differentiates content from status.
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringMatching(/content field\(s\)/),
+      );
+    });
+
+    it("preserves in-flight runtime fields not owned by the plan (worktree path, refinement state)", async () => {
+      // The reconcile must NOT clobber per-run state (worktree paths
+      // assigned by the parallel executor, refinement state, etc.).
+      // We pin a few non-plan fields.
+      const persistedBatch = {
+        session_id: "plan-plan-X",
+        stories: [{
+          id: "HU-001",
+          status: "certified",
+          original: { text: "1" },
+          blocked_by: [],
+          acceptance_tests: [{ type: "shell", content: "echo 1" }],
+          // Runtime-only state — must survive reconcile:
+          context_requests: [{ id: "ctx-1", question: "?" }],
+          quality: { score: 0.9 },
+        }],
+      };
+      loadHuBatchMock.mockResolvedValue(persistedBatch);
+
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+      const huReviewerResult = {
+        ok: true, certified: 1, total: 1,
+        stories: [{ id: "HU-001", status: "certified", original: { text: "1" }, blocked_by: [], acceptance_tests: [{ type: "shell", content: "echo 1" }] }],
+        batchSessionId: "plan-plan-X",
+        source: { plan: true },
+      };
+
+      await runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger });
+
+      expect(persistedBatch.stories[0].context_requests).toEqual([{ id: "ctx-1", question: "?" }]);
+      expect(persistedBatch.stories[0].quality).toEqual({ score: 0.9 });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #543. Direct extension of PR #537.

## Why

PR #537 reconciles HU \`status\` between the plan JSON and the persisted on-disk batch. That fixed the "All HUs completed successfully for zero work" bug. But \`status\` is only ONE field of an HU.

2026-04-29 incident: planner emitted a syntactically-broken \`jq\` query inside HU 002's \`acceptance_tests\`. User fixed the plan JSON manually and relaunched. #537 reconciled status (correct). But \`acceptance_tests\` was NOT reconciled — acceptance runner read the broken test from the persisted batch every iteration, coder couldn't fix it (irreparable), HU 002 → failed → 7 dependents blocked. Same root cause, different field.

## What this PR does

In plan-driven runs (\`huReviewerResult.source?.plan === true\`), overlay every plan-owned field onto the persisted story:

- \`status\`
- \`title\`
- \`scope\`
- \`blocked_by\`
- \`acceptance_tests\`
- \`acceptance_criteria\`
- \`spec_section\`
- \`task_type\`
- \`certified\`
- \`original\`

Runtime-only fields are explicitly preserved (NOT reconciled):
- \`context_requests\`
- \`quality\` (certification scores)
- \`worktree_path\` (when set by parallel executor)
- \`refinement_state\`

Reconcile log differentiates content vs status: \`reconciled from plan — N status, M content field(s), K appended\`.

## Tests

| Test | Why |
|---|---|
| "overlays acceptance_tests from plan when persisted batch has stale tests" | The exact 2026-04-29 incident, pinned. |
| "preserves in-flight runtime fields not owned by the plan" | Pins context_requests + quality survive reconcile. |
| (existing) "overlays plan statuses onto persisted batch" | Still passes — status is now part of the broader content sweep. |
| (existing) "does NOT touch the persisted batch when source is not plan" | Auto-HU runs unaffected. |

Full suite: 4086/4086.