### PR TITLE
feat(audit): integrate harness scorecard into kj audit (KJC-TSK-0471)

### DIFF
--- a/src/audit/harness-section.js
+++ b/src/audit/harness-section.js
@@ -1,0 +1,77 @@
+// KJC-TSK-0471 — Harness Scorecard audit stage.
+// Runs the markmishaev76/ai-harness-scorecard container after the deterministic
+// phase, persists scorecard.json + scorecard-report.md under
+// .karajan/audit-runs/<ts>/, and returns a summary the renderer surfaces as a
+// "Harness Health Score" markdown block. KJC-TSK-0472 will consume the
+// persisted artefacts to build audit-history.db.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { normalizeHarnessConfig, runHarnessAssess } from "./harness-scorecard.js";
+
+const CATEGORIES = [
+  ["architectural_docs", "Architectural Docs", 20],
+  ["mechanical_constraints", "Mechanical Constraints", 25],
+  ["testing_stability", "Testing & Stability", 25],
+  ["review_drift_prevention", "Review & Drift Prevention", 15],
+  ["ai_specific_safeguards", "AI-Specific Safeguards", 15],
+];
+const labelFor = (k) => CATEGORIES.find(([key]) => key === k)?.[1] || k;
+const ts = () => new Date().toISOString().replaceAll(/[:.]/g, "-");
+
+export async function runHarnessSection({ projectDir, harnessConfig = null, runAssess = runHarnessAssess } = {}) {
+  const cfg = normalizeHarnessConfig(harnessConfig || {});
+  if (!cfg.enabled) return { ok: true, skipped: true, reason: "disabled" };
+  const res = await runAssess(projectDir, cfg);
+  if (!res.ok) return { ok: false, error: res.error };
+  const outDir = path.join(projectDir, ".karajan", "audit-runs", ts());
+  await fs.mkdir(outDir, { recursive: true });
+  const scorecardPath = path.join(outDir, "scorecard.json");
+  const rawReportPath = path.join(outDir, "scorecard-report.md");
+  await fs.writeFile(scorecardPath, JSON.stringify(res.raw, null, 2), "utf8");
+  await fs.writeFile(rawReportPath, res.raw?.report_markdown || res.raw?.markdown || "", "utf8");
+  return {
+    ok: true, score: res.score, grade: res.grade,
+    categories: res.raw?.categories || {},
+    checks: Array.isArray(res.raw?.checks) ? res.raw.checks : [],
+    scorecardPath, rawReportPath, image: cfg.image,
+  };
+}
+
+export function formatHarnessSection(summary) {
+  if (!summary || summary.skipped) return "";
+  if (!summary.ok) return `## Harness Scorecard\n\n_skipped: ${summary.error}_\n`;
+  const lines = [
+    `## Harness Health Score: ${summary.score}/100 (${summary.grade})`,
+    "",
+    "| Category | Weight | Score |",
+    "| --- | --- | --- |",
+  ];
+  for (const [key, label, weight] of CATEGORIES) {
+    const score = summary.categories?.[key]?.score ?? "—";
+    lines.push(`| ${label} | ${weight}% | ${score} |`);
+  }
+  const checks = Array.isArray(summary.checks) ? summary.checks : [];
+  if (checks.length) {
+    const groups = new Map();
+    for (const c of checks) {
+      const k = c.category || "other";
+      if (!groups.has(k)) groups.set(k, []);
+      groups.get(k).push(c);
+    }
+    lines.push("", "### Checks");
+    for (const [k, list] of groups) {
+      lines.push(`- **${labelFor(k)}**`);
+      for (const c of list) lines.push(`  - ${c.passed ? "✓" : "✗"} ${c.name}${c.detail ? ` — ${c.detail}` : ""}`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+export function harnessSummaryForJson(summary) {
+  if (!summary?.ok || summary.skipped) return null;
+  return {
+    score: summary.score, grade: summary.grade,
+    categories: summary.categories, checks: summary.checks,
+    rawReportPath: summary.rawReportPath, scorecardPath: summary.scorecardPath,
+  };
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -161,6 +161,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
     .option("--no-semgrep", "Skip the Semgrep SAST collector. Findings are also skipped automatically when semgrep is not installed (install via 'pipx install semgrep' or 'brew install semgrep').")
+    .option("--no-harness", "Skip the AI Harness Scorecard stage (Docker one-shot). Auto-skipped when Docker is unavailable; the run also persists scorecard.json + scorecard-report.md under .karajan/audit-runs/<ts>/ for trend tracking (KJC-TSK-0472).")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
     .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
@@ -182,6 +183,7 @@ export function registerMeta(program, { pkgVersion }) {
           noSonar: flags.sonar === false,
           noOsv: flags.osv === false,
           noSemgrep: flags.semgrep === false,
+          noHarness: flags.harness === false,
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -11,6 +11,7 @@ import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
 import { formatDeterministicSummary } from "../audit/deterministic-summary.js";
+import { runHarnessSection, formatHarnessSection, harnessSummaryForJson } from "../audit/harness-section.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -191,20 +192,21 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
-function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }) {
+function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
   if (noSonar) parts.push("--no-sonar");
   if (noOsv) parts.push("--no-osv");
   if (noSemgrep) parts.push("--no-semgrep");
+  if (noHarness) parts.push("--no-harness");
   if (deterministicOnly) parts.push("--deterministic-only");
   if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, noHarness = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -247,6 +249,27 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     const deterministicCtx = await role.collectDeterministic(roleInput);
     const deterministicMd = formatDeterministicSummary(deterministicCtx);
 
+    // KJC-TSK-0471 — Harness Scorecard (Docker one-shot, golden metric).
+    // Runs after the deterministic phase, before the LLM. Auto-skipped on
+    // --no-harness or if `runHarnessSection` surfaces an error (graceful
+    // degradation: a missing Docker daemon must not break `kj audit`).
+    let harnessSummary = null;
+    if (!noHarness) {
+      try {
+        harnessSummary = await runHarnessSection({
+          projectDir: config?.projectDir || process.cwd(),
+          harnessConfig: config?.audit?.harness || null,
+        });
+        if (harnessSummary?.ok && !harnessSummary.skipped) {
+          runLog.logText(`[audit] harness score=${harnessSummary.score}/100 grade=${harnessSummary.grade}`);
+        }
+      } catch (e) {
+        harnessSummary = { ok: false, error: e?.message || String(e) };
+        runLog.logText(`[audit] harness skipped: ${harnessSummary.error}`);
+      }
+    }
+    const harnessMd = formatHarnessSection(harnessSummary);
+
     // --json suppresses the interactive flow regardless: it would mangle
     // a script's stdout. JSON consumers always get the full audit unless
     // they explicitly pass deterministicOnly.
@@ -263,18 +286,19 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     if (!runLlm) {
       // Deterministic-only path. Produce the report from what we already
       // have, persist it (md or json), and exit. Zero tokens spent.
+      const harnessJson = harnessSummaryForJson(harnessSummary);
       const stdoutContent = json
-        ? JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2)
-        : (deterministicOnly ? deterministicMd : ""); // already printed above when interactive
-      if (json || deterministicOnly) console.log(stdoutContent);
+        ? JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, mode: "deterministic-only" }, null, 2)
+        : (deterministicOnly ? `${deterministicMd}\n${harnessMd}` : harnessMd); // deterministicMd already printed above when interactive
+      if (json || deterministicOnly || harnessMd) console.log(stdoutContent);
 
       if (reportPath) {
         let payload;
         if (reportPath.endsWith(".json")) {
-          payload = JSON.stringify({ deterministic: deterministicCtx, mode: "deterministic-only" }, null, 2);
+          payload = JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, mode: "deterministic-only" }, null, 2);
         } else {
-          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }));
-          payload = header + deterministicMd + "\n";
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));
+          payload = `${header}${deterministicMd}\n${harnessMd}`;
         }
         await fs.writeFile(reportPath, payload, "utf8");
         runLog.logText(`[audit] report written (deterministic-only) → ${reportPath}`);
