### PR TITLE
feat(brain): wire withBrainRecovery en plan flows críticos (KJC-TSK-0413 step A)

### DIFF
--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -32,6 +32,11 @@ function backoffDelay(policyForClass, attempt) {
 }
 
 function sleep(ms) {
+  // En tests (VITEST / NODE_ENV=test) saltamos sleeps reales — los tests que
+  // necesitan timing controlado inyectan sleepFn explícito. Esto evita que
+  // tests de stages downstream que llaman a withBrainRecovery se cuelguen
+  // esperando standby cuando el agente fake devuelve un error recoverable.
+  if (process.env.VITEST || process.env.NODE_ENV === "test") return Promise.resolve();
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -10,6 +10,7 @@ import { deriveProjectNameFromCwd } from "../../utils/derive-project-name-from-c
 import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js";
 import { runStructuralPass } from "../../plan/plan-structural-pass.js";
 import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-router.js";
+import { withBrainRecovery } from "../../brain/with-brain-recovery.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -61,11 +62,15 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   const progress = createCliProgressReporter({ role: "planner:initial", quiet: Boolean(json) });
   let result;
   try {
-    result = await planner.runTask({
-      prompt, role: "planner", silenceTimeoutMs, timeoutMs,
-      onOutput: progress.onOutput,
+    // KJC-TSK-0413: planner inicial pasa por Brain Recovery — clasifica
+    // 401/429/5xx/SILENCED/etc y decide retry/standby/hibernate/abort.
+    result = await withBrainRecovery({
+      agent: planner,
+      taskArgs: { prompt, role: "planner", silenceTimeoutMs, timeoutMs, onOutput: progress.onOutput },
+      role: "planner",
+      logger,
     });
-    progress.finish(result.ok ? "done" : "failed");
+    progress.finish(result.ok ? "done" : (result.action || "failed"));
   } catch (err) {
     progress.finish("failed");
     throw err;

--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -12,6 +12,7 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { addHu, removeHu } from "./plan-hu-ops.js";
 import { normaliseAcceptanceTests } from "./plan-schema.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 export function buildFixerPrompt({ task, hus, findings }) {
   const huSummary = hus.map((h) => {
@@ -90,14 +91,18 @@ function normalisePatch(raw) {
   return out;
 }
 
-export async function applyReviewerFeedback({ agent, task, hus, findings, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function applyReviewerFeedback({ agent, task, hus, findings, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   const prompt = buildFixerPrompt({ task, hus, findings });
   const runArgs = { prompt, role: "planner" };
   if (onOutput) runArgs.onOutput = onOutput;
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
-  const result = await agent.runTask(runArgs);
-  if (!result.ok) return { ok: false, error: result.error || "fixer agent failed" };
+  // KJC-TSK-0413: Brain Recovery — fix loop ya no muere silencioso.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "plan-fixer",
+    emitter, eventBase, logger,
+  });
+  if (!result.ok) return { ok: false, error: result.error || `fixer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   const parsed = extractFirstJson(result.output || "");
   if (!parsed || typeof parsed !== "object") {
     return { ok: false, error: "fixer returned no JSON object" };

--- a/src/plan/plan-reviewer.js
+++ b/src/plan/plan-reviewer.js
@@ -30,6 +30,7 @@
  */
 
 import { extractFirstJson } from "../utils/json-extract.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 /**
  * Build the focused review prompt. Exported for unit-testing the
@@ -113,7 +114,7 @@ export function buildReviewerPrompt({ task, hus }) {
  * @param {number} [args.timeoutMs]
  * @returns {Promise<{ ok: boolean, findings?: object, error?: string }>}
  */
-export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   if (!Array.isArray(hus) || hus.length === 0) {
     return { ok: true, findings: emptyFindings("Plan has no HUs to review.") };
   }
@@ -123,9 +124,15 @@ export async function reviewPlan({ agent, task, hus, onOutput, silenceTimeoutMs,
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
 
-  const result = await agent.runTask(runArgs);
+  // KJC-TSK-0413: el caso real del 2026-05-16 (plan-fix iter 2 "failed
+  // 219.3s" sin clase) entraba aquí. Ahora Brain clasifica el fallo y
+  // decide retry/standby/hibernate/abort.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "plan-reviewer",
+    emitter, eventBase, logger,
+  });
   if (!result.ok) {
-    return { ok: false, error: result.error || "reviewer agent failed" };
+    return { ok: false, error: result.error || `reviewer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   }
   const parsed = extractFirstJson(result.output || "");
   if (!parsed || typeof parsed !== "object") {

--- a/src/plan/tests-synthesizer.js
+++ b/src/plan/tests-synthesizer.js
@@ -22,6 +22,7 @@
 
 import { extractFirstJson } from "../utils/json-extract.js";
 import { normaliseAcceptanceTests } from "./plan-schema.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 /**
  * Build the focused-pass prompt asking ONLY for tests for the given
@@ -85,7 +86,7 @@ export function buildSynthesizerPrompt({ task, husNeedingTests }) {
  * @param {number} [args.timeoutMs]
  * @returns {Promise<{ ok: boolean, tests?: Record<string, object[]>, error?: string }>}
  */
-export async function synthesizeMissingTests({ agent, task, husNeedingTests, onOutput, silenceTimeoutMs, timeoutMs }) {
+export async function synthesizeMissingTests({ agent, task, husNeedingTests, onOutput, silenceTimeoutMs, timeoutMs, emitter, eventBase, logger }) {
   if (!Array.isArray(husNeedingTests) || husNeedingTests.length === 0) {
     return { ok: true, tests: {} };
   }
@@ -95,9 +96,13 @@ export async function synthesizeMissingTests({ agent, task, husNeedingTests, onO
   if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
   if (timeoutMs) runArgs.timeoutMs = timeoutMs;
 
-  const result = await agent.runTask(runArgs);
+  // KJC-TSK-0413: Brain Recovery wraps el agent call.
+  const result = await withBrainRecovery({
+    agent, taskArgs: runArgs, role: "tests-synthesizer",
+    emitter, eventBase, logger,
+  });
   if (!result.ok) {
-    return { ok: false, error: result.error || "synthesizer agent failed" };
+    return { ok: false, error: result.error || `synthesizer agent failed (${result.recovery?.class || "unknown"})`, recovery: result.recovery, action: result.action };
   }
 
   const parsed = extractFirstJson(result.output || "");

--- a/tests/plan/plan-reviewer.test.js
+++ b/tests/plan/plan-reviewer.test.js
@@ -113,11 +113,15 @@ describe("reviewPlan", () => {
     expect(result.findings.parallelisable_groups).toHaveLength(1);
   });
 
-  it("returns ok:false on agent failure", async () => {
+  it("returns ok:false on agent failure (post Brain Recovery: abort tras retries)", async () => {
+    // KJC-TSK-0413: ahora el agent error pasa por classifier+wrapper.
+    // "rate limited" se clasifica como RATE_LIMIT_SHORT, Brain reintenta
+    // y tras maxRetries devuelve action='abort' + recovery info.
     const agent = { runTask: vi.fn().mockResolvedValue({ ok: false, error: "rate limited" }) };
     const result = await reviewPlan({ agent, task: "x", hus: [{ id: "h1" }] });
     expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/rate limited/);
+    expect(result.recovery?.class).toBe("RATE_LIMIT_SHORT");
+    expect(result.action).toBe("abort");
   });
 
   it("returns ok:false on non-JSON output", async () => {


### PR DESCRIPTION
## Summary

Tercer paso del epic **KJC-PCS-0044 — Brain Recovery**. Wireados los 4 stages del path principal de \`kj plan\` donde el dogfooding del 2026-05-16 vio fallos silenciosos (\"failed (219.3s)\" sin clase):

| Stage | Antes | Después |
|---|---|---|
| plan-reviewer.js | \`agent.runTask\` directo | \`withBrainRecovery role=\"plan-reviewer\"\` |
| plan-fixer.js | id. | \`role=\"plan-fixer\"\` |
| tests-synthesizer.js | id. | \`role=\"tests-synthesizer\"\` |
| commands/plan/generate.js (planner inicial) | id. | \`role=\"planner\"\` |

> Reopened: PR #725 quedó huérfano cuando su base \`feat/with-brain-recovery-v2\` fue squash-merged.

### Cambio de semántica en fallo

\`\`\`js
// Antes
{ ok: false, error: \"agent failed\" }

// Ahora
{
  ok: false,
  error: \"Brain aborted: RATE_LIMIT_SHORT — rate limit, retry after 30 seconds\",
  recovery: { class, message, retryAfter, retryUntil, recoverable, provider, exitCode },
  action: \"abort\" | \"hibernate\"
}
\`\`\`

### Test sleep en test env

\`withBrainRecovery\` ahora usa sleep no-op cuando \`VITEST || NODE_ENV=test\`. Sin esto los unit tests downstream se colgarían esperando standby ante mock agents.

## Test plan

- [x] 353 tests pasando (plan/, brain/, commands/plan-fix)
- [x] lint clean
- [x] LOC: 46 add / 15 del = 31 line delta

## Próximas PRs

- **Step B**: hu-reviewer, security, audit, impeccable, refactorer, architect, researcher, discover, triage
- **Step C**: lazy-planner, splitting-generator, semantic-detector, comandos standalone
- **TSK-0414**: hibernación al disco