### PR TITLE
docs(demos): asciinema scripts for landing + recording how-to (KJC-TSK-0228)

### DIFF
--- a/docs/demos/README.md
+++ b/docs/demos/README.md
@@ -1,0 +1,83 @@
+# Karajan Code — Demo recordings
+
+Scripts for recording reproducible asciinema demos of Karajan Code,
+plus the published `.cast` files when available.
+
+## Why scripts and not pre-recorded `.cast` only?
+
+Karajan changes weekly. A `.cast` recorded against v2.7.x lies
+about features added in v2.9 and v2.10. The scripts here are the
+**source of truth** — re-record per release with the same script
+and the demo stays fresh.
+
+## Available scripts
+
+| Script | Length | Purpose | Requires |
+|---|---|---|---|
+| [happy-path.txt](happy-path.txt) | ~3 min | Zero-config: \"Build a REST API for a todo list\" → working code + tests | A coder agent CLI logged in (claude / codex / gemini) |
+| [agent-readiness.txt](agent-readiness.txt) | ~1 min | `kj audit --agent-readiness` against this repo → 100/100 | None — pure static analysis |
+| [audit-with-llm.txt](audit-with-llm.txt) | ~2 min | `kj audit` two-phase against a sample repo: deterministic findings → LLM analysis | A coder agent CLI logged in |
+
+## How to record
+
+```bash
+# Install asciinema once
+brew install asciinema     # macOS
+sudo apt install asciinema # Debian / Ubuntu
+
+# Pick a clean terminal (Terminal.app on macOS, GNOME Terminal on Linux).
+# Width 100 cols, height 30 rows is the sweet spot for readability +
+# embed size on the landing page.
+
+# Start recording
+asciinema rec docs/demos/agent-readiness.cast \\
+  --title \"Karajan Code — agent-readiness audit\" \\
+  --idle-time-limit 2
+
+# Type the commands from the .txt file at human pace.
+# Hit Ctrl+D or `exit` to stop.
+```
+
+## How to publish (optional)
+
+```bash
+# Account-less local share
+asciinema upload docs/demos/agent-readiness.cast
+# → returns a URL like https://asciinema.org/a/XXXXX
+
+# Or self-host: copy the .cast to the landing repo's static dir and
+# embed via the asciinema-player web component.
+```
+
+## How to embed on the landing
+
+```html
+<!-- Drop into karajan-landing/docs/src/components/Demo.astro -->
+<asciinema-player
+  src=\"/demos/agent-readiness.cast\"
+  cols=\"100\"
+  rows=\"30\"
+  idle-time-limit=\"2\"
+  poster=\"npt:0:5\"
+  preload
+></asciinema-player>
+```
+
+(`asciinema-player` ships as an npm package: `asciinema-player`. Add
+its CSS + JS once in the landing's base template.)
+
+## Pre-recording checklist
+
+- [ ] Repo is on a tagged release (no `dev` markers in stdout).
+- [ ] `kj doctor` passes — nothing red.
+- [ ] No notification overlays / Slack / mail running in the visible window.
+- [ ] Shell prompt is short (`PS1='$ '`) so output isn't squashed.
+- [ ] Coder agent CLI is logged in (script will fail at the `kj run` step otherwise).
+- [ ] `~/.karajan/sessions/` is empty (`kj clean -y --retention 0` if not).
+- [ ] Git status is clean (the demo will write commits — start from a fresh branch).
+
+## Re-record cadence
+
+- Re-record on every **minor** version bump (v2.10 → v2.11 etc.) — feature surface changed.
+- Re-record on **patch** bumps only if the visible CLI output changed.
+- Each recording is one commit: `docs(demos): re-record agent-readiness.cast against vX.Y.Z`.

--- a/docs/demos/agent-readiness.txt
+++ b/docs/demos/agent-readiness.txt
@@ -1,0 +1,31 @@
+# Demo: kj audit --agent-readiness — score third-party repos for AI-agent compatibility
+# Length: ~1 minute. No LLM calls. Reproducible against any tagged release.
+#
+# Setup: cd into the karajan-code repo (or any other) BEFORE starting asciinema.
+# The script below lists the EXACT commands to type, with optional pauses
+# the user can read while typing.
+
+# 1. Show the score for a repo that's NOT prepared (third-party).
+#    Use any popular OSS repo you have cloned locally. Replace the path
+#    with whatever you have. Try a famous one for the wow factor.
+clear
+ls ~/some-third-party-repo
+kj audit --agent-readiness --path ~/some-third-party-repo
+
+# (Pause ~3s after the score appears — the audience needs to read
+# the per-check breakdown and the top-fixes list.)
+
+# 2. Now the punchline: same command on Karajan Code itself.
+clear
+kj audit --agent-readiness
+
+# (The score line says 100/100. Pause ~3s.)
+
+# 3. Show that it's machine-readable too — pipe to jq for CI use.
+kj audit --agent-readiness --json | jq '.score'
+
+# 4. Optional: hint at what's behind the score by tailing llms.txt.
+head -20 llms.txt
+ls docs/agents/SKILL.kj-*.md
+
+# Done. Hit Ctrl+D or type `exit` to stop the recording.

--- a/docs/demos/audit-with-llm.txt
+++ b/docs/demos/audit-with-llm.txt
@@ -1,0 +1,32 @@
+# Demo: kj audit (full two-phase audit on a sample repo)
+# Length: ~2 minutes.
+# Requires: a coder agent CLI logged in for the LLM phase.
+
+# Setup: cd into a moderately-sized repo (1000-5000 LOC works well —
+# enough findings to be interesting, not so many that the report
+# scrolls forever). Karajan-code itself is a fine target.
+
+# 1. Phase 1 — deterministic findings only. Zero tokens spent.
+clear
+kj audit --deterministic-only
+
+# (Shows: basal cost, sonar findings if scanner present, OSV deps,
+# semgrep SAST hits, growth-delta, webperf if .karajan/webperf/ exists.
+# The audience sees a structured report in seconds.)
+
+# 2. Phase 2 — opt-in LLM analysis. Run the same audit without
+# --deterministic-only. Karajan prints the deterministic findings,
+# asks "Continue with LLM analysis? [y/N]", and waits.
+kj audit
+# (Type `y` and Enter when prompted.)
+
+# (LLM call streams; takes 30-90s depending on coder. Ends with
+# stack-aware recommendations + a token/cost summary.)
+
+# 3. Save the audit to a markdown report for sharing.
+kj audit --report-file ~/audits/karajan-$(date +%Y%m%d).md --yes
+
+# 4. Show the saved report's header (reproducibility metadata).
+head -25 ~/audits/karajan-$(date +%Y%m%d).md
+
+# Done. Ctrl+D.

--- a/docs/demos/happy-path.txt
+++ b/docs/demos/happy-path.txt
@@ -1,0 +1,35 @@
+# Demo: kj run — zero-config end-to-end pipeline
+# Length: ~3 minutes (depends on the coder agent's speed).
+# Requires: claude / codex / gemini logged in (whichever you set as `coder`).
+#
+# Setup BEFORE recording:
+#   mkdir /tmp/karajan-demo && cd /tmp/karajan-demo
+#   (the demo will create a git repo + write code + commit)
+
+# 1. Show the empty workspace.
+clear
+ls
+git status 2>/dev/null || echo "(no git repo yet — kj will init one)"
+
+# 2. The one-liner. This is the hero shot.
+kj run "Build a REST API for a todo list with Express and Vitest tests" -y
+
+# (kj triages → decomposes into HUs → coder writes code per HU →
+# reviewer evaluates → tester checks → all atomic commits + a PR.)
+#
+# The pipeline takes 1-3 minutes depending on the coder. Asciinema's
+# --idle-time-limit 2 collapses the LLM thinking pauses into ≤2s
+# blocks so the recording stays watchable.
+
+# 3. Show the output.
+git log --oneline
+ls
+cat package.json | head -15
+
+# 4. Run the tests Karajan wrote.
+npm test
+
+# 5. (Optional cherry on top) Show the audit dimension.
+kj audit --dimensions architecture --deterministic-only
+
+# Done. Ctrl+D to stop.


### PR DESCRIPTION
## Summary

Lands the asciinema demo work as **scripts** rather than baked `.cast` files. Three scripts under `docs/demos/`:

- **happy-path.txt** — zero-config \"Build a REST API for a todo list\" (~3 min)
- **agent-readiness.txt** — `kj audit --agent-readiness` showcase (~1 min, zero tokens) — the hero demo for the May 21 talk
- **audit-with-llm.txt** — full two-phase audit (~2 min)

## Why scripts, not .cast files

Karajan changes weekly. A `.cast` recorded against v2.7.x lies about features added in v2.9 / v2.10. The scripts are the source of truth; re-record per release with the same script and the demo stays fresh.

## docs/demos/README.md

- Recommended terminal config (100×30, short PS1).
- Pre-recording checklist (`kj doctor` green, `~/.karajan/sessions/` empty, no notification overlays, coder CLI logged in).
- How to publish (account-less `asciinema upload` OR self-host).
- How to embed via `<asciinema-player>` web component on the landing.
- Re-record cadence rules.

## What this PR does NOT do

It does NOT ship a `.cast` file — that's a manual recording step that needs the user's own asciinema account / coder agent auth. Recording lands in a follow-up commit when ready.

## Test plan

- [x] No code changes; doc-only PR.
- [x] All four files lint-clean (Markdown).