### PR TITLE
feat(onboarder): multi-stack frameworks + manifests in bundle (KJC-TSK-0477)

### DIFF
--- a/src/onboarder/collectors/framework-multilang.js
+++ b/src/onboarder/collectors/framework-multilang.js
@@ -1,0 +1,64 @@
+// KJC-TSK-0477 — Detectores mínimos de framework por stack (Python/Rust/Go).
+// Consume el sniff de manifests (PR-C) para conocer deps + presencia de
+// archivos canónicos. Cero deps externas, fail-soft (devuelve null o lista
+// vacía). El brief markdown se sintetiza río abajo desde estos campos.
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const PY_FW = [
+  { name: "django", deps: ["django"], file: "manage.py" },
+  { name: "flask", deps: ["flask"], file: "app.py" },
+  { name: "fastapi", deps: ["fastapi"], file: "main.py" },
+];
+const RUST_FW = [
+  { name: "axum", deps: ["axum"] },
+  { name: "actix-web", deps: ["actix-web"] },
+  { name: "rocket", deps: ["rocket"] },
+];
+const GO_FW = [
+  { name: "gin", deps: ["github.com/gin-gonic/gin"] },
+  { name: "echo", deps: ["github.com/labstack/echo"] },
+  { name: "fiber", deps: ["github.com/gofiber/fiber"] },
+];
+
+function matchFw(manifestRaw, projectDir, table) {
+  const found = [];
+  for (const fw of table) {
+    const hasDep = fw.deps.some((d) => manifestRaw?.includes(d));
+    const hasFile = fw.file ? existsSync(path.join(projectDir, fw.file)) : false;
+    if (hasDep || hasFile) found.push({ name: fw.name, viaDep: hasDep, viaFile: hasFile });
+  }
+  return found;
+}
+
+function detectLayout(projectDir, expected) {
+  return expected.filter((d) => existsSync(path.join(projectDir, d)));
+}
+
+// Detect frameworks + canonical layout per stack. Returns one entry per
+// detected manifest stack (skips Node — the existing JS path already covers
+// that with detectProjectStack).
+export function detectFrameworksMultiLang(projectDir, manifests = [], { readManifest } = {}) {
+  const out = [];
+  for (const m of manifests) {
+    if (m.stack === "node") continue;
+    const raw = readManifest ? readManifest(m) : "";
+    if (m.stack === "python") {
+      out.push({ stack: "python", manifest: m.manifest,
+        frameworks: matchFw(raw, projectDir, PY_FW),
+        layout: detectLayout(projectDir, ["apps", "src", "tests"]) });
+    } else if (m.stack === "rust") {
+      const isBin = existsSync(path.join(projectDir, "src", "main.rs"));
+      const isLib = existsSync(path.join(projectDir, "src", "lib.rs"));
+      out.push({ stack: "rust", manifest: m.manifest,
+        crateType: isBin && isLib ? "mixed" : isBin ? "binary" : isLib ? "library" : null,
+        frameworks: matchFw(raw, projectDir, RUST_FW),
+        layout: detectLayout(projectDir, ["src", "tests", "examples", "benches"]) });
+    } else if (m.stack === "go") {
+      out.push({ stack: "go", manifest: m.manifest, modulePath: m.name || null,
+        frameworks: matchFw(raw, projectDir, GO_FW),
+        layout: detectLayout(projectDir, ["cmd", "internal", "pkg"]) });
+    }
+  }
+  return out;
+}

