### PR TITLE
chore: audit cleanup v2.15.0 — Sonar BLOCKER false positives + dead exports

### DIFF
--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -12,5 +12,4 @@ export {
   planRemoveHuCommand,
   planMigrateResultCommand,
   planFixCommand,
-  planCommand,
 } from "./plan/index.js";

--- a/src/commands/plan/index.js
+++ b/src/commands/plan/index.js
@@ -1,6 +1,4 @@
 // Barrel: re-export all plan sub-command handlers.
-import { planGenerateCommand } from "./generate.js";
-
 export { planGenerateCommand } from "./generate.js";
 export { planListCommand } from "./list.js";
 export { planShowCommand } from "./show.js";
@@ -11,6 +9,3 @@ export { planAddHuCommand } from "./add-hu.js";
 export { planRemoveHuCommand } from "./remove-hu.js";
 export { planMigrateResultCommand } from "./migrate-result.js";
 export { planFixCommand } from "./fix.js";
-
-// Keep backward compat — old callers import planCommand
-export const planCommand = planGenerateCommand;

--- a/src/orchestrator/repair/repair-detector.js
+++ b/src/orchestrator/repair/repair-detector.js
@@ -50,9 +50,9 @@ const INFEASIBLE_SIGNATURES = [
 export function failureSignature(cmd, errorOutput) {
   const cmdNorm = String(cmd || "").trim().slice(0, 200);
   const errNorm = String(errorOutput || "")
-    .replace(/\s+/g, " ")        // collapse whitespace
-    .replace(/\d+/g, "N")          // numbers tend to drift; line numbers, counts
-    .replace(/\/[^\s]+/g, "/PATH") // absolute paths drift across runs
+    .replaceAll(/\s+/g, " ")        // collapse whitespace
+    .replaceAll(/\d+/g, "N")          // numbers tend to drift; line numbers, counts
+    .replaceAll(/\/[^\s]+/g, "/PATH") // absolute paths drift across runs
     .trim()
     .slice(0, 300);
   return `${cmdNorm}|||${errNorm}`;

--- a/src/plan/plan-structural-pass.js
+++ b/src/plan/plan-structural-pass.js
@@ -31,7 +31,7 @@ export function removeOrphanRefs(plan) {
   return fixes;
 }
 
-export function breakCycles(plan) {
+function breakCycles(plan) {
   const fixes = [];
   let cycles = findCycles(plan.hus);
   let budget = plan.hus.length;

--- a/tests/architecture/agent-readability.test.js
+++ b/tests/architecture/agent-readability.test.js
@@ -53,13 +53,12 @@ describe("agent-readability — llms.txt SKILL links resolve", () => {
       if (!fs.existsSync(abs)) missing.push(filename);
     }
 
-    if (missing.length > 0) {
-      throw new Error(
-        "llms.txt advertises SKILL files that don't exist:\n  " +
-        missing.map((f) => `docs/agents/${f}`).join("\n  ") +
-        "\n\nEither create them under docs/agents/ or remove the link from llms.txt.",
-      );
-    }
+    expect(
+      missing,
+      "llms.txt advertises SKILL files that don't exist:\n  " +
+      missing.map((f) => `docs/agents/${f}`).join("\n  ") +
+      "\n\nEither create them under docs/agents/ or remove the link from llms.txt.",
+    ).toEqual([]);
   });
 
   it("every SKILL.md under docs/agents/ has the expected sections", () => {
@@ -80,13 +79,12 @@ describe("agent-readability — llms.txt SKILL links resolve", () => {
       }
     }
 
-    if (offenders.length > 0) {
-      throw new Error(
-        "SKILL.md files missing required sections:\n  " +
-        offenders.join("\n  ") +
-        "\n\nEvery SKILL.md must have ## What it does, ## Inputs, ## Outputs, ## Example " +
-        "for agents to consume them deterministically.",
-      );
-    }
+    expect(
+      offenders,
+      "SKILL.md files missing required sections:\n  " +
+      offenders.join("\n  ") +
+      "\n\nEvery SKILL.md must have ## What it does, ## Inputs, ## Outputs, ## Example " +
+      "for agents to consume them deterministically.",
+    ).toEqual([]);
   });
 });

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -123,32 +123,30 @@ function findRedundantImports() {
 describe("architecture/dynamic-imports — budget + no-redundant rule", () => {
   it(`total dynamic import count is ≤ ${DYNAMIC_IMPORT_BUDGET}`, () => {
     const { total, perFile } = countDynamicImports();
-    if (total > DYNAMIC_IMPORT_BUDGET) {
-      const worst = [...perFile.entries()]
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 10)
-        .map(([f, n]) => `  ${n}  ${f}`)
-        .join("\n");
-      throw new Error(
-        `Dynamic imports under src/ grew past the ${DYNAMIC_IMPORT_BUDGET} budget ` +
-        `(now ${total}).\n\nTop offenders:\n${worst}\n\n` +
-        `Either convert a legitimate one to static (see ` +
-        `tests/architecture/dynamic-imports.test.js for when that applies), ` +
-        `or bump the budget in the SAME PR with a justification comment.`,
-      );
-    }
+    const worst = [...perFile.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([f, n]) => `  ${n}  ${f}`)
+      .join("\n");
+    expect(
+      total,
+      `Dynamic imports under src/ grew past the ${DYNAMIC_IMPORT_BUDGET} budget ` +
+      `(now ${total}).\n\nTop offenders:\n${worst}\n\n` +
+      `Either convert a legitimate one to static (see ` +
+      `tests/architecture/dynamic-imports.test.js for when that applies), ` +
+      `or bump the budget in the SAME PR with a justification comment.`,
+    ).toBeLessThanOrEqual(DYNAMIC_IMPORT_BUDGET);
   });
 
   it("no dynamic import is redundant with a static import of the same module", () => {
     const offenders = findRedundantImports();
-    if (offenders.length > 0) {
-      const msg = offenders
-        .map((o) => `  ${o.file}: await import("${o.mod}") — already statically imported`)
-        .join("\n");
-      throw new Error(
-        "Redundant dynamic imports detected — lift the static binding and " +
-        "reuse it at the callsite:\n" + msg,
-      );
-    }
+    const msg = offenders
+      .map((o) => `  ${o.file}: await import("${o.mod}") — already statically imported`)
+      .join("\n");
+    expect(
+      offenders,
+      "Redundant dynamic imports detected — lift the static binding and " +
+      "reuse it at the callsite:\n" + msg,
+    ).toEqual([]);
   });
 });

--- a/tests/architecture/layer-boundaries.test.js
+++ b/tests/architecture/layer-boundaries.test.js
@@ -68,14 +68,13 @@ describe("architecture/layer-boundaries — CLI and MCP are peer layers", () => 
         offenders.push({ file: path.relative(REPO_ROOT, file), imports: hits });
       }
     }
