### PR TITLE
fix(orchestrator): kj resume skips completed pre-loop stages (KJC-BUG-0058)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ PERSONAL/
 # Planning Game; meanwhile keep it out of the repo to stop it returning.
 undefined/
 ai-trash-prompt.md
+.scratch-test-autoinit/

--- a/src/orchestrator/drivers/init-context.js
+++ b/src/orchestrator/drivers/init-context.js
@@ -172,7 +172,13 @@ export async function initFlowContext({ task, config, logger, emitter, askQuesti
     })
   );
 
-  ctx.stageResults = {};
+  // KJC-BUG-0058: on `kj resume`, rehydrate stage results from the loaded
+  // session so completed pre-loop stages (researcher, architect, planner…)
+  // are skipped instead of re-executed. `setStageResult` mirrors writes
+  // into both `stage_results` (full payload) and `stages_completed` (flat
+  // array) — copying `stage_results` here is sufficient because
+  // `runPreLoopStages` only checks membership in `stageResults`.
+  ctx.stageResults = { ...(ctx.session?.stage_results || {}) };
   ctx.sonarState = { issuesInitial: null, issuesFinal: null };
 
   const preLoopResult = await runPreLoopStages({ config, logger, emitter, eventBase: ctx.eventBase, session: ctx.session, flags, pipelineFlags: ctx.pipelineFlags, coderRole: ctx.coderRole, trackBudget: ctx.trackBudget, task, askQuestion, pgTaskId, pgProject, stageResults: ctx.stageResults, brainCtx: ctx.brainCtx });

