### PR TITLE
fix(roles): propagate PR atomicity rule to per-provider templates

### DIFF
--- a/templates/roles/architect/anthropic.md
+++ b/templates/roles/architect/anthropic.md
@@ -63,3 +63,12 @@ Return a single valid JSON object and nothing else.
 
 If the architecture is fully defined, `verdict: "ready"` and `questions: []`.
 </output_format>
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/architect/default.md
+++ b/templates/roles/architect/default.md
@@ -61,3 +61,12 @@ If the architecture is fully defined with no open questions, return `verdict: "r
 - Document WHY each pattern was chosen, not just WHAT
 - If research context is provided, use it to inform architectural decisions
 - Never invent requirements — if something is unclear, add it to questions
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/architect/google.md
+++ b/templates/roles/architect/google.md
@@ -50,3 +50,12 @@ Questions MUST include which isolation level (shared DB + tenant_id column vs sc
 ## Output (strict JSON)
 
 Same shape as Example 1. Exactly one top-level object. No prose around it.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/architect/openai.md
+++ b/templates/roles/architect/openai.md
@@ -49,3 +49,12 @@ You are the Architect. Design the technical architecture BEFORE implementation.
 ```
 
 If fully defined → `verdict: "ready"` and `questions: []`.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/architect/opencode.md
+++ b/templates/roles/architect/opencode.md
@@ -48,3 +48,12 @@ Rules for the JSON:
 - Exact keys only. No extras.
 - All arrays may be empty but never null.
 - If `verdict` is "needs_clarification", `questions` must be non-empty.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder/anthropic.md
+++ b/templates/roles/coder/anthropic.md
@@ -70,3 +70,12 @@ Return a single JSON object matching this schema:
 }
 ```
 </output_format>
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder/default.md
+++ b/templates/roles/coder/default.md
@@ -67,3 +67,12 @@ Return a JSON object:
   "summary": "Human-readable summary of changes"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder/google.md
+++ b/templates/roles/coder/google.md
@@ -76,3 +76,12 @@ An incomplete implementation is worse than an error — don't claim success if p
   "summary": "Human-readable summary of changes"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder/openai.md
+++ b/templates/roles/coder/openai.md
@@ -57,3 +57,12 @@ Return JSON:
   "summary": "Human-readable summary of changes"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/coder/opencode.md
+++ b/templates/roles/coder/opencode.md
@@ -47,3 +47,12 @@ Rules for the JSON:
 - `approach` is one short sentence.
 - `summary` is one short sentence.
 - No extra keys. No text before or after the JSON.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/planner/anthropic.md
+++ b/templates/roles/planner/anthropic.md
@@ -48,3 +48,12 @@ Any of:
 }
 ```
 </output_format>
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/planner/default.md
+++ b/templates/roles/planner/default.md
@@ -46,3 +46,12 @@ You are the **Planner** in a multi-role AI pipeline. Your job is to create an im
   "summary": "Plan: 4 steps, estimated 2 files modified, 1 new file"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/planner/google.md
+++ b/templates/roles/planner/google.md
@@ -64,3 +64,12 @@ Approach must cite concurrency model, queue semantics, shutdown. Steps include i
   "summary": "Plan: N steps, M files modified, K new files"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/planner/openai.md
+++ b/templates/roles/planner/openai.md
@@ -44,3 +44,12 @@ You are the Planner. Produce an implementation plan for the task.
   "summary": "Plan: 4 steps, estimated 2 files modified, 1 new file"
 }
 ```
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.

--- a/templates/roles/planner/opencode.md
+++ b/templates/roles/planner/opencode.md
@@ -51,3 +51,12 @@ Rules for the JSON:
 - Exact keys only. No extras.
 - `order` is a positive integer.
 - Arrays may be empty but never null.
+
+## PR atomicity (hard project rule)
+
+Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan your work to stay atomic:
+
+- Aim for **~150 LOC** of changes per unit you produce (safety margin against the 200 hard limit).
+- The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
+- Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
+- Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.


### PR DESCRIPTION
PR #643 added the 200 LOC rule to the flat `coder.md` / `planner.md` / `architect.md` (legacy fallback). But the resolver in `src/prompts/prompt-resolver.js` loads per-provider variants FIRST. So claude/codex/gemini sessions were NOT seeing the rule.

Propagates the same 9-line block to 15 per-provider variants (3 roles × 5 providers).

## Test plan
- [x] LOC delta = 135 (bajo el 200 hard limit).
- [x] `npm test` — 4460/4460.
- [ ] CI green.