### PR TITLE
docs(agents): SKILL.md per kj subcommand + coverage guard (KJC-TSK-0349)

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -21,15 +21,20 @@ modes, and a runnable example for one `kj` command.
 | `kj plan` | [SKILL.kj-plan.md](SKILL.kj-plan.md) | Generate / list / show / approve plans |
 | `kj run` | [SKILL.kj-run.md](SKILL.kj-run.md) | Execute a plan or a one-shot task |
 | `kj audit` | [SKILL.kj-audit.md](SKILL.kj-audit.md) | Read-only repo analysis |
-| `kj doctor` | (TBD) | Environment checks + auto-remediation |
-| `kj init` | (TBD) | Bootstrap config + rules + SonarQube |
-| `kj board` | (TBD) | Web UI for plans + sessions |
-| `kj review` | (TBD) | Reviewer-only against current diff |
-| `kj resume` | (TBD) | Resume a paused / stopped session |
-| `kj clean` | (TBD) | GC stale plans / sessions / batches |
+| `kj doctor` | [SKILL.kj-doctor.md](SKILL.kj-doctor.md) | Environment checks + auto-remediation |
+| `kj init` | [SKILL.kj-init.md](SKILL.kj-init.md) | Bootstrap config + rules + SonarQube |
+| `kj board` | [SKILL.kj-board.md](SKILL.kj-board.md) | Web UI for plans + sessions |
+| `kj review` | [SKILL.kj-review.md](SKILL.kj-review.md) | Reviewer-only against current diff |
+| `kj resume` | [SKILL.kj-resume.md](SKILL.kj-resume.md) | Resume a paused / stopped session |
+| `kj clean` | [SKILL.kj-clean.md](SKILL.kj-clean.md) | GC stale plans / sessions / batches |
 
-(TBD) entries: contract is `kj <cmd> --help`. SKILL.md will be added
-incrementally — see issue #541 follow-ups.
+Other commands not (yet) covered by a dedicated SKILL.md — `kj code`,
+`kj scan`, `kj status`, `kj report`, `kj triage`, `kj discover`,
+`kj researcher`, `kj architect`, `kj agents`, `kj roles`,
+`kj skills`, `kj config`, `kj webperf`, `kj sync`, `kj undo` — fall
+back to `kj <cmd> --help`. They're either thin wrappers around an
+agent role (no novel inputs) or under iteration; SKILL.md will land
+when their surface stabilises.
 
 ## Conventions for agents
 
@@ -41,6 +46,8 @@ incrementally — see issue #541 follow-ups.
 
 ## Coverage guard
 
-`tests/architecture/agent-docs-coverage.test.js` (TBD, follow-up)
-asserts every kj subcommand has a matching SKILL.md. CI fails when
-a new subcommand is added without documenting it.
+[`tests/architecture/agent-readability.test.js`](../../tests/architecture/agent-readability.test.js)
+asserts every SKILL.md link in `llms.txt` resolves to a real file
+under `docs/agents/`, and that every SKILL.md has the four
+contract sections (`What it does`, `Inputs`, `Outputs`, `Example`).
+CI fails when those rot.

