### PR TITLE
test(activity-log): replace fixed sleeps with vi.waitFor (audit rec #7)

### DIFF
--- a/tests/activity-log.test.js
+++ b/tests/activity-log.test.js
@@ -37,7 +37,10 @@ describe("createActivityLog", () => {
     });
 
     // Wait for async flush
-    await new Promise((r) => setTimeout(r, 50));
+    // Audit follow-up: was a fixed 50 ms sleep that flaked under CI load.
+    // vi.waitFor polls until fs.appendFile has been called once (or until
+    // the default 1 s timeout). Tests run in <10 ms locally either way.
+    await vi.waitFor(() => expect(fs.appendFile).toHaveBeenCalled());
 
     expect(fs.appendFile).toHaveBeenCalledTimes(1);
     const written = fs.appendFile.mock.calls[0][1];
@@ -59,7 +62,10 @@ describe("createActivityLog", () => {
       message: "Coder completed"
     });
 
-    await new Promise((r) => setTimeout(r, 50));
+    // Audit follow-up: was a fixed 50 ms sleep that flaked under CI load.
+    // vi.waitFor polls until fs.appendFile has been called once (or until
+    // the default 1 s timeout). Tests run in <10 ms locally either way.
+    await vi.waitFor(() => expect(fs.appendFile).toHaveBeenCalled());
 
     expect(fs.appendFile).toHaveBeenCalledTimes(1);
     const written = fs.appendFile.mock.calls[0][1];
@@ -78,7 +84,10 @@ describe("createActivityLog", () => {
       message: "Coder failed"
     });
 
-    await new Promise((r) => setTimeout(r, 50));
+    // Audit follow-up: was a fixed 50 ms sleep that flaked under CI load.
+    // vi.waitFor polls until fs.appendFile has been called once (or until
+    // the default 1 s timeout). Tests run in <10 ms locally either way.
+    await vi.waitFor(() => expect(fs.appendFile).toHaveBeenCalled());
 
     const written = fs.appendFile.mock.calls[0][1];
     expect(written).toContain("[ERROR]");
@@ -95,7 +104,10 @@ describe("createActivityLog", () => {
     });
 
     // Should not throw
-    await new Promise((r) => setTimeout(r, 50));
+    // Audit follow-up: was a fixed 50 ms sleep that flaked under CI load.
+    // vi.waitFor polls until fs.appendFile has been called once (or until
+    // the default 1 s timeout). Tests run in <10 ms locally either way.
+    await vi.waitFor(() => expect(fs.appendFile).toHaveBeenCalled());
 
     expect(fs.appendFile).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Closes audit recommendation #7. activity-log.test.js had 4 fixed-50 ms sleeps to wait for async `fs.appendFile`. CI runners sometimes need >50 ms for a microtask flush — flaky. Replaced with `vi.waitFor(() => expect(fs.appendFile).toHaveBeenCalled())`.

Tests now run in ~5 ms locally and won't flake under CI load.

## Other test files audited and left untouched (justified sleeps)

- `timeout-handling.test.js`: real `sleep` shell commands testing process timeout enforcement
- `utils-with-timeout.test.js`: simulates a slow promise — timing is the test
- `orchestrator/concurrent-runs.test.js`: setTimeout in an ALS test asserts context survives await boundaries
- `session-store`/`kj-hu-tool`/`plan-to-run`/`plan-auto-certify-anomaly`: ≤20 ms sleeps to ensure two ISO timestamps differ. Clock mocking is a bigger refactor not in scope here
- `telemetry.test.js`, `board-prompt-bridge.test.js`: setTimeout schedules a deferred mock reaction — the timing IS the test

## Test plan

- [x] `npx vitest run tests/activity-log` → 5/5 passing
- [x] `npx vitest run` → **4192/4192 passing**