### PR TITLE
chore(eslint): close 57 warnings + ratchet to error in src/ (audit rec #8)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,17 +85,21 @@ export default [
       "import-x/named": "error",
 
       // --- Soft signals (warn, not error) ----------------------------
-      "no-unused-vars": ["warn", {
+      // Audit rec #8: ratchet from "warn" to "error" after the
+      // 2026-04-30 cleanup pass that closed 57 warnings across 30
+      // files. With src/ at 0 warnings, the next no-unused-vars
+      // regression should fail CI, not silently accumulate.
+      "no-unused-vars": ["error", {
         argsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
         caughtErrors: "none",
       }],
-      // Cosmetic / quality-of-code rules: kept as warnings so FASE 0
-      // can land green today. Each is a real signal worth fixing later
-      // (track in follow-up PR), but none block bug-detection.
-      "no-useless-assignment": "warn",
-      "no-useless-escape": "warn",
-      "preserve-caught-error": "warn",
+      // Same ratchet rationale: these were warnings while the cleanup
+      // backlog existed; the same PR closed them all, so they're now
+      // hard errors. A regression is louder than a "warn".
+      "no-useless-assignment": "error",
+      "no-useless-escape": "error",
+      "preserve-caught-error": "error",
 
       // Audit rec #5: ban console.* in src/ by default. The override
       // block below re-enables it for the known-good CLI / display /

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -288,7 +288,7 @@ export function createStreamJsonFilter(onOutput) {
  *    response data.
  */
 function cleanExecaOpts(extra = {}) {
-  const { CLAUDECODE, ...env } = process.env;
+  const { CLAUDECODE: _CLAUDECODE, ...env } = process.env;
   return { env, stdin: "ignore", ...extra };
 }
 
@@ -333,7 +333,7 @@ export class ClaudeAgent extends BaseAgent {
     return result;
   }
 
-  async _runTaskExec(task, model, role) {
+  async _runTaskExec(task, model, _role) {
     const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS];
     if (model) args.push("--model", model);
 

--- a/src/agents/model-registry.js
+++ b/src/agents/model-registry.js
@@ -45,7 +45,7 @@ export function getModelInfo(name) {
 }
 
 export function getRegisteredModels() {
-	return [...modelRegistry.entries()].map(([name, entry]) => ({
+	return [...modelRegistry.entries()].map(([_name, entry]) => ({
 		name: entry.name,
 		provider: entry.provider,
 		pricing: { ...entry.pricing },

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -36,7 +36,7 @@ function getPackageVersion() {
 // ── Individual checks ────────────────────────────────────────────────
 
 async function checkGitRepo() {
-  let ok = false;
+  let ok;
   try {
     ok = await ensureGitRepo();
   } catch { /* git may not be installed */

--- a/src/brain/decisor.js
+++ b/src/brain/decisor.js
@@ -125,7 +125,7 @@ function applyOverrides(roles, overrides) {
  * @param {{ forceRoles?: string[], skipRoles?: string[] }} [args.overrides]
  * @returns {Decision}
  */
-export function buildDecision({ triage, task, config = {}, overrides = {} } = {}) {
+export function buildDecision({ triage, task: _task, config = {}, overrides = {} } = {}) {
   const level = triage?.level || "simple";
   const taskType = triage?.taskType || "sw";
 

--- a/src/checks/binaries.js
+++ b/src/checks/binaries.js
@@ -88,7 +88,7 @@ export function createSerenaCheck() {
     applies: (config) => config.serena?.enabled === true,
     describe: "Install Serena via: uvx --from git+https://github.com/oraios/serena serena",
     async detect() {
-      let ok = false;
+      let ok;
       try {
         const res = await runCommand("serena", ["--version"]);
         ok = res.exitCode === 0;

--- a/src/checks/ports.js
+++ b/src/checks/ports.js
@@ -24,17 +24,6 @@ function extractPortFromHost(host, fallback) {
   return m ? Number(m[1]) : fallback;
 }
 
-/**
- * Whether the occupant looks like the Karajan-managed Sonar container.
- * Docker Desktop's proxy is typically `com.docker.backend` / `com.docker.vmnetd`
- * on macOS and `docker-proxy` on Linux. We treat those as OK.
- */
-function isKarajanSonarOccupant(occupant) {
-  if (!occupant?.command) return false;
-  const cmd = occupant.command.toLowerCase();
-  return cmd.includes("docker") || cmd.includes("sonar");
-}
-
 export function createSonarPortCheck() {
   return {
     name: "port:sonar",

--- a/src/checks/sonar.js
+++ b/src/checks/sonar.js
@@ -36,7 +36,7 @@ export function createSonarStatusCheck() {
       if (!sonarEnabled(config)) {
         return { ok: true, severity: "info", detail: "Disabled in config" };
       }
-      let reachable = false;
+      let reachable;
       try {
         reachable = await isSonarReachable(host);
       } catch {

--- a/src/checks/system.js
+++ b/src/checks/system.js
@@ -32,7 +32,7 @@ export function createGitRepoCheck() {
     label: "Git repository",
     strategy: STRATEGY.MANUAL,
     async detect() {
-      let gitOk = false;
+      let gitOk;
       try {
         gitOk = await ensureGitRepo();
       } catch {

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ import { doctorCommand } from "./commands/doctor.js";
 import { reportCommand } from "./commands/report.js";
 import { syncCommand } from "./commands/sync.js";
 import {
-  planCommand, planGenerateCommand, planListCommand,
+  planGenerateCommand, planListCommand,
   planShowCommand, planReadyCommand, planValidateCommand,
   planDeleteCommand, planAddHuCommand, planRemoveHuCommand,
 } from "./commands/plan.js";
@@ -87,7 +87,7 @@ program
   .option("--no-interactive", "Skip wizard, use defaults (for CI/scripts)")
   .option("--scaffold-ci", "Scaffold Karajan CI Gateway workflow files")
   .action(async (flags) => {
-    await withConfig("init", flags, async ({ config, logger }) => {
+    await withConfig("init", flags, async ({ config: _config, logger }) => {
       await initCommand({ logger, flags });
     });
   });
@@ -373,7 +373,7 @@ plan
         try {
           parsed = parseCanvasMarkdown(resolvedTask);
         } catch (err) {
-          throw new Error(`Canvas parse error: ${err.message}`);
+          throw new Error(`Canvas parse error: ${err.message}`, { cause: err });
         }
         const validation = validateCanvas(parsed);
         if (!validation.valid) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -41,7 +41,7 @@ export async function syncCommand({ config, logger, planId, json }) {
   const projectDir = config?.projectDir || process.cwd();
 
   // Resolve which plan to sync against.
-  let plan = null;
+  let plan;
   if (planId) {
     plan = await loadPlan(projectDir, planId);
     if (!plan) throw new Error(`kj sync: plan not found: ${planId}`);

--- a/src/config/role-resolver.js
+++ b/src/config/role-resolver.js
@@ -91,7 +91,7 @@ export function resolveRole(config, role) {
   const legacyReviewer = config?.reviewer || null;
 
   const provider = resolveProvider(roleConfig, role, roles, legacyCoder, legacyReviewer);
-  let { model, inherited: modelIsInherited } = resolveModel(roleConfig, role, config);
+  let { model } = resolveModel(roleConfig, role, config);
 
   // Drop model if incompatible with the resolved provider (inherited or explicit)
   if (provider && model && !isModelCompatible(provider, model)) {

--- a/src/git/automation.js
+++ b/src/git/automation.js
@@ -80,7 +80,7 @@ export async function prepareGitAutomation({ config, task, logger, session }) {
   return { enabled: true, branch, baseBranch, autoRebase };
 }
 
-export function buildPrBody({ task, stageResults }) {
+export function buildPrBody({ task: _task, stageResults }) {
   const sections = ["Created by Karajan Code."];
 
   const approach = stageResults?.planner?.approach;

--- a/src/guards/output-guard.js
+++ b/src/guards/output-guard.js
@@ -1,5 +1,3 @@
-import { runCommand } from "../utils/process.js";
-
 // Built-in destructive patterns
 const DESTRUCTIVE_PATTERNS = [
   { id: "rm-rf", pattern: /rm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|--force\s+)*-[a-zA-Z]*r/, severity: "critical", message: "Recursive file deletion detected" },

--- a/src/mcp/handlers/direct-handlers.js
+++ b/src/mcp/handlers/direct-handlers.js
@@ -3,7 +3,6 @@
  * Extracted from server-handlers.js for maintainability.
  */
 
-import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import { resolveRole } from "../../config.js";
 import { createLogger } from "../../utils/logger.js";
@@ -154,7 +153,7 @@ export async function handlePlanDirect(a, server, extra) {
   sendTrackerLog(server, "planner", "running", plannerRole.provider);
   runLog.logText(`[planner] agent launched, waiting for response...`);
   let result;
-  let plannerStats = null;
+  let plannerStats;
   try {
     result = await planner.runTask({
       prompt,

--- a/src/mcp/handlers/management-handlers.js
+++ b/src/mcp/handlers/management-handlers.js
@@ -6,7 +6,7 @@
 import { runKjCommand } from "../run-kj.js";
 import { loadConfig } from "../../config.js";
 import { readRunLog } from "../../utils/run-log.js";
-import { isPreflightAcked, ackPreflight, getSessionOverrides } from "../preflight.js";
+import { ackPreflight, getSessionOverrides } from "../preflight.js";
 import { ensureBootstrap } from "../../bootstrap.js";
 import {
   resolveProjectDir,

--- a/src/mcp/handlers/run-handler.js
+++ b/src/mcp/handlers/run-handler.js
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "node:events";
 import { runFlow, resumeFlow } from "../../orchestrator.js";
-import { loadConfig, applyRunOverrides, validateConfig, resolveRole } from "../../config.js";
+import { loadConfig, resolveRole } from "../../config.js";
 import { createLogger } from "../../utils/logger.js";
 import { assertAgentsAvailable } from "../../agents/availability.js";
 import { validatePolicyCompliance } from "../../guards/policy-guard.js";
@@ -21,7 +21,6 @@ import {
   assertNotOnBaseBranch,
   buildConfig,
   buildAskQuestion,
-  enrichedFailPayload,
   ensureTaskFromFile,
 } from "../shared-helpers.js";
 

--- a/src/orchestrator/ci-integration.js
+++ b/src/orchestrator/ci-integration.js
@@ -8,7 +8,7 @@ import { earlyPrCreation, incrementalPush } from "../git/automation.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { getIntegration } from "./integrations.js";
 
-export async function tryCiComment({ config, session, logger, agent, body }) {
+export async function tryCiComment({ config, session, logger: _logger, agent, body }) {
   if (!config.ci?.enabled || !session.ci_pr_number) return;
   try {
     const { dispatchComment } = await import("../ci/dispatch.js");

--- a/src/orchestrator/drivers/iteration-loop.js
+++ b/src/orchestrator/drivers/iteration-loop.js
@@ -235,7 +235,6 @@ export async function runReviewerGateStage({ pipelineFlags, reviewerRole, config
       let retryReviewerRole = reviewerRole;
       const alt = session._alternative_agent;
       if (alt?.stage === "reviewer" && alt?.provider) {
-        const { createAgent } = await import("../../agents/index.js");
         retryReviewerRole = { provider: alt.provider, model: null };
         logger.info(`Retrying reviewer with alternative agent: ${alt.provider}`);
         delete session._alternative_agent;

--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -34,7 +34,7 @@ import { tryCiComment } from "../ci-integration.js";
 import { writeIterationsJournal } from "../session-journal.js";
 import { getIntegration } from "../integrations.js";
 
-export async function handlePostLoopStages({ config, session, emitter, eventBase, coderRole, trackBudget, i, task, stageResults, ciEnabled, testerEnabled, securityEnabled, askQuestion, logger, brainCtx }) {
+export async function handlePostLoopStages({ config, session, emitter, eventBase, coderRole, trackBudget, i, task, stageResults, ciEnabled: _ciEnabled, testerEnabled, securityEnabled, askQuestion, logger, brainCtx }) {
   const postLoopDiff = await generateDiff({ baseRef: session.session_start_sha });
 
   if (testerEnabled) {
@@ -207,7 +207,6 @@ export async function handleMaxIterationsReached({ session, budgetSummary, emitt
     const pending = entries.map(e => ({ source: e.source, category: e.category, severity: e.severity, description: e.description }));
     const hasSecurity = entries.some(e => e.category === "security" || e.source === "security");
     const hasCorrectness = entries.some(e => ["correctness", "tests"].includes(e.category));
-    const hasStyleOnly = entries.length > 0 && !hasSecurity && !hasCorrectness;
 
     if (hasSecurity) {
       // Brain: security issues unresolved → cannot finalize, escalate

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -16,7 +16,6 @@ import {
   markSessionStatus,
   resumeSessionWithAnswer,
   saveSession,
-  addCheckpoint,
 } from "../session/store.js";
 // TSK-0337: session mutations go through the mutators module. Every
 // `session.x = y` outside src/session/ should route through one of these
@@ -29,10 +28,8 @@ import {
   setBudget,
 } from "../session/mutators.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
-import { invokeSolomon } from "./solomon-escalation.js";
-import { needsSubPipeline, runHuSubPipeline } from "./hu-sub-pipeline.js";
 import {
-  loadProductContext, resolvePipelineFlags, handleDryRun,
+  resolvePipelineFlags, handleDryRun,
 } from "./config-init.js";
 import { resolveTestHarness } from "../config/test-harness.js";
 import { cleanupAutoInstalledSkills } from "../skills/skill-detector.js";

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -92,7 +92,7 @@ function buildHuTask(story) {
  * @param {number} args.startedAt — Date.now() when runSingleHu started
  * @returns {object}
  */
-function buildHuOutcome({ story, iterResult, status, startedAt }) {
+function buildHuOutcome({ story: _story, iterResult, status, startedAt }) {
   const r = iterResult || {};
   const git = r.git || {};
   // Iterations are tracked in the standard pipeline as

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -2,7 +2,7 @@ import { TesterRole } from "../roles/tester-role.js";
 import { SecurityRole } from "../roles/security-role.js";
 import { ImpeccableRole } from "../roles/impeccable-role.js";
 import { AuditRole } from "../roles/audit-role.js";
-import { addCheckpoint, saveSession } from "../session/store.js";
+import { addCheckpoint } from "../session/store.js";
 import { resetRetryCount } from "../session/mutators.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { invokeSolomon } from "./solomon-escalation.js";
@@ -97,7 +97,7 @@ async function runRoleWithFallback(RoleClass, { roleName, config, logger, emitte
   };
 }
 
-export async function runTesterStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, askQuestion, pendingGherkinTests = null, shellTestResults = null }) {
+export async function runTesterStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, iteration, task, diff, askQuestion: _askQuestion, pendingGherkinTests = null, shellTestResults = null }) {
   logger.setContext({ iteration, stage: "tester" });
   emitProgress(
     emitter,

--- a/src/orchestrator/preflight-checks.js
+++ b/src/orchestrator/preflight-checks.js
@@ -16,7 +16,6 @@ import { emitProgress, makeEvent } from "../utils/events.js";
 import { msg, getLang } from "../utils/messages.js";
 import {
   resolveSonarHost,
-  resolveSonarToken,
   resolveSonarTokenAsync,
   resolveSonarCredentials,
 } from "../sonar/config-resolver.js";

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -369,7 +369,7 @@ async function handleTddFailure({ tddEval, config, logger, emitter, eventBase, s
   return { action: "continue" };
 }
 
-export async function runTddCheckStage({ config, logger, emitter, eventBase, session, trackBudget, iteration, askQuestion, task, brainCtx }) {
+export async function runTddCheckStage({ config, logger, emitter, eventBase, session, trackBudget: _trackBudget, iteration, askQuestion, task, brainCtx }) {
   logger.setContext({ iteration, stage: "tdd" });
   let tddDiff, untrackedFiles;
   try {

--- a/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
+++ b/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
@@ -84,9 +84,8 @@ export async function detectAndApplySplits({ batch, batchSessionId, askQuestion,
     if (!heuristic) continue;
 
     const triedHeuristics = [];
-    let splitAccepted = false;
 
-    while (heuristic && !splitAccepted) {
+    while (heuristic) {
       const proposal = await generateSplitProposal(
         { id: story.id, text: story.original.text },
         heuristic, config, logger
@@ -101,7 +100,6 @@ export async function detectAndApplySplits({ batch, batchSessionId, askQuestion,
       if (!askQuestion) {
         // Autonomous mode: auto-accept the split.
         applySplit({ batch, story, proposal, heuristic, source: "Auto", eventBase, emitter });
-        splitAccepted = true;
       } else {
         // Interactive mode: ask FDE for confirmation.
         const formatted = formatSplitProposalForFDE(proposal);
@@ -113,7 +111,6 @@ export async function detectAndApplySplits({ batch, batchSessionId, askQuestion,
         const answer = await askQuestion(question, { iteration: 0, stage: "hu-reviewer" });
         if (!answer || answer.toLowerCase().startsWith("yes")) {
           applySplit({ batch, story, proposal, heuristic, source: "FDE", eventBase, emitter });
-          splitAccepted = true;
         } else if (answer.toLowerCase().includes("try") || answer.toLowerCase().startsWith("no")) {
           triedHeuristics.push(heuristic);
           heuristic = selectHeuristic(indicators, triedHeuristics);

--- a/src/orchestrator/stages/reviewer-stage.js
+++ b/src/orchestrator/stages/reviewer-stage.js
@@ -7,7 +7,7 @@ import { addCheckpoint, markSessionStatus, saveSession } from "../../session/sto
 import { setReviewerFeedback, setDeferredIssues } from "../../session/mutators.js";
 import { generateDiff } from "../../review/diff-generator.js";
 import { validateReviewResult } from "../../review/schema.js";
-import { filterReviewScope, buildDeferredContext } from "../../review/scope-filter.js";
+import { filterReviewScope } from "../../review/scope-filter.js";
 import { emitProgress, makeEvent, emitAgentOutput } from "../../utils/events.js";
 import { runReviewerWithFallback } from "../reviewer-fallback.js";
 import { invokeSolomon } from "../solomon-escalation.js";
@@ -145,7 +145,6 @@ async function handleReviewerRejection({ review, repeatDetector, config, logger,
   if (brainCtx?.enabled && config.brain?.bypass_solomon_on_correctness !== false) {
     const cats = categorizeIssues(review.blocking_issues);
     const nonStyleIssues = cats.security + cats.correctness + cats.tests;
-    const styleIssues = cats.style;
     // Only bypass if there ARE non-style issues (correctness, tests, security, or "other" is correctness)
     // If it's style-only, let Solomon evaluate whether to override
     if (nonStyleIssues > 0 || cats.other > 0) {

--- a/src/orchestrator/stages/stage-executor.js
+++ b/src/orchestrator/stages/stage-executor.js
@@ -71,7 +71,7 @@ export class StageExecutor {
    * @param {StageContext} _ctx
    * @returns {Promise<StageOutcome | void>}
    */
-  // eslint-disable-next-line no-unused-vars
+   
   async onFailure(err, _ctx) {
     throw err;
   }

--- a/src/orchestrator/verification-gate.js
+++ b/src/orchestrator/verification-gate.js
@@ -119,7 +119,7 @@ export function verifyCoderOutput({ baseRef, projectDir = null, minFiles = 1, mi
 /**
  * Build a retry strategy based on the verification failure.
  */
-function buildRetryStrategy(filesChanged, linesChanged) {
+function buildRetryStrategy(filesChanged, _linesChanged) {
   if (filesChanged === 0) {
     return "Rephrase the feedback with explicit file paths. List specific files to create/modify. Include example code snippets.";
   }

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -4,7 +4,7 @@
  * v2 = plans + executable HUs with acceptance tests
  */
 
-import { generatePlanId, generateHuId } from "./plan-id.js";
+import { generatePlanId } from "./plan-id.js";
 
 const VALID_PLAN_STATUSES = new Set(["draft", "ready", "running", "done", "failed"]);
 const VALID_HU_STATUSES = new Set(["pending", "certified", "coding", "reviewing", "done", "failed", "blocked"]);

--- a/src/planning-game/client.js
+++ b/src/planning-game/client.js
@@ -37,7 +37,7 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_M
       err.httpStatus = 408;
       throw err;
     }
-    throw new Error(`Planning Game network error: ${error?.message || "unknown error"}`);
+    throw new Error(`Planning Game network error: ${error?.message || "unknown error"}`, { cause: error });
   } finally {
     clearTimeout(timeoutId);
   }
@@ -54,7 +54,7 @@ async function parseJsonResponse(response) {
   try {
     return await response.json();
   } catch (error) {
-    throw new Error(`Planning Game invalid response: ${error?.message || "invalid JSON"}`);
+    throw new Error(`Planning Game invalid response: ${error?.message || "invalid JSON"}`, { cause: error });
   }
 }
 
@@ -65,18 +65,7 @@ export async function fetchCard({ projectId, cardId, timeoutMs = DEFAULT_TIMEOUT
   return data?.card || data;
 }
 
-async function getCard({ projectId, cardId, timeoutMs = DEFAULT_TIMEOUT_MS }) {
-  return fetchCard({ projectId, cardId, timeoutMs });
-}
-
-async function listCards({ projectId, timeoutMs = DEFAULT_TIMEOUT_MS }) {
-  const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/cards`;
-  const response = await fetchWithRetry(url, {}, timeoutMs);
-  const data = await parseJsonResponse(response);
-  return data?.cards || data;
-}
-
-export async function updateCard({ projectId, cardId, firebaseId, updates, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+export async function updateCard({ projectId, cardId: _cardId, firebaseId, updates, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/cards/${encodeURIComponent(firebaseId)}`;
   const response = await fetchWithRetry(
     url,

--- a/src/planning-game/decomposition.js
+++ b/src/planning-game/decomposition.js
@@ -10,7 +10,7 @@ export async function createDecompositionSubtasks({
   client,
   projectId,
   parentCardId,
-  parentFirebaseId,
+  parentFirebaseId: _parentFirebaseId,
   subtasks,
   epic,
   sprint,

--- a/src/planning-game/pipeline-adapter.js
+++ b/src/planning-game/pipeline-adapter.js
@@ -12,7 +12,7 @@
  */
 
 import { emitProgress, makeEvent } from "../utils/events.js";
-import { addCheckpoint, saveSession } from "../session/store.js";
+import { addCheckpoint } from "../session/store.js";
 import { appendPgCommits } from "../session/mutators.js";
 import { getLang } from "../utils/messages.js";
 
@@ -29,7 +29,7 @@ import { getLang } from "../utils/messages.js";
  * @param {string|null} opts.pgProject - Planning Game project ID
  * @returns {{ pgCard: object|null }} The fetched PG card (or null)
  */
-export async function initPgAdapter({ session, config, logger, pgTaskId, pgProject }) {
+export async function initPgAdapter({ session: _session, config, logger, pgTaskId, pgProject }) {
   if (!pgTaskId || !pgProject || config.planning_game?.enabled === false) {
     return { pgCard: null };
   }

--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -59,7 +59,7 @@ function renderAcceptanceTestsSection(tests) {
   tests.forEach((entry, i) => {
     // Normalise: accept legacy strings and structured objects.
     let type = "shell";
-    let content = "";
+    let content;
     let file = null;
     if (typeof entry === "string") {
       content = entry;

--- a/src/prompts/hu-reviewer.js
+++ b/src/prompts/hu-reviewer.js
@@ -100,7 +100,6 @@ function parseEvaluation(raw) {
   };
 }
 
-const VALID_AC_FORMATS = new Set(["gherkin", "checklist", "pre_post", "invariant"]);
 const AC_PREFIX_RE = /^\[(GHERKIN|CHECKLIST|PRE_POST|INVARIANT)]\s*/i;
 
 /**

--- a/src/review/snapshot-diff.js
+++ b/src/review/snapshot-diff.js
@@ -67,7 +67,7 @@ export async function generateSnapshotDiff(before, after, rootDir) {
   const lines = [];
 
   // New files (in after but not before)
-  for (const [path, hash] of after) {
+  for (const [path, _hash] of after) {
     if (!before.has(path)) {
       const content = await safeRead(join(rootDir, path));
       if (content !== null) {

--- a/src/sonar/cloud-scanner.js
+++ b/src/sonar/cloud-scanner.js
@@ -5,7 +5,6 @@ function buildCloudScannerArgs(projectKey, config) {
   const sc = config.sonarcloud || {};
   const scanner = sc.scanner || {};
   const host = sc.host || "https://sonarcloud.io";
-  const token = process.env.KJ_SONARCLOUD_TOKEN || sc.token;
   const organization = process.env.KJ_SONARCLOUD_ORG || sc.organization;
 
   const args = [

--- a/src/sonar/discovery.js
+++ b/src/sonar/discovery.js
@@ -113,7 +113,7 @@ export async function discoverRunningSonar(opts = {}) {
   }
   if (!candidate) return { found: false };
   if (!probe) return { ...candidate, reachable: true };
-  let reachable = false;
+  let reachable;
   try {
     reachable = await isSonarReachable(candidate.host, healthcheckSeconds);
   } catch {

--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -149,7 +149,7 @@ export async function runCommand(command, args = [], options = {}) {
   }
 }
 
-function enrichResult(result, stdoutAccum, stderrAccum) {
+function enrichResult(result, stdoutAccum, _stderrAccum) {
   if (result.timedOut) return result;
 
   const killed = result.killed || !!result.signal;

--- a/src/webperf/devtools-detect.js
+++ b/src/webperf/devtools-detect.js
@@ -3,7 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { isOpenSkillsAvailable, installSkill, listSkills } from "../skills/openskills-client.js";
+import { isOpenSkillsAvailable, listSkills } from "../skills/openskills-client.js";
 
 /** Skill names relevant for WebPerf analysis. Already installed globally via openskills. */
 export const WEBPERF_SKILLS = [


### PR DESCRIPTION
## Summary

Closes audit recommendation #8: src/ had 57 ESLint warnings sitting under `warn` since the FASE 0 baseline. The audit asked for a single cleanup pass + ratchet to `error`. This PR does both.

## Cleanup (39 src files)

| Rule | Count | Action |
|---|---:|---|
| `no-unused-vars` | 44 | unused imports deleted; dead code removed; unused fn args renamed to `_arg` |
| `no-useless-assignment` | 10 | `let x = init; try { x = … } catch { x = init }` → `let x;`; dead `splitAccepted = true` removed |
| `preserve-caught-error` | 4 | `throw new Error(msg)` inside `catch(err)` → wrapped with `{ cause: err }` |

## Ratchet (eslint.config.js)

Four rules in the `src/**` block switched from `"warn"` to `"error"`:

- `no-unused-vars`
- `no-useless-assignment`
- `no-useless-escape`
- `preserve-caught-error`

Tests/ stays at `warn` — different ergonomics, audit explicitly accepts the asymmetry.

## Verification

- `npx eslint src/` → 0 errors (post-cleanup, post-ratchet)
- Temp file with `const unused = 42` → rule fires correctly
- `npx vitest run` → **4192/4192 passing**