### PR TITLE
feat(cli): kj plan output más limpio — fases acotadas, JSON suprimido, outOfScope honesto

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -51,7 +51,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   // Live progress to stderr so the user sees what the planner is doing
   // instead of staring at a silent shell for 30 s – 3 min. `--json` mode
   // stays quiet so stdout remains a pure JSON document.
-  const progress = createCliProgressReporter({ role: "planner", quiet: Boolean(json) });
+  // Sub-progress por fase (KJC outputs limpios): cada llamada al
+  // agente arranca su propio "[planner:fase] starting → done" para
+  // que el usuario no piense que "[planner] done" significa "el
+  // comando entero terminó" — sigue habiendo tests-synth, reviewer,
+  // self-fix iter N por delante.
+  const progress = createCliProgressReporter({ role: "planner:initial", quiet: Boolean(json) });
   let result;
   try {
     result = await planner.runTask({
@@ -175,7 +180,10 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     runLog.logText(
       `[planner] ${stepsMissingTests}/${steps.length} HUs missing acceptance_tests — running tests-synthesizer pass`
     );
-    progress.onOutput?.({ line: `${stepsMissingTests} HU(s) missing tests — running synthesizer pass`, kind: "text" });
+    // Sub-progress reporter por fase: el usuario ve cada fase como su
+    // propio "[planner:X] starting → done" en vez de un solo
+    // "[planner] done" que oculta que aún hay trabajo en cola.
+    const synthProgress = createCliProgressReporter({ role: "planner:tests-synth", quiet: Boolean(json) });
     const { synthesizeMissingTests } = await import("../../plan/tests-synthesizer.js");
     const husNeedingTests = plan.hus
       .filter((h) => !Array.isArray(h.acceptance_tests) || h.acceptance_tests.length === 0)
@@ -184,10 +192,11 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       agent: planner,
       task,
       husNeedingTests,
-      onOutput: progress.onOutput,
+      onOutput: synthProgress.onOutput,
       silenceTimeoutMs,
       timeoutMs,
     });
+    synthProgress.finish(synthResult.ok ? "done" : "failed");
     if (synthResult.ok) {
       let patched = 0;
       for (const hu of plan.hus) {
@@ -222,16 +231,17 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   const skipReview = Boolean(flags?.noPlanReview || flags?.quick);
   if (plan.hus.length > 0 && !skipReview) {
     runLog.logText("[planner] running plan reviewer pass");
-    progress.onOutput?.({ line: "Reviewing the plan for gaps / overlaps / order issues", kind: "text" });
+    const reviewProgress = createCliProgressReporter({ role: "planner:reviewer", quiet: Boolean(json) });
     const { reviewPlan, findingsCount } = await import("../../plan/plan-reviewer.js");
     const review = await reviewPlan({
       agent: planner,
       task,
       hus: plan.hus,
-      onOutput: progress.onOutput,
+      onOutput: reviewProgress.onOutput,
       silenceTimeoutMs,
       timeoutMs,
     });
+    reviewProgress.finish(review.ok ? "done" : "failed");
     if (review.ok) {
       plan.review = review.findings;
       const count = findingsCount(review.findings);
@@ -251,7 +261,7 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
           const currentCount = findingsCount(plan.review);
           if (currentCount === 0) break;
           runLog.logText(`[planner] self-fix iter ${i}/${maxFixerIterations} — patching ${currentCount} issue(s)`);
-          progress.onOutput?.({ line: `Self-fix iter ${i}: patching ${currentCount} issue(s)`, kind: "text" });
+          const fixProgress = createCliProgressReporter({ role: `planner:self-fix iter ${i}`, quiet: Boolean(json) });
           // KJC-BUG-0046 / P5: snapshot plan + review BEFORE applying the patch
           // so we can revert if the iteration regresses (newCount > currentCount).
           // Dogfooding 2026-05-12: GRETA Plan 2 iter 2 went 10 → 17 findings
@@ -262,23 +272,26 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
           const reviewSnapshot = JSON.parse(JSON.stringify(plan.review));
           const fix = await applyReviewerFeedback({
             agent: planner, task, hus: plan.hus, findings: plan.review,
-            onOutput: progress.onOutput, silenceTimeoutMs, timeoutMs,
+            onOutput: fixProgress.onOutput, silenceTimeoutMs, timeoutMs,
           });
           if (!fix.ok) {
+            fixProgress.finish("failed");
             runLog.logText(`[planner] self-fix iter ${i} failed (non-blocking): ${fix.error}`);
             break;
           }
           const ops = applyFixerPatch(plan, fix.patch);
           runLog.logText(`[planner] self-fix iter ${i} applied: +${ops.added} HU, +${ops.depsAdded} dep, -${ops.deleted} HU`);
           if (ops.added + ops.depsAdded + ops.deleted === 0) {
+            fixProgress.finish("done");
             runLog.logText(`[planner] self-fix iter ${i} empty patch — stopping`);
             break;
           }
           const review2 = await reviewPlan({
             agent: planner, task, hus: plan.hus,
-            onOutput: progress.onOutput, silenceTimeoutMs, timeoutMs,
+            onOutput: fixProgress.onOutput, silenceTimeoutMs, timeoutMs,
           });
           if (!review2.ok) {
+            fixProgress.finish("failed");
             runLog.logText(`[planner] re-review after iter ${i} failed: ${review2.error}`);
             plan.hus = husSnapshot;
             plan.review = reviewSnapshot;
@@ -289,10 +302,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
             // P5 convergence guard: iter made things worse — revert + stop.
             plan.hus = husSnapshot;
             plan.review = reviewSnapshot;
+            fixProgress.finish("reverted");
             runLog.logText(`[planner] self-fix iter ${i} regressed (${currentCount} → ${newCount}) — reverted, stopping`);
             break;
           }
           plan.review = review2.findings;
+          fixProgress.finish("done");
           runLog.logText(`[planner] after self-fix iter ${i}: ${newCount} issue(s) remaining`);
         }
       }

--- a/src/prompts/planner.js
+++ b/src/prompts/planner.js
@@ -246,7 +246,7 @@ export function buildPlannerPrompt({ task, context, architectContext, productCon
     "- `approach`: A concise paragraph describing the overall strategy.",
     "- `steps`: An array of step objects (see shape below). Each step = one commit.",
     "- `risks`: An array of strings describing potential risks or challenges.",
-    "- `outOfScope`: An array of strings listing what is explicitly NOT included.",
+    "- `outOfScope`: An array of strings listing what is explicitly NOT included. **RULES**: only populate it with items the task text EXPLICITLY excludes (phrases like 'NO incluye:', 'Fuera de scope:', 'Out of scope:', 'Not in this plan:', 'Plan N handles:', 'Reserved for plan…'). DO NOT invent items the task does not mention. DO NOT list things the user 'might' want next. If the task has no explicit exclusions, return `outOfScope: []` — an empty array is the correct answer.",
     "",
     "Each step in `steps` has this shape:",
     "```json",

--- a/src/utils/cli-progress.js
+++ b/src/utils/cli-progress.js
@@ -132,14 +132,46 @@ export function createCliProgressReporter(opts = {}) {
     if (typeof heartbeatTimer.unref === "function") heartbeatTimer.unref();
   }
 
+  // JSON suppression state — cuando el agente emite un bloque JSON
+  // multi-línea (``` json ... ``` o `{ ... }` standalone), evitamos
+  // imprimirlo línea a línea porque inunda el stderr con ruido
+  // estructural que nadie lee. Mostramos un solo marcador
+  // `<json suprimido>` la primera vez que abrimos un bloque.
+  //
+  // Dos modos de cierre:
+  //   - fenceMode = true  → terminamos al ver otro ``` (ignora brace count).
+  //   - fenceMode = false → terminamos cuando braceDepth llega a 0.
+  let inJsonBlock = false;
+  let fenceMode = false;
+  let braceDepth = 0;
+  const JSON_FENCE_RE = /^\s*```(json)?\s*$/;
   const onOutput = (event) => {
     if (!event || typeof event !== "object") return;
     const raw = typeof event.line === "string" ? event.line : "";
     if (!raw) return;
-    // Strip trailing newline — we re-add our own.
     const line = raw.replace(/\s+$/, "");
     if (!line) return;
     lastActivityAt = Date.now();
+    // Detección + supresión de JSON multilínea.
+    if (!inJsonBlock) {
+      if (JSON_FENCE_RE.test(line)) {
+        inJsonBlock = true; fenceMode = true; braceDepth = 0;
+        stream.write(`  ${ICONS.text} <json suprimido>\n`);
+        return;
+      }
+      if (/^[\s]*[{[]\s*$/.test(line)) {
+        inJsonBlock = true; fenceMode = false; braceDepth = 1;
+        stream.write(`  ${ICONS.text} <json suprimido>\n`);
+        return;
+      }
+    } else if (fenceMode) {
+      if (JSON_FENCE_RE.test(line)) { inJsonBlock = false; fenceMode = false; }
+      return; // sigue dentro del fence
+    } else {
+      braceDepth += (line.match(/[{[]/g) || []).length - (line.match(/[}\]]/g) || []).length;
+      if (braceDepth <= 0) { inJsonBlock = false; braceDepth = 0; }
+      return; // sigue dentro del brace-block
+    }
     const icon = ICONS[event.kind] || ICONS.text;
     stream.write(`  ${icon} ${line}\n`);
   };

--- a/tests/prompt-planner.test.js
+++ b/tests/prompt-planner.test.js
@@ -318,4 +318,20 @@ describe("prompts/planner buildPlannerPrompt", () => {
       expect(prompt).toMatch(/ONLY required output is the JSON object/);
     });
   });
+
+  // KJC outputs limpios: outOfScope NO debe inventarse.
+  describe("outOfScope hardening", () => {
+    it("instruye que NO se invente y que el default sea []", () => {
+      const prompt = buildPlannerPrompt({ task: "anything" });
+      expect(prompt).toMatch(/DO NOT invent items the task does not mention/);
+      expect(prompt).toMatch(/empty array is the correct answer/);
+    });
+
+    it("lista los marcadores aceptables para exclusiones explícitas", () => {
+      const prompt = buildPlannerPrompt({ task: "anything" });
+      expect(prompt).toMatch(/NO incluye:/);
+      expect(prompt).toMatch(/Fuera de scope:/);
+      expect(prompt).toMatch(/Out of scope:/);
+    });
+  });
 });

--- a/tests/utils/cli-progress.test.js
+++ b/tests/utils/cli-progress.test.js
@@ -96,4 +96,51 @@ describe("utils/cli-progress — createCliProgressReporter", () => {
     expect(() => onOutput({})).not.toThrow();
     expect(() => onOutput({ line: 123 })).not.toThrow(); // non-string ignored
   });
+
+  // KJC outputs limpios: bloques JSON multilínea NO inundan el stderr.
+  describe("JSON suppression", () => {
+    it("suprime bloque ```json ... ``` y muestra un marcador", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: "Generating plan...", kind: "text" });
+      onOutput({ line: "```json", kind: "text" });
+      onOutput({ line: '  "approach": "build it"', kind: "text" });
+      onOutput({ line: '  "steps": [', kind: "text" });
+      onOutput({ line: '    { "id": "INFRA-001" }', kind: "text" });
+      onOutput({ line: "  ]", kind: "text" });
+      onOutput({ line: "}", kind: "text" });
+      onOutput({ line: "```", kind: "text" });
+      onOutput({ line: "Done.", kind: "text" });
+      const suppressed = stream.out.split("\n").filter((l) => l.includes("<json suprimido>"));
+      expect(suppressed).toHaveLength(1);
+      expect(stream.out).not.toContain('"approach":');
+      expect(stream.out).not.toContain('"id": "INFRA-001"');
+      expect(stream.out).toMatch(/Generating plan\.\.\./);
+      expect(stream.out).toMatch(/Done\./);
+    });
+
+    it("suprime JSON sin fence (que empieza con `{` solo)", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: "Output:", kind: "text" });
+      onOutput({ line: "{", kind: "text" });
+      onOutput({ line: '  "ok": true', kind: "text" });
+      onOutput({ line: "}", kind: "text" });
+      onOutput({ line: "After.", kind: "text" });
+      expect(stream.out).toMatch(/<json suprimido>/);
+      expect(stream.out).not.toContain('"ok": true');
+      expect(stream.out).toMatch(/Output:/);
+      expect(stream.out).toMatch(/After\./);
+    });
+
+    it("no suprime líneas normales que casualmente tengan llaves", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: "Found {x} items.", kind: "text" });
+      onOutput({ line: "Listing patterns matching {pattern}", kind: "text" });
+      expect(stream.out).toMatch(/Found \{x\} items\./);
+      expect(stream.out).toMatch(/Listing patterns matching \{pattern\}/);
+      expect(stream.out).not.toMatch(/<json suprimido>/);
+    });
+  });
 });


