### PR TITLE
docs: add public Planning Game link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="docs/README.es.md">Leer en Español</a> · <a href="https://karajancode.com">Documentation</a>
+  <a href="docs/README.es.md">Leer en Español</a> · <a href="https://karajancode.com">Documentation</a> · <a href="https://planning-game-xp.web.app/public/?project=Karajan%20Code">Public roadmap</a>
 </p>
 
 ---

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="../README.md">Read in English</a> · <a href="https://karajancode.com">Documentacion</a>
+  <a href="../README.md">Read in English</a> · <a href="https://karajancode.com">Documentacion</a> · <a href="https://planning-game-xp.web.app/public/?project=Karajan%20Code">Roadmap publico</a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- Adds a third link in the README header next to "Documentation": **Public roadmap** → https://planning-game-xp.web.app/public/?project=Karajan%20Code
- Mirrored in `docs/README.es.md` as "Roadmap publico"
- Visitors get a one-click path from the repo front page to the live backlog/sprint board in Planning Game (read-only, no login required)

## Test plan

- [x] Manual: links resolve to the PG public view filtered by `Karajan Code`
- [x] No code touched — pure docs