### PR TITLE
feat(plan): kj plan asigna coder_model/reviewer_model a cada HU (KJC-TSK-0405 step 2)

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -9,6 +9,7 @@ import { promptProjectName } from "../../utils/prompt-project-name.js";
 import { deriveProjectNameFromCwd } from "../../utils/derive-project-name-from-cwd.js";
 import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js";
 import { runStructuralPass } from "../../plan/plan-structural-pass.js";
+import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-router.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -137,16 +138,29 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     // referencia en `kj run --hu INFRA-001`.
     const symbolicId = typeof step === "object" && typeof step.id === "string" && step.id.trim()
       ? step.id.trim() : null;
+    const taskType = classifyTaskType(desc);
+    // KJC-TSK-0405 step 2: asigna coder_model + reviewer_model
+    // automáticamente según complexity inferido del task_type. El
+    // planner puede emitir `step.complexity` (trivial/simple/medium/complex
+    // o score 1-5) para override más fino. Cross-provider reviewer
+    // (claude↔codex) por defecto.
+    const coderProvider = config?.roles?.coder?.provider || config?.coder || "claude";
+    const complexity = (typeof step === "object" && step.complexity)
+      ? step.complexity
+      : complexityFromTaskType(taskType);
+    const models = recommendModelsForHu({ complexity, coderProvider, config });
     const hu = addHu(plan, {
       title: desc.slice(0, 80),
-      task_type: classifyTaskType(desc),
+      task_type: taskType,
       scope: desc,
       blocked_by: [],
       acceptance_tests: tests,
       short_id: symbolicId,
-      // Spec mapping (PR C): preserve the planner's section citation
-      // so the coder/reviewer / board can show "implements §5.3".
       spec_section: typeof step === "object" && typeof step.spec_section === "string" ? step.spec_section.trim() || null : null,
+      coder_model: models.coder_model,
+      coder_provider: models.coder_provider,
+      reviewer_model: models.reviewer_model,
+      reviewer_provider: models.reviewer_provider,
     });
     if (symbolicId) symbolicToHuId.set(symbolicId, hu.id);
     const deps = typeof step === "object" && Array.isArray(step.dependencies) ? step.dependencies : [];

--- a/src/hu/model-router.js
+++ b/src/hu/model-router.js
@@ -30,6 +30,26 @@ const CROSS_PROVIDER_REVIEWER = {
   gemini: "claude",
 };
 
+// KJC-TSK-0405 step 2: heurística para inferir complexity desde
+// task_type cuando el planner no emite un score explícito. Permite
+// que el model-router asigne modelos razonables sin un triage explícito.
+const TASK_TYPE_COMPLEXITY = {
+  sw: "medium",
+  refactor: "medium",
+  "add-tests": "simple",
+  infra: "trivial",
+  doc: "trivial",
+  spike: "complex",
+  research: "complex",
+  audit: "complex",
+  analysis: "medium",
+  "no-code": "trivial",
+};
+
+export function complexityFromTaskType(taskType) {
+  return TASK_TYPE_COMPLEXITY[taskType] || "medium";
+}
+
 export function complexityToLevel(complexity) {
   if (typeof complexity === "string" && LEVELS.includes(complexity)) return complexity;
   if (typeof complexity === "number" && SCORE_TO_LEVEL[complexity]) return SCORE_TO_LEVEL[complexity];

--- a/tests/hu/model-router.test.js
+++ b/tests/hu/model-router.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { recommendModelsForHu, complexityToLevel } from "../../src/hu/model-router.js";
+import {
+  recommendModelsForHu, complexityToLevel, complexityFromTaskType,
+} from "../../src/hu/model-router.js";
 
 // KJC-TSK-0405: dado un HU con complexity score, devuelve qué coder_model
 // y reviewer_model usar. Cross-provider reviewer por defecto (claude→codex,
@@ -91,5 +93,31 @@ describe("recommendModelsForHu", () => {
   it("provider desconocido → coder_model null pero no throws", () => {
     const r = recommendModelsForHu({ complexity: "medium", coderProvider: "unknownProvider", config: baseConfig });
     expect(r.coder_model).toBeNull();
+  });
+});
+
+// KJC-TSK-0405 step 2: heurística task_type → complexity para inferir
+// nivel cuando el planner no emite score explícito.
+describe("complexityFromTaskType", () => {
+  it("sw / refactor → medium", () => {
+    expect(complexityFromTaskType("sw")).toBe("medium");
+    expect(complexityFromTaskType("refactor")).toBe("medium");
+  });
+  it("doc / infra / no-code → trivial", () => {
+    expect(complexityFromTaskType("doc")).toBe("trivial");
+    expect(complexityFromTaskType("infra")).toBe("trivial");
+    expect(complexityFromTaskType("no-code")).toBe("trivial");
+  });
+  it("spike / research / audit → complex", () => {
+    expect(complexityFromTaskType("spike")).toBe("complex");
+    expect(complexityFromTaskType("research")).toBe("complex");
+    expect(complexityFromTaskType("audit")).toBe("complex");
+  });
+  it("add-tests → simple", () => {
+    expect(complexityFromTaskType("add-tests")).toBe("simple");
+  });
+  it("desconocido → medium (fallback conservador)", () => {
+    expect(complexityFromTaskType("foobar")).toBe("medium");
+    expect(complexityFromTaskType(undefined)).toBe("medium");
   });
 });


### PR DESCRIPTION
## Summary

Segundo paso del epic. Cuando \`kj plan\` crea cada HU, ahora le asigna automáticamente:
- \`coder_model\` + \`coder_provider\`
- \`reviewer_model\` + \`reviewer_provider\` (cross-provider del coder)

Origen del complexity:
1. \`step.complexity\` si el planner lo emite (score 1-5 o string)
2. Fallback: \`complexityFromTaskType(taskType)\`

Heurística task_type → complexity:
| task_type | complexity |
|---|---|
| sw, refactor, analysis | medium |
| add-tests | simple |
| doc, infra, no-code | trivial |
| spike, research, audit | complex |
| desconocido | medium |

El board muestra los modelos automáticamente. El usuario puede overridearlos desde el modal (KJC-TSK-0406, ya merged).

## Test plan

- [x] 5 tests nuevos para complexityFromTaskType
- [x] 253 tests del suite plan/hu/ passing
- [x] lint clean