### PR TITLE
chore: release v2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.26.0] - 2026-05-24
+
+Minor release. **RAG Auto-Bootstrap** — Ollama runs in Docker out of the box.
+
+Closes the friction caught in the v2.25.0 smoke test: RAG required a manually installed Ollama, which made the feature invisible to new users. From v2.26.0, `kj init` provisions Ollama in Docker, pulls `nomic-embed-text`, and wires the embedder into the config — same opt-out shape as SonarQube.
+
+### Added
+
+- **Ollama-in-Docker manager** (KJC-TSK-0435, PR #825). `src/rag/ollama-manager.js` mirrors `src/sonar/manager.js`: `normalizeOllamaConfig`, `buildComposeTemplate`, `ensureComposeFile`, `isOllamaReachable`, `waitForOllamaReady`, `findAvailableOllamaPort`, `ollamaUp` / `ollamaDown`. `ollamaUp` short-circuits when the host is already reachable (returns `reusedHost`) and refuses when `external=true` and unreachable.
+- **Capability check + auto-pull + `kj init` bootstrap** (KJC-TSK-0436, PR #828). `src/rag/ollama-capability.js` checks Docker availability + free RAM (>= 4 GB default). `kj init` runs `bootstrapOllama()` after installing skills: skip on `--no-ollama`, skip with warning on capability fail, otherwise `ollamaUp()` + `waitForOllamaReady()` + `pullOllamaModel('nomic-embed-text')`.
+- **`kj doctor` Ollama check + `kj ollama` subcommand** (KJC-TSK-0437, PR #827). New `src/checks/ollama.js` and `src/commands/ollama.js`. `kj ollama [start|stop|status|pull <model>]` lets the user manage the container without touching docker compose.
+
+### CLI flags
+
+`kj init --no-ollama` — skip the RAG embedder bootstrap.
+
+### Behaviour matrix
+
+| Scenario | What happens |
+|---|---|
+| `kj init` on Linux with Docker + 8 GB free | Container starts, model pulls, RAG ready |
+| `kj init` on Windows without Docker | Warn `docker:not-installed`, init continues |
+| `kj init --no-ollama` | Skip with one-line log |
+| Host with Ollama on :11434 already | Reuses external instance |
+| `kj doctor`, `rag.preload.enabled=true`, container down | `warn` + fix hint `kj ollama start` |
+
+### Bug fix bundled
+
+- **KJC-BUG-0061** (PR #824): smoke test of v2.25.0 caught two latent bugs in `kj onboard` and a CLI/MCP empty-store contract mismatch. Fixed and shipped between v2.25.0 and v2.26.0.
+
 ## [2.25.0] - 2026-05-24
 
 Minor release. **RAG Camino B + Camino D** (KJC-PCS-0049). Closes the consumer-surface plan: Skills hosts can now invoke RAG without MCP, and the pre-loop retrieval stage only fires when triage signals make it worthwhile.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.26.0 released** — Minor. **RAG Auto-Bootstrap** — Ollama runs in Docker out of the box. `kj init` now provisions the embedder automatically (or skips with a clear reason on modest hardware / `--no-ollama`); `kj doctor` surfaces health; `kj ollama [start|stop|status|pull]` manages lifecycle without docker compose.
+>
+> Capability check (RAM + Docker) means the bootstrap never breaks init: on Windows without Docker Desktop, on hosts under 4 GB free, or with `--no-ollama`, the wizard logs a one-liner and continues. Where Ollama is already running on `:11434`, `kj init` reuses the external instance instead of spawning a second container.
+>
+> Bundles **KJC-BUG-0061** fix (caught during v2.25.0 smoke test): `kj onboard --no-synth` was ignored by Commander shape mapping, `OnboarderRole.run()` was called without `init()`, and `kj rag query --json` on empty store emitted just `[]` instead of the `{empty: true}` contract the MCP handler returns.
+>
+> **Coming in v2.27.0+**: chokidar watcher for live re-indexing, AST source chunker (tree-sitter / @babel/parser), BM25 + cosine hybrid scoring, OpenAI/Voyage embedder adapters (for users without local Docker).
+>
 > **v2.25.0 released** — Minor. **RAG Camino B + Camino D** (KJC-PCS-0049). Closes the consumer-surface plan. Skills hosts can now invoke RAG via `/kj-rag-query` without MCP, and the pre-loop retrieval stage from v2.24.0 only fires when triage signals make it worthwhile.
 >
 > Camino B — `/kj-rag-query <text> [--scope <s>] [--top-k <n>]` slash command shipped by `kj init` to `.claude/commands/`. Thin wrapper over `kj rag query`; passes flags through, surfaces `empty:true` as a one-line hint, renders hits as background context rather than raw JSON. For Claude Code / Cursor instances loaded without MCP.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (53k LOC, 387 files)
+├── src/              # Source code (53k LOC, 391 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.25.0
+kj --version    # 2.26.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.25.0
+kj --version    # 2.26.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Closes v2.26.0 = **RAG Auto-Bootstrap**. Ollama runs in Docker out of the box, resolving the friction caught during the v2.25.0 smoke test (the feature was invisible until users manually installed an embedder).

## What landed since v2.25.0

| PR | Title |
|---|---|
| #824 | fix(rag/onboard): smoke-test fixes (KJC-BUG-0061) |
| #825 | feat(rag): Ollama-in-Docker manager (KJC-TSK-0435) |
| #828 | feat(rag): capability check + auto-pull + kj init (KJC-TSK-0436) |
| #827 | feat(rag): kj doctor + kj ollama subcommand (KJC-TSK-0437) |

## Files touched in this release PR

- `package.json` + `package-lock.json` — 2.25.0 → 2.26.0
- `CHANGELOG.md` — new `[2.26.0]` entry
- `README.md` — release banner refreshed
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` — version line
- `docs/ARCHITECTURE.md` — 391 src files, 443 test files

## Smoke test plan

After merge:
1. Tag v2.26.0 + GitHub release
2. npm publish
3. Build + deploy landing (history Phase 80 + Recent releases card)
4. Smoke on a fresh sandbox: `kj init` (no --no-ollama) on a host **with** Docker available, verify container starts + model pulls + `kj doctor` reports reachable. Then `kj rag query` against an indexed onboarding brief should now return real hits (the missing piece in the v2.25.0 smoke).