### PR TITLE
feat(rag): Ollama embedder adapter (KJC-TSK-0424 / RAG Step 2)

### DIFF
--- a/src/rag/embedder.js
+++ b/src/rag/embedder.js
@@ -1,0 +1,81 @@
+// KJC-PCS-0049 Step 2 — Ollama embedder adapter for the RAG pipeline.
+// Talks to a local Ollama server (POST /api/embeddings) and returns
+// Float32Array vectors. Cero deps externas; usa fetch global.
+//
+// Defaults:
+//   url       = process.env.KJ_OLLAMA_URL or "http://localhost:11434"
+//   model     = process.env.KJ_OLLAMA_EMBED_MODEL or "nomic-embed-text"
+//   dim       = 768  (matches nomic-embed-text)
+//   timeoutMs = 30000
+
+const DEFAULT_URL = "http://localhost:11434";
+const DEFAULT_MODEL = "nomic-embed-text";
+const DEFAULT_DIM = 768;
+const DEFAULT_TIMEOUT_MS = 30000;
+
+export class OllamaEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) {
+    super(message);
+    this.name = "OllamaEmbedderError";
+    if (cause) this.cause = cause;
+    if (status != null) this.status = status;
+  }
+}
+
+export class OllamaEmbedder {
+  constructor({
+    url = process.env.KJ_OLLAMA_URL || DEFAULT_URL,
+    model = process.env.KJ_OLLAMA_EMBED_MODEL || DEFAULT_MODEL,
+    dim = DEFAULT_DIM,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    fetchFn = globalThis.fetch,
+  } = {}) {
+    this.url = url.replace(/\/$/, "");
+    this.model = model;
+    this.dim = dim;
+    this.timeoutMs = timeoutMs;
+    this.fetch = fetchFn;
+  }
+
+  /** Single-text embedding. Returns Float32Array(dim). */
+  async embed(text) {
+    if (typeof text !== "string" || text.length === 0) {
+      throw new OllamaEmbedderError("embed: text must be a non-empty string");
+    }
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    let res;
+    try {
+      res = await this.fetch(`${this.url}/api/embeddings`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: this.model, prompt: text }),
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      throw new OllamaEmbedderError(`Ollama embed request failed (${this.url}): ${err.message}`, { cause: err });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) {
+      throw new OllamaEmbedderError(`Ollama embed HTTP ${res.status} from ${this.url}`, { status: res.status });
+    }
+    const body = await res.json();
+    const arr = body?.embedding;
+    if (!Array.isArray(arr) || arr.length === 0) {
+      throw new OllamaEmbedderError("Ollama response missing 'embedding' array");
+    }
+    if (arr.length !== this.dim) {
+      throw new OllamaEmbedderError(`Ollama dim mismatch: got ${arr.length}, expected ${this.dim} for model ${this.model}`);
+    }
+    return Float32Array.from(arr);
+  }
+
+  /** Batch embedding (sequential — Ollama /api/embeddings is single-text). */
+  async embedBatch(texts) {
+    if (!Array.isArray(texts)) throw new OllamaEmbedderError("embedBatch: texts must be an array");
+    const out = [];
+    for (const t of texts) out.push(await this.embed(t));
+    return out;
+  }
+}

