### PR TITLE
fix(sonar): silent-skip SonarStage + tolerate empty post-loop commit (N4)

### DIFF
--- a/src/audit/sonar-findings.js
+++ b/src/audit/sonar-findings.js
@@ -22,33 +22,7 @@
 
 import { isSonarReachable } from "../sonar/manager.js";
 import { getOpenIssues, getQualityGateStatus } from "../sonar/api.js";
-import { runCommand } from "../utils/process.js";
-
-/**
- * Quick async check: does the cwd's git repo have a `remote.origin.url`
- * configured AND does the user have an explicit `project_key` override?
- *
- * Sonar's project key is derived from the git remote URL by default,
- * so a fresh repo with no remote (the typical `kj run` in /tmp/...
- * scenario detected on 2026-05-07) would otherwise hit
- * `resolveSonarProjectKey` → "Missing git remote.origin.url" → noisy
- * warning in every audit. This helper lets the caller skip the entire
- * Sonar collection cleanly with a "not applicable" reason instead of
- * an "error" warning.
- *
- * @param {object} config
- * @returns {Promise<boolean>} true when sonar input can be derived
- */
-async function canDeriveSonarProjectKey(config) {
-  const explicit = String(
-    process.env.KJ_SONAR_PROJECT_KEY || config?.sonarqube?.project_key || "",
-  ).trim();
-  if (explicit) return true;
-  const res = await runCommand("git", ["config", "--get", "remote.origin.url"]).catch(
-    () => ({ exitCode: 1, stdout: "" }),
-  );
-  return res.exitCode === 0 && String(res.stdout || "").trim().length > 0;
-}
+import { canResolveSonarProjectKey } from "../sonar/project-key.js";
 
 /**
  * Collect deterministic Sonar findings for the audit prompt.
@@ -74,7 +48,7 @@ export async function collectSonarFindings(config, logger = null) {
   // typical `kj run` in a fresh /tmp/... folder. Reporting it as a
   // warning treats it like an error (which it isn't — sonar simply
   // doesn't apply to a remoteless repo).
-  if (!(await canDeriveSonarProjectKey(config))) {
+  if (!(await canResolveSonarProjectKey(config))) {
     return {
       available: false,
       reason: "not applicable: no git remote and no sonarqube.project_key configured",

--- a/src/orchestrator/stages/sonar-stage.js
+++ b/src/orchestrator/stages/sonar-stage.js
@@ -11,6 +11,7 @@ import {
 import { emitProgress, makeEvent } from "../../utils/events.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { sonarUp, isSonarReachable } from "../../sonar/manager.js";
+import { canResolveSonarProjectKey } from "../../sonar/project-key.js";
 import { addEntries } from "../feedback-queue.js";
 
 /**
@@ -220,6 +221,24 @@ export async function runSonarStage({ config, logger, emitter, eventBase, sessio
       return { action: "ok", stageResult: { gateStatus: "PENDING", reason: "SonarQube starting up" } };
     }
     logger.info("SonarQube is ready");
+  }
+
+  // 2026-05-07 (N4 dogfooding): when the working tree has neither a git
+  // remote nor an explicit `sonarqube.project_key`, the scanner inside
+  // SonarRole would throw "Missing git remote.origin.url" — the Brain
+  // logs that as a sonar error, the iteration cap is reached, and the
+  // run finalises as "approved" by exhaustion fallback even though no
+  // sonar gate ever ran. KJC-TSK-0373 silenced this for the audit
+  // collector but the run loop hit it on the parallel code path.
+  // Skipping cleanly here means the gate reports "SKIPPED" once and
+  // the iteration loop progresses on the next stage.
+  if (!await canResolveSonarProjectKey(config)) {
+    logger.info("Sonar gate skipped: no git remote and no sonarqube.project_key configured");
+    emitProgress(emitter, makeEvent("sonar:end", { ...eventBase, stage: "sonar" }, {
+      status: "skip",
+      message: "Sonar skipped — no git remote and no sonarqube.project_key configured (run `git remote add origin …` or set `sonarqube.project_key` to enable)"
+    }));
+    return { action: "ok", stageResult: { gateStatus: "SKIPPED", reason: "no git remote and no sonarqube.project_key configured" } };
   }
 
   const sonarRole = new SonarRole({ config, logger, emitter });

--- a/src/sonar/project-key.js
+++ b/src/sonar/project-key.js
@@ -81,3 +81,40 @@ export async function resolveSonarProjectKey(config, options = {}) {
   const repo = slug(repoId.split("/").pop());
   return normalizeProjectKey(`kj-${repo}-${digest(repoId)}`);
 }
+
+/**
+ * Non-throwing predicate: can a Sonar project key be resolved for `config`?
+ *
+ * Used by callers (audit collector, run-loop SonarStage) that want to skip
+ * the Sonar work cleanly instead of letting `resolveSonarProjectKey` throw
+ * "Missing git remote.origin.url" deep inside the scanner. The scanner's
+ * thrown error is fine for an explicit `kj sonar` call (the user asked
+ * for it), but for implicit pipeline gates it produces a noisy "Sonar
+ * scan failed" loop in fresh /tmp/... repos.
+ *
+ * Returns true when EITHER:
+ *   - an explicit `project_key` is set (env var, config, or per-call option),
+ *   - OR `git config --get remote.origin.url` succeeds with a non-empty value.
+ *
+ * Side-effect-free apart from the git probe.
+ *
+ * @param {object} config
+ * @param {object} [options]
+ * @param {string} [options.projectKey]
+ * @returns {Promise<boolean>}
+ */
+export async function canResolveSonarProjectKey(config, options = {}) {
+  const explicit = String(
+    options.projectKey || process.env.KJ_SONAR_PROJECT_KEY || config?.sonarqube?.project_key || ""
+  ).trim();
+  if (explicit) return true;
+  // try/catch (instead of `.catch(...)`) tolerates two legitimate test
+  // realities: a runCommand mock that returns undefined, and a real
+  // promise rejection from a missing git binary. Either way we treat
+  // it as "no remote available" and let the caller skip Sonar cleanly.
+  let remote;
+  try { remote = await runCommand("git", ["config", "--get", "remote.origin.url"]); }
+  catch { return false; }
+  if (!remote) return false;
+  return remote.exitCode === 0 && String(remote.stdout || "").trim().length > 0;
+}

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -181,11 +181,43 @@ export async function listPendingPaths() {
   return out;
 }
 
