### PR TITLE
feat(rag): cross-encoder rerank (KJC-TSK-0449)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -181,6 +181,8 @@ const ragStubPlugin = {
           ONNXEmbedder: notAvailable, ONNXEmbedderError: notAvailable,
           // KJC-TSK-0448 — RAG --where metadata filter.
           parseWhere: notAvailable, buildWhereSql: notAvailable,
+          // KJC-TSK-0449 — RAG cross-encoder rerank.
+          rerank: notAvailable, RerankError: notAvailable, _resetPipeline: notAvailable,
           default: notAvailable,
         };
       `,

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -118,6 +118,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--mode <mode>", "hybrid (default) | semantic (cosine only) | keyword (BM25 only)", "hybrid")
     .option("--alpha <n>", "Hybrid weight for semantic component (0..1). Default 0.6", "0.6")
     .option("--where <clause>", "Metadata filter, e.g. 'symbol=loadConfig' or 'hu_id=HU-003 AND kind=plan'")
+    .option("--rerank", "Apply cross-encoder rerank to top-K (needs @huggingface/transformers, slower but more precise)")
+    .option("--rerank-model <name>", "Cross-encoder model id. Default: Xenova/ms-marco-MiniLM-L-6-v2")
     .option("--json", "Output the hits as JSON")
     .action(async (text, flags) => {
       await withConfig(pkgVersion, "rag-query", flags, async ({ config, logger }) => {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -58,7 +58,8 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     const mode = flags.mode || "hybrid";
     const alpha = Math.max(0, Math.min(1, Number(flags.alpha) || 0.6));
     const where = flags.where || null;
-    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha, where });
+    const rerankOpts = flags.rerank ? { model: flags.rerankModel } : null;
+    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha, where, rerankOpts });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);
     } else {

--- a/src/rag/rerank.js
+++ b/src/rag/rerank.js
@@ -1,0 +1,74 @@
+// KJC-TSK-0449 — Cross-encoder rerank stage. Re-scores the top-N hits
+// from the hybrid retriever using a (query, passage) cross-encoder.
+//
+// Cross-encoders are slower than the bi-encoder embedders (they jointly
+// encode query + passage instead of caching the passage), but they are
+// substantially more precise for the final top-K ranking. Karajan calls
+// the reranker only on the post-fusion candidates (≤topK*2), so the
+// added latency is bounded.
+//
+// Model is loaded dynamically via @huggingface/transformers (same dep as
+// the ONNX embedder, KJC-TSK-0447). Default: `Xenova/ms-marco-MiniLM-L-6-v2`,
+// the de-facto standard sentence-transformers reranker.
+
+const DEFAULT_MODEL = "Xenova/ms-marco-MiniLM-L-6-v2";
+
+export class RerankError extends Error {
+  constructor(message, { cause } = {}) { super(message); this.name = "RerankError"; if (cause) this.cause = cause; }
+}
+
+async function loadTransformers() {
+  /* eslint-disable import-x/no-unresolved */
+  try { return await import("@huggingface/transformers"); }
+  catch (e1) {
+    try { return await import("@xenova/transformers"); }
+    catch (e2) {
+      throw new RerankError(
+        "rerank requires @huggingface/transformers (or legacy @xenova/transformers). Install with `npm install @huggingface/transformers`.",
+        { cause: e2 },
+      );
+    }
+  }
+  /* eslint-enable import-x/no-unresolved */
+}
+
+/**
+ * Lazy singleton — first call downloads weights (~80 MB), every subsequent
+ * call reuses the same pipeline instance.
+ */
+let _pipelinePromise = null;
+function getPipeline(modelName) {
+  if (!_pipelinePromise) _pipelinePromise = (async () => {
+    const t = await loadTransformers();
+    // text-classification pipeline returns the cross-encoder relevance score
+    // for a `[query, passage]` text pair when applied to a CE model.
+    return t.pipeline("text-classification", modelName);
+  })();
+  return _pipelinePromise;
+}
+
+/** Reset for tests. */
+export function _resetPipeline() { _pipelinePromise = null; }
+
+/**
+ * Rerank `hits` against `queryText` using the cross-encoder. Returns a NEW
+ * array sorted by descending rerank score (best first), `score` mutated
+ * so the existing downstream code (kindBoost, slicing) keeps working.
+ *
+ * Each input hit is treated as a [query, hit.text] pair. Truncates the
+ * passage to `maxChars` to avoid blowing past the CE model's context
+ * window — most CE models handle 512 tokens, ~2000 chars is safe.
+ *
+ * If `pipelineFn` is injected (tests), it bypasses model loading.
+ */
+export async function rerank(queryText, hits, { model = process.env.KJ_RERANK_MODEL || DEFAULT_MODEL, maxChars = 2000, pipelineFn = null } = {}) {
+  if (!queryText || typeof queryText !== "string") throw new RerankError("rerank: queryText must be a non-empty string");
+  if (!Array.isArray(hits)) throw new RerankError("rerank: hits must be an array");
+  if (hits.length === 0) return hits;
+  const pipe = pipelineFn || await getPipeline(model);
+  const pairs = hits.map((h) => ({ text: queryText, text_pair: String(h.text || "").slice(0, maxChars) }));
+  const results = await pipe(pairs);
+  return hits
+    .map((h, i) => ({ ...h, _rerank: Number(results[i]?.score) || 0, score: -Number(results[i]?.score) || 0 }))
+    .sort((a, b) => a.score - b.score);
+}

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -1,6 +1,7 @@
 // KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline.
 import { searchSimilar, searchBM25 } from "./vec-store.js";
 import { parseWhere, buildWhereSql } from "./where-parser.js";
+import { rerank } from "./rerank.js";
 
 const DEFAULT_KIND_BOOST = { plan: 0.05, onboarding: 0.03, code: 0 };
 
@@ -40,7 +41,7 @@ function fuseHits(semantic, keyword, alpha, mode) {
   return list;
 }
 
-export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6, where = null } = {}) {
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6, where = null, rerankOpts = null } = {}) {
   if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
   const fetchK = Math.min(50, topK * 2);
   const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
@@ -63,6 +64,11 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
     const sourceB = (boostSources && r.kind === "code" && !isTestPath(r.source)) ? SOURCE_BOOST_NON_TEST : 0;
     return { ...r, score: r.distance - kindB - sourceB };
   }).sort((a, b) => a.score - b.score).slice(0, topK);
+  // KJC-TSK-0449 — optional cross-encoder rerank. When `rerankOpts` is set,
+  // we re-score the topK survivors with a (query, passage) cross-encoder;
+  // the kind+source boost has already been applied, so the rerank acts as
+  // a finer-grained quality lever on top.
+  if (rerankOpts) return await rerank(text, reranked, rerankOpts);
   return reranked;
 }
 

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -84,7 +84,12 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // runtime) so a static import would force every install to pay that cost
 // even for users who never opt into provider: onnx. Static imports are
 // not an option here by design.
-const DYNAMIC_IMPORT_BUDGET = 164;
+//
+// 2026-05-25 (KJC-TSK-0449 v2.29 cross-encoder rerank): bumped 164 → 166
+// for the same pattern inside `src/rag/rerank.js`. Same rationale —
+// transformers is an optional peer dep, opt-in `--rerank` flag, must
+// gracefully error on missing package.
+const DYNAMIC_IMPORT_BUDGET = 166;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/rag/rerank.test.js
+++ b/tests/rag/rerank.test.js
@@ -1,0 +1,76 @@
+// KJC-TSK-0449 — cross-encoder rerank tests. CI never downloads the
+// model weights; we inject a synthetic pipeline via `pipelineFn` so the
+// tests cover ordering, input validation, and truncation behaviour.
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { rerank, RerankError, _resetPipeline } from "../../src/rag/rerank.js";
+import { query } from "../../src/rag/retriever.js";
+import { openVecStore, insertChunk } from "../../src/rag/vec-store.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+beforeEach(() => _resetPipeline());
+
+describe("rerank()", () => {
+  it("rejects empty / non-string queryText", async () => {
+    await expect(rerank("", [{ text: "a" }])).rejects.toThrow(RerankError);
+    await expect(rerank(null, [{ text: "a" }])).rejects.toThrow(RerankError);
+  });
+
+  it("rejects non-array hits", async () => {
+    await expect(rerank("q", "not-array")).rejects.toThrow(/hits must be an array/);
+  });
+
+  it("returns empty hits unchanged", async () => {
+    const out = await rerank("q", []);
+    expect(out).toEqual([]);
+  });
+
+  it("reorders hits by descending pipeline score", async () => {
+    const hits = [
+      { id: 1, text: "totally unrelated content", source: "a", kind: "code", distance: 0.1 },
+      { id: 2, text: "perfect match for auth login", source: "b", kind: "code", distance: 0.2 },
+      { id: 3, text: "somewhat related text", source: "c", kind: "code", distance: 0.3 },
+    ];
+    const pipelineFn = vi.fn().mockResolvedValue([{ score: 0.1 }, { score: 0.95 }, { score: 0.4 }]);
+    const out = await rerank("auth login", hits, { pipelineFn });
+    expect(out[0].id).toBe(2);
+    expect(out[1].id).toBe(3);
+    expect(out[2].id).toBe(1);
+    expect(out[0]._rerank).toBeCloseTo(0.95, 5);
+  });
+
+  it("truncates long passages to maxChars before scoring", async () => {
+    const longText = "x".repeat(5000);
+    let received;
+    const pipelineFn = vi.fn(async (pairs) => { received = pairs; return pairs.map(() => ({ score: 0.5 })); });
+    await rerank("q", [{ id: 1, text: longText }], { pipelineFn, maxChars: 100 });
+    expect(received[0].text_pair.length).toBe(100);
+  });
+});
+
+describe("retriever query() with rerankOpts", () => {
+  let tmp, db;
+  const stubEmbedder = { embed: async () => Float32Array.from([0.5, 0.5, 0.5, 0.5]) };
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kj-rerank-"));
+    process.env.KJ_RAG_DB = join(tmp, "rag.db");
+    db = openVecStore({ dim: 4 });
+    insertChunk(db, { source: "a.js", kind: "code", text: "stub a", embedding: [0.1, 0.1, 0.1, 0.1], project: "x" });
+    insertChunk(db, { source: "b.js", kind: "code", text: "stub b", embedding: [0.2, 0.2, 0.2, 0.2], project: "x" });
+  });
+
+  it("invokes rerank when rerankOpts is set, surfacing the highest-scored hit first", async () => {
+    // Score "stub b" higher than "stub a" regardless of retrieval order.
+    const pipelineFn = vi.fn(async (pairs) =>
+      pairs.map((p) => ({ score: p.text_pair.includes("stub b") ? 0.9 : 0.1 })),
+    );
+    const hits = await query(db, stubEmbedder, "anything", { topK: 5, project: "x", rerankOpts: { pipelineFn } });
+    expect(pipelineFn).toHaveBeenCalledTimes(1);
+    expect(hits[0].text).toBe("stub b");
+    db.close();
+    rmSync(tmp, { recursive: true, force: true });
+    delete process.env.KJ_RAG_DB;
+  });
+});


### PR DESCRIPTION
PR5/5 of v2.29.0. Re-target of #847 (auto-closed when PR4's base was deleted on merge).

Opt-in cross-encoder rerank stage. `kj rag query 'auth' --rerank` re-scores the topK survivors with a (query, passage) cross-encoder (default `Xenova/ms-marco-MiniLM-L-6-v2`, ~80 MB cached). Runs only on post-fusion candidates so latency stays bounded. Plugs in after the kind+source boosts as a finer-grained quality lever.

Dynamic-imports budget bumped 164 → 166 with justification (same optional peer dep pattern as ONNX embedder).

6 new rerank tests + 121/121 RAG suite passing. 169 LOC total.