### PR TITLE
feat(audit): accessibility dimension auto-active on frontend (KJC-TSK-0359)

### DIFF
--- a/src/audit/sonar-findings.js
+++ b/src/audit/sonar-findings.js
@@ -1,0 +1,81 @@
+/**
+ * Sonar findings collector for `kj audit` (KJC-TSK-0361).
+ *
+ * The audit pipeline already pays for SonarQube to exist (kj run + the
+ * SonarStage drive a full scan and gate the pipeline on its result). When
+ * the user runs `kj audit`, we don't want to pay for *another* full scan
+ * (~1-3 min) — we want to read whatever Sonar already knows. This module
+ * does exactly that: ping the configured Sonar host, and if it's
+ * reachable, fetch the current open-issue list + quality-gate status via
+ * the existing sonar/api.js helpers. Both results are best-effort: a
+ * sonar-down host or a never-scanned project quietly returns
+ * `{available: false, reason: "..."}` and the audit continues without
+ * the section.
+ *
+ * Why this matters: the LLM auditor was previously asked to find issues
+ * by reading source code, but Sonar already produces them with rule IDs
+ * (squid:S1234), severity, and line precision. Feeding those in lets the
+ * LLM cross-reference its own findings (high-confidence overlap) and
+ * focus its tokens on patterns Sonar can't see (architecture, naming,
+ * API design).
+ */
+
+import { isSonarReachable } from "../sonar/manager.js";
+import { getOpenIssues, getQualityGateStatus } from "../sonar/api.js";
+
+/**
+ * Collect deterministic Sonar findings for the audit prompt.
+ *
+ * @param {object} config - resolved Karajan config (must have config.sonarqube.host)
+ * @param {object} [logger] - optional logger for warn-level traces
+ * @returns {Promise<{available: boolean, reason?: string, issues?: object[], total?: number, qualityGate?: object}>}
+ */
+export async function collectSonarFindings(config, logger = null) {
+  const sonarConfig = config?.sonarqube || {};
+  const host = sonarConfig.host || "http://localhost:9000";
+  const healthcheckSeconds = sonarConfig.timeouts?.healthcheckSeconds ?? 5;
+
+  // Ping first — avoids surfacing a 30-second timeout into audit runtime
+  // when Docker is simply down or the user opted out of Sonar.
+  const reachable = await isSonarReachable(host, healthcheckSeconds).catch(() => false);
+  if (!reachable) {
+    if (logger?.warn) logger.warn(`sonar audit input skipped: host ${host} not reachable`);
+    return { available: false, reason: `sonar host ${host} not reachable` };
+  }
+
+  let issuesResult;
+  try {
+    issuesResult = await getOpenIssues(config);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`sonar audit input: getOpenIssues failed: ${err?.message || err}`);
+    return { available: false, reason: `getOpenIssues failed: ${err?.message || err}` };
+  }
+
+  let qualityGate = null;
+  try {
+    const qg = await getQualityGateStatus(config);
+    if (qg?.ok) qualityGate = { status: qg.status, conditions: qg.conditions };
+  } catch { /* gate is optional context */ }
+
+  return {
+    available: true,
+    issues: issuesResult.issues || [],
+    total: issuesResult.total || 0,
+    qualityGate,
+  };
+}
+
+/**
+ * Group Sonar issues by severity, preserving Sonar's canonical ordering.
+ * Used by the prompt builder to render the findings section.
+ */
+export function groupIssuesBySeverity(issues) {
+  const order = ["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"];
+  const groups = Object.fromEntries(order.map(s => [s, []]));
+  for (const issue of issues || []) {
+    const sev = issue.severity || "INFO";
+    if (groups[sev]) groups[sev].push(issue);
+    else groups.INFO.push(issue);
+  }
+  return groups;
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -95,6 +95,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
+    .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -111,6 +112,7 @@ export function registerMeta(program, { pkgVersion }) {
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
           noSonar: flags.sonar === false,
+          reportFile: flags.reportFile || null,
         });
       });
     });

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -94,6 +94,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--json", "Output raw JSON")
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
+    .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -101,12 +102,15 @@ export function registerMeta(program, { pkgVersion }) {
           const { readTaskFile } = await import("../utils/task-file.js");
           resolvedTask = await readTaskFile(flags.taskFile, { projectDir: config.projectDir });
         }
