### PR TITLE
fix(sonar): auto-bootstrap token on 401 (KJC-BUG-0057)

### DIFF
--- a/src/sonar/api.js
+++ b/src/sonar/api.js
@@ -3,6 +3,7 @@ import { withRetry } from "../utils/retry.js";
 import { resolveSonarProjectKey } from "./project-key.js";
 import { resolveSonarToken } from "./config-resolver.js";
 import { filterFalsePositives } from "./issue-filter.js";
+import { recoverSonarToken } from "./token-recovery.js";
 
 class SonarApiError extends Error {
   constructor(message, { url, httpStatus, hint } = {}) {
@@ -25,7 +26,7 @@ function parseHttpResponse(stdout) {
   return { httpCode, body };
 }
 
-async function sonarFetchOnce(config, urlPath) {
+async function sonarFetchOnce(config, urlPath, { _retriedAfterRecovery = false, logger = null } = {}) {
   const token = tokenFromConfig(config);
   const url = `${config.sonarqube.host}${urlPath}`;
   const res = await runCommand("curl", ["-s", "-w", "\n%{http_code}", "-u", `${token}:`, url]);
@@ -42,9 +43,22 @@ async function sonarFetchOnce(config, urlPath) {
   const { httpCode, body } = parseHttpResponse(res.stdout);
 
   if (httpCode === 401) {
+    // KJC-BUG-0057 (v2.19.2): try to bootstrap a fresh token via the Sonar
+    // REST API and retry ONCE. If recovery still fails — or this was already
+    // the retry — surface the actionable error like before.
+    if (!_retriedAfterRecovery) {
+      const recovery = await recoverSonarToken(config, logger);
+      if (recovery.ok) {
+        return sonarFetchOnce(config, urlPath, { _retriedAfterRecovery: true, logger });
+      }
+      throw new SonarApiError(
+        `SonarQube authentication failed (HTTP 401) and auto-recovery failed: ${recovery.reason}. Regenerate the token manually with 'kj init' or save admin user/password in ~/.karajan/sonar-credentials.json.`,
+        { url, httpStatus: 401, hint: "Run 'kj init' to regenerate the SonarQube token, or save admin credentials in ~/.karajan/sonar-credentials.json so Karajan can re-bootstrap automatically." }
+      );
+    }
     throw new SonarApiError(
-      `SonarQube authentication failed (HTTP 401). Token may be invalid or expired. Regenerate with 'kj init'.`,
-      { url, httpStatus: 401, hint: "Run 'kj init' to regenerate the SonarQube token." }
+      `SonarQube authentication failed (HTTP 401) even after auto-recovery. The newly generated token is also being rejected — the Sonar instance may be in an inconsistent state.`,
+      { url, httpStatus: 401, hint: "Inspect the Sonar UI directly; consider 'kj sonar restart'." }
     );
   }
 

--- a/src/sonar/token-recovery.js
+++ b/src/sonar/token-recovery.js
@@ -1,0 +1,67 @@
+// Sonar 401 auto-recovery — KJC-BUG-0057 / v2.19.2.
+//
+// When the Sonar API returns 401 (token missing / invalid / expired / revoked)
+// and we still have admin/admin (or a user/pass we saved at `kj init` time),
+// regenerate the analysis token VIA THE REST API and persist it. The caller
+// retries the original request once with the new token.
+//
+// Programmatic, no LLM involvement. The whole point of the user feedback was
+// that this is plumbing, not a decision: Karajan has the credentials to
+// re-bootstrap and should do it without asking.
+
+import { bootstrapSonarToken } from "./token-bootstrap.js";
+import { saveSonarToken } from "./credentials.js";
+
+// Per-process latch: a single Sonar run that 401s on every endpoint must
+// only trigger ONE bootstrap attempt — not one per endpoint. The latch
+// resets when the process exits.
+let _recoveryAttempted = false;
+
+/**
+ * @internal Reset the latch between tests (mirrors __resetKjHomeWarningForTests).
+ */
+export function __resetSonarRecoveryLatchForTests() {
+  _recoveryAttempted = false;
+}
+
+/**
+ * Attempt to re-bootstrap the Sonar token after a 401. Mutates `config`
+ * in place when successful so the immediate retry picks up the new token.
+ *
+ * @param {object} config       Karajan config (will be mutated on success).
+ * @param {object} [logger]
+ * @returns {Promise<{ ok: boolean, reason?: string, newToken?: string, savedTo?: string, passwordRotated?: boolean }>}
+ */
+export async function recoverSonarToken(config, logger = null) {
+  if (_recoveryAttempted) {
+    return { ok: false, reason: "recovery already attempted in this process" };
+  }
+  _recoveryAttempted = true;
+
+  const host = config?.sonarqube?.host || "http://localhost:9000";
+  logger?.warn?.(`[sonar-recovery] 401 from ${host} — attempting token re-bootstrap`);
+
+  const result = await bootstrapSonarToken({ host });
+
+  if (!result.ok) {
+    logger?.warn?.(`[sonar-recovery] bootstrap failed: ${result.reason}`);
+    return { ok: false, reason: result.reason };
+  }
+
+  // Mutate the in-memory config so the caller's retry sees the new token.
+  config.sonarqube = config.sonarqube || {};
+  config.sonarqube.token = result.token;
+
+  // Also persist to ~/.karajan/sonar-credentials.json so future processes
+  // pick it up via the normal config-resolver chain instead of triggering
+  // recovery again. token-bootstrap.js already wrote sonar.token; this
+  // mirrors it into the structured credentials file the resolver reads.
+  try {
+    await saveSonarToken(result.token);
+  } catch (err) {
+    logger?.warn?.(`[sonar-recovery] persist to sonar-credentials.json failed (non-blocking): ${err.message}`);
+  }
+
+  logger?.info?.(`[sonar-recovery] new token persisted to ${result.savedTo}${result.passwordRotated ? " (admin password rotated)" : ""} — retrying original request`);
+  return { ok: true, newToken: result.token, savedTo: result.savedTo, passwordRotated: result.passwordRotated };
+}

--- a/tests/sonar/sonar-token-recovery.test.js
+++ b/tests/sonar/sonar-token-recovery.test.js
@@ -1,0 +1,91 @@
+// Tests for the Sonar 401 auto-recovery (KJC-BUG-0057 / v2.19.2).
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../src/sonar/token-bootstrap.js", () => ({
+  bootstrapSonarToken: vi.fn(),
+}));
+
+vi.mock("../../src/sonar/credentials.js", () => ({
+  saveSonarToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+const noopLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  const { __resetSonarRecoveryLatchForTests } = await import("../../src/sonar/token-recovery.js");
+  __resetSonarRecoveryLatchForTests();
+});
+
+describe("recoverSonarToken (KJC-BUG-0057)", () => {
+  it("calls bootstrapSonarToken with the configured host", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: true, token: "squ_new", savedTo: "/x/sonar.token" });
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+    const config = { sonarqube: { host: "http://localhost:9001", token: "stale" } };
+
+    const r = await recoverSonarToken(config, noopLog);
+
+    expect(r.ok).toBe(true);
+    expect(r.newToken).toBe("squ_new");
+    expect(bootstrapSonarToken).toHaveBeenCalledWith({ host: "http://localhost:9001" });
+  });
+
+  it("mutates config.sonarqube.token in place so the immediate retry sees the new token", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: true, token: "squ_new", savedTo: "/x/sonar.token" });
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+    const config = { sonarqube: { host: "http://localhost:9000", token: "stale" } };
+
+    await recoverSonarToken(config, noopLog);
+
+    expect(config.sonarqube.token).toBe("squ_new");
+  });
+
+  it("persists the new token to sonar-credentials.json (best-effort)", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: true, token: "squ_new", savedTo: "/x/sonar.token" });
+    const { saveSonarToken } = await import("../../src/sonar/credentials.js");
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+
+    await recoverSonarToken({ sonarqube: { host: "http://localhost:9000" } }, noopLog);
+
+    expect(saveSonarToken).toHaveBeenCalledWith("squ_new");
+  });
+
+  it("returns ok=false with the upstream reason when bootstrap fails", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: false, reason: "admin/admin login failed" });
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+
+    const r = await recoverSonarToken({ sonarqube: { host: "http://localhost:9000" } }, noopLog);
+
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("admin/admin");
+  });
+
+  it("only attempts recovery once per process even when called twice (latch)", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: true, token: "squ_new", savedTo: "/x" });
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+    const config = { sonarqube: { host: "http://localhost:9000" } };
+
+    await recoverSonarToken(config, noopLog);
+    const second = await recoverSonarToken(config, noopLog);
+
+    expect(second.ok).toBe(false);
+    expect(second.reason).toMatch(/already attempted/i);
+    expect(bootstrapSonarToken).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to default host when config.sonarqube is missing", async () => {
+    const { bootstrapSonarToken } = await import("../../src/sonar/token-bootstrap.js");
+    bootstrapSonarToken.mockResolvedValue({ ok: true, token: "squ_new", savedTo: "/x" });
+    const { recoverSonarToken } = await import("../../src/sonar/token-recovery.js");
+
+    await recoverSonarToken({}, noopLog);
+
+    expect(bootstrapSonarToken).toHaveBeenCalledWith({ host: "http://localhost:9000" });
+  });
+});


