### PR TITLE
feat(hu-board): validación estructural en PATCH blocked_by (KJC-TSK-0401)

### DIFF
--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -21,6 +21,7 @@ import { spawn } from 'node:child_process';
 import { trackRun, untrack } from './run-tracker.js';
 import { fileURLToPath } from 'node:url';
 import { updateHuStatus, certifyAllHus, updateHu } from '../../../src/plan/plan-hu-ops.js';
+import { validateBlockedByChange } from '../../../src/plan/plan-validation.js';
 import { syncPlanFile } from './sync.js';
 import { getDb } from './db.js';
 
@@ -149,6 +150,15 @@ export function setHuFields({ planId, huId, patch, projectId }) {
 
   const plan = readPlan(filePath);
   if (!Array.isArray(plan.hus)) return { ok: false, error: 'plan has no hus[]' };
+
+  // KJC-TSK-0401: si el patch toca blocked_by, validar antes de
+  // persistir. Rechazar refs huérfanas, auto-deps y ciclos.
+  if (patch && Object.prototype.hasOwnProperty.call(patch, 'blocked_by')) {
+    const result = validateBlockedByChange(plan, huId, patch.blocked_by);
+    if (!result.ok) {
+      return { ok: false, error: result.error, code: 'INVALID_BLOCKED_BY', cycle: result.cycle };
+    }
+  }
 
   const updated = updateHu(plan, huId, patch || {});
   if (!updated) return { ok: false, error: `hu not found: ${huId}` };

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -558,7 +558,15 @@ router.patch('/stories/:id', (req, res) => {
         patch: fieldPatch,
         projectId: row.project_id,
       });
-      if (!fieldResult.ok) return res.status(404).json({ error: fieldResult.error });
+      if (!fieldResult.ok) {
+        // KJC-TSK-0401: validación de blocked_by devuelve 400 con cycle?
+        // info para que el board destaque la cadena en la UI. Resto de
+        // fallos siguen devolviendo 404 (plan / hu no encontrados).
+        if (fieldResult.code === 'INVALID_BLOCKED_BY') {
+          return res.status(400).json({ error: fieldResult.error, cycle: fieldResult.cycle });
+        }
+        return res.status(404).json({ error: fieldResult.error });
+      }
       updatedHu = fieldResult.hu;
     }
 

--- a/src/plan/plan-validation.js
+++ b/src/plan/plan-validation.js
@@ -1,0 +1,82 @@
+// KJC-TSK-0401: validación estructural de cambios en blocked_by desde
+// el board. Se usa antes de persistir un PATCH /api/stories/:id para
+// que el usuario no pueda crear ciclos ni referencias huérfanas. La UI
+// preview la usa para deshabilitar las opciones que romperían el plan.
+
+/**
+ * Verifica que `newBlockedBy` para `huId` no rompa la estructura del plan.
+ *
+ * Reglas:
+ *   1. Cada ref en newBlockedBy debe existir como hu.id en el plan.
+ *   2. No se permite auto-dependencia (huId ∈ newBlockedBy).
+ *   3. Aplicar el cambio NO debe crear un ciclo en el grafo blocked_by.
+ *
+ * @param {object} plan
+ * @param {string} huId
+ * @param {string[]} newBlockedBy
+ * @returns {{ ok: true } | { ok: false, error: string, cycle?: string[] }}
+ */
+export function validateBlockedByChange(plan, huId, newBlockedBy) {
+  if (!plan || !Array.isArray(plan.hus)) {
+    return { ok: false, error: "plan inválido" };
+  }
+  const hu = plan.hus.find((h) => h.id === huId);
+  if (!hu) return { ok: false, error: `HU no encontrada: ${huId}` };
+  if (!Array.isArray(newBlockedBy)) {
+    return { ok: false, error: "blocked_by debe ser un array" };
+  }
+  const ids = new Set(plan.hus.map((h) => h.id));
+  for (const ref of newBlockedBy) {
+    if (typeof ref !== "string") {
+      return { ok: false, error: "blocked_by contiene un valor no-string" };
+    }
+    if (ref === huId) {
+      return { ok: false, error: `auto-dependencia no permitida: ${huId}` };
+    }
+    if (!ids.has(ref)) {
+      return { ok: false, error: `HU referenciada inexistente: ${ref}` };
+    }
+  }
+  // Simular el cambio sobre una copia del grafo y buscar ciclos.
+  const graph = new Map();
+  for (const h of plan.hus) {
+    graph.set(h.id, h.id === huId ? [...newBlockedBy] : (Array.isArray(h.blocked_by) ? [...h.blocked_by] : []));
+  }
+  const cycle = findCycleContaining(graph, huId);
+  if (cycle) {
+    return { ok: false, error: `Ciclo detectado: ${cycle.join(" → ")} → ${cycle[0]}`, cycle };
+  }
+  return { ok: true };
+}
+
+/**
+ * DFS desde `start` siguiendo aristas blocked_by. Devuelve el primer
+ * ciclo encontrado que pase por `start`, o null. La búsqueda no es
+ * exhaustiva — basta con detectar UN ciclo para rechazar el cambio.
+ *
+ * @param {Map<string,string[]>} graph
+ * @param {string} start
+ * @returns {string[]|null}
+ */
+function findCycleContaining(graph, start) {
+  const onStack = new Set();
+  const visited = new Set();
+  const stack = [];
+  function dfs(node) {
+    if (onStack.has(node)) {
+      const idx = stack.indexOf(node);
+      if (idx >= 0) return stack.slice(idx);
+      return [node];
+    }
+    if (visited.has(node)) return null;
+    onStack.add(node); stack.push(node); visited.add(node);
+    for (const dep of graph.get(node) || []) {
+      if (!graph.has(dep)) continue;
+      const found = dfs(dep);
+      if (found) return found;
+    }
+    stack.pop(); onStack.delete(node);
+    return null;
+  }
+  return dfs(start);
+}

