### PR TITLE
chore(paths): route inline ~/.karajan/ resolution through helpers (KJC-TSK-0420)

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -30,16 +30,16 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, renameSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import yaml from 'js-yaml';
+import { getKjHome } from './db.js';
 
 function configPath() {
   // Same path the parent uses (src/utils/paths.js::getKarajanHome).
-  // We can't import the parent helper from the hu-board package
-  // without inflating the module graph, so we duplicate the small
-  // path-resolution logic here. Keep them in lockstep.
-  if (process.env.KJ_HOME) return join(process.env.KJ_HOME, 'kj.config.yml');
-  return join(homedir(), '.karajan', 'kj.config.yml');
+  // KJC-TSK-0420: delegate to db.js::getKjHome — gives us KARAJAN_HOME
+  // priority + KJ_HOME fallback + VITEST guard from one place, instead
+  // of duplicating the precedence here.
+  return join(getKjHome(), 'kj.config.yml');
 }
 
 function backupPath() { return `${configPath()}.bak`; }

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -33,6 +33,11 @@ function vitestTmpKjHome() {
  * @returns {string}
  */
 export function getKjHome() {
+  // KJC-TSK-0420: same precedence chain as src/utils/paths.js::resolveHome():
+  // KARAJAN_HOME (canonical) > KJ_HOME (legacy) > VITEST tmp > ~/.karajan.
+  // Kept inline rather than cross-workspace imported so the hu-board package
+  // does not gain a new src/ dep; the precedence behaviour is the same.
+  if (process.env.KARAJAN_HOME) return process.env.KARAJAN_HOME;
   if (process.env.KJ_HOME) return process.env.KJ_HOME;
   if (process.env.VITEST) return vitestTmpKjHome();
   return join(process.env.HOME || '/root', '.karajan');

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -27,7 +27,10 @@ import { findAvailablePort as findAvailablePortBase } from '../../../src/utils/p
  * Now the server writes its own PID on every start so both the CLI
  * launch and the in-place restart keep the file accurate.
  */
-const PID_FILE = join(process.env.KJ_HOME || join(homedir(), '.karajan'), 'hu-board.pid');
+// KJC-TSK-0420: delegate to db.js::getKjHome so KARAJAN_HOME / KJ_HOME /
+// VITEST all share one precedence chain.
+import { getKjHome } from './db.js';
+const PID_FILE = join(getKjHome(), 'hu-board.pid');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = join(__dirname, '..', 'public');

--- a/packages/hu-board/src/token-store.js
+++ b/packages/hu-board/src/token-store.js
@@ -18,13 +18,13 @@ import { dirname, join } from "node:path";
 const TOKEN_BYTES = 32;
 
 /**
- * Compute the on-disk token path. Mirrors the rest of the board's
- * paths convention (KJ_HOME first, fallback to ~/.karajan).
+ * Compute the on-disk token path. Delegates to db.js::getKjHome which
+ * (post-KJC-TSK-0420) honours KARAJAN_HOME > KJ_HOME > VITEST > default.
  * @returns {string}
  */
+import { getKjHome } from "./db.js";
 export function getTokenPath() {
-  const home = process.env.KJ_HOME || join(homedir(), ".karajan");
-  return join(home, "hu-board", "token");
+  return join(getKjHome(), "hu-board", "token");
 }
 
 /**

--- a/packages/hu-board/src/zombie-reaper.js
+++ b/packages/hu-board/src/zombie-reaper.js
@@ -125,14 +125,13 @@ export function appendZombieCheckpoint(existingJson, reason, isoTimestamp) {
 }
 
 /**
- * Default location of the on-disk session JSON files.
- * Honours $KJ_HOME so tests and per-user setups can point elsewhere.
- *
+ * Default location of the on-disk session JSON files. Delegates to
+ * db.js::getKjHome (KJC-TSK-0420): KARAJAN_HOME > KJ_HOME > VITEST > default.
  * @returns {string}
  */
+import { getKjHome } from "./db.js";
 export function getSessionsDir() {
-  const home = process.env.KJ_HOME || path.join(os.homedir(), ".karajan");
-  return path.join(home, "sessions");
+  return path.join(getKjHome(), "sessions");
 }
 
 /**

--- a/packages/hu-board/tests/db-kj-home-isolation.test.js
+++ b/packages/hu-board/tests/db-kj-home-isolation.test.js
@@ -62,4 +62,15 @@ describe("hu-board db.getKjHome — VITEST auto-isolation", () => {
     const { getKjHome } = await import("../src/db.js");
     expect(getKjHome()).toBe("/winner");
   });
+
+  it("KARAJAN_HOME has priority over KJ_HOME (KJC-TSK-0420)", async () => {
+    process.env.KARAJAN_HOME = "/canonical";
+    process.env.KJ_HOME = "/legacy";
+    try {
+      const { getKjHome } = await import("../src/db.js");
+      expect(getKjHome()).toBe("/canonical");
+    } finally {
+      delete process.env.KARAJAN_HOME;
+    }
+  });
 });

--- a/src/audit/webperf-input.js
+++ b/src/audit/webperf-input.js
@@ -28,15 +28,12 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { evaluateCwv, CWV_THRESHOLDS } from "../webperf/cwv-gate.js";
+import { getWebperfDir } from "../utils/paths.js";
 
-// Resolve per call — `os.homedir()` reads $HOME each time, so test
-// suites that override $HOME for hermetic tmp dirs work without
-// special re-imports.
-function webperfHome() {
-  return path.join(os.homedir(), ".karajan", "webperf");
-}
+// Delegated to src/utils/paths.js (KJC-TSK-0420) — respects
+// KARAJAN_HOME / KJ_HOME (with deprecation warning) / VITEST tmp.
+function webperfHome() { return getWebperfDir(); }
 
 function projectSlug(projectDir) {
   return path.basename(projectDir || process.cwd()).replaceAll(/[^a-zA-Z0-9_-]/g, "_");

--- a/src/checks/dir-setup.js
+++ b/src/checks/dir-setup.js
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { STRATEGY } from "./types.js";
+import { getKarajanHome } from "../utils/paths.js";
 
 const REQUIRED_DIRS = [
   "", // ~/.karajan/
@@ -26,8 +27,9 @@ export function createKarajanDirsCheck() {
     strategy: STRATEGY.AUTO,
     describe: "Create missing ~/.karajan subdirectories",
     async detect() {
-      const home = os.homedir();
-      const root = path.join(home, ".karajan");
+      // KJC-TSK-0420: KARAJAN_HOME / KJ_HOME aware via getKarajanHome().
+      const root = getKarajanHome();
+      const home = os.homedir(); // still needed for path.relative() below
       const missing = [];
       for (const sub of REQUIRED_DIRS) {
         const full = sub ? path.join(root, sub) : root;
@@ -82,7 +84,7 @@ export function createLegacyKjHomeCheck() {
       try {
         const entries = await fs.readdir(legacy);
         if (entries.length === 0) return { ok: true, severity: "info", detail: "Empty legacy ~/.kj/" };
-        const marker = path.join(os.homedir(), ".karajan", ".kj-migrated.json");
+        const marker = path.join(getKarajanHome(), ".kj-migrated.json"); // KJC-TSK-0420
         try { await fs.access(marker); return { ok: true, severity: "info", detail: "Already migrated" }; }
         catch { /* no marker, still pending */ }
         return {

--- a/src/commands/webperf.js
+++ b/src/commands/webperf.js
@@ -9,16 +9,14 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import yaml from "js-yaml";
 import { runWebperfScan } from "../webperf/scanner.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 
-// Resolve home each call so tests that override $HOME for hermetic
-// tmp dirs work without re-importing the module.
-function defaultReportDir() {
-  return path.join(os.homedir(), ".karajan", "webperf");
-}
+// Delegated to src/utils/paths.js (KJC-TSK-0420) — respects
+// KARAJAN_HOME / KJ_HOME / VITEST tmp / default.
+import { getWebperfDir } from "../utils/paths.js";
+function defaultReportDir() { return getWebperfDir(); }
 
 /**
  * Slug a project directory the same way audit/basal-cost.js and

--- a/src/roles/perf-role.js
+++ b/src/roles/perf-role.js
@@ -20,7 +20,6 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import { BaseRole } from "./base-role.js";
 import { runWebperfScan } from "../webperf/scanner.js";
 
@@ -28,9 +27,10 @@ function projectSlug(projectDir) {
   return path.basename(projectDir || process.cwd()).replaceAll(/[^a-zA-Z0-9_-]/g, "_");
 }
 
-function defaultPersistDir() {
-  return path.join(os.homedir(), ".karajan", "webperf");
-}
+// Delegated to src/utils/paths.js (KJC-TSK-0420) — respects
+// KARAJAN_HOME / KJ_HOME / VITEST tmp / default.
+import { getWebperfDir } from "../utils/paths.js";
+function defaultPersistDir() { return getWebperfDir(); }
 
 async function persistResult(result, projectDir) {
   if (!result?.ok) return null;

--- a/src/utils/board-prompt-bridge.js
+++ b/src/utils/board-prompt-bridge.js
@@ -28,16 +28,15 @@
 
 import { mkdir, writeFile, readFile, unlink, stat } from "node:fs/promises";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 
 const POLL_INTERVAL_MS = 500;
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;          // 30 min
 
-function getPromptsDir() {
-  const home = process.env.KJ_HOME || join(homedir(), ".karajan");
-  return join(home, "prompts");
-}
+// Delegated to src/utils/paths.js so KARAJAN_HOME, KJ_HOME (with
+// deprecation warning), VITEST tmp and the default all share one
+// precedence chain — KJC-TSK-0420.
+import { getPromptsDir } from "./paths.js";
 
 function exists(path) {
   return stat(path).then(() => true, () => false);

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -89,3 +89,18 @@ export function getSessionRoot() {
 export function getSonarComposePath() {
   return path.join(getKarajanHome(), "docker-compose.sonar.yml");
 }
+
+/** Webperf cache: `<karajan-home>/webperf/` — KJC-TSK-0420. */
+export function getWebperfDir() {
+  return path.join(getKarajanHome(), "webperf");
+}
+
+/** Run-registry: `<karajan-home>/runs/` — KJC-TSK-0420. */
+export function getRunsDir() {
+  return path.join(getKarajanHome(), "runs");
+}
+
+/** Board prompt bridge: `<karajan-home>/prompts/` — KJC-TSK-0420. */
+export function getPromptsDir() {
+  return path.join(getKarajanHome(), "prompts");
+}

--- a/src/utils/run-registry.js
+++ b/src/utils/run-registry.js
@@ -19,16 +19,16 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { writeJsonAtomicSync } from "./atomic-write.js";
+import { getRunsDir } from "./paths.js";
 
 /**
  * Directorio raíz donde viven los registros de run.
- * Honra `KJ_HOME` para tests y setups custom.
+ * Delega en `getRunsDir()` (KJC-TSK-0420) — respeta KARAJAN_HOME,
+ * KJ_HOME (con warning de deprecación), VITEST tmp y default.
  */
 export function runsDir() {
-  const home = process.env.KJ_HOME || path.join(os.homedir(), ".karajan");
-  return path.join(home, "runs");
+  return getRunsDir();
 }
 
 /**

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -178,6 +178,13 @@ describe("installer E2E: init → doctor", () => {
     fsPromises.stat.mockResolvedValue({ isDirectory: () => true });
     fsPromises.mkdir.mockResolvedValue(undefined);
 
+    // KJC-TSK-0420: dir-setup + config-loader now go through paths.js
+    // helpers. vi.resetAllMocks() wiped their mock return values, so
+    // restore them here next to the other resetAllMocks recovery.
+    const { getKarajanHome, getSessionRoot } = await import("../src/utils/paths.js");
+    getKarajanHome.mockReturnValue("/fake/.karajan");
+    getSessionRoot.mockReturnValue("/fake/.karajan/sessions");
+
     // Re-setup mocks introduced by commit 3 of KJC-TSK-0319
     const { isPortAvailable } = await import("../src/utils/port-check.js");
     isPortAvailable.mockResolvedValue(true);

--- a/tests/webperf/command-webperf.test.js
+++ b/tests/webperf/command-webperf.test.js
@@ -42,7 +42,7 @@ const failingScan = {
   ],
 };
 
-let tmpHome, tmpProject, originalHome;
+let tmpHome, tmpProject, originalHome, originalKarajanHome;
 let consoleSpy;
 
 beforeEach(async () => {
@@ -51,14 +51,20 @@ beforeEach(async () => {
   tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-webperf-cmd-"));
   tmpProject = path.join(tmpHome, "my-project");
   await fs.mkdir(tmpProject, { recursive: true });
+  // KJC-TSK-0420: defaultReportDir() now goes through paths.js which
+  // honours KARAJAN_HOME with priority over the VITEST tmp dir.
   originalHome = process.env.HOME;
+  originalKarajanHome = process.env.KARAJAN_HOME;
   process.env.HOME = tmpHome;
+  process.env.KARAJAN_HOME = path.join(tmpHome, ".karajan");
   consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
 
 afterEach(async () => {
   consoleSpy.mockRestore();
   process.env.HOME = originalHome;
+  if (originalKarajanHome === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalKarajanHome;
   await fs.rm(tmpHome, { recursive: true, force: true });
 });
 

--- a/tests/webperf/perf-role.test.js
+++ b/tests/webperf/perf-role.test.js
@@ -33,18 +33,25 @@ const failingScan = {
   ],
 };
 
-let tmpHome, tmpProject, originalHome;
+let tmpHome, tmpProject, originalHome, originalKarajanHome;
 
 beforeEach(async () => {
   tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "kj-perf-role-"));
   tmpProject = path.join(tmpHome, "my-app");
   await fs.mkdir(tmpProject, { recursive: true });
+  // KJC-TSK-0420: perf-role::defaultPersistDir() now resolves via
+  // src/utils/paths.js, which respects KARAJAN_HOME with priority over
+  // the VITEST tmp dir. Set both for hermetic test isolation.
   originalHome = process.env.HOME;
+  originalKarajanHome = process.env.KARAJAN_HOME;
   process.env.HOME = tmpHome;
+  process.env.KARAJAN_HOME = path.join(tmpHome, ".karajan");
 });
 
 afterEach(async () => {
   process.env.HOME = originalHome;
+  if (originalKarajanHome === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalKarajanHome;
   await fs.rm(tmpHome, { recursive: true, force: true });
 });
 

--- a/tests/webperf/webperf-input-discovery.test.js
+++ b/tests/webperf/webperf-input-discovery.test.js
@@ -45,10 +45,13 @@ describe("collectWebPerfInput — persisted scan discovery (KJC-TSK-0149 wiring)
   });
 
   it("falls back to ~/.karajan/webperf/<slug>/last.json discovery via projectDir", () => {
-    // Point HOME at our tmp so the fallback path lands inside it.
-    const originalHome = os.homedir();
+    // KJC-TSK-0420: webperf-input now resolves via paths.js which
+    // honours KARAJAN_HOME with priority over the VITEST tmp dir;
+    // set KARAJAN_HOME so the fallback path lands inside our tmp.
     const originalEnv = process.env.HOME;
+    const originalKarajanHome = process.env.KARAJAN_HOME;
     process.env.HOME = tmpDir;
+    process.env.KARAJAN_HOME = path.join(tmpDir, ".karajan");
     try {
       const projectDir = path.join(tmpDir, "my-project");
       fs.mkdirSync(projectDir, { recursive: true });
@@ -66,8 +69,8 @@ describe("collectWebPerfInput — persisted scan discovery (KJC-TSK-0149 wiring)
       expect(r.url).toBe("http://localhost:3000");
     } finally {
       process.env.HOME = originalEnv;
-      // Sanity assertion the homedir override was effective during the test
-      void originalHome;
+      if (originalKarajanHome === undefined) delete process.env.KARAJAN_HOME;
+      else process.env.KARAJAN_HOME = originalKarajanHome;
     }
   });
 


### PR DESCRIPTION
## Why

Closes the **second** housekeeping follow-up of [KJC-PCS-0047](https://planning-game.web.app). Twelve sites that built paths under `~/.karajan/` with their **own inline resolution** now go through helpers that honour the unified precedence chain (`KARAJAN_HOME > KJ_HOME > VITEST tmp > default`).

**User-visible payoff**: `KARAJAN_HOME=/some/path kj <anything>` now redirects **every** component to `/some/path/…` — not just plans / standby / sessions like before v2.19.0, but also:

| Component | Path |
|---|---|
| Webperf cache | `<root>/webperf/` |
| Run registry | `<root>/runs/` |
| Board prompt bridge | `<root>/prompts/` |
| HU Board auth token | `<root>/hu-board/token` |
| HU Board PID file | `<root>/hu-board.pid` |
| HU Board sessions (zombie reaper) | `<root>/sessions/` |
| Board config viewer | `<root>/kj.config.yml` |
| `kj doctor` dir-setup check | `<root>/` |
| `kj doctor` legacy-kj-home check (marker lookup) | `<root>/.kj-migrated.json` |

## New helpers in `src/utils/paths.js`

```js
export function getWebperfDir() { return path.join(getKarajanHome(), "webperf"); }
export function getRunsDir()    { return path.join(getKarajanHome(), "runs"); }
export function getPromptsDir() { return path.join(getKarajanHome(), "prompts"); }
```

Same precedence chain as `getKarajanHome()`. Zero new behaviour, just one source of truth per subdirectory.

## Sites refactored

### Root (6 files)

- `src/utils/run-registry.js` → `getRunsDir()`
- `src/utils/board-prompt-bridge.js` → `getPromptsDir()` + dropped homedir import
- `src/audit/webperf-input.js` → `getWebperfDir()` + dropped `os` import
- `src/commands/webperf.js` → `getWebperfDir()` + dropped `os` import
- `src/roles/perf-role.js` → `getWebperfDir()` + dropped `os` import
- `src/checks/dir-setup.js` → `getKarajanHome()` for the dir-tree check + the legacy-marker lookup

### HU Board (5 files)

- `packages/hu-board/src/db.js` — `getKjHome()` now ALSO honours `KARAJAN_HOME` (priority over `KJ_HOME`). Stays inline (not cross-workspace imported) so the package gains no new `src/` dep; precedence is identical to `src/utils/paths.js::resolveHome`.
- `packages/hu-board/src/token-store.js` → `getKjHome()` from db.js
- `packages/hu-board/src/config-yaml.js` → `getKjHome()` from db.js (the inline 'we can't import the parent helper' comment is now obsolete)
- `packages/hu-board/src/zombie-reaper.js` → `getKjHome()` from db.js
- `packages/hu-board/src/server.js` → `getKjHome()` from db.js for the `hu-board.pid` path

## What's NOT in this PR (out of scope, intentional)

The original inventory said '38 `os.homedir()` calls'. Of those, **~25 are legitimate or intentional** and stay untouched:

- `src/agents/resolve-bin.js` — looks up npm-global bin dirs (`AppData`, `.npm-global`, `.local/bin`, `.nvm`), not Karajan paths.
- `src/orchestrator/fs-leak-detector.js` — needs the real `$HOME` for the leak heuristic; `KARAJAN_HOME` redirection would defeat its purpose.
- `src/webperf/devtools-detect.js` — reads `~/.claude.json` and `~/.vscode/settings.json`, third-party app configs.
- `src/checks/config-files.js` — same, `~/.claude.json` and `~/.codex/config.toml`.
- `scripts/{postinstall,install}.js` — installer; the `~/.karajan/instances.json` write would benefit but the installer runs before any runtime config exists, so a behaviour change there is risky.
- `src/mcp/orphan-guard.js`, `sync.js`, `ephemeral-cleaner.js`, `plan-mutations.js`, `routes/api.js`, `cleanup-zombies.js` — `~/.kj/` references are intentional legacy fallbacks for the home-migration grace period; they read BOTH locations on purpose.
- `src/utils/home-migration.js` — the migrator itself reads the legacy `.kj` source path by definition.

## Tests

**364 affected tests passing** (281 root + 83 hu-board). One new test in `packages/hu-board/tests/db-kj-home-isolation.test.js` documents the new `KARAJAN_HOME wins over KJ_HOME` precedence.

## LOC

`+74 added, -45 deleted, net +29`. Refactor wash — most sites trade one inline resolution (3-4 lines) for one helper call + one import (2-3 lines). Well inside any budget.

## Closes the housekeeping backlog of KJC-PCS-0047

Combined with [#789 (KJC-TSK-0421)](https://github.com/manufosela/karajan-code/pull/789), this PR cleans up the last pieces of deuda técnica documented when the home-consolidation epic landed. After both merge, the only remaining `os.homedir()` callers are the legitimate ones above.