### PR TITLE
feat(hu): snapshot pre-run + POST /undo + botón ⏪ Undo (KJC-TSK-0408 steps 2+3)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -1552,6 +1552,30 @@ window.saveHuModels = async function saveHuModels(storyId) {
   }
 };
 
+// KJC-TSK-0408: deshace los cambios de una HU restaurando el snapshot
+// git tomado pre-run. ATENCIÓN: es destructivo (git reset --hard) —
+// confirmamos siempre antes de invocar.
+window.undoHuChanges = async function undoHuChanges(storyId) {
+  const ok = await showConfirm(
+    '⚠️ Esta acción es destructiva.\n\nSe descartan los cambios de ficheros que esta HU hizo durante su última ejecución y se restaura el estado pre-run. La HU vuelve a pending y podrás relanzarla con otros modelos.\n\n¿Continuar?',
+    { title: 'Deshacer cambios de la HU', okLabel: 'Deshacer', cancelLabel: 'Cancelar' }
+  );
+  if (!ok) return;
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}/undo`, { method: 'POST' });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudo deshacer la HU' });
+      return;
+    }
+    closeModal();
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo al deshacer la HU' });
+  }
+};
+
 window.resetHuToPending = async function resetHuToPending(storyId) {
   const ok = await showConfirm(
     '¿Devolver esta HU a pending?\n\nEl estado se cambia a pending y se podrá relanzar. El resultado de la última ejecución (✓/✗/~) se conserva como historial hasta que vuelvas a ejecutarla.',
@@ -2230,6 +2254,20 @@ async function showStoryDetail(storyId) {
               ↺ Reset
             </button>
           ` : ''}
