### PR TITLE
test: add a resilience suite — index + quota-hibernation tripwire

### DIFF
--- a/tests/resilience/README.md
+++ b/tests/resilience/README.md
@@ -1,0 +1,48 @@
+# Resilience tests — `tests/resilience/`
+
+Index of the tests added by the **resilience audit (2026-05-22)**. Each
+entry pins a specific failure mode that Karajan used to handle silently
+or with an opaque crash. If you change anything in the affected file,
+run the listed test first — these are the tripwires.
+
+The audit's guiding rule: **the problem is not that something fails —
+the problem is failing without telling the user why.**
+
+## Phase 1 — Quota hibernation end to end
+
+| Failure mode | Test |
+|---|---|
+| `"You've hit your session limit"` reaches `UNKNOWN_FATAL` instead of being recognised as a recoverable quota cap | `tests/brain/agent-error-classifier.test.js` (session limit block) · `tests/rate-limit-detector.test.js` (12-hour clock block) |
+| `withBrainRecovery` does not persist a standby snapshot because no caller passes `sessionState` | `tests/brain/with-brain-recovery.test.js` (QUOTA + sessionState block) · `tests/brain/standby-store.test.js` (`buildStandbyState`) |
+| The orchestrator treats `action:"hibernate"` as a generic failure (HU sealed `failed` instead of `hibernated`) | `tests/orchestrator/coder-and-refactorer-hibernate.test.js` · `tests/session/session-status-sealing.test.js` (hibernated case) |
+| A stopped run never tells the user how to resume it | `tests/utils/resume-hint.test.js` · `hibernate-end-to-end.test.js` (in this folder) |
+
+## Phase 2 — Don't lie
+
+| Failure mode | Test |
+|---|---|
+| `runCommand` swallows an ENOENT (missing agent CLI) and returns an empty error | `tests/process-spawn-failure.test.js` |
+| `AgentRole.execute()` never forwards `silenceTimeoutMs`, so a hung coder hangs `kj run` forever | `tests/coder/coder-role.test.js` (silenceTimeoutMs block) |
+| State writes are not atomic — interrupted writes leave truncated JSON | `tests/utils/atomic-write.test.js` |
+
+## Phase 3 — Don't lose or block
+
+| Failure mode | Test |
+|---|---|
+| A corrupt plan JSON vanishes silently from `kj plan list` / `kj plan load` | `tests/plan/plan-store-corrupt.test.js` |
+| `kj.config.yml` parse error bricks every kj command (including `kj doctor`) with no path in the message | `tests/config-yaml-error.test.js` |
+| A killed `kj run --plan` leaves HUs stuck in `coding` forever — the board-side reaper never sees a headless run | `tests/orchestrator/plan-hu-zombie-reconciler.test.js` |
+| Board SQLite has no busy-timeout / no schema version / no corruption recovery | `packages/hu-board/tests/db-hardening.test.js` |
+
+## Phase 4 — Don't degrade silently
+
+| Failure mode | Test |
+|---|---|
+| `TriageRole` returns `ok:true` with safe defaults on an unparseable LLM output (skips roles silently) | `tests/triage/triage-role.test.js` (degraded triage block) |
+| `verifyCoderOutput` confuses a git failure (bad baseRef, repo corrupt, git missing) with "the coder did nothing" — burns iterations blaming the agent | `tests/verification-gate.test.js` (gitError block) |
+
+## Phase 5 — Integration tripwires
+
+| Scenario | Test |
+|---|---|
+| Quota exhaustion end-to-end: classified → standby persisted → action surfaced → resume hint printed | `tests/resilience/hibernate-end-to-end.test.js` |

