### PR TITLE
feat(hu-board): botón ⏹ Stop para abortar kj run en marcha (KJC-TSK-0396)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -505,6 +505,11 @@ async function renderBoard() {
                 title="Abrir el log de la HU en marcha">
             ⚙ ${runningCount} running…
           </button>
+          <button id="stop-run-btn" class="control-btn"
+                style="padding:4px 10px;font-size:0.8rem;background:var(--color-red,#ef4444);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;"
+                title="Abortar todos los kj run en marcha de este proyecto (SIGTERM con escalado a SIGKILL tras 5s)">
+            ⏹ Stop
+          </button>
         ` : ''}
         ${lastOpenedLog ? `
           <button class="control-btn" id="view-log-btn"
@@ -587,6 +592,47 @@ async function renderBoard() {
         const tailUrl = (offset) => `/api/runs/${encodeURIComponent(logBasename)}/log?offset=${offset || 0}`;
         lastOpenedLog = { id: logBasename, label: `HU ${localHuId}`, tailUrl };
         openGenericLogPanel({ id: logBasename, label: `HU ${localHuId}`, tailUrl });
+      });
+    }
+
+    // KJC-TSK-0396: botón ⏹ Stop. Abortar todos los kj run vivos del
+    // proyecto. Si hay múltiples planes corriendo (caso raro pero
+    // posible), itera sobre cada planId único de las HUs running.
+    const stopRunBtn = document.getElementById('stop-run-btn');
+    if (stopRunBtn) {
+      stopRunBtn.addEventListener('click', async () => {
+        const runningHus = stories.filter((s) => s.status === 'coding' || s.status === 'reviewing');
+        const planIds = [...new Set(runningHus.map((s) => s.plan_id).filter(Boolean))];
+        if (planIds.length === 0) {
+          await showError('No hay plan_id asociado a las HUs en marcha.', { title: 'Sin runs' });
+          return;
+        }
+        const ok = await showConfirm(
+          `Esto matará ${planIds.length === 1 ? 'el proceso' : `los ${planIds.length} procesos`} del orquestador en marcha y dejará las HUs en curso (coding/reviewing) en pending para que puedas relanzarlas.\n\n¿Seguro?`,
+          { title: 'Abortar kj run', okLabel: 'Stop', cancelLabel: 'Cancelar', destructive: true }
+        );
+        if (!ok) return;
+        const summaries = [];
+        for (const planId of planIds) {
+          try {
+            const res = await fetch(`/api/runs/${encodeURIComponent(planId)}/stop`, {
+              method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}',
+            });
+            const body = await res.json();
+            if (!res.ok) summaries.push(`${planId}: error ${body.error || res.status}`);
+            else summaries.push(`${planId}: ${body.stopped} SIGTERM, ${body.killed} SIGKILL, ${body.hu_reset_count || 0} HUs → pending`);
+          } catch (err) {
+            summaries.push(`${planId}: ${err.message}`);
+          }
+        }
+        await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+        await renderBoard();
+        if (summaries.some((s) => s.includes('SIGKILL') && !s.startsWith('0 ')) && summaries.some((s) => /\b[1-9]\d* SIGKILL/.test(s))) {
+          await showError(
+            `Algún proceso no respondió a SIGTERM en 5s y fue forzado con SIGKILL:\n\n${summaries.join('\n')}`,
+            { title: 'Forzado con SIGKILL' }
+          );
+        }
       });
     }
   } catch (err) {

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -18,6 +18,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, openSy
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
+import { trackRun, untrack } from './run-tracker.js';
 import { fileURLToPath } from 'node:url';
 import { updateHuStatus, certifyAllHus, updateHu } from '../../../src/plan/plan-hu-ops.js';
 import { syncPlanFile } from './sync.js';
@@ -326,5 +327,14 @@ export function runPlan({ planId, projectId, taskOverride, huIds = null } = {}) 
     env: { ...process.env, CLAUDECODE: undefined },
   });
   child.unref();
+  // KJC-TSK-0396: registrar el PID para que el botón ⏹ Stop del board
+  // sepa qué procesos matar. trackRun usa Set, así que llamadas
+  // duplicadas no inflan el registro. Cuando el proceso muera, el
+  // event 'exit' lo des-registra (defensa adicional: reaper periódico
+  // que limpia PIDs muertos cada 30s).
+  if (child.pid) {
+    trackRun(planId, { pid: child.pid, huIds: huIds || null });
+    child.on('exit', () => { untrack(planId, child.pid); });
+  }
   return { ok: true, pid: child.pid ?? 0, logPath };
 }

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -20,6 +20,7 @@ import {
 } from '../db.js';
 import { fullScan } from '../sync.js';
 import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject } from '../plan-mutations.js';
