### PR TITLE
fix(spec-review): await openEditor in refine-loop (KJC-BUG-0066)

### DIFF
--- a/src/spec-review/refine-loop.js
+++ b/src/spec-review/refine-loop.js
@@ -50,7 +50,7 @@ export async function runRefinePass({ spec, findings, role, projectDir, taskFile
   } catch (err) { return { ok: false, error: `persist failed: ${err.message}`, hashChanged: false }; }
 
   const before = sha256(refineRes.refinedSpec);
-  openEditor(v2Path, { logger, openEditorFn });
+  await openEditor(v2Path, { logger, openEditorFn });
   let after;
   try { after = await _fs.readFile(v2Path, "utf8"); }
   catch (err) { return { ok: false, error: `read v2 failed: ${err.message}`, hashChanged: false }; }


### PR DESCRIPTION
## Summary
- One-line fix: `await openEditor(...)` in `src/spec-review/refine-loop.js:53`.
- The async `openEditorFn` injected by tests writes via `await fs.writeFile`; the call site dropped the promise and then ran `fs.readFile` in the next microtask — under host contention `readFile` could win the race and return empty content.

## Background
- Node 22.x CI on PR #870 (KJC-TSK-0465) flaked on `tests/spec-review/refine-loop.test.js > reports hashChanged=true when the editor modifies v2` with `AssertionError: expected '' to be 'v2 EDITED'`.
- Historical: 2/15 main runs failed the same way pre-fix → pre-existing flake, not introduced by #870.

## Test plan
- [x] `npx vitest run tests/spec-review/refine-loop.test.js` → 4/4 green locally.
- [ ] Full CI passes on this PR.

Fixes KJC-BUG-0066.