### PR TITLE
fix(plan): no encadenar HUs por orden de aparición (KJC-BUG-0041)

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -105,24 +105,30 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   // the tests manually before executing.
   const { normaliseAcceptanceTests } = await import("../../plan/plan-schema.js");
   const steps = parsed?.steps || [];
-  let prevId = null;
   let stepsMissingTests = 0;
   for (const step of steps) {
     const desc = typeof step === "string" ? step : step.description || step.title || JSON.stringify(step);
     const rawTests = typeof step === "object" ? step.acceptance_tests : null;
     const tests = normaliseAcceptanceTests(rawTests);
     if (tests.length === 0) stepsMissingTests += 1;
-    const hu = addHu(plan, {
+    addHu(plan, {
       title: desc.slice(0, 80),
       task_type: classifyTaskType(desc),
       scope: desc,
-      blocked_by: prevId ? [prevId] : [],
+      // KJC-BUG-0041: never chain HUs by their order of appearance. The
+      // planner role doesn't model dependencies in its output schema; the
+      // pre-v2.13.1 code synthesised `blocked_by: [previousHuId]` for
+      // every HU, which produced a linear chain artefact and silently
+      // serialised parallelisable work. Real dependencies (when they
+      // exist in the user's spec text) are surfaced by the plan-reviewer
+      // pass as `order_issues`, and the user can promote them manually
+      // before `kj run --plan`.
+      blocked_by: [],
       acceptance_tests: tests,
       // Spec mapping (PR C): preserve the planner's section citation
       // so the coder/reviewer / board can show "implements §5.3".
       spec_section: typeof step === "object" && typeof step.spec_section === "string" ? step.spec_section.trim() || null : null,
     });
-    prevId = hu.id;
   }
   // Tests-synthesizer pass (v2.7.5): the first planner call asks for
   // acceptance_tests inline, but Claude / Codex frequently skip that

--- a/tests/plan-generate-no-chain.test.js
+++ b/tests/plan-generate-no-chain.test.js
@@ -1,0 +1,122 @@
+/**
+ * KJC-BUG-0041 — `kj plan generate` no debe encadenar HUs por orden
+ * de aparición. Pre-fix, el loop de `planGenerateImpl` rellenaba
+ * `blocked_by: [previousHuId]` para cada HU aunque el output del
+ * planner role NO modela dependencias. Resultado: cadena lineal
+ * artificial que serializaba todo el trabajo paralelizable.
+ *
+ * Este test bloquea la regresión: tras llamar al comando con un
+ * planner que devuelve N steps simples (sin deps en su output),
+ * todos los HUs del plan resultante deben tener `blocked_by: []`.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function loadOnlyPlan() {
+  const root = join(process.env.KJ_HOME, "plans");
+  const projectDirs = readdirSync(root);
+  for (const projDir of projectDirs) {
+    const projPath = join(root, projDir);
+    const files = readdirSync(projPath).filter((f) => f.startsWith("plan-") && f.endsWith(".json"));
+    if (files.length > 0) {
+      return JSON.parse(readFileSync(join(projPath, files[0]), "utf8"));
+    }
+  }
+  throw new Error("no plan written under KJ_HOME/plans");
+}
+
+vi.mock("../src/agents/index.js", () => ({ createAgent: vi.fn() }));
+vi.mock("../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../src/config.js", () => ({
+  resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || "claude" })),
+}));
+vi.mock("../src/prompts/planner.js", () => ({
+  buildPlannerPrompt: vi.fn().mockReturnValue("planner prompt"),
+}));
+
+const noopLogger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn(),
+};
+
+const sixSteps = JSON.stringify({
+  approach: "Build the foundation in six independent slices",
+  steps: [
+    { description: "Setup GCP project + Firebase", acceptance_tests: [{ type: "shell", content: "test 1" }] },
+    { description: "Enable GCIP multi-tenancy",     acceptance_tests: [{ type: "shell", content: "test 2" }] },
+    { description: "Create KMS keyring per org",    acceptance_tests: [{ type: "shell", content: "test 3" }] },
+    { description: "Wire CI/CD via GitHub Actions", acceptance_tests: [{ type: "shell", content: "test 4" }] },
+    { description: "Set up audit log collection",   acceptance_tests: [{ type: "shell", content: "test 5" }] },
+    { description: "Publish UI catalogue components", acceptance_tests: [{ type: "shell", content: "test 6" }] },
+  ],
+  risks: ["GCIP tenant limit"],
+  outOfScope: ["IA / RAG"],
+});
+
+let tmpHome;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-plan-no-chain-"));
+  process.env.KJ_HOME = tmpHome;
+  vi.resetAllMocks();
+
+  const agents = await import("../src/agents/index.js");
+  agents.createAgent.mockReturnValue({
+    runTask: vi.fn().mockResolvedValue({ ok: true, output: sixSteps, exitCode: 0 }),
+  });
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("KJC-BUG-0041 — planGenerate must NOT chain HUs by order", () => {
+  it("emits blocked_by: [] for every HU when the planner output declares no dependencies", async () => {
+    const { planGenerateCommand } = await import("../src/commands/plan/generate.js");
+    await planGenerateCommand({
+      task: "Build the foundation",
+      config: {
+        roles: { planner: { provider: "claude" } },
+        session: { max_iteration_minutes: 10 },
+        projectDir: tmpHome,
+      },
+      logger: noopLogger,
+      json: true,
+      flags: { yes: true, interactive: false, "no-tests-synth": true, "no-plan-review": true },
+    });
+
+    const plan = loadOnlyPlan();
+    expect(plan.hus).toHaveLength(6);
+    for (const hu of plan.hus) {
+      expect(hu.blocked_by).toEqual([]);
+    }
+  });
+
+  it("does NOT chain HUs by their order of appearance (no HU lists its predecessor as blocker)", async () => {
+    const { planGenerateCommand } = await import("../src/commands/plan/generate.js");
+    await planGenerateCommand({
+      task: "long plan",
+      config: {
+        roles: { planner: { provider: "claude" } },
+        session: { max_iteration_minutes: 10 },
+        projectDir: tmpHome,
+      },
+      logger: noopLogger,
+      json: true,
+      flags: { yes: true, interactive: false, "no-tests-synth": true, "no-plan-review": true },
+    });
+
+    const plan = loadOnlyPlan();
+    // Classic chain-artefact: blocked_by[i] === [hus[i-1].id]. We assert
+    // zero chained pairs — that's the strict regression invariant for
+    // KJC-BUG-0041.
+    const chained = plan.hus.slice(1).filter((hu, idx) => {
+      const prevId = plan.hus[idx].id;
+      return Array.isArray(hu.blocked_by) && hu.blocked_by.includes(prevId);
+    });
+    expect(chained, "no HU should declare its predecessor as a blocker").toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problema

\`kj plan generate\` produce planes donde cada HU declara \`blocked_by: [previousHuId]\` aunque el output del rol planner NO modela dependencias. Resultado: cadena lineal artificial que serializa todo el trabajo paralelizable.

Reproducido en dogfooding 2026-05-11 con un plan de 45 HUs (proyecto experimental). El plan-reviewer pass lo flageó textualmente:

> \"wrong order — cadena lineal artificial. UI-CAT-001..004 y COMP-001 no dependen unas de otras ni de INFRA-005.\"

Pero el reviewer **solo flagea, no corrige** — el plan se guardaba con las deps falsas y, ejecutado tal cual, aborta el sentido del paralelismo.

## Causa raíz

\`src/commands/plan/generate.js:108-126\` (pre-fix):

\`\`\`js
let prevId = null;
for (const step of steps) {
  const hu = addHu(plan, {
    // ...
    blocked_by: prevId ? [prevId] : [],   // ← BUG
  });
  prevId = hu.id;
}
\`\`\`

El planner role emite \`steps[]\` sin información de dependencias. Esta sintetización post-process atribuía dependencias inexistentes que el LLM nunca declaró.

## Fix

Eliminar el tracking de \`prevId\`. Toda HU se inicializa con \`blocked_by: []\`. Las dependencias reales (cuando existen en el spec del usuario) las detecta el plan-reviewer pass como \`order_issues\` y el usuario las promueve manualmente antes de \`kj run --plan\`.

## Files

- \`src/commands/plan/generate.js\` — 12 líneas (eliminar \`prevId\` tracking + reemplazar \`blocked_by\` por \`[]\` + comentario explicando por qué).
- \`tests/plan-generate-no-chain.test.js\` (NEW, 122 LOC) — 2 tests de regresión:
  - 6 HUs sin deps en el output del planner → todos \`blocked_by: []\`
  - Invariante estricta: ningún HU del plan declara su predecesor inmediato como blocker.

Total: 132 LOC.

## Tests

\`\`\`bash
$ npx vitest run tests/plan-generate-no-chain.test.js
Test Files  1 passed (1)
     Tests  2 passed (2)
\`\`\`

Suite total: **4524/4524 verde** (2 tests nuevos vs 4522 baseline).

## Impacto

- Cualquier \`kj plan generate\` futuro produce planes con paralelismo natural.
- Planes existentes quedan intactos (no migration); el usuario que tenga uno con la cadena vieja puede regenerar.
- El plan-reviewer sigue funcionando igual: detecta deps faltantes textualmente declaradas en el spec.

## Roadmap próximo

Cuando el reviewer detecte deps necesarias en el spec, **podría** sugerir el grafo correcto en lugar de solo flagear. Eso es card aparte (mejora del plan-reviewer-role para emitir `add_dependencies` aplicables automáticamente). El fix de hoy es la base para que esa mejora no entre en conflicto con la sintetización artificial vieja.

## Related

- KJC-BUG-0041 (este fix)
- Próximo paso: regenerar el plan v2 de Equipazgo con el bug ya corregido.