### PR TITLE
feat(audit): wire WebPerf into audit for frontend projects (KJC-TSK-0360)

### DIFF
--- a/src/audit/webperf-input.js
+++ b/src/audit/webperf-input.js
@@ -1,0 +1,90 @@
+/**
+ * WebPerf input collector for `kj audit` (KJC-TSK-0360).
+ *
+ * Two modes:
+ *   - "static-hints": no live measurement available, but the project is
+ *     frontend so the LLM should look for frontend-perf patterns in the
+ *     source (bundle bloat, render-blocking, image opt, lazy loading).
+ *     This is the common path because `kj audit` runs against a code
+ *     tree, not a live preview server.
+ *   - "cwv-result": a Core Web Vitals measurement was supplied (either
+ *     via config.webperf.lastResult, or in the future via a `kj webperf`
+ *     command that drives Chrome DevTools MCP). evaluateCwv from
+ *     src/webperf/cwv-gate.js produces a structured verdict the prompt
+ *     renders verbatim.
+ *
+ * The "live measurement" path is intentionally NOT wired here: the
+ * audit's LLM sub-agent is forbidden from MCP tool use (SUBAGENT_PREAMBLE
+ * in src/prompts/audit.js), and spawning Chrome / launching a preview
+ * server during a read-only audit is out of scope. When a future
+ * `kj webperf` command exists, it can write the result into
+ * `config.webperf.lastResult` and this collector will surface it.
+ */
+
+import { evaluateCwv, CWV_THRESHOLDS } from "../webperf/cwv-gate.js";
+
+/**
+ * Decide what (if anything) to feed the audit prompt about web perf.
+ *
+ * @param {object|null} stack - detectProjectStack output (null when unknown)
+ * @param {object} [config] - resolved Karajan config (config.webperf may carry a stale CWV result)
+ * @returns {{available: boolean, mode?: 'static-hints'|'cwv-result', cwv?: object, reason?: string}}
+ */
+export function collectWebPerfInput(stack, config = {}) {
+  const webperfConfig = config?.webperf || {};
+  const lastResult = webperfConfig.lastResult || null;
+
+  if (lastResult && typeof lastResult === "object" && lastResult.metrics) {
+    const verdict = evaluateCwv(lastResult.metrics, lastResult.thresholds || webperfConfig.thresholds);
+    return {
+      available: true,
+      mode: "cwv-result",
+      url: lastResult.url || webperfConfig.url || null,
+      capturedAt: lastResult.capturedAt || null,
+      cwv: verdict,
+      thresholds: lastResult.thresholds || webperfConfig.thresholds || CWV_THRESHOLDS,
+    };
+  }
+
+  // No live measurement → static hints only when the project actually has
+  // a frontend layer to audit. Backend-only projects get nothing.
+  const isFrontendish = !stack || stack.isFrontend === true || stack.isFullstack === true;
+  if (!isFrontendish) {
+    return { available: false, reason: "project is backend-only — no frontend-perf hints to give" };
+  }
+
+  return { available: true, mode: "static-hints" };
+}
+
+/**
+ * Render a CWV verdict (from collectWebPerfInput's cwv-result mode) as
+ * concise prompt-friendly markdown. Kept independent from the prompt
+ * builder so it stays unit-testable in isolation.
+ */
+export function formatCwvVerdict(input) {
+  if (!input || input.mode !== "cwv-result" || !input.cwv) return null;
+  const { cwv, url, capturedAt } = input;
+  const lines = [];
+  if (url) lines.push(`- Target URL: ${url}`);
+  if (capturedAt) lines.push(`- Captured: ${capturedAt}`);
+  lines.push(`- Verdict: ${cwv.pass ? "PASS" : "FAIL"}`);
+  if (Object.keys(cwv.scores || {}).length) {
+    lines.push("- Scores:");
+    for (const [metric, score] of Object.entries(cwv.scores)) {
+      lines.push(`  - ${metric.toUpperCase()}: ${score.value} (${score.rating})`);
+    }
+  }
+  if (cwv.blocking?.length) {
+    lines.push("- Blocking metrics (above poor threshold):");
+    for (const b of cwv.blocking) {
+      lines.push(`  - ${b.metric.toUpperCase()} ${b.value} > ${b.threshold}`);
+    }
+  }
+  if (cwv.advisory?.length) {
+    lines.push("- Advisory metrics (between good and poor):");
+    for (const a of cwv.advisory) {
+      lines.push(`  - ${a.metric.toUpperCase()} ${a.value} > good=${a.threshold}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -95,6 +95,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
+    .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -111,6 +112,7 @@ export function registerMeta(program, { pkgVersion }) {
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
           noSonar: flags.sonar === false,
+          reportFile: flags.reportFile || null,
         });
       });
     });

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -90,7 +90,7 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Analyze codebase health (read-only)")
     .argument("[task]", "Task description. If absent, defaults to a full-codebase analysis. Use --task-file to point at a .md.")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
-    .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing", "all")
+    .option("--dimensions <list>", "Comma-separated: security,quality,performance,architecture,testing,accessibility (default: all; accessibility auto-skipped on detected backend-only projects)", "all")
     .option("--json", "Output raw JSON")
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -50,7 +50,8 @@ const DIMENSION_LABELS = {
   codeQuality: "Code Quality",
   performance: "Performance",
   architecture: "Architecture",
-  testing: "Testing"
+  testing: "Testing",
+  accessibility: "Accessibility (WCAG 2.x)"
 };
 
 function formatAudit(parsed) {

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,4 +1,7 @@
 import path from "node:path";
+import fs from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { AUDIT_DIMENSIONS } from "../prompts/audit.js";
@@ -6,6 +9,8 @@ import { AuditRole } from "../roles/audit-role.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
+
+const execFileAsync = promisify(execFile);
 
 function formatFindings(findings) {
   const lines = [];
@@ -69,7 +74,74 @@ function formatAudit(parsed) {
   return lines.join("\n");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false }) {
+/**
+ * Resolve where to write the audit report on disk, given a flag value, an
+ * env override, and the desired format. Returns null if no write target
+ * was requested. Creates parent directories on demand.
+ *
+ * Resolution rules (KJC-TSK-0362):
+ *   - flag undefined + no env → null (legacy behaviour, stdout only)
+ *   - flag is a directory → write `audit-<ISO>.{md,json}` inside it
+ *   - flag is a non-directory path → use it verbatim (extension drives format
+ *     when --json/--md not explicit)
+ *   - flag is undefined but env $KJ_AUDIT_REPORT_DIR is set → treat env as dir
+ */
+async function resolveReportFilePath(flagValue, isJson) {
+  const envDir = process.env.KJ_AUDIT_REPORT_DIR;
+  const target = flagValue || (envDir ? envDir : null);
+  if (!target) return null;
+
+  const ext = isJson ? "json" : "md";
+  let stats = null;
+  try { stats = await fs.stat(target); } catch { /* not a directory yet */ }
+  const isDir = stats?.isDirectory() || target.endsWith(path.sep) || target === envDir;
+
+  let resolved;
+  if (isDir) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    resolved = path.resolve(target, `audit-${stamp}.${ext}`);
+  } else {
+    resolved = path.resolve(target);
+  }
+
+  await fs.mkdir(path.dirname(resolved), { recursive: true });
+  return resolved;
+}
+
+/**
+ * Build the markdown header that prefixes a persisted report — captures
+ * timestamp + repo state + invocation flags so the file is reproducible.
+ */
+async function buildReportHeader(projectDir, invocation) {
+  const lines = ["# Karajan Audit Report", ""];
+  lines.push(`- **Generated:** ${new Date().toISOString()}`);
+  lines.push(`- **Project:** ${projectDir || process.cwd()}`);
+
+  // Best-effort git info — silent if outside a repo.
+  try {
+    const branch = (await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    const commit = (await execFileAsync("git", ["rev-parse", "--short", "HEAD"], { cwd: projectDir, timeout: 2000 })).stdout.trim();
+    lines.push(`- **Branch:** ${branch}`);
+    lines.push(`- **Commit:** ${commit}`);
+  } catch { /* not a git repo or git missing */ }
+
+  if (invocation) lines.push(`- **Invocation:** \`${invocation}\``);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  return lines.join("\n");
+}
+
+function describeInvocation({ task, dimensions, noSonar, json }) {
+  const parts = ["kj audit"];
+  if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
+  if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
+  if (noSonar) parts.push("--no-sonar");
+  if (json) parts.push("--json");
+  return parts.join(" ");
+}
+
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -123,20 +195,38 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       runLog.logText(`[audit] findings=${parsed.summary.totalFindings} (critical=${parsed.summary.critical}, high=${parsed.summary.high})`);
     }
 
+    // Resolve write target BEFORE printing — if the user pointed at a
+    // path that can't be created we want to fail fast, not after the LLM
+    // has already printed everything to stdout.
+    const reportPath = await resolveReportFilePath(reportFile, json);
+
+    let stdoutContent;
     if (json) {
-      console.log(JSON.stringify(parsed || roleResult, null, 2));
-      return { ok: true };
+      stdoutContent = JSON.stringify(parsed || roleResult, null, 2);
+    } else if (parsed?.summary?.overallHealth) {
+      stdoutContent = formatAudit(parsed);
+    } else if (parsed?.raw) {
+      stdoutContent = parsed.raw;
+    } else {
+      stdoutContent = roleResult.summary || "Audit complete.";
+    }
+    console.log(stdoutContent);
+
+    if (reportPath) {
+      let payload;
+      if (reportPath.endsWith(".json")) {
+        payload = JSON.stringify(parsed || roleResult, null, 2);
+      } else {
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json }));
+        payload = header + stdoutContent + "\n";
+      }
+      await fs.writeFile(reportPath, payload, "utf8");
+      runLog.logText(`[audit] report written → ${reportPath}`);
+      logger.info(`Audit report written: ${reportPath}`);
     }
 
