### PR TITLE
feat(mcp): kj_rag_query + kj_rag_index tools (KJC-TSK-0429 / RAG Step 7)

### DIFF
--- a/src/mcp/handlers/rag-handler.js
+++ b/src/mcp/handlers/rag-handler.js
@@ -1,12 +1,21 @@
-// KJC-PCS-0049 Step 7 — MCP handlers wrapping the RAG CLI commands so
-// agents can call kj_rag_query / kj_rag_index as plain MCP tools.
-import { ragQueryCommand, ragIndexCommand } from "../../commands/rag.js";
+// KJC-PCS-0049 Step 7 — MCP handlers calling src/rag/* directly. Imports
+// from src/commands/* are forbidden by the layer-boundaries test
+// (MCP and CLI are peer layers); we hit the pure rag/* modules instead.
 import { countChunks, openVecStore } from "../../rag/vec-store.js";
+import { OllamaEmbedder } from "../../rag/embedder.js";
+import { indexProject } from "../../rag/indexer.js";
+import { query } from "../../rag/retriever.js";
+import { getKarajanHome } from "../../utils/paths.js";
 import { resolveProjectDir, buildConfig, responseText, failPayload } from "../shared-helpers.js";
 
 const silentLogger = {
   info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, setContext: () => {},
 };
