### PR TITLE
chore(deps): bump engines.node 20.19 → 22.22.1 (KJC-TSK-0500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,17 @@ permissions:
   contents: read
 
 jobs:
-  # node --check runs on 20/22 to catch parse-time syntax/import bugs.
-  # Node 18 was dropped 2026-04-30 (audit cleanup): Node 18 LTS hit EOL on
-  # 2025-04-30 and engines.node is now >=20.10.0.
+  # node --check catches parse-time syntax/import bugs. Node 20 was dropped
+  # in v3.0.0 (KJC-TSK-0500, 2026-06-03) when engines.node moved to >=22.22.1
+  # — Node 20 reaches EOL on 2026-04-30 and three deps (lint-staged 17,
+  # commander 15, better-sqlite3 12.10+) required the bump.
   syntax:
     name: Syntax (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Checkout
@@ -86,16 +87,15 @@ jobs:
       - name: Format (Prettier --check)
         run: npm run format:check
 
-  # ESLint runs on the same Node matrix as syntax (20/22). Pre-2026-04-30
-  # this used to mention "Node 18 users still get parse-time guarantees" —
-  # no longer relevant now that engines.node = >=20.10.0.
+  # ESLint runs on the same Node matrix as syntax (22/24). engines.node
+  # is now >=22.22.1 (v3.0.0, KJC-TSK-0500).
   lint:
     name: Lint (ESLint, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Checkout
@@ -113,15 +113,14 @@ jobs:
       - name: Lint (ESLint — no-undef + import resolution)
         run: npm run lint
 
-  # Tests run on Node 20/22 — the engine floor is now also >=20.10.0
-  # so this matrix matches the supported runtime range.
+  # Tests run on Node 22/24 — engines.node floor is now >=22.22.1 (v3.0.0).
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [20]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v5
@@ -73,7 +73,7 @@ jobs:
           echo "Templates OK"
 
   e2e-windows:
-    name: E2E (windows-latest, Node 20)
+    name: E2E (windows-latest, Node 22)
     runs-on: windows-latest
 
     steps:
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Pack and install globally
         shell: pwsh

--- a/.github/workflows/injection-guard.yml
+++ b/.github/workflows/injection-guard.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Get PR diff
         # KJC-BUG-0072 — never interpolate ${{ github.* }} directly inside a

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://www.npmjs.com/package/karajan-code"><img src="https://img.shields.io/npm/dw/karajan-code.svg" alt="npm downloads"></a>
   <a href="https://github.com/manufosela/karajan-code/actions"><img src="https://github.com/manufosela/karajan-code/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg" alt="Node.js"></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen.svg" alt="Node.js"></a>
   <a href="https://github.com/manufosela/homebrew-tap"><img src="https://img.shields.io/badge/homebrew-tap-orange.svg" alt="Homebrew"></a>
 </p>
 
@@ -22,6 +22,8 @@
 </p>
 
 ---
+
+> **⚠ v3.0.0 — BREAKING:** Node 22+ required. Karajan v3 drops Node 20 (EOL 2026-04-30) and aligns with the Active LTS line. Three deps forced the bump: `lint-staged 17`, `commander 15`, and `better-sqlite3 12.10+` (Node 20 prebuilds gone). Migration: `nvm install 22 && nvm use 22`. No public API changes if you were already on Node 22. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js ≥ 20.10
+- Node.js ≥ 22.22 (Karajan v3.0.0 dropped Node 20 — see CHANGELOG for migration notes)
 - Git
 - At least one AI CLI installed: `claude`, `codex`, `gemini`, `aider`, or `opencode`
 - (Optional) Docker for local SonarQube

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -2,7 +2,7 @@
 
 ## Requisitos previos
 
-- Node.js ≥ 20.10
+- Node.js ≥ 22.22 (Karajan v3.0.0 elimina soporte de Node 20 — ver CHANGELOG para notas de migración)
 - Git
 - Al menos una CLI de IA instalada: `claude`, `codex`, `gemini`, `aider` u `opencode`
 - (Opcional) Docker para SonarQube local

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "vitest": "^4.1.8"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.22.1"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cli"
   ],
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.22.1"
   },
   "imports": {
     "#utils/*": "./src/utils/*",

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -4,6 +4,9 @@
   "description": "HU Story Board dashboard for Karajan Code",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=22.22.1"
+  },
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",

--- a/src/checks/node.js
+++ b/src/checks/node.js
@@ -1,18 +1,17 @@
 /**
- * Node.js runtime version check. Requires Node >= 18 — the LTS baseline that
- * ships every runtime feature Karajan needs: ESM support, `fetch` (built-in),
- * `structuredClone` (17+), `AbortSignal.timeout` (17.3+), and
- * `Array.prototype.findLast` / `findLastIndex` (18+). Nothing in the runtime
- * code path uses Node 20+ APIs (no `Promise.withResolvers`, no
- * `Object.groupBy`, no `Set.prototype.union/intersection`, no
- * `Array.prototype.toSorted`). Strategy: manual — we cannot auto-upgrade the
- * runtime. Users on older Node get a clear upgrade instruction with nvm + brew
- * hints instead of a silent runtime crash.
+ * Node.js runtime version check. Requires Node >= 22 — the Active LTS
+ * baseline since Karajan v3.0.0 (KJC-TSK-0500, 2026-06-03). Node 20 was
+ * dropped because (a) Node 20 reaches EOL on 2026-04-30 and (b) three
+ * dependencies forced the bump: lint-staged 17 needs ≥22.22.1, commander
+ * 15 needs ≥22.12.0, and better-sqlite3 v12.10+ dropped Node 20 prebuilds.
+ * Strategy: manual — we cannot auto-upgrade the runtime. Users on older
+ * Node get a clear upgrade instruction with nvm + brew hints instead of a
+ * silent runtime crash.
  */
 
 import { STRATEGY } from "./types.js";
 
-export const MIN_NODE_MAJOR = 18;
+export const MIN_NODE_MAJOR = 22;
 
 /**
  * Accepts a version string in the form "v20.12.1" or "20.12.1" and returns

--- a/tests/checks/auto-remediation-e2e.test.js
+++ b/tests/checks/auto-remediation-e2e.test.js
@@ -154,26 +154,26 @@ describe("auto-remediation end-to-end", () => {
   });
 
   describe("Node version manual-only", () => {
-    it("Node 16 → FAIL with upgrade hint, remediation not attempted", async () => {
+    it("Node 20 → FAIL with upgrade hint, remediation not attempted (v3.0.0 dropped Node 20)", async () => {
       const { createNodeVersionCheck } = await import("../../src/checks/node.js");
-      const check = createNodeVersionCheck({ version: "v16.20.0" });
+      const check = createNodeVersionCheck({ version: "v20.18.0" });
       const report = await runChecks([check], { config: {} });
 
       expect(report.checks[0].status).toBe(STATUS.FAIL);
       expect(report.checks[0].fix).toContain("nvm install");
     });
 
-    it("Node 18 → OK (minimum supported baseline)", async () => {
+    it("Node 22 → OK (current minimum baseline since v3.0.0)", async () => {
       const { createNodeVersionCheck } = await import("../../src/checks/node.js");
-      const check = createNodeVersionCheck({ version: "v18.20.4" });
+      const check = createNodeVersionCheck({ version: "v22.22.1" });
       const report = await runChecks([check], { config: {} });
 
       expect(report.checks[0].status).toBe(STATUS.OK);
     });
 
-    it("Node 22 → OK", async () => {
+    it("Node 24 → OK", async () => {
       const { createNodeVersionCheck } = await import("../../src/checks/node.js");
-      const check = createNodeVersionCheck({ version: "v22.0.0" });
+      const check = createNodeVersionCheck({ version: "v24.0.0" });
       const report = await runChecks([check], { config: {} });
 
       expect(report.checks[0].status).toBe(STATUS.OK);

--- a/tests/checks/node.test.js
+++ b/tests/checks/node.test.js
@@ -15,19 +15,19 @@ describe("checks/node-version", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("passes for Node 18 (the current minimum baseline)", async () => {
-    const check = createNodeVersionCheck({ version: "v18.20.4" });
+  it("passes for Node 22 (the current minimum baseline since v3.0.0)", async () => {
+    const check = createNodeVersionCheck({ version: "v22.22.1" });
     const result = await check.detect({ config: {} });
     expect(result.ok).toBe(true);
   });
 
   it("fails for Node older than the required major", async () => {
-    const check = createNodeVersionCheck({ version: "v16.20.0" });
+    const check = createNodeVersionCheck({ version: "v20.18.0" });
     const result = await check.detect({ config: {} });
     expect(result.ok).toBe(false);
     expect(result.severity).toBe("fail");
     expect(result.fix).toContain("nvm install");
-    expect(result.extra.detected.major).toBe(16);
+    expect(result.extra.detected.major).toBe(20);
   });
 
   it("fails cleanly for an unparseable version", async () => {


### PR DESCRIPTION
## Summary

PR1 of the Karajan v3.0.0 chain (KJC-TSK-0500). Raises `engines.node` from `>=20.19.0` to `>=22.22.1`, which is the new baseline for Karajan v3.

## Why v3 (BREAKING)

Three concrete drivers:
- **Node 20 reaches EOL on 2026-04-30** — staying on a soon-to-be-unsupported runtime is a security/regression liability.
- **lint-staged 17** (next major in our deps) requires `>=22.22.1`.
- **commander 15** requires `>=22.12.0`.
- **better-sqlite3 v12.10+** dropped Node 20 prebuilds, forcing source compilation for anyone on Node 20.

Pinning to `>=22.22.1` is the deliberate floor so PR2/PR3/PR4 land cleanly on the same baseline.

## Scope of this PR

- `package.json` + `packages/hu-board/package.json` — `engines.node` bump
- CI workflows (`ci.yml`, `e2e.yml`, `injection-guard.yml`) — matrix moves from `20.x/22.x` to `22.x/24.x`
- `src/checks/node.js` — `MIN_NODE_MAJOR = 18` → `22`, comment block fully rewritten with the v3.0.0 rationale
- Tests (`tests/checks/node.test.js`, `tests/checks/auto-remediation-e2e.test.js`) — fixtures updated to use Node 20 as the rejected baseline and Node 22.22.1 as the accepted one
- `README.md` — Node badge updated + v3.0.0 BREAKING banner at the top
- `docs/GETTING-STARTED.md` (EN + ES) — prereqs line bumped

Net delta: **+43 / -40 lines** across 12 files, well under the 200-line PR budget.

## Test plan

- [x] `npm install` → lockfile refreshed
- [x] `npx vitest run tests/checks/auto-remediation-e2e.test.js tests/checks/node.test.js` → 19/19 passing
- [x] Full suite — **5410/5410 passing** locally
- [ ] CI green on matrix `[22.x, 24.x]`
- [ ] Squash-merge once green; sync local main

## Follow-ups (the v3.0.0 chain)

- PR2 — `lint-staged 16 → 17` (KJC-TSK-0491)
- PR3 — `commander 14 → 15` (KJC-TSK-0490)
- PR4 — `better-sqlite3 11 → 12` (KJC-TSK-0488)
- PR5 — CHANGELOG with full BREAKING explanation + version bump 2.34.0 → 3.0.0 + README sizing/HW table