--- a/docs/agents/SKILL.kj-board.md
+++ b/docs/agents/SKILL.kj-board.md
@@ -1,0 +1,81 @@
+# SKILL: kj board
+
+## What it does
+
+Manages the **HU Board** — a local web dashboard (Express + SQLite)
+that visualises plans, HU statuses, sessions and the run timeline.
+It auto-starts when `kj plan` produces a batch and can be used standalone.
+
+Subcommands: `start` | `stop` | `status` | `open`.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Action | positional `start` / `stop` / `status` / `open` (default `start`) | optional |
+| Port | `--port <n>` (default 4000, fallback 4001-4009 if busy) | optional |
+| Bind host | `--bind <host>` (default 127.0.0.1; use `0.0.0.0` for LAN) | optional |
+
+## Outputs
+
+- **stdout**: a small framed banner — PID, URL, status, project name when applicable.
+- **disk**:
+  - `~/.karajan/hu-board.pid` — PID file the CLI uses to track the daemon.
+  - `~/.karajan/hu-board/token` — auto-generated bearer token (mode 0600);
+    only enforced for non-loopback peers.
+  - SQLite database at `~/.karajan/hu-board/db.sqlite` (created by the daemon).
+- **HTTP server**: listens on `${bind}:${port}` (default `127.0.0.1:4000`).
+- **exit 0**: action completed; for `start`, the daemon is detached and
+  running in the background.
+- **exit non-zero**: port unavailable in fallback range, or PID file
+  pointed at a process that resists SIGTERM.
+
+## Constraints
+
+- Default bind is **loopback only**. `--bind 0.0.0.0` exposes on LAN
+  and auto-enforces token auth for non-loopback peers.
+- One daemon per machine: a second `kj board start` re-uses the existing
+  one (PID file + HTTP probe).
+- The daemon detaches via `child.unref()` and survives the parent shell.
+
+## Side effects
+
+- Starts a long-running Node process (`packages/hu-board/src/server.js`).
+- Generates an auth token on first run if none exists.
+- Writes a PID file the orchestrator's auto-start logic also reads.
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No free port in range 4000-4009` | All 10 fallback ports busy | `kj board stop` first, or `--port <free>` |
+| Stale `hu-board.pid` | Previous crash didn't clean up | `kj board stop` (now triple-fallback: PID → HTTP shutdown → port-occupant lookup) |
+| Browser keeps loading on `--bind 0.0.0.0` | Token required for non-loopback peers | Open the printed `?token=<token>` URL once; the cookie is set thereafter |
+| Daemon dies on SIGHUP from parent shell | Pre-v2.7.5 detach bug | Update Karajan; then `kj board start` again |
+
+## Example
+
+```bash
+# Default: localhost-only, port 4000
+kj board start
+
+# Open in default browser (starts daemon if needed)
+kj board open
+
+# Status check
+kj board status
+
+# Expose on LAN (token enforced)
+kj board start --bind 0.0.0.0
+
+# Custom port
+kj board start --port 5050
+
+# Stop
+kj board stop
+```
+
+## Related
+
+- [SKILL.kj-plan.md](SKILL.kj-plan.md) — produces the data the board displays.
+- [SKILL.kj-run.md](SKILL.kj-run.md) — auto-starts the board when generating HUs.

--- a/docs/agents/SKILL.kj-clean.md
+++ b/docs/agents/SKILL.kj-clean.md
@@ -1,0 +1,70 @@
+# SKILL: kj clean
+
+## What it does
+
+Garbage-collects stale plans, sessions, HU batches and audit/review
+outputs under `~/.karajan/`. Honors per-category retention windows
+configured in `~/.karajan/kj.config.yml`. Defaults are conservative
+(7 days for sessions, 30 days for plans).
+
+Use this when `~/.karajan/` has grown beyond what you want, or when
+debugging a clean-slate test scenario.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Dry run (preview only) | `--dry-run` | optional |
+| Override retention window | `--retention <days>` | optional, applies to all categories |
+| Wipe everything (zero retention + nuke board DB) | `--nuke` | optional, **destructive** |
+| Auto-confirm | `--yes` / `-y` | optional |
+
+## Outputs
+
+- **stdout**: per-category summary — count + total size freed.
+- **disk**: removes:
+  - `~/.karajan/sessions/<sid>/` older than retention.
+  - `~/.karajan/plans/plan-*.json` older than retention.
+  - `~/.karajan/hu-stories/<batchSessionId>/` older than retention.
+  - `~/.karajan/audits/`, `~/.karajan/reviews/` outputs older than retention.
+  - `~/.karajan/hu-board/db.sqlite` (only with `--nuke`).
+- **exit 0**: cleanup ran (regardless of how many entries were removed).
+- **exit non-zero**: filesystem error.
+
+## Constraints
+
+- Will NEVER touch your project repository or `kj.config.yml`.
+- `--nuke` is destructive: deletes the HU Board SQLite DB.
+- Will refuse `--nuke` without `--yes` in a TTY (safety prompt).
+
+## Side effects
+
+- Deletes files. The deletion is permanent (no trash).
+- A running HU Board daemon may need to be restarted after `--nuke`
+  because the DB it had open just disappeared.
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `EBUSY ~/.karajan/hu-board/db.sqlite` (`--nuke`) | Board daemon has the file open | `kj board stop`; rerun |
+| `Refusing --nuke without --yes` | Safety check | Add `-y` if you mean it |
+| `Permission denied` | File mode | `chown -R $USER ~/.karajan` |
+
+## Example
+
+```bash
+# Preview what would be removed
+kj clean --dry-run
+
+# Aggressive cleanup (everything older than 1 day)
+kj clean --retention 1 -y
+
+# Total reset (board DB included)
+kj board stop && kj clean --nuke -y
+```
+
+## Related
+
+- [SKILL.kj-resume.md](SKILL.kj-resume.md) — sessions you've cleaned can no longer be resumed.
+- [SKILL.kj-board.md](SKILL.kj-board.md) — `--nuke` wipes its DB; restart after.

--- a/docs/agents/SKILL.kj-doctor.md
+++ b/docs/agents/SKILL.kj-doctor.md
@@ -1,0 +1,71 @@
+# SKILL: kj doctor
+
+## What it does
+
+Runs a battery of environment checks (Node version, AI CLIs detected,
+ports free, SonarQube reachable, RTK installed, MCP servers healthy,
+config file shape, secrets/tokens) and **auto-remediates** what it
+safely can: starting Docker SonarQube containers, creating missing
+`~/.karajan/` directories, installing optional skill catalogs, etc.
+
+Always run before opening a bug.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Detect-only mode | `--check-only` | optional |
+| Auto-confirm prompts | `--yes` / `-y` | optional |
+| JSON output | `--json` | optional |
+| Verbose timing/hints | `--verbose` | optional |
+| Skip remediation, just exit code | `--check-only` | optional |
+
+## Outputs
+
+- **stdout**: per-check status (`PASS` / `WARN` / `FAIL`), an actionable
+  hint per non-PASS, and a final summary line `kj doctor: N pass / M warn / K fail`.
+- **stdout (`--json`)**: structured array `{check, status, message, fixed?}`.
+- **disk**: writes `~/.karajan/` skeleton if missing; creates Docker
+  containers if `kj-sonar` doesn't exist and Docker is running.
+- **exit 0**: zero `FAIL` checks (warnings allowed).
+- **exit non-zero**: at least one `FAIL` (count is the exit code, capped at 125).
+
+## Constraints
+
+- Read-mostly on the project. Will only modify `~/.karajan/` (skeleton)
+  and `~/.docker/` state (start sonar containers).
+- Never touches the project's `package.json` or `.git`.
+- Skips remediation when `--check-only` is passed.
+
+## Side effects
+
+- May start the Docker `kj-sonar` + `kj-sonar-db` containers (idempotent).
+- May `mkdir -p ~/.karajan/{sessions,plans,hu-stories,domains,...}`.
+- May fetch the addyosmani skill catalog if missing (cached in `~/.karajan/skills/addyosmani/`).
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Docker not running` | Need Docker Desktop / daemon up | Start Docker, rerun |
+| `claude CLI not found` | Coder agent not installed | `npm i -g @anthropic-ai/claude-code` (or use `--coder codex` etc.) |
+| `Port 4000 occupied` | Another HU Board running | `kj board stop` or `--port` override on next run |
+| `~/.karajan not writable` | Permission issue | `chown -R $USER ~/.karajan` |
+
+## Example
+
+```bash
+# Full check + remediate
+kj doctor
+
+# CI-friendly: detect only, JSON, fail on any FAIL
+kj doctor --check-only --json
+
+# After a fresh clone
+kj doctor -y
+```
+
+## Related
+
+- [SKILL.kj-init.md](SKILL.kj-init.md) — initial project bootstrap.
+- [SKILL.kj-board.md](SKILL.kj-board.md) — the board the doctor's port check is about.

