### PR TITLE
feat(orchestrator): RAG pre-loop auto-retrieval stage (KJC-TSK-0432 / RAG Camino C)

### DIFF
--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -40,6 +40,7 @@ import {
   runResearcherStage, runArchitectStage, runPlannerStage,
   runDiscoverStage, runHuReviewerStage,
 } from "../pre-loop-stages.js";
+import { runRagContextStage } from "../stages/rag-context-stage.js";
 // TSK-0336: triage goes through the StageRegistry / StageExecutor contract
 // so canRun / execute / onFailure are actually exercised in production.
 // The registry is a singleton with TriageStage / CoderStage / ReviewerStage
@@ -122,6 +123,20 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
   const triageResult = await runStage(stageRegistry.get("triage"), triageCtx) ?? { roleOverrides: null, stageResult: null };
   applyTriageOverrides(pipelineFlags, triageResult.roleOverrides);
   await persistStage("triage", triageResult.stageResult);
+
+  // --- RAG preload (KJC-PCS-0049 Camino C, opt-in) ---
+  // Runs only when config.rag.preload.enabled === true. Queries the local
+  // vector store with the task description, prepends the top-K chunks to
+  // the task as a markdown block so researcher/architect/planner/coder
+  // all see prior context without having to call kj_rag_query themselves.
+  // Empty store / network / etc. degrade to no-op via the stage itself.
+  if (!resumeSkip("ragPreload")) {
+    const ragRes = await runRagContextStage({ config, logger, emitter, eventBase, task });
+    if (!ragRes.skipped && ragRes.contextBlock) {
+      task = `${task}\n\n${ragRes.contextBlock}`;
+      await persistStage("ragPreload", { hits: ragRes.hits.length, scope: config?.rag?.preload?.scope || "all" });
+    }
+  }
 
   // --- Brain decisor (opt-in, intent-driven routing) ---
   //

--- a/src/orchestrator/stages/rag-context-stage.js
+++ b/src/orchestrator/stages/rag-context-stage.js
@@ -1,0 +1,60 @@
+// KJC-PCS-0049 Camino C — pre-loop RAG retrieval stage.
+// Runs between triage and domainCurator. When `config.rag.preload.enabled`
+// is true and the corpus has chunks, queries the retriever with the
+// task text and returns a markdown block ready to prepend to the task.
+// Failures degrade gracefully (warn + continue); the rest of the pipeline
+// never sees an exception from this stage.
+import { emitProgress, makeEvent } from "../../utils/events.js";
+import { openVecStore, countChunks } from "../../rag/vec-store.js";
+import { OllamaEmbedder } from "../../rag/embedder.js";
+import { query } from "../../rag/retriever.js";
+
+const DEFAULT_TOP_K = 5;
+const DEFAULT_SCOPE = "all";
+const MAX_CHUNK_CHARS = 600;
+
+/**
+ * Runs the RAG preload stage. Returns:
+ *   { skipped: true, reason }                  — when disabled / empty / error
+ *   { skipped: false, contextBlock, hits }     — markdown block + raw hits
+ *
+ * The caller decides whether to mutate `task` with the contextBlock. We
+ * keep that responsibility at the call site so this module stays pure.
+ */
+export async function runRagContextStage({ config, logger, emitter, eventBase, task }) {
+  const preload = config?.rag?.preload;
+  if (!preload?.enabled) return { skipped: true, reason: "disabled" };
+  if (typeof task !== "string" || task.length === 0) return { skipped: true, reason: "no-task" };
+  try {
+    const dim = config?.rag?.embedder?.dim || 768;
+    const db = openVecStore({ dim });
+    try {
+      if (countChunks(db) === 0) {
+        logger?.info?.("[rag-preload] corpus is empty, skipping (run `kj rag index` to seed)");
+        return { skipped: true, reason: "empty" };
+      }
+      const topK = preload.topK || DEFAULT_TOP_K;
+      const scope = preload.scope || DEFAULT_SCOPE;
+      const cfg = config?.rag?.embedder || {};
+      const embedder = new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim });
+      const hits = await query(db, embedder, task, { topK, scope });
+      if (hits.length === 0) return { skipped: true, reason: "no-hits" };
+      const lines = hits.map((h) => {
+        const label = h.metadata?.hu_id || h.metadata?.symbol || h.metadata?.headingPath?.join(" > ") || "block";
+        const text = h.text.length > MAX_CHUNK_CHARS ? `${h.text.slice(0, MAX_CHUNK_CHARS)}…` : h.text;
+        return `### [${h.kind} · ${label}] ${h.source}\n\n${text}`;
+      });
+      const contextBlock = `## Prior context from RAG (auto-retrieved, top ${hits.length})\n\n${lines.join("\n\n")}`;
+      emitProgress(emitter, makeEvent("rag-preload:hits", { ...eventBase, stage: "rag-preload" }, {
+        message: `RAG preload: injected ${hits.length} chunk(s) into the task context`,
+        detail: { topK, scope, hits: hits.length },
+      }));
+      return { skipped: false, contextBlock, hits };
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    logger?.warn?.(`[rag-preload] failed (non-blocking): ${err.message}`);
+    return { skipped: true, reason: "error", error: err.message };
+  }
+}