+import { getActiveRuns } from '../run-tracker.js';
 import { subscribe as subscribeEvents } from '../event-bus.js';
 import { runKjCommand, listSupportedCommands } from '../command-runner.js';
 import { runPreflight } from '../preflight.js';
@@ -1024,6 +1025,82 @@ router.post('/commands/:command', (req, res) => {
  *
  * Same offset semantics + 1 MiB cap as the plans endpoint.
  */
+/**
+ * GET /api/runs/:planId/active - Devuelve los runs activos (PIDs vivos)
+ * de un plan. Usado por el frontend para decidir si mostrar el botón
+ * ⏹ Stop. Respuesta: { active: [{pid, huIds, startedAt}, ...] }.
+ *
+ * KJC-TSK-0396.
+ */
+router.get('/runs/:planId/active', (req, res) => {
+  try {
+    const active = getActiveRuns(req.params.planId);
+    res.json({ active });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/runs/:planId/stop - Mata todos los procesos del orquestador
+ * asociados a este plan. SIGTERM primero, espera 5s, escala a SIGKILL
+ * si el proceso no respondió. Devuelve { stopped, killed, errors }.
+ *
+ * Tras matar el proceso, las HUs que estaban en coding/reviewing se
+ * resetean a pending (no a failed) vía hu-zombie-reaper logic — pero
+ * eso lo hace el reaper en el siguiente arranque del board. Para
+ * efecto inmediato, marcamos aquí las HUs running del plan a pending.
+ *
+ * KJC-TSK-0396.
+ */
+router.post('/runs/:planId/stop', async (req, res) => {
+  const { planId } = req.params;
+  const stopTimeoutMs = Number(req.body?.timeoutMs ?? 5000);
+  try {
+    const errors = [];
+    let stopped = 0;
+    let killed = 0;
+    const active = getActiveRuns(planId);
+    // Fase 1: SIGTERM a todos los procesos trackeados (si los hay).
+    for (const run of active) {
+      try { process.kill(run.pid, 'SIGTERM'); stopped += 1; }
+      catch (err) { errors.push({ pid: run.pid, phase: 'SIGTERM', error: err.message }); }
+    }
+    // Fase 2: esperar `stopTimeoutMs` y escalar a SIGKILL los que sigan
+    // vivos. Saltamos la espera si no había nada que matar.
+    if (active.length > 0) {
+      await new Promise((resolve) => setTimeout(resolve, stopTimeoutMs));
+      const stillAlive = getActiveRuns(planId);
+      for (const run of stillAlive) {
+        try { process.kill(run.pid, 'SIGKILL'); killed += 1; }
+        catch (err) { errors.push({ pid: run.pid, phase: 'SIGKILL', error: err.message }); }
+      }
+    }
+    // Fase 3: SIEMPRE reset de HUs en coding/reviewing del plan → pending.
+    // El reset corre aunque no hubiera PIDs trackeados (caso: el run lo
+    // lanzaste manualmente desde la terminal, killeaste tú mismo el
+    // proceso, pero la DB sigue mostrando HUs en coding y necesitas
+    // dejarlas en pending para relanzar limpio).
+    let hu_reset_count = 0;
+    try {
+      const db = getDb();
+      const result = db.prepare(
+        "UPDATE stories SET status = 'pending', updated_at = ? WHERE plan_id = ? AND status IN ('coding', 'reviewing', 'running')"
+      ).run(new Date().toISOString(), planId);
+      hu_reset_count = result.changes;
+    } catch (err) {
+      errors.push({ phase: 'hu_reset', error: err.message });
+    }
+    const out = { stopped, killed, errors, hu_reset_count };
+    if (stopped === 0 && killed === 0 && hu_reset_count === 0) {
+      out.message = 'No active runs and no stuck HUs for this plan.';
+    }
+    res.json(out);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 router.get('/runs/:commandId/log', (req, res) => {
   try {
     const runsDir = path.join(getKjHome(), 'hu-board-runs');

--- a/packages/hu-board/src/run-tracker.js
+++ b/packages/hu-board/src/run-tracker.js
@@ -1,0 +1,107 @@
+/**
+ * Run tracker — registro en memoria de procesos kj run activos por planId.
+ *
+ * KJC-TSK-0396: el botón ⏹ Stop del board necesita saber qué PIDs están
+ * vivos para cada plan. `runPlan` en plan-mutations.js hace `spawn`
+ * detached y devuelve el PID, pero ese PID se perdía: no había forma
+ * desde el frontend de saber "este plan tiene runs vivos".
+ *
+ * Este módulo guarda un Map<planId, Set<{ pid, huIds, startedAt }>> en
+ * memoria del proceso del board. Se limpia automáticamente cuando los
+ * procesos mueren (chequeo periódico vía `process.kill(pid, 0)` que NO
+ * envía señal — solo verifica existencia).
+ */
+
+const runs = new Map();
+let reaperTimer = null;
+
+/**
+ * Registra un nuevo run.
+ *
+ * @param {string} planId
+ * @param {{ pid: number, huIds?: string[]|null }} info
+ */
+export function trackRun(planId, info) {
+  if (!planId || !info?.pid) return;
+  const set = runs.get(planId) || new Set();
+  set.add({ pid: info.pid, huIds: info.huIds || null, startedAt: Date.now() });
+  runs.set(planId, set);
+  ensureReaper();
+}
+
+/**
+ * Devuelve los runs activos para un planId. Aplica un filtro
+ * `process.kill(pid, 0)` antes de devolver para evitar reportar PIDs
+ * muertos como vivos.
+ */
+export function getActiveRuns(planId) {
+  const set = runs.get(planId);
+  if (!set || set.size === 0) return [];
+  const alive = [];
+  for (const r of set) {
+    if (isAlive(r.pid)) alive.push(r);
+    else set.delete(r);
+  }
+  if (set.size === 0) runs.delete(planId);
+  return alive;
+}
+
+/**
+ * Igual que getActiveRuns pero para todos los planes. Útil para una
+ * vista global "qué está corriendo ahora mismo".
+ */
+export function getAllActiveRuns() {
+  const out = {};
+  for (const planId of runs.keys()) {
+    const alive = getActiveRuns(planId);
+    if (alive.length > 0) out[planId] = alive;
+  }
+  return out;
+}
+
+/**
+ * Quita el registro de un PID concreto (cuando lo paramos manualmente
+ * o lo detectamos muerto).
+ */
+export function untrack(planId, pid) {
+  const set = runs.get(planId);
+  if (!set) return;
+  for (const r of set) {
+    if (r.pid === pid) set.delete(r);
+  }
+  if (set.size === 0) runs.delete(planId);
+}
+
+/**
+ * Verifica si un PID sigue vivo. `process.kill(pid, 0)` NO envía
+ * señal — solo lanza ESRCH si el proceso no existe. Defensivo.
+ */
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM"; // EPERM = existe pero no tenemos permiso (sigue vivo)
+  }
+}
+
+/**
+ * Test-only reset.
+ */
+export function _resetForTests() {
+  runs.clear();
+  if (reaperTimer) { clearInterval(reaperTimer); reaperTimer = null; }
+}
+
+/**
+ * Reaper en background — cada 30s recorre todos los registros y limpia
+ * los PIDs muertos. Es defensa contra fugas de memoria si algún run
+ * murió sin notificarse y el frontend no consulta el endpoint.
+ */
+function ensureReaper() {
+  if (reaperTimer || process.env.VITEST) return;
+  reaperTimer = setInterval(() => {
+    for (const planId of [...runs.keys()]) getActiveRuns(planId);
+  }, 30_000);
+  reaperTimer.unref?.();
+}

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -436,6 +436,75 @@ describe('POST /api/plans/:planId/run', () => {
   });
 });
 
+// KJC-TSK-0396: endpoints de Stop + active runs.
+describe('POST /api/runs/:planId/stop + GET /api/runs/:planId/active', () => {
+  let trackerMod;
+  beforeEach(async () => {
+    trackerMod = await import('../src/run-tracker.js');
+    trackerMod._resetForTests();
+  });
+
+  it('GET /active devuelve [] cuando no hay runs', async () => {
+    const res = await request(app).get(`/api/runs/${PLAN_ID}/active`);
+    expect(res.status).toBe(200);
+    expect(res.body.active).toEqual([]);
+  });
+
+  it('GET /active devuelve los runs vivos tracked', async () => {
+    trackerMod.trackRun(PLAN_ID, { pid: process.pid });
+    const res = await request(app).get(`/api/runs/${PLAN_ID}/active`);
+    expect(res.status).toBe(200);
+    expect(res.body.active).toHaveLength(1);
+    expect(res.body.active[0].pid).toBe(process.pid);
+  });
+
+  it('POST /stop sin runs activos ni HUs zombi responde 200 con mensaje', async () => {
+    const res = await request(app)
+      .post(`/api/runs/${PLAN_ID}/stop`)
+      .send({});
+    expect(res.status).toBe(200);
+    expect(res.body.stopped).toBe(0);
+    expect(res.body.killed).toBe(0);
+    expect(res.body.hu_reset_count).toBe(0);
+    expect(res.body.message).toMatch(/No active runs and no stuck HUs/);
+  });
+
+  it('POST /stop con un PID falso (no existe) tras tracking devuelve errors + sigue limpio', async () => {
+    // Tracking de un PID que ya no existe (filtrado en getActiveRuns).
+    trackerMod.trackRun(PLAN_ID, { pid: 99999999 });
+    const res = await request(app)
+      .post(`/api/runs/${PLAN_ID}/stop`)
+      .send({ timeoutMs: 50 });
+    // getActiveRuns filtra el muerto antes de matar → sin runs activos.
+    expect(res.status).toBe(200);
+    expect(res.body.stopped).toBe(0);
+    expect(res.body.killed).toBe(0);
+  });
+
+  it('POST /stop resetea HUs en coding/reviewing del plan a pending', async () => {
+    // Pasamos la HU 001 a coding manualmente vía API para tener algo
+    // que resetear. Esto NO necesita un run real, solo el reset de DB.
+    await request(app)
+      .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_001`)}`)
+      .send({ status: 'certified' });
+    // Ahora simulamos que estaba coding (bypass API porque no acepta coding):
+    dbMod.getDb().prepare(
+      "UPDATE stories SET status = 'coding' WHERE id = ?"
+    ).run(`${PROJECT_ID}::${PLAN_ID}_001`);
+
+    const res = await request(app)
+      .post(`/api/runs/${PLAN_ID}/stop`)
+      .send({ timeoutMs: 10 });
+    expect(res.status).toBe(200);
+    expect(res.body.hu_reset_count).toBeGreaterThanOrEqual(1);
+
+    const row = dbMod.getDb().prepare(
+      'SELECT status FROM stories WHERE id = ?'
+    ).get(`${PROJECT_ID}::${PLAN_ID}_001`);
+    expect(row.status).toBe('pending');
+  });
+});
+
 describe('GET /api/plans/:planId/log', () => {
   it('returns exists:false when the log file does not exist yet', async () => {
     const res = await request(app).get(`/api/plans/${PLAN_ID}/log`);

--- a/packages/hu-board/tests/run-tracker.test.js
+++ b/packages/hu-board/tests/run-tracker.test.js
@@ -1,0 +1,60 @@
+// KJC-TSK-0396: tests del run-tracker en memoria.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { trackRun, getActiveRuns, getAllActiveRuns, untrack, _resetForTests } from '../src/run-tracker.js';
+
+beforeEach(() => { _resetForTests(); });
+
+describe('run-tracker', () => {
+  it('trackRun registra un PID para un planId', () => {
+    trackRun('plan-A', { pid: process.pid });
+    const active = getActiveRuns('plan-A');
+    expect(active).toHaveLength(1);
+    expect(active[0].pid).toBe(process.pid);
+  });
+
+  it('getActiveRuns filtra PIDs muertos (process.kill ESRCH)', () => {
+    // PID 99999999 prácticamente seguro que NO existe en el sistema.
+    trackRun('plan-A', { pid: 99999999 });
+    const active = getActiveRuns('plan-A');
+    expect(active).toEqual([]);
+  });
+
+  it('untrack elimina un PID concreto', () => {
+    trackRun('plan-A', { pid: process.pid });
+    trackRun('plan-A', { pid: process.ppid });
+    untrack('plan-A', process.pid);
+    const active = getActiveRuns('plan-A');
+    expect(active.map((r) => r.pid)).toEqual([process.ppid]);
+  });
+
+  it('getAllActiveRuns devuelve un map planId → runs vivos', () => {
+    trackRun('plan-A', { pid: process.pid });
+    trackRun('plan-B', { pid: process.pid });
+    trackRun('plan-C', { pid: 99999999 }); // muerto
+    const all = getAllActiveRuns();
+    expect(Object.keys(all).sort()).toEqual(['plan-A', 'plan-B']);
+    expect(all['plan-A']).toHaveLength(1);
+    expect(all['plan-B']).toHaveLength(1);
+    expect(all['plan-C']).toBeUndefined();
+  });
+
+  it('huIds se conserva en la entrada', () => {
+    trackRun('plan-A', { pid: process.pid, huIds: ['hu_1', 'hu_2'] });
+    const active = getActiveRuns('plan-A');
+    expect(active[0].huIds).toEqual(['hu_1', 'hu_2']);
+  });
+
+  it('múltiples PIDs por planId funcionan (múltiples runs simultáneos)', () => {
+    trackRun('plan-A', { pid: process.pid });
+    trackRun('plan-A', { pid: process.ppid });
+    const active = getActiveRuns('plan-A');
+    expect(active.map((r) => r.pid).sort()).toEqual([process.pid, process.ppid].sort());
+  });
+
+  it('llamadas degeneradas no rompen (planId vacío, pid 0)', () => {
+    trackRun('', { pid: 123 });
+    trackRun('plan-A', { pid: 0 });
+    trackRun('plan-A', null);
+    expect(getActiveRuns('plan-A')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Necesidad

Hasta ahora NO había forma de parar un \`kj run\` desde el board:
- Si lo lanzabas desde terminal: \`Ctrl+C\` en esa terminal.
- Si lo lanzabas desde el botón ▶ Run plan del board: solo \`pkill\` agresivo a mano.

Resultado: tokens malgastados en runs que ya sabías que no servían, sin manera de cortarlos limpiamente.

## Cambios

### Backend nuevo

- **\`packages/hu-board/src/run-tracker.js\`**: registro \`Map<planId, Set<{pid, huIds, startedAt}>>\` en memoria. API: \`trackRun\`, \`getActiveRuns\` (filtra PIDs muertos con \`process.kill(pid, 0)\`), \`getAllActiveRuns\`, \`untrack\`. Reaper background cada 30s.

- **\`plan-mutations.js::runPlan\`**: tras \`spawn(detached)\`, registra el PID + des-registra en \`exit\`.

- **2 endpoints nuevos en \`routes/api.js\`**:
  - \`GET /api/runs/:planId/active\` → \`{active: [{pid, huIds, startedAt}]}\`.
  - \`POST /api/runs/:planId/stop\` → SIGTERM, espera 5s (configurable \`body.timeoutMs\`), escala a SIGKILL los vivos. **SIEMPRE** ejecuta \`UPDATE stories SET status='pending' WHERE plan_id=? AND status IN ('coding','reviewing','running')\` — incluso sin PIDs trackeados (caso: runs lanzados desde terminal externa). Devuelve \`{stopped, killed, errors, hu_reset_count}\`.

### Frontend

- Botón \`⏹ Stop\` rojo en la cabecera del Story Board, al lado del badge \`⚙ N running…\`. Visible solo cuando hay HUs en coding/reviewing.
- Click → confirm modal destructivo → POST a \`/api/runs/<planId>/stop\` para cada plan_id único de las HUs running → sync + renderBoard.
- Warning visible si algún proceso escaló a SIGKILL.

## Tests

**7 nuevos en \`run-tracker.test.js\`**:
- trackRun + getActiveRuns + filtrado de PIDs muertos.
- untrack elimina PIDs concretos.
- Multi-plan con \`getAllActiveRuns\`.
- huIds se conserva.
- Múltiples PIDs por planId.
- Llamadas degeneradas no rompen.

**5 nuevos en \`plan-mutations.test.js\` (describe 'POST /api/runs/:planId/stop')**:
- GET /active vacío + poblado.
- POST /stop sin runs ni HUs zombi → mensaje.
- POST /stop con PID falso (filtrado).
- POST /stop reseteando HU coding → pending (verifica DB).

Suite global: 4649/4649 verde (+12). Paquete hu-board: 309 → 321.

## Limitaciones (out of scope explícito)

- Botón Stop **por HU** dentro de la card (caso 2.0, futura tarea).
- Persistencia del registro entre reinicios del board: el tracking es en memoria. Si reinicias el board mientras hay un \`kj run\` vivo de la sesión anterior, el board nuevo no lo verá. **Mitigación**: el reset de HUs por plan_id sigue funcionando sin tracking — el botón Stop usa SIEMPRE el reset de DB, no solo cuando hay PIDs registrados.

## Test plan

- [x] \`npm test\` 4649/4649.
- [ ] Lanzar \`kj run --plan <id>\` desde el board → ver el botón \`⏹ Stop\` aparecer junto al badge \`⚙ running\`.
- [ ] Click Stop → confirm → proceso muere, HUs vuelven a pending.
- [ ] Lanzar \`kj run\` desde terminal externa, ir al board, hacer Stop → no mata el proceso (no tracked) pero sí resetea las HUs en coding a pending (efecto inmediato en UI).