### PR TITLE
fix(brain): standby waits in-process instead of exiting on a short cooldown

### DIFF
--- a/src/brain/with-brain-recovery.js
+++ b/src/brain/with-brain-recovery.js
@@ -7,7 +7,7 @@
 // puede ignorarlo (fallback a long standby capped) hasta que llegue 0414.
 
 import { classifyAgentError, ERROR_CLASS } from "./agent-error-classifier.js";
-import { persistStandby } from "./standby-store.js";
+import { persistStandby, markStandbyDone } from "./standby-store.js";
 
 const ONE_MIN = 60 * 1000;
 
@@ -20,6 +20,13 @@ export const DEFAULT_RECOVERY_POLICY = Object.freeze({
   // KJC-TSK-0415: threshold de fallback. Si retryAfter > esto Y el role
   // tiene fallback configurado → switch provider en vez de hibernar.
   fallbackWaitHoursDefault: DEFAULT_FALLBACK_WAIT_HOURS,
+  // Standby-in-process: when the cooldown is short enough we keep the
+  // process alive and `await sleepFn(retryAfter)`, then retry the
+  // agent. The user sees nothing terminal — kj just pauses. A SIGINT /
+  // SIGTERM during the wait prints `kj standby resume <id>` and exits
+  // cleanly. For waits longer than this the process exits straight
+  // away (a multi-day weekly cap is not worth keeping kj running).
+  standbyWaitHoursMax: DEFAULT_FALLBACK_WAIT_HOURS,
   classes: {
     [ERROR_CLASS.RATE_LIMIT_SHORT]: { mode: "standby", maxRetries: 3 },
     [ERROR_CLASS.QUOTA_EXHAUSTED_DAILY]: { mode: "hibernate", maxRetries: 1, fallbackEligible: true },
@@ -132,10 +139,15 @@ export async function withBrainRecovery({
       }
     }
 
-    // HIBERNATE: persistir + signal action=hibernate al caller.
-    // Si el caller pasó `sessionState` (TSK-0414 PR2), persistimos el JSON
-    // automáticamente en ~/.kj/standby/<sessionId>.json. Caller decide qué
-    // hacer con action=hibernate (típicamente exit 0 para liberar memoria).
+    // HIBERNATE: the cooldown is too long for a short standby. Persist
+    // the snapshot first so a SIGINT / SIGTERM during the wait leaves a
+    // recoverable session on disk. Then either:
+    //   (a) wait in-process until cooldownUntil and retry (the common
+    //       case — daily quotas reset in a few hours), or
+    //   (b) when the wait would exceed `standbyWaitHoursMax`, return
+    //       action="hibernate" so the caller exits and the user
+    //       resumes later with `kj standby resume <id>` (weekly /
+    //       monthly caps).
     if (classPolicy.mode === "hibernate" && cls.retryAfter && cls.retryAfter > policy.hibernateThresholdMs) {
       let standbyFile = null;
       if (sessionState && sessionState.sessionId) {
@@ -147,13 +159,58 @@ export async function withBrainRecovery({
             role, provider: effectiveProvider,
             classifierMessage: cls.message,
           });
-          logger?.info?.(`[brain] hibernated session ${sessionState.sessionId} → ${standbyFile} (resume at ${cls.retryUntil})`);
         } catch (err) {
           logger?.warn?.(`[brain] failed to persist standby: ${err.message}`);
         }
       }
-      emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter, standbyFile });
-      return { ok: false, action: "hibernate", recovery: cls, standbyFile };
+
+      const maxWaitMs = (policy.standbyWaitHoursMax ?? DEFAULT_FALLBACK_WAIT_HOURS) * ONE_HOUR;
+      const tooLongToWait = cls.retryAfter > maxWaitMs;
+
+      if (tooLongToWait) {
+        logger?.info?.(`[brain] hibernated session ${sessionState?.sessionId ?? "(no id)"} → ${standbyFile} (resume at ${cls.retryUntil}; wait > ${Math.round(maxWaitMs/ONE_HOUR)}h, exiting)`);
+        emit(emitter, "brain:hibernate-request", eventBase, { role, class: cls.class, retryUntil: cls.retryUntil, retryAfter: cls.retryAfter, standbyFile });
+        return { ok: false, action: "hibernate", recovery: cls, standbyFile };
+      }
+
+      // Standby-in-process: keep kj alive, sleep until the cooldown,
+      // then retry. A SIGINT / SIGTERM during the wait prints the
+      // resume command and exits — the standby JSON is already on
+      // disk so the user can pick it up later.
+      const sid = sessionState?.sessionId ?? null;
+      const onSignal = (signal) => {
+        // eslint-disable-next-line no-console
+        console.log(`\n⏸  Standby interrupted (${signal}). Resume with:`);
+        // eslint-disable-next-line no-console
+        if (sid) console.log(`     kj standby resume ${sid}`);
+        // eslint-disable-next-line no-console
+        else console.log(`     kj standby list   (no session id was assigned)`);
+        process.exit(signal === "SIGINT" ? 130 : 143);
+      };
+      const detach = () => {
+        process.removeListener("SIGINT", onSignal);
+        process.removeListener("SIGTERM", onSignal);
+      };
+      process.once("SIGINT", onSignal);
+      process.once("SIGTERM", onSignal);
+
+      const hours = Math.round((cls.retryAfter / ONE_HOUR) * 10) / 10;
+      logger?.info?.(`[brain] ${role}: standby for ~${hours}h until ${cls.retryUntil} (Ctrl+C to detach; will resume with 'kj standby resume ${sid}').`);
+      emit(emitter, "brain:standby-wait", eventBase, { role, class: cls.class, waitMs: cls.retryAfter, retryUntil: cls.retryUntil, standbyFile });
+
+      try {
+        await sleepFn(cls.retryAfter);
+      } finally {
+        detach();
+      }
+
+      // Wait finished without an interrupt — mark the standby JSON
+      // done so it does not auto-resume from disk later.
+      if (sid) {
+        try { markStandbyDone(sid); } catch { /* ignore */ }
+      }
+      emit(emitter, "brain:standby-resumed", eventBase, { role, class: cls.class });
+      continue;
     }
 
     // STANDBY: espera hasta cooldownUntil (capado por longStandbyCapMs).

