### PR TITLE
fix(hu-board): detectar restart del server y forzar reload (KJC-TSK-0379)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -3605,3 +3605,38 @@ refreshInterval = setInterval(async () => {
     await smartRefresh(null);
   }
 }, 60_000);
+
+// --- Server-restart detector (KJC-TSK-0379) ---------------------------
+// Poll /api/version every 30s. First response anchors the baseline; if
+// `boot_time` later differs, the server restarted (likely after a `kj
+// board start`) and the client reloads to pick up any new HTML/JS
+// served with `Cache-Control: no-store`. Avoids the "I killed the
+// server but the browser keeps showing stale UI" pain.
+let __versionBaseline = null;
+async function pollServerVersion() {
+  try {
+    const res = await api('/version');
+    if (!__versionBaseline) { __versionBaseline = res; return; }
+    if (res.boot_time !== __versionBaseline.boot_time) {
+      console.info('[hu-board] server restart detected, reloading...');
+      window.forceRefresh();
+    }
+  } catch (_) { /* network blip; try next tick */ }
+}
+setInterval(pollServerVersion, 30_000);
+pollServerVersion();
+
+// Manual escape hatch: bound to the 🔄 button in the header. Wipes all
+// caches the browser may be holding (Cache API + sessionStorage) and
+// hard-reloads. Useful when the user thinks something is wrong even
+// though the version-poll hasn't fired.
+window.forceRefresh = async function forceRefresh() {
+  try {
+    if ('caches' in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+    sessionStorage.clear();
+  } catch (_) { /* best effort */ }
+  window.location.reload();
+};

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -34,6 +34,7 @@
         <button class="control-btn" id="commands-btn" title="Launch a Karajan CLI command (kj plan, kj architect, kj clean…)">⚡</button>
         <button class="control-btn" id="restart-btn" title="Restart the HU Board server (preserves URL, the page reconnects automatically)">🔁</button>
         <button class="control-btn" id="sync-btn" title="Re-scan disk for new batches">🔄</button>
+        <button class="control-btn" id="force-refresh-btn" title="Force a clean reload — wipes browser caches and reloads. Use when the UI looks stale and a normal refresh isn't fixing it." onclick="window.forceRefresh()">🧹</button>
       </div>
     </nav>
   </header>

--- a/packages/hu-board/src/boot-info.js
+++ b/packages/hu-board/src/boot-info.js
@@ -1,0 +1,16 @@
+/**
+ * Process-scoped boot info (KJC-TSK-0379).
+ *
+ * BOOT_TIME is captured at module load and exposed via /api/version so
+ * the client can detect server restarts and trigger a reload. Lives in
+ * its own module to avoid the server.js ↔ routes/api.js import cycle.
+ */
+
+import { createRequire } from 'node:module';
+
+export const BOOT_TIME = new Date().toISOString();
+
+const require = createRequire(import.meta.url);
+export const PKG_VERSION = (() => {
+  try { return require('../package.json').version; } catch { return 'unknown'; }
+})();

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -24,8 +24,20 @@ import { subscribe as subscribeEvents } from '../event-bus.js';
 import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
 import { readConfig, writeConfigPatch } from '../config-yaml.js';
+import { BOOT_TIME, PKG_VERSION } from '../boot-info.js';
 
 const router = Router();
+
+/**
+ * GET /api/version - Server version + boot timestamp.
+ * The client polls this every 30s; if `boot_time` differs from the first
+ * response, the server restarted and the client triggers a reload to pick
+ * up any new HTML/JS (KJC-TSK-0379).
+ */
+router.get('/version', (_req, res) => {
+  res.set('Cache-Control', 'no-store');
+  res.json({ version: PKG_VERSION, boot_time: BOOT_TIME });
+});
 
 /**
  * Resolve the hu-stories dir where batch.json files live.

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -30,6 +30,18 @@ const PID_FILE = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-bo
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = join(__dirname, '..', 'public');
 
+/**
+ * Cache-Control headers that tell the browser to revalidate every fetch.
+ * Applied to HTML / JS / CSS so a server restart can't be hidden by stale
+ * in-memory cache. Assets with content-hash in filename can override this
+ * later with `immutable` if we adopt a build step.
+ */
+function noStoreHeaders(res, filePath) {
+  if (/\.(html|js|css)$/i.test(filePath)) {
+    res.setHeader('Cache-Control', 'no-store, must-revalidate');
+  }
+}
+
 /** Default bind: loopback only. Override with BIND_HOST=0.0.0.0 (or any IP). */
 const DEFAULT_BIND_HOST = '127.0.0.1';
 
@@ -203,12 +215,13 @@ async function main() {
   const app = express();
   app.use(...buildSecurityMiddleware());
   app.use(express.json());
-  app.use(express.static(PUBLIC_DIR));
+  app.use(express.static(PUBLIC_DIR, { setHeaders: noStoreHeaders, etag: false, lastModified: false }));
   app.use('/api', buildRateLimiter(), authMiddleware(), apiRoutes);
   app.use('/api/pipeline', authMiddleware(), pipelineRoutes);
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {
+    res.setHeader('Cache-Control', 'no-store, must-revalidate');
     res.sendFile(join(PUBLIC_DIR, 'index.html'));
   });
 

--- a/packages/hu-board/tests/version.test.js
+++ b/packages/hu-board/tests/version.test.js
@@ -1,0 +1,99 @@
+/**
+ * KJC-TSK-0379 — server restart detection.
+ *
+ * Covers: /api/version returns version + boot_time; the route is not
+ * cached; the static-file middleware sets `Cache-Control: no-store`
+ * on .html / .js / .css; the SPA fallback sets the same.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import express from 'express';
+import request from 'supertest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PUBLIC_DIR = join(__dirname, '..', 'public');
+
+let tmpDir;
+let app;
+
+beforeAll(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-version-'));
+  process.env.KJ_HOME = tmpDir;
+
+  const dbMod = await import('../src/db.js');
+  dbMod.initDb();
+
+  const { default: apiRoutes } = await import('../src/routes/api.js');
+
+  // Replicate the exact mounting from server.js so the static-file +
+  // SPA-fallback headers tested below match production behaviour.
+  function noStoreHeaders(res, filePath) {
+    if (/\.(html|js|css)$/i.test(filePath)) {
+      res.setHeader('Cache-Control', 'no-store, must-revalidate');
+    }
+  }
+  app = express();
+  app.use(express.json());
+  app.use(express.static(PUBLIC_DIR, { setHeaders: noStoreHeaders, etag: false, lastModified: false }));
+  app.use('/api', apiRoutes);
+  app.get('/{*splat}', (_req, res) => {
+    res.setHeader('Cache-Control', 'no-store, must-revalidate');
+    res.sendFile(join(PUBLIC_DIR, 'index.html'));
+  });
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe('/api/version', () => {
+  it('returns { version, boot_time } as JSON', async () => {
+    const r = await request(app).get('/api/version').expect(200);
+    expect(r.body).toMatchObject({
+      version: expect.any(String),
+      boot_time: expect.any(String),
+    });
+    expect(new Date(r.body.boot_time).toString()).not.toBe('Invalid Date');
+  });
+
+  it('serves the same boot_time on repeated calls (process-scoped, not per-request)', async () => {
+    const r1 = await request(app).get('/api/version').expect(200);
+    const r2 = await request(app).get('/api/version').expect(200);
+    expect(r2.body.boot_time).toBe(r1.body.boot_time);
+  });
+
+  it('responds with Cache-Control: no-store so the browser never serves a stale boot_time', async () => {
+    const r = await request(app).get('/api/version').expect(200);
+    expect(r.headers['cache-control']).toMatch(/no-store/);
+  });
+});
+
+describe('Static file Cache-Control', () => {
+  it('serves index.html with no-store + must-revalidate', async () => {
+    const r = await request(app).get('/index.html').expect(200);
+    expect(r.headers['cache-control']).toMatch(/no-store/);
+    expect(r.headers['cache-control']).toMatch(/must-revalidate/);
+  });
+
+  it('serves /app.js with no-store + must-revalidate', async () => {
+    const r = await request(app).get('/app.js').expect(200);
+    expect(r.headers['cache-control']).toMatch(/no-store/);
+  });
+
+  it('serves the SPA fallback (any unknown route) with no-store too', async () => {
+    const r = await request(app).get('/some-spa-route').expect(200);
+    expect(r.headers['cache-control']).toMatch(/no-store/);
+    // body should be the index.html
+    expect(r.text).toContain('Karajan HU Board');
+  });
+
+  it('does NOT send an ETag for static files (would let conditional requests bypass no-store)', async () => {
+    const r = await request(app).get('/app.js').expect(200);
+    expect(r.headers.etag).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problema

Tras matar el server del HU Board (\`kj board stop\` o kill directo) y reiniciarlo, el navegador seguía mostrando UI stale durante minutos. La página parecía colgada o mostraba estados zombi (proyectos viejos, modales sin razón). Workaround actual: cerrar todas las pestañas + DevTools → Application → Clear Site Data + reload.

Causa raíz: \`express.static()\` se montaba sin opciones, dejando los headers Cache-Control por defecto + ETag activo. El navegador cacheaba HTML/JS agresivamente. No había endpoint de versionado, así que el cliente no podía detectar que el server había rearrancado.

Reportado durante dogfooding del proyecto Equipazgo (KJC-BUG-0038, KJC-BUG-0039).

## Solución

Cuatro piezas, todas pequeñas:

1. **Headers cache-busters**. \`express.static\` con \`setHeaders\` que emite \`Cache-Control: no-store, must-revalidate\` para \`.html / .js / .css\`. \`etag: false\` y \`lastModified: false\` para que tampoco haya revalidación condicional. Mismo header en el SPA fallback.

2. **\`GET /api/version\`** devuelve \`{ version, boot_time }\`. \`boot_time\` se captura una vez al arranque del proceso (en \`src/boot-info.js\`, módulo separado para evitar ciclo \`server.js\` ↔ \`routes/api.js\`).

3. **Polling cliente**. \`app.js\` llama \`/api/version\` cada 30 s. La primera respuesta ancla el baseline; si \`boot_time\` cambia, el server rearrancó → \`forceRefresh()\`.

4. **Escape hatch manual**. Botón 🧹 en el header (\`public/index.html\`) ejecuta \`forceRefresh()\` que limpia \`caches\` + \`sessionStorage\` + \`location.reload()\`. Visible siempre, para los casos en que el polling todavía no ha disparado pero el usuario ve algo raro.

## Archivos

| Archivo | Líneas |
| --- | --- |
| \`packages/hu-board/src/boot-info.js\` (NEW) | +16 |
| \`packages/hu-board/src/server.js\` | +14 / -1 |
| \`packages/hu-board/src/routes/api.js\` | +12 |
| \`packages/hu-board/public/app.js\` | +35 |
| \`packages/hu-board/public/index.html\` | +1 |
| \`packages/hu-board/tests/version.test.js\` (NEW) | +99 |
| **Total** | **+177 / -1 LOC** |

Bajo el budget de 200 LOC ✓.

## Tests

7 nuevos en \`tests/version.test.js\`:
- \`/api/version\` devuelve JSON con shape correcta
- \`boot_time\` es estable entre llamadas (process-scoped)
- \`Cache-Control: no-store\` en \`/api/version\`
- \`/index.html\` con \`no-store, must-revalidate\`
- \`/app.js\` con \`no-store\`
- SPA fallback (ruta desconocida) con \`no-store\`
- ETag desactivado para estáticos

Suite total: **4522/4522 passing**.

## Notas

- No introduce Service Worker. El HU Board es un dashboard de admin sin necesidad real de offline; añadir SW + Workbox metería más complejidad de la que arregla. Si en el futuro se quiere offline, este parche no estorba.
- \`KJC-BUG-0038\` (pop-up zombi) probablemente queda absorbida por este fix — el modal era un fallback de error UI cuando el frontend cacheado intentaba reconectar a un server muerto.

## Test plan

- [x] \`npm test\` — 4522/4522 verde
- [ ] Manual: \`kj board start\` → abrir \`localhost:4000\` → en otra terminal \`kj board stop\` + \`kj board start\` → en ≤30 s la pestaña se recarga sola
- [ ] Manual: forzar inconsistencia visual → click 🧹 → recarga limpia

## Related

- KJC-TSK-0379 (este)
- KJC-BUG-0038 / KJC-BUG-0039 (mismo síntoma desde otra cara)