### PR TITLE
feat(utils): tool-call extractor from agent transcripts (KJC-TSK-0375 PR2)

### DIFF
--- a/src/utils/tool-call-extractor.js
+++ b/src/utils/tool-call-extractor.js
@@ -1,0 +1,56 @@
+// KJC-TSK-0375 PR2 — Extract structured tool calls from an agent transcript.
+//
+// The ToolCorrectnessJudgeRole (PR1) consumes a list of `{tool, args}`
+// objects. The coder writes a raw transcript (provider-dependent format) to
+// disk per iteration. This module bridges the two: parse the transcript,
+// return the ordered list of tool invocations.
+//
+// Provider-agnostic interface; Claude stream-json is the only format
+// implemented today. New providers add a branch below — keep parsers
+// pure (no I/O), so the role tests can mock transcripts trivially.
+
+const PROVIDER_PARSERS = {
+  claude: parseClaudeStreamJson,
+};
+
+/**
+ * Extract tool calls from a transcript string.
+ *
+ * @param {object} args
+ * @param {string} args.transcript - raw agent output (stdout/stderr buffer).
+ * @param {string} [args.provider] - "claude" (default). Unknown returns [].
+ * @returns {Array<{tool:string, args:object}>}
+ */
+export function extractToolCalls({ transcript, provider = "claude" } = {}) {
+  if (typeof transcript !== "string" || transcript.length === 0) return [];
+  const parser = PROVIDER_PARSERS[provider];
+  if (!parser) return [];
+  return parser(transcript);
+}
+
+// Claude emits one JSON event per line. We care about `assistant` events
+// whose `message.content` is an array containing `tool_use` blocks with
+// `{type:"tool_use", name, input}`. Lines that fail to parse, that are
+// not `assistant`, or whose content is not an array are silently skipped:
+// the transcript also carries `system`, `result`, `rate_limit_event`, etc.
+function parseClaudeStreamJson(transcript) {
+  const out = [];
+  for (const raw of transcript.split("\n")) {
+    const line = raw.trim();
+    if (!line || line[0] !== "{") continue;
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    if (obj?.type !== "assistant") continue;
+    const content = obj?.message?.content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (block?.type === "tool_use" && typeof block.name === "string") {
+        out.push({
+          tool: block.name,
+          args: block.input && typeof block.input === "object" ? block.input : {},
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/tests/utils/tool-call-extractor.test.js
+++ b/tests/utils/tool-call-extractor.test.js
@@ -1,0 +1,71 @@
+// KJC-TSK-0375 PR2 — Tests for the tool-call extractor.
+import { describe, expect, it } from "vitest";
+import { extractToolCalls } from "../../src/utils/tool-call-extractor.js";
+
+const claudeLine = (content) => JSON.stringify({ type: "assistant", message: { content } });
+const noise = [
+  JSON.stringify({ type: "system", subtype: "init", model: "claude-opus-4-7" }),
+  JSON.stringify({ type: "rate_limit_event", rate_limit_info: { status: "allowed" } }),
+  JSON.stringify({ type: "result", result: "done" }),
+  "non-json garbage line",
+  "",
+  "  ",
+].join("\n");
+
+describe("extractToolCalls", () => {
+  it("returns [] for empty / non-string transcript or unknown provider", () => {
+    expect(extractToolCalls({ transcript: "" })).toEqual([]);
+    expect(extractToolCalls({ transcript: null })).toEqual([]);
+    expect(extractToolCalls({})).toEqual([]);
+    expect(extractToolCalls({ transcript: "x", provider: "wat" })).toEqual([]);
+  });
+
+  it("parses Claude stream-json tool_use blocks in order", () => {
+    const transcript = [
+      noise,
+      claudeLine([
+        { type: "text", text: "I will read the file." },
+        { type: "tool_use", name: "Read", input: { file_path: "/tmp/a.js" } },
+      ]),
+      claudeLine([
+        { type: "tool_use", name: "Bash", input: { command: "ls -la" } },
+        { type: "tool_use", name: "Edit", input: { file_path: "/tmp/a.js", old: "x", new: "y" } },
+      ]),
+    ].join("\n");
+
+    const calls = extractToolCalls({ transcript, provider: "claude" });
+    expect(calls).toHaveLength(3);
+    expect(calls[0]).toEqual({ tool: "Read", args: { file_path: "/tmp/a.js" } });
+    expect(calls[1]).toEqual({ tool: "Bash", args: { command: "ls -la" } });
+    expect(calls[2].tool).toBe("Edit");
+    expect(calls[2].args.old).toBe("x");
+  });
+
+  it("ignores assistant blocks without content array, non-tool_use blocks, and bad inputs", () => {
+    const transcript = [
+      // Missing content array entirely.
+      JSON.stringify({ type: "assistant", message: {} }),
+      // content is not an array.
+      JSON.stringify({ type: "assistant", message: { content: "string-not-array" } }),
+      // tool_use block with no name → skipped.
+      claudeLine([{ type: "tool_use", input: { x: 1 } }]),
+      // text block alongside a real tool_use → only the tool_use comes out.
+      claudeLine([
+        { type: "text", text: "thinking…" },
+        { type: "tool_use", name: "Glob", input: { pattern: "**/*.js" } },
+      ]),
+      // tool_use with non-object input → args defaults to {}.
+      claudeLine([{ type: "tool_use", name: "Bash", input: null }]),
+    ].join("\n");
+
+    const calls = extractToolCalls({ transcript });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({ tool: "Glob", args: { pattern: "**/*.js" } });
+    expect(calls[1]).toEqual({ tool: "Bash", args: {} });
+  });
+
+  it("defaults provider to claude when omitted", () => {
+    const transcript = claudeLine([{ type: "tool_use", name: "Read", input: { file_path: "x" } }]);
+    expect(extractToolCalls({ transcript })).toEqual([{ tool: "Read", args: { file_path: "x" } }]);
+  });
+});


### PR DESCRIPTION
## Summary

PR2 of 3 for **KJC-TSK-0375 ToolCorrectnessJudge**.

Bridges the coder's raw transcript to the role's `{tool, args}[]` input. Pure, provider-agnostic module — Claude stream-json parser implemented; codex/gemini/aider can be added later in a single branch.

## What's in PR2

- `src/utils/tool-call-extractor.js` — `extractToolCalls({transcript, provider})`. Skips structural noise (`system`, `result`, `rate_limit_event`, garbage), assistant frames without content array, `tool_use` blocks without name, and normalizes non-object inputs to `{}`.
- `tests/utils/tool-call-extractor.test.js` — 4 tests, all passing.

## Independence

PR2 has no dependency on PR1 — both are pure modules. PR3 will import both into `quality-gates.js` behind the `--tool-judge` / `pipeline.tool_judge.enabled` flag.

## Test plan
- [x] `npx vitest run tests/utils/tool-call-extractor.test.js` → 4/4 passing
- [x] `npx prettier --check` clean
- [x] `npx eslint` clean
- [x] LOC budget: 127 / 200 ✅

## PG card
KJC-TSK-0375 — PR1 = #964