### PR TITLE
feat(golden): dataset schema + loader (TSK-0374 PR-1)

### DIFF
--- a/src/golden/loader.js
+++ b/src/golden/loader.js
@@ -1,0 +1,52 @@
+/**
+ * Golden tasks loader (KJC-TSK-0374). Reads + validates JSON files
+ * under a directory; aggregates errors; rejects duplicate ids.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { safeParseGoldenTask } from "./schema.js";
+
+export async function loadGoldenTasks(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch((err) => {
+    throw new Error(`golden tasks directory not readable: ${dir} (${err.code || err.message})`);
+  });
+  const jsonFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith(".json"))
+    .map((e) => path.join(dir, e.name))
+    .sort();
+
+  const tasks = [];
+  const errors = [];
+  const seenIds = new Map();
+
+  for (const filePath of jsonFiles) {
+    let raw;
+    try {
+      const content = await fs.readFile(filePath, "utf8");
+      raw = JSON.parse(content);
+    } catch (err) {
+      errors.push(`${path.basename(filePath)}: invalid JSON (${err.message})`);
+      continue;
+    }
+    const result = safeParseGoldenTask(raw);
+    if (!result.ok) {
+      const summary = result.issues.map((iss) => `  - ${iss.path || "(root)"}: ${iss.message}`).join("\n");
+      errors.push(`${path.basename(filePath)}:\n${summary}`);
+      continue;
+    }
+    const existing = seenIds.get(result.task.id);
+    if (existing) {
+      errors.push(`${path.basename(filePath)}: duplicate id "${result.task.id}" (also in ${existing})`);
+      continue;
+    }
+    seenIds.set(result.task.id, path.basename(filePath));
+    tasks.push(result.task);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`golden tasks failed validation:\n${errors.join("\n")}`);
+  }
+
+  return { tasks };
+}

--- a/src/golden/schema.js
+++ b/src/golden/schema.js
@@ -1,0 +1,41 @@
+/**
+ * Golden tasks regression suite — schema (KJC-TSK-0374). Pure data,
+ * no I/O. See docs/golden-tasks.md (PR-3) for the full spec.
+ */
+
+import * as v from "valibot";
+
+const NonEmptyString = v.pipe(v.string(), v.minLength(1));
+const Percent = v.pipe(v.number(), v.minValue(0), v.maxValue(100));
+
+const NonNegInt = v.pipe(v.number(), v.integer(), v.minValue(0));
+const LocRangeSchema = v.pipe(v.array(NonNegInt), v.length(2),
+  v.check((arr) => arr[0] <= arr[1], "allowed_loc_range: min must be <= max"));
+
+export const GoldenTaskSchema = v.looseObject({
+  id: v.pipe(NonEmptyString, v.regex(/^[a-z0-9_-]+$/, "id must be lowercase a-z0-9_-")),
+  title: NonEmptyString,
+  prompt: NonEmptyString,
+  description: v.optional(v.string()),
+  timeout_minutes: v.optional(v.pipe(v.number(), v.integer(), v.minValue(1)), 30),
+  expected_commits_min: NonNegInt,
+  expected_audit_status: v.picklist(["pass", "warning", "fail"]),
+  expected_test_files: v.array(NonEmptyString),
+  allowed_loc_range: LocRangeSchema,
+  expected_plan_adherence_min: v.optional(Percent),
+});
+
+/** @typedef {import("valibot").InferOutput<typeof GoldenTaskSchema>} GoldenTask */
+
+export function parseGoldenTask(raw) {
+  return v.parse(GoldenTaskSchema, raw);
+}
+
+export function safeParseGoldenTask(raw) {
+  const result = v.safeParse(GoldenTaskSchema, raw);
+  if (result.success) return { ok: true, task: result.output };
+  return { ok: false, issues: result.issues.map((iss) => ({
+    path: (iss.path || []).map((p) => p.key).join("."),
+    message: iss.message,
+  })) };
+}

--- a/tests/golden/loader.test.js
+++ b/tests/golden/loader.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { loadGoldenTasks } from "../../src/golden/loader.js";
+
+const taskJson = (id, overrides = {}) => JSON.stringify({
+  id, title: `Task ${id}`, prompt: `Build ${id}`,
+  expected_commits_min: 2, expected_audit_status: "pass",
+  expected_test_files: ["tests/x.test.js"], allowed_loc_range: [50, 200],
+  ...overrides,
+});
+
+describe("golden/loader", () => {
+  let tmp;
+  beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-golden-")); });
+  afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }).catch(() => {}); });
+
+  it("returns [] for an empty directory", async () => {
+    expect((await loadGoldenTasks(tmp)).tasks).toEqual([]);
+  });
+
+  it("loads multiple valid files in deterministic (filename) order", async () => {
+    await fs.writeFile(path.join(tmp, "b.json"), taskJson("two"));
+    await fs.writeFile(path.join(tmp, "a.json"), taskJson("one"));
+    const { tasks } = await loadGoldenTasks(tmp);
+    expect(tasks.map((t) => t.id)).toEqual(["one", "two"]);
+  });
+
+  it("ignores non-json files", async () => {
+    await fs.writeFile(path.join(tmp, "a.json"), taskJson("one"));
+    await fs.writeFile(path.join(tmp, "README.md"), "ignore me");
+    expect((await loadGoldenTasks(tmp)).tasks).toHaveLength(1);
+  });
+
+  it("aggregates errors across multiple bad files", async () => {
+    await fs.writeFile(path.join(tmp, "ok.json"), taskJson("ok"));
+    await fs.writeFile(path.join(tmp, "broken.json"), "{not json");
+    await fs.writeFile(path.join(tmp, "invalid.json"), JSON.stringify({ id: "" }));
+    await expect(loadGoldenTasks(tmp)).rejects.toThrow(/broken\.json[\s\S]+invalid\.json/);
+  });
+
+  it("rejects duplicate ids across files", async () => {
+    await fs.writeFile(path.join(tmp, "a.json"), taskJson("dup"));
+    await fs.writeFile(path.join(tmp, "b.json"), taskJson("dup"));
+    await expect(loadGoldenTasks(tmp)).rejects.toThrow(/duplicate id "dup"/);
+  });
+
+  it("throws a descriptive error when the directory does not exist", async () => {
+    await expect(loadGoldenTasks(path.join(tmp, "nope"))).rejects.toThrow(/not readable/);
+  });
+});

