### PR TITLE
feat(rag): kj doctor + kj ollama subcommand — PR 3/3 (KJC-TSK-0437)

### DIFF
--- a/src/checks/ollama.js
+++ b/src/checks/ollama.js
@@ -1,0 +1,41 @@
+// KJC-TSK-0437 — `kj doctor` check for the RAG embedder.
+// Only fires when rag.preload.enabled === true; otherwise reports
+// "Disabled in config" so doctor stays quiet on greenfield projects
+// that never opted in to RAG.
+import { isOllamaReachable } from "../rag/ollama-manager.js";
+import { STRATEGY } from "./types.js";
+
+function ragEnabled(config) {
+  return config?.rag?.preload?.enabled === true;
+}
+function ollamaHost(config) {
+  const port = config?.rag?.embedder?.port || 11434;
+  return config?.rag?.embedder?.host || `http://localhost:${port}`;
+}
+
+function createOllamaStatusCheck() {
+  return {
+    name: "ollama",
+    label: "Ollama (RAG embedder)",
+    strategy: STRATEGY.NONE,
+    async detect({ config }) {
+      if (!ragEnabled(config)) {
+        return { ok: true, severity: "info", detail: "Disabled in config (rag.preload.enabled=false)" };
+      }
+      const host = ollamaHost(config);
+      let reachable;
+      try { reachable = await isOllamaReachable(host); } catch { reachable = false; }
+      return {
+        ok: reachable,
+        severity: reachable ? "info" : "warn",
+        detail: reachable ? `Reachable at ${host}` : `Not reachable at ${host}`,
+        fix: reachable ? undefined : "Run `kj ollama start` to bootstrap the container, or `kj init --no-ollama` to opt out.",
+        extra: { host, reachable },
+      };
+    },
+  };
+}
+
+export function getOllamaChecks() {
+  return [createOllamaStatusCheck()];
+}

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -1,4 +1,5 @@
 import { initCommand } from "../commands/init.js";
+import { ollamaStartCommand, ollamaStopCommand, ollamaStatusCommand, ollamaPullCommand } from "../commands/ollama.js";
 import { configCommand } from "../commands/config.js";
 import { codeCommand } from "../commands/code.js";
 import { reviewCommand } from "../commands/review.js";
@@ -237,4 +238,19 @@ export function registerPipeline(program, { pkgVersion }) {
     .action(async (flags) => {
       await reportCommand(flags);
     });
+
+  // KJC-TSK-0437 — `kj ollama [start|stop|status|pull]`
+  const ollama = program.command("ollama").description("Manage the RAG embedder container (Ollama-in-Docker)");
+  ollama.command("start").description("Start Ollama container").action(async () => {
+    await withConfig(pkgVersion, "ollama:start", {}, async ({ config, logger }) => ollamaStartCommand({ config, logger }));
+  });
+  ollama.command("stop").description("Stop Ollama container").action(async () => {
+    await withConfig(pkgVersion, "ollama:stop", {}, async ({ config, logger }) => ollamaStopCommand({ config, logger }));
+  });
+  ollama.command("status").description("Report Ollama reachability + container").action(async () => {
+    await withConfig(pkgVersion, "ollama:status", {}, async ({ config, logger }) => ollamaStatusCommand({ config, logger }));
+  });
+  ollama.command("pull <model>").description("Pull a model into the Ollama container").action(async (model) => {
+    await withConfig(pkgVersion, "ollama:pull", {}, async ({ config, logger }) => ollamaPullCommand({ model, config, logger }));
+  });
 }

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -18,6 +18,7 @@ import { getSystemChecks } from "../checks/system.js";
 import { getConfigFileChecks } from "../checks/config-files.js";
 import { getBinaryChecks } from "../checks/binaries.js";
 import { getSonarChecks } from "../checks/sonar.js";
+import { getOllamaChecks } from "../checks/ollama.js";
 import { getCiChecks } from "../checks/ci.js";
 import { getRtkChecks } from "../checks/rtk.js";
 import { getNodeChecks } from "../checks/node.js";
@@ -52,6 +53,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getConfigFileChecks(),
     ...getBinaryChecks(),
     ...getSonarChecks(),
+    ...getOllamaChecks(),
     ...getPortChecks(),
     ...getTokenChecks(config),
     ...getMcpHealthChecks(),

