### PR TITLE
feat(roles): tool-correctness-judge role + prompt (KJC-TSK-0375 PR1)

### DIFF
--- a/src/prompts/tool-correctness-judge.js
+++ b/src/prompts/tool-correctness-judge.js
@@ -1,0 +1,31 @@
+// KJC-TSK-0375 — Prompt builder for the ToolCorrectnessJudge role.
+// Inspired by deepeval's tool-correctness metric.
+
+const PREAMBLE = "IMPORTANT: You are running as a Karajan sub-agent. "
+  + "Do NOT use any MCP tools, do NOT mention Karajan. "
+  + "Your job is to judge another agent's tool choices.";
+
+export function buildToolCorrectnessJudgePrompt({ task, toolCalls, instructions }) {
+  const calls = toolCalls
+    .map((c, i) => `${i + 1}. **${c.tool}** — args: ${JSON.stringify(c.args)}`)
+    .join("\n");
+  const body = [
+    "You are the ToolCorrectnessJudge for Karajan Code.",
+    "Input: (a) a task description and (b) the ordered tool calls an LLM coder",
+    "made (Read/Edit/Write/Bash/Glob/Grep/MultiEdit). Judge each call on:",
+    "  - tool choice: right tool for the intent?",
+    "  - argument quality: paths plausible, commands valid, no garbage placeholders?",
+    "Per-call verdict: `correct=true|false` + one-sentence `reason`.",
+    "Aggregate into a single 0-100 score:",
+    "  - 100 = every call right with clean args",
+    "  - 70-99 = mostly right, minor missteps",
+    "  - 40-69 = several wrong choices, budget wasted",
+    "  - 0-39 = predominantly bad, retry advised",
+    "Return a single valid JSON object and nothing else.",
+    'Schema: {"score":0-100,"summary":string,"breakdown":[{"tool":string,"args":object,"correct":boolean,"reason":string}]}',
+  ].join("\n");
+  const sections = [PREAMBLE];
+  if (instructions) sections.push(instructions);
+  sections.push(body, `## Task\n${task}`, `## Tool calls (${toolCalls.length})\n${calls || "(no tool calls captured)"}`);
+  return sections.join("\n\n");
+}

--- a/src/roles/tool-correctness-judge-role.js
+++ b/src/roles/tool-correctness-judge-role.js
@@ -1,0 +1,78 @@
+// KJC-TSK-0375 — ToolCorrectnessJudgeRole.
+// Post-iteration LLM judge scoring how well a coder picked its tool calls.
+// PR1 ships role + tests; wiring lives in PR3.
+
+import { AgentRole } from "./agent-role.js";
+import { buildToolCorrectnessJudgePrompt } from "../prompts/tool-correctness-judge.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+
+const DEFAULT_THRESHOLD = 70;
+
+const clampScore = (n) => Number.isFinite(n) ? Math.max(0, Math.min(100, Math.round(n))) : null;
+
+const normalizeBreakdown = (b) => Array.isArray(b) ? b.map((x) => ({
+  tool: typeof x?.tool === "string" ? x.tool : "unknown",
+  args: x?.args && typeof x.args === "object" ? x.args : {},
+  correct: Boolean(x?.correct),
+  reason: typeof x?.reason === "string" ? x.reason.trim() : "",
+})) : [];
+
+export class ToolCorrectnessJudgeRole extends AgentRole {
+  constructor(opts) {
+    super({ ...opts, name: "tool-correctness-judge" });
+    this.threshold = opts?.threshold ?? this.config?.pipeline?.tool_judge?.threshold ?? DEFAULT_THRESHOLD;
+  }
+
+  resolveProvider() {
+    return this.config?.roles?.["tool-correctness-judge"]?.provider
+      || this.config?.roles?.reviewer?.provider
+      || this.config?.roles?.coder?.provider
+      || "claude";
+  }
+
+  extractInput(input) {
+    return { ...super.extractInput(input), toolCalls: Array.isArray(input?.toolCalls) ? input.toolCalls : [] };
+  }
+
+  async buildPrompt({ task, toolCalls }) {
+    return { prompt: buildToolCorrectnessJudgePrompt({ task, toolCalls, instructions: this.instructions }) };
+  }
+
+  parseOutput(raw) { return extractFirstJson(raw); }
+
+  buildSuccessResult(parsed, provider) {
+    const score = clampScore(parsed?.score);
+    return {
+      score,
+      summary: typeof parsed?.summary === "string" ? parsed.summary.trim() : "",
+      breakdown: normalizeBreakdown(parsed?.breakdown),
+      threshold: this.threshold,
+      lowQuality: score !== null && score < this.threshold,
+      provider,
+    };
+  }
+
+  buildSummary(parsed) {
+    const score = clampScore(parsed?.score);
+    if (score === null) return "Tool-judge: unparseable score";
+    return `Tool-judge: ${score}/100 (${score < this.threshold ? "LOW" : "OK"})`;
+  }
+
+  // Empty tool-call list = nothing to judge. Skip the LLM and report a
+  // neutral score so an absent transcript is never read as a failure.
+  async execute(input) {
+    const extracted = this.extractInput(input);
+    if (extracted.toolCalls.length === 0) {
+      return {
+        ok: true,
+        result: {
+          score: null, summary: "no tool calls captured (skipped)", breakdown: [],
+          threshold: this.threshold, lowQuality: false, provider: this.resolveProvider(), skipped: true,
+        },
+        summary: "Tool-judge: skipped (no calls)",
+        usage: null,
+      };
+    }
+    return super.execute(extracted);
+  }
+}

