### PR TITLE
chore(ci): bump checkout/setup-node v4→v5; opt release-binaries into Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,9 +21,9 @@ jobs:
         node: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
 
@@ -77,9 +77,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/injection-guard.yml
+++ b/.github/workflows/injection-guard.yml
@@ -9,11 +9,11 @@ jobs:
     name: Scan PR for prompt injection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -8,6 +8,16 @@ on:
 permissions:
   contents: write
 
+# Force JS actions in this workflow to run on Node.js 24. GitHub will
+# make this the default on 2026-06-02 and remove Node.js 20 from the
+# runner on 2026-09-16. `actions/checkout@v5` and `actions/setup-node@v5`
+# already declare Node 24, but `softprops/action-gh-release@v2` (used
+# below to upload SEA binaries) still ships a Node 20 runtime in its
+# action.yml; this env opts it into Node 24 today so we don't get the
+# deprecation banner on every release.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -26,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
GitHub announced (2025-09-19) that JS actions will be forced to run on Node.js 24 by default starting **2026-06-02**, with Node.js 20 removed from the runner on **2026-09-16**. Deprecation banner showed on every workflow run since.

## What changed
- `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` across all four workflows.
- `softprops/action-gh-release@v2` (release-binaries) still ships Node 20 in its `action.yml` and no v3 stable. Workflow-level env `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` opts it into Node 24 today.

## What did NOT change
- Test/build matrix: still `[20.x, 22.x]`. Adding 24.x is a separate decision.
- `engines.node` intact at `>=20.10`.

## Test plan
- [x] YAML syntax verified locally (python yaml.safe_load).
- [ ] CI green — exercises ci.yml, injection-guard.yml, e2e.yml.
- [ ] release-binaries.yml validation requires a tag push; will verify on next release.