--- a/tests/resilience/hibernate-end-to-end.test.js
+++ b/tests/resilience/hibernate-end-to-end.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { classifyAgentError, ERROR_CLASS } from "../../src/brain/agent-error-classifier.js";
+import { withBrainRecovery } from "../../src/brain/with-brain-recovery.js";
+import { buildStandbyState } from "../../src/brain/standby-store.js";
+import { printResumeHint } from "../../src/utils/display/resume-hint.js";
+
+// Resilience audit, Phase 5: integration tripwire for the quota
+// hibernation flow that motivated the entire audit. A teammate's
+// `kj run` hit Claude Code's "You've hit your session limit" and the
+// HU was sealed `failed` with `UNKNOWN_FATAL` and no resume hint. This
+// test walks the WHOLE chain so a regression in any one link is
+// caught — not just by its own unit test, but as the end-to-end
+// degradation the user actually experiences.
+
+const SESSION_LIMIT_STDERR = "You've hit your session limit · resets 10:10pm (Europe/Madrid)";
+
+const noSleep = () => Promise.resolve();
+
+function makeQuotaAgent() {
+  return {
+    provider: "claude",
+    runTask: async () => ({
+      ok: false, error: SESSION_LIMIT_STDERR, output: "", exitCode: 1,
+    }),
+  };
+}
+
+describe("resilience: quota exhaustion end to end", () => {
+  it("classifies the Claude Code session limit as a recoverable quota cap", () => {
+    const cls = classifyAgentError({
+      provider: "claude", stderr: SESSION_LIMIT_STDERR, exitCode: 1,
+    });
+    expect(cls.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
+    expect(cls.recoverable).toBe(true);
+    expect(cls.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("withBrainRecovery with sessionState persists a standby snapshot to disk", async () => {
+    const sessionState = buildStandbyState({
+      session: { id: "s_e2e-quota" },
+      config: { projectDir: "/tmp/e2e" },
+      huId: "hu_e2e",
+    });
+    expect(sessionState.sessionId).toBe("s_e2e-quota");
+
+    const result = await withBrainRecovery({
+      agent: makeQuotaAgent(),
+      taskArgs: {},
+      role: "coder",
+      sessionState,
+      sleepFn: noSleep,
+    });
+
+    expect(result.action).toBe("hibernate");
+    expect(result.standbyFile).toBeTruthy();
+    const persisted = JSON.parse(readFileSync(result.standbyFile, "utf-8"));
+    expect(persisted.sessionId).toBe("s_e2e-quota");
+    expect(persisted.huId).toBe("hu_e2e");
+    expect(persisted.cooldownUntil).toBeTruthy();
+  });
+
+  it("a hibernated result produces a 'kj standby resume <id>' hint as the last line", () => {
+    const lines = [];
+    printResumeHint(
+      { hibernated: true, sessionId: "s_e2e-quota", reason: "quota_exhausted" },
+      { print: (l) => lines.push(l) }
+    );
+    const joined = lines.join("\n");
+    expect(joined).toMatch(/kj standby resume s_e2e-quota/);
+  });
+
+  it("the env subset persisted is ALLOWLISTED — no API key leaks into the snapshot", () => {
+    process.env.KJ_TEST_FLAG = "kj-only";
+    process.env.SECRET_API_KEY = "must-not-leak";
+    try {
+      const state = buildStandbyState({ session: { id: "s_x" } });
+      expect(state.env.KJ_TEST_FLAG).toBe("kj-only");
+      expect(state.env).not.toHaveProperty("SECRET_API_KEY");
+    } finally {
+      delete process.env.KJ_TEST_FLAG;
+      delete process.env.SECRET_API_KEY;
+    }
+  });
+});


### PR DESCRIPTION
**Phase 5** of the resilience audit (closes the audit).

## What this adds
`tests/resilience/`:

- **`README.md`** — indexes every failure mode the audit caught in Phases 1-4 and the test that pins it. A contributor editing one of the affected source files sees at a glance which tripwire to run. No more "the test was there but nobody knew about it".

- **`hibernate-end-to-end.test.js`** — walks the whole quota flow that motivated the audit, end to end:
  1. classify the Claude Code `"session limit"` message → `QUOTA_EXHAUSTED_DAILY`,
  2. `withBrainRecovery` persists a standby JSON with the right `sessionId` / `huId` / `cooldownUntil`,
  3. `printResumeHint` emits `kj standby resume <id>` as the last line,
  4. the env allowlist refuses to leak `SECRET_API_KEY` into the snapshot.

  A regression in **any single link** surfaces here, not only in its unit test.

## Closes the resilience audit
- Phase 1 (hibernation): #756 · #757 · #758 · #759
- Phase 2 (don't lie): #761 · #762 · #763
- Phase 3 (don't lose / block): #764 · #765 · #766 · #767
- Phase 4 (don't degrade silently): #768 · #769
- Phase 5 (safety net): **this PR**

Net +133 LOC. The next stop is the release: bump → `2.18.0`, CHANGELOG consolidated, npm publish, landing deploy.