### PR TITLE
feat(rag): /kj-rag-query slash command for Skills hosts (KJC-TSK-0433)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -544,7 +544,7 @@ async function installSkills(logger, interactive) {
 
   if (installed > 0) {
     logger.info(`Installed ${installed} Karajan skill(s) in .claude/commands/`);
-    logger.info("Available as slash commands: /kj-run, /kj-code, /kj-review, /kj-test, /kj-security, /kj-discover, /kj-architect, /kj-sonar");
+    logger.info("Available as slash commands: /kj-run, /kj-code, /kj-review, /kj-test, /kj-security, /kj-discover, /kj-architect, /kj-sonar, /kj-rag-query");
   } else {
     logger.info("All skills already installed.");
   }

--- a/templates/skills/kj-rag-query.md
+++ b/templates/skills/kj-rag-query.md
@@ -1,0 +1,50 @@
+# kj-rag-query — Query Project RAG index
+
+Query the Project RAG (vector store + embedder) and return the top-K most relevant chunks of the indexed project: plans, onboarding briefs, and (optionally) source code.
+
+Use this when you need prior context about the project before deciding, refactoring, planning, or coding — without scanning the filesystem manually.
+
+## Your task
+
+$ARGUMENTS
+
+## How it works
+
+This skill is a thin wrapper over the Karajan CLI:
+
+```
+kj rag query "<text>" [--scope <all|plans|onboarding|code>] [--top-k <n>] [--json]
+```
+
+Parse `$ARGUMENTS` as the natural-language query plus optional flags:
+
+- `--scope <s>`: restrict retrieval to one source bucket. Default: `all`.
+  - `plans` → indexed plan JSON files (HU titles, scope, blocked_by).
+  - `onboarding` → onboarding briefs from `~/.karajan/onboarding/`.
+  - `code` → indexed source files (only present if user ran `kj rag index --with-sources`).
+- `--top-k <n>`: number of chunks to return. Default: 3. Max recommended: 10.
+- `--json`: emit raw JSON (use when piping into another tool).
+
+If `$ARGUMENTS` is empty, print a one-line usage hint and stop.
+
+## Behavior contract
+
+1. **Empty store**: if the CLI replies with `empty: true`, do NOT block the conversation. Tell the user once: "RAG index is empty — run `kj rag index` to seed it" and continue without prior context.
+2. **Zero hits**: if the store has chunks but no match scored above threshold, say "no relevant prior context" and continue.
+3. **Hits returned**: render each as a short block — `[score] source — snippet` — and use them as background context for the user's actual question. Do NOT dump raw JSON unless `--json` was passed.
+4. **Never re-validate flags**. Pass `--scope`/`--top-k` straight to the CLI; the CLI is the source of truth.
+
+## Examples
+
+User: `/kj-rag-query how does the retriever rank chunks`
+→ `kj rag query "how does the retriever rank chunks"`
+
+User: `/kj-rag-query auth flow --scope plans --top-k 5`
+→ `kj rag query "auth flow" --scope plans --top-k 5`
+
+User: `/kj-rag-query --scope onboarding architecture`
+→ `kj rag query "architecture" --scope onboarding`
+
+## Why this exists (Camino B)
+
+Hosts that load Karajan as Skills (Claude Code without MCP, Cursor without MCP) cannot reach the `kj_rag_query` MCP tool. This skill bridges that gap with the same retrieval contract.

--- a/tests/templates-skills-rag-query.test.js
+++ b/tests/templates-skills-rag-query.test.js
@@ -1,0 +1,38 @@
+// KJC-TSK-0433 (Camino B): asegura que el slash command /kj-rag-query
+// existe como template y respeta el contrato esperado (texto $ARGUMENTS,
+// referencia al CLI `kj rag query`, manejo de empty store).
+import { describe, expect, it } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SKILL_PATH = path.resolve(HERE, "../templates/skills/kj-rag-query.md");
+
+describe("templates/skills/kj-rag-query.md (RAG Camino B)", () => {
+  it("exists and is non-empty", async () => {
+    const content = await readFile(SKILL_PATH, "utf8");
+    expect(content.length).toBeGreaterThan(200);
+  });
+
+  it("uses $ARGUMENTS so hosts can inject the user query", async () => {
+    const content = await readFile(SKILL_PATH, "utf8");
+    expect(content).toContain("$ARGUMENTS");
+  });
+
+  it("delegates to the kj rag query CLI", async () => {
+    const content = await readFile(SKILL_PATH, "utf8");
+    expect(content).toMatch(/kj rag query/);
+  });
+
+  it("documents --scope and --top-k flags as passthrough", async () => {
+    const content = await readFile(SKILL_PATH, "utf8");
+    expect(content).toContain("--scope");
+    expect(content).toContain("--top-k");
+  });
+
+  it("instructs to handle empty store without blocking", async () => {
+    const content = await readFile(SKILL_PATH, "utf8");
+    expect(content.toLowerCase()).toMatch(/empty|kj rag index/);
+  });
+});


### PR DESCRIPTION
Camino B of the RAG consumer surface plan.

## What

Adds `templates/skills/kj-rag-query.md` so hosts running Karajan as Skills (Claude Code without MCP, Cursor without MCP) can reach the RAG retrieval pipeline through a slash command instead of needing the MCP `kj_rag_query` tool.

The skill is a thin wrapper over the existing CLI:

```
kj rag query "<text>" [--scope <all|plans|onboarding|code>] [--top-k <n>] [--json]
```

## Contract

- Parses `$ARGUMENTS` as the user's natural-language query.
- Passes through `--scope` / `--top-k` to the CLI without re-validation (CLI is the source of truth).
- On empty store: surfaces a one-line hint (`run kj rag index`) without blocking the conversation.
- On zero hits above threshold: says so and continues.
- On hits: renders `[score] source — snippet` blocks rather than raw JSON.

## Files

- `templates/skills/kj-rag-query.md` — the skill template (~50 LOC)
- `src/commands/init.js` — adds `/kj-rag-query` to the post-init log line
- `tests/templates-skills-rag-query.test.js` — contract assertions (5 cases)

## LOC

Net +89 LOC across 3 files. Well under the 150/200 budget.