### PR TITLE
feat(hu-board): result badge + Reset + ▶ Run on done (KJC-TSK-0394 step 2)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -957,15 +957,18 @@ function renderStoryCard(story) {
   const missingTestContract = testCount === 0 && ['pending', 'certified'].includes(story.status);
 
   // PR4: per-HU ▶ Run button. Visible when:
-  //   - the HU is certified or failed (re-run after fixing) AND
-  //   - it has at least one acceptance test (otherwise the run
-  //     would refuse) AND
+  //   - the HU is in a re-runnable lifecycle state (certified / failed /
+  //     pending / done — KJC-TSK-0394 step 2 adds `done` so the user can
+  //     replay a HU whose `result` was fail or partial without having to
+  //     "reset to pending" first) AND
+  //   - it has at least one acceptance test (otherwise the run would
+  //     refuse) AND
   //   - it isn't currently coding/reviewing AND
   //   - KJC-BUG-0048: it has no unresolved blocked_by deps. The card
   //     already shows "⏳ waits for: ..." below the title; the ▶ button
   //     must match that gating or the user can launch a HU whose deps
   //     don't exist yet, hitting the missing-prereq path at runtime.
-  const canRunHu = ['certified', 'failed', 'pending'].includes(story.status)
+  const canRunHu = ['certified', 'failed', 'pending', 'done'].includes(story.status)
     && testCount > 0
     && !['coding', 'reviewing'].includes(story.status)
     && blockedBy.length === 0;
@@ -1009,11 +1012,34 @@ function renderStoryCard(story) {
       ${antipatterns.length > 0 ? `<div class="story-card__antipattern">${antipatterns.map((a) => esc(a)).join(', ')}</div>` : ''}
       <div class="story-card__meta" style="margin-top:6px">
         <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
+        ${renderResultBadge(story.result)}
         <span class="story-card__time">${timeAgo(story.updated_at)}</span>
         ${renderOutcomeChip(story.outcome)}
       </div>
     </div>
   `;
+}
+
+/**
+ * KJC-TSK-0394 step 2: render the per-HU `result` badge. Ortogonal al
+ * status — el status es lifecycle (pending → running → done), el result
+ * es el último outcome conocido de la ejecución (pass / fail / partial).
+ * Sin result = nunca se ha ejecutado, no se pinta nada.
+ *
+ * @param {string|null} result
+ * @returns {string} HTML
+ */
+function renderResultBadge(result) {
+  if (!result) return '';
+  const icons = { pass: '✓', fail: '✗', partial: '~' };
+  const titles = {
+    pass: 'Última ejecución: todos los tests pasaron',
+    fail: 'Última ejecución: falló',
+    partial: 'Última ejecución: pasó parcialmente',
+  };
+  const icon = icons[result];
+  if (!icon) return '';
+  return `<span class="story-card__result result--${esc(result)}" title="${esc(titles[result])}">${icon}</span>`;
 }
 
 /**
@@ -1371,6 +1397,45 @@ window.runSingleHuFromCard = async function runSingleHuFromCard(huId, title) {
     await renderBoard();
   } catch (err) {
     await showError(err.message || String(err), { title: 'Fallo al lanzar la HU' });
+  }
+};
+
+/**
+ * KJC-TSK-0394 step 2: devolver una HU al estado `pending` desde
+ * cualquier estado no-terminal (coding/reviewing/blocked zombi) o
+ * terminal (done/failed) que el usuario quiera relanzar limpio.
+ *
+ * No tocamos el campo `result`: si una HU acaba en done+fail y el
+ * usuario hace Reset → status: pending, result: fail (badge ✗ persiste
+ * como historial). El siguiente run sobreescribirá result cuando
+ * termine.
+ *
+ * El backend ya acepta {status: 'pending'} en ALLOWED_STORY_STATUSES
+ * (ver routes/api.js); plan-mutations::setHuStatus refleja el cambio
+ * al fichero del plan y resincroniza la BBDD.
+ */
+window.resetHuToPending = async function resetHuToPending(storyId) {
+  const ok = await showConfirm(
+    '¿Devolver esta HU a pending?\n\nEl estado se cambia a pending y se podrá relanzar. El resultado de la última ejecución (✓/✗/~) se conserva como historial hasta que vuelvas a ejecutarla.',
+    { title: 'Reset HU', okLabel: 'Reset', cancelLabel: 'Cancelar' }
+  );
+  if (!ok) return;
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'pending' }),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudo resetear la HU' });
+      return;
+    }
+    closeModal();
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo al resetear la HU' });
   }
 };
 
@@ -1975,6 +2040,12 @@ async function showStoryDetail(storyId) {
     // (plan_id null) have no source-of-truth file to write to, so PATCH
     // would 409 anyway.
     const canEdit = ['pending', 'certified', 'needs_context', 'blocked'].includes(story.status);
+    // KJC-TSK-0394 step 2: "Reset to pending" para destrabar HUs zombi
+    // (coding/reviewing/blocked colgados) o relanzar limpio una HU
+    // done/failed. Solo plan-backed. Pending/certified ya están en el
+    // estado destino, no tiene sentido el botón.
+    const canResetToPending = story.plan_id
+      && !['pending', 'certified'].includes(story.status);
 
     content.innerHTML = `
       <div class="modal__header">
@@ -1989,6 +2060,14 @@ async function showStoryDetail(storyId) {
                     style="padding:6px 12px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem"
                     title="Edit title, scope, task type, and acceptance criteria">
               ✎ Edit
+            </button>
+          ` : ''}
+          ${canResetToPending ? `
+            <button id="reset-hu-btn" class="control-btn"
+                    style="padding:6px 12px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem"
+                    title="Devolver esta HU a pending (sin tocar el result anterior)"
+                    onclick="resetHuToPending('${esc(story.id)}')">
+              ↺ Reset
             </button>
           ` : ''}
           <button class="modal__close" onclick="closeModal()">&times;</button>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -383,6 +383,22 @@ a:hover {
 .status--done { background: rgba(52, 211, 153, 0.15); color: var(--color-green); }
 .status--coding { background: rgba(124, 58, 237, 0.15); color: var(--accent-purple); }
 
+/* KJC-TSK-0394 step 2: badge ortogonal al status que pinta el último
+   `result` conocido (pass / fail / partial). Convive con el status:
+   p. ej. status=done + result=pass = "terminó y todo OK"; status=done
+   + result=fail = "terminó pero tests fallaron"; status=pending +
+   result=fail = "está en cola para reintentar (último run falló)". */
+.story-card__result {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: var(--font-mono, monospace);
+}
+.result--pass { background: rgba(52, 211, 153, 0.15); color: var(--color-green); }
+.result--fail { background: rgba(248, 113, 113, 0.15); color: var(--color-red); }
+.result--partial { background: rgba(234, 179, 8, 0.15); color: var(--color-yellow); }
+
 .story-card__time {
   font-size: 0.65rem;
   color: var(--text-muted);

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -152,6 +152,50 @@ describe('PATCH /api/stories/:id', () => {
       .send({ status: 'certified' });
     expect(res.status).toBe(404);
   });
+
+  // KJC-TSK-0394 step 2: el botón "↺ Reset" del modal envía
+  // PATCH {status: 'pending'} desde cualquier estado no terminal
+  // o terminal. La API ya aceptaba 'pending' en ALLOWED_STORY_STATUSES,
+  // pero conviene asegurar que el reset SOBREVIVE al ciclo escritura→
+  // sync de plan-mutations y NO toca el campo `result` (historial).
+  it('reset desde "coding" zombi a "pending" reescribe el plan', async () => {
+    // Simulamos el zombi: el orquestador empezó la HU y murió antes de
+    // estampar outcome. El plan-on-disk tiene status=coding.
+    const plan = readPlanFromDisk();
+    plan.hus[0].status = 'coding';
+    plan.hus[0].result = 'fail';
+    writeFileSync(planPath(), JSON.stringify(plan, null, 2), 'utf-8');
+    syncMod.syncPlanFile(planPath());
+
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ status: 'pending' });
+
+    expect(res.status).toBe(200);
+    const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.status).toBe('pending');
+    // result se preserva como historial
+    expect(hu.result).toBe('fail');
+  });
+
+  it('reset desde "done" a "pending" preserva el result anterior', async () => {
+    const plan = readPlanFromDisk();
+    plan.hus[0].status = 'done';
+    plan.hus[0].result = 'pass';
+    writeFileSync(planPath(), JSON.stringify(plan, null, 2), 'utf-8');
+    syncMod.syncPlanFile(planPath());
+
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ status: 'pending' });
+
+    expect(res.status).toBe(200);
+    const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.status).toBe('pending');
+    expect(hu.result).toBe('pass');
+  });
 });
 
 describe('POST /api/plans/:planId/ready', () => {


### PR DESCRIPTION
## Summary

Step 2 of 5 del refactor del modelo de estados del HU Board (KJC-TSK-0394). UI sobre el campo \`result\` introducido en step 1 (#693).

## Cambios

### 1. Badge \`result\` en la story card
Junto al status pintamos un chip ortogonal con el último outcome conocido:

| status   | result   | Pintado                |
|----------|----------|------------------------|
| done     | pass     | \`done\` + \`✓\`           |
| done     | fail     | \`done\` + \`✗\`           |
| done     | partial  | \`done\` + \`~\`           |
| pending  | fail     | \`pending\` + \`✗\` (replay) |
| pending  | null     | \`pending\` (nunca corrió) |

### 2. \`▶ Run\` disponible en HUs \`done\`
\`canRunHu\` ahora incluye \`done\` (antes: \`['certified', 'failed', 'pending']\`). Permite relanzar una HU done+fail sin pasar por Reset. Misma gating: \`testCount > 0\`, no \`coding/reviewing\`, sin \`blocked_by\` pendientes.

### 3. Botón \`↺ Reset\` en el modal
PATCH \`/api/stories/:id\` con \`{status: 'pending'}\` (la API ya lo aceptaba, sólo se expone en UI). Visible cuando la HU es plan-backed y NO está en \`pending/certified\`. Casos:
- **Zombi**: HU stuck en \`coding/reviewing\` porque el orquestador murió.
- **Replay**: HU \`done+fail\` o \`done+partial\` → Reset + ▶ Run.

**El campo \`result\` se preserva en el Reset como historial.** La siguiente ejecución lo sobreescribirá.

### 4. CSS
\`.story-card__result\` + variantes \`pass/fail/partial\` con tonos consistentes con los status (verde/rojo/amarillo).

## Tests

2 nuevos en \`plan-mutations.test.js\` (38 totales, +2):

- Reset desde \`coding\` zombi → \`pending\`: status cambia, \`result\` se preserva.
- Reset desde \`done\` → \`pending\`: status cambia, \`result\` se preserva.

Suite global: **4622/4622 verde**. LOC: **143** (under 200 budget).

## Próximos steps

3. Zombie HU reaper (status running >N min sin updates → pending automático).
4. Migration script para plan files existentes (\`mapLegacyStatusToResult\` sobre cada HU del disco).
5. Cleanup del enum legacy (eliminar \`certified\`/\`failed\` como status, ya solo result).

## Test plan

- [x] \`npm test\` 4622/4622
- [ ] Abrir el board con una HU done+fail y verificar que el badge \`✗\` aparece junto a \`done\`
- [ ] Click ▶ Run sobre una HU done → relanza
- [ ] Abrir modal de una HU \`coding\` zombi → botón Reset visible
- [ ] Click Reset → status pasa a pending, badge result se mantiene