### PR TITLE
feat(plan): loadPlan fallback to .karajan-shared/ (KJC-PRP-0002 PR1a)

### DIFF
--- a/src/plan/plan-store.js
+++ b/src/plan/plan-store.js
@@ -8,6 +8,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { writeJsonAtomic } from "../utils/atomic-write.js";
 import { resolveHome } from "../utils/paths.js";
+import { getSharedPlansDir } from "../utils/shared-paths.js";
 import { generatePlanId, normaliseAlias } from "./plan-id.js";
 
 /**
@@ -154,7 +155,15 @@ async function resolveUniqueAlias(dir, ownPlanId, base) {
  */
 export async function loadPlan(projectDir, ref) {
   if (!ref) return null;
-  const dir = plansDir(projectDir);
+  // Local plans take precedence — if a teammate's shared copy and your
+  // working copy share a planId, your local edits win until you re-share.
+  const local = await loadPlanFromDir(plansDir(projectDir), ref);
+  if (local) return local;
+  // Fallback: shared plans committed by a teammate. KJC-PRP-0002 PR1.
+  return loadPlanFromDir(getSharedPlansDir(projectDir), ref);
+}
+
+async function loadPlanFromDir(dir, ref) {
   // 1. Match exacto por planId.json (camino caliente).
   const direct = path.join(dir, `${ref}.json`);
   try {

--- a/src/utils/shared-paths.js
+++ b/src/utils/shared-paths.js
@@ -1,0 +1,41 @@
+/**
+ * Team-shared HU Board paths — KJC-PRP-0002 / v2.31.0 PR1.
+ *
+ * The shared root lives INSIDE the project, not in `~/.karajan/`, so a team
+ * can commit it to git (or sync via Drive/SyncThing) and share plans + HU
+ * stories without each member regenerating them locally.
+ *
+ *   <projectDir>/.karajan-shared/
+ *     plans/<planId>.json     ← `kj plan share <planId>` copies here
+ *     hu-stories/<huId>.md    ← reserved for PR2+ (board reads it)
+ *
+ * Keep the dir name in lockstep with the HU Board sync layer
+ * (`packages/hu-board/src/sync.js`) — diverging the constant breaks the
+ * watcher silently. One source of truth lives here.
+ */
+
+import path from "node:path";
+
+export const SHARED_DIR_NAME = ".karajan-shared";
+
+export function getSharedRoot(projectDir) {
+  return path.join(projectDir, SHARED_DIR_NAME);
+}
+
+export function getSharedPlansDir(projectDir) {
+  return path.join(getSharedRoot(projectDir), "plans");
+}
+
+export function getSharedHuStoriesDir(projectDir) {
+  return path.join(getSharedRoot(projectDir), "hu-stories");
+}
+
+/**
+ * Quick check used by callers that decide whether a plan came from local
+ * (`~/.karajan/plans/`) or from the shared dir. The HU Board uses this to
+ * stamp a `source` column on each record so the UI can render a 🌐 badge.
+ */
+export function isSharedPath(p) {
+  if (!p) return false;
+  return p.split(path.sep).includes(SHARED_DIR_NAME);
+}

--- a/tests/plan/plan-store-shared-fallback.test.js
+++ b/tests/plan/plan-store-shared-fallback.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+// loadPlan falls back to <projectDir>/.karajan-shared/plans/ when the
+// plan is not found in the per-user `~/.karajan/plans/<slug>/`.
+// KJC-PRP-0002 PR1.
+
+describe("plan-store loadPlan — shared-dir fallback (KJC-PRP-0002 PR1)", () => {
+  let projectDir;
+  const originalKjHome = process.env.KJ_HOME;
+  const originalKarajanHome = process.env.KARAJAN_HOME;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "kjc-shared-fallback-"));
+  });
+
+  afterEach(async () => {
+    if (originalKjHome !== undefined) process.env.KJ_HOME = originalKjHome;
+    else delete process.env.KJ_HOME;
+    if (originalKarajanHome !== undefined) process.env.KARAJAN_HOME = originalKarajanHome;
+    else delete process.env.KARAJAN_HOME;
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("loads from .karajan-shared/plans when the local dir has no copy", async () => {
+    const { loadPlan } = await import("../../src/plan/plan-store.js");
+    const sharedDir = path.join(projectDir, ".karajan-shared", "plans");
+    await fs.mkdir(sharedDir, { recursive: true });
+    const plan = {
+      version: 2,
+      planId: "plan-team-shared-001",
+      task: "shared fixture",
+      hus: [],
+      status: "draft",
+      createdAt: "2026-05-26T00:00:00Z",
+    };
+    await fs.writeFile(path.join(sharedDir, "plan-team-shared-001.json"), JSON.stringify(plan));
+
+    const loaded = await loadPlan(projectDir, "plan-team-shared-001");
+    expect(loaded).not.toBeNull();
+    expect(loaded.planId).toBe("plan-team-shared-001");
+    expect(loaded.task).toBe("shared fixture");
+  });
+
+  it("local plan wins over the shared copy when both exist", async () => {
+    const { savePlan, loadPlan } = await import("../../src/plan/plan-store.js");
+    await savePlan(projectDir, {
+      version: 2,
+      planId: "plan-collision-001",
+      task: "local wins",
+      hus: [],
+      status: "draft",
+      createdAt: "2026-05-26T00:00:00Z",
+    });
+
+    const sharedDir = path.join(projectDir, ".karajan-shared", "plans");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sharedDir, "plan-collision-001.json"),
+      JSON.stringify({
+        version: 2,
+        planId: "plan-collision-001",
+        task: "shared loses",
+        hus: [],
+        status: "draft",
+        createdAt: "2026-05-26T00:00:00Z",
+      })
+    );
+
+    const loaded = await loadPlan(projectDir, "plan-collision-001");
+    expect(loaded.task).toBe("local wins");
+  });
+
+  it("resolves shared plans by alias too", async () => {
+    const { loadPlan } = await import("../../src/plan/plan-store.js");
+    const sharedDir = path.join(projectDir, ".karajan-shared", "plans");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sharedDir, "plan-aliased-001.json"),
+      JSON.stringify({
+        version: 2,
+        planId: "plan-aliased-001",
+        alias: "auth-rework",
+        task: "by alias",
+        hus: [],
+        status: "draft",
+        createdAt: "2026-05-26T00:00:00Z",
+      })
+    );
+
+    const loaded = await loadPlan(projectDir, "auth-rework");
+    expect(loaded).not.toBeNull();
+    expect(loaded.planId).toBe("plan-aliased-001");
+  });
+
+  it("returns null when neither local nor shared has the plan", async () => {
+    const { loadPlan } = await import("../../src/plan/plan-store.js");
+    const loaded = await loadPlan(projectDir, "plan-does-not-exist");
+    expect(loaded).toBeNull();
+  });
+});

