### PR TITLE
feat(audit): diff + trend sparkline for kj audit (KJC-TSK-0473)

### DIFF
--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -196,7 +196,7 @@ const auditHistoryStubPlugin = {
   name: "audit-history-stub",
   setup(b) {
     b.onResolve({ filter: /[\\/]audit[\\/]audit-history\.js$/ }, (a) => ({ path: a.path, namespace: "ahs" }));
-    b.onLoad({ filter: /.*/, namespace: "ahs" }, () => ({ contents: "module.exports = { __esModule: false, persistAuditRun: () => ({ ok: false, error: 'history disabled in SEA' }), getAuditHistoryDbPath: () => null, openAuditHistoryDb: () => null, recordAuditRun: () => null, listRecentRuns: () => [], countRuns: () => 0, pruneOldRuns: () => 0 };", loader: "js" }));
+    b.onLoad({ filter: /.*/, namespace: "ahs" }, () => ({ contents: "module.exports = { __esModule: false, persistAuditRun: () => ({ ok: false, error: 'history disabled in SEA' }), getAuditHistoryDbPath: () => null, openAuditHistoryDb: () => null, recordAuditRun: () => null, listRecentRuns: () => [], countRuns: () => 0, pruneOldRuns: () => 0, getLatestPreviousRun: () => null, getRecentScores: () => [] };", loader: "js" }));
   },
 };
 

--- a/src/audit/audit-history-display.js
+++ b/src/audit/audit-history-display.js
@@ -1,0 +1,61 @@
+// KJC-TSK-0473 — Pure display helpers for audit history (diff + sparkline).
+// No DB / native-module deps; safe to bundle into the SEA binary.
+
+const SPARK_BARS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+function scoreOf(c) {
+  if (!c || typeof c !== "object") return null;
+  return typeof c.score === "number" ? c.score : typeof c.percent === "number" ? c.percent : null;
+}
+
+export function computeHistoryDiff(currentHarness, previousRow) {
+  if (!currentHarness || typeof currentHarness.score !== "number") return null;
+  if (!previousRow || typeof previousRow.score !== "number") return { previousScore: null, firstRun: true };
+  let prevCats = {};
+  try { prevCats = previousRow.categories_json ? JSON.parse(previousRow.categories_json) || {} : {}; } catch { /* keep empty */ }
+  const currCats = currentHarness.categories || {};
+  const categoryDeltas = [];
+  for (const name of Object.keys(currCats)) {
+    const cur = scoreOf(currCats[name]);
+    const prev = scoreOf(prevCats[name]);
+    if (typeof cur === "number" && typeof prev === "number") {
+      categoryDeltas.push({ name, current: cur, previous: prev, delta: cur - prev });
+    }
+  }
+  const sorted = [...categoryDeltas].sort((a, b) => b.delta - a.delta);
+  const t = previousRow.timestamp ? Date.parse(previousRow.timestamp) : NaN;
+  const ageDays = Number.isNaN(t) ? null : Math.floor((Date.now() - t) / 86400000);
+  return {
+    previousScore: previousRow.score,
+    previousGrade: previousRow.grade || null,
+    previousTimestamp: previousRow.timestamp,
+    delta: currentHarness.score - previousRow.score,
+    categoryDeltas,
+    biggestImprovement: sorted.find((c) => c.delta > 0) || null,
+    biggestRegression: [...sorted].reverse().find((c) => c.delta < 0) || null,
+    baselineAgeDays: ageDays,
+    baselineStale: ageDays != null && ageDays > 30,
+  };
+}
+
+export function formatHistoryDiff(diff) {
+  if (!diff) return "";
+  if (diff.firstRun) return "_First run for this project — no baseline yet._";
+  const arrow = diff.delta > 0 ? "↑" : diff.delta < 0 ? "↓" : "=";
+  const sign = diff.delta > 0 ? "+" : "";
+  const prevDate = (diff.previousTimestamp || "").slice(0, 10);
+  const lines = [`**Δ ${sign}${diff.delta} ${arrow} vs run anterior** (${prevDate}, ${diff.previousScore}/100 ${diff.previousGrade || ""})`];
+  if (diff.baselineStale) lines.push(`> ⚠ baseline antigua (${diff.baselineAgeDays} días) — considera ejecutar \`kj audit\` con más frecuencia.`);
+  if (diff.biggestImprovement) lines.push(`- Mayor mejora: **${diff.biggestImprovement.name}** (+${diff.biggestImprovement.delta})`);
+  if (diff.biggestRegression) lines.push(`- Mayor regresión: **${diff.biggestRegression.name}** (${diff.biggestRegression.delta})`);
+  return lines.join("\n");
+}
+
+export function formatTrendSparkline(scores) {
+  const xs = (scores || []).map((r) => (typeof r === "number" ? r : r?.score)).filter((n) => typeof n === "number");
+  if (xs.length === 0) return "";
+  if (xs.length === 1) return `Score trend: ${xs[0]} (single run)`;
+  const min = Math.min(...xs), max = Math.max(...xs), range = max - min || 1;
+  const bars = xs.map((n) => SPARK_BARS[Math.min(SPARK_BARS.length - 1, Math.floor(((n - min) / range) * (SPARK_BARS.length - 1)))]).join("");
+  return `Score trend (last ${xs.length} runs): ${xs[0]} ${bars} ${xs[xs.length - 1]}`;
+}

