### PR TITLE
feat(hu-board): in-UI help + tab tooltips (KJC-TSK-0372)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -2583,6 +2583,66 @@ function showError(message, opts = {}) {
 }
 
 /**
+ * Five-view quick reference modal (KJC-TSK-0372 — board polish #4).
+ *
+ * Triggered by the `?` button in the header. The native `title=`
+ * attributes on each tab cover the hover-1s tooltip case (browsers
+ * surface those automatically). This modal is the deeper "what does
+ * each view do" answer for users who arrive cold.
+ *
+ * Returns a promise that resolves when the user dismisses the modal.
+ */
+function showHelp() {
+  return new Promise((resolve) => {
+    const dlg = ensureDialog();
+    const sections = [
+      ['📋 Board',
+       'Kanban with every HU of the selected project, grouped by status (Pending → Certified → Done). Click a card to open its detail panel; cards highlight when blocked-by another HU.'],
+      ['🌐 Graph',
+       'Dependency graph of the selected project — who blocks whom. Useful before scheduling work to spot critical paths or orphan HUs.'],
+      ['📊 Dashboard',
+       'Per-project landing: stats grid (total / certified / done) + project list. Click a project card to focus the kanban / graph on that project.'],
+      ['📚 Sessions',
+       'Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.'],
+      ['⚙️ Pipeline',
+       'Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs. Opens in a separate page since the data is per-run, not per-project.'],
+    ];
+    const sectionHtml = sections
+      .map(([title, body]) => `
+        <div style="padding:10px 0;border-bottom:1px solid var(--border)">
+          <div style="font-weight:600;color:var(--accent-purple);margin-bottom:4px">${esc(title)}</div>
+          <div style="font-size:0.85rem;line-height:1.5;color:var(--text-secondary)">${esc(body)}</div>
+        </div>`)
+      .join('');
+    dlg.innerHTML = `
+      <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:600">
+        HU Board — what does each view do?
+      </div>
+      <div style="padding:8px 18px 4px 18px">${sectionHtml}</div>
+      <div style="padding:10px 18px;border-top:1px solid var(--border);
+                  font-size:0.78rem;color:var(--text-muted)">
+        Tip: hover any tab in the header for ~1 second to see a one-line summary.
+      </div>
+      <div style="padding:12px 18px;border-top:1px solid var(--border);text-align:right">
+        <button id="app-dialog-close" class="control-btn"
+                style="padding:6px 16px;border:1px solid var(--border);
+                       background:var(--bg-primary);color:var(--text);
+                       border-radius:var(--radius-sm);cursor:pointer">
+          Close
+        </button>
+      </div>
+    `;
+    const done = () => {
+      if (dlg.open) dlg.close();
+      resolve();
+    };
+    dlg.addEventListener('close', done, { once: true });
+    dlg.querySelector('#app-dialog-close').addEventListener('click', done, { once: true });
+    dlg.showModal();
+  });
+}
+
+/**
  * Show a blocking confirm dialog. Resolves to true when the user clicks
  * the primary action, false otherwise (cancel / Esc / backdrop click).
  * @param {string} message
@@ -3054,6 +3114,13 @@ document.getElementById('sync-btn').addEventListener('click', async () => {
 // dropping to a terminal. Output streams to the existing log panel.
 document.getElementById('commands-btn').addEventListener('click', () => {
   showCommandLauncher();
+});
+
+// Help button — KJC-TSK-0372. Quick reference modal for the 5 views.
+// Hover tooltips on each tab cover the 1-line case; this modal is
+// for users who arrive cold and want "ok, what does each one do?".
+document.getElementById('help-btn').addEventListener('click', () => {
+  showHelp();
 });
 
 // PR5: Settings button — opens the kj.config.yml editor modal.

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -20,15 +20,16 @@
       </div>
     </div>
     <nav class="header__nav">
-      <button class="nav-btn active" data-view="board">Board</button>
-      <button class="nav-btn" data-view="graph" title="Dependency graph of the selected project's HUs">Graph</button>
-      <button class="nav-btn" data-view="dashboard">Dashboard</button>
-      <button class="nav-btn" data-view="sessions">Sessions</button>
-      <a class="nav-btn" href="/pipeline.html" title="Pipeline observability view (v2.7)">Pipeline</a>
+      <button class="nav-btn active" data-view="board" title="Kanban board: every HU of the selected project, grouped by status (Pending → Certified → Done). Click an HU card to expand the detail panel.">Board</button>
+      <button class="nav-btn" data-view="graph" title="Dependency graph of the selected project's HUs — who blocks whom. Useful before scheduling work.">Graph</button>
+      <button class="nav-btn" data-view="dashboard" title="Per-project landing: stats grid + project list. Click a project card to focus the kanban / graph on that project.">Dashboard</button>
+      <button class="nav-btn" data-view="sessions" title="Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
+      <a class="nav-btn" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
       <select class="project-select" id="project-select">
         <option value="">All Projects</option>
       </select>
       <div class="header__controls">
+        <button class="control-btn" id="help-btn" title="What does each view do? Quick reference for Board / Graph / Dashboard / Sessions / Pipeline.">?</button>
         <button class="control-btn" id="config-btn" title="Configurar Karajan (modelos, agentes, tope de iteraciones, …)">⚙</button>
         <button class="control-btn" id="commands-btn" title="Launch a Karajan CLI command (kj plan, kj architect, kj clean…)">⚡</button>
         <button class="control-btn" id="restart-btn" title="Restart the HU Board server (preserves URL, the page reconnects automatically)">🔁</button>


### PR DESCRIPTION
## Summary
A new user landing on the HU Board had no way to know what each header tab did. Flagged by the user on 2026-05-07 in the "problemas a resolver antes de nada en el HUBoard" list. Two complementary affordances:

1. **Hover tooltip** (the AC's "1s hover → tooltip"): native `title=` attributes on every nav tab. Browsers handle the timing automatically.
2. **`?` button** in the header (the AC's "click → modal"): new modal with a one-short-paragraph summary of each view (Board / Graph / Dashboard / Sessions / Pipeline).

## What changed
- `packages/hu-board/public/index.html` — enriched `title=` on every nav button; new `#help-btn` in `.header__controls`.
- `packages/hu-board/public/app.js` — new `showHelp()` modal (uses the same `ensureDialog()` primitive as `showError` / `showConfirm`); click handler wired in the same registration block as `commands-btn`.

No new tests: the modal uses the same DOM primitives already exercised by the other dialog helpers, and hu-board has no jsdom env (adding one for one function would be disproportionate).

## Test plan
- [x] `node --check` on app.js + index.html parses
- [x] `npx vitest run` (hu-board) — 226/226
- [ ] Manual: hover each tab → tooltip appears after ~1s; click `?` → modal renders, Esc/Close dismiss it.