### PR TITLE
feat(hu): result field orthogonal to status (KJC-TSK-0394 step 1)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -173,6 +173,10 @@ export function initDb() {
   // again. Stored as TEXT (JSON.stringify'd) for simplicity —
   // parsed on read by the UI.
   try { db.exec('ALTER TABLE stories ADD COLUMN outcome TEXT'); } catch { /* already migrated */ }
+  // KJC-TSK-0394: result (pass | fail | partial | null) ortogonal al status.
+  // Diferente del campo `outcome` arriba (que es blob JSON con metadata del
+  // run). result es el enum de "último resultado" para mostrar como badge.
+  try { db.exec('ALTER TABLE stories ADD COLUMN result TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
@@ -228,14 +232,14 @@ export function upsertStory(story) {
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
-      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome
+      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome, result
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
-      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome
+      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome, @result
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -263,7 +267,8 @@ export function upsertStory(story) {
       acceptance_tests = COALESCE(@acceptance_tests, acceptance_tests),
       plan_order = COALESCE(@plan_order, plan_order),
       spec_section = COALESCE(@spec_section, spec_section),
-      outcome = COALESCE(@outcome, outcome)
+      outcome = COALESCE(@outcome, outcome),
+      result = COALESCE(@result, result)
   `);
   stmt.run({
     id: story.id,
@@ -296,6 +301,7 @@ export function upsertStory(story) {
     plan_order: story.plan_order ?? null,
     spec_section: story.spec_section || null,
     outcome: story.outcome || null,
+    result: story.result || null,
   });
 }
 

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -432,6 +432,10 @@ export function syncPlanFile(filePath) {
         // the front parses on read. Null until hu-sub-pipeline
         // stamps it at the end of each HU.
         outcome: hu.outcome ? JSON.stringify(hu.outcome) : null,
+        // KJC-TSK-0394: result (pass|fail|partial|null) ortogonal al status.
+        // Distinto de `outcome` (blob JSON) — esto es el enum corto para
+        // badge ✓/✗ en la card.
+        result: hu.result || null,
       });
     }
 

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -33,6 +33,12 @@ export function addHu(plan, huData) {
     title: huData.title,
     task_type: huData.task_type || "sw",
     status: "pending",
+    // KJC-TSK-0394: result ortogonal al status (último resultado conocido
+    // de la ejecución; null = nunca ejecutada). Se actualiza cuando el
+    // pipeline termina con pass / fail / partial. Nombre `result` (no
+    // `outcome`) porque `outcome` ya está en uso como blob JSON con
+    // iterations/duration/commits del run.
+    result: huData.result ?? null,
     blocked_by: huData.blocked_by || [],
     // KJC-BUG-0044 / P3: ids of OTHER HUs whose implementation this HU
     // piggy-backs on instead of reimplementing the same logic. Set by
@@ -83,7 +89,7 @@ export function removeHu(plan, huId) {
 export function updateHu(plan, huId, patch) {
   const hu = plan.hus.find(h => h.id === huId);
   if (!hu) return null;
-  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section"];
+  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result"];
   for (const key of allowed) {
     if (patch[key] !== undefined) hu[key] = patch[key];
   }

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -8,8 +8,47 @@ import { generatePlanId } from "./plan-id.js";
 
 const VALID_PLAN_STATUSES = new Set(["draft", "ready", "running", "done", "failed"]);
 const VALID_HU_STATUSES = new Set(["pending", "certified", "coding", "reviewing", "done", "failed", "blocked"]);
+// KJC-TSK-0394: nuevo campo `result` ortogonal a status. Reemplaza la
+// sobrecarga semántica del status (certified=pass, failed=fail) por una
+// distinción explícita entre lifecycle (status) y último resultado (result).
+// Vacío `null` significa "nunca ejecutado". Migración no-breaking: status
+// legacy sigue válido durante el período de transición.
+// Nota: usamos `result` y NO `outcome` porque el campo `outcome` ya existe
+// con otra semántica (blob JSON con iterations/duration/commits del run).
+export const VALID_HU_RESULTS = new Set([null, "pass", "fail", "partial"]);
 const VALID_TASK_TYPES = new Set(["sw", "infra", "doc", "add-tests", "refactor", "nocode"]);
 const VALID_TEST_TYPES = new Set(["shell", "gherkin"]);
+
+/**
+ * Map a legacy status to (newStatus, result) pair. Used by addHu() defaults
+ * and by the migration script in step 4. Idempotent: re-mapping a value that
+ * is already in the canonical {pending, running, done} set keeps it.
+ *
+ * @param {string|null|undefined} legacy
+ * @returns {{ status: string, result: string|null }}
+ */
+export function mapLegacyStatusToResult(legacy) {
+  switch (legacy) {
+    case "pending":
+    case "blocked":         // blocked es lifecycle no terminal → pending
+    case "needs_context":   // ídem
+    case undefined:
+    case null:
+      return { status: "pending", result: null };
+    case "coding":
+    case "reviewing":
+    case "running":
+      return { status: "running", result: null };
+    case "certified":
+      return { status: "done", result: "pass" };
+    case "failed":
+      return { status: "done", result: "fail" };
+    case "done":
+      return { status: "done", result: null }; // sin result conocido (raro)
+    default:
+      return { status: "pending", result: null };
+  }
+}
 
 /**
  * Structured acceptance-test shape introduced in v2.7.5 (tests-first):
@@ -144,6 +183,10 @@ export function validatePlan(plan) {
     huIds.add(hu.id);
     if (!hu.title) errors.push(`HU ${hu.id}: missing title`);
     if (!VALID_HU_STATUSES.has(hu.status)) errors.push(`HU ${hu.id}: invalid status ${hu.status}`);
+    // KJC-TSK-0394: result es opcional. Si está presente, debe ser pass/fail/partial.
+    if (hu.result !== undefined && hu.result !== null && !VALID_HU_RESULTS.has(hu.result)) {
+      errors.push(`HU ${hu.id}: invalid result ${hu.result} (expected pass|fail|partial|null)`);
+    }
     if (hu.task_type && !VALID_TASK_TYPES.has(hu.task_type)) errors.push(`HU ${hu.id}: invalid task_type ${hu.task_type}`);
     // acceptance_tests: may be absent (legacy) or an array of either
     // plain strings (legacy shell) or { type, content, file? } objects.

--- a/tests/plan/plan-module.test.js
+++ b/tests/plan/plan-module.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { generatePlanId, generateHuId } from "../../src/plan/plan-id.js";
-import { createPlanV2, migratePlanV1toV2, isPlanV2, validatePlan } from "../../src/plan/plan-schema.js";
+import { createPlanV2, migratePlanV1toV2, isPlanV2, validatePlan, mapLegacyStatusToResult, VALID_HU_RESULTS } from "../../src/plan/plan-schema.js";
 import { addHu, removeHu, updateHu, updateHuStatus, certifyAllHus, reorderHus } from "../../src/plan/plan-hu-ops.js";
 
 describe("plan-id", () => {
@@ -105,6 +105,50 @@ describe("plan-hu-ops", () => {
     expect(plan.hus.length).toBe(1);
   });
 
+  // KJC-TSK-0394: campo `result` ortogonal al status
+  it("addHu inicializa result a null por defecto", () => {
+    const hu = addHu(plan, { title: "X" });
+    expect(hu.result).toBe(null);
+  });
+
+  it("addHu acepta result inicial cuando se pasa explícitamente", () => {
+    const hu = addHu(plan, { title: "X", result: "pass" });
+    expect(hu.result).toBe("pass");
+  });
+
+  it("updateHu permite mutar el campo result", () => {
+    const hu = addHu(plan, { title: "X" });
+    updateHu(plan, hu.id, { result: "fail" });
+    expect(plan.hus[0].result).toBe("fail");
+  });
+
+  it("validatePlan rechaza result fuera del enum", () => {
+    const hu = addHu(plan, { title: "X" });
+    hu.result = "weird-value";
+    const v = validatePlan(plan);
+    expect(v.valid).toBe(false);
+    expect(v.errors.some(e => /invalid result/i.test(e))).toBe(true);
+  });
+
+  it("validatePlan acepta result null/pass/fail/partial", () => {
+    for (const r of [null, "pass", "fail", "partial"]) {
+      const p = createPlanV2(`task ${r}`);
+      const hu = addHu(p, { title: "X" });
+      hu.result = r;
+      const v = validatePlan(p);
+      expect(v.valid, `result=${r}`).toBe(true);
+    }
+  });
+
+  it("VALID_HU_RESULTS contiene exactamente null+pass+fail+partial", () => {
+    expect(VALID_HU_RESULTS.has(null)).toBe(true);
+    expect(VALID_HU_RESULTS.has("pass")).toBe(true);
+    expect(VALID_HU_RESULTS.has("fail")).toBe(true);
+    expect(VALID_HU_RESULTS.has("partial")).toBe(true);
+    expect(VALID_HU_RESULTS.has("done")).toBe(false);
+    expect(VALID_HU_RESULTS.size).toBe(4);
+  });
+
   it("sequential IDs increment", () => {
     addHu(plan, { title: "First" });
     const second = addHu(plan, { title: "Second" });
@@ -190,5 +234,38 @@ describe("plan-hu-ops", () => {
     expect(updateHu(plan, "fake", { title: "x" })).toBeNull();
     expect(updateHuStatus(plan, "fake", "done")).toBe(false);
     expect(removeHu(plan, "fake")).toBe(false);
+  });
+});
+
+describe("mapLegacyStatusToResult (KJC-TSK-0394 migration)", () => {
+  it("pending → pending+null", () => {
+    expect(mapLegacyStatusToResult("pending")).toEqual({ status: "pending", result: null });
+  });
+  it("blocked/needs_context → pending+null (lifecycle non-terminal)", () => {
+    expect(mapLegacyStatusToResult("blocked")).toEqual({ status: "pending", result: null });
+    expect(mapLegacyStatusToResult("needs_context")).toEqual({ status: "pending", result: null });
+  });
+  it("coding/reviewing/running → running+null (zombi recovery)", () => {
+    expect(mapLegacyStatusToResult("coding")).toEqual({ status: "running", result: null });
+    expect(mapLegacyStatusToResult("reviewing")).toEqual({ status: "running", result: null });
+    expect(mapLegacyStatusToResult("running")).toEqual({ status: "running", result: null });
+  });
+  it("certified → done+pass (success en el modelo viejo)", () => {
+    expect(mapLegacyStatusToResult("certified")).toEqual({ status: "done", result: "pass" });
+  });
+  it("failed → done+fail", () => {
+    expect(mapLegacyStatusToResult("failed")).toEqual({ status: "done", result: "fail" });
+  });
+  it("done → done+null (status terminal sin info de result)", () => {
+    expect(mapLegacyStatusToResult("done")).toEqual({ status: "done", result: null });
+  });
+  it("undefined/null/desconocido → pending+null (defensive)", () => {
+    expect(mapLegacyStatusToResult(null)).toEqual({ status: "pending", result: null });
+    expect(mapLegacyStatusToResult(undefined)).toEqual({ status: "pending", result: null });
+    expect(mapLegacyStatusToResult("weird")).toEqual({ status: "pending", result: null });
+  });
+  it("idempotente — re-mapear un valor canónico no rompe", () => {
+    expect(mapLegacyStatusToResult("pending").status).toBe("pending");
+    expect(mapLegacyStatusToResult("done").status).toBe("done");
   });
 });


### PR DESCRIPTION
## Summary

Step 1 of 5 del refactor del modelo de estados del HU Board (KJC-TSK-0394).

El status actual mezcla 2 conceptos en un solo enum: lifecycle (pending → running → done) y outcome (pass/fail/partial). Esto causa fricciones recurrentes:

- Status zombi tras crash (coding/reviewing quedan stuck sin forma de saber si pasó o falló).
- No se puede re-correr una HU `done` (no hay distinción entre "done con éxito" y "done con fallo recuperable").
- `failed` ocupa una columna del board cuando lógicamente es un badge sobre `done`.

Este PR introduce el campo `result` ortogonal al `status` **sin romper el modelo legacy** (status enum sigue siendo `{pending, certified, coding, reviewing, done, failed, blocked}`). Los próximos steps separan la migración de UI/UX, zombie reaper y cleanup del enum legacy.

## Cambios

- **`src/plan/plan-schema.js`**: `VALID_HU_RESULTS = {null, pass, fail, partial}`. Nueva función `mapLegacyStatusToResult()` (utilizada por el migration script del step 4). `validatePlan()` valida `result` si está presente.
- **`src/plan/plan-hu-ops.js`**: `addHu` inicializa `result: null`. `updateHu` lo acepta en `allowed`.
- **`packages/hu-board/src/db.js`**: `ALTER TABLE stories ADD COLUMN result` (la columna `outcome` ya existía con otra semántica: blob JSON con `iterations/duration/commits` del run — ortogonales, no se toca). `upsertStory` persiste `result`.
- **`packages/hu-board/src/sync.js`**: `syncPlanFile` propaga `hu.result` al `upsertStory`.

## Tests

14 nuevos (36 totales en `plan-module.test.js`, suite global 4622/4622 verde):

- `addHu` default `result: null` + acepta inicial explícito.
- `updateHu` muta `result`.
- `validatePlan` rechaza valores fuera del enum + acepta `null/pass/fail/partial`.
- `VALID_HU_RESULTS` contiene exactamente esos 4.
- 8 mapeos de `mapLegacyStatusToResult` (pending/blocked/needs_context → pending, coding/reviewing/running → running, certified → pass, failed → fail, done → null, undefined/null/unknown → pending+null, idempotencia).

## Próximos steps (PRs separadas)

2. UI: badge `result` (✓/✗/~) en la card + botón "Reset to pending" en modal + ▶ Run disponible en HUs `done`.
3. Zombie HU reaper (status `running` >N min sin updates → `pending`).
4. Migration script para plan files existentes (`mapLegacyStatusToResult` sobre cada HU).
5. Cleanup del enum legacy (eliminar `certified`/`failed` del enum una vez migrados todos los plans).

## Test plan

- [x] `npm test` — 4622/4622 verde
- [ ] No tocar la columna `outcome` existente (sigue siendo blob JSON)
- [ ] Verificar que un plan existente sin `result` carga sin warnings