### PR TITLE
feat(cli): supresión silenciosa de JSON (sin marker '<json suprimido>')

### DIFF
--- a/src/utils/cli-progress.js
+++ b/src/utils/cli-progress.js
@@ -132,19 +132,33 @@ export function createCliProgressReporter(opts = {}) {
     if (typeof heartbeatTimer.unref === "function") heartbeatTimer.unref();
   }
 
-  // JSON suppression state — cuando el agente emite un bloque JSON
-  // multi-línea (``` json ... ``` o `{ ... }` standalone), evitamos
-  // imprimirlo línea a línea porque inunda el stderr con ruido
-  // estructural que nadie lee. Mostramos un solo marcador
-  // `<json suprimido>` la primera vez que abrimos un bloque.
+  // JSON suppression — cuando el agente emite estructura JSON, la
+  // suprimimos por completo SIN marker ("<json suprimido>" confundía
+  // tanto como el propio JSON). Si no hay nada útil que decirle al
+  // usuario, mejor silencio.
   //
-  // Dos modos de cierre:
-  //   - fenceMode = true  → terminamos al ver otro ``` (ignora brace count).
-  //   - fenceMode = false → terminamos cuando braceDepth llega a 0.
+  // Capturamos 4 patrones:
+  //   1. Fence multilínea ``` json ... ``` (state in fence hasta cierre).
+  //   2. Brace block standalone { ... } o [ ... ] (state hasta brace=0).
+  //   3. Línea suelta con ``` o ```json EN CUALQUIER PARTE (incluso
+  //      "done: ```json" embedded en texto): suprimida + abre fence
+  //      si no estaba abierto.
+  //   4. Línea suelta con shape de propiedad JSON (`  "key": ...`,
+  //      `  },`, `  ],`, `  {`) cuando NO estamos en bloque: heurística
+  //      de "trozo de JSON suelto" — se suprime, no entra al stderr.
   let inJsonBlock = false;
   let fenceMode = false;
   let braceDepth = 0;
