### PR TITLE
feat(audit): inject SonarQube findings as deterministic input (KJC-TSK-0361)

### DIFF
--- a/src/audit/sonar-findings.js
+++ b/src/audit/sonar-findings.js
@@ -1,0 +1,81 @@
+/**
+ * Sonar findings collector for `kj audit` (KJC-TSK-0361).
+ *
+ * The audit pipeline already pays for SonarQube to exist (kj run + the
+ * SonarStage drive a full scan and gate the pipeline on its result). When
+ * the user runs `kj audit`, we don't want to pay for *another* full scan
+ * (~1-3 min) — we want to read whatever Sonar already knows. This module
+ * does exactly that: ping the configured Sonar host, and if it's
+ * reachable, fetch the current open-issue list + quality-gate status via
+ * the existing sonar/api.js helpers. Both results are best-effort: a
+ * sonar-down host or a never-scanned project quietly returns
+ * `{available: false, reason: "..."}` and the audit continues without
+ * the section.
+ *
+ * Why this matters: the LLM auditor was previously asked to find issues
+ * by reading source code, but Sonar already produces them with rule IDs
+ * (squid:S1234), severity, and line precision. Feeding those in lets the
+ * LLM cross-reference its own findings (high-confidence overlap) and
+ * focus its tokens on patterns Sonar can't see (architecture, naming,
+ * API design).
+ */
+
+import { isSonarReachable } from "../sonar/manager.js";
+import { getOpenIssues, getQualityGateStatus } from "../sonar/api.js";
+
+/**
+ * Collect deterministic Sonar findings for the audit prompt.
+ *
+ * @param {object} config - resolved Karajan config (must have config.sonarqube.host)
+ * @param {object} [logger] - optional logger for warn-level traces
+ * @returns {Promise<{available: boolean, reason?: string, issues?: object[], total?: number, qualityGate?: object}>}
+ */
+export async function collectSonarFindings(config, logger = null) {
+  const sonarConfig = config?.sonarqube || {};
+  const host = sonarConfig.host || "http://localhost:9000";
+  const healthcheckSeconds = sonarConfig.timeouts?.healthcheckSeconds ?? 5;
+
+  // Ping first — avoids surfacing a 30-second timeout into audit runtime
+  // when Docker is simply down or the user opted out of Sonar.
+  const reachable = await isSonarReachable(host, healthcheckSeconds).catch(() => false);
+  if (!reachable) {
+    if (logger?.warn) logger.warn(`sonar audit input skipped: host ${host} not reachable`);
+    return { available: false, reason: `sonar host ${host} not reachable` };
+  }
+
+  let issuesResult;
+  try {
+    issuesResult = await getOpenIssues(config);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`sonar audit input: getOpenIssues failed: ${err?.message || err}`);
+    return { available: false, reason: `getOpenIssues failed: ${err?.message || err}` };
+  }
+
+  let qualityGate = null;
+  try {
+    const qg = await getQualityGateStatus(config);
+    if (qg?.ok) qualityGate = { status: qg.status, conditions: qg.conditions };
+  } catch { /* gate is optional context */ }
+
+  return {
+    available: true,
+    issues: issuesResult.issues || [],
+    total: issuesResult.total || 0,
+    qualityGate,
+  };
+}
+
+/**
+ * Group Sonar issues by severity, preserving Sonar's canonical ordering.
+ * Used by the prompt builder to render the findings section.
+ */
+export function groupIssuesBySeverity(issues) {
+  const order = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"];
+  const groups = Object.fromEntries(order.map(s => [s, []]));
+  for (const issue of issues || []) {
+    const sev = issue.severity || "INFO";
+    if (groups[sev]) groups[sev].push(issue);
+    else groups.INFO.push(issue);
+  }
+  return groups;
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -94,6 +94,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--json", "Output raw JSON")
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
+    .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -101,12 +102,15 @@ export function registerMeta(program, { pkgVersion }) {
           const { readTaskFile } = await import("../utils/task-file.js");
           resolvedTask = await readTaskFile(flags.taskFile, { projectDir: config.projectDir });
         }
+        // commander resolves --no-sonar to flags.sonar=false (negation flag).
+        // We translate to the explicit `noSonar: true` shape AuditRole expects.
         await auditCommand({
           task: resolvedTask || "Analyze the full codebase",
           config, logger,
           dimensions: flags.dimensions, json: flags.json,
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
+          noSonar: flags.sonar === false,
         });
       });
     });

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -69,7 +69,7 @@ function formatAudit(parsed) {
   return lines.join("\n");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -108,6 +108,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         task: task || "Analyze the full codebase",
         dimensions: dimensions || null,
         onOutput: progress.onOutput,
+        noSonar,
       });
       progress.finish(roleResult.ok ? "done" : "failed");
     } catch (err) { progress.finish("failed"); throw err; }

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,4 +1,7 @@
 import { extractFirstJson } from "../utils/json-extract.js";
