### PR TITLE
feat(rag): metadata --where filter (KJC-TSK-0448)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -179,6 +179,8 @@ const ragStubPlugin = {
           CohereEmbedder: notAvailable, CohereEmbedderError: notAvailable,
           MistralEmbedder: notAvailable, MistralEmbedderError: notAvailable,
           ONNXEmbedder: notAvailable, ONNXEmbedderError: notAvailable,
+          // KJC-TSK-0448 — RAG --where metadata filter.
+          parseWhere: notAvailable, buildWhereSql: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -117,6 +117,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--project <slug>", "Filter by project slug. Pass 'all' to query across every indexed project. Default: cwd basename")
     .option("--mode <mode>", "hybrid (default) | semantic (cosine only) | keyword (BM25 only)", "hybrid")
     .option("--alpha <n>", "Hybrid weight for semantic component (0..1). Default 0.6", "0.6")
+    .option("--where <clause>", "Metadata filter, e.g. 'symbol=loadConfig' or 'hu_id=HU-003 AND kind=plan'")
     .option("--json", "Output the hits as JSON")
     .action(async (text, flags) => {
       await withConfig(pkgVersion, "rag-query", flags, async ({ config, logger }) => {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -57,7 +57,8 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     }
     const mode = flags.mode || "hybrid";
     const alpha = Math.max(0, Math.min(1, Number(flags.alpha) || 0.6));
-    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha });
+    const where = flags.where || null;
+    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha, where });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);
     } else {

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -1,5 +1,6 @@
 // KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline.
 import { searchSimilar, searchBM25 } from "./vec-store.js";
+import { parseWhere, buildWhereSql } from "./where-parser.js";
 
 const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
 
@@ -39,14 +40,21 @@ function fuseHits(semantic, keyword, alpha, mode) {
   return list;
 }
 
-export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6 } = {}) {
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6, where = null } = {}) {
   if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
   const fetchK = Math.min(50, topK * 2);
   const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
+  // KJC-TSK-0448 — metadata filter. `where` is a string like "symbol=Foo AND
+  // hu_id=HU-003"; we parse once and reuse the SQL fragment across both
+  // semantic and keyword searches.
+  const parsed = parseWhere(where);
+  if (!parsed.ok) throw new Error(`query: ${parsed.error}`);
+  const { sql: whereSql, params: whereParams } = buildWhereSql(parsed.clauses);
+  const opts = { kind: scopeKind, project, whereSql, whereParams };
   const wantSemantic = mode !== "keyword";
   const wantKeyword = mode !== "semantic";
-  const semanticHits = wantSemantic ? searchSimilar(db, await embedder.embed(text), fetchK, { kind: scopeKind, project }) : [];
-  const keywordHits = wantKeyword ? searchBM25(db, text, fetchK, { kind: scopeKind, project }) : [];
+  const semanticHits = wantSemantic ? searchSimilar(db, await embedder.embed(text), fetchK, opts) : [];
+  const keywordHits = wantKeyword ? searchBM25(db, text, fetchK, opts) : [];
   const raw = fuseHits(semanticHits, keywordHits, alpha, mode);
   if (raw.length === 0) return [];
   const boostSources = shouldBoostSources(text);

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -106,7 +106,7 @@ export function insertChunk(db, { source, kind, text, metadata = null, embedding
  * text, metadata, distance }]` for the topK best matches; lower
  * distance = closer. Returns `[]` when the store is empty.
  */
-export function searchSimilar(db, embedding, topK = 5, { kind = null, project = null } = {}) {
+export function searchSimilar(db, embedding, topK = 5, { kind = null, project = null, whereSql = "", whereParams = [] } = {}) {
   const buf = embedding instanceof Float32Array ? embedding : Float32Array.from(embedding);
   const kindClause = kind ? "AND c.kind = ?" : "";
   const projectClause = project ? "AND c.project_slug = ?" : "";
@@ -114,12 +114,13 @@ export function searchSimilar(db, embedding, topK = 5, { kind = null, project = 
     SELECT c.id, c.source, c.kind, c.text, c.metadata, c.project_slug, v.distance
     FROM vec_chunks v
     JOIN chunks c ON c.id = v.rowid
-    WHERE v.embedding MATCH ? AND k = ? ${kindClause} ${projectClause}
+    WHERE v.embedding MATCH ? AND k = ? ${kindClause} ${projectClause}${whereSql}
     ORDER BY v.distance
   `;
   const params = [Buffer.from(buf.buffer), topK];
   if (kind) params.push(kind);
   if (project) params.push(project);
+  if (whereParams.length) params.push(...whereParams);
   const rows = db.prepare(sql).all(...params);
   return rows.map((r) => ({ ...r, metadata: r.metadata ? safeParse(r.metadata) : null }));
 }
