### PR TITLE
feat(rag): BM25 + cosine hybrid scoring — PR 3/5 v2.28.0 (KJC-TSK-0443)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -115,6 +115,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--scope <scope>", "plans | code | onboarding | all (default: all)", "all")
     .option("--top-k <n>", "Number of hits to return (default: 5)", "5")
     .option("--project <slug>", "Filter by project slug. Pass 'all' to query across every indexed project. Default: cwd basename")
+    .option("--mode <mode>", "hybrid (default) | semantic (cosine only) | keyword (BM25 only)", "hybrid")
+    .option("--alpha <n>", "Hybrid weight for semantic component (0..1). Default 0.6", "0.6")
     .option("--json", "Output the hits as JSON")
     .action(async (text, flags) => {
       await withConfig(pkgVersion, "rag-query", flags, async ({ config, logger }) => {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -55,7 +55,9 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
       if (flags.json) process.stdout.write(`${JSON.stringify({ hits: [], empty: true, topK, scope })}\n`);
       return [];
     }
-    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project });
+    const mode = flags.mode || "hybrid";
+    const alpha = Math.max(0, Math.min(1, Number(flags.alpha) || 0.6));
+    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);
     } else {

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -1,69 +1,54 @@
-// KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline. Composes the
-// embedder (Step 2) + vec store (Step 1) into a one-call query API.
-// The CLI (Step 6) and the future MCP tool are the only consumers.
+// KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline.
+import { searchSimilar, searchBM25 } from "./vec-store.js";
 
-import { searchSimilar } from "./vec-store.js";
-
-// Kind boosts for rerank: a plan chunk is more "intentional" than a
-// raw code chunk, an onboarding brief sits between them. Tunable via
-// the third argument; the defaults are conservative — they break ties
-// between equidistant chunks but won't reorder by big distance gaps.
 const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
 
-// KJC-TSK-0440 — asymmetric source/test boost. v2.26 smoke caught a
-// systematic bias: queries in natural language ("how does X work") return
-// tests/X.test.js ahead of src/X.js because tests carry more descriptive
-// prose. When the query itself does NOT mention test-flavoured terms,
-// give code chunks +0.05 — but only chunks whose source path is NOT a
-// test file. Tests keep the baseline boost.
+// KJC-TSK-0440 — asymmetric source/test boost.
 const SOURCE_BOOST_NON_TEST = 0.05;
 const TEST_TERMS_RE = /\b(test|tests|spec|specs|expect|describe|it\(|jest|vitest|mocha)\b/i;
 const TEST_PATH_RE = /[\\/](tests?|specs?|__tests__)[\\/]|\.test\.[jt]sx?$|\.spec\.[jt]sx?$/i;
 
-function shouldBoostSources(queryText) {
-  return !TEST_TERMS_RE.test(queryText);
+function shouldBoostSources(queryText) { return !TEST_TERMS_RE.test(queryText); }
+function isTestPath(source) { return TEST_PATH_RE.test(source || ""); }
+
+// KJC-TSK-0443 — fuse semantic + keyword hits into a unified candidate set.
+// For 'semantic'/'keyword' modes we surface that side. For 'hybrid' (default)
+// we min-max normalise both scores to [0,1] (lower=better) and linear-combine
+// via alpha * semantic + (1-alpha) * keyword. Result written back to
+// `distance` so the kind+source boost pipeline keeps working unchanged.
+function fuseHits(semantic, keyword, alpha, mode) {
+  if (mode === "semantic") return semantic;
+  if (mode === "keyword") return keyword.map((h) => ({ ...h, distance: h.bm25 }));
+  const byId = new Map();
+  for (const h of semantic) byId.set(h.id, { ...h, _sem: h.distance });
+  for (const h of keyword) {
+    const prev = byId.get(h.id);
+    if (prev) prev._kw = h.bm25;
+    else byId.set(h.id, { ...h, _kw: h.bm25, distance: h.bm25 });
+  }
+  const list = [...byId.values()];
+  const norm = (vals) => {
+    const xs = vals.filter((v) => Number.isFinite(v));
+    if (xs.length === 0) return () => 0.5;
+    const min = Math.min(...xs); const max = Math.max(...xs); const span = max - min || 1;
+    return (v) => Number.isFinite(v) ? (v - min) / span : 1;
+  };
+  const nSem = norm(list.map((h) => h._sem));
+  const nKw = norm(list.map((h) => h._kw));
+  for (const h of list) h.distance = alpha * nSem(h._sem) + (1 - alpha) * nKw(h._kw);
+  return list;
 }
 
-function isTestPath(source) {
-  return TEST_PATH_RE.test(source || "");
-}
-
-/**
- * Run a natural-language query against the indexed RAG corpus. Returns
- * the top-K chunks ranked by adjusted distance (lower = closer).
- *
- *   query(db, embedder, "how did I handle auth in module X?",
- *         { topK: 5, scope: 'plans' })
- *
- * @param {Database} db           — opened via openVecStore()
- * @param {OllamaEmbedder} embedder
- * @param {string} text           — the query
- * @param {Object} [opts]
- * @param {number} [opts.topK=5]
- * @param {'plans'|'code'|'onboarding'|'all'} [opts.scope='all']
- * @param {Object} [opts.kindBoost]
- */
-export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null } = {}) {
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6 } = {}) {
   if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
-  const queryEmbedding = await embedder.embed(text);
-  // Over-fetch (topK * 2) so the rerank step has room to reshuffle
-  // without dropping a relevant chunk past the cut. Clamped at 50 to
-  // avoid loading the entire store on tiny topK calls.
   const fetchK = Math.min(50, topK * 2);
   const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
-  // KJC-TSK-0438 — `project` filters by chunks.project_slug. null means
-  // no filter (pre-v2.27 behaviour). Caller's CLI defaults this to the
-  // basename of cwd; pass "all" through commands/rag.js to disable.
-  const raw = searchSimilar(db, queryEmbedding, fetchK, { kind: scopeKind, project });
+  const wantSemantic = mode !== "keyword";
+  const wantKeyword = mode !== "semantic";
+  const semanticHits = wantSemantic ? searchSimilar(db, await embedder.embed(text), fetchK, { kind: scopeKind, project }) : [];
+  const keywordHits = wantKeyword ? searchBM25(db, text, fetchK, { kind: scopeKind, project }) : [];
+  const raw = fuseHits(semanticHits, keywordHits, alpha, mode);
   if (raw.length === 0) return [];
-  // Adjust each chunk's distance by its kind boost. The vec store returns
-  // cosine distance (smaller = closer); subtracting the boost makes
-  // higher-priority kinds appear "closer" without altering the source
-  // truth in the DB.
-  // KJC-TSK-0440 — apply the source-vs-test asymmetric boost only when
-  // the query itself is not test-flavoured. Test-flavoured queries keep
-  // the symmetric baseline so e.g. "vitest mock setup" still surfaces
-  // test files.
   const boostSources = shouldBoostSources(text);
   const reranked = raw.map((r) => {
     const kindB = kindBoost[r.kind] || 0;
@@ -73,5 +58,4 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   return reranked;
 }
 
-// Exported for tests.
-export { shouldBoostSources, isTestPath };
+export { shouldBoostSources, isTestPath, fuseHits };

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -54,6 +54,29 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     db.exec("CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);");
   }
   db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[${dim}]);`);
+  // KJC-TSK-0443 — FTS5 keyword index for BM25 hybrid scoring. content='chunks'
+  // makes it a contentless mirror linked by id (no double storage); triggers
+  // sync the FTS5 rows on insert/update/delete. Rebuilds idempotently when
+  // the FTS5 table exists but is empty (e.g. created post-migration on a
+  // DB with pre-v2.28 chunks).
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(text, content='chunks', content_rowid='id');
+    CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+      INSERT INTO chunks_fts(rowid, text) VALUES (new.id, new.text);
+    END;
+    CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+      INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES ('delete', old.id, old.text);
+    END;
+    CREATE TRIGGER IF NOT EXISTS chunks_au AFTER UPDATE ON chunks BEGIN
+      INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES ('delete', old.id, old.text);
+      INSERT INTO chunks_fts(rowid, text) VALUES (new.id, new.text);
+    END;
+  `);
+  const ftsCount = db.prepare("SELECT COUNT(*) AS n FROM chunks_fts").get().n;
+  const chunksCount = db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
+  if (ftsCount === 0 && chunksCount > 0) {
+    db.exec("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild');");
+  }
   return db;
 }
 