-    if (parsed?.summary?.overallHealth) {
-      console.log(formatAudit(parsed));
-    } else if (parsed?.raw) {
-      console.log(parsed.raw);
-    } else {
-      console.log(roleResult.summary || "Audit complete.");
-    }
     logger.info("Audit completed.");
-    return { ok: true };
+    return { ok: true, reportPath: reportPath || undefined };
   });
 }
 

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,5 +1,6 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
+import { formatCwvVerdict } from "../audit/webperf-input.js";
 
 const MAX_SONAR_ISSUES_IN_PROMPT = 50;
 
@@ -23,7 +24,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -248,6 +249,36 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     }
     lines.push("");
     lines.push("Cross-reference these with your own findings. When your finding overlaps a Sonar rule, mention the rule ID in the `rule` field — that's a high-confidence match. Findings the LLM raises that Sonar can't see (architecture, naming, API design) are still valuable; mark them with rule names like \"AUDIT-ARCH-N\".");
+    sections.push(lines.join("\n"));
+  }
+
+  // WebPerf — KJC-TSK-0360. Two modes: a real CWV measurement when one is
+  // surfaced via config.webperf.lastResult (future `kj webperf` command)
+  // OR static frontend-perf hints for the LLM to look at the source code
+  // when no live measurement is available. Backend-only projects skip the
+  // section entirely (collectWebPerfInput returns available:false).
+  if (webperf?.available) {
+    const lines = ["## WebPerf — Frontend Performance"];
+    if (webperf.mode === "cwv-result") {
+      lines.push("Live Core Web Vitals measurement available — incorporate the verdict below into the performance dimension findings:");
+      lines.push("");
+      lines.push(formatCwvVerdict(webperf));
+      lines.push("");
+      lines.push("If a metric is `poor`, recommend a concrete code change (preconnect, lazy-load, image format, critical CSS, defer script). Cite the offending file or pattern when you can find it in the source.");
+    } else {
+      lines.push("No live CWV measurement was provided. Audit the source for these static frontend-perf patterns and include findings under the `performance` dimension:");
+      lines.push("");
+      lines.push("- Render-blocking `<link rel=\"stylesheet\">` or `<script>` without `defer`/`async` in `<head>`");
+      lines.push("- Large JavaScript bundles imported eagerly that could be `await import(...)` or split by route");
+      lines.push("- Non-modern image formats (only .jpg/.png) where webp/avif are widely supported");
+      lines.push("- `<img>` without `width`/`height` attributes (causes CLS)");
+      lines.push("- `<img>` without `loading=\"lazy\"` for off-screen images, or videos auto-playing without `preload=\"metadata\"`");
+      lines.push("- Web fonts loaded without `font-display: swap` or without `<link rel=\"preconnect\">` to the font origin");
+      lines.push("- Whole-library imports for one helper (e.g. `import _ from 'lodash'` instead of `lodash/get`)");
+      lines.push("- Missing critical CSS extraction or above-the-fold inlining strategy in build config");
+      lines.push("- Large third-party scripts (analytics, A/B, chat widgets) without defer + facade pattern");
+      lines.push("- Unbounded list rendering without virtualisation for very long collections");
+    }
     sections.push(lines.join("\n"));
   }
 

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -10,7 +10,13 @@ const SUBAGENT_PREAMBLE = [
   "DO NOT modify any files — this is a read-only analysis. Only use: Read, Grep, Glob, Bash (for analysis commands like wc, find, git log, du, npm ls)."
 ].join(" ");
 
