### PR TITLE
feat(hu-board): auto-cleanup of ephemeral test projects (KJC-TSK-0371)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -288,6 +288,25 @@ function esc(str) {
   return el.innerHTML;
 }
 
+// is_test toggle visuals (KJC-TSK-0371). The icon and tooltip
+// reflect the user's explicit override OR the default heuristic
+// when none is set. Heuristic mirrors ephemeral-cleaner.js so the
+// UI never lies about what the cleaner will actually do.
+const EPHEMERAL_HEURISTIC_RE = /^(auto-)?(tmp_|test_|demo_|kj-test-)/i;
+function isTestIcon(p) {
+  if (p.is_test === 1) return '🧪';                                  // user marked
+  if (p.is_test === 0) return '📌';                                  // user pinned
+  return EPHEMERAL_HEURISTIC_RE.test(p.id || '') ? '🧪?' : '·';      // heuristic
+}
+function isTestTitle(p) {
+  if (p.is_test === 1) return 'Marked as test — auto-cleans 24h after last activity. Click to pin.';
+  if (p.is_test === 0) return 'Pinned — never auto-cleans. Click to clear.';
+  if (EPHEMERAL_HEURISTIC_RE.test(p.id || '')) {
+    return 'Looks ephemeral by id heuristic — will auto-clean after 24h. Click to pin.';
+  }
+  return 'Real project — never auto-cleans. Click to mark as test.';
+}
+
 /**
  * Truncates text to a max length.
  * @param {string} text
@@ -360,6 +379,7 @@ async function renderDashboard() {
           ${projects.map((p) => `
             <div class="project-card">
               <button class="project-card__delete" title="Delete project (cascade)" data-project-id="${esc(p.id)}" data-project-name="${esc(p.name || p.id)}">🗑️</button>
+              <button class="project-card__is-test" title="${esc(isTestTitle(p))}" data-project-id="${esc(p.id)}" data-is-test="${p.is_test === null || p.is_test === undefined ? '' : p.is_test}">${isTestIcon(p)}</button>
               <div class="project-card__body" onclick="selectProject('${esc(p.id)}')">
                 <div class="project-card__name">${esc(p.name || p.id)}</div>
                 <div class="project-card__stats">
@@ -3078,6 +3098,41 @@ document.getElementById('restart-btn').addEventListener('click', async () => {
   } catch { /* the server is going down; the catch is expected */ }
   // Give the new server a beat to bind, then reload the page.
   setTimeout(() => window.location.reload(), 1200);
