### PR TITLE
feat(hu-board): UI override coder_model/reviewer_model por HU (KJC-TSK-0406)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1524,6 +1524,34 @@ window.changeHuStatusFromModal = async function changeHuStatusFromModal(storyId,
   }
 };
 
+// KJC-TSK-0406: persist coder_model + reviewer_model overrides from the
+// modal. Vacío → null (re-asignación automática por triage en siguiente
+// run). Cada modelo es independiente.
+window.saveHuModels = async function saveHuModels(storyId) {
+  const coderInput = document.getElementById('hu-coder-model');
+  const reviewerInput = document.getElementById('hu-reviewer-model');
+  const patch = {
+    coder_model: coderInput?.value?.trim() || null,
+    reviewer_model: reviewerInput?.value?.trim() || null,
+  };
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudieron guardar los modelos' });
+      return;
+    }
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo guardando modelos' });
+  }
+};
+
 window.resetHuToPending = async function resetHuToPending(storyId) {
   const ok = await showConfirm(
     '¿Devolver esta HU a pending?\n\nEl estado se cambia a pending y se podrá relanzar. El resultado de la última ejecución (✓/✗/~) se conserva como historial hasta que vuelvas a ejecutarla.',
@@ -2211,6 +2239,47 @@ async function showStoryDetail(storyId) {
         <div class="modal__section-title">Original Text</div>
         <div class="modal__field-value">${esc(story.original_text || 'N/A')}</div>
       </div>
+
+      ${(story.coder_model || story.reviewer_model || canEdit) ? `
+        <!-- KJC-TSK-0406: model routing per HU. Cada modelo es independiente
+             y editable. Reviewer cross-provider del coder por defecto. -->
+        <div class="modal__section">
+          <div class="modal__section-title">Models</div>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;font-size:0.85rem">
+            <div>
+              <div class="modal__field-label">Coder</div>
+              <div class="modal__field-value" style="font-family:monospace">
+                ${esc(story.coder_model || 'auto')} ${story.coder_provider ? `<span style="color:var(--text-muted)">(${esc(story.coder_provider)})</span>` : ''}
+              </div>
+              ${canEdit ? `
+                <input id="hu-coder-model" type="text" placeholder="modelo override"
+                       value="${esc(story.coder_model || '')}"
+                       style="margin-top:4px;width:100%;padding:4px;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:4px;font-family:monospace;font-size:0.8rem">
+              ` : ''}
+            </div>
+            <div>
+              <div class="modal__field-label">Reviewer (cross-provider)</div>
+              <div class="modal__field-value" style="font-family:monospace">
+                ${esc(story.reviewer_model || 'auto')} ${story.reviewer_provider ? `<span style="color:var(--text-muted)">(${esc(story.reviewer_provider)})</span>` : ''}
+              </div>
+              ${canEdit ? `
+                <input id="hu-reviewer-model" type="text" placeholder="modelo override"
+                       value="${esc(story.reviewer_model || '')}"
+                       style="margin-top:4px;width:100%;padding:4px;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:4px;font-family:monospace;font-size:0.8rem">
+              ` : ''}
+            </div>
+          </div>
+          ${canEdit ? `
+            <div style="margin-top:8px;display:flex;gap:6px;align-items:center">
+              <button onclick="saveHuModels('${esc(story.id)}')" class="control-btn"
+                      style="padding:4px 10px;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.8rem">
+                💾 Save models
+              </button>
+              <span style="color:var(--text-muted);font-size:0.75rem">vacío → re-asignar automáticamente</span>
+            </div>
+          ` : ''}
+        </div>
+      ` : ''}
 
       ${story.certified_as ? `
         <div class="modal__section">

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -177,6 +177,14 @@ export function initDb() {
   // Diferente del campo `outcome` arriba (que es blob JSON con metadata del
   // run). result es el enum de "último resultado" para mostrar como badge.
   try { db.exec('ALTER TABLE stories ADD COLUMN result TEXT'); } catch { /* already migrated */ }
+  // KJC-TSK-0406: coder_model y reviewer_model independientes por HU.
+  // Asignados por el triage según complexity (KJC-TSK-0405) y override-able
+  // desde el modal del board. coder_provider y reviewer_provider permiten
+  // cross-provider review (claude↔codex) sin tocar el config global.
+  try { db.exec('ALTER TABLE stories ADD COLUMN coder_model TEXT'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN reviewer_model TEXT'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN coder_provider TEXT'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN reviewer_provider TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
@@ -232,14 +240,16 @@ export function upsertStory(story) {
       quality_total, quality_d1, quality_d2, quality_d3, quality_d4, quality_d5, quality_d6,
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
-      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome, result
+      ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome, result,
+      coder_model, reviewer_model, coder_provider, reviewer_provider
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
       @quality_total, @quality_d1, @quality_d2, @quality_d3, @quality_d4, @quality_d5, @quality_d6,
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
-      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome, @result
+      @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome, @result,
+      @coder_model, @reviewer_model, @coder_provider, @reviewer_provider
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -268,7 +278,11 @@ export function upsertStory(story) {
       plan_order = COALESCE(@plan_order, plan_order),
       spec_section = COALESCE(@spec_section, spec_section),
       outcome = COALESCE(@outcome, outcome),
-      result = COALESCE(@result, result)
+      result = COALESCE(@result, result),
+      coder_model = COALESCE(@coder_model, coder_model),
+      reviewer_model = COALESCE(@reviewer_model, reviewer_model),
+      coder_provider = COALESCE(@coder_provider, coder_provider),
+      reviewer_provider = COALESCE(@reviewer_provider, reviewer_provider)
   `);
   stmt.run({
     id: story.id,
@@ -302,6 +316,10 @@ export function upsertStory(story) {
     spec_section: story.spec_section || null,
     outcome: story.outcome || null,
     result: story.result || null,
+    coder_model: story.coder_model || null,
+    reviewer_model: story.reviewer_model || null,
+    coder_provider: story.coder_provider || null,
+    reviewer_provider: story.reviewer_provider || null,
   });
 }
 

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -518,7 +518,10 @@ router.post('/tombstones/:type/:id/restore', (req, res) => {
 // KJC-TSK-0403: 'failed' eliminado — el orquestador estampa result=fail
 // dejando status=pending. Setearlo a mano vía PATCH ya no tiene sentido.
 const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'blocked', 'needs_context']);
-const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by'];
+// KJC-TSK-0406: coder_model y reviewer_model son editables desde el
+// modal del board. Independientes — el usuario puede subir el reviewer
+// y bajar el coder sin afectar al resto del plan.
+const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by', 'coder_model', 'reviewer_model', 'coder_provider', 'reviewer_provider'];
 
 router.patch('/stories/:id', (req, res) => {
   try {

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -449,6 +449,13 @@ export function syncPlanFile(filePath) {
         // Distinto de `outcome` (blob JSON) — esto es el enum corto para
         // badge ✓/✗ en la card.
         result: hu.result || null,
+        // KJC-TSK-0406: coder_model y reviewer_model por HU. Reflejan
+        // qué modelo se va a usar (o se usó) en este HU. El modal del
+        // board los muestra y permite cambiarlos antes de run.
+        coder_model: hu.coder_model || null,
+        reviewer_model: hu.reviewer_model || null,
+        coder_provider: hu.coder_provider || null,
+        reviewer_provider: hu.reviewer_provider || null,
       });
     }
 

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -215,6 +215,34 @@ describe('PATCH /api/stories/:id', () => {
     },
   );
 
+  // KJC-TSK-0406: PATCH stories acepta coder_model / reviewer_model
+  // como overrides per-HU.
+  it('PATCH stories acepta coder_model y reviewer_model como overrides', async () => {
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ coder_model: 'opus', reviewer_model: 'o3' });
+    expect(res.status).toBe(200);
+    const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.coder_model).toBe('opus');
+    expect(hu.reviewer_model).toBe('o3');
+  });
+
+  it('PATCH stories con coder_model=null limpia el override', async () => {
+    // Pre-set algún valor
+    const planPre = readPlanFromDisk();
+    planPre.hus[0].coder_model = 'opus';
+    writeFileSync(planPath(), JSON.stringify(planPre, null, 2), 'utf-8');
+    syncMod.syncPlanFile(planPath());
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`)
+      .send({ coder_model: null });
+    expect(res.status).toBe(200);
+    const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.coder_model).toBeNull();
+  });
+
   it('reset desde "done" a "pending" preserva el result anterior', async () => {
     const plan = readPlanFromDisk();
     plan.hus[0].status = 'done';


### PR DESCRIPTION
## Summary

Segundo paso del epic **KJC-PCS-0043** (Model routing per HU). Expone los campos del model-router de KJC-TSK-0405 (#715) en el modal del board para edición manual.

### Backend
- \`routes/api\` EDITABLE_HU_FIELDS añade coder_model, reviewer_model, coder_provider, reviewer_provider
- \`db.js\`: 4 nuevas columnas en stories (ALTER ADD COLUMN idempotente, COALESCE en update)
- \`sync.js\`: copia los campos del plan JSON al row SQLite

### UI
- Nueva sección \"Models\" en el modal con grid 2-col: Coder (provider) y Reviewer (cross-provider)
- Si canEdit: 2 inputs + botón \"💾 Save models\"
- Vacío → null → re-asignación automática por triage en siguiente run

## Test plan

- [x] PATCH stories acepta coder_model/reviewer_model
- [x] PATCH con coder_model=null limpia el override
- [x] 51 tests plan-mutations passing