### PR TITLE
feat(brain): hibernación PR1 — standby-store + scheduler event-driven (KJC-TSK-0414)

### DIFF
--- a/src/brain/standby-scheduler.js
+++ b/src/brain/standby-scheduler.js
@@ -1,0 +1,92 @@
+// KJC-TSK-0414 PR 1: scheduler event-driven para hibernación.
+//
+// Diseño: setTimeout único por sesión, dispara EXACTAMENTE en cooldownUntil.
+// Cero polling. Si el proceso muere antes del fire, reconcileAll() al
+// arrancar el board re-programa los timeouts pendientes (o reanuda
+// inmediatamente los expirados).
+
+import { listPendingStandby, acquireStandbyLock, markStandbyDone } from "./standby-store.js";
+
+// Mapa sessionId → NodeJS.Timeout — accesible para test/cancel.
+const _scheduled = new Map();
+
+export function _resetScheduledForTests() {
+  for (const t of _scheduled.values()) clearTimeout(t);
+  _scheduled.clear();
+}
+
+/**
+ * Programa un único setTimeout que dispara `onResume(sessionId)` en cooldownUntil.
+ *
+ * @param {object} args
+ * @param {string} args.sessionId
+ * @param {string} args.cooldownUntil - ISO timestamp
+ * @param {Function} args.onResume - callback(sessionId) cuando llega el momento
+ * @param {object} [args.logger]
+ * @returns {{ scheduled: boolean, msUntil?: number, immediate?: boolean }}
+ */
+export function scheduleResume({ sessionId, cooldownUntil, onResume, logger }) {
+  if (!sessionId || !cooldownUntil || typeof onResume !== "function") {
+    return { scheduled: false };
+  }
+  cancelScheduled(sessionId);
+  const targetMs = new Date(cooldownUntil).getTime();
+  if (Number.isNaN(targetMs)) return { scheduled: false };
+  const delay = targetMs - Date.now();
+  if (delay <= 0) {
+    // Ya expiró — reanudar inmediato (caso: board reiniciado tras llegar la hora).
+    logger?.info?.(`[standby-scheduler] ${sessionId}: cooldown ya expirado, resume inmediato`);
+    Promise.resolve().then(() => onResume(sessionId)).catch(() => { /* swallow */ });
+    return { scheduled: true, immediate: true };
+  }
+  const timer = setTimeout(() => {
+    _scheduled.delete(sessionId);
+    logger?.info?.(`[standby-scheduler] ${sessionId}: cooldown alcanzado, disparando resume`);
+    try { onResume(sessionId); } catch (err) { logger?.warn?.(`[standby-scheduler] onResume threw: ${err.message}`); }
+  }, delay);
+  if (typeof timer.unref === "function") timer.unref();
+  _scheduled.set(sessionId, timer);
+  logger?.info?.(`[standby-scheduler] ${sessionId}: scheduled in ${Math.round(delay / 1000)}s (until ${cooldownUntil})`);
+  return { scheduled: true, msUntil: delay };
+}
+
+/** Cancela el setTimeout de una sesión (caso: usuario hizo kj resume manual). */
+export function cancelScheduled(sessionId) {
+  const t = _scheduled.get(sessionId);
+  if (!t) return false;
+  clearTimeout(t);
+  _scheduled.delete(sessionId);
+  return true;
+}
+
+/**
+ * Reconciliación al arrancar el board / kj. Lee todas las sesiones pendientes
+ * y para cada una:
+ *   - cooldownUntil < now → onResume inmediato
+ *   - cooldownUntil > now → re-programa setTimeout
+ *
+ * Idempotente: el lockfile en standby-store previene dobles spawns si
+ * reconcileAll() corre dos veces concurrentes (board reload).
+ *
+ * @param {object} args
+ * @param {Function} args.onResume - callback(sessionId)
+ * @param {object} [args.logger]
+ * @returns {{ scheduled: number, immediate: number, total: number }}
+ */
+export function reconcileAll({ onResume, logger }) {
+  const sessions = listPendingStandby();
+  let scheduled = 0;
+  let immediate = 0;
+  for (const s of sessions) {
+    if (!s?.sessionId || !s?.cooldownUntil) continue;
+    const r = scheduleResume({ sessionId: s.sessionId, cooldownUntil: s.cooldownUntil, onResume, logger });
+    if (r.scheduled && r.immediate) immediate += 1;
+    else if (r.scheduled) scheduled += 1;
+  }
+  logger?.info?.(`[standby-scheduler] reconcile: ${sessions.length} sesiones (${immediate} resume inmediato, ${scheduled} programadas)`);
+  return { scheduled, immediate, total: sessions.length };
+}
+
+// Re-export para que callers no tengan que importar standby-store si solo
+// necesitan el flow scheduler → lock → done.
+export { acquireStandbyLock, markStandbyDone };

