### PR TITLE
fix(hu-board): tombstone de proyecto NO bloquea planes nuevos (KJC-BUG-0050)

### DIFF
--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -10,6 +10,7 @@ import {
   insertContextRequest,
   getDb,
   isTombstoned,
+  removeTombstone,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
 
@@ -340,7 +341,19 @@ export function syncPlanFile(filePath) {
       : data.planId;
 
     if (skipIfTombstoned('plan', data.planId, filePath)) return;
-    if (skipIfTombstoned('project', projectId, dirname(filePath))) return;
+    // KJC-BUG-0050: el tombstone del PROYECTO no debe bloquear plans
+    // futuros. Cuando el usuario borra un proyecto del board (🗑️), el
+    // tombstone permanente impedía regenerar planes en el mismo
+    // projectDir — `kj plan` escribía el JSON y este sync lo borraba.
+    // Fix: si el proyecto está tombstoned pero el PLAN concreto NO lo
+    // está, asumimos que el usuario quiere resurrectarlo (creó un plan
+    // nuevo) y borramos el tombstone del proyecto. El tombstone-de-plan
+    // sigue respetándose: planes individuales que el usuario borró
+    // siguen muertos hasta que se cree un planId distinto.
+    if (isTombstoned('project', projectId)) {
+      console.log(`[sync] Project ${projectId} was tombstoned but a new plan ${data.planId} arrived — reviving (removing project tombstone).`);
+      removeTombstone('project', projectId);
+    }
     // Human-friendly project name resolution order (most-specific first):
     //   1. plan.name explicitly set by the user / planner ("Linux Assistant
     //      Orchestrator" — preserved across renames done from the board).

--- a/packages/hu-board/tests/tombstones.test.js
+++ b/packages/hu-board/tests/tombstones.test.js
@@ -115,6 +115,34 @@ describe('tombstones — sync.* skip + cleanup', () => {
     syncMod.fullScan();
     expect(existsSync(planPath)).toBe(false);
   });
+
+  // KJC-BUG-0050: tombstone de proyecto NO debe bloquear nuevos planes.
+  // Cuando el usuario borra un proyecto desde el board (🗑️ Delete project)
+  // y luego lanza `kj plan` otra vez en el mismo projectDir, el plan
+  // nuevo (con planId distinto del que estaba al borrar) DEBE sobrevivir
+  // al sync. El tombstone del proyecto se reabsorbe.
+  // El `projectId` se deriva de `data.projectDir` con la misma regla que
+  // `deriveProjectIdFromDir` — `/some/path` → `some_path`.
+  it('syncPlanFile resurrects a tombstoned project when a NEW plan arrives', () => {
+    const planPath = writePlan('some_path', 'plan-NEW');
+    dbMod.addTombstone('project', 'some_path');
+    expect(dbMod.isTombstoned('project', 'some_path')).toBe(true);
+    syncMod.fullScan();
+    // El plan sobrevive en disco
+    expect(existsSync(planPath)).toBe(true);
+    // El tombstone del proyecto se ha borrado
+    expect(dbMod.isTombstoned('project', 'some_path')).toBe(false);
+  });
+
+  // El tombstone del PLAN sigue respetándose aunque el proyecto NO esté tombstoned.
+  it('syncPlanFile still skips when the PLAN itself is tombstoned (project not)', () => {
+    const planPath = writePlan('some_path', 'plan-dead');
+    dbMod.addTombstone('plan', 'plan-dead');
+    syncMod.fullScan();
+    expect(existsSync(planPath)).toBe(false);
+    // El plan permanece tombstoned tras el sync.
+    expect(dbMod.isTombstoned('plan', 'plan-dead')).toBe(true);
+  });
 });
 
 // ---------- DELETE endpoints behaviour ---------------------------------------


### PR DESCRIPTION
## Bug