--- a/src/audit/audit-history.js
+++ b/src/audit/audit-history.js
@@ -64,6 +64,17 @@ export function listRecentRuns(db, limit = 10) {
   return db.prepare(`SELECT run_id, timestamp, git_sha, score, grade FROM audits ORDER BY timestamp DESC LIMIT ?`).all(limit);
 }
 
+// KJC-TSK-0473 — Fetch previous run (excluding current) for diff rendering.
+export function getLatestPreviousRun(db, currentTimestamp) {
+  return db.prepare(`SELECT run_id, timestamp, git_sha, score, grade, categories_json FROM audits WHERE timestamp < ? AND score IS NOT NULL ORDER BY timestamp DESC LIMIT 1`).get(currentTimestamp || new Date().toISOString()) || null;
+}
+
+// KJC-TSK-0473 — Score timeline (ASC) for sparkline rendering.
+export function getRecentScores(db, limit = 10) {
+  const rows = db.prepare(`SELECT timestamp, score FROM audits WHERE score IS NOT NULL ORDER BY timestamp DESC LIMIT ?`).all(limit);
+  return rows.reverse();
+}
+
 export function countRuns(db) {
   return db.prepare(`SELECT COUNT(*) AS n FROM audits`).get().n;
 }

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -161,7 +161,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-sonar", "Skip the SonarQube findings collector (faster, less context). Sonar findings are also skipped automatically when SonarQube is unreachable.")
     .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
     .option("--no-semgrep", "Skip the Semgrep SAST collector. Findings are also skipped automatically when semgrep is not installed (install via 'pipx install semgrep' or 'brew install semgrep').")
-    .option("--no-harness", "Skip the AI Harness Scorecard stage (Docker one-shot). Auto-skipped when Docker is unavailable; the run also persists scorecard.json + scorecard-report.md under .karajan/audit-runs/<ts>/ for trend tracking (KJC-TSK-0472).")
+    .option("--no-harness", "Skip the AI Harness Scorecard stage (Docker one-shot). Auto-skipped when Docker is unavailable. Each run is also persisted to .karajan/audit-history.db (KJC-TSK-0472) for diff/trend tracking.")
+    .option("--trend", "Append a sparkline of the harness score across the last 10 runs (uses .karajan/audit-history.db). KJC-TSK-0473.")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
     .option("-y, --yes", "Auto-confirm the 'Continue with LLM analysis?' prompt. Useful in scripts that want the full audit non-interactively. CI/non-TTY paths already auto-confirm without this flag.")
@@ -187,6 +188,7 @@ export function registerMeta(program, { pkgVersion }) {
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),
+          trend: Boolean(flags.trend),
         });
       });
     });

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -12,7 +12,8 @@ import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
 import { formatDeterministicSummary } from "../audit/deterministic-summary.js";
 import { runHarnessSection, formatHarnessSection, harnessSummaryForJson } from "../audit/harness-section.js";
