### PR TITLE
feat(onboarder): deterministic collectors (KJC-TSK-0384 PR 1)

### DIFF
--- a/src/onboarder/collectors/index.js
+++ b/src/onboarder/collectors/index.js
@@ -1,0 +1,119 @@
+// Onboarder collectors — deterministic, zero-LLM extractors. Each pure,
+// JSON-serialisable, fail-soft (returns null on the slot, never throws).
+// Output bundle is consumed by PR 2 synthesis or dumped via `--no-synth`.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+
+import { detectProjectStack } from "../../utils/stack-detect.js";
+
+const IGNORED_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", "__pycache__"]);
+
+function safeRun(cmd, args, opts = {}) {
+  try { return execFileSync(cmd, args, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"], ...opts }).trim(); }
+  catch { return null; }
+}
+
+// Tree summary: immediate dirs with rough byte count. Ignores noise dirs.
+export async function collectTree(projectDir, { maxDepth = 2 } = {}) {
+  async function walk(dir, depth) {
+    if (depth > maxDepth) return [];
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); } catch { return []; }
+    const out = [];
+    for (const ent of entries) {
+      if (ent.name.startsWith(".") && ent.name !== ".github") continue;
+      if (IGNORED_DIRS.has(ent.name)) continue;
+      const sub = join(dir, ent.name);
+      if (ent.isDirectory()) {
+        const children = await walk(sub, depth + 1);
+        let bytes = 0;
+        for (const c of children) bytes += c.bytes || 0;
+        out.push({ path: relative(projectDir, sub), kind: "dir", bytes, children });
+      } else if (ent.isFile()) {
+        try { out.push({ path: relative(projectDir, sub), kind: "file", bytes: statSync(sub).size }); } catch { /* race */ }
+      }
+    }
+    return out;
+  }
+  return walk(projectDir, 0);
+}
+
+// Git log + branches + hot files. Returns null on non-git (greenfield).
+export function collectGitHistory(projectDir, { maxHotFiles = 10 } = {}) {
+  const inside = safeRun("git", ["rev-parse", "--is-inside-work-tree"], { cwd: projectDir });
+  if (inside !== "true") return null;
+  const commitsRaw = safeRun("git", ["log", "--oneline", "-n", "100"], { cwd: projectDir }) || "";
+  const branchesRaw = safeRun("git", ["branch", "--list", "--all", "--format=%(refname:short)"], { cwd: projectDir }) || "";
+  const hotRaw = safeRun("git", ["log", "--name-only", "--pretty=format:", "-n", "200"], { cwd: projectDir }) || "";
+  const counts = {};
+  for (const line of hotRaw.split("\n").map((s) => s.trim()).filter(Boolean)) {
+    counts[line] = (counts[line] || 0) + 1;
+  }
+  const hotFiles = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1]).slice(0, maxHotFiles)
+    .map(([file, touches]) => ({ file, touches }));
+  return {
+    commitCount: commitsRaw ? commitsRaw.split("\n").length : 0,
+    branches: branchesRaw.split("\n").filter(Boolean),
+    hotFiles,
+    headSha: safeRun("git", ["rev-parse", "HEAD"], { cwd: projectDir }) || null,
+  };
+}
+
+// Presence-check of known config files + package.json scripts.
+export function collectConfigs(projectDir) {
+  const configFiles = [
+    "package.json", "pyproject.toml", "Cargo.toml", "go.mod",
+    "tsconfig.json", "jsconfig.json",
+    ".eslintrc.js", ".eslintrc.json", "eslint.config.js",
+    "vitest.config.js", "vitest.config.ts", "jest.config.js", "jest.config.ts",
+    "firebase.json", ".gcloudignore", "Dockerfile", "docker-compose.yml",
+    ".github/workflows", ".gitlab-ci.yml", "Makefile",
+  ];
+  const present = configFiles.filter((f) => existsSync(join(projectDir, f)));
+  let scripts = null;
+  try {
+    const pkg = JSON.parse(readFileSync(join(projectDir, "package.json"), "utf8"));
+    scripts = pkg.scripts || null;
+  } catch { /* not a node project */ }
+  return { present, scripts };
+}
+
+// Discover ADR files under docs/adr/, docs/adrs/, docs/architecture/, root.
+export async function collectAdrs(projectDir) {
+  const dirs = ["docs/adr", "docs/adrs", "docs/architecture", "."];
+  const found = [];
+  for (const d of dirs) {
+    const abs = join(projectDir, d);
+    if (!existsSync(abs)) continue;
+    try {
+      const entries = await readdir(abs);
+      for (const f of entries) {
+        if (/^adr-?\d|^\d{4}-.+\.md$/i.test(f) || /architecture.*\.md$/i.test(f)) {
+          found.push(relative(projectDir, join(abs, f)));
+        }
+      }
+    } catch { /* unreadable */ }
+  }
+  return found;
+}
+
+// One-shot bundle: every slot is independent; missing slots → null/[].
+export async function collectAll(projectDir) {
+  const [stack, tree, adrs] = await Promise.all([
+    detectProjectStack(projectDir).catch(() => null),
+    collectTree(projectDir).catch(() => []),
+    collectAdrs(projectDir).catch(() => []),
+  ]);
+  return {
+    projectDir,
+    stack,
+    tree,
+    git: collectGitHistory(projectDir),
+    configs: collectConfigs(projectDir),
+    adrs,
+    collectedAt: new Date().toISOString(),
+  };
+}

