### PR TITLE
ci(shrink-budget): exclude human docs from LOC budget; keep AI-rule files capped

### DIFF
--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -58,8 +58,12 @@ jobs:
           set -euo pipefail
 
           # Excluded paths: lockfiles, snapshots, build output, vendored
-          # third-party, minified bundles, generated diet baselines, and
-          # binary fixtures. Each entry is a glob pattern interpreted by
+          # third-party, minified bundles, generated diet baselines,
+          # binary fixtures, and *documentation files* — Markdown, MDX,
+          # plain text and reST are docs, not code, so they don't burn
+          # the LOC budget (clarified 2026-05-09 — the gate exists to
+          # cap code growth, not to ration documentation).
+          # Each entry is a glob pattern interpreted by
           # `git diff --diff-filter=AM ... -- :(exclude)<pattern>`.
           excludes=(
             ":(exclude)package-lock.json"
@@ -73,6 +77,10 @@ jobs:
             ":(exclude)**/*.min.js"
             ":(exclude)tests/_diet/**"
             ":(exclude)public/docs/**"
+            ":(exclude)**/*.md"
+            ":(exclude)**/*.mdx"
+            ":(exclude)**/*.txt"
+            ":(exclude)**/*.rst"
           )
 
           stats=$(git diff --numstat "$BASE_SHA"..."$HEAD_SHA" -- . "${excludes[@]}")

--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -59,12 +59,16 @@ jobs:
 
           # Excluded paths: lockfiles, snapshots, build output, vendored
           # third-party, minified bundles, generated diet baselines,
-          # binary fixtures, and *documentation files* — Markdown, MDX,
-          # plain text and reST are docs, not code, so they don't burn
-          # the LOC budget (clarified 2026-05-09 — the gate exists to
-          # cap code growth, not to ration documentation).
-          # Each entry is a glob pattern interpreted by
-          # `git diff --diff-filter=AM ... -- :(exclude)<pattern>`.
+          # binary fixtures, and *human-facing documentation* — README,
+          # CHANGELOG, the `docs/` tree, etc. (clarified 2026-05-09 —
+          # the gate exists to cap code growth, not to ration docs).
+          #
+          # IMPORTANT: AI-rule Markdown files (CLAUDE.md, AGENTS.md,
+          # templates/**/*.md including role prompts) DO count toward
+          # the budget on purpose — those files become part of the
+          # agent's context window every run, and unbounded growth
+          # there dilutes the signal the AI receives. They follow the
+          # same ≤200 LOC discipline as code.
           excludes=(
             ":(exclude)package-lock.json"
             ":(exclude)pnpm-lock.yaml"
@@ -77,10 +81,18 @@ jobs:
             ":(exclude)**/*.min.js"
             ":(exclude)tests/_diet/**"
             ":(exclude)public/docs/**"
-            ":(exclude)**/*.md"
-            ":(exclude)**/*.mdx"
-            ":(exclude)**/*.txt"
-            ":(exclude)**/*.rst"
+            ":(exclude)docs/**/*.md"
+            ":(exclude)docs/**/*.mdx"
+            ":(exclude)docs/**/*.txt"
+            ":(exclude)docs/**/*.rst"
+            ":(exclude)CHANGELOG.md"
+            ":(exclude)README.md"
+            ":(exclude)README.*.md"
+            ":(exclude)CODE_OF_CONDUCT.md"
+            ":(exclude)CONTRIBUTING.md"
+            ":(exclude)SECURITY.md"
+            ":(exclude)MIGRATION*.md"
+            ":(exclude)TODO*.md"
           )
 
           stats=$(git diff --numstat "$BASE_SHA"..."$HEAD_SHA" -- . "${excludes[@]}")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,13 @@ When asked to implement, fix, or refactor, use `kj_run` via MCP instead of editi
 - Manual editing only if the user asks or KJ cannot complete.
 
 ## PR atomicity (hard project rule)
-This repo enforces a CI gate that fails any PR whose net delta of **code** exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
-- Aim for **~150 LOC of code per PR** (margin against the 200 hard limit).
-- The gate counts the SUM of every changed source file. Tests count. **Documentation files do NOT count** — `*.md`, `*.mdx`, `*.txt`, `*.rst` are excluded (a 10 000-line README is fine; a 500-line refactor is not). Also excluded: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
-- If a task clearly needs >150 LOC of code, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, work gets redone, tokens burn twice.
+This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed source file. Tests count.
+- **Human-facing docs are excluded** — `docs/**/*.md`, `docs/**/*.mdx`, `CHANGELOG.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATION*.md`, `TODO*.md`. A 10 000-line README is fine; a 500-line refactor is not.
+- **AI-rule files DO count** — `CLAUDE.md`, `AGENTS.md`, `templates/**/*.md` (role prompts, coder rules, review rules). Those go into the agent's context every run, so the same ≤200 LOC discipline applies — bloating them dilutes the signal the AI receives.
+- Other exclusions: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
+- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, work gets redone, tokens burn twice.
 - Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
 
 ## Example

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ When asked to implement, fix, or refactor, use `kj_run` via MCP instead of editi
 - Manual editing only if the user asks or KJ cannot complete.
 
 ## PR atomicity (hard project rule)
