### PR TITLE
fix(hu-git): fall back to master/HEAD when configured base_branch missing (N6)

### DIFF
--- a/src/git/hu-automation.js
+++ b/src/git/hu-automation.js
@@ -42,6 +42,34 @@ export function resolveHuBase(story, huBranches, baseBranch) {
 }
 
 /**
+ * Resolve to an actually-existing local ref. Tries the preferred branch
+ * first, then `main` and `master`, then plain `HEAD` as last resort.
+ *
+ * Why: N6 plan-flow dogfooding (2026-05-07) on a `git init -q` repo
+ * with `init.defaultBranch=master` produced 7 identical warnings:
+ *   `failed to create branch feat/...-001 from main:
+ *    fatal: 'main' is not a commit and a branch can't be created`.
+ * Every HU then fell back to running on the original branch, which
+ * defeats the per-HU isolation the sub-pipeline was supposed to give.
+ *
+ * The configured base_branch is honoured when it exists; otherwise we
+ * pick the most likely default. HEAD always exists once the repo has
+ * any commit, so the fallback never throws past the gate.
+ *
+ * @param {string} preferred
+ * @returns {Promise<string>}
+ */
+async function resolveExistingBranchRef(preferred) {
+  const candidates = [preferred, "main", "master", "HEAD"]
+    .filter((c, i, arr) => c && arr.indexOf(c) === i); // unique, truthy
+  for (const ref of candidates) {
+    const probe = await runCommand("git", ["rev-parse", "--verify", "--quiet", ref], {});
+    if (probe.exitCode === 0) return ref;
+  }
+  return preferred; // give up; caller will surface the original error
+}
+
+/**
  * Create a branch for an HU starting from its resolved base.
  * Returns the branch name created (or null if git automation is disabled).
  *
@@ -57,17 +85,21 @@ export async function prepareHuBranch({ story, huBranches, config, logger }) {
     return null;
   }
   const baseBranch = resolveHuBase(story, huBranches, config.base_branch || "main");
+  const effectiveBase = await resolveExistingBranchRef(baseBranch);
+  if (effectiveBase !== baseBranch) {
+    logger.info(`HU git: configured base '${baseBranch}' not found locally — using '${effectiveBase}' instead`);
+  }
   const prefix = config.git?.branch_prefix || "feat/";
   const branchName = buildHuBranchName(prefix, story);
 
   // Checkout from the resolved base. Use `git checkout -B` to overwrite if rerun.
-  const res = await runCommand("git", ["checkout", "-B", branchName, baseBranch], {});
+  const res = await runCommand("git", ["checkout", "-B", branchName, effectiveBase], {});
   if (res.exitCode !== 0) {
-    logger.warn(`HU git: failed to create branch ${branchName} from ${baseBranch}: ${res.stderr}`);
+    logger.warn(`HU git: failed to create branch ${branchName} from ${effectiveBase}: ${res.stderr}`);
     return null;
   }
   huBranches.set(story.id, branchName);
-  logger.info(`HU ${story.id}: branch '${branchName}' from '${baseBranch}'`);
+  logger.info(`HU ${story.id}: branch '${branchName}' from '${effectiveBase}'`);
   return branchName;
 }
 

--- a/tests/hu-git-automation.test.js
+++ b/tests/hu-git-automation.test.js
@@ -1,5 +1,17 @@
-import { describe, it, expect } from "vitest";
-import { buildHuBranchName, resolveHuBase } from "../src/git/hu-automation.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
+vi.mock("../src/utils/git.js", () => ({
+  commitAll: vi.fn(),
+  pushBranch: vi.fn(),
+  createPullRequest: vi.fn(),
+  hasChanges: vi.fn(),
+}));
+
+const { buildHuBranchName, resolveHuBase, prepareHuBranch } = await import("../src/git/hu-automation.js");
+const { runCommand } = await import("../src/utils/process.js");
 
 describe("buildHuBranchName", () => {
   it("builds branch name with prefix, id and slug", () => {
@@ -55,5 +67,91 @@ describe("resolveHuBase", () => {
     const story = { id: "HU-02", blocked_by: ["HU-01"] };
     const branches = new Map();
     expect(resolveHuBase(story, branches, "main")).toBe("main");
+  });
+});
+
+// N6 dogfooding 2026-05-07: `git init -q` + init.defaultBranch=master
+// produced 7 identical "branch 'main' is not a commit" warnings — every
+// HU silently fell back to the original branch and the per-HU isolation
+// the sub-pipeline was designed to provide was lost.
+describe("prepareHuBranch — base-branch fallback (N6 dogfooding)", () => {
+  const logger = { info: vi.fn(), warn: vi.fn() };
+  const baseConfig = { git: { auto_commit: true, branch_prefix: "feat/" }, base_branch: "main" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the configured base_branch when it exists locally", async () => {
+    runCommand
+      // resolveExistingBranchRef: probe `main` → exists.
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" })
+      // checkout -B feat/HU-01-... main → ok.
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+
+    const story = { id: "HU-01", title: "Setup", blocked_by: [] };
+    const huBranches = new Map();
+    const branch = await prepareHuBranch({ story, huBranches, config: baseConfig, logger });
+
+    expect(branch).toBe("feat/HU-01-setup");
+    expect(runCommand).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--verify", "--quiet", "main"], {});
+    expect(runCommand).toHaveBeenNthCalledWith(2, "git", ["checkout", "-B", "feat/HU-01-setup", "main"], {});
+    expect(huBranches.get("HU-01")).toBe("feat/HU-01-setup");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to 'master' when 'main' does not exist", async () => {
+    // Candidate order after dedup: main, master, HEAD. Probe in order;
+    // first match wins.
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "fatal: Needed a single revision" }) // main missing
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" })  // master exists → win
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });          // checkout -B ... master
+
+    const story = { id: "HU-01", title: "Setup", blocked_by: [] };
+    const huBranches = new Map();
+    const branch = await prepareHuBranch({ story, huBranches, config: baseConfig, logger });
+
+    expect(branch).toBe("feat/HU-01-setup");
+    // Last checkout call should branch from master, not main
+    const checkoutCall = runCommand.mock.calls.find(c => c[0] === "git" && c[1][0] === "checkout");
+    expect(checkoutCall[1]).toEqual(["checkout", "-B", "feat/HU-01-setup", "master"]);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/configured base 'main' not found locally — using 'master'/));
+  });
+
+  it("falls back to HEAD when neither 'main' nor 'master' exist", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" }) // main missing
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" }) // master missing
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" }) // HEAD exists
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });        // checkout
+
+    const story = { id: "HU-01", title: "Setup", blocked_by: [] };
+    const branch = await prepareHuBranch({ story, huBranches: new Map(), config: baseConfig, logger });
+
+    expect(branch).toBe("feat/HU-01-setup");
+    const checkoutCall = runCommand.mock.calls.find(c => c[0] === "git" && c[1][0] === "checkout");
+    expect(checkoutCall[1]).toEqual(["checkout", "-B", "feat/HU-01-setup", "HEAD"]);
+  });
+
+  it("returns null and warns when checkout still fails after fallback", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" }) // main missing
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" }) // master missing
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" }) // HEAD missing (zero-commits)
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "fatal: empty repo" }); // checkout fails
+
+    const story = { id: "HU-01", title: "Setup", blocked_by: [] };
+    const branch = await prepareHuBranch({ story, huBranches: new Map(), config: baseConfig, logger });
+
+    expect(branch).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/HU git: failed to create branch/));
+  });
+
+  it("noop returns null when no git automation flags are set", async () => {
+    const config = { git: { auto_commit: false, auto_push: false, auto_pr: false }, base_branch: "main" };
+    const branch = await prepareHuBranch({ story: { id: "HU-01" }, huBranches: new Map(), config, logger });
+    expect(branch).toBeNull();
+    expect(runCommand).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fix for HU sub-pipeline branch creation when base_branch doesn't exist locally. See commit message for details.

## Test plan
- [x] hu-git-automation tests 14/14
- [x] Full suite 4452/4452
- [x] Lint clean
- [ ] CI green