### PR TITLE
chore: release v2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.28.0] - 2026-05-25
+
+Minor release. **RAG advanced** — live re-index + cloud embedders + hybrid scoring + AST chunker.
+
+Five PRs landed plus a real fix for the chapuza shipped in v2.27.0:
+
+- **PR #836 (KJC-TSK-0441) — chokidar watcher**. New `kj watch [start|stop|status]` daemon vigilando `~/.karajan/onboarding/`, `~/.karajan/plans/` y (opt) projectDir sources. Re-indexa el archivo afectado tras 1 s de debounce. `unlink` limpia los chunks. Single-daemon arbitrate via PID file `~/.karajan/watcher.pid`. Resuelve la fricción del manual `kj rag index` tras cada edit.
+- **PR #841 (KJC-TSK-0442) — OpenAI + Voyage embedder adapters**. Nuevos `src/rag/embedders/{openai,voyage,_cloud-base,factory}.js`. Desbloquea RAG para usuarios sin Docker local. `config.rag.embedder.provider: ollama | openai | voyage` (default ollama). Env vars Karajan-scoped: `KJ_OPENAI_KEY`, `KJ_VOYAGE_KEY` (preserva architecture invariant — Karajan nunca lee `OPENAI_API_KEY` directamente).
+- **PR #838 (KJC-TSK-0443) — BM25 + cosine hybrid scoring**. SQLite FTS5 virtual table `chunks_fts` (contentless + triggers). Nueva función `searchBM25()` + `fuseHits()` que normaliza ambos scores a `[0,1]` y linear-combina via alpha. CLI: `--mode hybrid|semantic|keyword` (default hybrid, alpha=0.6). Hace que queries con símbolos exactos rankeen correctamente.
+- **PR #839 (KJC-TSK-0444) — AST source chunker (@babel/parser)**. Reemplaza el regex chunker para JS/TS/JSX. Cada top-level declaration es un chunk; JSDoc + comments leading se foldean. Plugins: typescript, jsx, decorators-legacy, classProperties, topLevelAwait. Fallback a regex chunker si parseo falla.
+
+### Fixed
+
+- **KJC-BUG-0064 (PR #840)** — `parseCooldown` ahora TZ-aware. Cuando el stderr contiene `(Continent/City)`, resuelve el wall-clock target en esa TZ específica via `Intl.DateTimeFormat`. Deshace el workaround skip-in-CI shipped en v2.27.0 (KJC-BUG-0063). Tests pasan en TZ=UTC, Europe/Madrid, Asia/Tokyo, America/Los_Angeles.
+
 ## [2.27.0] - 2026-05-25
 
 Minor release. **RAG polish — per-project isolation, unified docs, fairer ranking.**

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.28.0 released** — Minor. **RAG advanced** — live re-index + cloud embedders + hybrid scoring + AST chunker, plus a real fix for the v2.27.0 chapuza.
+>
+> - **`kj watch`** (PR #836): chokidar daemon que re-indexa los archivos del proyecto tras cada edit (1s debounce). Fin del `kj rag index` manual.
+> - **OpenAI + Voyage embedders** (PR #841): para usuarios sin Docker local. `config.rag.embedder.provider: openai | voyage` + `KJ_OPENAI_KEY` / `KJ_VOYAGE_KEY` env vars (Karajan-scoped — preserva el architecture invariant).
+> - **BM25 hybrid scoring** (PR #838): SQLite FTS5 + cosine fusion. `kj rag query --mode hybrid|semantic|keyword`. Queries con símbolos exactos rankean correctamente.
+> - **AST source chunker** (PR #839): `@babel/parser`. Cada top-level declaration entera en un chunk; TypeScript + JSX + decorators soportados.
+> - **KJC-BUG-0064** (PR #840): `parseCooldown` TZ-aware via `Intl.DateTimeFormat`. Deshace el skip-in-CI workaround de v2.27.0 — tests pasan en cualquier TZ.
+>
 > **v2.27.0 released** — Minor. **RAG polish** — three improvements triggered by the v2.26.0 smoke test on karajan-code itself:
 >
 > - **Per-project isolation** (PR #831): new `project_slug` column on chunks; `kj rag query --project <slug>` (auto-detected from cwd) filters the global DB. `--project all` to query across everything.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (53k LOC, 391 files)
+├── src/              # Source code (54k LOC, 398 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.27.0
+kj --version    # 2.28.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.27.0
+kj --version    # 2.28.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.27.0",
+      "version": "2.28.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.27.0",
+  "version": "2.28.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Closes v2.28.0 — RAG advanced features + KJC-BUG-0064 fix real.

| PR | Card | Title |
|---|---|---|
| #836 | KJC-TSK-0441 | chokidar watcher (kj watch) |
| #841 | KJC-TSK-0442 | OpenAI + Voyage embedders |
| #838 | KJC-TSK-0443 | BM25 + cosine hybrid |
| #839 | KJC-TSK-0444 | AST source chunker |
| #840 | KJC-BUG-0064 | parseCooldown TZ-aware |

Bump 2.27.0 → 2.28.0 + CHANGELOG + README banner + GETTING-STARTED + ARCHITECTURE stats.