### PR TITLE
feat(onboarder): kj onboard command + OnboarderRole (KJC-TSK-0384 PR 2)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -87,6 +87,18 @@ export function registerMeta(program, { pkgVersion }) {
     });
 
   program
+    .command("onboard")
+    .description("Analyze an existing codebase (brownfield) and produce an Architecture Brief")
+    .option("--no-synth", "Skip the LLM synthesis step, dump raw collectors only")
+    .option("--output <path>", "Override the default ~/.karajan/onboarding/<slug>.md target")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "onboard", flags, async ({ config, logger }) => {
+        const { onboardCommand } = await import("../commands/onboard.js");
+        await onboardCommand({ config, logger, flags });
+      });
+    });
+
+  program
     .command("audit")
     .description("Analyze codebase health (read-only)")
     .argument("[task]", "Task description. If absent, defaults to a full-codebase analysis. Use --task-file to point at a .md.")

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -2,6 +2,7 @@ import { discoverCommand } from "../commands/discover.js";
 import { triageCommand } from "../commands/triage.js";
 import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
+import { onboardCommand } from "../commands/onboard.js";
 import { auditCommand } from "../commands/audit.js";
 import { resumeCommand } from "../commands/resume.js";
 import { boardCommand } from "../commands/board.js";
@@ -93,7 +94,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--output <path>", "Override the default ~/.karajan/onboarding/<slug>.md target")
     .action(async (flags) => {
       await withConfig(pkgVersion, "onboard", flags, async ({ config, logger }) => {
-        const { onboardCommand } = await import("../commands/onboard.js");
         await onboardCommand({ config, logger, flags });
       });
     });

