### PR TITLE
feat(cli): IDs humanos para planes (alias) y HUs (short_id)

### DIFF
--- a/src/commands/plan/_shared.js
+++ b/src/commands/plan/_shared.js
@@ -25,16 +25,31 @@ export function formatPlan(plan) {
   return lines.join("\n");
 }
 
+/**
+ * Convierte el id largo de una dep `hu_<planId>_<NNN>` al short_id de
+ * la HU correspondiente cuando lo conoce. Mantiene el id largo si la
+ * dep no tiene short_id (HU legacy pre-humanización).
+ */
+function displayDep(depId, hus) {
+  const hu = hus.find((h) => h.id === depId);
+  if (hu?.short_id) return hu.short_id;
+  return depId;
+}
+
 export function formatHuTable(hus) {
   if (!hus?.length) return "  (no HUs)";
+  // Humanización IDs: si la HU tiene short_id ("INFRA-001"), úsalo
+  // como columna ID; si no, fallback al id largo (HU legacy).
+  const idOf = (h) => h.short_id || h.id;
   const lines = [];
+  const maxId = Math.min(20, Math.max(...hus.map((h) => idOf(h).length || 0)));
   const maxTitle = Math.min(50, Math.max(...hus.map(h => h.title?.length || 0)));
-  lines.push(`  ${"ID".padEnd(30)} ${"Title".padEnd(maxTitle)} ${"Type".padEnd(10)} ${"Status".padEnd(10)} Deps`);
-  lines.push(`  ${"─".repeat(30)} ${"─".repeat(maxTitle)} ${"─".repeat(10)} ${"─".repeat(10)} ${"─".repeat(15)}`);
+  lines.push(`  ${"ID".padEnd(maxId)} ${"Title".padEnd(maxTitle)} ${"Type".padEnd(10)} ${"Status".padEnd(10)} Deps`);
+  lines.push(`  ${"─".repeat(maxId)} ${"─".repeat(maxTitle)} ${"─".repeat(10)} ${"─".repeat(10)} ${"─".repeat(15)}`);
   for (const hu of hus) {
     const title = (hu.title || "").slice(0, maxTitle).padEnd(maxTitle);
-    const deps = (hu.blocked_by || []).join(", ") || "—";
-    lines.push(`  ${hu.id.padEnd(30)} ${title} ${(hu.task_type || "sw").padEnd(10)} ${(hu.status || "?").padEnd(10)} ${deps}`);
+    const deps = (hu.blocked_by || []).map((d) => displayDep(d, hus)).join(", ") || "—";
+    lines.push(`  ${idOf(hu).padEnd(maxId)} ${title} ${(hu.task_type || "sw").padEnd(10)} ${(hu.status || "?").padEnd(10)} ${deps}`);
   }
   return lines.join("\n");
 }

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -124,19 +124,25 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     const rawTests = typeof step === "object" ? step.acceptance_tests : null;
     const tests = normaliseAcceptanceTests(rawTests);
     if (tests.length === 0) stepsMissingTests += 1;
+    // Humanización IDs: preservar el id simbólico del planner ("INFRA-001",
+    // "AUTH-SIGNUP", etc.) como short_id del HU. La clave canónica
+    // sigue siendo el `hu.id` largo (`hu_<planId>_<NNN>`); el short_id
+    // solo da una etiqueta amigable que la CLI muestra y acepta como
+    // referencia en `kj run --hu INFRA-001`.
+    const symbolicId = typeof step === "object" && typeof step.id === "string" && step.id.trim()
+      ? step.id.trim() : null;
     const hu = addHu(plan, {
       title: desc.slice(0, 80),
       task_type: classifyTaskType(desc),
       scope: desc,
       blocked_by: [],
       acceptance_tests: tests,
+      short_id: symbolicId,
       // Spec mapping (PR C): preserve the planner's section citation
       // so the coder/reviewer / board can show "implements §5.3".
       spec_section: typeof step === "object" && typeof step.spec_section === "string" ? step.spec_section.trim() || null : null,
     });
-    if (typeof step === "object" && typeof step.id === "string" && step.id.trim()) {
-      symbolicToHuId.set(step.id.trim(), hu.id);
-    }
+    if (symbolicId) symbolicToHuId.set(symbolicId, hu.id);
     const deps = typeof step === "object" && Array.isArray(step.dependencies) ? step.dependencies : [];
     stepDeps.push(deps);
     const reuse = typeof step === "object" && Array.isArray(step.reuse) ? step.reuse : [];