@@ -306,18 +330,19 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       runLog.logText(`[audit] usage tokens=${usage.total_tokens} cost=$${(usage.cost_usd ?? 0).toFixed(4)} duration=${(usage.durationMs / 1000).toFixed(1)}s`);
     }
 
+    const harnessJson = harnessSummaryForJson(harnessSummary);
     let stdoutContent;
     if (json) {
       const jsonPayload = parsed
-        ? { ...parsed, usage: usage || undefined }
-        : { ...roleResult, usage: usage || undefined };
+        ? { ...parsed, harnessScore: harnessJson, usage: usage || undefined }
+        : { ...roleResult, harnessScore: harnessJson, usage: usage || undefined };
       stdoutContent = JSON.stringify(jsonPayload, null, 2);
     } else if (parsed?.summary?.overallHealth) {
-      stdoutContent = formatAudit(parsed, usage);
+      stdoutContent = `${formatAudit(parsed, usage)}\n${harnessMd}`;
     } else if (parsed?.raw) {
-      stdoutContent = parsed.raw + (usage ? `\n\n${formatUsageSummary(usage) || ""}` : "");
+      stdoutContent = parsed.raw + (usage ? `\n\n${formatUsageSummary(usage) || ""}` : "") + `\n${harnessMd}`;
     } else {
-      stdoutContent = roleResult.summary || "Audit complete.";
+      stdoutContent = `${roleResult.summary || "Audit complete."}\n${harnessMd}`;
     }
     console.log(stdoutContent);
 
