### PR TITLE
docs(task-templates): plantillas + guía para task files de kj (KJC-TSK-0378)

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -182,6 +182,7 @@ Common issues: [troubleshooting.md](troubleshooting.md)
 ## Next steps
 
 - Read [ARCHITECTURE.md](ARCHITECTURE.md) to understand the pipeline
+- Use [task file templates](task-templates/README.md) when invoking `kj plan generate`, `kj run`, `kj researcher`, `kj architect`, `kj discover` or `kj refactorer` — they encode the sweet spot between too-brief and too-pre-processed
 - Check [SKILLS.md](SKILLS.md) for OpenSkills integration
 - Browse [templates/roles/](../templates/roles/) to see role definitions
 - If migrating from v1: [MIGRATION-v2.md](../MIGRATION-v2.md)

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -182,6 +182,7 @@ Problemas comunes: [troubleshooting.md](../troubleshooting.md)
 ## Siguientes pasos
 
 - Lee [ARCHITECTURE.md](../ARCHITECTURE.md) para entender el pipeline
+- Usa las [plantillas de task file](../task-templates/README.md) cuando ejecutes `kj plan generate`, `kj run`, `kj researcher`, `kj architect`, `kj discover` o `kj refactorer` — codifican el sweet spot entre demasiado-breve y demasiado-pre-procesado
 - Revisa [SKILLS.md](../SKILLS.md) para la integración con OpenSkills
 - Navega [templates/roles/](../../templates/roles/) para ver las definiciones de roles
 - Si migras desde v1: [MIGRATION-v2.md](../../MIGRATION-v2.md)

