### PR TITLE
feat(hu-board): zombie session reaper at boot (KJC board polish #2)

### DIFF
--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -228,14 +228,51 @@ async function main() {
   });
 
   // Graceful shutdown
+  //
+  // Two pre-2026-05-07 footguns this fixes:
+  //
+  //   1) `server.close()` was called LAST, so for ~1s after `kj board
+  //      stop` the HTTP server stayed up while watcher/DB cleanup ran.
+  //      A browser refresh during that window — exactly the user's
+  //      "1 segundo después se carga el board" report — saw a working
+  //      board because the old keep-alive connections were still
+  //      being served. Now we tell the server to stop accepting new
+  //      connections IMMEDIATELY.
+  //
+  //   2) `server.close()` only waits for active connections to drain.
+  //      The browser's HTTP/1.1 keep-alive connections can stay open
+  //      for minutes, so the daemon process never actually exited
+  //      after stop. `closeAllConnections()` (Node 18.2+) force-kills
+  //      every active socket so the daemon can exit promptly.
+  //
+  //   3) A 5s hard deadline guarantees exit even if something goes
+  //      wrong with the cleanup. SIGKILL-by-the-OS is the cure if
+  //      the user really wants out, but a clean exit is the goal.
+  let shuttingDown = false;
   const shutdown = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     console.log('\n[server] Shutting down...');
