### PR TITLE
feat(audit): integrate osv-scanner for deterministic vuln findings (KJC-TSK-0365)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -10,12 +10,14 @@
  */
 
 import { groupIssuesBySeverity } from "./sonar-findings.js";
+import { groupVulnerabilitiesBySeverity } from "./osv-findings.js";
 
 const MAX_SAMPLE_DEAD_EXPORTS = 10;
 const MAX_SAMPLE_SONAR_PER_SEVERITY = 5;
+const MAX_SAMPLE_OSV_PER_SEVERITY = 5;
 
 /**
- * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object}} ctx
+ * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object, osvFindings?: object}} ctx
  * @returns {string} markdown block
  */
 export function formatDeterministicSummary(ctx) {
@@ -26,9 +28,35 @@ export function formatDeterministicSummary(ctx) {
   if (ctx.stack) lines.push(...formatStackBlock(ctx.stack));
   if (ctx.basalCost) lines.push(...formatBasalCostBlock(ctx.basalCost, ctx.growthDelta));
   if (ctx.sonarFindings) lines.push(...formatSonarBlock(ctx.sonarFindings));
+  if (ctx.osvFindings) lines.push(...formatOsvBlock(ctx.osvFindings));
   if (ctx.webperf) lines.push(...formatWebperfBlock(ctx.webperf));
 
   return lines.join("\n");
+}
+
+function formatOsvBlock(osvFindings) {
+  if (!osvFindings.available) {
+    return ["### OSV Vulnerabilities", `- Status: not available — ${osvFindings.reason || "osv-scanner not installed"}`, ""];
+  }
+  const lines = ["### OSV Vulnerabilities (Dependencies)"];
+  lines.push(`- Total open: ${osvFindings.total ?? 0}`);
+  if ((osvFindings.total ?? 0) > 0) {
+    const groups = groupVulnerabilitiesBySeverity(osvFindings.vulnerabilities || []);
+    for (const [severity, vulns] of Object.entries(groups)) {
+      if (vulns.length === 0) continue;
+      lines.push(`  - ${severity} (${vulns.length}):`);
+      for (const v of vulns.slice(0, MAX_SAMPLE_OSV_PER_SEVERITY)) {
+        const where = v.package ? `${v.package}@${v.version || "?"}` : "(unknown)";
+        const fixed = v.fixed ? ` → fixed in ${v.fixed}` : "";
+        lines.push(`    - ${v.id} ${where}${fixed}`);
+      }
+      if (vulns.length > MAX_SAMPLE_OSV_PER_SEVERITY) {
+        lines.push(`    - ... and ${vulns.length - MAX_SAMPLE_OSV_PER_SEVERITY} more in ${severity}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines;
 }
 
 function formatStackBlock(stack) {
@@ -138,6 +166,7 @@ export function deterministicContextHasFindings(ctx) {
   if (ctx.basalCost?.unusedDependencies?.unused?.length > 0) return true;
   if (ctx.sonarFindings?.available && (ctx.sonarFindings.total ?? 0) > 0) return true;
   if (ctx.sonarFindings?.qualityGate?.status === "ERROR") return true;
+  if (ctx.osvFindings?.available && (ctx.osvFindings.total ?? 0) > 0) return true;
   if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;
   return false;
 }

--- a/src/audit/osv-findings.js
+++ b/src/audit/osv-findings.js
@@ -1,0 +1,162 @@
+/**
+ * OSV-Scanner findings collector for `kj audit` (KJC-TSK-0365).
+ *
+ * Wraps Google's `osv-scanner` CLI and feeds its results into the audit
+ * prompt as a deterministic vulnerability section. OSV.dev's database
+ * pulls from GitHub Advisory Database, GLSA, PyPI advisories, Go vuln
+ * DB and others — broader coverage than `npm audit` alone, with no
+ * account, token, or upload (the scanner runs locally and only the
+ * advisory data is fetched on demand).
+ *
+ * This module follows the same pattern as src/audit/sonar-findings.js:
+ *   - Best-effort: missing binary or scan errors return
+ *     {available: false, reason} and the audit continues without the
+ *     section.
+ *   - Severity-grouped: helps the LLM (and the deterministic summary)
+ *     prioritise the worst issues without scrolling.
+ *   - Capped: only the first MAX_OSV_VULNS_IN_PROMPT entries land in
+ *     the prompt, with overflow markers per severity, so an
+ *     out-of-control result list cannot blow the token budget.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SCAN_TIMEOUT_MS = 60_000;
+const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE"];
+
+/**
+ * Run osv-scanner on the project and return a structured result.
+ *
+ * @param {string} projectDir - absolute path to the project root
+ * @param {object} [logger]
+ * @returns {Promise<{available: boolean, reason?: string, total?: number, vulnerabilities?: object[]}>}
+ */
+export async function collectOsvFindings(projectDir, logger = null) {
+  let stdout;
+  try {
+    const { stdout: out } = await execFileAsync(
+      "osv-scanner",
+      ["--format=json", "--recursive", projectDir || "."],
+      { cwd: projectDir, timeout: SCAN_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 }
+    );
+    stdout = out;
+  } catch (err) {
+    // osv-scanner exits with non-zero when vulnerabilities are found, so
+    // err.code 1 is NORMAL — we still want the stdout. Real failures are
+    // ENOENT (binary missing) or stdout empty.
+    if (err.code === "ENOENT") {
+      if (logger?.warn) logger.warn("osv-scanner not found in PATH — install via 'go install github.com/google/osv-scanner@latest'");
+      return { available: false, reason: "osv-scanner not installed" };
+    }
+    if (err.killed) {
+      if (logger?.warn) logger.warn(`osv-scanner timed out after ${SCAN_TIMEOUT_MS}ms`);
+      return { available: false, reason: `osv-scanner timed out after ${SCAN_TIMEOUT_MS}ms` };
+    }
+    if (typeof err.stdout === "string" && err.stdout.trim().length > 0) {
+      stdout = err.stdout;
+    } else {
+      if (logger?.warn) logger.warn(`osv-scanner failed: ${err.message}`);
+      return { available: false, reason: `osv-scanner failed: ${err.message}` };
+    }
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`osv-scanner output not parseable: ${err.message}`);
+    return { available: false, reason: "osv-scanner output not parseable as JSON" };
+  }
+
+  return { available: true, ...parseOsvOutput(parsed) };
+}
+
+/**
+ * Flatten the osv-scanner JSON shape into a flat list of vulnerabilities.
+ * The scanner emits results[].packages[].vulnerabilities[].
+ *
+ * @param {object} raw - parsed osv-scanner JSON
+ * @returns {{total: number, vulnerabilities: object[]}}
+ */
+export function parseOsvOutput(raw) {
+  const flat = [];
+  const results = Array.isArray(raw?.results) ? raw.results : [];
+  for (const result of results) {
+    const source = result.source?.path || result.source || "";
+    const packages = Array.isArray(result.packages) ? result.packages : [];
+    for (const pkg of packages) {
+      const name = pkg.package?.name || "";
+      const version = pkg.package?.version || "";
+      const ecosystem = pkg.package?.ecosystem || "";
+      const vulns = Array.isArray(pkg.vulnerabilities) ? pkg.vulnerabilities : [];
+      const groups = Array.isArray(pkg.groups) ? pkg.groups : [];
+      for (const vuln of vulns) {
+        flat.push({
+          id: vuln.id || vuln.aliases?.[0] || "UNKNOWN",
+          aliases: vuln.aliases || [],
+          severity: extractSeverity(vuln, groups),
+          summary: vuln.summary || vuln.details?.split("\n")[0] || "",
+          package: name,
+          version,
+          ecosystem,
+          source,
+          fixed: extractFixedVersion(vuln),
+        });
+      }
+    }
+  }
+  return { total: flat.length, vulnerabilities: flat };
+}
+
+/**
+ * Resolve a vulnerability's effective severity. osv-scanner reports
+ * CVSS (per-vuln) and a separate `groups[].severity` (per scanner run).
+ * Group severity wins when present because it reflects scanner policy.
+ */
+function extractSeverity(vuln, groups) {
+  // Group-level severity (scanner-resolved, includes ecosystem context)
+  for (const group of groups) {
+    if (group.ids?.includes(vuln.id) && group.severity) {
+      return String(group.severity).toUpperCase();
+    }
+  }
+  // Per-vuln CVSS — pick the highest score
+  const severities = Array.isArray(vuln.severity) ? vuln.severity : [];
+  for (const sev of severities) {
+    if (sev?.severity) return String(sev.severity).toUpperCase();
+  }
+  // database_specific severity (GHSA-style)
+  if (vuln.database_specific?.severity) {
+    return String(vuln.database_specific.severity).toUpperCase();
+  }
+  return "UNKNOWN";
+}
+
+function extractFixedVersion(vuln) {
+  const ranges = vuln.affected?.[0]?.ranges || [];
+  for (const range of ranges) {
+    const events = range.events || [];
+    for (const event of events) {
+      if (event.fixed) return event.fixed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Group vulnerabilities by severity, preserving canonical ordering
+ * (CRITICAL → HIGH → MEDIUM/MODERATE → LOW → UNKNOWN).
+ */
+export function groupVulnerabilitiesBySeverity(vulnerabilities) {
+  const groups = Object.fromEntries(SEVERITY_ORDER.map(s => [s, []]));
+  groups.UNKNOWN = [];
+  for (const vuln of vulnerabilities || []) {
+    const sev = (vuln.severity || "UNKNOWN").toUpperCase();
+    if (groups[sev]) groups[sev].push(vuln);
+    else groups.UNKNOWN.push(vuln);
+  }
+  return groups;
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -95,6 +95,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
+    .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
     .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
@@ -114,6 +115,7 @@ export function registerMeta(program, { pkgVersion }) {
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
           noSonar: flags.sonar === false,
+          noOsv: flags.osv === false,
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -191,18 +191,19 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
-function describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }) {
+function describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
   if (noSonar) parts.push("--no-sonar");
+  if (noOsv) parts.push("--no-osv");
   if (deterministicOnly) parts.push("--deterministic-only");
   if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -235,6 +236,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       task: task || "Analyze the full codebase",
       dimensions: dimensions || null,
       noSonar,
+      noOsv,
     };
     const deterministicCtx = await role.collectDeterministic(roleInput);
     const deterministicMd = formatDeterministicSummary(deterministicCtx);
@@ -265,7 +267,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         if (reportPath.endsWith(".json")) {
           payload = JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2);
         } else {
-          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
           payload = header + deterministicMd + "\n";
         }
         await fs.writeFile(reportPath, payload, "utf8");
@@ -321,7 +323,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
           : { ...roleResult, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,8 +1,10 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
+import { groupVulnerabilitiesBySeverity } from "../audit/osv-findings.js";
 import { formatCwvVerdict } from "../audit/webperf-input.js";
 
 const MAX_SONAR_ISSUES_IN_PROMPT = 50;
+const MAX_OSV_VULNS_IN_PROMPT = 50;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -24,7 +26,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null, osvFindings = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -279,6 +281,36 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
       lines.push("- Large third-party scripts (analytics, A/B, chat widgets) without defer + facade pattern");
       lines.push("- Unbounded list rendering without virtualisation for very long collections");
     }
+    sections.push(lines.join("\n"));
+  }
+
+  // OSV vulnerabilities — KJC-TSK-0365. Deterministic CVE/GHSA findings
+  // from osv-scanner across the dependency manifest. Capped at
+  // MAX_OSV_VULNS_IN_PROMPT entries; the LLM is told the truncated count.
+  // Findings fold into the `security` dimension with the upstream
+  // identifier (CVE-/GHSA-) as the rule.
+  if (osvFindings?.available && (osvFindings.total > 0)) {
+    const lines = ["## OSV Vulnerabilities"];
+    lines.push(`- Total open vulnerabilities in dependencies: ${osvFindings.total}`);
+    const groups = groupVulnerabilitiesBySeverity(osvFindings.vulnerabilities);
+    let remaining = MAX_OSV_VULNS_IN_PROMPT;
+    for (const [severity, vulns] of Object.entries(groups)) {
+      if (vulns.length === 0) continue;
+      lines.push("");
+      lines.push(`### ${severity} (${vulns.length})`);
+      const slice = vulns.slice(0, Math.max(0, remaining));
+      for (const vuln of slice) {
+        const where = vuln.package ? `${vuln.package}@${vuln.version || "?"}` : "(unknown package)";
+        const fixed = vuln.fixed ? ` → fixed in ${vuln.fixed}` : "";
+        lines.push(`  - ${vuln.id} ${where}${fixed}: ${vuln.summary || ""}`.trim());
+      }
+      if (vulns.length > slice.length) {
+        lines.push(`  - ... and ${vulns.length - slice.length} more in ${severity}`);
+      }
+      remaining -= slice.length;
+    }
+    lines.push("");
+    lines.push("These CVE/GHSA findings are GROUND TRUTH — incorporate them into the `security` dimension. Use the OSV id (CVE-XXXX-XXXX or GHSA-xxxx-xxxx-xxxx) as the `rule` field. Recommend the fixed version when available.");
     sections.push(lines.join("\n"));
   }
 

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -4,6 +4,7 @@ import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDe
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { collectSonarFindings } from "../audit/sonar-findings.js";
 import { collectWebPerfInput } from "../audit/webperf-input.js";
+import { collectOsvFindings } from "../audit/osv-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -43,12 +44,14 @@ export class AuditRole extends AgentRole {
    */
   async collectDeterministic(input) {
     const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
+    const noOsv = typeof input === "object" ? Boolean(input?.noOsv) : false;
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
     let stack = null;
     let sonarFindings = null;
     let webperf = null;
+    let osvFindings = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -65,7 +68,15 @@ export class AuditRole extends AgentRole {
     try {
       webperf = collectWebPerfInput(stack, this.config);
     } catch { /* webperf input is best-effort */ }
-    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf };
+    // OSV vulnerabilities — KJC-TSK-0365. Best-effort: missing
+    // osv-scanner binary returns available:false and the audit
+    // continues without the section.
+    if (!noOsv) {
+      try {
+        osvFindings = await collectOsvFindings(projectDir, this.logger);
+      } catch { /* osv-scanner is best-effort */ }
+    }
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings };
   }
 
   /**
@@ -81,11 +92,11 @@ export class AuditRole extends AgentRole {
     const context = typeof input === "object" ? input?.context || null : null;
     const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
 
-    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf } = deterministicCtx;
+    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings } = deterministicCtx;
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const startedAt = Date.now();
@@ -115,6 +126,7 @@ export class AuditRole extends AgentRole {
           stack: stack || undefined,
           sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
           webperf: webperf?.available ? webperf : undefined,
+          osvFindings: osvFindings?.available ? osvFindings : undefined,
           provider
         },
         summary: buildSummary(parsed),

--- a/tests/audit/osv-findings.test.js
+++ b/tests/audit/osv-findings.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock execFile + promisify so we can drive collectOsvFindings under
+// controlled conditions. promisify(execFile) resolves to {stdout, stderr}
+// (Node's custom impl). We bypass that nuance by faking promisify too.
+const execFileMock = vi.fn();
+
+vi.mock("node:util", async () => {
+  const actual = await vi.importActual("node:util");
+  return {
+    ...actual,
+    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
+  };
+});
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+import { collectOsvFindings, parseOsvOutput, groupVulnerabilitiesBySeverity } from "../../src/audit/osv-findings.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+describe("collectOsvFindings (KJC-TSK-0365)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns available=false when osv-scanner is not installed (ENOENT)", async () => {
+    const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });
+    execFileMock.mockRejectedValue(enoErr);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not installed/);
+    expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringContaining("osv-scanner not found"));
+  });
+
+  it("returns available=false when scanner times out", async () => {
+    const timeoutErr = Object.assign(new Error("killed"), { killed: true });
+    execFileMock.mockRejectedValue(timeoutErr);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/timed out/);
+  });
+
+  it("returns available=false when scanner output is unparseable", async () => {
+    execFileMock.mockResolvedValue({ stdout: "not JSON {{{", stderr: "" });
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not parseable/);
+  });
+
+  it("parses a clean osv-scanner JSON result and groups vulnerabilities", async () => {
+    const sample = {
+      results: [{
+        source: { path: "package-lock.json" },
+        packages: [{
+          package: { name: "lodash", version: "4.17.20", ecosystem: "npm" },
+          vulnerabilities: [
+            { id: "GHSA-xxxx-xxxx-1111", aliases: ["CVE-2021-23337"], summary: "Command injection", database_specific: { severity: "HIGH" }, affected: [{ ranges: [{ events: [{ fixed: "4.17.21" }] }] }] },
+          ],
+          groups: [{ ids: ["GHSA-xxxx-xxxx-1111"], severity: "HIGH" }],
+        }],
+      }],
+    };
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(sample), stderr: "" });
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(1);
+    expect(r.vulnerabilities[0]).toMatchObject({
+      id: "GHSA-xxxx-xxxx-1111",
+      package: "lodash",
+      version: "4.17.20",
+      severity: "HIGH",
+      fixed: "4.17.21",
+    });
+  });
+
+  it("treats exit code 1 with valid JSON stdout as success (osv exits 1 when vulns are found)", async () => {
+    // osv-scanner exits 1 when it finds vulnerabilities — execFile rejects
+    // but stdout has the structured output. The collector should parse it.
+    const sample = { results: [{ packages: [{ package: { name: "x", version: "1" }, vulnerabilities: [{ id: "CVE-1" }] }] }] };
+    const err = Object.assign(new Error("exit 1"), { code: 1, stdout: JSON.stringify(sample), stderr: "" });
+    execFileMock.mockRejectedValue(err);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(1);
+  });
+});
+
+describe("parseOsvOutput", () => {
+  it("flattens nested results.packages.vulnerabilities", () => {
+    const raw = {
+      results: [
+        { packages: [
+          { package: { name: "a", version: "1.0" }, vulnerabilities: [{ id: "CVE-1" }, { id: "CVE-2" }] },
+          { package: { name: "b", version: "2.0" }, vulnerabilities: [{ id: "CVE-3" }] },
+        ] },
+      ],
+    };
+    const r = parseOsvOutput(raw);
+    expect(r.total).toBe(3);
+    expect(r.vulnerabilities.map(v => v.id)).toEqual(["CVE-1", "CVE-2", "CVE-3"]);
+  });
+
+  it("handles empty results gracefully", () => {
+    expect(parseOsvOutput({ results: [] })).toEqual({ total: 0, vulnerabilities: [] });
+    expect(parseOsvOutput({})).toEqual({ total: 0, vulnerabilities: [] });
+  });
+
+  it("prefers group severity over database_specific severity", () => {
+    const raw = {
+      results: [{
+        packages: [{
+          package: { name: "x" },
+          vulnerabilities: [{ id: "V1", database_specific: { severity: "MEDIUM" } }],
+          groups: [{ ids: ["V1"], severity: "CRITICAL" }],
+        }],
+      }],
+    };
+    const r = parseOsvOutput(raw);
+    expect(r.vulnerabilities[0].severity).toBe("CRITICAL");
+  });
+});
+
+describe("groupVulnerabilitiesBySeverity", () => {
+  it("groups in canonical order (CRITICAL → HIGH → MEDIUM → MODERATE → LOW → UNKNOWN)", () => {
+    const groups = groupVulnerabilitiesBySeverity([
+      { severity: "MEDIUM" }, { severity: "CRITICAL" }, { severity: "INVALID" }, { severity: "HIGH" },
+    ]);
+    expect(Object.keys(groups)).toEqual(["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE", "UNKNOWN"]);
+    expect(groups.CRITICAL).toHaveLength(1);
+    expect(groups.HIGH).toHaveLength(1);
+    expect(groups.MEDIUM).toHaveLength(1);
+    expect(groups.UNKNOWN).toHaveLength(1);
+  });
+});
+
+describe("buildAuditPrompt — OSV Vulnerabilities section", () => {
+  it("omits the section when osvFindings is null or empty", () => {
+    const a = buildAuditPrompt({ task: "audit", osvFindings: null });
+    const b = buildAuditPrompt({ task: "audit", osvFindings: { available: true, total: 0, vulnerabilities: [] } });
+    const c = buildAuditPrompt({ task: "audit", osvFindings: { available: false, reason: "not installed" } });
+    expect(a).not.toContain("## OSV Vulnerabilities");
+    expect(b).not.toContain("## OSV Vulnerabilities");
+    expect(c).not.toContain("## OSV Vulnerabilities");
+  });
+
+  it("renders findings grouped by severity with package + version + fixed version", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      osvFindings: {
+        available: true,
+        total: 2,
+        vulnerabilities: [
+          { id: "GHSA-aaaa", package: "lodash", version: "4.17.20", severity: "HIGH", summary: "command injection", fixed: "4.17.21" },
+          { id: "CVE-2024-9999", package: "axios", version: "0.21.0", severity: "CRITICAL", summary: "ssrf", fixed: "1.7.4" },
+        ],
+      },
+    });
+    expect(prompt).toContain("## OSV Vulnerabilities");
+    expect(prompt).toContain("Total open vulnerabilities in dependencies: 2");
+    expect(prompt).toContain("### CRITICAL (1)");
+    expect(prompt).toContain("### HIGH (1)");
+    expect(prompt).toContain("CVE-2024-9999");
+    expect(prompt).toContain("axios@0.21.0");
+    expect(prompt).toContain("→ fixed in 1.7.4");
+    expect(prompt).toContain("These CVE/GHSA findings are GROUND TRUTH");
+  });
+
+  it("caps the rendered list at MAX_OSV_VULNS_IN_PROMPT (50) with overflow per severity", () => {
+    const vulns = Array.from({ length: 75 }, (_, i) => ({
+      id: `CVE-2024-${i}`, package: `pkg${i}`, version: "1.0", severity: "HIGH", summary: "x",
+    }));
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      osvFindings: { available: true, total: 75, vulnerabilities: vulns },
+    });
+    expect(prompt).toContain("Total open vulnerabilities in dependencies: 75");
+    expect(prompt).toContain("and 25 more in HIGH");
+  });
+});

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -210,8 +210,8 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     // (MCP clients toggle the same control via the AuditRole input
     // directly when they want it). Strip both before comparing the
     // structural shape that drives the prompt.
-    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, ...mcpCore } = mcpArgs;
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

KJC-TSK-0365 — Karajan's audit security dimension was getting all its dependency vulnerability signal from `npm audit` (via basalCost). osv-scanner's DB is broader — it pulls from GitHub Advisory Database, GLSA, PyPI advisories, Go vuln DB and others — and runs entirely locally with **no account, token, or upload**.

Same pattern as #588 (sonar-findings): a new collector that's best-effort (missing binary or scan errors silently skip the section) and feeds structured vulnerabilities into both the LLM prompt and the deterministic-only summary.

## What changes

### New `## OSV Vulnerabilities` section in the prompt
```markdown
## OSV Vulnerabilities
- Total open vulnerabilities in dependencies: 2

### CRITICAL (1)
  - CVE-2024-9999 axios@0.21.0 → fixed in 1.7.4: ssrf

### HIGH (1)
  - GHSA-aaaa lodash@4.17.20 → fixed in 4.17.21: command injection

These CVE/GHSA findings are GROUND TRUTH — incorporate them into the
`security` dimension. Use the OSV id as the `rule` field. Recommend
the fixed version when available.
```

Capped at 50 entries with overflow markers per severity.

### CLI
- `--no-osv` flag (mirrors `--no-sonar`)
- Also auto-skipped when `osv-scanner` is not installed in PATH

### Best-effort handling
- ENOENT (binary missing) → skip with helpful install hint in logger
- Timeout (60s) → skip with reason
- Unparseable output → skip
- **Exit code 1 with valid JSON** → SUCCESS (osv-scanner exits 1 when finding vulns; the collector rescues this case)

## Test plan
- [x] `npx vitest run tests/audit/osv-findings.test.js` — 12/12 passing
- [x] `npx vitest run` — **4293/4293 passing** (12 new tests added, parity test updated)

## Stacked on
Branched from latest main (after #597 merged). Clean diff.

## Note on Snyk
This was originally proposed as a Snyk integration. We chose osv-scanner instead because it covers the same dependency-vulnerability use case **without account/token/data upload** and aligns with Karajan's local-first philosophy. Future work in #KJC-TSK-0366 adds semgrep for SAST (the part of `snyk code` that complements rather than overlaps).