### PR TITLE
ci: add commitlint Conventional Commits job (KJC-TSK-0466)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "header-max-length": [2, "always", 100],
+    "type-enum": [
+      2,
+      "always",
+      ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,29 @@ jobs:
       - name: Lint (node --check — parse-time syntax)
         run: npm run lint:syntax
 
+  # Conventional Commits enforcement on PR head. Closes the
+  # ai-harness-scorecard "Mechanical Constraints / Conventional Commits"
+  # FAIL by adding CI-side enforcement on top of the local pre-commit hook
+  # (KJC-TSK-0466, 2026-05-27). wagoid/commitlint-github-action handles
+  # checkout depth, fetches the PR commit range, and runs commitlint with
+  # the config in .commitlintrc.json.
+  commitlint:
+    name: Commit messages (Conventional Commits)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Lint PR commits
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .commitlintrc.json
+          failOnWarnings: false
+
   # Prettier check — blocks PRs whose formatting drifts from the repo's
   # .prettierrc.json. Added in KJC-TSK-0464 (2026-05-26) to close the
   # ai-harness-scorecard "Formatter Enforcement" FAIL. Scope is


### PR DESCRIPTION
## Summary

Closes ai-harness-scorecard **Mechanical Constraints / Conventional Commits** FAIL (0/2) by adding CI-side enforcement on top of the local pre-commit hook.

The scorecard awards 2/2 only when a workflow validates commit messages, not when validation lives in a local hook (which can be bypassed via `--no-verify`, fork pushes, or hookless checkouts).

### What ships

- **`.commitlintrc.json`** — extends `@commitlint/config-conventional`, restricts `type-enum` to the 11 conventional types this repo already uses (`feat/fix/chore/refactor/docs/test/build/ci/perf/revert/style`), caps header at 100 chars.
- **`.github/workflows/ci.yml`** — new job *Commit messages (Conventional Commits)* gated on `pull_request` events, using [`wagoid/commitlint-github-action@v6`](https://github.com/wagoid/commitlint-github-action). It self-installs commitlint, so no `package.json` change.

### Why no devDependency

The action ships its own commitlint runtime and reads `.commitlintrc.json` directly. Adding `@commitlint/cli` to devDeps would be dead weight (we don't run `commitlint` locally — `simple-git-hooks` already validates messages via `commit-msg` from a different path).

### Net LOC

34 lines added (under the 200-LOC shrink-budget).

## Test plan

- [x] Local prettier check passes
- [ ] CI green on this PR
- [ ] Commitlint job appears in checks and validates this PR's commit message
- [ ] After merge, re-running ai-harness-scorecard scores 2/2 on Conventional Commits