### PR TITLE
fix(solomon): security issues no longer misclassified as style-block (KJC-BUG-0026)

### DIFF
--- a/src/orchestrator/solomon-rules.js
+++ b/src/orchestrator/solomon-rules.js
@@ -68,8 +68,24 @@ export function evaluateRules(context, rulesConfig = {}) {
   // Rule 6: Reviewer style-only block — all blocking issues are style/naming/formatting, not security/correctness
   if (rules.reviewer_style_block && context.blockingIssues?.length > 0) {
     const styleKeywords = /\b(naming|name|rename|style|format|formatting|indent|spacing|camelCase|snake_case|convention|cosmetic|readability|comment|jsdoc|documentation|whitespace|semicolon|quotes|trailing)\b/i;
+    // Anti-style: if any of these match, the issue is NOT style — it's a real correctness/security concern.
+    // Fixes KJC-BUG-0026 (Solomon approving legitimate security blockers misclassified as "style").
+    const securityKeywords = /\b(sql\s*injection|xss|csrf|ssrf|rce|injection|vulnerab|exploit|sanitiz|escape\b|encod\b|cors|auth|authn|authz|password|secret|credential|token|api[-_\s]*key|private[-_\s]*key|hash|cipher|crypto|encrypt|decrypt|tls|ssl|certificate|leak|sensitive|pii|privacy|insecure|unsafe|race[-_\s]*condition|deadlock|memory[-_\s]*leak|null[-_\s]*deref|uaf|overflow|traversal|prototype[-_\s]*pollution|deserializ|eval\b|exec\b|spawn|shell|command[-_\s]*injection)\b/i;
+    const securityCategories = new Set(["security", "correctness", "bug", "vulnerability"]);
     const styleSeverities = new Set(["low", "minor"]);
+    const blockingSeverities = new Set(["critical", "high", "blocker", "major"]);
+    const isSecurityIssue = issue => {
+      const desc = issue.description || "";
+      const sev = (issue.severity || "").toLowerCase();
+      const cat = (issue.category || issue.type || "").toLowerCase();
+      const tags = Array.isArray(issue.tags) ? issue.tags.map(t => String(t).toLowerCase()) : [];
+      if (blockingSeverities.has(sev)) return true;
+      if (securityCategories.has(cat)) return true;
+      if (tags.some(t => securityCategories.has(t))) return true;
+      return securityKeywords.test(desc);
+    };
     const allStyle = context.blockingIssues.every(issue => {
+      if (isSecurityIssue(issue)) return false;
       const desc = issue.description || "";
       const sev = (issue.severity || "").toLowerCase();
       return styleSeverities.has(sev) || styleKeywords.test(desc);

--- a/tests/solomon-rules.test.js
+++ b/tests/solomon-rules.test.js
@@ -95,6 +95,72 @@ describe("evaluateRules", () => {
     expect(result2.alerts[0].rule).toBe("max_stale_iterations");
   });
 
+  describe("reviewer_style_block rule (BUG-0026 regression)", () => {
+    it("triggers when all blocking issues are pure style/naming", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "variable naming convention violation", severity: "low" },
+          { description: "indentation inconsistent in user.js", severity: "minor" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(true);
+      expect(result.hasCritical).toBe(true);
+    });
+
+    it("does NOT trigger when severity is critical/high even if matches style keyword", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "input validation missing in user form", severity: "critical" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(false);
+    });
+
+    it("does NOT trigger when description mentions security (BUG-0026)", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "SQL injection in user input parsing", severity: "low" },
+          { description: "Missing CORS documentation policy", severity: "low" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(false);
+    });
+
+    it("does NOT trigger when description mentions secrets/credentials", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "Hardcoded API token in config file", severity: "minor" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(false);
+    });
+
+    it("does NOT trigger when category/tags flag the issue as security", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "weak naming on hash", severity: "low", category: "security" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(false);
+    });
+
+    it("does NOT trigger on mixed issues (one security + one style)", () => {
+      const result = evaluateRules({
+        ...baseContext,
+        blockingIssues: [
+          { description: "variable naming convention", severity: "low" },
+          { description: "XSS vulnerability in render path", severity: "low" }
+        ]
+      });
+      expect(result.alerts.some(a => a.rule === "reviewer_style_block")).toBe(false);
+    });
+  });
+
   it("hasCritical and hasWarnings flags are correct", () => {
     // Only warnings
     const warnOnly = evaluateRules({


### PR DESCRIPTION
## Summary
- Solomon Rule 6 (`reviewer_style_block`) clasificaba security blockers legítimos como "style" y aprobaba merges peligrosos.
- Causa raíz: heurística usaba `severity ∈ {low, minor}` OR `regex(naming|name|format|documentation|...)` sin anti-features.
- Fix: añadir `isSecurityIssue()` que excluye del "all style" issues con severity crítica, categoría security/correctness, tags, o keywords de security/correctness en la descripción.

## Casos del bug
| Issue del reviewer | Antes | Después |
|---|---|---|
| `SQL injection in user input parsing` (low) | ❌ style → Solomon approve | ✅ no es style |
| `Missing CORS documentation` (low) | ❌ style → Solomon approve | ✅ no es style |
| `Weak hash MD5` (low) | ❌ style → Solomon approve | ✅ no es style |
| `Hardcoded API token in config` (minor) | ❌ style → Solomon approve | ✅ no es style |
| `variable naming convention` (low) | ✅ style | ✅ style (sigue funcionando) |

## Test plan
- [x] 6 nuevos tests en `tests/solomon-rules.test.js` cubren regression
- [x] Suite completa 4536/4536 verde
- [x] No rompe el caso legítimo de style-only block (test 1 del nuevo describe)