+        // commander resolves --no-sonar to flags.sonar=false (negation flag).
+        // We translate to the explicit `noSonar: true` shape AuditRole expects.
         await auditCommand({
           task: resolvedTask || "Analyze the full codebase",
           config, logger,
           dimensions: flags.dimensions, json: flags.json,
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
+          noSonar: flags.sonar === false,
         });
       });
     });

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -90,7 +90,7 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Analyze codebase health (read-only)")
     .argument("[task]", "Task description. If absent, defaults to a full-codebase analysis. Use --task-file to point at a .md.")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
-    .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing", "all")
+    .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing,accessibility (default: all; accessibility auto-skipped on detected backend-only projects)", "all")
     .option("--json", "Output raw JSON")
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -50,7 +50,8 @@ const DIMENSION_LABELS = {
   codeQuality: "Code Quality",
   performance: "Performance",
   architecture: "Architecture",
-  testing: "Testing"
+  testing: "Testing",
+  accessibility: "Accessibility (WCAG 2.x)"
 };
 
 function formatAudit(parsed) {

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,4 +1,7 @@
 import path from "node:path";
+import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { AUDIT_DIMENSIONS } from "../prompts/audit.js";
@@ -6,6 +9,8 @@ import { AuditRole } from "../roles/audit-role.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
+
+const execFileAsync = promisify(execFile);
 
 function formatFindings(findings) {
   const lines = [];
@@ -69,7 +74,74 @@ function formatAudit(parsed) {
   return lines.join("\n");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false }) {
+/**
+ * Resolve where to write the audit report on disk, given a flag value, an
+ * env override, and the desired format. Returns null if no write target
+ * was requested. Creates parent directories on demand.
+ *
+ * Resolution rules (KJC-TSK-0362):
+ *   - flag undefined + no env → null (legacy behaviour, stdout only)
+ *   - flag is a directory → write `audit-<ISO>.{md,json}` inside it
+ *   - flag is a non-directory path → use it verbatim (extension drives format
+ *     when --json/--md not explicit)
+ *   - flag is undefined but env $KJ_AUDIT_REPORT_DIR is set → treat env as dir
+ */
+async function resolveReportFilePath(flagValue, isJson) {
+  const envDir = process.env.KJ_AUDIT_REPORT_DIR;
+  const target = flagValue || (envDir ? envDir : null);
+  if (!target) return null;
+
+  const ext = isJson ? "json" : "md";
+  let stats = null;
+  try { stats = await fs.stat(target); } catch { /* not a directory yet */ }
+  const isDir = stats?.isDirectory() || target.endsWith(path.sep) || target === envDir;
+
+  let resolved;
+  if (isDir) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    resolved = path.resolve(target, `audit-${stamp}.${ext}`);
+  } else {
+    resolved = path.resolve(target);
+  }
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  return resolved;
+}
+
+/**
+ * Build the markdown header that prefixes a persisted report — captures
+ * timestamp + repo state + invocation flags so the file is reproducible.
+ */
+async function buildReportHeader(projectDir, invocation) {
+  const lines = ["# Karajan Audit Report", ""];
+  lines.push(`- **Generated:** ${new Date().toISOString()}`);
+  lines.push(`- **Project:** ${projectDir || process.cwd()}`);
+
+  // Best-effort git info — silent if outside a repo.
+  try {
+    const branch = (await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    const commit = (await execFileAsync("git", ["rev-parse", "--short", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    lines.push(`- **Branch:** ${branch}`);
+    lines.push(`- **Commit:** ${commit}`);
+  } catch { /* not a git repo or git missing */ }
+
+  if (invocation) lines.push(`- **Invocation:** \`${invocation}\``);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+function describeInvocation({ task, dimensions, noSonar, json }) {
+  const parts = ["kj audit"];
+  if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
+  if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
+  if (noSonar) parts.push("--no-sonar");
+  if (json) parts.push("--json");
+  return parts.join(" ");
+}
+
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -123,20 +195,38 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       runLog.logText(`[audit] findings=${parsed.summary.totalFindings} (critical=${parsed.summary.critical}, high=${parsed.summary.high})`);
     }
 
+    // Resolve write target BEFORE printing — if the user pointed at a
+    // path that can't be created we want to fail fast, not after the LLM
+    // has already printed everything to stdout.
+    const reportPath = await resolveReportFilePath(reportFile, json);
+
+    let stdoutContent;
     if (json) {
-      console.log(JSON.stringify(parsed || roleResult, null, 2));
-      return { ok: true };
+      stdoutContent = JSON.stringify(parsed || roleResult, null, 2);
+    } else if (parsed?.summary?.overallHealth) {
+      stdoutContent = formatAudit(parsed);
+    } else if (parsed?.raw) {
+      stdoutContent = parsed.raw;
+    } else {
+      stdoutContent = roleResult.summary || "Audit complete.";
+    }
+    console.log(stdoutContent);
+
+    if (reportPath) {
+      let payload;
+      if (reportPath.endsWith(".json")) {
+        payload = JSON.stringify(parsed || roleResult, null, 2);
+      } else {
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json }));
+        payload = header + stdoutContent + "\n";
+      }
+      await fs.writeFile(reportPath, payload, "utf8");
+      runLog.logText(`[audit] report written → ${reportPath}`);
+      logger.info(`Audit report written: ${reportPath}`);
     }
 
-    if (parsed?.summary?.overallHealth) {
-      console.log(formatAudit(parsed));
-    } else if (parsed?.raw) {
-      console.log(parsed.raw);
-    } else {
-      console.log(roleResult.summary || "Audit complete.");
-    }
     logger.info("Audit completed.");
-    return { ok: true };
+    return { ok: true, reportPath: reportPath || undefined };
   });
 }
 

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -69,7 +69,7 @@ function formatAudit(parsed) {
   return lines.join("\n");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -108,6 +108,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         task: task || "Analyze the full codebase",
         dimensions: dimensions || null,
         onOutput: progress.onOutput,
+        noSonar,
       });
       progress.finish(roleResult.ok ? "done" : "failed");
     } catch (err) { progress.finish("failed"); throw err; }

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,4 +1,7 @@
 import { extractFirstJson } from "../utils/json-extract.js";
