### PR TITLE
feat(hu-board): sharedConflictPolicy local-wins escape hatch (KJC-PRP-0002 PR5)

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -79,6 +79,11 @@ export const CATEGORIES = [
   { id: 'rag',      label: 'RAG (búsqueda de contexto)', icon: '📚', order: 3 },
   { id: 'session',  label: 'Tiempos de sesión',        icon: '⏱',  order: 4 },
   { id: 'quality',  label: 'Calidad',                  icon: '✅', order: 5 },
+  // KJC-PRP-0002 PR5: team-shared HU board controls. Today only carries
+  // the conflict-resolution policy when a planId lives in both
+  // ~/.karajan/plans/ (per-user) and <projectDir>/.karajan-shared/plans/
+  // (team-committed). Will grow as more board-level multi-user knobs land.
+  { id: 'huBoard',  label: 'HU Board (equipo)',        icon: '🔗', order: 6 },
 ];
 
 /**
@@ -274,6 +279,22 @@ export const EDITABLE_FIELDS = [
     help: 'Ollama local es gratis. OpenAI/Voyage/Cohere/Mistral son cloud (requieren API key). ONNX corre 100% local con @huggingface/transformers.',
     options: ['ollama', 'openai', 'voyage', 'cohere', 'mistral', 'onnx'],
     default: 'ollama',
+  },
+  // KJC-PRP-0002 PR5: when the board scans plans, it visits both
+  // ~/.karajan/plans/<slug>/ (per-user cache) and .karajan-shared/plans/
+  // (team copy). If a planId lives in both, the second pass overwrites
+  // the first. Before this knob the order was hard-coded shared-wins
+  // (per-user → shared) — fine in a team but unsafe for a solo dev who
+  // forgets a stale `.karajan-shared/` exists in the repo.
+  {
+    key: 'huBoardSharedConflictPolicy',
+    path: 'huBoard.sharedConflictPolicy',
+    category: 'huBoard',
+    type: 'select',
+    label: 'Política ante plan compartido y local',
+    help: '"shared-wins" (recomendado en equipo): la copia en .karajan-shared/ pisa la local. "local-wins" (solo dev individual): tu copia en ~/.karajan/plans/ pisa la compartida — útil si todavía estás iterando antes de publicarla.',
+    options: ['shared-wins', 'local-wins'],
+    default: 'shared-wins',
   },
 ];
 

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -15,6 +15,35 @@ import {
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
 import { getSharedPlansDir, SHARED_DIR_NAME, isSharedPath } from '../../../src/utils/shared-paths.js';
+import { readConfig } from './config-yaml.js';
+
+/**
+ * KJC-PRP-0002 PR5: resolve the conflict policy that decides who wins
+ * when the same planId is present in both the per-user cache
+ * (~/.karajan/plans/<slug>/) and the shared dir (.karajan-shared/plans/).
+ *
+ * Implementation is "order of last write": `syncPlanFile` upserts by
+ * planId, so whichever scan runs second overwrites whatever the first
+ * one wrote. We just swap the visit order based on policy.
+ *
+ *   shared-wins (default) → per-user first, shared second
+ *   local-wins            → shared first, per-user second
+ *
+ * Reads from kj.config.yml live; absent / malformed config falls back to
+ * the safe team default. Project scope wins over global scope (same
+ * precedence the rest of the config UI honours).
+ */
+function getSharedConflictPolicy() {
+  const pluck = (cfg) => cfg?.raw?.huBoard?.sharedConflictPolicy;
+  const valid = (v) => v === 'local-wins' || v === 'shared-wins';
+  try {
+    const projectCfg = readConfig({ scope: 'project' });
+    if (valid(pluck(projectCfg))) return pluck(projectCfg);
+    const globalCfg = readConfig({ scope: 'global' });
+    if (valid(pluck(globalCfg))) return pluck(globalCfg);
+  } catch { /* swallow — config UI handles surfacing errors */ }
+  return 'shared-wins';
+}
 
 /**
  * Skip + best-effort fs cleanup when the resource is tombstoned. Returns
@@ -534,37 +563,38 @@ export function fullScan() {
     }
   }
 
-  // Scan v2 plans (`kj plan` writes to `~/.karajan/plans/<slug>/` after
-  // KJC-PCS-0047 PR 3). `KJ_PLANS_DIR` keeps overriding for test
-  // isolation. A second pass picks up the legacy `~/.kj/plans/`
-  // location for users whose CLI hasn't yet run the migrator (e.g.
-  // the board was started before any `kj` command on a fresh upgrade).
-  const kjDir = process.env.KJ_PLANS_DIR || join(homedir(), '.karajan', 'plans');
-  const legacyKjDir = process.env.KJ_PLANS_DIR ? null : join(homedir(), '.kj', 'plans');
-  for (const root of [kjDir, legacyKjDir]) {
-    if (!root || !existsSync(root)) continue;
-    const projectDirs = readdirSync(root);
-    for (const projDir of projectDirs) {
-      const projPath = join(root, projDir);
-      try {
-        const files = readdirSync(projPath);
-        for (const file of files) {
-          if (file.startsWith('plan-') && file.endsWith('.json')) {
-            syncPlanFile(join(projPath, file));
+  // KJC-PRP-0002 PR5: order plans scans by conflict policy. `syncPlanFile`
+  // upserts by planId, so whichever pass runs LAST wins. Default
+  // shared-wins matches what teams expect (the committed copy is canonical);
+  // local-wins is the escape hatch for a solo dev still iterating before
+  // publishing. Same projectDir scan, only the order changes.
+  const scanPerUserPlans = () => {
+    const kjDir = process.env.KJ_PLANS_DIR || join(homedir(), '.karajan', 'plans');
+    const legacyKjDir = process.env.KJ_PLANS_DIR ? null : join(homedir(), '.kj', 'plans');
+    for (const root of [kjDir, legacyKjDir]) {
+      if (!root || !existsSync(root)) continue;
+      const projectDirs = readdirSync(root);
+      for (const projDir of projectDirs) {
+        const projPath = join(root, projDir);
+        try {
+          const files = readdirSync(projPath);
+          for (const file of files) {
+            if (file.startsWith('plan-') && file.endsWith('.json')) {
+              syncPlanFile(join(projPath, file));
+            }
           }
-        }
-      } catch { /* skip */ }
+        } catch { /* skip */ }
+      }
     }
