### PR TITLE
feat(rag): Ollama-in-Docker manager — bootstrap PR 1/3 (KJC-TSK-0435)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -161,6 +161,10 @@ const ragStubPlugin = {
           openVecStore: notAvailable, OllamaEmbedder: notAvailable,
           indexFile: notAvailable, indexProject: notAvailable,
           query: notAvailable, chunkMarkdown: notAvailable, chunkPlan: notAvailable, chunkSource: notAvailable,
+          // KJC-TSK-0435 — Ollama Docker manager.
+          ollamaUp: notAvailable, ollamaDown: notAvailable, ensureComposeFile: notAvailable,
+          isOllamaReachable: notAvailable, findAvailableOllamaPort: notAvailable,
+          waitForOllamaReady: notAvailable, buildComposeTemplate: notAvailable, normalizeOllamaConfig: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/rag/ollama-manager.js
+++ b/src/rag/ollama-manager.js
@@ -1,0 +1,98 @@
+// KJC-TSK-0435 (RAG Auto-Bootstrap PR1) — Ollama-in-Docker manager.
+// Mirrors src/sonar/manager.js: write docker-compose, start/stop the
+// container, discover a free port, wait for readiness. Next PR wires
+// it to `kj init`.
+import fs from "node:fs/promises";
+import net from "node:net";
+import { ensureDir } from "../utils/fs.js";
+import { runCommand } from "../utils/process.js";
+import { getKarajanHome, getOllamaComposePath } from "../utils/paths.js";
+
+const DEFAULTS = { port: 11434, hcS: 5, upMs: 300000, ctrlMs: 120000, readyMs: 90000 };
+const pos = (v, d) => (Number(v) > 0 ? Number(v) : d);
+
+export function normalizeOllamaConfig(ollama = {}) {
+  const t = ollama.timeouts || {};
+  const port = Number(ollama.port) || DEFAULTS.port;
+  return {
+    host: ollama.host || `http://localhost:${port}`,
+    port,
+    external: ollama.external === true,
+    containerName: ollama.container_name || "kj-ollama",
+    volume: ollama.volume || "kj_ollama_data",
+    timeouts: {
+      healthcheckSeconds: pos(t.healthcheck_seconds, DEFAULTS.hcS),
+      composeUpMs: pos(t.compose_up_ms, DEFAULTS.upMs),
+      composeControlMs: pos(t.compose_control_ms, DEFAULTS.ctrlMs),
+      readyMs: pos(t.ready_ms, DEFAULTS.readyMs),
+    },
+  };
+}
+
+export function buildComposeTemplate(cfg) {
+  return `services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ${cfg.containerName}
+    ports:
+      - "${cfg.port}:11434"
+    volumes:
+      - ${cfg.volume}:/root/.ollama
+    restart: unless-stopped
+
+volumes:
+  ${cfg.volume}:
+`;
+}
+
+export async function ensureComposeFile(ollama = null) {
+  const cfg = normalizeOllamaConfig(ollama || {});
+  await ensureDir(getKarajanHome());
+  await fs.writeFile(getOllamaComposePath(), buildComposeTemplate(cfg), "utf8");
+  return getOllamaComposePath();
+}
+
+export async function isOllamaReachable(host, healthcheckSeconds = DEFAULTS.hcS) {
+  const t = String(pos(healthcheckSeconds, DEFAULTS.hcS));
+  const r = await runCommand("curl", ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", t, `${host}/api/tags`]);
+  return r.exitCode === 0 && r.stdout.trim().startsWith("2");
+}
+
+export async function findAvailableOllamaPort(start = DEFAULTS.port, span = 10) {
+  for (let p = start; p < start + span; p++) {
+    const free = await new Promise((res) => {
+      const s = net.createServer();
+      s.once("error", () => res(false));
+      s.once("listening", () => s.close(() => res(true)));
+      s.listen(p, "127.0.0.1");
+    });
+    if (free) return p;
+  }
+  throw new Error(`No free port in [${start}, ${start + span})`);
+}
+
+export async function waitForOllamaReady(host, timeoutMs = DEFAULTS.readyMs) {
+  const dl = Date.now() + timeoutMs;
+  while (Date.now() < dl) {
+    if (await isOllamaReachable(host, 2)) return true;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  return false;
+}
+
+export async function ollamaUp(ollama = null) {
+  const cfg = normalizeOllamaConfig(ollama || {});
+  if (await isOllamaReachable(cfg.host, cfg.timeouts.healthcheckSeconds)) {
+    return { exitCode: 0, stdout: `Ollama already reachable at ${cfg.host}, skipping container start.`, stderr: "", reusedHost: cfg.host };
+  }
+  if (cfg.external) return { exitCode: 1, stdout: "", stderr: `Configured external Ollama is not reachable at ${cfg.host}.` };
+  const compose = await ensureComposeFile(ollama);
+  return runCommand("docker", ["compose", "-f", compose, "up", "-d"], { timeout: cfg.timeouts.composeUpMs });
+}
+
+export async function ollamaDown(ollama = null) {
+  const cfg = normalizeOllamaConfig(ollama || {});
+  if (cfg.external) return { exitCode: 0, stdout: "ollama.external=true, skipping Docker stop.", stderr: "" };
+  const compose = await ensureComposeFile(ollama);
+  return runCommand("docker", ["compose", "-f", compose, "stop"], { timeout: cfg.timeouts.composeControlMs });
+}

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -90,6 +90,11 @@ export function getSonarComposePath() {
   return path.join(getKarajanHome(), "docker-compose.sonar.yml");
 }
 
+/** Ollama RAG embedder compose: `<karajan-home>/docker-compose.ollama.yml` — KJC-TSK-0435. */
+export function getOllamaComposePath() {
+  return path.join(getKarajanHome(), "docker-compose.ollama.yml");
+}
+
 /** Webperf cache: `<karajan-home>/webperf/` — KJC-TSK-0420. */
 export function getWebperfDir() {
   return path.join(getKarajanHome(), "webperf");

--- a/tests/rag/ollama-manager.test.js
+++ b/tests/rag/ollama-manager.test.js
@@ -1,0 +1,91 @@
+// KJC-TSK-0435 — ollama-manager.js contract.
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import net from "node:net";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn(),
+}));
+import { runCommand } from "../../src/utils/process.js";
+import {
+  normalizeOllamaConfig, buildComposeTemplate, ensureComposeFile,
+  isOllamaReachable, findAvailableOllamaPort, ollamaUp, ollamaDown,
+} from "../../src/rag/ollama-manager.js";
+
+describe("ollama-manager — KJC-TSK-0435", () => {
+  let prevHome;
+  beforeEach(() => {
+    prevHome = process.env.KARAJAN_HOME;
+    process.env.KARAJAN_HOME = mkdtempSync(join(tmpdir(), "kj-ollama-home-"));
+    runCommand.mockReset();
+  });
+  afterEach(() => {
+    if (process.env.KARAJAN_HOME) rmSync(process.env.KARAJAN_HOME, { recursive: true, force: true });
+    if (prevHome === undefined) delete process.env.KARAJAN_HOME;
+    else process.env.KARAJAN_HOME = prevHome;
+  });
+
+  it("normalizeOllamaConfig fills defaults + honours overrides", () => {
+    const d = normalizeOllamaConfig({});
+    expect(d).toMatchObject({ host: "http://localhost:11434", port: 11434, containerName: "kj-ollama", external: false });
+    expect(d.timeouts.healthcheckSeconds).toBe(5);
+    const o = normalizeOllamaConfig({ port: 11500, container_name: "x", external: true, volume: "v" });
+    expect(o).toMatchObject({ port: 11500, host: "http://localhost:11500", containerName: "x", external: true, volume: "v" });
+  });
+
+  it("buildComposeTemplate + ensureComposeFile produce a usable yaml", async () => {
+    const yml = buildComposeTemplate(normalizeOllamaConfig({ port: 11500 }));
+    expect(yml).toContain("ollama/ollama:latest");
+    expect(yml).toContain("- \"11500:11434\"");
+    const p = await ensureComposeFile({});
+    expect(existsSync(p) && readFileSync(p, "utf8")).toContain("ollama/ollama:latest");
+  });
+
+  it("isOllamaReachable reflects HTTP status from /api/tags", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "200", stderr: "" });
+    expect(await isOllamaReachable("http://localhost:11434")).toBe(true);
+    runCommand.mockResolvedValueOnce({ exitCode: 7, stdout: "", stderr: "" });
+    expect(await isOllamaReachable("http://localhost:11434")).toBe(false);
+  });
+
+  it("findAvailableOllamaPort skips occupied ports", async () => {
+    const occ = await new Promise((r) => { const s = net.createServer(); s.listen(0, "127.0.0.1", () => r(s)); });
+    try { expect(await findAvailableOllamaPort(occ.address().port, 5)).toBeGreaterThan(occ.address().port); }
+    finally { occ.close(); }
+  });
+
+  it("ollamaUp short-circuits when host already reachable", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "200", stderr: "" });
+    const res = await ollamaUp({});
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toMatch(/already reachable/);
+    expect(res.reusedHost).toBe("http://localhost:11434");
+  });
+
+  it("ollamaUp refuses when external=true and host unreachable", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 7, stdout: "", stderr: "" });
+    const res = await ollamaUp({ external: true, host: "http://nope:9999" });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/external Ollama is not reachable/);
+  });
+
+  it("ollamaUp falls through to docker compose up when unreachable", async () => {
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 7, stdout: "", stderr: "" })   // healthcheck fail
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "Started", stderr: "" }); // docker
+    const res = await ollamaUp({});
+    expect(res.exitCode).toBe(0);
+    expect(runCommand).toHaveBeenLastCalledWith("docker", expect.arrayContaining(["compose", "up", "-d"]), expect.any(Object));
+  });
+
+  it("ollamaDown skips when external, otherwise invokes docker compose stop", async () => {
+    const skipped = await ollamaDown({ external: true });
+    expect(skipped.stdout).toMatch(/skipping Docker stop/);
+    expect(runCommand).not.toHaveBeenCalled();
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "stopped", stderr: "" });
+    await ollamaDown({});
+    expect(runCommand).toHaveBeenCalledWith("docker", expect.arrayContaining(["compose", "stop"]), expect.any(Object));
+  });
+});


