### PR TITLE
feat(hu-board): api only accepts canonical statuses with legacy suggestion (KJC-TSK-0394)

### DIFF
--- a/packages/hu-board/public/utils/story-detail-view.js
+++ b/packages/hu-board/public/utils/story-detail-view.js
@@ -59,9 +59,13 @@ async function showStoryDetail(storyId) {
     // reviewing/running (esos los pone el orquestador; setearlos a
     // mano genera zombies en el reaper).
     const canChangeStatus = !!story.plan_id;
-    // KJC-TSK-0403: 'failed' eliminado del dropdown — result=fail vive en
-    // la HU via outcome.blockers, no como status manual.
-    const userSettableStatuses = ['pending', 'certified', 'done', 'blocked', 'needs_context'];
+    // KJC-TSK-0394 PR6 (AC 6): dropdown alineado con el modelo canónico
+    // que acepta el endpoint. `running` queda fuera porque settearlo a
+    // mano genera zombies (lifecycle del orquestador). Los status legacy
+    // (`certified`, `blocked`, `needs_context`) ya no se ofrecen — los
+    // plans en disco siguen vivos pero la UI sólo emite escrituras
+    // canónicas. Reset → pending y Run → running cubren el flujo.
+    const userSettableStatuses = ['pending', 'done'];
 
     content.innerHTML = `
       <div class="modal__header">

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -545,15 +545,27 @@ router.post('/tombstones/:type/:id/restore', (req, res) => {
  * rewritten before we ack, then re-synced into SQLite, so a reload
  * renders the committed state.
  */
-// Status que el USUARIO puede setear manualmente vía el dropdown del
-// modal. NO incluimos coding/reviewing/running — esos son lifecycle
-// del orquestador (settearlos a mano genera zombies). Tampoco
-// incluimos los canonicales (`running`) por la misma razón. `failed`
-// y `blocked` son útiles para que el usuario marque manualmente HUs
-// que no quiere correr ahora.
-// KJC-TSK-0403: 'failed' eliminado — el orquestador estampa result=fail
-// dejando status=pending. Setearlo a mano vía PATCH ya no tiene sentido.
-const ALLOWED_STORY_STATUSES = new Set(['pending', 'certified', 'done', 'blocked', 'needs_context']);
+// KJC-TSK-0394 PR6 (AC 6): el PATCH endpoint sólo acepta el modelo
+// canónico {pending, running, done}. Status legacy (`certified`,
+// `coding`, `reviewing`, `failed`, `blocked`, `needs_context`) siguen
+// vivos en plans existentes y los traduce la UI con canonicalStatus(),
+// pero NO pueden ser seteados por escrituras nuevas — devolvemos 400
+// con `suggestion` apuntando al mapping correcto. `running` queda fuera
+// del dropdown del modal (lifecycle del orquestador), pero el endpoint
+// lo acepta por si un programa externo lo necesita.
+const ALLOWED_STORY_STATUSES = new Set(['pending', 'running', 'done']);
+// Mapping canónico para la sugerencia del 400 cuando el caller manda
+// un valor legacy. Mantenemos la regla viva en src/plan/plan-schema.js
+// (mapLegacyStatusToResult) — esta tabla es sólo el subset accionable
+// desde el endpoint (status + result).
+const LEGACY_STATUS_SUGGESTION = {
+  certified: { status: 'done', result: 'pass' },
+  failed: { status: 'pending', result: 'fail' },
+  coding: { status: 'running', result: null },
+  reviewing: { status: 'running', result: null },
+  blocked: { status: 'pending', result: null },
+  needs_context: { status: 'pending', result: null },
+};
 // KJC-TSK-0406: coder_model y reviewer_model son editables desde el
 // modal del board. Independientes — el usuario puede subir el reviewer
 // y bajar el coder sin afectar al resto del plan.
@@ -579,8 +591,14 @@ router.patch('/stories/:id', (req, res) => {
       });
     }
     if (hasStatus && !ALLOWED_STORY_STATUSES.has(body.status)) {
+      // KJC-TSK-0394 PR6 (AC 6): si el caller manda un status legacy,
+      // devolvemos un 400 con `suggestion` apuntando al mapping canónico.
+      // Una herramienta externa puede leer el body, aplicar el mapeo y
+      // re-intentar — sin tener que descubrir la tabla por ensayo y error.
+      const suggestion = LEGACY_STATUS_SUGGESTION[body.status] || null;
       return res.status(400).json({
         error: `status must be one of: ${[...ALLOWED_STORY_STATUSES].join(', ')}`,
+        suggestion,
       });
     }
 

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -263,6 +263,84 @@ describe('PATCH /api/projects/:id/is-test', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// PATCH /api/stories/:id — KJC-TSK-0394 PR6 (AC 6).
+//
+// El endpoint sólo acepta el modelo canónico {pending, running, done}.
+// Status legacy (`certified`, `failed`, `coding`, `reviewing`, `blocked`,
+// `needs_context`) devuelven 400 con `suggestion` apuntando al mapping
+// canónico {status, result} — herramientas externas pueden leerlo,
+// aplicar el mapeo, y re-intentar sin descubrir la tabla por ensayo.
+// Status desconocido también devuelve 400, con `suggestion: null`.
+// ---------------------------------------------------------------------------
+describe('PATCH /api/stories/:id — canonical status guard (KJC-TSK-0394 AC 6)', () => {
+  it('returns 400 + suggestion when status is legacy "certified"', async () => {
+    seed();
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'certified' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/status must be one of/);
+    expect(res.body.suggestion).toEqual({ status: 'done', result: 'pass' });
+  });
+
+  it('returns 400 + suggestion when status is legacy "failed"', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'failed' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toEqual({ status: 'pending', result: 'fail' });
+  });
+
+  it('returns 400 + suggestion when status is legacy "coding"', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'coding' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toEqual({ status: 'running', result: null });
+  });
+
+  it('returns 400 + suggestion when status is legacy "reviewing"', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'reviewing' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toEqual({ status: 'running', result: null });
+  });
+
+  it('returns 400 + suggestion when status is legacy "blocked"', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'blocked' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toEqual({ status: 'pending', result: null });
+  });
+
+  it('returns 400 + suggestion when status is legacy "needs_context"', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'needs_context' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toEqual({ status: 'pending', result: null });
+  });
+
+  it('returns 400 + suggestion:null when status is unknown', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({ status: 'banana' });
+    expect(res.status).toBe(400);
+    expect(res.body.suggestion).toBeNull();
+  });
+
+  it('returns 400 when body has neither status nor editable field', async () => {
+    const res = await request(app)
+      .patch('/api/stories/story-1')
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Body must include status/);
+  });
+});
+
 // KJC-TSK-0414 PR4
 describe('GET /api/standby', () => {
   it('lista vacía cuando no hay sesiones hibernadas', async () => {

--- a/packages/hu-board/tests/plan-mutations.test.js
+++ b/packages/hu-board/tests/plan-mutations.test.js
@@ -97,39 +97,41 @@ afterEach(() => {
 });
 
 describe('PATCH /api/stories/:id', () => {
-  it('certifies a pending HU and writes the new status to the plan JSON', async () => {
+  it('marks a pending HU as done and writes the new status to the plan JSON', async () => {
+    // KJC-TSK-0394 PR6: la API ya sólo acepta {pending, running, done}.
+    // `done` es el equivalente canónico del legacy `certified`.
     const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
     const res = await request(app)
       .patch(`/api/stories/${encodeURIComponent(storyId)}`)
-      .send({ status: 'certified' });
+      .send({ status: 'done' });
 
     expect(res.status).toBe(200);
-    expect(res.body.status).toBe('certified');
+    expect(res.body.status).toBe('done');
 
     const diskPlan = readPlanFromDisk();
     const hu = diskPlan.hus.find((h) => h.id === `${PLAN_ID}_001`);
-    expect(hu.status).toBe('certified');
+    expect(hu.status).toBe('done');
   });
 
-  it('auto-advances plan.status to ready when every HU ends up certified', async () => {
+  it('auto-advances plan.status to ready when every HU ends up done', async () => {
     for (const n of ['001', '002', '003']) {
       await request(app)
         .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_${n}`)}`)
-        .send({ status: 'certified' });
+        .send({ status: 'done' });
     }
     const diskPlan = readPlanFromDisk();
     expect(diskPlan.status).toBe('ready');
   });
 
-  it('rolls plan.status back to draft when a certified HU is downgraded', async () => {
+  it('rolls plan.status back to draft when a done HU is downgraded to pending', async () => {
     // First make the plan ready...
     for (const n of ['001', '002', '003']) {
       await request(app)
         .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_${n}`)}`)
-        .send({ status: 'certified' });
+        .send({ status: 'done' });
     }
     expect(readPlanFromDisk().status).toBe('ready');
-    // ...then uncertify one.
+    // ...then revert one back to pending.
     const res = await request(app)
       .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_002`)}`)
       .send({ status: 'pending' });
@@ -149,7 +151,7 @@ describe('PATCH /api/stories/:id', () => {
   it('returns 404 for an unknown story id', async () => {
     const res = await request(app)
       .patch('/api/stories/nope')
-      .send({ status: 'certified' });
+      .send({ status: 'done' });
     expect(res.status).toBe(404);
   });
 
@@ -179,34 +181,28 @@ describe('PATCH /api/stories/:id', () => {
     expect(hu.result).toBe('fail');
   });
 
-  // KJC-TSK-0403: 'failed' eliminado del dropdown — el orquestador
-  // estampa result=fail dejando status=pending. Setearlo a mano ya no
-  // tiene sentido. Set permitido: pending/certified/done/blocked/needs_context.
-  it.each(['certified', 'done', 'blocked', 'needs_context'])(
-    'PATCH stories acepta cambiar a "%s" manualmente',
-    async (target) => {
-      const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
-      const res = await request(app)
-        .patch(`/api/stories/${encodeURIComponent(storyId)}`)
-        .send({ status: target });
-      expect(res.status).toBe(200);
-      const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
-      expect(hu.status).toBe(target);
-    },
-  );
-
-  // KJC-TSK-0403: 'failed' explícitamente RECHAZADO.
-  it('PATCH stories RECHAZA status="failed" con 400 (KJC-TSK-0403)', async () => {
+  // KJC-TSK-0394 PR6: PATCH sólo acepta canónicos {pending, running, done}.
+  // Status legacy (certified, failed, blocked, needs_context, coding,
+  // reviewing) devuelven 400 con `suggestion` — cobertura específica de
+  // ese mapping vive en api.test.js. Aquí sólo confirmamos que el happy
+  // path con `done` (el reemplazo canónico del legacy `certified`) llega
+  // al plan-mutations runtime y escribe el plan-on-disk.
+  it('PATCH stories acepta cambiar a "done" manualmente', async () => {
     const storyId = `${PROJECT_ID}::${PLAN_ID}_001`;
     const res = await request(app)
       .patch(`/api/stories/${encodeURIComponent(storyId)}`)
-      .send({ status: 'failed' });
-    expect(res.status).toBe(400);
+      .send({ status: 'done' });
+    expect(res.status).toBe(200);
+    const hu = readPlanFromDisk().hus.find((h) => h.id === `${PLAN_ID}_001`);
+    expect(hu.status).toBe('done');
   });
 
-  // NO se permite settear lifecycle del orquestador (genera zombies).
-  it.each(['coding', 'reviewing', 'running'])(
-    'PATCH stories RECHAZA status del orquestador "%s" con 400',
+  // KJC-TSK-0394 PR6: `running` SÍ es canónico — el endpoint lo acepta
+  // (útil para programas externos), aunque el dropdown del modal no lo
+  // ofrezca (lifecycle del orquestador). 'coding' y 'reviewing' siguen
+  // rechazados porque son etiquetas legacy ya no representables.
+  it.each(['coding', 'reviewing'])(
+    'PATCH stories RECHAZA status legacy del orquestador "%s" con 400',
     async (target) => {
       const res = await request(app)
         .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_001`)}`)
@@ -451,12 +447,12 @@ describe('PATCH /api/stories/:id - field edits (title, scope, task_type, accepta
   it('allows combining a status change with field edits in one PATCH', async () => {
     const res = await request(app)
       .patch(`/api/stories/${encodeURIComponent(storyId)}`)
-      .send({ title: 'combined edit', status: 'certified' });
+      .send({ title: 'combined edit', status: 'done' });
     expect(res.status).toBe(200);
     const plan = readPlanFromDisk();
     const hu = plan.hus.find((h) => h.id === `${PLAN_ID}_001`);
     expect(hu.title).toBe('combined edit');
-    expect(hu.status).toBe('certified');
+    expect(hu.status).toBe('done');
   });
 
   it('ignores unknown fields', async () => {
@@ -551,11 +547,11 @@ describe('POST /api/runs/:planId/stop + GET /api/runs/:planId/active', () => {
   });
 
   it('POST /stop resetea HUs en coding/reviewing del plan a pending', async () => {
-    // Pasamos la HU 001 a coding manualmente vía API para tener algo
+    // Pasamos la HU 001 a done manualmente vía API para tener algo
     // que resetear. Esto NO necesita un run real, solo el reset de DB.
     await request(app)
       .patch(`/api/stories/${encodeURIComponent(`${PROJECT_ID}::${PLAN_ID}_001`)}`)
-      .send({ status: 'certified' });
+      .send({ status: 'done' });
     // Ahora simulamos que estaba coding (bypass API porque no acepta coding):
     dbMod.getDb().prepare(
       "UPDATE stories SET status = 'coding' WHERE id = ?"


### PR DESCRIPTION
## Summary

Closes AC 6 de KJC-TSK-0394 (canonical HU status model). `PATCH /api/stories/:id` y el dropdown del modal sólo aceptan/ofrecen el modelo canónico `{pending, running, done}`. Los valores legacy devuelven 400 con `suggestion` apuntando al mapeo `{status, result}` correspondiente — herramientas externas pueden leerlo, aplicar el mapeo, y reintentar sin descubrir la tabla por ensayo.

(Reemplaza PR #961 — mismo contenido, header reescrito en minúsculas para pasar commitlint `subject-case`.)

## What changed

- **`src/routes/api.js`**: `ALLOWED_STORY_STATUSES = {pending, running, done}` + `LEGACY_STATUS_SUGGESTION` table. 400 incluye `suggestion: {status, result} | null`.
- **`public/utils/story-detail-view.js`**: dropdown `userSettableStatuses = ['pending', 'done']` (sin legacy, sin `running` — los settea el orquestador).
- **`tests/api.test.js`**: +78 LOC, 8 nuevos casos cubren los 6 valores legacy + unknown + empty body.
- **`tests/plan-mutations.test.js`**: tests migrados de `'certified'` → `'done'`. El runtime de `setHuStatus` ya acepta ambos como terminales para `plan.status='ready'` (compat backwards garantizada, ver `src/plan-mutations.js:124`).

## Deferred (documented, NOT part of this PR)

El runtime de `setHuStatus` sigue tratando `'certified'` como terminal por compat. Migración completa a sólo `'done'` queda para una task de seguimiento — requiere normalizar planes legacy en disco.

## Test plan

- [x] `npm test` — 5 445/5 445 root suite passing
- [x] `npm test -w packages/hu-board` — 375/375 hu-board passing
- [x] LOC budget: net +96 (well under 200)
- [x] commitlint header: 89 chars, lowercase subject