### PR TITLE
feat(audit): multi-stack manifest sniffer for basal-cost (KJC-TSK-0476)

### DIFF
--- a/src/audit/basal-cost.js
+++ b/src/audit/basal-cost.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { getKarajanHome } from "../utils/paths.js";
+import { sniffManifests, summariseStack } from "../utils/manifest-sniff.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -59,16 +60,16 @@ async function countLines(filePath) {
   }
 }
 
-async function countDependencies(projectDir) {
-  const pkgPath = path.join(projectDir, "package.json");
-  try {
-    const pkg = JSON.parse(await fs.readFile(pkgPath, "utf8"));
-    const deps = Object.keys(pkg.dependencies || {});
-    const devDeps = Object.keys(pkg.devDependencies || {});
-    return { dependencies: deps.length, devDependencies: devDeps.length, total: deps.length + devDeps.length };
-  } catch {
-    return { dependencies: 0, devDependencies: 0, total: 0 };
+function countDependenciesFromStack(stack) {
+  // Suma deps + devDeps de TODOS los manifests detectados (multi-stack).
+  // Si no hay manifests, devuelve ceros — coherente con repos sin paquete.
+  let deps = 0;
+  let devDeps = 0;
+  for (const m of stack.manifests) {
+    deps += m.deps;
+    devDeps += m.devDeps;
   }
+  return { dependencies: deps, devDependencies: devDeps, total: deps + devDeps };
 }
 
 function runDepcheck(projectDir) {
@@ -231,8 +232,11 @@ export async function measureBasalCost(projectDir) {
     totalLines += await countLines(f);
   }
 
-  const depInfo = await countDependencies(projectDir);
-  const depcheck = await runDepcheck(projectDir);
+  const stack = summariseStack(await sniffManifests(projectDir));
+  const depInfo = countDependenciesFromStack(stack);
+  // depcheck solo aplica a Node; en stacks puros no-Node lo saltamos.
+  const hasNode = stack.manifests.some((m) => m.stack === "node");
+  const depcheck = hasNode ? await runDepcheck(projectDir) : { unused: [], note: "depcheck skipped (no package.json)" };
   const deadExports = await findDeadExports(sourceFiles);
 
   return {
@@ -240,7 +244,8 @@ export async function measureBasalCost(projectDir) {
     totalFiles: sourceFiles.length,
     dependencies: depInfo,
     unusedDependencies: depcheck,
-    deadExports
+    deadExports,
+    stack
   };
 }
 

--- a/src/utils/manifest-sniff.js
+++ b/src/utils/manifest-sniff.js
@@ -1,0 +1,82 @@
+// KJC-TSK-0476 — Multi-stack manifest sniffer. Sin libs externas: JSON.parse
+// para package.json, regex para TOML y go.mod. Lo consumen audit (basal-cost)
+// y, vía PR-D, el onboarder.
+import fs from "node:fs/promises";
+import path from "node:path";
+
+async function readMaybe(file) {
+  try { return await fs.readFile(file, "utf8"); } catch { return null; }
+}
+
+async function sniffNode(dir) {
+  const raw = await readMaybe(path.join(dir, "package.json"));
+  if (!raw) return null;
+  try {
+    const pkg = JSON.parse(raw);
+    return { stack: "node", manifest: "package.json", name: pkg.name || null,
+      deps: Object.keys(pkg.dependencies || {}).length,
+      devDeps: Object.keys(pkg.devDependencies || {}).length };
+  } catch {
+    return { stack: "node", manifest: "package.json", name: null, deps: 0, devDeps: 0, malformed: true };
+  }
+}
+
+// Cuerpo TOML de `[section]` hasta el siguiente `\n[` o EOF. Lookahead con `/m`
+// cambia el significado de `$` y producía capturas vacías.
+function tomlSection(toml, section) {
+  const i = toml.indexOf(`[${section}]`);
+  if (i === -1) return "";
+  const rest = toml.slice(i + section.length + 2);
+  const n = rest.search(/\n\[/);
+  return n === -1 ? rest : rest.slice(0, n);
+}
+
+const DEP_LINE_RE = /^\s*[A-Za-z0-9_-]+\s*=/;
+const countDepLines = (block, excludePython) => block.split("\n")
+  .filter((l) => DEP_LINE_RE.test(l) && !(excludePython && /^\s*python\s*=/.test(l))).length;
+
+async function sniffPython(dir) {
+  const py = await readMaybe(path.join(dir, "pyproject.toml"));
+  if (py) {
+    const name = /^name\s*=\s*["']([^"']+)["']/m.exec(py)?.[1] || null;
+    const projectDeps = /\[project\][\s\S]*?dependencies\s*=\s*\[([^\]]*)\]/m.exec(py)?.[1] || "";
+    const projectCount = projectDeps.split(",").map((s) => s.trim()).filter(Boolean).length;
+    const poetryCount = countDepLines(tomlSection(py, "tool.poetry.dependencies"), true);
+    return { stack: "python", manifest: "pyproject.toml", name, deps: projectCount + poetryCount, devDeps: 0 };
+  }
+  const req = await readMaybe(path.join(dir, "requirements.txt"));
+  if (!req) return null;
+  const lines = req.split("\n").map((l) => l.replace(/#.*$/, "").trim()).filter(Boolean);
+  return { stack: "python", manifest: "requirements.txt", name: null, deps: lines.length, devDeps: 0 };
+}
+
+async function sniffRust(dir) {
+  const toml = await readMaybe(path.join(dir, "Cargo.toml"));
+  if (!toml) return null;
+  return { stack: "rust", manifest: "Cargo.toml",
+    name: /^name\s*=\s*["']([^"']+)["']/m.exec(toml)?.[1] || null,
+    deps: countDepLines(tomlSection(toml, "dependencies")),
+    devDeps: countDepLines(tomlSection(toml, "dev-dependencies")) };
+}
+
+async function sniffGo(dir) {
+  const mod = await readMaybe(path.join(dir, "go.mod"));
+  if (!mod) return null;
+  const block = /require\s*\(([\s\S]*?)\)/m.exec(mod)?.[1] || "";
+  const blockCount = block.split("\n").filter((l) => /\S/.test(l) && !l.trim().startsWith("//")).length;
+  const singleCount = mod.split("\n").filter((l) => /^require\s+\S+\s+\S+/.test(l)).length;
+  return { stack: "go", manifest: "go.mod",
+    name: /^module\s+(\S+)/m.exec(mod)?.[1] || null,
+    deps: blockCount + singleCount, devDeps: 0 };
+}
+
+export async function sniffManifests(dir) {
+  const r = await Promise.all([sniffNode(dir), sniffPython(dir), sniffRust(dir), sniffGo(dir)]);
+  return r.filter(Boolean);
+}
+
+export function summariseStack(manifests) {
+  if (!manifests.length) return { primary: null, multi: false, manifests: [] };
+  const ranked = [...manifests].sort((a, b) => (b.deps + b.devDeps) - (a.deps + a.devDeps));
+  return { primary: ranked[0].stack, multi: manifests.length > 1, manifests };
+}

--- a/tests/audit/basal-cost-multilang.test.js
+++ b/tests/audit/basal-cost-multilang.test.js
@@ -1,0 +1,47 @@
+// KJC-TSK-0476 — measureBasalCost ahora cuenta deps de todos los stacks
+// detectados y devuelve `stack` con el summary.
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { measureBasalCost } from "../../src/audit/basal-cost.js";
+
+async function mkProject(layout) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "basal-multilang-"));
+  for (const [rel, content] of Object.entries(layout)) {
+    const full = path.join(root, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, "utf8");
+  }
+  return root;
+}
+
+describe("measureBasalCost — multi-stack", () => {
+  let project;
+  afterEach(async () => { if (project) await fs.rm(project, { recursive: true, force: true }); });
+
+  it("reports stack=python and counts pyproject deps in a Python-only repo", async () => {
+    project = await mkProject({
+      "pyproject.toml": `[project]\nname = "py"\ndependencies = ["requests", "click"]\n`,
+      "src/main.py": "def main(): pass\n",
+    });
+    const r = await measureBasalCost(project);
+    expect(r.stack.primary).toBe("python");
+    expect(r.stack.multi).toBe(false);
+    expect(r.dependencies.total).toBe(2);
+    // depcheck no debe ejecutarse sin package.json.
+    expect(r.unusedDependencies.note).toMatch(/skipped/);
+  });
+
+  it("sums deps across stacks in a mixed Node + Python repo", async () => {
+    project = await mkProject({
+      "package.json": JSON.stringify({ name: "front", dependencies: { react: "18" }, devDependencies: { vitest: "1" } }),
+      "pyproject.toml": `[project]\nname = "back"\ndependencies = ["fastapi"]\n`,
+    });
+    const r = await measureBasalCost(project);
+    expect(r.stack.multi).toBe(true);
+    expect(r.stack.manifests.map((m) => m.stack).sort()).toEqual(["node", "python"]);
+    expect(r.dependencies.total).toBe(3); // 1 + 1 + 1
+  });
+});

--- a/tests/utils/manifest-sniff.test.js
+++ b/tests/utils/manifest-sniff.test.js
@@ -1,0 +1,64 @@
+// KJC-TSK-0476 — sniff de manifests por stack, sin libs externas.
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { sniffManifests, summariseStack } from "../../src/utils/manifest-sniff.js";
+
+async function mkProject(layout) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "sniff-"));
+  for (const [rel, content] of Object.entries(layout)) {
+    const full = path.join(root, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, "utf8");
+  }
+  return root;
+}
+
+describe("sniffManifests — KJC-TSK-0476", () => {
+  let project;
+  afterEach(async () => { if (project) await fs.rm(project, { recursive: true, force: true }); });
+
+  it("counts Node deps + devDeps from package.json", async () => {
+    project = await mkProject({
+      "package.json": JSON.stringify({ name: "x", dependencies: { a: "1", b: "2" }, devDependencies: { c: "3" } }),
+    });
+    expect((await sniffManifests(project))[0]).toMatchObject({ stack: "node", name: "x", deps: 2, devDeps: 1 });
+  });
+
+  it("counts Python deps from pyproject.toml [project] dependencies", async () => {
+    project = await mkProject({ "pyproject.toml": `[project]\nname = "demo"\ndependencies = ["requests>=2", "click", "rich"]\n` });
+    expect((await sniffManifests(project))[0]).toMatchObject({ stack: "python", manifest: "pyproject.toml", name: "demo", deps: 3 });
+  });
+
+  it("falls back to requirements.txt when no pyproject", async () => {
+    project = await mkProject({ "requirements.txt": "# comment\nrequests==2.0\nclick\n\nrich # inline note\n" });
+    expect((await sniffManifests(project))[0]).toMatchObject({ stack: "python", manifest: "requirements.txt", deps: 3 });
+  });
+
+  it("counts Rust deps and dev-deps from Cargo.toml", async () => {
+    project = await mkProject({
+      "Cargo.toml": `[package]\nname = "demo"\n\n[dependencies]\nserde = "1"\ntokio = "1"\n\n[dev-dependencies]\nassert_cmd = "2"\n`,
+    });
+    expect((await sniffManifests(project))[0]).toMatchObject({ stack: "rust", name: "demo", deps: 2, devDeps: 1 });
+  });
+
+  it("counts Go requires (both block and single-line forms)", async () => {
+    project = await mkProject({
+      "go.mod": `module example.com/x\n\ngo 1.21\n\nrequire (\n  github.com/foo v1.0.0\n  github.com/bar v2.0.0\n)\n\nrequire example.com/baz v0.1.0\n`,
+    });
+    expect((await sniffManifests(project))[0]).toMatchObject({ stack: "go", name: "example.com/x", deps: 3 });
+  });
+
+  it("detects multi-stack repos; summariseStack picks primary by deps count", async () => {
+    project = await mkProject({
+      "package.json": JSON.stringify({ name: "front", dependencies: { react: "18" } }),
+      "pyproject.toml": `[project]\nname = "back"\ndependencies = ["fastapi", "uvicorn"]\n`,
+    });
+    const sniffed = await sniffManifests(project);
+    expect(sniffed.map((m) => m.stack).sort()).toEqual(["node", "python"]);
+    expect(summariseStack(sniffed)).toMatchObject({ primary: "python", multi: true });
+    expect(summariseStack([])).toEqual({ primary: null, multi: false, manifests: [] });
+  });
+});


