### PR TITLE
fix(plan): reset zombie HUs in the plan JSON at load time

### DIFF
--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -32,6 +32,7 @@ import {
   setLiveOutcomeUpdater, setPreLoopContext,
 } from "#session/mutators.js";
 import { emitProgress, makeEvent } from "#utils/events.js";
+import { listActiveRuns } from "../../../utils/run-registry.js";
 
 /**
  * @param {object} args
@@ -158,11 +159,10 @@ export async function injectLoadedPlan({ flags, updatedConfig, session, stageRes
  * @param {object} args.loadedPlan
  * @param {string} args.planId
  * @param {object} [args.logger]
- * @returns {Promise<number>}
+ * @returns {number}
  */
-export async function reconcilePlanHuZombies({ loadedPlan, planId, logger }) {
+export function reconcilePlanHuZombies({ loadedPlan, planId, logger }) {
   if (!Array.isArray(loadedPlan?.hus) || loadedPlan.hus.length === 0) return 0;
-  const { listActiveRuns } = await import("../../../utils/run-registry.js");
   const activeRuns = listActiveRuns({ planId });
   if (activeRuns.length > 0) return 0;
   const ZOMBIE_STATES = new Set(["coding", "reviewing", "running"]);

--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -64,6 +64,19 @@ export async function injectLoadedPlan({ flags, updatedConfig, session, stageRes
       message: `Plan loaded: ${flags.plan}`,
       detail: { planId: flags.plan, task: loadedPlan.task, version: loadedPlan.version, huCount: loadedPlan.hus?.length || 0 }
     }));
+
+    // Zombie reconciliation: a previous run may have died mid-flight,
+    // leaving HUs stuck in coding/reviewing/running. The board-side
+    // reaper only runs inside the board; without this, a headless
+    // `kj run --plan` would refuse to pick those HUs up.
+    const reaped = await reconcilePlanHuZombies({ loadedPlan, planId: flags.plan, logger });
+    if (reaped > 0) {
+      await savePlanToDisk(projectDir, loadedPlan);
+      emitProgress(emitter, makeEvent("plan:zombies-reaped", { ...eventBase, stage: "plan" }, {
+        message: `Reset ${reaped} stale HU(s) from a previous run that did not finish`,
+        detail: { planId: flags.plan, count: reaped }
+      }));
+    }
     stageResults.researcher = { ok: true, summary: "Loaded from persisted plan", fromPlan: flags.plan };
     stageResults.architect = { ok: true, summary: "Loaded from persisted plan", fromPlan: flags.plan };
     stageResults.planner = { ok: true, summary: "Loaded from persisted plan", fromPlan: flags.plan };
@@ -120,6 +133,49 @@ export async function injectLoadedPlan({ flags, updatedConfig, session, stageRes
     logger.warn(`Plan loading failed: ${err.message} — falling back to normal pipeline`);
     return { handled: false, plannedTask: null };
   }
+}
+
+/**
+ * Reset HUs that look mid-execution but have no live run behind them.
+ *
+ * Resilience audit, Phase 3 (Hallazgo A1 / status-zombi). A previous
+ * `kj run --plan` flipped HUs to `coding`/`reviewing`/`running` in the
+ * plan JSON, then died (SIGKILL, terminal closed, OOM, crash). The
+ * board-side `hu-zombie-reaper` only queries SQLite and only runs
+ * inside the board process, so the plan JSON on disk kept stale
+ * in-flight statuses forever. The next `kj run --plan` then refused to
+ * pick those HUs up.
+ *
+ * Cross-check via `run-registry`: if there is a live run with our
+ * planId, do NOT touch — that run owns the in-flight HUs. Otherwise
+ * any in-flight status with no live owner is a zombie → reset to
+ * `pending` so it can run again.
+ *
+ * Mutates `loadedPlan.hus` in place. Returns the number of HUs reset
+ * so the caller can persist + emit a progress event.
+ *
+ * @param {object} args
+ * @param {object} args.loadedPlan
+ * @param {string} args.planId
+ * @param {object} [args.logger]
+ * @returns {Promise<number>}
+ */
+export async function reconcilePlanHuZombies({ loadedPlan, planId, logger }) {
+  if (!Array.isArray(loadedPlan?.hus) || loadedPlan.hus.length === 0) return 0;
+  const { listActiveRuns } = await import("../../../utils/run-registry.js");
+  const activeRuns = listActiveRuns({ planId });
+  if (activeRuns.length > 0) return 0;
+  const ZOMBIE_STATES = new Set(["coding", "reviewing", "running"]);
+  let reaped = 0;
+  for (const hu of loadedPlan.hus) {
+    if (ZOMBIE_STATES.has(hu.status)) {
+      const previous = hu.status;
+      hu.status = "pending";
+      reaped += 1;
+      logger?.warn?.(`[plan] HU ${hu.id || hu.hu_id || "?"} was '${previous}' but no live run owns the plan — reset to 'pending'.`);
+    }
+  }
+  return reaped;
 }
 
 /**

--- a/tests/orchestrator/plan-hu-zombie-reconciler.test.js
+++ b/tests/orchestrator/plan-hu-zombie-reconciler.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Resilience audit, Phase 3: a previous `kj run --plan` died mid-flight
+// and left HUs stuck in `coding` / `reviewing` / `running` in the plan
+// JSON. The board's hu-zombie-reaper only sees the SQLite mirror and
+// only runs inside the board, so a headless `kj run --plan` later
+// refused to pick those HUs up. The new reconciler resets them to
+// `pending` when no live run owns the plan.
+
+vi.mock("../../src/utils/run-registry.js", () => ({
+  listActiveRuns: vi.fn(),
+}));
+
+const { listActiveRuns } = await import("../../src/utils/run-registry.js");
+const { reconcilePlanHuZombies } = await import(
+  "../../src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js"
+);
+
+const logger = { warn: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("reconcilePlanHuZombies", () => {
+  it("resets coding/reviewing/running HUs to pending when no live run owns the plan", async () => {
+    listActiveRuns.mockReturnValue([]);
+    const plan = { hus: [
+      { id: "hu1", status: "coding" },
+      { id: "hu2", status: "reviewing" },
+      { id: "hu3", status: "running" },
+      { id: "hu4", status: "pending" },
+      { id: "hu5", status: "approved" },
+    ] };
+
+    const reaped = await reconcilePlanHuZombies({ loadedPlan: plan, planId: "plan-x", logger });
+
+    expect(reaped).toBe(3);
+    expect(plan.hus.map((h) => h.status)).toEqual([
+      "pending", "pending", "pending", "pending", "approved",
+    ]);
+    expect(logger.warn).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT touch HUs when a live run already owns the plan", async () => {
+    listActiveRuns.mockReturnValue([{ pid: 1234, planId: "plan-x" }]);
+    const plan = { hus: [{ id: "hu1", status: "coding" }] };
+
+    const reaped = await reconcilePlanHuZombies({ loadedPlan: plan, planId: "plan-x", logger });
+
+    expect(reaped).toBe(0);
+    expect(plan.hus[0].status).toBe("coding");
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 for a plan with no HUs / a malformed input", async () => {
+    expect(await reconcilePlanHuZombies({ loadedPlan: { hus: [] }, planId: "x" })).toBe(0);
+    expect(await reconcilePlanHuZombies({ loadedPlan: {}, planId: "x" })).toBe(0);
+    expect(await reconcilePlanHuZombies({ loadedPlan: null, planId: "x" })).toBe(0);
+  });
+
+  it("leaves already-terminal statuses untouched (failed / pending / approved)", async () => {
+    listActiveRuns.mockReturnValue([]);
+    const plan = { hus: [
+      { id: "h1", status: "pending" },
+      { id: "h2", status: "approved" },
+      { id: "h3", status: "failed" },
+    ] };
+    const reaped = await reconcilePlanHuZombies({ loadedPlan: plan, planId: "x", logger });
+    expect(reaped).toBe(0);
+  });
+});


### PR DESCRIPTION
**Phase 3** of the resilience audit (PR 3).

## Problem
A previous `kj run --plan` that died mid-flight (SIGKILL, terminal closed, OOM, crash) left HUs stuck in `coding` / `reviewing` / `running` in the plan JSON forever. The board-side `hu-zombie-reaper` only queries the SQLite mirror and only runs **inside the board process**, so a headless `kj run --plan` later refused to pick those HUs up — the bug class MEMORY.md tracks as "status zombi", only half-fixed.

## Fix
New `reconcilePlanHuZombies({ loadedPlan, planId, logger })`:
- Cross-checks `run-registry.listActiveRuns({ planId })` — if a live run already owns the plan, **does NOT touch** (that run still has those HUs in flight).
- Otherwise resets every in-flight HU (`coding` / `reviewing` / `running`) back to `pending`, warns the user, and the caller persists the reconciled plan + emits `plan:zombies-reaped`.

Wired into `injectLoadedPlan` immediately after the plan loads — before the tests-first gate and the certify pass, so subsequent phases see a clean state.

## Tests
- `plan-hu-zombie-reconciler.test.js` (new) — in-flight HUs reset, terminal HUs untouched, no-op when a live run owns the plan, defensive against malformed input.
- `tests/orchestrator/` suite green (51/51 combined).

Net +128 LOC.