### PR TITLE
fix(ci): remove env context from shrink-budget job name (silent workflow failure)

### DIFF
--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -32,7 +32,14 @@ env:
 
 jobs:
   loc-budget:
-    name: Net LOC delta <= ${{ env.LOC_LIMIT }}
+    # GHA forbids `${{ env.* }}` inside `name:` at the job level (only
+    # `github`, `inputs`, `matrix`, `needs`, `strategy`, `vars` are
+    # allowed there — see actionlint expression rules). The original
+    # PR carried the same bug, which silently disabled the entire
+    # workflow file with a 0s "validation failure" run on every push.
+    # Hard-coded number here; the real limit lives in `env.LOC_LIMIT`
+    # below and the steps still read that — name is purely cosmetic.
+    name: Net LOC delta within budget
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'large-pr-justified') }}
 


### PR DESCRIPTION
Heredado del PR #577 (cerrado) y reintroducido en #640: `name: Net LOC delta <= ${{ env.LOC_LIMIT }}` rompe la validación de GHA porque `env` no es contexto válido a nivel de job-name. El workflow llevaba fallando silenciosamente desde que mergeamos #640 (3 runs zombi en 0s, jobs=[]).

Detectado hoy con `docker run rhysd/actionlint`. Hard-codeo el display name; `LOC_LIMIT` sigue activo en `env` y en los pasos.

## Test plan
- [x] `actionlint` clean (sólo queda SC2129 stylistic, pre-existente).
- [x] No conflict con tests del PR #641 (no asseta job.name).
- [ ] CI green.
- [ ] Verificación final: tras merge, esta misma PR debe ser la primera vez que el workflow corre con éxito sobre un PR.