### PR TITLE
docs(readme): pipeline 24 stages / 3 phases + missing role rows (KJC-TSK-0418)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,12 @@ $ claude                         $ kj-tail
 ## The pipeline
 
 ```
-hu-reviewer? → triage → domain-curator? → discover? → architect? → planner? → coder → sonar? → impeccable? → reviewer → tester? → security? → solomon → commiter?
+pre-loop:  intent → hu-reviewer? → triage? → domain-curator? → discover? → skills? → researcher? → architect? → planner? → acceptance?
+iteration: coder → refactorer? → guard(output) → guard(perf) → sonar? → tdd → reviewer → solomon? → brain?   (loops 1..N)
+post-loop: tester? → security? → perf? → impeccable? → audit?
 ```
 
-**16 roles**, each executed by the AI agent you choose:
+**24 stages** across three phases: 18 AI-agent-backed roles (table below), 6 deterministic stages without an LLM call (`intent`, `skills`, `acceptance`, `guard(output)`, `guard(perf)`, `tdd`). Two extra classes (`commiter`, `repairer`) are post-approval / internal helpers, not standalone pipeline stages. Each AI role is executed by the agent you choose:
 
 | Role | What it does | Default |
 |------|-------------|---------|
@@ -238,7 +240,16 @@ hu-reviewer? → triage → domain-curator? → discover? → architect? → pla
 | **security** | OWASP security audit | **On** |
 | **solomon** | Pipeline boss: evaluates every rejection, overrides style-only blocks | **On** |
 | **commiter** | Git commit, push, and PR automation after approval | Off |
+| **researcher** | Investigates the codebase before planning (file map + signatures + related tests) | Off |
+| **perf** | WebPerf quality gate — Core Web Vitals (LCP, CLS, INP) via Lighthouse | Off |
+| **brain** | Central AI orchestrator: routing, feedback enrichment, output compression | **On** |
 | **audit** | Read-only codebase health analysis (5 dimensions, A-F scores) | Standalone |
