### PR TITLE
refactor(hu-board): extract formatters into utils/formatters.js (KJC-TSK-0501)

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -35,58 +35,11 @@ let selectedProject = scopedProjectSlug || '';
 /** @type {number | null} Auto-refresh interval ID */
 let refreshInterval = null;
 
-// ---- Format helpers (KEEP IN SYNC with packages/hu-board/src/format.js) ----
-//
-// Browsers don't share Node's module loader and `app.js` is a classic
-// (non-module) <script>, so the helpers below are duplicated inline.
-// The source of truth for tests lives at packages/hu-board/src/format.js;
-// any change to one MUST be made to the other. Tests in
-// packages/hu-board/tests/format.test.js pin the contract.
-
-/** Format an ISO 8601 timestamp as HH:MM (24h, server-local). Falls back to "—". */
-function formatHHMM(iso) {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${hh}:${mm}`;
-}
-
-/** Truncate a task description to <=max chars, ellipsis when truncated. */
-function shortTask(text, max = 60) {
-  if (!text) return "";
-  const collapsed = String(text).replace(/\s+/g, " ").trim();
-  if (collapsed.length <= max) return collapsed;
-  return collapsed.slice(0, max - 1).trimEnd() + "…";
-}
-
-/**
- * Build the human-readable label tuple used by the Sessions view.
- * Replaces the cryptic `s_2026-05-07T08-35-58-010Z` rendered before
- * KJC fix on 2026-05-07. The id is preserved as `idChip` so the user
- * can still grab it for `kj resume <id>`.
- *
- * @returns {{ title: string, subtitle: string, idChip: string }}
- */
-function formatSessionLabel(session) {
-  if (!session || !session.id) {
-    return { title: "(no session)", subtitle: "", idChip: "" };
-  }
-  const projectName = (session.project_name || "").trim();
-  const time = formatHHMM(session.created_at);
-  const projectPart = projectName
-    ? projectName.length > 40
-      ? projectName.slice(0, 39) + "…"
-      : projectName
-    : session.id;
-  const title = time !== "—" ? `${projectPart} · ${time}` : projectPart;
-  return {
-    title,
-    subtitle: shortTask(session.task, 60),
-    idChip: session.id,
-  };
-}
+// Format helpers (formatHHMM, shortTask, formatSessionLabel) live in
+// /utils/formatters.js — loaded as a classic script before this file by
+// index.html. KJC-TSK-0501 (step 1/8) moved them out of here so they're
+// reusable from future split modules. packages/hu-board/src/format.js
+// still owns the Node-side duplicates for tests.
 
 // ---- API Layer ----
 
@@ -198,43 +151,8 @@ const projectNameCache = {};
 // 0/1 mirror what sqlite stores; undefined = not yet hydrated.
 const projectIsSharedCache = {};
 
-/**
- * Humanise a slug-ish project id so the board can show
- * "Linux Assistant Orchestrator" instead of
- * "home_manu_ws_ai_linux-assistant-orchestrator" in the header.
- *
- * Strategy: take the last slash/underscore-separated segment (that's the
- * project folder name), split it on dashes, drop short fragments and
- * title-case the rest.
- */
-function humaniseProjectName(id) {
-  if (!id || typeof id !== 'string') return id || '';
-  const tail = id.split(/[/_]/).filter(Boolean).pop() || id;
-  const words = tail
-    .split(/[\s\-]+/)
-    .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
-    .filter((w) => w.length > 0);
-  if (words.length === 0) return id;
-  return words.map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase()).join(' ');
-}
-
-/**
- * Derive initials from a project name. Splits on non-word characters,
- * drops single-letter fragments ("a", "x") to avoid gibberish, keeps
- * short-but-meaningful ones ("ai", "ui"), lowercases, caps to 5 chars.
- *
- * Examples:
- *   "Linux Assistant Orchestrator"    → "lao"
- *   "AI Linux Assistant Orchestrator" → "alao"
- *   "karajan-code"                    → "kc"
- */
-function deriveInitialsFromName(name) {
-  const words = String(name || '')
-    .split(/[\s\-_/]+/)
-    .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
-    .filter((w) => w.length > 1);
-  return words.map((w) => w[0].toLowerCase()).join('').slice(0, 5) || 'kj';
-}
+// humaniseProjectName + deriveInitialsFromName moved to utils/formatters.js
+// (KJC-TSK-0501 step 1/8).
 
 /**
  * Fetch-and-cache a project's metadata. Populates initialsCache and
@@ -272,128 +190,9 @@ async function resolveProjectInitials(projectId) {
   return meta.initials;
 }
 
-/**
- * Build the human-facing short ID for a story card.
- * Example: `lao-003` for `home_…::hu_plan-20260424182640-4icc_003`.
- * @param {object} story
- * @param {string} initials
- * @returns {string}
- */
-function shortStoryId(story, initials) {
-  const id = story?.id || '';
-  // Match `_<digits>` at the tail of the ID (with or without a trailing
-  // namespace part). This covers `…_003` as well as `…_0012`.
-  const m = /_(\d+)(?!.*\d)/.exec(id);
-  const num = m ? m[1] : '?';
-  return `${initials || 'kj'}-${num}`;
-}
-
-// ---- Utility Functions ----
-
-/**
- * Returns relative time string (e.g., "2 min ago").
- * @param {string} dateStr - ISO date string
- * @returns {string}
- */
-function timeAgo(dateStr) {
-  if (!dateStr) return '';
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes} min ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-/**
- * Formats milliseconds to human readable duration.
- * @param {number | null} ms
- * @returns {string}
- */
-function formatDuration(ms) {
-  if (!ms) return '--';
-  const totalSec = Math.floor(ms / 1000);
-  const min = Math.floor(totalSec / 60);
-  const sec = totalSec % 60;
-  if (min === 0) return `${sec}s`;
-  return `${min}m ${sec.toString().padStart(2, '0')}s`;
-}
-
-/**
- * Returns a quality score CSS class based on value.
- * @param {number | null} score
- * @param {number} max
- * @returns {string}
- */
-function scoreClass(score, max = 60) {
-  if (score === null || score === undefined) return '';
-  const pct = score / max;
-  if (pct >= 0.7) return 'story-card__score--good';
-  if (pct >= 0.4) return 'story-card__score--ok';
-  return 'story-card__score--bad';
-}
-
-/**
- * Generates quality bar HTML segments.
- * @param {number | null} score
- * @param {number} max
- * @returns {string}
- */
-function qualityBar(score, max = 60) {
-  if (score === null || score === undefined) return '';
-  const filled = Math.round((score / max) * 10);
-  let html = '<span class="quality-bar">';
-  for (let i = 0; i < 10; i++) {
-    html += `<span class="quality-bar__segment${i < filled ? ' quality-bar__segment--filled' : ''}"></span>`;
-  }
-  html += '</span>';
-  return html;
-}
-
-/**
- * Escapes HTML entities.
- * @param {string} str
- * @returns {string}
- */
-function esc(str) {
-  if (!str) return '';
-  const el = document.createElement('span');
-  el.textContent = str;
-  return el.innerHTML;
-}
-
-// is_test toggle visuals (KJC-TSK-0371). The icon and tooltip
-// reflect the user's explicit override OR the default heuristic
-// when none is set. Heuristic mirrors ephemeral-cleaner.js so the
-// UI never lies about what the cleaner will actually do.
-const EPHEMERAL_HEURISTIC_RE = /^(auto-)?(tmp_|test_|demo_|kj-test-)/i;
-function isTestIcon(p) {
-  if (p.is_test === 1) return '🧪';                                  // user marked
-  if (p.is_test === 0) return '📌';                                  // user pinned
-  return EPHEMERAL_HEURISTIC_RE.test(p.id || '') ? '🧪?' : '·';      // heuristic
-}
-function isTestTitle(p) {
-  if (p.is_test === 1) return 'Marked as test — auto-cleans 24h after last activity. Click to pin.';
-  if (p.is_test === 0) return 'Pinned — never auto-cleans. Click to clear.';
-  if (EPHEMERAL_HEURISTIC_RE.test(p.id || '')) {
-    return 'Looks ephemeral by id heuristic — will auto-clean after 24h. Click to pin.';
-  }
-  return 'Real project — never auto-cleans. Click to mark as test.';
-}
-
-/**
- * Truncates text to a max length.
- * @param {string} text
- * @param {number} max
- * @returns {string}
- */
-function truncate(text, max = 100) {
-  if (!text) return '';
-  return text.length > max ? text.slice(0, max) + '...' : text;
-}
+// shortStoryId + timeAgo + formatDuration + scoreClass + qualityBar + esc
+// + EPHEMERAL_HEURISTIC_RE + isTestIcon + isTestTitle + truncate moved to
+// utils/formatters.js (KJC-TSK-0501 step 1/8).
 
 // ---- Render Functions ----
 
@@ -2002,122 +1801,8 @@ async function runProject(projectId) {
 let logPollTimer = null;
 let logViewerState = { planId: null, panel: null, offset: 0, isMax: false, isMin: false };
 
-// Map common ANSI SGR codes to inline CSS. Anything we don't know is
-// stripped silently (still removes the escape, just doesn't colour).
-// We render into a styled <pre> so newlines + spaces preserve.
-const ANSI_SGR = {
-  1: 'font-weight:bold',
-  2: 'opacity:0.65',
-  3: 'font-style:italic',
-  4: 'text-decoration:underline',
-  30: 'color:#1f2937', 31: 'color:#f87171', 32: 'color:#4ade80',
-  33: 'color:#fbbf24', 34: 'color:#60a5fa', 35: 'color:#c084fc',
-  36: 'color:#22d3ee', 37: 'color:#e5e7eb',
-  90: 'color:#9ca3af', 91: 'color:#fca5a5', 92: 'color:#86efac',
-  93: 'color:#fde68a', 94: 'color:#93c5fd', 95: 'color:#d8b4fe',
-  96: 'color:#67e8f9', 97: 'color:#f3f4f6',
-};
-
-/**
- * Map an xterm 256-colour index to a CSS rgb(). 0-15 = the 16 standard
- * + bright colours; 16-231 = the 6x6x6 RGB cube; 232-255 = grayscale.
- */
-function ansi256ToCss(n) {
-  if (n < 0 || n > 255) return 'inherit';
-  const std = [
-    '#000000', '#800000', '#008000', '#808000', '#000080', '#800080', '#008080', '#c0c0c0',
-    '#808080', '#ff0000', '#00ff00', '#ffff00', '#0000ff', '#ff00ff', '#00ffff', '#ffffff',
-  ];
-  if (n < 16) return std[n];
-  if (n < 232) {
-    const idx = n - 16;
-    const r = Math.floor(idx / 36);
-    const g = Math.floor(idx / 6) % 6;
-    const b = idx % 6;
-    const v = (c) => (c === 0 ? 0 : 55 + c * 40);
-    return `rgb(${v(r)},${v(g)},${v(b)})`;
-  }
-  const v = 8 + (n - 232) * 10;
-  return `rgb(${v},${v},${v})`;
-}
-
-const ESC_CHARS = new Set([0x1B, 0x241B]);    // real ESC + Unicode "Symbol For Escape"
-const HTML_ESC = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-
-/**
- * Convert text containing ANSI SGR escapes into HTML with inline-styled
- * spans. The previous implementation had two bugs that turned the log
- * into unreadable garbage:
- *
- *   1. It searched for `[` (just the bracket) instead of `ESC + [`,
- *      so the ESC byte itself was sliced into the output. The browser
- *      then rendered it as the literal substitute character (escape).
- *   2. It only knew the 16-colour codes (30-37, 90-97). Karajan's
- *      banner uses 24-bit RGB (`38;2;r;g;b`) and codex emits
- *      256-colour (`38;5;n`); both showed as plain unstyled text with
- *      the escape sequences leaking through.
- *
- * Also accepts U+241B "Symbol For Escape" which some loggers /
- * clipboards substitute for the raw 0x1B byte.
- *
- * @param {string} text
- * @returns {string} safe HTML
- */
-function ansiToHtml(text) {
-  const src = String(text);
-  const N = src.length;
-  let out = '';
-  let openSpans = 0;
-  let i = 0;
-
-  while (i < N) {
-    const code = src.charCodeAt(i);
-    // Not an escape: fast-batch the literal run up to the next escape.
-    if (!ESC_CHARS.has(code)) {
-      let j = i + 1;
-      while (j < N && !ESC_CHARS.has(src.charCodeAt(j))) j += 1;
-      out += HTML_ESC(src.slice(i, j));
-      i = j;
-      continue;
-    }
-    // Escape but not followed by `[` -- drop the lone escape byte so
-    // it doesn't render as the substitute character.
-    if (src[i + 1] !== '[') { i += 1; continue; }
-    const endM = src.indexOf('m', i + 2);
-    if (endM === -1) { i += 1; continue; }
-    const params = src.slice(i + 2, endM).split(';').map((n) => Number(n) || 0);
-    let k = 0;
-    while (k < params.length) {
-      const c = params[k];
-      if (c === 0) {
-        while (openSpans > 0) { out += '</span>'; openSpans -= 1; }
-        k += 1;
-      } else if ((c === 38 || c === 48) && params[k + 1] === 2 && params.length >= k + 5) {
-        // 24-bit truecolor: 38;2;r;g;b (foreground) or 48;2;r;g;b (background)
-        const r = params[k + 2], g = params[k + 3], b = params[k + 4];
-        const prop = c === 38 ? 'color' : 'background-color';
-        out += `<span style="${prop}:rgb(${r},${g},${b})">`;
-        openSpans += 1;
-        k += 5;
-      } else if ((c === 38 || c === 48) && params[k + 1] === 5 && params.length >= k + 3) {
-        // 256-colour palette: 38;5;n / 48;5;n
-        const prop = c === 38 ? 'color' : 'background-color';
-        out += `<span style="${prop}:${ansi256ToCss(params[k + 2])}">`;
-        openSpans += 1;
-        k += 3;
-      } else if (ANSI_SGR[c]) {
-        out += `<span style="${ANSI_SGR[c]}">`;
-        openSpans += 1;
-        k += 1;
-      } else {
-        k += 1;                             // unknown -- silently drop
-      }
-    }
-    i = endM + 1;
-  }
-  while (openSpans > 0) { out += '</span>'; openSpans -= 1; }
-  return out;
-}
+// ANSI_SGR + ansi256ToCss + ESC_CHARS + HTML_ESC + ansiToHtml moved to
+// utils/formatters.js (KJC-TSK-0501 step 1/8).
 
 /**
  * Open (or refocus) the run-log panel for the given plan. Thin shim
@@ -4146,13 +3831,7 @@ async function patchBoardIncremental() {
   return true;
 }
 
-/**
- * CSS.escape polyfill wrapper. Story IDs can contain "::" and other
- * characters that break querySelector when interpolated raw.
- */
-function cssEscape(str) {
-  return (window.CSS && CSS.escape) ? CSS.escape(str) : String(str).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
-}
+// cssEscape moved to utils/formatters.js (KJC-TSK-0501 step 1/8).
 
 // Auto-refresh every 60 seconds as a SAFETY NET only — the board is
 // SSE-driven (push from server) so this should rarely fire. We keep

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -51,6 +51,7 @@
     <div class="modal" id="modal-content"></div>
   </div>
 
+  <script src="/utils/formatters.js"></script>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/packages/hu-board/public/utils/formatters.js
+++ b/packages/hu-board/public/utils/formatters.js
@@ -1,0 +1,232 @@
+// KJC-TSK-0501 — Pure formatters extracted from app.js (step 1/8).
+// Loaded as a classic script before app.js — all declarations hoist to
+// global scope so app.js consumes them transparently. No ES module syntax
+// here on purpose: app.js still has 16+ inline `onclick="fn(...)"`
+// handlers that rely on global functions. Conversion to `type="module"`
+// will land in a later PR of this split alongside event delegation.
+//
+// Functions here are side-effect-free (no DOM mutation beyond
+// `document.createElement('span')` for HTML-escape, no fetch, no
+// module-level mutable state). Unit-tested directly via
+// packages/hu-board/tests/format.test.js for the three shared helpers.
+
+function formatHHMM(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+function shortTask(text, max = 60) {
+  if (!text) return "";
+  const collapsed = String(text).replace(/\s+/g, " ").trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1).trimEnd() + "…";
+}
+
+function formatSessionLabel(session) {
+  if (!session || !session.id) {
+    return { title: "(no session)", subtitle: "", idChip: "" };
+  }
+  const projectName = (session.project_name || "").trim();
+  const time = formatHHMM(session.created_at);
+  const projectPart = projectName
+    ? projectName.length > 40
+      ? projectName.slice(0, 39) + "…"
+      : projectName
+    : session.id;
+  const title = time !== "—" ? `${projectPart} · ${time}` : projectPart;
+  return {
+    title,
+    subtitle: shortTask(session.task, 60),
+    idChip: session.id,
+  };
+}
+
+function humaniseProjectName(id) {
+  if (!id || typeof id !== 'string') return id || '';
+  const tail = id.split(/[/_]/).filter(Boolean).pop() || id;
+  const words = tail
+    .split(/[\s\-]+/)
+    .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter((w) => w.length > 0);
+  if (words.length === 0) return id;
+  return words.map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase()).join(' ');
+}
+
+function deriveInitialsFromName(name) {
+  const words = String(name || '')
+    .split(/[\s\-_/]+/)
+    .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
+    .filter((w) => w.length > 1);
+  return words.map((w) => w[0].toLowerCase()).join('').slice(0, 5) || 'kj';
+}
+
+function shortStoryId(story, initials) {
+  const id = story?.id || '';
+  const m = /_(\d+)(?!.*\d)/.exec(id);
+  const num = m ? m[1] : '?';
+  return `${initials || 'kj'}-${num}`;
+}
+
+function timeAgo(dateStr) {
+  if (!dateStr) return '';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatDuration(ms) {
+  if (!ms) return '--';
+  const totalSec = Math.floor(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${sec.toString().padStart(2, '0')}s`;
+}
+
+function scoreClass(score, max = 60) {
+  if (score === null || score === undefined) return '';
+  const pct = score / max;
+  if (pct >= 0.7) return 'story-card__score--good';
+  if (pct >= 0.4) return 'story-card__score--ok';
+  return 'story-card__score--bad';
+}
+
+function qualityBar(score, max = 60) {
+  if (score === null || score === undefined) return '';
+  const filled = Math.round((score / max) * 10);
+  let html = '<span class="quality-bar">';
+  for (let i = 0; i < 10; i++) {
+    html += `<span class="quality-bar__segment${i < filled ? ' quality-bar__segment--filled' : ''}"></span>`;
+  }
+  html += '</span>';
+  return html;
+}
+
+function esc(str) {
+  if (!str) return '';
+  const el = document.createElement('span');
+  el.textContent = str;
+  return el.innerHTML;
+}
+
+const EPHEMERAL_HEURISTIC_RE = /^(auto-)?(tmp_|test_|demo_|kj-test-)/i;
+
+function isTestIcon(p) {
+  if (p.is_test === 1) return '🧪';
+  if (p.is_test === 0) return '📌';
+  return EPHEMERAL_HEURISTIC_RE.test(p.id || '') ? '🧪?' : '·';
+}
+
+function isTestTitle(p) {
+  if (p.is_test === 1) return 'Marked as test — auto-cleans 24h after last activity. Click to pin.';
+  if (p.is_test === 0) return 'Pinned — never auto-cleans. Click to clear.';
+  if (EPHEMERAL_HEURISTIC_RE.test(p.id || '')) {
+    return 'Looks ephemeral by id heuristic — will auto-clean after 24h. Click to pin.';
+  }
+  return 'Real project — never auto-cleans. Click to mark as test.';
+}
+
+function truncate(text, max = 100) {
+  if (!text) return '';
+  return text.length > max ? text.slice(0, max) + '...' : text;
+}
+
+function ansi256ToCss(n) {
+  if (n < 0 || n > 255) return 'inherit';
+  const std = [
+    '#000000', '#800000', '#008000', '#808000', '#000080', '#800080', '#008080', '#c0c0c0',
+    '#808080', '#ff0000', '#00ff00', '#ffff00', '#0000ff', '#ff00ff', '#00ffff', '#ffffff',
+  ];
+  if (n < 16) return std[n];
+  if (n < 232) {
+    const idx = n - 16;
+    const r = Math.floor(idx / 36);
+    const g = Math.floor(idx / 6) % 6;
+    const b = idx % 6;
+    const v = (c) => (c === 0 ? 0 : 55 + c * 40);
+    return `rgb(${v(r)},${v(g)},${v(b)})`;
+  }
+  const v = 8 + (n - 232) * 10;
+  return `rgb(${v},${v},${v})`;
+}
+
+const ANSI_SGR = {
+  1: 'font-weight:bold',
+  2: 'opacity:0.65',
+  3: 'font-style:italic',
+  4: 'text-decoration:underline',
+  30: 'color:#1f2937', 31: 'color:#f87171', 32: 'color:#4ade80',
+  33: 'color:#fbbf24', 34: 'color:#60a5fa', 35: 'color:#c084fc',
+  36: 'color:#22d3ee', 37: 'color:#e5e7eb',
+  90: 'color:#9ca3af', 91: 'color:#fca5a5', 92: 'color:#86efac',
+  93: 'color:#fde68a', 94: 'color:#93c5fd', 95: 'color:#d8b4fe',
+  96: 'color:#67e8f9', 97: 'color:#f3f4f6',
+};
+
+const ESC_CHARS = new Set([0x1B, 0x241B]);
+const HTML_ESC = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function ansiToHtml(text) {
+  const src = String(text);
+  const N = src.length;
+  let out = '';
+  let openSpans = 0;
+  let i = 0;
+
+  while (i < N) {
+    const code = src.charCodeAt(i);
+    if (!ESC_CHARS.has(code)) {
+      let j = i + 1;
+      while (j < N && !ESC_CHARS.has(src.charCodeAt(j))) j += 1;
+      out += HTML_ESC(src.slice(i, j));
+      i = j;
+      continue;
+    }
+    if (src[i + 1] !== '[') { i += 1; continue; }
+    const endM = src.indexOf('m', i + 2);
+    if (endM === -1) { i += 1; continue; }
+    const params = src.slice(i + 2, endM).split(';').map((n) => Number(n) || 0);
+    let k = 0;
+    while (k < params.length) {
+      const c = params[k];
+      if (c === 0) {
+        while (openSpans > 0) { out += '</span>'; openSpans -= 1; }
+        k += 1;
+      } else if ((c === 38 || c === 48) && params[k + 1] === 2 && params.length >= k + 5) {
+        const r = params[k + 2], g = params[k + 3], b = params[k + 4];
+        const prop = c === 38 ? 'color' : 'background-color';
+        out += `<span style="${prop}:rgb(${r},${g},${b})">`;
+        openSpans += 1;
+        k += 5;
+      } else if ((c === 38 || c === 48) && params[k + 1] === 5 && params.length >= k + 3) {
+        const prop = c === 38 ? 'color' : 'background-color';
+        out += `<span style="${prop}:${ansi256ToCss(params[k + 2])}">`;
+        openSpans += 1;
+        k += 3;
+      } else if (ANSI_SGR[c]) {
+        out += `<span style="${ANSI_SGR[c]}">`;
+        openSpans += 1;
+        k += 1;
+      } else {
+        k += 1;
+      }
+    }
+    i = endM + 1;
+  }
+  while (openSpans > 0) { out += '</span>'; openSpans -= 1; }
+  return out;
+}
+
+function cssEscape(str) {
+  return (window.CSS && CSS.escape) ? CSS.escape(str) : String(str).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+}


### PR DESCRIPTION
## Summary

Step 1/8 of the app.js split tracked by KJC-TSK-0501. Moves 16 pure formatters out of `packages/hu-board/public/app.js` into a new `packages/hu-board/public/utils/formatters.js`, loaded as a classic script before app.js by `index.html`.

Functions relocated:
- `formatHHMM`, `shortTask`, `formatSessionLabel`
- `humaniseProjectName`, `deriveInitialsFromName`, `shortStoryId`
- `timeAgo`, `formatDuration`, `scoreClass`, `qualityBar`, `esc`, `truncate`
- `isTestIcon`, `isTestTitle` (+ `EPHEMERAL_HEURISTIC_RE`)
- `ansi256ToCss`, `ansiToHtml`, `cssEscape` (+ `ANSI_SGR`, `ESC_CHARS`, `HTML_ESC`)

Net delta: **+246 / −334 LOC = −88** (within the ≤200 budget).

## Design choices

- **Classic script, not `type="module"`.** `app.js` still has 16+ inline `onclick="fn(...)"` handlers embedded in dynamically rendered HTML. Converting to ES modules would silently break those because module-scoped declarations don't hoist to globals. ESM + event-delegation conversion is reserved for a later step of the split.
- **No behaviour change.** Pure relocation — `app.js` keeps consuming the same globals it always did; the only callers that exist already reference them by bare name.

## Follow-ups (this PR is step 1 of 8)

- PR3b: extract `utils/modals.js`
- PR3c: extract `utils/api.js`
- PR3d: split Sessions view
- PR3e: split Board view
- PR3f: split Dashboard + graph
- PR3g: split Story-detail / Projects / Preflight / Logs / Config-launcher
- PR3h: router-only `app.js` + module conversion

## Test plan

- [x] `npx vitest run` — **5426/5426** passing across 491 files locally
- [x] `npx vitest run tests/format.test.js` (hu-board package) — 15/15 (existing helper contract still pinned)
- [ ] Smoke: open the HU Board, verify session cards / story cards / log viewer render correctly (manual; reviewer to confirm in their dogfood pass)