### PR TITLE
fix(init): stop persisting deprecated sonarqube.enabled to kj.config.yml (KJC-BUG-0034)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -277,6 +277,37 @@ async function runWizard(config, logger) {
   return config;
 }
 
+/**
+ * Persist the wizard's choices to disk WITHOUT serializing the
+ * `sonarqube.enabled` key. That key was deprecated in v2.7.4 (sonar
+ * is intrinsic to code-task pipelines and skipped for non-code by
+ * policy). The wizard still uses it as an in-memory flag during
+ * `init` to drive `setupSonarQube` (whether to bring up the
+ * container right now), but persisting it to kj.config.yml causes a
+ * "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
+ * on every `kj run` afterwards — KJC-BUG-0034 / N3-3, observed in
+ * dogfooding 2026-05-07.
+ *
+ * @param {string} configPath
+ * @param {object} config
+ */
+export async function writeInitConfig(configPath, config) {
+  const out = stripDeprecatedSonarEnabled(config);
+  await writeConfig(configPath, out);
+}
+
+function stripDeprecatedSonarEnabled(config) {
+  if (!config?.sonarqube || !Object.prototype.hasOwnProperty.call(config.sonarqube, "enabled")) {
+    return config;
+  }
+  // Shallow copy + drop `enabled`. Other sonar fields (host, token,
+  // container_name, timeouts, …) MUST survive — they are still
+  // honoured by the runtime.
+  const { enabled: _drop, ...rest } = config.sonarqube;
+  void _drop;
+  return { ...config, sonarqube: rest };
+}
+
 async function handleConfigSetup({ config, configExists, interactive, configPath, logger }) {
   if (configExists && interactive) {
     const wizard = createWizard();
@@ -284,7 +315,7 @@ async function handleConfigSetup({ config, configExists, interactive, configPath
       const reconfigure = await wizard.confirm("Config already exists. Reconfigure?", false);
       if (reconfigure) {
         const updated = await runWizard(config, logger);
-        await writeConfig(configPath, updated);
+        await writeInitConfig(configPath, updated);
         logger.info(`Updated ${configPath}`);
       } else {
         logger.info("Keeping existing config.");
@@ -294,10 +325,10 @@ async function handleConfigSetup({ config, configExists, interactive, configPath
     }
   } else if (!configExists && interactive) {
     const updated = await runWizard(config, logger);
-    await writeConfig(configPath, updated);
+    await writeInitConfig(configPath, updated);
     logger.info(`Created ${configPath}`);
   } else if (!configExists) {
-    await writeConfig(configPath, config);
+    await writeInitConfig(configPath, config);
     logger.info(`Created ${configPath}`);
   }
 }
@@ -561,7 +592,7 @@ export async function initCommand({ logger, flags = {} }) {
       config.development.methodology = config.development.methodology || "tdd";
     }
 
-    await writeConfig(configPath, config);
+    await writeInitConfig(configPath, config);
   } else {
     logger.info("No project stack detected — using default configuration.");
   }
@@ -582,7 +613,10 @@ export async function initCommand({ logger, flags = {} }) {
   await scaffoldCiGateway(config, flags, logger);
 
   // Persist any changes setupSonarQube made (token, etc.) back to disk.
-  await writeConfig(configPath, config);
+  // Use writeInitConfig so the deprecated `sonarqube.enabled` key —
+  // which setupSonarQube still mutates as an in-memory hint — never
+  // reaches the YAML file.
+  await writeInitConfig(configPath, config);
 
   // Telemetry: anonymous install event (non-blocking)
   const { sendTelemetryEvent } = await import("../utils/telemetry.js");

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -463,3 +463,61 @@ describe("askBoardSecurity (KJC-TSK-0367)", () => {
     expect(config.hu_board.port).toBe(4000);
   });
 });
+
+// =====================================================================
+// KJC-BUG-0034 / N3-3 — writeInitConfig must NOT persist the deprecated
+// `sonarqube.enabled` key, which was removed from the runtime in v2.7.4.
+// The wizard still uses it as an in-memory hint to drive
+// setupSonarQube(), but it must be stripped before serialization or
+// every fresh `kj run` after `kj init` would emit the
+// "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
+// (the user hit this on 2026-05-07).
+// =====================================================================
+describe("writeInitConfig — strips deprecated sonarqube.enabled (KJC-BUG-0034)", () => {
+  let writeInitConfig;
+  let writeConfig;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ writeConfig } = await import("../src/config.js"));
+    ({ writeInitConfig } = await import("../src/commands/init.js"));
+  });
+
+  it("removes sonarqube.enabled before delegating to writeConfig", async () => {
+    const config = {
+      coder: "claude",
+      sonarqube: { enabled: true, host: "http://localhost:9000", token: "abc" },
+    };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.sonarqube).toBeDefined();
+    expect("enabled" in persisted.sonarqube).toBe(false);
+    // Sister keys MUST survive — only the deprecated one is dropped.
+    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
+    expect(persisted.sonarqube.token).toBe("abc");
+  });
+
+  it("does not mutate the caller's config object (purity)", async () => {
+    const config = { sonarqube: { enabled: false, host: "http://localhost:9000" } };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    // Caller still sees the in-memory hint.
+    expect(config.sonarqube.enabled).toBe(false);
+  });
+
+  it("is a no-op when sonarqube.enabled is already absent", async () => {
+    const config = { coder: "claude", sonarqube: { host: "http://localhost:9000" } };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
+    // Same reference is fine here — nothing had to change.
+    expect("enabled" in persisted.sonarqube).toBe(false);
+  });
+
+  it("survives a config without a sonarqube block", async () => {
+    const config = { coder: "claude" };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.coder).toBe("claude");
+    expect(persisted.sonarqube).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Since v2.7.4 the runtime ignores `sonarqube.enabled` (sonar is intrinsic for code tasks, skipped by policy for non-code). The init wizard kept writing it to disk, so every freshly init'd project emitted `DEPRECATED: sonarqube.enabled is ignored since v2.7.4` on every subsequent `kj run`. The user hit this on 2026-05-07.
- Fix: split the in-memory hint (still useful for `setupSonarQube` during init itself) from the on-disk representation. New `writeInitConfig()` strips the deprecated key before delegating to `writeConfig`.

## What changed
- `src/commands/init.js`:
  - New `writeInitConfig(path, config)` + private `stripDeprecatedSonarEnabled()`. Pure (no mutation of caller's object).
  - All five `writeConfig` call-sites in `init.js` migrated to `writeInitConfig`.
- `tests/init-wizard.test.js`: 4 new cases — strips the key, sister keys survive, caller's config is not mutated, no-sonarqube-block path.

## Test plan
- [x] `npx vitest run tests/init-wizard.test.js` — 20/20
- [x] ESLint clean
- [ ] CI green