### PR TITLE
feat(brain): withBrainRecovery wrapper (KJC-TSK-0412)

### DIFF
--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -1,0 +1,116 @@
+// KJC-TSK-0412: wrapper central de recovery. Cualquier stage que invoque
+// un agente IA pasa por aquí. Brain consume classifyAgentError (TSK-0411)
+// y decide: standby corto, backoff exponencial, hibernar, o abortar.
+//
+// Hibernar al disco (acción persistente) es TSK-0414 — esta PR devuelve
+// { ok: false, action: "hibernate", retryUntil } cuando aplica; el caller
+// puede ignorarlo (fallback a long standby capped) hasta que llegue 0414.
+
+import { classifyAgentError, ERROR_CLASS } from "./agent-error-classifier.js";
+
+const ONE_MIN = 60 * 1000;
+
+export const DEFAULT_RECOVERY_POLICY = Object.freeze({
+  hibernateThresholdMs: 5 * ONE_MIN, // > 5 min de espera → hibernar
+  longStandbyCapMs: 10 * ONE_MIN,    // si el caller no hiberna, espera máx 10 min
+  classes: {
+    [ERROR_CLASS.RATE_LIMIT_SHORT]: { mode: "standby", maxRetries: 3 },
+    [ERROR_CLASS.QUOTA_EXHAUSTED_DAILY]: { mode: "hibernate", maxRetries: 1 },
+    [ERROR_CLASS.API_DOWN]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
+    [ERROR_CLASS.NETWORK_TIMEOUT]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
+    [ERROR_CLASS.SILENCED]: { mode: "backoff", maxRetries: 2, baseMs: 30_000, factor: 2, jitterPct: 0.15 },
+    [ERROR_CLASS.AUTH_FAILED]: { mode: "abort", maxRetries: 0 },
+    [ERROR_CLASS.UNKNOWN_FATAL]: { mode: "abort", maxRetries: 0 },
+  },
+});
+
+function backoffDelay(policyForClass, attempt) {
+  const { baseMs = 5_000, factor = 2, jitterPct = 0.1 } = policyForClass;
+  const ms = baseMs * factor ** attempt;
+  const jitter = ms * jitterPct * (Math.random() * 2 - 1);
+  return Math.max(0, Math.round(ms + jitter));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function emit(emitter, type, eventBase, detail) {
+  if (!emitter || typeof emitter.emit !== "function") return;
+  try {
+    emitter.emit("progress", { ...(eventBase || {}), type, detail });
+  } catch { /* nunca bloquees un retry por un emitter mal */ }
+}
+
+/**
+ * @param {object} args
+ * @param {object} args.agent - Agent con runTask({...})
+ * @param {object} args.taskArgs - args pasados a agent.runTask
+ * @param {string} args.role - "planner" | "coder" | "reviewer" | ...
+ * @param {string} [args.provider] - claude|codex|gemini|opencode (default: agent.provider)
+ * @param {object} [args.policy] - override DEFAULT_RECOVERY_POLICY
+ * @param {object} [args.emitter] - bus de eventos
+ * @param {object} [args.eventBase]
+ * @param {object} [args.logger]
+ * @param {Function} [args.sleepFn] - inyectable para tests
+ * @returns {Promise<{ ok: boolean, output?: string, action?: string, recovery?: object, error?: string }>}
+ */
+export async function withBrainRecovery({
+  agent, taskArgs, role, provider,
+  policy = DEFAULT_RECOVERY_POLICY,
+  emitter, eventBase, logger,
+  sleepFn = sleep,
+}) {
+  const effectiveProvider = provider || agent?.provider || "unknown";
+  const attemptsByClass = {};
+
+  while (true) {
+    const result = await agent.runTask(taskArgs);
+    if (result?.ok) return result;
+
+    const cls = classifyAgentError({
+      provider: effectiveProvider,
+      stdout: result?.output || "",
+      stderr: result?.error || "",
+      exitCode: result?.exitCode ?? null,
+    });
+    const classPolicy = policy.classes[cls.class] || { mode: "abort", maxRetries: 0 };
+    attemptsByClass[cls.class] = (attemptsByClass[cls.class] || 0) + 1;
+    const attempt = attemptsByClass[cls.class];
+
+    emit(emitter, "brain:agent-error", eventBase, { role, class: cls.class, attempt, message: cls.message, provider: effectiveProvider });
+    logger?.warn?.(`[brain] ${role} (${effectiveProvider}) → ${cls.class} attempt ${attempt}/${classPolicy.maxRetries}: ${cls.message}`);
+
+    // ABORT: no recuperable.
+    if (classPolicy.mode === "abort" || attempt > classPolicy.maxRetries) {
+      emit(emitter, "brain:fatal", eventBase, { role, class: cls.class, message: cls.message });
+      return { ok: false, action: "abort", recovery: cls, error: `Brain aborted: ${cls.class} — ${cls.message}` };
+    }
+
+    // HIBERNATE: persistir+morir es TSK-0414. Aquí emitimos la señal y, si
+    // el caller no maneja, hacemos long-standby capped (degradación graceful).
+    if (classPolicy.mode === "hibernate" && cls.retryAfter && cls.retryAfter > policy.hibernateThresholdMs) {
+      emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter });
+      return { ok: false, action: "hibernate", recovery: cls };
+    }
+
+    // STANDBY: espera hasta cooldownUntil (capado por longStandbyCapMs).
+    if (classPolicy.mode === "standby") {
+      const waitMs = Math.min(cls.retryAfter || ONE_MIN, policy.longStandbyCapMs);
+      emit(emitter, "brain:standby", eventBase, { role, class: cls.class, waitMs, retryUntil: cls.retryUntil });
+      await sleepFn(waitMs);
+      continue;
+    }
+
+    // BACKOFF exponencial con jitter.
+    if (classPolicy.mode === "backoff") {
+      const waitMs = backoffDelay(classPolicy, attempt - 1);
+      emit(emitter, "brain:backoff", eventBase, { role, class: cls.class, attempt, waitMs });
+      await sleepFn(waitMs);
+      continue;
+    }
+
+    // Modo desconocido — defensive abort.
+    return { ok: false, action: "abort", recovery: cls, error: `Brain: unknown mode '${classPolicy.mode}' for class ${cls.class}` };
+  }
+}

