### PR TITLE
feat(rag): capability check + auto-pull + kj init bootstrap — PR 2/3 (KJC-TSK-0436)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -165,6 +165,9 @@ const ragStubPlugin = {
           ollamaUp: notAvailable, ollamaDown: notAvailable, ensureComposeFile: notAvailable,
           isOllamaReachable: notAvailable, findAvailableOllamaPort: notAvailable,
           waitForOllamaReady: notAvailable, buildComposeTemplate: notAvailable, normalizeOllamaConfig: notAvailable,
+          // KJC-TSK-0436 — Ollama capability check + model pull.
+          checkDockerAvailable: notAvailable, checkRamCapacity: notAvailable,
+          checkOllamaCapability: notAvailable, pullOllamaModel: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -25,6 +25,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--scaffold-ci", "Scaffold Karajan CI Gateway workflow files")
     .option("--global", "Save config to ~/.karajan/kj.config.yml (skip the scope wizard)")
     .option("--local", "Save config to ./.karajan/kj.config.yml (skip the scope wizard)")
+    .option("--no-ollama", "Skip the RAG embedder bootstrap (Ollama-in-Docker). Useful on modest hardware or when an external embedder will be wired manually")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { getConfigPath, getProjectConfigPath, loadConfig, writeConfig } from "../config.js";
 import { sonarUp, checkVmMaxMapCount } from "../sonar/manager.js";
+import { ollamaUp, waitForOllamaReady, normalizeOllamaConfig } from "../rag/ollama-manager.js";
+import { checkOllamaCapability, pullOllamaModel } from "../rag/ollama-capability.js";
 import { exists, ensureDir } from "../utils/fs.js";
 import { getKarajanHome } from "../utils/paths.js";
 import { detectAvailableAgents } from "../utils/agent-detect.js";
@@ -500,6 +502,50 @@ async function scaffoldCiGateway(config, flags, logger) {
   logger.info("  4. Push the workflow files and enable 'kj run --enable-ci'");
 }
 
+// KJC-TSK-0436 — RAG embedder bootstrap. Default-on, opt-out with
+// `--no-ollama`. Skipped automatically when the host can't run it
+// (no Docker, daemon down, < 4 GB free RAM) — a one-line warning
+// tells the user how to wire an external embedder instead.
+async function bootstrapOllama({ flags, config, logger, interactive }) {
+  // Commander maps `--no-ollama` to `flags.ollama=false`.
+  const skip = flags?.noOllama === true || flags?.ollama === false;
+  if (skip) {
+    logger.info("Ollama bootstrap skipped (--no-ollama). RAG embedder will be unavailable until you configure one.");
+    return;
+  }
+  const cap = await checkOllamaCapability();
+  if (!cap.capable) {
+    logger.warn(`Ollama bootstrap skipped: ${cap.reasons.join("; ")}.`);
+    logger.warn("  Wire an external embedder via `config.rag.embedder` or rerun `kj init` after fixing the cause.");
+    return;
+  }
+  const result = await ollamaUp(config?.rag?.embedder || null);
+  if (result.exitCode !== 0) {
+    logger.warn(`Ollama bootstrap failed: ${result.stderr || result.stdout}`);
+    return;
+  }
+  if (result.reusedHost) {
+    logger.info(`Reusing existing Ollama at ${result.reusedHost}.`);
+  } else {
+    logger.info("Ollama container started. Waiting for /api/tags...");
+    const ollamaCfg = normalizeOllamaConfig(config?.rag?.embedder || {});
+    const ready = await waitForOllamaReady(ollamaCfg.host, ollamaCfg.timeouts.readyMs);
+    if (!ready) {
+      logger.warn(`Ollama did not become ready within ${ollamaCfg.timeouts.readyMs} ms. Continuing — pull the model manually with \`kj ollama pull nomic-embed-text\`.`);
+      return;
+    }
+  }
+  const model = config?.rag?.embedder?.model || "nomic-embed-text";
+  logger.info(`Pulling embedder model ${model} (first run downloads ~270 MB)...`);
+  const pull = await pullOllamaModel(model, { containerName: config?.rag?.embedder?.container_name });
+  if (pull.exitCode === 0) {
+    logger.info(`  -> ${model} ready. RAG embedder available.`);
+    if (interactive) logger.info("  -> Enable pre-loop retrieval with `yq -i '.rag.preload.enabled = true' " + getConfigPath() + "`");
+  } else {
+    logger.warn(`Model pull failed: ${pull.stderr || pull.stdout}. Retry with \`kj ollama pull ${model}\`.`);
+  }
+}
+
 async function installSkills(logger, interactive) {
   const projectDir = process.cwd();
   const commandsDir = path.join(projectDir, ".claude", "commands");
@@ -636,6 +682,7 @@ export async function initCommand({ logger, flags = {} }) {
   await ensureCoderRules(coderRulesPath, logger);
   await ensureGitignoreEntries(process.cwd(), logger);
   await installSkills(logger, interactive);
+  await bootstrapOllama({ flags, config, logger, interactive });
 
   // Auto-detect project stack and preconfigure
   const stack = await detectProjectStack(process.cwd());

--- a/src/rag/ollama-capability.js
+++ b/src/rag/ollama-capability.js
@@ -1,0 +1,59 @@
+// KJC-TSK-0436 (RAG Auto-Bootstrap PR2) — Capability check for Ollama
+// bootstrap. Returns whether the host can reasonably run a local Ollama
+// container: Docker installed, daemon reachable, and enough RAM
+// (default >= 4 GB free). The caller (kj init) decides whether to
+// bootstrap, warn, or skip.
+import os from "node:os";
+import { runCommand } from "../utils/process.js";
+
+const DEFAULT_MIN_RAM_BYTES = 4 * 1024 * 1024 * 1024; // 4 GB free
+const DEFAULT_TIMEOUT_MS = 5000;
+
+export async function checkDockerAvailable(timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const v = await runCommand("docker", ["--version"], { timeout: timeoutMs }).catch(() => ({ exitCode: 127 }));
+  if (v.exitCode !== 0) return { ok: false, reason: "docker:not-installed" };
+  const info = await runCommand("docker", ["info"], { timeout: timeoutMs }).catch(() => ({ exitCode: 1 }));
+  if (info.exitCode !== 0) return { ok: false, reason: "docker:daemon-unreachable" };
+  return { ok: true };
+}
+
+export function checkRamCapacity(minBytes = DEFAULT_MIN_RAM_BYTES) {
+  const free = os.freemem();
+  const total = os.totalmem();
+  if (free < minBytes) {
+    return {
+      ok: false,
+      reason: `ram:insufficient (${formatGB(free)} free < ${formatGB(minBytes)} required)`,
+      freeBytes: free,
+      totalBytes: total,
+    };
+  }
+  return { ok: true, freeBytes: free, totalBytes: total };
+}
+
+/**
+ * Combined capability check. Returns `{ capable, reasons[] }`.
+ * Caller decides what to do (bootstrap, warn, skip).
+ */
+export async function checkOllamaCapability({ minRamBytes = DEFAULT_MIN_RAM_BYTES } = {}) {
+  const reasons = [];
+  const docker = await checkDockerAvailable();
+  if (!docker.ok) reasons.push(docker.reason);
+  const ram = checkRamCapacity(minRamBytes);
+  if (!ram.ok) reasons.push(ram.reason);
+  return { capable: reasons.length === 0, reasons, docker, ram };
+}
+
+function formatGB(bytes) {
+  return `${(bytes / (1024 ** 3)).toFixed(1)} GB`;
+}
+
+/**
+ * Pull a model into the Ollama container. Uses `docker exec` so we do
+ * not depend on the host having `ollama` CLI installed. Wired by `kj
+ * init` after `ollamaUp`, and by `kj ollama pull <model>` (PR3).
+ */
+export async function pullOllamaModel(model, { containerName = "kj-ollama", timeoutMs = 10 * 60 * 1000 } = {}) {
+  if (!model || typeof model !== "string") throw new Error("pullOllamaModel: model is required");
+  return runCommand("docker", ["exec", containerName, "ollama", "pull", model], { timeout: timeoutMs });
+}

--- a/tests/rag/ollama-capability.test.js
+++ b/tests/rag/ollama-capability.test.js
@@ -1,0 +1,64 @@
+// KJC-TSK-0436 — capability check + model pull.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import os from "node:os";
+
+vi.mock("../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+import { runCommand } from "../../src/utils/process.js";
+import {
+  checkDockerAvailable, checkRamCapacity, checkOllamaCapability, pullOllamaModel,
+} from "../../src/rag/ollama-capability.js";
+
+describe("ollama-capability — KJC-TSK-0436", () => {
+  beforeEach(() => runCommand.mockReset());
+
+  it("checkDockerAvailable=ok when docker --version + docker info succeed", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0 }).mockResolvedValueOnce({ exitCode: 0 });
+    expect(await checkDockerAvailable()).toEqual({ ok: true });
+  });
+  it("checkDockerAvailable flags not-installed when --version exits non-zero", async () => {
+    runCommand.mockResolvedValue({ exitCode: 127 });
+    expect(await checkDockerAvailable()).toEqual({ ok: false, reason: "docker:not-installed" });
+  });
+  it("checkDockerAvailable flags daemon-unreachable when info fails", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0 }).mockResolvedValueOnce({ exitCode: 1 });
+    expect(await checkDockerAvailable()).toEqual({ ok: false, reason: "docker:daemon-unreachable" });
+  });
+
+  it("checkRamCapacity passes when free RAM >= minBytes", () => {
+    const free = os.freemem();
+    expect(checkRamCapacity(free - 1)).toMatchObject({ ok: true });
+  });
+  it("checkRamCapacity fails with reason when below minBytes", () => {
+    const r = checkRamCapacity(os.totalmem() * 10);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/ram:insufficient/);
+  });
+
+  it("checkOllamaCapability aggregates docker + ram reasons", async () => {
+    runCommand.mockResolvedValue({ exitCode: 127 });
+    const r = await checkOllamaCapability({ minRamBytes: os.totalmem() * 10 });
+    expect(r.capable).toBe(false);
+    expect(r.reasons).toContain("docker:not-installed");
+    expect(r.reasons.find((s) => s.startsWith("ram:insufficient"))).toBeTruthy();
+  });
+
+  it("checkOllamaCapability reports capable=true when both checks pass", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0 }).mockResolvedValueOnce({ exitCode: 0 });
+    const r = await checkOllamaCapability({ minRamBytes: 1 });
+    expect(r.capable).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+
+  it("pullOllamaModel invokes docker exec with ollama pull <model>", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "pulled", stderr: "" });
+    await pullOllamaModel("nomic-embed-text");
+    expect(runCommand).toHaveBeenCalledWith(
+      "docker",
+      ["exec", "kj-ollama", "ollama", "pull", "nomic-embed-text"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+  it("pullOllamaModel rejects when model missing", async () => {
+    await expect(pullOllamaModel()).rejects.toThrow(/model is required/);
+  });
+});


