### PR TITLE
feat(telemetry): transparency — wizard preview + kj telemetry cmd (KJC-TSK-0496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Three event types, anonymous, no userID / email / IP collected by Karajan itself
 | Event | When | Payload |
 |---|---|---|
 | `install` | first `kj init` | `version`, `os`, `node`, `ts` |
-| `cli_command` | each `kj <subcommand>` | `version`, `os`, `node`, `ts`, `command`, `duration_ms`, `exit_code` |
+| `cli_command` | each `kj <subcommand>` | `version`, `os`, `node`, `ts`, `command` |
 | `pipeline_complete` | end of `kj run` | `version`, `os`, `node`, `ts`, `mode`, `agent`, `duration_s`, `success`, `taskType` |
 
 Endpoint: `https://karajan-code.web.app/api/telemetry` (POST, 3 s timeout, fire-and-forget).

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -13,6 +13,7 @@ import { webperfCommand } from "../commands/webperf.js";
 import { undoCommand } from "../commands/undo.js";
 import { syncCommand } from "../commands/sync.js";
 import { cleanCommand } from "../commands/clean.js";
+import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { withConfig } from "./_shared.js";
 
 /**
@@ -318,6 +319,27 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "sync", flags, async ({ config, logger }) => {
         await syncCommand({ config, logger, planId: flags.plan, json: flags.json });
+      });
+    });
+
+  // KJC-TSK-0496 — surface the exact telemetry payload without sending it,
+  // and report whether telemetry is currently enabled. Read-only inspection
+  // commands so users can audit the contract without grepping the source.
+  const telemetry = program.command("telemetry").description("Inspect what Karajan telemetry sends and whether it's enabled (never opens a socket)");
+  telemetry.command("preview")
+    .description("Print the exact JSON payload for every event type (install, cli_command, pipeline_complete) — no network call")
+    .option("--json", "Emit the full preview as JSON")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "telemetry:preview", flags, async ({ config, logger }) => {
+        await telemetryPreviewCommand({ config, logger, version: pkgVersion, json: Boolean(flags.json) });
+      });
+    });
+  telemetry.command("status")
+    .description("Report whether telemetry is enabled and where the endpoint lives")
+    .option("--json", "Emit the status as JSON")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "telemetry:status", flags, async ({ config, logger }) => {
+        await telemetryStatusCommand({ config, logger, json: Boolean(flags.json) });
       });
     });
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -12,6 +12,7 @@ import { createWizard, isTTY } from "../utils/wizard.js";
 import { runCommand } from "../utils/process.js";
 import { getInstallCommand } from "../utils/os-detect.js";
 import { detectOsLocale, SUPPORTED_LANGUAGES } from "../utils/locale.js";
+import { buildTelemetryPayload, sendTelemetryEvent } from "../utils/telemetry.js";
 import { detectRtk } from "../utils/rtk-detect.js";
 import { installRtk } from "../utils/rtk-install.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
@@ -270,18 +271,23 @@ async function askTelemetry(wizard, config, logger) {
     es: {
       question: "¿Quieres ayudar a mejorar Karajan enviando telemetría anónima al proyecto?",
       detail: "  (versión, OS, comandos, duración del pipeline — sin código, sin tareas, sin datos personales)",
+      previewIntro: "  Ejemplo del payload exacto que se enviaría al ejecutar `kj run` (puedes inspeccionar más con `kj telemetry preview`):",
       enabled: "  -> Telemetría: activada (¡gracias!)",
       disabled: "  -> Telemetría: desactivada",
     },
     en: {
       question: "Help improve Karajan by sending anonymous telemetry to the project?",
       detail: "  (version, OS, commands, pipeline duration — no code, no tasks, no personal data)",
+      previewIntro: "  Example of the exact payload that would be sent when you run `kj run` (inspect more with `kj telemetry preview`):",
       enabled: "  -> Telemetry: enabled (thank you!)",
       disabled: "  -> Telemetry: disabled",
     },
   };
   const t = prompts[locale] || prompts.en;
   logger.info(t.detail);
+  const example = buildTelemetryPayload("cli_command", { version: "x.y.z", command: "run" });
+  logger.info(t.previewIntro);
+  logger.info(`    ${JSON.stringify(example)}`);
   const enabled = await wizard.confirm(t.question, false);
   config.telemetry = enabled;
   logger.info(enabled ? t.enabled : t.disabled);
@@ -770,7 +776,6 @@ export async function initCommand({ logger, flags = {} }) {
   await writeInitConfig(configPath, config);
 
   // Telemetry: anonymous install event (non-blocking)
-  const { sendTelemetryEvent } = await import("../utils/telemetry.js");
   const { readFileSync } = await import("node:fs");
   const { fileURLToPath } = await import("node:url");
   try {

--- a/src/commands/telemetry.js
+++ b/src/commands/telemetry.js
@@ -1,0 +1,70 @@
+import { TELEMETRY_ENDPOINT, buildTelemetryPayload, isTelemetryEnabled } from "../utils/telemetry.js";
+
+/**
+ * Render the exact payload that would be POSTed for every event type.
+ *
+ * Read-only by design: this never opens a socket. It exists so users
+ * can inspect what telemetry sends before (or after) opting in,
+ * without grepping the source. The contract here MUST stay in sync
+ * with the producers in src/cli/_shared.js and the pipeline emitter
+ * in src/orchestrator/flow-runner.js — if a new field appears there,
+ * mirror it in the example below.
+ */
+function buildPreview(version) {
+  const v = version || "x.y.z";
+  return {
+    endpoint: TELEMETRY_ENDPOINT,
+    events: [
+      buildTelemetryPayload("install", { version: v }),
+      buildTelemetryPayload("cli_command", { version: v, command: "run" }),
+      buildTelemetryPayload("pipeline_complete", {
+        version: v,
+        mode: "standard",
+        agent: "claude",
+        duration_s: 42,
+        success: true,
+        taskType: "feature"
+      })
+    ]
+  };
+}
+
+export async function telemetryPreviewCommand({ config, logger, version, json }) {
+  const preview = buildPreview(version);
+  if (json) {
+    logger.info(JSON.stringify(preview, null, 2));
+    return preview;
+  }
+  const enabled = isTelemetryEnabled(config);
+  logger.info(`Telemetry endpoint: ${preview.endpoint}`);
+  logger.info(`Telemetry enabled:  ${enabled ? "yes" : "no"}`);
+  logger.info("");
+  logger.info("Exact payloads that would be POSTed (one per event type):");
+  logger.info("");
+  for (const payload of preview.events) {
+    logger.info(`  [${payload.event}]`);
+    logger.info(`    ${JSON.stringify(payload)}`);
+    logger.info("");
+  }
+  logger.info("No data was sent — `kj telemetry preview` never opens a socket.");
+  return preview;
+}
+
+export async function telemetryStatusCommand({ config, logger, json }) {
+  const enabled = isTelemetryEnabled(config);
+  const report = {
+    enabled,
+    endpoint: TELEMETRY_ENDPOINT,
+    flipHint: enabled
+      ? "Set `telemetry: false` in ~/.karajan/kj.config.yml (or re-run `kj init`) to turn it off."
+      : "Set `telemetry: true` in ~/.karajan/kj.config.yml (or re-run `kj init`) to turn it on."
+  };
+  if (json) {
+    logger.info(JSON.stringify(report, null, 2));
+    return report;
+  }
+  logger.info(`Telemetry: ${enabled ? "enabled" : "disabled"}`);
+  logger.info(`Endpoint:  ${report.endpoint}`);
+  logger.info(report.flipHint);
+  return report;
+}

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -1,4 +1,30 @@
-const TELEMETRY_ENDPOINT = "https://karajan-code.web.app/api/telemetry";
+export const TELEMETRY_ENDPOINT = "https://karajan-code.web.app/api/telemetry";
+
+/**
+ * Build the exact JSON payload that would be POSTed for an event.
+ * Pure function: deterministic given (eventName, data) — exposed so
+ * `kj telemetry preview` can render the literal bytes the backend
+ * receives without performing any network call.
+ *
+ * The `data.version` field is folded into `v`; the rest of the
+ * event-specific keys ride through `...data` after the common ones,
+ * matching the order sent over the wire.
+ *
+ * @param {string} eventName
+ * @param {object} [data]
+ * @returns {object}
+ */
+export function buildTelemetryPayload(eventName, data = {}) {
+  const { version, ...rest } = data;
+  return {
+    event: eventName,
+    v: version || "unknown",
+    os: process.platform,
+    node: process.version,
+    ts: Date.now(),
+    ...rest
+  };
+}
 
 /**
  * Send an anonymous telemetry event. Non-blocking, fire-and-forget.
@@ -12,14 +38,7 @@ export async function sendTelemetryEvent(eventName, data, config) {
   if (!isTelemetryEnabled(config)) return;
 
   try {
-    const payload = {
-      event: eventName,
-      v: data.version || "unknown",
-      os: process.platform,
-      node: process.version,
-      ts: Date.now(),
-      ...data
-    };
+    const payload = buildTelemetryPayload(eventName, data);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
     try {

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendTelemetryEvent, isTelemetryEnabled } from "../src/utils/telemetry.js";
+import { sendTelemetryEvent, isTelemetryEnabled, buildTelemetryPayload, TELEMETRY_ENDPOINT } from "../src/utils/telemetry.js";
 
 describe("telemetry", () => {
   let originalFetch;
@@ -128,6 +128,41 @@ describe("telemetry", () => {
 
       const opts = global.fetch.mock.calls[0][1];
       expect(opts.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  describe("buildTelemetryPayload (KJC-TSK-0496)", () => {
+    it("exports the canonical endpoint", () => {
+      expect(TELEMETRY_ENDPOINT).toBe("https://karajan-code.web.app/api/telemetry");
+    });
+
+    it("produces the same shape sendTelemetryEvent posts", () => {
+      const payload = buildTelemetryPayload("cli_command", { version: "2.0.0", command: "run" });
+      expect(payload.event).toBe("cli_command");
+      expect(payload.v).toBe("2.0.0");
+      expect(payload.os).toBe(process.platform);
+      expect(payload.node).toBe(process.version);
+      expect(typeof payload.ts).toBe("number");
+      expect(payload.command).toBe("run");
+    });
+
+    it("defaults v to 'unknown' when version missing", () => {
+      const payload = buildTelemetryPayload("install", {});
+      expect(payload.v).toBe("unknown");
+    });
+
+    it("never includes a raw `version` key (it is folded into `v`)", () => {
+      const payload = buildTelemetryPayload("install", { version: "3.0.0" });
+      expect(payload).not.toHaveProperty("version");
+      expect(payload.v).toBe("3.0.0");
+    });
+
+    it("is pure: matches the body actually sent", async () => {
+      const preview = buildTelemetryPayload("test_event", { version: "1.0.0", extra: 1 });
+      await sendTelemetryEvent("test_event", { version: "1.0.0", extra: 1 }, { telemetry: true });
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      // ts will differ by a few ms; everything else must be identical.
+      expect({ ...preview, ts: 0 }).toEqual({ ...body, ts: 0 });
     });
   });
 });


### PR DESCRIPTION
## Summary
- README: drop `duration_ms`/`exit_code` from `cli_command` spec (they were never sent)
- Wizard preview: render literal payload during `kj init` opt-in flow
- New `kj telemetry preview` / `kj telemetry status` — read-only, no socket
- Refactor: `buildTelemetryPayload` pure builder + `TELEMETRY_ENDPOINT` exported

Replaces #914 (closed for commitlint body-max-line-length on a stale commit).

## Why
Users opt in without seeing the payload. Transparency means showing the exact bytes before consent **and** on demand afterwards.

## Test plan
- [x] 20/20 `tests/telemetry.test.js` green locally
- [x] Architecture `tests/architecture/dynamic-imports.test.js` — budget stays at 167 (static imports in `init.js`)
- [x] CLI smoke: `node ./bin/kj.js telemetry preview` renders all 3 event types with no network call