### PR TITLE
feat(repairer): runtime safety net for irreparable acceptance tests (#538)

### DIFF
--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -27,6 +27,8 @@ import { needsSubPipeline, runHuSubPipeline } from "../hu-sub-pipeline.js";
 import { runCoderStage } from "../stages/coder-stage.js";
 import { runSonarStage } from "../stages/sonar-stage.js";
 import { runIterationLoop } from "./iteration-loop.js";
+import { classifyFailure, createFailureTracker } from "../repair/repair-detector.js";
+import { runRepair } from "../repair/repair-runner.js";
 import { writeHistoryRecord } from "./post-loop.js";
 import { setReviewerFeedback } from "../../session/mutators.js";
 
@@ -107,6 +109,12 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       // concrete executable tests replace subjective reviewer opinions.
       if (story.acceptance_tests?.length > 0) {
         const { runAcceptanceTests, buildDiagnosticPrompt } = await import("../../hu/acceptance-runner.js");
+        // Issue #538 — Repairer runtime safety net. The tracker remembers
+        // each test's last failure signature; classifyFailure flags
+        // structural bugs (broken jq, shell parse error, missing tool)
+        // after 2 consecutive identical failures so we don't burn 5
+        // iterations against an irreparable test (the 2026-04-29 bug).
+        const failureTracker = createFailureTracker();
 
         for (let attempt = 1; attempt <= ctx.config.max_iterations; attempt++) {
           logger.info(`HU ${story.id}: coder iteration ${attempt}/${ctx.config.max_iterations}`);
@@ -232,6 +240,66 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
 
           // Brain diagnoses failures and sends concrete fix to coder
           const failed = testResult.results.filter(r => !r.passed);
+
+          // Repairer (#538): for each failing shell test, see if it's been
+          // failing the same way 2× in a row AND looks structurally broken
+          // (jq syntax, shell parse error, missing tool, etc.). If yes,
+          // invoke RepairerRole to rewrite the test in the plan + batch
+          // before iterating again. If unfixable, escalate (fail the HU
+          // immediately rather than burn the rest of max_iterations).
+          let repairedAny = false;
+          let repairEscalate = null;
+          for (const f of failed) {
+            if (f.type !== "shell") continue;
+            const consecutive = failureTracker.record(f.cmd, f.output);
+            const cls = classifyFailure({
+              cmd: f.cmd, errorOutput: f.output, consecutive,
+            });
+            if (!cls.infeasible) continue;
+            const testIndex = story.acceptance_tests.findIndex((t) => {
+              const c = typeof t === "object" ? t.content : t;
+              return c === f.cmd;
+            });
+            if (testIndex < 0) continue;
+            // Mutate `story.acceptance_tests` in place. The same story
+            // reference lives inside runHuSubPipeline's batch (passed
+            // by ref), so the next iteration's acceptance runner sees
+            // the fixed test without us needing batch+batchSessionId
+            // in this scope. The reconcile from PR #544 will sync the
+            // plan JSON on the next run.
+            const repair = await runRepair({
+              story, testIndex, errorOutput: f.output,
+              batchSessionId: ctx.stageResults.huReviewer.batchSessionId,
+              // batch unavailable in this closure scope — runRepair
+              // gates saveHuBatch on its presence and skips when
+              // missing; the in-memory mutation alone is sufficient
+              // for the next acceptance run within this same HU loop.
+              batch: null,
+              config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
+              failureKind: cls.kind,
+              savePlanPatch: null,
+            });
+            if (repair.escalate) { repairEscalate = repair.reason; break; }
+            if (repair.repaired) {
+              repairedAny = true;
+              failureTracker.reset(f.cmd);
+            }
+          }
+
+          if (repairEscalate) {
+            logger.warn(`HU ${story.id}: Repairer escalated — ${repairEscalate}`);
+            return { approved: false, sessionId: ctx.session.id, reason: "repair_escalated" };
+          }
+          if (repairedAny) {
+            // Tests were rewritten — restart iteration with the fixed
+            // tests in place; do NOT increment attempt against the user
+            // because the failure was the planner's bug, not the coder's.
+            logger.info(`HU ${story.id}: Repairer fixed test(s); restarting acceptance gate without consuming iteration`);
+            attempt -= 1;
+            continue;
+          }
+
+          // No repair happened — normal coder feedback path.
           const diagnostic = buildDiagnosticPrompt(failed);
           logger.warn(`HU ${story.id}: ${failed.length} acceptance test(s) FAILED — sending diagnostic to coder`);
           setReviewerFeedback(ctx.session, diagnostic);

--- a/src/orchestrator/repair/repair-detector.js
+++ b/src/orchestrator/repair/repair-detector.js
@@ -1,0 +1,117 @@
+/**
+ * Heuristics for classifying an acceptance-test failure as "possibly
+ * infeasible" — i.e. the test itself looks broken, not the code.
+ *
+ * Used by the HU sub-pipeline to decide when to invoke the Repairer
+ * role instead of feeding the failure back to the coder for ANOTHER
+ * iteration. Each iteration costs real money + time; classifying
+ * misroutes is the difference between a 3-minute repair and a
+ * 30-minute budget burn.
+ *
+ * The classifier is deliberately CONSERVATIVE: false negatives
+ * (treating a broken test as just-failed) cost an extra iteration;
+ * false positives (treating a real failure as infeasible) waste a
+ * Repairer call AND give the coder a spec change it shouldn't
+ * receive. We err toward false negatives.
+ */
+
+/**
+ * Signatures that strongly suggest the TEST is broken, not the code.
+ * Each is a regex applied to the failing command's stderr+stdout.
+ */
+const INFEASIBLE_SIGNATURES = [
+  // jq: `length as $n | .field` after a transform — the binding doesn't
+  // change the value flowing through, so `.field` is applied to the wrong
+  // thing. Real-world example from 2026-04-29: "Cannot index array with
+  // string \"filesOver300LOC\"".
+  { kind: "jq-as-binding-misuse", re: /Cannot index array with string/i },
+  // bash -n / shell parse errors before the command even runs.
+  { kind: "shell-parse-error", re: /syntax error|unexpected token|unexpected EOF/i },
+  // jq: invalid query syntax detected by jq itself.
+  { kind: "jq-syntax", re: /jq: error \(at .*\): (?!Cannot index)/i },
+  // command not found = test references a tool that doesn't exist in
+  // this environment. Could be a fixable typo or a real env mismatch.
+  { kind: "missing-tool", re: /command not found|: not found$|No such file or directory.*\.(sh|mjs|js|py)/im },
+  // jq fails to parse the JSON input — the input file is wrong, the
+  // path is wrong, or the assumed schema is off.
+  { kind: "jq-parse-input", re: /jq: error: Could not (open|parse)/i },
+];
+
+/**
+ * Compute a stable signature for a single failing test outcome — the
+ * test command + a normalized error fingerprint. Used to detect when
+ * the SAME test is failing the SAME way across iterations; that's the
+ * pattern that argues for a Repairer call (vs. a coder retry).
+ *
+ * @param {string} cmd
+ * @param {string} errorOutput
+ * @returns {string}
+ */
+export function failureSignature(cmd, errorOutput) {
+  const cmdNorm = String(cmd || "").trim().slice(0, 200);
+  const errNorm = String(errorOutput || "")
+    .replace(/\s+/g, " ")        // collapse whitespace
+    .replace(/\d+/g, "N")          // numbers tend to drift; line numbers, counts
+    .replace(/\/[^\s]+/g, "/PATH") // absolute paths drift across runs
+    .trim()
+    .slice(0, 300);
+  return `${cmdNorm}|||${errNorm}`;
+}
+
+/**
+ * Classify a single test failure as `infeasible` or `regular`.
+ *
+ * @param {object} args
+ * @param {string} args.cmd          — the command that ran
+ * @param {string} args.errorOutput  — stdout + stderr from the failing run
+ * @param {number} args.consecutive  — how many iterations in a row this
+ *                                      same signature has failed
+ * @param {number} [args.threshold=2] — min consecutive failures before
+ *                                       infeasibility is even considered.
+ *                                       Below this, we always say "regular"
+ *                                       (let the coder try once more).
+ * @returns {{infeasible: boolean, kind: string|null, signature: string}}
+ */
+export function classifyFailure({ cmd, errorOutput, consecutive, threshold = 2 }) {
+  const signature = failureSignature(cmd, errorOutput);
+  if (!Number.isFinite(consecutive) || consecutive < threshold) {
+    return { infeasible: false, kind: null, signature };
+  }
+  for (const sig of INFEASIBLE_SIGNATURES) {
+    if (sig.re.test(errorOutput || "")) {
+      return { infeasible: true, kind: sig.kind, signature };
+    }
+  }
+  return { infeasible: false, kind: null, signature };
+}
+
+/**
+ * Track consecutive identical failures across iterations of the same HU.
+ * Caller passes the same instance across iterations; the tracker
+ * remembers the last signature per command.
+ */
+export function createFailureTracker() {
+  // Map<cmd, { signature, count }>
+  const state = new Map();
+  return {
+    /**
+     * Record a failure and return how many consecutive iterations have
+     * produced the same signature for this cmd.
+     * @returns {number}
+     */
+    record(cmd, errorOutput) {
+      const signature = failureSignature(cmd, errorOutput);
+      const prev = state.get(cmd);
+      if (prev && prev.signature === signature) {
+        prev.count += 1;
+        return prev.count;
+      }
+      state.set(cmd, { signature, count: 1 });
+      return 1;
+    },
+    /** Reset tracker for a cmd that just passed (stops false positives). */
+    reset(cmd) { state.delete(cmd); },
+    /** Diagnostic: dump current state. */
+    snapshot() { return Object.fromEntries(state); },
+  };
+}

--- a/src/orchestrator/repair/repair-runner.js
+++ b/src/orchestrator/repair/repair-runner.js
@@ -1,0 +1,142 @@
+/**
+ * Repair runner — orchestrates the Repairer role end-to-end.
+ *
+ * Called from run-hu-batch when an acceptance test failure has been
+ * classified as `infeasible` by repair-detector. The runner:
+ *   1. Builds the prompt context (failing test, error output, HU
+ *      intent, sibling tests).
+ *   2. Invokes RepairerRole.
+ *   3. If verdict=fixable: patches the plan JSON's acceptance_tests
+ *      AND the in-memory batch story so the next coder iteration sees
+ *      the corrected test. Saves both. Returns { repaired: true }.
+ *   4. If verdict=unfixable: returns { repaired: false, escalate: true,
+ *      reason } so the caller can hand off to Solomon / FDE.
+ *   5. If RepairerRole itself fails (agent error): returns
+ *      { repaired: false, escalate: false, error } so the caller
+ *      decides whether to retry coder or escalate.
+ */
+
+import { RepairerRole } from "../../roles/repairer-role.js";
+import { saveHuBatch } from "../../hu/store.js";
+import { emitProgress, makeEvent } from "../../utils/events.js";
+
+/**
+ * @param {object} args
+ * @param {object} args.story       — the HU story object (in-memory batch slice). MUTATED.
+ * @param {number} args.testIndex   — index in story.acceptance_tests of the failing test.
+ * @param {string} args.errorOutput — last failing run's stderr+stdout.
+ * @param {string} args.batchSessionId
+ * @param {object} args.batch       — full batch object. MUTATED (story is a slice).
+ * @param {object} args.config
+ * @param {object} args.logger
+ * @param {object} args.emitter
+ * @param {object} args.eventBase
+ * @param {string} args.failureKind — repair-detector's `kind` (e.g. "jq-as-binding-misuse").
+ * @param {Function} [args.savePlanPatch] — async (huId, fieldPatch) => void; if provided,
+ *                                          patches the plan JSON on disk too.
+ * @returns {Promise<{repaired: boolean, escalate?: boolean, reason?: string, error?: string}>}
+ */
+export async function runRepair({
+  story, testIndex, errorOutput, batchSessionId, batch,
+  config, logger, emitter, eventBase, failureKind, savePlanPatch,
+}) {
+  if (!story || !Array.isArray(story.acceptance_tests) || !story.acceptance_tests[testIndex]) {
+    return { repaired: false, escalate: false, error: "repair-runner: invalid story or testIndex" };
+  }
+
+  const failingTest = story.acceptance_tests[testIndex];
+  const siblingTests = story.acceptance_tests.filter((_, i) => i !== testIndex);
+
+  emitProgress(emitter, makeEvent("repair:start", { ...eventBase, stage: "repair" }, {
+    message: `Repairer invoked for HU ${story.id} test #${testIndex} (kind=${failureKind})`,
+    detail: {
+      huId: story.id,
+      testIndex,
+      testContent: typeof failingTest === "object" ? failingTest.content : failingTest,
+      kind: failureKind,
+    },
+  }));
+
+  const repairer = new RepairerRole({ config, logger, emitter });
+  await repairer.init({ task: story.scope || story.title || story.id, sessionId: batchSessionId, iteration: 0 });
+
+  let result;
+  try {
+    result = await repairer.run({
+      failingTest,
+      errorOutput,
+      huTitle: story.title || story.id,
+      huScope: story.scope || "",
+      siblingTests,
+      iteration: 0,
+    });
+  } catch (err) {
+    logger.warn(`Repairer threw: ${err.message}`);
+    emitProgress(emitter, makeEvent("repair:end", { ...eventBase, stage: "repair" }, {
+      status: "fail",
+      message: `Repairer error: ${err.message}`,
+      detail: { huId: story.id, testIndex },
+    }));
+    return { repaired: false, escalate: false, error: err.message };
+  }
+
+  if (!result?.ok) {
+    logger.warn(`Repairer failed: ${result?.summary || "unknown"}`);
+    emitProgress(emitter, makeEvent("repair:end", { ...eventBase, stage: "repair" }, {
+      status: "fail",
+      message: `Repairer could not produce a verdict: ${result?.summary || "unknown"}`,
+      detail: { huId: story.id, testIndex },
+    }));
+    return { repaired: false, escalate: false, error: result?.summary || "no verdict" };
+  }
+
+  const { verdict, fixed_test: fixedTest, reason } = result.result;
+
+  if (verdict === "unfixable") {
+    logger.info(`Repairer: HU ${story.id} test #${testIndex} unfixable — ${reason}`);
+    emitProgress(emitter, makeEvent("repair:end", { ...eventBase, stage: "repair" }, {
+      status: "escalate",
+      message: `Repairer: unfixable — ${reason}`,
+      detail: { huId: story.id, testIndex, reason },
+    }));
+    return { repaired: false, escalate: true, reason };
+  }
+
+  if (verdict !== "fixable" || !fixedTest) {
+    logger.warn(`Repairer returned unexpected verdict: ${verdict}`);
+    return { repaired: false, escalate: false, error: `unexpected verdict: ${verdict}` };
+  }
+
+  // Apply the fix in-memory and persist when we have the batch handle.
+  // Some callers can't pass `batch` from their scope (closure depth);
+  // the in-memory mutation of `story.acceptance_tests` is enough for
+  // the next iteration of the same HU loop because every acceptance
+  // run reads the live story object. Disk persistence is a "next run
+  // sees the fix too" optimisation; PR #544's reconcile keeps the
+  // plan JSON consistent across runs in either case.
+  story.acceptance_tests[testIndex] = fixedTest;
+  if (batch && batchSessionId) {
+    await saveHuBatch(batchSessionId, batch);
+  }
+
+  if (typeof savePlanPatch === "function") {
+    try {
+      await savePlanPatch(story.id, { acceptance_tests: story.acceptance_tests });
+    } catch (err) {
+      logger.warn(`Repairer: in-memory + batch fixed but plan-patch failed: ${err.message}`);
+    }
+  }
+
+  logger.info(`Repairer: HU ${story.id} test #${testIndex} REPAIRED — ${reason}`);
+  emitProgress(emitter, makeEvent("repair:end", { ...eventBase, stage: "repair" }, {
+    status: "ok",
+    message: `Repairer fixed HU ${story.id} test #${testIndex}: ${reason}`,
+    detail: {
+      huId: story.id,
+      testIndex,
+      reason,
+      fixedContent: typeof fixedTest === "object" ? fixedTest.content : fixedTest,
+    },
+  }));
+  return { repaired: true, reason };
+}

--- a/src/roles/repairer-role.js
+++ b/src/roles/repairer-role.js
@@ -1,0 +1,181 @@
+/**
+ * RepairerRole — repairs broken acceptance tests at runtime.
+ *
+ * The Brain calls this when an HU's acceptance test has failed N
+ * consecutive iterations with the same error signature, signalling
+ * that the test ITSELF may be the bug (not the implementation).
+ * Originated from the 2026-04-29 incident where the planner emitted
+ * a syntactically-broken jq query in HU 002's acceptance_tests; the
+ * coder iterated 3× trying to make an irreparable test pass; HU 002
+ * → failed → 7 dependents blocked.
+ *
+ * The role takes the failing test + its error output + HU intent and
+ * returns either a corrected test (`verdict: "fixable"` with
+ * `fixed_test`) or an escalation (`verdict: "unfixable"` with reason).
+ *
+ * Behaviour notes:
+ *  - The role MUST NOT soften assertions to make them pass — the test
+ *    defines the contract; this role's job is to make the test ASK
+ *    its question correctly, not weakly.
+ *  - The role MUST NOT rewrite a test to pass against the current
+ *    code. Code is measured against the test, not the other way.
+ *  - One bug per repair. If the test is layered with problems, return
+ *    the most blocking fix first; subsequent invocations handle the
+ *    rest.
+ */
+
+import { AgentRole } from "./agent-role.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
+  "Do NOT use any MCP tools. Focus only on diagnosing and (if possible) repairing a single broken acceptance test.",
+].join(" ");
+
+export class RepairerRole extends AgentRole {
+  constructor(opts) {
+    super({ ...opts, name: "repairer" });
+  }
+
+  resolveProvider() {
+    // Default to the same provider family the coder uses — keeps
+    // the repair attempt cheap and consistent. Per-role override
+    // works as for every other role.
+    return this.config?.roles?.repairer?.provider
+      || this.config?.roles?.coder?.provider
+      || this.config?.coder
+      || "claude";
+  }
+
+  /**
+   * Inputs:
+   *   - failingTest: the test object (`{ type, content }` or string).
+   *   - errorOutput: stdout+stderr from the last test run (truncated to
+   *     ~2KB to keep the prompt small).
+   *   - huTitle, huScope: intent context.
+   *   - siblingTests: the HU's other acceptance_tests (for consistency).
+   *   - iteration: how many coder iterations have already failed on this.
+   */
+  extractInput(input) {
+    if (typeof input === "string") {
+      return {
+        failingTest: input, errorOutput: "", huTitle: "", huScope: "",
+        siblingTests: [], iteration: 0, onOutput: null,
+      };
+    }
+    return {
+      failingTest: input?.failingTest ?? null,
+      errorOutput: input?.errorOutput ?? "",
+      huTitle: input?.huTitle ?? "",
+      huScope: input?.huScope ?? "",
+      siblingTests: Array.isArray(input?.siblingTests) ? input.siblingTests : [],
+      iteration: Number.isFinite(input?.iteration) ? input.iteration : 0,
+      onOutput: input?.onOutput ?? null,
+    };
+  }
+
+  async buildPrompt({ failingTest, errorOutput, huTitle, huScope, siblingTests, iteration }) {
+    const sections = [SUBAGENT_PREAMBLE];
+    if (this.instructions) sections.push(this.instructions);
+
+    const testContent = (failingTest && typeof failingTest === "object")
+      ? failingTest.content
+      : String(failingTest || "");
+    const testType = (failingTest && typeof failingTest === "object" && failingTest.type)
+      ? failingTest.type
+      : "shell";
+
+    sections.push(
+      "You are repairing a broken acceptance test. The coder has failed to satisfy it across multiple iterations,",
+      "and the Brain suspects the test ITSELF is the bug — not the implementation.",
+      "",
+      "## HU intent",
+      `Title: ${huTitle || "(unknown)"}`,
+      `Scope: ${huScope || "(unknown)"}`,
+      "",
+      `## Failing test (type: ${testType}, after ${iteration} iteration(s))`,
+      "```",
+      testContent,
+      "```",
+      "",
+      "## Last error output",
+      "```",
+      String(errorOutput || "").slice(0, 2048),
+      "```",
+    );
+
+    if (siblingTests.length > 0) {
+      sections.push("## HU's other acceptance tests (for consistency — do NOT modify these)", "```");
+      for (const t of siblingTests) {
+        const c = typeof t === "object" ? t.content : t;
+        sections.push(`- ${c}`);
+      }
+      sections.push("```");
+    }
+
+    sections.push(
+      "",
+      "## Your job",
+      "Decide whether the failing test is **fixable** (you can correct a syntactic / structural bug)",
+      "or **unfixable** (test is fundamentally impossible, or the test is correct and the code must change).",
+      "",
+      "Return ONLY a single valid JSON object:",
+      '{"verdict":"fixable"|"unfixable","fixed_test":{"type":"shell"|"gherkin","content":string}|null,"reason":string,"diagnostics":[string]}',
+      "",
+      "- When verdict=fixable, fixed_test is REQUIRED and reason describes the bug class.",
+      "- When verdict=unfixable, fixed_test is null and reason explains why.",
+      "- NEVER soften an assertion. NEVER rewrite to pass against current code.",
+    );
+
+    const projectDir = this.config?.projectDir || process.cwd();
+    const skills = await loadAvailableSkills(projectDir);
+    const skillSection = buildSkillSection(skills, {
+      provider: this._resolvedProvider || (typeof this.resolveProvider === "function" ? this.resolveProvider() : null),
+      role: "repairer",
+    });
+    if (skillSection) sections.push(skillSection);
+
+    return { prompt: sections.join("\n\n") };
+  }
+
+  parseOutput(raw) { return extractFirstJson(raw); }
+
+  isSuccessful(parsed) {
+    if (!parsed || typeof parsed !== "object") return false;
+    if (parsed.verdict === "fixable") {
+      // Must produce a complete fixed_test object.
+      const ft = parsed.fixed_test;
+      return Boolean(ft && typeof ft === "object" && typeof ft.content === "string" && ft.content.trim());
+    }
+    if (parsed.verdict === "unfixable") {
+      // Unfixable is a valid OUTCOME (escalation), not a role failure.
+      return Boolean(parsed.reason && String(parsed.reason).trim());
+    }
+    return false;
+  }
+
+  buildSuccessResult(parsed, provider) {
+    return {
+      verdict: parsed.verdict,
+      fixed_test: parsed.fixed_test || null,
+      reason: parsed.reason || "",
+      diagnostics: Array.isArray(parsed.diagnostics) ? parsed.diagnostics : [],
+      provider,
+    };
+  }
+
+  buildSummary(parsed) {
+    if (!parsed) return "Repairer: no parseable output";
+    if (parsed.verdict === "fixable") {
+      const reason = (parsed.reason || "").slice(0, 120);
+      return `Repairer: fixable — ${reason}`;
+    }
+    if (parsed.verdict === "unfixable") {
+      const reason = (parsed.reason || "").slice(0, 120);
+      return `Repairer: unfixable — ${reason}`;
+    }
+    return `Repairer: unexpected verdict "${parsed.verdict}"`;
+  }
+}

--- a/templates/roles/repairer.md
+++ b/templates/roles/repairer.md
@@ -1,0 +1,94 @@
+# Repairer Role
+
+You are the **Repairer** in a multi-role AI pipeline. Your single job is
+to look at a **failing acceptance test** that the coder has tried and
+failed to satisfy across multiple iterations, decide whether the test
+**itself** is broken (vs. the code), and — if it is — return a corrected
+test that preserves the original intent.
+
+## When you are invoked
+
+The Brain calls you when an HU's acceptance test has failed N
+consecutive iterations with the same error signature, and the coder
+cannot make it pass. The Brain has classified the failure as
+*possibly infeasible* (the test may itself be the problem, not the
+implementation under test).
+
+## Your task
+
+You receive:
+
+- The failing acceptance test (string or `{ type, content }`).
+- The most recent error output from running it.
+- The HU's title and scope so you understand intent.
+- A list of all of the HU's other acceptance tests (so any rewrite
+  stays consistent with them).
+
+Decide:
+
+1. **fixable**: the test has a syntactic / structural bug you can
+   correct (e.g. invalid `jq` query, wrong shell quoting, unreachable
+   path assumed to exist, command name typo). Return the corrected
+   test content.
+2. **unfixable**: the test is fundamentally impossible (asks for a
+   contradiction, depends on an external service that's unreachable,
+   the HU's intent itself is wrong). Escalate.
+
+## Diagnostic checklist (apply in order)
+
+For shell tests:
+- Does `bash -n -c '<cmd>'` parse? If not → syntax fix.
+- Does the test invoke `jq`? Run `echo '{}' | jq <query>` to check
+  the jq query parses. If "Cannot index array with string", the test
+  likely uses `as $n | .field` after a transform — restructure with
+  `as $r` binding the root.
+- Does the test reference a file path that the HU explicitly creates?
+  If the path doesn't match what the HU actually produces, fix the
+  path.
+- Does the test depend on a tool not in the project's runtime
+  (`pnpm` vs `npm` vs `yarn`, `python3` vs `python`)? Match what's
+  actually used.
+
+For Gherkin tests:
+- Are Given/When/Then well-formed? If a step is ambiguous, narrow it.
+- Does the test rely on state set up by another scenario? Inline the
+  setup or mark the scenario as needing the upstream HU.
+
+## When NOT to "fix"
+
+- The test is correct and the code is wrong → return `unfixable` with
+  reason `"test is correct; coder must fix the implementation"`. The
+  Brain will treat this as a normal failure, not as a repair.
+- The HU's intent contradicts the test (the HU asks to do A, the test
+  checks B) → return `unfixable` with reason `"intent mismatch"`.
+  This is an FDE problem, not a Repairer problem.
+
+## Output format
+
+Return ONLY a single valid JSON object:
+
+```json
+{
+  "verdict": "fixable" | "unfixable",
+  "fixed_test": { "type": "shell" | "gherkin", "content": "..." } | null,
+  "reason": "one-sentence explanation of what was wrong (or why unfixable)",
+  "diagnostics": ["any tool-output snippets you used to diagnose"]
+}
+```
+
+- When `verdict: "fixable"`, `fixed_test` is REQUIRED and `reason`
+  describes the bug class (e.g. `"jq query had 'as $n | .field' on
+  the array tail"`).
+- When `verdict: "unfixable"`, `fixed_test` is `null` and `reason`
+  explains why (`"test depends on Sonar 9000 reachable, network
+  isolated"`, `"intent mismatch — HU asks X, test checks Y"`).
+
+## Constraints
+
+- NEVER soften an assertion just to make it pass. If the test was
+  asking the right question, your job is to make it ask it correctly,
+  not weakly.
+- NEVER rewrite a test to pass against the CURRENT code. The test
+  defines the contract; the code is what's measured against it.
+- Keep changes minimal. One bug at a time. If the test has multiple
+  problems, fix the most blocking one first.

--- a/tests/repair/repair-detector.test.js
+++ b/tests/repair/repair-detector.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { classifyFailure, failureSignature, createFailureTracker } from "../../src/orchestrator/repair/repair-detector.js";
+
+describe("repair-detector / failureSignature", () => {
+  it("collapses whitespace and digits so flaky line numbers don't break dedup", () => {
+    const a = failureSignature("jq -e '.x' f.json", "jq: error at line 12: bad");
+    const b = failureSignature("jq -e '.x' f.json", "jq: error  at  line   99: bad");
+    expect(a).toBe(b);
+  });
+  it("normalises absolute paths so cwd differences don't break dedup", () => {
+    const a = failureSignature("cmd", "could not open /home/manu/foo");
+    const b = failureSignature("cmd", "could not open /tmp/work/foo");
+    expect(a).toBe(b);
+  });
+});
+
+describe("repair-detector / classifyFailure", () => {
+  it("returns infeasible=false when consecutive count is below threshold (lets coder retry once)", () => {
+    const r = classifyFailure({
+      cmd: "jq -e 'BROKEN'", errorOutput: "Cannot index array with string", consecutive: 1,
+    });
+    expect(r.infeasible).toBe(false);
+  });
+
+  it("flags 'jq as-binding misuse' (the 2026-04-29 incident) as infeasible after 2 consecutive failures", () => {
+    const r = classifyFailure({
+      cmd: "jq -e '[.x[]] | length as $n | .y == $n' f.json",
+      errorOutput: "jq: error (at f.json:1): Cannot index array with string \"y\"",
+      consecutive: 2,
+    });
+    expect(r.infeasible).toBe(true);
+    expect(r.kind).toBe("jq-as-binding-misuse");
+  });
+
+  it("flags shell parse errors as infeasible", () => {
+    const r = classifyFailure({
+      cmd: "echo 'hi", errorOutput: "syntax error: unexpected end of file", consecutive: 2,
+    });
+    expect(r.infeasible).toBe(true);
+    expect(r.kind).toBe("shell-parse-error");
+  });
+
+  it("flags missing tools as infeasible (typo or env mismatch)", () => {
+    const r = classifyFailure({
+      cmd: "yarn build", errorOutput: "yarn: command not found", consecutive: 2,
+    });
+    expect(r.infeasible).toBe(true);
+    expect(r.kind).toBe("missing-tool");
+  });
+
+  it("does NOT flag a normal assertion failure as infeasible (false-positive guard)", () => {
+    const r = classifyFailure({
+      cmd: "test -f foo && grep -q bar foo",
+      errorOutput: "false",   // typical jq -e exit-1 with no error message
+      consecutive: 5,
+    });
+    expect(r.infeasible).toBe(false);
+  });
+});
+
+describe("repair-detector / createFailureTracker", () => {
+  it("returns 1 on first record, increments on identical signature", () => {
+    const t = createFailureTracker();
+    expect(t.record("cmd-A", "err1")).toBe(1);
+    expect(t.record("cmd-A", "err1")).toBe(2);
+    expect(t.record("cmd-A", "err1")).toBe(3);
+  });
+
+  it("resets count when the error signature changes (different bug = different problem)", () => {
+    const t = createFailureTracker();
+    t.record("cmd-A", "err1");
+    t.record("cmd-A", "err1");
+    expect(t.record("cmd-A", "completely different error")).toBe(1);
+  });
+
+  it("tracks each cmd independently", () => {
+    const t = createFailureTracker();
+    t.record("cmd-A", "err");
+    t.record("cmd-B", "err");
+    t.record("cmd-A", "err");
+    expect(t.snapshot()["cmd-A"].count).toBe(2);
+    expect(t.snapshot()["cmd-B"].count).toBe(1);
+  });
+
+  it("reset() drops a cmd entirely (used after a passing run)", () => {
+    const t = createFailureTracker();
+    t.record("cmd-A", "err");
+    t.record("cmd-A", "err");
+    t.reset("cmd-A");
+    expect(t.record("cmd-A", "err")).toBe(1);
+  });
+});

--- a/tests/repair/repair-runner.test.js
+++ b/tests/repair/repair-runner.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+const repairerRunMock = vi.fn();
+const saveHuBatchMock = vi.fn(async () => {});
+
+vi.mock("../../src/roles/repairer-role.js", () => ({
+  RepairerRole: class {
+    async init() {}
+    async run(input) { return repairerRunMock(input); }
+  },
+}));
+
+vi.mock("../../src/hu/store.js", () => ({
+  saveHuBatch: (...a) => saveHuBatchMock(...a),
+}));
+
+const { runRepair } = await import("../../src/orchestrator/repair/repair-runner.js");
+
+describe("repair-runner / runRepair", () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn(), resetContext: vi.fn() };
+  let emitter, events;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitter = new EventEmitter();
+    events = [];
+    emitter.on("progress", (e) => events.push(e));
+  });
+
+  function makeStory() {
+    return {
+      id: "HU-001",
+      title: "Add audit script",
+      scope: "Generates JSON report",
+      acceptance_tests: [
+        { type: "shell", content: "echo ok" },
+        { type: "shell", content: "jq -e 'BROKEN' f.json" },
+        { type: "shell", content: "ls" },
+      ],
+    };
+  }
+
+  it("returns repaired:true and patches in-memory + persists when verdict=fixable", async () => {
+    const fixed = { type: "shell", content: "jq -e '.x == 1' f.json" };
+    repairerRunMock.mockResolvedValueOnce({
+      ok: true,
+      result: { verdict: "fixable", fixed_test: fixed, reason: "rewrote jq" },
+      summary: "Repairer: fixable — rewrote jq",
+    });
+
+    const story = makeStory();
+    const batch = { session_id: "sid", stories: [story] };
+    const planPatchMock = vi.fn(async () => {});
+
+    const out = await runRepair({
+      story, testIndex: 1, errorOutput: "Cannot index array with string",
+      batchSessionId: "sid", batch,
+      config: {}, logger, emitter, eventBase: { sessionId: "sid", iteration: 0, stage: null, startedAt: Date.now() },
+      failureKind: "jq-as-binding-misuse",
+      savePlanPatch: planPatchMock,
+    });
+
+    expect(out.repaired).toBe(true);
+    expect(story.acceptance_tests[1]).toEqual(fixed);
+    expect(saveHuBatchMock).toHaveBeenCalledWith("sid", batch);
+    expect(planPatchMock).toHaveBeenCalledWith("HU-001", { acceptance_tests: story.acceptance_tests });
+  });
+
+  it("returns repaired:false + escalate:true when verdict=unfixable", async () => {
+    repairerRunMock.mockResolvedValueOnce({
+      ok: true,
+      result: { verdict: "unfixable", fixed_test: null, reason: "intent mismatch" },
+      summary: "Repairer: unfixable",
+    });
+
+    const story = makeStory();
+    const before = JSON.parse(JSON.stringify(story.acceptance_tests));
+    const batch = { session_id: "sid", stories: [story] };
+
+    const out = await runRepair({
+      story, testIndex: 1, errorOutput: "...",
+      batchSessionId: "sid", batch,
+      config: {}, logger, emitter, eventBase: { sessionId: "sid", iteration: 0, stage: null, startedAt: Date.now() },
+      failureKind: "intent",
+    });
+
+    expect(out.repaired).toBe(false);
+    expect(out.escalate).toBe(true);
+    expect(out.reason).toBe("intent mismatch");
+    // Story untouched.
+    expect(story.acceptance_tests).toEqual(before);
+    expect(saveHuBatchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns repaired:false + escalate:false on Repairer agent error (caller decides)", async () => {
+    repairerRunMock.mockRejectedValueOnce(new Error("provider down"));
+    const story = makeStory();
+    const batch = { session_id: "sid", stories: [story] };
+
+    const out = await runRepair({
+      story, testIndex: 1, errorOutput: "...",
+      batchSessionId: "sid", batch,
+      config: {}, logger, emitter, eventBase: { sessionId: "sid", iteration: 0, stage: null, startedAt: Date.now() },
+      failureKind: "x",
+    });
+
+    expect(out.repaired).toBe(false);
+    expect(out.escalate).toBeFalsy();
+    expect(out.error).toMatch(/provider down/);
+  });
+
+  it("rejects an invalid story or testIndex without invoking the role", async () => {
+    const out = await runRepair({
+      story: { id: "X", acceptance_tests: [] }, testIndex: 99, errorOutput: "",
+      batchSessionId: "sid", batch: { stories: [] },
+      config: {}, logger, emitter, eventBase: {}, failureKind: "x",
+    });
+    expect(out.repaired).toBe(false);
+    expect(out.error).toMatch(/invalid story or testIndex/);
+    expect(repairerRunMock).not.toHaveBeenCalled();
+  });
+
+  it("emits repair:start and repair:end progress events", async () => {
+    repairerRunMock.mockResolvedValueOnce({
+      ok: true,
+      result: { verdict: "fixable", fixed_test: { type: "shell", content: "x" }, reason: "x" },
+      summary: "Repairer: fixable",
+    });
+    const story = makeStory();
+    const batch = { session_id: "sid", stories: [story] };
+
+    await runRepair({
+      story, testIndex: 1, errorOutput: "err",
+      batchSessionId: "sid", batch,
+      config: {}, logger, emitter, eventBase: { sessionId: "sid", iteration: 0, stage: null, startedAt: Date.now() },
+      failureKind: "x",
+    });
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain("repair:start");
+    expect(types).toContain("repair:end");
+  });
+});

