### PR TITLE
chore(codemod): replace(/regex/g) → replaceAll en 27 ficheros

### DIFF
--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -156,7 +156,7 @@ function summarizeToolCall(name, input = {}) {
     case "Glob": return `Glob ${input.pattern || ""}`.trim();
     case "Grep": return `Grep "${(input.pattern || "").slice(0, 60)}"${input.path ? ` in ${rel(input.path)}` : ""}`;
     case "Bash": {
-      const cmd = String(input.command || "").replace(/\s+/g, " ").slice(0, 100);
+      const cmd = String(input.command || "").replaceAll(/\s+/g, " ").slice(0, 100);
       return `Bash $ ${cmd}`;
     }
     case "TodoWrite": return `Todo ${(input.todos || []).length} items`;
@@ -259,7 +259,7 @@ export function createStreamJsonFilter(onOutput) {
         } else if (block.type === "tool_use") {
           onOutput({ stream, line: summarizeToolCall(block.name, block.input), kind: "tool" });
         } else if (block.type === "thinking" && block.thinking) {
-          onOutput({ stream, line: `thinking: ${block.thinking.slice(0, 80).replace(/\s+/g, " ")}…`, kind: "thinking" });
+          onOutput({ stream, line: `thinking: ${block.thinking.slice(0, 80).replaceAll(/\s+/g, " ")}…`, kind: "thinking" });
         }
       }
       return;

--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -11,7 +11,7 @@ import { resolveBin } from "./resolve-bin.js";
 function extractCodexTokens(stdout) {
   const match = (stdout || "").match(/tokens?\s+used\s*\n\s*([\d,]+)/i);
   if (!match) return null;
-  const total = Number(match[1].replace(/,/g, ""));
+  const total = Number(match[1].replaceAll(/,/g, ""));
   if (!Number.isFinite(total) || total <= 0) return null;
   return { tokens_in: 0, tokens_out: total };
 }

