### PR TITLE
chore: release v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.25.0] - 2026-05-24
+
+Minor release. **RAG Camino B + Camino D** (KJC-PCS-0049). Closes the consumer-surface plan: Skills hosts can now invoke RAG without MCP, and the pre-loop retrieval stage only fires when triage signals make it worthwhile.
+
+### Added
+
+- **`/kj-rag-query` slash command** (KJC-TSK-0433, PR #821). New `templates/skills/kj-rag-query.md` template. `kj init` ships it to `.claude/commands/` so hosts that load Karajan via Skills (Claude Code without MCP, Cursor without MCP) can reach the RAG retriever through `/kj-rag-query <text> [--scope <s>] [--top-k <n>]`. Thin wrapper over the existing `kj rag query` CLI: passthrough flags, empty-store hint without blocking the conversation, render chunks as background context (not raw JSON).
+- **Brain decisor heuristic for pre-loop retrieval** (KJC-TSK-0434, PR #822). New module `src/orchestrator/stages/rag-preload-decisor.js`. Pure function `shouldPreloadRag({triage, task, config}) → {pull, reason}`. Wired in `pre-loop.js` before `runRagContextStage`. Policy `config.rag.preload.policy`: `always` (back-compat with v2.24.0), `never` (benchmarking), `auto` (default). In auto mode, pulls when triage decomposes, level is complex/high/epic, task body ≥ 200 chars, or `config.rag.preload.brownfield` is set. Otherwise persists `ragPreload: { skipped: true, reason: 'auto:low-value' }` so resume + audit see why retrieval was skipped.
+
+### Toggle
+
+`config.rag.preload.enabled` still defaults to `false` (opt-in). `config.rag.preload.policy` defaults to `auto`. Existing v2.24.0 setups behave unchanged unless they explicitly set `policy=auto`.
+
+### Out of scope (v2.26.0+)
+
+chokidar watcher (live re-indexing), AST source chunker (tree-sitter or `@babel/parser`), BM25 + cosine hybrid scoring.
+
 ## [2.24.0] - 2026-05-24
 
 Minor release. **RAG Camino C — pre-loop auto-retrieval** (KJC-PCS-0049). After v2.23.0 taught the agents that `kj_rag_query` exists, Karajan now injects prior context for them automatically.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.25.0 released** — Minor. **RAG Camino B + Camino D** (KJC-PCS-0049). Closes the consumer-surface plan. Skills hosts can now invoke RAG via `/kj-rag-query` without MCP, and the pre-loop retrieval stage from v2.24.0 only fires when triage signals make it worthwhile.
+>
+> Camino B — `/kj-rag-query <text> [--scope <s>] [--top-k <n>]` slash command shipped by `kj init` to `.claude/commands/`. Thin wrapper over `kj rag query`; passes flags through, surfaces `empty:true` as a one-line hint, renders hits as background context rather than raw JSON. For Claude Code / Cursor instances loaded without MCP.
+>
+> Camino D — Brain decisor heuristic in `src/orchestrator/stages/rag-preload-decisor.js`. New `config.rag.preload.policy`: `always` (v2.24.0 behaviour, kept for back-compat), `never` (benchmarking), `auto` (default). In `auto` mode, retrieval fires when triage decomposes, level ∈ {complex, high, epic}, task body ≥ 200 chars, or `config.rag.preload.brownfield` is set. Otherwise the stage persists `{ skipped: true, reason: 'auto:low-value' }` and the pipeline pays no retrieval cost on trivial tasks.
+>
+> **Coming in v2.26.0+**: chokidar watcher for live re-indexing, AST source chunker (tree-sitter / `@babel/parser`), BM25 + cosine hybrid scoring.
+>
 > **v2.24.0 released** — Minor. **RAG Camino C — pre-loop auto-retrieval** (KJC-PCS-0049). After v2.23.0 taught the agents that `kj_rag_query` exists, Karajan now injects prior context for them automatically: a new pre-loop stage queries the vec store with the task description and prepends the top-K chunks to the task before any LLM call.
 >
 > Opt-in: `config.rag.preload.enabled = false` by default. Five guards before the retrieval fires (`disabled`, `no-task`, empty corpus, no hits, error). The stage never throws — best-effort enrichment, opt-out by default, opt-back-out on failure. When all guards pass, the task receives an extra block:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (53k LOC, 386 files)
+├── src/              # Source code (53k LOC, 387 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.24.0
+kj --version    # 2.25.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.24.0
+kj --version    # 2.25.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.24.0",
+      "version": "2.25.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Closes v2.25.0 = **RAG Camino B + Camino D**, closing the consumer-surface plan started in v2.22.0.

- **Camino B** (PR #821, KJC-TSK-0433): `/kj-rag-query` slash command for Skills hosts without MCP.
- **Camino D** (PR #822, KJC-TSK-0434): Brain decisor heuristic for pre-loop retrieval. New `config.rag.preload.policy` with `always` / `never` / `auto` (default).

## Files touched

- `package.json` + `package-lock.json` — 2.24.0 → 2.25.0
- `CHANGELOG.md` — new entry under [2.25.0]
- `README.md` — release banner refreshed (v2.24.0 → v2.25.0; "Coming next" line moved to v2.26.0+)
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` — version line bumped
- `docs/ARCHITECTURE.md` — stats regenerated (387 src files, 439 test files)

## Tests

`tests/orchestrator/{rag-context-stage,rag-preload-decisor}.test.js` + `tests/templates-skills-rag-query.test.js` → 22/22 passing locally. CI will run the full suite.