### PR TITLE
refactor(checks): clean 24 dead exports (KJC-TSK-0354 PR-C of 5)

### DIFF
--- a/src/checks/binaries.js
+++ b/src/checks/binaries.js
@@ -60,7 +60,7 @@ function createCoreBinaryCheck(bin) {
 /**
  * Docker check. Manual strategy (platform-dependent install).
  */
-export function createDockerCheck() {
+function createDockerCheck() {
   return {
     name: "docker",
     label: "Docker",
@@ -80,7 +80,7 @@ export function createDockerCheck() {
 /**
  * Serena MCP (optional). Prompt strategy: we know how to install it.
  */
-export function createSerenaCheck() {
+function createSerenaCheck() {
   return {
     name: "serena",
     label: "Serena MCP",

--- a/src/checks/ci.js
+++ b/src/checks/ci.js
@@ -37,7 +37,7 @@ function createWorkflowCheck(workflow) {
   };
 }
 
-export function createGhCliCheck() {
+function createGhCliCheck() {
   return {
     name: "ci:gh",
     label: "CI: gh CLI",
@@ -55,7 +55,7 @@ export function createGhCliCheck() {
   };
 }
 
-export function createGhSecretsCheck() {
+function createGhSecretsCheck() {
   return {
     name: "ci:secrets",
     label: "CI: GitHub secrets",

--- a/src/checks/config-files.js
+++ b/src/checks/config-files.js
@@ -20,7 +20,7 @@ import { STRATEGY } from "./types.js";
 /**
  * kj.config.yml presence check.
  */
-export function createConfigFileCheck() {
+function createConfigFileCheck() {
   return {
     name: "config",
     label: "Config file",
@@ -42,7 +42,7 @@ export function createConfigFileCheck() {
 /**
  * Review rules (.md) informational check.
  */
-export function createReviewRulesCheck() {
+function createReviewRulesCheck() {
   return {
     name: "review-rules",
     label: "Reviewer rules (.md)",
@@ -63,7 +63,7 @@ export function createReviewRulesCheck() {
 /**
  * Coder rules (.md) informational check.
  */
-export function createCoderRulesCheck() {
+function createCoderRulesCheck() {
   return {
     name: "coder-rules",
     label: "Coder rules (.md)",
@@ -104,7 +104,7 @@ function findDuplicateTomlKeys(content) {
 /**
  * Claude config (~/.claude.json) validity.
  */
-export function createClaudeConfigCheck() {
+function createClaudeConfigCheck() {
   return {
     name: "agent-config:claude",
     label: "Agent config: claude (~/.claude.json)",
@@ -135,7 +135,7 @@ export function createClaudeConfigCheck() {
 /**
  * Codex config (~/.codex/config.toml) validity.
  */
-export function createCodexConfigCheck() {
+function createCodexConfigCheck() {
   return {
     name: "agent-config:codex",
     label: "Agent config: codex (~/.codex/config.toml)",
@@ -173,7 +173,7 @@ export function createCodexConfigCheck() {
 /**
  * KJ config (~/.karajan/kj.config.yml) YAML validity (separate from existence).
  */
-export function createKjConfigYamlCheck() {
+function createKjConfigYamlCheck() {
   return {
     name: "agent-config:karajan",
     label: "Agent config: karajan (kj.config.yml)",

--- a/src/checks/dir-setup.js
+++ b/src/checks/dir-setup.js
@@ -15,6 +15,10 @@ const REQUIRED_DIRS = [
   "logs",
 ];
 
+/**
+ * @internal Exported for dynamic import from tests/checks/dir-setup.test.js
+ * and tests/checks/auto-remediation-e2e.test.js. Knip false positive.
+ */
 export function createKarajanDirsCheck() {
   return {
     name: "karajan-dirs",

--- a/src/checks/mcp-health.js
+++ b/src/checks/mcp-health.js
@@ -86,6 +86,9 @@ async function pingMcpStdio(command, args) {
 /**
  * karajan-mcp health — stdio server bundled with this package.
  * Strategy: auto (we can re-spawn it ourselves).
+ *
+ * @internal Exported for dynamic import from tests/checks/mcp-health.test.js.
+ * Knip false positive.
  */
 export function createKarajanMcpCheck() {
   return {
@@ -121,6 +124,9 @@ export function createKarajanMcpCheck() {
 /**
  * Serena MCP — external tool the user installs themselves. Warn only when
  * enabled in config. Strategy: manual (we don't manage its lifecycle).
+ *
+ * @internal Exported for dynamic import from tests/checks/mcp-health.test.js.
+ * Knip false positive.
  */
 export function createSerenaMcpCheck() {
   return {

--- a/src/checks/ports.js
+++ b/src/checks/ports.js
@@ -24,6 +24,10 @@ function extractPortFromHost(host, fallback) {
   return m ? Number(m[1]) : fallback;
 }
 
+/**
+ * @internal Exported for dynamic import from tests/checks/ports.test.js
+ * and tests/checks/auto-remediation-e2e.test.js. Knip false positive.
+ */
 export function createSonarPortCheck() {
   return {
     name: "port:sonar",
@@ -133,6 +137,10 @@ export function createSonarPortCheck() {
   };
 }
 
+/**
+ * @internal Exported for dynamic import from tests/checks/ports.test.js
+ * and tests/checks/auto-remediation-e2e.test.js. Knip false positive.
+ */
 export function createHuBoardPortCheck() {
   return {
     name: "port:hu-board",

--- a/src/checks/rtk.js
+++ b/src/checks/rtk.js
@@ -8,7 +8,7 @@ import { getInstallCommand } from "../utils/os-detect.js";
 import { withDocLink } from "../utils/doc-links.js";
 import { STRATEGY } from "./types.js";
 
-export function createRtkCheck() {
+function createRtkCheck() {
   return {
     name: "rtk",
     label: "RTK (Rust Token Killer)",

--- a/src/checks/skills.js
+++ b/src/checks/skills.js
@@ -8,10 +8,14 @@ import { isOpenSkillsAvailable } from "../skills/openskills-client.js";
 import { runCommand } from "../utils/process.js";
 import { STRATEGY } from "./types.js";
 
-export function skillsEnabled(config) {
+function skillsEnabled(config) {
   return config?.skills?.enabled !== false;
 }
 
+/**
+ * @internal Exported for dynamic import from tests/checks/skills.test.js
+ * and tests/checks/auto-remediation-e2e.test.js. Knip false positive.
+ */
 export function createOpenSkillsCheck() {
   return {
     name: "openskills",

--- a/src/checks/sonar.js
+++ b/src/checks/sonar.js
@@ -26,7 +26,7 @@ function sonarHost(config) {
  * Informative check: Sonar enabled/disabled status.
  * Produces an OK result with disabled description when Sonar is off.
  */
-export function createSonarStatusCheck() {
+function createSonarStatusCheck() {
   return {
     name: "sonarqube",
     label: "SonarQube",

--- a/src/checks/system.js
+++ b/src/checks/system.js
@@ -14,7 +14,7 @@ function getPackageVersion() {
   return JSON.parse(readFileSync(pkgPath, "utf8")).version;
 }
 
-export function createKarajanVersionCheck() {
+function createKarajanVersionCheck() {
   return {
     name: "karajan",
     label: "Karajan Code",
@@ -26,7 +26,7 @@ export function createKarajanVersionCheck() {
   };
 }
 
-export function createGitRepoCheck() {
+function createGitRepoCheck() {
   return {
     name: "git",
     label: "Git repository",

--- a/src/checks/tokens.js
+++ b/src/checks/tokens.js
@@ -146,4 +146,4 @@ export function getTokenChecks(config) {
 }
 
 // Re-export for tests that need to introspect the mapping.
-export { PROVIDER_TO_CLI, normalizeProvider };
+export { normalizeProvider };

--- a/src/checks/types.js
+++ b/src/checks/types.js
@@ -91,15 +91,3 @@ export const STRATEGY = Object.freeze({
   NONE: "none",
 });
 
-export const SEVERITY = Object.freeze({
-  FAIL: "fail",
-  WARN: "warn",
-  INFO: "info",
-});
-
-/**
- * Whether the final status blocks the pipeline (for preflight).
- */
-export function isBlocking(status) {
-  return status === STATUS.FAIL || status === STATUS.TIMEOUT;
-}


### PR DESCRIPTION
## Summary

Part **C of 5** of [KJC-TSK-0354](https://github.com/manufosela/karajan-code/issues/575) — eliminate the 228 dead exports detected by knip, scoped to `src/checks/`.

- **15** helpers demoted from `export function` → `function` (binaries, ci, config-files, rtk, skills:`skillsEnabled`, sonar, system).
- **3** truly-dead exports removed: `SEVERITY` const + `isBlocking()` in `types.js`, `PROVIDER_TO_CLI` from the `tokens.js` re-export (still defined and used internally).
- **6** helpers kept exported but marked `@internal` via JSDoc — they're imported dynamically by tests, which is exactly the false-positive case the AC anticipates:
  - `createKarajanDirsCheck`
  - `createSonarPortCheck`, `createHuBoardPortCheck`
  - `createOpenSkillsCheck`
  - `createKarajanMcpCheck`, `createSerenaMcpCheck`

## Test plan

- [x] `npx vitest run tests/checks/` — 72/72 passing
- [x] `npx knip` — `src/checks/` reports 0 dead exports
- [x] No external code outside `src/checks/` referenced the removed/demoted symbols (manually grep-verified)

## Follow-up

PR-D (`src/agents+brain/`) and PR-E (rest) still pending.