### PR TITLE
feat(rag): vector store on better-sqlite3 + sqlite-vec (KJC-TSK-0423 / RAG Step 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "js-yaml": "^4.1.0",
         "knip": "^6.14.1",
         "madge": "^8.0.0",
+        "sqlite-vec": "^0.1.9",
         "valibot": "^1.3.1"
       },
       "bin": {
@@ -6330,6 +6331,84 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sqlite-vec": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+      "integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+      "license": "MIT OR Apache",
+      "optionalDependencies": {
+        "sqlite-vec-darwin-arm64": "0.1.9",
+        "sqlite-vec-darwin-x64": "0.1.9",
+        "sqlite-vec-linux-arm64": "0.1.9",
+        "sqlite-vec-linux-x64": "0.1.9",
+        "sqlite-vec-windows-x64": "0.1.9"
+      }
+    },
+    "node_modules/sqlite-vec-darwin-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+      "integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-darwin-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+      "integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-arm64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+      "integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-linux-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+      "integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sqlite-vec-windows-x64": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+      "integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "js-yaml": "^4.1.0",
     "knip": "^6.14.1",
     "madge": "^8.0.0",
+    "sqlite-vec": "^0.1.9",
     "valibot": "^1.3.1"
   },
   "devDependencies": {

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -1,0 +1,113 @@
+// KJC-PCS-0049 Step 1 — Vector store sobre better-sqlite3 + sqlite-vec.
+// El RAG indexer (Step 4) escribe; el retriever (Step 5) lee. Una sola
+// DB en `~/.karajan/rag.db` por instalación.
+import { mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+
+import { getKarajanHome } from "../utils/paths.js";
+
+const DEFAULT_DIM = 768;
+
+export function dbPath() {
+  return process.env.KJ_RAG_DB || join(getKarajanHome(), "rag.db");
+}
+
+/**
+ * Open the rag.db, load the sqlite-vec extension, and ensure the
+ * chunks + vec_chunks tables exist. Idempotent: a second call against
+ * the same file is a no-op past the schema creation.
+ *
+ * Returns the open Database handle. Caller owns close().
+ *
+ * @param {Object} [opts]
+ * @param {number} [opts.dim=768] — embedding dimension. Must match
+ *   the embedder configured for the project (Step 2). Changing it
+ *   later requires a fresh DB; the constant is captured in the
+ *   virtual table DDL.
+ */
+export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
+  if (!existsSync(dirname(path))) mkdirSync(dirname(path), { recursive: true });
+  const db = new Database(path);
+  sqliteVec.load(db);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding')),
+      text TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS chunks_by_source ON chunks(source);
+    CREATE INDEX IF NOT EXISTS chunks_by_kind ON chunks(kind);
+  `);
+  db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[${dim}]);`);
+  return db;
+}
+
+/**
+ * Persist one chunk. The chunks.id and vec_chunks.rowid stay in sync
+ * because the virtual table rowid is set explicitly to the freshly
+ * minted chunks.id. Returns that id.
+ */
+export function insertChunk(db, { source, kind, text, metadata = null, embedding }) {
+  if (!Array.isArray(embedding) && !ArrayBuffer.isView(embedding)) {
+    throw new Error("insertChunk: embedding must be an array or typed array of floats");
+  }
+  const meta = metadata == null ? null : (typeof metadata === "string" ? metadata : JSON.stringify(metadata));
+  const ins = db.prepare("INSERT INTO chunks (source, kind, text, metadata) VALUES (?, ?, ?, ?)");
+  const info = ins.run(source, kind, text, meta);
+  // sqlite-vec's vec0 virtual table requires the rowid to arrive as a BigInt
+  // even for values that comfortably fit in a Number. Better-sqlite3 returns
+  // lastInsertRowid as BigInt only when safeIntegers mode is on; force it.
+  const id = typeof info.lastInsertRowid === "bigint" ? info.lastInsertRowid : BigInt(info.lastInsertRowid);
+  const buf = embedding instanceof Float32Array ? embedding : Float32Array.from(embedding);
+  db.prepare("INSERT INTO vec_chunks(rowid, embedding) VALUES (?, ?)").run(id, Buffer.from(buf.buffer));
+  return Number(id);
+}
+
+/**
+ * Cosine-ordered nearest-neighbour search. Returns `[{ id, source, kind,
+ * text, metadata, distance }]` for the topK best matches; lower
+ * distance = closer. Returns `[]` when the store is empty.
+ */
+export function searchSimilar(db, embedding, topK = 5, { kind = null } = {}) {
+  const buf = embedding instanceof Float32Array ? embedding : Float32Array.from(embedding);
+  const kindClause = kind ? "AND c.kind = ?" : "";
+  const sql = `
+    SELECT c.id, c.source, c.kind, c.text, c.metadata, v.distance
+    FROM vec_chunks v
+    JOIN chunks c ON c.id = v.rowid
+    WHERE v.embedding MATCH ? AND k = ? ${kindClause}
+    ORDER BY v.distance
+  `;
+  const params = [Buffer.from(buf.buffer), topK];
+  if (kind) params.push(kind);
+  const rows = db.prepare(sql).all(...params);
+  return rows.map((r) => ({ ...r, metadata: r.metadata ? safeParse(r.metadata) : null }));
+}
+
+function safeParse(s) { try { return JSON.parse(s); } catch { return s; } }
+
+/**
+ * Remove every chunk that came from a given source path. Both tables
+ * are touched explicitly because vec0 virtual tables do not honour
+ * SQLite foreign-key cascades.
+ */
+export function deleteChunksBySource(db, source) {
+  const ids = db.prepare("SELECT id FROM chunks WHERE source = ?").all(source).map((r) => r.id);
+  if (ids.length === 0) return 0;
+  const placeholders = ids.map(() => "?").join(",");
+  db.prepare(`DELETE FROM vec_chunks WHERE rowid IN (${placeholders})`).run(...ids);
+  db.prepare(`DELETE FROM chunks WHERE id IN (${placeholders})`).run(...ids);
+  return ids.length;
+}
+
+export function countChunks(db, { kind = null } = {}) {
+  if (kind) return db.prepare("SELECT COUNT(*) AS n FROM chunks WHERE kind = ?").get(kind).n;
+  return db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
+}