### PR DESCRIPTION
## Why

> *Si karajan ve que no funciona sonar, que tiene el user/passw, que genere nuevo token, karajan debe tener capacidad de hacer esto y no tiene que hacerlo la IA, es algo programatico.*
>
> — User feedback after Aitor's Sonar 401 report

`bootstrapSonarToken()` already exists in `src/sonar/token-bootstrap.js` (added in v2.10.2 — it probes admin/admin, rotates the default password, revokes the existing `karajan-cli` token and generates a fresh one). But it was **only invoked from `kj init`**. Every other code path that hit Sonar with a missing / stale / revoked token just threw `SonarApiError` HTTP 401 with the hint "Regenerate with `kj init`". That's not what the user expects — Karajan has the credentials, the plumbing exists, it should re-bootstrap itself.

## What changes

### NEW — `src/sonar/token-recovery.js` (67 LOC)

Single async function `recoverSonarToken(config, logger)` that:

1. Honours a **per-process latch** — one Sonar run that 401s on N endpoints triggers ONE bootstrap attempt, not N.
2. Calls `bootstrapSonarToken({ host: config.sonarqube.host })` — reuses the v2.10.2 code path.
3. **Mutates** `config.sonarqube.token` in place so the caller's immediate retry sees the new token (no config reload).
4. Persists the new token to `~/.karajan/sonar-credentials.json` via `saveSonarToken` so future processes pick it up via the normal resolver chain instead of triggering recovery again.

