### PR TITLE
feat(doctor): platform-aware install hints for external audit tools

### DIFF
--- a/src/checks/binaries.js
+++ b/src/checks/binaries.js
@@ -15,6 +15,7 @@
 import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
 import { runCommand } from "../utils/process.js";
 import { withDocLink } from "../utils/doc-links.js";
+import { getInstallHint, appliesToStack } from "../utils/install-hints.js";
 import { STRATEGY } from "./types.js";
 
 /**
@@ -106,6 +107,56 @@ function createSerenaCheck() {
 }
 
 /**
+ * Audit-side external tool (semgrep, osv-scanner, lighthouse) check.
+ *
+ * These are not blockers: `kj audit` and `kj webperf` degrade to
+ * available:false when missing. We surface them in `kj doctor` so the
+ * user can see at a glance which audit dimensions are active, and we
+ * point to `kj install-tools` for one-line remediation.
+ *
+ * `lighthouse` is stack-gated: only flagged when the project is
+ * frontend / fullstack. On backend-only projects the check is a no-op
+ * (returns ok:true with detail "n/a") to keep doctor output focused.
+ */
+function createAuditToolCheck(tool, { gatedByStack = false, label }) {
+  return {
+    name: `audit-tool:${tool}`,
+    label,
+    strategy: STRATEGY.MANUAL,
+    async detect({ config } = {}) {
+      if (gatedByStack) {
+        // Stack detection is best-effort — failing here just means we
+        // treat the project as backend-only (skip the check). Keeps the
+        // doctor pipeline resilient to weird repos.
+        let stack = null;
+        try {
+          const { detectProjectStack } = await import("../utils/stack-detect.js");
+          stack = await detectProjectStack(config?.projectDir || process.cwd());
+        } catch { /* ignore */ }
+        if (!appliesToStack(tool, stack)) {
+          return { ok: true, severity: "info", detail: "n/a (no frontend stack detected)" };
+        }
+      }
+      const result = await checkBinary(tool);
+      if (result.ok) {
+        return { ok: true, severity: "info", detail: result.version || "available" };
+      }
+      const hint = await getInstallHint(tool);
+      const fixLine = hint.command
+        ? `Run \`kj install-tools --only ${tool}\` or: ${hint.command}`
+        : `Run \`kj install-tools --only ${tool}\` or see ${hint.manualUrl}`;
+      return {
+        ok: false,
+        severity: "warn",
+        detail: "Not found — `kj audit` dimension will degrade",
+        fix: fixLine,
+        extra: { tool, suggested: hint.command, manager: hint.manager, manualUrl: hint.manualUrl },
+      };
+    },
+  };
+}
+
+/**
  * Aggregate: all binary-related checks for the current config.
  * @returns {import("./types.js").Check[]}
  */
@@ -119,5 +170,10 @@ export function getBinaryChecks() {
   }
   checks.push(createDockerCheck());
   checks.push(createSerenaCheck());
+  // KJC-TSK v2.18 — surface audit-side tools in doctor so the user knows
+  // which dimensions will work. lighthouse is gated to frontend stacks.
+  checks.push(createAuditToolCheck("semgrep", { label: "Semgrep (audit/security)" }));
+  checks.push(createAuditToolCheck("osv-scanner", { label: "OSV-Scanner (audit/security)" }));
+  checks.push(createAuditToolCheck("lighthouse", { label: "Lighthouse (webperf)", gatedByStack: true }));
   return checks;
 }

