### PR TITLE
chore(deps): bump commander 14 → 15 (KJC-TSK-0490)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^11.0.0",
         "chokidar": "^5.0.0",
-        "commander": "^14.0.0",
+        "commander": "^15.0.0",
         "execa": "^9.6.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
@@ -2980,12 +2980,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/comment-parser": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^11.0.0",
     "chokidar": "^5.0.0",
-    "commander": "^14.0.0",
+    "commander": "^15.0.0",
     "execa": "^9.6.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.0",


### PR DESCRIPTION
## Summary

PR3 of the Karajan v3.0.0 chain. Bumps `commander` from `^14.0.0` to `^15.0.0`. Its new Node floor (`>=22.12`) is comfortably below the v3.0.0 baseline (`>=22.22.1`) shipped in #920.

## Why

- commander 15 is **ESM-only** — Karajan is already `"type": "module"`, so this is a no-op.
- The only `--no-*` default-behavior tweak in v15 does not hit any flag we define.
- Together with #921 (lint-staged 17) and the upcoming better-sqlite3 12 bump, this is one of the three majors that were blocked on the old Node 20 baseline.

## Test plan

- [x] `node bin/kj.js --help` shows all 20+ subcommands cleanly (run, audit, rag, board, init, doctor, scan, ollama, plan, skills, roles, agents, discover, ...)
- [x] `node bin/kj.js --version` returns `2.34.0`
- [x] `node bin/kj.js run --help`, `audit --help`, `rag --help`, `board --help` all parse without errors
- [x] CLI test suite: `vitest tests/cli` → 77/77 green
- [ ] CI green on `[22.x, 24.x]`

Net delta: 2 files (`package.json` + lock).