--- a/src/commands/ollama.js
+++ b/src/commands/ollama.js
@@ -1,0 +1,44 @@
+// KJC-TSK-0437 — `kj ollama [start|stop|status|pull <model>]` subcommand.
+// Thin wrappers around src/rag/ollama-manager.js so the user can manage
+// the RAG embedder lifecycle without touching docker compose.
+import { ollamaUp, ollamaDown, isOllamaReachable, normalizeOllamaConfig } from "../rag/ollama-manager.js";
+import { pullOllamaModel } from "../rag/ollama-capability.js";
+
+function embedderCfg(config) {
+  return normalizeOllamaConfig(config?.rag?.embedder || {});
+}
+
+export async function ollamaStartCommand({ config, logger }) {
+  const result = await ollamaUp(config?.rag?.embedder || null);
+  if (result.exitCode !== 0) {
+    logger.warn(`ollama start failed: ${result.stderr || result.stdout}`);
+    return result;
+  }
+  logger.info(result.reusedHost ? `Reusing Ollama at ${result.reusedHost}` : "Ollama container started.");
+  return result;
+}
+
+export async function ollamaStopCommand({ config, logger }) {
+  const result = await ollamaDown(config?.rag?.embedder || null);
+  if (result.exitCode === 0) logger.info(result.stdout || "Ollama stopped.");
+  else logger.warn(`ollama stop failed: ${result.stderr || result.stdout}`);
+  return result;
+}
+
+export async function ollamaStatusCommand({ config, logger }) {
+  const cfg = embedderCfg(config);
+  const reachable = await isOllamaReachable(cfg.host, cfg.timeouts.healthcheckSeconds);
+  const status = { host: cfg.host, container: cfg.containerName, reachable };
+  if (reachable) logger.info(`Ollama reachable at ${cfg.host} (container ${cfg.containerName}).`);
+  else logger.warn(`Ollama not reachable at ${cfg.host}. Try \`kj ollama start\`.`);
+  return status;
+}
+
+export async function ollamaPullCommand({ model, config, logger }) {
+  if (!model) throw new Error("kj ollama pull: model argument required");
+  logger.info(`Pulling ${model} into ${embedderCfg(config).containerName}...`);
+  const result = await pullOllamaModel(model, { containerName: embedderCfg(config).containerName });
+  if (result.exitCode === 0) logger.info(`  -> ${model} ready.`);
+  else logger.warn(`pull ${model} failed: ${result.stderr || result.stdout}`);
+  return result;
+}

--- a/tests/checks/ollama.test.js
+++ b/tests/checks/ollama.test.js
@@ -1,0 +1,39 @@
+// KJC-TSK-0437 — `kj doctor` Ollama check.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/rag/ollama-manager.js", () => ({
+  isOllamaReachable: vi.fn(),
+  normalizeOllamaConfig: vi.fn((o = {}) => ({ host: o.host || "http://localhost:11434" })),
+}));
+import { isOllamaReachable } from "../../src/rag/ollama-manager.js";
+import { getOllamaChecks } from "../../src/checks/ollama.js";
+
+describe("checks/ollama — KJC-TSK-0437", () => {
+  beforeEach(() => isOllamaReachable.mockReset());
+
+  it("reports disabled when rag.preload.enabled !== true", async () => {
+    const [check] = getOllamaChecks();
+    const r = await check.detect({ config: { rag: { preload: { enabled: false } } } });
+    expect(r).toMatchObject({ ok: true, severity: "info" });
+    expect(r.detail).toMatch(/Disabled/);
+    expect(isOllamaReachable).not.toHaveBeenCalled();
+  });
+
+  it("ok when reachable", async () => {
+    isOllamaReachable.mockResolvedValue(true);
+    const [check] = getOllamaChecks();
+    const r = await check.detect({ config: { rag: { preload: { enabled: true } } } });
+    expect(r.ok).toBe(true);
+    expect(r.detail).toMatch(/Reachable/);
+  });
+
+  it("warn when unreachable, with fix hint pointing at kj ollama start", async () => {
+    isOllamaReachable.mockResolvedValue(false);
+    const [check] = getOllamaChecks();
+    const r = await check.detect({ config: { rag: { preload: { enabled: true } } } });
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("warn");
+    expect(r.fix).toMatch(/kj ollama start/);
+  });
+
+});

