### PR TITLE
fix(state): atomic JSON writes via write-temp + rename

### DIFF
--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -14,9 +14,10 @@
  * Steps 2-4 must share a single on-disk write: we never ack the mutation to
  * the UI without persisting it, otherwise a reload would silently revert.
  */
-import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, openSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, mkdirSync, openSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { writeJsonAtomicSync } from '../../../src/utils/atomic-write.js';
 import { spawn } from 'node:child_process';
 import { trackRun, untrack } from './run-tracker.js';
 import { fileURLToPath } from 'node:url';
@@ -83,7 +84,7 @@ function readPlan(filePath) {
 }
 
 function writePlan(filePath, plan) {
-  writeFileSync(filePath, JSON.stringify(plan, null, 2), 'utf-8');
+  writeJsonAtomicSync(filePath, plan);
 }
 
 /**

--- a/src/brain/standby-store.js
+++ b/src/brain/standby-store.js
@@ -15,6 +15,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { writeJsonAtomicSync } from "../utils/atomic-write.js";
 
 const FILENAME_RE = /^[a-zA-Z0-9._-]+\.json$/;
 
@@ -56,7 +57,7 @@ export function persistStandby(state) {
     createdAt: state.createdAt || new Date().toISOString(),
     persistedAt: new Date().toISOString(),
   };
-  fs.writeFileSync(file, JSON.stringify(payload, null, 2), "utf-8");
+  writeJsonAtomicSync(file, payload);
   return file;
 }
 

--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -7,6 +7,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { writeJsonAtomic } from "../utils/atomic-write.js";
 import { generatePlanId, normaliseAlias } from "./plan-id.js";
 import { isPlanV2, migratePlanV1toV2 } from "./plan-schema.js";
 
@@ -83,7 +84,7 @@ export async function savePlan(projectDir, planResult) {
     if (!planResult.alias && planResult.name) {
       planResult.alias = await resolveUniqueAlias(dir, planResult.planId, normaliseAlias(planResult.name));
     }
-    await fs.writeFile(filePath, JSON.stringify(planResult, null, 2), "utf8");
+    await writeJsonAtomic(filePath, planResult);
     return planResult.planId;
   }
 
@@ -100,7 +101,7 @@ export async function savePlan(projectDir, planResult) {
   };
 
   const filePath = path.join(dir, `${planId}.json`);
-  await fs.writeFile(filePath, JSON.stringify(record, null, 2), "utf8");
+  await writeJsonAtomic(filePath, record);
   return planId;
 }
 

--- a/src/session/store.js
+++ b/src/session/store.js
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureDir, exists } from "../utils/fs.js";
 import { getSessionRoot } from "../utils/paths.js";
+import { writeJsonAtomic } from "../utils/atomic-write.js";
 
 const SESSION_ROOT = getSessionRoot();
 
@@ -31,7 +32,7 @@ export async function saveSession(session) {
   const dir = path.join(SESSION_ROOT, session.id);
   await ensureDir(dir);
   session.updated_at = new Date().toISOString();
-  await fs.writeFile(path.join(dir, "session.json"), JSON.stringify(session, null, 2), "utf8");
+  await writeJsonAtomic(path.join(dir, "session.json"), session);
 }
 
 export async function loadSession(sessionId) {

--- a/src/utils/atomic-write.js
+++ b/src/utils/atomic-write.js
@@ -1,0 +1,43 @@
+// Atomic JSON writes for persistent state (resilience audit, Phase 2).
+//
+// A plain `writeFile(path, JSON.stringify(...))` truncates the live file
+// before the new content lands. If the process is killed mid-write
+// (SIGKILL, crash, power loss) the file is left truncated and the only
+// good copy is already gone — the plan / session / standby JSON
+// silently corrupts.
+//
+// write-temp + rename fixes it: `rename` is atomic on the same
+// filesystem, so a reader sees either the old file or the complete new
+// one, never a half-written one. The temp file sits next to the target
+// (same dir → same FS) and is uniquely named so concurrent writers do
+// not clobber each other's temp. A crash before the rename leaves an
+// orphan `.tmp` but never a corrupt target.
+
+import { writeFileSync, renameSync } from "node:fs";
+import { writeFile, rename } from "node:fs/promises";
+
+function tempPath(target) {
+  return `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+}
+
+/**
+ * Atomically write `obj` as pretty JSON to `target` (synchronous).
+ * @param {string} target - destination path; its directory must exist
+ * @param {unknown} obj
+ */
+export function writeJsonAtomicSync(target, obj) {
+  const tmp = tempPath(target);
+  writeFileSync(tmp, JSON.stringify(obj, null, 2), "utf-8");
+  renameSync(tmp, target);
+}
+
+/**
+ * Atomically write `obj` as pretty JSON to `target` (async).
+ * @param {string} target - destination path; its directory must exist
+ * @param {unknown} obj
+ */
+export async function writeJsonAtomic(target, obj) {
+  const tmp = tempPath(target);
+  await writeFile(tmp, JSON.stringify(obj, null, 2), "utf-8");
+  await rename(tmp, target);
+}

