### PR TITLE
fix(audit): reduce findDeadExports false positives 166 → 4 (KJC-TSK-0356)

### DIFF
--- a/src/audit/basal-cost.js
+++ b/src/audit/basal-cost.js
@@ -92,14 +92,68 @@ function runDepcheck(projectDir) {
   });
 }
 
+// Regexes hoisted to module scope so they're compiled once instead of per file.
+// Naming: *Re catches static/syntactic patterns; we still rely on the import set
+// being a superset (false negative > false positive in audit context).
+const EXPORT_RE = /export\s+(?:default\s+)?(?:function|class|const|let|var|async\s+function)\s+(\w+)/g;
+const NAMED_EXPORT_RE = /export\s*\{([^}]+)\}/g;
+const STATIC_NAMED_IMPORT_RE = /import\s+\{([^}]+)\}\s+from/g;
+const DEFAULT_IMPORT_RE = /import\s+(\w+)\s+from/g;
+// Namespace import (`import * as ns from <path>`) — knip-equivalent: mark
+// the target file as fully-consumed because we cannot statically know
+// which `ns.X` accesses happen.
+const NAMESPACE_IMPORT_RE = /import\s+\*\s+as\s+\w+\s+from\s+["']([^"']+)["']/g;
+// Any dynamic `await import(<path>)` — destructured, late-bound, or
+// member-accessed. Conservatively mark the target as fully-consumed:
+// trying to enumerate downstream destructuring/member-access patterns is
+// fragile (the same test may use parenthesised assignment with no const,
+// or bind first and `.foo`-access later). A false-negative here (one
+// extra "live" export we can't prove dead) is always cheaper than a
+// false-positive in audit context.
+const DYNAMIC_IMPORT_RE = /\bawait\s+import\s*\(\s*["']([^"']+)["']\s*\)/g;
+// Re-export bridges (`export { x } from <path>` and `export * from <path>`)
+// — both consume from the target file (the re-exporter is itself another
+// file consumer downstream).
+const RE_EXPORT_NAMED_RE = /export\s*\{([^}]+)\}\s*from\s*["']([^"']+)["']/g;
+const RE_EXPORT_STAR_RE = /export\s*\*\s*from\s*["']([^"']+)["']/g;
+// Export preceded by a JSDoc block with `@internal` is opt-out: documented as
+// dynamic-import-only or test-fixture surface that the regex passes can't see.
+const INTERNAL_EXPORT_RE = /\/\*\*[\s\S]*?@internal[\s\S]*?\*\/\s*export\s+(?:default\s+)?(?:function|class|const|let|var|async\s+function)\s+(\w+)/g;
+
+function resolveImportSpecifier(fromFile, specifier) {
+  // Only resolve project-relative paths; bare specifiers (npm packages) and
+  // node: builtins are not in our exportMap and don't matter here.
+  if (!specifier.startsWith(".") && !specifier.startsWith("/")) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  // Caller will probe both with and without explicit extensions.
+  return base.endsWith(".js") || base.endsWith(".mjs") || base.endsWith(".cjs")
+    || base.endsWith(".ts") || base.endsWith(".tsx")
+    ? base
+    : `${base}.js`;
+}
+
+// Strip every string literal (template, double, single) from the content
+// before scanning for export declarations. Test files routinely embed
+// sample source code inside fixtures (template literals for plugin
+// modules, double-quoted diff lines for prompt tests, etc.). At top level
+// `export ...` is a statement, never an expression, so it can never
+// legitimately appear inside a quoted string in real code — meaning the
+// strip is safe for export detection. We do NOT use this stripped view
+// for import detection: the import regexes anchor on `import {...} from`
+// regardless of the path string, but the namespace/dynamic-import passes
+// need the actual path inside the quotes to resolve the target module.
+function stripStringLiterals(content) {
+  return content
+    .replace(/`[^`]*`/g, "``")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''");
+}
+
 async function findDeadExports(sourceFiles) {
   const exportMap = new Map(); // file -> [exportName]
+  const internalExportsByFile = new Map(); // file -> Set<exportName>
   const importedNames = new Set();
-
-  const exportRe = /export\s+(?:default\s+)?(?:function|class|const|let|var|async\s+function)\s+(\w+)/g;
-  const namedExportRe = /export\s*\{([^}]+)\}/g;
-  const importRe = /import\s+\{([^}]+)\}\s+from/g;
-  const defaultImportRe = /import\s+(\w+)\s+from/g;
+  const fullyConsumedFiles = new Set(); // resolved file paths reached via `import *` or bound dynamic import
 
   for (const file of sourceFiles) {
     let content;
@@ -108,12 +162,13 @@ async function findDeadExports(sourceFiles) {
     } catch {
       continue;
     }
+    const exportContent = stripStringLiterals(content);
 
     const exports = [];
-    for (const match of content.matchAll(exportRe)) {
+    for (const match of exportContent.matchAll(EXPORT_RE)) {
       exports.push(match[1]);
     }
-    for (const match of content.matchAll(namedExportRe)) {
+    for (const match of exportContent.matchAll(NAMED_EXPORT_RE)) {
       const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/).pop().trim());
       exports.push(...names);
     }
@@ -121,18 +176,46 @@ async function findDeadExports(sourceFiles) {
       exportMap.set(file, exports);
     }
 
-    for (const match of content.matchAll(importRe)) {
+    // Collect `@internal`-tagged exports up front so the dead-pass can skip them.
+    const internalSet = new Set();
+    for (const match of exportContent.matchAll(INTERNAL_EXPORT_RE)) {
+      internalSet.add(match[1]);
+    }
+    if (internalSet.size > 0) {
+      internalExportsByFile.set(file, internalSet);
+    }
+
+    for (const match of content.matchAll(STATIC_NAMED_IMPORT_RE)) {
       const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/)[0].trim());
       for (const name of names) importedNames.add(name);
     }
-    for (const match of content.matchAll(defaultImportRe)) {
+    for (const match of content.matchAll(DEFAULT_IMPORT_RE)) {
       importedNames.add(match[1]);
+    }
+    for (const match of content.matchAll(NAMESPACE_IMPORT_RE)) {
+      const resolved = resolveImportSpecifier(file, match[1]);
+      if (resolved) fullyConsumedFiles.add(resolved);
+    }
+    for (const match of content.matchAll(DYNAMIC_IMPORT_RE)) {
+      const resolved = resolveImportSpecifier(file, match[1]);
+      if (resolved) fullyConsumedFiles.add(resolved);
+    }
+    for (const match of content.matchAll(RE_EXPORT_NAMED_RE)) {
+      const names = match[1].split(",").map(n => n.trim().split(/\s+as\s+/)[0].trim());
+      for (const name of names) importedNames.add(name);
+    }
+    for (const match of content.matchAll(RE_EXPORT_STAR_RE)) {
+      const resolved = resolveImportSpecifier(file, match[1]);
+      if (resolved) fullyConsumedFiles.add(resolved);
     }
   }
 
   const dead = [];
   for (const [file, exports] of exportMap) {
+    if (fullyConsumedFiles.has(file)) continue; // module imported via * or bound await import — can't tell which exports are used
+    const internalSet = internalExportsByFile.get(file);
     for (const name of exports) {
+      if (internalSet?.has(name)) continue; // explicitly opted out via @internal
       if (!importedNames.has(name)) {
         dead.push({ file, name });
       }

--- a/tests/audit/basal-cost.test.js
+++ b/tests/audit/basal-cost.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { measureBasalCost } from "../../src/audit/basal-cost.js";
+
+// Integration test: build a tiny project on disk and assert what
+// findDeadExports flags (vs what it correctly skips). Each scenario covers
+// one false-positive class the regex pass historically tripped on.
+async function makeProject(layout) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "basal-cost-"));
+  for (const [rel, content] of Object.entries(layout)) {
+    const full = path.join(root, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, "utf8");
+  }
+  return root;
+}
+
+async function deadNames(projectDir) {
+  const r = await measureBasalCost(projectDir);
+  return r.deadExports.map(d => d.name).sort();
+}
+
+describe("findDeadExports — false positive avoidance", () => {
+  let project;
+  afterEach(async () => {
+    if (project) await fs.rm(project, { recursive: true, force: true });
+  });
+
+  it("ignores exports tagged @internal in JSDoc", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/lib.js": [
+        "/**",
+        " * @internal Used dynamically by tests.",
+        " */",
+        "export function helperA() {}",
+        "export function helperB() {}",
+      ].join("\n"),
+    });
+    expect(await deadNames(project)).toEqual(["helperB"]);
+  });
+
+  it("treats `await import('mod')` as fully consuming mod", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/mod.js": "export function liveOne() {}\nexport function liveTwo() {}",
+      "src/consumer.js": "async function load() { return await import('./mod.js'); }",
+    });
+    expect(await deadNames(project)).toEqual([]);
+  });
+
+  it("treats `import * as ns from 'mod'` as fully consuming mod", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/mod.js": "export const A = 1;\nexport const B = 2;",
+      "src/consumer.js": "import * as ns from './mod.js';\nconsole.log(ns.A);",
+    });
+    expect(await deadNames(project)).toEqual([]);
+  });
+
+  it("treats `export { x } from 'mod'` as importing x from mod", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/mod.js": "export function reExportedFn() {}\nexport function trulyDeadFn() {}",
+      "src/barrel.js": "export { reExportedFn } from './mod.js';",
+      "src/consumer.js": "import { reExportedFn } from './barrel.js';\nreExportedFn();",
+    });
+    expect(await deadNames(project)).toEqual(["trulyDeadFn"]);
+  });
+
+  it("treats `export * from 'mod'` as fully consuming mod", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/mod.js": "export const A = 1;\nexport const B = 2;",
+      "src/barrel.js": "export * from './mod.js';",
+    });
+    expect(await deadNames(project)).toEqual([]);
+  });
+
+  it("ignores `export ...` patterns inside template literals", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "tests/fixture.js": [
+        "// pretend this is a test file feeding source-code-as-data to a tool",
+        "const sample = `",
+        "  export function notRealExport() {}",
+        "`;",
+        "console.log(sample);",
+      ].join("\n"),
+    });
+    expect(await deadNames(project)).toEqual([]);
+  });
+
+  it("ignores `export ...` patterns inside double-quoted strings", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "tests/fixture.js": [
+        'const diff = "diff --git a/x.js\\n+export function notRealEither() {}";',
+        "console.log(diff);",
+      ].join("\n"),
+    });
+    expect(await deadNames(project)).toEqual([]);
+  });
+
+  it("still flags genuinely dead exports", async () => {
+    project = await makeProject({
+      "package.json": "{}",
+      "src/lib.js": "export function used() {}\nexport function unused() {}",
+      "src/consumer.js": "import { used } from './lib.js';\nused();",
+    });
+    expect(await deadNames(project)).toEqual(["unused"]);
+  });
+});


