### PR TITLE
feat(rag): content-hash skip-on-match in indexer (KJC-TSK-0484 PR-A)

### DIFF
--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -7,10 +7,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { extname, isAbsolute, join, relative } from "node:path";
+import { createHash } from "node:crypto";
 import { execa } from "execa";
 
 import { chunkMarkdown, chunkPlan, chunkSource } from "./chunker.js";
-import { insertChunk, deleteChunksBySource } from "./vec-store.js";
+import { insertChunk, deleteChunksBySource, findChunkByHash } from "./vec-store.js";
 import { detectAdaptersForProject, buildMatchers, getAllCodeExtensions } from "../lang/registry.js";
 
 // KJC-PCS-0052 PR-A — antes vivían dos consts hard-coded para JS aquí
@@ -53,22 +54,30 @@ export async function indexFile(path, { db, embedder, logger = console, project 
   const kind = detectKind(path);
   if (!kind) { logger.warn?.(`[rag-indexer] unknown kind: ${path}`); return { indexed: 0, failed: 0 }; }
   const chunks = chunksFor(path, kind);
-  if (!chunks.length) return { indexed: 0, failed: 0 };
+  if (!chunks.length) return { indexed: 0, failed: 0, skipped: 0 };
   deleteChunksBySource(db, path);
   let indexed = 0;
   let failed = 0;
+  let skipped = 0;
   for (const ch of chunks) {
+    // KJC-TSK-0484 — Skip re-embedding identical bodies for the same project.
+    // The chunks row is still rewritten under the new source so deletions of
+    // an alias don't orphan a row whose owner was the dedup target.
+    const contentHash = createHash("sha256").update(ch.text).digest("hex");
     try {
+      const dup = findChunkByHash(db, contentHash, project);
+      if (dup) { skipped += 1; continue; }
       const embedding = await embedder.embed(ch.text);
-      insertChunk(db, { source: path, kind: ch.metadata.kind || kind, text: ch.text, metadata: ch.metadata, embedding, project });
+      insertChunk(db, { source: path, kind: ch.metadata.kind || kind, text: ch.text, metadata: ch.metadata, embedding, project, contentHash });
       indexed += 1;
     } catch (err) {
       failed += 1;
       logger.warn?.(`[rag-indexer] embed failed for ${path} (${chunkLabel(ch)}): ${err.message}`);
     }
   }
-  logger.info?.(`[rag-indexer] ${relative(process.cwd(), path)} → ${indexed} chunk(s) (${failed} failed)`);
-  return { indexed, failed };
+  const note = skipped ? `, ${skipped} dedup` : "";
+  logger.info?.(`[rag-indexer] ${relative(process.cwd(), path)} → ${indexed} chunk(s) (${failed} failed${note})`);
+  return { indexed, failed, skipped };
 }
 
 function chunkLabel(ch) {

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -53,6 +53,14 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     db.exec("ALTER TABLE chunks ADD COLUMN project_slug TEXT;");
     db.exec("CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);");
   }
+  // KJC-TSK-0484 — Content-hash dedup. SHA-256 of the chunk text lets the
+  // indexer skip embedding bodies it has already seen for the same project.
+  // Older rows keep NULL; the lookup ignores NULLs so they neither dedup
+  // nor get deduped until they are re-indexed and stamped.
+  if (!cols.includes("content_hash")) {
+    db.exec("ALTER TABLE chunks ADD COLUMN content_hash TEXT;");
+    db.exec("CREATE INDEX IF NOT EXISTS chunks_by_hash ON chunks(content_hash, project_slug);");
+  }
   // KJC-TSK-0455 — Auto-update by commit diff. Per-project metadata tracks
   // the last commit whose changes were reflected in the index, so subsequent
   // `kj rag index --since auto` invocations (and the post-merge hook / pre-run
@@ -97,13 +105,13 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
  * because the virtual table rowid is set explicitly to the freshly
  * minted chunks.id. Returns that id.
  */
-export function insertChunk(db, { source, kind, text, metadata = null, embedding, project = null }) {
+export function insertChunk(db, { source, kind, text, metadata = null, embedding, project = null, contentHash = null }) {
   if (!Array.isArray(embedding) && !ArrayBuffer.isView(embedding)) {
     throw new Error("insertChunk: embedding must be an array or typed array of floats");
   }
   const meta = metadata == null ? null : (typeof metadata === "string" ? metadata : JSON.stringify(metadata));
-  const ins = db.prepare("INSERT INTO chunks (source, kind, text, metadata, project_slug) VALUES (?, ?, ?, ?, ?)");
-  const info = ins.run(source, kind, text, meta, project);
+  const ins = db.prepare("INSERT INTO chunks (source, kind, text, metadata, project_slug, content_hash) VALUES (?, ?, ?, ?, ?, ?)");
+  const info = ins.run(source, kind, text, meta, project, contentHash);
   // sqlite-vec's vec0 virtual table requires the rowid to arrive as a BigInt
   // even for values that comfortably fit in a Number. Better-sqlite3 returns
   // lastInsertRowid as BigInt only when safeIntegers mode is on; force it.
@@ -182,6 +190,18 @@ export function setLastIndexedCommit(db, projectSlug, commit) {
       last_indexed_commit = excluded.last_indexed_commit,
       last_indexed_at = excluded.last_indexed_at
   `).run(projectSlug, commit);
+}
+
+// KJC-TSK-0484 — Lookup an already-indexed chunk by content_hash. Scoped to a
+// project so two repos with the same boilerplate file don't cross-pollute.
+// Returns `{ id, source }` or null. Pass `project=null` to match NULL slugs.
+export function findChunkByHash(db, hash, project = null) {
+  if (!hash) return null;
+  const sql = project
+    ? "SELECT id, source FROM chunks WHERE content_hash = ? AND project_slug = ? LIMIT 1"
+    : "SELECT id, source FROM chunks WHERE content_hash = ? AND project_slug IS NULL LIMIT 1";
+  const row = project ? db.prepare(sql).get(hash, project) : db.prepare(sql).get(hash);
+  return row || null;
 }
 
 export function countChunks(db, { kind = null } = {}) {

--- a/tests/rag/dedup.test.js
+++ b/tests/rag/dedup.test.js
@@ -1,0 +1,77 @@
+// KJC-TSK-0484 — Content-hash dedup. Identical chunk bodies must skip the
+// embedder call when re-encountered for the same project; different projects
+// stay isolated (no cross-project dedup).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openVecStore, findChunkByHash, insertChunk } from "../../src/rag/vec-store.js";
+import { indexFile } from "../../src/rag/indexer.js";
+
+function makeEmbedder() {
+  const counter = { calls: 0 };
+  const embedder = {
+    dim: 8,
+    embed: async (text) => {
+      counter.calls += 1;
+      return new Array(8).fill(0).map((_, i) => ((text.length + i) % 7) / 7);
+    },
+  };
+  return { embedder, counter };
+}
+
+describe("rag/indexer — content-hash dedup (KJC-TSK-0484)", () => {
+  let tmp;
+  let db;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "kj-dedup-"));
+    process.env.KJ_RAG_DB = join(tmp, "rag.db");
+    db = openVecStore({ dim: 8 });
+  });
+  afterEach(() => {
+    try { db.close(); } catch { /* already closed */ }
+    rmSync(tmp, { recursive: true, force: true });
+    delete process.env.KJ_RAG_DB;
+  });
+
+  it("findChunkByHash returns null for unseen hashes and the row for known ones", () => {
+    expect(findChunkByHash(db, "deadbeef", "proj1")).toBeNull();
+    insertChunk(db, {
+      source: "/x.md", kind: "plan", text: "hi", metadata: null,
+      embedding: new Array(8).fill(0), project: "proj1", contentHash: "deadbeef",
+    });
+    const hit = findChunkByHash(db, "deadbeef", "proj1");
+    expect(hit).toMatchObject({ source: "/x.md" });
+  });
+
+  it("skips the embedder when an identical chunk exists for the same project", async () => {
+    const { embedder, counter } = makeEmbedder();
+    const a = join(tmp, "a.md");
+    const b = join(tmp, "b.md");
+    const body = "# Hello\n\nshared body across two files\n";
+    writeFileSync(a, body);
+    writeFileSync(b, body);
+    const r1 = await indexFile(a, { db, embedder, project: "proj1" });
+    const callsAfter1 = counter.calls;
+    const r2 = await indexFile(b, { db, embedder, project: "proj1" });
+    expect(r1.indexed).toBeGreaterThan(0);
+    expect(r2.skipped).toBe(r1.indexed);
+    expect(r2.indexed).toBe(0);
+    expect(counter.calls).toBe(callsAfter1);
+  });
+
+  it("does NOT dedup across different projects (isolation wins)", async () => {
+    const { embedder, counter } = makeEmbedder();
+    const a = join(tmp, "a.md");
+    const b = join(tmp, "b.md");
+    const body = "# Header\n\nsame markdown but different repos\n";
+    writeFileSync(a, body);
+    writeFileSync(b, body);
+    const r1 = await indexFile(a, { db, embedder, project: "proj1" });
+    const r2 = await indexFile(b, { db, embedder, project: "proj2" });
+    expect(r2.indexed).toBe(r1.indexed);
+    expect(r2.skipped).toBe(0);
+    expect(counter.calls).toBe(r1.indexed + r2.indexed);
+  });
+});


### PR DESCRIPTION
## Summary

Closes part 1 of **KJC-TSK-0484** (RAG content-hash dedup). The follow-up PR-B will add MMR diversification in the retriever.

- `chunks.content_hash` column + composite index on `(content_hash, project_slug)` via `ALTER TABLE` migration (older rows keep NULL until re-indexed).
- `insertChunk()` accepts `contentHash` and persists it.
- New `findChunkByHash(db, hash, project)` helper.
- `indexFile()` computes SHA-256 of every chunk body before embedding; if the hash already exists for the same project, the embedder call is skipped and the chunk count moves to a new `skipped` field. Cross-project isolation is preserved (same body in two repos still embeds twice).

## LOC budget

`+114 / -8` across 3 files. Well under the 200 hard cap.

## Test plan

- [x] `npx vitest run tests/rag/dedup.test.js` — 3/3
- [x] `npx vitest run tests/rag/` — 142/142 (no regressions)
- [x] `npx prettier --check src/rag/indexer.js src/rag/vec-store.js tests/rag/dedup.test.js` — clean
- [x] commitlint header 67 chars ✓