### PR TITLE
feat(review): tdd-discipline module + config flag (KJC-TSK-0398 PR1)

### DIFF
--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -70,6 +70,11 @@ const DEFAULTS = {
   development: {
     methodology: "tdd",
     require_test_changes: true,
+    // KJC-TSK-0398: opt-in red-then-green gate. When true, the pipeline
+    // stashes source files and re-runs the test suite to confirm the new
+    // tests actually fail without the implementation. Off by default to
+    // preserve current iteration latency.
+    require_red_then_green: false,
     test_file_patterns: ["/tests/", "/__tests__/", ".test.", ".spec."],
     source_file_extensions: [".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".java", ".rb", ".php", ".cs"]
   },

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -115,6 +115,8 @@ const PipelineMap = v.optional(v.looseObject({
 const Development = v.optional(v.looseObject({
   methodology: v.optional(Methodology),
   require_test_changes: v.optional(v.boolean()),
+  // KJC-TSK-0398: opt-in flag; module lands in PR1, integration in PR3.
+  require_red_then_green: v.optional(v.boolean()),
   test_file_patterns: v.optional(v.array(v.string())),
   source_file_extensions: v.optional(v.array(v.string())),
 }));

--- a/src/review/tdd-discipline.js
+++ b/src/review/tdd-discipline.js
@@ -1,0 +1,90 @@
+// TDD discipline gate (KJC-TSK-0398 PR1).
+// PR1 ships the pure decision logic with injected runTests/stashFiles
+// helpers. PR2 ships the real surgical stash. PR3 wires the gate into
+// the pipeline behind `development.require_red_then_green`.
+
+const PARSERS = {
+  vitest: parseVitestFailures,
+  jest: parseVitestFailures,
+  pytest: parsePytestFailures,
+};
+
+function parseVitestFailures(output) {
+  const failures = new Set();
+  for (const line of String(output || "").split("\n")) {
+    const m = line.match(/^\s*(?:FAIL|×|✖)\s+(\S+)/);
+    if (m) failures.add(m[1].trim());
+  }
+  return failures;
+}
+
+function parsePytestFailures(output) {
+  const failures = new Set();
+  for (const line of String(output || "").split("\n")) {
+    const m = line.match(/^FAILED\s+(\S+)/);
+    if (m) failures.add(m[1].trim());
+  }
+  return failures;
+}
+
+function anyNewTestIn(failures, testFiles) {
+  return [...failures].some((f) => testFiles.some((t) => f.includes(t) || t.includes(f)));
+}
+
+export async function verifyTddDiscipline({
+  projectDir,
+  sourceFiles = [],
+  testFiles = [],
+  framework = null,
+  runTests,
+  stashFiles,
+  restoreFiles,
+} = {}) {
+  if (sourceFiles.length === 0) {
+    return { ok: true, reason: "no_source_changes", sourceFiles, testFiles };
+  }
+  if (testFiles.length === 0) {
+    return { ok: true, reason: "no_test_changes", sourceFiles, testFiles };
+  }
+
+  const parser = framework ? PARSERS[framework] : null;
+  if (!parser) {
+    return {
+      ok: true,
+      reason: "framework_unsupported",
+      sourceFiles,
+      testFiles,
+      warning: `tdd-discipline: framework "${framework || "unknown"}" has no failure parser; gate skipped`,
+    };
+  }
+
+  let stashToken = null;
+  try {
+    stashToken = await stashFiles(sourceFiles);
+    const before = await runTests(projectDir);
+    if (!anyNewTestIn(parser(before.output), testFiles)) {
+      return {
+        ok: false,
+        reason: "tests_pass_without_impl",
+        sourceFiles,
+        testFiles,
+        message:
+          "TDD discipline violation: new tests pass without the implementation. Tests must fail first (red), then pass (green).",
+      };
+    }
+  } finally {
+    if (stashToken) await restoreFiles(stashToken);
+  }
+
+  const after = await runTests(projectDir);
+  if (anyNewTestIn(parser(after.output), testFiles)) {
+    return {
+      ok: false,
+      reason: "tests_fail_with_impl",
+      sourceFiles,
+      testFiles,
+      message: "TDD discipline violation: new tests still fail with the implementation present.",
+    };
+  }
+  return { ok: true, reason: "red_then_green_verified", sourceFiles, testFiles };
+}

--- a/tests/review/tdd-discipline.test.js
+++ b/tests/review/tdd-discipline.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { verifyTddDiscipline } from "../../src/review/tdd-discipline.js";
+
+function makeDeps({ outputs = ["", ""], stashToken = "STASH-1" } = {}) {
+  return {
+    runTests: vi.fn(async () => ({ exitCode: 0, output: outputs.shift() ?? "" })),
+    stashFiles: vi.fn(async () => stashToken),
+    restoreFiles: vi.fn(async () => true),
+  };
+}
+
+describe("verifyTddDiscipline", () => {
+  it("skips when there are no source changes", async () => {
+    const deps = makeDeps();
+    const out = await verifyTddDiscipline({
+      sourceFiles: [], testFiles: ["tests/x.test.js"], framework: "vitest", ...deps,
+    });
+    expect(out).toMatchObject({ ok: true, reason: "no_source_changes" });
+    expect(deps.runTests).not.toHaveBeenCalled();
+  });
+
+  it("skips when there are no test changes", async () => {
+    const deps = makeDeps();
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/x.js"], testFiles: [], framework: "vitest", ...deps,
+    });
+    expect(out).toMatchObject({ ok: true, reason: "no_test_changes" });
+    expect(deps.stashFiles).not.toHaveBeenCalled();
+  });
+
+  it("skips with warning when the framework has no parser", async () => {
+    const deps = makeDeps();
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/x.js"], testFiles: ["tests/x.test.js"], framework: "rspec", ...deps,
+    });
+    expect(out.ok).toBe(true);
+    expect(out.reason).toBe("framework_unsupported");
+    expect(out.warning).toMatch(/rspec/);
+  });
+
+  it("fails when new tests pass without the implementation", async () => {
+    const deps = makeDeps({ outputs: ["", ""] });
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], framework: "vitest", ...deps,
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe("tests_pass_without_impl");
+    expect(deps.restoreFiles).toHaveBeenCalledTimes(1);
+    expect(deps.runTests).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes on the red-then-green happy path", async () => {
+    const deps = makeDeps({
+      outputs: [" FAIL  tests/auth.test.js\n", " PASS  tests/auth.test.js\n"],
+    });
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], framework: "vitest", ...deps,
+    });
+    expect(out).toMatchObject({ ok: true, reason: "red_then_green_verified" });
+    expect(deps.runTests).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails when new tests still fail after restoring the implementation", async () => {
+    const deps = makeDeps({
+      outputs: [" FAIL  tests/auth.test.js\n", " FAIL  tests/auth.test.js\n"],
+    });
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], framework: "vitest", ...deps,
+    });
+    expect(out).toMatchObject({ ok: false, reason: "tests_fail_with_impl" });
+  });
+
+  it("restores files even if runTests throws", async () => {
+    const deps = makeDeps();
+    deps.runTests = vi.fn(async () => { throw new Error("boom"); });
+    await expect(verifyTddDiscipline({
+      sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], framework: "vitest", ...deps,
+    })).rejects.toThrow(/boom/);
+    expect(deps.restoreFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognises pytest failures", async () => {
+    const deps = makeDeps({
+      outputs: ["FAILED tests/test_auth.py::test_login\n", "1 passed\n"],
+    });
+    const out = await verifyTddDiscipline({
+      sourceFiles: ["src/auth.py"], testFiles: ["tests/test_auth.py"], framework: "pytest", ...deps,
+    });
+    expect(out).toMatchObject({ ok: true, reason: "red_then_green_verified" });
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/review/tdd-discipline.js`: pure `verifyTddDiscipline()` with injected `runTests` / `stashFiles` / `restoreFiles` helpers. Detects red-then-green discipline (tests fail without impl, pass with impl) using framework-specific failure parsers (vitest, jest, pytest).
- New unit tests `tests/review/tdd-discipline.test.js` — 8 cases covering happy path, both failure modes, error-safe restore (finally), and skip cases (no source / no tests / framework unsupported).
- Config: `development.require_red_then_green: false` added to `defaults.js` and `schema.js` (Valibot). Module is exported but **not yet integrated** in the pipeline — that lands in PR3.

PR2 will ship the surgical stash helper (`git stash` + untracked move-aside). PR3 will wire `runTddDisciplineStage` into `coder-stage.js` / `quality-gates.js` behind the flag.

Net delta: **188 LOC** (well under the 200-LOC PR atomicity gate).

## Test plan
- [x] `npx vitest run tests/review/tdd-discipline.test.js` — 8/8 pass
- [ ] CI: Lint + Tests + Coverage + LOC budget + commit messages + prettier