### PR TITLE
fix(plan): planner respeta exclusiones explícitas del scope (KJC-BUG-0042 / P1)

### DIFF
--- a/src/prompts/planner.js
+++ b/src/prompts/planner.js
@@ -50,6 +50,61 @@ export function parsePlannerOutput(output) {
   return { title: state.title, approach: state.approach, steps };
 }
 
+/**
+ * KJC-BUG-0042 / P1: extract explicit scope exclusions from the task.
+ *
+ * The planner consistently produced HUs for items the user explicitly
+ * excluded ("NO incluye en este plan: vistas compartidas, …"). Once
+ * these phrases land in the task text, the LLM still generated steps
+ * for them — the rule was implicit, never made FORBIDDEN. This function
+ * harvests them so the prompt can echo them back literally.
+ *
+ * Detected patterns (inline comma-separated lists, case-insensitive):
+ *   - "NO incluye[...]: a, b, c"           (Spanish)
+ *   - "Fuera de(l) scope[...]: a, b, c"
+ *   - "Out of scope[...]: a, b, c"          (English)
+ *   - "Not in (this) plan[...]: a, b, c"
+ *   - "Plan N handles: a, b, c"             (cross-plan reference)
+ *   - "Reserved for plan[...]: a, b, c"
+ *
+ * @param {string} task
+ * @returns {string[]} deduplicated trimmed exclusion items
+ */
+export function extractScopeExclusions(task) {
+  if (!task || typeof task !== "string") return [];
+  const patterns = [
+    /\bNO\s+incluye[^:\n]{0,60}:\s*([^.\n]+)/gi,
+    /\bFuera\s+de(?:l)?\s+scope[^:\n]{0,60}:\s*([^.\n]+)/gi,
+    /\bOut\s+of\s+scope[^:\n]{0,60}:\s*([^.\n]+)/gi,
+    /\bNot\s+in\s+(?:this\s+)?plan[^:\n]{0,60}:\s*([^.\n]+)/gi,
+    /\bPlan\s+\d+\s+handles[^:\n]{0,60}:?\s*([^.\n]+)/gi,
+    /\bReserved\s+for\s+plan[^:\n]{0,60}:\s*([^.\n]+)/gi,
+  ];
+  const items = new Set();
+  for (const re of patterns) {
+    let m;
+    while ((m = re.exec(task)) !== null) {
+      const list = m[1] || "";
+      for (const raw of list.split(/,|;| y |\sand\s/)) {
+        const item = raw.trim().replace(/^[-*]\s*/, "").replace(/\.$/, "");
+        if (item && item.length < 120) items.add(item);
+      }
+    }
+  }
+  return Array.from(items);
+}
+
+function renderScopeExclusions(exclusions) {
+  if (!exclusions || exclusions.length === 0) return null;
+  const list = exclusions.map((e) => `  - ${e}`).join("\n");
+  return [
+    "## FORBIDDEN scope (out-of-scope items declared in the task)",
+    "The task explicitly excludes the following from this plan. Do NOT generate steps that implement them. If a step would touch any of these, drop it and put the item in `outOfScope` instead:",
+    "",
+    list,
+  ].join("\n");
+}
+
 function formatArchitectContext(architectContext) {
   if (!architectContext) return null;
   const arch = architectContext.architecture || {};
@@ -146,6 +201,12 @@ export function buildPlannerPrompt({ task, context, architectContext, productCon
 
   if (context) {
     parts.push("## Context", context, "");
+  }
+
+  const exclusions = extractScopeExclusions(task);
+  const exclusionsSection = renderScopeExclusions(exclusions);
+  if (exclusionsSection) {
+    parts.push(exclusionsSection, "");
   }
 
   const archSection = formatArchitectContext(architectContext);

--- a/tests/prompt-planner.test.js
+++ b/tests/prompt-planner.test.js
@@ -142,4 +142,56 @@ describe("prompts/planner buildPlannerPrompt", () => {
       expect(prompt).toMatch(/NEVER `null`, NEVER omitted, NEVER a free-form paraphrase/);
     });
   });
+
+  describe("scope exclusions (KJC-BUG-0042 / P1)", () => {
+    it("echoes NO incluye items as FORBIDDEN scope when task has explicit Spanish exclusions", () => {
+      const SPEC = [
+        "# Plan 2 — GRETA",
+        "## Scope",
+        "Cubre PROFILE, ASSESS, AI.",
+        "",
+        "NO incluye en este plan: vistas compartidas, filtros comparativos, exportación CSV.",
+      ].join("\n");
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toContain("FORBIDDEN");
+      expect(prompt).toContain("vistas compartidas");
+      expect(prompt).toContain("filtros comparativos");
+      expect(prompt).toContain("exportación CSV");
+    });
+
+    it("echoes Out of scope items when task has English exclusions", () => {
+      const SPEC = [
+        "# Spec",
+        "Out of scope: real-time sync, mobile UI, payment integration.",
+      ].join("\n");
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toContain("FORBIDDEN");
+      expect(prompt).toContain("real-time sync");
+      expect(prompt).toContain("mobile UI");
+      expect(prompt).toContain("payment integration");
+    });
+
+    it("echoes 'Plan X handles' references as out-of-scope for current plan", () => {
+      const SPEC = [
+        "# Plan 2",
+        "Plan 3 handles cross-tenant views and shared dashboards.",
+      ].join("\n");
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toContain("FORBIDDEN");
+      expect(prompt).toContain("cross-tenant views");
+      expect(prompt).toContain("shared dashboards");
+    });
+
+    it("does NOT emit FORBIDDEN section when no exclusions are declared", () => {
+      const prompt = buildPlannerPrompt({ task: "Add login page with email/password" });
+      expect(prompt).not.toContain("FORBIDDEN");
+    });
+
+    it("instructs the planner to NEVER generate steps for FORBIDDEN items", () => {
+      const SPEC = "NO incluye: foo, bar.";
+      const prompt = buildPlannerPrompt({ task: SPEC });
+      expect(prompt).toMatch(/Do NOT generate steps/i);
+      expect(prompt).toMatch(/outOfScope/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Detectado en regeneración Plan 2 GRETA (2026-05-11): el planner generaba HUs para items que el task file marcaba explícitamente como out-of-scope.
- Causa raíz: el prompt no menciona la regla "respeta exclusiones explícitas". Las frases del task se quedan en la sección Task pero no se elevan a FORBIDDEN.
- Fix: añadir `extractScopeExclusions(task)` que detecta 6 patrones (ES + EN) y renderiza una sección **FORBIDDEN scope** con instrucción explícita.

## Patrones detectados (case-insensitive)
| Patrón | Idioma |
|---|---|
| `NO incluye[…]: a, b, c` | ES |
| `Fuera de(l) scope[…]: a, b, c` | ES |
| `Out of scope[…]: a, b, c` | EN |
| `Not in (this) plan[…]: a, b, c` | EN |
| `Plan N handles[…]: a, b, c` | cross-plan reference |
| `Reserved for plan[…]: a, b, c` | EN |

Items separados por `,`, `;`, ` y ` (ES), ` and ` (EN). Cada item se trimea y se filtra por longitud (<120 chars) para evitar capturar párrafos enteros.

## Test plan
- [x] 5 nuevos tests en `tests/prompt-planner.test.js`
- [x] Suite completa: 4556/4556 verde
- [x] Back-compat: prompt NO emite FORBIDDEN si no hay exclusiones declaradas