-    if (offenders.length > 0) {
-      const msg = offenders
-        .map((o) => `  ${o.file}: ${o.imports.join(", ")}`)
-        .join("\n");
-      throw new Error(
-        "src/commands/ must not depend on src/mcp/. Shared concepts go to src/session/ or src/config/:\n" + msg,
-      );
-    }
+    const msg = offenders
+      .map((o) => `  ${o.file}: ${o.imports.join(", ")}`)
+      .join("\n");
+    expect(
+      offenders,
+      "src/commands/ must not depend on src/mcp/. Shared concepts go to src/session/ or src/config/:\n" + msg,
+    ).toEqual([]);
   });
 
   it("src/mcp/ → src/commands/ is a known debt, not worse than baseline", () => {

--- a/tests/architecture/no-globalThis-kj.test.js
+++ b/tests/architecture/no-globalThis-kj.test.js
@@ -73,17 +73,16 @@ describe("architecture/no-globalThis-kj — test-harness globals isolated to sin
         offenders.push({ file: path.relative(REPO_ROOT, file), snippet: match?.[0] ?? "" });
       }
     }
-    if (offenders.length > 0) {
-      const msg = offenders
-        .map((o) => `  ${o.file}: ${o.snippet}`)
-        .join("\n");
-      throw new Error(
-        "globalThis.__KJ_* reads must live only in src/config/test-harness.js.\n" +
-        "Production code should read config.testHarness.* instead.\n" +
-        "See src/config/test-harness.js for the resolution contract.\n\n" +
-        "Offenders:\n" + msg,
-      );
-    }
+    const msg = offenders
+      .map((o) => `  ${o.file}: ${o.snippet}`)
+      .join("\n");
+    expect(
+      offenders,
+      "globalThis.__KJ_* reads must live only in src/config/test-harness.js.\n" +
+      "Production code should read config.testHarness.* instead.\n" +
+      "See src/config/test-harness.js for the resolution contract.\n\n" +
+      "Offenders:\n" + msg,
+    ).toEqual([]);
   });
 
   it("the allowed site actually reads globalThis", () => {

--- a/tests/architecture/session-store-imports.test.js
+++ b/tests/architecture/session-store-imports.test.js
@@ -114,13 +114,12 @@ describe("architecture / session/store imports", () => {
         }
       }
     }
-    if (offenders.length > 0) {
-      const list = offenders.map((o) => `  ${o.file}: calls ${o.name}() but doesn't import it`).join("\n");
-      throw new Error(
-        `Found ${offenders.length} call(s) to session/store functions without a matching import.\n` +
-        `This is the exact bug class that broke the demo on 2026-04-27 — fix by adding the import:\n\n` +
-        list,
-      );
-    }
+    const list = offenders.map((o) => `  ${o.file}: calls ${o.name}() but doesn't import it`).join("\n");
+    expect(
+      offenders,
+      `Found ${offenders.length} call(s) to session/store functions without a matching import.\n` +
+      `This is the exact bug class that broke the demo on 2026-04-27 — fix by adding the import:\n\n` +
+      list,
+    ).toEqual([]);
   });
 });

