### PR TITLE
fix(brain): persist sessionState so hibernating runs can be resumed

### DIFF
--- a/src/brain/standby-store.js
+++ b/src/brain/standby-store.js
@@ -60,6 +60,42 @@ export function persistStandby(state) {
   return file;
 }
 
+// Only these env vars are carried into the standby snapshot. NEVER
+// persist the whole `process.env` — that would leak API keys and other
+// secrets into ~/.kj/standby/*.json. `kj standby resume` re-spawns with
+// the live env merged on top, so the snapshot only needs what is needed
+// to relaunch from the right place.
+const STANDBY_ENV_ALLOWLIST = ["KJ_HOME", "HOME", "PATH"];
+
+/**
+ * Builds the `sessionState` object that `withBrainRecovery` persists when
+ * a run hibernates. Pulls the session id, the relaunch metadata and an
+ * allowlisted env subset so `kj standby resume` can re-spawn the command.
+ * @param {object} args
+ * @param {object} args.session    - the pipeline session ({ id, plan_id? })
+ * @param {object} [args.config]   - resolved config ({ projectDir?, plan? })
+ * @param {string|null} [args.huId]
+ * @returns {object|null} sessionState, or null when there is no session id
+ */
+export function buildStandbyState({ session, config = {}, huId = null } = {}) {
+  if (!session?.id) return null;
+  const env = {};
+  for (const key of STANDBY_ENV_ALLOWLIST) {
+    if (process.env[key] != null) env[key] = process.env[key];
+  }
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("KJ_") && value != null) env[key] = value;
+  }
+  return {
+    sessionId: session.id,
+    planId: session.plan_id || config.plan || null,
+    huId: huId || null,
+    argv: process.argv.slice(2),
+    cwd: config.projectDir || process.cwd(),
+    env,
+  };
+}
+
 /**
  * @param {string} sessionId
  * @returns {object|null}

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -11,6 +11,7 @@ import { applyReviewerFeedback, applyFixerPatch } from "../../plan/plan-fixer.js
 import { runStructuralPass } from "../../plan/plan-structural-pass.js";
 import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-router.js";
 import { withBrainRecovery } from "../../brain/with-brain-recovery.js";
+import { buildStandbyState } from "../../brain/standby-store.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -64,11 +65,19 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   try {
     // KJC-TSK-0413: planner inicial pasa por Brain Recovery — clasifica
     // 401/429/5xx/SILENCED/etc y decide retry/standby/hibernate/abort.
+    // `kj plan` has no pipeline session, so synthesise a standby id
+    // (`plan_<stamp>`). If the planner hits a quota cap, withBrainRecovery
+    // persists it and `kj standby resume` re-spawns via the saved argv.
+    const plannerSessionState = buildStandbyState({
+      session: { id: `plan_${new Date().toISOString().replaceAll(/[:.]/g, "-")}` },
+      config,
+    });
     result = await withBrainRecovery({
       agent: planner,
       taskArgs: { prompt, role: "planner", silenceTimeoutMs, timeoutMs, onOutput: progress.onOutput },
       role: "planner",
       logger,
+      sessionState: plannerSessionState,
     });
     progress.finish(result.ok ? "done" : (result.action || "failed"));
   } catch (err) {

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -18,6 +18,7 @@ import { runCoderWithFallback } from "../agent-fallback.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
+import { buildStandbyState } from "../../brain/standby-store.js";
 import { snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage, verifyLeaksAgainstTranscript, detectTranscriptCdLeaks } from "../fs-leak-detector.js";
 
 export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
@@ -66,7 +67,10 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       // the plan, the rest are scoped to this HU. All four pass through
       // untouched when the caller omits them (legacy single-task runs).
       adrs, specSection, reviewerFindings, huId,
-      onOutput: coderStall.onOutput
+      onOutput: coderStall.onOutput,
+      // Lets Brain Recovery persist a standby snapshot if the coder's
+      // provider hits a quota cap mid-run (KJC hibernation wiring).
+      sessionState: buildStandbyState({ session, config, huId }),
     });
   } finally {
     coderStall.stop();

--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -130,6 +130,11 @@ export class AgentRole extends BaseRole {
       provider,
       emitter: this.emitter,
       logger: this.logger,
+      // KJC: sessionState lets withBrainRecovery persist a hibernating run
+      // to ~/.kj/standby/ so it can be resumed. Without it a quota-exhausted
+      // run had nothing to resume from. Caller (coder-stage etc.) passes it
+      // through the input object; extractInput forwards it via `...input`.
+      sessionState: extracted.sessionState || this.context?.sessionState || null,
     });
 
     if (!result.ok) {

--- a/tests/brain/standby-store.test.js
+++ b/tests/brain/standby-store.test.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   persistStandby, loadStandby, listPendingStandby,
   markStandbyDone, acquireStandbyLock, standbyDir, standbyDoneDir,
+  buildStandbyState,
 } from "../../src/brain/standby-store.js";
 
 // KJC-TSK-0414 PR 1: persistencia de sesiones hibernadas al disco.
@@ -110,5 +111,38 @@ describe("acquireStandbyLock", () => {
     const b = acquireStandbyLock("s6");
     expect(b.acquired).toBe(true);
     b.release();
+  });
+});
+
+describe("buildStandbyState", () => {
+  it("devuelve null cuando no hay session.id", () => {
+    expect(buildStandbyState({ session: {} })).toBeNull();
+    expect(buildStandbyState({})).toBeNull();
+  });
+
+  it("incluye sessionId, planId, huId, cwd y argv", () => {
+    const state = buildStandbyState({
+      session: { id: "s_x", plan_id: "plan-7" },
+      config: { projectDir: "/tmp/proj" },
+      huId: "hu_3",
+    });
+    expect(state.sessionId).toBe("s_x");
+    expect(state.planId).toBe("plan-7");
+    expect(state.huId).toBe("hu_3");
+    expect(state.cwd).toBe("/tmp/proj");
+    expect(Array.isArray(state.argv)).toBe(true);
+  });
+
+  it("solo copia env allowlisted + KJ_* — nunca secretos arbitrarios", () => {
+    process.env.KJ_CUSTOM_FLAG = "kj-value";
+    process.env.SECRET_API_KEY = "do-not-leak";
+    try {
+      const state = buildStandbyState({ session: { id: "s_x" } });
+      expect(state.env.KJ_CUSTOM_FLAG).toBe("kj-value");
+      expect(state.env).not.toHaveProperty("SECRET_API_KEY");
+    } finally {
+      delete process.env.KJ_CUSTOM_FLAG;
+      delete process.env.SECRET_API_KEY;
+    }
   });
 });

--- a/tests/brain/with-brain-recovery.test.js
+++ b/tests/brain/with-brain-recovery.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import { withBrainRecovery, DEFAULT_RECOVERY_POLICY } from "../../src/brain/with-brain-recovery.js";
 
 // KJC-TSK-0412: Brain decide retry/standby/hibernate/abort según clase.
@@ -67,6 +68,33 @@ describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
     // Debe haber emitido la señal de hibernate-request
     const hibernateEvent = emit.mock.calls.find(([_evt, payload]) => payload?.type === "brain:hibernate-request");
     expect(hibernateEvent).toBeTruthy();
+  });
+
+  it("con sessionState persiste el standby a disco y devuelve standbyFile", async () => {
+    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    const agent = makeAgent([
+      { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
+    ]);
+    const sessionState = {
+      sessionId: "s_test-hibernate", argv: ["run", "build a thing"], cwd: "/tmp/proj", env: {},
+    };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sessionState, sleepFn: noSleep });
+    expect(r.action).toBe("hibernate");
+    expect(r.standbyFile).toBeTruthy();
+    const persisted = JSON.parse(readFileSync(r.standbyFile, "utf-8"));
+    expect(persisted.sessionId).toBe("s_test-hibernate");
+    expect(persisted.cooldownUntil).toBe(target);
+    expect(persisted.argv).toEqual(["run", "build a thing"]);
+  });
+
+  it("sin sessionState NO persiste (standbyFile null) — regresión del bug original", async () => {
+    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    const agent = makeAgent([
+      { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
+    ]);
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
+    expect(r.action).toBe("hibernate");
+    expect(r.standbyFile ?? null).toBeNull();
   });
 });
 


### PR DESCRIPTION
**Phase 1 (PR 1/4)** of the resilience audit — wiring quota-exhaustion hibernation end to end.

## Problem
`withBrainRecovery` already classifies a quota cap as `QUOTA_EXHAUSTED_DAILY` and returns `action:"hibernate"`, and it persists `~/.kj/standby/<id>.json` — **but only when given a `sessionState`**. `agent-role.js` (every role) and `plan/generate.js` (the planner) called it **without one**, so a hibernating run had nothing on disk to resume from.

## Changes
- **`standby-store.js`** — new `buildStandbyState()`: assembles `sessionId` + relaunch metadata (`argv`, `cwd`) + an **allowlisted** env subset (`KJ_*`, `HOME`, `PATH` only — never the full `process.env`, which would leak API keys into the standby JSON).
- **`agent-role.js`** — forwards `sessionState` to `withBrainRecovery` (covers every role inheriting `AgentRole`).
- **`coder-stage.js`** — builds `sessionState` from the live `session`/`config`/`huId`.
- **`plan/generate.js`** — synthesises a `plan_<stamp>` `sessionState` (a `kj plan` run has no pipeline session).

## Scope
This PR only makes hibernation **persist**. Consuming `action:"hibernate"` so the orchestrator stops cleanly (instead of marking the HU `failed`) is **PR 2/4**; `kj plan` handling and the resume-hint message are PR 3 and 4.

## Tests
- `with-brain-recovery.test.js` — quota + `sessionState` → `standbyFile` written, JSON contains `cooldownUntil` + `argv`; **without** `sessionState` → `standbyFile` null (regression guard).
- `standby-store.test.js` — `buildStandbyState`: null without session id; fields populated; env allowlist drops `SECRET_API_KEY`, keeps `KJ_*`.

Net +116 LOC.