### PR TITLE
chore: release v2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
+## [2.31.0] - 2026-05-26
+
+Minor release. **Team-shared HU Board** — landing the full KJC-PRP-0002 prerequisite: plans can now opt-in their HUs into a `.karajan-shared/` cohort that the board surfaces with a `shared` badge, lets multiple machines work the same plan without trampling each other, and tracks who owns each HU.
+
+Seven PRs ship the feature end-to-end (PR1a loader fallback, PR1b `kj plan share`, PR2 board scanner, PR3 `kj plan unshare` + UI badge, PR4 `share --only/--exclude` HU filter, PR5 conflict policy, PR6 per-HU assignee).
+
+### Added
+
+- **PR #859 (KJC-PRP-0002 PR1a) — `loadPlan` fallback to `.karajan-shared/`**. The loader now resolves a plan id by trying the local `~/.karajan/plans/<project>/` first, then `<projectDir>/.karajan-shared/plans/<project>/`. Shared plans become first-class citizens for every code path that reads a plan (board sync, `kj plan show`, MCP).
+- **PR #860 (KJC-PRP-0002 PR1b) — `kj plan share` command**. New subcommand copies a local plan into `.karajan-shared/plans/<project>/`, marking it as team-shared. Idempotent — re-running on an already-shared plan updates the copy with the local edits.
+- **PR #861 (KJC-PRP-0002 PR2) — board scans `.karajan-shared/`**. `syncDb` and the file watcher now walk both `~/.karajan/plans/` and every detected `.karajan-shared/plans/` under the active project roots. Shared HUs flow into the same `stories` table tagged with `is_shared = 1`.
+- **PR #862 (KJC-PRP-0002 PR3) — `kj plan unshare` + shared badge**. Mirror of PR1b: removes the shared copy and reverts the plan to local-only. The HU Board renders a small `shared` pill next to plan titles whose `project.is_shared = 1`.
+- **PR #863 (KJC-PRP-0002 PR4) — `kj plan share --only/--exclude` HU filter**. Selective sharing: `--only HU-001,HU-003` shares just those HUs; `--exclude HU-005` shares everything else. Lets users keep WIP HUs private without splitting the plan file.
+- **PR #864 (KJC-PRP-0002 PR5) — `sharedConflictPolicy` escape hatch**. New config field `hu_board.sharedConflictPolicy: prompt | local-wins | shared-wins` (default `prompt`). When two machines edit the same shared HU, the chosen policy decides without manual intervention. Logged in `~/.karajan/board-conflicts.log`.
+- **PR #865 (KJC-PRP-0002 PR6) — per-HU `assignee` field**. Optional free-form handle (`@manufosela`, `dev_016`, `becaria`…) stored on every HU. Surfaced in the board modal **only** for shared projects, editable inline. Backed by an idempotent sqlite migration on `stories.assignee`.
+
+### Tests
+
+5 237 / 5 237 passing in CI across 461 test files (+21 new tests across the 7 PRs, +4 new files).
+
+### Internal
+
+- `EDITABLE_HU_FIELDS` whitelist in `packages/hu-board/src/routes/api.js` now includes `assignee` — PATCH `/api/stories/:id` routes through `setHuFields` → `updateHu` → `writePlan` → `syncPlanFile` end-to-end.
+- Frontend caches a per-project `is_shared` flag at `resolveProjectMeta` time, so the "Asignado a" section is conditional without an extra round-trip.
+
 ## [2.30.0] - 2026-05-26
 
 Minor release. **Writable config UI on HU Board** — the kj.config.yml is no longer an editor-only file. The board now exposes a settings modal with grouped sections, an atomic-write backend, and a scope toggle between global (`~/.karajan/`) and per-project (`<projectDir>/.karajan/`) configs.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.31.0 released** — Minor. **Team-shared HU Board** — the full KJC-PRP-0002: opt-in HUs into a `.karajan-shared/` cohort, the board surfaces them with a `shared` badge, and per-HU `assignee` lets multiple machines work the same plan without trampling each other.
+>
+> - **`kj plan share` / `kj plan unshare`** (PRs #860, #862): mueve plans entre `~/.karajan/plans/` (local) y `<projectDir>/.karajan-shared/plans/` (compartido). Idempotente. El loader probará ambos automáticamente.
+> - **`share --only HU-001,HU-003` / `--exclude HU-005`** (PR #863): selective sharing — comparte solo lo que quieres, deja los WIP privados sin partir el plan.
+> - **Board scanner + `shared` badge** (PRs #861, #862): el watcher recorre los dos roots, mete las HUs compartidas en la misma tabla con `is_shared = 1`, y el modal pinta un pill `shared` junto al título del plan.
+> - **`sharedConflictPolicy` escape hatch** (PR #864): `prompt | local-wins | shared-wins` en kj.config.yml. Cuando dos máquinas editan la misma HU compartida, la política decide sin intervención. Log en `~/.karajan/board-conflicts.log`.
+> - **Per-HU `assignee`** (PR #865): handle libre (`@manufosela`, `dev_016`, `becaria`…) por HU. Visible y editable en el modal **solo** en proyectos shared. Migración sqlite idempotente.
+>
 > **v2.30.0 released** — Minor. **Writable config UI on HU Board** — settings modal with grouped sections, atomic-write backend, and a global vs per-project scope toggle. No more hand-editing the YAML.
 >
 > - **Pipeline role toggles** (PR #854): 8 nuevos booleanos en el modal (`planner`, `researcher`, `architect`, `tester`, `security`, `refactorer`, `impeccable`, `brain`) reflejan los defaults reales de `src/config/defaults.js`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (54k LOC, 398 files)
+├── src/              # Source code (54k LOC, 406 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.30.0
+kj --version    # 2.31.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.30.0
+kj --version    # 2.31.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.30.0",
+      "version": "2.31.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

**v2.31.0 release** — Team-shared HU Board (KJC-PRP-0002 complete).

Consolidates seven feature PRs landed since v2.30.0:

- #859 — `loadPlan` fallback to `.karajan-shared/` (PR1a)
- #860 — `kj plan share` command (PR1b)
- #861 — board scans `.karajan-shared/plans/` (PR2)
- #862 — `kj plan unshare` + shared badge (PR3)
- #863 — `share --only/--exclude` HU filter (PR4)
- #864 — `sharedConflictPolicy` escape hatch (PR5)
- #865 — per-HU `assignee` on shared boards (PR6)

5 237 / 5 237 tests passing in CI across 461 test files.

## Test plan

- [x] `npm install --package-lock-only` clean
- [x] CHANGELOG entry added under [2.31.0]
- [x] README banner updated (Recent releases — v2.31.0 first)
- [x] `kj --version` comment bumped in both EN and ES GETTING-STARTED
- [x] `scripts/regen-arch-stats.sh` run — ARCHITECTURE.md src count refreshed
- [x] LOC budget check passes (only package.json counts; ±1)