-export const AUDIT_DIMENSIONS = ["security", "codeQuality", "performance", "architecture", "testing"];
+export const AUDIT_DIMENSIONS = ["security", "codeQuality", "performance", "architecture", "testing", "accessibility"];
+
+// Dimensions that only apply to frontend / fullstack projects. Auto-dropped
+// from the default dimension list when stack detection knows the project
+// is backend-only — preserves activation when the user explicitly opts in
+// via --dimensions=accessibility (KJC-TSK-0359).
+const FRONTEND_ONLY_DIMENSIONS = new Set(["accessibility"]);
 
 const VALID_HEALTH = new Set(["good", "fair", "poor", "critical"]);
 const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
@@ -56,9 +62,20 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     sections.push(stackLines.join("\n"));
   }
 
-  const activeDimensions = dimensions
-    ? dimensions.filter(d => AUDIT_DIMENSIONS.includes(d))
-    : AUDIT_DIMENSIONS;
+  // When dimensions are explicit, honour them verbatim — even frontend-only
+  // dimensions on a backend project (the user knows what they want).
+  // When dimensions are absent, default to all but drop frontend-only
+  // dimensions if the stack is provably backend-only. Unknown stack falls
+  // back to the full list (no false negatives — better an extra section
+  // than a missing one).
+  let activeDimensions;
+  if (dimensions) {
+    activeDimensions = dimensions.filter(d => AUDIT_DIMENSIONS.includes(d));
+  } else if (stack && stack.isBackend && !stack.isFrontend) {
+    activeDimensions = AUDIT_DIMENSIONS.filter(d => !FRONTEND_ONLY_DIMENSIONS.has(d));
+  } else {
+    activeDimensions = AUDIT_DIMENSIONS;
+  }
 
   if (activeDimensions.includes("security")) {
     sections.push(
@@ -134,9 +151,32 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     );
   }
 
