### PR TITLE
fix(cli): tell the user how to resume a stopped run

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -12,6 +12,7 @@ import { runStructuralPass } from "../../plan/plan-structural-pass.js";
 import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-router.js";
 import { withBrainRecovery } from "../../brain/with-brain-recovery.js";
 import { buildStandbyState } from "../../brain/standby-store.js";
+import { printResumeHint } from "../../utils/display/resume-hint.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -62,16 +63,16 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   // self-fix iter N por delante.
   const progress = createCliProgressReporter({ role: "planner:initial", quiet: Boolean(json) });
   let result;
+  // `kj plan` has no pipeline session, so synthesise a standby id
+  // (`plan_<stamp>`). If the planner hits a quota cap, withBrainRecovery
+  // persists it and `kj standby resume` re-spawns via the saved argv.
+  const plannerSessionState = buildStandbyState({
+    session: { id: `plan_${new Date().toISOString().replaceAll(/[:.]/g, "-")}` },
+    config,
+  });
   try {
     // KJC-TSK-0413: planner inicial pasa por Brain Recovery — clasifica
     // 401/429/5xx/SILENCED/etc y decide retry/standby/hibernate/abort.
-    // `kj plan` has no pipeline session, so synthesise a standby id
-    // (`plan_<stamp>`). If the planner hits a quota cap, withBrainRecovery
-    // persists it and `kj standby resume` re-spawns via the saved argv.
-    const plannerSessionState = buildStandbyState({
-      session: { id: `plan_${new Date().toISOString().replaceAll(/[:.]/g, "-")}` },
-      config,
-    });
     result = await withBrainRecovery({
       agent: planner,
       taskArgs: { prompt, role: "planner", silenceTimeoutMs, timeoutMs, onOutput: progress.onOutput },
@@ -85,6 +86,18 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     throw err;
   }
 
+  if (!result.ok && result.action === "hibernate") {
+    // Quota cap: Brain Recovery persisted a standby snapshot. Stop
+    // cleanly with a resume hint instead of throwing a generic error.
+    const hibResult = {
+      ok: false, hibernated: true,
+      sessionId: plannerSessionState?.sessionId || null,
+      standbyFile: result.standbyFile || null,
+    };
+    if (!json) printResumeHint(hibResult);
+    process.exitCode = 1;
+    return hibResult;
+  }
   if (!result.ok) throw new Error(result.error || result.output || "Planner failed");
 
   const parsed = parseMaybeJsonString(result.output);

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -7,6 +7,7 @@ import { withCliRunLog } from "../utils/cli-run-log.js";
 import { registerRun, unregisterRun } from "../utils/run-registry.js";
 import { printHeader } from "../utils/display/header.js";
 import { printEvent } from "../utils/display/event-handlers.js";
+import { printResumeHint } from "../utils/display/resume-hint.js";
 import { resolveRole } from "../config.js";
 import { parseCardId } from "../planning-game/adapter.js";
 import { confirmCwd } from "../utils/cwd-confirm.js";
@@ -175,6 +176,10 @@ export async function runCommandHandler({ task, config, logger, flags }) {
 
     if (jsonMode) {
       console.log(JSON.stringify(result, null, 2));
+    } else {
+      // Last line printed: if the run stopped (hibernated / paused /
+      // failed), tell the user the exact command to resume it.
+      printResumeHint(result);
     }
     return { ok: !result?.paused && result?.approved !== false };
   });

--- a/src/utils/display/resume-hint.js
+++ b/src/utils/display/resume-hint.js
@@ -1,0 +1,41 @@
+/**
+ * Prints — as the LAST line of a stopped `kj run` / `kj plan` — the exact
+ * command to resume it. A halted run that never tells you how to restart
+ * it is the resilience gap this closes (resilience audit, Phase 1).
+ *
+ *   Quota hibernation → `kj standby resume <id>`
+ *   Solomon pause     → `kj resume <id> --answer "..."`
+ *   Stopped / failed  → `kj resume <id>`
+ *   Success           → nothing.
+ *
+ * @param {object} result          - the flow / command result
+ * @param {object} [opts]
+ * @param {(line:string)=>void} [opts.print] - sink, default console.log
+ */
+export function printResumeHint(result, { print = console.log } = {}) {
+  if (!result || typeof result !== "object") return;
+  const id = result.sessionId || result.session?.id || null;
+
+  if (result.hibernated === true) {
+    print("");
+    print("⏸  Run hibernated — provider quota exhausted.");
+    print(`   Resume when the quota resets:  kj standby resume ${id || "<session-id>"}`);
+    if (!id) print("   (run `kj standby list` to find the id)");
+    return;
+  }
+
+  if (result.paused === true && id) {
+    print("");
+    print("⏸  Run paused — waiting for your input.");
+    print(`   Resume:  kj resume ${id} --answer "<your answer>"`);
+    return;
+  }
+
+  // Stopped / failed / aborted but with a session on record → resumable.
+  // A successful run has approved === true and prints nothing.
+  if (id && result.approved !== true && result.paused !== true) {
+    print("");
+    print("✗  Run stopped before finishing.");
+    print(`   Resume:  kj resume ${id}`);
+  }
+}

--- a/tests/utils/resume-hint.test.js
+++ b/tests/utils/resume-hint.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { printResumeHint } from "../../src/utils/display/resume-hint.js";
+
+// Phase 1 (PR 3+4/4) of the resilience audit: when a `kj run` / `kj plan`
+// stops, the LAST thing printed must be the exact command to resume it.
+
+function capture(result) {
+  const lines = [];
+  printResumeHint(result, { print: (l) => lines.push(l) });
+  return lines.join("\n");
+}
+
+describe("printResumeHint", () => {
+  it("hibernated → 'kj standby resume <id>'", () => {
+    expect(capture({ hibernated: true, sessionId: "s_2026" }))
+      .toContain("kj standby resume s_2026");
+  });
+
+  it("hibernated without id → placeholder + 'kj standby list' pointer", () => {
+    const out = capture({ hibernated: true });
+    expect(out).toContain("kj standby resume <session-id>");
+    expect(out).toContain("kj standby list");
+  });
+
+  it("paused → 'kj resume <id> --answer'", () => {
+    expect(capture({ paused: true, sessionId: "s_x" }))
+      .toContain('kj resume s_x --answer');
+  });
+
+  it("stopped/failed with a sessionId → 'kj resume <id>'", () => {
+    expect(capture({ approved: false, sessionId: "s_fail" }))
+      .toContain("kj resume s_fail");
+  });
+
+  it("a successful run prints nothing", () => {
+    expect(capture({ approved: true, sessionId: "s_ok" })).toBe("");
+  });
+
+  it("a failure with no session id prints nothing (nothing to resume blindly)", () => {
+    expect(capture({ approved: false })).toBe("");
+  });
+
+  it("tolerates a null / non-object result", () => {
+    expect(capture(null)).toBe("");
+    expect(capture(undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
**Phase 1 (PR 3+4/4)** of the resilience audit — closes the phase.

## Problem
- A stopped `kj run` / `kj plan` never told the user **how to restart it**. The user's explicit request: when a run stops, the last message should be the resume command.
- `kj plan` turned a planner quota cap into a generic **thrown error** (`Planner failed`), losing the `action:"hibernate"` signal.

## Changes
- **New `src/utils/display/resume-hint.js`** — `printResumeHint()`: prints, as the **last line**, the exact resume command:
  - hibernation → `kj standby resume <id>`
  - Solomon pause → `kj resume <id> --answer "..."`
  - any other stop with a session → `kj resume <id>`
  - a successful run prints nothing.
- **`run.js`** — calls `printResumeHint(result)` after `runFlow` (skipped in `--json` mode so stdout stays pure JSON).
- **`plan/generate.js`** — a planner quota cap no longer throws: returns `{ hibernated:true, sessionId, standbyFile }`, prints the resume hint, sets a non-zero exit code.

## Phase 1 complete
With PRs #757, #758 and this one, a quota-exhausted run now: **persists** a standby snapshot → **stops cleanly** without failing the HU → is sealed `hibernated` (resumable) → and **tells the user exactly how to resume it**. This is the real end-to-end fix for the teammate's `UNKNOWN_FATAL` abort.

## Tests
- `resume-hint.test.js` (new) — every result shape: hibernated (with/without id), paused, stopped, success (silent), no-id (silent), null-tolerant.

Net +106 LOC.