### PR TITLE
feat(board): config scope toggle global vs per-project (v2.30.0 PR4)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -3272,10 +3272,14 @@ function handleRoute() {
 // row. `select` → <select>, `boolean` → <input type=checkbox>,
 // `number` → <input type=number min/max>. Help text under each
 // label as a small grey paragraph.
-async function showConfigEditor() {
+async function showConfigEditor(scope = 'global') {
+  // v2.30.0 PR4 — scope toggle. 'global' edita ~/.karajan/kj.config.yml
+  // (afecta a todos los proyectos); 'project' edita
+  // <projectDir>/.karajan/kj.config.yml (sólo el repo actual). El backend
+  // resuelve <projectDir> desde KJ_PROJECT_DIR || cwd.
   let cfg;
   try {
-    const r = await fetch('/api/config');
+    const r = await fetch(`/api/config?scope=${encodeURIComponent(scope)}`);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     cfg = await r.json();
   } catch (err) {
@@ -3341,11 +3345,28 @@ async function showConfigEditor() {
   }
   const sectionsHtml = allCats.map(renderSection).join('');
 
+  // PR4 — toggle global / proyecto. Cambiarlo recarga el modal contra el
+  // otro fichero. Visual: dos pills mutuamente excluyentes.
+  const pill = (id, value, label, active) => `
+    <button data-scope="${value}" id="${id}" type="button"
+      style="padding:4px 10px;border-radius:999px;border:1px solid var(--border);
+      background:${active ? 'var(--color-blue)' : 'var(--bg-primary)'};
+      color:${active ? '#fff' : 'var(--text)'};font-size:0.75rem;cursor:pointer;">
+      ${esc(label)}
+    </button>`;
+  const scopeToggle = `
+    <div style="display:flex;align-items:center;gap:4px;margin-left:auto;" role="radiogroup" aria-label="Ámbito de configuración">
+      ${pill('cfg-scope-global',  'global',  'Global',         scope === 'global')}
+      ${pill('cfg-scope-project', 'project', 'Este proyecto',  scope === 'project')}
+    </div>`;
   dlg.innerHTML = `
     <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:700;display:flex;align-items:center;gap:10px;">
       <span style="font-size:1.2rem;">⚙</span>
       <span>Configuración de Karajan</span>
-      <span style="margin-left:auto;font-family:var(--font-mono,monospace);font-size:0.75rem;color:var(--text-muted);">${esc(cfg.path || '')}</span>
+      ${scopeToggle}
+    </div>
+    <div style="padding:6px 18px 0;font-family:var(--font-mono,monospace);font-size:0.7rem;color:var(--text-muted);">
+      ${esc(cfg.path || '')}${cfg.exists === false ? ' · (aún no existe, se creará al guardar)' : ''}
     </div>
     <div style="padding:14px 18px;max-height:65vh;overflow:auto;">
       ${sectionsHtml}
@@ -3360,6 +3381,15 @@ async function showConfigEditor() {
     </div>
   `;
   if (typeof dlg.showModal === 'function' && !dlg.open) dlg.showModal();
+  // PR4 — al cambiar de pill, recargar el modal con el otro scope.
+  for (const btn of dlg.querySelectorAll('[data-scope]')) {
+    btn.addEventListener('click', () => {
+      const next = btn.getAttribute('data-scope');
+      if (next === scope) return;
+      try { dlg.close(); } catch { /* ignore */ }
+      showConfigEditor(next);
+    }, { once: true });
+  }
   dlg.querySelector('#config-cancel')?.addEventListener('click', () => { try { dlg.close(); } catch { /* ignore */ } }, { once: true });
   dlg.querySelector('#config-save')?.addEventListener('click', async () => {
     // Build the patch from the form, comparing against initial values
@@ -3382,7 +3412,7 @@ async function showConfigEditor() {
       const r = await fetch('/api/config', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ patch }),
+        body: JSON.stringify({ patch, scope }),
       });
       if (!r.ok) {
         const body = await r.json().catch(() => ({}));

--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -34,7 +34,29 @@ import { tmpdir } from 'node:os';
 import yaml from 'js-yaml';
 import { getKjHome } from './db.js';
 
-function configPath() {
+/**
+ * v2.30.0 PR4 — scope resolver.
+ *
+ *   'global'  → ~/.karajan/kj.config.yml (mismo path que el resto de
+ *               Karajan; afecta a todos los proyectos).
+ *   'project' → <projectDir>/.karajan/kj.config.yml (override por
+ *               proyecto; cuando existe, el loader del padre lo prefiere
+ *               sobre el global).
+ *
+ * projectDir se resuelve desde `KJ_PROJECT_DIR` (ya usado por
+ * journal-parser.js) con fallback a `process.cwd()` — el board se
+ * arranca desde el repo del usuario, así que cwd es el proyecto.
+ */
+export const SCOPES = ['global', 'project'];
+
+function getProjectDir() {
+  return process.env.KJ_PROJECT_DIR || process.cwd();
+}
+
+function configPath(scope = 'global') {
+  if (scope === 'project') {
+    return join(getProjectDir(), '.karajan', 'kj.config.yml');
+  }
   // Same path the parent uses (src/utils/paths.js::getKarajanHome).
   // KJC-TSK-0420: delegate to db.js::getKjHome — gives us KARAJAN_HOME
   // priority + KJ_HOME fallback + VITEST guard from one place, instead
@@ -42,7 +64,7 @@ function configPath() {
   return join(getKjHome(), 'kj.config.yml');
 }
 
-function backupPath() { return `${configPath()}.bak`; }
+function backupPath(scope = 'global') { return `${configPath(scope)}.bak`; }
 
 /**
  * v2.30.0 — Categorías para agrupar los campos en el modal. El backend
@@ -345,8 +367,13 @@ function applyModelMode(parsed, mode) {
  *
  * Returns sane defaults when the file doesn't exist yet.
  */
-export function readConfig() {
-  const p = configPath();
+export function readConfig({ scope = 'global' } = {}) {
+  // PR4 — accept scope. Default 'global' preserves the previous behavior;
+  // 'project' reads <projectDir>/.karajan/kj.config.yml.
+  if (!SCOPES.includes(scope)) {
+    throw new Error(`Scope inválido: ${scope}. Permitidos: ${SCOPES.join(', ')}`);
+  }
+  const p = configPath(scope);
   let parsed = {};
   let exists = false;
   if (existsSync(p)) {
@@ -368,7 +395,7 @@ export function readConfig() {
   // sections without re-importing the constant client-side. Ordered
   // by `order` for deterministic UI.
   const categories = [...CATEGORIES].sort((a, b) => (a.order ?? 999) - (b.order ?? 999));
-  return { path: p, exists, fields, categories, raw: parsed };
+  return { path: p, scope, exists, fields, categories, raw: parsed };
 }
 
 /**
@@ -378,16 +405,20 @@ export function readConfig() {
  *
  * @returns {{ path: string, written: boolean, applied: object[], errors: string[] }}
  */
-export function writeConfigPatch(patch) {
+export function writeConfigPatch(patch, { scope = 'global' } = {}) {
+  // PR4 — same shape as readConfig: scope decides target file.
+  if (!SCOPES.includes(scope)) {
+    return { path: '', scope, written: false, applied: [], errors: [`Scope inválido: ${scope}. Permitidos: ${SCOPES.join(', ')}`] };
+  }
   if (!patch || typeof patch !== 'object') {
-    return { path: configPath(), written: false, applied: [], errors: ['patch debe ser un objeto'] };
+    return { path: configPath(scope), scope, written: false, applied: [], errors: ['patch debe ser un objeto'] };
   }
   // Read current state (or empty if file doesn't exist yet).
-  const p = configPath();
+  const p = configPath(scope);
   let parsed = {};
   if (existsSync(p)) {
     try { parsed = yaml.load(readFileSync(p, 'utf8'), { json: true }) || {}; }
-    catch (err) { return { path: p, written: false, applied: [], errors: [`No se pudo parsear el yml actual: ${err.message}`] }; }
+    catch (err) { return { path: p, scope, written: false, applied: [], errors: [`No se pudo parsear el yml actual: ${err.message}`] }; }
   }
   const errors = [];
   const applied = [];
@@ -414,18 +445,18 @@ export function writeConfigPatch(patch) {
     else setDeep(parsed, field.path, field.type === 'number' ? Number(val) : val);
     applied.push({ key, value: val });
   }
-  if (errors.length > 0) return { path: p, written: false, applied, errors };
+  if (errors.length > 0) return { path: p, scope, written: false, applied, errors };
 
   // Write atomically: serialize → write to .tmp → rename. Backup the
   // existing file first so the user can recover.
   const dir = dirname(p);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  if (existsSync(p)) { try { copyFileSync(p, backupPath()); } catch { /* best-effort */ } }
+  if (existsSync(p)) { try { copyFileSync(p, backupPath(scope)); } catch { /* best-effort */ } }
   const dump = yaml.dump(parsed, { lineWidth: 120 });
   // mkstemp would be nicer but we want to stay in the same dir for
   // a guaranteed-atomic rename across the same filesystem.
   const tmpFile = join(dir, `.kj.config.yml.${process.pid}.${Date.now()}.tmp`);
   writeFileSync(tmpFile, dump, 'utf8');
   renameSync(tmpFile, p);
-  return { path: p, written: true, applied, errors: [] };
+  return { path: p, scope, written: true, applied, errors: [] };
 }

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1031,29 +1031,41 @@ router.post('/projects/:id/run', (req, res) => {
 });
 
 /**
- * GET /api/config — read the editable subset of ~/.karajan/kj.config.yml.
+ * GET /api/config — read the editable subset of the kj.config.yml.
  * Powers the board's settings modal; non-editable keys in the yml are
  * left untouched on PUT (see writeConfigPatch's whitelist semantics).
+ *
+ * v2.30.0 PR4 — supports `?scope=global|project`:
+ *   - `global` (default): reads ~/.karajan/kj.config.yml.
+ *   - `project`: reads <projectDir>/.karajan/kj.config.yml.
+ * Unknown scopes are 400'd. Response includes the resolved `scope` and
+ * `path` so the UI can show which file backs the current view.
  */
-router.get('/config', (_req, res) => {
+router.get('/config', (req, res) => {
   try {
-    const data = readConfig();
+    const scope = req.query?.scope || 'global';
+    const data = readConfig({ scope });
     res.json(data);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    res.status(400).json({ error: err.message });
   }
 });
 
 /**
- * PUT /api/config — apply a patch to the yml. Body is `{ patch: { key: value } }`
- * with the keys defined in EDITABLE_FIELDS. Unknown keys are 400'd; type
- * errors are 400'd; validation errors are 400'd. Writes are atomic
- * (tmp + rename) and a `.bak` is kept of the previous content.
+ * PUT /api/config — apply a patch to the yml. Body is
+ * `{ patch: { key: value }, scope?: 'global'|'project' }` with the keys
+ * defined in EDITABLE_FIELDS. Unknown keys are 400'd; type errors are
+ * 400'd; validation errors are 400'd. Writes are atomic (tmp + rename)
+ * and a `.bak` is kept of the previous content.
+ *
+ * v2.30.0 PR4 — `scope` decides which file is patched. Default 'global'
+ * preserves the previous behavior.
  */
 router.put('/config', (req, res) => {
   try {
     const patch = req.body?.patch;
-    const result = writeConfigPatch(patch);
+    const scope = req.body?.scope || 'global';
+    const result = writeConfigPatch(patch, { scope });
     if (!result.written) {
       return res.status(400).json({ error: 'No se pudo guardar la configuración', details: result });
     }

--- a/tests/board/config-yaml-scope.test.js
+++ b/tests/board/config-yaml-scope.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+// v2.30.0 PR4 — Scope toggle for the writable config (global vs per-project).
+// Verifies that:
+//   1. readConfig() defaults to 'global' (back-compat).
+//   2. readConfig({ scope: 'project' }) targets <projectDir>/.karajan/kj.config.yml.
+//   3. writeConfigPatch routes writes by scope without leaking across files.
+//   4. Invalid scope is rejected on both read and write.
+//   5. Response shape includes the resolved `scope` so the UI can render it.
+
+let kjHome;
+let projectDir;
+let envBackup;
+
+beforeEach(() => {
+  kjHome = mkdtempSync(join(tmpdir(), "kj-cfg-scope-home-"));
+  projectDir = mkdtempSync(join(tmpdir(), "kj-cfg-scope-proj-"));
+  envBackup = {
+    KARAJAN_HOME: process.env.KARAJAN_HOME,
+    KJ_PROJECT_DIR: process.env.KJ_PROJECT_DIR,
+  };
+  process.env.KARAJAN_HOME = kjHome;
+  process.env.KJ_PROJECT_DIR = projectDir;
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(envBackup)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(kjHome, { recursive: true, force: true });
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+const { readConfig, writeConfigPatch, SCOPES } = await import(
+  "../../packages/hu-board/src/config-yaml.js"
+);
+
+describe("config-yaml — scope toggle (v2.30.0 PR4)", () => {
+  it("exports the documented scopes", () => {
+    expect(SCOPES).toEqual(expect.arrayContaining(["global", "project"]));
+  });
+
+  it("readConfig() defaults to 'global' and reports the scope", () => {
+    const out = readConfig();
+    expect(out.scope).toBe("global");
+    expect(out.path).toBe(join(kjHome, "kj.config.yml"));
+  });
+
+  it("readConfig({ scope: 'project' }) targets <projectDir>/.karajan/kj.config.yml", () => {
+    const out = readConfig({ scope: "project" });
+    expect(out.scope).toBe("project");
+    expect(out.path).toBe(join(projectDir, ".karajan", "kj.config.yml"));
+    expect(out.exists).toBe(false);
+  });
+
+  it("writes are routed by scope without leaking across files", () => {
+    const w1 = writeConfigPatch({ coder: "claude" }, { scope: "global" });
+    expect(w1.written).toBe(true);
+    expect(w1.scope).toBe("global");
+    expect(w1.path).toBe(join(kjHome, "kj.config.yml"));
+
+    const w2 = writeConfigPatch({ coder: "gemini" }, { scope: "project" });
+    expect(w2.written).toBe(true);
+    expect(w2.scope).toBe("project");
+    expect(w2.path).toBe(join(projectDir, ".karajan", "kj.config.yml"));
+
+    const globalYml = yaml.load(readFileSync(join(kjHome, "kj.config.yml"), "utf8"));
+    const projectYml = yaml.load(
+      readFileSync(join(projectDir, ".karajan", "kj.config.yml"), "utf8"),
+    );
+    expect(globalYml.coder).toBe("claude");
+    expect(projectYml.coder).toBe("gemini");
+
+    const readGlobal = readConfig({ scope: "global" });
+    const readProject = readConfig({ scope: "project" });
+    const fGlobal = readGlobal.fields.find((f) => f.key === "coder");
+    const fProject = readProject.fields.find((f) => f.key === "coder");
+    expect(fGlobal.value).toBe("claude");
+    expect(fProject.value).toBe("gemini");
+  });
+
+  it("project scope creates the .karajan directory on demand", () => {
+    const target = join(projectDir, ".karajan");
+    expect(existsSync(target)).toBe(false);
+    const r = writeConfigPatch({ sonarEnabled: true }, { scope: "project" });
+    expect(r.written).toBe(true);
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(join(target, "kj.config.yml"))).toBe(true);
+  });
+
+  it("rejects unknown scopes on read", () => {
+    expect(() => readConfig({ scope: "nope" })).toThrow(/Scope inválido/);
+  });
+
+  it("rejects unknown scopes on write without touching disk", () => {
+    const r = writeConfigPatch({ coder: "claude" }, { scope: "nope" });
+    expect(r.written).toBe(false);
+    expect(r.errors[0]).toMatch(/Scope inválido/);
+    expect(existsSync(join(kjHome, "kj.config.yml"))).toBe(false);
+    expect(existsSync(join(projectDir, ".karajan", "kj.config.yml"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

PR4 of v2.30.0 — adds scope toggle (global vs per-project) to the HU Board writable config UI.

- New `SCOPES = ['global', 'project']` export in `config-yaml.js`
- `'global'` → `~/.karajan/kj.config.yml` (default, back-compat)
- `'project'` → `<projectDir>/.karajan/kj.config.yml` (resolved via `KJ_PROJECT_DIR || cwd()`, same pattern as journal-parser)
- `readConfig({ scope })` and `writeConfigPatch(patch, { scope })` route reads/writes by scope without leaking across files
- API: `GET /api/config?scope=...` and `PUT /api/config` body `{ patch, scope }`
- UI: two-pill toggle in modal header; clicking switches scope; path line shows `(aún no existe, se creará al guardar)` when project file is missing
- Validation: unknown scopes rejected on both read (throws) and write (no disk touch)

## Stats

- 4 files changed, 205 insertions(+), 25 deletions(-) ≈ 180 NET LOC (under 200 budget)
- Tests: 23/23 config-yaml tests pass (7 new tests in `tests/board/config-yaml-scope.test.js`)

## Test plan

- [x] Test export of SCOPES
- [x] Default 'global' on `readConfig()` (back-compat)
- [x] `readConfig({ scope: 'project' })` targets `<projectDir>/.karajan/kj.config.yml`
- [x] Writes route by scope without cross-leak
- [x] Project scope creates `.karajan/` directory on demand
- [x] Invalid scope rejected on read (throw)
- [x] Invalid scope rejected on write (no disk write)