### PR TITLE
feat(git): módulo hu-snapshot — refs git para Undo per HU (KJC-TSK-0408 step 1)

### DIFF
--- a/src/git/hu-snapshot.js
+++ b/src/git/hu-snapshot.js
@@ -1,0 +1,105 @@
+// KJC-TSK-0408: snapshots de ficheros por HU para soportar Undo.
+//
+// Antes de ejecutar una HU, guardamos un ref git apuntando al HEAD
+// actual (`refs/kj-snapshots/<huId>`). Si el usuario hace Undo después,
+// hacemos `git reset --hard <ref>` para volver al estado pre-run.
+//
+// Por qué refs en lugar de stash/tarball:
+//   - Refs son objetos git nativos. No mueven blobs (todos compartidos
+//     con HEAD), así que crear el snapshot es O(1).
+//   - El snapshot persiste a través de checkouts y rebases.
+//   - Si el ref ya apunta al SHA correcto, restore es no-op.
+//
+// El runner es inyectable para que los tests no necesiten un repo git real.
+
+import { runCommand } from "../utils/process.js";
+
+const REF_PREFIX = "refs/kj-snapshots/";
+
+/**
+ * Sanitiza un huId para uso como nombre de ref. Git rechaza:
+ *   - `..`, `:`, `~`, `^`, `?`, `*`, `[`, `\`, espacios, control chars
+ *   - segmentos que empiecen por `.` o terminen en `.lock`
+ * Reemplazamos cualquier no [a-zA-Z0-9_-] por `_`.
+ */
+export function snapshotRefForHu(huId) {
+  if (!huId) throw new Error("huId requerido");
+  const safe = String(huId).replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
+  return REF_PREFIX + safe;
+}
+
+async function defaultRunner(args, opts = {}) {
+  return runCommand("git", args, opts);
+}
+
+/**
+ * Crea (o actualiza) el ref del snapshot apuntando al HEAD actual.
+ *
+ * @param {object} args
+ * @param {string} args.projectDir
+ * @param {string} args.huId
+ * @param {Function} [args.runner] - sustituye git CLI en tests
+ * @returns {Promise<{ ok: boolean, ref?: string, sha?: string, error?: string }>}
+ */
+export async function createHuSnapshot({ projectDir, huId, runner }) {
+  const run = runner || defaultRunner;
+  const ref = snapshotRefForHu(huId);
+  const head = await run(["rev-parse", "HEAD"], { cwd: projectDir });
+  if (head.exitCode !== 0) {
+    return { ok: false, error: `rev-parse HEAD failed: ${(head.stderr || "").trim()}` };
+  }
+  const sha = (head.stdout || "").trim();
+  if (!sha) return { ok: false, error: "HEAD vacío" };
+  const update = await run(["update-ref", ref, sha], { cwd: projectDir });
+  if (update.exitCode !== 0) {
+    return { ok: false, error: `update-ref falló: ${(update.stderr || "").trim()}` };
+  }
+  return { ok: true, ref, sha };
+}
+
+/**
+ * @param {object} args
+ * @param {string} args.projectDir
+ * @param {string} args.huId
+ * @param {Function} [args.runner]
+ * @returns {Promise<{ ok: boolean, sha?: string }>}
+ */
+export async function hasHuSnapshot({ projectDir, huId, runner }) {
+  const run = runner || defaultRunner;
+  const ref = snapshotRefForHu(huId);
+  const r = await run(["rev-parse", "--verify", "--quiet", ref], { cwd: projectDir });
+  if (r.exitCode !== 0) return { ok: false };
+  return { ok: true, sha: (r.stdout || "").trim() };
+}
+
+/**
+ * Restaura el workspace al snapshot. DESTRUCTIVO: hace `git reset --hard`,
+ * lo que descarta cambios no committeados. Caller debe avisar al usuario.
+ *
+ * @returns {Promise<{ ok: boolean, sha?: string, error?: string }>}
+ */
+export async function restoreHuSnapshot({ projectDir, huId, runner }) {
+  const run = runner || defaultRunner;
+  const ref = snapshotRefForHu(huId);
+  const has = await hasHuSnapshot({ projectDir, huId, runner: run });
+  if (!has.ok) return { ok: false, error: `snapshot no encontrado para HU ${huId}` };
+  const r = await run(["reset", "--hard", ref], { cwd: projectDir });
+  if (r.exitCode !== 0) {
+    return { ok: false, error: `reset --hard falló: ${(r.stderr || "").trim()}` };
+  }
+  return { ok: true, sha: has.sha };
+}
+
+/**
+ * Borra el ref del snapshot. Idempotente: si no existe, devuelve ok:true.
+ */
+export async function removeHuSnapshot({ projectDir, huId, runner }) {
+  const run = runner || defaultRunner;
+  const ref = snapshotRefForHu(huId);
+  const r = await run(["update-ref", "-d", ref], { cwd: projectDir });
+  // git update-ref -d devuelve 0 incluso si el ref no existía.
+  if (r.exitCode !== 0) {
+    return { ok: false, error: `update-ref -d falló: ${(r.stderr || "").trim()}` };
+  }
+  return { ok: true };
+}

