### PR TITLE
feat(webperf): kj webperf scanner + audit auto-discovery (KJC-TSK-0149)

### DIFF
--- a/src/audit/webperf-input.js
+++ b/src/audit/webperf-input.js
@@ -7,21 +7,66 @@
  *     source (bundle bloat, render-blocking, image opt, lazy loading).
  *     This is the common path because `kj audit` runs against a code
  *     tree, not a live preview server.
- *   - "cwv-result": a Core Web Vitals measurement was supplied (either
- *     via config.webperf.lastResult, or in the future via a `kj webperf`
- *     command that drives Chrome DevTools MCP). evaluateCwv from
- *     src/webperf/cwv-gate.js produces a structured verdict the prompt
- *     renders verbatim.
+ *   - "cwv-result": a Core Web Vitals measurement was supplied. Three
+ *     possible sources, in priority order:
+ *       1. `config.webperf.lastResult` — inline {metrics, thresholds, ...}
+ *          (rare; legacy / programmatic injection)
+ *       2. `config.webperf.lastResultPath` — file path written by
+ *          `kj webperf` (KJC-TSK-0149). This is the standard wiring.
+ *       3. `~/.karajan/webperf/<projectSlug>/last.json` — fallback
+ *          discovery when the user ran `kj webperf` but didn't patch
+ *          their kj.config.yml.
+ *     evaluateCwv from src/webperf/cwv-gate.js produces a structured
+ *     verdict the prompt renders verbatim.
  *
  * The "live measurement" path is intentionally NOT wired here: the
  * audit's LLM sub-agent is forbidden from MCP tool use (SUBAGENT_PREAMBLE
  * in src/prompts/audit.js), and spawning Chrome / launching a preview
- * server during a read-only audit is out of scope. When a future
- * `kj webperf` command exists, it can write the result into
- * `config.webperf.lastResult` and this collector will surface it.
+ * server during a read-only audit is wrong layer. `kj webperf` does
+ * the measurement; `kj audit` consumes the persisted result.
  */
 
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 import { evaluateCwv, CWV_THRESHOLDS } from "../webperf/cwv-gate.js";
+
+// Resolve per call — `os.homedir()` reads $HOME each time, so test
+// suites that override $HOME for hermetic tmp dirs work without
+// special re-imports.
+function webperfHome() {
+  return path.join(os.homedir(), ".karajan", "webperf");
+}
+
+function projectSlug(projectDir) {
+  return path.basename(projectDir || process.cwd()).replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+/**
+ * Try the three discovery paths in priority order. Returns the parsed
+ * scan object (shape produced by src/webperf/scanner.js) or null.
+ */
+function loadPersistedScan(webperfConfig, projectDir) {
+  // 1. Inline result on the config (back-compat)
+  if (webperfConfig.lastResult && typeof webperfConfig.lastResult === "object" && webperfConfig.lastResult.metrics) {
+    return webperfConfig.lastResult;
+  }
+  // 2. Explicit file path on the config
+  const candidates = [];
+  if (webperfConfig.lastResultPath) candidates.push(webperfConfig.lastResultPath);
+  // 3. Fallback: ~/.karajan/webperf/<slug>/last.json
+  if (projectDir) {
+    candidates.push(path.join(webperfHome(), projectSlug(projectDir), "last.json"));
+  }
+  for (const candidate of candidates) {
+    try {
+      const raw = fs.readFileSync(candidate, "utf8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && parsed.metrics) return parsed;
+    } catch { /* missing file or unparseable — try next */ }
+  }
+  return null;
+}
 
 /**
  * Decide what (if anything) to feed the audit prompt about web perf.
@@ -32,17 +77,18 @@ import { evaluateCwv, CWV_THRESHOLDS } from "../webperf/cwv-gate.js";
  */
 export function collectWebPerfInput(stack, config = {}) {
   const webperfConfig = config?.webperf || {};
-  const lastResult = webperfConfig.lastResult || null;
+  const projectDir = config?.projectDir;
+  const persisted = loadPersistedScan(webperfConfig, projectDir);
 
-  if (lastResult && typeof lastResult === "object" && lastResult.metrics) {
-    const verdict = evaluateCwv(lastResult.metrics, lastResult.thresholds || webperfConfig.thresholds);
+  if (persisted) {
+    const verdict = persisted.cwv || evaluateCwv(persisted.metrics, persisted.thresholds || webperfConfig.thresholds);
     return {
       available: true,
       mode: "cwv-result",
-      url: lastResult.url || webperfConfig.url || null,
-      capturedAt: lastResult.capturedAt || null,
+      url: persisted.url || webperfConfig.url || null,
+      capturedAt: persisted.capturedAt || null,
       cwv: verdict,
-      thresholds: lastResult.thresholds || webperfConfig.thresholds || CWV_THRESHOLDS,
+      thresholds: persisted.thresholds || webperfConfig.thresholds || CWV_THRESHOLDS,
     };
   }
 

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -5,6 +5,7 @@ import { architectCommand } from "../commands/architect.js";
 import { auditCommand } from "../commands/audit.js";
 import { resumeCommand } from "../commands/resume.js";
 import { boardCommand } from "../commands/board.js";
+import { webperfCommand } from "../commands/webperf.js";
 import { undoCommand } from "../commands/undo.js";
 import { syncCommand } from "../commands/sync.js";
 import { cleanCommand } from "../commands/clean.js";
@@ -122,6 +123,27 @@ export function registerMeta(program, { pkgVersion }) {
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),
         });
+      });
+    });
+
+  program
+    .command("webperf")
+    .description("Run a Lighthouse web-perf scan against a URL — Core Web Vitals + opportunities")
+    .argument("<url>", "Target URL (e.g. http://localhost:3000)")
+    .option("--mobile", "Use the Lighthouse mobile preset (default: desktop)")
+    .option("--json", "Output raw JSON")
+    .option("--no-persist", "Don't write the result into ~/.karajan/webperf/<slug>/last.json (kj audit reads it from there)")
+    .action(async (url, flags) => {
+      await withConfig(pkgVersion, "webperf", flags, async ({ config, logger }) => {
+        const result = await webperfCommand({
+          url,
+          config, logger,
+          mobile: Boolean(flags.mobile),
+          json: Boolean(flags.json),
+          persist: flags.persist !== false,
+        });
+        // Exit with non-zero when the verdict is FAIL so CI can gate.
+        if (result && result.ok === false) process.exitCode = 1;
       });
     });
 