--- a/tests/architecture/session-write-boundary.test.js
+++ b/tests/architecture/session-write-boundary.test.js
@@ -97,15 +97,14 @@ describe("architecture/session-write-boundary — mutations only via src/session
       }
     }
 
-    if (offenders.length > 0) {
-      const msg = offenders
-        .map((o) => `  ${o.site}: ${o.snippet}`)
-        .join("\n");
-      throw new Error(
-        "Direct session mutations outside src/session/ — route through " +
-        "src/session/mutators.js (or add a whitelist entry with a reason):\n" + msg,
-      );
-    }
+    const msg = offenders
+      .map((o) => `  ${o.site}: ${o.snippet}`)
+      .join("\n");
+    expect(
+      offenders,
+      "Direct session mutations outside src/session/ — route through " +
+      "src/session/mutators.js (or add a whitelist entry with a reason):\n" + msg,
+    ).toEqual([]);
   });
 
   it("mutators module exports the documented core helpers", async () => {

--- a/tests/architecture/tracker-coupling.test.js
+++ b/tests/architecture/tracker-coupling.test.js
@@ -61,18 +61,17 @@ describe("architecture/tracker-coupling — orchestrator depends only on integra
         });
       }
     }
-    if (offenders.length > 0) {
-      const msg = offenders
-        .map((o) => `  ${o.file}: ${o.import}`)
-        .join("\n");
-      throw new Error(
-        "src/orchestrator/ must not import src/planning-game/ directly.\n" +
-        "Route through the integrations registry:\n" +
-        "  import { getIntegration } from \"./integrations.js\";\n" +
-        "  await getIntegration(\"tracker\")?.hookName?.(...);\n\n" +
-        "Offenders:\n" + msg,
-      );
-    }
+    const msg = offenders
+      .map((o) => `  ${o.file}: ${o.import}`)
+      .join("\n");
+    expect(
+      offenders,
+      "src/orchestrator/ must not import src/planning-game/ directly.\n" +
+      "Route through the integrations registry:\n" +
+      "  import { getIntegration } from \"./integrations.js\";\n" +
+      "  await getIntegration(\"tracker\")?.hookName?.(...);\n\n" +
+      "Offenders:\n" + msg,
+    ).toEqual([]);
   });
 
   it("integrations module exports the documented API", async () => {

--- a/tests/commands/command-plan.test.js
+++ b/tests/commands/command-plan.test.js
@@ -62,18 +62,18 @@ describe("commands/plan", () => {
   });
 
   it("asserts planner agent is available", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    await planGenerateCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
     consoleSpy.mockRestore();
 
     expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
   });
 
   it("builds planner prompt with task", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    await planGenerateCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
     consoleSpy.mockRestore();
 
     expect(buildPlannerPrompt).toHaveBeenCalledWith(expect.objectContaining({
@@ -82,9 +82,9 @@ describe("commands/plan", () => {
   });
 
   it("calls agent runTask with prompt and planner role", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    await planGenerateCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
     consoleSpy.mockRestore();
 
     const agent = createAgent.mock.results[0].value;
@@ -95,9 +95,9 @@ describe("commands/plan", () => {
   });
 
   it("passes planner runtime and silence timeouts when configured", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({
+    await planGenerateCommand({
       task: "Add auth",
       config: makeConfig({ session: { max_planner_minutes: 2, max_agent_silence_minutes: 1 } }),
       logger: noopLogger
@@ -112,9 +112,9 @@ describe("commands/plan", () => {
   });
 
   it("prints formatted plan on success", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
+    await planGenerateCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger });
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("modular design");
@@ -123,9 +123,9 @@ describe("commands/plan", () => {
   });
 
   it("outputs raw JSON in json mode", async () => {
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger, json: true });
+    await planGenerateCommand({ task: "Add auth", config: makeConfig(), logger: noopLogger, json: true });
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain('"approach"');
@@ -137,9 +137,9 @@ describe("commands/plan", () => {
       runTask: vi.fn().mockResolvedValue({ ok: false, error: "planner crashed", exitCode: 1 })
     });
 
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     await expect(
-      planCommand({ task: "Bad plan", config: makeConfig(), logger: noopLogger })
+      planGenerateCommand({ task: "Bad plan", config: makeConfig(), logger: noopLogger })
     ).rejects.toThrow("planner crashed");
   });
 
@@ -148,9 +148,9 @@ describe("commands/plan", () => {
       runTask: vi.fn().mockResolvedValue({ ok: true, output: "Plain text plan:\n1. Do this\n2. Do that", exitCode: 0 })
     });
 
-    const { planCommand } = await import("../../src/commands/plan.js");
+    const { planGenerateCommand } = await import("../../src/commands/plan.js");
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await planCommand({ task: "Add feature", config: makeConfig(), logger: noopLogger });
+    await planGenerateCommand({ task: "Add feature", config: makeConfig(), logger: noopLogger });
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("Do this");


### PR DESCRIPTION
## Summary

Cleanup post-release tras ejecutar \`kj audit --deterministic-only\` sobre v2.15.0.

### Sonar BLOCKER × 8 (\`S2699 "Add at least one assertion"\`)

Falsos positivos en \`tests/architecture/*\`: usaban \`throw new Error(msg)\` para fallar con mensaje rico. Sonar no detectaba la aserción semántica.

**Fix**: refactor a \`expect(offenders, msg).toEqual([])\` — mantiene el mensaje custom, satisface Sonar, más idiomático en Vitest.

Files: session-store-imports, dynamic-imports (×2), tracker-coupling, session-write-boundary, no-globalThis-kj, layer-boundaries, agent-readability (×2).

### Dead exports

- \`planCommand\` alias en \`plan/index.js\` y \`plan.js\` — back-compat sin callers reales
- \`breakCycles\` en \`plan-structural-pass.js\` — uso solo interno

Test \`command-plan.test.js\` renombrado: \`planCommand\` → \`planGenerateCommand\` (única usuaria).

### MINOR — codemod parcial

\`repair-detector.js\` 3 sites de \`replace\` → \`replaceAll\`. Codemod completo (~60 sites en 20 files) en PR aparte.

## Test plan

- [x] 4 835/4 835 tests passing
- [x] lint clean
- [x] Net delta: 97 add / 112 del = **-15 LOC** (cleanup real)