### PR TITLE
feat(plan): kj plan fix [planId] [--prompt] (KJC-TSK-0402)

### DIFF
--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -8,6 +8,7 @@ import {
   planAddHuCommand,
   planRemoveHuCommand,
   planMigrateResultCommand,
+  planFixCommand,
 } from "../commands/plan.js";
 import { parseCanvasMarkdown } from "../canvas/parse-md.js";
 import { validateCanvas } from "../canvas/validate.js";
@@ -150,6 +151,20 @@ export function registerPlan(program, { pkgVersion }) {
       await planRemoveHuCommand({ config, planId, huId });
     });
   });
+
+  // KJC-TSK-0402: re-ejecuta reviewer + self-fix + structural pass sobre
+  // un plan existente. Acepta --prompt opcional con feedback humano que
+  // el reviewer inyecta como contexto extra antes de revisar.
+  plan.command("fix")
+    .description("Relanzar self-fix loop sobre plan existente (con --prompt opcional)")
+    .argument("<planId>")
+    .option("--prompt <text>", "Feedback del usuario para guiar al reviewer")
+    .option("--json", "Output JSON con before/after counts")
+    .action(async (planId, flags) => {
+      await withConfig(pkgVersion, "plan", flags, async ({ config, logger }) => {
+        await planFixCommand({ config, planId, prompt: flags.prompt, logger, json: flags.json });
+      });
+    });
 
   // KJC-TSK-0394 step 4: migración one-shot que siembra `result` en las
   // HUs de los plan files existentes (basado en su status legacy). Solo

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -11,5 +11,6 @@ export {
   planAddHuCommand,
   planRemoveHuCommand,
   planMigrateResultCommand,
+  planFixCommand,
   planCommand,
 } from "./plan/index.js";

