### PR TITLE
fix(tests): repair 42 failing tests on main (KJC-BUG-0065)

### DIFF
--- a/tests/board/board.test.js
+++ b/tests/board/board.test.js
@@ -53,6 +53,9 @@ describe("config defaults include hu_board", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-cfg-test-"));
     const prevKjHome = process.env.KJ_HOME;
     process.env.KJ_HOME = tmpDir;
+    // loadConfig refuses local config without a global counterpart
+    // (KJC-TSK-0395). Pre-seed an empty global config.
+    fs.writeFileSync(path.join(tmpDir, "kj.config.yml"), "");
     try {
       const { loadConfig } = await import("../../src/config.js");
       const { config } = await loadConfig();

--- a/tests/sea-build.test.js
+++ b/tests/sea-build.test.js
@@ -14,7 +14,7 @@
 
 import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import { execFileSync } from "node:child_process";
-import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { readFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -54,14 +54,22 @@ describe("SEA bundle (KJC-BUG-0040)", () => {
   });
 
   it("emits the stub message (not a stack trace) when `board cleanup` is invoked", () => {
+    // The child node process inherits process.env.VITEST, which routes
+    // KARAJAN_HOME to a fresh tmp dir without a global kj.config.yml. The
+    // repo's .karajan/kj.config.yml then trips loadConfig's local-without-
+    // global guard. Pre-seed an empty global config for the child.
+    const childHome = mkdtempSync(join(tmpdir(), "kj-sea-home-"));
+    writeFileSync(join(childHome, "kj.config.yml"), "");
+    const env = { ...process.env, KARAJAN_HOME: childHome };
     let stdout = "";
     let stderr = "";
     try {
-      stdout = execFileSync("node", [bundlePath, "board", "cleanup"], { encoding: "utf8" });
+      stdout = execFileSync("node", [bundlePath, "board", "cleanup"], { encoding: "utf8", env });
     } catch (err) {
       stdout = String(err.stdout || "");
       stderr = String(err.stderr || "");
     }
+    rmSync(childHome, { recursive: true, force: true });
     const combined = `${stdout}\n${stderr}`;
     expect(combined).toContain("The HU Board is not available in this standalone binary");
     expect(combined).toContain("npm install -g karajan-code");

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -17,11 +17,27 @@
  *    `config.preflight.extended: true` or override the global.
  */
 
+import fs from "node:fs";
+import path from "node:path";
+import { getKarajanHome } from "../src/utils/paths.js";
+
 process.env.ANTHROPIC_API_KEY ??= "sk-test-anthropic";
 process.env.OPENAI_API_KEY ??= "sk-test-openai";
 process.env.GEMINI_API_KEY ??= "sk-test-gemini";
 process.env.GOOGLE_API_KEY ??= "sk-test-google";
 process.env.OPENCODE_API_KEY ??= "sk-test-opencode";
+
+// loadConfig refuses local config without a global counterpart (KJC-TSK-0395).
+// Under Vitest, KARAJAN_HOME is auto-isolated to a tmp dir per worker but the
+// cwd is still the karajan-code repo, which ships a real `.karajan/kj.config.yml`.
+// Pre-seed an empty global config so loadConfig is happy in tests that exercise
+// it (i18n.test.js, board.test.js, sea-build.test.js).
+const _home = getKarajanHome();
+fs.mkdirSync(_home, { recursive: true });
+const _globalCfg = path.join(_home, "kj.config.yml");
+if (!fs.existsSync(_globalCfg)) {
+  fs.writeFileSync(_globalCfg, "");
+}
 
 globalThis.__KJ_DEFAULT_PREFLIGHT_EXTENDED = false;
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -24,7 +24,19 @@ export default defineConfig({
       "demo/**"
     ],
     setupFiles: ["./tests/setup.js"],
-    testTimeout: 30000,
+    // 120s default. Orchestrator integration tests (runflow-*, reviewer-*,
+    // kj-run-smoke, subloop-limits) wire up multi-stage pipelines and can
+    // take 60-90s under host contention even though each test passes in
+    // ~5-15s in isolation. Use forks (not threads) because several config
+    // tests call process.chdir(), which throws inside worker_threads.
+    testTimeout: 120000,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 6,
+        minForks: 1,
+      },
+    },
     // Audit recommendation #7: per-directory coverage thresholds for the
     // areas the audit flagged as "large surfaces with no same-name test
     // file". Coverage isn't a CI gate yet (would block PRs unrelated to


### PR DESCRIPTION
## Summary

Fixes two root causes that combined to break 42 tests on `main` before any of my recent work landed:

### Root cause #1 — `loadConfig` guard rejected the repo's local config
KJC-TSK-0395 added a guard in `src/config/loader.js`:

```js
if (projectConfig && !globalExists) {
  throw new Error("Local config found at … but no global config exists");
}
```

Under Vitest, `KARAJAN_HOME` is auto-isolated to a tmp dir per worker (empty), but the `cwd` remains the karajan-code repo — which ships a real `.karajan/kj.config.yml`. Loader throws.

**Fix:** pre-seed an empty global `kj.config.yml` in three places:
- `tests/setup.js` — global vitest setup, covers all suites that touch `loadConfig`
- `tests/board/board.test.js` — test sets its own `KJ_HOME` to a fresh tmp dir; seed there too
- `tests/sea-build.test.js` — the spawned child node process inherits `process.env.VITEST` and routes to an empty tmp HOME; pass an explicit `KARAJAN_HOME` with the pre-seeded global

### Root cause #2 — `testTimeout=30s` insufficient under host contention
Orchestrator integration tests (`runflow-*`, `reviewer-*`, `kj-run-smoke`, `subloop-limits`) pass in 5–15s individually but stall to 60–90s when 20 vitest workers contend for CPU. The 30s ceiling timed them out.

**Fix:**
- Bumped `testTimeout` to 120s
- Switched `pool` from `threads` (default) to `forks` with `maxForks: 6` — `process.chdir()` (used by `tests/config.test.js`) is not supported inside worker_threads

## Verification

```
Test Files  462 passed (462)
Tests       5246 passed (5246)
Duration    320.82s
```

Diff: `+42 / -3` LOC, well within the 200-LOC shrink-budget.

## Why "fix all tests even when not my fault"

Project rule: tests must always pass on main. These regressions were pre-existing but blocked every other PR's CI signal. Refs KJC-BUG-0065.

## Test plan

- [x] `npm test` — all 5246 tests pass locally
- [ ] CI green on this PR
- [ ] No new flakiness introduced (orchestrator suites still run fast in isolation)