### PR TITLE
fix(sea): excluir hu-board del bundle (KJC-BUG-0040)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -19,7 +19,10 @@ const PKG_VERSION = JSON.parse(readFileSync(path.join(ROOT, "package.json"), "ut
 const seaTransformPlugin = {
   name: "sea-transform",
   setup(build) {
-    build.onLoad({ filter: /\.m?js$/ }, async (args) => {
+    // Only process real files. Imports redirected by hu-board-stub (or any
+    // other namespaced plugin) MUST not pass through this transform —
+    // their `args.path` is a virtual id, not a path readFile can open.
+    build.onLoad({ filter: /\.m?js$/, namespace: "file" }, async (args) => {
       let contents = await fs.readFile(args.path, "utf8");
       let modified = false;
 
@@ -86,6 +89,56 @@ const seaTransformPlugin = {
   }
 };
 
+/**
+ * Stub plugin for the HU Board package (KJC-BUG-0040).
+ *
+ * The HU Board lives in `packages/hu-board/` and requires `better-sqlite3`
+ * — a native node-gyp module that esbuild cannot resolve at bundle time
+ * (it has no JS entry point, only `.node` binaries compiled per platform).
+ *
+ * The SEA binary is the lean CLI distribution. Users who want the HU
+ * Board install via `npm install -g karajan-code`, which installs
+ * better-sqlite3 normally. So the right answer is: do NOT include
+ * `packages/hu-board/` in the SEA bundle at all.
+ *
+ * This plugin intercepts every import / dynamic import that points into
+ * `packages/hu-board/src/*` and rewrites it to a stub module that throws
+ * a clear, actionable error when invoked at runtime — instead of failing
+ * silently during bundling.
+ */
+const huBoardStubPlugin = {
+  name: "hu-board-stub",
+  setup(build) {
+    build.onResolve({ filter: /packages[\\/]hu-board[\\/]src[\\/].*/ }, (args) => ({
+      path: args.path,
+      namespace: "hu-board-stub",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "hu-board-stub" }, () => ({
+      contents: `
+        const NOT_AVAILABLE = "The HU Board is not available in this standalone binary.\\n" +
+          "Install karajan-code from npm to get the dashboard:\\n" +
+          "  npm install -g karajan-code\\n";
+        function notAvailable() { throw new Error(NOT_AVAILABLE); }
+        // Explicit named exports for every symbol the CLI imports from
+        // hu-board. Adding them by name (rather than relying on a Proxy)
+        // avoids esbuild's CJS↔ESM interop confusion: a Proxy that
+        // returns truthy for "__esModule" makes esbuild wrap the import
+        // and the destructured names resolve to undefined.
+        module.exports = {
+          __esModule: false,
+          initDb: notAvailable,
+          closeDb: notAvailable,
+          cleanupZombies: notAvailable,
+          // Catch-all default so \`import foo from\` and \`import * as foo\`
+          // also throw the same message instead of returning undefined.
+          default: notAvailable,
+        };
+      `,
+      loader: "js",
+    }));
+  },
+};
+
 /** @type {import('esbuild').BuildOptions} */
 export const seaBuildOptions = {
   entryPoints: ["src/cli.js"],
@@ -95,7 +148,12 @@ export const seaBuildOptions = {
   target: "node20",
   bundle: true,
   minify: false,
-  external: [],
-  plugins: [seaTransformPlugin],
+  // better-sqlite3 is a native module imported by packages/hu-board/src/db.js.
+  // The hu-board-stub plugin below replaces the whole hu-board package so
+  // this `external` entry is belt-and-braces — if any other dependency
+  // pulls better-sqlite3 in we want a clear "not bundled" error, not a
+  // silent half-bundle.
+  external: ["better-sqlite3"],
+  plugins: [seaTransformPlugin, huBoardStubPlugin],
   logLevel: "info",
 };

--- a/tests/sea-build.test.js
+++ b/tests/sea-build.test.js
@@ -1,0 +1,69 @@
+/**
+ * KJC-BUG-0040 — el SEA bundle de esbuild fallaba al intentar resolver
+ * `better-sqlite3` (módulo nativo, importado por packages/hu-board/src/db.js).
+ * Pre-fix, el workflow `release-binaries.yml` rompía desde v2.12.0 y no
+ * publicaba binarios standalone para ninguna release.
+ *
+ * Este test smokea el flujo entero:
+ *  1. `seaBuildOptions` produce un bundle sin errores.
+ *  2. El stub de hu-board reemplaza el código real (so the binary does
+ *     NOT carry better-sqlite3 / chokidar / etc native deps).
+ *  3. Invocar el bundle con `board cleanup` lanza el mensaje del stub
+ *     (en lugar de un crash de runtime opaco).
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let outDir;
+let bundlePath;
+
+beforeAll(async () => {
+  outDir = mkdtempSync(join(tmpdir(), "kj-sea-bundle-"));
+  bundlePath = join(outDir, "kj-bundle.cjs");
+
+  const { seaBuildOptions } = await import("../scripts/esbuild-sea.config.mjs");
+  const { build } = await import("esbuild");
+  const result = await build({ ...seaBuildOptions, outfile: bundlePath, logLevel: "silent" });
+  expect(result.errors).toHaveLength(0);
+}, 30_000);
+
+afterAll(() => {
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+describe("SEA bundle (KJC-BUG-0040)", () => {
+  it("bundles without resolving better-sqlite3 (native dep)", () => {
+    const code = readFileSync(bundlePath, "utf8");
+    // better-sqlite3 is marked external + reached only via the hu-board
+    // stub, so the bundled CJS source must NOT contain its native binding.
+    expect(code).not.toMatch(/require\(["']better-sqlite3["']\)/);
+  });
+
+  it("embeds the hu-board stub message so the binary fails loudly when board cleanup is invoked", () => {
+    const code = readFileSync(bundlePath, "utf8");
+    expect(code).toContain("The HU Board is not available in this standalone binary");
+  });
+
+  it("runs --version end-to-end without crashing", () => {
+    const out = execFileSync("node", [bundlePath, "--version"], { encoding: "utf8" }).trim();
+    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("emits the stub message (not a stack trace) when `board cleanup` is invoked", () => {
+    let stdout = "";
+    let stderr = "";
+    try {
+      stdout = execFileSync("node", [bundlePath, "board", "cleanup"], { encoding: "utf8" });
+    } catch (err) {
+      stdout = String(err.stdout || "");
+      stderr = String(err.stderr || "");
+    }
+    const combined = `${stdout}\n${stderr}`;
+    expect(combined).toContain("The HU Board is not available in this standalone binary");
+    expect(combined).toContain("npm install -g karajan-code");
+  });
+});


### PR DESCRIPTION
## Problema

\`release-binaries.yml\` falla desde v2.12.0 porque esbuild no resuelve \`better-sqlite3\` (módulo nativo, importado por \`packages/hu-board/src/db.js\`). El comando \`kj board cleanup\` (KJC-TSK-0380 PR-C, #657) hace \`await import(\"../../packages/hu-board/src/cleanup-zombies.js\")\`, lo que arrastra todo el hu-board al bundle SEA.

Resultado: los binarios standalone NO se han publicado para v2.12.0 ni v2.13.0. Quien quería distribución sin npm se quedaba sin opción.

## Solución

El HU Board no tiene sentido en un binario standalone — es un dashboard con DB SQLite local y filesystem watcher. Quien quiera el board hace \`npm install -g karajan-code\` (que sí instala \`better-sqlite3\` con node-gyp). El SEA binary es la distribución CLI lean: planificación, ejecución, audit.

### Cambios en \`scripts/esbuild-sea.config.mjs\`

1. **\`external: [\"better-sqlite3\"]\`** — belt-and-braces: si algo más pulla la dep, el error es claro en lugar de un half-bundle.

2. **Plugin \`hu-board-stub\`** — intercepta cualquier import a \`packages/hu-board/src/*\` y lo redirige a un módulo virtual que exporta funciones que lanzan un error claro al runtime:

   \`\`\`
   The HU Board is not available in this standalone binary.
   Install karajan-code from npm to get the dashboard:
     npm install -g karajan-code
   \`\`\`

3. **Guard \`namespace: \"file\"\` en el plugin existente \`sea-transform\`** para que NO procese módulos virtuales del stub (sin el guard, el onLoad de sea-transform intentaba \`fs.readFile()\` rutas relativas imposibles → ENOENT).

## Tests

\`tests/sea-build.test.js\` (NEW, 4 casos):

- ✅ el bundle compila sin errors (\`builders.errors\` array vacío)
- ✅ el código bundleado **NO** contiene \`require(\"better-sqlite3\")\`
- ✅ el código bundleado **SÍ** contiene el mensaje del stub
- ✅ \`node bundle --version\` ejecuta end-to-end
- ✅ \`node bundle board cleanup\` lanza el mensaje del stub (no un stack trace opaco)

Suite total: **4528/4528 verde**.

## LOC

140 (config + tests, bajo budget).

## Impacto

Tras merge, la próxima release que dispare \`release-binaries.yml\` debería publicar los binarios SEA correctamente para linux-x64, darwin-arm64 y win-x64.

## Verificación manual post-merge

\`\`\`bash
cd ~/ws_npm-packages/karajan-code
node scripts/build-sea.mjs    # local SEA build
./dist/kj-linux-x64 --version  # debe responder con la version
./dist/kj-linux-x64 board cleanup  # debe lanzar el mensaje del stub
\`\`\`

## Related

- KJC-BUG-0040 (este)
- Habilita los binarios SEA para futuros releases (v2.13.1+)