### PR TITLE
feat(mcp): kj-rag-mcp standalone binary for external IDEs (KJC-TSK-0492 PR1)

### DIFF
--- a/bin/kj-rag-mcp.js
+++ b/bin/kj-rag-mcp.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * kj-rag-mcp — standalone MCP server exposing only RAG tools.
+ *
+ * For external IDEs (Cursor, Windsurf, Continue, Zed) that want semantic
+ * search over a Karajan-indexed project without pulling in the full 27-tool
+ * orchestrator surface. Re-uses handleRagQuery / handleRagIndex from the
+ * main server, so behavior stays in sync with `karajan-mcp`.
+ */
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { handleRagQuery, handleRagIndex } from "../src/mcp/handlers/rag-handler.js";
+import { responseText, enrichedFailPayload } from "../src/mcp/shared-helpers.js";
+import { setupOrphanGuard } from "../src/mcp/orphan-guard.js";
+
+const MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PKG_PATH = path.resolve(MODULE_DIR, "../package.json");
+const VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
+
+const RAG_TOOLS = [
+  {
+    name: "kj_rag_query",
+    description: "Semantic search across the indexed Karajan plans, onboarding briefs and (optionally) project source code. Returns the top-K nearest chunks with metadata so the agent can quote prior decisions or locate where a concept was last implemented. Empty until `kj_rag_index` has run at least once.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "Natural-language query." },
+        topK: { type: "number", description: "Max hits to return. Default 5." },
+        scope: { type: "string", description: "'plans' | 'code' | 'onboarding' | 'all' (default)." },
+        projectDir: { type: "string", description: "Absolute path to the project directory." }
+      },
+      required: ["text"]
+    }
+  },
+  {
+    name: "kj_rag_index",
+    description: "(Re)index this project's Karajan-managed assets into the local vector store. Idempotent. Pass `withSources: true` to also index project source files. Required as a one-time bootstrap before `kj_rag_query` returns anything.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        withSources: { type: "boolean", description: "Also index source files under projectDir. Default false." },
+        projectDir: { type: "string", description: "Absolute path to the project directory." }
+      }
+    }
+  }
+];
+
+const mcpServer = new McpServer(
+  { name: "kj-rag-mcp", version: VERSION },
+  { capabilities: { tools: {}, logging: {} } }
+);
+const server = mcpServer.server;
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: RAG_TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const name = request.params?.name;
+  const args = request.params?.arguments || {};
+  try {
+    if (name === "kj_rag_query") return responseText(await handleRagQuery(args, server));
+    if (name === "kj_rag_index") return responseText(await handleRagIndex(args, server));
+    return responseText({ ok: false, error: `Unknown tool: ${name}` });
+  } catch (error) {
+    return responseText(enrichedFailPayload(error, name));
+  }
+});
+
+setupOrphanGuard();
+
+const transport = new StdioServerTransport();
+await mcpServer.connect(transport);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "bin": {
     "kj": "bin/kj.js",
     "kj-tail": "bin/kj-tail",
-    "karajan-mcp": "bin/karajan-mcp.js"
+    "karajan-mcp": "bin/karajan-mcp.js",
+    "kj-rag-mcp": "bin/kj-rag-mcp.js"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js",

--- a/tests/mcp/kj-rag-mcp-binary.test.js
+++ b/tests/mcp/kj-rag-mcp-binary.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const BIN = path.resolve(process.cwd(), "bin/kj-rag-mcp.js");
+
+function send(child, msg) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        child.stdout.off("data", onData);
+        try { resolve(JSON.parse(line)); } catch (e) { reject(e); }
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stdin.write(JSON.stringify(msg) + "\n");
+    setTimeout(() => reject(new Error("timeout")), 4000);
+  });
+}
+
+describe("kj-rag-mcp standalone binary", () => {
+  it("lists exactly the two RAG tools and nothing else", async () => {
+    const child = spawn("node", [BIN], { stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      const res = await send(child, { jsonrpc: "2.0", method: "tools/list", id: 1 });
+      const names = res?.result?.tools?.map(t => t.name).sort();
+      expect(names).toEqual(["kj_rag_index", "kj_rag_query"]);
+    } finally {
+      child.kill();
+    }
+  });
+
+  it("declares text as required parameter for kj_rag_query", async () => {
+    const child = spawn("node", [BIN], { stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      const res = await send(child, { jsonrpc: "2.0", method: "tools/list", id: 2 });
+      const query = res.result.tools.find(t => t.name === "kj_rag_query");
+      expect(query.inputSchema.required).toContain("text");
+    } finally {
+      child.kill();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new binary entry **\`kj-rag-mcp\`** — a slim, standalone MCP server that exposes **only** the two RAG tools (\`kj_rag_query\` and \`kj_rag_index\`).

Aimed at external IDEs that want Karajan's per-project semantic search without pulling in the full 27-tool orchestrator surface: Cursor, Windsurf, Continue, Zed, etc.

## Why

- Today users have to wire \`karajan-mcp\` (27 tools) into their IDE just to get \`kj_rag_query\` working. Most IDEs throttle/limit tool counts, and many users don't want to expose pipeline commands to an external IDE.
- The RAG handlers already live in \`src/mcp/handlers/rag-handler.js\` and are stateless. A second bin that re-uses them is the cheapest possible delivery — no code duplication, no behaviour drift.

## Changes

- \`bin/kj-rag-mcp.js\` (new, 75 LOC) — minimal MCP server: McpServer + StdioServerTransport, ListTools returns exactly 2 tools, CallTool dispatches to \`handleRagQuery\`/\`handleRagIndex\` via the same \`responseText\`/\`enrichedFailPayload\` plumbing as \`karajan-mcp\`. Orphan-guard reused.
- \`tests/mcp/kj-rag-mcp-binary.test.js\` (new, 47 LOC) — spawns the binary and asserts the tool list contains exactly \`kj_rag_index\` and \`kj_rag_query\` (no surprise additions) and that \`text\` stays \`required\` on the query schema.
- \`package.json\` — new \`bin\` entry \`kj-rag-mcp\`.

## Test plan

- [x] \`node --check bin/kj-rag-mcp.js\` passes
- [x] Smoke test via stdio: \`echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | node bin/kj-rag-mcp.js\` returns the 2 tools
- [x] \`npx vitest run tests/mcp/kj-rag-mcp-binary.test.js\` — 2/2 passing locally
- [ ] CI green (shrink-budget, prettier, eslint, full test suite)

## Follow-ups (separate PRs, KJC-TSK-0492)

- **PR2**: \`docs/RAG.md\` — new "Use from external IDEs" section with Cursor / Windsurf / Continue / Zed snippets
- **PR3** (optional): \`kj rag mcp\` CLI subcommand wrapper for discoverability