### PR TITLE
fix(board): detect canonical + legacy plans roots in 5 sites (KJC-BUG-0059)

### DIFF
--- a/packages/hu-board/src/cleanup-zombies.js
+++ b/packages/hu-board/src/cleanup-zombies.js
@@ -47,8 +47,12 @@ function isEphemeralId(id) {
   return EPHEMERAL_PREFIXES.some((p) => id.startsWith(p));
 }
 
-function plansRoot() {
-  return process.env.KJ_PLANS_DIR || path.join(homedir(), '.kj', 'plans');
+// KJC-BUG-0059 (v2.19.3): cleanup walks all known plan roots,
+// canonical first then legacy. Pre-fix hard-coded `~/.kj/plans/`
+// missed every plan post-v2.19.0 → zombies never garbage-collected.
+import { getHuBoardPlansDirs } from './db.js';
+function plansRoots() {
+  return getHuBoardPlansDirs();
 }
 
 function olderThanDays(isoStr, days) {
@@ -90,7 +94,7 @@ export function cleanupZombies(opts = {}) {
     const fsPaths = [
       ...storyIds.map((sid) => path.join(getKjHome(), 'hu-stories', sid)),
       ...sessionIds.map((sid) => path.join(getKjHome(), 'sessions', sid)),
-      path.join(plansRoot(), proj.id),
+      ...plansRoots().map((root) => path.join(root, proj.id)),
     ];
     deleteProject(proj.id);
     addTombstone('project', proj.id, { source: 'auto-cleanup', fsPaths });

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -56,6 +56,51 @@ export function getHuBoardRunsDir() {
   return join(getKjHome(), 'hu-board-runs');
 }
 
+/**
+ * Canonical path to the plans directory the board scans
+ * (`<karajan-home>/plans/`). Respects `KJ_PLANS_DIR` as an absolute
+ * override, mirroring sync.js. KJC-BUG-0059 (v2.19.3): preflight
+ * endpoint used a hard-coded `~/.kj/plans/` legacy fallback that
+ * survived the v2.19.0 consolidation, causing the board to report
+ * "directorio del proyecto: no detectado" even when the plan on disk
+ * had a valid `projectDir`.
+ *
+ * @returns {string}
+ */
+export function getHuBoardPlansDir() {
+  return process.env.KJ_PLANS_DIR || join(getKjHome(), 'plans');
+}
+
+/**
+ * Legacy `~/.kj/plans/` directory — only returned when KJ_PLANS_DIR
+ * is unset (it would be the same path anyway when overridden).
+ * Callers iterate canonical + legacy so users who have not yet run
+ * the v2.19.0 auto-migrator still see their plans. KJC-BUG-0059.
+ *
+ * @returns {string|null}
+ */
+export function getHuBoardLegacyPlansDir() {
+  if (process.env.KJ_PLANS_DIR) return null;
+  return join(process.env.HOME || '/root', '.kj', 'plans');
+}
+
+/**
+ * Ordered list of every plans root the board should scan: canonical
+ * first (`~/.karajan/plans/`), legacy second when applicable
+ * (`~/.kj/plans/`). Honours `KJ_PLANS_DIR` as a single override,
+ * matching `sync.js`'s fullScan / startWatcher precedence so the
+ * preflight, plans-outcome, delete-project and delete-plan endpoints
+ * see the same set of files the watcher sees. KJC-BUG-0059.
+ *
+ * @returns {string[]}
+ */
+export function getHuBoardPlansDirs() {
+  const dirs = [getHuBoardPlansDir()];
+  const legacy = getHuBoardLegacyPlansDir();
+  if (legacy) dirs.push(legacy);
+  return dirs;
+}
+
 // Bump when the schema gains a column / index / table that older
 // Karajan versions cannot understand. A DB written by a newer Karajan
 // refuses to open here so it does not get silently downgraded.

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -40,10 +40,13 @@ const KJ_CLI = join(REPO_ROOT, 'src', 'cli.js');
  * `KJ_PLANS_DIR` (tests) then `KJ_HOME/plans` (power users) then
  * `~/.kj/plans/` (default) — same precedence as `sync.js::fullScan`.
  */
+// KJC-BUG-0059: write operations go to the canonical plans dir.
+// Read operations should iterate getHuBoardPlansDirs() instead, to
+// pick up plans the user has under the legacy ~/.kj/plans/ tree
+// while the auto-migrator has not yet fired.
+import { getHuBoardPlansDir } from './db.js';
 function plansRoot() {
-  if (process.env.KJ_PLANS_DIR) return process.env.KJ_PLANS_DIR;
-  if (process.env.KJ_HOME) return join(process.env.KJ_HOME, 'plans');
-  return join(homedir(), '.kj', 'plans');
+  return getHuBoardPlansDir();
 }
 
 /**

--- a/packages/hu-board/src/preflight.js
+++ b/packages/hu-board/src/preflight.js
@@ -30,6 +30,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { getHuBoardPlansDirs } from './db.js';
 
 function runQuiet(cmd, opts = {}) {
   try {
@@ -221,13 +222,13 @@ function checkConfigYml() {
 }
 
 function checkPlans(projectId) {
-  // Plans live at ~/.kj/plans/<projectId>/*.json (or
-  // $KJ_HOME/plans/<projectId>/*.json under VITEST or custom config).
-  // Mirror plan-mutations.js::plansRoot() so the path matches reality.
-  const dir = process.env.KJ_HOME
-    ? join(process.env.KJ_HOME, 'plans', projectId)
-    : join(process.env.HOME || '', '.kj', 'plans', projectId);
-  if (!existsSync(dir)) {
+  // KJC-BUG-0059 (v2.19.3): scan canonical + legacy roots, same as
+  // the preflight route. Pre-fix this hard-coded `~/.kj/plans/`
+  // missed every plan post-v2.19.0 → preflight reported "sin plans
+  // aún" even when the user had a valid plan on disk.
+  const dirs = getHuBoardPlansDirs().map((root) => join(root, projectId));
+  const dir = dirs.find((d) => existsSync(d));
+  if (!dir) {
     return {
       id: 'plans', label: 'Plans en disco', status: 'info',
       detail: 'sin plans aún',

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -15,6 +15,9 @@ import {
   deleteSession,
   getKjHome,
   getHuBoardRunsDir,
+  getHuBoardPlansDir,
+  getHuBoardLegacyPlansDir,
+  getHuBoardPlansDirs,
   getStoryRow,
   listPlanIdsForProject,
   updateStoryStatus,
@@ -192,22 +195,23 @@ router.get('/projects/:id/preflight', async (req, res) => {
   try {
     const projectId = req.params.id;
     let projectDir = null;
+    // KJC-BUG-0059 (v2.19.3): scan plans in BOTH the canonical
+    // ~/.karajan/plans/ AND the legacy ~/.kj/plans/ — the legacy
+    // fallback covers users who started the board before running any
+    // `kj` command on a fresh install (so the auto-migrator from
+    // v2.19.0 has not fired yet). Pre-fix, this endpoint hard-coded
+    // ~/.kj/plans/ as the default, missing every plan post-2.19.0
+    // → board card showed "directorio del proyecto: no detectado"
+    // even though the plan on disk had a valid projectDir.
     try {
-      // Plans live at ~/.kj/plans/<slug>/ when KJ_HOME is unset, or
-      // $KJ_HOME/plans/<slug>/ when set. db.js::getKjHome() returns
-      // the .karajan root, NOT the .kj root — they are sister dirs.
-      // Mirror plan-mutations.js::plansRoot() exactly.
-      const plansBase = process.env.KJ_HOME
-        ? path.join(process.env.KJ_HOME, 'plans')
-        : path.join(process.env.HOME || '', '.kj', 'plans');
-      const plansDir = path.join(plansBase, projectId);
-      if (fs.existsSync(plansDir)) {
-        const files = fs.readdirSync(plansDir).filter((f) => f.endsWith('.json'));
-        for (const f of files) {
+      outer: for (const root of getHuBoardPlansDirs()) {
+        const plansDir = path.join(root, projectId);
+        if (!fs.existsSync(plansDir)) continue;
+        for (const f of fs.readdirSync(plansDir).filter((x) => x.endsWith('.json'))) {
           try {
             const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
-            if (plan?.projectDir) { projectDir = plan.projectDir; break; }
-          } catch { /* try next */ }
+            if (plan?.projectDir) { projectDir = plan.projectDir; break outer; }
+          } catch { /* try next file */ }
         }
       }
     } catch { /* projectDir stays null → preflight will report it */ }
