### PR TITLE
fix(release): close KJC-BUG-0040 — race between gh release create and softprops

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -66,6 +66,34 @@ jobs:
         if: runner.os == 'Windows'
         run: certutil -hashfile dist\kj-${{ matrix.target }}.exe SHA256 > dist\kj-${{ matrix.target }}.exe.sha256
 
+      # KJC-BUG-0040 root cause: the release-create from the human's
+      # release checklist (`gh release create`) and softprops fight for
+      # the same tag. linux-x64 is always the fastest job in the matrix
+      # so it reaches the upload step BEFORE GitHub has indexed the
+      # release-by-tag — softprops then creates a duplicate DRAFT, uploads
+      # there, and fails the final PATCH draft:false with 422 already_exists.
+      # Result: linux assets end up in an orphan draft, the human's
+      # release misses kj-linux-x64. Poll until the release is discoverable
+      # so softprops finds it and uploads to the right place. 60 s window
+      # is plenty for `gh release create` to land (typically <5 s).
+      - name: Wait for release to be discoverable by tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for i in $(seq 1 30); do
+            if gh release view "${GITHUB_REF_NAME}" \
+                 --repo "${GITHUB_REPOSITORY}" \
+                 --json id >/dev/null 2>&1; then
+              echo "Release ${GITHUB_REF_NAME} is discoverable (attempt $i)."
+              exit 0
+            fi
+            echo "Waiting for release ${GITHUB_REF_NAME} to be discoverable... ($i/30)"
+            sleep 2
+          done
+          echo "::error::Release ${GITHUB_REF_NAME} not discoverable after 60 s. Was 'gh release create' run? Aborting to avoid creating a duplicate draft."
+          exit 1
+
       - name: Upload release assets (Linux/macOS)
         if: runner.os != 'Windows'
         uses: softprops/action-gh-release@v2
@@ -73,6 +101,10 @@ jobs:
           files: |
             dist/kj-${{ matrix.target }}
             dist/kj-${{ matrix.target }}.sha256
+          # Defensive: never mutate the human-created release's metadata.
+          # We are only uploading assets to an existing release.
+          make_latest: false
+          append_body: false
 
       - name: Upload release assets (Windows)
         if: runner.os == 'Windows'
@@ -81,3 +113,5 @@ jobs:
           files: |
             dist/kj-${{ matrix.target }}.exe
             dist/kj-${{ matrix.target }}.exe.sha256
+          make_latest: false
+          append_body: false


### PR DESCRIPTION
**Closes KJC-BUG-0040** (binarios SEA fallan intermitentemente desde v2.12.0 — el bug que llevaba 6 versiones abierto).

## The memory was wrong
This was **NOT** `esbuild + better-sqlite3`. That bug existed in v2.13.0 and was fixed there with the `huBoardStubPlugin` in `scripts/esbuild-sea.config.mjs`. The SEA has built cleanly on all 3 platforms since v2.14.0. Memory misled us into looking at the wrong layer for 6 versions.

## The real cause
Race condition between **the human's `gh release create v<X>`** (step 17 of the release checklist) and **`softprops/action-gh-release@v2`** in the workflow.

`linux-x64` is **always the fastest job** in the matrix (~14 s vs ~22 s darwin / ~30 s win) — so it reaches the upload step BEFORE GitHub has indexed the release-by-tag. softprops then:

1. `GET /releases/tags/v<X>` → 404 (stale index window),
2. `POST /releases` with `tag_name=v<X>` → creates a duplicate **draft**,
3. uploads `kj-linux-x64*` to that draft,
4. `PATCH /releases/<draft_id> { draft:false, tag_name:'v<X>' }` → **422 already_exists**,
5. 3 retries, same error, job fails.

The human's "real" release ends up with darwin + win assets and the linux binary stranded in an orphan draft. There are **4 such orphan drafts** in the repo right now (v2.7.4 · v2.10.0 · v2.11.0 · v2.18.0) — you can delete them with `gh release delete` after merging this.

## Fix
- **Polling step before softprops**: 60 s window (`gh release view --json id`). If `gh release create` was never run, fails fast — **without** creating the orphan draft.
- **`make_latest: false` + `append_body: false`** on both softprops invocations: even by accident, the action cannot mutate the human-created release's metadata. It only uploads assets to an existing release.

Verified by YAML schema parse; the real proof will be the next release of any version having all 6 assets on the first run.