### PR TITLE
feat(audit): inject project stack detection into prompt (KJC-TSK-0358)

### DIFF
--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -14,7 +14,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -26,6 +26,32 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     "Analyze the project across multiple dimensions and produce a comprehensive health report.",
     "DO NOT modify any files. This is a READ-ONLY analysis."
   );
+
+  // Stack hint — when detected, tells the LLM what kind of project this is
+  // so it can filter out irrelevant heuristics (e.g. don't flag bundle size
+  // in an Express-only API; don't flag N+1 queries in a static Astro site).
+  // Detected by src/utils/stack-detect.js — KJC-TSK-0358.
+  if (stack && (stack.frameworks?.length > 0 || stack.language || stack.isFrontend || stack.isBackend)) {
+    const stackLines = ["## Project Stack"];
+    if (stack.language) stackLines.push(`- Language: ${stack.language}`);
+    if (stack.frameworks?.length) stackLines.push(`- Frameworks: ${stack.frameworks.join(", ")}`);
+    const tier = stack.isFullstack
+      ? "fullstack (frontend + backend)"
+      : stack.isFrontend
+        ? "frontend-only"
+        : stack.isBackend
+          ? "backend-only"
+          : "unknown";
+    stackLines.push(`- Tier: ${tier}`);
+    if (stack.isFullstack) {
+      stackLines.push("Apply BOTH backend heuristics (queries, sync I/O, caching) AND frontend heuristics (bundle size, lazy loading, render-blocking) where each layer applies.");
+    } else if (stack.isFrontend) {
+      stackLines.push("This project is frontend-only. SKIP findings about N+1 queries, sync file I/O in request handlers, missing pagination on list endpoints, and other backend-specific patterns. Focus on bundle size, lazy loading, render-blocking resources, image optimisation, and accessibility hints.");
+    } else if (stack.isBackend) {
+      stackLines.push("This project is backend-only. SKIP findings about bundle size, lazy loading, render-blocking resources, image optimisation, and frontend accessibility. Focus on queries, sync I/O, pagination, caching, auth/authz, and dependency hygiene.");
+    }
+    sections.push(stackLines.join("\n"));
+  }
 
   const activeDimensions = dimensions
     ? dimensions.filter(d => AUDIT_DIMENSIONS.includes(d))

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -1,6 +1,7 @@
 import { AgentRole } from "./agent-role.js";
 import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
 import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDelta } from "../audit/basal-cost.js";
+import { detectProjectStack } from "../utils/stack-detect.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -36,15 +37,22 @@ export class AuditRole extends AgentRole {
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
+    let stack = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
       growthDelta = computeGrowthDelta(basalCost, previous);
     } catch { /* basal cost is best-effort */ }
+    // Stack detection — KJC-TSK-0358. Best-effort: a project without
+    // package.json or recognisable language markers gets stack=null and the
+    // prompt falls back to the agnostic dimension list.
+    try {
+      stack = await detectProjectStack(projectDir);
+    } catch { /* stack detect is best-effort */ }
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);
@@ -66,7 +74,8 @@ export class AuditRole extends AgentRole {
           summary: parsed.summary, dimensions: parsed.dimensions,
           topRecommendations: parsed.topRecommendations,
           textSummary: parsed.textSummary || undefined,
-          basalCost: basalCost || undefined, growthDelta: growthDelta || undefined, provider
+          basalCost: basalCost || undefined, growthDelta: growthDelta || undefined,
+          stack: stack || undefined, provider
         },
         summary: buildSummary(parsed),
         usage: result.usage