### PR DESCRIPTION
## Summary

Companion task to [KJC-TSK-0354](https://github.com/manufosela/karajan-code/issues/575) (which cleaned up the 228 dead exports knip flagged). After that work, running `kj audit` on a healthy main was still reporting **166 dead exports** because the naive regex pass in `src/audit/basal-cost.js` doesn't understand four common patterns. Knip — the ground-truth tool — reports just 3 on the same tree, a 55x noise ratio that made the finding useless.

This patch teaches `findDeadExports` four patterns it was missing, plus a preprocessing trick.

### What was missing

| Pattern | Example | Before | After |
|---|---|---|---|
| `@internal` JSDoc opt-out | the 6 helpers PR-C documented as test-only dynamic imports | flagged | skipped |
| `await import("…")` (any flavour) | `const { x } = await import(p)`, `(await import(p)).foo`, late-bound `m = await import(p)` | flagged | target fully-consumed |
| `import * as ns from "…"` | `import * as queue from "./feedback-queue.js"; queue.addEntries(...)` | flagged | target fully-consumed |
| `export { x } from "…"` / `export * from "…"` | barrel modules | flagged | target consumed |

### Plus: strip strings before export detection

Test files routinely embed sample source code inside fixtures — template literals for plugin modules, double-quoted diff strings for prompt tests, single-quoted snippets for output-guard. The naive regex was matching `export ...` lines _inside_ those strings as if they were real exports of the test file.

At top level `export …` is always a statement, never an expression, so it can never legitimately appear inside a quoted string. The patch strips template, double-quoted, and single-quoted string contents before running the export-detection regex pass. Strings are **NOT** stripped for the import-detection pass — the path inside the quotes is load-bearing for namespace/dynamic-import resolution.

### Result

| State | Detector says | Knip says | Noise ratio |
|---|---|---|---|
| Before | 166 dead exports | 3 dead exports | 55x |
| After | **4 dead exports** | 3 dead exports | 1.3x |

The 4 remaining are all real:
- `REVIEW_BLOCKING`, `mockCreateAgent` in `tests/fixtures/orchestrator-mocks.js` — PR-A of KJC-TSK-0354 left them behind.
- `BasicReporter` (`tests/_diet/basic-reporter.js`) and `register` (`tests/fixtures/plugins/dummy-agent.js`) — knip itself reports both files as fully unused.

The detector's only remaining false-negative vs knip is one extra "live" call from cross-file name collisions (e.g. `createLogger` exists in both `src/utils/logger.js` — used — and `tests/fixtures/orchestrator-mocks.js` — dead — and the regex doesn't path-resolve). Acceptable trade-off; an LLM auditor reading the report still sees 4 real findings instead of drowning in 166.

## Test plan

- [x] 8 new integration tests in `tests/audit/basal-cost.test.js` covering every false-positive class above + a "still flags genuinely dead exports" regression guard.
- [x] Full suite: **4207/4207 passing** (was 4199 before this patch added the 8 new tests).