### PR TITLE
feat(roles): add spec-reviewer — audit user spec BEFORE pipeline (KJC-PCS-0048 PR 1/3)

### DIFF
--- a/src/config/role-resolver.js
+++ b/src/config/role-resolver.js
@@ -49,7 +49,9 @@ function isModelCompatible(agent, model) {
 // Roles that inherit provider/model from the coder when not explicitly configured
 const CODER_INHERITED_ROLES = new Set([
   "planner", "refactorer", "solomon", "researcher", "tester", "security",
-  "impeccable", "triage", "discover", "architect", "audit", "hu_reviewer", "hu-reviewer"
+  "impeccable", "triage", "discover", "architect", "audit",
+  "hu_reviewer", "hu-reviewer",
+  "spec_reviewer", "spec-reviewer",
 ]);
 
 function resolveProvider(roleConfig, role, roles, legacyCoder, legacyReviewer) {

--- a/src/prompts/spec-reviewer.js
+++ b/src/prompts/spec-reviewer.js
@@ -1,0 +1,42 @@
+// Prompt builder for the `spec-reviewer` role (KJC-PCS-0048 PR 1).
+// Mirrors src/prompts/triage.js — project-level override at
+// `<projectDir>/.karajan/roles/spec-reviewer.md` is injected via `instructions`.
+
+const SUBAGENT_PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent.",
+  "Do NOT execute or plan the task. Do NOT mention Karajan.",
+  "Do NOT use any MCP tools. Your only job is to audit the user's spec.",
+].join(" ");
+
+const VALID_CATEGORIES = [
+  "ambiguity", "missing_scope", "missing_ac", "contradiction",
+  "stack", "assumptions", "out_of_scope",
+];
+
+const SCHEMA_HINT = JSON.stringify({
+  severity: "ok|info|warn|fail",
+  findings: [{
+    id: "F-001",
+    severity: "info|warn|fail",
+    category: VALID_CATEGORIES.join("|"),
+    message: "concrete description",
+    suggestion: "concrete sentence the user can paste",
+  }],
+  reasoning: "one or two sentences",
+}, null, 2);
+
+export function buildSpecReviewerPrompt({ spec, instructions } = {}) {
+  const sections = [SUBAGENT_PREAMBLE];
+  if (instructions) sections.push(instructions);
+  sections.push(
+    "You are the **Spec Reviewer** for Karajan Code.",
+    `Categories (pick one per finding): ${VALID_CATEGORIES.join(", ")}.`,
+    "Severity: `info` (nuance), `warn` (real gap), `fail` (unworkable). Top-level severity is the WORST of any finding (or `ok` if none).",
+    "Return JSON only:",
+    "```json", SCHEMA_HINT, "```",
+    "## Spec to audit", "```", String(spec || "").trim(), "```",
+  );
+  return sections.join("\n");
+}
+
+export { VALID_CATEGORIES };

--- a/src/roles/spec-reviewer-role.js
+++ b/src/roles/spec-reviewer-role.js
@@ -1,0 +1,81 @@
+// Spec Reviewer role (KJC-PCS-0048 PR 1). Runs BEFORE intent/triage/planner;
+// audits the user's spec and returns structured findings. Does NOT execute.
+
+import { AgentRole } from "./agent-role.js";
+import { buildSpecReviewerPrompt, VALID_CATEGORIES } from "../prompts/spec-reviewer.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+
+const F_SEVS = new Set(["info", "warn", "fail"]);
+const T_SEVS = new Set(["ok", "info", "warn", "fail"]);
+const CATS = new Set(VALID_CATEGORIES);
+const ORDER = { ok: 0, info: 1, warn: 2, fail: 3 };
+
+function normalise(findings) {
+  if (!Array.isArray(findings)) return [];
+  return findings.map((f, i) => ({
+    id: typeof f?.id === "string" && f.id.trim() ? f.id.trim() : `F-${String(i + 1).padStart(3, "0")}`,
+    severity: F_SEVS.has(f?.severity) ? f.severity : "warn",
+    category: CATS.has(f?.category) ? f.category : "ambiguity",
+    message: String(f?.message || "").trim() || "(no description)",
+    suggestion: typeof f?.suggestion === "string" && f.suggestion.trim() ? f.suggestion.trim() : null,
+  }));
+}
+
+const worstOf = (findings) => findings.reduce((m, f) => (ORDER[f.severity] > ORDER[m] ? f.severity : m), "ok");
+
+export class SpecReviewerRole extends AgentRole {
+  constructor(opts) { super({ ...opts, name: "spec-reviewer" }); }
+
+  extractInput(input) {
+    if (typeof input === "string") return { spec: input, onOutput: null };
+    return {
+      spec: input?.spec || input?.task || this.context?.task || "",
+      onOutput: input?.onOutput || null,
+      sessionState: input?.sessionState || null,
+    };
+  }
+
+  async buildPrompt({ spec }) {
+    return { prompt: buildSpecReviewerPrompt({ spec, instructions: this.instructions }) };
+  }
+
+  parseOutput(raw) { return extractFirstJson(raw); }
+
+  buildSuccessResult(parsed, provider) {
+    const findings = normalise(parsed?.findings);
+    const declared = T_SEVS.has(parsed?.severity) ? parsed.severity : null;
+    const derived = worstOf(findings);
+    // Trust the worse of declared vs derived — agents sometimes report
+    // `severity: "ok"` while still listing fail-level findings.
+    const severity = !declared || ORDER[derived] > ORDER[declared] ? derived : declared;
+    return { severity, findings, reasoning: String(parsed?.reasoning || "").trim() || null, provider };
+  }
+
+  buildSummary(parsed) {
+    const findings = normalise(parsed?.findings);
+    if (findings.length === 0) return "Spec OK (no findings)";
+    return `Spec ${worstOf(findings)}: ${findings.length} finding${findings.length === 1 ? "" : "s"}`;
+  }
+
+  // Parse failures degrade to a soft warning so the pipeline never blocks.
+  handleParseNull(r, p) { return this.#degraded(r, p, "parse-null", "LLM output was unstructured"); }
+  handleParseError(e, r, p) { return this.#degraded(r, p, "parse-error", e?.message || "unknown"); }
+
+  #degraded(agentResult, provider, reason, detail) {
+    return {
+      ok: true,
+      result: {
+        severity: "warn",
+        findings: [{
+          id: "F-DEG", severity: "warn", category: "assumptions",
+          message: `[spec-reviewer] degraded (${reason}): ${detail}`,
+          suggestion: "Re-run with --skip-spec-review if this keeps failing.",
+        }],
+        reasoning: "Spec reviewer could not parse the LLM output; treating as a soft warning.",
+        provider, degraded: true,
+      },
+      summary: `Spec reviewer degraded: ${reason}`,
+      usage: agentResult?.usage,
+    };
+  }
+}

--- a/templates/roles/spec-reviewer.md
+++ b/templates/roles/spec-reviewer.md
@@ -1,0 +1,38 @@
+You are the **Spec Reviewer**. You run BEFORE every other role. You audit the
+user's spec (prompt or `.md`) for deficiencies. You do NOT execute or plan.
+
+## Categories (every finding gets exactly one)
+
+- **ambiguity** — words without a concrete metric ("better", "clean", "fast").
+- **missing_scope** — no boundary of what should and should not be touched.
+- **missing_ac** — no acceptance criteria; nothing to verify against.
+- **contradiction** — two requirements that cannot both be satisfied.
+- **stack** — no tech stack hint when one is required.
+- **assumptions** — depends on unstated context.
+- **out_of_scope** — asks for things outside what Karajan can do.
+
+## Severity
+
+`info` (nuance), `warn` (real gap), `fail` (unworkable). Top-level `severity`
+is the WORST of any finding, or `ok` if findings is empty.
+
+## Output (JSON, nothing else)
+
+```json
+{
+  "severity": "ok|info|warn|fail",
+  "findings": [
+    {
+      "id": "F-001",
+      "severity": "info|warn|fail",
+      "category": "ambiguity|missing_scope|missing_ac|contradiction|stack|assumptions|out_of_scope",
+      "message": "quote the offending phrase verbatim when possible",
+      "suggestion": "a sentence the user can paste into the spec"
+    }
+  ],
+  "reasoning": "one or two sentences summarising the verdict"
+}
+```
+
+Direct, accionable. No moralising. `suggestion` must be concrete (a paste-able
+sentence), not vague advice.

--- a/tests/roles/spec-reviewer.test.js
+++ b/tests/roles/spec-reviewer.test.js
@@ -1,0 +1,63 @@
+// Tests for the spec-reviewer role (KJC-PCS-0048 PR 1).
+
+import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { SpecReviewerRole } from "../../src/roles/spec-reviewer-role.js";
+import { buildSpecReviewerPrompt, VALID_CATEGORIES } from "../../src/prompts/spec-reviewer.js";
+
+const TEMPLATE = path.resolve(import.meta.dirname, "..", "..", "templates", "roles", "spec-reviewer.md");
+const noopLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+function role({ output }) {
+  return new SpecReviewerRole({
+    config: { roles: { coder: { provider: "claude" } } },
+    logger: noopLog,
+    createAgentFn: () => ({ async runTask() { return { ok: true, output, usage: {} }; } }),
+  });
+}
+
+describe("spec-reviewer (KJC-PCS-0048 PR 1)", () => {
+  it("template + prompt embed every category, severities and the spec verbatim", async () => {
+    const tpl = await fs.readFile(TEMPLATE, "utf8");
+    expect(tpl.length).toBeGreaterThan(200);
+    for (const cat of VALID_CATEGORIES) expect(tpl).toContain(cat);
+    for (const sev of ["info", "warn", "fail", "ok"]) expect(tpl).toContain(sev);
+    const p = buildSpecReviewerPrompt({ spec: "haz algo bonito", instructions: "EXTRA-Z" });
+    expect(p).toContain("Karajan sub-agent");
+    expect(p).toContain("haz algo bonito");
+    expect(p).toContain("EXTRA-Z");
+  });
+
+  it("parses a clean OK response", async () => {
+    const res = await role({ output: JSON.stringify({ severity: "ok", findings: [] }) }).execute({ spec: "good" });
+    expect(res.ok).toBe(true);
+    expect(res.result.severity).toBe("ok");
+    expect(res.summary).toMatch(/no findings/i);
+  });
+
+  it("derives top-level severity from the worst finding + clamps unknowns", async () => {
+    const res = await role({
+      output: JSON.stringify({
+        severity: "info", // agent under-reports
+        findings: [
+          { severity: "warn", category: "ambiguity", message: "vague" }, // missing id
+          { severity: "nonsense", category: "made-up", message: "x" }, // both invalid → clamped warn/ambiguity
+          { severity: "fail", category: "missing_ac", message: "no AC" },
+        ],
+      }),
+    }).execute({ spec: "x" });
+    expect(res.result.severity).toBe("fail");
+    expect(res.result.findings[0].id).toBe("F-001"); // auto-generated
+    expect(res.result.findings[1].severity).toBe("warn");
+    expect(res.result.findings[1].category).toBe("ambiguity");
+  });
+
+  it("degrades non-JSON output to a single soft warning instead of failing", async () => {
+    const res = await role({ output: "garbage prose, no JSON" }).execute({ spec: "x" });
+    expect(res.ok).toBe(true);
+    expect(res.result.degraded).toBe(true);
+    expect(res.result.severity).toBe("warn");
+    expect(res.result.findings[0].id).toBe("F-DEG");
+  });
+});


### PR DESCRIPTION
## Why

Step 1 of 3 in the [spec-reviewer epic KJC-PCS-0048](https://planning-game.web.app). Adds the role itself — a new pipeline role that runs **BEFORE** `intent` / `triage` / `planner` and audits the user's spec for deficiencies that would otherwise cause the pipeline to spend tokens on the wrong work.

User-stated motivation:
> *Cuando el usuario lanza un plan o un run y le pasa unas specs/prompts, bien por un md o por texto directamente, un rol previo, analiza el prompt/specs y en caso de detectar deficiencias, informe de ellas y pregunte si desea continuar o prefiere refinar.*

Same family of "fail loud" as the resilience audit v2.18.0 — except this time the failure is the **input**, before any agent has run.

## Why three PRs

| PR | Scope | User-visible? |
|----|-------|---------------|
| **#1 (this one)** | The `SpecReviewerRole` class + its prompt builder + its template + unit tests. No CLI integration. | **No** |
| **#2 (next)** | Hook into `kj run` / `kj plan` pre-pipeline. Interactive `[c]ontinue/[r]efine/[x]cancel` prompt. Refine loop + persistence of `spec-v1.md` / `spec-v2.md` with hash-diff re-validation. `--skip-spec-review` bypass flag. | **Yes** |
| **#3** | MCP parity (`spec_review_mode` parameter on `kj_run` / `kj_plan`), UX polish, docs, CHANGELOG. | Polish only |

## What the role does

- Receives a spec (prompt or .md content).
- Audits it across **7 categories**: `ambiguity`, `missing_scope`, `missing_ac`, `contradiction`, `stack`, `assumptions`, `out_of_scope`.
- Returns JSON with findings + per-finding `severity` (`info` / `warn` / `fail`) + a top-level `severity` that is the **WORST** of any finding (`ok` if no findings).
- Does **NOT** execute, **NOT** plan, **NOT** touch the filesystem.

### Trust-the-worse semantic

Agents sometimes report `severity: "ok"` while still listing fail-level findings. The role derives severity from the findings list and uses the **worse** of declared vs derived. Documented in code + tested.

### Degradation (no silent failures)

If the LLM returns garbage (no JSON), the role emits a single `F-DEG` soft-warning finding instead of throwing — same pattern as `TriageRole::degradedTriageResult`. Fits the no-silent-fail family from v2.18.0.

### Provider inheritance

`spec_reviewer` + `spec-reviewer` added to `CODER_INHERITED_ROLES` so it defaults to the coder's provider unless the user explicitly sets `roles.spec_reviewer.provider` in config. Same pattern as triage, hu-reviewer, researcher, etc.

## Files

- `templates/roles/spec-reviewer.md` — **NEW**. Role prompt template (the user can override per-project via `<projectDir>/.karajan/roles/spec-reviewer.md`).
- `src/prompts/spec-reviewer.js` — **NEW**. `buildSpecReviewerPrompt({spec, instructions})`. Mirrors `src/prompts/triage.js`.
- `src/roles/spec-reviewer-role.js` — **NEW**. `SpecReviewerRole` class extending `AgentRole`. Implements `buildPrompt`, `parseOutput`, `buildSuccessResult`, `buildSummary`, `handleParseNull`, `handleParseError`.
- `src/config/role-resolver.js` — **1 line**. Add `spec_reviewer` + `spec-reviewer` to `CODER_INHERITED_ROLES`.
- `tests/roles/spec-reviewer.test.js` — **NEW**. 4 tests covering template + prompt + parse paths + degradation.

## LOC budget — large-pr-justified

```
5 files changed, 227 insertions(+), 1 deletion(-)
```

**227 added LOC, 27 over the 200 hard limit**. Justified:

- This is a **new role** with 4 net-new files (template + prompt builder + role class + tests).
- Cannot be split further without breaking atomicity:
  - Template-only PR would land docs with no code referencing them.
  - Prompt-builder-only PR would have nothing to test.
  - Role-only PR would not compile (depends on prompt builder).
- The closest neighbour (TriageRole) is 122 LOC of just-the-role; this PR also adds the prompt builder + template + unit tests in one cohesive landing.

Label: `large-pr-justified`.

## Tests

4 tests, all passing locally:
- Template + prompt embed every category, severities and the spec verbatim.
- Parses a clean OK response.
- Derives top-level severity from the worst finding + clamps unknowns.
- Degrades non-JSON output to a single soft warning instead of failing.

## What's NOT in this PR

- **No CLI integration.** `kj run` and `kj plan` still skip the reviewer; PR 2 wires the hook.
- **No interactive prompt.** PR 2 adds the `[c]ontinue/[r]efine/[x]cancel` loop with `createCliAskQuestion()`.
- **No refine loop / v1.md+v2.md persistence.** PR 2.
- **No MCP parameter.** PR 3 (with docs).
- **No CHANGELOG entry.** Lands in PR 3 (one entry covers the 3-PR series, same pattern as v2.19.0).

PG: [KJC-TSK-0422](https://planning-game.web.app) under epic [KJC-PCS-0048](https://planning-game.web.app). Plan: `/home/manu/.claude/plans/tranquil-zooming-melody.md`.