@@ -341,9 +347,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       console.log(`Reviewer flagged: ${counts.join(", ")} — see \`kj plan show ${planId}\``);
     }
   }
+  // Humanización IDs: si el plan tiene alias, lo preferimos como
+  // referencia visible (más legible). Fallback al planId.
+  const ref = plan.alias || planId;
   console.log("");
-  console.log(`Inspect: kj plan show ${planId}`);
-  console.log(`Run:     kj run --plan ${planId} "${task.slice(0, 40)}..."`);
+  console.log(`Inspect: kj plan show ${ref}`);
+  console.log(`Run:     kj run --plan ${ref}`);
   console.log(`         (or click ▶ Run plan on the board, if running)`);
 
   // UX boost for HU-bearing plans: auto-start the HU Board (same pattern as

--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -189,23 +189,33 @@ function applyHuFilterIfRequested({ huBatch, flags, eventBase, emitter, logger }
     logger.warn(`--hu was empty after parsing — falling back to running every certified HU`);
     return;
   }
-  const requestedSet = new Set(requested);
-  const found = huBatch.stories.filter((s) => requestedSet.has(s.id));
-  const missing = requested.filter((id) => !huBatch.stories.some((s) => s.id === id));
-  if (missing.length > 0) {
-    logger.warn(`--hu: ignored ${missing.length} unknown HU id(s): ${missing.join(", ")}`);
+  // Humanización IDs: resolver cada ref a un hu.id largo aceptando 3 formas:
+  //  1. `hu_<planId>_<NNN>` (id largo, exacto)
+  //  2. `INFRA-001` (short_id que el planner asignó)
+  //  3. `001` (sufijo numérico — busca un hu.id que termine en `_001`)
+  // El resolver es case-insensitive para short_id y sufijo.
+  const resolvedIds = new Set();
+  const unresolved = [];
+  for (const ref of requested) {
+    const id = resolveHuRef(ref, huBatch.stories);
+    if (id) resolvedIds.add(id);
+    else unresolved.push(ref);
+  }
+  const found = huBatch.stories.filter((s) => resolvedIds.has(s.id));
+  if (unresolved.length > 0) {
+    logger.warn(`--hu: ignored ${unresolved.length} unknown HU ref(s): ${unresolved.join(", ")}`);
   }
   if (found.length === 0) {
-    throw new Error(`--hu: none of the requested HU id(s) exist in plan ${flags.plan}: ${requested.join(", ")}`);
+    throw new Error(`--hu: none of the requested HU ref(s) exist in plan ${flags.plan}: ${requested.join(", ")}`);
   }
   for (const story of huBatch.stories) {
-    if (!requestedSet.has(story.id)) story.status = "done";
+    if (!resolvedIds.has(story.id)) story.status = "done";
   }
   huBatch.certified = found.length;
   logger.info(`Plan ${flags.plan}: --hu filter active — ${found.length}/${huBatch.total} HU(s) will run (${found.map((s) => s.id).join(", ")})`);
   emitProgress(emitter, makeEvent("plan:hu-filter", { ...eventBase, stage: "plan" }, {
     message: `--hu filter: ${found.length} HU(s) selected, ${huBatch.total - found.length} skipped`,
-    detail: { planId: flags.plan, requested, ignored: missing, willRun: found.map((s) => s.id) }
+    detail: { planId: flags.plan, requested, ignored: unresolved, willRun: found.map((s) => s.id) }
   }));
 }
 
@@ -244,6 +254,35 @@ function wirePlanCallbacks({ session, loadedPlan, projectDir, syncResultsToPlan,
       logger?.warn?.(`Live outcome update failed for ${huId}: ${err.message}`);
     }
   });