+// Locale-tolerant detection of "git commit refused because the working
+// tree was already clean by the time we ran it". Observed in N4
+// dogfooding (2026-05-07) — `hasChanges()` reported true after `add -A`
+// but `git commit` then failed with the Spanish message "nada para hacer
+// commit, el árbol de trabajo está limpio". The race window is real:
+// post-loop journal writes can finish between hasChanges and commit, and
+// some files come back from `add -A` with no diff vs HEAD even though
+// they show up in `git status --porcelain`. We treat any of those as
+// "no commit needed" rather than escalating to Solomon.
+const NOTHING_TO_COMMIT_PATTERNS = [
+  /nothing to commit/i,
+  /nada para hacer commit/i,         // git in es_ES locale
+  /no hay nada para confirmar/i,     // git in es_ES alt phrasing
+  /aucune modification ajout[ée]e au commit/i, // fr_FR
+  /nichts zu committen/i,            // de_DE
+];
+function isNothingToCommit(message) {
+  const m = String(message || "");
+  return NOTHING_TO_COMMIT_PATTERNS.some((re) => re.test(m));
+}
+
 export async function commitAll(message) {
   await runGit(["add", "-A"]);
   const changed = await hasChanges();
   if (!changed) return { committed: false };
-  await runGit(["commit", "-m", message]);
+  try {
+    await runGit(["commit", "-m", message]);
+  } catch (err) {
+    // `git status --porcelain` and `git commit` disagreed about whether
+    // there was anything to commit. Don't escalate — the only outcome
+    // either way is "no new commit was created", which the caller
+    // already handles via committed=false.
+    if (isNothingToCommit(err?.message)) {
+      return { committed: false };
+    }
+    throw err;
+  }
   const raw = await runGit(["log", "-1", "--pretty=format:%H%x1f%s"]);
   const [hash, commitMessage] = raw.split("\x1f");
   return { committed: true, commit: { hash, message: commitMessage } };

--- a/tests/kj-run-smoke.test.js
+++ b/tests/kj-run-smoke.test.js
@@ -176,6 +176,8 @@ describe("kj_run smoke", () => {
 
     const { runCommand } = await import("../src/utils/process.js");
     runCommand
+      // Extra git probe consumed by canResolveSonarProjectKey before the scanner runs (KJC-TSK-0373 / N4)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "scan ok", stderr: "" });
 
@@ -242,6 +244,8 @@ describe("kj_run smoke", () => {
 
     const { runCommand } = await import("../src/utils/process.js");
     runCommand
+      // Extra git probe consumed by canResolveSonarProjectKey before the scanner runs (KJC-TSK-0373 / N4)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: JSON.stringify({ valid: true }), stderr: "" })
       .mockResolvedValueOnce({
@@ -321,6 +325,8 @@ describe("kj_run smoke", () => {
 
     const { runCommand } = await import("../src/utils/process.js");
     runCommand
+      // Extra git probe consumed by canResolveSonarProjectKey before the scanner runs (KJC-TSK-0373 / N4)
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "git@github.com:acme/repo.git\n", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "coverage ok", stderr: "" })
       .mockResolvedValueOnce({ exitCode: 0, stdout: "scan ok", stderr: "" });
@@ -362,9 +368,17 @@ describe("kj_run smoke", () => {
     const result = await runFlow({ task: "smoke test", config, logger, flags: {}, emitter });
 
     expect(result.approved).toBe(true);
+    // Calls 0 and 1 are git probes (canResolveSonarProjectKey + scanner's
+    // resolveSonarProjectKey). The contract being tested is the ordering
+    // of coverage→docker, which still holds — assert by content rather
+    // than by absolute index so the test doesn't break when more probes
+    // are added in front.
+    const bashIdx = runCommand.mock.calls.findIndex(([bin]) => bin === "bash");
+    const dockerIdx = runCommand.mock.calls.findIndex(([bin]) => bin === "docker");
+    expect(bashIdx).toBeGreaterThanOrEqual(0);
+    expect(dockerIdx).toBeGreaterThanOrEqual(0);
+    expect(bashIdx).toBeLessThan(dockerIdx);
+    expect(runCommand.mock.calls[bashIdx][1]).toEqual(["-lc", "echo coverage"]);
     expect(runCommand.mock.calls[0][0]).toBe("git");
-    expect(runCommand.mock.calls[1][0]).toBe("bash");
-    expect(runCommand.mock.calls[1][1]).toEqual(["-lc", "echo coverage"]);
-    expect(runCommand.mock.calls[2][0]).toBe("docker");
   });
 });

--- a/tests/sonar-project-key.test.js
+++ b/tests/sonar-project-key.test.js
@@ -5,7 +5,7 @@ vi.mock("../src/utils/process.js", () => ({
 }));
 
 const { runCommand } = await import("../src/utils/process.js");
-const { resolveSonarProjectKey } = await import("../src/sonar/project-key.js");
+const { resolveSonarProjectKey, canResolveSonarProjectKey } = await import("../src/sonar/project-key.js");
 
 describe("[opt-in: sonar] resolveSonarProjectKey", () => {
   beforeEach(() => {
@@ -116,5 +116,69 @@ describe("[opt-in: sonar] resolveSonarProjectKey", () => {
     await expect(resolveSonarProjectKey(config)).rejects.toThrow(
       "Unable to parse git remote.origin.url. Use a valid SSH/HTTPS remote or set sonarqube.project_key explicitly."
     );
+  });
+});
+
+// =====================================================================
+// canResolveSonarProjectKey — non-throwing predicate used by callers
+// (run-loop SonarStage, audit collector) that want to skip Sonar
+// cleanly instead of letting the scanner throw "Missing git remote".
+// 2026-05-07 dogfooding: N4 hit this on a fresh /tmp/... repo with no
+// remote — the SonarStage threw repeatedly until max_iterations and the
+// run finalised as "approved" by exhaustion fallback.
+// =====================================================================
+describe("[opt-in: sonar] canResolveSonarProjectKey (KJC-TSK-0373 / N4)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.KJ_SONAR_PROJECT_KEY;
+  });
+
+  it("returns true when an explicit projectKey option is passed", async () => {
+    expect(await canResolveSonarProjectKey({ sonarqube: {} }, { projectKey: "kj-explicit" })).toBe(true);
+    // git probe must NOT be invoked when an explicit key short-circuits.
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns true when KJ_SONAR_PROJECT_KEY env is set", async () => {
+    process.env.KJ_SONAR_PROJECT_KEY = "env-key";
+    expect(await canResolveSonarProjectKey({ sonarqube: {} })).toBe(true);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns true when sonarqube.project_key is set in config", async () => {
+    expect(await canResolveSonarProjectKey({ sonarqube: { project_key: "config-key" } })).toBe(true);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns true when git remote.origin.url is present", async () => {
+    runCommand.mockResolvedValue({
+      exitCode: 0,
+      stdout: "git@github.com:owner/repo.git\n",
+      stderr: "",
+    });
+    expect(await canResolveSonarProjectKey({ sonarqube: {} })).toBe(true);
+  });
+
+  it("returns false when no explicit key AND no git remote", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    expect(await canResolveSonarProjectKey({ sonarqube: {} })).toBe(false);
+  });
+
+  it("returns false when git probe throws (defensive — keep run-loop alive)", async () => {
+    runCommand.mockRejectedValue(new Error("git binary missing"));
+    expect(await canResolveSonarProjectKey({ sonarqube: {} })).toBe(false);
+  });
+
+  it("treats whitespace-only env var as 'not set' and falls back to git probe", async () => {
+    process.env.KJ_SONAR_PROJECT_KEY = "   ";
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    expect(await canResolveSonarProjectKey({ sonarqube: {} })).toBe(false);
+    expect(runCommand).toHaveBeenCalled();
+  });
+
+  it("treats whitespace-only config project_key as 'not set'", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    expect(await canResolveSonarProjectKey({ sonarqube: { project_key: "  " } })).toBe(false);
+    expect(runCommand).toHaveBeenCalled();
   });
 });

--- a/tests/sonar-token-flow.test.js
+++ b/tests/sonar-token-flow.test.js
@@ -169,7 +169,6 @@ describe("sonar token resolution — runSonarStage", () => {
       }
     }));
 
