### PR TITLE
feat(review): surgical stash helper (KJC-TSK-0398 PR2)

### DIFF
--- a/src/review/git-stash-helper.js
+++ b/src/review/git-stash-helper.js
@@ -1,0 +1,104 @@
+// Surgical stash helper for the TDD discipline gate (KJC-TSK-0398 PR2).
+// Stashes only the source files we want to hide for the "red" run and
+// restores them afterwards. Tracked files use `git stash push -- <paths>`;
+// untracked files (not yet known to git) are moved aside to a private
+// `.karajan/tmp/stash-<id>/` tree because `git stash` would ignore them.
+
+import { mkdir, rename, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { runCommand } from "../utils/process.js";
+
+function defaultRunner(cmd, args, opts) {
+  return runCommand(cmd, args, opts);
+}
+
+async function isTracked(runner, projectDir, file) {
+  const res = await runner("git", ["ls-files", "--error-unmatch", "--", file], { cwd: projectDir });
+  return res.exitCode === 0;
+}
+
+async function stashRefForToken(runner, projectDir, marker) {
+  const res = await runner("git", ["stash", "list"], { cwd: projectDir });
+  if (res.exitCode !== 0) return null;
+  for (const line of String(res.stdout || "").split("\n")) {
+    if (line.includes(marker)) {
+      const m = line.match(/^(stash@\{\d+\})/);
+      if (m) return m[1];
+    }
+  }
+  return null;
+}
+
+// Move `files` aside so a test run sees them as missing. Returns a token to
+// pass to `restoreFiles()`. Throws on failure with the partial token attached.
+export async function stashFilesAside(files, { projectDir = process.cwd(), runner = defaultRunner, tmpRoot } = {}) {
+  if (!Array.isArray(files) || files.length === 0) {
+    return { trackedStashRef: null, untrackedMoves: [], marker: null };
+  }
+  const tracked = [];
+  const untracked = [];
+  for (const f of files) {
+    if (await isTracked(runner, projectDir, f)) tracked.push(f);
+    else if (existsSync(resolve(projectDir, f))) untracked.push(f);
+  }
+
+  const marker = `kj-tdd-discipline-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const stashRoot = tmpRoot || join(projectDir, ".karajan", "tmp", marker);
+  const untrackedMoves = [];
+  let trackedStashRef = null;
+
+  if (tracked.length > 0) {
+    const args = ["stash", "push", "--keep-index", "-m", marker, "--", ...tracked];
+    const res = await runner("git", args, { cwd: projectDir });
+    if (res.exitCode !== 0) {
+      throw new Error(`git stash push failed: ${res.stderr || res.stdout}`);
+    }
+    trackedStashRef = await stashRefForToken(runner, projectDir, marker);
+  }
+
+  for (const f of untracked) {
+    const src = resolve(projectDir, f);
+    const dst = join(stashRoot, f);
+    await mkdir(dirname(dst), { recursive: true });
+    await rename(src, dst);
+    untrackedMoves.push({ src, dst });
+  }
+
+  return { trackedStashRef, untrackedMoves, marker, stashRoot };
+}
+
+// Reverse a `stashFilesAside` token. Idempotent: a restored token becomes a no-op.
+export async function restoreFiles(token, { projectDir = process.cwd(), runner = defaultRunner } = {}) {
+  if (!token || (token.trackedStashRef == null && token.untrackedMoves.length === 0)) return;
+
+  for (const { src, dst } of token.untrackedMoves) {
+    if (existsSync(dst)) {
+      await mkdir(dirname(src), { recursive: true });
+      await rename(dst, src);
+    }
+  }
+  if (token.stashRoot && existsSync(token.stashRoot)) {
+    await rm(token.stashRoot, { recursive: true, force: true });
+  }
+
+  if (token.trackedStashRef) {
+    const res = await runner("git", ["stash", "pop", token.trackedStashRef], { cwd: projectDir });
+    if (res.exitCode !== 0) {
+      throw new Error(`git stash pop failed: ${res.stderr || res.stdout}`);
+    }
+  }
+  token.trackedStashRef = null;
+  token.untrackedMoves = [];
+}
+
+// Run `body` with `files` stashed aside, always restoring them — even when
+// `body` throws. The TDD discipline stage wraps its "red" run with this.
+export async function withStashedFiles(files, body, opts = {}) {
+  const token = await stashFilesAside(files, opts);
+  try {
+    return await body(token);
+  } finally {
+    await restoreFiles(token, opts).catch(() => { /* swallow: surface body error */ });
+  }
+}

--- a/tests/review/git-stash-helper.test.js
+++ b/tests/review/git-stash-helper.test.js
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  restoreFiles,
+  stashFilesAside,
+  withStashedFiles,
+} from "../../src/review/git-stash-helper.js";
+
+function makeRunner({ trackedFiles = new Set() } = {}) {
+  let marker = null;
+  const fn = vi.fn(async (_cmd, args) => {
+    const [sub, sub2] = args;
+    if (sub === "ls-files" && args.includes("--error-unmatch")) {
+      const file = args[args.length - 1];
+      return { exitCode: trackedFiles.has(file) ? 0 : 1, stdout: "", stderr: "" };
+    }
+    if (sub === "stash" && sub2 === "push") {
+      marker = args[args.indexOf("-m") + 1];
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    if (sub === "stash" && sub2 === "list") {
+      return { exitCode: 0, stdout: `stash@{0}: ${marker || ""}\n`, stderr: "" };
+    }
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
+  return fn;
+}
+
+describe("git-stash-helper", () => {
+  let projectDir;
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "kj-stash-test-"));
+  });
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("no-ops on empty file list", async () => {
+    const runner = makeRunner();
+    const token = await stashFilesAside([], { projectDir, runner });
+    expect(token).toMatchObject({ trackedStashRef: null, untrackedMoves: [], marker: null });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("moves untracked files aside and restores them", async () => {
+    await writeFile(join(projectDir, "u.js"), "hello");
+    const runner = makeRunner();
+    const token = await stashFilesAside(["u.js"], { projectDir, runner });
+    expect(existsSync(join(projectDir, "u.js"))).toBe(false);
+    expect(token.untrackedMoves).toHaveLength(1);
+    await restoreFiles(token, { projectDir, runner });
+    expect(await readFile(join(projectDir, "u.js"), "utf8")).toBe("hello");
+  });
+
+  it("stashes tracked files via git stash push and pops on restore", async () => {
+    const runner = makeRunner({ trackedFiles: new Set(["t.js"]) });
+    const token = await stashFilesAside(["t.js"], { projectDir, runner });
+    expect(token.trackedStashRef).toBe("stash@{0}");
+    await restoreFiles(token, { projectDir, runner });
+    expect(runner).toHaveBeenCalledWith("git", ["stash", "pop", "stash@{0}"], { cwd: projectDir });
+  });
+
+  it("throws when git stash push fails", async () => {
+    const runner = vi.fn(async (_cmd, args) => {
+      if (args[0] === "ls-files") return { exitCode: 0, stdout: "", stderr: "" };
+      if (args[0] === "stash" && args[1] === "push") {
+        return { exitCode: 1, stdout: "", stderr: "boom" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    await expect(stashFilesAside(["t.js"], { projectDir, runner })).rejects.toThrow(/boom/);
+  });
+
+  it("withStashedFiles restores even when body throws", async () => {
+    await writeFile(join(projectDir, "u.js"), "x");
+    const runner = makeRunner();
+    await expect(
+      withStashedFiles(["u.js"], async () => { throw new Error("body"); }, { projectDir, runner })
+    ).rejects.toThrow(/body/);
+    expect(existsSync(join(projectDir, "u.js"))).toBe(true);
+  });
+
+  it("restoreFiles is idempotent for already-empty tokens", async () => {
+    const token = { trackedStashRef: null, untrackedMoves: [] };
+    await expect(restoreFiles(token, { projectDir, runner: makeRunner() })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- PR2 of the TDD discipline gate (KJC-TSK-0398).
- Adds `src/review/git-stash-helper.js` with `stashFilesAside`, `restoreFiles`, `withStashedFiles`.
- Tracked files → `git stash push --keep-index -m <marker> -- <files>`.
- Untracked files → moved to `.karajan/tmp/<marker>/` (git stash would ignore them).
- Token shape `{ trackedStashRef, untrackedMoves[], marker, stashRoot }` — idempotent restore.
- Runner injectable for unit tests; default is `runCommand` from `src/utils/process.js`.

## Test plan
- [x] `npx vitest run tests/review/git-stash-helper.test.js` — 6/6 passing
- [x] Covers: empty input no-op, untracked round-trip, tracked stash+pop, push failure error, withStashedFiles restoring on body throw, idempotent re-restore.
- [x] Net delta 194 LOC ≤ 200 budget.

## Next
PR3 will wire `verifyTddDiscipline` + this helper into the pipeline behind `development.require_red_then_green`.