+import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
+
+const MAX_SONAR_ISSUES_IN_PROMPT = 50;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -14,7 +17,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -169,6 +172,42 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     }
     lines.push("");
     lines.push("Flag if basal cost is growing faster than feature delivery. Recommend elimination of unused code and dependencies.");
+    sections.push(lines.join("\n"));
+  }
+
+  // Sonar findings — KJC-TSK-0361. Deterministic input from a tool the
+  // codebase already runs (kj run + SonarStage). The audit reads existing
+  // open issues + quality-gate state instead of re-scanning. Capped at
+  // MAX_SONAR_ISSUES_IN_PROMPT total entries (50) across all severities to
+  // bound prompt size; the LLM is told the truncated count so it can
+  // prioritise.
+  if (sonarFindings?.available && (sonarFindings.total > 0 || sonarFindings.qualityGate)) {
+    const lines = ["## SonarQube Findings"];
+    if (sonarFindings.qualityGate?.status) {
+      lines.push(`- Quality gate: ${sonarFindings.qualityGate.status}`);
+    }
+    if (sonarFindings.total > 0) {
+      lines.push(`- Total open issues: ${sonarFindings.total}`);
+      const groups = groupIssuesBySeverity(sonarFindings.issues);
+      let remaining = MAX_SONAR_ISSUES_IN_PROMPT;
+      for (const [severity, issues] of Object.entries(groups)) {
+        if (issues.length === 0) continue;
+        lines.push("");
+        lines.push(`### ${severity} (${issues.length})`);
+        const slice = issues.slice(0, Math.max(0, remaining));
+        for (const issue of slice) {
+          const loc = issue.component ? `${issue.component}${issue.line ? `:${issue.line}` : ""}` : "";
+          const rule = issue.rule ? ` [${issue.rule}]` : "";
+          lines.push(`  - ${loc}${rule} ${issue.message || ""}`.trim());
+        }
+        if (issues.length > slice.length) {
+          lines.push(`  - ... and ${issues.length - slice.length} more in ${severity}`);
+        }
+        remaining -= slice.length;
+      }
+    }
+    lines.push("");
+    lines.push("Cross-reference these with your own findings. When your finding overlaps a Sonar rule, mention the rule ID in the `rule` field — that's a high-confidence match. Findings the LLM raises that Sonar can't see (architecture, naming, API design) are still valuable; mark them with rule names like \"AUDIT-ARCH-N\".");
     sections.push(lines.join("\n"));
   }
 

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -10,7 +10,13 @@ const SUBAGENT_PREAMBLE = [
   "DO NOT modify any files — this is a read-only analysis. Only use: Read, Grep, Glob, Bash (for analysis commands like wc, find, git log, du, npm ls)."
 ].join(" ");
 
