### PR TITLE
feat(config): sección model_routing en schema (KJC-TSK-0407)

### DIFF
--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -177,6 +177,30 @@ const Skills = v.optional(v.looseObject({
 }));
 
 /**
+ * KJC-TSK-0407: routing automático de modelos por HU según complexity.
+ *   - by_provider: override de tiers per provider (claude/codex/gemini).
+ *     Cada provider mapea level → modelo. Sobreescribe defaults del router.
+ *   - fixed.coder / fixed.reviewer: si presentes, override TOTAL — todas
+ *     las HUs usan esos modelos independientemente del score. Útil para
+ *     forzar Sonnet en todo el proyecto, por ejemplo.
+ */
+const ModelRouting = v.optional(v.looseObject({
+  by_provider: v.optional(v.record(
+    v.string(),
+    v.looseObject({
+      trivial: v.optional(v.string()),
+      simple: v.optional(v.string()),
+      medium: v.optional(v.string()),
+      complex: v.optional(v.string()),
+    })
+  )),
+  fixed: v.optional(v.looseObject({
+    coder: v.optional(v.nullable(v.string())),
+    reviewer: v.optional(v.nullable(v.string())),
+  })),
+}));
+
+/**
  * Main config schema. `looseObject` lets every consumer that reads an
  * undeclared key keep working while the schema catches the bugs we care
  * about.
@@ -207,6 +231,7 @@ export const ConfigSchema = v.looseObject({
   policies: v.optional(v.record(v.string(), v.unknown())),
   telemetry: v.optional(v.boolean()),
   skills: Skills,
+  model_routing: ModelRouting,
 });
 
 /**

--- a/tests/config/config-schema.test.js
+++ b/tests/config/config-schema.test.js
@@ -181,3 +181,47 @@ describe("applyRunOverrides — falsy handling regressions from #367", () => {
       .toThrow(/review_mode must be one of/);
   });
 });
+
+// KJC-TSK-0407: nueva sección model_routing.
+describe("config schema — model_routing", () => {
+  it("acepta config sin model_routing (campo opcional)", () => {
+    const out = parseConfig({});
+    expect(out.model_routing).toBeUndefined();
+  });
+
+  it("acepta model_routing.by_provider con tiers per provider", () => {
+    const out = parseConfig({
+      model_routing: {
+        by_provider: {
+          claude: { trivial: "haiku", medium: "sonnet", complex: "opus" },
+          codex: { medium: "o4-mini", complex: "o3" },
+        },
+      },
+    });
+    expect(out.model_routing.by_provider.claude.medium).toBe("sonnet");
+    expect(out.model_routing.by_provider.codex.complex).toBe("o3");
+  });
+
+  it("acepta model_routing.fixed.coder y fixed.reviewer como override total", () => {
+    const out = parseConfig({
+      model_routing: { fixed: { coder: "claude-sonnet-4-6", reviewer: "opus" } },
+    });
+    expect(out.model_routing.fixed.coder).toBe("claude-sonnet-4-6");
+    expect(out.model_routing.fixed.reviewer).toBe("opus");
+  });
+
+  it("acepta fixed.coder = null (uso parcial: solo fija reviewer)", () => {
+    const out = parseConfig({
+      model_routing: { fixed: { coder: null, reviewer: "opus" } },
+    });
+    expect(out.model_routing.fixed.coder).toBeNull();
+    expect(out.model_routing.fixed.reviewer).toBe("opus");
+  });
+
+  it("by_provider acepta providers desconocidos (looseObject — futuro-proof)", () => {
+    const out = parseConfig({
+      model_routing: { by_provider: { someNewProvider: { medium: "x" } } },
+    });
+    expect(out.model_routing.by_provider.someNewProvider.medium).toBe("x");
+  });
+});


### PR DESCRIPTION
## Summary

Valida la sección \`model_routing\` que el model-router de KJC-TSK-0405 consume:

- \`model_routing.by_provider\`: override de tiers per provider (claude/codex/gemini → { trivial, simple, medium, complex }).
- \`model_routing.fixed.coder\` / \`fixed.reviewer\`: override total. Cuando presentes, todas las HUs usan ese modelo independientemente del complexity score.

\`looseObject\` en ambos niveles: providers desconocidos pasan (futuro-proof), keys extra ignoradas.

## Test plan

- [x] 5 tests nuevos en config-schema.test.js
- [x] 23 tests del módulo pasando
- [x] lint clean