### PR TITLE
fix(orchestrator): autoInit must not commit on parent repo (KJC-BUG-0060)

### DIFF
--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -26,17 +26,27 @@ import { exists, ensureDir } from "../utils/fs.js";
  * Called by the orchestrator before the pipeline starts.
  */
 export async function autoInit(projectDir, logger) {
-  // Ensure git repo exists — without git, diff/reviewer/commit won't work
-  const gitDir = path.join(projectDir, ".git");
-  if (!(await exists(gitDir))) {
-    // Audit follow-up: was execSync with constant strings. Inputs are
-    // hardcoded, so injection isn't possible, but the project standard
-    // since #555 is execFileSync everywhere. Migrated for consistency.
-    const { execFileSync } = await import("node:child_process");
+  // Ensure git repo exists — without git, diff/reviewer/commit won't work.
+  //
+  // KJC-BUG-0060: the previous guard `!exists(projectDir/.git)` was insufficient
+  // when projectDir is a subdirectory inside an existing repo (common in dogfooding
+  // scenarios where kj-linked runs from the karajan-code source tree). In that case
+  // `git commit --allow-empty` would resolve upward to the parent repo and land an
+  // empty "initial commit" on the user's main branch. Use `git rev-parse
+  // --is-inside-work-tree` instead — it follows the same upward traversal that git
+  // does naturally, so a subdir inside a repo correctly reports `true` and we don't
+  // touch anything. We also drop the `git commit --allow-empty -m "initial commit"`
+  // step: a root commit is not required for any downstream stage (diff, review,
+  // coder, sonar) and the empty-commit zombie history was the user-visible symptom.
+  const { execFileSync } = await import("node:child_process");
+  try {
+    execFileSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd: projectDir, stdio: "pipe" });
+    // Already inside a git work tree (own .git or parent's). Nothing to do.
+  } catch {
+    // Not inside any repo — create a fresh one. No empty seed commit.
     try {
       execFileSync("git", ["init"], { cwd: projectDir, stdio: "pipe" });
-      execFileSync("git", ["commit", "--allow-empty", "-m", "initial commit"], { cwd: projectDir, stdio: "pipe" });
-      logger.info("Initialized git repository with empty initial commit");
+      logger.info("Initialized git repository (no seed commit)");
     } catch (err) {
       logger.warn(`Failed to init git repo: ${err.message}`);
     }

--- a/tests/orchestrator/config-init-autoinit.test.js
+++ b/tests/orchestrator/config-init-autoinit.test.js
@@ -1,0 +1,98 @@
+/**
+ * Regression pin for KJC-BUG-0060.
+ *
+ * The previous `autoInit()` guard only checked `existsSync(projectDir/.git)`.
+ * That was insufficient: a `projectDir` pointing to a subdirectory of an
+ * existing git repo would still pass the guard (no local `.git/`), causing
+ * the subsequent `git commit --allow-empty -m "initial commit"` to resolve
+ * upward and land an empty commit on the parent repo's main branch.
+ *
+ * The new guard runs `git rev-parse --is-inside-work-tree`, which follows
+ * the same upward traversal that git would do for the commit itself, so
+ * the two are guaranteed to agree.
+ *
+ * Acceptance:
+ *   A) autoInit in subdir of repo → no .git/ created, no new commit on parent
+ *   B) autoInit in clean dir (no parent repo) → git init runs, no seed commit
+ *   C) autoInit in own repo → no-op, HEAD untouched
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { autoInit } from "../../src/orchestrator/config-init.js";
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
+
+function gitLog(cwd) {
+  return execFileSync("git", ["log", "--oneline", "--all"], { cwd, encoding: "utf8" }).trim();
+}
+
+function gitInit(cwd) {
+  execFileSync("git", ["init", "--quiet"], { cwd, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd, stdio: "pipe" });
+}
+
+describe("autoInit — KJC-BUG-0060 guard against empty-commit zombies", () => {
+  let root;
+
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "kj-autoinit-")); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it("A) does NOT commit to parent repo when projectDir is a subdir without its own .git", () => {
+    gitInit(root);
+    writeFileSync(join(root, "seed.txt"), "seed");
+    execFileSync("git", ["add", "-A"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "seed", "--quiet"], { cwd: root, stdio: "pipe" });
+    const headBefore = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+
+    const sub = join(root, "subdir-without-git");
+    mkdirSync(sub);
+
+    return autoInit(sub, silentLogger).then(() => {
+      // No nested .git/ inside the subdir
+      expect(existsSync(join(sub, ".git"))).toBe(false);
+      // Parent HEAD unchanged — no zombie commit appended
+      const headAfter = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+      expect(headAfter).toBe(headBefore);
+      // And no "initial commit" anywhere in the parent log
+      expect(gitLog(root)).not.toMatch(/initial commit/);
+    });
+  });
+
+  it("B) runs git init in a clean dir (no parent repo) but does NOT create a seed commit", async () => {
+    const fresh = join(root, "fresh");
+    mkdirSync(fresh);
+    // Disable upward discovery so the test is independent of the runner's cwd.
+    process.env.GIT_CEILING_DIRECTORIES = root;
+    try {
+      await autoInit(fresh, silentLogger);
+      expect(existsSync(join(fresh, ".git"))).toBe(true);
+      // Repo exists but has no commits (no seed, no zombie)
+      let threw = false;
+      try {
+        execFileSync("git", ["rev-parse", "HEAD"], { cwd: fresh, stdio: "pipe" });
+      } catch { threw = true; }
+      expect(threw).toBe(true);
+    } finally {
+      delete process.env.GIT_CEILING_DIRECTORIES;
+    }
+  });
+
+  it("C) is a no-op when projectDir already has its own .git", async () => {
+    gitInit(root);
+    writeFileSync(join(root, "seed.txt"), "seed");
+    execFileSync("git", ["add", "-A"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "seed", "--quiet"], { cwd: root, stdio: "pipe" });
+    const headBefore = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+
+    await autoInit(root, silentLogger);
+
+    const headAfter = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
+    expect(headAfter).toBe(headBefore);
+    expect(gitLog(root)).not.toMatch(/initial commit/);
+  });
+});


### PR DESCRIPTION
Closes KJC-BUG-0060. Reported by mjfosela during the v2.19.3 release.

## Síntoma

Tras hacer `git checkout main` en el repo karajan-code, `git status` reporta `[adelante 27]` ante origin/main. Los 27 commits — titulados `initial commit`, autor `manufosela <manufosela@gmail.com>` (el git config local de karajan-code, no el global `mjfosela@gmail.com`), tree exactamente igual al padre = **commits completamente vacíos**.

El reflog acumulaba **2 495 SHAs distintos** con el mismo patrón desde abril 2026. Ninguno llegó nunca a `origin/main` (gh push / CI los habrían rechazado), y el usuario consume de main vía kj-linked, así que **impacto runtime = cero**. Pero ensucian main local y en cada release parecía pérdida de sync.

## Causa raíz

`src/orchestrator/config-init.js::autoInit()` usaba un guard demasiado débil:

```js
const gitDir = path.join(projectDir, '.git');
if (!(await exists(gitDir))) {
  execFileSync('git', ['init'], { cwd: projectDir });
  execFileSync('git', ['commit', '--allow-empty', '-m', 'initial commit'], { cwd: projectDir });
}
```

Dos modos de fallo combinados:

1. **Dogfooding kj sobre karajan-code** (kj-linked apunta al source tree). `kj run` invocado desde un subdir del repo → `initFlowContext` (drivers/init-context.js:42) pasaba ese subdir como `projectDir`. El subdir no tenía `.git/` propio — `exists()` devolvía `false` — pero el `git init` siguiente reinicializaba el `.git/` del padre (idempotente), y el `git commit --allow-empty` resolvía hacia arriba y aterrizaba un commit vacío en `main`.
2. **Race FS** transitoria (EACCES / ENOENT durante un scan concurrente de `.karajan/`) que hacía `exists()` devolver `false` por error y disparaba el mismo bug.

## Fix

Cambio el FS probe estático por la propia upward-traversal de git:

```js
try {
  execFileSync('git', ['rev-parse', '--is-inside-work-tree'], { cwd: projectDir, stdio: 'pipe' });
  // ya dentro de un work tree — propio o de un padre — bail out
} catch {
  execFileSync('git', ['init'], { cwd: projectDir, stdio: 'pipe' });
  // YA NO commit --allow-empty
}
```

Dos cambios:

1. **`rev-parse --is-inside-work-tree`** hace la misma búsqueda hacia arriba que git usaría para el commit; el guard no puede discrepar con la operación que custodia.
2. **Drop del seed commit vacío**. Ninguna stage downstream (diff, review, coder, sonar) necesita un root commit — los 2 495 commits que se acumularon nunca rompieron nada. El seed era decorativo y resultó ser el síntoma user-visible.

## Tests

`tests/orchestrator/config-init-autoinit.test.js` (3 acceptance tests):

- **A)** autoInit en subdir de un repo → sin `.git/` anidado, HEAD del padre inalterado, **sin `initial commit` en el log del padre**.
- **B)** autoInit en dir limpio (`GIT_CEILING_DIRECTORIES` bloquea upward discovery) → `git init` corre, `.git/` existe, **sin commits aún** (`rev-parse HEAD` debe fallar).
- **C)** autoInit en repo propio → no-op, HEAD intacto, sin `initial commit`.

Los 9 test files / 54 tests de `tests/orchestrator/` siguen verdes.

## LOC

+117 / -9, net +108. Dentro del budget 200 hard / 150 ideal.

## Próximo en v2.19.4

PR siguiente: **KJC-BUG-0058** — `kj resume` skip completed stages (~150-200 LOC). Después: release v2.19.4.