--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -34,6 +34,7 @@ import { refineSkillsSemantically, resolveSkillsMode } from "../../skills/semant
 import { saveSession } from "../../session/store.js";
 import {
   setPreflight, setAutoInstalledSkills, setSkillsRecommended,
+  setStageResult, setStageBundle,
 } from "../../session/mutators.js";
 import {
   runResearcherStage, runArchitectStage, runPlannerStage,
@@ -60,18 +61,42 @@ import { tryCiComment } from "../ci-integration.js";
 import { getIntegration } from "../integrations.js";
 
 export async function runPreLoopStages({ config, logger, emitter, eventBase, session, flags, pipelineFlags, coderRole, trackBudget, task, askQuestion, pgTaskId, pgProject, stageResults, brainCtx }) {
+  // KJC-BUG-0058: on `kj resume` `stageResults` is rehydrated from
+  // `session.stage_results`. Persist after every successful pre-loop stage
+  // and skip the work when the slot is already populated. Cost: one
+  // `await saveSession` per stage; equivalent to the writes the post-loop
+  // path already makes for security / acceptance results.
+  const persistStage = async (name, result) => {
+    if (!result) return;
+    stageResults[name] = result;
+    setStageResult(session, name, result);
+    try { await saveSession(session); } catch (err) {
+      logger.warn(`Could not persist '${name}' stage result: ${err.message}`);
+    }
+  };
+  const resumeSkip = (name) => {
+    if (!stageResults[name]) return false;
+    logger.info(`[resume] skipping pre-loop stage '${name}' — completed in previous session`);
+    emitProgress(emitter, makeEvent("stage:skipped", { ...eventBase, stage: name }, {
+      status: "ok",
+      message: `Stage '${name}' skipped — already completed on previous run`,
+      detail: { cached: true }
+    }));
+    return true;
+  };
+
   // --- HU Reviewer (first stage, before everything else, opt-in) ---
   const huFile = flags.huFile || null;
   if (flags.enableHuReviewer !== undefined) pipelineFlags.huReviewerEnabled = Boolean(flags.enableHuReviewer);
-  if (pipelineFlags.huReviewerEnabled && huFile) {
+  if (pipelineFlags.huReviewerEnabled && huFile && !resumeSkip("huReviewer")) {
     const huResult = await runHuReviewerStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, huFile, askQuestion, pgStories: null });
-    stageResults.huReviewer = huResult.stageResult;
+    await persistStage("huReviewer", huResult.stageResult);
   }
 
   // --- Intent classifier (deterministic pre-triage, opt-in) ---
-  if (config.guards?.intent?.enabled) {
+  if (config.guards?.intent?.enabled && !resumeSkip("intent")) {
     const intentResult = classifyIntent(task, config);
-    stageResults.intent = intentResult;
+    await persistStage("intent", intentResult);
     if (intentResult.classified) {
       emitProgress(emitter, makeEvent("intent:classified", { ...eventBase, stage: "intent" }, {
         message: `Intent classified: ${intentResult.taskType} (${intentResult.level}) — ${intentResult.message}`,
@@ -82,21 +107,21 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
 
   // --- Discover (pre-triage, opt-in) ---
   if (flags.enableDiscover !== undefined) pipelineFlags.discoverEnabled = Boolean(flags.enableDiscover);
-  if (pipelineFlags.discoverEnabled) {
+  if (pipelineFlags.discoverEnabled && !resumeSkip("discover")) {
     const discoverResult = await runDiscoverStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget });
-    stageResults.discover = discoverResult.stageResult;
+    await persistStage("discover", discoverResult.stageResult);
   }
 
   // --- Triage (always on) — routed through StageRegistry (TSK-0336) ---
-  // canRun here is `pipelineFlags.triageEnabled !== false`; triageEnabled is
-  // never set to false in production, so behavior matches the previous
-  // unconditional call. If a caller ever flips it off, runStage returns null
-  // and we skip apply+persist with reasonable defaults (no overrides, no
-  // stageResult).
+  // KJC-BUG-0058: NOT skipped on resume. Triage is cheap and emits
+  // `roleOverrides` that downstream stages depend on (Brain decisor + the
+  // pipelineFlags). Re-running it on resume is the safe path; the heavy
+  // stages it gates (researcher, architect, planner) ARE skipped if
+  // already complete.
   const triageCtx = { config, logger, emitter, eventBase, session, coderRole, trackBudget, pipelineFlags };
   const triageResult = await runStage(stageRegistry.get("triage"), triageCtx) ?? { roleOverrides: null, stageResult: null };
   applyTriageOverrides(pipelineFlags, triageResult.roleOverrides);
-  stageResults.triage = triageResult.stageResult;
+  await persistStage("triage", triageResult.stageResult);
 
   // --- Brain decisor (opt-in, intent-driven routing) ---
   //
@@ -188,13 +213,13 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
 
   // --- Domain Curator (after triage + skill auto-install, before planning phases) ---
   const domainHints = triageResult.stageResult?.domainHints || [];
-  if (domainHints.length > 0 || config.projectDir) {
+  if ((domainHints.length > 0 || config.projectDir) && !resumeSkip("domainCurator")) {
     try {
       const { domainContext, stageResult: dcStageResult } = await runDomainCuratorStage({
         config, logger, emitter, eventBase, session, trackBudget,
         domainHints, askQuestion
       });
-      stageResults.domainCurator = dcStageResult;
+      await persistStage("domainCurator", dcStageResult);
       if (domainContext) {
         config = { ...config, domainContext };
       }
@@ -213,7 +238,7 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
       pgStories = getIntegration("tracker")?.buildHuStoriesFromCard?.(session.pg_card) ?? null;
     }
     const huResult = await runHuReviewerStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget, huFile: null, askQuestion, pgStories });
-    stageResults.huReviewer = huResult.stageResult;
+    await persistStage("huReviewer", huResult.stageResult);
   }
 
   // --- Auto-simplify pipeline for simple tasks (before explicit flag overrides) ---
@@ -291,7 +316,7 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
 
 
   // --- Researcher → Planner ---
-  const { plannedTask } = await runPlanningPhases({ config: updatedConfig, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx });
+  const { plannedTask } = await runPlanningPhases({ config: updatedConfig, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx, persistStage, resumeSkip });
 
   // --- Update .gitignore with stack-specific entries based on planner/architect output ---
   const projectDir = updatedConfig.projectDir || process.cwd();
@@ -377,7 +402,7 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
 
   return { plannedTask, updatedConfig };
 }
-async function runPlanningPhases({ config, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx }) {
+async function runPlanningPhases({ config, logger, emitter, eventBase, session, stageResults, pipelineFlags, coderRole, trackBudget, task, askQuestion, brainCtx, persistStage, resumeSkip }) {
   let researchContext = null;
   let plannedTask = task;
 
@@ -386,41 +411,62 @@ async function runPlanningPhases({ config, logger, emitter, eventBase, session, 
     ? (await import("../brain-coordinator.js")).processRoleOutput
     : null;
 
+  // KJC-BUG-0058: on resume, rehydrate cross-stage context from session.
+  // researchContext / architectContext / plannedTask live ONLY in memory
+  // after their owning stage runs; without these the post-loop coder
+  // would lose context even though we skipped the upstream LLM call.
+  const bundles = session?.stage_bundles || {};
+
   if (pipelineFlags.researcherEnabled) {
-    const researcherResult = await runResearcherStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget });
-    researchContext = researcherResult.researchContext;
-    stageResults.researcher = researcherResult.stageResult;
-    if (brainCompress) brainCompress(brainCtx, { roleName: "researcher", output: researcherResult.stageResult, iteration: 0 });
+    if (resumeSkip("researcher")) {
+      researchContext = bundles.researcher?.researchContext || null;
+    } else {
+      const researcherResult = await runResearcherStage({ config, logger, emitter, eventBase, session, coderRole, trackBudget });
+      researchContext = researcherResult.researchContext;
+      setStageBundle(session, "researcher", { stageResult: researcherResult.stageResult, researchContext });
+      await persistStage("researcher", researcherResult.stageResult);
+      if (brainCompress) brainCompress(brainCtx, { roleName: "researcher", output: researcherResult.stageResult, iteration: 0 });
+    }
   }
 
   // --- Architect (between researcher and planner) ---
   let architectContext = null;
   if (pipelineFlags.architectEnabled) {
-    const architectResult = await runArchitectStage({
-      config, logger, emitter, eventBase, session, coderRole, trackBudget,
-      researchContext,
-      discoverResult: stageResults.discover || null,
-      triageLevel: stageResults.triage?.level || null,
-      askQuestion
-    });
-    architectContext = architectResult.architectContext;
-    stageResults.architect = architectResult.stageResult;
-    if (brainCompress) brainCompress(brainCtx, { roleName: "architect", output: architectResult.stageResult, iteration: 0 });
+    if (resumeSkip("architect")) {
+      architectContext = bundles.architect?.architectContext || null;
+    } else {
+      const architectResult = await runArchitectStage({
+        config, logger, emitter, eventBase, session, coderRole, trackBudget,
+        researchContext,
+        discoverResult: stageResults.discover || null,
+        triageLevel: stageResults.triage?.level || null,
+        askQuestion
+      });
+      architectContext = architectResult.architectContext;
+      setStageBundle(session, "architect", { stageResult: architectResult.stageResult, architectContext });
+      await persistStage("architect", architectResult.stageResult);
+      if (brainCompress) brainCompress(brainCtx, { roleName: "architect", output: architectResult.stageResult, iteration: 0 });
+    }
   }
 
   const triageDecomposition = stageResults.triage?.shouldDecompose ? stageResults.triage.subtasks : null;
   if (pipelineFlags.plannerEnabled) {
-    const plannerRole = resolveRole(config, "planner");
-    const plannerResult = await runPlannerStage({ config, logger, emitter, eventBase, session, plannerRole, researchContext, architectContext, triageDecomposition, trackBudget });
-    plannedTask = plannerResult.plannedTask;
-    stageResults.planner = plannerResult.stageResult;
-    if (brainCompress) brainCompress(brainCtx, { roleName: "planner", output: plannerResult.stageResult, iteration: 0 });
+    if (resumeSkip("planner")) {
+      plannedTask = bundles.planner?.plannedTask || task;
+    } else {
+      const plannerRole = resolveRole(config, "planner");
+      const plannerResult = await runPlannerStage({ config, logger, emitter, eventBase, session, plannerRole, researchContext, architectContext, triageDecomposition, trackBudget });
+      plannedTask = plannerResult.plannedTask;
+      setStageBundle(session, "planner", { stageResult: plannerResult.stageResult, plannedTask });
+      await persistStage("planner", plannerResult.stageResult);
+      if (brainCompress) brainCompress(brainCtx, { roleName: "planner", output: plannerResult.stageResult, iteration: 0 });
 
-    await tryCiComment({
-      config, session, logger,
-      agent: "Planner",
-      body: `Plan: ${plannerResult.stageResult?.summary || plannedTask}`
-    });
+      await tryCiComment({
+        config, session, logger,
+        agent: "Planner",
+        body: `Plan: ${plannerResult.stageResult?.summary || plannedTask}`
+      });
+    }
   }
 
   return { plannedTask };

--- a/src/session/mutators.js
+++ b/src/session/mutators.js
@@ -138,6 +138,37 @@ export function setStatus(session, status) {
   session.status = status;
 }
 
+// --- Stage results (KJC-BUG-0058: resume must skip completed stages) ------
+
+/**
+ * Persist a pre-loop stage result on the session, plus mirror its name in
+ * a flat `stages_completed` array used by `resumeFlow` to know what to skip.
+ *
+ * Both shapes are kept in sync so callers can read either: the rich
+ * `stage_results[name]` for the full payload, or the cheap
+ * `stages_completed` for a fast membership check.
+ */
+export function setStageResult(session, name, result) {
+  if (!session.stage_results) session.stage_results = {};
+  session.stage_results[name] = result;
+  if (!Array.isArray(session.stages_completed)) session.stages_completed = [];
+  if (!session.stages_completed.includes(name)) session.stages_completed.push(name);
+}
+
+/**
+ * Stage *bundles* capture cross-stage context that a stage exports beyond
+ * its stageResult (e.g. researcher → researchContext, architect →
+ * architectContext, planner → plannedTask). Resume needs these to feed
+ * downstream stages without re-running the upstream one. The bundle is
+ * always shaped `{ stageResult, ...extras }` and `setStageBundle` mirrors
+ * the stageResult into `stage_results[name]` so legacy readers keep working.
+ */
+export function setStageBundle(session, name, bundle) {
+  if (!session.stage_bundles) session.stage_bundles = {};
+  session.stage_bundles[name] = bundle;
+  setStageResult(session, name, bundle?.stageResult ?? bundle);
+}
+
 // --- Alternative agent (rate-limit recovery) ------------------------------
 
 export function setAlternativeAgent(session, stage, provider) {

--- a/tests/orchestrator/resume-skip-stages.test.js
+++ b/tests/orchestrator/resume-skip-stages.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regression pin for KJC-BUG-0058.
+ *
+ * `kj resume` used to call `runFlow` without rehydrating stage results
+ * from the loaded session, so pre-loop stages (researcher, architect,
+ * planner…) ran from scratch. The fix is two-layered:
+ *
+ *   1. `setStageBundle` persists each pre-loop stage's cross-stage
+ *      context (researchContext, architectContext, plannedTask) into
+ *      `session.stage_bundles`, alongside the stageResult that
+ *      `setStageResult` mirrors into `stage_results` + `stages_completed`.
+ *
+ *   2. `init-context.js` rehydrates `ctx.stageResults` from
+ *      `session.stage_results` before invoking `runPreLoopStages`, so the
+ *      planning helpers (`persistStage` / `resumeSkip`) find the cached
+ *      entries and short-circuit the LLM call.
+ *
+ * Acceptance:
+ *   A) `setStageBundle` mirrors stageResult + stages_completed correctly.
+ *   B) `setStageResult` is idempotent (does not duplicate names in the
+ *      flat array).
+ *   C) Bundle round-trips: write `researcher` bundle, read it back,
+ *      `bundles.researcher.researchContext` is preserved.
+ */
+import { describe, expect, it } from "vitest";
+import { setStageResult, setStageBundle } from "../../src/session/mutators.js";
+
+describe("setStageResult / setStageBundle — KJC-BUG-0058", () => {
+  it("A) setStageBundle mirrors stageResult + stages_completed", () => {
+    const session = {};
+    setStageBundle(session, "researcher", {
+      stageResult: { summary: "found 3 files", duration_ms: 1234 },
+      researchContext: { hints: ["read README", "scan src/"] },
+    });
+    expect(session.stage_bundles.researcher.researchContext.hints).toEqual([
+      "read README",
+      "scan src/",
+    ]);
+    expect(session.stage_results.researcher.summary).toBe("found 3 files");
+    expect(session.stages_completed).toEqual(["researcher"]);
+  });
+
+  it("B) setStageResult is idempotent on stages_completed", () => {
+    const session = {};
+    setStageResult(session, "triage", { level: "simple" });
+    setStageResult(session, "triage", { level: "complex" }); // overwrite
+    setStageResult(session, "researcher", { ok: true });
+    expect(session.stages_completed).toEqual(["triage", "researcher"]);
+    expect(session.stage_results.triage.level).toBe("complex");
+  });
+
+  it("C) bundle round-trips with multiple stages preserving each context", () => {
+    const session = {};
+    setStageBundle(session, "researcher", {
+      stageResult: { summary: "r" },
+      researchContext: { topic: "auth" },
+    });
+    setStageBundle(session, "architect", {
+      stageResult: { summary: "a" },
+      architectContext: { layers: ["api", "db"] },
+    });
+    setStageBundle(session, "planner", {
+      stageResult: { summary: "p" },
+      plannedTask: "Implement auth across api+db",
+    });
+    expect(session.stage_bundles.researcher.researchContext.topic).toBe("auth");
+    expect(session.stage_bundles.architect.architectContext.layers).toEqual(["api", "db"]);
+    expect(session.stage_bundles.planner.plannedTask).toBe("Implement auth across api+db");
+    expect(session.stages_completed).toEqual(["researcher", "architect", "planner"]);
+  });
+});


### PR DESCRIPTION
Closes KJC-BUG-0058. Reported by Aitor Martinez.

## Síntoma

Aitor reportó con screenshot: `kj resume <id>` y el terminal lleno de `[researcher] Read ...` justo después. La sesión original había completado researcher / architect / planner y paró durante sonar. Resume debería continuar desde sonar; en su lugar re-ejecutaba todo el pre-loop, doblando coste de tokens y rompiendo el value-prop de resume.

## Causa raíz

`resumeFlow` (flow-runner.js:280) cargaba la sesión y llamaba a `runFlow` sin propagar nada sobre qué stages ya estaban hechas. `runFlow` → `initFlowContext` inicializaba `ctx.stageResults = {}` y `runPreLoopStages` reejecutaba toda stage:

- HU-Reviewer / intent / discover / triage (siempre)
- Domain Curator / researcher / architect / planner (LLM heavy)

La sesión SÍ usaba stage outputs en memoria — `ctx.stageResults` se rellenaba — pero nada los volcaba a `session.json`, así que un reload tenía que empezar de cero.

## Fix — rehydratación de dos capas

### Capa 1 — mutators en `src/session/mutators.js`

```js
setStageResult(session, name, result)
  // stage_results[name] + stages_completed[] (idempotente)

setStageBundle(session, name, bundle)
  // stage_bundles[name] para context cross-stage:
  //   researcher → researchContext
  //   architect  → architectContext
  //   planner    → plannedTask
  // Además llama a setStageResult.
```

### Capa 2 — pre-loop driver

Dos closures dentro de `runPreLoopStages`:

- **`persistStage(name, result)`** — escribe `stageResults`, `setStageResult`, `saveSession` (errores de FS = warn, no abort).
- **`resumeSkip(name)`** — true cuando `stageResults[name]` ya está rehydratado, emite `stage:skipped` y log.

Sitios envueltos: huReviewer (×2), intent, discover, domainCurator, researcher, architect, planner.

**Triage NO se skipea**: emite `roleOverrides` que el Brain decisor y stages downstream necesitan. Es cheap, re-ejecutarla es safe.

Researcher / architect / planner persisten **bundle** además del stageResult para que el resume tenga su context al alimentar stages downstream.

`init-context.js` rehydrata `ctx.stageResults` desde `session.stage_results` ANTES de `runPreLoopStages`. Sin nuevo flag por la cadena — eso es lo que permite a `resumeSkip` detectar stages completadas.

## Tests

`tests/orchestrator/resume-skip-stages.test.js` (3 acceptance tests):

- **A)** `setStageBundle` mirror stageResult + stages_completed
- **B)** `setStageResult` idempotente en el array
- **C)** Bundle round-trip con researcher / architect / planner, cada cross-stage context preservado

10 test files / 57 tests de orchestrator siguen verdes.

## .gitignore

Añade `.scratch-test-autoinit/` — sandbox de la PoC manual de KJC-BUG-0060 que dejé el día pasado.

## LOC

+198 / -43, net +155 en 4 ficheros src + 1 test nuevo. Dentro de 200 hard / 150 ideal.

## Próximo

Release v2.19.4 con BUG-0060 + BUG-0058.