-export const AUDIT_DIMENSIONS = ["security", "codeQuality", "performance", "architecture", "testing"];
+export const AUDIT_DIMENSIONS = ["security", "codeQuality", "performance", "architecture", "testing", "accessibility"];
+
+// Dimensions that only apply to frontend / fullstack projects. Auto-dropped
+// from the default dimension list when stack detection knows the project
+// is backend-only — preserves activation when the user explicitly opts in
+// via --dimensions=accessibility (KJC-TSK-0359).
+const FRONTEND_ONLY_DIMENSIONS = new Set(["accessibility"]);
 
 const VALID_HEALTH = new Set(["good", "fair", "poor", "critical"]);
 const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
@@ -56,9 +62,20 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     sections.push(stackLines.join("\n"));
   }
 
-  const activeDimensions = dimensions
-    ? dimensions.filter(d => AUDIT_DIMENSIONS.includes(d))
-    : AUDIT_DIMENSIONS;
+  // When dimensions are explicit, honour them verbatim — even frontend-only
+  // dimensions on a backend project (the user knows what they want).
+  // When dimensions are absent, default to all but drop frontend-only
+  // dimensions if the stack is provably backend-only. Unknown stack falls
+  // back to the full list (no false negatives — better an extra section
+  // than a missing one).
+  let activeDimensions;
+  if (dimensions) {
+    activeDimensions = dimensions.filter(d => AUDIT_DIMENSIONS.includes(d));
+  } else if (stack && stack.isBackend && !stack.isFrontend) {
+    activeDimensions = AUDIT_DIMENSIONS.filter(d => !FRONTEND_ONLY_DIMENSIONS.has(d));
+  } else {
+    activeDimensions = AUDIT_DIMENSIONS;
+  }
 
   if (activeDimensions.includes("security")) {
     sections.push(
@@ -134,9 +151,32 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     );
   }
 
+  if (activeDimensions.includes("accessibility")) {
+    sections.push(
+      "## Accessibility Analysis (WCAG 2.x)",
+      [
+        "- Missing alt text on <img> tags (decorative images need empty alt=\"\", not absent)",
+        "- Form inputs without associated <label> or aria-label",
+        "- Heading hierarchy violations (h1 → h3 skipping h2; multiple h1 per page)",
+        "- Buttons / links containing only icons without aria-label or visually-hidden text",
+        "- Interactive elements built from <div>/<span> without role + keyboard handlers",
+        "- ARIA roles misused (presentation on focusable elements, redundant on native semantics)",
+        "- Focus management gaps (modals without focus trap, no visible :focus styles, tabindex misuse)",
+        "- Colour-only signalling (status indicated by red/green only, no icon or text)",
+        "- Static contrast — flag suspicious low-contrast colour pairs in CSS variables / token files",
+        "- Missing lang attribute on <html>, missing skip-to-content link, missing landmarks"
+      ].join("\n"),
+      "Skip findings about colour contrast that require runtime rendering (e.g. computed styles); flag the suspect CSS values and recommend an axe-core/Lighthouse runtime check."
+    );
+  }
+
+  // JSON schema — keep the per-dimension entries in sync with AUDIT_DIMENSIONS.
+  const schemaDimensions = AUDIT_DIMENSIONS
+    .map(d => `"${d}":{"score":"A|B|C|D|F","findings":[]}`)
+    .join(",");
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    'JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{"security":{"score":"A|B|C|D|F","findings":[]},"codeQuality":{"score":"A|B|C|D|F","findings":[]},"performance":{"score":"A|B|C|D|F","findings":[]},"architecture":{"score":"A|B|C|D|F","findings":[]},"testing":{"score":"A|B|C|D|F","findings":[]}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}',
+    `JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{${schemaDimensions}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}`,
     'Each finding: {"severity":"critical|high|medium|low","file":string,"line":number,"rule":string,"description":string,"recommendation":string}',
     `Only include dimensions you were asked to analyze: ${activeDimensions.join(", ")}`
   );

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -2,6 +2,7 @@ import { AgentRole } from "./agent-role.js";
 import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts/audit.js";
 import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDelta } from "../audit/basal-cost.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
+import { collectSonarFindings } from "../audit/sonar-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -32,12 +33,14 @@ export class AuditRole extends AgentRole {
     const onOutput = typeof input === "string" ? null : input?.onOutput || null;
     const rawDimensions = typeof input === "object" ? input?.dimensions || null : null;
     const context = typeof input === "object" ? input?.context || null : null;
+    const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
     const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
 
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
     let stack = null;
