### PR TITLE
feat(audit): plan-adherence pure module (KJC-TSK-0376 PR-A)

### DIFF
--- a/src/audit/plan-adherence.js
+++ b/src/audit/plan-adherence.js
@@ -1,46 +1,10 @@
 /**
  * Plan adherence metric — KJC-TSK-0376 (deepeval-inspired).
- *
- * Computes a 0-100 score measuring how faithfully the coder respected
- * the plan emitted by `kj plan generate`. Pure offline calculation —
- * no LLM judge, derives everything from the plan JSON + the commits
- * the run produced + the files it changed.
- *
- * The score is a weighted average of four components:
- *
- *   commit_attribution    40%  — fraction of commits that can be tied
- *                                back to one of the plan's HUs (by id
- *                                in the message, or by branch name).
- *   acceptance_tests       30%  — fraction of plan acceptance tests
- *                                that the coder appears to have
- *                                introduced (heuristic: there is at
- *                                least one `test:`-prefixed commit
- *                                touching test files for that HU).
- *   scope_discipline       20%  — fraction of file changes that fall
- *                                within at least one HU's declared
- *                                scope (matched against id/title slug
- *                                or scope keywords).
- *   dependency_order       10%  — fraction of declared dependency
- *                                edges (HU-B blocked_by HU-A) where
- *                                the commit timestamps respect the
- *                                ordering (A's commit older than B's).
- *
- * When a metric has no data to score (e.g. no acceptance tests
- * declared in the plan), it returns `null` and the aggregator
- * redistributes its weight across the other three components so the
- * score is comparable across runs of different shapes.
- *
- * Output:
- *   {
- *     score: 0-100,
- *     breakdown: {
- *       commit_attribution: 0-100 | null,
- *       acceptance_tests:   0-100 | null,
- *       scope_discipline:   0-100 | null,
- *       dependency_order:   0-100 | null
- *     },
- *     hu_scores: [{ huId, attributed: bool, issues: string[] }]
- *   }
+ * Pure offline 0-100 score: how faithfully did the coder follow the plan?
+ * Components (weighted): commit_attribution 40%, acceptance_tests 30%,
+ * scope_discipline 20%, dependency_order 10%. Components return null
+ * when no data; aggregator redistributes the weight.
+ * See docs/plan-adherence.md (PR-C) for the full spec.
  */
 
 const WEIGHTS = {

--- a/src/audit/plan-adherence.js
+++ b/src/audit/plan-adherence.js
@@ -1,0 +1,258 @@
+/**
+ * Plan adherence metric — KJC-TSK-0376 (deepeval-inspired).
+ *
+ * Computes a 0-100 score measuring how faithfully the coder respected
+ * the plan emitted by `kj plan generate`. Pure offline calculation —
+ * no LLM judge, derives everything from the plan JSON + the commits
+ * the run produced + the files it changed.
+ *
+ * The score is a weighted average of four components:
+ *
+ *   commit_attribution    40%  — fraction of commits that can be tied
+ *                                back to one of the plan's HUs (by id
+ *                                in the message, or by branch name).
+ *   acceptance_tests       30%  — fraction of plan acceptance tests
+ *                                that the coder appears to have
+ *                                introduced (heuristic: there is at
+ *                                least one `test:`-prefixed commit
+ *                                touching test files for that HU).
+ *   scope_discipline       20%  — fraction of file changes that fall
+ *                                within at least one HU's declared
+ *                                scope (matched against id/title slug
+ *                                or scope keywords).
+ *   dependency_order       10%  — fraction of declared dependency
+ *                                edges (HU-B blocked_by HU-A) where
+ *                                the commit timestamps respect the
+ *                                ordering (A's commit older than B's).
+ *
+ * When a metric has no data to score (e.g. no acceptance tests
+ * declared in the plan), it returns `null` and the aggregator
+ * redistributes its weight across the other three components so the
+ * score is comparable across runs of different shapes.
+ *
+ * Output:
+ *   {
+ *     score: 0-100,
+ *     breakdown: {
+ *       commit_attribution: 0-100 | null,
+ *       acceptance_tests:   0-100 | null,
+ *       scope_discipline:   0-100 | null,
+ *       dependency_order:   0-100 | null
+ *     },
+ *     hu_scores: [{ huId, attributed: bool, issues: string[] }]
+ *   }
+ */
+
+const WEIGHTS = {
+  commit_attribution: 40,
+  acceptance_tests: 30,
+  scope_discipline: 20,
+  dependency_order: 10,
+};
+
+/**
+ * Build a regex that matches the HU id anywhere in a commit message
+ * (case-insensitive, word-boundary friendly). The `_` and `-` characters
+ * appear inside HU ids so we anchor on whole-token rather than \b.
+ */
+function huIdMatcher(huId) {
+  const escaped = String(huId).replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, "i");
+}
+
+/**
+ * Slugify an HU title for branch-name / scope matching. Mirrors the
+ * `buildHuBranchName` slug rule (lowercase, non-alnum → "-").
+ */
+function slugify(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/(^-+)|(-+$)/g, "");
+}
+
+/**
+ * Try to attribute a single commit to one of the plan's HUs.
+ *
+ * Order of evidence, strongest first:
+ *   1. The HU id appears in the commit message.
+ *   2. The HU id appears in the branch name where the commit lives
+ *      (commit.branch is supplied by listCommitsBetween's caller when
+ *      it knows the per-HU branches).
+ *   3. The HU title slug matches the commit message.
+ *
+ * Returns the matched huId, or null when none of the above fires.
+ */
+export function attributeCommitToHu(commit, hus) {
+  if (!commit || !Array.isArray(hus) || hus.length === 0) return null;
+  const msg = String(commit.message || "");
+  const branch = String(commit.branch || "");
+  for (const hu of hus) {
+    if (!hu?.id) continue;
+    const matcher = huIdMatcher(hu.id);
+    if (matcher.test(msg)) return hu.id;
+    if (branch && matcher.test(branch)) return hu.id;
+  }
+  // Fallback: title slug
+  for (const hu of hus) {
+    const slug = slugify(hu.title);
+    if (!slug || slug.length < 6) continue;
+    if (slugify(msg).includes(slug)) return hu.id;
+  }
+  return null;
+}
+
+/**
+ * Component 1: commit attribution. Returns null when the run produced
+ * no commits at all (avoids penalising analysis-only or doc-only runs).
+ */
+export function computeCommitAttribution(commits, plan) {
+  if (!Array.isArray(commits) || commits.length === 0) return null;
+  if (!plan?.hus || plan.hus.length === 0) return null;
+  let attributed = 0;
+  for (const commit of commits) {
+    if (attributeCommitToHu(commit, plan.hus)) attributed += 1;
+  }
+  return Math.round((attributed / commits.length) * 100);
+}
+
+/**
+ * Component 2: acceptance test coverage. Heuristic: each HU declares
+ * `acceptance_tests`. We check whether at least one commit from that
+ * HU's pool has a `test:`-prefixed message. Per-HU score (1 or 0),
+ * averaged across HUs that DO declare tests. Returns null when no HU
+ * declares acceptance tests.
+ */
+export function computeAcceptanceTestCoverage(commits, plan) {
+  if (!plan?.hus || plan.hus.length === 0) return null;
+  if (!Array.isArray(commits) || commits.length === 0) return null;
+  const husWithTests = plan.hus.filter(
+    (hu) => Array.isArray(hu?.acceptance_tests) && hu.acceptance_tests.length > 0,
+  );
+  if (husWithTests.length === 0) return null;
+
+  let covered = 0;
+  for (const hu of husWithTests) {
+    const huCommits = (commits || []).filter(
+      (c) => attributeCommitToHu(c, [hu]) === hu.id,
+    );
+    const hasTestCommit = huCommits.some((c) =>
+      /^test[:(]/i.test(String(c.message || "").trim()),
+    );
+    if (hasTestCommit) covered += 1;
+  }
+  return Math.round((covered / husWithTests.length) * 100);
+}
+
+/**
+ * Component 3: scope discipline. For each file changed by the run, we
+ * try to match it against at least one HU's id slug, title slug, or
+ * `scope` text. A file that matches no HU is flagged as out-of-scope.
+ * Returns null when the run changed no files.
+ */
+export function computeScopeDiscipline(filesChanged, plan) {
+  if (!Array.isArray(filesChanged) || filesChanged.length === 0) return null;
+  if (!plan?.hus || plan.hus.length === 0) return null;
+  const huKeywords = plan.hus.map((hu) => ({
+    id: hu.id,
+    matchers: [
+      slugify(hu.id),
+      slugify(hu.title),
+      // Pull alpha-rich words from `scope` text (length >= 4).
+      ...String(hu.scope || "")
+        .toLowerCase()
+        .split(/[^a-z]+/)
+        .filter((w) => w.length >= 4),
+    ].filter(Boolean),
+  }));
+  let inScope = 0;
+  for (const file of filesChanged) {
+    const slug = slugify(file);
+    const matched = huKeywords.some((hk) =>
+      hk.matchers.some((m) => slug.includes(m) || file.includes(m)),
+    );
+    if (matched) inScope += 1;
+  }
+  return Math.round((inScope / filesChanged.length) * 100);
+}
+
+/**
+ * Component 4: dependency order. For every `(parent, child)` edge
+ * declared via `child.blocked_by`, check that the EARLIEST commit
+ * attributed to `parent` is older than the EARLIEST commit attributed
+ * to `child`. Returns null when no dependency edges exist.
+ *
+ * `commits` are expected oldest-first (the shape `listCommitsBetween`
+ * returns). When that's not the case the score still makes sense — we
+ * just compare relative positions in the array.
+ */
+export function computeDependencyOrder(commits, plan) {
+  if (!plan?.hus || plan.hus.length === 0) return null;
+  const edges = [];
+  for (const hu of plan.hus) {
+    for (const parentId of hu.blocked_by || []) {
+      edges.push([parentId, hu.id]);
+    }
+  }
+  if (edges.length === 0) return null;
+  if (!Array.isArray(commits) || commits.length === 0) return null;
+
+  // Build huId → first commit index (oldest first attribution).
+  const firstIndex = new Map();
+  commits.forEach((commit, idx) => {
+    const huId = attributeCommitToHu(commit, plan.hus);
+    if (huId && !firstIndex.has(huId)) firstIndex.set(huId, idx);
+  });
+
+  let respected = 0;
+  let evaluable = 0;
+  for (const [parentId, childId] of edges) {
+    const p = firstIndex.get(parentId);
+    const c = firstIndex.get(childId);
+    if (p === undefined || c === undefined) continue; // can't evaluate
+    evaluable += 1;
+    if (p < c) respected += 1;
+  }
+  if (evaluable === 0) return null;
+  return Math.round((respected / evaluable) * 100);
+}
+
+/**
+ * Aggregator: compute every component and weight them. Components
+ * that return `null` are excluded and their weight redistributed
+ * proportionally across the rest, so a run that legitimately has no
+ * acceptance tests or no dependencies isn't penalised.
+ *
+ * Returns the full structured result (see file header for shape).
+ */
+export function computePlanAdherenceScore({ commits, plan, filesChanged }) {
+  const breakdown = {
+    commit_attribution: computeCommitAttribution(commits, plan),
+    acceptance_tests: computeAcceptanceTestCoverage(commits, plan),
+    scope_discipline: computeScopeDiscipline(filesChanged, plan),
+    dependency_order: computeDependencyOrder(commits, plan),
+  };
+
+  // Weighted average over non-null components only.
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const [key, weight] of Object.entries(WEIGHTS)) {
+    const value = breakdown[key];
+    if (value === null || value === undefined) continue;
+    totalWeight += weight;
+    weightedSum += value * weight;
+  }
+  const score = totalWeight === 0 ? null : Math.round(weightedSum / totalWeight);
+
+  // Per-HU detail: was the HU "touched" (attributed at least one commit)?
+  const hu_scores = (plan?.hus || []).map((hu) => {
+    const huCommits = (commits || []).filter(
+      (c) => attributeCommitToHu(c, [hu]) === hu.id,
+    );
+    const issues = [];
+    if (huCommits.length === 0) issues.push("no commit attributed");
+    return { huId: hu.id, attributed: huCommits.length > 0, issues };
+  });
+
+  return { score, breakdown, hu_scores };
+}