--- a/src/utils/install-hints.js
+++ b/src/utils/install-hints.js
@@ -1,0 +1,136 @@
+// Platform-aware install hints for external tools that `kj audit` /
+// `kj webperf` use (semgrep, osv-scanner, lighthouse).
+//
+// `kj doctor` calls these to render hint strings ("Install with:
+// pipx install semgrep") that match what's actually available on the
+// user's machine, rather than a generic "see docs" message. The same
+// metadata drives `kj install-tools` (HU2) — it decides which package
+// manager to invoke per tool.
+//
+// We probe each package manager once with `which`/`where`-style checks
+// and cache the result for the lifetime of the process.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * @typedef {"pipx"|"brew"|"go"|"npm"|"pip"|"apt"|"dnf"|"choco"|"scoop"|"docker"} PackageManager
+ */
+
+/** @type {Record<PackageManager, boolean>|null} */
+let cachedAvailability = null;
+
+const PROBES = [
+  ["pipx", ["--version"]],
+  ["brew", ["--version"]],
+  ["go", ["version"]],
+  ["npm", ["--version"]],
+  ["pip", ["--version"]],
+  ["apt", ["--version"]],
+  ["dnf", ["--version"]],
+  ["choco", ["--version"]],
+  ["scoop", ["--version"]],
+  ["docker", ["--version"]],
+];
+
+async function probeOne(bin, args) {
+  try {
+    await execFileAsync(bin, args, { timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect which package managers are reachable on PATH. Cached on first
+ * call. Exported for tests; production callers go through getInstallHint.
+ */
+export async function detectPackageManagers() {
+  if (cachedAvailability) return cachedAvailability;
+  const entries = await Promise.all(
+    PROBES.map(async ([bin, args]) => [bin, await probeOne(bin, args)]),
+  );
+  cachedAvailability = Object.fromEntries(entries);
+  return cachedAvailability;
+}
+
+/** Test helper — reset the cache between unit cases. */
+export function resetPackageManagerCache() {
+  cachedAvailability = null;
+}
+
+/**
+ * Returns the install command for a tool, preferring the highest-priority
+ * package manager available on the current system.
+ *
+ * The order encodes our recommendation when multiple managers can install
+ * the same tool. We prefer isolated installs (pipx, brew) over global
+ * `pip install` so we don't pollute the user's site-packages.
+ *
+ * @param {"semgrep"|"osv-scanner"|"lighthouse"|"docker"} tool
+ * @param {Record<PackageManager, boolean>} [available] — pre-computed availability; if omitted, detects.
+ * @returns {Promise<{ command: string|null, manager: PackageManager|null, manualUrl: string }>}
+ */
+export async function getInstallHint(tool, available = null) {
+  const avail = available || (await detectPackageManagers());
+  const candidates = INSTALL_CANDIDATES[tool] || [];
+  for (const { manager, command } of candidates) {
+    if (avail[manager]) return { command, manager, manualUrl: MANUAL_URLS[tool] };
+  }
+  // Nothing matched — fall back to the first candidate's command as a
+  // suggestion, so the user at least sees a working recipe.
+  const first = candidates[0];
+  return {
+    command: first ? first.command : null,
+    manager: null,
+    manualUrl: MANUAL_URLS[tool],
+  };
+}
+
+const INSTALL_CANDIDATES = {
+  semgrep: [
+    { manager: "pipx", command: "pipx install semgrep" },
+    { manager: "brew", command: "brew install semgrep" },
+    { manager: "pip", command: "pip install semgrep" },
+  ],
+  "osv-scanner": [
+    { manager: "go", command: "go install github.com/google/osv-scanner@latest" },
+    { manager: "brew", command: "brew install osv-scanner" },
+  ],
+  lighthouse: [
+    { manager: "npm", command: "npm install -g lighthouse" },
+  ],
+  docker: [
+    // Docker Desktop / Engine cannot be installed by a package manager
+    // reliably across platforms — always point users to the official docs.
+    // Listing brew anyway as a hint for macOS users.
+    { manager: "brew", command: "brew install --cask docker" },
+  ],
+};
+
+const MANUAL_URLS = {
+  semgrep: "https://semgrep.dev/docs/getting-started",
+  "osv-scanner": "https://google.github.io/osv-scanner/installation/",
+  lighthouse: "https://github.com/GoogleChrome/lighthouse#using-the-cli",
+  docker: "https://docs.docker.com/get-docker/",
+};
+
+/**
+ * Tools whose hint depends on the project stack. lighthouse is only
+ * relevant for frontend projects; suppressing the hint elsewhere keeps
+ * `kj doctor` output free of irrelevant noise.
+ *
+ * @param {string} tool
+ * @param {Object} stack — shape returned by detectProjectStack()
+ */
+export function appliesToStack(tool, stack) {
+  if (tool === "lighthouse") {
+    if (!stack) return false;
+    return Boolean(stack.isFrontend || stack.isFullstack);
+  }
+  // semgrep, osv-scanner, docker, sonar — always relevant.
+  return true;
+}

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -68,7 +68,14 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // `kj audit` working in npm installs and degrades gracefully in the SEA
 // binary (madge is marked external; the import throws there and the
 // collector returns available:false).
-const DYNAMIC_IMPORT_BUDGET = 161;
+//
+// 2026-05-18 (KJC-TSK v2.18 doctor-external-tool-hints): bumped 161 →
+// 162 for the lazy `await import("../utils/stack-detect.js")` inside the
+// gated lighthouse check (`src/checks/binaries.js`). Stack detection is
+// only needed when the lighthouse check actually runs (i.e. when the
+// user has the binary or wants the install hint) — deferring it keeps
+// non-frontend doctor runs from paying the cost.
+const DYNAMIC_IMPORT_BUDGET = 162;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/checks/audit-tools.test.js
+++ b/tests/checks/audit-tools.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getBinaryChecks } from "../../src/checks/binaries.js";
+
+// KJC-TSK v2.18 — doctor checks for audit-side tools (semgrep, osv-scanner,
+// lighthouse). These are warn-severity: missing tools degrade audit
+// dimensions but don't block.
+
+vi.mock("../../src/utils/agent-detect.js", async (orig) => {
+  const real = await orig();
+  return {
+    ...real,
+    // Default: report tool as missing so we exercise the warn path. Each
+    // test overrides per scenario.
+    checkBinary: vi.fn(async (name) => ({ ok: false, version: null, path: null, install: name })),
+  };
+});
+
+vi.mock("../../src/utils/install-hints.js", () => ({
+  getInstallHint: vi.fn(async (tool) => ({
+    command: `mock-install ${tool}`,
+    manager: "mock-pm",
+    manualUrl: `https://mock.example/${tool}`,
+  })),
+  appliesToStack: vi.fn((tool, stack) => {
+    if (tool === "lighthouse") return Boolean(stack?.isFrontend || stack?.isFullstack);
+    return true;
+  }),
+}));
+
+vi.mock("../../src/utils/stack-detect.js", () => ({
+  detectProjectStack: vi.fn(async () => ({ isBackend: true, isFrontend: false, isFullstack: false })),
+}));
+
+function findCheck(name) {
+  return getBinaryChecks().find((c) => c.name === name);
+}
+
+describe("audit-tool checks — registered in getBinaryChecks", () => {
+  it("includes semgrep, osv-scanner, lighthouse", () => {
+    const names = getBinaryChecks().map((c) => c.name);
+    expect(names).toContain("audit-tool:semgrep");
+    expect(names).toContain("audit-tool:osv-scanner");
+    expect(names).toContain("audit-tool:lighthouse");
+  });
+});
+
+describe("audit-tool semgrep check", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("reports warn + install hint when missing", async () => {
+    const check = findCheck("audit-tool:semgrep");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    expect(res.ok).toBe(false);
+    expect(res.severity).toBe("warn");
+    expect(res.fix).toMatch(/kj install-tools.*semgrep/);
+    expect(res.fix).toMatch(/mock-install semgrep/);
+    expect(res.extra.tool).toBe("semgrep");
+    expect(res.extra.suggested).toBe("mock-install semgrep");
+  });
+
+  it("reports ok when binary present", async () => {
+    const { checkBinary } = await import("../../src/utils/agent-detect.js");
+    checkBinary.mockResolvedValueOnce({ ok: true, version: "1.0.0", path: "/usr/bin/semgrep" });
+    const check = findCheck("audit-tool:semgrep");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    expect(res.ok).toBe(true);
+    expect(res.detail).toBe("1.0.0");
+  });
+});
+
+describe("audit-tool lighthouse check — stack gated", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("is a no-op on backend-only stacks", async () => {
+    const { detectProjectStack } = await import("../../src/utils/stack-detect.js");
+    detectProjectStack.mockResolvedValueOnce({ isBackend: true, isFrontend: false, isFullstack: false });
+
+    const check = findCheck("audit-tool:lighthouse");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    expect(res.ok).toBe(true);
+    expect(res.detail).toMatch(/n\/a/);
+  });
+
+  it("runs the binary check on frontend stacks", async () => {
+    const { detectProjectStack } = await import("../../src/utils/stack-detect.js");
+    detectProjectStack.mockResolvedValueOnce({ isFrontend: true, isFullstack: false, isBackend: false });
+
+    const check = findCheck("audit-tool:lighthouse");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    expect(res.ok).toBe(false);
+    expect(res.severity).toBe("warn");
+    expect(res.fix).toMatch(/lighthouse/);
+  });
+
+  it("falls back to backend-treatment if stack detection throws", async () => {
+    const { detectProjectStack } = await import("../../src/utils/stack-detect.js");
+    detectProjectStack.mockRejectedValueOnce(new Error("boom"));
+
+    const check = findCheck("audit-tool:lighthouse");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    // No frontend stack detected → no-op (ok:true)
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("audit-tool osv-scanner check", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("uses the suggested command in the fix line", async () => {
+    const check = findCheck("audit-tool:osv-scanner");
+    const res = await check.detect({ config: { projectDir: "/tmp" } });
+    expect(res.fix).toMatch(/mock-install osv-scanner/);
+    expect(res.extra.tool).toBe("osv-scanner");
+  });
+});

--- a/tests/doctor.test.js
+++ b/tests/doctor.test.js
@@ -45,9 +45,13 @@ vi.mock("node:fs/promises", () => ({
 
 // Stub spawn so mcp-health check doesn't actually fork `node bin/karajan-mcp.js`
 // during unit runs. A minimal fake emits a JSON-RPC result so the check passes.
-vi.mock("node:child_process", () => {
+vi.mock("node:child_process", async (orig) => {
+  const real = await orig();
   const { EventEmitter } = require("node:events");
   return {
+    // Keep real execFile / exec etc. so modules that probe binaries via
+    // child_process (install-hints.js, agent-detect.js) still work.
+    ...real,
     spawn: vi.fn(() => {
       const child = new EventEmitter();
       child.stdin = { write: vi.fn() };

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -49,9 +49,13 @@ vi.mock("../src/checks/project-checks.js", () => ({
   detectProjectSignals: vi.fn(() => new Set()),
 }));
 
-vi.mock("node:child_process", () => {
+vi.mock("node:child_process", async (orig) => {
+  const real = await orig();
   const { EventEmitter } = require("node:events");
   return {
+    // Preserve real execFile / exec so modules that probe binaries via
+    // child_process (install-hints.js, agent-detect.js) keep working.
+    ...real,
     spawn: vi.fn(() => {
       const child = new EventEmitter();
       child.stdin = { write: vi.fn() };

--- a/tests/utils/install-hints.test.js
+++ b/tests/utils/install-hints.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getInstallHint, appliesToStack, resetPackageManagerCache } from "../../src/utils/install-hints.js";
+
+// KJC-TSK v2.18 — platform-aware install hints for external audit tools.
+
+describe("getInstallHint — manager prioritization", () => {
+  beforeEach(() => { resetPackageManagerCache(); });
+
+  it("prefers pipx > brew > pip for semgrep", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: true, brew: true, pip: true });
+    expect(hint.command).toBe("pipx install semgrep");
+    expect(hint.manager).toBe("pipx");
+  });
+
+  it("falls back to brew when pipx absent", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: false, brew: true, pip: true });
+    expect(hint.command).toBe("brew install semgrep");
+    expect(hint.manager).toBe("brew");
+  });
+
+  it("falls back to pip when only pip available", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: false, brew: false, pip: true });
+    expect(hint.command).toBe("pip install semgrep");
+  });
+
+  it("prefers go install for osv-scanner", async () => {
+    const hint = await getInstallHint("osv-scanner", { go: true, brew: true });
+    expect(hint.command).toMatch(/go install.*osv-scanner/);
+    expect(hint.manager).toBe("go");
+  });
+
+  it("uses brew for osv-scanner when go missing", async () => {
+    const hint = await getInstallHint("osv-scanner", { go: false, brew: true });
+    expect(hint.command).toBe("brew install osv-scanner");
+  });
+
+  it("uses npm for lighthouse always", async () => {
+    const hint = await getInstallHint("lighthouse", { npm: true });
+    expect(hint.command).toBe("npm install -g lighthouse");
+  });
+
+  it("returns null manager + fallback command when nothing matches", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: false, brew: false, pip: false });
+    expect(hint.manager).toBeNull();
+    // The hint still offers a command for the user to consider.
+    expect(hint.command).toBe("pipx install semgrep");
+  });
+
+  it("always includes the manual URL", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: true });
+    expect(hint.manualUrl).toMatch(/semgrep\.dev/);
+  });
+
+  it("returns command:null for an unknown tool", async () => {
+    const hint = await getInstallHint("nonexistent-tool", { brew: true });
+    expect(hint.command).toBeNull();
+    expect(hint.manager).toBeNull();
+  });
+});
+
+describe("appliesToStack — stack gating", () => {
+  it("lighthouse applies to frontend stacks", () => {
+    expect(appliesToStack("lighthouse", { isFrontend: true })).toBe(true);
+    expect(appliesToStack("lighthouse", { isFullstack: true })).toBe(true);
+  });
+
+  it("lighthouse does NOT apply to backend-only stacks", () => {
+    expect(appliesToStack("lighthouse", { isBackend: true })).toBe(false);
+  });
+
+  it("lighthouse does NOT apply to null/empty stack", () => {
+    expect(appliesToStack("lighthouse", null)).toBe(false);
+    expect(appliesToStack("lighthouse", {})).toBe(false);
+  });
+
+  it("non-frontend tools (semgrep, osv) always apply", () => {
+    expect(appliesToStack("semgrep", null)).toBe(true);
+    expect(appliesToStack("osv-scanner", { isBackend: true })).toBe(true);
+    expect(appliesToStack("docker", {})).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

HU1 of the external-tools-onboarding epic (3 HUs total). Adds platform-
aware install hints to \`kj doctor\` for the three external tools that
\`kj audit\` and \`kj webperf\` rely on but do not install: **semgrep**,
**osv-scanner**, **lighthouse**.

- Each missing tool surfaces as a warn (not blocker).
- Fix line picks the install command for the package manager actually
  available on the user's system (pipx > brew > pip for semgrep,
  go > brew for osv-scanner, npm for lighthouse).
- **Lighthouse is stack-gated**: only checked when the project is
  frontend / fullstack. Backend-only projects don't see lighthouse noise.

## Test plan
- [x] 20 new unit cases (\`install-hints.test.js\` + \`audit-tools.test.js\`)
- [x] Full suite 4 892/4 892 passing
- [x] Lint clean
- [x] Dynamic-import budget bumped 161 → 162 (rationale documented)

Adds ~400 net LOC; labelling \`large-pr-justified\` for the shrink-budget
gate. Tests are indivisible from the implementation.

Follow-ups: HU2 (\`kj install-tools\` command that consumes these hints
to actually install the tool), HU3 (wire-up + docs).