### PR TITLE
feat(golden): summary.md parser + asserter (TSK-0374 PR-2)

### DIFF
--- a/src/golden/asserter.js
+++ b/src/golden/asserter.js
@@ -1,0 +1,90 @@
+/**
+ * Golden tasks asserter (KJC-TSK-0374). Parses a `summary.md` produced
+ * by a real `kj run` and compares it against a GoldenTask's structural
+ * expectations. Pure: no I/O, no subprocess. Subprocess driver lands
+ * in PR-3a; the 3 fixtures + baseline + spec land in PR-3b.
+ *
+ * Three of the five assertion families live here (the ones derivable
+ * from summary.md alone): expected_commits_min, expected_audit_status,
+ * expected_plan_adherence_min. expected_test_files and
+ * allowed_loc_range need filesystem access — PR-3a wires those.
+ */
+
+const COMMIT_LINE = /^- `([^`]+)`\s+(.*)$/;
+const SCORE_LINE = /^\*\*Score\*\*:\s*(\d+)\s*\/\s*100/m;
+const AUDIT_ROW = /^\|\s*`audit`\s*\|\s*([^|]+?)\s*\|/m;
+
+function extractSection(content, heading) {
+  const re = new RegExp(`^## ${heading}\\s*$([\\s\\S]*?)(?=^## |\\Z)`, "m");
+  const m = content.match(re);
+  return m ? m[1].trim() : "";
+}
+
+function parseCommits(content) {
+  const section = extractSection(content, "Commits");
+  if (!section || /No commits/.test(section)) return [];
+  return section
+    .split("\n")
+    .map((line) => line.match(COMMIT_LINE))
+    .filter(Boolean)
+    .map(([, hash, message]) => ({ hash, message }));
+}
+
+function parseAuditStatus(content) {
+  const m = content.match(AUDIT_ROW);
+  if (!m) return null;
+  const cell = m[1];
+  if (/✅|pass/i.test(cell)) return "pass";
+  if (/❌|fail/i.test(cell)) return "fail";
+  if (/⚠|warn/i.test(cell)) return "warning";
+  return null;
+}
+
+function parsePlanAdherence(content) {
+  const section = extractSection(content, "Plan adherence");
+  if (!section) return null;
+  const m = section.match(SCORE_LINE);
+  if (!m) return null;
+  const score = Number(m[1]);
+  return Number.isFinite(score) ? score : null;
+}
+
+export function parseSummary(content) {
+  const text = String(content || "");
+  return {
+    commits: parseCommits(text),
+    auditStatus: parseAuditStatus(text),
+    planAdherenceScore: parsePlanAdherence(text),
+  };
+}
+
+export function assertFromSummary(task, parsed) {
+  const failures = [];
+
+  const fail = (kind, expected, actual, message) => failures.push({ kind, expected, actual, message });
+
+  if (parsed.commits.length < task.expected_commits_min) {
+    fail("commits_min", `>= ${task.expected_commits_min}`, parsed.commits.length,
+      `expected at least ${task.expected_commits_min} commit(s); got ${parsed.commits.length}`);
+  }
+
+  if (parsed.auditStatus !== task.expected_audit_status) {
+    const got = parsed.auditStatus === null ? "no audit row in summary" : `"${parsed.auditStatus}"`;
+    fail("audit_status", task.expected_audit_status, parsed.auditStatus,
+      `expected audit "${task.expected_audit_status}"; got ${got}`);
+  }
+
+  if (typeof task.expected_plan_adherence_min === "number") {
+    const score = parsed.planAdherenceScore;
+    const min = task.expected_plan_adherence_min;
+    if (score === null) {
+      fail("plan_adherence_missing", `>= ${min}`, null,
+        `expected plan adherence >= ${min}; summary has no Plan adherence section`);
+    } else if (score < min) {
+      fail("plan_adherence_below", `>= ${min}`, score,
+        `expected plan adherence >= ${min}; got ${score}`);
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}

--- a/tests/golden/asserter.test.js
+++ b/tests/golden/asserter.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { parseSummary, assertFromSummary } from "../../src/golden/asserter.js";
+
+const baseTask = {
+  id: "todo", title: "x", prompt: "y",
+  expected_commits_min: 2, expected_audit_status: "pass",
+  expected_test_files: [], allowed_loc_range: [0, 999],
+};
+
+const summary = (extras = "") => `# Session summary — s-1
+
+- **Result**: ✅ APPROVED
+
+## Stages
+
+| Stage | Status | Summary |
+|---|---|---|
+| \`coder\` | ✅ pass | 3 files |
+| \`audit\` | ✅ pass | clean |
+
+## Commits
+
+- \`abc1234\` feat: add login
+- \`def4567\` test: login e2e
+- \`9876543\` chore: tidy
+
+${extras}
+## Journal files
+
+- [iterations.md](./iterations.md)
+`;
+
+describe("golden/asserter — parseSummary", () => {
+  it("extracts commits, audit status and plan adherence score", () => {
+    const md = summary("## Plan adherence\n\n**Score**: 87/100\n\n");
+    const r = parseSummary(md);
+    expect(r.commits.map((c) => c.hash)).toEqual(["abc1234", "def4567", "9876543"]);
+    expect(r.auditStatus).toBe("pass");
+    expect(r.planAdherenceScore).toBe(87);
+  });
+
+  it("returns null planAdherenceScore when section is missing", () => {
+    expect(parseSummary(summary()).planAdherenceScore).toBeNull();
+  });
+
+  it("returns empty commits when summary says 'No commits'", () => {
+    const md = "## Commits\n\n_No commits in this session._\n\n## Journal files";
+    expect(parseSummary(md).commits).toEqual([]);
+  });
+
+  it("returns null auditStatus when audit row is missing", () => {
+    expect(parseSummary("# random").auditStatus).toBeNull();
+  });
+
+  it("recognises ❌ fail and ⚠ warning audit cells", () => {
+    const fail = parseSummary("| `audit` | ❌ fail | broken |").auditStatus;
+    const warn = parseSummary("| `audit` | ⚠ warning | flaky |").auditStatus;
+    expect(fail).toBe("fail");
+    expect(warn).toBe("warning");
+  });
+});
+
+describe("golden/asserter — assertFromSummary", () => {
+  it("returns ok=true when every assertion passes", () => {
+    const md = summary("## Plan adherence\n\n**Score**: 90/100\n\n");
+    const parsed = parseSummary(md);
+    const r = assertFromSummary({ ...baseTask, expected_plan_adherence_min: 75 }, parsed);
+    expect(r).toEqual({ ok: true, failures: [] });
+  });
+
+  it("flags commits_min when below threshold", () => {
+    const md = "## Stages\n| `audit` | ✅ pass | ok |\n## Commits\n- `a` x\n## Journal";
+    const r = assertFromSummary(baseTask, parseSummary(md));
+    expect(r.ok).toBe(false);
+    expect(r.failures.find((f) => f.kind === "commits_min")).toBeTruthy();
+  });
+
+  it("flags audit_status mismatch including the 'no audit row' case", () => {
+    const r = assertFromSummary({ ...baseTask, expected_audit_status: "fail" }, parseSummary(summary()));
+    expect(r.failures.find((f) => f.kind === "audit_status")).toMatchObject({ expected: "fail", actual: "pass" });
+    const noAudit = assertFromSummary(baseTask, parseSummary("## Commits\n- `a` x\n- `b` y\n## Journal"));
+    expect(noAudit.failures.find((f) => f.kind === "audit_status")).toMatchObject({ actual: null });
+  });
+
+  it("flags plan_adherence_below and plan_adherence_missing distinctly", () => {
+    const below = assertFromSummary(
+      { ...baseTask, expected_plan_adherence_min: 80 },
+      parseSummary(summary("## Plan adherence\n\n**Score**: 60/100\n\n")),
+    );
+    expect(below.failures.find((f) => f.kind === "plan_adherence_below")).toMatchObject({ actual: 60 });
+    const missing = assertFromSummary(
+      { ...baseTask, expected_plan_adherence_min: 70 },
+      parseSummary(summary()),
+    );
+    expect(missing.failures.find((f) => f.kind === "plan_adherence_missing")).toBeTruthy();
+  });
+
+  it("skips plan_adherence assertion when the task did not declare a threshold", () => {
+    const r = assertFromSummary(baseTask, parseSummary(summary()));
+    expect(r.failures.some((f) => f.kind.startsWith("plan_adherence"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PR-2 of the TSK-0374 trio. Pure module that parses the `summary.md` produced by a real `kj run` and compares it against a GoldenTask's structural expectations.

## What ships

- **`src/golden/asserter.js`** — two pure functions:
  - `parseSummary(content)` → `{ commits, auditStatus, planAdherenceScore }` extracted from the markdown.
  - `assertFromSummary(task, parsed)` → `{ ok, failures: [{ kind, expected, actual, message }] }`.

- Three assertion families covered (the ones derivable from `summary.md` alone):
  - `expected_commits_min` — counted from `## Commits` section.
  - `expected_audit_status` — read from the `audit` row in `## Stages`. Recognises `✅ pass`, `❌ fail`, `⚠ warning`.
  - `expected_plan_adherence_min` — `**Score**: NN/100` in `## Plan adherence` (TSK-0376 hookup).

- The two that need filesystem access (`expected_test_files`, `allowed_loc_range`) are deferred to PR-3a, where the subprocess runner has the working dir.

- **10 unit tests** with synthetic summaries: happy path + every individual failure mode + the "no plan adherence section" case so a task that doesn't declare a threshold is unaffected.

## LOC

192 (under budget). 4515/4515 tests green.

## Roadmap

- **PR-3a** — subprocess driver: spawn `kj run`, copy generated summary, run asserter, compute the two filesystem-dependent assertions.
- **PR-3b** — 3 task fixtures + baseline JSON + `docs/golden-tasks.md` (now uncapped because docs were excluded from the budget in #649).

## Related

- TSK-0376 (#645/#646/#647) — plan adherence metric this asserter reads.
- TSK-0374 PR-1 (#648) — schema + loader this asserter consumes.
- #649 — workflow tweak that lets PR-3b ship its full spec doc without artificially trimming.