### PR TITLE
feat(rag): asymmetric source-vs-test kind boost — PR 3/3 (KJC-TSK-0440)

### DIFF
--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -10,6 +10,24 @@ import { searchSimilar } from "./vec-store.js";
 // between equidistant chunks but won't reorder by big distance gaps.
 const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
 
+// KJC-TSK-0440 — asymmetric source/test boost. v2.26 smoke caught a
+// systematic bias: queries in natural language ("how does X work") return
+// tests/X.test.js ahead of src/X.js because tests carry more descriptive
+// prose. When the query itself does NOT mention test-flavoured terms,
+// give code chunks +0.05 — but only chunks whose source path is NOT a
+// test file. Tests keep the baseline boost.
+const SOURCE_BOOST_NON_TEST = 0.05;
+const TEST_TERMS_RE = /\b(test|tests|spec|specs|expect|describe|it\(|jest|vitest|mocha)\b/i;
+const TEST_PATH_RE = /[\\/](tests?|specs?|__tests__)[\\/]|\.test\.[jt]sx?$|\.spec\.[jt]sx?$/i;
+
+function shouldBoostSources(queryText) {
+  return !TEST_TERMS_RE.test(queryText);
+}
+
+function isTestPath(source) {
+  return TEST_PATH_RE.test(source || "");
+}
+
 /**
  * Run a natural-language query against the indexed RAG corpus. Returns
  * the top-K chunks ranked by adjusted distance (lower = closer).
@@ -42,9 +60,18 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   // cosine distance (smaller = closer); subtracting the boost makes
   // higher-priority kinds appear "closer" without altering the source
   // truth in the DB.
-  const reranked = raw.map((r) => ({
-    ...r,
-    score: r.distance - (kindBoost[r.kind] || 0),
-  })).sort((a, b) => a.score - b.score).slice(0, topK);
+  // KJC-TSK-0440 — apply the source-vs-test asymmetric boost only when
+  // the query itself is not test-flavoured. Test-flavoured queries keep
+  // the symmetric baseline so e.g. "vitest mock setup" still surfaces
+  // test files.
+  const boostSources = shouldBoostSources(text);
+  const reranked = raw.map((r) => {
+    const kindB = kindBoost[r.kind] || 0;
+    const sourceB = (boostSources && r.kind === "code" && !isTestPath(r.source)) ? SOURCE_BOOST_NON_TEST : 0;
+    return { ...r, score: r.distance - kindB - sourceB };
+  }).sort((a, b) => a.score - b.score).slice(0, topK);
   return reranked;
 }
+
+// Exported for tests.
+export { shouldBoostSources, isTestPath };

--- a/tests/rag/retriever.test.js
+++ b/tests/rag/retriever.test.js
@@ -36,7 +36,10 @@ describe("retriever — KJC-PCS-0049 Step 5", () => {
   });
 
   it("kind boost reorders equidistant chunks (plan > code)", async () => {
-    insertChunk(db, { source: "/c1", kind: "code", text: "code", embedding: oneHot(0) });
+    // KJC-TSK-0440: use test-path sources so the asymmetric source boost
+    // does not kick in and the original plan > onboarding > code ordering
+    // still holds when the query is a single token (non-test-flavoured).
+    insertChunk(db, { source: "/tests/c1.test.js", kind: "code", text: "code", embedding: oneHot(0) });
     insertChunk(db, { source: "/p1", kind: "plan", text: "plan", embedding: oneHot(0) });
     insertChunk(db, { source: "/o1", kind: "onboarding", text: "brief", embedding: oneHot(0) });
     const hits = await query(db, fakeEmbedderFor(0), "?", { topK: 3 });
@@ -54,5 +57,27 @@ describe("retriever — KJC-PCS-0049 Step 5", () => {
     const fakeE = { embed: vi.fn(async () => oneHot(0)) };
     await expect(query(db, fakeE, "", { topK: 5 })).rejects.toThrow(/non-empty string/);
     expect(fakeE.embed).not.toHaveBeenCalled();
+  });
+
+  // KJC-TSK-0440 — asymmetric source-vs-test boost
+  it("ranks src/X.js above tests/X.test.js when query is NL (no test terms)", async () => {
+    // Both code chunks, exact same vector → cosine distance is identical.
+    // The asymmetric boost must surface the source path first.
+    insertChunk(db, { source: "/repo/tests/auth.test.js", kind: "code", text: "auth test prose", embedding: oneHot(0) });
+    insertChunk(db, { source: "/repo/src/auth.js", kind: "code", text: "auth impl", embedding: oneHot(0) });
+    const hits = await query(db, fakeEmbedderFor(0), "how does auth work", { topK: 2 });
+    expect(hits[0].source).toBe("/repo/src/auth.js");
+    expect(hits[1].source).toBe("/repo/tests/auth.test.js");
+  });
+
+  it("keeps test files visible when query mentions test terms", async () => {
+    insertChunk(db, { source: "/repo/tests/auth.test.js", kind: "code", text: "auth test", embedding: oneHot(0) });
+    insertChunk(db, { source: "/repo/src/auth.js", kind: "code", text: "auth impl", embedding: oneHot(0) });
+    const hits = await query(db, fakeEmbedderFor(0), "vitest mock for auth", { topK: 2 });
+    // With test-flavoured query both keep the baseline (code: 0) → ordering is by distance only,
+    // which is identical for both. We assert both appear, in any order.
+    const sources = hits.map((h) => h.source);
+    expect(sources).toContain("/repo/tests/auth.test.js");
+    expect(sources).toContain("/repo/src/auth.js");
   });
 });


### PR DESCRIPTION
PR 3 of 3 for v2.27.0. Stacked on #832 (which is stacked on #831).

## Problem

v2.26 smoke on karajan-code revealed a systematic ranking bias: natural-language queries (`how does X work`) returned `tests/X.test.js` ahead of `src/X.js` because:
- tests carry richer descriptive prose ("it should handle the case when...")
- cosine-only similarity rewards lexical match with descriptive text
- the kind boost was symmetric (code: 0 for everyone)

## Fix

Asymmetric source boost: when the query does NOT mention test/spec/expect/describe/it/jest/vitest/mocha, code chunks whose source path is NOT a test file get +0.05.

| Query mentions test? | Source is test file? | Extra boost |
|---|---|---|
| No (`how does X work`) | No (`src/X.js`) | +0.05 ✓ |
| No | Yes (`tests/X.test.js`) | 0 |
| Yes (`vitest mock setup`) | * | 0 (test files still visible) |

`TEST_PATH_RE` matches `/tests/`, `/__tests__/`, `.test.{j,t}sx?`, `.spec.{j,t}sx?`. `TEST_TERMS_RE` matches the common framework + assertion vocabulary.

## Files

- `src/rag/retriever.js` — `shouldBoostSources()` + `isTestPath()` + rerank tweak (~28 LOC including exports + comments)
- `tests/rag/retriever.test.js` — 2 new cases (src beats test for NL, both visible for test-flavoured), 1 pre-existing test updated to use a test path so the original plan>onboarding>code symmetry assertion still holds

**Net +57 LOC**. All RAG tests 58/58.

## Stacked PR

Base: `feat/KJC-TSK-0439-rag-docs` (#832) → `feat/KJC-TSK-0438-rag-project-isolation` (#831) → main. Merge order #831 → #832 → this. GitHub auto-rebases the chain.

After this lands: chore release v2.27.0.