### PR TITLE
fix(verification-gate): distinguish a git failure from '0 changes by the coder'

### DIFF
--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -209,8 +209,17 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       baseRef: session.session_start_sha,
       projectDir: config.projectDir || process.cwd()
     });
-    filesChanged = verif.filesChanged || 0;
-  } catch { /* ignore verification errors */ }
+    if (verif.gitError) {
+      // Git failed (bad baseRef, corrupt repo, git missing). Don't
+      // feed filesChanged=0 into stale detection — it would blame the
+      // coder for an infrastructure problem.
+      logger?.warn?.(`[verification-gate] Git failed, change count is unreliable: ${verif.gitError}`);
+    } else {
+      filesChanged = verif.filesChanged || 0;
+    }
+  } catch (err) {
+    logger?.warn?.(`[verification-gate] Skipped: ${err?.message || err}`);
+  }
 
   await addCheckpoint(session, { stage: "coder", iteration, note: "Coder applied changes", provider: coderRole.provider, model: coderRole.model || null, filesChanged });
   emitProgress(

--- a/src/orchestrator/verification-gate.js
+++ b/src/orchestrator/verification-gate.js
@@ -47,8 +47,16 @@ export function countChangesSince(baseRef, projectDir = null) {
     }
 
     return { files, filesChanged: files.length, linesAdded, linesDeleted };
-  } catch {
-    return { files: [], filesChanged: 0, linesAdded: 0, linesDeleted: 0 };
+  } catch (err) {
+    // Git itself failed (baseRef invalid, repo corrupt, git binary
+    // missing). Previously we returned `filesChanged: 0` silently —
+    // indistinguishable from "the coder did nothing". Surface the
+    // error so verifyCoderOutput stops blaming the agent for an
+    // infrastructure failure.
+    return {
+      files: [], filesChanged: 0, linesAdded: 0, linesDeleted: 0,
+      gitError: err?.stderr?.toString?.() || err?.message || String(err),
+    };
   }
 }
 
@@ -65,10 +73,13 @@ export function countUntrackedFiles(projectDir = null) {
       encoding: "utf8", stdio: ["pipe", "pipe", "pipe"],
     }).trim();
 
-    if (!output) return [];
-    return output.split("\n").filter(Boolean);
-  } catch {
-    return [];
+    if (!output) return { files: [] };
+    return { files: output.split("\n").filter(Boolean) };
+  } catch (err) {
+    return {
+      files: [],
+      gitError: err?.stderr?.toString?.() || err?.message || String(err),
+    };
   }
 }
 