-  const JSON_FENCE_RE = /^\s*```(json)?\s*$/;
+  const FULL_FENCE_RE = /^\s*```(?:json)?\s*$/;
+  const HAS_FENCE_RE = /```/;
+  const STANDALONE_BRACE_OPEN = /^[\s]*[{[]\s*$/;
+  // Trozo de línea que es CLARAMENTE sintaxis JSON aislada:
+  //   - `  "foo": "bar",`        propiedad
+  //   - `  "foo": 123`           propiedad numérica
+  //   - `  "foo": {`             apertura de objeto en valor
+  //   - `  },` / `  ],` / `  }` / `  ]`  cierre con o sin coma
+  const JSON_SCRAP_RE =
+    /^\s*(?:"[^"\\]*(?:\\.[^"\\]*)*"\s*:\s*.+|[}\]][,]?)\s*$/;
   const onOutput = (event) => {
     if (!event || typeof event !== "object") return;
     const raw = typeof event.line === "string" ? event.line : "";
@@ -152,26 +166,37 @@ export function createCliProgressReporter(opts = {}) {
     const line = raw.replace(/\s+$/, "");
     if (!line) return;
     lastActivityAt = Date.now();
-    // Detección + supresión de JSON multilínea.
-    if (!inJsonBlock) {
-      if (JSON_FENCE_RE.test(line)) {
-        inJsonBlock = true; fenceMode = true; braceDepth = 0;
-        stream.write(`  ${ICONS.text} <json suprimido>\n`);
+    // Estado: dentro de bloque ya marcado.
+    if (inJsonBlock) {
+      if (fenceMode) {
+        if (HAS_FENCE_RE.test(line)) { inJsonBlock = false; fenceMode = false; }
         return;
       }
-      if (/^[\s]*[{[]\s*$/.test(line)) {
-        inJsonBlock = true; fenceMode = false; braceDepth = 1;
-        stream.write(`  ${ICONS.text} <json suprimido>\n`);
-        return;
-      }
-    } else if (fenceMode) {
-      if (JSON_FENCE_RE.test(line)) { inJsonBlock = false; fenceMode = false; }
-      return; // sigue dentro del fence
-    } else {
       braceDepth += (line.match(/[{[]/g) || []).length - (line.match(/[}\]]/g) || []).length;
       if (braceDepth <= 0) { inJsonBlock = false; braceDepth = 0; }
-      return; // sigue dentro del brace-block
+      return;
     }
+    // Apertura de bloque por fence (línea es SOLO ``` o ```json).
+    if (FULL_FENCE_RE.test(line)) {
+      inJsonBlock = true; fenceMode = true; braceDepth = 0;
+      return;
+    }
+    // Apertura de bloque por brace standalone.
+    if (STANDALONE_BRACE_OPEN.test(line)) {
+      inJsonBlock = true; fenceMode = false; braceDepth = 1;
+      return;
+    }
+    // Fence embedded en texto (línea tipo `done: ```json` o `texto ```).
+    // Si la fence está sin cerrar en la misma línea → entra al modo.
+    if (HAS_FENCE_RE.test(line)) {
+      const fences = (line.match(/```/g) || []).length;
+      if (fences % 2 === 1) {           // impar → queda fence abierto
+        inJsonBlock = true; fenceMode = true; braceDepth = 0;
+      }
+      return;                            // suprimida en cualquier caso
+    }
+    // Trozo de JSON suelto sin fence: suprimir silenciosamente.
+    if (JSON_SCRAP_RE.test(line)) return;
     const icon = ICONS[event.kind] || ICONS.text;
     stream.write(`  ${icon} ${line}\n`);
   };

--- a/tests/utils/cli-progress.test.js
+++ b/tests/utils/cli-progress.test.js
@@ -97,9 +97,11 @@ describe("utils/cli-progress — createCliProgressReporter", () => {
     expect(() => onOutput({ line: 123 })).not.toThrow(); // non-string ignored
   });
 
-  // KJC outputs limpios: bloques JSON multilínea NO inundan el stderr.
+  // KJC outputs limpios: bloques JSON NO inundan el stderr.
+  // Supresión SILENCIOSA (sin marker "<json suprimido>" — un marker
+  // también confunde al usuario; si suprimimos, suprimimos sin más).
   describe("JSON suppression", () => {
-    it("suprime bloque ```json ... ``` y muestra un marcador", () => {
+    it("suprime bloque ```json ... ``` sin dejar marker", () => {
       const stream = fakeStream();
       const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
       onOutput({ line: "Generating plan...", kind: "text" });
@@ -111,10 +113,10 @@ describe("utils/cli-progress — createCliProgressReporter", () => {
       onOutput({ line: "}", kind: "text" });
       onOutput({ line: "```", kind: "text" });
       onOutput({ line: "Done.", kind: "text" });
-      const suppressed = stream.out.split("\n").filter((l) => l.includes("<json suprimido>"));
-      expect(suppressed).toHaveLength(1);
       expect(stream.out).not.toContain('"approach":');
       expect(stream.out).not.toContain('"id": "INFRA-001"');
+      expect(stream.out).not.toMatch(/<json suprimido>/);
+      expect(stream.out).not.toContain("```");
       expect(stream.out).toMatch(/Generating plan\.\.\./);
       expect(stream.out).toMatch(/Done\./);
     });
@@ -127,8 +129,8 @@ describe("utils/cli-progress — createCliProgressReporter", () => {
       onOutput({ line: '  "ok": true', kind: "text" });
       onOutput({ line: "}", kind: "text" });
       onOutput({ line: "After.", kind: "text" });
-      expect(stream.out).toMatch(/<json suprimido>/);
       expect(stream.out).not.toContain('"ok": true');
+      expect(stream.out).not.toMatch(/<json suprimido>/);
       expect(stream.out).toMatch(/Output:/);
       expect(stream.out).toMatch(/After\./);
     });
@@ -140,6 +142,42 @@ describe("utils/cli-progress — createCliProgressReporter", () => {
       onOutput({ line: "Listing patterns matching {pattern}", kind: "text" });
       expect(stream.out).toMatch(/Found \{x\} items\./);
       expect(stream.out).toMatch(/Listing patterns matching \{pattern\}/);
+    });
+
+    // Casos del usuario en dogfooding GRETA: trozos de JSON SUELTOS
+    // sin bloque previo y fences embedidos en texto.
+    it("suprime trozos de propiedad JSON sueltos sin bloque", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: '  "spec_section": "1"', kind: "text" });
+      onOutput({ line: '  "id": "INFRA-001",', kind: "text" });
+      onOutput({ line: "  },", kind: "text" });
+      onOutput({ line: "  ],", kind: "text" });
+      onOutput({ line: "Texto normal después", kind: "text" });
+      expect(stream.out).not.toContain('"spec_section":');
+      expect(stream.out).not.toContain('"id": "INFRA-001"');
+      expect(stream.out).toMatch(/Texto normal después/);
+    });
+
+    it("suprime líneas con fence embedded en texto (done: ```json)", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: "done: ```json", kind: "text" });
+      onOutput({ line: '  "x": 1', kind: "text" });
+      onOutput({ line: "```", kind: "text" });
+      onOutput({ line: "Plan completed.", kind: "text" });
+      expect(stream.out).not.toContain("done: ");
+      expect(stream.out).not.toContain('"x": 1');
+      expect(stream.out).not.toContain("```");
+      expect(stream.out).toMatch(/Plan completed\./);
+    });
+
+    it("ya NO emite el marker `<json suprimido>` en ningún caso", () => {
+      const stream = fakeStream();
+      const { onOutput } = createCliProgressReporter({ role: "x", stream, heartbeatMs: 0 });
+      onOutput({ line: "```json", kind: "text" });
+      onOutput({ line: '"foo": "bar"', kind: "text" });
+      onOutput({ line: "```", kind: "text" });
       expect(stream.out).not.toMatch(/<json suprimido>/);
     });
   });


