### PR TITLE
feat(rag): watcher matcher derived from language registry (KJC-TSK-0482)

### DIFF
--- a/src/rag/watcher.js
+++ b/src/rag/watcher.js
@@ -1,23 +1,25 @@
 // KJC-TSK-0441 (RAG v2.28.0 PR1) — chokidar watcher. Live re-index of plans
 // + onboarding + (opt) sources, debounced. PID file arbitrates a single daemon.
+// KJC-TSK-0482 — source matcher derivado del registry (multi-lang: JS/Py/Rust/Go/Java).
 import { writeFileSync, readFileSync, existsSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import { extname, join } from "node:path";
 import chokidar from "chokidar";
 import { openVecStore, deleteChunksBySource, projectSlug } from "./vec-store.js";
 import { makeEmbedder } from "./embedders/factory.js";
 import { indexFile } from "./indexer.js";
 import { getKarajanHome } from "../utils/paths.js";
+import { getAllCodeExtensions } from "../lang/registry.js";
 
 const PIDFILE = () => join(getKarajanHome(), "watcher.pid");
 const DEFAULT_DEBOUNCE_MS = 1000;
 const SKIP_SEGMENTS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".next", ".kj", "_diet"]);
-const SOURCE_RE = /\.(js|mjs|cjs|ts|tsx|jsx)$/;
+const SOURCE_EXTS = new Set(getAllCodeExtensions().map((e) => e.toLowerCase()));
 
-function isWatchable(path) {
+export function isWatchable(path) {
   if (path.includes("/.karajan/onboarding/")) return /\.md$/.test(path);
   if (path.includes("/.karajan/plans/")) return /\.json$/.test(path);
   if (path.split("/").some((seg) => SKIP_SEGMENTS.has(seg))) return false;
-  return SOURCE_RE.test(path);
+  return SOURCE_EXTS.has(extname(path).toLowerCase());
 }
 
 export function startWatcher({ projectDir, config, logger = console, debounceMs = DEFAULT_DEBOUNCE_MS, withSources = false } = {}) {

--- a/tests/rag/watcher.test.js
+++ b/tests/rag/watcher.test.js
@@ -1,9 +1,10 @@
 // KJC-TSK-0441 — watcher PID lifecycle helpers.
+// KJC-TSK-0482 — multi-lang source matcher (Python/Rust/Go/Java).
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { writePidFile, readPidFile, clearPidFile, isPidAlive } from "../../src/rag/watcher.js";
+import { writePidFile, readPidFile, clearPidFile, isPidAlive, isWatchable } from "../../src/rag/watcher.js";
 
 describe("rag/watcher — PID file (KJC-TSK-0441)", () => {
   let prev;
@@ -30,5 +31,33 @@ describe("rag/watcher — PID file (KJC-TSK-0441)", () => {
 
   it("clearPidFile is a no-op when missing", () => {
     expect(() => clearPidFile()).not.toThrow();
+  });
+});
+
+describe("rag/watcher — multi-lang source matcher (KJC-TSK-0482)", () => {
+  it("accepts every code extension registered in the language registry (JS/Py/Rust/Go/Java)", () => {
+    expect(isWatchable("/repo/src/main.js")).toBe(true);
+    expect(isWatchable("/repo/src/main.ts")).toBe(true);
+    expect(isWatchable("/repo/src/app.py")).toBe(true);
+    expect(isWatchable("/repo/src/lib.rs")).toBe(true);
+    expect(isWatchable("/repo/cmd/main.go")).toBe(true);
+    expect(isWatchable("/repo/src/Alpha.java")).toBe(true);
+  });
+
+  it("rejects non-code extensions and SKIP_SEGMENTS regardless of extension", () => {
+    expect(isWatchable("/repo/README.md")).toBe(false);
+    expect(isWatchable("/repo/data.json")).toBe(false);
+    expect(isWatchable("/repo/node_modules/foo/index.js")).toBe(false);
+    expect(isWatchable("/repo/.git/HEAD")).toBe(false);
+    expect(isWatchable("/repo/dist/bundle.js")).toBe(false);
+    expect(isWatchable("/repo/coverage/lcov.info")).toBe(false);
+    expect(isWatchable("/repo/.karajan/scratch/foo.py")).toBe(false);
+  });
+
+  it("keeps the karajan onboarding/plans special-cases (md / json only inside their dirs)", () => {
+    expect(isWatchable("/repo/.karajan/onboarding/brief.md")).toBe(true);
+    expect(isWatchable("/repo/.karajan/onboarding/brief.txt")).toBe(false);
+    expect(isWatchable("/repo/.karajan/plans/p1.json")).toBe(true);
+    expect(isWatchable("/repo/.karajan/plans/p1.md")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Wire the chokidar live re-index watcher to the same language registry the indexer/audit/onboarder already use, so it picks up `.py / .rs / .go / .java` edits in addition to `.js / .ts`.

Before this PR, `src/rag/watcher.js` filtered new/changed files with a hardcoded `SOURCE_RE = /\.(js|mjs|cjs|ts|tsx|jsx)$/`. After **KJC-PCS-0052** (epic "Language-agnostic Karajan") the language registry exposes adapters for JS, Python, Rust, Go and Java — but the watcher was still on the old regex, so Python/Rust/Go/Java edits silently went un-reindexed and the RAG served stale code to agents.

### Changes
- **`src/rag/watcher.js`** — replace `SOURCE_RE` with a `SOURCE_EXTS` Set built from `getAllCodeExtensions()` (single source of truth across watcher / indexer / audit / onboarder). Export `isWatchable` so the matcher is directly testable.
- **`tests/rag/watcher.test.js`** — 3 new cases:
  - Accepts every registered code extension (`.js .ts .py .rs .go .java`).
  - Rejects non-code extensions and every `SKIP_SEGMENTS` (`node_modules`, `.git`, `dist`, `build`, `coverage`, `.karajan`, `.next`, `.kj`, `_diet`).
  - Preserves Karajan-home special-cases (`onboarding/*.md`, `plans/*.json`).

### What stays the same
- Karajan-home special-cases (`onboarding/*.md`, `plans/*.json`).
- `SKIP_SEGMENTS` list (unchanged — separate concern, tracked elsewhere if needed).
- The adapter `prepare()` lifecycle — `indexFile` keeps driving `prepareAdapters()`, so the watcher needs no extra wiring.

### LOC delta
| File | + | - | net |
|---|---|---|---|
| `src/rag/watcher.js` | 6 | 4 | +2 |
| `tests/rag/watcher.test.js` | 30 | 1 | +29 |
| **Total** | **36** | **5** | **+31** |

Well under the 200 LOC shrink-budget.

## Test plan
- [x] `npx vitest run tests/rag/watcher.test.js` — 6/6 green (3 pre-existing PID + 3 new matcher tests)
- [x] Linting clean (lint-staged passed pre-commit)
- [x] Manual: confirm `getAllCodeExtensions()` returns `.js .mjs .cjs .ts .tsx .jsx .py .rs .go .java`

Card: KJC-TSK-0482
Epic: KJC-PCS-0053 (RAG Quality & Observability)