### PR TITLE
fix(config): actionable YAML error names the offending file

### DIFF
--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -28,6 +28,30 @@ import { safeParseConfig, formatConfigIssues } from "./schema.js";
 import { DEFAULTS } from "./defaults.js";
 import { resolveTestHarness } from "./test-harness.js";
 
+/**
+ * Parse a YAML config file with an actionable error message.
+ * Plain `yaml.load` throws `YAMLException: bad indentation ...` with NO
+ * file path, so a single bad edit bricked the entire CLI (including
+ * `kj doctor`, the one command meant to diagnose it). Wrapping every
+ * read site in the same prefix means the user always knows which file
+ * they need to fix.
+ * @param {string} raw - file contents
+ * @param {string} filePath - absolute path (for the error message)
+ * @returns {object}
+ */
+function parseYamlOrThrow(raw, filePath) {
+  try {
+    return yaml.load(raw, { json: true }) || {};
+  } catch (err) {
+    const detail = err?.message || String(err);
+    const e = new Error(`Invalid YAML in ${filePath}:\n  ${detail}`);
+    e.cause = err;
+    e.code = "INVALID_YAML";
+    e.path = filePath;
+    throw e;
+  }
+}
+
 export function mergeDeep(base, override) {
   const output = { ...base };
   for (const [key, value] of Object.entries(override || {})) {
@@ -56,7 +80,7 @@ export async function loadProjectConfig(projectDir = process.cwd()) {
     return null;
   }
   const raw = await fs.readFile(projectConfigPath, "utf8");
-  return yaml.load(raw, { json: true }) || {};
+  return parseYamlOrThrow(raw, projectConfigPath);
 }
 
 async function loadProjectPricingOverrides(projectDir = process.cwd()) {
@@ -66,7 +90,7 @@ async function loadProjectPricingOverrides(projectDir = process.cwd()) {
   }
 
   const raw = await fs.readFile(projectConfigPath, "utf8");
-  const parsed = yaml.load(raw, { json: true }) || {};
+  const parsed = parseYamlOrThrow(raw, projectConfigPath);
   const pricing = parsed?.budget?.pricing;
   if (!pricing || typeof pricing !== "object") {
     return null;
@@ -84,7 +108,7 @@ export async function loadConfig(projectDir) {
   const globalExists = await exists(configPath);
   if (globalExists) {
     const raw = await fs.readFile(configPath, "utf8");
-    globalConfig = yaml.load(raw, { json: true }) || {};
+    globalConfig = parseYamlOrThrow(raw, configPath);
   }
 
   // Load project config (.karajan/kj.config.yml)

--- a/tests/config-yaml-error.test.js
+++ b/tests/config-yaml-error.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Resilience audit, Phase 3: a single bad edit in kj.config.yml used to
+// brick every kj command — even `kj doctor` — because js-yaml's
+// YAMLException propagates with NO file path. The error path now
+// always names the file the user has to fix.
+
+let projectDir;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "kj-yaml-err-proj-"));
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+const { loadProjectConfig, loadConfig } = await import("../src/config/loader.js");
+
+function writeBadProjectYaml(dir, body) {
+  const cfgDir = join(dir, ".karajan");
+  mkdirSync(cfgDir, { recursive: true });
+  const p = join(cfgDir, "kj.config.yml");
+  writeFileSync(p, body);
+  return p;
+}
+
+describe("loader — actionable YAML error messages", () => {
+  it("loadProjectConfig wraps the parse error with the offending file path", async () => {
+    const badPath = writeBadProjectYaml(projectDir, "coder: claude\n  bad: [x\n");
+
+    await expect(loadProjectConfig(projectDir)).rejects.toThrow(/Invalid YAML in/);
+    await expect(loadProjectConfig(projectDir)).rejects.toThrow(badPath);
+  });
+
+  it("the thrown error carries code INVALID_YAML, the path and the original cause", async () => {
+    const badPath = writeBadProjectYaml(projectDir, "broken: {");
+
+    try {
+      await loadProjectConfig(projectDir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err.code).toBe("INVALID_YAML");
+      expect(err.path).toBe(badPath);
+      expect(err.cause).toBeDefined();
+    }
+  });
+
+  it("loadConfig propagates the same actionable error for a broken project config", async () => {
+    const badPath = writeBadProjectYaml(projectDir, "trash: [unclosed\n");
+
+    await expect(loadConfig(projectDir)).rejects.toThrow(/Invalid YAML in/);
+    await expect(loadConfig(projectDir)).rejects.toThrow(badPath);
+  });
+
+  it("a valid YAML still loads without error (no regression on the happy path)", async () => {
+    writeBadProjectYaml(projectDir, "coder: claude\n");
+
+    const cfg = await loadProjectConfig(projectDir);
+    expect(cfg).toEqual({ coder: "claude" });
+  });
+});


### PR DESCRIPTION
**Phase 3** of the resilience audit (PR 2).

## Problem
A single bad edit in `kj.config.yml` bricked **every** `kj` command — including `kj doctor`, the one command meant to diagnose it — because `js-yaml`'s `YAMLException` propagates with **no file path**:

```
YAMLException: bad indentation of a mapping entry (2:13)
```

The user has three config files (global, project, project pricing) and the error never says which one is broken.

## Fix
New `parseYamlOrThrow(raw, path)` wraps every `yaml.load` in the loader (global config, project config, project pricing overrides) and re-throws as:

```
Invalid YAML in /home/.../.karajan/kj.config.yml:
  bad indentation of a mapping entry (2:13)
```

The error carries `code: "INVALID_YAML"`, `path` and the original error as `cause` for programmatic handling (e.g. a future "doctor survives a broken config" PR can switch on `err.code`).

## Tests
- `config-yaml-error.test.js` (new) — broken YAML → message contains `Invalid YAML in <path>`; `err.code`, `err.path`, `err.cause` populated; `loadConfig` propagates the same error; a valid YAML still loads (no regression on the happy path).
- Existing `tests/config.test.js` still green (25/25 combined).

Net +89 LOC.