### PR TITLE
chore(imports): Node subpath imports for orchestrator phases (audit rec #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
   "engines": {
     "node": ">=20.10.0"
   },
+  "imports": {
+    "#utils/*": "./src/utils/*",
+    "#session/*": "./src/session/*",
+    "#hu/*": "./src/hu/*",
+    "#skills/*": "./src/skills/*"
+  },
   "files": [
     "src/",
     "bin/",

--- a/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
+++ b/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
@@ -15,7 +15,7 @@
  *   - Auto-starts the HU board (skipped under VITEST / NODE_ENV=test).
  */
 
-import { emitProgress, makeEvent } from "../../../utils/events.js";
+import { emitProgress, makeEvent } from "#utils/events.js";
 
 export async function maybeGenerateAutoHuBatch({
   flags, stageResults, task, logger, emitter, eventBase, projectDir, session,
@@ -29,7 +29,7 @@ export async function maybeGenerateAutoHuBatch({
   const subtasks = stageResults.triage?.subtasks;
   if (!shouldDecompose || !Array.isArray(subtasks) || subtasks.length < 2) return;
 
-  const { generateHuBatch } = await import("../../../hu/auto-generator.js");
+  const { generateHuBatch } = await import("#hu/auto-generator.js");
 
   // Detect if project is new: empty dir or only .git/.karajan/.gitignore
   let isNewProject = false;
@@ -63,7 +63,7 @@ export async function maybeGenerateAutoHuBatch({
   try {
     const fs = await import("node:fs/promises");
     const path = await import("node:path");
-    const { getKarajanHome } = await import("../../../utils/paths.js");
+    const { getKarajanHome } = await import("#utils/paths.js");
     const huDir = path.join(getKarajanHome(), "hu-stories", batchSessionId);
     await fs.mkdir(huDir, { recursive: true });
     const persistBatch = {

--- a/src/orchestrator/drivers/pre-loop-phases/config-deprecations.js
+++ b/src/orchestrator/drivers/pre-loop-phases/config-deprecations.js
@@ -14,7 +14,7 @@
  *   - `--no-sonar` CLI flag → ignored
  */
 
-import { emitProgress, makeEvent } from "../../../utils/events.js";
+import { emitProgress, makeEvent } from "#utils/events.js";
 
 export function emitConfigDeprecations(config, logger, emitter, eventBase) {
   const dep = config?._deprecated;

--- a/src/orchestrator/drivers/pre-loop-phases/ensure-addyosmani-skills.js
+++ b/src/orchestrator/drivers/pre-loop-phases/ensure-addyosmani-skills.js
@@ -19,10 +19,10 @@
 import {
   refreshIfStale as refreshAddyosmaniCatalog,
   listAvailableSlugs as listAddyosmaniSlugs,
-} from "../../../skills/addyosmani-catalog.js";
-import { resolveAddyosmaniSlugs } from "../../../skills/addyosmani-role-map.js";
-import { setAddyosmaniSkills } from "../../../session/mutators.js";
-import { emitProgress, makeEvent } from "../../../utils/events.js";
+} from "#skills/addyosmani-catalog.js";
+import { resolveAddyosmaniSlugs } from "#skills/addyosmani-role-map.js";
+import { setAddyosmaniSkills } from "#session/mutators.js";
+import { emitProgress, makeEvent } from "#utils/events.js";
 
 export async function ensureAddyosmaniSkills({ task, config, logger, session, emitter, eventBase }) {
   const skillsConfig = config?.skills || {};

--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -26,12 +26,12 @@
  * mutator-routing invariant.
  */
 
-import { saveSession } from "../../../session/store.js";
+import { saveSession } from "#session/store.js";
 import {
   setPlanRef, setPlanSyncCallback, setLiveStatusUpdater,
   setLiveOutcomeUpdater, setPreLoopContext,
-} from "../../../session/mutators.js";
-import { emitProgress, makeEvent } from "../../../utils/events.js";
+} from "#session/mutators.js";
+import { emitProgress, makeEvent } from "#utils/events.js";
 
 /**
  * @param {object} args

--- a/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
+++ b/src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js
@@ -23,10 +23,10 @@
  * function parameters.
  */
 
-import { saveHuBatch, updateStoryStatus } from "../../../hu/store.js";
-import { emitProgress, makeEvent } from "../../../utils/events.js";
-import { detectIndicators, selectHeuristic } from "../../../hu/splitting-detector.js";
-import { generateSplitProposal, formatSplitProposalForFDE, buildSplitDependencies } from "../../../hu/splitting-generator.js";
+import { saveHuBatch, updateStoryStatus } from "#hu/store.js";
+import { emitProgress, makeEvent } from "#utils/events.js";
+import { detectIndicators, selectHeuristic } from "#hu/splitting-detector.js";
+import { generateSplitProposal, formatSplitProposalForFDE, buildSplitDependencies } from "#hu/splitting-generator.js";
 
 /**
  * Build a fresh sub-HU story object from a proposal entry. Same


### PR DESCRIPTION
## Summary

Closes audit recommendation #6: orchestrator phase directories used 3-level relative imports (`../../../utils/events.js` etc.) that coupled them to the whole src tree shape.

Added Node's `imports` map to package.json:

```json
"imports": {
  "#utils/*":   "./src/utils/*",
  "#session/*": "./src/session/*",
  "#hu/*":      "./src/hu/*",
  "#skills/*":  "./src/skills/*"
}
```

Replaced 13 deep imports across 5 files. No logic touched.

## Files migrated

- `src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js`
- `src/orchestrator/drivers/pre-loop-phases/config-deprecations.js`
- `src/orchestrator/drivers/pre-loop-phases/ensure-addyosmani-skills.js`
- `src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js`
- `src/orchestrator/stages/hu-reviewer-phases/detect-and-apply-splits.js`

## Test plan

- [x] `node --check` on all 5 modified files
- [x] `npx vitest run` → **4192/4192 passing**