### PR TITLE
feat(rag): retriever + ranking on top of vec store (KJC-TSK-0427 / RAG Step 5)

### DIFF
--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -1,0 +1,47 @@
+// KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline. Composes the
+// embedder (Step 2) + vec store (Step 1) into a one-call query API.
+// The CLI (Step 6) and the future MCP tool are the only consumers.
+
+import { searchSimilar } from "./vec-store.js";
+
+// Kind boosts for rerank: a plan chunk is more "intentional" than a
+// raw code chunk, an onboarding brief sits between them. Tunable via
+// the third argument; the defaults are conservative — they break ties
+// between equidistant chunks but won't reorder by big distance gaps.
+const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
+
+/**
+ * Run a natural-language query against the indexed RAG corpus. Returns
+ * the top-K chunks ranked by adjusted distance (lower = closer).
+ *
+ *   query(db, embedder, "how did I handle auth in module X?",
+ *         { topK: 5, scope: 'plans' })
+ *
+ * @param {Database} db           — opened via openVecStore()
+ * @param {OllamaEmbedder} embedder
+ * @param {string} text           — the query
+ * @param {Object} [opts]
+ * @param {number} [opts.topK=5]
+ * @param {'plans'|'code'|'onboarding'|'all'} [opts.scope='all']
+ * @param {Object} [opts.kindBoost]
+ */
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST } = {}) {
+  if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
+  const queryEmbedding = await embedder.embed(text);
+  // Over-fetch (topK * 2) so the rerank step has room to reshuffle
+  // without dropping a relevant chunk past the cut. Clamped at 50 to
+  // avoid loading the entire store on tiny topK calls.
+  const fetchK = Math.min(50, topK * 2);
+  const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
+  const raw = searchSimilar(db, queryEmbedding, fetchK, { kind: scopeKind });
+  if (raw.length === 0) return [];
+  // Adjust each chunk's distance by its kind boost. The vec store returns
+  // cosine distance (smaller = closer); subtracting the boost makes
+  // higher-priority kinds appear "closer" without altering the source
+  // truth in the DB.
+  const reranked = raw.map((r) => ({
+    ...r,
+    score: r.distance - (kindBoost[r.kind] || 0),
+  })).sort((a, b) => a.score - b.score).slice(0, topK);
+  return reranked;
+}

--- a/tests/rag/retriever.test.js
+++ b/tests/rag/retriever.test.js
@@ -1,0 +1,58 @@
+// KJC-PCS-0049 Step 5 — retriever acceptance pins.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openVecStore, insertChunk } from "../../src/rag/vec-store.js";
+import { query } from "../../src/rag/retriever.js";
+
+function oneHot(idx, dim = 8) { const v = new Float32Array(dim); v[idx % dim] = 1; return v; }
+function fakeEmbedderFor(idx) { return { embed: vi.fn(async () => oneHot(idx)), dim: 8 }; }
+
+describe("retriever — KJC-PCS-0049 Step 5", () => {
+  let root, db;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-rag-ret-"));
+    db = openVecStore({ dim: 8, path: join(root, "rag.db") });
+  });
+  afterEach(() => { db?.close(); rmSync(root, { recursive: true, force: true }); });
+
+  it("returns the topK nearest chunks ordered by score", async () => {
+    insertChunk(db, { source: "/a", kind: "plan", text: "A", embedding: oneHot(0) });
+    insertChunk(db, { source: "/b", kind: "plan", text: "B", embedding: oneHot(1) });
+    insertChunk(db, { source: "/c", kind: "plan", text: "C", embedding: oneHot(2) });
+    const hits = await query(db, fakeEmbedderFor(1), "?", { topK: 2 });
+    expect(hits.length).toBe(2);
+    expect(hits[0].text).toBe("B");
+    expect(hits[0].score).toBeLessThanOrEqual(hits[1].score);
+  });
+
+  it("scope='plans' filters out code chunks", async () => {
+    insertChunk(db, { source: "/p", kind: "plan", text: "plan-A", embedding: oneHot(0) });
+    insertChunk(db, { source: "/c", kind: "code", text: "code-A", embedding: oneHot(0) });
+    const hits = await query(db, fakeEmbedderFor(0), "?", { topK: 5, scope: "plans" });
+    expect(hits.every((h) => h.kind === "plan")).toBe(true);
+  });
+
+  it("kind boost reorders equidistant chunks (plan > code)", async () => {
+    insertChunk(db, { source: "/c1", kind: "code", text: "code", embedding: oneHot(0) });
+    insertChunk(db, { source: "/p1", kind: "plan", text: "plan", embedding: oneHot(0) });
+    insertChunk(db, { source: "/o1", kind: "onboarding", text: "brief", embedding: oneHot(0) });
+    const hits = await query(db, fakeEmbedderFor(0), "?", { topK: 3 });
+    expect(hits[0].kind).toBe("plan");
+    expect(hits[1].kind).toBe("onboarding");
+    expect(hits[2].kind).toBe("code");
+  });
+
+  it("returns [] on an empty store", async () => {
+    const hits = await query(db, fakeEmbedderFor(0), "?", { topK: 5 });
+    expect(hits).toEqual([]);
+  });
+
+  it("rejects empty / non-string queries before hitting the embedder", async () => {
+    const fakeE = { embed: vi.fn(async () => oneHot(0)) };
+    await expect(query(db, fakeE, "", { topK: 5 })).rejects.toThrow(/non-empty string/);
+    expect(fakeE.embed).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fifth of 6 PRs for the Project RAG epic (KJC-PCS-0049). Composes the embedder + vec store into a one-call query API.

## New module `src/rag/retriever.js`

`query(db, embedder, text, { topK, scope, kindBoost })` does:

1. Reject empty / non-string queries before hitting the embedder.
2. Embed the query.
3. Over-fetch `topK * 2` (clamped at 50) for rerank headroom.
4. Apply kind boosts: plan −0.05, onboarding −0.03, code 0 (tunable). Breaks ties without reordering across big distance gaps.
5. Sort by adjusted score and slice topK.

Scope filter: `'plans'` / `'code'` / `'onboarding'` / `'all'` (default).

Returns `[{ id, source, kind, text, metadata, distance, score }]`.

## Tests

`tests/rag/retriever.test.js` — 5 acceptance tests with synthetic one-hot embeddings + fake embedder, zero network:

- topK nearest by score
- scope='plans' filters code out
- equidistant chunks reorder plan > onboarding > code
- empty store → []
- empty query rejected before embedder call

## LOC

+105 net. Well inside 200 hard / 150 ideal.

## Next

Step 6 — CLI: `kj rag <query>` + `kj rag index --project <id>`. Last step of v2.22.0.

Project RAG epic KJC-PCS-0049.