### PR TITLE
feat(plan): kj plan migrate-result (KJC-TSK-0394 step 4)

### DIFF
--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -7,6 +7,7 @@ import {
   planDeleteCommand,
   planAddHuCommand,
   planRemoveHuCommand,
+  planMigrateResultCommand,
 } from "../commands/plan.js";
 import { parseCanvasMarkdown } from "../canvas/parse-md.js";
 import { validateCanvas } from "../canvas/validate.js";
@@ -149,4 +150,17 @@ export function registerPlan(program, { pkgVersion }) {
       await planRemoveHuCommand({ config, planId, huId });
     });
   });
+
+  // KJC-TSK-0394 step 4: migración one-shot que siembra `result` en las
+  // HUs de los plan files existentes (basado en su status legacy). Solo
+  // toca el campo result, NO el status — el cleanup del enum lo hará
+  // step 5. Idempotente.
+  plan.command("migrate-result")
+    .description("Backfill the `result` field on existing plan HUs (KJC-TSK-0394 step 4)")
+    .option("--dry-run", "Show what would change without writing")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "plan", flags, async ({ config }) => {
+        await planMigrateResultCommand({ config, flags: { dryRun: flags.dryRun } });
+      });
+    });
 }

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -10,5 +10,6 @@ export {
   planDeleteCommand,
   planAddHuCommand,
   planRemoveHuCommand,
+  planMigrateResultCommand,
   planCommand,
 } from "./plan/index.js";

--- a/src/commands/plan/index.js
+++ b/src/commands/plan/index.js
@@ -9,6 +9,7 @@ export { planValidateCommand } from "./validate.js";
 export { planDeleteCommand } from "./delete.js";
 export { planAddHuCommand } from "./add-hu.js";
 export { planRemoveHuCommand } from "./remove-hu.js";
+export { planMigrateResultCommand } from "./migrate-result.js";
 
 // Keep backward compat — old callers import planCommand
 export const planCommand = planGenerateCommand;

--- a/src/commands/plan/migrate-result.js
+++ b/src/commands/plan/migrate-result.js
@@ -1,0 +1,41 @@
+/**
+ * kj plan migrate-result [--dry-run] — KJC-TSK-0394 step 4.
+ * Siembra `result` en las HUs de los plan files existentes,
+ * deducido del status legacy. Idempotente.
+ */
+import { listPlans, loadPlan, savePlan } from "../../plan/plan-store.js";
+import { migratePlanResult } from "../../plan/plan-migrate-result.js";
+
+export async function planMigrateResultCommand({ config, flags = {} }) {
+  const projectDir = config.projectDir || process.cwd();
+  const dryRun = !!flags.dryRun;
+
+  const plans = await listPlans(projectDir);
+  if (plans.length === 0) {
+    console.log("No hay plans que migrar en este proyecto.");
+    return;
+  }
+
+  let totalPlans = 0;
+  let totalHus = 0;
+  for (const meta of plans) {
+    const plan = await loadPlan(projectDir, meta.planId);
+    if (!plan) continue;
+    const { plan: migrated, changes } = migratePlanResult(plan);
+    if (changes.length === 0) continue;
+    totalPlans += 1;
+    totalHus += changes.length;
+    const summary = changes
+      .map((c) => `${c.huId}→${c.result ?? "null"}`)
+      .join(", ");
+    console.log(`${dryRun ? "[dry-run] " : ""}${meta.planId}: ${changes.length} HU(s) — ${summary}`);
+    if (!dryRun) await savePlan(projectDir, migrated);
+  }
+
+  if (totalPlans === 0) {
+    console.log("Todos los plans ya tienen `result` sembrado. Nada que hacer.");
+  } else {
+    const prefix = dryRun ? "[dry-run] " : "";
+    console.log(`${prefix}Migrados ${totalHus} HU(s) en ${totalPlans} plan(s).`);
+  }
+}

