### PR TITLE
feat(rag): mmr diversification in retriever (KJC-TSK-0484 PR-B)

### DIFF
--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -1,5 +1,5 @@
 // KJC-PCS-0049 Step 5 — Retriever for the RAG pipeline.
-import { searchSimilar, searchBM25 } from "./vec-store.js";
+import { searchSimilar, searchBM25, getEmbeddingsByIds } from "./vec-store.js";
 import { parseWhere, buildWhereSql } from "./where-parser.js";
 import { rerank } from "./rerank.js";
 
@@ -41,7 +41,46 @@ function fuseHits(semantic, keyword, alpha, mode) {
   return list;
 }
 
-export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6, where = null, rerankOpts = null } = {}) {
+// KJC-TSK-0484 PR-B — Maximal Marginal Relevance. Given an ordered list of
+// candidates (best-first by `score`), pick `topK` that balance relevance
+// against intra-result diversity. `lambda=1` collapses to plain relevance;
+// `lambda=0` maximises diversity. Cosine sim between candidate embeddings
+// drives the redundancy penalty. Candidates without an embedding are kept
+// at the end (no penalty applies).
+function cosineSim(a, b) {
+  if (!a || !b || a.length !== b.length) return 0;
+  let dot = 0; let na = 0; let nb = 0;
+  for (let i = 0; i < a.length; i += 1) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+export function mmrRerank(candidates, embeddings, { topK, lambda = 0.7 }) {
+  const remaining = candidates.slice();
+  const picked = [];
+  const relevance = (c) => 1 / (1 + Math.max(0, c.score ?? c.distance ?? 0));
+  while (picked.length < topK && remaining.length > 0) {
+    let bestIdx = 0; let bestVal = -Infinity;
+    for (let i = 0; i < remaining.length; i += 1) {
+      const c = remaining[i];
+      const rel = relevance(c);
+      let maxSim = 0;
+      const ce = embeddings.get(c.id);
+      if (ce && picked.length > 0) {
+        for (const p of picked) {
+          const pe = embeddings.get(p.id);
+          if (pe) maxSim = Math.max(maxSim, cosineSim(ce, pe));
+        }
+      }
+      const score = lambda * rel - (1 - lambda) * maxSim;
+      if (score > bestVal) { bestVal = score; bestIdx = i; }
+    }
+    picked.push(remaining.splice(bestIdx, 1)[0]);
+  }
+  return picked;
+}
+
+export async function query(db, embedder, text, { topK = 5, scope = "all", kindBoost = DEFAULT_KIND_BOOST, project = null, mode = "hybrid", alpha = 0.6, where = null, rerankOpts = null, diversify = false, mmrLambda = 0.7 } = {}) {
   if (!text || typeof text !== "string") throw new Error("query: text must be a non-empty string");
   const fetchK = Math.min(50, topK * 2);
   const scopeKind = scope === "plans" ? "plan" : scope === "code" ? "code" : scope === "onboarding" ? "onboarding" : null;
@@ -59,11 +98,24 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   const raw = fuseHits(semanticHits, keywordHits, alpha, mode);
   if (raw.length === 0) return [];
   const boostSources = shouldBoostSources(text);
-  const reranked = raw.map((r) => {
+  const scored = raw.map((r) => {
     const kindB = kindBoost[r.kind] || 0;
     const sourceB = (boostSources && r.kind === "code" && !isTestPath(r.source)) ? SOURCE_BOOST_NON_TEST : 0;
     return { ...r, score: r.distance - kindB - sourceB };
-  }).sort((a, b) => a.score - b.score).slice(0, topK);
+  }).sort((a, b) => a.score - b.score);
+  // KJC-TSK-0484 PR-B — MMR diversification over topK*2 candidates. Fetches
+  // embeddings only when requested; cosine between candidate vectors drives
+  // the redundancy penalty so near-duplicates that survived dedup (e.g. a
+  // boilerplate chunk repeated under slightly different wording) get pushed
+  // down. Skipped entirely when `diversify=false` (default).
+  let reranked;
+  if (diversify) {
+    const pool = scored.slice(0, Math.min(scored.length, topK * 2));
+    const embeddings = getEmbeddingsByIds(db, pool.map((c) => c.id));
+    reranked = mmrRerank(pool, embeddings, { topK, lambda: mmrLambda });
+  } else {
+    reranked = scored.slice(0, topK);
+  }
   // KJC-TSK-0449 — optional cross-encoder rerank. When `rerankOpts` is set,
   // we re-score the topK survivors with a (query, passage) cross-encoder;
   // the kind+source boost has already been applied, so the rerank acts as
@@ -72,4 +124,4 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   return reranked;
 }
 
-export { shouldBoostSources, isTestPath, fuseHits };
+export { shouldBoostSources, isTestPath, fuseHits, cosineSim };

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -192,6 +192,21 @@ export function setLastIndexedCommit(db, projectSlug, commit) {
   `).run(projectSlug, commit);
 }
 
+// KJC-TSK-0484 PR-B — Bulk fetch embeddings for an explicit set of chunk ids.
+// Returns Map<id, Float32Array>. Used by MMR diversification in retriever.js.
+export function getEmbeddingsByIds(db, ids) {
+  const out = new Map();
+  if (!ids?.length) return out;
+  const placeholders = ids.map(() => "?").join(",");
+  const rows = db.prepare(`SELECT rowid AS id, embedding FROM vec_chunks WHERE rowid IN (${placeholders})`).all(...ids);
+  for (const row of rows) {
+    if (!row.embedding) continue;
+    const buf = Buffer.isBuffer(row.embedding) ? row.embedding : Buffer.from(row.embedding);
+    out.set(Number(row.id), new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4));
+  }
+  return out;
+}
+
 // KJC-TSK-0484 — Lookup an already-indexed chunk by content_hash. Scoped to a
 // project so two repos with the same boilerplate file don't cross-pollute.
 // Returns `{ id, source }` or null. Pass `project=null` to match NULL slugs.

--- a/tests/rag/diversify.test.js
+++ b/tests/rag/diversify.test.js
@@ -1,0 +1,64 @@
+// KJC-TSK-0484 PR-B — MMR diversification. The retriever has to balance
+// pure relevance against intra-result variety so near-duplicates that
+// slipped past the content-hash dedup don't all crowd the topK.
+import { describe, it, expect } from "vitest";
+
+import { mmrRerank, cosineSim } from "../../src/rag/retriever.js";
+
+function vec(...nums) { return new Float32Array(nums); }
+
+describe("cosineSim — KJC-TSK-0484 PR-B", () => {
+  it("returns 1 for identical vectors and ~0 for orthogonal ones", () => {
+    expect(cosineSim(vec(1, 0, 0), vec(1, 0, 0))).toBeCloseTo(1, 5);
+    expect(cosineSim(vec(1, 0, 0), vec(0, 1, 0))).toBeCloseTo(0, 5);
+  });
+  it("safely returns 0 on zero-length or length-mismatch inputs", () => {
+    expect(cosineSim(vec(0, 0, 0), vec(0, 0, 0))).toBe(0);
+    expect(cosineSim(vec(1, 2), vec(1, 2, 3))).toBe(0);
+    expect(cosineSim(null, vec(1, 2))).toBe(0);
+  });
+});
+
+describe("mmrRerank — KJC-TSK-0484 PR-B", () => {
+  it("with lambda=1 collapses to plain relevance order (first topK)", () => {
+    const candidates = [
+      { id: 1, score: 0.1 },
+      { id: 2, score: 0.2 },
+      { id: 3, score: 0.3 },
+      { id: 4, score: 0.4 },
+    ];
+    const e = new Map([
+      [1, vec(1, 0, 0)], [2, vec(1, 0, 0)], [3, vec(0, 1, 0)], [4, vec(0, 0, 1)],
+    ]);
+    const picked = mmrRerank(candidates, e, { topK: 3, lambda: 1 });
+    expect(picked.map((c) => c.id)).toEqual([1, 2, 3]);
+  });
+
+  it("with lambda=0 maximises diversity, dropping near-duplicates of the leader", () => {
+    const candidates = [
+      { id: 1, score: 0.1 }, // anchor
+      { id: 2, score: 0.11 }, // near-dup of 1
+      { id: 3, score: 0.5 }, // less relevant but orthogonal
+      { id: 4, score: 0.6 }, // also orthogonal to 1 and 3
+    ];
+    const e = new Map([
+      [1, vec(1, 0, 0)], [2, vec(0.99, 0.01, 0)], [3, vec(0, 1, 0)], [4, vec(0, 0, 1)],
+    ]);
+    const picked = mmrRerank(candidates, e, { topK: 3, lambda: 0 });
+    expect(picked[0].id).toBe(1);
+    expect(picked.map((c) => c.id)).not.toContain(2);
+    expect(new Set(picked.map((c) => c.id))).toEqual(new Set([1, 3, 4]));
+  });
+
+  it("does not crash when some candidates lack embeddings", () => {
+    const candidates = [
+      { id: 1, score: 0.1 },
+      { id: 2, score: 0.2 },
+      { id: 3, score: 0.3 },
+    ];
+    const e = new Map([[1, vec(1, 0)]]); // 2 and 3 have no embedding
+    const picked = mmrRerank(candidates, e, { topK: 2, lambda: 0.5 });
+    expect(picked).toHaveLength(2);
+    expect(picked[0].id).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR-B of **KJC-TSK-0484** (RAG content-hash dedup + near-duplicate detection). PR-A (#896) added the content-hash skip in the indexer; this one closes the loop on the retrieval side with **Maximal Marginal Relevance** reranking so near-duplicates that survived dedup (boilerplate chunk repeated under slightly different wording, two near-identical sections of a plan, etc.) get pushed down instead of crowding the topK.

Opt-in via new \`query()\` params; defaults keep the prior behaviour.

## Changes

- \`src/rag/retriever.js\` — \`cosineSim()\` + exported \`mmrRerank(candidates, embeddings, { topK, lambda })\` implementing classic MMR (\`lambda=1\` collapses to relevance order, \`lambda=0\` maximises diversity). \`query()\` gains \`diversify=false\` and \`mmrLambda=0.7\`; when on, fetches embeddings for the top \`topK*2\` and reranks.
- \`src/rag/vec-store.js\` — new \`getEmbeddingsByIds(db, ids)\` returning \`Map<id, Float32Array>\` from \`vec_chunks\` in a single batched read.
- \`tests/rag/diversify.test.js\` — 5 new tests:
  - \`cosineSim\` identity / orthogonality
  - \`cosineSim\` safe on zero-length, length-mismatch, null inputs
  - \`mmrRerank\` with \`lambda=1\` collapses to plain relevance order
  - \`mmrRerank\` with \`lambda=0\` drops the near-duplicate of the leader
  - \`mmrRerank\` does not crash when some candidates lack embeddings

## LOC budget

\`+136 / -5\` across 3 files — well under the 200-line cap.

## Test plan

- [x] \`npx vitest run tests/rag/diversify.test.js\` → 5/5
- [x] \`npx vitest run tests/rag/\` → 147/147 (no regressions on the surrounding RAG suite)
- [x] Prettier clean on all 3 files

## Related

- Epic: KJC-PCS-0053 (RAG Quality & Observability)
- Card: KJC-TSK-0484
- Preceded by: #896 (PR-A, content-hash dedup)