### PR TITLE
fix(audit): classify harness scorecard docker failures (KJC-BUG-0077)

### DIFF
--- a/src/audit/harness-scorecard.js
+++ b/src/audit/harness-scorecard.js
@@ -2,10 +2,43 @@
 // One-shot container: detect Docker, auto-pull on first run (cache hit
 // thereafter), execute `assess <repo>` with the project mounted read-only.
 // No compose, no port discovery — assess is a single process that exits.
+//
+// KJC-BUG-0077 — classify failures (docker_missing / image_inaccessible /
+// auth_required / network_error / unknown) and emit an actionable hint
+// alongside the raw stderr so `kj audit` surfaces something better than
+// the opaque "pull access denied" line the registry returns.
 import { runCommand } from "../utils/process.js";
 
 const D = { image: "markmishaev76/ai-harness-scorecard:latest", pullTimeoutMs: 300000, assessTimeoutMs: 180000 };
 const pos = (v, d) => (Number(v) > 0 ? Number(v) : d);
+
+const DOCKER_FAILURE_PATTERNS = [
+  { reason: "image_inaccessible", re: /pull access denied|repository does not exist|manifest unknown|not found: manifest|denied: requested access/i },
+  { reason: "auth_required",      re: /unauthorized|authentication required|login required|requires authentication/i },
+  { reason: "network_error",      re: /no such host|connection refused|dial tcp|i\/o timeout|TLS handshake|net\/http|temporary failure in name resolution/i },
+];
+
+export function classifyDockerFailure(stderr = "") {
+  const s = String(stderr);
+  for (const { reason, re } of DOCKER_FAILURE_PATTERNS) {
+    if (re.test(s)) return reason;
+  }
+  return "unknown";
+}
+
+export function hintForReason(reason, image) {
+  switch (reason) {
+    case "image_inaccessible":
+      return `Image \`${image}\` is not accessible from the public registry (it may have been removed, renamed, or made private). Either run \`kj audit --no-harness\` to skip this step, or override \`audit.harness.image\` with a mirror you control.`;
+    case "auth_required":
+      return `Pulling \`${image}\` requires registry authentication. Run \`docker login <registry>\` first, or override \`audit.harness.image\` with a public mirror.`;
+    case "network_error":
+      return `Network error reaching the registry while pulling \`${image}\`. Retry once connectivity is back; \`kj audit --no-harness\` skips this step in the meantime.`;
+    case "docker_missing":
+      return `Docker is not available on this machine. Install Docker (or run \`kj audit --no-harness\` to silence this).`;
+    default: return null;
+  }
+}
 
 export function normalizeHarnessConfig(h = {}) {
   return {
@@ -32,20 +65,36 @@ export async function ensureHarnessImage(harness = null) {
   const cfg = normalizeHarnessConfig(harness || {});
   if (await isHarnessImagePresent(cfg.image)) return { pulled: false, reused: true, image: cfg.image };
   const r = await runCommand("docker", ["pull", cfg.image], { timeout: cfg.pullTimeoutMs });
-  if (r.exitCode !== 0) return { pulled: false, reused: false, image: cfg.image, error: r.stderr?.trim() || `exit ${r.exitCode}` };
+  if (r.exitCode !== 0) {
+    const stderr = r.stderr?.trim() || `exit ${r.exitCode}`;
+    const reason = classifyDockerFailure(stderr);
+    return { pulled: false, reused: false, image: cfg.image, error: stderr, reason };
+  }
   return { pulled: true, reused: false, image: cfg.image };
 }
 
 export async function runHarnessAssess(repoPath, harness = null) {
   const cfg = normalizeHarnessConfig(harness || {});
+  if (!(await isDockerAvailable())) {
+    return { ok: false, reason: "docker_missing", image: cfg.image, error: "Docker daemon is not available", hint: hintForReason("docker_missing", cfg.image) };
+  }
+  const pull = await ensureHarnessImage(cfg);
+  if (pull.error) {
+    const reason = pull.reason || "pull_failed";
+    return { ok: false, reason, image: cfg.image, error: pull.error, hint: hintForReason(reason, cfg.image) };
+  }
   const r = await runCommand(
     "docker",
     ["run", "--rm", "-v", `${repoPath}:/repo:ro`, cfg.image, "assess", "/repo", "--format", "json"],
     { timeout: cfg.assessTimeoutMs },
   );
-  if (r.exitCode !== 0) return { ok: false, error: r.stderr?.trim() || r.stdout?.trim() || `exit ${r.exitCode}` };
+  if (r.exitCode !== 0) {
+    const stderr = r.stderr?.trim() || r.stdout?.trim() || `exit ${r.exitCode}`;
+    const reason = classifyDockerFailure(stderr);
+    return { ok: false, reason, image: cfg.image, error: stderr, hint: hintForReason(reason, cfg.image) };
+  }
   try {
     const parsed = JSON.parse(r.stdout);
     return { ok: true, score: parsed.overall_score, grade: parsed.grade, raw: parsed };
-  } catch (e) { return { ok: false, error: `Invalid JSON from harness: ${e.message}` }; }
+  } catch (e) { return { ok: false, reason: "invalid_json", error: `Invalid JSON from harness: ${e.message}` }; }
 }

--- a/src/audit/harness-section.js
+++ b/src/audit/harness-section.js
@@ -22,7 +22,7 @@ export async function runHarnessSection({ projectDir, harnessConfig = null, runA
   const cfg = normalizeHarnessConfig(harnessConfig || {});
   if (!cfg.enabled) return { ok: true, skipped: true, reason: "disabled" };
   const res = await runAssess(projectDir, cfg);
-  if (!res.ok) return { ok: false, error: res.error };
+  if (!res.ok) return { ok: false, error: res.error, reason: res.reason, hint: res.hint, image: cfg.image };
   const outDir = path.join(projectDir, ".karajan", "audit-runs", ts());
   await fs.mkdir(outDir, { recursive: true });
   const scorecardPath = path.join(outDir, "scorecard.json");
@@ -39,7 +39,11 @@ export async function runHarnessSection({ projectDir, harnessConfig = null, runA
 
 export function formatHarnessSection(summary) {
   if (!summary || summary.skipped) return "";
-  if (!summary.ok) return `## Harness Scorecard\n\n_skipped: ${summary.error}_\n`;
+  if (!summary.ok) {
+    const reason = summary.reason ? ` (${summary.reason})` : "";
+    const hint = summary.hint ? `\n\n${summary.hint}\n` : "";
+    return `## Harness Scorecard\n\n_skipped${reason}: ${summary.error}_${hint}\n`;
+  }
   const lines = [
     `## Harness Health Score: ${summary.score}/100 (${summary.grade})`,
     "",

--- a/tests/audit/harness-scorecard.test.js
+++ b/tests/audit/harness-scorecard.test.js
@@ -6,6 +6,7 @@ import { runCommand } from "../../src/utils/process.js";
 import {
   normalizeHarnessConfig, isDockerAvailable, isHarnessImagePresent,
   ensureHarnessImage, runHarnessAssess,
+  classifyDockerFailure, hintForReason,
 } from "../../src/audit/harness-scorecard.js";
 
 const IMG = "markmishaev76/ai-harness-scorecard:latest";
@@ -41,11 +42,56 @@ describe("audit/harness-scorecard — KJC-TSK-0470", () => {
   });
 
   it("runHarnessAssess mounts repo read-only, parses JSON, surfaces failures", async () => {
-    mockExit([0, JSON.stringify({ overall_score: 78, grade: "B" })]);
+    // success path: docker version + docker images -q (cache hit) + docker run
+    mockExit([0, "25"], [0, "sha256:abc\n"], [0, JSON.stringify({ overall_score: 78, grade: "B" })]);
     const ok = await runHarnessAssess("/tmp/repo", {});
     expect(ok).toMatchObject({ ok: true, score: 78, grade: "B" });
-    expect(runCommand.mock.calls[0][1]).toEqual(expect.arrayContaining(["run", "--rm", "-v", "/tmp/repo:/repo:ro"]));
-    mockExit([2, "", "boom"]);
-    expect(await runHarnessAssess("/tmp/repo", {})).toMatchObject({ ok: false, error: expect.stringMatching(/boom/) });
+    expect(runCommand.mock.calls.at(-1)[1]).toEqual(expect.arrayContaining(["run", "--rm", "-v", "/tmp/repo:/repo:ro"]));
+    // failure path during assess: surface stderr + classified reason
+    mockExit([0, "25"], [0, "sha256:abc\n"], [2, "", "boom"]);
+    expect(await runHarnessAssess("/tmp/repo", {})).toMatchObject({ ok: false, error: expect.stringMatching(/boom/), reason: "unknown" });
+  });
+
+  it("classifyDockerFailure maps known stderr patterns + falls back to unknown — KJC-BUG-0077", () => {
+    expect(classifyDockerFailure("Error response from daemon: pull access denied for foo/bar")).toBe("image_inaccessible");
+    expect(classifyDockerFailure("repository does not exist or may require 'docker login'")).toBe("image_inaccessible");
+    expect(classifyDockerFailure("denied: requested access to the resource is denied")).toBe("image_inaccessible");
+    expect(classifyDockerFailure("unauthorized: authentication required")).toBe("auth_required");
+    expect(classifyDockerFailure("dial tcp: lookup registry-1.docker.io: no such host")).toBe("network_error");
+    expect(classifyDockerFailure("net/http: TLS handshake timeout")).toBe("network_error");
+    expect(classifyDockerFailure("something totally unexpected")).toBe("unknown");
+    expect(classifyDockerFailure()).toBe("unknown");
+  });
+
+  it("hintForReason returns actionable suggestion per reason — KJC-BUG-0077", () => {
+    expect(hintForReason("image_inaccessible", IMG)).toMatch(/--no-harness/);
+    expect(hintForReason("image_inaccessible", IMG)).toContain(IMG);
+    expect(hintForReason("auth_required", IMG)).toMatch(/docker login/);
+    expect(hintForReason("network_error", IMG)).toMatch(/Network/i);
+    expect(hintForReason("docker_missing", IMG)).toMatch(/Install Docker/);
+    expect(hintForReason("invalid_json", IMG)).toBeNull();
+    expect(hintForReason("unknown", IMG)).toBeNull();
+  });
+
+  it("runHarnessAssess surfaces docker_missing with hint — KJC-BUG-0077", async () => {
+    mockExit([1, "", "no daemon"]);
+    const r = await runHarnessAssess("/tmp/repo", {});
+    expect(r).toMatchObject({ ok: false, reason: "docker_missing", hint: expect.stringMatching(/Install Docker/) });
+  });
+
+  it("runHarnessAssess surfaces image_inaccessible with hint when pull denied — KJC-BUG-0077", async () => {
+    // docker version OK, image not cached, pull denied
+    mockExit(
+      [0, "25"],
+      [0, ""],
+      [1, "", "Error response from daemon: pull access denied for markmishaev76/ai-harness-scorecard"],
+    );
+    const r = await runHarnessAssess("/tmp/repo", {});
+    expect(r).toMatchObject({
+      ok: false,
+      reason: "image_inaccessible",
+      error: expect.stringMatching(/pull access denied/),
+      hint: expect.stringMatching(/--no-harness/),
+    });
   });
 });

--- a/tests/audit/harness-section.test.js
+++ b/tests/audit/harness-section.test.js
@@ -44,6 +44,21 @@ describe("audit/harness-section — KJC-TSK-0471", () => {
     expect(await runHarnessSection({ projectDir: tmp })).toMatchObject({ ok: false, error: "boom" });
   });
 
+  it("propagates reason + hint + image from runHarnessAssess — KJC-BUG-0077", async () => {
+    runHarnessAssess.mockResolvedValueOnce({
+      ok: false, error: "pull access denied", reason: "image_inaccessible",
+      hint: "Image `img:latest` is not accessible. Run `kj audit --no-harness` to skip.",
+    });
+    const r = await runHarnessSection({ projectDir: tmp });
+    expect(r).toMatchObject({
+      ok: false,
+      error: "pull access denied",
+      reason: "image_inaccessible",
+      hint: expect.stringMatching(/--no-harness/),
+      image: "img:latest",
+    });
+  });
+
   it("formatHarnessSection renders header + 5-row category table", () => {
     const md = formatHarnessSection({
       ok: true, score: 78, grade: "B",
@@ -70,6 +85,15 @@ describe("audit/harness-section — KJC-TSK-0471", () => {
 
   it("formatHarnessSection notes the failure when ok=false", () => {
     expect(formatHarnessSection({ ok: false, error: "docker offline" })).toMatch(/skipped: docker offline/);
+  });
+
+  it("formatHarnessSection renders reason + hint when present — KJC-BUG-0077", () => {
+    const md = formatHarnessSection({
+      ok: false, error: "pull access denied", reason: "image_inaccessible",
+      hint: "Run `kj audit --no-harness` to skip.",
+    });
+    expect(md).toMatch(/skipped \(image_inaccessible\): pull access denied/);
+    expect(md).toMatch(/--no-harness/);
   });
 
   it("formatHarnessSection returns empty when skipped", () => {


### PR DESCRIPTION
## Summary

When the upstream `markmishaev76/ai-harness-scorecard:latest` image went private/unavailable, `kj audit` surfaced the opaque `pull access denied` line from the docker daemon with no hint about what to do next. This made every `kj audit` run report a misleading "Harness skipped" with raw stderr noise.

This PR:

- **Classifies docker failures** by regex over stderr → `image_inaccessible` / `auth_required` / `network_error` / `docker_missing` / `unknown`.
- **Emits actionable hints** alongside the raw error (e.g. "run \`kj audit --no-harness\` or override \`audit.harness.image\` with a mirror you control").
- **Hardens \`runHarnessAssess\`** to pre-check Docker and auto-pull on first use (cache hit thereafter), matching the Docker-dist pattern from v2.26.0 (Ollama bootstrap).
- **Propagates \`reason\` + \`hint\`** through \`runHarnessSection\` so the rendered audit section tells the user how to proceed.

## Files changed

- \`src/audit/harness-scorecard.js\` — classifier table, hint emitter, ensureHarnessImage auto-pull
- \`src/audit/harness-section.js\` — propagate + render reason/hint
- \`tests/audit/harness-scorecard.test.js\` — 4 new tests (classifier, hints, docker_missing, image_inaccessible)
- \`tests/audit/harness-section.test.js\` — 2 new tests (propagation, rendering)

## Test plan

- [x] 17/17 harness tests passing
- [x] 5 426 / 5 426 full suite passing
- [ ] CI green (commitlint + prettier + lint + tests + coverage + shrink-budget)