### PR TITLE
feat(runs): registry persistente para bidireccionalidad terminal ↔ board (KJC-TSK-0396 ext)

### DIFF
--- a/packages/hu-board/src/run-tracker.js
+++ b/packages/hu-board/src/run-tracker.js
@@ -1,22 +1,28 @@
 /**
- * Run tracker — registro en memoria de procesos kj run activos por planId.
+ * Run tracker — registro híbrido (memoria + disco) de procesos kj run.
  *
- * KJC-TSK-0396: el botón ⏹ Stop del board necesita saber qué PIDs están
- * vivos para cada plan. `runPlan` en plan-mutations.js hace `spawn`
- * detached y devuelve el PID, pero ese PID se perdía: no había forma
- * desde el frontend de saber "este plan tiene runs vivos".
+ * KJC-TSK-0396: el botón ⏹ Stop del board combina dos fuentes:
  *
- * Este módulo guarda un Map<planId, Set<{ pid, huIds, startedAt }>> en
- * memoria del proceso del board. Se limpia automáticamente cuando los
- * procesos mueren (chequeo periódico vía `process.kill(pid, 0)` que NO
- * envía señal — solo verifica existencia).
+ * 1. **Memoria** (`runs` Map) — runs lanzados desde el board vía
+ *    `runPlan` en plan-mutations.js. Bajo coste, sin I/O.
+ *
+ * 2. **Disco** (`~/.karajan/runs/<runId>.json` vía run-registry.js) —
+ *    runs lanzados desde la terminal externa (cualquier `kj run`). El
+ *    CLI escribe el registro al arranque y lo borra al final. Esto da
+ *    bidireccionalidad terminal ↔ board.
+ *
+ * `getActiveRuns(planId)` une las dos fuentes y dedupe por PID. Los
+ * registros con PID muerto se filtran automáticamente y los del disco
+ * se borran como cleanup (responsabilidad de run-registry).
  */
