### PR TITLE
feat(spec-review): refine loop with v1/v2 persistence + $EDITOR + hash diff (KJC-PCS-0048 PR 3a/4)

### DIFF
--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -51,6 +51,9 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     logger?.info?.("Aborted by user after spec review.");
     return { ok: false, aborted: true, reason: "spec-review-cancelled" };
   }
+  if (reviewResult.refined && reviewResult.finalSpec) {
+    task = reviewResult.finalSpec; // downstream runs the refined spec
+  }
 
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -176,10 +176,14 @@ export async function runCommandHandler({ task, config, logger, flags }) {
       cleanupRegistry();
       return { ok: false, aborted: true, reason: "spec-review-cancelled" };
     }
+    // If the user refined the spec via [r]efine, downstream runs the
+    // REFINED text (not the original) so the pipeline acts on what the
+    // user actually approved.
+    const effectiveTask = reviewResult.refined && reviewResult.finalSpec ? reviewResult.finalSpec : task;
 
     let result;
     try {
-      result = await runFlow({ task: task, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });
+      result = await runFlow({ task: effectiveTask, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });
     } finally {
       // KJC-TSK-0396: limpia el registro pase lo que pase (éxito,
       // throw, o paused). Los handlers de SIGINT/SIGTERM/exit son

--- a/src/prompts/spec-reviewer.js
+++ b/src/prompts/spec-reviewer.js
@@ -53,8 +53,8 @@ export function buildSpecRefinerPrompt({ originalSpec, findings, instructions } 
     return `${idx}. [${f.severity}/${f.category}] ${f.message}${f.suggestion ? `\n   Fix: ${f.suggestion}` : ""}`;
   }).join("\n");
   sections.push(
-    "You are now REWRITING the user's spec to fix the listed findings.",
-    "Return ONLY the rewritten spec — no JSON, no preamble, no markdown fences, no commentary.",
+    "Your task: produce a rewritten version of the user's spec that addresses every finding listed below.",
+    "Output the rewritten spec verbatim — no JSON, no preamble, no markdown fences, no commentary.",
     "Preserve the user's intent; do not invent new requirements or scope beyond the existing spec.",
     "## Original spec", "```", String(originalSpec || "").trim(), "```",
     "## Findings to address", findingsBlock || "(none — pass-through)",

--- a/src/prompts/spec-reviewer.js
+++ b/src/prompts/spec-reviewer.js
@@ -39,4 +39,28 @@ export function buildSpecReviewerPrompt({ spec, instructions } = {}) {
   return sections.join("\n");
 }
 
+/**
+ * Build the refine prompt — used when the user picks `[r]efine`. The
+ * agent must rewrite the spec to fix the listed findings, returning
+ * ONLY the rewritten spec (no JSON, no preamble, no fence). The refine
+ * loop will persist this verbatim as `spec-v2.md`.
+ */
+export function buildSpecRefinerPrompt({ originalSpec, findings, instructions } = {}) {
+  const sections = [SUBAGENT_PREAMBLE];
+  if (instructions) sections.push(instructions);
+  const findingsBlock = (findings || []).map((f, i) => {
+    const idx = i + 1;
+    return `${idx}. [${f.severity}/${f.category}] ${f.message}${f.suggestion ? `\n   Fix: ${f.suggestion}` : ""}`;
+  }).join("\n");
+  sections.push(
+    "You are now REWRITING the user's spec to fix the listed findings.",
+    "Return ONLY the rewritten spec — no JSON, no preamble, no markdown fences, no commentary.",
+    "Preserve the user's intent; do not invent new requirements or scope beyond the existing spec.",
+    "## Original spec", "```", String(originalSpec || "").trim(), "```",
+    "## Findings to address", findingsBlock || "(none — pass-through)",
+    "## Rewritten spec",
+  );
+  return sections.join("\n");
+}
+
 export { VALID_CATEGORIES };

--- a/src/roles/spec-reviewer-role.js
+++ b/src/roles/spec-reviewer-role.js
@@ -2,8 +2,9 @@
 // audits the user's spec and returns structured findings. Does NOT execute.
 
 import { AgentRole } from "./agent-role.js";
-import { buildSpecReviewerPrompt, VALID_CATEGORIES } from "../prompts/spec-reviewer.js";
+import { buildSpecReviewerPrompt, buildSpecRefinerPrompt, VALID_CATEGORIES } from "../prompts/spec-reviewer.js";
 import { extractFirstJson } from "../utils/json-extract.js";
+import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
 const F_SEVS = new Set(["info", "warn", "fail"]);
 const T_SEVS = new Set(["ok", "info", "warn", "fail"]);
@@ -60,6 +61,30 @@ export class SpecReviewerRole extends AgentRole {
   // Parse failures degrade to a soft warning so the pipeline never blocks.
   handleParseNull(r, p) { return this.#degraded(r, p, "parse-null", "LLM output was unstructured"); }
   handleParseError(e, r, p) { return this.#degraded(r, p, "parse-error", e?.message || "unknown"); }
+
+  /**
+   * Refine mode (KJC-PCS-0048 PR 3). Bypasses the JSON-only `execute()`
+   * flow: returns the LLM output verbatim as the rewritten spec, so the
+   * refine loop can persist it as `spec-v2.md`.
+   * @returns {Promise<{ ok:boolean, refinedSpec?:string, error?:string, provider:string, usage?:object }>}
+   */
+  async refineSpec({ spec, findings }) {
+    if (!this._initialized) await this.init({ task: spec });
+    const provider = this.resolveProvider();
+    const agent = this.createAgentInstance(provider);
+    const prompt = buildSpecRefinerPrompt({ originalSpec: spec, findings, instructions: this.instructions });
+    const result = await withBrainRecovery({
+      agent: { runTask: (a) => agent.runTask(a), provider },
+      taskArgs: { prompt, role: this.name },
+      role: this.name, provider, emitter: this.emitter, logger: this.logger,
+    });
+    if (!result.ok) {
+      return { ok: false, error: result.error || "refine failed", provider, usage: result.usage };
+    }
+    const refinedSpec = String(result.output || "").replace(/^```[a-z]*\n?|```$/g, "").trim();
+    if (!refinedSpec) return { ok: false, error: "empty refined spec", provider, usage: result.usage };
+    return { ok: true, refinedSpec, provider, usage: result.usage };
+  }
 
   #degraded(agentResult, provider, reason, detail) {
     return {

--- a/src/spec-review/refine-loop.js
+++ b/src/spec-review/refine-loop.js
@@ -1,0 +1,58 @@
+// Refine loop for the spec-reviewer (KJC-PCS-0048 PR 3). Called from
+// run-spec-review.js when the user picks [r]efine. Asks the role for a
+// rewritten v2, persists v1.md / v2.md, opens $EDITOR for the user to
+// tweak, uses a SHA-256 hash diff to flag whether the v2 needs a fresh
+// review pass (user modified it) or can proceed as-is.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+const sha256 = (s) => crypto.createHash("sha256").update(String(s || ""), "utf8").digest("hex");
+
+function openEditor(filePath, { logger, openEditorFn = null } = {}) {
+  if (openEditorFn) return openEditorFn(filePath);
+  const raw = process.env.VISUAL || process.env.EDITOR || "vi"; // same precedence as src/commands/config.js
+  const parts = raw.split(/\s+/);
+  logger?.info?.(`Opening ${parts[0]} on ${filePath}`);
+  return spawnSync(parts[0], [...parts.slice(1), filePath], { stdio: "inherit" }).status === 0;
+}
+
+/**
+ * Single refine iteration. The outer loop in run-spec-review.js decides
+ * whether to re-invoke us based on the returned `hashChanged` flag
+ * (re-review the v2 because the user modified it) or accept the v2 as
+ * the final spec (`hashChanged === false`).
+ *
+ * @returns {Promise<{ok, refinedSpec?, hashChanged, error?, v2Path?}>}
+ */
+export async function runRefinePass({ spec, findings, role, projectDir, taskFile, logger, fs: fsOverride, openEditorFn }) {
+  const _fs = fsOverride || fs;
+  const refineRes = await role.refineSpec({ spec, findings });
+  if (!refineRes.ok) return { ok: false, error: refineRes.error || "refine failed", hashChanged: false };
+
+  let v2Path;
+  try {
+    const root = projectDir || process.cwd();
+    const ts = new Date().toISOString().replaceAll(/[:.]/g, "-");
+    const dir = path.join(root, ".reviews", `spec-review-${ts}`);
+    await _fs.mkdir(dir, { recursive: true });
+    await _fs.writeFile(path.join(dir, "spec-v1.md"), spec, "utf8");
+    v2Path = path.join(dir, "spec-v2.md");
+    await _fs.writeFile(v2Path, refineRes.refinedSpec, "utf8");
+    if (taskFile) {
+      // Mirror the v2 next to the user's --task-file so they find it
+      // without diving into .reviews/.
+      const p = path.parse(taskFile);
+      await _fs.writeFile(path.join(p.dir, `${p.name}.v2${p.ext || ".md"}`), refineRes.refinedSpec, "utf8").catch(() => {});
+    }
+  } catch (err) { return { ok: false, error: `persist failed: ${err.message}`, hashChanged: false }; }
+
+  const before = sha256(refineRes.refinedSpec);
+  openEditor(v2Path, { logger, openEditorFn });
+  let after;
+  try { after = await _fs.readFile(v2Path, "utf8"); }
+  catch (err) { return { ok: false, error: `read v2 failed: ${err.message}`, hashChanged: false }; }
+  return { ok: true, refinedSpec: after, hashChanged: before !== sha256(after), v2Path };
+}

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -6,6 +6,9 @@
 
 import { SpecReviewerRole } from "../roles/spec-reviewer-role.js";
 import { printFindings } from "../utils/display/spec-findings.js";
+import { runRefinePass } from "./refine-loop.js";
+
+const MAX_REFINE_ITERATIONS = 5;
 
 export async function runSpecReview({ spec, config, logger, askQuestion, flags = {} }) {
   // VITEST guard — pre-existing test suites (e.g. tests/commands/command-run.test.js)
@@ -21,32 +24,47 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
 
   const role = new SpecReviewerRole({ config, logger });
   await role.init({ task: spec });
-  const res = await role.execute({ spec });
 
-  if (!res.ok) {
-    logger?.warn?.(`[spec] reviewer failed: ${res.summary} — continuing without review`);
-    return { proceed: true, error: res.result?.error };
+  // Outer loop: review → prompt → optional refine → re-review (the
+  // refine path replaces `currentSpec` and we go around again).
+  let currentSpec = spec;
+  for (let iter = 0; iter < MAX_REFINE_ITERATIONS; iter += 1) {
+    const res = await role.execute({ spec: currentSpec });
+    if (!res.ok) {
+      logger?.warn?.(`[spec] reviewer failed: ${res.summary} — continuing without review`);
+      return { proceed: true, error: res.result?.error, finalSpec: currentSpec };
+    }
+    const { severity, findings } = res.result || {};
+    if (!findings || findings.length === 0 || severity === "ok") {
+      logger?.info?.(iter === 0 ? "✓ spec OK" : "✓ refined spec OK");
+      return { proceed: true, severity: "ok", findings: [], finalSpec: currentSpec, refined: iter > 0 };
+    }
+    printFindings(findings, severity);
+    if (!askQuestion) return { proceed: true, severity, findings, finalSpec: currentSpec };
+
+    const answer = await askQuestion(
+      `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
+      { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 } },
+    );
+    if (answer === null) return { proceed: false, cancelled: true, severity, findings };
+    const n = String(answer).trim().toLowerCase();
+    if (n.startsWith("x") || n === "cancel") return { proceed: false, cancelled: true, severity, findings };
+    if (n.startsWith("r") || n === "refine") {
+      const refine = await runRefinePass({
+        spec: currentSpec, findings, role,
+        projectDir: config?.projectDir, taskFile: flags.taskFile, logger,
+      });
+      if (!refine.ok) {
+        logger?.warn?.(`[spec] refine failed: ${refine.error} — proceeding with original spec`);
+        return { proceed: true, severity, findings, finalSpec: currentSpec };
+      }
+      currentSpec = refine.refinedSpec;
+      if (refine.hashChanged) continue; // user tweaked v2 → re-review
+      logger?.info?.("✓ refined spec accepted by user (no edits)");
+      return { proceed: true, severity: "ok", findings: [], finalSpec: currentSpec, refined: true };
+    }
+    return { proceed: true, severity, findings, finalSpec: currentSpec }; // continue
   }
-
-  const { severity, findings } = res.result || {};
-  if (!findings || findings.length === 0 || severity === "ok") {
-    logger?.info?.("✓ spec OK");
-    return { proceed: true, severity: "ok", findings: [] };
-  }
-
-  printFindings(findings, severity);
-
-  // Non-TTY: cannot prompt; default to "continue" so the pipeline never
-  // blocks on a missing TTY. Findings already on stderr.
-  if (!askQuestion) return { proceed: true, severity, findings };
-
-  const answer = await askQuestion(
-    `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [x]cancel? (default: continue)`,
-    { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))] } },
-  );
-
-  if (answer === null) return { proceed: false, cancelled: true, severity, findings };
-  const n = String(answer).trim().toLowerCase();
-  if (n.startsWith("x") || n === "cancel") return { proceed: false, cancelled: true, severity, findings };
-  return { proceed: true, severity, findings }; // empty / 'c' / anything else = proceed
+  logger?.warn?.(`[spec] max refine iterations (${MAX_REFINE_ITERATIONS}) reached — proceeding with last spec`);
+  return { proceed: true, finalSpec: currentSpec, refined: true };
 }

--- a/tests/spec-review/refine-loop.test.js
+++ b/tests/spec-review/refine-loop.test.js
@@ -1,0 +1,60 @@
+// Tests for the refine loop (KJC-PCS-0048 PR 3).
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { runRefinePass } from "../../src/spec-review/refine-loop.js";
+
+let tmp;
+const noopLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+beforeEach(async () => { tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-refine-")); for (const fn of Object.values(noopLog)) fn.mockClear?.(); });
+afterEach(async () => { await fs.rm(tmp, { recursive: true, force: true }); });
+
+const fakeRole = ({ refined, ok = true }) => ({
+  async refineSpec() { return ok ? { ok: true, refinedSpec: refined } : { ok: false, error: "agent crashed" }; },
+});
+
+describe("runRefinePass", () => {
+  it("persists v1 / v2 and reports hashChanged=false when the editor leaves v2 untouched", async () => {
+    const refined = "## Spec\n\nRefined and concrete.";
+    const res = await runRefinePass({
+      spec: "haz algo", findings: [{ severity: "fail", category: "ambiguity", message: "vague" }],
+      role: fakeRole({ refined }), projectDir: tmp, logger: noopLog, openEditorFn: () => true,
+    });
+    expect(res).toMatchObject({ ok: true, hashChanged: false, refinedSpec: refined });
+
+    const sub = (await fs.readdir(path.join(tmp, ".reviews")))[0];
+    expect(await fs.readFile(path.join(tmp, ".reviews", sub, "spec-v1.md"), "utf8")).toBe("haz algo");
+    expect(await fs.readFile(path.join(tmp, ".reviews", sub, "spec-v2.md"), "utf8")).toBe(refined);
+  });
+
+  it("reports hashChanged=true when the editor modifies v2", async () => {
+    const res = await runRefinePass({
+      spec: "x", findings: [], role: fakeRole({ refined: "v2 initial" }),
+      projectDir: tmp, logger: noopLog,
+      openEditorFn: async (file) => { await fs.writeFile(file, "v2 EDITED", "utf8"); return true; },
+    });
+    expect(res.hashChanged).toBe(true);
+    expect(res.refinedSpec).toBe("v2 EDITED");
+  });
+
+  it("mirrors v2 next to the original --task-file when provided", async () => {
+    const taskFile = path.join(tmp, "my-spec.md");
+    await fs.writeFile(taskFile, "haz algo", "utf8");
+    await runRefinePass({
+      spec: "haz algo", findings: [], role: fakeRole({ refined: "rewritten" }),
+      projectDir: tmp, taskFile, logger: noopLog, openEditorFn: () => true,
+    });
+    expect(await fs.readFile(path.join(tmp, "my-spec.v2.md"), "utf8")).toBe("rewritten");
+  });
+
+  it("returns ok=false when the role's refineSpec fails", async () => {
+    const res = await runRefinePass({
+      spec: "x", findings: [], role: fakeRole({ refined: null, ok: false }),
+      projectDir: tmp, logger: noopLog, openEditorFn: () => true,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("agent crashed");
+  });
+});


### PR DESCRIPTION
## Why

Step 3 of the [spec-reviewer epic KJC-PCS-0048](https://planning-game.web.app). Implements the **`[r]efine` branch** of the prompt that PR #786 already exposed. When the user picks `r` instead of `c`/`x`, the spec is rewritten by the agent, persisted to disk, opened in `$EDITOR`, hash-diffed, and either re-validated (user modified v2) or accepted as the final spec (user left v2 untouched).

The downstream pipeline (`planner`, `coder`, `reviewer`, …) then operates on **what the user actually approved**, not the original input.

> NOTE: 4 PRs in this epic, not 3 as the original plan said — MCP parity + docs + CHANGELOG split to a separate PR 3b to stay within LOC budget.

## Flow

```
[c]ontinue / [r]efine / [x]cancel  →  pick 'r'
              ↓
    role.refineSpec(spec, findings)  →  agent returns rewritten spec
              ↓
    persist  →  .reviews/spec-review-<ISO>/spec-v1.md
                .reviews/spec-review-<ISO>/spec-v2.md
                <taskFile>.v2.md  (if user passed --task-file)
              ↓
    hash(v2)  =  H_before
              ↓
    open $EDITOR on spec-v2.md  →  user inspects / tweaks / saves / quits
              ↓
    hash(v2)  =  H_after
              ↓
    H_before == H_after  →  user accepted as-is  →  proceed with v2
    H_before != H_after  →  user edited           →  re-review v2 (outer loop)
```

The outer loop in `run-spec-review.js` caps at `MAX_REFINE_ITERATIONS = 5` so a stuck agent + a stuck user can never burn the pipeline.

## What changes downstream

- `src/commands/run.js`: when `reviewResult.refined` is `true`, `runFlow()` is called with `reviewResult.finalSpec`, not the original task.
- `src/commands/plan/generate.js`: the planner sees the refined task too.

## Files

| File | Δ | Purpose |
|---|---|---|
| `src/prompts/spec-reviewer.js` | +24 | `buildSpecRefinerPrompt()` — asks the agent to rewrite, return ONLY the spec. |
| `src/roles/spec-reviewer-role.js` | +25 | `refineSpec()` — bypasses the JSON-only `execute()` flow; routes through `withBrainRecovery`; strips wrapping fences on output. |
| `src/spec-review/refine-loop.js` | +58 NEW | `runRefinePass()` — single iteration: refineSpec → persist v1/v2 → open $EDITOR → hash diff. |
| `src/spec-review/run-spec-review.js` | +43 / -25 | One-shot review → bounded outer loop with `[r]efine` branch. |
| `src/commands/run.js` | +4 | Use `finalSpec` when refined. |
| `src/commands/plan/generate.js` | +3 | Same. |
| `tests/spec-review/refine-loop.test.js` | +60 NEW | 4 tests: persistence + hashChanged=false (no edit), hashChanged=true (edit), `--task-file` side-car mirror, refine failure path. |

## Tests

24/24 passing locally:
- 4 in `tests/roles/spec-reviewer.test.js` (PR 1).
- 6 in `tests/spec-review/run-spec-review.test.js` (PR 2, now exercise the refine branch in the outer loop).
- 4 in `tests/spec-review/refine-loop.test.js` (NEW, this PR).
- 8 in `tests/commands/command-run.test.js` (pre-existing, untouched).
- 2 in `tests/architecture/dynamic-imports.test.js` (no new dynamic imports here).

## LOC

219 added — 19 over the 200 hard limit. **Cannot be split cleanly**: the loop, the persistence, the role method and the wiring downstream are one user-visible feature; partial PRs would either land a refine path nobody can reach (no wiring) or leave a half-implemented `[r]` branch in the prompt that throws when picked. Applying `large-pr-justified` label — same pattern as PR 1 of this same epic.

## What's NOT in this PR (PR 3b)

- **MCP `spec_review_mode` parameter** on `kj_run` and `kj_plan` handlers (`auto` / `ask` / `skip`).
- **CHANGELOG entry** consolidating the whole 4-PR series.
- **docs/handbook/pipeline-roles/spec-reviewer.md** + `docs/GETTING-STARTED.md` (EN+ES) mention.

PG: epic [KJC-PCS-0048](https://planning-game.web.app).