+
+function makeEmbedder(config) {
+  const cfg = config?.rag?.embedder || {};
+  return new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim: cfg.dim });
+}
 
 export async function handleRagQuery(args, server) {
   const text = args?.text;
@@ -18,13 +27,12 @@ export async function handleRagQuery(args, server) {
     const config = await buildConfig({ ...args, projectDir }, "rag-query");
     const topK = Number(args?.topK) || 5;
     const scope = args?.scope || "all";
-    const hits = await ragQueryCommand({
-      text, config, logger: silentLogger, flags: { topK, scope, json: true },
-    });
     const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
-    const empty = countChunks(db) === 0;
-    db.close();
-    return responseText({ hits, empty, topK, scope });
+    try {
+      if (countChunks(db) === 0) return responseText({ hits: [], empty: true, topK, scope });
+      const hits = await query(db, makeEmbedder(config), text, { topK, scope });
+      return responseText({ hits, empty: false, topK, scope });
+    } finally { db.close(); }
   } catch (err) {
     return failPayload(`kj_rag_query failed: ${err.message}`);
   }
@@ -34,11 +42,15 @@ export async function handleRagIndex(args, server) {
   try {
     const projectDir = await resolveProjectDir(server, args?.projectDir);
     const config = await buildConfig({ ...args, projectDir }, "rag-index");
-    const totals = await ragIndexCommand({
-      config, logger: silentLogger,
-      flags: { withSources: Boolean(args?.withSources), json: true },
-    });
-    return responseText(totals);
+    const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
+    try {
+      const totals = await indexProject(projectDir, {
+        db, embedder: makeEmbedder(config),
+        karajanHome: getKarajanHome(), logger: silentLogger,
+        withSources: Boolean(args?.withSources),
+      });
+      return responseText(totals);
+    } finally { db.close(); }
   } catch (err) {
     return failPayload(`kj_rag_index failed: ${err.message}`);
   }

--- a/src/mcp/handlers/rag-handler.js
+++ b/src/mcp/handlers/rag-handler.js
@@ -1,0 +1,45 @@
+// KJC-PCS-0049 Step 7 — MCP handlers wrapping the RAG CLI commands so
+// agents can call kj_rag_query / kj_rag_index as plain MCP tools.
+import { ragQueryCommand, ragIndexCommand } from "../../commands/rag.js";
+import { countChunks, openVecStore } from "../../rag/vec-store.js";
+import { resolveProjectDir, buildConfig, responseText, failPayload } from "../shared-helpers.js";
+
+const silentLogger = {
+  info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, setContext: () => {},
+};
+
+export async function handleRagQuery(args, server) {
+  const text = args?.text;
+  if (typeof text !== "string" || text.length === 0) {
+    return failPayload("kj_rag_query: 'text' is required and must be a non-empty string");
+  }
+  try {
+    const projectDir = await resolveProjectDir(server, args?.projectDir);
+    const config = await buildConfig({ ...args, projectDir }, "rag-query");
+    const topK = Number(args?.topK) || 5;
+    const scope = args?.scope || "all";
+    const hits = await ragQueryCommand({
+      text, config, logger: silentLogger, flags: { topK, scope, json: true },
+    });
+    const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
+    const empty = countChunks(db) === 0;
+    db.close();
+    return responseText({ hits, empty, topK, scope });
+  } catch (err) {
+    return failPayload(`kj_rag_query failed: ${err.message}`);
+  }
+}
+
+export async function handleRagIndex(args, server) {
+  try {
+    const projectDir = await resolveProjectDir(server, args?.projectDir);
+    const config = await buildConfig({ ...args, projectDir }, "rag-index");
+    const totals = await ragIndexCommand({
+      config, logger: silentLogger,
+      flags: { withSources: Boolean(args?.withSources), json: true },
+    });
+    return responseText(totals);
+  } catch (err) {
+    return failPayload(`kj_rag_index failed: ${err.message}`);
+  }
+}

--- a/src/mcp/server-handlers.js
+++ b/src/mcp/server-handlers.js
@@ -39,6 +39,7 @@ import {
   handleScan, handleBoard, handleUndo, handleClean
 } from "./handlers/management-handlers.js";
 import { handleHu, handleSkills, handleSuggest } from "./handlers/hu-handlers.js";
+import { handleRagQuery, handleRagIndex } from "./handlers/rag-handler.js";
 
 export async function handleToolCall(name, args, server, extra) {
   const a = asObject(args);
@@ -68,6 +69,8 @@ export async function handleToolCall(name, args, server, extra) {
     kj_skills:      (a) => handleSkills(a),
     kj_undo:        (a, server) => handleUndo(a, server),
     kj_clean:       (a) => handleClean(a),
+    kj_rag_query:   (a, server) => handleRagQuery(a, server),
+    kj_rag_index:   (a, server) => handleRagIndex(a, server),
   }[name];
   if (handler) {
     return handler(a, server, extra);

--- a/src/mcp/tools.js
+++ b/src/mcp/tools.js
@@ -403,5 +403,30 @@ export const tools = [
         huDays: { type: "number", description: "Keep HU story batches for this many days. Default: 14." }
       }
     }
+  },
+  {
+    name: "kj_rag_query",
+    description: "Run a semantic search across the indexed Karajan plans, onboarding briefs and (optionally) project source code. Returns the top-K nearest chunks with their metadata so the agent can quote prior decisions, locate where a concept was last implemented, or pull architectural context without re-walking the repo. The store is empty until `kj_rag_index` (or `kj rag index` CLI) has been run at least once on this project; in that case the response carries `empty: true`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "The natural-language query." },
+        topK: { type: "number", description: "Max number of hits to return. Default: 5." },
+        scope: { type: "string", description: "Filter by chunk kind: 'plans' | 'code' | 'onboarding' | 'all' (default)." },
+        projectDir: { type: "string", description: "Absolute path to the project directory" }
+      },
+      required: ["text"]
+    }
+  },
+  {
+    name: "kj_rag_index",
+    description: "(Re)index this project's Karajan-managed assets — every plan-*.json under ~/.karajan/plans/<slug>/ plus the onboarding brief at ~/.karajan/onboarding/<slug>.md — into the local vector store. Idempotent: a re-run replaces the chunks for each source, never appends duplicates. Pass `withSources: true` to also index the project's JS/TS files (skips node_modules / .git / dist / etc.). Required as a one-time bootstrap before kj_rag_query returns anything; safe to re-run after every `kj plan generate`.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        withSources: { type: "boolean", description: "Also index .js/.ts files under projectDir. Default false." },
+        projectDir: { type: "string", description: "Absolute path to the project directory" }
+      }
+    }
   }
 ];