--- a/tests/roles/tool-correctness-judge.test.js
+++ b/tests/roles/tool-correctness-judge.test.js
@@ -1,0 +1,81 @@
+// KJC-TSK-0375 — Tests for ToolCorrectnessJudgeRole (PR1).
+import { describe, expect, it, vi } from "vitest";
+import { ToolCorrectnessJudgeRole } from "../../src/roles/tool-correctness-judge-role.js";
+import { buildToolCorrectnessJudgePrompt as build } from "../../src/prompts/tool-correctness-judge.js";
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+const CALLS = [
+  { tool: "Read", args: { file_path: "/tmp/a.js" } },
+  { tool: "Bash", args: { command: "ls" } },
+];
+const mkRole = ({ output, config } = {}) => new ToolCorrectnessJudgeRole({
+  config: config ?? { roles: { coder: { provider: "claude" } } }, logger: log,
+  createAgentFn: () => ({ async runTask() { return { ok: true, output, usage: {} }; } }),
+});
+const run = (output, config) => mkRole({ output, config }).execute({ task: "t", toolCalls: CALLS });
+
+describe("tool-correctness-judge", () => {
+  it("prompt embeds preamble, task, instructions, calls and empty placeholder", () => {
+    const p = build({ task: "fix X", toolCalls: CALLS, instructions: "EXTRA-Z" });
+    expect(p).toContain("Karajan sub-agent");
+    expect(p).toContain("EXTRA-Z");
+    expect(p).toContain("fix X");
+    expect(p).toContain("Read");
+    expect(p).toContain("/tmp/a.js");
+    expect(build({ task: "t", toolCalls: [] })).toContain("(no tool calls captured)");
+  });
+
+  it("fast-paths empty toolCalls without invoking the LLM", async () => {
+    const createAgentFn = vi.fn();
+    const r = new ToolCorrectnessJudgeRole({ config: {}, logger: log, createAgentFn });
+    const res = await r.execute({ task: "t", toolCalls: [] });
+    expect(res.ok).toBe(true);
+    expect(res.result).toMatchObject({ skipped: true, score: null, lowQuality: false });
+    expect(res.summary).toMatch(/skipped/i);
+    expect(createAgentFn).not.toHaveBeenCalled();
+  });
+
+  it("parses OK response, rounds score, OK label below threshold flips to LOW", async () => {
+    const ok = await run(JSON.stringify({
+      score: 88.7, summary: "fine",
+      breakdown: [{ tool: "Read", args: { file_path: "x" }, correct: true, reason: "ok" }],
+    }));
+    expect(ok.ok).toBe(true);
+    expect(ok.result).toMatchObject({ score: 89, lowQuality: false, threshold: 70 });
+    expect(ok.summary).toContain("89/100");
+    expect(ok.summary).toContain("OK");
+
+    const low = await run(JSON.stringify({ score: 42, breakdown: [] }));
+    expect(low.result.lowQuality).toBe(true);
+    expect(low.summary).toContain("LOW");
+  });
+
+  it("honors custom threshold from config", async () => {
+    const cfg = { roles: { coder: { provider: "claude" } }, pipeline: { tool_judge: { threshold: 90 } } };
+    const res = await run(JSON.stringify({ score: 85, breakdown: [] }), cfg);
+    expect(res.result).toMatchObject({ threshold: 90, lowQuality: true });
+  });
+
+  it("clamps score bounds and normalizes malformed breakdown", async () => {
+    expect((await run(JSON.stringify({ score: 250, breakdown: [] }))).result.score).toBe(100);
+    expect((await run(JSON.stringify({ score: -10, breakdown: [] }))).result.score).toBe(0);
+    const res = await run(JSON.stringify({
+      score: 60, breakdown: [{ tool: 123, args: null, correct: "yes", reason: 42 }, {}],
+    }));
+    expect(res.result.breakdown[0]).toEqual({ tool: "unknown", args: {}, correct: true, reason: "" });
+    expect(res.result.breakdown[1].tool).toBe("unknown");
+  });
+
+  it("returns parse error when output is not JSON", async () => {
+    const res = await run("no json here");
+    expect(res.ok).toBe(false);
+    expect(res.summary).toMatch(/parse error/i);
+  });
+
+  it("resolveProvider walks role → reviewer → coder → claude fallback", () => {
+    const cfg = (roles) => new ToolCorrectnessJudgeRole({ config: { roles }, logger: log });
+    expect(cfg({ "tool-correctness-judge": { provider: "codex" }, coder: { provider: "claude" } }).resolveProvider()).toBe("codex");
+    expect(cfg({ reviewer: { provider: "gemini" }, coder: { provider: "claude" } }).resolveProvider()).toBe("gemini");
+    expect(new ToolCorrectnessJudgeRole({ config: {}, logger: log }).resolveProvider()).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Summary

PR1 of 3 for **KJC-TSK-0375 ToolCorrectnessJudge** (deepeval-inspired tool-correctness metric).

Post-iteration LLM judge that scores how well a coder picked its tool calls (Read/Edit/Write/Bash/Glob/Grep/MultiEdit). Per-call verdict + aggregated 0-100 score with lowQuality flag below threshold.

## What's in PR1

- `src/prompts/tool-correctness-judge.js` — prompt builder with sub-agent preamble, ordered tool-call rendering, JSON schema spec.
- `src/roles/tool-correctness-judge-role.js` — `AgentRole` subclass with:
  - fast-path skip when no tool calls captured (returns neutral skipped result, never reads as failure)
  - threshold-driven `lowQuality` flag (default 70, configurable via `pipeline.tool_judge.threshold`)
  - score clamping into `[0, 100]` + rounding
  - breakdown normalization for malformed LLM output
  - provider fallback chain: role-specific → reviewer → coder → claude
- `tests/roles/tool-correctness-judge.test.js` — 7 tests, all passing.

## Deferred to follow-up PRs

- **PR2**: tool-call extractor from coder transcript (parses Claude stream-json `tool_use` blocks into `{tool, args}[]`).
- **PR3**: tool-judge stage wired into `quality-gates.js` behind `--tool-judge` / `pipeline.tool_judge.enabled` flag.

## Test plan
- [x] `npx vitest run tests/roles/tool-correctness-judge.test.js` → 7/7 passing
- [x] `npx prettier --check` clean
- [x] `npx eslint` clean
- [x] LOC budget: 190 / 200 ✅

## PG card
KJC-TSK-0375 — devPoints=3 — epic KJC-PCS-0023 (Lean Software Practices)