### PR TITLE
feat(hu-board): per-HU assignee on team-shared boards (KJC-PRP-0002 PR6)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -193,6 +193,10 @@ async function triggerSync() {
 
 const projectInitialsCache = {};
 const projectNameCache = {};
+// KJC-PRP-0002 PR6: cache project.is_shared so the HU modal can gate the
+// "Asignado a" field without re-fetching /api/projects/:id each open.
+// 0/1 mirror what sqlite stores; undefined = not yet hydrated.
+const projectIsSharedCache = {};
 
 /**
  * Humanise a slug-ish project id so the board can show
@@ -251,11 +255,13 @@ async function resolveProjectMeta(projectId) {
     const initials = deriveInitialsFromName(rawName);
     projectInitialsCache[projectId] = initials;
     projectNameCache[projectId] = rawName;
+    projectIsSharedCache[projectId] = project.is_shared === 1 ? 1 : 0;
     return { initials, name: rawName };
   } catch {
     const fallbackName = humaniseProjectName(projectId);
     projectInitialsCache[projectId] = deriveInitialsFromName(fallbackName);
     projectNameCache[projectId] = fallbackName;
+    projectIsSharedCache[projectId] = 0;
     return { initials: projectInitialsCache[projectId], name: fallbackName };
   }
 }
@@ -1668,6 +1674,31 @@ window.saveHuModels = async function saveHuModels(storyId) {
   }
 };
 
+// KJC-PRP-0002 PR6: persist `hu.assignee` (free-form handle of whoever owns
+// this HU on a team-shared board). Empty string → null so the API knows to
+// clear, not store "". The modal only renders the input when the project is
+// `is_shared = 1`, so non-team boards never trigger this path.
+window.saveHuAssignee = async function saveHuAssignee(storyId) {
+  const input = document.getElementById('hu-assignee');
+  const value = input?.value?.trim() || null;
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(storyId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ assignee: value }),
+    });
+    if (!res.ok) {
+      const msg = (await res.json().catch(() => ({}))).error || `HTTP ${res.status}`;
+      await showError(msg, { title: 'No se pudo guardar el asignado' });
+      return;
+    }
+    await fetch('/api/sync', { method: 'POST' }).catch(() => {});
+    await renderBoard();
+  } catch (err) {
+    await showError(err.message || String(err), { title: 'Fallo guardando asignado' });
+  }
+};
+
 // KJC-TSK-0408: deshace los cambios de una HU restaurando el snapshot
 // git tomado pre-run. ATENCIÓN: es destructivo (git reset --hard) —
 // confirmamos siempre antes de invocar.
@@ -2431,6 +2462,27 @@ async function showStoryDetail(storyId) {
               </button>
               <span style="color:var(--text-muted);font-size:0.75rem">vacío → re-asignar automáticamente</span>
             </div>
+          ` : ''}
+        </div>
+      ` : ''}
+
+      ${projectIsSharedCache[story.project_id] === 1 ? `
+        <!-- KJC-PRP-0002 PR6: per-HU assignee — only surfaced when the
+             project is team-shared. Free-form string; no entity table. -->
+        <div class="modal__section">
+          <div class="modal__section-title">Asignado a</div>
+          <div class="modal__field-value" style="font-family:monospace">${esc(story.assignee || '—')}</div>
+          ${canEdit ? `
+            <div style="margin-top:6px;display:flex;gap:6px;align-items:center">
+              <input id="hu-assignee" type="text" placeholder="@manu, dev_016, becaria…"
+                     value="${esc(story.assignee || '')}"
+                     style="flex:1;padding:4px;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:4px;font-family:monospace;font-size:0.8rem">
+              <button onclick="saveHuAssignee('${esc(story.id)}')" class="control-btn"
+                      style="padding:4px 10px;background:var(--bg-primary);color:var(--text);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.8rem">
+                💾 Save
+              </button>
+            </div>
+            <div style="margin-top:4px;color:var(--text-muted);font-size:0.75rem">vacío → sin asignar</div>
           ` : ''}
         </div>
       ` : ''}

--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -304,6 +304,12 @@ export function initDb() {
   try { db.exec('ALTER TABLE stories ADD COLUMN reviewer_model TEXT'); } catch { /* already migrated */ }
   try { db.exec('ALTER TABLE stories ADD COLUMN coder_provider TEXT'); } catch { /* already migrated */ }
   try { db.exec('ALTER TABLE stories ADD COLUMN reviewer_provider TEXT'); } catch { /* already migrated */ }