--- a/tests/plan/plan-validation.test.js
+++ b/tests/plan/plan-validation.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { validateBlockedByChange } from "../../src/plan/plan-validation.js";
+
+// KJC-TSK-0401: validación de cambios en blocked_by para edición desde
+// el board. Rechaza auto-deps, refs huérfanas y ciclos.
+
+const makePlan = (hus) => ({ planId: "p", hus: hus.map((h) => ({ blocked_by: [], ...h })) });
+
+describe("validateBlockedByChange", () => {
+  it("acepta cambio válido sin ciclos ni huérfanos", () => {
+    const plan = makePlan([
+      { id: "A" }, { id: "B" }, { id: "C" },
+    ]);
+    expect(validateBlockedByChange(plan, "A", ["B"])).toEqual({ ok: true });
+    expect(validateBlockedByChange(plan, "C", ["A", "B"])).toEqual({ ok: true });
+  });
+
+  it("rechaza array vacío como válido (no es error)", () => {
+    const plan = makePlan([{ id: "A", blocked_by: ["B"] }, { id: "B" }]);
+    expect(validateBlockedByChange(plan, "A", [])).toEqual({ ok: true });
+  });
+
+  it("rechaza referencia a HU inexistente", () => {
+    const plan = makePlan([{ id: "A" }, { id: "B" }]);
+    const r = validateBlockedByChange(plan, "A", ["GHOST"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/inexistente.*GHOST/);
+  });
+
+  it("rechaza auto-dependencia A → A", () => {
+    const plan = makePlan([{ id: "A" }]);
+    const r = validateBlockedByChange(plan, "A", ["A"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/auto-dependencia/);
+  });
+
+  it("rechaza ciclo directo A↔B (A bloqueada por B, intento B bloqueada por A)", () => {
+    const plan = makePlan([
+      { id: "A", blocked_by: ["B"] }, { id: "B" },
+    ]);
+    const r = validateBlockedByChange(plan, "B", ["A"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ciclo detectado/);
+    expect(r.cycle).toBeDefined();
+  });
+
+  it("rechaza ciclo indirecto A→B→C→A", () => {
+    const plan = makePlan([
+      { id: "A", blocked_by: ["C"] },
+      { id: "B", blocked_by: ["A"] },
+      { id: "C" },
+    ]);
+    const r = validateBlockedByChange(plan, "C", ["B"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Ciclo detectado/);
+  });
+
+  it("rechaza payload no-array", () => {
+    const plan = makePlan([{ id: "A" }]);
+    const r = validateBlockedByChange(plan, "A", "B");
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/array/);
+  });
+
+  it("rechaza valor no-string dentro del array", () => {
+    const plan = makePlan([{ id: "A" }, { id: "B" }]);
+    const r = validateBlockedByChange(plan, "A", [123]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no-string/);
+  });
+
+  it("rechaza HU no presente en el plan", () => {
+    const plan = makePlan([{ id: "A" }]);
+    const r = validateBlockedByChange(plan, "ZZZ", []);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no encontrada/);
+  });
+
+  it("plan inválido (sin hus[]) → error", () => {
+    expect(validateBlockedByChange(null, "A", []).ok).toBe(false);
+    expect(validateBlockedByChange({}, "A", []).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

El board permitía editar blocked_by sin validar — usuario podía crear ciclos o referenciar HUs inexistentes, dejando el plan no ejecutable hasta editar el JSON a mano.

### Backend
- Nuevo módulo `src/plan/plan-validation.js` con `validateBlockedByChange(plan, huId, newBlockedBy)`.
- Rechaza: array no-array, valores no-string, auto-deps, refs huérfanas, ciclos.
- Devuelve `{ ok, error, cycle? }` para que la UI destaque la cadena del ciclo.

### Wiring
- `plan-mutations.setHuFields`: valida antes de `updateHu` cuando patch toca blocked_by. Si falla → code `INVALID_BLOCKED_BY`.
- `routes/api.PATCH /stories/:id`: HTTP 400 con `{ error, cycle }` cuando es validación; 404 sigue para resto.

## Test plan

- [x] 10 tests unit en `plan-validation.test.js` (válido, vacío, huérfano, auto-dep, ciclo directo, ciclo indirecto, no-array, no-string, HU inexistente, plan inválido)
- [x] hu-board api + plan-mutations tests siguen pasando (68 tests)
- [x] lint clean

## Out of scope (próxima PR)

- UI multi-select con search + tooltip de "crearía ciclo" en el modal Edit. El backend ya está listo para soportarlo (devuelve cycle en el 400).