### PR TITLE
ci: add shrink-budget workflow to cap LOC growth per PR

### DIFF
--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -1,0 +1,168 @@
+# Shrink Budget — prevents uncontrolled LOC growth.
+#
+# Fires on PRs to main and computes the net LOC delta (added - removed) of
+# source files vs. the base branch. If a PR adds more than LOC_LIMIT net
+# lines without paired removals, the job fails. Authors who legitimately
+# need to grow the codebase (e.g. landing a vendored dependency, bringing in
+# a new orchestrator stage) can apply the `shrink-budget-exempt` label on
+# the PR — the job is skipped entirely.
+#
+# A separate, non-blocking check warns when package.json adds new entries
+# under `dependencies` or `devDependencies`. To silence the warning, apply
+# the `new-dep-approved` label or justify the new dep in the PR body.
+#
+# Source: kj_audit 2026-05-03 finding #3 (codeQuality, high impact) —
+# the repo grew +47% LOC in 4 weeks vs ~20% audit-driven cleanup.
+# Ref: KJC-TSK-0352, GitHub issue #573.
+name: Shrink Budget
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  # Net LOC limit per PR before the budget check fails. Tune carefully —
+  # raising this defeats the purpose. Use the `shrink-budget-exempt` label
+  # for one-off exceptions instead.
+  LOC_LIMIT: "500"
+
+jobs:
+  loc-budget:
+    name: Net LOC delta <= ${{ env.LOC_LIMIT }}
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'shrink-budget-exempt') }}
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute net LOC delta
+        id: loc
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Excluded paths: lockfiles, snapshots, build output, vendored
+          # third-party, minified bundles, generated diet baselines, and
+          # binary fixtures. Each entry is a glob pattern interpreted by
+          # `git diff --diff-filter=AM ... -- :(exclude)<pattern>`.
+          excludes=(
+            ":(exclude)package-lock.json"
+            ":(exclude)pnpm-lock.yaml"
+            ":(exclude)yarn.lock"
+            ":(exclude)**/*.snap"
+            ":(exclude)**/*.snapshot"
+            ":(exclude)dist/**"
+            ":(exclude)**/dist/**"
+            ":(exclude)node_modules/**"
+            ":(exclude)**/*.min.js"
+            ":(exclude)tests/_diet/**"
+            ":(exclude)public/docs/**"
+          )
+
+          stats=$(git diff --numstat "$BASE_SHA"..."$HEAD_SHA" -- . "${excludes[@]}")
+          # numstat columns: added removed path. Binary files emit '-'; skip those.
+          added=$(echo "$stats" | awk '$1 != "-" { sum += $1 } END { print sum + 0 }')
+          removed=$(echo "$stats" | awk '$2 != "-" { sum += $2 } END { print sum + 0 }')
+          net=$(( added - removed ))
+
+          echo "added=$added"     >> "$GITHUB_OUTPUT"
+          echo "removed=$removed" >> "$GITHUB_OUTPUT"
+          echo "net=$net"         >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Shrink Budget — net LOC delta"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Lines added | $added |"
+            echo "| Lines removed | $removed |"
+            echo "| **Net delta** | **$net** |"
+            echo "| Limit | ${LOC_LIMIT} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce LOC limit
+        env:
+          NET: ${{ steps.loc.outputs.net }}
+        run: |
+          set -euo pipefail
+          if [ "$NET" -gt "${LOC_LIMIT}" ]; then
+            echo "::error::Net LOC delta is $NET, exceeds limit ${LOC_LIMIT}."
+            echo ""
+            echo "Karajan tracks LOC delta per PR to prevent uncontrolled growth"
+            echo "(audit 2026-05-03 found +47% LOC in 4 weeks)."
+            echo ""
+            echo "Options:"
+            echo "  1. Pair the addition with removals so the net stays under ${LOC_LIMIT}."
+            echo "  2. If the growth is unavoidable (vendored dep, new pipeline role,"
+            echo "     legitimate large feature), apply the 'shrink-budget-exempt' label"
+            echo "     to this PR to skip the check."
+            exit 1
+          fi
+          echo "Net LOC delta $NET is within budget (limit ${LOC_LIMIT})."
+
+  new-deps-warning:
+    name: New dependencies (advisory)
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'new-dep-approved') }}
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect new entries in package.json
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Compare base vs head versions of package.json. Extract dep names
+          # from each, then diff to find net additions. We only WARN — this
+          # job is intentionally non-blocking; the LOC budget is the gate.
+          base_pkg=$(git show "$BASE_SHA":package.json 2>/dev/null || echo '{}')
+          head_pkg=$(git show "$HEAD_SHA":package.json 2>/dev/null || echo '{}')
+
+          extract_deps() {
+            echo "$1" | jq -r '
+              [
+                (.dependencies // {} | keys[]),
+                (.devDependencies // {} | keys[])
+              ] | sort | unique | .[]
+            ' 2>/dev/null || true
+          }
+
+          base_deps=$(extract_deps "$base_pkg")
+          head_deps=$(extract_deps "$head_pkg")
+
+          new_deps=$(comm -13 <(echo "$base_deps") <(echo "$head_deps") || true)
+
+          if [ -z "$new_deps" ]; then
+            echo "No new dependencies in this PR."
+            echo "## New dependencies — none" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "::warning::This PR introduces new dependencies. Justify in the PR body or apply the 'new-dep-approved' label."
+            echo "## New dependencies (advisory)"
+            echo ""
+            echo "| Dependency |"
+            echo "| --- |"
+            while IFS= read -r dep; do
+              [ -n "$dep" ] && echo "| \`$dep\` |"
+            done <<< "$new_deps"
+            echo ""
+            echo "Each new dep is install cost + supply-chain surface."
+            echo "Apply the \`new-dep-approved\` label to silence this warning."
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/tests/shrink-budget-workflow.test.js
+++ b/tests/shrink-budget-workflow.test.js
@@ -1,0 +1,86 @@
+// Structural test for .github/workflows/shrink-budget.yml.
+//
+// The workflow itself is shell + GitHub Actions, not testable as a unit.
+// What we CAN test is that the YAML parses, has the two expected jobs,
+// keeps the env-level LOC_LIMIT switch, and preserves the label-based
+// opt-out ("shrink-budget-exempt", "new-dep-approved"). These are the
+// pieces that, if accidentally renamed or removed, would silently disable
+// the budget guard.
+//
+// Source: KJC-TSK-0352 / GitHub issue #573 (audit 2026-05-03 finding #3).
+
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import yaml from "js-yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WORKFLOW_PATH = resolve(__dirname, "../.github/workflows/shrink-budget.yml");
+
+async function loadWorkflow() {
+  const raw = await readFile(WORKFLOW_PATH, "utf8");
+  return yaml.load(raw);
+}
+
+describe("shrink-budget workflow", () => {
+  it("parses as valid YAML", async () => {
+    const wf = await loadWorkflow();
+    expect(wf).toBeTypeOf("object");
+    expect(wf.name).toBe("Shrink Budget");
+  });
+
+  it("triggers on pull_request to main", async () => {
+    const wf = await loadWorkflow();
+    // js-yaml parses YAML's `on:` as boolean true (1.1 quirk). Either key
+    // is acceptable as long as exactly one of them maps to the trigger.
+    const onKey = "on" in wf ? "on" : true;
+    const trigger = wf[onKey] ?? wf.on;
+    expect(trigger?.pull_request?.branches).toContain("main");
+  });
+
+  it("declares LOC_LIMIT at env level (default 500)", async () => {
+    const wf = await loadWorkflow();
+    expect(wf.env?.LOC_LIMIT).toBeDefined();
+    // Allow string or number; YAML coerces depending on quoting.
+    expect(String(wf.env.LOC_LIMIT)).toBe("500");
+  });
+
+  it("defines exactly the two expected jobs", async () => {
+    const wf = await loadWorkflow();
+    const jobNames = Object.keys(wf.jobs ?? {});
+    expect(jobNames.sort()).toEqual(["loc-budget", "new-deps-warning"]);
+  });
+
+  it("loc-budget job has the shrink-budget-exempt label opt-out", async () => {
+    const wf = await loadWorkflow();
+    const ifClause = wf.jobs["loc-budget"].if ?? "";
+    expect(ifClause).toContain("shrink-budget-exempt");
+    expect(ifClause).toContain("contains(github.event.pull_request.labels.*.name");
+  });
+
+  it("new-deps-warning job has the new-dep-approved label opt-out", async () => {
+    const wf = await loadWorkflow();
+    const ifClause = wf.jobs["new-deps-warning"].if ?? "";
+    expect(ifClause).toContain("new-dep-approved");
+  });
+
+  it("both jobs checkout with full history (fetch-depth: 0)", async () => {
+    const wf = await loadWorkflow();
+    for (const jobName of ["loc-budget", "new-deps-warning"]) {
+      const steps = wf.jobs[jobName].steps ?? [];
+      const checkout = steps.find((s) => typeof s.uses === "string" && s.uses.startsWith("actions/checkout"));
+      expect(checkout, `${jobName} must have a checkout step`).toBeDefined();
+      expect(checkout.with?.["fetch-depth"], `${jobName} checkout must use fetch-depth: 0`).toBe(0);
+    }
+  });
+
+  it("loc-budget enforces the limit by failing (exit 1) when net > LOC_LIMIT", async () => {
+    const raw = await readFile(WORKFLOW_PATH, "utf8");
+    // The enforcement step uses bash. We assert the exit-1 contract is
+    // present so a future cleanup that turns the gate into a soft warning
+    // would have to remove this token (and we'd catch it).
+    expect(raw).toMatch(/exit\s+1/);
+    expect(raw).toContain("Net LOC delta is");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/shrink-budget.yml` with two jobs:
  - **`loc-budget`** — fails PRs whose net LOC delta (added − removed) exceeds `500`. Opt out via `shrink-budget-exempt` label.
  - **`new-deps-warning`** — advisory job that flags new entries under `dependencies` / `devDependencies` in `package.json`. Silenced by `new-dep-approved` label.
- Adds `tests/shrink-budget-workflow.test.js` (8 structural tests) that pin the shape of the workflow so accidental edits don't silently disable the gate.

## Why

`kj_audit` (2026-05-03) flagged this as **finding #3, high impact**:

> The repo grew **+47% LOC in 4 weeks** while audit-driven cleanup only achieved ~20%. Without a budget, this trend turns Karajan into the internal sprawl we explicitly want to avoid.

Closes the loop with an automated, opt-out gate that runs on every PR — gives the maintainer a moment of friction proportional to the cost of unrestrained growth, while leaving an explicit escape hatch (the label) for legitimate large landings.

## Out of scope

- Other audit findings (deps cleanup, dead exports, HU Board security) — separate cards / issues
- LOC limit tuning (start with 500, adjust later if it proves wrong)

## Test plan

- [x] `npx vitest run tests/shrink-budget-workflow.test.js` → 8/8 passing
- [x] Full suite: `KJ_SKIP_ALL_OPTIN=1 npx vitest run` → 4207/4207 passing, no regressions
- [x] `npm run lint` → clean
- [x] `npm run lint:syntax` → clean
- [x] YAML parses with `python3 -c "import yaml; yaml.safe_load(...)"`
- [ ] First-run validation: this very PR is the first to hit the new workflow. Net delta is +254 (within budget). The job should pass.

## Tracking

- PG card: **KJC-TSK-0352** (project Karajan Code, epic KJC-PCS-0006 DevOps & Installer, plan "Audit cleanup 2026-05-03 Fase 1+2")
- Issue: #573