### PR TITLE
feat(rag): retrieval-quality dashboard in HU Board (KJC-TSK-0445)

### DIFF
--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -25,6 +25,7 @@
       <button class="nav-btn" data-view="dashboard" title="Per-project landing: stats grid + project list. Click a project card to focus the kanban / graph on that project.">Dashboard</button>
       <button class="nav-btn" data-view="sessions" title="Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
       <a class="nav-btn" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
+      <a class="nav-btn" href="/rag.html" title="RAG retrieval-quality dashboard: chunk counts, embedder provider, db size.">RAG</a>
       <select class="project-select" id="project-select">
         <option value="">All Projects</option>
       </select>

--- a/packages/hu-board/public/rag.html
+++ b/packages/hu-board/public/rag.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Karajan RAG · Retrieval Dashboard</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header__logo"><div><div class="header__title">Karajan RAG</div><div class="header__subtitle">retrieval-quality dashboard</div></div></div>
+    <nav class="header__nav">
+      <a class="nav-btn" href="/">← Board</a>
+      <button class="nav-btn active">RAG</button>
+      <div class="header__controls"><button class="control-btn" id="rag-refresh" title="Reload stats">🔄</button></div>
+    </nav>
+  </header>
+  <main class="main" id="rag-app"><div class="loading"><div class="loading__spinner"></div><p>Loading…</p></div></main>
+  <script src="/rag.js"></script>
+</body>
+</html>

--- a/packages/hu-board/public/rag.js
+++ b/packages/hu-board/public/rag.js
@@ -1,0 +1,39 @@
+// KJC-TSK-0445 — Retrieval dashboard frontend. Fetches /api/rag/stats and
+// renders chunk counts per project/kind, embedder, DB size and last-index.
+const TOKEN = new URLSearchParams(location.search).get("token") || localStorage.getItem("kj_board_token") || "";
+const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
+const ESC = (s) => String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+function bytes(n) { for (const u of ["B", "KB", "MB", "GB"]) { if (n < 1024) return `${u === "B" ? n : n.toFixed(1)} ${u}`; n /= 1024; } return `${n.toFixed(2)} TB`; }
+
+function bars(rows, lab, val, max) {
+  if (!rows.length) return '<p class="rag-empty">no data</p>';
+  return rows.map((r) => `<div class="rag-bar"><span class="rag-bar__label">${ESC(lab(r))}</span><span class="rag-bar__fill" style="width:${Math.round((val(r) / max) * 100)}%"></span><span class="rag-bar__value">${val(r).toLocaleString()}</span></div>`).join("");
+}
+
+function embedderCard(e) {
+  return e ? `<div class="rag-card"><h3>Embedder</h3><p class="rag-stat-big">${ESC(e.provider)}</p><p class="rag-stat-sub">${ESC(e.model || "default model")} · dim ${e.dim ?? "?"}</p></div>` : "";
+}
+
+function render(root, data) {
+  if (!data.initialized) { root.innerHTML = `<section class="rag-grid"><div class="rag-card"><h3>RAG DB</h3><p class="rag-empty">${ESC(data.message || "not initialized")}</p></div>${embedderCard(data.embedder)}</section>`; return; }
+  const lastIdx = data.last_indexed ? new Date(data.last_indexed).toLocaleString() : "never";
+  const mk = Math.max(1, ...data.by_kind.map((r) => r.n));
+  const mp = Math.max(1, ...data.by_project.map((r) => r.n));
+  root.innerHTML = `<section class="rag-grid">
+    <div class="rag-card"><h3>Totals</h3><p class="rag-stat-big">${data.total_chunks.toLocaleString()}</p><p class="rag-stat-sub">chunks · ${bytes(data.db_size_bytes)} · last indexed ${ESC(lastIdx)}</p></div>
+    ${embedderCard(data.embedder)}
+    <div class="rag-card rag-card--wide"><h3>By kind</h3>${bars(data.by_kind, (r) => r.kind, (r) => r.n, mk)}</div>
+    <div class="rag-card rag-card--wide"><h3>By project (top 20)</h3>${bars(data.by_project, (r) => r.project, (r) => r.n, mp)}</div>
+  </section>`;
+}
+
+async function load() {
+  const app = document.getElementById("rag-app");
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading…</p></div>';
+  try { const r = await fetch("/api/rag/stats", { headers: HEADERS }); if (!r.ok) throw new Error(`HTTP ${r.status}`); render(app, await r.json()); }
+  catch (e) { app.innerHTML = `<div class="rag-card rag-card--error"><strong>Error:</strong> ${ESC(e.message)}</div>`; }
+}
+
+document.getElementById("rag-refresh").addEventListener("click", load);
+load();

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -916,3 +916,17 @@ body.scoped-mode .nav-btn[data-view="dashboard"],
 body.scoped-mode .header__nav a[href="/pipeline.html"] {
   display: none;
 }