@@ -325,11 +350,11 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       let payload;
       if (reportPath.endsWith(".json")) {
         const jsonPayload = parsed
-          ? { ...parsed, usage: usage || undefined }
-          : { ...roleResult, usage: usage || undefined };
+          ? { ...parsed, harnessScore: harnessJson, usage: usage || undefined }
+          : { ...roleResult, harnessScore: harnessJson, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, json, deterministicOnly, yes }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/tests/audit/harness-section.test.js
+++ b/tests/audit/harness-section.test.js
@@ -1,0 +1,78 @@
+// KJC-TSK-0471 — kj audit harness section (run + format).
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+vi.mock("../../src/audit/harness-scorecard.js", () => ({
+  normalizeHarnessConfig: vi.fn((h = {}) => ({
+    enabled: h.enabled !== false,
+    image: h.image || "img:latest",
+  })),
+  runHarnessAssess: vi.fn(),
+}));
+import { runHarnessAssess } from "../../src/audit/harness-scorecard.js";
+import { runHarnessSection, formatHarnessSection } from "../../src/audit/harness-section.js";
+
+describe("audit/harness-section — KJC-TSK-0471", () => {
+  let tmp;
+  beforeEach(async () => {
+    runHarnessAssess.mockReset();
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), "kj-harness-"));
+  });
+
+  it("skipped when disabled in config", async () => {
+    const r = await runHarnessSection({ projectDir: tmp, harnessConfig: { enabled: false } });
+    expect(r).toMatchObject({ ok: true, skipped: true, reason: "disabled" });
+    expect(runHarnessAssess).not.toHaveBeenCalled();
+  });
+
+  it("persists scorecard.json + scorecard-report.md under .karajan/audit-runs", async () => {
+    runHarnessAssess.mockResolvedValueOnce({
+      ok: true, score: 78, grade: "B",
+      raw: { overall_score: 78, grade: "B", categories: {}, checks: [], report_markdown: "# Report\n" },
+    });
+    const r = await runHarnessSection({ projectDir: tmp });
+    expect(r).toMatchObject({ ok: true, score: 78, grade: "B" });
+    expect(r.scorecardPath).toMatch(/\.karajan[\\/]audit-runs[\\/].+[\\/]scorecard\.json$/);
+    expect(await fs.readFile(r.scorecardPath, "utf8")).toContain('"overall_score": 78');
+    expect(await fs.readFile(r.rawReportPath, "utf8")).toBe("# Report\n");
+  });
+
+  it("surfaces runHarnessAssess failure without throwing", async () => {
+    runHarnessAssess.mockResolvedValueOnce({ ok: false, error: "boom" });
+    expect(await runHarnessSection({ projectDir: tmp })).toMatchObject({ ok: false, error: "boom" });
+  });
+
+  it("formatHarnessSection renders header + 5-row category table", () => {
+    const md = formatHarnessSection({
+      ok: true, score: 78, grade: "B",
+      categories: { architectural_docs: { score: 16 }, testing_stability: { score: 20 } },
+      checks: [],
+    });
+    expect(md).toMatch(/Harness Health Score: 78\/100 \(B\)/);
+    expect(md).toMatch(/Architectural Docs \| 20% \| 16/);
+    expect(md).toMatch(/Testing & Stability \| 25% \| 20/);
+    expect(md).toMatch(/Review & Drift Prevention \| 15% \| —/);
+  });
+
+  it("formatHarnessSection groups checks by category with pass/fail marks", () => {
+    const md = formatHarnessSection({
+      ok: true, score: 50, grade: "C", categories: {},
+      checks: [
+        { name: "ADR present", passed: true, category: "architectural_docs" },
+        { name: "AGENTS.md", passed: false, category: "architectural_docs", detail: "missing" },
+      ],
+    });
+    expect(md).toMatch(/✓ ADR present/);
+    expect(md).toMatch(/✗ AGENTS\.md — missing/);
+  });
+
+  it("formatHarnessSection notes the failure when ok=false", () => {
+    expect(formatHarnessSection({ ok: false, error: "docker offline" })).toMatch(/skipped: docker offline/);
+  });
+
+  it("formatHarnessSection returns empty when skipped", () => {
+    expect(formatHarnessSection({ ok: true, skipped: true, reason: "disabled" })).toBe("");
+  });
+});

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -33,6 +33,11 @@ vi.mock("../../src/utils/cli-run-log.js", () => ({
     return fn({ runLog, forwardProgress: vi.fn() });
   }),
 }));
