### PR TITLE
chore(deps): bump chokidar 4 → 5 (KJC-TSK-0489)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/parser": "^7.29.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^11.0.0",
-        "chokidar": "^4.0.0",
+        "chokidar": "^5.0.0",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
         "express": "^5.1.0",
@@ -29,6 +29,7 @@
       "bin": {
         "karajan-mcp": "bin/karajan-mcp.js",
         "kj": "bin/kj.js",
+        "kj-rag-mcp": "bin/kj-rag-mcp.js",
         "kj-tail": "bin/kj-tail"
       },
       "devDependencies": {
@@ -2886,15 +2887,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6323,12 +6324,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/parser": "^7.29.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^11.0.0",
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
     "express": "^5.1.0",

--- a/packages/hu-board/package-lock.json
+++ b/packages/hu-board/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
-        "chokidar": "^4.0.0",
+        "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
         "helmet": "^8.1.0"
@@ -713,15 +713,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2106,12 +2106,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.0.0",
-    "chokidar": "^4.0.0",
+    "chokidar": "^5.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.0",
     "helmet": "^8.1.0"


### PR DESCRIPTION
## Summary
- Bump `chokidar` from `^4.0.0` to `^5.0.0` in both root and `packages/hu-board`
- Chokidar v5 is ESM-only and requires Node ≥20.19 — both already met by this repo (`type: module`, `engines.node >=20.19.0`)
- No source changes needed; existing imports (`import chokidar from "chokidar"` in `src/rag/watcher.js` and `import { watch } from "chokidar"` in `packages/hu-board/src/sync.js`) work unchanged with v5

## Verification
- 5410/5410 tests passing locally (`npm test`)
- `npm ls chokidar` shows v5 in both workspaces
- Export-shape sanity check confirms `default.watch` and named `watch` still exist

## Test plan
- [x] Local full test suite passes
- [ ] CI green
- [ ] Smoke test of `kj rag watch` post-merge