### PR TITLE
feat(hu-board): HU zombie reaper at startup (KJC-TSK-0394 step 3)

### DIFF
--- a/packages/hu-board/src/hu-zombie-reaper.js
+++ b/packages/hu-board/src/hu-zombie-reaper.js
@@ -1,0 +1,91 @@
+/**
+ * HU-level zombie reaper (KJC-TSK-0394 step 3).
+ *
+ * Counterpart to zombie-reaper.js (que opera sobre sesiones). Detecta
+ * HUs que el orquestador dejó stuck en `coding`/`reviewing` —síntoma
+ * de crash mid-iteration— y las resetea a `pending`.
+ *
+ * Threshold separado de las sesiones: una sesión legítima puede
+ * tardar horas (loop largo), una HU individual rara vez >30 min. Por
+ * eso este reaper trabaja en minutos, no en horas.
+ *
+ * Semántica del reap: status → `pending` (NO `failed`: el orquestador
+ * perdió contacto, no podemos afirmar el outcome). El campo `result`
+ * NO se toca — se conserva como historial. La persistencia pasa por
+ * plan-mutations::setHuStatus (escribe el plan JSON + resync DB). Si
+ * el JSON write falla cae al fallback DB-only.
+ */
+
+const DEFAULT_RUNNING_MINUTES = 30;
+// `coding` + `reviewing` son los nombres legacy; `running` es el
+// canónico tras step 5. Aceptamos los tres durante la transición.
+const RUNNING_STATUSES = new Set(["coding", "reviewing", "running"]);
+
+/**
+ * Pure. Decide si un HU row es zombi a `now`.
+ */
+export function classifyHuZombie(hu, ctx) {
+  if (!hu || !hu.status) return { zombie: false };
+  const status = String(hu.status).toLowerCase();
+  if (!RUNNING_STATUSES.has(status)) return { zombie: false };
+  const refIso = hu.updated_at;
+  if (!refIso) return { zombie: false };
+  const refTs = new Date(refIso).getTime();
+  if (Number.isNaN(refTs)) return { zombie: false };
+  const ageMinutes = (ctx.now - refTs) / 60_000;
+  if (ageMinutes < ctx.runningMinutes) return { zombie: false };
+  return {
+    zombie: true,
+    reason: `${status} ${ageMinutes.toFixed(0)}min inactive (>= ${ctx.runningMinutes}min)`,
+  };
+}
+
+/** Pure. Filtra solo los zombis. */
+export function findZombieHus(hus, opts = {}) {
+  const ctx = {
+    now: opts.now ?? Date.now(),
+    runningMinutes: opts.runningMinutes ?? DEFAULT_RUNNING_MINUTES,
+  };
+  const out = [];
+  for (const hu of hus || []) {
+    const verdict = classifyHuZombie(hu, ctx);
+    if (verdict.zombie) out.push({ hu, reason: verdict.reason });
+  }
+  return out;
+}
+
+/**
+ * Resetea a `pending` cada HU zombi en la DB Y en el fichero del
+ * plan. `setHuStatus` se inyecta para que los tests no necesiten un
+ * plan-file real. Devuelve la lista de reapeados para el log.
+ */
+export function reapZombieHus({ db, setHuStatus, opts = {}, now = () => Date.now() }) {
+  if (!db || typeof setHuStatus !== "function") return [];
+  const rows = db.prepare(
+    "SELECT id, project_id, plan_id, status, updated_at FROM stories WHERE status IN ('coding', 'reviewing', 'running')",
+  ).all();
+  const zombies = findZombieHus(rows, { ...opts, now: now() });
+  if (zombies.length === 0) return [];
+  const reaped = [];
+  for (const { hu, reason } of zombies) {
+    // El id compuesto del board es `${projectId}::${huId}`; setHuStatus
+    // quiere el huId local.
+    const localHuId = hu.id.includes("::") ? hu.id.split("::").slice(1).join("::") : hu.id;
+    let planPersisted = false;
+    if (hu.plan_id) {
+      try {
+        const result = setHuStatus({ planId: hu.plan_id, huId: localHuId, status: "pending", projectId: hu.project_id });
+        planPersisted = !!(result && result.ok);
+      } catch { /* swallow — never block startup */ }
+    }
+    // Fallback DB-only para legacy rows (plan_id null) o si el write al
+    // plan falló. setHuStatus ya resincroniza en el caso happy.
+    if (!planPersisted) {
+      try {
+        db.prepare("UPDATE stories SET status = 'pending', updated_at = ? WHERE id = ?").run(new Date(now()).toISOString(), hu.id);
+      } catch { /* swallow */ }
+    }
+    reaped.push({ id: hu.id, status_before: hu.status, reason, plan_persisted: planPersisted });
+  }
+  return reaped;
+}

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -12,6 +12,8 @@ import pipelineRoutes from './routes/pipeline.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
+import { reapZombieHus } from './hu-zombie-reaper.js';
+import { setHuStatus as setHuStatusPlanMutation } from './plan-mutations.js';
 import { cleanupEphemeralProjects } from './ephemeral-cleaner.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