--- a/src/onboarder/collectors/index.js
+++ b/src/onboarder/collectors/index.js
@@ -7,6 +7,8 @@ import { readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
 
 import { detectProjectStack } from "../../utils/stack-detect.js";
+import { sniffManifests } from "../../utils/manifest-sniff.js";
+import { detectFrameworksMultiLang } from "./framework-multilang.js";
 
 const IGNORED_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", "__pycache__"]);
 
@@ -100,16 +102,31 @@ export async function collectAdrs(projectDir) {
   return found;
 }
 
+// Read a manifest file as raw text (best-effort) for framework dep matching.
+function readManifestRaw(projectDir) {
+  return (m) => {
+    try { return readFileSync(join(projectDir, m.manifest), "utf8"); }
+    catch { return ""; }
+  };
+}
+
 // One-shot bundle: every slot is independent; missing slots → null/[].
+// KJC-TSK-0477: manifests (multi-stack) + frameworksMultiLang (Python/Rust/Go)
+// se añaden de forma aditiva para que el brief pueda incluir secciones
+// condicionales sin romper consumidores existentes.
 export async function collectAll(projectDir) {
-  const [stack, tree, adrs] = await Promise.all([
+  const [stack, tree, adrs, manifests] = await Promise.all([
     detectProjectStack(projectDir).catch(() => null),
     collectTree(projectDir).catch(() => []),
     collectAdrs(projectDir).catch(() => []),
+    sniffManifests(projectDir).catch(() => []),
   ]);
+  const frameworksMultiLang = detectFrameworksMultiLang(projectDir, manifests, { readManifest: readManifestRaw(projectDir) });
   return {
     projectDir,
     stack,
+    manifests,
+    frameworksMultiLang,
     tree,
     git: collectGitHistory(projectDir),
     configs: collectConfigs(projectDir),

--- a/templates/roles/onboarder.md
+++ b/templates/roles/onboarder.md
@@ -14,7 +14,10 @@ If the project is greenfield (no git, no configs, empty tree) emit
 
 ## Input
 
-JSON bundle with `projectDir`, `stack`, `tree`, `git` (or null), `configs`,
+JSON bundle with `projectDir`, `stack`, `manifests` (per-stack: node /
+python / rust / go with deps count), `frameworksMultiLang` (Django / Flask /
+FastAPI / Axum / Actix / Rocket / Gin / Echo / Fiber + Rust crate type + Go
+module path + canonical layout dirs), `tree`, `git` (or null), `configs`,
 `adrs`. Slots may be null/empty.
 
 ## Output
@@ -24,6 +27,8 @@ Markdown only — skip any section without data:
 ```markdown
 # Architecture Brief — <projectDir>
 ## Stack
+## Manifests           # only when manifests has entries beyond node
+## Frameworks          # only when frameworksMultiLang has entries
 ## Layout
 ## Configs
 ## Git history
@@ -31,6 +36,10 @@ Markdown only — skip any section without data:
 ## Conventions inferred
 ## Recommendations for new work
 ```
+
+For non-Node stacks (`frameworksMultiLang[].stack` in {python, rust, go}),
+mention the detected framework(s), crate type or module path, and canonical
+layout dirs (apps/, cmd/, internal/, src/, tests/) when present.
 
 Be conservative: only assert what the bundle shows. "Likely" / "appears to"
 are fine; invention is not. Aim for ~40–80 lines total.

--- a/tests/onboarder/framework-multilang.test.js
+++ b/tests/onboarder/framework-multilang.test.js
@@ -1,0 +1,94 @@
+// KJC-TSK-0477 — framework detector (Django/Flask/FastAPI/Axum/Actix/Gin/Echo).
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { sniffManifests } from "../../src/utils/manifest-sniff.js";
+import { detectFrameworksMultiLang } from "../../src/onboarder/collectors/framework-multilang.js";
+import { collectAll } from "../../src/onboarder/collectors/index.js";
+
+async function mkProject(layout) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "fw-multilang-"));
+  for (const [rel, content] of Object.entries(layout)) {
+    const full = path.join(root, rel);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    await fs.writeFile(full, content, "utf8");
+  }
+  return root;
+}
+const readRaw = (root) => (m) => readFileSync(path.join(root, m.manifest), "utf8");
+
+describe("detectFrameworksMultiLang — KJC-TSK-0477", () => {
+  let project;
+  afterEach(async () => { if (project) await fs.rm(project, { recursive: true, force: true }); });
+
+  it("Django via deps + manage.py + apps/ layout", async () => {
+    project = await mkProject({
+      "pyproject.toml": `[project]\nname = "x"\ndependencies = ["django"]\n`,
+      "manage.py": "import django\n",
+      "apps/users/__init__.py": "",
+    });
+    const m = await sniffManifests(project);
+    const fw = detectFrameworksMultiLang(project, m, { readManifest: readRaw(project) });
+    expect(fw).toHaveLength(1);
+    expect(fw[0]).toMatchObject({ stack: "python" });
+    expect(fw[0].frameworks.map((f) => f.name)).toContain("django");
+    expect(fw[0].layout).toContain("apps");
+  });
+
+  it("FastAPI via deps only (no main.py)", async () => {
+    project = await mkProject({
+      "pyproject.toml": `[project]\nname = "api"\ndependencies = ["fastapi", "uvicorn"]\n`,
+    });
+    const m = await sniffManifests(project);
+    const fw = detectFrameworksMultiLang(project, m, { readManifest: readRaw(project) });
+    expect(fw[0].frameworks.map((f) => f.name)).toEqual(["fastapi"]);
+  });
+
+  it("Rust binary crate + Axum framework", async () => {
+    project = await mkProject({
+      "Cargo.toml": `[package]\nname = "svc"\n\n[dependencies]\naxum = "0.7"\ntokio = "1"\n`,
+      "src/main.rs": "fn main() {}\n",
+    });
+    const m = await sniffManifests(project);
+    const fw = detectFrameworksMultiLang(project, m, { readManifest: readRaw(project) });
+    expect(fw[0]).toMatchObject({ stack: "rust", crateType: "binary" });
+    expect(fw[0].frameworks.map((f) => f.name)).toContain("axum");
+    expect(fw[0].layout).toEqual(expect.arrayContaining(["src"]));
+  });
+
+  it("Go module with cmd/ + internal/ + gin", async () => {
+    project = await mkProject({
+      "go.mod": `module example.com/x\n\ngo 1.21\n\nrequire github.com/gin-gonic/gin v1.9.0\n`,
+      "cmd/server/main.go": "package main\n",
+      "internal/svc/svc.go": "package svc\n",
+    });
+    const m = await sniffManifests(project);
+    const fw = detectFrameworksMultiLang(project, m, { readManifest: readRaw(project) });
+    expect(fw[0]).toMatchObject({ stack: "go", modulePath: "example.com/x" });
+    expect(fw[0].frameworks.map((f) => f.name)).toEqual(["gin"]);
+    expect(fw[0].layout.sort()).toEqual(["cmd", "internal"]);
+  });
+
+  it("Node stacks are skipped (covered by detectProjectStack)", () => {
+    const fw = detectFrameworksMultiLang("/tmp", [{ stack: "node", deps: 1, devDeps: 0 }]);
+    expect(fw).toEqual([]);
+  });
+});
+
+describe("collectAll — KJC-TSK-0477 multi-stack fields", () => {
+  let project;
+  afterEach(async () => { if (project) await fs.rm(project, { recursive: true, force: true }); });
+
+  it("emits manifests[] + frameworksMultiLang[] on a Python repo", async () => {
+    project = await mkProject({
+      "pyproject.toml": `[project]\nname = "py"\ndependencies = ["flask"]\n`,
+      "app.py": "from flask import Flask\n",
+    });
+    const bundle = await collectAll(project);
+    expect(bundle.manifests.map((m) => m.stack)).toEqual(["python"]);
+    expect(bundle.frameworksMultiLang[0].frameworks.map((f) => f.name)).toContain("flask");
+  });
+});


### PR DESCRIPTION
## What

PR-D del epic **KJC-PCS-0052** (language-agnostic Karajan). El onboarder ya no asume `package.json`: reutiliza el sniffer de manifests entregado por PR-C (`src/utils/manifest-sniff.js`) y añade detección mínima de frameworks por stack.

## Changes

- **`src/onboarder/collectors/framework-multilang.js`** (nuevo, sin deps externas): Django / Flask / FastAPI para Python, Axum / Actix / Rocket para Rust, Gin / Echo / Fiber para Go. Incluye `crateType` (binary/library/mixed) para Rust y `modulePath` para Go, además del layout canónico (`apps/`, `cmd/`, `internal/`, `src/`, `tests/`, …).
- **`src/onboarder/collectors/index.js`**: `collectAll()` añade `manifests[]` + `frameworksMultiLang[]` al bundle (additive — los consumidores que ignoren campos siguen funcionando).
- **`templates/roles/onboarder.md`**: documenta los nuevos slots del bundle y dos secciones opcionales en el brief markdown (`## Manifests` / `## Frameworks`).
- **Tests** (`tests/onboarder/framework-multilang.test.js`): Django + `apps/`, FastAPI vía deps, Rust binary + Axum, Go `cmd/internal` + Gin, fila Node ignorada, smoke de `collectAll`.

## Out of scope

- AST chunking multi-lang (cubierto por PR-B.2.x).
- Sonar/Semgrep para non-JS (otra task).
- Monorepos polyglot con sub-paths múltiples (mejora futura).

## Acceptance criteria

- [x] Django repo (`pyproject.toml` + `manage.py` + `apps/`) → framework `django` + layout `apps`.
- [x] Rust binary (`Cargo.toml` + `src/main.rs`) + Axum → `crateType: binary` + framework `axum`.
- [x] Go module (`go.mod` + `cmd/` + `internal/` + Gin) → `modulePath: example.com/x` + framework `gin`.
- [x] Repo JS puro: bundle existente intacto (zero-regresión; tests previos del onboarder pasan).

## Tests

19/19 tests passing (`framework-multilang.test.js` + suite onboarder previa).

## LOC budget

Net 184 (≤ 200, sin etiqueta `large-pr-justified`).

Refs **KJC-TSK-0477** (epic **KJC-PCS-0052**). Sprint **KJC-SPR-0011**.