### PR TITLE
feat(golden): subprocess runner + filesystem assertions (TSK-0374 PR-3a)

### DIFF
--- a/src/golden/runner.js
+++ b/src/golden/runner.js
@@ -1,0 +1,92 @@
+/**
+ * Golden tasks subprocess runner (KJC-TSK-0374). Spawns `kj run` in
+ * a sandbox dir, reads back summary.md, evaluates the schema's
+ * filesystem-dependent assertions (expected_test_files, allowed_loc_range),
+ * and merges them with `assertFromSummary` into a single result.
+ *
+ * The kj subprocess + diff calls are injected so unit tests can drive
+ * the runner without spawning anything (real e2e is opt-in via PR-3b).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runCommand as defaultRun } from "../utils/process.js";
+import { parseSummary, assertFromSummary } from "./asserter.js";
+
+async function findLatestSummary(workDir) {
+  const journalRoot = path.join(workDir, ".karajan", "sessions");
+  const sessions = await fs.readdir(journalRoot).catch(() => []);
+  if (sessions.length === 0) return null;
+  const stats = await Promise.all(sessions.map(async (id) => {
+    const file = path.join(journalRoot, id, "summary.md");
+    const stat = await fs.stat(file).catch(() => null);
+    return stat ? { file, mtimeMs: stat.mtimeMs } : null;
+  }));
+  const valid = stats.filter(Boolean).sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return valid[0]?.file ?? null;
+}
+
+async function findMissingTestFiles(workDir, paths) {
+  const checks = await Promise.all(paths.map(async (rel) =>
+    [rel, await fs.stat(path.join(workDir, rel)).then(() => true).catch(() => false)]));
+  return checks.filter(([, ok]) => !ok).map(([rel]) => rel);
+}
+
+async function totalLocSince(workDir, baseSha, run) {
+  const res = await run("git", ["diff", "--numstat", `${baseSha}..HEAD`], { cwd: workDir }).catch(() => null);
+  if (!res || res.exitCode !== 0) return null;
+  return String(res.stdout || "").split("\n").filter(Boolean)
+    .map((l) => l.split("\t")).filter(([a]) => a !== "-")
+    .reduce((sum, [a]) => sum + Number(a || 0), 0);
+}
+
+export async function runGoldenTask(task, opts = {}) {
+  const run = opts.run || defaultRun;
+  const fsApi = opts.fs || fs;
+  const workDir = opts.workDir;
+  if (!workDir) throw new Error("runGoldenTask requires opts.workDir");
+
+  const baseSha = opts.baseSha || null;
+  const kjResult = await run("kj", ["run", task.prompt, "-y"], {
+    cwd: workDir,
+    timeout: (task.timeout_minutes || 30) * 60_000,
+  });
+
+  const summaryPath = opts.summaryPath || await findLatestSummary(workDir);
+  if (!summaryPath) {
+    return { ok: false, kjExit: kjResult?.exitCode ?? -1, failures: [{
+      kind: "no_summary", expected: "summary.md", actual: null,
+      message: "kj run finished without producing a summary.md",
+    }] };
+  }
+  const content = await fsApi.readFile(summaryPath, "utf8");
+  const parsed = parseSummary(content);
+  const summaryAssertion = assertFromSummary(task, parsed);
+
+  const failures = [...summaryAssertion.failures];
+
+  if (Array.isArray(task.expected_test_files) && task.expected_test_files.length > 0) {
+    const missing = await findMissingTestFiles(workDir, task.expected_test_files);
+    if (missing.length > 0) {
+      failures.push({ kind: "test_files_missing", expected: task.expected_test_files, actual: missing,
+        message: `expected test files not produced: ${missing.join(", ")}` });
+    }
+  }
+
+  if (baseSha) {
+    const loc = await totalLocSince(workDir, baseSha, run);
+    const [min, max] = task.allowed_loc_range;
+    if (loc !== null && (loc < min || loc > max)) {
+      failures.push({ kind: "loc_out_of_range", expected: `${min}..${max}`, actual: loc,
+        message: `LOC added (${loc}) is outside the allowed range [${min}, ${max}]` });
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    kjExit: kjResult?.exitCode ?? null,
+    summaryPath,
+    parsed,
+    failures,
+  };
+}

--- a/tests/golden/runner.test.js
+++ b/tests/golden/runner.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { runGoldenTask } from "../../src/golden/runner.js";
+
+const baseTask = {
+  id: "todo", title: "x", prompt: "Build todo",
+  timeout_minutes: 5,
+  expected_commits_min: 2, expected_audit_status: "pass",
+  expected_test_files: ["tests/todo.test.js"], allowed_loc_range: [50, 250],
+};
+
+const okSummary = `## Stages
+| Stage | Status | Summary |
+| \`audit\` | ✅ pass | clean |
+## Commits
+- \`a\` feat: x
+- \`b\` test: y
+- \`c\` chore: z
+## Plan adherence
+**Score**: 92/100
+## Journal`;
+
+describe("golden/runner — runGoldenTask", () => {
+  let tmp;
+
+  beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-runner-")); });
+  afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }).catch(() => {}); });
+
+  function setupFiles({ summary, testFile = true } = {}) {
+    const summaryPath = path.join(tmp, "summary.md");
+    return Promise.all([
+      summary !== undefined ? fs.writeFile(summaryPath, summary) : Promise.resolve(),
+      testFile ? fs.mkdir(path.join(tmp, "tests"), { recursive: true })
+        .then(() => fs.writeFile(path.join(tmp, "tests/todo.test.js"), "")) : Promise.resolve(),
+    ]).then(() => summaryPath);
+  }
+
+  it("returns ok=true when every assertion passes", async () => {
+    const summaryPath = await setupFiles({ summary: okSummary });
+    // 60 + 40 = 100 LOC, within [50, 250]
+    const run = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "60\t0\ta.js\n40\t0\tb.js\n", stderr: "" });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, summaryPath, run, baseSha: "abc" });
+    expect(r.ok).toBe(true);
+    expect(r.failures).toEqual([]);
+    expect(r.parsed.commits).toHaveLength(3);
+  });
+
+  it("returns no_summary when kj produced none and findLatestSummary fails", async () => {
+    const run = vi.fn().mockResolvedValue({ exitCode: 1, stdout: "", stderr: "boom" });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, run });
+    expect(r.ok).toBe(false);
+    expect(r.failures[0].kind).toBe("no_summary");
+    expect(r.kjExit).toBe(1);
+  });
+
+  it("flags test_files_missing when an expected test file is absent", async () => {
+    const summaryPath = await setupFiles({ summary: okSummary, testFile: false });
+    const run = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, summaryPath, run });
+    expect(r.failures.find((f) => f.kind === "test_files_missing")).toMatchObject({
+      actual: ["tests/todo.test.js"],
+    });
+  });
+
+  it("flags loc_out_of_range when total added LOC falls outside the bounds", async () => {
+    const summaryPath = await setupFiles({ summary: okSummary });
+    // numstat says 5 lines added — below the [50,250] range.
+    const run = vi.fn().mockImplementation((cmd, args) => {
+      if (args?.[0] === "diff") return Promise.resolve({ exitCode: 0, stdout: "5\t0\tfoo.js\n", stderr: "" });
+      return Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+    });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, summaryPath, run, baseSha: "abc" });
+    expect(r.failures.find((f) => f.kind === "loc_out_of_range")).toMatchObject({ actual: 5 });
+  });
+
+  it("ignores LOC range when no baseSha is provided", async () => {
+    const summaryPath = await setupFiles({ summary: okSummary });
+    const run = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, summaryPath, run });
+    expect(r.failures.find((f) => f.kind === "loc_out_of_range")).toBeUndefined();
+  });
+
+  it("propagates summary-derived failures (commits_min)", async () => {
+    const summaryPath = await setupFiles({
+      summary: "## Stages\n| `audit` | ✅ pass | ok |\n## Commits\n- `a` x\n## Journal",
+    });
+    const run = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await runGoldenTask(baseTask, { workDir: tmp, summaryPath, run });
+    expect(r.failures.find((f) => f.kind === "commits_min")).toBeTruthy();
+  });
+
+  it("rejects when workDir is missing", async () => {
+    await expect(runGoldenTask(baseTask, {})).rejects.toThrow(/workDir/);
+  });
+});


### PR DESCRIPTION
## Summary

PR-3a of the TSK-0374 trio. Connects PR-1 (schema/loader) and PR-2 (asserter) to a real `kj run` subprocess.

## What ships

- **`src/golden/runner.js`** — `runGoldenTask(task, opts)`:
  1. Spawns \`kj run \"<prompt>\" -y\` in \`opts.workDir\` with the task's timeout.
  2. Locates the produced \`summary.md\` (newest under \`.karajan/sessions/*/summary.md\`).
  3. Calls the PR-2 asserter for the 3 markdown-derivable checks.
  4. Adds the **two filesystem-dependent assertions**:
     - \`expected_test_files\` → \`fs.stat\` each declared path; collect missing into \`test_files_missing\`.
     - \`allowed_loc_range\` → \`git diff --numstat baseSha..HEAD\` summed, compared against the range.
  5. Returns \`{ ok, kjExit, summaryPath, parsed, failures }\`.

The kj subprocess + \`git diff\` are injected via \`opts.run\` so unit tests drive the runner with a \`vi.fn()\` mock — no real subprocess spawned in the suite.

- **7 unit tests**: happy path, no-summary fallback, missing test files, LOC out of range, no baseSha (LOC skipped), summary-derived failures propagated, missing workDir argument.

## LOC

189 (under budget). 4522/4522 tests green.

## Roadmap

- **PR-3b** — 3 task fixtures (todo-rest-api, npm-package-cli, react-component) + baseline JSON + \`docs/golden-tasks.md\`. The spec doc can grow without budget concerns since #649 excluded \`docs/**/*.md\`.
- After PR-3b is merged, release **v2.12.0** (plan adherence + golden tasks complete).

## Related

- TSK-0374 PR-1 (#648) — schema + loader
- TSK-0374 PR-2 (#650) — summary parser + asserter
- TSK-0376 (#645/646/647) — plan adherence metric this asserts against