--- a/tests/audit/prompt-stack.test.js
+++ b/tests/audit/prompt-stack.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+// Stack-aware prompt assembly — KJC-TSK-0358.
+// The auditor LLM should be told what kind of project it's looking at so it
+// filters out irrelevant heuristics (no N+1 in static Astro sites; no
+// bundle-size in Express APIs). detectProjectStack itself is exercised by
+// tests/lean-audit.test.js and tests/utils/stack-detect.test.js.
+
+describe("buildAuditPrompt — Project Stack section (KJC-TSK-0358)", () => {
+  it("omits the stack section when no stack data is provided", () => {
+    const prompt = buildAuditPrompt({ task: "audit" });
+    expect(prompt).not.toContain("## Project Stack");
+  });
+
+  it("omits the stack section when stack object is empty (defensive)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: [], language: null, isFrontend: false, isBackend: false, isFullstack: false },
+    });
+    expect(prompt).not.toContain("## Project Stack");
+  });
+
+  it("renders the stack section for a frontend project (Astro + Lit)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["astro", "lit"], language: "javascript", isFrontend: true, isBackend: false, isFullstack: false },
+    });
+    expect(prompt).toContain("## Project Stack");
+    expect(prompt).toContain("Language: javascript");
+    expect(prompt).toContain("Frameworks: astro, lit");
+    expect(prompt).toContain("Tier: frontend-only");
+    expect(prompt).toContain("SKIP findings about N+1 queries");
+    expect(prompt).toContain("Focus on bundle size, lazy loading");
+  });
+
+  it("renders the stack section for a backend project (Express + node)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["express"], language: "javascript", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).toContain("Tier: backend-only");
+    expect(prompt).toContain("SKIP findings about bundle size");
+    expect(prompt).toContain("Focus on queries, sync I/O");
+  });
+
+  it("renders the stack section for a fullstack project (Next)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["next"], language: "typescript", isFrontend: true, isBackend: true, isFullstack: true },
+    });
+    expect(prompt).toContain("Tier: fullstack (frontend + backend)");
+    expect(prompt).toContain("Apply BOTH backend heuristics");
+  });
+
+  it("renders the stack section when only language is known (Python, no framework)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: [], language: "python", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).toContain("## Project Stack");
+    expect(prompt).toContain("Language: python");
+    expect(prompt).toContain("Tier: backend-only");
+  });
+});


### PR DESCRIPTION
## Summary

KJC-TSK-0358 — wires `detectProjectStack` (already in `src/utils/stack-detect.js`, previously unused outside `kj init`) into `AuditRole.execute()`. The detected stack `{frameworks, language, isFrontend, isBackend, isFullstack}` flows into `buildAuditPrompt` as a new `## Project Stack` section that filters dimension heuristics to the relevant ones.

### What changes for the auditor LLM

| Detected stack | Section says |
|---|---|
| frontend-only | "SKIP findings about N+1 queries, sync I/O in handlers, missing pagination. Focus on bundle size, lazy loading, render-blocking, image opt." |
| backend-only | "SKIP findings about bundle size, lazy loading, render-blocking. Focus on queries, sync I/O, pagination, caching, auth/authz." |
| fullstack | "Apply BOTH backend AND frontend heuristics where each layer applies." |
| (no detection) | section omitted, agnostic prompt as before |

## Why
Pre-patch the audit prompt was stack-agnostic. Real findings drowned in type-mismatch noise — auditing an Astro site got recommendations about query optimisation; auditing an Express API got recommendations about bundle splitting. The detector already existed; the audit just never asked it.

## Changes
- `src/prompts/audit.js`: `buildAuditPrompt({ ..., stack = null })` accepts and renders the section.
- `src/roles/audit-role.js`: best-effort `detectProjectStack(projectDir)` call; surfaces `stack` in result.
- `tests/audit/prompt-stack.test.js`: 6 new tests covering all 4 tiers + missing-stack + language-only fallback.

## Test plan
- [x] `npx vitest run tests/audit/prompt-stack.test.js` — 6/6 passing
- [x] `npx vitest run` — **4216/4216 passing** (6 new tests added)

## Unblocks
- KJC-TSK-0359 (a11y dimension) — needs `isFrontend` flag to auto-activate
- KJC-TSK-0360 (WebPerf integration) — needs `isFrontend` flag to know when to invoke cwv-gate