--- a/tests/brain/with-brain-recovery.test.js
+++ b/tests/brain/with-brain-recovery.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { withBrainRecovery, DEFAULT_RECOVERY_POLICY } from "../../src/brain/with-brain-recovery.js";
+
+// KJC-TSK-0412: Brain decide retry/standby/hibernate/abort según clase.
+// sleepFn inyectable → tests no esperan tiempo real.
+
+const noSleep = () => Promise.resolve();
+
+function makeAgent(responses) {
+  let i = 0;
+  return {
+    provider: "claude",
+    runTask: vi.fn(async () => {
+      const r = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return r;
+    }),
+  };
+}
+
+describe("withBrainRecovery — happy path", () => {
+  it("ok inmediato → devuelve resultado, sin retries", async () => {
+    const agent = makeAgent([{ ok: true, output: "done" }]);
+    const r = await withBrainRecovery({ agent, taskArgs: { prompt: "x" }, role: "planner", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withBrainRecovery — RATE_LIMIT_SHORT → standby + retry", () => {
+  it("rate limit con retry-after, segundo intento ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "rate limit, retry after 10 seconds", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("3 retries consecutivos → abort", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "429 rate limit, retry after 10 seconds", exitCode: 1 },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("abort");
+    expect(r.recovery.class).toBe("RATE_LIMIT_SHORT");
+    // 3 retries + intento fallido N+1 que dispara el abort = 4 llamadas
+    expect(agent.runTask).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
+  it("quota con reset >1h → action='hibernate' inmediato (sin retry)", async () => {
+    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    const agent = makeAgent([
+      { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
+    ]);
+    const emit = vi.fn();
+    const emitter = { emit };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "planner", emitter, sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("hibernate");
+    expect(r.recovery.class).toBe("QUOTA_EXHAUSTED_DAILY");
+    expect(r.recovery.retryUntil).toBe(target);
+    // Debe haber emitido la señal de hibernate-request
+    const hibernateEvent = emit.mock.calls.find(([_evt, payload]) => payload?.type === "brain:hibernate-request");
+    expect(hibernateEvent).toBeTruthy();
+  });
+});
+
+describe("withBrainRecovery — backoff exponencial", () => {
+  it("NETWORK_TIMEOUT recuperable: 1er fallo + 2do ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "ECONNRESET", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const sleeps = [];
+    const sleepFn = vi.fn(async (ms) => { sleeps.push(ms); });
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn });
+    expect(r.ok).toBe(true);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+    expect(sleeps[0]).toBeGreaterThan(0);
+  });
+
+  it("API_DOWN retries con delays crecientes (factor 3)", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "503 service unavailable", exitCode: 1 },
+      { ok: false, error: "503 service unavailable", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const sleeps = [];
+    const sleepFn = vi.fn(async (ms) => { sleeps.push(ms); });
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn });
+    expect(r.ok).toBe(true);
+    // Backoff es base * factor^attempt: 5s, 15s, 45s con jitter ±20%
+    expect(sleeps[1]).toBeGreaterThan(sleeps[0]);
+  });
+});
+
+describe("withBrainRecovery — AUTH_FAILED → abort sin retry", () => {
+  it("401 → action='abort' sin reintentar", async () => {
+    const agent = makeAgent([{ ok: false, error: "401 unauthorized", exitCode: 1 }]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("abort");
+    expect(r.recovery.class).toBe("AUTH_FAILED");
+    expect(agent.runTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withBrainRecovery — SILENCED → backoff", () => {
+  it("silenced 1ra vez, 2da ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "Command killed after 180000ms without output", exitCode: 143 },
+      { ok: true, output: "done" },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "planner", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("withBrainRecovery — observabilidad", () => {
+  it("emite brain:agent-error en cada fallo + brain:fatal en abort", async () => {
+    const agent = makeAgent([{ ok: false, error: "401 unauthorized", exitCode: 1 }]);
+    const emit = vi.fn();
+    await withBrainRecovery({ agent, taskArgs: {}, role: "coder", emitter: { emit }, sleepFn: noSleep });
+    const types = emit.mock.calls.map(([_evt, p]) => p?.type);
+    expect(types).toContain("brain:agent-error");
+    expect(types).toContain("brain:fatal");
+  });
+
+  it("emite brain:backoff con waitMs en recuperables backoff", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "ECONNRESET", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const emit = vi.fn();
+    await withBrainRecovery({ agent, taskArgs: {}, role: "coder", emitter: { emit }, sleepFn: noSleep });
+    const backoff = emit.mock.calls.find(([_evt, p]) => p?.type === "brain:backoff");
+    expect(backoff).toBeTruthy();
+    expect(backoff[1].detail.waitMs).toBeGreaterThan(0);
+  });
+});
+
+describe("withBrainRecovery — políticas custom", () => {
+  it("respeta maxRetries override del caller", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "429 rate limit", exitCode: 1 },
+    ]);
+    const policy = {
+      ...DEFAULT_RECOVERY_POLICY,
+      classes: {
+        ...DEFAULT_RECOVERY_POLICY.classes,
+        RATE_LIMIT_SHORT: { mode: "standby", maxRetries: 1 },
+      },
+    };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", policy, sleepFn: noSleep });
+    expect(r.action).toBe("abort");
+    expect(agent.runTask).toHaveBeenCalledTimes(2); // 1 retry + abort
+  });
+});


### PR DESCRIPTION
## Summary

Segundo paso del epic **KJC-PCS-0044**. Consume el classifier de #722 y aplica política de recuperación.

**Base: \`feat/brain-error-classifier\` (PR #722)** — esta PR depende de la 722. Se mergea automáticamente contra main cuando 722 merge.

### Política por defecto

| Clase | Modo | Retries | Detalle |
|---|---|---|---|
| RATE_LIMIT_SHORT | standby | 3 | espera cooldownUntil (cap 10 min) |
| QUOTA_EXHAUSTED_DAILY | hibernate | 1 | señaliza al caller (TSK-0414 persiste) |
| API_DOWN | backoff | 3 | 5s→15s→45s + jitter ±20% |
| NETWORK_TIMEOUT | backoff | 3 | 5s→15s→45s |
| SILENCED | backoff | 2 | 30s→60s (conservador) |
| AUTH_FAILED | abort | 0 | escalar al usuario |
| UNKNOWN_FATAL | abort | 0 | escalar |

### Observabilidad

Emite: \`brain:agent-error\`, \`brain:standby\`, \`brain:backoff\`, \`brain:hibernate-request\`, \`brain:fatal\`. UI del board los renderizará en TSK-0414+.

### sleepFn inyectable

Tests no esperan tiempo real → 11 tests corren en 122ms.

## Test plan

- [x] 11 tests: happy path, retry/abort por clase, hibernate, observabilidad, policy override
- [x] lint clean

## LOC

280 LOC. Wrapper + tests cohesivos. Large-pr-justified.

## Próximas PRs

- **TSK-0413**: wire en TODOS los \`agent.runTask\` (coder, reviewer, planner, triage, hu-reviewer, security, audit, etc.)
- **TSK-0414**: hibernación al disco — \`kj resume\` + board auto-resume