### PR TITLE
chore(deps): bump better-sqlite3 11 → 12 (KJC-TSK-0488)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",
         "commander": "^15.0.0",
         "execa": "^9.6.0",
@@ -2717,14 +2717,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@babel/parser": "^7.29.7",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
     "commander": "^15.0.0",
     "execa": "^9.6.0",

--- a/packages/hu-board/package-lock.json
+++ b/packages/hu-board/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@karajan/hu-board",
       "version": "1.0.0",
       "dependencies": {
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
@@ -17,6 +17,9 @@
       "devDependencies": {
         "supertest": "^7.1.0",
         "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.22.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -586,14 +589,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.0",


### PR DESCRIPTION
## Summary

PR4 of the v3.0.0 dependency chain. Bumps **better-sqlite3** from `^11.0.0` to `^12.10.0` in both the root and `packages/hu-board/`.

Unblocked by PR1 (#920) which set `engines.node >=22.22.1` — better-sqlite3 v12.10.0 drops Node 20 prebuilds, so we needed the runtime floor in place first.

## What changes

- `package.json`: `better-sqlite3` `^11.0.0` → `^12.10.0`
- `packages/hu-board/package.json`: same bump
- `package-lock.json`: regenerated

## Why

- **v12.0.0** (May 2025): drops Node 18 + EOL Electron 26/27/28 → no impact (we already require Node 22+).
- **v12.10.0** (Apr 2026): drops Node 20 prebuilds, adds Node 26 prebuilds, ships SQLite 3.53.1. With Karajan v3.0.0 mandating Node ≥22.22.1, we get clean native prebuilds across `linux-x64`, `darwin-arm64`, `win-x64` for both `kj` and the HU Board SEA binary.
- **No API changes** between v11 and v12.10 — same `better-sqlite3` surface (`new Database(...)`, `prepare()`, `run()`, `all()`, `get()`, `exec()`, transactions).

## Test plan

- [x] `npm install` clean — better-sqlite3 12.10.0 prebuild downloaded for linux-x64
- [x] In-memory smoke test: `CREATE TABLE` + `INSERT` + `SELECT` round-trip green
- [x] `vitest run tests/board tests/hu-board` → **60/60** passing across 11 test files
- [ ] CI green on Node 22.x and 24.x matrix
- [ ] shrink-budget gate ≤200 LOC (3 file lines)

## Chain context

- PR1 #920 — engines.node ≥22.22.1 ✅ merged
- PR2 #921 — drop node-20 from CI matrices ✅ merged
- PR3 #922 — commander 14 → 15 ✅ merged
- **PR4 (this PR)** — better-sqlite3 11 → 12 ← *we are here*
- PR5 — v3.0.0 release cut (CHANGELOG + version bump + tag + npm publish)