### PR TITLE
fix(security): close exec residuals (post-#555 follow-up)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -569,18 +569,21 @@ program
   .command("update")
   .description("Update karajan-code to the latest version from npm")
   .action(async () => {
-    const { execaCommand } = await import("execa");
+    // Audit follow-up: was execaCommand (shell parsing). Inputs are
+    // constants today, but the project standard since #555 is execa
+    // with arg arrays (no shell). Migrated for consistency.
+    const { execa } = await import("execa");
     console.log(`Current version: ${PKG_VERSION}`);
     console.log("Checking for updates...");
     try {
-      const { stdout } = await execaCommand("npm view karajan-code version");
+      const { stdout } = await execa("npm", ["view", "karajan-code", "version"]);
       const latest = stdout.trim();
       if (latest === PKG_VERSION) {
         console.log(`Already on the latest version (${PKG_VERSION}).`);
         return;
       }
       console.log(`Updating ${PKG_VERSION} → ${latest}...`);
-      await execaCommand("npm install -g karajan-code@latest", { stdio: "inherit" });
+      await execa("npm", ["install", "-g", "karajan-code@latest"], { stdio: "inherit" });
       console.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
     } catch (err) {
       console.error(`Update failed: ${err.message}`);

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -28,10 +28,13 @@ export async function autoInit(projectDir, logger) {
   // Ensure git repo exists — without git, diff/reviewer/commit won't work
   const gitDir = path.join(projectDir, ".git");
   if (!(await exists(gitDir))) {
-    const { execSync } = await import("node:child_process");
+    // Audit follow-up: was execSync with constant strings. Inputs are
+    // hardcoded, so injection isn't possible, but the project standard
+    // since #555 is execFileSync everywhere. Migrated for consistency.
+    const { execFileSync } = await import("node:child_process");
     try {
-      execSync("git init", { cwd: projectDir, stdio: "pipe" });
-      execSync("git commit --allow-empty -m 'initial commit'", { cwd: projectDir, stdio: "pipe" });
+      execFileSync("git", ["init"], { cwd: projectDir, stdio: "pipe" });
+      execFileSync("git", ["commit", "--allow-empty", "-m", "initial commit"], { cwd: projectDir, stdio: "pipe" });
       logger.info("Initialized git repository with empty initial commit");
     } catch (err) {
       logger.warn(`Failed to init git repo: ${err.message}`);

--- a/src/orchestrator/drivers/init-context.js
+++ b/src/orchestrator/drivers/init-context.js
@@ -58,8 +58,9 @@ export async function initFlowContext({ task, config, logger, emitter, askQuesti
   let diffScope = config.projectDir || null;
   if (!diffScope) {
     try {
-      const { execSync } = await import("node:child_process");
-      const repoRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+      // Audit follow-up: same execSync→execFileSync migration as #555.
+      const { execFileSync } = await import("node:child_process");
+      const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
       const cwd = process.cwd();
       if (cwd !== repoRoot && cwd.startsWith(repoRoot)) {
         diffScope = cwd.slice(repoRoot.length + 1);

--- a/src/orchestrator/solomon-rules.js
+++ b/src/orchestrator/solomon-rules.js
@@ -118,11 +118,15 @@ export async function buildRulesContext({ session, task, iteration, blockingIssu
 
   // Count files changed via git
   try {
-    const { execaCommand } = await import("execa");
+    // Audit follow-up: was using execaCommand with template-string
+    // interpolation of `baseRef`. baseRef comes from session state, not
+    // user input, but the shape is a known shell-injection vector.
+    // Switched to execa with arg arrays so no shell expansion happens.
+    const { execa } = await import("execa");
     const baseRef = session.session_start_sha || "HEAD~1";
 
     // Files changed
-    const diffResult = await execaCommand(`git diff --name-only ${baseRef}`, { reject: false });
+    const diffResult = await execa("git", ["diff", "--name-only", String(baseRef)], { reject: false });
     if (diffResult.stdout) {
       const files = diffResult.stdout.split("\n").filter(Boolean);
       context.filesChanged = files.length;
@@ -142,7 +146,7 @@ export async function buildRulesContext({ session, task, iteration, blockingIssu
       // Detect new dependencies
       if (files.includes("package.json")) {
         try {
-          const pkgDiff = await execaCommand(`git diff ${baseRef} -- package.json`, { reject: false });
+          const pkgDiff = await execa("git", ["diff", String(baseRef), "--", "package.json"], { reject: false });
           const addedDeps = (pkgDiff.stdout || "").split("\n")
             .filter(line => line.startsWith("+") && line.includes('"') && !line.startsWith("+++"))
             .map(line => {


### PR DESCRIPTION
## Summary

Re-audit (post-#555/#556/#557) found four exec call sites that PR #555 didn't reach: same shell-injection-vector shape, different child_process APIs.

| Site | Severity | Was | Now |
|---|---|---|---|
| `src/orchestrator/solomon-rules.js:125,145` | HIGH | `execaCommand("git diff --name-only ${baseRef}")` | `execa("git", ["diff", "--name-only", baseRef])` |
| `src/cli.js:576,583` | MEDIUM | `execaCommand("npm view karajan-code version")` | `execa("npm", ["view", "karajan-code", "version"])` |
| `src/orchestrator/config-init.js:33,34` | LOW | `execSync("git init")` etc. | `execFileSync("git", ["init"])` etc. |
| `src/orchestrator/drivers/init-context.js:62` | LOW | `execSync("git rev-parse --show-toplevel")` | `execFileSync("git", ["rev-parse", "--show-toplevel"])` |

After this PR every child_process call in src/ uses tokenised arg arrays; no shell metacharacter expansion anywhere.

## Test plan

- [x] `node --check` on all four files
- [x] `npx vitest run` → **4192/4192 passing**
- [x] `npx eslint src/` → 0 errors