### PR TITLE
feat(doctor): suggest `kj install-tools` for missing audit tools + docs

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -21,6 +21,34 @@ Karajan's audit pipeline runs deterministic scanners in parallel and feeds their
 
 Skip any of them per-run with the matching `--no-*` flag (`--no-sonar`, `--no-osv`, `--no-semgrep`).
 
+### One-command install with `kj install-tools` (v2.18+)
+
+You don't have to copy the commands above by hand. After `npm install -g karajan-code`:
+
+```bash
+kj doctor                 # Shows what's missing and the install command for YOUR system
+kj install-tools          # Interactive — installs every missing tool using the package manager you already have
+kj install-tools --yes    # Non-interactive (CI / automation)
+kj install-tools --dry-run                       # Plan-only, prints what it would do
+kj install-tools --only semgrep,osv-scanner      # Subset
+```
+
+Behaviour per tool:
+
+- **Semgrep**: picks `pipx install semgrep` if pipx is available, falls back to `brew install semgrep`, then `pip install semgrep`.
+- **OSV-Scanner**: picks `go install github.com/google/osv-scanner@latest` if Go is available, falls back to `brew install osv-scanner`.
+- **Lighthouse**: `npm install -g lighthouse`. **Only suggested on frontend / fullstack projects** — backend-only projects don't see lighthouse noise. Use `--only lighthouse` to force.
+- **Docker**: never auto-installed (platform-specific). Prints docs URL and, on macOS, the `brew install --cask docker` hint.
+- **Sonar**: requires Docker. If a `docker-compose.yml` exists in the cwd, suggests `docker compose up -d`; otherwise a one-shot `docker run` with the official SonarQube image.
+
+`kj doctor` lists each missing tool with the exact install command picked for your system and ends with a one-line `Tip: run kj install-tools …` reminder, so the typical flow is:
+
+```bash
+kj doctor              # see what's missing
+kj install-tools       # fix it
+kj doctor              # confirm clean
+```
+
 ## Install
 
 ```bash

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -21,6 +21,34 @@ El pipeline de audit de Karajan corre scanners deterministas en paralelo y mete 
 
 Saltar cualquiera por ejecución con el flag `--no-*` correspondiente (`--no-sonar`, `--no-osv`, `--no-semgrep`).
 
+### Instalación en un comando con `kj install-tools` (v2.18+)
+
+No hace falta copiar los comandos de arriba a mano. Después de `npm install -g karajan-code`:
+
+```bash
+kj doctor                 # Muestra qué falta y el comando de instalación para TU sistema
+kj install-tools          # Interactivo — instala cada herramienta usando el gestor de paquetes que ya tienes
+kj install-tools --yes    # No interactivo (CI / automatización)
+kj install-tools --dry-run                       # Solo planifica, imprime qué haría
+kj install-tools --only semgrep,osv-scanner      # Subset
+```
+
+Comportamiento por herramienta:
+
+- **Semgrep**: usa `pipx install semgrep` si pipx está disponible, cae a `brew install semgrep`, luego `pip install semgrep`.
+- **OSV-Scanner**: usa `go install github.com/google/osv-scanner@latest` si Go está disponible, cae a `brew install osv-scanner`.
+- **Lighthouse**: `npm install -g lighthouse`. **Solo se sugiere en proyectos frontend / fullstack** — proyectos backend-only no ven ruido de lighthouse. Usa `--only lighthouse` para forzar.
+- **Docker**: nunca se auto-instala (depende de plataforma). Imprime URL de docs y, en macOS, el hint `brew install --cask docker`.
+- **Sonar**: necesita Docker. Si hay un `docker-compose.yml` en el cwd, sugiere `docker compose up -d`; si no, un `docker run` puntual con la imagen oficial de SonarQube.
+
+`kj doctor` lista cada herramienta faltante con el comando de install elegido para tu sistema y termina con un recordatorio `Tip: run kj install-tools …`, así que el flujo típico es:
+
+```bash
+kj doctor              # ver qué falta
+kj install-tools       # arreglarlo
+kj doctor              # confirmar limpio
+```
+
 ## Instalación
 
 ```bash

--- a/src/checks/runner.js
+++ b/src/checks/runner.js
@@ -196,6 +196,10 @@ export async function runChecks(checks, ctx, options = {}) {
     detail: e.detail ?? "",
     fix: e.detectResult?.fix,
     runMs: e.runMs,
+    // Forward optional structured metadata so the doctor printer can
+    // surface per-tool remediation tips (KJC-TSK v2.18). Undefined when
+    // the check didn't set one — kept minimal so JSON output stays tight.
+    extra: e.detectResult?.extra,
   }));
 
   const summary = summarize(reports);

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -171,4 +171,21 @@ function printHuman(report, { verbose }) {
   if (Object.keys(report.overrides).length > 0) {
     console.log(`Runtime overrides applied: ${JSON.stringify(report.overrides)}`);
   }
+
+  // KJC-TSK v2.18 — if any external audit tool (semgrep, osv-scanner,
+  // lighthouse) reported missing, surface the one-line remediation so
+  // the user doesn't have to dig the fix lines out of the wall of
+  // checks. The audit-tool checks emit names like "audit-tool:semgrep"
+  // and embed { tool, suggested } in `extra` (see binaries.js).
+  const installable = report.checks
+    .filter((c) => c.name?.startsWith("audit-tool:") && c.status === STATUS.WARN && c.extra?.tool)
+    .map((c) => c.extra.tool);
+  if (installable.length > 0) {
+    console.log();
+    const list = installable.join(", ");
+    const only = installable.length === 1 ? ` --only ${installable[0]}` : "";
+    console.log(`Tip: run \`kj install-tools${only}\` to install: ${list}.`);
+  }
 }
