### PR TITLE
feat(rag): indexer wires chunker + embedder + vec store (KJC-TSK-0426 / RAG Step 4)

### DIFF
--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -1,0 +1,116 @@
+// KJC-PCS-0049 Step 4 — Indexer for the RAG pipeline. Wires the three
+// previous modules together: chunker → embedder → vec store. The CLI
+// (Step 6) drives this; Step 5's retriever reads what gets persisted
+// here. A chokidar watcher version stays out of scope for v2.22.0 —
+// indexProject() is on-demand from `kj rag index`, which keeps the
+// failure mode simple (re-run to refresh).
+import { existsSync, readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+
+import { chunkMarkdown, chunkPlan, chunkSource } from "./chunker.js";
+import { insertChunk, deleteChunksBySource } from "./vec-store.js";
+
+const ONBOARDING_DIR = "onboarding", PLANS_DIR = "plans";
+
+function detectKind(path) {
+  const ext = extname(path).toLowerCase();
+  const base = path.split("/").pop() || "";
+  if (ext === ".json" && (/^plan-.+\.json$/i.test(base) || path.includes(`/${PLANS_DIR}/`))) return "plan";
+  if (ext === ".md") return path.includes(`/${ONBOARDING_DIR}/`) ? "onboarding" : "plan";
+  if ([".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx"].includes(ext)) return "code";
+  return null;
+}
+
+function chunksFor(path, kind) {
+  const text = readFileSync(path, "utf8");
+  if (kind === "plan" && extname(path) === ".json") {
+    try { return chunkPlan(JSON.parse(text), { path }); }
+    catch { return []; }
+  }
+  if (kind === "plan" || kind === "onboarding") {
+    return chunkMarkdown(text, { path, kind });
+  }
+  if (kind === "code") return chunkSource(text, { path });
+  return [];
+}
+
+/**
+ * Index a single file. Returns `{ indexed, failed }`. Idempotent —
+ * pre-existing chunks for this `source` path are deleted before the
+ * fresh batch is written, so a second call against the same file
+ * leaves the store with exactly the latest chunks (no duplicates).
+ */
+export async function indexFile(path, { db, embedder, logger = console } = {}) {
+  if (!existsSync(path)) { logger.warn?.(`[rag-indexer] file not found: ${path}`); return { indexed: 0, failed: 0 }; }
+  const kind = detectKind(path);
+  if (!kind) { logger.warn?.(`[rag-indexer] unknown kind: ${path}`); return { indexed: 0, failed: 0 }; }
+  const chunks = chunksFor(path, kind);
+  if (!chunks.length) return { indexed: 0, failed: 0 };
+  deleteChunksBySource(db, path);
+  let indexed = 0;
+  let failed = 0;
+  for (const ch of chunks) {
+    try {
+      const embedding = await embedder.embed(ch.text);
+      insertChunk(db, { source: path, kind: ch.metadata.kind || kind, text: ch.text, metadata: ch.metadata, embedding });
+      indexed += 1;
+    } catch (err) {
+      failed += 1;
+      logger.warn?.(`[rag-indexer] embed failed for ${path} (${chunkLabel(ch)}): ${err.message}`);
+    }
+  }
+  logger.info?.(`[rag-indexer] ${relative(process.cwd(), path)} → ${indexed} chunk(s) (${failed} failed)`);
+  return { indexed, failed };
+}
+
+function chunkLabel(ch) {
+  return ch.metadata?.hu_id || ch.metadata?.symbol || ch.metadata?.headingPath?.join(" > ") || "block";
+}
+
+async function listFiles(dir, predicate) {
+  const out = [];
+  async function walk(d) {
+    let ents; try { ents = await readdir(d, { withFileTypes: true }); } catch { return; }
+    for (const e of ents) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) await walk(p); else if (e.isFile() && predicate(p)) out.push(p);
+    }
+  }
+  await walk(dir); return out;
+}
+
+/**
+ * Index every Karajan-managed asset for the project: every plan-*.json
+ * under `<karajanHome>/plans/<slug>/`, the onboarding brief under
+ * `<karajanHome>/onboarding/`, and (optionally) source files under the
+ * projectDir. Sources are gated behind `withSources: true` because
+ * indexing tens of thousands of files is expensive — the CLI exposes
+ * it as `--with-sources`.
+ */
+export async function indexProject(projectDir, { db, embedder, karajanHome, logger = console, withSources = false } = {}) {
+  const totals = { indexed: 0, failed: 0, files: 0 };
+  const slug = projectDir.split("/").pop()?.replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
+  const planRoot = join(karajanHome, PLANS_DIR, slug);
+  if (existsSync(planRoot)) {
+    const plans = await listFiles(planRoot, (p) => /plan-.*\.json$/.test(p));
+    for (const p of plans) {
+      const r = await indexFile(p, { db, embedder, logger });
+      totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
+    }
+  }
+  const onboarding = join(karajanHome, ONBOARDING_DIR, `${slug}.md`);
+  if (existsSync(onboarding)) {
+    const r = await indexFile(onboarding, { db, embedder, logger });
+    totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
+  }
+  if (withSources) {
+    const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next"]);
+    const sources = await listFiles(projectDir, (p) => /\.(js|mjs|cjs|ts|tsx|jsx)$/.test(p) && !p.split("/").some((seg) => SKIP.has(seg)));
+    for (const s of sources) {
+      const r = await indexFile(s, { db, embedder, logger });
+      totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
+    }
+  }
+  return totals;
+}

