### PR TITLE
feat(clean): kj clean --repo (KJC-TSK-0499 PR1)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -352,10 +352,16 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--draft-days <n>", "Keep draft plans for N days (default: 60)")
     .option("--session-days <n>", "Keep finalised sessions for N days (default: 7)")
     .option("--hu-days <n>", "Keep HU story batches for N days (default: 14)")
+    .option("--repo", "Also report repo-level candidates (merged branches, dist/, coverage/, *.tmp, *.bak)")
+    .option("--repo-days <n>", "Age threshold for repo artifacts in days (default: 7)")
+    .option("--repo-base <ref>", "Base ref to detect merged branches (default: origin/main)")
     .action(async (flags) => {
       await cleanCommand({
         yes: Boolean(flags.yes),
         nuke: Boolean(flags.nuke),
+        repo: Boolean(flags.repo),
+        repoDays: flags.repoDays ? Number(flags.repoDays) : undefined,
+        repoBase: flags.repoBase || undefined,
         planDays: flags.planDays ? Number(flags.planDays) : undefined,
         draftDays: flags.draftDays ? Number(flags.draftDays) : undefined,
         sessionDays: flags.sessionDays ? Number(flags.sessionDays) : undefined,

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -19,11 +19,15 @@
  */
 
 import { runManualGC, summarizeGC, nukeBoardDb } from "../utils/garbage-collector.js";
+import { collectRepoCandidates } from "../utils/repo-cleaner.js";
 
 /**
  * @param {Object} opts
  * @param {boolean} [opts.yes=false]           - when false, dry-run only
  * @param {boolean} [opts.nuke=false]          - retention=0 for every bucket + wipe board DB
+ * @param {boolean} [opts.repo=false]          - also report repo-level candidates (branches, dist, *.tmp, *.bak)
+ * @param {number}  [opts.repoDays=7]          - age threshold for repo artifacts (default 7d)
+ * @param {string}  [opts.repoBase="origin/main"]
  * @param {number}  [opts.planDays=30]
  * @param {number}  [opts.draftDays=60]
  * @param {number}  [opts.sessionDays=7]
@@ -79,5 +83,30 @@ export async function cleanCommand(opts = {}) {
     console.log(summarizeGC(result));
   }
 
+  if (opts.repo) await printRepoReport(opts);
+
   return { ok: true, removed: result.removed.length, bytesFreed: result.bytesFreed };
+}
+
+async function printRepoReport(opts) {
+  const { candidates, errors } = await collectRepoCandidates({
+    maxAgeDays: opts.repoDays ?? 7,
+    mergedTo: opts.repoBase ?? "origin/main",
+  });
+  console.log("");
+  if (!candidates.length) {
+    console.log("[clean:repo] no repo-level candidates — branches/dist/tmp are tidy.");
+    return;
+  }
+  console.log(`[clean:repo] ${candidates.length} candidate(s) — review and run the command to remove:`);
+  for (const c of candidates) {
+    console.log(`  - ${c.kind.padEnd(11)} ${c.target}`);
+    console.log(`                ${c.reason}`);
+    console.log(`                $ ${c.command}`);
+  }
+  if (errors.length) {
+    console.log(`[clean:repo] ${errors.length} non-blocking error(s):`);
+    for (const e of errors) console.log(`  - ${e.stage}: ${e.error}`);
+  }
+  console.log("[clean:repo] read-only — commands are printed, never executed.");
 }

--- a/src/utils/repo-cleaner.js
+++ b/src/utils/repo-cleaner.js
@@ -1,0 +1,79 @@
+/**
+ * Repo-level cleaner — KJC-TSK-0499 PR1. Read-only collector that
+ * surfaces stale local artifacts so the user can decide what to drop.
+ * Detects: branches merged into a base ref, branches with `[gone]`
+ * upstream, top-level `dist/` `coverage/` `logs/` older than N days,
+ * `*.tmp` / `*.bak` older than N days. Never spawns destructive ops.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execa } from "execa";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const STALE_DIRS = ["dist", "coverage", "logs"];
+const STALE_FILE_RX = /\.(tmp|bak)$/;
+
+async function safeGit(cwd, args) {
+  try {
+    const { stdout, exitCode } = await execa("git", args, { cwd, reject: false });
+    return exitCode === 0 ? stdout : "";
+  } catch { return ""; }
+}
+
+async function collectBranches(cwd, baseRef) {
+  const items = [];
+  const baseShort = baseRef.replace(/^origin\//, "");
+  const current = (await safeGit(cwd, ["symbolic-ref", "--short", "HEAD"])).trim();
+  const merged = await safeGit(cwd, ["branch", "--merged", baseRef, "--format=%(refname:short)"]);
+  for (const raw of merged.split("\n")) {
+    const name = raw.trim();
+    if (!name || name === current || name === baseShort) continue;
+    items.push({ kind: "branch", target: name, reason: `merged into ${baseRef}`, command: `git branch -d ${name}` });
+  }
+  for (const line of (await safeGit(cwd, ["branch", "-vv"])).split("\n")) {
+    const m = line.match(/^[\s*]+(\S+)\s+\S+\s+\[[^:]+: gone\]/);
+    if (m && m[1] !== current) items.push({ kind: "branch-gone", target: m[1], reason: "upstream gone", command: `git branch -D ${m[1]}` });
+  }
+  return items;
+}
+
+async function ageMs(p) {
+  try { return Date.now() - (await fs.stat(p)).mtimeMs; } catch { return -1; }
+}
+
+async function collectStale(cwd, maxAgeDays) {
+  const cutoff = maxAgeDays * DAY_MS;
+  const items = [];
+  for (const name of STALE_DIRS) {
+    const full = path.join(cwd, name);
+    if (await ageMs(full) > cutoff) {
+      items.push({ kind: "dir", target: full, reason: `${name}/ older than ${maxAgeDays}d`, command: `rm -rf ${full}` });
+    }
+  }
+  let entries = [];
+  try { entries = await fs.readdir(cwd, { withFileTypes: true }); } catch { /* cwd unreadable */ }
+  for (const e of entries) {
+    if (!e.isFile() || !STALE_FILE_RX.test(e.name)) continue;
+    const full = path.join(cwd, e.name);
+    if (await ageMs(full) > cutoff) {
+      items.push({ kind: "file", target: full, reason: `${path.extname(e.name)} older than ${maxAgeDays}d`, command: `rm -f ${full}` });
+    }
+  }
+  return items;
+}
+
+/**
+ * Discover repo-level cleanup candidates.
+ * @param {object} opts
+ * @param {string} [opts.cwd=process.cwd()]
+ * @param {number} [opts.maxAgeDays=7]
+ * @param {string} [opts.mergedTo="origin/main"]
+ * @returns {Promise<{candidates: Array, errors: Array}>}
+ */
+export async function collectRepoCandidates({ cwd = process.cwd(), maxAgeDays = 7, mergedTo = "origin/main" } = {}) {
+  const candidates = [];
+  const errors = [];
+  try { candidates.push(...await collectBranches(cwd, mergedTo)); } catch (e) { errors.push({ stage: "branches", error: String(e?.message ?? e) }); }
+  try { candidates.push(...await collectStale(cwd, maxAgeDays)); } catch (e) { errors.push({ stage: "stale", error: String(e?.message ?? e) }); }
+  return { candidates, errors };
+}

--- a/tests/utils/repo-cleaner.test.js
+++ b/tests/utils/repo-cleaner.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { execa } from "execa";
+import { collectRepoCandidates } from "../../src/utils/repo-cleaner.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+async function git(cwd, args) {
+  await execa("git", args, { cwd });
+}
+
+async function initRepo(cwd) {
+  await git(cwd, ["init", "-q", "-b", "main"]);
+  await git(cwd, ["config", "user.email", "t@t.local"]);
+  await git(cwd, ["config", "user.name", "t"]);
+  await git(cwd, ["config", "commit.gpgsign", "false"]);
+  await fs.writeFile(path.join(cwd, "README.md"), "# x\n");
+  await git(cwd, ["add", "."]);
+  await git(cwd, ["commit", "-q", "-m", "init"]);
+}
+
+describe("repo-cleaner", () => {
+  let cwd;
+  beforeEach(async () => {
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), "repo-cleaner-"));
+    await initRepo(cwd);
+  });
+  afterEach(async () => {
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  it("returns empty when nothing stale", async () => {
+    const { candidates, errors } = await collectRepoCandidates({ cwd, maxAgeDays: 7, mergedTo: "main" });
+    expect(candidates).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  it("detects stale dist/ and *.tmp older than threshold", async () => {
+    await fs.mkdir(path.join(cwd, "dist"), { recursive: true });
+    await fs.writeFile(path.join(cwd, "dist", "bundle.js"), "x");
+    await fs.writeFile(path.join(cwd, "old.tmp"), "x");
+    const past = (Date.now() - 30 * DAY) / 1000;
+    await fs.utimes(path.join(cwd, "dist"), past, past);
+    await fs.utimes(path.join(cwd, "old.tmp"), past, past);
+    const { candidates } = await collectRepoCandidates({ cwd, maxAgeDays: 7, mergedTo: "main" });
+    const kinds = candidates.map((c) => c.kind).sort();
+    expect(kinds).toContain("dir");
+    expect(kinds).toContain("file");
+    const dist = candidates.find((c) => c.target.endsWith("/dist"));
+    expect(dist.command).toMatch(/^rm -rf /);
+  });
+
+  it("ignores recent dist/", async () => {
+    await fs.mkdir(path.join(cwd, "dist"), { recursive: true });
+    await fs.writeFile(path.join(cwd, "dist", "bundle.js"), "x");
+    const { candidates } = await collectRepoCandidates({ cwd, maxAgeDays: 7, mergedTo: "main" });
+    expect(candidates.find((c) => c.target.endsWith("/dist"))).toBeUndefined();
+  });
+
+  it("detects branches merged into base ref", async () => {
+    await git(cwd, ["checkout", "-q", "-b", "feat/x"]);
+    await fs.writeFile(path.join(cwd, "f.txt"), "y");
+    await git(cwd, ["add", "."]);
+    await git(cwd, ["commit", "-q", "-m", "feat"]);
+    await git(cwd, ["checkout", "-q", "main"]);
+    await git(cwd, ["merge", "-q", "--no-ff", "feat/x", "-m", "merge"]);
+    const { candidates } = await collectRepoCandidates({ cwd, maxAgeDays: 365, mergedTo: "main" });
+    const branch = candidates.find((c) => c.kind === "branch" && c.target === "feat/x");
+    expect(branch).toBeDefined();
+    expect(branch.command).toBe("git branch -d feat/x");
+  });
+});


### PR DESCRIPTION
## Summary
- PR1 of KJC-TSK-0499 (kj cleaner umbrella). Extends `kj clean` with a new read-only flag `--repo` that surfaces stale local artifacts the user can decide to remove.
- New collector `src/utils/repo-cleaner.js` detects:
  - Local branches merged into `origin/main` (or `--repo-base`)
  - Local branches whose upstream is `[gone]`
  - Top-level `dist/`, `coverage/`, `logs/` older than `--repo-days` (default 7)
  - Top-level `*.tmp` / `*.bak` older than `--repo-days`
- Output prints copy-paste commands per candidate; the report itself never executes destructive ops, preserving dry-run-by-default as a hard invariant.
- 4-case test suite (empty repo, stale dirs/files, fresh dist ignored, merged branches detected).
- Net delta: 188 LOC added — within the 200 LOC PR atomicity gate.

## Acceptance criterion covered
Card scenario 1: when I run `kj clean --repo`, the report shows merged-branch candidates with the exact `git branch -d <name>` command ready to copy. Verified manually on this repo (13 merged branches surfaced).

PR2 (`--vector-stores`) and PR3 (`--all`) remain pending per the card's implementation plan.

## Test plan
- [x] `npx vitest run tests/utils/repo-cleaner.test.js` — 4/4 passing
- [x] Full smoke (`npm test`) — green
- [x] Manual run `node src/cli.js clean --repo` from this repo — surfaces real merged branches with correct commands