### PR TITLE
chore: release v2.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.20.0] - 2026-05-24
+
+Minor release. **HU Board polish + UX papercuts** cluster: 5 cards closed (2 net-new features, 2 housekeeping PG syncs for work that had already landed quietly, 1 doc refresh).
+
+### Added
+
+- **`kj plan generate` now prepends a `[PREFLIGHT-000]` HU to every plan** and gates all functional HUs on it via `blocked_by` (KJC-TSK-0397, PR #801). The HU's acceptance tests are stack-aware shell commands — `git status --porcelain`, `node --version` + `npm install` + conditional `npm test`/`npm run lint` for Node, `python --version` + `pip install -r requirements.txt` (or `poetry install`) + `pytest --collect-only` for Python, plus `firebase projects:list` when `firebase.json` exists and `gcloud auth list` when `.gcloudignore` exists. Idempotent: a plan that already has a HU titled `PREFLIGHT-000` / "verificar entorno" is left untouched. Opt out per-invocation with `--no-preflight-hu`. New module `src/plan/preflight-hu.js` (102 LOC) + 6 acceptance tests.
+- **`kj init` learns a config scope wizard plus `--global` / `--local` flags** (KJC-TSK-0395, PR #802). In an interactive TTY without flags, the wizard now asks whether the config should land at `~/.karajan/kj.config.yml` (global, applies to all projects) or `./.karajan/kj.config.yml` (local override, project-scoped). `--global` and `--local` skip the prompt for CI scripts; passing both throws `Cannot pass both --global and --local`. Non-interactive without flags stays on global for legacy CI compatibility. `loadConfig` (src/config/loader.js) now refuses to load a project that has a local config without a global counterpart — the override-only-on-top-of-base invariant — with an actionable message pointing at `kj init --global` to create the base. New exported function `resolveConfigScope({ flags, interactive })` for unit testing without spinning up the rest of `initCommand`.
+
+### Synced to PG
+
+These were already implemented in main but their cards were stuck in "To Do" until today's PG housekeeping pass:
+
+- **HU Board `⏹ Stop` button** (KJC-TSK-0396, originally PRs #702 + #703): aborts every `kj run` associated with a plan via SIGTERM → SIGKILL escalation (5 s timeout), resets running HUs to pending, available only when at least one HU is in `coding`/`reviewing`. Frontend delegate handler + backend `POST /api/runs/:planId/stop` + persistent run-tracker registry for terminal↔board bidirectionality.
+- **HU Board auto-cleanup ampliado** (KJC-TSK-0377, originally PR #683): the ephemeral-project sweep now also catches `s_*`, `plan-*`, `auto-tmp_*`, `auto-test_*` prefixes alongside the original `tmp_*` / `test_*` / `demo_*` / `kj-test-*` set. Projects with `is_test=2` (📌 keep) stay exempt. Home-style `home_<path>` projects with real git repos are never swept.
+
+### Docs
+
+- `docs/task-templates/spec-conventions.md` adds two sections (KJC-TSK-0385, PR #800): **Section 8** documents that numbered headings (`## 1.`, `### 2.1`, `§5`) activate the `spec_section` REQUIRED field on every step. **Section 9** documents the `acceptance_tests` shape: 2-4 tests per step, mix of `gherkin` and `shell`, pre-implementation, never the placeholder `npx vitest run`. The top quick-reference table + the pre-generate checklist were updated to reference both. Plus `docs/task-templates/plan-generate.md` switches its two stale `~/.kj/plans/` example paths to `~/.karajan/plans/` (post-v2.19.0 home consolidation).
+
 ## [2.19.4] - 2026-05-24
 
 Patch release. `kj resume` continúa donde paró y `autoInit` ya no produce commits zombie en el repo del usuario.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,18 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.20.0 released** — Minor. **HU Board polish + UX papercuts** cluster: 5 cards closed across two net-new features, two PG housekeeping syncs for work that had already landed, and one docs refresh.
+>
+> KJC-TSK-0397 (PR #801): **`kj plan generate` now prepends a `[PREFLIGHT-000]` HU to every plan** and gates every functional HU on it. The HU's acceptance tests are stack-aware shell commands — Node gets `node --version` + `npm install` + conditional `npm test` / `npm run lint`; Python gets `python --version` + `pip install -r requirements.txt` (or `poetry install`) + `pytest --collect-only`; Firebase projects get `firebase projects:list`; GCP projects get `gcloud auth list`; everyone gets `git status --porcelain`. Idempotent: a plan that already has a HU titled `PREFLIGHT-000` / "verificar entorno" is left untouched. Opt out per-invocation with `--no-preflight-hu`. The point: Karajan owns the plumbing, the user no longer has to remember to add a 'verify env' step to every task file.
+>
+> KJC-TSK-0395 (PR #802): **`kj init` learns a config scope wizard plus `--global` / `--local` flags**. The wizard now asks where the config should land — `~/.karajan/kj.config.yml` (global) or `./.karajan/kj.config.yml` (local override). `loadConfig` refuses to load a project that has a local config without a global counterpart with an actionable message — the override-on-top-of-base invariant. Use case: a repo with `coder=claude`, another with `coder=opencode`, without editing YAML by hand.
+>
+> KJC-TSK-0396 (PG sync, originally PRs #702 + #703): **HU Board `⏹ Stop` button** aborts every `kj run` associated with a plan via SIGTERM → SIGKILL escalation, resets running HUs to pending. Already shipped in v2.10.x; today's release closes the PG card with the canonical commits as evidence.
+>
+> KJC-TSK-0377 (PG sync, originally PR #683): **auto-cleanup ampliado** to also catch `s_*`, `plan-*`, `auto-tmp_*`, `auto-test_*` prefixes during the boot ephemeral-project sweep. Already shipped in v2.12.x.
+>
+> KJC-TSK-0385 (PR #800): **`docs/task-templates/spec-conventions.md` gains Section 8 (`spec_section` REQUIRED when numbered SPEC headings present) and Section 9 (`acceptance_tests` shape, 2-4 tests, gherkin + shell mix)**. Plus `plan-generate.md` switches two stale `~/.kj/plans/` paths to `~/.karajan/plans/`.
+>
 > **v2.19.4 released** — Patch. **`kj resume` now continues from where it stopped** + **autoInit no longer commits zombies on the user's main**. Two bugs closed in one release.
 >
 > KJC-BUG-0058 (PR #798, reported by [@aitormf](https://github.com/aitormf)): a session that stopped during Sonar would re-run the full pre-loop on `kj resume <id>` — HU-reviewer, intent, discover, triage, domainCurator, **researcher, architect, planner** all from scratch — doubling token cost and breaking the value-prop of the command. Root cause: `resumeFlow` (flow-runner.js:280) called `runFlow` without rehydrating stage state, and the session never persisted stage outputs in the first place. **Fix**: two new mutators in `src/session/mutators.js` (`setStageResult` mirrors into `stage_results[name]` + `stages_completed[]`; `setStageBundle` adds `stage_bundles[name]` for cross-stage context like `researchContext`, `architectContext`, `plannedTask`). Two closures inside `runPreLoopStages` (`persistStage` + `resumeSkip`) wrap every cacheable stage. `init-context.js` rehydrates `ctx.stageResults` from the loaded session before invoking the pre-loop. Triage is *not* skipped on resume — it produces `roleOverrides` the Brain decisor depends on and is cheap to re-run.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (52k LOC, 373 files)
+├── src/              # Source code (52k LOC, 374 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.19.4
+kj --version    # 2.20.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.19.4
+kj --version    # 2.20.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.19.4",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.19.4",
+      "version": "2.20.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.19.4",
+  "version": "2.20.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Minor release. **HU Board polish + UX papercuts** cluster — 5 cards closed.

## Cards in v2.20.0

| Card | PR | Notes |
|---|---|---|
| KJC-TSK-0397 | #801 | [PREFLIGHT-000] HU auto-inject + stack-aware tests + --no-preflight-hu |
| KJC-TSK-0395 | #802 | kj init scope wizard + --global/--local + loadConfig validation |
| KJC-TSK-0396 | #702 + #703 (synced) | HU Board ⏹ Stop button (shipped v2.10.x, PG sync) |
| KJC-TSK-0377 | #683 (synced) | auto-cleanup ampliado (shipped v2.12.x, PG sync) |
| KJC-TSK-0385 | #800 | docs spec-conventions.md Sections 8+9 + plan-generate.md path fix |

## Tests

5363+ tests / 453+ test files passing on Node 20 + Node 22 CI.

## Files bumped

| File | Change |
|---|---|
| package.json | 2.19.4 → 2.20.0 |
| package-lock.json | regenerated |
| CHANGELOG.md | new [2.20.0] entry |
| README.md | 'Recent releases' banner appended |
| docs/GETTING-STARTED.md + es/ | kj --version  # 2.20.0 |
| docs/ARCHITECTURE.md | regen-arch-stats.sh refresh |

## Post-merge

- Tag v2.20.0 + GitHub Release
- npm publish (OTP needed)
- Landing deploy