### PR TITLE
chore: release v2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.23.0] - 2026-05-24
+
+Minor release. **RAG exposed to agents and humans alike**: closes Steps 7 + 8 + Camino A of the Project RAG epic (KJC-PCS-0049).
+
+### Added
+
+- **`kj_rag_query` + `kj_rag_index` MCP tools** (KJC-TSK-0429, PR #815). Tool count 25 → 27. Empty store responds `empty: true`.
+- **HU Board RAG search panel + `/api/rag/query` endpoint** (KJC-TSK-0430, PR #816). Input + scope dropdown + Search button + results pane between preflight and kanban.
+- **Role templates teach agents about the tool** (KJC-TSK-0431, PR #817). `templates/roles/{coder,researcher,architect,planner,spec-reviewer}.md` gain tailored 'Prior context (RAG, opt-in)' sections.
+
+### Workflow
+
+```bash
+kj onboard                              # one-time per project
+kj rag index                            # one-time per project
+kj plan generate task.md --use-onboarding
+# Agents call kj_rag_query via MCP, humans use the Board panel.
+```
+
+### Out of scope (v2.24.0+)
+
+Camino B (slash command for Skills hosts), Camino C (pre-loop stage with automatic retrieval), Camino D (Brain decisor for when to retrieve), chokidar watcher, AST source chunker, BM25 hybrid scoring.
+
 ## [2.22.0] - 2026-05-24
 
 Minor release. **Project RAG epic (KJC-PCS-0049) MVP** ships in six PRs: Karajan now indexes plans + onboarding briefs (and optionally project sources) into a local vector store and lets you query them semantically from the CLI.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,24 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.23.0 released** — Minor. **RAG exposed to agents and humans alike** (KJC-PCS-0049, Steps 7+8+Camino A). After v2.22.0's CLI MVP, the corpus is now reachable from three more places.
+>
+> 1. **MCP tools** `kj_rag_query` + `kj_rag_index` (PR #815). Any MCP-connected agent — Claude Desktop, Cursor, Claude Code, Karajan's own roles — can call them. Tool count 25 → 27. Empty store responds `empty: true` so agents have a deterministic recovery signal.
+> 2. **HU Board RAG panel** (PR #816). New input + scope dropdown (All / Plans / Onboarding / Code) + Search button + results pane between the preflight panel and the kanban. `POST /api/rag/query` backs it.
+> 3. **Role templates teach agents about the tool** (PR #817). `templates/roles/{coder,researcher,architect,planner,spec-reviewer}.md` each gain a tailored 'Prior context (RAG, opt-in)' section. Shared rule: when the store is empty, proceed without retrieval — do NOT block, do NOT ask the human to seed.
+>
+> Workflow:
+>
+> ```bash
+> kj onboard
+> kj rag index
+> kj plan generate task.md --use-onboarding
+> # From here on, every agent invocation can call kj_rag_query via MCP.
+> # Humans get the panel on the Board.
+> ```
+>
+> **Coming in v2.24.0+**: Camino B (`/kj-rag-query` slash command for hosts in Skills mode without MCP), Camino C (automatic pre-loop stage that pre-fetches retrieval and prepends it to the coder/researcher/architect prompt without the agent having to ask), Camino D (Brain decisor heuristic for when retrieval is worth the tokens), chokidar watcher for live re-indexing, AST-aware source chunker, BM25 + cosine hybrid scoring.
+>
 > **v2.22.0 released** — Minor. **Project RAG MVP** (KJC-PCS-0049). Karajan now indexes its plans + onboarding briefs (and optionally project sources) into a local vector store and lets you query them semantically from the CLI. Six PRs.
 >
 > | Step | PR | Module |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (53k LOC, 384 files)
+├── src/              # Source code (53k LOC, 385 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.22.0
+kj --version    # 2.23.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.22.0
+kj --version    # 2.23.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Minor release. **RAG exposed to agents and humans alike** (KJC-PCS-0049 Steps 7+8+Camino A).

## Cards in v2.23.0

| Card | PR | What |
|---|---|---|
| KJC-TSK-0429 | #815 | kj_rag_query + kj_rag_index MCP tools |
| KJC-TSK-0430 | #816 | HU Board RAG search panel + /api/rag/query |
| KJC-TSK-0431 | #817 | Role templates teach kj_rag_query availability |

## Tests

5 400+ tests passing on Node 20 + Node 22 CI.

## Post-merge

- Tag v2.23.0 + GitHub Release
- npm publish (OTP needed)
- Landing deploy

## What's next (v2.24.0+)

Camino B (Skills slash command), Camino C (pre-loop auto-retrieval), Camino D (Brain decisor for retrieval), chokidar watcher, AST source chunker, BM25 hybrid scoring.