### PR TITLE
fix(audit): CLI parity — kj audit uses AuditRole (KJC-TSK-0357)

### DIFF
--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,8 +1,8 @@
 import path from "node:path";
-import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
-import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
+import { AUDIT_DIMENSIONS } from "../prompts/audit.js";
+import { AuditRole } from "../roles/audit-role.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
@@ -88,44 +88,56 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
   }
 
   return withCliRunLog("audit", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
-    const auditRole = resolveRole(config, "audit");
-    await assertAgentsAvailable([auditRole.provider]);
-    logger.info(`Audit (${auditRole.provider}) starting...`);
-    runLog.logText(`[audit] provider=${auditRole.provider} dimensions=${dimensions || "all"}`);
+    const auditRoleConfig = resolveRole(config, "audit");
+    await assertAgentsAvailable([auditRoleConfig.provider]);
+    logger.info(`Audit (${auditRoleConfig.provider}) starting...`);
+    runLog.logText(`[audit] provider=${auditRoleConfig.provider} dimensions=${dimensions || "all"}`);
 
-    const agent = createAgent(auditRole.provider, config, logger);
-    const dimList = dimensions && dimensions !== "all"
-      ? dimensions.split(",").map(d => d.trim().toLowerCase()).map(d => d === "quality" ? "codeQuality" : d).filter(d => AUDIT_DIMENSIONS.includes(d))
-      : null;
-
-    const prompt = buildAuditPrompt({ task: task || "Analyze the full codebase", dimensions: dimList });
+    // Path to audit output goes through AuditRole — same code path as MCP
+    // (kj_audit) and the orchestrator pipeline. Pre-KJC-TSK-0357 this CLI
+    // re-implemented createAgent + buildAuditPrompt + parseAuditOutput
+    // inline, which silently dropped the deterministic basalCost /
+    // growthDelta inputs that AuditRole.execute() collects. The result was
+    // a CLI prompt that didn't tell the LLM about deadExports, unused
+    // dependencies, or growth since the last audit.
+    const role = new AuditRole({ config, logger });
     const progress = createCliProgressReporter({ role: "auditor" });
-    let result;
+    let roleResult;
     try {
-      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "audit" });
-      progress.finish(result.ok ? "done" : "failed");
+      roleResult = await role.execute({
+        task: task || "Analyze the full codebase",
+        dimensions: dimensions || null,
+        onOutput: progress.onOutput,
+      });
+      progress.finish(roleResult.ok ? "done" : "failed");
     } catch (err) { progress.finish("failed"); throw err; }
 
-    if (!result.ok) {
-      throw new Error(result.error || result.output || "Audit failed");
+    if (!roleResult.ok) {
+      const err = roleResult.result?.error || "Audit failed";
+      throw new Error(err);
     }
 
-    const parsed = parseAuditOutput(result.output);
-    if (parsed?.summary) {
+    const parsed = roleResult.result;
+    if (parsed?.summary?.overallHealth) {
       runLog.logText(`[audit] findings=${parsed.summary.totalFindings} (critical=${parsed.summary.critical}, high=${parsed.summary.high})`);
     }
 
     if (json) {
-      console.log(JSON.stringify(parsed || result.output, null, 2));
+      console.log(JSON.stringify(parsed || roleResult, null, 2));
       return { ok: true };
     }
 
-    if (parsed?.summary) {
+    if (parsed?.summary?.overallHealth) {
       console.log(formatAudit(parsed));
+    } else if (parsed?.raw) {
+      console.log(parsed.raw);
     } else {
-      console.log(result.output);
+      console.log(roleResult.summary || "Audit complete.");
     }
     logger.info("Audit completed.");
     return { ok: true };
   });
 }
