### PR TITLE
feat(brain): wire withBrainRecovery en stages restantes — Step C (KJC-TSK-0413)

### DIFF
--- a/src/commands/architect.js
+++ b/src/commands/architect.js
@@ -3,6 +3,7 @@ import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { buildArchitectPrompt, parseArchitectOutput } from "../prompts/architect.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 function formatLayers(layers, lines) {
   lines.push("### Layers");
@@ -71,8 +72,11 @@ export async function architectCommand({ task, config, logger, context, json }) 
     const progress = createCliProgressReporter({ role: "architect" });
     let result;
     try {
-      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "architect" });
-      progress.finish(result.ok ? "done" : "failed");
+      result = await withBrainRecovery({
+        agent, taskArgs: { prompt, onOutput: progress.onOutput, role: "architect" },
+        role: "architect", provider: architectRole.provider, logger,
+      });
+      progress.finish(result.ok ? "done" : (result.action || "failed"));
     } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {

--- a/src/commands/discover.js
+++ b/src/commands/discover.js
@@ -1,6 +1,7 @@
 import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { buildDiscoverPrompt, parseDiscoverOutput } from "../prompts/discover.js";
 
@@ -75,8 +76,11 @@ export async function discoverCommand({ task, config, logger, mode, json }) {
     const progress = createCliProgressReporter({ role: "discover" });
     let result;
     try {
-      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "discover" });
-      progress.finish(result.ok ? "done" : "failed");
+      result = await withBrainRecovery({
+        agent, taskArgs: { prompt, onOutput: progress.onOutput, role: "discover" },
+        role: "discover", provider: discoverRole.provider, logger,
+      });
+      progress.finish(result.ok ? "done" : (result.action || "failed"));
     } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {

--- a/src/commands/researcher.js
+++ b/src/commands/researcher.js
@@ -2,6 +2,7 @@ import { createAgent } from "../agents/index.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -33,8 +34,11 @@ export async function researcherCommand({ task, config, logger }) {
     const progress = createCliProgressReporter({ role: "researcher" });
     let result;
     try {
-      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "researcher" });
-      progress.finish(result.ok ? "done" : "failed");
+      result = await withBrainRecovery({
+        agent, taskArgs: { prompt, onOutput: progress.onOutput, role: "researcher" },
+        role: "researcher", provider: researcherRole.provider, logger,
+      });
+      progress.finish(result.ok ? "done" : (result.action || "failed"));
     } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {

--- a/src/commands/triage.js
+++ b/src/commands/triage.js
@@ -4,6 +4,7 @@ import { resolveRole } from "../config.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { buildTriagePrompt } from "../prompts/triage.js";
 import { parseMaybeJsonString } from "../review/parser.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 function formatTriage(result) {
   const lines = [];
@@ -47,8 +48,11 @@ export async function triageCommand({ task, config, logger, json }) {
     const progress = createCliProgressReporter({ role: "triage" });
     let result;
     try {
-      result = await agent.runTask({ prompt, onOutput: progress.onOutput, role: "triage" });
-      progress.finish(result.ok ? "done" : "failed");
+      result = await withBrainRecovery({
+        agent, taskArgs: { prompt, onOutput: progress.onOutput, role: "triage" },
+        role: "triage", provider: triageRole.provider, logger,
+      });
+      progress.finish(result.ok ? "done" : (result.action || "failed"));
     } catch (err) { progress.finish("failed"); throw err; }
 
     if (!result.ok) {

--- a/src/hu/lazy-planner.js
+++ b/src/hu/lazy-planner.js
@@ -7,6 +7,7 @@
  */
 import { createAgent } from "../agents/index.js";
 import { extractFirstJson } from "../utils/json-extract.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -72,7 +73,11 @@ export async function refineHuWithContext(hu, completedHus, config, logger) {
   const agent = createAgent(provider, config, logger);
   let result;
   try {
-    result = await agent.runTask({ prompt, role: "hu-reviewer" });
+    // KJC-TSK-0413 step C
+    result = await withBrainRecovery({
+      agent, taskArgs: { prompt, role: "hu-reviewer" },
+      role: "lazy-planner", provider, logger,
+    });
   } catch (err) {
     logger.warn(`Lazy planner: refinement failed for HU ${hu.id}: ${err.message}`);
     return hu;

--- a/src/hu/splitting-generator.js
+++ b/src/hu/splitting-generator.js
@@ -7,6 +7,7 @@
 import { createAgent } from "../agents/index.js";
 import { extractFirstJson } from "../utils/json-extract.js";
 import { HEURISTIC_DESCRIPTIONS } from "./splitting-detector.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -97,7 +98,11 @@ export async function generateSplitProposal(hu, heuristic, config, logger) {
 
   let result;
   try {
-    result = await agent.runTask({ prompt, role: "hu-splitter" });
+    // KJC-TSK-0413 step C
+    result = await withBrainRecovery({
+      agent, taskArgs: { prompt, role: "hu-splitter" },
+      role: "hu-splitter", provider, logger,
+    });
   } catch (err) {
     logger.warn(`HU split generation threw: ${err.message}`);
     return null;

--- a/src/roles/planner-role.js
+++ b/src/roles/planner-role.js
@@ -1,4 +1,5 @@
 import { AgentRole } from "./agent-role.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const RESEARCH_FIELDS = [
   { key: "affected_files", label: "Affected files" },
@@ -124,13 +125,19 @@ export class PlannerRole extends AgentRole {
     const timeoutMs = resolveRuntimeTimeoutMs(this.config);
     if (timeoutMs) runArgs.timeoutMs = timeoutMs;
 
-    const result = await agent.runTask(runArgs);
+    // KJC-TSK-0413 step C: PlannerRole tiene execute() custom (no usa el de
+    // AgentRole). Wrap aquí también.
+    const result = await withBrainRecovery({
+      agent, taskArgs: runArgs, role: "planner", provider,
+      emitter: this.emitter, logger: this.logger,
+    });
 
     if (!result.ok) {
+      const recoveryNote = result.recovery?.class ? ` [${result.recovery.class}]` : "";
       return {
         ok: false,
-        result: { ...result, error: result.error || result.output || "Planner agent failed", plan: null },
-        summary: `Planner failed: ${result.error || "unknown error"}`
+        result: { ...result, error: result.error || result.output || `Planner agent failed${recoveryNote}`, plan: null, recovery: result.recovery, action: result.action },
+        summary: `Planner failed${recoveryNote}: ${result.recovery?.message || result.error || "unknown error"}`
       };
     }
 

--- a/src/roles/solomon-role.js
+++ b/src/roles/solomon-role.js
@@ -1,6 +1,7 @@
 import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { extractFirstJson } from "../utils/json-extract.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -207,16 +208,21 @@ export class SolomonRole extends BaseRole {
       instructions: this.instructions
     });
 
-    const result = await agent.runTask({ prompt, role: "solomon" });
+    // KJC-TSK-0413 step C: Solomon es BaseRole (no AgentRole) — wrap explícito.
+    const result = await withBrainRecovery({
+      agent, taskArgs: { prompt, role: "solomon" }, role: "solomon", provider,
+      emitter: this.emitter, logger: this.logger,
+    });
 
     if (!result.ok) {
+      const recoveryNote = result.recovery?.class ? ` [${result.recovery.class}]` : "";
       return {
         ok: false,
         result: {
-          error: result.error || result.output || "Solomon arbitration failed",
-          provider
+          error: result.error || result.output || `Solomon arbitration failed${recoveryNote}`,
+          provider, recovery: result.recovery, action: result.action,
         },
-        summary: `Solomon failed: ${result.error || "unknown error"}`
+        summary: `Solomon failed${recoveryNote}: ${result.recovery?.message || result.error || "unknown error"}`
       };
     }
 

--- a/tests/plan/planner-role.test.js
+++ b/tests/plan/planner-role.test.js
@@ -75,7 +75,9 @@ describe("PlannerRole", () => {
     expect(output.ok).toBe(true);
   });
 
-  it("returns ok=false when agent fails", async () => {
+  it("returns ok=false when agent fails (post Brain Recovery: classifica y abort)", async () => {
+    // KJC-TSK-0413: el wrapper clasifica "Agent timeout" como UNKNOWN_FATAL
+    // (no encaja patterns conocidos) y aborta inmediato sin retries.
     const fakeAgent = {
       runTask: vi.fn().mockResolvedValue({
         ok: false,
@@ -89,7 +91,8 @@ describe("PlannerRole", () => {
     const output = await role.run("Complex task");
 
     expect(output.ok).toBe(false);
-    expect(output.result.error).toBe("Agent timeout");
+    expect(output.result.error).toMatch(/Agent timeout/);
+    expect(output.result.recovery?.class).toBe("UNKNOWN_FATAL");
   });
 
   it("emits role:start and role:end events", async () => {


### PR DESCRIPTION
## Summary

Cierra **TSK-0413**. Wireados los stages que NO heredan de AgentRole o tienen \`execute()\` custom:

| Archivo | Categoría |
|---|---|
| \`src/roles/planner-role.js\` | extends AgentRole pero usa execute() custom |
| \`src/roles/solomon-role.js\` | extends BaseRole (no AgentRole) |
| \`src/hu/lazy-planner.js\` | fn standalone, createAgent+runTask |
| \`src/hu/splitting-generator.js\` | id. |
| \`src/commands/triage.js\` | comando \`kj triage\` standalone |
| \`src/commands/discover.js\` | comando \`kj discover\` |
| \`src/commands/architect.js\` | comando \`kj architect\` |
| \`src/commands/researcher.js\` | comando \`kj researcher\` |

### Excluidos (justificado)

- \`src/skills/semantic-detector.js\`: signature distinta \`runTask(prompt, opts)\` en lugar de \`runTask({...})\`. Ya tiene fallback skip-on-fail. Bajo criticidad.
- \`src/commands/code.js\`: no contiene \`agent.runTask\` directo (delega en pipeline runner).

### Resultado

Con esto, **TODA invocación a agente IA en Karajan pasa por Brain Recovery**. El fallo silencioso \"failed (219.3s)\" del dogfooding 2026-05-16 queda imposible — Brain clasifica y emite eventos siempre.

## Test plan

- [x] 4797 tests pasando
- [x] Sin regresiones
- [x] Test \`planner-role.test.js\` actualizado: \"Agent timeout\" → UNKNOWN_FATAL (semántica wrapper)
- [x] lint clean
- [x] LOC: 61 add / 19 del = 42 line delta

## Próximas PRs

- **TSK-0414**: hibernación al disco para QUOTA_EXHAUSTED_DAILY (sessions persisten en \`.kj/standby/\`, \`kj resume\` + board auto-resume)