### PR TITLE
fix(display): Sonar SKIPPED renders gray, not red, in result banner

### DIFF
--- a/src/utils/display/session-summary.js
+++ b/src/utils/display/session-summary.js
@@ -26,9 +26,19 @@ function printSessionPlanner(planner) {
   }
 }
 
-function printSessionSonar(sonar) {
+export function printSessionSonar(sonar) {
   if (!sonar) return;
-  const gateLabel = sonar.gateStatus === "OK" ? ANSI.green : ANSI.red;
+  // Three buckets so the banner reads correctly:
+  //   - OK                                 \u2192 green (real pass).
+  //   - SKIPPED / PENDING                  \u2192 gray (informational; sonar
+  //     wasn't gated against, this is NOT a fail). Pre-2026-05-07 N4
+  //     dogfooding these were rendered red, which made a clean run
+  //     look like a sonar failure during the live demo.
+  //   - everything else (ERROR, WARN, ...) \u2192 red (real fail).
+  let gateLabel;
+  if (sonar.gateStatus === "OK") gateLabel = ANSI.green;
+  else if (sonar.gateStatus === "SKIPPED" || sonar.gateStatus === "PENDING") gateLabel = ANSI.gray;
+  else gateLabel = ANSI.red;
   console.log(`  ${ANSI.dim}\ud83d\udd0d Sonar: ${gateLabel}${sonar.gateStatus}${ANSI.reset}${ANSI.dim} (${sonar.openIssues ?? 0} issues)${ANSI.reset}`);
   if (typeof sonar.issuesInitial === "number" || typeof sonar.issuesResolved === "number") {
     const issuesInitial = sonar.issuesInitial ?? sonar.openIssues ?? 0;

--- a/tests/display/sonar-banner.test.js
+++ b/tests/display/sonar-banner.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { printSessionSonar } from "../../src/utils/display/session-summary.js";
+import { ANSI } from "../../src/utils/display/formatters.js";
+
+// Regression for N4 dogfooding (2026-05-07): the `🏁 Result` banner's
+// Sonar line rendered every non-OK gate status in red, which made
+// a legitimate SKIPPED (no git remote / no project_key — opt-out, not
+// a failure) look like a fail during the live demo.
+
+describe("display/session-summary — printSessionSonar gate colour", () => {
+  let output;
+  beforeEach(() => {
+    output = [];
+    vi.spyOn(console, "log").mockImplementation((...args) => { output.push(args.join(" ")); });
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  function lastLine() {
+    return output.at(-1) || "";
+  }
+
+  it("noop when sonar is null/undefined", () => {
+    printSessionSonar(null);
+    expect(output).toHaveLength(0);
+  });
+
+  it("renders OK in green", () => {
+    printSessionSonar({ gateStatus: "OK", openIssues: 0 });
+    expect(lastLine()).toContain(ANSI.green);
+    expect(lastLine()).not.toContain(ANSI.red);
+    expect(lastLine()).toContain("Sonar:");
+    expect(lastLine()).toContain("OK");
+  });
+
+  it("renders SKIPPED in gray (NOT red)", () => {
+    printSessionSonar({ gateStatus: "SKIPPED", openIssues: 0 });
+    expect(lastLine()).toContain(ANSI.gray);
+    expect(lastLine()).not.toContain(ANSI.red);
+    expect(lastLine()).not.toContain(ANSI.green);
+    expect(lastLine()).toContain("SKIPPED");
+  });
+
+  it("renders PENDING in gray", () => {
+    printSessionSonar({ gateStatus: "PENDING", openIssues: 0 });
+    expect(lastLine()).toContain(ANSI.gray);
+    expect(lastLine()).not.toContain(ANSI.red);
+    expect(lastLine()).toContain("PENDING");
+  });
+
+  it("renders ERROR in red", () => {
+    printSessionSonar({ gateStatus: "ERROR", openIssues: 12 });
+    expect(lastLine()).toContain(ANSI.red);
+    expect(lastLine()).not.toContain(ANSI.green);
+    expect(lastLine()).toContain("ERROR");
+    expect(lastLine()).toContain("12 issues");
+  });
+
+  it("renders WARN (or any other unexpected status) in red — fail-safe", () => {
+    printSessionSonar({ gateStatus: "WARN", openIssues: 3 });
+    expect(lastLine()).toContain(ANSI.red);
+    expect(lastLine()).toContain("WARN");
+  });
+
+  it("includes openIssues count in the banner", () => {
+    printSessionSonar({ gateStatus: "OK", openIssues: 7 });
+    expect(lastLine()).toContain("7 issues");
+  });
+
+  it("falls back to '0 issues' when openIssues is missing", () => {
+    printSessionSonar({ gateStatus: "SKIPPED" });
+    expect(lastLine()).toContain("0 issues");
+  });
+});


### PR DESCRIPTION
## Summary
N4 dogfooding (2026-05-07) showed the `🏁 Result` banner painting every non-OK Sonar gateStatus in red. So a legitimate `SKIPPED` (no git remote and no project_key — the talk's main zero-config demo path) looked like a failure on screen.

## What changed
- `src/utils/display/session-summary.js`:
  - `OK` → green (real pass)
  - `SKIPPED` / `PENDING` → gray (informational, not a fail)
  - everything else (`ERROR`, `WARN`, …) → red (real fail)
  - Promoted `printSessionSonar` to `export` so the new test can drive it directly.
- `tests/display/sonar-banner.test.js` (new): 8 cases covering all three buckets, noop-on-null, and the `0 issues` fallback.

## Test plan
- [x] `npx vitest run tests/display/sonar-banner.test.js` — 8/8
- [x] `npm test` — 4435/4435
- [x] ESLint clean
- [ ] CI green