### PR TITLE
fix(coder): wire detectProjectStack into the coder prompt (stack-aware)

### DIFF
--- a/src/prompts/coder.js
+++ b/src/prompts/coder.js
@@ -158,7 +158,28 @@ function renderReviewerFindingsSection(findings, huId) {
   ].join("\n");
 }
 
-export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
+// KJC sesgo-de-stack: Karajan used to default every prompt to JS/TS
+// (vitest, npm install, console.log, JSDoc, httpOnly cookies). When
+// the project is Python / Go / Rust / Ruby, that produced absurd
+// outputs (e.g. installing vitest in a pure-python repo to satisfy a
+// hardcoded `npx vitest run` acceptance test). When we know the
+// stack we tell the coder explicitly so it stops assuming.
+function buildStackSection({ stack, testFramework }) {
+  if (!stack && !testFramework) return null;
+  const lines = ["## Project Stack — match this, don't assume JavaScript"];
+  if (stack?.language) lines.push(`- Language: **${stack.language}**`);
+  if (stack?.frameworks?.length) lines.push(`- Frameworks: ${stack.frameworks.join(", ")}`);
+  if (testFramework?.hasTests && testFramework?.framework) {
+    lines.push(`- Test framework already in use: **${testFramework.framework}** (${testFramework.language || stack?.language || "unknown"}). Use it for new tests; do NOT add a JS test framework on top.`);
+  } else if (stack?.language && stack.language !== "javascript" && stack.language !== "typescript") {
+    lines.push(`- No test framework detected yet. Pick the canonical one for ${stack.language} (e.g. pytest for python, \`go test\` for go, \`cargo test\` for rust, rspec for ruby). Do NOT use vitest / jest / \`npm install\` in a non-JS project.`);
+  }
+  lines.push("");
+  lines.push("If an acceptance_test command on this HU points at a foreign framework (e.g. `npx vitest run` on a python project), REPLACE the command with the equivalent for the project's actual stack and use that to verify your work.");
+  return lines.join("\n");
+}
+
+export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSummary = null, coderRules = null, methodology = "tdd", serenaEnabled = false, rtkAvailable = false, deferredContext = null, productContext = null, domainContext = null, plan = null, projectDir = null, language = "en", provider = null, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null, stack = null, testFramework = null }) {
   const langInstruction = getLanguageInstruction(language);
   // KJC-BUG-0032 (PR-I): hard rule about file paths. Real bug: a HU
   // titled "Initialize project skeleton: create assistant/ directory…"
@@ -190,10 +211,12 @@ export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSum
     "Keep changes minimal and production-ready.",
     "Follow SOLID principles. Write small, focused functions (< 30 lines).",
     "Make atomic commits: 1 logical change = 1 commit. Keep PRs small and reviewable.",
-    "Security: use httpOnly cookies for auth tokens, validate all input, parameterize queries, never expose secrets.",
-    "No console.log — use a structured logger. No 'any' types — use JSDoc annotations.",
+    "Security: validate all input, parameterize queries, never expose secrets. Use the auth pattern that matches the stack (e.g. httpOnly cookies for web sessions).",
+    "Use the project's standard logger and type system (no console.log when a structured logger exists; use the project's type idiom — TS types, JSDoc, Python type hints, Go interfaces…).",
     SUBPROCESS_CONSTRAINTS
   ];
