### PR TITLE
fix(plan): surface corrupt plan JSON instead of silently skipping

### DIFF
--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -9,6 +9,33 @@ import path from "node:path";
 import os from "node:os";
 import { writeJsonAtomic } from "../utils/atomic-write.js";
 import { generatePlanId, normaliseAlias } from "./plan-id.js";
+
+/**
+ * A plan JSON file failed to parse — typically an interrupted write
+ * leaves it truncated. Previously every read site swallowed this with
+ * a silent catch and the plan vanished from `kj plan list` and
+ * `kj plan load` as if it had never existed.
+ *
+ * Now: warn loudly so the user knows their plan is corrupt, and rename
+ * the file to `<name>.corrupt-<ts>` so it stops blocking subsequent
+ * reads of the same alias / planId (without destroying evidence).
+ * Best-effort: if the rename itself fails (read-only FS, permissions),
+ * we log and move on — never escalate to a throw, that would block the
+ * caller from reading the rest of the directory.
+ */
+async function handleCorruptPlanFile(filePath, error) {
+  const corruptPath = `${filePath}.corrupt-${Date.now()}`;
+  // eslint-disable-next-line no-console
+  console.warn(`[plan-store] Corrupt plan JSON at ${filePath}: ${error.message}`);
+  try {
+    await fs.rename(filePath, corruptPath);
+    // eslint-disable-next-line no-console
+    console.warn(`[plan-store] Renamed to ${path.basename(corruptPath)} so it stops blocking subsequent reads.`);
+  } catch (renameErr) {
+    // eslint-disable-next-line no-console
+    console.warn(`[plan-store] Could not rename ${filePath}: ${renameErr.message}`);
+  }
+}
 import { isPlanV2, migratePlanV1toV2 } from "./plan-schema.js";
 
 // Per-process tmp dir for VITEST runs that forget to set KJ_HOME. We
@@ -120,11 +147,14 @@ async function resolveUniqueAlias(dir, ownPlanId, base) {
   const taken = new Set();
   for (const f of files) {
     if (!f.endsWith(".json")) continue;
+    const filePath = path.join(dir, f);
     try {
-      const record = JSON.parse(await fs.readFile(path.join(dir, f), "utf8"));
+      const record = JSON.parse(await fs.readFile(filePath, "utf8"));
       if (record.planId === ownPlanId) continue;
       if (record.alias) taken.add(record.alias);
-    } catch { /* skip corrupt */ }
+    } catch (err) {
+      if (err.code !== "ENOENT") await handleCorruptPlanFile(filePath, err);
+    }
   }
   if (!taken.has(base)) return base;
   for (let i = 2; i < 1000; i += 1) {
@@ -152,19 +182,28 @@ export async function loadPlan(projectDir, ref) {
     const plan = JSON.parse(data);
     if (!isPlanV2(plan)) return migratePlanV1toV2(plan);
     return plan;
-  } catch { /* fall through to alias scan */ }
+  } catch (err) {
+    // ENOENT is expected (caller may have passed an alias, not a planId)
+    // → fall through to the alias scan. Anything else means the file is
+    // there but unreadable / corrupt; surface it instead of silently
+    // hiding the plan.
+    if (err.code !== "ENOENT") await handleCorruptPlanFile(direct, err);
+  }
   // 2. Escaneo del dir por alias. Coste O(N) pero N suele ser <10.
   let files;
   try { files = await fs.readdir(dir); } catch { return null; }
   for (const f of files) {
     if (!f.endsWith(".json")) continue;
+    const filePath = path.join(dir, f);
     try {
-      const record = JSON.parse(await fs.readFile(path.join(dir, f), "utf8"));
+      const record = JSON.parse(await fs.readFile(filePath, "utf8"));
       if (record.alias === ref || record.planId === ref) {
         if (!isPlanV2(record)) return migratePlanV1toV2(record);
         return record;
       }
-    } catch { /* skip corrupt */ }
+    } catch (err) {
+      if (err.code !== "ENOENT") await handleCorruptPlanFile(filePath, err);
+    }
   }
   return null;
 }
@@ -198,8 +237,10 @@ export async function listPlans(projectDir) {
   const plans = [];
   for (const file of files) {
     if (!file.endsWith(".json")) continue;
+    if (file.includes(".corrupt-")) continue; // own renamed-aside files
+    const filePath = path.join(dir, file);
     try {
-      const data = await fs.readFile(path.join(dir, file), "utf8");
+      const data = await fs.readFile(filePath, "utf8");
       const record = JSON.parse(data);
       plans.push({
         planId: record.planId,
@@ -211,7 +252,9 @@ export async function listPlans(projectDir) {
         huCount: Array.isArray(record.hus) ? record.hus.length : 0,
         createdAt: record.createdAt
       });
-    } catch { /* skip corrupt */ }
+    } catch (err) {
+      if (err.code !== "ENOENT") await handleCorruptPlanFile(filePath, err);
+    }
   }
 
   plans.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));