+import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
+
+const MAX_SONAR_ISSUES_IN_PROMPT = 50;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -14,7 +17,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -169,6 +172,42 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     }
     lines.push("");
     lines.push("Flag if basal cost is growing faster than feature delivery. Recommend elimination of unused code and dependencies.");
+    sections.push(lines.join("\n"));
+  }
+
+  // Sonar findings — KJC-TSK-0361. Deterministic input from a tool the
+  // codebase already runs (kj run + SonarStage). The audit reads existing
+  // open issues + quality-gate state instead of re-scanning. Capped at
+  // MAX_SONAR_ISSUES_IN_PROMPT total entries (50) across all severities to
+  // bound prompt size; the LLM is told the truncated count so it can
+  // prioritise.
+  if (sonarFindings?.available && (sonarFindings.total > 0 || sonarFindings.qualityGate)) {
+    const lines = ["## SonarQube Findings"];
+    if (sonarFindings.qualityGate?.status) {
+      lines.push(`- Quality gate: ${sonarFindings.qualityGate.status}`);
+    }
+    if (sonarFindings.total > 0) {
+      lines.push(`- Total open issues: ${sonarFindings.total}`);
+      const groups = groupIssuesBySeverity(sonarFindings.issues);
+      let remaining = MAX_SONAR_ISSUES_IN_PROMPT;
+      for (const [severity, issues] of Object.entries(groups)) {
+        if (issues.length === 0) continue;
+        lines.push("");
+        lines.push(`### ${severity} (${issues.length})`);
+        const slice = issues.slice(0, Math.max(0, remaining));
+        for (const issue of slice) {
+          const loc = issue.component ? `${issue.component}${issue.line ? `:${issue.line}` : ""}` : "";
+          const rule = issue.rule ? ` [${issue.rule}]` : "";
+          lines.push(`  - ${loc}${rule} ${issue.message || ""}`.trim());
+        }
+        if (issues.length > slice.length) {
+          lines.push(`  - ... and ${issues.length - slice.length} more in ${severity}`);
+        }
+        remaining -= slice.length;
+      }
+    }
+    lines.push("");
+    lines.push("Cross-reference these with your own findings. When your finding overlaps a Sonar rule, mention the rule ID in the `rule` field — that's a high-confidence match. Findings the LLM raises that Sonar can't see (architecture, naming, API design) are still valuable; mark them with rule names like \"AUDIT-ARCH-N\".");
     sections.push(lines.join("\n"));
   }
 

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -2,6 +2,7 @@ import { AgentRole } from "./agent-role.js";
 import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
 import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDelta } from "../audit/basal-cost.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
+import { collectSonarFindings } from "../audit/sonar-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -32,12 +33,14 @@ export class AuditRole extends AgentRole {
     const onOutput = typeof input === "string" ? null : input?.onOutput || null;
     const rawDimensions = typeof input === "object" ? input?.dimensions || null : null;
     const context = typeof input === "object" ? input?.context || null : null;
+    const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
     const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
 
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
     let stack = null;
+    let sonarFindings = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -49,10 +52,20 @@ export class AuditRole extends AgentRole {
     try {
       stack = await detectProjectStack(projectDir);
     } catch { /* stack detect is best-effort */ }
+    // Sonar findings — KJC-TSK-0361. Always best-effort + opt-out via
+    // noSonar (CLI --no-sonar). When sonar is reachable we read the open
+    // issues + quality gate to give the LLM deterministic findings with
+    // rule IDs and line numbers; the section is omitted when sonar is
+    // down or disabled.
+    if (!noSonar) {
+      try {
+        sonarFindings = await collectSonarFindings(this.config, this.logger);
+      } catch { /* sonar fetch is best-effort */ }
+    }
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);
@@ -75,7 +88,9 @@ export class AuditRole extends AgentRole {
           topRecommendations: parsed.topRecommendations,
           textSummary: parsed.textSummary || undefined,
           basalCost: basalCost || undefined, growthDelta: growthDelta || undefined,
-          stack: stack || undefined, provider
+          stack: stack || undefined,
+          sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
+          provider
         },
         summary: buildSummary(parsed),
         usage: result.usage