--- a/tests/golden/schema.test.js
+++ b/tests/golden/schema.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { safeParseGoldenTask, parseGoldenTask } from "../../src/golden/schema.js";
+
+const validTask = (overrides = {}) => ({
+  id: "todo-rest-api",
+  title: "Build a REST API for a todo list",
+  prompt: "Build a REST API for a todo list. Express + Vitest.",
+  expected_commits_min: 3,
+  expected_audit_status: "pass",
+  expected_test_files: ["tests/todo.test.js"],
+  allowed_loc_range: [80, 250],
+  ...overrides,
+});
+
+describe("golden/schema", () => {
+  it("accepts a minimal valid task and applies the default timeout", () => {
+    const r = safeParseGoldenTask(validTask());
+    expect(r.ok).toBe(true);
+    expect(r.task.timeout_minutes).toBe(30);
+  });
+
+  it("accepts the optional plan adherence threshold", () => {
+    const r = safeParseGoldenTask(validTask({ expected_plan_adherence_min: 75 }));
+    expect(r).toMatchObject({ ok: true, task: { expected_plan_adherence_min: 75 } });
+  });
+
+  it("rejects an empty prompt", () => {
+    const r = safeParseGoldenTask(validTask({ prompt: "" }));
+    expect(r.ok).toBe(false);
+    expect(r.issues.some((i) => i.path === "prompt")).toBe(true);
+  });
+
+  it("rejects an id with invalid characters", () => {
+    const r = safeParseGoldenTask(validTask({ id: "Todo Task!" }));
+    expect(r.ok).toBe(false);
+    expect(r.issues.some((i) => i.path === "id")).toBe(true);
+  });
+
+  it("rejects audit status outside the picklist", () => {
+    expect(safeParseGoldenTask(validTask({ expected_audit_status: "great" })).ok).toBe(false);
+  });
+
+  it("rejects allowed_loc_range when min > max", () => {
+    const r = safeParseGoldenTask(validTask({ allowed_loc_range: [200, 100] }));
+    expect(r.ok).toBe(false);
+    expect(r.issues.some((i) => /min must be/.test(i.message))).toBe(true);
+  });
+
+  it("rejects plan adherence outside 0-100; parseGoldenTask throws on invalid input", () => {
+    expect(safeParseGoldenTask(validTask({ expected_plan_adherence_min: -5 })).ok).toBe(false);
+    expect(safeParseGoldenTask(validTask({ expected_plan_adherence_min: 101 })).ok).toBe(false);
+    expect(() => parseGoldenTask({ id: "" })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Scaffolding for the golden-tasks regression suite. Pure data layer — no runner, no fixtures, no LLM calls.

## What ships

- **`src/golden/schema.js`** — Valibot schema for a golden task: \`id\`, \`title\`, \`prompt\`, \`expected_commits_min\`, \`expected_audit_status\`, \`expected_test_files\`, \`allowed_loc_range\`, optional \`expected_plan_adherence_min\` (ties into TSK-0376 just merged).
- **`src/golden/loader.js`** — reads + validates \`*.json\` from a directory, aggregates errors across files, rejects duplicate ids, ignores non-json siblings.
- **13 unit tests** — schema (8): happy path, defaults, every reject path. Loader (5): empty dir, deterministic order, non-json filtering, error aggregation, dup-id rejection, missing dir.

## Why now

This is PR-1 of a 3-PR split for TSK-0374:
- **PR-1 (this)**: data layer — 199 LOC
- **PR-2**: runner that subprocess-drives \`kj run\` and asserts the schema
- **PR-3**: 3 task fixtures + baseline JSON + spec doc

Splitting because each PR needs to fit ≤200 LOC by repo policy.

## Test plan

- [x] \`npm test\` — 4505/4505 green
- [x] \`npx vitest run tests/golden/\` — 13/13 green
- [x] LOC delta: 199 (under budget)

## Related

- TSK-0376 (#645/#646/#647) — plan adherence metric this suite will assert against