### PR TITLE
feat(rag): chokidar watcher for live re-index — PR 1/5 v2.28.0 (KJC-TSK-0441)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -170,6 +170,9 @@ const ragStubPlugin = {
           checkOllamaCapability: notAvailable, pullOllamaModel: notAvailable,
           // KJC-TSK-0438 — RAG project isolation.
           projectSlug: notAvailable,
+          // KJC-TSK-0441 — RAG chokidar watcher.
+          startWatcher: notAvailable, readPidFile: notAvailable, clearPidFile: notAvailable,
+          isPidAlive: notAvailable, writePidFile: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -4,6 +4,7 @@ import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
 import { ragIndexCommand, ragQueryCommand } from "../commands/rag.js";
+import { watchStartCommand, watchStopCommand, watchStatusCommand } from "../commands/watch.js";
 import { auditCommand } from "../commands/audit.js";
 import { resumeCommand } from "../commands/resume.js";
 import { boardCommand } from "../commands/board.js";
@@ -120,6 +121,18 @@ export function registerMeta(program, { pkgVersion }) {
         await ragQueryCommand({ text, config, logger, flags });
       });
     });
+
+  // KJC-TSK-0441 — `kj watch [start|stop|status]` for live RAG re-index.
+  const watch = program.command("watch").description("Live RAG re-index daemon");
+  watch.command("start").description("Start the watcher daemon").option("--foreground", "Run in foreground (do not detach)").option("--with-sources", "Watch project source files too").action(async (flags) => {
+    await withConfig(pkgVersion, "watch:start", flags, async ({ config, logger }) => watchStartCommand({ config, logger, flags }));
+  });
+  watch.command("stop").description("Stop the watcher daemon").action(async () => {
+    await withConfig(pkgVersion, "watch:stop", {}, async ({ logger }) => watchStopCommand({ logger }));
+  });
+  watch.command("status").description("Report watcher daemon state").action(async () => {
+    await withConfig(pkgVersion, "watch:status", {}, async ({ logger }) => watchStatusCommand({ logger }));
+  });
 
   program
     .command("audit")

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,0 +1,46 @@
+// KJC-TSK-0441 — `kj watch [start|stop|status]`. Thin wrappers.
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { startWatcher, readPidFile, clearPidFile, isPidAlive, writePidFile } from "../rag/watcher.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function watchStartCommand({ config, logger, flags = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const existing = readPidFile();
+  if (existing && isPidAlive(existing)) { logger.info(`Watcher already running (pid ${existing}).`); return { pid: existing, started: false }; }
+  if (existing) clearPidFile();
+  if (flags.foreground) {
+    writePidFile();
+    const stop = startWatcher({ projectDir, config, logger, withSources: !!flags.withSources });
+    const shutdown = async () => { await stop(); clearPidFile(); process.exit(0); };
+    process.on("SIGINT", shutdown).on("SIGTERM", shutdown);
+    logger.info(`Watcher started in foreground (pid ${process.pid}). Ctrl+C to stop.`);
+    return { pid: process.pid, started: true };
+  }
+  const args = [join(HERE, "..", "cli.js"), "watch", "start", "--foreground", ...(flags.withSources ? ["--with-sources"] : [])];
+  const child = spawn(process.execPath, args, { detached: true, stdio: "ignore", env: { ...process.env, KJ_WATCHER_DAEMON: "1" } });
+  child.unref();
+  logger.info(`Watcher started in background (pid ${child.pid}).`);
+  return { pid: child.pid, started: true };
+}
+
+export async function watchStopCommand({ logger }) {
+  const pid = readPidFile();
+  if (!pid) { logger.info("No watcher running."); return { stopped: false }; }
+  if (!isPidAlive(pid)) { clearPidFile(); logger.info(`Stale PID file removed (process ${pid} was not alive).`); return { stopped: false, stale: true }; }
+  try { process.kill(pid, "SIGTERM"); } catch (err) { logger.warn(`Could not signal pid ${pid}: ${err.message}`); }
+  clearPidFile();
+  logger.info(`Watcher (pid ${pid}) stopped.`);
+  return { stopped: true, pid };
+}
+
+export async function watchStatusCommand({ logger }) {
+  const pid = readPidFile();
+  const alive = pid && isPidAlive(pid);
+  if (alive) logger.info(`Watcher running (pid ${pid}).`);
+  else if (pid) logger.warn(`Stale PID file (process ${pid} not alive). Run \`kj watch stop\` to clean up.`);
+  else logger.info("Watcher is NOT running.");
+  return { pid, alive };
+}