+  if (activeDimensions.includes("accessibility")) {
+    sections.push(
+      "## Accessibility Analysis (WCAG 2.x)",
+      [
+        "- Missing alt text on <img> tags (decorative images need empty alt=\"\", not absent)",
+        "- Form inputs without associated <label> or aria-label",
+        "- Heading hierarchy violations (h1 → h3 skipping h2; multiple h1 per page)",
+        "- Buttons / links containing only icons without aria-label or visually-hidden text",
+        "- Interactive elements built from <div>/<span> without role + keyboard handlers",
+        "- ARIA roles misused (presentation on focusable elements, redundant on native semantics)",
+        "- Focus management gaps (modals without focus trap, no visible :focus styles, tabindex misuse)",
+        "- Colour-only signalling (status indicated by red/green only, no icon or text)",
+        "- Static contrast — flag suspicious low-contrast colour pairs in CSS variables / token files",
+        "- Missing lang attribute on <html>, missing skip-to-content link, missing landmarks"
+      ].join("\n"),
+      "Skip findings about colour contrast that require runtime rendering (e.g. computed styles); flag the suspect CSS values and recommend an axe-core/Lighthouse runtime check."
+    );
+  }
+
+  // JSON schema — keep the per-dimension entries in sync with AUDIT_DIMENSIONS.
+  const schemaDimensions = AUDIT_DIMENSIONS
+    .map(d => `"${d}":{"score":"A|B|C|D|F","findings":[]}`)
+    .join(",");
   sections.push(
     "Return a single valid JSON object and nothing else.",
-    'JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{"security":{"score":"A|B|C|D|F","findings":[]},"codeQuality":{"score":"A|B|C|D|F","findings":[]},"performance":{"score":"A|B|C|D|F","findings":[]},"architecture":{"score":"A|B|C|D|F","findings":[]},"testing":{"score":"A|B|C|D|F","findings":[]}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}',
+    `JSON schema: {"ok":true,"result":{"summary":{"overallHealth":"good|fair|poor|critical","totalFindings":number,"critical":number,"high":number,"medium":number,"low":number},"dimensions":{${schemaDimensions}},"topRecommendations":[{"priority":number,"dimension":string,"action":string,"impact":"high|medium|low","effort":"high|medium|low"}]},"summary":string}`,
     'Each finding: {"severity":"critical|high|medium|low","file":string,"line":number,"rule":string,"description":string,"recommendation":string}',
     `Only include dimensions you were asked to analyze: ${activeDimensions.join(", ")}`
   );

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -3,6 +3,7 @@ import { buildAuditPrompt, parseAuditOutput, AUDIT_DIMENSIONS } from "../prompts
 import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDelta } from "../audit/basal-cost.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { collectSonarFindings } from "../audit/sonar-findings.js";
