### PR TITLE
chore: release v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.29.0] - 2026-05-25
+
+Minor release. **RAG quality lift** — retrieval dashboard, three new embedder providers, metadata filtering, cross-encoder rerank.
+
+Five PRs land the next layer of the RAG track. The dashboard is also the first piece of the v2.30 config-UI roadmap (writable settings on the HU Board).
+
+### Added
+
+- **PR #843 (KJC-TSK-0445) — retrieval-quality dashboard on HU Board**. New `/rag.html` page with active embedder, DB size, last-index timestamp, chunks per kind, chunks per project (top 20). Backend `GET /api/rag/stats` reads the local rag.db read-only and embedder config from kj.config.yml. Empty-state when the DB isn't initialized. Linked from main nav.
+- **PR #848 (KJC-TSK-0446) — Cohere + Mistral embedder adapters**. `embed-multilingual-v3.0` (1024 dim, strong multilingual) and `mistral-embed` (1024 dim, EU-hosted). KJ_COHERE_KEY / KJ_MISTRAL_KEY scoped env vars. Replaces the "Anthropic via OAuth" roadmap slot — Anthropic has no embeddings endpoint. Shared `_cloud-base.js` keeps the Bearer auth + dim validation single-source.
+- **PR #?? (KJC-TSK-0447) — ONNX local embedder via `@huggingface/transformers`**. Sixth provider, fully local: no Docker, no API key, no external service after the first model download. Default `Xenova/all-MiniLM-L6-v2` (384 dim, ~80 MB cached). Higher-quality option `Xenova/jina-embeddings-v2-base-en` (768 dim). The transformers package is an optional peer dep (not auto-installed; helpful error on missing). Unlocks v2.31 zero-config init.
+- **PR #?? (KJC-TSK-0448) — metadata `--where` filter for `kj rag query`**. New CLI flag with `KEY=VALUE AND KEY=VALUE` grammar. `kind` filters the column; every other key (symbol, hu_id, headingPath, file, …) goes through SQLite `json_extract` so any metadata the chunker emits is queryable without schema changes. Examples: `--where symbol=loadConfig`, `--where 'hu_id=HU-003 AND kind=plan'`.
+- **PR #?? (KJC-TSK-0449) — cross-encoder rerank stage**. Opt-in `--rerank` flag re-scores the topK survivors with a (query, passage) cross-encoder. Default `Xenova/ms-marco-MiniLM-L-6-v2` (~80 MB cached on first use). Runs only on post-fusion candidates so latency is bounded. Plugs in after the kind+source boosts, acting as a finer-grained quality lever.
+
+### Tests
+
+5 757 / 5 757 passing across 396 test files (+87 new tests across the 5 PRs, +7 files).
+
+### Internal
+
+- Embedder factory now wires six providers (ollama / openai / voyage / cohere / mistral / onnx) from a single PROVIDERS table.
+- SEA stub registry updated with every new export so the standalone binary keeps printing the friendly "not available" message instead of crashing.
+
 ## [2.28.0] - 2026-05-25
 
 Minor release. **RAG advanced** — live re-index + cloud embedders + hybrid scoring + AST chunker.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.29.0 released** — Minor. **RAG quality lift** — dashboard + three new providers + metadata filter + rerank.
+>
+> - **Retrieval dashboard on HU Board** (PR #843): nuevo `/rag.html` con embedder activo, tamaño de DB, last-index, chunks por kind, chunks por proyecto. Primera pieza del config UI que llega completo en v2.30.
+> - **Cohere + Mistral embedders** (PR #848): `embed-multilingual-v3.0` (multi-idioma) y `mistral-embed` (EU-hosted, útil para GDPR). `KJ_COHERE_KEY` / `KJ_MISTRAL_KEY` Karajan-scoped.
+> - **ONNX local embedder** (PR #??): `@huggingface/transformers` corriendo en Node — sin Docker, sin API key, sin Ollama. Default `Xenova/all-MiniLM-L6-v2` (384 dim). Es la base para el zero-config init de v2.31.
+> - **Metadata `--where` filter** (PR #??): `kj rag query 'auth' --where 'symbol=loadConfig AND kind=plan'`. Gramática mínima KEY=VALUE AND KEY=VALUE; cualquier metadata que emite el chunker es queryable sin schema changes.
+> - **Cross-encoder rerank** (PR #??): opt-in `--rerank` re-ordena los topK con un cross-encoder (`Xenova/ms-marco-MiniLM-L-6-v2`). Latencia acotada, calidad final notablemente mejor.
+>
 > **v2.28.0 released** — Minor. **RAG advanced** — live re-index + cloud embedders + hybrid scoring + AST chunker, plus a real fix for the v2.27.0 chapuza.
 >
 > - **`kj watch`** (PR #836): chokidar daemon que re-indexa los archivos del proyecto tras cada edit (1s debounce). Fin del `kj rag index` manual.
@@ -360,7 +368,7 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 > - **Asymmetric source-vs-test ranking** (PR #833): NL queries like `how does X work` no longer rank `tests/X.test.js` above `src/X.js`; test-flavoured queries still surface tests.
 > - Plus **KJC-BUG-0063** (PR #834): skipped a TZ-dependent test that was blocking every CI run, and a `shrink-budget` workflow exclude fix for `docs/*.md` at the root.
 >
-> **Coming in v2.28.0+**: chokidar watcher for live re-indexing, AST source chunker (tree-sitter / @babel/parser), BM25 + cosine hybrid scoring, OpenAI/Voyage embedder adapters (for users without local Docker).
+> **Coming in v2.30.0+**: writable config UI on the HU Board (toggle roles, switch coder/reviewer, adjust alpha/mode/rerank without re-editing the YAML), then v2.31 zero-config init (reduce the wizard to one critical question, smart defaults for everything).
 >
 > **v2.26.0 released** — Minor. **RAG Auto-Bootstrap** — Ollama runs in Docker out of the box. `kj init` now provisions the embedder automatically (or skips with a clear reason on modest hardware / `--no-ollama`); `kj doctor` surfaces health; `kj ollama [start|stop|status|pull]` manages lifecycle without docker compose. See [docs/RAG.md](docs/RAG.md) for the full RAG guide ([español](docs/es/RAG.md)).
 >

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.28.0
+kj --version    # 2.29.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.28.0
+kj --version    # 2.29.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release bump for v2.29.0 — RAG quality lift (5 PRs merged: #843 dashboard, #848 Cohere+Mistral, #850 ONNX, #851 --where, #852 rerank).

- `package.json` 2.28.0 → 2.29.0
- `package-lock.json` regenerated
- `CHANGELOG.md` new `[2.29.0]` entry
- `README.md` banner + Coming-next section
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` version refs

Next: tag v2.29.0, gh release create, npm publish, landing deploy.