### PR TITLE
feat(cli): new ▸ semgrep: running `pipx install semgrep`...
✓ semgrep: installed via pipx
⊘ lighthouse: skipped (no frontend stack detected; use --only lighthouse to force)
✓ docker: already installed
✓ sonar: already installed command for external audit tools

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -3,6 +3,7 @@ import { configCommand } from "../commands/config.js";
 import { codeCommand } from "../commands/code.js";
 import { reviewCommand } from "../commands/review.js";
 import { scanCommand } from "../commands/scan.js";
+import { installToolsCommand } from "../commands/install-tools.js";
 import { doctorCommand } from "../commands/doctor.js";
 import { reportCommand } from "../commands/report.js";
 import { runCommandHandler } from "../commands/run.js";
@@ -190,6 +191,26 @@ export function registerPipeline(program, { pkgVersion }) {
         })
       );
       if (Number.isInteger(exitCode)) process.exit(exitCode);
+    });
+
+  program
+    .command("install-tools")
+    .description("Install external audit tools (semgrep, osv-scanner, lighthouse, docker, sonar) using the package manager available on your system")
+    .option("--only <tools>", "Comma-separated subset (e.g. \"semgrep,osv-scanner\"). Bypasses stack-gating.")
+    .option("-y, --yes", "Auto-accept all prompts (non-interactive)")
+    .option("--dry-run", "Show what would be installed without running anything")
+    .action(async (flags) => {
+      try {
+        const { exitCode } = await installToolsCommand({
+          only: flags.only,
+          yes: !!flags.yes,
+          dryRun: !!flags.dryRun,
+        });
+        if (Number.isInteger(exitCode)) process.exit(exitCode);
+      } catch (err) {
+        console.error(`kj install-tools: ${err?.message || err}`);
+        process.exit(1);
+      }
     });
 
   program

