### PR TITLE
feat(rag): Brain decisor heuristic for pre-loop retrieval (KJC-TSK-0434)

### DIFF
--- a/src/orchestrator/drivers/pre-loop.js
+++ b/src/orchestrator/drivers/pre-loop.js
@@ -41,6 +41,7 @@ import {
   runDiscoverStage, runHuReviewerStage,
 } from "../pre-loop-stages.js";
 import { runRagContextStage } from "../stages/rag-context-stage.js";
+import { shouldPreloadRag } from "../stages/rag-preload-decisor.js";
 // TSK-0336: triage goes through the StageRegistry / StageExecutor contract
 // so canRun / execute / onFailure are actually exercised in production.
 // The registry is a singleton with TriageStage / CoderStage / ReviewerStage
@@ -131,10 +132,24 @@ export async function runPreLoopStages({ config, logger, emitter, eventBase, ses
   // all see prior context without having to call kj_rag_query themselves.
   // Empty store / network / etc. degrade to no-op via the stage itself.
   if (!resumeSkip("ragPreload")) {
-    const ragRes = await runRagContextStage({ config, logger, emitter, eventBase, task });
-    if (!ragRes.skipped && ragRes.contextBlock) {
-      task = `${task}\n\n${ragRes.contextBlock}`;
-      await persistStage("ragPreload", { hits: ragRes.hits.length, scope: config?.rag?.preload?.scope || "all" });
+    // KJC-TSK-0434 (Camino D): Brain decisor heuristic — skip retrieval
+    // when triage + task shape say it would be low-value. Defaults to
+    // policy=auto; `always`/`never` are escape hatches.
+    const decision = shouldPreloadRag({ triage: triageResult.stageResult, task, config });
+    if (!decision.pull) {
+      await persistStage("ragPreload", { skipped: true, reason: decision.reason });
+    } else {
+      const ragRes = await runRagContextStage({ config, logger, emitter, eventBase, task });
+      if (!ragRes.skipped && ragRes.contextBlock) {
+        task = `${task}\n\n${ragRes.contextBlock}`;
+        await persistStage("ragPreload", {
+          hits: ragRes.hits.length,
+          scope: config?.rag?.preload?.scope || "all",
+          decisor: decision.reason,
+        });
+      } else {
+        await persistStage("ragPreload", { skipped: true, reason: ragRes.reason, decisor: decision.reason });
+      }
     }
   }
 

--- a/src/orchestrator/stages/rag-preload-decisor.js
+++ b/src/orchestrator/stages/rag-preload-decisor.js
@@ -1,0 +1,58 @@
+// KJC-TSK-0434 — RAG Camino D: Brain decisor heuristic for retrieval.
+// Decides WHETHER to pay the cost of running the RAG preload stage based
+// on signals from triage + task shape, instead of pre-fetching every run.
+//
+// Returns `{ pull: boolean, reason: string }`. The pre-loop driver
+// skips `runRagContextStage` when `pull === false`.
+//
+// Policies (config.rag.preload.policy):
+//   - "always"  : pull regardless (back-compat with v2.24.0 behaviour)
+//   - "never"   : never pull (useful for benchmarking, debugging)
+//   - "auto"    : heuristic — pull only when triage signals complexity,
+//                 decomposition, or when the task body is long enough
+//                 to suggest non-trivial scope. Default.
+
+const DEFAULT_POLICY = "auto";
+const COMPLEX_LEVELS = new Set(["complex", "high", "epic"]);
+const LONG_TASK_CHARS = 200;
+
+/**
+ * @param {object} params
+ * @param {object} [params.triage]   - triage stage result (may be null)
+ * @param {string} [params.task]     - the user task text
+ * @param {object} [params.config]   - full karajan config
+ * @returns {{ pull: boolean, reason: string }}
+ */
+export function shouldPreloadRag({ triage, task, config } = {}) {
+  const policy = config?.rag?.preload?.policy || DEFAULT_POLICY;
+
+  if (policy === "always") return { pull: true, reason: "policy:always" };
+  if (policy === "never") return { pull: false, reason: "policy:never" };
+
+  // policy === "auto" — apply heuristic.
+  // Brownfield is an explicit user signal — if onboarding produced a
+  // brief and config marks the project as brownfield, prior context is
+  // almost always worth pulling.
+  if (config?.rag?.preload?.brownfield === true) {
+    return { pull: true, reason: "auto:brownfield" };
+  }
+
+  // Triage said this is big enough to decompose → multi-HU run benefits
+  // from prior context fed to researcher/architect/planner.
+  if (triage?.shouldDecompose === true) {
+    return { pull: true, reason: "auto:decompose" };
+  }
+
+  // Triage classified the task as complex / high-effort.
+  if (triage?.level && COMPLEX_LEVELS.has(String(triage.level).toLowerCase())) {
+    return { pull: true, reason: "auto:complex" };
+  }
+
+  // Long task body usually means a brief with context, motivation and
+  // non-trivial scope — worth checking the RAG.
+  if (typeof task === "string" && task.length >= LONG_TASK_CHARS) {
+    return { pull: true, reason: "auto:long-task" };
+  }
+
+  return { pull: false, reason: "auto:low-value" };
+}

--- a/tests/orchestrator/rag-preload-decisor.test.js
+++ b/tests/orchestrator/rag-preload-decisor.test.js
@@ -1,0 +1,97 @@
+// KJC-TSK-0434 (RAG Camino D) — pure-heuristic decisor.
+import { describe, expect, it } from "vitest";
+import { shouldPreloadRag } from "../../src/orchestrator/stages/rag-preload-decisor.js";
+
+describe("shouldPreloadRag — Brain decisor heuristic", () => {
+  describe("policy overrides", () => {
+    it("policy=always always pulls", () => {
+      const r = shouldPreloadRag({ task: "tiny", config: { rag: { preload: { policy: "always" } } } });
+      expect(r).toEqual({ pull: true, reason: "policy:always" });
+    });
+
+    it("policy=never never pulls", () => {
+      const r = shouldPreloadRag({
+        task: "x".repeat(5000),
+        triage: { shouldDecompose: true, level: "complex" },
+        config: { rag: { preload: { policy: "never" } } },
+      });
+      expect(r).toEqual({ pull: false, reason: "policy:never" });
+    });
+  });
+
+  describe("policy=auto (default)", () => {
+    it("brownfield flag forces pull", () => {
+      const r = shouldPreloadRag({
+        task: "x",
+        config: { rag: { preload: { brownfield: true } } },
+      });
+      expect(r.pull).toBe(true);
+      expect(r.reason).toBe("auto:brownfield");
+    });
+
+    it("triage.shouldDecompose=true pulls", () => {
+      const r = shouldPreloadRag({ task: "x", triage: { shouldDecompose: true } });
+      expect(r).toEqual({ pull: true, reason: "auto:decompose" });
+    });
+
+    it("triage.level=complex pulls", () => {
+      const r = shouldPreloadRag({ task: "x", triage: { level: "complex" } });
+      expect(r).toEqual({ pull: true, reason: "auto:complex" });
+    });
+
+    it("triage.level=high pulls (alias)", () => {
+      const r = shouldPreloadRag({ task: "x", triage: { level: "HIGH" } });
+      expect(r).toEqual({ pull: true, reason: "auto:complex" });
+    });
+
+    it("long task body pulls", () => {
+      const r = shouldPreloadRag({ task: "x".repeat(250) });
+      expect(r).toEqual({ pull: true, reason: "auto:long-task" });
+    });
+
+    it("short task + no signals → skip", () => {
+      const r = shouldPreloadRag({ task: "fix typo", triage: { level: "trivial" } });
+      expect(r).toEqual({ pull: false, reason: "auto:low-value" });
+    });
+
+    it("no triage and short task → skip", () => {
+      const r = shouldPreloadRag({ task: "rename file" });
+      expect(r).toEqual({ pull: false, reason: "auto:low-value" });
+    });
+
+    it("defaults to auto when config missing", () => {
+      const r = shouldPreloadRag({ task: "tiny" });
+      expect(r.pull).toBe(false);
+      expect(r.reason).toBe("auto:low-value");
+    });
+  });
+
+  describe("precedence", () => {
+    it("policy:always wins over auto signals", () => {
+      const r = shouldPreloadRag({
+        task: "tiny",
+        triage: { level: "trivial" },
+        config: { rag: { preload: { policy: "always" } } },
+      });
+      expect(r.reason).toBe("policy:always");
+    });
+
+    it("policy:never wins over brownfield/decompose/complex", () => {
+      const r = shouldPreloadRag({
+        task: "x".repeat(500),
+        triage: { shouldDecompose: true, level: "complex" },
+        config: { rag: { preload: { policy: "never", brownfield: true } } },
+      });
+      expect(r.reason).toBe("policy:never");
+    });
+
+    it("brownfield wins over no-other-signals when policy=auto", () => {
+      const r = shouldPreloadRag({
+        task: "x",
+        triage: { level: "trivial" },
+        config: { rag: { preload: { brownfield: true } } },
+      });
+      expect(r.reason).toBe("auto:brownfield");
+    });
+  });
+});


### PR DESCRIPTION
Camino D of the RAG consumer surface plan.

## What

Adds a Brain decisor heuristic that decides **whether** to pay the cost of running the RAG preload stage based on signals from triage + task shape, instead of pre-fetching every run.

`shouldPreloadRag({ triage, task, config }) → { pull, reason }`

## Policy precedence

`config.rag.preload.policy`:

- `always` — pull every run (back-compat with v2.24.0 behaviour)
- `never` — never pull (benchmarking / debugging)
- `auto` (default) — heuristic

In `auto` mode, pulls when **any** of:
- `config.rag.preload.brownfield === true` (explicit brownfield signal)
- `triage.shouldDecompose === true` (multi-HU run)
- `triage.level in {complex, high, epic}`
- `task.length >= 200` chars (long brief usually = non-trivial scope)

Otherwise skips with `reason: 'auto:low-value'`. The pre-loop driver still persists a `ragPreload` stage result with the decisor reason so resume + audit can see why retrieval was skipped.

## Files

- `src/orchestrator/stages/rag-preload-decisor.js` — pure heuristic (~58 LOC)
- `src/orchestrator/drivers/pre-loop.js` — wired before `runRagContextStage`
- `tests/orchestrator/rag-preload-decisor.test.js` — 13 cases covering all branches + precedence

## LOC

Net +174 LOC across 3 files (heuristic + tests). Under the 200 budget.

## Behaviour matrix

| triage.shouldDecompose | triage.level | task length | brownfield | policy | pull? | reason |
|---|---|---|---|---|---|---|
| true | * | * | * | auto | ✓ | auto:decompose |
| false | complex/high/epic | * | * | auto | ✓ | auto:complex |
| false | trivial | < 200 | false | auto | ✗ | auto:low-value |
| false | trivial | >= 200 | false | auto | ✓ | auto:long-task |
| * | * | * | true | auto | ✓ | auto:brownfield |
| * | * | * | * | always | ✓ | policy:always |
| * | * | * | * | never | ✗ | policy:never |