+
+// Exposed for tests — kept module-private otherwise.
+export { formatAudit, AUDIT_DIMENSIONS };

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -65,6 +65,7 @@ export class AuditRole extends AgentRole {
         result: {
           summary: parsed.summary, dimensions: parsed.dimensions,
           topRecommendations: parsed.topRecommendations,
+          textSummary: parsed.textSummary || undefined,
           basalCost: basalCost || undefined, growthDelta: growthDelta || undefined, provider
         },
         summary: buildSummary(parsed),

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -1,108 +1,121 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-vi.mock("../src/agents/index.js", () => ({
-  createAgent: vi.fn()
+// AuditRole.execute() is what auditCommand now drives (post KJC-TSK-0357).
+// Mocking the role surface keeps the CLI test focused on argument flow and
+// output formatting; AuditRole's own contract has its own test suite.
+const executeMock = vi.fn();
+class MockAuditRole {
+  constructor(opts) { this.opts = opts; }
+  async execute(input) { return executeMock(input); }
+}
+
+vi.mock("../src/roles/audit-role.js", () => ({
+  AuditRole: MockAuditRole,
 }));
 
 vi.mock("../src/agents/availability.js", () => ({
-  assertAgentsAvailable: vi.fn()
+  assertAgentsAvailable: vi.fn(),
 }));
 
 vi.mock("../src/config.js", () => ({
   resolveRole: vi.fn((config, role) => ({
-    provider: config.roles?.[role]?.provider || role
-  }))
+    provider: config.roles?.[role]?.provider || role,
+  })),
 }));
 
-vi.mock("../src/prompts/audit.js", () => ({
-  buildAuditPrompt: vi.fn().mockReturnValue("audit prompt"),
-  parseAuditOutput: vi.fn().mockReturnValue({
-    summary: { overallHealth: "fair", totalFindings: 3, critical: 0, high: 1, medium: 1, low: 1 },
-    dimensions: {
-      security: { score: "B", findings: [] },
-      codeQuality: { score: "C", findings: [{ severity: "high", file: "src/foo.js", line: 10, rule: "SOLID-SRP", description: "Too many responsibilities", recommendation: "Split" }] },
-      performance: { score: "A", findings: [] },
-      architecture: { score: "B", findings: [] },
-      testing: { score: "C", findings: [] }
-    },
-    topRecommendations: [{ priority: 1, dimension: "codeQuality", action: "Split god module", impact: "high", effort: "medium" }],
-    textSummary: "Fair health"
+vi.mock("../src/utils/cli-progress.js", () => ({
+  createCliProgressReporter: vi.fn(() => ({
+    onOutput: vi.fn(),
+    finish: vi.fn(),
+  })),
+}));
+
+vi.mock("../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
   }),
-  AUDIT_DIMENSIONS: ["security", "codeQuality", "performance", "architecture", "testing"]
 }));
 
 function makeConfig(overrides = {}) {
   return {
     roles: { audit: { provider: "claude" } },
-    ...overrides
+    ...overrides,
   };
 }
 
 const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn(),
 };
 
-describe("commands/audit", () => {
-  let createAgent, assertAgentsAvailable, buildAuditPrompt;
+const successResult = {
+  ok: true,
+  result: {
+    summary: { overallHealth: "fair", totalFindings: 3, critical: 0, high: 1, medium: 1, low: 1 },
+    dimensions: {
+      security: { score: "B", findings: [] },
+      codeQuality: { score: "C", findings: [] },
+      performance: { score: "A", findings: [] },
+      architecture: { score: "B", findings: [] },
+      testing: { score: "C", findings: [] },
+    },
+    topRecommendations: [],
+    textSummary: "Fair health",
+    provider: "claude",
+  },
+  summary: "Overall health: fair. 3 findings (1 high, 1 medium, 1 low)",
+};
+
+describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
+  let assertAgentsAvailable;
 
   beforeEach(async () => {
     vi.resetAllMocks();
-
-    const agents = await import("../src/agents/index.js");
-    createAgent = agents.createAgent;
+    executeMock.mockResolvedValue(successResult);
 
     const avail = await import("../src/agents/availability.js");
     assertAgentsAvailable = avail.assertAgentsAvailable;
-
-    const prompts = await import("../src/prompts/audit.js");
-    buildAuditPrompt = prompts.buildAuditPrompt;
-    buildAuditPrompt.mockReturnValue("audit prompt");
-    prompts.parseAuditOutput.mockReturnValue({
-      summary: { overallHealth: "fair", totalFindings: 3, critical: 0, high: 1, medium: 1, low: 1 },
-      dimensions: {
-        security: { score: "B", findings: [] },
-        codeQuality: { score: "C", findings: [] },
-        performance: { score: "A", findings: [] },
-        architecture: { score: "B", findings: [] },
-        testing: { score: "C", findings: [] }
-      },
-      topRecommendations: [],
-      textSummary: "Fair health"
-    });
-
-    createAgent.mockReturnValue({
-      runTask: vi.fn().mockResolvedValue({ ok: true, output: '{"ok":true}', exitCode: 0 })
-    });
   });
 
-  it("asserts audit provider is available", async () => {
+  it("asserts audit provider is available before invoking the role", async () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
 
     expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
   });
 
-  it("builds prompt with task", async () => {
+  it("invokes AuditRole.execute with the task verbatim", async () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
 
-    expect(buildAuditPrompt).toHaveBeenCalledWith(
+    expect(executeMock).toHaveBeenCalledWith(
       expect.objectContaining({ task: "audit codebase" })
     );
   });
 
-  it("filters dimensions when specified", async () => {
+  it("forwards --dimensions to AuditRole.execute (parseDimensions runs inside the role)", async () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger, dimensions: "security,testing" });
 
-    expect(buildAuditPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({ dimensions: ["security", "testing"] })
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: "security,testing" })
     );
   });
 
-  it("throws when audit fails", async () => {
-    createAgent.mockReturnValue({
-      runTask: vi.fn().mockResolvedValue({ ok: false, error: "agent error", exitCode: 1 })
+  it("falls back to a default task when none is provided", async () => {
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ config: makeConfig(), logger: noopLogger });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ task: "Analyze the full codebase" })
+    );
+  });
+
+  it("throws when AuditRole returns ok=false", async () => {
+    executeMock.mockResolvedValueOnce({
+      ok: false,
+      result: { error: "agent error", provider: "claude" },
+      summary: "Audit failed: agent error",
     });
 
     const { auditCommand } = await import("../src/commands/audit.js");
@@ -120,12 +133,68 @@ describe("commands/audit", () => {
     spy.mockRestore();
   });
 
-  it("maps quality shorthand to codeQuality", async () => {
+  it("formats the report when JSON is off", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     const { auditCommand } = await import("../src/commands/audit.js");
-    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, dimensions: "quality" });
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
 
-    expect(buildAuditPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({ dimensions: ["codeQuality"] })
-    );
+    const allOutput = spy.mock.calls.map(c => c[0]).join("\n");
+    expect(allOutput).toContain("## Codebase Health Report");
+    expect(allOutput).toContain("**Overall Health:** fair");
+    spy.mockRestore();
+  });
+
+  it("falls back to printing roleResult.summary when LLM output is unstructured", async () => {
+    executeMock.mockResolvedValueOnce({
+      ok: true,
+      result: { raw: "free-form text from the LLM", provider: "claude" },
+      summary: "Audit complete (unstructured output)",
+    });
+
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    const allOutput = spy.mock.calls.map(c => c[0]).join("\n");
+    expect(allOutput).toContain("free-form text from the LLM");
+    spy.mockRestore();
+  });
+});
+
+describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    executeMock.mockResolvedValue(successResult);
+  });
+
+  it("CLI auditCommand and MCP direct-handler both reach AuditRole.execute with the same input shape", async () => {
+    // CLI path: invoke auditCommand and capture what it passed to execute().
+    const { auditCommand } = await import("../src/commands/audit.js");
+    await auditCommand({
+      task: "Analyze the full codebase",
+      config: makeConfig(),
+      logger: noopLogger,
+      dimensions: "all",
+    });
+    const cliArgs = executeMock.mock.calls[executeMock.mock.calls.length - 1][0];
+
+    // MCP path: instantiate AuditRole directly the same way direct-handlers
+    // does (see src/mcp/handlers/direct-handlers.js — `new AuditRole(...)`)
+    // and invoke execute() with the same input shape.
+    executeMock.mockClear();
+    const { AuditRole } = await import("../src/roles/audit-role.js");
+    const mcpRole = new AuditRole({ config: makeConfig(), logger: noopLogger });
+    await mcpRole.execute({
+      task: "Analyze the full codebase",
+      dimensions: "all",
+    });
+    const mcpArgs = executeMock.mock.calls[executeMock.mock.calls.length - 1][0];
+
+    // Parity: both routes pass equivalent task + dimensions. CLI also adds
+    // an onOutput callback for terminal progress (MCP forwards events
+    // differently); strip that before comparing structural shape.
+    const { onOutput: _cliOnOutput, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, ...mcpCore } = mcpArgs;
+    expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

[KJC-TSK-0357](https://planning-game.kj-code.com) — fixes a CLI/MCP parity bug. Pre-patch, `kj audit` from CLI re-implemented `createAgent + buildAuditPrompt + parseAuditOutput` inline, which silently dropped the deterministic `basalCost`/`growthDelta` inputs that `AuditRole.execute()` collects when invoked via MCP (`kj_audit`) or the orchestrator pipeline. The CLI prompt never told the LLM about deadExports, unused dependencies, or growth since the last audit — so CLI and MCP produced audits of different quality from the same project.

This patch routes the CLI through `AuditRole` exactly like MCP does. Same code path = same prompt content = parity.

## Changes
- `src/commands/audit.js`: replaces direct `createAgent`/`buildAuditPrompt`/`parseAuditOutput` calls with `new AuditRole({config, logger}).execute({task, dimensions, onOutput})`.
- `src/roles/audit-role.js`: carries `textSummary` through to the result so CLI's `formatAudit` keeps printing the LLM's own narrative footer.
- `tests/command-audit.test.js`: rewritten around the new path. Mocks `AuditRole` instead of the underlying agent surface; adds an explicit parity test that drives both CLI `auditCommand` and a direct `AuditRole` instantiation (the MCP pattern from `src/mcp/handlers/direct-handlers.js`) and asserts both reach `execute()` with equivalent input shape.

## Test plan
- [x] `npx vitest run tests/command-audit.test.js` — 9/9 passing
- [x] `npx vitest run` — **4210/4210 passing** (3 new tests added)

## Unblocks
- KJC-TSK-0358 (stack detection) — needs CLI to use AuditRole so the stack data lands in CLI prompts too
- KJC-TSK-0361 (sonar) — same story
- KJC-TSK-0362 (--report-file) — refactors that adapt to the new shape