--- a/tests/rag/vec-store.test.js
+++ b/tests/rag/vec-store.test.js
@@ -1,0 +1,84 @@
+// KJC-PCS-0049 Step 1 — vec-store acceptance pins.
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  openVecStore, insertChunk, searchSimilar, deleteChunksBySource, countChunks, dbPath,
+} from "../../src/rag/vec-store.js";
+
+// Synthetic one-hot embeddings → predictable cosine ordering.
+function oneHot(idx, dim = 8) {
+  const v = new Float32Array(dim); v[idx % dim] = 1; return v;
+}
+
+describe("vec-store — KJC-PCS-0049 Step 1", () => {
+  let dbFile, db;
+  beforeEach(() => {
+    const dir = mkdtempSync(join(tmpdir(), "kj-vec-"));
+    dbFile = join(dir, "rag.db");
+    db = openVecStore({ dim: 8, path: dbFile });
+  });
+  afterEach(() => {
+    db?.close();
+    if (existsSync(dbFile)) rmSync(dbFile.replace("/rag.db", ""), { recursive: true, force: true });
+  });
+
+  it("creates the DB + schema and the file is materialised on disk", () => {
+    expect(existsSync(dbFile)).toBe(true);
+    expect(countChunks(db)).toBe(0);
+  });
+
+  it("insertChunk persists a row and returns a numeric id", () => {
+    const id = insertChunk(db, {
+      source: "/tmp/a.md", kind: "plan", text: "hello", metadata: { tag: "x" }, embedding: oneHot(0),
+    });
+    expect(typeof id).toBe("number");
+    expect(countChunks(db)).toBe(1);
+    expect(countChunks(db, { kind: "plan" })).toBe(1);
+    expect(countChunks(db, { kind: "code" })).toBe(0);
+  });
+
+  it("searchSimilar returns the nearest chunks ordered by distance", () => {
+    insertChunk(db, { source: "/a", kind: "plan", text: "A", embedding: oneHot(0) });
+    insertChunk(db, { source: "/b", kind: "plan", text: "B", embedding: oneHot(1) });
+    insertChunk(db, { source: "/c", kind: "plan", text: "C", embedding: oneHot(2) });
+    const hits = searchSimilar(db, oneHot(1), 3);
+    expect(hits[0].text).toBe("B"); // exact match → distance 0
+    expect(hits[0].distance).toBeLessThan(hits[1].distance);
+    expect(hits[0].metadata).toBeNull();
+  });
+
+  it("searchSimilar honours the kind filter", () => {
+    insertChunk(db, { source: "/p", kind: "plan", text: "plan-A", embedding: oneHot(0) });
+    insertChunk(db, { source: "/c", kind: "code", text: "code-A", embedding: oneHot(0) });
+    const onlyCode = searchSimilar(db, oneHot(0), 5, { kind: "code" });
+    expect(onlyCode.length).toBe(1);
+    expect(onlyCode[0].kind).toBe("code");
+  });
+
+  it("deleteChunksBySource removes from both tables and returns the count", () => {
+    insertChunk(db, { source: "/a", kind: "plan", text: "x", embedding: oneHot(0) });
+    insertChunk(db, { source: "/a", kind: "plan", text: "y", embedding: oneHot(1) });
+    insertChunk(db, { source: "/b", kind: "plan", text: "z", embedding: oneHot(2) });
+    expect(deleteChunksBySource(db, "/a")).toBe(2);
+    expect(countChunks(db)).toBe(1);
+    expect(searchSimilar(db, oneHot(0), 5).every((r) => r.source !== "/a")).toBe(true);
+  });
+
+  it("openVecStore is idempotent on a populated DB", () => {
+    insertChunk(db, { source: "/a", kind: "plan", text: "seed", embedding: oneHot(0) });
+    db.close();
+    const reopened = openVecStore({ dim: 8, path: dbFile });
+    expect(countChunks(reopened)).toBe(1);
+    reopened.close();
+  });
+
+  it("dbPath honours KJ_RAG_DB env override", () => {
+    const prev = process.env.KJ_RAG_DB;
+    process.env.KJ_RAG_DB = "/tmp/x.db";
+    try { expect(dbPath()).toBe("/tmp/x.db"); }
+    finally { if (prev === undefined) delete process.env.KJ_RAG_DB; else process.env.KJ_RAG_DB = prev; }
+  });
+});