### PR DESCRIPTION
## Tres mejoras al output del comando \`kj plan\` (puntos 1-4 del usuario)

### 1. Sub-progress reporters por fase

**Antes**: un solo \`[planner] starting → done\` cubría todas las llamadas al agente. El usuario veía \`[planner] done (232s)\` y pensaba que el comando había terminado, pero seguían tests-synth + reviewer + self-fix.

**Ahora**:
- \`[planner:initial] starting → done\`
- \`[planner:tests-synth] starting → done\` (si aplica)
- \`[planner:reviewer] starting → done\` (si aplica)
- \`[planner:self-fix iter N] starting → done | reverted | failed\`

Cada fase tiene su propio cronómetro y outcome. El usuario sabe exactamente qué fase está corriendo y cuántas faltan.

### 2. Supresión de bloques JSON multilínea

**Antes**: el planner emitía el JSON del plan como output literal, y cli-progress imprimía línea a línea al stderr (100+ líneas de \`"approach": ...\`, \`{ "id": "X" }\`).

**Ahora**: el cli-progress detecta apertura (\` \`\`\`json \` o solo \`{\`/\`[\`) y cierre (fence \` \`\`\` \` o brace count = 0). Sustituye todo el bloque por un solo marcador \`· <json suprimido>\`.

Líneas normales con llaves casuales (\`Found {x} items.\`) NO se suprimen — la detección es estricta.

### 3. outOfScope honesto en el prompt del planner

**Antes**: el planner inventaba items en outOfScope (\"el usuario podría querer X\", \"escalabilidad futura\").

**Ahora** en el prompt:
> \`outOfScope\`: solo items que el task EXPLÍCITAMENTE excluye (frases tipo 'NO incluye:', 'Fuera de scope:', 'Out of scope:'). NO inventes. NO listes cosas que el usuario 'podría' querer. Si el task no tiene exclusiones explícitas, devuelve \`outOfScope: []\` — un array vacío es la respuesta correcta.

## Tests

- **3 nuevos en \`tests/utils/cli-progress.test.js\`**: JSON con fence, sin fence, llaves casuales NO suprimidas.
- **2 nuevos en \`tests/prompt-planner.test.js\`**: outOfScope hardening con reglas + marcadores reconocibles.

**Suite global**: 4675/4675 verde (+5). **LOC**: 120.

## Cierre de los 5 puntos del usuario

| # | Punto | Estado |
|---|-------|--------|
| 1 | \`done (Xs)\` ambiguo | ✅ Este PR — sub-progress por fase |
| 2 | \`[reviewer]\` no acotado | ✅ Este PR — \`[planner:reviewer]\` propio |
| 3 | JSONs visibles | ✅ Este PR — \`<json suprimido>\` |
| 4 | \`outOfScope\` inventado | ✅ Este PR — reglas explícitas en prompt |
| 5 | IDs crípticos en tabla | ✅ PR #704 (alias + short_id) |