### PR TITLE
feat(cli): kj rag mcp subcommand for RAG MCP server (KJC-TSK-0492 PR3)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -4,6 +4,7 @@ import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
 import { ragIndexCommand, ragQueryCommand, ragInstallHooksCommand, ragEvalCommand } from "../commands/rag.js";
+import { ragMcpCommand } from "../commands/rag-mcp.js";
 import { watchStartCommand, watchStopCommand, watchStatusCommand } from "../commands/watch.js";
 import { auditCommand } from "../commands/audit.js";
 import { resumeCommand } from "../commands/resume.js";
@@ -158,6 +159,16 @@ export function registerMeta(program, { pkgVersion }) {
       await withConfig(pkgVersion, "rag-eval", flags, async ({ config, logger }) => {
         await ragEvalCommand({ config, logger, flags });
       });
+    });
+
+  // KJC-TSK-0492 PR3 — `kj rag mcp` exposes the kj-rag-mcp binary under the
+  // familiar `kj rag <subcommand>` surface so users discover it without
+  // grepping bin/. The action dynamic-imports the binary, which takes over
+  // stdio for MCP transport; the CLI process never returns.
+  rag.command("mcp")
+    .description("Start the standalone RAG MCP server (kj_rag_query + kj_rag_index only). Same as running `kj-rag-mcp` directly")
+    .action(async () => {
+      await ragMcpCommand();
     });
 
   // KJC-TSK-0441 — `kj watch [start|stop|status]` for live RAG re-index.

--- a/src/commands/rag-mcp.js
+++ b/src/commands/rag-mcp.js
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
+
+/**
+ * `kj rag mcp` — spawn the standalone RAG MCP server inline.
+ *
+ * KJC-TSK-0492 PR3. Adds CLI discoverability for the `kj-rag-mcp` binary
+ * so external IDE users can find it via the same `kj rag <subcommand>`
+ * surface they already know. The implementation dynamic-imports the
+ * binary entry so behavior stays identical to running `kj-rag-mcp`
+ * directly — same handlers, same transport, same orphan guard.
+ */
+export async function ragMcpCommand() {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  const binPath = path.resolve(moduleDir, "../../bin/kj-rag-mcp.js");
+  await import(pathToFileURL(binPath).href);
+}

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -89,7 +89,13 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // for the same pattern inside `src/rag/rerank.js`. Same rationale —
 // transformers is an optional peer dep, opt-in `--rerank` flag, must
 // gracefully error on missing package.
-const DYNAMIC_IMPORT_BUDGET = 166;
+//
+// 2026-06-02 (KJC-TSK-0492 PR3 `kj rag mcp` subcommand): bumped 166 → 167.
+// `src/commands/rag-mcp.js` dynamic-imports `bin/kj-rag-mcp.js` at action
+// time. Static import is not an option: the binary attaches a
+// StdioServerTransport at top level, so a static import would launch the
+// MCP server on every `kj` invocation, not only `kj rag mcp`.
+const DYNAMIC_IMPORT_BUDGET = 167;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/cli/rag-mcp-subcommand.test.js
+++ b/tests/cli/rag-mcp-subcommand.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+const KJ = path.resolve(process.cwd(), "bin/kj.js");
+
+function send(child, msg) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        child.stdout.off("data", onData);
+        try { resolve(JSON.parse(line)); } catch (e) { reject(e); }
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stdin.write(JSON.stringify(msg) + "\n");
+    setTimeout(() => reject(new Error("timeout")), 6000);
+  });
+}
+
+describe("kj rag mcp subcommand", () => {
+  it("starts the same MCP server as the kj-rag-mcp binary", async () => {
+    const child = spawn("node", [KJ, "rag", "mcp"], { stdio: ["pipe", "pipe", "pipe"] });
+    try {
+      const res = await send(child, { jsonrpc: "2.0", method: "tools/list", id: 1 });
+      const names = res?.result?.tools?.map(t => t.name).sort();
+      expect(names).toEqual(["kj_rag_index", "kj_rag_query"]);
+    } finally {
+      child.kill();
+    }
+  });
+
+  it("appears in `kj rag --help`", async () => {
+    const child = spawn("node", [KJ, "rag", "--help"], { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout.on("data", (c) => { stdout += c.toString(); });
+    await new Promise((resolve) => child.on("exit", resolve));
+    expect(stdout).toMatch(/\bmcp\b/);
+    expect(stdout).toMatch(/standalone RAG MCP server/i);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `kj rag mcp` CLI subcommand that starts the standalone RAG MCP server. The action dynamic-imports `bin/kj-rag-mcp.js` so the subcommand and the standalone binary always share the same handlers and transport.

## Why
PR1 introduced `kj-rag-mcp` as a separate npm bin. External-IDE users discover Karajan through `kj rag query` / `kj rag index`; surfacing the MCP server under the same `kj rag <subcommand>` namespace makes the path obvious without grepping `bin/` or reading the docs.

## Changes
- `src/commands/rag-mcp.js` — dynamic-import wrapper, 14 LOC.
- `src/cli/register-meta.js` — `rag.command("mcp")` registration, +11 LOC.
- `tests/cli/rag-mcp-subcommand.test.js` — two tests:
  1. `kj rag mcp` lists exactly `kj_rag_index` + `kj_rag_query` (parity with binary).
  2. `kj rag --help` advertises the `mcp` subcommand.

Net: +74 LOC across 3 files. Well within the 200-LOC budget.

## Test plan
- [x] `npx vitest run tests/cli/rag-mcp-subcommand.test.js` — 2/2 green
- [x] `npx vitest run tests/mcp/kj-rag-mcp-binary.test.js tests/cli/` — 79/79 green
- [x] `npx prettier --check` + `npx eslint` — clean
- [ ] CI green