### PR TITLE
docs(roles): kj_rag_query availability note in 5 templates (KJC-TSK-0431 / RAG Camino A)

### DIFF
--- a/templates/roles/architect.md
+++ b/templates/roles/architect.md
@@ -70,3 +70,7 @@ Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds
 - The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
 - Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
 - Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.
+
+## Prior context (RAG, opt-in)
+
+If a design decision touches an area the project already shaped (layering, patterns, contract style), call the `kj_rag_query` MCP tool with `{ text, topK: 3, scope: "all" }` and align your `tradeoffs` / `patterns` with what the prior plans already used. When the response carries `empty: true`, the corpus has not been indexed — proceed without it; do NOT block on retrieval.

--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -110,3 +110,7 @@ Return a JSON object:
   "summary": "Human-readable summary of changes"
 }
 ```
+
+## Prior context (RAG, opt-in)
+
+If you need to know how the project handled a similar concern before (auth, error model, retry policy, naming convention…), call the `kj_rag_query` MCP tool with `{ text, topK: 3, scope: "all" }`. It returns the closest chunks from prior plans + onboarding brief + indexed sources. When the response carries `empty: true`, the corpus has not been indexed yet — proceed without it; do NOT block on retrieval, and do NOT ask the human to run `kj rag index`. Use sparingly: one query per concern, not per file.

--- a/templates/roles/planner.md
+++ b/templates/roles/planner.md
@@ -55,3 +55,7 @@ Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds
 - The gate counts the SUM of every changed file, not per-file. Tests count too. 5 files × 40 LOC = 200 = on the limit.
 - Excluded from the count: lockfiles, snapshots, `dist/`, `node_modules/`, generated `tests/_diet/`, `public/docs/`. Source + tests count.
 - Token-economy: oversized PRs get rejected at CI and the work is redone — partitioning upfront saves the round-trip.
+
+## Prior context (RAG, opt-in)
+
+Before emitting blocked_by graphs, dependencies, or reuse markers, query the local RAG corpus via the `kj_rag_query` MCP tool with `{ text, topK: 5, scope: "plans" }` to see how previous plans wired similar HUs. If a prior plan already produced the utility/spike the new plan would need, mark `reuse: ["<that-hu-id>"]` instead of re-implementing. When `empty: true`, the corpus has not been indexed — proceed without retrieval; do NOT block on it.

--- a/templates/roles/researcher.md
+++ b/templates/roles/researcher.md
@@ -35,3 +35,7 @@ You are the **Researcher** in a multi-role AI pipeline. Your job is to investiga
   "summary": "Research complete: 5 files affected, 2 risks identified"
 }
 ```
+
+## Prior context (RAG, opt-in)
+
+Before re-walking the repo, query the local RAG corpus via the `kj_rag_query` MCP tool with `{ text, topK: 5, scope: "plans" }` to surface decisions, hot files and ADR mentions captured in past plans + onboarding brief. When the response carries `empty: true`, the corpus has not been indexed yet — proceed with file-level research; do NOT block on retrieval. Quote retrieved evidence as bullet items under your `affects` list when relevant; do NOT paste raw chunks into the summary.

--- a/templates/roles/spec-reviewer.md
+++ b/templates/roles/spec-reviewer.md
@@ -36,3 +36,7 @@ is the WORST of any finding, or `ok` if findings is empty.
 
 Direct, accionable. No moralising. `suggestion` must be concrete (a paste-able
 sentence), not vague advice.
+
+## Prior context (RAG, opt-in)
+
+When evaluating whether the spec duplicates a prior plan's scope or contradicts an ADR, call the `kj_rag_query` MCP tool with `{ text, topK: 3, scope: "all" }` using a phrase from the spec as the query. If retrieved chunks describe overlapping HUs already approved, surface the conflict via a finding with `kind: "scope_overlap"` and reference the prior HU id. When `empty: true`, the corpus has not been indexed — proceed without retrieval; do NOT block on it.


### PR DESCRIPTION
Third and **final** PR for v2.23.0. Closes the gap Step 7 (#815) opened: the MCP tool exists, but until the role templates mention it, agents won't think to call it.

## What's added

Each of the 5 role templates gains a short 'Prior context (RAG, opt-in)' section, tailored to what THAT role would query:

| Template | Phrasing | Args suggested |
|---|---|---|
| `coder.md` | 'how the project handled a similar concern before (auth, error model, retry policy, naming convention…)' | `topK: 3, scope: 'all'` |
| `researcher.md` | 'before re-walking the repo' | `topK: 5, scope: 'plans'` |
| `architect.md` | 'a design decision touching an area the project already shaped (layering, patterns, contract style)' | `topK: 3, scope: 'all'` |
| `planner.md` | 'before emitting blocked_by graphs, dependencies, or reuse markers' | `topK: 5, scope: 'plans'` |
| `spec-reviewer.md` | 'evaluating whether the spec duplicates a prior plan's scope or contradicts an ADR' | `topK: 3, scope: 'all'` |

## Shared guardrail across all five

Every block ends with the same rule: **when the response carries `empty: true` (no chunks indexed yet), proceed without retrieval, do NOT block on it, do NOT ask the human to run `kj rag index`**. The corpus is opt-in by design — agents that block on empty stores degrade the UX for greenfield projects.

## LOC

+20 LOC total (5 templates × 4 LOC each). AI-rule files cohort, but well inside budget.

## v2.23.0 ready to release after this merges

3 PRs in the bag:
- #815 — Step 7 MCP tool
- #816 — Step 8 HU Board panel
- #817 — Camino A role templates