### PR TITLE
feat(rag): retrieval-quality harness + golden queries (KJC-TSK-0483 PR-A)

### DIFF
--- a/src/rag/eval.js
+++ b/src/rag/eval.js
@@ -1,0 +1,61 @@
+// KJC-TSK-0483 — Retrieval-quality harness. Loads a golden set of queries
+// (each with expected source paths and/or symbol names), runs the retriever
+// against each, and reports recall@k + MRR per query and aggregated. Pure:
+// the runner takes `runQuery` as a function so the CLI plugs in `query()`
+// while tests can use a stub.
+import { readFileSync } from "node:fs";
+
+const DEFAULT_KS = [5, 10];
+
+export function loadGoldenQueries(path) {
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  if (!Array.isArray(data)) throw new Error(`golden queries: expected an array in ${path}`);
+  return data;
+}
+
+function hitMatchesExpected(hit, expected) {
+  if (!hit) return false;
+  const src = hit.source || "";
+  if (expected.sources?.some((s) => src.endsWith(s))) return true;
+  const sym = hit.metadata?.symbol;
+  if (sym && expected.symbols?.includes(sym)) return true;
+  return false;
+}
+
+// Per-query metrics. `recall@k` is binary — 1 if any expected match lands in
+// the top-k, else 0. `rr` is the reciprocal of the first relevant rank (1 if
+// the very first hit matches, 0 if none do). `firstRank` is null on miss so
+// callers can render "—" without re-checking.
+export function scoreQuery(hits, expected, ks = DEFAULT_KS) {
+  const recall = {};
+  for (const k of ks) {
+    recall[`@${k}`] = hits.slice(0, k).some((h) => hitMatchesExpected(h, expected)) ? 1 : 0;
+  }
+  let firstRank = null;
+  let rr = 0;
+  for (let i = 0; i < hits.length; i += 1) {
+    if (hitMatchesExpected(hits[i], expected)) { firstRank = i + 1; rr = 1 / firstRank; break; }
+  }
+  return { recall, rr, firstRank };
+}
+
+export function aggregate(results, ks = DEFAULT_KS) {
+  const n = results.length || 1;
+  const recall = {};
+  for (const k of ks) {
+    recall[`@${k}`] = results.reduce((acc, r) => acc + (r.recall[`@${k}`] || 0), 0) / n;
+  }
+  const mrr = results.reduce((acc, r) => acc + (r.rr || 0), 0) / n;
+  return { n: results.length, recall, mrr };
+}
+
+export async function runEval(queries, runQuery, { topK = 10, ks = DEFAULT_KS } = {}) {
+  const results = [];
+  for (const q of queries) {
+    const hits = (await runQuery(q.query, topK)) || [];
+    const expected = { sources: q.expected_sources || [], symbols: q.expected_symbols || [] };
+    const scored = scoreQuery(hits, expected, ks);
+    results.push({ query: q.query, hits, ...scored });
+  }
+  return { results, aggregate: aggregate(results, ks) };
+}

