### PR TITLE
feat(telemetry): opt-in default + explicit wizard consent (KJC-TSK-0495)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,13 +351,36 @@ npm run validate      # Lint + test
 
 Issues and pull requests welcome. If something doesn't work as documented, [open an issue](https://github.com/manufosela/karajan-code/issues). That's the most useful contribution at this stage.
 
-## Telemetry
+## Privacy & telemetry
 
-Karajan collects anonymous usage statistics to improve the tool:
-version, OS, command used, pipeline duration and success rate.
-No code, task descriptions, or personal data is ever sent.
+**Telemetry is OFF by default.** The `kj init` wizard asks once, in your OS
+language, with a plain-text "yes / no" prompt:
 
-Opt out: set `telemetry: false` in `~/.karajan/kj.config.yml`
+> *Help improve Karajan by sending anonymous telemetry to the project?*
+> *(version, OS, commands, pipeline duration — no code, no tasks, no personal data)*
+
+Answer "yes" once and `telemetry: true` is persisted to `~/.karajan/kj.config.yml`.
+Anything else — undefined, missing key, `false`, fresh install with no wizard run —
+keeps it off. There is no hidden default-on path.
+
+### What gets sent (when enabled)
+
+Three event types, anonymous, no userID / email / IP collected by Karajan itself:
+
+| Event | When | Payload |
+|---|---|---|
+| `install` | first `kj init` | `version`, `os`, `node`, `ts` |
+| `cli_command` | each `kj <subcommand>` | `version`, `os`, `node`, `ts`, `command`, `duration_ms`, `exit_code` |
+| `pipeline_complete` | end of `kj run` | `version`, `os`, `node`, `ts`, `mode`, `agent`, `duration_s`, `success`, `taskType` |
+
+Endpoint: `https://karajan-code.web.app/api/telemetry` (POST, 3 s timeout, fire-and-forget).
+Implementation: [`src/utils/telemetry.js`](src/utils/telemetry.js).
+
+### Flip it later
+
+Open `~/.karajan/kj.config.yml`, set `telemetry: true` (opt in) or `telemetry: false` (opt out),
+save. Or re-run `kj init` and answer the prompt again. Set `KJ_DEBUG=1` to see telemetry
+errors on stderr (otherwise failures are silent — telemetry never blocks the pipeline).
 
 ## Recent releases
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -256,6 +256,37 @@ async function askBoardSecurity(wizard, config, logger) {
   logger.info(`  -> HU Board port: ${config.hu_board.port}`);
 }
 
