### PR TITLE
feat(plan): kj plan share command (KJC-PRP-0002 PR1b)

### DIFF
--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -9,6 +9,7 @@ import {
   planRemoveHuCommand,
   planMigrateResultCommand,
   planFixCommand,
+  planShareCommand,
 } from "../commands/plan.js";
 import { parseCanvasMarkdown } from "../canvas/parse-md.js";
 import { validateCanvas } from "../canvas/validate.js";
@@ -139,6 +140,19 @@ export function registerPlan(program, { pkgVersion }) {
       await planDeleteCommand({ config, planId });
     });
   });
+
+  // KJC-PRP-0002 / v2.31.0 PR1: promote a local plan into the project's
+  // `.karajan-shared/plans/` so teammates picking up the repo (or the same
+  // dev on another machine) see it in their HU Board without re-running
+  // the planner. The shared dir is meant to be committed to git.
+  plan.command("share")
+    .description("Promote a local plan to <projectDir>/.karajan-shared/ so the team can see it")
+    .argument("<planId>")
+    .action(async (planId, flags) => {
+      await withConfig(pkgVersion, "plan", flags, async ({ config, logger }) => {
+        await planShareCommand({ config, planId, logger });
+      });
+    });
 
   plan.command("add-hu").description("Add HU to plan").argument("<planId>")
     .option("--title <text>", "HU title")

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -12,4 +12,5 @@ export {
   planRemoveHuCommand,
   planMigrateResultCommand,
   planFixCommand,
+  planShareCommand,
 } from "./plan/index.js";

--- a/src/commands/plan/index.js
+++ b/src/commands/plan/index.js
@@ -9,3 +9,4 @@ export { planAddHuCommand } from "./add-hu.js";
 export { planRemoveHuCommand } from "./remove-hu.js";
 export { planMigrateResultCommand } from "./migrate-result.js";
 export { planFixCommand } from "./fix.js";
+export { planShareCommand } from "./share.js";

