### PR TITLE
feat(hu-board): zombie reaper marca result=fail + blocker (KJC-TSK-0404 step 1)

### DIFF
--- a/packages/hu-board/src/hu-zombie-reaper.js
+++ b/packages/hu-board/src/hu-zombie-reaper.js
@@ -59,7 +59,7 @@ export function findZombieHus(hus, opts = {}) {
  * plan. `setHuStatus` se inyecta para que los tests no necesiten un
  * plan-file real. Devuelve la lista de reapeados para el log.
  */
-export function reapZombieHus({ db, setHuStatus, opts = {}, now = () => Date.now() }) {
+export function reapZombieHus({ db, setHuStatus, setHuFailResult, opts = {}, now = () => Date.now() }) {
   if (!db || typeof setHuStatus !== "function") return [];
   const rows = db.prepare(
     "SELECT id, project_id, plan_id, status, updated_at FROM stories WHERE status IN ('coding', 'reviewing', 'running')",
@@ -77,6 +77,18 @@ export function reapZombieHus({ db, setHuStatus, opts = {}, now = () => Date.now
         const result = setHuStatus({ planId: hu.plan_id, huId: localHuId, status: "pending", projectId: hu.project_id });
         planPersisted = !!(result && result.ok);
       } catch { /* swallow — never block startup */ }
+      // KJC-TSK-0404: además de resetear status=pending, marcar la HU con
+      // result=fail + blocker. El siguiente `kj run` ve el blocker y se
+      // lo inyecta al coder como "## PREVIOUS ATTEMPT FAILED" para que
+      // no repita el mismo error. No-op si la fn no se inyectó.
+      if (planPersisted && typeof setHuFailResult === "function") {
+        try {
+          setHuFailResult({
+            planId: hu.plan_id, huId: localHuId, projectId: hu.project_id,
+            blocker: `timeout: ${reason}`,
+          });
+        } catch { /* swallow — el status reset ya está hecho */ }
+      }
     }
     // Fallback DB-only para legacy rows (plan_id null) o si el write al
     // plan falló. setHuStatus ya resincroniza en el caso happy.

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -169,6 +169,39 @@ export function setHuFields({ planId, huId, patch, projectId }) {
 }
 
 /**
+ * KJC-TSK-0404: marcar una HU como fallida con blocker y timestamp
+ * (sin tocar status). Usado por el zombie-reaper al detectar timeout
+ * para que el siguiente `kj run` sepa el motivo del último fallo.
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} args.huId
+ * @param {string} args.blocker - razón del fallo
+ * @param {string} [args.projectId]
+ * @returns {{ ok: boolean, hu?: object, error?: string }}
+ */
+export function setHuFailResult({ planId, huId, blocker, projectId }) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+  const plan = readPlan(filePath);
+  if (!Array.isArray(plan.hus)) return { ok: false, error: 'plan has no hus[]' };
+  const hu = plan.hus.find(h => h.id === huId);
+  if (!hu) return { ok: false, error: `hu not found: ${huId}` };
+
+  hu.result = 'fail';
+  hu.updatedAt = new Date().toISOString();
+  const existing = (hu.outcome && Array.isArray(hu.outcome.blockers)) ? hu.outcome.blockers : [];
+  hu.outcome = {
+    ...(hu.outcome || {}),
+    blockers: blocker ? [...existing, blocker] : existing,
+    failedAt: new Date().toISOString(),
+  };
+  writePlan(filePath, plan);
+  syncPlanFile(filePath);
+  return { ok: true, hu };
+}
+
+/**
  * Bulk certify: equivalent to `kj plan ready <planId>` over HTTP. Flips
  * every pending HU to certified and sets `plan.status = "ready"`. No-op
  * on already-ready plans (idempotent, returns count=0).

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -13,7 +13,7 @@ import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
 import { reapZombieHus } from './hu-zombie-reaper.js';
-import { setHuStatus as setHuStatusPlanMutation } from './plan-mutations.js';
+import { setHuStatus as setHuStatusPlanMutation, setHuFailResult as setHuFailResultPlanMutation } from './plan-mutations.js';
 import { cleanupEphemeralProjects } from './ephemeral-cleaner.js';
 import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/port-check.js';
 
@@ -198,7 +198,11 @@ async function main() {
   // a `failed` porque no sabemos el outcome; `result` se preserva.
   try {
     const dbHandle = (await import('./db.js')).getDb();
-    const reapedHus = reapZombieHus({ db: dbHandle, setHuStatus: setHuStatusPlanMutation });
+    const reapedHus = reapZombieHus({
+      db: dbHandle,
+      setHuStatus: setHuStatusPlanMutation,
+      setHuFailResult: setHuFailResultPlanMutation,
+    });
     if (reapedHus.length > 0) {
       console.log(`[hu-zombie-reaper] reset ${reapedHus.length} stuck HU(s) to pending:`);
       for (const r of reapedHus) {

--- a/packages/hu-board/tests/hu-zombie-reaper.test.js
+++ b/packages/hu-board/tests/hu-zombie-reaper.test.js
@@ -81,4 +81,27 @@ describe('reapZombieHus', () => {
     expect(reapZombieHus({ db, setHuStatus: vi.fn(), now: () => NOW })).toEqual([]);
     expect(reapZombieHus({ db: null, setHuStatus: vi.fn() })).toEqual([]);
   });
+
+  // KJC-TSK-0404: además de resetear status=pending, el reaper marca
+  // la HU con result=fail + blocker para que el siguiente `kj run`
+  // tenga contexto del fallo previo.
+  it('al detectar zombi llama setHuFailResult con el motivo del timeout', () => {
+    insert('proj::hu_001', 'plan-x', 'coding', null, ago(60));
+    const setHuStatus = vi.fn(() => ({ ok: true, status: 'pending', planStatus: 'draft' }));
+    const setHuFailResult = vi.fn(() => ({ ok: true }));
+    reapZombieHus({ db, setHuStatus, setHuFailResult, opts: { runningMinutes: 30 }, now: () => NOW });
+    expect(setHuFailResult).toHaveBeenCalledTimes(1);
+    const call = setHuFailResult.mock.calls[0][0];
+    expect(call.planId).toBe('plan-x');
+    expect(call.huId).toBe('hu_001');
+    expect(call.blocker).toMatch(/timeout/i);
+  });
+
+  it('no llama setHuFailResult si setHuStatus falla (DB-only fallback)', () => {
+    insert('proj::hu_001', 'plan-x', 'coding', null, ago(60));
+    const setHuStatus = vi.fn(() => ({ ok: false, error: 'plan not found' }));
+    const setHuFailResult = vi.fn(() => ({ ok: true }));
+    reapZombieHus({ db, setHuStatus, setHuFailResult, opts: { runningMinutes: 30 }, now: () => NOW });
+    expect(setHuFailResult).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Primer paso de KJC-TSK-0404. El reaper detectaba HUs colgadas en coding/reviewing >30min y las pasaba a pending — pero sin contexto del motivo. El usuario relanzaba y el coder repetía el mismo error.

Ahora cuando el reaper resetea un zombi, además llama \`setHuFailResult({ blocker: 'timeout: ...' })\` que marca:
- \`hu.result = 'fail'\`
- \`hu.outcome.blockers += blocker\`
- \`hu.outcome.failedAt = now\`

El siguiente kj run podrá leer outcome.blockers e inyectarlo al coder como \"## PREVIOUS ATTEMPT FAILED\".

## Test plan

- [x] Tests reaper + mutations: 59 passing
- [x] setHuFailResult invocado con planId/huId/blocker correctos
- [x] No se llama si status reset falló (fallback DB-only intacto)

## Out of scope (próximas PRs)

- Inyectar \"## PREVIOUS ATTEMPT FAILED\" en el prompt del coder
- Tracking 3-fails-warn modal
- Snapshot/undo de ficheros por HU