### PR TITLE
fix(sonar): rotación de admin password no falla silenciosamente (KJC-BUG-0035)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -397,6 +397,12 @@ async function setupSonarQube(config, logger, { interactive } = {}) {
       logger.info(`  -> Sonar token saved to ${result.savedTo}`);
       if (result.passwordRotated) {
         logger.info(`  -> Sonar admin password rotated. New value at ${result.passwordSavedTo}`);
+      } else if (result.passwordRotationError) {
+        // KJC-BUG-0035: rotation failed but token generation succeeded.
+        // admin/admin is still live — surface it loudly so the user can
+        // fix it manually before someone else exploits it.
+        logger.warn(`  -> SonarQube admin password NOT rotated: ${result.passwordRotationError}`);
+        logger.warn("     admin/admin remains active. Rotate it manually at http://localhost:9000/account/security");
       }
       return;
     }

--- a/src/sonar/token-bootstrap.js
+++ b/src/sonar/token-bootstrap.js
@@ -102,6 +102,10 @@ export async function bootstrapSonarToken({ host = "http://localhost:9000" } = {
   let pass = DEFAULT_PASS;
   let passwordRotated = false;
   let passwordSavedTo = null;
+  // KJC-BUG-0035: capture rotation failures so the caller can log them
+  // instead of swallowing the error silently. Pre-fix the rotation
+  // returned status 403/500/network were ignored and the user never knew.
+  let passwordRotationError = null;
 
   // 1) Probe: does admin/admin still work?
   const probe = await call(host, "/api/authentication/validate", { user, pass }).catch((err) => ({ status: 0, body: err.message }));
@@ -142,10 +146,19 @@ export async function bootstrapSonarToken({ host = "http://localhost:9000" } = {
       pass = longerPass;
       passwordRotated = true;
       passwordSavedTo = persistSecret("sonar.admin-password", pass);
+    } else {
+      passwordRotationError = `rotate-retry HTTP ${retry.status}: ${detailFromBody(retry.body)}`;
     }
-  } else if (change.status !== 0 && change.status !== 401) {
-    // Non-fatal: probably the admin already changed the password. We
-    // continue using whatever credentials worked at the probe step.
+  } else if (change.status === 401) {
+    // Expected: admin already changed password — not a failure.
+  } else if (change.status !== 0) {
+    // KJC-BUG-0035: ANY other non-success status (403, 500, 400-without-default, …)
+    // means the rotation didn't happen and admin/admin is still live on disk.
+    // Surface it via the result so the caller can warn the user.
+    passwordRotationError = `rotate HTTP ${change.status}: ${detailFromBody(change.body)}`;
+  } else {
+    // status === 0: network error before getting any HTTP response.
+    passwordRotationError = `rotate network error: ${detailFromBody(change.body)}`;
   }
 
   // 3) Token already exists? Revoke it so we can re-create cleanly.
@@ -178,5 +191,15 @@ export async function bootstrapSonarToken({ host = "http://localhost:9000" } = {
     savedTo,
     passwordRotated,
     passwordSavedTo: passwordRotated ? passwordSavedTo : null,
+    passwordRotationError,
   };
+}
+
+function detailFromBody(body) {
+  if (!body) return "no body";
+  if (typeof body === "string") return body.slice(0, 200);
+  if (Array.isArray(body.errors)) {
+    return body.errors.map(e => e?.msg || JSON.stringify(e)).join("; ").slice(0, 200);
+  }
+  try { return JSON.stringify(body).slice(0, 200); } catch { return "(unserialisable)"; }
 }

--- a/tests/sonar-token-bootstrap.test.js
+++ b/tests/sonar-token-bootstrap.test.js
@@ -93,6 +93,57 @@ describe("bootstrapSonarToken (KJC-TSK-0367)", () => {
     expect(r.ok).toBe(true);
     expect(r.token).toBe("squ_kept_password");
     expect(r.passwordRotated).toBe(false);
+    // 401 = "admin already changed it" → not an error, no rotation diagnostic
+    expect(r.passwordRotationError).toBe(null);
+  });
+
+  // KJC-BUG-0035: rotation must NOT fail silently on unexpected statuses.
+  // Pre-fix the bootstrapper swallowed 403/500/etc., leaving admin/admin
+  // live on disk while pretending everything worked.
+  it("surfaces passwordRotationError on HTTP 403 rotation (no permission)", async () => {
+    fetchMock
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      .mockReturnValueOnce(jsonResponse(403, { errors: [{ msg: "Forbidden" }] }))
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      .mockReturnValueOnce(jsonResponse(200, { token: "squ_kept_403" }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(true);
+    expect(r.passwordRotated).toBe(false);
+    expect(r.passwordRotationError).toMatch(/HTTP 403/);
+    expect(r.passwordRotationError).toMatch(/Forbidden/);
+  });
+
+  it("surfaces passwordRotationError on HTTP 500 rotation (server error)", async () => {
+    fetchMock
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      .mockReturnValueOnce(jsonResponse(500, { errors: [{ msg: "Internal error" }] }))
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      .mockReturnValueOnce(jsonResponse(200, { token: "squ_kept_500" }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(true);
+    expect(r.passwordRotated).toBe(false);
+    expect(r.passwordRotationError).toMatch(/HTTP 500/);
+  });
+
+  it("surfaces passwordRotationError on 400-without-default-error (validation mismatch)", async () => {
+    fetchMock
+      .mockReturnValueOnce(jsonResponse(200, { valid: true }))
+      .mockReturnValueOnce(jsonResponse(400, { errors: [{ msg: "Password too short" }] }))
+      .mockReturnValueOnce(jsonResponse(200, ""))
+      .mockReturnValueOnce(jsonResponse(200, { token: "squ_kept_400" }));
+
+    const { bootstrapSonarToken } = await import("../src/sonar/token-bootstrap.js");
+    const r = await bootstrapSonarToken({ host: "http://localhost:9000" });
+
+    expect(r.ok).toBe(true);
+    expect(r.passwordRotated).toBe(false);
+    expect(r.passwordRotationError).toMatch(/HTTP 400/);
   });
 
   it("returns ok=false with reason when token generation itself fails", async () => {


### PR DESCRIPTION
## Summary
- Pre-fix: si `change_password` devolvía HTTP 403/500/400-sin-error-default o network error, el bootstrapper **ignoraba silenciosamente**. El token se generaba con admin/admin, el usuario veía "Sonar token saved" y nunca sabía que la rotación había fallado.
- Fix: capturar el detalle del fallo en `passwordRotationError` y loguear WARNING explícito en `init.js`.

## Cambios
- `src/sonar/token-bootstrap.js`: distinguir entre 401 (expected — admin ya cambió, no es error) y otros statuses (capturar `passwordRotationError`). Nuevo helper `detailFromBody()`.
- `src/commands/init.js`: si `result.ok && !result.passwordRotated && result.passwordRotationError`, loguear warning con instrucciones para rotar a mano.

## Test plan
- [x] 3 nuevos tests: HTTP 403, HTTP 500, HTTP 400-sin-default-error
- [x] Test existente 401 ahora verifica `passwordRotationError === null` (es legítimo)
- [x] Suite completa: 4577/4577 verde