### PR TITLE
chore: release v2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.27.0] - 2026-05-25
+
+Minor release. **RAG polish — per-project isolation, unified docs, fairer ranking.**
+
+Three independent improvements triggered by the v2.26.0 smoke test on karajan-code itself, plus a workflow fix surfaced while landing the docs.
+
+### Added
+
+- **Per-project isolation** (KJC-TSK-0438, PR #831). New `project_slug TEXT` column on `chunks` (schema migration is non-breaking — old DBs keep working with NULL). `insertChunk` / `searchSimilar` accept `{ project }`. `indexProject` auto-stamps every chunk with the projectDir basename. `kj rag query` adds `--project <slug>` (defaults to cwd basename; `--project all` disables the filter). Same shape exposed through MCP and the slash command.
+- **`docs/RAG.md` + `docs/es/RAG.md`** (KJC-TSK-0439, PR #832). Single unified guide consolidating CHANGELOG entries, role templates and landing pages. Sections: quick start, architecture diagram, installation, six workflows (CLI/MCP/skill/Board/pre-loop/role-instructions), configuration matrix, limitations + roadmap, troubleshooting. README banner links both languages.
+- **Asymmetric source-vs-test kind boost** (KJC-TSK-0440, PR #833). The v2.26.0 smoke caught a systematic bias: natural-language queries (`how does X work`) ranked `tests/X.test.js` above `src/X.js` because tests carry more descriptive prose. New rule in `retriever.js`: when the query does NOT mention `test|spec|expect|describe|it|jest|vitest|mocha`, code chunks whose source path is NOT a test file get +0.05 boost. Test-flavoured queries keep the baseline so `vitest mock setup` still surfaces test files.
+
+### Fixed
+
+- **KJC-BUG-0063** (PR #834): `tests/resilience/hibernate-end-to-end.test.js` was time-zone-dependent and broke CI on every PR (passed in `TZ=Europe/Madrid`, failed in CI's `TZ=UTC`). Skipped in CI via `process.env.CI === 'true'` until `parseCooldown` becomes TZ-aware.
+- **shrink-budget workflow excludes** (PR #832): `docs/**/*.md` only matched files in subdirectories (`docs/es/RAG.md`) but not `docs/RAG.md` at the root of `docs/`. Mirrored every doc-extension exclude with both `docs/*.ext` and `docs/**/*.ext` patterns. Caught while landing the docs themselves.
+
 ## [2.26.0] - 2026-05-24
 
 Minor release. **RAG Auto-Bootstrap** — Ollama runs in Docker out of the box.

--- a/README.md
+++ b/README.md
@@ -345,13 +345,22 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.27.0 released** — Minor. **RAG polish** — three improvements triggered by the v2.26.0 smoke test on karajan-code itself:
+>
+> - **Per-project isolation** (PR #831): new `project_slug` column on chunks; `kj rag query --project <slug>` (auto-detected from cwd) filters the global DB. `--project all` to query across everything.
+> - **`docs/RAG.md` + `docs/es/RAG.md`** (PR #832): single unified guide covering architecture, install, six workflows, configuration, limitations and troubleshooting. Replaces the documentation spread across CHANGELOG / templates / landing.
+> - **Asymmetric source-vs-test ranking** (PR #833): NL queries like `how does X work` no longer rank `tests/X.test.js` above `src/X.js`; test-flavoured queries still surface tests.
+> - Plus **KJC-BUG-0063** (PR #834): skipped a TZ-dependent test that was blocking every CI run, and a `shrink-budget` workflow exclude fix for `docs/*.md` at the root.
+>
+> **Coming in v2.28.0+**: chokidar watcher for live re-indexing, AST source chunker (tree-sitter / @babel/parser), BM25 + cosine hybrid scoring, OpenAI/Voyage embedder adapters (for users without local Docker).
+>
 > **v2.26.0 released** — Minor. **RAG Auto-Bootstrap** — Ollama runs in Docker out of the box. `kj init` now provisions the embedder automatically (or skips with a clear reason on modest hardware / `--no-ollama`); `kj doctor` surfaces health; `kj ollama [start|stop|status|pull]` manages lifecycle without docker compose. See [docs/RAG.md](docs/RAG.md) for the full RAG guide ([español](docs/es/RAG.md)).
 >
 > Capability check (RAM + Docker) means the bootstrap never breaks init: on Windows without Docker Desktop, on hosts under 4 GB free, or with `--no-ollama`, the wizard logs a one-liner and continues. Where Ollama is already running on `:11434`, `kj init` reuses the external instance instead of spawning a second container.
 >
 > Bundles **KJC-BUG-0061** fix (caught during v2.25.0 smoke test): `kj onboard --no-synth` was ignored by Commander shape mapping, `OnboarderRole.run()` was called without `init()`, and `kj rag query --json` on empty store emitted just `[]` instead of the `{empty: true}` contract the MCP handler returns.
 >
-> **Coming in v2.27.0+**: chokidar watcher for live re-indexing, AST source chunker (tree-sitter / @babel/parser), BM25 + cosine hybrid scoring, OpenAI/Voyage embedder adapters (for users without local Docker).
+> **Coming next from v2.26.0**: addressed in v2.27.0 above.
 >
 > **v2.25.0 released** — Minor. **RAG Camino B + Camino D** (KJC-PCS-0049). Closes the consumer-surface plan. Skills hosts can now invoke RAG via `/kj-rag-query` without MCP, and the pre-loop retrieval stage from v2.24.0 only fires when triage signals make it worthwhile.
 >

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.26.0
+kj --version    # 2.27.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.26.0
+kj --version    # 2.27.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.26.0",
+      "version": "2.27.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Closes v2.27.0 = RAG polish (isolation + docs + ranking).

## Mergeado en este ciclo

| PR | Card | Title |
|---|---|---|
| #834 | KJC-BUG-0063 | test(ci): skip TZ-dependent hibernate test in CI |
| #831 | KJC-TSK-0438 | feat(rag): per-project isolation via project_slug column |
| #832 | KJC-TSK-0439 | docs(rag): docs/RAG.md + docs/es/RAG.md unified + shrink-budget exclude fix |
| #833 | KJC-TSK-0440 | feat(rag): asymmetric source-vs-test kind boost |

## Este PR

- `package.json` + `package-lock.json` → 2.26.0 → 2.27.0
- `CHANGELOG.md` — entry `[2.27.0]` con detalle por PR
- `README.md` — banner actualizado (v2.26.0 → v2.27.0)
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` — version bump
- `docs/ARCHITECTURE.md` — stats refreshed

## Tras merge

1. Tag v2.27.0 + GitHub Release
2. npm publish (OTP requerido)
3. Landing update (Phase 81 + Recent releases card)