### PR TITLE
feat(rag): language adapter registry + Python canary (KJC-TSK-0474)

### DIFF
--- a/src/lang/js.js
+++ b/src/lang/js.js
@@ -1,0 +1,8 @@
+// KJC-PCS-0052 PR-A — JS/TS adapter. Codifica las constantes que vivían
+// hard-coded en src/rag/indexer.js antes del registry.
+export const JS_ADAPTER = {
+  id: "js",
+  extensions: [".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx"],
+  skipSegments: ["node_modules", ".next", ".nuxt", ".svelte-kit"],
+  manifests: ["package.json"],
+};

--- a/src/lang/python.js
+++ b/src/lang/python.js
@@ -1,0 +1,14 @@
+// KJC-PCS-0052 PR-A — Python adapter. Primer lenguaje no-JS soportado
+// por el RAG indexer. La detección por manifest (pyproject.toml,
+// setup.py, requirements.txt, Pipfile) activa el adapter; los virtualenvs
+// y caches típicos se excluyen del walk para no contaminar el índice con
+// dependencias ya vendoreadas. El chunker AST (tree-sitter) llega en PR-B;
+// hasta entonces, la cadena chunkSourceAST → chunkSourceRegex → windowText
+// devuelve windowing puro para .py (sigue siendo recuperable, solo sin
+// metadata.symbol).
+export const PYTHON_ADAPTER = {
+  id: "python",
+  extensions: [".py"],
+  skipSegments: ["__pycache__", ".venv", "venv", ".tox", ".pytest_cache", ".mypy_cache", ".ruff_cache"],
+  manifests: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"],
+};

--- a/src/lang/registry.js
+++ b/src/lang/registry.js
@@ -1,0 +1,64 @@
+// KJC-PCS-0052 PR-A — Language adapter registry. Antes vivían CODE_EXT_RE
+// y SKIP_SEGMENTS hardcoded en indexer.js (solo JS/TS); ahora cada adapter
+// declara extensiones, skipSegments y manifests. PR-B añadirá AST chunkers
+// (tree-sitter); PR-C/D usan el mismo registry para audit y onboarder.
+import { existsSync } from "node:fs";
+import { extname, join } from "node:path";
+
+import { JS_ADAPTER } from "./js.js";
+import { PYTHON_ADAPTER } from "./python.js";
+
+// Segmentos siempre excluidos del walk, independientes de stack: VCS,
+// outputs de build, scratch de Karajan, sandbox del audit. Lo que viva
+// aquí jamás se indexa.
+const COMMON_SKIP_SEGMENTS = [".git", "dist", "build", "coverage", ".karajan", ".kj", "_diet"];
+
+const REGISTRY = [JS_ADAPTER, PYTHON_ADAPTER];
+
+export function getAdapters() {
+  return REGISTRY.slice();
+}
+
+/**
+ * Detecta qué adapters aplican a un projectDir mirando los manifests
+ * declarados. Si ningún adapter coincide (proyecto sin manifest), cae
+ * a JS para no romper repos legacy o sandboxes de tests.
+ */
+export function detectAdaptersForProject(projectDir) {
+  if (!projectDir) return [JS_ADAPTER];
+  const matched = REGISTRY.filter((a) => a.manifests.some((m) => existsSync(join(projectDir, m))));
+  return matched.length ? matched : [JS_ADAPTER];
+}
+
+/**
+ * Construye los matchers que usa el indexer al recorrer el árbol:
+ * `isCodeFile(path)` decide si la extensión cuadra con algún adapter
+ * activo; `shouldSkip(path)` aplica la unión de skipSegments comunes +
+ * los del adapter. Devuelve también `extensions` por si el caller quiere
+ * inspeccionarlas (p.ej. tests).
+ */
+export function buildMatchers(adapters) {
+  const extSet = new Set();
+  const skipSet = new Set(COMMON_SKIP_SEGMENTS);
+  for (const a of adapters) {
+    for (const e of a.extensions) extSet.add(e.toLowerCase());
+    for (const s of a.skipSegments || []) skipSet.add(s);
+  }
+  return {
+    isCodeFile: (p) => extSet.has(extname(p).toLowerCase()),
+    shouldSkip: (p) => p.split("/").some((seg) => skipSet.has(seg)),
+    extensions: [...extSet],
+  };
+}
+
+/**
+ * Unión de extensiones de TODOS los adapters registrados. Útil para
+ * `detectKind` en el indexer, que recibe un path suelto sin saber el
+ * projectDir y necesita reconocer una extensión de código aunque venga
+ * de un adapter no detectado en el proyecto actual.
+ */
+export function getAllCodeExtensions() {
+  const out = new Set();
+  for (const a of REGISTRY) for (const e of a.extensions) out.add(e.toLowerCase());
+  return [...out];
+}