--- a/src/plan/plan-migrate-result.js
+++ b/src/plan/plan-migrate-result.js
@@ -1,0 +1,24 @@
+/**
+ * KJC-TSK-0394 step 4: migration helper para plan files existentes.
+ * Siembra `result` en las HUs vía inferResultFromLegacyStatus.
+ * Idempotente. NO toca `status` (eso será step 5).
+ */
+import { inferResultFromLegacyStatus } from "./plan-schema.js";
+
+/** Pura. Devuelve {plan: nuevo, changes: [...]}, sin mutar el input. */
+export function migratePlanResult(plan) {
+  if (!plan || !Array.isArray(plan.hus)) return { plan, changes: [] };
+  const changes = [];
+  const hus = plan.hus.map((hu) => {
+    // Sembrar explícito (incluso null) marca el HU como migrado para
+    // pasadas posteriores. hasOwnProperty distingue "no migrado" de
+    // "migrado a null".
+    const already = Object.prototype.hasOwnProperty.call(hu, "result") && hu.result !== undefined;
+    if (already) return hu;
+    const inferred = inferResultFromLegacyStatus(hu);
+    changes.push({ huId: hu.id, result: inferred });
+    return { ...hu, result: inferred };
+  });
+  if (changes.length === 0) return { plan, changes };
+  return { plan: { ...plan, hus, updatedAt: new Date().toISOString() }, changes };
+}

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -20,6 +20,18 @@ const VALID_TASK_TYPES = new Set(["sw", "infra", "doc", "add-tests", "refactor",
 const VALID_TEST_TYPES = new Set(["shell", "gherkin"]);
 
 /**
+ * KJC-TSK-0394 step 4: deduce `result` de un HU legacy. Idempotente.
+ * Heurística: done→pass (si hubiera fallado estaría en failed),
+ * failed→fail, resto→null. NO toca status (eso es step 5).
+ */
+export function inferResultFromLegacyStatus(hu) {
+  if (hu && hu.result != null) return hu.result;
+  if (hu?.status === "done") return "pass";
+  if (hu?.status === "failed") return "fail";
+  return null;
+}
+
+/**
  * Map a legacy status to (newStatus, result) pair. Used by addHu() defaults
  * and by the migration script in step 4. Idempotent: re-mapping a value that
  * is already in the canonical {pending, running, done} set keeps it.

--- a/tests/plan/plan-migrate-result.test.js
+++ b/tests/plan/plan-migrate-result.test.js
@@ -1,0 +1,80 @@
+// KJC-TSK-0394 step 4: tests del migration helper de `result`.
+import { describe, it, expect } from "vitest";
+import { migratePlanResult } from "../../src/plan/plan-migrate-result.js";
+import { inferResultFromLegacyStatus, createPlanV2 } from "../../src/plan/plan-schema.js";
+import { addHu } from "../../src/plan/plan-hu-ops.js";
+
+describe("inferResultFromLegacyStatus", () => {
+  it("done sin result → pass (asunción: si hubiera fallado estaría en failed)", () => {
+    expect(inferResultFromLegacyStatus({ status: "done" })).toBe("pass");
+  });
+  it("failed sin result → fail", () => {
+    expect(inferResultFromLegacyStatus({ status: "failed" })).toBe("fail");
+  });
+  it("estados no-terminales → null", () => {
+    for (const s of ["pending", "certified", "coding", "reviewing", "blocked", "needs_context"]) {
+      expect(inferResultFromLegacyStatus({ status: s })).toBe(null);
+    }
+  });
+  it("respeta result existente (idempotencia)", () => {
+    expect(inferResultFromLegacyStatus({ status: "done", result: "fail" })).toBe("fail");
+    expect(inferResultFromLegacyStatus({ status: "failed", result: "partial" })).toBe("partial");
+  });
+  it("result null explícito → infiere (migration helper chequea hasOwnProperty antes)", () => {
+    expect(inferResultFromLegacyStatus({ status: "done", result: null })).toBe("pass");
+  });
+});
+
+describe("migratePlanResult", () => {
+  function planWith(huStatuses) {
+    const plan = createPlanV2("test");
+    for (let i = 0; i < huStatuses.length; i += 1) {
+      const hu = addHu(plan, { title: `hu ${i}` });
+      hu.status = huStatuses[i];
+      delete hu.result;       // simula plan legacy sin campo result
+    }
+    return plan;
+  }
+
+  it("siembra result en HUs sin campo", () => {
+    const plan = planWith(["done", "failed", "pending", "coding"]);
+    const { plan: out, changes } = migratePlanResult(plan);
+    expect(changes).toHaveLength(4);
+    expect(out.hus.map((h) => h.result)).toEqual(["pass", "fail", null, null]);
+  });
+
+  it("es idempotente — segunda pasada NO produce changes", () => {
+    const plan = planWith(["done", "failed", "pending"]);
+    const { plan: once } = migratePlanResult(plan);
+    const { changes: twiceChanges } = migratePlanResult(once);
+    expect(twiceChanges).toEqual([]);
+  });
+
+  it("no muta el plan original", () => {
+    const plan = planWith(["done"]);
+    const before = JSON.stringify(plan);
+    migratePlanResult(plan);
+    expect(JSON.stringify(plan)).toBe(before);
+  });
+
+  it("plan vacío o sin hus → noop", () => {
+    expect(migratePlanResult({ hus: [] }).changes).toEqual([]);
+    expect(migratePlanResult({}).changes).toEqual([]);
+    expect(migratePlanResult(null).changes).toEqual([]);
+  });
+
+  it("respeta HUs que ya tenían result asignado (incluso null explícito)", () => {
+    const plan = planWith(["done", "failed"]);
+    plan.hus[0].result = "partial";    // ya migrado manualmente
+    plan.hus[1].result = null;          // ya migrado explícitamente a null
+    const { changes } = migratePlanResult(plan);
+    expect(changes).toEqual([]);
+  });
+
+  it("actualiza updatedAt cuando hay cambios", async () => {
+    const plan = planWith(["done"]);
+    plan.updatedAt = "2020-01-01T00:00:00Z";
+    const { plan: out } = migratePlanResult(plan);
+    expect(out.updatedAt).not.toBe("2020-01-01T00:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary

Step 4 of 5 del refactor del modelo de estados del HU Board (KJC-TSK-0394).

Migration one-shot que siembra el campo \`result\` (step 1) en cada HU de los plan files existentes del proyecto, deducido del status legacy. Idempotente.

## Heurística

| status legacy   | result inferido |
|-----------------|-----------------|
| \`done\`        | \`pass\` (en el modelo legacy una HU en done implícitamente había pasado los tests; si hubiera fallado estaría en \`failed\`) |
| \`failed\`      | \`fail\` |
| resto           | \`null\` |

**IMPORTANT**: NO toca el campo \`status\` — eso es step 5 (cleanup del enum legacy). Aquí solo sembramos \`result\` para que la UI pueda pintar badges retroactivamente en plans antiguos.

## Cambios

- \`src/plan/plan-schema.js\`: nueva función \`inferResultFromLegacyStatus\`.
- \`src/plan/plan-migrate-result.js\`: helper puro \`migratePlanResult\` (no muta el input). \`hasOwnProperty(result)\` distingue "no migrado" de "migrado a null explícito" → idempotencia real.
- \`src/commands/plan/migrate-result.js\`: CLI handler. Itera \`listPlans\` → \`loadPlan\` → \`migratePlanResult\` → \`savePlan\`. Flag \`--dry-run\` para solo imprimir el resumen.
- Registro del subcomando \`kj plan migrate-result\` en \`register-plan.js\` + \`index.js\` + el shim \`plan.js\`.

## Uso

\`\`\`bash
$ kj plan migrate-result --dry-run
[dry-run] plan-20260424101010-abcd: 3 HU(s) — hu_001→pass, hu_002→fail, hu_003→null
[dry-run] Migrados 3 HU(s) en 1 plan(s).

$ kj plan migrate-result
plan-20260424101010-abcd: 3 HU(s) — hu_001→pass, hu_002→fail, hu_003→null
Migrados 3 HU(s) en 1 plan(s).

$ kj plan migrate-result   # segunda corrida
Todos los plans ya tienen \`result\` sembrado. Nada que hacer.
\`\`\`

## Tests

11 nuevos en \`tests/plan/plan-migrate-result.test.js\`:
- \`inferResultFromLegacyStatus\`: done→pass, failed→fail, no-terminal→null, idempotencia (respeta result existente), null explícito.
- \`migratePlanResult\`: siembra, idempotencia (2ª pasada sin changes), no muta el input, edge cases (plan vacío/null/sin hus), respeta HUs ya migradas, actualiza \`updatedAt\` cuando hay cambios.

**Suite global**: 4633/4633 verde (+11). **LOC**: 172 (under 200 budget).

## Próximo step

5. Cleanup del enum legacy — eliminar \`certified\`/\`failed\` como status (ya solo \`result\`). Implica migrar runtime + UI para usar el nuevo modelo de lifecycle \`{pending, running, done}\`.

## Test plan

- [x] \`npm test\` 4633/4633
- [ ] Correr \`kj plan migrate-result --dry-run\` en un proyecto con plans con HUs en \`done\`/\`failed\` → ver el resumen
- [ ] Correr sin \`--dry-run\` → plans escritos con \`result\` sembrado
- [ ] Re-ejecutar → "Nada que hacer"