--- a/tests/git/hu-snapshot.test.js
+++ b/tests/git/hu-snapshot.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  snapshotRefForHu, createHuSnapshot, hasHuSnapshot,
+  restoreHuSnapshot, removeHuSnapshot,
+} from "../../src/git/hu-snapshot.js";
+
+// KJC-TSK-0408: snapshots git per-HU. Tests con runner mock — no
+// necesitan un repo git real.
+
+describe("snapshotRefForHu", () => {
+  it("genera ref bajo refs/kj-snapshots/", () => {
+    expect(snapshotRefForHu("hu_001")).toBe("refs/kj-snapshots/hu_001");
+  });
+  it("sanitiza caracteres no válidos para git refs", () => {
+    expect(snapshotRefForHu("hu/with..weird:chars")).toBe("refs/kj-snapshots/hu_with__weird_chars");
+  });
+  it("trunca a 80 chars el segmento del HU", () => {
+    const long = "x".repeat(200);
+    const r = snapshotRefForHu(long);
+    expect(r.length).toBeLessThanOrEqual("refs/kj-snapshots/".length + 80);
+  });
+  it("falla con huId vacío", () => {
+    expect(() => snapshotRefForHu("")).toThrow(/huId/);
+    expect(() => snapshotRefForHu(null)).toThrow(/huId/);
+  });
+});
+
+const okRun = (impl) => vi.fn(impl);
+
+describe("createHuSnapshot", () => {
+  it("rev-parse + update-ref → ok con sha del HEAD", async () => {
+    const runner = okRun((args) => {
+      if (args[0] === "rev-parse" && args[1] === "HEAD") return { exitCode: 0, stdout: "abc123def\n", stderr: "" };
+      if (args[0] === "update-ref") return { exitCode: 0, stdout: "", stderr: "" };
+      return { exitCode: 1, stderr: "unexpected" };
+    });
+    const r = await createHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(true);
+    expect(r.ref).toBe("refs/kj-snapshots/hu_001");
+    expect(r.sha).toBe("abc123def");
+    // update-ref llamado con el ref + sha
+    expect(runner).toHaveBeenCalledWith(["update-ref", "refs/kj-snapshots/hu_001", "abc123def"], expect.any(Object));
+  });
+
+  it("rev-parse falla → ok:false con error", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 128, stdout: "", stderr: "not a git repo" });
+    const r = await createHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/rev-parse/);
+  });
+
+  it("update-ref falla → ok:false con error", async () => {
+    const runner = vi.fn()
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc\n", stderr: "" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "permission denied" });
+    const r = await createHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/update-ref/);
+  });
+});
+
+describe("hasHuSnapshot", () => {
+  it("ref existe → ok:true + sha", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "abc123\n", stderr: "" });
+    const r = await hasHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r).toEqual({ ok: true, sha: "abc123" });
+  });
+  it("ref no existe → ok:false", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    const r = await hasHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("restoreHuSnapshot", () => {
+  it("snapshot existe + reset OK → ok:true con sha", async () => {
+    const runner = vi.fn()
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" }) // hasHuSnapshot
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });        // reset --hard
+    const r = await restoreHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(true);
+    expect(r.sha).toBe("abc123");
+  });
+  it("snapshot no existe → ok:false", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 1, stdout: "", stderr: "" });
+    const r = await restoreHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no encontrado/);
+  });
+  it("reset falla → ok:false", async () => {
+    const runner = vi.fn()
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "abc123\n", stderr: "" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "merge in progress" });
+    const r = await restoreHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/reset/);
+  });
+});
+
+describe("removeHuSnapshot", () => {
+  it("ok → update-ref -d invocado y ok:true", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await removeHuSnapshot({ projectDir: "/x", huId: "hu_001", runner });
+    expect(r.ok).toBe(true);
+    expect(runner).toHaveBeenCalledWith(["update-ref", "-d", "refs/kj-snapshots/hu_001"], expect.any(Object));
+  });
+  it("idempotente: ref no existía → todavía ok:true (git devuelve 0)", async () => {
+    const runner = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const r = await removeHuSnapshot({ projectDir: "/x", huId: "missing", runner });
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Primer paso de **KJC-TSK-0408** (Undo per HU). Módulo bajo nivel que crea, restaura y borra snapshots git por HU usando refs nativos.

### Por qué refs git
- **O(1) en disco**: comparten blobs con HEAD (no copia ficheros).
- **Persisten** a través de checkouts y rebases.
- **restore = \`git reset --hard <ref>\`** nativo, sin lógica custom.

### API

\`\`\`js
snapshotRefForHu(huId) → 'refs/kj-snapshots/<safe-id>'
createHuSnapshot({ projectDir, huId, runner? }) → { ok, ref, sha }
hasHuSnapshot({ projectDir, huId, runner? }) → { ok, sha? }
restoreHuSnapshot(...) → { ok, sha? }     // destructivo
removeHuSnapshot(...) → { ok }            // idempotente
\`\`\`

\`runner\` inyectable: tests usan mock, producción usa \`runCommand('git')\`.

## Test plan

- [x] 14 tests cubren ref naming + sanitización, create happy path + fallos rev-parse/update-ref, has existe/no-existe, restore happy + sin snapshot + reset falla, remove idempotente
- [x] lint clean

## Out of scope (próximas PRs)

- Hook en \`runCoderStage\` para snapshot pre-coder
- API endpoint \`POST /api/stories/:id/undo\`
- Botón ↺ Undo en el modal con confirm
- Persistencia de \`snapshot_sha\` en \`hu.outcome\`

## LOC

217 LOC. Módulo + tests cohesivos (un módulo nuevo sin tests sería irresponsable).