### PR TITLE
feat(rag): chunkers for markdown / plan JSON / source (KJC-TSK-0425 / RAG Step 3)

### DIFF
--- a/src/rag/chunker.js
+++ b/src/rag/chunker.js
@@ -1,0 +1,119 @@
+// KJC-PCS-0049 Step 3 — Chunkers for the RAG indexer.
+// Each chunker is pure: takes text + opts, returns
+// `[{ text, metadata: { source, kind, ...extras } }]`. The indexer
+// (Step 4) hands every chunk to the embedder + vec store; the
+// retriever (Step 5) reads metadata back to enrich results.
+
+const DEFAULT_CHUNK_LIMIT = 800;
+const DEFAULT_OVERLAP = 100;
+
+// ---------- shared splitter ---------------------------------------
+
+/**
+ * Split a long string into overlapping windows. Used by every chunker
+ * that produces a single section too big for the embedder's context.
+ */
+function windowText(text, { limit = DEFAULT_CHUNK_LIMIT, overlap = DEFAULT_OVERLAP } = {}) {
+  if (text.length <= limit) return [text];
+  const step = Math.max(1, limit - overlap);
+  const out = [];
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + limit));
+    if (i + limit >= text.length) break;
+  }
+  return out;
+}
+
+// ---------- markdown chunker (plans / onboarding briefs) ----------
+
+const HEADING_RE = /^(#{1,6})\s+(.+)$/gm;
+
+/**
+ * Chunk a markdown document by heading hierarchy. The headingPath
+ * metadata tracks ancestors so a retrieval result can show "from
+ * '# Plan' › '## Auth' › '### Login'".
+ */
+export function chunkMarkdown(text, { path = "<inline>", kind = "plan", limit = DEFAULT_CHUNK_LIMIT, overlap = DEFAULT_OVERLAP } = {}) {
+  const sections = [];
+  const stack = []; // [{ depth, title }]
+  let cursor = 0;
+  let pending = { headingPath: [], start: 0 };
+  HEADING_RE.lastIndex = 0;
+  let m;
+  while ((m = HEADING_RE.exec(text)) !== null) {
+    if (m.index > cursor) {
+      pending.body = text.slice(pending.start, m.index).trim();
+      if (pending.body) sections.push({ ...pending });
+    }
+    const depth = m[1].length;
+    const title = m[2].trim();
+    while (stack.length > 0 && stack[stack.length - 1].depth >= depth) stack.pop();
+    stack.push({ depth, title });
+    pending = { headingPath: stack.map((s) => s.title), start: HEADING_RE.lastIndex };
+    cursor = HEADING_RE.lastIndex;
+  }
+  const tail = text.slice(pending.start).trim();
+  if (tail) sections.push({ ...pending, body: tail });
+  const chunks = [];
+  for (const sec of sections) {
+    const pieces = windowText(sec.body, { limit, overlap });
+    for (const piece of pieces) {
+      chunks.push({ text: piece, metadata: { source: path, kind, headingPath: sec.headingPath } });
+    }
+  }
+  return chunks;
+}
+
+// ---------- plan chunker (one chunk per HU) -----------------------
+
+/**
+ * Chunk a Karajan plan JSON. One chunk per HU; an extra chunk for the
+ * plan-level summary if present. The retriever uses hu_id to deep-link
+ * back to the board.
+ */
+export function chunkPlan(plan, { path = "<plan>", limit = DEFAULT_CHUNK_LIMIT } = {}) {
+  const out = [];
+  if (plan?.summary) {
+    const pieces = windowText(String(plan.summary), { limit });
+    for (const piece of pieces) {
+      out.push({ text: piece, metadata: { source: path, kind: "plan", section: "summary" } });
+    }
+  }
+  for (const hu of plan?.hus || []) {
+    const parts = [hu.title, hu.description, hu.scope].filter(Boolean).join("\n\n");
+    if (!parts.trim()) continue;
+    for (const piece of windowText(parts, { limit })) {
+      out.push({ text: piece, metadata: { source: path, kind: "plan", hu_id: hu.id || null, title: hu.title || null } });
+    }
+  }
+  return out;
+}
+
+// ---------- source chunker (export-symbol granularity) ------------
+
+const EXPORT_RE = /^export\s+(?:async\s+)?(?:function|class|const|let)\s+(\w+)/gm;
+
+/**
+ * Chunk a JS/TS source file by top-level export symbol. Falls back to
+ * the windowed splitter on files without explicit exports.
+ */
+export function chunkSource(text, { path = "<src>", limit = DEFAULT_CHUNK_LIMIT, overlap = DEFAULT_OVERLAP } = {}) {
+  const marks = [];
+  EXPORT_RE.lastIndex = 0;
+  let m;
+  while ((m = EXPORT_RE.exec(text)) !== null) marks.push({ idx: m.index, symbol: m[1] });
+  if (marks.length === 0) {
+    return windowText(text, { limit, overlap })
+      .map((piece) => ({ text: piece, metadata: { source: path, kind: "code", symbol: null } }));
+  }
+  const out = [];
+  for (let i = 0; i < marks.length; i += 1) {
+    const start = marks[i].idx;
+    const end = i + 1 < marks.length ? marks[i + 1].idx : text.length;
+    const body = text.slice(start, end);
+    for (const piece of windowText(body, { limit, overlap })) {
+      out.push({ text: piece, metadata: { source: path, kind: "code", symbol: marks[i].symbol } });
+    }
+  }
+  return out;
+}

--- a/tests/rag/chunker.test.js
+++ b/tests/rag/chunker.test.js
@@ -1,0 +1,72 @@
+// KJC-PCS-0049 Step 3 — chunker acceptance pins.
+import { describe, expect, it } from "vitest";
+import { chunkMarkdown, chunkPlan, chunkSource } from "../../src/rag/chunker.js";
+
+describe("chunkMarkdown — KJC-PCS-0049 Step 3", () => {
+  it("respects heading hierarchy in metadata.headingPath", () => {
+    const md = "# Top\n\nIntro.\n\n## A\n\nBody A.\n\n## B\n\nBody B.\n\n### B1\n\nDeep.";
+    const chunks = chunkMarkdown(md, { path: "/p.md" });
+    const paths = chunks.map((c) => c.metadata.headingPath.join(" > "));
+    expect(paths).toContain("Top");
+    expect(paths).toContain("Top > A");
+    expect(paths).toContain("Top > B");
+    expect(paths).toContain("Top > B > B1");
+  });
+
+  it("propagates source + kind on every chunk", () => {
+    const md = "# X\n\nBody.";
+    const chunks = chunkMarkdown(md, { path: "/x.md", kind: "onboarding" });
+    expect(chunks.every((c) => c.metadata.source === "/x.md" && c.metadata.kind === "onboarding")).toBe(true);
+  });
+
+  it("subdivides oversized sections via overlapping windows", () => {
+    const long = "x".repeat(2500);
+    const md = `# T\n\n${long}`;
+    const chunks = chunkMarkdown(md, { path: "/t.md", limit: 800, overlap: 100 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((c) => c.text.length <= 800)).toBe(true);
+  });
+});
+
+describe("chunkPlan — KJC-PCS-0049 Step 3", () => {
+  it("emits one chunk per HU with hu_id + title metadata", () => {
+    const plan = {
+      summary: "A plan.",
+      hus: [
+        { id: "HU-A", title: "Login", description: "Build login.", scope: "auth" },
+        { id: "HU-B", title: "Logout", description: "Build logout.", scope: "auth" },
+      ],
+    };
+    const chunks = chunkPlan(plan, { path: "/plan.json" });
+    const huChunks = chunks.filter((c) => c.metadata.hu_id);
+    expect(huChunks.map((c) => c.metadata.hu_id)).toEqual(["HU-A", "HU-B"]);
+    expect(huChunks[0].metadata.title).toBe("Login");
+  });
+
+  it("skips HUs with no narrative text", () => {
+    const plan = { hus: [{ id: "HU-X" }, { id: "HU-Y", title: "Real", description: "Has body." }] };
+    const chunks = chunkPlan(plan, { path: "/p.json" });
+    const ids = chunks.map((c) => c.metadata.hu_id);
+    expect(ids).toEqual(["HU-Y"]);
+  });
+});
+
+describe("chunkSource — KJC-PCS-0049 Step 3", () => {
+  it("splits by top-level export symbol with metadata.symbol", () => {
+    const src = `
+import x from "y";
+export function alpha() { return 1; }
+export const beta = 42;
+export async function gamma() {}
+`;
+    const chunks = chunkSource(src, { path: "/s.js" });
+    expect(chunks.map((c) => c.metadata.symbol)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("falls back to windowed chunks when no exports exist", () => {
+    const src = "const a = 1;\nconsole.log(a);";
+    const chunks = chunkSource(src, { path: "/s.js" });
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].metadata.symbol).toBeNull();
+  });
+});


### PR DESCRIPTION
Third of 6 PRs for the Project RAG epic (KJC-PCS-0049). Between the embedder (Step 2 #809) and the indexer (Step 4).

## New module `src/rag/chunker.js`

Three pure chunkers returning `[{ text, metadata: { source, kind, ...extras } }]`:

| Function | What it understands | Metadata extras |
|---|---|---|
| `chunkMarkdown(text, { path, kind, limit, overlap })` | Heading hierarchy (`#`, `##`, `###`). Used for plans + onboarding briefs. | `headingPath: string[]` (ancestors first) |
| `chunkPlan(planObject, { path, limit })` | Karajan plan JSON: one chunk per HU (title+description+scope), one optional summary chunk. | `hu_id`, `title`, `section` |
| `chunkSource(text, { path, limit, overlap })` | JS/TS export-symbol granularity via regex. Falls back to windowed splitter when no exports. | `symbol: string\|null` |

All three share a windowed splitter (`limit` 800 chars, `overlap` 100) for sections too long for the embedder's context. Zero new deps; a future AST-based source chunker can replace the regex without changing the public contract.

## Tests

`tests/rag/chunker.test.js` — 7 acceptance tests:

- Markdown: heading hierarchy, source/kind propagation, oversized split
- Plan: one chunk per HU with hu_id + title, skips empty HUs
- Source: export-symbol splitting, fallback to windowed when no exports

## LOC

+191 net. Inside 200 hard. Slightly over 150 ideal — three chunker functions sharing one window helper, with their own metadata shapes.

## Next

| Step | Module |
|---|---|
| 4 | indexer (chokidar watcher; chunker → embedder → vec store) |
| 5 | retriever + ranking |
| 6 | CLI: `kj rag` |

Project RAG epic KJC-PCS-0049 → v2.22.0.