### PR TITLE
feat(board): pipeline role toggles in writable config UI

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -111,6 +111,74 @@ export const EDITABLE_FIELDS = [
     help: 'Pasa el código por SonarQube y bloquea si el quality gate falla. Requiere SonarQube corriendo.',
     default: false,
   },
+  // v2.30.0 — pipeline role toggles. Cada uno controla si una etapa
+  // del pipeline se ejecuta. Brain está OFF por defecto porque sigue
+  // siendo opt-in (v2 feature); el resto reflejan los defaults de
+  // src/config/defaults.js.
+  {
+    key: 'plannerEnabled',
+    path: 'pipeline.planner.enabled',
+    type: 'boolean',
+    label: 'Activar rol planner',
+    help: 'Genera un plan de implementación antes de codificar. Útil en tareas con >2 archivos o devPoints ≥ 3.',
+    default: true,
+  },
+  {
+    key: 'researcherEnabled',
+    path: 'pipeline.researcher.enabled',
+    type: 'boolean',
+    label: 'Activar rol researcher',
+    help: 'Investiga la codebase antes del coder (lectura de archivos clave, patrones existentes).',
+    default: true,
+  },
+  {
+    key: 'architectEnabled',
+    path: 'pipeline.architect.enabled',
+    type: 'boolean',
+    label: 'Activar rol architect',
+    help: 'Diseña la arquitectura (capas, patrones, contratos) antes de codificar. Recomendado en cambios estructurales.',
+    default: true,
+  },
+  {
+    key: 'testerEnabled',
+    path: 'pipeline.tester.enabled',
+    type: 'boolean',
+    label: 'Activar rol tester',
+    help: 'Genera tests automáticos durante o después del coder. Refuerza la calidad.',
+    default: true,
+  },
+  {
+    key: 'securityEnabled',
+    path: 'pipeline.security.enabled',
+    type: 'boolean',
+    label: 'Activar rol security',
+    help: 'Audita el código contra OWASP-style issues, secret leaks, dependencias vulnerables.',
+    default: true,
+  },
+  {
+    key: 'refactorerEnabled',
+    path: 'pipeline.refactorer.enabled',
+    type: 'boolean',
+    label: 'Activar rol refactorer',
+    help: 'Pasa una iteración de limpieza tras el coder (extract function, rename, etc.).',
+    default: false,
+  },
+  {
+    key: 'impeccableEnabled',
+    path: 'pipeline.impeccable.enabled',
+    type: 'boolean',
+    label: 'Activar rol impeccable',
+    help: 'Auditoría UI/UX automática (Lighthouse, a11y, contraste). Solo útil en frontend.',
+    default: false,
+  },
+  {
+    key: 'brainEnabled',
+    path: 'pipeline.brain.enabled',
+    type: 'boolean',
+    label: 'Activar Karajan Brain (v2)',
+    help: 'Orquestador IA central: enriquece feedback, comprime outputs y verifica cambios reales. Opt-in.',
+    default: false,
+  },
 ];
 
 const ROLES_FOR_MODEL_MODE = [

--- a/tests/board/config-yaml-pipeline-toggles.test.js
+++ b/tests/board/config-yaml-pipeline-toggles.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+// v2.30.0 — pipeline role toggles in EDITABLE_FIELDS.
+// Verifies that the board can read the boolean toggles for every
+// pipeline stage exposed in the UI, and that writeConfigPatch persists
+// them under pipeline.<role>.enabled in the yml.
+
+let home;
+let originalEnv;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kj-cfg-pipeline-"));
+  originalEnv = process.env.KARAJAN_HOME;
+  process.env.KARAJAN_HOME = home;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const { readConfig, writeConfigPatch, EDITABLE_FIELDS } = await import(
+  "../../packages/hu-board/src/config-yaml.js"
+);
+
+const TOGGLE_KEYS = [
+  "plannerEnabled",
+  "researcherEnabled",
+  "architectEnabled",
+  "testerEnabled",
+  "securityEnabled",
+  "refactorerEnabled",
+  "impeccableEnabled",
+  "brainEnabled",
+];
+
+describe("config-yaml — pipeline role toggles (v2.30.0)", () => {
+  it("exposes a boolean toggle for every pipeline role", () => {
+    for (const key of TOGGLE_KEYS) {
+      const field = EDITABLE_FIELDS.find((f) => f.key === key);
+      expect(field, `missing field ${key}`).toBeDefined();
+      expect(field.type).toBe("boolean");
+      expect(field.path.startsWith("pipeline.")).toBe(true);
+      expect(field.path.endsWith(".enabled")).toBe(true);
+    }
+  });
+
+  it("readConfig returns documented defaults when the yml is absent", () => {
+    const out = readConfig();
+    expect(out.exists).toBe(false);
+    const get = (k) => out.fields.find((f) => f.key === k).value;
+    expect(get("plannerEnabled")).toBe(true);
+    expect(get("researcherEnabled")).toBe(true);
+    expect(get("brainEnabled")).toBe(false);
+    expect(get("impeccableEnabled")).toBe(false);
+  });
+
+  it("writeConfigPatch persists each toggle under pipeline.<role>.enabled", () => {
+    const res = writeConfigPatch({
+      plannerEnabled: false,
+      brainEnabled: true,
+      impeccableEnabled: true,
+    });
+    expect(res.written).toBe(true);
+    expect(res.errors).toEqual([]);
+
+    const parsed = yaml.load(readFileSync(res.path, "utf8"));
+    expect(parsed.pipeline.planner.enabled).toBe(false);
+    expect(parsed.pipeline.brain.enabled).toBe(true);
+    expect(parsed.pipeline.impeccable.enabled).toBe(true);
+    // Other roles must NOT be touched if the user didn't ask.
+    expect(parsed.pipeline.researcher).toBeUndefined();
+  });
+
+  it("re-reading after a write reflects the persisted toggles", () => {
+    writeConfigPatch({ brainEnabled: true });
+    const out = readConfig();
+    const get = (k) => out.fields.find((f) => f.key === k).value;
+    expect(get("brainEnabled")).toBe(true);
+    expect(get("plannerEnabled")).toBe(true); // unchanged → default
+  });
+
+  it("rejects non-boolean values with a clear error", () => {
+    const res = writeConfigPatch({ plannerEnabled: "yes" });
+    expect(res.written).toBe(false);
+    expect(res.errors.some((e) => e.includes("plannerEnabled"))).toBe(true);
+    expect(existsSync(join(home, "kj.config.yml"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Primer PR de la serie v2.30.0 (Writable config UI en HU Board).

Añade 8 toggles boolean a `EDITABLE_FIELDS` en `packages/hu-board/src/config-yaml.js` para que el modal de Settings del board pueda activar/desactivar roles del pipeline sin editar el yml a mano:

- `plannerEnabled`, `researcherEnabled`, `architectEnabled`, `testerEnabled`, `securityEnabled` (default `true`)
- `refactorerEnabled`, `impeccableEnabled`, `brainEnabled` (default `false`)

Cada toggle persiste bajo `pipeline.<role>.enabled` y respeta el contrato atómico (tmp+rename, `.bak`) que ya tenía el resto del módulo. Los roles no incluidos en el patch no son tocados.

PG card: **KJC-TSK-0450** (epic KJC-PCS-0042).

## Test plan

- [x] `npx vitest run tests/board/config-yaml-pipeline-toggles.test.js` → 5/5 verde
- [x] Shape de campos (path empieza por `pipeline.` y termina en `.enabled`)
- [x] Defaults documentados cuando el yml no existe
- [x] Write persiste solo los toggles del patch, no toca el resto
- [x] Re-read tras write refleja el estado
- [x] Rechaza valores no-boolean sin escribir nada al disco

## LOC budget

`+162 insertions, 0 deletions` (68 src + 94 test). Bajo el límite de 200 LOC.