### PR TITLE
feat(testing): env var to dry-run quota standby/hibernation (KJC-TSK-0493)

### DIFF
--- a/docs/quota-simulation.md
+++ b/docs/quota-simulation.md
@@ -1,0 +1,72 @@
+# Simulating provider quota exhaustion (`KJ_SIMULATE_QUOTA`)
+
+Flat-rate subscribers (Claude Pro, Gemini Code Assist Standard, Codex
+subscription tiers, …) almost never see the real "weekly usage limit"
+stderr line that Karajan's rate-limit detector listens for. That made it
+impossible to verify end-to-end that:
+
+- the run halts cleanly when a coder / refactorer / reviewer hits a
+  quota cap,
+- the session is persisted under `~/.karajan/standby/<sessionId>.json`,
+- `kj standby list` finds it back, and
+- `kj standby resume <sessionId> --force` rehydrates it.
+
+`KJ_SIMULATE_QUOTA` is a **testing / demo hook** that injects a synthetic
+"weekly limit. resets at <ISO>" line into the next agent's stderr at a
+chosen iteration, without consuming any real quota. The existing
+`detectRateLimit` branch picks it up; the existing standby + Brain
+Recovery wiring takes over from there.
+
+> This is for testing and dogfooding only — it does **not** alter your
+> real provider state.
+
+## Usage
+
+```bash
+KJ_SIMULATE_QUOTA=after-iter-2 \
+KJ_SIMULATE_QUOTA_RESET=2026-06-02T15:30:00Z \
+kj run "build a hello-world CLI"
+```
+
+After iteration `2`, the next coder execution returns a synthetic stderr
+line, the coder stage emits `coder:hibernate` / enters standby, and the
+session is written to `~/.karajan/standby/<sessionId>.json`. Resume with:
+
+```bash
+kj standby list
+kj standby resume <sessionId> --force
+```
+
+## Variables
+
+| Env var | Required | Default | Meaning |
+|---|---|---|---|
+| `KJ_SIMULATE_QUOTA` | yes | — | `after-iter-<N>` — fire on iteration `N` (1-based). Anything else logs a one-shot warning and is ignored. |
+| `KJ_SIMULATE_QUOTA_RESET` | no | `now + 1h` (ISO) | The `resets at <ISO>` timestamp embedded in the synthetic line. |
+| `KJ_SIMULATE_QUOTA_AGENT` | no | `claude` | Which provider to match. Accepts `claude`, `codex`, `gemini`, or `any`. |
+
+## Which stages are wired
+
+The simulator fires on the same three call sites that already check
+`detectRateLimit`:
+
+- coder stage (`src/orchestrator/stages/coder-stage.js` — `runCoderStage`)
+- refactorer stage (same file — `runRefactorerStage`)
+- reviewer stage (`src/orchestrator/stages/reviewer-stage.js`)
+
+If the active agent in that stage matches the configured
+`KJ_SIMULATE_QUOTA_AGENT` (or you set it to `any`), the result is
+mutated to `ok=false` with the synthetic line prepended to `result.error`
+before the existing rate-limit detector runs. No other code paths
+change.
+
+## What does **not** happen
+
+- No fallback agent is invoked (the synthetic line goes through the
+  standby branch, not the rate-limit-with-fallback branch — that is
+  intentional, so you can demo a single-provider hibernation cleanly).
+- No real provider quota is consumed.
+- The simulator is a no-op when `KJ_SIMULATE_QUOTA` is unset, so it is
+  safe to leave the wiring in place in production builds.
+
+Tracked in `KJC-TSK-0493`.

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -19,6 +19,7 @@ import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
 import { buildStandbyState } from "../../brain/standby-store.js";
+import { applyQuotaSimulation } from "../../utils/quota-simulator.js";
 import { snapshotHomeTopLevel, detectNewHomeEntries, formatLeakMessage, verifyLeaksAgainstTranscript, detectTranscriptCdLeaks } from "../fs-leak-detector.js";
 
 export async function runCoderStage({ coderRoleInstance, coderRole, config, logger, emitter, eventBase, session, plannedTask, trackBudget, iteration, brainCtx, acceptanceTests = null, adrs = null, specSection = null, reviewerFindings = null, huId = null }) {
@@ -76,6 +77,7 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
     coderStall.stop();
   }
   trackBudget({ role: "coder", provider: coderRole.provider, model: coderRole.model, result: coderExecResult.result, duration_ms: Date.now() - coderStart });
