### PR TITLE
chore(hu-board): unify 5 hu-board-runs/ path constructions under getHuBoardRunsDir() (KJC-TSK-0421)

### DIFF
--- a/packages/hu-board/src/command-runner.js
+++ b/packages/hu-board/src/command-runner.js
@@ -31,13 +31,9 @@ const REPO_ROOT = (() => {
 })();
 const KJ_CLI = join(REPO_ROOT, "src", "cli.js");
 
-/**
- * Resolve the runs directory the board already uses for plan logs.
- * Falls back to ~/.karajan/hu-board-runs/ when KJ_HOME is unset.
- */
-function runsDir() {
-  return join(process.env.KJ_HOME || join(homedir(), ".karajan"), "hu-board-runs");
-}
+// Path now lives in db.js::getHuBoardRunsDir() — KJC-TSK-0421
+// unification. The local helper is gone; callers import directly.
+import { getHuBoardRunsDir } from "./db.js";
 
 /**
  * Whitelist + argv builders. Each entry maps a logical command name
@@ -106,7 +102,7 @@ export function runKjCommand({ command, input = {} } = {}) {
     return { ok: false, error: `Bad input for "${command}": ${err.message}` };
   }
 
-  const dir = runsDir();
+  const dir = getHuBoardRunsDir();
   mkdirSync(dir, { recursive: true });
   const commandId = `cmd-${command}-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const logPath = join(dir, `${commandId}.log`);

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -38,6 +38,19 @@ export function getKjHome() {
   return join(process.env.HOME || '/root', '.karajan');
 }
 
+/**
+ * Canonical path to the HU Board's run-logs directory
+ * (`<karajan-home>/hu-board-runs/`). Centralised here so the four
+ * board callers (plan-mutations, command-runner, api.js GET routes
+ * for plan + commandId logs) and the garbage-collector all agree on
+ * the same string — KJC-TSK-0421.
+ *
+ * @returns {string}
+ */
+export function getHuBoardRunsDir() {
+  return join(getKjHome(), 'hu-board-runs');
+}
+
 // Bump when the schema gains a column / index / table that older
 // Karajan versions cannot understand. A DB written by a newer Karajan
 // refuses to open here so it does not get silently downgraded.

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -20,6 +20,7 @@ import { homedir } from 'node:os';
 import { writeJsonAtomicSync } from '../../../src/utils/atomic-write.js';
 import { spawn } from 'node:child_process';
 import { trackRun, untrack } from './run-tracker.js';
+import { getHuBoardRunsDir } from './db.js';
 import { fileURLToPath } from 'node:url';
 import { updateHuStatus, certifyAllHus, updateHu } from '../../../src/plan/plan-hu-ops.js';
 import { validateBlockedByChange } from '../../../src/plan/plan-validation.js';
@@ -377,7 +378,7 @@ export function runPlan({ planId, projectId, taskOverride, huIds = null } = {}) 
     huFlag = huIds.join(',');
   }
 
-  const runsDir = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-board-runs');
+  const runsDir = getHuBoardRunsDir(); // KJC-TSK-0421 — centralised in db.js
   mkdirSync(runsDir, { recursive: true });
   // PR4: when running a single HU, suffix the log with the HU id so
   // a subsequent full-plan run doesn't overwrite the per-HU log.

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -14,6 +14,7 @@ import {
   deleteStory,
   deleteSession,
   getKjHome,
+  getHuBoardRunsDir,
   getStoryRow,
   listPlanIdsForProject,
   updateStoryStatus,
@@ -865,7 +866,7 @@ router.get('/events', (req, res) => {
  */
 router.get('/plans/:planId/log', (req, res) => {
   try {
-    const runsDir = path.join(getKjHome(), 'hu-board-runs');
+    const runsDir = getHuBoardRunsDir(); // KJC-TSK-0421
     const logPath = path.join(runsDir, `${req.params.planId}.log`);
     if (!fs.existsSync(logPath)) {
       return res.json({ exists: false, size: 0, content: '' });
@@ -1171,7 +1172,7 @@ router.post('/runs/:planId/stop', async (req, res) => {
 
 router.get('/runs/:commandId/log', (req, res) => {
   try {
-    const runsDir = path.join(getKjHome(), 'hu-board-runs');
+    const runsDir = getHuBoardRunsDir(); // KJC-TSK-0421
     const logPath = path.join(runsDir, `${req.params.commandId}.log`);
     if (!fs.existsSync(logPath)) {
       return res.json({ exists: false, size: 0, content: '' });


### PR DESCRIPTION
## Why

First of the two housekeeping follow-ups from the [home-consolidation epic KJC-PCS-0047](https://planning-game.web.app). **Pure DRY** — no semantic change, no behaviour change, just one source of truth for the path.

(Original card title said `runs/` but the real culprit was `hu-board-runs/` — corrected scope.)

## Before

Five sites built the path `<karajan-home>/hu-board-runs/` themselves, **two of them inline** (bypassing the canonical `db.js::getKjHome()` of the package):

| File:line | Pattern |
|---|---|
| `src/utils/garbage-collector.js:335` | `getKarajanHome() + 'hu-board-runs'` |
| `packages/hu-board/src/plan-mutations.js:380` | **inline** `process.env.KJ_HOME \|\| homedir+.karajan + 'hu-board-runs'` |
| `packages/hu-board/src/command-runner.js:39` | **inline** in a local `runsDir()` helper |
| `packages/hu-board/src/routes/api.js:868` | `path.join(getKjHome(), 'hu-board-runs')` |
| `packages/hu-board/src/routes/api.js:1174` | same as above, duplicated |

A future change to where the board stores its run logs would have to touch 5 sites — and the two inline ones would silently miss the update.

## After

One canonical helper `getHuBoardRunsDir()` in `db.js`, four callers in the package import it:

```js
// packages/hu-board/src/db.js
export function getHuBoardRunsDir() {
  return join(getKjHome(), 'hu-board-runs');
}
```

The local `runsDir()` helper in `command-runner.js` is gone (replaced by the import). `plan-mutations.js` and the two `api.js` sites use the helper.

## What's NOT in this PR

`src/utils/garbage-collector.js` is in the **root package** (not `hu-board`) and uses `getKarajanHome()` from `src/utils/paths.js`. Cross-workspace imports between the two are technically possible but require a tooling refactor; that's [KJC-TSK-0420](https://planning-game.web.app) territory (route 38 direct `os.homedir()` callers through the unified resolver), not this PR.

## Files

```
packages/hu-board/src/db.js                    +13 (new helper)
packages/hu-board/src/command-runner.js        +4 / -8 (drop local runsDir(), import helper)
packages/hu-board/src/plan-mutations.js        +2 / -1 (use helper)
packages/hu-board/src/routes/api.js            +3 / -2 (use helper at both sites)
```

**Net +11 LOC**, well inside any budget.

## Tests

83 tests passing across the two suites that touch `hu-board-runs/`:

- 64 in `packages/hu-board/tests/{command-runner,plan-mutations}.test.js` (run with `packages/hu-board` vitest config).
- 19 in `tests/utils/garbage-collector.test.js` (root vitest config).

No regressions.

## Closes

[KJC-TSK-0421](https://planning-game.web.app) — under epic [KJC-PCS-0047](https://planning-game.web.app).