### PR TITLE
fix(resilience): pin clock in hibernate e2e quota test (KJC-BUG-0079)

### DIFF
--- a/tests/resilience/hibernate-end-to-end.test.js
+++ b/tests/resilience/hibernate-end-to-end.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { classifyAgentError, ERROR_CLASS } from "../../src/brain/agent-error-classifier.js";
 import { withBrainRecovery } from "../../src/brain/with-brain-recovery.js";
@@ -35,17 +35,26 @@ describe("resilience: quota exhaustion end to end", () => {
   // literal in the stderr and resolves via Intl.DateTimeFormat. Test passes on
   // any host TZ; the v2.27.0 skip-in-CI workaround is gone.
   it("classifies the Claude Code session limit as a recoverable quota cap", () => {
-    // The original user-reported message uses the 12-hour clock; parseCooldown
-    // must understand it. Resilience tripwire for #756 — independent of how
-    // long the wait will be (that's tested via the ISO path below).
-    const cls = classifyAgentError({
-      provider: "claude",
-      stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
-      exitCode: 1,
-    });
-    expect(cls.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
-    expect(cls.recoverable).toBe(true);
-    expect(cls.retryAfter).toBeGreaterThan(0);
+    // KJC-BUG-0079: the classifier splits RATE_LIMIT_SHORT vs
+    // QUOTA_EXHAUSTED_DAILY at the 1h threshold. With a literal "10:10pm
+    // Madrid" in the stderr, a CI run between 19:10-21:10 UTC resolves
+    // the cooldown to <1h and the assertion below flips. Pin "now" to a
+    // morning hour so the gap to 22:10 Madrid is always >12h, regardless
+    // of the host TZ.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T06:00:00Z"));
+    try {
+      const cls = classifyAgentError({
+        provider: "claude",
+        stderr: "You've hit your session limit · resets 10:10pm (Europe/Madrid)",
+        exitCode: 1,
+      });
+      expect(cls.class).toBe(ERROR_CLASS.QUOTA_EXHAUSTED_DAILY);
+      expect(cls.recoverable).toBe(true);
+      expect(cls.retryAfter).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("withBrainRecovery with sessionState persists a standby snapshot to disk", async () => {


### PR DESCRIPTION
## Summary

Pin `Date.now()` via `vi.setSystemTime` en el test `classifies the Claude Code session limit as a recoverable quota cap` (tests/resilience/hibernate-end-to-end.test.js) para evitar fallo TZ-dependiente en CI.

## Root cause

`classifyAgentError` separa `RATE_LIMIT_SHORT` y `QUOTA_EXHAUSTED_DAILY` por el threshold de 1h (`src/brain/agent-error-classifier.js:81`). La stderr literal del test (`"resets 10:10pm (Europe/Madrid)"`) resuelve a 22:10 Madrid → 20:10 UTC (verano) o 21:10 UTC (invierno). Runs CI entre 19:10-21:10 UTC dan delta <1h → clase `RATE_LIMIT_SHORT` → fallo.

KJC-BUG-0064 (#840) eliminó el `skip(CI)` original confiando en que `parseCooldown` era TZ-aware; lo que faltaba era pinear "ahora" del lado del test.

## Fix

`vi.useFakeTimers()` + `vi.setSystemTime("2026-06-04T06:00:00Z")` antes de la llamada, `vi.useRealTimers()` en finally para no contaminar tests siguientes del describe.

## Test plan

- [x] `TZ=UTC npx vitest run tests/resilience/hibernate-end-to-end.test.js` → 4/4 pasa
- [x] Net delta +21/-12 LOC
- [x] Header lowercase 69 chars