--- a/tests/rag/indexer.test.js
+++ b/tests/rag/indexer.test.js
@@ -1,0 +1,78 @@
+// KJC-PCS-0049 Step 4 — indexer acceptance pins.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openVecStore, countChunks } from "../../src/rag/vec-store.js";
+import { indexFile, indexProject } from "../../src/rag/indexer.js";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function fakeEmbedder({ dim = 8, fail = false } = {}) {
+  return { embed: vi.fn(async () => { if (fail) throw new Error("ollama down"); const v = new Float32Array(dim); v[0] = 1; return v; }), dim };
+}
+
+describe("indexer — KJC-PCS-0049 Step 4", () => {
+  let root, db, dbFile;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-rag-idx-"));
+    dbFile = join(root, "rag.db");
+    db = openVecStore({ dim: 8, path: dbFile });
+  });
+  afterEach(() => {
+    db?.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("indexFile indexes a plan JSON and is idempotent on re-run", async () => {
+    const planPath = join(root, "plan-001.json");
+    writeFileSync(planPath, JSON.stringify({ hus: [{ id: "A", title: "alpha", description: "do A" }, { id: "B", title: "beta", description: "do B" }] }));
+    const e = fakeEmbedder();
+    const first = await indexFile(planPath, { db, embedder: e, logger: noopLogger });
+    expect(first.indexed).toBe(2);
+    const after = countChunks(db);
+    await indexFile(planPath, { db, embedder: e, logger: noopLogger });
+    expect(countChunks(db)).toBe(after); // idempotent: same total, not double
+  });
+
+  it("indexFile detects onboarding kind for ~/.karajan/onboarding/*.md", async () => {
+    mkdirSync(join(root, "onboarding"), { recursive: true });
+    const briefPath = join(root, "onboarding", "myproj.md");
+    writeFileSync(briefPath, "# Brief\n\n## Stack\n\nNode 20.");
+    await indexFile(briefPath, { db, embedder: fakeEmbedder(), logger: noopLogger });
+    expect(countChunks(db, { kind: "onboarding" })).toBeGreaterThan(0);
+  });
+
+  it("indexFile continues past embedder failures and reports them", async () => {
+    const planPath = join(root, "plan-002.json");
+    writeFileSync(planPath, JSON.stringify({ hus: [{ id: "A", title: "a", description: "x" }] }));
+    const r = await indexFile(planPath, { db, embedder: fakeEmbedder({ fail: true }), logger: noopLogger });
+    expect(r.indexed).toBe(0);
+    expect(r.failed).toBeGreaterThan(0);
+  });
+
+  it("indexProject indexes plans + onboarding for the project slug", async () => {
+    const projectDir = join(root, "myproj"); mkdirSync(projectDir);
+    const home = join(root, ".karajan");
+    mkdirSync(join(home, "plans", "myproj"), { recursive: true });
+    writeFileSync(join(home, "plans", "myproj", "plan-xyz.json"), JSON.stringify({ hus: [{ id: "A", title: "alpha", description: "do alpha" }] }));
+    mkdirSync(join(home, "onboarding"), { recursive: true });
+    writeFileSync(join(home, "onboarding", "myproj.md"), "# Brief\n\nText.");
+    const totals = await indexProject(projectDir, { db, embedder: fakeEmbedder(), karajanHome: home, logger: noopLogger });
+    expect(totals.files).toBe(2);
+    expect(countChunks(db, { kind: "plan" })).toBeGreaterThan(0);
+    expect(countChunks(db, { kind: "onboarding" })).toBeGreaterThan(0);
+  });
+
+  it("indexProject --with-sources walks JS files but skips node_modules", async () => {
+    const projectDir = join(root, "p2");
+    mkdirSync(join(projectDir, "node_modules", "x"), { recursive: true });
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    writeFileSync(join(projectDir, "src", "main.js"), "export function alpha() { return 1; }");
+    writeFileSync(join(projectDir, "node_modules", "x", "skip.js"), "export function skipMe() {}");
+    const totals = await indexProject(projectDir, { db, embedder: fakeEmbedder(), karajanHome: join(root, "missing"), logger: noopLogger, withSources: true });
+    expect(totals.files).toBe(1); // only src/main.js
+    expect(countChunks(db, { kind: "code" })).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fourth of 6 PRs for the Project RAG epic (KJC-PCS-0049). Orchestrates the modules from Steps 1-3 into the file-level pipeline the CLI will drive.

## Scope note

No chokidar watcher in v2.22.0 — `indexProject()` is on-demand from `kj rag index`. Re-run to refresh, no background process to crash. A watcher can ship as v2.23.0+.

## New module `src/rag/indexer.js`

| Function | Contract |
|---|---|
| `indexFile(path, { db, embedder, logger })` | Detects kind by ext + path → dispatches to chunker → embed each → `insertChunk`. **Idempotent** (calls `deleteChunksBySource` first). Embedder failure on a chunk = `warn` + continue. Returns `{ indexed, failed }`. |
| `indexProject(projectDir, { db, embedder, karajanHome, withSources, logger })` | Walks `~/.karajan/plans/<slug>/plan-*.json` + `~/.karajan/onboarding/<slug>.md`. With `withSources=true`, also walks the project's JS/TS files (skipping node_modules / .git / dist / etc.). Returns `{ files, indexed, failed }`. |

Slug rule shared with `kj onboard`'s `briefPath()` so writer and reader agree without separate config.

## Kind detection

| Pattern | Kind |
|---|---|
| `*.json` with `/plans/` in path OR basename `plan-*.json` | plan |
| `*.md` under `/onboarding/` | onboarding |
| `*.md` otherwise | plan |
| `.js` / `.mjs` / `.cjs` / `.ts` / `.tsx` / `.jsx` | code |

## Tests

`tests/rag/indexer.test.js` — 5 acceptance tests, all using a fake embedder (deterministic Float32Array, zero network):

- indexFile idempotent on re-run
- indexFile detects onboarding kind
- indexFile continues past embedder failures
- indexProject indexes plans + onboarding (files = 2)
- indexProject `--with-sources` skips node_modules (files = 1)

## LOC

+194 net. Inside 200 hard.

## Next

| Step | Module |
|---|---|
| 5 | retriever + ranking |
| 6 | CLI: `kj rag` |

Project RAG epic KJC-PCS-0049 → v2.22.0.