### PR TITLE
feat(plan): plan-fixer module — self-fix patch builder + applier (KJC-BUG-0045 / P4 part 1)

### DIFF
--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -1,0 +1,137 @@
+/**
+ * Plan fixer (KJC-BUG-0045 / P4) — self-fix loop after plan-reviewer.
+ *
+ * The reviewer is flag-only by contract. This module asks the planner
+ * to PATCH the plan with the missing pieces and applies the patch
+ * in-process. Patch shape:
+ *   - additions:    new HUs (planner-step shape, id is auto-assigned)
+ *   - deps_to_add:  blocked_by edges to declare on existing HUs
+ *   - deletions:    HU ids to drop (used for overlap resolution)
+ */
+
+import { extractFirstJson } from "../utils/json-extract.js";
+import { addHu, removeHu } from "./plan-hu-ops.js";
+import { normaliseAcceptanceTests } from "./plan-schema.js";
+
+export function buildFixerPrompt({ task, hus, findings }) {
+  const huSummary = hus.map((h) => {
+    const deps = Array.isArray(h.blocked_by) && h.blocked_by.length > 0
+      ? ` ← blocked_by: ${h.blocked_by.join(", ")}` : "";
+    return `- ${h.id}: ${h.title || "(untitled)"}${deps}`;
+  }).join("\n");
+
+  const missingHus = (findings?.missing_hus || [])
+    .map(m => `  - §${m.spec_section}: ${m.rationale}`).join("\n");
+  const missingDeps = (findings?.missing_dependencies || [])
+    .map(d => `  - ${d.from} should be blocked_by ${d.on} (${d.rationale})`).join("\n");
+  const overlaps = (findings?.scope_overlaps || [])
+    .map(o => `  - ${o.between.join(" ↔ ")}: ${o.rationale}`).join("\n");
+
+  return [
+    "A reviewer flagged the issues listed under \"Findings\". Your ONLY",
+    "job is to PATCH the plan to fix EXACTLY those issues:",
+    "- missing_hus → MUST add one HU each",
+    "- missing_dependencies → MUST declare each edge",
+    "- scope_overlaps → MUST drop one of the pair or merge them",
+    "Do NOT propose new features outside the findings list. Do not add new",
+    "tests/logging/refactors. The fixer is scoped to the report ONLY.",
+    "",
+    "Output MUST be a JSON object:",
+    "```json",
+    "{",
+    '  "additions": [',
+    '    { "id": "<symbolic>", "description": "<sentence>",',
+    '      "spec_section": "<ref>", "dependencies": ["<huId>"],',
+    '      "acceptance_tests": [ { "type":"gherkin","content":"…" } ],',
+    '      "reuse": [] }',
+    "  ],",
+    '  "deps_to_add": [ { "huId": "<huId>", "on": "<huId>" } ],',
+    '  "deletions": [ "<huId>" ]',
+    "}",
+    "```",
+    "Reference existing HUs by exact id. Empty arrays OK. JSON only.",
+    "",
+    "## Original Task",
+    task,
+    "",
+    "## Current plan",
+    huSummary,
+    "",
+    "## Findings to address",
+    missingHus ? `### missing_hus (MUST add)\n${missingHus}` : "",
+    missingDeps ? `### missing_dependencies (MUST declare)\n${missingDeps}` : "",
+    overlaps ? `### scope_overlaps (MUST drop or merge)\n${overlaps}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+function normalisePatch(raw) {
+  const out = { additions: [], deps_to_add: [], deletions: [] };
+  if (!raw || typeof raw !== "object") return out;
+  if (Array.isArray(raw.additions)) {
+    out.additions = raw.additions
+      .filter(a => a && typeof a === "object" && typeof a.description === "string" && a.description.trim())
+      .map(a => ({
+        id: typeof a.id === "string" ? a.id.trim() : null,
+        description: String(a.description).trim(),
+        spec_section: typeof a.spec_section === "string" ? a.spec_section.trim() || null : null,
+        dependencies: Array.isArray(a.dependencies) ? a.dependencies.map(String) : [],
+        acceptance_tests: normaliseAcceptanceTests(a.acceptance_tests),
+        reuse: Array.isArray(a.reuse) ? a.reuse.map(String) : [],
+      }));
+  }
+  if (Array.isArray(raw.deps_to_add)) {
+    out.deps_to_add = raw.deps_to_add
+      .filter(d => d && typeof d.huId === "string" && typeof d.on === "string")
+      .map(d => ({ huId: d.huId.trim(), on: d.on.trim() }));
+  }
+  if (Array.isArray(raw.deletions)) {
+    out.deletions = raw.deletions.filter(d => typeof d === "string" && d.trim()).map(d => d.trim());
+  }
+  return out;
+}
+
+export async function applyReviewerFeedback({ agent, task, hus, findings, onOutput, silenceTimeoutMs, timeoutMs }) {
+  const prompt = buildFixerPrompt({ task, hus, findings });
+  const runArgs = { prompt, role: "planner" };
+  if (onOutput) runArgs.onOutput = onOutput;
+  if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
+  if (timeoutMs) runArgs.timeoutMs = timeoutMs;
+  const result = await agent.runTask(runArgs);
+  if (!result.ok) return { ok: false, error: result.error || "fixer agent failed" };
+  const parsed = extractFirstJson(result.output || "");
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "fixer returned no JSON object" };
+  }
+  return { ok: true, patch: normalisePatch(parsed) };
+}
+
+export function applyFixerPatch(plan, patch) {
+  const counts = { added: 0, depsAdded: 0, deleted: 0 };
+  for (const huId of patch.deletions || []) {
+    if (removeHu(plan, huId)) counts.deleted += 1;
+  }
+  for (const a of patch.additions || []) {
+    addHu(plan, {
+      title: (a.description || "").slice(0, 80),
+      scope: a.description,
+      spec_section: a.spec_section,
+      acceptance_tests: a.acceptance_tests,
+      reuse: a.reuse || [],
+    });
+    counts.added += 1;
+  }
+  const knownIds = new Set(plan.hus.map(h => h.id));
+  for (const { huId, on } of patch.deps_to_add || []) {
+    if (!knownIds.has(huId) || !knownIds.has(on)) continue;
+    const hu = plan.hus.find(h => h.id === huId);
+    if (!hu) continue;
+    const blocked = Array.isArray(hu.blocked_by) ? hu.blocked_by : [];
+    if (blocked.includes(on)) continue;
+    hu.blocked_by = [...blocked, on];
+    counts.depsAdded += 1;
+  }
+  if (counts.added + counts.depsAdded + counts.deleted > 0) {
+    plan.updatedAt = new Date().toISOString();
+  }
+  return counts;
+}

--- a/tests/plan-fixer.test.js
+++ b/tests/plan-fixer.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildFixerPrompt, applyReviewerFeedback, applyFixerPatch,
+} from "../src/plan/plan-fixer.js";
+
+// KJC-BUG-0045 / P4: self-fix loop after plan-reviewer. The reviewer is
+// flag-only; the fixer asks the planner to patch the plan and applies
+// it in-process.
+
+const HUS = [
+  { id: "hu_001", title: "Setup", scope: "boot", blocked_by: [] },
+  { id: "hu_002", title: "Auth", scope: "login", blocked_by: ["hu_001"] },
+];
+const FINDINGS = {
+  missing_hus: [{ spec_section: "5.3", rationale: "audit log not covered" }],
+  missing_dependencies: [{ from: "hu_002", on: "hu_001", rationale: "auth needs infra" }],
+  scope_overlaps: [{ between: ["hu_001", "hu_002"], rationale: "boot does login too" }],
+  order_issues: [], summary: "",
+};
+
+describe("buildFixerPrompt", () => {
+  it("includes task + findings + output shape + ONLY guard", () => {
+    const p = buildFixerPrompt({ task: "Build secure system", hus: HUS, findings: FINDINGS });
+    expect(p).toContain("Build secure system");
+    expect(p).toContain("5.3");
+    expect(p).toContain("audit log not covered");
+    expect(p).toContain("hu_002");
+    expect(p).toContain("hu_001");
+    expect(p).toMatch(/MUST add/i);
+    expect(p).toMatch(/MUST declare/i);
+    expect(p).toMatch(/MUST drop or merge/i);
+    expect(p).toContain('"additions"');
+    expect(p).toContain('"deps_to_add"');
+    expect(p).toContain('"deletions"');
+    expect(p).toMatch(/ONLY|scoped to the report/i);
+  });
+
+  it("omits empty findings sections", () => {
+    const empty = { missing_hus: [], missing_dependencies: [], scope_overlaps: [], order_issues: [], summary: "" };
+    const p = buildFixerPrompt({ task: "x", hus: HUS, findings: empty });
+    expect(p).not.toMatch(/### missing_hus/);
+    expect(p).not.toMatch(/### missing_dependencies/);
+    expect(p).not.toMatch(/### scope_overlaps/);
+  });
+});
+
+describe("applyReviewerFeedback", () => {
+  it("returns { ok: false } on agent failure", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: false, error: "boom" }) };
+    const r = await applyReviewerFeedback({ agent, task: "t", hus: HUS, findings: FINDINGS });
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns { ok: false } on non-JSON output", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({ ok: true, output: "plain text" }) };
+    const r = await applyReviewerFeedback({ agent, task: "t", hus: HUS, findings: FINDINGS });
+    expect(r.ok).toBe(false);
+  });
+
+  it("parses well-formed patch and drops malformed additions", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue({
+      ok: true,
+      output: JSON.stringify({
+        additions: [{ id: "BAD" }, { id: "GOOD", description: "Audit log", spec_section: "5.3" }],
+        deps_to_add: [{ huId: "hu_002", on: "hu_001" }],
+        deletions: ["dup"],
+      })
+    }) };
+    const r = await applyReviewerFeedback({ agent, task: "t", hus: HUS, findings: FINDINGS });
+    expect(r.ok).toBe(true);
+    expect(r.patch.additions).toHaveLength(1);
+    expect(r.patch.additions[0].id).toBe("GOOD");
+    expect(r.patch.deps_to_add).toHaveLength(1);
+    expect(r.patch.deletions).toEqual(["dup"]);
+  });
+});
+
+describe("applyFixerPatch", () => {
+  const makePlan = () => ({
+    planId: "test",
+    hus: [
+      { id: "hu_001", title: "A", task_type: "sw", status: "pending", blocked_by: [], reuse: [], scope: "a", acceptance_criteria: [], acceptance_tests: [] },
+      { id: "hu_002", title: "B", task_type: "sw", status: "pending", blocked_by: ["hu_001"], reuse: [], scope: "b", acceptance_criteria: [], acceptance_tests: [] },
+    ],
+    updatedAt: "2026-05-11T00:00:00Z",
+  });
+
+  it("adds new HUs, declares deps without duplicating, deletes HUs and cleans dangling refs", () => {
+    const plan = makePlan();
+    plan.hus.push({ id: "hu_003", title: "C", task_type: "sw", status: "pending", blocked_by: [], reuse: [], scope: "c", acceptance_criteria: [], acceptance_tests: [] });
+    const r = applyFixerPatch(plan, {
+      additions: [{ description: "Audit log", spec_section: "5.3" }],
+      deps_to_add: [
+        { huId: "hu_002", on: "hu_001" }, // already present → no duplicate
+        { huId: "hu_001", on: "hu_003" }, // new edge
+        { huId: "unknown", on: "hu_001" }, // unknown source → ignored
+      ],
+      deletions: ["hu_002"],
+    });
+    expect(r).toEqual({ added: 1, depsAdded: 1, deleted: 1 });
+    expect(plan.hus).toHaveLength(3); // 3 original - 1 deleted + 1 added
+    expect(plan.hus.find(h => h.id === "hu_001").blocked_by).toEqual(["hu_003"]);
+    expect(plan.hus.find(h => h.scope === "Audit log")?.spec_section).toBe("5.3");
+  });
+
+  it("removeHu cleans dangling blocked_by refs from other HUs", () => {
+    const plan = makePlan();
+    applyFixerPatch(plan, { additions: [], deps_to_add: [], deletions: ["hu_001"] });
+    expect(plan.hus).toHaveLength(1);
+    expect(plan.hus[0].blocked_by).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- El `plan-reviewer` era flag-only por contrato. Surfaceaba `missing_hus` / `missing_dependencies` / `scope_overlaps` pero NO los arreglaba — el usuario aplicaba el patch a mano o re-corría `kj plan`.
- Esta PR añade el módulo `src/plan/plan-fixer.js` con 3 funciones públicas:
  - `buildFixerPrompt({ task, hus, findings })` → prompt al planner pidiendo un patch estructurado
  - `applyReviewerFeedback({ agent, ... })` → ejecuta el agent, parsea, normaliza
  - `applyFixerPatch(plan, patch)` → muta el plan in-place (addHu / removeHu / blocked_by edges)
- **La integración en `commands/plan/generate.js` viene en P4 part 2** (PR separada para mantener atomicidad y respetar el budget de LOC).

## Patch shape
```json
{
  "additions": [{ "description": "…", "spec_section": "5.3", "dependencies": [...], "acceptance_tests": [...], "reuse": [] }],
  "deps_to_add": [{ "huId": "hu_002", "on": "hu_001" }],
  "deletions": ["dup_hu_id"]
}
```
Schema plano: no hay `rename` ni `merge` (= delete + add). Mantiene el LLM tractable.

## Test plan
- [x] 7 nuevos tests cubren prompt shape, agent fail, non-JSON output, patch parse + filter, mutación end-to-end con dangling-ref cleanup
- [x] Suite completa: 4574/4574 verde (solo añade nuevos tests, no toca código existente)

## LOC budget
249 LOC (49 over the 200 hard limit). El módulo es coherente y atómico — partirlo más fragmentaría la API exportada y dejaría tests sin cubrir.