### PR TITLE
chore: per-dir coverage thresholds + run-log doc update (audit recs #7 + perf-LOW)

### DIFF
--- a/src/utils/run-log.js
+++ b/src/utils/run-log.js
@@ -57,6 +57,18 @@ export function createRunLog(projectDir) {
   // Truncate/create the log file
   fs.writeFileSync(logPath, `--- Karajan run started at ${new Date().toISOString()} ---\n`);
 
+  // Audit recommendation (perf-LOW): suggested createWriteStream + queue.
+  // Tried it; broke the contract. `readRunLog` (used by `kj_status`,
+  // `kj-tail`, and the HU board's chokidar tick) reads the file with
+  // `fs.readFileSync` and expects every prior write to be visible the
+  // moment the writer's `logEvent()` returns — which is what
+  // `fs.writeSync(fd, ...)` guarantees and `stream.write()` does NOT.
+  //
+  // The current shape is already opened-once: `fs.openSync(logPath, "a")`
+  // returns an fd that every subsequent `fs.writeSync` reuses (no extra
+  // open/close per call). The hot-path complaint was about the FALLBACK
+  // `fs.appendFileSync` line, which only fires when openSync itself
+  // fails (rare; FS error or RO mount).
   let fd = null;
   try {
     fd = fs.openSync(logPath, "a");

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -24,6 +24,37 @@ export default defineConfig({
       "demo/**"
     ],
     setupFiles: ["./tests/setup.js"],
-    testTimeout: 30000
+    testTimeout: 30000,
+    // Audit recommendation #7: per-directory coverage thresholds for the
+    // areas the audit flagged as "large surfaces with no same-name test
+    // file". Coverage isn't a CI gate yet (would block PRs unrelated to
+    // these dirs); when run with `npx vitest run --coverage` the values
+    // below are enforced only when the user explicitly opts in.
+    //
+    // Why `thresholds.perFile: false`: file-level thresholds are too
+    // strict for a project this size; we want directory-level signal.
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["src/**/*.js"],
+      exclude: [
+        "src/**/*.test.js",
+        "src/cli.js",                  // the CLI entry — exercised by e2e
+        "src/mcp/server.js",           // long-running process, hard to unit
+      ],
+      thresholds: {
+        // Per-glob targets reflect the audit's prioritisation:
+        // - agents/ talk to LLM SDKs and have lots of branches → 80%
+        // - mcp/handlers/ are the public RPC surface → 80%
+        // - session/journal/ persists run state → 70% (lots of fs IO)
+        "src/agents/**/*.js": { lines: 80, functions: 80 },
+        "src/mcp/handlers/**/*.js": { lines: 80, functions: 80 },
+        "src/session/journal/**/*.js": { lines: 70, functions: 70 },
+        // Defaults for everything else: keep low so coverage runs are
+        // useful as a signal without flipping into a blocking gate.
+        lines: 40,
+        functions: 40,
+      },
+    },
   }
 });


### PR DESCRIPTION
## Summary

Two small audit follow-ups bundled.

### #7: Per-directory coverage thresholds (vitest.config.js)

Coverage opt-in (no CI gate flip): `npx vitest run --coverage` enforces:

| Glob | Threshold |
|---|---|
| `src/agents/**` | lines/functions ≥ 80% |
| `src/mcp/handlers/**` | lines/functions ≥ 80% |
| `src/session/journal/**` | lines/functions ≥ 70% |
| (default) | ≥ 40% |

`src/cli.js` and `src/mcp/server.js` excluded (e2e-covered, hard to unit).

### perf-LOW: run-log createWriteStream — REJECTED, comment updated

Audit suggested switching from `fs.openSync+writeSync` to `fs.createWriteStream`. Tried it — broke the public contract: `readRunLog` (kj_status, kj-tail, HU board) reads sync via `fs.readFileSync` and expects writes visible immediately. `stream.write()` doesn't guarantee that without explicit drain.

Reverted. Updated the in-source comment to document why the sync shape is correct here (fd opened ONCE per run, `appendFileSync` fallback only on the `openSync` failure path — not the hot path the audit interpreted).

## Test plan

- [x] `npx vitest run tests/run-log` → 14/14
- [x] `npx vitest run` → **4192/4192 passing**