### PR TITLE
refactor(pre-loop): extract phases under 600 LOC + console allow-list (audit rec #6)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -148,6 +148,11 @@ export default [
       "src/orchestrator/drivers/init-context.js",
       "src/orchestrator/drivers/pre-loop.js",
       "src/orchestrator/drivers/post-loop.js",
+      // Pre-loop phases (sub-modules of pre-loop.js): when a phase
+      // auto-starts the HU board it prints the same banner the parent
+      // driver does. Allow console.* in the whole sub-package for
+      // architectural consistency with pre-loop.js itself.
+      "src/orchestrator/drivers/pre-loop-phases/**/*.js",
     ],
     rules: {
       "no-console": "off",

--- a/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
+++ b/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
@@ -1,0 +1,116 @@
+/**
+ * Extracted from `src/orchestrator/drivers/pre-loop.js` in TSK-0337
+ * (audit recommendation #6). Previously an internal helper inside
+ * pre-loop.js; moved here so the driver stays under 600 LOC.
+ * Behaviour unchanged.
+ *
+ * Auto-generates an HU batch from triage's decomposition recommendation
+ * when no manual `huFile` is present. Runs after researcher/architect/
+ * planner so context is available for better HU generation. Sets
+ * `stageResults.huReviewer` so `needsSubPipeline` picks it up later.
+ *
+ * Side effects:
+ *   - Persists `batch.json` to `~/.karajan/hu-stories/<batchSessionId>/`
+ *     so the sub-pipeline can update story status via `saveHuBatch`.
+ *   - Auto-starts the HU board (skipped under VITEST / NODE_ENV=test).
+ */
+
+import { emitProgress, makeEvent } from "../../../utils/events.js";
+
+export async function maybeGenerateAutoHuBatch({
+  flags, stageResults, task, logger, emitter, eventBase, projectDir, session,
+}) {
+  // Skip if user passed a manual hu-file
+  if (flags?.huFile) return;
+  // Skip if hu-reviewer already produced a batch (manual enable + PG stories)
+  if (stageResults.huReviewer) return;
+  // Need triage decomposition recommendation
+  const shouldDecompose = stageResults.triage?.shouldDecompose;
+  const subtasks = stageResults.triage?.subtasks;
+  if (!shouldDecompose || !Array.isArray(subtasks) || subtasks.length < 2) return;
+
+  const { generateHuBatch } = await import("../../../hu/auto-generator.js");
+
+  // Detect if project is new: empty dir or only .git/.karajan/.gitignore
+  let isNewProject = false;
+  try {
+    const fs = await import("node:fs/promises");
+    const entries = await fs.readdir(projectDir);
+    const relevant = entries.filter(e => !e.startsWith(".git") && e !== ".karajan" && e !== ".gitignore");
+    isNewProject = relevant.length === 0;
+  } catch { /* ignore */ }
+
+  // Extract stack hints from planner + architect output
+  const stackHints = [];
+  const combined = `${stageResults.planner?.plan || ""} ${stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : ""} ${task}`.toLowerCase();
+  const stackKeywords = ["express", "vite", "vitest", "jest", "next", "astro", "react", "vue", "svelte", "fastapi", "django", "spring", "gin", "nestjs", "monorepo", "workspaces"];
+  for (const kw of stackKeywords) {
+    if (combined.includes(kw)) stackHints.push(kw);
+  }
+
+  const batch = generateHuBatch({
+    originalTask: task,
+    subtasks,
+    stackHints,
+    isNewProject,
+    researcherContext: stageResults.researcher?.summary || null,
+    architectContext: stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : null
+  });
+
+  // Persist batch to HU store so hu-sub-pipeline can update story status via saveHuBatch.
+  // Use session.id as batchSessionId.
+  const batchSessionId = `auto-${session.id}`;
+  try {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const { getKarajanHome } = await import("../../../utils/paths.js");
+    const huDir = path.join(getKarajanHome(), "hu-stories", batchSessionId);
+    await fs.mkdir(huDir, { recursive: true });
+    const persistBatch = {
+      session_id: batchSessionId,
+      project_id: batchSessionId,
+      project_name: batch.projectName,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      stories: batch.stories
+    };
+    await fs.writeFile(path.join(huDir, "batch.json"), JSON.stringify(persistBatch, null, 2));
+  } catch (err) {
+    logger.warn(`Auto-HU: failed to persist batch (${err.message}) — sub-pipeline will use in-memory fallback`);
+  }
+
+  // Wrap in format compatible with needsSubPipeline + runHuSubPipeline
+  stageResults.huReviewer = {
+    ok: true,
+    stories: batch.stories,
+    total: batch.total,
+    certified: batch.certified,
+    batchSessionId,
+    auto_generated: true,
+    source: batch.source
+  };
+
+  logger.info(`Auto-HU: generated ${batch.total} stories (${batch.source.triage_subtasks} subtasks${isNewProject ? ", new project" : ""}${stackHints.length ? `, stack: ${stackHints.join(",")}` : ""})`);
+  emitProgress(emitter, makeEvent("hu:auto-generated", { ...eventBase, stage: "hu-auto-gen" }, {
+    message: `Auto-generated ${batch.total} HU(s) from triage decomposition`,
+    detail: { total: batch.total, subtasks: batch.source.triage_subtasks, isNewProject, stackHints, projectName: batch.projectName }
+  }));
+
+  // Auto-start the board so the user can see the generated HUs.
+  // Always fires when auto-HU runs, independent of hu_board.auto_start flag.
+  // Never during vitest — would race the PID file and leave a detached
+  // node process around after the suite (TSK-0273).
+  if (process.env.VITEST || process.env.NODE_ENV === "test") return;
+  try {
+    const { startBoard, renderBoardBanner } = await import("../../../commands/board.js");
+    const desiredPort = session.config_snapshot?.hu_board?.port ?? 4000;
+    const boardResult = await startBoard(desiredPort);
+    const url = boardResult.url;
+    const status = boardResult.alreadyRunning ? "already running" : "started";
+    const projectName = batch.projectName || "Auto-generated HUs";
+    console.log(renderBoardBanner({ url, status, projectName }));
+    logger.info(`HU Board ${status} at ${url} (project: ${projectName})`);
+  } catch (err) {
+    logger.warn(`HU Board auto-start failed (non-blocking): ${err.message}`);
+  }
+}

--- a/src/orchestrator/drivers/pre-loop-phases/config-deprecations.js
+++ b/src/orchestrator/drivers/pre-loop-phases/config-deprecations.js
@@ -1,0 +1,47 @@
+/**
+ * Extracted from `src/orchestrator/drivers/pre-loop.js` in TSK-0337
+ * (audit recommendation #6: continue pre-loop extraction). pre-loop.js
+ * had grown to 626 LOC, over the 600-LOC ceiling that the file's own
+ * docstring set. Splitting the deprecation warnings, addyosmani skill
+ * bootstrap, and auto-HU batch generation into their own modules brings
+ * the driver back to ~440 LOC.
+ *
+ * Behaviour unchanged. The function is exported with the same name and
+ * signature so the move is mechanical.
+ *
+ * Emits one-shot warnings for config keys ignored since v2.7.4. Currently:
+ *   - `sonarqube.enabled` (kj.config.yml) → ignored, sonar is intrinsic
+ *   - `--no-sonar` CLI flag → ignored
+ */
+
+import { emitProgress, makeEvent } from "../../../utils/events.js";
+
+export function emitConfigDeprecations(config, logger, emitter, eventBase) {
+  const dep = config?._deprecated;
+  if (!dep) return;
+
+  if (dep.sonarqubeEnabledKey) {
+    const m =
+      "DEPRECATED: `sonarqube.enabled` in kj.config.yml is ignored since v2.7.4. " +
+      "Sonar is intrinsic to Karajan for code tasks (sw/refactor/add-tests) and " +
+      "skipped for non-code tasks (audit/doc/infra/analysis/no-code) by policy. " +
+      "Remove the key from your config to silence this warning.";
+    logger.warn(m);
+    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
+      message: m,
+      detail: { key: "sonarqube.enabled", since: "v2.7.4" },
+    }));
+  }
+
+  if (dep.noSonarFlag) {
+    const m =
+      "DEPRECATED: `--no-sonar` flag is ignored since v2.7.4. Sonar runs for code " +
+      "tasks by policy. To skip Sonar on a one-off run, use a non-code task type " +
+      "(e.g. `--task-type doc`) or rely on Solomon's runtime override.";
+    logger.warn(m);
+    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
+      message: m,
+      detail: { flag: "--no-sonar", since: "v2.7.4" },
+    }));
+  }
+}

