### PR TITLE
feat(brain): hibernación PR2 — wrapper persiste + kj resume + board reconcile (KJC-TSK-0414)

### DIFF
--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -216,6 +216,34 @@ async function main() {
     console.warn(`[hu-zombie-reaper] skipped: ${err.message}`);
   }
 
+  // KJC-TSK-0414 PR2 — reconciliación de sesiones hibernadas al arrancar.
+  // Para cada session en ~/.kj/standby/<id>.json:
+  //   - cooldownUntil <= now → spawn `kj resume <id>` inmediato
+  //   - cooldownUntil > now  → re-programa setTimeout que dispara en cooldown
+  // Idempotente (lockfile per session). Cero polling.
+  try {
+    const { reconcileAll } = await import('../../../src/brain/standby-scheduler.js');
+    const { spawn } = await import('node:child_process');
+    const { join, dirname } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+    const KJ_CLI = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'src', 'cli.js');
+    const onResume = (sessionId) => {
+      console.log(`[standby] reanudando sesión ${sessionId} (spawn kj resume)`);
+      try {
+        const child = spawn(process.execPath, [KJ_CLI, 'resume', sessionId], {
+          detached: true, stdio: 'ignore', env: process.env,
+        });
+        child.unref();
+      } catch (err) {
+        console.warn(`[standby] spawn resume falló para ${sessionId}: ${err.message}`);
+      }
+    };
+    const r = reconcileAll({ onResume, logger: { info: console.log.bind(console), warn: console.warn.bind(console) } });
+    if (r.total > 0) console.log(`[standby] reconcile: ${r.total} session(es) — ${r.immediate} resume inmediato, ${r.scheduled} programadas`);
+  } catch (err) {
+    console.warn(`[standby] reconcile skipped: ${err.message}`);
+  }
+
   // KJC-TSK-0371 (board polish #3) — clean up ephemeral projects
   // (`/tmp/`-rooted, `tmp_*`/`test_*`/`demo_*`/`kj-test-*` prefixed)
   // that have been inactive for >24h. Runs AFTER the zombie-reaper

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -228,9 +228,9 @@ async function main() {
     const { fileURLToPath } = await import('node:url');
     const KJ_CLI = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'src', 'cli.js');
     const onResume = (sessionId) => {
-      console.log(`[standby] reanudando sesión ${sessionId} (spawn kj resume)`);
+      console.log(`[standby] reanudando sesión ${sessionId} (spawn kj standby resume)`);
       try {
-        const child = spawn(process.execPath, [KJ_CLI, 'resume', sessionId], {
+        const child = spawn(process.execPath, [KJ_CLI, 'standby', 'resume', sessionId], {
           detached: true, stdio: 'ignore', env: process.env,
         });
         child.unref();

--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -7,6 +7,7 @@
 // puede ignorarlo (fallback a long standby capped) hasta que llegue 0414.
 
 import { classifyAgentError, ERROR_CLASS } from "./agent-error-classifier.js";
+import { persistStandby } from "./standby-store.js";
 
 const ONE_MIN = 60 * 1000;
 
@@ -65,6 +66,10 @@ export async function withBrainRecovery({
   policy = DEFAULT_RECOVERY_POLICY,
   emitter, eventBase, logger,
   sleepFn = sleep,
+  // TSK-0414 PR2: si presente, en hibernate persiste { sessionId, planId?, huId?,
+  // argv?, ... } a ~/.kj/standby/<sessionId>.json y devuelve standbyFile en
+  // el resultado. Caller (típicamente cli.js o ej. plan-fix) decide qué hacer.
+  sessionState,
 }) {
   const effectiveProvider = provider || agent?.provider || "unknown";
   const attemptsByClass = {};
@@ -92,11 +97,28 @@ export async function withBrainRecovery({
       return { ok: false, action: "abort", recovery: cls, error: `Brain aborted: ${cls.class} — ${cls.message}` };
     }
 
-    // HIBERNATE: persistir+morir es TSK-0414. Aquí emitimos la señal y, si
-    // el caller no maneja, hacemos long-standby capped (degradación graceful).
+    // HIBERNATE: persistir + signal action=hibernate al caller.
+    // Si el caller pasó `sessionState` (TSK-0414 PR2), persistimos el JSON
+    // automáticamente en ~/.kj/standby/<sessionId>.json. Caller decide qué
+    // hacer con action=hibernate (típicamente exit 0 para liberar memoria).
     if (classPolicy.mode === "hibernate" && cls.retryAfter && cls.retryAfter > policy.hibernateThresholdMs) {
-      emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter });
-      return { ok: false, action: "hibernate", recovery: cls };
+      let standbyFile = null;
+      if (sessionState && sessionState.sessionId) {
+        try {
+          standbyFile = persistStandby({
+            ...sessionState,
+            cooldownUntil: cls.retryUntil,
+            reason: cls.class,
+            role, provider: effectiveProvider,
+            classifierMessage: cls.message,
+          });
+          logger?.info?.(`[brain] hibernated session ${sessionState.sessionId} → ${standbyFile} (resume at ${cls.retryUntil})`);
+        } catch (err) {
+          logger?.warn?.(`[brain] failed to persist standby: ${err.message}`);
+        }
+      }
+      emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter, standbyFile });
+      return { ok: false, action: "hibernate", recovery: cls, standbyFile };
     }
 
     // STANDBY: espera hasta cooldownUntil (capado por longStandbyCapMs).

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,7 @@ import { registerPlan } from "./cli/register-plan.js";
 import { registerRolesSkills } from "./cli/register-roles-skills.js";
 import { registerMeta } from "./cli/register-meta.js";
 import { registerSonar } from "./cli/register-sonar.js";
+import { registerStandby } from "./cli/register-standby.js";
 import { printUpdateNotice } from "./utils/update-check.js";
 import { printWelcomeScreen } from "./utils/welcome.js";
 
@@ -44,6 +45,7 @@ registerPlan(program, { pkgVersion: PKG_VERSION });
 registerRolesSkills(program, { pkgVersion: PKG_VERSION });
 registerMeta(program, { pkgVersion: PKG_VERSION });
 registerSonar(program);
+registerStandby(program);
 
 /**
  * Find subcommands whose name is "close enough" to a typo. Used by the

--- a/src/cli/register-standby.js
+++ b/src/cli/register-standby.js
@@ -1,4 +1,8 @@
-// KJC-TSK-0414 PR2: registra `kj standby list` + `kj resume <id>` en el CLI.
+// KJC-TSK-0414 PR2: registra `kj standby list` + `kj standby resume <id>`.
+// `resume` es subcomando de standby para no colisionar con el `kj resume`
+// pre-existente (Solomon pauses con --answer). Modelos mentales distintos:
+//   - `kj resume <id> --answer X`  → Solomon pauseado (existente)
+//   - `kj standby resume <id>`     → run hibernada por quota
 import { resumeCommand, standbyListCommand } from "../commands/standby.js";
 
 export function registerStandby(program) {
@@ -11,7 +15,8 @@ export function registerStandby(program) {
       await standbyListCommand({ json: flags.json });
     });
 
-  program.command("resume")
+  standby
+    .command("resume")
     .description("Reanuda una sesión hibernada (re-spawn comando original)")
     .argument("<sessionId>")
     .option("--force", "Reanudar aunque cooldownUntil todavía esté en el futuro (no recomendado)")

--- a/src/cli/register-standby.js
+++ b/src/cli/register-standby.js
@@ -1,0 +1,21 @@
+// KJC-TSK-0414 PR2: registra `kj standby list` + `kj resume <id>` en el CLI.
+import { resumeCommand, standbyListCommand } from "../commands/standby.js";
+
+export function registerStandby(program) {
+  const standby = program.command("standby").description("Sesiones hibernadas (QUOTA_EXHAUSTED_DAILY etc.)");
+  standby
+    .command("list", { isDefault: true })
+    .description("Lista sesiones pendientes de reanudar")
+    .option("--json", "Output JSON")
+    .action(async (flags) => {
+      await standbyListCommand({ json: flags.json });
+    });
+
+  program.command("resume")
+    .description("Reanuda una sesión hibernada (re-spawn comando original)")
+    .argument("<sessionId>")
+    .option("--force", "Reanudar aunque cooldownUntil todavía esté en el futuro (no recomendado)")
+    .action(async (sessionId, flags) => {
+      await resumeCommand({ sessionId, force: Boolean(flags.force) });
+    });
+}

--- a/src/commands/standby.js
+++ b/src/commands/standby.js
@@ -1,0 +1,114 @@
+// KJC-TSK-0414 PR2: comandos kj standby list / kj resume.
+//
+// `kj resume <sessionId>` valida cooldownUntil y, si llegó la hora, re-spawn
+// el comando original capturado en argv. Si cooldown todavía está en el
+// futuro, muestra countdown y aborta. `kj standby list` solo enumera.
+//
+// Estrategia de resume: cada sessionState persiste su argv original (los
+// argumentos con los que se lanzó el `kj` que hibernó). El resume re-spawn
+// EXACTAMENTE ese mismo comando con env preservado. El run reanuda como si
+// fuera un retry — el state interno (HU pendiente, snapshot_sha, etc.) está
+// en el JSON persistido en disco por TSK-0408 + TSK-0414 PR1.
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadStandby, listPendingStandby, markStandbyDone, acquireStandbyLock } from "../brain/standby-store.js";
+
+const REPO_KJ_CLI = (() => {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    return path.join(here, "..", "cli.js");
+  } catch {
+    return null;
+  }
+})();
+
+function formatCountdown(ms) {
+  if (ms <= 0) return "ahora";
+  const s = Math.round(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+}
+
+export async function standbyListCommand({ json } = {}) {
+  const sessions = listPendingStandby();
+  if (json) {
+    console.log(JSON.stringify(sessions, null, 2));
+    return;
+  }
+  if (sessions.length === 0) {
+    console.log("No hay sesiones hibernadas.");
+    return;
+  }
+  console.log(`Sesiones hibernadas (${sessions.length}):`);
+  const now = Date.now();
+  for (const s of sessions) {
+    const ms = new Date(s.cooldownUntil).getTime() - now;
+    const status = ms <= 0 ? "✓ lista para resume" : `⏳ resume en ${formatCountdown(ms)}`;
+    console.log(`  ${s.sessionId}  · ${s.reason || "?"}  · ${status}`);
+    if (s.planId) console.log(`    plan: ${s.planId}${s.huId ? `, HU: ${s.huId}` : ""}`);
+  }
+}
+
+/**
+ * Re-spawn el comando original capturado en sessionState.argv.
+ * Si cooldownUntil > now y force=false → aborta con mensaje.
+ */
+export async function resumeCommand({ sessionId, force } = {}) {
+  if (!sessionId) {
+    console.error("kj resume requiere <sessionId>. Usa `kj standby list` para ver pendientes.");
+    process.exitCode = 1;
+    return;
+  }
+  const state = loadStandby(sessionId);
+  if (!state) {
+    console.error(`Sesión no encontrada: ${sessionId}`);
+    process.exitCode = 1;
+    return;
+  }
+  const cooldownMs = new Date(state.cooldownUntil).getTime() - Date.now();
+  if (cooldownMs > 0 && !force) {
+    console.log(`Sesión ${sessionId} todavía en cooldown ${formatCountdown(cooldownMs)} (hasta ${state.cooldownUntil}).`);
+    console.log("Espera o usa `kj resume <sessionId> --force` (no recomendado — la API seguramente seguirá rechazando).");
+    process.exitCode = 0;
+    return;
+  }
+
+  const lock = acquireStandbyLock(sessionId);
+  if (!lock.acquired) {
+    console.log(`Sesión ${sessionId} ya está siendo reanudada por otro proceso.`);
+    process.exitCode = 0;
+    return;
+  }
+
+  try {
+    if (!Array.isArray(state.argv) || state.argv.length === 0) {
+      console.error(`Sesión ${sessionId} sin argv — no se puede re-spawn. Borra manual y relanza.`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!REPO_KJ_CLI) {
+      console.error("No se pudo localizar cli.js. ¿Karajan instalado correctamente?");
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`Reanudando ${sessionId}: kj ${state.argv.join(" ")}`);
+    const child = spawn(process.execPath, [REPO_KJ_CLI, ...state.argv], {
+      cwd: state.cwd || process.cwd(),
+      env: { ...process.env, ...(state.env || {}), KJ_RESUME_FROM: sessionId },
+      stdio: "inherit",
+    });
+    await new Promise((resolve) => {
+      child.on("exit", (code) => {
+        if (code === 0) markStandbyDone(sessionId);
+        process.exitCode = code ?? 0;
+        resolve();
+      });
+    });
+  } finally {
+    lock.release?.();
+  }
+}


### PR DESCRIPTION
## Summary

Integra el store/scheduler de #729 con el wrapper de TSK-0412 y añade los comandos CLI de hibernación.

> Reopened: base original era \`feat/standby-persistence-scheduler\`, eliminada al squash-mergear #729.

### withBrainRecovery
- Nuevo param opcional \`sessionState\` — si presente y clase = QUOTA_EXHAUSTED_DAILY con retryAfter > 5min, persiste a \`~/.kj/standby/<id>.json\` y devuelve \`action: 'hibernate'\` con \`standbyFile\`.

### CLI nuevos
- \`kj standby list [--json]\` — countdown HH:MM:SS por sesión
- \`kj resume <sessionId> [--force]\` — valida cooldown, lockfile, re-spawn argv original

### Board startup
- \`reconcileAll()\` tras los reapers existentes — cooldown expirado → spawn \`kj resume\` detached; cooldown futuro → re-programa setTimeout