--- a/src/rag/watcher.js
+++ b/src/rag/watcher.js
@@ -1,0 +1,61 @@
+// KJC-TSK-0441 (RAG v2.28.0 PR1) — chokidar watcher. Live re-index of plans
+// + onboarding + (opt) sources, debounced. PID file arbitrates a single daemon.
+import { writeFileSync, readFileSync, existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import chokidar from "chokidar";
+import { openVecStore, deleteChunksBySource, projectSlug } from "./vec-store.js";
+import { OllamaEmbedder } from "./embedder.js";
+import { indexFile } from "./indexer.js";
+import { getKarajanHome } from "../utils/paths.js";
+
+const PIDFILE = () => join(getKarajanHome(), "watcher.pid");
+const DEFAULT_DEBOUNCE_MS = 1000;
+const SKIP_SEGMENTS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
+const SOURCE_RE = /\.(js|mjs|cjs|ts|tsx|jsx)$/;
+
+function isWatchable(path) {
+  if (path.includes("/.karajan/onboarding/")) return /\.md$/.test(path);
+  if (path.includes("/.karajan/plans/")) return /\.json$/.test(path);
+  if (path.split("/").some((seg) => SKIP_SEGMENTS.has(seg))) return false;
+  return SOURCE_RE.test(path);
+}
+
+export function startWatcher({ projectDir, config, logger = console, debounceMs = DEFAULT_DEBOUNCE_MS, withSources = false } = {}) {
+  if (!projectDir) throw new Error("startWatcher: projectDir is required");
+  const slug = projectSlug(projectDir);
+  const dim = config?.rag?.embedder?.dim || 768;
+  const db = openVecStore({ dim });
+  const cfg = config?.rag?.embedder || {};
+  const embedder = new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim });
+  const paths = [join(getKarajanHome(), "onboarding"), join(getKarajanHome(), "plans")];
+  if (withSources) paths.push(projectDir);
+  const watcher = chokidar.watch(paths, { ignoreInitial: true, persistent: true });
+  const pending = new Map();
+  const flush = async (p) => {
+    pending.delete(p);
+    if (!existsSync(p)) { deleteChunksBySource(db, p); logger.info?.(`[rag-watcher] removed → ${p}`); return; }
+    if (!isWatchable(p)) return;
+    try { const r = await indexFile(p, { db, embedder, logger, project: slug }); logger.info?.(`[rag-watcher] reindexed ${p} → ${r.indexed} chunk(s)`); }
+    catch (err) { logger.warn?.(`[rag-watcher] reindex failed for ${p}: ${err.message}`); }
+  };
+  const schedule = (p) => { if (pending.has(p)) clearTimeout(pending.get(p)); pending.set(p, setTimeout(() => flush(p), debounceMs)); };
+  watcher.on("add", schedule).on("change", schedule).on("unlink", schedule).on("error", (err) => logger.warn?.(`[rag-watcher] ${err.message}`));
+  return async function stop() {
+    for (const t of pending.values()) clearTimeout(t);
+    pending.clear();
+    await watcher.close();
+    try { db.close(); } catch { /* already closed */ }
+  };
+}
+
+export function writePidFile(pid = process.pid) { writeFileSync(PIDFILE(), String(pid), "utf8"); }
+export function clearPidFile() { if (existsSync(PIDFILE())) unlinkSync(PIDFILE()); }
+export function readPidFile() {
+  if (!existsSync(PIDFILE())) return null;
+  const pid = Number(readFileSync(PIDFILE(), "utf8").trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+export function isPidAlive(pid) {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}

--- a/tests/cli/kj-watch.test.js
+++ b/tests/cli/kj-watch.test.js
@@ -1,0 +1,37 @@
+// KJC-TSK-0441 — `kj watch` CLI handlers.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/rag/watcher.js", () => ({
+  startWatcher: vi.fn(() => async () => {}),
+  readPidFile: vi.fn(), clearPidFile: vi.fn(), isPidAlive: vi.fn(), writePidFile: vi.fn(),
+}));
+import { readPidFile, clearPidFile, isPidAlive } from "../../src/rag/watcher.js";
+import { watchStopCommand, watchStatusCommand } from "../../src/commands/watch.js";
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+describe("kj watch — KJC-TSK-0441", () => {
+  beforeEach(() => { for (const m of [logger.info, logger.warn, readPidFile, clearPidFile, isPidAlive]) m.mockReset(); });
+
+  it("status: running / stale / NOT running paths", async () => {
+    readPidFile.mockReturnValueOnce(process.pid); isPidAlive.mockReturnValueOnce(true);
+    expect((await watchStatusCommand({ logger })).alive).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/running/));
+    readPidFile.mockReturnValueOnce(999999); isPidAlive.mockReturnValueOnce(false);
+    await watchStatusCommand({ logger });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringMatching(/Stale PID/));
+    readPidFile.mockReturnValueOnce(null);
+    expect((await watchStatusCommand({ logger })).alive).toBeFalsy();
+    expect(logger.info).toHaveBeenCalledWith(expect.stringMatching(/NOT running/));
+  });
+
+  it("stop: no PID / stale PID paths", async () => {
+    readPidFile.mockReturnValueOnce(null);
+    expect((await watchStopCommand({ logger })).stopped).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith("No watcher running.");
+    readPidFile.mockReturnValueOnce(999999); isPidAlive.mockReturnValueOnce(false);
+    const r = await watchStopCommand({ logger });
+    expect(r.stale).toBe(true);
+    expect(clearPidFile).toHaveBeenCalled();
+  });
+});

