### PR TITLE
feat(doctor): hw-gpu detection follow-up (KJC-TSK-0497)

### DIFF
--- a/src/checks/hardware.js
+++ b/src/checks/hardware.js
@@ -4,12 +4,14 @@
 
 import os from "node:os";
 import { statfs } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { STRATEGY } from "./types.js";
 
 const RAM_WARN_GB = 4;
 const RAM_RECOMMENDED_GB = 8;
 const DISK_WARN_GB = 5;
 const DISK_RECOMMENDED_GB = 20;
+const GPU_DETECT_TIMEOUT_MS = 1500;
 
 const bytesToGb = (bytes) => Math.round((bytes / 1024 ** 3) * 10) / 10;
 const info = (detail, extra) => ({ ok: true, severity: "info", detail, extra });
@@ -79,8 +81,70 @@ function createDiskCheck() {
   };
 }
 
-export function getHardwareChecks() {
-  return [createRamCheck(), createCpuCheck(), createDiskCheck()];
+function runGpuCommand(cmd, args) {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    try {
+      const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "ignore"] });
+      const timer = setTimeout(() => {
+        try { child.kill("SIGKILL"); } catch { /* noop */ }
+        finish(null);
+      }, GPU_DETECT_TIMEOUT_MS);
+      child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+      child.on("error", () => { clearTimeout(timer); finish(null); });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        finish(code === 0 ? stdout : null);
+      });
+    } catch {
+      finish(null);
+    }
+  });
 }
 
-export const __test = { RAM_WARN_GB, RAM_RECOMMENDED_GB, DISK_WARN_GB, DISK_RECOMMENDED_GB, bytesToGb };
+async function detectGpu() {
+  const platform = process.platform;
+  if (platform === "linux" || platform === "win32") {
+    const out = await runGpuCommand("nvidia-smi", ["--query-gpu=name", "--format=csv,noheader"]);
+    const model = out?.split("\n").map((l) => l.trim()).find(Boolean);
+    if (model) return { vendor: "NVIDIA", model };
+    return null;
+  }
+  if (platform === "darwin") {
+    const out = await runGpuCommand("system_profiler", ["SPDisplaysDataType"]);
+    if (!out) return null;
+    const match = out.match(/Chipset Model:\s*(.+)/);
+    if (!match) return null;
+    const model = match[1].trim();
+    const vendor = /Apple/i.test(model) ? "Apple" : /AMD|Radeon/i.test(model) ? "AMD" : /Intel/i.test(model) ? "Intel" : "GPU";
+    return { vendor, model };
+  }
+  return null;
+}
+
+function createGpuCheck() {
+  return {
+    name: "hw-gpu",
+    label: "GPU",
+    strategy: STRATEGY.NONE,
+    async detect() {
+      const gpu = await detectGpu();
+      if (!gpu) {
+        return info("No discrete GPU detected (CPU-only)", { detected: false });
+      }
+      return info(`${gpu.vendor} ${gpu.model}`, { detected: true, vendor: gpu.vendor, model: gpu.model });
+    },
+  };
+}
+
+export function getHardwareChecks() {
+  return [createRamCheck(), createCpuCheck(), createDiskCheck(), createGpuCheck()];
+}
+
+export const __test = { RAM_WARN_GB, RAM_RECOMMENDED_GB, DISK_WARN_GB, DISK_RECOMMENDED_GB, GPU_DETECT_TIMEOUT_MS, bytesToGb, detectGpu };

--- a/tests/checks/hardware.test.js
+++ b/tests/checks/hardware.test.js
@@ -1,11 +1,26 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import os from "node:os";
+import { EventEmitter } from "node:events";
 
 const statfsMock = vi.fn();
+const spawnMock = vi.fn();
 vi.mock("node:fs/promises", () => ({ statfs: (...a) => statfsMock(...a) }));
+vi.mock("node:child_process", () => ({ spawn: (...a) => spawnMock(...a) }));
 
 const { getHardwareChecks, __test } = await import("../../src/checks/hardware.js");
 const { RAM_WARN_GB, RAM_RECOMMENDED_GB, DISK_WARN_GB, bytesToGb } = __test;
+
+function fakeChild({ stdout = "", exitCode = 0, error } = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.kill = () => {};
+  setImmediate(() => {
+    if (error) { child.emit("error", error); return; }
+    if (stdout) child.stdout.emit("data", stdout);
+    child.emit("close", exitCode);
+  });
+  return child;
+}
 
 const byName = () => Object.fromEntries(getHardwareChecks().map((c) => [c.name, c]));
 const GB = 1024 ** 3;
@@ -14,6 +29,7 @@ describe("checks/hardware", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     statfsMock.mockReset();
+    spawnMock.mockReset();
   });
 
   it("bytesToGb rounds to one decimal", () => {
@@ -69,7 +85,34 @@ describe("checks/hardware", () => {
     expect(r.detail).toMatch(/Cannot read/i);
   });
 
-  it("getHardwareChecks returns the three advisory checks", () => {
-    expect(getHardwareChecks().map((c) => c.name).sort()).toEqual(["hw-cpu", "hw-disk", "hw-ram"]);
+  it("hw-gpu reports vendor and model when nvidia-smi succeeds", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    spawnMock.mockImplementation(() => fakeChild({ stdout: "NVIDIA RTX 3050 Ti\n", exitCode: 0 }));
+    const r = await byName()["hw-gpu"].detect({ config: {} });
+    expect(r.ok).toBe(true);
+    expect(r.extra.detected).toBe(true);
+    expect(r.extra.vendor).toBe("NVIDIA");
+    expect(r.detail).toMatch(/NVIDIA RTX 3050 Ti/);
+  });
+
+  it("hw-gpu falls back gracefully when no GPU is detected", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    spawnMock.mockImplementation(() => fakeChild({ stdout: "", exitCode: 127 }));
+    const r = await byName()["hw-gpu"].detect({ config: {} });
+    expect(r.ok).toBe(true);
+    expect(r.extra.detected).toBe(false);
+    expect(r.detail).toMatch(/No discrete GPU/i);
+  });
+
+  it("hw-gpu does not throw when spawn fails", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    spawnMock.mockImplementation(() => fakeChild({ error: new Error("ENOENT") }));
+    const r = await byName()["hw-gpu"].detect({ config: {} });
+    expect(r.ok).toBe(true);
+    expect(r.extra.detected).toBe(false);
+  });
+
+  it("getHardwareChecks returns the four advisory checks", () => {
+    expect(getHardwareChecks().map((c) => c.name).sort()).toEqual(["hw-cpu", "hw-disk", "hw-gpu", "hw-ram"]);
   });
 });


### PR DESCRIPTION
## Summary
Completes the acceptance criteria for KJC-TSK-0497 by adding the missing `hw-gpu` advisory check to `kj doctor`.

- New `hw-gpu` check: spawns `nvidia-smi` on linux/win32 and `system_profiler SPDisplaysDataType` on darwin
- Hard 1.5s timeout with SIGKILL fallback — never throws, never blocks the doctor pipeline
- Reports vendor + model when detected (e.g. \`NVIDIA RTX 3050 Ti\`), info-only \`No discrete GPU detected (CPU-only)\` otherwise
- Three new tests cover OK detection, no-GPU fallback and spawn error

## Diff
111 LOC added (well under the 200-LOC budget). Splits the GPU work cleanly off PR #916.

## Test plan
- [x] \`npx vitest run tests/checks/hardware.test.js\` — 11/11 passing
- [ ] CI green
- [ ] \`kj doctor --check-only\` lists \`hw-gpu\` alongside ram/cpu/disk