### PR DESCRIPTION
PR 2 of 3 for v2.26.0 **RAG Auto-Bootstrap**. Stacked on top of #825.

## What

After #825 added the Ollama-in-Docker manager, this PR wires it to `kj init` so a fresh project gets a working RAG embedder out of the box without any manual step.

## New module: src/rag/ollama-capability.js

```js
checkDockerAvailable()      // docker --version + docker info
checkRamCapacity(minBytes)  // os.freemem() >= 4 GB default
checkOllamaCapability()     // both, returning aggregated reasons[]
pullOllamaModel(model)      // docker exec kj-ollama ollama pull <m>
```

## kj init flow change

```text
1. handleConfigSetup + reviewRules + coderRules + gitignore + skills
2. → bootstrapOllama()                    ← NEW
3. Auto-detect project stack
```

Inside `bootstrapOllama`:
- `--no-ollama` flag → skip with explanatory log
- Capability check fails (no Docker / < 4 GB free) → warn + skip, don't crash
- Otherwise: `ollamaUp()` → `waitForOllamaReady()` → `pullOllamaModel('nomic-embed-text')`

## CLI flag

```text
kj init --no-ollama
[info] Ollama bootstrap skipped (--no-ollama). RAG embedder will be unavailable until you configure one.
```

Commander shape honoured (`flags.ollama === false` from `--no-ollama`).

## Files

- `src/rag/ollama-capability.js` — 59 LOC
- `src/commands/init.js` — `+bootstrapOllama()` 47 LOC
- `src/cli/register-pipeline.js` — `+1` flag
- `scripts/esbuild-sea.config.mjs` — `+3` stub exports
- `tests/rag/ollama-capability.test.js` — 9 cases (docker matrix, RAM threshold, aggregated capability, pull command shape, missing-model guard)

Net **+174 LOC**, under the 200 budget.

## Stacked PR

Base branch is `feat/KJC-TSK-0435-ollama-bootstrap-pr1` (#825). When #825 merges to main this PR will auto-rebase. Tests will still pass since the new module is independent — the wire in `kj init` imports symbols from `src/rag/ollama-manager.js` which PR1 introduces.

## Coming next

PR 3 (KJC-TSK-0437): `kj ollama [start|stop|status|pull]` subcommand + `kj doctor` check.