### PR TITLE
feat(audit): two-phase mode — deterministic first, ask before LLM (KJC-TSK-0364)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -1,0 +1,143 @@
+/**
+ * Deterministic-only summary formatter for `kj audit` two-phase mode
+ * (KJC-TSK-0364). Renders the data AuditRole.collectDeterministic()
+ * gathers — basalCost, growth delta, stack, Sonar findings, WebPerf —
+ * as a self-contained markdown block the user can read BEFORE deciding
+ * whether to spend tokens on the LLM analysis.
+ *
+ * Kept in src/audit/ (not src/commands/) so the same formatter can be
+ * reused by future MCP tools and other entrypoints.
+ */
+
+import { groupIssuesBySeverity } from "./sonar-findings.js";
+
+const MAX_SAMPLE_DEAD_EXPORTS = 10;
+const MAX_SAMPLE_SONAR_PER_SEVERITY = 5;
+
+/**
+ * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object}} ctx
+ * @returns {string} markdown block
+ */
+export function formatDeterministicSummary(ctx) {
+  const lines = ["## Deterministic Findings", ""];
+  lines.push("These are the rule-based findings (no LLM). They cost zero tokens and are always factually accurate. The interactive prompt below asks if you want to extend this with an LLM analysis (which will cost tokens).");
+  lines.push("");
+
+  if (ctx.stack) lines.push(...formatStackBlock(ctx.stack));
+  if (ctx.basalCost) lines.push(...formatBasalCostBlock(ctx.basalCost, ctx.growthDelta));
+  if (ctx.sonarFindings) lines.push(...formatSonarBlock(ctx.sonarFindings));
+  if (ctx.webperf) lines.push(...formatWebperfBlock(ctx.webperf));
+
+  return lines.join("\n");
+}
+
+function formatStackBlock(stack) {
+  if (!stack || (!stack.frameworks?.length && !stack.language && !stack.isFrontend && !stack.isBackend)) return [];
+  const lines = ["### Project Stack"];
+  if (stack.language) lines.push(`- Language: ${stack.language}`);
+  if (stack.frameworks?.length) lines.push(`- Frameworks: ${stack.frameworks.join(", ")}`);
+  const tier = stack.isFullstack ? "fullstack (frontend + backend)"
+    : stack.isFrontend ? "frontend-only"
+    : stack.isBackend ? "backend-only"
+    : "unknown";
+  lines.push(`- Tier: ${tier}`);
+  lines.push("");
+  return lines;
+}
+
+function formatBasalCostBlock(basalCost, growthDelta) {
+  const lines = ["### Basal Cost"];
+  lines.push(`- Source: ${basalCost.totalLines} lines across ${basalCost.totalFiles} files`);
+  const deps = basalCost.dependencies || {};
+  if (deps.total) lines.push(`- Dependencies: ${deps.total} (${deps.dependencies} prod + ${deps.devDependencies} dev)`);
+
+  const unused = basalCost.unusedDependencies?.unused;
+  if (Array.isArray(unused) && unused.length > 0) {
+    lines.push(`- Unused dependencies (${unused.length}): ${unused.join(", ")}`);
+  }
+
+  const dead = Array.isArray(basalCost.deadExports) ? basalCost.deadExports : [];
+  if (dead.length > 0) {
+    lines.push(`- Dead exports: ${dead.length}`);
+    for (const de of dead.slice(0, MAX_SAMPLE_DEAD_EXPORTS)) {
+      lines.push(`  - \`${de.name}\` in ${de.file}`);
+    }
+    if (dead.length > MAX_SAMPLE_DEAD_EXPORTS) {
+      lines.push(`  - ... and ${dead.length - MAX_SAMPLE_DEAD_EXPORTS} more`);
+    }
+  } else {
+    lines.push("- Dead exports: 0");
+  }
+
+  if (growthDelta) {
+    lines.push("");
+    lines.push("**Growth since last audit**");
+    lines.push(`- Lines: ${growthDelta.lines >= 0 ? "+" : ""}${growthDelta.lines}`);
+    lines.push(`- Files: ${growthDelta.files >= 0 ? "+" : ""}${growthDelta.files}`);
+    lines.push(`- Dependencies: ${growthDelta.deps >= 0 ? "+" : ""}${growthDelta.deps}`);
+    if (growthDelta.since) lines.push(`- Since: ${growthDelta.since}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatSonarBlock(sonarFindings) {
+  if (!sonarFindings.available) {
+    return ["### SonarQube", `- Status: not available — ${sonarFindings.reason || "host unreachable"}`, ""];
+  }
+  const lines = ["### SonarQube"];
+  if (sonarFindings.qualityGate?.status) lines.push(`- Quality gate: ${sonarFindings.qualityGate.status}`);
+  lines.push(`- Open issues: ${sonarFindings.total ?? 0}`);
+  if ((sonarFindings.total ?? 0) > 0) {
+    const groups = groupIssuesBySeverity(sonarFindings.issues || []);
+    for (const [severity, issues] of Object.entries(groups)) {
+      if (issues.length === 0) continue;
+      lines.push(`  - ${severity} (${issues.length}):`);
+      for (const issue of issues.slice(0, MAX_SAMPLE_SONAR_PER_SEVERITY)) {
+        const loc = issue.component ? `${issue.component}${issue.line ? `:${issue.line}` : ""}` : "";
+        const rule = issue.rule ? ` [${issue.rule}]` : "";
+        lines.push(`    - ${loc}${rule} ${issue.message || ""}`.trim());
+      }
+      if (issues.length > MAX_SAMPLE_SONAR_PER_SEVERITY) {
+        lines.push(`    - ... and ${issues.length - MAX_SAMPLE_SONAR_PER_SEVERITY} more in ${severity}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatWebperfBlock(webperf) {
+  if (!webperf.available) {
+    return ["### WebPerf", `- Status: not collected — ${webperf.reason || "no frontend signal"}`, ""];
+  }
+  const lines = ["### WebPerf"];
+  if (webperf.mode === "cwv-result" && webperf.cwv) {
+    lines.push(`- Mode: live CWV measurement`);
+    if (webperf.url) lines.push(`- URL: ${webperf.url}`);
+    lines.push(`- Verdict: ${webperf.cwv.pass ? "PASS" : "FAIL"}`);
+    for (const [metric, score] of Object.entries(webperf.cwv.scores || {})) {
+      lines.push(`  - ${metric.toUpperCase()}: ${score.value} (${score.rating})`);
+    }
+  } else {
+    lines.push(`- Mode: static hints only (no live CWV measurement available)`);
+    lines.push(`- LLM phase will scan source for bundle/lazy/img-opt patterns when activated`);
+  }
+  lines.push("");
+  return lines;
+}
+
+/**
+ * Detect whether the deterministic context found any signal worth showing.
+ * If everything came back empty/unavailable, the CLI can skip the
+ * "Continue with LLM?" prompt — there's nothing to compare against.
+ */
+export function deterministicContextHasFindings(ctx) {
+  if (!ctx) return false;
+  if (ctx.basalCost?.deadExports?.length > 0) return true;
+  if (ctx.basalCost?.unusedDependencies?.unused?.length > 0) return true;
+  if (ctx.sonarFindings?.available && (ctx.sonarFindings.total ?? 0) > 0) return true;
+  if (ctx.sonarFindings?.qualityGate?.status === "ERROR") return true;
+  if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;
+  return false;
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -96,6 +96,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
+    .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
+    .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "audit", flags, async ({ config, logger }) => {
         let resolvedTask = task;
@@ -113,6 +115,8 @@ export function registerMeta(program, { pkgVersion }) {
           path: flags.path,
           noSonar: flags.sonar === false,
           reportFile: flags.reportFile || null,
+          deterministicOnly: Boolean(flags.deterministicOnly),
+          yes: Boolean(flags.yes),
         });
       });
     });

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import fs from "node:fs/promises";
+import readline from "node:readline";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { assertAgentsAvailable } from "../agents/availability.js";
@@ -9,8 +10,27 @@ import { AuditRole } from "../roles/audit-role.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
+import { formatDeterministicSummary } from "../audit/deterministic-summary.js";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Prompt the user (TTY only) to decide whether to continue with the LLM
+ * phase after deterministic findings have been printed. KJC-TSK-0364.
+ *
+ * @returns {Promise<boolean>} true to continue with LLM, false to skip
+ */
+function promptContinueWithLlm({ promptFn = null } = {}) {
+  if (typeof promptFn === "function") return promptFn();
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) { resolve(true); return; } // CI / piped input → continue
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question("Continue with LLM analysis? [y/N] ", (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test((answer || "").trim()));
+    });
+  });
+}
 
 function formatFindings(findings) {
   const lines = [];
@@ -171,16 +191,18 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
-function describeInvocation({ task, dimensions, noSonar, json }) {
+function describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
   if (noSonar) parts.push("--no-sonar");
+  if (deterministicOnly) parts.push("--deterministic-only");
+  if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -202,25 +224,63 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     const auditRoleConfig = resolveRole(config, "audit");
     await assertAgentsAvailable([auditRoleConfig.provider]);
     logger.info(`Audit (${auditRoleConfig.provider}) starting...`);
-    runLog.logText(`[audit] provider=${auditRoleConfig.provider} dimensions=${dimensions || "all"}`);
+    runLog.logText(`[audit] provider=${auditRoleConfig.provider} dimensions=${dimensions || "all"} deterministicOnly=${deterministicOnly}`);
 
-    // Path to audit output goes through AuditRole — same code path as MCP
-    // (kj_audit) and the orchestrator pipeline. Pre-KJC-TSK-0357 this CLI
-    // re-implemented createAgent + buildAuditPrompt + parseAuditOutput
-    // inline, which silently dropped the deterministic basalCost /
-    // growthDelta inputs that AuditRole.execute() collects. The result was
-    // a CLI prompt that didn't tell the LLM about deadExports, unused
-    // dependencies, or growth since the last audit.
+    // Two-phase audit (KJC-TSK-0364) — collect deterministic findings
+    // first; show them; ask the user (when TTY + not --yes + not
+    // --deterministic-only) whether to spend tokens on the LLM analysis.
+    // CI / piped input / --yes / --deterministic-only never prompts.
     const role = new AuditRole({ config, logger });
+    const roleInput = {
+      task: task || "Analyze the full codebase",
+      dimensions: dimensions || null,
+      noSonar,
+    };
+    const deterministicCtx = await role.collectDeterministic(roleInput);
+    const deterministicMd = formatDeterministicSummary(deterministicCtx);
+
+    // --json suppresses the interactive flow regardless: it would mangle
+    // a script's stdout. JSON consumers always get the full audit unless
+    // they explicitly pass deterministicOnly.
+    const reportPath = await resolveReportFilePath(reportFile, json);
+    let runLlm = !deterministicOnly;
+    if (runLlm && !json && !yes) {
+      console.log(deterministicMd);
+      console.log("");
+      const ok = await promptContinueWithLlm({ promptFn });
+      runLlm = ok;
+      if (!ok) logger.info("LLM analysis skipped (deterministic-only mode).");
+    }
+
+    if (!runLlm) {
+      // Deterministic-only path. Produce the report from what we already
+      // have, persist it (md or json), and exit. Zero tokens spent.
+      const stdoutContent = json
+        ? JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2)
+        : (deterministicOnly ? deterministicMd : ""); // already printed above when interactive
+      if (json || deterministicOnly) console.log(stdoutContent);
+
+      if (reportPath) {
+        let payload;
+        if (reportPath.endsWith(".json")) {
+          payload = JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2);
+        } else {
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
+          payload = header + deterministicMd + "\n";
+        }
+        await fs.writeFile(reportPath, payload, "utf8");
+        runLog.logText(`[audit] report written (deterministic-only) → ${reportPath}`);
+        logger.info(`Audit report written: ${reportPath}`);
+      }
+      logger.info("Audit completed (deterministic-only).");
+      return { ok: true, mode: "deterministic-only", reportPath: reportPath || undefined };
+    }
+
+    // Continue with the LLM phase using the already-collected context.
     const progress = createCliProgressReporter({ role: "auditor" });
     let roleResult;
     try {
-      roleResult = await role.execute({
-        task: task || "Analyze the full codebase",
-        dimensions: dimensions || null,
-        onOutput: progress.onOutput,
-        noSonar,
-      });
+      roleResult = await role.executeWithDeterministic({ ...roleInput, onOutput: progress.onOutput }, deterministicCtx);
       progress.finish(roleResult.ok ? "done" : "failed");
     } catch (err) { progress.finish("failed"); throw err; }
 