--- a/src/orchestrator/drivers/pre-loop-phases/ensure-addyosmani-skills.js
+++ b/src/orchestrator/drivers/pre-loop-phases/ensure-addyosmani-skills.js
@@ -1,0 +1,84 @@
+/**
+ * Extracted from `src/orchestrator/drivers/pre-loop.js` in TSK-0337
+ * (audit recommendation #6). Previously a 60-line export inside
+ * pre-loop.js; moved here to keep that driver under the 600-LOC
+ * ceiling its own docstring set. Behaviour and signature unchanged.
+ *
+ * Refreshes the addyosmani/agent-skills catalog (clones or pulls,
+ * gated by `refreshDays`) and resolves which slugs are relevant to
+ * the current task. Sets the result on the session via the
+ * `setAddyosmaniSkills` mutator so downstream stages can read it
+ * without re-running git.
+ *
+ * Failures are non-blocking: a missing git, a network blip, or an
+ * unparseable catalog all just mark the catalog unavailable and
+ * emit a `skills:addyosmani-unavailable` event. The pipeline keeps
+ * going — the addyosmani sources are an optional supplement.
+ */
+
+import {
+  refreshIfStale as refreshAddyosmaniCatalog,
+  listAvailableSlugs as listAddyosmaniSlugs,
+} from "../../../skills/addyosmani-catalog.js";
+import { resolveAddyosmaniSlugs } from "../../../skills/addyosmani-role-map.js";
+import { setAddyosmaniSkills } from "../../../session/mutators.js";
+import { emitProgress, makeEvent } from "../../../utils/events.js";
+
+export async function ensureAddyosmaniSkills({ task, config, logger, session, emitter, eventBase }) {
+  const skillsConfig = config?.skills || {};
+  const sources = Array.isArray(skillsConfig.sources) ? skillsConfig.sources : ["addyosmani", "openskills", "local"];
+  const addyConfig = skillsConfig.addyosmani || {};
+  // Test harness override: config.testHarness.defaultAddyosmaniEnabled=false
+  // prevents orchestrator tests from spawning git. Tests that need the real
+  // catalog opt in by setting config.skills.addyosmani.enabled = true.
+  // Post-v2.7.5 no longer reads globalThis directly — config.testHarness is
+  // populated by the loader from the global or the production default.
+  const harnessDefault = config?.testHarness?.defaultAddyosmaniEnabled;
+  const enabledFromConfig = addyConfig.enabled === true
+    || (addyConfig.enabled !== false && harnessDefault !== false);
+  const enabled = enabledFromConfig && sources.includes("addyosmani");
+  if (!enabled) return;
+
+  const refreshDays = Number.isFinite(addyConfig.refreshDays) ? addyConfig.refreshDays : 7;
+  const refreshMs = Math.max(0, refreshDays) * 24 * 60 * 60 * 1000;
+
+  try {
+    const refreshResult = await refreshAddyosmaniCatalog({
+      refreshMs,
+      repoUrl: addyConfig.repoUrl,
+      logger,
+    });
+
+    if (!refreshResult.ok) {
+      setAddyosmaniSkills(session, { available: false, reason: refreshResult.error || "refresh failed" });
+      emitProgress(emitter, makeEvent("skills:addyosmani-unavailable", { ...eventBase, stage: "skills" }, {
+        message: `addyosmani/agent-skills catalog unavailable: ${refreshResult.error || refreshResult.action}`,
+        detail: { action: refreshResult.action, hint: "Install git to enable process skills from addyosmani/agent-skills" },
+      }));
+      return;
+    }
+
+    const available = new Set(await listAddyosmaniSlugs());
+    const resolved = resolveAddyosmaniSlugs({ role: null, task }); // role resolution happens per-stage later
+    const valid = resolved.filter((slug) => available.has(slug));
+
+    setAddyosmaniSkills(session, {
+      available: true,
+      action: refreshResult.action,
+      resolvedSlugs: valid,
+      allAvailable: Array.from(available),
+    });
+
+    emitProgress(emitter, makeEvent("skills:addyosmani-ready", { ...eventBase, stage: "skills" }, {
+      message: `addyosmani/agent-skills ${refreshResult.action} — ${available.size} slug(s) available, ${valid.length} relevant to task`,
+      detail: {
+        action: refreshResult.action,
+        relevantSlugs: valid,
+        availableCount: available.size,
+      },
+    }));
+  } catch (err) {
+    logger.warn(`addyosmani catalog step failed (non-blocking): ${err.message}`);
+    setAddyosmaniSkills(session, { available: false, reason: err.message });
+  }
+}

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -31,15 +31,9 @@ import { persistInlineDomain } from "../../domains/domain-loader.js";
 import { detectTestFramework } from "../../utils/project-detect.js";
 import { detectNeededSkills, autoInstallSkills } from "../../skills/skill-detector.js";
 import { refineSkillsSemantically, resolveSkillsMode } from "../../skills/semantic-detector.js";