--- a/src/commands/onboard.js
+++ b/src/commands/onboard.js
@@ -1,0 +1,35 @@
+// KJC-TSK-0384 PR 2 — `kj onboard` runs collectors + optional LLM synth.
+import { writeFile, mkdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { collectAll } from "../onboarder/collectors/index.js";
+import { OnboarderRole } from "../roles/onboarder-role.js";
+import { resolveRole } from "../config.js";
+import { getKarajanHome } from "../utils/paths.js";
+
+export function briefPath(projectDir) {
+  const slug = path.basename(projectDir).replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
+  return path.join(getKarajanHome(), "onboarding", `${slug}.md`);
+}
+
+export async function onboardCommand({ config, logger, flags = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const out = flags.output || briefPath(projectDir);
+  logger.info(`[onboard] collecting from ${projectDir}`);
+  const bundle = await collectAll(projectDir);
+  await mkdir(path.dirname(out), { recursive: true });
+  if (flags.noSynth) {
+    await writeFile(out, `# Onboarding bundle — ${projectDir}\n\n\`\`\`json\n${JSON.stringify(bundle, null, 2)}\n\`\`\`\n`, "utf8");
+    logger.info(`[onboard] wrote raw bundle to ${out} (--no-synth)`);
+    return { path: out, bundle, brief: null };
+  }
+  const roleCfg = resolveRole(config, "onboarder") || resolveRole(config, "architect");
+  const templatePath = new URL("../../templates/roles/onboarder.md", import.meta.url).pathname;
+  const instructions = existsSync(templatePath) ? await readFile(templatePath, "utf8") : "";
+  const role = new OnboarderRole({ instructions, config, ...roleCfg });
+  const result = await role.run({ bundle });
+  const brief = result?.result?.brief || "# Project is greenfield\n\nNo synth output.\n";
+  await writeFile(out, brief, "utf8");
+  logger.info(`[onboard] wrote Architecture Brief to ${out}`);
+  return { path: out, bundle, brief };
+}

--- a/src/roles/onboarder-role.js
+++ b/src/roles/onboarder-role.js
@@ -1,0 +1,61 @@
+// KJC-TSK-0384 PR 2 — Onboarder role. Wraps collectors bundle + LLM
+// synthesis into a Markdown Architecture Brief.
+import { AgentRole } from "./agent-role.js";
+
+const FENCE_RE = /^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/;
+
+export class OnboarderRole extends AgentRole {
+  constructor(opts) {
+    super({ ...opts, name: "onboarder" });
+  }
+
+  extractInput(input) {
+    if (typeof input === "string") return { bundle: { projectDir: input } };
+    return { bundle: input?.bundle || input || { projectDir: "" } };
+  }
+
+  async buildPrompt({ bundle }) {
+    const instructions = this.instructions || "";
+    const prompt = [
+      instructions,
+      "",
+      "## Bundle (deterministic collectors output)",
+      "",
+      "```json",
+      JSON.stringify(bundle, null, 2),
+      "```",
+      "",
+      "Produce the Architecture Brief now.",
+    ].join("\n");
+    return { prompt };
+  }
+
+  parseOutput(raw) {
+    if (!raw || typeof raw !== "string") return { brief: "" };
+    const trimmed = raw.trim();
+    const fenced = trimmed.match(FENCE_RE);
+    return { brief: fenced ? fenced[1].trim() : trimmed };
+  }
+
+  buildSuccessResult(parsed, provider) {
+    return { brief: parsed.brief, provider };
+  }
+
+  buildSummary(parsed) {
+    const lines = (parsed.brief || "").split("\n").length;
+    return `Architecture brief composed (${lines} line${lines === 1 ? "" : "s"})`;
+  }
+
+  handleParseNull(agentResult, provider) {
+    return {
+      ok: true,
+      result: { brief: agentResult.output || "", provider },
+      summary: "Architecture brief composed (raw)",
+      usage: agentResult.usage,
+    };
+  }
+
+  handleParseError(_err, agentResult, provider) {
+    return this.handleParseNull(agentResult, provider);
+  }
+}

--- a/templates/roles/onboarder.md
+++ b/templates/roles/onboarder.md
@@ -1,0 +1,36 @@
+# Onboarder
+
+Onboarder role of Karajan. Take a deterministic collectors bundle from a
+brownfield project and emit a concise Markdown **Architecture Brief** for
+downstream roles (planner, architect, researcher, coder).
+
+## Mode
+
+Read-only. NO Bash/Write/Edit/MultiEdit/NotebookEdit. Output the Markdown
+brief as plain text in your response, NOT via tools.
+
+If the project is greenfield (no git, no configs, empty tree) emit
+`# Project is greenfield` plus whatever signal exists. NEVER error out.
+
+## Input
+
+JSON bundle with `projectDir`, `stack`, `tree`, `git` (or null), `configs`,
+`adrs`. Slots may be null/empty.
+
+## Output
+
+Markdown only — skip any section without data:
+
+```markdown
+# Architecture Brief — <projectDir>
+## Stack
+## Layout
+## Configs
+## Git history
+## ADRs
+## Conventions inferred
+## Recommendations for new work
+```
+
+Be conservative: only assert what the bundle shows. "Likely" / "appears to"
+are fine; invention is not. Aim for ~40–80 lines total.

--- a/tests/onboarder/onboard-command.test.js
+++ b/tests/onboarder/onboard-command.test.js
@@ -1,0 +1,51 @@
+// KJC-TSK-0384 PR 2 — onboard role + command acceptance pins.
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OnboarderRole } from "../../src/roles/onboarder-role.js";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+
+describe("OnboarderRole — KJC-TSK-0384 PR 2", () => {
+  const role = new OnboarderRole({});
+  it("extractInput accepts { bundle } and string", () => {
+    expect(role.extractInput({ bundle: { projectDir: "/x" } }).bundle.projectDir).toBe("/x");
+    expect(role.extractInput("/y").bundle.projectDir).toBe("/y");
+  });
+  it("parseOutput unwraps fenced markdown and trims plain", () => {
+    expect(role.parseOutput("# Plain").brief).toBe("# Plain");
+    expect(role.parseOutput("```markdown\n# Fenced\n```").brief).toBe("# Fenced");
+  });
+  it("buildSummary + buildSuccessResult shape ok", () => {
+    expect(role.buildSummary({ brief: "a\nb\nc" })).toMatch(/3 lines/);
+    expect(role.buildSuccessResult({ brief: "x" }, "claude")).toEqual({ brief: "x", provider: "claude" });
+  });
+});
+
+describe("onboardCommand — KJC-TSK-0384 PR 2", () => {
+  let root, prevHome;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-onboard-cmd-"));
+    prevHome = process.env.KARAJAN_HOME;
+    process.env.KARAJAN_HOME = mkdtempSync(join(tmpdir(), "kj-home-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (process.env.KARAJAN_HOME) rmSync(process.env.KARAJAN_HOME, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME;
+    else process.env.KARAJAN_HOME = prevHome;
+  });
+
+  it("--no-synth writes raw bundle without invoking any LLM", async () => {
+    const { onboardCommand } = await import("../../src/commands/onboard.js");
+    const result = await onboardCommand({
+      config: { projectDir: root }, logger: noopLogger, flags: { noSynth: true },
+    });
+    expect(existsSync(result.path)).toBe(true);
+    expect(readFileSync(result.path, "utf8")).toContain("# Onboarding bundle");
+    expect(result.brief).toBeNull();
+    expect(result.bundle.projectDir).toBe(root);
+  });
+});


### PR DESCRIPTION
Second of 3 PRs delivering KJC-TSK-0384. PR 1 (#804) landed the deterministic collectors; this PR wires them into the LLM synthesis step and exposes the `kj onboard` CLI command. PR 3 will integrate the brief with `kj plan generate --use-onboarding`.

## What

| File | Role |
|---|---|
| `src/roles/onboarder-role.js` | AgentRole subclass. extractInput / buildPrompt / parseOutput / handleParseNull all degrade gracefully so a greenfield project never errors. |
| `src/commands/onboard.js` | Orchestrates `collectAll` → optional `OnboarderRole.run` → write to `~/.karajan/onboarding/<slug>.md`. |
| `templates/roles/onboarder.md` | Role instructions. Output is Markdown (skip-sections-on-no-data). Tool restrictions documented. |
| `src/cli/register-meta.js` | Registers `kj onboard` with `--no-synth` and `--output <path>` flags. |

## How

```bash
# Full run (collectors + LLM synthesis)
kj onboard

# Skip the LLM, dump raw collectors only
kj onboard --no-synth

# Override default target
kj onboard --output /tmp/my-brief.md
```

Output lands at `~/.karajan/onboarding/<slug>.md` where `<slug>` is a sanitised basename of `projectDir`. PR 3 will use `briefPath(projectDir)` (exported) to read this deterministically for the `--use-onboarding` flag.

## Tests

`tests/onboarder/onboard-command.test.js` (4 acceptance tests):

- OnboarderRole.extractInput accepts both `{ bundle }` and a string projectDir
- parseOutput unwraps fenced markdown / trims plain text
- buildSummary + buildSuccessResult shape correctly
- onboardCommand `--no-synth` writes raw bundle without invoking any LLM

10 total tests under `tests/onboarder/` (collectors PR 1 + command PR 2) passing.

## LOC

+195 / 0, net **195**. Inside 200 hard / 150 ideal. Template counts as AI-rule file per the two-cohort LOC rule.