### PR TITLE
fix(rate-limit): parseCooldown TZ-aware (KJC-BUG-0064) — PR 5/5 v2.28.0

### DIFF
--- a/src/utils/rate-limit-detector.js
+++ b/src/utils/rate-limit-detector.js
@@ -39,23 +39,21 @@ export function parseCooldown(message) {
     }
   }
 
-  // 5. Claude Code session / weekly limit: "resets 10:10pm" / "resets 4am"
-  //    (12-hour clock, no date). Resolve to the next wall-clock occurrence
-  //    of that time in the machine's local timezone. Claude Code reports
-  //    the reset in the user's local TZ and kj runs on the same machine,
-  //    so the parenthesised "(Europe/Madrid)" hint is ignored on purpose.
-  const ampmMatch = /reset(?:s|ting)?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap]m)\b/i.exec(
-    message
-  );
+  // 5. Claude Code session / weekly limit: "resets 10:10pm (Europe/Madrid)" / "resets 4am"
+  //    KJC-BUG-0064: prefer the parenthesised IANA TZ when present so the
+  //    same stderr resolves to the same instant regardless of where kj runs
+  //    (CI in TZ=UTC was misclassifying Madrid 10:10pm as already past).
+  //    No TZ literal → fall back to the host's local TZ.
+  const ampmMatch = /reset(?:s|ting)?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap]m)\b/i.exec(message);
   if (ampmMatch) {
     let hour = Number.parseInt(ampmMatch[1], 10) % 12;
     if (/pm/i.test(ampmMatch[3])) hour += 12;
     const minute = ampmMatch[2] ? Number.parseInt(ampmMatch[2], 10) : 0;
     if (hour < 24 && minute < 60) {
-      const target = new Date();
-      target.setHours(hour, minute, 0, 0);
-      if (target.getTime() <= Date.now()) target.setDate(target.getDate() + 1);
-      return { cooldownUntil: target.toISOString(), cooldownMs: target.getTime() - Date.now() };
+      const tzMatch = /\(([A-Za-z]+\/[A-Za-z_/+\-0-9]+)\)/.exec(message);
+      const tz = tzMatch ? tzMatch[1] : null;
+      const target = tz ? nextOccurrenceInTZ(hour, minute, tz) : nextOccurrenceLocal(hour, minute);
+      if (target) return { cooldownUntil: target.toISOString(), cooldownMs: Math.max(0, target.getTime() - Date.now()) };
     }
   }
 
@@ -82,6 +80,50 @@ export function parseCooldown(message) {
   }
 
   return { cooldownUntil: null, cooldownMs: null };
