### PR TITLE
feat(hu-board): tombstones B — DELETE story/session/plan + restore + list (KJC-TSK-0380)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -25,7 +25,7 @@ import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
 import { readConfig, writeConfigPatch } from '../config-yaml.js';
 import { BOOT_TIME, PKG_VERSION } from '../boot-info.js';
-import { addTombstone, getDb, isTombstoned as isTombstonedFn } from '../db.js';
+import { addTombstone, getDb, isTombstoned as isTombstonedFn, removeTombstone, listTombstones } from '../db.js';
 import { publish as publishEvent } from '../event-bus.js';
 
 const router = Router();
@@ -385,28 +385,100 @@ router.delete('/prompts/:promptId', (req, res) => {
 });
 
 /**
- * DELETE /api/stories/:id - Delete a single story from DB.
- * The underlying batch.json is not mutated (story survives on disk and will
- * be re-imported on next sync). This endpoint is a DB-only soft hide.
+ * DELETE /api/stories/:id - Delete a single story.
+ *
+ * Tombstones the story (KJC-TSK-0380) and removes its batch directory
+ * from `~/.karajan/hu-stories/<id>/` so the next sync does NOT re-import
+ * it. Pre-tombstones this endpoint was a DB-only soft hide that the next
+ * chokidar event undid silently.
  */
 router.delete('/stories/:id', (req, res) => {
   try {
-    const ok = deleteStory(req.params.id);
+    const id = req.params.id;
+    const dir = path.join(huStoriesDir(), id);
+    const ok = deleteStory(id);
     if (!ok) return res.status(404).json({ error: 'Story not found' });
-    res.json({ deleted: true });
+    addTombstone('story', id, { source: 'api', fsPaths: [dir] });
+    let dirRemoved = false;
+    try { fs.rmSync(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
+    res.json({ deleted: true, dirRemoved });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
 /**
- * DELETE /api/sessions/:id - Delete a single session from DB.
+ * DELETE /api/sessions/:id - Delete a single session.
+ *
+ * Tombstones + removes `~/.karajan/sessions/<id>/` (KJC-TSK-0380).
  */
 router.delete('/sessions/:id', (req, res) => {
   try {
-    const ok = deleteSession(req.params.id);
+    const id = req.params.id;
+    const dir = path.join(getKjHome(), 'sessions', id);
+    const ok = deleteSession(id);
     if (!ok) return res.status(404).json({ error: 'Session not found' });
-    res.json({ deleted: true });
+    addTombstone('session', id, { source: 'api', fsPaths: [dir] });
+    let dirRemoved = false;
+    try { fs.rmSync(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
+    res.json({ deleted: true, dirRemoved });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * DELETE /api/plans/:planId - Delete a single plan file.
+ *
+ * Removes `~/.kj/plans/<projectSlug>/plan-<planId>.json` and tombstones
+ * the plan id so the next watcher event doesn't re-sync it. Does NOT
+ * delete the project: a project can have multiple plans, deleting one
+ * plan only removes that plan's HUs from the board.
+ */
+router.delete('/plans/:planId', (req, res) => {
+  try {
+    const planId = req.params.planId;
+    // Locate the plan file by scanning the plans dir for filename match.
+    const plansRoot = process.env.KJ_PLANS_DIR || path.join(getKjHome(), '..', '.kj', 'plans');
+    let foundPath = null;
+    try {
+      for (const projSlug of fs.readdirSync(plansRoot)) {
+        const candidate = path.join(plansRoot, projSlug, `plan-${planId}.json`);
+        if (fs.existsSync(candidate)) { foundPath = candidate; break; }
+      }
+    } catch { /* plansRoot missing */ }
+    addTombstone('plan', planId, { source: 'api', fsPaths: foundPath ? [foundPath] : [] });
+    if (foundPath) { try { fs.unlinkSync(foundPath); } catch { /* */ } }
+    res.json({ deleted: true, fileRemoved: !!foundPath });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/tombstones - List every active tombstone for diagnostics.
+ *
+ * Returns rows ordered by deleted_at DESC; useful for the diagnostics
+ * pane and for the cleanup script (KJC-TSK-0380 PR-C).
+ */
+router.get('/tombstones', (_req, res) => {
+  try {
+    res.json(listTombstones());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/tombstones/:type/:id/restore - Bring a buried id back to
+ * life. The next sync will then re-import the resource if its filesystem
+ * source still exists. Idempotent: returns false when nothing to remove.
+ */
+router.post('/tombstones/:type/:id/restore', (req, res) => {
+  try {
+    const removed = removeTombstone(req.params.type, req.params.id);
+    if (!removed) return res.status(404).json({ error: 'Tombstone not found' });
+    res.json({ restored: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/tombstones.test.js
+++ b/packages/hu-board/tests/tombstones.test.js
@@ -164,4 +164,64 @@ describe('tombstones — DELETE endpoints', () => {
     // And the file was cleaned up as a side effect of the listing
     expect(readdirSync(promptsRoot).filter((n) => n === 'pr-zombi.json')).toHaveLength(0);
   });
+
+  // ---------- PR B endpoints (story / session / plan / restore / list) ------
+
+  it('DELETE /api/stories/:id tombstones + removes its batch dir', async () => {
+    dbMod.upsertStory({ id: 'st-1', project_id: 'p1', status: 'pending' });
+    const dir = join(tmpDir, 'hu-stories', 'st-1');
+    mkdirSync(dir, { recursive: true });
+
+    const r = await request(app).delete('/api/stories/st-1').expect(200);
+    expect(r.body).toMatchObject({ deleted: true, dirRemoved: true });
+    expect(dbMod.isTombstoned('story', 'st-1')).toBe(true);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('DELETE /api/sessions/:id tombstones + removes its session dir', async () => {
+    dbMod.upsertSession({ id: 'sess-1', project_id: 'p1', status: 'running' });
+    const dir = join(tmpDir, 'sessions', 'sess-1');
+    mkdirSync(dir, { recursive: true });
+
+    const r = await request(app).delete('/api/sessions/sess-1').expect(200);
+    expect(r.body).toMatchObject({ deleted: true, dirRemoved: true });
+    expect(dbMod.isTombstoned('session', 'sess-1')).toBe(true);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('DELETE /api/plans/:planId tombstones + removes the plan file (not the project)', async () => {
+    const planDir = join(tmpDir, '.kj', 'plans', 'my-proj');
+    mkdirSync(planDir, { recursive: true });
+    const planFile = join(planDir, 'plan-xyz.json');
+    writeFileSync(planFile, JSON.stringify({ version: 2, planId: 'xyz', hus: [] }));
+
+    const r = await request(app).delete('/api/plans/xyz').expect(200);
+    expect(r.body).toMatchObject({ deleted: true, fileRemoved: true });
+    expect(dbMod.isTombstoned('plan', 'xyz')).toBe(true);
+    expect(existsSync(planFile)).toBe(false);
+  });
+
+  it('GET /api/tombstones lists every active tombstone newest first', async () => {
+    dbMod.addTombstone('project', 'old-proj', { source: 'api' });
+    await new Promise((r) => setTimeout(r, 5));
+    dbMod.addTombstone('prompt', 'recent-prompt', { source: 'api' });
+
+    const r = await request(app).get('/api/tombstones').expect(200);
+    expect(r.body).toHaveLength(2);
+    expect(r.body[0].resource_id).toBe('recent-prompt');
+    expect(r.body[1].resource_id).toBe('old-proj');
+  });
+
+  it('POST /api/tombstones/:type/:id/restore removes the tombstone', async () => {
+    dbMod.addTombstone('project', 'to-restore');
+    expect(dbMod.isTombstoned('project', 'to-restore')).toBe(true);
+
+    const r = await request(app).post('/api/tombstones/project/to-restore/restore').expect(200);
+    expect(r.body).toMatchObject({ restored: true });
+    expect(dbMod.isTombstoned('project', 'to-restore')).toBe(false);
+  });
+
+  it('POST /api/tombstones/.../restore returns 404 when tombstone does not exist', async () => {
+    await request(app).post('/api/tombstones/project/never-buried/restore').expect(404);
+  });
 });


### PR DESCRIPTION
## Summary

Continuación de #655. Completa los endpoints DELETE que faltaban (story / session / plan) reforzándolos con tombstone + cleanup de filesystem, y añade gestión de tombstones por API.

## Endpoints añadidos / reforzados

| Endpoint | Cambio |
| --- | --- |
| \`DELETE /api/stories/:id\` | Refuerzo: ahora tombstone + \`rm -rf ~/.karajan/hu-stories/<id>/\`. Antes era DB-only que el sync revertía. |
| \`DELETE /api/sessions/:id\` | Refuerzo: tombstone + \`rm -rf ~/.karajan/sessions/<id>/\`. |
| \`DELETE /api/plans/:planId\` | **NUEVO**. Escanea \`~/.kj/plans/<slug>/plan-<id>.json\` y lo borra. Tombstone del planId (NO del proyecto — un proyecto puede tener N planes). |
| \`GET /api/tombstones\` | **NUEVO**. Lista todas las activas (newest first) con \`fs_paths\` parseado. Útil para diagnóstico y para el script de cleanup (PR C). |
| \`POST /api/tombstones/:type/:id/restore\` | **NUEVO**. Revive un id enterrado. Idempotente; 404 si no existe. |

## LOC

150 (bajo budget 200).

## Tests

+6 nuevos (16 totales en \`tests/tombstones.test.js\`). Suite total **4522/4522 verde**.

Casos añadidos:
- \`DELETE /api/stories/:id\` tombstones + borra dir
- \`DELETE /api/sessions/:id\` tombstones + borra dir
- \`DELETE /api/plans/:planId\` borra archivo (no el proyecto)
- \`GET /api/tombstones\` ordena por \`deleted_at DESC\`
- \`POST /tombstones/.../restore\` quita la tombstone
- 404 cuando se intenta restaurar algo no enterrado

## Related

- KJC-TSK-0380 (este, continuación de #655)
- Siguiente: PR C — \`scripts/cleanup-zombies.mjs\` + \`kj board cleanup\` para limpieza retroactiva.