### PR TITLE
chore: release v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.21.0] - 2026-05-24
+
+Minor release. **Brownfield Onboarder role**: Karajan now ships a dedicated path to bootstrap an Architecture Brief from any existing codebase, and the planner can consume that brief as automatic context. Closes KJC-TSK-0384 in three PRs.
+
+### Added
+
+- **New `kj onboard` command + OnboarderRole** (KJC-TSK-0384, PRs #804 + #805). Runs five deterministic collectors over a project root — `collectTree` (directory walk ignoring `node_modules` / `.git` / `dist` / `build` / etc.), `collectGitHistory` (commits, branches, hot files via `--name-only` over the last 200 commits), `collectConfigs` (presence of 18 well-known config patterns + package.json scripts), `collectAdrs` (ADR-style filenames under `docs/adr/`, `docs/adrs/`, `docs/architecture/`), and `collectAll` as the one-shot bundle — and then optionally synthesises a Markdown Architecture Brief via the OnboarderRole. Output lands at `~/.karajan/onboarding/<slug>.md`. Flags: `--no-synth` (skip the LLM call and dump the raw collectors bundle, useful for CI / token-cost-sensitive contexts) and `--output <path>` (override default target). Greenfield projects produce `# Project is greenfield` instead of erroring. The collectors are stack-aware via `detectProjectStack`; adding a stack to the brief is one branch in `composePreflightTests`-style code.
+- **New `--use-onboarding` flag on `kj plan generate`** (PR #806). When set, reads the cached Architecture Brief via `readCachedBrief(projectDir)` and prepends it to the planner's context under a `## Architecture Brief (from kj onboard)` heading. Silent on cache miss without the flag; loud `warn` when the flag is set but no cache exists, so a missed `kj onboard` invocation surfaces immediately. The brief flows into the planner alongside any explicit `--context` the user passes; both compose.
+
+### Workflow
+
+```bash
+kj onboard                            # produces ~/.karajan/onboarding/<slug>.md
+kj plan generate task.md \
+    --use-onboarding                  # next plan reads the brief as context
+```
+
+### Out of scope
+
+- The Project RAG epic (KJC-PCS-0049) starts in v2.22.0 — vector store, Ollama embedder, indexer, retriever, CLI / MCP / HU Board consumers. Onboarder is the prerequisite (its `onboarding_context.json` feeds the indexer), so closing it cleanly here unblocks the next minor.
+
+### Tests
+
+5 387+ tests / 458+ test files passing on Node 20 and Node 22 CI.
+
 ## [2.20.0] - 2026-05-24
 
 Minor release. **HU Board polish + UX papercuts** cluster: 5 cards closed (2 net-new features, 2 housekeeping PG syncs for work that had already landed quietly, 1 doc refresh).

--- a/README.md
+++ b/README.md
@@ -345,6 +345,22 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.21.0 released** — Minor. **Brownfield Onboarder role**. Karajan now ships a dedicated path to analyze any existing codebase and produce a Markdown Architecture Brief that the planner can consume as automatic context. Closes KJC-TSK-0384 (3 PRs).
+>
+> KJC-TSK-0384 (PRs #804 + #805 + #806): **`kj onboard`** runs five deterministic collectors over a project root — directory walk (ignoring `node_modules` / `.git` / `dist` / `build`), git log (commits, branches, hot files via `--name-only` over the last 200 commits), 18 well-known config patterns + `package.json` scripts, ADR-style filenames under `docs/adr/`, `docs/adrs/`, `docs/architecture/`, plus a one-shot bundle. Then optionally synthesises a Markdown Architecture Brief via the new OnboarderRole. Output lands at `~/.karajan/onboarding/<slug>.md`. Flags: `--no-synth` (skip the LLM call, dump the raw collectors — useful for CI), `--output <path>` (override default target). Greenfield projects produce `# Project is greenfield` instead of erroring.
+>
+> **New `--use-onboarding` flag on `kj plan generate`**: reads the cached Architecture Brief and prepends it to the planner context under a `## Architecture Brief (from kj onboard)` heading. Silent on cache miss without the flag; loud `warn` when the flag is set but no cache exists, so a missed `kj onboard` invocation surfaces immediately.
+>
+> Workflow:
+>
+> ```bash
+> kj onboard                            # produces ~/.karajan/onboarding/<slug>.md once
+> kj plan generate task.md \
+>     --use-onboarding                  # next plan uses it as context
+> ```
+>
+> **What's next** — The **Project RAG** epic (KJC-PCS-0049) starts in v2.22.0: vector store + Ollama embedder + indexer + retriever + CLI / MCP / HU Board consumers. Onboarder is its prerequisite (the brief feeds the indexer's first pass).
+>
 > **v2.20.0 released** — Minor. **HU Board polish + UX papercuts** cluster: 5 cards closed across two net-new features, two PG housekeeping syncs for work that had already landed, and one docs refresh.
 >
 > KJC-TSK-0397 (PR #801): **`kj plan generate` now prepends a `[PREFLIGHT-000]` HU to every plan** and gates every functional HU on it. The HU's acceptance tests are stack-aware shell commands — Node gets `node --version` + `npm install` + conditional `npm test` / `npm run lint`; Python gets `python --version` + `pip install -r requirements.txt` (or `poetry install`) + `pytest --collect-only`; Firebase projects get `firebase projects:list`; GCP projects get `gcloud auth list`; everyone gets `git status --porcelain`. Idempotent: a plan that already has a HU titled `PREFLIGHT-000` / "verificar entorno" is left untouched. Opt out per-invocation with `--no-preflight-hu`. The point: Karajan owns the plumbing, the user no longer has to remember to add a 'verify env' step to every task file.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (52k LOC, 374 files)
+├── src/              # Source code (52k LOC, 378 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.20.0
+kj --version    # 2.21.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.20.0
+kj --version    # 2.21.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.20.0",
+      "version": "2.21.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.20.0",
+  "version": "2.21.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Minor release. **Brownfield Onboarder role** closes KJC-TSK-0384 in three PRs.

## Cards in v2.21.0

| Card | PR(s) | Notes |
|---|---|---|
| KJC-TSK-0384 | #804 + #805 + #806 | Onboarder role end-to-end: collectors + kj onboard command + kj plan generate --use-onboarding |

## Tests

5 387+ tests / 458+ test files passing on Node 20 + Node 22 CI.

## Files bumped

| File | Change |
|---|---|
| package.json | 2.20.0 → 2.21.0 |
| package-lock.json | regenerated |
| CHANGELOG.md | new [2.21.0] entry |
| README.md | 'Recent releases' banner appended |
| docs/GETTING-STARTED.md + es/ | kj --version  # 2.21.0 |
| docs/ARCHITECTURE.md | regen-arch-stats.sh refresh |

## Post-merge

- Tag v2.21.0 + GitHub Release
- npm publish (OTP needed)
- Landing deploy

## What's next

Project RAG epic (KJC-PCS-0049) starts in v2.22.0.