+}
+
+// KJC-BUG-0064 — TZ-aware "next occurrence of hour:minute" resolver.
+// Walks today + tomorrow in the given IANA TZ; returns the first instant
+// > now. Uses Intl.DateTimeFormat as the source of truth so it works on
+// any host TZ (CI runs UTC, dev runs Europe/Madrid, etc.).
+function nextOccurrenceInTZ(hour, minute, tz) {
+  try {
+    const now = new Date();
+    for (let dayOffset = 0; dayOffset <= 1; dayOffset++) {
+      const probe = new Date(now.getTime() + dayOffset * 86400000);
+      const parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+      }).formatToParts(probe).reduce((acc, p) => (p.type !== "literal" ? { ...acc, [p.type]: p.value } : acc), {});
+      if (!parts.year) return null;
+      const candidate = zonedTimeToUTC(Number(parts.year), Number(parts.month), Number(parts.day), hour, minute, tz);
+      if (candidate && candidate.getTime() > now.getTime()) return candidate;
+    }
+    return null;
+  } catch { return null; }
+}
+
+// Converts a wall-clock date + time in `tz` to a UTC Date.
+// Strategy: interpret year/month/day/hour/minute as naive UTC, see what
+// wall-clock that maps to in `tz`, derive the offset (tz - UTC at that
+// moment) and subtract it from the naive value to land on the true UTC.
+// One step suffices except at DST transitions (within ±1h, acceptable
+// for cooldown timing).
+function zonedTimeToUTC(year, month, day, hour, minute, tz) {
+  const naiveUTC = Date.UTC(year, month - 1, day, hour, minute);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", hour12: false,
+  }).formatToParts(new Date(naiveUTC)).reduce((acc, p) => (p.type !== "literal" ? { ...acc, [p.type]: p.value } : acc), {});
+  const wallInTZ = Date.UTC(Number(parts.year), Number(parts.month) - 1, Number(parts.day), Number(parts.hour) % 24, Number(parts.minute));
+  const tzOffset = wallInTZ - naiveUTC; // positive when tz is ahead of UTC
+  return new Date(naiveUTC - tzOffset);
+}
+
+function nextOccurrenceLocal(hour, minute) {
+  const target = new Date();
+  target.setHours(hour, minute, 0, 0);
+  if (target.getTime() <= Date.now()) target.setDate(target.getDate() + 1);
+  return target;
 }
 
 const RATE_LIMIT_PATTERNS = [

--- a/tests/rate-limit-detector.test.js
+++ b/tests/rate-limit-detector.test.js
@@ -303,13 +303,16 @@ describe("parseCooldown — 12-hour clock (Claude Code session limit)", () => {
     vi.useRealTimers();
   });
 
-  it("parses 'resets 10:10pm' to 22:10 the same day", () => {
+  it("parses 'resets 10:10pm (Europe/Madrid)' to 22:10 Madrid wall-clock (TZ-aware)", () => {
+    // KJC-BUG-0064 — verify the Madrid wall-clock regardless of host TZ.
     const { cooldownUntil, cooldownMs } = parseCooldown(
       "You've hit your session limit · resets 10:10pm (Europe/Madrid)"
     );
-    const target = new Date(cooldownUntil);
-    expect(target.getHours()).toBe(22);
-    expect(target.getMinutes()).toBe(10);
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "Europe/Madrid", hour: "2-digit", minute: "2-digit", hour12: false,
+    }).formatToParts(new Date(cooldownUntil)).reduce((a, p) => (p.type !== "literal" ? { ...a, [p.type]: p.value } : a), {});
+    expect(parts.hour).toBe("22");
+    expect(parts.minute).toBe("10");
     expect(cooldownMs).toBeGreaterThan(0);
   });
 

--- a/tests/resilience/hibernate-end-to-end.test.js
+++ b/tests/resilience/hibernate-end-to-end.test.js
@@ -31,12 +31,10 @@ function makeQuotaAgent() {
 }
 
 describe("resilience: quota exhaustion end to end", () => {
-  // KJC-BUG-0063: the "10:10pm (Europe/Madrid)" string is parsed against the
-  // local TZ. CI runs TZ=UTC, where 10:10pm Madrid is in the past → classify
-  // returns RATE_LIMIT_SHORT instead of QUOTA_EXHAUSTED_DAILY. Skip in CI
-  // until parseCooldown becomes TZ-aware. Tracked separately.
-  const isCI = process.env.CI === "true" || process.env.CI === "1";
-  (isCI ? it.skip : it)("classifies the Claude Code session limit as a recoverable quota cap", () => {
+  // KJC-BUG-0064: parseCooldown is now TZ-aware — picks up the (Europe/Madrid)
+  // literal in the stderr and resolves via Intl.DateTimeFormat. Test passes on
+  // any host TZ; the v2.27.0 skip-in-CI workaround is gone.
+  it("classifies the Claude Code session limit as a recoverable quota cap", () => {
     // The original user-reported message uses the 12-hour clock; parseCooldown
     // must understand it. Resilience tripwire for #756 — independent of how
     // long the wait will be (that's tested via the ISO path below).


### PR DESCRIPTION
PR 5 of 5 for v2.28.0. **Closes KJC-BUG-0064**, the proper fix for the workaround shipped in v2.27.0 (KJC-BUG-0063 skip-in-CI).

## Problem

`parseCooldown` matched `resets 10:10pm (Europe/Madrid)` and resolved hour/minute against the HOST timezone, **ignoring the parenthesised IANA TZ literal**. CI runs TZ=UTC, where 22:10 Madrid was already past → classifier returned `RATE_LIMIT_SHORT` instead of `QUOTA_EXHAUSTED_DAILY`.

## Fix

When the stderr contains `(<Continent>/<City>)` (regex `/\([A-Za-z]+\/...\)/`), resolve the wall-clock target **in that specific timezone** via `Intl.DateTimeFormat`. Algorithm:

```text
1. Build a candidate UTC by reading today/tomorrow in the target TZ
2. Compute the TZ offset at that moment by formatting the naive UTC
   back through Intl and measuring how far the wall-clock drifts
3. Subtract the offset to land on the true UTC
```

No TZ literal → fall back to host-local behaviour (back-compat).

## Verification

Tests pass on multiple TZ (CI's `TZ=UTC`, dev `Europe/Madrid`, `Asia/Tokyo`, `America/Los_Angeles`):

```
$ for tz in UTC Europe/Madrid Asia/Tokyo America/Los_Angeles; do
    TZ=$tz npx vitest run tests/rate-limit-detector.test.js tests/resilience/
  done
# 42/42 + 4/4 each
```

The skip-in-CI guard introduced by the v2.27 workaround is **removed** from `tests/resilience/hibernate-end-to-end.test.js` — closes the chapuza.

## Files

- `src/utils/rate-limit-detector.js` — `+66 −22`: TZ-aware path + `nextOccurrenceInTZ` + `zonedTimeToUTC` + `nextOccurrenceLocal` (refactor of the AMPM block)
- `tests/rate-limit-detector.test.js` — assert against `Intl.DateTimeFormat` wall-clock, not host `.getHours()`
- `tests/resilience/hibernate-end-to-end.test.js` — workaround removed

**Net +43 LOC**.

## Stacked

Base: `feat/KJC-TSK-0444-rag-ast-chunker` (#839). Final merge order: #836 → #837 → #838 → #839 → this → release v2.28.0.