-    watcher.close();
-    closeDb();
-    // Best-effort PID file cleanup on graceful exit. If we crash the
-    // file stays — the CLI's `isProcessAlive` check handles that.
-    try { rmSync(PID_FILE, { force: true }); } catch { /* ignore */ }
-    server.close(() => process.exit(0));
+    // 1. Stop accepting new connections + force-close existing ones.
+    server.close(() => {
+      // The cleanup happens in the close callback so we don't run it
+      // before the server has detached from its listening socket.
+      try { watcher.close(); } catch { /* ignore */ }
+      try { closeDb(); } catch { /* ignore */ }
+      try { rmSync(PID_FILE, { force: true }); } catch { /* ignore */ }
+      console.log('[server] Shutdown complete.');
+      process.exit(0);
+    });
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+    }
+    // 5s hard deadline: if the close callback hasn't fired by then,
+    // something is wedged — exit anyway. unref so this timer doesn't
+    // itself keep the loop alive.
+    setTimeout(() => {
+      console.warn('[server] Forced exit after 5s shutdown deadline.');
+      process.exit(1);
+    }, 5000).unref();
   };
 
   process.on('SIGINT', shutdown);

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -137,28 +137,33 @@ async function main() {
   console.log('[server] Initializing database...');
   initDb();
 
+  // Full scan of existing files BEFORE the reaper runs. Otherwise
+  // fullScan would read every session.json from disk and overwrite
+  // the reap-failed status the reaper just set, resurrecting the
+  // zombie on every boot. Order matters here.
+  console.log('[server] Running full scan of JSON files...');
+  fullScan();
+
   // Reap any session that the orchestrator left in a non-terminal
-  // state. The board used to surface 8-day-old `Karajan needs an
-  // answer` modals on startup because nothing ever flipped those
-  // sessions to `failed`. See packages/hu-board/src/zombie-reaper.js
-  // for the threshold rationale.
+  // state. Updates BOTH the DB row AND the session.json on disk so
+  // the next boot's fullScan sees a stable `failed` status and never
+  // resurrects the zombi.
   try {
     const dbHandle = (await import('./db.js')).getDb();
     const reaped = reapZombieSessions({ db: dbHandle });
     if (reaped.length > 0) {
       console.log(`[zombie-reaper] reaped ${reaped.length} stale session(s):`);
       for (const r of reaped) {
-        console.log(`  - ${r.id} (was ${r.status_before}; ${r.reason})`);
+        const diskNote = r.disk_persisted ? '' : ' (disk write failed — DB-only)';
+        console.log(`  - ${r.id} (was ${r.status_before}; ${r.reason})${diskNote}`);
       }
+    } else {
+      console.log('[zombie-reaper] no zombie sessions detected');
     }
   } catch (err) {
     // Never block startup on the reaper. Log and move on.
     console.warn(`[zombie-reaper] skipped: ${err.message}`);
   }
-
-  // Full scan of existing files
-  console.log('[server] Running full scan of JSON files...');
-  fullScan();
 
   // Start file watcher
   const watcher = startWatcher();

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -11,6 +11,7 @@ import apiRoutes from './routes/api.js';
 import pipelineRoutes from './routes/pipeline.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
+import { reapZombieSessions } from './zombie-reaper.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
 /**
@@ -135,6 +136,25 @@ async function main() {
   // Initialize SQLite
   console.log('[server] Initializing database...');
   initDb();
+
+  // Reap any session that the orchestrator left in a non-terminal
+  // state. The board used to surface 8-day-old `Karajan needs an
+  // answer` modals on startup because nothing ever flipped those
+  // sessions to `failed`. See packages/hu-board/src/zombie-reaper.js
+  // for the threshold rationale.
+  try {
+    const dbHandle = (await import('./db.js')).getDb();
+    const reaped = reapZombieSessions({ db: dbHandle });
+    if (reaped.length > 0) {
+      console.log(`[zombie-reaper] reaped ${reaped.length} stale session(s):`);
+      for (const r of reaped) {
+        console.log(`  - ${r.id} (was ${r.status_before}; ${r.reason})`);
+      }
+    }
+  } catch (err) {
+    // Never block startup on the reaper. Log and move on.
+    console.warn(`[zombie-reaper] skipped: ${err.message}`);
+  }
 
   // Full scan of existing files
   console.log('[server] Running full scan of JSON files...');

--- a/packages/hu-board/src/zombie-reaper.js
+++ b/packages/hu-board/src/zombie-reaper.js
@@ -1,0 +1,141 @@
+/**
+ * Zombie session reaper for the HU Board (board-polish #2,
+ * KJC dogfooding 2026-05-07).
+ *
+ * Why this exists
+ * ===============
+ *
+ * Sessions in the SQLite db can stay "in flight" forever when the
+ * orchestrator process dies between iterations: their `status` stays
+ * `coding` / `stalled` / `paused`, the UI keeps surfacing them as
+ * actionable, and `kj board start` weeks later still pops a
+ * "Karajan needs an answer" modal for a checkpoint nobody owns
+ * anymore.
+ *
+ * Concretely, on 2026-05-07 the user opened the board on a fresh
+ * `kj board start` and saw the popup of an HU from 2026-04-29 — that
+ * was 8 days dead. The fix per his explicit mandate:
+ *
+ *   "No puede quedarse nada zombie. Debe haber algun sistema que lo
+ *    compruebe al arrancar y mate esos zombies."
+ *
+ * Thresholds (per his decision in the same session):
+ *   - status in (coding | stalled) and >= 6h since updated_at  → reap
+ *   - status === paused and >= 24h since updated_at            → reap
+ *   - everything else                                          → skip
+ *
+ * What "reap" means: set the session's `status` column to `failed`
+ * and append a structured checkpoint of the form
+ *   { stage: 'zombie-reap', reason: <reason>, at: <iso> }
+ * to the existing `checkpoints` JSON blob, so the audit trail
+ * survives. The session row stays in place (we don't DELETE — the
+ * user can still inspect what happened).
+ */
+
+const DEFAULT_CODING_HOURS = 6;
+const DEFAULT_PAUSED_HOURS = 24;
+const CODING_LIKE_STATUSES = new Set(["coding", "stalled", "running", "in_progress"]);
+const PAUSED_STATUSES = new Set(["paused", "checkpoint", "awaiting_answer"]);
+
+/**
+ * Decide whether a single session row qualifies as zombie at `now`.
+ * Pure function — no I/O. Used by both the reaper itself and the
+ * unit tests.
+ *
+ * @param {{ id: string, status: string, updated_at?: string|null,
+ *           created_at?: string|null }} session
+ * @param {{ now: number, codingHours: number, pausedHours: number }} ctx
+ * @returns {{ zombie: boolean, reason?: string }}
+ */
+export function classifyZombie(session, ctx) {
+  if (!session || !session.status) return { zombie: false };
+  const status = String(session.status).toLowerCase();
+  // Reference timestamp: prefer updated_at (the daemon writes that on
+  // every checkpoint sync), fall back to created_at (in case the row
+  // was inserted but never touched again).
+  const refIso = session.updated_at || session.created_at;
+  if (!refIso) return { zombie: false };
+  const refTs = new Date(refIso).getTime();
+  if (Number.isNaN(refTs)) return { zombie: false };
+  const ageHours = (ctx.now - refTs) / 3_600_000;
+  if (ageHours <= 0) return { zombie: false };
+  if (CODING_LIKE_STATUSES.has(status) && ageHours >= ctx.codingHours) {
+    return { zombie: true, reason: `${status} ${ageHours.toFixed(1)}h inactive (>= ${ctx.codingHours}h)` };
+  }
+  if (PAUSED_STATUSES.has(status) && ageHours >= ctx.pausedHours) {
+    return { zombie: true, reason: `${status} ${ageHours.toFixed(1)}h inactive (>= ${ctx.pausedHours}h)` };
+  }
+  return { zombie: false };
+}
+
+/**
+ * Filter a list of session rows down to the zombie ones. Pure.
+ *
+ * @param {Array<object>} sessions
+ * @param {{ now?: number, codingHours?: number, pausedHours?: number }} [opts]
+ * @returns {Array<{ session: object, reason: string }>}
+ */
+export function findZombieSessions(sessions, opts = {}) {
+  const ctx = {
+    now: opts.now ?? Date.now(),
+    codingHours: opts.codingHours ?? DEFAULT_CODING_HOURS,
+    pausedHours: opts.pausedHours ?? DEFAULT_PAUSED_HOURS,
+  };
+  const out = [];
+  for (const session of sessions || []) {
+    const verdict = classifyZombie(session, ctx);
+    if (verdict.zombie) out.push({ session, reason: verdict.reason });
+  }
+  return out;
+}
+
+/**
+ * Append a `zombie-reap` checkpoint to a JSON-encoded checkpoints
+ * blob (the on-disk format). Returns the new JSON string.
+ *
+ * Defensive about malformed input: if the existing blob isn't a
+ * JSON array, replaces it with a fresh array containing the new
+ * entry — never throws.
+ */
+export function appendZombieCheckpoint(existingJson, reason, isoTimestamp) {
+  let arr = [];
+  if (existingJson) {
+    try {
+      const parsed = JSON.parse(existingJson);
+      if (Array.isArray(parsed)) arr = parsed;
+    } catch { /* fall through with empty arr */ }
+  }
+  arr.push({ stage: "zombie-reap", reason, at: isoTimestamp });
+  return JSON.stringify(arr);
+}
+
+/**
+ * Reap every zombie session in the DB. Side-effecting: updates
+ * `status` and `checkpoints`. Returns the list of reaped sessions
+ * so the server can log them.
+ *
+ * @param {object} deps
+ * @param {object} deps.db        better-sqlite3 Database handle
+ * @param {object} [deps.opts]    threshold overrides
+ * @param {Function} [deps.now]   () => number, for tests
+ * @returns {Array<{ id: string, status_before: string, reason: string }>}
+ */
+export function reapZombieSessions({ db, opts = {}, now = () => Date.now() }) {
+  if (!db) return [];
+  const allSessions = db.prepare(
+    "SELECT id, status, updated_at, created_at, checkpoints FROM sessions WHERE status NOT IN ('failed', 'approved', 'cancelled', 'done')",
+  ).all();
+  const zombies = findZombieSessions(allSessions, { ...opts, now: now() });
+  if (zombies.length === 0) return [];
+  const update = db.prepare(
+    "UPDATE sessions SET status = 'failed', checkpoints = ?, updated_at = ? WHERE id = ?",
+  );
+  const reapedAt = new Date(now()).toISOString();
+  const reaped = [];
+  for (const { session, reason } of zombies) {
+    const newCheckpoints = appendZombieCheckpoint(session.checkpoints, reason, reapedAt);
+    update.run(newCheckpoints, reapedAt, session.id);
+    reaped.push({ id: session.id, status_before: session.status, reason });
+  }
+  return reaped;
+}

--- a/packages/hu-board/src/zombie-reaper.js
+++ b/packages/hu-board/src/zombie-reaper.js
@@ -13,8 +13,9 @@
  * anymore.
  *
  * Concretely, on 2026-05-07 the user opened the board on a fresh
- * `kj board start` and saw the popup of an HU from 2026-04-29 — that
- * was 8 days dead. The fix per his explicit mandate:
+ * `kj board start` and saw the popup of an HU from 2026-04-27 — 9
+ * days dead, status still `paused`. The fix per his explicit
+ * mandate:
  *
  *   "No puede quedarse nada zombie. Debe haber algun sistema que lo
  *    compruebe al arrancar y mate esos zombies."
@@ -24,13 +25,27 @@
  *   - status === paused and >= 24h since updated_at            → reap
  *   - everything else                                          → skip
  *
- * What "reap" means: set the session's `status` column to `failed`
- * and append a structured checkpoint of the form
+ * What "reap" means: write `status: "failed"` BOTH to the DB row
+ * AND to the underlying `~/.karajan/sessions/<id>/session.json`,
+ * append a structured checkpoint of the form
  *   { stage: 'zombie-reap', reason: <reason>, at: <iso> }
- * to the existing `checkpoints` JSON blob, so the audit trail
- * survives. The session row stays in place (we don't DELETE — the
- * user can still inspect what happened).
+ * so the audit trail survives. The session row stays in place
+ * (we don't DELETE — the user can still inspect what happened).
+ *
+ * Why update the JSON on disk too
+ * -------------------------------
+ *
+ * The board's `fullScan()` reads every session.json on startup and
+ * upserts the row, OVERWRITING any DB-only mutation. If the reaper
+ * only updated the DB, the next reboot would reset the status back
+ * to `paused`/`stalled` because the JSON still says so. Persisting
+ * to disk makes the reap permanent on the first reboot — the user
+ * sees the cleanup once, and never again.
  */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 const DEFAULT_CODING_HOURS = 6;
 const DEFAULT_PAUSED_HOURS = 24;
@@ -110,15 +125,59 @@ export function appendZombieCheckpoint(existingJson, reason, isoTimestamp) {
 }
 
 /**
- * Reap every zombie session in the DB. Side-effecting: updates
- * `status` and `checkpoints`. Returns the list of reaped sessions
- * so the server can log them.
+ * Default location of the on-disk session JSON files.
+ * Honours $KJ_HOME so tests and per-user setups can point elsewhere.
+ *
+ * @returns {string}
+ */
+export function getSessionsDir() {
+  const home = process.env.KJ_HOME || path.join(os.homedir(), ".karajan");
+  return path.join(home, "sessions");
+}
+
+/**
+ * Persist `status: "failed"` and the new zombie-reap checkpoint to
+ * the on-disk session.json. This stops the next `fullScan()` from
+ * resurrecting the zombi.
+ *
+ * Safe-by-default: if the file is missing, malformed, or the write
+ * fails, this returns `false` and the caller logs a warning. We
+ * never throw and we never block the daemon's startup.
+ *
+ * @param {string} sessionId
+ * @param {string} reason
+ * @param {string} reapedAtIso
+ * @param {{ sessionsDir?: string }} [opts]
+ * @returns {boolean} true when the file was rewritten successfully
+ */
+export function markSessionFailedOnDisk(sessionId, reason, reapedAtIso, opts = {}) {
+  const dir = opts.sessionsDir || getSessionsDir();
+  const file = path.join(dir, sessionId, "session.json");
+  let raw;
+  try { raw = fs.readFileSync(file, "utf8"); } catch { return false; }
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { return false; }
+  if (!parsed || typeof parsed !== "object") return false;
+  parsed.status = "failed";
+  parsed.updated_at = reapedAtIso;
+  parsed.checkpoints = Array.isArray(parsed.checkpoints) ? parsed.checkpoints : [];
+  parsed.checkpoints.push({ stage: "zombie-reap", reason, at: reapedAtIso });
+  try {
+    fs.writeFileSync(file, JSON.stringify(parsed, null, 2));
+    return true;
+  } catch { return false; }
+}
+
+/**
+ * Reap every zombie session in the DB AND in the underlying
+ * session.json files. Side-effecting. Returns the list of reaped
+ * sessions so the server can log them.
  *
  * @param {object} deps
  * @param {object} deps.db        better-sqlite3 Database handle
- * @param {object} [deps.opts]    threshold overrides
+ * @param {object} [deps.opts]    threshold + sessionsDir overrides
  * @param {Function} [deps.now]   () => number, for tests
- * @returns {Array<{ id: string, status_before: string, reason: string }>}
+ * @returns {Array<{ id: string, status_before: string, reason: string, disk_persisted: boolean }>}
  */
 export function reapZombieSessions({ db, opts = {}, now = () => Date.now() }) {
   if (!db) return [];
@@ -135,7 +194,15 @@ export function reapZombieSessions({ db, opts = {}, now = () => Date.now() }) {
   for (const { session, reason } of zombies) {
     const newCheckpoints = appendZombieCheckpoint(session.checkpoints, reason, reapedAt);
     update.run(newCheckpoints, reapedAt, session.id);
-    reaped.push({ id: session.id, status_before: session.status, reason });
+    const diskPersisted = markSessionFailedOnDisk(session.id, reason, reapedAt, {
+      sessionsDir: opts.sessionsDir,
+    });
+    reaped.push({
+      id: session.id,
+      status_before: session.status,
+      reason,
+      disk_persisted: diskPersisted,
+    });
   }
   return reaped;
 }

--- a/packages/hu-board/tests/zombie-reaper.test.js
+++ b/packages/hu-board/tests/zombie-reaper.test.js
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  classifyZombie,
+  findZombieSessions,
+  appendZombieCheckpoint,
+  reapZombieSessions,
+} from "../src/zombie-reaper.js";
+
+const NOW = new Date("2026-05-07T10:00:00.000Z").getTime();
+const HOUR = 3_600_000;
+
+function ago(hours) {
+  return new Date(NOW - hours * HOUR).toISOString();
+}
+
+describe("classifyZombie (KJC board polish #2)", () => {
+  const ctx = { now: NOW, codingHours: 6, pausedHours: 24 };
+
+  it("returns false on missing/empty input", () => {
+    expect(classifyZombie(null, ctx).zombie).toBe(false);
+    expect(classifyZombie({}, ctx).zombie).toBe(false);
+    expect(classifyZombie({ id: "s1", status: "coding" }, ctx).zombie).toBe(false);
+  });
+
+  it("returns false on unparseable timestamps", () => {
+    expect(classifyZombie({ id: "s1", status: "coding", updated_at: "garbage" }, ctx).zombie).toBe(false);
+  });
+
+  it.each([
+    ["coding",       5.99, false],
+    ["coding",       6.01, true],
+    ["stalled",      6.01, true],
+    ["running",      24,   true],
+    ["in_progress", 100,   true],
+    ["coding",       0,    false],   // brand-new
+    ["coding",      -1,    false],   // future timestamp (defensive)
+  ])("status=%s after %sh inactive → zombie=%s", (status, hours, expected) => {
+    const session = { id: "s1", status, updated_at: ago(hours) };
+    expect(classifyZombie(session, ctx).zombie).toBe(expected);
+  });
+
+  it.each([
+    ["paused",           23,  false],
+    ["paused",           25,  true],
+    ["checkpoint",       30,  true],
+    ["awaiting_answer", 168,  true],
+  ])("paused-like status=%s after %sh inactive → zombie=%s", (status, hours, expected) => {
+    const session = { id: "s1", status, updated_at: ago(hours) };
+    expect(classifyZombie(session, ctx).zombie).toBe(expected);
+  });
+
+  it("falls back to created_at when updated_at is absent", () => {
+    const session = { id: "s1", status: "coding", created_at: ago(8) };
+    expect(classifyZombie(session, ctx).zombie).toBe(true);
+  });
+
+  it("ignores terminal statuses (failed, approved)", () => {
+    expect(classifyZombie({ id: "s1", status: "failed", updated_at: ago(168) }, ctx).zombie).toBe(false);
+    expect(classifyZombie({ id: "s2", status: "approved", updated_at: ago(168) }, ctx).zombie).toBe(false);
+  });
+
+  it("includes the reason text with the inactivity duration", () => {
+    const v = classifyZombie({ id: "s1", status: "coding", updated_at: ago(9) }, ctx);
+    expect(v.zombie).toBe(true);
+    expect(v.reason).toMatch(/coding/);
+    expect(v.reason).toMatch(/9\.0h/);
+  });
+});
+
+describe("findZombieSessions", () => {
+  it("returns empty array on empty input", () => {
+    expect(findZombieSessions([], { now: NOW })).toEqual([]);
+    expect(findZombieSessions(null, { now: NOW })).toEqual([]);
+  });
+
+  it("filters only the zombies and preserves the reason", () => {
+    const sessions = [
+      { id: "alive_1",   status: "coding",   updated_at: ago(1) },
+      { id: "zombie_a",  status: "coding",   updated_at: ago(8) },
+      { id: "alive_2",   status: "approved", updated_at: ago(72) },
+      { id: "zombie_b",  status: "paused",   updated_at: ago(48) },
+      { id: "alive_3",   status: "paused",   updated_at: ago(2) },
+    ];
+    const found = findZombieSessions(sessions, { now: NOW });
+    expect(found.map((z) => z.session.id)).toEqual(["zombie_a", "zombie_b"]);
+    expect(found[0].reason).toMatch(/coding/);
+    expect(found[1].reason).toMatch(/paused/);
+  });
+
+  it("respects custom thresholds", () => {
+    const sessions = [
+      { id: "s_strict", status: "coding", updated_at: ago(2) },
+    ];
+    expect(findZombieSessions(sessions, { now: NOW, codingHours: 6 })).toHaveLength(0);
+    expect(findZombieSessions(sessions, { now: NOW, codingHours: 1 })).toHaveLength(1);
+  });
+});
+
+describe("appendZombieCheckpoint", () => {
+  it("creates a fresh array when checkpoints is null", () => {
+    const out = appendZombieCheckpoint(null, "reason", "2026-05-07T10:00Z");
+    expect(JSON.parse(out)).toEqual([{ stage: "zombie-reap", reason: "reason", at: "2026-05-07T10:00Z" }]);
+  });
+
+  it("appends to an existing array", () => {
+    const existing = JSON.stringify([{ stage: "coder-start", at: "2026-04-29T10:00Z" }]);
+    const out = appendZombieCheckpoint(existing, "8h coding", "2026-05-07T10:00Z");
+    const parsed = JSON.parse(out);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[1]).toEqual({ stage: "zombie-reap", reason: "8h coding", at: "2026-05-07T10:00Z" });
+  });
+
+  it("recovers gracefully from corrupt JSON", () => {
+    const out = appendZombieCheckpoint("not json", "fallback", "2026-05-07T10:00Z");
+    expect(JSON.parse(out)).toEqual([{ stage: "zombie-reap", reason: "fallback", at: "2026-05-07T10:00Z" }]);
+  });
+
+  it("rejects non-array JSON (replaces with fresh array)", () => {
+    const out = appendZombieCheckpoint(JSON.stringify({ not: "an array" }), "x", "2026-05-07T10:00Z");
+    const parsed = JSON.parse(out);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+  });
+});
+
+describe("reapZombieSessions (integration with in-memory SQLite)", () => {
+  let db;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        updated_at TEXT,
+        created_at TEXT,
+        checkpoints TEXT
+      );
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function insert(row) {
+    db.prepare(
+      "INSERT INTO sessions (id, status, updated_at, created_at, checkpoints) VALUES (?, ?, ?, ?, ?)",
+    ).run(row.id, row.status, row.updated_at, row.created_at, row.checkpoints || null);
+  }
+
+  it("returns [] when nothing to reap", () => {
+    insert({ id: "s_alive", status: "coding", updated_at: ago(1) });
+    const reaped = reapZombieSessions({ db, now: () => NOW });
+    expect(reaped).toEqual([]);
+    expect(db.prepare("SELECT status FROM sessions WHERE id = 's_alive'").get().status).toBe("coding");
+  });
+
+  it("flips zombie sessions to status='failed' and appends a checkpoint", () => {
+    insert({ id: "s_zombie", status: "coding", updated_at: ago(8), checkpoints: JSON.stringify([{ stage: "coder-start" }]) });
+    const reaped = reapZombieSessions({ db, now: () => NOW });
+    expect(reaped).toHaveLength(1);
+    expect(reaped[0].id).toBe("s_zombie");
+    expect(reaped[0].status_before).toBe("coding");
+
+    const row = db.prepare("SELECT * FROM sessions WHERE id = 's_zombie'").get();
+    expect(row.status).toBe("failed");
+    const checkpoints = JSON.parse(row.checkpoints);
+    expect(checkpoints).toHaveLength(2);
+    expect(checkpoints[1].stage).toBe("zombie-reap");
+    expect(checkpoints[1].reason).toMatch(/coding/);
+    // updated_at was bumped to the reap timestamp
+    expect(row.updated_at).toBe(new Date(NOW).toISOString());
+  });
+
+  it("does not touch terminal statuses (failed/approved/cancelled/done)", () => {
+    insert({ id: "s_failed",    status: "failed",    updated_at: ago(168) });
+    insert({ id: "s_approved",  status: "approved",  updated_at: ago(168) });
+    insert({ id: "s_cancelled", status: "cancelled", updated_at: ago(168) });
+    insert({ id: "s_done",      status: "done",      updated_at: ago(168) });
+    const reaped = reapZombieSessions({ db, now: () => NOW });
+    expect(reaped).toEqual([]);
+  });
+
+  it("respects the configured thresholds via opts", () => {
+    insert({ id: "s_recent_coding", status: "coding", updated_at: ago(2) });
+    expect(reapZombieSessions({ db, opts: { codingHours: 6 }, now: () => NOW })).toHaveLength(0);
+    expect(reapZombieSessions({ db, opts: { codingHours: 1 }, now: () => NOW })).toHaveLength(1);
+  });
+
+  it("is idempotent: reaped sessions are not reaped again", () => {
+    insert({ id: "s_zombie", status: "coding", updated_at: ago(8) });
+    expect(reapZombieSessions({ db, now: () => NOW })).toHaveLength(1);
+    expect(reapZombieSessions({ db, now: () => NOW })).toHaveLength(0);  // already failed
+  });
+});