+
+> **Deterministic stages (no class):** `intent` (task-type classifier — `sw` / `infra` / `doc` / `add-tests` / `refactor` / `audit`), `skills` (slash-command surface), `acceptance` (executable acceptance tests), `guard(output)` (destructive ops + credential leaks), `guard(perf)` (frontend anti-patterns), `tdd` (test-coverage check).
+>
+> **Internal helpers (have a class, not a standalone stage):** `commiter` (git automation post-approval), `repairer` (repairs broken acceptance tests at runtime, invoked by `acceptance` / `tdd`).
+>
+> Full per-stage reference: [Pipeline roles](https://karajan-code.web.app/docs/handbook/pipeline-roles/) (handbook).
 
 ## 5 AI agents supported
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -141,10 +141,12 @@ kj-tail --help           # Todas las opciones
 ## El pipeline
 
 ```
-hu-reviewer? → triage → domain-curator? → discover? → architect? → planner? → coder → sonar? → impeccable? → reviewer → tester? → security? → solomon → commiter?
+pre-loop:  intent → hu-reviewer? → triage? → domain-curator? → discover? → skills? → researcher? → architect? → planner? → acceptance?
+iteration: coder → refactorer? → guard(output) → guard(perf) → sonar? → tdd → reviewer → solomon? → brain?   (bucle 1..N)
+post-loop: tester? → security? → perf? → impeccable? → audit?
 ```
 
-**16 roles**, cada uno ejecutado por el agente de IA que elijas:
+**24 etapas** repartidas en tres fases: 18 roles respaldados por agente IA (tabla abajo), 6 etapas deterministas sin llamada al LLM (`intent`, `skills`, `acceptance`, `guard(output)`, `guard(perf)`, `tdd`). Dos clases extra (`commiter`, `repairer`) son post-aprobación / auxiliares internas, no etapas independientes del pipeline. Cada rol IA es ejecutado por el agente que tú elijas:
 
 | Rol | Que hace | Por defecto |
 |-----|----------|-------------|
@@ -163,7 +165,16 @@ hu-reviewer? → triage → domain-curator? → discover? → architect? → pla
 | **security** | Auditoria de seguridad OWASP | **On** |
 | **solomon** | Jefe del pipeline: evalua cada rechazo, anula bloqueos solo de estilo | **On** |
 | **commiter** | Automatizacion de git commit, push y PR tras aprobacion | Off |
+| **researcher** | Investiga el codebase antes de planificar (mapa de ficheros + signatures + tests relacionados) | Off |
+| **perf** | Quality gate WebPerf — Core Web Vitals (LCP, CLS, INP) via Lighthouse | Off |
+| **brain** | Orquestador IA central: routing, enriquecimiento de feedback, compresión de salidas | **On** |
 | **audit** | Analisis de salud del codebase solo-lectura (5 dimensiones, scores A-F) | Standalone |
+
+> **Etapas deterministas (sin clase):** `intent` (clasificador de tipo de tarea — `sw` / `infra` / `doc` / `add-tests` / `refactor` / `audit`), `skills` (superficie de slash-commands), `acceptance` (tests de aceptación ejecutables), `guard(output)` (operaciones destructivas + fugas de credenciales), `guard(perf)` (anti-patrones frontend), `tdd` (verificación de cobertura).
+>
+> **Auxiliares internas (tienen clase, no etapa independiente):** `commiter` (automatización git post-aprobación), `repairer` (repara tests de aceptación rotos en runtime, invocado por `acceptance` / `tdd`).
+>
+> Referencia completa por etapa: [Roles del pipeline](https://karajan-code.web.app/docs/es/handbook/pipeline-roles/) (handbook).
 
 ## 5 agentes de IA soportados
 


### PR DESCRIPTION
## Why

Both READMEs were stuck on the pre-v2.10 picture: a 1-line linear pipeline of 14 nodes and a `16 roles` header. Reality today is **24 stages across three phases**, with 18 AI-backed roles, 6 deterministic stages and 2 internal helpers. Three roles missing from the table for releases: `researcher` (v2.7), `perf` (v2.10), `brain` (v2.15+).

## What changes

Both `README.md` and `docs/README.es.md` (symmetric edits):

1. **Pipeline diagram** — single-line flow → three blocks:
   - `pre-loop:  intent → hu-reviewer? → triage? → domain-curator? → discover? → skills? → researcher? → architect? → planner? → acceptance?`
   - `iteration: coder → refactorer? → guard(output) → guard(perf) → sonar? → tdd → reviewer → solomon? → brain?   (loops 1..N)`
   - `post-loop: tester? → security? → perf? → impeccable? → audit?`

2. **Header text** — `16 roles` → `24 stages across three phases: 18 AI-agent-backed roles (table below), 6 deterministic stages without an LLM call …`

3. **Three new role rows** in the table — `researcher`, `perf`, `brain` (in that order, between `commiter` and `audit`).

4. **Footnote** after the table:
   - Lists the 6 deterministic stages with one-liner each.
   - Lists the 2 internal helpers (commiter, repairer).
   - Links to handbook `pipeline-roles` page for the per-stage reference.

## Verification (from the task spec)

```
$ grep -nE "\b16\b[^.]{0,40}\b(roles?|specialized roles)" README.md docs/README.es.md
(empty — OK)

$ grep -cE "^\| \*\*[a-z-]+\*\* \|" README.md docs/README.es.md
docs/README.es.md:19
README.md:19   # 16 originals + 3 new (researcher / perf / brain)
```

## Net delta

```
README.md         | 15 +++++++++++++--
docs/README.es.md | 15 +++++++++++++--
2 files changed, 26 insertions(+), 4 deletions(-)
```

+22 LOC net. Both files are human-facing docs, exempt from the 200-LOC shrink-budget.

PG: KJC-TSK-0418 under epic KJC-PCS-0046.