--- a/src/utils/run-registry.js
+++ b/src/utils/run-registry.js
@@ -20,6 +20,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { writeJsonAtomicSync } from "./atomic-write.js";
 
 /**
  * Directorio raíz donde viven los registros de run.
@@ -54,7 +55,7 @@ export function registerRun(info = {}) {
       source: info.source || "cli",
       startedAt: new Date().toISOString(),
     };
-    fs.writeFileSync(filePath, JSON.stringify(entry, null, 2), "utf8");
+    writeJsonAtomicSync(filePath, entry);
     return runId;
   } catch {
     return null;

--- a/tests/session/session-pause.test.js
+++ b/tests/session/session-pause.test.js
@@ -11,6 +11,14 @@ vi.mock("../../src/utils/fs.js", () => ({
   exists: vi.fn().mockResolvedValue(true)
 }));
 
+// saveSession now writes via writeJsonAtomic — mock it so the test
+// does not hit disk (ensureDir above is a no-op so the parent dir
+// does not exist; otherwise a real write fails with ENOENT).
+vi.mock("../../src/utils/atomic-write.js", () => ({
+  writeJsonAtomic: vi.fn().mockResolvedValue(undefined),
+  writeJsonAtomicSync: vi.fn(),
+}));
+
 describe("pauseSession", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/tests/session/session-store.test.js
+++ b/tests/session/session-store.test.js
@@ -10,14 +10,25 @@ vi.mock("../../src/utils/fs.js", () => ({
   exists: vi.fn()
 }));
 
+// saveSession now delegates to writeJsonAtomic (resilience audit,
+// Phase 2). Without mocking it the test would write a real tmp file
+// and fail with ENOENT because ensureDir above is a no-op.
+vi.mock("../../src/utils/atomic-write.js", () => ({
+  writeJsonAtomic: vi.fn().mockResolvedValue(undefined),
+  writeJsonAtomicSync: vi.fn(),
+}));
+
 // Dynamic import so mocks are set up first
 const { createSession, saveSession, loadSession, addCheckpoint, markSessionStatus, pauseSession, resumeSessionWithAnswer, loadMostRecentSession } = await import("../../src/session/store.js");
 const { exists } = await import("../../src/utils/fs.js");
+const { writeJsonAtomic } = await import("../../src/utils/atomic-write.js");
 
 describe("session-store", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(fs, "writeFile").mockResolvedValue(undefined);
+    writeJsonAtomic.mockClear();
+    writeJsonAtomic.mockResolvedValue(undefined);
   });
 
   // ── createSession ─────────────────────────────────────────────
@@ -57,10 +68,9 @@ describe("session-store", () => {
     it("writes session.json to disk", async () => {
       await createSession({ id: "s_disk-check" });
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
+      expect(writeJsonAtomic).toHaveBeenCalledWith(
         "/tmp/test-sessions/s_disk-check/session.json",
-        expect.any(String),
-        "utf8"
+        expect.objectContaining({ id: "s_disk-check" })
       );
     });
 
@@ -82,10 +92,9 @@ describe("session-store", () => {
 
       await saveSession(session);
 
-      expect(fs.writeFile).toHaveBeenCalledWith(
+      expect(writeJsonAtomic).toHaveBeenCalledWith(
         "/tmp/test-sessions/s_save-test/session.json",
-        expect.any(String),
-        "utf8"
+        expect.objectContaining({ id: "s_save-test" })
       );
     });
 
@@ -99,15 +108,15 @@ describe("session-store", () => {
       expect(new Date(session.updated_at).toISOString()).toBe(session.updated_at);
     });
 
-    it("serializes session as pretty JSON", async () => {
+    it("hands the session object to writeJsonAtomic (pretty JSON is the helper's job)", async () => {
       const session = { id: "s_pretty", status: "running", checkpoints: [] };
 
       await saveSession(session);
 
-      const written = fs.writeFile.mock.calls[0][1];
-      expect(written).toContain("\n");
-      const parsed = JSON.parse(written);
-      expect(parsed.id).toBe("s_pretty");
+      expect(writeJsonAtomic).toHaveBeenCalledWith(
+        "/tmp/test-sessions/s_pretty/session.json",
+        expect.objectContaining({ id: "s_pretty", status: "running" })
+      );
     });
   });
 
@@ -171,7 +180,7 @@ describe("session-store", () => {
 
       await addCheckpoint(session, { info: "test" });
 
-      expect(fs.writeFile).toHaveBeenCalled();
+      expect(writeJsonAtomic).toHaveBeenCalled();
     });
   });
 
@@ -191,7 +200,7 @@ describe("session-store", () => {
 
       await markSessionStatus(session, "failed");
 
-      expect(fs.writeFile).toHaveBeenCalled();
+      expect(writeJsonAtomic).toHaveBeenCalled();
     });
   });
 

--- a/tests/utils/atomic-write.test.js
+++ b/tests/utils/atomic-write.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeJsonAtomic, writeJsonAtomicSync } from "../../src/utils/atomic-write.js";
+
+// Resilience audit, Phase 2: state writes must be crash-safe. A plain
+// writeFile truncates the live file first; a kill mid-write loses it.
+// write-temp + rename means a reader sees the old file or the complete
+// new one — never a half-written one — and no .tmp is left on success.
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "kj-atomic-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+const tmpLeftovers = () => readdirSync(dir).filter((f) => f.endsWith(".tmp"));
+
+describe("writeJsonAtomicSync", () => {
+  it("writes valid JSON and leaves no .tmp behind", () => {
+    const target = join(dir, "state.json");
+    writeJsonAtomicSync(target, { a: 1, b: "x" });
+    expect(JSON.parse(readFileSync(target, "utf-8"))).toEqual({ a: 1, b: "x" });
+    expect(tmpLeftovers()).toEqual([]);
+  });
+
+  it("replaces an existing file's content completely", () => {
+    const target = join(dir, "state.json");
+    writeFileSync(target, JSON.stringify({ old: true, extra: "gone" }));
+    writeJsonAtomicSync(target, { new: true });
+    expect(JSON.parse(readFileSync(target, "utf-8"))).toEqual({ new: true });
+  });
+});
+
+describe("writeJsonAtomic (async)", () => {
+  it("writes valid JSON and leaves no .tmp behind", async () => {
+    const target = join(dir, "state.json");
+    await writeJsonAtomic(target, { nested: { x: [1, 2] } });
+    expect(JSON.parse(readFileSync(target, "utf-8"))).toEqual({ nested: { x: [1, 2] } });
+    expect(tmpLeftovers()).toEqual([]);
+  });
+
+  it("concurrent writers do not collide on the temp file", async () => {
+    const target = join(dir, "state.json");
+    await Promise.all([
+      writeJsonAtomic(target, { writer: 1 }),
+      writeJsonAtomic(target, { writer: 2 }),
+    ]);
+    // One of the two writers wins; the file is always valid JSON.
+    expect([1, 2]).toContain(JSON.parse(readFileSync(target, "utf-8")).writer);
+    expect(tmpLeftovers()).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Phase 2** of the resilience audit (PR 3/3) — closes the phase.

## Problem
Every persistent state file was written with `fs.writeFile(path, JSON.stringify(...))`, which **truncates the live file** before the new bytes land. A kill / crash / power loss mid-write left the file truncated and the previous good copy already gone — silently corrupting plans, sessions, standby snapshots, board mutations.

6 call sites, none atomic:
- `src/plan/plan-store.js` × 2 (`savePlan`)
- `src/session/store.js` (`saveSession`)
- `src/utils/run-registry.js`
- `src/brain/standby-store.js` (`persistStandby`)
- `packages/hu-board/src/plan-mutations.js` (`writePlan`)

## Fix
New `writeJsonAtomic` / `writeJsonAtomicSync` helper: write to a unique sibling `.tmp` and `rename` onto the target. `rename` is atomic on the same filesystem, so a reader sees either the old file or the complete new one — **never a half-written one**. A crash before the rename leaves an orphan `.tmp` but never a corrupt target.

All 6 sites routed through the helper. The standby **lockfile** keeps its `flag:"wx"` — that is what makes it a lock, must stay non-atomic.

## Tests
- `atomic-write.test.js` (new) — round-trip JSON, no `.tmp` left behind, replaces existing files, concurrent writers don't collide.
- `session-store.test.js` / `session-pause.test.js` — mock the new helper (these tests use a no-op `ensureDir`, so an unmocked atomic write would hit ENOENT on the `.tmp`).
- Full `packages/hu-board` suite green (344/344), `tests/plan` + `tests/session` + `tests/utils` green (411/411).

Net +119 LOC. **Closes Phase 2** of the audit: ENOENT propagated (#761) · silence-timeout cabled (#762) · atomic writes (this).