-This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
-- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
-- The gate counts the SUM of every changed file. Tests count. Lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/` are excluded.
-- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, work gets redone, tokens burn twice.
+This repo enforces a CI gate that fails any PR whose net delta of **code** exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC of code per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed source file. Tests count. **Documentation files do NOT count** — `*.md`, `*.mdx`, `*.txt`, `*.rst` are excluded (a 10 000-line README is fine; a 500-line refactor is not). Also excluded: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
+- If a task clearly needs >150 LOC of code, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, work gets redone, tokens burn twice.
 - Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
 
 ## Example

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,13 @@ For `kj_run`, use:
 - Edit manually only if the user asks or KJ cannot complete the task.
 
 ## PR atomicity (hard project rule)
-This repo enforces a CI gate that fails any PR whose net delta of **code** exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
-- Aim for **~150 LOC of code per PR** (margin against the 200 hard limit).
-- The gate counts the SUM of every changed source file. Tests count. **Documentation files do NOT count** — `*.md`, `*.mdx`, `*.txt`, `*.rst` are excluded (a 10 000-line README is fine; a 500-line refactor is not). Also excluded: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
-- If a task clearly needs >150 LOC of code, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, the work gets redone, tokens burn twice.
+This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed source file. Tests count.
+- **Human-facing docs are excluded** — `docs/**/*.md`, `docs/**/*.mdx`, `CHANGELOG.md`, `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATION*.md`, `TODO*.md`. A 10 000-line README is fine; a 500-line refactor is not.
+- **AI-rule files DO count** — `CLAUDE.md`, `AGENTS.md`, `templates/**/*.md` (role prompts, coder rules, review rules). Those go into the agent's context every run, so the same ≤200 LOC discipline applies — bloating them dilutes the signal the AI receives.
+- Other exclusions: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
+- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, the work gets redone, tokens burn twice.
 - Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
 
 ## Troubleshooting and subprocess architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,10 @@ For `kj_run`, use:
 - Edit manually only if the user asks or KJ cannot complete the task.
 
 ## PR atomicity (hard project rule)
-This repo enforces a CI gate that fails any PR whose net delta exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
-- Aim for **~150 LOC per PR** (margin against the 200 hard limit).
-- The gate counts the SUM of every changed file. Tests count. Lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/` are excluded.
-- If a task clearly needs >150 LOC, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, the work gets redone, tokens burn twice.
+This repo enforces a CI gate that fails any PR whose net delta of **code** exceeds **200 lines added** (`shrink-budget` workflow, since 2026-05-08). Both for `kj_run` and for direct edits:
+- Aim for **~150 LOC of code per PR** (margin against the 200 hard limit).
+- The gate counts the SUM of every changed source file. Tests count. **Documentation files do NOT count** — `*.md`, `*.mdx`, `*.txt`, `*.rst` are excluded (a 10 000-line README is fine; a 500-line refactor is not). Also excluded: lockfiles, snapshots, `dist/`, `node_modules/`, `tests/_diet/`, `public/docs/`.
+- If a task clearly needs >150 LOC of code, **partition it upfront** (multiple PRs, multiple HUs, multiple commits). Don't ship a single 500-LOC PR — the gate rejects it, the work gets redone, tokens burn twice.
 - Escape hatch: `large-pr-justified` label on the PR, but use it sparingly and justify in the PR body.
 
 ## Troubleshooting and subprocess architecture


### PR DESCRIPTION
## Summary

The shrink-budget gate exists to cap **code** growth — not human-facing documentation. Markdown was caught by the same 200-line ceiling, which forced artificial truncation of legitimate docs (CHANGELOG entries, spec files) for no real benefit.

But Markdown isn't all the same. Two cohorts now treated differently:

- **Human-facing docs** — excluded. A 10 000-line README is fine.
  - `docs/**/*.md`, `docs/**/*.mdx`, `docs/**/*.txt`, `docs/**/*.rst`
  - `CHANGELOG.md`, `README.md`, `README.*.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATION*.md`, `TODO*.md`

- **AI-rule files** — still counted toward the budget on purpose. Those go into the agent's context every run; bloating them dilutes the signal the AI receives. Same ≤200 LOC discipline as source code.
  - `CLAUDE.md`, `AGENTS.md`
  - `templates/**/*.md` (role prompts, coder rules, review rules)

Rule text in `CLAUDE.md` and `AGENTS.md` updated so all coding agents (Claude Code, Codex, Gemini, OpenCode, Cursor) see the same distinction.

## Why two commits

The first commit applied a blanket \`**/*.md\` exclude. The user pointed out (correctly) that AI-rule files need to stay disciplined — bloating CLAUDE.md harms the agent's focus. The second commit refines the exclude list to be explicit about which Markdown counts and which doesn't. I left both commits in the history because the reasoning is useful for the next person who looks at this rule.

## Test plan

- [x] No source code changes — pure CI/policy
- [ ] CI on this PR runs with the new exclude list. Net LOC delta should report ~36 added (the 3-file diff sans docs paths) instead of \"infinity\" or whatever full-MD weight would be.

## Related

- KJC-TSK-0352 — original shrink-budget introduction
- Issue surfaced while shipping TSK-0376 PR-C and TSK-0374 PR-1 — both had to artificially trim docs to stay under budget.