### PR TITLE
fix(brain): classify Claude Code session limit as a recoverable quota

### DIFF
--- a/src/brain/agent-error-classifier.js
+++ b/src/brain/agent-error-classifier.js
@@ -33,7 +33,11 @@ const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 const AUTH_PATTERNS = /\b401\b|\b403\b|unauthorized|invalid\s+api\s+key|authentication\s+failed|expired\s+token/i;
 const SILENCED_PATTERNS = /killed\s+after\s+\d+\s*ms|silence\s*timeout|no\s+output\s+for\s+\d+/i;
-const RATE_LIMIT_PATTERNS = /usage\s+limit|rate\s*limit|too\s+many\s+requests|\b429\b|throttl|exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached|monthly\s+limit|daily\s+limit/i;
+// `session\s+limit` / `weekly\s+limit` cover Claude Code's usage caps
+// ("You've hit your session limit · resets 10:10pm"). Without them the
+// message fell through to UNKNOWN_FATAL and the run aborted instead of
+// hibernating until the reset.
+const RATE_LIMIT_PATTERNS = /usage\s+limit|rate\s*limit|too\s+many\s+requests|\b429\b|throttl|exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached|monthly\s+limit|weekly\s+limit|daily\s+limit|session\s+limit/i;
 const API_DOWN_PATTERNS = /\b50[0-4]\b|bad\s+gateway|service\s+unavailable|gateway\s+timeout|overloaded|internal\s+server\s+error/i;
 const NETWORK_PATTERNS = /ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket\s+hang\s+up|fetch\s+failed|network\s+error/i;
 

--- a/src/utils/rate-limit-detector.js
+++ b/src/utils/rate-limit-detector.js
@@ -39,6 +39,26 @@ export function parseCooldown(message) {
     }
   }
 
