### PR TITLE
feat(perf): wire PerfStage into iteration loop (KJC-TSK-0151)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -58,6 +58,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--enable-tester")
     .option("--enable-security")
     .option("--enable-impeccable")
+    .option("--enable-perf")
     .option("--enable-triage")
     .option("--enable-discover")
     .option("--enable-architect")

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -37,6 +37,7 @@ const DEFAULTS = {
     tester: { enabled: true },
     security: { enabled: true },
     impeccable: { enabled: false },
+    perf: { enabled: false },
     triage: { enabled: true },
     discover: { enabled: false },
     architect: { enabled: false },

--- a/src/config/overrides.js
+++ b/src/config/overrides.js
@@ -37,6 +37,7 @@ const PIPELINE_ENABLE_FLAGS = [
   ["enablePlanner", "planner"], ["enableRefactorer", "refactorer"],
   ["enableSolomon", "solomon"], ["enableResearcher", "researcher"],
   ["enableTester", "tester"], ["enableSecurity", "security"], ["enableImpeccable", "impeccable"],
+  ["enablePerf", "perf"],
   ["enableTriage", "triage"], ["enableDiscover", "discover"],
   ["enableArchitect", "architect"],
   ["enableHuReviewer", "hu_reviewer"]

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -89,6 +89,7 @@ const PipelineMap = v.optional(v.looseObject({
   tester: v.optional(PipelineEntry),
   security: v.optional(PipelineEntry),
   impeccable: v.optional(PipelineEntry),
+  perf: v.optional(PipelineEntry),
   triage: v.optional(PipelineEntry),
   discover: v.optional(PipelineEntry),
   architect: v.optional(PipelineEntry),

--- a/src/mcp/handlers/run-handler.js
+++ b/src/mcp/handlers/run-handler.js
@@ -263,7 +263,7 @@ export async function handleResume(a, server, extra) {
     }
     a.answer = validation.sanitized;
   }
-  applySessionOverrides(a, ["coder", "reviewer", "tester", "security", "solomon", "enableTester", "enableSecurity", "enableImpeccable"]);
+  applySessionOverrides(a, ["coder", "reviewer", "tester", "security", "solomon", "enableTester", "enableSecurity", "enableImpeccable", "enablePerf"]);
   return handleResumeDirect(a, server, extra);
 }
 
@@ -303,6 +303,6 @@ export async function handleRun(a, server, extra) {
     const logger = createLogger("info", "mcp");
     logger.info("Preflight auto-acknowledged with default agent config");
   }
-  applySessionOverrides(a, ["coder", "reviewer", "tester", "security", "solomon", "enableTester", "enableSecurity", "enableImpeccable"]);
+  applySessionOverrides(a, ["coder", "reviewer", "tester", "security", "solomon", "enableTester", "enableSecurity", "enableImpeccable", "enablePerf"]);
   return handleRunDirect(a, server, extra);
 }

--- a/src/mcp/run-kj.js
+++ b/src/mcp/run-kj.js
@@ -50,6 +50,7 @@ export async function runKjCommand({ command, commandArgs = [], options = {}, en
   normalizeBoolFlag(options.enableTester, "--enable-tester", args);
   normalizeBoolFlag(options.enableSecurity, "--enable-security", args);
   normalizeBoolFlag(options.enableImpeccable, "--enable-impeccable", args);
+  normalizeBoolFlag(options.enablePerf, "--enable-perf", args);
   normalizeBoolFlag(options.design, "--design", args);
   normalizeBoolFlag(options.enableTriage, "--enable-triage", args);
   normalizeBoolFlag(options.enableDiscover, "--enable-discover", args);

--- a/src/mcp/sovereignty-guard.js
+++ b/src/mcp/sovereignty-guard.js
@@ -14,7 +14,7 @@ const ALLOWED_PARAMS = new Set([
   "planner", "coder", "reviewer", "refactorer",
   "plannerModel", "coderModel", "reviewerModel", "refactorerModel",
   "enablePlanner", "enableReviewer", "enableRefactorer", "enableResearcher",
-  "enableTester", "enableSecurity", "enableImpeccable",
+  "enableTester", "enableSecurity", "enableImpeccable", "enablePerf",
   "enableDiscover", "enableArchitect",
   "architectModel", "huFile",
   "enableSerena", "enableCi",

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -76,6 +76,7 @@ export const tools = [
         enableTester: { type: "boolean" },
         enableSecurity: { type: "boolean" },
         enableImpeccable: { type: "boolean" },
+        enablePerf: { type: "boolean" },
         enableTriage: { type: "boolean" },
         enableDiscover: { type: "boolean" },
         enableArchitect: { type: "boolean" },

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -217,6 +217,7 @@ export function resolvePipelineFlags(config) {
     testerEnabled: Boolean(config.pipeline?.tester?.enabled),
     securityEnabled: Boolean(config.pipeline?.security?.enabled),
     impeccableEnabled: Boolean(config.pipeline?.impeccable?.enabled),
+    perfEnabled: Boolean(config.pipeline?.perf?.enabled),
     reviewerEnabled: config.pipeline?.reviewer?.enabled !== false,
     discoverEnabled: Boolean(config.pipeline?.discover?.enabled),
     architectEnabled: Boolean(config.pipeline?.architect?.enabled),
@@ -225,7 +226,7 @@ export function resolvePipelineFlags(config) {
 }
 
 export async function handleDryRun({ task, config, flags, emitter, pipelineFlags }) {
-  const { plannerEnabled, refactorerEnabled, researcherEnabled, testerEnabled, securityEnabled, impeccableEnabled, reviewerEnabled, discoverEnabled, architectEnabled, huReviewerEnabled } = pipelineFlags;
+  const { plannerEnabled, refactorerEnabled, researcherEnabled, testerEnabled, securityEnabled, impeccableEnabled, perfEnabled, reviewerEnabled, discoverEnabled, architectEnabled, huReviewerEnabled } = pipelineFlags;
   const plannerRole = resolveRole(config, "planner");
   const coderRole = resolveRole(config, "coder");
   const reviewerRole = resolveRole(config, "reviewer");
@@ -259,6 +260,7 @@ export async function handleDryRun({ task, config, flags, emitter, pipelineFlags
       tester_enabled: testerEnabled,
       security_enabled: securityEnabled,
       impeccable_enabled: impeccableEnabled,
+      perf_enabled: perfEnabled,
       solomon_enabled: Boolean(config.pipeline?.solomon?.enabled),
       hu_reviewer_enabled: huReviewerEnabled
     },

--- a/src/orchestrator/drivers/iteration-phases/quality-gates.js
+++ b/src/orchestrator/drivers/iteration-phases/quality-gates.js
@@ -18,6 +18,7 @@ import {
   runTddCheckStage, runSonarStage, runSonarCloudStage,
 } from "../../iteration-stages.js";
 import { runImpeccableStage } from "../../post-loop-stages.js";
+import { runPerfStage } from "../../stages/perf-stage.js";
 import { tryCiComment } from "../../ci-integration.js";
 
 export async function runQualityGateStages({ config, logger, emitter, eventBase, session, trackBudget, i, askQuestion, repeatDetector, budgetSummary, sonarState, task, stageResults, coderRole, pipelineFlags, brainCtx }) {
@@ -70,6 +71,17 @@ export async function runQualityGateStages({ config, logger, emitter, eventBase,
     if (impeccableResult.stageResult) {
       stageResults.impeccable = impeccableResult.stageResult;
     }
+  }
+
+  if (pipelineFlags?.perfEnabled) {
+    const perfResult = await runPerfStage({
+      config, logger, emitter, eventBase, session, trackBudget,
+      iteration: i, task, brainCtx
+    });
+    if (perfResult.stageResult) {
+      stageResults.perf = perfResult.stageResult;
+    }
+    if (perfResult.action === "continue") return { action: "continue" };
   }
 
   return { action: "ok" };

--- a/src/orchestrator/session-journal.js
+++ b/src/orchestrator/session-journal.js
@@ -239,6 +239,7 @@ export function buildPlanSummary({ pipelineFlags, config, stageResults, task }) 
   if (pipelineFlags.testerEnabled) activeStages.push("Tester");
   if (pipelineFlags.securityEnabled) activeStages.push("Security");
   if (pipelineFlags.impeccableEnabled) activeStages.push("Impeccable");
+  if (pipelineFlags.perfEnabled) activeStages.push("Perf");
   lines.push(`│ Stages: ${activeStages.join(" → ")}`);
 
   // Config

--- a/src/orchestrator/stages/perf-stage.js
+++ b/src/orchestrator/stages/perf-stage.js
@@ -1,0 +1,140 @@
+/**
+ * PerfStage — webperf quality gate inside the iteration loop.
+ *
+ * KJC-TSK-0151. Wraps PerfRole and slots into the existing
+ * runQualityGateStages flow alongside Sonar and Impeccable. Designed
+ * to be the simplest possible quality gate:
+ *
+ *   - PASS verdict (cwv.pass === true) → return ok, iteration continues.
+ *   - FAIL verdict → set reviewer feedback with the blocking metrics
+ *     so the coder receives concrete guidance next iteration. Returns
+ *     `continue` to retry the iteration loop. No repeat-detector +
+ *     retry-limit machinery: rerunning Lighthouse on the same URL
+ *     gives the same result unless the coder changes something, and
+ *     the iteration limit (max_iterations) is the natural ceiling.
+ *   - Scanner unavailable (lighthouse missing, URL unreachable, timeout)
+ *     → log a warn and return ok-skipped. Best-effort, never blocks
+ *     the pipeline by itself.
+ *
+ * The role surface (PerfRole) is responsible for persisting the result
+ * to ~/.karajan/webperf/<slug>/last.json so subsequent `kj audit` runs
+ * pick it up via the auto-discovery added in #602.
+ */
+
+import { PerfRole } from "../../roles/perf-role.js";
+import { setReviewerFeedback } from "../../session/mutators.js";
+import { saveSession } from "../../session/store.js";
+import { emitProgress, makeEvent } from "../../utils/events.js";
+
+/**
+ * Build the human-readable feedback line that goes back to the coder
+ * on FAIL. Concrete enough that the LLM can act on it without re-reading
+ * the whole report.
+ */
+function buildFeedback(roleResult) {
+  const { result } = roleResult;
+  const score = typeof result.performanceScore === "number" ? result.performanceScore : null;
+  const blocking = (result.cwv?.blocking || []).map(b => `${b.metric.toUpperCase()}=${Math.round(b.value)} (poor>${b.threshold})`);
+  const top = (result.issues || []).slice(0, 3).map(i => `${i.id}${i.savingsMs ? ` (~${Math.round(i.savingsMs)}ms)` : ""}`);
+
+  const lines = [`Webperf gate FAILED${score !== null ? ` (score ${score}/100)` : ""}.`];
+  if (blocking.length > 0) lines.push(`Blocking metrics: ${blocking.join(", ")}.`);
+  if (top.length > 0) lines.push(`Top opportunities: ${top.join(", ")}.`);
+  lines.push("Address the blocking metric(s) before the next iteration; rerunning without code changes will produce the same verdict.");
+  return lines.join(" ");
+}
+
+/**
+ * Run the perf gate against config.webperf.url.
+ *
+ * @returns {Promise<{action: "ok"|"continue", stageResult?: object, summary?: string}>}
+ */
+export async function runPerfStage({ config, logger, emitter, eventBase, session, trackBudget, iteration, task: _task, brainCtx }) {
+  if (!session) {
+    throw new Error("runPerfStage: `session` is required.");
+  }
+  logger.setContext({ iteration, stage: "perf" });
+  emitProgress(
+    emitter,
+    makeEvent("perf:start", { ...eventBase, stage: "perf" }, {
+      message: "WebPerf gate scanning",
+      detail: { url: config?.webperf?.url || null, preset: config?.webperf?.preset || "desktop" },
+    })
+  );
+
+  const role = new PerfRole({ config, logger, emitter });
+  const roleResult = await role.execute();
+
+  // Track budget — the role doesn't spawn an LLM but it does consume wall
+  // time; surface that in the budget summary alongside the agent calls.
+  if (trackBudget) {
+    try { trackBudget("perf", { tokens_in: 0, tokens_out: 0, cost_usd: 0 }); } catch { /* best-effort */ }
+  }
+
+  // Scanner unavailable → skip with warn. PerfRole returns ok=false for
+  // both "verdict FAIL" and "scanner failed", so we differentiate on the
+  // result.error field (set only by the second case).
+  if (!roleResult.ok && roleResult.result?.error) {
+    logger.warn(`Perf gate skipped: ${roleResult.result.error}`);
+    emitProgress(emitter, makeEvent("perf:end", { ...eventBase, stage: "perf" }, {
+      status: "warn",
+      message: `Perf gate skipped — ${roleResult.result.error}`,
+    }));
+    return { action: "ok", stageResult: { skipped: true, reason: roleResult.result.error } };
+  }
+
+  // PASS verdict
+  if (roleResult.ok === true) {
+    emitProgress(emitter, makeEvent("perf:end", { ...eventBase, stage: "perf" }, {
+      status: "ok",
+      message: roleResult.summary,
+    }));
+    return {
+      action: "ok",
+      stageResult: {
+        verdict: "PASS",
+        url: roleResult.result?.url,
+        performanceScore: roleResult.result?.performanceScore,
+        cwv: roleResult.result?.cwv,
+        savedPath: roleResult.result?.savedPath,
+        summary: roleResult.summary,
+      },
+    };
+  }
+
+  // FAIL verdict → push concrete feedback to the coder for next iteration.
+  const feedback = buildFeedback(roleResult);
+  setReviewerFeedback(session, feedback);
+  await saveSession(session);
+
+  // Brain: when enabled, surface perf feedback on the queue too.
+  if (brainCtx?.enabled) {
+    try {
+      const { processRoleOutput } = await import("../brain-coordinator.js");
+      processRoleOutput(brainCtx, {
+        roleName: "perf",
+        output: { verdict: "fail", summary: feedback },
+        iteration,
+      });
+    } catch (err) {
+      logger.warn(`Perf gate: brain queue push failed (non-blocking): ${err.message}`);
+    }
+  }
+
+  emitProgress(emitter, makeEvent("perf:end", { ...eventBase, stage: "perf" }, {
+    status: "fail",
+    message: roleResult.summary,
+  }));
+
+  return {
+    action: "continue",
+    stageResult: {
+      verdict: "FAIL",
+      url: roleResult.result?.url,
+      performanceScore: roleResult.result?.performanceScore,
+      cwv: roleResult.result?.cwv,
+      issues: roleResult.result?.issues,
+      summary: feedback,
+    },
+  };
+}

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -53,7 +53,14 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // `await import(...)` callsites were hiding behind that swallow and
 // never counted; they've always existed in the source. Real headcount
 // is 159.
-const DYNAMIC_IMPORT_BUDGET = 159;
+//
+// 2026-05-04 (KJC-TSK-0151): bumped 159 → 160 for the new PerfStage
+// brain-coordinator lazy import. Same feature-flag-gated pattern used
+// by sonar-stage.js — `processRoleOutput` is only needed when
+// `brainCtx.enabled`, and pulling its transitive graph during cold
+// pipeline starts (where the perf gate is off by default) would be
+// wasteful.
+const DYNAMIC_IMPORT_BUDGET = 160;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/webperf/perf-stage.test.js
+++ b/tests/webperf/perf-stage.test.js
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const emitter = { emit: vi.fn() };
+
+let tmpHome, tmpProject, originalHome;
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-perf-stage-"));
+  tmpProject = path.join(tmpHome, "my-app");
+  await fs.mkdir(tmpProject, { recursive: true });
+  await fs.mkdir(path.join(tmpProject, ".karajan", "sessions", "s_test"), { recursive: true });
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function makeSession() {
+  return {
+    session_id: "s_test",
+    sessionDir: path.join(tmpProject, ".karajan", "sessions", "s_test"),
+    journal: { iterations: [] },
+    feedback: {},
+  };
+}
+
+function makeArgs(overrides = {}) {
+  return {
+    config: {
+      projectDir: tmpProject,
+      webperf: { url: "http://localhost:3000" },
+    },
+    logger: noopLogger,
+    emitter,
+    eventBase: { session_id: "s_test" },
+    session: makeSession(),
+    trackBudget: vi.fn(),
+    iteration: 1,
+    task: "test task",
+    brainCtx: null,
+    ...overrides,
+  };
+}
+
+describe("runPerfStage (KJC-TSK-0151)", () => {
+  it("returns ok with PASS verdict and stage result when CWV pass", async () => {
+    vi.doMock("../../src/roles/perf-role.js", () => ({
+      PerfRole: class {
+        async execute() {
+          return {
+            ok: true,
+            summary: "Webperf PASS (score 92/100, lcp=good, cls=good, inp=good)",
+            result: {
+              url: "http://localhost:3000",
+              performanceScore: 92,
+              cwv: { pass: true, blocking: [] },
+              savedPath: "/tmp/last.json",
+            },
+          };
+        }
+      },
+    }));
+
+    const { runPerfStage } = await import("../../src/orchestrator/stages/perf-stage.js");
+    const r = await runPerfStage(makeArgs());
+
+    expect(r.action).toBe("ok");
+    expect(r.stageResult.verdict).toBe("PASS");
+    expect(r.stageResult.performanceScore).toBe(92);
+    expect(r.stageResult.url).toBe("http://localhost:3000");
+  });
+
+  it("returns continue with FAIL verdict and writes reviewer feedback on FAIL", async () => {
+    vi.doMock("../../src/roles/perf-role.js", () => ({
+      PerfRole: class {
+        async execute() {
+          return {
+            ok: false,
+            summary: "Webperf FAIL (score 35/100): LCP=5500 (poor>4000)",
+            result: {
+              url: "http://localhost:3000",
+              performanceScore: 35,
+              cwv: { pass: false, blocking: [{ metric: "lcp", value: 5500, threshold: 4000, rating: "poor" }] },
+              issues: [{ id: "render-blocking-resources", savingsMs: 800 }],
+            },
+          };
+        }
+      },
+    }));
+    const setReviewerFeedback = vi.fn();
+    const saveSession = vi.fn();
+    vi.doMock("../../src/session/mutators.js", () => ({ setReviewerFeedback }));
+    vi.doMock("../../src/session/store.js", () => ({ saveSession }));
+
+    const { runPerfStage } = await import("../../src/orchestrator/stages/perf-stage.js");
+    const r = await runPerfStage(makeArgs());
+
+    expect(r.action).toBe("continue");
+    expect(r.stageResult.verdict).toBe("FAIL");
+    expect(setReviewerFeedback).toHaveBeenCalledTimes(1);
+    const [, feedback] = setReviewerFeedback.mock.calls[0];
+    expect(feedback).toContain("Webperf gate FAILED");
+    expect(feedback).toContain("LCP=5500");
+    expect(feedback).toContain("render-blocking-resources");
+    expect(saveSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns ok-skipped when scanner is unavailable (lighthouse missing)", async () => {
+    vi.doMock("../../src/roles/perf-role.js", () => ({
+      PerfRole: class {
+        async execute() {
+          return {
+            ok: false,
+            summary: "Webperf scan failed: lighthouse not installed",
+            result: { error: "lighthouse not installed" },
+          };
+        }
+      },
+    }));
+
+    const { runPerfStage } = await import("../../src/orchestrator/stages/perf-stage.js");
+    const r = await runPerfStage(makeArgs());
+
+    expect(r.action).toBe("ok");
+    expect(r.stageResult.skipped).toBe(true);
+    expect(r.stageResult.reason).toContain("not installed");
+    expect(noopLogger.warn).toHaveBeenCalled();
+  });
+
+  it("invokes brain.processRoleOutput when brainCtx.enabled and verdict is FAIL", async () => {
+    vi.doMock("../../src/roles/perf-role.js", () => ({
+      PerfRole: class {
+        async execute() {
+          return {
+            ok: false,
+            summary: "Webperf FAIL",
+            result: {
+              url: "http://localhost:3000",
+              performanceScore: 30,
+              cwv: { pass: false, blocking: [{ metric: "lcp", value: 6000, threshold: 4000, rating: "poor" }] },
+              issues: [],
+            },
+          };
+        }
+      },
+    }));
+    vi.doMock("../../src/session/mutators.js", () => ({ setReviewerFeedback: vi.fn() }));
+    vi.doMock("../../src/session/store.js", () => ({ saveSession: vi.fn() }));
+    const processRoleOutput = vi.fn();
+    vi.doMock("../../src/orchestrator/brain-coordinator.js", () => ({ processRoleOutput }));
+
+    const { runPerfStage } = await import("../../src/orchestrator/stages/perf-stage.js");
+    const r = await runPerfStage(makeArgs({ brainCtx: { enabled: true } }));
+
+    expect(r.action).toBe("continue");
+    expect(processRoleOutput).toHaveBeenCalledTimes(1);
+    const callArg = processRoleOutput.mock.calls[0][1];
+    expect(callArg.roleName).toBe("perf");
+    expect(callArg.output.verdict).toBe("fail");
+  });
+
+  it("throws when session is missing", async () => {
+    vi.doMock("../../src/roles/perf-role.js", () => ({
+      PerfRole: class {
+        async execute() { return { ok: true, summary: "ok", result: {} }; }
+      },
+    }));
+
+    const { runPerfStage } = await import("../../src/orchestrator/stages/perf-stage.js");
+    await expect(runPerfStage(makeArgs({ session: null }))).rejects.toThrow(/session/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the webperf gate trilogy started in #602 (scanner CLI) and #603 (PerfRole). This PR wires the role into the iteration loop so the perf check actually runs as a quality gate alongside Sonar and Impeccable.

## What changes

- **`src/orchestrator/stages/perf-stage.js`** (new, 140 LOC) — `runPerfStage` wrapper. Three outcomes:
  - **PASS** verdict → returns `{action: ok}`, iteration continues.
  - **FAIL** verdict → `setReviewerFeedback` with concrete blocking metrics + top opportunities, returns `{action: continue}` (next iteration).
  - **Scanner unavailable** (lighthouse missing/timeout) → log warn + return `{action: ok, skipped: true}`. Best-effort, never blocks the pipeline by itself.
- **No retry/repeat-detector machinery**: rerunning Lighthouse on the same URL gives the same verdict unless the coder changes something. `max_iterations` is the natural ceiling.
- **`quality-gates.js`** — perf gate slots after impeccable, gated on `pipelineFlags.perfEnabled`.
- **CLI/MCP parity**:
  - `--enable-perf` flag in `register-pipeline.js`.
  - Matching `enablePerf` in `mcp/tools.js` schema, `mcp/run-kj.js` arg builder, `mcp/sovereignty-guard.js` allowlist, and `mcp/handlers/run-handler.js` `applySessionOverrides`.
- **Config schema/defaults**: `pipeline.perf.enabled` (default `false`).
- **Session journal**: "Perf" appended to active stages line when enabled.
- **Dry-run summary**: `perf_enabled` field added.

## Test plan

- [x] `tests/webperf/perf-stage.test.js` — 5 new tests covering PASS / FAIL / scanner-unavailable / brain-ctx integration / missing-session guard.
- [x] Full suite: `npx vitest run` — 4344/4344 passing (372 files).
- [x] Lint clean on changed files.
- [x] Dynamic-imports budget bumped 159 → 160 with justification (same feature-flag-gated lazy-import pattern as `sonar-stage.js`).