### PR TITLE
docs: document optional scanners (lighthouse / osv-scanner / semgrep / sonar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ cd wrappers/python && pip install .
 
 That's it. `kj init` auto-detects your installed agents and installs RTK for token optimization.
 
+### Optional scanners for `kj audit` + `kj webperf`
+
+Karajan auto-skips any scanner that isn't installed. Add the ones that match your projects:
+
+| Tool | Install | What you get |
+|------|---------|--------------|
+| **SonarQube** | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | Code quality + security rules with line-precision in `kj audit` |
+| **OSV-Scanner** | `go install github.com/google/osv-scanner@latest` | Dependency CVE coverage broader than `npm audit` |
+| **Semgrep** | `pipx install semgrep` | SAST: XSS, SQLi, taint flow, secrets — equivalent to `snyk code`, free for OSS |
+| **Lighthouse** | `npm install -g lighthouse` | Core Web Vitals + opportunities for `kj webperf` (auto-feeds `kj audit`) |
+
+Skip any per-run with `--no-sonar`, `--no-osv`, `--no-semgrep`. See [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md#optional-scanners--kj-audit--kj-webperf) for full table.
+
 ## Three ways to use Karajan
 
 Karajan installs **three commands**: `kj`, `kj-tail`, and `karajan-mcp`.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -2,11 +2,24 @@
 
 ## Prerequisites
 
-- Node.js ≥ 18
+- Node.js ≥ 20.10
 - Git
 - At least one AI CLI installed: `claude`, `codex`, `gemini`, `aider`, or `opencode`
 - (Optional) Docker for local SonarQube
 - (Optional) RTK for token savings: `cargo install rtk`
+
+### Optional scanners — `kj audit` + `kj webperf`
+
+Karajan's audit pipeline runs deterministic scanners in parallel and feeds their findings into the LLM prompt. **None are required** — Karajan auto-skips any that aren't installed, with a friendly hint. Install whichever match the kind of project you audit.
+
+| Tool | Install | Used by | Gives you |
+|------|---------|---------|-----------|
+| **SonarQube** | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | `kj audit`, `kj run` | Code quality + security rules with line-precision; `kj audit` cross-references the LLM's findings against Sonar rule IDs |
+| **OSV-Scanner** | `go install github.com/google/osv-scanner@latest` | `kj audit` | Dependency CVE coverage broader than `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + others). No account, no upload |
+| **Semgrep** | `pipx install semgrep` (or `brew install semgrep`) | `kj audit` | SAST: XSS, SQLi, taint flow, hardcoded secrets, language-specific anti-patterns. Equivalent to `snyk code` but free for OSS. `--config auto` ships 2 000+ rules |
+| **Lighthouse** | `npm install -g lighthouse` | `kj webperf`, `kj audit` (when scan exists) | Core Web Vitals (LCP, CLS, INP) + opportunity audits (render-blocking, unused CSS, image format, font-display) for frontend projects. `kj webperf` writes the result to `~/.karajan/webperf/<slug>/last.json` and `kj audit` reads it automatically |
+
+Skip any of them per-run with the matching `--no-*` flag (`--no-sonar`, `--no-osv`, `--no-semgrep`).
 
 ## Install
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -2,11 +2,24 @@
 
 ## Requisitos previos
 
-- Node.js ≥ 18
+- Node.js ≥ 20.10
 - Git
 - Al menos una CLI de IA instalada: `claude`, `codex`, `gemini`, `aider` u `opencode`
 - (Opcional) Docker para SonarQube local
 - (Opcional) RTK para ahorro de tokens: `cargo install rtk`
+
+### Scanners opcionales — `kj audit` + `kj webperf`
+
+El pipeline de audit de Karajan corre scanners deterministas en paralelo y mete sus hallazgos en el prompt del LLM. **Ninguno es obligatorio** — Karajan se salta los que no estén instalados, con un hint amigable. Instala los que correspondan al tipo de proyecto que auditas.
+
+| Tool | Instalación | Usado por | Te da |
+|------|-------------|-----------|-------|
+| **SonarQube** | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | `kj audit`, `kj run` | Code quality + security rules con line-precision; `kj audit` cruza los hallazgos del LLM con los rule IDs de Sonar |
+| **OSV-Scanner** | `go install github.com/google/osv-scanner@latest` | `kj audit` | Cobertura CVE de dependencias más amplia que `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + otros). Sin cuenta, sin upload |
+| **Semgrep** | `pipx install semgrep` (o `brew install semgrep`) | `kj audit` | SAST: XSS, SQLi, taint flow, secrets hardcodeados, anti-patrones específicos por lenguaje. Equivalente a `snyk code` pero gratis para OSS. `--config auto` trae 2 000+ reglas |
+| **Lighthouse** | `npm install -g lighthouse` | `kj webperf`, `kj audit` (cuando hay scan) | Core Web Vitals (LCP, CLS, INP) + audits de oportunidades (render-blocking, CSS sin uso, formato de imagen, font-display) para proyectos frontend. `kj webperf` escribe el resultado en `~/.karajan/webperf/<slug>/last.json` y `kj audit` lo lee automáticamente |
+
+Saltar cualquiera por ejecución con el flag `--no-*` correspondiente (`--no-sonar`, `--no-osv`, `--no-semgrep`).
 
 ## Instalación
 


### PR DESCRIPTION
## Summary

The v2.9 audit overhaul added three deterministic security collectors (Sonar findings, OSV-Scanner, Semgrep SAST) and the post-release #602/#603 added a Lighthouse-based webperf scanner. **All four are best-effort** — Karajan auto-skips any that aren't installed — but **none were documented anywhere**. New users had no way to discover what to install to unlock each collector.

## What's new

### `README.md` (new "Optional scanners" subsection under Install)
4-row table: SonarQube, OSV-Scanner, Semgrep, Lighthouse. Each row: tool, install command, what you get. Pointer to GETTING-STARTED for the full table with --no-* flags.

### `docs/GETTING-STARTED.md` (new "Optional scanners — kj audit + kj webperf" under Prerequisites)
Full 4-row table including which kj command uses each, plus the corresponding `--no-*` skip flag.

Also bumps the Node.js prereq from 18 to 20.10 (fixed since v2.8.0 but the doc still said 18).

### `docs/es/GETTING-STARTED.md`
Spanish mirror, same structure.

## Why we don't add these to `package.json`

Intentional. lighthouse + chrome-launcher = ~150MB; semgrep + Python deps = ~200MB; osv-scanner = Go binary. Bundling any of them into the global `kj` install would bloat every user that never opts into the matching feature. Same pattern as the existing optional RTK and SonarQube prereqs. Documenting the install path is the right trade-off.

## Files
- `README.md` (+13 lines, the install table)
- `docs/GETTING-STARTED.md` (+13 lines, the full table; fixes Node prereq 18→20.10)
- `docs/es/GETTING-STARTED.md` (+13 lines, mirror)

## Test plan
- [x] No code change → no test impact (pure docs)
- [x] Manual: tables render in markdown previews