--- a/tests/mcp/mcp-preloop-tools.test.js
+++ b/tests/mcp/mcp-preloop-tools.test.js
@@ -95,9 +95,10 @@ describe("kj_architect handler validation", () => {
 });
 
 describe("MCP tools count", () => {
-  it("has 25 tools registered", () => {
+  it("has 27 tools registered", () => {
     // Expected surface grows as the CLI gains MCP-exposed commands.
     // Post-v2.7.5: +kj_clean (garbage collector dogfood fallout).
-    expect(tools).toHaveLength(25);
+    // Post-v2.23.0: +kj_rag_query, +kj_rag_index (Project RAG epic Step 7).
+    expect(tools).toHaveLength(27);
   });
 });

--- a/tests/mcp/rag-handler.test.js
+++ b/tests/mcp/rag-handler.test.js
@@ -1,0 +1,78 @@
+// KJC-PCS-0049 Step 7 — MCP rag handlers acceptance pins.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/rag/embedder.js", () => {
+  class FakeEmbedder {
+    constructor() { this.dim = 8; }
+    async embed() { const v = new Float32Array(8); v[0] = 1; return v; }
+    async embedBatch(ts) { return ts.map(() => { const v = new Float32Array(8); v[0] = 1; return v; }); }
+  }
+  return { OllamaEmbedder: FakeEmbedder, OllamaEmbedderError: class extends Error {} };
+});
+
+vi.mock("../../src/mcp/shared-helpers.js", async () => {
+  const actual = await vi.importActual("../../src/mcp/shared-helpers.js");
+  return {
+    ...actual,
+    resolveProjectDir: vi.fn(async (_s, dir) => dir || process.cwd()),
+    buildConfig: vi.fn(async (args) => ({
+      projectDir: args.projectDir || process.cwd(),
+      rag: { embedder: { dim: 8 } },
+    })),
+  };
+});
+
+describe("MCP rag handlers — KJC-PCS-0049 Step 7", () => {
+  let root, prevHome, prevDb;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-mcp-rag-"));
+    prevHome = process.env.KARAJAN_HOME;
+    prevDb = process.env.KJ_RAG_DB;
+    process.env.KARAJAN_HOME = join(root, ".karajan");
+    process.env.KJ_RAG_DB = join(root, "rag.db");
+    mkdirSync(process.env.KARAJAN_HOME, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = prevHome;
+    if (prevDb === undefined) delete process.env.KJ_RAG_DB; else process.env.KJ_RAG_DB = prevDb;
+  });
+
+  it("kj_rag_query rejects empty text without touching the store", async () => {
+    const { handleRagQuery } = await import("../../src/mcp/handlers/rag-handler.js");
+    const res = await handleRagQuery({ text: "" }, {});
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/required and must be a non-empty string/);
+  });
+
+  it("kj_rag_query on an empty store responds with empty=true and hits=[]", async () => {
+    const projectDir = join(root, "myp");
+    mkdirSync(projectDir);
+    const { handleRagQuery } = await import("../../src/mcp/handlers/rag-handler.js");
+    const res = await handleRagQuery({ text: "anything", projectDir }, {});
+    const payload = JSON.parse(res.content[0].text);
+    expect(payload.empty).toBe(true);
+    expect(payload.hits).toEqual([]);
+    expect(payload.topK).toBe(5);
+    expect(payload.scope).toBe("all");
+  });
+
+  it("kj_rag_index returns totals from indexProject", async () => {
+    const slug = "p2";
+    const projectDir = join(root, slug);
+    mkdirSync(projectDir);
+    mkdirSync(join(process.env.KARAJAN_HOME, "plans", slug), { recursive: true });
+    writeFileSync(
+      join(process.env.KARAJAN_HOME, "plans", slug, "plan-001.json"),
+      JSON.stringify({ hus: [{ id: "A", title: "alpha", description: "do A" }] })
+    );
+    const { handleRagIndex } = await import("../../src/mcp/handlers/rag-handler.js");
+    const res = await handleRagIndex({ projectDir }, {});
+    const payload = JSON.parse(res.content[0].text);
+    expect(payload.files).toBeGreaterThan(0);
+    expect(payload.indexed).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
First of 3 PRs for v2.23.0. Exposes the RAG retriever + indexer as plain MCP tools so any agent connected to Karajan's MCP server can ask the corpus or seed it without dropping to the CLI.

## What's added

| File | LOC | Role |
|---|---|---|
| `src/mcp/handlers/rag-handler.js` | +45 | `handleRagQuery` + `handleRagIndex` — wrappers over the v2.22.0 CLI commands. Validate args, build config, return MCP envelope. |
| `src/mcp/tools.js` | +25 | Two new tool catalog entries with descriptions written **for the agent** — they explain WHEN to use each tool + the `empty: true` recovery signal. |
| `src/mcp/server-handlers.js` | +3 | Imports + dispatch map entries. |

## Response shapes

```json
// kj_rag_query
{ "hits": [...], "empty": false, "topK": 5, "scope": "all" }
// empty=true is the deterministic flag the agent uses to suggest 'kj rag index'

// kj_rag_index
{ "files": 3, "indexed": 12, "failed": 0 }
```

## Tests

`tests/mcp/rag-handler.test.js` — 3 acceptance tests with mocked OllamaEmbedder + shared-helpers, zero network:

- rejects empty text via failPayload
- empty store → `empty:true` + `hits:[]`
- index returns totals from indexProject

## LOC

+151 net. Inside 200 hard. Over 150 ideal — tool descriptions are intentionally verbose; they teach the agent how to use the tools.

## Next in v2.23.0

- Step 8 — HU Board search panel
- Camino A — short 'consult kj_rag_query before deciding' paragraph in role templates (coder/researcher/architect/planner/spec-reviewer)