--- a/src/commands/webperf.js
+++ b/src/commands/webperf.js
@@ -1,0 +1,164 @@
+/**
+ * `kj webperf <url>` — KJC-TSK-0149.
+ *
+ * Headless Lighthouse wrapper. Produces structured CWV + opportunities
+ * JSON. Writes the result into `~/.karajan/webperf/<projectSlug>/last.json`
+ * so future `kj audit` runs can surface the verdict via the existing
+ * WebPerf section (KJC-TSK-0360 cwv-result mode).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import yaml from "js-yaml";
+import { runWebperfScan } from "../webperf/scanner.js";
+import { withCliRunLog } from "../utils/cli-run-log.js";
+
+// Resolve home each call so tests that override $HOME for hermetic
+// tmp dirs work without re-importing the module.
+function defaultReportDir() {
+  return path.join(os.homedir(), ".karajan", "webperf");
+}
+
+/**
+ * Slug a project directory the same way audit/basal-cost.js and
+ * plan/plan-store.js do, so the per-project webperf history aligns
+ * with audit history under ~/.karajan/.
+ */
+function projectSlug(projectDir) {
+  return path.basename(projectDir || process.cwd()).replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function formatHumanReport(result) {
+  if (!result.ok) {
+    return `WebPerf scan FAILED — ${result.reason}`;
+  }
+  const lines = ["## WebPerf Scan", ""];
+  lines.push(`- URL: ${result.url}`);
+  lines.push(`- Preset: ${result.preset}`);
+  lines.push(`- Captured: ${result.capturedAt}`);
+  if (result.lighthouseVersion) lines.push(`- Lighthouse: v${result.lighthouseVersion}`);
+  if (typeof result.performanceScore === "number") {
+    lines.push(`- Performance score: ${result.performanceScore}/100`);
+  }
+  lines.push("");
+  lines.push(`### Verdict: ${result.cwv.pass ? "PASS" : "FAIL"}`);
+  lines.push("");
+  lines.push("### Core Web Vitals");
+  for (const [metric, score] of Object.entries(result.cwv.scores || {})) {
+    const value = formatMetricValue(metric, score.value);
+    lines.push(`- ${metric.toUpperCase()}: ${value} (${score.rating})`);
+  }
+  if (result.cwv.blocking?.length) {
+    lines.push("");
+    lines.push("### Blocking metrics (above poor threshold)");
+    for (const b of result.cwv.blocking) {
+      lines.push(`- ${b.metric.toUpperCase()}: ${formatMetricValue(b.metric, b.value)} > ${formatMetricValue(b.metric, b.threshold)}`);
+    }
+  }
+  if (result.issues?.length) {
+    lines.push("");
+    lines.push(`### Top opportunities (${result.issues.length})`);
+    for (const issue of result.issues.slice(0, 10)) {
+      const savings = issue.savingsMs ? ` (saves ~${Math.round(issue.savingsMs)}ms)` : "";
+      lines.push(`- [${issue.severity.toUpperCase()}] ${issue.id}${savings}: ${issue.title}`);
+    }
+    if (result.issues.length > 10) {
+      lines.push(`- ... and ${result.issues.length - 10} more`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatMetricValue(metric, value) {
+  if (typeof value !== "number") return "n/a";
+  if (metric === "cls") return value.toFixed(3);
+  return `${Math.round(value)}ms`;
+}
+
+/**
+ * Persist the scan result into ~/.karajan/webperf/<slug>/last.json so
+ * `kj audit` can read it via collectWebPerfInput (KJC-TSK-0360).
+ */
+async function persistResult(result, projectDir) {
+  if (!result.ok) return null;
+  const dir = path.join(defaultReportDir(), projectSlug(projectDir));
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, "last.json");
+  await fs.writeFile(filePath, JSON.stringify(result, null, 2), "utf8");
+  return filePath;
+}
+
+/**
+ * Optionally update kj.config.yml so `kj audit` finds the result by
+ * default (mirrors how sonar config is wired). Best-effort: never
+ * fails the command; absence of config file or write error is logged.
+ */
+async function patchConfigLastResult(configPath, lastResultPath, logger) {
+  if (!configPath || !lastResultPath) return false;
+  let raw;
+  try { raw = await fs.readFile(configPath, "utf8"); } catch { return false; }
+  let parsed;
+  try { parsed = yaml.load(raw) || {}; } catch (err) {
+    if (logger?.warn) logger.warn(`webperf: cannot parse ${configPath}: ${err.message}`);
+    return false;
+  }
+  parsed.webperf = parsed.webperf || {};
+  parsed.webperf.lastResultPath = lastResultPath;
+  try {
+    await fs.writeFile(configPath, yaml.dump(parsed), "utf8");
+    return true;
+  } catch (err) {
+    if (logger?.warn) logger.warn(`webperf: cannot write ${configPath}: ${err.message}`);
+    return false;
+  }
+}
+
+export async function webperfCommand({ url, config, logger, json = false, mobile = false, persist = true, thresholds = null }) {
+  if (!url) {
+    throw new Error("kj webperf: <url> is required (e.g. http://localhost:3000)");
+  }
+  return withCliRunLog("webperf", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
+    logger.info(`Running webperf scan against ${url} (preset: ${mobile ? "mobile" : "desktop"})`);
+    runLog.logText(`[webperf] scan url=${url} preset=${mobile ? "mobile" : "desktop"}`);
+
+    const scanThresholds = thresholds || config?.webperf?.thresholds || null;
+    const result = await runWebperfScan(url, {
+      preset: mobile ? "mobile" : "desktop",
+      thresholds: scanThresholds,
+      logger,
+    });
+
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatHumanReport(result));
+    }
+
+    if (!result.ok) {
+      runLog.logText(`[webperf] failed reason=${result.reason}`);
+      return { ok: false, reason: result.reason };
+    }
+
+    runLog.logText(`[webperf] verdict=${result.cwv.pass ? "PASS" : "FAIL"} score=${result.performanceScore}`);
+
+    let savedPath = null;
+    if (persist) {
+      try {
+        savedPath = await persistResult(result, config?.projectDir);
+        if (savedPath) {
+          logger.info(`WebPerf result saved: ${savedPath}`);
+          // Wire into kj.config.yml so `kj audit` picks it up automatically.
+          const configPath = config?.configFilePath
+            || path.join(config?.projectDir || process.cwd(), ".karajan", "kj.config.yml");
+          await patchConfigLastResult(configPath, savedPath, logger);
+        }
+      } catch (err) {
+        logger.warn(`webperf: persist failed (non-blocking): ${err.message}`);
+      }
+    }
+
+    // Exit code: 0 for PASS, 1 for FAIL. Lets CI gate on it.
+    return { ok: result.cwv.pass, result, savedPath };
+  });
+}

--- a/src/webperf/scanner.js
+++ b/src/webperf/scanner.js
@@ -1,0 +1,209 @@
+/**
+ * Web performance scanner — KJC-TSK-0149.
+ *
+ * Wraps Google's Lighthouse CLI (`lighthouse`) to produce a structured
+ * Core Web Vitals + opportunity report against a local URL. Same
+ * pattern as sonar-findings.js, osv-findings.js, semgrep-findings.js:
+ * best-effort, missing binary returns {ok:false, reason}, all heavy
+ * lifting happens in an external tool the user installs themselves.
+ *
+ * Output shape is designed to feed two downstream consumers:
+ *   1. The CLI `kj webperf <url>` (KJC-TSK-0149) — print JSON or human
+ *      report, optionally persist to config.webperf.lastResult.
+ *   2. `kj audit` WebPerf section (KJC-TSK-0360) — the `cwv-result` mode
+ *      reads exactly this shape from `config.webperf.lastResult`.
+ *
+ * Lighthouse JSON schema reference:
+ *   https://github.com/GoogleChrome/lighthouse/blob/main/types/lhr/lhr.d.ts
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { evaluateCwv, CWV_THRESHOLDS } from "./cwv-gate.js";
+
+const execFileAsync = promisify(execFile);
+
+const SCAN_TIMEOUT_MS = 120_000;
+const MAX_OPPORTUNITIES = 20;
+
+/**
+ * Opportunity audits we extract from Lighthouse output. Each maps to a
+ * known render-perf issue with actionable fixes; we keep the list short
+ * to bound the payload size and keep the LLM prompt tight when this
+ * result feeds `kj audit`.
+ */
+const OPPORTUNITY_AUDITS = [
+  "render-blocking-resources",
+  "unused-css-rules",
+  "unused-javascript",
+  "unminified-css",
+  "unminified-javascript",
+  "modern-image-formats",
+  "uses-optimized-images",
+  "uses-text-compression",
+  "uses-responsive-images",
+  "uses-rel-preconnect",
+  "uses-rel-preload",
+  "font-display",
+  "preload-lcp-image",
+  "lcp-lazy-loaded",
+  "non-composited-animations",
+  "third-party-summary",
+  "bootup-time",
+  "mainthread-work-breakdown",
+];
+
+/**
+ * Run Lighthouse against a URL and return a structured result.
+ *
+ * @param {string} url - target URL (must be reachable from the runner)
+ * @param {object} [opts]
+ * @param {object} [opts.thresholds] - CWV thresholds override (passed to evaluateCwv)
+ * @param {object} [opts.logger]
+ * @param {string} [opts.preset] - "desktop" or "mobile" (default: desktop)
+ * @param {number} [opts.timeoutMs] - override the 120s default
+ * @returns {Promise<object>} scanner result (see module JSDoc)
+ */
+export async function runWebperfScan(url, opts = {}) {
+  if (!url || typeof url !== "string") {
+    return { ok: false, reason: "no URL provided" };
+  }
+
+  const logger = opts.logger || null;
+  const preset = opts.preset === "mobile" ? "mobile" : "desktop";
+  const timeoutMs = opts.timeoutMs || SCAN_TIMEOUT_MS;
+
+  const lighthouseArgs = [
+    url,
+    "--output=json",
+    "--quiet",
+    "--chrome-flags=--headless --no-sandbox --disable-gpu",
+    `--preset=${preset}`,
+    "--only-categories=performance",
+  ];
+
+  let stdout;
+  try {
+    const result = await execFileAsync("lighthouse", lighthouseArgs, {
+      timeout: timeoutMs,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    stdout = result.stdout;
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      if (logger?.warn) logger.warn("lighthouse not found in PATH — install via 'npm install -g lighthouse'");
+      return { ok: false, reason: "lighthouse not installed", url };
+    }
+    if (err.killed) {
+      return { ok: false, reason: `lighthouse timed out after ${timeoutMs}ms`, url };
+    }
+    if (typeof err.stdout === "string" && err.stdout.trim().startsWith("{")) {
+      stdout = err.stdout;
+    } else {
+      const stderr = (err.stderr || "").trim().split("\n").pop() || err.message;
+      // Lighthouse prints clear NO_DCHECK / NO_NAVSTART errors when the URL
+      // is unreachable. Surface that verbatim.
+      const reason = /failed to fetch|connection refused|net::|navigation_start_time/i.test(stderr)
+        ? `URL ${url} not reachable: ${stderr}`
+        : `lighthouse failed: ${stderr}`;
+      if (logger?.warn) logger.warn(reason);
+      return { ok: false, reason, url };
+    }
+  }
+
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (err) {
+    return { ok: false, reason: `lighthouse output not parseable: ${err.message}`, url };
+  }
+
+  return parseLighthouseReport(report, { url, preset, thresholds: opts.thresholds });
+}
+
+/**
+ * Convert a raw Lighthouse JSON report into the scanner's flat output.
+ * Public so tests can drive parsing without spawning lighthouse.
+ *
+ * @param {object} report - parsed Lighthouse output (lhr)
+ * @param {{url: string, preset?: string, thresholds?: object}} ctx
+ */
+export function parseLighthouseReport(report, ctx = {}) {
+  const audits = report?.audits || {};
+  const metrics = extractMetrics(audits);
+  const issues = extractIssues(audits);
+  const cwv = evaluateCwv(metrics, ctx.thresholds || CWV_THRESHOLDS);
+
+  return {
+    ok: true,
+    url: ctx.url || report?.finalDisplayedUrl || report?.requestedUrl || null,
+    preset: ctx.preset || "desktop",
+    capturedAt: report?.fetchTime || new Date().toISOString(),
+    lighthouseVersion: report?.lighthouseVersion || null,
+    performanceScore: typeof report?.categories?.performance?.score === "number"
+      ? Math.round(report.categories.performance.score * 100)
+      : null,
+    metrics,
+    cwv,
+    issues,
+    thresholds: ctx.thresholds || CWV_THRESHOLDS,
+  };
+}
+
+/**
+ * Pull Core Web Vitals + supporting metrics out of the Lighthouse audit
+ * collection. `numericValue` is the raw measurement Google reports (ms
+ * for time-based metrics, score 0-1 for CLS).
+ */
+function extractMetrics(audits) {
+  const get = (id) => {
+    const v = audits[id]?.numericValue;
+    return typeof v === "number" ? v : null;
+  };
+  return {
+    // CWV — these three drive the cwv-gate verdict
+    lcp: get("largest-contentful-paint"),
+    cls: get("cumulative-layout-shift"),
+    inp: get("interaction-to-next-paint") ?? get("max-potential-fid"),
+    // Supporting (informational)
+    fcp: get("first-contentful-paint"),
+    tbt: get("total-blocking-time"),
+    si: get("speed-index"),
+    tti: get("interactive"),
+  };
+}
+
+/**
+ * Distil the Lighthouse opportunity audits into a flat `issues` array.
+ * Each issue carries the audit id, score, savings (when applicable) and
+ * a one-line description so consumers can prioritise without parsing
+ * the full lhr.
+ */
+function extractIssues(audits) {
+  const issues = [];
+  for (const id of OPPORTUNITY_AUDITS) {
+    const audit = audits[id];
+    if (!audit) continue;
+    // score === 1 means "passed" — skip clean audits
+    if (typeof audit.score === "number" && audit.score >= 1) continue;
+    if (audit.scoreDisplayMode === "notApplicable") continue;
+    issues.push({
+      id,
+      title: audit.title || id,
+      score: typeof audit.score === "number" ? audit.score : null,
+      savingsMs: audit.details?.overallSavingsMs ?? null,
+      savingsBytes: audit.details?.overallSavingsBytes ?? null,
+      severity: scoreToSeverity(audit.score),
+    });
+  }
+  return issues
+    .sort((a, b) => (b.savingsMs || 0) - (a.savingsMs || 0))
+    .slice(0, MAX_OPPORTUNITIES);
+}
+
+function scoreToSeverity(score) {
+  if (typeof score !== "number") return "info";
+  if (score < 0.5) return "high";
+  if (score < 0.9) return "medium";
+  return "low";
+}

--- a/tests/webperf/command-webperf.test.js
+++ b/tests/webperf/command-webperf.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const scanMock = vi.fn();
+
+vi.mock("../../src/webperf/scanner.js", () => ({ runWebperfScan: (...args) => scanMock(...args) }));
+vi.mock("../../src/utils/cli-run-log.js", () => ({
+  withCliRunLog: vi.fn(async (_name, _opts, fn) => {
+    const runLog = { logText: vi.fn(), logEvent: vi.fn(), close: vi.fn() };
+    return fn({ runLog, forwardProgress: vi.fn() });
+  }),
+}));
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+const passingScan = {
+  ok: true,
+  url: "http://localhost:3000",
+  preset: "desktop",
+  capturedAt: "2026-05-04T22:00:00Z",
+  lighthouseVersion: "11.4.0",
+  performanceScore: 92,
+  metrics: { lcp: 1500, cls: 0.05, inp: 100 },
+  cwv: { pass: true, scores: { lcp: { value: 1500, rating: "good" } }, blocking: [], advisory: [] },
+  issues: [],
+};
+
+const failingScan = {
+  ...passingScan,
+  performanceScore: 45,
+  metrics: { lcp: 5000, cls: 0.05, inp: 250 },
+  cwv: {
+    pass: false,
+    scores: { lcp: { value: 5000, rating: "poor" } },
+    blocking: [{ metric: "lcp", value: 5000, threshold: 4000, rating: "poor" }],
+    advisory: [],
+  },
+  issues: [
+    { id: "render-blocking-resources", title: "Eliminate render-blocking", score: 0.3, savingsMs: 800, severity: "high" },
+  ],
+};
+
+let tmpHome, tmpProject, originalHome;
+let consoleSpy;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  scanMock.mockResolvedValue(passingScan);
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-webperf-cmd-"));
+  tmpProject = path.join(tmpHome, "my-project");
+  await fs.mkdir(tmpProject, { recursive: true });
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  consoleSpy.mockRestore();
+  process.env.HOME = originalHome;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+function makeConfig() { return { projectDir: tmpProject }; }
+
+describe("kj webperf command (KJC-TSK-0149)", () => {
+  it("requires a URL", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await expect(
+      webperfCommand({ url: null, config: makeConfig(), logger: noopLogger })
+    ).rejects.toThrow(/url.*required/i);
+  });
+
+  it("prints human-readable report by default and exits ok=true on PASS verdict", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    const r = await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger });
+
+    expect(r.ok).toBe(true);
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("## WebPerf Scan");
+    expect(stdout).toContain("Verdict: PASS");
+    expect(stdout).toContain("Performance score: 92/100");
+  });
+
+  it("returns ok=false (non-zero exit) on FAIL verdict", async () => {
+    scanMock.mockResolvedValueOnce(failingScan);
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    const r = await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger });
+
+    expect(r.ok).toBe(false);
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("Verdict: FAIL");
+    expect(stdout).toContain("render-blocking-resources");
+    expect(stdout).toContain("(saves ~800ms)");
+  });
+
+  it("--json emits raw JSON", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger, json: true });
+
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    const parsed = JSON.parse(stdout);
+    expect(parsed.cwv.pass).toBe(true);
+    expect(parsed.url).toBe("http://localhost:3000");
+  });
+
+  it("--mobile passes the mobile preset to the scanner", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger, mobile: true });
+
+    expect(scanMock).toHaveBeenCalledWith("http://localhost:3000", expect.objectContaining({ preset: "mobile" }));
+  });
+
+  it("persists the result to ~/.karajan/webperf/<slug>/last.json", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger });
+
+    const slug = path.basename(tmpProject).replace(/[^a-zA-Z0-9_-]/g, "_");
+    const expected = path.join(tmpHome, ".karajan", "webperf", slug, "last.json");
+    const written = JSON.parse(await fs.readFile(expected, "utf8"));
+    expect(written.url).toBe("http://localhost:3000");
+    expect(written.cwv.pass).toBe(true);
+  });
+
+  it("--no-persist skips the disk write", async () => {
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger, persist: false });
+
+    const slug = path.basename(tmpProject).replace(/[^a-zA-Z0-9_-]/g, "_");
+    const target = path.join(tmpHome, ".karajan", "webperf", slug, "last.json");
+    await expect(fs.access(target)).rejects.toThrow();
+  });
+
+  it("returns ok=false with reason when scanner returns ok=false", async () => {
+    scanMock.mockResolvedValueOnce({ ok: false, reason: "lighthouse not installed" });
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    const r = await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger });
+
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/not installed/);
+    const stdout = consoleSpy.mock.calls.map(c => c[0]).join("\n");
+    expect(stdout).toContain("WebPerf scan FAILED");
+  });
+
+  it("end-to-end: kj webperf writes a scan that kj audit reads as cwv-result", async () => {
+    // Step 1: run webperf, persist
+    const { webperfCommand } = await import("../../src/commands/webperf.js");
+    await webperfCommand({ url: "http://localhost:3000", config: makeConfig(), logger: noopLogger });
+
+    // Step 2: run collectWebPerfInput against the same projectDir
+    const { collectWebPerfInput } = await import("../../src/audit/webperf-input.js");
+    const r = collectWebPerfInput(
+      { isFrontend: true, isBackend: false, isFullstack: false },
+      { projectDir: tmpProject, webperf: {} }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("cwv-result");
+    expect(r.url).toBe("http://localhost:3000");
+  });
+});

