### PR TITLE
feat(rag): ONNX local embedder via @huggingface/transformers (KJC-TSK-0447)

### DIFF
--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -25,6 +25,7 @@
       <button class="nav-btn" data-view="dashboard" title="Per-project landing: stats grid + project list. Click a project card to focus the kanban / graph on that project.">Dashboard</button>
       <button class="nav-btn" data-view="sessions" title="Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
       <a class="nav-btn" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
+      <a class="nav-btn" href="/rag.html" title="RAG retrieval-quality dashboard: chunk counts, embedder provider, db size.">RAG</a>
       <select class="project-select" id="project-select">
         <option value="">All Projects</option>
       </select>

--- a/packages/hu-board/public/rag.html
+++ b/packages/hu-board/public/rag.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Karajan RAG · Retrieval Dashboard</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header__logo"><div><div class="header__title">Karajan RAG</div><div class="header__subtitle">retrieval-quality dashboard</div></div></div>
+    <nav class="header__nav">
+      <a class="nav-btn" href="/">← Board</a>
+      <button class="nav-btn active">RAG</button>
+      <div class="header__controls"><button class="control-btn" id="rag-refresh" title="Reload stats">🔄</button></div>
+    </nav>
+  </header>
+  <main class="main" id="rag-app"><div class="loading"><div class="loading__spinner"></div><p>Loading…</p></div></main>
+  <script src="/rag.js"></script>
+</body>
+</html>

--- a/packages/hu-board/public/rag.js
+++ b/packages/hu-board/public/rag.js
@@ -1,0 +1,39 @@
+// KJC-TSK-0445 — Retrieval dashboard frontend. Fetches /api/rag/stats and
+// renders chunk counts per project/kind, embedder, DB size and last-index.
+const TOKEN = new URLSearchParams(location.search).get("token") || localStorage.getItem("kj_board_token") || "";
+const HEADERS = TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {};
+const ESC = (s) => String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+function bytes(n) { for (const u of ["B", "KB", "MB", "GB"]) { if (n < 1024) return `${u === "B" ? n : n.toFixed(1)} ${u}`; n /= 1024; } return `${n.toFixed(2)} TB`; }
+
+function bars(rows, lab, val, max) {
+  if (!rows.length) return '<p class="rag-empty">no data</p>';
+  return rows.map((r) => `<div class="rag-bar"><span class="rag-bar__label">${ESC(lab(r))}</span><span class="rag-bar__fill" style="width:${Math.round((val(r) / max) * 100)}%"></span><span class="rag-bar__value">${val(r).toLocaleString()}</span></div>`).join("");
+}
+
+function embedderCard(e) {
+  return e ? `<div class="rag-card"><h3>Embedder</h3><p class="rag-stat-big">${ESC(e.provider)}</p><p class="rag-stat-sub">${ESC(e.model || "default model")} · dim ${e.dim ?? "?"}</p></div>` : "";
+}
+
+function render(root, data) {
+  if (!data.initialized) { root.innerHTML = `<section class="rag-grid"><div class="rag-card"><h3>RAG DB</h3><p class="rag-empty">${ESC(data.message || "not initialized")}</p></div>${embedderCard(data.embedder)}</section>`; return; }
+  const lastIdx = data.last_indexed ? new Date(data.last_indexed).toLocaleString() : "never";
+  const mk = Math.max(1, ...data.by_kind.map((r) => r.n));
+  const mp = Math.max(1, ...data.by_project.map((r) => r.n));
+  root.innerHTML = `<section class="rag-grid">
+    <div class="rag-card"><h3>Totals</h3><p class="rag-stat-big">${data.total_chunks.toLocaleString()}</p><p class="rag-stat-sub">chunks · ${bytes(data.db_size_bytes)} · last indexed ${ESC(lastIdx)}</p></div>
+    ${embedderCard(data.embedder)}
+    <div class="rag-card rag-card--wide"><h3>By kind</h3>${bars(data.by_kind, (r) => r.kind, (r) => r.n, mk)}</div>
+    <div class="rag-card rag-card--wide"><h3>By project (top 20)</h3>${bars(data.by_project, (r) => r.project, (r) => r.n, mp)}</div>
+  </section>`;
+}
+
+async function load() {
+  const app = document.getElementById("rag-app");
+  app.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Loading…</p></div>';
+  try { const r = await fetch("/api/rag/stats", { headers: HEADERS }); if (!r.ok) throw new Error(`HTTP ${r.status}`); render(app, await r.json()); }
+  catch (e) { app.innerHTML = `<div class="rag-card rag-card--error"><strong>Error:</strong> ${ESC(e.message)}</div>`; }
+}
+
+document.getElementById("rag-refresh").addEventListener("click", load);
+load();

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -916,3 +916,17 @@ body.scoped-mode .nav-btn[data-view="dashboard"],
 body.scoped-mode .header__nav a[href="/pipeline.html"] {
   display: none;
 }
