### PR TITLE
fix(plan): plan-fixer asigna short_id y blocked_by a HUs añadidas (KJC-BUG-0053)

### DIFF
--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -110,15 +110,42 @@ export function applyFixerPatch(plan, patch) {
   for (const huId of patch.deletions || []) {
     if (removeHu(plan, huId)) counts.deleted += 1;
   }
+  // KJC-BUG-0053: las HUs añadidas por el fixer dejaban `short_id` y
+  // `blocked_by` vacíos porque addHu no recibía esos campos. Resultado:
+  // HUs huérfanas con id largo críptico y sin orden de ejecución.
+  //
+  // Fix: (1) pasar `short_id: a.id` (el id simbólico que el fixer LLM
+  // asigna a cada addition). (2) resolver `a.dependencies` simbólicas
+  // → hu.id largos contra el plan ya existente + el mapa de símbolos
+  // recién añadidos. La resolución necesita 2 pasadas (primera crea
+  // las HUs y registra el mapping, segunda asigna deps) para que
+  // additions que se referencian entre sí funcionen.
+  const symbolicToHuId = new Map();
+  for (const hu of plan.hus) {
+    if (hu.short_id) symbolicToHuId.set(hu.short_id, hu.id);
+  }
+  const addedHus = []; // {hu, depsSymbolic}
   for (const a of patch.additions || []) {
-    addHu(plan, {
+    const symbolicId = typeof a.id === "string" && a.id.trim() ? a.id.trim() : null;
+    const hu = addHu(plan, {
       title: (a.description || "").slice(0, 80),
       scope: a.description,
+      short_id: symbolicId,
       spec_section: a.spec_section,
       acceptance_tests: a.acceptance_tests,
       reuse: a.reuse || [],
     });
+    if (symbolicId) symbolicToHuId.set(symbolicId, hu.id);
+    const depsSymbolic = Array.isArray(a.dependencies) ? a.dependencies : [];
+    addedHus.push({ hu, depsSymbolic });
     counts.added += 1;
+  }
+  // Pasada 2: resolver deps simbólicas de las additions a ids largos.
+  for (const { hu, depsSymbolic } of addedHus) {
+    const resolved = depsSymbolic
+      .map((s) => typeof s === "string" ? symbolicToHuId.get(s.trim()) : null)
+      .filter(Boolean);
+    if (resolved.length > 0) hu.blocked_by = resolved;
   }
   const knownIds = new Set(plan.hus.map(h => h.id));
   for (const { huId, on } of patch.deps_to_add || []) {

--- a/tests/plan/plan-fixer.test.js
+++ b/tests/plan/plan-fixer.test.js
@@ -109,4 +109,55 @@ describe("applyFixerPatch", () => {
     expect(plan.hus).toHaveLength(1);
     expect(plan.hus[0].blocked_by).toEqual([]);
   });
+
+  // KJC-BUG-0053: HUs añadidas por fixer deben llevar short_id y blocked_by
+  // resueltos desde el id simbólico + dependencies del patch.
+  it("addition con id simbólico se persiste como short_id de la HU nueva", () => {
+    const plan = makePlan();
+    applyFixerPatch(plan, {
+      additions: [{ id: "INFRA-NEW", description: "Audit log", spec_section: "5.3" }],
+      deps_to_add: [],
+      deletions: [],
+    });
+    const added = plan.hus.find((h) => h.scope === "Audit log");
+    expect(added.short_id).toBe("INFRA-NEW");
+  });
+
+  it("addition con dependencies simbólicas se resuelve a blocked_by con ids largos de HUs existentes", () => {
+    const plan = makePlan();
+    plan.hus[0].short_id = "BASE-001"; // hu_001 tiene short_id conocido
+    applyFixerPatch(plan, {
+      additions: [{ id: "DERIVED-001", description: "Depends on base", dependencies: ["BASE-001"] }],
+      deps_to_add: [],
+      deletions: [],
+    });
+    const added = plan.hus.find((h) => h.short_id === "DERIVED-001");
+    expect(added.blocked_by).toEqual(["hu_001"]);
+  });
+
+  it("dependencies entre 2 additions del mismo patch se resuelven (forward ref)", () => {
+    const plan = makePlan();
+    applyFixerPatch(plan, {
+      additions: [
+        { id: "X-001", description: "first" },
+        { id: "Y-001", description: "second", dependencies: ["X-001"] },
+      ],
+      deps_to_add: [],
+      deletions: [],
+    });
+    const x = plan.hus.find((h) => h.short_id === "X-001");
+    const y = plan.hus.find((h) => h.short_id === "Y-001");
+    expect(y.blocked_by).toEqual([x.id]);
+  });
+
+  it("dependencies simbólicas desconocidas se descartan silenciosamente (sin matchear no se añaden)", () => {
+    const plan = makePlan();
+    applyFixerPatch(plan, {
+      additions: [{ id: "DANGLER", description: "orphan ref", dependencies: ["NONEXISTENT-999"] }],
+      deps_to_add: [],
+      deletions: [],
+    });
+    const added = plan.hus.find((h) => h.short_id === "DANGLER");
+    expect(added.blocked_by).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Bug

Cuando self-fix loop añadía HUs (reviewer marca `missing_hus`), `applyFixerPatch` las creaba sin `short_id` ni `blocked_by`. Resultado: HUs huérfanas con id largo críptico y sin orden de ejecución.

Repro real: GRETA plan-20260514020146-tc4i — HUs 100-104 con `short_id: null` y `blocked_by: []`.

## Fix

`src/plan/plan-fixer.js::applyFixerPatch`:
- Construye `symbolicToHuId` Map al inicio (poblado con `short_id` de HUs existentes).
- Pasa `short_id: a.id` al `addHu` de cada addition (el id simbólico que el fixer LLM asigna).
- Registra `symbolic → hu.id` justo tras crear cada HU para permitir forward refs entre additions.
- Pasada 2: resuelve `a.dependencies` simbólicas → `hu.id` largos como `blocked_by`. Refs desconocidas se descartan silenciosamente.

## Tests (4 nuevos en plan-fixer.test.js)

- `short_id` persiste tras applyFixerPatch.
- `blocked_by` resuelto contra HU existente con `short_id`.
- Forward ref entre 2 additions del mismo patch.
- Refs simbólicas desconocidas → `blocked_by: []` sin error.

Suite global: 4682/4682 verde.