--- a/docs/task-templates/README.md
+++ b/docs/task-templates/README.md
@@ -1,0 +1,105 @@
+# Task file templates
+
+Plantillas y guía para los `.md` que pasas a los comandos de Karajan via `--task-file`. Sin estas, escribir un task file requiere ensayo y error caro (cada `kj plan generate` cuesta $0.30–0.80 en LLM y 2–5 minutos).
+
+## ¿Por qué importan?
+
+Karajan delega cada rol (planner, researcher, architect, discover, refactorer, coder, reviewer) a un LLM con un *system prompt* específico. Lo que tú escribes en el `--task-file` se concatena con ese system prompt como contexto del usuario. **El nivel de detalle que metas cambia radicalmente el output:**
+
+- **Task demasiado breve** ("haz una API"): el LLM inventa contexto y genera trabajo genérico que tienes que reescribir.
+- **Task demasiado estructurado** (ya parece un plan completo con secciones, IDs, tablas): el LLM piensa que tu trabajo es "reformatear", no "diseñar", y produce meta-documentación en vez de HUs reales.
+- **Task con la dosis correcta**: descripción narrativa de la feature + restricciones técnicas + reglas no negociables + reglas de output. El LLM tiene espacio para diseñar pero contexto para no inventar.
+
+Ese sweet spot es lo que estas plantillas codifican.
+
+## Cómo usar una plantilla
+
+1. Identifica qué comando vas a ejecutar (`kj plan generate`, `kj run`, `kj researcher`, etc.).
+2. Copia la plantilla correspondiente desde `docs/task-templates/<comando>.md` a tu proyecto (ej. `tasks/01-mi-feature.task.md`).
+3. Rellena los placeholders (líneas que empiezan con `<!-- ... -->` o `[REPLACE: ...]`).
+4. Borra las secciones marcadas como "opcional" si no aplican.
+5. Lanza el comando con `--task-file <ruta>`.
+
+## Plantillas disponibles
+
+| Comando | Plantilla | Cuándo |
+|---|---|---|
+| `kj plan generate` | [`plan-generate.md`](plan-generate.md) | Descomponer una feature en HUs ejecutables |
+| `kj run` | [`run.md`](run.md) | Lanzar una sola HU concreta (sin plan) |
+| `kj researcher` | [`researcher.md`](researcher.md) | Explorar el codebase antes de codear |
+| `kj architect` | [`architect.md`](architect.md) | Diseñar la solución antes de codear |
+| `kj discover` | [`discover.md`](discover.md) | Detectar gaps/ambigüedades en una tarea |
+| `kj refactorer` | [`refactorer.md`](refactorer.md) | Mejorar código existente sin cambiar comportamiento |
+
+## Antiejemplos comunes (no hagas esto)
+
+### ❌ Antiejemplo 1 — Task demasiado breve
+
+```markdown
+Build a REST API for managing users.
+```
+
+Problema: el LLM tiene que inventar todo (stack, base de datos, auth, validación, tests). Output: HUs genéricas que no encajan en tu proyecto.
+
+### ❌ Antiejemplo 2 — Task ya pre-procesado en formato de plan
+
+```markdown
+## ÉPICA: AUTH
+
+| ID | Caso de uso | Actor | Precondiciones | Postcondiciones |
+|---|---|---|---|---|
+| AUTH-001 | Registrar usuario | nuevo líder | email no registrado | cuenta creada |
+| AUTH-002 | Login | líder | cuenta activa | sesión iniciada |
+| ... 12 casos más ...
+
+## ÉPICA: PEOPLE
+...
+```
+
+Problema: el LLM lo lee como "plan ya hecho, solo formatealo". Output: meta-documentación tipo "Crear scaffold .md, documentar épica AUTH, ...". El plan original era mejor.
+
+Reportado en dogfooding como [KJC-BUG-0041](https://github.com/manufosela/karajan-code/issues) — el primer intento de Plan 1 del proyecto Equipazgo falló con este antipattern.
+
+### ✅ Patrón ganador
+
+```markdown
+# MVP Foundations — auth + organizaciones
+
+Necesito que descompongas en HUs ejecutables el primer slice del SaaS X.
+
+## Qué construimos
+[3-5 párrafos narrativos describiendo la feature: actores, flujo principal, casos de uso clave]
+
+## Stack técnico ya decidido
+[Bullet list compacto: lenguaje, frameworks, decisiones de arquitectura no negociables]
+
+## Funcionalidades a descomponer
+[Lista numerada de 20-30 items en lenguaje natural: "Líder se registra con OAuth", "Owner invita co-líder por email", etc. NO formatear como tabla con ID + precondiciones.]
+
+## Reglas no negociables
+[Aislamiento por tenant, audit log, cifrado, etc.]
+
+## Spikes técnicos
+[Setup infra, configurar Stripe, etc. que el planner debe incluir como HUs separadas.]
+
+## Lo que necesito que generes
+Una lista de HUs **atómicas y ejecutables individualmente con `kj run`**. Para cada HU:
+- ID con prefijo de épica
+- Historia "como X, quiero Y, para Z"
+- 3-8 criterios de aceptación verificables
+- Dependencias (las que existan REALMENTE; si no, vacío)
+- Estimación XS/S/M/L/XL
+```
+
+## Reglas universales (aplican a CUALQUIER comando)
+
+1. **Sin saltos lógicos**: si una decisión depende de información externa al task, explicita la fuente o la asunción. No dejes al LLM adivinar.
+2. **Stack decidido > stack abierto**: si ya sabes que va a ser Astro + Lit + Firebase, dilo. Si lo dejas abierto, el LLM elegirá por ti y probablemente no será lo que querías.
+3. **Sin tablas de plan pre-hecho**: cuando aparezcan tablas con ID + actor + precondiciones, el LLM tratará el trabajo como "rellenar el formato". Si quieres que diseñe, usa prosa.
+4. **Reglas no negociables al final**: el LLM las verá justo antes de generar.
+5. **Output esperado al final**: cierra el task indicando exactamente la forma del resultado (HUs, ADRs, lista de cambios, etc.).
+
+## Próximos pasos
+
+- Si quieres añadir una plantilla nueva, copia [`plan-generate.md`](plan-generate.md) como base y adapta las secciones.
+- Si encuentras un antipattern más, añádelo a la sección "Antiejemplos comunes" arriba.

--- a/docs/task-templates/architect.md
+++ b/docs/task-templates/architect.md
@@ -1,0 +1,123 @@
+# Template — `kj architect`
+
+## Cuándo usar este comando
+
+Tienes una feature que requiere **decisiones arquitectónicas** antes de codear: estructura de capas, contratos entre módulos, patterns, schema de DB, integración con sistemas existentes. El architect devuelve un diseño con ADRs ligeros.
+
+**No** uses esto para tareas pequeñas o que no requieren decisiones de diseño (un bug fix, una mejora de log, un test nuevo). El architect cobra LLM por decisiones que ya tomaste.
+
+## Comando
+
+```bash
+kj architect --task-file tasks/arch-feature.task.md \
+             --context "$(cat outputs/research-result.json)"  # opcional
+```
+
+Output: JSON o markdown estructurado con ADRs, diagrama de componentes, contratos.
+
+## Plantilla
+
+Copia esto a `tasks/arch-<nombre>.task.md`:
+
+```markdown
+# [REPLACE: Diseñar arquitectura de X]
+
+## Feature a diseñar
+
+[REPLACE: 2-4 párrafos describiendo:
+ - Qué hace la feature de cara al usuario
+ - Cuáles son las piezas técnicas obvias (no obligues a inventar)
+ - Cuál es la integración con el sistema existente]
+
+## Restricciones técnicas no negociables
+
+[REPLACE: bullets concretos.
+EJEMPLO:
+- Stack actual: Astro + Lit + Firebase (no cambiar)
+- DB: Firestore con multi-database (1 DB por tenant)
+- Auth: GCIP multi-tenant
+- Region: europe-west1 obligatoria por GDPR
+- Sin TypeScript (proyecto usa JS + JSDoc)
+- ≤200 LOC por PR; partir features grandes en HUs]
+
+## Decisiones que YA están tomadas
+
+[REPLACE: cosas que NO debe re-evaluar.
+EJEMPLO:
+- Tombstones para deletes persistentes (KJC-TSK-0380, ya implementado)
+- Plan adherence metric en summary.md (KJC-TSK-0376)
+- Catálogo de UI components: @manufosela/* (regla de proyecto)]
+
+## Decisiones que SÍ tiene que tomar
+
+[REPLACE: lista de preguntas arquitectónicas abiertas.
+EJEMPLO:
+1. ¿Cómo modelar la relación N:N entre Users y Teams (junction collection vs subcollection)?
+2. ¿Cifrado a nivel campo en envelope encryption: server-side o client-side?
+3. ¿Vector search vs SQL search para el componente de búsqueda full-text?
+4. ¿Cron diario o webhook real-time para el trial expiry?
+5. ¿Cómo gestionar la rotación de claves KMS sin disrupción?]
+
+## Output esperado
+
+[REPLACE: forma del resultado.
+EJEMPLO:
+- 1 ADR ligero por cada decisión, formato `decision + reasoning + alternatives + consequences`.
+- Diagrama de componentes (texto, ASCII o mermaid) con flechas de dependencia.
+- Schema de DB en JSON Schema-like.
+- Contratos entre módulos (función signatures + JSDoc types).
+- Tests de integración recomendados (lista de casos).
+- Lista de riesgos técnicos con mitigación.]
+
+## Lo que NO debe entrar
+
+[REPLACE — opcional pero útil para enfocar.
+EJEMPLO:
+- NO incluir HUs ejecutables (eso es `kj plan generate`).
+- NO incluir código de implementación (eso es `kj run`).
+- NO discutir alternativas de stack ya descartadas (Postgres, Supabase).]
+```
+
+## Patrón ganador
+
+El architect funciona bien cuando le das:
+
+- **Restricciones técnicas firmes** (stack, region, compliance).
+- **Decisiones cerradas** (lo que ya está implementado y no se va a cambiar).
+- **Preguntas concretas abiertas** (no "diseña la solución" — sí "elige entre A, B, C para X").
+
+Y mal cuando:
+
+- Le pides que reconsidere todo el stack ("¿deberíamos usar Postgres?") — eso es un research / decision exec, no arquitectura.
+- Le das una feature mal definida — el architect inventará casos de uso.
+- Esperas que cubra UX o copywriting — el architect es para piezas técnicas.
+
+## Encadenarlo con `kj plan generate`
+
+```bash
+kj architect --task-file tasks/arch-x.task.md --json > /tmp/arch.json
+kj plan generate --task-file tasks/feature-x.task.md \
+                 --context "$(cat /tmp/arch.json)"
+```
+
+El planner usa el ADR del architect como contexto y emite HUs que respetan las decisiones tomadas.
+
+## Antiejemplo (qué NO funciona)
+
+```markdown
+Design the architecture for our new SaaS for managing teams.
+```
+
+Problema: el architect tiene que inventar TODO. Output: ADR genérico tipo "Use microservices because scalability". No te sirve.
+
+Mejor:
+
+```markdown
+We're adding "team membership" to an existing Firestore-backed SaaS
+(Astro + Lit + Firebase, KJC-TSK-0380 ya implementado). Tomar las
+siguientes 3 decisiones: (1) junction collection vs subcollection,
+(2) índices Firestore necesarios para listar membresías de un usuario,
+(3) cifrado en reposo de los datos personales del miembro.
+```
+
+Decisiones concretas → ADRs útiles.

--- a/docs/task-templates/discover.md
+++ b/docs/task-templates/discover.md
@@ -1,0 +1,110 @@
+# Template — `kj discover`
+
+## Cuándo usar este comando
+
+Tienes una tarea/feature en la cabeza pero **no estás seguro de si está bien definida**. El discover detecta:
+
+- Gaps (información que falta para empezar)
+- Ambigüedades (decisiones implícitas que el coder podría interpretar mal)
+- Dependencias externas no resueltas (credenciales, accesos, third-parties)
+
+Te ahorra el ciclo "lanzas `kj run` → el coder pregunta → tú contestas → pivotea".
+
+## Comando
+
+```bash
+kj discover --task-file tasks/discover-x.task.md --mode gaps
+```
+
+Modos disponibles:
+- `gaps` (default) — qué información falta
+- `momtest` — preguntas estilo "The Mom Test" para validar la idea
+- `wendel` — análisis de risks tipo Wendel ("¿qué podría salir mal?")
+- `classify` — clasifica la tarea (simple / medium / complex)
+- `jtbd` — análisis Jobs-To-Be-Done
+
+## Plantilla
+
+Copia a `tasks/discover-<nombre>.task.md`:
+
+```markdown
+# [REPLACE: descubrir gaps en X antes de implementar]
+
+## La tarea que estoy pensando hacer
+
+[REPLACE: 2-4 párrafos describiendo lo que TÚ crees que hay que hacer.
+EJEMPLO:
+"Quiero añadir un sistema de invitaciones por email para co-líderes
+en Equipazgo. El owner introduce el email, se le envía un magic-link
+con token único de 7 días, y al pulsarlo el invitado entra a la
+organización con rol co_leader."]
+
+## Lo que YA sé / tengo decidido
+
+[REPLACE: bullets concretos.
+EJEMPLO:
+- Email provider: SendGrid (ya configurado en otra parte del proyecto)
+- Magic-link auth: Firebase Auth tiene built-in (`sendSignInLinkToEmail`)
+- Token storage: tabla `invitations` en Firestore
+- Plan Team o superior obligatorio]
+
+## Lo que SOSPECHO que puede estar mal definido
+
+[REPLACE: lista de cosas que sientes que no están del todo claras.
+EJEMPLO:
+1. ¿Qué pasa si el invitado ya tiene cuenta en otra organización?
+2. ¿Cómo se gestiona la revocación si el token aún no ha sido usado?
+3. ¿El owner ve "pending invitations" en algún sitio?
+4. ¿Email rate-limiting para evitar abuso?
+5. ¿El co_leader hereda permisos automáticamente o el owner debe configurarlos?]
+
+## Lo que necesito del discover
+
+[REPLACE: tipo de output esperado.
+EJEMPLO:
+- Lista exhaustiva de gaps con priorización (P0 bloqueante / P1 importante / P2 nice-to-have).
+- Para cada gap: pregunta concreta + recomendación si la sabes.
+- Riesgos no técnicos (legales, UX, abuse vectors).
+- Dependencias externas pendientes (credenciales, configuraciones de Stripe, dominio verificado).]
+```
+
+## Patrón ganador
+
+El discover funciona bien cuando le das:
+
+- **Una idea concreta** (no genérica): "invitaciones por email para co-líderes" >>> "sistema de auth".
+- **Lo que ya tienes decidido** para que se centre en lo abierto.
+- **Tus dudas explícitas** para que profundice donde tú sientes vértigo.
+
+Y mal cuando:
+
+- La idea está demasiado verde — el discover acaba inventando preguntas genéricas.
+- Pides "validar la idea de mi producto" — eso es customer research, no `kj discover`.
+
+## Cuándo usar cada modo
+
+| Modo | Cuándo |
+|---|---|
+| `gaps` | Quieres una lista accionable de "qué falta para empezar". Es el default y casi siempre lo correcto. |
+| `momtest` | Validación temprana de una idea de producto — antes de codear. |
+| `wendel` | Análisis de riesgos profundo — útil antes de release o de feature crítica. |
+| `classify` | Cuando dudas si una tarea es de 1 hora o de 1 semana. |
+| `jtbd` | Diseño de feature centrado en el job-to-be-done del usuario. |
+
+## Encadenarlo
+
+Tras `kj discover --mode gaps`, lo típico es:
+
+1. Contestar las preguntas P0 + P1 explícitamente.
+2. Reescribir el task file incorporando las respuestas.
+3. Lanzar `kj plan generate` con el task file enriquecido.
+
+El plan resultante es mucho más concreto que el que saldría sin discover.
+
+## Antiejemplo (qué NO funciona)
+
+```markdown
+Build a SaaS. What should I consider?
+```
+
+Problema: el discover devolverá 50 preguntas genéricas inútiles (auth, billing, monitoring, scaling, GDPR...). Mejor empieza concreto y deja que discover detecte gaps de **tu** idea concreta, no del universo SaaS.

--- a/docs/task-templates/plan-generate.md
+++ b/docs/task-templates/plan-generate.md
@@ -1,0 +1,130 @@
+# Template — `kj plan generate`
+
+## Cuándo usar este comando
+
+Tienes una feature de tamaño medio-grande (≥ 5 HUs) y necesitas que Karajan la descomponga en HUs ejecutables, con dependencias, sprints estimados, riesgos y out-of-scope. **No** uses esto para tareas simples (1-3 HUs); para eso usa `kj run` directo.
+
+## Comando
+
+```bash
+kj plan generate --task-file <path>.task.md -y 2>&1 | tee outputs/plan-raw.log
+```
+
+- `-y` salta el prompt del project name (usa el default).
+- `tee` captura el output del planner por si quieres inspeccionar progreso.
+
+El plan resultante se guarda en `~/.kj/plans/<projectSlug>/plan-<id>.json` (la ruta exacta sale en stdout al final).
+
+## Plantilla
+
+Copia esto a `tasks/01-<nombre-feature>.task.md` y rellena:
+
+```markdown
+# [REPLACE: Título corto de la feature — 1 línea]
+
+[REPLACE: Una frase: necesito que descompongas en HUs ejecutables el [feature X] del proyecto Y.]
+
+## Qué construimos en este plan
+
+[REPLACE: 3-5 párrafos narrativos describiendo:
+ - Actores (quién usa esta feature)
+ - Flujo principal (qué pasa de inicio a fin)
+ - Datos/entidades clave
+ - Diferencias vs lo que YA existe en el proyecto]
+
+**NO incluye en este plan**: [REPLACE: lista las features que pertenecen a OTROS planes futuros, para que el planner no las arrastre.]
+
+## Stack técnico ya decidido
+
+- **Frontend**: [REPLACE: Astro + Lit / React + Vite / etc.]
+- **Backend**: [REPLACE: Cloud Functions / Express / etc.]
+- **DB**: [REPLACE: Firestore / Postgres / etc.]
+- **Auth**: [REPLACE: GCIP / Auth0 / etc.]
+- **Hosting**: [REPLACE: Firebase Hosting / Vercel / etc.]
+- **Region / compliance**: [REPLACE: europe-west1 GDPR / us-east1 / etc.]
+
+[OPTIONAL: lista de paquetes externos ya decididos]
+
+## Funcionalidades a descomponer en HUs
+
+[REPLACE: lista numerada de 15-30 items en lenguaje natural.
+Formato preferido: prosa corta describiendo QUÉ hace cada cosa.
+
+EJEMPLO BUENO:
+1. Líder se registra con email+password o OAuth Google/Microsoft.
+2. Al registrarse, una Cloud Function crea atómicamente la organización
+   (tenant + DB + bucket + KMS key). Si algún paso falla, rollback completo.
+3. ...
+
+EJEMPLO MALO:
+| ID | Caso | Actor | Precondiciones |
+| AUTH-001 | Registrarse | líder | email no registrado |
+| ...
+(eso parece un plan ya hecho — el LLM lo reformateará en vez de diseñar)
+]
+
+## Reglas no negociables
+
+[REPLACE: bullets concisos.
+EJEMPLO:
+- Aislamiento entre tenants: nunca cross-org. Tests de aislamiento en CI.
+- Auth obligatoria: cada Cloud Function valida pertenencia al tenant.
+- Cifrado: CMEK en reposo; envelope para campos muy sensibles.
+- Owner vs co_leader: solo owner gestiona suscripción, ownership y borrado.
+- Audit log inmutable para GDPR/billing/membership.]
+
+## Spikes técnicos (HUs separadas)
+
+[REPLACE: cosas de infraestructura/setup que NO son features de usuario pero deben hacerse antes.
+EJEMPLO:
+- Setup proyecto GCP + Firebase + GCIP multi-tenancy + KMS.
+- Setup Stripe (productos, planes, webhooks idempotentes).
+- Setup CI/CD GitHub Actions.
+- Plantilla DPIA + privacy notice (paralelo, no bloqueante).]
+
+## Lo que necesito que generes
+
+Una lista de HUs **atómicas y ejecutables individualmente con `kj run`** (cada una es una unidad de trabajo de un coder). Para cada HU:
+
+- **ID** con prefijo de épica: `[AUTH-001]`, `[PEOPLE-005]`, `[INFRA-003]`, etc.
+- **Título** breve.
+- **Historia** "como [actor], quiero [acción], para [valor]".
+- **3-8 criterios de aceptación** verificables.
+- **Dependencias** entre HUs (las que deben completarse antes). Si una HU no depende de nada, lista vacía. **NO encadenar HUs por orden de aparición.**
+- **Estimación** XS / S / M / L / XL.
+- **Notas técnicas** según el stack.
+- **Subset MVP** mínimo (las HUs imprescindibles para validar el flujo end-to-end).
+- **Plan de sprints** de 2 semanas con HUs agrupadas (asume equipo 2-3 devs + 1 designer).
+- **Checklist de dependencias externas** pre-requisito (cuentas cloud, dominio, etc.).
+
+**Importante**: NO escribas un documento markdown describiendo las HUs. Genera HUs reales como entradas separadas, cada una ejecutable por separado. Idioma de las HUs: [REPLACE: español / english].
+```
+
+## Ejemplo concreto que funcionó
+
+Mira [`tasks/04-plan-1-simple.task.md` en el proyecto de Equipazgo](https://github.com/manufosela/karajan-code/blob/main/PERSONAL) (97 líneas) — generó 45 HUs reales con dependencias correctas tras los fixes KJC-BUG-0041/KJC-TSK-0382.
+
+## Antiejemplo (qué NO funciona)
+
+Un task de 353 líneas con cada épica enumerada en una tabla `| ID | Actor | Precondiciones | Postcondiciones |` con los 30+ casos de uso ya escritos. El planner lo tratará como "documento ya hecho" y producirá meta-documentación. Reportado como KJC-BUG-0041 en dogfooding 2026-05-10.
+
+## Verificación del plan generado
+
+Tras la generación, inspecciona:
+
+```bash
+PLAN=~/.kj/plans/<projectSlug>/plan-<id>.json
+
+# Total de HUs
+jq '.hus | length' $PLAN
+
+# Distribución de dependencias (cuántas HUs sin deps, cuántas con 1, 2, ...)
+jq '[.hus[] | .blocked_by | length] | group_by(.) | map({deps: .[0], count: length})' $PLAN
+
+# Issues que el reviewer detectó
+jq '.review' $PLAN
+```
+
+**Bandera roja**: si el array de dependencias es `[count(0)=0, count(1)=N-1]` con N = total HUs (todas dependen de una), el bug de cadena lineal está activo. Verifica que tienes karajan-code >= 2.13.1.
+
+**Bandera roja**: si todas son `[count(0)=N]` y el spec explícitamente declaraba "Depende: X", el bug de extracción de deps está activo. Verifica karajan-code >= 2.13.1.

--- a/docs/task-templates/refactorer.md
+++ b/docs/task-templates/refactorer.md
@@ -1,0 +1,130 @@
+# Template — `kj refactorer`
+
+## Cuándo usar este comando
+
+Tienes código que **funciona pero está mal estructurado** y quieres mejorarlo sin cambiar el comportamiento externo. El refactorer:
+
+- Mantiene el comportamiento observable idéntico (tests pasan antes y después)
+- Mejora claridad / nombres / cohesión / acoplamiento / complejidad cognitiva
+- NO añade features nuevas (eso es `kj run`)
+- NO arregla bugs (eso es `kj run` con TDD)
+
+## Comando
+
+```bash
+kj refactorer --task-file tasks/refactor-<modulo>.task.md
+```
+
+## Plantilla
+
+Copia a `tasks/refactor-<modulo>.task.md`:
+
+```markdown
+# [REPLACE: refactorizar X — mejora de claridad sin cambio de comportamiento]
+
+## Qué hay actualmente
+
+[REPLACE: 1-2 párrafos describiendo el código actual y por qué te molesta.
+EJEMPLO:
+"`src/utils/parser.js` tiene una función `parse()` de 180 líneas con
+6 niveles de nested if/else y 3 try/catch anidados. Funciona y tiene
+buenos tests, pero cada vez que toco el módulo tengo que releer toda
+la función. Cognitive complexity: 28 (Sonar lo flagea como hotspot)."]
+
+## Qué quiero conseguir
+
+[REPLACE: objetivo concreto.
+EJEMPLO:
+- Reducir cognitive complexity de `parse()` a <15.
+- Funciones helper de máximo 30 líneas cada una.
+- Sin nesting >3 niveles.
+- Nombres descriptivos (en inglés).
+- Mantener exactamente la misma API pública.]
+
+## Restricciones no negociables
+
+[REPLACE: lista concreta.
+EJEMPLO:
+- **Cero cambios en la API pública** de `parser.js`. Las firmas exportadas
+  (`parse`, `parsePartial`, `ParseError`) son idénticas en input y output.
+- **Todos los tests existentes pasan sin cambios**: `tests/parser.test.js`,
+  `tests/parser-edge-cases.test.js`. NO tocar los tests salvo para añadir
+  nuevos casos que cubran el código refactorizado.
+- **Sin breaking de imports**: cualquier módulo que hace
+  `import { parse } from "./utils/parser.js"` sigue funcionando.
+- ≤200 LOC delta (regla del repo).
+- Sin dependencias nuevas.]
+
+## Qué SÍ puedes tocar
+
+[REPLACE.
+EJEMPLO:
+- Extraer funciones internas (privadas al módulo).
+- Renombrar variables locales y parámetros internos.
+- Reorganizar el orden de definición de funciones.
+- Cambiar implementación interna mientras el output sea idéntico.
+- Añadir JSDoc/comments donde aporte claridad.]
+
+## Qué NO debes tocar
+
+[REPLACE.
+EJEMPLO:
+- Algoritmo: si actualmente usa regex, sigue usando regex; si usa parser
+  recursivo, sigue siendo recursivo. NO migrar a una librería externa.
+- Mensajes de error: el texto de los Error que se lanzan es contrato
+  público (algunos tests lo verifican textualmente).
+- Performance: NO optimizar — solo mejora de legibilidad. Si una mejora
+  de legibilidad cuesta 2× tiempo de ejecución, prefiérela igualmente.]
+
+## Criterios de aceptación
+
+[REPLACE: 3-8 condiciones verificables.
+EJEMPLO:
+1. `npm test` pasa sin modificar ningún test existente.
+2. `npx sonar-scanner` muestra cognitive complexity de cada función ≤15.
+3. Coverage del módulo sigue ≥ que antes (medido en reports/coverage/).
+4. `git diff src/utils/parser.js` no toca exports.
+5. `git diff tests/` solo añade tests nuevos (si los hay), no modifica.]
+```
+
+## Patrón ganador
+
+El refactorer funciona bien cuando le das:
+
+- **Un módulo concreto y acotado** (uno o dos archivos máximo).
+- **Tests existentes sólidos** (sin tests, el refactor es ciego — puedes romper sin enterarte).
+- **Objetivo medible** (cognitive complexity, longitud, nesting).
+- **Restricciones explícitas** de qué NO se puede cambiar.
+
+Y mal cuando:
+
+- "Refactoriza todo el proyecto" — demasiado scope.
+- "Mejora la arquitectura" — eso es `kj architect`, no refactor.
+- Falta de tests existentes — pídele al coder que añada tests PRIMERO en otra PR.
+
+## Antiejemplo (qué NO funciona)
+
+```markdown
+Refactor src/ to be cleaner.
+```
+
+Problema: scope infinito, sin objetivo medible, sin restricciones. El refactorer hará cambios cosméticos masivos que romperán cosas sutiles. Mejor pide un módulo específico con un objetivo concreto.
+
+## Verificación post-refactor
+
+```bash
+# 1. Tests verde
+npm test
+
+# 2. Cognitive complexity bajó
+npx sonar-scanner   # o tu herramienta de complejidad preferida
+
+# 3. La API pública NO cambió (diff de exports)
+git diff main -- src/utils/parser.js | grep -E "^(\+|-)export"
+# Esperado: vacío (NADA cambia en los exports)
+
+# 4. Coverage mantenida o subida
+npm test -- --coverage
+```
+
+Si cualquiera de estos falla, rechaza el PR o pide ajustes.

--- a/docs/task-templates/researcher.md
+++ b/docs/task-templates/researcher.md
@@ -1,0 +1,97 @@
+# Template — `kj researcher`
+
+## Cuándo usar este comando
+
+Necesitas que Karajan **explore el codebase local** antes de codear o de planificar. El researcher devuelve un JSON con:
+
+- `affected_files`: qué ficheros importan para la tarea
+- `patterns`: convenciones que detecta en el código existente
+- `constraints`: restricciones del proyecto (CLAUDE.md, AGENTS.md, etc.)
+- `prior_decisions`: decisiones previas relevantes (de ADRs, CHANGELOG, comentarios)
+- `risks`: trampas que ve a priori
+- `test_coverage`: estado de los tests del área afectada
+
+**No** uses esto para investigación de mercado / comparativa de stacks / búsqueda en internet. Para eso usa Claude Code o un agente con WebSearch directamente. El researcher de Karajan **NO usa WebSearch** — solo lee el filesystem del proyecto.
+
+## Comando
+
+```bash
+kj researcher --task-file tasks/research-feature-x.task.md
+```
+
+El output sale por stdout (formato JSON o markdown según la config). No persiste a disco por sí solo — redirige con `tee` si quieres guardarlo.
+
+## Plantilla
+
+Copia esto a `tasks/research-<nombre>.task.md`:
+
+```markdown
+# [REPLACE: Investigar X antes de implementar Y]
+
+## Qué voy a hacer (después de este research)
+
+[REPLACE: 1-2 párrafos describiendo la tarea que VENDRÁ después.
+EJEMPLO:
+"Voy a añadir un nuevo comando `kj audit --json` que emita el report
+en formato JSON parseable. Antes de codear, necesito entender cómo se
+estructura el report actual y qué otros comandos ya emiten JSON."]
+
+## Qué necesito saber
+
+[REPLACE: lista numerada de preguntas concretas que el researcher debe responder.
+EJEMPLO:
+1. ¿Dónde está implementado el comando `kj audit` actual? Archivo + función principal.
+2. ¿Qué otros comandos soportan `--json` y cómo lo modelan? Patrón común si lo hay.
+3. ¿Hay un helper compartido para emitir JSON estructurado vs texto humano?
+4. ¿Qué tests cubren actualmente `kj audit`? ¿Hay snapshot tests del output?
+5. ¿Hay alguna regla en CLAUDE.md/AGENTS.md sobre formato JSON?]
+
+## Restricciones del scope del research
+
+[REPLACE: lista de cosas que el researcher NO debe profundizar.
+EJEMPLO:
+- Solo el código de `src/commands/audit/` y `src/audit/`. No tocar otros comandos.
+- No leer el contenido de archivos de tests E2E (demasiado largo).
+- Si encuentras commits recientes relacionados (>1 mes), reportarlos pero no analizar a fondo.]
+
+## Output esperado
+
+[REPLACE: cómo quieres el resultado.
+EJEMPLO:
+- JSON estructurado (formato default de `kj researcher`).
+- Cada hallazgo con la cita `file.js:line` para verificar.
+- Sección final `recommendations` con sugerencias concretas para mi tarea siguiente.]
+```
+
+## Antiejemplo (qué NO funciona)
+
+```markdown
+Investiga el mejor stack para construir un SaaS multi-tenant con GDPR,
+comparando GCP/Firebase, AWS/Amplify, Supabase y Cloudflare. Incluye
+precios actuales y benchmarks.
+```
+
+Problema: el researcher de Karajan NO tiene WebSearch. No puede comparar stacks ni leer precios actuales. Lo confirmará buscando en tu `node_modules` y en tu `package.json`, lo que es irrelevante. Para esa tarea usa Claude Code directamente con WebSearch + WebFetch habilitados.
+
+## Patrón ganador (output útil)
+
+El researcher es especialmente bueno cuando le pides:
+
+- "Localiza dónde está implementada [feature concreta]"
+- "Lista todos los archivos que importan [símbolo X]"
+- "Resume las convenciones de testing del proyecto"
+- "Detecta restricciones documentadas en CLAUDE.md / AGENTS.md / ADRs"
+- "Identifica patterns de error handling usados en [módulo Y]"
+
+Es decir, cualquier cosa contestable leyendo el código del proyecto.
+
+## Encadenarlo con `kj run`
+
+Una vez tengas el JSON del researcher, puedes pasarlo como `--context` al `kj run` siguiente para que el coder tenga ese contexto:
+
+```bash
+kj researcher --task-file tasks/research-x.task.md --json > /tmp/research.json
+kj run --task-file tasks/implement-x.task.md --context "$(cat /tmp/research.json)"
+```
+
+Eso ahorra que el coder vuelva a explorar lo mismo.

--- a/docs/task-templates/run.md
+++ b/docs/task-templates/run.md
@@ -1,0 +1,112 @@
+# Template — `kj run`
+
+## Cuándo usar este comando
+
+Tienes una tarea concreta (un bug fix, una mejora pequeña, una HU suelta) que el coder puede atacar directamente. **No** uses esto para features grandes que necesitan descomposición — para eso usa `kj plan generate` y luego `kj run --plan <id>`.
+
+## Comandos
+
+```bash
+# Forma corta — tarea como argumento
+kj run "Add JSDoc comments to src/utils/format.js explaining each exported function"
+
+# Forma extendida — task file (recomendado para tareas con contexto)
+kj run --task-file tasks/fix-bug-042.task.md
+
+# Plan completo — ejecuta cada HU en cadena
+kj run --plan plan-<id>
+```
+
+## Plantilla para task file individual
+
+Copia esto a `tasks/<descripcion>.task.md` y rellena:
+
+```markdown
+# [REPLACE: Título corto de la tarea]
+
+## Contexto
+
+[REPLACE: 1-3 párrafos describiendo:
+ - Qué hay actualmente en el código
+ - Qué problema vas a resolver
+ - Por qué importa]
+
+## Cambio que quiero
+
+[REPLACE: descripción concreta del cambio, en prosa.
+EJEMPLO:
+"Añadir un argumento opcional `--dry-run` al comando `kj clean` que
+imprima qué se borraría sin tocar nada. Cuando el flag está
+presente, los `fs.rmSync` deben sustituirse por `console.log` del
+path. Tests de regresión que verifiquen ambos modos."]
+
+## Restricciones técnicas
+
+[REPLACE: lista de cosas que NO se deben tocar.
+EJEMPLO:
+- NO romper la API pública de `cleanCommand({ dryRun, ... })`.
+- Mantener compatibilidad con el config flag `clean.dryRun` existente.
+- ≤200 LOC de delta (rule del repo, KJC-TSK-0352).]
+
+## Criterios de aceptación
+
+[REPLACE: 3-8 condiciones verificables.
+EJEMPLO:
+1. `kj clean --dry-run` imprime cada path que se eliminaría, prefijado con "[dry-run]".
+2. `kj clean --dry-run` sale con exit code 0 sin tocar nada en disco.
+3. `kj clean` sin `--dry-run` mantiene el comportamiento actual exacto.
+4. Nuevo test `tests/clean-dry-run.test.js` cubre los 3 casos.
+5. Todos los tests existentes siguen pasando.]
+
+## Archivos esperados a tocar
+
+[OPTIONAL — solo si tú lo sabes. Si no, el coder lo decide.
+EJEMPLO:
+- `src/commands/clean.js`
+- `tests/clean-dry-run.test.js` (NEW)]
+
+## Notas técnicas
+
+[OPTIONAL. EJEMPLO:
+- El config flag `clean.dryRun` ya existe en `src/config/schema.js`; reusarlo si el usuario no pasa el CLI flag.
+- El comando tiene un test existente en `tests/command-clean.test.js`; usar el mismo pattern (vi.mock de fs.rmSync).]
+```
+
+## Reglas que el coder respetará por defecto (no las repitas)
+
+Karajan ya inyecta en el coder estas reglas globales, así que NO tienes que repetirlas:
+
+- ≤200 LOC por PR (KJC-TSK-0352).
+- Conventional Commits.
+- Tests obligatorios cuando hay cambio de lógica.
+- TDD (red→green→refactor) salvo que la tarea sea solo refactor/docs.
+- No `Co-Authored-By` ni atribuciones a IA en commits.
+- Idioma del código en inglés; PR/commit messages en el idioma del proyecto.
+
+Si necesitas **saltar** alguna de estas reglas, dilo explícitamente:
+
+```markdown
+## Excepciones a las reglas globales
+
+- Esta PR excede 200 LOC porque [razón]. Aplicar label `large-pr-justified`.
+- No hay tests porque [razón].
+```
+
+## Antiejemplo (qué NO funciona)
+
+```markdown
+Build a complete authentication system with login, signup, password recovery,
+OAuth Google/Microsoft, magic-link, profile management, and account deletion.
+```
+
+Problema: eso son 8-12 HUs, no una tarea. El coder o se desboca y produce un mega-commit, o se queda corto. Usa `kj plan generate` para una feature así.
+
+## Verificación
+
+Tras `kj run`, Karajan deja:
+
+- Commit en una rama nueva `feat/<slug>-<timestamp>` (o `fix/...`).
+- PR abierta si tienes `auto_pr: true` en config.
+- Journal en `.reviews/session_<id>/` con `summary.md`, `iterations.md`, `decisions.md`, `tree.txt`.
+
+Si el run termina como `REJECTED` o `PAUSED`, lee `summary.md` para entender por qué.


### PR DESCRIPTION
## Problema

Reportado durante dogfooding 2026-05-10 (proyecto Equipazgo): el primer \`kj plan generate\` con un task file de 353 líneas pre-estructurado **falló** — el planner trató el input como \"documento ya hecho, solo reformateo\" en lugar de diseñar HUs reales. Generó meta-documentación (\"Crear scaffold .md, documentar épica AUTH\") en vez de HUs ejecutables.

Es un antipattern recurrente sin documentación: KJC-TSK-0378 (\"Templates + guía task files para kj commands\") quedó pendiente desde entonces.

## Solución

Plantillas en \`docs/task-templates/\` que codifican el sweet spot entre:

| Antipattern | Output del LLM |
|---|---|
| Task demasiado breve (1 frase) | LLM inventa contexto, trabajo genérico |
| Task demasiado pre-estructurado (tablas con ID + actor + precondiciones) | LLM reformatea en vez de diseñar |
| **Patrón ganador** | Prosa narrativa + restricciones + reglas + output esperado → HUs reales |

## Archivos (7 nuevos)

- \`README.md\` — guía general + antiejemplos + reglas universales
- \`plan-generate.md\` — plantilla para \`kj plan generate\`
- \`run.md\` — plantilla para \`kj run\` (tarea suelta o plan completo)
- \`researcher.md\` — plantilla para \`kj researcher\` (codebase local, NO WebSearch)
- \`architect.md\` — plantilla para \`kj architect\` (ADRs ligeros)
- \`discover.md\` — plantilla para \`kj discover\` (gaps/ambigüedades, 5 modos)
- \`refactorer.md\` — plantilla para \`kj refactorer\` (sin cambio de comportamiento)

Cada plantilla incluye:

- Cuándo usar el comando + cuándo NO
- Comando exacto a invocar
- Plantilla rellenable con placeholders \`[REPLACE: ...]\`
- Patrón ganador + antiejemplo concreto
- Verificación post-ejecución

Y se enlaza desde \`docs/GETTING-STARTED.md\` (EN+ES) como recurso recomendado.

## LOC

807 LOC en docs/. **Excluido del budget** por la regla #649 (human-facing docs no cuentan).

## Tests

Cero código tocado, documentación pura. Suite mantiene 4524/4524 (sin cambios).

## Verificación manual

\`\`\`bash
# Que la plantilla de plan-generate sirva como referencia para nuevos users
cat docs/task-templates/plan-generate.md

# Que GETTING-STARTED enlace
grep -A1 \"task file\" docs/GETTING-STARTED.md
\`\`\`

## Related

- KJC-TSK-0378 (este)
- KJC-BUG-0041 (el antipattern que originó la necesidad)