@@ -132,4 +155,31 @@ export function deleteChunksBySource(db, source) {
 export function countChunks(db, { kind = null } = {}) {
   if (kind) return db.prepare("SELECT COUNT(*) AS n FROM chunks WHERE kind = ?").get(kind).n;
   return db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
+}
+
+/**
+ * KJC-TSK-0443 — BM25 keyword search over chunks_fts. Returns
+ * [{ id, source, kind, text, metadata, project_slug, bm25 }] ordered by
+ * relevance (lower bm25 = better in SQLite FTS5). `query` is sanitized for
+ * the FTS5 grammar: special chars are stripped, words split on whitespace.
+ */
+export function searchBM25(db, queryText, topK = 10, { kind = null, project = null } = {}) {
+  const cleaned = String(queryText || "").replace(/["'()]/g, " ").split(/\s+/).filter(Boolean).join(" OR ");
+  if (!cleaned) return [];
+  const kindClause = kind ? "AND c.kind = ?" : "";
+  const projectClause = project ? "AND c.project_slug = ?" : "";
+  const sql = `
+    SELECT c.id, c.source, c.kind, c.text, c.metadata, c.project_slug, bm25(chunks_fts) AS bm25
+    FROM chunks_fts JOIN chunks c ON c.id = chunks_fts.rowid
+    WHERE chunks_fts MATCH ? ${kindClause} ${projectClause}
+    ORDER BY bm25 LIMIT ?
+  `;
+  const params = [cleaned];
+  if (kind) params.push(kind);
+  if (project) params.push(project);
+  params.push(topK);
+  try {
+    const rows = db.prepare(sql).all(...params);
+    return rows.map((r) => ({ ...r, metadata: r.metadata ? safeParse(r.metadata) : null }));
+  } catch { return []; }
 }

--- a/tests/rag/bm25-hybrid.test.js
+++ b/tests/rag/bm25-hybrid.test.js
@@ -1,0 +1,78 @@
+// KJC-TSK-0443 — BM25 keyword search + hybrid fusion.
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openVecStore, insertChunk, searchBM25 } from "../../src/rag/vec-store.js";
+import { query, fuseHits } from "../../src/rag/retriever.js";
+
+function oneHot(i, d = 8) { const v = new Float32Array(d); v[i % d] = 1; return v; }
+function fakeEmb(i) { return { embed: vi.fn(async () => oneHot(i)), dim: 8 }; }
+
+describe("rag/bm25 — KJC-TSK-0443", () => {
+  let root, db;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "kj-bm25-")); db = openVecStore({ dim: 8, path: join(root, "rag.db") }); });
+  afterEach(() => { db?.close(); rmSync(root, { recursive: true, force: true }); });
+
+  it("FTS5 chunks_fts table exists and counts mirror chunks via triggers", () => {
+    insertChunk(db, { source: "/a", kind: "code", text: "alpha auth login bcrypt", embedding: oneHot(0) });
+    insertChunk(db, { source: "/b", kind: "code", text: "beta cache LRU eviction", embedding: oneHot(1) });
+    const n = db.prepare("SELECT COUNT(*) AS n FROM chunks_fts").get().n;
+    expect(n).toBe(2);
+  });
+
+  it("searchBM25 ranks exact keyword matches over unrelated chunks", () => {
+    insertChunk(db, { source: "/auth", kind: "code", text: "authentication login password bcrypt", embedding: oneHot(0) });
+    insertChunk(db, { source: "/cache", kind: "code", text: "LRU cache TTL eviction in-memory", embedding: oneHot(1) });
+    insertChunk(db, { source: "/db", kind: "code", text: "postgres connection pool transaction", embedding: oneHot(2) });
+    const hits = searchBM25(db, "bcrypt password", 5);
+    expect(hits[0].source).toBe("/auth");
+  });
+
+  it("searchBM25 returns [] for whitespace-only queries (no FTS syntax leak)", () => {
+    expect(searchBM25(db, "   ", 5)).toEqual([]);
+    expect(searchBM25(db, "", 5)).toEqual([]);
+  });
+
+  it("searchBM25 sanitises FTS5 special characters", () => {
+    insertChunk(db, { source: "/x", kind: "code", text: "hello world", embedding: oneHot(0) });
+    const hits = searchBM25(db, "hello \"world\"", 5);
+    expect(hits.length).toBeGreaterThan(0);
+  });
+});
+
+describe("retriever/fuseHits — KJC-TSK-0443", () => {
+  it("mode=semantic returns only semantic hits unchanged", () => {
+    const sem = [{ id: 1, distance: 0.1 }, { id: 2, distance: 0.2 }];
+    expect(fuseHits(sem, [], 0.6, "semantic")).toEqual(sem);
+  });
+
+  it("mode=keyword surfaces bm25 as distance", () => {
+    const kw = [{ id: 1, bm25: -3.5 }, { id: 2, bm25: -1.2 }];
+    const out = fuseHits([], kw, 0.6, "keyword");
+    expect(out[0].distance).toBe(-3.5);
+  });
+
+  it("mode=hybrid normalises + linear-combines both scores", () => {
+    const sem = [{ id: 1, distance: 0.1 }, { id: 2, distance: 0.5 }];
+    const kw = [{ id: 1, bm25: -1 }, { id: 2, bm25: -3 }];
+    const out = fuseHits(sem, kw, 0.5, "hybrid");
+    // id=1 has best semantic (dist=0.1) but worst keyword (bm25=-1, less negative = less relevant)
+    // id=2 has worst semantic (dist=0.5) but best keyword (bm25=-3, more negative = more relevant)
+    // With alpha=0.5 the tie should resolve cleanly to a finite distance per id
+    expect(out.length).toBe(2);
+    out.forEach((h) => expect(Number.isFinite(h.distance)).toBe(true));
+  });
+
+  it("query mode=keyword skips embedder (no API call)", async () => {
+    const root2 = mkdtempSync(join(tmpdir(), "kj-bm25-q-"));
+    const db2 = openVecStore({ dim: 8, path: join(root2, "rag.db") });
+    insertChunk(db2, { source: "/x", kind: "code", text: "auth login", embedding: oneHot(0) });
+    const emb = fakeEmb(0);
+    await query(db2, emb, "auth", { topK: 1, mode: "keyword" });
+    expect(emb.embed).not.toHaveBeenCalled();
+    db2.close();
+    rmSync(root2, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
PR 3 of 5 for v2.28.0. Stacked on #837 → #836 → main.

## Problem

v2.27 smoke caught a ranking gap: natural-language queries return semantically related chunks but exact-symbol queries (`projectSlug`, `runRagContextStage`) don't rank top because pure cosine similarity doesn't reward literal lexical matches.

## Fix

**SQLite FTS5** virtual table `chunks_fts` (contentless mirror via `content='chunks'` + triggers on `AFTER INSERT/UPDATE/DELETE`) gives us BM25 ranking with zero extra storage and no rebuild on incremental indexing. `bm25(chunks_fts)` returns the standard relevance metric (lower = better).

**Hybrid fusion** (`fuseHits()`) normalises semantic distance + bm25 to `[0,1]` via min-max over the candidate set and linear-combines:

```
distance = α · norm(cosine_distance) + (1−α) · norm(bm25)
```

α defaults to 0.6 (semantic-leaning) but `--alpha 0.0` ≡ keyword-only, `--alpha 1.0` ≡ semantic-only. Escape hatches via `--mode`:

```
kj rag query "projectSlug helper"
kj rag query "auth flow architecture" --mode semantic    # cosine only
kj rag query "projectSlug" --mode keyword                # BM25 only, skip embedder API call
kj rag query "sonar token bootstrap" --alpha 0.3         # keyword-heavy
```

## Migration

`openVecStore` auto-creates the FTS5 table + triggers + rebuilds from existing chunks if the FTS5 table is empty (pre-v2.28 DBs). Idempotent: subsequent calls are no-ops past the `CREATE TABLE IF NOT EXISTS`.

## Files

- `src/rag/vec-store.js` — `+50`: FTS5 schema + triggers + `searchBM25()` (sanitises FTS5 grammar)
- `src/rag/retriever.js` — rewritten for hybrid: new `fuseHits()` + `mode` / `alpha` parameters
- `src/commands/rag.js` — picks up CLI `--mode` / `--alpha`
- `src/cli/register-meta.js` — flag declarations
- `tests/rag/bm25-hybrid.test.js` — 8 cases (FTS5 trigger, BM25 ranking, sanitisation, empty-query edge case, all three modes, keyword skips embedder)

**Net +116 LOC**.

## Stacked

Base: `feat/KJC-TSK-0442-rag-cloud-embedders` (#837). Final merge order #836 → #837 → this → #838 (AST chunker) → #839 (BUG-0064).