### PR TITLE
fix(hu-board): zombie-TTL para prompts huérfanos (KJC-BUG-0038)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -639,25 +639,46 @@ function promptsDir() {
  * boot to surface modals for prompts that were already pending when
  * the page loaded (the SSE event fires only on new arrivals).
  */
+// KJC-BUG-0038: prompts whose runner crashed leave the .json behind in
+// ~/.kj/prompts/. Without a TTL, every board reload re-shows the zombie
+// modal "Karajan needs an answer" with no runner behind it — the user
+// can answer but nothing happens. 30 minutes covers the longest legitimate
+// Solomon escalation; anything older is a crashed runner.
+const PROMPT_ZOMBIE_TTL_MS = 30 * 60 * 1000;
+
 router.get('/prompts', (_req, res) => {
   try {
     const dir = promptsDir();
     if (!fs.existsSync(dir)) return res.json([]);
     const entries = fs.readdirSync(dir);
     const result = [];
+    const now = Date.now();
     for (const name of entries) {
       if (!name.endsWith('.json') || name.endsWith('.answer.json')) continue;
       const promptId = name.replace(/\.json$/, '');
+      const mainPath = path.join(dir, name);
+      const answerPath = path.join(dir, `${promptId}.answer.json`);
       // KJC-TSK-0380 — skip tombstoned prompts and clean their files.
       if (isTombstonedFn('prompt', promptId)) {
-        try { fs.unlinkSync(path.join(dir, name)); } catch { /* */ }
-        try { fs.unlinkSync(path.join(dir, `${promptId}.answer.json`)); } catch { /* */ }
+        try { fs.unlinkSync(mainPath); } catch { /* */ }
+        try { fs.unlinkSync(answerPath); } catch { /* */ }
         continue;
       }
+      let parsed;
       try {
-        const raw = fs.readFileSync(path.join(dir, name), 'utf-8');
-        result.push(JSON.parse(raw));
-      } catch { /* malformed — skip */ }
+        parsed = JSON.parse(fs.readFileSync(mainPath, 'utf-8'));
+      } catch { continue; /* malformed — skip */ }
+      // KJC-BUG-0038: zombie detection. Prefer parsed.createdAt; fall back
+      // to mtime if the runner skipped the timestamp (older formats).
+      const createdMs = Date.parse(parsed?.createdAt || '');
+      const ageRef = Number.isFinite(createdMs) ? createdMs : safeMtime(mainPath);
+      if (ageRef && (now - ageRef) > PROMPT_ZOMBIE_TTL_MS) {
+        try { fs.unlinkSync(mainPath); } catch { /* */ }
+        try { fs.unlinkSync(answerPath); } catch { /* */ }
+        addTombstone('prompt', promptId, { source: 'zombie-ttl', fsPaths: [mainPath, answerPath] });
+        continue;
+      }
+      result.push(parsed);
     }
     result.sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
     res.json(result);
@@ -665,6 +686,10 @@ router.get('/prompts', (_req, res) => {
     res.status(500).json({ error: err.message });
   }
 });
+
+function safeMtime(p) {
+  try { return fs.statSync(p).mtimeMs; } catch { return 0; }
+}
 
 /**
  * POST /api/prompts/:promptId/answer - Body { answer }. Writes a

--- a/packages/hu-board/tests/prompts-api.test.js
+++ b/packages/hu-board/tests/prompts-api.test.js
@@ -36,11 +36,15 @@ describe("GET /api/prompts", () => {
   it("returns the pending prompts sorted by createdAt", async () => {
     const dir = join(tmp, "prompts");
     mkdirSync(dir);
+    // Use relative timestamps so the test is robust against the zombie-TTL
+    // filter (KJC-BUG-0038): both must be within the live window.
+    const t1 = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    const t2 = new Date(Date.now() - 1 * 60 * 1000).toISOString();
     writeFileSync(join(dir, "prompt-2.json"), JSON.stringify({
-      promptId: "prompt-2", sessionId: "s", question: "second?", createdAt: "2026-04-25T11:00:00Z",
+      promptId: "prompt-2", sessionId: "s", question: "second?", createdAt: t2,
     }));
     writeFileSync(join(dir, "prompt-1.json"), JSON.stringify({
-      promptId: "prompt-1", sessionId: "s", question: "first?", createdAt: "2026-04-25T10:00:00Z",
+      promptId: "prompt-1", sessionId: "s", question: "first?", createdAt: t1,
     }));
     const res = await request(app).get("/api/prompts");
     expect(res.status).toBe(200);
@@ -64,6 +68,48 @@ describe("GET /api/prompts", () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].promptId).toBe("good");
+  });
+
+  // KJC-BUG-0038: zombie prompts (runner crashed) must NOT keep showing
+  // the modal forever. After 30 minutes the GET drops them and unlinks
+  // the file from disk.
+  it("filters out zombie prompts older than the 30min TTL and deletes the file", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    const oldTs = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    const zombiePath = join(dir, "prompt-zombie.json");
+    writeFileSync(zombiePath, JSON.stringify({ promptId: "prompt-zombie", question: "?", createdAt: oldTs }));
+    writeFileSync(join(dir, "prompt-fresh.json"), JSON.stringify({ promptId: "prompt-fresh", question: "?", createdAt: new Date().toISOString() }));
+
+    const res = await request(app).get("/api/prompts");
+    expect(res.status).toBe(200);
+    expect(res.body.map(p => p.promptId)).toEqual(["prompt-fresh"]);
+    expect(existsSync(zombiePath)).toBe(false);
+  });
+
+  it("keeps a fresh prompt (createdAt 5 min old) — TTL does not over-fire", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    const recentTs = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const p = join(dir, "prompt-recent.json");
+    writeFileSync(p, JSON.stringify({ promptId: "prompt-recent", question: "?", createdAt: recentTs }));
+    const res = await request(app).get("/api/prompts");
+    expect(res.body.map(x => x.promptId)).toEqual(["prompt-recent"]);
+    expect(existsSync(p)).toBe(true);
+  });
+
+  it("uses file mtime as fallback when createdAt is missing", async () => {
+    const dir = join(tmp, "prompts");
+    mkdirSync(dir);
+    const p = join(dir, "prompt-legacy.json");
+    writeFileSync(p, JSON.stringify({ promptId: "prompt-legacy", question: "?" })); // no createdAt
+    // Backdate mtime by 1 hour
+    const { utimesSync } = await import("node:fs");
+    const past = (Date.now() - 60 * 60 * 1000) / 1000;
+    utimesSync(p, past, past);
+    const res = await request(app).get("/api/prompts");
+    expect(res.body).toEqual([]);
+    expect(existsSync(p)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Pre-fix: si el runner crashea sin responder a askQuestion, `~/.kj/prompts/prompt-XXX.json` queda huérfano. Cada reload del board muestra el modal "Karajan needs an answer" pero no hay runner detrás — el user contesta y nada pasa.
- Fix: TTL de 30 min en `GET /api/prompts`. Si `createdAt` (fallback a `mtime`) es más viejo, borrar archivos + tombstone + skip.

## Por qué 30 min
Cubre la Solomon escalation legítima más larga (un agent que tarda en responder). Cualquier prompt huérfano más viejo es un runner crashed.

## Test plan
- [x] 3 nuevos tests: zombie deleted, fresh prompt preserved, mtime fallback
- [x] Test existente actualizado: usaba fechas hardcoded de 2026-04-25 que ahora caerían en zona zombie
- [x] Suite root: 4577/4577 verde
- [x] Suite hu-board: 25 test files verde