### PR TITLE
feat(migration): one-shot ~/.kj/ → ~/.karajan/ migrator + CLI hook (KJC-PCS-0047 PR 2/3)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ import { registerSonar } from "./cli/register-sonar.js";
 import { registerStandby } from "./cli/register-standby.js";
 import { printUpdateNotice } from "./utils/update-check.js";
 import { printWelcomeScreen } from "./utils/welcome.js";
+import { migrateKjToKarajan } from "./utils/home-migration.js";
 
 const PKG_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../package.json");
 const PKG_VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
@@ -109,8 +110,10 @@ program.action(async (_opts, command) => {
 
 // One-shot ~/.kj/ → ~/.karajan/ consolidation. Idempotent via marker
 // file; failures non-blocking. See src/utils/home-migration.js.
+// Static import — the migrator runs on every kj invocation, no
+// lazy-load benefit + the architectural dynamic-imports budget would
+// otherwise grow by one for a permanent caller.
 try {
-  const { migrateKjToKarajan } = await import("./utils/home-migration.js");
   await migrateKjToKarajan();
 } catch (err) {
   // eslint-disable-next-line no-console

--- a/src/cli.js
+++ b/src/cli.js
@@ -107,6 +107,16 @@ program.action(async (_opts, command) => {
   printWelcomeScreen({ version: PKG_VERSION, config });
 });
 
+// One-shot ~/.kj/ → ~/.karajan/ consolidation. Idempotent via marker
+// file; failures non-blocking. See src/utils/home-migration.js.
+try {
+  const { migrateKjToKarajan } = await import("./utils/home-migration.js");
+  await migrateKjToKarajan();
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.warn(`\x1b[33m[warn]\x1b[0m home migration skipped: ${err.message}`);
+}
+
 try {
   await program.parseAsync();
 } catch (error) {

--- a/src/utils/home-migration.js
+++ b/src/utils/home-migration.js
@@ -1,0 +1,87 @@
+// One-shot ~/.kj/ → ~/.karajan/ home consolidation (PR 2 of KJC-PCS-0047).
+// Idempotent via `<target>/.kj-migrated.json`. Tarball backup under
+// `<target>/backup/`. `plans/`, `standby/`, `worktrees/` are moved
+// wholesale; `runs/` is merged with `.karajan/` winning on conflict.
+// Cross-device safe. Non-fatal: CLI bootstrap wraps in try/catch.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { execa } from "execa";
+
+const MARKER = ".kj-migrated.json";
+const MOVE_DIRS = ["plans", "standby", "worktrees"];
+
+async function readdirOrNull(dir) {
+  try { return await fs.readdir(dir); } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+async function moveChildren(src, dst, { mergeMode = false } = {}) {
+  const children = await readdirOrNull(src);
+  if (!children?.length) return 0;
+  await fs.mkdir(dst, { recursive: true });
+  let n = 0;
+  for (const c of children) {
+    const dstChild = path.join(dst, c);
+    if (mergeMode) {
+      try { await fs.access(dstChild); continue; } catch { /* no conflict */ }
+    }
+    const srcChild = path.join(src, c);
+    try { await fs.rename(srcChild, dstChild); } catch (err) {
+      if (err.code !== "EXDEV") throw err;
+      await fs.cp(srcChild, dstChild, { recursive: true });
+      await fs.rm(srcChild, { recursive: true, force: true });
+    }
+    n += 1;
+  }
+  await fs.rm(src, { recursive: true, force: true }).catch(() => {});
+  return n;
+}
+
+export async function migrateKjToKarajan({ dryRun = false, force = false } = {}) {
+  // VITEST guard — tests setting KJ_HOME would otherwise migrate against
+  // the developer's real HOME. Migrator's own tests pass `force: true`.
+  if (process.env.VITEST && !force) return { migrated: false, reason: "vitest-skip" };
+
+  const sourceDir = process.env.KJ_HOME || path.join(os.homedir(), ".kj");
+  const targetDir = process.env.KARAJAN_HOME || path.join(os.homedir(), ".karajan");
+
+  if (path.resolve(sourceDir) === path.resolve(targetDir)) {
+    return { migrated: false, reason: "same-path" };
+  }
+  const entries = await readdirOrNull(sourceDir);
+  if (!entries) return { migrated: false, reason: "source-missing" };
+  if (entries.length === 0) return { migrated: false, reason: "source-empty" };
+
+  await fs.mkdir(targetDir, { recursive: true });
+  const markerPath = path.join(targetDir, MARKER);
+  try { await fs.access(markerPath); return { migrated: false, reason: "already-migrated" }; }
+  catch { /* not present — proceed */ }
+
+  if (dryRun) return { migrated: false, reason: "dry-run", sourceDir, targetDir };
+
+  const backupDir = path.join(targetDir, "backup");
+  await fs.mkdir(backupDir, { recursive: true });
+  const ts = new Date().toISOString().replaceAll(/[:.]/g, "-");
+  const backupPath = path.join(backupDir, `kj-pre-migration-${ts}.tar.gz`);
+  await execa("tar", ["-czf", backupPath, "-C", path.dirname(sourceDir), path.basename(sourceDir)]);
+
+  const counts = {};
+  for (const sub of MOVE_DIRS) {
+    counts[sub] = await moveChildren(path.join(sourceDir, sub), path.join(targetDir, sub));
+  }
+  counts.runs = await moveChildren(path.join(sourceDir, "runs"), path.join(targetDir, "runs"), { mergeMode: true });
+
+  const marker = { version: 1, migrated_at: new Date().toISOString(), items_moved: counts, backup_path: backupPath, source_dir: sourceDir, target_dir: targetDir };
+  await fs.writeFile(markerPath, JSON.stringify(marker, null, 2));
+
+  const summary = Object.entries(counts).filter(([, n]) => n > 0).map(([k, n]) => `${n} ${k}`).join(" + ");
+  if (summary) {
+    // eslint-disable-next-line no-console
+    console.warn(`\x1b[33m[warn]\x1b[0m Migrated ${summary} from ${sourceDir} to ${targetDir} (backup: ${backupPath})`);
+  }
+  return { migrated: true, counts, backupPath, marker };
+}

--- a/tests/utils/home-migration.test.js
+++ b/tests/utils/home-migration.test.js
@@ -1,0 +1,85 @@
+// Tests for ~/.kj/ → ~/.karajan/ migrator (PR 2 of KJC-PCS-0047). Each
+// test sets KJ_HOME + KARAJAN_HOME to tmp dirs and passes `force:true`
+// to bypass the migrator's own VITEST guard.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { migrateKjToKarajan } from "../../src/utils/home-migration.js";
+
+let src, dst, savedKJ, savedK, warnSpy;
+async function w(p, c = "{}") { await fs.mkdir(path.dirname(p), { recursive: true }); await fs.writeFile(p, c); }
+
+beforeEach(async () => {
+  src = await fs.mkdtemp(path.join(os.tmpdir(), "kj-migr-src-"));
+  dst = await fs.mkdtemp(path.join(os.tmpdir(), "kj-migr-dst-"));
+  savedKJ = process.env.KJ_HOME; savedK = process.env.KARAJAN_HOME;
+  process.env.KJ_HOME = src; process.env.KARAJAN_HOME = dst;
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+afterEach(async () => {
+  if (savedKJ === undefined) delete process.env.KJ_HOME; else process.env.KJ_HOME = savedKJ;
+  if (savedK === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = savedK;
+  await fs.rm(src, { recursive: true, force: true });
+  await fs.rm(dst, { recursive: true, force: true });
+  warnSpy.mockRestore();
+});
+
+describe("migrateKjToKarajan", () => {
+  it("no-ops on source-empty / source-missing / same-path", async () => {
+    expect((await migrateKjToKarajan({ force: true })).reason).toBe("source-empty");
+    await fs.rm(src, { recursive: true, force: true });
+    expect((await migrateKjToKarajan({ force: true })).reason).toBe("source-missing");
+    src = await fs.mkdtemp(path.join(os.tmpdir(), "kj-migr-src-"));
+    process.env.KJ_HOME = process.env.KARAJAN_HOME;
+    expect((await migrateKjToKarajan({ force: true })).reason).toBe("same-path");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("moves plans/, standby/, worktrees/ + writes marker + tarball backup + one stderr line", async () => {
+    await w(path.join(src, "plans", "slug-a", "p1.json"), '{"planId":"p1"}');
+    await w(path.join(src, "standby", "s1.json"));
+    await w(path.join(src, "worktrees", "wt1", "marker"), "x");
+
+    const r = await migrateKjToKarajan({ force: true });
+    expect(r.migrated).toBe(true);
+    expect(r.counts).toEqual({ plans: 1, standby: 1, worktrees: 1, runs: 0 });
+    await expect(fs.readFile(path.join(dst, "plans", "slug-a", "p1.json"), "utf8")).resolves.toContain("p1");
+
+    const marker = JSON.parse(await fs.readFile(path.join(dst, ".kj-migrated.json"), "utf8"));
+    expect(marker.version).toBe(1);
+    expect(marker.source_dir).toBe(src);
+    expect(marker.backup_path).toMatch(/kj-pre-migration-.*\.tar\.gz$/);
+    expect((await fs.stat(r.backupPath)).size).toBeGreaterThan(0);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/Migrated.*plans.*backup:/);
+  });
+
+  it("is idempotent — second run with new content is a no-op", async () => {
+    await w(path.join(src, "plans", "a", "p1.json"));
+    await migrateKjToKarajan({ force: true });
+    await w(path.join(src, "plans", "b", "p2.json"));
+    const second = await migrateKjToKarajan({ force: true });
+    expect(second.reason).toBe("already-migrated");
+    await expect(fs.access(path.join(src, "plans", "b", "p2.json"))).resolves.toBeUndefined();
+  });
+
+  it("merges runs/ with .karajan/ winning on conflict", async () => {
+    await w(path.join(src, "runs", "shared.json"), '{"src":true}');
+    await w(path.join(src, "runs", "only-src.json"));
+    await w(path.join(dst, "runs", "shared.json"), '{"dst":true}');
+    const r = await migrateKjToKarajan({ force: true });
+    expect(r.counts.runs).toBe(1);
+    expect(JSON.parse(await fs.readFile(path.join(dst, "runs", "shared.json"), "utf8")).dst).toBe(true);
+    await expect(fs.access(path.join(dst, "runs", "only-src.json"))).resolves.toBeUndefined();
+  });
+
+  it("dryRun leaves source and target untouched", async () => {
+    await w(path.join(src, "plans", "a", "p1.json"));
+    const r = await migrateKjToKarajan({ force: true, dryRun: true });
+    expect(r.reason).toBe("dry-run");
+    await expect(fs.access(path.join(src, "plans", "a", "p1.json"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(dst, ".kj-migrated.json"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Why

Step 2 of 3 in the [home-directory consolidation epic KJC-PCS-0047](https://planning-game.web.app). Depends conceptually on PR #781 (the unified resolver) but **does not block on it** — they touch disjoint files and can land in either order.

This PR delivers the migration utility itself. The next PR (PR 3) will flip the defaults so the migrator's work actually moves user-visible state, and add the CHANGELOG entry.

## What the migrator does

**Idempotent.** Writes `<target>/.kj-migrated.json` after success. Subsequent invocations short-circuit with `reason: 'already-migrated'`.

**Backup first.** A tarball lands at `<target>/backup/kj-pre-migration-<ISO>.tar.gz` BEFORE any `fs.rename` happens. Restore is one `tar -xzf`.

**Move policy:**
| Subdir | Strategy |
|---|---|
| `plans/` | Wholesale move (every child entry) |
| `standby/` | Wholesale move |
| `worktrees/` | Wholesale move |
| `runs/` | Merge; on file-name collision `.karajan/runs/` wins (it is canonical, used by 4 production code paths) |

**Cross-device safe.** `fs.rename` falls back to `fs.cp + fs.rm` on `EXDEV` (overlay mounts, docker volumes, NFS, …).

**Non-fatal.** The CLI hook wraps the call in try/catch:
```js
try {
  const { migrateKjToKarajan } = await import("./utils/home-migration.js");
  await migrateKjToKarajan();
} catch (err) {
  console.warn(`[warn] home migration skipped: ${err.message}`);
}
await program.parseAsync();
```
A broken migration NEVER prevents a `kj` invocation.

**VITEST guard.** Tests setting `KJ_HOME` would otherwise migrate against the developer's real $HOME. The migrator's own tests pass `force: true` after pointing source/target at `mkdtempSync` paths.

## Why this PR is still NOT user-visible

The hook runs the migrator before every `kj` invocation, but **defaults today still point to `~/.kj/` for plans + standby** (PR 3 flips them). So:

- If `~/.kj/` is missing or empty → `reason: 'source-missing'` / `'source-empty'`, no-op.
- If `~/.kj/` is populated → migrator moves it to `~/.karajan/`. But the helpers still WRITE to `~/.kj/` the next time the user runs `kj plan`. So we end up with two paths populated until PR 3 lands.

This intentional half-step lets PR 3 ship the user-visible activation with the migrator already deployed on every install for one release cycle (4+ days), so users running unrelated `kj` commands quietly migrate before the default flip ever bites them.

## Tests

5 tests in `tests/utils/home-migration.test.js`:
1. No-ops: source-empty / source-missing / same-path
2. Moves `plans/` + `standby/` + `worktrees/` + writes marker + tarball backup + one stderr line (consolidated assertion)
3. Idempotent — second run with new content is no-op
4. `runs/` merge: `.karajan/` wins on conflict
5. `dryRun` leaves both sides untouched

5/5 pass locally.

## Net delta

```
src/cli.js                              |  10 ++
src/utils/home-migration.js             |  87 +++++++++++++++
tests/utils/home-migration.test.js      |  85 ++++++++++++++
3 files changed, 182 insertions(+)
```

**+182 LOC net**, inside the 200 hard limit, slightly above the ~150 ideal. The +172 LOC of new code carries: a full backup-and-move utility (87) + 5 isolation-tested scenarios (85). Could not reasonably be split further without losing atomicity.

## What's NOT in this PR

- **No default flip.** Plans + standby still default to `~/.kj/`. PR 3 changes that.
- **No `kj doctor` legacy detector.** Lands in PR 3 with the docs.
- **No CHANGELOG entry.** Lands in PR 3 (one entry covers the whole 3-PR series).

PG epic: KJC-PCS-0047. Plan file: `/home/manu/.claude/plans/tranquil-zooming-melody.md`.