### PR TITLE
fix(hu-board): rate-limit menos agresivo + SSE exento (KJC-BUG-0039)

### DIFF
--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -123,18 +123,31 @@ export function buildSecurityMiddleware() {
 }
 
 /**
- * Build the rate-limit middleware for `/api`. Default is 300 req/min
- * per IP — comfortable for the dashboard's polling pattern (typical:
- * a /api/sync + a /api/dashboard every 2-3s) and well below what an
- * abusive scanner would do.
+ * Build the rate-limit middleware for `/api`.
+ *
+ * Default is 600 req/min per IP (raised from 300 in KJC-BUG-0039 —
+ * the first-load fanout of the dashboard + multiple tabs + SSE
+ * reconnects after a refresh could push past 300/min and hit the user
+ * with a 429 on the very first page they see).
+ *
+ * Override via env var `HU_BOARD_RATE_LIMIT=<n>` for unusual setups
+ * (load tests, multi-board farms behind a shared NAT).
+ *
+ * SSE (`/api/events`) is exempt — a single persistent stream should
+ * not count toward a per-minute request budget, and tab refreshes
+ * legitimately create new SSE connections.
+ *
  * @returns {import('express').RequestHandler}
  */
 export function buildRateLimiter() {
+  const raw = Number(process.env.HU_BOARD_RATE_LIMIT);
+  const limit = Number.isFinite(raw) && raw > 0 ? raw : 600;
   return rateLimit({
     windowMs: 60 * 1000,
-    limit: 300,
+    limit,
     standardHeaders: 'draft-7',  // RateLimit-* headers
     legacyHeaders: false,         // drop X-RateLimit-*
+    skip: (req) => req.path === '/events' || req.path.startsWith('/events/'),
     message: {
       error: 'Too Many Requests',
       message: 'Rate limit exceeded. Try again in a few seconds.',

--- a/packages/hu-board/tests/security-middleware.test.js
+++ b/packages/hu-board/tests/security-middleware.test.js
@@ -98,4 +98,48 @@ describe('security middleware — rate limit', () => {
     expect(blocked.status).toBe(429);
     expect(blocked.body.error).toBe('Too Many Requests');
   });
+
+  // KJC-BUG-0039: SSE must be exempt from the rate limit. A single
+  // persistent stream + tab refreshes were enough to hit the old 300/min
+  // budget on the very first page load.
+  it('exempts /api/events (SSE) from the rate limit', async () => {
+    const original = process.env.HU_BOARD_RATE_LIMIT;
+    process.env.HU_BOARD_RATE_LIMIT = '3';
+    try {
+      const app = express();
+      app.use(...buildSecurityMiddleware());
+      app.use('/api', buildRateLimiter());
+      app.get('/api/events', (_req, res) => res.json({ stream: true }));
+      app.get('/api/ping', (_req, res) => res.json({ ok: true }));
+      const agent = request(app);
+      // Exhaust ping quota
+      for (let i = 0; i < 3; i++) await agent.get('/api/ping');
+      const pingBlocked = await agent.get('/api/ping');
+      expect(pingBlocked.status).toBe(429);
+      // SSE must still pass even when quota is exhausted
+      const sse = await agent.get('/api/events');
+      expect(sse.status).toBe(200);
+    } finally {
+      if (original === undefined) delete process.env.HU_BOARD_RATE_LIMIT;
+      else process.env.HU_BOARD_RATE_LIMIT = original;
+    }
+  });
+
+  it('honors HU_BOARD_RATE_LIMIT env var override', async () => {
+    const original = process.env.HU_BOARD_RATE_LIMIT;
+    process.env.HU_BOARD_RATE_LIMIT = '2';
+    try {
+      const app = express();
+      app.use(...buildSecurityMiddleware());
+      app.use('/api', buildRateLimiter());
+      app.get('/api/ping', (_req, res) => res.json({ ok: true }));
+      const agent = request(app);
+      expect((await agent.get('/api/ping')).status).toBe(200);
+      expect((await agent.get('/api/ping')).status).toBe(200);
+      expect((await agent.get('/api/ping')).status).toBe(429);
+    } finally {
+      if (original === undefined) delete process.env.HU_BOARD_RATE_LIMIT;
+      else process.env.HU_BOARD_RATE_LIMIT = original;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Rate-limit 300 req/min era demasiado bajo. Primer load del board hace fanout de varios endpoints + SSE persistente. Multiples tabs o un refresh durante sesión activa → 429 en la primera interacción.
- Fix: default 300→600, env var override `HU_BOARD_RATE_LIMIT`, SSE (`/api/events`) exento del límite.

## Cambios
- `buildRateLimiter()` lee `HU_BOARD_RATE_LIMIT` con fallback 600
- `skip: (req) => req.path === '/events' || req.path.startsWith('/events/')`
- Comentario explicando la razón del raise

## Por qué exemptar SSE
- 1 conexión persistente, no es polling
- Reconnects del browser son automáticos e inevitables
- Cada refresh de tab abre nueva conexión

## Test plan
- [x] 2 nuevos tests: SSE pasa con cuota agotada, env var override funciona
- [x] Suite hu-board: 10/10 verde en security-middleware
- [x] Suite root: 4577/4577 verde