### PR TITLE
feat(plan): structural integrity pass (KJC-TSK-0399)

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -8,6 +8,7 @@ import { runAutoGC, summarizeGC } from "../../utils/garbage-collector.js";
 import { promptProjectName } from "../../utils/prompt-project-name.js";
 import { deriveProjectNameFromCwd } from "../../utils/derive-project-name-from-cwd.js";
 import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js";
+import { runStructuralPass } from "../../plan/plan-structural-pass.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -348,7 +349,6 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   // orphan refs, missing short_id. Runs after self-fix loop because
   // the LLM is bad at graph problems. Always runs (cheap, no network).
   if (plan.hus.length > 0) {
-    const { runStructuralPass } = await import("../../plan/plan-structural-pass.js");
     const { fixes } = runStructuralPass(plan);
     if (fixes.length > 0) {
       if (!plan.review) plan.review = {};

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -344,6 +344,20 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     }
   }
 
+  // KJC-TSK-0399: deterministic structural integrity pass — cycles,
+  // orphan refs, missing short_id. Runs after self-fix loop because
+  // the LLM is bad at graph problems. Always runs (cheap, no network).
+  if (plan.hus.length > 0) {
+    const { runStructuralPass } = await import("../../plan/plan-structural-pass.js");
+    const { fixes } = runStructuralPass(plan);
+    if (fixes.length > 0) {
+      if (!plan.review) plan.review = {};
+      plan.review.structural_fixes = fixes;
+      const byKind = fixes.reduce((a, f) => ({ ...a, [f.kind]: (a[f.kind] || 0) + 1 }), {});
+      runLog.logText(`[planner] structural pass: ${fixes.length} fix(es) — ${JSON.stringify(byKind)}`);
+    }
+  }
+
   const planId = await savePlan(projectDir, plan);
   const { plansDir } = await import("../../plan/plan-store.js");
   const path = await import("node:path");