--- a/tests/audit/sonar-findings.test.js
+++ b/tests/audit/sonar-findings.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the sonar surface so we can drive collectSonarFindings under
+// controlled conditions without spinning up a real SonarQube container.
+vi.mock("../../src/sonar/manager.js", () => ({
+  isSonarReachable: vi.fn(),
+}));
+vi.mock("../../src/sonar/api.js", () => ({
+  getOpenIssues: vi.fn(),
+  getQualityGateStatus: vi.fn(),
+}));
+
+import { collectSonarFindings, groupIssuesBySeverity } from "../../src/audit/sonar-findings.js";
+import { isSonarReachable } from "../../src/sonar/manager.js";
+import { getOpenIssues, getQualityGateStatus } from "../../src/sonar/api.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+const baseConfig = { sonarqube: { host: "http://localhost:9000" } };
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+describe("collectSonarFindings (KJC-TSK-0361)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns available=false when sonar host is unreachable (no API call attempted)", async () => {
+    isSonarReachable.mockResolvedValue(false);
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not reachable/);
+    expect(getOpenIssues).not.toHaveBeenCalled();
+    expect(noopLogger.warn).toHaveBeenCalled();
+  });
+
+  it("returns available=false when isSonarReachable rejects (defensive catch)", async () => {
+    isSonarReachable.mockRejectedValue(new Error("dns lookup failed"));
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+  });
+
+  it("returns the issues + quality gate when sonar is reachable", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockResolvedValue({
+      total: 2,
+      issues: [
+        { rule: "squid:S1234", severity: "MAJOR", component: "src/foo.js", line: 12, message: "Cognitive complexity too high" },
+        { rule: "squid:S5678", severity: "BLOCKER", component: "src/bar.js", line: 1, message: "Hardcoded secret" },
+      ],
+    });
+    getQualityGateStatus.mockResolvedValue({ ok: true, status: "ERROR", conditions: [] });
+
+    const r = await collectSonarFindings(baseConfig);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(2);
+    expect(r.issues).toHaveLength(2);
+    expect(r.qualityGate.status).toBe("ERROR");
+  });
+
+  it("survives quality-gate fetch failure (returns issues without QG)", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+    getQualityGateStatus.mockRejectedValue(new Error("project not yet analysed"));
+
+    const r = await collectSonarFindings(baseConfig);
+    expect(r.available).toBe(true);
+    expect(r.qualityGate).toBeNull();
+  });
+
+  it("returns available=false when getOpenIssues throws", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockRejectedValue(new Error("401 unauthorized"));
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/getOpenIssues failed/);
+  });
+});
+
+describe("groupIssuesBySeverity", () => {
+  it("groups issues into Sonar's canonical severity order (BLOCKER first)", () => {
+    const groups = groupIssuesBySeverity([
+      { severity: "MAJOR", message: "a" },
+      { severity: "BLOCKER", message: "b" },
+      { severity: "INFO", message: "c" },
+      { severity: "MAJOR", message: "d" },
+    ]);
+    expect(Object.keys(groups)).toEqual(["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]);
+    expect(groups.BLOCKER).toHaveLength(1);
+    expect(groups.MAJOR).toHaveLength(2);
+    expect(groups.INFO).toHaveLength(1);
+  });
+
+  it("buckets unknown severity into INFO", () => {
+    const groups = groupIssuesBySeverity([{ severity: "MYSTERY" }, {}]);
+    expect(groups.INFO).toHaveLength(2);
+  });
+});
+
+describe("buildAuditPrompt — Sonar section integration", () => {
+  it("omits the section when sonarFindings is null or unavailable", () => {
+    const a = buildAuditPrompt({ task: "audit", sonarFindings: null });
+    const b = buildAuditPrompt({ task: "audit", sonarFindings: { available: false, reason: "down" } });
+    expect(a).not.toContain("## SonarQube Findings");
+    expect(b).not.toContain("## SonarQube Findings");
+  });
+
+  it("renders findings grouped by severity with rule + location", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: {
+        available: true,
+        total: 2,
+        issues: [
+          { rule: "squid:S1234", severity: "MAJOR", component: "src/foo.js", line: 12, message: "Cognitive complexity too high" },
+          { rule: "squid:S5678", severity: "BLOCKER", component: "src/bar.js", line: 1, message: "Hardcoded secret" },
+        ],
+        qualityGate: { status: "ERROR", conditions: [] },
+      },
+    });
+    expect(prompt).toContain("## SonarQube Findings");
+    expect(prompt).toContain("Quality gate: ERROR");
+    expect(prompt).toContain("Total open issues: 2");
+    expect(prompt).toContain("### BLOCKER (1)");
+    expect(prompt).toContain("### MAJOR (1)");
+    expect(prompt).toContain("squid:S1234");
+    expect(prompt).toContain("Cross-reference these with your own findings");
+  });
+
+  it("caps the rendered issue list at MAX_SONAR_ISSUES_IN_PROMPT (50) with overflow line", () => {
+    const issues = Array.from({ length: 75 }, (_, i) => ({
+      rule: `squid:R${i}`, severity: "MAJOR", component: `f${i}.js`, line: i, message: `m${i}`,
+    }));
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: { available: true, total: 75, issues },
+    });
+    expect(prompt).toContain("Total open issues: 75");
+    expect(prompt).toContain("and 25 more in MAJOR");
+  });
+
+  it("renders only the quality-gate line when there are zero open issues but a gate result exists", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: { available: true, total: 0, issues: [], qualityGate: { status: "OK", conditions: [] } },
+    });
+    expect(prompt).toContain("Quality gate: OK");
+    expect(prompt).not.toContain("### BLOCKER");
+  });
+});

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -190,11 +190,14 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     });
     const mcpArgs = executeMock.mock.calls[executeMock.mock.calls.length - 1][0];
 
