### PR TITLE
fix(security): prototype pollution guards in setDeep/setDotPath (KJC-BUG-0076)

### DIFF
--- a/packages/hu-board/src/config-yaml.js
+++ b/packages/hu-board/src/config-yaml.js
@@ -349,11 +349,19 @@ function getDeep(obj, path) {
   return cur;
 }
 
+// KJC-BUG-0076: never walk into Object.prototype via crafted YAML keys
+// (`__proto__.x`, `constructor.prototype.y`, `prototype.z`). Silent skip
+// over a poisoned segment — the rest of the path is untouched.
+const UNSAFE_KEY_RE = /^(?:__proto__|constructor|prototype)$/;
+
 function setDeep(obj, path, value) {
+  if (typeof path !== 'string') return;
   const parts = path.split('.');
   const last = parts.pop();
+  if (UNSAFE_KEY_RE.test(last)) return;
   let cur = obj;
   for (const p of parts) {
+    if (UNSAFE_KEY_RE.test(p)) return;
     if (cur[p] == null || typeof cur[p] !== 'object') cur[p] = {};
     cur = cur[p];
   }
@@ -361,10 +369,13 @@ function setDeep(obj, path, value) {
 }
 
 function deleteDeep(obj, path) {
+  if (typeof path !== 'string') return;
   const parts = path.split('.');
   const last = parts.pop();
+  if (UNSAFE_KEY_RE.test(last)) return;
   let cur = obj;
   for (const p of parts) {
+    if (UNSAFE_KEY_RE.test(p)) return;
     if (cur == null || typeof cur !== 'object') return;
     cur = cur[p];
   }
@@ -516,3 +527,6 @@ export function writeConfigPatch(patch, { scope = 'global' } = {}) {
   renameSync(tmpFile, p);
   return { path: p, scope, written: true, applied, errors: [] };
 }
+
+// Exposed for prototype-pollution regression tests (KJC-BUG-0076).
+export const __pollutionInternals = { setDeep, deleteDeep };

--- a/packages/hu-board/tests/config-yaml-prototype-pollution.test.js
+++ b/packages/hu-board/tests/config-yaml-prototype-pollution.test.js
@@ -1,0 +1,59 @@
+// KJC-BUG-0076 — guard against CWE-915 (prototype pollution) in the
+// dot-path mutators used by writeConfigPatch. The deterministic audit
+// flagged setDeep/deleteDeep as HIGH because a crafted YAML key like
+// `__proto__.polluted` would walk into Object.prototype. The guard
+// silently skips writes whose path contains __proto__, constructor or
+// prototype, so the rest of the patch still lands.
+import { describe, expect, it, afterEach } from 'vitest';
+import { __pollutionInternals } from '../src/config-yaml.js';
+
+const { setDeep, deleteDeep } = __pollutionInternals;
+
+describe('config-yaml prototype pollution guards', () => {
+  afterEach(() => {
+    // Belt-and-suspenders: scrub any pollution a failing test might
+    // leave behind so it does not leak to the next test file.
+    delete Object.prototype.polluted;
+    delete Object.prototype.viaConstructor;
+    delete Object.prototype.viaPrototype;
+  });
+
+  it('setDeep refuses to walk into __proto__', () => {
+    const obj = {};
+    setDeep(obj, '__proto__.polluted', 'pwned');
+    expect(({}).polluted).toBeUndefined();
+    expect(obj.polluted).toBeUndefined();
+  });
+
+  it('setDeep refuses to walk into constructor.prototype', () => {
+    const obj = {};
+    setDeep(obj, 'constructor.prototype.viaConstructor', 'pwned');
+    expect(({}).viaConstructor).toBeUndefined();
+  });
+
+  it('setDeep refuses to walk into prototype', () => {
+    const obj = {};
+    setDeep(obj, 'prototype.viaPrototype', 'pwned');
+    expect(({}).viaPrototype).toBeUndefined();
+  });
+
+  it('setDeep still writes safe nested paths', () => {
+    const obj = {};
+    setDeep(obj, 'foo.bar.baz', 42);
+    expect(obj.foo.bar.baz).toBe(42);
+  });
+
+  it('deleteDeep refuses to remove keys on Object.prototype', () => {
+    Object.prototype.polluted = 'sentinel';
+    const obj = {};
+    deleteDeep(obj, '__proto__.polluted');
+    expect(({}).polluted).toBe('sentinel');
+    delete Object.prototype.polluted;
+  });
+
+  it('deleteDeep still removes safe nested keys', () => {
+    const obj = { foo: { bar: 'gone' } };
+    deleteDeep(obj, 'foo.bar');
+    expect(obj.foo.bar).toBeUndefined();
+  });
+});

--- a/src/checks/runner.js
+++ b/src/checks/runner.js
@@ -249,8 +249,15 @@ function summarize(reports) {
  *
  * @example setDotPath({}, "git.auto_pr", false) // → { git: { auto_pr: false } }
  */
+// KJC-BUG-0076: prototype-pollution guard. dot-paths come from check
+// remediation outputs (internal but LLM-generated), so a malformed
+// `__proto__.x` would mutate Object.prototype. Skip the whole write
+// when any segment matches a forbidden key.
+const UNSAFE_DOT_KEY_RE = /^(?:__proto__|constructor|prototype)$/;
+
 function setDotPath(target, dotPath, value) {
   const parts = String(dotPath).split(".");
+  if (parts.some((p) => UNSAFE_DOT_KEY_RE.test(p))) return;
   let cursor = target;
   for (let i = 0; i < parts.length - 1; i++) {
     const k = parts[i];
@@ -314,3 +321,6 @@ export function toLegacyShape(runReport) {
     fix: c.fix ?? null,
   }));
 }
+
+// Exposed for prototype-pollution regression tests (KJC-BUG-0076).
+export const __pollutionInternals = { setDotPath };

--- a/tests/checks/runner-prototype-pollution.test.js
+++ b/tests/checks/runner-prototype-pollution.test.js
@@ -1,0 +1,42 @@
+// KJC-BUG-0076 — guard against CWE-915 (prototype pollution) in
+// setDotPath. The function is invoked by runChecks() when a degradable
+// check returns a remediation. Remediation outputs are LLM-generated
+// today, so a malformed dot-path like `__proto__.x` would mutate
+// Object.prototype globally. The guard refuses the whole write.
+import { describe, expect, it, afterEach } from "vitest";
+import { __pollutionInternals } from "../../src/checks/runner.js";
+
+const { setDotPath } = __pollutionInternals;
+
+describe("checks/runner setDotPath prototype pollution guard", () => {
+  afterEach(() => {
+    delete Object.prototype.polluted;
+    delete Object.prototype.viaConstructor;
+    delete Object.prototype.viaPrototype;
+  });
+
+  it("refuses __proto__ segments", () => {
+    const overrides = {};
+    setDotPath(overrides, "__proto__.polluted", true);
+    expect(({}).polluted).toBeUndefined();
+  });
+
+  it("refuses constructor.prototype segments", () => {
+    const overrides = {};
+    setDotPath(overrides, "constructor.prototype.viaConstructor", true);
+    expect(({}).viaConstructor).toBeUndefined();
+  });
+
+  it("refuses prototype segments anywhere in the path", () => {
+    const overrides = {};
+    setDotPath(overrides, "git.prototype.viaPrototype", true);
+    expect(({}).viaPrototype).toBeUndefined();
+    expect(overrides.git).toBeUndefined();
+  });
+
+  it("still writes safe dot-paths (regression: git.auto_pr=false)", () => {
+    const overrides = {};
+    setDotPath(overrides, "git.auto_pr", false);
+    expect(overrides.git.auto_pr).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the 2 HIGH prototype-pollution findings from \`kj audit --yes\` (2026-06-04).

- \`packages/hu-board/src/config-yaml.js\` — \`setDeep\` and \`deleteDeep\` now skip any path segment matching \`__proto__\`, \`constructor\` or \`prototype\` (CWE-915).
- \`src/checks/runner.js\` — same guard on \`setDotPath\` (used by degradable check remediation).
- Both helpers re-exported as \`__pollutionInternals\` so the regression tests can exercise the guard directly without forging EDITABLE_FIELDS or runChecks orchestration.

## Test plan

- [x] \`tests/checks/runner-prototype-pollution.test.js\` (4 tests): \`__proto__\`, \`constructor.prototype\`, mid-path \`prototype\`, plus safe write regression.
- [x] \`packages/hu-board/tests/config-yaml-prototype-pollution.test.js\` (6 tests): same coverage plus \`deleteDeep\` regression.
- [x] Existing \`tests/checks/runner.test.js\` (22 tests) still green.
- [x] Existing \`packages/hu-board/tests/config-yaml.test.js\` (13 tests) still green.

LOC: 125 net (well below 200 budget; 24 source + 101 tests).

Closes KJC-BUG-0076.