### PR TITLE
feat(sonar): pre-filtro determinístico de falsos positivos (KJC-TSK-0416)

### DIFF
--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -2,6 +2,7 @@ import { runCommand } from "../utils/process.js";
 import { withRetry } from "../utils/retry.js";
 import { resolveSonarProjectKey } from "./project-key.js";
 import { resolveSonarToken } from "./config-resolver.js";
+import { filterFalsePositives } from "./issue-filter.js";
 
 class SonarApiError extends Error {
   constructor(message, { url, httpStatus, hint } = {}) {
@@ -83,10 +84,27 @@ export async function getOpenIssues(config, projectKey = null) {
   const effectiveProjectKey = await resolveSonarProjectKey(config, { projectKey });
   const body = await sonarFetch(config, `/api/issues/search?projectKeys=${effectiveProjectKey}&statuses=OPEN`);
 
+  let parsedIssues = [];
+  let parsedRaw = body;
   try {
     const parsed = JSON.parse(body);
-    return { total: parsed.total || 0, issues: parsed.issues || [], raw: parsed };
-  } catch { /* SonarQube response is not valid JSON */
-    return { total: 0, issues: [], raw: body };
-  }
+    parsedIssues = parsed.issues || [];
+    parsedRaw = parsed;
+  } catch { /* SonarQube response is not valid JSON */ }
+
+  // KJC-TSK-0416: pre-filtro de falsos positivos antes de devolver al
+  // caller. El coder, audit y scan consumen lo que pasa el filtro;
+  // suppressed se devuelve aparte para observabilidad.
+  const extraRules = config?.sonar?.false_positives || [];
+  const { kept, suppressed } = filterFalsePositives(parsedIssues, {
+    extraRules,
+    projectRoot: config?.projectDir,
+  });
+
+  return {
+    total: kept.length,
+    issues: kept,
+    suppressed,
+    raw: parsedRaw,
+  };
 }

--- a/src/sonar/issue-filter.js
+++ b/src/sonar/issue-filter.js
@@ -1,0 +1,110 @@
+// KJC-TSK-0416: pre-filtro determinístico de falsos positivos Sonar.
+//
+// Antes de que los issues Sonar lleguen al coder como feedback (sonar-role)
+// o al auditor (audit), filtramos los que sabemos que son falsos positivos
+// por reglas conocidas. Sin esto el coder quemaba tokens intentando
+// "arreglar" cosas que no están rotas.
+//
+// Dos mecanismos complementarios:
+//   1. Rules estáticas: { rule, filePattern, reason } — match por reglaId
+//      + patrón de path. Cargadas por defecto del catálogo de FALSE_POSITIVES
+//      abajo + extensibles via config.sonar.false_positives.
+//   2. Inline ignore: `// karajan-sonar-ignore: <ruleId>` en la línea del
+//      issue (o la anterior) → suprime ese hit exacto.
+
+import fs from "node:fs";
+
+// Catálogo built-in de patrones conocidos. Cada entrada:
+//   { rule: "javascript:S2699", filePattern: RegExp, reason: "..." }
+// Ampliable via config.sonar.false_positives.
+export const DEFAULT_FALSE_POSITIVES = [
+  {
+    rule: "javascript:S2699",
+    filePattern: /tests\/architecture\//,
+    reason: "Tests structurales fallan vía expect(offenders, msg).toEqual([]) — Sonar no detecta el assert con mensaje custom",
+  },
+];
+
+/**
+ * Comprueba si una línea del file contiene `// karajan-sonar-ignore: <ruleId>`.
+ * Acepta la línea exacta del issue o la inmediatamente anterior.
+ *
+ * @param {string} filePath
+ * @param {number} line - 1-indexed
+ * @param {string} ruleId
+ * @returns {boolean}
+ */
+export function hasInlineIgnore(filePath, line, ruleId) {
+  if (!filePath || !line || !ruleId) return false;
+  if (!fs.existsSync(filePath)) return false;
+  try {
+    const lines = fs.readFileSync(filePath, "utf8").split("\n");
+    const idx = line - 1;
+    const candidates = [lines[idx], lines[idx - 1]].filter(Boolean);
+    const re = new RegExp(`karajan-sonar-ignore\\s*:\\s*${escapeRegex(ruleId)}\\b`);
+    return candidates.some((l) => re.test(l));
+  } catch {
+    return false;
+  }
+}
+
+function escapeRegex(s) {
+  return String(s).replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Filtra issues de Sonar separando los reales de los falsos positivos.
+ *
+ * @param {object[]} issues - array de Sonar issues (shape: { rule, component, line, message, severity, ... })
+ * @param {object} [opts]
+ * @param {object[]} [opts.extraRules] - rules adicionales del config
+ * @param {string} [opts.projectRoot] - para resolver component → ruta absoluta
+ * @returns {{ kept: object[], suppressed: object[] }}
+ */
+export function filterFalsePositives(issues, opts = {}) {
+  if (!Array.isArray(issues)) return { kept: [], suppressed: [] };
+  const rules = [...DEFAULT_FALSE_POSITIVES, ...(opts.extraRules || [])].map((r) => ({
+    ...r,
+    filePattern: r.filePattern instanceof RegExp ? r.filePattern : new RegExp(String(r.filePattern || ".*")),
+  }));
+  const projectRoot = opts.projectRoot || process.cwd();
+  const kept = [];
+  const suppressed = [];
+
+  for (const issue of issues) {
+    const path = componentToPath(issue.component);
+    let matched = null;
+
+    // 1. Rules estáticas.
+    for (const rule of rules) {
+      if (issue.rule === rule.rule && rule.filePattern.test(path)) {
+        matched = { rule: rule.rule, path, reason: rule.reason };
+        break;
+      }
+    }
+
+    // 2. Inline ignore (más caro — solo si la regla estática no matchea).
+    if (!matched && issue.rule && issue.line && path) {
+      const absPath = path.startsWith("/") ? path : `${projectRoot}/${path}`;
+      if (hasInlineIgnore(absPath, issue.line, issue.rule)) {
+        matched = { rule: issue.rule, path, reason: "inline `// karajan-sonar-ignore`" };
+      }
+    }
+
+    if (matched) {
+      suppressed.push({ ...issue, _suppressedBy: matched });
+    } else {
+      kept.push(issue);
+    }
+  }
+  return { kept, suppressed };
+}
+
+/**
+ * Sonar reporta component como `<projectKey>:<relativePath>`. Extrae el path.
+ */
+function componentToPath(component) {
+  if (typeof component !== "string") return "";
+  const colonIdx = component.indexOf(":");
+  return colonIdx >= 0 ? component.slice(colonIdx + 1) : component;
+}

--- a/tests/sonar/issue-filter.test.js
+++ b/tests/sonar/issue-filter.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  filterFalsePositives,
+  hasInlineIgnore,
+  DEFAULT_FALSE_POSITIVES,
+} from "../../src/sonar/issue-filter.js";
+
+// KJC-TSK-0416: pre-filtro de falsos positivos Sonar.
+
+describe("DEFAULT_FALSE_POSITIVES", () => {
+  it("contiene la regla S2699 para tests/architecture/", () => {
+    expect(DEFAULT_FALSE_POSITIVES.some(
+      (r) => r.rule === "javascript:S2699" && r.filePattern.test("tests/architecture/foo.test.js")
+    )).toBe(true);
+  });
+});
+
+describe("filterFalsePositives — rules estáticas", () => {
+  const mkIssue = (rule, component) => ({ rule, component, line: 10, severity: "BLOCKER" });
+
+  it("suprime issue que matchea rule + filePattern del default", () => {
+    const issues = [
+      mkIssue("javascript:S2699", "proj-x:tests/architecture/foo.test.js"),
+      mkIssue("javascript:S1234", "proj-x:tests/architecture/foo.test.js"), // mismo file, distinta regla
+      mkIssue("javascript:S2699", "proj-x:src/something.js"),                 // misma regla, otro file
+    ];
+    const { kept, suppressed } = filterFalsePositives(issues);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].rule).toBe("javascript:S2699");
+    expect(suppressed[0]._suppressedBy.reason).toMatch(/structural/i);
+    expect(kept).toHaveLength(2);
+  });
+
+  it("acepta extraRules del config con filePattern como string", () => {
+    const issues = [{ rule: "X", component: "p:src/legacy/foo.js", line: 1 }];
+    const { kept, suppressed } = filterFalsePositives(issues, {
+      extraRules: [{ rule: "X", filePattern: "src/legacy/", reason: "deprecated dir" }],
+    });
+    expect(kept).toHaveLength(0);
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0]._suppressedBy.reason).toBe("deprecated dir");
+  });
+
+  it("rule sin match deja el issue en kept", () => {
+    const issues = [{ rule: "X", component: "p:src/y.js", line: 1 }];
+    const { kept, suppressed } = filterFalsePositives(issues);
+    expect(kept).toHaveLength(1);
+    expect(suppressed).toHaveLength(0);
+  });
+
+  it("array vacío / no-array → no rompe", () => {
+    expect(filterFalsePositives([])).toEqual({ kept: [], suppressed: [] });
+    expect(filterFalsePositives(null)).toEqual({ kept: [], suppressed: [] });
+  });
+});
+
+describe("hasInlineIgnore", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(path.join(tmpdir(), "issue-filter-")); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it("detecta `// karajan-sonar-ignore: <ruleId>` en la línea exacta", () => {
+    const file = path.join(tmpDir, "x.js");
+    writeFileSync(file, "const a = 1; // karajan-sonar-ignore: javascript:S1234\nconst b = 2;\n");
+    expect(hasInlineIgnore(file, 1, "javascript:S1234")).toBe(true);
+  });
+
+  it("detecta el comment en la línea anterior", () => {
+    const file = path.join(tmpDir, "y.js");
+    writeFileSync(file, "// karajan-sonar-ignore: javascript:S1234\nconst a = 1;\n");
+    expect(hasInlineIgnore(file, 2, "javascript:S1234")).toBe(true);
+  });
+
+  it("no matchea otra ruleId", () => {
+    const file = path.join(tmpDir, "z.js");
+    writeFileSync(file, "// karajan-sonar-ignore: javascript:S9999\nconst a = 1;\n");
+    expect(hasInlineIgnore(file, 2, "javascript:S1234")).toBe(false);
+  });
+
+  it("file no existe → false", () => {
+    expect(hasInlineIgnore(path.join(tmpDir, "ghost.js"), 1, "X")).toBe(false);
+  });
+
+  it("args inválidos → false sin throw", () => {
+    expect(hasInlineIgnore(null, 1, "X")).toBe(false);
+    expect(hasInlineIgnore("/x", null, "X")).toBe(false);
+    expect(hasInlineIgnore("/x", 1, null)).toBe(false);
+  });
+});
+
+describe("filterFalsePositives — inline ignore integration", () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(path.join(tmpdir(), "issue-filter-int-")); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it("respeta inline ignore como segundo mecanismo (cuando rule estática no aplica)", () => {
+    mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    const relativePath = "src/foo.js";
+    const absPath = path.join(tmpDir, relativePath);
+    writeFileSync(absPath, "const a = 1; // karajan-sonar-ignore: javascript:S1234\n");
+    const issues = [{ rule: "javascript:S1234", component: `proj:${relativePath}`, line: 1 }];
+    const { kept, suppressed } = filterFalsePositives(issues, { projectRoot: tmpDir });
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0]._suppressedBy.reason).toMatch(/inline/i);
+    expect(kept).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Resuelve el gap real detectado al responder tu pregunta sobre falsos positivos Sonar: hasta v2.15.0 los issues pasaban al coder/audit/scan en crudo, el coder quemaba iteraciones intentando arreglar falsos positivos, y Solomon clasificaba post-hoc vía LLM (no determinístico).

### Dos mecanismos

**1. Rules estáticas** (catálogo built-in + extensible)
```js
DEFAULT_FALSE_POSITIVES = [
  { rule: 'javascript:S2699', filePattern: /tests\/architecture\//, reason: '...' },
  // extensible via config.sonar.false_positives
];
```

**2. Inline ignore** (rápido sin tocar config)
```js
const x = doThing(); // karajan-sonar-ignore: javascript:S1234
```

### Hook único en `getOpenIssues`

Cubre los 3 consumers a la vez: audit/sonar-findings, roles/sonar-role (coder feedback), commands/scan.

### Default rule incluida

`javascript:S2699` en `tests/architecture/*` (los 8 BLOCKERs del audit de v2.15.0 ya tratados en #738 — ahora también filtrados pre-coder).

## Test plan

- [x] 11 tests nuevos (rules estáticas, regex/string filePattern, inline ignore variants, integración)
- [x] 4 846/4 846 tests totales
- [x] lint clean

## LOC

242 LOC (módulo 110 + tests 110 + integración 22). Cohesivo: módulo + tests + hook. `large-pr-justified`.