-import { persistAuditRun } from "../audit/audit-history.js";
+import { persistAuditRun, openAuditHistoryDb, getLatestPreviousRun, getRecentScores } from "../audit/audit-history.js";
+import { computeHistoryDiff, formatHistoryDiff, formatTrendSparkline } from "../audit/audit-history-display.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -193,6 +194,28 @@ async function buildReportHeader(projectDir, invocation) {
   return lines.join("\n");
 }
 
+function composeHistoryBlock({ diffMd, trendMd }) {
+  const parts = [];
+  if (diffMd) parts.push(diffMd);
+  if (trendMd) parts.push(trendMd);
+  return parts.length ? `\n\n## Harness Score History\n${parts.join("\n\n")}` : "";
+}
+
+// KJC-TSK-0473 — Resolve diff vs previous run + optional trend sparkline.
+// Errors silenced: history is a nice-to-have; a broken db must not break audit.
+function loadAuditHistoryContext(projectDir, currentHarness, { showTrend = false } = {}) {
+  let db;
+  try {
+    db = openAuditHistoryDb(projectDir);
+    if (!db) return { diff: null, diffMd: "", trendMd: "" };
+    const previous = currentHarness?.score != null ? getLatestPreviousRun(db, new Date().toISOString()) : null;
+    const diff = currentHarness?.score != null ? computeHistoryDiff(currentHarness, previous) : null;
+    const trendMd = showTrend ? formatTrendSparkline(getRecentScores(db, 10)) : "";
+    return { diff, diffMd: formatHistoryDiff(diff), trendMd };
+  } catch { return { diff: null, diffMd: "", trendMd: "" }; }
+  finally { try { db?.close(); } catch { /* noop */ } }
+}
+
 function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
@@ -207,7 +230,7 @@ function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHar
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, noHarness = false, reportFile = null, deterministicOnly = false, yes = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, noHarness = false, reportFile = null, deterministicOnly = false, yes = false, trend = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -288,18 +311,21 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       // Deterministic-only path. Produce the report from what we already
       // have, persist it (md or json), and exit. Zero tokens spent.
       const harnessJson = harnessSummaryForJson(harnessSummary);
+      const currentHarness = harnessSummary?.ok && !harnessSummary.skipped ? harnessSummary : null;
+      const history = loadAuditHistoryContext(config?.projectDir || process.cwd(), currentHarness, { showTrend: trend });
+      const historyMd = composeHistoryBlock(history);
       const stdoutContent = json
-        ? JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, mode: "deterministic-only" }, null, 2)
-        : (deterministicOnly ? `${deterministicMd}\n${harnessMd}` : harnessMd); // deterministicMd already printed above when interactive
+        ? JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, harnessScoreDiff: history.diff, mode: "deterministic-only" }, null, 2)
+        : (deterministicOnly ? `${deterministicMd}\n${harnessMd}${historyMd}` : `${harnessMd}${historyMd}`);
       if (json || deterministicOnly || harnessMd) console.log(stdoutContent);
 
       if (reportPath) {
         let payload;
         if (reportPath.endsWith(".json")) {
-          payload = JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, mode: "deterministic-only" }, null, 2);
+          payload = JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, harnessScoreDiff: history.diff, mode: "deterministic-only" }, null, 2);
         } else {
           const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));
-          payload = `${header}${deterministicMd}\n${harnessMd}`;
+          payload = `${header}${deterministicMd}\n${harnessMd}${historyMd}`;
         }
         await fs.writeFile(reportPath, payload, "utf8");
         runLog.logText(`[audit] report written (deterministic-only) → ${reportPath}`);
@@ -333,18 +359,21 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     }
 
     const harnessJson = harnessSummaryForJson(harnessSummary);