--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -11,10 +11,13 @@ import { execa } from "execa";
 
 import { chunkMarkdown, chunkPlan, chunkSource } from "./chunker.js";
 import { insertChunk, deleteChunksBySource } from "./vec-store.js";
+import { detectAdaptersForProject, buildMatchers, getAllCodeExtensions } from "../lang/registry.js";
 
-const CODE_EXT_RE = /\.(js|mjs|cjs|ts|tsx|jsx)$/;
-const SKIP_SEGMENTS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
-
+// KJC-PCS-0052 PR-A — antes vivían dos consts hard-coded para JS aquí
+// (CODE_EXT_RE + SKIP_SEGMENTS). Ahora vienen del registry de adapters,
+// que se consulta una vez por proceso para el conjunto global y por
+// projectDir cuando hace falta filtrar el walk.
+const ALL_CODE_EXTENSIONS = new Set(getAllCodeExtensions());
 const ONBOARDING_DIR = "onboarding", PLANS_DIR = "plans";
 
 function detectKind(path) {
@@ -22,7 +25,7 @@ function detectKind(path) {
   const base = path.split("/").pop() || "";
   if (ext === ".json" && (/^plan-.+\.json$/i.test(base) || path.includes(`/${PLANS_DIR}/`))) return "plan";
   if (ext === ".md") return path.includes(`/${ONBOARDING_DIR}/`) ? "onboarding" : "plan";
-  if ([".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx"].includes(ext)) return "code";
+  if (ALL_CODE_EXTENSIONS.has(ext)) return "code";
   return null;
 }
 
@@ -113,8 +116,9 @@ export async function indexProject(projectDir, { db, embedder, karajanHome, logg
     // per HU during `kj run`; they hold complete copies of `src/` that
     // duplicate every chunk and contaminate retrieval scores. `_diet` is the
     // tests/_diet/ sandbox used by the test-diet audit harness — never user
-    // code. Skip both.
-    const sources = await listFiles(projectDir, (p) => CODE_EXT_RE.test(p) && !p.split("/").some((seg) => SKIP_SEGMENTS.has(seg)));
+    // code. Both viven en COMMON_SKIP_SEGMENTS dentro del registry.
+    const matchers = buildMatchers(detectAdaptersForProject(projectDir));
+    const sources = await listFiles(projectDir, (p) => matchers.isCodeFile(p) && !matchers.shouldSkip(p));
     for (const s of sources) {
       const r = await indexFile(s, { db, embedder, logger, project: slug });
       totals.indexed += r.indexed; totals.failed += r.failed; totals.files += 1;
@@ -145,9 +149,10 @@ export async function indexProjectDelta(projectDir, { db, embedder, since, logge
     else if (s === "D") { ops.push({ kind: "del", p: parts[++i] }); }
     else { ops.push({ kind: "idx", p: parts[++i] }); }
   }
+  const matchers = buildMatchers(detectAdaptersForProject(projectDir));
   for (const { kind, p } of ops) {
-    if (p.split("/").some((seg) => SKIP_SEGMENTS.has(seg))) continue;
-    if (!CODE_EXT_RE.test(p)) continue;
+    if (matchers.shouldSkip(p)) continue;
+    if (!matchers.isCodeFile(p)) continue;
     const abs = isAbsolute(p) ? p : join(projectDir, p);
     if (kind === "del") {
       totals.deleted += deleteChunksBySource(db, abs);

--- a/tests/lang/registry.test.js
+++ b/tests/lang/registry.test.js
@@ -1,0 +1,88 @@
+// KJC-PCS-0052 PR-A — registry de adapters: detección por manifest +
+// matchers (isCodeFile / shouldSkip). Repo legacy sin manifest cae a JS
+// para preservar el comportamiento pre-PR.
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMatchers,
+  detectAdaptersForProject,
+  getAdapters,
+  getAllCodeExtensions,
+} from "../../src/lang/registry.js";
+
+function mkRoot() {
+  return mkdtempSync(join(tmpdir(), "kj-lang-"));
+}
+
+describe("language registry — KJC-PCS-0052 PR-A", () => {
+  it("getAdapters returns a defensive copy", () => {
+    const a = getAdapters();
+    const b = getAdapters();
+    expect(a).not.toBe(b);
+    expect(a.map((x) => x.id).sort()).toEqual(["js", "python"]);
+  });
+
+  it("getAllCodeExtensions includes both JS and Python", () => {
+    const exts = getAllCodeExtensions();
+    expect(exts).toContain(".js");
+    expect(exts).toContain(".ts");
+    expect(exts).toContain(".py");
+  });
+
+  it("detects JS via package.json", () => {
+    const root = mkRoot();
+    writeFileSync(join(root, "package.json"), "{}");
+    const adapters = detectAdaptersForProject(root);
+    expect(adapters.map((a) => a.id)).toEqual(["js"]);
+  });
+
+  it("detects Python via pyproject.toml", () => {
+    const root = mkRoot();
+    writeFileSync(join(root, "pyproject.toml"), "[project]\nname='x'\n");
+    const adapters = detectAdaptersForProject(root);
+    expect(adapters.map((a) => a.id)).toEqual(["python"]);
+  });
+
+  it("detects multi-stack repos (JS + Python manifests both present)", () => {
+    const root = mkRoot();
+    writeFileSync(join(root, "package.json"), "{}");
+    writeFileSync(join(root, "requirements.txt"), "requests\n");
+    const ids = detectAdaptersForProject(root).map((a) => a.id).sort();
+    expect(ids).toEqual(["js", "python"]);
+  });
+
+  it("falls back to JS when no manifest is recognised (legacy / sandbox)", () => {
+    const root = mkRoot();
+    const adapters = detectAdaptersForProject(root);
+    expect(adapters.map((a) => a.id)).toEqual(["js"]);
+  });
+
+  it("buildMatchers unions extensions and skipSegments across active adapters", () => {
+    const root = mkRoot();
+    writeFileSync(join(root, "package.json"), "{}");
+    writeFileSync(join(root, "pyproject.toml"), "");
+    const m = buildMatchers(detectAdaptersForProject(root));
+    expect(m.isCodeFile("/x/main.py")).toBe(true);
+    expect(m.isCodeFile("/x/main.ts")).toBe(true);
+    expect(m.isCodeFile("/x/README.md")).toBe(false);
+    // skipSegments: comunes (.git, dist, .karajan) + JS (node_modules) + Python (__pycache__, .venv).
+    expect(m.shouldSkip("/x/.git/config")).toBe(true);
+    expect(m.shouldSkip("/x/node_modules/foo/index.js")).toBe(true);
+    expect(m.shouldSkip("/x/__pycache__/foo.pyc")).toBe(true);
+    expect(m.shouldSkip("/x/.venv/lib/python3.11/site.py")).toBe(true);
+    expect(m.shouldSkip("/x/src/main.py")).toBe(false);
+  });
+
+  it("Python-only repo: matcher does NOT pull in JS skipSegments", () => {
+    const root = mkRoot();
+    writeFileSync(join(root, "pyproject.toml"), "");
+    const m = buildMatchers(detectAdaptersForProject(root));
+    expect(m.isCodeFile("/x/main.py")).toBe(true);
+    expect(m.isCodeFile("/x/main.js")).toBe(false);
+    expect(m.shouldSkip("/x/node_modules/foo/index.js")).toBe(false);
+    expect(m.shouldSkip("/x/__pycache__/foo.pyc")).toBe(true);
+  });
+});

--- a/tests/rag/indexer.test.js
+++ b/tests/rag/indexer.test.js
@@ -76,6 +76,22 @@ describe("indexer — KJC-PCS-0049 Step 4", () => {
     expect(countChunks(db, { kind: "code" })).toBeGreaterThan(0);
   });
 
+  // KJC-PCS-0052 PR-A — un repo Python (detectado por pyproject.toml) indexa
+  // .py via el language adapter registry, y NO recoge node_modules (que en un
+  // repo Python no debería existir, pero el matcher cumple igual). Cero
+  // regresión en repos JS: el test JS-only de arriba sigue verde sin tocar.
+  it("indexProject --with-sources indexes .py files in a Python project (manifest detected)", async () => {
+    const projectDir = join(root, "py-proj");
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    mkdirSync(join(projectDir, "__pycache__"), { recursive: true });
+    writeFileSync(join(projectDir, "pyproject.toml"), "[project]\nname='demo'\n");
+    writeFileSync(join(projectDir, "src", "app.py"), "def alpha():\n    return 1\n");
+    writeFileSync(join(projectDir, "__pycache__", "app.cpython-311.pyc"), "x");
+    const totals = await indexProject(projectDir, { db, embedder: fakeEmbedder(), karajanHome: join(root, "missing-py"), logger: noopLogger, withSources: true });
+    expect(totals.files).toBe(1); // only src/app.py — __pycache__ skipped
+    expect(countChunks(db, { kind: "code" })).toBeGreaterThan(0);
+  });
+
   // KJC-BUG-0062: `.kj/worktrees/HU-*/` and `tests/_diet/` are scratch
   // sandboxes (per-HU git worktrees and the test-diet audit harness).
   // They contain duplicates of src/ that contaminate retrieval scores.


### PR DESCRIPTION
## Summary

**KJC-PCS-0052 PR-A** — extrae las constantes hard-coded para JS/TS del indexer del RAG a un registry de adapters por lenguaje, y suma Python como primera canary.

Antes: `src/rag/indexer.js` llevaba `CODE_EXT_RE` y `SKIP_SEGMENTS` pensados solo para JS/TS. Un usuario con un proyecto Python/Rust/Go obtenía índice vacío incluso con `--with-sources`.

Ahora: cada adapter declara `{id, extensions, skipSegments, manifests}`; el indexer detecta qué aplica al `projectDir` mirando manifests y construye los matchers. Zero regresión en repos JS (fallback explícito a JS si no hay manifest, lo que preserva sandboxes de tests).

- `src/lang/js.js`, `src/lang/python.js` — adapters.
- `src/lang/registry.js` — `getAdapters`, `detectAdaptersForProject`, `buildMatchers`, `getAllCodeExtensions`.
- `src/rag/indexer.js` — drop constantes hardcoded; `indexProject --with-sources` e `indexProjectDelta` consumen el matcher.
- El chunker existente ya degrada solo a `windowText` para extensiones no-JS (AST multi-lang llega en PR-B con tree-sitter).

## Test plan

- [x] `npx vitest run tests/lang/ tests/rag/indexer.test.js` — 15/15 verde
  - 7 tests nuevos en `tests/lang/registry.test.js` (defensive copy, detección por manifest, multi-stack, fallback legacy, matcher union, isolation Python-only)
  - 1 test nuevo en `tests/rag/indexer.test.js`: indexa `.py` en repo Python detectado por `pyproject.toml`, salta `__pycache__`
- [x] `npx eslint src/lang/ src/rag/indexer.js tests/lang/ tests/rag/indexer.test.js` — clean (warning preexistente en `existsSync` no introducido aquí)
- [x] Diff: 203 insertions / 8 deletions = **+195 LOC neto** (bajo el 200 hard limit del shrink-budget)

## Epic context

Esta es PR-A de **KJC-PCS-0052** (multi-lang support). Los siguientes PRs construirán sobre este registry:
- **PR-B** (KJC-TSK-0475) — AST chunker multi-lang vía tree-sitter
- **PR-C** (KJC-TSK-0476) — audit collectors multi-stack
- **PR-D** (KJC-TSK-0477) — onboarder multi-stack

Cierra parte de [#135](https://github.com/manufosela/karajan-code/issues/135) (RAG non-JS).