--- a/tests/plan/plan-store-corrupt.test.js
+++ b/tests/plan/plan-store-corrupt.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Resilience audit, Phase 3: a corrupt plan JSON (truncated by an
+// interrupted write, hand-edit gone wrong) used to be silently skipped
+// — `kj plan list` lost the plan with no error or warning, and a
+// `loadPlan(planId)` of a corrupt file returned null as if the plan
+// did not exist. Now we WARN and rename the file aside.
+
+let kjHome;
+let projectDir;
+let plansSubDir;
+
+beforeEach(() => {
+  kjHome = mkdtempSync(join(tmpdir(), "kj-plan-corrupt-"));
+  process.env.KJ_HOME = kjHome;
+  projectDir = "/proj"; // → projectSlug = "proj"
+  plansSubDir = join(kjHome, "plans", "proj");
+  mkdirSync(plansSubDir, { recursive: true });
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.KJ_HOME;
+  rmSync(kjHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const { listPlans, loadPlan } = await import("../../src/plan/plan-store.js");
+
+describe("plan-store — corrupt JSON handling", () => {
+  it("listPlans warns about a corrupt file (was silently skipped)", async () => {
+    writeFileSync(join(plansSubDir, "plan-bad.json"), "{not valid json");
+
+    const plans = await listPlans(projectDir);
+
+    expect(plans).toEqual([]);
+    expect(
+      console.warn.mock.calls.some(([msg]) => /Corrupt plan JSON/.test(String(msg)))
+    ).toBe(true);
+  });
+
+  it("renames the corrupt file aside so subsequent reads do not trip on it", async () => {
+    writeFileSync(join(plansSubDir, "plan-bad.json"), "{not valid json");
+
+    await listPlans(projectDir);
+
+    const files = readdirSync(plansSubDir);
+    expect(files.some((f) => f.includes(".corrupt-"))).toBe(true);
+    expect(files).not.toContain("plan-bad.json");
+  });
+
+  it("listPlans skips renamed-aside .corrupt-* files in its own output", async () => {
+    writeFileSync(
+      join(plansSubDir, "plan-bad.json.corrupt-1700000000000"),
+      "{not valid"
+    );
+    writeFileSync(
+      join(plansSubDir, "plan-ok.json"),
+      JSON.stringify({ planId: "plan-ok", version: 2, hus: [], task: "t" })
+    );
+
+    const plans = await listPlans(projectDir);
+
+    expect(plans.map((p) => p.planId)).toEqual(["plan-ok"]);
+    // The corrupt aside file is NOT re-processed as a new corrupt.
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("loadPlan returns null AND warns when the targeted plan is corrupt", async () => {
+    writeFileSync(join(plansSubDir, "plan-x.json"), "broken");
+
+    const result = await loadPlan(projectDir, "plan-x");
+
+    expect(result).toBeNull();
+    expect(
+      console.warn.mock.calls.some(([msg]) => /Corrupt plan JSON/.test(String(msg)))
+    ).toBe(true);
+  });
+
+  it("loadPlan stays silent on ENOENT — caller may legitimately probe an unknown id", async () => {
+    const result = await loadPlan(projectDir, "plan-nonexistent");
+    expect(result).toBeNull();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Phase 3** of the resilience audit (PR 1).

## Problem
`plan-store.js` wrapped every `JSON.parse` in `catch { /* skip corrupt */ }`. A truncated plan file (interrupted write, hand-edit gone wrong) **silently vanished** from `kj plan list` and made `kj plan load` return `null` — the user thought the plan had never existed, while in fact hours of planning + HU decomposition were sitting unreadable on disk.

## Fix
- `handleCorruptPlanFile()` — **warns** with the file path on parse failure and renames the broken file to `<name>.corrupt-<ts>` (evidence kept, no longer blocks reads of the same alias / planId).
- All 4 read sites (`resolveUniqueAlias`, `loadPlan` direct read, `loadPlan` alias scan, `listPlans`) wired through the helper; only ENOENT keeps its quiet fall-through (a missed file during an alias scan is legitimate).
- `listPlans` filters out its own `.corrupt-*` aside files so a renamed aside is not re-flagged on every call.
- The rename itself is best-effort — a failure logs and continues, never throws.

## Tests
- `plan-store-corrupt.test.js` (new) — corrupt → warn fired, file renamed aside, `.corrupt-*` ignored by subsequent `listPlans`, `loadPlan` corrupt → null+warn, ENOENT silent.
- Full `tests/plan/` suite green (240/240).

Net +131 LOC.