+
+/* KJC-TSK-0445 — RAG dashboard */
+.rag-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; padding: 1rem; }
+.rag-card { background: var(--bg-secondary, #1e1e2e); border-radius: 8px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.rag-card--wide { grid-column: 1 / -1; }
+.rag-card--error { color: #f87171; background: #2a1414; }
+.rag-card h3 { margin: 0 0 .75rem; font-size: .9rem; text-transform: uppercase; letter-spacing: .05em; color: var(--text-secondary, #94a3b8); }
+.rag-stat-big { font-size: 2rem; font-weight: 700; margin: 0; color: var(--text-primary, #f8fafc); }
+.rag-stat-sub { margin: .25rem 0 0; font-size: .85rem; color: var(--text-secondary, #94a3b8); }
+.rag-empty { color: var(--text-secondary, #94a3b8); font-style: italic; }
+.rag-bar { display: grid; grid-template-columns: 140px 1fr 60px; align-items: center; gap: .5rem; margin: .35rem 0; font-size: .85rem; }
+.rag-bar__label { color: var(--text-secondary, #cbd5e1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rag-bar__fill { display: block; height: 14px; background: linear-gradient(90deg, #7c3aed, #a78bfa); border-radius: 3px; }
+.rag-bar__value { text-align: right; color: var(--text-primary, #f8fafc); font-variant-numeric: tabular-nums; }

--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -1,0 +1,36 @@
+// KJC-TSK-0445 — RAG retrieval-quality dashboard route.
+// GET /api/rag/stats → snapshot of the local rag.db (counts per kind/project,
+// active embedder, db size, last-index timestamp). Missing DB returns an
+// "uninitialized" payload so the dashboard renders an empty state cleanly.
+import { Router } from "express";
+import { existsSync, statSync } from "node:fs";
+import Database from "better-sqlite3";
+import { dbPath } from "../../../../src/rag/vec-store.js";
+import { readConfig } from "../config-yaml.js";
+
+const router = Router();
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024 };
+
+function embedder() {
+  try {
+    const e = (readConfig()?.rag?.embedder) || {};
+    const provider = e.provider || "ollama";
+    return { provider, model: e.model || null, dim: e.dim || DIMS[provider] || null };
+  } catch { return { provider: "ollama", model: null, dim: 768 }; }
+}
+
+router.get("/stats", (_req, res) => {
+  const path = dbPath();
+  if (!existsSync(path)) return res.json({ ok: true, initialized: false, message: "rag.db not initialized — run `kj rag index <dir>` to start indexing.", embedder: embedder() });
+  try {
+    const db = new Database(path, { readonly: true, fileMustExist: true });
+    const total_chunks = db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
+    const by_kind = db.prepare("SELECT kind, COUNT(*) AS n FROM chunks GROUP BY kind").all();
+    const by_project = db.prepare("SELECT COALESCE(project_slug, '(no slug)') AS project, COUNT(*) AS n FROM chunks GROUP BY project_slug ORDER BY n DESC LIMIT 20").all();
+    const last_indexed = db.prepare("SELECT MAX(created_at) AS ts FROM chunks").get().ts;
+    db.close();
+    res.json({ ok: true, initialized: true, db_path: path, db_size_bytes: statSync(path).size, total_chunks, by_kind, by_project, last_indexed, embedder: embedder() });
+  } catch (err) { res.status(500).json({ ok: false, error: String(err.message || err) }); }
+});
+
+export default router;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -9,6 +9,7 @@ import { initDb, closeDb } from './db.js';
 import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
 import pipelineRoutes from './routes/pipeline.js';
+import ragRoutes from './routes/rag.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
@@ -298,6 +299,7 @@ async function main() {
   app.use(express.static(PUBLIC_DIR, { setHeaders: noStoreHeaders, etag: false, lastModified: false }));
   app.use('/api', buildRateLimiter(), authMiddleware(), apiRoutes);
   app.use('/api/pipeline', authMiddleware(), pipelineRoutes);
+  app.use('/api/rag', authMiddleware(), ragRoutes);
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {

--- a/packages/hu-board/tests/rag-routes.test.js
+++ b/packages/hu-board/tests/rag-routes.test.js
@@ -1,0 +1,52 @@
+// KJC-TSK-0445 — Tests for /api/rag/stats. Verifies snapshot shape against
+// (a) an empty/uninitialized DB and (b) a DB seeded with chunks.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+let tmpHome, app;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "hu-board-rag-"));
+  process.env.KJ_HOME = tmpHome;
+  process.env.KARAJAN_HOME = tmpHome;
+  process.env.KJ_RAG_DB = join(tmpHome, "rag.db");
+  const { default: ragRoutes } = await import("../src/routes/rag.js");
+  app = express();
+  app.use("/api/rag", ragRoutes);
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME; delete process.env.KARAJAN_HOME; delete process.env.KJ_RAG_DB;
+});
+
+describe("GET /api/rag/stats", () => {
+  it("reports uninitialized when rag.db does not exist", async () => {
+    const res = await request(app).get("/api/rag/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.initialized).toBe(false);
+    expect(res.body.embedder.provider).toBe("ollama");
+  });
+
+  it("returns chunk counts grouped by kind and project when populated", async () => {
+    const { openVecStore, insertChunk } = await import("../../../src/rag/vec-store.js");
+    const db = openVecStore({ dim: 4 });
+    insertChunk(db, { source: "a.js", kind: "code", text: "auth", embedding: [0.1, 0.2, 0.3, 0.4], project: "proj-a" });
+    insertChunk(db, { source: "b.md", kind: "plan", text: "spec", embedding: [0.5, 0.6, 0.7, 0.8], project: "proj-a" });
+    insertChunk(db, { source: "c.js", kind: "code", text: "router", embedding: [0.1, 0.1, 0.1, 0.1], project: "proj-b" });
+    insertChunk(db, { source: "x.js", kind: "code", text: "legacy", embedding: [0.1, 0.1, 0.1, 0.1] });
+    db.close();
+    const res = await request(app).get("/api/rag/stats");
+    expect(res.body.initialized).toBe(true);
+    expect(res.body.total_chunks).toBe(4);
+    const byKind = Object.fromEntries(res.body.by_kind.map((r) => [r.kind, r.n]));
+    expect(byKind).toEqual({ code: 3, plan: 1 });
+    const byProj = Object.fromEntries(res.body.by_project.map((r) => [r.project, r.n]));
+    expect(byProj).toEqual({ "proj-a": 2, "proj-b": 1, "(no slug)": 1 });
+    expect(res.body.db_size_bytes).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What

First piece of the v2.29.0 / v2.30.0 'config UI' track: a new `/rag.html` page served by HU Board showing the live state of the local rag.db.

### Surface
- Active embedder (provider · model · dim)
- Total chunks · DB size · last-index timestamp
- Bar chart: chunks per kind (code / plan / onboarding)
- Bar chart: chunks per project (top 20, slug → count)
- Empty-state when rag.db hasn't been initialized

### Backend
- New `packages/hu-board/src/routes/rag.js` — single GET /api/rag/stats endpoint
- Reads the DB read-only via better-sqlite3; reads kj.config.yml for embedder
- Missing DB → `{ initialized: false, message }` so the page renders cleanly
- No new dependencies

### Frontend
- Standalone page (`rag.html` + `rag.js`)
- Zero charting libs — plain divs + CSS for bar charts
- Linked from main nav (`<a href="/rag.html">RAG</a>`)
- Auth via existing token mechanism (Bearer header from URL or localStorage)

## Why

User feedback during v2.28 dogfooding asked for a post-setup config surface on the board. Visibility is the obvious first step: you can't tweak what you can't see. v2.30 will turn this into a writable config UI; v2.29 lays the read-only foundation.

## Tests

`packages/hu-board/tests/rag-routes.test.js` (2 cases):
- uninitialized DB → `{ initialized: false, embedder.provider: 'ollama' }`
- populated DB → correct counts grouped by kind and project, with null project_slug bucketed as `(no slug)`

## LOC

165 lines (under 200 budget).

## Roadmap link

PR1/5 of v2.29.0. Next PRs add Cohere/Mistral/ONNX embedders, metadata filtering, and rerank — the dashboard will surface them automatically as the embedder factory grows.