+}
+
+/**
+ * Resuelve una referencia humana a HU al `id` canónico largo. Acepta:
+ *   - id largo exacto: `hu_<planId>_<NNN>` → match directo.
+ *   - short_id: `INFRA-001`, `AUTH-SIGNUP` → match case-insensitive contra hu.short_id.
+ *   - sufijo numérico: `001` → match contra hu.id terminado en `_001`.
+ * Devuelve el hu.id largo o null si no resuelve.
+ *
+ * @param {string} ref
+ * @param {Array<{id: string, short_id?: string|null}>} hus
+ * @returns {string|null}
+ */
+function resolveHuRef(ref, hus) {
+  if (!ref || !Array.isArray(hus)) return null;
+  // Match exacto contra id largo (camino caliente).
+  const exact = hus.find((s) => s.id === ref);
+  if (exact) return exact.id;
+  // Match case-insensitive contra short_id.
+  const lower = ref.toLowerCase();
+  const byShort = hus.find((s) => s.short_id && String(s.short_id).toLowerCase() === lower);
+  if (byShort) return byShort.id;
+  // Match por sufijo numérico (`001` → cualquier hu cuyo id termine en `_001`).
+  if (/^\d+$/.test(ref)) {
+    const padded = ref.padStart(3, "0");
+    const bySuffix = hus.find((s) => s.id.endsWith(`_${padded}`));
+    if (bySuffix) return bySuffix.id;
+  }
+  return null;
 }
 
 /**

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -39,6 +39,12 @@ export function addHu(plan, huData) {
     // `outcome`) porque `outcome` ya está en uso como blob JSON con
     // iterations/duration/commits del run.
     result: huData.result ?? null,
+    // Humanización IDs: short_id es el id legible que el planner asignó
+    // al step (ej "INFRA-001", "AUTH-SIGNUP"). El `id` largo
+    // (`hu_<planId>_<NNN>`) sigue siendo la clave canónica, pero el
+    // CLI / board prefieren short_id para mostrar y aceptarlo como
+    // referencia en `--hu`. Null cuando el planner no lo emitió.
+    short_id: huData.short_id || null,
     blocked_by: huData.blocked_by || [],
     // KJC-BUG-0044 / P3: ids of OTHER HUs whose implementation this HU
     // piggy-backs on instead of reimplementing the same logic. Set by
@@ -89,7 +95,7 @@ export function removeHu(plan, huId) {
 export function updateHu(plan, huId, patch) {
   const hu = plan.hus.find(h => h.id === huId);
   if (!hu) return null;
-  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result"];
+  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result", "short_id"];
   for (const key of allowed) {
     if (patch[key] !== undefined) hu[key] = patch[key];
   }

--- a/src/plan/plan-id.js
+++ b/src/plan/plan-id.js
@@ -23,3 +23,23 @@ export function generatePlanId() {
 export function generateHuId(planId, seq) {
   return `hu_${planId}_${String(seq).padStart(3, "0")}`;
 }
+
+/**
+ * Normalise a human-friendly name into a CLI-typeable alias.
+ * "Greta App" → "greta-app", "Linux Assistant Orchestrator" → "linux-assistant-orchestrator".
+ * Acotado a 60 chars para que no se vuelva tan ilegible como el planId.
+ *
+ * @param {string|null|undefined} name
+ * @returns {string|null} alias o null si name está vacío.
+ */
+export function normaliseAlias(name) {
+  if (!name || typeof name !== "string") return null;
+  const slug = name
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")        // strip diacritics
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")            // non-alphanum → guion
+    .replace(/^-+|-+$/g, "")                // trim guiones extremos
+    .slice(0, 60);
+  return slug || null;
+}

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -188,6 +188,12 @@ export function createPlanV2(task, context = {}) {
   const planId = generatePlanId();
   return {
     planId,
+    // KJC-TSK humanización IDs: alias legible (ej "greta-app"). Se
+    // asigna en savePlan a partir de plan.name. El planId sigue
+    // siendo la ID canónica interna (timestamp+random), pero la CLI
+    // y el board prefieren el alias para mostrar y aceptan ambos
+    // como referencia (--plan greta-app o --plan plan-XXX-XX).
+    alias: null,
     version: 2,
     task,
     name: null, // set by caller via deriveProjectName or manually

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -7,7 +7,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { generatePlanId } from "./plan-id.js";
+import { generatePlanId, normaliseAlias } from "./plan-id.js";
 import { isPlanV2, migratePlanV1toV2 } from "./plan-schema.js";
 
 // Per-process tmp dir for VITEST runs that forget to set KJ_HOME. We
@@ -77,6 +77,12 @@ export async function savePlan(projectDir, planResult) {
     // engineering it from the slug is lossy (underscores in the original
     // name collide with underscores introduced by slash-substitution).
     if (!planResult.projectDir && projectDir) planResult.projectDir = projectDir;
+    // Humanización IDs: si el plan no tiene alias todavía, derívalo de
+    // plan.name (lo que el planner pidió al usuario). Resuelve
+    // colisiones con sufijo -2, -3… leyendo el dir antes.
+    if (!planResult.alias && planResult.name) {
+      planResult.alias = await resolveUniqueAlias(dir, planResult.planId, normaliseAlias(planResult.name));
+    }
     await fs.writeFile(filePath, JSON.stringify(planResult, null, 2), "utf8");
     return planResult.planId;
   }
@@ -99,19 +105,67 @@ export async function savePlan(projectDir, planResult) {
 }
 
 /**
- * Load a plan by ID. Auto-migrates v1 to v2 on read (lazy).
- * @returns {Promise<object|null>} v2 plan or null
+ * Resuelve un alias único en `dir`. Si `base` ya está en uso por otro
+ * plan, intenta `base-2`, `base-3`… hasta encontrar libre.
+ * @param {string} dir
+ * @param {string} ownPlanId - planId del plan que se está guardando (su propio archivo se ignora en el lookup).
+ * @param {string|null} base
+ * @returns {Promise<string|null>}
  */
-export async function loadPlan(projectDir, planId) {
-  const filePath = path.join(plansDir(projectDir), `${planId}.json`);
+async function resolveUniqueAlias(dir, ownPlanId, base) {
+  if (!base) return null;
+  let files;
+  try { files = await fs.readdir(dir); } catch { return base; }
+  const taken = new Set();
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const record = JSON.parse(await fs.readFile(path.join(dir, f), "utf8"));
+      if (record.planId === ownPlanId) continue;
+      if (record.alias) taken.add(record.alias);
+    } catch { /* skip corrupt */ }
+  }
+  if (!taken.has(base)) return base;
+  for (let i = 2; i < 1000; i += 1) {
+    const candidate = `${base}-${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${ownPlanId.slice(-4)}`;  // fallback improbable
+}
+
+/**
+ * Load a plan by ID or alias. Auto-migrates v1 to v2 on read (lazy).
+ * Acepta tanto el planId canónico (plan-XXX-XX) como el alias humano
+ * (greta-app). Primero busca por filename exacto (planId.json), luego
+ * escanea el dir y matchea por alias.
+ *
+ * @returns {Promise<object|null>} v2 plan o null
+ */
+export async function loadPlan(projectDir, ref) {
+  if (!ref) return null;
+  const dir = plansDir(projectDir);
+  // 1. Match exacto por planId.json (camino caliente).
+  const direct = path.join(dir, `${ref}.json`);
   try {
-    const data = await fs.readFile(filePath, "utf8");
+    const data = await fs.readFile(direct, "utf8");
     const plan = JSON.parse(data);
     if (!isPlanV2(plan)) return migratePlanV1toV2(plan);
     return plan;
-  } catch {
-    return null;
+  } catch { /* fall through to alias scan */ }
+  // 2. Escaneo del dir por alias. Coste O(N) pero N suele ser <10.
+  let files;
+  try { files = await fs.readdir(dir); } catch { return null; }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const record = JSON.parse(await fs.readFile(path.join(dir, f), "utf8"));
+      if (record.alias === ref || record.planId === ref) {
+        if (!isPlanV2(record)) return migratePlanV1toV2(record);
+        return record;
+      }
+    } catch { /* skip corrupt */ }
   }
+  return null;
 }
 
 /**
@@ -148,6 +202,7 @@ export async function listPlans(projectDir) {
       const record = JSON.parse(data);
       plans.push({
         planId: record.planId,
+        alias: record.alias || null,
         task: record.task,
         name: record.name || null,
         status: record.status || "draft",

--- a/tests/plan/plan-alias-and-short-id.test.js
+++ b/tests/plan/plan-alias-and-short-id.test.js
@@ -1,0 +1,134 @@
+// Humanización IDs: tests para alias del plan + short_id de HU.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { savePlan, loadPlan, listPlans, plansDir } from "../../src/plan/plan-store.js";
+import { createPlanV2, normaliseAcceptanceTests } from "../../src/plan/plan-schema.js";
+import { addHu } from "../../src/plan/plan-hu-ops.js";
+import { normaliseAlias } from "../../src/plan/plan-id.js";
+import { formatHuTable } from "../../src/commands/plan/_shared.js";
+
+let tmpHome;
+const projectDir = "/tmp/test-greta-app";
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), "kj-alias-"));
+  process.env.KJ_HOME = tmpHome;
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+});
+
+describe("normaliseAlias", () => {
+  it("normaliza nombres humanos a slug typeable", () => {
+    expect(normaliseAlias("Greta App")).toBe("greta-app");
+    expect(normaliseAlias("Linux Assistant Orchestrator")).toBe("linux-assistant-orchestrator");
+    expect(normaliseAlias("My Project (v2)")).toBe("my-project-v2");
+  });
+  it("devuelve null para vacíos/inválidos", () => {
+    expect(normaliseAlias("")).toBe(null);
+    expect(normaliseAlias(null)).toBe(null);
+    expect(normaliseAlias(123)).toBe(null);
+  });
+  it("acota a 60 chars", () => {
+    const long = "a".repeat(200);
+    expect(normaliseAlias(long).length).toBeLessThanOrEqual(60);
+  });
+});
+
+describe("plan alias persistence + resolution", () => {
+  it("savePlan asigna alias desde plan.name si no estaba", async () => {
+    const plan = createPlanV2("build greta");
+    plan.name = "Greta App";
+    addHu(plan, { title: "x" });
+    await savePlan(projectDir, plan);
+    const reloaded = await loadPlan(projectDir, plan.planId);
+    expect(reloaded.alias).toBe("greta-app");
+  });
+
+  it("loadPlan resuelve por alias humano", async () => {
+    const plan = createPlanV2("t");
+    plan.name = "Greta App";
+    addHu(plan, { title: "x" });
+    await savePlan(projectDir, plan);
+    const byAlias = await loadPlan(projectDir, "greta-app");
+    expect(byAlias).not.toBeNull();
+    expect(byAlias.planId).toBe(plan.planId);
+  });
+
+  it("loadPlan sigue resolviendo por planId largo", async () => {
+    const plan = createPlanV2("t");
+    plan.name = "Greta App";
+    addHu(plan, { title: "x" });
+    await savePlan(projectDir, plan);
+    const byId = await loadPlan(projectDir, plan.planId);
+    expect(byId.planId).toBe(plan.planId);
+  });
+
+  it("colisión de alias resuelve con sufijo -2, -3...", async () => {
+    const p1 = createPlanV2("t"); p1.name = "Greta App"; addHu(p1, { title: "x" });
+    const p2 = createPlanV2("t"); p2.name = "Greta App"; addHu(p2, { title: "y" });
+    const p3 = createPlanV2("t"); p3.name = "Greta App"; addHu(p3, { title: "z" });
+    await savePlan(projectDir, p1);
+    await savePlan(projectDir, p2);
+    await savePlan(projectDir, p3);
+    expect((await loadPlan(projectDir, p1.planId)).alias).toBe("greta-app");
+    expect((await loadPlan(projectDir, p2.planId)).alias).toBe("greta-app-2");
+    expect((await loadPlan(projectDir, p3.planId)).alias).toBe("greta-app-3");
+  });
+
+  it("listPlans incluye alias en el resumen", async () => {
+    const plan = createPlanV2("t"); plan.name = "Greta App"; addHu(plan, { title: "x" });
+    await savePlan(projectDir, plan);
+    const list = await listPlans(projectDir);
+    expect(list[0].alias).toBe("greta-app");
+  });
+
+  it("loadPlan devuelve null para ref inexistente", async () => {
+    expect(await loadPlan(projectDir, "nope")).toBeNull();
+  });
+});
+
+describe("HU short_id", () => {
+  it("addHu acepta short_id y lo persiste", () => {
+    const plan = createPlanV2("t");
+    const hu = addHu(plan, { title: "x", short_id: "INFRA-001" });
+    expect(hu.short_id).toBe("INFRA-001");
+  });
+
+  it("addHu deja short_id null cuando no se pasa", () => {
+    const plan = createPlanV2("t");
+    const hu = addHu(plan, { title: "x" });
+    expect(hu.short_id).toBe(null);
+  });
+
+  it("formatHuTable muestra short_id en la columna ID si está poblado", () => {
+    const plan = createPlanV2("t");
+    addHu(plan, { title: "first", short_id: "INFRA-001" });
+    addHu(plan, { title: "second", short_id: "AUTH-002" });
+    const table = formatHuTable(plan.hus);
+    expect(table).toMatch(/INFRA-001/);
+    expect(table).toMatch(/AUTH-002/);
+    expect(table).not.toMatch(/hu_plan-/);
+  });
+
+  it("formatHuTable cae al id largo si no hay short_id (HU legacy)", () => {
+    const plan = createPlanV2("t");
+    addHu(plan, { title: "legacy" });
+    const table = formatHuTable(plan.hus);
+    expect(table).toMatch(/hu_plan-/);
+  });
+
+  it("formatHuTable muestra deps por short_id cuando existen", () => {
+    const plan = createPlanV2("t");
+    const a = addHu(plan, { title: "first", short_id: "INFRA-001" });
+    addHu(plan, { title: "second", short_id: "AUTH-002", blocked_by: [a.id] });
+    const table = formatHuTable(plan.hus);
+    // El segundo HU debe mostrar la dep como "INFRA-001", no como el id largo
+    const secondLine = table.split("\n").find((l) => l.includes("AUTH-002"));
+    expect(secondLine).toMatch(/INFRA-001/);
+  });
+});


### PR DESCRIPTION
## Problema

Antes el CLI forzaba a escribir IDs crípticos:

\`\`\`bash
kj run --plan plan-20260513204652-2n26 --hu hu_plan-20260513204652-2n26_001
\`\`\`

Ahora:

\`\`\`bash
kj run --plan greta-app --hu INFRA-001
\`\`\`

## Diseño

**Mantengo intacta la ID canónica interna** (planId timestamp+random, hu.id largo). Las usa la IA, el FS, el board. Añado **alias humano** opcional como capa de presentación + resolución de refs en el CLI.

### Plan alias
- \`plan.alias\` se deriva en \`savePlan\` de \`plan.name\` vía \`normaliseAlias\` (slug typeable, max 60 chars).
- Colisión → sufijo \`-2\`, \`-3\`...
- \`loadPlan(projectDir, ref)\` acepta **planId OR alias**. Match exacto por filename primero (camino caliente), fallback escaneo del dir.
- \`listPlans\` incluye \`alias\` en el resumen.
- El banner final de \`kj plan generate\` muestra \`kj run --plan <alias>\` en lugar del planId largo.

### HU short_id
- El planner ya emitía \`step.id\` simbólico (\`INFRA-001\`, \`AUTH-SIGNUP\`) pero solo se usaba para resolver deps internamente y se descartaba.
- Ahora \`addHu\` persiste como \`hu.short_id\`.
- El resolver \`resolveHuRef\` en el orquestador acepta:
  1. **id largo** (\`hu_plan-XXX_001\`) → match exacto.
  2. **short_id** (\`INFRA-001\`) → match case-insensitive.
  3. **sufijo numérico** (\`001\`) → busca \`hu.id\` que termine en \`_001\`.

### Tabla CLI
- \`formatHuTable\` muestra \`short_id\` como columna ID si existe, fallback al id largo (HUs legacy).
- Las deps \`blocked_by\` también se renderizan por short_id.

## Backwards-compat

Total. Planes sin alias y HUs sin short_id siguen funcionando — el CLI hace fallback al id largo en todos los puntos. Migración gradual: planes nuevos generados con esta versión llevan alias y short_id; los antiguos siguen siendo válidos.

## Bug encontrado y arreglado durante el cambio

Refactor mío de \`applyHuFilterIfRequested\` rompió el e2e/03: renombré \`missing\` → \`unresolved\` pero olvidé actualizar una referencia en \`emitProgress.detail.ignored\` → \`ReferenceError: missing is not defined\` silencioso (warn-only, fallback al normal pipeline). El e2e quedaba con la HU target en \`certified\` en lugar de \`done\`. Fix en el mismo PR.

## Tests

14 nuevos en \`tests/plan/plan-alias-and-short-id.test.js\`:
- \`normaliseAlias\` (slug + null + max 60).
- savePlan asigna alias, loadPlan por alias / por planId, colisión.
- listPlans incluye alias, ref inexistente.
- addHu acepta short_id.
- formatHuTable muestra short_id + fallback id largo.
- Deps blocked_by renderizadas por short_id.

**Suite global**: 4670/4670 verde (+14). e2e/03 sigue verde tras el fix.

## Ejemplo de uso

Tras este PR, en tu repo de GRETA:

\`\`\`bash
cd ~/ws_firebase/greta-app
kj plan generate --task-file docs/GRETA-app.task.md
# → Plan saved: plan-XXX-YY  alias: greta-app
# → Run: kj run --plan greta-app

kj run --plan greta-app --hu INFRA-001
# resuelve por short_id automáticamente
\`\`\`