### PR TITLE
feat(board): RAG controls in writable config UI (KJC-TSK-0451)

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -179,6 +179,47 @@ export const EDITABLE_FIELDS = [
     help: 'Orquestador IA central: enriquece feedback, comprime outputs y verifica cambios reales. Opt-in.',
     default: false,
   },
+  // v2.30.0 — RAG controls. Sólo se exponen las claves que el código
+  // realmente lee hoy (rag.preload.* en rag-context-stage.js y
+  // rag.embedder.provider en embedders/factory.js). mode/alpha/rerank
+  // se controlan vía flags CLI; cuando se cableen en config se añadirán
+  // aquí (ver task #99).
+  {
+    key: 'ragPreloadEnabled',
+    path: 'rag.preload.enabled',
+    type: 'boolean',
+    label: 'Activar pre-carga RAG en el pipeline',
+    help: 'Si está activo, antes de cada iteración se inyecta contexto del vector store en el prompt del coder.',
+    default: false,
+  },
+  {
+    key: 'ragPreloadTopK',
+    path: 'rag.preload.topK',
+    type: 'number',
+    label: 'Nº de chunks a pre-cargar (topK)',
+    help: 'Cuántos fragmentos del vector store se inyectan como contexto. 3-5 funciona bien; subir gasta tokens.',
+    min: 1,
+    max: 20,
+    default: 5,
+  },
+  {
+    key: 'ragPreloadScope',
+    path: 'rag.preload.scope',
+    type: 'select',
+    label: 'Scope de la pre-carga RAG',
+    help: '"all" mezcla todo. "code" solo busca en el código indexado, "plans" en planes previos, "onboarding" en el brief del proyecto.',
+    options: ['all', 'code', 'plans', 'onboarding'],
+    default: 'all',
+  },
+  {
+    key: 'ragEmbedderProvider',
+    path: 'rag.embedder.provider',
+    type: 'select',
+    label: 'Proveedor de embeddings RAG',
+    help: 'Ollama local es gratis. OpenAI/Voyage/Cohere/Mistral son cloud (requieren API key). ONNX corre 100% local con @huggingface/transformers.',
+    options: ['ollama', 'openai', 'voyage', 'cohere', 'mistral', 'onnx'],
+    default: 'ollama',
+  },
 ];
 
 const ROLES_FOR_MODEL_MODE = [

--- a/tests/board/config-yaml-rag-controls.test.js
+++ b/tests/board/config-yaml-rag-controls.test.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+// v2.30.0 — RAG controls in EDITABLE_FIELDS.
+// Verifies that the board can read/write the RAG keys that the code
+// actually reads today: rag.preload.{enabled,topK,scope} (consumed in
+// src/orchestrator/stages/rag-context-stage.js) and rag.embedder.provider
+// (consumed in src/rag/embedders/factory.js).
+
+let home;
+let originalEnv;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kj-cfg-rag-"));
+  originalEnv = process.env.KARAJAN_HOME;
+  process.env.KARAJAN_HOME = home;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const { readConfig, writeConfigPatch, EDITABLE_FIELDS } = await import(
+  "../../packages/hu-board/src/config-yaml.js"
+);
+
+describe("config-yaml — RAG controls (v2.30.0)", () => {
+  it("exposes the four documented RAG fields with the expected shape", () => {
+    const get = (k) => EDITABLE_FIELDS.find((f) => f.key === k);
+
+    const preloadEnabled = get("ragPreloadEnabled");
+    expect(preloadEnabled).toBeDefined();
+    expect(preloadEnabled.type).toBe("boolean");
+    expect(preloadEnabled.path).toBe("rag.preload.enabled");
+
+    const topK = get("ragPreloadTopK");
+    expect(topK.type).toBe("number");
+    expect(topK.path).toBe("rag.preload.topK");
+    expect(topK.min).toBe(1);
+    expect(topK.max).toBe(20);
+
+    const scope = get("ragPreloadScope");
+    expect(scope.type).toBe("select");
+    expect(scope.path).toBe("rag.preload.scope");
+    expect(scope.options).toEqual(["all", "code", "plans", "onboarding"]);
+
+    const provider = get("ragEmbedderProvider");
+    expect(provider.type).toBe("select");
+    expect(provider.path).toBe("rag.embedder.provider");
+    expect(provider.options).toEqual([
+      "ollama",
+      "openai",
+      "voyage",
+      "cohere",
+      "mistral",
+      "onnx",
+    ]);
+  });
+
+  it("readConfig returns documented defaults when the yml is absent", () => {
+    const out = readConfig();
+    expect(out.exists).toBe(false);
+    const get = (k) => out.fields.find((f) => f.key === k).value;
+    expect(get("ragPreloadEnabled")).toBe(false);
+    expect(get("ragPreloadTopK")).toBe(5);
+    expect(get("ragPreloadScope")).toBe("all");
+    expect(get("ragEmbedderProvider")).toBe("ollama");
+  });
+
+  it("writeConfigPatch persists every RAG field under the right yml path", () => {
+    const res = writeConfigPatch({
+      ragPreloadEnabled: true,
+      ragPreloadTopK: 8,
+      ragPreloadScope: "code",
+      ragEmbedderProvider: "voyage",
+    });
+    expect(res.written).toBe(true);
+    expect(res.errors).toEqual([]);
+
+    const parsed = yaml.load(readFileSync(res.path, "utf8"));
+    expect(parsed.rag.preload.enabled).toBe(true);
+    expect(parsed.rag.preload.topK).toBe(8);
+    expect(parsed.rag.preload.scope).toBe("code");
+    expect(parsed.rag.embedder.provider).toBe("voyage");
+  });
+
+  it("re-reading after a write reflects the persisted RAG values", () => {
+    writeConfigPatch({
+      ragPreloadEnabled: true,
+      ragEmbedderProvider: "onnx",
+    });
+    const out = readConfig();
+    const get = (k) => out.fields.find((f) => f.key === k).value;
+    expect(get("ragPreloadEnabled")).toBe(true);
+    expect(get("ragEmbedderProvider")).toBe("onnx");
+    expect(get("ragPreloadTopK")).toBe(5); // unchanged → default
+    expect(get("ragPreloadScope")).toBe("all"); // unchanged → default
+  });
+
+  it("rejects topK out of [1,20] with a clear error and does not write", () => {
+    const tooHigh = writeConfigPatch({ ragPreloadTopK: 50 });
+    expect(tooHigh.written).toBe(false);
+    expect(tooHigh.errors.some((e) => e.includes("ragPreloadTopK"))).toBe(true);
+
+    const tooLow = writeConfigPatch({ ragPreloadTopK: 0 });
+    expect(tooLow.written).toBe(false);
+    expect(tooLow.errors.some((e) => e.includes("ragPreloadTopK"))).toBe(true);
+
+    expect(existsSync(join(home, "kj.config.yml"))).toBe(false);
+  });
+
+  it("rejects unknown embedder providers", () => {
+    const res = writeConfigPatch({ ragEmbedderProvider: "claude-magic" });
+    expect(res.written).toBe(false);
+    expect(res.errors.some((e) => e.includes("ragEmbedderProvider"))).toBe(true);
+    expect(existsSync(join(home, "kj.config.yml"))).toBe(false);
+  });
+
+  it("rejects unknown scope values", () => {
+    const res = writeConfigPatch({ ragPreloadScope: "everywhere" });
+    expect(res.written).toBe(false);
+    expect(res.errors.some((e) => e.includes("ragPreloadScope"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 4 RAG fields to the board's `EDITABLE_FIELDS` so users can toggle pre-load behaviour and pick the embedder provider from the modal instead of hand-editing `kj.config.yml`
- Only keys the code already reads are exposed: `rag.preload.{enabled,topK,scope}` (consumed in `src/orchestrator/stages/rag-context-stage.js`) and `rag.embedder.provider` (consumed in `src/rag/embedders/factory.js`)
- `mode` / `alpha` / `rerank` are deferred — they live only in CLI flags today; will be added once wired into config (tracked as follow-up)

## Fields added
| Key | Path | Type | Default |
|---|---|---|---|
| ragPreloadEnabled | rag.preload.enabled | bool | false |
| ragPreloadTopK | rag.preload.topK | number 1..20 | 5 |
| ragPreloadScope | rag.preload.scope | select | all |
| ragEmbedderProvider | rag.embedder.provider | select | ollama |

## Test plan
- [x] `npx vitest run tests/board/config-yaml-rag-controls.test.js` → 7/7 passing
- [x] Re-runs the pipeline-toggles test (PR1, KJC-TSK-0450) → 5/5 passing (no regression)
- [x] LOC budget: +170 insertions across 2 files (well under the 200 cap)

Card: KJC-TSK-0451 · Epic: KJC-PCS-0042 · Part of v2.30.0 (PR 2/5)