+    const currentHarness = harnessSummary?.ok && !harnessSummary.skipped ? harnessSummary : null;
+    const history = loadAuditHistoryContext(config?.projectDir || process.cwd(), currentHarness, { showTrend: trend });
+    const historyMd = composeHistoryBlock(history);
     let stdoutContent;
     if (json) {
       const jsonPayload = parsed
-        ? { ...parsed, harnessScore: harnessJson, usage: usage || undefined }
-        : { ...roleResult, harnessScore: harnessJson, usage: usage || undefined };
+        ? { ...parsed, harnessScore: harnessJson, harnessScoreDiff: history.diff, usage: usage || undefined }
+        : { ...roleResult, harnessScore: harnessJson, harnessScoreDiff: history.diff, usage: usage || undefined };
       stdoutContent = JSON.stringify(jsonPayload, null, 2);
     } else if (parsed?.summary?.overallHealth) {
-      stdoutContent = `${formatAudit(parsed, usage)}\n${harnessMd}`;
+      stdoutContent = `${formatAudit(parsed, usage)}\n${harnessMd}${historyMd}`;
     } else if (parsed?.raw) {
-      stdoutContent = parsed.raw + (usage ? `\n\n${formatUsageSummary(usage) || ""}` : "") + `\n${harnessMd}`;
+      stdoutContent = parsed.raw + (usage ? `\n\n${formatUsageSummary(usage) || ""}` : "") + `\n${harnessMd}${historyMd}`;
     } else {
-      stdoutContent = `${roleResult.summary || "Audit complete."}\n${harnessMd}`;
+      stdoutContent = `${roleResult.summary || "Audit complete."}\n${harnessMd}${historyMd}`;
     }
     console.log(stdoutContent);
 
@@ -352,8 +381,8 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       let payload;
       if (reportPath.endsWith(".json")) {
         const jsonPayload = parsed
-          ? { ...parsed, harnessScore: harnessJson, usage: usage || undefined }
-          : { ...roleResult, harnessScore: harnessJson, usage: usage || undefined };
+          ? { ...parsed, harnessScore: harnessJson, harnessScoreDiff: history.diff, usage: usage || undefined }
+          : { ...roleResult, harnessScore: harnessJson, harnessScoreDiff: history.diff, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
         const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));

