### PR TITLE
chore: release v2.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.22.0] - 2026-05-24
+
+Minor release. **Project RAG epic (KJC-PCS-0049) MVP** ships in six PRs: Karajan now indexes plans + onboarding briefs (and optionally project sources) into a local vector store and lets you query them semantically from the CLI.
+
+### Added
+
+- **`kj rag` command group** (KJC-TSK-0428, PR #813). Two subcommands:
+  - `kj rag index [--with-sources] [--json]` — runs `indexer.indexProject()` on the current project: every `~/.karajan/plans/<slug>/plan-*.json` + `~/.karajan/onboarding/<slug>.md` is chunked, embedded and persisted. With `--with-sources` also walks `.js/.ts/.tsx/.jsx` (skipping `node_modules`, `.git`, `dist`).
+  - `kj rag query <text> [--scope plans|code|onboarding|all] [--top-k N] [--json]` — embeds the query, fetches top-K nearest, reranks by kind (plan +0.05, onboarding +0.03, code 0), prints each hit with its most-specific label.
+- **Vector store on better-sqlite3 + sqlite-vec** (KJC-TSK-0423, PR #808). `~/.karajan/rag.db` (override via `KJ_RAG_DB`). New dep `sqlite-vec ^0.1.9`.
+- **Ollama embedder adapter** (KJC-TSK-0424, PR #809). `OllamaEmbedder.embed/embedBatch` against the local Ollama endpoint. Defaults `localhost:11434` + `nomic-embed-text` + dim 768. Zero new deps.
+- **Three chunkers** (KJC-TSK-0425, PR #810). `chunkMarkdown` (heading hierarchy), `chunkPlan` (one chunk per HU), `chunkSource` (JS/TS export-symbol via regex). Shared windowed splitter for oversized sections.
+- **Indexer** (KJC-TSK-0426, PR #811). `indexFile` + `indexProject`. Idempotent — calls `deleteChunksBySource` before re-indexing. Embedder failures = `warn` + continue.
+- **Retriever** (KJC-TSK-0427, PR #812). `query(db, embedder, text, { topK, scope, kindBoost })` — over-fetches `topK*2`, applies kind boosts, returns ranked hits with metadata.
+
+### SEA binary
+
+`src/rag/*` + `src/commands/rag.js` join `packages/hu-board/src/*` in the list of modules the SEA bundle stubs out (`scripts/esbuild-sea.config.mjs::ragStubPlugin`). The standalone binary points users at `npm install -g karajan-code` for RAG.
+
+### End-to-end workflow
+
+```bash
+cd ~/your-project
+kj onboard                       # Architecture Brief at ~/.karajan/onboarding/<slug>.md
+kj plan generate task.md -y      # Plans at ~/.karajan/plans/<slug>/plan-*.json
+kj rag index                     # Seed the vec store
+kj rag query "how did I handle auth in module X?"
+```
+
+### Out of scope (v2.23.0+)
+
+MCP tool `kj_rag_query`, HU Board search panel, chokidar watcher for live re-indexing, AST-aware source chunker, BM25 + cosine hybrid scoring.
+
 ## [2.21.0] - 2026-05-24
 
 Minor release. **Brownfield Onboarder role**: Karajan now ships a dedicated path to bootstrap an Architecture Brief from any existing codebase, and the planner can consume that brief as automatic context. Closes KJC-TSK-0384 in three PRs.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,29 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.22.0 released** — Minor. **Project RAG MVP** (KJC-PCS-0049). Karajan now indexes its plans + onboarding briefs (and optionally project sources) into a local vector store and lets you query them semantically from the CLI. Six PRs.
+>
+> | Step | PR | Module |
+> |---|---|---|
+> | 1 | #808 | Vector store on `better-sqlite3` + `sqlite-vec` at `~/.karajan/rag.db` |
+> | 2 | #809 | Ollama embedder adapter (`nomic-embed-text`, dim 768, `localhost:11434`) |
+> | 3 | #810 | Three chunkers: markdown heading hierarchy, plan JSON per-HU, JS/TS export-symbol |
+> | 4 | #811 | Indexer (`indexFile` + `indexProject`), idempotent, embedder failures = warn + continue |
+> | 5 | #812 | Retriever + ranking, kind boost breaks ties (plan +0.05, onboarding +0.03, code 0) |
+> | 6 | #813 | `kj rag` CLI: `index [--with-sources]` + `query <text> [--scope] [--top-k]` |
+>
+> ```bash
+> cd ~/your-project
+> kj onboard                       # Architecture Brief
+> kj plan generate task.md -y      # Plans
+> kj rag index                     # Seed the vec store
+> kj rag query "how did I handle auth in module X?"
+> ```
+>
+> **Coming in v2.23.0**: MCP tool `kj_rag_query` (other agents query the RAG), HU Board search panel, chokidar watcher for live re-indexing, AST-aware source chunker, BM25 + cosine hybrid scoring.
+>
+> The SEA binary stubs out `src/rag/*` + `src/commands/rag.js` (same pattern as the HU Board) — `kj rag` requires `npm install -g karajan-code`.
+>
 > **v2.21.0 released** — Minor. **Brownfield Onboarder role**. Karajan now ships a dedicated path to analyze any existing codebase and produce a Markdown Architecture Brief that the planner can consume as automatic context. Closes KJC-TSK-0384 (3 PRs).
 >
 > KJC-TSK-0384 (PRs #804 + #805 + #806): **`kj onboard`** runs five deterministic collectors over a project root — directory walk (ignoring `node_modules` / `.git` / `dist` / `build`), git log (commits, branches, hot files via `--name-only` over the last 200 commits), 18 well-known config patterns + `package.json` scripts, ADR-style filenames under `docs/adr/`, `docs/adrs/`, `docs/architecture/`, plus a one-shot bundle. Then optionally synthesises a Markdown Architecture Brief via the new OnboarderRole. Output lands at `~/.karajan/onboarding/<slug>.md`. Flags: `--no-synth` (skip the LLM call, dump the raw collectors — useful for CI), `--output <path>` (override default target). Greenfield projects produce `# Project is greenfield` instead of erroring.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (52k LOC, 378 files)
+├── src/              # Source code (53k LOC, 384 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.21.0
+kj --version    # 2.22.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.21.0
+kj --version    # 2.22.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Minor release. **Project RAG epic (KJC-PCS-0049) MVP** ships in 6 PRs.

## Cards in v2.22.0

| Card | PR | Module |
|---|---|---|
| KJC-TSK-0423 | #808 | Vector store + sqlite-vec |
| KJC-TSK-0424 | #809 | Ollama embedder adapter |
| KJC-TSK-0425 | #810 | Chunker (markdown + plan + source) |
| KJC-TSK-0426 | #811 | Indexer |
| KJC-TSK-0427 | #812 | Retriever + ranking |
| KJC-TSK-0428 | #813 | kj rag CLI |

## Tests

5 400+ tests passing on Node 20 + Node 22 CI.

## Post-merge

- Tag v2.22.0 + GitHub Release
- npm publish (OTP needed)
- Landing deploy

## What's next (v2.23.0+)

MCP tool `kj_rag_query`, HU Board search panel, chokidar watcher for live re-indexing, AST-aware source chunker, BM25 + cosine hybrid scoring.