### PR TITLE
chore: release v2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.24.0] - 2026-05-24
+
+Minor release. **RAG Camino C — pre-loop auto-retrieval** (KJC-PCS-0049). After v2.23.0 taught the agents that `kj_rag_query` exists, Karajan now injects prior context for them automatically.
+
+### Added
+
+- **`runRagContextStage` pre-loop stage** (KJC-TSK-0432, PR #819). New module `src/orchestrator/stages/rag-context-stage.js`. Runs between triage and domainCurator. Five guards before retrieval fires: `disabled`, `no-task`, empty corpus, no hits, error. All five degrade silently except `empty` (info log pointing at `kj rag index`). The stage never throws. When all guards pass, mutates the `task` parameter prepending `## Prior context from RAG` block with top-K chunks. One mutation feeds researcher/architect/planner/coder via the existing parameter chain.
+
+### Toggle
+
+`config.rag.preload.enabled = false` by default (opt-in). `config.rag.preload.topK` (5) + `config.rag.preload.scope` (`all`).
+
+### Compatibility with Camino A (v2.23.0)
+
+Role templates from PR #817 already tell agents that `kj_rag_query` exists for on-demand queries. Camino C complements: agent gets context automatically at start; agent can still call the tool for follow-ups.
+
+### Out of scope (v2.25.0+)
+
+Camino B (Skills slash command), Camino D (Brain decisor for when to pre-fetch), chokidar watcher, AST source chunker, BM25 hybrid scoring.
+
+### Workflow
+
+```bash
+kj onboard
+kj rag index
+yq -i '.rag.preload.enabled = true' ~/.karajan/kj.config.yml
+kj run task.md  # researcher/architect/planner/coder see prior context automatically
+```
+
 ## [2.23.0] - 2026-05-24
 
 Minor release. **RAG exposed to agents and humans alike**: closes Steps 7 + 8 + Camino A of the Project RAG epic (KJC-PCS-0049).

--- a/README.md
+++ b/README.md
@@ -345,6 +345,31 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.24.0 released** — Minor. **RAG Camino C — pre-loop auto-retrieval** (KJC-PCS-0049). After v2.23.0 taught the agents that `kj_rag_query` exists, Karajan now injects prior context for them automatically: a new pre-loop stage queries the vec store with the task description and prepends the top-K chunks to the task before any LLM call.
+>
+> Opt-in: `config.rag.preload.enabled = false` by default. Five guards before the retrieval fires (`disabled`, `no-task`, empty corpus, no hits, error). The stage never throws — best-effort enrichment, opt-out by default, opt-back-out on failure. When all guards pass, the task receives an extra block:
+>
+> ```markdown
+> ## Prior context from RAG (auto-retrieved, top N)
+>
+> ### [plan · AUTH-1] /path/to/plan.json
+>
+> <chunk text, truncated 600 chars>
+> ```
+>
+> Because `task` flows through `runPlanningPhases` to researcher / architect / planner via parameter passing, **one mutation feeds six consumers** — no per-stage prompt wrapper, no fan-out through `pipelineFlags`. Triage runs first because its `roleOverrides` gate the rest of the pipeline; the RAG stage runs right after, before `domainCurator`.
+>
+> Workflow:
+>
+> ```bash
+> kj onboard
+> kj rag index
+> yq -i '.rag.preload.enabled = true' ~/.karajan/kj.config.yml
+> kj run task.md  # researcher/architect/planner/coder all see prior context
+> ```
+>
+> **Coming in v2.25.0+**: Camino B (`/kj-rag-query` slash command for Skills hosts), Camino D (Brain decisor heuristic deciding **when** to pre-fetch based on task complexity — refinement on top of C), chokidar watcher for live re-indexing, AST source chunker, BM25 + cosine hybrid scoring.
+>
 > **v2.23.0 released** — Minor. **RAG exposed to agents and humans alike** (KJC-PCS-0049, Steps 7+8+Camino A). After v2.22.0's CLI MVP, the corpus is now reachable from three more places.
 >
 > 1. **MCP tools** `kj_rag_query` + `kj_rag_index` (PR #815). Any MCP-connected agent — Claude Desktop, Cursor, Claude Code, Karajan's own roles — can call them. Tool count 25 → 27. Empty store responds `empty: true` so agents have a deterministic recovery signal.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (53k LOC, 385 files)
+├── src/              # Source code (53k LOC, 386 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.23.0
+kj --version    # 2.24.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.23.0
+kj --version    # 2.24.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Minor release. **RAG Camino C — pre-loop auto-retrieval** (KJC-PCS-0049).

## Cards in v2.24.0

| Card | PR | What |
|---|---|---|
| KJC-TSK-0432 | #819 | runRagContextStage pre-loop stage + integration in pre-loop driver |

## Tests

5 410+ tests passing on Node 20 + Node 22 CI.

## Post-merge

- Tag v2.24.0 + GitHub Release
- npm publish (OTP needed)
- Landing deploy

## What's next (v2.25.0+)

Camino B (Skills slash command), Camino D (Brain decisor for retrieval), chokidar watcher, AST source chunker, BM25 hybrid scoring.