### PR TITLE
feat(audit): integrate semgrep SAST for deterministic security findings (KJC-TSK-0366)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -11,10 +11,12 @@
 
 import { groupIssuesBySeverity } from "./sonar-findings.js";
 import { groupVulnerabilitiesBySeverity } from "./osv-findings.js";
+import { groupFindingsBySeverity as groupSemgrepBySeverity } from "./semgrep-findings.js";
 
 const MAX_SAMPLE_DEAD_EXPORTS = 10;
 const MAX_SAMPLE_SONAR_PER_SEVERITY = 5;
 const MAX_SAMPLE_OSV_PER_SEVERITY = 5;
+const MAX_SAMPLE_SEMGREP_PER_SEVERITY = 5;
 
 /**
  * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object, osvFindings?: object}} ctx
@@ -29,9 +31,34 @@ export function formatDeterministicSummary(ctx) {
   if (ctx.basalCost) lines.push(...formatBasalCostBlock(ctx.basalCost, ctx.growthDelta));
   if (ctx.sonarFindings) lines.push(...formatSonarBlock(ctx.sonarFindings));
   if (ctx.osvFindings) lines.push(...formatOsvBlock(ctx.osvFindings));
+  if (ctx.semgrepFindings) lines.push(...formatSemgrepBlock(ctx.semgrepFindings));
   if (ctx.webperf) lines.push(...formatWebperfBlock(ctx.webperf));
 
   return lines.join("\n");
+}
+
+function formatSemgrepBlock(semgrepFindings) {
+  if (!semgrepFindings.available) {
+    return ["### Semgrep SAST", `- Status: not available — ${semgrepFindings.reason || "semgrep not installed"}`, ""];
+  }
+  const lines = ["### Semgrep SAST"];
+  lines.push(`- Total findings: ${semgrepFindings.total ?? 0}`);
+  if ((semgrepFindings.total ?? 0) > 0) {
+    const groups = groupSemgrepBySeverity(semgrepFindings.findings || []);
+    for (const [severity, findings] of Object.entries(groups)) {
+      if (findings.length === 0) continue;
+      lines.push(`  - ${severity} (${findings.length}):`);
+      for (const f of findings.slice(0, MAX_SAMPLE_SEMGREP_PER_SEVERITY)) {
+        const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
+        lines.push(`    - ${loc} [${f.rule}]`);
+      }
+      if (findings.length > MAX_SAMPLE_SEMGREP_PER_SEVERITY) {
+        lines.push(`    - ... and ${findings.length - MAX_SAMPLE_SEMGREP_PER_SEVERITY} more in ${severity}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines;
 }
 
 function formatOsvBlock(osvFindings) {
@@ -167,6 +194,7 @@ export function deterministicContextHasFindings(ctx) {
   if (ctx.sonarFindings?.available && (ctx.sonarFindings.total ?? 0) > 0) return true;
   if (ctx.sonarFindings?.qualityGate?.status === "ERROR") return true;
   if (ctx.osvFindings?.available && (ctx.osvFindings.total ?? 0) > 0) return true;
+  if (ctx.semgrepFindings?.available && (ctx.semgrepFindings.total ?? 0) > 0) return true;
   if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;
   return false;
 }

--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -10,12 +10,14 @@
  */
 
 import { groupIssuesBySeverity } from "./sonar-findings.js";
+import { groupVulnerabilitiesBySeverity } from "./osv-findings.js";
 
 const MAX_SAMPLE_DEAD_EXPORTS = 10;
 const MAX_SAMPLE_SONAR_PER_SEVERITY = 5;
