### PR TITLE
refactor(orchestrator): clean 21 dead exports (KJC-TSK-0354 PR-D of 5)

### DIFF
--- a/src/orchestrator/ci-integration.js
+++ b/src/orchestrator/ci-integration.js
@@ -86,7 +86,7 @@ export async function handleCiEarlyPrOrPush({ ciEnabled, config, session, emitte
   }
 }
 
-export function formatBlockingIssues(issues) {
+function formatBlockingIssues(issues) {
   return issues?.map((x) => `- ${x.id || "ISSUE"} [${x.severity || ""}] ${x.description}`).join("\n") || "";
 }
 

--- a/src/orchestrator/direct-actions.js
+++ b/src/orchestrator/direct-actions.js
@@ -190,4 +190,4 @@ export function getAllowedActionTypes() {
   return Object.keys(ACTION_HANDLERS);
 }
 
-export { ALLOWED_COMMANDS, isCommandAllowed };
+export { isCommandAllowed };

--- a/src/orchestrator/drivers/error-recovery.js
+++ b/src/orchestrator/drivers/error-recovery.js
@@ -119,7 +119,7 @@ export async function handleStandbyResult({ stageResult, session, emitter, event
 }
 
 
-export function emitSolomonAlerts(alerts, emitter, eventBase, logger) {
+function emitSolomonAlerts(alerts, emitter, eventBase, logger) {
   for (const alert of alerts) {
     emitProgress(emitter, makeEvent("brain:rules-alert", { ...eventBase, stage: "brain" }, {
       status: alert.severity === "critical" ? "fail" : "warn",
@@ -198,7 +198,7 @@ export async function handleSolomonCheck({ config, session, emitter, eventBase, 
   return { action: "continue" };
 }
 
-export async function checkSolomonCriticalAlerts({ rulesResult, askQuestion, session, i }) {
+async function checkSolomonCriticalAlerts({ rulesResult, askQuestion, session, i }) {
   if (!rulesResult.hasCritical || !askQuestion) return null;
 
   const alertSummary = rulesResult.alerts

--- a/src/orchestrator/drivers/iteration-loop.js
+++ b/src/orchestrator/drivers/iteration-loop.js
@@ -44,23 +44,13 @@ import { runQualityGateStages } from "./iteration-phases/quality-gates.js";
 import { runReviewerGateStage } from "./iteration-phases/reviewer-gate.js";
 import { handleApprovedReview } from "./iteration-phases/handle-approved.js";
 
-// Re-export for back-compat with any external caller; the canonical
-// definitions now live in ./iteration-phases/.
-export { runCoderAndRefactorerStages } from "./iteration-phases/coder-and-refactorer.js";
-export { runGuardStages } from "./iteration-phases/guards.js";
-export { runQualityGateStages } from "./iteration-phases/quality-gates.js";
-export { runReviewerGateStage } from "./iteration-phases/reviewer-gate.js";
-export { handleApprovedReview } from "./iteration-phases/handle-approved.js";
-
 // `runCoderAndRefactorerStages`, `runGuardStages`, `runQualityGateStages`,
 // `runReviewerGateStage` and `handleApprovedReview` were extracted to
 // ./iteration-phases/ in the v2.7.x audit follow-up (same pattern as
-// pre-loop-phases/). The imports above pull them back in; re-exports
-// keep the previous public surface for any external caller. Behaviour
-// is unchanged.
+// pre-loop-phases/). The back-compat re-exports were removed in
+// KJC-TSK-0354 PR-D — no caller imported them via this module.
 
-
-export async function runSingleIteration(ctx) {
+async function runSingleIteration(ctx) {
   // Use plannedTask (HU-scoped or planner-enriched) over the raw original task.
   // When running per-HU sub-pipelines, plannedTask is the HU's text, not the full spec.
   const { config, logger, emitter, eventBase, session, iteration: i } = ctx;

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -52,9 +52,6 @@ import { emitConfigDeprecations } from "./pre-loop-phases/config-deprecations.js
 import { ensureAddyosmaniSkills } from "./pre-loop-phases/ensure-addyosmani-skills.js";
 import { maybeGenerateAutoHuBatch } from "./pre-loop-phases/auto-hu-batch.js";
 
-// Re-export for back-compat with any external caller; the canonical
-// definitions now live in ./pre-loop-phases/.
-export { ensureAddyosmaniSkills };
 import {
   applyTriageOverrides, applyAutoSimplify, applyFlagOverrides,
   resolvePipelinePolicies, updateGitignoreForStack,
@@ -380,7 +377,7 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
 
   return { plannedTask, updatedConfig };
 }
-export async function runPlanningPhases({ config, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx }) {
+async function runPlanningPhases({ config, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx }) {
   let researchContext = null;
   let plannedTask = task;
 

--- a/src/orchestrator/feedback-queue.js
+++ b/src/orchestrator/feedback-queue.js
@@ -149,4 +149,3 @@ export function deserialize(str) {
   }
 }
 
-export { SEVERITY_ORDER, CATEGORY_ORDER };

--- a/src/orchestrator/integrations.js
+++ b/src/orchestrator/integrations.js
@@ -73,13 +73,6 @@ export function unregisterIntegration(name) {
 }
 
 /**
- * Clear the registry. Test-only; production never calls this.
- */
-export function __clearIntegrations() {
-  registry.clear();
-}
-
-/**
  * List registered integration names. Useful for bootstrap logging.
  * @returns {string[]}
  */

--- a/src/orchestrator/role-output-compressor.js
+++ b/src/orchestrator/role-output-compressor.js
@@ -187,4 +187,3 @@ export function measureCompression(original, compressed) {
   };
 }
 
-export { COMPRESSORS };

--- a/src/orchestrator/session-journal.js
+++ b/src/orchestrator/session-journal.js
@@ -2,7 +2,6 @@
 // Creates .reviews/session_*/ directories containing markdown files per stage.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { runCommand } from "../utils/process.js";
 
 /**
  * Create the journal directory for a session.
@@ -174,29 +173,6 @@ export function formatDecision({ timestamp, trigger, context, action, reasoning 
   return lines.join("\n");
 }
 
-// ── Tree of affected files ───────────────────────────────────────────────────
-
-export async function generateFileTree(baseRef) {
-  try {
-    const result = await runCommand("git", ["diff", "--name-status", `${baseRef}...HEAD`]);
-    if (result.exitCode !== 0 || !result.stdout?.trim()) return null;
-
-    const lines = ["# Affected Files\n"];
-    const statusMap = { M: "modified", A: "added", D: "deleted", R: "renamed" };
-
-    for (const line of result.stdout.trim().split("\n")) {
-      const [status, ...fileParts] = line.split("\t");
-      const file = fileParts.join("\t");
-      const label = statusMap[status?.[0]] || status;
-      lines.push(`- [${label}] ${file}`);
-    }
-
-    return lines.join("\n");
-  } catch {
-    return null;
-  }
-}
-
 // ── Summary ──────────────────────────────────────────────────────────────────
 
 export function generateSummary({ task, result, sessionId, iterations, durationMs, budget, stages, commits, files }) {
@@ -325,20 +301,7 @@ export async function writeDecisionsJournal(journalDir, decisionEntries) {
   await writeJournalFile(journalDir, "decisions.md", content);
 }
 
-/**
- * Write the file tree.
- */
-export async function writeTreeJournal(journalDir, baseRef) {
-  const tree = await generateFileTree(baseRef);
-  if (tree) await writeJournalFile(journalDir, "tree.txt", tree);
-  return Boolean(tree);
-}
-
-/**
- * Write the session summary.
- */
-export async function writeSummaryJournal(journalDir, summaryData) {
-  const files = summaryData.files || [];
-  const content = generateSummary({ ...summaryData, files: [...files, "summary.md"] });
-  await writeJournalFile(journalDir, "summary.md", content);
-}
+// writeTreeJournal / writeSummaryJournal / generateFileTree were
+// superseded in v2.7.x by src/session/journal/{tree-writer,summary-writer}.js
+// (the V2 split). post-loop.js dynamically imports the V2 versions; this
+// orchestrator-side copy is no longer wired anywhere. KJC-TSK-0354 PR-D.

--- a/src/orchestrator/stages/stage-classes.js
+++ b/src/orchestrator/stages/stage-classes.js
@@ -82,5 +82,3 @@ export const stageRegistry = new StageRegistry();
 stageRegistry.register(new TriageStage());
 stageRegistry.register(new CoderStage());
 stageRegistry.register(new ReviewerStage());
-
-export { StageExecutor, StageRegistry };


### PR DESCRIPTION
## Summary

Part **D of 5** of [KJC-TSK-0354](https://github.com/manufosela/karajan-code/issues/575). Re-scoped from the original 'src/agents+brain/' label because knip reported **0** dead exports there — the actual brain of Karajan lives in `src/orchestrator/`, where 21 dead exports were piling up after the V2 refactors.

### What was dead and why
Eight subdrivers carried export surface that nothing imported — split between back-compat shims left by V2 splits and test-only/legacy helpers that survived their callers.

- **Deleted (6 functions/blocks):**
  - `writeTreeJournal`, `writeSummaryJournal`, `generateFileTree` — V2 lives in `src/session/journal/{tree-writer,summary-writer}.js`; `post-loop.js` already dynamically imports the V2 versions.
  - `__clearIntegrations` — test-only helper nobody used.
  - `ensureAddyosmaniSkills` re-export from `pre-loop.js` — V2 in `pre-loop-phases/`.
  - 5 re-exports from `iteration-loop.js` (`runCoderAndRefactorerStages`, `runGuardStages`, `runQualityGateStages`, `runReviewerGateStage`, `handleApprovedReview`) — V2 in `iteration-phases/`.

- **Demoted to private (7, still used internally):**
  - `emitSolomonAlerts`, `checkSolomonCriticalAlerts` (called by `handleSolomonCheck`).
  - `runPlanningPhases`, `runSingleIteration` (called by their host loop).
  - `formatBlockingIssues` (called by ci-integration locally).
  - Removed named re-exports `SEVERITY_ORDER`, `CATEGORY_ORDER`, `COMPRESSORS`, `ALLOWED_COMMANDS` (still defined as module-locals where needed).

- **Removed dead barrel re-export** from `stage-classes.js`: `export { StageExecutor, StageRegistry }`. Tests import `StageExecutor` from `stage-executor.js` directly; nobody uses the barrel surface.

## Test plan

- [x] `npx vitest run` — **4199/4199 passing**
- [x] `npx knip` — `src/orchestrator/` reports 0 dead exports (was 21)
- [x] No external code outside `src/orchestrator/` referenced the removed/demoted symbols (manually grep-verified, including `vi.mock` factories — the only mocking test only relies on `runIterationLoop`, which is untouched)

## Follow-up

PR-E (rest of `src/`: canvas, commands, config, plan, planning-game, prompts, sonar, utils) still pending. After E lands the knip baseline drops from ~228 to <30 — the AC target.