### PR TITLE
refactor(hu-board): demote 4 helpers from export to private (KJC-TSK-0354 PR-B of 5)

### DIFF
--- a/packages/hu-board/public/pipeline.js
+++ b/packages/hu-board/public/pipeline.js
@@ -64,7 +64,7 @@ async function api(path) {
  * appears in the latest iteration and has no "error" marker; "error" if the
  * body of its latest stage contains /error|failed/i.
  */
-export function deriveRoleStatus(iterations) {
+function deriveRoleStatus(iterations) {
   const summary = new Map();
   iterations.forEach((it) => {
     it.stages.forEach((stage) => {

--- a/packages/hu-board/src/journal-parser.js
+++ b/packages/hu-board/src/journal-parser.js
@@ -25,14 +25,14 @@ import path from "node:path";
  * for the common "hu-board runs in a different process from the pipeline"
  * case; otherwise falls back to the current working directory.
  */
-export function getProjectDir() {
+function getProjectDir() {
   return process.env.KJ_PROJECT_DIR || process.cwd();
 }
 
 /**
  * Resolve the `.reviews/` directory under the active project dir.
  */
-export function getReviewsDir() {
+function getReviewsDir() {
   return path.join(getProjectDir(), ".reviews");
 }
 

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -52,7 +52,7 @@ function plansRoot() {
  * @param {string|undefined} projectId
  * @returns {string|null}
  */
-export function findPlanFilePath(planId, projectId) {
+function findPlanFilePath(planId, projectId) {
   const root = plansRoot();
   if (!existsSync(root)) return null;
   const fileName = `${planId}.json`;


### PR DESCRIPTION
## Summary

This is **PR-B of 5** in the dead-exports cleanup (KJC-TSK-0354 / issue #575). Scope: `packages/hu-board/` only.

The audit flagged 8 exports as unused. Manual verification revealed **0 deletions are warranted** — but **4 demotions** (export → private) reduce public surface without touching behavior.

## What changed

3 files, 4 lines modified, 4 lines added (net 0 LOC). All four edits are identical: the keyword `export ` removed in front of a `function` declaration.

| File | Function | Internal callers |
| --- | --- | --- |
| `pipeline.js` | `deriveRoleStatus` | line 83 (in same file) |
| `journal-parser.js` | `getProjectDir` | `getReviewsDir` |
| `journal-parser.js` | `getReviewsDir` | `listSessions`, `readJournal` |
| `plan-mutations.js` | `findPlanFilePath` | `setHuStatus`, `setHuFields`, `markPlanReady`, `runPlan` |

Each function stays exactly as-is — only the `export` keyword is dropped. Reduces the public API surface of these modules.

## False positives — kept exported

The audit also flagged these four, but they ARE used:

| Export | Why kept |
| --- | --- |
| `splitByHeading` | Tested via `parser = await import("../src/journal-parser.js")` (namespace dynamic import — knip can't see property access) |
| `parseIterations` | idem |
| `parseDecisions` | idem |
| `parseSummary` | idem |

Pattern documented in `docs/audit-false-positives.md` (PR #578) — once that lands, this batch will be added under "Test-only namespace imports".

## Test plan

- [x] `npx vitest run --exclude tests/board.test.js` → 4194/4194 passing
- [x] `npm run lint` → clean
- [x] `npm run lint:syntax` → clean
- [x] `tests/board.test.js`: 1 of 5 tests fails locally with a 30s timeout, but **the same test passed in CI on PR #577 and #579 within the last hour**. Local-only environment issue (probably `lsof` slow), not a regression of this PR. Stashing my changes reproduces the same failure → preexisting.

## Tracking

- PG card: **KJC-TSK-0354** (still In Progress; closes when PRs A-E all merged)
- Issue: #575