### PR DESCRIPTION
## Problema

El marker \`· <json suprimido>\` añadido en PR #705 confundía igual o más que el propio JSON. Comentario del usuario en dogfooding:

> "Sale en el planner \`· <json suprimido>\` esto que es? que significa? a un usuario le creará incertidumbre. Si hay algo que mostrar se muestra pero en formato amigable no un json. Si no, no que no diga nada. Y luego saca trozos de jsons... trozos, que igualmente confunden."

Además, el filtro anterior dejaba pasar:
- Trozos sueltos sin bloque (\`  "spec_section": ...,\`, \`  },\`, \`  ],\`).
- Fences embedded en texto (\`done: \`\`\`json\`).

## Cambios

\`src/utils/cli-progress.js\`:

1. **Sin marker** — si suprimimos, se calla. No emite nada al stderr.
2. **Fence embedded en texto** — detecta \` ``` \` en cualquier parte de la línea (no solo línea aislada). Suprime la línea + evalúa paridad: número impar de fences deja la fence abierta para suprimir lo siguiente hasta el cierre.
3. **Trozos de JSON sueltos** — nueva regex que matchea propiedades aisladas (\`"key": value,\`) y cierres (\`},\`, \`],\`, \`}\`, \`]\`). Se suprimen sin abrir bloque. NO afecta a texto normal con llaves casuales (\`Found {x} items\`).

## Tests

17 totales en \`cli-progress.test.js\` (2 nuevos sobre el PR #705):

- Bloque suprimido sin marker.
- Trozos JSON sueltos sin bloque suprimidos.
- Fence embedded en texto suprime + abre fence.
- Asserción explícita: \`<json suprimido>\` nunca aparece.
- Texto normal con llaves casuales NO se toca.

**Suite global**: 4678/4678 verde.

## Resultado para el usuario

\`kj plan generate\` ya no muestra ni JSONs ni markers crípticos. Solo:
- Heartbeats / acciones / texto narrativo del agente.
- \`[fase] starting → done (Xs)\`.
- Banner final con tabla legible.

Si una fase no tiene nada humano que decir, se queda en silencio (lo que prefiere el usuario).

## Test plan

- [x] \`npm test\` 4678/4678.
- [ ] Lanzar \`kj plan generate\` en GRETA: NO debe aparecer \`<json suprimido>\` ni trozos sueltos tipo \`"id": "..."\`.