### PR TITLE
fix(security): execSync → execFileSync (audit rec #1)

### DIFF
--- a/src/orchestrator/direct-actions.js
+++ b/src/orchestrator/direct-actions.js
@@ -1,7 +1,7 @@
 // Direct actions: commands Karajan Brain can execute without invoking a full role.
 // Keeps the action catalog small, auditable, and safe.
 
-import { execSync, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -48,7 +48,11 @@ async function runCommand({ cmd, cwd }) {
   }
 
   try {
-    const output = execSync(cmd, {
+    // Audit follow-up: was using execSync, which routes through /bin/sh.
+    // Even though `cmd` is allow-listed, defense-in-depth: switched to
+    // execFileSync with a tokenised arg array so no shell expansion at all.
+    const [program, ...args] = cmd.trim().split(/\s+/);
+    const output = execFileSync(program, args, {
       cwd: cwd || process.cwd(),
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/orchestrator/verification-gate.js
+++ b/src/orchestrator/verification-gate.js
@@ -1,7 +1,7 @@
 // Verification gate: checks whether the coder actually produced changes.
 // Prevents advancing the pipeline when coder iterations produce 0 file changes.
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 /**
  * @typedef {Object} VerificationResult
@@ -16,14 +16,20 @@ import { execSync } from "node:child_process";
 /**
  * Count files and lines changed since a base reference.
  * Uses git diff --numstat to get both file and line counts.
+ *
+ * Audit follow-up: was using execSync with template-string interpolation
+ * of `baseRef` and `projectDir`. Both come ultimately from session
+ * state / config — not user shell input — but the shape was a known
+ * shell-injection vector. Switched to execFileSync with arg arrays so
+ * no interpolation reaches /bin/sh.
  */
 export function countChangesSince(baseRef, projectDir = null) {
   try {
-    const scope = projectDir ? `-- ${projectDir}` : "";
-    const output = execSync(
-      `git diff --numstat ${baseRef} ${scope}`,
-      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
-    ).trim();
+    const args = ["diff", "--numstat", String(baseRef)];
+    if (projectDir) args.push("--", String(projectDir));
+    const output = execFileSync("git", args, {
+      encoding: "utf8", stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
 
     if (!output) return { files: [], filesChanged: 0, linesAdded: 0, linesDeleted: 0 };
 
@@ -48,14 +54,16 @@ export function countChangesSince(baseRef, projectDir = null) {
 
 /**
  * Also count untracked files (new files not yet added to git).
+ *
+ * Audit follow-up: same execSync→execFileSync change as countChangesSince.
  */
 export function countUntrackedFiles(projectDir = null) {
   try {
-    const scope = projectDir || ".";
-    const output = execSync(
-      `git ls-files --others --exclude-standard ${scope}`,
-      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
-    ).trim();
+    const args = ["ls-files", "--others", "--exclude-standard"];
+    if (projectDir) args.push(String(projectDir));
+    const output = execFileSync("git", args, {
+      encoding: "utf8", stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
 
     if (!output) return [];
     return output.split("\n").filter(Boolean);

--- a/src/utils/derive-project-name-from-cwd.js
+++ b/src/utils/derive-project-name-from-cwd.js
@@ -27,7 +27,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 /**
  * Turn `weather-dashboard` / `weather_dashboard` / `WeatherDashboard`
@@ -70,7 +70,10 @@ function readPackageJsonName(cwd) {
 function readGitRemoteBasename(cwd) {
   try {
     // -C points git at the cwd without us cd'ing the process.
-    const out = execSync(`git -C "${cwd}" config --get remote.origin.url`, {
+    // Audit follow-up: was using execSync with template-string interpolation
+    // of `cwd`. Switched to execFileSync with arg arrays so no interpolation
+    // reaches /bin/sh.
+    const out = execFileSync("git", ["-C", String(cwd), "config", "--get", "remote.origin.url"], {
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
       timeout: 1500,

--- a/tests/direct-actions.test.js
+++ b/tests/direct-actions.test.js
@@ -3,12 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 
+// Audit follow-up: run_command now uses execFileSync (no shell expansion).
+// Tests mock only execFileSync — execSync is no longer imported by the source.
 vi.mock("node:child_process", () => ({
-  execSync: vi.fn(),
   execFileSync: vi.fn()
 }));
 
-import { execSync, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 const {
   executeAction, executeActions, getAllowedActionTypes, isCommandAllowed
 } = await import("../src/orchestrator/direct-actions.js");
@@ -44,13 +45,15 @@ describe("direct-actions", () => {
 
   describe("run_command", () => {
     it("executes allowed command", async () => {
-      execSync.mockReturnValue("added 42 packages");
+      execFileSync.mockReturnValue("added 42 packages");
       const result = await executeAction({
         type: "run_command",
         params: { cmd: "npm install" }
       });
       expect(result.ok).toBe(true);
       expect(result.output).toContain("42 packages");
+      // Tokenised arg array, no shell expansion.
+      expect(execFileSync).toHaveBeenCalledWith("npm", ["install"], expect.any(Object));
     });
 
     it("rejects disallowed command", async () => {
@@ -63,7 +66,7 @@ describe("direct-actions", () => {
     });
 
     it("handles command failure", async () => {
-      execSync.mockImplementation(() => { throw new Error("install failed"); });
+      execFileSync.mockImplementation(() => { throw new Error("install failed"); });
       const result = await executeAction({
         type: "run_command",
         params: { cmd: "npm install" }
@@ -184,7 +187,7 @@ describe("direct-actions", () => {
 
   describe("executeActions", () => {
     it("executes multiple actions in sequence", async () => {
-      execSync.mockReturnValue("");
+      execFileSync.mockReturnValue("");
       const results = await executeActions([
         { type: "update_gitignore", params: { entries: ["a/"], cwd: tmpDir } },
         { type: "update_gitignore", params: { entries: ["b/"], cwd: tmpDir } }

--- a/tests/verification-gate.test.js
+++ b/tests/verification-gate.test.js
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Audit follow-up: verification-gate now uses execFileSync instead of
+// execSync (no shell expansion of `baseRef` / `projectDir`). Tests mock
+// execFileSync accordingly and assert on the arg-array shape.
 vi.mock("node:child_process", () => ({
-  execSync: vi.fn()
+  execFileSync: vi.fn()
 }));
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 const {
   countChangesSince, countUntrackedFiles, verifyCoderOutput, VerificationTracker
 } = await import("../src/orchestrator/verification-gate.js");
@@ -14,7 +17,7 @@ describe("verification-gate", () => {
 
   describe("countChangesSince", () => {
     it("parses git diff --numstat output", () => {
-      execSync.mockReturnValue("10\t5\tsrc/a.js\n3\t2\tsrc/b.js\n");
+      execFileSync.mockReturnValue("10\t5\tsrc/a.js\n3\t2\tsrc/b.js\n");
       const result = countChangesSince("HEAD~1");
       expect(result.filesChanged).toBe(2);
       expect(result.linesAdded).toBe(13);
@@ -23,24 +26,27 @@ describe("verification-gate", () => {
     });
 
     it("returns zeros on empty output", () => {
-      execSync.mockReturnValue("");
+      execFileSync.mockReturnValue("");
       const result = countChangesSince("HEAD~1");
       expect(result.filesChanged).toBe(0);
       expect(result.linesAdded).toBe(0);
     });
 
     it("returns zeros on git error", () => {
-      execSync.mockImplementation(() => { throw new Error("not a git repo"); });
+      execFileSync.mockImplementation(() => { throw new Error("not a git repo"); });
       const result = countChangesSince("HEAD~1");
       expect(result.filesChanged).toBe(0);
       expect(result.files).toEqual([]);
     });
 
-    it("includes projectDir scope in command", () => {
-      execSync.mockReturnValue("");
+    it("includes projectDir scope in command (as a separate arg, post-`--`)", () => {
+      execFileSync.mockReturnValue("");
       countChangesSince("abc123", "demo/");
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining("-- demo/"),
+      // execFileSync receives ("git", [args...], opts).
+      // No shell expansion: each arg is its own array element.
+      expect(execFileSync).toHaveBeenCalledWith(
+        "git",
+        expect.arrayContaining(["diff", "--numstat", "abc123", "--", "demo/"]),
         expect.any(Object)
       );
     });
@@ -48,25 +54,25 @@ describe("verification-gate", () => {
 
   describe("countUntrackedFiles", () => {
     it("returns list of untracked files", () => {
-      execSync.mockReturnValue("new.js\nnew-dir/file.ts\n");
+      execFileSync.mockReturnValue("new.js\nnew-dir/file.ts\n");
       const files = countUntrackedFiles();
       expect(files).toEqual(["new.js", "new-dir/file.ts"]);
     });
 
     it("returns empty array on no untracked", () => {
-      execSync.mockReturnValue("");
+      execFileSync.mockReturnValue("");
       expect(countUntrackedFiles()).toEqual([]);
     });
 
     it("returns empty array on error", () => {
-      execSync.mockImplementation(() => { throw new Error("fail"); });
+      execFileSync.mockImplementation(() => { throw new Error("fail"); });
       expect(countUntrackedFiles()).toEqual([]);
     });
   });
 
   describe("verifyCoderOutput", () => {
     it("passes when files are changed", () => {
-      execSync
+      execFileSync
         .mockReturnValueOnce("10\t5\tsrc/a.js\n")
         .mockReturnValueOnce("");
       const result = verifyCoderOutput({ baseRef: "HEAD~1" });
@@ -76,7 +82,7 @@ describe("verification-gate", () => {
     });
 
     it("passes when only untracked files exist", () => {
-      execSync
+      execFileSync
         .mockReturnValueOnce("")
         .mockReturnValueOnce("new.js\nother.js\n");
       const result = verifyCoderOutput({ baseRef: "HEAD~1" });
@@ -85,7 +91,7 @@ describe("verification-gate", () => {
     });
 
     it("fails when no changes at all", () => {
-      execSync.mockReturnValue("");
+      execFileSync.mockReturnValue("");
       const result = verifyCoderOutput({ baseRef: "HEAD~1" });
       expect(result.passed).toBe(false);
       expect(result.reason).toContain("0 file changes");
@@ -93,7 +99,7 @@ describe("verification-gate", () => {
     });
 
     it("combines tracked + untracked files", () => {
-      execSync
+      execFileSync
         .mockReturnValueOnce("5\t0\tsrc/existing.js\n")
         .mockReturnValueOnce("new.js\n");
       const result = verifyCoderOutput({ baseRef: "HEAD~1" });


### PR DESCRIPTION
## Summary

Addresses kj audit's top security recommendation: convert three `execSync` call sites that used template-string interpolation to `execFileSync` with arg arrays. No more shell expansion — defense in depth even though the values come from session state / config rather than direct user input.

**Sites fixed:**

- `src/orchestrator/verification-gate.js` — `countChangesSince`, `countUntrackedFiles` (baseRef, projectDir)
- `src/utils/derive-project-name-from-cwd.js` — `readGitRemoteBasename` (cwd)
- `src/orchestrator/direct-actions.js` — `runCommand` (allow-listed cmd, now tokenised)

## Test plan

- [x] Unit tests updated to mock `execFileSync` and assert arg-array shape
- [x] `tests/verification-gate.test.js` — 15/15 passing
- [x] `tests/direct-actions.test.js` — 24/24 passing  
- [x] `tests/derive-project-name-from-cwd.test.js` — 19/19 passing
- [x] Full suite: **4192/4192 passing**
- [x] `node --check` on all three modified source files