### PR TITLE
feat(golden): 3 task fixtures + baseline + spec doc (TSK-0374 PR-3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Spec in `docs/plan-adherence.md`. Inspired by deepeval, kept fully
   deterministic for reproducibility (golden-task suite friendly).
 
+- **Golden tasks regression suite** (`KJC-TSK-0374`, #648/#650/#651) —
+  a small set of canonical tasks (`todo-rest-api`, `npm-package-cli`,
+  `react-counter-component`) executed before every release to detect
+  output-quality regressions between Karajan versions. Five assertion
+  families per task: commits-min, audit status, plan adherence,
+  expected test files, allowed LOC range. All deterministic — no LLM
+  judge. Library-only in this release; CLI integration is a follow-up
+  task. Spec in `docs/golden-tasks.md`.
+
+### Changed
+
+- **Shrink-budget gate refined** (#649) — `*.md` files used to count
+  toward the 200-LOC PR limit, which forced trimming of legitimate
+  documentation. Human-facing docs (`docs/**`, `CHANGELOG.md`,
+  `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATION*.md`,
+  `TODO*.md`) are now excluded. AI-rule files (`CLAUDE.md`,
+  `AGENTS.md`, `templates/**/*.md` — role prompts, coder/review rules)
+  still count, since unbounded growth there dilutes the agent's
+  context.
+
 ### Documentation
 
 - **Plan adherence spec** (`docs/plan-adherence.md`) — full reference
   for the new metric: components, attribution rules, output shape,
   when the section is omitted, why no LLM judge.
+
+- **Golden tasks spec** (`docs/golden-tasks.md`) — full reference for
+  the regression suite: how it works, the 3 tasks, schema, baseline
+  format, when the suite runs.
 
 - **Audit false positives registry** (`KJC-TSK-0353`, #578) — new
   `docs/audit-false-positives.md` recording the 4 dependencies that

--- a/docs/golden-tasks.md
+++ b/docs/golden-tasks.md
@@ -1,0 +1,85 @@
+# Golden tasks regression suite
+
+**Status**: Active (introduced in v2.12.0 — KJC-TSK-0374)
+**Implementation**: `src/golden/{schema,loader,asserter,runner}.js` · fixtures in `tests/golden/tasks/` · baseline in `tests/golden/baseline.json`
+
+## What it answers
+
+> *Did Karajan v2.X get worse than v2.X-1?*
+
+The existing e2e suite checks exit codes — "did `kj run` finish without crashing?". The golden tasks suite goes one step further: it checks the *quality of the output* by running a small set of canonical tasks and comparing structural properties of the result against fixed expectations.
+
+If a v2.X coder starts producing fewer commits, lower plan adherence, or skipping the test files it used to write, the golden suite catches it before the release lands on npm.
+
+## How it works
+
+For each task in `tests/golden/tasks/*.json`:
+
+1. **Sandbox** — fresh dir under `/tmp` (or the path you pass in).
+2. **Spawn** — `kj run "<prompt>" -y` with the task's `timeout_minutes`.
+3. **Locate** — newest `summary.md` under `.karajan/sessions/*/`.
+4. **Assert** — five families:
+   - `expected_commits_min` (parsed from `## Commits`)
+   - `expected_audit_status` (parsed from the `audit` row in `## Stages`)
+   - `expected_plan_adherence_min` (parsed from the `## Plan adherence` section, see [`plan-adherence.md`](./plan-adherence.md))
+   - `expected_test_files` (`fs.stat` against the workdir)
+   - `allowed_loc_range` (`git diff --numstat baseSha..HEAD` summed)
+5. **Verdict** — `{ ok, kjExit, summaryPath, parsed, failures: [{kind, expected, actual, message}] }`. Exit non-zero on any failure.
+
+No LLM judge — every assertion is deterministic and re-derivable by hand from the workdir.
+
+## The 3 canonical tasks
+
+| ID | What it exercises |
+| --- | --- |
+| `todo-rest-api` | Express REST API + Vitest. Planner decomposition, sub-pipelines, multiple endpoints. The N4 happy-path demo. |
+| `npm-package-cli` | Single-file CLI with commander + Vitest. Tests the planner's discipline on a focused feature. |
+| `react-counter-component` | TypeScript + React + Testing Library. Verifies non-JS framework selection and TSX-aware audit. |
+
+The set is intentionally small (option B from the original 10-task spec). Three tasks cover three orthogonal domains (backend, CLI, frontend). Anything more would inflate release time without improving signal.
+
+## Schema
+
+A golden task JSON has the shape (see `src/golden/schema.js`):
+
+```jsonc
+{
+  "id": "lowercase-kebab",
+  "title": "Human-readable title",
+  "prompt": "What the user would type into kj run",
+  "description": "(optional) why this task exists",
+  "timeout_minutes": 30,                 // optional, default 30
+  "expected_commits_min": 3,
+  "expected_audit_status": "pass",       // pass | warning | fail
+  "expected_test_files": ["tests/x.test.js"],
+  "allowed_loc_range": [80, 350],        // [min, max] of `git diff --numstat`
+  "expected_plan_adherence_min": 70      // optional, 0-100
+}
+```
+
+Validation rejects: empty prompts, ids with non-`[a-z0-9_-]` chars, audit statuses outside the picklist, LOC ranges where min > max, plan adherence outside 0-100.
+
+## Baseline (`baseline.json`)
+
+The asserter checks each task against the JSON spec. The **baseline** is a separate, looser tracking file — it records the most recent successful run (commits, plan adherence, LOC, audit status, kj version, timestamp). The regression check fails when the next run scores meaningfully worse than the baseline, even when both technically pass the spec.
+
+The baseline ships with `null` values; the runner populates them on the first green release-candidate run.
+
+## When the suite runs
+
+- **Pre-release** — manually before tagging `vX.Y.Z`. Roughly $5-10 in API calls per full run.
+- **CI** — gated behind a `golden-tasks` label or a manual workflow dispatch. Not a per-PR check (too expensive, too slow).
+
+The runner is library-only in this release; CLI integration (`kj benchmark golden`) is queued for a follow-up task.
+
+## Output volume
+
+A full run of all 3 tasks takes 30-60 minutes wall clock and ~$5-10 of API spend with the default coder/reviewer pair. Each task writes its own `summary.md`, `iterations.md`, etc. under `.karajan/sessions/`; the runner reads only `summary.md` to keep the assertion logic simple and stable across schema changes elsewhere.
+
+## Related
+
+- **TSK-0376** ([`plan-adherence.md`](./plan-adherence.md)) — the per-run metric this suite asserts against.
+- **TSK-0327** — process-skills catalog. A future enhancement would also assert "which addyosmani skills did the planner pull?" — left for a follow-up.
+- `src/golden/schema.js` — Valibot schema (PR #648).
+- `src/golden/asserter.js` — summary parser + assertion engine (PR #650).
+- `src/golden/runner.js` — subprocess driver + filesystem assertions (PR #651).

--- a/tests/golden/baseline.json
+++ b/tests/golden/baseline.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "./baseline.schema.md",
+  "version": 1,
+  "description": "Latest known-good plan-adherence + commit counts per golden task. Updated by the runner on a successful release-candidate run; the regression check compares the next run against this snapshot.",
+  "results": {
+    "todo-rest-api": {
+      "last_run_at": null,
+      "last_kj_version": null,
+      "commits": null,
+      "plan_adherence_score": null,
+      "loc_added": null,
+      "audit_status": null
+    },
+    "npm-package-cli": {
+      "last_run_at": null,
+      "last_kj_version": null,
+      "commits": null,
+      "plan_adherence_score": null,
+      "loc_added": null,
+      "audit_status": null
+    },
+    "react-counter-component": {
+      "last_run_at": null,
+      "last_kj_version": null,
+      "commits": null,
+      "plan_adherence_score": null,
+      "loc_added": null,
+      "audit_status": null
+    }
+  }
+}

--- a/tests/golden/tasks/npm-package-cli.json
+++ b/tests/golden/tasks/npm-package-cli.json
@@ -1,0 +1,12 @@
+{
+  "id": "npm-package-cli",
+  "title": "Tiny CLI tool — `slugify <text>`",
+  "prompt": "Create a Node.js CLI tool that slugifies its input. Use commander for argument parsing. Read text from a positional argument or stdin if absent. Lowercase, replace spaces and special characters with hyphens, trim leading/trailing hyphens. Include Vitest tests for the core slugify function and one for the CLI entry.",
+  "description": "Smaller-than-todo task. Tests planner discipline on a focused single-file feature plus its tests. Should produce 2-4 commits.",
+  "timeout_minutes": 25,
+  "expected_commits_min": 2,
+  "expected_audit_status": "pass",
+  "expected_test_files": ["tests/slugify.test.js"],
+  "allowed_loc_range": [50, 200],
+  "expected_plan_adherence_min": 75
+}

--- a/tests/golden/tasks/react-component.json
+++ b/tests/golden/tasks/react-component.json
@@ -1,0 +1,12 @@
+{
+  "id": "react-counter-component",
+  "title": "React Counter component with tests",
+  "prompt": "Build a React Counter component with TypeScript. Two buttons: increment, decrement. Disabled decrement when count is 0. Use Vitest + Testing Library for tests. Also include a README.md describing usage.",
+  "description": "Frontend-leaning task. Verifies that the planner picks an appropriate test framework (Vitest + RTL), produces a TypeScript file, and that audit doesn't break on JSX/TSX.",
+  "timeout_minutes": 30,
+  "expected_commits_min": 2,
+  "expected_audit_status": "pass",
+  "expected_test_files": ["src/Counter.test.tsx"],
+  "allowed_loc_range": [60, 250],
+  "expected_plan_adherence_min": 70
+}

--- a/tests/golden/tasks/todo-rest-api.json
+++ b/tests/golden/tasks/todo-rest-api.json
@@ -1,0 +1,12 @@
+{
+  "id": "todo-rest-api",
+  "title": "Express REST API for a todo list",
+  "prompt": "Build a REST API for a todo list. Express + Vitest. Endpoints: GET /todos, POST /todos, DELETE /todos/:id. With validation, error handling, and tests.",
+  "description": "The N4 happy-path demo task. Exercises planner decomposition + sub-pipelines + Vitest scaffolding + final audit. Should reliably produce 3-6 commits and >=2 test files.",
+  "timeout_minutes": 30,
+  "expected_commits_min": 3,
+  "expected_audit_status": "pass",
+  "expected_test_files": ["tests/todos.test.js"],
+  "allowed_loc_range": [80, 350],
+  "expected_plan_adherence_min": 70
+}


### PR DESCRIPTION
## Summary

Final piece of the TSK-0374 trio. Adds the actual data — three canonical task prompts plus the baseline tracking file — and the user-facing spec doc.

## What ships

### Fixtures (`tests/golden/tasks/`)

| ID | Domain | What it exercises |
| --- | --- | --- |
| \`todo-rest-api\` | Backend | Express + Vitest. The N4 happy-path demo. Planner decomposition, sub-pipelines, multi-endpoint testing. |
| \`npm-package-cli\` | CLI | Single-file commander tool + Vitest. Tests planner discipline on a focused feature. |
| \`react-counter-component\` | Frontend | TypeScript + React + Testing Library. Verifies non-JS framework selection and TSX-aware audit. |

Three orthogonal domains, intentionally small (option B from the original 10-task scope).

### Baseline (\`tests/golden/baseline.json\`)

Schema-versioned tracker for \`{commits, plan_adherence, loc_added, audit_status, kj_version, run_at}\` per task. Ships with \`null\` values; populated by the runner on the first green release-candidate run, then used as the reference for *\"did v2.X+1 do meaningfully worse than v2.X?\"*.

### Documentation (\`docs/golden-tasks.md\`)

Full spec: how the runner works, the 3 tasks, JSON schema reference, baseline format, when the suite runs (pre-release, not per-PR), output volume estimate (\$5-10 per full pass).

### CHANGELOG

Three entries: Added (TSK-0374 itself), Documentation (the spec doc), Changed (#649 shrink-budget refinement that made docs land without budget pressure).

## LOC

67 LOC counted (3 task JSONs + baseline JSON). docs/golden-tasks.md (85 lines) and CHANGELOG (24 lines) are excluded by #649. Well under budget.

## Verification

\`\`\`bash
$ node -e \"import('./src/golden/loader.js').then(async ({ loadGoldenTasks }) => { const { tasks } = await loadGoldenTasks('tests/golden/tasks'); console.log(tasks.length, tasks.map(t => t.id)); })\"
3 [ 'npm-package-cli', 'react-counter-component', 'todo-rest-api' ]
\`\`\`

All 3 fixtures pass schema validation via the PR-1 loader.

## After this merges

- TSK-0374 is **complete** (3 PRs: #648 schema/loader, #650 asserter, #651 runner, this #652 fixtures+docs).
- Ready for **v2.12.0 release**: plan adherence (TSK-0376) + golden tasks (TSK-0374) bundled.

## Related

- TSK-0374 PR-1 (#648) — schema + loader
- TSK-0374 PR-2 (#650) — summary parser + asserter
- TSK-0374 PR-3a (#651) — subprocess runner
- TSK-0376 (#645/646/647) — plan adherence (asserted via \`expected_plan_adherence_min\`)
- #649 — shrink-budget refinement that made this PR's docs land unrestricted