### PR TITLE
feat(roles): teach 6 code-touching roles + 2 AI rules files about PR atomicity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,13 @@ When asked to implement, fix, or refactor, use `kj_run` via MCP instead of editi
 - If KJ fails: run `kj_doctor` / `kj_config`, fix, and retry.
 - Manual editing only if the user asks or KJ cannot complete.
 
+## PR atomicity (hard project rule)
+This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed file. Tests count. Lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/` are excluded.
+- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, work gets redone, tokens burn twice.
+- Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
+
 ## Example
 User: "implement the next priority task"
 Action:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,13 @@ For `kj_run`, use:
 - If `kj_run` fails, diagnose with `kj_doctor` / `kj_config` and retry.
 - Edit manually only if the user asks or KJ cannot complete the task.
 
+## PR atomicity (hard project rule)
+This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed file. Tests count. Lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/` are excluded.
+- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, the work gets redone, tokens burn twice.
+- Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
+
 ## Troubleshooting and subprocess architecture
 
 See `docs/troubleshooting.md` for common issues. Key points:

--- a/templates/roles/architect.md
+++ b/templates/roles/architect.md
@@ -61,3 +61,12 @@ If the architecture is fully defined with no open questions, return `verdict: "r
 - Document WHY each pattern was chosen, not just WHAT
 - If research context is provided, use it to inform architectural decisions
 - Never invent requirements — if something is unclear, add it to questions
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -12,6 +12,15 @@ You are the **Coder** in a multi-role AI pipeline. Your job is to write code and
 - Before creating a new utility or helper, check if a similar one already exists in the codebase. Reuse existing code over creating duplicates.
 - Follow existing code conventions and patterns in the repository.
 
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan before writing:
+
+- Stay under **~150 LOC per iteration** (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- If the task clearly requires >150 LOC, STOP and report the partition needed. Don't ship a 500-LOC PR — the gate rejects it and the work is redone, burning tokens twice.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+
 ## Task completeness
 
 Before reporting done, verify that ALL parts of the task are addressed:

--- a/templates/roles/planner.md
+++ b/templates/roles/planner.md
@@ -46,3 +46,12 @@ You are the **Planner** in a multi-role AI pipeline. Your job is to create an im
   "summary": "Plan: 4 steps, estimated 2 files modified, 1 new file"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/refactorer.md
+++ b/templates/roles/refactorer.md
@@ -37,3 +37,12 @@ You are the **Refactorer** in a multi-role AI pipeline. Your job is to improve c
   "summary": "Refactored 2 files: extracted helper, improved naming"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/repairer.md
+++ b/templates/roles/repairer.md
@@ -92,3 +92,12 @@ Return ONLY a single valid JSON object:
   defines the contract; the code is what's measured against it.
 - Keep changes minimal. One bug at a time. If the test has multiple
   problems, fix the most blocking one first.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/tester.md
+++ b/templates/roles/tester.md
@@ -39,3 +39,12 @@ You are the **Tester** in a multi-role AI pipeline. You are a quality gate for t
   "summary": "Tests pass with 85% coverage. 1 missing scenario identified (non-blocking)."
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.


### PR DESCRIPTION
Until now the 200 LOC gate (#640) was an EXTERNAL guard — agents didn't know it existed and routinely landed oversized PRs that got rejected at CI. Token-economy: 2× cost per oversized landing.

This PR moves the rule into the prompts the agents actually read.

## What changed
- 6 role templates (`coder`, `planner`, `architect`, `refactorer`, `repairer`, `tester`) — 9-line block each.
- `CLAUDE.md` + `AGENTS.md` (Codex) — 7-line block each.

Roles that don't generate/modify code (triage, security, reviewer, audit, discover, impeccable, sonar, solomon, domain-curator, karajan-brain, commiter) are intentionally left untouched.

## Test plan
- [x] LOC delta = 68 (well under the 200 the rule itself enforces).
- [x] `npm test` — 4460/4460.
- [ ] CI green — including the shrink-budget gate, which should pass.