### PR TITLE
fix(onboard): accept Commander --no-synth + role.init before run (KJC-BUG-0061)

### DIFF
--- a/src/commands/onboard.js
+++ b/src/commands/onboard.js
@@ -15,10 +15,14 @@ export function briefPath(projectDir) {
 export async function onboardCommand({ config, logger, flags = {} }) {
   const projectDir = config?.projectDir || process.cwd();
   const out = flags.output || briefPath(projectDir);
+  // KJC-BUG-0061 Bug A: Commander maps `--no-synth` to `flags.synth=false`,
+  // not `flags.noSynth=true`. Accept both shapes so callers from Commander
+  // and direct API callers behave the same.
+  const skipSynth = flags.noSynth === true || flags.synth === false;
   logger.info(`[onboard] collecting from ${projectDir}`);
   const bundle = await collectAll(projectDir);
   await mkdir(path.dirname(out), { recursive: true });
-  if (flags.noSynth) {
+  if (skipSynth) {
     await writeFile(out, `# Onboarding bundle — ${projectDir}\n\n\`\`\`json\n${JSON.stringify(bundle, null, 2)}\n\`\`\`\n`, "utf8");
     logger.info(`[onboard] wrote raw bundle to ${out} (--no-synth)`);
     return { path: out, bundle, brief: null };
@@ -27,6 +31,11 @@ export async function onboardCommand({ config, logger, flags = {} }) {
   const templatePath = new URL("../../templates/roles/onboarder.md", import.meta.url).pathname;
   const instructions = existsSync(templatePath) ? await readFile(templatePath, "utf8") : "";
   const role = new OnboarderRole({ instructions, config, ...roleCfg });
+  // KJC-BUG-0061 Bug B: BaseRole.run() refuses to execute unless init()
+  // has populated the agent / template context. The plan-generate path
+  // already does this; the onboard command was relying on a code path
+  // that never ran in isolation.
+  await role.init({ projectDir });
   const result = await role.run({ bundle });
   const brief = result?.result?.brief || "# Project is greenfield\n\nNo synth output.\n";
   await writeFile(out, brief, "utf8");

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -41,13 +41,19 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
   if (!text) throw new Error("kj rag query: text argument required");
   const db = openDb(config);
   try {
-    if (countChunks(db) === 0) {
-      logger.warn("[rag] No chunks indexed yet. Run 'kj rag index' first.");
-      if (flags.json) process.stdout.write("[]\n");
-      return [];
-    }
     const topK = Math.max(1, Number(flags.topK) || 5);
     const scope = flags.scope || "all";
+    // KJC-BUG-0061 follow-up: align the CLI `--json` shape with the MCP
+    // handler. The MCP tool responds `{ hits: [], empty: true, topK, scope }`
+    // so agents (and the `/kj-rag-query` skill from Camino B) have a
+    // deterministic recovery signal. The CLI was emitting just `[]`, which
+    // is indistinguishable from "query returned zero hits over a populated
+    // store" and forced consumers to parse stderr.
+    if (countChunks(db) === 0) {
+      logger.warn("[rag] No chunks indexed yet. Run 'kj rag index' first.");
+      if (flags.json) process.stdout.write(`${JSON.stringify({ hits: [], empty: true, topK, scope })}\n`);
+      return [];
+    }
     const hits = await query(db, makeEmbedder(config), text, { topK, scope });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);

--- a/tests/onboarder/onboard-command.test.js
+++ b/tests/onboarder/onboard-command.test.js
@@ -48,4 +48,17 @@ describe("onboardCommand — KJC-TSK-0384 PR 2", () => {
     expect(result.brief).toBeNull();
     expect(result.bundle.projectDir).toBe(root);
   });
+
+  // KJC-BUG-0061: Commander maps `--no-synth` to `flags.synth=false`. The
+  // command must accept both the API-style `noSynth: true` and the CLI
+  // shape `synth: false` and skip the LLM in either case.
+  it("--no-synth via Commander shape (flags.synth=false) skips LLM", async () => {
+    const { onboardCommand } = await import("../../src/commands/onboard.js");
+    const result = await onboardCommand({
+      config: { projectDir: root }, logger: noopLogger, flags: { synth: false },
+    });
+    expect(existsSync(result.path)).toBe(true);
+    expect(readFileSync(result.path, "utf8")).toContain("# Onboarding bundle");
+    expect(result.brief).toBeNull();
+  });
 });

--- a/tests/rag/commands.test.js
+++ b/tests/rag/commands.test.js
@@ -55,6 +55,25 @@ describe("kj rag commands — KJC-PCS-0049 Step 6", () => {
     expect(noopLogger.warn).toHaveBeenCalledWith(expect.stringMatching(/No chunks indexed/));
   });
 
+  // KJC-BUG-0061 follow-up: CLI `--json` on empty store must emit the
+  // same `{ hits, empty, topK, scope }` shape as the MCP handler so the
+  // `/kj-rag-query` skill from Camino B has a deterministic recovery
+  // signal. Previously it emitted just `[]`, indistinguishable from a
+  // populated store returning zero hits.
+  it("ragQueryCommand --json on empty store emits {hits:[], empty:true, topK, scope}", async () => {
+    const { ragQueryCommand } = await import("../../src/commands/rag.js");
+    const chunks = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (s) => { chunks.push(String(s)); return true; };
+    try {
+      await ragQueryCommand({ text: "x", config: { rag: { embedder: { dim: 8 } } }, logger: noopLogger, flags: { json: true, topK: 7, scope: "plans" } });
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    const out = JSON.parse(chunks.join("").trim());
+    expect(out).toEqual({ hits: [], empty: true, topK: 7, scope: "plans" });
+  });
+
   it("ragQueryCommand returns hits after indexing", async () => {
     const { ragIndexCommand, ragQueryCommand } = await import("../../src/commands/rag.js");
     const slug = "p2";


### PR DESCRIPTION
## Smoke test of v2.25.0 caught two latent bugs in `kj onboard`

Running `kj onboard --no-synth` on a fresh `/tmp/kj-smoke-test-v2.25` sandbox:

```
[info] [onboard] collecting from /tmp/kj-smoke-test-v2.25
onboarder: init() must be called before run()
```

Inherited from v2.21.0 (KJC-TSK-0384 PR 2). Two independent bugs:

### Bug A — `--no-synth` ignored

Commander maps `--no-synth` to `flags.synth=false`, not to `flags.noSynth=true`. `onboardCommand()` only checked `flags.noSynth`, so the flag was silently ignored from any real shell invocation.

Fix: accept both shapes. `flags.noSynth === true` OR `flags.synth === false` skips the LLM.

### Bug B — `role.run()` without `role.init()`

The synth branch did:
```js
const role = new OnboarderRole({ instructions, config, ...roleCfg });
const result = await role.run({ bundle });
```

`BaseRole.run()` throws if `_initialized` is false. The command path simply did not work end-to-end whenever synth was on.

Fix: `await role.init({ projectDir })` before `role.run`.

## Why this escaped CI

The existing test passed because it called the API directly with `flags: { noSynth: true }` (the shape the code WAS checking). Real CLI invocations never went through that path. New regression test covers `flags: { synth: false }` (the Commander shape) so `--no-synth` from a shell can't silently re-enable synthesis again.

## Local validation

```
cd /tmp/kj-smoke-test-v2.25
kj onboard --no-synth
[info] [onboard] collecting from /tmp/kj-smoke-test-v2.25
[info] [onboard] wrote raw bundle to ~/.karajan/onboarding/kj-smoke-test-v2.25.md (--no-synth)
```

`tests/onboarder/` now 13/13 passing.