### PR TITLE
feat(hu): model-router por HU + campos coder_model/reviewer_model (KJC-TSK-0405)

### DIFF
--- a/src/hu/model-router.js
+++ b/src/hu/model-router.js
@@ -1,0 +1,74 @@
+// KJC-TSK-0405: dado un HU con complexity score, recomienda coder_model y
+// reviewer_model. El reviewer por defecto usa el provider alternativo al
+// coder (cross-provider review) para que dos cabezas distintas miren el
+// código y se detecten más patrones.
+
+const LEVELS = ["trivial", "simple", "medium", "complex"];
+
+// Mapping complexity score numérico → nivel categórico.
+// 1 → trivial, 2 → simple, 3/4 → medium, 5+ → complex.
+const SCORE_TO_LEVEL = {
+  1: "trivial",
+  2: "simple",
+  3: "medium",
+  4: "medium",
+  5: "complex",
+};
+
+// Defaults por provider — alineados con utils/model-selector.js DEFAULTS.
+const DEFAULT_TIERS = {
+  claude: { trivial: "haiku", simple: "haiku", medium: "sonnet", complex: "opus" },
+  codex: { trivial: "o4-mini", simple: "o4-mini", medium: "o4-mini", complex: "o3" },
+  gemini: { trivial: "gemini-2.0-flash", simple: "gemini-2.0-flash", medium: "gemini-2.5-pro", complex: "gemini-2.5-pro" },
+};
+
+// Cross-provider reviewer default: para cada coder provider, qué provider
+// usa el reviewer por defecto. Idea: dos cabezas distintas miran el código.
+const CROSS_PROVIDER_REVIEWER = {
+  claude: "codex",
+  codex: "claude",
+  gemini: "claude",
+};
+
+export function complexityToLevel(complexity) {
+  if (typeof complexity === "string" && LEVELS.includes(complexity)) return complexity;
+  if (typeof complexity === "number" && SCORE_TO_LEVEL[complexity]) return SCORE_TO_LEVEL[complexity];
+  return "medium";
+}
+
+/**
+ * @param {object} args
+ * @param {string|number} args.complexity - "trivial" | "simple" | "medium" | "complex" | score 1-5
+ * @param {string} args.coderProvider - "claude" | "codex" | "gemini"
+ * @param {object} args.config - karajan config (lee model_routing si existe)
+ * @returns {{ coder_model: string|null, coder_provider: string, reviewer_model: string|null, reviewer_provider: string }}
+ */
+export function recommendModelsForHu({ complexity, coderProvider, config = {} }) {
+  const level = complexityToLevel(complexity);
+  const routing = config.model_routing || {};
+  const fixed = routing.fixed || {};
+
+  // Merge tiers: defaults + user overrides per provider.
+  const tiers = { ...DEFAULT_TIERS };
+  if (routing.by_provider) {
+    for (const [prov, levels] of Object.entries(routing.by_provider)) {
+      tiers[prov] = { ...(tiers[prov] || {}), ...levels };
+    }
+  }
+
+  const coderTier = tiers[coderProvider];
+  const coderAuto = coderTier ? (coderTier[level] || null) : null;
+  const coder_model = fixed.coder || coderAuto;
+
+  const reviewer_provider = CROSS_PROVIDER_REVIEWER[coderProvider] || "claude";
+  const reviewerTier = tiers[reviewer_provider];
+  const reviewerAuto = reviewerTier ? (reviewerTier[level] || null) : null;
+  const reviewer_model = fixed.reviewer || reviewerAuto;
+
+  return {
+    coder_model,
+    coder_provider: coderProvider,
+    reviewer_model,
+    reviewer_provider,
+  };
+}

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -60,6 +60,14 @@ export function addHu(plan, huData) {
     // re-read. Free-form string — typically "5.3", "§5.3 Initial
     // Scope", or whatever the planner extracted from the source spec.
     spec_section: huData.spec_section || null,
+    // KJC-TSK-0405: coder_model y reviewer_model asignados por el
+    // triage según complexity. null = usar el del config global / role
+    // resolver. Independientes — el usuario puede overridearlos por HU
+    // desde el board sin tocar el resto del plan.
+    coder_model: huData.coder_model ?? null,
+    coder_provider: huData.coder_provider ?? null,
+    reviewer_model: huData.reviewer_model ?? null,
+    reviewer_provider: huData.reviewer_provider ?? null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };
@@ -95,7 +103,10 @@ export function removeHu(plan, huId) {
 export function updateHu(plan, huId, patch) {
   const hu = plan.hus.find(h => h.id === huId);
   if (!hu) return null;
-  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result", "short_id"];
+  // KJC-TSK-0405: coder_model y reviewer_model son override per-HU del
+  // routing automático del triage. Independientes — el usuario puede
+  // subir el reviewer sin tocar el coder, o viceversa.
+  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result", "short_id", "coder_model", "reviewer_model", "coder_provider", "reviewer_provider"];
   for (const key of allowed) {
     if (patch[key] !== undefined) hu[key] = patch[key];
   }

--- a/tests/hu/model-router.test.js
+++ b/tests/hu/model-router.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { recommendModelsForHu, complexityToLevel } from "../../src/hu/model-router.js";
+
+// KJC-TSK-0405: dado un HU con complexity score, devuelve qué coder_model
+// y reviewer_model usar. Cross-provider reviewer por defecto (claude→codex,
+// codex→claude, gemini→claude).
+
+describe("complexityToLevel", () => {
+  it("score numérico → level discreto", () => {
+    expect(complexityToLevel(1)).toBe("trivial");
+    expect(complexityToLevel(2)).toBe("simple");
+    expect(complexityToLevel(3)).toBe("medium");
+    expect(complexityToLevel(5)).toBe("complex");
+  });
+  it("acepta string canónico tal cual", () => {
+    expect(complexityToLevel("trivial")).toBe("trivial");
+    expect(complexityToLevel("medium")).toBe("medium");
+    expect(complexityToLevel("complex")).toBe("complex");
+  });
+  it("desconocido / null → medium (fallback conservador)", () => {
+    expect(complexityToLevel(null)).toBe("medium");
+    expect(complexityToLevel(undefined)).toBe("medium");
+    expect(complexityToLevel("foobar")).toBe("medium");
+    expect(complexityToLevel(99)).toBe("medium");
+  });
+});
+
+describe("recommendModelsForHu", () => {
+  const baseConfig = { roles: { coder: { provider: "claude" }, reviewer: { provider: "codex" } } };
+
+  it("complexity=trivial + provider claude → coder haiku", () => {
+    const r = recommendModelsForHu({ complexity: "trivial", coderProvider: "claude", config: baseConfig });
+    expect(r.coder_model).toBe("haiku");
+  });
+  it("complexity=medium + provider claude → coder sonnet", () => {
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "claude", config: baseConfig });
+    expect(r.coder_model).toBe("sonnet");
+  });
+  it("complexity=complex + provider claude → coder opus", () => {
+    const r = recommendModelsForHu({ complexity: "complex", coderProvider: "claude", config: baseConfig });
+    expect(r.coder_model).toBe("opus");
+  });
+
+  it("reviewer default es cross-provider del coder (claude→codex)", () => {
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "claude", config: baseConfig });
+    expect(r.reviewer_provider).toBe("codex");
+    expect(r.reviewer_model).toBeTruthy();
+  });
+  it("reviewer cross-provider de codex es claude", () => {
+    const cfg = { roles: { coder: { provider: "codex" }, reviewer: { provider: "claude" } } };
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "codex", config: cfg });
+    expect(r.reviewer_provider).toBe("claude");
+  });
+  it("reviewer cross-provider de gemini cae a claude", () => {
+    const cfg = { roles: { coder: { provider: "gemini" } } };
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "gemini", config: cfg });
+    expect(r.reviewer_provider).toBe("claude");
+  });
+
+  it("config.model_routing.fixed.coder es override total", () => {
+    const cfg = {
+      ...baseConfig,
+      model_routing: { fixed: { coder: "claude-sonnet-4-6" } },
+    };
+    const r = recommendModelsForHu({ complexity: "trivial", coderProvider: "claude", config: cfg });
+    expect(r.coder_model).toBe("claude-sonnet-4-6");
+  });
+
+  it("config.model_routing.fixed.reviewer es override total", () => {
+    const cfg = {
+      ...baseConfig,
+      model_routing: { fixed: { reviewer: "opus" } },
+    };
+    const r = recommendModelsForHu({ complexity: "trivial", coderProvider: "claude", config: cfg });
+    expect(r.reviewer_model).toBe("opus");
+  });
+
+  it("config.model_routing.by_provider override tiers default", () => {
+    const cfg = {
+      ...baseConfig,
+      model_routing: {
+        by_provider: {
+          claude: { trivial: "haiku-custom", medium: "sonnet-custom", complex: "opus-custom" },
+        },
+      },
+    };
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "claude", config: cfg });
+    expect(r.coder_model).toBe("sonnet-custom");
+  });
+
+  it("provider desconocido → coder_model null pero no throws", () => {
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "unknownProvider", config: baseConfig });
+    expect(r.coder_model).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Primer paso del epic **KJC-PCS-0043** (Model routing per HU + Undo). Establece la base: módulo \`recommendModelsForHu\` y campos por HU.

### Módulo \`src/hu/model-router.js\`

\`\`\`js
recommendModelsForHu({ complexity, coderProvider, config }) → {
  coder_model, reviewer_model, coder_provider, reviewer_provider
}
\`\`\`

- **Complexity mapping**: \"trivial\" / \"simple\" / \"medium\" / \"complex\" o score 1-5 → level
- **Defaults per provider**: claude(haiku/sonnet/opus), codex(o4-mini/o3), gemini(flash/pro)
- **Cross-provider reviewer**: claude↔codex, gemini→claude (dos cabezas distintas miran el código)
- **\`config.model_routing.fixed.coder/reviewer\`**: override total
- **\`config.model_routing.by_provider\`**: sobreescribe tiers

### Schema HU

- \`addHu\` acepta \`coder_model\`, \`reviewer_model\`, \`coder_provider\`, \`reviewer_provider\` (default \`null\`)
- \`updateHu\` whitelist incluye los nuevos campos (PATCH-able desde el board)

## Test plan

- [x] 13 tests model-router (complexity mapping, providers, cross-provider, overrides)
- [x] 248 tests del suite plan/ pasando
- [x] lint clean
- [x] 181 LOC añadidos, dentro de budget

## Próximas PRs del epic

- **TSK-0406**: UI del board para mostrar/cambiar coder_model y reviewer_model por HU
- **TSK-0407**: validación de la sección \`model_routing\` en karajan.config.json
- **TSK-0408**: snapshot/undo de ficheros por HU