--- a/docs/agents/SKILL.kj-init.md
+++ b/docs/agents/SKILL.kj-init.md
@@ -1,0 +1,77 @@
+# SKILL: kj init
+
+## What it does
+
+One-time bootstrap for a project that wants to use Karajan: writes
+`~/.karajan/kj.config.yml` (global config), seeds `<project>/.karajan/`
+with role rule templates (coder-rules, review-rules), and optionally
+brings up SonarQube via Docker. Idempotent — re-running on an already
+initialised project leaves existing files alone.
+
+`kj run` invokes this automatically when it detects a fresh project,
+so manual `kj init` is mostly for users who want to inspect/edit the
+config before the first run.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Skip Docker / SonarQube provisioning | `--no-sonar` | optional |
+| Auto-confirm prompts | `--yes` / `-y` | optional |
+| Force overwrite existing config | `--force` | optional |
+| Verbose | `--verbose` | optional |
+
+## Outputs
+
+- **disk**:
+  - `~/.karajan/kj.config.yml` — global config (coder/reviewer
+    providers, model overrides, pipeline flags).
+  - `<project>/.karajan/coder-rules.md` — per-project coder rules.
+  - `<project>/.karajan/review-rules.md` — per-project reviewer rules.
+  - `<project>/.gitignore` — extended with Karajan local artifacts if
+    needed.
+- **Docker**: `kj-sonar` + `kj-sonar-db` containers created and
+  started (unless `--no-sonar`).
+- **exit 0**: bootstrap complete.
+- **exit non-zero**: filesystem error or Docker failure.
+
+## Constraints
+
+- The current working directory must be a directory you own (will not
+  attempt to chmod / sudo).
+- Will not overwrite `kj.config.yml` if it already exists, unless
+  `--force` is passed.
+- Docker provisioning is best-effort: if Docker is missing the
+  command logs a warning and continues without SonarQube.
+
+## Side effects
+
+- Writes `~/.karajan/` and `<project>/.karajan/` directory trees.
+- Starts up to 2 Docker containers (`kj-sonar`, `kj-sonar-db`).
+- Adds entries to project `.gitignore`.
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `kj.config.yml already exists` | Re-running on configured project | Use `--force` to overwrite or edit by hand |
+| `Docker daemon not running` | Docker Desktop down | Start Docker, rerun (or `--no-sonar`) |
+| `EACCES ~/.karajan` | Permission issue | `chown -R $USER ~/.karajan` |
+
+## Example
+
+```bash
+# First time setup in a fresh project
+kj init -y
+
+# Already configured, just (re-)provision SonarQube
+kj init --force --yes
+
+# CI / minimal env without Docker
+kj init --no-sonar -y
+```
+
+## Related
+
+- [SKILL.kj-doctor.md](SKILL.kj-doctor.md) — verify the bootstrap actually worked.
+- [SKILL.kj-run.md](SKILL.kj-run.md) — what you do next.

