### PR TITLE
feat(board): RAG search panel + /api/rag/query endpoint (KJC-TSK-0430 / RAG Step 8)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -590,6 +590,18 @@ async function renderBoard() {
           Comprobando estado del proyecto…
         </div>
       </div>
+      <div id="rag-panel" class="rag-panel" style="margin:8px 0;display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap;">
+        <input id="rag-query" type="text" placeholder="🔍 RAG search: ask anything about this project's plans / onboarding / code…"
+               style="flex:1;min-width:260px;padding:6px 10px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);" />
+        <select id="rag-scope" style="padding:6px 10px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);">
+          <option value="all">All</option><option value="plans">Plans</option><option value="onboarding">Onboarding</option><option value="code">Code</option>
+        </select>
+        <button id="rag-search-btn" class="control-btn"
+                style="padding:6px 12px;font-size:0.85rem;background:var(--color-blue,#3b82f6);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;">
+          Search
+        </button>
+        <div id="rag-results" style="flex-basis:100%;font-size:0.8rem;color:var(--text-muted);"></div>
+      </div>
       <div id="plan-rollup-banner"></div>
       <div class="kanban">
         ${visibleColumns.map((c) => renderKanbanColumn(c.title, c.cls, c.rows)).join('')}
@@ -694,6 +706,39 @@ async function renderBoard() {
         }
       });
     }
+
+    // RAG search panel (KJC-PCS-0049 Step 8) — input + scope + render hits.
+    const ragInput = document.getElementById('rag-query');
+    const ragScope = document.getElementById('rag-scope');
+    const ragBtn = document.getElementById('rag-search-btn');
+    const ragResults = document.getElementById('rag-results');
+    async function runRagSearch() {
+      const text = ragInput?.value?.trim();
+      if (!text) return;
+      ragResults.innerHTML = '<em>Searching…</em>';
+      try {
+        const res = await fetch('/api/rag/query', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text, topK: 5, scope: ragScope?.value || 'all' }),
+        });
+        const body = await res.json();
+        if (!res.ok) { ragResults.innerHTML = `<span style="color:var(--color-red);">Error: ${esc(body.error || res.status)}</span>`; return; }
+        if (body.empty) { ragResults.innerHTML = '<em>No chunks indexed yet. Run <code>kj rag index</code> in this project\'s terminal first.</em>'; return; }
+        if (body.hits.length === 0) { ragResults.innerHTML = '<em>No hits.</em>'; return; }
+        ragResults.innerHTML = body.hits.map((h) => {
+          const label = h.metadata?.hu_id || h.metadata?.symbol || h.metadata?.headingPath?.join(' > ') || 'block';
+          const snippet = h.text.length > 240 ? `${esc(h.text.slice(0, 240))}…` : esc(h.text);
+          return `<div style="border-left:3px solid var(--color-blue,#3b82f6);padding:6px 10px;margin:6px 0;background:var(--bg-primary);">
+            <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:4px;">[${esc(h.kind)} · ${esc(label)} · score=${h.score.toFixed(4)}] ${esc(h.source)}</div>
+            <div style="font-size:0.85rem;white-space:pre-wrap;">${snippet}</div>
+          </div>`;
+        }).join('');
+      } catch (err) {
+        ragResults.innerHTML = `<span style="color:var(--color-red);">Error: ${esc(err.message)}</span>`;
+      }
+    }
+    ragBtn?.addEventListener('click', runRagSearch);
+    ragInput?.addEventListener('keydown', (e) => { if (e.key === 'Enter') runRagSearch(); });
   } catch (err) {
     app.innerHTML = `<div class="empty-state"><div class="empty-state__title">Error loading board</div><div class="empty-state__text">${esc(err.message)}</div></div>`;
   }

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1279,4 +1279,31 @@ router.post('/sync', (_req, res) => {
   }
 });
 
