### PR TITLE
feat(init): expand wizard — per-role provider + Sonar token auto-gen + git automation + HU Board security (KJC-TSK-0367)

### DIFF
--- a/docs/agents/SKILL.kj-init.md
+++ b/docs/agents/SKILL.kj-init.md
@@ -4,9 +4,34 @@
 
 One-time bootstrap for a project that wants to use Karajan: writes
 `~/.karajan/kj.config.yml` (global config), seeds `<project>/.karajan/`
-with role rule templates (coder-rules, review-rules), and optionally
-brings up SonarQube via Docker. Idempotent — re-running on an already
-initialised project leaves existing files alone.
+with role rule templates (coder-rules, review-rules), brings up
+SonarQube via Docker (and **auto-generates the analysis token** via
+the Sonar REST API), and walks the user through a wizard that covers
+**all** the meaningful runtime knobs:
+
+1. **Coder + reviewer agent** (which CLI to use as default).
+2. **Per-role provider** (planner / researcher / architect / refactorer
+   / tester / security / solomon / impeccable / perf / hu_reviewer):
+   for each one, choose to inherit from coder/reviewer, pick a specific
+   CLI, or disable the role.
+3. **Pipeline toggles**: triage, SonarQube, HU Board.
+4. **Methodology** (TDD vs standard).
+5. **Pipeline + HU language**.
+6. **Git automation**: `auto_commit`, `auto_push`, `auto_pr`, plus
+   `branch_prefix` when auto_commit is on.
+7. **HU Board security** (only if HU Board is on): bind host
+   (loopback default | `0.0.0.0` with auto-generated token enforced
+   for non-loopback peers), port.
+8. **Sonar token bootstrap** (when interactive + Docker container up):
+   logs in with admin/admin, rotates the default password to a fresh
+   value persisted at `~/.karajan/sonar.admin-password` (mode 0600),
+   generates the `karajan-cli` analysis token via
+   `POST /api/user_tokens/generate`, writes it to the config and to
+   `~/.karajan/sonar.token` (mode 0600). Falls back to manual flow
+   if any step fails.
+
+Idempotent — re-running on an already initialised project asks
+"Reconfigure? [y/N]" first.
 
 `kj run` invokes this automatically when it detects a fresh project,
 so manual `kj init` is mostly for users who want to inspect/edit the

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -13,6 +13,200 @@ import { detectOsLocale, SUPPORTED_LANGUAGES } from "../utils/locale.js";
 import { detectRtk } from "../utils/rtk-detect.js";
 import { installRtk } from "../utils/rtk-install.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