--- a/tests/webperf/scanner.test.js
+++ b/tests/webperf/scanner.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Same promisify trick as osv-findings / semgrep tests so we can drive
+// runWebperfScan without depending on lighthouse being installed.
+const execFileMock = vi.fn();
+
+vi.mock("node:util", async () => {
+  const actual = await vi.importActual("node:util");
+  return {
+    ...actual,
+    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
+  };
+});
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+import { runWebperfScan, parseLighthouseReport } from "../../src/webperf/scanner.js";
+
+const noopLogger = { warn: vi.fn(), info: vi.fn() };
+
+// Minimal lighthouse JSON fixture covering the audit ids the scanner cares about.
+function lighthouseFixture(overrides = {}) {
+  return {
+    fetchTime: "2026-05-04T22:00:00.000Z",
+    requestedUrl: "http://localhost:3000",
+    finalDisplayedUrl: "http://localhost:3000",
+    lighthouseVersion: "11.4.0",
+    categories: { performance: { score: 0.78 } },
+    audits: {
+      "largest-contentful-paint": { numericValue: 5000 },
+      "cumulative-layout-shift": { numericValue: 0.05 },
+      "interaction-to-next-paint": { numericValue: 250 },
+      "first-contentful-paint": { numericValue: 1500 },
+      "total-blocking-time": { numericValue: 300 },
+      "speed-index": { numericValue: 2500 },
+      "interactive": { numericValue: 3500 },
+      "render-blocking-resources": {
+        title: "Eliminate render-blocking resources",
+        score: 0.3,
+        details: { overallSavingsMs: 800 },
+      },
+      "unused-css-rules": {
+        title: "Reduce unused CSS",
+        score: 0.6,
+        details: { overallSavingsMs: 200, overallSavingsBytes: 12000 },
+      },
+      "modern-image-formats": {
+        title: "Serve images in next-gen formats",
+        score: 1, // passed — should be filtered
+      },
+      "third-party-summary": {
+        title: "Minimize third-party usage",
+        scoreDisplayMode: "notApplicable",
+      },
+      ...(overrides.audits || {}),
+    },
+  };
+}
+
+describe("runWebperfScan (KJC-TSK-0149)", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns ok=false with no URL", async () => {
+    const r = await runWebperfScan(null);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/no URL/);
+  });
+
+  it("returns ok=false when lighthouse is not installed (ENOENT)", async () => {
+    const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });
+    execFileMock.mockRejectedValue(enoErr);
+
+    const r = await runWebperfScan("http://localhost:3000", { logger: noopLogger });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/not installed/);
+    expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringContaining("lighthouse not found"));
+  });
+
+  it("returns ok=false when scan times out", async () => {
+    const timeoutErr = Object.assign(new Error("killed"), { killed: true });
+    execFileMock.mockRejectedValue(timeoutErr);
+
+    const r = await runWebperfScan("http://localhost:3000", { timeoutMs: 5000 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/timed out/);
+  });
+
+  it("returns ok=false with a clear message when the URL is unreachable", async () => {
+    const fetchErr = Object.assign(new Error("exit 1"), {
+      code: 1,
+      stdout: "",
+      stderr: "Runtime error encountered: net::ERR_CONNECTION_REFUSED",
+    });
+    execFileMock.mockRejectedValue(fetchErr);
+
+    const r = await runWebperfScan("http://localhost:3000");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/not reachable/);
+    expect(r.url).toBe("http://localhost:3000");
+  });
+
+  it("rescues exit-code-non-zero with valid JSON stdout (lighthouse warning exit)", async () => {
+    const err = Object.assign(new Error("exit 1"), {
+      code: 1,
+      stdout: JSON.stringify(lighthouseFixture()),
+      stderr: "warning: ...",
+    });
+    execFileMock.mockRejectedValue(err);
+
+    const r = await runWebperfScan("http://localhost:3000");
+    expect(r.ok).toBe(true);
+    expect(r.metrics.lcp).toBe(5000);
+  });
+
+  it("returns structured CWV + opportunities on a clean scan", async () => {
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(lighthouseFixture()), stderr: "" });
+
+    const r = await runWebperfScan("http://localhost:3000");
+    expect(r.ok).toBe(true);
+    expect(r.url).toBe("http://localhost:3000");
+    expect(r.preset).toBe("desktop");
+    expect(r.performanceScore).toBe(78);
+    expect(r.metrics).toMatchObject({ lcp: 5000, cls: 0.05, inp: 250 });
+    expect(r.cwv.pass).toBe(false); // LCP 5000 > poor 4000
+    expect(r.cwv.blocking).toEqual(expect.arrayContaining([expect.objectContaining({ metric: "lcp" })]));
+    expect(r.issues).toHaveLength(2); // render-blocking + unused-css; modern-image-formats passed; third-party N/A
+    expect(r.issues[0].id).toBe("render-blocking-resources"); // sorted by savingsMs desc
+    expect(r.issues[0].severity).toBe("high"); // score 0.3
+  });
+
+  it("uses the mobile preset when requested", async () => {
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(lighthouseFixture()), stderr: "" });
+
+    const r = await runWebperfScan("http://localhost:3000", { preset: "mobile" });
+    expect(r.preset).toBe("mobile");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "lighthouse",
+      expect.arrayContaining(["--preset=mobile"]),
+      expect.any(Object)
+    );
+  });
+
+  it("honors custom thresholds for the verdict", async () => {
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(lighthouseFixture()), stderr: "" });
+
+    // Loosen LCP threshold so the same metric passes.
+    const r = await runWebperfScan("http://localhost:3000", {
+      thresholds: { lcp: { good: 6000, poor: 8000 } },
+    });
+    expect(r.cwv.pass).toBe(true);
+  });
+
+  it("falls back to max-potential-fid when interaction-to-next-paint is missing", async () => {
+    const fixture = lighthouseFixture();
+    delete fixture.audits["interaction-to-next-paint"];
+    fixture.audits["max-potential-fid"] = { numericValue: 180 };
+    execFileMock.mockResolvedValue({ stdout: JSON.stringify(fixture), stderr: "" });
+
+    const r = await runWebperfScan("http://localhost:3000");
+    expect(r.metrics.inp).toBe(180);
+  });
+});
+
+describe("parseLighthouseReport", () => {
+  it("filters out passed audits (score === 1)", () => {
+    const r = parseLighthouseReport(lighthouseFixture());
+    const ids = r.issues.map(i => i.id);
+    expect(ids).not.toContain("modern-image-formats");
+  });
+
+  it("filters out N/A audits (notApplicable)", () => {
+    const r = parseLighthouseReport(lighthouseFixture());
+    const ids = r.issues.map(i => i.id);
+    expect(ids).not.toContain("third-party-summary");
+  });
+
+  it("caps issues at MAX_OPPORTUNITIES", () => {
+    // Manufacture more opportunities than the cap allows
+    const audits = {};
+    for (let i = 0; i < 30; i++) {
+      audits[`opp-${i}`] = { score: 0.5, details: { overallSavingsMs: i } };
+    }
+    // We can only test the cap on KNOWN opportunity audits.
+    // Use the known list and stuff each with a low score.
+    const knownAudits = {};
+    const KNOWN = [
+      "render-blocking-resources", "unused-css-rules", "unused-javascript",
+      "unminified-css", "unminified-javascript", "modern-image-formats",
+      "uses-optimized-images", "uses-text-compression", "uses-responsive-images",
+      "uses-rel-preconnect", "uses-rel-preload", "font-display",
+      "preload-lcp-image", "lcp-lazy-loaded", "non-composited-animations",
+      "third-party-summary", "bootup-time", "mainthread-work-breakdown",
+    ];
+    for (const id of KNOWN) {
+      knownAudits[id] = { title: id, score: 0.4, details: { overallSavingsMs: 100 } };
+    }
+    const fixture = lighthouseFixture({ audits: knownAudits });
+    const r = parseLighthouseReport(fixture);
+    expect(r.issues.length).toBeLessThanOrEqual(20);
+  });
+
+  it("handles a report missing categories.performance gracefully", () => {
+    const fixture = lighthouseFixture();
+    delete fixture.categories.performance;
+    const r = parseLighthouseReport(fixture);
+    expect(r.performanceScore).toBeNull();
+  });
+});

