### PR TITLE
feat(audit): plan adherence integration in post-loop (TSK-0376 PR-B)

### DIFF
--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -23,7 +23,9 @@
 
 import { generateDiff } from "../../review/diff-generator.js";
 import { finalizeGitAutomation } from "../../git/automation.js";
-import { listCommitsBetween } from "../../utils/git.js";
+import { listCommitsBetween, listFilesChangedSince } from "../../utils/git.js";
+import { loadPlan, projectSlug as slugFor } from "../../plan/plan-store.js";
+import { computePlanAdherenceScore } from "../../audit/plan-adherence.js";
 import { saveSession, markSessionStatus } from "../../session/store.js";
 import {
   setReviewerFeedback, setBudget, setRtkSavings, resetRetryCount,
@@ -166,6 +168,36 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
       try { allCommits = (await listCommitsBetween(session.head_at_start || session.session_start_sha)) || []; }
       catch { allCommits = gitResult?.commits || []; }
       const summaryCommits = allCommits.length > 0 ? allCommits : (gitResult?.commits || []);
+
+      // KJC-TSK-0376 — plan adherence metric (deepeval-inspired). When the
+      // run executed against a known plan (`kj run --plan <id>`), score how
+      // faithfully the coder followed it. Pure offline; safe-by-default
+      // (try/catch swallows missing helper or unreadable plan).
+      let planAdherence = null;
+      try {
+        const planId = session._planRef?.planId
+          || stageResults?.huReviewer?.planId
+          || null;
+        if (planId) {
+          const projectDir = config?.projectDir
+            || session.config_snapshot?.projectDir
+            || process.cwd();
+          const plan = await loadPlan(projectDir, planId).catch(() => null);
+          if (plan && Array.isArray(plan.hus) && plan.hus.length > 0) {
+            const filesChanged = await listFilesChangedSince(
+              session.head_at_start || session.session_start_sha,
+            ).catch(() => []);
+            planAdherence = computePlanAdherenceScore({
+              commits: summaryCommits,
+              plan,
+              filesChanged,
+            });
+          }
+        }
+      } catch (err) {
+        logger?.warn?.(`Plan adherence calculation skipped: ${err.message}`);
+      }
+
       await writeSummaryJournalV2(journalDir, {
         task: session.task,
         result: "APPROVED",
@@ -188,6 +220,7 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
           installed: session.autoInstalledSkills,
           recommended: session.skillsRecommended,
         },
+        planAdherence,
       }, { logger });
       logger.info(`Session journal written to ${journalDir}`);
     } catch (err) {
@@ -361,7 +394,6 @@ export async function tryAutoStartBoard(config, logger, emitter, eventBase) {
 
   try {
     const { startBoard, renderBoardBanner } = await import("../../commands/board.js");
-    const { projectSlug: slugFor } = await import("../../plan/plan-store.js");
     const boardPort = config.hu_board.port || 4000;
     // Scope the board URL to the current run's project (`/p/<slug>`) so
     // the user lands on a filtered view, not the global dashboard.

--- a/src/session/journal/summary-writer.js
+++ b/src/session/journal/summary-writer.js
@@ -199,9 +199,48 @@ export function buildSummaryMarkdown(input) {
 
   sections.push("", "## Commits", "", renderCommits(input.commits));
 
+  // KJC-TSK-0376 — plan adherence metric (deepeval-inspired). Only
+  // rendered when the run executed against a known plan and the
+  // calculation produced a non-null score (a run with no commits or
+  // no files changed yields nulls everywhere → omit the section).
+  const planAdherenceSection = renderPlanAdherence(input.planAdherence);
+  if (planAdherenceSection) {
+    sections.push("", "## Plan adherence", "", planAdherenceSection);
+  }
+
   sections.push("", "## Journal files", "", renderJournalLinks(input.files));
 
   return sections.join("\n") + "\n";
+}
+
+function renderPlanAdherence(planAdherence) {
+  if (!planAdherence || typeof planAdherence !== "object") return "";
+  if (planAdherence.score === null || planAdherence.score === undefined) return "";
+  const lines = [`**Score**: ${planAdherence.score}/100`, ""];
+  const breakdown = planAdherence.breakdown || {};
+  lines.push("| Component | Score | Weight |");
+  lines.push("| --- | --- | --- |");
+  const rows = [
+    ["Commit attribution", breakdown.commit_attribution, "40%"],
+    ["Acceptance tests",   breakdown.acceptance_tests,   "30%"],
+    ["Scope discipline",   breakdown.scope_discipline,   "20%"],
+    ["Dependency order",   breakdown.dependency_order,   "10%"],
+  ];
+  for (const [label, value, weight] of rows) {
+    const cell = value === null || value === undefined ? "n/a" : `${value}/100`;
+    lines.push(`| ${label} | ${cell} | ${weight} |`);
+  }
+  const huScores = Array.isArray(planAdherence.hu_scores) ? planAdherence.hu_scores : [];
+  if (huScores.length > 0) {
+    const unattributed = huScores.filter((h) => !h.attributed);
+    if (unattributed.length > 0) {
+      lines.push("", `_${unattributed.length} HU(s) without an attributed commit:_`);
+      for (const h of unattributed) {
+        lines.push(`- \`${h.huId}\``);
+      }
+    }
+  }
+  return lines.join("\n");
 }
 
 /**

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -80,6 +80,33 @@ export async function revParse(ref) {
  * @param {string} [toRef="HEAD"]
  * @returns {Promise<Array<{hash: string, message: string}>>}
  */
+/**
+ * List the file paths changed in the range `fromSha..toRef`. Used by the
+ * plan-adherence metric (KJC-TSK-0376) to score whether the coder's
+ * file changes fall within any HU's declared scope.
+ *
+ * Returns a deduplicated array of file paths, oldest commit's files
+ * first. Defensive: returns [] on missing `fromSha`, non-zero git exit,
+ * or thrown error — consistent with `listCommitsBetween`'s contract.
+ *
+ * @param {string|null|undefined} fromSha
+ * @param {string} [toRef="HEAD"]
+ * @returns {Promise<string[]>}
+ */
+export async function listFilesChangedSince(fromSha, toRef = "HEAD") {
+  if (!fromSha) return [];
+  const result = await run(
+    "git",
+    ["diff", "--name-only", `${fromSha}..${toRef}`],
+  ).catch(() => null);
+  if (!result || result.exitCode !== 0) return [];
+  const lines = String(result.stdout || "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return Array.from(new Set(lines));
+}
+
 export async function listCommitsBetween(fromSha, toRef = "HEAD") {
   if (!fromSha) return [];
   const result = await run(

--- a/tests/session/summary-writer.test.js
+++ b/tests/session/summary-writer.test.js
@@ -241,4 +241,58 @@ describe("session/journal/summary-writer — writeSummaryJournal", () => {
     expect(result.written).toBe(false);
     expect(result.path).toBeNull();
   });
+
+  // KJC-TSK-0376 — Plan adherence section.
+  describe("Plan adherence section", () => {
+    it("omits the section when planAdherence is missing or null", () => {
+      expect(buildSummaryMarkdown(sample())).not.toContain("## Plan adherence");
+      expect(buildSummaryMarkdown(sample({ planAdherence: null }))).not.toContain("## Plan adherence");
+    });
+
+    it("omits the section when score is null (no data to compute)", () => {
+      const md = buildSummaryMarkdown(sample({
+        planAdherence: { score: null, breakdown: {}, hu_scores: [] },
+      }));
+      expect(md).not.toContain("## Plan adherence");
+    });
+
+    it("renders score, breakdown table, and unattributed HUs", () => {
+      const md = buildSummaryMarkdown(sample({
+        planAdherence: {
+          score: 87,
+          breakdown: {
+            commit_attribution: 100,
+            acceptance_tests: 67,
+            scope_discipline: 80,
+            dependency_order: null,
+          },
+          hu_scores: [
+            { huId: "hu_001", attributed: true, issues: [] },
+            { huId: "hu_002", attributed: false, issues: ["no commit attributed"] },
+          ],
+        },
+      }));
+      expect(md).toContain("## Plan adherence");
+      expect(md).toContain("**Score**: 87/100");
+      expect(md).toContain("| Commit attribution | 100/100 | 40% |");
+      expect(md).toContain("| Acceptance tests | 67/100 | 30% |");
+      expect(md).toContain("| Dependency order | n/a | 10% |");
+      expect(md).toContain("1 HU(s) without an attributed commit");
+      expect(md).toContain("`hu_002`");
+    });
+
+    it("hides the unattributed-HUs list when all HUs got at least one commit", () => {
+      const md = buildSummaryMarkdown(sample({
+        planAdherence: {
+          score: 100,
+          breakdown: { commit_attribution: 100, acceptance_tests: 100, scope_discipline: 100, dependency_order: 100 },
+          hu_scores: [
+            { huId: "hu_001", attributed: true, issues: [] },
+          ],
+        },
+      }));
+      expect(md).toContain("## Plan adherence");
+      expect(md).not.toContain("without an attributed commit");
+    });
+  });
 });

--- a/tests/utils-git.test.js
+++ b/tests/utils-git.test.js
@@ -347,4 +347,47 @@ describe("utils/git", () => {
       expect(commits.map((c) => c.hash)).toEqual(["abc1", "def2"]);
     });
   });
+
+  // KJC-TSK-0376 — used by the plan-adherence metric to score whether
+  // the coder's file changes fall inside any HU's declared scope.
+  describe("listFilesChangedSince", () => {
+    it("returns [] on empty / missing fromSha", async () => {
+      expect(await git.listFilesChangedSince()).toEqual([]);
+      expect(await git.listFilesChangedSince(null)).toEqual([]);
+      expect(runCommand).not.toHaveBeenCalled();
+    });
+
+    it("invokes `git diff --name-only` and returns the unique paths", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "src/store.js\nsrc/routes/todos.js\npackage.json\n",
+        stderr: "",
+      });
+      const files = await git.listFilesChangedSince("abc123");
+      expect(runCommand).toHaveBeenCalledWith(
+        "git",
+        ["diff", "--name-only", "abc123..HEAD"],
+      );
+      expect(files).toEqual(["src/store.js", "src/routes/todos.js", "package.json"]);
+    });
+
+    it("dedupes when a file is listed more than once across the range", async () => {
+      runCommand.mockResolvedValue({
+        exitCode: 0,
+        stdout: "src/foo.js\nsrc/bar.js\nsrc/foo.js\n",
+        stderr: "",
+      });
+      expect(await git.listFilesChangedSince("a")).toEqual(["src/foo.js", "src/bar.js"]);
+    });
+
+    it("returns [] on non-zero exit (defensive)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 128, stdout: "", stderr: "fatal: bad rev" });
+      expect(await git.listFilesChangedSince("nope")).toEqual([]);
+    });
+
+    it("returns [] when runCommand throws", async () => {
+      runCommand.mockRejectedValue(new Error("git not on PATH"));
+      expect(await git.listFilesChangedSince("a")).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Wires the plan-adherence metric (introduced in PR #645) into the actual run pipeline so it shows up in `summary.md` after each `kj run`.

## What changed

- **`src/orchestrator/drivers/post-loop.js`** — after computing `summaryCommits`, look up the plan referenced by the session (`session._planRef.planId` or `stageResults.huReviewer.planId`), load it via `loadPlan`, gather changed files via `listFilesChangedSince`, and call `computePlanAdherenceScore`. Result piped into `writeSummaryJournalV2`. Wrapped in try/catch — non-blocking by design.
- **`src/session/journal/summary-writer.js`** — new `renderPlanAdherence(planAdherence)` that emits a `## Plan adherence` section with score, 4-component breakdown table (commit_attribution / acceptance_tests / scope_discipline / dependency_order), and the list of HUs that didn't get an attributed commit. Section is fully omitted when score is null.
- **`src/utils/git.js`** — new `listFilesChangedSince(fromSha, toRef = "HEAD")` helper, parallel to `listCommitsBetween`. Defensive: returns `[]` on missing input, non-zero git exit, or thrown error.

## Tests

- +4 in `tests/session/summary-writer.test.js` (omit/render/unattributed/all-attributed paths)
- +5 in `tests/utils-git.test.js` (empty fromSha / happy path / dedup / non-zero exit / throw)
- All 4492 tests passing

## LOC

197 lines net (under the 200 budget).

## Test plan

- [x] `npm test` — 4492/4492 passing
- [x] `npx vitest run tests/architecture/dynamic-imports.test.js` — within budget, no redundant imports
- [ ] Manual: run `kj run` against a project with a plan and verify `summary.md` has the new section