--- a/src/commands/plan/share.js
+++ b/src/commands/plan/share.js
@@ -1,0 +1,44 @@
+/**
+ * kj plan share <planId>
+ *
+ * Promotes a local plan (under `~/.karajan/plans/<projectSlug>/`) to the
+ * project's shared dir (`<projectDir>/.karajan-shared/plans/`) so teammates
+ * pulling the repo see the same HUs in their HU Board. KJC-PRP-0002 / PR1.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { writeJsonAtomic } from "../../utils/atomic-write.js";
+import { getSharedPlansDir } from "../../utils/shared-paths.js";
+import { loadPlan } from "../../plan/plan-store.js";
+
+export async function planShareCommand({ config, planId, logger }) {
+  const log = logger || console;
+  const projectDir = config.projectDir || process.cwd();
+
+  if (!planId) {
+    log.error?.("kj plan share <planId> — planId is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const plan = await loadPlan(projectDir, planId);
+  if (!plan) {
+    log.error?.(`Plan not found: ${planId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sharedDir = getSharedPlansDir(projectDir);
+  await fs.mkdir(sharedDir, { recursive: true });
+  const targetFile = path.join(sharedDir, `${plan.planId}.json`);
+
+  // Stamp a `shared: true` marker so consumers (board sync, audit, etc.)
+  // can tell promoted copies from local ones without inspecting the path.
+  const sharedPlan = { ...plan, shared: true, sharedAt: new Date().toISOString() };
+  await writeJsonAtomic(targetFile, sharedPlan);
+
+  const rel = path.relative(projectDir, targetFile);
+  log.info?.(`✓ Shared plan ${plan.planId} → ${rel}`);
+  log.info?.(`  Commit '.karajan-shared/' so your team picks it up.`);
+}

--- a/tests/plan/plan-share.test.js
+++ b/tests/plan/plan-share.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { planShareCommand } from "../../src/commands/plan/share.js";
+
+describe("kj plan share — KJC-PRP-0002 PR1", () => {
+  let projectDir;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "kjc-plan-share-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  function makeLogger() {
+    const captured = { info: [], error: [] };
+    return {
+      info: (m) => captured.info.push(m),
+      error: (m) => captured.error.push(m),
+      captured,
+    };
+  }
+
+  it("promotes a local plan to <projectDir>/.karajan-shared/plans/", async () => {
+    const { savePlan } = await import("../../src/plan/plan-store.js");
+    await savePlan(projectDir, {
+      version: 2,
+      planId: "plan-share-001",
+      task: "shareable",
+      hus: [],
+      status: "draft",
+      createdAt: "2026-05-26T00:00:00Z",
+    });
+
+    const logger = makeLogger();
+    await planShareCommand({ config: { projectDir }, planId: "plan-share-001", logger });
+
+    const target = path.join(projectDir, ".karajan-shared", "plans", "plan-share-001.json");
+    const written = JSON.parse(await fs.readFile(target, "utf8"));
+    expect(written.planId).toBe("plan-share-001");
+    expect(written.shared).toBe(true);
+    expect(written.sharedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(logger.captured.info.join("\n")).toMatch(/Shared plan plan-share-001/);
+  });
+
+  it("exits with code 1 when planId is missing", async () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const logger = makeLogger();
+    await planShareCommand({ config: { projectDir }, planId: "", logger });
+    expect(process.exitCode).toBe(1);
+    expect(logger.captured.error.join("\n")).toMatch(/planId is required/);
+    process.exitCode = prev;
+  });
+
+  it("exits with code 1 when the plan is not found", async () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const logger = makeLogger();
+    await planShareCommand({ config: { projectDir }, planId: "plan-missing-999", logger });
+    expect(process.exitCode).toBe(1);
+    expect(logger.captured.error.join("\n")).toMatch(/Plan not found: plan-missing-999/);
+    process.exitCode = prev;
+  });
+
+  it("is idempotent — sharing twice rewrites the file without error", async () => {
+    const { savePlan } = await import("../../src/plan/plan-store.js");
+    await savePlan(projectDir, {
+      version: 2,
+      planId: "plan-share-idem-001",
+      task: "twice",
+      hus: [],
+      status: "draft",
+      createdAt: "2026-05-26T00:00:00Z",
+    });
+
+    await planShareCommand({ config: { projectDir }, planId: "plan-share-idem-001", logger: makeLogger() });
+    const target = path.join(projectDir, ".karajan-shared", "plans", "plan-share-idem-001.json");
+    const firstStamp = JSON.parse(await fs.readFile(target, "utf8")).sharedAt;
+
+    await new Promise((r) => setTimeout(r, 5));
+    await planShareCommand({ config: { projectDir }, planId: "plan-share-idem-001", logger: makeLogger() });
+    const secondStamp = JSON.parse(await fs.readFile(target, "utf8")).sharedAt;
+
+    expect(secondStamp >= firstStamp).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `kj plan share <planId>` — promotes a local plan from `~/.karajan/plans/<slug>/` to the project-relative `.karajan-shared/plans/` so teammates pulling the repo pick it up via the loadPlan fallback shipped in PR1a (#859).
- Stamps `shared: true` + `sharedAt` ISO marker so consumers (board sync, audit) can tell promoted copies from local ones without inspecting the path.
- Idempotent: re-running `kj plan share` rewrites the file with a fresh `sharedAt`.

Part of KJC-PRP-0002 (Team-shared HU Board, v2.31.0). PR2 will land HU Board sync over `.karajan-shared/`.

## Files
- `src/commands/plan/share.js` (NEW, 44 LOC) — `planShareCommand`
- `tests/plan/plan-share.test.js` (NEW, 91 LOC, 4 tests)
- `src/cli/register-plan.js` — register `plan share` subcommand
- `src/commands/plan.js` + `src/commands/plan/index.js` — barrel re-export

## Net delta
151 added, 0 removed. Within shrink-budget (200 LOC hard limit).

## Test plan
- [x] `npx vitest run tests/plan/plan-share.test.js` — 4/4 pass
- [x] success path: shared:true + sharedAt ISO + log line
- [x] missing planId → exitCode 1 + error log
- [x] plan not found → exitCode 1 + error log
- [x] idempotent re-share rewrites with newer timestamp