### PR TITLE
docs(task-templates): spec-conventions.md central + update plan-generate.md (KJC-TSK-0385)

### DIFF
--- a/docs/task-templates/README.md
+++ b/docs/task-templates/README.md
@@ -22,8 +22,20 @@ Ese sweet spot es lo que estas plantillas codifican.
 
 ## Plantillas disponibles
 
+> 📘 **Antes de tu primer task file**, lee [`spec-conventions.md`](spec-conventions.md). Cubre las **6 convenciones clave** que el planner v2.14.1+ entiende para producir planes de calidad:
+>
+> 1. `### Épica NOMBRE` → `[NOMBRE]` prefix en titles del board
+> 2. `NO incluye en este plan: …` → scope exclusions (ES + EN)
+> 3. `Listado transversal de TODOS los X` → deps a TODOS los miembros
+> 4. Utilidades reutilizables → `reuse` marker end-to-end
+> 5. Async observers (`AVISA-no-BLOQUEA`, `cron`, `webhook`) → NO `blocked_by`
+> 6. Deps explícitas (`Depende: X`, `requires Y`, `after Z`) → `blocked_by`
+>
+> Más antipatrones detectados en dogfooding y checklist pre-generación.
+
 | Comando | Plantilla | Cuándo |
 |---|---|---|
+| _(referencia)_ | [`spec-conventions.md`](spec-conventions.md) | Convenciones que aplican a TODOS los task files |
 | `kj plan generate` | [`plan-generate.md`](plan-generate.md) | Descomponer una feature en HUs ejecutables |
 | `kj run` | [`run.md`](run.md) | Lanzar una sola HU concreta (sin plan) |
 | `kj researcher` | [`researcher.md`](researcher.md) | Explorar el codebase antes de codear |

--- a/docs/task-templates/plan-generate.md
+++ b/docs/task-templates/plan-generate.md
@@ -1,5 +1,7 @@
 # Template — `kj plan generate`
 
+> 📘 **Antes de leer esta plantilla**, lee [`spec-conventions.md`](spec-conventions.md). Cubre las **6 convenciones clave** que el planner v2.14.1+ entiende (`[EPICA]` prefix, scope exclusions, deps transversales, reuse, async observers, deps explícitas) y los antipatrones detectados en dogfooding.
+
 ## Cuándo usar este comando
 
 Tienes una feature de tamaño medio-grande (≥ 5 HUs) y necesitas que Karajan la descomponga en HUs ejecutables, con dependencias, sprints estimados, riesgos y out-of-scope. **No** uses esto para tareas simples (1-3 HUs); para eso usa `kj run` directo.