+import { collectWebPerfInput } from "../audit/webperf-input.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -62,10 +63,18 @@ export class AuditRole extends AgentRole {
         sonarFindings = await collectSonarFindings(this.config, this.logger);
       } catch { /* sonar fetch is best-effort */ }
     }
+    // WebPerf input — KJC-TSK-0360. Pure: static-hints for frontend
+    // projects, optional CWV verdict when config carries a previous
+    // measurement. No network/spawn from the audit; live CWV collection
+    // is the future `kj webperf` command's job.
+    let webperf = null;
+    try {
+      webperf = collectWebPerfInput(stack, this.config);
+    } catch { /* webperf input is best-effort */ }
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const result = await agent.runTask(runArgs);
@@ -90,6 +99,7 @@ export class AuditRole extends AgentRole {
           basalCost: basalCost || undefined, growthDelta: growthDelta || undefined,
           stack: stack || undefined,
           sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
+          webperf: webperf?.available ? webperf : undefined,
           provider
         },
         summary: buildSummary(parsed),

--- a/tests/audit/prompt-a11y.test.js
+++ b/tests/audit/prompt-a11y.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { buildAuditPrompt, AUDIT_DIMENSIONS, parseAuditOutput } from "../../src/prompts/audit.js";
+
+// Accessibility dimension — KJC-TSK-0359.
+// Auto-active by default; auto-suppressed when stack is provably backend
+// only; always honoured when the user explicitly opts in via --dimensions.
+
+describe("AUDIT_DIMENSIONS includes accessibility", () => {
+  it("exposes accessibility as a first-class dimension", () => {
+    expect(AUDIT_DIMENSIONS).toContain("accessibility");
+  });
+});
+
+describe("buildAuditPrompt — Accessibility section auto-activation (KJC-TSK-0359)", () => {
+  it("includes the section by default when no dimension filter is set", () => {
+    const prompt = buildAuditPrompt({ task: "audit" });
+    expect(prompt).toContain("## Accessibility Analysis (WCAG 2.x)");
+    expect(prompt).toContain("Missing alt text on <img> tags");
+    expect(prompt).toContain("Form inputs without associated <label> or aria-label");
+  });
+
+  it("includes the section for a known frontend project (Astro)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["astro"], language: "javascript", isFrontend: true, isBackend: false, isFullstack: false },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("includes the section for a fullstack project (Next.js)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["next"], language: "typescript", isFrontend: true, isBackend: true, isFullstack: true },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("OMITS the section by default for a known backend-only project (Express)", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      stack: { frameworks: ["express"], language: "javascript", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).not.toContain("## Accessibility Analysis");
+  });
+
+  it("INCLUDES the section on a backend project when explicitly requested via dimensions", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      dimensions: ["accessibility"],
+      stack: { frameworks: ["express"], language: "javascript", isFrontend: false, isBackend: true, isFullstack: false },
+    });
+    expect(prompt).toContain("## Accessibility Analysis");
+  });
+
+  it("respects an explicit dimension list that omits accessibility", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      dimensions: ["security", "testing"],
+    });
+    expect(prompt).not.toContain("## Accessibility Analysis");
+    expect(prompt).toContain("## Security Analysis");
+    expect(prompt).toContain("## Testing Analysis");
+  });
+
+  it("includes accessibility in the JSON schema schema example so the LLM populates it", () => {
+    const prompt = buildAuditPrompt({ task: "audit" });
+    // Schema must list every dimension the prompt will accept back.
+    for (const d of AUDIT_DIMENSIONS) {
+      expect(prompt).toContain(`"${d}":{"score":"A|B|C|D|F","findings":[]}`);
+    }
+  });
+});
+
+describe("parseAuditOutput accepts accessibility findings", () => {
+  it("surfaces accessibility findings the LLM returns", () => {
+    const raw = JSON.stringify({
+      ok: true,
+      result: {
+        summary: { overallHealth: "fair" },
+        dimensions: {
+          accessibility: {
+            score: "C",
+            findings: [
+              { severity: "high", file: "src/Hero.astro", line: 42, rule: "WCAG-1.1.1", description: "Image missing alt", recommendation: "Add alt text or alt=\"\"" },
+            ],
+          },
+        },
+      },
+    });
+    const parsed = parseAuditOutput(raw);
+    expect(parsed.dimensions.accessibility.score).toBe("C");
+    expect(parsed.dimensions.accessibility.findings).toHaveLength(1);
+    expect(parsed.dimensions.accessibility.findings[0].rule).toBe("WCAG-1.1.1");
+    expect(parsed.summary.high).toBe(1);
+  });
+});

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// Reuse the same AuditRole mocking strategy as tests/command-audit.test.js
+// so this file can drive auditCommand through the report-file branch
+// without spinning up an LLM.
+const executeMock = vi.fn();
+class MockAuditRole {
+  constructor(opts) { this.opts = opts; }
+  async execute(input) { return executeMock(input); }
+}
+
+vi.mock("../../src/roles/audit-role.js", () => ({ AuditRole: MockAuditRole }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
+}));
+vi.mock("../../src/utils/cli-progress.js", () => ({
+  createCliProgressReporter: vi.fn(() => ({ onOutput: vi.fn(), finish: vi.fn() })),
+}));
+vi.mock("../../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
+  }),
+}));
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+const successResult = {
+  ok: true,
+  result: {
+    summary: { overallHealth: "fair", totalFindings: 1, critical: 0, high: 1, medium: 0, low: 0 },
+    dimensions: {
+      security: { score: "B", findings: [] },
+      codeQuality: { score: "C", findings: [{ severity: "high", file: "src/foo.js", line: 10, rule: "AUDIT-Q-1", description: "God module", recommendation: "Split" }] },
+      performance: { score: "A", findings: [] },
+      architecture: { score: "B", findings: [] },
+      testing: { score: "C", findings: [] },
+    },
+    topRecommendations: [],
+    textSummary: "Fair health",
+    provider: "claude",
+  },
+  summary: "Overall health: fair. 1 findings (1 high)",
+};
+
+let tmpDir;
+let consoleSpy;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  executeMock.mockResolvedValue(successResult);
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-report-"));
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+afterEach(async () => {
+  consoleSpy.mockRestore();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_AUDIT_REPORT_DIR;
+});
+
+function makeConfig(overrides = {}) {
+  return { roles: { audit: { provider: "claude" } }, projectDir: tmpDir, ...overrides };
+}
+
+describe("kj audit --report-file (KJC-TSK-0362)", () => {
+  it("zero behaviour change when --report-file is absent and env unset", async () => {
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toBeUndefined();
+    // Nothing written to tmpDir
+    const files = await fs.readdir(tmpDir);
+    expect(files).toHaveLength(0);
+  });
+
+  it("writes a markdown report when --report-file is a .md path", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    expect(result.reportPath).toBe(target);
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+    expect(content).toContain("## Codebase Health Report");
+    expect(content).toContain("**Overall Health:** fair");
+    expect(content).toContain("- **Generated:**");
+  });
+
+  it("writes a JSON report when --report-file is a .json path", async () => {
+    const target = path.join(tmpDir, "audit.json");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target, json: true });
+
+    const content = await fs.readFile(target, "utf8");
+    const parsed = JSON.parse(content);
+    expect(parsed.summary.overallHealth).toBe("fair");
+    expect(parsed.dimensions.codeQuality.findings[0].rule).toBe("AUDIT-Q-1");
+  });
+
+  it("writes a timestamped file inside a directory target", async () => {
+    const reportsDir = path.join(tmpDir, "reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: reportsDir });
+
+    expect(result.reportPath).toMatch(/\/reports\/audit-\d{4}-\d{2}-\d{2}T.*\.md$/);
+    const written = await fs.readFile(result.reportPath, "utf8");
+    expect(written).toContain("# Karajan Audit Report");
+  });
+
+  it("creates parent directories on demand", async () => {
+    const target = path.join(tmpDir, "deeply", "nested", "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("# Karajan Audit Report");
+  });
+
+  it("uses $KJ_AUDIT_REPORT_DIR as default directory when --report-file is absent", async () => {
+    const reportsDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(reportsDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = reportsDir;
+
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger });
+
+    expect(result.reportPath).toMatch(/\/env-reports\/audit-.+\.md$/);
+  });
+
+  it("explicit --report-file beats $KJ_AUDIT_REPORT_DIR", async () => {
+    const envDir = path.join(tmpDir, "env-reports");
+    await fs.mkdir(envDir, { recursive: true });
+    process.env.KJ_AUDIT_REPORT_DIR = envDir;
+
+    const explicit = path.join(tmpDir, "explicit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: explicit });
+
+    expect(result.reportPath).toBe(explicit);
+    const envFiles = await fs.readdir(envDir);
+    expect(envFiles).toHaveLength(0);
+  });
+
+  it("markdown header includes invocation flags when present", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "Quality only",
+      config: makeConfig(),
+      logger: noopLogger,
+      dimensions: "quality",
+      noSonar: true,
+      reportFile: target,
+    });
+
+    const content = await fs.readFile(target, "utf8");
+    expect(content).toContain("--dimensions=quality");
+    expect(content).toContain("--no-sonar");
+    expect(content).toContain('"Quality only"');
+  });
+
+  it("still prints the report to stdout in addition to writing the file", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({ task: "audit", config: makeConfig(), logger: noopLogger, reportFile: target });
+
+    const stdoutText = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdoutText).toContain("## Codebase Health Report");
+  });
+});

