### PR TITLE
fix(config): writeConfig strips runtime-only keys before serialising (KJC-BUG-0036)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -278,34 +278,19 @@ async function runWizard(config, logger) {
 }
 
 /**
- * Persist the wizard's choices to disk WITHOUT serializing the
- * `sonarqube.enabled` key. That key was deprecated in v2.7.4 (sonar
- * is intrinsic to code-task pipelines and skipped for non-code by
- * policy). The wizard still uses it as an in-memory flag during
- * `init` to drive `setupSonarQube` (whether to bring up the
- * container right now), but persisting it to kj.config.yml causes a
- * "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
- * on every `kj run` afterwards — KJC-BUG-0034 / N3-3, observed in
- * dogfooding 2026-05-07.
+ * Backwards-compatible alias for `writeConfig`. Pre-KJC-BUG-0036 this
+ * wrapper was the *only* writer that stripped `sonarqube.enabled`
+ * before serialising — we needed it because the global `writeConfig`
+ * would happily persist the wizard's transient hint. KJC-BUG-0036
+ * moved that strip (and the equivalent `_deprecated` strip) into
+ * `writeConfig` itself, so this is now a thin alias kept around to
+ * keep callers and tests stable. Prefer `writeConfig` in new code.
  *
  * @param {string} configPath
  * @param {object} config
  */
 export async function writeInitConfig(configPath, config) {
-  const out = stripDeprecatedSonarEnabled(config);
-  await writeConfig(configPath, out);
-}
-
-function stripDeprecatedSonarEnabled(config) {
-  if (!config?.sonarqube || !Object.prototype.hasOwnProperty.call(config.sonarqube, "enabled")) {
-    return config;
-  }
-  // Shallow copy + drop `enabled`. Other sonar fields (host, token,
-  // container_name, timeouts, …) MUST survive — they are still
-  // honoured by the runtime.
-  const { enabled: _drop, ...rest } = config.sonarqube;
-  void _drop;
-  return { ...config, sonarqube: rest };
+  await writeConfig(configPath, config);
 }
 
 async function handleConfigSetup({ config, configExists, interactive, configPath, logger }) {

--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -128,9 +128,40 @@ export async function loadConfig(projectDir) {
   return { config: merged, path: configPath, exists: globalExists, hasProjectConfig: !!projectConfig };
 }
 
+/**
+ * Runtime-only keys that the loader synthesises on every load (or that
+ * a wizard uses as transient in-memory hints). They MUST NOT survive
+ * to the on-disk YAML — otherwise the `kj run` deprecation warning
+ * fossilises (KJC-BUG-0036, observed in dogfooding 2026-05-07: the
+ * `_deprecated.sonarqubeEnabledKey: true` block ended up baked into
+ * `~/.karajan/kj.config.yml` and re-fired the warning on every run
+ * even after the user cleaned `sonarqube.enabled`).
+ *
+ * Pure: returns a shallow-copied config without the runtime keys —
+ * the caller's object is left untouched.
+ */
+function stripRuntimeOnlyKeys(config) {
+  if (!config || typeof config !== "object") return config;
+  const out = { ...config };
+  // _deprecated is loader-synthesised — never written intentionally.
+  if ("_deprecated" in out) delete out._deprecated;
+  // sonarqube.enabled was deprecated in v2.7.4. The init wizard still
+  // uses it as a hint to drive setupSonarQube during install, but the
+  // runtime ignores it. Persisting it would re-trigger the deprecation
+  // warning on every subsequent kj run.
+  if (out.sonarqube && typeof out.sonarqube === "object"
+      && Object.prototype.hasOwnProperty.call(out.sonarqube, "enabled")) {
+    const { enabled: _drop, ...rest } = out.sonarqube;
+    void _drop;
+    out.sonarqube = rest;
+  }
+  return out;
+}
+
 export async function writeConfig(configPath, config) {
   await ensureDir(path.dirname(configPath));
-  await fs.writeFile(configPath, yaml.dump(config, { lineWidth: 120 }), "utf8");
+  const sanitized = stripRuntimeOnlyKeys(config);
+  await fs.writeFile(configPath, yaml.dump(sanitized, { lineWidth: 120 }), "utf8");
 }
 
 // Declarative mappings for applyRunOverrides to reduce cognitive complexity.

--- a/tests/config-loader-strip.test.js
+++ b/tests/config-loader-strip.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+import { writeConfig } from "../src/config/loader.js";
+
+// =====================================================================
+// KJC-BUG-0036 — `writeConfig` MUST strip runtime-only keys before
+// serialising. Two such keys today:
+//
+//   1. `_deprecated`        — synthesised by the loader on every load
+//                             when the user had a deprecated key set.
+//                             Pure runtime metadata; persisting it
+//                             "fossilises" the deprecation warning so
+//                             it keeps firing even after the user
+//                             cleans the offending source key.
+//
+//   2. `sonarqube.enabled`  — wizard-only hint (the init flow uses it
+//                             to drive setupSonarQube during install,
+//                             but the runtime ignored it from v2.7.4
+//                             onwards). Persisting it re-triggers the
+//                             deprecation warning on every kj run.
+//
+// Both bugs were observed during dogfooding 2026-05-07: the global
+// kj.config.yml ended up with both keys baked in, making `kj run`
+// noisy until cleaned up by hand.
+// =====================================================================
+
+let tmp;
+let configPath;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kj-writeconfig-strip-"));
+  configPath = join(tmp, "kj.config.yml");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("writeConfig — strip runtime-only keys (KJC-BUG-0036)", () => {
+  it("removes the `_deprecated` block before serialising", async () => {
+    await writeConfig(configPath, {
+      coder: "claude",
+      sonarqube: { host: "http://localhost:9000" },
+      _deprecated: { sonarqubeEnabledKey: true },
+    });
+    const onDisk = yaml.load(readFileSync(configPath, "utf8"));
+    expect(onDisk._deprecated).toBeUndefined();
+    expect(onDisk.sonarqube.host).toBe("http://localhost:9000");
+    expect(onDisk.coder).toBe("claude");
+  });
+
+  it("removes `sonarqube.enabled` while preserving sister sonar keys", async () => {
+    await writeConfig(configPath, {
+      coder: "claude",
+      sonarqube: {
+        enabled: true,
+        host: "http://localhost:9000",
+        token: "sqa_xxx",
+        container_name: "kj-sonar",
+      },
+    });
+    const onDisk = yaml.load(readFileSync(configPath, "utf8"));
+    expect("enabled" in onDisk.sonarqube).toBe(false);
+    expect(onDisk.sonarqube.host).toBe("http://localhost:9000");
+    expect(onDisk.sonarqube.token).toBe("sqa_xxx");
+    expect(onDisk.sonarqube.container_name).toBe("kj-sonar");
+  });
+
+  it("strips both keys in the same pass when both are present", async () => {
+    await writeConfig(configPath, {
+      sonarqube: { enabled: false, host: "http://localhost:9000" },
+      _deprecated: { sonarqubeEnabledKey: true },
+    });
+    const onDisk = yaml.load(readFileSync(configPath, "utf8"));
+    expect(onDisk._deprecated).toBeUndefined();
+    expect("enabled" in onDisk.sonarqube).toBe(false);
+    expect(onDisk.sonarqube.host).toBe("http://localhost:9000");
+  });
+
+  it("is a no-op when neither key is present (regression pin)", async () => {
+    await writeConfig(configPath, {
+      coder: "claude",
+      sonarqube: { host: "http://localhost:9000" },
+      pipeline: { triage: { enabled: true } }, // unrelated `enabled`s survive
+    });
+    const onDisk = yaml.load(readFileSync(configPath, "utf8"));
+    expect(onDisk.coder).toBe("claude");
+    expect(onDisk.sonarqube.host).toBe("http://localhost:9000");
+    expect(onDisk.pipeline.triage.enabled).toBe(true);
+  });
+
+  it("does NOT mutate the caller's config object (purity)", async () => {
+    const original = {
+      sonarqube: { enabled: true, host: "http://localhost:9000" },
+      _deprecated: { sonarqubeEnabledKey: true },
+    };
+    await writeConfig(configPath, original);
+    // The caller still sees the original in-memory hint — it's only
+    // the on-disk YAML that gets cleaned.
+    expect(original.sonarqube.enabled).toBe(true);
+    expect(original._deprecated.sonarqubeEnabledKey).toBe(true);
+  });
+
+  it("creates the parent directory when missing", async () => {
+    const nestedPath = join(tmp, "deep", "nested", "kj.config.yml");
+    await writeConfig(nestedPath, { coder: "claude" });
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+
+  it("survives a config without a sonarqube block at all", async () => {
+    await writeConfig(configPath, {
+      coder: "claude",
+      _deprecated: { sonarqubeEnabledKey: true },
+    });
+    const onDisk = yaml.load(readFileSync(configPath, "utf8"));
+    expect(onDisk._deprecated).toBeUndefined();
+    expect(onDisk.coder).toBe("claude");
+    expect(onDisk.sonarqube).toBeUndefined();
+  });
+});

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -465,15 +465,18 @@ describe("askBoardSecurity (KJC-TSK-0367)", () => {
 });
 
 // =====================================================================
-// KJC-BUG-0034 / N3-3 — writeInitConfig must NOT persist the deprecated
-// `sonarqube.enabled` key, which was removed from the runtime in v2.7.4.
-// The wizard still uses it as an in-memory hint to drive
-// setupSonarQube(), but it must be stripped before serialization or
-// every fresh `kj run` after `kj init` would emit the
-// "DEPRECATED: sonarqube.enabled is ignored since v2.7.4" warning
-// (the user hit this on 2026-05-07).
+// KJC-BUG-0034 / KJC-BUG-0036 — `writeInitConfig` is now a thin alias
+// for `writeConfig`. The actual stripping of runtime-only keys
+// (sonarqube.enabled + the loader-synthesised `_deprecated` block)
+// lives inside `writeConfig` so EVERY caller benefits, not just init.
+// The end-to-end strip behaviour is exercised in
+// tests/config-loader-strip.test.js against the real writer.
+//
+// This block stays here as a contract-level test: writeInitConfig must
+// delegate to writeConfig with the same arguments, and must NOT mutate
+// the caller's config object.
 // =====================================================================
-describe("writeInitConfig — strips deprecated sonarqube.enabled (KJC-BUG-0034)", () => {
+describe("writeInitConfig — delegates to writeConfig (KJC-BUG-0034 / 0036)", () => {
   let writeInitConfig;
   let writeConfig;
 
@@ -483,41 +486,20 @@ describe("writeInitConfig — strips deprecated sonarqube.enabled (KJC-BUG-0034)
     ({ writeInitConfig } = await import("../src/commands/init.js"));
   });
 
-  it("removes sonarqube.enabled before delegating to writeConfig", async () => {
+  it("forwards path + config to writeConfig untouched", async () => {
     const config = {
       coder: "claude",
       sonarqube: { enabled: true, host: "http://localhost:9000", token: "abc" },
     };
     await writeInitConfig("/tmp/kj.config.yml", config);
-    const persisted = writeConfig.mock.calls[0][1];
-    expect(persisted.sonarqube).toBeDefined();
-    expect("enabled" in persisted.sonarqube).toBe(false);
-    // Sister keys MUST survive — only the deprecated one is dropped.
-    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
-    expect(persisted.sonarqube.token).toBe("abc");
+    expect(writeConfig).toHaveBeenCalledTimes(1);
+    expect(writeConfig).toHaveBeenCalledWith("/tmp/kj.config.yml", config);
   });
 
   it("does not mutate the caller's config object (purity)", async () => {
     const config = { sonarqube: { enabled: false, host: "http://localhost:9000" } };
     await writeInitConfig("/tmp/kj.config.yml", config);
-    // Caller still sees the in-memory hint.
     expect(config.sonarqube.enabled).toBe(false);
-  });
-
-  it("is a no-op when sonarqube.enabled is already absent", async () => {
-    const config = { coder: "claude", sonarqube: { host: "http://localhost:9000" } };
-    await writeInitConfig("/tmp/kj.config.yml", config);
-    const persisted = writeConfig.mock.calls[0][1];
-    expect(persisted.sonarqube.host).toBe("http://localhost:9000");
-    // Same reference is fine here — nothing had to change.
-    expect("enabled" in persisted.sonarqube).toBe(false);
-  });
-
-  it("survives a config without a sonarqube block", async () => {
-    const config = { coder: "claude" };
-    await writeInitConfig("/tmp/kj.config.yml", config);
-    const persisted = writeConfig.mock.calls[0][1];
-    expect(persisted.coder).toBe("claude");
-    expect(persisted.sonarqube).toBeUndefined();
+    expect(config.sonarqube.host).toBe("http://localhost:9000");
   });
 });


### PR DESCRIPTION
## Summary
During post-N1 cleanup on 2026-05-07 the user's global `~/.karajan/kj.config.yml` was found to contain a baked-in `_deprecated: { sonarqubeEnabledKey: true }` block. The loader synthesises `_deprecated` on every load (it drives the "DEPRECATED: …" warning at run start) — but somewhere in the codebase a `writeConfig(merged)` call persisted it, fossilising the warning so it kept firing even after the user removed the offending `sonarqube.enabled` key.

Same root cause: `writeConfig` was a naive serialiser. KJC-BUG-0034 / PR #626 worked around it at the `writeInitConfig` wrapper level, but only for `sonarqube.enabled` — any caller that reached `writeConfig` directly was still leaking the deprecated value.

## What changed
- `src/config/loader.js` — new pure `stripRuntimeOnlyKeys()` helper called inside `writeConfig` before `yaml.dump`. Strips both `_deprecated` and `sonarqube.enabled`. Doesn't mutate the caller's object.
- `src/commands/init.js` — `writeInitConfig` collapses to a thin alias for `writeConfig` (back-compat). The duplicate `stripDeprecatedSonarEnabled` helper is gone.
- `tests/init-wizard.test.js` — the `writeInitConfig` describe block becomes a contract-level "delegates to writeConfig untouched" test.
- `tests/config-loader-strip.test.js` (new) — 7 cases against the real writer with a tempfile.

## Test plan
- [x] `npx vitest run tests/config-loader-strip.test.js tests/init-wizard.test.js` — 25/25
- [x] `npm test` — **4409/4409**
- [x] ESLint clean
- [x] End-to-end canary verified manually: `writeConfig({ sonarqube: { enabled: true, host: …, token: … }, _deprecated: { … } })` → on-disk YAML has only `coder, sonarqube.{host, token}`.
- [ ] CI green