--- a/tests/orchestrator/rag-context-stage.test.js
+++ b/tests/orchestrator/rag-context-stage.test.js
@@ -1,0 +1,79 @@
+// KJC-PCS-0049 Camino C — pre-loop RAG retrieval stage acceptance pins.
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/rag/embedder.js", () => {
+  class FakeEmbedder {
+    constructor() { this.dim = 768; }
+    async embed() { const v = new Float32Array(768); v[0] = 1; return v; }
+  }
+  return { OllamaEmbedder: FakeEmbedder, OllamaEmbedderError: class extends Error {} };
+});
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const noopEmitter = { emit: vi.fn() };
+
+describe("rag-context-stage — KJC-PCS-0049 Camino C", () => {
+  let root, prevDb;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-rag-preload-"));
+    prevDb = process.env.KJ_RAG_DB;
+    process.env.KJ_RAG_DB = join(root, "rag.db");
+    noopLogger.info.mockClear(); noopLogger.warn.mockClear();
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (prevDb === undefined) delete process.env.KJ_RAG_DB; else process.env.KJ_RAG_DB = prevDb;
+  });
+
+  it("skips when config.rag.preload.enabled is missing or false", async () => {
+    const { runRagContextStage } = await import("../../src/orchestrator/stages/rag-context-stage.js");
+    const r1 = await runRagContextStage({ config: {}, logger: noopLogger, emitter: noopEmitter, task: "hi" });
+    expect(r1.skipped).toBe(true);
+    expect(r1.reason).toBe("disabled");
+    const r2 = await runRagContextStage({ config: { rag: { preload: { enabled: false } } }, logger: noopLogger, emitter: noopEmitter, task: "hi" });
+    expect(r2.skipped).toBe(true);
+  });
+
+  it("skips with reason='empty' on a fresh vec store", async () => {
+    mkdirSync(root, { recursive: true });
+    const { runRagContextStage } = await import("../../src/orchestrator/stages/rag-context-stage.js");
+    const r = await runRagContextStage({
+      config: { rag: { preload: { enabled: true }, embedder: { dim: 768 } } },
+      logger: noopLogger, emitter: noopEmitter, task: "anything",
+    });
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe("empty");
+    expect(noopLogger.info).toHaveBeenCalled();
+  });
+
+  it("returns contextBlock with prior context when chunks exist", async () => {
+    const { openVecStore, insertChunk } = await import("../../src/rag/vec-store.js");
+    const db = openVecStore({ dim: 768 });
+    const v = new Float32Array(768); v[0] = 1;
+    insertChunk(db, { source: "/p", kind: "plan", text: "Previously: auth used JWT.", metadata: { hu_id: "AUTH-1" }, embedding: v });
+    db.close();
+    const { runRagContextStage } = await import("../../src/orchestrator/stages/rag-context-stage.js");
+    const r = await runRagContextStage({
+      config: { rag: { preload: { enabled: true, topK: 3 }, embedder: { dim: 768 } } },
+      logger: noopLogger, emitter: noopEmitter, task: "implement auth",
+    });
+    expect(r.skipped).toBe(false);
+    expect(r.contextBlock).toContain("Prior context from RAG");
+    expect(r.contextBlock).toContain("AUTH-1");
+    expect(r.contextBlock).toContain("Previously: auth used JWT.");
+    expect(r.hits.length).toBeGreaterThan(0);
+  });
+
+  it("returns skipped + reason on missing task", async () => {
+    const { runRagContextStage } = await import("../../src/orchestrator/stages/rag-context-stage.js");
+    const r = await runRagContextStage({
+      config: { rag: { preload: { enabled: true } } },
+      logger: noopLogger, emitter: noopEmitter, task: "",
+    });
+    expect(r.skipped).toBe(true);
+    expect(r.reason).toBe("no-task");
+  });
+});


### PR DESCRIPTION
Camino C of the Project RAG integration plan. After Camino A (#817) the agents KNOW the tool exists; this PR makes Karajan **inject the context for them** — transparent, automatic, no MCP call from the agent required.

## Default: opt-in

`config.rag.preload.enabled = false` by default. Users flip it to `true` after dogfooding. The corpus only gets queried when the user signs the contract.

## What ships

**`src/orchestrator/stages/rag-context-stage.js` (60 LOC)** — five guards before retrieval ever fires (`disabled`, `no-task`, `empty` corpus, `no-hits`, `error`). All five degrade silently except `empty` (info log pointing at `kj rag index`). The stage never throws — best-effort enrichment, opt-out by default, opt-back-out on failure.

When all guards pass, returns:

```md
## Prior context from RAG (auto-retrieved, top N)

### [plan · AUTH-1] /path/to/plan.json

<chunk text, truncated 600 chars>

### [plan · …] …
```

Label rule (`hu_id > symbol > headingPath > 'block'`) matches the CLI renderer; agents see the same shape via tool calls and via pre-loop injection.

**`src/orchestrator/drivers/pre-loop.js` (+15 LOC)** — one if-block right after triage, before domainCurator. Mutates the local `task` parameter; `task` flows through `runPlanningPhases` to researcher/architect/planner. **One mutation, six consumers** (no fan-out, no per-stage prompt wrapper).

`resumeSkip('ragPreload')` keeps the integration composable with future Caminos B/D.

## Tests

4 acceptance tests with fake embedder + temp vec store:

- skips with `config.rag.preload.enabled` missing/false
- skips with `empty` on a fresh store + emits info log
- returns contextBlock containing chunk text + `hu_id` label
- skips with `no-task` on empty string

## LOC

+154 net. Inside 200 hard / over 150 ideal — test file is 79 LOC because each acceptance covers a different code path.

## Static imports

The first draft used `await import` for vec-store / embedder / retriever to keep RAG out of the SEA bundle. Broke the dynamic-imports invariant (162 → 166). Promoted to static — the existing `ragStubPlugin` in `scripts/esbuild-sea.config.mjs` already intercepts `/rag/` paths at build time.

## v2.24.0 ready to release after this merges