### PR TITLE
docs(rag): six-questions internals deep-dive (KJC-TSK-0485)

### DIFF
--- a/docs/RAG.md
+++ b/docs/RAG.md
@@ -160,23 +160,88 @@ rag:
 
 Skipped runs persist `ragPreload: { skipped: true, reason: 'auto:low-value' }` so `kj resume` and `kj audit` can see why retrieval was skipped.
 
-## Limitations
+## Internals — the six questions
 
-### Single shared DB
+### 1. Chunking
 
-`~/.karajan/rag.db` is **global** across all your projects. Use `--project <slug>` (CLI/MCP) or set `KJ_RAG_DB=/per-project/path.db` to keep corpora separate. Since v2.27.0, the indexer auto-stamps every chunk with the projectDir basename; queries default to that slug.
+Each consumer (plan, markdown, source) has its own chunker, all routed through `src/rag/chunker.js → chunkSource`. The source chunker delegates to a per-language adapter looked up by extension (`src/lang/registry.js → adapterForPath`).
 
-### Cosine-only ranking
+| Language | Strategy | File |
+|---|---|---|
+| JS / TS | `@babel/parser` AST + leading JSDoc + `export <symbol>` fallback | `src/rag/chunker.js` |
+| Python  | tree-sitter `function_definition` / `class_definition` + regex fallback | `src/lang/chunk-python.js` |
+| Rust    | tree-sitter `function_item` / `struct_item` / `enum_item` / `impl_item` + regex fallback | `src/lang/chunk-rust.js` |
+| Go      | tree-sitter `function_declaration` / `method_declaration` / `type_declaration` + regex fallback | `src/lang/chunk-go.js` |
+| Java    | tree-sitter 2-level walker (class/interface/enum/record → method/constructor) + regex fallback | `src/lang/chunk-java.js` |
+| Markdown / plans | Heading-based split | `src/rag/chunker.js` |
 
