### PR TITLE
fix(skills): addyosmani catalog recovers from upstream force-push (KJC-BUG-0033)

### DIFF
--- a/src/skills/addyosmani-catalog.js
+++ b/src/skills/addyosmani-catalog.js
@@ -146,7 +146,7 @@ export async function ensureCatalog(opts = {}) {
  * ensureCatalog().
  *
  * @param {{ refreshMs?: number, repoUrl?: string, force?: boolean, logger?: object }} [opts]
- * @returns {Promise<{ok: boolean, action: "cloned"|"pulled"|"fresh"|"skipped", error?: string}>}
+ * @returns {Promise<{ok: boolean, action: "cloned"|"pulled"|"reset"|"fresh"|"skipped", error?: string}>}
  */
 export async function refreshIfStale(opts = {}) {
   const { refreshMs = DEFAULT_REFRESH_MS, repoUrl = REPO_URL, force = false, logger } = opts;
@@ -171,16 +171,38 @@ export async function refreshIfStale(opts = {}) {
     return { ok: true, action: "skipped" };
   }
 
-  const result = await runCommand(
+  const pullResult = await runCommand(
     "git",
     ["-C", root, "pull", "--ff-only", "--depth", "1"],
     { timeout: 60_000 }
   );
 
-  if (result.exitCode !== 0) {
-    const stderr = (result.stderr || "").trim();
-    logger?.warn?.(`addyosmani-catalog: git pull failed — ${stderr} (keeping stale cache)`);
-    return { ok: false, action: "skipped", error: stderr };
+  let action = "pulled";
+  if (pullResult.exitCode !== 0) {
+    // The cached catalog is read-only (we never commit to it), so a
+    // non-fast-forward result is virtually always upstream rewriting
+    // history with `git push --force` — see KJC-BUG-0033 / N3-2 (the
+    // user hit this on 2026-05-07 when addyosmani force-pushed his
+    // skills repo). Recover by fetching shallow and hard-resetting to
+    // FETCH_HEAD: there's nothing local to lose.
+    const fetchResult = await runCommand(
+      "git",
+      ["-C", root, "fetch", "--depth", "1", "origin", "HEAD"],
+      { timeout: 60_000 }
+    );
+    const resetResult = fetchResult.exitCode === 0
+      ? await runCommand("git", ["-C", root, "reset", "--hard", "FETCH_HEAD"], { timeout: 30_000 })
+      : { exitCode: fetchResult.exitCode, stderr: fetchResult.stderr };
+
+    if (resetResult.exitCode !== 0) {
+      const pullErr = (pullResult.stderr || "").trim();
+      const recoveryErr = (resetResult.stderr || "").trim();
+      const combined = recoveryErr ? `${pullErr} | recovery: ${recoveryErr}` : pullErr;
+      logger?.warn?.(`addyosmani-catalog: git pull failed — ${combined} (keeping stale cache)`);
+      return { ok: false, action: "skipped", error: combined };
+    }
+    action = "reset";
+    logger?.info?.("addyosmani-catalog: ff-only failed, recovered via fetch+reset (upstream force-pushed)");
   }
 
   await writeMeta({
@@ -189,7 +211,7 @@ export async function refreshIfStale(opts = {}) {
     lastPullAt: new Date().toISOString(),
   });
 
-  return { ok: true, action: "pulled" };
+  return { ok: true, action };
 }
 
 /**

--- a/tests/skills/addyosmani-catalog.test.js
+++ b/tests/skills/addyosmani-catalog.test.js
@@ -238,14 +238,60 @@ describe("skills/addyosmani-catalog", () => {
       expect(result.action).toBe("pulled");
     });
 
-    it("degrades to 'skipped' without error when git pull fails", async () => {
+    it("degrades to 'skipped' without error when git pull AND fetch/reset both fail", async () => {
       await seedCatalog({ lastPullAgoMs: 8 * 24 * 60 * 60 * 1000 });
-      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" });
-      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "conflict" });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" }); // probe
+      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "conflict" });    // pull
+      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "no remote" });   // fetch fails
 
       const result = await mod.refreshIfStale({ refreshMs: 0 });
       expect(result.ok).toBe(false);
       expect(result.action).toBe("skipped");
+      expect(result.error).toMatch(/recovery/);
+    });
+
+    // KJC-BUG-0033 / N3-2: when upstream force-pushes (rewriting
+    // history), `git pull --ff-only` exits non-zero with "non-fast-
+    // forward". The catalog is read-only, so we recover by fetching
+    // shallow and hard-resetting to FETCH_HEAD instead of staying
+    // on a stale cache. The user hit this on 2026-05-07 when the
+    // addyosmani/agent-skills repo was force-pushed.
+    it("recovers via fetch+reset when ff-only pull fails (upstream force-push)", async () => {
+      await seedCatalog({ lastPullAgoMs: 8 * 24 * 60 * 60 * 1000 });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" }); // probe
+      runCommand.mockResolvedValueOnce({                                                    // pull --ff-only
+        exitCode: 128,
+        stdout: "",
+        stderr: "fatal: Not possible to fast-forward, aborting.",
+      });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" }); // fetch HEAD
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" }); // reset --hard
+
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const result = await mod.refreshIfStale({ refreshMs: 0, logger });
+
+      expect(result.ok).toBe(true);
+      expect(result.action).toBe("reset");
+      // The recovery emits an info log so the user understands what
+      // happened. No warn (warn is reserved for genuine failures).
+      expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/force-pushed|fetch\+reset/));
+      expect(logger.warn).not.toHaveBeenCalled();
+      // The 4 expected git invocations: probe, pull, fetch, reset.
+      expect(runCommand).toHaveBeenCalledTimes(4);
+    });
+
+    it("degrades to 'skipped' when ff-only fails and the recovery reset also fails", async () => {
+      await seedCatalog({ lastPullAgoMs: 8 * 24 * 60 * 60 * 1000 });
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "git version", stderr: "" }); // probe
+      runCommand.mockResolvedValueOnce({ exitCode: 128, stdout: "", stderr: "non-ff" });    // pull
+      runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });            // fetch ok
+      runCommand.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "permission denied" }); // reset fails
+
+      const result = await mod.refreshIfStale({ refreshMs: 0 });
+      expect(result.ok).toBe(false);
+      expect(result.action).toBe("skipped");
+      expect(result.error).toMatch(/permission denied/);
+      expect(result.error).toMatch(/recovery/);
     });
 
     it("delegates to ensureCatalog when catalog is absent", async () => {


### PR DESCRIPTION
## Summary
- `refreshIfStale()` only did `git pull --ff-only`, so when addyosmani/agent-skills got force-pushed (the user hit this on 2026-05-07) the cached catalog stayed broken until the user manually `rm -rf`'d it.
- Now, on a non-zero `pull --ff-only`, we fall back to `git fetch --depth 1 origin HEAD` + `git reset --hard FETCH_HEAD`. The catalog is read-only — there's nothing local to lose.

## What changed
- `src/skills/addyosmani-catalog.js` — when `pull --ff-only` exits non-zero, run fetch+reset; only surface the failure (and keep the stale cache) when *both* fail. New action `"reset"` distinguishes recovery from a clean fast-forward.
- `tests/skills/addyosmani-catalog.test.js` — 2 new cases (happy-path recovery, recovery-also-fails) + the existing pull-fails test now stubs the fetch attempt.

## Test plan
- [x] `npx vitest run tests/skills/addyosmani-catalog.test.js` — 24/24
- [x] ESLint clean
- [ ] CI green