+vi.mock("../../src/audit/harness-section.js", () => ({
+  runHarnessSection: vi.fn(async () => ({ ok: true, skipped: true, reason: "disabled" })),
+  formatHarnessSection: vi.fn(() => ""),
+  harnessSummaryForJson: vi.fn(() => null),
+}));
 
 const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
 

--- a/tests/audit/two-phase.test.js
+++ b/tests/audit/two-phase.test.js
@@ -30,6 +30,11 @@ vi.mock("../../src/utils/cli-run-log.js", () => ({
     return fn({ runLog, forwardProgress: vi.fn() });
   }),
 }));
+vi.mock("../../src/audit/harness-section.js", () => ({
+  runHarnessSection: vi.fn(async () => ({ ok: true, skipped: true, reason: "disabled" })),
+  formatHarnessSection: vi.fn(() => ""),
+  harnessSummaryForJson: vi.fn(() => null),
+}));
 
 const sampleDeterministicCtx = {
   projectDir: "/tmp/x",

--- a/tests/commands/command-audit.test.js
+++ b/tests/commands/command-audit.test.js
@@ -42,6 +42,13 @@ vi.mock("../../src/utils/cli-run-log.js", () => ({
   }),
 }));
 
+// Harness stage runs Docker; stub it out so CLI tests stay hermetic.
+vi.mock("../../src/audit/harness-section.js", () => ({
+  runHarnessSection: vi.fn(async () => ({ ok: true, skipped: true, reason: "disabled" })),
+  formatHarnessSection: vi.fn(() => ""),
+  harnessSummaryForJson: vi.fn(() => null),
+}));
+
 function makeConfig(overrides = {}) {
   return {
     roles: { audit: { provider: "claude" } },


### PR DESCRIPTION
## Summary

Wire the AI Harness Scorecard ([TSK-0470](https://github.com/manufosela/karajan-code/pull/877)) into the two-phase `kj audit` flow as a deterministic golden metric.

The harness runs after the deterministic phase and before the optional LLM phase. Output (score + grade + categories + checks) is appended to the markdown report under `## Harness Health Score` and surfaced in the JSON payload as `harnessScore`.

## Changes

- **New module** `src/audit/harness-section.js` (77 LOC): `runHarnessSection`, `formatHarnessSection`, `harnessSummaryForJson`. DI-friendly (`runAssess` param) for hermetic testing.
- **Persistence**: writes `scorecard.json` + `scorecard-report.md` under `<projectDir>/.karajan/audit-runs/<ts>/` — the trend-tracking artefacts that KJC-TSK-0472 will consume to build `audit-history.db`.
- **Graceful degradation**: docker offline / image missing / runAssess failure → warning `"skipped: <reason>"`, audit continues normally. No throw, no broken exit code.
- **New CLI flag** `--no-harness` to opt out of the stage. Auto-skipped when docker is unavailable.
- **Markdown**: `## Harness Health Score: N/100 (grade)` + 5-row category breakdown + per-check pass/fail list grouped by category.
- **JSON**: `harnessScore` field next to `summary` + `usage` in both deterministic-only and full-audit payloads.

## Test plan

- [x] 7 new tests in `tests/audit/harness-section.test.js` (disabled / persists / failure / format)
- [x] 199/199 audit-related tests green (`tests/audit/` + `tests/commands/command-audit.test.js`)
- [x] Existing 3 audit test files mock the new module to keep CI hermetic (no docker pulls)
- [x] `prettier --check` on all touched files
- [x] Net delta within shrink-budget (215 insertions, 16 deletions)

## Notes

This is PR 2 of 4 in v2.33.0 candidate (KJC-PCS-0051 — golden metric epic). Next:
- KJC-TSK-0472 — Persistencia per-project `audit-history.db` (consumes the artefacts written here)
- KJC-TSK-0473 — Diff vs último run + trend sparkline