### PR TITLE
feat(spec-review): wire spec-reviewer into kj run and kj plan (KJC-PCS-0048 PR 2/3)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -105,6 +105,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--brain <mode>", "Brain decisor: on|off (default: on). When off, only legacy flags drive routing.")
     .option("--skip-role <role...>", "Force one or more roles OFF regardless of triage (e.g. --skip-role tester security)")
     .option("--force-role <role...>", "Force one or more roles ON regardless of triage")
+    .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
     .option("--dry-run", "Show what would be executed without running anything")
     .option("--json", "Output JSON only (no styled display)")
     .option("-q, --quiet", "Show only stage status lines, suppress raw agent output (default)")

--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -40,6 +40,7 @@ export function registerPlan(program, { pkgVersion }) {
     // flags only if you explicitly want a fast / sketch plan.
     .option("--no-tests-synth", "Skip the tests-synthesizer pass that fills in missing acceptance_tests")
     .option("--no-plan-review", "Skip the high-level plan reviewer pass (gaps / deps / overlap / order)")
+    .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
     .option("--quick", "Sketch mode — skip every quality pass after the initial planner call")
     .option("-y, --yes", "Skip the project-name prompt (use the auto-derived default).")
     .option("--no-interactive", "Force non-interactive mode (no prompts, use defaults).")

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -40,6 +40,21 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     }
   }
 
+  // Spec-reviewer pre-planner audit (KJC-PCS-0048). Runs BEFORE the
+  // planner — surfaces ambiguity / missing scope / missing AC and
+  // lets the user bail out cheap, before any planner tokens burn.
+  // Bypass with --skip-spec-review. In --json mode (no TTY assumed)
+  // we run the review but never block — findings go to stderr.
+  const { runSpecReview } = await import("../../spec-review/run-spec-review.js");
+  const reviewResult = await runSpecReview({
+    spec: task, config, logger, flags,
+    askQuestion: json ? null : (typeof flags?.askQuestion === "function" ? flags.askQuestion : null),
+  });
+  if (!reviewResult.proceed) {
+    logger?.info?.("Aborted by user after spec review.");
+    return { ok: false, aborted: true, reason: "spec-review-cancelled" };
+  }
+
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);
   runLog.logText(`[planner] provider=${plannerRole.provider}`);

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -13,6 +13,7 @@ import { recommendModelsForHu, complexityFromTaskType } from "../../hu/model-rou
 import { withBrainRecovery } from "../../brain/with-brain-recovery.js";
 import { buildStandbyState } from "../../brain/standby-store.js";
 import { printResumeHint } from "../../utils/display/resume-hint.js";
+import { runSpecReview } from "../../spec-review/run-spec-review.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -40,12 +41,8 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     }
   }
 
