### PR TITLE
feat(rag): wire rag.search.{mode,alpha,rerank} to pre-loop (KJC-TSK-0463)

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -235,11 +235,10 @@ export const EDITABLE_FIELDS = [
     help: 'Orquestador IA central: enriquece feedback, comprime outputs y verifica cambios reales. Opt-in.',
     default: false,
   },
-  // v2.30.0 — RAG controls. Sólo se exponen las claves que el código
-  // realmente lee hoy (rag.preload.* en rag-context-stage.js y
-  // rag.embedder.provider en embedders/factory.js). mode/alpha/rerank
-  // se controlan vía flags CLI; cuando se cableen en config se añadirán
-  // aquí (ver task #99).
+  // v2.30.0 — RAG controls. Cubren los tres ejes que afectan al
+  // retrieval en tiempo de pipeline: pre-carga (rag.preload.*),
+  // proveedor de embeddings (rag.embedder.provider) y parámetros de
+  // búsqueda (rag.search.*, cableados al stage en KJC-TSK-0463).
   {
     key: 'ragPreloadEnabled',
     path: 'rag.preload.enabled',
@@ -279,6 +278,39 @@ export const EDITABLE_FIELDS = [
     help: 'Ollama local es gratis. OpenAI/Voyage/Cohere/Mistral son cloud (requieren API key). ONNX corre 100% local con @huggingface/transformers.',
     options: ['ollama', 'openai', 'voyage', 'cohere', 'mistral', 'onnx'],
     default: 'ollama',
+  },
+  // KJC-TSK-0463 — search-time knobs ahora cableados al stage.
+  // mode/alpha controlan el fuse semantic vs keyword; rerank activa el
+  // cross-encoder opcional (más calidad, más latencia).
+  {
+    key: 'ragSearchMode',
+    path: 'rag.search.mode',
+    category: 'rag',
+    type: 'select',
+    label: 'Modo de búsqueda RAG',
+    help: '"hybrid" mezcla semántico + BM25 (recomendado). "semantic" sólo embeddings. "keyword" sólo BM25 (útil si los embeddings están desafinados).',
+    options: ['hybrid', 'semantic', 'keyword'],
+    default: 'hybrid',
+  },
+  {
+    key: 'ragSearchAlpha',
+    path: 'rag.search.alpha',
+    category: 'rag',
+    type: 'number',
+    label: 'Alpha del modo hybrid (0-1)',
+    help: 'Peso del scoring semántico vs keyword en modo hybrid. 1.0 = sólo semántico, 0.0 = sólo BM25, 0.6 (default) = inclinado a semántico.',
+    min: 0,
+    max: 1,
+    default: 0.6,
+  },
+  {
+    key: 'ragSearchRerank',
+    path: 'rag.search.rerank',
+    category: 'rag',
+    type: 'boolean',
+    label: 'Activar rerank cross-encoder',
+    help: 'Re-puntúa los topK supervivientes con un cross-encoder. Mejora calidad pero añade latencia y requiere modelo extra. Opt-in.',
+    default: false,
   },
   // KJC-PRP-0002 PR5: when the board scans plans, it visits both
   // ~/.karajan/plans/<slug>/ (per-user cache) and .karajan-shared/plans/

--- a/src/orchestrator/stages/rag-context-stage.js
+++ b/src/orchestrator/stages/rag-context-stage.js
@@ -11,7 +11,24 @@ import { query } from "../../rag/retriever.js";
 
 const DEFAULT_TOP_K = 5;
 const DEFAULT_SCOPE = "all";
+const DEFAULT_SEARCH_MODE = "hybrid";
+const DEFAULT_SEARCH_ALPHA = 0.6;
 const MAX_CHUNK_CHARS = 600;
+
+// KJC-TSK-0463 — pull search-time knobs from config so the HU Board
+// modal (rag.search.{mode,alpha,rerank}) actually steers retrieval at
+// pipeline time. Returns the args object query() expects; unset fields
+// fall back to the retriever's own defaults.
+export function resolveSearchOpts(config) {
+  const s = config?.rag?.search ?? {};
+  const out = {
+    mode: typeof s.mode === "string" ? s.mode : DEFAULT_SEARCH_MODE,
+    alpha: Number.isFinite(s.alpha) ? s.alpha : DEFAULT_SEARCH_ALPHA,
+  };
+  if (s.rerank && typeof s.rerank === "object") out.rerankOpts = s.rerank;
+  else if (s.rerank === true) out.rerankOpts = {};
+  return out;
+}
 
 /**
  * Runs the RAG preload stage. Returns:
@@ -36,7 +53,8 @@ export async function runRagContextStage({ config, logger, emitter, eventBase, t
       const topK = preload.topK || DEFAULT_TOP_K;
       const scope = preload.scope || DEFAULT_SCOPE;
       const embedder = makeEmbedder(config);
-      const hits = await query(db, embedder, task, { topK, scope });
+      const searchOpts = resolveSearchOpts(config);
+      const hits = await query(db, embedder, task, { topK, scope, ...searchOpts });
       if (hits.length === 0) return { skipped: true, reason: "no-hits" };
       const lines = hits.map((h) => {
         const label = h.metadata?.hu_id || h.metadata?.symbol || h.metadata?.headingPath?.join(" > ") || "block";
@@ -46,7 +64,7 @@ export async function runRagContextStage({ config, logger, emitter, eventBase, t
       const contextBlock = `## Prior context from RAG (auto-retrieved, top ${hits.length})\n\n${lines.join("\n\n")}`;
       emitProgress(emitter, makeEvent("rag-preload:hits", { ...eventBase, stage: "rag-preload" }, {
         message: `RAG preload: injected ${hits.length} chunk(s) into the task context`,
-        detail: { topK, scope, hits: hits.length },
+        detail: { topK, scope, hits: hits.length, mode: searchOpts.mode, alpha: searchOpts.alpha, rerank: Boolean(searchOpts.rerankOpts) },
       }));
       return { skipped: false, contextBlock, hits };
     } finally {

--- a/tests/board/config-yaml-categories.test.js
+++ b/tests/board/config-yaml-categories.test.js
@@ -79,6 +79,9 @@ describe("config-yaml — categories metadata (v2.30.0)", () => {
       "ragPreloadTopK",
       "ragPreloadScope",
       "ragEmbedderProvider",
+      "ragSearchMode",
+      "ragSearchAlpha",
+      "ragSearchRerank",
     ]);
   });
 

--- a/tests/board/config-yaml-rag-search.test.js
+++ b/tests/board/config-yaml-rag-search.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+// KJC-TSK-0463 — RAG search-time knobs (rag.search.{mode,alpha,rerank})
+// exposed in EDITABLE_FIELDS, persisted to yml, and consumed by the
+// pre-loop retrieval stage (rag-context-stage.js).
+
+let home;
+let originalEnv;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kj-cfg-ragsearch-"));
+  originalEnv = process.env.KARAJAN_HOME;
+  process.env.KARAJAN_HOME = home;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.KARAJAN_HOME;
+  else process.env.KARAJAN_HOME = originalEnv;
+  rmSync(home, { recursive: true, force: true });
+});
+
+const { readConfig, writeConfigPatch, EDITABLE_FIELDS } = await import(
+  "../../packages/hu-board/src/config-yaml.js"
+);
+const { resolveSearchOpts } = await import(
+  "../../src/orchestrator/stages/rag-context-stage.js"
+);
+
+describe("config-yaml — RAG search knobs (KJC-TSK-0463)", () => {
+  it("exposes ragSearchMode/Alpha/Rerank with the expected shape", () => {
+    const get = (k) => EDITABLE_FIELDS.find((f) => f.key === k);
+
+    const mode = get("ragSearchMode");
+    expect(mode).toBeDefined();
+    expect(mode.type).toBe("select");
+    expect(mode.path).toBe("rag.search.mode");
+    expect(mode.options).toEqual(["hybrid", "semantic", "keyword"]);
+    expect(mode.default).toBe("hybrid");
+
+    const alpha = get("ragSearchAlpha");
+    expect(alpha.type).toBe("number");
+    expect(alpha.path).toBe("rag.search.alpha");
+    expect(alpha.min).toBe(0);
+    expect(alpha.max).toBe(1);
+    expect(alpha.default).toBe(0.6);
+
+    const rerank = get("ragSearchRerank");
+    expect(rerank.type).toBe("boolean");
+    expect(rerank.path).toBe("rag.search.rerank");
+    expect(rerank.default).toBe(false);
+  });
+
+  it("writeConfigPatch persists the three keys under rag.search", () => {
+    const res = writeConfigPatch({
+      ragSearchMode: "semantic",
+      ragSearchAlpha: 0.8,
+      ragSearchRerank: true,
+    });
+    expect(res.written).toBe(true);
+    const parsed = yaml.load(readFileSync(res.path, "utf8"));
+    expect(parsed.rag.search.mode).toBe("semantic");
+    expect(parsed.rag.search.alpha).toBe(0.8);
+    expect(parsed.rag.search.rerank).toBe(true);
+  });
+
+  it("rejects unknown mode values and alpha out of [0,1]", () => {
+    const badMode = writeConfigPatch({ ragSearchMode: "fuzzy-magic" });
+    expect(badMode.written).toBe(false);
+    expect(badMode.errors.some((e) => e.includes("ragSearchMode"))).toBe(true);
+
+    const badAlpha = writeConfigPatch({ ragSearchAlpha: 1.5 });
+    expect(badAlpha.written).toBe(false);
+    expect(badAlpha.errors.some((e) => e.includes("ragSearchAlpha"))).toBe(true);
+  });
+
+  it("readConfig returns documented defaults when yml is absent", () => {
+    const out = readConfig();
+    const get = (k) => out.fields.find((f) => f.key === k).value;
+    expect(get("ragSearchMode")).toBe("hybrid");
+    expect(get("ragSearchAlpha")).toBe(0.6);
+    expect(get("ragSearchRerank")).toBe(false);
+  });
+});
+
+describe("rag-context-stage — resolveSearchOpts (KJC-TSK-0463)", () => {
+  it("falls back to defaults when rag.search is absent", () => {
+    const out = resolveSearchOpts({});
+    expect(out.mode).toBe("hybrid");
+    expect(out.alpha).toBe(0.6);
+    expect(out.rerankOpts).toBeUndefined();
+  });
+
+  it("forwards explicit mode/alpha as-is", () => {
+    const out = resolveSearchOpts({ rag: { search: { mode: "keyword", alpha: 0.2 } } });
+    expect(out.mode).toBe("keyword");
+    expect(out.alpha).toBe(0.2);
+  });
+
+  it("maps rerank=true to an empty rerankOpts object", () => {
+    const out = resolveSearchOpts({ rag: { search: { rerank: true } } });
+    expect(out.rerankOpts).toEqual({});
+  });
+
+  it("forwards an object-shaped rerank config verbatim", () => {
+    const cfg = { rag: { search: { rerank: { provider: "cohere", model: "rerank-3" } } } };
+    const out = resolveSearchOpts(cfg);
+    expect(out.rerankOpts).toEqual({ provider: "cohere", model: "rerank-3" });
+  });
+
+  it("ignores non-finite alpha (NaN, string) and falls back to default", () => {
+    expect(resolveSearchOpts({ rag: { search: { alpha: "nope" } } }).alpha).toBe(0.6);
+    expect(resolveSearchOpts({ rag: { search: { alpha: NaN } } }).alpha).toBe(0.6);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to v2.30.0 PR2 (#841). The HU Board modal already exposed
search-time RAG knobs (`rag.search.{mode,alpha,rerank}`), but they were
**dead settings** — `rag-context-stage.js` was calling `retriever.query()`
with only `topK`/`scope`, ignoring mode/alpha/rerank from config. This PR
wires them up.

- New exported helper `resolveSearchOpts(config)` in `rag-context-stage.js`:
  reads `config.rag.search.{mode,alpha,rerank}` with safe fallbacks
  (`hybrid` / `0.6` / no-rerank) and produces the shape `query()` expects
  (`rerank: true` ⇒ `rerankOpts: {}`; `rerank: object` ⇒ verbatim).
- `EDITABLE_FIELDS` gains the three matching entries
  (`ragSearchMode`/`Alpha`/`Rerank`) so they show up in the config modal
  and persist to `kj.config.yml` under `rag.search.*`.
- The pre-loop event detail now reports `mode`, `alpha`, `rerank` so the
  HU Board dashboard can show what actually drove retrieval.

## Test plan

- [x] `npx vitest run tests/board/config-yaml-rag-search.test.js` — 9/9
- [x] `npx vitest run tests/board/config-yaml-categories.test.js` — covers
  the updated category enumeration (4 → 7 RAG fields)
- [x] `git diff --stat` — 178 LOC (under the 200 LOC PR budget)

Refs: KJC-TSK-0463 · planning game task #99 (board scope: \"PR follow-up — wire rag.search.{mode,alpha,rerank} en rag-context-stage\")