+import { bootstrapSonarToken } from "../sonar/token-bootstrap.js";
+
+/**
+ * Roles asked individually after coder/reviewer. Each entry:
+ *   - key: config.roles.<key>.provider
+ *   - pipelineKey: config.pipeline.<key>.enabled (omit when not gated by a flag)
+ *   - default: which role's CLI to inherit ("coder" | "reviewer")
+ *   - allowDisable: true if "off" is a valid choice
+ *
+ * Order matters — keep the most-impactful first so the wizard never hides
+ * critical roles behind a long tail of opt-ins.
+ */
+const PER_ROLE_QUESTIONS = [
+  { key: "planner",     pipelineKey: "planner",     default: "coder",    allowDisable: true,  label: "Planner (decomposes complex tasks into HUs)" },
+  { key: "researcher",  pipelineKey: "researcher",  default: "coder",    allowDisable: true,  label: "Researcher (explores codebase before coding)" },
+  { key: "architect",   pipelineKey: "architect",   default: "coder",    allowDisable: true,  label: "Architect (designs solution + contracts)" },
+  { key: "tester",      pipelineKey: "tester",      default: "coder",    allowDisable: false, label: "Tester (verifies tests + coverage)" },
+  { key: "security",    pipelineKey: "security",    default: "coder",    allowDisable: false, label: "Security (OWASP audit)" },
+  { key: "solomon",     pipelineKey: "solomon",     default: "reviewer", allowDisable: false, label: "Solomon (judge AI for dilemmas)" },
+  { key: "refactorer",  pipelineKey: "refactorer",  default: "coder",    allowDisable: true,  label: "Refactorer (clarity passes)" },
+  { key: "impeccable",  pipelineKey: "impeccable",  default: "coder",    allowDisable: true,  label: "Impeccable (UI/UX audit — frontend only)" },
+  { key: "perf",        pipelineKey: "perf",        default: "coder",    allowDisable: true,  label: "Perf (Core Web Vitals gate — frontend only)" },
+  { key: "hu_reviewer", pipelineKey: "hu_reviewer", default: "reviewer", allowDisable: true,  label: "HU Reviewer (mandatory user-story certification)" },
+];
+
+// ---- Sub-asks ----
+
+async function askAgents(wizard, available, config, logger) {
+  if (available.length === 1) {
+    const only = available[0].name;
+    logger.info(`Only one agent available: ${only}. Using it for all roles.\n`);
+    config.coder = only;
+    config.reviewer = only;
+    config.roles.coder.provider = only;
+    config.roles.reviewer.provider = only;
+    return { coder: only, reviewer: only };
+  }
+
+  const agentOptions = available.map((a) => ({
+    label: `${a.name} (${a.version})`,
+    value: a.name,
+    available: true,
+  }));
+
+  const coder = await wizard.select("Select default CODER agent:", agentOptions);
+  config.coder = coder;
+  config.roles.coder.provider = coder;
+  logger.info(`  -> Coder: ${coder}`);
+
+  const reviewer = await wizard.select("Select default REVIEWER agent:", agentOptions);
+  config.reviewer = reviewer;
+  config.roles.reviewer.provider = reviewer;
+  logger.info(`  -> Reviewer: ${reviewer}`);
+
+  return { coder, reviewer };
+}
+
+/**
+ * For each non-coder/non-reviewer role, ask: use coder default | use reviewer
+ * default | pick a specific CLI | (when allowed) disable. The choice is
+ * persisted as `config.roles.<role>.provider` (null means "inherit from
+ * coder" at runtime). Pipeline-flag-gated roles also flip
+ * `config.pipeline.<role>.enabled`.
+ *
+ * `available.length === 1` short-circuits: every role uses the only CLI
+ * available, no point asking.
+ */
+async function askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger) {
+  if (available.length <= 1) return;
+
+  logger.info("");
+  logger.info("Configure provider per role (Enter accepts the default):");
+
+  // Make sure containers exist for every role/pipeline key we touch —
+  // older configs may have a sparser shape than DEFAULTS.
+  config.roles = config.roles || {};
+  config.pipeline = config.pipeline || {};
+
+  for (const role of PER_ROLE_QUESTIONS) {
+    config.roles[role.key] = config.roles[role.key] || { provider: null, model: null };
+    if (role.pipelineKey) {
+      config.pipeline[role.pipelineKey] = config.pipeline[role.pipelineKey] || { enabled: false };
+    }
+
+    const defaultLabel = role.default === "coder" ? `coder (${coder})` : `reviewer (${reviewer})`;
+    const baseOptions = [
+      { label: `Use ${defaultLabel} — default`, value: "__default__", available: true },
+    ];
+    for (const a of available) {
+      if ((role.default === "coder" && a.name === coder) || (role.default === "reviewer" && a.name === reviewer)) continue;
+      baseOptions.push({ label: a.name, value: a.name, available: true });
+    }
+    if (role.allowDisable) {
+      baseOptions.push({ label: "Disable role", value: "__disabled__", available: true });
+    }
+
+    const choice = await wizard.select(`  ${role.label}:`, baseOptions);
+
+    if (choice === "__disabled__") {
+      if (role.pipelineKey) config.pipeline[role.pipelineKey].enabled = false;
+      logger.info(`    -> ${role.key}: disabled`);
+    } else if (choice === "__default__") {
+      // Inherit from coder/reviewer at runtime — leave provider null.
+      config.roles[role.key].provider = null;
+      if (role.pipelineKey) config.pipeline[role.pipelineKey].enabled = true;
+      logger.info(`    -> ${role.key}: ${defaultLabel}`);
+    } else {
+      config.roles[role.key].provider = choice;
+      if (role.pipelineKey) config.pipeline[role.pipelineKey].enabled = true;
+      logger.info(`    -> ${role.key}: ${choice}`);
+    }
+  }
+}
+
+async function askMethodology(wizard, config, logger) {
+  const methodology = await wizard.select("Development methodology:", [
+    { label: "TDD (test-driven development)", value: "tdd", available: true },
+    { label: "Standard (no TDD enforcement)", value: "standard", available: true },
+  ]);
+  config.development.methodology = methodology;
+  config.development.require_test_changes = methodology === "tdd";
+  logger.info(`  -> Methodology: ${methodology}`);
+}
+
+async function askLanguages(wizard, config, logger) {
+  const detectedLocale = detectOsLocale();
+  const allLangEntries = Object.entries(SUPPORTED_LANGUAGES).map(([code, name]) => ({
+    label: `${name} (${code})`,
+    value: code,
+    available: true,
+  }));
+  const languageOptions = [
+    ...allLangEntries.filter((o) => o.value === detectedLocale),
+    ...allLangEntries.filter((o) => o.value !== detectedLocale),
+  ];
+
+  const pipelineLang = await wizard.select("Pipeline language:", languageOptions);
+  config.language = pipelineLang;
+  logger.info(`  -> Pipeline language: ${pipelineLang}`);
+
+  const huLangOptions = [
+    ...allLangEntries.filter((o) => o.value === pipelineLang),
+    ...allLangEntries.filter((o) => o.value !== pipelineLang),
+  ];
+  const huLang = await wizard.select("HU language (for user stories):", huLangOptions);
+  config.hu_language = huLang;
+  logger.info(`  -> HU language: ${huLang}`);
+}
+
+async function askGitAutomation(wizard, config, logger) {
+  config.git = config.git || {};
+  const autoCommit = await wizard.confirm("Auto-commit per HU? (recommended for `kj run` so commits show up in git log)", false);
+  config.git.auto_commit = autoCommit;
+  logger.info(`  -> auto_commit: ${autoCommit}`);
+
+  const autoPush = await wizard.confirm("Auto-push to remote after each commit?", false);
+  config.git.auto_push = autoPush;
+  logger.info(`  -> auto_push: ${autoPush}`);
+
+  const autoPr = await wizard.confirm("Auto-open a Pull Request when the run finishes?", false);
+  config.git.auto_pr = autoPr;
+  logger.info(`  -> auto_pr: ${autoPr}`);
+
+  // Branch prefix only worth asking when auto_commit is on; otherwise leave default.
+  if (autoCommit) {
+    const prefix = await wizard.ask("Branch prefix (e.g. feat/, kj/, ai/) [feat/]: ");
+    config.git.branch_prefix = (prefix && prefix.trim()) || "feat/";
+    logger.info(`  -> branch_prefix: ${config.git.branch_prefix}`);
+  }
+}
+
+async function askBoardSecurity(wizard, config, logger) {
+  if (!config.hu_board?.enabled) return;
+
+  const bindChoice = await wizard.select(
+    "HU Board bind host:",
+    [
+      { label: "127.0.0.1 (loopback only — recommended for personal laptops)", value: "127.0.0.1", available: true },
+      { label: "0.0.0.0 (LAN exposure — token auth auto-enforced for non-loopback peers)", value: "0.0.0.0", available: true },
+    ],
+  );
+  config.hu_board.bind = bindChoice;
+  logger.info(`  -> HU Board bind: ${bindChoice}`);
+
+  if (bindChoice === "0.0.0.0") {
+    logger.info("     A secret token will be auto-generated on first start at ~/.karajan/hu-board/token (mode 0600).");
+    logger.info("     Open the URL printed by `kj board start` to grab it.");
+  }
+
+  const portInput = await wizard.ask("HU Board port [4000]: ");
+  const port = Number.parseInt(portInput, 10);
+  config.hu_board.port = Number.isFinite(port) && port > 0 && port < 65536 ? port : 4000;
+  logger.info(`  -> HU Board port: ${config.hu_board.port}`);
+}
 
 async function runWizard(config, logger) {
   const agents = await detectAvailableAgents();
@@ -41,30 +235,7 @@ async function runWizard(config, logger) {
 
   const wizard = createWizard();
   try {
-    if (available.length === 1) {
-      const only = available[0].name;
-      logger.info(`Only one agent available: ${only}. Using it for all roles.\n`);
-      config.coder = only;
-      config.reviewer = only;
-      config.roles.coder.provider = only;
-      config.roles.reviewer.provider = only;
-    } else {
-      const agentOptions = available.map((a) => ({
-        label: `${a.name} (${a.version})`,
-        value: a.name,
-        available: true
-      }));
-
-      const coder = await wizard.select("Select default CODER agent:", agentOptions);
-      config.coder = coder;
-      config.roles.coder.provider = coder;
-      logger.info(`  -> Coder: ${coder}`);
-
-      const reviewer = await wizard.select("Select default REVIEWER agent:", agentOptions);
-      config.reviewer = reviewer;
-      config.roles.reviewer.provider = reviewer;
-      logger.info(`  -> Reviewer: ${reviewer}`);
-    }
+    const { coder, reviewer } = await askAgents(wizard, available, config, logger);
 
     const enableTriage = await wizard.confirm("Enable triage (auto-classify task complexity)?", false);
     config.pipeline.triage = config.pipeline.triage || {};
@@ -84,38 +255,19 @@ async function runWizard(config, logger) {
     }
     logger.info(`  -> HU Board: ${enableHuBoard ? "enabled (auto-start on kj run)" : "disabled"}`);
 
-    const methodology = await wizard.select("Development methodology:", [
-      { label: "TDD (test-driven development)", value: "tdd", available: true },
-      { label: "Standard (no TDD enforcement)", value: "standard", available: true }
-    ]);
-    config.development.methodology = methodology;
-    config.development.require_test_changes = methodology === "tdd";
-    logger.info(`  -> Methodology: ${methodology}`);
+    await askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger);
+    await askMethodology(wizard, config, logger);
+    await askLanguages(wizard, config, logger);
 
-    const detectedLocale = detectOsLocale();
-    const allLangEntries = Object.entries(SUPPORTED_LANGUAGES).map(([code, name]) => ({
-      label: `${name} (${code})`,
-      value: code,
-      available: true
-    }));
-    // Put detected locale first so it becomes the default selection
-    const languageOptions = [
-      ...allLangEntries.filter((o) => o.value === detectedLocale),
-      ...allLangEntries.filter((o) => o.value !== detectedLocale)
-    ];
+    logger.info("");
+    logger.info("Git automation:");
+    await askGitAutomation(wizard, config, logger);
 
-    const pipelineLang = await wizard.select("Pipeline language:", languageOptions);
-    config.language = pipelineLang;
-    logger.info(`  -> Pipeline language: ${pipelineLang}`);
-
-    // Reorder for HU language with pipeline language as default
-    const huLangOptions = [
-      ...allLangEntries.filter((o) => o.value === pipelineLang),
-      ...allLangEntries.filter((o) => o.value !== pipelineLang)
-    ];
-    const huLang = await wizard.select("HU language (for user stories):", huLangOptions);
-    config.hu_language = huLang;
-    logger.info(`  -> HU language: ${huLang}`);
+    if (enableHuBoard) {
+      logger.info("");
+      logger.info("HU Board security:");
+      await askBoardSecurity(wizard, config, logger);
+    }
 
     logger.info("");
   } finally {
@@ -182,7 +334,7 @@ async function ensureCoderRules(coderRulesPath, logger) {
   logger.info("Created .karajan/coder-rules.md");
 }
 
-async function setupSonarQube(config, logger) {
+async function setupSonarQube(config, logger, { interactive } = {}) {
   if (config.sonarqube?.enabled === false) {
     logger.info("SonarQube disabled — skipping container setup.");
     return;
@@ -212,8 +364,32 @@ async function setupSonarQube(config, logger) {
   }
 
   logger.info("SonarQube container started");
+
+  // KJC-TSK-0367: try to bootstrap the analysis token automatically. The
+  // bootstrapper logs in with admin/admin, rotates the password if it's
+  // still the default, and POSTs to /api/user_tokens/generate. On 401 or
+  // any other failure, we fall back to the manual flow that was the only
+  // option before this card.
+  if (interactive) {
+    logger.info("Bootstrapping SonarQube token automatically...");
+    const result = await bootstrapSonarToken({
+      host: config.sonarqube.host || "http://localhost:9000",
+      configPath: getConfigPath(),
+    });
+    if (result.ok) {
+      config.sonarqube.token = result.token;
+      logger.info(`  -> Sonar token saved to ${result.savedTo}`);
+      if (result.passwordRotated) {
+        logger.info(`  -> Sonar admin password rotated. New value at ${result.passwordSavedTo}`);
+      }
+      return;
+    }
+    logger.warn(`Could not auto-generate Sonar token: ${result.reason}`);
+    logger.info("Falling back to manual flow:");
+  }
+
   logger.info("");
-  logger.info("To configure the SonarQube token:");
+  logger.info("To configure the SonarQube token manually:");
   logger.info("  1. Open http://localhost:9000");
   logger.info("  2. Log in (default credentials: admin / admin)");
   logger.info("  3. Go to: My Account > Security > Generate Token");
@@ -402,8 +578,11 @@ export async function initCommand({ logger, flags = {} }) {
     }
   }
 
-  await setupSonarQube(config, logger);
+  await setupSonarQube(config, logger, { interactive });
   await scaffoldCiGateway(config, flags, logger);
+
+  // Persist any changes setupSonarQube made (token, etc.) back to disk.
+  await writeConfig(configPath, config);
 
   // Telemetry: anonymous install event (non-blocking)
   const { sendTelemetryEvent } = await import("../utils/telemetry.js");
@@ -416,3 +595,14 @@ export async function initCommand({ logger, flags = {} }) {
     sendTelemetryEvent("install", { version }, config).catch(() => {});
   } catch { /* non-blocking */ }
 }
+
+// Internal exports for unit testing (KJC-TSK-0367)
+export const __test__ = {
+  askAgents,
+  askPerRoleProviders,
+  askMethodology,
+  askLanguages,
+  askGitAutomation,
+  askBoardSecurity,
+  PER_ROLE_QUESTIONS,
+};

--- a/src/sonar/token-bootstrap.js
+++ b/src/sonar/token-bootstrap.js
@@ -1,0 +1,182 @@
+/**
+ * Sonar token bootstrap (KJC-TSK-0367).
+ *
+ * On `kj init`, after the SonarQube container is up, try to generate the
+ * analysis token via the REST API instead of asking the user to walk
+ * through the web UI manually. The bootstrapper:
+ *
+ *   1. Probes the host with admin/admin (the container default).
+ *   2. If login succeeds AND the password is still default, it rotates
+ *      the password to a freshly generated value and persists that to
+ *      `~/.karajan/sonar.admin-password` (mode 0600). This avoids
+ *      leaving the deployment with the well-known default credentials.
+ *   3. Generates a Global Analysis Token named `karajan-cli` via
+ *      `POST /api/user_tokens/generate` and returns it.
+ *   4. Persists the token to `~/.karajan/sonar.token` (mode 0600). The
+ *      caller writes it into `config.sonarqube.token` separately.
+ *
+ * On any HTTP error, we return `{ ok: false, reason }` and let the
+ * caller fall back to the manual-flow instructions that existed before
+ * this card. We never throw — the wizard must keep going.
+ */
+
+import { writeFileSync, chmodSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getKarajanHome } from "../utils/paths.js";
+import path from "node:path";
+
+const DEFAULT_USER = "admin";
+const DEFAULT_PASS = "admin";
+const TOKEN_NAME = "karajan-cli";
+
+/**
+ * @param {string} host        e.g. http://localhost:9000
+ * @param {string} pathname    "/api/..."
+ * @param {object} opts
+ * @param {"GET"|"POST"} [opts.method="GET"]
+ * @param {Record<string,string>} [opts.form]   form-urlencoded body
+ * @param {string} opts.user
+ * @param {string} opts.pass
+ * @returns {Promise<{ status: number, body: any }>}
+ */
+async function call(host, pathname, opts) {
+  const url = host.replace(/\/$/, "") + pathname;
+  const headers = {
+    Authorization: "Basic " + Buffer.from(`${opts.user}:${opts.pass}`).toString("base64"),
+  };
+  let body;
+  if (opts.method === "POST" && opts.form) {
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
+    body = new URLSearchParams(opts.form).toString();
+  }
+  const res = await fetch(url, { method: opts.method || "GET", headers, body });
+  let parsed = null;
+  const text = await res.text();
+  if (text) {
+    try { parsed = JSON.parse(text); } catch { parsed = text; }
+  }
+  return { status: res.status, body: parsed };
+}
+
+/**
+ * Generate a strong (32-byte hex) random password. We never re-use the
+ * default `admin` password and never persist `admin` to disk.
+ */
+function generatePassword() {
+  return randomBytes(24).toString("base64url");
+}
+
+/**
+ * Persist a value at `~/.karajan/<filename>` with mode 0600.
+ */
+function persistSecret(filename, value) {
+  const home = getKarajanHome();
+  const target = path.join(home, filename);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, value, { mode: 0o600 });
+  try { chmodSync(target, 0o600); } catch { /* best-effort on Windows */ }
+  return target;
+}
+
+/**
+ * Bootstrap the Sonar analysis token. Idempotent: if the
+ * `karajan-cli` token already exists Sonar will refuse to create it
+ * again (HTTP 400 with `"errors":[{"msg":"A user token...exists"}]`).
+ * In that case we delete-and-recreate so kj init always returns a
+ * usable token.
+ *
+ * @param {object} opts
+ * @param {string} opts.host           Default http://localhost:9000
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   token?: string,
+ *   savedTo?: string,
+ *   passwordRotated?: boolean,
+ *   passwordSavedTo?: string,
+ *   reason?: string,
+ * }>}
+ */
+export async function bootstrapSonarToken({ host = "http://localhost:9000" } = {}) {
+  let user = DEFAULT_USER;
+  let pass = DEFAULT_PASS;
+  let passwordRotated = false;
+  let passwordSavedTo = null;
+
+  // 1) Probe: does admin/admin still work?
+  const probe = await call(host, "/api/authentication/validate", { user, pass }).catch((err) => ({ status: 0, body: err.message }));
+  if (probe.status === 0) {
+    return { ok: false, reason: `network error reaching ${host}: ${probe.body}` };
+  }
+  if (probe.status === 401 || (probe.body && probe.body.valid === false)) {
+    return { ok: false, reason: "admin/admin login failed (password may already be customized — set sonarqube.token manually)" };
+  }
+
+  // 2) Rotate the default password if it's still in place. This stops
+  //    the well-known credentials from being a stable attack surface
+  //    on this user's machine.
+  const newPass = generatePassword();
+  const change = await call(host, "/api/users/change_password", {
+    method: "POST",
+    user,
+    pass,
+    form: { login: user, previousPassword: pass, password: newPass },
+  }).catch((err) => ({ status: 0, body: err.message }));
+
+  if (change.status === 204 || change.status === 200) {
+    pass = newPass;
+    passwordRotated = true;
+    passwordSavedTo = persistSecret("sonar.admin-password", pass);
+  } else if (change.status === 400 && Array.isArray(change.body?.errors)
+              && change.body.errors.some(e => /default/i.test(e.msg))) {
+    // Sonar complained the password matches a default — rare. Try with
+    // a longer one.
+    const longerPass = generatePassword() + generatePassword();
+    const retry = await call(host, "/api/users/change_password", {
+      method: "POST",
+      user,
+      pass,
+      form: { login: user, previousPassword: pass, password: longerPass },
+    }).catch(() => ({ status: 0 }));
+    if (retry.status === 204 || retry.status === 200) {
+      pass = longerPass;
+      passwordRotated = true;
+      passwordSavedTo = persistSecret("sonar.admin-password", pass);
+    }
+  } else if (change.status !== 0 && change.status !== 401) {
+    // Non-fatal: probably the admin already changed the password. We
+    // continue using whatever credentials worked at the probe step.
+  }
+
+  // 3) Token already exists? Revoke it so we can re-create cleanly.
+  await call(host, "/api/user_tokens/revoke", {
+    method: "POST",
+    user,
+    pass,
+    form: { name: TOKEN_NAME },
+  }).catch(() => { /* token may not exist — that's fine */ });
+
+  // 4) Generate the analysis token.
+  const gen = await call(host, "/api/user_tokens/generate", {
+    method: "POST",
+    user,
+    pass,
+    form: { name: TOKEN_NAME, type: "GLOBAL_ANALYSIS_TOKEN" },
+  }).catch((err) => ({ status: 0, body: err.message }));
+
+  if (gen.status !== 200 || !gen.body?.token) {
+    const detail = gen.body?.errors?.[0]?.msg || gen.body || `HTTP ${gen.status}`;
+    return { ok: false, reason: `token generation failed: ${detail}`, passwordRotated, passwordSavedTo };
+  }
+
+  const token = gen.body.token;
+  const savedTo = persistSecret("sonar.token", token);
+
+  return {
+    ok: true,
+    token,
+    savedTo,
+    passwordRotated,
+    passwordSavedTo: passwordRotated ? passwordSavedTo : null,
+  };
+}

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -133,14 +133,28 @@ describe("initCommand", () => {
     ]);
 
     const mockWizard = {
-      ask: vi.fn(),
+      ask: vi.fn().mockResolvedValue(""),  // branch_prefix only asked if auto_commit
       confirm: vi.fn().mockResolvedValue(false),
       select: vi.fn()
-        .mockResolvedValueOnce("codex")  // coder
-        .mockResolvedValueOnce("claude") // reviewer
-        .mockResolvedValueOnce("tdd")    // methodology
-        .mockResolvedValueOnce("en")     // pipeline language
-        .mockResolvedValueOnce("en"),    // HU language
+        .mockResolvedValueOnce("codex")        // coder
+        .mockResolvedValueOnce("claude")       // reviewer
+        // KJC-TSK-0367: 10 per-role selects (planner, researcher,
+        // architect, tester, security, solomon, refactorer,
+        // impeccable, perf, hu_reviewer). Sentinel "__default__"
+        // means "inherit from coder/reviewer".
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("__default__")
+        .mockResolvedValueOnce("tdd")          // methodology
+        .mockResolvedValueOnce("en")           // pipeline language
+        .mockResolvedValueOnce("en"),          // HU language
       close: vi.fn()
     };
     createWizard.mockReturnValue(mockWizard);
@@ -148,13 +162,21 @@ describe("initCommand", () => {
     await initCommand({ logger, flags: {} });
 
     expect(detectAvailableAgents).toHaveBeenCalled();
-    expect(mockWizard.select).toHaveBeenCalledTimes(5);
+    // 2 (agents) + 10 (per-role) + 3 (methodology/pipelineLang/huLang) = 15
+    expect(mockWizard.select).toHaveBeenCalledTimes(15);
     expect(writeConfig).toHaveBeenCalled();
     const writtenConfig = writeConfig.mock.calls[0][1];
     expect(writtenConfig.coder).toBe("codex");
     expect(writtenConfig.reviewer).toBe("claude");
     expect(writtenConfig.language).toBe("en");
     expect(writtenConfig.hu_language).toBe("en");
+    // KJC-TSK-0367: per-role providers default to null (inherit at runtime)
+    expect(writtenConfig.roles.tester.provider).toBeNull();
+    expect(writtenConfig.roles.solomon.provider).toBeNull();
+    // git automation defaults to false when user accepts defaults
+    expect(writtenConfig.git.auto_commit).toBe(false);
+    expect(writtenConfig.git.auto_push).toBe(false);
+    expect(writtenConfig.git.auto_pr).toBe(false);
     mockWizard.close();
   });
 
@@ -224,5 +246,220 @@ describe("initCommand", () => {
     expect(mockWizard.confirm).toHaveBeenCalledWith(expect.stringContaining("triage"), false);
     expect(mockWizard.confirm).toHaveBeenCalledWith(expect.stringContaining("SonarQube"), true);
     expect(mockWizard.select).toHaveBeenCalledWith(expect.stringContaining("methodology"), expect.any(Array));
+  });
+});
+
+// =====================================================================
+// KJC-TSK-0367 — direct unit tests for the new wizard sub-functions.
+// We exercise them via the internal `__test__` export so we don't need
+// to drive the whole initCommand pipeline for each scenario.
+// =====================================================================
+describe("askPerRoleProviders (KJC-TSK-0367)", () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  function makeBlankConfig() {
+    return {
+      coder: "claude",
+      reviewer: "codex",
+      roles: {
+        planner: {}, researcher: {}, architect: {}, refactorer: {}, coder: {},
+        reviewer: {}, tester: {}, security: {}, solomon: {}, impeccable: {},
+        triage: {}, discover: {}, architect2: {}, hu_reviewer: {}, perf: {},
+      },
+      pipeline: {
+        planner: { enabled: false }, researcher: { enabled: false },
+        architect: { enabled: false }, refactorer: { enabled: false },
+        tester: { enabled: false }, security: { enabled: false },
+        solomon: { enabled: false }, impeccable: { enabled: false },
+        perf: { enabled: false }, hu_reviewer: { enabled: false },
+      },
+    };
+  }
+
+  it("noop when only one agent is available", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = makeBlankConfig();
+    const wizard = { select: vi.fn() };
+    await __test__.askPerRoleProviders(wizard, [{ name: "claude" }], config, { coder: "claude", reviewer: "claude" }, logger);
+    expect(wizard.select).not.toHaveBeenCalled();
+  });
+
+  it("answering '__default__' for every role leaves provider null and enables the pipeline flag", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = makeBlankConfig();
+    const wizard = { select: vi.fn().mockResolvedValue("__default__") };
+
+    await __test__.askPerRoleProviders(
+      wizard,
+      [{ name: "claude" }, { name: "codex" }],
+      config,
+      { coder: "claude", reviewer: "codex" },
+      logger,
+    );
+
+    // 10 selects: one per non-coder/non-reviewer role we ask about.
+    expect(wizard.select).toHaveBeenCalledTimes(10);
+    // Spot-check several roles
+    expect(config.roles.tester.provider).toBeNull();
+    expect(config.roles.security.provider).toBeNull();
+    expect(config.roles.solomon.provider).toBeNull();
+    expect(config.pipeline.tester.enabled).toBe(true);
+    expect(config.pipeline.solomon.enabled).toBe(true);
+  });
+
+  it("answering '__disabled__' on a disable-allowed role flips its pipeline flag off", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = makeBlankConfig();
+    config.pipeline.researcher.enabled = true;  // pretend it was on
+    const wizard = {
+      select: vi.fn(),
+    };
+    // PER_ROLE_QUESTIONS: planner(disable-allowed), researcher(disable-allowed), architect, tester(no-disable), ...
+    // Rather than tracking exact order, return __disabled__ first time, __default__ otherwise.
+    let call = 0;
+    wizard.select.mockImplementation(() => {
+      call += 1;
+      return Promise.resolve(call === 1 ? "__disabled__" : "__default__");
+    });
+
+    await __test__.askPerRoleProviders(
+      wizard,
+      [{ name: "claude" }, { name: "codex" }],
+      config,
+      { coder: "claude", reviewer: "codex" },
+      logger,
+    );
+
+    // First role asked is planner — should now be disabled.
+    expect(config.pipeline.planner.enabled).toBe(false);
+  });
+
+  it("answering with an explicit CLI name persists provider correctly", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = makeBlankConfig();
+    const wizard = {
+      select: vi.fn().mockResolvedValue("gemini"),
+    };
+
+    await __test__.askPerRoleProviders(
+      wizard,
+      [{ name: "claude" }, { name: "codex" }, { name: "gemini" }],
+      config,
+      { coder: "claude", reviewer: "codex" },
+      logger,
+    );
+
+    expect(config.roles.tester.provider).toBe("gemini");
+    expect(config.roles.solomon.provider).toBe("gemini");
+  });
+});
+
+describe("askGitAutomation (KJC-TSK-0367)", () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  it("persists three booleans + branch_prefix when auto_commit is on", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = {};
+    const wizard = {
+      confirm: vi.fn()
+        .mockResolvedValueOnce(true)   // auto_commit
+        .mockResolvedValueOnce(true)   // auto_push
+        .mockResolvedValueOnce(false), // auto_pr
+      ask: vi.fn().mockResolvedValue("kj/"),
+    };
+
+    await __test__.askGitAutomation(wizard, config, logger);
+
+    expect(config.git.auto_commit).toBe(true);
+    expect(config.git.auto_push).toBe(true);
+    expect(config.git.auto_pr).toBe(false);
+    expect(config.git.branch_prefix).toBe("kj/");
+  });
+
+  it("skips branch_prefix when auto_commit is off", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = {};
+    const wizard = {
+      confirm: vi.fn().mockResolvedValue(false),
+      ask: vi.fn(),
+    };
+
+    await __test__.askGitAutomation(wizard, config, logger);
+
+    expect(config.git.auto_commit).toBe(false);
+    expect(wizard.ask).not.toHaveBeenCalled();
+    expect(config.git.branch_prefix).toBeUndefined();
+  });
+
+  it("falls back to feat/ when user submits an empty branch prefix", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = {};
+    const wizard = {
+      confirm: vi.fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false),
+      ask: vi.fn().mockResolvedValue(""),  // empty input → default
+    };
+
+    await __test__.askGitAutomation(wizard, config, logger);
+
+    expect(config.git.branch_prefix).toBe("feat/");
+  });
+});
+
+describe("askBoardSecurity (KJC-TSK-0367)", () => {
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  it("noop when HU board is disabled", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = { hu_board: { enabled: false } };
+    const wizard = { select: vi.fn(), ask: vi.fn() };
+
+    await __test__.askBoardSecurity(wizard, config, logger);
+
+    expect(wizard.select).not.toHaveBeenCalled();
+    expect(wizard.ask).not.toHaveBeenCalled();
+  });
+
+  it("default loopback bind + default port", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = { hu_board: { enabled: true } };
+    const wizard = {
+      select: vi.fn().mockResolvedValue("127.0.0.1"),
+      ask: vi.fn().mockResolvedValue(""),  // empty port → default
+    };
+
+    await __test__.askBoardSecurity(wizard, config, logger);
+
+    expect(config.hu_board.bind).toBe("127.0.0.1");
+    expect(config.hu_board.port).toBe(4000);
+  });
+
+  it("LAN bind + custom port", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = { hu_board: { enabled: true } };
+    const wizard = {
+      select: vi.fn().mockResolvedValue("0.0.0.0"),
+      ask: vi.fn().mockResolvedValue("5050"),
+    };
+
+    await __test__.askBoardSecurity(wizard, config, logger);
+
+    expect(config.hu_board.bind).toBe("0.0.0.0");
+    expect(config.hu_board.port).toBe(5050);
+  });
+
+  it("falls back to 4000 when user provides invalid port", async () => {
+    const { __test__ } = await import("../src/commands/init.js");
+    const config = { hu_board: { enabled: true } };
+    const wizard = {
+      select: vi.fn().mockResolvedValue("127.0.0.1"),
+      ask: vi.fn().mockResolvedValue("not-a-number"),
+    };
+
+    await __test__.askBoardSecurity(wizard, config, logger);
+
+    expect(config.hu_board.port).toBe(4000);
   });
 });

