### PR TITLE
feat(rag): kj rag CLI (index + query) closes v2.22.0 (KJC-TSK-0428 / RAG Step 6)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -139,6 +139,36 @@ const huBoardStubPlugin = {
   },
 };
 
+// Same reasoning as the HU Board stub: src/rag/* + src/commands/rag.js
+// depend on better-sqlite3 + sqlite-vec, native modules that esbuild
+// cannot bundle. The SEA binary stubs them out and tells the user to
+// install via npm to get RAG. KJC-PCS-0049 / Step 6.
+const ragStubPlugin = {
+  name: "rag-stub",
+  setup(build) {
+    build.onResolve({ filter: /[\\/](rag[\\/][^\\/]+|commands[\\/]rag)\.js$/ }, (args) => ({
+      path: args.path, namespace: "rag-stub",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "rag-stub" }, () => ({
+      contents: `
+        const NOT_AVAILABLE = "The RAG subsystem is not available in this standalone binary.\\n" +
+          "Install karajan-code from npm to get \\\`kj rag\\\`:\\n" +
+          "  npm install -g karajan-code\\n";
+        function notAvailable() { throw new Error(NOT_AVAILABLE); }
+        module.exports = {
+          __esModule: false,
+          ragIndexCommand: notAvailable, ragQueryCommand: notAvailable,
+          openVecStore: notAvailable, OllamaEmbedder: notAvailable,
+          indexFile: notAvailable, indexProject: notAvailable,
+          query: notAvailable, chunkMarkdown: notAvailable, chunkPlan: notAvailable, chunkSource: notAvailable,
+          default: notAvailable,
+        };
+      `,
+      loader: "js",
+    }));
+  },
+};
+
 /** @type {import('esbuild').BuildOptions} */
 export const seaBuildOptions = {
   entryPoints: ["src/cli.js"],
@@ -169,6 +199,6 @@ export const seaBuildOptions = {
   // throws → collector returns available:false. npm installs get knip
   // resolved normally from node_modules.
   external: ["better-sqlite3", "madge", "knip", "oxc-parser", "oxc-resolver"],
-  plugins: [seaTransformPlugin, huBoardStubPlugin],
+  plugins: [seaTransformPlugin, huBoardStubPlugin, ragStubPlugin],
   logLevel: "info",
 };

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -3,6 +3,7 @@ import { triageCommand } from "../commands/triage.js";
 import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
+import { ragIndexCommand, ragQueryCommand } from "../commands/rag.js";
 import { auditCommand } from "../commands/audit.js";
 import { resumeCommand } from "../commands/resume.js";
 import { boardCommand } from "../commands/board.js";
@@ -95,6 +96,27 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "onboard", flags, async ({ config, logger }) => {
         await onboardCommand({ config, logger, flags });
+      });
+    });
+
+  const rag = program.command("rag").description("Retrieval-augmented search over Karajan plans, onboarding briefs and project code");
+  rag.command("index")
+    .description("Index plans + onboarding (and optionally project sources) into the local vector store")
+    .option("--with-sources", "Also index the projectDir's JS/TS files")
+    .option("--json", "Output the totals as JSON")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "rag-index", flags, async ({ config, logger }) => {
+        await ragIndexCommand({ config, logger, flags });
+      });
+    });
+  rag.command("query <text>")
+    .description("Run a semantic query against the indexed RAG corpus")
+    .option("--scope <scope>", "plans | code | onboarding | all (default: all)", "all")
+    .option("--top-k <n>", "Number of hits to return (default: 5)", "5")
+    .option("--json", "Output the hits as JSON")
+    .action(async (text, flags) => {
+      await withConfig(pkgVersion, "rag-query", flags, async ({ config, logger }) => {
+        await ragQueryCommand({ text, config, logger, flags });
       });
     });
 

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -1,0 +1,66 @@
+// KJC-PCS-0049 Step 6 — `kj rag` command group. Two subcommands:
+//   kj rag index [--project <slug>] [--with-sources]
+//   kj rag query <text>   [--scope plans|code|onboarding|all] [--top-k N] [--json]
+// Closes the v2.22.0 RAG MVP end-to-end from the terminal.
+import { openVecStore, countChunks } from "../rag/vec-store.js";
+import { OllamaEmbedder } from "../rag/embedder.js";
+import { indexProject } from "../rag/indexer.js";
+import { query } from "../rag/retriever.js";
+import { getKarajanHome } from "../utils/paths.js";
+
+function makeEmbedder(config) {
+  const cfg = config?.rag?.embedder || {};
+  return new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim: cfg.dim });
+}
+
+function openDb(config) {
+  return openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
+}
+
+export async function ragIndexCommand({ config, logger, flags = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const db = openDb(config);
+  try {
+    const totals = await indexProject(projectDir, {
+      db, embedder: makeEmbedder(config),
+      karajanHome: getKarajanHome(), logger,
+      withSources: Boolean(flags.withSources),
+    });
+    if (flags.json) {
+      process.stdout.write(`${JSON.stringify(totals)}\n`);
+    } else {
+      logger.info(`[rag] indexed ${totals.indexed} chunk(s) across ${totals.files} file(s) (${totals.failed} failed)`);
+    }
+    return totals;
+  } finally {
+    db.close();
+  }
+}
+
+export async function ragQueryCommand({ text, config, logger, flags = {} }) {
+  if (!text) throw new Error("kj rag query: text argument required");
+  const db = openDb(config);
+  try {
+    if (countChunks(db) === 0) {
+      logger.warn("[rag] No chunks indexed yet. Run 'kj rag index' first.");
+      if (flags.json) process.stdout.write("[]\n");
+      return [];
+    }
+    const topK = Math.max(1, Number(flags.topK) || 5);
+    const scope = flags.scope || "all";
+    const hits = await query(db, makeEmbedder(config), text, { topK, scope });
+    if (flags.json) {
+      process.stdout.write(`${JSON.stringify(hits)}\n`);
+    } else {
+      for (const h of hits) {
+        const label = h.metadata?.hu_id || h.metadata?.symbol || h.metadata?.headingPath?.join(" > ") || "block";
+        logger.info(`[${h.kind} · ${label} · score=${h.score.toFixed(4)}] ${h.source}`);
+        logger.info(h.text.length > 240 ? `${h.text.slice(0, 240)}…` : h.text);
+        logger.info("");
+      }
+    }
+    return hits;
+  } finally {
+    db.close();
+  }
+}

--- a/tests/rag/commands.test.js
+++ b/tests/rag/commands.test.js
@@ -1,0 +1,72 @@
+// KJC-PCS-0049 Step 6 — kj rag command acceptance pins.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+vi.mock("../../src/rag/embedder.js", () => {
+  class FakeEmbedder {
+    constructor() { this.dim = 8; }
+    async embed() { const v = new Float32Array(8); v[0] = 1; return v; }
+    async embedBatch(ts) { return ts.map(() => { const v = new Float32Array(8); v[0] = 1; return v; }); }
+  }
+  return { OllamaEmbedder: FakeEmbedder, OllamaEmbedderError: class extends Error {} };
+});
+
+describe("kj rag commands — KJC-PCS-0049 Step 6", () => {
+  let root, prevHome, prevDb;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-rag-cmd-"));
+    prevHome = process.env.KARAJAN_HOME;
+    prevDb = process.env.KJ_RAG_DB;
+    process.env.KARAJAN_HOME = join(root, ".karajan");
+    process.env.KJ_RAG_DB = join(root, "rag.db");
+    mkdirSync(process.env.KARAJAN_HOME, { recursive: true });
+    noopLogger.info.mockClear();
+    noopLogger.warn.mockClear();
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = prevHome;
+    if (prevDb === undefined) delete process.env.KJ_RAG_DB; else process.env.KJ_RAG_DB = prevDb;
+  });
+
+  it("ragIndexCommand reports totals from indexProject", async () => {
+    const { ragIndexCommand } = await import("../../src/commands/rag.js");
+    const slug = "myp";
+    const projectDir = join(root, slug);
+    mkdirSync(projectDir);
+    mkdirSync(join(process.env.KARAJAN_HOME, "plans", slug), { recursive: true });
+    writeFileSync(
+      join(process.env.KARAJAN_HOME, "plans", slug, "plan-001.json"),
+      JSON.stringify({ hus: [{ id: "A", title: "alpha", description: "do A" }] })
+    );
+    const totals = await ragIndexCommand({ config: { projectDir, rag: { embedder: { dim: 8 } } }, logger: noopLogger, flags: {} });
+    expect(totals.files).toBeGreaterThan(0);
+    expect(totals.indexed).toBeGreaterThan(0);
+  });
+
+  it("ragQueryCommand on an empty store warns and returns []", async () => {
+    const { ragQueryCommand } = await import("../../src/commands/rag.js");
+    const hits = await ragQueryCommand({ text: "anything", config: { rag: { embedder: { dim: 8 } } }, logger: noopLogger, flags: {} });
+    expect(hits).toEqual([]);
+    expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringMatching(/No chunks indexed/));
+  });
+
+  it("ragQueryCommand returns hits after indexing", async () => {
+    const { ragIndexCommand, ragQueryCommand } = await import("../../src/commands/rag.js");
+    const slug = "p2";
+    const projectDir = join(root, slug);
+    mkdirSync(projectDir);
+    mkdirSync(join(process.env.KARAJAN_HOME, "plans", slug), { recursive: true });
+    writeFileSync(
+      join(process.env.KARAJAN_HOME, "plans", slug, "plan-001.json"),
+      JSON.stringify({ hus: [{ id: "A", title: "alpha auth", description: "do A" }] })
+    );
+    await ragIndexCommand({ config: { projectDir, rag: { embedder: { dim: 8 } } }, logger: noopLogger, flags: {} });
+    const hits = await ragQueryCommand({ text: "auth", config: { projectDir, rag: { embedder: { dim: 8 } } }, logger: noopLogger, flags: { topK: 3 } });
+    expect(hits.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Sixth and **final** PR for the Project RAG epic (KJC-PCS-0049). Closes v2.22.0 end-to-end from the terminal.

## What ships

`src/commands/rag.js` — two orchestrators:

- `ragIndexCommand` — opens the vec store, builds an OllamaEmbedder, calls `indexer.indexProject()` with `--with-sources` gated.
- `ragQueryCommand` — embeds the query, calls `retriever.query()`, prints each hit as a three-line block with the most specific metadata label (hu_id > symbol > headingPath > 'block').

`src/cli/register-meta.js` — new command group sitting next to `kj onboard`:

```bash
kj rag index [--with-sources] [--json]
kj rag query <text> [--scope plans|code|onboarding|all] [--top-k N] [--json]
```

Flags forwarded through the explicit whitelist (KJC-TSK-0397 lesson — no dropped flags).

## End-to-end

```bash
cd ~/ws_firebase/my-project
kj onboard                       # Architecture Brief
kj plan generate task.md -y      # plan-*.json in ~/.karajan/plans/<slug>/
kj rag index                     # seed the vec store
kj rag query 'how did I handle auth?'
```

## Tests

`tests/rag/commands.test.js` — 3 acceptance tests with a mocked `OllamaEmbedder` (zero network):

- `ragIndexCommand` reports totals from indexProject
- `ragQueryCommand` on empty store warns + returns []
- Full index-then-query round-trip returns hits

## LOC

+160 net. Inside 200 hard.

## Why no MCP / HU Board panel here

Always the v2.22.0 → v2.23.0 split: CLI end-to-end first so the user can validate the pipeline against their own plans; MCP + Board panel after the CLI shape is proven. Step 7 (kj_rag_query MCP tool) and Step 8 (Board search panel) ship in v2.23.0.

Project RAG epic KJC-PCS-0049 → **v2.22.0 ready to release.**