--- a/tests/repair/repairer-role.test.js
+++ b/tests/repair/repairer-role.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { RepairerRole } from "../../src/roles/repairer-role.js";
+
+const makeLogger = () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn(), resetContext: vi.fn() });
+
+describe("RepairerRole", () => {
+  it("extractInput accepts a string and yields safe defaults", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    const got = r.extractInput("just a cmd");
+    expect(got.failingTest).toBe("just a cmd");
+    expect(got.errorOutput).toBe("");
+    expect(got.huTitle).toBe("");
+    expect(got.siblingTests).toEqual([]);
+    expect(got.iteration).toBe(0);
+  });
+
+  it("extractInput accepts a structured object", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    const got = r.extractInput({
+      failingTest: { type: "shell", content: "jq -e '.x'" },
+      errorOutput: "err", huTitle: "T", huScope: "S",
+      siblingTests: [{ type: "shell", content: "echo 1" }],
+      iteration: 3,
+    });
+    expect(got.failingTest.content).toBe("jq -e '.x'");
+    expect(got.iteration).toBe(3);
+    expect(got.siblingTests).toHaveLength(1);
+  });
+
+  it("buildPrompt includes the failing test, error output and HU intent", async () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    const { prompt } = await r.buildPrompt({
+      failingTest: { type: "shell", content: "jq -e 'BROKEN' f.json" },
+      errorOutput: "Cannot index array with string \"foo\"",
+      huTitle: "Add audit script",
+      huScope: "Generates a JSON report classifying every test file",
+      siblingTests: [],
+      iteration: 3,
+    });
+    expect(prompt).toMatch(/jq -e 'BROKEN'/);
+    expect(prompt).toMatch(/Cannot index array/);
+    expect(prompt).toMatch(/Add audit script/);
+    expect(prompt).toMatch(/3 iteration\(s\)/);
+    // Output schema is part of the prompt, so the LLM knows the shape.
+    expect(prompt).toMatch(/"verdict":"fixable"\|"unfixable"/);
+  });
+
+  it("buildPrompt lists sibling tests when present (consistency context)", async () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    const { prompt } = await r.buildPrompt({
+      failingTest: { type: "shell", content: "echo bad" },
+      errorOutput: "",
+      huTitle: "T", huScope: "S",
+      siblingTests: [
+        { type: "shell", content: "echo sibling-1" },
+        { type: "gherkin", content: "Given X When Y Then Z" },
+      ],
+      iteration: 0,
+    });
+    expect(prompt).toMatch(/echo sibling-1/);
+    expect(prompt).toMatch(/Given X When Y Then Z/);
+    expect(prompt).toMatch(/do NOT modify these/);
+  });
+
+  it("isSuccessful: fixable + complete fixed_test → true", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    expect(r.isSuccessful({
+      verdict: "fixable",
+      fixed_test: { type: "shell", content: "jq -e '.x == 1' f.json" },
+      reason: "rewrote jq",
+    })).toBe(true);
+  });
+
+  it("isSuccessful: fixable but missing fixed_test → false", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    expect(r.isSuccessful({ verdict: "fixable", fixed_test: null, reason: "x" })).toBe(false);
+    expect(r.isSuccessful({ verdict: "fixable", fixed_test: { type: "shell", content: "" }, reason: "x" })).toBe(false);
+  });
+
+  it("isSuccessful: unfixable + reason → true (escalation is a valid OUTCOME, not a role failure)", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    expect(r.isSuccessful({
+      verdict: "unfixable",
+      fixed_test: null,
+      reason: "test depends on Sonar 9000 reachable, network isolated",
+    })).toBe(true);
+  });
+
+  it("isSuccessful: unfixable but no reason → false", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    expect(r.isSuccessful({ verdict: "unfixable", fixed_test: null, reason: "" })).toBe(false);
+    expect(r.isSuccessful({ verdict: "unfixable", fixed_test: null })).toBe(false);
+  });
+
+  it("isSuccessful: unknown verdict → false", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    expect(r.isSuccessful({ verdict: "maybe", reason: "x" })).toBe(false);
+    expect(r.isSuccessful(null)).toBe(false);
+  });
+
+  it("buildSuccessResult preserves all fields", () => {
+    const r = new RepairerRole({ config: {}, logger: makeLogger() });
+    const out = r.buildSuccessResult({
+      verdict: "fixable",
+      fixed_test: { type: "shell", content: "fixed" },
+      reason: "jq as-binding misuse",
+      diagnostics: ["jq -n '.x' parsed", "echo |jq -n '.x' worked"],
+    }, "claude");
+    expect(out.verdict).toBe("fixable");
+    expect(out.fixed_test).toEqual({ type: "shell", content: "fixed" });
+    expect(out.reason).toBe("jq as-binding misuse");
+    expect(out.diagnostics).toHaveLength(2);
+    expect(out.provider).toBe("claude");
+  });
+});


