### PR TITLE
feat(hu-board): tombstones — delete persistente que sobrevive a fullScan (KJC-TSK-0380)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -114,10 +114,26 @@ export function initDb() {
       answered_at TEXT
     );
 
+    -- KJC-TSK-0380 — Tombstones: "deleted, do not resurrect".
+    -- The board's data is reconstructed from the filesystem on every
+    -- fullScan(), so a plain DELETE from the table is silently undone
+    -- the next time chokidar fires. The tombstone table holds the ids
+    -- the user explicitly killed; sync* functions check it before any
+    -- upsert and skip + clean fs paths.
+    CREATE TABLE IF NOT EXISTS tombstones (
+      resource_type TEXT NOT NULL,
+      resource_id   TEXT NOT NULL,
+      deleted_at    TEXT NOT NULL,
+      source        TEXT NOT NULL,
+      fs_paths      TEXT,
+      PRIMARY KEY (resource_type, resource_id)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_stories_project ON stories(project_id);
     CREATE INDEX IF NOT EXISTS idx_stories_status ON stories(status);
     CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
     CREATE INDEX IF NOT EXISTS idx_context_story ON context_requests(story_id);
+    CREATE INDEX IF NOT EXISTS idx_tombstones_deleted_at ON tombstones(deleted_at);
   `);
 
   // --- Migrations ---
@@ -561,6 +577,44 @@ export function deleteSession(sessionId) {
   const db = getDb();
   const res = db.prepare('DELETE FROM sessions WHERE id = ?').run(sessionId);
   return res.changes > 0;
+}
+
+// --- Tombstones (KJC-TSK-0380) ---------------------------------------
+// "This (resource_type, resource_id) is dead — don't bring it back." The
+// sync layer consults this table BEFORE every upsert and skips records
+// whose id is buried. Restoration is explicit via removeTombstone().
+
+export function addTombstone(resourceType, resourceId, opts = {}) {
+  getDb().prepare(`
+    INSERT OR REPLACE INTO tombstones (resource_type, resource_id, deleted_at, source, fs_paths)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(
+    resourceType, resourceId,
+    new Date().toISOString(),
+    opts.source || 'api',
+    opts.fsPaths ? JSON.stringify(opts.fsPaths) : null,
+  );
+}
+
+export function isTombstoned(resourceType, resourceId) {
+  return !!getDb().prepare(
+    'SELECT 1 FROM tombstones WHERE resource_type = ? AND resource_id = ? LIMIT 1'
+  ).get(resourceType, resourceId);
+}
+
+export function removeTombstone(resourceType, resourceId) {
+  return getDb().prepare(
+    'DELETE FROM tombstones WHERE resource_type = ? AND resource_id = ?'
+  ).run(resourceType, resourceId).changes > 0;
+}
+
+export function listTombstones() {
+  return getDb().prepare(
+    'SELECT resource_type, resource_id, deleted_at, source, fs_paths FROM tombstones ORDER BY deleted_at DESC'
+  ).all().map((row) => ({
+    ...row,
+    fs_paths: row.fs_paths ? JSON.parse(row.fs_paths) : [],
+  }));
 }
 
 /**

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -25,6 +25,8 @@ import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
 import { readConfig, writeConfigPatch } from '../config-yaml.js';
 import { BOOT_TIME, PKG_VERSION } from '../boot-info.js';
+import { addTombstone, getDb, isTombstoned as isTombstonedFn } from '../db.js';
+import { publish as publishEvent } from '../event-bus.js';
 
 const router = Router();
 
@@ -324,10 +326,59 @@ router.get('/sessions', (_req, res) => {
  */
 router.delete('/projects/:id', (req, res) => {
   try {
-    const existed = deleteProject(req.params.id);
+    const id = req.params.id;
+    // Gather filesystem paths to remove BEFORE deleting DB rows so we
+    // can stop the next sync from resurrecting anything.
+    const db = getDb();
+    const storyIds = db.prepare('SELECT id FROM stories WHERE project_id = ?').all(id).map((r) => r.id);
+    const sessionIds = db.prepare('SELECT id FROM sessions WHERE project_id = ?').all(id).map((r) => r.id);
+    const fsPaths = [
+      ...storyIds.map((sid) => path.join(huStoriesDir(), sid)),
+      ...sessionIds.map((sid) => path.join(getKjHome(), 'sessions', sid)),
+      path.join(getKjHome(), '..', '.kj', 'plans', id),
+    ];
+
+    const existed = deleteProject(id);
     if (!existed) return res.status(404).json({ error: 'Project not found' });
-    const dirRemoved = removeBatchDir(req.params.id);
-    res.json({ deleted: true, dirRemoved });
+
+    // Tombstone the project AND its children so chokidar / fullScan
+    // can't bring them back via syncStoryFile / syncSessionFile.
+    addTombstone('project', id, { source: 'api', fsPaths });
+    for (const sid of storyIds) addTombstone('story', sid, { source: 'api' });
+    for (const sid of sessionIds) addTombstone('session', sid, { source: 'api' });
+
+    // Best-effort fs cleanup; failure does NOT undo the tombstones.
+    let pathsRemoved = 0;
+    for (const p of fsPaths) {
+      try { fs.rmSync(p, { recursive: true, force: true }); pathsRemoved++; } catch { /* */ }
+    }
+    res.json({ deleted: true, pathsRemoved, tombstoned: 1 + storyIds.length + sessionIds.length });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * DELETE /api/prompts/:promptId - Discard a pending prompt the runner left
+ * behind (KJC-TSK-0380). Removes the RPC files from disk, tombstones the
+ * prompt id so a stale chokidar event can't recreate it, and emits a
+ * `prompt:resolved` event so all open boards close the modal.
+ */
+router.delete('/prompts/:promptId', (req, res) => {
+  try {
+    const promptId = req.params.promptId;
+    const dir = promptsDir();
+    const main = path.join(dir, `${promptId}.json`);
+    const answer = path.join(dir, `${promptId}.answer.json`);
+    let removed = 0;
+    for (const p of [main, answer]) {
+      try { fs.unlinkSync(p); removed++; } catch { /* missing is fine */ }
+    }
+    addTombstone('prompt', promptId, { source: 'api', fsPaths: [main, answer] });
+    // Re-use the same event the runner emits when answered, so any open
+    // modal in any connected board client closes itself.
+    publishEvent({ type: 'prompt-resolved', promptId });
+    res.json({ deleted: true, filesRemoved: removed });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -524,6 +575,13 @@ router.get('/prompts', (_req, res) => {
     const result = [];
     for (const name of entries) {
       if (!name.endsWith('.json') || name.endsWith('.answer.json')) continue;
+      const promptId = name.replace(/\.json$/, '');
+      // KJC-TSK-0380 — skip tombstoned prompts and clean their files.
+      if (isTombstonedFn('prompt', promptId)) {
+        try { fs.unlinkSync(path.join(dir, name)); } catch { /* */ }
+        try { fs.unlinkSync(path.join(dir, `${promptId}.answer.json`)); } catch { /* */ }
+        continue;
+      }
       try {
         const raw = fs.readFileSync(path.join(dir, name), 'utf-8');
         result.push(JSON.parse(raw));

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -1,6 +1,6 @@
 import { watch } from 'chokidar';
-import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { readFileSync, readdirSync, existsSync, statSync, rmSync } from 'node:fs';
+import { dirname, join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import {
   getKjHome,
@@ -9,8 +9,24 @@ import {
   upsertSession,
   insertContextRequest,
   getDb,
+  isTombstoned,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
+
+/**
+ * Skip + best-effort fs cleanup when the resource is tombstoned. Returns
+ * true if the caller should bail out (resource is dead).
+ *
+ * KJC-TSK-0380: without this, every fullScan/chokidar event resurrects
+ * resources the user already deleted via the API.
+ */
+function skipIfTombstoned(resourceType, resourceId, fsPathToRemove) {
+  if (!isTombstoned(resourceType, resourceId)) return false;
+  if (fsPathToRemove) {
+    try { rmSync(fsPathToRemove, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+  return true;
+}
 
 /**
  * Derive a human-readable project name from batch data.
@@ -106,6 +122,11 @@ function syncStoryFile(filePath) {
     const data = JSON.parse(raw);
     const sessionId = data.session_id || basename(join(filePath, '..'));
     const projectId = data.project_id || sessionId;
+
+    // Tombstone gate: if the project or its batch is buried, drop the
+    // file from disk and skip. Without this, fullScan resurrects them.
+    if (skipIfTombstoned('project', projectId, dirname(filePath))) return;
+    if (skipIfTombstoned('story', sessionId, dirname(filePath))) return;
 
     // Skip if this is a non-auto batch and an auto- version already exists.
     // Prevents duplicate projects when both auto-s_xxx/ and s_xxx/ exist.
@@ -207,6 +228,8 @@ function syncSessionFile(filePath) {
     const raw = readFileSync(filePath, 'utf-8');
     const data = JSON.parse(raw);
     const sessionId = data.id || basename(join(filePath, '..'));
+
+    if (skipIfTombstoned('session', sessionId, dirname(filePath))) return;
 
     // Resolve which project this session belongs to:
     //   1. If a plan / HU batch already created `auto-<sessionId>`, reuse it
@@ -315,6 +338,9 @@ export function syncPlanFile(filePath) {
     const projectId = data.projectDir
       ? deriveProjectIdFromDir(data.projectDir)
       : data.planId;
+
+    if (skipIfTombstoned('plan', data.planId, filePath)) return;
+    if (skipIfTombstoned('project', projectId, dirname(filePath))) return;
     // Human-friendly project name resolution order (most-specific first):
     //   1. plan.name explicitly set by the user / planner ("Linux Assistant
     //      Orchestrator" — preserved across renames done from the board).

--- a/packages/hu-board/tests/tombstones.test.js
+++ b/packages/hu-board/tests/tombstones.test.js
@@ -1,0 +1,167 @@
+/**
+ * KJC-TSK-0380 — Tombstones: "deleted, do not resurrect".
+ *
+ * Verifies the contract the rest of the board now relies on:
+ *  - addTombstone + isTombstoned + removeTombstone round-trip.
+ *  - sync functions (story/session/plan) bail out on tombstoned ids.
+ *  - DELETE /api/projects/:id tombstones the project AND its children.
+ *  - DELETE /api/prompts/:id tombstones the prompt and removes fs files.
+ *  - GET /api/prompts hides tombstoned prompts even if files remain.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+
+let tmpDir;
+let dbMod, syncMod;
+let app;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-tomb-'));
+  process.env.KJ_HOME = tmpDir;
+  process.env.KJ_PLANS_DIR = join(tmpDir, '.kj', 'plans');
+
+  // Vitest caches modules per test process; resetting per-test would be
+  // overkill, so we rely on a fresh KJ_HOME per test + closeDb at teardown.
+  dbMod = await import('../src/db.js');
+  dbMod.initDb();
+  syncMod = await import('../src/sync.js');
+
+  const { default: apiRoutes } = await import('../src/routes/api.js');
+  app = express();
+  app.use(express.json());
+  app.use('/api', apiRoutes);
+});
+
+afterEach(() => {
+  dbMod.closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+});
+
+// ---------- db-layer contract -------------------------------------------------
+
+describe('tombstones — db layer', () => {
+  it('addTombstone + isTombstoned + removeTombstone round-trip', () => {
+    expect(dbMod.isTombstoned('project', 'P1')).toBe(false);
+    dbMod.addTombstone('project', 'P1', { source: 'api', fsPaths: ['/x/y'] });
+    expect(dbMod.isTombstoned('project', 'P1')).toBe(true);
+    expect(dbMod.removeTombstone('project', 'P1')).toBe(true);
+    expect(dbMod.isTombstoned('project', 'P1')).toBe(false);
+  });
+
+  it('listTombstones returns rows with parsed fs_paths', () => {
+    dbMod.addTombstone('prompt', 'pr1', { fsPaths: ['/a', '/a.answer.json'] });
+    const rows = dbMod.listTombstones();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      resource_type: 'prompt',
+      resource_id: 'pr1',
+      fs_paths: ['/a', '/a.answer.json'],
+    });
+  });
+
+  it('addTombstone twice on the same id is idempotent (REPLACE)', () => {
+    dbMod.addTombstone('story', 's1');
+    dbMod.addTombstone('story', 's1', { source: 'auto-cleanup' });
+    expect(dbMod.listTombstones()).toHaveLength(1);
+    expect(dbMod.listTombstones()[0].source).toBe('auto-cleanup');
+  });
+});
+
+// ---------- sync layer respects tombstones -----------------------------------
+
+describe('tombstones — sync.* skip + cleanup', () => {
+  function writeStory(batchId, projectId, stories = []) {
+    const dir = join(tmpDir, 'hu-stories', batchId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'batch.json'), JSON.stringify({
+      id: batchId, session_id: batchId, project_id: projectId, stories,
+    }));
+  }
+  function writePlan(projectSlug, planId) {
+    const dir = join(tmpDir, '.kj', 'plans', projectSlug);
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, `plan-${planId}.json`);
+    writeFileSync(file, JSON.stringify({
+      version: 2, planId, projectDir: '/some/path', hus: [{ id: 'hu_1', title: 't' }],
+    }));
+    return file;
+  }
+
+  it('fullScan does NOT resurrect a tombstoned project', async () => {
+    writeStory('batch-1', 'proj-A');
+    dbMod.addTombstone('project', 'proj-A');
+    syncMod.fullScan();
+    expect(dbMod.getProjects().find((p) => p.id === 'proj-A')).toBeUndefined();
+  });
+
+  it('fullScan REMOVES the fs directory of a tombstoned story', () => {
+    writeStory('batch-2', 'proj-B');
+    const batchDir = join(tmpDir, 'hu-stories', 'batch-2');
+    dbMod.addTombstone('story', 'batch-2');
+    syncMod.fullScan();
+    expect(existsSync(batchDir)).toBe(false);
+  });
+
+  it('fullScan ignores a tombstoned plan and deletes its file', () => {
+    const planPath = writePlan('proj-slug', 'plan-xyz');
+    dbMod.addTombstone('plan', 'plan-xyz');
+    syncMod.fullScan();
+    expect(existsSync(planPath)).toBe(false);
+  });
+});
+
+// ---------- DELETE endpoints behaviour ---------------------------------------
+
+describe('tombstones — DELETE endpoints', () => {
+  it('DELETE /api/projects/:id tombstones project + its stories + sessions, removes fs paths', async () => {
+    dbMod.upsertProject({ id: 'proj-X', name: 'X' });
+    dbMod.upsertStory({ id: 'st-X-1', project_id: 'proj-X', status: 'pending' });
+    dbMod.upsertSession({ id: 'sess-X-1', project_id: 'proj-X', status: 'running' });
+    mkdirSync(join(tmpDir, 'hu-stories', 'st-X-1'), { recursive: true });
+    mkdirSync(join(tmpDir, 'sessions', 'sess-X-1'), { recursive: true });
+
+    const r = await request(app).delete('/api/projects/proj-X').expect(200);
+    expect(r.body).toMatchObject({ deleted: true });
+    expect(dbMod.isTombstoned('project', 'proj-X')).toBe(true);
+    expect(dbMod.isTombstoned('story', 'st-X-1')).toBe(true);
+    expect(dbMod.isTombstoned('session', 'sess-X-1')).toBe(true);
+    expect(existsSync(join(tmpDir, 'hu-stories', 'st-X-1'))).toBe(false);
+    expect(existsSync(join(tmpDir, 'sessions', 'sess-X-1'))).toBe(false);
+  });
+
+  it('DELETE /api/projects/:id returns 404 when the project does not exist', async () => {
+    await request(app).delete('/api/projects/missing').expect(404);
+    expect(dbMod.isTombstoned('project', 'missing')).toBe(false);
+  });
+
+  it('DELETE /api/prompts/:id removes fs files + tombstones', async () => {
+    const promptsRoot = join(tmpDir, 'prompts');
+    mkdirSync(promptsRoot, { recursive: true });
+    writeFileSync(join(promptsRoot, 'pr-1.json'), JSON.stringify({ promptId: 'pr-1', question: 'q' }));
+    writeFileSync(join(promptsRoot, 'pr-1.answer.json'), '{}');
+
+    const r = await request(app).delete('/api/prompts/pr-1').expect(200);
+    expect(r.body).toMatchObject({ deleted: true, filesRemoved: 2 });
+    expect(dbMod.isTombstoned('prompt', 'pr-1')).toBe(true);
+    expect(existsSync(join(promptsRoot, 'pr-1.json'))).toBe(false);
+  });
+
+  it('GET /api/prompts hides tombstoned prompts even if the .json file is still on disk', async () => {
+    const promptsRoot = join(tmpDir, 'prompts');
+    mkdirSync(promptsRoot, { recursive: true });
+    writeFileSync(join(promptsRoot, 'pr-zombi.json'), JSON.stringify({ promptId: 'pr-zombi', question: 'q' }));
+    dbMod.addTombstone('prompt', 'pr-zombi');
+
+    const r = await request(app).get('/api/prompts').expect(200);
+    expect(r.body.find((p) => p.promptId === 'pr-zombi')).toBeUndefined();
+    // And the file was cleaned up as a side effect of the listing
+    expect(readdirSync(promptsRoot).filter((n) => n === 'pr-zombi.json')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problema (causa raíz)

El HU Board reconstruye la DB SQLite desde el filesystem (\`~/.karajan/\` + \`~/.kj/plans/\`) en cada \`fullScan\` y en cada evento de chokidar. La DB es **caché**, el filesystem es **source-of-truth**. Consecuencia silenciosa: un \`DELETE\` por API a la DB se revierte al siguiente sync porque el archivo sigue ahí.

Síntoma vivido durante dogfooding de Equipazgo (2026-05-10):
- 18 proyectos zombi del 2026-05-07 reaparecen aunque borre la DB con sqlite3.
- Modal \"Karajan needs an answer\" bloqueante de un runner del 7 de mayo persiste 3 días después.
- Tras \`kj board start\`, el navegador ve los zombis OTRA vez.

Ver KJC-BUG-0038 (modal zombi) y KJC-BUG-0039 (UI stale).

## Solución

Tabla nueva \`tombstones (resource_type, resource_id, deleted_at, source, fs_paths)\` con clave primaria compuesta. Registra los ids que el usuario **enterró** explícitamente. Los syncs consultan la tombstone ANTES de upsert; si está → \`rm -rf\` del path del filesystem y \`return\`.

Patrón clásico de BBDD distribuidas (Cassandra, Riak). Permanentes por decisión de producto. Restauración explícita vía \`removeTombstone()\` (la PR B añadirá el endpoint HTTP).

## Archivos

| Archivo | Cambio |
| --- | --- |
| \`packages/hu-board/src/db.js\` | Tabla + índice + 4 funciones (\`addTombstone\`, \`isTombstoned\`, \`removeTombstone\`, \`listTombstones\`). Migración idempotente en \`initDb()\`. |
| \`packages/hu-board/src/sync.js\` | Helper \`skipIfTombstoned()\` llamado al inicio de \`syncStoryFile\`, \`syncSessionFile\`, \`syncPlanFile\`. \`rm -rf\` del archivo si tombstone existe. |
| \`packages/hu-board/src/routes/api.js\` | \`DELETE /api/projects/:id\` refuerza (tombstones project + stories + sessions + rm -rf fs); \`DELETE /api/prompts/:id\` (NUEVO); \`GET /api/prompts\` filtra tombstoned + limpia ficheros huérfanos. |
| \`packages/hu-board/tests/tombstones.test.js\` (NEW) | 10 tests: db round-trip, listTombstones, fullScan respect, fs cleanup, DELETE project cascade, DELETE prompt, GET prompts filter. |

## LOC

310 (excede el budget 200). **Justificación**: cambio atómico — la tabla sin endpoints no sirve, los endpoints sin integración en sync se revierten, los tests cubren la combinación. Partir en piezas menores deja PRs sin valor entregable. Label \`large-pr-justified\` aplicado.

## Tests

10 nuevos en \`tests/tombstones.test.js\`. Suite total **4522/4522 verde**.

Casos cubiertos:
- \`addTombstone\` / \`isTombstoned\` / \`removeTombstone\` round-trip
- \`listTombstones\` parsea \`fs_paths\`
- \`addTombstone\` es idempotente (INSERT OR REPLACE)
- \`fullScan\` NO resucita un proyecto tombstoned
- \`fullScan\` BORRA el directorio fs de un story tombstoned
- \`fullScan\` ignora un plan tombstoned y borra su archivo
- \`DELETE /api/projects/:id\` tombstones project + stories + sessions y borra fs paths
- \`DELETE /api/projects/:id\` devuelve 404 si no existe
- \`DELETE /api/prompts/:id\` borra fs files y tombstones
- \`GET /api/prompts\` esconde tombstoned y limpia ficheros sueltos

## Lo que NO incluye (planeado en PRs siguientes)

- **PR B**: DELETE para stories, sessions, plans + endpoints \`POST /api/tombstones/:type/:id/restore\` + \`GET /api/tombstones\`.
- **PR C**: \`scripts/cleanup-zombies.mjs\` + comando \`kj board cleanup\` para limpiar los 18 zombis retroactivamente.

## Test plan manual

- [x] \`npm test\` — 4522/4522 verde
- [ ] Tras merge: \`kj board start\` → \`DELETE\` un proyecto vía DevTools (\`fetch('/api/projects/X', {method:'DELETE'})\`) → \`kj board stop\` + \`kj board start\` → verificar que el proyecto NO vuelve a aparecer.

## Related

- KJC-TSK-0380 (este)
- KJC-BUG-0038 / KJC-BUG-0039 (resueltos en root cause)