-    // Parity: both routes pass equivalent task + dimensions. CLI also adds
-    // an onOutput callback for terminal progress (MCP forwards events
-    // differently); strip that before comparing structural shape.
-    const { onOutput: _cliOnOutput, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, ...mcpCore } = mcpArgs;
+    // Parity: both routes pass equivalent task + dimensions. CLI also
+    // attaches an onOutput callback for terminal progress (MCP forwards
+    // events differently) and a noSonar boolean from the --no-sonar flag
+    // (MCP clients toggle the same control via the AuditRole input
+    // directly when they want it). Strip both before comparing the
+    // structural shape that drives the prompt.
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

KJC-TSK-0361 — Sonar already produces findings with rule IDs (squid:SXXXX), severity, and line precision. Pre-patch, the LLM auditor was asked to find issues by reading source code while ignoring this richer existing data. This patch reads the current Sonar state (when reachable) and feeds open issues + quality-gate status into the audit prompt as a deterministic section.

**Read-only by design** — the audit doesn't trigger a new scan (~1-3 min); it queries the existing Sonar HTTP API. If the host is unreachable, the section is silently omitted (best-effort, matches the basalCost pattern).

> Replaces #587 (closed). The original branch was a stack on top of #586's working branch, which left it tangled with pre-merge commit history after #586 squash-merged. This PR is a clean cherry-pick onto the post-merge main.

## Changes
- `src/audit/sonar-findings.js` (new) — `collectSonarFindings(config, logger)` and `groupIssuesBySeverity(issues)`. Pings `isSonarReachable` first to bound runtime when Docker is down.
- `src/prompts/audit.js` — `buildAuditPrompt({..., sonarFindings})` renders `## SonarQube Findings` grouped BLOCKER → INFO, capped at 50 total entries with overflow markers per severity. Tells the LLM to cross-reference and to label its own architectural findings with `AUDIT-ARCH-N` rule names.
- `src/roles/audit-role.js` — invokes the collector unless `noSonar:true` is passed; surfaces `sonarFindings` on the result.
- `src/commands/audit.js` + `src/cli/register-meta.js` — wires the new `--no-sonar` flag (commander's negation form).
- `tests/command-audit.test.js` — parity test updated to strip the new `noSonar` shape control before CLI/MCP comparison.

## Test plan
- [x] `npx vitest run tests/audit/sonar-findings.test.js` — 11/11 passing
- [x] `npx vitest run` — **4227/4227 passing** (11 new tests added)