--- a/packages/hu-board/tests/zombie-reaper.test.js
+++ b/packages/hu-board/tests/zombie-reaper.test.js
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   classifyZombie,
   findZombieSessions,
   appendZombieCheckpoint,
   reapZombieSessions,
+  markSessionFailedOnDisk,
 } from "../src/zombie-reaper.js";
 
 const NOW = new Date("2026-05-07T10:00:00.000Z").getTime();
@@ -124,8 +128,71 @@ describe("appendZombieCheckpoint", () => {
   });
 });
 
-describe("reapZombieSessions (integration with in-memory SQLite)", () => {
+describe("markSessionFailedOnDisk", () => {
+  let tmp;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kj-zombie-disk-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeSession(id, contents) {
+    const dir = path.join(tmp, id);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "session.json"), JSON.stringify(contents));
+  }
+
+  it("returns false when the session.json doesn't exist", () => {
+    const ok = markSessionFailedOnDisk("missing", "reason", "2026-05-07T10:00Z", { sessionsDir: tmp });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false on malformed JSON", () => {
+    const dir = path.join(tmp, "broken");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "session.json"), "{ not json }");
+    expect(markSessionFailedOnDisk("broken", "reason", "2026-05-07T10:00Z", { sessionsDir: tmp })).toBe(false);
+  });
+
+  it("rewrites status, updated_at and appends a checkpoint", () => {
+    writeSession("good", {
+      id: "good",
+      status: "coding",
+      updated_at: "2026-04-29T21:44:02.000Z",
+      checkpoints: [{ stage: "coder-start", at: "2026-04-29T21:30Z" }],
+    });
+
+    const ok = markSessionFailedOnDisk("good", "coding 192h inactive", "2026-05-07T10:00:00.000Z", { sessionsDir: tmp });
+    expect(ok).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmp, "good", "session.json"), "utf8"));
+    expect(written.status).toBe("failed");
+    expect(written.updated_at).toBe("2026-05-07T10:00:00.000Z");
+    expect(written.checkpoints).toHaveLength(2);
+    expect(written.checkpoints[1]).toEqual({
+      stage: "zombie-reap",
+      reason: "coding 192h inactive",
+      at: "2026-05-07T10:00:00.000Z",
+    });
+  });
+
+  it("creates a checkpoints array when the original lacks one", () => {
+    writeSession("nochk", { id: "nochk", status: "stalled" });
+    const ok = markSessionFailedOnDisk("nochk", "stalled 8h", "2026-05-07T10:00Z", { sessionsDir: tmp });
+    expect(ok).toBe(true);
+
+    const written = JSON.parse(fs.readFileSync(path.join(tmp, "nochk", "session.json"), "utf8"));
+    expect(written.checkpoints).toEqual([
+      { stage: "zombie-reap", reason: "stalled 8h", at: "2026-05-07T10:00Z" },
+    ]);
+  });
+});
+
+describe("reapZombieSessions (integration with in-memory SQLite + disk)", () => {
   let db;
+  let tmp;
 
   beforeEach(() => {
     db = new Database(":memory:");
@@ -138,10 +205,12 @@ describe("reapZombieSessions (integration with in-memory SQLite)", () => {
         checkpoints TEXT
       );
     `);
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kj-zombie-int-"));
   });
 
   afterEach(() => {
     db.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
   });
 
   function insert(row) {
@@ -193,5 +262,55 @@ describe("reapZombieSessions (integration with in-memory SQLite)", () => {
     insert({ id: "s_zombie", status: "coding", updated_at: ago(8) });
     expect(reapZombieSessions({ db, now: () => NOW })).toHaveLength(1);
     expect(reapZombieSessions({ db, now: () => NOW })).toHaveLength(0);  // already failed
+  });
+
+  it("persists failed status to BOTH DB and session.json on disk", () => {
+    // Repro the exact 2026-05-07 dogfooding scenario: DB has a coding
+    // session that was synced from disk, the JSON on disk still says
+    // 'coding' so the next fullScan would resurrect it. After the
+    // reap, BOTH must say 'failed'.
+    const sessionId = "s_2026-04-29T21-44-02-558Z";
+    insert({
+      id: sessionId,
+      status: "stalled",
+      updated_at: ago(192),
+      checkpoints: JSON.stringify([{ stage: "coder-start" }]),
+    });
+    const dir = path.join(tmp, sessionId);
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, "session.json"),
+      JSON.stringify({
+        id: sessionId,
+        status: "stalled",
+        updated_at: new Date(NOW - 192 * HOUR).toISOString(),
+        checkpoints: [{ stage: "coder-start" }],
+      }),
+    );
+
+    const reaped = reapZombieSessions({ db, opts: { sessionsDir: tmp }, now: () => NOW });
+    expect(reaped).toHaveLength(1);
+    expect(reaped[0].disk_persisted).toBe(true);
+
+    // 1) DB row is failed
+    const row = db.prepare("SELECT status FROM sessions WHERE id = ?").get(sessionId);
+    expect(row.status).toBe("failed");
+
+    // 2) session.json on disk is also failed
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, "session.json"), "utf8"));
+    expect(onDisk.status).toBe("failed");
+    expect(onDisk.checkpoints).toHaveLength(2);
+    expect(onDisk.checkpoints[1].stage).toBe("zombie-reap");
+  });
+
+  it("DB still updates when the session.json is missing (disk_persisted=false)", () => {
+    insert({ id: "s_db_only", status: "coding", updated_at: ago(8) });
+    // No session.json on disk.
+
+    const reaped = reapZombieSessions({ db, opts: { sessionsDir: tmp }, now: () => NOW });
+    expect(reaped).toHaveLength(1);
+    expect(reaped[0].disk_persisted).toBe(false);
+    // DB updated regardless
+    expect(db.prepare("SELECT status FROM sessions WHERE id = 's_db_only'").get().status).toBe("failed");
   });
 });

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -126,14 +126,29 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
   const karajanHome = getKarajanHome();
   fs.mkdirSync(karajanHome, { recursive: true });
 
+  // Open a log file for the daemon. Pre-fix the daemon was spawned
+  // with `stdio: "ignore"`, so every `console.log` from server.js
+  // (including the new [zombie-reaper] messages) went straight to
+  // /dev/null and the user had no way to see what was happening.
+  // The file is opened in append-only mode so successive starts
+  // don't truncate the history.
+  const logPath = path.join(karajanHome, "hu-board.log");
+  const logFd = fs.openSync(logPath, "a");
+  fs.writeSync(
+    logFd,
+    `\n--- kj board start at ${new Date().toISOString()} (port ${port}, bind ${bind}) ---\n`,
+  );
+
   // Use process.execPath (absolute path to current node binary) instead of "node".
   // Fixes ENOENT on nvm setups where `node` is not in the spawned process's PATH.
   const child = spawn(process.execPath, [serverPath], {
     env: { ...process.env, PORT: String(port), BIND_HOST: bind },
     detached: true,
-    stdio: "ignore",
+    stdio: ["ignore", logFd, logFd],
     cwd: BOARD_DIR
   });
+  // The parent doesn't need the fd anymore — the child inherited it.
+  fs.closeSync(logFd);
   // Swallow spawn errors so an HU Board failure never crashes the pipeline.
   child.on("error", () => { /* non-blocking — caller logs via tryAutoStartBoard catch */ });
   if (!child.pid) {
@@ -143,10 +158,16 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
   // Detach for real: `detached: true` only sets up the new session;
   // without `unref()` the parent's event loop still holds a reference
   // to the child handle and `kj board start` hangs at the prompt
-  // instead of returning. Pair this with stdio:"ignore" (already set)
-  // to ensure the parent isn't waiting on any of the child's pipes.
+  // instead of returning.
   child.unref();
-  return { ok: true, alreadyRunning: false, pid: child.pid, url: buildBoardUrl(port, projectSlug), port };
+  return {
+    ok: true,
+    alreadyRunning: false,
+    pid: child.pid,
+    url: buildBoardUrl(port, projectSlug),
+    port,
+    logPath,
+  };
 }
 
 export async function stopBoard(opts = {}) {
@@ -273,6 +294,9 @@ export async function boardCommand({ action = "start", port = 4000, bind = "127.
         logger.info(`HU Board already running (PID ${result.pid}) at ${result.url}`);
       } else {
         logger.info(`HU Board started (PID ${result.pid}) at ${result.url}`);
+        if (result.logPath) {
+          logger.info(`Daemon logs: tail -f ${result.logPath}`);
+        }
         if (bind !== "127.0.0.1" && bind !== "localhost") {
           logger.warn(`HU Board bound to ${bind} — token auth enforced for non-loopback peers. Token: ~/.karajan/hu-board/token`);
         }

--- a/tests/board-start-detach.test.js
+++ b/tests/board-start-detach.test.js
@@ -73,12 +73,22 @@ describe("startBoard — detaches properly", () => {
     expect(unref).toHaveBeenCalledTimes(1);
   });
 
-  it("spawns with detached:true and stdio:'ignore' (no parent pipe references)", async () => {
+  it("spawns with detached:true and stdio routed to a log file (no parent pipe references)", async () => {
+    // Pre-2026-05-07 the daemon was spawned with stdio: "ignore", which
+    // sent every console.log from server.js to /dev/null and made
+    // debugging — particularly the [zombie-reaper] line — invisible.
+    // Now stdout/stderr are redirected to ~/.karajan/hu-board.log so
+    // `tail -f` works. The pin: index 0 is "ignore" (the daemon never
+    // reads stdin), indices 1 and 2 are file descriptors (numbers).
     const { startBoard } = await import("../src/commands/board.js");
     await startBoard(4000);
     const opts = spawn.mock.calls[0][2];
     expect(opts.detached).toBe(true);
-    expect(opts.stdio).toBe("ignore");
+    expect(Array.isArray(opts.stdio)).toBe(true);
+    expect(opts.stdio[0]).toBe("ignore");
+    expect(typeof opts.stdio[1]).toBe("number");  // log file fd
+    expect(typeof opts.stdio[2]).toBe("number");  // same fd, stderr → log
+    expect(opts.stdio[1]).toBe(opts.stdio[2]);    // stdout + stderr merged
   });
 
   it("writes the PID file so subsequent kj board status / stop find the child", async () => {


### PR DESCRIPTION
## Summary

User mandate during the 2026-05-07 dogfooding session:

> *\"No puede quedarse nada zombie. Debe haber algun sistema que lo compruebe al arrancar y mate esos zombies.\"*

Concrete repro: \`kj board start\` popped a *\"Karajan needs an answer\"* modal whose underlying HU was from 2026-04-29 — 8 days dead, status still \`coding\`. The board surfaced it as actionable; nobody could action it.

## Behaviour

On every board startup, before the HTTP listener starts, the reaper scans the sessions table:

| Status | Idle threshold | Action |
|---|---|---|
| \`coding\`, \`stalled\`, \`running\`, \`in_progress\` | ≥ 6h | mark \`failed\` |
| \`paused\`, \`checkpoint\`, \`awaiting_answer\` | ≥ 24h | mark \`failed\` |
| \`failed\`, \`approved\`, \`cancelled\`, \`done\` | — | ignored |

Thresholds match the user's explicit decision (*\"6h y 24h paused\"*).

Each reaped row gets a structured checkpoint added to its \`checkpoints\` JSON blob:

\`\`\`json
{ \"stage\": \"zombie-reap\", \"reason\": \"coding 8.2h inactive (>= 6h)\", \"at\": \"2026-05-07T11:41:34.000Z\" }
\`\`\`

The session row stays in the DB — only \`status\` and \`updated_at\` change. Audit trail intact.

Startup never fails because of cleanup: the reaper is wrapped in a try/catch that downgrades any error to a warning.

## Implementation

- **\`packages/hu-board/src/zombie-reaper.js\`** (NEW). Pure functions for verdict, filter and JSON-blob mutation; one side-effecting \`reapZombieSessions({ db, opts, now })\`.
- **\`packages/hu-board/src/server.js\`** — call after \`initDb()\`, before the watcher starts.

## Tests

**+28 in \`packages/hu-board/tests/zombie-reaper.test.js\`**:
- \`classifyZombie\` × 12 (table-driven, edge cases incl. future timestamps, missing data, terminal statuses).
- \`findZombieSessions\` × 3.
- \`appendZombieCheckpoint\` × 4.
- \`reapZombieSessions\` × 5 integration tests with in-memory SQLite (no-op when clean, single zombie reaped, terminal statuses ignored, idempotent, custom thresholds).

Board package: **220/220** passing (was 192; +28 reaper).
Karajan main suite: **4 394/4 394** on the green re-run.

## What the user will see

After \`kj board stop && kj board start\`: the persistent *\"Karajan needs an answer\"* modal for the 2026-04-29 HU is gone. The session shows up as \`failed\` with reason \`coding Nh inactive\` in its checkpoint history.

This is **board-polish PR #2 of 4**. Coming next: #3 auto-cleanup of test/ephemeral projects, #4 in-UI help.