### PR TITLE
feat(plan): canonicalStatus + effectiveResult helpers (KJC-TSK-0394 step 5)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1012,12 +1012,29 @@ function renderStoryCard(story) {
       ${antipatterns.length > 0 ? `<div class="story-card__antipattern">${antipatterns.map((a) => esc(a)).join(', ')}</div>` : ''}
       <div class="story-card__meta" style="margin-top:6px">
         <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
-        ${renderResultBadge(story.result)}
+        ${renderResultBadge(computeEffectiveResult(story))}
         <span class="story-card__time">${timeAgo(story.updated_at)}</span>
         ${renderOutcomeChip(story.outcome)}
       </div>
     </div>
   `;
+}
+
+/**
+ * KJC-TSK-0394 step 5: result "efectivo" para la UI. Sobre el campo
+ * persistido `story.result` (si existe), o inferido del status legacy
+ * (done→pass, failed→fail). Permite pintar badges en plans antiguos
+ * sin requerir migración previa con `kj plan migrate-result`.
+ *
+ * Espejo de plan-schema.js::effectiveResult — necesario aquí porque la
+ * UI corre en el browser y no puede importar módulos Node del backend.
+ */
+function computeEffectiveResult(story) {
+  if (!story) return null;
+  if (story.result !== undefined && story.result !== null) return story.result;
+  if (story.status === 'done') return 'pass';
+  if (story.status === 'failed') return 'fail';
+  return null;
 }
 
 /**

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -7,7 +7,21 @@
 import { generatePlanId } from "./plan-id.js";
 
 const VALID_PLAN_STATUSES = new Set(["draft", "ready", "running", "done", "failed"]);
-const VALID_HU_STATUSES = new Set(["pending", "certified", "coding", "reviewing", "done", "failed", "blocked"]);
+// KJC-TSK-0394 step 5: el modelo CANONICAL del lifecycle es
+// {pending, running, done}. Los valores certified/coding/reviewing/
+// failed/blocked/needs_context se mantienen como LEGACY (siguen
+// aceptados por validatePlan para no romper plans existentes ni el
+// runtime actual). El cleanup definitivo del runtime queda como
+// follow-up; mientras tanto la UI puede usar canonicalStatus +
+// effectiveResult para presentar el modelo de 3 estados sin tocar
+// la persistencia.
+const VALID_HU_STATUSES = new Set([
+  // Canonical
+  "pending", "running", "done",
+  // Legacy
+  "certified", "coding", "reviewing", "failed", "blocked", "needs_context",
+]);
+export const CANONICAL_HU_STATUSES = new Set(["pending", "running", "done"]);
 // KJC-TSK-0394: nuevo campo `result` ortogonal a status. Reemplaza la
 // sobrecarga semántica del status (certified=pass, failed=fail) por una
 // distinción explícita entre lifecycle (status) y último resultado (result).
@@ -29,6 +43,51 @@ export function inferResultFromLegacyStatus(hu) {
   if (hu?.status === "done") return "pass";
   if (hu?.status === "failed") return "fail";
   return null;
+}
+
+/**
+ * KJC-TSK-0394 step 5: mapea cualquier status (legacy o canonical) al
+ * modelo CANONICAL {pending, running, done}. Permite que la UI y los
+ * agregados (counts, kanban columns) trabajen contra un enum pequeño
+ * sin tener que conocer todas las variantes legacy.
+ *
+ *   certified | blocked | needs_context | pending → pending
+ *   coding | reviewing | running                  → running
+ *   done | failed                                 → done
+ *
+ * `failed` mapea a `done` porque conceptualmente es lifecycle terminal
+ * — el "falló" lo lleva el campo `result` ortogonal (step 1). Lo mismo
+ * para `certified`: no es un lifecycle, es "ready to run" que en el
+ * modelo canónico vive como `pending` + acceptance_tests no vacío.
+ */
+export function canonicalStatus(status) {
+  switch (status) {
+    case "running":
+    case "coding":
+    case "reviewing":
+      return "running";
+    case "done":
+    case "failed":
+      return "done";
+    default:
+      return "pending";
+  }
+}
+
+/**
+ * KJC-TSK-0394 step 5: result "efectivo" para la UI. Si el HU tiene
+ * `result` poblado (plans migrados), lo usa directamente. Si no
+ * (plans legacy pre-migración), lo deduce del status — equivalente a
+ * inferResultFromLegacyStatus pero llamable directamente sobre cada
+ * HU al renderizar.
+ *
+ * Permite a la UI mostrar badges ✓/✗ en plans antiguos sin esperar a
+ * que el usuario corra `kj plan migrate-result`.
+ */
+export function effectiveResult(hu) {
+  if (!hu) return null;
+  if (hu.result !== undefined && hu.result !== null) return hu.result;
+  return inferResultFromLegacyStatus(hu);
 }
 
 /**

--- a/tests/plan/plan-module.test.js
+++ b/tests/plan/plan-module.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { generatePlanId, generateHuId } from "../../src/plan/plan-id.js";
-import { createPlanV2, migratePlanV1toV2, isPlanV2, validatePlan, mapLegacyStatusToResult, VALID_HU_RESULTS } from "../../src/plan/plan-schema.js";
+import { createPlanV2, migratePlanV1toV2, isPlanV2, validatePlan, mapLegacyStatusToResult, VALID_HU_RESULTS, canonicalStatus, effectiveResult, CANONICAL_HU_STATUSES } from "../../src/plan/plan-schema.js";
 import { addHu, removeHu, updateHu, updateHuStatus, certifyAllHus, reorderHus } from "../../src/plan/plan-hu-ops.js";
 
 describe("plan-id", () => {
@@ -267,5 +267,63 @@ describe("mapLegacyStatusToResult (KJC-TSK-0394 migration)", () => {
   it("idempotente — re-mapear un valor canónico no rompe", () => {
     expect(mapLegacyStatusToResult("pending").status).toBe("pending");
     expect(mapLegacyStatusToResult("done").status).toBe("done");
+  });
+});
+
+describe("canonicalStatus (KJC-TSK-0394 step 5)", () => {
+  it("canónicos se devuelven intactos", () => {
+    expect(canonicalStatus("pending")).toBe("pending");
+    expect(canonicalStatus("running")).toBe("running");
+    expect(canonicalStatus("done")).toBe("done");
+  });
+  it("coding/reviewing → running", () => {
+    expect(canonicalStatus("coding")).toBe("running");
+    expect(canonicalStatus("reviewing")).toBe("running");
+  });
+  it("failed → done (failure lo lleva el campo result, no el status)", () => {
+    expect(canonicalStatus("failed")).toBe("done");
+  });
+  it("certified/blocked/needs_context → pending", () => {
+    expect(canonicalStatus("certified")).toBe("pending");
+    expect(canonicalStatus("blocked")).toBe("pending");
+    expect(canonicalStatus("needs_context")).toBe("pending");
+  });
+  it("valor desconocido → pending (defensive)", () => {
+    expect(canonicalStatus("weird")).toBe("pending");
+    expect(canonicalStatus(undefined)).toBe("pending");
+  });
+  it("CANONICAL_HU_STATUSES expone los 3 canónicos", () => {
+    expect([...CANONICAL_HU_STATUSES].sort()).toEqual(["done", "pending", "running"]);
+  });
+});
+
+describe("effectiveResult (KJC-TSK-0394 step 5)", () => {
+  it("hu con result poblado → lo devuelve", () => {
+    expect(effectiveResult({ status: "done", result: "partial" })).toBe("partial");
+    expect(effectiveResult({ status: "running", result: "fail" })).toBe("fail");
+  });
+  it("hu legacy sin result + status done → pass", () => {
+    expect(effectiveResult({ status: "done" })).toBe("pass");
+  });
+  it("hu legacy sin result + status failed → fail", () => {
+    expect(effectiveResult({ status: "failed" })).toBe("fail");
+  });
+  it("hu sin result y status no-terminal → null", () => {
+    expect(effectiveResult({ status: "pending" })).toBe(null);
+    expect(effectiveResult({ status: "coding" })).toBe(null);
+  });
+  it("hu null o vacío → null", () => {
+    expect(effectiveResult(null)).toBe(null);
+    expect(effectiveResult({})).toBe(null);
+  });
+});
+
+// validatePlan ahora acepta el nuevo status canonical `running`.
+describe("validatePlan running canonical (KJC-TSK-0394 step 5)", () => {
+  it("acepta status `running` como válido", () => {
+    const plan = createPlanV2("test");
+    addHu(plan, { title: "x" });
+    plan.hus[0].status = "running";
+    expect(validatePlan(plan).valid).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Step 5 (final) of 5 del refactor del modelo de estados del HU Board (KJC-TSK-0394).

**Step 5 conservador**: introduce los helpers canonicales \`canonicalStatus\` y \`effectiveResult\` SIN forzar el cleanup del runtime/UI/tests existentes. El cleanup definitivo (renombrar el dato persistido en plans y DB) queda como follow-up declarado.

## Modelo canonical

El lifecycle CANONICAL pasa a ser **{pending, running, done}** (3 estados), ortogonal a \`result\` (pass | fail | partial | null). Los valores legacy (\`certified\`, \`coding\`, \`reviewing\`, \`failed\`, \`blocked\`, \`needs_context\`) siguen aceptados por \`validatePlan\` para no romper plans existentes ni el runtime actual.

### Mapeo

\`canonicalStatus(status)\`:

| Input legacy/canonical                          | Output canonical |
|-------------------------------------------------|------------------|
| \`coding\`, \`reviewing\`, \`running\`          | \`running\`      |
| \`done\`, \`failed\`                            | \`done\` (failure va en \`result\`) |
| \`certified\`, \`blocked\`, \`needs_context\`, \`pending\` | \`pending\` |

\`effectiveResult(hu)\`:

- Si \`hu.result\` está poblado → ese valor
- Si no, lo deduce del status legacy (done→pass, failed→fail, resto→null)
- Permite pintar badges en plans antiguos **SIN requerir** \`kj plan migrate-result\` previo (sigue siendo bienvenido pero ya no es obligatorio).

## Cambios

- **\`src/plan/plan-schema.js\`**:
  - \`VALID_HU_STATUSES\` amplía aceptando \`running\` (canonical) + \`needs_context\` (estaba implícitamente aceptado en otras partes pero no en el enum).
  - Export \`CANONICAL_HU_STATUSES = {pending, running, done}\`.
  - Export \`canonicalStatus()\` y \`effectiveResult()\`.
- **\`packages/hu-board/public/app.js\`**:
  - \`renderStoryCard\` usa \`computeEffectiveResult(story)\` en lugar de \`story.result\` directamente. Espejo de \`effectiveResult\` para el runtime browser (no puede importar módulos Node).
  - Resultado visible: HUs done/failed legacy también pintan badge ✓/✗ aunque el plan no haya sido migrado.

## Tests

12 nuevos en \`plan-module.test.js\` (48 totales, +12):

- \`canonicalStatus\`: 3 canónicos identidad, coding/reviewing→running, failed→done, certified/blocked/needs_context→pending, defensive para valor desconocido/undefined, \`CANONICAL_HU_STATUSES\` exporta exactamente los 3.
- \`effectiveResult\`: respeta result poblado (5 escenarios incl. partial), infiere de status done/failed, null para no-terminales, defensivo para null/{}.
- \`validatePlan\` acepta el nuevo status \`running\` canonical.

**Suite global**: 4645/4645 verde (+12). **LOC**: 137 (well under budget).

## Follow-up (NO parte de TSK-0394)

- Migrar **runtime** (hu-sub-pipeline, plan-executor, hu-reviewer-stage) para emitir \`running\`/\`done\`+\`result\` en lugar de coding/reviewing/failed.
- Migrar **UI kanban** para usar \`canonicalStatus\` directamente en lugar de listas hard-coded de status.
- Migrar **API** \`ALLOWED_STORY_STATUSES\` y los tests de plan-mutations.

## Cierre de KJC-TSK-0394

Con este PR cierra el refactor de status/outcome:

1. ✅ Schema + campo \`result\` (PR #693)
2. ✅ UI badge + Reset + ▶ Run en done (PR #694)
3. ✅ HU zombie reaper (PR #695)
4. ✅ \`kj plan migrate-result\` (PR #696)
5. ✅ Helpers canonicales + UI usa \`effectiveResult\` (este PR)

## Test plan

- [x] \`npm test\` 4645/4645
- [ ] Abrir board con plan legacy (sin \`result\` poblado) y verificar que HUs en \`done\`/\`failed\` muestran badge ✓/✗ automáticamente
- [ ] \`kj plan validate <id>\` sobre un plan con HU en \`running\` (nuevo canonical) → válido