-  }
+  };
 
-  // KJC-PRP-0002 PR2: team-shared plans live under <projectDir>/.karajan-shared/plans/
-  // (committed to git so teammates pulling the repo see the same HUs without
-  // having to re-run `kj plan generate`). The board reads them on top of the
-  // per-user `~/.karajan/plans/` cache. If both exist for the same planId,
-  // `syncPlanFile`'s upsert uses planId as key — last write wins, which is
-  // fine because both copies share the same content modulo the `shared:true`
-  // marker stamped by `kj plan share`.
-  scanSharedPlans();
+  if (getSharedConflictPolicy() === 'local-wins') {
+    scanSharedPlans();
+    scanPerUserPlans();
+  } else {
+    scanPerUserPlans();
+    scanSharedPlans();
+  }
 
   console.log('[sync] Full scan completed');
 }

--- a/packages/hu-board/tests/conflict-policy.test.js
+++ b/packages/hu-board/tests/conflict-policy.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+
+// KJC-PRP-0002 PR5: when the same planId lives in both
+// ~/.karajan/plans/<slug>/ (per-user cache) and
+// <projectDir>/.karajan-shared/plans/ (team copy), the conflict policy
+// configured in kj.config.yml decides who wins. Default = shared-wins.
+
+let tmpDir;
+let projectDir;
+let kjHome;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-conflict-'));
+  kjHome = join(tmpDir, 'kj-home');
+  mkdirSync(kjHome, { recursive: true });
+  process.env.KJ_HOME = kjHome;
+  // Per-user plans live under KJ_PLANS_DIR/<slug>/. Project dir hosts the
+  // shared copy via .karajan-shared/plans/.
+  process.env.KJ_PLANS_DIR = join(tmpDir, 'plans');
+  mkdirSync(process.env.KJ_PLANS_DIR, { recursive: true });
+  projectDir = join(tmpDir, 'projDir');
+  mkdirSync(projectDir, { recursive: true });
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../src/db.js');
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+  delete process.env.KJ_SHARED_PROJECT_DIRS;
+});
+
+async function setup() {
+  const db = await import('../src/db.js');
+  db.initDb();
+  const sync = await import('../src/sync.js');
+  return { db, sync };
+}
+
+function writePlanInDir(dir, planId, huTitle, projectName) {
+  mkdirSync(dir, { recursive: true });
+  const plan = {
+    version: 2,
+    planId,
+    task: 'conflict policy test',
+    projectDir,
+    name: projectName,
+    hus: [{ id: 'hu-policy-01', status: 'pending', title: huTitle }],
+    status: 'draft',
+    createdAt: '',
+  };
+  writeFileSync(join(dir, `${planId}.json`), JSON.stringify(plan));
+}
+
+function writeConfigPolicy(policy) {
+  const yml = yaml.dump({ huBoard: { sharedConflictPolicy: policy } });
+  writeFileSync(join(kjHome, 'kj.config.yml'), yml);
+}
+
+describe('HU Board sync — sharedConflictPolicy (KJC-PRP-0002 PR5)', () => {
+  function seedBothCopies() {
+    // Per-user copy says "Local title".
+    writePlanInDir(
+      join(process.env.KJ_PLANS_DIR, 'proj'),
+      'plan-conflict-001',
+      'Local title',
+      'ConflictProj'
+    );
+    // Shared copy (committed in the repo) says "Shared title".
+    const sharedDir = join(projectDir, '.karajan-shared', 'plans');
+    writePlanInDir(sharedDir, 'plan-conflict-001', 'Shared title', 'ConflictProj');
+    // Stamp the `shared:true` marker the way `kj plan share` does, so the
+    // is_shared column is set deterministically.
+    const sharedFile = join(sharedDir, 'plan-conflict-001.json');
+    const parsed = JSON.parse(readFileSync(sharedFile, 'utf8'));
+    parsed.shared = true;
+    writeFileSync(sharedFile, JSON.stringify(parsed));
+  }
+
+  it('defaults to shared-wins when no policy is configured', async () => {
+    const { db, sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = projectDir;
+    seedBothCopies();
+    sync.fullScan();
+    const proj = db.getProjects().find((p) => p.name === 'ConflictProj');
+    const stories = db.getStoriesByProject(proj.id);
+    expect(stories[0].title).toBe('Shared title');
+  });
+
+  it('honors explicit shared-wins policy from kj.config.yml', async () => {
+    writeConfigPolicy('shared-wins');
+    const { db, sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = projectDir;
+    seedBothCopies();
+    sync.fullScan();
+    const proj = db.getProjects().find((p) => p.name === 'ConflictProj');
+    const stories = db.getStoriesByProject(proj.id);
+    expect(stories[0].title).toBe('Shared title');
+  });
+
+  it('honors local-wins policy — per-user copy overrides the shared one', async () => {
+    writeConfigPolicy('local-wins');
+    const { db, sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = projectDir;
+    seedBothCopies();
+    sync.fullScan();
+    const proj = db.getProjects().find((p) => p.name === 'ConflictProj');
+    const stories = db.getStoriesByProject(proj.id);
+    expect(stories[0].title).toBe('Local title');
+  });
+
+  it('falls back to shared-wins when the config value is malformed', async () => {
+    // Garbage value should NOT be honored — we want the safe team default.
+    writeConfigPolicy('newest-wins');
+    const { db, sync } = await setup();
+    process.env.KJ_SHARED_PROJECT_DIRS = projectDir;
+    seedBothCopies();
+    sync.fullScan();
+    const proj = db.getProjects().find((p) => p.name === 'ConflictProj');
+    const stories = db.getStoriesByProject(proj.id);
+    expect(stories[0].title).toBe('Shared title');
+  });
+});


### PR DESCRIPTION
## Summary

- **What**: makes the HU Board's plan-conflict resolution configurable when the same `planId` lives in both `~/.karajan/plans/<slug>/` (per-user cache) and `<projectDir>/.karajan-shared/plans/` (team-committed copy).
- **Why**: until now the order of `fullScan` was hard-coded shared-wins — sane in a team but unsafe for a solo dev who forgets a stale `.karajan-shared/` exists in the repo and wonders why their local iteration is silently overwritten on every board refresh.
- **How**: new `huBoard.sharedConflictPolicy` config field (`shared-wins` default, `local-wins` opt-in). The board reads it via `readConfig` (project scope first, global fallback) and swaps the order of `scanPerUserPlans()` / `scanSharedPlans()` accordingly. `syncPlanFile` upserts by `planId`, so whoever runs last wins.

## Files

- `packages/hu-board/src/config-yaml.js` — new `huBoard` category + `sharedConflictPolicy` editable field.
- `packages/hu-board/src/sync.js` — `getSharedConflictPolicy()` resolver + refactor of `fullScan()` to honour the policy.
- `packages/hu-board/tests/conflict-policy.test.js` — 4 new tests (default, explicit shared-wins, local-wins flip, malformed value → safe fallback).

## Test plan

- [x] `npx vitest run tests/conflict-policy.test.js` — 4/4 passing
- [x] `npx vitest run` (full hu-board suite) — 361/361 passing
- [x] LOC budget: net +179 (well under 200)
- [ ] CI gates green (Test 20.x/22.x, Lint, Syntax, Shrink Budget, Injection Guard, GitGuardian)

## PR series

This is **KJC-PRP-0002 PR5** (Karajan Code v2.31.0 — Team-shared HU Board).

- PR1a `feat(plan): kj plan share` — #855
- PR1b `feat(hu-board): is_shared column + UI badge` — #857
- PR2 `feat(hu-board): scan .karajan-shared/plans/` — #861
- PR3 `feat(plan): kj plan unshare + 🔗 badge polish` — #862
- PR4 `feat(plan): kj plan share --only/--exclude HU filter` — #863
- PR5 (this) — conflict policy config
- PR6 (next) — HU assignments
- Release v2.31.0 — bundle everything