### PR TITLE
feat(rag): Cohere + Mistral embedder adapters (KJC-TSK-0446)

### DIFF
--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -9,7 +9,7 @@ import { dbPath } from "../../../../src/rag/vec-store.js";
 import { readConfig } from "../config-yaml.js";
 
 const router = Router();
-const DIMS = { ollama: 768, openai: 1536, voyage: 1024 };
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024 };
 
 function embedder() {
   try {

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -173,9 +173,11 @@ const ragStubPlugin = {
           // KJC-TSK-0441 — RAG chokidar watcher.
           startWatcher: notAvailable, readPidFile: notAvailable, clearPidFile: notAvailable,
           isPidAlive: notAvailable, writePidFile: notAvailable,
-          // KJC-TSK-0442 — RAG embedders cloud + factory.
+          // KJC-TSK-0442 / KJC-TSK-0446 — RAG embedders cloud + factory.
           makeEmbedder: notAvailable, OpenAIEmbedder: notAvailable, VoyageEmbedder: notAvailable,
           OpenAIEmbedderError: notAvailable, VoyageEmbedderError: notAvailable, PROVIDERS: notAvailable,
+          CohereEmbedder: notAvailable, CohereEmbedderError: notAvailable,
+          MistralEmbedder: notAvailable, MistralEmbedderError: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/rag/embedders/cohere.js
+++ b/src/rag/embedders/cohere.js
@@ -1,0 +1,28 @@
+// KJC-TSK-0446 — Cohere embed-v3 adapter. Cohere returns
+// { embeddings: { float: [[...]] } } when `embedding_types: ["float"]`
+// is requested, or { embeddings: [[...]] } in legacy v1. We extract the
+// modern shape with a v1 fallback.
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.cohere.com/v2/embed", model: "embed-multilingual-v3.0", dim: 1024, timeoutMs: 30000 };
+
+export class CohereEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "CohereEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class CohereEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.KJ_COHERE_KEY, model = process.env.KJ_COHERE_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    // KJC architecture invariant: scoped env var (KJ_COHERE_KEY), not the
+    // generic COHERE_API_KEY — same rule as OpenAI/Voyage adapters.
+    if (!apiKey) throw new CohereEmbedderError("Cohere embedder requires an api_key (config.rag.embedder.api_key or KJ_COHERE_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) {
+    return cloudEmbed(this, text, CohereEmbedderError, {
+      provider: "Cohere",
+      body: { model: this.model, texts: [text], input_type: "search_document", embedding_types: ["float"] },
+      extract: (b) => b?.embeddings?.float?.[0] || b?.embeddings?.[0],
+    });
+  }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new CohereEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -1,12 +1,20 @@
-// KJC-TSK-0442 — Embedder factory. Selects provider from
-// config.rag.embedder.provider (ollama | openai | voyage; default ollama).
-// Each provider has its own dim default; the factory wires it so the
-// caller does not need to know.
+// KJC-TSK-0442 / KJC-TSK-0446 — Embedder factory. Selects provider from
+// config.rag.embedder.provider (ollama | openai | voyage | cohere | mistral;
+// default ollama). Each provider has its own dim default; the factory wires
+// it so the caller does not need to know.
 import { OllamaEmbedder } from "../embedder.js";
 import { OpenAIEmbedder } from "./openai.js";
 import { VoyageEmbedder } from "./voyage.js";
+import { CohereEmbedder } from "./cohere.js";
+import { MistralEmbedder } from "./mistral.js";
 
-const PROVIDERS = { ollama: { cls: OllamaEmbedder, dim: 768 }, openai: { cls: OpenAIEmbedder, dim: 1536 }, voyage: { cls: VoyageEmbedder, dim: 1024 } };
+const PROVIDERS = {
+  ollama: { cls: OllamaEmbedder, dim: 768 },
+  openai: { cls: OpenAIEmbedder, dim: 1536 },
+  voyage: { cls: VoyageEmbedder, dim: 1024 },
+  cohere: { cls: CohereEmbedder, dim: 1024 },
+  mistral: { cls: MistralEmbedder, dim: 1024 },
+};
 
 export function makeEmbedder(config = {}) {
   const cfg = config?.rag?.embedder || {};

--- a/src/rag/embedders/mistral.js
+++ b/src/rag/embedders/mistral.js
@@ -1,0 +1,26 @@
+// KJC-TSK-0446 — Mistral AI embeddings adapter. EU-hosted, useful for
+// users with GDPR constraints that prefer not to send chunks to US
+// endpoints. Single model today (`mistral-embed`, 1024 dim).
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.mistral.ai/v1/embeddings", model: "mistral-embed", dim: 1024, timeoutMs: 30000 };
+
+export class MistralEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "MistralEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class MistralEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.KJ_MISTRAL_KEY, model = process.env.KJ_MISTRAL_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    // KJC architecture invariant: scoped env var (KJ_MISTRAL_KEY).
+    if (!apiKey) throw new MistralEmbedderError("Mistral embedder requires an api_key (config.rag.embedder.api_key or KJ_MISTRAL_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) {
+    return cloudEmbed(this, text, MistralEmbedderError, {
+      provider: "Mistral",
+      body: { model: this.model, input: [text] },
+      extract: (b) => b?.data?.[0]?.embedding,
+    });
+  }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new MistralEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/tests/rag/embedders-factory.test.js
+++ b/tests/rag/embedders-factory.test.js
@@ -3,6 +3,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { makeEmbedder } from "../../src/rag/embedders/factory.js";
 import { OpenAIEmbedder, OpenAIEmbedderError } from "../../src/rag/embedders/openai.js";
 import { VoyageEmbedder, VoyageEmbedderError } from "../../src/rag/embedders/voyage.js";
+import { CohereEmbedder, CohereEmbedderError } from "../../src/rag/embedders/cohere.js";
+import { MistralEmbedder, MistralEmbedderError } from "../../src/rag/embedders/mistral.js";
 import { OllamaEmbedder } from "../../src/rag/embedder.js";
 
 describe("rag/embedders factory (KJC-TSK-0442)", () => {
@@ -21,6 +23,18 @@ describe("rag/embedders factory (KJC-TSK-0442)", () => {
   it("selects Voyage provider when configured", () => {
     const e = makeEmbedder({ rag: { embedder: { provider: "voyage", api_key: "pa-test" } } });
     expect(e).toBeInstanceOf(VoyageEmbedder);
+    expect(e.dim).toBe(1024);
+  });
+
+  it("selects Cohere provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "cohere", api_key: "co-test" } } });
+    expect(e).toBeInstanceOf(CohereEmbedder);
+    expect(e.dim).toBe(1024);
+  });
+
+  it("selects Mistral provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "mistral", api_key: "ms-test" } } });
+    expect(e).toBeInstanceOf(MistralEmbedder);
     expect(e.dim).toBe(1024);
   });
 
@@ -83,5 +97,49 @@ describe("VoyageEmbedder (KJC-TSK-0442)", () => {
     const body = JSON.parse(fetchFn.mock.calls[0][1].body);
     expect(body.input_type).toBe("document");
     expect(body.input).toEqual(["auth flow"]);
+  });
+});
+
+describe("CohereEmbedder (KJC-TSK-0446)", () => {
+  it("rejects without api key", () => {
+    const prev = process.env.KJ_COHERE_KEY;
+    delete process.env.KJ_COHERE_KEY;
+    try { expect(() => new CohereEmbedder({})).toThrow(CohereEmbedderError); }
+    finally { if (prev !== undefined) process.env.KJ_COHERE_KEY = prev; }
+  });
+
+  it("POSTs with embedding_types=float + extracts embeddings.float[0]", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ embeddings: { float: [new Array(1024).fill(0.3)] } }) });
+    const e = new CohereEmbedder({ apiKey: "co-test", fetchFn });
+    const v = await e.embed("login flow");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(1024);
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.embedding_types).toEqual(["float"]);
+    expect(body.input_type).toBe("search_document");
+  });
+
+  it("falls back to legacy embeddings[0] shape", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ embeddings: [new Array(1024).fill(0.4)] }) });
+    const e = new CohereEmbedder({ apiKey: "k", fetchFn });
+    const v = await e.embed("x");
+    expect(v.length).toBe(1024);
+  });
+});
+
+describe("MistralEmbedder (KJC-TSK-0446)", () => {
+  it("rejects without api key", () => {
+    const prev = process.env.KJ_MISTRAL_KEY;
+    delete process.env.KJ_MISTRAL_KEY;
+    try { expect(() => new MistralEmbedder({})).toThrow(MistralEmbedderError); }
+    finally { if (prev !== undefined) process.env.KJ_MISTRAL_KEY = prev; }
+  });
+
+  it("POSTs to api.mistral.ai + returns Float32Array", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [{ embedding: new Array(1024).fill(0.5) }] }) });
+    const e = new MistralEmbedder({ apiKey: "ms-test", fetchFn });
+    const v = await e.embed("router config");
+    expect(v.length).toBe(1024);
+    expect(fetchFn.mock.calls[0][0]).toBe("https://api.mistral.ai/v1/embeddings");
   });
 });


