### PR TITLE
fix(flow-runner): seal session status at runFlow boundary (KJC-BUG-0037)

### DIFF
--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -60,6 +60,45 @@ import { runSecurityStage, runFinalAuditStage } from "./post-loop-stages.js";
 // PG card "In Progress" logic moved to src/planning-game/pipeline-adapter.js → initPgAdapter()
 
 
+/**
+ * Boundary guard: make sure the session's terminal status reflects what
+ * actually happened, even if some inner exit path forgot to call
+ * `markSessionStatus`. KJC-BUG-0037 (N1 dogfooding 2026-05-07): runs
+ * that took the Brain "max_iterations approved" / "Solomon-after-error
+ * approved" / "Brain solomon-approved" exits returned `{approved:true}`
+ * upstream but left `session.status = "running"` on disk indefinitely.
+ * `kj status` then showed "Pipeline RUNNING" forever and the HU Board
+ * carried a perma-zombie.
+ *
+ * Maps the result shape to a terminal status:
+ *   approved → "approved"
+ *   paused   → "paused"
+ *   cancelled → "cancelled"
+ *   anything else → "failed"
+ *
+ * Idempotent: only writes when the current status is still "running"
+ * (or unset). If an inner path already sealed it correctly, this is a
+ * no-op.
+ *
+ * Safe-by-default: never throws. A failure here must not block the
+ * top-level result from being returned to the caller.
+ *
+ * @param {object} session
+ * @param {object} [result]
+ */
+export async function sealSessionStatusIfStillRunning(session, result) {
+  try {
+    if (!session) return;
+    const current = session.status;
+    if (current && current !== "running") return;
+    let target = "failed";
+    if (result?.approved === true) target = "approved";
+    else if (result?.paused === true) target = "paused";
+    else if (result?.cancelled === true) target = "cancelled";
+    await markSessionStatus(session, target);
+  } catch { /* non-blocking */ }
+}
+
 export async function runFlow(opts) {
   // TSK-0338: isolate per-run state (git/diff runner, projectDir, snapshot)
   // inside an AsyncLocalStorage scope. Two concurrent `runFlow` invocations
@@ -193,12 +232,14 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
     // policies + acceptance-tests gate + Sonar + tester translation.
     const huBatch = await runHuBatch({ ctx, task, askQuestion, emitter, logger });
     if (huBatch.handled) {
+      await sealSessionStatusIfStillRunning(ctx.session, huBatch.result);
       return huBatch.result;
     }
 
     // --- Standard single-task pipeline (1 HU or no HU reviewer) ---
     const result = await runIterationLoop(ctx, { task: ctx.plannedTask, askQuestion, emitter, logger });
     await writeHistoryRecord({ sessionId: ctx.session.id, task, result, logger });
+    await sealSessionStatusIfStillRunning(ctx.session, result);
     return result;
   } finally {
     // --- Cleanup auto-installed skills ---

--- a/tests/session-status-sealing.test.js
+++ b/tests/session-status-sealing.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// We exercise the boundary guard directly. The mocks isolate
+// markSessionStatus so the test doesn't need a real session-store.
+vi.mock("../src/session/store.js", () => ({
+  markSessionStatus: vi.fn(),
+  saveSession: vi.fn(),
+  loadSession: vi.fn(),
+  resumeSessionWithAnswer: vi.fn(),
+  resetAllRetryCounters: vi.fn(),
+  setStatus: vi.fn(),
+  setReviewerFeedback: vi.fn(),
+  setSonarIssueSignature: vi.fn(),
+  setSonarRepeatCount: vi.fn(),
+  setReviewerIssueSignature: vi.fn(),
+  setReviewerRepeatCount: vi.fn(),
+  setBudget: vi.fn(),
+}));
+
+const { sealSessionStatusIfStillRunning } = await import("../src/orchestrator/flow-runner.js");
+const { markSessionStatus } = await import("../src/session/store.js");
+
+describe("sealSessionStatusIfStillRunning (KJC-BUG-0037)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // ---- happy paths ---------------------------------------------------------
+
+  it("seals as 'approved' when result.approved is true and session is still running", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session, { approved: true });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "approved");
+  });
+
+  it("seals as 'paused' when result.paused is true", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session, { paused: true });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "paused");
+  });
+
+  it("seals as 'cancelled' when result.cancelled is true", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session, { cancelled: true });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "cancelled");
+  });
+
+  // ---- failure / fallback paths ---------------------------------------------
+
+  it("seals as 'failed' when result is undefined / has no recognised flag", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session);
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "failed");
+  });
+
+  it("seals as 'failed' on result.approved=false (the explicit-fail return shape)", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session, { approved: false, reason: "stage_error" });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "failed");
+  });
+
+  it("also seals when status is missing entirely (defensive)", async () => {
+    const session = { id: "s1" }; // no status key
+    await sealSessionStatusIfStillRunning(session, { approved: true });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "approved");
+  });
+
+  // ---- idempotence: do NOT overwrite a real terminal status -----------------
+
+  it("does NOT overwrite when session.status is already 'approved'", async () => {
+    const session = { id: "s1", status: "approved" };
+    await sealSessionStatusIfStillRunning(session, { approved: true });
+    expect(markSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("does NOT overwrite when session.status is already 'failed'", async () => {
+    const session = { id: "s1", status: "failed" };
+    await sealSessionStatusIfStillRunning(session, { approved: true });
+    expect(markSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("does NOT overwrite when session.status is 'paused'", async () => {
+    const session = { id: "s1", status: "paused" };
+    await sealSessionStatusIfStillRunning(session, { approved: true });
+    expect(markSessionStatus).not.toHaveBeenCalled();
+  });
+
+  it("does NOT overwrite when session.status is 'cancelled'", async () => {
+    const session = { id: "s1", status: "cancelled" };
+    await sealSessionStatusIfStillRunning(session);
+    expect(markSessionStatus).not.toHaveBeenCalled();
+  });
+
+  // ---- never-throws contract ------------------------------------------------
+
+  it("never throws when markSessionStatus rejects (non-blocking)", async () => {
+    markSessionStatus.mockRejectedValueOnce(new Error("disk full"));
+    const session = { id: "s1", status: "running" };
+    await expect(sealSessionStatusIfStillRunning(session, { approved: true })).resolves.toBeUndefined();
+  });
+
+  it("never throws when session is null/undefined", async () => {
+    await expect(sealSessionStatusIfStillRunning(null, { approved: true })).resolves.toBeUndefined();
+    await expect(sealSessionStatusIfStillRunning(undefined, { approved: true })).resolves.toBeUndefined();
+    expect(markSessionStatus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Several `runFlow` exit paths returned the result upstream without calling `markSessionStatus`, so the `session.json` on disk stayed at `status: "running"` even when the run had clearly finished. `kj status` displayed "Pipeline RUNNING" forever and the HU Board carried a perma-zombie until the 6 h reaper cutoff.

Detected on 2026-05-07 (N1 dogfooding). Specifically affects every "approved by exception" exit:
- Brain "max_iterations approved" (post-loop.js:263)
- Brain "Solomon-after-max-iterations approved" (post-loop.js:285)
- Solomon "approved-after-stage-error" (iteration-loop.js:234)
- Brain "approved by exhaustion" with clean queue
- Legacy Solomon "approved at max_iterations" (post-loop.js:313)

## What changed
- `src/orchestrator/flow-runner.js` — new exported helper `sealSessionStatusIfStillRunning(session, result)` invoked before each `return` at the runFlow boundary. Maps the result shape to a terminal status, idempotent (no-op when the status was already sealed), never throws.
- `tests/session-status-sealing.test.js` — 12 cases: all four target statuses, the `failed` fallback, no-overwrite when already terminal, defensive null/undefined session, and the never-throws contract.

## Test plan
- [x] `npx vitest run tests/session-status-sealing.test.js` — 12/12
- [x] `npm test` — 4447/4447
- [x] ESLint clean
- [ ] CI green
- [ ] Live N5 + manual `jq .status ~/.karajan/sessions/<id>/session.json` confirms terminal status after each run