+});
+
+// is_test toggle (KJC-TSK-0371 — board polish #3). Three-state cycle:
+//   null (heuristic) → 1 (always test) → 0 (always keep) → null …
+// `null` is encoded as the empty string in `data-is-test` so the
+// button's HTML serialisation is stable across renders.
+function nextIsTestValue(current) {
+  // Treat both empty string ("") and "null" as "no override" — the
+  // dataset value is the empty string at render time, but URLs and
+  // some legacy callers may send the literal "null".
+  if (current === '' || current === 'null') return 1;
+  if (current === '1') return 0;
+  return null;  // from "0" → revert to default
+}
+
+document.addEventListener('click', async (e) => {
+  const btn = e.target.closest('.project-card__is-test');
+  if (!btn) return;
+  e.stopPropagation();
+  e.preventDefault();
+  const projectId = btn.dataset.projectId;
+  const next = nextIsTestValue(btn.dataset.isTest);
+  try {
+    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/is-test`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_test: next }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    // Re-render the project list so the badge reflects the new value.
+    await populateProjectSelect();
+    render();
+  } catch (err) {
+    await showError(err.message, { title: 'Failed to update is_test' });
+  }
 });
 
 // Delete project (cascade) — delegated handler on the dashboard grid

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -711,6 +711,35 @@ a:hover {
   border-color: rgba(255, 80, 80, 0.4);
 }
 
+/* is_test toggle (KJC-TSK-0371). Sits to the LEFT of the delete
+ * button, same affordances. Visible at low opacity by default
+ * because — unlike delete — it conveys live state (is the
+ * cleaner watching this project?). Hovering brightens it. */
+.project-card__is-test {
+  position: absolute;
+  top: 8px;
+  right: 44px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  opacity: 0.55;
+  transition: all 0.15s;
+  z-index: 2;
+}
+
+.project-card:hover .project-card__is-test {
+  opacity: 0.85;
+}
+
+.project-card__is-test:hover {
+  opacity: 1 !important;
+  background: rgba(160, 160, 255, 0.15);
+  border-color: rgba(160, 160, 255, 0.4);
+}
+
 .project-card__name {
   font-size: 1rem;
   font-weight: 600;

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -159,6 +159,13 @@ export function initDb() {
   try { db.exec('ALTER TABLE stories ADD COLUMN outcome TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
+  // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
+  // controls the ephemeral-cleanup heuristic. NULL = follow heuristic
+  // (id under tmp_/test_/demo_/kj-test- → ephemeral after 24h);
+  // 1 = always treat as ephemeral; 0 = NEVER auto-clean (user override).
+  // The UI surfaces this as a toggle on each project card.
+  try { db.exec('ALTER TABLE projects ADD COLUMN is_test INTEGER'); } catch { /* already migrated */ }
+
   return db;
 }
 
@@ -514,6 +521,28 @@ export function deleteProject(projectId) {
     db.prepare('DELETE FROM projects WHERE id = ?').run(projectId);
   })();
   return true;
+}
+
+/**
+ * Set or clear the `is_test` flag on a project. Drives the
+ * ephemeral-cleanup heuristic in ephemeral-cleaner.js:
+ *   - 1     → always treat as ephemeral (cleanup once last_activity > TTL)
+ *   - 0     → NEVER auto-clean, regardless of id pattern (user override)
+ *   - null  → follow the default id-pattern heuristic
+ *
+ * @param {string} projectId
+ * @param {number|null} value  one of 0, 1, null
+ * @returns {boolean} true when the project existed and was updated
+ */
+export function setProjectIsTest(projectId, value) {
+  if (value !== 0 && value !== 1 && value !== null) {
+    throw new Error(`setProjectIsTest: value must be 0, 1, or null (got ${value})`);
+  }
+  const db = getDb();
+  const result = db
+    .prepare('UPDATE projects SET is_test = ? WHERE id = ?')
+    .run(value, projectId);
+  return result.changes > 0;
 }
 
 /**

--- a/packages/hu-board/src/ephemeral-cleaner.js
+++ b/packages/hu-board/src/ephemeral-cleaner.js
@@ -1,0 +1,148 @@
+/**
+ * Ephemeral project cleaner for the HU Board (board-polish #3,
+ * KJC-TSK-0371 — dogfooding 2026-05-07).
+ *
+ * Why this exists
+ * ===============
+ *
+ * Every `kj run` against a throwaway directory (`/tmp/kj-test-1`,
+ * `/tmp/demo-foo`, ad-hoc scratch projects under `tmp_*`) produces
+ * a board project that hangs around forever, even after the user
+ * has long since rm-rf'd the source tree. After 12 days of
+ * dogfooding the board ended up with 30+ "kj-test-N" projects
+ * the user couldn't tell apart from real ones — exactly the
+ * "noise on the demo" risk the user flagged on 2026-05-07.
+ *
+ * Heuristic (per the user's spec on the same session, "solución
+ * c — heurística + flag visible"):
+ *
+ *   1. Project is ephemeral when:
+ *        a) `is_test = 1` (user explicitly marked it test), OR
+ *        b) project id matches /^(tmp_|test_|demo_|kj-test-)/i
+ *           AND `is_test IS NULL` (no override).
+ *   2. AND last_activity is older than `ttlHours` (default 24h).
+ *
+ *   3. Override: when `is_test = 0` (user clicked "keep it"), the
+ *      project is NEVER deleted, even if the heuristic would match.
+ *
+ * What "cleanup" means: DELETE the project row + cascade-delete
+ * its stories and sessions (see `deleteProject` in db.js — this
+ * module piggybacks on the same statement set, so the cleanup
+ * cannot leave orphan rows behind).
+ */
+
+const DEFAULT_TTL_HOURS = 24;
+const EPHEMERAL_ID_PATTERNS = [
+  /^tmp_/i,
+  /^test_/i,
+  /^demo_/i,
+  /^kj-test-/i,
+  /^auto-tmp_/i,    // also covers auto-batch projects derived from /tmp/
+  /^auto-test_/i,
+  /^auto-demo_/i,
+];
+
+/**
+ * Decide whether a single project row qualifies as an ephemeral
+ * candidate ready for deletion at `now`. Pure function — no I/O.
+ *
+ * The matrix:
+ *   is_test = 1         → ephemeral (user marked it)
+ *   is_test = 0         → not ephemeral, EVER (user override wins)
+ *   is_test = NULL/und. → fall back to id-pattern heuristic
+ *   too recent          → not ephemeral (still in use)
+ *
+ * @param {{ id: string, last_activity?: string|null, first_seen?: string|null,
+ *           is_test?: number|null }} project
+ * @param {{ now: number, ttlHours: number }} ctx
+ * @returns {{ ephemeral: boolean, reason?: string }}
+ */
+export function classifyEphemeral(project, ctx) {
+  if (!project || !project.id) return { ephemeral: false };
+  // Explicit user override always wins. is_test=0 means "keep it".
+  if (project.is_test === 0) return { ephemeral: false };
+
+  const idMatch = EPHEMERAL_ID_PATTERNS.some((re) => re.test(project.id));
+  const explicitTest = project.is_test === 1;
+  if (!idMatch && !explicitTest) return { ephemeral: false };
+
+  const refIso = project.last_activity || project.first_seen;
+  if (!refIso) return { ephemeral: false };
+  const refTs = new Date(refIso).getTime();
+  if (Number.isNaN(refTs)) return { ephemeral: false };
+  const ageHours = (ctx.now - refTs) / 3_600_000;
+  if (ageHours <= 0) return { ephemeral: false };
+  if (ageHours < ctx.ttlHours) return { ephemeral: false };
+
+  const why = explicitTest ? "is_test=1" : "id heuristic";
+  return {
+    ephemeral: true,
+    reason: `${why}, ${ageHours.toFixed(1)}h inactive (>= ${ctx.ttlHours}h)`,
+  };
+}
+
+/**
+ * Filter a list of project rows down to the ephemeral ones. Pure.
+ *
+ * @param {Array<object>} projects
+ * @param {{ now?: number, ttlHours?: number }} [opts]
+ * @returns {Array<{ project: object, reason: string }>}
+ */
+export function findEphemeralProjects(projects, opts = {}) {
+  const ctx = {
+    now: opts.now ?? Date.now(),
+    ttlHours: opts.ttlHours ?? DEFAULT_TTL_HOURS,
+  };
+  const out = [];
+  for (const project of projects || []) {
+    const verdict = classifyEphemeral(project, ctx);
+    if (verdict.ephemeral) out.push({ project, reason: verdict.reason });
+  }
+  return out;
+}
+
+/**
+ * Cascade-delete every ephemeral project at `now`. Side-effecting.
+ * Returns the list of cleaned projects so the server can log them.
+ *
+ * Idempotent: cleanup deletes the rows outright, so running twice
+ * has no effect on the second pass.
+ *
+ * @param {object} deps
+ * @param {object} deps.db        better-sqlite3 Database handle
+ * @param {object} [deps.opts]    threshold overrides
+ * @param {Function} [deps.now]   () => number, for tests
+ * @returns {Array<{ id: string, reason: string, stories_deleted: number, sessions_deleted: number }>}
+ */
+export function cleanupEphemeralProjects({ db, opts = {}, now = () => Date.now() }) {
+  if (!db) return [];
+  const allProjects = db
+    .prepare("SELECT id, last_activity, first_seen, is_test FROM projects")
+    .all();
+  const candidates = findEphemeralProjects(allProjects, { ...opts, now: now() });
+  if (candidates.length === 0) return [];
+
+  const countStories = db.prepare("SELECT COUNT(*) AS n FROM stories WHERE project_id = ?");
+  const countSessions = db.prepare("SELECT COUNT(*) AS n FROM sessions WHERE project_id = ?");
+  const delStories = db.prepare("DELETE FROM stories WHERE project_id = ?");
+  const delSessions = db.prepare("DELETE FROM sessions WHERE project_id = ?");
+  const delProject = db.prepare("DELETE FROM projects WHERE id = ?");
+
+  const cleaned = [];
+  for (const { project, reason } of candidates) {
+    const storiesN = countStories.get(project.id).n;
+    const sessionsN = countSessions.get(project.id).n;
+    db.transaction(() => {
+      delStories.run(project.id);
+      delSessions.run(project.id);
+      delProject.run(project.id);
+    })();
+    cleaned.push({
+      id: project.id,
+      reason,
+      stories_deleted: storiesN,
+      sessions_deleted: sessionsN,
+    });
+  }
+  return cleaned;
+}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -16,6 +16,7 @@ import {
   getStoryRow,
   listPlanIdsForProject,
   updateStoryStatus,
+  setProjectIsTest,
 } from '../db.js';
 import { fullScan } from '../sync.js';
 import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject } from '../plan-mutations.js';
@@ -99,6 +100,39 @@ router.put('/projects/:id/name', (req, res) => {
       return res.status(code).json({ error: result.error });
     }
     res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * PATCH /api/projects/:id/is-test — KJC-TSK-0371 (board polish #3).
+ *
+ * Sets/clears the per-project ephemeral-cleanup override. The
+ * heuristic (id under tmp_/test_/demo_/kj-test- AND last_activity
+ * older than 24h → auto-delete on next board start) is the default.
+ * `is_test` lets the user override per-project:
+ *   - body { is_test: 1 }    → always treat as ephemeral
+ *   - body { is_test: 0 }    → NEVER auto-clean (keep this one)
+ *   - body { is_test: null } → revert to the default heuristic
+ *
+ * Sending anything else is a 400 — explicit ternary, no truthy/
+ * falsy coercion, because that exact distinction is what the
+ * cleaner relies on.
+ */
+router.patch('/projects/:id/is-test', (req, res) => {
+  const raw = req.body?.is_test;
+  // Accept the three legal sentinel values explicitly — undefined
+  // (key missing) is rejected because this endpoint only exists to
+  // set or clear, not to "leave as-is".
+  const allowed = raw === 0 || raw === 1 || raw === null;
+  if (!allowed) {
+    return res.status(400).json({ error: 'is_test must be 0, 1, or null' });
+  }
+  try {
+    const ok = setProjectIsTest(req.params.id, raw);
+    if (!ok) return res.status(404).json({ error: 'project not found' });
+    res.json({ ok: true, project_id: req.params.id, is_test: raw });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -12,6 +12,7 @@ import pipelineRoutes from './routes/pipeline.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
+import { cleanupEphemeralProjects } from './ephemeral-cleaner.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
 /**
@@ -163,6 +164,27 @@ async function main() {
   } catch (err) {
     // Never block startup on the reaper. Log and move on.
     console.warn(`[zombie-reaper] skipped: ${err.message}`);
+  }
+
+  // KJC-TSK-0371 (board polish #3) — clean up ephemeral projects
+  // (`/tmp/`-rooted, `tmp_*`/`test_*`/`demo_*`/`kj-test-*` prefixed)
+  // that have been inactive for >24h. Runs AFTER the zombie-reaper
+  // so any session that just got marked failed counts toward
+  // last_activity correctly. The user can override per-project via
+  // PATCH /api/projects/:id/is-test.
+  try {
+    const dbHandle = (await import('./db.js')).getDb();
+    const cleaned = cleanupEphemeralProjects({ db: dbHandle });
+    if (cleaned.length > 0) {
+      console.log(`[ephemeral-cleaner] removed ${cleaned.length} ephemeral project(s):`);
+      for (const c of cleaned) {
+        console.log(`  - ${c.id} (${c.reason}; ${c.stories_deleted} stories, ${c.sessions_deleted} sessions cascaded)`);
+      }
+    } else {
+      console.log('[ephemeral-cleaner] no ephemeral projects detected');
+    }
+  } catch (err) {
+    console.warn(`[ephemeral-cleaner] skipped: ${err.message}`);
   }
 
   // Start file watcher

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -199,3 +199,66 @@ describe('GET /api/sessions', () => {
     expect(ids).toContain('sess-2');
   });
 });
+
+// ---------------------------------------------------------------------------
+// PATCH /api/projects/:id/is-test  (KJC-TSK-0371 — board polish #3)
+//
+// The endpoint exists so the user can override the default ephemeral-
+// cleanup heuristic per-project: keep something the heuristic would
+// delete (`is_test=0`) or force-delete something it wouldn't
+// (`is_test=1`). The handler accepts ONLY the three legal sentinels
+// (0, 1, null) — anything else is a 400.
+// ---------------------------------------------------------------------------
+describe('PATCH /api/projects/:id/is-test', () => {
+  it('accepts is_test=1 and persists it', async () => {
+    seed();
+    const res = await request(app)
+      .patch('/api/projects/proj-1/is-test')
+      .send({ is_test: 1 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, project_id: 'proj-1', is_test: 1 });
+    const projects = dbMod.getProjects();
+    expect(projects.find((p) => p.id === 'proj-1').is_test).toBe(1);
+  });
+
+  it('accepts is_test=0 (preserve override) and persists it', async () => {
+    const res = await request(app)
+      .patch('/api/projects/proj-1/is-test')
+      .send({ is_test: 0 });
+    expect(res.status).toBe(200);
+    expect(res.body.is_test).toBe(0);
+    expect(dbMod.getProjects().find((p) => p.id === 'proj-1').is_test).toBe(0);
+  });
+
+  it('accepts is_test=null (revert to default heuristic)', async () => {
+    const res = await request(app)
+      .patch('/api/projects/proj-1/is-test')
+      .send({ is_test: null });
+    expect(res.status).toBe(200);
+    expect(res.body.is_test).toBeNull();
+    expect(dbMod.getProjects().find((p) => p.id === 'proj-1').is_test).toBeNull();
+  });
+
+  it('returns 400 for an invalid is_test value', async () => {
+    const res = await request(app)
+      .patch('/api/projects/proj-1/is-test')
+      .send({ is_test: 'yes' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/must be 0, 1, or null/);
+  });
+
+  it('returns 400 when is_test key is missing', async () => {
+    const res = await request(app)
+      .patch('/api/projects/proj-1/is-test')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown project', async () => {
+    const res = await request(app)
+      .patch('/api/projects/no-such-id/is-test')
+      .send({ is_test: 1 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/);
+  });
+});

--- a/packages/hu-board/tests/ephemeral-cleaner.test.js
+++ b/packages/hu-board/tests/ephemeral-cleaner.test.js
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  classifyEphemeral,
+  findEphemeralProjects,
+  cleanupEphemeralProjects,
+} from "../src/ephemeral-cleaner.js";
+
+// Fixed clock so the "X.Yh inactive" reason text is reproducible.
+const NOW = new Date("2026-05-07T12:00:00.000Z").getTime();
+const HOUR = 3_600_000;
+
+function ago(hours) {
+  return new Date(NOW - hours * HOUR).toISOString();
+}
+
+describe("classifyEphemeral (KJC-TSK-0371 — board polish #3)", () => {
+  const ctx = { now: NOW, ttlHours: 24 };
+
+  it("returns false on missing/empty input", () => {
+    expect(classifyEphemeral(null, ctx).ephemeral).toBe(false);
+    expect(classifyEphemeral({}, ctx).ephemeral).toBe(false);
+  });
+
+  it.each([
+    ["tmp_home_user_kjtest", true],
+    ["test_foo", true],
+    ["demo_bar", true],
+    ["kj-test-1", true],
+    ["auto-tmp_home_user_kjtest", true],
+    ["my-real-project", false],
+    ["linux-assistant-orchestrator", false],
+    // case-insensitive
+    ["TMP_FOO", true],
+    ["Test_bar", true],
+  ])("id-pattern heuristic: %s → %s (when stale)", (id, expected) => {
+    const project = { id, last_activity: ago(48), is_test: null };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(expected);
+  });
+
+  it("respects user override is_test=0 (NEVER auto-clean)", () => {
+    // The id matches the heuristic AND it's old, but the user said "keep".
+    const project = { id: "tmp_keepme", last_activity: ago(48), is_test: 0 };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(false);
+  });
+
+  it("treats is_test=1 as ephemeral even when id does NOT match the heuristic", () => {
+    // Real-looking id, but user explicitly tagged it as test.
+    const project = { id: "my-real-looking-name", last_activity: ago(48), is_test: 1 };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(true);
+    expect(classifyEphemeral(project, ctx).reason).toMatch(/is_test=1/);
+  });
+
+  it("does NOT clean projects within the TTL window", () => {
+    const project = { id: "tmp_recent", last_activity: ago(2), is_test: null };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(false);
+  });
+
+  it("falls back to first_seen when last_activity is absent", () => {
+    const project = { id: "tmp_nolast", first_seen: ago(48), last_activity: null, is_test: null };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(true);
+  });
+
+  it("returns false on garbage timestamps", () => {
+    const project = { id: "tmp_bad", last_activity: "not-a-date", is_test: null };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(false);
+  });
+
+  it("returns false on future timestamps (defensive)", () => {
+    const project = { id: "tmp_future", last_activity: ago(-2), is_test: null };
+    expect(classifyEphemeral(project, ctx).ephemeral).toBe(false);
+  });
+
+  it("includes the inactivity duration in the reason text", () => {
+    const v = classifyEphemeral({ id: "tmp_old", last_activity: ago(72), is_test: null }, ctx);
+    expect(v.ephemeral).toBe(true);
+    expect(v.reason).toMatch(/72\.0h/);
+    expect(v.reason).toMatch(/id heuristic/);
+  });
+});
+
+describe("findEphemeralProjects", () => {
+  it("returns [] on empty/null input", () => {
+    expect(findEphemeralProjects([], { now: NOW })).toEqual([]);
+    expect(findEphemeralProjects(null, { now: NOW })).toEqual([]);
+  });
+
+  it("filters only the ephemeral ones, preserving the reason", () => {
+    const projects = [
+      { id: "tmp_old",  last_activity: ago(48), is_test: null },
+      { id: "real-a",   last_activity: ago(48), is_test: null },
+      { id: "demo_old", last_activity: ago(72), is_test: null },
+      { id: "tmp_keep", last_activity: ago(48), is_test: 0 },     // user override
+      { id: "real-b",   last_activity: ago(48), is_test: 1 },     // explicit test
+    ];
+    const found = findEphemeralProjects(projects, { now: NOW });
+    expect(found.map((f) => f.project.id).sort()).toEqual(["demo_old", "real-b", "tmp_old"]);
+  });
+
+  it("respects custom ttlHours via opts", () => {
+    const projects = [{ id: "tmp_2h", last_activity: ago(2), is_test: null }];
+    expect(findEphemeralProjects(projects, { now: NOW, ttlHours: 24 })).toHaveLength(0);
+    expect(findEphemeralProjects(projects, { now: NOW, ttlHours: 1 })).toHaveLength(1);
+  });
+});
+
+describe("cleanupEphemeralProjects (integration with in-memory SQLite)", () => {
+  let db;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        name TEXT,
+        first_seen TEXT,
+        last_activity TEXT,
+        total_stories INTEGER DEFAULT 0,
+        is_test INTEGER
+      );
+      CREATE TABLE stories (
+        id TEXT PRIMARY KEY,
+        project_id TEXT,
+        status TEXT
+      );
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project_id TEXT,
+        status TEXT
+      );
+    `);
+  });
+
+  afterEach(() => db.close());
+
+  function insertProject(row) {
+    db.prepare(
+      "INSERT INTO projects (id, name, first_seen, last_activity, is_test) VALUES (?, ?, ?, ?, ?)"
+    ).run(row.id, row.name || row.id, row.first_seen || row.last_activity, row.last_activity, row.is_test ?? null);
+  }
+
+  function insertStory(id, projectId) {
+    db.prepare("INSERT INTO stories (id, project_id, status) VALUES (?, ?, ?)").run(id, projectId, "pending");
+  }
+
+  function insertSession(id, projectId) {
+    db.prepare("INSERT INTO sessions (id, project_id, status) VALUES (?, ?, ?)").run(id, projectId, "approved");
+  }
+
+  it("returns [] when nothing matches", () => {
+    insertProject({ id: "real_one", last_activity: ago(48) });
+    expect(cleanupEphemeralProjects({ db, now: () => NOW })).toEqual([]);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM projects").get().n).toBe(1);
+  });
+
+  it("cascade-deletes the project + its stories + sessions", () => {
+    insertProject({ id: "tmp_old", last_activity: ago(48) });
+    insertStory("s1", "tmp_old");
+    insertStory("s2", "tmp_old");
+    insertSession("se1", "tmp_old");
+
+    const cleaned = cleanupEphemeralProjects({ db, now: () => NOW });
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0].id).toBe("tmp_old");
+    expect(cleaned[0].stories_deleted).toBe(2);
+    expect(cleaned[0].sessions_deleted).toBe(1);
+
+    expect(db.prepare("SELECT id FROM projects WHERE id = 'tmp_old'").get()).toBeUndefined();
+    expect(db.prepare("SELECT COUNT(*) AS n FROM stories").get().n).toBe(0);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM sessions").get().n).toBe(0);
+  });
+
+  it("respects user override is_test=0 (project survives even when stale)", () => {
+    insertProject({ id: "tmp_keepme", last_activity: ago(72), is_test: 0 });
+    insertStory("s1", "tmp_keepme");
+
+    const cleaned = cleanupEphemeralProjects({ db, now: () => NOW });
+    expect(cleaned).toEqual([]);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM projects").get().n).toBe(1);
+  });
+
+  it("does NOT touch real-named projects, even when very old", () => {
+    insertProject({ id: "linux-assistant-orchestrator", last_activity: ago(7 * 24) });
+    expect(cleanupEphemeralProjects({ db, now: () => NOW })).toEqual([]);
+    expect(db.prepare("SELECT COUNT(*) AS n FROM projects").get().n).toBe(1);
+  });
+
+  it("is idempotent — second pass is a no-op", () => {
+    insertProject({ id: "tmp_old", last_activity: ago(48) });
+    expect(cleanupEphemeralProjects({ db, now: () => NOW })).toHaveLength(1);
+    expect(cleanupEphemeralProjects({ db, now: () => NOW })).toHaveLength(0);
+  });
+
+  it("processes multiple ephemeral projects in a single pass", () => {
+    insertProject({ id: "tmp_a", last_activity: ago(48) });
+    insertProject({ id: "test_b", last_activity: ago(48) });
+    insertProject({ id: "demo_c", last_activity: ago(48) });
+    insertProject({ id: "real_d", last_activity: ago(48) });
+
+    const cleaned = cleanupEphemeralProjects({ db, now: () => NOW });
+    expect(cleaned.map((c) => c.id).sort()).toEqual(["demo_c", "test_b", "tmp_a"]);
+    expect(db.prepare("SELECT id FROM projects").all().map((r) => r.id)).toEqual(["real_d"]);
+  });
+});

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -277,6 +277,37 @@ async function runWizard(config, logger) {
   return config;
 }
 