@@ -238,16 +298,8 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       runLog.logText(`[audit] usage tokens=${usage.total_tokens} cost=$${(usage.cost_usd ?? 0).toFixed(4)} duration=${(usage.durationMs / 1000).toFixed(1)}s`);
     }
 
-    // Resolve write target BEFORE printing — if the user pointed at a
-    // path that can't be created we want to fail fast, not after the LLM
-    // has already printed everything to stdout.
-    const reportPath = await resolveReportFilePath(reportFile, json);
-
     let stdoutContent;
     if (json) {
-      // Surface usage on the JSON output so CI scripts can budget against it
-      // (KJC-TSK-0363). Falls into a top-level `usage` key so consumers
-      // don't have to dig into role-shape internals.
       const jsonPayload = parsed
         ? { ...parsed, usage: usage || undefined }
         : { ...roleResult, usage: usage || undefined };
@@ -264,15 +316,12 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     if (reportPath) {
       let payload;
       if (reportPath.endsWith(".json")) {
-        // Mirror the stdout JSON shape exactly — a top-level `usage` key
-        // alongside the parsed audit result. Same payload no matter whether
-        // the user used --json on stdout or got it via --report-file alone.
         const jsonPayload = parsed
           ? { ...parsed, usage: usage || undefined }
           : { ...roleResult, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -29,48 +29,59 @@ export class AuditRole extends AgentRole {
     super({ ...opts, name: "audit" });
   }
 
-  async execute(input) {
-    const task = typeof input === "string" ? input : input?.task || this.context?.task || "";
-    const onOutput = typeof input === "string" ? null : input?.onOutput || null;
-    const rawDimensions = typeof input === "object" ? input?.dimensions || null : null;
-    const context = typeof input === "object" ? input?.context || null : null;
+  /**
+   * Run the deterministic side of an audit — basalCost, stack detection,
+   * Sonar issues, WebPerf input — without invoking the LLM. Cheap (no
+   * tokens, no API call). KJC-TSK-0364 splits the original execute() into
+   * this collector + executeWithDeterministic() so the CLI can show
+   * deterministic findings first and ask the user before paying for the
+   * LLM phase.
+   *
+   * @param {object|string} input - same shape execute() accepts
+   * @returns {Promise<object>} deterministic context (the same data
+   *   execute() would gather internally)
+   */
+  async collectDeterministic(input) {
     const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
-    const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
-
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
     let stack = null;
     let sonarFindings = null;
+    let webperf = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
       growthDelta = computeGrowthDelta(basalCost, previous);
     } catch { /* basal cost is best-effort */ }
-    // Stack detection — KJC-TSK-0358. Best-effort: a project without
-    // package.json or recognisable language markers gets stack=null and the
-    // prompt falls back to the agnostic dimension list.
     try {
       stack = await detectProjectStack(projectDir);
     } catch { /* stack detect is best-effort */ }
-    // Sonar findings — KJC-TSK-0361. Always best-effort + opt-out via
-    // noSonar (CLI --no-sonar). When sonar is reachable we read the open
-    // issues + quality gate to give the LLM deterministic findings with
-    // rule IDs and line numbers; the section is omitted when sonar is
-    // down or disabled.
     if (!noSonar) {
       try {
         sonarFindings = await collectSonarFindings(this.config, this.logger);
       } catch { /* sonar fetch is best-effort */ }
     }
-    // WebPerf input — KJC-TSK-0360. Pure: static-hints for frontend
-    // projects, optional CWV verdict when config carries a previous
-    // measurement. No network/spawn from the audit; live CWV collection
-    // is the future `kj webperf` command's job.
-    let webperf = null;
     try {
       webperf = collectWebPerfInput(stack, this.config);
     } catch { /* webperf input is best-effort */ }
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf };
+  }
+
+  /**
+   * Run the LLM phase of an audit using a pre-collected deterministic
+   * context. KJC-TSK-0364: separated from execute() so the CLI can run
+   * collectDeterministic() first, show findings, prompt, and only then
+   * call this if the user wants to spend tokens.
+   */
+  async executeWithDeterministic(input, deterministicCtx) {
+    const task = typeof input === "string" ? input : input?.task || this.context?.task || "";
+    const onOutput = typeof input === "string" ? null : input?.onOutput || null;
+    const rawDimensions = typeof input === "object" ? input?.dimensions || null : null;
+    const context = typeof input === "object" ? input?.context || null : null;
+    const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
+
+    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf } = deterministicCtx;
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
@@ -81,13 +92,6 @@ export class AuditRole extends AgentRole {
     const result = await agent.runTask(runArgs);
     const durationMs = Date.now() - startedAt;
 
-    // KJC-TSK-0363 — extract usage fields the agent SPREADS at the
-    // top level of its result (tokens_in, tokens_out, cost_usd, model)
-    // and consolidate them under a single `usage` object. Pre-patch we
-    // forwarded `result.usage` which was always undefined because no
-    // agent uses that key. Providers without usage telemetry (gemini,
-    // aider, opencode) get an `available:false` marker so the consumer
-    // can render "usage data not available" instead of zeros.
     const usage = extractUsage(result, { provider, durationMs });
 
     if (!result.ok) {
@@ -119,6 +123,15 @@ export class AuditRole extends AgentRole {
     } catch {
       return { ok: true, result: { raw: result.output, provider }, summary: "Audit complete (unstructured output)", usage };
     }
+  }
+
+  /**
+   * Convenience: run both phases in one call. Identical to the previous
+   * (single-phase) execute() so MCP and pipeline callers don't change.
+   */
+  async execute(input) {
+    const deterministicCtx = await this.collectDeterministic(input);
+    return this.executeWithDeterministic(input, deterministicCtx);
   }
 }
 

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -5,14 +5,21 @@ import os from "node:os";
 
 // Reuse the same AuditRole mocking strategy as tests/command-audit.test.js
 // so this file can drive auditCommand through the report-file branch
-// without spinning up an LLM.
+// without spinning up an LLM. Post KJC-TSK-0364 the role exposes both
+// the legacy execute() AND the two-phase split (collectDeterministic +
+// executeWithDeterministic). All three are mocked.
 const executeMock = vi.fn();
-class MockAuditRole {
-  constructor(opts) { this.opts = opts; }
-  async execute(input) { return executeMock(input); }
-}
+const collectMock = vi.fn();
+const executeWithDetMock = vi.fn();
 
-vi.mock("../../src/roles/audit-role.js", () => ({ AuditRole: MockAuditRole }));
+vi.mock("../../src/roles/audit-role.js", () => ({
+  AuditRole: class {
+    constructor(opts) { this.opts = opts; }
+    async execute(input) { return executeMock(input); }
+    async collectDeterministic(input) { return collectMock(input); }
+    async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
+  },
+}));
 vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
 vi.mock("../../src/config.js", () => ({
   resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
@@ -53,6 +60,8 @@ let consoleSpy;
 beforeEach(async () => {
   vi.resetAllMocks();
   executeMock.mockResolvedValue(successResult);
+  collectMock.mockResolvedValue({ projectDir: "/tmp", basalCost: null, growthDelta: null, stack: null, sonarFindings: null, webperf: null });
+  executeWithDetMock.mockResolvedValue(successResult);
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-report-"));
   consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   delete process.env.KJ_AUDIT_REPORT_DIR;

--- a/tests/audit/two-phase.test.js
+++ b/tests/audit/two-phase.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { formatDeterministicSummary, deterministicContextHasFindings } from "../../src/audit/deterministic-summary.js";
+
+// Two-phase audit (deterministic first, ask before LLM) — KJC-TSK-0364.
+
+const collectMock = vi.fn();
+const executeWithDetMock = vi.fn();
+
+vi.mock("../../src/roles/audit-role.js", () => ({
+  AuditRole: class {
+    constructor(opts) { this.opts = opts; }
+    async collectDeterministic(input) { return collectMock(input); }
+    async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
+    async execute(input) { const ctx = await this.collectDeterministic(input); return this.executeWithDeterministic(input, ctx); }
+  },
+}));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
+}));
+vi.mock("../../src/utils/cli-progress.js", () => ({
+  createCliProgressReporter: vi.fn(() => ({ onOutput: vi.fn(), finish: vi.fn() })),
+}));
+vi.mock("../../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
+  }),
+}));
+
+const sampleDeterministicCtx = {
+  projectDir: "/tmp/x",
+  basalCost: { totalLines: 5000, totalFiles: 80, dependencies: { total: 12, dependencies: 5, devDependencies: 7 }, deadExports: [{ name: "unused", file: "src/dead.js" }], unusedDependencies: { unused: ["lodash"] } },
+  growthDelta: { lines: 200, files: 5, deps: 1, since: "2026-04-01" },
+  stack: { language: "javascript", frameworks: ["astro"], isFrontend: true, isBackend: false, isFullstack: false },
+  sonarFindings: { available: true, total: 1, issues: [{ rule: "squid:S1234", severity: "MAJOR", component: "src/foo.js", line: 1, message: "complexity" }], qualityGate: { status: "OK" } },
+  webperf: { available: true, mode: "static-hints" },
+};
+
+const successResult = {
+  ok: true,
+  result: {
+    summary: { overallHealth: "fair", totalFindings: 1, critical: 0, high: 1, medium: 0, low: 0 },
+    dimensions: { security: { score: "B", findings: [] }, codeQuality: { score: "B", findings: [] }, performance: { score: "A", findings: [] }, architecture: { score: "B", findings: [] }, testing: { score: "B", findings: [] }, accessibility: { score: "C", findings: [] } },
+    topRecommendations: [],
+    provider: "claude",
+  },
+  summary: "Overall health: fair. 1 findings (1 high)",
+  usage: { available: true, provider: "claude", model: "claude-sonnet-4-6", tokens_in: 1000, tokens_out: 200, total_tokens: 1200, cost_usd: 0.005, durationMs: 4500 },
+};
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+let tmpDir;
+let consoleSpy;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  collectMock.mockResolvedValue(sampleDeterministicCtx);
+  executeWithDetMock.mockResolvedValue(successResult);
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-2phase-"));
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  consoleSpy.mockRestore();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function makeConfig() { return { roles: { audit: { provider: "claude" } }, projectDir: tmpDir }; }
+
+describe("formatDeterministicSummary (KJC-TSK-0364)", () => {
+  it("renders all sections when full context is available", () => {
+    const md = formatDeterministicSummary(sampleDeterministicCtx);
+    expect(md).toContain("## Deterministic Findings");
+    expect(md).toContain("### Project Stack");
+    expect(md).toContain("Frameworks: astro");
+    expect(md).toContain("### Basal Cost");
+    expect(md).toContain("Source: 5000 lines across 80 files");
+    expect(md).toContain("Dead exports: 1");
+    expect(md).toContain("`unused` in src/dead.js");
+    expect(md).toContain("Unused dependencies (1): lodash");
+    expect(md).toContain("### SonarQube");
+    expect(md).toContain("Open issues: 1");
+    expect(md).toContain("squid:S1234");
+    expect(md).toContain("### WebPerf");
+    expect(md).toContain("Mode: static hints only");
+  });
+
+  it("omits sections that have no data", () => {
+    const md = formatDeterministicSummary({});
+    expect(md).toContain("## Deterministic Findings");
+    expect(md).not.toContain("### Project Stack");
+    expect(md).not.toContain("### Basal Cost");
+    expect(md).not.toContain("### SonarQube");
+    expect(md).not.toContain("### WebPerf");
+  });
+
+  it("renders sonar 'not available' line gracefully when host is down", () => {
+    const md = formatDeterministicSummary({ sonarFindings: { available: false, reason: "host unreachable" } });
+    expect(md).toContain("Status: not available — host unreachable");
+  });
+});
+
+describe("deterministicContextHasFindings", () => {
+  it("returns true when there are dead exports", () => {
+    expect(deterministicContextHasFindings(sampleDeterministicCtx)).toBe(true);
+  });
+
+  it("returns false when nothing notable was found", () => {
+    expect(deterministicContextHasFindings({
+      basalCost: { deadExports: [], unusedDependencies: { unused: [] } },
+      sonarFindings: { available: true, total: 0, qualityGate: { status: "OK" } },
+    })).toBe(false);
+  });
+});
+
+describe("auditCommand two-phase flow (KJC-TSK-0364)", () => {
+  it("--deterministic-only skips the LLM phase entirely (no executeWithDeterministic call)", async () => {
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      deterministicOnly: true,
+    });
+
+    expect(executeWithDetMock).not.toHaveBeenCalled();
+    expect(collectMock).toHaveBeenCalledOnce();
+    expect(result.mode).toBe("deterministic-only");
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("## Deterministic Findings");
+    expect(stdout).not.toContain("Codebase Health Report"); // no LLM section
+  });
+
+  it("--yes auto-confirms and proceeds to LLM (no prompt shown)", async () => {
+    const promptFn = vi.fn().mockResolvedValue(false); // would say no, but --yes wins
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      yes: true, promptFn,
+    });
+
+    expect(promptFn).not.toHaveBeenCalled();
+    expect(executeWithDetMock).toHaveBeenCalledOnce();
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("Codebase Health Report");
+  });
+
+  it("interactive YES → runs LLM phase", async () => {
+    const promptFn = vi.fn().mockResolvedValue(true);
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      promptFn,
+    });
+
+    expect(promptFn).toHaveBeenCalledOnce();
+    expect(executeWithDetMock).toHaveBeenCalledOnce();
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("## Deterministic Findings"); // shown before prompt
+    expect(stdout).toContain("Codebase Health Report"); // LLM result
+  });
+
+  it("interactive NO → skips LLM and exits clean (deterministic-only mode)", async () => {
+    const promptFn = vi.fn().mockResolvedValue(false);
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    const result = await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      promptFn,
+    });
+
+    expect(promptFn).toHaveBeenCalledOnce();
+    expect(executeWithDetMock).not.toHaveBeenCalled();
+    expect(result.mode).toBe("deterministic-only");
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("## Deterministic Findings");
+    expect(stdout).not.toContain("Codebase Health Report");
+  });
+
+  it("--json never prompts (would mangle script output) and runs full audit", async () => {
+    const promptFn = vi.fn().mockResolvedValue(false);
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      json: true, promptFn,
+    });
+
+    expect(promptFn).not.toHaveBeenCalled();
+    expect(executeWithDetMock).toHaveBeenCalledOnce();
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    const parsed = JSON.parse(stdout);
+    expect(parsed.summary.overallHealth).toBe("fair");
+  });
+
+  it("--json + --deterministic-only emits a deterministic-only JSON payload", async () => {
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      json: true, deterministicOnly: true,
+    });
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    const parsed = JSON.parse(stdout);
+    expect(parsed.mode).toBe("deterministic-only");
+    expect(parsed.deterministic.basalCost.totalLines).toBe(5000);
+    expect(executeWithDetMock).not.toHaveBeenCalled();
+  });
+
+  it("deterministic-only writes to --report-file as markdown without LLM section", async () => {
+    const target = path.join(tmpDir, "audit.md");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      reportFile: target, deterministicOnly: true,
+    });
+
+    const written = await fs.readFile(target, "utf8");
+    expect(written).toContain("# Karajan Audit Report");
+    expect(written).toContain("--deterministic-only");
+    expect(written).toContain("## Deterministic Findings");
+    expect(written).not.toContain("Codebase Health Report");
+  });
+
+  it("deterministic-only writes to --report-file as json with mode marker", async () => {
+    const target = path.join(tmpDir, "audit.json");
+    const { auditCommand } = await import("../../src/commands/audit.js");
+    await auditCommand({
+      task: "audit", config: makeConfig(), logger: noopLogger,
+      reportFile: target, deterministicOnly: true, json: true,
+    });
+
+    const written = JSON.parse(await fs.readFile(target, "utf8"));
+    expect(written.mode).toBe("deterministic-only");
+    expect(written.deterministic.basalCost).toBeTruthy();
+  });
+});

