### PR TITLE
feat(lint): eslint-plugin-security focused rules (KJC-TSK-0468)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@
 
 import js from "@eslint/js";
 import importX from "eslint-plugin-import-x";
+import security from "eslint-plugin-security";
 import globals from "globals";
 
 export default [
@@ -73,6 +74,7 @@ export default [
     },
     plugins: {
       "import-x": importX,
+      security,
     },
     rules: {
       // --- Hard fail (the bug-killers) -------------------------------
@@ -86,6 +88,23 @@ export default [
         },
       ],
       "import-x/named": "error",
+
+      // --- Unsafe code policy (KJC-TSK-0468) -------------------------
+      // High-signal rules from eslint-plugin-security. The "noisy"
+      // members of the recommended preset (`detect-object-injection`,
+      // `detect-non-literal-fs-filename`, `detect-child-process`) are
+      // intentionally NOT enabled — they flag a huge percentage of
+      // legitimate orchestrator code (fs ops on user paths, execa
+      // calls). The rules below catch concrete dynamic-code-execution
+      // and crypto smells without false-positive churn.
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-new-func": "error",
+      "security/detect-eval-with-expression": "error",
+      "security/detect-non-literal-require": "error",
+      "security/detect-pseudoRandomBytes": "error",
+      "security/detect-disable-mustache-escape": "error",
+      "security/detect-non-literal-regexp": "warn",
 
       // --- Soft signals (warn, not error) ----------------------------
       // Audit rec #8: ratchet from "warn" to "error" after the

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "esbuild": "^0.28.0",
         "eslint": "^10.2.1",
         "eslint-plugin-import-x": "^4.16.2",
+        "eslint-plugin-security": "^4.0.0",
         "globals": "^17.5.0",
         "lint-staged": "^16.4.0",
         "postject": "^1.0.0-alpha.6",
@@ -3410,6 +3411,22 @@
         }
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+      "integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -5872,6 +5889,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6039,6 +6066,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "esbuild": "^0.28.0",
     "eslint": "^10.2.1",
     "eslint-plugin-import-x": "^4.16.2",
+    "eslint-plugin-security": "^4.0.0",
     "globals": "^17.5.0",
     "lint-staged": "^16.4.0",
     "postject": "^1.0.0-alpha.6",


### PR DESCRIPTION
## Summary
- Adds `eslint-plugin-security@^4.0.0` with **focused** high-signal rules
- Bans dynamic code execution: `no-eval`, `no-implied-eval`, `no-new-func`, `security/detect-eval-with-expression`, `security/detect-non-literal-require`
- Bans weak crypto and mustache escape disable: `security/detect-pseudoRandomBytes`, `security/detect-disable-mustache-escape`
- `security/detect-non-literal-regexp` as **warn** (internal patterns, not user input)
- Closes the **Unsafe Code Policy** FAIL on the AI Harness Scorecard

## Trade-off vs the recommended preset
The recommended set includes `detect-object-injection`, `detect-non-literal-fs-filename`, and `detect-child-process`. All three would flag a huge percentage of legitimate orchestrator code (user-path fs ops, execa calls) — those are **intentionally NOT enabled**. The rules above catch the concrete dynamic-code-execution and crypto smells without false-positive churn.

## Lint output
- **0 errors**
- **14 warnings**, all `detect-non-literal-regexp`, all internal pattern construction (not user input)

Card: [KJC-TSK-0468](https://planning-game.io)

## Test plan
- [x] `npm run lint` → exit 0
- [x] `prettier --check` → clean
- [ ] CI: syntax, format, lint, test (Node 20+22), commitlint (after #872 merges), coverage