### PR DESCRIPTION
PR 1 of 3 for v2.26.0 **RAG Auto-Bootstrap**.

## What

Adds `src/rag/ollama-manager.js` mirroring `src/sonar/manager.js`: build & write docker-compose, start/stop the container, find a free port, wait for readiness.

## API

```js
import {
  normalizeOllamaConfig, buildComposeTemplate, ensureComposeFile,
  isOllamaReachable, waitForOllamaReady, findAvailableOllamaPort,
  ollamaUp, ollamaDown,
} from "./src/rag/ollama-manager.js";
```

### Defaults (`normalizeOllamaConfig({})`)
- host: `http://localhost:11434`
- containerName: `kj-ollama`
- volume: `kj_ollama_data`
- timeouts: healthcheck 5s, compose-up 5min, ready 90s

### Behaviour
- `ollamaUp` short-circuits if host is already reachable → returns `{ reusedHost }`.
- `ollamaUp({ external: true })` and unreachable → refuses (exitCode 1) — explicit opt-out.
- `ollamaDown` is a no-op when `external: true`.
- `findAvailableOllamaPort(start, span)` scans a port range; throws if none free.

## SEA bundle

The existing `ragStubPlugin` already matches `src/rag/*`; export list extended to include the 8 new symbols so SEA binaries throw the standard "install karajan-code from npm" instead of failing to load.

## Files

- `src/rag/ollama-manager.js` — 98 LOC
- `src/utils/paths.js` — `+getOllamaComposePath()`
- `scripts/esbuild-sea.config.mjs` — stub exports
- `tests/rag/ollama-manager.test.js` — 8 cases (defaults, override, compose, reachable, port scan, up short-circuit, up external refuse, up fallthrough, down)

Net **+198 LOC**, under the 200 budget.

## Coming next

- PR 2 (KJC-TSK-0436): capability check (RAM, Docker) + auto-pull `nomic-embed-text` + `kj init` wizard integration (`--no-ollama` flag).
- PR 3 (KJC-TSK-0437): `kj ollama [start|stop|status|pull]` subcommand + `kj doctor` check.