### PR TITLE
feat(audit): --report-file flag persists audit report on disk (KJC-TSK-0362)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -95,6 +95,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
+    .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -111,6 +112,7 @@ export function registerMeta(program, { pkgVersion }) {
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
           noSonar: flags.sonar === false,
+          reportFile: flags.reportFile || null,
         });
       });
     });

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,4 +1,7 @@
 import path from "node:path";
+import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { AUDIT_DIMENSIONS } from "../prompts/audit.js";
@@ -6,6 +9,8 @@ import { AuditRole } from "../roles/audit-role.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
+
+const execFileAsync = promisify(execFile);
 
 function formatFindings(findings) {
   const lines = [];
@@ -69,7 +74,74 @@ function formatAudit(parsed) {
   return lines.join("\n");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false }) {
+/**
+ * Resolve where to write the audit report on disk, given a flag value, an
+ * env override, and the desired format. Returns null if no write target
+ * was requested. Creates parent directories on demand.
+ *
+ * Resolution rules (KJC-TSK-0362):
+ *   - flag undefined + no env → null (legacy behaviour, stdout only)
+ *   - flag is a directory → write `audit-<ISO>.{md,json}` inside it
+ *   - flag is a non-directory path → use it verbatim (extension drives format
+ *     when --json/--md not explicit)
+ *   - flag is undefined but env $KJ_AUDIT_REPORT_DIR is set → treat env as dir
+ */
+async function resolveReportFilePath(flagValue, isJson) {
+  const envDir = process.env.KJ_AUDIT_REPORT_DIR;
+  const target = flagValue || (envDir ? envDir : null);
+  if (!target) return null;
+
+  const ext = isJson ? "json" : "md";
+  let stats = null;
+  try { stats = await fs.stat(target); } catch { /* not a directory yet */ }
+  const isDir = stats?.isDirectory() || target.endsWith(path.sep) || target === envDir;
+
+  let resolved;
+  if (isDir) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    resolved = path.resolve(target, `audit-${stamp}.${ext}`);
+  } else {
+    resolved = path.resolve(target);
+  }
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  return resolved;
+}
+
+/**
+ * Build the markdown header that prefixes a persisted report — captures
+ * timestamp + repo state + invocation flags so the file is reproducible.
+ */
+async function buildReportHeader(projectDir, invocation) {
+  const lines = ["# Karajan Audit Report", ""];
+  lines.push(`- **Generated:** ${new Date().toISOString()}`);
+  lines.push(`- **Project:** ${projectDir || process.cwd()}`);
+
+  // Best-effort git info — silent if outside a repo.
+  try {
+    const branch = (await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    const commit = (await execFileAsync("git", ["rev-parse", "--short", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    lines.push(`- **Branch:** ${branch}`);
+    lines.push(`- **Commit:** ${commit}`);
+  } catch { /* not a git repo or git missing */ }
+
+  if (invocation) lines.push(`- **Invocation:** \`${invocation}\``);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+function describeInvocation({ task, dimensions, noSonar, json }) {
+  const parts = ["kj audit"];
+  if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
+  if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
+  if (noSonar) parts.push("--no-sonar");
+  if (json) parts.push("--json");
+  return parts.join(" ");
+}
+
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -123,20 +195,38 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       runLog.logText(`[audit] findings=${parsed.summary.totalFindings} (critical=${parsed.summary.critical}, high=${parsed.summary.high})`);
     }
 
+    // Resolve write target BEFORE printing — if the user pointed at a
+    // path that can't be created we want to fail fast, not after the LLM
+    // has already printed everything to stdout.
+    const reportPath = await resolveReportFilePath(reportFile, json);
+
+    let stdoutContent;
     if (json) {
-      console.log(JSON.stringify(parsed || roleResult, null, 2));
-      return { ok: true };
+      stdoutContent = JSON.stringify(parsed || roleResult, null, 2);
+    } else if (parsed?.summary?.overallHealth) {
+      stdoutContent = formatAudit(parsed);
+    } else if (parsed?.raw) {
+      stdoutContent = parsed.raw;
+    } else {
+      stdoutContent = roleResult.summary || "Audit complete.";
+    }
+    console.log(stdoutContent);
+
+    if (reportPath) {
+      let payload;
+      if (reportPath.endsWith(".json")) {
+        payload = JSON.stringify(parsed || roleResult, null, 2);
+      } else {
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json }));
+        payload = header + stdoutContent + "\n";
+      }
+      await fs.writeFile(reportPath, payload, "utf8");
+      runLog.logText(`[audit] report written → ${reportPath}`);
+      logger.info(`Audit report written: ${reportPath}`);
     }
 
-    if (parsed?.summary?.overallHealth) {
-      console.log(formatAudit(parsed));
-    } else if (parsed?.raw) {
-      console.log(parsed.raw);
-    } else {
-      console.log(roleResult.summary || "Audit complete.");
-    }
     logger.info("Audit completed.");
-    return { ok: true };
+    return { ok: true, reportPath: reportPath || undefined };
   });
 }
 

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// Reuse the same AuditRole mocking strategy as tests/command-audit.test.js
+// so this file can drive auditCommand through the report-file branch
+// without spinning up an LLM.
+const executeMock = vi.fn();
+class MockAuditRole {
+  constructor(opts) { this.opts = opts; }
+  async execute(input) { return executeMock(input); }
+}
+
+vi.mock("../../src/roles/audit-role.js", () => ({ AuditRole: MockAuditRole }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
+}));
+vi.mock("../../src/utils/cli-progress.js", () => ({
+  createCliProgressReporter: vi.fn(() => ({ onOutput: vi.fn(), finish: vi.fn() })),
+}));
+vi.mock("../../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
+  }),
+}));
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+const successResult = {
+  ok: true,
+  result: {
+    summary: { overallHealth: "fair", totalFindings: 1, critical: 0, high: 1, medium: 0, low: 0 },
+    dimensions: {
+      security: { score: "B", findings: [] },
+      codeQuality: { score: "C", findings: [{ severity: "high", file: "src/foo.js", line: 10, rule: "AUDIT-Q-1", description: "God module", recommendation: "Split" }] },
+      performance: { score: "A", findings: [] },
+      architecture: { score: "B", findings: [] },
+      testing: { score: "C", findings: [] },
+    },
+    topRecommendations: [],
+    textSummary: "Fair health",
+    provider: "claude",
+  },
+  summary: "Overall health: fair. 1 findings (1 high)",
+};
+
+let tmpDir;
+let consoleSpy;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  executeMock.mockResolvedValue(successResult);
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-report-"));
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+afterEach(async () => {
+  consoleSpy.mockRestore();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+function makeConfig(overrides = {}) {
+  return { roles: { audit: { provider: "claude" } }, projectDir: tmpDir, ...overrides };
+}
+
+describe("kj audit --report-file (KJC-TSK-0362)", () => {
+  it("zero behaviour change when --report-file is absent and env unset", async () => {
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toBeUndefined();
+    // Nothing written to tmpDir
+    const files = await fs.readdir(tmpDir);
+    expect(files).toHaveLength(0);
+  });
+
+  it("writes a markdown report when --report-file is a .md path", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    expect(result.reportPath).toBe(target);
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+    expect(content).toContain("## Codebase Health Report");
+    expect(content).toContain("**Overall Health:** fair");
+    expect(content).toContain("- **Generated:**");
+  });
+
+  it("writes a JSON report when --report-file is a .json path", async () => {
+    const target = path.join(tmpDir, "audit.json");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target, json: true });
+
+    const content = await fs.readFile(target, "utf8");
+    const parsed = JSON.parse(content);
+    expect(parsed.summary.overallHealth).toBe("fair");
+    expect(parsed.dimensions.codeQuality.findings[0].rule).toBe("AUDIT-Q-1");
+  });
+
+  it("writes a timestamped file inside a directory target", async () => {
+    const reportsDir = path.join(tmpDir, "reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: reportsDir });
+
+    expect(result.reportPath).toMatch(/\/reports\/audit-\d{4}-\d{2}-\d{2}T.*\.md$/);
+    const written = await fs.readFile(result.reportPath, "utf8");
+    expect(written).toContain("# Karajan Audit Report");
+  });
+
+  it("creates parent directories on demand", async () => {
+    const target = path.join(tmpDir, "deeply", "nested", "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+  });
+
+  it("uses $KJ_AUDIT_REPORT_DIR as default directory when --report-file is absent", async () => {
+    const reportsDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = reportsDir;
+
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toMatch(/\/env-reports\/audit-.+\.md$/);
+  });
+
+  it("explicit --report-file beats $KJ_AUDIT_REPORT_DIR", async () => {
+    const envDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(envDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = envDir;
+
+    const explicit = path.join(tmpDir, "explicit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: explicit });
+
+    expect(result.reportPath).toBe(explicit);
+    const envFiles = await fs.readdir(envDir);
+    expect(envFiles).toHaveLength(0);
+  });
+
+  it("markdown header includes invocation flags when present", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "Quality only",
+      config: makeConfig(),
+      logger: noopLogger,
+      dimensions: "quality",
+      noSonar: true,
+      reportFile: target,
+    });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("--dimensions=quality");
+    expect(content).toContain("--no-sonar");
+    expect(content).toContain('"Quality only"');
+  });
+
+  it("still prints the report to stdout in addition to writing the file", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const stdoutText = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdoutText).toContain("## Codebase Health Report");
+  });
+});


### PR DESCRIPTION
## Summary

KJC-TSK-0362 — Pre-patch the audit report only existed in stdout. Closing the terminal or scrolling past it lost the result. CI integrations had to redirect manually; there was no way to keep an audit history for diff comparison without shell glue.

This patch adds two small surfaces and zero behaviour change for users that don't opt in.

> Replaces #589 (closed) — rebased onto current main after #588 (sonar) merged.

### What's new

- `--report-file <path>` flag: writes the formatted report to disk in addition to stdout. Path can be a file (`.md`/`.json` extension drives format) or a directory (creates `audit-<ISO>.<md|json>` inside; auto-creates the directory if missing).
- `$KJ_AUDIT_REPORT_DIR` env var: default directory when no `--report-file`. Useful in CI. Explicit `--report-file` always wins.
- Markdown output gets a reproducibility header (timestamp, project, branch + commit, invocation flags).
- Parent directories of arbitrary paths are created on demand.

## Test plan
- [x] `npx vitest run tests/audit/report-file.test.js` — 9/9 passing
- [x] Full suite previously verified at 4236/4236 on the v2 branch