### PR TITLE
docs: README footprint & hardware requirements section (KJC-TSK-0202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,46 @@ None of these are required. Karajan auto-skips any scanner that isn't installed,
 
 Skip any per-run with `--no-sonar`, `--no-osv`, `--no-semgrep`. See [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md#optional-scanners--kj-audit--kj-webperf) for full table.
 
+## Footprint & hardware requirements
+
+Karajan ships as **layers you opt into**. The base CLI is tiny (~5 MB). Heavier pieces — Ollama for local RAG, SonarQube for static analysis, the `qmd` model cache for global semantic search — are only pulled if you ask for them. None of them are pulled during `npm install`.
+
+### What lives where
+
+| Layer | Size | When you pay it | Notes |
+| --- | --- | --- | --- |
+| `karajan-code` npm tarball | 5.2 MB / 555 files | Always | The CLI itself |
+| `node_modules/` (global) | ~208 MB | After `npm install -g karajan-code` | Standard for any Node global; SEA binary skips it |
+| `~/.karajan/` (state) | ~40 MB typical | After first `kj run` | Sessions, plans, audit history, HU board DB. `kj clean` prunes it |
+| Ollama Docker image | 6.55 GB | If you use the **local** RAG embedder (default since v2.26) | Auto-pulled in the background on first `kj rag index` (~5 min) |
+| Ollama embedding model | ~260 MB | First `kj rag index` | `nomic-embed-text` by default; lives inside the Ollama container |
+| SonarQube Docker image | 1.47 GB | If you enable Sonar in `kj init` | Optional; `kj audit` runs fine without it |
+| `qmd` model cache | ~2.2 GB | If you use `qmd query` for global semantic search | Local LLMs for query expansion + rerank; entirely off-box otherwise |
+
+### Three install profiles
+
+| Profile | Disk | What's enabled | Trade-off |
+| --- | --- | --- | --- |
+| **Minimum** | ~250 MB | `kj`, audits, reviews, RAG with **cloud embedder** (OpenAI / Voyage / Cohere / Mistral) | Needs an API key; no offline RAG |
+| **Recommended** | ~8.5 GB | + Ollama (local RAG, no API key) + SonarQube | Offline-capable; needs Docker running |
+| **Full house** | ~11 GB | + `qmd` (semantic search across personal docs/memory) | All features local; biggest footprint |
+
+### Hardware
+
+| Profile | CPU | RAM | Free disk | Notes |
+| --- | --- | --- | --- | --- |
+| **Minimum** | 2 cores | 4 GB | 1 GB | Cloud embedder only; pipeline peaks ~1 GB RAM |
+| **Recommended** | 4–8 cores | 8–12 GB | 10–15 GB | Docker + Ollama running in background |
+| **Ideal** | 16+ cores | 32+ GB | 50+ GB | Multiple Docker stacks, large repos, big audit history |
+
+### Operational notes
+
+- **No GPU required.** Embeddings are CPU-only by default; cloud embedders push the compute off-box entirely.
+- **Pipeline RAM peak**: 1–2 GB per `kj run` (one orchestrator + one coder + one reviewer subprocess at a time).
+- **SQLite is in-process.** No separate DB daemon. `~/.karajan/` is a folder, not a service.
+- **First-run Ollama pull**: ~5 min in the background; you can keep working — `kj` falls back to a cloud embedder if Ollama isn't ready yet.
+- **Runtime**: Node.js ≥ 22.22.1 (Active LTS). v3.0.0 dropped Node 20 support. Use `kj doctor` to verify your environment.
+
 ## Two ways to use Karajan
 
 Karajan installs **three commands**: `kj` (the CLI), `karajan-mcp` (the MCP server) and `kj-tail` (a monitoring companion). There are two *ways to use it* — CLI or MCP — and `kj-tail` is the monitor you keep open in a second terminal while either mode is running.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -215,6 +215,8 @@ Everything Karajan keeps across runs now lives under a single home root: **`~/.k
 
 Override the root by exporting `KARAJAN_HOME=/some/path` (legacy `KJ_HOME` still honoured, with a deprecation warning).
 
+> **Footprint & HW**: typical `~/.karajan/` weight is ~40 MB after a few weeks of use. For the full sizing table (npm tarball, Docker images, Ollama models, qmd cache) and HW requirements per install profile, see the [Footprint & hardware requirements section in README](../README.md#footprint--hardware-requirements).
+
 ## Pipeline visualization
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full architecture diagram and component documentation.

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -215,6 +215,8 @@ Todo lo que Karajan persiste entre ejecuciones vive ahora bajo una única raíz:
 
 Para sobrescribir la raíz exporta `KARAJAN_HOME=/ruta`. La variable legacy `KJ_HOME` sigue respetada pero imprime un warning de deprecación.
 
+> **Footprint & HW**: el peso típico de `~/.karajan/` es ~40 MB tras varias semanas de uso. Para la tabla completa de tamaños (tarball npm, imágenes Docker, modelos de Ollama, caché de qmd) y los requisitos de hardware por perfil de instalación, consulta la sección [Footprint & hardware requirements en el README](../../README.md#footprint--hardware-requirements).
+
 ## Visualización del pipeline
 
 Consulta [ARCHITECTURE.md](../ARCHITECTURE.md) para el diagrama completo de arquitectura y la documentación de componentes.


### PR DESCRIPTION
## Summary

- New `## Footprint & hardware requirements` section in README between Optional scanners and Two-ways-to-use.
- Three tables: layer sizes (npm tarball / node_modules / ~/.karajan / Ollama image+model / SonarQube / qmd cache), three install profiles (Minimum ~250 MB cloud-embedder / Recommended ~8.5 GB +Ollama+Sonar / Full house ~11 GB +qmd), hardware per profile (CPU / RAM / free disk).
- Operational notes: no GPU required, 1–2 GB RAM peak per pipeline, in-process SQLite, ~5 min Ollama auto-pull, Node ≥ 22.22.1 for v3.0.0.
- `docs/GETTING-STARTED.md` (EN + ES) blockquote pointers to the new README section.

## Why

User-requested blocker before v3.0.0 publish: surface real footprint (npm/Docker/qmd) and HW requirements so adopters know what they're signing up for. Markdown-only; no code changes; counts excluded from shrink-budget.

## Test plan

- [x] Section renders with proper anchors (`#footprint--hardware-requirements`).
- [x] EN + ES blockquote pointers resolve to the README anchor.
- [x] No code changes, no test changes, no behavior changes.

Card: KJC-TSK-0202. Part of v3.0.0 release prep.