### PR TITLE
feat(hu): opencode + aider como first-class en model-router (KJC-TSK-0410)

### DIFF
--- a/src/hu/model-router.js
+++ b/src/hu/model-router.js
@@ -16,18 +16,32 @@ const SCORE_TO_LEVEL = {
 };
 
 // Defaults por provider — alineados con utils/model-selector.js DEFAULTS.
+// opencode: usa "coder" como alias razonable; el usuario suele definir
+// gemma-local/coder, ollama/coder o similar en opencode.json. Override
+// per-tier vía config.model_routing.by_provider.opencode si quieres
+// rutear distinto por complexity (ej. fast para trivial, coder para
+// complex). aider: null porque aider envuelve a otros providers — no
+// tiene "modelos propios". Si el usuario lo elige, debe configurarlo
+// explícito en config.model_routing.by_provider.aider o vía override
+// del modal por HU.
 const DEFAULT_TIERS = {
   claude: { trivial: "haiku", simple: "haiku", medium: "sonnet", complex: "opus" },
   codex: { trivial: "o4-mini", simple: "o4-mini", medium: "o4-mini", complex: "o3" },
   gemini: { trivial: "gemini-2.0-flash", simple: "gemini-2.0-flash", medium: "gemini-2.5-pro", complex: "gemini-2.5-pro" },
+  opencode: { trivial: "coder", simple: "coder", medium: "coder", complex: "coder" },
+  aider: { trivial: null, simple: null, medium: null, complex: null },
 };
 
 // Cross-provider reviewer default: para cada coder provider, qué provider
-// usa el reviewer por defecto. Idea: dos cabezas distintas miran el código.
+// usa el reviewer por defecto. Dos cabezas distintas miran el código.
+// opencode → claude: pattern "local barato escribe + cloud revisa".
+// aider → claude: aider suele correr en un model pequeño, claude verifica.
 const CROSS_PROVIDER_REVIEWER = {
   claude: "codex",
   codex: "claude",
   gemini: "claude",
+  opencode: "claude",
+  aider: "claude",
 };
 
 // KJC-TSK-0405 step 2: heurística para inferir complexity desde

--- a/tests/hu/model-router.test.js
+++ b/tests/hu/model-router.test.js
@@ -121,3 +121,38 @@ describe("complexityFromTaskType", () => {
     expect(complexityFromTaskType(undefined)).toBe("medium");
   });
 });
+
+// KJC-TSK-0410: opencode + aider como first-class providers en el router.
+describe("recommendModelsForHu — opencode / aider", () => {
+  it("opencode coder usa alias 'coder' por defecto en cualquier complexity", () => {
+    const cfg = { roles: { coder: { provider: "opencode" } } };
+    for (const level of ["trivial", "simple", "medium", "complex"]) {
+      const r = recommendModelsForHu({ complexity: level, coderProvider: "opencode", config: cfg });
+      expect(r.coder_model).toBe("coder");
+    }
+  });
+
+  it("opencode → reviewer claude (cross-provider: local escribe, cloud revisa)", () => {
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "opencode", config: {} });
+    expect(r.reviewer_provider).toBe("claude");
+    expect(r.reviewer_model).toBe("sonnet");
+  });
+
+  it("aider coder devuelve null por defecto (aider envuelve a otros, no tiene modelos propios)", () => {
+    const r = recommendModelsForHu({ complexity: "medium", coderProvider: "aider", config: {} });
+    expect(r.coder_model).toBeNull();
+    expect(r.reviewer_provider).toBe("claude");
+  });
+
+  it("by_provider.opencode override per-tier funciona — fast para trivial, coder-n3 para complex", () => {
+    const cfg = {
+      model_routing: {
+        by_provider: {
+          opencode: { trivial: "fast", complex: "coder-n3" },
+        },
+      },
+    };
+    expect(recommendModelsForHu({ complexity: "trivial", coderProvider: "opencode", config: cfg }).coder_model).toBe("fast");
+    expect(recommendModelsForHu({ complexity: "complex", coderProvider: "opencode", config: cfg }).coder_model).toBe("coder-n3");
+  });
+});


### PR DESCRIPTION
## Summary

Antes: \`model-router\` solo conocía claude/codex/gemini. Si el usuario configuraba opencode (local/VPS) como provider, \`recommendModelsForHu\` devolvía \`coder_model=null\` y se perdía el cross-provider review.

### Cambios

**DEFAULT_TIERS:**
- \`opencode\`: alias \"coder\" en todas las complexity (el alias estándar de opencode.json). Override per-tier vía \`config.model_routing.by_provider.opencode\`
- \`aider\`: null en todos los tiers — aider envuelve a otros providers, no tiene modelos propios

**CROSS_PROVIDER_REVIEWER:**
- \`opencode → claude\` (pattern: local barato escribe, cloud revisa)
- \`aider → claude\`

### Ejemplo de uso

\`\`\`json
{
  \"roles\": { \"coder\": { \"provider\": \"opencode\" } },
  \"model_routing\": {
    \"by_provider\": {
      \"opencode\": { \"trivial\": \"fast\", \"medium\": \"coder\", \"complex\": \"coder-n3\" }
    }
  }
}
\`\`\`

Resultado: HU complejas → \`coder-n3\` local + reviewer \`claude/opus\` en cloud.

## Test plan

- [x] 4 tests nuevos
- [x] 22 tests model-router passing
- [x] lint clean