### PR TITLE
fix(brain): stop the run cleanly when a stage hibernates

### DIFF
--- a/src/orchestrator/drivers/iteration-phases/coder-and-refactorer.js
+++ b/src/orchestrator/drivers/iteration-phases/coder-and-refactorer.js
@@ -18,6 +18,25 @@ import { stageRegistry } from "../../stages/stage-classes.js";
 import { runStage } from "../../stages/stage-executor.js";
 import { handleStandbyResult } from "../error-recovery.js";
 
+/**
+ * A coder/refactorer stage hit a provider quota cap and Brain Recovery
+ * hibernated the run. Turn it into a clean loop return carrying
+ * `hibernated:true` — the iteration loop and flow-runner read that to
+ * seal the session as `hibernated` (NOT `failed`) so it stays resumable.
+ */
+function hibernateReturn(stageResult, session) {
+  return {
+    action: "return",
+    result: {
+      hibernated: true,
+      sessionId: session?.id || null,
+      reason: "quota_exhausted",
+      standbyFile: stageResult.standbyFile || null,
+      recovery: stageResult.recovery || null,
+    },
+  };
+}
+
 export async function runCoderAndRefactorerStages({ coderRoleInstance, coderRole, refactorerRole, pipelineFlags, config, logger, emitter, eventBase, session, plannedTask, trackBudget, i, brainCtx }) {
   // Coder via StageRegistry (TSK-0336). canRun = coderRequired !== false; in
   // analysis-only task types coderRequired is set to false by policy, so the
@@ -25,6 +44,7 @@ export async function runCoderAndRefactorerStages({ coderRoleInstance, coderRole
   // runFlow.
   const coderCtx = { coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i, brainCtx, pipelineFlags };
   const coderResult = await runStage(stageRegistry.get("coder"), coderCtx);
+  if (coderResult?.action === "hibernate") return hibernateReturn(coderResult, session);
   if (coderResult?.action === "pause") return { action: "return", result: coderResult.result };
   const coderStandby = await handleStandbyResult({ stageResult: coderResult, session, emitter, eventBase, i, stage: "coder", logger, config });
   if (coderStandby.handled) {
@@ -35,6 +55,7 @@ export async function runCoderAndRefactorerStages({ coderRoleInstance, coderRole
 
   if (pipelineFlags.refactorerEnabled) {
     const refResult = await runRefactorerStage({ refactorerRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration: i });
+    if (refResult?.action === "hibernate") return hibernateReturn(refResult, session);
     if (refResult?.action === "pause") return { action: "return", result: refResult.result };
     const refStandby = await handleStandbyResult({ stageResult: refResult, session, emitter, eventBase, i, stage: "refactorer", logger, config });
     if (refStandby.handled) {

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -74,6 +74,7 @@ import { runSecurityStage, runFinalAuditStage } from "./post-loop-stages.js";
  *   approved → "approved"
  *   paused   → "paused"
  *   cancelled → "cancelled"
+ *   hibernated → "hibernated"
  *   anything else → "failed"
  *
  * Idempotent: only writes when the current status is still "running"
@@ -95,6 +96,10 @@ export async function sealSessionStatusIfStillRunning(session, result) {
     if (result?.approved === true) target = "approved";
     else if (result?.paused === true) target = "paused";
     else if (result?.cancelled === true) target = "cancelled";
+    // A run hibernated on a provider quota cap is NOT a failure — it is
+    // suspended and resumable via `kj standby resume`. Sealing it as
+    // `failed` would let the HU-zombie reaper treat it as dead work.
+    else if (result?.hibernated === true) target = "hibernated";
     await markSessionStatus(session, target);
   } catch { /* non-blocking */ }
 }

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -79,6 +79,21 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
 
   if (!coderExecResult.ok) {
     const details = coderExecResult.result?.error || coderExecResult.summary || "unknown error";
+    // Quota cap → Brain Recovery already hibernated the run and persisted
+    // the standby snapshot. Stop the stage cleanly: no fallback, no
+    // Solomon. The caller turns this into a clean run halt; the HU is NOT
+    // marked failed — it resumes via `kj standby resume`.
+    if (coderExecResult.result?.action === "hibernate") {
+      emitProgress(emitter, makeEvent("coder:hibernate", { ...eventBase, stage: "coder" }, {
+        message: "Coder hibernated — provider quota exhausted, run can be resumed",
+        detail: { standbyFile: coderExecResult.result?.standbyFile || null }
+      }));
+      return {
+        action: "hibernate",
+        standbyFile: coderExecResult.result?.standbyFile || null,
+        recovery: coderExecResult.result?.recovery || null,
+      };
+    }
     const rateLimitCheck = detectRateLimit({
       stderr: coderExecResult.result?.error || "",
       stdout: coderExecResult.result?.output || ""
@@ -249,13 +264,28 @@ export async function runRefactorerStage({ refactorerRole, config, logger, emitt
   const refactorerStart = Date.now();
   let refResult;
   try {
-    refResult = await refRole.execute({ task: plannedTask, onOutput: refactorerStall.onOutput });
+    refResult = await refRole.execute({
+      task: plannedTask, onOutput: refactorerStall.onOutput,
+      sessionState: buildStandbyState({ session, config }),
+    });
   } finally {
     refactorerStall.stop();
   }
   trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refResult.result, duration_ms: Date.now() - refactorerStart });
   if (!refResult.ok) {
     const details = refResult.result?.error || refResult.summary || "unknown error";
+    // Quota cap → hibernate cleanly, same as the coder stage above.
+    if (refResult.result?.action === "hibernate") {
+      emitProgress(emitter, makeEvent("refactorer:hibernate", { ...eventBase, stage: "refactorer" }, {
+        message: "Refactorer hibernated — provider quota exhausted, run can be resumed",
+        detail: { standbyFile: refResult.result?.standbyFile || null }
+      }));
+      return {
+        action: "hibernate",
+        standbyFile: refResult.result?.standbyFile || null,
+        recovery: refResult.result?.recovery || null,
+      };
+    }
     const rateLimitCheck = detectRateLimit({
       stderr: refResult.result?.error || "",
       stdout: refResult.result?.output || ""

--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -141,7 +141,7 @@ export class AgentRole extends BaseRole {
       const recoveryNote = result.recovery?.class ? ` [${result.recovery.class}]` : "";
       return {
         ok: false,
-        result: { error: result.error || result.output || `${this.name} failed${recoveryNote}`, provider, recovery: result.recovery, action: result.action },
+        result: { error: result.error || result.output || `${this.name} failed${recoveryNote}`, provider, recovery: result.recovery, action: result.action, standbyFile: result.standbyFile || null },
         summary: `${this.name} failed${recoveryNote}: ${result.recovery?.message || result.error || "unknown error"}`,
         usage: result.usage
       };

--- a/tests/orchestrator/coder-and-refactorer-hibernate.test.js
+++ b/tests/orchestrator/coder-and-refactorer-hibernate.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Phase 1 (PR 2/4) of the resilience audit: when the coder or refactorer
+// stage hits a provider quota cap, Brain Recovery hibernates the run and
+// the stage returns `action:"hibernate"`. runCoderAndRefactorerStages must
+// turn that into a clean loop return carrying `hibernated:true` — so the
+// session is sealed `hibernated`, NOT `failed`, and stays resumable.
+
+vi.mock("../../src/orchestrator/stages/stage-executor.js", () => ({
+  runStage: vi.fn(),
+}));
+vi.mock("../../src/orchestrator/stages/stage-classes.js", () => ({
+  stageRegistry: { get: vi.fn(() => ({})) },
+}));
+vi.mock("../../src/orchestrator/iteration-stages.js", () => ({
+  runRefactorerStage: vi.fn(),
+}));
+vi.mock("../../src/orchestrator/drivers/error-recovery.js", () => ({
+  handleStandbyResult: vi.fn(async () => ({ handled: false })),
+}));
+
+const { runStage } = await import("../../src/orchestrator/stages/stage-executor.js");
+const { runRefactorerStage } = await import("../../src/orchestrator/iteration-stages.js");
+const { runCoderAndRefactorerStages } = await import(
+  "../../src/orchestrator/drivers/iteration-phases/coder-and-refactorer.js"
+);
+
+function baseArgs(overrides = {}) {
+  return {
+    coderRoleInstance: {}, coderRole: {}, refactorerRole: {},
+    pipelineFlags: { refactorerEnabled: false },
+    config: {}, logger: {}, emitter: null, eventBase: {},
+    session: { id: "s_quota" }, plannedTask: "do the thing",
+    trackBudget: () => {}, i: 1, brainCtx: {},
+    ...overrides,
+  };
+}
+
+describe("runCoderAndRefactorerStages — hibernation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("coder hibernate → { action:'return', result.hibernated:true }", async () => {
+    runStage.mockResolvedValue({
+      action: "hibernate", standbyFile: "/tmp/standby/s_quota.json",
+      recovery: { class: "QUOTA_EXHAUSTED_DAILY" },
+    });
+    const r = await runCoderAndRefactorerStages(baseArgs());
+    expect(r.action).toBe("return");
+    expect(r.result.hibernated).toBe(true);
+    expect(r.result.sessionId).toBe("s_quota");
+    expect(r.result.reason).toBe("quota_exhausted");
+    expect(r.result.standbyFile).toBe("/tmp/standby/s_quota.json");
+  });
+
+  it("refactorer hibernate is also turned into a clean return", async () => {
+    runStage.mockResolvedValue({ action: "ok" });
+    runRefactorerStage.mockResolvedValue({
+      action: "hibernate", standbyFile: "/tmp/standby/s_quota.json", recovery: {},
+    });
+    const r = await runCoderAndRefactorerStages(baseArgs({
+      pipelineFlags: { refactorerEnabled: true },
+    }));
+    expect(r.action).toBe("return");
+    expect(r.result.hibernated).toBe(true);
+  });
+
+  it("a normal coder result is unaffected (no hibernation)", async () => {
+    runStage.mockResolvedValue({ action: "ok" });
+    const r = await runCoderAndRefactorerStages(baseArgs());
+    expect(r.action).toBe("ok");
+  });
+});

--- a/tests/session/session-status-sealing.test.js
+++ b/tests/session/session-status-sealing.test.js
@@ -37,6 +37,12 @@ describe("sealSessionStatusIfStillRunning (KJC-BUG-0037)", () => {
     expect(markSessionStatus).toHaveBeenCalledWith(session, "paused");
   });
 
+  it("seals as 'hibernated' when result.hibernated is true (not 'failed')", async () => {
+    const session = { id: "s1", status: "running" };
+    await sealSessionStatusIfStillRunning(session, { hibernated: true, reason: "quota_exhausted" });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "hibernated");
+  });
+
   it("seals as 'cancelled' when result.cancelled is true", async () => {
     const session = { id: "s1", status: "running" };
     await sealSessionStatusIfStillRunning(session, { cancelled: true });


### PR DESCRIPTION
**Phase 1 (PR 2/4)** of the resilience audit.

## Problem
`withBrainRecovery` returns `action:"hibernate"` on a provider quota cap — but **no orchestrator code ever consumed it** (`grep` found consumers for `pause`/`retry`/`return`/`approve`/`subtask` — never `hibernate`). So a hibernation was indistinguishable from a generic failure: the HU got sealed `failed`, and PR 1's persisted standby snapshot was never acted on.

## Changes
- **`agent-role.js`** — propagate `standbyFile` in the failure result (was dropped).
- **`coder-stage.js`** — `runCoderStage` / `runRefactorerStage` detect `action:"hibernate"` **before** the legacy `detectRateLimit` path (no fallback, no Solomon) and return `{ action:"hibernate", standbyFile, recovery }`. The refactorer now also passes `sessionState` so it can persist a standby snapshot.
- **`coder-and-refactorer.js`** — `hibernateReturn()` turns a stage hibernation into a clean loop return carrying `{ hibernated:true, sessionId, reason:"quota_exhausted", standbyFile }`.
- **`flow-runner.js`** — `sealSessionStatusIfStillRunning` seals the session as `hibernated` (not `failed`), so the HU-zombie reaper won't treat it as dead work and it stays resumable.

## Scope
After PR 1 + PR 2, a quota-exhausted `kj run` **persists a standby snapshot and stops cleanly without failing the HU**. Still pending: `kj plan` hibernation handling (PR 3) and the final "how to resume" message (PR 4).

## Tests
- `coder-and-refactorer-hibernate.test.js` (new) — coder/refactorer `hibernate` → `{action:"return", result.hibernated:true}`; normal result unaffected.
- `session-status-sealing.test.js` — `result.hibernated` → sealed `hibernated`, not `failed`.

Net +134 LOC.