### PR TITLE
feat(clean): kj clean --vector-stores (KJC-TSK-0499 PR2)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -355,6 +355,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--repo", "Also report repo-level candidates (merged branches, dist/, coverage/, *.tmp, *.bak)")
     .option("--repo-days <n>", "Age threshold for repo artifacts in days (default: 7)")
     .option("--repo-base <ref>", "Base ref to detect merged branches (default: origin/main)")
+    .option("--vector-stores", "Also report orphan RAG vector-store entries in ~/.karajan/rag.db")
+    .option("--project-roots <list>", "Colon-separated directories to scan for live projects (default: ~/ws_*, ~/projects, ~/code)")
     .action(async (flags) => {
       await cleanCommand({
         yes: Boolean(flags.yes),
@@ -362,6 +364,8 @@ export function registerMeta(program, { pkgVersion }) {
         repo: Boolean(flags.repo),
         repoDays: flags.repoDays ? Number(flags.repoDays) : undefined,
         repoBase: flags.repoBase || undefined,
+        vectorStores: Boolean(flags.vectorStores),
+        projectRoots: flags.projectRoots ? flags.projectRoots.split(":").filter(Boolean) : undefined,
         planDays: flags.planDays ? Number(flags.planDays) : undefined,
         draftDays: flags.draftDays ? Number(flags.draftDays) : undefined,
         sessionDays: flags.sessionDays ? Number(flags.sessionDays) : undefined,

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -20,6 +20,7 @@
 
 import { runManualGC, summarizeGC, nukeBoardDb } from "../utils/garbage-collector.js";
 import { collectRepoCandidates } from "../utils/repo-cleaner.js";
+import { collectVectorStoreOrphans } from "../utils/vector-store-orphans.js";
 
 /**
  * @param {Object} opts
@@ -28,6 +29,8 @@ import { collectRepoCandidates } from "../utils/repo-cleaner.js";
  * @param {boolean} [opts.repo=false]          - also report repo-level candidates (branches, dist, *.tmp, *.bak)
  * @param {number}  [opts.repoDays=7]          - age threshold for repo artifacts (default 7d)
  * @param {string}  [opts.repoBase="origin/main"]
+ * @param {boolean} [opts.vectorStores=false]  - also report orphan RAG vector-store entries
+ * @param {string[]} [opts.projectRoots]       - directories scanned to resolve slugs (default: ~/ws_*, ~/projects, ~/code)
  * @param {number}  [opts.planDays=30]
  * @param {number}  [opts.draftDays=60]
  * @param {number}  [opts.sessionDays=7]
@@ -84,6 +87,7 @@ export async function cleanCommand(opts = {}) {
   }
 
   if (opts.repo) await printRepoReport(opts);
+  if (opts.vectorStores) await printVectorStoreReport(opts);
 
   return { ok: true, removed: result.removed.length, bytesFreed: result.bytesFreed };
 }
@@ -109,4 +113,33 @@ async function printRepoReport(opts) {
     for (const e of errors) console.log(`  - ${e.stage}: ${e.error}`);
   }
   console.log("[clean:repo] read-only — commands are printed, never executed.");
+}
+
+async function printVectorStoreReport(opts) {
+  const { rows, orphans, errors } = await collectVectorStoreOrphans({
+    projectRoots: opts.projectRoots,
+  });
+  console.log("");
+  if (errors.length && !rows.length) {
+    console.log("[clean:rag] could not read rag.db — RAG may not be initialised yet.");
+    for (const e of errors) console.log(`  - ${e.stage}: ${e.error}`);
+    return;
+  }
+  console.log(`[clean:rag] ${rows.length} project_slug(s) indexed in rag.db:`);
+  for (const r of rows) {
+    const tag = r.orphan ? " ORPHAN" : "";
+    const when = r.lastAt || "n/a";
+    console.log(`  - ${r.slug.padEnd(28)} chunks=${String(r.chunkCount).padStart(5)}  last=${when}${tag}`);
+  }
+  if (!orphans.length) {
+    console.log("[clean:rag] no orphans — every indexed slug resolves to a live project directory.");
+    return;
+  }
+  console.log("");
+  console.log(`[clean:rag] ${orphans.length} orphan(s) — review and run to purge:`);
+  for (const o of orphans) {
+    console.log(`  - ${o.slug}`);
+    console.log(`                $ ${o.command}`);
+  }
+  console.log("[clean:rag] read-only — commands are printed, never executed.");
 }

--- a/src/utils/vector-store-orphans.js
+++ b/src/utils/vector-store-orphans.js
@@ -1,0 +1,89 @@
+/**
+ * RAG vector-store orphan collector — KJC-TSK-0499 PR2.
+ *
+ * Enumerates distinct `project_slug` rows in `~/.karajan/rag.db`,
+ * augments each with chunk count + last_indexed_{at,commit}, and
+ * marks as orphan the slugs whose basename does not resolve to a
+ * directory in any of the configured `projectRoots`.
+ *
+ * Read-only. Returns rows + a copy-paste sqlite3 command per orphan.
+ * Deliberate inverse of the RAG indexer: never opens the DB for write.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { dbPath, openVecStore, projectSlug } from "../rag/vec-store.js";
+
+const DEFAULT_ROOTS = [
+  path.join(os.homedir(), "ws_npm-packages"),
+  path.join(os.homedir(), "ws_firebase"),
+  path.join(os.homedir(), "projects"),
+  path.join(os.homedir(), "code"),
+];
+
+async function listDirs(root) {
+  try {
+    const entries = await fs.readdir(root, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => path.join(root, e.name));
+  } catch {
+    return [];
+  }
+}
+
+async function buildSlugIndex(roots) {
+  const index = new Map();
+  for (const root of roots) {
+    for (const dir of await listDirs(root)) {
+      const slug = projectSlug(dir);
+      if (slug && !index.has(slug)) index.set(slug, dir);
+    }
+  }
+  return index;
+}
+
+function purgeCommand(slug) {
+  const slugSafe = slug.replace(/'/g, "''");
+  return `sqlite3 ${dbPath()} "DELETE FROM chunks WHERE project_slug='${slugSafe}'; DELETE FROM vec_store_meta WHERE project_slug='${slugSafe}';"`;
+}
+
+/**
+ * Collect RAG vector-store orphans.
+ * @param {object} [opts]
+ * @param {string[]} [opts.projectRoots] — directories to look for live
+ *   projects whose basename matches each slug. Defaults to the usual
+ *   `~/ws_*`, `~/projects`, `~/code` set.
+ * @returns {Promise<{rows: Array, orphans: Array, errors: Array}>}
+ */
+export async function collectVectorStoreOrphans({ projectRoots = DEFAULT_ROOTS } = {}) {
+  const rows = [];
+  const errors = [];
+  let db;
+  try { db = openVecStore(); } catch (e) {
+    return { rows, orphans: [], errors: [{ stage: "open", error: String(e?.message ?? e) }] };
+  }
+  try {
+    const stats = db.prepare(`
+      SELECT COALESCE(c.project_slug, '<null>') AS slug,
+             COUNT(c.id) AS chunkCount,
+             COALESCE(m.last_indexed_commit, '') AS lastCommit,
+             COALESCE(m.last_indexed_at, '') AS lastAt
+      FROM chunks c
+      LEFT JOIN vec_store_meta m ON m.project_slug = c.project_slug
+      GROUP BY c.project_slug
+      ORDER BY chunkCount DESC
+    `).all();
+    const slugIndex = await buildSlugIndex(projectRoots);
+    for (const r of stats) {
+      const resolved = slugIndex.get(r.slug) || null;
+      rows.push({ ...r, resolvedDir: resolved, orphan: !resolved && r.slug !== "<null>" });
+    }
+  } catch (e) {
+    errors.push({ stage: "query", error: String(e?.message ?? e) });
+  } finally {
+    try { db.close(); } catch { /* close errors are non-fatal */ }
+  }
+  const orphans = rows
+    .filter((r) => r.orphan)
+    .map((r) => ({ ...r, command: purgeCommand(r.slug) }));
+  return { rows, orphans, errors };
+}

--- a/tests/utils/vector-store-orphans.test.js
+++ b/tests/utils/vector-store-orphans.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { collectVectorStoreOrphans } from "../../src/utils/vector-store-orphans.js";
+import { openVecStore, insertChunk } from "../../src/rag/vec-store.js";
+
+function makeEmbedding(dim = 768) {
+  const buf = new Float32Array(dim);
+  for (let i = 0; i < dim; i++) buf[i] = Math.random();
+  return buf;
+}
+
+describe("vector-store-orphans", () => {
+  let tmpDb;
+  let roots;
+  let originalDb;
+  beforeEach(async () => {
+    tmpDb = await fs.mkdtemp(path.join(os.tmpdir(), "vec-store-orphans-"));
+    originalDb = process.env.KJ_RAG_DB;
+    process.env.KJ_RAG_DB = path.join(tmpDb, "rag.db");
+    roots = await fs.mkdtemp(path.join(os.tmpdir(), "vec-store-orphans-roots-"));
+  });
+  afterEach(async () => {
+    if (originalDb === undefined) delete process.env.KJ_RAG_DB;
+    else process.env.KJ_RAG_DB = originalDb;
+    await fs.rm(tmpDb, { recursive: true, force: true });
+    await fs.rm(roots, { recursive: true, force: true });
+  });
+
+  it("returns empty rows on a fresh rag.db", async () => {
+    const { rows, orphans, errors } = await collectVectorStoreOrphans({ projectRoots: [roots] });
+    expect(rows).toEqual([]);
+    expect(orphans).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  it("marks slugs whose basename is not in roots as orphan and resolves the rest", async () => {
+    await fs.mkdir(path.join(roots, "live-project"), { recursive: true });
+    const db = openVecStore();
+    insertChunk(db, { source: "/x/live-project/a.js", kind: "code", text: "a", embedding: makeEmbedding(), project: "live-project" });
+    insertChunk(db, { source: "/old/gone-project/a.js", kind: "code", text: "b", embedding: makeEmbedding(), project: "gone-project" });
+    db.close();
+    const { rows, orphans } = await collectVectorStoreOrphans({ projectRoots: [roots] });
+    const live = rows.find((r) => r.slug === "live-project");
+    const gone = rows.find((r) => r.slug === "gone-project");
+    expect(live.orphan).toBe(false);
+    expect(live.resolvedDir).toBe(path.join(roots, "live-project"));
+    expect(gone.orphan).toBe(true);
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].command).toMatch(/^sqlite3 /);
+    expect(orphans[0].command).toContain("project_slug='gone-project'");
+  });
+});


### PR DESCRIPTION
## Summary
- New flag \`kj clean --vector-stores\` enumerates every distinct \`project_slug\` in \`~/.karajan/rag.db\` and reports chunk count + last indexed commit/date per slug.
- Slugs whose basename does not resolve to a directory in \`--project-roots\` (default: \`~/ws_npm-packages\`, \`~/ws_firebase\`, \`~/projects\`, \`~/code\`) are marked **ORPHAN** with a copy-paste \`sqlite3\` DELETE command.
- Read-only: commands are printed, never executed (matches \`--repo\` from PR1).

## PR scope (KJC-TSK-0499 implementation plan step 2)
- New module \`src/utils/vector-store-orphans.js\` (collector).
- \`src/commands/clean.js\` learns \`--vector-stores\` and prints the report.
- CLI registers \`--vector-stores\` and \`--project-roots <list>\` (colon-separated).
- Unit tests: empty DB; orphan vs live slug resolution.

## Test plan
- [x] \`npx vitest run tests/utils/vector-store-orphans.test.js\` — 2/2 passing.
- [x] Smoke \`node src/cli.js clean --vector-stores\` against live \`~/.karajan/rag.db\` — reports the karajan-code slug as resolved, no orphans.

## LOC budget
180 added lines (≤200 hard gate, target 150).