@@ -87,11 +98,29 @@ export function verifyCoderOutput({ baseRef, projectDir = null, minFiles = 1, mi
   const tracked = countChangesSince(baseRef, projectDir);
   const untracked = countUntrackedFiles(projectDir);
 
-  const totalFiles = tracked.filesChanged + untracked.length;
-  const totalLines = tracked.linesAdded + tracked.linesDeleted;
-  const allFiles = [...tracked.files, ...untracked];
+  // Git infra failure (bad baseRef, corrupt repo, git missing) — not
+  // the coder's fault. Bail out with `gitError` so the caller can log
+  // it and skip the "retry with explicit file paths" feedback that
+  // would otherwise blame the agent.
+  const gitError = tracked.gitError || untracked.gitError;
+  if (gitError) {
+    return {
+      passed: false,
+      filesChanged: 0,
+      linesChanged: 0,
+      files: [],
+      reason: `Git verification failed: ${gitError}`,
+      retryStrategy: null,
+      gitError,
+    };
+  }
 
-  const passed = totalFiles >= minFiles && (untracked.length > 0 || totalLines >= minLines);
+  const untrackedFiles = untracked.files || [];
+  const totalFiles = tracked.filesChanged + untrackedFiles.length;
+  const totalLines = tracked.linesAdded + tracked.linesDeleted;
+  const allFiles = [...tracked.files, ...untrackedFiles];
+
+  const passed = totalFiles >= minFiles && (untrackedFiles.length > 0 || totalLines >= minLines);
 
   if (passed) {
     return {

--- a/tests/verification-gate.test.js
+++ b/tests/verification-gate.test.js
@@ -32,11 +32,12 @@ describe("verification-gate", () => {
       expect(result.linesAdded).toBe(0);
     });
 
-    it("returns zeros on git error", () => {
+    it("surfaces git failures via `gitError` (no longer silently 0)", () => {
       execFileSync.mockImplementation(() => { throw new Error("not a git repo"); });
       const result = countChangesSince("HEAD~1");
       expect(result.filesChanged).toBe(0);
       expect(result.files).toEqual([]);
+      expect(result.gitError).toMatch(/not a git repo/);
     });
 
     it("includes projectDir scope in command (as a separate arg, post-`--`)", () => {
@@ -53,20 +54,23 @@ describe("verification-gate", () => {
   });
 
   describe("countUntrackedFiles", () => {
-    it("returns list of untracked files", () => {
+    it("returns { files: [...] } with the untracked files", () => {
       execFileSync.mockReturnValue("new.js\nnew-dir/file.ts\n");
-      const files = countUntrackedFiles();
-      expect(files).toEqual(["new.js", "new-dir/file.ts"]);
+      const result = countUntrackedFiles();
+      expect(result.files).toEqual(["new.js", "new-dir/file.ts"]);
+      expect(result.gitError).toBeUndefined();
     });
 
-    it("returns empty array on no untracked", () => {
+    it("returns { files: [] } when there are no untracked files", () => {
       execFileSync.mockReturnValue("");
-      expect(countUntrackedFiles()).toEqual([]);
+      expect(countUntrackedFiles()).toEqual({ files: [] });
     });
 
-    it("returns empty array on error", () => {
+    it("surfaces git failures via `gitError` (no longer empty-array silent)", () => {
       execFileSync.mockImplementation(() => { throw new Error("fail"); });
-      expect(countUntrackedFiles()).toEqual([]);
+      const result = countUntrackedFiles();
+      expect(result.files).toEqual([]);
+      expect(result.gitError).toMatch(/fail/);
     });
   });
 
@@ -106,6 +110,22 @@ describe("verification-gate", () => {
       expect(result.filesChanged).toBe(2);
       expect(result.files).toContain("src/existing.js");
       expect(result.files).toContain("new.js");
+    });
+
+    // Resilience audit, Phase 4: previously a git failure (bad
+    // baseRef, corrupt repo, git missing) was indistinguishable from
+    // "the coder did nothing", so the orchestrator wasted iterations
+    // retrying the agent with "rephrase the feedback with explicit
+    // file paths" when the real cause was infrastructure.
+    it("when git itself fails, returns gitError and a null retryStrategy (no agent blame)", () => {
+      execFileSync.mockImplementation(() => {
+        throw new Error("fatal: bad revision 'HEAD~1'");
+      });
+      const result = verifyCoderOutput({ baseRef: "HEAD~1" });
+      expect(result.passed).toBe(false);
+      expect(result.gitError).toMatch(/bad revision/);
+      expect(result.reason).toMatch(/Git verification failed/);
+      expect(result.retryStrategy).toBeNull();
     });
   });
 


### PR DESCRIPTION
**Phase 4** of the resilience audit (PR 2 — closes the phase).

## Problem
`countChangesSince` and `countUntrackedFiles` wrapped git in `catch { return zeros }`, so a **git failure** (bad `baseRef`, corrupt repo, git binary missing) was indistinguishable from **"the coder produced no changes"**. The orchestrator then burned iterations retrying the agent with `retryStrategy: "Rephrase the feedback with explicit file paths"` — when the real cause was infrastructure, not the agent.

This bug was **blinded by its own test** (`tests/verification-gate.test.js:35` asserted that a git error → 0 changes was correct behaviour).

## Fix
- `countChangesSince` now adds `gitError: <message>` on the catch path (zeros stay for back-compat).
- `countUntrackedFiles` moves to `{ files, gitError? }` (single internal caller updated for symmetry).
- `verifyCoderOutput` short-circuits on `gitError` with `reason: "Git verification failed: ..."` and `retryStrategy: null` — **never blames the coder for a git problem**.
- `coder-stage.js` logs a `warn` on `gitError` and skips the unreliable `filesChanged` for stale detection (instead of feeding 0 into solomon-rules).

## Tests
Updated the existing test that asserted the silent behaviour as "correct" (it was hiding the bug) and added a new test that pins the gitError shape on `verifyCoderOutput`. Full `tests/verification-gate.test.js` green (16/16).

Net +58 LOC. **Closes Phase 4** of the audit: triage no silent degrade (#768) · verification-gate distinguishes git failure (this).