### PR TITLE
fix(tests): stabilise ollama-capability freemem assertion (KJC-BUG-0078)

### DIFF
--- a/tests/rag/ollama-capability.test.js
+++ b/tests/rag/ollama-capability.test.js
@@ -25,8 +25,11 @@ describe("ollama-capability — KJC-TSK-0436", () => {
   });
 
   it("checkRamCapacity passes when free RAM >= minBytes", () => {
-    const free = os.freemem();
-    expect(checkRamCapacity(free - 1)).toMatchObject({ ok: true });
+    // KJC-BUG-0078: anchor minBytes to a deterministic floor (1 byte) instead
+    // of `os.freemem() - 1`. The old form re-sampled `os.freemem()` inside
+    // checkRamCapacity, so any GC pressure between the two reads made
+    // actual < expected and the test flaked during full-suite runs.
+    expect(checkRamCapacity(1)).toMatchObject({ ok: true });
   });
   it("checkRamCapacity fails with reason when below minBytes", () => {
     const r = checkRamCapacity(os.totalmem() * 10);


### PR DESCRIPTION
## Summary
`tests/rag/ollama-capability.test.js:27` (`checkRamCapacity passes when free RAM >= minBytes`) sampled `os.freemem()` once into `free` and then asserted that `checkRamCapacity(free - 1)` returned `{ ok: true }`. Internally `checkRamCapacity` re-samples `os.freemem()`. Under full-suite load — GC pressure from 5 425 other tests — the two reads diverged enough that `actual < expected` flipped the assertion to `{ ok: false }`.

Anchor `minBytes` to a deterministic floor (`1` byte). The branch under test is "passes when free RAM ≥ minBytes" — that branch is exercised correctly without depending on a moving baseline.

Repro before fix: `npx vitest run` (full suite) — flake.
Repro after fix: full suite no longer flips this test. Isolated `npx vitest run tests/rag/ollama-capability.test.js` still passes (9/9).

## Test plan
- [x] `npx vitest run tests/rag/ollama-capability.test.js` — 9/9 passing.
- [ ] CI green.