--- a/src/plan/plan-structural-pass.js
+++ b/src/plan/plan-structural-pass.js
@@ -1,0 +1,122 @@
+// KJC-TSK-0399: deterministic post-review pass — cycles, orphan refs,
+// missing short_id. No LLM. Fix shape: { kind, huId?, ...details };
+// stored in plan.review.structural_fixes.
+
+export function runStructuralPass(plan) {
+  const fixes = [];
+  if (!plan || !Array.isArray(plan.hus) || plan.hus.length === 0) {
+    return { fixes, modified: false };
+  }
+  fixes.push(...removeOrphanRefs(plan));
+  fixes.push(...breakCycles(plan));
+  fixes.push(...assignMissingShortIds(plan));
+  const modified = fixes.length > 0;
+  if (modified) plan.updatedAt = new Date().toISOString();
+  return { fixes, modified };
+}
+
+export function removeOrphanRefs(plan) {
+  const fixes = [];
+  const known = new Set(plan.hus.map((h) => h.id));
+  for (const hu of plan.hus) {
+    const removed = [];
+    if (Array.isArray(hu.blocked_by) && hu.blocked_by.length > 0) {
+      hu.blocked_by = hu.blocked_by.filter((d) => {
+        if (known.has(d)) return true;
+        removed.push(d); return false;
+      });
+    }
+    if (removed.length > 0) fixes.push({ kind: "orphan_ref_removed", huId: hu.id, removed });
+  }
+  return fixes;
+}
+
+export function breakCycles(plan) {
+  const fixes = [];
+  let cycles = findCycles(plan.hus);
+  let budget = plan.hus.length;
+  while (cycles.length > 0 && budget-- > 0) {
+    const cycle = cycles[0];
+    const dropped = breakCycle(plan, cycle);
+    if (!dropped) break;
+    fixes.push({ kind: "cycle_break", cycle: [...cycle], droppedEdge: dropped });
+    cycles = findCycles(plan.hus);
+  }
+  return fixes;
+}
+
+export function findCycles(hus) {
+  const graph = new Map();
+  for (const hu of hus) graph.set(hu.id, Array.isArray(hu.blocked_by) ? hu.blocked_by : []);
+  const cycles = [];
+  const seen = new Set();
+  const onStack = new Set();
+  const stack = [];
+  function dfs(node) {
+    onStack.add(node); stack.push(node); seen.add(node);
+    for (const dep of graph.get(node) || []) {
+      if (!graph.has(dep)) continue;
+      if (onStack.has(dep)) {
+        const idx = stack.indexOf(dep);
+        if (idx >= 0) {
+          const cycle = stack.slice(idx);
+          if (!cycles.some((c) => sameCycle(c, cycle))) cycles.push(cycle);
+        }
+      } else if (!seen.has(dep)) dfs(dep);
+    }
+    stack.pop(); onStack.delete(node);
+  }
+  for (const id of graph.keys()) if (!seen.has(id)) dfs(id);
+  return cycles;
+}
+
+function sameCycle(a, b) {
+  if (a.length !== b.length) return false;
+  return [...a].sort().join("|") === [...b].sort().join("|");
+}
+
+// Heurística: dropea arista cuyo origen tiene menos incoming. Tiebreak edge.to.
+export function breakCycle(plan, cycle) {
+  const incoming = new Map();
+  for (const hu of plan.hus) {
+    for (const dep of hu.blocked_by || []) incoming.set(dep, (incoming.get(dep) || 0) + 1);
+  }
+  const edges = [];
+  for (let i = 0; i < cycle.length; i++) {
+    const from = cycle[i];
+    const to = cycle[(i + 1) % cycle.length];
+    const hu = plan.hus.find((h) => h.id === from);
+    if (hu && Array.isArray(hu.blocked_by) && hu.blocked_by.includes(to)) edges.push({ from, to });
+  }
+  if (edges.length === 0) return null;
+  edges.sort((a, b) => {
+    const d = (incoming.get(a.from) || 0) - (incoming.get(b.from) || 0);
+    return d !== 0 ? d : a.to.localeCompare(b.to);
+  });
+  const drop = edges[0];
+  const hu = plan.hus.find((h) => h.id === drop.from);
+  hu.blocked_by = hu.blocked_by.filter((d) => d !== drop.to);
+  return drop;
+}
+
+export function assignMissingShortIds(plan) {
+  const fixes = [];
+  const used = new Set();
+  let maxAuto = 0;
+  for (const hu of plan.hus) {
+    if (!hu.short_id) continue;
+    used.add(hu.short_id);
+    const m = String(hu.short_id).match(/^AUTOFIX-(\d+)$/);
+    if (m) maxAuto = Math.max(maxAuto, Number(m[1]));
+  }
+  for (const hu of plan.hus) {
+    if (hu.short_id) continue;
+    maxAuto += 1;
+    const candidate = `AUTOFIX-${String(maxAuto).padStart(3, "0")}`;
+    if (used.has(candidate)) continue;
+    hu.short_id = candidate;
+    used.add(candidate);
+    fixes.push({ kind: "short_id_assigned", huId: hu.id, assigned: candidate });
+  }
+  return fixes;
+}

