### PR TITLE
chore: release v2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`spec-reviewer` role** runs BEFORE every `kj run` / `kj plan` (KJC-PCS-0048). See full description below — it remains queued for the next minor release (v2.20.0).
 
-## [2.32.0] - 2026-05-27
+## [2.33.0] - 2026-05-28
+
+Minor release. **AI Harness Scorecard golden metric (KJC-PCS-0051, Plan B)** — the four cards close the loop opened in v2.32.0 (Plan A hardening): every `kj audit` now boots a Docker one-shot of `addyosmani/ai-harness-scorecard`, gets a deterministic 0–100 score + A–F grade, persists it to a per-project `audit-history.db`, and on the next run renders the delta vs the previous baseline plus an optional Unicode-bar trend sparkline. Karajan finally has a single golden metric for "how AI-friendly is this repo today vs last week," with zero LLM tokens spent.
+
+### Added
+
+- **PR #877 (KJC-TSK-0470) — Bootstrap `ai-harness-scorecard` Docker one-shot**. New `src/audit/harness-runner.js` runs `docker run --rm -v <repo>:/repo addyosmani/ai-harness-scorecard analyze` with a 5-minute timeout, parses the JSON verdict, and surfaces it as a structured object. Auto-skipped (graceful degradation) when Docker is unreachable. CLI flag `--no-harness` opts out. Image is pulled lazily on first use; subsequent runs are cached.
+- **PR #878 (KJC-TSK-0471) — `kj audit` integrates harness score**. New `src/audit/harness-section.js` renders the harness result as a Markdown section (overall score + per-category breakdown + grade badge), woven into both the deterministic-only path and the post-LLM report path of `kj audit`. JSON output gets a `harnessScore` field. Two-phase audit honored: the harness runs during the deterministic phase, so `--deterministic-only` users get it too.
+- **PR #879 (KJC-TSK-0472) — Persistent per-project audit history**. New `src/audit/audit-history.js` opens `.karajan/audit-history.db` (better-sqlite3, WAL mode, `PRAGMA user_version=1`) per project root and persists every audit run's harness score, grade, category breakdown, git SHA and ISO timestamp. SEA bundle is patched with `auditHistoryStubPlugin` (same pattern as the existing rag-stub + hu-board-stub) so the standalone binary degrades gracefully — `npm install -g karajan-code` is the install path that unlocks history.
+- **PR #880 (KJC-TSK-0473) — Diff vs previous run + trend sparkline**. New `src/audit/audit-history-display.js` (pure module, no native deps, safe in the SEA bundle) exposes `computeHistoryDiff` (overall delta + per-category deltas + biggest improvement/regression + stale-baseline flag at >30 days) and `formatTrendSparkline` (Unicode block bars `▁▂▃▄▅▆▇█` over the last N runs). The history block is appended to every `kj audit` report (Markdown + JSON), and the optional `--trend` flag prints the sparkline. First-run baselines render a friendly "no baseline yet" line instead of an error.
+
+
 
 Minor release. **AI Harness Scorecard hardening (KJC-PCS-0051)** — Plan A closes five FAILs from the external scorecard audit in a single sprint: Prettier check, Coverage v8 reports, Conventional Commits enforcement, nightly drift detection, and unsafe-code lint policy. Two bug fixes ship alongside: 42 broken tests on `main` restored and a `spec-reviewer` refine-loop async bug.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,13 @@ Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
 
 ## Recent releases
 
+> **v2.33.0 released** — Minor. **AI Harness Scorecard golden metric (KJC-PCS-0051, Plan B)** — every `kj audit` now boots a Docker one-shot of `addyosmani/ai-harness-scorecard`, gets a deterministic 0–100 score + A–F grade, persists it to a per-project `audit-history.db`, and on the next run renders the delta vs the previous baseline plus an optional Unicode-bar trend sparkline. One golden number for "how AI-friendly is this repo today vs last week," zero LLM tokens spent.
+>
+> - **Harness Docker one-shot** (PR #877, KJC-TSK-0470): `src/audit/harness-runner.js` runs `docker run --rm -v <repo>:/repo addyosmani/ai-harness-scorecard analyze`, parses the verdict, auto-skips on missing Docker. `--no-harness` opts out.
+> - **`kj audit` integrates the score** (PR #878, KJC-TSK-0471): new harness-section renderer; JSON output gains `harnessScore`; runs during the deterministic phase so `--deterministic-only` users get it too.
+> - **Per-project audit history** (PR #879, KJC-TSK-0472): `.karajan/audit-history.db` (better-sqlite3 + WAL + `PRAGMA user_version=1`) persists every run. SEA bundle stubbed (degrades gracefully); npm install unlocks history.
+> - **Diff + trend sparkline** (PR #880, KJC-TSK-0473): `src/audit/audit-history-display.js` (pure module, safe in SEA) computes overall delta + per-category deltas + biggest improvement/regression + stale-baseline flag (>30 days). New `--trend` flag prints a `▁▂▃▄▅▆▇█` sparkline over the last N runs.
+>
 > **v2.32.0 released** — Minor. **AI Harness Scorecard hardening (KJC-PCS-0051)** — Plan A closes five FAILs from the external scorecard audit in one sprint: Prettier `--check`, Coverage v8 reports, Conventional Commits enforcement, nightly drift detection, and an unsafe-code lint policy. Plus two bug fixes shipped alongside.
 >
 > - **Prettier `--check` CI job** (PR #868, KJC-TSK-0464): new `format` job blocks PRs whose formatting drifts from `.prettierrc.json`. Scope narrow at first (`.github/workflows/`, root config); future PRs fold in more dirs under the shrink-budget cap.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (54k LOC, 406 files)
+├── src/              # Source code (55k LOC, 411 files)
 ├── tests/            # Test suite (291 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 2.32.0
+kj --version    # 2.33.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -57,7 +57,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 2.32.0
+kj --version    # 2.33.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

Release **v2.33.0** — **AI Harness Scorecard golden metric** (KJC-PCS-0051, Plan B). Closes the epic opened in v2.32.0 by wiring the deterministic Docker-based scorecard into `kj audit`, persisting every run, and rendering the diff + trend on the next pass.

Includes the 4 already-merged cards:

- **KJC-TSK-0470** (PR #877) — Bootstrap `addyosmani/ai-harness-scorecard` Docker one-shot (`src/audit/harness-runner.js`).
- **KJC-TSK-0471** (PR #878) — `kj audit` integrates the score (`src/audit/harness-section.js`); JSON output gains `harnessScore`.
- **KJC-TSK-0472** (PR #879) — Per-project `.karajan/audit-history.db` (better-sqlite3 + WAL + `PRAGMA user_version=1`); SEA stubbed.
- **KJC-TSK-0473** (PR #880) — Diff vs previous run + `--trend` Unicode sparkline (`src/audit/audit-history-display.js`, pure module, safe in SEA).

## Bump checklist (already applied in this PR)

- `package.json` 2.32.0 → 2.33.0
- `package-lock.json` regenerated
- `CHANGELOG.md` entry for `[2.33.0] - 2026-05-28` (Added section, all 4 PRs documented)
- `README.md` banner (Recent releases) updated
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` version comment updated
- `docs/ARCHITECTURE.md` regenerated via `scripts/regen-arch-stats.sh`

## Test plan

- [ ] CI all-green (lint, format, syntax, tests, commitlint, coverage, prompt-injection scan, shrink-budget)
- [ ] Net LOC well under 200 (mostly human docs, excluded)
- [ ] After merge: tag `v2.33.0`, `gh release create`, `npm publish --otp=<code>`, landing PR, deploy