@@ -189,6 +191,25 @@ async function main() {
   } catch (err) {
     // Never block startup on the reaper. Log and move on.
     console.warn(`[zombie-reaper] skipped: ${err.message}`);
+  }
+
+  // KJC-TSK-0394 step 3 — resetear a `pending` HUs colgadas en
+  // coding/reviewing >30min (orquestador crashed mid-iteration). NO
+  // a `failed` porque no sabemos el outcome; `result` se preserva.
+  try {
+    const dbHandle = (await import('./db.js')).getDb();
+    const reapedHus = reapZombieHus({ db: dbHandle, setHuStatus: setHuStatusPlanMutation });
+    if (reapedHus.length > 0) {
+      console.log(`[hu-zombie-reaper] reset ${reapedHus.length} stuck HU(s) to pending:`);
+      for (const r of reapedHus) {
+        const planNote = r.plan_persisted ? '' : ' (plan write failed — DB-only)';
+        console.log(`  - ${r.id} (was ${r.status_before}; ${r.reason})${planNote}`);
+      }
+    } else {
+      console.log('[hu-zombie-reaper] no stuck HUs detected');
+    }
+  } catch (err) {
+    console.warn(`[hu-zombie-reaper] skipped: ${err.message}`);
   }
 
   // KJC-TSK-0371 (board polish #3) — clean up ephemeral projects