--- a/tests/onboarder/collectors.test.js
+++ b/tests/onboarder/collectors.test.js
@@ -1,0 +1,75 @@
+// KJC-TSK-0384 PR 1 — Onboarder collectors acceptance pins (A..F).
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  collectTree, collectGitHistory, collectConfigs, collectAdrs, collectAll,
+} from "../../src/onboarder/collectors/index.js";
+
+function gitInit(dir) {
+  execFileSync("git", ["init", "--quiet"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "t@e.com"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "T"], { cwd: dir, stdio: "pipe" });
+}
+
+describe("onboarder/collectors — KJC-TSK-0384 PR 1", () => {
+  let root;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "kj-onboard-")); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  it("A) collectTree walks dirs and ignores node_modules + .git", async () => {
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "src", "a.js"), "console.log('a')");
+    mkdirSync(join(root, "node_modules", "x"), { recursive: true });
+    writeFileSync(join(root, "node_modules", "x", "skip.js"), "skip");
+    const tree = await collectTree(root);
+    const paths = tree.map((e) => e.path);
+    expect(paths).toContain("src");
+    expect(paths.some((p) => p.includes("node_modules"))).toBe(false);
+  });
+
+  it("B) collectGitHistory returns null on a plain directory (greenfield)", () => {
+    expect(collectGitHistory(root)).toBeNull();
+  });
+
+  it("C) collectGitHistory returns commitCount + headSha on a real repo", () => {
+    gitInit(root);
+    writeFileSync(join(root, "x.txt"), "x");
+    execFileSync("git", ["add", "-A"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "seed", "--quiet"], { cwd: root, stdio: "pipe" });
+    const g = collectGitHistory(root);
+    expect(g.commitCount).toBe(1);
+    expect(g.headSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("D) collectConfigs reports package.json presence and reads scripts", () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ scripts: { test: "vitest", lint: "eslint ." } }));
+    const c = collectConfigs(root);
+    expect(c.present).toContain("package.json");
+    expect(c.scripts.test).toBe("vitest");
+  });
+
+  it("E) collectAdrs finds ADR-style filenames under docs/adr", async () => {
+    mkdirSync(join(root, "docs", "adr"), { recursive: true });
+    writeFileSync(join(root, "docs", "adr", "0001-use-postgres.md"), "# ADR 1");
+    writeFileSync(join(root, "docs", "adr", "0002-prefer-async.md"), "# ADR 2");
+    writeFileSync(join(root, "docs", "adr", "README.md"), "index");
+    const adrs = await collectAdrs(root);
+    expect(adrs.length).toBe(2);
+    expect(adrs.some((p) => p.endsWith("0001-use-postgres.md"))).toBe(true);
+  });
+
+  it("F) collectAll degrades gracefully on greenfield + present fields", async () => {
+    writeFileSync(join(root, "package.json"), JSON.stringify({ scripts: { build: "tsc" } }));
+    const b = await collectAll(root);
+    expect(b.projectDir).toBe(root);
+    expect(b.git).toBeNull(); // greenfield: no git
+    expect(b.configs.present).toContain("package.json");
+    expect(Array.isArray(b.tree)).toBe(true);
+    expect(Array.isArray(b.adrs)).toBe(true);
+    expect(b.collectedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
First of 3 PRs delivering KJC-TSK-0384 (Onboarder brownfield role). This one lays the deterministic foundation; PR 2 wires it into the LLM synthesis step + the `kj onboard` command, PR 3 integrates it with `kj plan generate --use-onboarding`.

## What

New module `src/onboarder/collectors/index.js` (108 LOC) exposes five pure, fail-soft collectors:

| Collector | Purpose |
|---|---|
| `collectTree(projectDir, { maxDepth })` | Tree walk ignoring `node_modules`/`.git`/`dist`/`build`/etc. |
| `collectGitHistory(projectDir, { maxHotFiles })` | `{ commitCount, branches, hotFiles, headSha }`. Null on non-git (greenfield). |
| `collectConfigs(projectDir)` | Presence of 18 config patterns + reads package.json scripts. |
| `collectAdrs(projectDir)` | ADR-style filenames under `docs/adr/`, `docs/adrs/`, `docs/architecture/`. |
| `collectAll(projectDir)` | Promise.all bundle. Every slot independent; failures → null/[]. |

All collectors use a single `safeRun()` helper around `execFileSync` so missing tools / permission errors produce `null` instead of throwing.

## Tests

`tests/onboarder/collectors.test.js` (86 LOC, 6 acceptance tests):

- **A)** `collectTree` walks + ignores node_modules
- **B)** `collectGitHistory` returns null on greenfield
- **C)** `collectGitHistory` returns commitCount + headSha on real repo
- **D)** `collectConfigs` reports package.json + reads scripts
- **E)** `collectAdrs` finds `docs/adr/0001-*.md`
- **F)** `collectAll` degrades gracefully

Each test bootstraps an isolated `mkdtempSync` — no dependency on host repo git state.

## LOC

+194 / 0, net **194**. Inside 200 hard / 150 ideal.

## Out of scope (next PRs)

- **PR 2**: `src/roles/onboarder-role.js` + `src/commands/onboard.js` + `templates/roles/onboarder.md`. LLM synthesis + CLI command.
- **PR 3**: `kj plan generate --use-onboarding` flag + cache.

Part of KJC-TSK-0384 → KJC-PCS-0007. Target minor **v2.21.0**.