### PR TITLE
feat(brain): hibernación PR3 — GC extendido standby/audits/hu-board-runs (KJC-TSK-0414)

### DIFF
--- a/src/utils/garbage-collector.js
+++ b/src/utils/garbage-collector.js
@@ -274,6 +274,82 @@ async function gcHuStories(opts) {
   return result;
 }
 
+// KJC-TSK-0414 PR3: limpia ~/.kj/standby/done/<id>-<ts>.json finalizadas
+// hace > N días. Las pendientes en ~/.kj/standby/<id>.json NUNCA se tocan
+// — son las que esperan resume.
+async function gcStandbyDone(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const doneDir = path.join(getKjHome(), "standby", "done");
+  if (!(await exists(doneDir))) return result;
+
+  const entries = (await listDir(doneDir)).filter((e) => e.isFile());
+  for (const entry of entries) {
+    const file = path.join(doneDir, entry.name);
+    const stat = await tryStat(file);
+    if (!stat) continue;
+    const days = ageInDays(stat, now);
+    if (days <= opts.standbyDoneRetentionDays) continue;
+    try {
+      await unlinkOrRm(file, opts.dryRun);
+      result.removed.push({ path: file, reason: `standby done > ${opts.standbyDoneRetentionDays}d (${Math.round(days)}d)`, kind: "standby-done" });
+    } catch (err) {
+      result.errors.push({ path: file, error: err.message });
+    }
+  }
+  return result;
+}
+
+// KJC-TSK-0414 PR3: limpia ~/.karajan/audits/<project>/ con last mtime > N días.
+// El usuario reportó decenas de carpetas kj-test-* huérfanas — son audits de
+// runs antiguos cuyo project ya no existe o que llevan meses sin actividad.
+async function gcAudits(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const auditRoot = path.join(getKarajanHome(), "audits");
+  if (!(await exists(auditRoot))) return result;
+
+  const entries = (await listDir(auditRoot)).filter((e) => e.isDirectory());
+  for (const entry of entries) {
+    const dir = path.join(auditRoot, entry.name);
+    const stat = await tryStat(dir);
+    if (!stat) continue;
+    const days = ageInDays(stat, now);
+    if (days <= opts.auditsRetentionDays) continue;
+    try {
+      await unlinkOrRm(dir, opts.dryRun);
+      result.removed.push({ path: dir, reason: `audit > ${opts.auditsRetentionDays}d sin actividad (${Math.round(days)}d)`, kind: "audit" });
+    } catch (err) {
+      result.errors.push({ path: dir, error: err.message });
+    }
+  }
+  return result;
+}
+
+// KJC-TSK-0414 PR3: ~/.karajan/hu-board-runs/<runId>/ con mtime > N días.
+async function gcHuBoardRuns(opts) {
+  const result = { removed: [], bytesFreed: 0, errors: [] };
+  const now = opts.now || new Date();
+  const root = path.join(getKarajanHome(), "hu-board-runs");
+  if (!(await exists(root))) return result;
+
+  const entries = (await listDir(root)).filter((e) => e.isDirectory());
+  for (const entry of entries) {
+    const dir = path.join(root, entry.name);
+    const stat = await tryStat(dir);
+    if (!stat) continue;
+    const days = ageInDays(stat, now);
+    if (days <= opts.huBoardRunsRetentionDays) continue;
+    try {
+      await unlinkOrRm(dir, opts.dryRun);
+      result.removed.push({ path: dir, reason: `hu-board-run > ${opts.huBoardRunsRetentionDays}d (${Math.round(days)}d)`, kind: "hu-board-run" });
+    } catch (err) {
+      result.errors.push({ path: dir, error: err.message });
+    }
+  }
+  return result;
+}
+
 function mergeResults(...parts) {
   const out = { removed: [], bytesFreed: 0, errors: [] };
   for (const r of parts) {
@@ -290,6 +366,10 @@ function defaultOpts(opts = {}) {
     draftRetentionDays: opts.draftRetentionDays ?? 60,
     sessionRetentionDays: opts.sessionRetentionDays ?? 7,
     huRetentionDays: opts.huRetentionDays ?? 14,
+    // KJC-TSK-0414 PR3
+    standbyDoneRetentionDays: opts.standbyDoneRetentionDays ?? 7,
+    auditsRetentionDays: opts.auditsRetentionDays ?? 30,
+    huBoardRunsRetentionDays: opts.huBoardRunsRetentionDays ?? 30,
     dryRun: Boolean(opts.dryRun),
     now: opts.now || new Date(),
   };
@@ -307,12 +387,15 @@ export async function runManualGC(opts = {}) {
   // stories live in different directory subtrees and don't share state,
   // so Promise.all is safe and roughly halves end-to-end GC latency on
   // a populated KJ_HOME.
-  const [plans, sessions, huStories] = await Promise.all([
+  const [plans, sessions, huStories, standbyDone, audits, huBoardRuns] = await Promise.all([
     gcPlans(o),
     gcSessions(o),
     gcHuStories(o),
+    gcStandbyDone(o),
+    gcAudits(o),
+    gcHuBoardRuns(o),
   ]);
-  return mergeResults(plans, sessions, huStories);
+  return mergeResults(plans, sessions, huStories, standbyDone, audits, huBoardRuns);
 }
 
 /**

--- a/tests/utils/garbage-collector.test.js
+++ b/tests/utils/garbage-collector.test.js
@@ -201,6 +201,71 @@ describe("garbage-collector — HU story batches", () => {
   });
 });
 
+// KJC-TSK-0414 PR3: GC para standby/done, audits, hu-board-runs.
+describe("garbage-collector — KJC-TSK-0414 categorías nuevas", () => {
+  async function writeStandbyDone(id, { mtime } = {}) {
+    const dir = path.join(tmpKj, "standby", "done");
+    await mkdirp(dir);
+    const file = path.join(dir, `${id}.json`);
+    await fs.writeFile(file, "{}");
+    if (mtime) await fs.utimes(file, mtime, mtime);
+    return file;
+  }
+  async function writeAudit(name, { mtime } = {}) {
+    const dir = path.join(tmpKarajan, "audits", name);
+    await mkdirp(dir);
+    await fs.writeFile(path.join(dir, "report.md"), "x");
+    if (mtime) await fs.utimes(dir, mtime, mtime);
+    return dir;
+  }
+  async function writeHuBoardRun(name, { mtime } = {}) {
+    const dir = path.join(tmpKarajan, "hu-board-runs", name);
+    await mkdirp(dir);
+    await fs.writeFile(path.join(dir, "run.log"), "x");
+    if (mtime) await fs.utimes(dir, mtime, mtime);
+    return dir;
+  }
+
+  it("standby/done > 7d eliminado, < 7d preservado", async () => {
+    const old = await writeStandbyDone("s-old", { mtime: new Date(Date.now() - 30 * DAY) });
+    const fresh = await writeStandbyDone("s-fresh", { mtime: new Date(Date.now() - 2 * DAY) });
+    const r = await runManualGC({ standbyDoneRetentionDays: 7, dryRun: false });
+    const paths = r.removed.map((x) => x.path);
+    expect(paths).toContain(old);
+    expect(paths).not.toContain(fresh);
+  });
+
+  it("audits/<project> > 30d eliminado", async () => {
+    const old = await writeAudit("kj-test-old", { mtime: new Date(Date.now() - 60 * DAY) });
+    const fresh = await writeAudit("kj-recent", { mtime: new Date(Date.now() - 10 * DAY) });
+    const r = await runManualGC({ auditsRetentionDays: 30, dryRun: false });
+    const paths = r.removed.map((x) => x.path);
+    expect(paths).toContain(old);
+    expect(paths).not.toContain(fresh);
+  });
+
+  it("hu-board-runs/<runId> > 30d eliminado", async () => {
+    const old = await writeHuBoardRun("run-old", { mtime: new Date(Date.now() - 60 * DAY) });
+    const fresh = await writeHuBoardRun("run-fresh", { mtime: new Date(Date.now() - 10 * DAY) });
+    const r = await runManualGC({ huBoardRunsRetentionDays: 30, dryRun: false });
+    const paths = r.removed.map((x) => x.path);
+    expect(paths).toContain(old);
+    expect(paths).not.toContain(fresh);
+  });
+
+  it("standby/<id>.json (pendiente, NO done) NUNCA se toca", async () => {
+    const pendingDir = path.join(tmpKj, "standby");
+    await mkdirp(pendingDir);
+    const pending = path.join(pendingDir, "active.json");
+    await fs.writeFile(pending, JSON.stringify({ sessionId: "active", cooldownUntil: "2099-01-01T00:00:00Z" }));
+    await fs.utimes(pending, new Date(Date.now() - 365 * DAY), new Date(Date.now() - 365 * DAY));
+    const r = await runManualGC({ standbyDoneRetentionDays: 7, dryRun: false });
+    expect(r.removed.map((x) => x.path)).not.toContain(pending);
+    // Y el archivo sigue ahí
+    await expect(fs.access(pending)).resolves.toBeUndefined();
+  });
+});
+
 describe("garbage-collector — summary + autoGC", () => {
   it("runAutoGC is runManualGC with dryRun=false", async () => {
     const orphan = await writePlan("x", "plan-auto", {


### PR DESCRIPTION
## Summary

Resuelve el problema real: \`~/.karajan/audits/\` tenía 12 carpetas huérfanas y \`hu-board-runs/\` otras 13.

> Reopened: base original era \`feat/standby-persistence-scheduler\`, eliminada al squash-mergear #729.

### Nuevas categorías GC
- **gcStandbyDone** — \`~/.kj/standby/done/<id>-<ts>.json\` > 7d
- **gcAudits** — \`~/.karajan/audits/<project>/\` > 30d
- **gcHuBoardRuns** — \`~/.karajan/hu-board-runs/<runId>/\` > 30d

\`runAutoGC\` se ejecuta al inicio de cada \`kj run\`/\`kj plan\` → limpieza transparente.

**Regression guard:** \`standby/<id>.json\` pendiente NUNCA se toca (el scheduler las consume).