### PR DESCRIPTION
## Summary

- New util `src/utils/manifest-sniff.js`: reads `package.json` (JSON.parse), `pyproject.toml` / `requirements.txt` (regex + small TOML section helper), `Cargo.toml`, and `go.mod`. No new runtime deps.
- `measureBasalCost` now sums dependencies across **all** detected manifests and exposes a `stack` field (`{ primary, multi, manifests: [{stack, manifest, name, deps, devDeps}] }`). Python-, Rust- and Go-only repos are no longer reported with `dependencies.total = 0`.
- `depcheck` is skipped when `package.json` is absent (Node-only tool).

Part of epic **KJC-PCS-0052** — language-agnostic Karajan. Sets up the manifest detection the onboarder needs in PR-D.

## Net delta

210 added, 12 removed → **net 198** (≤200 budget).

## Tests

- `tests/utils/manifest-sniff.test.js` — 6 cases: node, python (pyproject + requirements.txt fallback), rust, go (block + single-line require), multi-stack summary.
- `tests/audit/basal-cost-multilang.test.js` — 2 cases: python-only repo and mixed node+python.
- Full `tests/audit/` + `tests/utils/` suites: 464/464 passing.

## Test plan

- [x] `npx vitest run tests/utils/manifest-sniff.test.js tests/audit/basal-cost-multilang.test.js` → green
- [x] `npx vitest run tests/audit/ tests/utils/` → 464/464
- [ ] CI green (shrink-budget, commitlint, prettier, eslint, tests, coverage)