+
+/* KJC-TSK-0445 — RAG dashboard */
+.rag-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; padding: 1rem; }
+.rag-card { background: var(--bg-secondary, #1e1e2e); border-radius: 8px; padding: 1.25rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.rag-card--wide { grid-column: 1 / -1; }
+.rag-card--error { color: #f87171; background: #2a1414; }
+.rag-card h3 { margin: 0 0 .75rem; font-size: .9rem; text-transform: uppercase; letter-spacing: .05em; color: var(--text-secondary, #94a3b8); }
+.rag-stat-big { font-size: 2rem; font-weight: 700; margin: 0; color: var(--text-primary, #f8fafc); }
+.rag-stat-sub { margin: .25rem 0 0; font-size: .85rem; color: var(--text-secondary, #94a3b8); }
+.rag-empty { color: var(--text-secondary, #94a3b8); font-style: italic; }
+.rag-bar { display: grid; grid-template-columns: 140px 1fr 60px; align-items: center; gap: .5rem; margin: .35rem 0; font-size: .85rem; }
+.rag-bar__label { color: var(--text-secondary, #cbd5e1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rag-bar__fill { display: block; height: 14px; background: linear-gradient(90deg, #7c3aed, #a78bfa); border-radius: 3px; }
+.rag-bar__value { text-align: right; color: var(--text-primary, #f8fafc); font-variant-numeric: tabular-nums; }

--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -9,7 +9,7 @@ import { dbPath } from "../../../../src/rag/vec-store.js";
 import { readConfig } from "../config-yaml.js";
 
 const router = Router();
-const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024 };
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024, onnx: 384 };
 
 function embedder() {
   try {

--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -9,7 +9,7 @@ import { dbPath } from "../../../../src/rag/vec-store.js";
 import { readConfig } from "../config-yaml.js";
 
 const router = Router();
-const DIMS = { ollama: 768, openai: 1536, voyage: 1024 };
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024 };
 
 function embedder() {
   try {

--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -1,0 +1,36 @@
+// KJC-TSK-0445 — RAG retrieval-quality dashboard route.
+// GET /api/rag/stats → snapshot of the local rag.db (counts per kind/project,
+// active embedder, db size, last-index timestamp). Missing DB returns an
+// "uninitialized" payload so the dashboard renders an empty state cleanly.
+import { Router } from "express";
+import { existsSync, statSync } from "node:fs";
+import Database from "better-sqlite3";
+import { dbPath } from "../../../../src/rag/vec-store.js";
+import { readConfig } from "../config-yaml.js";
+
+const router = Router();
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024 };
+
+function embedder() {
+  try {
+    const e = (readConfig()?.rag?.embedder) || {};
+    const provider = e.provider || "ollama";
+    return { provider, model: e.model || null, dim: e.dim || DIMS[provider] || null };
+  } catch { return { provider: "ollama", model: null, dim: 768 }; }
+}
+
+router.get("/stats", (_req, res) => {
+  const path = dbPath();
+  if (!existsSync(path)) return res.json({ ok: true, initialized: false, message: "rag.db not initialized — run `kj rag index <dir>` to start indexing.", embedder: embedder() });
+  try {
+    const db = new Database(path, { readonly: true, fileMustExist: true });
+    const total_chunks = db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
+    const by_kind = db.prepare("SELECT kind, COUNT(*) AS n FROM chunks GROUP BY kind").all();
+    const by_project = db.prepare("SELECT COALESCE(project_slug, '(no slug)') AS project, COUNT(*) AS n FROM chunks GROUP BY project_slug ORDER BY n DESC LIMIT 20").all();
+    const last_indexed = db.prepare("SELECT MAX(created_at) AS ts FROM chunks").get().ts;
+    db.close();
+    res.json({ ok: true, initialized: true, db_path: path, db_size_bytes: statSync(path).size, total_chunks, by_kind, by_project, last_indexed, embedder: embedder() });
+  } catch (err) { res.status(500).json({ ok: false, error: String(err.message || err) }); }
+});
+
+export default router;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -9,6 +9,7 @@ import { initDb, closeDb } from './db.js';
 import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
 import pipelineRoutes from './routes/pipeline.js';
+import ragRoutes from './routes/rag.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
@@ -298,6 +299,7 @@ async function main() {
   app.use(express.static(PUBLIC_DIR, { setHeaders: noStoreHeaders, etag: false, lastModified: false }));
   app.use('/api', buildRateLimiter(), authMiddleware(), apiRoutes);
   app.use('/api/pipeline', authMiddleware(), pipelineRoutes);
+  app.use('/api/rag', authMiddleware(), ragRoutes);
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {

--- a/packages/hu-board/tests/rag-routes.test.js
+++ b/packages/hu-board/tests/rag-routes.test.js
@@ -1,0 +1,52 @@
+// KJC-TSK-0445 — Tests for /api/rag/stats. Verifies snapshot shape against
+// (a) an empty/uninitialized DB and (b) a DB seeded with chunks.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import express from "express";
+import request from "supertest";
+
+let tmpHome, app;
+
+beforeEach(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), "hu-board-rag-"));
+  process.env.KJ_HOME = tmpHome;
+  process.env.KARAJAN_HOME = tmpHome;
+  process.env.KJ_RAG_DB = join(tmpHome, "rag.db");
+  const { default: ragRoutes } = await import("../src/routes/rag.js");
+  app = express();
+  app.use("/api/rag", ragRoutes);
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+  delete process.env.KJ_HOME; delete process.env.KARAJAN_HOME; delete process.env.KJ_RAG_DB;
+});
+
+describe("GET /api/rag/stats", () => {
+  it("reports uninitialized when rag.db does not exist", async () => {
+    const res = await request(app).get("/api/rag/stats");
+    expect(res.status).toBe(200);
+    expect(res.body.initialized).toBe(false);
+    expect(res.body.embedder.provider).toBe("ollama");
+  });
+
+  it("returns chunk counts grouped by kind and project when populated", async () => {
+    const { openVecStore, insertChunk } = await import("../../../src/rag/vec-store.js");
+    const db = openVecStore({ dim: 4 });
+    insertChunk(db, { source: "a.js", kind: "code", text: "auth", embedding: [0.1, 0.2, 0.3, 0.4], project: "proj-a" });
+    insertChunk(db, { source: "b.md", kind: "plan", text: "spec", embedding: [0.5, 0.6, 0.7, 0.8], project: "proj-a" });
+    insertChunk(db, { source: "c.js", kind: "code", text: "router", embedding: [0.1, 0.1, 0.1, 0.1], project: "proj-b" });
+    insertChunk(db, { source: "x.js", kind: "code", text: "legacy", embedding: [0.1, 0.1, 0.1, 0.1] });
+    db.close();
+    const res = await request(app).get("/api/rag/stats");
+    expect(res.body.initialized).toBe(true);
+    expect(res.body.total_chunks).toBe(4);
+    const byKind = Object.fromEntries(res.body.by_kind.map((r) => [r.kind, r.n]));
+    expect(byKind).toEqual({ code: 3, plan: 1 });
+    const byProj = Object.fromEntries(res.body.by_project.map((r) => [r.project, r.n]));
+    expect(byProj).toEqual({ "proj-a": 2, "proj-b": 1, "(no slug)": 1 });
+    expect(res.body.db_size_bytes).toBeGreaterThan(0);
+  });
+});

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -173,9 +173,11 @@ const ragStubPlugin = {
           // KJC-TSK-0441 — RAG chokidar watcher.
           startWatcher: notAvailable, readPidFile: notAvailable, clearPidFile: notAvailable,
           isPidAlive: notAvailable, writePidFile: notAvailable,
-          // KJC-TSK-0442 — RAG embedders cloud + factory.
+          // KJC-TSK-0442 / KJC-TSK-0446 — RAG embedders cloud + factory.
           makeEmbedder: notAvailable, OpenAIEmbedder: notAvailable, VoyageEmbedder: notAvailable,
           OpenAIEmbedderError: notAvailable, VoyageEmbedderError: notAvailable, PROVIDERS: notAvailable,
+          CohereEmbedder: notAvailable, CohereEmbedderError: notAvailable,
+          MistralEmbedder: notAvailable, MistralEmbedderError: notAvailable,
           default: notAvailable,
         };
       `,

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -178,6 +178,7 @@ const ragStubPlugin = {
           OpenAIEmbedderError: notAvailable, VoyageEmbedderError: notAvailable, PROVIDERS: notAvailable,
           CohereEmbedder: notAvailable, CohereEmbedderError: notAvailable,
           MistralEmbedder: notAvailable, MistralEmbedderError: notAvailable,
+          ONNXEmbedder: notAvailable, ONNXEmbedderError: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/rag/embedders/cohere.js
+++ b/src/rag/embedders/cohere.js
@@ -1,0 +1,28 @@
+// KJC-TSK-0446 — Cohere embed-v3 adapter. Cohere returns
+// { embeddings: { float: [[...]] } } when `embedding_types: ["float"]`
+// is requested, or { embeddings: [[...]] } in legacy v1. We extract the
+// modern shape with a v1 fallback.
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.cohere.com/v2/embed", model: "embed-multilingual-v3.0", dim: 1024, timeoutMs: 30000 };
+
+export class CohereEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "CohereEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class CohereEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.KJ_COHERE_KEY, model = process.env.KJ_COHERE_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    // KJC architecture invariant: scoped env var (KJ_COHERE_KEY), not the
+    // generic COHERE_API_KEY — same rule as OpenAI/Voyage adapters.
+    if (!apiKey) throw new CohereEmbedderError("Cohere embedder requires an api_key (config.rag.embedder.api_key or KJ_COHERE_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) {
+    return cloudEmbed(this, text, CohereEmbedderError, {
+      provider: "Cohere",
+      body: { model: this.model, texts: [text], input_type: "search_document", embedding_types: ["float"] },
+      extract: (b) => b?.embeddings?.float?.[0] || b?.embeddings?.[0],
+    });
+  }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new CohereEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -1,12 +1,20 @@
-// KJC-TSK-0442 — Embedder factory. Selects provider from
-// config.rag.embedder.provider (ollama | openai | voyage; default ollama).
-// Each provider has its own dim default; the factory wires it so the
-// caller does not need to know.
+// KJC-TSK-0442 / KJC-TSK-0446 — Embedder factory. Selects provider from
+// config.rag.embedder.provider (ollama | openai | voyage | cohere | mistral;
+// default ollama). Each provider has its own dim default; the factory wires
+// it so the caller does not need to know.
 import { OllamaEmbedder } from "../embedder.js";
 import { OpenAIEmbedder } from "./openai.js";
 import { VoyageEmbedder } from "./voyage.js";
+import { CohereEmbedder } from "./cohere.js";
+import { MistralEmbedder } from "./mistral.js";
 
-const PROVIDERS = { ollama: { cls: OllamaEmbedder, dim: 768 }, openai: { cls: OpenAIEmbedder, dim: 1536 }, voyage: { cls: VoyageEmbedder, dim: 1024 } };
+const PROVIDERS = {
+  ollama: { cls: OllamaEmbedder, dim: 768 },
+  openai: { cls: OpenAIEmbedder, dim: 1536 },
+  voyage: { cls: VoyageEmbedder, dim: 1024 },
+  cohere: { cls: CohereEmbedder, dim: 1024 },
+  mistral: { cls: MistralEmbedder, dim: 1024 },
+};
 
 export function makeEmbedder(config = {}) {
   const cfg = config?.rag?.embedder || {};

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -7,6 +7,7 @@ import { OpenAIEmbedder } from "./openai.js";
 import { VoyageEmbedder } from "./voyage.js";
 import { CohereEmbedder } from "./cohere.js";
 import { MistralEmbedder } from "./mistral.js";
+import { ONNXEmbedder } from "./onnx.js";
 
 const PROVIDERS = {
   ollama: { cls: OllamaEmbedder, dim: 768 },
@@ -14,6 +15,7 @@ const PROVIDERS = {
   voyage: { cls: VoyageEmbedder, dim: 1024 },
   cohere: { cls: CohereEmbedder, dim: 1024 },
   mistral: { cls: MistralEmbedder, dim: 1024 },
+  onnx: { cls: ONNXEmbedder, dim: 384 },
 };
 
 export function makeEmbedder(config = {}) {

--- a/src/rag/embedders/mistral.js
+++ b/src/rag/embedders/mistral.js
@@ -1,0 +1,26 @@
+// KJC-TSK-0446 — Mistral AI embeddings adapter. EU-hosted, useful for
+// users with GDPR constraints that prefer not to send chunks to US
+// endpoints. Single model today (`mistral-embed`, 1024 dim).
+import { cloudEmbed } from "./_cloud-base.js";
+
+const DEFAULTS = { url: "https://api.mistral.ai/v1/embeddings", model: "mistral-embed", dim: 1024, timeoutMs: 30000 };
+
+export class MistralEmbedderError extends Error {
+  constructor(message, { cause, status } = {}) { super(message); this.name = "MistralEmbedderError"; if (cause) this.cause = cause; if (status != null) this.status = status; }
+}
+
+export class MistralEmbedder {
+  constructor({ url = DEFAULTS.url, apiKey = process.env.KJ_MISTRAL_KEY, model = process.env.KJ_MISTRAL_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, timeoutMs = DEFAULTS.timeoutMs, fetchFn = globalThis.fetch } = {}) {
+    // KJC architecture invariant: scoped env var (KJ_MISTRAL_KEY).
+    if (!apiKey) throw new MistralEmbedderError("Mistral embedder requires an api_key (config.rag.embedder.api_key or KJ_MISTRAL_KEY env)");
+    Object.assign(this, { url, apiKey, model, dim, timeoutMs, fetch: fetchFn });
+  }
+  async embed(text) {
+    return cloudEmbed(this, text, MistralEmbedderError, {
+      provider: "Mistral",
+      body: { model: this.model, input: [text] },
+      extract: (b) => b?.data?.[0]?.embedding,
+    });
+  }
+  async embedBatch(texts) { if (!Array.isArray(texts)) throw new MistralEmbedderError("embedBatch: texts must be an array"); const out = []; for (const t of texts) out.push(await this.embed(t)); return out; }
+}

--- a/src/rag/embedders/onnx.js
+++ b/src/rag/embedders/onnx.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0447 — ONNX local embedder via @huggingface/transformers
+// (formerly @xenova/transformers). Runs sentence-transformer models
+// directly in Node — no API key, no Docker, no Ollama.
+//
+// First call downloads the model weights to ~/.cache/huggingface/ (~80 MB
+// for the default MiniLM). Subsequent calls reuse the cache, so the steady
+// state is fully offline.
+//
+// Default model: `Xenova/all-MiniLM-L6-v2` (384 dim, ~80 MB, fast).
+// Higher-quality alternative: `Xenova/jina-embeddings-v2-base-en`
+// (768 dim, ~260 MB, slower but better for retrieval).
+
+const DEFAULTS = { model: "Xenova/all-MiniLM-L6-v2", dim: 384, pooling: "mean", normalize: true };
+
+export class ONNXEmbedderError extends Error {
+  constructor(message, { cause } = {}) { super(message); this.name = "ONNXEmbedderError"; if (cause) this.cause = cause; }
+}
+
+async function loadTransformers() {
+  // Prefer the modern @huggingface/transformers (post-2024 rebrand);
+  // fall back to @xenova/transformers for users still on the legacy package.
+  // Both are optional peer deps — Karajan does not ship them by default to
+  // keep the install size small (~500 MB with WASM + weights). The user
+  // installs whichever they prefer when they opt into provider: onnx.
+  /* eslint-disable import-x/no-unresolved */
+  try { return await import("@huggingface/transformers"); }
+  catch (e1) {
+    try { return await import("@xenova/transformers"); }
+    catch (e2) {
+      throw new ONNXEmbedderError(
+        "ONNX embedder requires @huggingface/transformers (or legacy @xenova/transformers). Install with `npm install @huggingface/transformers`.",
+        { cause: e2 },
+      );
+    }
+  }
+  /* eslint-enable import-x/no-unresolved */
+}
+
+export class ONNXEmbedder {
+  constructor({ model = process.env.KJ_ONNX_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, pooling = DEFAULTS.pooling, normalize = DEFAULTS.normalize } = {}) {
+    Object.assign(this, { model, dim, pooling, normalize, _pipe: null });
+  }
+  async _ensurePipeline() {
+    if (this._pipe) return this._pipe;
+    const transformers = await loadTransformers();
+    this._pipe = await transformers.pipeline("feature-extraction", this.model);
+    return this._pipe;
+  }
+  async embed(text) {
+    if (typeof text !== "string" || text.length === 0) throw new ONNXEmbedderError("embed: text must be a non-empty string");
+    const pipe = await this._ensurePipeline();
+    const out = await pipe(text, { pooling: this.pooling, normalize: this.normalize });
+    const arr = Array.from(out.data || []);
+    if (arr.length !== this.dim) throw new ONNXEmbedderError(`ONNX dim mismatch: got ${arr.length}, expected ${this.dim} for model ${this.model}`);
+    return Float32Array.from(arr);
+  }
+  async embedBatch(texts) {
+    if (!Array.isArray(texts)) throw new ONNXEmbedderError("embedBatch: texts must be an array");
+    const out = [];
+    for (const t of texts) out.push(await this.embed(t));
+    return out;
+  }
+}

--- a/tests/rag/embedders-factory.test.js
+++ b/tests/rag/embedders-factory.test.js
@@ -3,6 +3,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { makeEmbedder } from "../../src/rag/embedders/factory.js";
 import { OpenAIEmbedder, OpenAIEmbedderError } from "../../src/rag/embedders/openai.js";
 import { VoyageEmbedder, VoyageEmbedderError } from "../../src/rag/embedders/voyage.js";
+import { CohereEmbedder, CohereEmbedderError } from "../../src/rag/embedders/cohere.js";
+import { MistralEmbedder, MistralEmbedderError } from "../../src/rag/embedders/mistral.js";
 import { OllamaEmbedder } from "../../src/rag/embedder.js";
 
 describe("rag/embedders factory (KJC-TSK-0442)", () => {
@@ -21,6 +23,18 @@ describe("rag/embedders factory (KJC-TSK-0442)", () => {
   it("selects Voyage provider when configured", () => {
     const e = makeEmbedder({ rag: { embedder: { provider: "voyage", api_key: "pa-test" } } });
     expect(e).toBeInstanceOf(VoyageEmbedder);
+    expect(e.dim).toBe(1024);
+  });
+
+  it("selects Cohere provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "cohere", api_key: "co-test" } } });
+    expect(e).toBeInstanceOf(CohereEmbedder);
+    expect(e.dim).toBe(1024);
+  });
+
+  it("selects Mistral provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "mistral", api_key: "ms-test" } } });
+    expect(e).toBeInstanceOf(MistralEmbedder);
     expect(e.dim).toBe(1024);
   });
 
@@ -83,5 +97,49 @@ describe("VoyageEmbedder (KJC-TSK-0442)", () => {
     const body = JSON.parse(fetchFn.mock.calls[0][1].body);
     expect(body.input_type).toBe("document");
     expect(body.input).toEqual(["auth flow"]);
+  });
+});
+
+describe("CohereEmbedder (KJC-TSK-0446)", () => {
+  it("rejects without api key", () => {
+    const prev = process.env.KJ_COHERE_KEY;
+    delete process.env.KJ_COHERE_KEY;
+    try { expect(() => new CohereEmbedder({})).toThrow(CohereEmbedderError); }
+    finally { if (prev !== undefined) process.env.KJ_COHERE_KEY = prev; }
+  });
+
+  it("POSTs with embedding_types=float + extracts embeddings.float[0]", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ embeddings: { float: [new Array(1024).fill(0.3)] } }) });
+    const e = new CohereEmbedder({ apiKey: "co-test", fetchFn });
+    const v = await e.embed("login flow");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(v.length).toBe(1024);
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.embedding_types).toEqual(["float"]);
+    expect(body.input_type).toBe("search_document");
+  });
+
+  it("falls back to legacy embeddings[0] shape", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ embeddings: [new Array(1024).fill(0.4)] }) });
+    const e = new CohereEmbedder({ apiKey: "k", fetchFn });
+    const v = await e.embed("x");
+    expect(v.length).toBe(1024);
+  });
+});
+
+describe("MistralEmbedder (KJC-TSK-0446)", () => {
+  it("rejects without api key", () => {
+    const prev = process.env.KJ_MISTRAL_KEY;
+    delete process.env.KJ_MISTRAL_KEY;
+    try { expect(() => new MistralEmbedder({})).toThrow(MistralEmbedderError); }
+    finally { if (prev !== undefined) process.env.KJ_MISTRAL_KEY = prev; }
+  });
+
+  it("POSTs to api.mistral.ai + returns Float32Array", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [{ embedding: new Array(1024).fill(0.5) }] }) });
+    const e = new MistralEmbedder({ apiKey: "ms-test", fetchFn });
+    const v = await e.embed("router config");
+    expect(v.length).toBe(1024);
+    expect(fetchFn.mock.calls[0][0]).toBe("https://api.mistral.ai/v1/embeddings");
   });
 });

--- a/tests/rag/embedders-onnx.test.js
+++ b/tests/rag/embedders-onnx.test.js
@@ -1,0 +1,56 @@
+// KJC-TSK-0447 — ONNX local embedder tests. We don't actually download
+// model weights in CI (slow + flaky), so the tests cover the synchronous
+// surface: factory selection, dim defaults, helpful error when the
+// peer dep is not installed, and the embed() guard rails (input
+// validation, dim mismatch detection).
+import { describe, expect, it, vi } from "vitest";
+import { makeEmbedder } from "../../src/rag/embedders/factory.js";
+import { ONNXEmbedder, ONNXEmbedderError } from "../../src/rag/embedders/onnx.js";
+
+describe("rag/embedders/onnx — factory wiring", () => {
+  it("selects ONNX provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "onnx" } } });
+    expect(e).toBeInstanceOf(ONNXEmbedder);
+    expect(e.dim).toBe(384);
+    expect(e.model).toMatch(/MiniLM/);
+  });
+
+  it("honors explicit model + dim override", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "onnx", model: "Xenova/jina-embeddings-v2-base-en", dim: 768 } } });
+    expect(e.model).toMatch(/jina/);
+    expect(e.dim).toBe(768);
+  });
+});
+
+describe("ONNXEmbedder", () => {
+  it("rejects empty input before touching the pipeline", async () => {
+    const e = new ONNXEmbedder();
+    await expect(e.embed("")).rejects.toThrow(ONNXEmbedderError);
+    await expect(e.embed(null)).rejects.toThrow(ONNXEmbedderError);
+  });
+
+  it("rejects non-array input to embedBatch", async () => {
+    const e = new ONNXEmbedder();
+    await expect(e.embedBatch("not-an-array")).rejects.toThrow(/must be an array/);
+  });
+
+  it("returns Float32Array from the pipeline output", async () => {
+    const e = new ONNXEmbedder({ dim: 4 });
+    // Stub the pipeline to bypass model download.
+    e._pipe = vi.fn().mockResolvedValue({ data: new Float32Array([0.1, 0.2, 0.3, 0.4]) });
+    const v = await e.embed("hello");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(Array.from(v)).toEqual([
+      expect.closeTo(0.1, 6),
+      expect.closeTo(0.2, 6),
+      expect.closeTo(0.3, 6),
+      expect.closeTo(0.4, 6),
+    ]);
+  });
+
+  it("throws on dim mismatch from the pipeline", async () => {
+    const e = new ONNXEmbedder({ dim: 4 });
+    e._pipe = vi.fn().mockResolvedValue({ data: new Float32Array([0.1, 0.2]) });
+    await expect(e.embed("x")).rejects.toThrow(/dim mismatch/);
+  });
+});


### PR DESCRIPTION
## What

Sixth embedder provider — and the first **fully local** one outside Ollama.
Runs sentence-transformer models directly inside Node.js, no API key, no
Docker, no external service after the first model download.

| Default model | `Xenova/all-MiniLM-L6-v2` |
| Dim | 384 |
| Disk after first run | ~80 MB cached in `~/.cache/huggingface/` |
| Higher-quality option | `Xenova/jina-embeddings-v2-base-en` (768 dim, ~260 MB) |

## Why this matters

This is the missing piece for **v2.31 zero-config init**:

- **No API key** → no setup friction
- **No Docker** → works on minimal CI / sandboxed env
- **No Ollama** → no `docker pull`, no port discovery, no health check
- **Cached after first call** → subsequent runs are fully offline

Users still get strong cloud options (OpenAI / Voyage / Cohere / Mistral) when they want them; ONNX becomes the new sensible default the wizard can suggest with confidence.

## Implementation

- New `src/rag/embedders/onnx.js` (~60 LOC) wraps the transformers pipeline
- Library loaded dynamically: prefers modern `@huggingface/transformers` (post-2024 rebrand), falls back to legacy `@xenova/transformers`, throws an actionable install hint if neither is installed
- **Not added to package.json** — both packages are optional peer deps (combined ~500 MB with WASM + ONNX runtime). Users install when they opt into `provider: onnx`.
- Factory wired (`PROVIDERS.onnx` = MiniLM 384 dim)
- Dashboard route's DIMS map updated to know the new provider
- SEA stub exports added

## Tests

`tests/rag/embedders-onnx.test.js` (6 cases) covers everything reachable without downloading the model:
- factory selects ONNX and honours explicit `model`/`dim` override
- `embed('')`, `embed(null)`, `embedBatch('x')` all reject before touching the pipeline
- pipeline stub returns Float32Array of the expected dim
- dim mismatch from the pipeline throws `/dim mismatch/`

24/24 across factory + ONNX tests, no model download in CI.

## LOC

123 net (well under 200).

## Roadmap link

PR3/5 of v2.29.0. PR4 adds metadata filtering (`--where`); PR5 adds rerank cross-encoder (the second @huggingface/transformers use case).