--- a/src/audit/agent-readiness.js
+++ b/src/audit/agent-readiness.js
@@ -178,7 +178,7 @@ function safeRead(p) {
  * line counts keeps later byte-offset checks stable.
  */
 function stripFencedCodeBlocks(text) {
-  return text.replace(/^([ \t]*)(```|~~~)[^\n]*\n([\s\S]*?)\n\1\2[^\n]*$/gm, (match) => {
+  return text.replaceAll(/^([ \t]*)(```|~~~)[^\n]*\n([\s\S]*?)\n\1\2[^\n]*$/gm, (match) => {
     const lineCount = match.split("\n").length;
     return "\n".repeat(lineCount - 1);
   });

--- a/src/audit/basal-cost.js
+++ b/src/audit/basal-cost.js
@@ -18,7 +18,7 @@ const EXCLUDE_DIRS = new Set([
 ]);
 
 function slugify(projectDir) {
-  return path.basename(projectDir).replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.basename(projectDir).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 async function walkSourceFiles(dir) {
@@ -144,9 +144,9 @@ function resolveImportSpecifier(fromFile, specifier) {
 // need the actual path inside the quotes to resolve the target module.
 function stripStringLiterals(content) {
   return content
-    .replace(/`[^`]*`/g, "``")
-    .replace(/"(?:\\.|[^"\\])*"/g, '""')
-    .replace(/'(?:\\.|[^'\\])*'/g, "''");
+    .replaceAll(/`[^`]*`/g, "``")
+    .replaceAll(/"(?:\\.|[^"\\])*"/g, '""')
+    .replaceAll(/'(?:\\.|[^'\\])*'/g, "''");
 }
 
 async function findDeadExports(sourceFiles) {

--- a/src/audit/webperf-input.js
+++ b/src/audit/webperf-input.js
@@ -39,7 +39,7 @@ function webperfHome() {
 }
 
 function projectSlug(projectDir) {
-  return path.basename(projectDir || process.cwd()).replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.basename(projectDir || process.cwd()).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 /**

--- a/src/brain/standby-store.js
+++ b/src/brain/standby-store.js
@@ -34,7 +34,7 @@ export function standbyDoneDir() {
 
 function sanitizeId(sessionId) {
   if (!sessionId || typeof sessionId !== "string") throw new Error("sessionId requerido");
-  return sessionId.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
+  return sessionId.replaceAll(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
 }
 
 /**

--- a/src/canvas/parse-md.js
+++ b/src/canvas/parse-md.js
@@ -218,7 +218,7 @@ function parseOperations(text) {
       if (testMatch && inAcceptance) {
         current.acceptance.push({
           type: testMatch[1].toLowerCase(),
-          content: testMatch[2].replace(/^`+|`+$/g, "").trim(),
+          content: testMatch[2].replaceAll(/^`+|`+$/g, "").trim(),
         });
       }
     }

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -157,7 +157,7 @@ async function resolveReportFilePath(flagValue, isJson) {
 
   let resolved;
   if (isDir) {
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const stamp = new Date().toISOString().replaceAll(/[:.]/g, "-");
     resolved = path.resolve(target, `audit-${stamp}.${ext}`);
   } else {
     resolved = path.resolve(target);

--- a/src/commands/webperf.js
+++ b/src/commands/webperf.js
@@ -26,7 +26,7 @@ function defaultReportDir() {
  * with audit history under ~/.karajan/.
  */
 function projectSlug(projectDir) {
-  return path.basename(projectDir || process.cwd()).replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.basename(projectDir || process.cwd()).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 function formatHumanReport(result) {

--- a/src/domains/domain-synthesizer.js
+++ b/src/domains/domain-synthesizer.js
@@ -80,7 +80,7 @@ function buildKeywords(task, hints) {
 
   const taskWords = task
     .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, " ")
+    .replaceAll(/[^a-z0-9\s-]/g, " ")
     .split(/\s+/)
     .filter(w => w.length > 3 && !stopWords.has(w));
 

--- a/src/git/hu-automation.js
+++ b/src/git/hu-automation.js
@@ -14,8 +14,8 @@ import { runCommand } from "../utils/process.js";
 export function buildHuBranchName(prefix, story) {
   const baseSlug = String(story.title || story.id || "hu")
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
     .slice(0, 40);
   return `${prefix}${story.id}-${baseSlug}`;
 }

--- a/src/git/hu-snapshot.js
+++ b/src/git/hu-snapshot.js
@@ -24,7 +24,7 @@ const REF_PREFIX = "refs/kj-snapshots/";
  */
 export function snapshotRefForHu(huId) {
   if (!huId) throw new Error("huId requerido");
-  const safe = String(huId).replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
+  const safe = String(huId).replaceAll(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80);
   return REF_PREFIX + safe;
 }
 

--- a/src/hu/auto-generator.js
+++ b/src/hu/auto-generator.js
@@ -24,7 +24,7 @@ export function deriveProjectName(originalTask) {
   ]);
   const words = originalTask
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
+    .replaceAll(/[^\p{L}\p{N}\s-]/gu, " ")
     .split(/\s+/)
     .filter(w => w && !STOPWORDS.has(w));
   const meaningful = words.slice(0, 6);

--- a/src/plan/adr-generator.js
+++ b/src/plan/adr-generator.js
@@ -38,11 +38,11 @@ function slugifyTitle(title) {
     // Decompose accents (NFD) then strip combining marks so "versión"
     // → "version", keeping the ADR id ASCII-only and filesystem-safe.
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
+    .replaceAll(/[̀-ͯ]/g, "")
+    .replaceAll(/[^a-z0-9\s-]/g, "")
+    .replaceAll(/\s+/g, "-")
+    .replaceAll(/-+/g, "-")
+    .replaceAll(/^-|-$/g, "")
     .slice(0, 80) || "untitled";
 }
 

--- a/src/plan/plan-id.js
+++ b/src/plan/plan-id.js
@@ -8,7 +8,7 @@
  */
 export function generatePlanId() {
   const now = new Date();
-  const ts = now.toISOString().replace(/[-:T]/g, "").replace(/\.\d+Z$/, "");
+  const ts = now.toISOString().replaceAll(/[-:T]/g, "").replace(/\.\d+Z$/, "");
   const rand = Math.random().toString(36).slice(2, 6);
   return `plan-${ts}-${rand}`;
 }
@@ -36,10 +36,10 @@ export function normaliseAlias(name) {
   if (!name || typeof name !== "string") return null;
   const slug = name
     .normalize("NFKD")
-    .replace(/[̀-ͯ]/g, "")        // strip diacritics
+    .replaceAll(/[̀-ͯ]/g, "")        // strip diacritics
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")            // non-alphanum → guion
-    .replace(/^-+|-+$/g, "")                // trim guiones extremos
+    .replaceAll(/[^a-z0-9]+/g, "-")            // non-alphanum → guion
+    .replaceAll(/^-+|-+$/g, "")                // trim guiones extremos
     .slice(0, 60);
   return slug || null;
 }

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -50,7 +50,7 @@ export function projectSlug(projectDir) {
   return projectDir
     .replace(/^\//, "")
     .replace(/[/\\]/g, "_")
-    .replace(/[^a-zA-Z0-9_.-]/g, "")
+    .replaceAll(/[^a-zA-Z0-9_.-]/g, "")
     .slice(0, 120);
 }
 

--- a/src/roles/perf-role.js
+++ b/src/roles/perf-role.js
@@ -25,7 +25,7 @@ import { BaseRole } from "./base-role.js";
 import { runWebperfScan } from "../webperf/scanner.js";
 
 function projectSlug(projectDir) {
-  return path.basename(projectDir || process.cwd()).replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.basename(projectDir || process.cwd()).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 }
 
 function defaultPersistDir() {

--- a/src/session/journal/decisions-writer.js
+++ b/src/session/journal/decisions-writer.js
@@ -41,7 +41,7 @@ import { getSessionRoot } from "../../utils/paths.js";
  */
 
 function esc(text) {
-  return String(text ?? "").replace(/\|/g, "\\|");
+  return String(text ?? "").replaceAll(/\|/g, "\\|");
 }
 
 function formatConditions(conditions) {

--- a/src/session/journal/iteration-logger.js
+++ b/src/session/journal/iteration-logger.js
@@ -28,7 +28,7 @@
  */
 
 function esc(text) {
-  return String(text ?? "").replace(/\|/g, "\\|");
+  return String(text ?? "").replaceAll(/\|/g, "\\|");
 }
 
 function formatDuration(ms) {

--- a/src/session/journal/summary-writer.js
+++ b/src/session/journal/summary-writer.js
@@ -33,7 +33,7 @@ import path from "node:path";
  */
 
 function esc(text) {
-  return String(text ?? "").replace(/\|/g, "\\|");
+  return String(text ?? "").replaceAll(/\|/g, "\\|");
 }
 
 function formatDuration(ms) {

--- a/src/skills/addyosmani-catalog.js
+++ b/src/skills/addyosmani-catalog.js
@@ -279,7 +279,7 @@ export async function listAvailableSlugs() {
  */
 export async function loadSkillBySlug(slug) {
   if (!slug || typeof slug !== "string") return null;
-  const safeSlug = slug.trim().replace(/[^A-Za-z0-9._-]/g, "");
+  const safeSlug = slug.trim().replaceAll(/[^A-Za-z0-9._-]/g, "");
   if (!safeSlug) return null;
 
   const skillPath = path.join(getSkillsRoot(), safeSlug, SKILL_FILE);

--- a/src/skills/skills-cache.js
+++ b/src/skills/skills-cache.js
@@ -24,7 +24,7 @@ export function getCacheRoot() {
 
 function sanitize(name) {
   // Allow safe skill name characters, replace everything else with "_".
-  return String(name || "").replace(/[^A-Za-z0-9._-]/g, "_");
+  return String(name || "").replaceAll(/[^A-Za-z0-9._-]/g, "_");
 }
 
 function metaPath(name) {

--- a/src/sonar/config-resolver.js
+++ b/src/sonar/config-resolver.js
@@ -16,7 +16,7 @@ const DEFAULT_HOST = "http://localhost:9000";
  */
 export function resolveSonarHost(rawHost) {
   const host = String(rawHost || DEFAULT_HOST)
-    .replace(/host\.docker\.internal/g, "localhost")
+    .replaceAll(/host\.docker\.internal/g, "localhost")
     .replace(/\/+$/, "");
   return host;
 }

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -164,7 +164,7 @@ async function ensureSonarProjectProperties(cwd = process.cwd()) {
     } catch {
       // no package.json or invalid JSON — use defaults
     }
-    const projectKey = (pkg.name || path.basename(cwd)).replace(/[^a-zA-Z0-9_.-]/g, "_");
+    const projectKey = (pkg.name || path.basename(cwd)).replaceAll(/[^a-zA-Z0-9_.-]/g, "_");
     const props = [
       `sonar.projectKey=${projectKey}`,
       `sonar.projectName=${pkg.name || path.basename(cwd)}`,

--- a/src/utils/derive-project-name-from-cwd.js
+++ b/src/utils/derive-project-name-from-cwd.js
@@ -40,9 +40,9 @@ function prettifyName(raw) {
   if (!trimmed) return null;
   // Insert space at camelCase boundaries, then split on -/_/whitespace.
   const spaced = trimmed
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[-_]+/g, " ")
-    .replace(/\s+/g, " ")
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll(/[-_]+/g, " ")
+    .replaceAll(/\s+/g, " ")
     .trim();
   if (!spaced) return null;
   return spaced

--- a/src/utils/injection-guard.js
+++ b/src/utils/injection-guard.js
@@ -178,7 +178,7 @@ export function scanDiff(diff, opts = {}) {
 function excerpt(text, index) {
   const start = Math.max(0, index - 20);
   const end = Math.min(text.length, index + 100);
-  return text.slice(start, end).replace(/\n/g, "\\n").slice(0, 120);
+  return text.slice(start, end).replaceAll(/\n/g, "\\n").slice(0, 120);
 }
 
 function lineAt(text, index) {

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -48,7 +48,7 @@ const MESSAGES = {
  */
 export function msg(key, lang = "en", params = {}) {
   const template = MESSAGES[lang]?.[key] || MESSAGES.en[key] || key;
-  return template.replace(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
+  return template.replaceAll(/\{(\w+)\}/g, (_, k) => params[k] ?? `{${k}}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

Sonar MINOR S7781 cleanup masivo. Codemod determinístico via script Node.

- **41 invocaciones** convertidas en **27 ficheros**
- Sólo donde el regex tiene flag /g (replaceAll exige global)
- 0 LOC net delta (41+ / 41-)

## Test plan

- [x] 4 835/4 835 tests passing (semánticamente equivalente)
- [x] lint clean