### PR TITLE
fix(deps): override fast-uri@3.1.2 to patch high audit (KJC-BUG-0074)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,9 +3810,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
   "lint-staged": {
     "src/**/*.js": "eslint --max-warnings=999"
   },
+  "overrides": {
+    "fast-uri": "^3.1.2"
+  },
   "dependencies": {
     "@babel/parser": "^7.29.3",
     "@modelcontextprotocol/sdk": "^1.26.0",


### PR DESCRIPTION
## Summary

Pin `fast-uri >=3.1.2` via npm `overrides` to clear two HIGH npm audit findings dragged in transitively by `@modelcontextprotocol/sdk → ajv@8.18.0 → fast-uri@3.1.0`.

**CVEs:**
- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments (CVSS 7.5)
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters (CVSS 7.5)

Both are fixed in `fast-uri@3.1.2`. \`ajv\` hasn't shipped a new release pinning it yet, so an override is the cleanest path until upstream catches up.

## Verification

\`\`\`console
$ npm ls fast-uri
karajan-code@2.34.0
└─┬ @modelcontextprotocol/sdk@1.26.0
  └─┬ ajv@8.18.0
    └── fast-uri@3.1.2 overridden

$ npm audit
3 moderate severity vulnerabilities    # was 5 (2 high + 3 moderate)
\`\`\`

## Test plan

- [x] \`npm install --no-audit\` clean
- [x] \`npm ls fast-uri\` → 3.1.2 overridden
- [x] \`npm audit\` → 0 high, 0 critical (3 unrelated moderates remain)
- [x] \`npx vitest run tests/mcp\` → 177/177 passing (ajv path still works)

Closes #876