### PR DESCRIPTION
Closes #538.

## Why

2026-04-29 incident: planner emitted a syntactically broken jq query in HU 002's \`acceptance_tests\`. The test was irreparable. The coder had no escape hatch — it can fix code, not the test contract. After 3 iterations max-iterations was hit, HU 002 → failed, 7 dependents blocked.

This PR gives the orchestrator the escape hatch.

## What ships

1. **\`RepairerRole\`** — new role that takes a failing test + error output + HU intent and returns either \`{verdict:"fixable", fixed_test}\` or \`{verdict:"unfixable", reason}\`. Strict discipline: never soften assertions, never rewrite to pass against current code.
2. **\`repair-detector\`** — classifies a failure as infeasible when the SAME test fails the SAME way 2× in a row AND the error matches one of: jq-as-binding-misuse, shell-parse-error, jq-syntax, missing-tool, jq-parse-input. Conservative (errs on false-negatives).
3. **\`repair-runner\`** — orchestrates the role, patches in-memory story on fixable, escalates on unfixable.
4. **Wired in \`run-hu-batch\`** — between acceptance failure and coder-feedback. On repair, \`attempt -= 1\` (planner bug, not coder bug, so don't burn iteration). On escalate, fail HU immediately (don't waste remaining iterations).

## Tests

26 new in \`tests/repair/\` covering detector, tracker, role schema, runner happy/escalate/error paths, progress events. Full suite: 4110/4110.

## Follow-up

Plan-JSON patching callback (\`savePlanPatch\`) wired but caller passes null. In-memory mutation is enough for next iteration; PR #544's reconcile keeps the plan JSON consistent across runs.