--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -1,0 +1,211 @@
+// `kj install-tools` — install the external audit tools that `kj audit`
+// and `kj webperf` rely on but does not bundle.
+//
+// Covers semgrep, osv-scanner, lighthouse, docker, sonar. Picks the
+// install command per tool from `getInstallHint` (HU1) so the command
+// matches the package manager available on the user's system.
+//
+// Lighthouse is stack-gated: by default we only prompt about it when
+// the project is frontend/fullstack. Pass `--only lighthouse` to bypass
+// the gate.
+//
+// Docker and sonar are special cases — see TOOL_HANDLERS below.
+
+import readline from "node:readline";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { checkBinary } from "../utils/agent-detect.js";
+import { getInstallHint, detectPackageManagers, appliesToStack } from "../utils/install-hints.js";
+import { detectProjectStack } from "../utils/stack-detect.js";
+
+const execFileAsync = promisify(execFile);
+
+const ALL_TOOLS = ["semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
+
+function parseOnlyList(raw) {
+  if (!raw) return null;
+  const wanted = String(raw).split(",").map((t) => t.trim()).filter(Boolean);
+  const invalid = wanted.filter((t) => !ALL_TOOLS.includes(t));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown tool(s) in --only: ${invalid.join(", ")}. Valid: ${ALL_TOOLS.join(", ")}`);
+  }
+  return wanted;
+}
+
+function promptYesNo(question, defaultYes = true) {
+  return new Promise((resolve) => {
+    if (!process.stdin.isTTY) { resolve(defaultYes); return; } // non-TTY → assume default
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const hint = defaultYes ? "Y/n" : "y/N";
+    rl.question(`${question} [${hint}] `, (answer) => {
+      rl.close();
+      const a = (answer || "").trim().toLowerCase();
+      if (!a) return resolve(defaultYes);
+      resolve(a === "y" || a === "yes");
+    });
+  });
+}
+
+async function isInstalled(tool) {
+  // sonar is a Docker container, not a binary. We check it separately
+  // by looking at running containers via `docker ps`.
+  if (tool === "sonar") return checkSonarRunning();
+  if (tool === "lighthouse") return (await checkBinary("lighthouse")).ok;
+  if (tool === "docker") return (await checkBinary("docker")).ok;
+  return (await checkBinary(tool)).ok;
+}
+
+async function checkSonarRunning() {
+  try {
+    const { stdout } = await execFileAsync("docker", ["ps", "--format", "{{.Names}}", "--filter", "name=sonarqube"], { timeout: 5000 });
+    return stdout.trim().length > 0;
+  } catch { return false; }
+}
+
+async function runInstall(command) {
+  // Split on whitespace (commands here are simple, no nested quoting).
+  const [bin, ...args] = command.split(/\s+/);
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, args, { timeout: 300_000, maxBuffer: 32 * 1024 * 1024 });
+    return { ok: true, stdout, stderr };
+  } catch (err) {
+    return { ok: false, error: err?.shortMessage || err?.message || String(err), stderr: err?.stderr };
+  }
+}
+
+/**
+ * Sonar handler: special case. Cannot install Sonar via package manager;
+ * the install is `docker compose -f <our-template> up -d` if Docker is
+ * available. Falls back to a manual URL otherwise.
+ */
+async function handleSonar({ available, dryRun }) {
+  if (!available.docker) {
+    return {
+      tool: "sonar",
+      action: "manual",
+      reason: "docker not available — sonar needs docker. Install docker first.",
+      manualUrl: "https://docs.docker.com/get-docker/",
+    };
+  }
+  const composePath = path.join(process.cwd(), "docker-compose.yml");
+  let composeExists = false;
+  try { await fs.access(composePath); composeExists = true; } catch { /* missing */ }
+  const command = composeExists
+    ? "docker compose up -d"
+    : "docker run -d --name sonarqube -p 9000:9000 sonarqube:lts-community";
+  return {
+    tool: "sonar",
+    action: dryRun ? "dry-run" : "ready",
+    command,
+    manualUrl: "https://docs.sonarsource.com/sonarqube-community-build/try-out-sonarqube/",
+  };
+}
+
+/**
+ * Docker handler: never auto-install (platform-specific, invasive).
+ * Always point at the official docs.
+ */
+function handleDocker(available) {
+  return {
+    tool: "docker",
+    action: "manual",
+    reason: "Docker install is platform-specific — see official docs.",
+    manualUrl: "https://docs.docker.com/get-docker/",
+    suggested: available.brew ? "brew install --cask docker" : null,
+  };
+}
+
+/**
+ * Plan + (optionally execute) the install of every requested tool.
+ *
+ * @param {Object} opts
+ * @param {string|null} [opts.only] - comma-separated subset
+ * @param {boolean} [opts.yes] - skip prompts
+ * @param {boolean} [opts.dryRun] - plan-only, no execution
+ * @param {Object} [opts.logger]
+ * @returns {Promise<{ results: Array<Object>, exitCode: number }>}
+ */
+export async function installToolsCommand(opts = {}) {
+  const only = parseOnlyList(opts.only);
+  const yes = !!opts.yes;
+  const dryRun = !!opts.dryRun;
+  const logger = opts.logger || console;
+
+  const targetTools = only || ALL_TOOLS;
+  const available = await detectPackageManagers();
+  const stack = await detectProjectStack(process.cwd()).catch(() => null);
+
+  const results = [];
+  for (const tool of targetTools) {
+    // Stack gating — lighthouse on backend-only projects is skipped
+    // UNLESS the user passed --only lighthouse explicitly.
+    if (tool === "lighthouse" && !only && !appliesToStack(tool, stack)) {
+      results.push({ tool, action: "skipped", reason: "no frontend stack detected" });
+      logger.info?.(`⊘ ${tool}: skipped (no frontend stack detected; use --only lighthouse to force)`);
+      continue;
+    }
+
+    if (await isInstalled(tool)) {
+      results.push({ tool, action: "already-installed" });
+      logger.info?.(`✓ ${tool}: already installed`);
+      continue;
+    }
+
+    if (tool === "sonar") {
+      const result = await handleSonar({ available, dryRun });
+      results.push(result);
+      logger.info?.(`▸ sonar: ${result.command || result.manualUrl}`);
+      if (!dryRun && result.action === "ready") {
+        const proceed = yes || await promptYesNo(`Start SonarQube with: ${result.command}?`);
+        if (proceed) {
+          const r = await runInstall(result.command);
+          result.action = r.ok ? "installed" : "failed";
+          if (!r.ok) result.error = r.error;
+        }
+      }
+      continue;
+    }
+
+    if (tool === "docker") {
+      const result = handleDocker(available);
+      results.push(result);
+      logger.info?.(`▸ docker: ${result.suggested || result.manualUrl}`);
+      continue;
+    }
+
+    // semgrep / osv-scanner / lighthouse — package-manager driven.
+    const hint = await getInstallHint(tool, available);
+    if (!hint.command || !hint.manager) {
+      results.push({ tool, action: "manual", reason: "no compatible package manager found", manualUrl: hint.manualUrl, suggested: hint.command });
+      logger.warn?.(`✗ ${tool}: no compatible package manager. Manual: ${hint.manualUrl}`);
+      continue;
+    }
+    if (dryRun) {
+      results.push({ tool, action: "dry-run", command: hint.command, manager: hint.manager });
+      logger.info?.(`▸ ${tool}: would run \`${hint.command}\` (manager: ${hint.manager})`);
+      continue;
+    }
+    const proceed = yes || await promptYesNo(`Install ${tool} with: ${hint.command}?`);
+    if (!proceed) {
+      results.push({ tool, action: "declined", command: hint.command });
+      logger.info?.(`⊘ ${tool}: declined`);
+      continue;
+    }
+    logger.info?.(`▸ ${tool}: running \`${hint.command}\`...`);
+    const r = await runInstall(hint.command);
+    if (r.ok) {
+      results.push({ tool, action: "installed", command: hint.command, manager: hint.manager });
+      logger.info?.(`✓ ${tool}: installed via ${hint.manager}`);
+    } else {
+      results.push({ tool, action: "failed", command: hint.command, error: r.error });
+      logger.warn?.(`✗ ${tool}: install failed (${r.error})`);
+    }
+  }
+
+  const failures = results.filter((r) => r.action === "failed").length;
+  return { results, exitCode: failures > 0 ? 1 : 0 };
+}
+
+export const __test = { parseOnlyList, isInstalled, ALL_TOOLS };

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// KJC-TSK v2.18 — `kj install-tools` command.
+
+vi.mock("../../src/utils/agent-detect.js", () => ({
+  checkBinary: vi.fn(async () => ({ ok: false, version: null, path: null })),
+}));
+
+vi.mock("../../src/utils/install-hints.js", () => ({
+  detectPackageManagers: vi.fn(async () => ({
+    pipx: true, brew: false, go: false, npm: true, pip: false, apt: false, dnf: false, choco: false, scoop: false, docker: true,
+  })),
+  getInstallHint: vi.fn(async (tool) => {
+    const mapping = {
+      semgrep: { command: "pipx install semgrep", manager: "pipx", manualUrl: "https://semgrep.dev" },
+      "osv-scanner": { command: null, manager: null, manualUrl: "https://google.github.io/osv-scanner" },
+      lighthouse: { command: "npm install -g lighthouse", manager: "npm", manualUrl: "https://lighthouse" },
+    };
+    return mapping[tool] || { command: null, manager: null, manualUrl: "x" };
+  }),
+  appliesToStack: vi.fn((tool, stack) => {
+    if (tool === "lighthouse") return Boolean(stack?.isFrontend || stack?.isFullstack);
+    return true;
+  }),
+}));
+
+vi.mock("../../src/utils/stack-detect.js", () => ({
+  detectProjectStack: vi.fn(async () => ({ isBackend: true, isFrontend: false, isFullstack: false })),
+}));
+
+// Skip child_process exec entirely for these tests — we never want to
+// actually install anything during the test run.
+vi.mock("node:child_process", async (orig) => {
+  const real = await orig();
+  return {
+    ...real,
+    execFile: vi.fn((bin, args, _opts, cb) => {
+      // sonar's checkSonarRunning uses execFile("docker", ["ps"...]) — return empty
+      // so we treat sonar as not running and runInstall fails cleanly.
+      if (cb) cb(new Error("mocked execFile failure"), { stdout: "", stderr: "" });
+      return { unref: () => {} };
+    }),
+  };
+});
+
+const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("kj install-tools — dry-run", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("plans installs without running anything (semgrep + osv-scanner + docker + sonar; lighthouse skipped on backend stack)", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results, exitCode } = await installToolsCommand({ dryRun: true, logger: silentLogger });
+
+    expect(exitCode).toBe(0);
+    expect(results.find((r) => r.tool === "semgrep").action).toBe("dry-run");
+    expect(results.find((r) => r.tool === "semgrep").command).toBe("pipx install semgrep");
+    expect(results.find((r) => r.tool === "osv-scanner").action).toBe("manual");
+    expect(results.find((r) => r.tool === "lighthouse").action).toBe("skipped");
+    expect(results.find((r) => r.tool === "docker").action).toBe("manual");
+    expect(results.find((r) => r.tool === "sonar").action).toBe("dry-run");
+  });
+
+  it("--only semgrep limits the run to one tool", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "semgrep", logger: silentLogger });
+    expect(results).toHaveLength(1);
+    expect(results[0].tool).toBe("semgrep");
+  });
+
+  it("--only lighthouse bypasses stack gating", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "lighthouse", logger: silentLogger });
+    expect(results).toHaveLength(1);
+    expect(results[0].tool).toBe("lighthouse");
+    // With explicit --only, we should NOT skip even on backend stacks.
+    expect(results[0].action).not.toBe("skipped");
+  });
+
+  it("rejects unknown tools in --only", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    await expect(installToolsCommand({ only: "ghost-tool", logger: silentLogger })).rejects.toThrow(/ghost-tool/);
+  });
+
+  it("skips tools that are already installed", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { checkBinary } = await import("../../src/utils/agent-detect.js");
+    checkBinary.mockResolvedValueOnce({ ok: true, version: "1.0.0", path: "/usr/bin/semgrep" });
+    const { results } = await installToolsCommand({ dryRun: true, only: "semgrep", logger: silentLogger });
+    expect(results[0].action).toBe("already-installed");
+  });
+
+  it("flags osv-scanner as manual when no compatible package manager is available", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "osv-scanner", logger: silentLogger });
+    expect(results[0].action).toBe("manual");
+    expect(results[0].suggested).toBeNull();
+  });
+});
+
+describe("kj install-tools — stack-aware lighthouse", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("does NOT skip lighthouse on frontend stacks", async () => {
+    const { detectProjectStack } = await import("../../src/utils/stack-detect.js");
+    detectProjectStack.mockResolvedValueOnce({ isFrontend: true, isFullstack: false, isBackend: false });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, logger: silentLogger });
+    const lh = results.find((r) => r.tool === "lighthouse");
+    expect(lh.action).toBe("dry-run");
+    expect(lh.command).toBe("npm install -g lighthouse");
+  });
+});
+
+describe("parseOnlyList", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("accepts a comma-separated subset of valid tools", async () => {
+    const { __test } = await import("../../src/commands/install-tools.js");
+    expect(__test.parseOnlyList("semgrep,osv-scanner")).toEqual(["semgrep", "osv-scanner"]);
+  });
+
+  it("returns null when input is empty / undefined", async () => {
+    const { __test } = await import("../../src/commands/install-tools.js");
+    expect(__test.parseOnlyList(undefined)).toBeNull();
+    expect(__test.parseOnlyList("")).toBeNull();
+  });
+
+  it("throws on unknown tool name", async () => {
+    const { __test } = await import("../../src/commands/install-tools.js");
+    expect(() => __test.parseOnlyList("foo,semgrep")).toThrow(/Unknown tool/);
+  });
+});