+    let sonarFindings = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -49,10 +52,20 @@ export class AuditRole extends AgentRole {
     try {
       stack = await detectProjectStack(projectDir);
     } catch { /* stack detect is best-effort */ }
+    // Sonar findings — KJC-TSK-0361. Always best-effort + opt-out via
+    // noSonar (CLI --no-sonar). When sonar is reachable we read the open
+    // issues + quality gate to give the LLM deterministic findings with
+    // rule IDs and line numbers; the section is omitted when sonar is
+    // down or disabled.
+    if (!noSonar) {
+      try {
+        sonarFindings = await collectSonarFindings(this.config, this.logger);
+      } catch { /* sonar fetch is best-effort */ }
+    }
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);
@@ -75,7 +88,9 @@ export class AuditRole extends AgentRole {
           topRecommendations: parsed.topRecommendations,
           textSummary: parsed.textSummary || undefined,
           basalCost: basalCost || undefined, growthDelta: growthDelta || undefined,
-          stack: stack || undefined, provider
+          stack: stack || undefined,
+          sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
+          provider
         },
         summary: buildSummary(parsed),
         usage: result.usage

--- a/tests/audit/prompt-a11y.test.js
+++ b/tests/audit/prompt-a11y.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildAuditPrompt, AUDIT_DIMENSIONS, parseAuditOutput } from "../../src/prompts/audit.js";
+
+// Accessibility dimension — KJC-TSK-0359.
+// Auto-active by default; auto-suppressed when stack is provably backend
+// only; always honoured when the user explicitly opts in via --dimensions.
+
+describe("AUDIT_DIMENSIONS includes accessibility", () => {
+  it("exposes accessibility as a first-class dimension", () => {
+    expect(AUDIT_DIMENSIONS).toContain("accessibility");
+  });
+});
+
+describe("buildAuditPrompt — Accessibility section auto-activation (KJC-TSK-0359)", () => {
+  it("includes the section by default when no dimension filter is set", () => {
+    const prompt = buildAuditPrompt({ task: "audit" });
+    expect(prompt).toContain("## Accessibility Analysis (WCAG 2.x)");
+    expect(prompt).toContain("Missing alt text on <img> tags");
+    expect(prompt).toContain("Form inputs without associated <label> or aria-label");
+  });
+
+  it("includes the section for a known frontend project (Astro)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["astro"], language: "javascript", isFrontend: true, isBackend: false, isFullstack: false },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("includes the section for a fullstack project (Next.js)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["next"], language: "typescript", isFrontend: true, isBackend: true, isFullstack: true },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("OMITS the section by default for a known backend-only project (Express)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["express"], language: "javascript", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).not.toContain("## Accessibility Analysis");
+  });
+
+  it("INCLUDES the section on a backend project when explicitly requested via dimensions", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      dimensions: ["accessibility"],
+      stack: { frameworks: ["express"], language: "javascript", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("respects an explicit dimension list that omits accessibility", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      dimensions: ["security", "testing"],
+    });
+    expect(prompt).not.toContain("## Accessibility Analysis");
+    expect(prompt).toContain("## Security Analysis");
+    expect(prompt).toContain("## Testing Analysis");
+  });
+
+  it("includes accessibility in the JSON schema schema example so the LLM populates it", () => {
+    const prompt = buildAuditPrompt({ task: "audit" });
+    // Schema must list every dimension the prompt will accept back.
+    for (const d of AUDIT_DIMENSIONS) {
+      expect(prompt).toContain(`"${d}":{"score":"A|B|C|D|F","findings":[]}`);
+    }
+  });
+});
+
+describe("parseAuditOutput accepts accessibility findings", () => {
+  it("surfaces accessibility findings the LLM returns", () => {
+    const raw = JSON.stringify({
+      ok: true,
+      result: {
+        summary: { overallHealth: "fair" },
+        dimensions: {
+          accessibility: {
+            score: "C",
+            findings: [
+              { severity: "high", file: "src/Hero.astro", line: 42, rule: "WCAG-1.1.1", description: "Image missing alt", recommendation: "Add alt text or alt=\"\"" },
+            ],
+          },
+        },
+      },
+    });
+    const parsed = parseAuditOutput(raw);
+    expect(parsed.dimensions.accessibility.score).toBe("C");
+    expect(parsed.dimensions.accessibility.findings).toHaveLength(1);
+    expect(parsed.dimensions.accessibility.findings[0].rule).toBe("WCAG-1.1.1");
+    expect(parsed.summary.high).toBe(1);
+  });
+});

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// Reuse the same AuditRole mocking strategy as tests/command-audit.test.js
+// so this file can drive auditCommand through the report-file branch
+// without spinning up an LLM.
+const executeMock = vi.fn();
+class MockAuditRole {
+  constructor(opts) { this.opts = opts; }
+  async execute(input) { return executeMock(input); }
+}
+
+vi.mock("../../src/roles/audit-role.js", () => ({ AuditRole: MockAuditRole }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
+}));
+vi.mock("../../src/utils/cli-progress.js", () => ({
+  createCliProgressReporter: vi.fn(() => ({ onOutput: vi.fn(), finish: vi.fn() })),
+}));
+vi.mock("../../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
+  }),
+}));
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+const successResult = {
+  ok: true,
+  result: {
+    summary: { overallHealth: "fair", totalFindings: 1, critical: 0, high: 1, medium: 0, low: 0 },
+    dimensions: {
+      security: { score: "B", findings: [] },
+      codeQuality: { score: "C", findings: [{ severity: "high", file: "src/foo.js", line: 10, rule: "AUDIT-Q-1", description: "God module", recommendation: "Split" }] },
+      performance: { score: "A", findings: [] },
+      architecture: { score: "B", findings: [] },
+      testing: { score: "C", findings: [] },
+    },
+    topRecommendations: [],
+    textSummary: "Fair health",
+    provider: "claude",
+  },
+  summary: "Overall health: fair. 1 findings (1 high)",
+};
+
+let tmpDir;
+let consoleSpy;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  executeMock.mockResolvedValue(successResult);
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-report-"));
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+afterEach(async () => {
+  consoleSpy.mockRestore();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+function makeConfig(overrides = {}) {
+  return { roles: { audit: { provider: "claude" } }, projectDir: tmpDir, ...overrides };
+}
+
+describe("kj audit --report-file (KJC-TSK-0362)", () => {
+  it("zero behaviour change when --report-file is absent and env unset", async () => {
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toBeUndefined();
+    // Nothing written to tmpDir
+    const files = await fs.readdir(tmpDir);
+    expect(files).toHaveLength(0);
+  });
+
+  it("writes a markdown report when --report-file is a .md path", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    expect(result.reportPath).toBe(target);
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+    expect(content).toContain("## Codebase Health Report");
+    expect(content).toContain("**Overall Health:** fair");
+    expect(content).toContain("- **Generated:**");
+  });
+
+  it("writes a JSON report when --report-file is a .json path", async () => {
+    const target = path.join(tmpDir, "audit.json");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target, json: true });
+
+    const content = await fs.readFile(target, "utf8");
+    const parsed = JSON.parse(content);
+    expect(parsed.summary.overallHealth).toBe("fair");
+    expect(parsed.dimensions.codeQuality.findings[0].rule).toBe("AUDIT-Q-1");
+  });
+
+  it("writes a timestamped file inside a directory target", async () => {
+    const reportsDir = path.join(tmpDir, "reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: reportsDir });
+
+    expect(result.reportPath).toMatch(/\/reports\/audit-\d{4}-\d{2}-\d{2}T.*\.md$/);
+    const written = await fs.readFile(result.reportPath, "utf8");
+    expect(written).toContain("# Karajan Audit Report");
+  });
+
+  it("creates parent directories on demand", async () => {
+    const target = path.join(tmpDir, "deeply", "nested", "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+  });
+
+  it("uses $KJ_AUDIT_REPORT_DIR as default directory when --report-file is absent", async () => {
+    const reportsDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = reportsDir;
+
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toMatch(/\/env-reports\/audit-.+\.md$/);
+  });
+
+  it("explicit --report-file beats $KJ_AUDIT_REPORT_DIR", async () => {
+    const envDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(envDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = envDir;
+
+    const explicit = path.join(tmpDir, "explicit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: explicit });
+
+    expect(result.reportPath).toBe(explicit);
+    const envFiles = await fs.readdir(envDir);
+    expect(envFiles).toHaveLength(0);
+  });
+
+  it("markdown header includes invocation flags when present", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "Quality only",
+      config: makeConfig(),
+      logger: noopLogger,
+      dimensions: "quality",
+      noSonar: true,
+      reportFile: target,
+    });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("--dimensions=quality");
+    expect(content).toContain("--no-sonar");
+    expect(content).toContain('"Quality only"');
+  });
+
+  it("still prints the report to stdout in addition to writing the file", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const stdoutText = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdoutText).toContain("## Codebase Health Report");
+  });
+});