--- a/src/commands/plan/fix.js
+++ b/src/commands/plan/fix.js
@@ -1,0 +1,99 @@
+// KJC-TSK-0402: relanzar el self-fix loop sobre un plan ya generado,
+// opcionalmente con feedback humano que guía al reviewer hacia los
+// puntos débiles que la primera pasada no detectó. NO regenera desde
+// cero — preserva el trabajo previo.
+
+import { createAgent } from "../../agents/index.js";
+import { assertAgentsAvailable } from "../../agents/availability.js";
+import { resolveRole } from "../../config.js";
+import { createCliProgressReporter } from "../../utils/cli-progress.js";
+import { reviewPlan, findingsCount, findingsCountByType } from "../../plan/plan-reviewer.js";
+import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js";
+import { runStructuralPass } from "../../plan/plan-structural-pass.js";
+import { loadPlan, savePlan } from "../../plan/plan-store.js";
+
+export async function planFixCommand({ config, planId, prompt, logger, json }) {
+  const projectDir = config.projectDir || process.cwd();
+  const plan = await loadPlan(projectDir, planId);
+  if (!plan) throw new Error(`Plan no encontrado: ${planId}`);
+  if (!Array.isArray(plan.hus) || plan.hus.length === 0) {
+    throw new Error(`Plan ${planId} no tiene HUs.`);
+  }
+
+  const before = { hus: plan.hus.length, deps: plan.hus.reduce((a, h) => a + (h.blocked_by?.length || 0), 0) };
+
+  const plannerRole = resolveRole(config, "planner");
+  await assertAgentsAvailable([plannerRole.provider]);
+  const planner = createAgent(plannerRole.provider, config, logger);
+  const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
+    ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000) : undefined;
+  const timeoutMs = Number(config?.session?.max_planner_minutes) > 0
+    ? Math.round(Number(config.session.max_planner_minutes) * 60 * 1000) : undefined;
+
+  // Reviewer con prompt opcional del usuario inyectado como contexto extra.
+  // El prompt se prepende al task original para que el reviewer LLM lo lea
+  // antes de la HU list.
+  const enrichedTask = prompt
+    ? `${plan.task || ""}\n\n## USER FEEDBACK (priorizar estos puntos)\n${prompt}\n`
+    : plan.task || "";
+
+  const reviewProgress = createCliProgressReporter({ role: "plan-fix:reviewer", quiet: Boolean(json) });
+  const review = await reviewPlan({
+    agent: planner, task: enrichedTask, hus: plan.hus,
+    onOutput: reviewProgress.onOutput, silenceTimeoutMs, timeoutMs,
+  });
+  reviewProgress.finish(review.ok ? "done" : "failed");
+  if (!review.ok) throw new Error(`Reviewer falló: ${review.error}`);
+  plan.review = review.findings;
+  let count = findingsCount(review.findings);
+  if (!json) process.stderr.write(`Reviewer encontró ${count} item(s).\n`);
+
+  // Self-fix loop con smart convergence guard (mismo que generate.js).
+  const maxIter = 4;
+  for (let i = 1; i <= maxIter && count > 0; i++) {
+    const husSnapshot = JSON.parse(JSON.stringify(plan.hus));
+    const reviewSnapshot = JSON.parse(JSON.stringify(plan.review));
+    const fixProgress = createCliProgressReporter({ role: `plan-fix:iter ${i}`, quiet: Boolean(json) });
+    const fix = await applyReviewerFeedback({
+      agent: planner, task: enrichedTask, hus: plan.hus, findings: plan.review,
+      onOutput: fixProgress.onOutput, silenceTimeoutMs, timeoutMs,
+    });
+    if (!fix.ok) { fixProgress.finish("failed"); break; }
+    const ops = applyFixerPatch(plan, fix.patch);
+    if (ops.added + ops.depsAdded + ops.deleted === 0) { fixProgress.finish("done"); break; }
+    const review2 = await reviewPlan({
+      agent: planner, task: enrichedTask, hus: plan.hus,
+      onOutput: fixProgress.onOutput, silenceTimeoutMs, timeoutMs,
+    });
+    if (!review2.ok) { plan.hus = husSnapshot; plan.review = reviewSnapshot; fixProgress.finish("failed"); break; }
+    const b = findingsCountByType(reviewSnapshot);
+    const a = findingsCountByType(review2.findings);
+    const accept = a.priority < b.priority || (a.priority === b.priority && a.total <= b.total);
+    if (!accept) { plan.hus = husSnapshot; plan.review = reviewSnapshot; fixProgress.finish("reverted"); break; }
+    plan.review = review2.findings;
+    count = a.total;
+    fixProgress.finish("done");
+  }
+
+  // Structural integrity pass determinístico al final.
+  const { fixes: structuralFixes } = runStructuralPass(plan);
+  if (structuralFixes.length > 0) {
+    if (!plan.review) plan.review = {};
+    plan.review.structural_fixes = structuralFixes;
+  }
+
+  await savePlan(projectDir, plan);
+  const after = { hus: plan.hus.length, deps: plan.hus.reduce((a, h) => a + (h.blocked_by?.length || 0), 0) };
+
+  if (json) {
+    console.log(JSON.stringify({ planId, before, after, structuralFixes }, null, 2));
+    return;
+  }
+  const diffHus = after.hus - before.hus;
+  const diffDeps = after.deps - before.deps;
+  const structuralSummary = structuralFixes.length > 0
+    ? `, ${structuralFixes.length} structural fix(es)` : "";
+  console.log(
+    `kj plan fix ${planId}: ${diffHus >= 0 ? "+" : ""}${diffHus} HUs, ${diffDeps >= 0 ? "+" : ""}${diffDeps} deps${structuralSummary}. Findings: ${count} restantes.`
+  );
+}

--- a/src/commands/plan/index.js
+++ b/src/commands/plan/index.js
@@ -10,6 +10,7 @@ export { planDeleteCommand } from "./delete.js";
 export { planAddHuCommand } from "./add-hu.js";
 export { planRemoveHuCommand } from "./remove-hu.js";
 export { planMigrateResultCommand } from "./migrate-result.js";
+export { planFixCommand } from "./fix.js";
 
 // Keep backward compat — old callers import planCommand
 export const planCommand = planGenerateCommand;

