### PR TITLE
feat(brain): wire withBrainRecovery en plan flows críticos (KJC-TSK-0413 step A)

### DIFF
--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -1,0 +1,116 @@
+// KJC-TSK-0412: wrapper central de recovery. Cualquier stage que invoque
+// un agente IA pasa por aquí. Brain consume classifyAgentError (TSK-0411)
+// y decide: standby corto, backoff exponencial, hibernar, o abortar.
+//
+// Hibernar al disco (acción persistente) es TSK-0414 — esta PR devuelve
+// { ok: false, action: "hibernate", retryUntil } cuando aplica; el caller
+// puede ignorarlo (fallback a long standby capped) hasta que llegue 0414.
+
+import { classifyAgentError, ERROR_CLASS } from "./agent-error-classifier.js";
+
+const ONE_MIN = 60 * 1000;
+
+export const DEFAULT_RECOVERY_POLICY = Object.freeze({
+  hibernateThresholdMs: 5 * ONE_MIN, // > 5 min de espera → hibernar
+  longStandbyCapMs: 10 * ONE_MIN,    // si el caller no hiberna, espera máx 10 min
+  classes: {
+    [ERROR_CLASS.RATE_LIMIT_SHORT]: { mode: "standby", maxRetries: 3 },
+    [ERROR_CLASS.QUOTA_EXHAUSTED_DAILY]: { mode: "hibernate", maxRetries: 1 },
+    [ERROR_CLASS.API_DOWN]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
+    [ERROR_CLASS.NETWORK_TIMEOUT]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
+    [ERROR_CLASS.SILENCED]: { mode: "backoff", maxRetries: 2, baseMs: 30_000, factor: 2, jitterPct: 0.15 },
+    [ERROR_CLASS.AUTH_FAILED]: { mode: "abort", maxRetries: 0 },
+    [ERROR_CLASS.UNKNOWN_FATAL]: { mode: "abort", maxRetries: 0 },
+  },
+});
+
+function backoffDelay(policyForClass, attempt) {
+  const { baseMs = 5_000, factor = 2, jitterPct = 0.1 } = policyForClass;
+  const ms = baseMs * factor ** attempt;
+  const jitter = ms * jitterPct * (Math.random() * 2 - 1);
+  return Math.max(0, Math.round(ms + jitter));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function emit(emitter, type, eventBase, detail) {
+  if (!emitter || typeof emitter.emit !== "function") return;
+  try {
+    emitter.emit("progress", { ...(eventBase || {}), type, detail });
+  } catch { /* nunca bloquees un retry por un emitter mal */ }
+}
+
+/**
+ * @param {object} args
+ * @param {object} args.agent - Agent con runTask({...})
+ * @param {object} args.taskArgs - args pasados a agent.runTask
+ * @param {string} args.role - "planner" | "coder" | "reviewer" | ...
+ * @param {string} [args.provider] - claude|codex|gemini|opencode (default: agent.provider)
+ * @param {object} [args.policy] - override DEFAULT_RECOVERY_POLICY
+ * @param {object} [args.emitter] - bus de eventos
+ * @param {object} [args.eventBase]
+ * @param {object} [args.logger]
+ * @param {Function} [args.sleepFn] - inyectable para tests
+ * @returns {Promise<{ ok: boolean, output?: string, action?: string, recovery?: object, error?: string }>}
+ */
+export async function withBrainRecovery({
+  agent, taskArgs, role, provider,
+  policy = DEFAULT_RECOVERY_POLICY,
+  emitter, eventBase, logger,
+  sleepFn = sleep,
+}) {
+  const effectiveProvider = provider || agent?.provider || "unknown";
+  const attemptsByClass = {};
+
+  while (true) {
+    const result = await agent.runTask(taskArgs);
+    if (result?.ok) return result;
+
+    const cls = classifyAgentError({
+      provider: effectiveProvider,
+      stdout: result?.output || "",
+      stderr: result?.error || "",
+      exitCode: result?.exitCode ?? null,
+    });
+    const classPolicy = policy.classes[cls.class] || { mode: "abort", maxRetries: 0 };
+    attemptsByClass[cls.class] = (attemptsByClass[cls.class] || 0) + 1;
+    const attempt = attemptsByClass[cls.class];
+
+    emit(emitter, "brain:agent-error", eventBase, { role, class: cls.class, attempt, message: cls.message, provider: effectiveProvider });
+    logger?.warn?.(`[brain] ${role} (${effectiveProvider}) → ${cls.class} attempt ${attempt}/${classPolicy.maxRetries}: ${cls.message}`);
+
+    // ABORT: no recuperable.
+    if (classPolicy.mode === "abort" || attempt > classPolicy.maxRetries) {
+      emit(emitter, "brain:fatal", eventBase, { role, class: cls.class, message: cls.message });
+      return { ok: false, action: "abort", recovery: cls, error: `Brain aborted: ${cls.class} — ${cls.message}` };
+    }
+
+    // HIBERNATE: persistir+morir es TSK-0414. Aquí emitimos la señal y, si
+    // el caller no maneja, hacemos long-standby capped (degradación graceful).
+    if (classPolicy.mode === "hibernate" && cls.retryAfter && cls.retryAfter > policy.hibernateThresholdMs) {
+      emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter });
+      return { ok: false, action: "hibernate", recovery: cls };
+    }
+
+    // STANDBY: espera hasta cooldownUntil (capado por longStandbyCapMs).
+    if (classPolicy.mode === "standby") {
+      const waitMs = Math.min(cls.retryAfter || ONE_MIN, policy.longStandbyCapMs);
+      emit(emitter, "brain:standby", eventBase, { role, class: cls.class, waitMs, retryUntil: cls.retryUntil });
+      await sleepFn(waitMs);
+      continue;
+    }
+
+    // BACKOFF exponencial con jitter.
+    if (classPolicy.mode === "backoff") {
+      const waitMs = backoffDelay(classPolicy, attempt - 1);
+      emit(emitter, "brain:backoff", eventBase, { role, class: cls.class, attempt, waitMs });
+      await sleepFn(waitMs);
+      continue;
+    }
+
+    // Modo desconocido — defensive abort.
+    return { ok: false, action: "abort", recovery: cls, error: `Brain: unknown mode '${classPolicy.mode}' for class ${cls.class}` };
+  }
+}