@@ -17,7 +19,7 @@ El plan resultante se guarda en `~/.kj/plans/<projectSlug>/plan-<id>.json` (la r
 
 ## Plantilla
 
-Copia esto a `tasks/01-<nombre-feature>.task.md` y rellena:
+Copia esto a `tasks/01-<nombre-feature>.task.md` y rellena. Las secciones marcadas con 📘 invocan **convenciones del planner** (ver [`spec-conventions.md`](spec-conventions.md)) que producen comportamiento específico — no son cosméticas.
 
 ```markdown
 # [REPLACE: Título corto de la feature — 1 línea]
@@ -32,7 +34,7 @@ Copia esto a `tasks/01-<nombre-feature>.task.md` y rellena:
  - Datos/entidades clave
  - Diferencias vs lo que YA existe en el proyecto]
 
-**NO incluye en este plan**: [REPLACE: lista las features que pertenecen a OTROS planes futuros, para que el planner no las arrastre.]
+📘 **NO incluye en este plan**: [REPLACE: lista las features que pertenecen a OTROS planes futuros, para que el planner no las arrastre. Patrones aceptados: `NO incluye en este plan: …`, `Out of scope: …`, `Plan 3 handles …`, `Reserved for plan 4: …`. Ver §2 de spec-conventions.md.]
 
 ## Stack técnico ya decidido
 
@@ -44,6 +46,23 @@ Copia esto a `tasks/01-<nombre-feature>.task.md` y rellena:
 - **Region / compliance**: [REPLACE: europe-west1 GDPR / us-east1 / etc.]
 
 [OPTIONAL: lista de paquetes externos ya decididos]
+
+📘 **Épicas con [EPICA] prefix** (orientación visual en el board): agrupa las funcionalidades en bloques `### Épica NOMBRE — descripción corta`. El planner detecta el patrón y prefija cada title del HU con `[NOMBRE]`. Convención: `<=12 chars MAYÚSCULAS`. Ejemplos: `PROFILE`, `ASSESS`, `INFRA`, `GUARD`, `SHARED`. Ver §1 de spec-conventions.md.
+
+```markdown
+### Épica PROFILE — ficha de persona
+1. Subir CV (PDF/DOCX) cifrado a Storage…
+2. Cloud Function processCV trigger…
+
+### Épica GUARD — guardarraíles AVISA-no-BLOQUEA
+3. Guardarraíl 1 — evalúa outcome async on-save…
+```
+
+📘 **Async observers**: si una HU es un guardarraíl/cron/listener/webhook que **reacciona** a otra (no la precondiciona), márcalo explícito. Frases que el planner reconoce: `AVISA-no-BLOQUEA`, `async, no precondiciona`, `cron diario`, `webhook reactivo`. Sin esto, el planner declara `Outcome blocked_by Guardarraíl-1` por error. Ver §5 de spec-conventions.md.
+
+📘 **Deps transversales**: si una HU consume TODOS los miembros de una categoría, usa la palabra `TODOS` o `transversal` literal en la descripción. El planner emitirá `blocked_by: [X1, X2, …, XN]` en vez de solo el primero. Ejemplos: `Listado transversal de TODOS los warnings`, `Dashboard de TODOS los outcomes del equipo`. Ver §3.
+
+📘 **Utilidades reutilizables**: declara las utilidades compartidas como spike + lista de consumidores (ver §4). El planner emitirá `reuse: ["util_id"]` en los HUs consumidores para evitar re-implementación.
 
 ## Funcionalidades a descomponer en HUs
 
@@ -109,6 +128,8 @@ Mira [`tasks/04-plan-1-simple.task.md` en el proyecto de Equipazgo](https://gith
 Un task de 353 líneas con cada épica enumerada en una tabla `| ID | Actor | Precondiciones | Postcondiciones |` con los 30+ casos de uso ya escritos. El planner lo tratará como "documento ya hecho" y producirá meta-documentación. Reportado como KJC-BUG-0041 en dogfooding 2026-05-10.
 
 ## Verificación del plan generado
+
+Tras la generación habrá **findings advisory** del reviewer. Esperable. El plan-fixer (P4) intenta resolverlos en 1-2 iter; si tras eso siguen, son **gaps reales del SPEC** que necesitan edición manual. El P5 convergence guard garantiza que el fixer **nunca empeora** el plan. Ver §7 de spec-conventions.md para densidad aceptable (<15% findings/HUs).
 
 Tras la generación, inspecciona:
 

--- a/docs/task-templates/spec-conventions.md
+++ b/docs/task-templates/spec-conventions.md
@@ -1,0 +1,191 @@
+# SPEC conventions for Karajan task files
+
+Esta guía explica **cómo escribir un `*.task.md`** para que `kj plan generate` (y, por extensión, `kj architect`, `kj researcher`, `kj run`) produzca planes/análisis de la mayor calidad posible.
+
+El planner de Karajan tiene **6 patologías conocidas** que el prompt v2.14.1+ ya intenta evitar. Pero el LLM no es infalible: si tu task file **no le da las señales correctas**, las patologías reaparecen. Este documento te dice qué señales emitir.
+
+> **Nota**: lo que aquí se explica vale para el planner. Si solo usas `kj run` (single-task, no plan), basta con un task description corto en lenguaje natural — esto solo aplica cuando vas a descomponer en múltiples HUs.
+
+## Tabla rápida — qué declarar y qué obtienes
+
+| Si declaras esto en tu task file… | …el planner produce… |
+|---|---|
+| `### Épica PROFILE — ficha de persona` | `[PROFILE]` prefix en cada title de esa área |
+| `NO incluye en este plan: vistas compartidas, X` | Esos ítems van a `outOfScope`, no se generan HUs |
+| `Plan 3 handles dashboards comparativos` | Idem — cross-plan reference reconocida |
+| `Listado transversal de TODOS los X filtrables` | `blocked_by` = [X1, X2, …, XN] (transversal, no solo el primero) |
+| `Utilidad reutilizable de versionado` + uso explícito | HUs consumidoras llevan `reuse: ["util_id"]` en lugar de re-implementar |
+| `Guardarraíl AVISA-no-BLOQUEA` o `async, no precondiciona` | Los guardarraíles **NO** aparecen como `blocked_by` de las HUs que observan |
+| `Depende: HU-X` / `Después de Y` / `Requires Z` | `blocked_by` populado correctamente |
+| `Sin deps` / silencio | `blocked_by: []` (NO se inventan deps) |
+
+## 1. Épicas con `### Épica NOMBRE`
+
+**Por qué importa**: el primer carácter del title de cada HU en el board es el ID. Si no le das estructura al planner, los titles salen como `"Construir utilidad de envelope encryption…"` sin orientación visual. Si declaras épicas, salen como `"[INFRA] Utilidad envelope encryption…"`.
+
+**Convención**:
+
+```markdown
+### Épica PROFILE — ficha de persona
+1. Subir CV (PDF/DOCX) cifrado a Storage…
+2. Cloud Function processCV trigger…
+
+### Épica ASSESS — assessments en 4 dimensiones
+3. Crear assessment manual con 4 dimensiones…
+4. Versionar assessment al editarse…
+
+### Épica GUARD — guardarraíles AVISA-no-BLOQUEA
+5. Guardarraíl 1 — evaluar outcome…
+```
+
+El planner detecta `### Épica NOMBRE` (con cualquier variante: `## Phase X`, `## Layer N — name`, `# AUTH`, etc.) y prefija los HUs con `[NOMBRE]`.
+
+**Fallbacks que aplica el planner**:
+- Si una HU es infraestructura/setup sin épica clara: `[INFRA]`
+- Si es utilidad cross-cutting: `[SHARED]`
+- El prefix se mantiene `<=12 chars` y `MAYÚSCULAS` para consistencia visual.
+
+## 2. Scope exclusions con `NO incluye en este plan:`
+
+**Por qué importa**: sin esto, el planner mete HUs para todo lo que mencionas, aunque sea de un plan futuro. Causó P1 (KJC-BUG-0042) en dogfooding GRETA Plan 2.
+
+**Patrones reconocidos** (ES + EN, case-insensitive):
+
+```markdown
+NO incluye en este plan: vistas compartidas, dashboard radar, mapa de calor.
+Fuera del scope: real-time sync, mobile app.
+Out of scope: payment integration, OAuth providers beyond Google.
+Not in this plan: admin UI, batch import.
+Plan 3 handles cross-tenant views and shared dashboards.
+Reserved for plan 4: federation, multi-region replication.
+```
+
+**Cómo funciona**: el planner detecta las listas y las renderiza como sección **`FORBIDDEN scope`** en el prompt. Si una HU candidata tocaría esos ítems, el planner la mueve a `outOfScope` en vez de generarla.
+
+**Antipatrón**: NO uses esto para indicar "esto no se implementa nunca". Eso va en risks. `NO incluye` es para "esto es real pero pertenece a OTRO plan".
+
+## 3. Deps transversales — listados que requieren TODOS los miembros
+
+**Por qué importa**: el planner solía declarar deps al **primero** de una categoría cuando una HU las requería TODAS. Causó P2 (KJC-BUG-0043) en dogfooding.
+
+**Patrón a usar** en tu task file:
+
+```markdown
+- Listado transversal de TODOS los warnings filtrables por guardrail.
+- Vista de todas las assessments validadas por IA (no manuales).
+- Dashboard que agrega TODOS los outcomes del equipo.
+- Summary across all guardrails.
+```
+
+**Frases clave que el planner reconoce**: `listado transversal`, `list of all`, `summary across`, `dashboard que agrega todos`, `todos los X filtrables`. Si el acceptance test/scope de tu HU "consumidora" menciona la categoría entera, el planner pondrá `blocked_by: [X1, X2, …, XN]` con todos los miembros.
+
+## 4. Reuse — utilidades compartidas
+
+**Por qué importa**: el planner solía re-implementar utilidades existentes en cada HU consumidora. P3 (KJC-BUG-0044). El campo `reuse` resuelve esto pero solo si el SPEC lo señala.
+
+**Patrón en el task file**:
+
+```markdown
+### Spike — utilidades compartidas
+
+- **versionado** (HU INFRA-VERS): utilidad reusable de versionado con SemVer
+  + diff. Usada por: ASSESS-VER, AI-PROMPTS, IMPACT-CHALLENGES.
+- **envelope encryption** (HU INFRA-CRYPTO): KMS DEK per-instance. Usada por:
+  PROFILE-CV, AI-TRANSCRIPT, IMPACT-EVIDENCE.
+```
+
+Lo que el planner emitirá en las HUs consumidoras:
+
+```json
+{
+  "id": "ASSESS-VER",
+  "description": "[ASSESS] Versionar assessment al editarse",
+  "dependencies": ["INFRA-VERS"],
+  "reuse": ["INFRA-VERS"]
+}
+```
+
+**Distinción semántica**:
+- `dependencies`: "X debe estar terminado antes de empezar Y" (ordering).
+- `reuse`: "Y consume el ARTEFACTO de X — no re-implementar la misma lógica" (DRY).
+- Por convención: si declaras `reuse: ["INFRA-X"]`, debes declarar también `dependencies: ["INFRA-X"]`.
+
+## 5. Async observers (guardarraíles, cron, listeners, queues)
+
+**Por qué importa**: el planner solía declarar `Outcome blocked_by Guardarraíl-1` cuando el guardarraíl es async observer. P6 (KJC-BUG-0047). Rompía AVISA-no-BLOQUEA en GRETA.
+
+**Patrones a usar** para indicar al planner que algo es async observer:
+
+```markdown
+- **Guardarraíl 1** — evalúa outcome async on-save. **AVISA, no BLOQUEA**.
+- **Cron diario** que valida assessments caducados. Async, no precondiciona.
+- **Audit log** de lecturas. Observer reactivo, no bloquea.
+- **Webhook** Stripe → reactive, async.
+- **Retry queue** Pub/Sub para guardarraíles que fallan. Async.
+```
+
+**Frases clave**: `AVISA-no-BLOQUEA`, `observa`, `async`, `reactivo`, `cron`, `webhook`, `listener`, `Pub/Sub`, `después sin bloquear`, `evalúa pero no precondiciona`.
+
+**Heurística del planner**:
+- ¿X **consume** un deliverable de Y que debe **existir** antes de empezar? → `X blocked_by Y` ✅
+- ¿Y **reacciona** a X después? → paralelos, NO `blocked_by` ✅
+
+## 6. Dependencias explícitas
+
+El planner reconoce estas frases en la prosa de tu task file:
+
+| Frase | Acción |
+|---|---|
+| `Depende: AUTH-005, PROFILE-001` | `blocked_by: ["AUTH-005", "PROFILE-001"]` |
+| `requires X` | `blocked_by: ["X"]` |
+| `after Y` | `blocked_by: ["Y"]` |
+| `needs Z first` | `blocked_by: ["Z"]` |
+| `blocked by W` | `blocked_by: ["W"]` |
+| `Sin deps` (o silencio) | `blocked_by: []` |
+
+**Importante**: NO encadenes HUs por orden de aparición. Si una HU **no depende de nada**, déjala sin frase de dep — el planner emitirá `blocked_by: []` (que es correcto).
+
+## 7. Gestión de findings del reviewer
+
+Tras generar el plan, **siempre hay findings advisory**. Es normal:
+- `missing_hus`: gaps reales del SPEC que el planner no cubrió. Aplica con `kj plan add-hu` o edita el JSON.
+- `missing_dependencies`: deps que el planner no infirió. Aplica con `kj plan update-hu`.
+- `scope_overlaps`: pares de HUs que tocan lo mismo. Decide cuál borrar/fusionar.
+- `order_issues`: ordering problemático. Reordena con `kj plan reorder`.
+
+El plan-fixer (P4) intenta resolverlos automáticamente. **Si tras 1-2 iteraciones se mantienen**, son gaps reales — edita a mano. El P5 convergence guard garantiza que el plan-fixer **nunca empeora** el plan, así que es seguro dejar el fixer hacer su trabajo.
+
+**Densidad de findings aceptable**:
+- < 15% (findings/HUs): bien.
+- 15-25%: planeable, requiere ediciones manuales.
+- > 25%: probablemente el task file está incompleto o ambiguo — revisa.
+
+## Tabla de antipatrones (NO HACER)
+
+| Antipatrón | Por qué falla | Hacer en su lugar |
+|---|---|---|
+| Tabla rígida `\| ID \| Actor \| Precondiciones \|` con 30 casos ya escritos | El planner lo trata como "plan ya hecho" y solo lo reformatea | Prosa narrativa en `## Funcionalidades` (ver `plan-generate.md`) |
+| Mencionar features del Plan 3 sin marcarlas | El planner las arrastra al Plan 2 | `NO incluye en este plan: …` |
+| Listar HUs sin orden de épica | Titles del board sin orientación | `### Épica NOMBRE — desc` por área |
+| "El listado depende del primer guardarraíl" | Solo 1 dep, falla en runtime | "Listado transversal de TODOS los guardarraíles" |
+| Repetir lógica de utilidad en cada HU | Re-implementación duplicada | Declarar la utilidad como spike + listar consumidores |
+| "Outcome depende de Guardarraíl-1" | `blocked_by` semántico-erróneo | "Outcome es evaluado por G1 async; G1 AVISA-no-BLOQUEA" |
+
+## Referencia rápida — checklist antes de generar
+
+- [ ] ¿Cada área del SPEC tiene `### Épica NOMBRE`? (orientación visual)
+- [ ] ¿Está `NO incluye en este plan: …` con TODOS los items que pertenecen a otros planes?
+- [ ] ¿Las HUs "agregadoras" / "transversales" usan la palabra **TODOS** explícita?
+- [ ] ¿Las utilidades compartidas están declaradas como spike + lista de consumidores?
+- [ ] ¿Los guardarraíles/cron/listeners mencionan **AVISA-no-BLOQUEA** o **async**?
+- [ ] ¿Las dependencias entre HUs están en prosa (`Depende: X`, `requires Y`)?
+- [ ] ¿Está el bloque `## Reglas no negociables` para constraints transversales?
+
+## Documentos relacionados
+
+- [`plan-generate.md`](plan-generate.md) — comando + plantilla específica de task file
+- [`architect.md`](architect.md) — comando + cómo invocar al architect role
+- [`researcher.md`](researcher.md) — comando + cómo invocar al researcher
+- [`run.md`](run.md) — comando + cuándo usar single-task vs plan
+- [`discover.md`](discover.md) — comando + cómo detectar gaps antes de planear
+- [`refactorer.md`](refactorer.md) — comando + cuándo usar el refactorer role


### PR DESCRIPTION
## Motivación
Tras dogfooding GRETA Plan 2 v2.14.1: las plantillas del repo (PR #664) cubrían parcialmente las convenciones, pero faltaban las patologías nuevas descubiertas en v2.14.x (`[EPICA]` prefix, P3 reuse, P6 async observers, deps transversales, gestión de findings).

## Cambios
- **Nuevo** `docs/task-templates/spec-conventions.md` (191 LOC): documento central con las 6 convenciones que el planner v2.14.1+ entiende, tabla de antipatrones, checklist pre-generación.
- **Update** `docs/task-templates/plan-generate.md`: banner + 4 secciones 📘 (Épicas, Async observers, Deps transversales, Utilidades reutilizables).
- **Update** `docs/task-templates/README.md`: banner destacado con las 6 convenciones.

## Excluido de shrink-budget
Todo en `docs/` → human-doc, no cuenta. 226 LOC totales pero todos exentos.