### PR TITLE
fix(hu-board): proyectos borrados ya no resucitan al `kj plan` (KJC-BUG-0055)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -626,6 +626,19 @@ export function isTombstoned(resourceType, resourceId) {
   ).get(resourceType, resourceId);
 }
 
+/**
+ * Read a single tombstone row (or null). Needed so callers can compare
+ * `deleted_at` against a resource's own timestamp before deciding whether
+ * to revive it (KJC-BUG-0055).
+ */
+export function getTombstone(resourceType, resourceId) {
+  const row = getDb().prepare(
+    'SELECT resource_type, resource_id, deleted_at, source, fs_paths FROM tombstones WHERE resource_type = ? AND resource_id = ?'
+  ).get(resourceType, resourceId);
+  if (!row) return null;
+  return { ...row, fs_paths: row.fs_paths ? JSON.parse(row.fs_paths) : [] };
+}
+
 export function removeTombstone(resourceType, resourceId) {
   return getDb().prepare(
     'DELETE FROM tombstones WHERE resource_type = ? AND resource_id = ?'

--- a/packages/hu-board/src/ephemeral-cleaner.js
+++ b/packages/hu-board/src/ephemeral-cleaner.js
@@ -25,11 +25,18 @@
  *   3. Override: when `is_test = 0` (user clicked "keep it"), the
  *      project is NEVER deleted, even if the heuristic would match.
  *
- * What "cleanup" means: DELETE the project row + cascade-delete
- * its stories and sessions (see `deleteProject` in db.js — this
- * module piggybacks on the same statement set, so the cleanup
- * cannot leave orphan rows behind).
+ * What "cleanup" means: DELETE the project row + cascade-delete its
+ * stories and sessions, ADD a project tombstone, and rm-rf the
+ * on-disk dirs (`hu-stories/<sid>/`, `sessions/<sid>/`,
+ * `~/.kj/plans/<projectId>/`). Without the tombstone + fs cleanup,
+ * the very next chokidar `add` event or `fullScan` would re-import
+ * those files as a brand-new project (KJC-BUG-0055).
  */
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+import { addTombstone, getKjHome } from "./db.js";
 
 const DEFAULT_TTL_HOURS = 24;
 const EPHEMERAL_ID_PATTERNS = [
@@ -121,7 +128,21 @@ export function findEphemeralProjects(projects, opts = {}) {
  * @param {Function} [deps.now]   () => number, for tests
  * @returns {Array<{ id: string, reason: string, stories_deleted: number, sessions_deleted: number }>}
  */
-export function cleanupEphemeralProjects({ db, opts = {}, now = () => Date.now() }) {
+export function cleanupEphemeralProjects({
+  db,
+  opts = {},
+  now = () => Date.now(),
+  // Deps are injectable so the legacy in-memory tests (which never
+  // call `initDb()`) can pass no-op stubs and still verify the
+  // cascade-delete logic. Production callers omit them and get the
+  // real persistence + fs side-effects.
+  tombstone = (type, id, o) => {
+    try { addTombstone(type, id, o); } catch { /* DB not initialised (test) */ }
+  },
+  kjHome = () => {
+    try { return getKjHome(); } catch { return null; }
+  },
+} = {}) {
   if (!db) return [];
   const allProjects = db
     .prepare("SELECT id, last_activity, first_seen, is_test FROM projects")
@@ -135,20 +156,42 @@ export function cleanupEphemeralProjects({ db, opts = {}, now = () => Date.now()
   const delSessions = db.prepare("DELETE FROM sessions WHERE project_id = ?");
   const delProject = db.prepare("DELETE FROM projects WHERE id = ?");
 
+  const selStories = db.prepare("SELECT id FROM stories WHERE project_id = ?");
+  const selSessions = db.prepare("SELECT id FROM sessions WHERE project_id = ?");
+  const plansRoot = process.env.KJ_PLANS_DIR
+    || path.join(homedir(), ".kj", "plans");
+  const home = kjHome();
   const cleaned = [];
   for (const { project, reason } of candidates) {
-    const storiesN = countStories.get(project.id).n;
-    const sessionsN = countSessions.get(project.id).n;
+    const storyIds = selStories.all(project.id).map((r) => r.id);
+    const sessionIds = selSessions.all(project.id).map((r) => r.id);
+    const fsPaths = home
+      ? [
+          ...storyIds.map((sid) => path.join(home, "hu-stories", sid)),
+          ...sessionIds.map((sid) => path.join(home, "sessions", sid)),
+          path.join(plansRoot, project.id),
+        ]
+      : [];
     db.transaction(() => {
       delStories.run(project.id);
       delSessions.run(project.id);
       delProject.run(project.id);
     })();
+    // Tombstone the lot + best-effort rm-rf. If the fs op fails (perm
+    // error, file in use) we still keep the tombstone — that alone is
+    // enough to stop sync.js from re-importing on the next chokidar
+    // event, and `fullScan` will retry the rm-rf at next boot.
+    tombstone("project", project.id, { source: "ephemeral-cleaner", fsPaths });
+    for (const sid of storyIds) tombstone("story", sid, { source: "ephemeral-cleaner" });
+    for (const sid of sessionIds) tombstone("session", sid, { source: "ephemeral-cleaner" });
+    for (const p of fsPaths) {
+      try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
     cleaned.push({
       id: project.id,
       reason,
-      stories_deleted: storiesN,
-      sessions_deleted: sessionsN,
+      stories_deleted: storyIds.length,
+      sessions_deleted: sessionIds.length,
     });
   }
   return cleaned;

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { spawn as spawnChild } from 'node:child_process';
 import {
@@ -349,10 +350,17 @@ router.delete('/projects/:id', (req, res) => {
     const db = getDb();
     const storyIds = db.prepare('SELECT id FROM stories WHERE project_id = ?').all(id).map((r) => r.id);
     const sessionIds = db.prepare('SELECT id FROM sessions WHERE project_id = ?').all(id).map((r) => r.id);
+    // KJC-BUG-0055: honour KJ_PLANS_DIR (the env override the sync /
+    // cleanup-zombies layers already respect). Previously hardcoded to
+    // ~/.kj/plans relative to KJ_HOME's parent, which broke when the
+    // two homes were configured separately and left orphan plan dirs
+    // on disk after a 🗑️ delete.
+    const plansRoot = process.env.KJ_PLANS_DIR
+      || path.join(os.homedir(), '.kj', 'plans');
     const fsPaths = [
       ...storyIds.map((sid) => path.join(huStoriesDir(), sid)),
       ...sessionIds.map((sid) => path.join(getKjHome(), 'sessions', sid)),
-      path.join(getKjHome(), '..', '.kj', 'plans', id),
+      path.join(plansRoot, id),
     ];
 
     const existed = deleteProject(id);

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -10,6 +10,7 @@ import {
   insertContextRequest,
   getDb,
   isTombstoned,
+  getTombstone,
   removeTombstone,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
@@ -341,18 +342,29 @@ export function syncPlanFile(filePath) {
       : data.planId;
 
     if (skipIfTombstoned('plan', data.planId, filePath)) return;
-    // KJC-BUG-0050: el tombstone del PROYECTO no debe bloquear plans
-    // futuros. Cuando el usuario borra un proyecto del board (🗑️), el
-    // tombstone permanente impedía regenerar planes en el mismo
-    // projectDir — `kj plan` escribía el JSON y este sync lo borraba.
-    // Fix: si el proyecto está tombstoned pero el PLAN concreto NO lo
-    // está, asumimos que el usuario quiere resurrectarlo (creó un plan
-    // nuevo) y borramos el tombstone del proyecto. El tombstone-de-plan
-    // sigue respetándose: planes individuales que el usuario borró
-    // siguen muertos hasta que se cree un planId distinto.
-    if (isTombstoned('project', projectId)) {
-      console.log(`[sync] Project ${projectId} was tombstoned but a new plan ${data.planId} arrived — reviving (removing project tombstone).`);
-      removeTombstone('project', projectId);
+    // KJC-BUG-0055 (supersedes KJC-BUG-0050): gating por timestamp.
+    // El "fix" anterior quitaba el tombstone del proyecto en CUALQUIER
+    // llegada de plan — eso resucitaba proyectos borrados cuando un plan
+    // anterior reaparecía (DB nueva + plan-files viejos en disco) o
+    // cuando un fullScan posterior los re-encontraba. Comportamiento:
+    //   • plan.updatedAt/createdAt > tombstone.deleted_at → el usuario
+    //     ha generado el plan DESPUÉS de borrar el proyecto → revivir.
+    //   • plan.updatedAt/createdAt <= tombstone.deleted_at → plan stale
+    //     pre-existente al borrado → respetar el tombstone y borrar el
+    //     fichero en disco para que no vuelva a re-importarse.
+    const projectTomb = getTombstone('project', projectId);
+    if (projectTomb) {
+      const planTime = data.updatedAt || data.createdAt || null;
+      const planTs = planTime ? Date.parse(planTime) : NaN;
+      const tombTs = Date.parse(projectTomb.deleted_at);
+      if (Number.isFinite(planTs) && planTs > tombTs) {
+        console.log(`[sync] Project ${projectId} resucitado: plan ${data.planId} es más reciente (${planTime}) que el tombstone (${projectTomb.deleted_at}).`);
+        removeTombstone('project', projectId);
+      } else {
+        console.log(`[sync] Plan ${data.planId} ignorado: proyecto ${projectId} tombstoned (${projectTomb.deleted_at}); borrando ${filePath}.`);
+        try { rmSync(filePath, { force: true }); } catch { /* best effort */ }
+        return;
+      }
     }
     // Human-friendly project name resolution order (most-specific first):
     //   1. plan.name explicitly set by the user / planner ("Linux Assistant
@@ -477,6 +489,21 @@ export function fullScan() {
   db.exec('DELETE FROM stories');
   db.exec('DELETE FROM sessions');
   db.exec('DELETE FROM projects');
+
+  // KJC-BUG-0055: garbage-collect on-disk story/session artefacts whose
+  // ids carry an active tombstone. Without this, a tombstone is useless
+  // against a stray ~/.karajan/hu-stories/<id>/ that survived a manual
+  // DB wipe — the next pass would re-import it as a ghost project.
+  // (Plan dirs are NOT pre-purged here: a tombstoned project may hold a
+  // newer plan from a legit projectDir re-use; `syncPlanFile`'s
+  // timestamp gate decides per-file.)
+  for (const [type, root] of [['story', storiesDir], ['session', sessionsDir]]) {
+    if (!existsSync(root)) continue;
+    for (const name of readdirSync(root)) {
+      if (!isTombstoned(type, name)) continue;
+      try { rmSync(join(root, name), { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }
 
   // Scan stories
   if (existsSync(storiesDir)) {

--- a/packages/hu-board/tests/ephemeral-cleaner.test.js
+++ b/packages/hu-board/tests/ephemeral-cleaner.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
+import fs from "node:fs";
 import {
   classifyEphemeral,
   findEphemeralProjects,
@@ -205,5 +206,39 @@ describe("cleanupEphemeralProjects (integration with in-memory SQLite)", () => {
     const cleaned = cleanupEphemeralProjects({ db, now: () => NOW });
     expect(cleaned.map((c) => c.id).sort()).toEqual(["demo_c", "test_b", "tmp_a"]);
     expect(db.prepare("SELECT id FROM projects").all().map((r) => r.id)).toEqual(["real_d"]);
+  });
+
+  // KJC-BUG-0055: cleanup must tombstone + rm-rf the on-disk artefacts,
+  // not just drop DB rows. Without this, the very next chokidar `add`
+  // (or the next boot's fullScan) would re-import the surviving files
+  // as a ghost project.
+  it("tombstones the project + its children AND removes their fs paths", () => {
+    insertProject({ id: "tmp_zombie", last_activity: ago(48) });
+    insertStory("story_x", "tmp_zombie");
+    insertSession("sess_x", "tmp_zombie");
+
+    const tombstoneCalls = [];
+    const tombstone = (type, id, opts) => tombstoneCalls.push({ type, id, opts });
+    const removedPaths = [];
+    const realRm = fs.rmSync;
+    fs.rmSync = (p) => { removedPaths.push(p); };
+    try {
+      cleanupEphemeralProjects({
+        db,
+        now: () => NOW,
+        tombstone,
+        kjHome: () => "/fake/home",
+      });
+    } finally {
+      fs.rmSync = realRm;
+    }
+
+    expect(tombstoneCalls.map((c) => `${c.type}:${c.id}`).sort()).toEqual([
+      "project:tmp_zombie",
+      "session:sess_x",
+      "story:story_x",
+    ]);
+    expect(removedPaths).toContain("/fake/home/hu-stories/story_x");
+    expect(removedPaths).toContain("/fake/home/sessions/sess_x");
   });
 });

--- a/packages/hu-board/tests/tombstones.test.js
+++ b/packages/hu-board/tests/tombstones.test.js
@@ -84,13 +84,15 @@ describe('tombstones — sync.* skip + cleanup', () => {
       id: batchId, session_id: batchId, project_id: projectId, stories,
     }));
   }
-  function writePlan(projectSlug, planId) {
+  function writePlan(projectSlug, planId, { updatedAt = null, projectDir = '/some/path' } = {}) {
     const dir = join(tmpDir, '.kj', 'plans', projectSlug);
     mkdirSync(dir, { recursive: true });
     const file = join(dir, `plan-${planId}.json`);
-    writeFileSync(file, JSON.stringify({
-      version: 2, planId, projectDir: '/some/path', hus: [{ id: 'hu_1', title: 't' }],
-    }));
+    const payload = {
+      version: 2, planId, projectDir, hus: [{ id: 'hu_1', title: 't' }],
+    };
+    if (updatedAt) payload.updatedAt = updatedAt;
+    writeFileSync(file, JSON.stringify(payload));
     return file;
   }
 
@@ -116,22 +118,35 @@ describe('tombstones — sync.* skip + cleanup', () => {
     expect(existsSync(planPath)).toBe(false);
   });
 
-  // KJC-BUG-0050: tombstone de proyecto NO debe bloquear nuevos planes.
-  // Cuando el usuario borra un proyecto desde el board (🗑️ Delete project)
-  // y luego lanza `kj plan` otra vez en el mismo projectDir, el plan
-  // nuevo (con planId distinto del que estaba al borrar) DEBE sobrevivir
-  // al sync. El tombstone del proyecto se reabsorbe.
-  // El `projectId` se deriva de `data.projectDir` con la misma regla que
-  // `deriveProjectIdFromDir` — `/some/path` → `some_path`.
-  it('syncPlanFile resurrects a tombstoned project when a NEW plan arrives', () => {
-    const planPath = writePlan('some_path', 'plan-NEW');
+  // KJC-BUG-0055 (supersedes KJC-BUG-0050): la resurrección de un proyecto
+  // tombstoned requiere que el plan sea MÁS NUEVO que el tombstone. Un plan
+  // con timestamp posterior al delete es "el usuario lanzó kj plan después
+  // de borrar"; ese sí revive. Un plan sin timestamp o anterior al delete
+  // es basura stale en disco y NO debe resucitar nada.
+  it('syncPlanFile resurrects a tombstoned project ONLY when plan.updatedAt > tombstone.deleted_at', () => {
     dbMod.addTombstone('project', 'some_path');
-    expect(dbMod.isTombstoned('project', 'some_path')).toBe(true);
+    const tomb = dbMod.getTombstone('project', 'some_path');
+    const newer = new Date(Date.parse(tomb.deleted_at) + 60_000).toISOString();
+    const planPath = writePlan('some_path', 'plan-NEW', { updatedAt: newer });
     syncMod.fullScan();
-    // El plan sobrevive en disco
     expect(existsSync(planPath)).toBe(true);
-    // El tombstone del proyecto se ha borrado
     expect(dbMod.isTombstoned('project', 'some_path')).toBe(false);
+  });
+
+  // Stale plan (older timestamp OR no timestamp) must NOT resurrect a
+  // tombstoned project — that was the regression in v2.13 dogfooding.
+  it.each([
+    ['older', () => new Date(Date.now() - 3_600_000).toISOString()],
+    ['absent', () => null],
+  ])('syncPlanFile does NOT resurrect when plan.updatedAt is %s', (_label, mkTs) => {
+    const opts = {};
+    const ts = mkTs();
+    if (ts) opts.updatedAt = ts;
+    const planPath = writePlan('some_path', `plan-${_label}`, opts);
+    dbMod.addTombstone('project', 'some_path');
+    syncMod.fullScan();
+    expect(existsSync(planPath)).toBe(false);
+    expect(dbMod.isTombstoned('project', 'some_path')).toBe(true);
   });
 
   // El tombstone del PLAN sigue respetándose aunque el proyecto NO esté tombstoned.
@@ -142,6 +157,22 @@ describe('tombstones — sync.* skip + cleanup', () => {
     expect(existsSync(planPath)).toBe(false);
     // El plan permanece tombstoned tras el sync.
     expect(dbMod.isTombstoned('plan', 'plan-dead')).toBe(true);
+  });
+
+  // KJC-BUG-0055: orphan hu-stories/<id>/ and sessions/<id>/ dirs with
+  // a tombstone (but no DB row — typical after a manual DB wipe) MUST
+  // be rm-rfed by fullScan before the per-file scan; otherwise they
+  // re-enter as ghost projects.
+  it('fullScan rm-rfs tombstoned hu-stories + sessions dirs at boot', () => {
+    writeStory('ghost-batch', 'ghost-proj');
+    const sessDir = join(tmpDir, 'sessions', 'ghost-sess');
+    mkdirSync(sessDir, { recursive: true });
+    writeFileSync(join(sessDir, 'session.json'), JSON.stringify({ id: 'ghost-sess' }));
+    dbMod.addTombstone('story', 'ghost-batch');
+    dbMod.addTombstone('session', 'ghost-sess');
+    syncMod.fullScan();
+    expect(existsSync(join(tmpDir, 'hu-stories', 'ghost-batch'))).toBe(false);
+    expect(existsSync(sessDir)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Cierra cuatro fugas independientes que hacían que un proyecto borrado del board (botón 🗑️) reapareciera al ejecutar `kj plan` o al reiniciar el board:

1. **sync.js: gate temporal** — el `removeTombstone('project', ...)` incondicional añadido por KJC-BUG-0050 se sustituye por una comparación `plan.updatedAt > tombstone.deleted_at`. Solo revive si el plan es genuinamente posterior al delete; planes stale en disco se ignoran y se borran.
2. **ephemeral-cleaner.js: tombstone + fs cleanup** — al borrar proyectos ephemeral al boot (`s_*`, `plan-*`, `tmp_*`, …), ahora añade tombstone y rm-rf de `hu-stories/<id>/`, `sessions/<id>/`, `~/.kj/plans/<id>/`. Antes solo borraba en DB.
3. **sync.js::fullScan: GC al boot** — barre dirs huérfanos tombstoneados (caso "wipe manual de DB").
4. **routes/api.js DELETE /api/projects/:id**: respeta `KJ_PLANS_DIR` en lugar del path hardcodeado.

Nueva helper `getTombstone(type, id)` en `db.js`.

## Repro (cómo cazamos el bug)

1. `kj board` → vacío.
2. `cd ~/demo/kanban-app && kj plan` → genera plan, board muestra 1 proyecto.
3. Si hay restos en `~/.karajan/hu-stories/` o `~/.karajan/sessions/` (de sesiones previas no terminadas), aparecen 2-3 proyectos extra "zombi".
4. `~/.karajan/hu-board.log` contiene la prueba directa: `Project home_manu_ws_firebase_greta-app was tombstoned but a new plan ... arrived — reviving (removing project tombstone)`.

## Test plan

- [x] `tests/tombstones.test.js`: 3 tests nuevos cubriendo el gate temporal (revive con plan más nuevo, no revive con plan más antiguo o sin timestamp) + 1 test para el GC del fullScan.
- [x] `tests/ephemeral-cleaner.test.js`: 1 test que verifica tombstone + fs rm en la limpieza ephemeral.
- [x] 342/342 tests del paquete `hu-board` en verde.
- [ ] Dogfooding: borrar proyecto del board → ejecutar `kj plan` en mismo `projectDir` con plan más nuevo → el proyecto revive una sola vez (correcto), no de forma silenciosa-y-repetida.
- [ ] Dogfooding: borrar proyecto + dejar plan stale en disco → el plan stale NO resucita el proyecto.

## LOC delta

195 added / 38 removed / **net +157**. Bajo el límite de 200 del shrink-budget.

## Refs

- Card PG: `KJC-BUG-0055`
- Supersedes parcialmente: KJC-BUG-0050 (la lógica de auto-resurrect se vuelve condicional, no se elimina)