--- a/docs/agents/SKILL.kj-resume.md
+++ b/docs/agents/SKILL.kj-resume.md
@@ -1,0 +1,72 @@
+# SKILL: kj resume
+
+## What it does
+
+Resumes a **paused, stopped or failed** Karajan session by id.
+Sessions are persisted under `~/.karajan/sessions/<sid>/`; each one
+carries a `config_snapshot` so resumption preserves the original
+flags (`--no-sonar`, `--coder`, etc.) — no need to remember what
+the original `kj run` command looked like.
+
+`kj run` itself auto-resumes recoverable failures up to
+`session.max_auto_resumes` (default 2) before surfacing the error,
+so manual `kj resume` is mostly for explicit pause-checkpoints.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Session id | positional `<sessionId>` | yes |
+| Answer to a paused question | `--answer <text>` | optional, only for paused sessions |
+| Project dir | `--project-dir <path>` | optional, when running outside the session's project |
+
+## Outputs
+
+- **stdout**: streaming pipeline log resuming from the stage that
+  was active when the session paused/failed.
+- **disk**: same set as `kj run` — commits, session metadata,
+  HU batch state.
+- **exit 0**: session reached a terminal state successfully.
+- **exit non-zero**: same failure surfaces as `kj run`.
+
+## Constraints
+
+- The session id must exist under `~/.karajan/sessions/`.
+- For paused sessions, the resume answer must satisfy the question's
+  validation (e.g. \"yes / no\", a checkpoint decision).
+- Will refuse to resume a session whose status is `done` or
+  `cancelled`.
+
+## Side effects
+
+- Same as `kj run`: writes to the project, commits, optionally
+  pushes / opens PRs depending on `git.auto_*` config.
+- Updates the session's status under `~/.karajan/sessions/<sid>/`.
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Session not found: <sid>` | Wrong id, or `~/.karajan` lives elsewhere | `ls ~/.karajan/sessions/`; set `KJ_HOME` if customised |
+| `Session is in terminal state \"done\"` | Already finished | Start a new run instead |
+| `Resume answer rejected: pattern mismatch` | Answer triggered the prompt-injection guard | Provide a plain factual answer (yes/no, file path) |
+| `Auto-resume limit reached (2/2)` | The error keeps re-occurring | Inspect the underlying failure; clear it manually before resuming |
+
+## Example
+
+```bash
+# List sessions
+ls ~/.karajan/sessions/
+
+# Resume a paused session by id
+kj resume s_20260505101530_abcd
+
+# Resume a paused checkpoint with an answer
+kj resume s_20260505101530_abcd --answer "yes"
+```
+
+## Related
+
+- [SKILL.kj-run.md](SKILL.kj-run.md) — what created the session.
+- `kj report --session <sid>` — inspect what happened before the
+  pause/failure.

--- a/docs/agents/SKILL.kj-review.md
+++ b/docs/agents/SKILL.kj-review.md
@@ -1,0 +1,68 @@
+# SKILL: kj review
+
+## What it does
+
+Runs the **reviewer role only** against the current diff (uncommitted
+changes by default; against a base ref if requested). Useful for
+\"second-opinion\" passes when you wrote code by hand and want
+Karajan's reviewer to weigh in without going through the full
+coder/iterate cycle.
+
+## Inputs
+
+| Input | Form | Required |
+|---|---|---|
+| Override reviewer agent | `--reviewer <provider>` | optional |
+| Reviewer model | `--reviewer-model <name>` | optional |
+| Base ref | `--base-ref <ref>` (default: working tree vs HEAD) | optional |
+| Mode | `--mode strict|standard|loose` | optional |
+| JSON output | `--json` | optional |
+
+## Outputs
+
+- **stdout**: per-file findings (severity, file:line, suggestion) +
+  final verdict (`approve` / `request_changes`).
+- **stdout (`--json`)**: `{ findings: [...], verdict, summary }`.
+- **disk**: review report at `~/.karajan/reviews/<timestamp>.md` if
+  `reviews.persist: true` in config.
+- **exit 0**: verdict is `approve` (or `request_changes` with
+  warnings only).
+- **exit non-zero**: blocking findings present (configurable threshold).
+
+## Constraints
+
+- Read-only on the project. Never modifies files.
+- Requires the reviewer agent CLI to be installed and authenticated.
+- Diff is computed via `git diff` — must be inside a git repo.
+
+## Side effects
+
+- One LLM call to the reviewer provider (token cost surfaced in
+  stdout).
+- Optional disk write under `~/.karajan/reviews/`.
+
+## Common failure modes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No diff to review` | Working tree clean and no `--base-ref` | Stage changes first, or pass `--base-ref main` |
+| `Reviewer failed: 403 ...` | Reviewer LLM auth expired | Re-login (e.g. `claude login`, `codex login`) |
+| `Diff too large (> N tokens)` | Massive PR | Split the change, or pass `--base-ref` to a closer ancestor |
+
+## Example
+
+```bash
+# Quick review of uncommitted work
+kj review
+
+# Compare current branch against main
+kj review --base-ref main
+
+# Strict mode + JSON for CI
+kj review --mode strict --json > review.json
+```
+
+## Related
+
+- [SKILL.kj-run.md](SKILL.kj-run.md) — full pipeline (coder + reviewer + tester + …).
+- [SKILL.kj-audit.md](SKILL.kj-audit.md) — static analysis instead of LLM-based review.

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@ Each entry below is a single fetch under 8 KB tokens.
 - [kj audit](docs/agents/SKILL.kj-audit.md) (~3 KB) — read-only analysis of any repo: god-functions, missing imports, structure smells.
 - [kj doctor](docs/agents/SKILL.kj-doctor.md) (~2 KB) — environment checks + auto-remediation.
 - [kj init](docs/agents/SKILL.kj-init.md) (~2 KB) — bootstrap config + review rules + SonarQube.
-- [kj board](docs/agents/SKILL.kj-board.md) (~2 KB) — start/stop the HU Board (web UI for plans + sessions).
+- [kj board](docs/agents/SKILL.kj-board.md) (~2 KB) — start/stop the HU Board (web UI for plans + sessions). Default bind 127.0.0.1; `--bind 0.0.0.0` exposes on LAN with token auth.
 - [kj review](docs/agents/SKILL.kj-review.md) (~2 KB) — run the reviewer role only against current diff.
 - [kj resume](docs/agents/SKILL.kj-resume.md) (~2 KB) — resume a paused / stopped / failed session.
 - [kj clean](docs/agents/SKILL.kj-clean.md) (~2 KB) — GC stale plans / sessions / HU batches.

--- a/tests/architecture/agent-readability.test.js
+++ b/tests/architecture/agent-readability.test.js
@@ -1,0 +1,92 @@
+/**
+ * Architecture regression guard — verify Karajan's agent-readability
+ * promise: every CLI subcommand listed as having a SKILL.md in
+ * `llms.txt` actually resolves to a file under `docs/agents/`.
+ *
+ * KJC-TSK-0349. Without this guard, llms.txt rots silently:
+ * we'd ship a "kj does X — see SKILL.kj-x.md" line that 404s
+ * for every external agent following it. The fix is one line of
+ * code; the audit was not catching it.
+ */
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const LLMS_TXT = path.join(REPO_ROOT, "llms.txt");
+const SKILL_DIR = path.join(REPO_ROOT, "docs/agents");
+
+/**
+ * Pull every `[label](docs/agents/SKILL.kj-foo.md)` link out of
+ * llms.txt. Returns the relative paths exactly as written so the
+ * error messages point at the real source line.
+ */
+function extractSkillLinks(text) {
+  const re = /\(docs\/agents\/(SKILL\.kj-[a-z0-9-]+\.md)\)/g;
+  const out = new Set();
+  let m;
+  while ((m = re.exec(text)) !== null) out.add(m[1]);
+  return [...out];
+}
+
+describe("agent-readability — llms.txt SKILL links resolve", () => {
+  it("llms.txt exists at repo root", () => {
+    expect(fs.existsSync(LLMS_TXT), "llms.txt should exist at repo root for agent discovery").toBe(true);
+  });
+
+  it("docs/agents/ contains a README.md as the entry point", () => {
+    const readme = path.join(SKILL_DIR, "README.md");
+    expect(fs.existsSync(readme), "docs/agents/README.md is the agent-facing entry point").toBe(true);
+  });
+
+  it("every SKILL.md link in llms.txt resolves to an actual file", () => {
+    const text = fs.readFileSync(LLMS_TXT, "utf8");
+    const links = extractSkillLinks(text);
+
+    expect(links.length, "llms.txt should advertise at least one SKILL.md").toBeGreaterThan(0);
+
+    const missing = [];
+    for (const filename of links) {
+      const abs = path.join(SKILL_DIR, filename);
+      if (!fs.existsSync(abs)) missing.push(filename);
+    }
+
+    if (missing.length > 0) {
+      throw new Error(
+        "llms.txt advertises SKILL files that don't exist:\n  " +
+        missing.map((f) => `docs/agents/${f}`).join("\n  ") +
+        "\n\nEither create them under docs/agents/ or remove the link from llms.txt.",
+      );
+    }
+  });
+
+  it("every SKILL.md under docs/agents/ has the expected sections", () => {
+    const REQUIRED_SECTIONS = ["What it does", "Inputs", "Outputs", "Example"];
+    const files = fs.readdirSync(SKILL_DIR)
+      .filter((f) => f.startsWith("SKILL.kj-") && f.endsWith(".md"));
+
+    expect(files.length, "docs/agents/ should contain SKILL.kj-*.md files").toBeGreaterThan(0);
+
+    const offenders = [];
+    for (const file of files) {
+      const text = fs.readFileSync(path.join(SKILL_DIR, file), "utf8");
+      for (const section of REQUIRED_SECTIONS) {
+        const re = new RegExp(`^##\\s+${section.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\b`, "m");
+        if (!re.test(text)) {
+          offenders.push(`${file} → missing "## ${section}"`);
+        }
+      }
+    }
+
+    if (offenders.length > 0) {
+      throw new Error(
+        "SKILL.md files missing required sections:\n  " +
+        offenders.join("\n  ") +
+        "\n\nEvery SKILL.md must have ## What it does, ## Inputs, ## Outputs, ## Example " +
+        "for agents to consume them deterministically.",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`llms.txt` was promising 9 SKILL.md files (one per CLI subcommand) but only **3 existed** (`plan`, `run`, `audit`). Any external agent following the manifest hit 404 on six links.

This PR closes the gap and adds a CI guard so it stays closed.

## What changes

### Six new SKILL.md files

| File | Subcommand |
|---|---|
| `docs/agents/SKILL.kj-doctor.md` | `kj doctor` |
| `docs/agents/SKILL.kj-init.md` | `kj init` |
| `docs/agents/SKILL.kj-board.md` | `kj board` (includes the new `--bind` flag from #607) |
| `docs/agents/SKILL.kj-review.md` | `kj review` |
| `docs/agents/SKILL.kj-resume.md` | `kj resume` |
| `docs/agents/SKILL.kj-clean.md` | `kj clean` |

Each follows the contract already established by `SKILL.kj-run.md` / `SKILL.kj-audit.md`: What it does · Inputs · Outputs · Constraints · Side effects · Common failure modes · Example · Related.

### Coverage guard

`tests/architecture/agent-readability.test.js` (4 assertions):

1. `llms.txt` exists at repo root.
2. `docs/agents/README.md` exists as the entry point.
3. **Every** `(docs/agents/SKILL.kj-*.md)` link in `llms.txt` resolves to an actual file.
4. Every SKILL.md under `docs/agents/` has the four contract sections (`## What it does`, `## Inputs`, `## Outputs`, `## Example`).

Failures point at the offending file/link with an actionable hint.

### Cleanup

- `docs/agents/README.md` — drops the six `(TBD)` placeholders and points at the new test as the coverage guard.
- `llms.txt` — `kj board` line now mentions the `--bind 0.0.0.0` LAN-exposure surface that landed in KJC-TSK-0355.

## Test plan

- [x] `npx vitest run tests/architecture/agent-readability.test.js` — 4/4 passing.
- [x] Full root suite: 4343/4343 passing (372 files).

## Why this matters for the May 21 talk

\"Karajan is the only orchestrator with a full agent-readability surface\" is a real differentiator — and one I wasn't going to be able to claim with three out of nine links broken. With this PR + the test guarding it, that claim survives a cold-start agent following `llms.txt`.