+  // 5. Claude Code session / weekly limit: "resets 10:10pm" / "resets 4am"
+  //    (12-hour clock, no date). Resolve to the next wall-clock occurrence
+  //    of that time in the machine's local timezone. Claude Code reports
+  //    the reset in the user's local TZ and kj runs on the same machine,
+  //    so the parenthesised "(Europe/Madrid)" hint is ignored on purpose.
+  const ampmMatch = /reset(?:s|ting)?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap]m)\b/i.exec(
+    message
+  );
+  if (ampmMatch) {
+    let hour = Number.parseInt(ampmMatch[1], 10) % 12;
+    if (/pm/i.test(ampmMatch[3])) hour += 12;
+    const minute = ampmMatch[2] ? Number.parseInt(ampmMatch[2], 10) : 0;
+    if (hour < 24 && minute < 60) {
+      const target = new Date();
+      target.setHours(hour, minute, 0, 0);
+      if (target.getTime() <= Date.now()) target.setDate(target.getDate() + 1);
+      return { cooldownUntil: target.toISOString(), cooldownMs: target.getTime() - Date.now() };
+    }
+  }
+
   // 2. Relative seconds: "retry after 120 seconds" / "retry in 120s" / "Retry-After: 120"
   const secMatch = /(?:retry[\s-]*after|retry\s+in|wait)\s*:?\s*(\d+)\s*(?:seconds?|secs?|s\b)/i.exec(
     message
@@ -69,6 +89,8 @@ const RATE_LIMIT_PATTERNS = [
   { pattern: /usage limit/i, agent: "claude" },
   { pattern: /plan's usage limit/i, agent: "claude" },
   { pattern: /Claude Pro usage limit/i, agent: "claude" },
+  { pattern: /session limit/i, agent: "claude" },
+  { pattern: /weekly limit/i, agent: "claude" },
 
   // OpenAI / Codex CLI
   { pattern: /exceeded your current quota/i, agent: "codex" },

--- a/tests/brain/agent-error-classifier.test.js
+++ b/tests/brain/agent-error-classifier.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { classifyAgentError, ERROR_CLASS } from "../../src/brain/agent-error-classifier.js";
 
 // KJC-TSK-0411: clasificación rica de errores de agente para que Brain
@@ -139,5 +139,41 @@ describe("classifyAgentError — provider passthrough", () => {
   it("preserva el provider en la salida", () => {
     const r = classifyAgentError({ provider: "opencode", stderr: "429 rate limit", exitCode: 1 });
     expect(r.provider).toBe("opencode");
+  });
+});
+
+// Regression for the 2026-05-22 dogfooding: Claude Code's
+// "You've hit your session limit · resets <time>" reached UNKNOWN_FATAL
+// (abort) because the rate-limit regex lacked "session limit". It must
+// classify as a recoverable quota class so Brain hibernates.
+describe("classifyAgentError — Claude Code session limit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T17:24:00"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("'hit your session limit · resets 10:10pm' → QUOTA_EXHAUSTED_DAILY, recoverable", () => {
+    const r = classifyAgentError({
+      provider: "claude",
+      stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
+      exitCode: 1,
+    });
+    expect(r.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
+    expect(r.recoverable).toBe(true);
+    // > 1h until the 22:10 reset → Brain hibernates instead of aborting.
+    expect(r.retryAfter).toBeGreaterThan(60 * 60 * 1000);
+    expect(r.retryUntil).toBeTruthy();
+  });
+
+  it("is no longer misclassified as UNKNOWN_FATAL", () => {
+    const r = classifyAgentError({
+      provider: "claude",
+      stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
+      exitCode: 1,
+    });
+    expect(r.class).not.toBe(ERROR_CLASS.UNKNOWN_FATAL);
   });
 });

--- a/tests/rate-limit-detector.test.js
+++ b/tests/rate-limit-detector.test.js
@@ -293,3 +293,45 @@ describe("parseCooldown", () => {
     expect(result.cooldownUntil).toBe("2026-03-07T11:00:00.000Z");
   });
 });
+
+describe("parseCooldown — 12-hour clock (Claude Code session limit)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-22T17:24:00"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("parses 'resets 10:10pm' to 22:10 the same day", () => {
+    const { cooldownUntil, cooldownMs } = parseCooldown(
+      "You've hit your session limit · resets 10:10pm (Europe/Madrid)"
+    );
+    const target = new Date(cooldownUntil);
+    expect(target.getHours()).toBe(22);
+    expect(target.getMinutes()).toBe(10);
+    expect(cooldownMs).toBeGreaterThan(0);
+  });
+
+  it("rolls over to the next day when the reset time already passed", () => {
+    vi.setSystemTime(new Date("2026-05-22T23:00:00"));
+    const { cooldownUntil } = parseCooldown("resets 10:10pm");
+    expect(new Date(cooldownUntil).getDate()).toBe(23);
+  });
+
+  it("handles the hour-only form 'resets 4am'", () => {
+    const { cooldownUntil } = parseCooldown("your limit resets 4am");
+    expect(new Date(cooldownUntil).getHours()).toBe(4);
+  });
+});
+
+describe("detectRateLimit — Claude Code session limit", () => {
+  it("detects 'hit your session limit' as a Claude rate limit", () => {
+    const result = detectRateLimit({
+      stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
+      stdout: "",
+    });
+    expect(result.isRateLimit).toBe(true);
+    expect(result.agent).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Problem

A teammate's `kj run` hit Claude Code's usage cap and **aborted the HU** instead of hibernating:

```
[brain] coder (claude) → UNKNOWN_FATAL attempt 1/0: You've hit your session limit · resets 10:10pm (Europe/Madrid)
HU ... status → failed
HU ... threw: Coder failed: Brain aborted: UNKNOWN_FATAL — You've hit your session limit
```

Brain Recovery (v2.15.0) is supposed to hibernate to `~/.kj/standby/` until the quota resets. It didn't — two encheained gaps:

1. **`agent-error-classifier.js`** — `RATE_LIMIT_PATTERNS` had `usage limit`, `monthly limit`, `daily limit`… but **not `session limit`**. Claude Code's current cap message ("hit your **session limit**") matched nothing → fell through to `UNKNOWN_FATAL` → `recoverable: false` → `abort`.
2. **`rate-limit-detector.js` `parseCooldown`** — even once matched, it could not parse the **12-hour `resets 10:10pm`** form (it only knew ISO timestamps and `HH:MM UTC`). `retryAfter` stayed `null`, and `withBrainRecovery` only hibernates when `retryAfter > 5min` — so it would still not hibernate.

## Fix

- **`agent-error-classifier.js`** — add `session limit` and `weekly limit` to `RATE_LIMIT_PATTERNS`.
- **`rate-limit-detector.js`** — `parseCooldown` learns the 12-hour clock: `resets 10:10pm` / `resets 4am` → resolved to the next wall-clock occurrence in the machine's local timezone (the `(Europe/Madrid)` hint is ignored on purpose — Claude Code reports in the user's local TZ and `kj` runs on the same machine). `detectRateLimit` also recognises the message.

Result: the error now classifies as `QUOTA_EXHAUSTED_DAILY` with a real `retryUntil`, so the Brain **hibernates until the reset** instead of failing the HU.

## Tests

- `agent-error-classifier.test.js` — session-limit message → `QUOTA_EXHAUSTED_DAILY`, `recoverable`, `retryAfter > 1h`; explicitly asserts it is no longer `UNKNOWN_FATAL`.
- `rate-limit-detector.test.js` — `parseCooldown` 12-hour parsing, next-day rollover, hour-only form; `detectRateLimit` recognises the message. Deterministic via `vi.setSystemTime`.

Net +104 LOC. Full classifier + detector + with-brain-recovery suites green locally (82 tests).