### PR TITLE
fix(fs-leak): segunda capa detecta cd <abs-out-of-project> && write (KJC-BUG-0032)

### DIFF
--- a/src/orchestrator/fs-leak-detector.js
+++ b/src/orchestrator/fs-leak-detector.js
@@ -129,6 +129,55 @@ export function verifyLeaksAgainstTranscript(leaks, transcript) {
 }
 
 /**
+ * Layer 2 detection (KJC-BUG-0032): scan the coder's transcript for
+ * `cd <abs-path> && <write-cmd>` patterns where <abs-path> is OUTSIDE
+ * projectDir. Catches the bug class even when the target directory
+ * already existed (so snapshot-diff misses it) — e.g.
+ *   `cd /home/manu/assistant && pnpm init -y`
+ * when `~/assistant` was pre-existing.
+ *
+ * Filters applied:
+ *  - Only absolute paths (`/`, `~/`, `$HOME/`) — relative `cd subdir`
+ *    is assumed inside projectDir.
+ *  - Skips `/tmp/...` (ephemeral, legitimate scratch).
+ *  - Skips targets inside projectDir.
+ *  - Only flags if followed (same line, within 200 chars) by a
+ *    write/creation command: mkdir / touch / cp / mv / git init /
+ *    {pnpm,npm,yarn} init / {pnpm,npm,yarn,npx} create / cat > /
+ *    echo > / shell redirect (>, >>).
+ *  - Pure read commands (ls, which, cat <file>, grep) do NOT flag.
+ *
+ * @param {string|null|undefined} transcript
+ * @param {string|null} projectDir
+ * @returns {string[]} deduplicated absolute leak paths
+ */
+export function detectTranscriptCdLeaks(transcript, projectDir) {
+  if (!transcript || typeof transcript !== "string") return [];
+  const projectDirAbs = projectDir ? path.resolve(projectDir) : null;
+  const homeDir = os.homedir();
+  // Capture cd target + the next ~200 chars of the same line for write-cmd lookup.
+  const cdRegex = /\bcd\s+(~\/[^\s&|;`'"\n]+|\$HOME\/[^\s&|;`'"\n]+|\/[^\s&|;`'"\n]+)([^\n]{0,200})/g;
+  const writeCmdRegex = /\b(mkdir|touch|cp|mv|git\s+init|(?:pnpm|npm|yarn)\s+(?:init|create)|npx\s+create|cat\s*>|echo\s+[^|]*>|>>?\s*\S)/i;
+  const leaks = new Set();
+  let match;
+  while ((match = cdRegex.exec(transcript)) !== null) {
+    const original = match[1];
+    let target = original;
+    const rest = match[2] || "";
+    if (target.startsWith("~/")) target = path.join(homeDir, target.slice(2));
+    else if (target.startsWith("$HOME/")) target = path.join(homeDir, target.slice(6));
+    const abs = path.resolve(target);
+    // /tmp guard only applies to literal /tmp/... paths (ephemeral scratch),
+    // not to ~/ expansions that happen to land in /tmp during tests.
+    if (original === "/tmp" || original.startsWith("/tmp/")) continue;
+    if (projectDirAbs && (abs === projectDirAbs || abs.startsWith(projectDirAbs + path.sep))) continue;
+    if (!writeCmdRegex.test(rest)) continue;
+    leaks.add(abs);
+  }
+  return Array.from(leaks);
+}
+
+/**
  * Format a leak list into a multiline plain-Spanish error message.
  * Includes a hint about how to recover (move-or-delete) so the user
  * isn't left guessing.

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -18,7 +18,7 @@ import { runCoderWithFallback } from "../agent-fallback.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
-import { snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage, verifyLeaksAgainstTranscript } from "../fs-leak-detector.js";
+import { snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage, verifyLeaksAgainstTranscript, detectTranscriptCdLeaks } from "../fs-leak-detector.js";
 
 export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
   logger.setContext({ iteration, stage: "coder" });
@@ -159,10 +159,14 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
   // detected entries against the coder's transcript: only flag those
   // the coder demonstrably referenced.
   const coderTranscript = coderExecResult.result?.output || "";
-  const fsLeaks = verifyLeaksAgainstTranscript(candidateLeaks, coderTranscript);
-  if (candidateLeaks.length > 0 && fsLeaks.length === 0) {
+  const layer1Leaks = verifyLeaksAgainstTranscript(candidateLeaks, coderTranscript);
+  if (candidateLeaks.length > 0 && layer1Leaks.length === 0) {
     logger.warn(`fs-leak-detector: ${candidateLeaks.length} new $HOME entr(y/ies) detected but none referenced in the coder transcript — likely a concurrent host-side write, not flagging (#546).`);
   }
+  // Layer 2 (BUG-0032): scan the transcript for `cd <abs-out-of-project> && <write-cmd>`
+  // patterns the snapshot-diff misses (e.g. when target dir pre-existed).
+  const layer2Leaks = detectTranscriptCdLeaks(coderTranscript, projectDirAbs);
+  const fsLeaks = Array.from(new Set([...layer1Leaks, ...layer2Leaks]));
   if (fsLeaks.length > 0) {
     const msg = formatLeakMessage(fsLeaks, projectDirAbs);
     logger.error(msg);

--- a/tests/fs-leak-detector.test.js
+++ b/tests/fs-leak-detector.test.js
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage,
-  verifyLeaksAgainstTranscript,
+  verifyLeaksAgainstTranscript, detectTranscriptCdLeaks,
 } from "../src/orchestrator/fs-leak-detector.js";
 
 // KJC-BUG-0032 (PR-I): the coder's Bash tool can `cd` anywhere and
@@ -175,5 +175,98 @@ describe("verifyLeaksAgainstTranscript (issue #546 — host-write false positive
     const leaks = ["/home/x/assistant"];
     const transcript = "src/foo.js\nsrc/bar.js\nsrc/baz.js\nassistant\nfile.txt\n".repeat(100);
     expect(verifyLeaksAgainstTranscript(leaks, transcript)).toEqual(["/home/x/assistant"]);
+  });
+});
+
+describe("detectTranscriptCdLeaks (BUG-0032 layer 2 — cd-then-write outside projectDir)", () => {
+  it("flags `cd /abs && pnpm init` when target is outside projectDir", () => {
+    const transcript = "cd /home/manu/assistant && pnpm init -y\nDone.";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain("/home/manu/assistant");
+  });
+
+  it("flags `cd /abs && mkdir foo` when target is outside projectDir", () => {
+    const transcript = "cd /opt/other && mkdir -p src/index.js";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain("/opt/other");
+  });
+
+  it("flags `cd /abs && touch file.txt`", () => {
+    const transcript = "cd /var/data && touch new.csv";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain("/var/data");
+  });
+
+  it("flags `cd /abs && git init`", () => {
+    const transcript = "cd /home/manu/other-proj && git init";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain("/home/manu/other-proj");
+  });
+
+  it("flags `cd /abs && echo ... > file`", () => {
+    const transcript = "cd /home/manu/x && echo 'hi' > config.yaml";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain("/home/manu/x");
+  });
+
+  it("does NOT flag `cd /abs && ls` (pure read command)", () => {
+    const transcript = "cd /usr/local/bin && ls -la";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toEqual([]);
+  });
+
+  it("does NOT flag `cd /abs && which node` (read command)", () => {
+    const transcript = "cd /usr && which node";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toEqual([]);
+  });
+
+  it("does NOT flag `cd <relative> && pnpm init` (relative paths are inside projectDir)", () => {
+    const transcript = "cd subdir && pnpm init -y";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toEqual([]);
+  });
+
+  it("does NOT flag when target is INSIDE projectDir", () => {
+    const transcript = "cd /home/manu/proj/sub && pnpm init -y";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toEqual([]);
+  });
+
+  it("does NOT flag /tmp (ephemeral, legitimate scratch space)", () => {
+    const transcript = "cd /tmp/scratch && touch test.txt";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toEqual([]);
+  });
+
+  it("handles ~/path expansion", () => {
+    const home = process.env.HOME;
+    const transcript = "cd ~/rogue && pnpm init -y";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain(`${home}/rogue`);
+  });
+
+  it("handles $HOME expansion", () => {
+    const home = process.env.HOME;
+    const transcript = "cd $HOME/rogue && touch x.js";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks).toContain(`${home}/rogue`);
+  });
+
+  it("deduplicates leaks across multiple cd commands to the same dir", () => {
+    const transcript = "cd /opt/x && touch a\ncd /opt/x && touch b";
+    const leaks = detectTranscriptCdLeaks(transcript, "/home/manu/proj");
+    expect(leaks.filter(l => l === "/opt/x")).toHaveLength(1);
+  });
+
+  it("returns [] for empty/null transcript", () => {
+    expect(detectTranscriptCdLeaks("", "/proj")).toEqual([]);
+    expect(detectTranscriptCdLeaks(null, "/proj")).toEqual([]);
+    expect(detectTranscriptCdLeaks(undefined, "/proj")).toEqual([]);
+  });
+
+  it("does NOT crash when projectDir is null", () => {
+    const leaks = detectTranscriptCdLeaks("cd /opt/x && touch a", null);
+    expect(Array.isArray(leaks)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Defensa actual (`snapshotHomeTopLevel` + diff): solo detecta si el target del coder es un \$HOME top-level **nuevo**. Si el dir target ya existía (caso típico cuando el usuario reusa una carpeta), pasa inadvertido.
- Añade **segunda capa**: `detectTranscriptCdLeaks()` escanea el transcript del coder buscando `cd <ruta-abs> ... <write-cmd>` con ruta absoluta fuera de projectDir y comando de creación.
- Las dos capas se unifican en `coder-stage.js`.

## Patrones detectados (write-cmd)
`mkdir`, `touch`, `cp`, `mv`, `git init`, `{pnpm,npm,yarn} init`, `{pnpm,npm,yarn,npx} create`, `cat >`, `echo >`, `> file`, `>> file`

## Patrones NO detectados (read-only, legítimo)
`ls`, `which`, `cat <file>`, `grep`, etc. → 0 falsos positivos en pure-read.

## Exclusiones
- `/tmp/...` literal (scratch ephemeral)
- Targets dentro de projectDir
- Rutas relativas (`cd subdir`)

## Test plan
- [x] 14 nuevos tests en `tests/fs-leak-detector.test.js`
- [x] Suite completa: 4551/4551 verde
- [x] No regresión de layer 1 (snapshot-diff)