### PR TITLE
fix(hu-board): harden the SQLite cache against corruption, busy and schema drift

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { join } from 'node:path';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, renameSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 /** @type {import('better-sqlite3').Database | null} */
@@ -38,6 +38,44 @@ export function getKjHome() {
   return join(process.env.HOME || '/root', '.karajan');
 }
 
+// Bump when the schema gains a column / index / table that older
+// Karajan versions cannot understand. A DB written by a newer Karajan
+// refuses to open here so it does not get silently downgraded.
+const SCHEMA_VERSION = 1;
+
+/**
+ * Tries to open the SQLite database; if it is corrupt, moves it aside
+ * and opens a fresh one. `fullScan` afterwards rebuilds the cache from
+ * the JSON files on disk — the DB is a cache, never the source of
+ * truth. Without this the board crashed at startup with a raw
+ * `SqliteError: database disk image is malformed` whenever the WAL
+ * checkpoint died in the wrong place.
+ *
+ * @param {string} dbPath
+ * @returns {import('better-sqlite3').Database}
+ */
+function openDbResilient(dbPath) {
+  try {
+    const handle = new Database(dbPath);
+    // better-sqlite3 opens lazily — the first pragma is what actually
+    // touches the file and surfaces "file is not a database". Probe
+    // `schema_version` (a built-in SQLite pragma) to force it.
+    handle.pragma("schema_version", { simple: true });
+    return handle;
+  } catch (err) {
+    const code = err?.code || "";
+    const msg = err?.message || "";
+    if (code === "SQLITE_CORRUPT" || code === "SQLITE_NOTADB" || /malformed|not a database/i.test(msg)) {
+      const aside = `${dbPath}.corrupt-${Date.now()}`;
+      try { renameSync(dbPath, aside); } catch { /* may already be gone */ }
+      // eslint-disable-next-line no-console
+      console.warn(`[hu-board] DB at ${dbPath} was corrupt; moved aside to ${aside}. Rebuilding from disk via fullScan.`);
+      return new Database(dbPath);
+    }
+    throw err;
+  }
+}
+
 /**
  * Initializes the SQLite database and creates tables if they don't exist.
  * @returns {import('better-sqlite3').Database}
@@ -47,10 +85,28 @@ export function initDb() {
   mkdirSync(kjHome, { recursive: true });
 
   const dbPath = join(kjHome, 'hu-board.db');
-  db = new Database(dbPath);
+  db = openDbResilient(dbPath);
 
   db.pragma('journal_mode = WAL');
   db.pragma('foreign_keys = ON');
+  // Wait up to 5s for a competing writer (e.g. concurrent fullScan +
+  // mutation) before giving up. Without this any contention surfaced
+  // as SQLITE_BUSY and crashed the request mid-flight.
+  db.pragma('busy_timeout = 5000');
+
+  // Schema-version guard. If the DB was written by a newer Karajan with
+  // a different schema, refuse to open instead of silently mis-binding
+  // named parameters against a renamed column.
+  const onDisk = db.pragma('user_version', { simple: true });
+  if (onDisk > SCHEMA_VERSION) {
+    throw new Error(
+      `[hu-board] DB schema is from a newer Karajan (user_version=${onDisk}, this build expects ${SCHEMA_VERSION}). `
+      + `Upgrade karajan-code or remove ${dbPath} (it will be rebuilt from disk).`
+    );
+  }
+  if (onDisk < SCHEMA_VERSION) {
+    db.pragma(`user_version = ${SCHEMA_VERSION}`);
+  }
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS projects (

--- a/packages/hu-board/tests/db-hardening.test.js
+++ b/packages/hu-board/tests/db-hardening.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDb, closeDb } from "../src/db.js";
+
+// Resilience audit, Phase 3: the board's SQLite was a single point of
+// failure — no busy_timeout (SQLITE_BUSY crashed the request), no
+// schema version (a newer DB silently mis-bound named parameters
+// against renamed columns), no recovery on corruption (a half-written
+// WAL crashed the whole board at startup).
+
+let kjHome;
+
+beforeEach(() => {
+  kjHome = mkdtempSync(join(tmpdir(), "kj-db-hard-"));
+  process.env.KJ_HOME = kjHome;
+});
+
+afterEach(() => {
+  try { closeDb(); } catch { /* may already be closed */ }
+  delete process.env.KJ_HOME;
+  rmSync(kjHome, { recursive: true, force: true });
+});
+
+describe("hu-board db hardening", () => {
+  it("sets busy_timeout so concurrent writers wait instead of crashing", () => {
+    const db = initDb();
+    expect(db.pragma("busy_timeout", { simple: true })).toBe(5000);
+  });
+
+  it("stamps user_version on a fresh DB", () => {
+    const db = initDb();
+    expect(db.pragma("user_version", { simple: true })).toBeGreaterThanOrEqual(1);
+  });
+
+  it("recovers from a corrupt DB file: moves it aside and opens a fresh one", () => {
+    const dbPath = join(kjHome, "hu-board.db");
+    writeFileSync(dbPath, "this is not a valid sqlite database");
+
+    const db = initDb();
+
+    expect(db).toBeTruthy();
+    // initDb returned a working handle — read a pragma to prove it.
+    expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+    // The corrupt file was moved aside (not deleted).
+    const files = readdirSync(kjHome);
+    expect(files.some((f) => f.startsWith("hu-board.db.corrupt-"))).toBe(true);
+    expect(existsSync(dbPath)).toBe(true); // fresh DB took its place
+  });
+
+  it("refuses to open a DB written by a newer Karajan (user_version > current)", () => {
+    const db = initDb();
+    db.pragma("user_version = 99");
+    closeDb();
+
+    expect(() => initDb()).toThrow(/schema is from a newer Karajan/);
+  });
+});


### PR DESCRIPTION
**Phase 3** of the resilience audit (PR 4 — closes the phase).

## Problem
The board's SQLite was a single point of failure with three silent / opaque failure modes:

| Failure | Symptom |
|---|---|
| **SQLITE_BUSY** (concurrent fullScan + mutation, two `kj` runs) | crashed the request — no `busy_timeout` set |
| **Corrupt DB** (interrupted WAL checkpoint, disk issue) | `new Database()` threw `file is not a database` at the first pragma → whole board down at startup |
| **DB written by a newer Karajan** (renamed columns) | silently mis-bound named parameters at runtime — no schema version gate |

## Fix
- `busy_timeout = 5000` — writers wait instead of crashing.
- `openDbResilient(dbPath)` probes the file (forces the lazy open with a `schema_version` pragma) and, on `SQLITE_CORRUPT` / `SQLITE_NOTADB` / "malformed", **moves it aside** to `<path>.corrupt-<ts>` and opens a fresh DB. `fullScan` repopulates the cache from the JSON files on disk afterwards — the DB is a **cache**, never the truth.
- `PRAGMA user_version` stamps `SCHEMA_VERSION = 1` on new DBs. An on-disk version GREATER than the current build refuses to open with a clear message; LESS gets stamped to current.

## Tests
- `db-hardening.test.js` (new) — `busy_timeout` set, `user_version` stamped, corrupt file recovered + moved aside (not deleted), `user_version > SCHEMA_VERSION` throws actionable error.
- Full `packages/hu-board` suite green (348/348 — 4 new tests).

Net +115 LOC. **Closes Phase 3** of the audit: corrupt plan JSON surfaced (#764) · YAML actionable error (#765) · plan HU zombie reconciler (#766) · DB hardening (this).