--- a/tests/commands/plan-fix.test.js
+++ b/tests/commands/plan-fix.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// KJC-TSK-0402: `kj plan fix [planId] [--prompt]` relanza self-fix sobre
+// un plan ya generado. Tests cubren: prompt opcional, plan ya válido
+// (no-op), persistencia.
+
+vi.mock("../../src/agents/index.js", () => ({ createAgent: vi.fn() }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/config.js", async () => ({
+  ...(await vi.importActual("../../src/config.js")),
+  resolveRole: vi.fn(() => ({ provider: "claude" })),
+}));
+vi.mock("../../src/plan/plan-reviewer.js", async () => {
+  const actual = await vi.importActual("../../src/plan/plan-reviewer.js");
+  return { ...actual, reviewPlan: vi.fn() };
+});
+vi.mock("../../src/plan/plan-fixer.js", async () => {
+  const actual = await vi.importActual("../../src/plan/plan-fixer.js");
+  return { ...actual, applyReviewerFeedback: vi.fn() };
+});
+
+const EMPTY_FINDINGS = {
+  missing_hus: [], missing_dependencies: [], scope_overlaps: [],
+  order_issues: [], parallelisable_groups: [], summary: "OK",
+};
+
+let projectDir;
+let kjHome;
+const SAVED_KJ_HOME = process.env.KJ_HOME;
+
+beforeEach(async () => {
+  projectDir = mkdtempSync(path.join(tmpdir(), "kj-plan-fix-proj-"));
+  kjHome = mkdtempSync(path.join(tmpdir(), "kj-plan-fix-home-"));
+  process.env.KJ_HOME = kjHome;
+  // Limpiar el mock entre tests para que .mock.calls[0] sea el de ESTE test.
+  const { reviewPlan } = await import("../../src/plan/plan-reviewer.js");
+  reviewPlan.mockClear();
+});
+
+afterEach(() => {
+  if (SAVED_KJ_HOME === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = SAVED_KJ_HOME;
+  rmSync(projectDir, { recursive: true, force: true });
+  rmSync(kjHome, { recursive: true, force: true });
+});
+
+async function seedPlan(planId) {
+  const { projectSlug } = await import("../../src/plan/plan-store.js");
+  const slug = projectSlug(projectDir);
+  const dir = path.join(kjHome, "plans", slug);
+  mkdirSync(dir, { recursive: true });
+  const plan = {
+    version: 2, planId, name: "test", task: "Build a thing", status: "draft",
+    hus: [
+      { id: "hu_001", title: "A", task_type: "sw", status: "pending", blocked_by: [], reuse: [], scope: "a", acceptance_criteria: [], acceptance_tests: [], short_id: "X-1" },
+      { id: "hu_002", title: "B", task_type: "sw", status: "pending", blocked_by: ["hu_001"], reuse: [], scope: "b", acceptance_criteria: [], acceptance_tests: [], short_id: "X-2" },
+    ],
+    review: null, createdAt: "2026-05-14T00:00:00Z", updatedAt: "2026-05-14T00:00:00Z",
+  };
+  writeFileSync(path.join(dir, `${planId}.json`), JSON.stringify(plan, null, 2));
+  return { dir, plan };
+}
+
+describe("planFixCommand", () => {
+  it("sin --prompt: reviewer ve task original, plan ya limpio → no-op log", async () => {
+    await seedPlan("plan-clean");
+    const { reviewPlan } = await import("../../src/plan/plan-reviewer.js");
+    reviewPlan.mockResolvedValueOnce({ ok: true, findings: EMPTY_FINDINGS });
+    const { planFixCommand } = await import("../../src/commands/plan/fix.js");
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const config = { projectDir };
+    const logs = [];
+    const origLog = console.log;
+    console.log = (msg) => logs.push(msg);
+    try {
+      await planFixCommand({ config, planId: "plan-clean", logger, json: false });
+    } finally { console.log = origLog; }
+    const reviewerCall = reviewPlan.mock.calls[0][0];
+    expect(reviewerCall.task).toBe("Build a thing");
+    expect(reviewerCall.task).not.toContain("USER FEEDBACK");
+    expect(logs.some(l => l.includes("plan-clean"))).toBe(true);
+  });
+
+  it("con --prompt: el reviewer recibe USER FEEDBACK injection", async () => {
+    await seedPlan("plan-prompt");
+    const { reviewPlan } = await import("../../src/plan/plan-reviewer.js");
+    reviewPlan.mockResolvedValueOnce({ ok: true, findings: EMPTY_FINDINGS });
+    const { planFixCommand } = await import("../../src/commands/plan/fix.js");
+    const config = { projectDir };
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await planFixCommand({ config, planId: "plan-prompt", prompt: "falta HU export GDPR", logger: { info() {}, warn() {} }, json: true });
+    } finally { console.log = origLog; }
+    const reviewerCall = reviewPlan.mock.calls[0][0];
+    expect(reviewerCall.task).toContain("USER FEEDBACK");
+    expect(reviewerCall.task).toContain("falta HU export GDPR");
+  });
+
+  it("plan inexistente → error claro", async () => {
+    const { planFixCommand } = await import("../../src/commands/plan/fix.js");
+    await expect(
+      planFixCommand({ config: { projectDir }, planId: "ghost", logger: { info() {}, warn() {} } })
+    ).rejects.toThrow(/no encontrado/i);
+  });
+
+  it("--json: emite estructura before/after", async () => {
+    await seedPlan("plan-json");
+    const { reviewPlan } = await import("../../src/plan/plan-reviewer.js");
+    reviewPlan.mockResolvedValueOnce({ ok: true, findings: EMPTY_FINDINGS });
+    const { planFixCommand } = await import("../../src/commands/plan/fix.js");
+    const logs = [];
+    const origLog = console.log;
+    console.log = (msg) => logs.push(msg);
+    try {
+      await planFixCommand({ config: { projectDir }, planId: "plan-json", logger: { info() {}, warn() {} }, json: true });
+    } finally { console.log = origLog; }
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.planId).toBe("plan-json");
+    expect(parsed.before.hus).toBe(2);
+    expect(parsed.after.hus).toBe(2);
+  });
+
+  it("persiste el plan actualizado en disco", async () => {
+    const { dir } = await seedPlan("plan-persist");
+    const { reviewPlan } = await import("../../src/plan/plan-reviewer.js");
+    reviewPlan.mockResolvedValueOnce({ ok: true, findings: EMPTY_FINDINGS });
+    const { planFixCommand } = await import("../../src/commands/plan/fix.js");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await planFixCommand({ config: { projectDir }, planId: "plan-persist", logger: { info() {}, warn() {} }, json: true });
+    } finally { console.log = origLog; }
+    const persisted = JSON.parse(readFileSync(path.join(dir, "plan-persist.json"), "utf8"));
+    expect(persisted.review).toBeTruthy();
+    expect(persisted.review.summary).toBe("OK");
+  });
+});


### PR DESCRIPTION
## Summary

Comando para relanzar el self-fix loop sobre un plan ya generado sin regenerar desde cero. Carga el plan, ejecuta reviewer + self-fix loop (con smart convergence guard) + structural pass, persiste. Opcional `--prompt` con feedback del usuario inyectado como \`## USER FEEDBACK\` antes de la HU list.

\`\`\`bash
kj plan fix greta-app
kj plan fix greta-app --prompt \"falta HU export GDPR; HU_049 y HU_063 forman ciclo\"
\`\`\`

## Test plan

- [x] sin prompt → reviewer ve task original
- [x] con prompt → reviewer ve USER FEEDBACK injection
- [x] plan inexistente → error claro
- [x] --json → estructura before/after
- [x] persistencia al disco
- [x] lint clean

## Out of scope (próxima PR)

- Botón ✏️ Fix plan en el board que dispare este comando como background process.

## LOC

257 LOC. New CLI subcommand cohesivo: módulo + register + tests son atómicos. Justifica \`large-pr-justified\`.