+
+export const __test = { printHuman };

--- a/tests/doctor-install-tip.test.js
+++ b/tests/doctor-install-tip.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { STATUS, STRATEGY } from "../src/checks/types.js";
+import { __test } from "../src/commands/doctor.js";
+
+// KJC-TSK v2.18 — the doctor's human printer should suggest
+// `kj install-tools` whenever one or more external audit tools are
+// missing (semgrep / osv-scanner / lighthouse). This test exercises the
+// pure renderer (no mocked pipeline) by feeding it synthetic reports.
+
+const { printHuman } = __test;
+
+function makeReport(checks) {
+  return {
+    checks,
+    overrides: {},
+    summary: { ok: checks.filter((c) => c.status === STATUS.OK).length, fixed: 0, warn: checks.filter((c) => c.status === STATUS.WARN).length, fail: 0, skipped: 0, timeout: 0 },
+    totalMs: 1,
+  };
+}
+
+let logs;
+
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => { logs.push(args.join(" ")); });
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("printHuman — install-tools tip", () => {
+  it("emits a single-tool tip with --only when ONE audit tool is missing", () => {
+    printHuman(
+      makeReport([
+        { name: "audit-tool:semgrep", label: "Semgrep", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not found", fix: "Run kj install-tools…", extra: { tool: "semgrep" }, runMs: 1 },
+      ]),
+      { verbose: false },
+    );
+    const out = logs.join("\n");
+    expect(out).toContain("kj install-tools --only semgrep");
+    expect(out).toContain("install: semgrep");
+  });
+
+  it("emits a multi-tool tip without --only when TWO+ audit tools are missing", () => {
+    printHuman(
+      makeReport([
+        { name: "audit-tool:semgrep", label: "Semgrep", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not found", fix: "x", extra: { tool: "semgrep" }, runMs: 1 },
+        { name: "audit-tool:osv-scanner", label: "OSV", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not found", fix: "y", extra: { tool: "osv-scanner" }, runMs: 1 },
+      ]),
+      { verbose: false },
+    );
+    const out = logs.join("\n");
+    // No --only flag when multiple tools are listed.
+    expect(out).toMatch(/kj install-tools(?!.*--only)/);
+    expect(out).toContain("semgrep");
+    expect(out).toContain("osv-scanner");
+  });
+
+  it("does NOT emit the tip when all audit tools are OK", () => {
+    printHuman(
+      makeReport([
+        { name: "audit-tool:semgrep", label: "Semgrep", status: STATUS.OK, strategy: STRATEGY.MANUAL, detail: "1.0.0", runMs: 1 },
+        { name: "git", label: "git", status: STATUS.OK, strategy: STRATEGY.MANUAL, detail: "git 2.45", runMs: 1 },
+      ]),
+      { verbose: false },
+    );
+    const out = logs.join("\n");
+    expect(out).not.toContain("kj install-tools");
+  });
+
+  it("ignores non-audit-tool warnings (no false positives)", () => {
+    printHuman(
+      makeReport([
+        { name: "sonar:reachable", label: "Sonar", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not reachable", fix: "Start docker", runMs: 1 },
+      ]),
+      { verbose: false },
+    );
+    const out = logs.join("\n");
+    expect(out).not.toContain("kj install-tools");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the external-tools-onboarding epic (HU3/3). Builds on the install-
hints surfaced in #748 and the new command in #749.

- \`kj doctor\` now ends its report with a one-line tip when one or more
  external audit tools (semgrep / osv-scanner / lighthouse) are missing.
  Uses \`--only <tool>\` when exactly one tool is missing.
- \`src/checks/runner.js\` forwards the optional \`extra\` field from
  CheckResult into the flat report so the printer can read \`extra.tool\`.
- \`docs/GETTING-STARTED.md\` (EN + ES) gain a new "One-command install
  with \`kj install-tools\`" section with per-tool behaviour, flags, and
  the typical \`doctor → install-tools → doctor\` flow.

## Test plan
- [x] 4 new unit cases (\`tests/doctor-install-tip.test.js\`)
- [x] Full pipeline tests pass in isolation (\`runflow-*\` flaky under
  high parallelism, pre-existing; tracked separately)
- [x] Lint clean
- [x] Under shrink-budget (~155 lines)