+/**
+ * Persist the wizard's choices to disk WITHOUT serializing the
+ * `sonarqube.enabled` key. That key was deprecated in v2.7.4 (sonar
+ * is intrinsic to code-task pipelines and skipped for non-code by
+ * policy). The wizard still uses it as an in-memory flag during
+ * `init` to drive `setupSonarQube` (whether to bring up the
+ * container right now), but persisting it to kj.config.yml causes a
+ * "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
+ * on every `kj run` afterwards — KJC-BUG-0034 / N3-3, observed in
+ * dogfooding 2026-05-07.
+ *
+ * @param {string} configPath
+ * @param {object} config
+ */
+export async function writeInitConfig(configPath, config) {
+  const out = stripDeprecatedSonarEnabled(config);
+  await writeConfig(configPath, out);
+}
+
+function stripDeprecatedSonarEnabled(config) {
+  if (!config?.sonarqube || !Object.prototype.hasOwnProperty.call(config.sonarqube, "enabled")) {
+    return config;
+  }
+  // Shallow copy + drop `enabled`. Other sonar fields (host, token,
+  // container_name, timeouts, …) MUST survive — they are still
+  // honoured by the runtime.
+  const { enabled: _drop, ...rest } = config.sonarqube;
+  void _drop;
+  return { ...config, sonarqube: rest };
+}
+
 async function handleConfigSetup({ config, configExists, interactive, configPath, logger }) {
   if (configExists && interactive) {
     const wizard = createWizard();
@@ -284,7 +315,7 @@ async function handleConfigSetup({ config, configExists, interactive, configPath
       const reconfigure = await wizard.confirm("Config already exists. Reconfigure?", false);
       if (reconfigure) {
         const updated = await runWizard(config, logger);
-        await writeConfig(configPath, updated);
+        await writeInitConfig(configPath, updated);
         logger.info(`Updated ${configPath}`);
       } else {
         logger.info("Keeping existing config.");
@@ -294,10 +325,10 @@ async function handleConfigSetup({ config, configExists, interactive, configPath
     }
   } else if (!configExists && interactive) {
     const updated = await runWizard(config, logger);
-    await writeConfig(configPath, updated);
+    await writeInitConfig(configPath, updated);
     logger.info(`Created ${configPath}`);
   } else if (!configExists) {
-    await writeConfig(configPath, config);
+    await writeInitConfig(configPath, config);
     logger.info(`Created ${configPath}`);
   }
 }
@@ -561,7 +592,7 @@ export async function initCommand({ logger, flags = {} }) {
       config.development.methodology = config.development.methodology || "tdd";
     }
 
-    await writeConfig(configPath, config);
+    await writeInitConfig(configPath, config);
   } else {
     logger.info("No project stack detected — using default configuration.");
   }
@@ -582,7 +613,10 @@ export async function initCommand({ logger, flags = {} }) {
   await scaffoldCiGateway(config, flags, logger);
 
   // Persist any changes setupSonarQube made (token, etc.) back to disk.
-  await writeConfig(configPath, config);
+  // Use writeInitConfig so the deprecated `sonarqube.enabled` key —
+  // which setupSonarQube still mutates as an in-memory hint — never
+  // reaches the YAML file.
+  await writeInitConfig(configPath, config);
 
   // Telemetry: anonymous install event (non-blocking)
   const { sendTelemetryEvent } = await import("../utils/telemetry.js");

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -463,3 +463,61 @@ describe("askBoardSecurity (KJC-TSK-0367)", () => {
     expect(config.hu_board.port).toBe(4000);
   });
 });
+
+// =====================================================================
+// KJC-BUG-0034 / N3-3 — writeInitConfig must NOT persist the deprecated
+// `sonarqube.enabled` key, which was removed from the runtime in v2.7.4.
+// The wizard still uses it as an in-memory hint to drive
+// setupSonarQube(), but it must be stripped before serialization or
+// every fresh `kj run` after `kj init` would emit the
+// "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
+// (the user hit this on 2026-05-07).
+// =====================================================================
+describe("writeInitConfig — strips deprecated sonarqube.enabled (KJC-BUG-0034)", () => {
+  let writeInitConfig;
+  let writeConfig;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ writeConfig } = await import("../src/config.js"));
+    ({ writeInitConfig } = await import("../src/commands/init.js"));
+  });
+
+  it("removes sonarqube.enabled before delegating to writeConfig", async () => {
+    const config = {
+      coder: "claude",
+      sonarqube: { enabled: true, host: "http://localhost:9000", token: "abc" },
+    };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.sonarqube).toBeDefined();
+    expect("enabled" in persisted.sonarqube).toBe(false);
+    // Sister keys MUST survive — only the deprecated one is dropped.
+    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
+    expect(persisted.sonarqube.token).toBe("abc");
+  });
+
+  it("does not mutate the caller's config object (purity)", async () => {
+    const config = { sonarqube: { enabled: false, host: "http://localhost:9000" } };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    // Caller still sees the in-memory hint.
+    expect(config.sonarqube.enabled).toBe(false);
+  });
+
+  it("is a no-op when sonarqube.enabled is already absent", async () => {
+    const config = { coder: "claude", sonarqube: { host: "http://localhost:9000" } };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
+    // Same reference is fine here — nothing had to change.
+    expect("enabled" in persisted.sonarqube).toBe(false);
+  });
+
+  it("survives a config without a sonarqube block", async () => {
+    const config = { coder: "claude" };
+    await writeInitConfig("/tmp/kj.config.yml", config);
+    const persisted = writeConfig.mock.calls[0][1];
+    expect(persisted.coder).toBe("claude");
+    expect(persisted.sonarqube).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
After 12 days of dogfooding the HU Board accumulated 30+ `kj-test-N` projects from `/tmp/` runs the user couldn't tell apart from real ones (demo-noise risk flagged 2026-05-07). This adds an automatic cleanup at board start, following the user's "solución c — heurística + flag visible".

**Heuristic** (the cleaner deletes the project + cascade-deletes its stories/sessions when ALL three are true):
1. `id` matches `/^(tmp_|test_|demo_|kj-test-)/i` **OR** `is_test = 1`
2. `last_activity > 24h` ago
3. `is_test ≠ 0` (the user-pin override ALWAYS wins)

The cleanup runs after `fullScan` + `zombie-reaper` so the data it sees is fresh.

## What changed
- `packages/hu-board/src/ephemeral-cleaner.js` (new) — pure `classifyEphemeral` + `findEphemeralProjects`, side-effecting `cleanupEphemeralProjects` (transactional cascade delete).
- `packages/hu-board/src/db.js` — `is_test INTEGER` migration on `projects`, new strict `setProjectIsTest()` setter.
- `packages/hu-board/src/routes/api.js` — `PATCH /api/projects/:id/is-test` accepting only `{is_test: 0|1|null}`.
- `packages/hu-board/src/server.js` — wires the cleaner at startup, never blocks boot on failure.
- `packages/hu-board/public/app.js` + `styles.css` — three-state toggle button (🧪 / 📌 / ·) on each project card with a tooltip explaining the effective state.

## Test plan
- [x] 26 pure-function tests covering the classification matrix
- [x] 13 SQLite integration tests for cascade + idempotence
- [x] 6 HTTP tests for the PATCH endpoint
- [x] `npx vitest run` (hu-board) — 258/258
- [ ] CI green
- [ ] Manual: dashboard shows the toggle, click cycles state, server restart honours the new value.