### PR TITLE
feat(policies): skip Sonar/TDD/tests en HUs no-code (KJC-TSK-0400)

### DIFF
--- a/src/guards/policy-resolver.js
+++ b/src/guards/policy-resolver.js
@@ -6,7 +6,14 @@
  * @typedef {import("../types/config.js").KarajanConfig} KarajanConfig
  */
 
-export const VALID_TASK_TYPES = new Set(["sw", "infra", "doc", "add-tests", "refactor", "audit", "analysis", "no-code"]);
+// KJC-TSK-0400: spike y research añadidos como tipos no-code. Comparten
+// las defaults restrictivas (tdd/sonar/testsRequired off) porque NO
+// producen código que medir: un SPIKE es un .md de decisión, un research
+// es una nota de investigación. Forzar Sonar les hace fallar siempre.
+export const VALID_TASK_TYPES = new Set([
+  "sw", "infra", "doc", "add-tests", "refactor",
+  "audit", "analysis", "no-code", "spike", "research",
+]);
 
 export const DEFAULT_POLICIES = {
   sw:        { tdd: true,  sonar: true,  reviewer: true, testsRequired: true  },
@@ -17,7 +24,37 @@ export const DEFAULT_POLICIES = {
   audit:     { tdd: false, sonar: false, reviewer: false, testsRequired: false, coderRequired: false },
   analysis:  { tdd: false, sonar: false, reviewer: false, testsRequired: false, coderRequired: false },
   "no-code": { tdd: false, sonar: false, reviewer: true, testsRequired: false, coderRequired: true },
+  spike:     { tdd: false, sonar: false, reviewer: true, testsRequired: false, coderRequired: true },
+  research:  { tdd: false, sonar: false, reviewer: true, testsRequired: false, coderRequired: true },
 };
+
+// KJC-TSK-0400: si el title arranca con [SPIKE] / [DOC] / [RESEARCH] /
+// [NOCODE], inferimos el task_type del prefijo. Pensado para casos donde
+// el planner emite task_type='sw' por defecto pero el title declara
+// claramente que la HU no produce código. Devuelve null si no hay match.
+const TITLE_PREFIX_TO_TYPE = {
+  SPIKE: "spike",
+  RESEARCH: "research",
+  DOC: "doc",
+  NOCODE: "no-code",
+  "NO-CODE": "no-code",
+};
+
+export function inferTaskTypeFromTitle(title) {
+  if (typeof title !== "string") return null;
+  const m = title.match(/^\s*\[([A-Z][A-Z-]+)\]/);
+  if (!m) return null;
+  return TITLE_PREFIX_TO_TYPE[m[1].toUpperCase()] || null;
+}
+
+// KJC-TSK-0400: dado un HU del plan, devuelve el task_type efectivo:
+// explícito en story.task_type si es válido, si no inferido del title.
+// Fallback 'sw' (conservador, mantiene gates activos cuando hay duda).
+export function effectiveTaskType(story) {
+  if (!story || typeof story !== "object") return "sw";
+  if (VALID_TASK_TYPES.has(story.task_type)) return story.task_type;
+  return inferTaskTypeFromTitle(story.title) || "sw";
+}
 
 const FALLBACK_TYPE = "sw";
 

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -91,15 +91,23 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
         ctx.brainCtx.feedbackQueue = fresh.feedbackQueue;
         ctx.brainCtx.verificationTracker = fresh.verificationTracker;
       }
-      // Apply per-HU policies based on task_type (infra skips reviewer/sonar/tdd)
-      const { applyPolicies } = await import("../../guards/policy-resolver.js");
-      const huPolicies = applyPolicies({ taskType: story.task_type, policies: ctx.config.policies });
+      // Apply per-HU policies based on task_type (infra skips reviewer/sonar/tdd).
+      // KJC-TSK-0400: `effectiveTaskType` mira primero story.task_type y, si
+      // no es válido, infiere del prefijo del title ([SPIKE], [DOC]…). Así
+      // un HU con title "[SPIKE] Decidir auth" entra automáticamente a las
+      // policies de spike (sin Sonar/TDD/tests).
+      const { applyPolicies, effectiveTaskType } = await import("../../guards/policy-resolver.js");
+      const resolvedTaskType = effectiveTaskType(story);
+      if (resolvedTaskType !== story.task_type) {
+        logger.info(`HU ${story.id}: task_type inferido del title → ${resolvedTaskType} (era ${story.task_type || "null"})`);
+      }
+      const huPolicies = applyPolicies({ taskType: resolvedTaskType, policies: ctx.config.policies });
       const savedFlags = { ...ctx.pipelineFlags };
       if (!huPolicies.reviewer) ctx.pipelineFlags.reviewerEnabled = false;
       if (!huPolicies.tdd) ctx.config.development = { ...ctx.config.development, methodology: "standard", require_test_changes: false };
       if (!huPolicies.sonar) ctx.config.sonarqube = { ...ctx.config.sonarqube, enabled: false };
       if (!huPolicies.testsRequired) ctx.pipelineFlags.testerEnabled = false;
-      logger.info(`HU ${story.id} (${story.task_type}): policies → reviewer=${huPolicies.reviewer}, tdd=${huPolicies.tdd}, sonar=${huPolicies.sonar}, tests=${huPolicies.testsRequired}`);
+      logger.info(`HU ${story.id} (${resolvedTaskType}): policies → reviewer=${huPolicies.reviewer}, tdd=${huPolicies.tdd}, sonar=${huPolicies.sonar}, tests=${huPolicies.testsRequired}`);
 
       const branchName = await prepareHuBranch({ story, huBranches, config: ctx.config, logger });
       const projectDir = ctx.config.projectDir || process.cwd();