--- a/tests/audit/usage-summary.test.js
+++ b/tests/audit/usage-summary.test.js
@@ -7,9 +7,16 @@ import os from "node:os";
 // the mocked modules. We import formatAudit/formatUsageSummary lazily
 // inside each describe/it that needs them.
 const executeMock = vi.fn();
+const collectMock = vi.fn();
+const executeWithDetMock = vi.fn();
 
 vi.mock("../../src/roles/audit-role.js", () => ({
-  AuditRole: class { constructor(opts) { this.opts = opts; } async execute(input) { return executeMock(input); } },
+  AuditRole: class {
+    constructor(opts) { this.opts = opts; }
+    async execute(input) { return executeMock(input); }
+    async collectDeterministic(input) { return collectMock(input); }
+    async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
+  },
 }));
 vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
 vi.mock("../../src/config.js", () => ({
@@ -157,6 +164,8 @@ describe("auditCommand integration — usage flows through CLI/JSON/report-file"
   beforeEach(async () => {
     vi.resetAllMocks();
     executeMock.mockResolvedValue(successResult);
+    collectMock.mockResolvedValue({ projectDir: "/tmp", basalCost: null, growthDelta: null, stack: null, sonarFindings: null, webperf: null });
+    executeWithDetMock.mockResolvedValue(successResult);
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-usage-"));
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   });

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -1,16 +1,21 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-// AuditRole.execute() is what auditCommand now drives (post KJC-TSK-0357).
-// Mocking the role surface keeps the CLI test focused on argument flow and
+// AuditRole.collectDeterministic() + executeWithDeterministic() drive
+// auditCommand post KJC-TSK-0364 (two-phase). The legacy execute()
+// convenience is kept for back-compat with MCP/pipeline callers.
+// Mocking all three keeps the CLI test focused on argument flow and
 // output formatting; AuditRole's own contract has its own test suite.
 const executeMock = vi.fn();
-class MockAuditRole {
-  constructor(opts) { this.opts = opts; }
-  async execute(input) { return executeMock(input); }
-}
+const collectMock = vi.fn();
+const executeWithDetMock = vi.fn();
 
 vi.mock("../src/roles/audit-role.js", () => ({
-  AuditRole: MockAuditRole,
+  AuditRole: class {
+    constructor(opts) { this.opts = opts; }
+    async execute(input) { return executeMock(input); }
+    async collectDeterministic(input) { return collectMock(input); }
+    async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
+  },
 }));
 
 vi.mock("../src/agents/availability.js", () => ({
@@ -72,6 +77,8 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
   beforeEach(async () => {
     vi.resetAllMocks();
     executeMock.mockResolvedValue(successResult);
+    collectMock.mockResolvedValue({ projectDir: "/tmp", basalCost: null, growthDelta: null, stack: null, sonarFindings: null, webperf: null });
+    executeWithDetMock.mockResolvedValue(successResult);
 
     const avail = await import("../src/agents/availability.js");
     assertAgentsAvailable = avail.assertAgentsAvailable;
@@ -84,21 +91,23 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
     expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
   });
 
-  it("invokes AuditRole.execute with the task verbatim", async () => {
+  it("invokes AuditRole.executeWithDeterministic with the task verbatim", async () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
 
-    expect(executeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ task: "audit codebase" })
+    expect(executeWithDetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ task: "audit codebase" }),
+      expect.any(Object)
     );
   });
 
-  it("forwards --dimensions to AuditRole.execute (parseDimensions runs inside the role)", async () => {
+  it("forwards --dimensions to AuditRole (parseDimensions runs inside the role)", async () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger, dimensions: "security,testing" });
 
-    expect(executeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ dimensions: "security,testing" })
+    expect(executeWithDetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dimensions: "security,testing" }),
+      expect.any(Object)
     );
   });
 
@@ -106,13 +115,14 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({ config: makeConfig(), logger: noopLogger });
 
-    expect(executeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ task: "Analyze the full codebase" })
+    expect(executeWithDetMock).toHaveBeenCalledWith(
+      expect.objectContaining({ task: "Analyze the full codebase" }),
+      expect.any(Object)
     );
   });
 
   it("throws when AuditRole returns ok=false", async () => {
-    executeMock.mockResolvedValueOnce({
+    executeWithDetMock.mockResolvedValueOnce({
       ok: false,
       result: { error: "agent error", provider: "claude" },
       summary: "Audit failed: agent error",
@@ -145,7 +155,7 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
   });
 
   it("falls back to printing roleResult.summary when LLM output is unstructured", async () => {
-    executeMock.mockResolvedValueOnce({
+    executeWithDetMock.mockResolvedValueOnce({
       ok: true,
       result: { raw: "free-form text from the LLM", provider: "claude" },
       summary: "Audit complete (unstructured output)",
@@ -165,10 +175,12 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     executeMock.mockResolvedValue(successResult);
+    collectMock.mockResolvedValue({ projectDir: "/tmp", basalCost: null, growthDelta: null, stack: null, sonarFindings: null, webperf: null });
+    executeWithDetMock.mockResolvedValue(successResult);
   });
 
-  it("CLI auditCommand and MCP direct-handler both reach AuditRole.execute with the same input shape", async () => {
-    // CLI path: invoke auditCommand and capture what it passed to execute().
+  it("CLI auditCommand and MCP direct-handler both reach AuditRole with the same input shape", async () => {
+    // CLI path: invoke auditCommand and capture what it passed to executeWithDeterministic().
     const { auditCommand } = await import("../src/commands/audit.js");
     await auditCommand({
       task: "Analyze the full codebase",
@@ -176,11 +188,13 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
       logger: noopLogger,
       dimensions: "all",
     });
-    const cliArgs = executeMock.mock.calls[executeMock.mock.calls.length - 1][0];
+    const cliArgs = executeWithDetMock.mock.calls[executeWithDetMock.mock.calls.length - 1][0];
 
     // MCP path: instantiate AuditRole directly the same way direct-handlers
     // does (see src/mcp/handlers/direct-handlers.js — `new AuditRole(...)`)
-    // and invoke execute() with the same input shape.
+    // and invoke execute() with the same input shape. The MCP path uses the
+    // legacy execute() convenience which internally calls
+    // collectDeterministic() then executeWithDeterministic().
     executeMock.mockClear();
     const { AuditRole } = await import("../src/roles/audit-role.js");
     const mcpRole = new AuditRole({ config: makeConfig(), logger: noopLogger });


### PR DESCRIPTION
## Summary

KJC-TSK-0364 — Pre-patch every `kj audit` invocation always called the LLM, even when the user only wanted the deterministic facts (dead exports, sonar issues, growth delta). This patch separates the two phases and lets the user opt in to the LLM portion.

> Replaces #596 (closed) — rebased onto current main after #595 (token summary) merged.

## How it behaves

| TTY | Flag | Behaviour |
|---|---|---|
| Yes | (none) | Print deterministic findings → ask "Continue with LLM analysis? [y/N]" |
| Yes | `--deterministic-only` | Print deterministic only, no prompt, no tokens |
| Yes | `-y` / `--yes` | Auto-confirm, full audit |
| Yes | `--json` | Bypass prompt (would corrupt JSON), run full audit |
| No (CI) | (none) | Auto-confirm, full audit (zero behaviour change for CI) |

## Implementation
- `AuditRole` split into `collectDeterministic()` and `executeWithDeterministic()`. The legacy `execute()` chains both, so MCP/pipeline callers don't change.
- New formatter `src/audit/deterministic-summary.js` renders Project Stack, Basal Cost (with growth delta), Sonar findings, WebPerf input as a self-contained markdown block.
- New helper `deterministicContextHasFindings(ctx)` ready for future "auto-skip prompt when nothing was found" logic.
- CLI flags: `--deterministic-only` and `-y`/`--yes`.
- Output paths cover stdout (md/json), report-file (md/json), and the deterministic-only payload variant.

## Real-world example
Tested against karajan-code with `kj audit --deterministic-only`:
```
### Project Stack
- Language: javascript
- Tier: unknown

### Basal Cost
- Source: 118715 lines across 758 files
- Dependencies: 16 (5 prod + 11 dev)
- Unused dependencies (4): @changesets/cli, @vitest/coverage-v8, postject, simple-git-hooks
- Dead exports: 4
  - `BasicReporter` in tests/_diet/basic-reporter.js
  - ...

**Growth since last audit**
- Lines: +791
- Since: 2026-05-04T08:56:21.668Z
```
3 seconds, 0 tokens. No interactive prompt. Useful for daily codebase health checks.

## Test plan
- [x] `npx vitest run tests/audit/two-phase.test.js` — 13/13 passing
- [x] `npx vitest run tests/audit/ tests/command-audit.test.js` — 22/22 passing
- [x] Real-world: `kj audit --deterministic-only --report-file ./audits/det.md` works against karajan-code itself