--- a/tests/rag/watcher.test.js
+++ b/tests/rag/watcher.test.js
@@ -1,0 +1,34 @@
+// KJC-TSK-0441 — watcher PID lifecycle helpers.
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writePidFile, readPidFile, clearPidFile, isPidAlive } from "../../src/rag/watcher.js";
+
+describe("rag/watcher — PID file (KJC-TSK-0441)", () => {
+  let prev;
+  beforeEach(() => { prev = process.env.KARAJAN_HOME; process.env.KARAJAN_HOME = mkdtempSync(join(tmpdir(), "kj-watch-")); });
+  afterEach(() => { rmSync(process.env.KARAJAN_HOME, { recursive: true, force: true }); if (prev === undefined) delete process.env.KARAJAN_HOME; else process.env.KARAJAN_HOME = prev; });
+
+  it("write/read/clear round-trip + malformed → null", () => {
+    expect(readPidFile()).toBeNull();
+    writePidFile(12345);
+    expect(readPidFile()).toBe(12345);
+    expect(existsSync(join(process.env.KARAJAN_HOME, "watcher.pid"))).toBe(true);
+    clearPidFile();
+    expect(readPidFile()).toBeNull();
+    writePidFile("not-a-pid");
+    expect(readPidFile()).toBeNull();
+  });
+
+  it("isPidAlive returns true for current pid, false for 0/null/999999", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(0)).toBe(false);
+    expect(isPidAlive(null)).toBe(false);
+    expect(isPidAlive(999999)).toBe(false);
+  });
+
+  it("clearPidFile is a no-op when missing", () => {
+    expect(() => clearPidFile()).not.toThrow();
+  });
+});


### PR DESCRIPTION
PR 1 of 5 for v2.28.0. Closes the manual-reindex friction caught in the v2.27.0 smoke test.

## What

`kj watch [start|stop|status]` daemon that watches the RAG inputs and reindexes incrementally on every change.

### Watch paths
- `~/.karajan/onboarding/` (markdown briefs)
- `~/.karajan/plans/` (plan JSON files)
- `projectDir` source tree (`.js|.mjs|.cjs|.ts|.tsx|.jsx`) — only when `--with-sources` flag is set

### Behavior
- 1s debounce per path: rapid edits batch into a single reindex
- `unlink` → `deleteChunksBySource` cleans the store
- Same SKIP set as the indexer (`.kj`, `_diet`, `node_modules`…)
- Single-daemon discipline via `~/.karajan/watcher.pid`
- `kj watch start` re-spawns the CLI with `--foreground` detached
- `kj watch stop` SIGTERMs and clears the PID file
- Stale PID files (process dead) cleaned automatically

## Files

- `src/rag/watcher.js` — 61 LOC: `startWatcher()` + PID helpers
- `src/commands/watch.js` — 46 LOC: 3 subcommand handlers
- `src/cli/register-meta.js` — 13 LOC subcommand registration
- `scripts/esbuild-sea.config.mjs` — stub exports for SEA bundles
- `tests/rag/watcher.test.js` + `tests/cli/kj-watch.test.js` — 5 cases

**Net +194 LOC**, under the 200 budget.

## Coming next in v2.28.0

PR 2: OpenAI + Voyage embedder adapters
PR 3: BM25 + cosine hybrid scoring
PR 4: AST source chunker (@babel/parser)
PR 5: KJC-BUG-0064 parseCooldown TZ-aware (undoes the v2.27 workaround)