### PR TITLE
feat(hu-board): dropdown libre de status en el modal

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1449,6 +1449,47 @@ window.runSingleHuFromCard = async function runSingleHuFromCard(huId, title) {
  * (ver routes/api.js); plan-mutations::setHuStatus refleja el cambio
  * al fichero del plan y resincroniza la BBDD.
  */
+/**
+ * Cambio libre de status desde el dropdown del modal. PATCH al backend
+ * con el status nuevo + confirmación (algunos targets como `done` /
+ * `failed` son blast-radius alto: no se puede deshacer sin Reset).
+ *
+ * El propio backend valida que `newStatus` esté en ALLOWED_STORY_
+ * STATUSES, así que si el dropdown trae basura el servidor rechaza con
+ * 400 — no necesitamos re-validar aquí.
+ */
+window.changeHuStatusFromModal = async function changeHuStatusFromModal(storyId, newStatus, oldStatus) {
+  // Opción "Cambiar a…" placeholder: el usuario abrió el dropdown sin
+  // elegir nada. Selecciona el placeholder otra vez para no quedar en
+  // un estado ambiguo.
+  if (!newStatus) return;
+  const select = document.getElementById('hu-status-select');
+  const ok = await showConfirm(
+    `Cambiar el status de esta HU de "${oldStatus}" a "${newStatus}"?\n\nEl plan file y el board se actualizan al instante. El campo result (badge ✓/✗) se conserva como historial.`,
+    { title: 'Cambiar status', okLabel: 'Cambiar', cancelLabel: 'Cancelar' }
+  );
+  if (!ok) { if (select) select.value = ''; return; }
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: newStatus }),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudo cambiar el status' });
+      if (select) select.value = '';
+      return;
+    }
+    closeModal();
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo al cambiar el status' });
+    if (select) select.value = '';
+  }
+};
+
 window.resetHuToPending = async function resetHuToPending(storyId) {
   const ok = await showConfirm(
     '¿Devolver esta HU a pending?\n\nEl estado se cambia a pending y se podrá relanzar. El resultado de la última ejecución (✓/✗/~) se conserva como historial hasta que vuelvas a ejecutarla.',
@@ -2081,13 +2122,33 @@ async function showStoryDetail(storyId) {
     // estado destino, no tiene sentido el botón.
     const canResetToPending = story.plan_id
       && !['pending', 'certified'].includes(story.status);
+    // Dropdown libre de status. Solo plan-backed. La lista es la misma
+    // que ALLOWED_STORY_STATUSES en el backend — NO incluye coding/
+    // reviewing/running (esos los pone el orquestador; setearlos a
+    // mano genera zombies en el reaper).
+    const canChangeStatus = !!story.plan_id;
+    const userSettableStatuses = ['pending', 'certified', 'done', 'failed', 'blocked', 'needs_context'];
 
     content.innerHTML = `
       <div class="modal__header">
         <div>
           <div class="modal__title" title="${esc(story.id)}">${esc(shortId)}</div>
           <div class="modal__subtitle" style="font-size:0.75rem;color:var(--text-muted);font-family:monospace;margin-top:2px">${esc(story.id)}</div>
-          <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
+          <div style="display:flex;align-items:center;gap:8px;margin-top:6px">
+            <span class="story-card__status status--${story.status}">${esc(story.status)}</span>
+            ${canChangeStatus ? `
+              <select id="hu-status-select"
+                      title="Cambiar manualmente el status de esta HU"
+                      style="padding:3px 6px;font-size:0.75rem;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:var(--radius-sm);cursor:pointer"
+                      onchange="changeHuStatusFromModal('${esc(story.id)}', this.value, '${esc(story.status)}')">
+                <option value="">Cambiar a…</option>
+                ${userSettableStatuses
+                  .filter((s) => s !== story.status)
+                  .map((s) => `<option value="${s}">${s}</option>`)
+                  .join('')}
+              </select>
+            ` : ''}
+          </div>
         </div>
         <div style="display:flex;align-items:center;gap:8px">
           ${canEdit ? `

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -508,7 +508,13 @@ router.post('/tombstones/:type/:id/restore', (req, res) => {
  * rewritten before we ack, then re-synced into SQLite, so a reload
  * renders the committed state.
  */
-const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'needs_context']);
+// Status que el USUARIO puede setear manualmente vía el dropdown del
+// modal. NO incluimos coding/reviewing/running — esos son lifecycle
+// del orquestador (settearlos a mano genera zombies). Tampoco
+// incluimos los canonicales (`running`) por la misma razón. `failed`
+// y `blocked` son útiles para que el usuario marque manualmente HUs
+// que no quiere correr ahora.
+const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'failed', 'blocked', 'needs_context']);
 const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by'];
 
 router.patch('/stories/:id', (req, res) => {

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -179,6 +179,32 @@ describe('PATCH /api/stories/:id', () => {
     expect(hu.result).toBe('fail');
   });
 
+  // Dropdown libre del modal: PATCH acepta cualquier status del set
+  // user-settable (pending/certified/done/failed/blocked/needs_context).
+  it.each(['certified', 'done', 'failed', 'blocked', 'needs_context'])(
+    'PATCH stories acepta cambiar a "%s" manualmente',
+    async (target) => {
+      const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+      const res = await request(app)
+        .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+        .send({ status: target });
+      expect(res.status).toBe(200);
+      const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+      expect(hu.status).toBe(target);
+    },
+  );
+
+  // NO se permite settear lifecycle del orquestador (genera zombies).
+  it.each(['coding', 'reviewing', 'running'])(
+    'PATCH stories RECHAZA status del orquestador "%s" con 400',
+    async (target) => {
+      const res = await request(app)
+        .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_001`)}`)
+        .send({ status: target });
+      expect(res.status).toBe(400);
+    },
+  );
+
   it('reset desde "done" a "pending" preserva el result anterior', async () => {
     const plan = readPlanFromDisk();
     plan.hus[0].status = 'done';

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -15,6 +15,10 @@ const VALID_PLAN_STATUSES = new Set(["draft", "ready", "running", "done", "faile
 // follow-up; mientras tanto la UI puede usar canonicalStatus +
 // effectiveResult para presentar el modelo de 3 estados sin tocar
 // la persistencia.
+//
+// needs_context se PATCHeaba vía /api/stories/:id (dropdown libre del
+// modal) sin que el enum lo aceptara → `kj plan validate` daba
+// false-negative tras un set manual. Incluido aquí para alinear.
 const VALID_HU_STATUSES = new Set([
   // Canonical
   "pending", "running", "done",


### PR DESCRIPTION
## Summary

Permite al usuario cambiar manualmente el status de una HU desde el modal del board. Hasta ahora solo había \`↺ Reset\` (un único destino: pending) y \`✎ Edit\` (no tocaba status).

## Cambios

### 1. Backend: \`ALLOWED_STORY_STATUSES\` ampliado
\`packages/hu-board/src/routes/api.js\` — añade \`failed\` y \`blocked\` al set de status user-settable: \`{pending, certified, done, failed, blocked, needs_context}\`. **NO incluye** \`coding\`/\`reviewing\`/\`running\` — esos son lifecycle del orquestador; setearlos manualmente generaría zombies en el reaper.

### 2. Fix bug latente
\`src/plan/plan-schema.js\` — \`needs_context\` se PATCHeaba sin estar en \`VALID_HU_STATUSES\`, por lo que tras un set manual \`kj plan validate\` daba false-negative. Añadido al enum para alinear ambos.

### 3. UI: dropdown en el modal
\`packages/hu-board/public/app.js\` — \`<select>\` junto al badge de status:

\`\`\`
[ pending ] [Cambiar a… ▾]
              certified
              done
              failed
              blocked
              needs_context
\`\`\`

- Solo visible cuando \`story.plan_id\` existe (legacy rows no persisten).
- Excluye el status actual de las opciones.
- \`showConfirm\` + \`PATCH\` + \`/api/sync\` + \`renderBoard\`.
- Si el usuario cancela en el confirm, el dropdown vuelve al placeholder \`Cambiar a…\`.
- Mantiene \`↺ Reset\` como atajo al caso común (volver a pending).

## Tests

8 nuevos en \`plan-mutations.test.js\` (44 totales en este file, +8):

- \`it.each\` sobre los 5 status user-settable nuevos → PATCH acepta cada uno con 200 y el plan file refleja el cambio.
- \`it.each\` sobre \`coding\`, \`reviewing\`, \`running\` → PATCH rechaza con 400.

**Suite global**: 4633/4633 verde. **Paquete hu-board**: 327 (+8). **LOC**: 99.

## Test plan

- [x] \`npm test\` 4633/4633
- [ ] Abrir el board, click en una HU → ver el dropdown junto al status
- [ ] Cambiar a \`blocked\` → confirm modal → status pasa a blocked, plan file refleja
- [ ] Re-abrir la HU → dropdown ya no muestra "blocked" en las opciones
- [ ] Intentar setear \`coding\` con curl directo al PATCH → 400