### PR TITLE
fix(plan): convergence guard inteligente del self-fix loop (KJC-BUG-0054)

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -232,7 +232,7 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   if (plan.hus.length > 0 && !skipReview) {
     runLog.logText("[planner] running plan reviewer pass");
     const reviewProgress = createCliProgressReporter({ role: "planner:reviewer", quiet: Boolean(json) });
-    const { reviewPlan, findingsCount } = await import("../../plan/plan-reviewer.js");
+    const { reviewPlan, findingsCount, findingsCountByType } = await import("../../plan/plan-reviewer.js");
     const review = await reviewPlan({
       agent: planner,
       task,
@@ -255,7 +255,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       // PATCH the plan, apply in-process, and re-review. Loop until 0
       // findings or maxIterations. Skippable with --no-plan-fixer/--quick.
       const skipFixer = Boolean(flags?.noPlanFixer || flags?.quick);
-      const maxFixerIterations = 2;
+      // KJC-BUG-0054: bumped 2 → 4 — el guard antiguo cortaba el loop
+      // demasiado pronto cuando había muchos hallazgos. Con el guard
+      // inteligente (priority vs secondary) podemos permitir más
+      // iteraciones sin riesgo de divergir indefinidamente, porque
+      // cada iter que NO reduce priority ni total se revierte.
+      const maxFixerIterations = 4;
       if (count > 0 && !skipFixer) {
         for (let i = 1; i <= maxFixerIterations; i++) {
           const currentCount = findingsCount(plan.review);
@@ -297,18 +302,41 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
             plan.review = reviewSnapshot;
             break;
           }
-          const newCount = findingsCount(review2.findings);
-          if (newCount > currentCount) {
-            // P5 convergence guard: iter made things worse — revert + stop.
+          // KJC-BUG-0054: smart convergence guard. El guard antiguo
+          // (newCount > currentCount → revert) tiraba iteraciones
+          // VÁLIDAS que arreglaban un ciclo o una HU faltante pero
+          // a cambio creaban deps menores. Ahora distinguimos:
+          //   - priority = cycles + missing_hus (CRÍTICO, no ignorable)
+          //   - secondary = missing_deps + overlaps + order non-circular
+          //
+          // Reglas (en orden):
+          //   1. priority bajó → ACEPTAR (aunque secondary suba — el plan es ejecutable)
+          //   2. priority igual + total bajó → ACEPTAR
+          //   3. priority igual + total igual → ACEPTAR (lateral move, da chance)
+          //   4. priority subió → REVERT
+          //   5. priority igual + total subió → REVERT (regresión genuina)
+          const before = findingsCountByType(reviewSnapshot);
+          const after = findingsCountByType(review2.findings);
+          const newCount = after.total;
+          const accept =
+            after.priority < before.priority
+            || (after.priority === before.priority && after.total <= before.total);
+          if (!accept) {
+            const reason = after.priority > before.priority
+              ? `priority ${before.priority}→${after.priority}`
+              : `total ${before.total}→${after.total} (priority unchanged at ${after.priority})`;
             plan.hus = husSnapshot;
             plan.review = reviewSnapshot;
             fixProgress.finish("reverted");
-            runLog.logText(`[planner] self-fix iter ${i} regressed (${currentCount} → ${newCount}) — reverted, stopping`);
+            runLog.logText(`[planner] self-fix iter ${i} regressed (${reason}) — reverted, stopping`);
             break;
           }
           plan.review = review2.findings;
           fixProgress.finish("done");
-          runLog.logText(`[planner] after self-fix iter ${i}: ${newCount} issue(s) remaining`);
+          const deltaSummary = after.priority < before.priority
+            ? `priority ${before.priority}→${after.priority}, total ${before.total}→${after.total}`
+            : `total ${before.total}→${after.total}`;
+          runLog.logText(`[planner] after self-fix iter ${i}: ${newCount} issue(s) (${deltaSummary})`);
         }
       }
     } else {

--- a/src/plan/plan-reviewer.js
+++ b/src/plan/plan-reviewer.js
@@ -197,3 +197,33 @@ export function findingsCount(findings) {
     // parallelisable_groups is informational, not an issue.
   );
 }
+
+/**
+ * KJC-BUG-0054: count findings categorised por prioridad, para que
+ * el self-fix convergence guard pueda distinguir "regresión genuina"
+ * de "regresión por arreglar algo importante".
+ *
+ * Categorías:
+ *   - priority: ciclos (order_issues con issue=='circular') + missing_hus.
+ *     Estos NO pueden ignorarse — un ciclo deja el plan no ejecutable;
+ *     una HU faltante es feature missing.
+ *   - secondary: missing_dependencies + scope_overlaps + order_issues
+ *     no-circulares. Importantes pero recuperables.
+ *
+ * @param {object} findings
+ * @returns {{ priority: number, secondary: number, total: number, cycles: number }}
+ */
+export function findingsCountByType(findings) {
+  if (!findings) return { priority: 0, secondary: 0, total: 0, cycles: 0 };
+  const orderIssues = findings.order_issues || [];
+  const cycles = orderIssues.filter(
+    (i) => i && typeof i === "object" && i.issue === "circular"
+  ).length;
+  const orderNonCircular = orderIssues.length - cycles;
+  const missingHus = findings.missing_hus?.length || 0;
+  const missingDeps = findings.missing_dependencies?.length || 0;
+  const overlaps = findings.scope_overlaps?.length || 0;
+  const priority = cycles + missingHus;
+  const secondary = missingDeps + overlaps + orderNonCircular;
+  return { priority, secondary, total: priority + secondary, cycles };
+}

--- a/tests/plan/plan-reviewer.test.js
+++ b/tests/plan/plan-reviewer.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildReviewerPrompt, reviewPlan, findingsCount } from "../../src/plan/plan-reviewer.js";
+import { buildReviewerPrompt, reviewPlan, findingsCount, findingsCountByType } from "../../src/plan/plan-reviewer.js";
 
 describe("buildReviewerPrompt", () => {
   it("constrains the LLM to five closed-ended questions, no free-form suggestions", () => {
@@ -155,5 +155,48 @@ describe("findingsCount", () => {
     expect(findingsCount(null)).toBe(0);
     expect(findingsCount({})).toBe(0);
     expect(findingsCount({ missing_hus: [] })).toBe(0);
+  });
+});
+
+// KJC-BUG-0054: convergence guard inteligente necesita distinguir
+// "regresión genuina" (priority subió) de "tradeoff válido" (priority
+// bajó pero secondary subió). El test fija las dos categorías.
+describe("findingsCountByType", () => {
+  it("clasifica cycles + missing_hus como priority; el resto como secondary", () => {
+    const f = {
+      missing_hus: [{ spec_section: "5.1", rationale: "x" }, { spec_section: "5.2", rationale: "y" }],
+      missing_dependencies: [{ from: "h1", on: "h2", rationale: "z" }],
+      scope_overlaps: [{ between: ["h3", "h4"], rationale: "w" }, { between: ["h5", "h6"], rationale: "v" }],
+      order_issues: [
+        { hus: ["h7", "h8"], issue: "circular", rationale: "loop" },
+        { hus: ["h9"], issue: "wrong order", rationale: "non-circular" },
+      ],
+    };
+    const r = findingsCountByType(f);
+    expect(r.priority).toBe(3);    // 1 cycle + 2 missing_hus
+    expect(r.secondary).toBe(4);   // 1 dep + 2 overlaps + 1 non-circular order
+    expect(r.total).toBe(7);
+    expect(r.cycles).toBe(1);
+  });
+
+  it("vuelve a cero para findings vacíos / nulos", () => {
+    expect(findingsCountByType(null)).toEqual({ priority: 0, secondary: 0, total: 0, cycles: 0 });
+    expect(findingsCountByType({})).toEqual({ priority: 0, secondary: 0, total: 0, cycles: 0 });
+  });
+
+  it("distingue order_issues circulares vs no-circulares (los no-circulares NO son priority)", () => {
+    const onlyNonCircular = findingsCountByType({
+      order_issues: [{ hus: ["h1"], issue: "wrong order", rationale: "x" }],
+    });
+    expect(onlyNonCircular.priority).toBe(0);
+    expect(onlyNonCircular.cycles).toBe(0);
+    expect(onlyNonCircular.secondary).toBe(1);
+
+    const onlyCircular = findingsCountByType({
+      order_issues: [{ hus: ["h1", "h2"], issue: "circular", rationale: "loop" }],
+    });
+    expect(onlyCircular.priority).toBe(1);
+    expect(onlyCircular.cycles).toBe(1);
+    expect(onlyCircular.secondary).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Guard antiguo** (`newCount > currentCount → revert`) tiraba iteraciones VÁLIDAS del self-fix loop: si la iter arreglaba un ciclo (priority) pero creaba 1-2 deps menores (secondary), se revertía y el plan quedaba peor.
- **Guard nuevo** distingue **priority** (cycles + missing_hus, no ignorable) de **secondary** (missing_deps + overlaps + order non-circular, recuperable).
- **Reglas**: priority bajó → ACEPTAR (aunque secondary suba); priority igual + total bajó → ACEPTAR; priority subió → REVERT.
- **maxFixerIterations** 2 → 4: con guard inteligente podemos permitir más iteraciones sin divergir.

## Test plan

- [x] `npx vitest run tests/plan/plan-reviewer.test.js tests/plan/plan-fixer.test.js` — 26 passed
- [x] `npx vitest run tests/plan/ tests/commands/plan/` — 215 passed
- [x] `npm run lint` — clean
- [ ] Dogfooding con plan complejo (GRETA) — confirmar que iteraciones que antes se descartaban ahora convergen