+/**
+ * Explicit, opt-in telemetry consent. We do NOT inherit a "Karajan-installed
+ * users want to help" assumption — silence and missing config keys both mean
+ * "no". The prompt is rendered in the OS locale (EN/ES today; falls back to
+ * EN for everything else) so users see it in their own language even before
+ * they've set `config.language`. See src/utils/telemetry.js and the
+ * "Privacy & Telemetry" section of README.md for what gets sent.
+ */
+async function askTelemetry(wizard, config, logger) {
+  const locale = detectOsLocale();
+  const prompts = {
+    es: {
+      question: "¿Quieres ayudar a mejorar Karajan enviando telemetría anónima al proyecto?",
+      detail: "  (versión, OS, comandos, duración del pipeline — sin código, sin tareas, sin datos personales)",
+      enabled: "  -> Telemetría: activada (¡gracias!)",
+      disabled: "  -> Telemetría: desactivada",
+    },
+    en: {
+      question: "Help improve Karajan by sending anonymous telemetry to the project?",
+      detail: "  (version, OS, commands, pipeline duration — no code, no tasks, no personal data)",
+      enabled: "  -> Telemetry: enabled (thank you!)",
+      disabled: "  -> Telemetry: disabled",
+    },
+  };
+  const t = prompts[locale] || prompts.en;
+  logger.info(t.detail);
+  const enabled = await wizard.confirm(t.question, false);
+  config.telemetry = enabled;
+  logger.info(enabled ? t.enabled : t.disabled);
+}
+
 async function runWizard(config, logger) {
   const agents = await detectAvailableAgents();
   const available = agents.filter((a) => a.available);
@@ -317,6 +348,10 @@ async function runWizard(config, logger) {
       logger.info("HU Board security:");
       await askBoardSecurity(wizard, config, logger);
     }
+
+    logger.info("");
+    logger.info("Privacy:");
+    await askTelemetry(wizard, config, logger);
 
     logger.info("");
   } finally {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -196,7 +196,10 @@ const DEFAULTS = {
     // hook. Both default ON; flip to false to opt out without uninstalling.
     autoUpdate: { onCommit: true, onRun: true }
   },
-  telemetry: true,
+  // Opt-in. Set by the `kj init` wizard (explicit consent prompt in the OS
+  // locale). When the key is absent or false, no events are sent. See
+  // src/utils/telemetry.js and the Privacy & Telemetry section of README.md.
+  telemetry: false,
   guards: {
     output: {
       enabled: true,

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -48,12 +48,15 @@ export async function sendTelemetryEvent(eventName, data, config) {
 }
 
 /**
- * Check if telemetry is enabled (opt-out model).
- * Returns false only when the user explicitly sets telemetry: false.
+ * Check if telemetry is enabled (opt-in model).
+ *
+ * Returns true ONLY when the user explicitly answered "yes" in the
+ * `kj init` wizard and we persisted `telemetry: true` to their config.
+ * Anything else — undefined, null, missing key, false — disables sending.
  *
  * @param {object} [config] - Karajan config
  * @returns {boolean}
  */
 export function isTelemetryEnabled(config) {
-  return config?.telemetry !== false;
+  return config?.telemetry === true;
 }

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -14,25 +14,31 @@ describe("telemetry", () => {
     vi.restoreAllMocks();
   });
 
-  describe("isTelemetryEnabled", () => {
-    it("returns true when config is undefined", () => {
-      expect(isTelemetryEnabled(undefined)).toBe(true);
+  describe("isTelemetryEnabled (opt-in)", () => {
+    it("returns false when config is undefined", () => {
+      expect(isTelemetryEnabled(undefined)).toBe(false);
     });
 
-    it("returns true when config is null", () => {
-      expect(isTelemetryEnabled(null)).toBe(true);
+    it("returns false when config is null", () => {
+      expect(isTelemetryEnabled(null)).toBe(false);
     });
 
-    it("returns true when config has no telemetry key", () => {
-      expect(isTelemetryEnabled({})).toBe(true);
+    it("returns false when config has no telemetry key", () => {
+      expect(isTelemetryEnabled({})).toBe(false);
     });
 
-    it("returns true when telemetry is true", () => {
+    it("returns true only when telemetry is explicitly true", () => {
       expect(isTelemetryEnabled({ telemetry: true })).toBe(true);
     });
 
     it("returns false when telemetry is false", () => {
       expect(isTelemetryEnabled({ telemetry: false })).toBe(false);
+    });
+
+    it("returns false for truthy-but-not-strict-true values", () => {
+      // Guards against accidental `telemetry: 1` / `"true"` in YAML configs.
+      expect(isTelemetryEnabled({ telemetry: 1 })).toBe(false);
+      expect(isTelemetryEnabled({ telemetry: "true" })).toBe(false);
     });
   });
 
@@ -54,10 +60,16 @@ describe("telemetry", () => {
       expect(typeof body.ts).toBe("number");
     });
 
-    it("sends when config is undefined (opt-in by default)", async () => {
+    it("does NOT send when config is undefined (opt-in default)", async () => {
       await sendTelemetryEvent("test_event", { version: "1.0.0" });
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does NOT send when config lacks the telemetry key", async () => {
+      await sendTelemetryEvent("test_event", { version: "1.0.0" }, {});
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("skips when telemetry is false", async () => {


### PR DESCRIPTION
## Summary

Telemetry was shipping default-on with a silent fallback: `telemetry: true` in `defaults.js` and `isTelemetryEnabled` returning true for anything except an explicit `false`. A fresh install emitted events before the user had any chance to read the policy. The endpoint itself (`https://karajan-code.web.app/api/telemetry`) is currently 404, so nothing was actually being received — but the contract was wrong.

This PR flips it to **opt-in** and adds an explicit consent prompt to the `kj init` wizard.

### Changes

- `src/config/defaults.js`: `telemetry: true` → `telemetry: false` with a 3-line comment block explaining opt-in semantics.
- `src/utils/telemetry.js`: `isTelemetryEnabled` now `config?.telemetry === true` (strict). Guards against accidental truthy values like `1` or `"true"` in YAML.
- `src/commands/init.js`: new `askTelemetry(wizard, config, logger)` rendered in the OS locale (EN/ES today, falls back to EN), default no. Wired into `runWizard` after HU-Board security.
  - ES: "¿Quieres ayudar a mejorar Karajan enviando telemetría anónima al proyecto?"
  - EN: "Help improve Karajan by sending anonymous telemetry to the project?"
- `README.md`: section renamed to "Privacy & telemetry"; documents event payloads, endpoint, fire-and-forget behavior, `KJ_DEBUG=1`.
- `tests/telemetry.test.js`: flipped the opt-out assertions to opt-in + added strict-true guard. 15/15 passing.

### Net delta
`+95 / −19 = +76 LOC` — well under the 200 hard cap.

## Test plan

- [x] `npx vitest run tests/telemetry.test.js` → 15/15
- [x] `npx eslint` on touched files → clean
- [x] `import('./src/commands/init.js')` smoke-loads OK
- [ ] CI green
- [ ] Manual `kj init` run on a throwaway directory to confirm the locale-aware prompt fires and the answer persists to `kj.config.yml`

## Related

- Backend half (Firebase Function + Firestore) tracked as KJL-TSK-0035 — landing as a follow-up PR after this one merges.

Closes KJC-TSK-0495.