### PR TITLE
feat(init): wizard scope (global vs local) + validation (KJC-TSK-0395)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -23,6 +23,8 @@ export function registerPipeline(program, { pkgVersion }) {
     .description("Initialize config, review rules and SonarQube")
     .option("--no-interactive", "Skip wizard, use defaults (for CI/scripts)")
     .option("--scaffold-ci", "Scaffold Karajan CI Gateway workflow files")
+    .option("--global", "Save config to ~/.karajan/kj.config.yml (skip the scope wizard)")
+    .option("--local", "Save config to ./.karajan/kj.config.yml (skip the scope wizard)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { getConfigPath, loadConfig, writeConfig } from "../config.js";
+import { getConfigPath, getProjectConfigPath, loadConfig, writeConfig } from "../config.js";
 import { sonarUp, checkVmMaxMapCount } from "../sonar/manager.js";
 import { exists, ensureDir } from "../utils/fs.js";
 import { getKarajanHome } from "../utils/paths.js";
@@ -579,19 +579,50 @@ async function ensureGitignoreEntries(projectDir, logger) {
   logger.info(`Added to .gitignore: ${missing.map(e => e.pattern).join(", ")}`);
 }
 
+/**
+ * KJC-TSK-0395: decide where the config is written based on the flags
+ * and (when interactive) a wizard prompt. Returns { configPath, scope }.
+ * Throws when both --global and --local are passed (mutually exclusive).
+ */
+export async function resolveConfigScope({ flags, interactive }) {
+  if (flags?.global && flags?.local) {
+    throw new Error("Cannot pass both --global and --local — pick one scope for the config.");
+  }
+  if (flags?.global) return { configPath: getConfigPath(), scope: "global" };
+  if (flags?.local) return { configPath: getProjectConfigPath(process.cwd()), scope: "local" };
+  if (interactive) {
+    const wizard = createWizard();
+    try {
+      const choice = await wizard.select(
+        "Where do you want to save the config? (default: global)",
+        [
+          { value: "global", label: `Global (${getConfigPath()} — applies to all projects)` },
+          { value: "local",  label: `Local  (${getProjectConfigPath(process.cwd())} — overrides global for this project only)` },
+        ]
+      );
+      return { configPath: choice === "local" ? getProjectConfigPath(process.cwd()) : getConfigPath(), scope: choice };
+    } finally {
+      wizard.close();
+    }
+  }
+  // Non-interactive + no flags → legacy behaviour: global. Keeps CI scripts working.
+  return { configPath: getConfigPath(), scope: "global" };
+}
+
 export async function initCommand({ logger, flags = {} }) {
   const karajanHome = getKarajanHome();
   await ensureDir(karajanHome);
   logger.info(`Ensured ${karajanHome} exists`);
 
-  const configPath = getConfigPath();
+  const interactive = flags.noInteractive !== true && isTTY();
+  const { configPath, scope } = await resolveConfigScope({ flags, interactive });
+  logger.info(`Config scope: ${scope} → ${configPath}`);
   const karajanDir = path.join(process.cwd(), ".karajan");
   await ensureDir(karajanDir);
   const reviewRulesPath = path.resolve(karajanDir, "review-rules.md");
   const coderRulesPath = path.resolve(karajanDir, "coder-rules.md");
 
   const { config, exists: configExists } = await loadConfig();
-  const interactive = flags.noInteractive !== true && isTTY();
 
   // Auto-detect language from OS locale for non-interactive mode
   if (!interactive && !configExists) {

--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -114,6 +114,18 @@ export async function loadConfig(projectDir) {
   // Load project config (.karajan/kj.config.yml)
   const projectConfig = await loadProjectConfig(projectDir);
 
+  // KJC-TSK-0395: enforce the local-overrides-global hierarchy. A project
+  // config with no global counterpart is almost always user error (copied
+  // a .karajan dir from another repo, edited the wrong file, etc.) and
+  // would silently behave like a global config without the defaults
+  // people expect. Refuse with an actionable message.
+  if (projectConfig && !globalExists) {
+    throw new Error(
+      `Local config found at ${getProjectConfigPath(projectDir)} but no global config exists.\n` +
+      "Local configs are merged ON TOP of the global one — run `kj init --global` first to create the base."
+    );
+  }
+
   // Merge: DEFAULTS < global < project
   let merged = mergeDeep(DEFAULTS, globalConfig);
   if (projectConfig) {

--- a/tests/commands/init-scope.test.js
+++ b/tests/commands/init-scope.test.js
@@ -1,0 +1,68 @@
+/**
+ * KJC-TSK-0395 — `kj init` config scope (global vs local) + hierarchy
+ * validation in loadConfig.
+ *
+ * Acceptance pins:
+ *   A) `--global` → returns the global path, no wizard.
+ *   B) `--local`  → returns the project-local path, no wizard.
+ *   C) `--global --local` → throws (mutually exclusive).
+ *   D) Non-interactive + no flags → global (legacy default).
+ *   E) loadConfig throws when a local config exists without a global one
+ *      (the override-only-on-top-of-base invariant).
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveConfigScope } from "../../src/commands/init.js";
+import { loadConfig, getConfigPath, getProjectConfigPath } from "../../src/config.js";
+
+describe("kj init — resolveConfigScope — KJC-TSK-0395", () => {
+  it("A) --global returns the global path with scope 'global'", async () => {
+    const r = await resolveConfigScope({ flags: { global: true }, interactive: false });
+    expect(r.scope).toBe("global");
+    expect(r.configPath).toBe(getConfigPath());
+  });
+
+  it("B) --local returns the project-local path with scope 'local'", async () => {
+    const r = await resolveConfigScope({ flags: { local: true }, interactive: false });
+    expect(r.scope).toBe("local");
+    expect(r.configPath).toBe(getProjectConfigPath(process.cwd()));
+  });
+
+  it("C) --global + --local together throws a clear error", async () => {
+    await expect(resolveConfigScope({ flags: { global: true, local: true }, interactive: false }))
+      .rejects.toThrow(/both --global and --local/);
+  });
+
+  it("D) non-interactive + no flags defaults to global (legacy)", async () => {
+    const r = await resolveConfigScope({ flags: {}, interactive: false });
+    expect(r.scope).toBe("global");
+  });
+});
+
+describe("loadConfig — local-sin-global rejection — KJC-TSK-0395", () => {
+  let projectDir;
+  let prevHome;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "kj-scope-"));
+    // Redirect KARAJAN_HOME to an empty temp dir so getConfigPath()
+    // points to a location with NO global config.
+    prevHome = process.env.KARAJAN_HOME;
+    process.env.KARAJAN_HOME = mkdtempSync(join(tmpdir(), "kj-home-"));
+  });
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+    if (process.env.KARAJAN_HOME) rmSync(process.env.KARAJAN_HOME, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME;
+    else process.env.KARAJAN_HOME = prevHome;
+  });
+
+  it("E) throws when local config exists without a global counterpart", async () => {
+    mkdirSync(join(projectDir, ".karajan"));
+    writeFileSync(join(projectDir, ".karajan", "kj.config.yml"), "roles:\n  coder:\n    provider: opencode\n");
+    await expect(loadConfig(projectDir)).rejects.toThrow(/Local config found.*no global config/);
+  });
+});

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("../src/config.js", () => ({
   getConfigPath: vi.fn().mockReturnValue("/fake/.karajan/kj.config.yml"),
+  getProjectConfigPath: vi.fn().mockReturnValue("/fake/project/.karajan/kj.config.yml"),
   loadConfig: vi.fn(),
   writeConfig: vi.fn()
 }));
@@ -136,6 +137,7 @@ describe("initCommand", () => {
       ask: vi.fn().mockResolvedValue(""),  // branch_prefix only asked if auto_commit
       confirm: vi.fn().mockResolvedValue(false),
       select: vi.fn()
+        .mockResolvedValueOnce("global")       // KJC-TSK-0395: config scope
         .mockResolvedValueOnce("codex")        // coder
         .mockResolvedValueOnce("claude")       // reviewer
         // KJC-TSK-0367: 10 per-role selects (planner, researcher,
@@ -162,8 +164,8 @@ describe("initCommand", () => {
     await initCommand({ logger, flags: {} });
 
     expect(detectAvailableAgents).toHaveBeenCalled();
-    // 2 (agents) + 10 (per-role) + 3 (methodology/pipelineLang/huLang) = 15
-    expect(mockWizard.select).toHaveBeenCalledTimes(15);
+    // 1 (KJC-TSK-0395 scope) + 2 (agents) + 10 (per-role) + 3 (methodology/pipelineLang/huLang) = 16
+    expect(mockWizard.select).toHaveBeenCalledTimes(16);
     expect(writeConfig).toHaveBeenCalled();
     const writtenConfig = writeConfig.mock.calls[0][1];
     expect(writtenConfig.coder).toBe("codex");


### PR DESCRIPTION
Closes KJC-TSK-0395. Last card of v2.20.0.

## What

`kj init` grows two flags: `--global` and `--local`. In an interactive TTY without flags, the wizard asks where the config should land. Non-interactive + no flags = global (legacy, doesn't break CI).

| Scenario | Result |
|---|---|
| `kj init --global` | Writes to `~/.karajan/kj.config.yml` |
| `kj init --local` | Writes to `./.karajan/kj.config.yml` |
| `kj init --global --local` | Throws (mutually exclusive) |
| `kj init` (interactive) | Wizard asks |
| `kj init --no-interactive` | Global (legacy) |

## Validation in loadConfig

If a project has a local config (`./.karajan/kj.config.yml`) but no global one, `loadConfig` now throws with a clear message:

```
Local config found at <path> but no global config exists.
Local configs are merged ON TOP of the global one — run `kj init --global` first to create the base.
```

This catches the common user mistake of copying a `.karajan` dir from another repo without a global baseline.

## Tests

`tests/commands/init-scope.test.js` (5 acceptance tests):

- A) `--global` → global path
- B) `--local` → project-local path
- C) `--global --local` → throws
- D) Non-interactive + no flags → global (legacy)
- E) loadConfig with local + no global → throws

41/41 tests under `tests/config/` + `tests/commands/init.test.js` still passing.

## LOC

+116 / -3, net **113**. Inside 200 hard / 150 ideal.

## v2.20.0 status

**5/5 cards.** After this PR: release v2.20.0 with TSK-0385, TSK-0397, TSK-0396, TSK-0377, TSK-0395.