Cuando el usuario borraba un proyecto desde el board (🗑️ Delete project), `DELETE /api/projects/:id` creaba un tombstone permanente. **Cualquier `kj plan generate` posterior en el mismo `projectDir` quedaba inutilizable**: `savePlan` escribía el JSON, chokidar del board lo detectaba, llamaba `syncPlanFile`, veía el tombstone del proyecto y ejecutaba `rmSync(dirname(filePath))` borrando la carpeta entera del plan recién creado.

Síntoma observado: `kj plan` reportaba `[kj_plan] finished — ok=true`, pero `~/.kj/plans/<slug>/` quedaba vacío 50-1000 ms después. Imposible de diagnosticar sin abrir la DB sqlite a mano.

Diagnóstico completo: **KJC-BUG-0050** en planning-game.

## Cambio

`packages/hu-board/src/sync.js::syncPlanFile`:

- **Antes**: si `isTombstoned('project', projectId)` → skip + `rmSync(dirname(filePath))`.
- **Después**: si `isTombstoned('plan', data.planId)` → skip (igual que antes). Si el plan NO está tombstoned pero el proyecto sí → asumimos resurrección intencionada (kj plan recién generado) y **borramos el tombstone del proyecto** (`removeTombstone`), luego continuamos el sync normal.

El tombstone del PLAN sigue respetándose. Planes individuales que el usuario borró siguen muertos hasta que se cree un `planId` distinto. **Solo el tombstone del proyecto se reabsorbe**.

## Diff

```diff
+ import { removeTombstone } from './db.js';

  if (skipIfTombstoned('plan', data.planId, filePath)) return;
- if (skipIfTombstoned('project', projectId, dirname(filePath))) return;
+ if (isTombstoned('project', projectId)) {
+   console.log(`[sync] Project ${projectId} was tombstoned but a new plan ${data.planId} arrived — reviving (removing project tombstone).`);
+   removeTombstone('project', projectId);
+ }
```

## Tests

2 nuevos en `packages/hu-board/tests/tombstones.test.js` (18 totales, +2):

1. **`syncPlanFile resurrects a tombstoned project when a NEW plan arrives`**: `addTombstone('project', ...)` + `writePlan(planId nuevo)` + `fullScan` → plan sobrevive en disco, tombstone del proyecto borrado.
2. **`syncPlanFile still skips when the PLAN itself is tombstoned (project not)`**: `addTombstone('plan', planId)` + `writePlan(MISMO planId)` + `fullScan` → plan se borra (comportamiento preservado).

Suite global: **4633/4633 verde** (1 flaky en orquestador, pasa en re-run — no relacionado). Paquete hu-board: **309/309**. LOC: **42**.

## Por qué no es chapuza

Considerada y descartada la opción de TTL para tombstones — corre el riesgo de resurrecciones espurias para usuarios que olvidaron que borraron. La opción elegida (borrar tombstone del proyecto cuando llega un planId nuevo) es **explícita**: el evento "usuario lanza `kj plan` en el mismo projectDir" es señal clara de intención. No hay magia temporal.

El tombstone-de-plan sigue siendo la barrera dura: si hay un `planId` específico que se quiere muerto, así sigue. El usuario no puede regenerar accidentalmente un plan concreto.

## Test plan

- [x] `npm test` 4633/4633
- [ ] Repro manual: 
  1. `kj plan generate --task-file <task>` en un repo.
  2. `kj board start` → ver el proyecto.
  3. Click 🗑️ Delete project.
  4. `kj plan generate --task-file <task>` otra vez (mismo repo).
  5. Verificar que el nuevo plan SÍ aparece en el board (antes desaparecía).

## Cómo se descubrió

Dogfooding en GRETA SaaS. El usuario probó el botón 🗑️ Delete recién hecho visible en PR #699, luego no pudo regenerar el plan. 3 intentos de `kj plan` perdidos antes de localizar la causa. Bug latente que la papelera-visible expuso.