--- a/tests/utils/shared-paths.test.js
+++ b/tests/utils/shared-paths.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import {
+  SHARED_DIR_NAME,
+  getSharedRoot,
+  getSharedPlansDir,
+  getSharedHuStoriesDir,
+  isSharedPath,
+} from "../../src/utils/shared-paths.js";
+
+describe("shared-paths — KJC-PRP-0002 PR1", () => {
+  const projectDir = "/tmp/fake/project";
+
+  it("exposes the canonical dir name", () => {
+    expect(SHARED_DIR_NAME).toBe(".karajan-shared");
+  });
+
+  it("builds the shared root under <projectDir>/.karajan-shared", () => {
+    expect(getSharedRoot(projectDir)).toBe(path.join(projectDir, ".karajan-shared"));
+  });
+
+  it("builds plans and hu-stories subdirs", () => {
+    expect(getSharedPlansDir(projectDir)).toBe(path.join(projectDir, ".karajan-shared", "plans"));
+    expect(getSharedHuStoriesDir(projectDir)).toBe(path.join(projectDir, ".karajan-shared", "hu-stories"));
+  });
+
+  it("isSharedPath flags paths under the shared dir", () => {
+    expect(isSharedPath(path.join(projectDir, ".karajan-shared", "plans", "plan-x.json"))).toBe(true);
+    expect(isSharedPath(path.join(projectDir, "src", "x.js"))).toBe(false);
+    expect(isSharedPath(null)).toBe(false);
+    expect(isSharedPath("")).toBe(false);
+  });
+
+  it("isSharedPath only matches the exact segment, not substrings", () => {
+    // A directory called `my.karajan-shared.bak` must NOT match.
+    expect(isSharedPath(path.join(projectDir, "my.karajan-shared.bak", "x"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of v2.31.0 (team-shared HU Board, KJC-PRP-0002).

- Adds `<projectDir>/.karajan-shared/` as the team-shared root inside each project (committable to git or syncable via Drive/SyncThing).
- `loadPlan(projectDir, ref)` now reads the per-user dir first and **falls back** to `.karajan-shared/plans/` when nothing matches. Local wins on collision so your in-flight edits aren't shadowed.
- New `src/utils/shared-paths.js` centralises the dir name + `plans/`, `hu-stories/` subpaths. PR2 (HU Board sync) will import the same constant so the watcher and the loader can never diverge silently.

This is the **consumer half**: anything that drops a `.karajan-shared/plans/<planId>.json` (manually committed, scripted, or — coming in PR1b — produced by `kj plan share`) becomes visible to the existing system with no other changes.

## Scope notes

- Net delta: **+191 LOC** (target ≤200). PR1b (the `kj plan share` command + ~140 LOC) ships separately to keep the budget atomic.
- No public API renamed or removed. `loadPlan` signature unchanged.
- `tests/architecture/dynamic-imports.test.js` budget untouched — only static imports added.

## Test plan

- [x] `npx vitest run tests/utils/shared-paths.test.js tests/plan/plan-store-shared-fallback.test.js` → **9/9 passing**
  - shared-paths: constant value, root/plans/hu-stories paths, `isSharedPath` segment-only matching (rejects `my.karajan-shared.bak` substrings)
  - plan-store fallback: loads from shared when local empty, local wins precedence, alias resolution in shared, returns null when neither has plan
- [x] `npx vitest run tests/plan/` → **253/253 passing** (no regression in the existing plan-store suite)
- [ ] CI: lint + full vitest + e2e + shrink-budget