-import {
-  refreshIfStale as refreshAddyosmaniCatalog,
-  listAvailableSlugs as listAddyosmaniSlugs,
-} from "../../skills/addyosmani-catalog.js";
-import { resolveAddyosmaniSlugs } from "../../skills/addyosmani-role-map.js";
 import { saveSession } from "../../session/store.js";
 import {
-  setPreflight, setPreLoopContext, setPlanRef, setPlanSyncCallback, setLiveStatusUpdater, setLiveOutcomeUpdater,
-  setAutoInstalledSkills, setSkillsRecommended, setAddyosmaniSkills,
+  setPreflight, setAutoInstalledSkills, setSkillsRecommended,
 } from "../../session/mutators.js";
 import {
   runResearcherStage, runArchitectStage, runPlannerStage,
@@ -54,6 +48,13 @@ import { runStage } from "../stages/stage-executor.js";
 import { runDomainCuratorStage } from "../stages/domain-curator-stage.js";
 import { runPreflightChecks } from "../preflight-checks.js";
 import { injectLoadedPlan } from "./pre-loop-phases/inject-loaded-plan.js";
+import { emitConfigDeprecations } from "./pre-loop-phases/config-deprecations.js";
+import { ensureAddyosmaniSkills } from "./pre-loop-phases/ensure-addyosmani-skills.js";
+import { maybeGenerateAutoHuBatch } from "./pre-loop-phases/auto-hu-batch.js";
+
+// Re-export for back-compat with any external caller; the canonical
+// definitions now live in ./pre-loop-phases/.
+export { ensureAddyosmaniSkills };
 import {
   applyTriageOverrides, applyAutoSimplify, applyFlagOverrides,
   resolvePipelinePolicies, updateGitignoreForStack,
@@ -427,200 +428,7 @@ export async function runPlanningPhases({ config, logger, emitter, eventBase, se
 
   return { plannedTask };
 }
-/**
- * Print one-time deprecation warnings for config keys / CLI flags that
- * Karajan no longer honours. Called once per run, after policy resolution
- * so the message lands in context (the user sees what's being ignored
- * RIGHT before the preflight that would have been affected).
- *
- * Currently surfaces:
- *   - `sonarqube.enabled` set in user config → ignored since v2.7.4
- *   - `--no-sonar` CLI flag → ignored since v2.7.4
- */
-function emitConfigDeprecations(config, logger, emitter, eventBase) {
-  const dep = config?._deprecated;
-  if (!dep) return;
-
-  if (dep.sonarqubeEnabledKey) {
-    const m =
-      "DEPRECATED: `sonarqube.enabled` in kj.config.yml is ignored since v2.7.4. " +
-      "Sonar is intrinsic to Karajan for code tasks (sw/refactor/add-tests) and " +
-      "skipped for non-code tasks (audit/doc/infra/analysis/no-code) by policy. " +
-      "Remove the key from your config to silence this warning.";
-    logger.warn(m);
-    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
-      message: m,
-      detail: { key: "sonarqube.enabled", since: "v2.7.4" },
-    }));
-  }
-
-  if (dep.noSonarFlag) {
-    const m =
-      "DEPRECATED: `--no-sonar` flag is ignored since v2.7.4. Sonar runs for code " +
-      "tasks by policy. To skip Sonar on a one-off run, use a non-code task type " +
-      "(e.g. `--task-type doc`) or rely on Solomon's runtime override.";
-    logger.warn(m);
-    emitProgress(emitter, makeEvent("config:deprecated", { ...eventBase, stage: "config" }, {
-      message: m,
-      detail: { flag: "--no-sonar", since: "v2.7.4" },
-    }));
-  }
-}
-export async function ensureAddyosmaniSkills({ task, config, logger, session, emitter, eventBase }) {
-  const skillsConfig = config?.skills || {};
-  const sources = Array.isArray(skillsConfig.sources) ? skillsConfig.sources : ["addyosmani", "openskills", "local"];
-  const addyConfig = skillsConfig.addyosmani || {};
-  // Test harness override: config.testHarness.defaultAddyosmaniEnabled=false
-  // prevents orchestrator tests from spawning git. Tests that need the real
-  // catalog opt in by setting config.skills.addyosmani.enabled = true.
-  // Post-v2.7.5 no longer reads globalThis directly — config.testHarness is
-  // populated by the loader from the global or the production default.
-  const harnessDefault = config?.testHarness?.defaultAddyosmaniEnabled;
-  const enabledFromConfig = addyConfig.enabled === true
-    || (addyConfig.enabled !== false && harnessDefault !== false);
-  const enabled = enabledFromConfig && sources.includes("addyosmani");
-  if (!enabled) return;
-
-  const refreshDays = Number.isFinite(addyConfig.refreshDays) ? addyConfig.refreshDays : 7;
-  const refreshMs = Math.max(0, refreshDays) * 24 * 60 * 60 * 1000;
-
-  try {
-    const refreshResult = await refreshAddyosmaniCatalog({
-      refreshMs,
-      repoUrl: addyConfig.repoUrl,
-      logger,
-    });
-
-    if (!refreshResult.ok) {
-      setAddyosmaniSkills(session, { available: false, reason: refreshResult.error || "refresh failed" });
-      emitProgress(emitter, makeEvent("skills:addyosmani-unavailable", { ...eventBase, stage: "skills" }, {
-        message: `addyosmani/agent-skills catalog unavailable: ${refreshResult.error || refreshResult.action}`,
-        detail: { action: refreshResult.action, hint: "Install git to enable process skills from addyosmani/agent-skills" },
-      }));
-      return;
-    }
-
-    const available = new Set(await listAddyosmaniSlugs());
-    const resolved = resolveAddyosmaniSlugs({ role: null, task }); // role resolution happens per-stage later
-    const valid = resolved.filter((slug) => available.has(slug));
-
-    setAddyosmaniSkills(session, {
-      available: true,
-      action: refreshResult.action,
-      resolvedSlugs: valid,
-      allAvailable: Array.from(available),
-    });
-
-    emitProgress(emitter, makeEvent("skills:addyosmani-ready", { ...eventBase, stage: "skills" }, {
-      message: `addyosmani/agent-skills ${refreshResult.action} — ${available.size} slug(s) available, ${valid.length} relevant to task`,
-      detail: {
-        action: refreshResult.action,
-        relevantSlugs: valid,
-        availableCount: available.size,
-      },
-    }));
-  } catch (err) {
-    logger.warn(`addyosmani catalog step failed (non-blocking): ${err.message}`);
-    setAddyosmaniSkills(session, { available: false, reason: err.message });
-  }
-}
-/**
- * Auto-generate HU batch from triage decomposition when no manual huFile is present.
- * Runs after researcher/architect/planner so that context is available for better HUs.
- * Sets stageResults.huReviewer so needsSubPipeline picks it up later.
- */
-async function maybeGenerateAutoHuBatch({ flags, stageResults, task, plannedTask, logger, emitter, eventBase, projectDir, session }) {
-  // Skip if user passed a manual hu-file
-  if (flags?.huFile) return;
-  // Skip if hu-reviewer already produced a batch (manual enable + PG stories)
-  if (stageResults.huReviewer) return;
-  // Need triage decomposition recommendation
-  const shouldDecompose = stageResults.triage?.shouldDecompose;
-  const subtasks = stageResults.triage?.subtasks;
-  if (!shouldDecompose || !Array.isArray(subtasks) || subtasks.length < 2) return;
-
-  const { generateHuBatch } = await import("../../hu/auto-generator.js");
-
-  // Detect if project is new: empty dir or only .git/.karajan/.gitignore
-  let isNewProject = false;
-  try {
-    const fs = await import("node:fs/promises");
-    const entries = await fs.readdir(projectDir);
-    const relevant = entries.filter(e => !e.startsWith(".git") && e !== ".karajan" && e !== ".gitignore");
-    isNewProject = relevant.length === 0;
-  } catch { /* ignore */ }
-
-  // Extract stack hints from planner + architect output
-  const stackHints = [];
-  const combined = `${stageResults.planner?.plan || ""} ${stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : ""} ${task}`.toLowerCase();
-  const stackKeywords = ["express", "vite", "vitest", "jest", "next", "astro", "react", "vue", "svelte", "fastapi", "django", "spring", "gin", "nestjs", "monorepo", "workspaces"];
-  for (const kw of stackKeywords) {
-    if (combined.includes(kw)) stackHints.push(kw);
-  }
-
-  const batch = generateHuBatch({
-    originalTask: task,
-    subtasks,
-    stackHints,
-    isNewProject,
-    researcherContext: stageResults.researcher?.summary || null,
-    architectContext: stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : null
-  });
-
-  // Persist batch to HU store so hu-sub-pipeline can update story status via saveHuBatch.
-  // Use session.id as batchSessionId.
-  const batchSessionId = `auto-${session.id}`;
-  try {
-    const fs = await import("node:fs/promises");
-    const path = await import("node:path");
-    const { getKarajanHome } = await import("../../utils/paths.js");
-    const huDir = path.join(getKarajanHome(), "hu-stories", batchSessionId);
-    await fs.mkdir(huDir, { recursive: true });
-    const persistBatch = {
-      session_id: batchSessionId,
-      project_id: batchSessionId,
-      project_name: batch.projectName,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      stories: batch.stories
-    };
-    await fs.writeFile(path.join(huDir, "batch.json"), JSON.stringify(persistBatch, null, 2));
-  } catch (err) {
-    logger.warn(`Auto-HU: failed to persist batch (${err.message}) — sub-pipeline will use in-memory fallback`);
-  }
-
-  // Wrap in format compatible with needsSubPipeline + runHuSubPipeline
-  stageResults.huReviewer = {
-    ok: true,
-    stories: batch.stories,
-    total: batch.total,
-    certified: batch.certified,
-    batchSessionId,
-    auto_generated: true,
-    source: batch.source
-  };
-
-  logger.info(`Auto-HU: generated ${batch.total} stories (${batch.source.triage_subtasks} subtasks${isNewProject ? ", new project" : ""}${stackHints.length ? `, stack: ${stackHints.join(",")}` : ""})`);
-  emitProgress(emitter, makeEvent("hu:auto-generated", { ...eventBase, stage: "hu-auto-gen" }, {
-    message: `Auto-generated ${batch.total} HU(s) from triage decomposition`,
-    detail: { total: batch.total, subtasks: batch.source.triage_subtasks, isNewProject, stackHints, projectName: batch.projectName }
-  }));
-
-  // Auto-start the board so the user can see the generated HUs.
-  // Always fires when auto-HU runs, independent of hu_board.auto_start flag.
-  // Never during vitest — would race the PID file and leave a detached
-  // node process around after the suite (TSK-0273).
-  if (process.env.VITEST || process.env.NODE_ENV === "test") return;
-  try {
-    const { startBoard, renderBoardBanner } = await import("../../commands/board.js");
-    const desiredPort = session.config_snapshot?.hu_board?.port ?? 4000;
-    const boardResult = await startBoard(desiredPort);
-    const url = boardResult.url;
-    const status = boardResult.alreadyRunning ? "already running" : "started";
-    const projectName = batch.projectName || "Auto-generated HUs";
-    console.log(renderBoardBanner({ url, status, projectName }));
-    logger.info(`HU Board ${status} at ${url} (project: ${projectName})`);
-  } catch (err) {
-    logger.warn(`HU Board auto-start failed (non-blocking): ${err.message}`);
-  }
-}
+// `emitConfigDeprecations`, `ensureAddyosmaniSkills` and
+// `maybeGenerateAutoHuBatch` were extracted to ./pre-loop-phases/ in
+// TSK-0337 to keep this driver under the 600-LOC ceiling. Imports at
+// the top of this file pull them back in; behaviour is unchanged.