+  const stackRule = buildStackSection({ stack, testFramework });
+  if (stackRule) sections.push(stackRule);
   if (projectDirRule) sections.push(projectDirRule);
 
   if (serenaEnabled) {
@@ -268,7 +291,7 @@ export async function buildCoderPrompt({ task, reviewerFeedback = null, sonarSum
       "1. Find the relevant file(s) in the project",
       "2. Make the specific code change needed to resolve the issue",
       "3. If tests are missing, write them",
-      "4. If dependencies are needed, install them (npm install)",
+      "4. If dependencies are needed, install them with the project's package manager (npm install / pip install / go get / cargo add — pick the one that matches the stack above)",
       "5. Do NOT skip any issue — all must be resolved"
     );
   }

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -2,6 +2,8 @@ import { AgentRole } from "./agent-role.js";
 import { buildCoderPrompt } from "../prompts/coder.js";
 import { isHostAgent } from "../utils/agent-detect.js";
 import { HostAgent } from "../agents/host-agent.js";
+import { detectProjectStack } from "../utils/stack-detect.js";
+import { detectTestFramework } from "../utils/project-detect.js";
 
 export class CoderRole extends AgentRole {
   constructor(opts) {
@@ -54,6 +56,16 @@ export class CoderRole extends AgentRole {
   }
 
   async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests, adrs, specSection, reviewerFindings, huId }) {
+    const projectDir = this.config?.projectDir || null;
+    // KJC sesgo-de-stack: pasar stack/testFramework al prompt para que
+    // el coder no asuma JS/vitest en proyectos Python / Go / Rust /
+    // Ruby. audit-role.js y tester-role.js ya lo hacen así.
+    let stack = null;
+    let testFramework = null;
+    if (projectDir) {
+      try { stack = await detectProjectStack(projectDir); } catch { /* best-effort */ }
+      try { testFramework = await detectTestFramework(projectDir); } catch { /* best-effort */ }
+    }
     const prompt = await buildCoderPrompt({
       task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests,
       adrs, specSection, reviewerFindings, huId,
@@ -63,7 +75,8 @@ export class CoderRole extends AgentRole {
       rtkAvailable: Boolean(this.config?.rtk?.available),
       productContext: this.config?.productContext || null,
       domainContext: this.config?.domainContext || null,
-      projectDir: this.config?.projectDir || null,
+      projectDir,
+      stack, testFramework,
       provider: this._resolvedProvider || (typeof this.resolveProvider === "function" ? this.resolveProvider() : null)
     });
     return { prompt };

--- a/tests/prompt-coder.test.js
+++ b/tests/prompt-coder.test.js
@@ -150,4 +150,47 @@ describe("buildCoderPrompt", () => {
     expect(result).not.toContain("RTK");
     expect(result).not.toContain("Token Optimization");
   });
+
+  // Resilience audit followup — sesgo de stack: when the caller passes
+  // a detected stack, the prompt MUST tell the coder which framework to
+  // use, so it does not install vitest in a pure-Python repo.
+  describe("Project Stack section (stack-aware prompt)", () => {
+    it("emits 'Project Stack' + the detected language and test framework", async () => {
+      const result = await buildCoderPrompt({
+        task: "Add login",
+        stack: { language: "python", frameworks: ["fastapi"] },
+        testFramework: { hasTests: true, framework: "pytest", language: "python" },
+      });
+      expect(result).toContain("Project Stack");
+      expect(result).toContain("Language: **python**");
+      expect(result).toContain("fastapi");
+      expect(result).toContain("**pytest**");
+    });
+
+    it("warns against vitest / jest / npm install when language is non-JS and no framework yet", async () => {
+      const result = await buildCoderPrompt({
+        task: "Add login",
+        stack: { language: "python", frameworks: [] },
+        testFramework: { hasTests: false },
+      });
+      expect(result).toMatch(/pytest for python/);
+      expect(result).toMatch(/Do NOT use vitest \/ jest \/ `npm install` in a non-JS project/);
+    });
+
+    it("omits the Project Stack section when no stack is provided (back-compat)", async () => {
+      const result = await buildCoderPrompt({ task: "Add login" });
+      expect(result).not.toContain("Project Stack");
+    });
+
+    it("the 'install dependencies' guidance is no longer hardcoded to npm install", async () => {
+      const result = await buildCoderPrompt({
+        task: "Fix the bug",
+        reviewerFeedback: "missing null check",
+      });
+      // Either it mentions the family of package managers or it doesn't
+      // mention any (instead of saying just `npm install` as if every
+      // project were a JS project).
+      expect(result).toMatch(/pip install|cargo add|go get|package manager/);
+    });
+  });
 });


### PR DESCRIPTION
**Sesgo-de-stack PR 1/3** — bajar el detector al coder.

## Problem
Karajan has had a multi-language stack detector for a while (`stack-detect.js`, `project-detect.js`, `skill-detector.js`), but **only `audit-role.js` and `tester-role.js` actually consume it**. In a pure-Python repo the coder used to receive a prompt with `No console.log — use JSDoc annotations.` and `If dependencies are needed, install them (npm install)` — so it would install vitest to make a hardcoded `npx vitest run` acceptance_test pass. The user's symptom: *"un proyecto puro Python recibe vitest en sus tests"*.

## Fix
`CoderRole.buildPrompt()` now calls `detectProjectStack(projectDir)` and `detectTestFramework(projectDir)` (same pattern `audit-role.js` already uses) and passes them to `buildCoderPrompt`. `buildCoderPrompt` emits a new section `## Project Stack — match this, don't assume JavaScript`:
- detected language,
- existing test framework (use it, don't add a JS one on top),
- if none yet AND the language is not JS/TS: hint of the canonical framework (`pytest` / `go test` / `cargo test` / `rspec`) and an **explicit** `do NOT use vitest / jest / npm install in a non-JS project`,
- a directive: if an acceptance_test command targets a foreign framework, REPLACE it with the stack equivalent.

Also relaxed three lines that were hardcoded JS in every prompt:
- httpOnly-cookies-only-auth → *"use the auth pattern that matches the stack"*,
- `No console.log — JSDoc annotations` → *"use the project's standard logger and type system (TS types, JSDoc, Python type hints, Go interfaces…)"*,
- `install dependencies (npm install)` → *"… with the project's package manager (npm install / pip install / go get / cargo add …)"*.

## Scope
This PR only fixes the **coder** path. The auto-generator HU template with hardcoded vitest (`buildSetupHu` / `buildTaskHu`) is **PR B**. The planner + tests-synthesizer canal is **PR C**.

## Tests
- `tests/prompt-coder.test.js` — Project Stack section emitted with `language`, frameworks, test framework; warning against vitest on non-JS; absent when no stack provided (back-compat); install-dependencies guidance no longer says only `npm install`.
- Full `tests/coder/` + `tests/prompt-coder.test.js` green (66/66).

Net +79 LOC.