@@ -229,17 +233,17 @@ router.get('/projects/:id/preflight', async (req, res) => {
 router.get('/projects/:id/plans-outcome', (req, res) => {
   try {
     const projectId = req.params.id;
-    const plansBase = process.env.KJ_HOME
-      ? path.join(process.env.KJ_HOME, 'plans')
-      : path.join(process.env.HOME || '', '.kj', 'plans');
-    const plansDir = path.join(plansBase, projectId);
-    if (!fs.existsSync(plansDir)) return res.json({ projectId, plans: [] });
+    // KJC-BUG-0059 (v2.19.3): scan canonical + legacy roots so users
+    // who have not yet run the auto-migrator still see their plans.
     const out = [];
-    for (const f of fs.readdirSync(plansDir).filter(n => n.endsWith('.json'))) {
-      try {
-        const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
-        if (plan?.version !== 2) continue;
-        out.push({
+    for (const root of getHuBoardPlansDirs()) {
+      const plansDir = path.join(root, projectId);
+      if (!fs.existsSync(plansDir)) continue;
+      for (const f of fs.readdirSync(plansDir).filter(n => n.endsWith('.json'))) {
+        try {
+          const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
+          if (plan?.version !== 2) continue;
+          out.push({
           planId: plan.planId,
           name: plan.name || (plan.task ? plan.task.slice(0, 80) : plan.planId),
           status: plan.status || 'draft',
@@ -248,6 +252,7 @@ router.get('/projects/:id/plans-outcome', (req, res) => {
           huCount: Array.isArray(plan.hus) ? plan.hus.length : 0,
         });
       } catch { /* skip unreadable plan */ }
+      }
     }
     res.json({ projectId, plans: out });
   } catch (err) {
@@ -356,12 +361,13 @@ router.delete('/projects/:id', (req, res) => {
     // ~/.kj/plans relative to KJ_HOME's parent, which broke when the
     // two homes were configured separately and left orphan plan dirs
     // on disk after a 🗑️ delete.
-    const plansRoot = process.env.KJ_PLANS_DIR
-      || path.join(os.homedir(), '.kj', 'plans');
+    // KJC-BUG-0059 (v2.19.3): when removing a deleted project's
+    // residual plan dirs, sweep BOTH the canonical and legacy roots
+    // so the cleanup is consistent for users mid-migration.
     const fsPaths = [
       ...storyIds.map((sid) => path.join(huStoriesDir(), sid)),
       ...sessionIds.map((sid) => path.join(getKjHome(), 'sessions', sid)),
-      path.join(plansRoot, id),
+      ...getHuBoardPlansDirs().map((root) => path.join(root, id)),
     ];
 
     const existed = deleteProject(id);
@@ -464,13 +470,18 @@ router.delete('/sessions/:id', (req, res) => {
 router.delete('/plans/:planId', (req, res) => {
   try {
     const planId = req.params.planId;
-    // Locate the plan file by scanning the plans dir for filename match.
-    const plansRoot = process.env.KJ_PLANS_DIR || path.join(getKjHome(), '..', '.kj', 'plans');
+    // Locate the plan file by scanning both canonical and legacy plans
+    // roots — KJC-BUG-0059 (v2.19.3). Pre-fix this hard-coded
+    // `getKjHome()/../.kj/plans` which silently misses plans saved by
+    // post-2.19.0 callers under `~/.karajan/plans/`.
     let foundPath = null;
     try {
-      for (const projSlug of fs.readdirSync(plansRoot)) {
-        const candidate = path.join(plansRoot, projSlug, `plan-${planId}.json`);
-        if (fs.existsSync(candidate)) { foundPath = candidate; break; }
+      outer: for (const plansRoot of getHuBoardPlansDirs()) {
+        if (!fs.existsSync(plansRoot)) continue;
+        for (const projSlug of fs.readdirSync(plansRoot)) {
+          const candidate = path.join(plansRoot, projSlug, `plan-${planId}.json`);
+          if (fs.existsSync(candidate)) { foundPath = candidate; break outer; }
+        }
       }
     } catch { /* plansRoot missing */ }
     addTombstone('plan', planId, { source: 'api', fsPaths: foundPath ? [foundPath] : [] });


### PR DESCRIPTION
Closes KJC-BUG-0059. Reported by Aitor Martinez.

## Síntoma

El card superior del HU Board muestra 'Directorio del proyecto — no detectado' aun cuando la run tiene `projectDir` válido y el coder está leyendo ficheros de él. Aitor lo reportó con screenshot.

## Causa raíz

5 call sites de `packages/hu-board/src/` hardcoded a `~/.kj/plans/`, supervivientes de la consolidación de home v2.19.0 (PR #783 corrigió `sync.js` pero estos 5 quedaron). Tras la auto-migración los planes están en `~/.karajan/plans/<slug>/` y el board los seguía buscando en `~/.kj/plans/<slug>/`.

| Endpoint / función | Síntoma del bug |
|---|---|
| `GET /api/projects/:id/preflight` | 'no detectado' (el literal de Aitor) |
| `GET /api/projects/:id/plans-outcome` | devuelve `plans: []` para todo proyecto post-v2.19.0 |
| `DELETE /api/projects/:id` | barre la ruta incorrecta → residuo en disco tras 🗑 |
| `DELETE /api/plans/:planId` | falla silente |
| `preflight.checkPlans` | reporta 'plans missing' aun habiéndolos |
| `plan-mutations.plansRoot` | escribe nuevos run logs al root legacy |
| `cleanup-zombies` | nunca GC bajo `~/.karajan/plans/` |

## Fix

3 helpers nuevos en `packages/hu-board/src/db.js`:

- `getHuBoardPlansDir()` — canonical (`~/.karajan/plans/` o override `KJ_PLANS_DIR`)
- `getHuBoardLegacyPlansDir()` — legacy (`~/.kj/plans/`, null si `KJ_PLANS_DIR`)
- `getHuBoardPlansDirs()` — `[canonical, legacy?]` ordenado, para iterar en read/delete/GC

Single-writer (`plan-mutations`) usa el canonical. Read/delete/GC iteran ambos para no romper a usuarios mid-migration con planes pre-v2.19.0.

## Tests

29 test files / 349 tests verdes en hu-board. Sin tests nuevos: la suite existente mockea env vars y el fix la desbloquea también.

## LOC

+108 / -44, net +64. Dentro del budget de 200 (hard) / 150 (ideal).

## Fuera de esta PR

- KJC-BUG-0058 (`kj resume` re-ejecuta researcher+architect): requiere persistencia de stage outputs y skip logic — diferido a v2.19.4 / v2.20.0.