### PR TITLE
fix(hu-board): modal transparente + icono ☐ feo del empty-state

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1116,7 +1116,6 @@ function renderSessionCard(session) {
 function renderEmptyState(title, text) {
   return `
     <div class="empty-state">
-      <div class="empty-state__icon">&#9744;</div>
       <div class="empty-state__title">${title || 'No data yet'}</div>
       <div class="empty-state__text">${text || 'HU stories and sessions will appear here as Karajan processes them.'}</div>
       <div class="empty-state__path">~/.karajan/hu-stories/</div>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -6,6 +6,12 @@
 
 :root {
   --bg-primary: #0a0e1a;
+  /* --bg-secondary was referenced from app.js (modal backgrounds, inputs,
+     code blocks) but never declared, so it fell back to `transparent` and
+     made the prompt modal show cards bleeding through. Anchored to a
+     slightly lighter shade than --bg-card so layered surfaces stay
+     visually distinct. */
+  --bg-secondary: #131a30;
   --bg-card: #0f1425;
   --bg-card-hover: #141a30;
   --border: #1e2740;
@@ -781,12 +787,6 @@ a:hover {
   text-align: center;
   padding: 60px 20px;
   color: var(--text-muted);
-}
-
-.empty-state__icon {
-  font-size: 3rem;
-  margin-bottom: 16px;
-  opacity: 0.4;
 }
 
 .empty-state__title {


### PR DESCRIPTION
## Problemas

Dos bugs visuales reportados durante dogfooding del 2026-05-10:

1. **Modal del prompt es transparente** — las cards del board se ven detrás del modal. Pasaba con \`ensureDialog()\` (modal del prompt 'Karajan needs an answer'), \`prompt-answer\` textarea, los inputs de edición de HUs, y otros 8 sitios.
2. **Empty-state muestra ☐** — un cuadrado vacío Unicode (U+2610) sin estilo coherente con el board.

## Causas raíz

| Bug | Causa |
| --- | --- |
| Modal transparente | \`var(--bg-secondary)\` referenciada en 8 sitios de \`app.js\` pero **NUNCA declarada en \`:root\`**. Las CSS vars no resueltas caen a \`transparent\`. |
| ☐ feo | Hardcodeado como \`<div class=\"empty-state__icon\">&#9744;</div>\` en \`renderEmptyState()\`. |

## Fix

- **\`styles.css\`**: declarar \`--bg-secondary: #131a30\` en \`:root\` (ligeramente más claro que \`--bg-card #0f1425\` para mantener jerarquía visual de capas). Una sola línea arregla los 8 sitios automáticamente.
- **\`app.js\`**: quitar el \`<div class=\"empty-state__icon\">&#9744;</div>\` de \`renderEmptyState()\`. El title + text + path ya transmiten \"no hay nada aún\".
- **\`styles.css\`**: eliminar la regla CSS \`.empty-state__icon\` huérfana.

## LOC

13 (bajo budget). \`styles.css\`: +6 / -6 (incluye comentario explicando por qué la var existe). \`app.js\`: -1.

## Tests

4522/4522 verde. Cambios visuales puros — ningún test E2E afectado.

## Test plan manual

- [x] \`npm test\` verde
- [ ] Tras merge: recarga el board → empty-state ya no muestra ☐, solo el title/text
- [ ] Abrir cualquier modal (Karajan needs answer / editar HU / configurar) → fondo opaco, no transparenta cards