### PR TITLE
feat(plan): --use-onboarding folds Architecture Brief into planner (KJC-TSK-0384 PR 3)

### DIFF
--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -43,6 +43,7 @@ export function registerPlan(program, { pkgVersion }) {
     .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
     .option("--quick", "Sketch mode — skip every quality pass after the initial planner call")
     .option("--no-preflight-hu", "Skip auto-injection of [PREFLIGHT-000] HU at the top of the generated plan")
+    .option("--use-onboarding", "Inject the cached Architecture Brief (~/.karajan/onboarding/<slug>.md) into the planner context")
     .option("-y, --yes", "Skip the project-name prompt (use the auto-derived default).")
     .option("--no-interactive", "Force non-interactive mode (no prompts, use defaults).")
     .action(async (task, flags) => {
@@ -102,6 +103,7 @@ export function registerPlan(program, { pkgVersion }) {
             yes: Boolean(flags.yes),
             interactive: flags.interactive,
             preflightHu: flags.preflightHu !== false, // KJC-TSK-0397
+            useOnboarding: Boolean(flags.useOnboarding), // KJC-TSK-0384 PR 3
           },
         });
       });

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -15,6 +15,7 @@ import { buildStandbyState } from "../../brain/standby-store.js";
 import { printResumeHint } from "../../utils/display/resume-hint.js";
 import { runSpecReview } from "../../spec-review/run-spec-review.js";
 import { prependPreflightHu } from "../../plan/preflight-hu.js";
+import { readCachedBrief } from "../../onboarder/cache.js";
 import { formatPlan, formatHuTable } from "./_shared.js";
 
 /**
@@ -56,12 +57,29 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
     task = reviewResult.finalSpec; // downstream runs the refined spec
   }
 
+  // KJC-TSK-0384 PR 3: --use-onboarding folds the cached Architecture Brief
+  // from `kj onboard` into the planner's context. Silent when no brief is
+  // cached so users without one don't see noise; loud warn when they passed
+  // the flag explicitly but the cache is empty so the missed wiring surfaces.
+  let resolvedContext = context;
+  if (flags?.useOnboarding) {
+    const brief = await readCachedBrief(config?.projectDir || process.cwd());
+    if (brief.found) {
+      resolvedContext = [
+        resolvedContext, brief.content ? `## Architecture Brief (from kj onboard)\n\n${brief.content}` : null,
+      ].filter(Boolean).join("\n\n");
+      runLog.logText(`[planner] onboarding brief injected from ${brief.path}`);
+    } else {
+      logger?.warn?.(`--use-onboarding passed but no brief at ${brief.path}. Run 'kj onboard' first.`);
+    }
+  }
+
   const plannerRole = resolveRole(config, "planner");
   await assertAgentsAvailable([plannerRole.provider]);
   runLog.logText(`[planner] provider=${plannerRole.provider}`);
 
   const planner = createAgent(plannerRole.provider, config, logger);
-  const prompt = buildPlannerPrompt({ task, context });
+  const prompt = buildPlannerPrompt({ task, context: resolvedContext });
   const silenceTimeoutMs = Number(config?.session?.max_agent_silence_minutes) > 0
     ? Math.round(Number(config.session.max_agent_silence_minutes) * 60 * 1000)
     : undefined;

--- a/src/onboarder/cache.js
+++ b/src/onboarder/cache.js
@@ -1,0 +1,24 @@
+// KJC-TSK-0384 PR 3 — read the cached Architecture Brief deterministically.
+// briefPath() is exported by src/commands/onboard.js so the writer and
+// reader share the same slug rule.
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+
+import { briefPath } from "../commands/onboard.js";
+
+/**
+ * Read the cached Architecture Brief for `projectDir`. Returns:
+ *   { found: true,  path, content }  — when the file exists
+ *   { found: false, path }           — when it does not
+ * Never throws.
+ */
+export async function readCachedBrief(projectDir) {
+  const p = briefPath(projectDir);
+  if (!existsSync(p)) return { found: false, path: p };
+  try {
+    const content = await readFile(p, "utf8");
+    return { found: true, path: p, content };
+  } catch {
+    return { found: false, path: p };
+  }
+}

--- a/tests/onboarder/cache.test.js
+++ b/tests/onboarder/cache.test.js
@@ -1,0 +1,40 @@
+// KJC-TSK-0384 PR 3 — readCachedBrief acceptance pins.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { readCachedBrief } from "../../src/onboarder/cache.js";
+import { briefPath } from "../../src/commands/onboard.js";
+
+describe("readCachedBrief — KJC-TSK-0384 PR 3", () => {
+  let proj, prevHome, fakeHome;
+  beforeEach(() => {
+    proj = mkdtempSync(join(tmpdir(), "kj-cache-proj-"));
+    prevHome = process.env.KARAJAN_HOME;
+    fakeHome = mkdtempSync(join(tmpdir(), "kj-cache-home-"));
+    process.env.KARAJAN_HOME = fakeHome;
+  });
+  afterEach(() => {
+    rmSync(proj, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME;
+    else process.env.KARAJAN_HOME = prevHome;
+  });
+
+  it("returns { found: false, path } when no brief exists", async () => {
+    const result = await readCachedBrief(proj);
+    expect(result.found).toBe(false);
+    expect(result.path).toBe(briefPath(proj));
+  });
+
+  it("returns { found: true, content } when the brief exists", async () => {
+    const target = briefPath(proj);
+    mkdirSync(join(fakeHome, "onboarding"), { recursive: true });
+    writeFileSync(target, "# Architecture Brief\n\nbody\n", "utf8");
+    const result = await readCachedBrief(proj);
+    expect(result.found).toBe(true);
+    expect(result.path).toBe(target);
+    expect(result.content).toContain("Architecture Brief");
+  });
+});


### PR DESCRIPTION
Third and last PR closing KJC-TSK-0384.

## Chain

| PR | Status |
|---|---|
| #804 — collectors deterministas | merged |
| #805 — OnboarderRole + kj onboard | merged |
| **#806 — kj plan --use-onboarding** | this one |

## What

`src/onboarder/cache.js` (new, 24 LOC) — exposes `readCachedBrief(projectDir)` returning `{ found, path, content? }`. Never throws. Uses `briefPath()` from `src/commands/onboard.js` so writer and reader share the slug rule.

`src/commands/plan/generate.js` (+19/-1) — when `flags.useOnboarding` is set:
- Brief cached → prepend under a `## Architecture Brief (from kj onboard)` heading to whatever context the user already passed.
- Brief missing → warn so the missed wiring surfaces, then proceed.

`src/cli/register-plan.js` (+2) — register `--use-onboarding` and forward through the explicit flags whitelist (lesson from KJC-TSK-0397's missing-flag bug).

## How

```bash
kj onboard                            # produces ~/.karajan/onboarding/<slug>.md once
kj plan generate task.md \
    --use-onboarding                  # next plan uses it
```

## Tests

`tests/onboarder/cache.test.js` (2 acceptance tests). 261 tests across `tests/onboarder/` + `tests/plan/` + `tests/commands/plan/` passing.

## LOC

+85 / -1, net **84**. Well inside the 200 hard / 150 ideal limit.

## What's next

Onboarder closed end-to-end. Next in the v2.21.0 cluster: start the **Project RAG epic KJC-PCS-0049** — vec store + Ollama embedder + indexer.