### PR TITLE
feat(ci): prettier --check job (KJC-TSK-0464)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,32 @@ jobs:
       - name: Lint (node --check — parse-time syntax)
         run: npm run lint:syntax
 
+  # Prettier check — blocks PRs whose formatting drifts from the repo's
+  # .prettierrc.json. Added in KJC-TSK-0464 (2026-05-26) to close the
+  # ai-harness-scorecard "Formatter Enforcement" FAIL. Scope is
+  # intentionally small (workflows + root config) per .prettierignore;
+  # additional directories are folded in by future PRs to keep each
+  # change under the shrink-budget LOC cap.
+  format:
+    name: Format (Prettier --check)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Format (Prettier --check)
+        run: npm run format:check
+
   # ESLint runs on the same Node matrix as syntax (20/22). Pre-2026-04-30
   # this used to mention "Node 18 users still get parse-time guarantees" —
   # no longer relevant now that engines.node = >=20.10.0.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'scripts/**'
-      - 'src/**'
-      - 'bin/**'
+      - "package.json"
+      - "scripts/**"
+      - "src/**"
+      - "bin/**"
   workflow_dispatch:
 
 jobs:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,50 @@
+# KJC-TSK-0464 — start small. Prettier only enforces on a curated subset
+# of the repo (new workflows, root config JSON, .prettierrc/.prettierignore).
+# The bulk of the existing tree is excluded to avoid a mass-reformat PR
+# that would blow the 200-LOC shrink-budget gate. Future PRs can shrink
+# this list progressively, one directory at a time.
+
+# Build artifacts and vendored output
+dist/
+build/
+coverage/
+node_modules/
+**/node_modules/
+**/dist/
+**/build/
+**/coverage/
+
+# Lockfiles — never auto-format
+package-lock.json
+**/package-lock.json
+pnpm-lock.yaml
+yarn.lock
+
+# Karajan runtime state
+.kj/
+.karajan/
+.karajan-shared/
+sessions/
+**/__pycache__/
+
+# Existing source not yet under prettier (deferred)
+src/
+tests/
+templates/
+packages/hu-board/src/
+packages/hu-board/public/
+packages/hu-board/tests/
+scripts/
+bin/
+
+# Human-facing docs — markdown formatting is curated by hand, not by tool
+docs/
+*.md
+**/*.md
+**/*.mdx
+
+# Snapshots and fixtures
+**/*.snap
+**/__snapshots__/
+**/_diet/
+**/fixtures/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,11 +77,14 @@ export default [
     rules: {
       // --- Hard fail (the bug-killers) -------------------------------
       "no-undef": "error",
-      "import-x/no-unresolved": ["error", {
-        // Node built-ins like "node:fs" are fine even though no JS
-        // file lives behind them.
-        ignore: ["^node:"],
-      }],
+      "import-x/no-unresolved": [
+        "error",
+        {
+          // Node built-ins like "node:fs" are fine even though no JS
+          // file lives behind them.
+          ignore: ["^node:"],
+        },
+      ],
       "import-x/named": "error",
 
       // --- Soft signals (warn, not error) ----------------------------
@@ -89,11 +92,14 @@ export default [
       // 2026-04-30 cleanup pass that closed 57 warnings across 30
       // files. With src/ at 0 warnings, the next no-unused-vars
       // regression should fail CI, not silently accumulate.
-      "no-unused-vars": ["error", {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        caughtErrors: "none",
-      }],
+      "no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrors: "none",
+        },
+      ],
       // Same ratchet rationale: these were warnings while the cleanup
       // backlog existed; the same PR closed them all, so they're now
       // hard errors. A regression is louder than a "warn".
@@ -116,13 +122,16 @@ export default [
       // The selector matches both reads (`globalThis.__KJ_FOO`) and
       // writes (`globalThis.__KJ_FOO = ...`), which is what we want —
       // production code shouldn't touch these at all.
-      "no-restricted-syntax": ["error", {
-        selector: "MemberExpression[object.name='globalThis'][property.name=/^__KJ_/]",
-        message:
-          "globalThis.__KJ_* is a test-only override surface. " +
-          "Read/write it only from src/config/test-harness.js, then expose " +
-          "the value through a typed config getter that the rest of src/ uses.",
-      }],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "MemberExpression[object.name='globalThis'][property.name=/^__KJ_/]",
+          message:
+            "globalThis.__KJ_* is a test-only override surface. " +
+            "Read/write it only from src/config/test-harness.js, then expose " +
+            "the value through a typed config getter that the rest of src/ uses.",
+        },
+      ],
     },
   },
   {
@@ -185,9 +194,12 @@ export default [
     rules: {
       // --- Hard fail (the bug-killers) -------------------------------
       "no-undef": "error",
-      "import-x/no-unresolved": ["error", {
-        ignore: ["^node:"],
-      }],
+      "import-x/no-unresolved": [
+        "error",
+        {
+          ignore: ["^node:"],
+        },
+      ],
       "import-x/named": "error",
 
       // --- Soft signals (warn, not error) ----------------------------

--- a/examples/dni-validator/package.json
+++ b/examples/dni-validator/package.json
@@ -1,1 +1,11 @@
-{"name":"kj-demo","version":"1.0.0","type":"module","scripts":{"test":"vitest run"},"devDependencies":{"vitest":"^4.0.0"}}
+{
+  "name": "kj-demo",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0"
+  }
+}

--- a/examples/dni-validator/validateDNI.js
+++ b/examples/dni-validator/validateDNI.js
@@ -1,4 +1,4 @@
-const DNI_LETTERS = 'TRWAGMYFPDXBNJZSQVHLCKE';
+const DNI_LETTERS = "TRWAGMYFPDXBNJZSQVHLCKE";
 const DNI_REGEX = /^(\d{8})([A-Za-z])$/;
 
 /**
@@ -7,13 +7,13 @@ const DNI_REGEX = /^(\d{8})([A-Za-z])$/;
  * @returns {{ valid: boolean, error: string|null }}
  */
 export function validateDNI(input) {
-  if (typeof input !== 'string') {
-    return { valid: false, error: 'Formato inválido: se esperan 8 dígitos y una letra' };
+  if (typeof input !== "string") {
+    return { valid: false, error: "Formato inválido: se esperan 8 dígitos y una letra" };
   }
 
   const match = input.match(DNI_REGEX);
   if (!match) {
-    return { valid: false, error: 'Formato inválido: se esperan 8 dígitos y una letra' };
+    return { valid: false, error: "Formato inválido: se esperan 8 dígitos y una letra" };
   }
 
   const digits = parseInt(match[1], 10);
@@ -21,7 +21,10 @@ export function validateDNI(input) {
   const expectedLetter = DNI_LETTERS[digits % 23];
 
   if (letter !== expectedLetter) {
-    return { valid: false, error: `Letra inválida: se esperaba '${expectedLetter}', se recibió '${letter}'` };
+    return {
+      valid: false,
+      error: `Letra inválida: se esperaba '${expectedLetter}', se recibió '${letter}'`,
+    };
   }
 
   return { valid: true, error: null };

--- a/examples/dni-validator/validateDNI.test.js
+++ b/examples/dni-validator/validateDNI.test.js
@@ -1,60 +1,60 @@
-import { describe, it, expect } from 'vitest';
-import { validateDNI } from './validateDNI.js';
+import { describe, it, expect } from "vitest";
+import { validateDNI } from "./validateDNI.js";
 
-describe('validateDNI', () => {
-  it('returns valid for a correct DNI', () => {
+describe("validateDNI", () => {
+  it("returns valid for a correct DNI", () => {
     // 12345678Z is valid: 12345678 % 23 = 14 → letter 'Z'
-    expect(validateDNI('12345678Z')).toEqual({ valid: true, error: null });
+    expect(validateDNI("12345678Z")).toEqual({ valid: true, error: null });
   });
 
-  it('is case-insensitive', () => {
-    expect(validateDNI('12345678z')).toEqual({ valid: true, error: null });
+  it("is case-insensitive", () => {
+    expect(validateDNI("12345678z")).toEqual({ valid: true, error: null });
   });
 
-  it('returns error for wrong letter', () => {
-    const result = validateDNI('12345678A');
+  it("returns error for wrong letter", () => {
+    const result = validateDNI("12345678A");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/letra/i);
   });
 
-  it('returns error for invalid format - too few digits', () => {
-    const result = validateDNI('1234567Z');
+  it("returns error for invalid format - too few digits", () => {
+    const result = validateDNI("1234567Z");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/formato/i);
   });
 
-  it('returns error for invalid format - too many digits', () => {
-    const result = validateDNI('123456789Z');
+  it("returns error for invalid format - too many digits", () => {
+    const result = validateDNI("123456789Z");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/formato/i);
   });
 
-  it('returns error for invalid format - no letter', () => {
-    const result = validateDNI('123456789');
+  it("returns error for invalid format - no letter", () => {
+    const result = validateDNI("123456789");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/formato/i);
   });
 
-  it('returns error for empty input', () => {
-    const result = validateDNI('');
+  it("returns error for empty input", () => {
+    const result = validateDNI("");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/formato/i);
   });
 
-  it('returns error for null/undefined', () => {
+  it("returns error for null/undefined", () => {
     expect(validateDNI(null).valid).toBe(false);
     expect(validateDNI(undefined).valid).toBe(false);
   });
 
-  it('validates several known-good DNIs', () => {
+  it("validates several known-good DNIs", () => {
     // 00000000T → 0 % 23 = 0 → 'T'
-    expect(validateDNI('00000000T')).toEqual({ valid: true, error: null });
+    expect(validateDNI("00000000T")).toEqual({ valid: true, error: null });
     // 99999999R → 99999999 % 23 = 3 → 'R'
-    expect(validateDNI('99999999R')).toEqual({ valid: true, error: null });
+    expect(validateDNI("99999999R")).toEqual({ valid: true, error: null });
   });
 
-  it('rejects DNI with spaces or special chars', () => {
-    const result = validateDNI('1234 678Z');
+  it("rejects DNI with spaces or special chars", () => {
+    const result = validateDNI("1234 678Z");
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/formato/i);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "globals": "^17.5.0",
         "lint-staged": "^16.4.0",
         "postject": "^1.0.0-alpha.6",
+        "prettier": "^3.4.2",
         "simple-git-hooks": "^2.13.1",
         "vitest": "^4.0.0"
       },
@@ -5718,6 +5719,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "lint:syntax": "((command -v rg >/dev/null 2>&1 && rg --files src tests | rg '\\.js$') || find src tests -type f -name '*.js') | while IFS= read -r f; do node --check \"$f\"; done",
+    "format:check": "prettier --check .",
+    "format:fix": "prettier --write .",
     "typecheck": "npx -p typescript@5 tsc --noEmit -p tsconfig.json",
     "validate": "npm run lint && npm run lint:syntax && npm test",
     "mcp": "node src/mcp/server.js"
@@ -93,6 +95,7 @@
     "globals": "^17.5.0",
     "lint-staged": "^16.4.0",
     "postject": "^1.0.0-alpha.6",
+    "prettier": "^3.4.2",
     "simple-git-hooks": "^2.13.1",
     "vitest": "^4.0.0"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,11 +30,5 @@
     "src/brain/solomon-consult.js",
     "src/session/journal/**/*.js"
   ],
-  "exclude": [
-    "node_modules",
-    "packages",
-    "dist",
-    "coverage",
-    "tests"
-  ]
+  "exclude": ["node_modules", "packages", "dist", "coverage", "tests"]
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,17 +12,11 @@ const basicReporterPath = fileURLToPath(
 export default defineConfig({
   resolve: {
     alias: {
-      basic: basicReporterPath
-    }
+      basic: basicReporterPath,
+    },
   },
   test: {
-    exclude: [
-      "node_modules/**",
-      "packages/**",
-      ".claude/**",
-      ".kj/**",
-      "demo/**"
-    ],
+    exclude: ["node_modules/**", "packages/**", ".claude/**", ".kj/**", "demo/**"],
     setupFiles: ["./tests/setup.js"],
     testTimeout: 30000,
     // Audit recommendation #7: per-directory coverage thresholds for the
@@ -39,8 +33,8 @@ export default defineConfig({
       include: ["src/**/*.js"],
       exclude: [
         "src/**/*.test.js",
-        "src/cli.js",                  // the CLI entry — exercised by e2e
-        "src/mcp/server.js",           // long-running process, hard to unit
+        "src/cli.js", // the CLI entry — exercised by e2e
+        "src/mcp/server.js", // long-running process, hard to unit
       ],
       thresholds: {
         // Per-glob targets reflect the audit's prioritisation:
@@ -56,5 +50,5 @@ export default defineConfig({
         functions: 40,
       },
     },
-  }
+  },
 });


### PR DESCRIPTION
## Summary

Closes the **Formatter Enforcement** FAIL in [ai-harness-scorecard](https://github.com/manufosela/karajan-code) and brings karajan-code from grade C toward B.

- Adds **prettier 3.4.2** as devDependency
- `.prettierrc.json` matches the existing project style (double quotes, semicolons, 100-char width, es5 trailing commas, lf line endings, arrow parens always)
- `.prettierignore` keeps the enforced scope **deliberately narrow** (workflows + root config + examples). Source trees (\`src/\`, \`tests/\`, \`templates/\`, \`packages/hu-board/\`, \`scripts/\`, \`bin/\`) and human docs (\`docs/\`, \`*.md\`) are excluded to avoid a mass-reformat PR that would explode the 200-LOC shrink-budget. Future PRs can fold in directories one at a time.
- New CI job **\`format\`** (Node 22.x) runs \`prettier --check .\` and blocks PRs with formatting drift
- npm scripts: \`format:check\`, \`format:fix\`
- Reformats **7 in-scope files** that had drifted

## Test plan

- [x] \`npm run format:check\` passes locally
- [x] \`npm run format:fix\` is idempotent
- [x] Net diff (~113 LOC) within shrink-budget
- [ ] CI \`format\` job passes
- [ ] CI \`lint\` / \`tests\` jobs remain green

## Notes

Pre-existing test failures (42/5246) are unrelated to this PR (confirmed via \`git stash\` comparison on main). They will be addressed in a separate card.