### PR TITLE
feat(brain): wire withBrainRecovery en AgentRole.execute — cubre 11+ roles (KJC-TSK-0413 step B)

### DIFF
--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -15,6 +15,7 @@
  */
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 export class AgentRole extends BaseRole {
   constructor({ name, config, logger, emitter = null, createAgentFn = null }) {
@@ -116,13 +117,27 @@ export class AgentRole extends BaseRole {
     const runArgs = { prompt, role: this.name };
     if (onOutput) runArgs.onOutput = onOutput;
 
-    const result = await agent[this.agentMethod](runArgs);
+    // KJC-TSK-0413 step B: TODAS las roles que heredan de AgentRole pasan
+    // por Brain Recovery aquí — cubre AuditRole, SecurityRole, HuReviewerRole,
+    // CoderRole, ArchitectRole, DiscoverRole, ImpeccableRole, RefactorerRole,
+    // ResearcherRole, TriageRole, etc. Roles con agentMethod custom (ej.
+    // reviewer usa reviewTask) también funcionan: el wrapper sólo necesita
+    // un objeto con la firma `runTask(args) → { ok, output, error, exitCode }`.
+    const result = await withBrainRecovery({
+      agent: { runTask: (args) => agent[this.agentMethod](args), provider },
+      taskArgs: runArgs,
+      role: this.name,
+      provider,
+      emitter: this.emitter,
+      logger: this.logger,
+    });
 
     if (!result.ok) {
+      const recoveryNote = result.recovery?.class ? ` [${result.recovery.class}]` : "";
       return {
         ok: false,
-        result: { error: result.error || result.output || `${this.name} failed`, provider },
-        summary: `${this.name} failed: ${result.error || "unknown error"}`,
+        result: { error: result.error || result.output || `${this.name} failed${recoveryNote}`, provider, recovery: result.recovery, action: result.action },
+        summary: `${this.name} failed${recoveryNote}: ${result.recovery?.message || result.error || "unknown error"}`,
         usage: result.usage
       };
     }


### PR DESCRIPTION
## Summary

Cambio quirúrgico en \`AgentRole.execute()\`, el método único donde TODAS las roles que heredan invocan a su agente. Una sola modificación cubre 11+ roles.

### Cobertura automática

| Role | Antes | Después |
|---|---|---|
| AuditRole | runTask directo | ✅ wrapped |
| SecurityRole | id. | ✅ |
| HuReviewerRole | id. | ✅ |
| CoderRole | id. | ✅ |
| ArchitectRole | id. | ✅ |
| DiscoverRole | id. | ✅ |
| ImpeccableRole | id. | ✅ |
| RefactorerRole | id. | ✅ |
| ResearcherRole | id. | ✅ |
| TriageRole | id. | ✅ |
| (cualquier role futura) | — | ✅ |

### Compatibilidad agentMethod custom

El reviewer usa \`reviewTask\` (no \`runTask\`). El wrapper recibe un adapter:

\`\`\`js
{ runTask: (args) => agent[this.agentMethod](args), provider }
\`\`\`

Así cualquier role funciona sin más cambios.

### Error shape cuando hay recovery

\`\`\`js
{
  ok: false,
  result: { error: \"<role> failed [CLASS]\", recovery, action },
  summary: \"<role> failed [CLASS]: <message>\"
}
\`\`\`

## Test plan

- [x] 4797 tests pasando (suite completa)
- [x] Sin regresiones en ninguna role
- [x] lint clean
- [x] LOC: 18 add / 3 del = 15 line delta

## Out of scope (próximas PRs)

- **Step C**: lazy-planner, splitting-generator, semantic-detector, comandos standalone (\`kj triage/architect/researcher/discover/code\`)
- **TSK-0414**: hibernación al disco