### PR TITLE
fix(audit): silent-skip Sonar when no git remote and no project_key (KJC-TSK-0373)

### DIFF
--- a/src/audit/sonar-findings.js
+++ b/src/audit/sonar-findings.js
@@ -22,6 +22,33 @@
 
 import { isSonarReachable } from "../sonar/manager.js";
 import { getOpenIssues, getQualityGateStatus } from "../sonar/api.js";
+import { runCommand } from "../utils/process.js";
+
+/**
+ * Quick async check: does the cwd's git repo have a `remote.origin.url`
+ * configured AND does the user have an explicit `project_key` override?
+ *
+ * Sonar's project key is derived from the git remote URL by default,
+ * so a fresh repo with no remote (the typical `kj run` in /tmp/...
+ * scenario detected on 2026-05-07) would otherwise hit
+ * `resolveSonarProjectKey` → "Missing git remote.origin.url" → noisy
+ * warning in every audit. This helper lets the caller skip the entire
+ * Sonar collection cleanly with a "not applicable" reason instead of
+ * an "error" warning.
+ *
+ * @param {object} config
+ * @returns {Promise<boolean>} true when sonar input can be derived
+ */
+async function canDeriveSonarProjectKey(config) {
+  const explicit = String(
+    process.env.KJ_SONAR_PROJECT_KEY || config?.sonarqube?.project_key || "",
+  ).trim();
+  if (explicit) return true;
+  const res = await runCommand("git", ["config", "--get", "remote.origin.url"]).catch(
+    () => ({ exitCode: 1, stdout: "" }),
+  );
+  return res.exitCode === 0 && String(res.stdout || "").trim().length > 0;
+}
 
 /**
  * Collect deterministic Sonar findings for the audit prompt.
@@ -41,6 +68,17 @@ export async function collectSonarFindings(config, logger = null) {
   if (!reachable) {
     if (logger?.warn) logger.warn(`sonar audit input skipped: host ${host} not reachable`);
     return { available: false, reason: `sonar host ${host} not reachable` };
+  }
+
+  // No git remote and no explicit project_key → silent skip. This is the
+  // typical `kj run` in a fresh /tmp/... folder. Reporting it as a
+  // warning treats it like an error (which it isn't — sonar simply
+  // doesn't apply to a remoteless repo).
+  if (!(await canDeriveSonarProjectKey(config))) {
+    return {
+      available: false,
+      reason: "not applicable: no git remote and no sonarqube.project_key configured",
+    };
   }
 
   let issuesResult;

--- a/tests/audit/sonar-findings.test.js
+++ b/tests/audit/sonar-findings.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the sonar surface so we can drive collectSonarFindings under
 // controlled conditions without spinning up a real SonarQube container.
@@ -9,17 +9,41 @@ vi.mock("../../src/sonar/api.js", () => ({
   getOpenIssues: vi.fn(),
   getQualityGateStatus: vi.fn(),
 }));
+// Stub runCommand so the silent-skip "no git remote" path is
+// deterministic — we don't want the test to depend on whatever git
+// remote happens to be configured in the working tree.
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
 
 import { collectSonarFindings, groupIssuesBySeverity } from "../../src/audit/sonar-findings.js";
 import { isSonarReachable } from "../../src/sonar/manager.js";
 import { getOpenIssues, getQualityGateStatus } from "../../src/sonar/api.js";
+import { runCommand } from "../../src/utils/process.js";
 import { buildAuditPrompt } from "../../src/prompts/audit.js";
 
 const baseConfig = { sonarqube: { host: "http://localhost:9000" } };
 const noopLogger = { warn: vi.fn(), info: vi.fn() };
 
+// Default git-remote stub: pretend the working tree HAS a remote so the
+// existing tests (written before the silent-skip path) keep exercising
+// the happy-path Sonar API code. Per-test overrides cover the new path.
+function stubGitRemote(remoteUrl) {
+  runCommand.mockImplementation(async () => ({
+    exitCode: remoteUrl ? 0 : 1,
+    stdout: remoteUrl || "",
+    stderr: "",
+  }));
+}
+
 describe("collectSonarFindings (KJC-TSK-0361)", () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => {
+    vi.resetAllMocks();
+    stubGitRemote("git@github.com:manufosela/karajan-code.git");
+  });
+  afterEach(() => {
+    delete process.env.KJ_SONAR_PROJECT_KEY;
+  });
 
   it("returns available=false when sonar host is unreachable (no API call attempted)", async () => {
     isSonarReachable.mockResolvedValue(false);
@@ -73,6 +97,66 @@ describe("collectSonarFindings (KJC-TSK-0361)", () => {
     const r = await collectSonarFindings(baseConfig, noopLogger);
     expect(r.available).toBe(false);
     expect(r.reason).toMatch(/getOpenIssues failed/);
+  });
+
+  // KJC-TSK-0373 — silent-skip path. When the working tree has no
+  // git remote AND no explicit project_key, Sonar simply doesn't
+  // apply: we mustn't hit the API (which would 404 noisy) and we
+  // mustn't surface a "Missing git remote" warning to the user.
+  describe("silent-skip when sonar can't be addressed (KJC-TSK-0373)", () => {
+    it("returns 'not applicable' when git has no remote and no project_key is configured", async () => {
+      isSonarReachable.mockResolvedValue(true);
+      stubGitRemote(null); // git config exitCode 1 = no remote.origin.url
+
+      const r = await collectSonarFindings(baseConfig, noopLogger);
+      expect(r.available).toBe(false);
+      expect(r.reason).toMatch(/not applicable/);
+      expect(r.reason).toMatch(/no git remote/);
+      // The whole point: don't call the Sonar API and don't warn.
+      expect(getOpenIssues).not.toHaveBeenCalled();
+      expect(noopLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it("bypasses the git-remote check when sonarqube.project_key is set in config", async () => {
+      isSonarReachable.mockResolvedValue(true);
+      stubGitRemote(null); // even with no remote...
+      getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+      getQualityGateStatus.mockResolvedValue({ ok: true, status: "OK", conditions: [] });
+
+      const r = await collectSonarFindings(
+        { sonarqube: { host: "http://localhost:9000", project_key: "explicit-key" } },
+      );
+      // ...the explicit project_key short-circuits the skip.
+      expect(r.available).toBe(true);
+      expect(getOpenIssues).toHaveBeenCalled();
+    });
+
+    it("bypasses the git-remote check when KJ_SONAR_PROJECT_KEY env var is set", async () => {
+      process.env.KJ_SONAR_PROJECT_KEY = "env-key";
+      isSonarReachable.mockResolvedValue(true);
+      stubGitRemote(null);
+      getOpenIssues.mockResolvedValue({ total: 0, issues: [] });
+      getQualityGateStatus.mockResolvedValue({ ok: true, status: "OK", conditions: [] });
+
+      const r = await collectSonarFindings(baseConfig);
+      expect(r.available).toBe(true);
+      expect(getOpenIssues).toHaveBeenCalled();
+    });
+
+    it("treats whitespace-only project_key as 'no override' and falls through to the git check", async () => {
+      // Defensive: an env var like `export KJ_SONAR_PROJECT_KEY=" "`
+      // should NOT count as a real override. The user almost
+      // certainly meant "unset", and triggering the API with an
+      // empty key would return 404.
+      process.env.KJ_SONAR_PROJECT_KEY = "   ";
+      isSonarReachable.mockResolvedValue(true);
+      stubGitRemote(null);
+
+      const r = await collectSonarFindings(baseConfig, noopLogger);
+      expect(r.available).toBe(false);
+      expect(r.reason).toMatch(/not applicable/);
+      expect(getOpenIssues).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- `kj run` / `kj audit` in a fresh `/tmp/...` folder was emitting `Missing git remote.origin.url` on every run (the audit stage tried to derive the Sonar project key from a non-existent remote).
- Sonar simply doesn't apply when there's no remote AND no explicit `project_key` configured, so we now skip cleanly with `available: false, reason: "not applicable …"` and no warning.

## What changed
- `src/audit/sonar-findings.js`:
  - New `canDeriveSonarProjectKey(config)` helper that returns true iff either `KJ_SONAR_PROJECT_KEY` / `config.sonarqube.project_key` is set, or `git config --get remote.origin.url` succeeds.
  - `collectSonarFindings()` calls it right after the host reachability check and short-circuits with a "not applicable" reason. No API call. No log.
- `tests/audit/sonar-findings.test.js`:
  - Mock `runCommand` so the existing happy-path tests stay deterministic on any working tree.
  - 4 new cases under `silent-skip when sonar can't be addressed (KJC-TSK-0373)`: no remote + no key → skip; explicit `project_key` bypasses; env var bypasses; whitespace-only env var falls through to git check.

## Test plan
- [x] `npx vitest run tests/audit/sonar-findings.test.js` — 15/15
- [x] `npx vitest run tests/audit` — 131/131
- [x] `npx eslint src/audit/sonar-findings.js tests/audit/sonar-findings.test.js` — clean
- [ ] CI green