--- a/tests/audit/plan-adherence.test.js
+++ b/tests/audit/plan-adherence.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  attributeCommitToHu,
+  computeCommitAttribution,
+  computeAcceptanceTestCoverage,
+  computeScopeDiscipline,
+  computeDependencyOrder,
+  computePlanAdherenceScore,
+} from "../../src/audit/plan-adherence.js";
+
+const HUS = [
+  { id: "hu_001", title: "Setup project skeleton", scope: "Initialize Node.js project with Express, Vitest, and package json", blocked_by: [], task_type: "infra", acceptance_tests: [{ type: "shell", content: "test -f package.json" }] },
+  { id: "hu_002", title: "Add todo store", scope: "In-memory store for todos with CRUD", blocked_by: ["hu_001"], task_type: "sw", acceptance_tests: [{ type: "shell", content: "test -f src/store.js" }] },
+  { id: "hu_003", title: "Wire HTTP routes", scope: "Express routes GET/POST/DELETE /todos", blocked_by: ["hu_002"], task_type: "sw", acceptance_tests: [{ type: "shell", content: "curl localhost:3000/todos" }] },
+];
+
+const PLAN = { status: "ready", version: 2, hus: HUS };
+
+describe("attributeCommitToHu", () => {
+  it("matches by id in the commit message", () => {
+    expect(attributeCommitToHu({ message: "feat(hu_002): add store" }, HUS)).toBe("hu_002");
+  });
+
+  it("matches by id even when surrounded by punctuation", () => {
+    expect(attributeCommitToHu({ message: "[hu_001] init project" }, HUS)).toBe("hu_001");
+  });
+
+  it("matches by branch name when message has no id", () => {
+    expect(attributeCommitToHu({ message: "wip", branch: "feat/hu_003-wire-http" }, HUS)).toBe("hu_003");
+  });
+
+  it("falls back to title slug when neither id nor branch match", () => {
+    expect(attributeCommitToHu({ message: "feat: add todo store with CRUD" }, HUS)).toBe("hu_002");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(attributeCommitToHu({ message: "random unrelated commit" }, HUS)).toBeNull();
+  });
+
+  it("returns null on empty / missing input", () => {
+    expect(attributeCommitToHu(null, HUS)).toBeNull();
+    expect(attributeCommitToHu({ message: "anything" }, [])).toBeNull();
+  });
+});
+
+describe("computeCommitAttribution", () => {
+  it("returns 100 when every commit references an HU", () => {
+    const commits = [
+      { message: "chore(hu_001): scaffold" },
+      { message: "feat(hu_002): store" },
+      { message: "feat(hu_003): routes" },
+    ];
+    expect(computeCommitAttribution(commits, PLAN)).toBe(100);
+  });
+
+  it("returns the proper percentage when some commits are unattributed", () => {
+    const commits = [
+      { message: "feat(hu_001): scaffold" },
+      { message: "chore: tweak gitignore" }, // unattributed
+      { message: "feat(hu_002): store" },
+      { message: "docs: update readme" },    // unattributed
+    ];
+    expect(computeCommitAttribution(commits, PLAN)).toBe(50);
+  });
+
+  it("returns null on empty commits or empty plan", () => {
+    expect(computeCommitAttribution([], PLAN)).toBeNull();
+    expect(computeCommitAttribution([{ message: "x" }], { hus: [] })).toBeNull();
+  });
+});
+
+describe("computeAcceptanceTestCoverage", () => {
+  it("returns 100 when every HU with tests has at least one test commit", () => {
+    const commits = [
+      { message: "test(hu_001): add scaffold acceptance" },
+      { message: "test(hu_002): add store acceptance" },
+      { message: "test(hu_003): add HTTP routes acceptance" },
+    ];
+    expect(computeAcceptanceTestCoverage(commits, PLAN)).toBe(100);
+  });
+
+  it("returns the partial coverage when only some HUs have test commits", () => {
+    const commits = [
+      { message: "feat(hu_001): scaffold" },        // no test commit for hu_001
+      { message: "test(hu_002): cover store" },     // ✓
+      { message: "feat(hu_003): routes" },          // no test commit for hu_003
+    ];
+    expect(computeAcceptanceTestCoverage(commits, PLAN)).toBe(33);
+  });
+
+  it("returns null when the plan declares no acceptance tests", () => {
+    const planNoTests = { hus: [{ id: "hu_x", title: "no tests", acceptance_tests: [] }] };
+    expect(computeAcceptanceTestCoverage([{ message: "test: x" }], planNoTests)).toBeNull();
+  });
+});
+
+describe("computeScopeDiscipline", () => {
+  it("returns 100 when every changed file matches an HU", () => {
+    const files = ["package.json", "src/store.js", "src/routes/todos.js"];
+    // package.json matches the 'package' word in scope of hu_001 (no, but its slug doesn't match)
+    // Actually package.json wouldn't match unless scope mentions package; let's use better fixtures.
+    const planWithFileScopes = {
+      hus: [
+        { id: "hu_setup", title: "Setup project", scope: "package json initialize" },
+        { id: "hu_store", title: "Add store", scope: "store backend" },
+        { id: "hu_routes", title: "Wire routes", scope: "routes todos" },
+      ],
+    };
+    expect(computeScopeDiscipline(files, planWithFileScopes)).toBe(100);
+  });
+
+  it("flags files that don't match any HU as out-of-scope", () => {
+    const files = [
+      "src/store.js",                  // matches hu_002 ('store')
+      "src/totally-unrelated/x.js",    // out of scope
+    ];
+    const score = computeScopeDiscipline(files, PLAN);
+    expect(score).toBe(50);
+  });
+
+  it("returns null on empty files or empty plan", () => {
+    expect(computeScopeDiscipline([], PLAN)).toBeNull();
+    expect(computeScopeDiscipline(["a.js"], { hus: [] })).toBeNull();
+  });
+});
+
+describe("computeDependencyOrder", () => {
+  it("returns 100 when commits respect every dependency edge", () => {
+    const commits = [
+      { message: "feat(hu_001): scaffold" },
+      { message: "feat(hu_002): store" },
+      { message: "feat(hu_003): routes" },
+    ];
+    expect(computeDependencyOrder(commits, PLAN)).toBe(100);
+  });
+
+  it("returns 0 when child commit comes before parent (out-of-order)", () => {
+    const commits = [
+      { message: "feat(hu_002): store" },     // child first
+      { message: "feat(hu_001): scaffold" },  // parent second
+    ];
+    // edge hu_001 → hu_002. Parent index 1, child index 0 → violated.
+    expect(computeDependencyOrder(commits, PLAN)).toBe(0);
+  });
+
+  it("returns null when the plan has no dependency edges", () => {
+    const planNoDeps = { hus: [{ id: "a", title: "A", blocked_by: [] }] };
+    expect(computeDependencyOrder([{ message: "feat(a): x" }], planNoDeps)).toBeNull();
+  });
+
+  it("returns null when the commits don't cover any edge endpoint", () => {
+    const commits = [{ message: "random" }];
+    // edges exist in PLAN but neither parent nor child appears in commits.
+    expect(computeDependencyOrder(commits, PLAN)).toBeNull();
+  });
+});
+
+describe("computePlanAdherenceScore — aggregator", () => {
+  it("returns a 100 score on a perfectly-adherent run", () => {
+    const commits = [
+      { message: "chore(hu_001): scaffold project" },
+      { message: "test(hu_001): scaffold acceptance" },
+      { message: "feat(hu_002): in-memory todo store" },
+      { message: "test(hu_002): store acceptance" },
+      { message: "feat(hu_003): wire routes /todos" },
+      { message: "test(hu_003): routes acceptance" },
+    ];
+    const filesChanged = ["package.json", "src/store.js", "src/routes/todos.js"];
+    const result = computePlanAdherenceScore({ commits, plan: PLAN, filesChanged });
+    expect(result.score).toBe(100);
+    expect(result.breakdown.commit_attribution).toBe(100);
+    expect(result.breakdown.acceptance_tests).toBe(100);
+    expect(result.breakdown.dependency_order).toBe(100);
+    expect(result.hu_scores).toHaveLength(3);
+    expect(result.hu_scores.every((h) => h.attributed)).toBe(true);
+  });
+
+  it("redistributes weight when components return null (run with no plan changes)", () => {
+    const result = computePlanAdherenceScore({ commits: [], plan: PLAN, filesChanged: [] });
+    // commits empty → attribution null + acceptance_tests has nothing to score
+    // → also null. No files → scope null. No commits → deps null.
+    // All four nulls → score is null (no data to compute).
+    expect(result.score).toBeNull();
+  });
+
+  it("flags HUs that received zero commits as 'no commit attributed'", () => {
+    const commits = [{ message: "chore(hu_001): scaffold" }];
+    const result = computePlanAdherenceScore({ commits, plan: PLAN, filesChanged: [] });
+    const huMap = new Map(result.hu_scores.map((h) => [h.huId, h]));
+    expect(huMap.get("hu_001").attributed).toBe(true);
+    expect(huMap.get("hu_002").attributed).toBe(false);
+    expect(huMap.get("hu_002").issues).toContain("no commit attributed");
+  });
+
+  it("partial run produces an intermediate score", () => {
+    const commits = [
+      { message: "chore(hu_001): scaffold" },     // attributed, no test commit for hu_001
+      { message: "feat(hu_002): store" },          // attributed
+      { message: "docs: update readme" },          // unattributed
+    ];
+    const filesChanged = ["package.json", "src/store.js"]; // both match
+    const result = computePlanAdherenceScore({ commits, plan: PLAN, filesChanged });
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThan(100);
+    // commit_attribution: 2/3 = 67
+    expect(result.breakdown.commit_attribution).toBe(67);
+  });
+});


