### PR TITLE
fix(post-loop): summary lists every commit the run produced (N3 dogfooding)

### DIFF
--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -5,6 +5,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { computeBaseRef, setSnapshot } from "../review/diff-generator.js";
+import { revParse } from "../utils/git.js";
 import { buildCoderPrompt } from "../prompts/coder.js";
 import { buildReviewerPrompt } from "../prompts/reviewer.js";
 import { resolveRole } from "../config.js";
@@ -367,12 +368,28 @@ export async function initializeSession({ task, config, flags, pgTaskId, pgProje
   const projectDir = config.projectDir || process.cwd();
   const project_id = projectSlug(projectDir);
 
+  // Capture HEAD at the very start of the run, separately from base_ref.
+  // session_start_sha was being conflated with base_ref (used for `git diff`)
+  // — when the user's repo had a single commit and no remote main, base_ref
+  // fell through to git's empty-tree SHA. The post-loop journal then read
+  // session_start_sha to enumerate "commits made by this run" and got back
+  // the entire history, including pre-existing commits. Capturing actual
+  // HEAD here makes "what did the run produce?" deterministic and correct.
+  // Falls back to baseRef when HEAD doesn't exist (zero-commits repo); in
+  // that case "everything since baseRef" still equals "everything the run
+  // produced" because there was no prior history.
+  let headAtStart;
+  try {
+    headAtStart = (await revParse("HEAD")) || baseRef;
+  } catch { headAtStart = baseRef; }
+
   const sessionInit = {
     task,
     project_id,
     config_snapshot: config,
     base_ref: baseRef,
     session_start_sha: baseRef,
+    head_at_start: headAtStart,
     last_reviewer_feedback: null,
     repeated_issue_count: 0,
     sonar_retry_count: 0,

--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -23,6 +23,7 @@
 
 import { generateDiff } from "../../review/diff-generator.js";
 import { finalizeGitAutomation } from "../../git/automation.js";
+import { listCommitsBetween } from "../../utils/git.js";
 import { saveSession, markSessionStatus } from "../../session/store.js";
 import {
   setReviewerFeedback, setBudget, setRtkSavings, resetRetryCount,
@@ -151,6 +152,20 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
       const { writeSummaryJournal: writeSummaryJournalV2 } =
         await import("../../session/journal/summary-writer.js");
       const startedAt = session._startedAt ? new Date(session._startedAt).toISOString() : undefined;
+      // 2026-05-07 dogfooding: gitResult.commits only carries the post-loop
+      // commit (scaffold), not the coder's own commit. The summary's
+      // "Commits" section was therefore misleading — it claimed the run
+      // produced one chore commit when in fact the coder had also written
+      // a docs/feat commit. Compute the full range from session_start_sha
+      // so every commit between then and HEAD shows up in execution order.
+      // try/catch (instead of `.catch(...)`) so we tolerate both promise
+      // rejection AND a sync return of undefined — the latter happens
+      // when a test mocks listCommitsBetween with a plain vi.fn() that
+      // resetAllMocks has stripped of its mockResolvedValue.
+      let allCommits = [];
+      try { allCommits = (await listCommitsBetween(session.head_at_start || session.session_start_sha)) || []; }
+      catch { allCommits = gitResult?.commits || []; }
+      const summaryCommits = allCommits.length > 0 ? allCommits : (gitResult?.commits || []);
       await writeSummaryJournalV2(journalDir, {
         task: session.task,
         result: "APPROVED",
@@ -159,7 +174,7 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
         durationMs: Date.now() - (session._startedAt || Date.now()),
         budget: budgetSummary(),
         stages: stageResults,
-        commits: gitResult?.commits || [],
+        commits: summaryCommits,
         files: journalFiles,
         startedAt,
         finishedAt: new Date().toISOString(),
@@ -180,7 +195,21 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
     }
   }
 
-  const endDetail = { approved: true, iterations: i, stages: stageResults, git: gitResult, budget: budgetSummary(), deferredIssues };
+  // Mirror the same enriched commit list into the session:end event so the
+  // terminal `🏁 Result` banner (printSessionGit) shows every commit the
+  // run produced, not just the post-loop scaffold one. We compute again
+  // (cheap: one git log call) rather than threading a variable through
+  // because the journal block is wrapped in try/catch and may have set
+  // `summaryCommits` to a fallback we don't want for the event detail.
+  // try/catch tolerates both promise rejection and sync undefined returns
+  // (see the journal block above for the detailed rationale).
+  let eventCommits = null;
+  try { eventCommits = await listCommitsBetween(session.head_at_start || session.session_start_sha); }
+  catch { /* leave null — we'll use gitResult unchanged */ }
+  const gitForEvent = (Array.isArray(eventCommits) && eventCommits.length > 0)
+    ? { ...gitResult, commits: eventCommits }
+    : gitResult;
+  const endDetail = { approved: true, iterations: i, stages: stageResults, git: gitForEvent, budget: budgetSummary(), deferredIssues };
   if (rtkSavings) endDetail.rtk_savings = rtkSavings;
   emitProgress(
     emitter,

--- a/src/types/session.js
+++ b/src/types/session.js
@@ -64,7 +64,8 @@
  * @property {string[]} [skillsRecommended]               - wouldHaveUsed when openskills missing
  * @property {string[]} [autoInstalledSkills]
  * @property {RtkSavings} [rtk_savings]
- * @property {string} [session_start_sha]
+ * @property {string} [session_start_sha]                 - baseline for `git diff`; may be the empty-tree SHA when no prior commits exist
+ * @property {string} [head_at_start]                     - actual HEAD when the run started; used by the post-loop journal to enumerate commits produced BY the run. Falls back to session_start_sha in zero-commits repos. (2026-05-07 dogfooding fix.)
  * @property {string} [_journalDir]                       - runtime journal path
  * @property {string[]} [_journalIterations]              - rendered iteration markdown
  * @property {string[]} [_journalFiles]

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -65,6 +65,42 @@ export async function revParse(ref) {
   return runGit(["rev-parse", ref]);
 }
 
+/**
+ * List commits in the range `fromSha..toRef`. Used by the post-loop
+ * journal builder to enumerate every commit produced during a `kj run`
+ * — both the coder's own commits AND the post-loop scaffold commit —
+ * so the user-visible summary doesn't lose track of them. Pre-fix the
+ * summary only listed `gitResult.commits` (post-loop only), which made
+ * `kj run "..."` runs look like the coder hadn't committed.
+ *
+ * Returns oldest-first so the list reads in execution order.
+ *
+ * @param {string|null|undefined} fromSha The SHA right BEFORE the run started
+ *   (typically `session.session_start_sha`). Empty/missing → returns [].
+ * @param {string} [toRef="HEAD"]
+ * @returns {Promise<Array<{hash: string, message: string}>>}
+ */
+export async function listCommitsBetween(fromSha, toRef = "HEAD") {
+  if (!fromSha) return [];
+  const result = await run(
+    "git",
+    ["log", "--reverse", "--format=%H%x09%s", `${fromSha}..${toRef}`],
+  ).catch(() => null);
+  if (!result || result.exitCode !== 0) return [];
+  return String(result.stdout || "")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const tabIdx = line.indexOf("\t");
+      // Defensive: if git emitted no tab (shouldn't happen with our format)
+      // treat the whole line as the hash and leave the message empty rather
+      // than throw — caller can still render the row.
+      if (tabIdx === -1) return { hash: line, message: "" };
+      return { hash: line.slice(0, tabIdx), message: line.slice(tabIdx + 1) };
+    });
+}
+
 export async function syncBaseBranch({ baseBranch, autoRebase }) {
   const local = await revParse(baseBranch);
   const remote = await revParse(`origin/${baseBranch}`);

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -92,7 +92,10 @@ vi.mock("../src/utils/git.js", () => ({
   buildBranchName: vi.fn().mockReturnValue("feat/test"),
   commitAll: vi.fn().mockResolvedValue({ committed: true }),
   pushBranch: vi.fn(),
-  createPullRequest: vi.fn()
+  createPullRequest: vi.fn(),
+  // Post-loop reads commit history via this helper for the summary.
+  // Empty array → summary falls back to gitResult.commits.
+  listCommitsBetween: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock("node:fs/promises", () => ({

--- a/tests/reviewer-parse-resilience.test.js
+++ b/tests/reviewer-parse-resilience.test.js
@@ -90,7 +90,10 @@ vi.mock("../src/utils/git.js", () => ({
   buildBranchName: vi.fn().mockReturnValue("feat/test"),
   commitAll: vi.fn().mockResolvedValue({ committed: true }),
   pushBranch: vi.fn(),
-  createPullRequest: vi.fn()
+  createPullRequest: vi.fn(),
+  // Post-loop reads commit history via this helper for the summary.
+  // Empty array → summary falls back to gitResult.commits.
+  listCommitsBetween: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock("../src/orchestrator/solomon-escalation.js", () => ({

--- a/tests/runflow-events.test.js
+++ b/tests/runflow-events.test.js
@@ -137,7 +137,10 @@ vi.mock("../src/utils/git.js", () => ({
   buildBranchName: vi.fn().mockReturnValue("feat/test"),
   commitAll: vi.fn().mockResolvedValue({ committed: true }),
   pushBranch: vi.fn(),
-  createPullRequest: vi.fn()
+  createPullRequest: vi.fn(),
+  // Post-loop reads commit history via this helper for the summary.
+  // Empty array → summary falls back to gitResult.commits.
+  listCommitsBetween: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock("node:fs/promises", () => ({

--- a/tests/runflow-repeat-detection.test.js
+++ b/tests/runflow-repeat-detection.test.js
@@ -132,7 +132,10 @@ vi.mock("../src/utils/git.js", () => ({
   buildBranchName: vi.fn().mockReturnValue("feat/test"),
   commitAll: vi.fn().mockResolvedValue({ committed: true }),
   pushBranch: vi.fn(),
-  createPullRequest: vi.fn()
+  createPullRequest: vi.fn(),
+  // Post-loop reads commit history via this helper for the summary.
+  // Empty array → summary falls back to gitResult.commits.
+  listCommitsBetween: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock("node:fs/promises", () => ({

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -128,7 +128,10 @@ vi.mock("../src/utils/git.js", () => ({
   buildBranchName: vi.fn().mockReturnValue("feat/test"),
   commitAll: vi.fn().mockResolvedValue({ committed: true }),
   pushBranch: vi.fn(),
-  createPullRequest: vi.fn()
+  createPullRequest: vi.fn(),
+  // Post-loop reads commit history via this helper for the summary.
+  // Empty array → summary falls back to gitResult.commits.
+  listCommitsBetween: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -249,7 +252,7 @@ describe("configurable sub-loop limits", () => {
     // max_sonar_retries=3, fail_fast_repeats=99 — sonar should use its own limit (3)
     const config = makeConfig({ max_sonar_retries: 3, fail_fast_repeats: 99, repeat_detection_threshold: 99 });
 
-    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+    await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
 
     const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
     // With Solomon boss, the sonar escalation event should fire after max_sonar_retries
@@ -306,7 +309,7 @@ describe("configurable sub-loop limits", () => {
 
     const config = makeConfig({ max_reviewer_retries: 4, fail_fast_repeats: 2 });
 
-    const result = await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
+    await runFlow({ task: "Fix bug", config, logger: noopLogger, emitter });
 
     const solomonEvents = events.filter((e) => e.type === "solomon:escalate");
     expect(solomonEvents[0].detail.retryCount).toBe(4);

--- a/tests/utils-git.test.js
+++ b/tests/utils-git.test.js
@@ -230,4 +230,83 @@ describe("utils/git", () => {
       ]);
     });
   });
+
+  // 2026-05-07 dogfooding fix: the post-loop summary was listing ONLY
+  // `gitResult.commits` (the scaffold commit produced by the post-loop)
+  // and forgetting the coder's own commits. listCommitsBetween() asks
+  // git for the full range so every commit shows up.
+  describe("listCommitsBetween", () => {
+    it("returns [] when fromSha is missing or empty", async () => {
+      expect(await git.listCommitsBetween()).toEqual([]);
+      expect(await git.listCommitsBetween(null)).toEqual([]);
+      expect(await git.listCommitsBetween("")).toEqual([]);
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("parses oldest-first hash<TAB>message lines", async () => {
+      // git log --reverse → coder's commit first, scaffold last.
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout:
+          "abc1234567890abcdef1234567890abcdef123456\tdocs: add JSDoc to index.js\n"
+          + "def4567890abcdef1234567890abcdef12345678\tchore: scaffold karajan workspace\n",
+        stderr: "",
+      });
+      const commits = await git.listCommitsBetween("a2516ec");
+      expect(runCommand).toHaveBeenCalledWith(
+        "git",
+        ["log", "--reverse", "--format=%H%x09%s", "a2516ec..HEAD"],
+      );
+      expect(commits).toHaveLength(2);
+      expect(commits[0]).toEqual({
+        hash: "abc1234567890abcdef1234567890abcdef123456",
+        message: "docs: add JSDoc to index.js",
+      });
+      expect(commits[1].message).toBe("chore: scaffold karajan workspace");
+    });
+
+    it("honours a custom toRef", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+      await git.listCommitsBetween("origin/main", "feat/foo");
+      expect(runCommand).toHaveBeenCalledWith(
+        "git",
+        ["log", "--reverse", "--format=%H%x09%s", "origin/main..feat/foo"],
+      );
+    });
+
+    it("returns [] on a non-zero git log exit (defensive — keep summary writable)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 128, stdout: "", stderr: "fatal: bad revision" });
+      expect(await git.listCommitsBetween("nonexistent")).toEqual([]);
+    });
+
+    it("returns [] when runCommand throws (no exception leak)", async () => {
+      runCommand.mockRejectedValue(new Error("git binary missing"));
+      expect(await git.listCommitsBetween("a2516ec")).toEqual([]);
+    });
+
+    it("survives a malformed line (no tab) by treating it as hash with empty message", async () => {
+      // Defensive: should never happen with --format=%H%x09%s, but if a
+      // future format change emits a hash on its own line we don't want
+      // to crash the summary writer.
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "abc1234567890abcdef1234567890abcdef123456\n",
+        stderr: "",
+      });
+      const commits = await git.listCommitsBetween("a2516ec");
+      expect(commits).toEqual([
+        { hash: "abc1234567890abcdef1234567890abcdef123456", message: "" },
+      ]);
+    });
+
+    it("filters empty trailing lines", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "abc1\tone\ndef2\ttwo\n\n\n",
+        stderr: "",
+      });
+      const commits = await git.listCommitsBetween("a");
+      expect(commits.map((c) => c.hash)).toEqual(["abc1", "def2"]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Re-running N3 (`kj run` trivial doc task) on 2026-05-07 surfaced a misleading post-mortem: the terminal `🏁 Result` banner and the on-disk `summary.md` both reported only **one** commit (the post-loop scaffold), while the coder had silently produced **another** (`docs: add JSDoc comment...`). For a user reviewing what the run actually did, half the work was invisible.

Two interlocking causes:

1. **`gitResult.commits` only carries the post-loop scaffold** — the coder's commits had no journal owner.
2. **`session.session_start_sha` was being conflated with `base_ref`** — when a single-commit repo had no remote, `computeBaseRef` fell through to git's empty-tree SHA, so the "list commits since run start" path returned the entire repo history (incl. the user's pre-existing `initial`).

## What changed
- `src/utils/git.js` — new `listCommitsBetween(fromSha, toRef="HEAD")` helper (pure, defensive).
- `src/orchestrator/config-init.js` — stamps a new `session.head_at_start` field at run start, separate from `session_start_sha`/`base_ref`. Captures actual HEAD via `revParse("HEAD")`; falls back to baseRef only when HEAD doesn't exist (zero-commits repo).
- `src/orchestrator/drivers/post-loop.js` — uses `listCommitsBetween` in two spots (journal summary + `session:end` event detail) so the terminal banner matches the persisted summary. Defensive try/catch.
- `src/types/session.js` — documented `head_at_start`, clarified `session_start_sha`.
- 7 new tests for `listCommitsBetween` + extended 5 existing test mock factories so they expose the new export.
- Cleaned 2 pre-existing `no-unused-vars` warnings in `tests/subloop-limits.test.js` (we were touching it).

## Verification (live, `/tmp/kj-test-3-v3`)
```
git log:
  a4f9ebb chore: scaffold karajan workspace
  72a4f9b docs: add JSDoc comment to index.js explaining exports
  0d420a2 initial            ← pre-existing, NOT produced by the run
Result panel + summary.md "Commits":
  - 72a4f9b docs: …
  - a4f9ebb chore: …
```
`initial` correctly excluded.

## Test plan
- [x] `npx vitest run tests/utils-git.test.js` — 30/30
- [x] `npm test` — 4416/4416
- [x] ESLint clean
- [x] Live N3 re-run on `/tmp/kj-test-3-v3` confirms summary + banner list both run-produced commits and exclude pre-existing
- [ ] CI green