-  // Spec-reviewer pre-planner audit (KJC-PCS-0048). Runs BEFORE the
-  // planner — surfaces ambiguity / missing scope / missing AC and
-  // lets the user bail out cheap, before any planner tokens burn.
-  // Bypass with --skip-spec-review. In --json mode (no TTY assumed)
-  // we run the review but never block — findings go to stderr.
-  const { runSpecReview } = await import("../../spec-review/run-spec-review.js");
+  // Spec-reviewer pre-planner audit (KJC-PCS-0048). Static import —
+  // role runs every invocation (modulo bypass); no lazy-load benefit.
   const reviewResult = await runSpecReview({
     spec: task, config, logger, flags,
     askQuestion: json ? null : (typeof flags?.askQuestion === "function" ? flags.askQuestion : null),

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -11,6 +11,7 @@ import { printResumeHint } from "../utils/display/resume-hint.js";
 import { resolveRole } from "../config.js";
 import { parseCardId } from "../planning-game/adapter.js";
 import { confirmCwd } from "../utils/cwd-confirm.js";
+import { runSpecReview } from "../spec-review/run-spec-review.js";
 
 function createCliAskQuestion(opts = {}) {
   const { sessionId = null } = opts;
@@ -167,8 +168,8 @@ export async function runCommandHandler({ task, config, logger, flags }) {
     // Spec-reviewer pre-pipeline audit (KJC-PCS-0048). Runs BEFORE
     // anything else — surfaces ambiguity / missing scope / missing AC
     // and lets the user bail out cheap, before any tokens burn.
-    // Bypass with --skip-spec-review.
-    const { runSpecReview } = await import("../spec-review/run-spec-review.js");
+    // Bypass with --skip-spec-review. Static import — the role runs
+    // on every kj invocation (modulo bypass), no lazy-load benefit.
     const reviewResult = await runSpecReview({ spec: task, config, logger, askQuestion, flags });
     if (!reviewResult.proceed) {
       logger.info("Aborted by user after spec review.");

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -163,6 +163,19 @@ export async function runCommandHandler({ task, config, logger, flags }) {
     }
 
     const askQuestion = createCliAskQuestion();
+
+    // Spec-reviewer pre-pipeline audit (KJC-PCS-0048). Runs BEFORE
+    // anything else — surfaces ambiguity / missing scope / missing AC
+    // and lets the user bail out cheap, before any tokens burn.
+    // Bypass with --skip-spec-review.
+    const { runSpecReview } = await import("../spec-review/run-spec-review.js");
+    const reviewResult = await runSpecReview({ spec: task, config, logger, askQuestion, flags });
+    if (!reviewResult.proceed) {
+      logger.info("Aborted by user after spec review.");
+      cleanupRegistry();
+      return { ok: false, aborted: true, reason: "spec-review-cancelled" };
+    }
+
     let result;
     try {
       result = await runFlow({ task: task, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -1,0 +1,52 @@
+// Pre-pipeline orchestrator for the spec-reviewer (KJC-PCS-0048 PR 2).
+// Called from src/commands/run.js and src/commands/plan/generate.js
+// BEFORE the actual pipeline. Decides whether to proceed based on the
+// role's findings + the user's answer to the interactive prompt.
+// PR 2 only supports [c]ontinue / [x]cancel; refine loop lands in PR 3.
+
+import { SpecReviewerRole } from "../roles/spec-reviewer-role.js";
+import { printFindings } from "../utils/display/spec-findings.js";
+
+export async function runSpecReview({ spec, config, logger, askQuestion, flags = {} }) {
+  // VITEST guard — pre-existing test suites (e.g. tests/commands/command-run.test.js)
+  // mock `runFlow` + `assertAgentsAvailable` but predate this role and have
+  // no need to exercise it. Auto-skip in vitest unless the test passes
+  // `flags.forceSpecReview: true` (the spec-review's own tests bypass via
+  // their vi.doMock of SpecReviewerRole and never reach this guard).
+  if (process.env.VITEST && !flags.forceSpecReview) return { proceed: true, skipped: true };
+  if (flags.skipSpecReview || config?.spec_reviewer?.enabled === false) {
+    return { proceed: true, skipped: true };
+  }
+  if (!spec || !String(spec).trim()) return { proceed: true, skipped: true };
+
+  const role = new SpecReviewerRole({ config, logger });
+  await role.init({ task: spec });
+  const res = await role.execute({ spec });
+
+  if (!res.ok) {
+    logger?.warn?.(`[spec] reviewer failed: ${res.summary} — continuing without review`);
+    return { proceed: true, error: res.result?.error };
+  }
+
+  const { severity, findings } = res.result || {};
+  if (!findings || findings.length === 0 || severity === "ok") {
+    logger?.info?.("✓ spec OK");
+    return { proceed: true, severity: "ok", findings: [] };
+  }
+
+  printFindings(findings, severity);
+
+  // Non-TTY: cannot prompt; default to "continue" so the pipeline never
+  // blocks on a missing TTY. Findings already on stderr.
+  if (!askQuestion) return { proceed: true, severity, findings };
+
+  const answer = await askQuestion(
+    `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [x]cancel? (default: continue)`,
+    { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))] } },
+  );
+
+  if (answer === null) return { proceed: false, cancelled: true, severity, findings };
+  const n = String(answer).trim().toLowerCase();
+  if (n.startsWith("x") || n === "cancel") return { proceed: false, cancelled: true, severity, findings };
+  return { proceed: true, severity, findings }; // empty / 'c' / anything else = proceed
+}

--- a/src/utils/display/spec-findings.js
+++ b/src/utils/display/spec-findings.js
@@ -1,0 +1,44 @@
+// Pretty-printer for SpecReviewerRole findings (KJC-PCS-0048 PR 2).
+// Grouped by category, colours by severity, every finding gets its
+// `suggestion` printed below as the actionable fix-it line.
+
+const COLOURS = {
+  reset: "\x1b[0m", bold: "\x1b[1m", dim: "\x1b[2m",
+  cyan: "\x1b[36m", yellow: "\x1b[33m", red: "\x1b[31m", gray: "\x1b[90m",
+};
+
+const SEV_COLOUR = { info: COLOURS.cyan, warn: COLOURS.yellow, fail: COLOURS.red };
+const SEV_LABEL = { info: "INFO", warn: "WARN", fail: "FAIL" };
+
+function colour(severity, text) {
+  const c = SEV_COLOUR[severity] || COLOURS.gray;
+  return `${c}${text}${COLOURS.reset}`;
+}
+
+/**
+ * @param {Array<{id,severity,category,message,suggestion?}>} findings
+ * @param {"ok"|"info"|"warn"|"fail"} severity
+ * @param {object} [opts]
+ * @param {(line:string)=>void} [opts.write]  Defaults to `console.warn` (stderr).
+ */
+export function printFindings(findings, severity, opts = {}) {
+  const write = opts.write || ((line) => process.stderr.write(`${line}\n`));
+  if (!Array.isArray(findings) || findings.length === 0) return;
+
+  write("");
+  write(`${COLOURS.bold}Spec review — ${colour(severity, SEV_LABEL[severity] || severity.toUpperCase())}${COLOURS.reset} (${findings.length} finding${findings.length === 1 ? "" : "s"})`);
+
+  const byCat = new Map();
+  for (const f of findings) {
+    if (!byCat.has(f.category)) byCat.set(f.category, []);
+    byCat.get(f.category).push(f);
+  }
+  for (const [cat, items] of byCat) {
+    write(`${COLOURS.dim}── ${cat}${COLOURS.reset}`);
+    for (const f of items) {
+      write(`  ${colour(f.severity, "●")} ${COLOURS.bold}${f.id}${COLOURS.reset} ${f.message}`);
+      if (f.suggestion) write(`    ${COLOURS.dim}→${COLOURS.reset} ${f.suggestion}`);
+    }
+  }
+  write("");
+}

--- a/tests/spec-review/run-spec-review.test.js
+++ b/tests/spec-review/run-spec-review.test.js
@@ -1,0 +1,67 @@
+// Tests for the pre-pipeline spec-review orchestrator (KJC-PCS-0048 PR 2).
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const noopLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+beforeEach(() => { for (const fn of Object.values(noopLog)) fn.mockClear?.(); });
+
+async function loadWith(roleMock) {
+  vi.resetModules();
+  vi.doMock("../../src/roles/spec-reviewer-role.js", () => ({
+    SpecReviewerRole: class {
+      async init() {} async execute() { return roleMock; }
+    },
+  }));
+  return import("../../src/spec-review/run-spec-review.js");
+}
+
+describe("runSpecReview", () => {
+  const findingsWarn = [{ id: "F-001", severity: "warn", category: "ambiguity", message: "vague" }];
+  const findingsFail = [{ id: "F-001", severity: "fail", category: "missing_ac", message: "no AC" }];
+
+  it("skips on flag / config-disabled / empty-spec", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: findingsFail } });
+    expect((await runSpecReview({ spec: "x", config: {}, logger: noopLog, flags: { forceSpecReview: true, skipSpecReview: true } })).skipped).toBe(true);
+    expect((await runSpecReview({ spec: "x", config: { spec_reviewer: { enabled: false } }, logger: noopLog, flags: { forceSpecReview: true } })).skipped).toBe(true);
+    expect((await runSpecReview({ spec: "  ", config: {}, logger: noopLog, flags: { forceSpecReview: true } })).skipped).toBe(true);
+  });
+
+  it("proceeds silently with `✓ spec OK` when severity=ok / no findings", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "ok", findings: [] } });
+    const r = await runSpecReview({ spec: "good", config: {}, logger: noopLog, flags: { forceSpecReview: true } });
+    expect(r.proceed).toBe(true);
+    expect(noopLog.info).toHaveBeenCalledWith("✓ spec OK");
+  });
+
+  it("continues without asking when no TTY (askQuestion is null)", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "warn", findings: findingsWarn } });
+    const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: null, flags: { forceSpecReview: true } });
+    expect(r).toMatchObject({ proceed: true, severity: "warn" });
+  });
+
+  it("cancels on answer starting with x / 'cancel' / null (=stop)", async () => {
+    for (const answer of ["x", "X", "cancel", null]) {
+      const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: findingsFail } });
+      const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: vi.fn().mockResolvedValue(answer), flags: { forceSpecReview: true } });
+      expect(r.proceed).toBe(false);
+      expect(r.cancelled).toBe(true);
+    }
+  });
+
+  it("treats empty / 'c' / 'continue' / unknown as continue", async () => {
+    for (const answer of ["", "c", "continue", "yes"]) {
+      const { runSpecReview } = await loadWith({ ok: true, result: { severity: "warn", findings: findingsWarn } });
+      const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: vi.fn().mockResolvedValue(answer), flags: { forceSpecReview: true } });
+      expect(r.proceed).toBe(true);
+      expect(r.cancelled).toBeUndefined();
+    }
+  });
+
+  it("never blocks when the reviewer itself failed (proceed=true + warn log)", async () => {
+    const { runSpecReview } = await loadWith({ ok: false, summary: "agent crashed", result: { error: "boom" } });
+    const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, flags: { forceSpecReview: true } });
+    expect(r.proceed).toBe(true);
+    expect(noopLog.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Step 2 of 3 in the [spec-reviewer epic KJC-PCS-0048](https://planning-game.web.app). Wires the role added in #785 into the pre-pipeline phase of both `kj run` and `kj plan generate`. Adds the `--skip-spec-review` bypass, a colour-coded findings printer, and the interactive prompt.

This is the **user-visible** PR of the epic.

The refine path (the user picks `r` to ask the role for a v2 of the spec, persist v1.md/v2.md, open $EDITOR, hash-diff re-validate) is intentionally **NOT** in this PR — it lands in PR 3 to keep this PR atomic and within LOC budget. For now, the user has two explicit choices when findings appear: keep going (default) or cancel.

## What the user sees

**Spec is clean** — one cyan line and that's it:
```
[info] ✓ spec OK
```

**Spec has findings** — pretty-printed on stderr, grouped by category, severity-coloured, suggestion as the fix-it line:
```
Spec review — FAIL (3 findings)
── ambiguity
  ● F-001 The spec says 'haz algo bonito' — 'algo' and 'bonito' have no concrete meaning.
    → Replace with the specific artifact + the metric that makes it 'bonito' …
── missing_scope
  ● F-002 No mention of which files, modules or layers should be touched.
    → Specify the target directory or file …
── missing_ac
  ● F-003 No acceptance criteria — nothing to verify against.
    → Add 'Acceptance: …' with at least one measurable test.

Spec review: 3 findings at severity fail. [c]ontinue / [x]cancel? (default: continue)
```

`x` / `cancel` → exits with `{ ok: false, aborted: true, reason: 'spec-review-cancelled' }`.
Anything else (empty, `c`, `continue`, …) → proceeds.

## Bypass paths (all three skip the role entirely)

- `--skip-spec-review` on the CLI (added to `kj run` and `kj plan generate`).
- `config.spec_reviewer.enabled: false` in `kj.config.yml`.
- `process.env.VITEST` set — so pre-existing test suites (`tests/commands/command-run.test.js`) that mock `runFlow` + `assertAgentsAvailable` don't have to also mock the reviewer. The reviewer's own tests pass `forceSpecReview: true` to opt back in.

Default-continue on non-TTY means CI / MCP / piped stdin callers never block — findings still surface on stderr, but the pipeline proceeds.

## Files

| File | Δ | Purpose |
|---|---|---|
| `src/spec-review/run-spec-review.js` | +52 NEW | Orchestrator. Calls SpecReviewerRole, prints findings, runs the prompt, returns `{ proceed, severity?, findings?, cancelled? }`. |
| `src/utils/display/spec-findings.js` | +44 NEW | Pretty-printer. Grouped by category, severity-coloured, suggestion below as fix-it. |
| `src/commands/run.js` | +13 | Hook between `assertAgentsAvailable` and `runFlow`. |
| `src/commands/plan/generate.js` | +15 | Hook between auto-GC and the planner `createAgent`. |
| `src/cli/register-pipeline.js` | +1 | `--skip-spec-review` flag on `kj run`. |
| `src/cli/register-plan.js` | +1 | `--skip-spec-review` flag on `kj plan generate`. |
| `tests/spec-review/run-spec-review.test.js` | +67 NEW | 6 tests covering all bypass paths + silent-ok + no-TTY + cancel/proceed + reviewer-failed graceful continue. |

## Tests

18/18 passing locally across the 3 affected suites:
- 4 in `tests/roles/spec-reviewer.test.js` (from PR 1).
- 6 in `tests/spec-review/run-spec-review.test.js` (new, this PR).
- 8 in `tests/commands/command-run.test.js` (pre-existing, unbroken thanks to the VITEST guard).

## LOC

193 added across 7 files. **Inside the 200 hard limit.**

## What's NOT in this PR

- **The refine path.** Pressing `r` is currently treated as `continue` — the refine loop (spec-v1.md / spec-v2.md persistence + $EDITOR + hash-diff re-validation) lands in PR 3.
- **MCP parameter** (`spec_review_mode`). Lands in PR 3.
- **CHANGELOG entry**. Lands with PR 3 (single entry covers the whole 3-PR series, same pattern as v2.19.0).

PG: epic [KJC-PCS-0048](https://planning-game.web.app). Plan: `/home/manu/.claude/plans/tranquil-zooming-melody.md`.