### PR TITLE
fix(roles): kill a hung agent by forwarding silenceTimeoutMs

### DIFF
--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -17,6 +17,19 @@ import { BaseRole } from "./base-role.js";
 import { createAgent as defaultCreateAgent } from "../agents/index.js";
 import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
+/**
+ * Silence timeout (ms) for an agent subprocess, from
+ * config.session.max_agent_silence_minutes. runCommand kills a child
+ * that produces no output for this long — without it a hung coder /
+ * reviewer leaves `kj run` waiting forever. Returns null when unset.
+ * @param {object} config
+ * @returns {number|null}
+ */
+export function resolveAgentSilenceTimeoutMs(config) {
+  const minutes = Number(config?.session?.max_agent_silence_minutes);
+  return Number.isFinite(minutes) && minutes > 0 ? Math.round(minutes * 60 * 1000) : null;
+}
+
 export class AgentRole extends BaseRole {
   constructor({ name, config, logger, emitter = null, createAgentFn = null }) {
     super({ name, config, logger, emitter });
@@ -116,6 +129,11 @@ export class AgentRole extends BaseRole {
 
     const runArgs = { prompt, role: this.name };
     if (onOutput) runArgs.onOutput = onOutput;
+    // Kill a hung agent: without a silence timeout a coder / reviewer
+    // that stalls with no output left `kj run` waiting indefinitely.
+    // PlannerRole set this itself; every other role was unprotected.
+    const silenceTimeoutMs = resolveAgentSilenceTimeoutMs(this.config);
+    if (silenceTimeoutMs) runArgs.silenceTimeoutMs = silenceTimeoutMs;
 
     // KJC-TSK-0413 step B: TODAS las roles que heredan de AgentRole pasan
     // por Brain Recovery aquí — cubre AuditRole, SecurityRole, HuReviewerRole,

--- a/tests/coder/coder-role.test.js
+++ b/tests/coder/coder-role.test.js
@@ -256,4 +256,29 @@ describe("CoderRole", () => {
 
     expect(output.result.provider).toBe("claude");
   });
+
+  // Resilience audit, Phase 2: a hung agent (no output) must be killed.
+  // AgentRole.execute() now forwards silenceTimeoutMs — previously only
+  // PlannerRole did, so a stalled coder left `kj run` waiting forever.
+  it("forwards silenceTimeoutMs to the agent when configured", async () => {
+    const cfg = {
+      roles: { coder: { provider: "claude", model: null } },
+      coder: "claude",
+      development: { methodology: "tdd" },
+      session: { max_agent_silence_minutes: 5 },
+    };
+    const role = new CoderRole({ config: cfg, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockRunTask.mock.calls[0][0].silenceTimeoutMs).toBe(5 * 60 * 1000);
+  });
+
+  it("omits silenceTimeoutMs when max_agent_silence_minutes is not set", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Task" });
+
+    expect(mockRunTask.mock.calls[0][0].silenceTimeoutMs).toBeUndefined();
+  });
 });


### PR DESCRIPTION
**Phase 2** of the resilience audit (PR 2/3).

## Problem
`runCommand` already kills a child process that produces no output for `silenceTimeoutMs` — but **only `PlannerRole`** ever set it (it has its own `execute()`). Every other role inherits `AgentRole.execute()`, which **never forwarded it**. A coder / reviewer / refactorer that stalled with no output (network wedged, waiting on an approval that never comes, an interactive prompt) left `kj run` **waiting indefinitely** — no timeout, no kill, no message.

## Fix
`AgentRole.execute()` now resolves `silenceTimeoutMs` from `config.session.max_agent_silence_minutes` and forwards it in `runArgs`, so every role gets the hung-agent kill. A killed agent surfaces as a recoverable `SILENCED` error (Brain backs off and retries) instead of an infinite hang.

## Tests
- `coder-role.test.js` — `silenceTimeoutMs` forwarded to the agent when `max_agent_silence_minutes` is set; omitted when it is not.

Net +43 LOC.