### PR DESCRIPTION
## What

Two new cloud embedder adapters: **Cohere** (`embed-multilingual-v3.0`, 1024 dim) and **Mistral AI** (`mistral-embed`, 1024 dim, EU-hosted).

### Providers landscape after this PR

| Provider | Endpoint | Dim | Default model | Env var |
|---|---|---|---|---|
| ollama | localhost / Docker | 768 | nomic-embed-text | — |
| openai | api.openai.com | 1536 | text-embedding-3-small | KJ_OPENAI_KEY |
| voyage | api.voyageai.com | 1024 | voyage-code-3 | KJ_VOYAGE_KEY |
| **cohere** | api.cohere.com | 1024 | embed-multilingual-v3.0 | KJ_COHERE_KEY |
| **mistral** | api.mistral.ai | 1024 | mistral-embed | KJ_MISTRAL_KEY |

### Why Cohere + Mistral instead of Anthropic

The original v2.28 roadmap mentioned 'Anthropic via OAuth' as a future embedder, but Anthropic doesn't offer an embeddings API. Cohere covers strong multilingual retrieval; Mistral covers EU-hosted users with GDPR constraints. PR3 of v2.29 adds an ONNX local option (`@xenova/transformers`) for users who want zero API keys at all.

### Architecture invariant preserved

Both adapters read **Karajan-scoped** env vars (`KJ_COHERE_KEY`, `KJ_MISTRAL_KEY`) — never the generic `COHERE_API_KEY` / `MISTRAL_API_KEY`. The `tests/architecture/no-provider-apis.test.js` check passes (5/5).

## Tests

- 2 new factory cases (cohere/mistral provider selection)
- 5 new adapter cases (auth rejection, POST shape, dim validation, legacy v1 fallback for Cohere)
- 18/18 in `tests/rag/embedders-factory.test.js` passing

## LOC

129 net (well under 200).

## Roadmap link

PR2/5 of v2.29.0. Next PR adds the ONNX local embedder — the no-Docker, no-API-key option that unlocks v2.31's zero-config init.