-    const { markSessionStatus } = await import("../src/session/store.js");
     const { runSonarStage } = await import("../src/orchestrator/iteration-stages.js");
 
     const session = {
@@ -181,7 +180,12 @@ describe("sonar token resolution — runSonarStage", () => {
     };
 
     const config = {
-      sonarqube: { enabled: true, host: "http://localhost:9000" },
+      // Set an explicit project_key so canResolveSonarProjectKey returns true
+      // and the stage proceeds to the token-resolution path being tested.
+      // Without this, the new (KJC-TSK-0373 / N4) "no git remote AND no
+      // project_key" silent-skip kicks in first and the token failure path
+      // is never exercised.
+      sonarqube: { enabled: true, host: "http://localhost:9000", project_key: "kj-test-token-flow" },
       session: { fail_fast_repeats: 3 }
     };
 

--- a/tests/utils-git.test.js
+++ b/tests/utils-git.test.js
@@ -96,6 +96,44 @@ describe("utils/git", () => {
     });
   });
 
+  // Regression for N4 (2026-05-07 dogfooding): commitAll was throwing
+  // "nada para hacer commit" when the working tree was clean by the
+  // time `git commit` ran, even though `hasChanges()` had reported a
+  // change moments earlier. The error escalated to Solomon and aborted
+  // the post-loop journal writer (no summary.md / iterations.md). The
+  // fix swallows the locale-specific "nothing to commit" message and
+  // returns `committed: false` cleanly.
+  describe("commitAll — race tolerance", () => {
+    it("returns committed: false when git commit refuses with English 'nothing to commit'", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })            // git add -A
+        .mockResolvedValueOnce({ exitCode: 0, stdout: " M file.js\n", stderr: "" }) // git status --porcelain → has changes
+        .mockResolvedValueOnce({ exitCode: 1, stdout: "nothing to commit, working tree clean\n", stderr: "" }); // git commit fails
+
+      const result = await git.commitAll("test commit");
+      expect(result).toEqual({ committed: false });
+    });
+
+    it("returns committed: false on Spanish 'nada para hacer commit'", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: " M file.js\n", stderr: "" })
+        .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "nada para hacer commit, el árbol de trabajo está limpio\n" });
+
+      const result = await git.commitAll("test commit");
+      expect(result).toEqual({ committed: false });
+    });
+
+    it("re-throws on a real git error (not a 'nothing to commit' false alarm)", async () => {
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: " M file.js\n", stderr: "" })
+        .mockResolvedValueOnce({ exitCode: 128, stdout: "", stderr: "fatal: unable to write index\n" });
+
+      await expect(git.commitAll("test commit")).rejects.toThrow(/unable to write index/);
+    });
+  });
+
   describe("commitAll", () => {
     it("stages and commits when there are changes", async () => {
       runCommand


### PR DESCRIPTION
## Summary
N4 (`kj run` zero-config rich task on a fresh `/tmp/` repo) surfaced two cascading bugs that turned the talk's main demo into a 5-iteration "approved by exhaustion" no-op:

1. **SonarStage threw "Missing git remote.origin.url" on every iteration**. PR #624 silenced this for the audit collector — but the run-loop sonar gate calls the scanner directly and hit the same throw. Brain treated each error as unresolved, iterated until the cap, then finalised via the `max_iterations reached with clean feedback queue` fallback — no real sonar gate ever ran.
2. **Post-loop `commitAll` race**: `hasChanges()` reported true after `git add -A`, but the subsequent `git commit` refused with `nada para hacer commit, el árbol de trabajo está limpio` (es_ES). The thrown error escalated to Solomon, which approved despite the stage error — but the journal writer never ran, so the user got NO `summary.md`, no `iterations.md`, and the `🏁 Result` banner never printed.

## What changed
- `src/sonar/project-key.js` — new exported `canResolveSonarProjectKey(config, options)` predicate (non-throwing, idempotent).
- `src/audit/sonar-findings.js` — drops its private duplicate; consumes the shared predicate.
- `src/orchestrator/stages/sonar-stage.js` — calls the predicate AFTER reachability; if false, emits `sonar:end` with `status: skip` and returns `gateStatus: "SKIPPED"`. The iteration loop progresses cleanly.
- `src/utils/git.js` — `commitAll()` catches locale-specific "nothing to commit" (en/es/de/fr) and returns `{ committed: false }` cleanly instead of throwing.
- Tests: 8 new `canResolveSonarProjectKey` cases, 3 new `commitAll` race-tolerance cases, plus mock-call adjustments in `kj-run-smoke` (3 tests) and `sonar-token-flow` (1 test).

## Live re-validation (`/tmp/kj-test-4-1778159231`)
- Sonar gate skipped: "no git remote and no sonarqube.project_key configured" — once per iteration, no error spam.
- 7 commits across 2 iterations.
- Audit CERTIFIED. Reviewer/Tester/Security all green.
- Total: **$2.26 / 19K tokens**.

## Test plan
- [x] `npx vitest run tests/sonar-project-key.test.js tests/utils-git.test.js tests/kj-run-smoke.test.js tests/sonar-token-flow.test.js` — all green
- [x] `npm test` — 4427/4427
- [x] ESLint clean
- [x] Live N4 confirms the silent-skip fix
- [ ] CI green
- [ ] Post-merge re-N4 to confirm summary.md is now written (commitAll race tolerance fix)