--- a/tests/sonar-token-bootstrap.test.js
+++ b/tests/sonar-token-bootstrap.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../src/utils/paths.js", () => ({
+  getKarajanHome: vi.fn(),
+}));
+
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock;
+
+let tmpHome;
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "kj-sonar-token-"));
+  const { getKarajanHome } = await import("../src/utils/paths.js");
+  getKarajanHome.mockReturnValue(tmpHome);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  });
+}
+
+describe("bootstrapSonarToken (KJC-TSK-0367)", () => {
+  it("returns ok with token + persists when admin/admin works and password rotates", async () => {
+    fetchMock
+      // 1. validate admin/admin → 200 valid
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      // 2. change_password → 204 (password rotated)
+      .mockReturnValueOnce(jsonResponse(204, ""))
+      // 3. token revoke (idempotent attempt) → 200 or 404, doesn't matter
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      // 4. generate token → 200 with token
+      .mockReturnValueOnce(jsonResponse(200, { token: "squ_aabbccdd11223344" }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(true);
+    expect(r.token).toBe("squ_aabbccdd11223344");
+    expect(r.passwordRotated).toBe(true);
+    expect(fs.readFileSync(r.savedTo, "utf8")).toBe("squ_aabbccdd11223344");
+    expect(fs.readFileSync(r.passwordSavedTo, "utf8").length).toBeGreaterThan(0);
+    if (process.platform !== "win32") {
+      const mode = fs.statSync(r.savedTo).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  it("returns ok=false when admin/admin login fails (password already customized)", async () => {
+    fetchMock.mockReturnValueOnce(jsonResponse(401, { errors: [{ msg: "no" }] }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/admin\/admin login failed/);
+  });
+
+  it("returns ok=false on network error reaching the host", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/network error/i);
+  });
+
+  it("succeeds when password rotation is rejected because the admin already changed it", async () => {
+    // probe ok, change_password 401 (admin already changed), revoke ok, generate ok
+    fetchMock
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      .mockReturnValueOnce(jsonResponse(401, { errors: [{ msg: "incorrect previous password" }] }))
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      .mockReturnValueOnce(jsonResponse(200, { token: "squ_kept_password" }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    // We continue with whatever creds worked at probe; here change failed
+    // so we use the original admin/admin to call generate. The mock
+    // returns a token, so end-to-end should still succeed.
+    expect(r.ok).toBe(true);
+    expect(r.token).toBe("squ_kept_password");
+    expect(r.passwordRotated).toBe(false);
+  });
+
+  it("returns ok=false with reason when token generation itself fails", async () => {
+    fetchMock
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      .mockReturnValueOnce(jsonResponse(204, ""))
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      // Generate fails
+      .mockReturnValueOnce(jsonResponse(403, { errors: [{ msg: "Insufficient privileges" }] }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/Insufficient privileges|token generation failed/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the gap that the pre-talk testing surfaced: the \`kj init\` wizard covered ~30% of the meaningful config. Users had to manually edit \`~/.karajan/kj.config.yml\` to pick a CLI per role, walk through the SonarQube web UI to generate the analysis token, and enable \`auto_commit\`/\`auto_push\`/\`auto_pr\` post-init.

This PR makes \`kj init\` a one-shot setup.

## What's new in the wizard

| Section | Behaviour |
|---|---|
| **Per-role provider** | For each of planner, researcher, architect, refactorer, tester, security, solomon, impeccable, perf, hu_reviewer: choose **inherit from coder/reviewer** (default), **pick a specific CLI**, or **disable the role** (when allowed). |
| **Sonar token bootstrap** | After the container is up, log in admin/admin, **rotate** the default password (saved at \`~/.karajan/sonar.admin-password\` mode 0600), revoke any pre-existing \`karajan-cli\` token, generate a fresh \`GLOBAL_ANALYSIS_TOKEN\`, persist it to \`~/.karajan/sonar.token\` (mode 0600) **and** to \`config.sonarqube.token\`. Falls back to manual flow on any HTTP error. |
| **Git automation** | Three booleans: \`auto_commit\`, \`auto_push\`, \`auto_pr\`. \`branch_prefix\` asked only when \`auto_commit\` is on (default \`feat/\`). |
| **HU Board security** | When HU Board is enabled, prompts for bind host (\`127.0.0.1\` default vs \`0.0.0.0\` with auto-generated token) and port. |

## Tests (`+16` net)

- \`tests/init-wizard.test.js\` extended:
  - Existing happy-path test updated to expect **15** \`wizard.select\` calls (2 agents + 10 per-role + 3 lang/methodology) instead of the pre-fix 5.
  - **4 new direct unit tests** for \`askPerRoleProviders\` covering: noop with one agent, all-defaults, disable case, explicit-CLI case.
  - **3 new tests** for \`askGitAutomation\`.
  - **4 new tests** for \`askBoardSecurity\`.
- **\`tests/sonar-token-bootstrap.test.js\`** (NEW, 5 tests): success path, admin/admin login fails, network error, password rotation rejected, token generation failure.

Internal \`__test__\` export on \`init.js\` so the sub-functions are testable without driving the whole \`initCommand\` pipeline.

## Test plan

- [x] \`npx vitest run\` — **4 375 / 4 375** passing (was 4 359; +16 new).
- [x] ESLint clean on the 5 changed/new files.
- [x] Manually verified the bootstrap flow falls back gracefully when \`fetch\` fails (network mock).

## Out of scope (deferred for follow-up cards)

- Wizard reentrante (\`kj init --role coder --change\`).
- Stack-driven defaults (frontend project → impeccable on by default).
- Sonar **Cloud** token bootstrap (only the local container is covered).

## For the May 21 talk

Pure UX improvement — does NOT affect the demo flow (\`kj run\`, \`kj audit\`). But makes the \"someone in the audience tries kj init at home tonight\" experience drastically better: from 10 manual steps to one wizard.