--- a/tests/audit/sonar-findings.test.js
+++ b/tests/audit/sonar-findings.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the sonar surface so we can drive collectSonarFindings under
+// controlled conditions without spinning up a real SonarQube container.
+vi.mock("../../src/sonar/manager.js", () => ({
+  isSonarReachable: vi.fn(),
+}));
+vi.mock("../../src/sonar/api.js", () => ({
+  getOpenIssues: vi.fn(),
+  getQualityGateStatus: vi.fn(),
+}));
+
+import { collectSonarFindings, groupIssuesBySeverity } from "../../src/audit/sonar-findings.js";
+import { isSonarReachable } from "../../src/sonar/manager.js";
+import { getOpenIssues, getQualityGateStatus } from "../../src/sonar/api.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+const baseConfig = { sonarqube: { host: "http://localhost:9000" } };
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+describe("collectSonarFindings (KJC-TSK-0361)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns available=false when sonar host is unreachable (no API call attempted)", async () => {
+    isSonarReachable.mockResolvedValue(false);
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not reachable/);
+    expect(getOpenIssues).not.toHaveBeenCalled();
+    expect(noopLogger.warn).toHaveBeenCalled();
+  });
+
+  it("returns available=false when isSonarReachable rejects (defensive catch)", async () => {
+    isSonarReachable.mockRejectedValue(new Error("dns lookup failed"));
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+  });
+
+  it("returns the issues + quality gate when sonar is reachable", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockResolvedValue({
+      total: 2,
+      issues: [
+        { rule: "squid:S1234", severity: "MAJOR", component: "src/foo.js", line: 12, message: "Cognitive complexity too high" },
+        { rule: "squid:S5678", severity: "BLOCKER", component: "src/bar.js", line: 1, message: "Hardcoded secret" },
+      ],
+    });
+    getQualityGateStatus.mockResolvedValue({ ok: true, status: "ERROR", conditions: [] });
+
+    const r = await collectSonarFindings(baseConfig);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(2);
+    expect(r.issues).toHaveLength(2);
+    expect(r.qualityGate.status).toBe("ERROR");
+  });
+
+  it("survives quality-gate fetch failure (returns issues without QG)", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+    getQualityGateStatus.mockRejectedValue(new Error("project not yet analysed"));
+
+    const r = await collectSonarFindings(baseConfig);
+    expect(r.available).toBe(true);
+    expect(r.qualityGate).toBeNull();
+  });
+
+  it("returns available=false when getOpenIssues throws", async () => {
+    isSonarReachable.mockResolvedValue(true);
+    getOpenIssues.mockRejectedValue(new Error("401 unauthorized"));
+
+    const r = await collectSonarFindings(baseConfig, noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/getOpenIssues failed/);
+  });
+});
+
+describe("groupIssuesBySeverity", () => {
+  it("groups issues into Sonar's canonical severity order (BLOCKER first)", () => {
+    const groups = groupIssuesBySeverity([
+      { severity: "MAJOR", message: "a" },
+      { severity: "BLOCKER", message: "b" },
+      { severity: "INFO", message: "c" },
+      { severity: "MAJOR", message: "d" },
+    ]);
+    expect(Object.keys(groups)).toEqual(["BLOCKER", "CRITICAL", "MAJOR", "MINOR", "INFO"]);
+    expect(groups.BLOCKER).toHaveLength(1);
+    expect(groups.MAJOR).toHaveLength(2);
+    expect(groups.INFO).toHaveLength(1);
+  });
+
+  it("buckets unknown severity into INFO", () => {
+    const groups = groupIssuesBySeverity([{ severity: "MYSTERY" }, {}]);
+    expect(groups.INFO).toHaveLength(2);
+  });
+});
+
+describe("buildAuditPrompt — Sonar section integration", () => {
+  it("omits the section when sonarFindings is null or unavailable", () => {
+    const a = buildAuditPrompt({ task: "audit", sonarFindings: null });
+    const b = buildAuditPrompt({ task: "audit", sonarFindings: { available: false, reason: "down" } });
+    expect(a).not.toContain("## SonarQube Findings");
+    expect(b).not.toContain("## SonarQube Findings");
+  });
+
+  it("renders findings grouped by severity with rule + location", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: {
+        available: true,
+        total: 2,
+        issues: [
+          { rule: "squid:S1234", severity: "MAJOR", component: "src/foo.js", line: 12, message: "Cognitive complexity too high" },
+          { rule: "squid:S5678", severity: "BLOCKER", component: "src/bar.js", line: 1, message: "Hardcoded secret" },
+        ],
+        qualityGate: { status: "ERROR", conditions: [] },
+      },
+    });
+    expect(prompt).toContain("## SonarQube Findings");
+    expect(prompt).toContain("Quality gate: ERROR");
+    expect(prompt).toContain("Total open issues: 2");
+    expect(prompt).toContain("### BLOCKER (1)");
+    expect(prompt).toContain("### MAJOR (1)");
+    expect(prompt).toContain("squid:S1234");
+    expect(prompt).toContain("Cross-reference these with your own findings");
+  });
+
+  it("caps the rendered issue list at MAX_SONAR_ISSUES_IN_PROMPT (50) with overflow line", () => {
+    const issues = Array.from({ length: 75 }, (_, i) => ({
+      rule: `squid:R${i}`, severity: "MAJOR", component: `f${i}.js`, line: i, message: `m${i}`,
+    }));
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: { available: true, total: 75, issues },
+    });
+    expect(prompt).toContain("Total open issues: 75");
+    expect(prompt).toContain("and 25 more in MAJOR");
+  });
+
+  it("renders only the quality-gate line when there are zero open issues but a gate result exists", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      sonarFindings: { available: true, total: 0, issues: [], qualityGate: { status: "OK", conditions: [] } },
+    });
+    expect(prompt).toContain("Quality gate: OK");
+    expect(prompt).not.toContain("### BLOCKER");
+  });
+});

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -190,11 +190,14 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     });
     const mcpArgs = executeMock.mock.calls[executeMock.mock.calls.length - 1][0];
 