--- a/tests/audit/audit-history-display.test.js
+++ b/tests/audit/audit-history-display.test.js
@@ -1,0 +1,92 @@
+// KJC-TSK-0473 — display helpers for audit-history diff + sparkline.
+import { describe, expect, it } from "vitest";
+import { computeHistoryDiff, formatHistoryDiff, formatTrendSparkline } from "../../src/audit/audit-history-display.js";
+
+const currentHarness = {
+  score: 74, grade: "B",
+  categories: { architectural_docs: { score: 80 }, testing_stability: { score: 60 }, security: { score: 70 } },
+};
+
+function prevRow(overrides = {}) {
+  return {
+    score: 71, grade: "C",
+    timestamp: "2026-05-20T10:00:00Z",
+    categories_json: JSON.stringify({ architectural_docs: { score: 60 }, testing_stability: { score: 65 }, security: { score: 70 } }),
+    ...overrides,
+  };
+}
+
+describe("computeHistoryDiff — KJC-TSK-0473", () => {
+  it("returns firstRun:true when previous row is missing", () => {
+    expect(computeHistoryDiff(currentHarness, null)).toMatchObject({ firstRun: true, previousScore: null });
+  });
+
+  it("returns null when current harness has no score", () => {
+    expect(computeHistoryDiff({ score: null }, prevRow())).toBeNull();
+  });
+
+  it("computes overall delta + per-category deltas", () => {
+    const diff = computeHistoryDiff(currentHarness, prevRow());
+    expect(diff.delta).toBe(3);
+    expect(diff.previousScore).toBe(71);
+    expect(diff.previousGrade).toBe("C");
+    expect(diff.categoryDeltas.find((c) => c.name === "architectural_docs").delta).toBe(20);
+    expect(diff.categoryDeltas.find((c) => c.name === "testing_stability").delta).toBe(-5);
+  });
+
+  it("highlights biggest improvement and regression", () => {
+    const diff = computeHistoryDiff(currentHarness, prevRow());
+    expect(diff.biggestImprovement.name).toBe("architectural_docs");
+    expect(diff.biggestImprovement.delta).toBe(20);
+    expect(diff.biggestRegression.name).toBe("testing_stability");
+    expect(diff.biggestRegression.delta).toBe(-5);
+  });
+
+  it("flags baseline as stale when >30 days old", () => {
+    const oldRow = prevRow({ timestamp: new Date(Date.now() - 32 * 86400000).toISOString() });
+    const diff = computeHistoryDiff(currentHarness, oldRow);
+    expect(diff.baselineStale).toBe(true);
+    expect(diff.baselineAgeDays).toBeGreaterThanOrEqual(32);
+  });
+});
+
+describe("formatHistoryDiff — KJC-TSK-0473", () => {
+  it("renders first-run message", () => {
+    expect(formatHistoryDiff({ firstRun: true })).toContain("First run");
+  });
+
+  it("renders delta + arrow + previous score", () => {
+    const md = formatHistoryDiff(computeHistoryDiff(currentHarness, prevRow()));
+    expect(md).toContain("Δ +3 ↑");
+    expect(md).toContain("2026-05-20");
+    expect(md).toContain("71/100");
+    expect(md).toContain("Mayor mejora");
+    expect(md).toContain("Mayor regresión");
+  });
+
+  it("includes stale-baseline warning", () => {
+    const oldRow = prevRow({ timestamp: new Date(Date.now() - 60 * 86400000).toISOString() });
+    const md = formatHistoryDiff(computeHistoryDiff(currentHarness, oldRow));
+    expect(md).toContain("baseline antigua");
+  });
+
+  it("returns empty string for null diff", () => {
+    expect(formatHistoryDiff(null)).toBe("");
+  });
+});
+
+describe("formatTrendSparkline — KJC-TSK-0473", () => {
+  it("renders unicode bars for a sequence of scores", () => {
+    const out = formatTrendSparkline([{ score: 62 }, { score: 65 }, { score: 68 }, { score: 71 }, { score: 74 }]);
+    expect(out).toMatch(/Score trend \(last 5 runs\): 62 .{5} 74/);
+  });
+
+  it("handles a single run gracefully", () => {
+    expect(formatTrendSparkline([{ score: 80 }])).toContain("single run");
+  });
+
+  it("returns empty string when there are no scores", () => {
+    expect(formatTrendSparkline([])).toBe("");
+    expect(formatTrendSparkline(null)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Renders a **Harness Score History** block on every `kj audit` (stdout, JSON, persisted report) showing delta vs the latest previous run, biggest improving and regressing category, and a stale-baseline warning when the previous run is >30 days old.
- New `--trend` flag appends a unicode sparkline of the last 10 harness scores using `.karajan/audit-history.db` (KJC-TSK-0472).
- Display logic lives in a brand-new pure module `src/audit/audit-history-display.js` with no DB / native-module deps → safe to bundle into the SEA binary without an additional stub.
- Two new query helpers in `src/audit/audit-history.js`: `getLatestPreviousRun` (excludes current row by timestamp) and `getRecentScores` (ASC for the sparkline).
- SEA stub extended with the two new noop exports (`getLatestPreviousRun`, `getRecentScores`).

Closes the last card of the Plan B sequence for the v2.33.0 candidate (`KJC-PCS-0051` — AI Harness Scorecard golden metric).

## Test plan
- [x] `npx vitest run tests/audit/audit-history-display.test.js` → 12/12 (firstRun branch, full diff, biggest +/-, stale baseline, formatHistoryDiff arrows/sign/Spanish copy, sparkline edge cases).
- [x] `npx vitest run tests/audit/ tests/audit-routing.test.js tests/roles/audit.test.js tests/checks/audit-tools.test.js` → 234/234 (no regression).
- [x] Net LOC delta ≤ 200 (computed 195, under the shrink-budget gate).

## Notes
- Errors loading / querying the history db are swallowed: history is a nice-to-have, a broken DB must not break `kj audit`.
- The diff is computed only when both the current run and the previous row carry a `score` — single-run projects render `_First run for this project — no baseline yet._`.