### PR TITLE
fix(cli): clarify "task is REQUIRED" in help across 8 commands

### DIFF
--- a/docs/dogfooding-levels.md
+++ b/docs/dogfooding-levels.md
@@ -70,9 +70,10 @@ cd ~/ws_npm-packages/karajan-code
 kj researcher "¿Dónde decide Brain entre Solomon y fallback?"
 # ⇒ summary con paths concretos
 
-# Reviewer sobre cambios actuales (si los hay) o vs main
-kj review --base-ref main
-# ⇒ findings o "nothing to review"
+# Reviewer sobre cambios actuales vs main (REQUIERE un task — lo positional o --task-file)
+kj review --base-ref main "Verifica que los cambios mantienen los contratos del módulo afectado"
+# ⇒ JSON con approved / blocking_issues / non_blocking_suggestions / confidence.
+# Si la rama coincide con main (diff vacío), el reviewer responde "no diff in request" y aprueba — esto es lo esperado.
 
 # Audit deterministic — zero tokens, full pipeline excepto LLM
 kj audit --deterministic-only
@@ -87,6 +88,13 @@ kj audit --deterministic-only
 **Stop si** algún rol crashea — no subir hasta arreglar.
 
 Histórico 2026-05-07: ✅ Verde. Triage 7.2 s, Researcher 90.9 s. Sonar 401 token expirado y MCP-CLI parity bug observados (3 issues operacionales que ya están en backlog/arreglados).
+
+Re-validado 2026-05-07 (post-fixes hygiene + writeConfig): ✅ Verde.
+- Triage `simple/sw/[reviewer,tester]` en 13.7 s.
+- Researcher 94.7 s (10 affected_files, 7 patterns, 6 constraints, 6 risks).
+- Review `--base-ref main` con task arg en 18.9 s — devuelve approved con "no diff in request" (esperado: rama sincronizada con main).
+- Audit deterministic 3.7 s — 304 sonar issues, 4 unused deps, 4 dead exports, +6680 LOC desde 2026-05-04.
+- Hallazgo cosmético resuelto: el help de `kj review/run/code/plan generate/discover/triage/researcher/architect` decía `[task]` (opcional) sin reflejar el requerimiento "task O --task-file". Aclarado en PR (texto "Task description (REQUIRED — provide as argument or via --task-file)").
 
 ---
 

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -24,7 +24,7 @@ export function registerMeta(program, { pkgVersion }) {
   program
     .command("discover")
     .description("Analyze task for gaps, ambiguities and missing info")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--mode <name>", "Discovery mode: gaps|momtest|wendel|classify|jtbd", "gaps")
     .option("--discover <name>", "Override discover agent")
@@ -41,7 +41,7 @@ export function registerMeta(program, { pkgVersion }) {
   program
     .command("triage")
     .description("Classify task complexity and recommend pipeline roles")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--triage <name>", "Override triage agent")
     .option("--triage-model <name>", "Override triage model")
@@ -57,7 +57,7 @@ export function registerMeta(program, { pkgVersion }) {
   program
     .command("researcher")
     .description("Research codebase for a task (files, patterns, constraints)")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--researcher <name>", "Override researcher agent")
     .option("--researcher-model <name>", "Override researcher model")
@@ -72,7 +72,7 @@ export function registerMeta(program, { pkgVersion }) {
   program
     .command("architect")
     .description("Design solution architecture (layers, patterns, contracts)")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--architect <name>", "Override architect agent")
     .option("--architect-model <name>", "Override architect model")

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -40,7 +40,7 @@ export function registerPipeline(program, { pkgVersion }) {
   program
     .command("run")
     .description("Run coder+sonar+reviewer loop")
-    .argument("[task]", "Task description (or use --task-file to read from a .md file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md). Alternative to the positional task argument.")
     .option("-y, --yes", "Skip the cwd confirmation prompt (CI / scripted runs).")
     .option("--planner <name>")
@@ -135,7 +135,7 @@ export function registerPipeline(program, { pkgVersion }) {
   program
     .command("code")
     .description("Run only coder")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--coder <name>")
     .option("--coder-model <name>")
@@ -150,7 +150,7 @@ export function registerPipeline(program, { pkgVersion }) {
   program
     .command("review")
     .description("Run only reviewer")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--reviewer <name>")
     .option("--reviewer-model <name>")

--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -26,7 +26,7 @@ export function registerPlan(program, { pkgVersion }) {
   plan
     .command("generate", { isDefault: true })
     .description("Generate implementation plan with HUs")
-    .argument("[task]", "Task description (or use --task-file)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--planner <name>")
     .option("--planner-model <name>")


### PR DESCRIPTION
## Summary
During N2 dogfooding 2026-05-07 the user ran `kj review --base-ref main` and got `No task provided. Pass a task argument or --task-file <path>.` — the help showed the positional as `[task]` (commander's "optional" syntax) but the runtime requires it. The same ambiguity affected 7 sibling commands.

## What changed
Updated 8 task-argument descriptions to be unambiguous:

> Before: `Task description (or use --task-file)`
> After:  `Task description (REQUIRED — provide as argument or via --task-file)`

- `src/cli/register-pipeline.js`: `kj run`, `kj code`, `kj review`
- `src/cli/register-meta.js`: `kj discover`, `kj triage`, `kj researcher`, `kj architect`
- `src/cli/register-plan.js`: `kj plan generate`

`kj audit` is intentionally untouched — there the positional truly IS optional ("If absent, defaults to a full-codebase analysis").

Also fixes `docs/dogfooding-levels.md`: the N2-C command was missing the task argument and the "⇒ findings or 'nothing to review'" hint was wrong (the reviewer correctly returns `approved` + `"no diff in request"` when branch matches base — design, not bug).

## Test plan
- [x] `kj review --help` now shows the REQUIRED hint
- [x] `npm test` — 4409/4409 still passing
- [x] N2 re-verified end-to-end: triage / review --base-ref main with task / audit --deterministic-only all green
- [ ] CI green