### PR TITLE
feat(rag): Python source chunker via adapter dispatch (KJC-TSK-0475)

### DIFF
--- a/src/lang/chunk-python.js
+++ b/src/lang/chunk-python.js
@@ -1,0 +1,48 @@
+// KJC-PCS-0052 PR-B — Python source chunker. Top-level `def`/`async def`/
+// `class` actúan como frontera de chunk; cada chunk lleva `metadata.symbol`
+// con el nombre + `metadata.language: "python"`. Mirrors el regex fallback
+// de JS (chunkSourceRegex) — no AST real porque tree-sitter (native vs
+// WASM) es decisión separada que vivirá en PR-B.2.
+//
+// Por qué basta con `^(def|async def|class)` en multiline: top-level en
+// Python convive en columna 0; métodos y funciones anidadas tienen
+// indentación, así que `^` (sin whitespace previo) las excluye de forma
+// natural — caen dentro del chunk de su clase/función padre.
+
+const DEFAULT_LIMIT = 800;
+const DEFAULT_OVERLAP = 100;
+const TOP_RE = /^(?:async\s+)?(?:def|class)\s+([A-Za-z_]\w*)/gm;
+
+function windowText(text, limit, overlap) {
+  if (text.length <= limit) return [text];
+  const step = Math.max(1, limit - overlap);
+  const out = [];
+  for (let i = 0; i < text.length; i += step) {
+    out.push(text.slice(i, i + limit));
+    if (i + limit >= text.length) break;
+  }
+  return out;
+}
+
+export function chunkPython(text, { path = "<src>", limit = DEFAULT_LIMIT, overlap = DEFAULT_OVERLAP } = {}) {
+  const marks = [];
+  TOP_RE.lastIndex = 0;
+  let m;
+  while ((m = TOP_RE.exec(text)) !== null) marks.push({ idx: m.index, symbol: m[1] });
+  if (marks.length === 0) {
+    return windowText(text, limit, overlap).map((piece) => ({
+      text: piece,
+      metadata: { source: path, kind: "code", symbol: null, language: "python" },
+    }));
+  }
+  const out = [];
+  for (let i = 0; i < marks.length; i += 1) {
+    const start = marks[i].idx;
+    const end = i + 1 < marks.length ? marks[i + 1].idx : text.length;
+    const body = text.slice(start, end);
+    for (const piece of windowText(body, limit, overlap)) {
+      out.push({ text: piece, metadata: { source: path, kind: "code", symbol: marks[i].symbol, language: "python" } });
+    }
+  }
+  return out;
+}

--- a/src/lang/python.js
+++ b/src/lang/python.js
@@ -1,14 +1,13 @@
-// KJC-PCS-0052 PR-A — Python adapter. Primer lenguaje no-JS soportado
-// por el RAG indexer. La detección por manifest (pyproject.toml,
-// setup.py, requirements.txt, Pipfile) activa el adapter; los virtualenvs
-// y caches típicos se excluyen del walk para no contaminar el índice con
-// dependencias ya vendoreadas. El chunker AST (tree-sitter) llega en PR-B;
-// hasta entonces, la cadena chunkSourceAST → chunkSourceRegex → windowText
-// devuelve windowing puro para .py (sigue siendo recuperable, solo sin
-// metadata.symbol).
+// KJC-PCS-0052 PR-A/PR-B — Python adapter. Detección por manifest activa
+// el adapter; virtualenvs y caches se excluyen del walk. PR-B añade
+// `chunkSource` regex top-level (def/async def/class) — tree-sitter real
+// queda para PR-B.2 (decisión WASM vs native).
+import { chunkPython } from "./chunk-python.js";
+
 export const PYTHON_ADAPTER = {
   id: "python",
   extensions: [".py"],
   skipSegments: ["__pycache__", ".venv", "venv", ".tox", ".pytest_cache", ".mypy_cache", ".ruff_cache"],
   manifests: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"],
+  chunkSource: chunkPython,
 };

--- a/src/lang/registry.js
+++ b/src/lang/registry.js
@@ -62,3 +62,15 @@ export function getAllCodeExtensions() {
   for (const a of REGISTRY) for (const e of a.extensions) out.add(e.toLowerCase());
   return [...out];
 }