--- a/tests/guards/policy-resolver.test.js
+++ b/tests/guards/policy-resolver.test.js
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { resolvePolicies, applyPolicies, VALID_TASK_TYPES, DEFAULT_POLICIES } from "../../src/guards/policy-resolver.js";
+import {
+  resolvePolicies, applyPolicies, VALID_TASK_TYPES, DEFAULT_POLICIES,
+  inferTaskTypeFromTitle, effectiveTaskType,
+} from "../../src/guards/policy-resolver.js";
 
 describe("policy-resolver", () => {
   describe("VALID_TASK_TYPES", () => {
-    it("contains exactly the eight expected task types", () => {
-      expect(VALID_TASK_TYPES).toEqual(new Set(["sw", "infra", "doc", "add-tests", "refactor", "audit", "analysis", "no-code"]));
+    it("contains all valid task types (sw + infra + doc + add-tests + refactor + audit + analysis + no-code + spike + research)", () => {
+      // KJC-TSK-0400: añadidos spike y research como no-code variants.
+      expect(VALID_TASK_TYPES).toEqual(new Set([
+        "sw", "infra", "doc", "add-tests", "refactor",
+        "audit", "analysis", "no-code", "spike", "research",
+      ]));
     });
   });
 
@@ -151,6 +158,63 @@ describe("policy-resolver", () => {
       const before = { ...DEFAULT_POLICIES.sw };
       resolvePolicies("sw", { sw: { tdd: false } });
       expect(DEFAULT_POLICIES.sw).toEqual(before);
+    });
+  });
+
+  // KJC-TSK-0400: spike y research como nuevos tipos no-code +
+  // inferencia de task_type desde prefijo del title.
+  describe("spike / research task types", () => {
+    it("spike → todo en false excepto reviewer (decisión arquitectónica)", () => {
+      expect(resolvePolicies("spike")).toEqual({
+        tdd: false, sonar: false, reviewer: true, testsRequired: false, coderRequired: true,
+      });
+    });
+    it("research → mismos defaults que spike", () => {
+      expect(resolvePolicies("research")).toEqual(resolvePolicies("spike"));
+    });
+  });
+
+  describe("inferTaskTypeFromTitle", () => {
+    it("[SPIKE] prefix → spike", () => {
+      expect(inferTaskTypeFromTitle("[SPIKE] Decidir auth strategy")).toBe("spike");
+    });
+    it("[DOC] prefix → doc", () => {
+      expect(inferTaskTypeFromTitle("[DOC] Escribir README")).toBe("doc");
+    });
+    it("[RESEARCH] prefix → research", () => {
+      expect(inferTaskTypeFromTitle("[RESEARCH] Comparar libs de PDF")).toBe("research");
+    });
+    it("[NOCODE] y [NO-CODE] → no-code", () => {
+      expect(inferTaskTypeFromTitle("[NOCODE] Subir assets")).toBe("no-code");
+      expect(inferTaskTypeFromTitle("[NO-CODE] Subir assets")).toBe("no-code");
+    });
+    it("sin prefijo → null", () => {
+      expect(inferTaskTypeFromTitle("Implementar login")).toBeNull();
+    });
+    it("prefijo desconocido → null", () => {
+      expect(inferTaskTypeFromTitle("[FOOBAR] cosa")).toBeNull();
+    });
+    it("entrada no-string → null", () => {
+      expect(inferTaskTypeFromTitle(null)).toBeNull();
+      expect(inferTaskTypeFromTitle(undefined)).toBeNull();
+    });
+  });
+
+  describe("effectiveTaskType", () => {
+    it("respeta task_type explícito si es válido", () => {
+      expect(effectiveTaskType({ task_type: "infra", title: "[SPIKE] x" })).toBe("infra");
+    });
+    it("infiere del title cuando task_type es null", () => {
+      expect(effectiveTaskType({ task_type: null, title: "[SPIKE] x" })).toBe("spike");
+    });
+    it("infiere del title cuando task_type es desconocido", () => {
+      expect(effectiveTaskType({ task_type: "junk", title: "[DOC] x" })).toBe("doc");
+    });
+    it("fallback sw cuando no hay nada que inferir", () => {
+      expect(effectiveTaskType({ title: "Implementar login" })).toBe("sw");
+    });
+    it("story null → sw conservador", () => {
+      expect(effectiveTaskType(null)).toBe("sw");
     });
   });
 });


### PR DESCRIPTION
## Summary

Un HU [SPIKE] / [DOC] / [RESEARCH] no produce código → forzar Sonar hace que fallen siempre aunque la decisión sea correcta.

- **policy-resolver**: nuevos types `spike` y `research` con defaults restrictivas (todo off excepto reviewer).
- **inferTaskTypeFromTitle**: si title arranca con `[SPIKE]` / `[DOC]` / `[RESEARCH]` / `[NOCODE]` / `[NO-CODE]` inferimos task_type.
- **effectiveTaskType**: explicit válido > inferred del title > fallback `sw`.
- **run-hu-batch** usa `effectiveTaskType` antes de `applyPolicies` y logea cuando hubo inferencia.

## Test plan

- [x] spike/research defaults
- [x] Inferencia [SPIKE] → spike, [DOC] → doc, [RESEARCH] → research, [NOCODE]/[NO-CODE] → no-code
- [x] Prefijo desconocido → null
- [x] Override explícito gana sobre inferencia
- [x] Story null → fallback sw
- [x] 40 tests passing
- [x] lint clean