### PR TITLE
feat(board): eliminar columna Failed — result=fail vive en Pending (KJC-TSK-0403)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -442,25 +442,16 @@ async function renderBoard() {
       ? (projectNameCache[selectedProject] || humaniseProjectName(selectedProject))
       : '';
 
-    // Kanban status → column mapping. The plan schema recognises seven
-    // statuses (pending/certified/coding/reviewing/done/failed/blocked/
-    // needs_context) but the user only cares about four lanes:
-    //   - Pending: anything generated but not running yet (including the
-    //     legacy intermediate "certified" state, which is a no-op from
-    //     the user's perspective — "I said it's ok to run but kj hasn't
-    //     started yet").
-    //   - Running: actively being processed by the pipeline.
-    //   - Done:    pipeline approved.
-    //   - Failed:  pipeline rejected.
-    // Empty lanes are hidden so the board doesn't fill with sad empty
-    // columns when a run is purely green.
+    // KJC-TSK-0403: status/result ortogonal. 3 columnas (Pending /
+    // Running / Done) en vez de 4. Las HUs que fallaron NO van a una
+    // columna "Failed" — vuelven a Pending con result=fail y badge ✗.
+    // status=failed legacy se trata como pending (migración lazy).
     const columns = {
       pending: stories.filter((s) =>
-        ['pending', 'certified', 'needs_context', 'blocked'].includes(s.status)
+        ['pending', 'certified', 'needs_context', 'blocked', 'failed'].includes(s.status)
       ),
       running: stories.filter((s) => ['coding', 'reviewing'].includes(s.status)),
       done: stories.filter((s) => s.status === 'done'),
-      failed: stories.filter((s) => s.status === 'failed'),
     };
 
     if (stories.length === 0) {
@@ -478,15 +469,12 @@ async function renderBoard() {
     const canRun = Boolean(selectedProject) && awaitingCount > 0 && runningCount === 0;
     const isRunning = runningCount > 0;
 
-    // Always show the four canonical lanes so the user has a mental
-    // map of the flow, even when every HU is still in Pending. Empty
-    // columns render their header (with count=0) but suppress the "No
-    // stories" placeholder inside so they don't steal visual space.
+    // KJC-TSK-0403: 3 canonical lanes. Failed eliminado — HUs con
+    // result=fail aparecen en Pending con badge ✗.
     const visibleColumns = [
       { title: 'Pending', cls: 'pending', rows: columns.pending },
       { title: 'Running', cls: 'running', rows: columns.running },
       { title: 'Done', cls: 'done', rows: columns.done },
-      { title: 'Failed', cls: 'failed', rows: columns.failed },
     ];
 
     app.innerHTML = `
@@ -2173,7 +2161,9 @@ async function showStoryDetail(storyId) {
     // reviewing/running (esos los pone el orquestador; setearlos a
     // mano genera zombies en el reaper).
     const canChangeStatus = !!story.plan_id;
-    const userSettableStatuses = ['pending', 'certified', 'done', 'failed', 'blocked', 'needs_context'];
+    // KJC-TSK-0403: 'failed' eliminado del dropdown — result=fail vive en
+    // la HU via outcome.blockers, no como status manual.
+    const userSettableStatuses = ['pending', 'certified', 'done', 'blocked', 'needs_context'];
 
     content.innerHTML = `
       <div class="modal__header">

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -515,7 +515,9 @@ router.post('/tombstones/:type/:id/restore', (req, res) => {
 // incluimos los canonicales (`running`) por la misma razón. `failed`
 // y `blocked` son útiles para que el usuario marque manualmente HUs
 // que no quiere correr ahora.
-const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'failed', 'blocked', 'needs_context']);
+// KJC-TSK-0403: 'failed' eliminado — el orquestador estampa result=fail
+// dejando status=pending. Setearlo a mano vía PATCH ya no tiene sentido.
+const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'blocked', 'needs_context']);
 const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by'];
 
 router.patch('/stories/:id', (req, res) => {

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -179,9 +179,10 @@ describe('PATCH /api/stories/:id', () => {
     expect(hu.result).toBe('fail');
   });
 
-  // Dropdown libre del modal: PATCH acepta cualquier status del set
-  // user-settable (pending/certified/done/failed/blocked/needs_context).
-  it.each(['certified', 'done', 'failed', 'blocked', 'needs_context'])(
+  // KJC-TSK-0403: 'failed' eliminado del dropdown — el orquestador
+  // estampa result=fail dejando status=pending. Setearlo a mano ya no
+  // tiene sentido. Set permitido: pending/certified/done/blocked/needs_context.
+  it.each(['certified', 'done', 'blocked', 'needs_context'])(
     'PATCH stories acepta cambiar a "%s" manualmente',
     async (target) => {
       const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
@@ -193,6 +194,15 @@ describe('PATCH /api/stories/:id', () => {
       expect(hu.status).toBe(target);
     },
   );
+
+  // KJC-TSK-0403: 'failed' explícitamente RECHAZADO.
+  it('PATCH stories RECHAZA status="failed" con 400 (KJC-TSK-0403)', async () => {
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ status: 'failed' });
+    expect(res.status).toBe(400);
+  });
 
   // NO se permite settear lifecycle del orquestador (genera zombies).
   it.each(['coding', 'reviewing', 'running'])(

--- a/src/plan/plan-executor.js
+++ b/src/plan/plan-executor.js
@@ -5,7 +5,7 @@
  */
 
 import { isPlanV2 } from "./plan-schema.js";
-import { updateHuStatus, computePlanOutcome, setPlanOutcome } from "./plan-hu-ops.js";
+import { updateHuStatus, updateHu, computePlanOutcome, setPlanOutcome } from "./plan-hu-ops.js";
 
 /**
  * Convert a v2 plan's HUs into the stageResults.huReviewer format
@@ -63,9 +63,18 @@ export function planToHuBatch(plan) {
 export function syncResultsToPlan(plan, subPipelineResult) {
   if (!isPlanV2(plan)) return;
 
+  // KJC-TSK-0403: status/result ortogonal. HU fallida queda en status=pending
+  // con result=fail (no status=failed) para que el usuario pueda relanzarla
+  // con el contexto del fallo previo. El plan se considera failed si CUALQUIER
+  // HU tiene result=fail.
   for (const r of subPipelineResult.results || []) {
-    const status = r.approved ? "done" : "failed";
-    updateHuStatus(plan, r.huId, status);
+    if (r.approved) {
+      updateHuStatus(plan, r.huId, "done");
+      updateHu(plan, r.huId, { result: "pass" });
+    } else {
+      updateHuStatus(plan, r.huId, "pending");
+      updateHu(plan, r.huId, { result: "fail" });
+    }
   }
 
   for (const blockedId of subPipelineResult.blockedIds || []) {
@@ -73,7 +82,7 @@ export function syncResultsToPlan(plan, subPipelineResult) {
   }
 
   const allDone = plan.hus.every(h => h.status === "done");
-  const anyFailed = plan.hus.some(h => h.status === "failed");
+  const anyFailed = plan.hus.some(h => h.result === "fail");
   plan.status = allDone ? "done" : anyFailed ? "failed" : "running";
   plan.updatedAt = new Date().toISOString();
 

--- a/src/plan/plan-schema.js
+++ b/src/plan/plan-schema.js
@@ -117,7 +117,10 @@ export function mapLegacyStatusToResult(legacy) {
     case "certified":
       return { status: "done", result: "pass" };
     case "failed":
-      return { status: "done", result: "fail" };
+      // KJC-TSK-0403: HU fallida vuelve a Pending con result=fail
+      // (no a Done) para que el usuario pueda relanzarla con el
+      // contexto del fallo previo (KJC-TSK-0404).
+      return { status: "pending", result: "fail" };
     case "done":
       return { status: "done", result: null }; // sin result conocido (raro)
     default:

--- a/tests/e2e/04-reviewer-rejected.test.js
+++ b/tests/e2e/04-reviewer-rejected.test.js
@@ -111,9 +111,10 @@ describe("e2e/04 — reviewer rejected → HU fails (no ReferenceError)", () => 
 
     const after = JSON.parse(fs.readFileSync(planPath, "utf8"));
     const hu = after.hus[0];
-    // After max_iterations the HU MUST end at `failed`, not still `coding`
-    // (zombie regression: 2026-04-27 HU-status-not-persisted-on-crash bug).
-    expect(["failed", "blocked"]).toContain(hu.status);
+    // KJC-TSK-0403: tras max_iterations la HU debe terminar en pending+result=fail
+    // o blocked (status/result ortogonal). NUNCA en coding/reviewing (zombi).
+    expect(["pending", "blocked"]).toContain(hu.status);
+    if (hu.status === "pending") expect(hu.result).toBe("fail");
     expect(hu.status).not.toBe("coding");
     expect(hu.status).not.toBe("reviewing");
   }, 90_000);

--- a/tests/e2e/05-sonar-config-error.test.js
+++ b/tests/e2e/05-sonar-config-error.test.js
@@ -125,11 +125,11 @@ describe("e2e/05 — Repairer escalation (regression #538)", () => {
     const seenRepairStart = /repair:start|Repairer.*invoked|Repairer escalated|Repairer fixed/i.test(all + runLog);
     expect(seenRepairStart, "Repairer should have been invoked at least once").toBe(true);
 
-    // HU ended `failed` — Repairer's `unfixable` verdict short-circuits
-    // max_iterations so this is the *immediate* failure path, not the
-    // generic max-iterations-exhausted path.
+    // KJC-TSK-0403: tras Repairer "unfixable" la HU vuelve a pending+result=fail
+    // (path inmediato de fallo, no el de max_iterations).
     const after = JSON.parse(fs.readFileSync(planPath, "utf8"));
     const hu = after.hus[0];
-    expect(["failed", "blocked"]).toContain(hu.status);
+    expect(["pending", "blocked"]).toContain(hu.status);
+    if (hu.status === "pending") expect(hu.result).toBe("fail");
   }, 90_000);
 });

--- a/tests/plan/plan-module.test.js
+++ b/tests/plan/plan-module.test.js
@@ -253,8 +253,8 @@ describe("mapLegacyStatusToResult (KJC-TSK-0394 migration)", () => {
   it("certified → done+pass (success en el modelo viejo)", () => {
     expect(mapLegacyStatusToResult("certified")).toEqual({ status: "done", result: "pass" });
   });
-  it("failed → done+fail", () => {
-    expect(mapLegacyStatusToResult("failed")).toEqual({ status: "done", result: "fail" });
+  it("failed → pending+fail (KJC-TSK-0403: HU fallida vuelve a pending para retry)", () => {
+    expect(mapLegacyStatusToResult("failed")).toEqual({ status: "pending", result: "fail" });
   });
   it("done → done+null (status terminal sin info de result)", () => {
     expect(mapLegacyStatusToResult("done")).toEqual({ status: "done", result: null });


### PR DESCRIPTION
## Summary

El status/result ortogonal (KJC-TSK-0394) permite que una HU fallida permanezca en pending con result=fail en vez de irse a una columna Failed muerta. Beneficios:
- 1 click menos para relanzar (ya está en pending)
- El usuario ve \"disponible para retry\" + \"último intento falló\" en una sola card
- Board más limpio: 3 columnas en vez de 4

## Changes

- `plan-executor.syncResultsToPlan`: HU no aprobada → status=pending, result=fail.
- `plan-schema.mapLegacyStatusToResult`: legacy \"failed\" → pending+fail (migración lazy).
- Board kanban: 3 lanes (Pending/Running/Done).
- Board modal dropdown sin 'failed'.
- `routes/api`: PATCH con status='failed' → 400.

## Test plan

- [x] Tests plan: 225 passing
- [x] Tests hu-board: 329 passing
- [x] e2e/04 reviewer-rejected actualizado
- [x] e2e/05 sonar-config-error actualizado
- [x] lint clean
- [x] Net LOC: 53 add / 38 del = 15 line delta