+  applyQuotaSimulation(coderExecResult, { iteration, agent: coderRole.provider });
 
   if (!coderExecResult.ok) {
     const details = coderExecResult.result?.error || coderExecResult.summary || "unknown error";
@@ -281,6 +283,7 @@ export async function runRefactorerStage({ refactorerRole, config, logger, emitt
     refactorerStall.stop();
   }
   trackBudget({ role: "refactorer", provider: refactorerRole.provider, model: refactorerRole.model, result: refResult.result, duration_ms: Date.now() - refactorerStart });
+  applyQuotaSimulation(refResult, { iteration, agent: refactorerRole.provider });
   if (!refResult.ok) {
     const details = refResult.result?.error || refResult.summary || "unknown error";
     // Quota cap → hibernate cleanly, same as the coder stage above.

--- a/src/orchestrator/stages/reviewer-stage.js
+++ b/src/orchestrator/stages/reviewer-stage.js
@@ -13,6 +13,7 @@ import { runReviewerWithFallback } from "../reviewer-fallback.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { detectRateLimit } from "../../utils/rate-limit-detector.js";
 import { createStallDetector } from "../../utils/stall-detector.js";
+import { applyQuotaSimulation } from "../../utils/quota-simulator.js";
 
 function categorizeIssues(issues) {
   const categories = { security: 0, correctness: 0, tests: 0, style: 0, other: 0 };
@@ -267,6 +268,16 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
     reviewerExec = { execResult: { ok: false, error: err.message }, attempts: [{ reviewer: reviewerRole.provider, result: { ok: false, error: err.message } }] };
   } finally {
     reviewerStall.stop();
+  }
+
+  if (applyQuotaSimulation(reviewerExec.execResult, { iteration, agent: reviewerRole.provider })) {
+    // Reviewer wraps the agent call: detectRateLimit reads `lastAttempt.result.error`,
+    // so propagate the synthetic line into the most recent attempt too.
+    const last = reviewerExec.attempts?.at(-1);
+    if (last) {
+      if (!last.result || typeof last.result !== "object") last.result = {};
+      last.result.error = reviewerExec.execResult.result.error;
+    }
   }
 
   if (!reviewerExec.execResult?.ok) {

--- a/src/utils/quota-simulator.js
+++ b/src/utils/quota-simulator.js
@@ -1,0 +1,56 @@
+// KJ_SIMULATE_QUOTA — testing hook for the standby flow. See
+// docs/quota-simulation.md. KJC-TSK-0493.
+
+let _warned = false;
+
+export function parseQuotaSimulationConfig(env = process.env) {
+  const trigger = env.KJ_SIMULATE_QUOTA;
+  if (!trigger) return null;
+  const m = /^after-iter-(\d+)$/i.exec(String(trigger).trim());
+  if (!m) {
+    if (!_warned) {
+      // eslint-disable-next-line no-console
+      console.warn(`[KJ_SIMULATE_QUOTA] Ignoring malformed value "${trigger}". Expected "after-iter-<N>".`);
+      _warned = true;
+    }
+    return null;
+  }
+  return {
+    afterIter: Number.parseInt(m[1], 10),
+    resetIso: env.KJ_SIMULATE_QUOTA_RESET || new Date(Date.now() + 3600_000).toISOString(),
+    agent: String(env.KJ_SIMULATE_QUOTA_AGENT || "claude").toLowerCase(),
+  };
+}
+
+const SYNTHETIC_MSG = {
+  claude: (iso) => `[KJ_SIMULATE_QUOTA] Claude Pro usage limit reached. weekly limit. resets at ${iso}`,
+  codex: () => `[KJ_SIMULATE_QUOTA] You have exceeded your current quota. retry after 60 seconds`,
+  gemini: () => `[KJ_SIMULATE_QUOTA] Resource exhausted: quota exceeded. retry after 60 seconds`,
+};
+
+export function buildSyntheticQuotaMessage(agent, resetIso) {
+  return (SYNTHETIC_MSG[agent] || SYNTHETIC_MSG.claude)(resetIso);
+}
+
+export function shouldSimulateQuota({ iteration, agent }, env = process.env) {
+  const cfg = parseQuotaSimulationConfig(env);
+  if (!cfg) return null;
+  if (Number(iteration) < cfg.afterIter) return null;
+  const a = String(agent || "").toLowerCase();
+  if (cfg.agent !== "any" && cfg.agent !== a) return null;
+  return { resetIso: cfg.resetIso, agent: a || cfg.agent };
+}
+
+// Mutates execResult: forces ok=false and prepends the synthetic quota
+// line to result.error so the existing detectRateLimit branch fires.
+export function applyQuotaSimulation(execResult, { iteration, agent }, env = process.env) {
+  const fire = shouldSimulateQuota({ iteration, agent }, env);
+  if (!fire || !execResult || typeof execResult !== "object") return false;
+  if (!execResult.result || typeof execResult.result !== "object") execResult.result = {};
+  execResult.result.error = `${buildSyntheticQuotaMessage(fire.agent, fire.resetIso)}\n${execResult.result.error || ""}`;
+  execResult.ok = false;
+  return true;
+}
+
+// Test seam — reset the one-shot warning between unit tests.
+export function _resetSimulatorWarning() { _warned = false; }

--- a/tests/utils/quota-simulator.test.js
+++ b/tests/utils/quota-simulator.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  parseQuotaSimulationConfig,
+  buildSyntheticQuotaMessage,
+  shouldSimulateQuota,
+  applyQuotaSimulation,
+  _resetSimulatorWarning,
+} from "../../src/utils/quota-simulator.js";
+
+describe("quota-simulator", () => {
+  beforeEach(() => _resetSimulatorWarning());
+
+  it("parses after-iter-<N> with defaults and overrides", () => {
+    expect(parseQuotaSimulationConfig({})).toBeNull();
+    const defaults = parseQuotaSimulationConfig({ KJ_SIMULATE_QUOTA: "after-iter-3" });
+    expect(defaults.afterIter).toBe(3);
+    expect(defaults.agent).toBe("claude");
+    expect(defaults.resetIso).toMatch(/^\d{4}-/);
+    expect(parseQuotaSimulationConfig({
+      KJ_SIMULATE_QUOTA: "after-iter-1",
+      KJ_SIMULATE_QUOTA_RESET: "2026-06-02T15:30:00Z",
+      KJ_SIMULATE_QUOTA_AGENT: "Codex",
+    })).toEqual({ afterIter: 1, resetIso: "2026-06-02T15:30:00Z", agent: "codex" });
+  });
+
+  it("warns once and ignores malformed values", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(parseQuotaSimulationConfig({ KJ_SIMULATE_QUOTA: "garbage" })).toBeNull();
+      expect(parseQuotaSimulationConfig({ KJ_SIMULATE_QUOTA: "garbage" })).toBeNull();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally { warn.mockRestore(); }
+  });
+
+  it("builds agent-specific synthetic messages, defaulting to Claude weekly-limit", () => {
+    expect(buildSyntheticQuotaMessage("claude", "2026-06-02T15:30:00Z")).toMatch(/weekly limit.*2026-06-02T15:30:00Z/i);
+    expect(buildSyntheticQuotaMessage("codex", "x")).toMatch(/exceeded your current quota/i);
+    expect(buildSyntheticQuotaMessage("gemini", "x")).toMatch(/quota exceeded/i);
+    expect(buildSyntheticQuotaMessage("unknown", "x")).toMatch(/weekly limit/i);
+  });
+
+  it("respects iteration threshold and agent filter", () => {
+    const env = { KJ_SIMULATE_QUOTA: "after-iter-2" };
+    expect(shouldSimulateQuota({ iteration: 1, agent: "claude" }, env)).toBeNull();
+    expect(shouldSimulateQuota({ iteration: 2, agent: "claude" }, env)).not.toBeNull();
+    const codexOnly = { KJ_SIMULATE_QUOTA: "after-iter-1", KJ_SIMULATE_QUOTA_AGENT: "codex" };
+    expect(shouldSimulateQuota({ iteration: 5, agent: "claude" }, codexOnly)).toBeNull();
+    expect(shouldSimulateQuota({ iteration: 5, agent: "codex" }, codexOnly)).not.toBeNull();
+    const any = { KJ_SIMULATE_QUOTA: "after-iter-1", KJ_SIMULATE_QUOTA_AGENT: "any" };
+    expect(shouldSimulateQuota({ iteration: 1, agent: "whatever" }, any)).not.toBeNull();
+  });
+
+  it("applyQuotaSimulation is a no-op when disabled or below threshold", () => {
+    const r1 = { ok: true, result: { output: "hi" } };
+    expect(applyQuotaSimulation(r1, { iteration: 5, agent: "claude" }, {})).toBe(false);
+    expect(r1.ok).toBe(true);
+    const r2 = { ok: true, result: {} };
+    expect(applyQuotaSimulation(r2, { iteration: 1, agent: "claude" }, { KJ_SIMULATE_QUOTA: "after-iter-3" })).toBe(false);
+    expect(r2.ok).toBe(true);
+    expect(applyQuotaSimulation(null, { iteration: 1, agent: "claude" }, { KJ_SIMULATE_QUOTA: "after-iter-1" })).toBe(false);
+  });
+
+  it("applyQuotaSimulation forces ok=false and prepends synthetic line", () => {
+    const env = { KJ_SIMULATE_QUOTA: "after-iter-2", KJ_SIMULATE_QUOTA_RESET: "2026-06-02T15:30:00Z" };
+    const r = { ok: true, result: { error: "previous noise" } };
+    expect(applyQuotaSimulation(r, { iteration: 2, agent: "claude" }, env)).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.result.error).toMatch(/weekly limit.*2026-06-02T15:30:00Z/i);
+    expect(r.result.error).toMatch(/previous noise/);
+  });
+
+  it("creates result object when missing", () => {
+    const r = { ok: true };
+    expect(applyQuotaSimulation(r, { iteration: 1, agent: "claude" }, { KJ_SIMULATE_QUOTA: "after-iter-1" })).toBe(true);
+    expect(r.result.error).toMatch(/weekly limit/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `KJ_SIMULATE_QUOTA=after-iter-<N>` — a testing/demo env var that injects a synthetic "weekly limit. resets at <ISO>" line into the next agent's stderr at a chosen iteration, without consuming real provider quota.

The existing `detectRateLimit` branch picks it up, the existing standby + Brain Recovery wiring takes over: session halts cleanly, gets persisted under `~/.karajan/standby/<sessionId>.json`, can be resumed via `kj standby list` / `kj standby resume --force`.

Use case: flat-rate subscribers (Claude Pro, Gemini Code Assist Standard, Codex sub tiers) almost never see the real limit line, so the hibernation/standby flow was untestable end-to-end.

## Wiring

Three call sites that already check `detectRateLimit`:
- `src/orchestrator/stages/coder-stage.js` — `runCoderStage` + `runRefactorerStage`
- `src/orchestrator/stages/reviewer-stage.js`

For reviewer, also propagates the synthetic line into `lastAttempt.result.error` because `detectRateLimit` reads from the most recent attempt of the fallback wrapper.

## Variables

| Env var | Required | Default | Meaning |
|---|---|---|---|
| `KJ_SIMULATE_QUOTA` | yes | — | `after-iter-<N>` — fire on iteration N |
| `KJ_SIMULATE_QUOTA_RESET` | no | `now + 1h` (ISO) | The `resets at <ISO>` timestamp |
| `KJ_SIMULATE_QUOTA_AGENT` | no | `claude` | `claude`, `codex`, `gemini`, or `any` |

## Safety

- No-op when `KJ_SIMULATE_QUOTA` is unset — safe to leave in production builds.
- Does NOT consume real provider quota.
- Synthetic line goes through the standby branch, not the rate-limit-with-fallback branch — single-provider hibernation demo.

## LOC budget

- Total delta sans docs: ~147 LOC (under 150 target, well under 200 hard).
- `docs/quota-simulation.md` excluded per the `docs/**/*.md` rule.

## Test plan

- [x] Unit tests for parser, message builder, threshold/agent filter, mutation behaviour, warn-once (7 tests passing)
- [ ] Manual smoke: `KJ_SIMULATE_QUOTA=after-iter-2 kj run "hello world CLI"` — verify session ends in standby and `kj standby list` finds it
- [ ] CI green (commitlint, shrink-budget, tests, coverage)

Card: KJC-TSK-0493