### PR TITLE
fix(hu-board): papelera siempre visible + presente en project-picker

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -865,13 +865,18 @@ async function renderProjectPicker() {
         const counts = bucket(byProject.get(p.id) || []);
         const total = counts.pending + counts.running + counts.done + counts.failed;
         const name = projectNameCache[p.id] || p.name || humaniseProjectName(p.id);
+        // div en lugar de <button> para poder anidar el botón de
+        // delete (HTML no permite buttons anidados). role+tabindex
+        // mantienen la accesibilidad equivalente.
         return `
-          <button type="button" class="project-picker__card" data-project-id="${esc(p.id)}"
-                  style="text-align:left;display:flex;flex-direction:column;gap:8px;padding:14px 16px;
+          <div role="button" tabindex="0" class="project-picker__card" data-project-id="${esc(p.id)}"
+                  style="position:relative;text-align:left;display:flex;flex-direction:column;gap:8px;padding:14px 16px;
                          background:var(--bg-secondary);border:1px solid var(--border);
                          border-radius:var(--radius-sm);cursor:pointer;color:var(--text);
                          transition:border-color 120ms">
-            <div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px">
+            <button class="project-card__delete" title="Borrar proyecto (cascade)"
+                    data-project-id="${esc(p.id)}" data-project-name="${esc(name)}">🗑️</button>
+            <div style="display:flex;align-items:baseline;justify-content:space-between;gap:8px;padding-right:32px">
               <strong style="font-size:0.95rem">${esc(name)}</strong>
               <span style="font-size:0.75rem;color:var(--text-muted)">${total} HU${total === 1 ? '' : 's'}</span>
             </div>
@@ -885,18 +890,31 @@ async function renderProjectPicker() {
             <div style="font-family:var(--font-mono, monospace);font-size:0.7rem;color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(p.id)}">
               ${esc(p.id)}
             </div>
-          </button>
+          </div>
         `;
       }).join('')}
     </div>
   `;
 
   app.querySelectorAll('.project-picker__card').forEach((btn) => {
-    btn.addEventListener('click', () => {
+    const enter = () => {
       const id = btn.dataset.projectId;
       // Use the existing route so back/forward work and the dropdown
       // syncs via handleRoute().
       window.location.hash = `board/${encodeURIComponent(id)}`;
+    };
+    btn.addEventListener('click', (e) => {
+      // Click sobre el botón delete anidado — el handler global ya
+      // hace stopPropagation + preventDefault, pero por defensa
+      // ignoramos aquí cualquier click que venga de dentro de él.
+      if (e.target.closest('.project-card__delete')) return;
+      enter();
+    });
+    btn.addEventListener('keydown', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !e.target.closest('.project-card__delete')) {
+        e.preventDefault();
+        enter();
+      }
     });
     // Tiny hover affordance — no CSS file edit needed.
     btn.addEventListener('mouseenter', () => { btn.style.borderColor = 'var(--color-green)'; });

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -718,13 +718,14 @@ a:hover {
   padding: 4px 8px;
   font-size: 0.95rem;
   cursor: pointer;
-  opacity: 0;
+  opacity: 0.55;
   transition: all 0.15s;
   z-index: 2;
 }
 
-.project-card:hover .project-card__delete {
-  opacity: 0.6;
+.project-card:hover .project-card__delete,
+.project-picker__card:hover .project-card__delete {
+  opacity: 0.85;
 }
 
 .project-card__delete:hover {


### PR DESCRIPTION
## Bug

El botón 🗑️ \"Delete project (cascade)\" del board tenía dos problemas:

1. **Invisible**: \`opacity: 0\` por defecto, solo aparecía al hover sobre la card. En la práctica los usuarios no descubrían su existencia.
2. **Ausente en project-picker**: solo se renderizaba en la grid \`.project-card\` del Dashboard. En la vista \`Board → Story Board\` (cuando no hay proyecto seleccionado) las cards del picker NO tenían botón.

Diagnóstico encontrado al recibir feedback explícito del usuario: \"Si veo un proyecto lo tengo que poder borrar [desde donde esté]\".

## Cambios

### 1. CSS: siempre visible
\`packages/hu-board/public/styles.css\`:
- \`.project-card__delete\` ahora \`opacity: 0.55\` baseline (igual que el botón \`is_test\` adyacente).
- Hover de la card → 0.85; hover del propio botón → 1 + halo rojo.
- El selector \`.project-card:hover .project-card__delete\` ahora también engancha \`.project-picker__card:hover .project-card__delete\` para que la mejora de visibilidad funcione en ambos lugares.

### 2. UI: papelera en project-picker
\`packages/hu-board/public/app.js\` (\`renderProjectPicker\`):
- Cada card del picker ahora incluye \`<button class=\"project-card__delete\">\` con \`data-project-id\` + \`data-project-name\`. El handler global \`document.addEventListener('click', ...)\` de la línea 3349 ya engancha por clase, así que **no hay código nuevo de wiring** — solo el botón.
- Wrapper pasa de \`<button>\` a \`<div role=\"button\" tabindex=\"0\">\` porque HTML no permite anidar buttons.
- Soporte teclado Enter/Space para mantener accesibilidad equivalente.
- Click handler ignora clicks originados en \`.project-card__delete\` (defensa en profundidad sobre el \`stopPropagation\` que ya hace el handler global).

## Tests

315/315 verde en el paquete hu-board. No hay tests de UI directos; los tests existentes del endpoint \`DELETE /api/projects/:id\` siguen pasando.

## Test plan

- [ ] Abrir Board → Story Board → ver la 🗑️ siempre visible (no requiere hover) en la esquina superior derecha de cada card de proyecto.
- [ ] Click en 🗑️ → confirm modal con texto en español → confirmar → cascade-delete OK.
- [ ] Click en el resto de la card → entra al kanban del proyecto.
- [ ] Tab → Enter sobre una card del picker → entra al kanban (accesibilidad mantenida).
- [ ] Tab → Tab → la 🗑️ recibe foco; Enter sobre ella → confirm modal.

## LOC

35 LOC añadidas. Sin nuevos tests (cambio puramente de UI; el wiring del API ya estaba testado).