--- a/tests/rag/embedder.test.js
+++ b/tests/rag/embedder.test.js
@@ -1,0 +1,79 @@
+// KJC-PCS-0049 Step 2 — OllamaEmbedder acceptance pins. Uses an injected
+// fetch mock; no real network call.
+import { describe, expect, it, vi } from "vitest";
+import { OllamaEmbedder, OllamaEmbedderError } from "../../src/rag/embedder.js";
+
+function okResponse(embedding) {
+  return { ok: true, status: 200, json: async () => ({ embedding }) };
+}
+function errResponse(status) {
+  return { ok: false, status, json: async () => ({}) };
+}
+
+describe("OllamaEmbedder — KJC-PCS-0049 Step 2", () => {
+  it("embed returns a Float32Array of the configured dim", async () => {
+    const vec = Array.from({ length: 8 }, (_, i) => i / 8);
+    const fetchFn = vi.fn().mockResolvedValue(okResponse(vec));
+    const e = new OllamaEmbedder({ dim: 8, fetchFn });
+    const r = await e.embed("hello");
+    expect(r).toBeInstanceOf(Float32Array);
+    expect(r.length).toBe(8);
+    expect(r[0]).toBeCloseTo(0);
+  });
+
+  it("embed POSTs to /api/embeddings with the right shape", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(okResponse([0, 0, 0, 0]));
+    const e = new OllamaEmbedder({ dim: 4, url: "http://x:11434/", model: "m", fetchFn });
+    await e.embed("hi");
+    expect(fetchFn).toHaveBeenCalledWith("http://x:11434/api/embeddings", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ model: "m", prompt: "hi" }),
+    }));
+  });
+
+  it("embed throws OllamaEmbedderError on HTTP 5xx", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(errResponse(500));
+    const e = new OllamaEmbedder({ dim: 4, fetchFn });
+    await expect(e.embed("hi")).rejects.toBeInstanceOf(OllamaEmbedderError);
+  });
+
+  it("embed throws on dim mismatch", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(okResponse([1, 2, 3]));
+    const e = new OllamaEmbedder({ dim: 768, fetchFn });
+    await expect(e.embed("x")).rejects.toThrow(/dim mismatch/);
+  });
+
+  it("embed rejects empty text without making any HTTP call", async () => {
+    const fetchFn = vi.fn();
+    const e = new OllamaEmbedder({ dim: 4, fetchFn });
+    await expect(e.embed("")).rejects.toThrow(/non-empty string/);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("embedBatch preserves input order", async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(okResponse([1, 0]))
+      .mockResolvedValueOnce(okResponse([0, 1]));
+    const e = new OllamaEmbedder({ dim: 2, fetchFn });
+    const out = await e.embedBatch(["a", "b"]);
+    expect(out.length).toBe(2);
+    expect(out[0][0]).toBe(1);
+    expect(out[1][1]).toBe(1);
+  });
+
+  it("KJ_OLLAMA_URL + KJ_OLLAMA_EMBED_MODEL env overrides reach the adapter", async () => {
+    const prevUrl = process.env.KJ_OLLAMA_URL;
+    const prevModel = process.env.KJ_OLLAMA_EMBED_MODEL;
+    process.env.KJ_OLLAMA_URL = "http://env-url:11434";
+    process.env.KJ_OLLAMA_EMBED_MODEL = "env-model";
+    try {
+      const fetchFn = vi.fn().mockResolvedValue(okResponse([0, 0]));
+      const e = new OllamaEmbedder({ dim: 2, fetchFn });
+      expect(e.url).toBe("http://env-url:11434");
+      expect(e.model).toBe("env-model");
+    } finally {
+      if (prevUrl === undefined) delete process.env.KJ_OLLAMA_URL; else process.env.KJ_OLLAMA_URL = prevUrl;
+      if (prevModel === undefined) delete process.env.KJ_OLLAMA_EMBED_MODEL; else process.env.KJ_OLLAMA_EMBED_MODEL = prevModel;
+    }
+  });
+});


### PR DESCRIPTION
Second of 6 PRs for the Project RAG epic (KJC-PCS-0049). Sits on top of Step 1 (#808 — vec store).

## New module `src/rag/embedder.js`

`OllamaEmbedder` class talking to local Ollama `POST /api/embeddings`.

| Default | Source |
|---|---|
| url | `KJ_OLLAMA_URL` env or `http://localhost:11434` |
| model | `KJ_OLLAMA_EMBED_MODEL` env or `nomic-embed-text` |
| dim | `768` (nomic-embed-text; mxbai-embed-large = 1024) |
| timeoutMs | `30000` |
| fetchFn | `globalThis.fetch` (injectable for tests) |

API:
- `embed(text)` → `Float32Array(dim)`. AbortController-based timeout. Throws `OllamaEmbedderError` on network failure / non-2xx / missing embedding / dim mismatch. **The dim check is loud on purpose**: an embedder of the wrong dimension would silently corrupt the vec store over time.
- `embedBatch(texts)` → `Float32Array[]`. Sequential (Ollama's endpoint is single-text only). Preserves input order.

`OllamaEmbedderError` extends `Error` with optional `{ cause, status }` so callers can branch on HTTP status.

## Tests

`tests/rag/embedder.test.js` — 7 acceptance tests, all using an injected `fetchFn` mock; no real network call. Covers dim correctness, request shape, 5xx handling, dim mismatch, empty-text rejection, batch ordering, env overrides.

## LOC

+160 net. Inside 200 hard. Slightly over the 150 ideal — exhaustive on purpose (every error branch + env override pinned).

## No new deps

Uses global `fetch` (Node 18+; engines.node = >=20.10).

## Next

| Step | Module |
|---|---|
| 3 | chunker (markdown semantic + AST) |
| 4 | indexer (chokidar watcher) |
| 5 | retriever + ranking |
| 6 | CLI: `kj rag` |

Project RAG epic KJC-PCS-0049 → v2.22.0.