Programmatic. Zero LLM involvement.

### MODIFIED — `src/sonar/api.js` (+17/-3)

`sonarFetchOnce()` gains a hidden `_retriedAfterRecovery` flag. On HTTP 401:

- **First call** → call `recoverSonarToken`, recurse with `_retriedAfterRecovery=true`. If recovery succeeds, the retry uses the new token transparently and the caller never sees the 401.
- **Recovery fails** → throw `SonarApiError` with a more actionable hint: *"…auto-recovery failed: ${reason}. Regenerate manually with kj init or save admin user/password in `~/.karajan/sonar-credentials.json` so Karajan can re-bootstrap automatically."*
- **Retry still 401s** → throw with a distinct hint pointing at the Sonar instance: *"…even after auto-recovery. The newly generated token is also being rejected — the Sonar instance may be in an inconsistent state."*

The diff stays minimal — no changes to `sonarFetch`, retry policy, or any caller.

## Tests

`tests/sonar/sonar-token-recovery.test.js` — 6 new tests:

1. Calls `bootstrapSonarToken` with the configured host.
2. Mutates `config.sonarqube.token` in place so the immediate retry sees the new token.
3. Persists to `sonar-credentials.json` (best-effort).
4. Returns `{ ok: false, reason }` with upstream reason on bootstrap failure.
5. Per-process latch: only attempts recovery once even after multiple calls.
6. Falls back to default host `http://localhost:9000` when `config.sonarqube` is missing.

**Full sonar suite (15 files, 160 tests) still green.**

## LOC

+175 added, -3 deleted, **net +172**. Inside the 200 hard limit.

## Release

Bug class: **Workflow Improvement** (workaround = `kj init`). Target patch **v2.19.2**.

Closes [KJC-BUG-0057](https://planning-game.web.app). Reported by [@aitormf](https://github.com/aitormf).