--- a/packages/hu-board/tests/hu-zombie-reaper.test.js
+++ b/packages/hu-board/tests/hu-zombie-reaper.test.js
@@ -1,0 +1,84 @@
+// KJC-TSK-0394 step 3: tests del HU zombie reaper.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { classifyHuZombie, findZombieHus, reapZombieHus } from '../src/hu-zombie-reaper.js';
+
+const NOW = new Date('2026-05-13T12:00:00Z').getTime();
+const ago = (min) => new Date(NOW - min * 60_000).toISOString();
+
+describe('classifyHuZombie', () => {
+  const ctx = { now: NOW, runningMinutes: 30 };
+
+  it('coding/reviewing/running >threshold son zombi', () => {
+    for (const status of ['coding', 'reviewing', 'running']) {
+      const v = classifyHuZombie({ id: 'a', status, updated_at: ago(45) }, ctx);
+      expect(v.zombie).toBe(true);
+      expect(v.reason).toMatch(new RegExp(status));
+    }
+  });
+
+  it('coding activo (<threshold) NO es zombi', () => {
+    expect(classifyHuZombie({ id: 'a', status: 'coding', updated_at: ago(10) }, ctx).zombie).toBe(false);
+  });
+
+  it('estados no-running (pending/done/failed) nunca son zombi', () => {
+    for (const status of ['pending', 'done', 'failed', 'certified', 'blocked']) {
+      expect(classifyHuZombie({ id: 'a', status, updated_at: ago(60 * 24) }, ctx).zombie).toBe(false);
+    }
+  });
+
+  it('updated_at ausente o inválido no es zombi', () => {
+    expect(classifyHuZombie({ id: 'a', status: 'coding' }, ctx).zombie).toBe(false);
+    expect(classifyHuZombie({ id: 'a', status: 'coding', updated_at: 'kk' }, ctx).zombie).toBe(false);
+  });
+});
+
+describe('findZombieHus', () => {
+  it('filtra solo zombis y respeta el threshold', () => {
+    const hus = [
+      { id: 'a', status: 'coding', updated_at: ago(90) },
+      { id: 'b', status: 'reviewing', updated_at: ago(90) },
+      { id: 'c', status: 'coding', updated_at: ago(5) },
+      { id: 'd', status: 'done', updated_at: ago(90) },
+    ];
+    expect(findZombieHus(hus, { now: NOW, runningMinutes: 30 }).map((z) => z.hu.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('reapZombieHus', () => {
+  let db;
+  const insert = (id, planId, status, result, updated) =>
+    db.prepare("INSERT INTO stories VALUES (?, ?, ?, ?, ?, ?)").run(id, 'proj', planId, status, result, updated);
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`CREATE TABLE stories (id TEXT PRIMARY KEY, project_id TEXT, plan_id TEXT, status TEXT, result TEXT, updated_at TEXT);`);
+  });
+  afterEach(() => { db.close(); });
+
+  it('resetea zombis a pending vía setHuStatus y preserva result', () => {
+    insert('proj::hu_001', 'plan-x', 'coding', 'fail', ago(60));
+    insert('proj::hu_002', 'plan-x', 'reviewing', null, ago(60));
+    insert('proj::hu_003', 'plan-x', 'coding', null, ago(5)); // activa, no se toca
+    const setHuStatus = vi.fn(() => ({ ok: true, status: 'pending', planStatus: 'draft' }));
+    const reaped = reapZombieHus({ db, setHuStatus, opts: { runningMinutes: 30 }, now: () => NOW });
+    expect(reaped).toHaveLength(2);
+    expect(reaped.map((r) => r.id).sort()).toEqual(['proj::hu_001', 'proj::hu_002']);
+    expect(reaped.every((r) => r.plan_persisted)).toBe(true);
+    expect(setHuStatus).toHaveBeenCalledWith({ planId: 'plan-x', huId: 'hu_001', status: 'pending', projectId: 'proj' });
+  });
+
+  it('fallback DB-only cuando setHuStatus falla', () => {
+    insert('proj::hu_001', 'plan-x', 'coding', null, ago(60));
+    const setHuStatus = vi.fn(() => ({ ok: false, error: 'plan not found' }));
+    const reaped = reapZombieHus({ db, setHuStatus, opts: { runningMinutes: 30 }, now: () => NOW });
+    expect(reaped[0].plan_persisted).toBe(false);
+    expect(db.prepare("SELECT status FROM stories WHERE id = 'proj::hu_001'").get().status).toBe('pending');
+  });
+
+  it('retorna [] sin zombis o sin db', () => {
+    insert('proj::hu_001', 'plan-x', 'done', 'pass', ago(60));
+    expect(reapZombieHus({ db, setHuStatus: vi.fn(), now: () => NOW })).toEqual([]);
+    expect(reapZombieHus({ db: null, setHuStatus: vi.fn() })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Step 3 of 5 del refactor del modelo de estados del HU Board (KJC-TSK-0394).

Contraparte de \`zombie-reaper.js\` (que opera sobre sessions). Detecta HUs colgadas en \`coding\`/\`reviewing\`/\`running\` >30 min sin updates — síntoma de que el orquestador murió mid-iteration — y las resetea a \`pending\` para que el usuario pueda relanzar.

## Por qué un módulo separado

Sesiones y HUs tienen lifecycles distintos. Una sesión legítima puede tardar horas (loop largo); una HU individual rara vez >30 min. Mezclarlos forzaría un threshold worst-case (6h) y dejaría HUs zombi sentadas durante un cuarto de día. El reaper de HUs trabaja en minutos.

## Semántica del reap (consistente con step 2)

- \`status\` → \`pending\` (NO \`failed\`: perdimos contacto, no sabemos outcome).
- \`result\` se preserva intacto como historial. El usuario verá la HU con badge ✗ si la ejecución anterior había fallado.
- Persistencia vía \`plan-mutations::setHuStatus\` (escribe plan JSON + resync DB). Si el write falla, fallback DB-only.

## Integración

\`packages/hu-board/src/server.js\` startup:
- Corre **después** del session reaper, **antes** del ephemeral cleaner.
- Logs en estilo session reaper: lista de reapeados con motivo.
- Never blocks startup: cualquier error se loguea como warning.

## Tests

8 nuevos en \`hu-zombie-reaper.test.js\`:

- \`classifyHuZombie\`: coding/reviewing/running >threshold; activos no zombi; estados no-running nunca zombi; \`updated_at\` ausente/inválido no zombi.
- \`findZombieHus\`: filtrado y threshold respetado.
- \`reapZombieHus\`: happy path (setHuStatus llamado con args correctos), fallback DB-only cuando setHuStatus falla, no-op sin db/sin zombis.

**Suite global**: 4622/4622 verde. **Paquete hu-board**: 319/319. **LOC**: 196 (under 200 budget).

## Próximos steps

4. Migration script para plan files existentes (\`mapLegacyStatusToResult\` sobre cada HU del disco).
5. Cleanup del enum legacy (\`certified\`/\`failed\` como status → solo result).

## Test plan

- [x] \`npm test\` 4622/4622
- [x] \`packages/hu-board\` 319/319
- [ ] Levantar el board con una HU stuck en coding hace >30 min → log \`[hu-zombie-reaper] reset 1 stuck HU(s) to pending\`
- [ ] Plan file refleja el cambio (status: pending, result intacto)