### PR TITLE
refactor: clean 16 dead exports across rest of src/ (KJC-TSK-0354 PR-E of 5)

### DIFF
--- a/src/canvas/schema.js
+++ b/src/canvas/schema.js
@@ -51,7 +51,7 @@ const Operation = v.looseObject({
   acceptance: v.pipe(v.array(AcceptanceTest), v.minLength(1)),
 });
 
-export const CanvasSchema = v.looseObject({
+const CanvasSchema = v.looseObject({
   // Title is the project / feature name. The planner uses it as the
   // plan name unless the user overrides on prompt.
   title: NonEmptyString,

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -77,7 +77,7 @@ function confirmViaTty(describe) {
  * @param {{ config: Object, checkOnly?: boolean, yes?: boolean, onConfirm?: Function, logger?: Object }} args
  * @returns {Promise<import("../checks/types.js").RunReport>}
  */
-export async function runDoctor({ config, checkOnly = false, yes = false, onConfirm, logger }) {
+async function runDoctor({ config, checkOnly = false, yes = false, onConfirm, logger }) {
   const checks = buildChecks(config);
   return runCheckPipeline(checks, { config }, {
     mode: checkOnly ? "check-only" : "fix",

--- a/src/config/test-harness.js
+++ b/src/config/test-harness.js
@@ -76,4 +76,3 @@ export function resolveTestHarness(explicit = {}) {
   return Object.freeze(out);
 }
 
-export { PROD_DEFAULTS, GLOBAL_KEYS };

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -115,20 +115,6 @@ export async function loadPlan(projectDir, planId) {
 }
 
 /**
- * Update a plan on disk (partial merge).
- * @returns {Promise<boolean>}
- */
-export async function updatePlan(projectDir, planId, patch) {
-  const plan = await loadPlan(projectDir, planId);
-  if (!plan) return false;
-  Object.assign(plan, patch);
-  plan.updatedAt = new Date().toISOString();
-  const filePath = path.join(plansDir(projectDir), `${planId}.json`);
-  await fs.writeFile(filePath, JSON.stringify(plan, null, 2), "utf8");
-  return true;
-}
-
-/**
  * Delete a plan from disk.
  * @returns {Promise<boolean>}
  */

--- a/src/planning-game/client.js
+++ b/src/planning-game/client.js
@@ -93,20 +93,6 @@ export async function createCard({ projectId, card, timeoutMs = DEFAULT_TIMEOUT_
   return parseJsonResponse(response);
 }
 
-export async function createAdr({ projectId, adr, timeoutMs = DEFAULT_TIMEOUT_MS }) {
-  const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/adrs`;
-  const response = await fetchWithRetry(
-    url,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(adr)
-    },
-    timeoutMs
-  );
-  return parseJsonResponse(response);
-}
-
 export async function relateCards({ projectId, sourceCardId, targetCardId, relationType, timeoutMs = DEFAULT_TIMEOUT_MS }) {
   const url = `${getApiUrl()}/projects/${encodeURIComponent(projectId)}/cards/relate`;
   const response = await fetchWithRetry(

--- a/src/planning-game/pipeline-adapter.js
+++ b/src/planning-game/pipeline-adapter.js
@@ -42,7 +42,7 @@ export async function initPgAdapter({ session: _session, config, logger, pgTaskI
  * Handle PG task decomposition after triage.
  * Creates subtask cards in PG when triage recommends decomposition.
  */
-export async function handlePgDecomposition({ triageResult, pgTaskId, pgProject, config, askQuestion, emitter, eventBase, session, stageResults, logger }) {
+async function handlePgDecomposition({ triageResult, pgTaskId, pgProject, config, askQuestion, emitter, eventBase, session, stageResults, logger }) {
   const shouldDecompose = triageResult.stageResult?.shouldDecompose
     && triageResult.stageResult.subtasks?.length > 1
     && pgTaskId

--- a/src/prompts/rtk-snippet.js
+++ b/src/prompts/rtk-snippet.js
@@ -2,7 +2,7 @@
  * RTK (Rust Token Killer) prompt instruction snippet.
  * Injected into coder/reviewer prompts when RTK is detected.
  */
-export const RTK_INSTRUCTIONS = [
+const RTK_INSTRUCTIONS = [
   "## Token Optimization (RTK detected)",
   "RTK is installed. Prefix ALL Bash tool calls with `rtk` to reduce token usage:",
   "- Use `rtk git status` instead of `git status`",

--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -3,7 +3,7 @@ import { withRetry } from "../utils/retry.js";
 import { resolveSonarProjectKey } from "./project-key.js";
 import { resolveSonarToken } from "./config-resolver.js";
 
-export class SonarApiError extends Error {
+class SonarApiError extends Error {
   constructor(message, { url, httpStatus, hint } = {}) {
     super(message);
     this.name = "SonarApiError";

--- a/src/utils/display/event-handlers.js
+++ b/src/utils/display/event-handlers.js
@@ -342,7 +342,7 @@ export const EVENT_HANDLERS = {
 };
 
 /** Event types suppressed in quiet mode (internal/noise events). */
-export const QUIET_SUPPRESSED = new Set([
+const QUIET_SUPPRESSED = new Set([
   "agent:output",
   "agent:stall",
   "pipeline:simplify",

--- a/src/utils/display/header.js
+++ b/src/utils/display/header.js
@@ -8,7 +8,7 @@ import { ANSI } from "./formatters.js";
 const DISPLAY_PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../package.json");
 const DISPLAY_VERSION = JSON.parse(readFileSync(DISPLAY_PKG_PATH, "utf8")).version;
 
-export const BAR = `${ANSI.dim}\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500${ANSI.reset}`;
+const BAR = `${ANSI.dim}\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500${ANSI.reset}`;
 
 /**
  * Print task, configuration and pipeline header

--- a/src/utils/display/session-summary.js
+++ b/src/utils/display/session-summary.js
@@ -15,7 +15,7 @@ export function printSessionStages(stages) {
   printSessionSonar(stages.sonar);
 }
 
-export function printSessionPlanner(planner) {
+function printSessionPlanner(planner) {
   if (!planner?.title && !planner?.approach && !planner?.completedSteps?.length) return;
   const planParts = [];
   if (planner.title) planParts.push(planner.title);
@@ -26,7 +26,7 @@ export function printSessionPlanner(planner) {
   }
 }
 
-export function printSessionSonar(sonar) {
+function printSessionSonar(sonar) {
   if (!sonar) return;
   const gateLabel = sonar.gateStatus === "OK" ? ANSI.green : ANSI.red;
   console.log(`  ${ANSI.dim}\ud83d\udd0d Sonar: ${gateLabel}${sonar.gateStatus}${ANSI.reset}${ANSI.dim} (${sonar.openIssues ?? 0} issues)${ANSI.reset}`);
@@ -55,7 +55,7 @@ export function printSessionGit(git) {
   }
 }
 
-export function isBudgetUnavailable(budget) {
+function isBudgetUnavailable(budget) {
   return budget.usage_available === false ||
     (budget.total_tokens === 0 && budget.total_cost_usd === 0 && Object.keys(budget.breakdown_by_role || {}).length > 0);
 }

--- a/src/utils/display/solomon.js
+++ b/src/utils/display/solomon.js
@@ -1,6 +1,6 @@
 import { ANSI } from "./formatters.js";
 
-export const SOLOMON_RULING_HANDLERS = {
+const SOLOMON_RULING_HANDLERS = {
   approve(detail, elapsed) {
     const dismissedCount = detail?.dismissed?.length || 0;
     const dismissedSuffix = dismissedCount > 0 ? ` (${dismissedCount} dismissed)` : "";

--- a/src/utils/role-assigner.js
+++ b/src/utils/role-assigner.js
@@ -128,4 +128,4 @@ export function applyRoleAssignments(config, assignments) {
   return config;
 }
 
-export { CAPABILITY_TIERS, ROLE_PREFERENCES };
+export { CAPABILITY_TIERS };


### PR DESCRIPTION
## Summary

**Final pass — part E of 5** of [KJC-TSK-0354](https://github.com/manufosela/karajan-code/issues/575). Cleans up the long-tail dead exports across `src/` subdirectories not covered by PR-A (tests/), PR-B (hu-board/), PR-C (checks/) or PR-D (orchestrator/).

### Triage
- **Deleted (2 truly-dead functions, no internal use either):**
  - `updatePlan` (`src/plan/plan-store.js`) — zero importers anywhere.
  - `createAdr` (`src/planning-game/client.js`) — zero importers; the external grep hits are `mcpClient.createAdr` method calls on a different object passed in by the caller.

- **Demoted to private (11 still used internally):**
  - `CanvasSchema` (consumed by `parseCanvas`/`safeParseCanvas` in same file)
  - `runDoctor` (called by other exports in `src/commands/doctor.js`)
  - `handlePgDecomposition` (called via the `handleDecomposition` adapter method)
  - `RTK_INSTRUCTIONS`, `SonarApiError`, `QUIET_SUPPRESSED`, `BAR`, `printSessionPlanner`, `printSessionSonar`, `isBudgetUnavailable`, `SOLOMON_RULING_HANDLERS` — all internal helpers in `src/utils/display/`, `src/sonar/`, `src/prompts/`.

- **Removed 3 named re-exports** (constants stay defined as module-locals):
  - `PROD_DEFAULTS`, `GLOBAL_KEYS` (`src/config/test-harness.js`)
  - `ROLE_PREFERENCES` (`src/utils/role-assigner.js`)

## Test plan

- [x] `npx vitest run` — **4199/4199 passing**
- [x] `npx knip` — PR-E scope reports 0 dead exports
- [x] No external code referenced the removed/demoted symbols (manually grep-verified including dynamic-import patterns and `vi.mock` factories)

## Net result of the 5-PR campaign

| PR | Scope | Dead exports cleaned |
|---|---|---|
| A (#579) | `tests/fixtures/orchestrator-mocks.js` | 12 mocks removed |
| B (#580) | `packages/hu-board/` | 4 helpers demoted |
| C (#581) | `src/checks/` | 24 cleaned (15 demoted, 3 deleted, 6 false positives documented) |
| D (#582) | `src/orchestrator/` | 21 cleaned (6 deleted, 15 demoted/un-re-exported) |
| **E (this)** | **rest of src/** | **16 cleaned (2 deleted, 14 demoted/un-re-exported)** |

Once all 5 land on main, knip should drop from the 228 baseline to ~0 dead exports — comfortably below the AC's <30 target.