--- a/tests/rag/eval.test.js
+++ b/tests/rag/eval.test.js
@@ -1,0 +1,94 @@
+// KJC-TSK-0483 — unit tests for the retrieval-quality harness. The runner
+// is intentionally decoupled from the retriever so we can drive it with
+// stub hits and assert recall@k / MRR math + the JSON loader.
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { loadGoldenQueries, scoreQuery, aggregate, runEval } from "../../src/rag/eval.js";
+
+function hit({ source, symbol }) {
+  return { source, metadata: symbol ? { symbol } : null };
+}
+
+describe("scoreQuery — KJC-TSK-0483", () => {
+  it("recall@k binary + MRR reciprocal of first relevant rank", () => {
+    const hits = [
+      hit({ source: "src/rag/other.js" }),
+      hit({ source: "src/rag/vec-store.js", symbol: "openVecStore" }),
+      hit({ source: "src/rag/indexer.js" }),
+    ];
+    const r = scoreQuery(hits, { sources: ["src/rag/vec-store.js"], symbols: [] }, [1, 5]);
+    expect(r.recall["@1"]).toBe(0);
+    expect(r.recall["@5"]).toBe(1);
+    expect(r.firstRank).toBe(2);
+    expect(r.rr).toBeCloseTo(0.5, 5);
+  });
+  it("symbol-only match still scores even if source path differs", () => {
+    const r = scoreQuery([hit({ source: "src/x.js", symbol: "openVecStore" })], { sources: [], symbols: ["openVecStore"] }, [5]);
+    expect(r.recall["@5"]).toBe(1);
+    expect(r.rr).toBe(1);
+  });
+  it("returns zeros when no hit matches", () => {
+    const r = scoreQuery([hit({ source: "a.js" }), hit({ source: "b.js" })], { sources: ["c.js"], symbols: [] }, [5, 10]);
+    expect(r.recall["@5"]).toBe(0);
+    expect(r.recall["@10"]).toBe(0);
+    expect(r.rr).toBe(0);
+    expect(r.firstRank).toBeNull();
+  });
+});
+
+describe("aggregate / runEval — KJC-TSK-0483", () => {
+  it("aggregates recall and MRR across queries", () => {
+    const results = [
+      { recall: { "@5": 1 }, rr: 1 },
+      { recall: { "@5": 1 }, rr: 0.5 },
+      { recall: { "@5": 0 }, rr: 0 },
+    ];
+    const agg = aggregate(results, [5]);
+    expect(agg.n).toBe(3);
+    expect(agg.recall["@5"]).toBeCloseTo(2 / 3, 5);
+    expect(agg.mrr).toBeCloseTo((1 + 0.5 + 0) / 3, 5);
+  });
+  it("runEval drives a stub retriever and produces results + aggregate", async () => {
+    const queries = [
+      { query: "find openVecStore", expected_sources: ["vec-store.js"] },
+      { query: "missing-target", expected_sources: ["does-not-exist.js"] },
+    ];
+    const stub = async (q) => q.includes("openVecStore")
+      ? [hit({ source: "/abs/path/vec-store.js" })]
+      : [hit({ source: "/abs/path/other.js" })];
+    const { results, aggregate: agg } = await runEval(queries, stub, { topK: 5, ks: [5] });
+    expect(results).toHaveLength(2);
+    expect(results[0].recall["@5"]).toBe(1);
+    expect(results[1].recall["@5"]).toBe(0);
+    expect(agg.recall["@5"]).toBe(0.5);
+    expect(agg.mrr).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("loadGoldenQueries — KJC-TSK-0483", () => {
+  it("parses an array of golden entries", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kj-golden-"));
+    const f = join(tmp, "g.json");
+    try {
+      writeFileSync(f, JSON.stringify([{ query: "x", expected_sources: ["y.js"] }]));
+      const out = loadGoldenQueries(f);
+      expect(out).toHaveLength(1);
+      expect(out[0].query).toBe("x");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+  it("throws when the file does not contain an array", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "kj-golden-"));
+    const f = join(tmp, "g.json");
+    try {
+      writeFileSync(f, JSON.stringify({ not: "array" }));
+      expect(() => loadGoldenQueries(f)).toThrow(/expected an array/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/rag/golden-queries.json
+++ b/tests/rag/golden-queries.json
@@ -1,0 +1,22 @@
+[
+  { "query": "openVecStore initialise sqlite-vec database", "expected_sources": ["src/rag/vec-store.js"], "expected_symbols": ["openVecStore"] },
+  { "query": "insertChunk persist embedding and metadata", "expected_sources": ["src/rag/vec-store.js"], "expected_symbols": ["insertChunk"] },
+  { "query": "BM25 keyword search FTS5", "expected_sources": ["src/rag/vec-store.js"], "expected_symbols": ["searchBM25"] },
+  { "query": "findChunkByHash dedup lookup", "expected_sources": ["src/rag/vec-store.js"], "expected_symbols": ["findChunkByHash"] },
+  { "query": "MMR diversification rerank candidates", "expected_sources": ["src/rag/retriever.js"], "expected_symbols": ["mmrRerank"] },
+  { "query": "cosine similarity helper between embeddings", "expected_sources": ["src/rag/retriever.js"], "expected_symbols": ["cosineSim"] },
+  { "query": "hybrid semantic + keyword score fusion", "expected_sources": ["src/rag/retriever.js"], "expected_symbols": ["fuseHits"] },
+  { "query": "index a single file content hash skip", "expected_sources": ["src/rag/indexer.js"], "expected_symbols": ["indexFile"] },
+  { "query": "walk project sources and embed everything", "expected_sources": ["src/rag/indexer.js"], "expected_symbols": ["indexProject"] },
+  { "query": "delta re-index files changed since git ref", "expected_sources": ["src/rag/indexer.js"], "expected_symbols": ["indexProjectDelta"] },
+  { "query": "chunkSource split JavaScript file into AST chunks", "expected_sources": ["src/rag/chunker.js", "src/rag/chunker-ast.js"], "expected_symbols": ["chunkSource"] },
+  { "query": "chunkMarkdown plan headings split", "expected_sources": ["src/rag/chunker.js"], "expected_symbols": ["chunkMarkdown"] },
+  { "query": "Ollama embedder local HTTP adapter", "expected_sources": ["src/rag/embedder.js", "src/rag/embedders/factory.js"] },
+  { "query": "Voyage cloud embedder", "expected_sources": ["src/rag/embedders/voyage.js"] },
+  { "query": "OpenAI cloud embedder adapter", "expected_sources": ["src/rag/embedders/openai.js"] },
+  { "query": "cross-encoder rerank top results", "expected_sources": ["src/rag/rerank.js"], "expected_symbols": ["rerank"] },
+  { "query": "chokidar watcher live re-index daemon", "expected_sources": ["src/rag/watcher.js"] },
+  { "query": "kj rag query CLI command implementation", "expected_sources": ["src/commands/rag.js"], "expected_symbols": ["ragQueryCommand"] },
+  { "query": "where clause parser metadata filter", "expected_sources": ["src/rag/where-parser.js"], "expected_symbols": ["parseWhere", "buildWhereSql"] },
+  { "query": "Ollama Docker manager auto-bootstrap", "expected_sources": ["src/rag/ollama-manager.js"] }
+]


### PR DESCRIPTION
## Summary
- Pure math module `src/rag/eval.js` to measure retrieval quality: loads golden queries from JSON, runs the retriever, computes per-query recall@k and reciprocal rank, aggregates into MRR.
- 20 initial golden queries (`tests/rag/golden-queries.json`) covering the karajan-code corpus: exact symbol lookups, semantic intents, and module identification.
- Decoupled from the retriever: the runner takes `runQuery` as a parameter so the CLI plugs in `query()` while unit tests drive it with stubs.

PR-A of two for KJC-TSK-0483. PR-B will add the `kj rag eval` CLI command + `docs/RAG.md` baseline section.

Last card of epic KJC-PCS-0053 — RAG Quality & Observability.

## LOC budget
`+177 / -0` across 3 new files. Well under the 200-LOC cap.

## Test plan
- [x] `npx vitest run tests/rag/eval.test.js` → 7/7 new passing (scoreQuery binary recall + MRR; symbol-only match; runEval stub end-to-end; loadGoldenQueries valid + invalid)
- [x] `npx vitest run tests/rag/` → 154/154 RAG-suite passing (no regression)
- [x] `npx prettier --check` clean

## Acceptance criteria from card
- ✅ `scoreQuery` computes recall@k binary + reciprocal rank per query.
- ✅ `aggregate` produces recall@k and MRR over a result set.
- ✅ `runEval` orchestrates queries → hits → scoring with a pluggable retriever.
- ⏳ `kj rag eval` CLI + `--min-recall` exit-code gate + docs baseline → PR-B.