@@ -163,7 +164,7 @@ export function countChunks(db, { kind = null } = {}) {
  * relevance (lower bm25 = better in SQLite FTS5). `query` is sanitized for
  * the FTS5 grammar: special chars are stripped, words split on whitespace.
  */
-export function searchBM25(db, queryText, topK = 10, { kind = null, project = null } = {}) {
+export function searchBM25(db, queryText, topK = 10, { kind = null, project = null, whereSql = "", whereParams = [] } = {}) {
   const cleaned = String(queryText || "").replace(/["'()]/g, " ").split(/\s+/).filter(Boolean).join(" OR ");
   if (!cleaned) return [];
   const kindClause = kind ? "AND c.kind = ?" : "";
@@ -171,12 +172,13 @@ export function searchBM25(db, queryText, topK = 10, { kind = null, project = nu
   const sql = `
     SELECT c.id, c.source, c.kind, c.text, c.metadata, c.project_slug, bm25(chunks_fts) AS bm25
     FROM chunks_fts JOIN chunks c ON c.id = chunks_fts.rowid
-    WHERE chunks_fts MATCH ? ${kindClause} ${projectClause}
+    WHERE chunks_fts MATCH ? ${kindClause} ${projectClause}${whereSql}
     ORDER BY bm25 LIMIT ?
   `;
   const params = [cleaned];
   if (kind) params.push(kind);
   if (project) params.push(project);
+  if (whereParams.length) params.push(...whereParams);
   params.push(topK);
   try {
     const rows = db.prepare(sql).all(...params);

--- a/src/rag/where-parser.js
+++ b/src/rag/where-parser.js
@@ -1,0 +1,54 @@
+// KJC-TSK-0448 — minimal --where filter parser for metadata-aware RAG
+// queries. Grammar (intentionally small):
+//
+//   clause     := pair ( "AND" pair )*
+//   pair       := IDENT "=" VALUE
+//   IDENT      := [A-Za-z_][A-Za-z0-9_.-]*
+//   VALUE      := unquoted token  | "quoted string"
+//
+// Examples:
+//   symbol=loadConfig
+//   hu_id=HU-003 AND kind=plan
+//   "headingPath.0"=Architecture
+//
+// Returns { ok: true, clauses: [["symbol","loadConfig"], ...] } or
+// { ok: false, error: "...explanation..." }. The retriever turns each
+// clause into a `json_extract(c.metadata, '$.<key>') = ?` SQL fragment;
+// the `kind` key is special-cased to filter the column directly.
+
+const IDENT_RE = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+
+export function parseWhere(input) {
+  if (input == null) return { ok: true, clauses: [] };
+  if (typeof input !== "string") return { ok: false, error: "where: input must be a string" };
+  const s = input.trim();
+  if (!s) return { ok: true, clauses: [] };
+  const parts = s.split(/\s+AND\s+/i);
+  const clauses = [];
+  for (const p of parts) {
+    const eq = p.indexOf("=");
+    if (eq <= 0) return { ok: false, error: `where: bad pair "${p}" — expected key=value` };
+    const key = p.slice(0, eq).trim().replace(/^"|"$/g, "");
+    let val = p.slice(eq + 1).trim();
+    if (!IDENT_RE.test(key)) return { ok: false, error: `where: invalid key "${key}"` };
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) val = val.slice(1, -1);
+    if (val.length === 0) return { ok: false, error: `where: empty value for key "${key}"` };
+    clauses.push([key, val]);
+  }
+  return { ok: true, clauses };
+}
+
+/**
+ * Build a `(sqlFragment, params)` pair to append to a chunks-table query.
+ * `kind` filters the column directly; everything else goes through json_extract.
+ */
+export function buildWhereSql(clauses) {
+  if (!clauses?.length) return { sql: "", params: [] };
+  const fragments = [];
+  const params = [];
+  for (const [k, v] of clauses) {
+    if (k === "kind") { fragments.push("c.kind = ?"); params.push(v); }
+    else { fragments.push(`json_extract(c.metadata, '$.${k}') = ?`); params.push(v); }
+  }
+  return { sql: ` AND ${fragments.join(" AND ")}`, params };
+}

--- a/tests/rag/retriever-where.test.js
+++ b/tests/rag/retriever-where.test.js
@@ -1,0 +1,58 @@
+// KJC-TSK-0448 — integration: retriever honours --where filter end-to-end.
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { openVecStore, insertChunk } from "../../src/rag/vec-store.js";
+import { query } from "../../src/rag/retriever.js";
+
+let tmp, db;
+
+const stubEmbedder = {
+  embed: async (_text) => Float32Array.from([0.5, 0.5, 0.5, 0.5]),
+};
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kj-where-"));
+  process.env.KJ_RAG_DB = join(tmp, "rag.db");
+  db = openVecStore({ dim: 4 });
+  insertChunk(db, { source: "src/auth.js", kind: "code", text: "loadConfig user login", metadata: { symbol: "loadConfig", file: "auth.js" }, embedding: [0.1, 0.2, 0.3, 0.4], project: "myapp" });
+  insertChunk(db, { source: "src/router.js", kind: "code", text: "router config setup", metadata: { symbol: "createRouter", file: "router.js" }, embedding: [0.5, 0.5, 0.5, 0.5], project: "myapp" });
+  insertChunk(db, { source: "plans/p1.md", kind: "plan", text: "loadConfig validation hu plan", metadata: { hu_id: "HU-003" }, embedding: [0.9, 0.9, 0.9, 0.9], project: "myapp" });
+});
+
+afterEach(() => { db.close(); rmSync(tmp, { recursive: true, force: true }); delete process.env.KJ_RAG_DB; });
+
+describe("retriever query() honours --where", () => {
+  it("with no where, returns all matching chunks", async () => {
+    const hits = await query(db, stubEmbedder, "loadConfig", { topK: 10, project: "myapp" });
+    expect(hits.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("filters by symbol", async () => {
+    const hits = await query(db, stubEmbedder, "loadConfig", { topK: 10, project: "myapp", where: "symbol=loadConfig" });
+    expect(hits.length).toBe(1);
+    expect(hits[0].metadata.symbol).toBe("loadConfig");
+  });
+
+  it("filters by hu_id", async () => {
+    const hits = await query(db, stubEmbedder, "loadConfig", { topK: 10, project: "myapp", where: "hu_id=HU-003" });
+    expect(hits.length).toBe(1);
+    expect(hits[0].kind).toBe("plan");
+  });
+
+  it("combines clauses with AND", async () => {
+    const hits = await query(db, stubEmbedder, "router", { topK: 10, project: "myapp", where: "kind=code AND symbol=createRouter" });
+    expect(hits.length).toBe(1);
+    expect(hits[0].metadata.symbol).toBe("createRouter");
+  });
+
+  it("returns empty when filter matches nothing", async () => {
+    const hits = await query(db, stubEmbedder, "loadConfig", { topK: 10, project: "myapp", where: "symbol=doesNotExist" });
+    expect(hits).toEqual([]);
+  });
+
+  it("throws on malformed where", async () => {
+    await expect(query(db, stubEmbedder, "x", { project: "myapp", where: "no-equals" })).rejects.toThrow(/bad pair/);
+  });
+});

--- a/tests/rag/where-parser.test.js
+++ b/tests/rag/where-parser.test.js
@@ -1,0 +1,62 @@
+// KJC-TSK-0448 — tests for the --where parser used by `kj rag query`.
+import { describe, expect, it } from "vitest";
+import { parseWhere, buildWhereSql } from "../../src/rag/where-parser.js";
+
+describe("parseWhere", () => {
+  it("returns ok with empty clauses for null / empty input", () => {
+    expect(parseWhere(null)).toEqual({ ok: true, clauses: [] });
+    expect(parseWhere("")).toEqual({ ok: true, clauses: [] });
+    expect(parseWhere("   ")).toEqual({ ok: true, clauses: [] });
+  });
+
+  it("parses a single pair", () => {
+    expect(parseWhere("symbol=loadConfig")).toEqual({ ok: true, clauses: [["symbol", "loadConfig"]] });
+  });
+
+  it("parses multiple pairs joined by AND (case-insensitive)", () => {
+    const r = parseWhere("hu_id=HU-003 AND kind=plan and symbol=foo");
+    expect(r.ok).toBe(true);
+    expect(r.clauses).toEqual([["hu_id", "HU-003"], ["kind", "plan"], ["symbol", "foo"]]);
+  });
+
+  it("handles quoted values with spaces", () => {
+    const r = parseWhere('headingPath="Architecture Decision Records"');
+    expect(r.ok).toBe(true);
+    expect(r.clauses).toEqual([["headingPath", "Architecture Decision Records"]]);
+  });
+
+  it("rejects malformed input", () => {
+    expect(parseWhere("no equals sign here").ok).toBe(false);
+    expect(parseWhere("=missing-key").ok).toBe(false);
+    expect(parseWhere("key=").ok).toBe(false);
+    expect(parseWhere("123key=value").ok).toBe(false);
+  });
+
+  it("rejects non-string input", () => {
+    expect(parseWhere(42).ok).toBe(false);
+    expect(parseWhere(["k=v"]).ok).toBe(false);
+  });
+});
+
+describe("buildWhereSql", () => {
+  it("emits empty fragment for empty clauses", () => {
+    expect(buildWhereSql([])).toEqual({ sql: "", params: [] });
+  });
+
+  it("special-cases `kind` to the column", () => {
+    expect(buildWhereSql([["kind", "plan"]])).toEqual({ sql: " AND c.kind = ?", params: ["plan"] });
+  });
+
+  it("uses json_extract for other keys", () => {
+    expect(buildWhereSql([["symbol", "loadConfig"]])).toEqual({
+      sql: " AND json_extract(c.metadata, '$.symbol') = ?",
+      params: ["loadConfig"],
+    });
+  });
+
+  it("combines multiple clauses with AND", () => {
+    const r = buildWhereSql([["kind", "plan"], ["hu_id", "HU-003"]]);
+    expect(r.sql).toBe(" AND c.kind = ? AND json_extract(c.metadata, '$.hu_id') = ?");
+    expect(r.params).toEqual(["plan", "HU-003"]);
+  });
+});


### PR DESCRIPTION
PR4/5 of v2.29.0. Re-target of #846 (auto-closed when PR3's base was deleted on merge).

New `kj rag query --where '<clause>'` flag with minimal KEY=VALUE AND KEY=VALUE grammar. `kind` filters the column; other keys go through SQLite json_extract on the metadata JSON. Applies uniformly to both semantic and BM25 sides of the hybrid retriever.

22 new tests + 121/121 full RAG suite passing. 196 LOC.

Original PR body: https://github.com/manufosela/karajan-code/pull/846