### PR DESCRIPTION
First PR of the deepeval-inspired evaluation layer (KJC-TSK-0376). Pure offline scorer 0-100 measuring how faithfully the coder respected the plan from `kj plan generate`. **No LLM judge, no extra runtime cost.**

## Components (weighted)
- commit_attribution (40%) — commits tied to an HU.
- acceptance_tests (30%) — HUs with `test:` commits.
- scope_discipline (20%) — files matching HU scope.
- dependency_order (10%) — parent-before-child commit ordering.

Components return null when no data; aggregator redistributes weight so runs without tests or deps aren't penalised.

## ⚠️ Why this PR exceeds the 200 LOC budget — `large-pr-justified` label applied

466 LOC = 258 module + 208 tests. Module + tests are **inseparable** for an initial feature landing; partitioning would leave PR-A1 with a half-baked module + no coverage. The next 2 PRs of this card will both be <200 LOC:

- PR-B: wiring with post-loop journal (estimated ~80 LOC).
- PR-C: docs (estimated ~30 LOC).

If you'd rather I split this into 3 sub-PRs creating files incrementally, ack here and I redo it. My honest read: it makes the history harder to read for marginal benefit.

## Test plan
- [x] 23 unit tests passing (matchers, every component, aggregator).
- [x] `npm test` — 4483/4483.
- [x] ESLint clean.
- [ ] CI green (including `Net LOC delta within budget` which will fail without the label).