### PR TITLE
fix(process): surface spawn failures instead of an empty error

### DIFF
--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -152,6 +152,24 @@ export async function runCommand(command, args = [], options = {}) {
 function enrichResult(result, stdoutAccum, _stderrAccum) {
   if (result.timedOut) return result;
 
+  // execa with reject:false RESOLVES (does not throw) on a spawn
+  // failure — ENOENT (binary not in PATH), EACCES, etc. The result
+  // then carries exitCode null/undefined, an empty stderr, and the
+  // real cause only in `code` / `shortMessage`. Surface it: a missing
+  // agent CLI used to fail with a completely empty error message,
+  // leaving the user with "coder failed" and no idea what to install.
+  if (result.failed && result.exitCode == null && !result.signal) {
+    const reason = result.shortMessage || result.message
+      || `spawn failed${result.code ? ` (${result.code})` : ""}`;
+    return {
+      ...result,
+      exitCode: 1,
+      stdout: result.stdout || stdoutAccum,
+      stderr: result.stderr || reason,
+      spawnError: result.code || true,
+    };
+  }
+
   const killed = result.killed || !!result.signal;
   const signal = result.signal || null;
 

--- a/tests/process-spawn-failure.test.js
+++ b/tests/process-spawn-failure.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { runCommand } from "../src/utils/process.js";
+
+// Resilience audit, Phase 2: execa with reject:false resolves (not
+// throws) on a spawn failure. ENOENT used to come back with exitCode
+// undefined and an empty stderr, so a missing agent CLI failed with
+// no message at all. runCommand must always surface the cause.
+
+describe("runCommand — spawn failure (ENOENT)", () => {
+  it("surfaces a non-empty error and a real exit code when the binary is missing", async () => {
+    const res = await runCommand("kj-nonexistent-binary-xyz-123", ["--version"]);
+    expect(res.exitCode).toBe(1);
+    expect(typeof res.stderr).toBe("string");
+    expect(res.stderr.length).toBeGreaterThan(0);
+    expect(res.spawnError).toBe("ENOENT");
+  });
+
+  it("a binary that exists still reports its own exit code (no false ENOENT)", async () => {
+    const res = await runCommand("node", ["-e", "process.exit(3)"]);
+    expect(res.exitCode).toBe(3);
+    expect(res.spawnError).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Phase 2** of the resilience audit (PR 1/3).

## Problem
`runCommand` runs execa with `reject:false`, so a **spawn failure** (`ENOENT` — binary not in PATH — `EACCES`, …) **resolves** instead of throwing. The result then has `exitCode` `undefined` and an **empty `stderr`**, and `enrichResult` passed it straight through.

The 5 agent adapters all do `error: res.stderr`. So a missing agent CLI (claude/codex/gemini/aider/opencode not installed) failed `kj run` with a **completely empty error message** — the user saw "coder failed" with no cause and no hint of what to install.

## Fix
`enrichResult` now detects `failed && exitCode == null && !signal` (the spawn-failure shape), normalises `exitCode` to `1`, fills `stderr` from `shortMessage`/`code`, and exposes a `spawnError` field (e.g. `"ENOENT"`) so callers can give an install-aware message in a follow-up.

## Tests
- `process-spawn-failure.test.js` (new) — missing binary → `exitCode 1`, non-empty `stderr`, `spawnError:"ENOENT"`; a real binary still reports its own exit code (no false ENOENT).

Net +41 LOC.