+/**
+ * POST /api/rag/query - Semantic search over the indexed RAG corpus
+ * (KJC-PCS-0049 Step 8). Body: { text, topK?, scope? }. Response:
+ * { hits: [...], empty, topK, scope }. Empty store carries empty=true
+ * so the UI can show an actionable hint instead of just empty results.
+ */
+router.post('/rag/query', async (req, res) => {
+  const { text, topK = 5, scope = 'all' } = req.body || {};
+  if (typeof text !== 'string' || text.length === 0) {
+    return res.status(400).json({ error: "'text' is required (non-empty string)" });
+  }
+  try {
+    const { openVecStore, countChunks } = await import('../../../../src/rag/vec-store.js');
+    const { OllamaEmbedder } = await import('../../../../src/rag/embedder.js');
+    const { query } = await import('../../../../src/rag/retriever.js');
+    const db = openVecStore({ dim: 768 });
+    try {
+      if (countChunks(db) === 0) return res.json({ hits: [], empty: true, topK, scope });
+      const embedder = new OllamaEmbedder({});
+      const hits = await query(db, embedder, text, { topK: Number(topK), scope });
+      res.json({ hits, empty: false, topK, scope });
+    } finally { db.close(); }
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 export default router;

--- a/packages/hu-board/tests/rag-endpoint.test.js
+++ b/packages/hu-board/tests/rag-endpoint.test.js
@@ -1,0 +1,74 @@
+// KJC-PCS-0049 Step 8 — POST /api/rag/query endpoint acceptance pins.
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../../src/rag/embedder.js", () => {
+  class FakeEmbedder {
+    constructor() { this.dim = 768; }
+    async embed() { const v = new Float32Array(768); v[0] = 1; return v; }
+    async embedBatch(ts) { return ts.map(() => { const v = new Float32Array(768); v[0] = 1; return v; }); }
+  }
+  return { OllamaEmbedder: FakeEmbedder, OllamaEmbedderError: class extends Error {} };
+});
+// Same module via the path the endpoint uses internally
+vi.mock("../../../../src/rag/embedder.js", () => {
+  class FakeEmbedder {
+    constructor() { this.dim = 768; }
+    async embed() { const v = new Float32Array(768); v[0] = 1; return v; }
+    async embedBatch(ts) { return ts.map(() => { const v = new Float32Array(768); v[0] = 1; return v; }); }
+  }
+  return { OllamaEmbedder: FakeEmbedder, OllamaEmbedderError: class extends Error {} };
+});
+
+let tmp, app;
+
+beforeAll(async () => {
+  tmp = mkdtempSync(join(tmpdir(), "hu-board-rag-api-"));
+  process.env.KJ_HOME = tmp;
+  process.env.KJ_RAG_DB = join(tmp, "rag.db");
+  const dbMod = await import("../src/db.js");
+  dbMod.initDb();
+  const { default: apiRoutes } = await import("../src/routes/api.js");
+  app = express();
+  app.use(express.json());
+  app.use("/api", apiRoutes);
+});
+
+afterAll(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_RAG_DB;
+});
+
+describe("POST /api/rag/query — KJC-PCS-0049 Step 8", () => {
+  it("rejects empty text with 400", async () => {
+    const res = await request(app).post("/api/rag/query").send({ text: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/non-empty string/);
+  });
+
+  it("responds with empty=true on a fresh store", async () => {
+    const res = await request(app).post("/api/rag/query").send({ text: "anything" });
+    expect(res.status).toBe(200);
+    expect(res.body.empty).toBe(true);
+    expect(res.body.hits).toEqual([]);
+    expect(res.body.topK).toBe(5);
+    expect(res.body.scope).toBe("all");
+  });
+
+  it("returns hits after seeding the vec store directly", async () => {
+    const { openVecStore, insertChunk } = await import("../../../src/rag/vec-store.js");
+    const db = openVecStore({ dim: 768 });
+    const vec = new Float32Array(768); vec[0] = 1;
+    insertChunk(db, { source: "/p", kind: "plan", text: "alpha auth", embedding: vec });
+    db.close();
+    const res = await request(app).post("/api/rag/query").send({ text: "auth", topK: 3 });
+    expect(res.status).toBe(200);
+    expect(res.body.empty).toBe(false);
+    expect(res.body.hits.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Second of 3 PRs for v2.23.0. Closes the loop Step 7 (#815) opened: anyone with the HU Board open in a browser can run the same semantic queries that an MCP-connected agent can.

## What's added

### Backend (`packages/hu-board/src/routes/api.js` +27 LOC)

```http
POST /api/rag/query
Body:     { text, topK = 5, scope = 'all' }
Response: { hits, empty, topK, scope }
```

Imports `src/rag/{vec-store,embedder,retriever}.js` directly — the neutral layer hu-board already consumes for atomic-write / plan-hu-ops. Validates non-empty text (400 if not); empty store responds `empty: true` so the UI can show an actionable hint.

### Frontend (`packages/hu-board/public/app.js` +45 LOC)

New `rag-panel` between the preflight panel and the kanban:

- `<input id='rag-query'>` (Enter triggers search)
- `<select id='rag-scope'>` (All / Plans / Onboarding / Code)
- `<button id='rag-search-btn'>`
- `<div id='rag-results'>`

`runRagSearch()` handles three responses: error → red message; empty store → italic hint pointing at `kj rag index`; hits → bordered cards with kind + label + score + source + truncated text (240 chars). Label rule = most-specific metadata (`hu_id` > `symbol` > `headingPath` > `'block'`), matching the CLI.

## Tests

`packages/hu-board/tests/rag-endpoint.test.js` (74 LOC, 3 acceptance tests via supertest, mocked embedder):

- rejects empty text → 400
- empty store → 200 + `empty:true`
- after seeding the vec store directly, returns hits

## Layer / mocking note

The OllamaEmbedder is mocked **both** at the test's relative path AND the endpoint's relative path — vitest matches the exact specifier each module imports, so mocking only one path lets the other through. Recorded as a comment in case future tests trip on the same.

## LOC

+146 net. Inside 200 hard / under 150 ideal.

## Next

Camino A — short `consult kj_rag_query before deciding` paragraph in role templates. Last PR of v2.23.0.