### PR TITLE
docs: register audit deps false positives (no removals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Audit false positives registry** (`KJC-TSK-0353`, #578) — new
+  `docs/audit-false-positives.md` recording the 4 dependencies that
+  `kj audit` flags as unused but are actually used via indirect
+  mechanisms (config files, hooks, `npx` from scripts): `@changesets/cli`,
+  `@vitest/coverage-v8`, `postject`, `simple-git-hooks`. Future audits
+  skip the same investigation. Re-confirmed live in N8 audit
+  (2026-05-07). No code or dependency changes.
+
 ## [2.11.0] - 2026-05-08
 
 Minor release. Two-day dogfooding pass (10-level test plan) surfaced and

--- a/docs/audit-false-positives.md
+++ b/docs/audit-false-positives.md
@@ -1,0 +1,47 @@
+# Audit false positives — verified non-removable dependencies
+
+> Living document. When a `kj audit` run flags a dependency as unused but
+> manual verification confirms it IS used (typically via config files,
+> hooks, or scripts not imported as JS modules), append an entry below.
+> Doing this prevents future audits from re-opening the same investigation.
+
+## Why this exists
+
+`kj audit` (and the underlying `knip` heuristic) detects dependencies
+that are not statically imported anywhere in the codebase. This catches
+real dead weight, but produces false positives for tools that integrate
+through indirect means:
+
+- **Build/test config files** referenced by name (e.g. a Vitest
+  `provider: "v8"` referencing `@vitest/coverage-v8`).
+- **Git hooks** installed once into `.git/hooks/` by the package itself
+  (e.g. `simple-git-hooks`).
+- **Scripts on disk** invoked via `npx` from shell scripts or CI
+  workflows (e.g. `postject` invoked by `scripts/build-sea.mjs`).
+- **External infrastructure** with config in dot-folders (e.g.
+  `@changesets/cli` driven by `.changeset/config.json`).
+
+If you remove one of these, the corresponding workflow breaks even
+though no JS test fails. Hence: verify before removing.
+
+## Verified false positives (2026-05-04)
+
+Audit run: `kj audit` on 2026-05-03 (PR #577 / KJC-TSK-0352 epoch).
+Investigation tracked in KJC-TSK-0353 / GH issue #574.
+
+| Dependency | Verdict | Evidence |
+| --- | --- | --- |
+| `@changesets/cli` | **Keep** | `.changeset/config.json` references `@changesets/cli/changelog`. PR #360 (Jorge del Casar) is in flight against changesets infra. |
+| `@vitest/coverage-v8` | **Keep** | `vitest.config.js` declares `coverage.provider = "v8"`. Activated when running `npx vitest run --coverage`. |
+| `postject` | **Keep** | `scripts/build-sea.mjs` invokes `npx postject` to inject the SEA blob into the binary. Workflow `release-binaries.yml` depends on this for every release. |
+| `simple-git-hooks` | **Keep** | Hook installed at `.git/hooks/pre-commit` (runs `npx lint-staged`). Config block in `package.json` under `"simple-git-hooks"`. |
+
+## Process for future audits
+
+1. Run `kj audit` and read the `unusedDependencies.unused` list.
+2. For each candidate, before opening a removal PR, grep the entire
+   repo: `grep -rn "<dep-name>" package.json scripts/ .github/ docs/`.
+3. If any indirect usage is found, append an entry to the table above
+   instead of removing the dependency.
+4. Only `npm uninstall` after all four verification paths come back
+   empty (JS imports, config files, scripts, hooks).


### PR DESCRIPTION
## Summary

`kj audit` (2026-05-03) flagged 4 npm deps as unused: `@changesets/cli`, `@vitest/coverage-v8`, `postject`, `simple-git-hooks`. Manual verification confirms **all 4 are false positives** — used via indirect mechanisms that knip's static-import scan misses (config files, hooks, `npx` from scripts, `.changeset/`).

This PR adds `docs/audit-false-positives.md` documenting the verification, so the next contributor (human or AI) doesn't re-open the same investigation.

## What changed

- **New**: `docs/audit-false-positives.md` — verification process + table of confirmed false positives with evidence
- **Modified**: `CHANGELOG.md` — entry under `[Unreleased]` / Infrastructure

**Zero code changes. Zero dependency changes.**

## Why this PR is the right outcome

The original card title said "remove unused deps". Reality: nothing removable. The deliverable that DOES carry value is the documentation — turning a one-time investigation into reusable knowledge. Future audits will skip this path; future contributors get a process to follow before opening removal PRs.

## Verification matrix

| Dep | Verdict | Evidence |
| --- | --- | --- |
| `@changesets/cli` | Keep | `.changeset/config.json` references its changelog. PR #360 (Jorge) in flight on changesets infra. |
| `@vitest/coverage-v8` | Keep | `vitest.config.js` line 37: `provider: "v8"` |
| `postject` | Keep | `scripts/build-sea.mjs` line 88 (`npx postject`) + `release-binaries.yml` |
| `simple-git-hooks` | Keep | `.git/hooks/pre-commit` installed; config in `package.json` |

## Test plan

- [x] Full suite: `KJ_SKIP_ALL_OPTIN=1 npx vitest run` → 4199/4199 passing (357 files), no regression
- [x] `npm run lint` → clean
- [x] `npm run lint:syntax` → clean
- [x] No deps actually removed → `npm ci` would still install everything used

## Tracking

- PG card: **KJC-TSK-0353** (epic KJC-PCS-0023 Lean Software Practices · plan "Audit cleanup 2026-05-03 Fase 1+2")
- Issue: #574