### PR DESCRIPTION
First of 6 PRs for the Project RAG epic (KJC-PCS-0049). Lays the persistence layer that the embedder, indexer and retriever sit on.

## New module `src/rag/vec-store.js`

| Function | Purpose |
|---|---|
| `openVecStore({ dim, path? })` | Open/create `~/.karajan/rag.db` + sqlite-vec extension + chunks/vec_chunks tables. Idempotent. `KJ_RAG_DB` env override. |
| `insertChunk(db, { source, kind, text, metadata, embedding })` | Atomic insert into both tables, chunks.id ↔ vec_chunks.rowid sync. |
| `searchSimilar(db, embedding, topK, { kind? })` | Cosine-ordered NN search via vec0 MATCH. |
| `deleteChunksBySource(db, source)` | Cascade delete from both tables (vec0 doesn't honour SQLite FKs). |
| `countChunks(db, { kind? })` | Cheap count for bootstrap detection. |

## Notes on the implementation

1. **vec0 wants BigInt rowids** even for values that fit in Number. Forcing `BigInt(info.lastInsertRowid)` is the only path that avoids `Only integers are allowed for primary key values on vec_chunks`.
2. **Dimension baked into DDL.** Changing it requires a fresh DB. Step 2 will document the dim per supported Ollama embedder.

## Tests

`tests/rag/vec-store.test.js` — 7 acceptance tests with synthetic one-hot embeddings (dim 8) so cosine ordering is deterministic. Covers materialisation, insert/count, distance ordering, kind filter, cascade delete, idempotent re-open, env override.

## LOC

+197 net. Inside 200 hard limit.

## New dep

`sqlite-vec ^0.1.9` — extension loaded via `better-sqlite3` (already a root dep). No new native build step.

## Next

| Step | Purpose |
|---|---|
| 2 | Ollama embedder adapter (local endpoint already configured in opencode.json) |
| 3 | Chunker (markdown + plan JSON + AST for code) |
| 4 | Indexer (chokidar watcher) |
| 5 | Retriever + ranking |
| 6 | CLI: `kj rag <query>` + `kj rag index` |

Project RAG epic KJC-PCS-0049 → v2.22.0.