### PR TITLE
feat(rag): ONNX local embedder via @huggingface/transformers (KJC-TSK-0447)

### DIFF
--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -9,7 +9,7 @@ import { dbPath } from "../../../../src/rag/vec-store.js";
 import { readConfig } from "../config-yaml.js";
 
 const router = Router();
-const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024 };
+const DIMS = { ollama: 768, openai: 1536, voyage: 1024, cohere: 1024, mistral: 1024, onnx: 384 };
 
 function embedder() {
   try {

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -178,6 +178,7 @@ const ragStubPlugin = {
           OpenAIEmbedderError: notAvailable, VoyageEmbedderError: notAvailable, PROVIDERS: notAvailable,
           CohereEmbedder: notAvailable, CohereEmbedderError: notAvailable,
           MistralEmbedder: notAvailable, MistralEmbedderError: notAvailable,
+          ONNXEmbedder: notAvailable, ONNXEmbedderError: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -7,6 +7,7 @@ import { OpenAIEmbedder } from "./openai.js";
 import { VoyageEmbedder } from "./voyage.js";
 import { CohereEmbedder } from "./cohere.js";
 import { MistralEmbedder } from "./mistral.js";
+import { ONNXEmbedder } from "./onnx.js";
 
 const PROVIDERS = {
   ollama: { cls: OllamaEmbedder, dim: 768 },
@@ -14,6 +15,7 @@ const PROVIDERS = {
   voyage: { cls: VoyageEmbedder, dim: 1024 },
   cohere: { cls: CohereEmbedder, dim: 1024 },
   mistral: { cls: MistralEmbedder, dim: 1024 },
+  onnx: { cls: ONNXEmbedder, dim: 384 },
 };
 
 export function makeEmbedder(config = {}) {

--- a/src/rag/embedders/onnx.js
+++ b/src/rag/embedders/onnx.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0447 — ONNX local embedder via @huggingface/transformers
+// (formerly @xenova/transformers). Runs sentence-transformer models
+// directly in Node — no API key, no Docker, no Ollama.
+//
+// First call downloads the model weights to ~/.cache/huggingface/ (~80 MB
+// for the default MiniLM). Subsequent calls reuse the cache, so the steady
+// state is fully offline.
+//
+// Default model: `Xenova/all-MiniLM-L6-v2` (384 dim, ~80 MB, fast).
+// Higher-quality alternative: `Xenova/jina-embeddings-v2-base-en`
+// (768 dim, ~260 MB, slower but better for retrieval).
+
+const DEFAULTS = { model: "Xenova/all-MiniLM-L6-v2", dim: 384, pooling: "mean", normalize: true };
+
+export class ONNXEmbedderError extends Error {
+  constructor(message, { cause } = {}) { super(message); this.name = "ONNXEmbedderError"; if (cause) this.cause = cause; }
+}
+
+async function loadTransformers() {
+  // Prefer the modern @huggingface/transformers (post-2024 rebrand);
+  // fall back to @xenova/transformers for users still on the legacy package.
+  // Both are optional peer deps — Karajan does not ship them by default to
+  // keep the install size small (~500 MB with WASM + weights). The user
+  // installs whichever they prefer when they opt into provider: onnx.
+  /* eslint-disable import-x/no-unresolved */
+  try { return await import("@huggingface/transformers"); }
+  catch (e1) {
+    try { return await import("@xenova/transformers"); }
+    catch (e2) {
+      throw new ONNXEmbedderError(
+        "ONNX embedder requires @huggingface/transformers (or legacy @xenova/transformers). Install with `npm install @huggingface/transformers`.",
+        { cause: e2 },
+      );
+    }
+  }
+  /* eslint-enable import-x/no-unresolved */
+}
+
+export class ONNXEmbedder {
+  constructor({ model = process.env.KJ_ONNX_EMBED_MODEL || DEFAULTS.model, dim = DEFAULTS.dim, pooling = DEFAULTS.pooling, normalize = DEFAULTS.normalize } = {}) {
+    Object.assign(this, { model, dim, pooling, normalize, _pipe: null });
+  }
+  async _ensurePipeline() {
+    if (this._pipe) return this._pipe;
+    const transformers = await loadTransformers();
+    this._pipe = await transformers.pipeline("feature-extraction", this.model);
+    return this._pipe;
+  }
+  async embed(text) {
+    if (typeof text !== "string" || text.length === 0) throw new ONNXEmbedderError("embed: text must be a non-empty string");
+    const pipe = await this._ensurePipeline();
+    const out = await pipe(text, { pooling: this.pooling, normalize: this.normalize });
+    const arr = Array.from(out.data || []);
+    if (arr.length !== this.dim) throw new ONNXEmbedderError(`ONNX dim mismatch: got ${arr.length}, expected ${this.dim} for model ${this.model}`);
+    return Float32Array.from(arr);
+  }
+  async embedBatch(texts) {
+    if (!Array.isArray(texts)) throw new ONNXEmbedderError("embedBatch: texts must be an array");
+    const out = [];
+    for (const t of texts) out.push(await this.embed(t));
+    return out;
+  }
+}

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -75,7 +75,16 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // only needed when the lighthouse check actually runs (i.e. when the
 // user has the binary or wants the install hint) — deferring it keeps
 // non-frontend doctor runs from paying the cost.
-const DYNAMIC_IMPORT_BUDGET = 162;
+//
+// 2026-05-25 (KJC-TSK-0447 v2.29 ONNX embedder): bumped 162 → 164 for two
+// dynamic imports inside `src/rag/embedders/onnx.js`: it tries
+// `@huggingface/transformers` first, then falls back to legacy
+// `@xenova/transformers`, and gracefully errors if neither is installed.
+// Both packages are optional peer deps (combined ~500 MB with WASM + ONNX
+// runtime) so a static import would force every install to pay that cost
+// even for users who never opt into provider: onnx. Static imports are
+// not an option here by design.
+const DYNAMIC_IMPORT_BUDGET = 164;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/rag/embedders-onnx.test.js
+++ b/tests/rag/embedders-onnx.test.js
@@ -1,0 +1,56 @@
+// KJC-TSK-0447 — ONNX local embedder tests. We don't actually download
+// model weights in CI (slow + flaky), so the tests cover the synchronous
+// surface: factory selection, dim defaults, helpful error when the
+// peer dep is not installed, and the embed() guard rails (input
+// validation, dim mismatch detection).
+import { describe, expect, it, vi } from "vitest";
+import { makeEmbedder } from "../../src/rag/embedders/factory.js";
+import { ONNXEmbedder, ONNXEmbedderError } from "../../src/rag/embedders/onnx.js";
+
+describe("rag/embedders/onnx — factory wiring", () => {
+  it("selects ONNX provider when configured", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "onnx" } } });
+    expect(e).toBeInstanceOf(ONNXEmbedder);
+    expect(e.dim).toBe(384);
+    expect(e.model).toMatch(/MiniLM/);
+  });
+
+  it("honors explicit model + dim override", () => {
+    const e = makeEmbedder({ rag: { embedder: { provider: "onnx", model: "Xenova/jina-embeddings-v2-base-en", dim: 768 } } });
+    expect(e.model).toMatch(/jina/);
+    expect(e.dim).toBe(768);
+  });
+});
+
+describe("ONNXEmbedder", () => {
+  it("rejects empty input before touching the pipeline", async () => {
+    const e = new ONNXEmbedder();
+    await expect(e.embed("")).rejects.toThrow(ONNXEmbedderError);
+    await expect(e.embed(null)).rejects.toThrow(ONNXEmbedderError);
+  });
+
+  it("rejects non-array input to embedBatch", async () => {
+    const e = new ONNXEmbedder();
+    await expect(e.embedBatch("not-an-array")).rejects.toThrow(/must be an array/);
+  });
+
+  it("returns Float32Array from the pipeline output", async () => {
+    const e = new ONNXEmbedder({ dim: 4 });
+    // Stub the pipeline to bypass model download.
+    e._pipe = vi.fn().mockResolvedValue({ data: new Float32Array([0.1, 0.2, 0.3, 0.4]) });
+    const v = await e.embed("hello");
+    expect(v).toBeInstanceOf(Float32Array);
+    expect(Array.from(v)).toEqual([
+      expect.closeTo(0.1, 6),
+      expect.closeTo(0.2, 6),
+      expect.closeTo(0.3, 6),
+      expect.closeTo(0.4, 6),
+    ]);
+  });
+
+  it("throws on dim mismatch from the pipeline", async () => {
+    const e = new ONNXEmbedder({ dim: 4 });
+    e._pipe = vi.fn().mockResolvedValue({ data: new Float32Array([0.1, 0.2]) });
+    await expect(e.embed("x")).rejects.toThrow(/dim mismatch/);
+  });
+});


### PR DESCRIPTION
PR3/5 of v2.29.0. Re-target of #845 (auto-closed when PR2's base was deleted on merge).

ONNX local embedder via @huggingface/transformers — sixth provider, fully local (no Docker, no API key, no Ollama). Default Xenova/all-MiniLM-L6-v2 (384 dim, ~80 MB cached). Library is an optional peer dep with a helpful install hint on missing.

24/24 factory + adapter tests. 123 LOC.

Original PR body: https://github.com/manufosela/karajan-code/pull/845