--- a/src/brain/standby-store.js
+++ b/src/brain/standby-store.js
@@ -1,0 +1,129 @@
+// KJC-TSK-0414 PR 1: persistencia de sesiones hibernadas al disco.
+//
+// Cuando Brain decide hibernar (QUOTA_EXHAUSTED_DAILY con retryAfter > 5min),
+// serializa el estado completo del run en ~/.kj/standby/<sessionId>.json.
+// El proceso de kj run muere (exit 0) tras persistir; el board (o kj resume)
+// lo reanuda cuando llega cooldownUntil.
+//
+// Layout en disco:
+//   ~/.kj/standby/
+//     <sessionId>.json    ← sesiones pendientes (scheduler les mete setTimeout)
+//     <sessionId>.lock    ← lockfile durante spawn de kj resume
+//     done/
+//       <sessionId>.json  ← finalizadas (consumibles por GC en TSK-0414 PR3)
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const FILENAME_RE = /^[a-zA-Z0-9._-]+\.json$/;
+
+function getKjHome() {
+  if (process.env.KJ_HOME) return process.env.KJ_HOME;
+  if (process.env.VITEST) return path.join(os.tmpdir(), `kj-vitest-${process.pid}-${Math.random().toString(36).slice(2, 10)}`, ".kj");
+  return path.join(os.homedir(), ".kj");
+}
+
+export function standbyDir() {
+  return path.join(getKjHome(), "standby");
+}
+
+export function standbyDoneDir() {
+  return path.join(standbyDir(), "done");
+}
+
+function sanitizeId(sessionId) {
+  if (!sessionId || typeof sessionId !== "string") throw new Error("sessionId requerido");
+  return sessionId.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
+}
+
+/**
+ * Persiste el estado completo de un run hibernado.
+ *
+ * @param {object} state - shape:
+ *   { sessionId, planId?, huId?, role, iteration?, prompt, agentConfig,
+ *     retryCount?, cooldownUntil, reason, snapshot_sha?, outcome_so_far? }
+ * @returns {string} path absoluto del JSON escrito
+ */
+export function persistStandby(state) {
+  if (!state || !state.sessionId) throw new Error("state.sessionId requerido");
+  if (!state.cooldownUntil) throw new Error("state.cooldownUntil requerido");
+  const dir = standbyDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${sanitizeId(state.sessionId)}.json`);
+  const payload = {
+    ...state,
+    createdAt: state.createdAt || new Date().toISOString(),
+    persistedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2), "utf-8");
+  return file;
+}
+
+/**
+ * @param {string} sessionId
+ * @returns {object|null}
+ */
+export function loadStandby(sessionId) {
+  const file = path.join(standbyDir(), `${sanitizeId(sessionId)}.json`);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Lista todas las sesiones pendientes (no las de done/).
+ * @returns {object[]}
+ */
+export function listPendingStandby() {
+  const dir = standbyDir();
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((f) => FILENAME_RE.test(f))
+    .map((f) => {
+      try {
+        return JSON.parse(fs.readFileSync(path.join(dir, f), "utf-8"));
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Mueve una sesión a done/ — consumible por GC en TSK-0414 PR3.
+ * @param {string} sessionId
+ * @returns {boolean} true si se movió
+ */
+export function markStandbyDone(sessionId) {
+  const id = sanitizeId(sessionId);
+  const src = path.join(standbyDir(), `${id}.json`);
+  if (!fs.existsSync(src)) return false;
+  const doneDir = standbyDoneDir();
+  fs.mkdirSync(doneDir, { recursive: true });
+  const dst = path.join(doneDir, `${id}-${Date.now()}.json`);
+  fs.renameSync(src, dst);
+  return true;
+}
+
+/**
+ * Lockfile para evitar dobles spawns de kj resume sobre la misma sesión.
+ * Devuelve { acquired: true, release: () => void } o { acquired: false } si ya hay lock.
+ *
+ * @param {string} sessionId
+ * @returns {{ acquired: boolean, release?: Function }}
+ */
+export function acquireStandbyLock(sessionId) {
+  const id = sanitizeId(sessionId);
+  const lockFile = path.join(standbyDir(), `${id}.lock`);
+  try {
+    fs.mkdirSync(standbyDir(), { recursive: true });
+    fs.writeFileSync(lockFile, String(process.pid), { flag: "wx" });
+    return { acquired: true, release: () => { try { fs.unlinkSync(lockFile); } catch { /* */ } } };
+  } catch {
+    return { acquired: false };
+  }
+}

--- a/tests/brain/standby-scheduler.test.js
+++ b/tests/brain/standby-scheduler.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { scheduleResume, cancelScheduled, reconcileAll, _resetScheduledForTests } from "../../src/brain/standby-scheduler.js";
+import { persistStandby } from "../../src/brain/standby-store.js";
+
+// KJC-TSK-0414 PR 1: scheduler event-driven (setTimeout único per session).
+
+let kjHome;
+const SAVED_KJ_HOME = process.env.KJ_HOME;
+
+beforeEach(() => {
+  kjHome = mkdtempSync(path.join(tmpdir(), "kj-sched-"));
+  process.env.KJ_HOME = kjHome;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  _resetScheduledForTests();
+  vi.useRealTimers();
+  if (SAVED_KJ_HOME === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = SAVED_KJ_HOME;
+  rmSync(kjHome, { recursive: true, force: true });
+});
+
+describe("scheduleResume", () => {
+  it("programa setTimeout y dispara onResume en cooldownUntil", () => {
+    const onResume = vi.fn();
+    const cooldownUntil = new Date(Date.now() + 60_000).toISOString();
+    const r = scheduleResume({ sessionId: "s1", cooldownUntil, onResume });
+    expect(r.scheduled).toBe(true);
+    expect(r.msUntil).toBeGreaterThan(0);
+    expect(onResume).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(60_000);
+    expect(onResume).toHaveBeenCalledWith("s1");
+  });
+
+  it("cooldownUntil ya pasado → onResume inmediato (async)", async () => {
+    const onResume = vi.fn();
+    const past = new Date(Date.now() - 1000).toISOString();
+    const r = scheduleResume({ sessionId: "s2", cooldownUntil: past, onResume });
+    expect(r.scheduled).toBe(true);
+    expect(r.immediate).toBe(true);
+    // Promise.resolve().then() — esperamos una microtask
+    await Promise.resolve();
+    expect(onResume).toHaveBeenCalledWith("s2");
+  });
+
+  it("re-scheduleResume cancela el previo (no doble fire)", () => {
+    const onResume = vi.fn();
+    const t1 = new Date(Date.now() + 60_000).toISOString();
+    const t2 = new Date(Date.now() + 120_000).toISOString();
+    scheduleResume({ sessionId: "s3", cooldownUntil: t1, onResume });
+    scheduleResume({ sessionId: "s3", cooldownUntil: t2, onResume });
+    vi.advanceTimersByTime(60_000);
+    expect(onResume).not.toHaveBeenCalled(); // primer timeout cancelado
+    vi.advanceTimersByTime(60_000);
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("args inválidos → { scheduled: false }", () => {
+    expect(scheduleResume({}).scheduled).toBe(false);
+    expect(scheduleResume({ sessionId: "x" }).scheduled).toBe(false);
+    expect(scheduleResume({ sessionId: "x", cooldownUntil: "not-a-date" }).scheduled).toBe(false);
+  });
+});
+
+describe("cancelScheduled", () => {
+  it("cancela el setTimeout pendiente", () => {
+    const onResume = vi.fn();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    scheduleResume({ sessionId: "s4", cooldownUntil: future, onResume });
+    expect(cancelScheduled("s4")).toBe(true);
+    vi.advanceTimersByTime(60_000);
+    expect(onResume).not.toHaveBeenCalled();
+  });
+  it("devuelve false si no había nada programado", () => {
+    expect(cancelScheduled("ghost")).toBe(false);
+  });
+});
+
+describe("reconcileAll", () => {
+  it("scan vacío → 0 sesiones", () => {
+    const r = reconcileAll({ onResume: vi.fn() });
+    expect(r).toEqual({ scheduled: 0, immediate: 0, total: 0 });
+  });
+
+  it("sesiones pendientes: expiradas → immediate; futuras → scheduled", async () => {
+    const past = new Date(Date.now() - 5000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    persistStandby({ sessionId: "expired", cooldownUntil: past });
+    persistStandby({ sessionId: "future", cooldownUntil: future });
+    persistStandby({ sessionId: "future2", cooldownUntil: future });
+
+    const onResume = vi.fn();
+    const r = reconcileAll({ onResume });
+    expect(r.total).toBe(3);
+    expect(r.immediate).toBe(1);
+    expect(r.scheduled).toBe(2);
+    // Esperamos a que el immediate se resuelva en microtask
+    await Promise.resolve();
+    expect(onResume).toHaveBeenCalledWith("expired");
+    // Las futuras todavía no
+    expect(onResume).toHaveBeenCalledTimes(1);
+    // Avanza el reloj — disparan las dos futuras
+    vi.advanceTimersByTime(60_000);
+    expect(onResume).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/brain/standby-store.test.js
+++ b/tests/brain/standby-store.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  persistStandby, loadStandby, listPendingStandby,
+  markStandbyDone, acquireStandbyLock, standbyDir, standbyDoneDir,
+} from "../../src/brain/standby-store.js";
+
+// KJC-TSK-0414 PR 1: persistencia de sesiones hibernadas al disco.
+
+let kjHome;
+const SAVED_KJ_HOME = process.env.KJ_HOME;
+
+beforeEach(() => {
+  kjHome = mkdtempSync(path.join(tmpdir(), "kj-standby-"));
+  process.env.KJ_HOME = kjHome;
+});
+
+afterEach(() => {
+  if (SAVED_KJ_HOME === undefined) delete process.env.KJ_HOME;
+  else process.env.KJ_HOME = SAVED_KJ_HOME;
+  rmSync(kjHome, { recursive: true, force: true });
+});
+
+describe("persistStandby", () => {
+  it("escribe JSON con createdAt y persistedAt", () => {
+    const file = persistStandby({
+      sessionId: "s1", role: "coder", prompt: "x",
+      cooldownUntil: "2026-05-18T09:00:00Z",
+      reason: "QUOTA_EXHAUSTED_DAILY",
+    });
+    expect(existsSync(file)).toBe(true);
+    expect(file).toContain(path.join(kjHome, "standby", "s1.json"));
+    const data = JSON.parse(readFileSync(file, "utf-8"));
+    expect(data.sessionId).toBe("s1");
+    expect(data.persistedAt).toBeTruthy();
+    expect(data.createdAt).toBeTruthy();
+  });
+
+  it("rechaza sessionId vacío o sin cooldownUntil", () => {
+    expect(() => persistStandby({})).toThrow(/sessionId/);
+    expect(() => persistStandby({ sessionId: "x" })).toThrow(/cooldownUntil/);
+  });
+
+  it("sanitiza sessionId con caracteres especiales", () => {
+    const file = persistStandby({
+      sessionId: "weird/path:with*chars",
+      cooldownUntil: "2026-05-18T09:00:00Z",
+    });
+    expect(file).toMatch(/weird_path_with_chars\.json$/);
+  });
+});
+
+describe("loadStandby", () => {
+  it("devuelve null si no existe", () => {
+    expect(loadStandby("ghost")).toBeNull();
+  });
+  it("devuelve el JSON parseado", () => {
+    persistStandby({ sessionId: "s2", cooldownUntil: "2026-05-18T09:00:00Z", planId: "p1" });
+    const data = loadStandby("s2");
+    expect(data.planId).toBe("p1");
+  });
+});
+
+describe("listPendingStandby", () => {
+  it("lista vacía cuando no existe el directorio", () => {
+    expect(listPendingStandby()).toEqual([]);
+  });
+  it("lista solo los JSON top-level, ignora done/", () => {
+    persistStandby({ sessionId: "s1", cooldownUntil: "2026-05-18T09:00:00Z" });
+    persistStandby({ sessionId: "s2", cooldownUntil: "2026-05-18T09:00:00Z" });
+    markStandbyDone("s1");
+    const pending = listPendingStandby();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].sessionId).toBe("s2");
+  });
+});
+
+describe("markStandbyDone", () => {
+  it("mueve el archivo a done/ con timestamp", () => {
+    persistStandby({ sessionId: "s3", cooldownUntil: "2026-05-18T09:00:00Z" });
+    expect(markStandbyDone("s3")).toBe(true);
+    expect(existsSync(path.join(standbyDir(), "s3.json"))).toBe(false);
+    expect(existsSync(standbyDoneDir())).toBe(true);
+  });
+  it("devuelve false si la sesión no existe", () => {
+    expect(markStandbyDone("ghost")).toBe(false);
+  });
+});
+
+describe("acquireStandbyLock", () => {
+  it("primer acquire devuelve { acquired: true, release }", () => {
+    const r = acquireStandbyLock("s4");
+    expect(r.acquired).toBe(true);
+    expect(typeof r.release).toBe("function");
+    r.release();
+  });
+  it("segundo acquire concurrente devuelve { acquired: false }", () => {
+    const a = acquireStandbyLock("s5");
+    const b = acquireStandbyLock("s5");
+    expect(a.acquired).toBe(true);
+    expect(b.acquired).toBe(false);
+    a.release();
+  });
+  it("tras release, otro acquire vuelve a ok", () => {
+    const a = acquireStandbyLock("s6");
+    a.release();
+    const b = acquireStandbyLock("s6");
+    expect(b.acquired).toBe(true);
+    b.release();
+  });
+});


### PR DESCRIPTION
## Summary

Primer paso de TSK-0414 (hibernación). Base para que Brain pueda hibernar runs cuando \`QUOTA_EXHAUSTED_DAILY\` con waits > 5 min en vez de mantener el proceso vivo horas con \`setTimeout\` in-process.

### Diseño event-driven (sin polling)

**\`src/brain/standby-store.js\`** — persistencia al disco
- \`persistStandby(state)\` → escribe \`~/.kj/standby/<sessionId>.json\`
- \`loadStandby(id)\`, \`listPendingStandby()\`, \`markStandbyDone(id)\`
- \`acquireStandbyLock(id)\` — lockfile previene dobles spawns

**\`src/brain/standby-scheduler.js\`** — un setTimeout único por sesión
- \`scheduleResume({ sessionId, cooldownUntil, onResume })\` → dispara EXACTAMENTE en cooldownUntil
- \`cancelScheduled(id)\` — si user reanuda manual antes
- **\`reconcileAll({ onResume })\`** — al arrancar board:
  - \`cooldownUntil < now\` → onResume inmediato (microtask)
  - \`cooldownUntil > now\` → re-programa setTimeout

Cero polling. Idempotente.

## Test plan

- [x] 24 tests nuevos (store + scheduler)
- [x] Cobertura: persist/load/list/markDone, sanitización id, lockfile concurrency
- [x] scheduleResume fires en cooldown, re-schedule cancela previo, args inválidos, reconcileAll mixto expirados+futuros
- [x] 133 tests brain/ totales pasando
- [x] lint clean

## LOC

446 LOC (módulos 221 + tests 225). Foundation cohesiva. Large-pr-justified.

## Próximas PRs

- **PR2**: \`withBrainRecovery\` consume hibernate → llama \`persistStandby\` + exit. \`kj resume <sessionId>\` CLI. Board startup llama \`reconcileAll\`.
- **PR3**: GC extension (standby/done/, audits/, hu-board-runs/) al arrancar
- **PR4**: Board UI badge "💤 standby · resume en HH:MM"