### PR TITLE
feat(rag): per-project isolation via project_slug column — PR 1/3 (KJC-TSK-0438)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -168,6 +168,8 @@ const ragStubPlugin = {
           // KJC-TSK-0436 — Ollama capability check + model pull.
           checkDockerAvailable: notAvailable, checkRamCapacity: notAvailable,
           checkOllamaCapability: notAvailable, pullOllamaModel: notAvailable,
+          // KJC-TSK-0438 — RAG project isolation.
+          projectSlug: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -113,6 +113,7 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Run a semantic query against the indexed RAG corpus")
     .option("--scope <scope>", "plans | code | onboarding | all (default: all)", "all")
     .option("--top-k <n>", "Number of hits to return (default: 5)", "5")
+    .option("--project <slug>", "Filter by project slug. Pass 'all' to query across every indexed project. Default: cwd basename")
     .option("--json", "Output the hits as JSON")
     .action(async (text, flags) => {
       await withConfig(pkgVersion, "rag-query", flags, async ({ config, logger }) => {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -43,6 +43,13 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
   try {
     const topK = Math.max(1, Number(flags.topK) || 5);
     const scope = flags.scope || "all";
+    // KJC-TSK-0438 — project isolation. Auto-detect slug from projectDir
+    // (basename normalised); `--project all` disables the filter, `--project
+    // <slug>` overrides. Pre-v2.27 chunks with NULL slug are only visible
+    // when no filter is in effect.
+    const { projectSlug } = await import("../rag/vec-store.js");
+    const detected = projectSlug(config?.projectDir || process.cwd());
+    const project = flags.project === "all" ? null : (flags.project || detected || null);
     // KJC-BUG-0061 follow-up: align the CLI `--json` shape with the MCP
     // handler. The MCP tool responds `{ hits: [], empty: true, topK, scope }`
     // so agents (and the `/kj-rag-query` skill from Camino B) have a
@@ -54,7 +61,7 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
       if (flags.json) process.stdout.write(`${JSON.stringify({ hits: [], empty: true, topK, scope })}\n`);
       return [];
     }
-    const hits = await query(db, makeEmbedder(config), text, { topK, scope });
+    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);
     } else {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -2,7 +2,7 @@
 //   kj rag index [--project <slug>] [--with-sources]
 //   kj rag query <text>   [--scope plans|code|onboarding|all] [--top-k N] [--json]
 // Closes the v2.22.0 RAG MVP end-to-end from the terminal.
-import { openVecStore, countChunks } from "../rag/vec-store.js";
+import { openVecStore, countChunks, projectSlug } from "../rag/vec-store.js";
 import { OllamaEmbedder } from "../rag/embedder.js";
 import { indexProject } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
@@ -47,7 +47,6 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     // (basename normalised); `--project all` disables the filter, `--project
     // <slug>` overrides. Pre-v2.27 chunks with NULL slug are only visible
     // when no filter is in effect.
-    const { projectSlug } = await import("../rag/vec-store.js");
     const detected = projectSlug(config?.projectDir || process.cwd());
     const project = flags.project === "all" ? null : (flags.project || detected || null);
     // KJC-BUG-0061 follow-up: align the CLI `--json` shape with the MCP

--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -41,7 +41,7 @@ function chunksFor(path, kind) {
  * fresh batch is written, so a second call against the same file
  * leaves the store with exactly the latest chunks (no duplicates).
  */
-export async function indexFile(path, { db, embedder, logger = console } = {}) {
+export async function indexFile(path, { db, embedder, logger = console, project = null } = {}) {
   if (!existsSync(path)) { logger.warn?.(`[rag-indexer] file not found: ${path}`); return { indexed: 0, failed: 0 }; }
   const kind = detectKind(path);
   if (!kind) { logger.warn?.(`[rag-indexer] unknown kind: ${path}`); return { indexed: 0, failed: 0 }; }
@@ -53,7 +53,7 @@ export async function indexFile(path, { db, embedder, logger = console } = {}) {
   for (const ch of chunks) {
     try {
       const embedding = await embedder.embed(ch.text);
-      insertChunk(db, { source: path, kind: ch.metadata.kind || kind, text: ch.text, metadata: ch.metadata, embedding });
+      insertChunk(db, { source: path, kind: ch.metadata.kind || kind, text: ch.text, metadata: ch.metadata, embedding, project });
       indexed += 1;
     } catch (err) {
       failed += 1;
@@ -95,13 +95,13 @@ export async function indexProject(projectDir, { db, embedder, karajanHome, logg
   if (existsSync(planRoot)) {
     const plans = await listFiles(planRoot, (p) => /plan-.*\.json$/.test(p));
     for (const p of plans) {
-      const r = await indexFile(p, { db, embedder, logger });
+      const r = await indexFile(p, { db, embedder, logger, project: slug });
       totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
     }
   }
   const onboarding = join(karajanHome, ONBOARDING_DIR, `${slug}.md`);
   if (existsSync(onboarding)) {
-    const r = await indexFile(onboarding, { db, embedder, logger });
+    const r = await indexFile(onboarding, { db, embedder, logger, project: slug });
     totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
   }
   if (withSources) {
@@ -113,7 +113,7 @@ export async function indexProject(projectDir, { db, embedder, karajanHome, logg
     const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
     const sources = await listFiles(projectDir, (p) => /\.(js|mjs|cjs|ts|tsx|jsx)$/.test(p) && !p.split("/").some((seg) => SKIP.has(seg)));
     for (const s of sources) {
-      const r = await indexFile(s, { db, embedder, logger });
+      const r = await indexFile(s, { db, embedder, logger, project: slug });
       totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
     }
   }

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -25,7 +25,7 @@ const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
  * @param {'plans'|'code'|'onboarding'|'all'} [opts.scope='all']
  * @param {Object} [opts.kindBoost]
  */
-export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST } = {}) {
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null } = {}) {
   if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
   const queryEmbedding = await embedder.embed(text);
   // Over-fetch (topK * 2) so the rerank step has room to reshuffle
@@ -33,7 +33,10 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   // avoid loading the entire store on tiny topK calls.
   const fetchK = Math.min(50, topK * 2);
   const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
-  const raw = searchSimilar(db, queryEmbedding, fetchK, { kind: scopeKind });
+  // KJC-TSK-0438 — `project` filters by chunks.project_slug. null means
+  // no filter (pre-v2.27 behaviour). Caller's CLI defaults this to the
+  // basename of cwd; pass "all" through commands/rag.js to disable.
+  const raw = searchSimilar(db, queryEmbedding, fetchK, { kind: scopeKind, project });
   if (raw.length === 0) return [];
   // Adjust each chunk's distance by its kind boost. The vec store returns
   // cosine distance (smaller = closer); subtracting the boost makes

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -45,6 +45,14 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     CREATE INDEX IF NOT EXISTS chunks_by_source ON chunks(source);
     CREATE INDEX IF NOT EXISTS chunks_by_kind ON chunks(kind);
   `);
+  // KJC-TSK-0438 — Project isolation. project_slug = basename of projectDir
+  // normalized; chunks indexed before the migration carry NULL and remain
+  // queryable when `--project all` (or no slug detected at query time).
+  const cols = db.prepare("PRAGMA table_info(chunks)").all().map((c) => c.name);
+  if (!cols.includes("project_slug")) {
+    db.exec("ALTER TABLE chunks ADD COLUMN project_slug TEXT;");
+    db.exec("CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);");
+  }
   db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[${dim}]);`);
   return db;
 }
@@ -54,13 +62,13 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
  * because the virtual table rowid is set explicitly to the freshly
  * minted chunks.id. Returns that id.
  */
-export function insertChunk(db, { source, kind, text, metadata = null, embedding }) {
+export function insertChunk(db, { source, kind, text, metadata = null, embedding, project = null }) {
   if (!Array.isArray(embedding) && !ArrayBuffer.isView(embedding)) {
     throw new Error("insertChunk: embedding must be an array or typed array of floats");
   }
   const meta = metadata == null ? null : (typeof metadata === "string" ? metadata : JSON.stringify(metadata));
-  const ins = db.prepare("INSERT INTO chunks (source, kind, text, metadata) VALUES (?, ?, ?, ?)");
-  const info = ins.run(source, kind, text, meta);
+  const ins = db.prepare("INSERT INTO chunks (source, kind, text, metadata, project_slug) VALUES (?, ?, ?, ?, ?)");
+  const info = ins.run(source, kind, text, meta, project);
   // sqlite-vec's vec0 virtual table requires the rowid to arrive as a BigInt
   // even for values that comfortably fit in a Number. Better-sqlite3 returns
   // lastInsertRowid as BigInt only when safeIntegers mode is on; force it.
@@ -75,20 +83,34 @@ export function insertChunk(db, { source, kind, text, metadata = null, embedding
  * text, metadata, distance }]` for the topK best matches; lower
  * distance = closer. Returns `[]` when the store is empty.
  */
-export function searchSimilar(db, embedding, topK = 5, { kind = null } = {}) {
+export function searchSimilar(db, embedding, topK = 5, { kind = null, project = null } = {}) {
   const buf = embedding instanceof Float32Array ? embedding : Float32Array.from(embedding);
   const kindClause = kind ? "AND c.kind = ?" : "";
+  const projectClause = project ? "AND c.project_slug = ?" : "";
   const sql = `
-    SELECT c.id, c.source, c.kind, c.text, c.metadata, v.distance
+    SELECT c.id, c.source, c.kind, c.text, c.metadata, c.project_slug, v.distance
     FROM vec_chunks v
     JOIN chunks c ON c.id = v.rowid
-    WHERE v.embedding MATCH ? AND k = ? ${kindClause}
+    WHERE v.embedding MATCH ? AND k = ? ${kindClause} ${projectClause}
     ORDER BY v.distance
   `;
   const params = [Buffer.from(buf.buffer), topK];
   if (kind) params.push(kind);
+  if (project) params.push(project);
   const rows = db.prepare(sql).all(...params);
   return rows.map((r) => ({ ...r, metadata: r.metadata ? safeParse(r.metadata) : null }));
+}
+
+/**
+ * Normalize a projectDir into a stable slug used for project isolation.
+ * Basename → lowercased → non-alphanumeric stripped to dashes.
+ * KJC-TSK-0438.
+ */
+export function projectSlug(projectDir) {
+  if (!projectDir) return null;
+  const base = String(projectDir).replace(/\/+$/, "").split("/").pop();
+  if (!base) return null;
+  return base.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return s; } }

--- a/tests/rag/vec-store.test.js
+++ b/tests/rag/vec-store.test.js
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-  openVecStore, insertChunk, searchSimilar, deleteChunksBySource, countChunks, dbPath,
+  openVecStore, insertChunk, searchSimilar, deleteChunksBySource, countChunks, dbPath, projectSlug,
 } from "../../src/rag/vec-store.js";
 
 // Synthetic one-hot embeddings → predictable cosine ordering.
@@ -80,5 +80,40 @@ describe("vec-store — KJC-PCS-0049 Step 1", () => {
     process.env.KJ_RAG_DB = "/tmp/x.db";
     try { expect(dbPath()).toBe("/tmp/x.db"); }
     finally { if (prev === undefined) delete process.env.KJ_RAG_DB; else process.env.KJ_RAG_DB = prev; }
+  });
+
+  // KJC-TSK-0438 — project isolation
+  it("projectSlug normalises projectDir into a stable slug", () => {
+    expect(projectSlug("/home/x/karajan-code")).toBe("karajan-code");
+    expect(projectSlug("/home/x/My Project/")).toBe("my-project");
+    expect(projectSlug("")).toBeNull();
+    expect(projectSlug(null)).toBeNull();
+  });
+
+  it("insertChunk persists project_slug and searchSimilar filters by it", () => {
+    insertChunk(db, { source: "/proja/a", kind: "code", text: "alpha", embedding: oneHot(0), project: "proja" });
+    insertChunk(db, { source: "/projb/a", kind: "code", text: "beta", embedding: oneHot(0), project: "projb" });
+    insertChunk(db, { source: "/legacy/a", kind: "code", text: "legacy", embedding: oneHot(0) /* no project */ });
+    const onlyA = searchSimilar(db, oneHot(0), 5, { project: "proja" });
+    expect(onlyA.length).toBe(1);
+    expect(onlyA[0].text).toBe("alpha");
+    const noFilter = searchSimilar(db, oneHot(0), 5);
+    expect(noFilter.length).toBe(3); // pre-migration chunks still queryable
+  });
+
+  it("openVecStore migrates old DBs without project_slug column", () => {
+    // Recreate without ALTER (simulate v2.26 schema)
+    db.close();
+    rmSync(dbFile, { force: true });
+    const legacy = openVecStore({ dim: 8, path: dbFile });
+    // Drop the column to simulate older schema, re-open should re-add it
+    legacy.exec("CREATE TABLE temp_chunks AS SELECT id, source, kind, text, metadata, created_at FROM chunks");
+    legacy.exec("DROP TABLE chunks");
+    legacy.exec("ALTER TABLE temp_chunks RENAME TO chunks");
+    legacy.close();
+    const migrated = openVecStore({ dim: 8, path: dbFile });
+    const cols = migrated.prepare("PRAGMA table_info(chunks)").all().map((c) => c.name);
+    expect(cols).toContain("project_slug");
+    migrated.close();
   });
 });


### PR DESCRIPTION
PR 1 of 3 for v2.27.0. Closes the DB-mixing issue caught in the v2.26.0 smoke test.

## Problem

`~/.karajan/rag.db` is global (single SQLite shared across every indexed project). Smoke on karajan-code itself showed chunks from a /tmp sandbox getting mixed with chunks from the karajan-code repo, since both went into the same store with no isolation key.

## Fix

Schema migration (non-breaking): add `project_slug TEXT` column on `openVecStore`. Pre-v2.27 chunks carry NULL and remain queryable when no filter is in effect.

### API

```js
insertChunk(db, { ..., project: 'slug' })
searchSimilar(db, vec, topK, { project: 'slug' })  // null = no filter
projectSlug(projectDir)  // basename → lowercased, [a-z0-9._-] only
```

`indexProject` derives the slug from `projectDir` and writes it on every chunk.

### CLI

```
kj rag query "text"                  # auto-detect slug from cwd basename
kj rag query "text" --project lib   # override
kj rag query "text" --project all   # disable filter
```

## Files

- `src/rag/vec-store.js` — schema migration + `project` param + `projectSlug()` helper
- `src/rag/indexer.js` — propagate slug into every `indexFile` call
- `src/rag/retriever.js` — pass-through `project` option
- `src/commands/rag.js` — CLI auto-detect + `--project` flag
- `src/cli/register-meta.js` — flag declaration
- `scripts/esbuild-sea.config.mjs` — stub plugin extended
- `tests/rag/vec-store.test.js` — 3 new cases (slug helper, filter, migration)

**Net +85 LOC**, all RAG tests 56/56.

## Coming next

PR 2: `docs/RAG.md` unified (EN + ES) consolidating CHANGELOG / README / templates / landing.

PR 3: asymmetric kind-boost to fix the test-bias caught in the v2.26 smoke (queries like `how does X work` returning `tests/X.test.js` ahead of `src/X.js`).