### PR TITLE
feat(board): scan .karajan-shared/plans/ for team-shared HUs (KJC-PRP-0002 PR2)

### DIFF
--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -14,6 +14,7 @@ import {
   removeTombstone,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
+import { getSharedPlansDir, SHARED_DIR_NAME } from '../../../src/utils/shared-paths.js';
 
 /**
  * Skip + best-effort fs cleanup when the resource is tombstoned. Returns
@@ -550,7 +551,46 @@ export function fullScan() {
     }
   }
 
+  // KJC-PRP-0002 PR2: team-shared plans live under <projectDir>/.karajan-shared/plans/
+  // (committed to git so teammates pulling the repo see the same HUs without
+  // having to re-run `kj plan generate`). The board reads them on top of the
+  // per-user `~/.karajan/plans/` cache. If both exist for the same planId,
+  // `syncPlanFile`'s upsert uses planId as key — last write wins, which is
+  // fine because both copies share the same content modulo the `shared:true`
+  // marker stamped by `kj plan share`.
+  scanSharedPlans();
+
   console.log('[sync] Full scan completed');
+}
+
+/**
+ * Scans `<projectDir>/.karajan-shared/plans/` for every known projectDir
+ * and feeds each plan into `syncPlanFile`. Discovery sources:
+ *   1. `process.cwd()` — covers the canonical case of running `kj board start`
+ *      from a project root with a freshly cloned `.karajan-shared/` and zero
+ *      local plans yet.
+ *   2. `KJ_SHARED_PROJECT_DIRS` env var (colon-separated paths) — escape
+ *      hatch for users running the board outside the project root or
+ *      tracking several repos with one board instance.
+ */
+function scanSharedPlans() {
+  const dirs = new Set([process.cwd()]);
+  const extra = process.env.KJ_SHARED_PROJECT_DIRS;
+  if (extra) {
+    for (const p of extra.split(':')) if (p) dirs.add(p);
+  }
+  for (const projectDir of dirs) {
+    const sharedDir = getSharedPlansDir(projectDir);
+    if (!existsSync(sharedDir)) continue;
+    try {
+      const files = readdirSync(sharedDir);
+      for (const file of files) {
+        if (file.startsWith('plan-') && file.endsWith('.json')) {
+          syncPlanFile(join(sharedDir, file));
+        }
+      }
+    } catch { /* skip */ }
+  }
 }
 
 /**
@@ -576,6 +616,17 @@ export function startWatcher() {
 
   const watchTargets = [storiesGlob, sessionsGlob, plansGlob, promptsGlob];
   if (legacyPlansGlob) watchTargets.push(legacyPlansGlob);
+  // KJC-PRP-0002 PR2: live-watch shared plans for the board's cwd + any
+  // dir listed in KJ_SHARED_PROJECT_DIRS. Without this, `kj plan share`
+  // updates would only land via the next fullScan / manual 🔄.
+  const sharedDirs = new Set([process.cwd()]);
+  const extraShared = process.env.KJ_SHARED_PROJECT_DIRS;
+  if (extraShared) {
+    for (const p of extraShared.split(':')) if (p) sharedDirs.add(p);
+  }
+  for (const d of sharedDirs) {
+    watchTargets.push(join(d, SHARED_DIR_NAME, 'plans', 'plan-*.json'));
+  }
   const watcher = watch(watchTargets, {
     ignoreInitial: true,
     awaitWriteFinish: { stabilityThreshold: 500, pollInterval: 100 },
@@ -585,6 +636,9 @@ export function startWatcher() {
     if (p.includes('hu-stories')) syncStoryFile(p);
     else if (p.includes('sessions')) syncSessionFile(p);
     else if (p.includes(`${plansRoot}${plansRoot.endsWith('/') ? '' : '/'}`) || p.includes('/plans/')) {
+      // Catches both per-user `~/.karajan/plans/<slug>/plan-*.json` and
+      // team-shared `<projectDir>/.karajan-shared/plans/plan-*.json` — the
+      // path-segment match `/plans/` is the same for both.
       syncPlanFile(p);
     } else if (p.includes('/prompts/')) {
       // Prompt files are RPC packets the runner writes when it needs

--- a/packages/hu-board/tests/sync-shared-plans.test.js
+++ b/packages/hu-board/tests/sync-shared-plans.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+// KJC-PRP-0002 PR2: HU Board sync scans `<projectDir>/.karajan-shared/plans/`
+// in addition to the per-user `~/.karajan/plans/` cache, so teammates pulling
+// the repo see the same HUs without re-running `kj plan`.
+
+let tmpDir;
+let projectADir;
+let projectBDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-shared-'));
+  process.env.KJ_HOME = tmpDir;
+  // Isolate the local plans dir so a stale `~/.karajan/plans/` on the
+  // dev's machine doesn't bleed into these fixtures.
+  process.env.KJ_PLANS_DIR = join(tmpDir, '_empty_plans_');
+  projectADir = join(tmpDir, 'projA');
+  projectBDir = join(tmpDir, 'projB');
+  mkdirSync(projectADir, { recursive: true });
+  mkdirSync(projectBDir, { recursive: true });
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../src/db.js');
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+  delete process.env.KJ_SHARED_PROJECT_DIRS;
+});
+
+async function setup() {
+  const db = await import('../src/db.js');
+  db.initDb();
+  const sync = await import('../src/sync.js');
+  return { db, sync };
+}
+
+function writeSharedPlan(projectDir, planId, extras = {}) {
+  const dir = join(projectDir, '.karajan-shared', 'plans');
+  mkdirSync(dir, { recursive: true });
+  const plan = {
+    version: 2,
+    planId,
+    task: extras.task || 'shared task',
+    projectDir,
+    name: extras.name || 'Shared Project',
+    hus: [{ id: 'hu-shared-01', status: 'pending', title: 'Login' }],
+    status: 'draft',
+    shared: true,
+    sharedAt: '2026-05-26T00:00:00Z',
+    createdAt: '2026-05-26T00:00:00Z',
+  };
+  writeFileSync(join(dir, `${planId}.json`), JSON.stringify(plan));
+  return plan;
+}
+
+function findProject(db, name) {
+  return db.getProjects().find((p) => p.name === name);
+}
+
+describe('HU Board sync — .karajan-shared/plans/ scan (KJC-PRP-0002 PR2)', () => {
+  it('imports a shared plan from process.cwd()/.karajan-shared/plans/', async () => {
+    const { db, sync } = await setup();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(projectADir);
+      writeSharedPlan(projectADir, 'plan-shared-001', { name: 'CwdProj' });
+      sync.fullScan();
+      const proj = findProject(db, 'CwdProj');
+      expect(proj).toBeTruthy();
+      const stories = db.getStoriesByProject(proj.id);
+      expect(stories.length).toBe(1);
+      expect(stories[0].title).toBe('Login');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it('honors KJ_SHARED_PROJECT_DIRS for boards running outside the project root', async () => {
+    const { db, sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = `${projectADir}:${projectBDir}`;
+    writeSharedPlan(projectADir, 'plan-mp-A', { name: 'ProjA' });
+    writeSharedPlan(projectBDir, 'plan-mp-B', { name: 'ProjB' });
+    sync.fullScan();
+    expect(findProject(db, 'ProjA')).toBeTruthy();
+    expect(findProject(db, 'ProjB')).toBeTruthy();
+  });
+
+  it('skips silently when .karajan-shared/plans/ does not exist', async () => {
+    const { sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = projectADir;
+    expect(() => sync.fullScan()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
HU Board's sync layer now also reads plans from `<projectDir>/.karajan-shared/plans/` on top of the per-user `~/.karajan/plans/` cache. A teammate cloning the repo runs `kj board start` and every HU that someone else has `kj plan share`'d shows up in their board immediately — no re-run of `kj plan`, no manual fiddling with `~/.karajan/`.

Closes the consumer side of KJC-PRP-0002. PR1a (#859) shipped the loadPlan fallback for CLI consumers; PR1b (#860) shipped `kj plan share`; this PR closes the loop by teaching the board where to look.

## Discovery sources
1. `process.cwd()/.karajan-shared/plans/` — canonical case (board started from the project root).
2. `KJ_SHARED_PROJECT_DIRS` env var (colon-separated paths) — escape hatch for boards tracking several repos or running outside any project root.

## Live updates
chokidar's watcher now also fires on `.karajan-shared/plans/plan-*.json` changes, so a teammate's `kj plan share` over a watched repo lands on the board without the user clicking 🔄.

## Files
- `packages/hu-board/src/sync.js` — new `scanSharedPlans()` helper invoked at the end of `runFullScan`, plus extra watch globs in `startWatcher`. Reuses `getSharedPlansDir` / `SHARED_DIR_NAME` from `src/utils/shared-paths.js` (PR1a) so the two layers can never disagree about the dir name.
- `packages/hu-board/tests/sync-shared-plans.test.js` — 3 new tests: cwd discovery, KJ_SHARED_PROJECT_DIRS multi-repo, missing dir is silent.

## Net delta
152 added, 0 removed. Within shrink-budget (200 LOC hard limit).

## Test plan
- [x] `npx vitest run packages/hu-board/tests/sync-shared-plans.test.js` — 3/3 pass
- [x] Full HU Board suite — 357/357 pass (no regression in existing sync.test.js / sync-orphan.test.js)
- [x] cwd discovery: plan stamped `name: "CwdProj"` lands on the board.
- [x] multi-repo via env: two plans across `projA` + `projB` both ingested.
- [x] empty / missing `.karajan-shared/plans/` → fullScan stays silent.