--- a/tests/webperf/webperf-input-discovery.test.js
+++ b/tests/webperf/webperf-input-discovery.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { collectWebPerfInput } from "../../src/audit/webperf-input.js";
+
+// Verifies the new lastResultPath / fallback discovery logic added in
+// KJC-TSK-0149 so `kj audit` reads the file `kj webperf` writes.
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-webperf-input-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const sampleScan = {
+  url: "http://localhost:3000",
+  capturedAt: "2026-05-04T22:00:00Z",
+  metrics: { lcp: 5000, cls: 0.05, inp: 250 },
+  cwv: {
+    pass: false,
+    scores: { lcp: { value: 5000, rating: "poor" } },
+    blocking: [{ metric: "lcp", value: 5000, threshold: 4000, rating: "poor" }],
+    advisory: [],
+  },
+};
+
+describe("collectWebPerfInput — persisted scan discovery (KJC-TSK-0149 wiring)", () => {
+  it("picks up an explicit config.webperf.lastResultPath", () => {
+    const target = path.join(tmpDir, "scan.json");
+    fs.writeFileSync(target, JSON.stringify(sampleScan));
+
+    const r = collectWebPerfInput(
+      { isFrontend: true, isBackend: false, isFullstack: false },
+      { webperf: { lastResultPath: target } }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("cwv-result");
+    expect(r.url).toBe("http://localhost:3000");
+    expect(r.cwv.pass).toBe(false);
+  });
+
+  it("falls back to ~/.karajan/webperf/<slug>/last.json discovery via projectDir", () => {
+    // Point HOME at our tmp so the fallback path lands inside it.
+    const originalHome = os.homedir();
+    const originalEnv = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const projectDir = path.join(tmpDir, "my-project");
+      fs.mkdirSync(projectDir, { recursive: true });
+      const slug = path.basename(projectDir).replace(/[^a-zA-Z0-9_-]/g, "_");
+      const fallbackDir = path.join(tmpDir, ".karajan", "webperf", slug);
+      fs.mkdirSync(fallbackDir, { recursive: true });
+      fs.writeFileSync(path.join(fallbackDir, "last.json"), JSON.stringify(sampleScan));
+
+      const r = collectWebPerfInput(
+        { isFrontend: true, isBackend: false, isFullstack: false },
+        { projectDir, webperf: {} }
+      );
+      expect(r.available).toBe(true);
+      expect(r.mode).toBe("cwv-result");
+      expect(r.url).toBe("http://localhost:3000");
+    } finally {
+      process.env.HOME = originalEnv;
+      // Sanity assertion the homedir override was effective during the test
+      void originalHome;
+    }
+  });
+
+  it("inline config.webperf.lastResult still works (back-compat)", () => {
+    const r = collectWebPerfInput(
+      null,
+      { webperf: { lastResult: { metrics: { lcp: 1000, cls: 0.05, inp: 100 } } } }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("cwv-result");
+    expect(r.cwv.pass).toBe(true); // good thresholds across the board
+  });
+
+  it("falls through to static-hints when persisted file is missing", () => {
+    const r = collectWebPerfInput(
+      { isFrontend: true, isBackend: false, isFullstack: false },
+      { webperf: { lastResultPath: path.join(tmpDir, "does-not-exist.json") } }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("static-hints");
+  });
+
+  it("falls through to static-hints when persisted file is unparseable", () => {
+    const target = path.join(tmpDir, "garbage.json");
+    fs.writeFileSync(target, "not json {{{");
+
+    const r = collectWebPerfInput(
+      { isFrontend: true, isBackend: false, isFullstack: false },
+      { webperf: { lastResultPath: target } }
+    );
+    expect(r.available).toBe(true);
+    expect(r.mode).toBe("static-hints");
+  });
+});


### PR DESCRIPTION
## Summary

KJC-TSK-0149 — Closes the loop opened by **KJC-TSK-0360** in v2.9.0. The audit's `cwv-result` mode existed in code but had no producer — nobody wrote `config.webperf.lastResult`. This PR adds the producer (`kj webperf`) and auto-discovery on the consumer side.

## What's new

### `kj webperf <url>` command
```bash
kj webperf http://localhost:3000           # desktop preset, human report
kj webperf http://localhost:3000 --mobile  # mobile preset
kj webperf http://localhost:3000 --json    # raw JSON for CI
kj webperf http://localhost:3000 --no-persist  # don't write to ~/.karajan
```
Exit codes: 0 PASS, 1 FAIL — gateable in CI.

### Three-source auto-discovery in `kj audit`
Pre-PR, `kj audit` read `cwv-result` only from inline `config.webperf.lastResult`. Now:
1. Inline `webperf.lastResult` (back-compat)
2. Explicit `webperf.lastResultPath` (auto-set by `kj webperf` patching kj.config.yml)
3. **Fallback**: `~/.karajan/webperf/<projectSlug>/last.json` — zero-config user journey

Run `kj webperf` once → every subsequent `kj audit` shows the verdict in the WebPerf section automatically.

### Scanner internals
- `src/webperf/scanner.js`: `runWebperfScan(url, opts)` shell-wraps `lighthouse --output=json --quiet --chrome-flags=...`
- Best-effort: missing binary, 120s timeout, unreachable URL, unparseable output → `{ok:false, reason}`
- Rescues exit-1-with-valid-JSON-stdout (lighthouse warning convention)
- Extracts CWV (LCP/CLS/INP) + supporting (FCP/TBT/SI/TTI) + curated opportunities
- Reuses `evaluateCwv` from `cwv-gate.js` for the verdict

## Test plan
- [x] `npx vitest run tests/webperf/` — 27 new tests passing
- [x] `npx vitest run` — **4332/4332 passing** (27 added)

## Stacked on
Branched from main. Required by KJC-TSK-0150 (PerfRole quality gate) and KJC-TSK-0151 (pipeline integration), which will be the next two PRs.