### PR TITLE
chore(eslint): ban globalThis.__KJ_* outside test-harness.js (audit rec #3)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,15 @@
  * `import-x/no-unresolved`, `import-x/named` — with a vitest globals
  * block and a relaxed `no-unused-vars` (test fixtures often declare
  * symbols for assertion-only purposes).
+ *
+ * 2026-04-27 follow-up (audit recommendation #3): bans
+ * `globalThis.__KJ_*` everywhere in src/ except the one file that
+ * legitimately reads them (`src/config/test-harness.js`). Pre-v2.7.5
+ * those globals were scattered across orchestrator code, which made
+ * test setup brittle and the runtime config un-typed. They're now
+ * read once, inside `test-harness.js`, and the rest of src/ talks
+ * to typed config getters. The selector below stops anyone (LLM or
+ * human) re-introducing the old pattern.
  */
 
 import js from "@eslint/js";
@@ -84,6 +93,27 @@ export default [
       // inside RegExp; disabling globally is fine because the codebase
       // doesn't accept untrusted regex from users.
       "no-control-regex": "off",
+
+      // Audit rec #3: ban globalThis.__KJ_* outside test-harness.js.
+      // The selector matches both reads (`globalThis.__KJ_FOO`) and
+      // writes (`globalThis.__KJ_FOO = ...`), which is what we want —
+      // production code shouldn't touch these at all.
+      "no-restricted-syntax": ["error", {
+        selector: "MemberExpression[object.name='globalThis'][property.name=/^__KJ_/]",
+        message:
+          "globalThis.__KJ_* is a test-only override surface. " +
+          "Read/write it only from src/config/test-harness.js, then expose " +
+          "the value through a typed config getter that the rest of src/ uses.",
+      }],
+    },
+  },
+  {
+    // The single file allowed to read/write globalThis.__KJ_*.
+    // (The override is *only* for `no-restricted-syntax`; everything
+    // else still applies.)
+    files: ["src/config/test-harness.js"],
+    rules: {
+      "no-restricted-syntax": "off",
     },
   },
   {


### PR DESCRIPTION
## Summary

Closes audit recommendation #3. Adds a `no-restricted-syntax` rule that catches any `globalThis.__KJ_*` read or write anywhere under `src/` except `src/config/test-harness.js` (the one file that legitimately reads them).

This stops the regression class where production code reaches into test-only override globals — pre-v2.7.5 these were scattered across orchestrator files, v2.7.5 consolidated them in test-harness, and now the lint rule prevents anyone re-introducing the old shape.

## Verification

- [x] `npx eslint src/` → 0 errors on existing code (the previous refactor was clean)
- [x] Temporary file with `globalThis.__KJ_FOO` access → rule fires with descriptive message pointing to test-harness.js
- [x] `src/config/test-harness.js` exempt via override block
- [x] Full vitest: 4192/4192 passing