### PR TITLE
chore: release v2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.30.0] - 2026-05-26
+
+Minor release. **Writable config UI on HU Board** — the kj.config.yml is no longer an editor-only file. The board now exposes a settings modal with grouped sections, an atomic-write backend, and a scope toggle between global (`~/.karajan/`) and per-project (`<projectDir>/.karajan/`) configs.
+
+Four PRs land the UI end-to-end (PR1 pipeline toggles, PR2 RAG controls, PR3 grouped modal sections, PR4 scope toggle). Old hand-editing of YAML keeps working — the modal only writes the whitelisted fields and preserves everything else verbatim.
+
+### Added
+
+- **PR #854 (KJC-TSK-0450) — pipeline role toggles in writable config UI**. Eight new boolean fields exposed on the board modal (`pipeline.planner.enabled`, `researcher`, `architect`, `tester`, `security`, `refactorer`, `impeccable`, `brain`). Mirrors the source-of-truth defaults in `src/config/defaults.js`.
+- **PR #855 (KJC-TSK-0451) — RAG controls in writable config UI**. Four new fields: `rag.preload.enabled` (boolean), `rag.preload.topK` (1–20), `rag.preload.scope` (all/code/plans/onboarding), `rag.embedder.provider` (ollama/openai/voyage/cohere/mistral/onnx). The provider dropdown matches the six embedders shipped through v2.28.0–v2.29.0.
+- **PR #856 (KJC-TSK-0452) — grouped sections in config modal**. Fields are now categorised (Agentes y modelos, Roles del pipeline, RAG, Tiempos de sesión, Calidad) with icons and deterministic order. Backend exports a `CATEGORIES` array so the front renders sections without hard-coding. Unknown categories fall back to "Otros" (defensive — new fields never get dropped from the UI).
+- **PR #857 (KJC-TSK-0453) — config scope toggle (global vs per-project)**. New `SCOPES = ['global', 'project']` export. Two-pill toggle in the modal header lets the user switch between `~/.karajan/kj.config.yml` (global, default) and `<projectDir>/.karajan/kj.config.yml` (per-project override). The project file is created on demand on first save. `KJ_PROJECT_DIR || cwd()` resolution matches the journal-parser pattern. Atomic-write + `.bak` discipline applies to both scopes.
+
+### Tests
+
+5 216 / 5 216 passing in CI across 457 test files (+25 new tests across the 4 PRs, +1 new file `tests/board/config-yaml-scope.test.js`).
+
+### Internal
+
+- Single source of truth for editable fields: `packages/hu-board/src/config-yaml.js::EDITABLE_FIELDS` (UI metadata) + `CATEGORIES` (grouping) + `SCOPES` (target file). The front (`packages/hu-board/public/app.js`) iterates the backend metadata — no field is duplicated client-side.
+
 ## [2.29.0] - 2026-05-25
 
 Minor release. **RAG quality lift** — retrieval dashboard, three new embedder providers, metadata filtering, cross-encoder rerank.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.30.0 released** — Minor. **Writable config UI on HU Board** — settings modal with grouped sections, atomic-write backend, and a global vs per-project scope toggle. No more hand-editing the YAML.
+>
+> - **Pipeline role toggles** (PR #854): 8 nuevos booleanos en el modal (`planner`, `researcher`, `architect`, `tester`, `security`, `refactorer`, `impeccable`, `brain`) reflejan los defaults reales de `src/config/defaults.js`.
+> - **RAG controls** (PR #855): `rag.preload.{enabled,topK,scope}` + `rag.embedder.provider` editables sin abrir el archivo. El dropdown del provider lista los 6 embedders (ollama / openai / voyage / cohere / mistral / onnx).
+> - **Grouped sections** (PR #856): los campos se agrupan por categoría (Agentes y modelos, Roles del pipeline, RAG, Tiempos de sesión, Calidad) con iconos y orden determinista. Campos nuevos sin categoría caen en "Otros" — defensivo.
+> - **Scope toggle global vs per-project** (PR #857): pill toggle en el header del modal. Switchea entre `~/.karajan/kj.config.yml` (global, default) y `<projectDir>/.karajan/kj.config.yml` (override del proyecto, se crea al guardar). Atomic-write + `.bak` aplican a ambos.
+>
 > **v2.29.0 released** — Minor. **RAG quality lift** — dashboard + three new providers + metadata filter + rerank.
 >
 > - **Retrieval dashboard on HU Board** (PR #843): nuevo `/rag.html` con embedder activo, tamaño de DB, last-index, chunks por kind, chunks por proyecto. Primera pieza del config UI que llega completo en v2.30.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.29.0
+kj --version    # 2.30.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.29.0
+kj --version    # 2.30.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.29.0",
+      "version": "2.30.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

Release v2.30.0 — **Writable config UI on HU Board**.

Bundles 4 already-merged PRs:

- PR #854 (KJC-TSK-0450) — pipeline role toggles (8 booleans)
- PR #855 (KJC-TSK-0451) — RAG controls (preload + embedder provider)
- PR #856 (KJC-TSK-0452) — grouped sections in config modal
- PR #857 (KJC-TSK-0453) — scope toggle global vs per-project

The kj.config.yml is no longer an editor-only file. The board now exposes a settings modal with grouped sections, atomic-write backend, and a scope toggle. Old hand-editing keeps working — the modal only writes the whitelisted fields and preserves everything else verbatim.

## Bump

- package.json: 2.29.0 → 2.30.0
- package-lock.json regenerated

## Docs touched

- CHANGELOG.md — new [2.30.0] entry
- README.md — Recent releases banner
- docs/GETTING-STARTED.md + es/ — kj --version comment

## Tests

5 216 / 5 216 passing in CI across 457 files (+25 new tests across the 4 PRs).

## Test plan

- [x] CHANGELOG entry added
- [x] package.json version bumped
- [x] package-lock.json regenerated
- [x] README banner updated
- [x] GETTING-STARTED docs updated (EN + ES)
- [ ] Tag + gh release + npm publish (after merge)
- [ ] Landing build + deploy (after merge)