+
+/**
+ * KJC-PCS-0052 PR-B — devuelve el adapter cuya `extensions` cubre el
+ * path, o `null` si ninguno matchea. Lo consume el chunker para delegar
+ * a un chunker específico por lenguaje (p.ej. Python).
+ */
+export function adapterForPath(path) {
+  if (!path) return null;
+  const ext = extname(path).toLowerCase();
+  for (const a of REGISTRY) if (a.extensions.includes(ext)) return a;
+  return null;
+}

--- a/src/rag/chunker.js
+++ b/src/rag/chunker.js
@@ -92,13 +92,17 @@ export function chunkPlan(plan, { path = "<plan>", limit = DEFAULT_CHUNK_LIMIT }
 // ---------- source chunker (export-symbol granularity) ------------
 
 import { chunkSourceAST } from "./chunker-ast.js";
+import { adapterForPath } from "../lang/registry.js";
 
 const EXPORT_RE = /^export\s+(?:async\s+)?(?:function|class|const|let)\s+(\w+)/gm;
 
-// KJC-TSK-0444 — try AST chunker first (top-level declarations as whole
-// units, JSDoc folded in); fall back to the export-regex if @babel/parser
-// can't parse the file (returns null).
+// KJC-TSK-0444 + KJC-PCS-0052 PR-B — dispatch por adapter cuando el path
+// coincide con un lenguaje registrado que aporta su propio `chunkSource`
+// (p.ej. Python regex top-level). Si no, mantiene el camino JS histórico:
+// AST de @babel/parser primero, fallback a export-regex.
 export function chunkSource(text, opts = {}) {
+  const ad = adapterForPath(opts.path);
+  if (ad?.chunkSource) return ad.chunkSource(text, opts);
   const ast = chunkSourceAST(text, opts);
   if (ast) return ast;
   return chunkSourceRegex(text, opts);

--- a/tests/lang/chunk-python.test.js
+++ b/tests/lang/chunk-python.test.js
@@ -1,0 +1,63 @@
+// KJC-PCS-0052 PR-B — Python chunker. Cubre las dos primeras acceptance
+// criteria del card (top-level def/class → chunks con symbol; fallback
+// windowing cuando no hay markers) y verifica el dispatch desde el
+// chunker general por adapter.
+import { describe, expect, it } from "vitest";
+
+import { chunkPython } from "../../src/lang/chunk-python.js";
+import { chunkSource } from "../../src/rag/chunker.js";
+
+describe("chunkPython — KJC-PCS-0052 PR-B", () => {
+  it("emits one chunk per top-level def/class with metadata.symbol", () => {
+    const text = "def alpha():\n    return 1\n\nclass Beta:\n    pass\n\nasync def gamma():\n    return 3\n";
+    const chunks = chunkPython(text, { path: "x.py" });
+    expect(chunks.map((c) => c.metadata.symbol)).toEqual(["alpha", "Beta", "gamma"]);
+    expect(chunks[0].text).toContain("def alpha()");
+    expect(chunks[1].text).toContain("class Beta");
+    expect(chunks[2].text).toContain("async def gamma");
+    for (const c of chunks) {
+      expect(c.metadata.language).toBe("python");
+      expect(c.metadata.kind).toBe("code");
+      expect(c.metadata.source).toBe("x.py");
+    }
+  });
+
+  it("does NOT pick up nested methods — indented def stays inside the parent class chunk", () => {
+    const text = "class Foo:\n    def method(self):\n        return 1\n\ndef top():\n    return 2\n";
+    const chunks = chunkPython(text, { path: "x.py" });
+    expect(chunks.map((c) => c.metadata.symbol)).toEqual(["Foo", "top"]);
+    expect(chunks[0].text).toContain("def method(self)");
+  });
+
+  it("falls back to windowText when no top-level markers exist (script-only)", () => {
+    const text = "# just a script\nprint('hi')\n";
+    const chunks = chunkPython(text, { path: "s.py" });
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].metadata.symbol).toBe(null);
+    expect(chunks[0].metadata.language).toBe("python");
+  });
+
+  it("windows oversized bodies (limit boundary)", () => {
+    const body = "x" + "y".repeat(2000);
+    const text = `def huge():\n    return "${body}"\n`;
+    const chunks = chunkPython(text, { path: "h.py", limit: 200, overlap: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.metadata.symbol).toBe("huge");
+  });
+});
+
+describe("chunkSource adapter dispatch — KJC-PCS-0052 PR-B", () => {
+  it("routes .py files through chunkPython (symbol metadata present)", () => {
+    const text = "def alpha():\n    return 1\n\ndef beta():\n    return 2\n";
+    const chunks = chunkSource(text, { path: "/tmp/x.py" });
+    expect(chunks.map((c) => c.metadata.symbol)).toEqual(["alpha", "beta"]);
+    expect(chunks[0].metadata.language).toBe("python");
+  });
+
+  it("keeps .js files on the JS path (no language tag, JS regex/AST decides symbol)", () => {
+    const text = "export function alpha() { return 1; }\n";
+    const chunks = chunkSource(text, { path: "/tmp/x.js" });
+    expect(chunks[0].metadata.symbol).toBe("alpha");
+    expect(chunks[0].metadata.language).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

**KJC-PCS-0052 PR-B** — los `.py` ahora se chunkean por límites sintácticos (`def` / `async def` / `class` top-level) en lugar de windowing puro. Cada chunk lleva `metadata.symbol` con el nombre + `metadata.language: \"python\"`, lo que permite filtrar por símbolo y por lenguaje en el retriever.

Antes: un usuario que buscara \"función authenticate\" en un repo Python recibía recortes arbitrarios sin `metadata.symbol` (windowing de 800 chars con overlap).

Ahora: el chunker general (`src/rag/chunker.js`) consulta el adapter del lenguaje via `adapterForPath(opts.path)`. Si el adapter expone `chunkSource`, delega; si no, fall-through al camino histórico JS (Babel AST → regex de exports). Cero regresión en repos JS/TS — `JS_ADAPTER` no expone `chunkSource`, así que `.js`/`.ts`/`.jsx`/`.tsx` siguen entrando por `chunkSourceAST`.

### Cambios

- `src/lang/chunk-python.js` — chunker regex top-level (`^(?:async\\s+)?(?:def|class)\\s+(\\w+)` en multiline). Métodos anidados y defs internas caen en el chunk del padre por la indentación natural de Python. Fallback a `windowText` para scripts lineales sin top-level.
- `src/lang/python.js` — `PYTHON_ADAPTER.chunkSource = chunkPython`.
- `src/lang/registry.js` — nuevo `adapterForPath(path)`: devuelve el adapter cuya extensión cubre el path o `null`.
- `src/rag/chunker.js` — `chunkSource` consulta `adapterForPath` antes de ir al camino JS.

## Test plan

- [x] `npx vitest run tests/lang/chunk-python.test.js` — 6/6 verde
- [x] `npx vitest run tests/rag/ tests/lang/` — 147/147 verde (regresión completa de RAG + lang)
- [x] `npx eslint src/lang/ src/rag/chunker.js tests/lang/chunk-python.test.js` — clean
- [x] Diff: 137 insertions / 11 deletions = **+126 LOC neto** (bajo el 200 hard limit)

## Scope reducido — heads-up

El card original ([KJC-TSK-0475](#)) describía Python + Rust + Go via **tree-sitter** real. Eso no entra en una PR de 200 LOC sin sacrificar fidelidad. He acotado a:

- ✅ **Python regex chunker** (AC1: top-level def/class → symbol chunks; AC3: fallback windowing)
- ⏸️ **Rust + Go** (AC2) — quedan para **PR-B.2**
- ⏸️ **Tree-sitter real** — decisión WASM (`@vscode/tree-sitter-wasm`, `web-tree-sitter`) vs native binding (`node-tree-sitter`) tiene impacto en distribución SEA y merece su propia PR. El \"riesgo SEA\" ya estaba documentado en el `implementationPlan.risks` del card.

El regex top-level entrega exactamente el mismo nivel de fidelidad que el `chunkSourceRegex` fallback de JS — no es un downgrade, es paridad con el camino regex de JS para repos donde Babel no puede parsear.

## Epic context

Esta es PR-B (Python only) de **KJC-PCS-0052**. Build-up:

- ✅ **PR-A** (#884, KJC-TSK-0474) — Language adapter registry + Python canary
- ✅ **PR-B** (this PR, KJC-TSK-0475 reducido) — Python chunker via adapter dispatch
- ⏸️ **PR-B.2** (nuevo card pendiente) — tree-sitter (WASM o native) + Rust + Go
- ⏸️ **PR-C** (KJC-TSK-0476) — audit collectors multi-stack
- ⏸️ **PR-D** (KJC-TSK-0477) — onboarder multi-stack