+
+import { listActiveRuns as fsList } from "../../../src/utils/run-registry.js";
 
 const runs = new Map();
 let reaperTimer = null;
 
 /**
- * Registra un nuevo run.
+ * Registra un run lanzado desde el board (memoria).
  *
  * @param {string} planId
  * @param {{ pid: number, huIds?: string[]|null }} info
@@ -30,38 +36,60 @@ export function trackRun(planId, info) {
 }
 
 /**
- * Devuelve los runs activos para un planId. Aplica un filtro
- * `process.kill(pid, 0)` antes de devolver para evitar reportar PIDs
- * muertos como vivos.
+ * Devuelve los runs activos para un planId. Une memoria + FS y dedupe
+ * por PID. Filtra PIDs muertos.
  */
 export function getActiveRuns(planId) {
+  const seen = new Set();
+  const out = [];
+  // Memoria
   const set = runs.get(planId);
-  if (!set || set.size === 0) return [];
-  const alive = [];
-  for (const r of set) {
-    if (isAlive(r.pid)) alive.push(r);
-    else set.delete(r);
+  if (set) {
+    for (const r of set) {
+      if (isAlive(r.pid)) {
+        seen.add(r.pid);
+        out.push({ pid: r.pid, huIds: r.huIds, startedAt: r.startedAt, source: "board" });
+      } else set.delete(r);
+    }
+    if (set.size === 0) runs.delete(planId);
   }
-  if (set.size === 0) runs.delete(planId);
-  return alive;
-}
-
-/**
- * Igual que getActiveRuns pero para todos los planes. Útil para una
- * vista global "qué está corriendo ahora mismo".
- */
-export function getAllActiveRuns() {
-  const out = {};
-  for (const planId of runs.keys()) {
-    const alive = getActiveRuns(planId);
-    if (alive.length > 0) out[planId] = alive;
+  // Disco
+  for (const entry of fsList({ planId })) {
+    if (seen.has(entry.pid)) continue;
+    seen.add(entry.pid);
+    out.push({
+      pid: entry.pid,
+      huIds: entry.huIds,
+      startedAt: entry.startedAt,
+      source: entry.source || "cli",
+      projectDir: entry.projectDir,
+    });
   }
   return out;
 }
 
 /**
- * Quita el registro de un PID concreto (cuando lo paramos manualmente
- * o lo detectamos muerto).
+ * Igual que getActiveRuns pero para todos los planes (memoria + FS).
+ */
+export function getAllActiveRuns() {
+  const out = {};
+  // Memoria
+  for (const planId of runs.keys()) {
+    const alive = getActiveRuns(planId);
+    if (alive.length > 0) out[planId] = alive;
+  }
+  // FS — añadir planes que solo viven en disco (no se vieron arriba).
+  for (const entry of fsList()) {
+    if (!entry.planId) continue;
+    if (out[entry.planId]) continue;
+    out[entry.planId] = getActiveRuns(entry.planId);
+  }
+  return out;
+}
+
+/**
+ * Quita el registro de un PID de memoria. Los registros FS los limpia
+ * el propio CLI (vía registry.unregisterRun en su finally).
  */
 export function untrack(planId, pid) {
   const set = runs.get(planId);
@@ -72,32 +100,18 @@ export function untrack(planId, pid) {
   if (set.size === 0) runs.delete(planId);
 }
 
-/**
- * Verifica si un PID sigue vivo. `process.kill(pid, 0)` NO envía
- * señal — solo lanza ESRCH si el proceso no existe. Defensivo.
- */
 function isAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    return err.code === "EPERM"; // EPERM = existe pero no tenemos permiso (sigue vivo)
-  }
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (err) { return err.code === "EPERM"; }
 }
 
-/**
- * Test-only reset.
- */
+/** Test-only reset. */
 export function _resetForTests() {
   runs.clear();
   if (reaperTimer) { clearInterval(reaperTimer); reaperTimer = null; }
 }
 
-/**
- * Reaper en background — cada 30s recorre todos los registros y limpia
- * los PIDs muertos. Es defensa contra fugas de memoria si algún run
- * murió sin notificarse y el frontend no consulta el endpoint.
- */
 function ensureReaper() {
   if (reaperTimer || process.env.VITEST) return;
   reaperTimer = setInterval(() => {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -4,6 +4,7 @@ import { runFlow } from "../orchestrator.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { createActivityLog } from "../activity-log.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
+import { registerRun, unregisterRun } from "../utils/run-registry.js";
 import { printHeader } from "../utils/display/header.js";
 import { printEvent } from "../utils/display/event-handlers.js";
 import { resolveRole } from "../config.js";
@@ -112,6 +113,28 @@ export async function runCommandHandler({ task, config, logger, flags }) {
   return withCliRunLog("run", { projectDir: config?.projectDir, logger }, async ({ runLog, forwardProgress }) => {
     runLog.logText(`[kj_run] task="${String(task).slice(0, 80)}..."`);
 
+    // KJC-TSK-0396 extensión: registrar el PID + planId + huIds en
+    // ~/.karajan/runs/<runId>.json para que el HU Board pueda mostrar
+    // el botón ⏹ Stop incluso cuando el run se lanza desde terminal
+    // externa (no solo desde el botón ▶ Run del board). Best-effort:
+    // si la escritura falla, el run sigue su curso normal. Limpieza
+    // garantizada en el finally del withCliRunLog vía registry.unregisterRun.
+    const huIdsFromFlag = typeof flags?.hu === "string"
+      ? flags.hu.split(",").map((s) => s.trim()).filter(Boolean)
+      : null;
+    const runId = registerRun({
+      pid: process.pid,
+      planId: flags?.plan || null,
+      huIds: huIdsFromFlag,
+      projectDir: config?.projectDir || process.cwd(),
+      source: "cli",
+    });
+    const cleanupRegistry = () => { if (runId) unregisterRun(runId); };
+    // Cubrir todos los caminos de salida del proceso.
+    process.once("exit", cleanupRegistry);
+    process.once("SIGTERM", () => { cleanupRegistry(); process.exit(143); });
+    process.once("SIGINT", () => { cleanupRegistry(); process.exit(130); });
+
     const emitter = new EventEmitter();
     let activityLog = null;
 
@@ -139,7 +162,16 @@ export async function runCommandHandler({ task, config, logger, flags }) {
     }
 
     const askQuestion = createCliAskQuestion();
-    const result = await runFlow({ task: task, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });
+    let result;
+    try {
+      result = await runFlow({ task: task, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });
+    } finally {
+      // KJC-TSK-0396: limpia el registro pase lo que pase (éxito,
+      // throw, o paused). Los handlers de SIGINT/SIGTERM/exit son
+      // backstop para casos donde el throw no llega aquí (segfault,
+      // kill -9, etc.).
+      cleanupRegistry();
+    }
 
     if (jsonMode) {
       console.log(JSON.stringify(result, null, 2));

--- a/src/utils/run-registry.js
+++ b/src/utils/run-registry.js
@@ -1,0 +1,115 @@
+/**
+ * Run registry — registro persistente de `kj run` activos.
+ *
+ * KJC-TSK-0396 (extensión): el HU Board necesita ver runs lanzados desde
+ * la terminal externa (no solo los lanzados desde el propio board). Para
+ * eso, cada `kj run` escribe su PID + planId + huIds + projectDir a un
+ * archivo en `~/.karajan/runs/<runId>.json` al arrancar, y lo borra al
+ * terminar (success o crash con cleanup vía finally).
+ *
+ * El board lee ese directorio en startup + cada vez que sirve el endpoint
+ * `/api/runs/:planId/active`, descartando los registros con PID muerto
+ * (filtrado con `process.kill(pid, 0)`). Resultado: bidireccionalidad
+ * total terminal ↔ board.
+ *
+ * Compartido entre el CLI (src/commands/run.js) y el board
+ * (packages/hu-board/src/run-tracker.js). Vive en src/utils/ porque
+ * el board ya importa cosas de src/ sin problema.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+/**
+ * Directorio raíz donde viven los registros de run.
+ * Honra `KJ_HOME` para tests y setups custom.
+ */
+export function runsDir() {
+  const home = process.env.KJ_HOME || path.join(os.homedir(), ".karajan");
+  return path.join(home, "runs");
+}
+
+/**
+ * Registra un nuevo run en disco. El runId es derivado del PID + timestamp
+ * para ser único por proceso.
+ *
+ * @param {{ pid: number, planId?: string|null, huIds?: string[]|null, projectDir?: string|null, source?: string }} info
+ * @returns {string|null} runId o null si la escritura falló (no bloquea al caller).
+ */
+export function registerRun(info = {}) {
+  if (!info?.pid) return null;
+  try {
+    fs.mkdirSync(runsDir(), { recursive: true });
+    // Sufijo random para evitar colisiones cuando 2 runs del mismo PID
+    // se registran en el mismo ms (raro en CLI, posible en tests).
+    const runId = `run-${Date.now()}-${info.pid}-${Math.random().toString(36).slice(2, 8)}`;
+    const filePath = path.join(runsDir(), `${runId}.json`);
+    const entry = {
+      runId,
+      pid: info.pid,
+      planId: info.planId || null,
+      huIds: Array.isArray(info.huIds) ? info.huIds : null,
+      projectDir: info.projectDir || null,
+      source: info.source || "cli",
+      startedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(filePath, JSON.stringify(entry, null, 2), "utf8");
+    return runId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Borra el registro de un run. Idempotente — silencia ENOENT.
+ *
+ * @param {string} runId
+ */
+export function unregisterRun(runId) {
+  if (!runId) return;
+  try {
+    fs.unlinkSync(path.join(runsDir(), `${runId}.json`));
+  } catch {
+    // Idempotente
+  }
+}
+
+/**
+ * Lista todos los runs activos en disco, filtrando los con PID muerto.
+ * Los muertos se borran del FS (auto-cleanup defensivo).
+ *
+ * @param {{ planId?: string }} [filter] - si se pasa planId, devuelve solo los runs de ese plan.
+ * @returns {Array<{runId, pid, planId, huIds, projectDir, source, startedAt}>}
+ */
+export function listActiveRuns(filter = {}) {
+  const dir = runsDir();
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  let files;
+  try { files = fs.readdirSync(dir); } catch { return []; }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    const filePath = path.join(dir, f);
+    let entry;
+    try { entry = JSON.parse(fs.readFileSync(filePath, "utf8")); }
+    catch { try { fs.unlinkSync(filePath); } catch { /* swallow */ } continue; }
+    if (!isAlive(entry.pid)) {
+      try { fs.unlinkSync(filePath); } catch { /* swallow */ }
+      continue;
+    }
+    if (filter.planId && entry.planId !== filter.planId) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Verifica si un PID sigue vivo. `process.kill(pid, 0)` NO envía
+ * señal — solo lanza ESRCH si el proceso no existe.
+ */
+function isAlive(pid) {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; }
+  catch (err) { return err.code === "EPERM"; }
+}

--- a/tests/utils/run-registry.test.js
+++ b/tests/utils/run-registry.test.js
@@ -1,0 +1,79 @@
+// KJC-TSK-0396 (extensión): tests del registry FS de runs.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { registerRun, unregisterRun, listActiveRuns, runsDir } from "../../src/utils/run-registry.js";
+
+let tmpHome;
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-run-registry-"));
+  process.env.KJ_HOME = tmpHome;
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("run-registry", () => {
+  it("registerRun escribe un JSON con el shape esperado", () => {
+    const runId = registerRun({
+      pid: process.pid,
+      planId: "plan-X",
+      huIds: ["hu_1", "hu_2"],
+      projectDir: "/tmp/foo",
+      source: "cli",
+    });
+    expect(runId).toMatch(/^run-\d+-\d+-[a-z0-9]+$/);
+    const files = readdirSync(runsDir());
+    expect(files).toContain(`${runId}.json`);
+  });
+
+  it("unregisterRun elimina el JSON (idempotente)", () => {
+    const runId = registerRun({ pid: process.pid, planId: "p" });
+    unregisterRun(runId);
+    expect(existsSync(join(runsDir(), `${runId}.json`))).toBe(false);
+    // Llamar otra vez no rompe.
+    unregisterRun(runId);
+  });
+
+  it("listActiveRuns filtra PIDs muertos y los borra del disco", () => {
+    registerRun({ pid: process.pid, planId: "alive" });
+    registerRun({ pid: 99999999, planId: "dead" });
+    const active = listActiveRuns();
+    expect(active.map((r) => r.planId).sort()).toEqual(["alive"]);
+    // El dead se ha borrado del disco.
+    const remaining = readdirSync(runsDir());
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("listActiveRuns filtra por planId cuando se pasa", () => {
+    registerRun({ pid: process.pid, planId: "plan-A" });
+    registerRun({ pid: process.pid, planId: "plan-B" });
+    expect(listActiveRuns({ planId: "plan-A" })).toHaveLength(1);
+    expect(listActiveRuns({ planId: "plan-A" })[0].planId).toBe("plan-A");
+  });
+
+  it("listActiveRuns devuelve [] si el dir no existe", () => {
+    // No registramos nada → dir no existe.
+    expect(listActiveRuns()).toEqual([]);
+  });
+
+  it("registerRun sin pid devuelve null sin escribir nada", () => {
+    expect(registerRun({})).toBeNull();
+    expect(existsSync(runsDir())).toBe(false);
+  });
+
+  it("listActiveRuns descarta archivos JSON corruptos y los borra", () => {
+    const runId = registerRun({ pid: process.pid, planId: "p" });
+    // Corrompemos otro archivo (manual fs write con contenido inválido).
+    const fs = require("node:fs");
+    fs.writeFileSync(join(runsDir(), "bad.json"), "{not valid json");
+    const active = listActiveRuns();
+    expect(active.map((r) => r.runId)).toEqual([runId]);
+    // bad.json se borró
+    expect(existsSync(join(runsDir(), "bad.json"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Necesidad

Tras el botón ⏹ Stop (PR #702), el tracker del board era solo en memoria. Resultado: un \`kj run\` lanzado desde terminal externa NO aparecía como activo en el board y el botón Stop no podía pararlo. Solo se veían los cambios de status de HUs (chokidar lee plan JSON), pero el PROCESO era invisible.

Este PR añade un **registry persistente en disco** (\`~/.karajan/runs/\`) que el CLI escribe al arrancar y el board lee. Bidireccionalidad completa.

## Cambios

### \`src/utils/run-registry.js\` (nuevo)

Módulo compartido entre CLI y board:
- \`registerRun({pid, planId, huIds, projectDir, source})\` escribe \`~/.karajan/runs/<runId>.json\` (sufijo random anti-colisión).
- \`unregisterRun(runId)\` borra el JSON. Idempotente.
- \`listActiveRuns({planId?})\` lee el dir, filtra PIDs muertos vía \`process.kill(pid, 0)\`, borra del disco los muertos.

### \`src/commands/run.js\` (kj run)

Tras \`withCliRunLog\`, antes de \`runFlow\`:
- \`registerRun()\` con \`process.pid\` + flags.
- Cleanup en 3 caminos: \`try/finally\` alrededor de runFlow, \`process.on('exit')\`, \`SIGTERM/SIGINT\`.

### \`packages/hu-board/src/run-tracker.js\` (híbrido)

\`getActiveRuns\` y \`getAllActiveRuns\` unen ahora memoria + FS, dedupe por PID. El endpoint \`/api/runs/:planId/active\` ve TODOS los runs vivos, vinieran de donde vinieran. \`POST /stop\` los mata todos (signal funciona igual para procesos no descendientes, mismo UID).

## Tests

**7 nuevos en \`tests/utils/run-registry.test.js\`**:
- register escribe JSON con shape esperado.
- unregister idempotente.
- listActiveRuns filtra PIDs muertos y los borra del FS.
- filter por planId.
- Dir inexistente → \`[]\`.
- Registro sin PID → \`null\`.
- JSON corruptos descartados + borrados.

**Suite global**: 4656/4656 verde (+7).

## Beneficio para el usuario

| Caso | Antes | Ahora |
|------|-------|-------|
| \`kj run\` desde terminal | Board NO veía el proceso, Stop no servía | Board ve ⚙ + Stop funcional |
| ▶ Run desde el board | Tracking en memoria | Idem + persistencia FS |
| Reinicio del board mid-run | Tracking perdido | Reconstruye del disco al primer \`/active\` |
| Mezcla terminal + board | Solo el del board visible | Todos visibles, dedup por PID |

## Test plan

- [x] \`npm test\` 4656/4656.
- [ ] Manual: \`kj run --plan <id>\` en terminal → board muestra ⚙ + Stop → click Stop → proceso muere y HUs vuelven a pending.
- [ ] Manual: reiniciar board con \`kj run\` vivo → board descubre el run en el siguiente render.