### PR TITLE
feat(board): grouped sections in config modal (v2.30.0 PR3)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -3306,6 +3306,41 @@ async function showConfigEditor() {
       </div>
     `;
   };
+
+  // v2.30.0 — agrupa los campos por `f.category`. El backend declara
+  // las categorías ordenadas en `cfg.categories`; cualquier campo sin
+  // categoría cae a "Otros" (defensivo, no se pierde si olvidamos
+  // etiquetar uno nuevo). Mantiene el orden interno del whitelist
+  // dentro de cada sección.
+  const cats = Array.isArray(cfg.categories) && cfg.categories.length > 0
+    ? cfg.categories
+    : [{ id: 'misc', label: 'Otros', icon: '⚙', order: 999 }];
+  const byCat = new Map(cats.map((c) => [c.id, []]));
+  byCat.set('misc', byCat.get('misc') || []);
+  for (const f of cfg.fields) {
+    const id = byCat.has(f.category) ? f.category : 'misc';
+    if (!byCat.has(id)) byCat.set(id, []);
+    byCat.get(id).push(f);
+  }
+  const renderSection = (cat) => {
+    const fields = byCat.get(cat.id) || [];
+    if (fields.length === 0) return '';
+    return `
+      <section style="margin-bottom:22px;">
+        <h3 style="display:flex;align-items:center;gap:8px;margin:0 0 12px;padding-bottom:6px;border-bottom:1px solid var(--border);font-size:0.95rem;font-weight:700;color:var(--text);">
+          <span aria-hidden="true">${esc(cat.icon || '⚙')}</span>
+          <span>${esc(cat.label)}</span>
+        </h3>
+        ${fields.map(renderField).join('')}
+      </section>
+    `;
+  };
+  const allCats = [...cats];
+  if ((byCat.get('misc') || []).length > 0 && !allCats.some((c) => c.id === 'misc')) {
+    allCats.push({ id: 'misc', label: 'Otros', icon: '⚙', order: 999 });
+  }
+  const sectionsHtml = allCats.map(renderSection).join('');
+
   dlg.innerHTML = `
     <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;gap:10px;">
       <span style="font-size:1.2rem;">⚙</span>
@@ -3313,7 +3348,7 @@ async function showConfigEditor() {
       <span style="margin-left:auto;font-family:var(--font-mono,monospace);font-size:0.75rem;color:var(--text-muted);">${esc(cfg.path || '')}</span>
     </div>
     <div style="padding:14px 18px;max-height:65vh;overflow:auto;">
-      ${cfg.fields.map(renderField).join('')}
+      ${sectionsHtml}
       <p style="margin:14px 0 0;font-size:0.75rem;color:var(--text-muted);">
         Los cambios se guardan en <code>kj.config.yml</code> de forma atómica (con copia de seguridad <code>.bak</code>).
         El próximo <code>kj run</code> los aplicará — no hace falta reiniciar el board.

--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -45,10 +45,25 @@ function configPath() {
 function backupPath() { return `${configPath()}.bak`; }
 
 /**
+ * v2.30.0 — Categorías para agrupar los campos en el modal. El backend
+ * sólo declara la metadata (id, label, icon, order). El front (app.js)
+ * itera sobre EDITABLE_FIELDS, agrupa por `f.category` y dibuja un
+ * <h3> por sección. Si un campo nuevo no declara categoría, cae en
+ * "Otros" (defensivo: no se pierde aunque se nos olvide etiquetarlo).
+ */
+export const CATEGORIES = [
+  { id: 'agents',   label: 'Agentes y modelos',        icon: '🤖', order: 1 },
+  { id: 'pipeline', label: 'Roles del pipeline',       icon: '🔌', order: 2 },
+  { id: 'rag',      label: 'RAG (búsqueda de contexto)', icon: '📚', order: 3 },
+  { id: 'session',  label: 'Tiempos de sesión',        icon: '⏱',  order: 4 },
+  { id: 'quality',  label: 'Calidad',                  icon: '✅', order: 5 },
+];
+
+/**
  * Whitelist of fields the board's modal exposes. Everything else
  * stays untouched in the yml. Each entry says where in the yml the
  * field lives (`path`) and how to render it for the UI (`type`,
- * `label`, `options` for selects).
+ * `label`, `options` for selects, `category` for grouping).
  *
  * The path is a dotted notation we resolve manually (so we never
  * need to take a runtime dep on lodash for `_.get`/`_.set`).
@@ -57,6 +72,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'coder',
     path: 'coder',
+    category: 'agents',
     type: 'select',
     label: 'Agente para el rol "coder"',
     help: 'Quién escribe el código. Claude es el más fiable, Codex es más rápido.',
@@ -66,6 +82,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'reviewer',
     path: 'reviewer',
+    category: 'agents',
     type: 'select',
     label: 'Agente para el rol "reviewer"',
     help: 'Quién revisa el código del coder. Conviene que sea un agente distinto al coder para detectar errores.',
@@ -75,6 +92,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'modelMode',
     path: '_modelMode_virtual',
+    category: 'agents',
     type: 'select',
     label: 'Estrategia de modelos',
     help: 'Auto = Karajan elige el modelo según la complejidad (haiku/sonnet/opus). Sonnet siempre = barato, ideal para pruebas. Opus siempre = caro, máxima calidad.',
@@ -86,6 +104,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'maxIterationMinutes',
     path: 'session.max_iteration_minutes',
+    category: 'session',
     type: 'number',
     label: 'Tope de minutos por iteración',
     help: 'Si una iteración (coder + reviewer) supera este tiempo, Karajan la corta y Solomon decide qué hacer.',
@@ -96,6 +115,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'maxTotalMinutes',
     path: 'session.max_total_minutes',
+    category: 'session',
     type: 'number',
     label: 'Tope de minutos total por sesión',
     help: 'Tope absoluto del wall-clock de la sesión. Si se llega aquí, Karajan para aunque queden HUs.',
@@ -106,6 +126,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'sonarEnabled',
     path: 'sonarqube.enabled',
+    category: 'quality',
     type: 'boolean',
     label: 'Activar análisis SonarQube',
     help: 'Pasa el código por SonarQube y bloquea si el quality gate falla. Requiere SonarQube corriendo.',
@@ -118,6 +139,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'plannerEnabled',
     path: 'pipeline.planner.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol planner',
     help: 'Genera un plan de implementación antes de codificar. Útil en tareas con >2 archivos o devPoints ≥ 3.',
@@ -126,6 +148,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'researcherEnabled',
     path: 'pipeline.researcher.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol researcher',
     help: 'Investiga la codebase antes del coder (lectura de archivos clave, patrones existentes).',
@@ -134,6 +157,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'architectEnabled',
     path: 'pipeline.architect.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol architect',
     help: 'Diseña la arquitectura (capas, patrones, contratos) antes de codificar. Recomendado en cambios estructurales.',
@@ -142,6 +166,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'testerEnabled',
     path: 'pipeline.tester.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol tester',
     help: 'Genera tests automáticos durante o después del coder. Refuerza la calidad.',
@@ -150,6 +175,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'securityEnabled',
     path: 'pipeline.security.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol security',
     help: 'Audita el código contra OWASP-style issues, secret leaks, dependencias vulnerables.',
@@ -158,6 +184,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'refactorerEnabled',
     path: 'pipeline.refactorer.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol refactorer',
     help: 'Pasa una iteración de limpieza tras el coder (extract function, rename, etc.).',
@@ -166,6 +193,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'impeccableEnabled',
     path: 'pipeline.impeccable.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar rol impeccable',
     help: 'Auditoría UI/UX automática (Lighthouse, a11y, contraste). Solo útil en frontend.',
@@ -174,6 +202,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'brainEnabled',
     path: 'pipeline.brain.enabled',
+    category: 'pipeline',
     type: 'boolean',
     label: 'Activar Karajan Brain (v2)',
     help: 'Orquestador IA central: enriquece feedback, comprime outputs y verifica cambios reales. Opt-in.',
@@ -187,6 +216,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'ragPreloadEnabled',
     path: 'rag.preload.enabled',
+    category: 'rag',
     type: 'boolean',
     label: 'Activar pre-carga RAG en el pipeline',
     help: 'Si está activo, antes de cada iteración se inyecta contexto del vector store en el prompt del coder.',
@@ -195,6 +225,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'ragPreloadTopK',
     path: 'rag.preload.topK',
+    category: 'rag',
     type: 'number',
     label: 'Nº de chunks a pre-cargar (topK)',
     help: 'Cuántos fragmentos del vector store se inyectan como contexto. 3-5 funciona bien; subir gasta tokens.',
@@ -205,6 +236,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'ragPreloadScope',
     path: 'rag.preload.scope',
+    category: 'rag',
     type: 'select',
     label: 'Scope de la pre-carga RAG',
     help: '"all" mezcla todo. "code" solo busca en el código indexado, "plans" en planes previos, "onboarding" en el brief del proyecto.',
@@ -214,6 +246,7 @@ export const EDITABLE_FIELDS = [
   {
     key: 'ragEmbedderProvider',
     path: 'rag.embedder.provider',
+    category: 'rag',
     type: 'select',
     label: 'Proveedor de embeddings RAG',
     help: 'Ollama local es gratis. OpenAI/Voyage/Cohere/Mistral son cloud (requieren API key). ONNX corre 100% local con @huggingface/transformers.',
@@ -331,7 +364,11 @@ export function readConfig() {
     if (value === undefined) value = f.default;
     return { ...f, value };
   });
-  return { path: p, exists, fields, raw: parsed };
+  // v2.30.0 — also expose CATEGORIES so the modal can render grouped
+  // sections without re-importing the constant client-side. Ordered
+  // by `order` for deterministic UI.
+  const categories = [...CATEGORIES].sort((a, b) => (a.order ?? 999) - (b.order ?? 999));
+  return { path: p, exists, fields, categories, raw: parsed };
 }
 
 /**

--- a/tests/board/config-yaml-categories.test.js
+++ b/tests/board/config-yaml-categories.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// v2.30.0 — Categories metadata for the grouped settings modal.
+// Verifies that:
+//   1. CATEGORIES exposes the documented sections with id/label/icon/order.
+//   2. Every EDITABLE_FIELDS entry declares a `category` that maps to a
+//      known CATEGORY id (no silent "Otros" fallback hiding misspellings).
+//   3. The grouping the UI relies on is consistent with the documented
+//      buckets (agents/pipeline/rag/session/quality).
+//   4. readConfig() echoes categories so the client can render sections
+//      without re-importing the constant.
+
+let home;
+let originalEnv;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kj-cfg-cats-"));
+  originalEnv = process.env.KARAJAN_HOME;
+  process.env.KARAJAN_HOME = home;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const { readConfig, EDITABLE_FIELDS, CATEGORIES } = await import(
+  "../../packages/hu-board/src/config-yaml.js"
+);
+
+describe("config-yaml — categories metadata (v2.30.0)", () => {
+  it("exports the five documented categories with id/label/icon/order", () => {
+    expect(Array.isArray(CATEGORIES)).toBe(true);
+    const ids = CATEGORIES.map((c) => c.id);
+    expect(ids).toEqual(
+      expect.arrayContaining(["agents", "pipeline", "rag", "session", "quality"]),
+    );
+    for (const cat of CATEGORIES) {
+      expect(typeof cat.id).toBe("string");
+      expect(typeof cat.label).toBe("string");
+      expect(cat.label.length).toBeGreaterThan(0);
+      expect(typeof cat.icon).toBe("string");
+      expect(typeof cat.order).toBe("number");
+    }
+  });
+
+  it("every EDITABLE_FIELDS entry declares a category that maps to a known CATEGORY id", () => {
+    const validIds = new Set(CATEGORIES.map((c) => c.id));
+    for (const f of EDITABLE_FIELDS) {
+      expect(f.category, `field ${f.key} is missing a category`).toBeDefined();
+      expect(
+        validIds.has(f.category),
+        `field ${f.key} has unknown category "${f.category}"`,
+      ).toBe(true);
+    }
+  });
+
+  it("groups the documented fields into the expected buckets", () => {
+    const byCat = (id) => EDITABLE_FIELDS.filter((f) => f.category === id).map((f) => f.key);
+    expect(byCat("agents")).toEqual(["coder", "reviewer", "modelMode"]);
+    expect(byCat("session")).toEqual(["maxIterationMinutes", "maxTotalMinutes"]);
+    expect(byCat("quality")).toEqual(["sonarEnabled"]);
+    expect(byCat("pipeline")).toEqual([
+      "plannerEnabled",
+      "researcherEnabled",
+      "architectEnabled",
+      "testerEnabled",
+      "securityEnabled",
+      "refactorerEnabled",
+      "impeccableEnabled",
+      "brainEnabled",
+    ]);
+    expect(byCat("rag")).toEqual([
+      "ragPreloadEnabled",
+      "ragPreloadTopK",
+      "ragPreloadScope",
+      "ragEmbedderProvider",
+    ]);
+  });
+
+  it("readConfig() returns categories sorted by order", () => {
+    const out = readConfig();
+    expect(Array.isArray(out.categories)).toBe(true);
+    expect(out.categories.length).toBe(CATEGORIES.length);
+    const orders = out.categories.map((c) => c.order ?? 999);
+    const sorted = [...orders].sort((a, b) => a - b);
+    expect(orders).toEqual(sorted);
+  });
+});


### PR DESCRIPTION
## Summary

The HU Board config modal (introduced in v2.29.x and grown in PR1/PR2 of
v2.30.0) renders 15 editable fields in a single flat list — agents, session
timeouts, quality gates, 8 pipeline toggles and 4 RAG controls all mixed
together. Past ~5 entries the modal stops being scannable.

This PR groups the fields into **five documented sections**:

| Section | Icon | Fields |
|---|---|---|
| Agentes y modelos | 🤖 | coder, reviewer, modelMode |
| Roles del pipeline | 🔌 | 8 \*Enabled toggles |
| RAG (búsqueda de contexto) | 📚 | 4 rag\* controls |
| Tiempos de sesión | ⏱ | maxIterationMinutes, maxTotalMinutes |
| Calidad | ✅ | sonarEnabled |

### Server-side

`packages/hu-board/src/config-yaml.js`:

- New exported `CATEGORIES` constant with `{id, label, icon, order}` per section.
- New `category` field on every `EDITABLE_FIELDS` entry.
- `readConfig()` returns `categories` sorted by order so the client doesn't
  need to re-import the constant.

### Client-side

`packages/hu-board/public/app.js::showConfigEditor()`:

- Groups `cfg.fields` by `f.category`, renders a `<section>` per group with
  a `<h3>` header (icon + label).
- Defensive fallback: any field without a known category lands in an
  \"Otros\" bucket so a future field is never silently dropped from the UI.

### Test

`tests/board/config-yaml-categories.test.js` (NEW, 93 LOC):

1. CATEGORIES exposes the five documented sections with full metadata.
2. Every EDITABLE_FIELDS entry declares a category that maps to a known id.
3. The bucketing matches the documented per-section field lists.
4. `readConfig()` echoes categories sorted by \`order\`.

## LOC

168 added / 3 deleted — under the 200-LOC project cap.

## Test plan

- [x] \`npx vitest run tests/board/config-yaml-categories.test.js\` → 4/4 green
- [x] Existing \`config-yaml-rag-controls.test.js\` + \`config-yaml-pipeline-toggles.test.js\` still pass
- [ ] Manual smoke: open the board, click ⚙, verify 5 sections render in the documented order, save a value from each section

## Cards

- KJC-TSK-0452 — Writable config UI on HU Board — grouped sections (v2.30.0 PR3)