### PR TITLE
feat(plan): kj plan share --only/--exclude HU filter (KJC-PRP-0002 PR4)

### DIFF
--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -149,9 +149,11 @@ export function registerPlan(program, { pkgVersion }) {
   plan.command("share")
     .description("Promote a local plan to <projectDir>/.karajan-shared/ so the team can see it")
     .argument("<planId>")
+    .option("--only <ids>", "Comma-separated HU IDs to include (share a subset)")
+    .option("--exclude <ids>", "Comma-separated HU IDs to omit from the shared copy")
     .action(async (planId, flags) => {
       await withConfig(pkgVersion, "plan", flags, async ({ config, logger }) => {
-        await planShareCommand({ config, planId, logger });
+        await planShareCommand({ config, planId, logger, only: flags.only, exclude: flags.exclude });
       });
     });
 

--- a/src/commands/plan/share.js
+++ b/src/commands/plan/share.js
@@ -12,12 +12,26 @@ import { writeJsonAtomic } from "../../utils/atomic-write.js";
 import { getSharedPlansDir } from "../../utils/shared-paths.js";
 import { loadPlan } from "../../plan/plan-store.js";
 
-export async function planShareCommand({ config, planId, logger }) {
+function parseIdList(raw) {
+  if (!raw) return null;
+  const ids = String(raw).split(",").map((s) => s.trim()).filter(Boolean);
+  return ids.length ? ids : null;
+}
+
+export async function planShareCommand({ config, planId, logger, only, exclude }) {
   const log = logger || console;
   const projectDir = config.projectDir || process.cwd();
 
   if (!planId) {
     log.error?.("kj plan share <planId> — planId is required");
+    process.exitCode = 1;
+    return;
+  }
+
+  const onlyIds = parseIdList(only);
+  const excludeIds = parseIdList(exclude);
+  if (onlyIds && excludeIds) {
+    log.error?.("kj plan share — --only and --exclude are mutually exclusive");
     process.exitCode = 1;
     return;
   }
@@ -29,16 +43,43 @@ export async function planShareCommand({ config, planId, logger }) {
     return;
   }
 
+  // KJC-PRP-0002 PR4: optional per-HU filter. Lets a dev share a curated
+  // subset of HUs without splitting the plan or hand-editing the JSON.
+  let hus = plan.hus || [];
+  let filterSummary = "";
+  if (onlyIds) {
+    hus = hus.filter((h) => onlyIds.includes(h.id));
+    filterSummary = ` [only: ${onlyIds.join(",")}]`;
+  } else if (excludeIds) {
+    hus = hus.filter((h) => !excludeIds.includes(h.id));
+    filterSummary = ` [excluding: ${excludeIds.join(",")}]`;
+  }
+  if ((onlyIds || excludeIds) && hus.length === 0) {
+    log.error?.(`No HUs left after applying filter — aborting share.`);
+    process.exitCode = 1;
+    return;
+  }
+
   const sharedDir = getSharedPlansDir(projectDir);
   await fs.mkdir(sharedDir, { recursive: true });
   const targetFile = path.join(sharedDir, `${plan.planId}.json`);
 
   // Stamp a `shared: true` marker so consumers (board sync, audit, etc.)
   // can tell promoted copies from local ones without inspecting the path.
-  const sharedPlan = { ...plan, shared: true, sharedAt: new Date().toISOString() };
+  const sharedPlan = {
+    ...plan,
+    hus,
+    shared: true,
+    sharedAt: new Date().toISOString(),
+  };
+  if (onlyIds || excludeIds) {
+    sharedPlan.sharedFilter = onlyIds
+      ? { only: onlyIds }
+      : { exclude: excludeIds };
+  }
   await writeJsonAtomic(targetFile, sharedPlan);
 
   const rel = path.relative(projectDir, targetFile);
-  log.info?.(`✓ Shared plan ${plan.planId} → ${rel}`);
+  log.info?.(`✓ Shared plan ${plan.planId} → ${rel}${filterSummary}`);
   log.info?.(`  Commit '.karajan-shared/' so your team picks it up.`);
 }

--- a/tests/plan/plan-share.test.js
+++ b/tests/plan/plan-share.test.js
@@ -67,6 +67,99 @@ describe("kj plan share — KJC-PRP-0002 PR1", () => {
     process.exitCode = prev;
   });
 
+  // KJC-PRP-0002 PR4: per-HU filter — --only / --exclude.
+  describe("per-HU filter (--only / --exclude)", () => {
+    async function seedThreeHuPlan() {
+      const { savePlan } = await import("../../src/plan/plan-store.js");
+      await savePlan(projectDir, {
+        version: 2,
+        planId: "plan-filter-001",
+        task: "filtered share",
+        hus: [
+          { id: "HU-1", status: "pending", title: "A" },
+          { id: "HU-2", status: "pending", title: "B" },
+          { id: "HU-3", status: "pending", title: "C" },
+        ],
+        status: "draft",
+        createdAt: "",
+      });
+    }
+
+    it("with --only, shares only the listed HUs and records the filter", async () => {
+      await seedThreeHuPlan();
+      await planShareCommand({
+        config: { projectDir },
+        planId: "plan-filter-001",
+        logger: makeLogger(),
+        only: "HU-1,HU-3",
+      });
+      const target = path.join(projectDir, ".karajan-shared", "plans", "plan-filter-001.json");
+      const written = JSON.parse(await fs.readFile(target, "utf8"));
+      expect(written.hus.map((h) => h.id)).toEqual(["HU-1", "HU-3"]);
+      expect(written.sharedFilter).toEqual({ only: ["HU-1", "HU-3"] });
+    });
+
+    it("with --exclude, shares all HUs except the listed ones", async () => {
+      await seedThreeHuPlan();
+      await planShareCommand({
+        config: { projectDir },
+        planId: "plan-filter-001",
+        logger: makeLogger(),
+        exclude: "HU-2",
+      });
+      const target = path.join(projectDir, ".karajan-shared", "plans", "plan-filter-001.json");
+      const written = JSON.parse(await fs.readFile(target, "utf8"));
+      expect(written.hus.map((h) => h.id)).toEqual(["HU-1", "HU-3"]);
+      expect(written.sharedFilter).toEqual({ exclude: ["HU-2"] });
+    });
+
+    it("rejects --only + --exclude together", async () => {
+      await seedThreeHuPlan();
+      const prev = process.exitCode;
+      process.exitCode = undefined;
+      const logger = makeLogger();
+      await planShareCommand({
+        config: { projectDir },
+        planId: "plan-filter-001",
+        logger,
+        only: "HU-1",
+        exclude: "HU-2",
+      });
+      expect(process.exitCode).toBe(1);
+      expect(logger.captured.error.join("\n")).toMatch(/mutually exclusive/);
+      process.exitCode = prev;
+    });
+
+    it("exits with code 1 when the filter removes every HU", async () => {
+      await seedThreeHuPlan();
+      const prev = process.exitCode;
+      process.exitCode = undefined;
+      const logger = makeLogger();
+      await planShareCommand({
+        config: { projectDir },
+        planId: "plan-filter-001",
+        logger,
+        only: "HU-nope",
+      });
+      expect(process.exitCode).toBe(1);
+      expect(logger.captured.error.join("\n")).toMatch(/No HUs left/);
+      process.exitCode = prev;
+    });
+
+    it("leaves the per-user copy untouched (only filters the shared copy)", async () => {
+      await seedThreeHuPlan();
+      await planShareCommand({
+        config: { projectDir },
+        planId: "plan-filter-001",
+        logger: makeLogger(),
+        only: "HU-1",
+      });
+      const { loadPlan } = await import("../../src/plan/plan-store.js");
+      const local = await loadPlan(projectDir, "plan-filter-001");
+      expect(local.hus.map((h) => h.id)).toEqual(["HU-1", "HU-2", "HU-3"]);
+    });
+  });
+
   it("is idempotent — sharing twice rewrites the file without error", async () => {
     const { savePlan } = await import("../../src/plan/plan-store.js");
     await savePlan(projectDir, {


### PR DESCRIPTION
## Summary

PR4 of KJC-PRP-0002 (team-shared HU Board). Lets the user share a curated SUBSET of HUs, not the whole plan.

- **`kj plan share <planId> --only HU-1,HU-3`** — only those HUs go to `.karajan-shared/`.
- **`kj plan share <planId> --exclude HU-2`** — every HU except the listed ones.
- Mutex (\`--only\` + \`--exclude\` → exit 1). Empty post-filter HU list → exit 1.
- The shared JSON records the filter under \`sharedFilter\` so an audit/board-sync inspection can tell *why* certain HUs are missing.
- **The per-user copy is never modified** — only the file written to \`.karajan-shared/\`.

## Files

- \`src/commands/plan/share.js\`: \`parseIdList\` helper + filter logic + sharedFilter stamping. +47 LOC.
- \`src/cli/register-plan.js\`: \`--only\` / \`--exclude\` flags. +4 LOC.
- \`tests/plan/plan-share.test.js\`: 5 new specs. +93 LOC.

## Test plan

- [x] \`npx vitest run tests/plan/plan-share.test.js tests/plan/plan-unshare.test.js\` → 12/12 green.
- [ ] CI green.

## LOC budget

3 files, +140 -4, net 136 LOC. Under the 200 hard limit.