### PR TITLE
feat(rag): vec_store_meta + kj rag index --since (KJC-TSK-0455 PR1)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -104,6 +104,7 @@ export function registerMeta(program, { pkgVersion }) {
   rag.command("index")
     .description("Index plans + onboarding (and optionally project sources) into the local vector store")
     .option("--with-sources", "Also index the projectDir's JS/TS files")
+    .option("--since <ref>", "Only re-index files changed since <ref> ('auto' uses the last indexed commit; falls back to full index if unset). KJC-TSK-0455.")
     .option("--json", "Output the totals as JSON")
     .action(async (flags) => {
       await withConfig(pkgVersion, "rag-index", flags, async ({ config, logger }) => {

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -2,9 +2,9 @@
 //   kj rag index [--project <slug>] [--with-sources]
 //   kj rag query <text>   [--scope plans|code|onboarding|all] [--top-k N] [--json]
 // Closes the v2.22.0 RAG MVP end-to-end from the terminal.
-import { openVecStore, countChunks, projectSlug } from "../rag/vec-store.js";
+import { openVecStore, countChunks, projectSlug, getLastIndexedCommit, setLastIndexedCommit } from "../rag/vec-store.js";
 import { makeEmbedder } from "../rag/embedders/factory.js";
-import { indexProject } from "../rag/indexer.js";
+import { indexProject, indexProjectDelta } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
 import { getKarajanHome } from "../utils/paths.js";
 
@@ -16,15 +16,39 @@ export async function ragIndexCommand({ config, logger, flags = {} }) {
   const projectDir = config?.projectDir || process.cwd();
   const db = openDb(config);
   try {
-    const totals = await indexProject(projectDir, {
-      db, embedder: makeEmbedder(config),
-      karajanHome: getKarajanHome(), logger,
-      withSources: Boolean(flags.withSources),
-    });
+    const slug = projectSlug(projectDir);
+    const embedder = makeEmbedder(config);
+    const sinceFlag = flags.since;
+    // KJC-TSK-0455 — `--since auto` resolves to the last commit we indexed;
+    // an explicit ref is honoured as-is. Without a baseline (first-time
+    // index) we fall back to a full reindex with a friendly warning so the
+    // hook in PR2 stays a no-op-friendly entrypoint.
+    let since = null;
+    if (sinceFlag) {
+      since = sinceFlag === "auto" ? getLastIndexedCommit(db, slug) : sinceFlag;
+      if (!since) logger.warn?.("[rag] --since auto: no previous index recorded; running full index");
+    }
+    let totals;
+    if (since) {
+      try {
+        totals = await indexProjectDelta(projectDir, { db, embedder, since, logger });
+      } catch (err) {
+        logger.warn?.(`[rag] delta index failed (${err.message}); falling back to full index`);
+        totals = null;
+      }
+    }
+    if (!totals) {
+      totals = await indexProject(projectDir, {
+        db, embedder,
+        karajanHome: getKarajanHome(), logger,
+        withSources: Boolean(flags.withSources),
+      });
+    }
+    if (totals.head) setLastIndexedCommit(db, slug, totals.head);
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(totals)}\n`);
     } else {
-      logger.info(`[rag] indexed ${totals.indexed} chunk(s) across ${totals.files} file(s) (${totals.failed} failed)`);
+      logger.info(`[rag] indexed ${totals.indexed} chunk(s) across ${totals.files} file(s) (${totals.failed} failed${totals.deleted ? `, ${totals.deleted} chunks deleted` : ""})`);
     }
     return totals;
   } finally {

--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -6,10 +6,14 @@
 // failure mode simple (re-run to refresh).
 import { existsSync, readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
-import { extname, join, relative } from "node:path";
+import { extname, isAbsolute, join, relative } from "node:path";
+import { execa } from "execa";
 
 import { chunkMarkdown, chunkPlan, chunkSource } from "./chunker.js";
 import { insertChunk, deleteChunksBySource } from "./vec-store.js";
+
+const CODE_EXT_RE = /\.(js|mjs|cjs|ts|tsx|jsx)$/;
+const SKIP_SEGMENTS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
 
 const ONBOARDING_DIR = "onboarding", PLANS_DIR = "plans";
 
@@ -110,10 +114,46 @@ export async function indexProject(projectDir, { db, embedder, karajanHome, logg
     // duplicate every chunk and contaminate retrieval scores. `_diet` is the
     // tests/_diet/ sandbox used by the test-diet audit harness — never user
     // code. Skip both.
-    const SKIP = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
-    const sources = await listFiles(projectDir, (p) => /\.(js|mjs|cjs|ts|tsx|jsx)$/.test(p) && !p.split("/").some((seg) => SKIP.has(seg)));
+    const sources = await listFiles(projectDir, (p) => CODE_EXT_RE.test(p) && !p.split("/").some((seg) => SKIP_SEGMENTS.has(seg)));
     for (const s of sources) {
       const r = await indexFile(s, { db, embedder, logger, project: slug });
+      totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
+    }
+  }
+  return totals;
+}
+
+/**
+ * KJC-TSK-0455 — Re-index only the files changed between `since` and HEAD.
+ * `git diff --name-status -z` drives the work: A/M re-embed, D drop chunks,
+ * R drops old + indexes new. Returns `{ indexed, failed, files, deleted, head }`;
+ * `head` lets callers persist via setLastIndexedCommit. Throws on diff failure
+ * (shallow clone, unknown ref) so the CLI can fall back to a full reindex.
+ */
+export async function indexProjectDelta(projectDir, { db, embedder, since, logger = console } = {}) {
+  const totals = { indexed: 0, failed: 0, files: 0, deleted: 0, head: null };
+  const slug = projectDir.split("/").pop()?.replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
+  const { stdout: head } = await execa("git", ["-C", projectDir, "rev-parse", "HEAD"]);
+  totals.head = head.trim();
+  if (totals.head === since) return totals;
+  const { stdout } = await execa("git", ["-C", projectDir, "diff", "--name-status", "-z", since, "HEAD"]);
+  const parts = stdout.split("\0").filter(Boolean);
+  const ops = []; // { kind: 'del'|'idx', p }
+  for (let i = 0; i < parts.length; i += 1) {
+    const s = parts[i];
+    if (s.startsWith("R")) { ops.push({ kind: "del", p: parts[++i] }, { kind: "idx", p: parts[++i] }); }
+    else if (s === "D") { ops.push({ kind: "del", p: parts[++i] }); }
+    else { ops.push({ kind: "idx", p: parts[++i] }); }
+  }
+  for (const { kind, p } of ops) {
+    if (p.split("/").some((seg) => SKIP_SEGMENTS.has(seg))) continue;
+    if (!CODE_EXT_RE.test(p)) continue;
+    const abs = isAbsolute(p) ? p : join(projectDir, p);
+    if (kind === "del") {
+      totals.deleted += deleteChunksBySource(db, abs);
+      logger.info?.(`[rag-indexer] delta delete ${relative(process.cwd(), abs)}`);
+    } else if (existsSync(abs)) {
+      const r = await indexFile(abs, { db, embedder, logger, project: slug });
       totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
     }
   }

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -53,6 +53,18 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     db.exec("ALTER TABLE chunks ADD COLUMN project_slug TEXT;");
     db.exec("CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);");
   }
+  // KJC-TSK-0455 — Auto-update by commit diff. Per-project metadata tracks
+  // the last commit whose changes were reflected in the index, so subsequent
+  // `kj rag index --since auto` invocations (and the post-merge hook / pre-run
+  // drift check landed in PR2) only re-embed the actual delta instead of the
+  // whole project.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS vec_store_meta (
+      project_slug TEXT PRIMARY KEY,
+      last_indexed_commit TEXT,
+      last_indexed_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
   db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(embedding float[${dim}]);`);
   // KJC-TSK-0443 — FTS5 keyword index for BM25 hybrid scoring. content='chunks'
   // makes it a contentless mirror linked by id (no double storage); triggers
@@ -151,6 +163,25 @@ export function deleteChunksBySource(db, source) {
   db.prepare(`DELETE FROM vec_chunks WHERE rowid IN (${placeholders})`).run(...ids);
   db.prepare(`DELETE FROM chunks WHERE id IN (${placeholders})`).run(...ids);
   return ids.length;
+}
+
+// KJC-TSK-0455 — Per-project commit watermark for `kj rag index --since auto`
+// and the post-merge / pre-run drift hooks landing in PR2.
+export function getLastIndexedCommit(db, projectSlug) {
+  if (!projectSlug) return null;
+  const row = db.prepare("SELECT last_indexed_commit FROM vec_store_meta WHERE project_slug = ?").get(projectSlug);
+  return row?.last_indexed_commit ?? null;
+}
+
+export function setLastIndexedCommit(db, projectSlug, commit) {
+  if (!projectSlug || !commit) return;
+  db.prepare(`
+    INSERT INTO vec_store_meta (project_slug, last_indexed_commit, last_indexed_at)
+    VALUES (?, ?, datetime('now'))
+    ON CONFLICT(project_slug) DO UPDATE SET
+      last_indexed_commit = excluded.last_indexed_commit,
+      last_indexed_at = excluded.last_indexed_at
+  `).run(projectSlug, commit);
 }
 
 export function countChunks(db, { kind = null } = {}) {

--- a/tests/rag/auto-update.test.js
+++ b/tests/rag/auto-update.test.js
@@ -1,0 +1,104 @@
+// KJC-TSK-0455 — vec_store_meta helpers + indexProjectDelta() vs a synthetic git repo.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execa } from "execa";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  openVecStore, countChunks,
+  getLastIndexedCommit, setLastIndexedCommit,
+} from "../../src/rag/vec-store.js";
+import { indexProject, indexProjectDelta } from "../../src/rag/indexer.js";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const embedder = { embed: vi.fn(async () => { const v = new Float32Array(8); v[0] = 1; return v; }), dim: 8 };
+
+async function gitInit(dir) {
+  await execa("git", ["-C", dir, "init", "-q"]);
+  await execa("git", ["-C", dir, "config", "user.email", "t@e.x"]);
+  await execa("git", ["-C", dir, "config", "user.name", "t"]);
+  await execa("git", ["-C", dir, "config", "commit.gpgsign", "false"]);
+}
+async function gitCommit(dir, msg) {
+  await execa("git", ["-C", dir, "add", "-A"]);
+  await execa("git", ["-C", dir, "commit", "-q", "-m", msg]);
+  const { stdout } = await execa("git", ["-C", dir, "rev-parse", "HEAD"]);
+  return stdout.trim();
+}
+
+describe("vec_store_meta helpers — KJC-TSK-0455", () => {
+  let root, db;
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), "kj-meta-")); db = openVecStore({ dim: 8, path: join(root, "rag.db") }); });
+  afterEach(() => { db?.close(); rmSync(root, { recursive: true, force: true }); });
+
+  it("round-trip, upsert and per-slug isolation", () => {
+    expect(getLastIndexedCommit(db, "proja")).toBeNull();
+    setLastIndexedCommit(db, "proja", "aaa");
+    setLastIndexedCommit(db, "projb", "bbb");
+    setLastIndexedCommit(db, "proja", "ccc"); // upsert
+    expect(getLastIndexedCommit(db, "proja")).toBe("ccc");
+    expect(getLastIndexedCommit(db, "projb")).toBe("bbb");
+  });
+
+  it("is a no-op with missing args", () => {
+    setLastIndexedCommit(db, null, "abc");
+    setLastIndexedCommit(db, "p", null);
+    expect(getLastIndexedCommit(db, null)).toBeNull();
+    expect(getLastIndexedCommit(db, "p")).toBeNull();
+  });
+});
+
+describe("indexProjectDelta — KJC-TSK-0455", () => {
+  let root, projectDir, db;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "kj-delta-"));
+    projectDir = join(root, "myproj");
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    db = openVecStore({ dim: 8, path: join(root, "rag.db") });
+  });
+  afterEach(() => { db?.close(); rmSync(root, { recursive: true, force: true }); });
+
+  it("returns head + zero changes when since === HEAD", async () => {
+    await gitInit(projectDir);
+    writeFileSync(join(projectDir, "src", "a.js"), "export const a = 1;");
+    const head = await gitCommit(projectDir, "init");
+    const t = await indexProjectDelta(projectDir, { db, embedder, since: head, logger: noopLogger });
+    expect(t.head).toBe(head);
+    expect(t.indexed).toBe(0);
+    expect(t.deleted).toBe(0);
+  });
+
+  it("processes A/M, D and R (rename) statuses; skips non-code and excluded segments", async () => {
+    await gitInit(projectDir);
+    writeFileSync(join(projectDir, "src", "old.js"), "export const x = 1;");
+    writeFileSync(join(projectDir, "src", "doomed.js"), "export const y = 1;");
+    const base = await gitCommit(projectDir, "init");
+    // Pre-seed so D and R can actually drop chunks.
+    await indexProject(projectDir, { db, embedder, karajanHome: join(root, "missing"), logger: noopLogger, withSources: true });
+    const seeded = countChunks(db);
+    expect(seeded).toBeGreaterThan(0);
+    // A new, M existing, D one, R another. Plus noise that must be skipped.
+    writeFileSync(join(projectDir, "src", "added.js"), "export const z = 1;");
+    rmSync(join(projectDir, "src", "doomed.js"));
+    await execa("git", ["-C", projectDir, "mv", "src/old.js", "src/new.js"]);
+    writeFileSync(join(projectDir, "README.md"), "# noise");
+    mkdirSync(join(projectDir, "dist"), { recursive: true });
+    writeFileSync(join(projectDir, "dist", "bundle.js"), "// noise");
+    await gitCommit(projectDir, "delta");
+    const t = await indexProjectDelta(projectDir, { db, embedder, since: base, logger: noopLogger });
+    expect(t.indexed).toBeGreaterThan(0); // added.js + new.js
+    expect(t.deleted).toBeGreaterThan(0); // doomed.js + old.js
+    // README.md (non-code) and dist/bundle.js (excluded segment) must NOT be counted.
+    expect(t.files).toBe(2); // added.js + new.js
+  });
+
+  it("throws when since is unknown so the CLI can fall back", async () => {
+    await gitInit(projectDir);
+    writeFileSync(join(projectDir, "src", "a.js"), "export const a = 1;");
+    await gitCommit(projectDir, "init");
+    await expect(
+      indexProjectDelta(projectDir, { db, embedder, since: "0".repeat(40), logger: noopLogger })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

PR1 of two for **KJC-TSK-0455** — RAG auto-update by commit diff. This PR lands the persistence layer and the explicit `--since` flag; PR2 will land the post-merge hook and the pre-run drift check that activate this path automatically (default-on, opt-out via `.karajanrc`).

## Changes

- **`vec_store_meta` table** in `src/rag/vec-store.js` tracks per-project `(slug, last_indexed_commit, last_indexed_at)` so `kj rag index --since auto` knows what to diff against. Plus `getLastIndexedCommit` / `setLastIndexedCommit` helpers (idempotent upsert).
- **`indexProjectDelta(projectDir, { since })`** in `src/rag/indexer.js` parses `git diff --name-status -z <since> HEAD` and processes:
  - **A / M** — re-embed via `indexFile`
  - **D** — drop chunks via `deleteChunksBySource`
  - **R** (rename) — drop old path + index new path
  - Skips non-code extensions and `SKIP_SEGMENTS` noise (dist/, .kj/worktrees/, _diet/, …)
- **CLI** `kj rag index --since <ref>` — `auto` resolves to the stored SHA, or falls back to a full reindex with a warning if no baseline exists. The handler wraps `indexProjectDelta` in try/catch so a shallow clone or unknown ref falls back gracefully to `indexProject`. Persists HEAD on success.

## Tests

`tests/rag/auto-update.test.js` — 5 tests:
- `vec_store_meta` round-trip + upsert + per-slug isolation + no-op with missing args
- `indexProjectDelta` zero-changes path (since === HEAD), combined A/M/D/R + skip noise, throws on unknown ref so the CLI can fall back

Full RAG suite: **126/126 passing**.

## LOC

Net delta: **200/200** (exactly at the shrink-budget limit).

## Out of scope (deferred to PR2)

- Post-merge git hook installer
- Pre-run drift check inside the pipeline entry point
- `rag.autoUpdate.{onCommit, onRun}` config schema with `--no-rag-update` opt-out