### PR TITLE
feat(rag): wire preparePython/prepareRust in indexer (KJC-TSK-0480)

### DIFF
--- a/src/lang/python.js
+++ b/src/lang/python.js
@@ -2,7 +2,7 @@
 // el adapter; virtualenvs y caches se excluyen del walk. PR-B añade
 // `chunkSource` regex top-level (def/async def/class) — tree-sitter real
 // queda para PR-B.2 (decisión WASM vs native).
-import { chunkPython } from "./chunk-python.js";
+import { chunkPython, preparePython } from "./chunk-python.js";
 
 export const PYTHON_ADAPTER = {
   id: "python",
@@ -10,4 +10,5 @@ export const PYTHON_ADAPTER = {
   skipSegments: ["__pycache__", ".venv", "venv", ".tox", ".pytest_cache", ".mypy_cache", ".ruff_cache"],
   manifests: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile"],
   chunkSource: chunkPython,
+  prepare: preparePython,
 };

--- a/src/lang/rust.js
+++ b/src/lang/rust.js
@@ -2,7 +2,7 @@
 // y skip segments evitan que el indexer recorra builds. chunk-rust usa
 // AST (tree-sitter) cuando el caller hizo `await prepareRust()` y cae a
 // regex en otro caso (mismo patrón que PYTHON_ADAPTER).
-import { chunkRust } from "./chunk-rust.js";
+import { chunkRust, prepareRust } from "./chunk-rust.js";
 
 export const RUST_ADAPTER = {
   id: "rust",
@@ -10,4 +10,5 @@ export const RUST_ADAPTER = {
   skipSegments: ["target", ".cargo"],
   manifests: ["Cargo.toml", "Cargo.lock"],
   chunkSource: chunkRust,
+  prepare: prepareRust,
 };

--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -75,6 +75,20 @@ function chunkLabel(ch) {
   return ch.metadata?.hu_id || ch.metadata?.symbol || ch.metadata?.headingPath?.join(" > ") || "block";
 }
 
+// KJC-PCS-0052 PR-B.2.4 — Activa el camino AST en chunkers cuyo adapter
+// expone `prepare()` (Python, Rust). Promise.allSettled aísla cada grammar:
+// si uno falla (red, wasm corrupto), el resto se carga y los .py/.rs sin
+// AST listo caen al fallback regex en chunkSource. JS no tiene `prepare`
+// porque chunker-ast.js usa @babel/parser síncrono (ya cargado).
+export async function prepareAdapters(adapters, { logger = console } = {}) {
+  const tasks = adapters.filter((a) => typeof a.prepare === "function");
+  if (tasks.length === 0) return;
+  const results = await Promise.allSettled(tasks.map((a) => a.prepare()));
+  results.forEach((r, i) => {
+    if (r.status === "rejected") logger.warn?.(`[rag-indexer] adapter ${tasks[i].id} prepare failed: ${r.reason?.message || r.reason}`);
+  });
+}
+
 async function listFiles(dir, predicate) {
   const out = [];
   async function walk(d) {
@@ -98,6 +112,7 @@ async function listFiles(dir, predicate) {
 export async function indexProject(projectDir, { db, embedder, karajanHome, logger = console, withSources = false } = {}) {
   const totals = { indexed: 0, failed: 0, files: 0 };
   const slug = projectDir.split("/").pop()?.replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
+  await prepareAdapters(detectAdaptersForProject(projectDir), { logger });
   const planRoot = join(karajanHome, PLANS_DIR, slug);
   if (existsSync(planRoot)) {
     const plans = await listFiles(planRoot, (p) => /plan-.*\.json$/.test(p));
@@ -149,7 +164,9 @@ export async function indexProjectDelta(projectDir, { db, embedder, since, logge
     else if (s === "D") { ops.push({ kind: "del", p: parts[++i] }); }
     else { ops.push({ kind: "idx", p: parts[++i] }); }
   }
-  const matchers = buildMatchers(detectAdaptersForProject(projectDir));
+  const adapters = detectAdaptersForProject(projectDir);
+  await prepareAdapters(adapters, { logger });
+  const matchers = buildMatchers(adapters);
   for (const { kind, p } of ops) {
     if (matchers.shouldSkip(p)) continue;
     if (!matchers.isCodeFile(p)) continue;

--- a/tests/lang/registry.test.js
+++ b/tests/lang/registry.test.js
@@ -25,6 +25,13 @@ describe("language registry — KJC-PCS-0052 PR-A", () => {
     expect(a.map((x) => x.id).sort()).toEqual(["js", "python", "rust"]);
   });
 
+  it("only Python and Rust adapters expose prepare() (JS uses sync @babel)", () => {
+    const byId = Object.fromEntries(getAdapters().map((a) => [a.id, a]));
+    expect(typeof byId.python.prepare).toBe("function");
+    expect(typeof byId.rust.prepare).toBe("function");
+    expect(byId.js.prepare).toBeUndefined();
+  });
+
   it("getAllCodeExtensions includes JS, Python and Rust", () => {
     const exts = getAllCodeExtensions();
     expect(exts).toContain(".js");

--- a/tests/rag/indexer-prepare.test.js
+++ b/tests/rag/indexer-prepare.test.js
@@ -1,0 +1,39 @@
+// KJC-PCS-0052 PR-B.2.4 — prepareAdapters: activa AST en chunkers que la
+// soportan. Verifica que sólo se invoca a los adapters con prepare(), que
+// JS_ADAPTER no se toca y que un fallo en un grammar deja seguir al resto
+// sin abortar el index.
+import { describe, expect, it, vi } from "vitest";
+
+import { prepareAdapters } from "../../src/rag/indexer.js";
+
+describe("prepareAdapters — KJC-PCS-0052 PR-B.2.4", () => {
+  it("invokes prepare() on every adapter that exposes one", async () => {
+    const py = vi.fn().mockResolvedValue(undefined);
+    const rs = vi.fn().mockResolvedValue(undefined);
+    await prepareAdapters([
+      { id: "js" },
+      { id: "python", prepare: py },
+      { id: "rust", prepare: rs },
+    ]);
+    expect(py).toHaveBeenCalledTimes(1);
+    expect(rs).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores adapters without prepare (JS path)", async () => {
+    // No adapter has prepare → resolves without errors.
+    await expect(prepareAdapters([{ id: "js" }])).resolves.toBeUndefined();
+  });
+
+  it("logs a warning when a grammar fails, never throws", async () => {
+    const logger = { warn: vi.fn() };
+    const ok = vi.fn().mockResolvedValue(undefined);
+    const ko = vi.fn().mockRejectedValue(new Error("wasm missing"));
+    await prepareAdapters(
+      [{ id: "python", prepare: ok }, { id: "rust", prepare: ko }],
+      { logger },
+    );
+    expect(ok).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("rust prepare failed"));
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("wasm missing"));
+  });
+});


### PR DESCRIPTION
## Summary
- PR-B.2.4 del epic **KJC-PCS-0052**. Cablea el hook que faltaba para que la AST de tree-sitter (vendorizada en PR-B.2.1 y PR-B.2.2) se active al runtime durante el indexado.
- Añade `prepare?: () => Promise<void>` opcional al shape de adapter: `PYTHON_ADAPTER.prepare = preparePython`, `RUST_ADAPTER.prepare = prepareRust`. JS no expone `prepare` (chunker-ast.js usa @babel síncrono).
- Nuevo helper `prepareAdapters(adapters, {logger})` en `src/rag/indexer.js`. Usa `Promise.allSettled`: un grammar roto loggea warning y el resto sigue cargando; los chunkers afectados caen al regex backward-compat.
- `indexProject` e `indexProjectDelta` llaman a `prepareAdapters` justo después de `detectAdaptersForProject`, antes del walk.

## Tests
- `tests/rag/indexer-prepare.test.js`: invoca solo los adapters con prepare, ignora los demás, un grammar rechazado loggea warning sin lanzar.
- `tests/lang/registry.test.js`: assertion del shape (Python+Rust expose prepare, JS no).
- Suite completa local: **5318/5318** (4 nuevos vs 5314 de main).

## Out of scope
- `indexFile` suelto y `watcher.js`: hoy chunkean `.py`/`.rs` sin conocer `projectDir`, así que la AST sólo se activa por la vía `indexProject*`. Si se quiere, próximo PR puede llamar `prepareAdapters` con `adapterForPath(p)` antes de cada `indexFile`.
- **PR-B.2.3 (Go)** — sigue pendiente como continuación natural del multi-stack.

## Test plan
- [x] `npx vitest run` → 5318/5318.
- [x] `npm run lint` → 0 errors.
- [x] LOC budget: 29 added, 3 removed, net 26 (`shrink-budget` ≤200 ✅).
- [ ] CI green.