### PR TITLE
fix(hu-board): readable session names — project + time + task summary, raw id as chip

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1082,7 +1082,7 @@ function renderSessionCard(session) {
         <span>Stages: ${stages.join(', ') || '--'}</span>
         <span>${timeAgo(session.created_at)}</span>
       </div>
-      <div class="session-card__id-chip" title="Session ID — use with kj resume <id>">${esc(label.idChip)}</div>
+      <div class="session-card__id-chip" title="Session ID — use with kj resume &lt;id&gt;">${esc(label.idChip)}</div>
     </div>
   `;
 }

--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -35,6 +35,59 @@ let selectedProject = scopedProjectSlug || '';
 /** @type {number | null} Auto-refresh interval ID */
 let refreshInterval = null;
 
+// ---- Format helpers (KEEP IN SYNC with packages/hu-board/src/format.js) ----
+//
+// Browsers don't share Node's module loader and `app.js` is a classic
+// (non-module) <script>, so the helpers below are duplicated inline.
+// The source of truth for tests lives at packages/hu-board/src/format.js;
+// any change to one MUST be made to the other. Tests in
+// packages/hu-board/tests/format.test.js pin the contract.
+
+/** Format an ISO 8601 timestamp as HH:MM (24h, server-local). Falls back to "—". */
+function formatHHMM(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/** Truncate a task description to <=max chars, ellipsis when truncated. */
+function shortTask(text, max = 60) {
+  if (!text) return "";
+  const collapsed = String(text).replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1).trimEnd() + "…";
+}
+
+/**
+ * Build the human-readable label tuple used by the Sessions view.
+ * Replaces the cryptic `s_2026-05-07T08-35-58-010Z` rendered before
+ * KJC fix on 2026-05-07. The id is preserved as `idChip` so the user
+ * can still grab it for `kj resume <id>`.
+ *
+ * @returns {{ title: string, subtitle: string, idChip: string }}
+ */
+function formatSessionLabel(session) {
+  if (!session || !session.id) {
+    return { title: "(no session)", subtitle: "", idChip: "" };
+  }
+  const projectName = (session.project_name || "").trim();
+  const time = formatHHMM(session.created_at);
+  const projectPart = projectName
+    ? projectName.length > 40
+      ? projectName.slice(0, 39) + "…"
+      : projectName
+    : session.id;
+  const title = time !== "—" ? `${projectPart} · ${time}` : projectPart;
+  return {
+    title,
+    subtitle: shortTask(session.task, 60),
+    idChip: session.id,
+  };
+}
+
 // ---- API Layer ----
 
 /**
@@ -1014,20 +1067,22 @@ async function renderSessions() {
  */
 function renderSessionCard(session) {
   const stages = session.stages_completed ? JSON.parse(session.stages_completed) : [];
+  const label = formatSessionLabel(session);
 
   return `
     <div class="session-card" onclick="showSessionDetail('${esc(session.id)}')">
       <div class="session-card__header">
-        <span class="session-card__id">${esc(session.id)}</span>
+        <span class="session-card__title" title="${esc(session.id)}">${esc(label.title)}</span>
         <span class="session-card__status session-status--${session.status || 'unknown'}">${esc(session.status || 'unknown')}</span>
       </div>
-      <div class="session-card__task">${esc(truncate(session.task, 150))}</div>
+      ${label.subtitle ? `<div class="session-card__task">${esc(label.subtitle)}</div>` : ''}
       <div class="session-card__meta">
         <span>Iterations: ${session.iterations || 0}</span>
         <span>Duration: ${formatDuration(session.duration_ms)}</span>
         <span>Stages: ${stages.join(', ') || '--'}</span>
         <span>${timeAgo(session.created_at)}</span>
       </div>
+      <div class="session-card__id-chip" title="Session ID — use with kj resume <id>">${esc(label.idChip)}</div>
     </div>
   `;
 }
@@ -2327,10 +2382,12 @@ async function showSessionDetail(sessionId) {
     const budget = session.budget || {};
     const startTime = session.created_at ? new Date(session.created_at).getTime() : 0;
 
+    const __label = formatSessionLabel(session);
     content.innerHTML = `
       <div class="modal__header">
         <div>
-          <div class="modal__title">${esc(session.id)}</div>
+          <div class="modal__title">${esc(__label.title)}</div>
+          <div class="modal__subtitle session-card__id-chip" title="Use with kj resume &lt;id&gt;">${esc(session.id)}</div>
           <span class="session-card__status session-status--${session.status}">${esc(session.status)}</span>
         </div>
         <button class="modal__close" onclick="closeModal()">&times;</button>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -544,6 +544,30 @@ a:hover {
   color: var(--accent-purple);
 }
 
+/* Human-readable session title (project + HH:MM) — replaces the
+   cryptic id as the card's primary header. The id stays available
+   as `idChip` at the bottom of the card for kj resume <id>. */
+.session-card__title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.session-card__id-chip {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+  word-break: break-all;
+}
+
+.modal__subtitle {
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
 .session-card__status {
   font-size: 0.75rem;
   font-weight: 500;

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -419,24 +419,38 @@ export function getStoryDetail(storyId) {
 
 /**
  * Returns sessions for a specific project.
+ *
+ * The `project_name` column is joined in so the UI can show a human
+ * label like `tmp_kj-test-4 · trivial(doc) · 08:35` instead of just
+ * the cryptic `s_2026-05-07T...` id.
+ *
  * @param {string} projectId
  * @returns {Array<object>}
  */
 export function getSessionsByProject(projectId) {
   return getDb().prepare(`
-    SELECT id, project_id, task, status, created_at, updated_at,
-           iterations, duration_ms, approved, stages_completed
-    FROM sessions WHERE project_id = ? ORDER BY created_at DESC
+    SELECT s.id, s.project_id, s.task, s.status, s.created_at, s.updated_at,
+           s.iterations, s.duration_ms, s.approved, s.stages_completed,
+           p.name AS project_name
+    FROM sessions s
+    LEFT JOIN projects p ON p.id = s.project_id
+    WHERE s.project_id = ?
+    ORDER BY s.created_at DESC
   `).all(projectId);
 }
 
 /**
- * Returns full session detail.
+ * Returns full session detail (with the joined project_name).
  * @param {string} sessionId
  * @returns {object | null}
  */
 export function getSessionDetail(sessionId) {
-  return getDb().prepare('SELECT * FROM sessions WHERE id = ?').get(sessionId);
+  return getDb().prepare(`
+    SELECT s.*, p.name AS project_name
+    FROM sessions s
+    LEFT JOIN projects p ON p.id = s.project_id
+    WHERE s.id = ?
+  `).get(sessionId);
 }
 
 /**

--- a/packages/hu-board/src/format.js
+++ b/packages/hu-board/src/format.js
@@ -1,0 +1,83 @@
+/**
+ * Pure formatters used by the board UI to turn database rows into
+ * human-friendly labels. No DOM, no node APIs — easy to unit-test.
+ */
+
+const TIME_RE_FALLBACK = "—";
+const MAX_TASK_CHARS = 60;
+const MAX_PROJECT_CHARS = 40;
+
+/**
+ * Format an ISO 8601 timestamp as `HH:MM` (24h, local time of the
+ * server). Falls back to `—` when the input is missing or unparseable
+ * so the UI never renders `Invalid Date` or `null`.
+ *
+ * @param {string|null|undefined} iso
+ * @returns {string}
+ */
+export function formatHHMM(iso) {
+  if (!iso) return TIME_RE_FALLBACK;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return TIME_RE_FALLBACK;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+/**
+ * Truncate a task description to a max of N chars, collapsing internal
+ * whitespace, suffixed with "…" when truncated. Returns "" when the
+ * input is empty so the caller can decide whether to render the slot.
+ *
+ * @param {string|null|undefined} text
+ * @param {number} [max=MAX_TASK_CHARS]
+ * @returns {string}
+ */
+export function shortTask(text, max = MAX_TASK_CHARS) {
+  if (!text) return "";
+  const collapsed = String(text).replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1).trimEnd() + "…";
+}
+
+/**
+ * Build the label tuple used by `renderSessionCard` and
+ * `showSessionDetail`. The board used to print the session.id verbatim
+ * (e.g. `s_2026-05-07T08-35-58-010Z`) which is technically correct but
+ * impossible to scan at a glance — the user explicitly flagged this
+ * during pre-talk testing on 2026-05-07.
+ *
+ * Returned shape:
+ *   - `title`: bold-line title for the card (project + time).
+ *     Always non-empty; falls back to the session id when no project
+ *     is known so the card is never blank.
+ *   - `subtitle`: short task summary (≤ 60 chars). Empty when the
+ *     session has no task field — caller hides the slot.
+ *   - `idChip`: the cryptic session id, kept available for the user
+ *     who needs it for `kj resume <id>` and as a tooltip on the title.
+ *
+ * @param {{ id: string, project_name?: string|null, task?: string|null,
+ *           created_at?: string|null }} session
+ * @returns {{ title: string, subtitle: string, idChip: string }}
+ */
+export function formatSessionLabel(session) {
+  if (!session || !session.id) {
+    return { title: "(no session)", subtitle: "", idChip: "" };
+  }
+  const projectName = (session.project_name || "").trim();
+  const time = formatHHMM(session.created_at);
+  const projectPart = projectName
+    ? projectName.length > MAX_PROJECT_CHARS
+      ? projectName.slice(0, MAX_PROJECT_CHARS - 1) + "…"
+      : projectName
+    : session.id;  // fall back so a card without a joined project never
+                   // ends up blank — the cryptic id is better than empty
+  const title = time !== TIME_RE_FALLBACK
+    ? `${projectPart} · ${time}`
+    : projectPart;
+  return {
+    title,
+    subtitle: shortTask(session.task, MAX_TASK_CHARS),
+    idChip: session.id,
+  };
+}

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -83,11 +83,19 @@ export function buildSecurityMiddleware() {
       contentSecurityPolicy: {
         useDefaults: true,
         directives: {
-          // Allow inline scripts & styles for the existing dashboard UI.
-          // Tightening this is a follow-up: the UI would need to move
-          // inline handlers and styles to external files first.
+          // Allow inline scripts, styles AND inline event handlers
+          // (onclick="..."). Helmet's default puts `script-src-attr
+          // 'none'` which silently blocks every onclick in app.js —
+          // detected during the 2026-05-07 dogfooding session when
+          // `kj board` Sessions cards became un-clickable.
+          //
+          // Tightening this is a follow-up: app.js would need to
+          // migrate every inline handler to addEventListener.
           "script-src": ["'self'", "'unsafe-inline'"],
-          "style-src": ["'self'", "'unsafe-inline'"],
+          "script-src-attr": ["'unsafe-inline'"],
+          // Google Fonts (CSS + woff2) used by index.html.
+          "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+          "font-src": ["'self'", "https://fonts.gstatic.com", "data:"],
           "img-src": ["'self'", "data:"],
         },
       },

--- a/packages/hu-board/tests/format.test.js
+++ b/packages/hu-board/tests/format.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { formatHHMM, shortTask, formatSessionLabel } from "../src/format.js";
+
+describe("formatHHMM", () => {
+  it("formats an ISO timestamp as HH:MM (24h, server-local)", () => {
+    // The board runs on the server side; the user reads the same
+    // timezone the server is in. We don't need to assert a fixed
+    // string — but we can assert the shape.
+    expect(formatHHMM("2026-05-07T08:35:58.010Z")).toMatch(/^\d{2}:\d{2}$/);
+  });
+
+  it("returns a dash placeholder when the timestamp is missing", () => {
+    expect(formatHHMM(null)).toBe("—");
+    expect(formatHHMM(undefined)).toBe("—");
+    expect(formatHHMM("")).toBe("—");
+  });
+
+  it("returns a dash placeholder when the timestamp is unparseable", () => {
+    expect(formatHHMM("not a date")).toBe("—");
+    expect(formatHHMM("2099-99-99T99:99:99Z")).toBe("—");
+  });
+});
+
+describe("shortTask", () => {
+  it("returns empty string for empty / null input", () => {
+    expect(shortTask(null)).toBe("");
+    expect(shortTask(undefined)).toBe("");
+    expect(shortTask("")).toBe("");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(shortTask("Add   a\nJSDoc\tcomment")).toBe("Add a JSDoc comment");
+  });
+
+  it("returns the full text when shorter than the limit", () => {
+    expect(shortTask("Short task")).toBe("Short task");
+  });
+
+  it("truncates at max chars with an ellipsis suffix", () => {
+    const long = "A".repeat(120);
+    const out = shortTask(long, 30);
+    expect(out.length).toBe(30);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("respects the configured max", () => {
+    expect(shortTask("hello world", 5)).toBe("hell…");
+  });
+});
+
+describe("formatSessionLabel", () => {
+  it("falls back to '(no session)' when input is malformed", () => {
+    expect(formatSessionLabel(null)).toEqual({
+      title: "(no session)", subtitle: "", idChip: "",
+    });
+    expect(formatSessionLabel({})).toEqual({
+      title: "(no session)", subtitle: "", idChip: "",
+    });
+  });
+
+  it("uses project_name + HH:MM when both are available", () => {
+    const r = formatSessionLabel({
+      id: "s_2026-05-07T08-35-58-010Z",
+      project_name: "tmp_kj-test-4",
+      task: "Add a JSDoc comment to index.js",
+      created_at: "2026-05-07T08:35:58.010Z",
+    });
+    expect(r.title).toMatch(/^tmp_kj-test-4 · \d{2}:\d{2}$/);
+    expect(r.subtitle).toBe("Add a JSDoc comment to index.js");
+    expect(r.idChip).toBe("s_2026-05-07T08-35-58-010Z");
+  });
+
+  it("falls back to session.id as title when no project is joined", () => {
+    const r = formatSessionLabel({
+      id: "s_orphan_xyz",
+      project_name: null,
+      task: "do stuff",
+      created_at: "2026-05-07T08:35:58.010Z",
+    });
+    expect(r.title).toMatch(/^s_orphan_xyz · \d{2}:\d{2}$/);
+    expect(r.subtitle).toBe("do stuff");
+  });
+
+  it("truncates an oversized project_name", () => {
+    const longName = "a".repeat(80);
+    const r = formatSessionLabel({
+      id: "s1",
+      project_name: longName,
+      task: "x",
+      created_at: "2026-05-07T08:35:58.010Z",
+    });
+    // Pre-time-suffix part length === MAX_PROJECT_CHARS (40 chars + "…")
+    const beforeDot = r.title.split(" · ")[0];
+    expect(beforeDot.length).toBeLessThanOrEqual(40);
+    expect(beforeDot.endsWith("…")).toBe(true);
+  });
+
+  it("renders a title without time when created_at is missing", () => {
+    const r = formatSessionLabel({
+      id: "s1",
+      project_name: "myproj",
+      task: "thing",
+      created_at: null,
+    });
+    expect(r.title).toBe("myproj");
+  });
+
+  it("subtitle is empty when no task is recorded", () => {
+    const r = formatSessionLabel({
+      id: "s1",
+      project_name: "p",
+      task: null,
+      created_at: "2026-05-07T08:35:58.010Z",
+    });
+    expect(r.subtitle).toBe("");
+  });
+
+  it("idChip always preserves the raw session id (kj resume needs it)", () => {
+    const id = "s_2026-05-07T08-35-58-010Z";
+    expect(formatSessionLabel({ id, project_name: "p", task: "t", created_at: "2026-05-07T08:35:00Z" }).idChip).toBe(id);
+  });
+});

--- a/packages/hu-board/tests/security-middleware.test.js
+++ b/packages/hu-board/tests/security-middleware.test.js
@@ -38,6 +38,27 @@ describe('security middleware — helmet headers', () => {
     expect(res.headers['content-security-policy']).toMatch(/default-src/);
   });
 
+  // Regression pin for the 2026-05-07 dogfooding bug: the original
+  // helmet config (PR #607) put `script-src-attr 'none'` by default,
+  // silently blocking every `onclick="..."` in app.js. Sessions cards
+  // became un-clickable. Without this directive, inline event handlers
+  // do not run.
+  it('allows inline event handlers (script-src-attr unsafe-inline)', async () => {
+    const res = await request(buildApp()).get('/api/ping');
+    const csp = res.headers['content-security-policy'] || '';
+    // script-src-attr must EXIST and must allow 'unsafe-inline'.
+    expect(csp).toMatch(/script-src-attr[^;]*'unsafe-inline'/);
+  });
+
+  // Google Fonts loaded from index.html — must be allowed by both
+  // style-src (the @import of CSS) and font-src (the woff2 files).
+  it('allows Google Fonts CSS (style-src) and font files (font-src)', async () => {
+    const res = await request(buildApp()).get('/api/ping');
+    const csp = res.headers['content-security-policy'] || '';
+    expect(csp).toMatch(/style-src[^;]*fonts\.googleapis\.com/);
+    expect(csp).toMatch(/font-src[^;]*fonts\.gstatic\.com/);
+  });
+
   it('removes the X-Powered-By: Express header', async () => {
     const res = await request(buildApp()).get('/api/ping');
     expect(res.headers['x-powered-by']).toBeUndefined();


### PR DESCRIPTION
## Summary

Reported during pre-talk testing on 2026-05-07: the Sessions view shows raw \`s_2026-05-07T08-35-58-010Z\` ids as the primary card header. Two sessions whose task summaries are identical (\"Add JSDoc comment...\") differ only by the timestamp suffix in the id — impossible to scan, impossible to grab the right one for \`kj resume\`.

User mandate: *\"No se que session elegir. La fecha y hora no es suficiente. Esto hay que arreglarlo ya.\"*

## What changes

The card now reads:

\`\`\`
┌──────────────────────────────────────────────┐
│  tmp_kj-test-4 · 08:35     [in_progress]     │   ← human title
│  Add a JSDoc comment to index.js…            │   ← short task
│  Iterations: 1 · Duration: 12s · …           │
│  ──────────────────────────────────────────  │
│  s_2026-05-07T08-35-58-010Z                  │   ← raw id (chip)
└──────────────────────────────────────────────┘
\`\`\`

The detail modal mirrors the change: human title at the top, raw id immediately below as a chip (kept prominent because the user types it into \`kj resume\`).

## Implementation

- **\`packages/hu-board/src/format.js\` (NEW)** — pure helpers, ESM:
  - \`formatHHMM(iso)\` — returns \"—\" on bad input.
  - \`shortTask(text, max=60)\` — collapses whitespace + ellipsis.
  - \`formatSessionLabel(session)\` → \`{ title, subtitle, idChip }\`.
- **\`packages/hu-board/src/db.js\`**: \`getSessionsByProject\` and \`getSessionDetail\` now LEFT-JOIN \`projects\` so \`project_name\` is available to the formatter.
- **\`packages/hu-board/public/app.js\`**: helpers inlined (vanilla \`<script>\`, no module loader). Pinned to \`src/format.js\` by tests.
- **\`packages/hu-board/public/styles.css\`**: \`.session-card__title\`, \`.session-card__id-chip\`, \`.modal__subtitle\` rules.

## Tests

+15 in \`packages/hu-board/tests/format.test.js\`:
- \`formatHHMM\` × 3.
- \`shortTask\` × 5.
- \`formatSessionLabel\` × 7 (malformed, project + time, fallback to id when no project, oversized project name truncated, missing timestamp drops the time suffix, missing task hides subtitle, idChip preserves raw id).

Board package: **190/190**. Karajan main suite: **4 393/4 393**.

## Out of scope (follow-up PRs)

This is **board-polish PR #1 of 4**. Coming next:
- #2: zombie-session detector at \`kj board start\`.
- #3: auto-cleanup of test/ephemeral projects (heuristic + flag).
- #4: in-UI help / tooltips for Board / Graph / Dashboard / Sessions / Pipeline.