### PR TITLE
feat(brain): hibernación PR4 — board UI banner con countdown (KJC-TSK-0414)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -101,6 +101,77 @@ async function api(path) {
   return res.json();
 }
 
+// KJC-TSK-0414 PR4: standby banner — sesiones hibernadas pendientes de resume.
+// Polleamos /api/standby cada 30s + tick countdown cada 1s.
+let _standbyData = { sessions: [] };
+let _standbyPollTimer = null;
+let _standbyTickTimer = null;
+
+function _fmtCountdown(ms) {
+  if (ms <= 0) return '✓ resume inmediato';
+  const s = Math.round(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}
+
+async function refreshStandby() {
+  try {
+    const r = await api('/api/standby');
+    _standbyData = r || { sessions: [] };
+    _renderStandbyBanner();
+  } catch { /* silencioso — endpoint nuevo, podría no existir en versiones viejas */ }
+}
+
+function _renderStandbyBanner() {
+  let banner = document.getElementById('standby-banner');
+  const sessions = _standbyData.sessions || [];
+  if (sessions.length === 0) {
+    if (banner) banner.remove();
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'standby-banner';
+    banner.style.cssText = 'background:rgba(251,191,36,0.12);border-left:4px solid #fbbf24;padding:10px 16px;margin:0 0 12px;font-size:0.85rem';
+    const app = document.getElementById('app');
+    if (app?.parentNode) app.parentNode.insertBefore(banner, app);
+  }
+  const now = Date.now();
+  banner.innerHTML = `
+    <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+      <strong>💤 ${sessions.length} sesión(es) hibernadas:</strong>
+      ${sessions.map((s) => {
+        const ms = new Date(s.cooldownUntil).getTime() - now;
+        const label = _fmtCountdown(ms);
+        const reason = s.reason || '?';
+        const planInfo = s.planId ? ` · ${s.planId}${s.huId ? '/' + s.huId : ''}` : '';
+        return `<span data-session="${esc(s.sessionId)}" data-cooldown="${esc(s.cooldownUntil)}" style="background:rgba(0,0,0,0.15);padding:4px 8px;border-radius:4px;font-family:monospace" title="${esc(reason)}${esc(planInfo)}">${esc(s.sessionId)} · <span class="standby-countdown">${label}</span></span>`;
+      }).join('')}
+      <span style="margin-left:auto;color:var(--text-muted);font-size:0.75rem">Auto-resume al llegar el cooldown (board) o <code>kj resume &lt;id&gt;</code></span>
+    </div>
+  `;
+}
+
+function _tickStandbyCountdowns() {
+  const banner = document.getElementById('standby-banner');
+  if (!banner) return;
+  const now = Date.now();
+  for (const chip of banner.querySelectorAll('[data-cooldown]')) {
+    const target = new Date(chip.getAttribute('data-cooldown')).getTime();
+    const span = chip.querySelector('.standby-countdown');
+    if (span) span.textContent = _fmtCountdown(target - now);
+  }
+}
+
+function startStandbyPolling() {
+  if (_standbyPollTimer || _standbyTickTimer) return;
+  refreshStandby();
+  _standbyPollTimer = setInterval(refreshStandby, 30_000);
+  _standbyTickTimer = setInterval(_tickStandbyCountdowns, 1000);
+}
+
 /**
  * Trigger a full re-scan of disk data (hu-stories + sessions).
  * Called on page load and via the sync button.
@@ -3566,6 +3637,9 @@ window.showStoryDetail = showStoryDetail;
 window.showSessionDetail = showSessionDetail;
 window.closeModal = closeModal;
 window.selectProject = selectProject;
+
+// KJC-TSK-0414 PR4: arranca el polling del banner de standby al cargar la página.
+startStandbyPolling();
 
 // Initial load — sync disk data first so new batches are visible
 triggerSync().then(() => {

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -43,6 +43,22 @@ router.get('/version', (_req, res) => {
 });
 
 /**
+ * GET /api/standby — KJC-TSK-0414 PR4. Lista sesiones hibernadas.
+ * Devuelve [{ sessionId, planId, huId, role, cooldownUntil, reason, ... }]
+ * El front renderiza un badge "💤 standby · resume en HH:MM:SS" por sesión.
+ */
+router.get('/standby', async (_req, res) => {
+  try {
+    const { listPendingStandby } = await import('../../../../src/brain/standby-store.js');
+    const sessions = listPendingStandby();
+    res.set('Cache-Control', 'no-store');
+    res.json({ sessions });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
  * Resolve the hu-stories dir where batch.json files live.
  */
 function huStoriesDir() {

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -262,3 +262,28 @@ describe('PATCH /api/projects/:id/is-test', () => {
     expect(res.body.error).toMatch(/not found/);
   });
 });
+
+// KJC-TSK-0414 PR4
+describe('GET /api/standby', () => {
+  it('lista vacía cuando no hay sesiones hibernadas', async () => {
+    const res = await request(app).get('/api/standby');
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toEqual([]);
+  });
+
+  it('devuelve las sesiones persistidas', async () => {
+    const { persistStandby } = await import('../../../src/brain/standby-store.js');
+    persistStandby({
+      sessionId: 'test-s1',
+      cooldownUntil: '2099-01-01T00:00:00Z',
+      reason: 'QUOTA_EXHAUSTED_DAILY',
+      planId: 'p1',
+      huId: 'hu_001',
+    });
+    const res = await request(app).get('/api/standby');
+    expect(res.status).toBe(200);
+    expect(res.body.sessions).toHaveLength(1);
+    expect(res.body.sessions[0].sessionId).toBe('test-s1');
+    expect(res.body.sessions[0].planId).toBe('p1');
+  });
+});


### PR DESCRIPTION
## Summary

Cierre del epic. UI para que el usuario vea las sesiones hibernadas y countdown hasta resume.

> Base: \`feat/standby-persistence-scheduler\` (#729). Rebase a main cuando 729 merge.

### API
- \`GET /api/standby\` → \`{ sessions: [{ sessionId, planId, huId, role, cooldownUntil, reason }] }\`

### UI banner
\`\`\`
💤 2 sesión(es) hibernadas:
  s_001 · 02:34:18    s_002 · 00:05:12
  Auto-resume al llegar el cooldown (board) o kj resume <id>
\`\`\`

- Cada chip: sessionId monospace + countdown \`HH:MM:SS\`
- tooltip con reason + planId/huId
- \"✓ resume inmediato\" cuando llega el cooldown
- Auto-desaparece cuando no hay sesiones

### Polling
- \`refreshStandby()\` cada 30s (detecta sesiones nuevas / consumidas)
- \`_tickStandbyCountdowns()\` cada 1s (in-place update)

## Test plan

- [x] 2 tests nuevos en api.test.js para GET /api/standby
- [x] 21 api.test passing
- [x] lint clean
- [x] LOC: 115 add

## Epic TSK-0414 cerrado

Cuatro PRs construyen hibernación end-to-end:
1. #729 store + scheduler
2. #730 wrapper + kj resume + board reconcile
3. #731 GC extension (standby/done, audits, hu-board-runs)
4. ESTA UI banner

Flow completo: Brain detecta \`QUOTA_EXHAUSTED_DAILY\` → \`withBrainRecovery\` persiste a \`~/.kj/standby/\` + exit 0 → Board reconcile al arrancar registra setTimeout → al cooldown: spawn \`kj resume\` → UI banner siempre visible con countdown → GC limpia tras 7 días.