### PR TITLE
feat(orchestrator): wire tdd-discipline into pipeline (KJC-TSK-0398 PR3)

### DIFF
--- a/src/orchestrator/drivers/iteration-phases/quality-gates.js
+++ b/src/orchestrator/drivers/iteration-phases/quality-gates.js
@@ -19,12 +19,23 @@ import {
 } from "../../iteration-stages.js";
 import { runImpeccableStage } from "../../post-loop-stages.js";
 import { runPerfStage } from "../../stages/perf-stage.js";
+import { runTddDisciplineStage } from "../../stages/tdd-discipline-stage.js";
 import { tryCiComment } from "../../ci-integration.js";
 
 export async function runQualityGateStages({ config, logger, emitter, eventBase, session, trackBudget, i, askQuestion, repeatDetector, budgetSummary, sonarState, task, stageResults, coderRole, pipelineFlags, brainCtx }) {
   const tddResult = await runTddCheckStage({ config, logger, emitter, eventBase, session, trackBudget, iteration: i, askQuestion, task, brainCtx });
   if (tddResult.action === "pause") return { action: "return", result: tddResult.result };
   if (tddResult.action === "continue") return { action: "continue" };
+
+  // KJC-TSK-0398 PR3: opt-in red-then-green check.
+  if (config.development?.require_red_then_green) {
+    const disc = await runTddDisciplineStage({
+      config, logger, emitter, eventBase,
+      sourceFiles: tddResult.sourceFiles || [],
+      testFiles: tddResult.testFiles || [],
+    });
+    if (disc.action === "continue") return { action: "continue" };
+  }
 
   // Sonar runs for code tasks per policy. Since v2.7.4 it is NOT
   // toggleable via config — that's intrinsic to Karajan. The taskType

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -459,5 +459,5 @@ export async function runTddCheckStage({ config, logger, emitter, eventBase, ses
     return handleTddFailure({ tddEval, config, logger, emitter, eventBase, session, iteration, askQuestion, task, brainCtx });
   }
 
-  return { action: "ok" };
+  return { action: "ok", sourceFiles: tddEval.sourceFiles, testFiles: tddEval.testFiles };
 }

--- a/src/orchestrator/stages/tdd-discipline-stage.js
+++ b/src/orchestrator/stages/tdd-discipline-stage.js
@@ -1,0 +1,56 @@
+// TDD discipline stage (KJC-TSK-0398 PR3).
+// Runs the red-then-green check when `development.require_red_then_green`
+// is true. Wraps `verifyTddDiscipline` with the surgical stash helper and
+// the project's detected test framework. Gate is opt-in; an unsupported
+// framework reports a warning and does not block the iteration.
+
+import { detectTestFramework } from "../../utils/project-detect.js";
+import { verifyTddDiscipline } from "../../review/tdd-discipline.js";
+import { stashFilesAside, restoreFiles } from "../../review/git-stash-helper.js";
+import { runCommand } from "../../utils/process.js";
+import { emitProgress, makeEvent } from "../../utils/events.js";
+
+const TDD_DISCIPLINE_COMMANDS = {
+  vitest: ["npx", ["vitest", "run", "--reporter=verbose"]],
+  jest: ["npx", ["jest", "--verbose"]],
+  pytest: ["pytest", ["--tb=short"]],
+};
+
+export async function runTddDisciplineStage({
+  config, logger, emitter, eventBase, sourceFiles = [], testFiles = [],
+  detectFramework = detectTestFramework,
+  runTestsImpl,
+  stashImpl = stashFilesAside,
+  restoreImpl = restoreFiles,
+} = {}) {
+  const projectDir = config?.projectDir || process.cwd();
+  const detection = await detectFramework(projectDir);
+  const framework = detection?.framework || null;
+
+  const runTests = runTestsImpl || (async () => {
+    const cmd = TDD_DISCIPLINE_COMMANDS[framework];
+    if (!cmd) return { exitCode: 0, output: "" };
+    const res = await runCommand(cmd[0], cmd[1], { cwd: projectDir, reject: false });
+    return { exitCode: res.exitCode ?? 0, output: `${res.stdout || ""}\n${res.stderr || ""}` };
+  });
+
+  const result = await verifyTddDiscipline({
+    projectDir, sourceFiles, testFiles, framework,
+    runTests,
+    stashFiles: (files) => stashImpl(files, { projectDir }),
+    restoreFiles: (token) => restoreImpl(token, { projectDir }),
+  });
+
+  emitProgress(emitter, makeEvent("tdd:discipline", { ...eventBase, stage: "tdd" }, {
+    status: result.ok ? "ok" : "fail",
+    message: result.message || `TDD discipline: ${result.reason}`,
+    detail: { reason: result.reason, framework },
+  }));
+
+  if (result.warning) logger?.warn?.(result.warning);
+  if (!result.ok) {
+    logger?.warn?.(`TDD discipline violation: ${result.reason}`);
+    return { action: "continue", result };
+  }
+  return { action: "ok", result };
+}

--- a/tests/orchestrator/stages/tdd-discipline-stage.test.js
+++ b/tests/orchestrator/stages/tdd-discipline-stage.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { runTddDisciplineStage } from "../../../src/orchestrator/stages/tdd-discipline-stage.js";
+
+function makeDeps({ framework = "vitest", outputs = ["", ""] } = {}) {
+  return {
+    detectFramework: vi.fn(async () => ({ framework })),
+    runTestsImpl: vi.fn(async () => ({ exitCode: 0, output: outputs.shift() ?? "" })),
+    stashImpl: vi.fn(async () => ({ trackedStashRef: null, untrackedMoves: [], marker: "M" })),
+    restoreImpl: vi.fn(async () => undefined),
+  };
+}
+
+const baseArgs = {
+  config: { projectDir: "/tmp/x" },
+  logger: { warn: vi.fn() },
+  emitter: { emit: vi.fn() },
+  eventBase: {},
+};
+
+describe("runTddDisciplineStage", () => {
+  it("returns ok with framework_unsupported when detection has no framework", async () => {
+    const deps = makeDeps({ framework: null });
+    const out = await runTddDisciplineStage({
+      ...baseArgs, sourceFiles: ["src/x.js"], testFiles: ["tests/x.test.js"], ...deps,
+    });
+    expect(out.action).toBe("ok");
+    expect(out.result.reason).toBe("framework_unsupported");
+    expect(deps.runTestsImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns continue when new tests pass without the implementation", async () => {
+    const deps = makeDeps({ outputs: ["", ""] });
+    const out = await runTddDisciplineStage({
+      ...baseArgs, sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], ...deps,
+    });
+    expect(out.action).toBe("continue");
+    expect(out.result.reason).toBe("tests_pass_without_impl");
+    expect(deps.stashImpl).toHaveBeenCalledTimes(1);
+    expect(deps.restoreImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns ok on red-then-green happy path", async () => {
+    const deps = makeDeps({
+      outputs: [" FAIL  tests/auth.test.js\n", " PASS  tests/auth.test.js\n"],
+    });
+    const out = await runTddDisciplineStage({
+      ...baseArgs, sourceFiles: ["src/auth.js"], testFiles: ["tests/auth.test.js"], ...deps,
+    });
+    expect(out.action).toBe("ok");
+    expect(out.result.reason).toBe("red_then_green_verified");
+  });
+
+  it("recognises pytest framework via detector", async () => {
+    const deps = makeDeps({
+      framework: "pytest",
+      outputs: ["FAILED tests/test_auth.py::t\n", "1 passed\n"],
+    });
+    const out = await runTddDisciplineStage({
+      ...baseArgs, sourceFiles: ["src/auth.py"], testFiles: ["tests/test_auth.py"], ...deps,
+    });
+    expect(out.action).toBe("ok");
+    expect(deps.detectFramework).toHaveBeenCalledWith("/tmp/x");
+  });
+
+  it("skips when there are no source files", async () => {
+    const deps = makeDeps();
+    const out = await runTddDisciplineStage({
+      ...baseArgs, sourceFiles: [], testFiles: ["tests/x.test.js"], ...deps,
+    });
+    expect(out.action).toBe("ok");
+    expect(out.result.reason).toBe("no_source_changes");
+    expect(deps.stashImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- PR3 of the TDD discipline gate. **Closes KJC-TSK-0398.**
- New `src/orchestrator/stages/tdd-discipline-stage.js` glues `verifyTddDiscipline` (PR1) and the surgical stash helper (PR2) to the project's detected test framework.
- Wired into `quality-gates.js` right after the existing TDD policy check, gated on `development.require_red_then_green` (off by default — no behavioural change for current runs).
- `runTddCheckStage` now returns `{ sourceFiles, testFiles }` on success so the discipline stage reuses the diff classification.

## Supported frameworks (PR3)
- vitest, jest → `npx <runner> --reporter=verbose`
- pytest → `pytest --tb=short`
- Anything else → warning + skip (no block).

## Test plan
- [x] `npx vitest run tests/orchestrator/stages/tdd-discipline-stage.test.js` — 5/5
- [x] Regression: `tests/runflow-iteration.test.js`, `tests/iteration-stages-unit.test.js` — 34/34
- [x] PR1+PR2 modules still green — 14/14
- [x] Net delta 141 LOC ≤ 200 budget.

## Wraps up KJC-TSK-0398
PR1 (#957) — pure decision module + config flag.
PR2 (#958) — surgical stash helper.
PR3 (this) — pipeline integration.