--- a/tests/plan/plan-structural-pass.test.js
+++ b/tests/plan/plan-structural-pass.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  runStructuralPass, findCycles, breakCycle,
+  removeOrphanRefs, assignMissingShortIds,
+} from "../../src/plan/plan-structural-pass.js";
+
+// KJC-TSK-0399: post-review structural integrity pass (no LLM).
+// Cubre: ciclo simple A↔B, ciclo de 3, short_id auto, ref huérfana, no-op.
+
+const makePlan = (hus) => ({
+  planId: "test",
+  hus: hus.map((h) => ({ blocked_by: [], reuse: [], short_id: null, ...h })),
+  updatedAt: "2026-05-14T00:00:00Z",
+});
+
+describe("findCycles", () => {
+  it("detecta ciclo simple A↔B", () => {
+    const cycles = findCycles([
+      { id: "A", blocked_by: ["B"] }, { id: "B", blocked_by: ["A"] },
+    ]);
+    expect(new Set(cycles[0])).toEqual(new Set(["A", "B"]));
+  });
+  it("detecta ciclo de 3 A→B→C→A", () => {
+    const cycles = findCycles([
+      { id: "A", blocked_by: ["C"] }, { id: "B", blocked_by: ["A"] }, { id: "C", blocked_by: ["B"] },
+    ]);
+    expect(new Set(cycles[0])).toEqual(new Set(["A", "B", "C"]));
+  });
+  it("plan acíclico → []", () => {
+    expect(findCycles([
+      { id: "A", blocked_by: [] }, { id: "B", blocked_by: ["A"] },
+    ])).toEqual([]);
+  });
+  it("ignora refs huérfanas", () => {
+    expect(findCycles([{ id: "A", blocked_by: ["GHOST"] }])).toEqual([]);
+  });
+});
+
+describe("breakCycle", () => {
+  it("prefiere romper la arista de la HU con menos incoming", () => {
+    const plan = makePlan([
+      { id: "A", blocked_by: ["B"] }, { id: "B", blocked_by: ["A"] },
+      { id: "X", blocked_by: ["A"] }, { id: "Y", blocked_by: ["A"] },
+    ]);
+    expect(breakCycle(plan, ["A", "B"]).from).toBe("B");
+  });
+});
+
+describe("removeOrphanRefs", () => {
+  it("limpia blocked_by con HU inexistente", () => {
+    const plan = makePlan([
+      { id: "A", blocked_by: ["GHOST", "B"] }, { id: "B" },
+    ]);
+    const fixes = removeOrphanRefs(plan);
+    expect(fixes[0]).toMatchObject({ kind: "orphan_ref_removed", huId: "A", removed: ["GHOST"] });
+    expect(plan.hus.find((h) => h.id === "A").blocked_by).toEqual(["B"]);
+  });
+});
+
+describe("assignMissingShortIds", () => {
+  it("asigna AUTOFIX-NNN continuando la serie", () => {
+    const plan = makePlan([
+      { id: "A", short_id: "AUTOFIX-007" },
+      { id: "B" }, { id: "C", short_id: "USER-001" }, { id: "D" },
+    ]);
+    assignMissingShortIds(plan);
+    expect(plan.hus.find((h) => h.id === "B").short_id).toBe("AUTOFIX-008");
+    expect(plan.hus.find((h) => h.id === "D").short_id).toBe("AUTOFIX-009");
+    expect(plan.hus.find((h) => h.id === "C").short_id).toBe("USER-001");
+  });
+});
+
+describe("runStructuralPass", () => {
+  it("plan limpio → no-op", () => {
+    const plan = makePlan([
+      { id: "A", short_id: "X-001" }, { id: "B", short_id: "X-002", blocked_by: ["A"] },
+    ]);
+    const r = runStructuralPass(plan);
+    expect(r).toEqual({ fixes: [], modified: false });
+  });
+  it("ciclo + ref huérfana + short_id missing → 3 categorías de fix", () => {
+    const plan = makePlan([
+      { id: "A", blocked_by: ["B", "GHOST"] },
+      { id: "B", short_id: "USER-001", blocked_by: ["A"] },
+    ]);
+    const r = runStructuralPass(plan);
+    expect(r.modified).toBe(true);
+    const kinds = new Set(r.fixes.map((f) => f.kind));
+    expect(kinds.has("orphan_ref_removed")).toBe(true);
+    expect(kinds.has("cycle_break")).toBe(true);
+    expect(kinds.has("short_id_assigned")).toBe(true);
+    expect(findCycles(plan.hus)).toEqual([]);
+  });
+  it("plan vacío → no-op", () => {
+    expect(runStructuralPass({ planId: "x", hus: [] })).toEqual({ fixes: [], modified: false });
+  });
+});


### PR DESCRIPTION
## Summary

- Nuevo módulo determinístico `src/plan/plan-structural-pass.js` que corre después del self-fix LLM loop. Cubre ciclos, refs huérfanas, short_id missing — problemas de grafo que el LLM hace mal.
- Resultados en `plan.review.structural_fixes: [{ kind, huId?, ... }]`.
- Runs siempre (cheap, sin red), agnóstico al provider.

## API

```js
runStructuralPass(plan) → { fixes, modified }
```

Internamente:
- `removeOrphanRefs(plan)` — drop blocked_by refs a HUs inexistentes
- `findCycles(hus)` / `breakCycles(plan)` — DFS + heurística (drop edge cuyo origen tiene menos incoming, tiebreak edge.to)
- `assignMissingShortIds(plan)` — `AUTOFIX-NNN` continuando max existente

## Test plan

- [x] Ciclo simple A↔B detectado y roto
- [x] Ciclo de 3 A→B→C→A detectado
- [x] Heurística incoming dropea correctamente
- [x] Ref huérfana eliminada
- [x] short_id auto continúa serie desde AUTOFIX-007 → AUTOFIX-008
- [x] Plan limpio → no-op
- [x] Plan vacío → no-op
- [x] All 222 plan tests pass
- [x] lint clean

## LOC

233 LOC. Por encima de 200 budget (16% over) pero atómico: módulo + tests + wiring son cohesivos. Justifica `large-pr-justified`.