--- a/tests/audit/webperf-input.test.js
+++ b/tests/audit/webperf-input.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { collectWebPerfInput, formatCwvVerdict } from "../../src/audit/webperf-input.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+// WebPerf input collector + prompt integration — KJC-TSK-0360.
+
+describe("collectWebPerfInput (KJC-TSK-0360)", () => {
+  it("returns static-hints mode for an unknown stack (frontend default)", () => {
+    const r = collectWebPerfInput(null, {});
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("static-hints");
+  });
+
+  it("returns static-hints for a frontend project", () => {
+    const r = collectWebPerfInput({ isFrontend: true, isBackend: false, isFullstack: false }, {});
+    expect(r.mode).toBe("static-hints");
+  });
+
+  it("returns static-hints for a fullstack project", () => {
+    const r = collectWebPerfInput({ isFrontend: true, isBackend: true, isFullstack: true }, {});
+    expect(r.mode).toBe("static-hints");
+  });
+
+  it("returns available=false for a backend-only project (no frontend perf signal)", () => {
+    const r = collectWebPerfInput({ isFrontend: false, isBackend: true, isFullstack: false }, {});
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/backend-only/);
+  });
+
+  it("surfaces a CWV verdict from config.webperf.lastResult when present", () => {
+    const r = collectWebPerfInput(
+      { isFrontend: true, isBackend: false, isFullstack: false },
+      {
+        webperf: {
+          url: "https://example.com",
+          lastResult: {
+            url: "https://example.com",
+            capturedAt: "2026-05-04T20:00:00Z",
+            metrics: { lcp: 5000, cls: 0.05, inp: 250 },
+          },
+        },
+      }
+    );
+    expect(r.mode).toBe("cwv-result");
+    expect(r.url).toBe("https://example.com");
+    expect(r.cwv.pass).toBe(false); // LCP 5000 > 4000 (poor)
+    expect(r.cwv.blocking).toHaveLength(1);
+    expect(r.cwv.blocking[0].metric).toBe("lcp");
+    expect(r.cwv.advisory).toHaveLength(1); // INP 250 between good=200 and poor=500
+    expect(r.cwv.advisory[0].metric).toBe("inp");
+  });
+
+  it("uses custom thresholds from lastResult when supplied", () => {
+    const r = collectWebPerfInput(null, {
+      webperf: {
+        lastResult: {
+          metrics: { lcp: 1500 },
+          thresholds: { lcp: { good: 1000, poor: 2000 } },
+        },
+      },
+    });
+    expect(r.cwv.scores.lcp.rating).toBe("needs-improvement");
+  });
+
+  it("CWV-result mode beats stack heuristics (works even on backend-only)", () => {
+    // Edge case: a backend-only project that somehow has a previous CWV
+    // result attached. Surfacing the result is more useful than dropping it.
+    const r = collectWebPerfInput(
+      { isFrontend: false, isBackend: true, isFullstack: false },
+      { webperf: { lastResult: { metrics: { lcp: 1000 } } } }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("cwv-result");
+  });
+});
+
+describe("formatCwvVerdict", () => {
+  it("returns null when input is not in cwv-result mode", () => {
+    expect(formatCwvVerdict(null)).toBeNull();
+    expect(formatCwvVerdict({ mode: "static-hints" })).toBeNull();
+  });
+
+  it("renders verdict + scores + blocking + advisory", () => {
+    const text = formatCwvVerdict({
+      mode: "cwv-result",
+      url: "https://example.com",
+      capturedAt: "2026-05-04T20:00:00Z",
+      cwv: {
+        pass: false,
+        scores: { lcp: { value: 5000, rating: "poor" }, cls: { value: 0.05, rating: "good" } },
+        blocking: [{ metric: "lcp", value: 5000, threshold: 4000, rating: "poor" }],
+        advisory: [],
+      },
+    });
+    expect(text).toContain("Target URL: https://example.com");
+    expect(text).toContain("Verdict: FAIL");
+    expect(text).toContain("LCP: 5000 (poor)");
+    expect(text).toContain("CLS: 0.05 (good)");
+    expect(text).toContain("LCP 5000 > 4000");
+  });
+});
+
+describe("buildAuditPrompt — WebPerf section integration", () => {
+  it("omits the section when webperf is null or unavailable", () => {
+    const a = buildAuditPrompt({ task: "audit", webperf: null });
+    const b = buildAuditPrompt({ task: "audit", webperf: { available: false, reason: "backend-only" } });
+    expect(a).not.toContain("## WebPerf");
+    expect(b).not.toContain("## WebPerf");
+  });
+
+  it("renders static frontend-perf hints for a frontend project without live measurement", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      webperf: { available: true, mode: "static-hints" },
+    });
+    expect(prompt).toContain("## WebPerf — Frontend Performance");
+    expect(prompt).toContain("No live CWV measurement was provided");
+    expect(prompt).toContain("Render-blocking");
+    expect(prompt).toContain("`<img>` without `loading=\"lazy\"`");
+    expect(prompt).toContain("`font-display: swap`");
+  });
+
+  it("renders the CWV verdict block when a measurement is provided", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      webperf: {
+        available: true,
+        mode: "cwv-result",
+        url: "https://example.com",
+        cwv: {
+          pass: false,
+          scores: { lcp: { value: 5000, rating: "poor" } },
+          blocking: [{ metric: "lcp", value: 5000, threshold: 4000, rating: "poor" }],
+          advisory: [],
+        },
+      },
+    });
+    expect(prompt).toContain("Live Core Web Vitals measurement available");
+    expect(prompt).toContain("Verdict: FAIL");
+    expect(prompt).toContain("LCP: 5000 (poor)");
+  });
+});