+  // KJC-PRP-0002 PR6: free-form handle of the human (or dev_XXX AI) who
+  // owns this HU on a team-shared board. NULL = unassigned. Only surfaced
+  // in the UI when the parent project is `is_shared = 1`, but stored
+  // unconditionally so solo devs who later promote a plan don't lose
+  // values they typed pre-share.
+  try { db.exec('ALTER TABLE stories ADD COLUMN assignee TEXT'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
@@ -370,7 +376,7 @@ export function upsertStory(story) {
       antipatterns, ac_format, acceptance_criteria,
       created_at, updated_at, certified_at, plan_id,
       ac_count, test_count, blocked_by, acceptance_tests, plan_order, spec_section, outcome, result,
-      coder_model, reviewer_model, coder_provider, reviewer_provider
+      coder_model, reviewer_model, coder_provider, reviewer_provider, assignee
     ) VALUES (
       @id, @project_id, @session_id, @status, @title, @original_text,
       @certified_as, @certified_want, @certified_so_that,
@@ -378,7 +384,7 @@ export function upsertStory(story) {
       @antipatterns, @ac_format, @acceptance_criteria,
       @created_at, @updated_at, @certified_at, @plan_id,
       @ac_count, @test_count, @blocked_by, @acceptance_tests, @plan_order, @spec_section, @outcome, @result,
-      @coder_model, @reviewer_model, @coder_provider, @reviewer_provider
+      @coder_model, @reviewer_model, @coder_provider, @reviewer_provider, @assignee
     )
     ON CONFLICT(id) DO UPDATE SET
       status = @status,
@@ -411,7 +417,8 @@ export function upsertStory(story) {
       coder_model = COALESCE(@coder_model, coder_model),
       reviewer_model = COALESCE(@reviewer_model, reviewer_model),
       coder_provider = COALESCE(@coder_provider, coder_provider),
-      reviewer_provider = COALESCE(@reviewer_provider, reviewer_provider)
+      reviewer_provider = COALESCE(@reviewer_provider, reviewer_provider),
+      assignee = COALESCE(@assignee, assignee)
   `);
   stmt.run({
     id: story.id,
@@ -449,6 +456,7 @@ export function upsertStory(story) {
     reviewer_model: story.reviewer_model || null,
     coder_provider: story.coder_provider || null,
     reviewer_provider: story.reviewer_provider || null,
+    assignee: story.assignee || null,
   });
 }
 

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -557,7 +557,11 @@ const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'blocked
 // KJC-TSK-0406: coder_model y reviewer_model son editables desde el
 // modal del board. Independientes — el usuario puede subir el reviewer
 // y bajar el coder sin afectar al resto del plan.
-const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by', 'coder_model', 'reviewer_model', 'coder_provider', 'reviewer_provider'];
+// KJC-PRP-0002 PR6: `assignee` is editable from the board modal when the
+// project is team-shared. The whitelist itself is project-agnostic — the
+// modal hides the input on non-shared projects, but accepting the field
+// here doesn't hurt (sync just stores it).
+const EDITABLE_HU_FIELDS = ['title', 'scope', 'task_type', 'acceptance_criteria', 'acceptance_tests', 'blocked_by', 'coder_model', 'reviewer_model', 'coder_provider', 'reviewer_provider', 'assignee'];
 
 router.patch('/stories/:id', (req, res) => {
   try {

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -504,6 +504,10 @@ export function syncPlanFile(filePath) {
         reviewer_model: hu.reviewer_model || null,
         coder_provider: hu.coder_provider || null,
         reviewer_provider: hu.reviewer_provider || null,
+        // KJC-PRP-0002 PR6: optional handle of the owner of this HU
+        // (free-form string). Only surfaced in UI when project is_shared,
+        // but stored unconditionally so values survive share/unshare flips.
+        assignee: typeof hu.assignee === 'string' && hu.assignee.trim() ? hu.assignee.trim() : null,
       });
     }
 

--- a/packages/hu-board/tests/hu-assignee.test.js
+++ b/packages/hu-board/tests/hu-assignee.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import express from 'express';
+import request from 'supertest';
+import { addHu, updateHu } from '../../../src/plan/plan-hu-ops.js';
+import { createPlanV2 } from '../../../src/plan/plan-schema.js';
+
+// KJC-PRP-0002 PR6: per-HU `assignee` field (team-shared boards). Stored
+// unconditionally; UI gates visibility on project.is_shared. Covers the
+// chain plan-hu-ops → sync.js → PATCH /api/stories/:id.
+
+describe('PR6 plan-hu-ops accepts assignee', () => {
+  it('addHu defaults to null and stores provided value verbatim', () => {
+    const p = createPlanV2('t');
+    expect(addHu(p, { title: 'h1' }).assignee).toBeNull();
+    expect(addHu(p, { title: 'h2', assignee: '@manufosela' }).assignee).toBe('@manufosela');
+  });
+
+  it('updateHu sets and clears assignee', () => {
+    const p = createPlanV2('t');
+    const hu = addHu(p, { title: 'h1' });
+    expect(updateHu(p, hu.id, { assignee: 'dev_016' }).assignee).toBe('dev_016');
+    expect(updateHu(p, hu.id, { assignee: null }).assignee).toBeNull();
+  });
+});
+
+describe('PR6 sync + API end-to-end', () => {
+  const PROJECT_ID = 'home_manu_ws_ai_pr6-demo';
+  const PLAN_ID = 'plan-20260526010101-pr6x';
+  let tmpHome, tmpPlansDir, app, dbMod, syncMod;
+  const planPath = () => join(tmpPlansDir, PROJECT_ID, `${PLAN_ID}.json`);
+
+  beforeEach(async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'hu-board-pr6-'));
+    tmpPlansDir = mkdtempSync(join(tmpdir(), 'hu-board-plans-pr6-'));
+    process.env.KJ_HOME = tmpHome;
+    process.env.KJ_PLANS_DIR = tmpPlansDir;
+    process.env.KJ_RUN_SPAWN_MODE = 'echo';
+
+    dbMod = await import('../src/db.js');
+    syncMod = await import('../src/sync.js');
+    const { default: apiRoutes } = await import('../src/routes/api.js');
+    dbMod.initDb();
+    app = express();
+    app.use(express.json());
+    app.use('/api', apiRoutes);
+
+    mkdirSync(join(tmpPlansDir, PROJECT_ID), { recursive: true });
+    const plan = createPlanV2('build thing');
+    plan.planId = PLAN_ID;
+    plan.projectDir = '/home/manu/ws/ai/pr6-demo';
+    addHu(plan, { title: 'hu uno', assignee: '@manufosela' });
+    writeFileSync(planPath(), JSON.stringify(plan, null, 2), 'utf-8');
+    syncMod.syncPlanFile(planPath());
+  });
+
+  afterEach(() => {
+    delete process.env.KJ_RUN_SPAWN_MODE;
+    dbMod.closeDb();
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpPlansDir, { recursive: true, force: true });
+    delete process.env.KJ_HOME;
+    delete process.env.KJ_PLANS_DIR;
+  });
+
+  it('syncPlanFile propagates assignee from plan JSON to the stories row', async () => {
+    const res = await request(app).get(`/api/projects/${encodeURIComponent(PROJECT_ID)}/stories`);
+    expect(res.status).toBe(200);
+    expect(res.body.find((s) => s.id.endsWith(`${PLAN_ID}_001`)).assignee).toBe('@manufosela');
+  });
+
+  it('PATCH /api/stories/:id with {assignee} writes the new value, null clears it', async () => {
+    const huId = JSON.parse(readFileSync(planPath(), 'utf-8')).hus[0].id;
+    const storyId = `${PROJECT_ID}::${huId}`;
+
+    const setRes = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`).send({ assignee: 'dev_016' });
+    expect(setRes.status).toBe(200);
+    expect(JSON.parse(readFileSync(planPath(), 'utf-8')).hus[0].assignee).toBe('dev_016');
+
+    const clearRes = await request(app)
+      .patch(`/api/stories/${encodeURIComponent(storyId)}`).send({ assignee: null });
+    expect(clearRes.status).toBe(200);
+    expect(JSON.parse(readFileSync(planPath(), 'utf-8')).hus[0].assignee).toBeNull();
+  });
+});

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -68,6 +68,12 @@ export function addHu(plan, huData) {
     coder_provider: huData.coder_provider ?? null,
     reviewer_model: huData.reviewer_model ?? null,
     reviewer_provider: huData.reviewer_provider ?? null,
+    // KJC-PRP-0002 PR6: optional handle of the human (or AI dev_XXX) who
+    // owns this HU in a team-shared board. null = unassigned. Free-form
+    // string — the board prints it as-is; no entity table is enforced
+    // because team rosters are out of scope (and would force every solo
+    // dev to register themselves).
+    assignee: huData.assignee ?? null,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };
@@ -106,7 +112,7 @@ export function updateHu(plan, huId, patch) {
   // KJC-TSK-0405: coder_model y reviewer_model son override per-HU del
   // routing automático del triage. Independientes — el usuario puede
   // subir el reviewer sin tocar el coder, o viceversa.
-  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result", "short_id", "coder_model", "reviewer_model", "coder_provider", "reviewer_provider"];
+  const allowed = ["title", "task_type", "scope", "acceptance_criteria", "acceptance_tests", "blocked_by", "reuse", "spec_section", "result", "short_id", "coder_model", "reviewer_model", "coder_provider", "reviewer_provider", "assignee"];
   for (const key of allowed) {
     if (patch[key] !== undefined) hu[key] = patch[key];
   }


### PR DESCRIPTION
## Summary

KJC-PRP-0002 PR6 — adds optional `hu.assignee` (free-form handle) surfaced
in the HU Board only when the parent project is `is_shared = 1`. Stored
unconditionally so values survive share/unshare flips; UI gates visibility
on `projectIsSharedCache[story.project_id] === 1`.

- `src/plan/plan-hu-ops.js` — `addHu` defaults assignee=null, `updateHu`
  accepts assignee in its whitelist.
- `packages/hu-board/src/sync.js` — propagates assignee from plan JSON to
  the sqlite `stories` row.
- `packages/hu-board/src/db.js` — idempotent `ALTER TABLE stories ADD COLUMN
  assignee TEXT` migration; `upsertStory` INSERT + ON CONFLICT include the
  column with COALESCE so partial updates don't blank out the value.
- `packages/hu-board/src/routes/api.js` — `assignee` appended to
  `EDITABLE_HU_FIELDS` whitelist for `PATCH /api/stories/:id`.
- `packages/hu-board/public/app.js` — `projectIsSharedCache` populated by
  `resolveProjectMeta`; new modal section "Asignado a" renders read-only
  value and (when canEdit) input + save button; `window.saveHuAssignee`
  hits the PATCH endpoint and reloads the board.

## Tests

- `packages/hu-board/tests/hu-assignee.test.js` — 4 tests covering:
  - addHu default + provided value
  - updateHu set / clear
  - sync propagates plan JSON → stories.assignee
  - PATCH `/api/stories/:id` round-trips set + clear
- Full hu-board suite still passes (368/368)
- Full karajan-code plan suite still passes (265/265)

## Test plan

- [x] vitest hu-board passes
- [x] vitest karajan-code plan/ passes
- [x] LOC delta < 200 (net 162)
- [ ] CI green on PR

Closes KJC-TSK-0462. Concludes KJC-PRP-0002 (team-shared HU Board) — v2.31.0 release cut is next.