### PR DESCRIPTION
## Summary

HU2 of the external-tools-onboarding epic (3 HUs). Builds on the install
hints introduced in #748: now \`kj install-tools\` actually executes the
suggested command.

Covers: **semgrep, osv-scanner, lighthouse, docker, sonar**.

- For each tool, if already installed → skipped.
- semgrep / osv-scanner / lighthouse: picks install command from the
  HU1 \`getInstallHint()\` util (pipx > brew > pip; go > brew; npm).
  Interactive confirm by default; \`--yes\` to auto-accept.
- docker: never auto-install (platform-specific). Print docs URL +
  brew-cask hint on macOS.
- sonar: requires docker. If a local docker-compose.yml exists →
  \`docker compose up -d\`; otherwise \`docker run\` with sonarqube image.

## Flags
- \`--only <tools>\` — comma-separated subset. Also bypasses stack gating.
- \`--yes / -y\` — non-interactive auto-accept.
- \`--dry-run\` — plan-only.

## Test plan
- [x] 10 new unit cases (dry-run for all 5 tools, --only subset, unknown
  tool rejection, already-installed short-circuit, missing pkg manager,
  lighthouse stack gating)
- [x] Smoke test: \`node bin/kj.js install-tools --dry-run\` on this repo
- [x] Full suite 4 902/4 902 passing
- [x] Lint clean

Adds ~363 net LOC. Labelling \`large-pr-justified\`.

Follow-ups: HU3 (wire-up: kj doctor suggests \`kj install-tools\` when
hints exist; GETTING-STARTED docs section).