--- a/tests/brain/fallback-chain.test.js
+++ b/tests/brain/fallback-chain.test.js
@@ -71,22 +71,27 @@ describe("withBrainRecovery — fallback switch", () => {
     expect(r.ok).toBe(true);
   });
 
-  it("DAILY con retryAfter < maxWaitHours → NO switch, hiberna como antes", async () => {
+  it("DAILY con retryAfter < maxWaitHours → NO switch (cooldown corto = standby in-process)", async () => {
+    // Primary fails once with a daily quota, then succeeds when the
+    // standby-in-process wait wakes up and retries. The fallback agent
+    // must NEVER be called because the wait is below `maxWaitHours`.
     const primary = {
       provider: "claude",
-      runTask: vi.fn().mockResolvedValue(quotaDailyError()),
+      runTask: vi.fn()
+        .mockResolvedValueOnce(quotaDailyError())
+        .mockResolvedValueOnce({ ok: true, output: "primary recovered" }),
     };
     const fallbackAgent = {
       provider: "codex",
-      runTask: vi.fn().mockResolvedValue({ ok: true, output: "ok" }),
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "should not be called" }),
     };
-    // 5h cooldown, maxWaitHours=12 → NO switch
     const r = await withBrainRecovery({
       agent: primary, taskArgs: {}, role: "coder",
       fallback: { agent: fallbackAgent, provider: "codex", maxWaitHours: 12 },
       sleepFn: noSleep,
     });
-    expect(r.action).toBe("hibernate");
+    expect(r.ok).toBe(true);
+    expect(r.output).toBe("primary recovered");
     expect(fallbackAgent.runTask).not.toHaveBeenCalled();
   });
 

--- a/tests/brain/with-brain-recovery.test.js
+++ b/tests/brain/with-brain-recovery.test.js
@@ -53,8 +53,8 @@ describe("withBrainRecovery — RATE_LIMIT_SHORT → standby + retry", () => {
 });
 
 describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