### PR DESCRIPTION
## Summary

KJC-TSK-0360 — Pre-patch the performance dimension was backend-flavoured. Frontend projects got no signal about bundle size, render-blocking resources, image optimisation, lazy loading, web fonts.

> Replaces #591 (closed) — rebased onto current main after #588 (sonar) merged.

## Two execution modes

### `static-hints` (default for frontend / fullstack / unknown stack)
New `## WebPerf — Frontend Performance` section listing 10 source-readable patterns: render-blocking head scripts, eager imports of heavy modules, non-modern image formats, missing img width/height (CLS), missing loading="lazy", web fonts without font-display: swap, whole-library imports, missing critical CSS, third-party scripts without facade pattern, unbounded list rendering. Findings fold into the existing `performance` dimension.

### `cwv-result` (when `config.webperf.lastResult` is present)
Renders a Core Web Vitals verdict via `formatCwvVerdict` — verdict (PASS/FAIL), per-metric scores with ratings, blocking metrics above poor, advisory metrics between good and poor. Reuses `evaluateCwv` from `src/webperf/cwv-gate.js`.

## What's NOT wired
**Live CWV measurement** is intentionally out of scope. Audit's LLM sub-agent is forbidden from MCP tool use; spawning Chrome / launching a preview server during a read-only audit is wrong layer. A future `kj webperf` command can write a result into `config.webperf.lastResult` and this collector will surface it.

## Stacked on
This branch builds on #592 (--report-file) and #593 (a11y). Merge order: #592 → #593 → this.

## Test plan
- [x] `npx vitest run tests/audit/webperf-input.test.js` — 12/12 passing
- [x] Full suite previously verified at 4257/4257 on v1