-Pure semantic similarity is biased: long descriptive prose (often in tests) outranks terse source files for natural-language queries. Mitigated since v2.27.0 by an asymmetric kind-boost (code +0.05 when query doesn't mention test/spec/expect). For exact-symbol queries (`projectSlug`, `runRagContextStage`), BM25 hybrid is on the v2.28.0+ roadmap.
+Common contract: every chunk emits `{ text, metadata: { source, kind, symbol, language } }`. Oversize bodies are passed through `windowText(text, limit=800, overlap=100)` so embeddings stay under the model context. When no top-level symbol is found (e.g. comment-only file), the whole text is windowed with `symbol: null`.
 
-### No live watcher
+The AST path is opt-in per index run — the indexer calls `prepareAdapters()` (`src/rag/indexer.js`) once before walking, which awaits every `adapter.prepare()` (cached after first load via `src/lang/tree-sitter-loader.js`). Grammars are vendored under `vendor/tree-sitter-grammars/*.wasm` so SEA binaries stay self-contained.
 
-Re-run `kj rag index` after editing files. Chokidar watcher with debounced re-index is on the v2.28.0+ roadmap.
+### 2. Embedder
 
-### Source chunker is regex-based
+`createEmbedderFromConfig(config)` (`src/rag/embedder-factory.js`) returns one of six adapters, all implementing `{ embed(text), dim }`:
 
-`chunkSource` splits by `export <symbol>` lines + sliding window. Function bodies past the symbol line may be split mid-statement. AST-aware chunking (tree-sitter or `@babel/parser`) is on the v2.28.0+ roadmap.
+| Provider | Default model | Dim | Notes |
+|---|---|---|---|
+| Ollama (default) | `nomic-embed-text` | 768 | Local, no API key. Auto-pulled by `kj init` |
+| OpenAI | `text-embedding-3-small` | 1536 | `OPENAI_API_KEY` |
+| Voyage AI | `voyage-3-lite` | 512 | `VOYAGE_API_KEY` — code-specialized variants available |
+| Cohere | `embed-multilingual-v3.0` | 1024 | `COHERE_API_KEY` |
+| Mistral | `mistral-embed` | 1024 | `MISTRAL_API_KEY` |
+| ONNX local | `Xenova/all-MiniLM-L6-v2` | 384 | `@xenova/transformers`, no Docker, slowest |
+
+Decisions:
+- **Ollama default** — zero cost, runs in `kj-ollama` Docker container, works offline. The price is ~270 MB model download once and ~2 GB RAM while indexing.
+- **No code-specialized default** — Voyage/Cohere have code-tuned variants but they're paid and the cross-language quality gap on small corpora doesn't justify the cost gate. Users wanting it can flip `rag.embedder.provider`.
+- **No Matryoshka truncation** — sqlite-vec stores the full dim; truncated re-ranking is on backlog for very large corpora where storage matters.
+
+Switching providers requires a re-index (`kj rag index` after editing `rag.embedder.provider/model`) — dimensions and embedding spaces are not interchangeable.
+
+### 3. Search
+
+Two-stage retrieval over `~/.karajan/rag.db` (sqlite + `sqlite-vec` extension):
+
+1. **Vector recall** — exact cosine via `vec_distance_cosine`, over-fetched (`topK × 3`) to leave headroom for re-ranking. Exact (not ANN) is fine up to ~100K chunks; ANN switch is on backlog.
+2. **Hybrid rerank** — when `rag.search.mode = hybrid` (default since v2.28.0), the same query is run against an FTS5 BM25 index and scores are normalised + blended:
+   `final = alpha * cosine + (1 - alpha) * bm25`, with `alpha = 0.7` by default.
+3. **Kind boost** — asymmetric: `code +0.05` when the query has no test/spec/expect tokens; `test +0.05` otherwise. Pulls relevant source up over verbose test prose for natural-language queries.
+4. **Optional cross-encoder rerank** — `rag.search.rerank = true` re-scores top-N with a local cross-encoder (`Xenova/ms-marco-MiniLM-L-6-v2`). Adds ~80 ms / 5 hits but lifts precision@5 on ambiguous queries.
+5. **Metadata filter** — `--where "kind='code' AND language='java'"` is parsed into a parameterised SQL WHERE clause applied before the vector search.
+
+Tweak from the HU Board config panel or `~/.karajan/kj.config.yml`. Both knobs (`alpha`, `mode`, `rerank`) are wired to the pre-loop stage and the CLI.
+
+### 4. Update strategy
+
+Re-indexing is **incremental** and tracked by commit SHA stamped in the `vec_store_meta` table:
+
+| Trigger | How | Since |
+|---|---|---|
+| Manual | `kj rag index [--with-sources]` | v2.22.0 |
+| Live watcher | `kj watch` — chokidar debounced re-index per changed file | v2.28.0 |
+| Post-merge git hook | `kj rag index --since <last-indexed-sha>` after `git merge`/`git pull` | v2.31.0 |
+| Pre-run drift check | Compares `HEAD` to last indexed SHA before every `kj run`; emits a hint if drift > N files | v2.31.0 |
+
+`--since <sha>` walks `git diff --name-only <sha>...HEAD` and re-indexes only changed paths, calling `deleteChunksForSource` first to avoid duplicates. Idempotent.
+
+### 5. What gets embedded
+
+Only the `text` field of each chunk is embedded. Everything else (`source`, `kind`, `symbol`, `language`, `commit`, `project`) lives in queryable columns and is exposed to the `--where` filter. No PII heuristics — the indexer trusts the project tree; secrets that leak into the corpus leak into the embeddings. Run `kj audit` to flag obvious secret files before indexing if you don't trust the tree.
+
+Project isolation is enforced by stamping each row with the projectDir basename. Queries default to the cwd's slug; `--project all` opts out, `--project <slug>` targets another.
+
+### 6. Validation
+
+Two tiers:
+
+- **Pipeline tests** — `tests/rag/*.test.js` covers the chunkers, embedder factory, retriever ranking, hybrid scoring, watcher and CLI. Pre-merge gate ensures green CI before any change to `src/rag/` lands.
+- **Retrieval quality** — `kj rag eval` (KJC-TSK-0483, in progress) runs a frozen set of golden queries against the current index and reports `recall@k` and MRR vs. a stored baseline. Used to detect regressions when changing chunkers, embedders or alpha. The retrieval-quality dashboard in the HU Board surfaces the same metric live per query.
+
+Known gaps:
+
+- **Content-hash dedup** is not on by default — KJC-TSK-0484. Re-indexing identical bodies wastes embeddings; a SHA-256 column + skip-on-match is on backlog.
+- **Near-duplicate clustering** (cosine > 0.97 between chunks) is exploratory under the same card.
 
 ## Troubleshooting
 

--- a/docs/es/RAG.md
+++ b/docs/es/RAG.md
@@ -160,23 +160,88 @@ rag:
 
 Runs skipeados persisten `ragPreload: { skipped: true, reason: 'auto:low-value' }` para que `kj resume` y `kj audit` puedan ver por qué se saltó retrieval.
 
-## Limitaciones
+## Internals — las seis preguntas
 
-### DB compartida única
+### 1. Chunking
 
-`~/.karajan/rag.db` es **global** entre todos los proyectos. Usa `--project <slug>` (CLI/MCP) o define `KJ_RAG_DB=/per-proyecto/path.db` para mantener los corpus separados. Desde v2.27.0, el indexer estampa cada chunk con el basename del projectDir; las queries default a ese slug.
+Cada consumidor (plan, markdown, source) tiene su propio chunker, todos enrutados a través de `src/rag/chunker.js → chunkSource`. El source chunker delega a un adapter por lenguaje consultado por extensión (`src/lang/registry.js → adapterForPath`).
 
-### Ranking solo cosine
+| Lenguaje | Estrategia | Fichero |
+|---|---|---|
+| JS / TS | AST con `@babel/parser` + JSDoc líder + fallback `export <symbol>` | `src/rag/chunker.js` |
+| Python  | tree-sitter `function_definition` / `class_definition` + fallback regex | `src/lang/chunk-python.js` |
+| Rust    | tree-sitter `function_item` / `struct_item` / `enum_item` / `impl_item` + fallback regex | `src/lang/chunk-rust.js` |
+| Go      | tree-sitter `function_declaration` / `method_declaration` / `type_declaration` + fallback regex | `src/lang/chunk-go.js` |
+| Java    | tree-sitter walker 2 niveles (class/interface/enum/record → method/constructor) + fallback regex | `src/lang/chunk-java.js` |
+| Markdown / planes | Split por headings | `src/rag/chunker.js` |
 
-Similitud semántica pura tiene sesgo: prosa descriptiva larga (frecuente en tests) rankea encima de source files concisos para queries en lenguaje natural. Mitigado desde v2.27.0 con kind-boost asimétrico (code +0.05 cuando query no menciona test/spec/expect). Para queries exact-symbol (`projectSlug`, `runRagContextStage`), BM25 híbrido está en el roadmap de v2.28.0+.
+Contrato común: cada chunk emite `{ text, metadata: { source, kind, symbol, language } }`. Cuerpos grandes pasan por `windowText(text, limit=800, overlap=100)` para no salirse del contexto del modelo. Si no hay símbolo top-level (fichero solo con comentarios), el texto entero se ventana con `symbol: null`.
 
-### Sin watcher en vivo
+El camino AST es opt-in por run — el indexer llama a `prepareAdapters()` (`src/rag/indexer.js`) una vez antes del walk, que await-ea cada `adapter.prepare()` (cacheado tras la primera carga vía `src/lang/tree-sitter-loader.js`). Las gramáticas viven en `vendor/tree-sitter-grammars/*.wasm` para que los binarios SEA sigan siendo self-contained.
 
-Re-correr `kj rag index` después de editar archivos. Chokidar watcher con re-index debounced está en el roadmap de v2.28.0+.
+### 2. Embedder
 
-### Source chunker basado en regex
+`createEmbedderFromConfig(config)` (`src/rag/embedder-factory.js`) devuelve uno de seis adapters, todos con `{ embed(text), dim }`:
 
-`chunkSource` separa por líneas `export <symbol>` + sliding window. Cuerpos de función pasada la línea del símbolo pueden separarse mid-statement. Chunking AST-aware (tree-sitter o `@babel/parser`) está en el roadmap de v2.28.0+.
+| Provider | Modelo por defecto | Dim | Notas |
+|---|---|---|---|
+| Ollama (default) | `nomic-embed-text` | 768 | Local, sin API key. Auto-pull en `kj init` |
+| OpenAI | `text-embedding-3-small` | 1536 | `OPENAI_API_KEY` |
+| Voyage AI | `voyage-3-lite` | 512 | `VOYAGE_API_KEY` — variantes code-specialized |
+| Cohere | `embed-multilingual-v3.0` | 1024 | `COHERE_API_KEY` |
+| Mistral | `mistral-embed` | 1024 | `MISTRAL_API_KEY` |
+| ONNX local | `Xenova/all-MiniLM-L6-v2` | 384 | `@xenova/transformers`, sin Docker, más lento |
+
+Decisiones:
+- **Ollama por defecto** — coste cero, corre en el container Docker `kj-ollama`, funciona offline. El precio: ~270 MB de descarga una vez y ~2 GB RAM mientras indexa.
+- **Sin code-specialized por defecto** — Voyage/Cohere tienen variantes ajustadas a código pero son de pago y la brecha de calidad cross-language en corpus pequeños no justifica la barrera. Quien lo quiera, cambia `rag.embedder.provider`.
+- **Sin truncado Matryoshka** — sqlite-vec guarda el dim completo; re-ranking con truncado está en backlog para corpus muy grandes donde el storage importa.
+
+Cambiar de provider exige re-indexar (`kj rag index` tras editar `rag.embedder.provider/model`) — las dimensiones y los espacios de embedding no son intercambiables.
+
+### 3. Search
+
+Retrieval en dos etapas sobre `~/.karajan/rag.db` (sqlite + extensión `sqlite-vec`):
+
+1. **Vector recall** — cosine exacto vía `vec_distance_cosine`, over-fetch (`topK × 3`) para dejar margen al rerank. Exacto (no ANN) va bien hasta ~100K chunks; el switch a ANN está en backlog.
+2. **Rerank híbrido** — cuando `rag.search.mode = hybrid` (default desde v2.28.0), la misma query corre contra un índice FTS5 BM25 y los scores se normalizan + mezclan:
+   `final = alpha * cosine + (1 - alpha) * bm25`, con `alpha = 0.7` por defecto.
+3. **Boost por kind** — asimétrico: `code +0.05` cuando la query no tiene tokens test/spec/expect; `test +0.05` si los tiene. Empuja source files relevantes encima de prosa verbosa de tests para queries en lenguaje natural.
+4. **Rerank cross-encoder opcional** — `rag.search.rerank = true` re-puntúa el top-N con un cross-encoder local (`Xenova/ms-marco-MiniLM-L-6-v2`). Añade ~80 ms / 5 hits pero sube la precisión@5 en queries ambiguas.
+5. **Filtro de metadata** — `--where "kind='code' AND language='java'"` se parsea a un WHERE SQL parametrizado aplicado antes del vector search.
+
+Ajustable desde el panel de config del HU Board o `~/.karajan/kj.config.yml`. Los tres knobs (`alpha`, `mode`, `rerank`) están cableados al pre-loop stage y al CLI.
+
+### 4. Estrategia de update
+
+La re-indexación es **incremental** y se rastrea por SHA de commit guardado en la tabla `vec_store_meta`:
+
+| Trigger | Cómo | Desde |
+|---|---|---|
+| Manual | `kj rag index [--with-sources]` | v2.22.0 |
+| Watcher en vivo | `kj watch` — chokidar con re-index debounced por fichero | v2.28.0 |
+| Hook post-merge | `kj rag index --since <last-indexed-sha>` tras `git merge`/`git pull` | v2.31.0 |
+| Pre-run drift check | Compara `HEAD` con el último SHA indexado antes de cada `kj run`; emite hint si el drift supera N ficheros | v2.31.0 |
+
+`--since <sha>` recorre `git diff --name-only <sha>...HEAD` y reindexa solo las rutas cambiadas, llamando primero a `deleteChunksForSource` para evitar duplicados. Idempotente.
+
+### 5. Qué se embebe
+
+Solo se embebe el campo `text` de cada chunk. Todo lo demás (`source`, `kind`, `symbol`, `language`, `commit`, `project`) vive en columnas consultables y queda expuesto al filtro `--where`. Sin heurísticas de PII — el indexer confía en el árbol del proyecto; lo que se cuele al corpus se cuela en los embeddings. Si no confías en el árbol, corre `kj audit` para marcar los ficheros sospechosos antes de indexar.
+
+El aislamiento por proyecto se hace estampando cada fila con el basename del projectDir. Las queries default al slug del cwd; `--project all` se sale, `--project <slug>` apunta a otro.
+
+### 6. Validación
+
+Dos niveles:
+
+- **Tests del pipeline** — `tests/rag/*.test.js` cubre los chunkers, embedder factory, retriever ranking, scoring híbrido, watcher y CLI. Gate pre-merge garantiza CI verde antes de que ningún cambio sobre `src/rag/` aterrice.
+- **Calidad de retrieval** — `kj rag eval` (KJC-TSK-0483, en curso) corre un conjunto frozen de golden queries contra el índice actual y reporta `recall@k` y MRR vs. baseline guardada. Sirve para detectar regresiones al cambiar chunkers, embedders o alpha. El dashboard de retrieval-quality del HU Board surfacea la misma métrica viva por query.
+
+Huecos conocidos:
+
+- **Content-hash dedup** no va activo por defecto — KJC-TSK-0484. Re-indexar cuerpos idénticos malgasta embeddings; columna SHA-256 + skip-on-match en backlog.
+- **Clustering de near-duplicates** (cosine > 0.97 entre chunks) es exploratorio dentro de la misma card.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Replaces the outdated **Limitations** section in `docs/RAG.md` and `docs/es/RAG.md` with a new **Internals — the six questions** deep-dive that documents how the RAG stack actually works after the recent multi-language and hybrid-search work.

### Sections added
1. **Chunking** — per-language adapter table (JS/TS via `@babel/parser`, Python/Rust/Go/Java via tree-sitter, Markdown by headings), common chunk contract, `prepareAdapters()` lifecycle, vendored `.wasm` grammars.
2. **Embedder** — six-provider matrix (Ollama default, OpenAI, Voyage AI, Cohere, Mistral, ONNX local) with default models, dimensions, decisions and re-index cost.
3. **Search** — two-stage retrieval: exact cosine over-fetch ($topK \times 3$), hybrid BM25 blend ($alpha = 0.7$), asymmetric kind boost, optional cross-encoder rerank, `--where` SQL filter.
4. **Update strategy** — manual, chokidar watcher, post-merge git hook, pre-run drift check tracked in `vec_store_meta`.
5. **What gets embedded** — only the `text` field; everything else queryable in columns; project isolation by `projectDir` basename stamping.
6. **Validation** — pipeline tests + `kj rag eval` (KJC-TSK-0483, in progress) with recall@k / MRR vs a frozen baseline. Linked known gaps for KJC-TSK-0484 (content-hash dedup, near-duplicate clustering).

Both English and Spanish docs are kept in sync with full diacritics on the ES side.

### Why this matters
- Closes the documentation pillar of epic **KJC-PCS-0053** (RAG Quality & Observability).
- Makes the multi-language story (JS / Python / Rust / Go / Java) discoverable from a single page after PR-B.2.5 (KJC-TSK-0486).
- Gives consumers a clear answer to "what knobs are there?" without digging through `src/rag/*`.

### LOC budget
Both files are under `docs/**/*.md`, which is excluded from the 200 LOC shrink-budget gate.

## Test plan
- [x] `npm test` — no source changes, no test changes
- [x] LOC budget excluded (docs-only)
- [x] Prettier `--check` passes
- [x] Conventional Commit header ≤100 chars, lowercase subject
- [x] Spanish version uses full diacritics ("indización", "métrica", "validación", "huecos conocidos", "cross-encoder")

Card: KJC-TSK-0485
Epic: KJC-PCS-0053 (RAG Quality & Observability)