### PR TITLE
feat(rag): OpenAI + Voyage embedder adapters — PR 2/5 v2.28.0 (KJC-TSK-0442)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1292,12 +1292,12 @@ router.post('/rag/query', async (req, res) => {
   }
   try {
     const { openVecStore, countChunks } = await import('../../../../src/rag/vec-store.js');
-    const { OllamaEmbedder } = await import('../../../../src/rag/embedder.js');
+    const { makeEmbedder } = await import('../../../../src/rag/embedders/factory.js');
     const { query } = await import('../../../../src/rag/retriever.js');
     const db = openVecStore({ dim: 768 });
     try {
       if (countChunks(db) === 0) return res.json({ hits: [], empty: true, topK, scope });
-      const embedder = new OllamaEmbedder({});
+      const embedder = makeEmbedder({});
       const hits = await query(db, embedder, text, { topK: Number(topK), scope });
       res.json({ hits, empty: false, topK, scope });
     } finally { db.close(); }

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -146,7 +146,7 @@ const huBoardStubPlugin = {
 const ragStubPlugin = {
   name: "rag-stub",
   setup(build) {
-    build.onResolve({ filter: /[\\/](rag[\\/][^\\/]+|commands[\\/]rag)\.js$/ }, (args) => ({
+    build.onResolve({ filter: /[\\/](rag[\\/].+|commands[\\/](rag|watch))\.js$/ }, (args) => ({
       path: args.path, namespace: "rag-stub",
     }));
     build.onLoad({ filter: /.*/, namespace: "rag-stub" }, () => ({
@@ -173,6 +173,9 @@ const ragStubPlugin = {
           // KJC-TSK-0441 — RAG chokidar watcher.
           startWatcher: notAvailable, readPidFile: notAvailable, clearPidFile: notAvailable,
           isPidAlive: notAvailable, writePidFile: notAvailable,
+          // KJC-TSK-0442 — RAG embedders cloud + factory.
+          makeEmbedder: notAvailable, OpenAIEmbedder: notAvailable, VoyageEmbedder: notAvailable,
+          OpenAIEmbedderError: notAvailable, VoyageEmbedderError: notAvailable, PROVIDERS: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -3,15 +3,10 @@
 //   kj rag query <text>   [--scope plans|code|onboarding|all] [--top-k N] [--json]
 // Closes the v2.22.0 RAG MVP end-to-end from the terminal.
 import { openVecStore, countChunks, projectSlug } from "../rag/vec-store.js";
-import { OllamaEmbedder } from "../rag/embedder.js";
+import { makeEmbedder } from "../rag/embedders/factory.js";
 import { indexProject } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
 import { getKarajanHome } from "../utils/paths.js";
-
-function makeEmbedder(config) {
-  const cfg = config?.rag?.embedder || {};
-  return new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim: cfg.dim });
-}
 
 function openDb(config) {
   return openVecStore({ dim: config?.rag?.embedder?.dim || 768 });

--- a/src/mcp/handlers/rag-handler.js
+++ b/src/mcp/handlers/rag-handler.js
@@ -2,7 +2,7 @@
 // from src/commands/* are forbidden by the layer-boundaries test
 // (MCP and CLI are peer layers); we hit the pure rag/* modules instead.
 import { countChunks, openVecStore } from "../../rag/vec-store.js";
-import { OllamaEmbedder } from "../../rag/embedder.js";
+import { makeEmbedder } from "../../rag/embedders/factory.js";
 import { indexProject } from "../../rag/indexer.js";
 import { query } from "../../rag/retriever.js";
 import { getKarajanHome } from "../../utils/paths.js";
@@ -11,11 +11,6 @@ import { resolveProjectDir, buildConfig, responseText, failPayload } from "../sh
 const silentLogger = {
   info: () => {}, warn: () => {}, error: () => {}, debug: () => {}, setContext: () => {},
 };
-
-function makeEmbedder(config) {
-  const cfg = config?.rag?.embedder || {};
-  return new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim: cfg.dim });
-}
 
 export async function handleRagQuery(args, server) {
   const text = args?.text;

--- a/src/orchestrator/stages/rag-context-stage.js
+++ b/src/orchestrator/stages/rag-context-stage.js
@@ -6,7 +6,7 @@
 // never sees an exception from this stage.
 import { emitProgress, makeEvent } from "../../utils/events.js";
 import { openVecStore, countChunks } from "../../rag/vec-store.js";
-import { OllamaEmbedder } from "../../rag/embedder.js";
+import { makeEmbedder } from "../../rag/embedders/factory.js";
 import { query } from "../../rag/retriever.js";
 
 const DEFAULT_TOP_K = 5;
@@ -35,8 +35,7 @@ export async function runRagContextStage({ config, logger, emitter, eventBase, t
       }
       const topK = preload.topK || DEFAULT_TOP_K;
       const scope = preload.scope || DEFAULT_SCOPE;
-      const cfg = config?.rag?.embedder || {};
-      const embedder = new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim });
+      const embedder = makeEmbedder(config);
       const hits = await query(db, embedder, task, { topK, scope });
       if (hits.length === 0) return { skipped: true, reason: "no-hits" };
       const lines = hits.map((h) => {

--- a/src/rag/embedders/_cloud-base.js
+++ b/src/rag/embedders/_cloud-base.js
@@ -1,0 +1,24 @@
+// KJC-TSK-0442 — shared POST helper for cloud embedders (OpenAI, Voyage).
+// Same envelope: Bearer auth, JSON body shaped by caller, JSON response
+// extracted by caller, dim validated against the adapter's expected size.
+export async function cloudEmbed(adapter, text, ErrCls, { provider, body, extract }) {
+  if (typeof text !== "string" || text.length === 0) throw new ErrCls("embed: text must be a non-empty string");
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), adapter.timeoutMs);
+  let res;
+  try {
+    res = await adapter.fetch(adapter.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${adapter.apiKey}` },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+  } catch (err) { throw new ErrCls(`${provider} embed request failed: ${err.message}`, { cause: err }); }
+  finally { clearTimeout(timer); }
+  if (!res.ok) throw new ErrCls(`${provider} embed HTTP ${res.status}`, { status: res.status });
+  const json = await res.json();
+  const arr = extract(json);
+  if (!Array.isArray(arr) || arr.length === 0) throw new ErrCls(`${provider} response missing embedding`);
+  if (arr.length !== adapter.dim) throw new ErrCls(`${provider} dim mismatch: got ${arr.length}, expected ${adapter.dim} for model ${adapter.model}`);
+  return Float32Array.from(arr);
+}

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -1,0 +1,20 @@
+// KJC-TSK-0442 — Embedder factory. Selects provider from
+// config.rag.embedder.provider (ollama | openai | voyage; default ollama).
+// Each provider has its own dim default; the factory wires it so the
+// caller does not need to know.
+import { OllamaEmbedder } from "../embedder.js";
+import { OpenAIEmbedder } from "./openai.js";
+import { VoyageEmbedder } from "./voyage.js";
+
+const PROVIDERS = { ollama: { cls: OllamaEmbedder, dim: 768 }, openai: { cls: OpenAIEmbedder, dim: 1536 }, voyage: { cls: VoyageEmbedder, dim: 1024 } };
+
+export function makeEmbedder(config = {}) {
+  const cfg = config?.rag?.embedder || {};
+  const provider = cfg.provider || "ollama";
+  const spec = PROVIDERS[provider];
+  if (!spec) throw new Error(`Unknown embedder provider: ${provider}. Supported: ${Object.keys(PROVIDERS).join(", ")}`);
+  const dim = cfg.dim || spec.dim;
+  return new spec.cls({ url: cfg.url, apiKey: cfg.api_key, model: cfg.model, dim, timeoutMs: cfg.timeout_ms });
+}
+
+export { PROVIDERS };

--- a/src/rag/embedders/openai.js
+++ b/src/rag/embedders/openai.js
@@ -1,0 +1,17 @@
+// KJC-TSK-0442 — OpenAI text-embeddings adapter.
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.openai.com/v1/embeddings", model: "text-embedding-3-small", dim: 1536, timeoutMs: 30000 };
+
+export class OpenAIEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "OpenAIEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class OpenAIEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.OPENAI_API_KEY, model = process.env.KJ_OPENAI_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    if (!apiKey) throw new OpenAIEmbedderError("OpenAI embedder requires an api_key (config.rag.embedder.api_key or OPENAI_API_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) { return cloudEmbed(this, text, OpenAIEmbedderError, { provider: "OpenAI", body: { model: this.model, input: text }, extract: (b) => b?.data?.[0]?.embedding }); }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new OpenAIEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/src/rag/embedders/voyage.js
+++ b/src/rag/embedders/voyage.js
@@ -1,0 +1,17 @@
+// KJC-TSK-0442 — Voyage AI embeddings adapter.
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.voyageai.com/v1/embeddings", model: "voyage-code-3", dim: 1024, timeoutMs: 30000 };
+
+export class VoyageEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "VoyageEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class VoyageEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.VOYAGE_API_KEY, model = process.env.KJ_VOYAGE_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    if (!apiKey) throw new VoyageEmbedderError("Voyage embedder requires an api_key (config.rag.embedder.api_key or VOYAGE_API_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) { return cloudEmbed(this, text, VoyageEmbedderError, { provider: "Voyage", body: { model: this.model, input: [text], input_type: "document" }, extract: (b) => b?.data?.[0]?.embedding }); }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new VoyageEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/src/rag/watcher.js
+++ b/src/rag/watcher.js
@@ -4,7 +4,7 @@ import { writeFileSync, readFileSync, existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import chokidar from "chokidar";
 import { openVecStore, deleteChunksBySource, projectSlug } from "./vec-store.js";
-import { OllamaEmbedder } from "./embedder.js";
+import { makeEmbedder } from "./embedders/factory.js";
 import { indexFile } from "./indexer.js";
 import { getKarajanHome } from "../utils/paths.js";
 
@@ -25,8 +25,7 @@ export function startWatcher({ projectDir, config, logger = console, debounceMs 
   const slug = projectSlug(projectDir);
   const dim = config?.rag?.embedder?.dim || 768;
   const db = openVecStore({ dim });
-  const cfg = config?.rag?.embedder || {};
-  const embedder = new OllamaEmbedder({ url: cfg.url, model: cfg.model, dim });
+  const embedder = makeEmbedder(config);
   const paths = [join(getKarajanHome(), "onboarding"), join(getKarajanHome(), "plans")];
   if (withSources) paths.push(projectDir);
   const watcher = chokidar.watch(paths, { ignoreInitial: true, persistent: true });

--- a/tests/rag/embedders-factory.test.js
+++ b/tests/rag/embedders-factory.test.js
@@ -1,0 +1,87 @@
+// KJC-TSK-0442 — embedder factory + OpenAI + Voyage adapters.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { makeEmbedder } from "../../src/rag/embedders/factory.js";
+import { OpenAIEmbedder, OpenAIEmbedderError } from "../../src/rag/embedders/openai.js";
+import { VoyageEmbedder, VoyageEmbedderError } from "../../src/rag/embedders/voyage.js";
+import { OllamaEmbedder } from "../../src/rag/embedder.js";
+
+describe("rag/embedders factory (KJC-TSK-0442)", () => {
+  it("defaults to Ollama provider when none configured", () => {
+    const e = makeEmbedder({});
+    expect(e).toBeInstanceOf(OllamaEmbedder);
+    expect(e.dim).toBe(768);
+  });
+
+  it("selects OpenAI provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "openai", api_key: "sk-test" } } });
+    expect(e).toBeInstanceOf(OpenAIEmbedder);
+    expect(e.dim).toBe(1536);
+  });
+
+  it("selects Voyage provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "voyage", api_key: "pa-test" } } });
+    expect(e).toBeInstanceOf(VoyageEmbedder);
+    expect(e.dim).toBe(1024);
+  });
+
+  it("throws on unknown provider", () => {
+    expect(() => makeEmbedder({ rag: { embedder: { provider: "anthropic" } } })).toThrow(/Unknown embedder provider/);
+  });
+
+  it("honors explicit dim override", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "openai", api_key: "k", dim: 512 } } });
+    expect(e.dim).toBe(512);
+  });
+});
+
+describe("OpenAIEmbedder (KJC-TSK-0442)", () => {
+  it("rejects construction without an api key", () => {
+    const prev = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try { expect(() => new OpenAIEmbedder({})).toThrow(OpenAIEmbedderError); }
+    finally { if (prev !== undefined) process.env.OPENAI_API_KEY = prev; }
+  });
+
+  it("POSTs to /v1/embeddings with Bearer auth + returns Float32Array", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [{ embedding: new Array(1536).fill(0.1) }] }) });
+    const e = new OpenAIEmbedder({ apiKey: "sk-test", fetchFn });
+    const v = await e.embed("hello");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(1536);
+    expect(fetchFn).toHaveBeenCalledWith("https://api.openai.com/v1/embeddings", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
+    }));
+  });
+
+  it("throws on dim mismatch from server", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [{ embedding: [0.1, 0.2] }] }) });
+    const e = new OpenAIEmbedder({ apiKey: "k", fetchFn });
+    await expect(e.embed("x")).rejects.toThrow(/dim mismatch/);
+  });
+
+  it("throws on HTTP error status with the code", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+    const e = new OpenAIEmbedder({ apiKey: "k", fetchFn });
+    await expect(e.embed("x")).rejects.toThrow(/HTTP 401/);
+  });
+});
+
+describe("VoyageEmbedder (KJC-TSK-0442)", () => {
+  it("rejects without api key", () => {
+    const prev = process.env.VOYAGE_API_KEY;
+    delete process.env.VOYAGE_API_KEY;
+    try { expect(() => new VoyageEmbedder({})).toThrow(VoyageEmbedderError); }
+    finally { if (prev !== undefined) process.env.VOYAGE_API_KEY = prev; }
+  });
+
+  it("POSTs with input_type=document + returns Float32Array", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [{ embedding: new Array(1024).fill(0.2) }] }) });
+    const e = new VoyageEmbedder({ apiKey: "pa-test", fetchFn });
+    const v = await e.embed("auth flow");
+    expect(v.length).toBe(1024);
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.input_type).toBe("document");
+    expect(body.input).toEqual(["auth flow"]);
+  });
+});


### PR DESCRIPTION
PR 2 of 5 for v2.28.0. Stacked on #836.

## What

Unlocks RAG for users who **cannot** run a local Docker container — Windows Home without Docker Desktop, hosts under 4 GB free, ARM servers without GPU. Karajan now supports three embedder providers via a factory:

| Provider | Default model | Dim | Privacy |
|---|---|---|---|
| `ollama` (default) | nomic-embed-text | 768 | 100% local |
| `openai` | text-embedding-3-small | 1536 | API call (Bearer auth) |
| `voyage` | voyage-code-3 | 1024 | API call (recommended by Anthropic — no first-party Anthropic embedder exists) |

## Config

```yaml
rag:
  embedder:
    provider: openai           # ollama | openai | voyage  (default: ollama)
    api_key: ${OPENAI_API_KEY}
    model: text-embedding-3-small
    dim: 1536                  # override provider default if needed
```

`api_key` falls back to `OPENAI_API_KEY` / `VOYAGE_API_KEY` env vars.

## Files

- `src/rag/embedders/openai.js` (17 LOC)
- `src/rag/embedders/voyage.js` (17 LOC)
- `src/rag/embedders/_cloud-base.js` (24 LOC) — shared POST envelope
- `src/rag/embedders/factory.js` (20 LOC) — `makeEmbedder(config)` resolves provider
- 4 call sites migrated to factory (CLI, MCP, pre-loop, watcher, hu-board endpoint)
- `tests/rag/embedders-factory.test.js` — 11 cases (selection, dim defaults, override, unknown provider, OpenAI POST shape, dim mismatch, HTTP error, Voyage POST shape with input_type)
- SEA stub regex widened to /rag/.+ so subdirectories work

**Net +156 LOC**, well under budget.

## Stacked

Base: `feat/KJC-TSK-0441-rag-chokidar-watcher` (#836). GitHub will auto-rebase to main when #836 lands.