### PR TITLE
fix(rag): indexer skips .kj/ worktrees and _diet sandboxes (KJC-BUG-0062)

### DIFF
--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -105,7 +105,12 @@ export async function indexProject(projectDir, { db, embedder, karajanHome, logg
     totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
   }
   if (withSources) {
-    const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next"]);
+    // KJC-BUG-0062: `.kj/worktrees/HU-*/` contains git worktrees Karajan spawns
+    // per HU during `kj run`; they hold complete copies of `src/` that
+    // duplicate every chunk and contaminate retrieval scores. `_diet` is the
+    // tests/_diet/ sandbox used by the test-diet audit harness — never user
+    // code. Skip both.
+    const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
     const sources = await listFiles(projectDir, (p) => /\.(js|mjs|cjs|ts|tsx|jsx)$/.test(p) && !p.split("/").some((seg) => SKIP.has(seg)));
     for (const s of sources) {
       const r = await indexFile(s, { db, embedder, logger });

--- a/tests/rag/indexer.test.js
+++ b/tests/rag/indexer.test.js
@@ -75,4 +75,19 @@ describe("indexer — KJC-PCS-0049 Step 4", () => {
     expect(totals.files).toBe(1); // only src/main.js
     expect(countChunks(db, { kind: "code" })).toBeGreaterThan(0);
   });
+
+  // KJC-BUG-0062: `.kj/worktrees/HU-*/` and `tests/_diet/` are scratch
+  // sandboxes (per-HU git worktrees and the test-diet audit harness).
+  // They contain duplicates of src/ that contaminate retrieval scores.
+  it("indexProject --with-sources skips .kj/ worktrees and _diet sandboxes", async () => {
+    const projectDir = join(root, "p3");
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    mkdirSync(join(projectDir, ".kj", "worktrees", "HU-001", "src"), { recursive: true });
+    mkdirSync(join(projectDir, "tests", "_diet"), { recursive: true });
+    writeFileSync(join(projectDir, "src", "main.js"), "export function alpha() { return 1; }");
+    writeFileSync(join(projectDir, ".kj", "worktrees", "HU-001", "src", "dup.js"), "export function dup() {}");
+    writeFileSync(join(projectDir, "tests", "_diet", "noise.js"), "export function noise() {}");
+    const totals = await indexProject(projectDir, { db, embedder: fakeEmbedder(), karajanHome: join(root, "missing-2"), logger: noopLogger, withSources: true });
+    expect(totals.files).toBe(1); // only src/main.js
+  });
 });


### PR DESCRIPTION
## v2.26.0 smoke test on karajan-code itself caught this

Indexing the repo with `kj rag index --with-sources` was absorbing 2193 files when only ~900 should enter:

```
$ find . -name '*.js' -not -path '*/node_modules/*' ... | wc -l → 2193
$ find . -name '*.js' -path '*/.kj/*' | wc -l → 1288
$ find ... -not -path '*/.kj/*' -not -path '*/_diet/*' ... | wc -l → 904
```

1288 of those 2193 came from `.kj/worktrees/HU-*/` (per-HU git worktrees Karajan spawns during `kj run`, each holding a full copy of `src/`). The rest came from `tests/_diet/` (test-diet audit sandbox).

## Effect on retrieval

Every source chunk was indexed N+1 times where N = active worktrees. Duplicates ranked higher than the canonical `src/` because their content was identical and the kind-boost was the same (`code`).

Visible in the v2.26.0 smoke output:
```
🔍 "how do I store JWT tokens"
  #1 [code] .kj/worktrees/HU-002/src/auth.js   ← duplicate
  #2 [code] .kj/worktrees/HU-002/src/auth.js   ← duplicate
```

Real source's auth.js got pushed out of top-K by the duplicates.

## Fix

```diff
-const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next"]);
+const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
```

Plus a regression test pinning both exclusions in `tests/rag/indexer.test.js` (6/6 cases passing).

This is bundle material for v2.26.1 patch, or can wait for v2.27.0.