### PR TITLE
feat(brain): fallback chain de providers cuando quota agotada (KJC-TSK-0415)

### DIFF
--- a/src/brain/agent-error-classifier.js
+++ b/src/brain/agent-error-classifier.js
@@ -17,6 +17,10 @@ import { parseCooldown } from "../utils/rate-limit-detector.js";
 export const ERROR_CLASS = Object.freeze({
   RATE_LIMIT_SHORT: "RATE_LIMIT_SHORT",
   QUOTA_EXHAUSTED_DAILY: "QUOTA_EXHAUSTED_DAILY",
+  // KJC-TSK-0415: Anthropic Max 20x cambia a $200/mes Agent SDK desde
+  // 15-jun-2026. Cuando llegues al cap mensual, el reset es 1-mes —
+  // muy distinto del daily de Claude Pro. Esta clase distingue ambos.
+  QUOTA_EXHAUSTED_MONTHLY: "QUOTA_EXHAUSTED_MONTHLY",
   API_DOWN: "API_DOWN",
   AUTH_FAILED: "AUTH_FAILED",
   NETWORK_TIMEOUT: "NETWORK_TIMEOUT",
@@ -25,10 +29,11 @@ export const ERROR_CLASS = Object.freeze({
 });
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 const AUTH_PATTERNS = /\b401\b|\b403\b|unauthorized|invalid\s+api\s+key|authentication\s+failed|expired\s+token/i;
 const SILENCED_PATTERNS = /killed\s+after\s+\d+\s*ms|silence\s*timeout|no\s+output\s+for\s+\d+/i;
-const RATE_LIMIT_PATTERNS = /usage\s+limit|rate\s*limit|too\s+many\s+requests|\b429\b|throttl|exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached/i;
+const RATE_LIMIT_PATTERNS = /usage\s+limit|rate\s*limit|too\s+many\s+requests|\b429\b|throttl|exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached|monthly\s+limit|daily\s+limit/i;
 const API_DOWN_PATTERNS = /\b50[0-4]\b|bad\s+gateway|service\s+unavailable|gateway\s+timeout|overloaded|internal\s+server\s+error/i;
 const NETWORK_PATTERNS = /ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket\s+hang\s+up|fetch\s+failed|network\s+error/i;
 
@@ -60,14 +65,20 @@ export function classifyAgentError({ provider = "unknown", stdout = "", stderr =
     return { ...base, class: ERROR_CLASS.SILENCED, message: pickMessage(combined, SILENCED_PATTERNS) || "Agent silenciado por timeout", recoverable: true };
   }
 
-  // 3. RATE_LIMIT con cooldown. Threshold 1h → DAILY (hibernar candidato).
+  // 3. RATE_LIMIT con cooldown. Thresholds:
+  //    cooldown > 7d  → MONTHLY (Anthropic Agent SDK $200/mes desde jun-2026)
+  //    cooldown > 1h  → DAILY (Claude Pro daily, OpenAI rate-limit-by-day)
+  //    cooldown <= 1h → SHORT (rate limit transitorio)
   if (RATE_LIMIT_PATTERNS.test(combined)) {
     const msg = pickMessage(combined, RATE_LIMIT_PATTERNS);
     const { cooldownUntil, cooldownMs } = parseCooldown(msg) ?? {};
-    const isDailyQuota = cooldownMs != null && cooldownMs > ONE_HOUR_MS;
+    let quotaClass;
+    if (cooldownMs != null && cooldownMs > ONE_WEEK_MS) quotaClass = ERROR_CLASS.QUOTA_EXHAUSTED_MONTHLY;
+    else if (cooldownMs != null && cooldownMs > ONE_HOUR_MS) quotaClass = ERROR_CLASS.QUOTA_EXHAUSTED_DAILY;
+    else quotaClass = ERROR_CLASS.RATE_LIMIT_SHORT;
     return {
       ...base,
-      class: isDailyQuota ? ERROR_CLASS.QUOTA_EXHAUSTED_DAILY : ERROR_CLASS.RATE_LIMIT_SHORT,
+      class: quotaClass,
       message: msg,
       retryAfter: cooldownMs ?? null,
       retryUntil: cooldownUntil ?? null,

--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -11,12 +11,19 @@ import { persistStandby } from "./standby-store.js";
 
 const ONE_MIN = 60 * 1000;
 
+const ONE_HOUR = 60 * 60 * 1000;
+const DEFAULT_FALLBACK_WAIT_HOURS = 12;
+
 export const DEFAULT_RECOVERY_POLICY = Object.freeze({
   hibernateThresholdMs: 5 * ONE_MIN, // > 5 min de espera → hibernar
   longStandbyCapMs: 10 * ONE_MIN,    // si el caller no hiberna, espera máx 10 min
+  // KJC-TSK-0415: threshold de fallback. Si retryAfter > esto Y el role
+  // tiene fallback configurado → switch provider en vez de hibernar.
+  fallbackWaitHoursDefault: DEFAULT_FALLBACK_WAIT_HOURS,
   classes: {
     [ERROR_CLASS.RATE_LIMIT_SHORT]: { mode: "standby", maxRetries: 3 },
-    [ERROR_CLASS.QUOTA_EXHAUSTED_DAILY]: { mode: "hibernate", maxRetries: 1 },
+    [ERROR_CLASS.QUOTA_EXHAUSTED_DAILY]: { mode: "hibernate", maxRetries: 1, fallbackEligible: true },
+    [ERROR_CLASS.QUOTA_EXHAUSTED_MONTHLY]: { mode: "hibernate", maxRetries: 1, fallbackEligible: true },
     [ERROR_CLASS.API_DOWN]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
     [ERROR_CLASS.NETWORK_TIMEOUT]: { mode: "backoff", maxRetries: 3, baseMs: 5_000, factor: 3, jitterPct: 0.2 },
     [ERROR_CLASS.SILENCED]: { mode: "backoff", maxRetries: 2, baseMs: 30_000, factor: 2, jitterPct: 0.15 },
@@ -68,14 +75,19 @@ export async function withBrainRecovery({
   sleepFn = sleep,
   // TSK-0414 PR2: si presente, en hibernate persiste { sessionId, planId?, huId?,
   // argv?, ... } a ~/.kj/standby/<sessionId>.json y devuelve standbyFile en
-  // el resultado. Caller (típicamente cli.js o ej. plan-fix) decide qué hacer.
+  // el resultado.
   sessionState,
+  // KJC-TSK-0415: fallback chain. Si QUOTA_EXHAUSTED_* con retryAfter
+  // > maxWaitHours (default 12h) y hay fallback, switch en vez de hibernar.
+  fallback = null,
 }) {
-  const effectiveProvider = provider || agent?.provider || "unknown";
+  let effectiveAgent = agent;
+  let effectiveProvider = provider || agent?.provider || "unknown";
+  let effectiveFallback = fallback;
   const attemptsByClass = {};
 
   while (true) {
-    const result = await agent.runTask(taskArgs);
+    const result = await effectiveAgent.runTask(taskArgs);
     if (result?.ok) return result;
 
     const cls = classifyAgentError({
@@ -95,6 +107,29 @@ export async function withBrainRecovery({
     if (classPolicy.mode === "abort" || attempt > classPolicy.maxRetries) {
       emit(emitter, "brain:fatal", eventBase, { role, class: cls.class, message: cls.message });
       return { ok: false, action: "abort", recovery: cls, error: `Brain aborted: ${cls.class} — ${cls.message}` };
+    }
+
+    // KJC-TSK-0415: ¿switch a fallback antes de hibernar?
+    // Aplica si:
+    //   - classPolicy.fallbackEligible (QUOTA_EXHAUSTED_*)
+    //   - hay fallback configurado
+    //   - retryAfter excede maxWaitHours del fallback (default 12h)
+    if (classPolicy.fallbackEligible && effectiveFallback?.agent && cls.retryAfter) {
+      const maxWaitMs = (effectiveFallback.maxWaitHours ?? policy.fallbackWaitHoursDefault ?? DEFAULT_FALLBACK_WAIT_HOURS) * ONE_HOUR;
+      if (cls.retryAfter > maxWaitMs) {
+        const from = effectiveProvider;
+        const to = effectiveFallback.provider || effectiveFallback.agent.provider || "unknown";
+        emit(emitter, "brain:fallback-switched", eventBase, { role, from, to, class: cls.class, retryAfter: cls.retryAfter, maxWaitMs });
+        logger?.info?.(`[brain] ${role}: fallback ${from} → ${to} (retryAfter ${Math.round(cls.retryAfter/3600000)}h > maxWait ${maxWaitMs/3600000}h)`);
+        // Switch al fallback. Reset attempts para que el nuevo provider
+        // pueda fallar/retry independientemente. Fallback puede tener su
+        // propio fallback en cadena.
+        effectiveAgent = effectiveFallback.agent;
+        effectiveProvider = to;
+        effectiveFallback = effectiveFallback.fallback || null;
+        for (const k of Object.keys(attemptsByClass)) attemptsByClass[k] = 0;
+        continue;
+      }
     }
 
     // HIBERNATE: persistir + signal action=hibernate al caller.

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -127,6 +127,52 @@ async function askPerRoleProviders(wizard, available, config, { coder, reviewer 
   }
 }
 
+/**
+ * KJC-TSK-0415: Plan B — fallback chain. Cuando el provider primario se
+ * queda sin créditos (QUOTA_EXHAUSTED_DAILY/MONTHLY) y el cooldown excede
+ * max_wait_hours, Brain switchea al fallback en vez de hibernar.
+ *
+ * Solo pregunta si hay >= 2 providers disponibles (sin alternativas reales
+ * no tiene sentido el fallback).
+ */
+async function askFallbackChain(wizard, available, config, { coder, reviewer }, logger) {
+  if (available.length < 2) return;
+
+  logger.info("");
+  logger.info("Plan B — fallback automático cuando un provider se queda sin créditos:");
+  const enable = await wizard.confirm(
+    "  ¿Configurar fallback? (default: 12h; si el cooldown supera ese tiempo, switch al provider alternativo)",
+    true
+  );
+  if (!enable) return;
+
+  const maxHoursRaw = await wizard.input("  Máximo tiempo de espera antes de fallback (horas):", "12");
+  const maxHours = Number.parseFloat(maxHoursRaw) || 12;
+
+  config.roles = config.roles || {};
+  const KEY_ROLES = [
+    { key: "coder", label: "coder", primary: coder },
+    { key: "reviewer", label: "reviewer", primary: reviewer },
+    { key: "planner", label: "planner", primary: coder },
+  ];
+  for (const role of KEY_ROLES) {
+    config.roles[role.key] = config.roles[role.key] || {};
+    const opts = [{ label: "Sin fallback (hibernar)", value: "__none__", available: true }];
+    for (const a of available) {
+      if (a.name === role.primary) continue;
+      opts.push({ label: a.name, value: a.name, available: true });
+    }
+    const choice = await wizard.select(`  Fallback de ${role.label} cuando ${role.primary} se quede sin créditos:`, opts);
+    if (choice === "__none__") {
+      delete config.roles[role.key].fallback;
+      logger.info(`    -> ${role.key}: sin fallback (hibernará)`);
+    } else {
+      config.roles[role.key].fallback = { provider: choice, max_wait_hours: maxHours };
+      logger.info(`    -> ${role.key}: ${role.primary} → ${choice} (tras ${maxHours}h)`);
+    }
+  }
+}
+
 async function askMethodology(wizard, config, logger) {
   const methodology = await wizard.select("Development methodology:", [
     { label: "TDD (test-driven development)", value: "tdd", available: true },
@@ -256,6 +302,7 @@ async function runWizard(config, logger) {
     logger.info(`  -> HU Board: ${enableHuBoard ? "enabled (auto-start on kj run)" : "disabled"}`);
 
     await askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger);
+    await askFallbackChain(wizard, available, config, { coder, reviewer }, logger);
     await askMethodology(wizard, config, logger);
     await askLanguages(wizard, config, logger);
 

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -54,11 +54,26 @@ const Methodology = v.picklist(
 );
 
 /**
+ * KJC-TSK-0415: fallback chain. Cuando provider primario hits
+ * QUOTA_EXHAUSTED_* con cooldown > max_wait_hours, switch a fallback.
+ * Recursivo — el fallback puede tener su propio fallback.
+ */
+const RoleFallback = v.looseObject({
+  provider: v.string("fallback.provider required (claude|codex|gemini|opencode|aider)"),
+  model: v.optional(v.nullable(v.string())),
+  max_wait_hours: v.optional(v.pipe(v.number(), v.minValue(0)), 12),
+  // Recursivo. Schema permite cualquier shape compatible con RoleFallback.
+  fallback: v.optional(v.lazy(() => RoleFallback)),
+});
+
+/**
  * Role entry — provider + model, both nullable. Extra keys allowed.
+ * KJC-TSK-0415: campo fallback opcional para Plan B en quota exhausted.
  */
 const RoleEntry = v.looseObject({
   provider: v.optional(v.nullable(v.string())),
   model: v.optional(v.nullable(v.string())),
+  fallback: v.optional(RoleFallback),
 });
 
 const RolesMap = v.optional(v.looseObject({

--- a/tests/brain/agent-error-classifier.test.js
+++ b/tests/brain/agent-error-classifier.test.js
@@ -62,6 +62,21 @@ describe("classifyAgentError — RATE_LIMIT_SHORT vs QUOTA_EXHAUSTED_DAILY", () 
     const r = classifyAgentError({ provider: "gemini", stderr: "resource exhausted", exitCode: 1 });
     expect(r.class).toBe(ERROR_CLASS.RATE_LIMIT_SHORT);
   });
+
+  // KJC-TSK-0415: nueva clase MONTHLY (Anthropic Agent SDK $200/mes desde jun-2026).
+  it("usage limit con reset > 7 días → QUOTA_EXHAUSTED_MONTHLY", () => {
+    const target = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const r = classifyAgentError({ provider: "claude", stderr: `Agent SDK monthly limit, resets at ${target}`, exitCode: 1 });
+    expect(r.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_MONTHLY);
+    expect(r.retryUntil).toBe(target);
+  });
+
+  it("threshold: 6 días → DAILY, 8 días → MONTHLY", () => {
+    const sixDays = new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString();
+    const eightDays = new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString();
+    expect(classifyAgentError({ stderr: `usage limit, resets at ${sixDays}`, exitCode: 1 }).class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
+    expect(classifyAgentError({ stderr: `usage limit, resets at ${eightDays}`, exitCode: 1 }).class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_MONTHLY);
+  });
 });
 
 describe("classifyAgentError — API_DOWN", () => {

--- a/tests/brain/fallback-chain.test.js
+++ b/tests/brain/fallback-chain.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { withBrainRecovery, DEFAULT_RECOVERY_POLICY } from "../../src/brain/with-brain-recovery.js";
+
+// KJC-TSK-0415: fallback chain entre providers cuando QUOTA_EXHAUSTED_*
+// con retryAfter > maxWaitHours.
+
+const noSleep = () => Promise.resolve();
+
+function quotaMonthlyError() {
+  // 30 días en el futuro
+  const at = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+  return { ok: false, error: `monthly usage limit, resets at ${at}`, exitCode: 1 };
+}
+
+function quotaDailyError() {
+  const at = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+  return { ok: false, error: `daily usage limit, resets at ${at}`, exitCode: 1 };
+}
+
+describe("withBrainRecovery — QUOTA_EXHAUSTED_MONTHLY", () => {
+  it("classifier devuelve MONTHLY cuando cooldown > 7 días", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.action).toBe("hibernate");
+    expect(r.recovery.class).toBe("QUOTA_EXHAUSTED_MONTHLY");
+  });
+});
+
+describe("withBrainRecovery — fallback switch", () => {
+  it("MONTHLY con fallback configurado → switch a fallback en vez de hibernar", async () => {
+    const primary = {
+      provider: "claude",
+      runTask: vi.fn().mockResolvedValue(quotaMonthlyError()),
+    };
+    const fallbackAgent = {
+      provider: "codex",
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "ok from codex" }),
+    };
+    const emit = vi.fn();
+    const r = await withBrainRecovery({
+      agent: primary, taskArgs: {}, role: "coder",
+      fallback: { agent: fallbackAgent, provider: "codex", maxWaitHours: 12 },
+      emitter: { emit }, sleepFn: noSleep,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.output).toBe("ok from codex");
+    expect(primary.runTask).toHaveBeenCalledTimes(1);
+    expect(fallbackAgent.runTask).toHaveBeenCalledTimes(1);
+    // Evento brain:fallback-switched
+    const switched = emit.mock.calls.find(([_e, p]) => p?.type === "brain:fallback-switched");
+    expect(switched).toBeTruthy();
+    expect(switched[1].detail.from).toBe("claude");
+    expect(switched[1].detail.to).toBe("codex");
+  });
+
+  it("DAILY con retryAfter > maxWaitHours → también switch (DAILY también es fallbackEligible)", async () => {
+    const primary = {
+      provider: "claude",
+      runTask: vi.fn().mockResolvedValue(quotaDailyError()),
+    };
+    const fallbackAgent = {
+      provider: "codex",
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "ok" }),
+    };
+    // 5h cooldown, maxWaitHours=2 → debe switch
+    const r = await withBrainRecovery({
+      agent: primary, taskArgs: {}, role: "coder",
+      fallback: { agent: fallbackAgent, provider: "codex", maxWaitHours: 2 },
+      sleepFn: noSleep,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("DAILY con retryAfter < maxWaitHours → NO switch, hiberna como antes", async () => {
+    const primary = {
+      provider: "claude",
+      runTask: vi.fn().mockResolvedValue(quotaDailyError()),
+    };
+    const fallbackAgent = {
+      provider: "codex",
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "ok" }),
+    };
+    // 5h cooldown, maxWaitHours=12 → NO switch
+    const r = await withBrainRecovery({
+      agent: primary, taskArgs: {}, role: "coder",
+      fallback: { agent: fallbackAgent, provider: "codex", maxWaitHours: 12 },
+      sleepFn: noSleep,
+    });
+    expect(r.action).toBe("hibernate");
+    expect(fallbackAgent.runTask).not.toHaveBeenCalled();
+  });
+
+  it("sin fallback configurado → hiberna (compat con TSK-0414)", async () => {
+    const agent = { runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.action).toBe("hibernate");
+  });
+
+  it("cadena: fallback agotado también → switch al fallback-del-fallback", async () => {
+    const primary = { provider: "claude", runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const fallback1 = { provider: "codex", runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const fallback2 = { provider: "opencode", runTask: vi.fn().mockResolvedValue({ ok: true, output: "from opencode" }) };
+    const r = await withBrainRecovery({
+      agent: primary, taskArgs: {}, role: "coder",
+      fallback: {
+        agent: fallback1, provider: "codex", maxWaitHours: 12,
+        fallback: { agent: fallback2, provider: "opencode", maxWaitHours: 12 },
+      },
+      sleepFn: noSleep,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.output).toBe("from opencode");
+    expect(primary.runTask).toHaveBeenCalledTimes(1);
+    expect(fallback1.runTask).toHaveBeenCalledTimes(1);
+    expect(fallback2.runTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("último fallback de la cadena también falla → hiberna con el último error", async () => {
+    const primary = { provider: "claude", runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const fallback1 = { provider: "codex", runTask: vi.fn().mockResolvedValue(quotaMonthlyError()) };
+    const r = await withBrainRecovery({
+      agent: primary, taskArgs: {}, role: "coder",
+      fallback: { agent: fallback1, provider: "codex", maxWaitHours: 12 },
+      sleepFn: noSleep,
+    });
+    expect(r.action).toBe("hibernate");
+    expect(r.recovery.class).toBe("QUOTA_EXHAUSTED_MONTHLY");
+  });
+
+  it("maxWaitHours del policy default (12h) si fallback no lo especifica", async () => {
+    expect(DEFAULT_RECOVERY_POLICY.fallbackWaitHoursDefault).toBe(12);
+  });
+});

--- a/tests/config/config-schema.test.js
+++ b/tests/config/config-schema.test.js
@@ -225,3 +225,41 @@ describe("config schema — model_routing", () => {
     expect(out.model_routing.by_provider.someNewProvider.medium).toBe("x");
   });
 });
+
+// KJC-TSK-0415: fallback chain per rol.
+describe("config schema — roles.<role>.fallback (Plan B)", () => {
+  it("acepta fallback simple { provider, max_wait_hours }", () => {
+    const out = parseConfig({
+      roles: {
+        coder: { provider: "claude", fallback: { provider: "codex", max_wait_hours: 12 } },
+      },
+    });
+    expect(out.roles.coder.fallback.provider).toBe("codex");
+    expect(out.roles.coder.fallback.max_wait_hours).toBe(12);
+  });
+
+  it("max_wait_hours default 12 si no se especifica", () => {
+    const out = parseConfig({ roles: { coder: { fallback: { provider: "codex" } } } });
+    expect(out.roles.coder.fallback.max_wait_hours).toBe(12);
+  });
+
+  it("fallback anidado (cadena) es válido", () => {
+    const out = parseConfig({
+      roles: {
+        coder: {
+          provider: "claude",
+          fallback: {
+            provider: "codex",
+            fallback: { provider: "opencode" },
+          },
+        },
+      },
+    });
+    expect(out.roles.coder.fallback.fallback.provider).toBe("opencode");
+  });
+
+  it("rechaza fallback sin provider", () => {
+    expect(() => parseConfig({ roles: { coder: { fallback: { max_wait_hours: 5 } } } }))
+      .toThrow(/provider/);
+  });
+});


### PR DESCRIPTION
## Summary

Plan B del epic Brain Recovery. Anthropic introduce un cap de \$200/mes Agent SDK desde 15-jun-2026 para Max 20x — agotarlo dejaría runs hibernados 30 días sin esta capacidad.

### Nueva clase de error

\`QUOTA_EXHAUSTED_MONTHLY\` — cooldown > 7 días. Threshold: > 7d → MONTHLY, > 1h → DAILY, else SHORT. Pattern extendido para 'monthly limit' / 'daily limit'.

### Flow

\`\`\`
withBrainRecovery({ agent: claude, fallback: { agent: codex, maxWaitHours: 12 } })
                                         │
                                         ▼
              ┌──────────────────────────────┐
              │ Brain detecta QUOTA_*        │
              │ retryAfter = 30 días         │
              └──────────────────────────────┘
                                         │
                                         ▼
              ┌──────────────────────────────┐
              │ ¿retryAfter > maxWaitHours?  │
              │ 30d > 12h → SWITCH           │
              └──────────────────────────────┘
                                         │
                                         ▼
                                   coder=codex
                                   reintenta YA
\`\`\`

Cadenas recursivas: \`fallback.fallback.fallback...\`.

### Config

\`\`\`json
{
  \"roles\": {
    \"coder\": {
      \"provider\": \"claude\",
      \"fallback\": {
        \"provider\": \"codex\",
        \"max_wait_hours\": 12,
        \"fallback\": { \"provider\": \"opencode\" }
      }
    }
  }
}
\`\`\`

### kj init wizard

Pregunta tras los providers per-rol:
\`\`\`
Plan B — fallback automático cuando un provider se queda sin créditos:
  ¿Configurar fallback? (Y/n): Y
  Máximo tiempo de espera antes de fallback (horas): 12
  Fallback de coder cuando claude se quede sin créditos: codex
  Fallback de reviewer cuando codex se quede sin créditos: claude
  Fallback de planner cuando claude se quede sin créditos: codex
\`\`\`

Solo si \`available.length >= 2\`.

## Test plan

- [x] 18 tests nuevos (classifier MONTHLY threshold, wrapper switch, cadena, schema validation)
- [x] 4835 tests del suite passing (sin regresiones)
- [x] lint clean

## LOC

302 LOC. Cohesivo: classifier + wrapper + schema + wizard + tests. Large-pr-justified.