### PR TITLE
feat(plan): kj plan unshare + HU Board shared badge (KJC-PRP-0002 PR3)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -452,7 +452,7 @@ async function renderDashboard() {
               <button class="project-card__delete" title="Delete project (cascade)" data-project-id="${esc(p.id)}" data-project-name="${esc(p.name || p.id)}">🗑️</button>
               <button class="project-card__is-test" title="${esc(isTestTitle(p))}" data-project-id="${esc(p.id)}" data-is-test="${p.is_test === null || p.is_test === undefined ? '' : p.is_test}">${isTestIcon(p)}</button>
               <div class="project-card__body" onclick="selectProject('${esc(p.id)}')">
-                <div class="project-card__name">${esc(p.name || p.id)}</div>
+                <div class="project-card__name">${p.is_shared === 1 ? '<span class="project-card__shared-badge" title="Team-shared via .karajan-shared/">🔗</span> ' : ''}${esc(p.name || p.id)}</div>
                 <div class="project-card__stats">
                   <div class="project-card__stat">
                     <div class="project-card__stat-value">${p.story_count || 0}</div>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -770,6 +770,15 @@ a:hover {
   margin-bottom: 8px;
 }
 
+/* KJC-PRP-0002 PR3: 🔗 badge for projects with a plan in .karajan-shared/. */
+.project-card__shared-badge {
+  display: inline-block;
+  font-size: 0.85em;
+  margin-right: 4px;
+  cursor: help;
+  vertical-align: baseline;
+}
+
 .project-card__stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -313,6 +313,11 @@ export function initDb() {
   // The UI surfaces this as a toggle on each project card.
   try { db.exec('ALTER TABLE projects ADD COLUMN is_test INTEGER'); } catch { /* already migrated */ }
 
+  // is_shared (KJC-PRP-0002 PR3): 1 when at least one plan of the project came
+  // from `<projectDir>/.karajan-shared/plans/`. Surfaced as a 🔗 badge on the
+  // board so the user can tell at a glance which projects are team-tracked.
+  try { db.exec('ALTER TABLE projects ADD COLUMN is_shared INTEGER'); } catch { /* already migrated */ }
+
   return db;
 }
 
@@ -330,13 +335,17 @@ export function getDb() {
  * @param {{ id: string, name?: string, first_seen?: string, last_activity?: string, total_stories?: number }} project
  */
 export function upsertProject(project) {
+  // is_shared (KJC-PRP-0002 PR3) is set by sync when a plan came from
+  // `.karajan-shared/`. COALESCE with the existing column keeps the badge
+  // once it's been promoted — a second non-shared plan won't unset it.
   const stmt = getDb().prepare(`
-    INSERT INTO projects (id, name, first_seen, last_activity, total_stories)
-    VALUES (@id, @name, @first_seen, @last_activity, @total_stories)
+    INSERT INTO projects (id, name, first_seen, last_activity, total_stories, is_shared)
+    VALUES (@id, @name, @first_seen, @last_activity, @total_stories, @is_shared)
     ON CONFLICT(id) DO UPDATE SET
       name = COALESCE(@name, name),
       last_activity = COALESCE(@last_activity, last_activity),
-      total_stories = COALESCE(@total_stories, total_stories)
+      total_stories = COALESCE(@total_stories, total_stories),
+      is_shared = COALESCE(@is_shared, is_shared)
   `);
   stmt.run({
     id: project.id,
@@ -344,6 +353,7 @@ export function upsertProject(project) {
     first_seen: project.first_seen || new Date().toISOString(),
     last_activity: project.last_activity || new Date().toISOString(),
     total_stories: project.total_stories || 0,
+    is_shared: project.is_shared ?? null,
   });
 }
 

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -14,7 +14,7 @@ import {
   removeTombstone,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
-import { getSharedPlansDir, SHARED_DIR_NAME } from '../../../src/utils/shared-paths.js';
+import { getSharedPlansDir, SHARED_DIR_NAME, isSharedPath } from '../../../src/utils/shared-paths.js';
 
 /**
  * Skip + best-effort fs cleanup when the resource is tombstoned. Returns
@@ -382,11 +382,17 @@ export function syncPlanFile(filePath) {
       || slugToTitle(data.task || '')
       || projectId;
 
+    // KJC-PRP-0002 PR3: stamp `is_shared` from the path (authoritative — works
+    // even for legacy plan files without the `shared:true` envelope marker).
+    // OR with existing value so a single shared plan promotes the project,
+    // while unsharing the LAST shared plan still leaves the flag set (we
+    // clear it lazily only when the user explicitly tombstones / re-creates).
     upsertProject({
       id: projectId,
       name: projectName,
       last_activity: data.updatedAt || data.createdAt || new Date().toISOString(),
       total_stories: data.hus.length,
+      is_shared: isSharedPath(filePath) || data.shared === true ? 1 : undefined,
     });
 
     for (let i = 0; i < data.hus.length; i += 1) {

--- a/packages/hu-board/tests/sync-shared-plans.test.js
+++ b/packages/hu-board/tests/sync-shared-plans.test.js
@@ -72,6 +72,9 @@ describe('HU Board sync — .karajan-shared/plans/ scan (KJC-PRP-0002 PR2)', () 
       sync.fullScan();
       const proj = findProject(db, 'CwdProj');
       expect(proj).toBeTruthy();
+      // KJC-PRP-0002 PR3: the project is stamped is_shared=1 because the plan
+      // came from `.karajan-shared/plans/`. UI uses this for the 🔗 badge.
+      expect(proj.is_shared).toBe(1);
       const stories = db.getStoriesByProject(proj.id);
       expect(stories.length).toBe(1);
       expect(stories[0].title).toBe('Login');

--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -10,6 +10,7 @@ import {
   planMigrateResultCommand,
   planFixCommand,
   planShareCommand,
+  planUnshareCommand,
 } from "../commands/plan.js";
 import { parseCanvasMarkdown } from "../canvas/parse-md.js";
 import { validateCanvas } from "../canvas/validate.js";
@@ -151,6 +152,18 @@ export function registerPlan(program, { pkgVersion }) {
     .action(async (planId, flags) => {
       await withConfig(pkgVersion, "plan", flags, async ({ config, logger }) => {
         await planShareCommand({ config, planId, logger });
+      });
+    });
+
+  // KJC-PRP-0002 / v2.31.0 PR3: inverse of `kj plan share`. Removes the plan
+  // from `.karajan-shared/plans/` but keeps the per-user copy intact, so the
+  // dev still has the plan locally while the team stops seeing it.
+  plan.command("unshare")
+    .description("Remove a plan from <projectDir>/.karajan-shared/ (keeps local copy)")
+    .argument("<planId>")
+    .action(async (planId, flags) => {
+      await withConfig(pkgVersion, "plan", flags, async ({ config, logger }) => {
+        await planUnshareCommand({ config, planId, logger });
       });
     });
 

--- a/src/commands/plan.js
+++ b/src/commands/plan.js
@@ -13,4 +13,5 @@ export {
   planMigrateResultCommand,
   planFixCommand,
   planShareCommand,
+  planUnshareCommand,
 } from "./plan/index.js";

--- a/src/commands/plan/index.js
+++ b/src/commands/plan/index.js
@@ -10,3 +10,4 @@ export { planRemoveHuCommand } from "./remove-hu.js";
 export { planMigrateResultCommand } from "./migrate-result.js";
 export { planFixCommand } from "./fix.js";
 export { planShareCommand } from "./share.js";
+export { planUnshareCommand } from "./unshare.js";

--- a/src/commands/plan/unshare.js
+++ b/src/commands/plan/unshare.js
@@ -1,0 +1,41 @@
+/**
+ * kj plan unshare <planId>
+ *
+ * Inverse of `kj plan share`. Removes the plan from the project's shared dir
+ * (`<projectDir>/.karajan-shared/plans/`). The per-user copy at
+ * `~/.karajan/plans/<projectSlug>/<planId>.json` stays untouched, so the dev
+ * keeps the plan locally while the team stops seeing it. KJC-PRP-0002 / PR3.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getSharedPlansDir } from "../../utils/shared-paths.js";
+
+export async function planUnshareCommand({ config, planId, logger }) {
+  const log = logger || console;
+  const projectDir = config.projectDir || process.cwd();
+
+  if (!planId) {
+    log.error?.("kj plan unshare <planId> — planId is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const sharedDir = getSharedPlansDir(projectDir);
+  const targetFile = path.join(sharedDir, `${planId}.json`);
+
+  try {
+    await fs.unlink(targetFile);
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      log.error?.(`Plan not shared: ${planId} (no file at .karajan-shared/plans/)`);
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+
+  const rel = path.relative(projectDir, targetFile);
+  log.info?.(`✓ Unshared plan ${planId} (removed ${rel})`);
+  log.info?.(`  Commit '.karajan-shared/' so your team stops seeing it.`);
+}

--- a/tests/plan/plan-unshare.test.js
+++ b/tests/plan/plan-unshare.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { planShareCommand } from "../../src/commands/plan/share.js";
+import { planUnshareCommand } from "../../src/commands/plan/unshare.js";
+
+describe("kj plan unshare — KJC-PRP-0002 PR3", () => {
+  let projectDir;
+
+  beforeEach(async () => {
+    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "kjc-plan-unshare-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  function makeLogger() {
+    const captured = { info: [], error: [] };
+    return {
+      info: (m) => captured.info.push(m),
+      error: (m) => captured.error.push(m),
+      captured,
+    };
+  }
+
+  it("removes a shared plan and keeps the per-user copy intact", async () => {
+    const { savePlan, loadPlan } = await import("../../src/plan/plan-store.js");
+    await savePlan(projectDir, {
+      version: 2, planId: "plan-unshare-001", task: "t", hus: [], status: "draft", createdAt: "",
+    });
+
+    // First share, then unshare.
+    await planShareCommand({ config: { projectDir }, planId: "plan-unshare-001", logger: makeLogger() });
+    const sharedPath = path.join(projectDir, ".karajan-shared", "plans", "plan-unshare-001.json");
+    await fs.access(sharedPath); // exists
+
+    const logger = makeLogger();
+    await planUnshareCommand({ config: { projectDir }, planId: "plan-unshare-001", logger });
+
+    // Shared copy gone, local copy still there.
+    await expect(fs.access(sharedPath)).rejects.toThrow();
+    const local = await loadPlan(projectDir, "plan-unshare-001");
+    expect(local).toBeTruthy();
+    expect(local.planId).toBe("plan-unshare-001");
+    expect(logger.captured.info.join("\n")).toMatch(/Unshared plan plan-unshare-001/);
+  });
+
+  it("exits with code 1 when planId is missing", async () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const logger = makeLogger();
+    await planUnshareCommand({ config: { projectDir }, planId: "", logger });
+    expect(process.exitCode).toBe(1);
+    expect(logger.captured.error.join("\n")).toMatch(/planId is required/);
+    process.exitCode = prev;
+  });
+
+  it("exits with code 1 when the plan is not shared", async () => {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    const logger = makeLogger();
+    await planUnshareCommand({ config: { projectDir }, planId: "plan-never-shared", logger });
+    expect(process.exitCode).toBe(1);
+    expect(logger.captured.error.join("\n")).toMatch(/Plan not shared/);
+    process.exitCode = prev;
+  });
+});


### PR DESCRIPTION
## Summary

PR3 of KJC-PRP-0002 (team-shared HU Board). Closes the share/unshare loop and surfaces the team-tracked state in the dashboard.

- **`kj plan unshare <planId>`** — inverse of `kj plan share`. Removes the file from `<projectDir>/.karajan-shared/plans/` and leaves the per-user copy in `~/.karajan/plans/` intact. Exits 1 on missing `planId` or when the plan was never shared.
- **HU Board `projects.is_shared`** — sticky column (COALESCE-updated), stamped to `1` by `sync.js` whenever a scanned plan's source path lives under `.karajan-shared/` or its `shared` flag is true. Once a project has ever surfaced a shared plan, it stays flagged.
- **🔗 badge** on the dashboard project cards for any `is_shared=1` project, with a "Team-shared via `.karajan-shared/`" tooltip.

## Files

- `src/commands/plan/unshare.js` (new, 41 LOC) + register in `plan/index.js`, `plan.js`, `cli/register-plan.js`.
- `packages/hu-board/src/db.js`: idempotent `ALTER TABLE` for `is_shared`, updated `upsertProject` with COALESCE.
- `packages/hu-board/src/sync.js`: import `isSharedPath`, set `is_shared` in `upsertProject` call.
- `packages/hu-board/public/app.js` + `styles.css`: 🔗 inline badge.

## Tests

- `tests/plan/plan-unshare.test.js` (3 tests, all passing):
  - removes shared file, keeps local copy.
  - exits 1 on missing planId.
  - exits 1 when plan isn't shared.
- `packages/hu-board/tests/sync-shared-plans.test.js`: extended with `expect(proj.is_shared).toBe(1)` assertion (3/3 passing).

## LOC budget

10 files, +159 -5, net 154 LOC. Under the 200 hard limit.

## Test plan

- [x] `npx vitest run tests/plan/plan-unshare.test.js` green.
- [x] `cd packages/hu-board && npx vitest run tests/sync-shared-plans.test.js` green.
- [ ] CI green.