### PR TITLE
fix(sonar): auto-prefer native sonar-scanner on arm64 hosts (KJC-BUG-0073)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,27 @@ kj sonar start
 ```
 Karajan will use these credentials to auto-generate a token on each run.
 
+### `kj scan` fails on Apple Silicon (ARM64)
+
+**Cause**: `sonarsource/sonar-scanner-cli` ships only `linux/amd64`. Under Rosetta/QEMU emulation the embedded JS/TS plugin crashes the WebSocket bridge with `IllegalStateException: WebSocket connection closed abnormally`.
+
+**Fix**: Install `sonar-scanner` natively and let Karajan auto-detect it:
+
+```bash
+# macOS
+brew install sonar-scanner
+```
+
+On `arm64` hosts, Karajan now auto-prefers a native `sonar-scanner` on PATH and falls back to Docker if missing. To force one mode explicitly:
+
+```yaml
+sonarqube:
+  scanner:
+    command: native   # or "docker" to keep the container
+```
+
+`command` also accepts an absolute path (e.g. `/opt/homebrew/bin/sonar-scanner`).
+
 ### Quality gate fails repeatedly
 
 **Cause**: SonarQube detects blocking issues that the coder cannot resolve.

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
 import { runCommand } from "../utils/process.js";
 import { sonarUp } from "./manager.js";
 import { resolveSonarProjectKey } from "./project-key.js";
@@ -9,6 +10,32 @@ import {
   resolveSonarToken as resolveToken,
   resolveSonarCredentials,
 } from "./config-resolver.js";
+
+export async function findNativeSonarScanner() {
+  const which = await runCommand("sh", ["-c", "command -v sonar-scanner"]);
+  if (which.exitCode === 0) {
+    const bin = String(which.stdout || "").trim();
+    if (bin) return bin;
+  }
+  return null;
+}
+
+export async function pickSonarScanner(scannerConfig = {}, deps = {}) {
+  const find = deps.findNativeSonarScanner || findNativeSonarScanner;
+  const arch = deps.arch || os.arch();
+  const forced = String(scannerConfig.command || "").trim().toLowerCase();
+  if (forced === "docker") return { type: "docker" };
+  if (forced === "native" || forced === "sonar-scanner" || forced.endsWith("/sonar-scanner")) {
+    const bin = (forced === "native" || forced === "sonar-scanner") ? await find() : forced;
+    if (bin) return { type: "native", bin };
+    return { type: "docker", reason: "native sonar-scanner not found on PATH" };
+  }
+  if (arch === "arm64") {
+    const bin = await find();
+    if (bin) return { type: "native", bin, reason: "ARM64 host — preferring native binary" };
+  }
+  return { type: "docker" };
+}
 
 export function buildScannerOpts(projectKey, scanner = {}) {
   const opts = [`-Dsonar.projectKey=${projectKey}`];
@@ -236,31 +263,39 @@ export async function runSonarScan(config, projectKey = null) {
     ...coverage.scannerPatch
   });
 
-  const args = [
-    "run",
-    "--rm",
-    "-v",
-    `${process.cwd()}:/usr/src`,
-    ...(isLocalHost ? ["--add-host", "host.docker.internal:host-gateway"] : []),
-    ...(isLocalHost || isExternalSonar ? [] : ["--network", sonarNetwork]),
-    "-e", "SONAR_HOST_URL",
-    "-e", "SONAR_TOKEN",
-    "-e", "SONAR_SCANNER_OPTS",
-    "sonarsource/sonar-scanner-cli"
-  ];
-
-  // Pass secrets via process env, not CLI args — invisible in `ps aux`
+  const pick = await pickSonarScanner(sonarConfig.scanner);
   const env = {
     ...process.env,
-    SONAR_HOST_URL: host,
+    SONAR_HOST_URL: pick.type === "native" ? rawHost : host,
     SONAR_TOKEN: token || "",
     SONAR_SCANNER_OPTS: buildScannerOpts(effectiveProjectKey, scannerConfig)
   };
 
-  const result = await runCommand("docker", args, { timeout: scannerTimeout, env });
+  let cmd, args;
+  if (pick.type === "native") {
+    cmd = pick.bin;
+    args = [];
+  } else {
+    cmd = "docker";
+    args = [
+      "run",
+      "--rm",
+      "-v",
+      `${process.cwd()}:/usr/src`,
+      ...(isLocalHost ? ["--add-host", "host.docker.internal:host-gateway"] : []),
+      ...(isLocalHost || isExternalSonar ? [] : ["--network", sonarNetwork]),
+      "-e", "SONAR_HOST_URL",
+      "-e", "SONAR_TOKEN",
+      "-e", "SONAR_SCANNER_OPTS",
+      "sonarsource/sonar-scanner-cli"
+    ];
+  }
+
+  const result = await runCommand(cmd, args, { timeout: scannerTimeout, env });
   return {
     ok: result.exitCode === 0,
     projectKey: effectiveProjectKey,
+    scanner: pick.type,
     stdout: result.stdout,
     stderr: result.stderr,
     exitCode: result.exitCode

--- a/tests/sonar/sonar-pick-scanner.test.js
+++ b/tests/sonar/sonar-pick-scanner.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { pickSonarScanner } from "../../src/sonar/scanner.js";
+
+const fakeFind = (bin) => vi.fn().mockResolvedValue(bin);
+
+describe("[opt-in: sonar] pickSonarScanner", () => {
+  it("forces docker when scanner.command='docker'", async () => {
+    const pick = await pickSonarScanner({ command: "docker" }, {
+      findNativeSonarScanner: fakeFind("/usr/local/bin/sonar-scanner"),
+      arch: "arm64"
+    });
+    expect(pick.type).toBe("docker");
+  });
+
+  it("uses native when scanner.command='native' and binary exists", async () => {
+    const pick = await pickSonarScanner({ command: "native" }, {
+      findNativeSonarScanner: fakeFind("/opt/homebrew/bin/sonar-scanner"),
+      arch: "x64"
+    });
+    expect(pick.type).toBe("native");
+    expect(pick.bin).toBe("/opt/homebrew/bin/sonar-scanner");
+  });
+
+  it("uses absolute path when scanner.command points to a binary", async () => {
+    const find = vi.fn();
+    const pick = await pickSonarScanner({ command: "/custom/path/sonar-scanner" }, {
+      findNativeSonarScanner: find,
+      arch: "x64"
+    });
+    expect(pick.type).toBe("native");
+    expect(pick.bin).toBe("/custom/path/sonar-scanner");
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("falls back to docker when native is forced but binary not found", async () => {
+    const pick = await pickSonarScanner({ command: "native" }, {
+      findNativeSonarScanner: fakeFind(null),
+      arch: "x64"
+    });
+    expect(pick.type).toBe("docker");
+    expect(pick.reason).toMatch(/not found/);
+  });
+
+  it("auto-prefers native on ARM64 when binary exists", async () => {
+    const pick = await pickSonarScanner({}, {
+      findNativeSonarScanner: fakeFind("/opt/homebrew/bin/sonar-scanner"),
+      arch: "arm64"
+    });
+    expect(pick.type).toBe("native");
+    expect(pick.reason).toMatch(/ARM64/);
+  });
+
+  it("uses docker on ARM64 when native binary missing", async () => {
+    const pick = await pickSonarScanner({}, {
+      findNativeSonarScanner: fakeFind(null),
+      arch: "arm64"
+    });
+    expect(pick.type).toBe("docker");
+  });
+
+  it("uses docker by default on x64 even if native binary exists", async () => {
+    const find = vi.fn();
+    const pick = await pickSonarScanner({}, {
+      findNativeSonarScanner: find,
+      arch: "x64"
+    });
+    expect(pick.type).toBe("docker");
+    expect(find).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #887.

- `sonarsource/sonar-scanner-cli` has no `linux/arm64` image. Apple Silicon runs it under Rosetta/QEMU and the embedded JS/TS WebSocket bridge crashes mid-analysis.
- New `pickSonarScanner()` decides transport: explicit `sonarqube.scanner.command` override (`docker` | `native` | absolute path), auto-detect native binary on ARM64 hosts, fallback to Docker.
- `runSonarScan()` branches on the picked transport — native uses host network directly.
- Adds 7 unit tests for the picker.

## Test plan
- [x] `npx vitest run tests/sonar/` — 167/167 passing
- [ ] Manual verification on Apple Silicon (not available in CI)

## Notes
- Docs updated in `docs/troubleshooting.md` with an "Apple Silicon" section explaining `brew install sonar-scanner` and the new `scanner.command` knob.
- No breaking changes — default behaviour on `x64` hosts unchanged (still Docker).