-    // Parity: both routes pass equivalent task + dimensions. CLI also adds
-    // an onOutput callback for terminal progress (MCP forwards events
-    // differently); strip that before comparing structural shape.
-    const { onOutput: _cliOnOutput, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, ...mcpCore } = mcpArgs;
+    // Parity: both routes pass equivalent task + dimensions. CLI also
+    // attaches an onOutput callback for terminal progress (MCP forwards
+    // events differently) and a noSonar boolean from the --no-sonar flag
+    // (MCP clients toggle the same control via the AuditRole input
+    // directly when they want it). Strip both before comparing the
+    // structural shape that drives the prompt.
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

KJC-TSK-0359 — Pre-patch the audit had **zero** accessibility coverage. Security/quality/perf/architecture/testing were the only dimensions, leaving WCAG entirely unaudited. For an Astro/React/Vue project this was a glaring gap.

This patch adds `accessibility` as a first-class dimension that auto-activates based on detected stack (depends on KJC-TSK-0358 #586).

### Activation matrix

| Dimensions arg | Stack detected | Result |
|---|---|---|
| (default — none) | unknown | included |
| (default — none) | frontend / fullstack | included |
| (default — none) | backend-only | **auto-skipped** |
| `--dimensions=accessibility` | any | always included |

### What the LLM gets asked

- Missing `alt` text on `<img>` (decorative images need `alt=""`, not absent)
- Form inputs without `<label>` or `aria-label`
- Heading hierarchy violations (h1 → h3 skipping h2; multiple h1)
- Icon-only buttons / links without `aria-label` or visually-hidden text
- `<div>`/`<span>` pretending to be buttons (no role + keyboard handlers)
- ARIA misuse (presentation on focusable elements, redundant on native semantics)
- Focus management gaps (modals without focus trap, no visible `:focus`, tabindex misuse)
- Colour-only signalling (red/green-only status)
- Suspicious low-contrast colour pairs in CSS variables / token files
- Missing `lang`, skip-to-content, landmarks
- Static checks only — runtime contrast checks are deferred to axe-core/Lighthouse with a recommendation

## Implementation notes
- New `FRONTEND_ONLY_DIMENSIONS` set formalises the auto-skip category so future frontend-only dimensions (webperf in TSK-0360) plug in trivially.
- JSON schema example is now generated from `AUDIT_DIMENSIONS` so adding a dimension automatically extends the schema (no drift).

## Stacked on
This branch builds on #586 (stack detection), #588 (sonar), #589 (--report-file).

## Test plan
- [x] `npx vitest run tests/audit/prompt-a11y.test.js` — 9/9 passing
- [x] `npx vitest run` — **4245/4245 passing** (9 new tests added)