### PR DESCRIPTION
## Summary

Closes audit recommendation #6: pre-loop.js had drifted to 626 LOC, over the 600-LOC ceiling its own docstring set in TSK-0335. Extracted three helpers to `./pre-loop-phases/` with no behaviour change.

| New file | LOC | Was |
|---|---:|---|
| `pre-loop-phases/config-deprecations.js` | 47 | internal `emitConfigDeprecations` |
| `pre-loop-phases/ensure-addyosmani-skills.js` | 84 | exported `ensureAddyosmaniSkills` (re-exported from pre-loop.js for back-compat) |
| `pre-loop-phases/auto-hu-batch.js` | 116 | internal `maybeGenerateAutoHuBatch` |

Plus removed five stale mutator imports pre-loop.js wasn't actually using (`setPreLoopContext`, `setPlanRef`, `setPlanSyncCallback`, `setLiveStatusUpdater`, `setLiveOutcomeUpdater`).

**pre-loop.js: 626 → 435 LOC.**

## Plus eslint allow-list update (commit 2)

`auto-hu-batch.js` legitimately prints the HU board banner via `console.log(renderBoardBanner(...))` — the parent `pre-loop.js` was already allow-listed for the same reason in #559. Extended the allow-list to `src/orchestrator/drivers/pre-loop-phases/**/*.js` for architectural consistency.

## Test plan

- [x] `node --check` on all 4 modified/created files
- [x] `npx eslint src/` → 0 errors
- [x] `npx vitest run` → **4192/4192 passing**