+          ${(() => {
+            // KJC-TSK-0408: Undo solo si la HU tiene snapshot_sha en outcome.
+            let parsedOutcome = null;
+            try { parsedOutcome = typeof story.outcome === 'string' ? JSON.parse(story.outcome) : story.outcome; } catch { /* */ }
+            const canUndo = parsedOutcome?.snapshot_sha && !parsedOutcome?.reverted;
+            return canUndo ? `
+              <button id="undo-hu-btn" class="control-btn"
+                      style="padding:6px 12px;border:1px solid var(--color-red,#ef4444);background:var(--bg-primary);color:var(--color-red,#ef4444);border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem"
+                      title="Deshacer cambios de esta HU: restaura los ficheros al snapshot pre-run y marca pending"
+                      onclick="undoHuChanges('${esc(story.id)}')">
+                ⏪ Undo
+              </button>
+            ` : '';
+          })()}
           <button class="modal__close" onclick="closeModal()">&times;</button>
         </div>
       </div>

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -202,6 +202,43 @@ export function setHuFailResult({ planId, huId, blocker, projectId }) {
 }
 
 /**
+ * KJC-TSK-0408 step 2/3: deshace los cambios de una HU restaurando
+ * el snapshot git tomado pre-run. Marca status=pending, result=null
+ * y outcome.reverted=true para que la UI muestre "deshecha".
+ *
+ * @param {object} args
+ * @param {string} args.planId
+ * @param {string} args.huId
+ * @param {string} [args.projectId]
+ * @returns {Promise<{ ok: boolean, sha?: string, error?: string }>}
+ */
+export async function revertHuFromSnapshot({ planId, huId, projectId }) {
+  const filePath = findPlanFilePath(planId, projectId);
+  if (!filePath) return { ok: false, error: `plan not found: ${planId}` };
+  const plan = readPlan(filePath);
+  const hu = plan.hus?.find(h => h.id === huId);
+  if (!hu) return { ok: false, error: `hu not found: ${huId}` };
+  const snapshotSha = hu.outcome?.snapshot_sha;
+  if (!snapshotSha) {
+    return { ok: false, error: 'esta HU no tiene snapshot — solo HUs ejecutadas con KJC-TSK-0408 pueden deshacerse' };
+  }
+  const projectDir = plan.projectDir;
+  if (!projectDir) return { ok: false, error: 'plan sin projectDir' };
+
+  const { restoreHuSnapshot } = await import('../../../src/git/hu-snapshot.js');
+  const restore = await restoreHuSnapshot({ projectDir, huId });
+  if (!restore.ok) return { ok: false, error: `restore falló: ${restore.error}` };
+
+  hu.status = 'pending';
+  hu.result = null;
+  hu.outcome = { ...(hu.outcome || {}), reverted: true, revertedAt: new Date().toISOString() };
+  hu.updatedAt = new Date().toISOString();
+  writePlan(filePath, plan);
+  syncPlanFile(filePath);
+  return { ok: true, sha: restore.sha };
+}
+
+/**
  * Bulk certify: equivalent to `kj plan ready <planId>` over HTTP. Flips
  * every pending HU to certified and sets `plan.status = "ready"`. No-op
  * on already-ready plans (idempotent, returns count=0).

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -19,7 +19,7 @@ import {
   setProjectIsTest,
 } from '../db.js';
 import { fullScan } from '../sync.js';
-import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject } from '../plan-mutations.js';
+import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject, revertHuFromSnapshot } from '../plan-mutations.js';
 import { getActiveRuns } from '../run-tracker.js';
 import { subscribe as subscribeEvents } from '../event-bus.js';
 import { runKjCommand, listSupportedCommands } from '../command-runner.js';
@@ -593,6 +593,37 @@ router.patch('/stories/:id', (req, res) => {
       planStatus: statusResult ? statusResult.planStatus : undefined,
       hu: updatedHu,
     });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * POST /api/stories/:id/undo — KJC-TSK-0408: revert a HU.
+ *
+ * Restaura los ficheros del workspace al snapshot pre-run guardado por
+ * la pipeline. Marca status=pending + result=null + outcome.reverted=true
+ * para que el usuario pueda relanzar la HU con otros modelos.
+ *
+ * Falla con 400 si la HU no tiene snapshot (HUs anteriores al hook).
+ * Falla con 404 si plan/HU no existe.
+ */
+router.post('/stories/:id/undo', async (req, res) => {
+  try {
+    const row = getStoryRow(req.params.id);
+    if (!row) return res.status(404).json({ error: 'Story not found' });
+    if (!row.plan_id) {
+      return res.status(409).json({ error: 'Story sin plan_id — legacy row no soportada.' });
+    }
+    const huId = req.params.id.includes('::')
+      ? req.params.id.split('::').slice(1).join('::')
+      : req.params.id;
+    const result = await revertHuFromSnapshot({ planId: row.plan_id, huId, projectId: row.project_id });
+    if (!result.ok) {
+      const code = /not found|no encontrado/i.test(result.error) ? 404 : 400;
+      return res.status(code).json({ error: result.error });
+    }
+    res.json({ ok: true, id: req.params.id, sha: result.sha });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -262,6 +262,37 @@ describe('PATCH /api/stories/:id', () => {
   });
 });
 
+// KJC-TSK-0408: POST /api/stories/:id/undo deshace una HU restaurando
+// el snapshot git. Los tests cubren los códigos de error (sin snapshot,
+// HU inexistente, plan sin projectDir); el happy path requiere un repo
+// git real así que se valida en e2e.
+describe('POST /api/stories/:id/undo', () => {
+  it('400 cuando la HU no tiene snapshot_sha en outcome', async () => {
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app).post(`/api/stories/${encodeURIComponent(storyId)}/undo`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/snapshot/i);
+  });
+
+  it('404 cuando la story no existe', async () => {
+    const res = await request(app).post('/api/stories/ghost/undo');
+    expect(res.status).toBe(404);
+  });
+
+  it('400 cuando el plan no tiene projectDir', async () => {
+    // Pre-seed: la HU tiene snapshot_sha pero el plan carece de projectDir
+    const plan = readPlanFromDisk();
+    plan.hus[0].outcome = { snapshot_sha: 'abc123', snapshot_ref: 'refs/kj-snapshots/x' };
+    delete plan.projectDir;
+    writeFileSync(planPath(), JSON.stringify(plan, null, 2), 'utf-8');
+    syncMod.syncPlanFile(planPath());
+    const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
+    const res = await request(app).post(`/api/stories/${encodeURIComponent(storyId)}/undo`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/projectDir/);
+  });
+});
+
 describe('POST /api/plans/:planId/ready', () => {
   it('certifies every pending HU and flips the plan to ready', async () => {
     const res = await request(app)

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -31,6 +31,7 @@ import { classifyFailure, createFailureTracker } from "../repair/repair-detector
 import { runRepair } from "../repair/repair-runner.js";
 import { writeHistoryRecord } from "./post-loop.js";
 import { setReviewerFeedback } from "../../session/mutators.js";
+import { createHuSnapshot } from "../../git/hu-snapshot.js";
 
 /**
  * @param {object} args
@@ -118,7 +119,6 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       // así que apunta al estado limpio sobre el que el coder empieza.
       // Idempotente — si la HU ya tenía snapshot, se sobreescribe.
       try {
-        const { createHuSnapshot } = await import("../../git/hu-snapshot.js");
         const snap = await createHuSnapshot({ projectDir, huId: story.id });
         if (snap.ok) {
           story.outcome = { ...(story.outcome || {}), snapshot_sha: snap.sha, snapshot_ref: snap.ref };

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -112,6 +112,24 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       const branchName = await prepareHuBranch({ story, huBranches, config: ctx.config, logger });
       const projectDir = ctx.config.projectDir || process.cwd();
 
+      // KJC-TSK-0408 step 2: snapshot del workspace ANTES de invocar al
+      // coder. Si el usuario hace Undo después, restaura este SHA. El
+      // ref se crea sobre el HEAD ya checkouteado a la rama de la HU,
+      // así que apunta al estado limpio sobre el que el coder empieza.
+      // Idempotente — si la HU ya tenía snapshot, se sobreescribe.
+      try {
+        const { createHuSnapshot } = await import("../../git/hu-snapshot.js");
+        const snap = await createHuSnapshot({ projectDir, huId: story.id });
+        if (snap.ok) {
+          story.outcome = { ...(story.outcome || {}), snapshot_sha: snap.sha, snapshot_ref: snap.ref };
+          logger.info(`HU ${story.id}: snapshot ${snap.sha.slice(0, 7)} (ref ${snap.ref})`);
+        } else {
+          logger.warn(`HU ${story.id}: snapshot falló (non-blocking): ${snap.error}`);
+        }
+      } catch (err) {
+        logger.warn(`HU ${story.id}: snapshot threw (non-blocking): ${err.message}`);
+      }
+
       // If HU has acceptance_tests, Brain runs them as the gate instead of
       // the standard reviewer/tester pipeline. This is the radical fix:
       // concrete executable tests replace subjective reviewer opinions.


### PR DESCRIPTION
## Summary

Cierra el epic **KJC-TSK-0408** sobre el módulo de snapshots ya merged en #718.

### Step 2 — pipeline hook
- \`run-hu-batch.js\` llama \`createHuSnapshot\` tras \`prepareHuBranch\` y antes del coder
- Guarda \`snapshot_sha\` + \`snapshot_ref\` en \`story.outcome\`
- Non-blocking: si la snapshot falla (warning), el run continúa

### Step 3 — undo
- \`plan-mutations.revertHuFromSnapshot({ planId, huId, projectId })\`: lee \`outcome.snapshot_sha\`, llama \`restoreHuSnapshot\` (reset --hard), marca status=pending, result=null, outcome.reverted=true
- \`routes/api POST /api/stories/:id/undo\`: 404 si no existe la story, 400 si no hay snapshot o falla el restore
- **UI**: botón ⏪ Undo en el header del modal cuando \`outcome.snapshot_sha\` está presente y \`reverted\` no es true. Confirm modal antes (destructivo)

## Test plan

- [x] 3 tests nuevos: 400 sin snapshot, 404 si story no existe, 400 si plan sin projectDir
- [x] 54 tests plan-mutations passing
- [x] lint clean
- [x] Happy path requiere repo git real → validar manualmente en e2e