### PR TITLE
fix(synthesizer,auto-hu-batch): take stack from the filesystem, not from the task text

### DIFF
--- a/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
+++ b/src/orchestrator/drivers/pre-loop-phases/auto-hu-batch.js
@@ -16,6 +16,7 @@
  */
 
 import { emitProgress, makeEvent } from "#utils/events.js";
+import { detectProjectStack } from "#utils/stack-detect.js";
 
 export async function maybeGenerateAutoHuBatch({
   flags, stageResults, task, logger, emitter, eventBase, projectDir, session,
@@ -40,19 +41,38 @@ export async function maybeGenerateAutoHuBatch({
     isNewProject = relevant.length === 0;
   } catch { /* ignore */ }
 
-  // Extract stack hints from planner + architect output
+  // Stack hints from planner + architect text. Now multi-ecosystem
+  // (was 13/16 JS keywords — Python/Go/Rust barely existed). Combined
+  // with `detectProjectStack(projectDir)` below to override the text
+  // heuristic with the actual filesystem reality when available.
   const stackHints = [];
   const combined = `${stageResults.planner?.plan || ""} ${stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : ""} ${task}`.toLowerCase();
-  const stackKeywords = ["express", "vite", "vitest", "jest", "next", "astro", "react", "vue", "svelte", "fastapi", "django", "spring", "gin", "nestjs", "monorepo", "workspaces"];
+  const stackKeywords = [
+    "express", "vite", "vitest", "jest", "next", "astro", "react", "vue", "svelte", "nestjs", "monorepo", "workspaces",
+    "pytest", "flask", "fastapi", "django", "numpy", "pandas",
+    "gin", "fiber", "go",
+    "cargo", "rust",
+    "spring",
+  ];
   for (const kw of stackKeywords) {
     if (combined.includes(kw)) stackHints.push(kw);
   }
+
+  // Filesystem trumps text. detectProjectStack inspects package.json /
+  // pyproject.toml / go.mod / Cargo.toml, so a pure-python repo gets
+  // `language: "python"` regardless of what the task text says.
+  let detectedLanguage = null;
+  try {
+    const fsStack = await detectProjectStack(projectDir);
+    if (fsStack?.language) detectedLanguage = fsStack.language;
+  } catch { /* best-effort */ }
 
   const batch = generateHuBatch({
     originalTask: task,
     subtasks,
     stackHints,
     isNewProject,
+    language: detectedLanguage,
     researcherContext: stageResults.researcher?.summary || null,
     architectContext: stageResults.architect?.architecture ? JSON.stringify(stageResults.architect.architecture) : null
   });

--- a/src/plan/tests-synthesizer.js
+++ b/src/plan/tests-synthesizer.js
@@ -33,7 +33,7 @@ import { withBrainRecovery } from "../brain/with-brain-recovery.js";
  * @param {Array<{ id: string, title?: string, scope?: string }>} args.husNeedingTests
  * @returns {string}
  */
-export function buildSynthesizerPrompt({ task, husNeedingTests }) {
+export function buildSynthesizerPrompt({ task, husNeedingTests, stack = null, testFramework = null }) {
   const lines = [
     "You previously generated an implementation plan for the task below, but some HUs were left without acceptance_tests.",
     "Your ONLY job in this call is to fill that gap.",
@@ -59,12 +59,22 @@ export function buildSynthesizerPrompt({ task, husNeedingTests }) {
     "- Tests must be writable BEFORE the HU is implemented (they should fail until done).",
     "- Return ONLY the JSON — no prose, no markdown fences around it.",
     "",
-    "## Task",
-    task,
-    "",
-    "## HUs that need acceptance_tests",
-    "",
   ];
+  // Stack-aware hint: tell the LLM what test framework / language to
+  // emit shell commands for. Without this it defaulted to vitest /
+  // npm even on Python / Go / Rust projects (sesgo-de-stack audit).
+  if (stack || testFramework) {
+    lines.push("## Project Stack — generate shell tests for THIS stack, not generic JS");
+    if (stack?.language) lines.push(`- Language: **${stack.language}**`);
+    if (stack?.frameworks?.length) lines.push(`- Frameworks: ${stack.frameworks.join(", ")}`);
+    if (testFramework?.hasTests && testFramework?.framework) {
+      lines.push(`- Test framework already in use: **${testFramework.framework}** — use it for the shell commands.`);
+    } else if (stack?.language && stack.language !== "javascript" && stack.language !== "typescript") {
+      lines.push(`- Use the canonical test runner for ${stack.language} (pytest / go test / cargo test / rspec). Do NOT emit vitest, jest, or npm commands.`);
+    }
+    lines.push("");
+  }
+  lines.push("## Task", task, "", "## HUs that need acceptance_tests", "");
   for (const hu of husNeedingTests) {
     lines.push(`### ${hu.id}: ${hu.title || ""}`);
     lines.push(hu.scope ? `Scope: ${hu.scope}` : "(no scope)");

--- a/tests/plan/tests-synthesizer.test.js
+++ b/tests/plan/tests-synthesizer.test.js
@@ -160,4 +160,41 @@ describe("synthesizeMissingTests", () => {
     expect(args.timeoutMs).toBe(12345);
     expect(args.role).toBe("planner");
   });
+
+  // Sesgo-de-stack PR 3/3: synthesizer used to emit `npx vitest run`
+  // as the fallback shell command for any project. Now the caller can
+  // pass stack/testFramework so the prompt tells the LLM what runner
+  // to use (pytest, go test, cargo test, ...).
+  describe("stack-aware prompt", () => {
+    it("emits the Project Stack section when a stack is provided", () => {
+      const prompt = buildSynthesizerPrompt({
+        task: "Build it",
+        husNeedingTests: [{ id: "hu1", title: "x" }],
+        stack: { language: "python", frameworks: ["fastapi"] },
+        testFramework: { hasTests: true, framework: "pytest" },
+      });
+      expect(prompt).toContain("Project Stack");
+      expect(prompt).toContain("**python**");
+      expect(prompt).toContain("**pytest**");
+    });
+
+    it("warns against vitest/jest/npm on a non-JS stack with no framework yet", () => {
+      const prompt = buildSynthesizerPrompt({
+        task: "Build it",
+        husNeedingTests: [{ id: "hu1", title: "x" }],
+        stack: { language: "rust" },
+        testFramework: { hasTests: false },
+      });
+      expect(prompt).toMatch(/cargo test/);
+      expect(prompt).toMatch(/Do NOT emit vitest, jest/);
+    });
+
+    it("omits the Project Stack section when none is passed (back-compat)", () => {
+      const prompt = buildSynthesizerPrompt({
+        task: "Build it",
+        husNeedingTests: [{ id: "hu1", title: "x" }],
+      });
+      expect(prompt).not.toContain("Project Stack");
+    });
+  });
 });


### PR DESCRIPTION
**Sesgo-de-stack PR 3/3** — closes the audit follow-up.

## Problem
Two layers of the planner pipeline assumed JS:

1. **`auto-hu-batch.js`** derived the project's stack from a 16-keyword text scan over `planner + architect + task` (13 of the 16 keywords were JS). A pure-Python project whose task didn't happen to mention `pytest` got classified as JS and inherited the JS HU templates (vitest, npm install).
2. **`tests-synthesizer.js`** never received any stack at all — it told the LLM "do not use generic fallbacks like `npx vitest run`" but gave it no alternative, so the LLM defaulted back to JS commands by model bias.

## Fix

**`auto-hu-batch.js`** —
- Keyword set extended to all ecosystems (`pytest`/`flask`/`fastapi`/`django`/`numpy`/`pandas` + `gin`/`fiber`/`go` + `cargo`/`rust` on top of the JS set).
- More importantly: calls `detectProjectStack(projectDir)` on the **real filesystem** and, if it returns a language, passes it **explicitly** to `generateHuBatch` — overriding any text-based guess. So a python repo with no python keywords in its task still gets the python templates.

**`tests-synthesizer.js`** —
- `buildSynthesizerPrompt` accepts `stack` and `testFramework`.
- Emits a `## Project Stack` block telling the LLM to use the canonical runner for the language (`pytest` / `go test` / `cargo test` / `rspec`) and **NOT** to emit `vitest`, `jest` or `npm`. Section absent when no stack is passed (back-compat).

## Tests
- `tests-synthesizer.test.js` — Project Stack section emitted with language + framework; non-JS without a framework gets a `Do NOT emit vitest / jest` warning; absent when no stack (back-compat).
- 192/192 in `tests/plan/` + `tests/hu/`.

Net +67 LOC. **Closes the sesgo-de-stack audit follow-up.**