-  it("quota con reset >1h → action='hibernate' inmediato (sin retry)", async () => {
-    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+  it("quota con reset >12h → action='hibernate' inmediato (demasiado largo para esperar in-process)", async () => {
+    const target = new Date(Date.now() + 15 * 60 * 60 * 1000).toISOString();
     const agent = makeAgent([
       { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
     ]);
@@ -65,13 +65,12 @@ describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
     expect(r.action).toBe("hibernate");
     expect(r.recovery.class).toBe("QUOTA_EXHAUSTED_DAILY");
     expect(r.recovery.retryUntil).toBe(target);
-    // Debe haber emitido la señal de hibernate-request
     const hibernateEvent = emit.mock.calls.find(([_evt, payload]) => payload?.type === "brain:hibernate-request");
     expect(hibernateEvent).toBeTruthy();
   });
 
-  it("con sessionState persiste el standby a disco y devuelve standbyFile", async () => {
-    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+  it("con sessionState (>12h) persiste el standby a disco y devuelve standbyFile", async () => {
+    const target = new Date(Date.now() + 15 * 60 * 60 * 1000).toISOString();
     const agent = makeAgent([
       { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
     ]);
@@ -88,13 +87,37 @@ describe("withBrainRecovery — QUOTA_EXHAUSTED_DAILY → hibernate", () => {
   });
 
   it("sin sessionState NO persiste (standbyFile null) — regresión del bug original", async () => {
-    const target = new Date(Date.now() + 5 * 60 * 60 * 1000).toISOString();
+    const target = new Date(Date.now() + 15 * 60 * 60 * 1000).toISOString();
     const agent = makeAgent([
       { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
     ]);
     const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", sleepFn: noSleep });
     expect(r.action).toBe("hibernate");
     expect(r.standbyFile ?? null).toBeNull();
+  });
+
+  // The user's request: short cooldowns (daily quota resets ~5h)
+  // should NOT exit kj — kj stays alive, waits, retries on its own.
+  // Only Ctrl+C during the wait should print the resume hint.
+  it("quota con reset corto (<=12h) → standby in-process + retry cuando despierta", async () => {
+    const target = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
+    const agent = makeAgent([
+      { ok: false, error: `usage limit reached, resets at ${target}`, exitCode: 1 },
+      { ok: true, output: "second call succeeds after the wait" },
+    ]);
+    const emit = vi.fn();
+    const emitter = { emit };
+    const r = await withBrainRecovery({ agent, taskArgs: {}, role: "coder", emitter, sleepFn: noSleep });
+    expect(r.ok).toBe(true);
+    expect(r.output).toContain("second call succeeds");
+    expect(agent.runTask).toHaveBeenCalledTimes(2);
+    // Emitted the standby-wait + standby-resumed events, NOT hibernate-request.
+    const waitEvt = emit.mock.calls.find(([_e, p]) => p?.type === "brain:standby-wait");
+    const resumedEvt = emit.mock.calls.find(([_e, p]) => p?.type === "brain:standby-resumed");
+    const hibernateEvt = emit.mock.calls.find(([_e, p]) => p?.type === "brain:hibernate-request");
+    expect(waitEvt).toBeTruthy();
+    expect(resumedEvt).toBeTruthy();
+    expect(hibernateEvt).toBeFalsy();
   });
 });
 

--- a/tests/resilience/hibernate-end-to-end.test.js
+++ b/tests/resilience/hibernate-end-to-end.test.js
@@ -13,7 +13,11 @@ import { printResumeHint } from "../../src/utils/display/resume-hint.js";
 // caught — not just by its own unit test, but as the end-to-end
 // degradation the user actually experiences.
 
-const SESSION_LIMIT_STDERR = "You've hit your session limit · resets 10:10pm (Europe/Madrid)";
+// Long ISO target (>12h ahead) so the helper exercises the
+// hibernate-and-exit branch (longer waits don't keep kj alive),
+// NOT the standby-in-process branch. Independent of wall-clock time.
+const FAR_FUTURE_TARGET = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+const QUOTA_STDERR_LONG = `usage limit reached, resets at ${FAR_FUTURE_TARGET}`;
 
 const noSleep = () => Promise.resolve();
 
@@ -21,15 +25,20 @@ function makeQuotaAgent() {
   return {
     provider: "claude",
     runTask: async () => ({
-      ok: false, error: SESSION_LIMIT_STDERR, output: "", exitCode: 1,
+      ok: false, error: QUOTA_STDERR_LONG, output: "", exitCode: 1,
     }),
   };
 }
 
 describe("resilience: quota exhaustion end to end", () => {
   it("classifies the Claude Code session limit as a recoverable quota cap", () => {
+    // The original user-reported message uses the 12-hour clock; parseCooldown
+    // must understand it. Resilience tripwire for #756 — independent of how
+    // long the wait will be (that's tested via the ISO path below).
     const cls = classifyAgentError({
-      provider: "claude", stderr: SESSION_LIMIT_STDERR, exitCode: 1,
+      provider: "claude",
+      stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
+      exitCode: 1,
     });
     expect(cls.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
     expect(cls.recoverable).toBe(true);


### PR DESCRIPTION
## Problem (user-reported)
*"Si se queda sin poder seguir por agotamiento de la suscripción no se queda esperando? se sale? No es así como debe funcionar. ... debe quedar en standby hasta la hora indicada. Si el usuario lo corta / para estando en standby me parece correcto que muestre cómo continuar."*

Previously **every** hibernation returned `action:"hibernate"` and the caller exited the process — so even a 4-hour daily-quota wait forced the user to come back later and run `kj standby resume <id>` manually. That defeats the point of a hibernation flow for short cooldowns; it only makes sense for very long ones (weekly / monthly caps).

## Fix
`withBrainRecovery` now:

- **Always persists the standby snapshot first** — so a Ctrl+C during the wait still leaves a recoverable session on disk.
- **If `retryAfter <= standbyWaitHoursMax`** (default `12h`, configurable per-policy): emits `brain:standby-wait`, sleeps in-process (`await sleepFn(retryAfter)`), releases the standby via `markStandbyDone`, then **retries the agent**. The user sees nothing terminal — kj just pauses.
- **If `retryAfter > standbyWaitHoursMax`**: returns `action:"hibernate"` exactly as before, the caller exits, the user resumes later (weekly / monthly caps).
- **During the wait**: a SIGINT / SIGTERM handler prints `⏸  Standby interrupted. Resume with: kj standby resume <id>` and exits cleanly (the snapshot is still on disk — we did NOT mark it done).

## Tests rewritten
The original quota-hibernate cases switched to ISO targets > 12h so they continue to exercise the immediate-exit branch. A new test pins the standby-wait + retry path with `brain:standby-wait` / `brain:standby-resumed` events and a 2-call agent recovery. `fallback-chain` test updated to the new shape (cooldown < `maxWaitHours` is now an in-process wait, not a hibernate-exit).

158/158 in `tests/brain/` + `tests/resilience/` + the orchestrator hibernate test.

Net +94 LOC.