### PR TITLE
ci: run the hu-board package test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,16 @@ jobs:
 
       - name: Run tests
         run: npx vitest run --reporter=default --reporter=github-actions
+
+      # The hu-board package ships its own package.json + vitest config,
+      # and the root vitest run excludes packages/** — so without these
+      # two steps its test suite never runs in CI. Regression cover for
+      # the 2026-05 dogfooding where a broken packages/hu-board change
+      # would have passed CI unnoticed.
+      - name: Install hu-board package dependencies
+        run: npm ci
+        working-directory: packages/hu-board
+
+      - name: Run hu-board package tests
+        run: npx vitest run --reporter=default --reporter=github-actions
+        working-directory: packages/hu-board


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml`'s `test` job runs `npm ci` + `npx vitest run` at the repo root only. The root vitest config **excludes `packages/**`**, and `packages/hu-board` has its own `package.json` (with `better-sqlite3`, `express`, `helmet`, …) and vitest config.

Result: the **~344 tests under `packages/hu-board/tests/` never run in CI**. A broken change inside `packages/hu-board/` would pass CI unnoticed — exactly the gap surfaced while shipping #753 (the silent board-start fix), whose `server-daemon-guard.test.js` lives in that package.

## Fix

Two extra steps in the `test` job (runs on the existing Node 20.x / 22.x matrix):

- `npm ci` in `packages/hu-board` — installs the package's own deps.
- `npx vitest run` in `packages/hu-board` — runs its suite.

## Verification

This PR's own CI run is the proof: the new **Run hu-board package tests** step now executes the package suite. Locally: 28 files / 344 tests passing.