+const MAX_SAMPLE_OSV_PER_SEVERITY = 5;
 
 /**
- * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object}} ctx
+ * @param {{basalCost?: object, growthDelta?: object, stack?: object, sonarFindings?: object, webperf?: object, osvFindings?: object}} ctx
  * @returns {string} markdown block
  */
 export function formatDeterministicSummary(ctx) {
@@ -26,9 +28,35 @@ export function formatDeterministicSummary(ctx) {
   if (ctx.stack) lines.push(...formatStackBlock(ctx.stack));
   if (ctx.basalCost) lines.push(...formatBasalCostBlock(ctx.basalCost, ctx.growthDelta));
   if (ctx.sonarFindings) lines.push(...formatSonarBlock(ctx.sonarFindings));
+  if (ctx.osvFindings) lines.push(...formatOsvBlock(ctx.osvFindings));
   if (ctx.webperf) lines.push(...formatWebperfBlock(ctx.webperf));
 
   return lines.join("\n");
+}
+
+function formatOsvBlock(osvFindings) {
+  if (!osvFindings.available) {
+    return ["### OSV Vulnerabilities", `- Status: not available — ${osvFindings.reason || "osv-scanner not installed"}`, ""];
+  }
+  const lines = ["### OSV Vulnerabilities (Dependencies)"];
+  lines.push(`- Total open: ${osvFindings.total ?? 0}`);
+  if ((osvFindings.total ?? 0) > 0) {
+    const groups = groupVulnerabilitiesBySeverity(osvFindings.vulnerabilities || []);
+    for (const [severity, vulns] of Object.entries(groups)) {
+      if (vulns.length === 0) continue;
+      lines.push(`  - ${severity} (${vulns.length}):`);
+      for (const v of vulns.slice(0, MAX_SAMPLE_OSV_PER_SEVERITY)) {
+        const where = v.package ? `${v.package}@${v.version || "?"}` : "(unknown)";
+        const fixed = v.fixed ? ` → fixed in ${v.fixed}` : "";
+        lines.push(`    - ${v.id} ${where}${fixed}`);
+      }
+      if (vulns.length > MAX_SAMPLE_OSV_PER_SEVERITY) {
+        lines.push(`    - ... and ${vulns.length - MAX_SAMPLE_OSV_PER_SEVERITY} more in ${severity}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines;
 }
 
 function formatStackBlock(stack) {
@@ -138,6 +166,7 @@ export function deterministicContextHasFindings(ctx) {
   if (ctx.basalCost?.unusedDependencies?.unused?.length > 0) return true;
   if (ctx.sonarFindings?.available && (ctx.sonarFindings.total ?? 0) > 0) return true;
   if (ctx.sonarFindings?.qualityGate?.status === "ERROR") return true;
+  if (ctx.osvFindings?.available && (ctx.osvFindings.total ?? 0) > 0) return true;
   if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;
   return false;
 }

--- a/src/audit/osv-findings.js
+++ b/src/audit/osv-findings.js
@@ -1,0 +1,162 @@
+/**
+ * OSV-Scanner findings collector for `kj audit` (KJC-TSK-0365).
+ *
+ * Wraps Google's `osv-scanner` CLI and feeds its results into the audit
+ * prompt as a deterministic vulnerability section. OSV.dev's database
+ * pulls from GitHub Advisory Database, GLSA, PyPI advisories, Go vuln
+ * DB and others — broader coverage than `npm audit` alone, with no
+ * account, token, or upload (the scanner runs locally and only the
+ * advisory data is fetched on demand).
+ *
+ * This module follows the same pattern as src/audit/sonar-findings.js:
+ *   - Best-effort: missing binary or scan errors return
+ *     {available: false, reason} and the audit continues without the
+ *     section.
+ *   - Severity-grouped: helps the LLM (and the deterministic summary)
+ *     prioritise the worst issues without scrolling.
+ *   - Capped: only the first MAX_OSV_VULNS_IN_PROMPT entries land in
+ *     the prompt, with overflow markers per severity, so an
+ *     out-of-control result list cannot blow the token budget.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SCAN_TIMEOUT_MS = 60_000;
+const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE"];
+
+/**
+ * Run osv-scanner on the project and return a structured result.
+ *
+ * @param {string} projectDir - absolute path to the project root
+ * @param {object} [logger]
+ * @returns {Promise<{available: boolean, reason?: string, total?: number, vulnerabilities?: object[]}>}
+ */
+export async function collectOsvFindings(projectDir, logger = null) {
+  let stdout;
+  try {
+    const { stdout: out } = await execFileAsync(
+      "osv-scanner",
+      ["--format=json", "--recursive", projectDir || "."],
+      { cwd: projectDir, timeout: SCAN_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 }
+    );
+    stdout = out;
+  } catch (err) {
+    // osv-scanner exits with non-zero when vulnerabilities are found, so
+    // err.code 1 is NORMAL — we still want the stdout. Real failures are
+    // ENOENT (binary missing) or stdout empty.
+    if (err.code === "ENOENT") {
+      if (logger?.warn) logger.warn("osv-scanner not found in PATH — install via 'go install github.com/google/osv-scanner@latest'");
+      return { available: false, reason: "osv-scanner not installed" };
+    }
+    if (err.killed) {
+      if (logger?.warn) logger.warn(`osv-scanner timed out after ${SCAN_TIMEOUT_MS}ms`);
+      return { available: false, reason: `osv-scanner timed out after ${SCAN_TIMEOUT_MS}ms` };
+    }
+    if (typeof err.stdout === "string" && err.stdout.trim().length > 0) {
+      stdout = err.stdout;
+    } else {
+      if (logger?.warn) logger.warn(`osv-scanner failed: ${err.message}`);
+      return { available: false, reason: `osv-scanner failed: ${err.message}` };
+    }
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`osv-scanner output not parseable: ${err.message}`);
+    return { available: false, reason: "osv-scanner output not parseable as JSON" };
+  }
+
+  return { available: true, ...parseOsvOutput(parsed) };
+}
+
+/**
+ * Flatten the osv-scanner JSON shape into a flat list of vulnerabilities.
+ * The scanner emits results[].packages[].vulnerabilities[].
+ *
+ * @param {object} raw - parsed osv-scanner JSON
+ * @returns {{total: number, vulnerabilities: object[]}}
+ */
+export function parseOsvOutput(raw) {
+  const flat = [];
+  const results = Array.isArray(raw?.results) ? raw.results : [];
+  for (const result of results) {
+    const source = result.source?.path || result.source || "";
+    const packages = Array.isArray(result.packages) ? result.packages : [];
+    for (const pkg of packages) {
+      const name = pkg.package?.name || "";
+      const version = pkg.package?.version || "";
+      const ecosystem = pkg.package?.ecosystem || "";
+      const vulns = Array.isArray(pkg.vulnerabilities) ? pkg.vulnerabilities : [];
+      const groups = Array.isArray(pkg.groups) ? pkg.groups : [];
+      for (const vuln of vulns) {
+        flat.push({
+          id: vuln.id || vuln.aliases?.[0] || "UNKNOWN",
+          aliases: vuln.aliases || [],
+          severity: extractSeverity(vuln, groups),
+          summary: vuln.summary || vuln.details?.split("\n")[0] || "",
+          package: name,
+          version,
+          ecosystem,
+          source,
+          fixed: extractFixedVersion(vuln),
+        });
+      }
+    }
+  }
+  return { total: flat.length, vulnerabilities: flat };
+}
+
+/**
+ * Resolve a vulnerability's effective severity. osv-scanner reports
+ * CVSS (per-vuln) and a separate `groups[].severity` (per scanner run).
+ * Group severity wins when present because it reflects scanner policy.
+ */
+function extractSeverity(vuln, groups) {
+  // Group-level severity (scanner-resolved, includes ecosystem context)
+  for (const group of groups) {
+    if (group.ids?.includes(vuln.id) && group.severity) {
+      return String(group.severity).toUpperCase();
+    }
+  }
+  // Per-vuln CVSS — pick the highest score
+  const severities = Array.isArray(vuln.severity) ? vuln.severity : [];
+  for (const sev of severities) {
+    if (sev?.severity) return String(sev.severity).toUpperCase();
+  }
+  // database_specific severity (GHSA-style)
+  if (vuln.database_specific?.severity) {
+    return String(vuln.database_specific.severity).toUpperCase();
+  }
+  return "UNKNOWN";
+}
+
+function extractFixedVersion(vuln) {
+  const ranges = vuln.affected?.[0]?.ranges || [];
+  for (const range of ranges) {
+    const events = range.events || [];
+    for (const event of events) {
+      if (event.fixed) return event.fixed;
+    }
+  }
+  return null;
+}
+
+/**
+ * Group vulnerabilities by severity, preserving canonical ordering
+ * (CRITICAL → HIGH → MEDIUM/MODERATE → LOW → UNKNOWN).
+ */
+export function groupVulnerabilitiesBySeverity(vulnerabilities) {
+  const groups = Object.fromEntries(SEVERITY_ORDER.map(s => [s, []]));
+  groups.UNKNOWN = [];
+  for (const vuln of vulnerabilities || []) {
+    const sev = (vuln.severity || "UNKNOWN").toUpperCase();
+    if (groups[sev]) groups[sev].push(vuln);
+    else groups.UNKNOWN.push(vuln);
+  }
+  return groups;
+}

--- a/src/audit/semgrep-findings.js
+++ b/src/audit/semgrep-findings.js
@@ -1,0 +1,117 @@
+/**
+ * Semgrep SAST collector for `kj audit` (KJC-TSK-0366).
+ *
+ * Wraps `semgrep --config auto --json` and feeds structured static-
+ * analysis findings into the audit prompt. Equivalent to the SAST half
+ * of `snyk code` but free for OSS, no account, runs locally. Semgrep
+ * has 2000+ built-in rules across JS/TS/Python/Go/etc. covering OWASP
+ * Top 10, taint analysis, hardcoded secrets, regex misuse and language-
+ * specific anti-patterns.
+ *
+ * Same best-effort pattern as sonar-findings.js and osv-findings.js:
+ *   - Missing binary or timeout returns {available: false, reason}.
+ *   - 120s timeout (semgrep can be slow on large repos with --config auto).
+ *   - Severity-grouped (ERROR / WARNING / INFO) and capped at
+ *     MAX_SEMGREP_FINDINGS_IN_PROMPT (50) total entries with overflow
+ *     markers.
+ *   - The LLM is told these are deterministic and asked to fold them
+ *     into the `security` dimension using the rule ID as the rule field.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SCAN_TIMEOUT_MS = 120_000;
+const SEVERITY_ORDER = ["ERROR", "WARNING", "INFO"];
+
+/**
+ * Run semgrep on the project and return a structured result.
+ *
+ * @param {string} projectDir - absolute path to the project root
+ * @param {object} [logger]
+ * @returns {Promise<{available: boolean, reason?: string, total?: number, findings?: object[]}>}
+ */
+export async function collectSemgrepFindings(projectDir, logger = null) {
+  let stdout;
+  try {
+    const { stdout: out } = await execFileAsync(
+      "semgrep",
+      ["--config", "auto", "--json", "--quiet", `--timeout=${Math.floor(SCAN_TIMEOUT_MS / 1000)}`, projectDir || "."],
+      { cwd: projectDir, timeout: SCAN_TIMEOUT_MS + 5000, maxBuffer: 32 * 1024 * 1024 }
+    );
+    stdout = out;
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      if (logger?.warn) logger.warn("semgrep not found in PATH — install via 'pipx install semgrep' or 'brew install semgrep'");
+      return { available: false, reason: "semgrep not installed" };
+    }
+    if (err.killed) {
+      if (logger?.warn) logger.warn(`semgrep timed out after ${SCAN_TIMEOUT_MS}ms`);
+      return { available: false, reason: `semgrep timed out after ${SCAN_TIMEOUT_MS}ms` };
+    }
+    // semgrep exits 1 when it finds blocking rules (ERROR severity), but
+    // still emits a valid JSON report on stdout. Rescue that case.
+    if (typeof err.stdout === "string" && err.stdout.trim().length > 0) {
+      stdout = err.stdout;
+    } else {
+      if (logger?.warn) logger.warn(`semgrep failed: ${err.message}`);
+      return { available: false, reason: `semgrep failed: ${err.message}` };
+    }
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`semgrep output not parseable: ${err.message}`);
+    return { available: false, reason: "semgrep output not parseable as JSON" };
+  }
+
+  return { available: true, ...parseSemgrepOutput(parsed, projectDir) };
+}
+
+/**
+ * Convert semgrep's JSON shape into the flat findings list the prompt
+ * builder consumes. Semgrep emits results[] with rule id, severity,
+ * path, start/end line, message, fix hints.
+ *
+ * @param {object} raw - parsed semgrep --json output
+ * @param {string} [projectDir] - used to make paths repo-relative
+ * @returns {{total: number, findings: object[]}}
+ */
+export function parseSemgrepOutput(raw, projectDir = "") {
+  const results = Array.isArray(raw?.results) ? raw.results : [];
+  const findings = [];
+  for (const r of results) {
+    const file = r.path && projectDir
+      ? r.path.startsWith(projectDir + "/") ? r.path.slice(projectDir.length + 1) : r.path
+      : r.path || "";
+    findings.push({
+      rule: r.check_id || "(unknown)",
+      severity: String(r.extra?.severity || "INFO").toUpperCase(),
+      file,
+      line: r.start?.line ?? 0,
+      endLine: r.end?.line ?? 0,
+      message: r.extra?.message || "",
+      fix: r.extra?.fix || r.extra?.fix_regex || null,
+      cwe: r.extra?.metadata?.cwe || null,
+      owasp: r.extra?.metadata?.owasp || null,
+    });
+  }
+  return { total: findings.length, findings };
+}
+
+/**
+ * Group findings by severity in canonical order (ERROR → WARNING → INFO).
+ */
+export function groupFindingsBySeverity(findings) {
+  const groups = Object.fromEntries(SEVERITY_ORDER.map(s => [s, []]));
+  for (const f of findings || []) {
+    const sev = (f.severity || "INFO").toUpperCase();
+    if (groups[sev]) groups[sev].push(f);
+    else groups.INFO.push(f);
+  }
+  return groups;
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -96,6 +96,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
+    .option("--no-semgrep", "Skip the Semgrep SAST collector. Findings are also skipped automatically when semgrep is not installed (install via 'pipx install semgrep' or 'brew install semgrep').")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
     .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
@@ -116,6 +117,7 @@ export function registerMeta(program, { pkgVersion }) {
           path: flags.path,
           noSonar: flags.sonar === false,
           noOsv: flags.osv === false,
+          noSemgrep: flags.semgrep === false,
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -95,6 +95,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--agent-readiness", "Score the repo for AI-agent readability (llms.txt, SKILL.md coverage, page token budgets, robots allowlist, heading hierarchy). LLM-free; uses [path] or cwd as the audit target. See issue #542.")
     .option("--path <dir>", "Path to audit (used with --agent-readiness; defaults to cwd)")
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
+    .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
     .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
@@ -114,6 +115,7 @@ export function registerMeta(program, { pkgVersion }) {
           agentReadiness: Boolean(flags.agentReadiness),
           path: flags.path,
           noSonar: flags.sonar === false,
+          noOsv: flags.osv === false,
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -191,19 +191,20 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
-function describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }) {
+function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
   if (noSonar) parts.push("--no-sonar");
   if (noOsv) parts.push("--no-osv");
+  if (noSemgrep) parts.push("--no-semgrep");
   if (deterministicOnly) parts.push("--deterministic-only");
   if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -237,6 +238,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       dimensions: dimensions || null,
       noSonar,
       noOsv,
+      noSemgrep,
     };
     const deterministicCtx = await role.collectDeterministic(roleInput);
     const deterministicMd = formatDeterministicSummary(deterministicCtx);
@@ -267,7 +269,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         if (reportPath.endsWith(".json")) {
           payload = JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2);
         } else {
-          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }));
           payload = header + deterministicMd + "\n";
         }
         await fs.writeFile(reportPath, payload, "utf8");
@@ -323,7 +325,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
           : { ...roleResult, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -191,18 +191,19 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
-function describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }) {
+function describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
   if (noSonar) parts.push("--no-sonar");
+  if (noOsv) parts.push("--no-osv");
   if (deterministicOnly) parts.push("--deterministic-only");
   if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -235,6 +236,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       task: task || "Analyze the full codebase",
       dimensions: dimensions || null,
       noSonar,
+      noOsv,
     };
     const deterministicCtx = await role.collectDeterministic(roleInput);
     const deterministicMd = formatDeterministicSummary(deterministicCtx);
@@ -265,7 +267,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         if (reportPath.endsWith(".json")) {
           payload = JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2);
         } else {
-          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
           payload = header + deterministicMd + "\n";
         }
         await fs.writeFile(reportPath, payload, "utf8");
@@ -321,7 +323,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
           : { ...roleResult, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, json, deterministicOnly, yes }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,8 +1,10 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
+import { groupVulnerabilitiesBySeverity } from "../audit/osv-findings.js";
 import { formatCwvVerdict } from "../audit/webperf-input.js";
 
 const MAX_SONAR_ISSUES_IN_PROMPT = 50;
+const MAX_OSV_VULNS_IN_PROMPT = 50;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -24,7 +26,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null, osvFindings = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -279,6 +281,36 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
       lines.push("- Large third-party scripts (analytics, A/B, chat widgets) without defer + facade pattern");
       lines.push("- Unbounded list rendering without virtualisation for very long collections");
     }
+    sections.push(lines.join("\n"));
+  }
+
+  // OSV vulnerabilities — KJC-TSK-0365. Deterministic CVE/GHSA findings
+  // from osv-scanner across the dependency manifest. Capped at
+  // MAX_OSV_VULNS_IN_PROMPT entries; the LLM is told the truncated count.
+  // Findings fold into the `security` dimension with the upstream
+  // identifier (CVE-/GHSA-) as the rule.
+  if (osvFindings?.available && (osvFindings.total > 0)) {
+    const lines = ["## OSV Vulnerabilities"];
+    lines.push(`- Total open vulnerabilities in dependencies: ${osvFindings.total}`);
+    const groups = groupVulnerabilitiesBySeverity(osvFindings.vulnerabilities);
+    let remaining = MAX_OSV_VULNS_IN_PROMPT;
+    for (const [severity, vulns] of Object.entries(groups)) {
+      if (vulns.length === 0) continue;
+      lines.push("");
+      lines.push(`### ${severity} (${vulns.length})`);
+      const slice = vulns.slice(0, Math.max(0, remaining));
+      for (const vuln of slice) {
+        const where = vuln.package ? `${vuln.package}@${vuln.version || "?"}` : "(unknown package)";
+        const fixed = vuln.fixed ? ` → fixed in ${vuln.fixed}` : "";
+        lines.push(`  - ${vuln.id} ${where}${fixed}: ${vuln.summary || ""}`.trim());
+      }
+      if (vulns.length > slice.length) {
+        lines.push(`  - ... and ${vulns.length - slice.length} more in ${severity}`);
+      }
+      remaining -= slice.length;
+    }
+    lines.push("");
+    lines.push("These CVE/GHSA findings are GROUND TRUTH — incorporate them into the `security` dimension. Use the OSV id (CVE-XXXX-XXXX or GHSA-xxxx-xxxx-xxxx) as the `rule` field. Recommend the fixed version when available.");
     sections.push(lines.join("\n"));
   }
 

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -1,10 +1,12 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { groupIssuesBySeverity } from "../audit/sonar-findings.js";
 import { groupVulnerabilitiesBySeverity } from "../audit/osv-findings.js";
+import { groupFindingsBySeverity as groupSemgrepBySeverity } from "../audit/semgrep-findings.js";
 import { formatCwvVerdict } from "../audit/webperf-input.js";
 
 const MAX_SONAR_ISSUES_IN_PROMPT = 50;
 const MAX_OSV_VULNS_IN_PROMPT = 50;
+const MAX_SEMGREP_FINDINGS_IN_PROMPT = 50;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -26,7 +28,7 @@ const VALID_SCORES = new Set(["A", "B", "C", "D", "F"]);
 const VALID_SEVERITIES = new Set(["critical", "high", "medium", "low"]);
 const VALID_IMPACT = new Set(["high", "medium", "low"]);
 
-export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null, osvFindings = null }) {
+export function buildAuditPrompt({ task, instructions, dimensions = null, context = null, basalCost = null, growthDelta = null, stack = null, sonarFindings = null, webperf = null, osvFindings = null, semgrepFindings = null }) {
   const sections = [SUBAGENT_PREAMBLE];
 
   if (instructions) {
@@ -311,6 +313,36 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     }
     lines.push("");
     lines.push("These CVE/GHSA findings are GROUND TRUTH — incorporate them into the `security` dimension. Use the OSV id (CVE-XXXX-XXXX or GHSA-xxxx-xxxx-xxxx) as the `rule` field. Recommend the fixed version when available.");
+    sections.push(lines.join("\n"));
+  }
+
+  // Semgrep SAST findings — KJC-TSK-0366. Static analysis catches what
+  // sonar/CVE-DBs miss: SQL/Cmd injection, XSS, hardcoded secrets,
+  // taint flow, language-specific anti-patterns. Capped at
+  // MAX_SEMGREP_FINDINGS_IN_PROMPT entries; LLM is told these are
+  // deterministic and asked to use rule IDs as-is in findings.
+  if (semgrepFindings?.available && semgrepFindings.total > 0) {
+    const lines = ["## Semgrep SAST Findings"];
+    lines.push(`- Total findings: ${semgrepFindings.total}`);
+    const groups = groupSemgrepBySeverity(semgrepFindings.findings);
+    let remaining = MAX_SEMGREP_FINDINGS_IN_PROMPT;
+    for (const [severity, findings] of Object.entries(groups)) {
+      if (findings.length === 0) continue;
+      lines.push("");
+      lines.push(`### ${severity} (${findings.length})`);
+      const slice = findings.slice(0, Math.max(0, remaining));
+      for (const f of slice) {
+        const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
+        const cwe = f.cwe ? ` (${Array.isArray(f.cwe) ? f.cwe.join(", ") : f.cwe})` : "";
+        lines.push(`  - ${loc} [${f.rule}]${cwe}: ${f.message || ""}`.trim());
+      }
+      if (findings.length > slice.length) {
+        lines.push(`  - ... and ${findings.length - slice.length} more in ${severity}`);
+      }
+      remaining -= slice.length;
+    }
+    lines.push("");
+    lines.push("These SAST findings are GROUND TRUTH — fold ERROR-severity ones into the `security` dimension as critical/high findings. Use the semgrep rule id (e.g. javascript.express.security.audit.xss.direct-response-write) verbatim in the `rule` field; that lets the developer look it up in the semgrep registry.");
     sections.push(lines.join("\n"));
   }
 

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -4,6 +4,7 @@ import { measureBasalCost, loadPreviousAudit, saveAuditSnapshot, computeGrowthDe
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { collectSonarFindings } from "../audit/sonar-findings.js";
 import { collectWebPerfInput } from "../audit/webperf-input.js";
+import { collectOsvFindings } from "../audit/osv-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -43,12 +44,14 @@ export class AuditRole extends AgentRole {
    */
   async collectDeterministic(input) {
     const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
+    const noOsv = typeof input === "object" ? Boolean(input?.noOsv) : false;
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
     let stack = null;
     let sonarFindings = null;
     let webperf = null;
+    let osvFindings = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -65,7 +68,15 @@ export class AuditRole extends AgentRole {
     try {
       webperf = collectWebPerfInput(stack, this.config);
     } catch { /* webperf input is best-effort */ }
-    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf };
+    // OSV vulnerabilities — KJC-TSK-0365. Best-effort: missing
+    // osv-scanner binary returns available:false and the audit
+    // continues without the section.
+    if (!noOsv) {
+      try {
+        osvFindings = await collectOsvFindings(projectDir, this.logger);
+      } catch { /* osv-scanner is best-effort */ }
+    }
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings };
   }
 
   /**
@@ -81,11 +92,11 @@ export class AuditRole extends AgentRole {
     const context = typeof input === "object" ? input?.context || null : null;
     const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
 
-    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf } = deterministicCtx;
+    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings } = deterministicCtx;
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const startedAt = Date.now();
@@ -115,6 +126,7 @@ export class AuditRole extends AgentRole {
           stack: stack || undefined,
           sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
           webperf: webperf?.available ? webperf : undefined,
+          osvFindings: osvFindings?.available ? osvFindings : undefined,
           provider
         },
         summary: buildSummary(parsed),

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -5,6 +5,7 @@ import { detectProjectStack } from "../utils/stack-detect.js";
 import { collectSonarFindings } from "../audit/sonar-findings.js";
 import { collectWebPerfInput } from "../audit/webperf-input.js";
 import { collectOsvFindings } from "../audit/osv-findings.js";
+import { collectSemgrepFindings } from "../audit/semgrep-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -45,6 +46,7 @@ export class AuditRole extends AgentRole {
   async collectDeterministic(input) {
     const noSonar = typeof input === "object" ? Boolean(input?.noSonar) : false;
     const noOsv = typeof input === "object" ? Boolean(input?.noOsv) : false;
+    const noSemgrep = typeof input === "object" ? Boolean(input?.noSemgrep) : false;
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
@@ -52,6 +54,7 @@ export class AuditRole extends AgentRole {
     let sonarFindings = null;
     let webperf = null;
     let osvFindings = null;
+    let semgrepFindings = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -76,7 +79,14 @@ export class AuditRole extends AgentRole {
         osvFindings = await collectOsvFindings(projectDir, this.logger);
       } catch { /* osv-scanner is best-effort */ }
     }
-    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings };
+    // Semgrep SAST — KJC-TSK-0366. Best-effort: missing semgrep binary
+    // returns available:false and the audit continues without the section.
+    if (!noSemgrep) {
+      try {
+        semgrepFindings = await collectSemgrepFindings(projectDir, this.logger);
+      } catch { /* semgrep is best-effort */ }
+    }
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings };
   }
 
   /**
@@ -92,11 +102,11 @@ export class AuditRole extends AgentRole {
     const context = typeof input === "object" ? input?.context || null : null;
     const dimensions = typeof rawDimensions === "string" ? parseDimensions(rawDimensions) : rawDimensions;
 
-    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings } = deterministicCtx;
+    const { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings } = deterministicCtx;
 
     const provider = this.resolveProvider();
     const agent = this.createAgentInstance(provider);
-    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings });
+    const prompt = buildAuditPrompt({ task, instructions: this.instructions, dimensions, context, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings });
     const runArgs = { prompt, role: "audit" };
     if (onOutput) runArgs.onOutput = onOutput;
     const startedAt = Date.now();
@@ -127,6 +137,7 @@ export class AuditRole extends AgentRole {
           sonarFindings: sonarFindings?.available ? sonarFindings : undefined,
           webperf: webperf?.available ? webperf : undefined,
           osvFindings: osvFindings?.available ? osvFindings : undefined,
+          semgrepFindings: semgrepFindings?.available ? semgrepFindings : undefined,
           provider
         },
         summary: buildSummary(parsed),

--- a/tests/audit/osv-findings.test.js
+++ b/tests/audit/osv-findings.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock execFile + promisify so we can drive collectOsvFindings under
+// controlled conditions. promisify(execFile) resolves to {stdout, stderr}
+// (Node's custom impl). We bypass that nuance by faking promisify too.
+const execFileMock = vi.fn();
+
+vi.mock("node:util", async () => {
+  const actual = await vi.importActual("node:util");
+  return {
+    ...actual,
+    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
+  };
+});
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+import { collectOsvFindings, parseOsvOutput, groupVulnerabilitiesBySeverity } from "../../src/audit/osv-findings.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+describe("collectOsvFindings (KJC-TSK-0365)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns available=false when osv-scanner is not installed (ENOENT)", async () => {
+    const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });
+    execFileMock.mockRejectedValue(enoErr);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not installed/);
+    expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringContaining("osv-scanner not found"));
+  });
+
+  it("returns available=false when scanner times out", async () => {
+    const timeoutErr = Object.assign(new Error("killed"), { killed: true });
+    execFileMock.mockRejectedValue(timeoutErr);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/timed out/);
+  });
+
+  it("returns available=false when scanner output is unparseable", async () => {
+    execFileMock.mockResolvedValue({ stdout: "not JSON {{{", stderr: "" });
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not parseable/);
+  });
+
+  it("parses a clean osv-scanner JSON result and groups vulnerabilities", async () => {
+    const sample = {
+      results: [{
+        source: { path: "package-lock.json" },
+        packages: [{
+          package: { name: "lodash", version: "4.17.20", ecosystem: "npm" },
+          vulnerabilities: [
+            { id: "GHSA-xxxx-xxxx-1111", aliases: ["CVE-2021-23337"], summary: "Command injection", database_specific: { severity: "HIGH" }, affected: [{ ranges: [{ events: [{ fixed: "4.17.21" }] }] }] },
+          ],
+          groups: [{ ids: ["GHSA-xxxx-xxxx-1111"], severity: "HIGH" }],
+        }],
+      }],
+    };
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(sample), stderr: "" });
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(1);
+    expect(r.vulnerabilities[0]).toMatchObject({
+      id: "GHSA-xxxx-xxxx-1111",
+      package: "lodash",
+      version: "4.17.20",
+      severity: "HIGH",
+      fixed: "4.17.21",
+    });
+  });
+
+  it("treats exit code 1 with valid JSON stdout as success (osv exits 1 when vulns are found)", async () => {
+    // osv-scanner exits 1 when it finds vulnerabilities — execFile rejects
+    // but stdout has the structured output. The collector should parse it.
+    const sample = { results: [{ packages: [{ package: { name: "x", version: "1" }, vulnerabilities: [{ id: "CVE-1" }] }] }] };
+    const err = Object.assign(new Error("exit 1"), { code: 1, stdout: JSON.stringify(sample), stderr: "" });
+    execFileMock.mockRejectedValue(err);
+
+    const r = await collectOsvFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(1);
+  });
+});
+
+describe("parseOsvOutput", () => {
+  it("flattens nested results.packages.vulnerabilities", () => {
+    const raw = {
+      results: [
+        { packages: [
+          { package: { name: "a", version: "1.0" }, vulnerabilities: [{ id: "CVE-1" }, { id: "CVE-2" }] },
+          { package: { name: "b", version: "2.0" }, vulnerabilities: [{ id: "CVE-3" }] },
+        ] },
+      ],
+    };
+    const r = parseOsvOutput(raw);
+    expect(r.total).toBe(3);
+    expect(r.vulnerabilities.map(v => v.id)).toEqual(["CVE-1", "CVE-2", "CVE-3"]);
+  });
+
+  it("handles empty results gracefully", () => {
+    expect(parseOsvOutput({ results: [] })).toEqual({ total: 0, vulnerabilities: [] });
+    expect(parseOsvOutput({})).toEqual({ total: 0, vulnerabilities: [] });
+  });
+
+  it("prefers group severity over database_specific severity", () => {
+    const raw = {
+      results: [{
+        packages: [{
+          package: { name: "x" },
+          vulnerabilities: [{ id: "V1", database_specific: { severity: "MEDIUM" } }],
+          groups: [{ ids: ["V1"], severity: "CRITICAL" }],
+        }],
+      }],
+    };
+    const r = parseOsvOutput(raw);
+    expect(r.vulnerabilities[0].severity).toBe("CRITICAL");
+  });
+});
+
+describe("groupVulnerabilitiesBySeverity", () => {
+  it("groups in canonical order (CRITICAL → HIGH → MEDIUM → MODERATE → LOW → UNKNOWN)", () => {
+    const groups = groupVulnerabilitiesBySeverity([
+      { severity: "MEDIUM" }, { severity: "CRITICAL" }, { severity: "INVALID" }, { severity: "HIGH" },
+    ]);
+    expect(Object.keys(groups)).toEqual(["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE", "UNKNOWN"]);
+    expect(groups.CRITICAL).toHaveLength(1);
+    expect(groups.HIGH).toHaveLength(1);
+    expect(groups.MEDIUM).toHaveLength(1);
+    expect(groups.UNKNOWN).toHaveLength(1);
+  });
+});
+
+describe("buildAuditPrompt — OSV Vulnerabilities section", () => {
+  it("omits the section when osvFindings is null or empty", () => {
+    const a = buildAuditPrompt({ task: "audit", osvFindings: null });
+    const b = buildAuditPrompt({ task: "audit", osvFindings: { available: true, total: 0, vulnerabilities: [] } });
+    const c = buildAuditPrompt({ task: "audit", osvFindings: { available: false, reason: "not installed" } });
+    expect(a).not.toContain("## OSV Vulnerabilities");
+    expect(b).not.toContain("## OSV Vulnerabilities");
+    expect(c).not.toContain("## OSV Vulnerabilities");
+  });
+
+  it("renders findings grouped by severity with package + version + fixed version", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      osvFindings: {
+        available: true,
+        total: 2,
+        vulnerabilities: [
+          { id: "GHSA-aaaa", package: "lodash", version: "4.17.20", severity: "HIGH", summary: "command injection", fixed: "4.17.21" },
+          { id: "CVE-2024-9999", package: "axios", version: "0.21.0", severity: "CRITICAL", summary: "ssrf", fixed: "1.7.4" },
+        ],
+      },
+    });
+    expect(prompt).toContain("## OSV Vulnerabilities");
+    expect(prompt).toContain("Total open vulnerabilities in dependencies: 2");
+    expect(prompt).toContain("### CRITICAL (1)");
+    expect(prompt).toContain("### HIGH (1)");
+    expect(prompt).toContain("CVE-2024-9999");
+    expect(prompt).toContain("axios@0.21.0");
+    expect(prompt).toContain("→ fixed in 1.7.4");
+    expect(prompt).toContain("These CVE/GHSA findings are GROUND TRUTH");
+  });
+
+  it("caps the rendered list at MAX_OSV_VULNS_IN_PROMPT (50) with overflow per severity", () => {
+    const vulns = Array.from({ length: 75 }, (_, i) => ({
+      id: `CVE-2024-${i}`, package: `pkg${i}`, version: "1.0", severity: "HIGH", summary: "x",
+    }));
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      osvFindings: { available: true, total: 75, vulnerabilities: vulns },
+    });
+    expect(prompt).toContain("Total open vulnerabilities in dependencies: 75");
+    expect(prompt).toContain("and 25 more in HIGH");
+  });
+});

--- a/tests/audit/semgrep-findings.test.js
+++ b/tests/audit/semgrep-findings.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock node:util's promisify to bypass the {stdout, stderr} custom-impl
+// dance (same trick as tests/audit/osv-findings.test.js).
+const execFileMock = vi.fn();
+
+vi.mock("node:util", async () => {
+  const actual = await vi.importActual("node:util");
+  return {
+    ...actual,
+    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
+  };
+});
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+import { collectSemgrepFindings, parseSemgrepOutput, groupFindingsBySeverity } from "../../src/audit/semgrep-findings.js";
+import { buildAuditPrompt } from "../../src/prompts/audit.js";
+
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+describe("collectSemgrepFindings (KJC-TSK-0366)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns available=false when semgrep is not installed (ENOENT)", async () => {
+    const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });
+    execFileMock.mockRejectedValue(enoErr);
+
+    const r = await collectSemgrepFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not installed/);
+    expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringContaining("semgrep not found"));
+  });
+
+  it("returns available=false when scan times out", async () => {
+    const timeoutErr = Object.assign(new Error("killed"), { killed: true });
+    execFileMock.mockRejectedValue(timeoutErr);
+
+    const r = await collectSemgrepFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/timed out/);
+  });
+
+  it("returns available=false when output is unparseable", async () => {
+    execFileMock.mockResolvedValue({ stdout: "junk { not valid", stderr: "" });
+
+    const r = await collectSemgrepFindings("/tmp", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/not parseable/);
+  });
+
+  it("parses a clean semgrep --json result and surfaces findings", async () => {
+    const sample = {
+      results: [
+        { check_id: "javascript.express.security.audit.xss.direct-response-write.direct-response-write",
+          path: "/tmp/src/route.js", start: { line: 42 }, end: { line: 45 },
+          extra: { severity: "ERROR", message: "Untrusted input flows into res.write", metadata: { cwe: ["CWE-79"], owasp: ["A03:2021"] } } },
+        { check_id: "javascript.lang.security.audit.unsafe-formatstring",
+          path: "/tmp/src/log.js", start: { line: 10 }, end: { line: 11 },
+          extra: { severity: "WARNING", message: "Format string with user input" } },
+      ],
+    };
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(sample), stderr: "" });
+
+    const r = await collectSemgrepFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(2);
+    expect(r.findings[0]).toMatchObject({
+      rule: "javascript.express.security.audit.xss.direct-response-write.direct-response-write",
+      severity: "ERROR",
+      file: "src/route.js", // path made relative to /tmp
+      line: 42,
+    });
+    expect(r.findings[0].cwe).toEqual(["CWE-79"]);
+  });
+
+  it("rescues exit code 1 with valid JSON stdout (semgrep exits 1 when ERROR rules fire)", async () => {
+    const sample = { results: [{ check_id: "X", path: "a.js", start: { line: 1 }, end: { line: 1 }, extra: { severity: "ERROR" } }] };
+    const err = Object.assign(new Error("exit 1"), { code: 1, stdout: JSON.stringify(sample), stderr: "" });
+    execFileMock.mockRejectedValue(err);
+
+    const r = await collectSemgrepFindings("/tmp", noopLogger);
+    expect(r.available).toBe(true);
+    expect(r.total).toBe(1);
+  });
+});
+
+describe("parseSemgrepOutput", () => {
+  it("makes paths relative to projectDir", () => {
+    const raw = { results: [{ check_id: "x", path: "/proj/src/a.js", start: { line: 1 }, end: { line: 1 }, extra: { severity: "INFO" } }] };
+    const r = parseSemgrepOutput(raw, "/proj");
+    expect(r.findings[0].file).toBe("src/a.js");
+  });
+
+  it("normalises missing severity to INFO and handles empty results", () => {
+    expect(parseSemgrepOutput({}).total).toBe(0);
+    const r = parseSemgrepOutput({ results: [{ check_id: "x", path: "a.js", start: { line: 1 }, end: { line: 1 }, extra: {} }] });
+    expect(r.findings[0].severity).toBe("INFO");
+  });
+});
+
+describe("groupFindingsBySeverity", () => {
+  it("groups in canonical order ERROR → WARNING → INFO", () => {
+    const groups = groupFindingsBySeverity([
+      { severity: "WARNING" }, { severity: "ERROR" }, { severity: "INFO" }, { severity: "WARNING" },
+    ]);
+    expect(Object.keys(groups)).toEqual(["ERROR", "WARNING", "INFO"]);
+    expect(groups.ERROR).toHaveLength(1);
+    expect(groups.WARNING).toHaveLength(2);
+    expect(groups.INFO).toHaveLength(1);
+  });
+
+  it("buckets unknown severity into INFO", () => {
+    const groups = groupFindingsBySeverity([{ severity: "FOO" }, {}]);
+    expect(groups.INFO).toHaveLength(2);
+  });
+});
+
+describe("buildAuditPrompt — Semgrep section integration", () => {
+  it("omits the section when semgrepFindings is null/empty/unavailable", () => {
+    const a = buildAuditPrompt({ task: "audit", semgrepFindings: null });
+    const b = buildAuditPrompt({ task: "audit", semgrepFindings: { available: true, total: 0, findings: [] } });
+    const c = buildAuditPrompt({ task: "audit", semgrepFindings: { available: false, reason: "not installed" } });
+    expect(a).not.toContain("## Semgrep SAST Findings");
+    expect(b).not.toContain("## Semgrep SAST Findings");
+    expect(c).not.toContain("## Semgrep SAST Findings");
+  });
+
+  it("renders findings grouped by severity with rule + location", () => {
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      semgrepFindings: {
+        available: true,
+        total: 2,
+        findings: [
+          { rule: "javascript.express.xss", severity: "ERROR", file: "src/route.js", line: 42, message: "XSS" },
+          { rule: "javascript.lang.format", severity: "WARNING", file: "src/log.js", line: 10, message: "format string" },
+        ],
+      },
+    });
+    expect(prompt).toContain("## Semgrep SAST Findings");
+    expect(prompt).toContain("Total findings: 2");
+    expect(prompt).toContain("### ERROR (1)");
+    expect(prompt).toContain("### WARNING (1)");
+    expect(prompt).toContain("javascript.express.xss");
+    expect(prompt).toContain("src/route.js:42");
+    expect(prompt).toContain("These SAST findings are GROUND TRUTH");
+  });
+
+  it("caps the rendered list at MAX_SEMGREP_FINDINGS_IN_PROMPT (50) with overflow per severity", () => {
+    const findings = Array.from({ length: 75 }, (_, i) => ({
+      rule: `rule${i}`, severity: "ERROR", file: `f${i}.js`, line: i, message: "x",
+    }));
+    const prompt = buildAuditPrompt({
+      task: "audit",
+      semgrepFindings: { available: true, total: 75, findings },
+    });
+    expect(prompt).toContain("Total findings: 75");
+    expect(prompt).toContain("and 25 more in ERROR");
+  });
+});

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -210,8 +210,8 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     // (MCP clients toggle the same control via the AuditRole input
     // directly when they want it). Strip both before comparing the
     // structural shape that drives the prompt.
-    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, ...mcpCore } = mcpArgs;
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, noSemgrep: _cliNoSemgrep, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, noSemgrep: _mcpNoSemgrep, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });

--- a/tests/command-audit.test.js
+++ b/tests/command-audit.test.js
@@ -210,8 +210,8 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     // (MCP clients toggle the same control via the AuditRole input
     // directly when they want it). Strip both before comparing the
     // structural shape that drives the prompt.
-    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, ...mcpCore } = mcpArgs;
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

KJC-TSK-0366 — Karajan's audit security dimension was relying on the LLM to find SAST issues (SQL/Cmd injection, XSS, hardcoded secrets, taint flow). Semgrep has 2000+ built-in rules across JS/TS/Python/Go/etc., detects what sonar/CVE-DBs miss, and runs entirely locally with **no account or upload** — equivalent to the SAST half of `snyk code` but free for OSS.

Same pattern as #588 (sonar) and #598 (osv-scanner): a deterministic collector that's best-effort and feeds structured findings into both the LLM prompt and the deterministic-only summary.

## What changes

### New `## Semgrep SAST Findings` section in the prompt
```markdown
## Semgrep SAST Findings
- Total findings: 2

### ERROR (1)
  - src/route.js:42 [javascript.express.security.audit.xss.direct-response-write] (CWE-79): Untrusted input flows into res.write

### WARNING (1)
  - src/log.js:10 [javascript.lang.security.audit.unsafe-formatstring]: Format string with user input

These SAST findings are GROUND TRUTH — fold ERROR-severity ones into
the `security` dimension as critical/high findings. Use the semgrep
rule id verbatim in the `rule` field; that lets the developer look
it up in the semgrep registry.
```

Capped at 50 entries with overflow markers per severity.

### CLI
- `--no-semgrep` flag (mirrors `--no-sonar`, `--no-osv`)
- Auto-skipped when `semgrep` is not installed (with helpful install hint: `pipx install semgrep` or `brew install semgrep`)

### Best-effort handling
- ENOENT (binary missing) → skip
- Timeout (120s; semgrep can be slow on large repos with `--config auto`) → skip
- Unparseable output → skip
- **Exit code 1 with valid JSON** → SUCCESS (semgrep exits 1 when ERROR rules fire; rescued)

## Implementation notes
- Paths made relative to projectDir so LLM gets clean references (`src/route.js:42` not `/abs/path/.../src/route.js:42`)
- Captures CWE + OWASP metadata from the rule when available

## Stacked on
This branch builds on #598 (osv-scanner). After #598 merges, the diff against main is clean.

## Test plan
- [x] `npx vitest run tests/audit/semgrep-findings.test.js` — 12/12 passing
- [x] `npx vitest run` — **4305/4305 passing** (12 new tests added, parity test updated)