--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -32,6 +32,11 @@ function backoffDelay(policyForClass, attempt) {
 }
 
 function sleep(ms) {
+  // En tests (VITEST / NODE_ENV=test) saltamos sleeps reales — los tests que
+  // necesitan timing controlado inyectan sleepFn explícito. Esto evita que
+  // tests de stages downstream que llaman a withBrainRecovery se cuelguen
+  // esperando standby cuando el agente fake devuelve un error recoverable.
+  if (process.env.VITEST || process.env.NODE_ENV === "test") return Promise.resolve();
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -10,6 +10,7 @@ import { deriveProjectNameFromCwd } from "../../utils/derive-project-name-from-c
 import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js";
 import { runStructuralPass } from "../../plan/plan-structural-pass.js";
 import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-router.js";
+import { withBrainRecovery } from "../../brain/with-brain-recovery.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -61,11 +62,15 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   const progress = createCliProgressReporter({ role: "planner:initial", quiet: Boolean(json) });
   let result;
   try {
-    result = await planner.runTask({
-      prompt, role: "planner", silenceTimeoutMs, timeoutMs,
-      onOutput: progress.onOutput,
+    // KJC-TSK-0413: planner inicial pasa por Brain Recovery — clasifica
+    // 401/429/5xx/SILENCED/etc y decide retry/standby/hibernate/abort.
+    result = await withBrainRecovery({
+      agent: planner,
+      taskArgs: { prompt, role: "planner", silenceTimeoutMs, timeoutMs, onOutput: progress.onOutput },
+      role: "planner",
+      logger,
     });
-    progress.finish(result.ok ? "done" : "failed");
+    progress.finish(result.ok ? "done" : (result.action || "failed"));
   } catch (err) {
     progress.finish("failed");
     throw err;

--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -12,6 +12,7 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { addHu, removeHu } from "./plan-hu-ops.js";
 import { normaliseAcceptanceTests } from "./plan-schema.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 export function buildFixerPrompt({ task, hus, findings }) {
   const huSummary = hus.map((h) => {
@@ -90,14 +91,18 @@ function normalisePatch(raw) {
   return out;
 }
 
-export async function applyReviewerFeedback({ agent, task, hus, findings, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function applyReviewerFeedback({ agent, task, hus, findings, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   const prompt = buildFixerPrompt({ task, hus, findings });
   const runArgs = { prompt, role: "planner" };
   if (onOutput) runArgs.onOutput = onOutput;
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
-  const result = await agent.runTask(runArgs);
-  if (!result.ok) return { ok: false, error: result.error || "fixer agent failed" };
+  // KJC-TSK-0413: Brain Recovery — fix loop ya no muere silencioso.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "plan-fixer",
+    emitter, eventBase, logger,
+  });
+  if (!result.ok) return { ok: false, error: result.error || `fixer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   const parsed = extractFirstJson(result.output || "");
   if (!parsed || typeof parsed !== "object") {
     return { ok: false, error: "fixer returned no JSON object" };

--- a/src/plan/plan-reviewer.js
+++ b/src/plan/plan-reviewer.js
@@ -30,6 +30,7 @@
  */
 
 import { extractFirstJson } from "../utils/json-extract.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 /**
  * Build the focused review prompt. Exported for unit-testing the
@@ -113,7 +114,7 @@ export function buildReviewerPrompt({ task, hus }) {
  * @param {number} [args.timeoutMs]
  * @returns {Promise<{ ok: boolean, findings?: object, error?: string }>}
  */
-export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   if (!Array.isArray(hus) || hus.length === 0) {
     return { ok: true, findings: emptyFindings("Plan has no HUs to review.") };
   }
@@ -123,9 +124,15 @@ export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs,
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
 
-  const result = await agent.runTask(runArgs);
+  // KJC-TSK-0413: el caso real del 2026-05-16 (plan-fix iter 2 "failed
+  // 219.3s" sin clase) entraba aquí. Ahora Brain clasifica el fallo y
+  // decide retry/standby/hibernate/abort.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "plan-reviewer",
+    emitter, eventBase, logger,
+  });
   if (!result.ok) {
-    return { ok: false, error: result.error || "reviewer agent failed" };
+    return { ok: false, error: result.error || `reviewer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   }
   const parsed = extractFirstJson(result.output || "");
   if (!parsed || typeof parsed !== "object") {

--- a/src/plan/tests-synthesizer.js
+++ b/src/plan/tests-synthesizer.js
@@ -22,6 +22,7 @@
 
 import { extractFirstJson } from "../utils/json-extract.js";
 import { normaliseAcceptanceTests } from "./plan-schema.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 /**
  * Build the focused-pass prompt asking ONLY for tests for the given
@@ -85,7 +86,7 @@ export function buildSynthesizerPrompt({ task, husNeedingTests }) {
  * @param {number} [args.timeoutMs]
  * @returns {Promise<{ ok: boolean, tests?: Record<string, object[]>, error?: string }>}
  */
-export async function synthesizeMissingTests({ agent, task, husNeedingTests, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function synthesizeMissingTests({ agent, task, husNeedingTests, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   if (!Array.isArray(husNeedingTests) || husNeedingTests.length === 0) {
     return { ok: true, tests: {} };
   }
@@ -95,9 +96,13 @@ export async function synthesizeMissingTests({ agent, task, husNeedingTests, onO
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
 
-  const result = await agent.runTask(runArgs);
+  // KJC-TSK-0413: Brain Recovery wraps el agent call.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "tests-synthesizer",
+    emitter, eventBase, logger,
+  });
   if (!result.ok) {
-    return { ok: false, error: result.error || "synthesizer agent failed" };
+    return { ok: false, error: result.error || `synthesizer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   }
 
   const parsed = extractFirstJson(result.output || "");

--- a/tests/brain/with-brain-recovery.test.js
+++ b/tests/brain/with-brain-recovery.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from "vitest";
+import { withBrainRecovery, DEFAULT_RECOVERY_POLICY } from "../../src/brain/with-brain-recovery.js";
+
+// KJC-TSK-0412: Brain decide retry/standby/hibernate/abort según clase.
+// sleepFn inyectable → tests no esperan tiempo real.
+
+const noSleep = () => Promise.resolve();
+
+function makeAgent(responses) {
+  let i = 0;
+  return {
+    provider: "claude",
+    runTask: vi.fn(async () => {
+      const r = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return r;
+    }),
+  };
+}
+
+describe("withBrainRecovery — happy path", () => {
+  it("ok inmediato → devuelve resultado, sin retries", async () => {
+    const agent = makeAgent([{ ok: true, output: "done" }]);
+    const r = await withBrainRecovery({ agent, taskArgs: { prompt: "x" }, role: "planner", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withBrainRecovery — RATE_LIMIT_SHORT → standby + retry", () => {
+  it("rate limit con retry-after, segundo intento ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "rate limit, retry after 10 seconds", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("3 retries consecutivos → abort", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "429 rate limit, retry after 10 seconds", exitCode: 1 },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("abort");
+    expect(r.recovery.class).toBe("RATE_LIMIT_SHORT");
+    // 3 retries + intento fallido N+1 que dispara el abort = 4 llamadas
+    expect(agent.runTask).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
+  it("quota con reset >1h → action='hibernate' inmediato (sin retry)", async () => {
+    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    const agent = makeAgent([
+      { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
+    ]);
+    const emit = vi.fn();
+    const emitter = { emit };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "planner", emitter, sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("hibernate");
+    expect(r.recovery.class).toBe("QUOTA_EXHAUSTED_DAILY");
+    expect(r.recovery.retryUntil).toBe(target);
+    // Debe haber emitido la señal de hibernate-request
+    const hibernateEvent = emit.mock.calls.find(([_evt, payload]) => payload?.type === "brain:hibernate-request");
+    expect(hibernateEvent).toBeTruthy();
+  });
+});
+
+describe("withBrainRecovery — backoff exponencial", () => {
+  it("NETWORK_TIMEOUT recuperable: 1er fallo + 2do ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "ECONNRESET", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const sleeps = [];
+    const sleepFn = vi.fn(async (ms) => { sleeps.push(ms); });
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn });
+    expect(r.ok).toBe(true);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+    expect(sleeps[0]).toBeGreaterThan(0);
+  });
+
+  it("API_DOWN retries con delays crecientes (factor 3)", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "503 service unavailable", exitCode: 1 },
+      { ok: false, error: "503 service unavailable", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const sleeps = [];
+    const sleepFn = vi.fn(async (ms) => { sleeps.push(ms); });
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn });
+    expect(r.ok).toBe(true);
+    // Backoff es base * factor^attempt: 5s, 15s, 45s con jitter ±20%
+    expect(sleeps[1]).toBeGreaterThan(sleeps[0]);
+  });
+});
+
+describe("withBrainRecovery — AUTH_FAILED → abort sin retry", () => {
+  it("401 → action='abort' sin reintentar", async () => {
+    const agent = makeAgent([{ ok: false, error: "401 unauthorized", exitCode: 1 }]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe("abort");
+    expect(r.recovery.class).toBe("AUTH_FAILED");
+    expect(agent.runTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withBrainRecovery — SILENCED → backoff", () => {
+  it("silenced 1ra vez, 2da ok", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "Command killed after 180000ms without output", exitCode: 143 },
+      { ok: true, output: "done" },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "planner", sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(agent.runTask).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("withBrainRecovery — observabilidad", () => {
+  it("emite brain:agent-error en cada fallo + brain:fatal en abort", async () => {
+    const agent = makeAgent([{ ok: false, error: "401 unauthorized", exitCode: 1 }]);
+    const emit = vi.fn();
+    await withBrainRecovery({ agent, taskArgs: {}, role: "coder", emitter: { emit }, sleepFn: noSleep });
+    const types = emit.mock.calls.map(([_evt, p]) => p?.type);
+    expect(types).toContain("brain:agent-error");
+    expect(types).toContain("brain:fatal");
+  });
+
+  it("emite brain:backoff con waitMs en recuperables backoff", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "ECONNRESET", exitCode: 1 },
+      { ok: true, output: "done" },
+    ]);
+    const emit = vi.fn();
+    await withBrainRecovery({ agent, taskArgs: {}, role: "coder", emitter: { emit }, sleepFn: noSleep });
+    const backoff = emit.mock.calls.find(([_evt, p]) => p?.type === "brain:backoff");
+    expect(backoff).toBeTruthy();
+    expect(backoff[1].detail.waitMs).toBeGreaterThan(0);
+  });
+});
+
+describe("withBrainRecovery — políticas custom", () => {
+  it("respeta maxRetries override del caller", async () => {
+    const agent = makeAgent([
+      { ok: false, error: "429 rate limit", exitCode: 1 },
+    ]);
+    const policy = {
+      ...DEFAULT_RECOVERY_POLICY,
+      classes: {
+        ...DEFAULT_RECOVERY_POLICY.classes,
+        RATE_LIMIT_SHORT: { mode: "standby", maxRetries: 1 },
+      },
+    };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", policy, sleepFn: noSleep });
+    expect(r.action).toBe("abort");
+    expect(agent.runTask).toHaveBeenCalledTimes(2); // 1 retry + abort
+  });
+});

--- a/tests/plan/plan-reviewer.test.js
+++ b/tests/plan/plan-reviewer.test.js
@@ -113,11 +113,15 @@ describe("reviewPlan", () => {
     expect(result.findings.parallelisable_groups).toHaveLength(1);
   });
 
-  it("returns ok:false on agent failure", async () => {
+  it("returns ok:false on agent failure (post Brain Recovery: abort tras retries)", async () => {
+    // KJC-TSK-0413: ahora el agent error pasa por classifier+wrapper.
+    // "rate limited" se clasifica como RATE_LIMIT_SHORT, Brain reintenta
+    // y tras maxRetries devuelve action='abort' + recovery info.
     const agent = { runTask: vi.fn().mockResolvedValue({ ok: false, error: "rate limited" }) };
     const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/rate limited/);
+    expect(result.recovery?.class).toBe("RATE_LIMIT_SHORT");
+    expect(result.action).toBe("abort");
   });
 
   it("returns ok:false on non-JSON output", async () => {


### PR DESCRIPTION
## Summary

Tercer paso del epic **KJC-PCS-0044**. Wireados los 4 stages del path principal de \`kj plan\` donde el dogfooding del 2026-05-16 vio fallos silenciosos (\"failed (219.3s)\" sin clase):

| Stage | Antes | Después |
|---|---|---|
| plan-reviewer.js | \`agent.runTask\` directo | \`withBrainRecovery role=\"plan-reviewer\"\` |
| plan-fixer.js | id. | \`role=\"plan-fixer\"\` |
| tests-synthesizer.js | id. | \`role=\"tests-synthesizer\"\` |
| commands/plan/generate.js (planner inicial) | id. | \`role=\"planner\"\` |

**Base: \`feat/with-brain-recovery-v2\` (PR #724)** — depende del wrapper.

### Cambio de semántica en fallo

\`\`\`js
// Antes
{ ok: false, error: \"agent failed\" }

// Ahora — Brain clasifica y reintenta antes de devolver
{
  ok: false,
  error: \"Brain aborted: RATE_LIMIT_SHORT — rate limit, retry after 30 seconds\",
  recovery: { class, message, retryAfter, retryUntil, recoverable, provider, exitCode },
  action: \"abort\" | \"hibernate\"
}
\`\`\`

### Test sleep en test env

\`withBrainRecovery\` ahora usa \`sleep no-op\` cuando \`process.env.VITEST || NODE_ENV===\"test\"\`. Tests que validen timing inyectan \`sleepFn\` explícito. Sin esto los unit tests de plan-reviewer se colgarían 60s+ esperando standby ante un mock agent.

## Test plan

- [x] 353 tests pasando (plan/, brain/, commands/plan-fix)
- [x] lint clean
- [x] LOC: 46 add / 15 del = 31 line delta

## Próximas PRs del step B/C

- hu-reviewer-stage, security-stage, audit-role, impeccable-role, refactorer-stage, architect-stage, researcher, discover-role, triage-stage
- lazy-planner, splitting-generator, semantic-detector
- comandos standalone: \`kj triage\`, \`kj architect\`, \`kj researcher\`, \`kj discover\`, \`kj code\`