### PR TITLE
fix(audit): showstopper --json banner contamination + demo script polish

### DIFF
--- a/TODO-post-talk.md
+++ b/TODO-post-talk.md
@@ -1,0 +1,234 @@
+# Post-talk backlog (post 2026-05-21)
+
+Findings de un code review pre-charla del ciclo v2.10.0 (PRs #605–#611).
+Lo crítico para la demo se arregló en el PR #613. Esto es lo que NO
+afecta al directo y se puede tocar después con calma.
+
+## P1 — Bugs latentes con impacto real
+
+### P1-1 · `kj board start --bind 0.0.0.0` — la UI del navegador no funciona desde otra máquina
+
+**Ficheros**: `packages/hu-board/public/app.js:46` (función `api`) + `packages/hu-board/src/server.js:185–191`.
+
+**Problema**: cuando el board se bindea no-loopback, el banner imprime
+`http://192.168.x.x:4000/?token=XYZ`. El HTML carga (estático, sin auth),
+pero `api()` hace `fetch(path)` sin propagar token ni credenciales. Cada
+GET a `/api/dashboard`, `/api/projects`, etc. devuelve 401. El cookie
+`kj_board_token` documentado en el mensaje de error tampoco funciona
+porque el server no envía `Set-Cookie` en ningún momento.
+
+**Resultado**: `--bind 0.0.0.0` carga la cáscara del board pero está
+vacía de datos. Feature inservible para usuarios LAN.
+
+**Fix sugerido (XS)**: en `app.js`, leer `?token=` de
+`window.location.search` en el primer `api()` y guardarlo en
+`localStorage`; añadirlo a cada request como `Authorization: Bearer`.
+Alternativa: el server emite `Set-Cookie: kj_board_token=...; SameSite=Lax`
+cuando valida el token por primera vez vía query.
+
+**Demo**: NO afecta — el demo usa loopback, donde la auth está
+desactivada por design.
+
+---
+
+### P1-2 · `parseLighthouseReport` devuelve `ok:true` con métricas null
+
+**Ficheros**: `src/webperf/scanner.js:131–151` + `src/webperf/cwv-gate.js:67–88`.
+
+**Problema**: si lighthouse devuelve JSON válido pero shape inválido
+(error envelope, schema futuro, truncado), `evaluateCwv` salta los
+metrics null, devuelve `pass: true` con todo vacío y el perf gate pasa
+silently sin haber medido nada.
+
+**Fix sugerido (S)**: guard en `parseLighthouseReport` — si
+`report?.categories?.performance` no está, devolver
+`{ ok: false, reason: "lighthouse report missing performance category" }`.
+
+**Demo**: NO afecta directamente — perf gate es opt-in y no se
+demuestra.
+
+---
+
+### P1-3 · `stripFencedCodeBlocks` falla en fences sin newline antes del cierre
+
+**Fichero**: `src/audit/agent-readiness.js:181`.
+
+**Problema**: el regex requiere `\n\1\2[^\n]*$`. Un fence cuya última
+línea de contenido no termina con newline antes del cierre no se
+elimina. Si dentro hay `# comment`, cuenta como H1 falso positivo.
+
+**Reproducción**:
+```
+\`\`\`bash
+# comment
+foo\`\`\`   ← no \n antes del cierre
+```
+
+**Fix sugerido (XS)**: cambiar `([\s\S]*?)\n\1\2[^\n]*$` por
+`([\s\S]*?)(\n\1\2[^\n]*|)\s*$` o normalizar trailing whitespace antes
+del match.
+
+**Demo**: NO afecta — Karajan-on-Karajan sigue 100/100. Riesgo en
+auditorías a repos de terceros con esta forma rara.
+
+---
+
+### P1-4 · `htmlH1Count` matchea `<h1>` dentro de comentarios HTML
+
+**Fichero**: `src/audit/agent-readiness.js:112`.
+
+**Problema**: el regex `/<h1[\s>]/gi` se aplica DESPUÉS de stripear
+fenced code blocks, pero NO strippea comentarios HTML. Un doc con
+`<!-- <h1>Title</h1> -->` + un H1 markdown real cuenta 2 H1s y se marca
+como violación.
+
+**Fix sugerido (XS)**: strip comentarios HTML antes del regex —
+`text.replace(/<!--[\s\S]*?-->/g, "")`.
+
+**Demo**: NO afecta — ningún doc actual de Karajan tiene `<h1>` dentro
+de comentarios.
+
+---
+
+## P2 — Code quality / edge cases
+
+### P2-1 · Race condition en `getOrCreateToken()`
+
+**Fichero**: `packages/hu-board/src/token-store.js:38–57`.
+
+**Problema**: `existsSync` + `writeFileSync` es TOCTOU. Si dos board
+processes arrancan simultáneamente, ambos generan token diferente, gana
+el segundo en escritura, el primero queda con `process.env.HU_BOARD_TOKEN`
+desfasado y todos sus auth checks fallan.
+
+**Mitigación actual**: el PID-file check de `kj board start` evita el
+spawn paralelo. Ventana de race muy estrecha.
+
+**Fix sugerido (XS)**: `writeFileSync(..., { flag: "wx" })` con
+fallback a `readFileSync`.
+
+---
+
+### P2-2 · CSP con `unsafe-inline` en script-src y style-src
+
+**Fichero**: `packages/hu-board/src/server.js:89–90`.
+
+**Problema**: necesario para el inline JS/CSS actual del dashboard.
+El comentario lo marca como follow-up. Cero vector XSS hoy. Riesgo
+materializa solo si el board se expone a LAN y hay XSS almacenado en
+session data.
+
+**Fix sugerido (M, deferido)**: mover `<script>` y `<style>` inline a
+ficheros externos. Solo urgente si se promociona `--bind 0.0.0.0`.
+
+---
+
+### P2-3 · Doble invocación de `authMiddleware` en `/api/pipeline`
+
+**Fichero**: `packages/hu-board/src/server.js:152–153`.
+
+**Problema**: `app.use('/api', auth, ...)` + `app.use('/api/pipeline', auth, ...)`
+hace que las requests a `/api/pipeline/*` pasen por `authMiddleware`
+dos veces. Sin impacto funcional, ~doble overhead en el polling.
+
+**Fix sugerido (XS)**: eliminar el `authMiddleware()` del segundo mount
+(ya cubierto por `/api`), o mover `pipelineRoutes` dentro de `apiRoutes`.
+
+---
+
+## Test gaps importantes
+
+### TG-1 · No hay e2e que valide el demo script literal
+
+Sólo se cubre paso 1 con tmp dir. Pasos 2–5 + el pipe a jq quedan sin
+red de seguridad. Debería existir un test que ejecute SECUENCIALMENTE
+los comandos exactos de `docs/demos/agent-readiness.txt` y asserte que
+cada uno exit 0 y stdout parseable.
+
+**Sugerencia**: extender `tests/e2e/07-kj-audit.test.js` con un test que
+ejecute todas las invocaciones encadenadas. Esfuerzo: S.
+
+---
+
+### TG-2 · `kj run` zero-config en dir totalmente vacío sin testear e2e
+
+Todos los e2e existentes usan `makeTmpProject()` que pre-inicializa
+git + `.karajan/`. El path `autoInit` real (sin git, sin nada) sólo se
+testea con `runCommand` mockeado en `tests/bootstrap.test.js`.
+
+**Sugerencia**: nuevo `tests/e2e/02-run-zero-config.test.js` que llame
+a `runKj(["run", "..."], { cwd: emptyDir })` con coder fake y verifique
+git repo + .gitignore creados. Esfuerzo: M.
+
+---
+
+### TG-3 · Cadena `enablePerf` MCP→CLI→config sin red de tests
+
+`enablePerf: true` en MCP → sovereignty-guard → `runKjCommand` →
+`--enable-perf` → `applyRunOverrides` → `pipeline.perf.enabled`. Cero
+test cubre la cadena completa. Si en una limpieza de dead exports se
+cae el entry de `PIPELINE_ENABLE_FLAGS`, el perf gate nunca se activa
+y nadie se entera.
+
+**Sugerencia**: 1 test en `tests/config.test.js` (sección
+`applyRunOverrides`) + 1 en `tests/mcp-tools-schema.test.js`.
+Esfuerzo: XS.
+
+---
+
+### TG-4 · Lighthouse JSON corrupto sin cubrir en scanner
+
+`tests/webperf/scanner.test.js` cubre ENOENT, killed, exit code ≠ 0,
+pero no `JSON.parse` failure de stdout válido pero garbled.
+
+**Sugerencia**: 1 `it` que mockee `execFile` con `"not json"` y verifique
+`{ ok: false, reason: /not parseable/ }`. Esfuerzo: XS.
+
+---
+
+### TG-5 · `--bind 0.0.0.0` testeado solo via mock, no socket real
+
+`auth.test.js` simula peer no-loopback con un middleware que sobreescribe
+`req.ip`. No hay test que de verdad bindee Express en un puerto real y
+haga una request HTTP TCP.
+
+**Sugerencia**: integration test en `packages/hu-board/tests/auth.test.js`
+con `app.listen(0)` + request real. Esfuerzo: S.
+
+---
+
+### TG-6 · Drift de versión README/GETTING-STARTED vs package.json sin guard CI
+
+El historial muestra que ha pasado: en v2.7.0 quedaron en v2.6.x sin
+detectarse. Hoy ambos en 2.10.0, OK. Pero el siguiente bump puede
+volver a romperlo.
+
+**Sugerencia**: 1 snapshot test en
+`tests/architecture/agent-readability.test.js` que compare las strings
+de versión en `README.md` línea 26 y `docs/GETTING-STARTED.md` con
+`package.json`. Esfuerzo: XS.
+
+---
+
+## Plan recomendado
+
+**Sprint inmediato post-charla** (1–2 días):
+1. P1-1 (HU board cookie) — feature está rota para el caso de uso anunciado.
+2. TG-1 + TG-2 (e2e demo + e2e run zero-config) — red de seguridad para
+   futuras releases.
+3. TG-6 (version drift guard) — barato, evita la próxima vergüenza.
+
+**Sprint medio plazo** (1 semana):
+4. P1-2, P1-3, P1-4 (regex + scanner edge cases) — todos XS.
+5. TG-3, TG-4, TG-5 — cubren los huecos de paridad.
+
+**Backlog deferido**:
+6. P2-1, P2-2, P2-3 — calidad pero sin urgencia.
+
+## Cómo se ha generado este documento
+
+Code review automatizado el 2026-05-06 con la skill `code-review` de
+Claude Code, ejecutada con 3 agentes Sonnet en paralelo (bug scan,
+test gaps, demo pre-flight). El showstopper detectado se arregló en
+PR #613 antes de tocar este backlog. Volver a ejecutar el review
+después de cada release mayor.

--- a/docs/demos/agent-readiness.txt
+++ b/docs/demos/agent-readiness.txt
@@ -6,11 +6,12 @@
 # the user can read while typing.
 
 # 1. Show the score for a repo that's NOT prepared (third-party).
-#    Use any popular OSS repo you have cloned locally. Replace the path
-#    with whatever you have. Try a famous one for the wow factor.
+#    Recommended: clone https://github.com/expressjs/express somewhere
+#    (it has no llms.txt → low score, big contrast vs Karajan's 100/100).
+#    Replace the path below with wherever you cloned it.
 clear
-ls ~/some-third-party-repo
-kj audit --agent-readiness --path ~/some-third-party-repo
+ls ~/oss/express
+kj audit --agent-readiness --path ~/oss/express
 
 # (Pause ~3s after the score appears — the audience needs to read
 # the per-check breakdown and the top-fixes list.)

--- a/docs/demos/happy-path.txt
+++ b/docs/demos/happy-path.txt
@@ -1,10 +1,13 @@
 # Demo: kj run — zero-config end-to-end pipeline
-# Length: ~3 minutes (depends on the coder agent's speed).
+# Length: ~5–10 minutes (depends on the coder agent's speed and how many
+# HUs triage produces — the audience watches REAL time, not asciinema-
+# accelerated time).
 # Requires: claude / codex / gemini logged in (whichever you set as `coder`).
 #
 # Setup BEFORE recording:
 #   mkdir /tmp/karajan-demo && cd /tmp/karajan-demo
-#   (the demo will create a git repo + write code + commit)
+#   (the demo will create a git repo + write code; commits depend on the
+#   coder agent. Pass --auto-commit if you want guaranteed atomic commits.)
 
 # 1. Show the empty workspace.
 clear
@@ -12,24 +15,31 @@ ls
 git status 2>/dev/null || echo "(no git repo yet — kj will init one)"
 
 # 2. The one-liner. This is the hero shot.
-kj run "Build a REST API for a todo list with Express and Vitest tests" -y
+#    --auto-commit forces atomic commits per HU so `git log` shows the
+#    audit-trail clearly. Drop it if you want to leave commits to the coder.
+kj run "Build a REST API for a todo list with Express and Vitest tests" -y --auto-commit
 
 # (kj triages → decomposes into HUs → coder writes code per HU →
-# reviewer evaluates → tester checks → all atomic commits + a PR.)
+# reviewer evaluates → tester checks → atomic commits per HU.)
 #
-# The pipeline takes 1-3 minutes depending on the coder. Asciinema's
-# --idle-time-limit 2 collapses the LLM thinking pauses into ≤2s
-# blocks so the recording stays watchable.
+# Pipeline timing: budget 5-10 minutes live. To cap it tighter for stage
+# pacing add: --max-iterations 3 --max-iteration-minutes 3
+# (a partially-complete run is also a valid demo: "Karajan worked for 3
+# min, here's what it produced").
 
 # 3. Show the output.
 git log --oneline
 ls
-cat package.json | head -15
+head -15 package.json
 
-# 4. Run the tests Karajan wrote.
+# 4. Run the tests Karajan wrote. Make sure deps are installed first
+#    (the coder may or may not run npm install on its own).
+npm install --silent
 npm test
 
-# 5. (Optional cherry on top) Show the audit dimension.
-kj audit --dimensions architecture --deterministic-only
+# 5. (Optional cherry on top) Show the deterministic audit.
+#    NOTE: --dimensions only affects the LLM phase; with
+#    --deterministic-only it has no effect, so we leave it out.
+kj audit --deterministic-only
 
 # Done. Ctrl+D to stop.

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -211,7 +211,11 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
   // Per addyosmani/agentic-seo. Issue #542.
   if (agentReadiness) {
     const rootDir = path.resolve(pathArg || config?.projectDir || process.cwd());
-    logger.info(`Auditing agent-readiness of ${rootDir}`);
+    // Suppress the info banner in --json mode so stdout stays a single
+    // valid JSON document. Without this guard, `kj audit --agent-readiness
+    // --json | jq` fails with a parse error because the logger writes
+    // "Auditing agent-readiness of ..." to stdout BEFORE the JSON blob.
+    if (!json) logger.info(`Auditing agent-readiness of ${rootDir}`);
     const report = runAgentReadiness(rootDir);
     if (json) {
       console.log(JSON.stringify(report, null, 2));

--- a/tests/e2e/07-kj-audit.test.js
+++ b/tests/e2e/07-kj-audit.test.js
@@ -77,4 +77,36 @@ describe("e2e/07 — kj audit on a smelly tmp repo", () => {
     const failed = parsed.checks.some(c => c.ok === false || (Number.isFinite(c.score) && c.score < c.weight));
     expect(failed, "audit should have flagged at least one missing-readiness item on a bare tmp repo").toBe(true);
   }, 90_000);
+
+  // Regression pin for the live-demo showstopper detected on 2026-05-06:
+  // `kj audit --agent-readiness --json` was emitting a colored
+  // `[info] Auditing agent-readiness of <path>` banner to stdout BEFORE
+  // the JSON document. The demo script `docs/demos/agent-readiness.txt`
+  // pipes that command into `jq '.score'`, which then dies with a parse
+  // error live on stage. The fix is a one-line guard in
+  // src/commands/audit.js. This test pins the contract so it cannot
+  // regress without CI catching it.
+  it("--json stdout is a single valid JSON document (no logger banner contamination)", () => {
+    proj = makeTmpProject({ prefix: "kj-e2e-07b-" });
+    writeSmellyFiles(proj.projectDir);
+
+    const r = runKj(
+      ["audit", "--agent-readiness", "--json", "--path", proj.projectDir],
+      { cwd: proj.projectDir, timeoutMs: 60_000 }
+    );
+
+    expect(r.exitCode, `audit stderr: ${r.stderr}`).toBe(0);
+
+    // First non-empty stdout char must be "{" — anything else (an ANSI
+    // colour code, a "[info]" banner, etc.) means a downstream `jq`
+    // pipe will die.
+    const trimmed = r.stdout.trimStart();
+    expect(
+      trimmed.startsWith("{"),
+      `stdout must start with '{' for downstream JSON consumers; got: ${JSON.stringify(r.stdout.slice(0, 80))}`,
+    ).toBe(true);
+
+    // And the entire stdout must parse without any preprocessing.
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+  }, 90_000);
 });


### PR DESCRIPTION
## Summary

Pre-talk code review of the v2.10.0 cycle flagged one **showstopper** for the live demo on 2026-05-21 plus four small polish items in \`docs/demos/\`.

## Showstopper

\`kj audit --agent-readiness --json | jq '.score'\` failed in front of any audience: the colored \`[info]\` banner was being emitted to stdout before the JSON, so jq saw garbage and died with a parse error. **One-line fix** in \`src/commands/audit.js\` + regression pin in \`tests/e2e/07-kj-audit.test.js\` (asserts stdout starts with \`{\` and parses without preprocessing).

## Demo script polish

- \`agent-readiness.txt\`: concrete repo recommendation (clone expressjs/express) instead of \`~/some-third-party-repo\` placeholder.
- \`happy-path.txt\`: realistic timing (~5–10 min, not ~3), \`--auto-commit\` on the hero \`kj run\` so \`git log\` actually shows commits, \`npm install\` safety net before \`npm test\`, drop \`--dimensions\` (no-op with \`--deterministic-only\`), fix UUOC.

## Test plan

- [x] Full suite: 4 359 / 4 359 (was 4 358 + 1 new regression test).
- [x] Manually verified \`node src/cli.js audit --agent-readiness --path . --json | jq '.score'\` returns \`100\`.
- [x] ESLint clean on changed files.

## Out of scope

The other 8 findings from the code review (P1/P2 latent bugs + test gaps) are dropped into \`TODO-post-talk.md\` as backlog for post-21-May. None affect the live demo.