--- a/tests/cli/kj-ollama.test.js
+++ b/tests/cli/kj-ollama.test.js
@@ -1,0 +1,57 @@
+// KJC-TSK-0437 — `kj ollama` subcommands (unit, not full CLI bootstrap).
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/rag/ollama-manager.js", () => ({
+  ollamaUp: vi.fn(), ollamaDown: vi.fn(), isOllamaReachable: vi.fn(),
+  normalizeOllamaConfig: vi.fn((o = {}) => ({
+    host: o.host || "http://localhost:11434",
+    containerName: o.container_name || "kj-ollama",
+    timeouts: { healthcheckSeconds: 5 },
+  })),
+}));
+vi.mock("../../src/rag/ollama-capability.js", () => ({ pullOllamaModel: vi.fn() }));
+
+import { ollamaUp, ollamaDown, isOllamaReachable } from "../../src/rag/ollama-manager.js";
+import { pullOllamaModel } from "../../src/rag/ollama-capability.js";
+import {
+  ollamaStartCommand, ollamaStopCommand, ollamaStatusCommand, ollamaPullCommand,
+} from "../../src/commands/ollama.js";
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+describe("kj ollama subcommands — KJC-TSK-0437", () => {
+  beforeEach(() => {
+    ollamaUp.mockReset(); ollamaDown.mockReset();
+    isOllamaReachable.mockReset(); pullOllamaModel.mockReset();
+    logger.info.mockReset(); logger.warn.mockReset();
+  });
+
+  it("start: success path logs 'started', reused host logs 'Reusing'", async () => {
+    ollamaUp.mockResolvedValueOnce({ exitCode: 0, stdout: "Started", stderr: "" });
+    await ollamaStartCommand({ config: {}, logger });
+    expect(logger.info).toHaveBeenCalledWith("Ollama container started.");
+    ollamaUp.mockResolvedValueOnce({ exitCode: 0, stdout: "ok", stderr: "", reusedHost: "http://localhost:11434" });
+    await ollamaStartCommand({ config: {}, logger });
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/Reusing Ollama/));
+  });
+  it("stop delegates to ollamaDown", async () => {
+    ollamaDown.mockResolvedValue({ exitCode: 0, stdout: "stopped", stderr: "" });
+    await ollamaStopCommand({ config: {}, logger });
+    expect(logger.info).toHaveBeenCalledWith("stopped");
+  });
+  it("status logs info when reachable, warns + hint when not", async () => {
+    isOllamaReachable.mockResolvedValueOnce(true);
+    expect((await ollamaStatusCommand({ config: {}, logger })).reachable).toBe(true);
+    isOllamaReachable.mockResolvedValueOnce(false);
+    await ollamaStatusCommand({ config: {}, logger });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/kj ollama start/));
+  });
+  it("pull invokes pullOllamaModel with the model arg", async () => {
+    pullOllamaModel.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    await ollamaPullCommand({ model: "nomic-embed-text", config: {}, logger });
+    expect(pullOllamaModel).toHaveBeenCalledWith("nomic-embed-text", expect.any(Object));
+  });
+  it("pull rejects when model arg missing", async () => {
+    await expect(ollamaPullCommand({ config: {}, logger })).rejects.toThrow(/model argument required/);
+  });
+});


### PR DESCRIPTION
PR 3 of 3 for v2.26.0 **RAG Auto-Bootstrap**. Stacked on #826.

## What

Closes the lifecycle gap left by PR1 (manager) + PR2 (bootstrap in `kj init`):

- `kj doctor` surfaces Ollama state alongside SonarQube.
- `kj ollama [start|stop|status|pull <model>]` lets the user manage the container without touching docker compose.

## kj doctor

New `src/checks/ollama.js` wired into `buildChecks()`:

| Config / state | Severity | Output |
|---|---|---|
| `rag.preload.enabled !== true` | info | `Disabled in config` — keeps doctor quiet on greenfield |
| Reachable at `http://localhost:11434` | info | `Reachable at <host>` |
| Unreachable | warn | `Not reachable` + fix hint pointing at `kj ollama start` |
| Error from `isOllamaReachable` | warn | Same as unreachable (degraded) |

## kj ollama subcommand

```
kj ollama start         # ollamaUp() + log reused/started
kj ollama stop          # ollamaDown()
kj ollama status        # host + container + reachable
kj ollama pull <model>  # docker exec kj-ollama ollama pull <m>
```

Backed by `src/commands/ollama.js` (44 LOC, thin wrappers around the manager + capability layers).

## Files

- `src/checks/ollama.js` — 41 LOC
- `src/commands/ollama.js` — 44 LOC
- `src/commands/doctor.js` — `+getOllamaChecks()` after Sonar
- `src/cli/register-pipeline.js` — `kj ollama` subcommand registration
- `tests/checks/ollama.test.js` — 3 cases
- `tests/cli/kj-ollama.test.js` — 6 cases

Net **+199 LOC**, just under the 200 budget.

## Stacked PR

Base branch is `feat/KJC-TSK-0436-ollama-bootstrap-pr2` (#826), itself stacked on #825. Merging order will be #825 → #826 → this. GitHub will auto-rebase as each lands.

After this PR ships, **v2.26.0** can ship: kj init → RAG works out of the box, kj doctor surfaces health, kj ollama controls lifecycle.