### PR TITLE
feat(stages): tool-judge stage wired into quality-gates (KJC-TSK-0375 PR3)

### DIFF
--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -229,6 +229,7 @@ export function resolvePipelineFlags(config) {
     securityEnabled: Boolean(config.pipeline?.security?.enabled),
     impeccableEnabled: Boolean(config.pipeline?.impeccable?.enabled),
     perfEnabled: Boolean(config.pipeline?.perf?.enabled),
+    toolJudgeEnabled: Boolean(config.pipeline?.tool_judge?.enabled),
     reviewerEnabled: config.pipeline?.reviewer?.enabled !== false,
     discoverEnabled: Boolean(config.pipeline?.discover?.enabled),
     architectEnabled: Boolean(config.pipeline?.architect?.enabled),

--- a/src/orchestrator/drivers/iteration-phases/quality-gates.js
+++ b/src/orchestrator/drivers/iteration-phases/quality-gates.js
@@ -20,6 +20,7 @@ import {
 import { runImpeccableStage } from "../../post-loop-stages.js";
 import { runPerfStage } from "../../stages/perf-stage.js";
 import { runTddDisciplineStage } from "../../stages/tdd-discipline-stage.js";
+import { runToolJudgeStage } from "../../stages/tool-judge-stage.js";
 import { tryCiComment } from "../../ci-integration.js";
 
 export async function runQualityGateStages({ config, logger, emitter, eventBase, session, trackBudget, i, askQuestion, repeatDetector, budgetSummary, sonarState, task, stageResults, coderRole, pipelineFlags, brainCtx }) {
@@ -93,6 +94,17 @@ export async function runQualityGateStages({ config, logger, emitter, eventBase,
       stageResults.perf = perfResult.stageResult;
     }
     if (perfResult.action === "continue") return { action: "continue" };
+  }
+
+  // KJC-TSK-0375 PR3: opt-in tool-call quality judge. Non-blocking.
+  if (pipelineFlags?.toolJudgeEnabled) {
+    const judgeResult = await runToolJudgeStage({
+      config, logger, emitter, eventBase, session, coderRole, trackBudget,
+      iteration: i, task,
+    });
+    if (judgeResult.stageResult) {
+      stageResults.toolJudge = judgeResult.stageResult;
+    }
   }
 
   return { action: "ok" };

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -8,7 +8,7 @@ import { CoderRole } from "../../roles/coder-role.js";
 import { RefactorerRole } from "../../roles/refactorer-role.js";
 import { addCheckpoint, markSessionStatus, saveSession } from "../../session/store.js";
 import {
-  setReviewerFeedback, incrementRetryCount, resetRetryCount,
+  setReviewerFeedback, setCoderTranscript, incrementRetryCount, resetRetryCount,
 } from "../../session/mutators.js";
 import { generateDiff, getUntrackedFiles } from "../../review/diff-generator.js";
 import { evaluateTddPolicy } from "../../review/tdd-policy.js";
@@ -222,6 +222,12 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
   } catch (err) {
     logger?.warn?.(`[verification-gate] Skipped: ${err?.message || err}`);
   }
+
+  // KJC-TSK-0375 PR3: stash the coder's raw transcript on the session so
+  // the optional tool-judge stage can extract structured tool calls later
+  // without re-invoking the coder. Cleared between iterations by the coder
+  // overwriting it; ignored when the tool-judge flag is off.
+  setCoderTranscript(session, coderTranscript);
 
   await addCheckpoint(session, { stage: "coder", iteration, note: "Coder applied changes", provider: coderRole.provider, model: coderRole.model || null, filesChanged });
   emitProgress(

--- a/src/orchestrator/stages/tool-judge-stage.js
+++ b/src/orchestrator/stages/tool-judge-stage.js
@@ -1,0 +1,53 @@
+// KJC-TSK-0375 PR3 — ToolJudgeStage.
+// Opt-in (`pipeline.tool_judge.enabled`). Scores the coder's tool calls
+// extracted from `session.last_coder_transcript`. Non-blocking: a low
+// score emits a warn event and surfaces in summary but never gates the
+// iteration loop. Wiring lives in `quality-gates.js`.
+
+import { ToolCorrectnessJudgeRole } from "../../roles/tool-correctness-judge-role.js";
+import { extractToolCalls } from "../../utils/tool-call-extractor.js";
+import { emitProgress, makeEvent } from "../../utils/events.js";
+
+export async function runToolJudgeStage({
+  config, logger, emitter, eventBase, session, coderRole, trackBudget,
+  iteration, task,
+  extractFn = extractToolCalls,
+  RoleClass = ToolCorrectnessJudgeRole,
+} = {}) {
+  logger?.setContext?.({ iteration, stage: "tool-judge" });
+  emitProgress(emitter, makeEvent("toolJudge:start", { ...eventBase, stage: "tool-judge" }, {
+    message: "Tool-judge scoring coder tool calls",
+  }));
+
+  const transcript = session?.last_coder_transcript || "";
+  const provider = coderRole?.provider || "claude";
+  const toolCalls = extractFn({ transcript, provider });
+
+  const role = new RoleClass({ config, logger, emitter });
+  const roleResult = await role.execute({ task, toolCalls });
+
+  try { trackBudget?.("tool-judge", roleResult.usage || { tokens_in: 0, tokens_out: 0, cost_usd: 0 }); } catch { /* best-effort */ }
+
+  const r = roleResult.result;
+  const status = r?.skipped ? "skip" : r?.lowQuality ? "warn" : roleResult.ok ? "ok" : "fail";
+
+  emitProgress(emitter, makeEvent("toolJudge:end", { ...eventBase, stage: "tool-judge" }, {
+    status,
+    message: roleResult.summary || "tool-judge done",
+    detail: { score: r?.score ?? null, threshold: r?.threshold ?? null, skipped: Boolean(r?.skipped), callCount: toolCalls.length },
+  }));
+
+  return {
+    action: "ok",
+    stageResult: {
+      ok: roleResult.ok !== false,
+      score: r?.score ?? null,
+      lowQuality: Boolean(r?.lowQuality),
+      skipped: Boolean(r?.skipped),
+      threshold: r?.threshold ?? null,
+      summary: roleResult.summary || "",
+      breakdown: r?.breakdown || [],
+      callCount: toolCalls.length,
+    },
+  };
+}

--- a/src/session/mutators.js
+++ b/src/session/mutators.js
@@ -109,6 +109,10 @@ export function setSonarSummary(session, text) {
   session.last_sonar_summary = text;
 }
 
+export function setCoderTranscript(session, text) {
+  session.last_coder_transcript = text;
+}
+
 export function setSonarIssueSignature(session, sig) {
   session.last_sonar_issue_signature = sig;
 }

--- a/tests/orchestrator/stages/tool-judge-stage.test.js
+++ b/tests/orchestrator/stages/tool-judge-stage.test.js
@@ -1,0 +1,78 @@
+// KJC-TSK-0375 PR3 — Tests for the ToolJudgeStage.
+import { describe, expect, it, vi } from "vitest";
+import { runToolJudgeStage } from "../../../src/orchestrator/stages/tool-judge-stage.js";
+
+const baseCtx = () => ({
+  config: { roles: {} },
+  logger: { setContext: vi.fn(), warn: vi.fn() },
+  emitter: { emit: vi.fn() },
+  eventBase: { runId: "r1" },
+  session: { last_coder_transcript: "stub" },
+  coderRole: { provider: "claude" },
+  iteration: 0,
+  task: { id: "t1", description: "do a thing" },
+});
+
+class FakeRole {
+  constructor(opts) { FakeRole.lastOpts = opts; }
+  async execute(input) {
+    FakeRole.lastInput = input;
+    return FakeRole.nextResult;
+  }
+}
+FakeRole.nextResult = null;
+FakeRole.lastOpts = null;
+FakeRole.lastInput = null;
+
+const fakeExtract = (calls) => vi.fn(() => calls);
+
+describe("runToolJudgeStage", () => {
+  it("emits events and returns stageResult on the OK happy path", async () => {
+    const ctx = baseCtx();
+    const calls = [{ tool: "Read", args: { file_path: "/x" } }];
+    FakeRole.nextResult = { ok: true, result: { score: 88, threshold: 70, lowQuality: false, breakdown: [] }, summary: "Tool-judge: 88/100 (OK)", usage: { tokens_in: 10 } };
+    const trackBudget = vi.fn();
+    const out = await runToolJudgeStage({ ...ctx, trackBudget, extractFn: fakeExtract(calls), RoleClass: FakeRole });
+    expect(out.action).toBe("ok");
+    expect(out.stageResult).toMatchObject({ score: 88, lowQuality: false, callCount: 1 });
+    expect(FakeRole.lastInput).toMatchObject({ toolCalls: calls, task: ctx.task });
+    expect(trackBudget).toHaveBeenCalledWith("tool-judge", FakeRole.nextResult.usage);
+    expect(ctx.emitter.emit).toHaveBeenCalled();
+  });
+
+  it("propagates lowQuality from the role result without blocking the iteration", async () => {
+    const ctx = baseCtx();
+    FakeRole.nextResult = { ok: true, result: { score: 40, threshold: 70, lowQuality: true, breakdown: [{ tool: "Bash", correct: false }] }, summary: "LOW" };
+    const out = await runToolJudgeStage({ ...ctx, extractFn: fakeExtract([{ tool: "Bash", args: { command: "ls" } }]), RoleClass: FakeRole });
+    expect(out.action).toBe("ok");
+    expect(out.stageResult).toMatchObject({ lowQuality: true });
+    expect(out.stageResult.breakdown).toHaveLength(1);
+  });
+
+  it("returns skipped stageResult when the role short-circuits on empty toolCalls", async () => {
+    const ctx = baseCtx();
+    ctx.session.last_coder_transcript = "";
+    FakeRole.nextResult = { ok: true, result: { score: null, breakdown: [], skipped: true, lowQuality: false, threshold: 70 }, summary: "skipped" };
+    const out = await runToolJudgeStage({ ...ctx, extractFn: fakeExtract([]), RoleClass: FakeRole });
+    expect(out.stageResult).toMatchObject({ skipped: true, score: null, callCount: 0 });
+  });
+
+  it("passes the session transcript + coder provider to the extractor", async () => {
+    const ctx = baseCtx();
+    ctx.session.last_coder_transcript = "raw-transcript";
+    ctx.coderRole.provider = "codex";
+    FakeRole.nextResult = { ok: true, result: { score: 70, threshold: 70, lowQuality: false, breakdown: [] }, summary: "OK" };
+    const extractFn = fakeExtract([]);
+    await runToolJudgeStage({ ...ctx, extractFn, RoleClass: FakeRole });
+    expect(extractFn).toHaveBeenCalledWith({ transcript: "raw-transcript", provider: "codex" });
+  });
+
+  it("survives a throwing trackBudget — best-effort accounting", async () => {
+    const ctx = baseCtx();
+    FakeRole.nextResult = { ok: true, result: { score: 90, threshold: 70, lowQuality: false, breakdown: [] }, summary: "OK", usage: { tokens_in: 1 } };
+    const trackBudget = vi.fn(() => { throw new Error("boom"); });
+    const out = await runToolJudgeStage({ ...ctx, trackBudget, extractFn: fakeExtract([{ tool: "Read", args: {} }]), RoleClass: FakeRole });
+    expect(out.action).toBe("ok");
+    expect(out.stageResult.score).toBe(90);
+  });
+});


### PR DESCRIPTION
## Summary

PR3 of 3 for **KJC-TSK-0375 — ToolCorrectnessJudge**. Final wiring that
closes the loop. Builds on:

- PR1 #964 — `ToolCorrectnessJudgeRole` (merged)
- PR2 #965 — `extractToolCalls` provider parser (merged)

### What this PR does

- New `setCoderTranscript` session mutator. The coder-stage stashes the
  raw transcript on `session.last_coder_transcript` on the success path.
- New `runToolJudgeStage` — opt-in via `pipeline.tool_judge.enabled`.
  Reads the transcript, runs `extractToolCalls`, executes the judge role,
  emits `toolJudge:start` / `toolJudge:end` events, returns a
  non-blocking `stageResult`. Status priority: `skip` > `warn`
  (lowQuality) > `ok` > `fail`.
- Wired into `runQualityGateStages` after the perf block. **Never gates
  the iteration loop** — low scores surface in summary, that's it.
- `resolvePipelineFlags` exposes `toolJudgeEnabled`.

### Tests

5 new unit tests for the stage:

- OK happy path with budget tracking
- `lowQuality` propagation without blocking
- skipped `stageResult` when extractor returns empty array
- transcript + provider passthrough to the extractor
- survives a throwing `trackBudget` (best-effort accounting)

Stage takes `extractFn` and `RoleClass` as injectable deps so tests can
swap in fakes — same pattern as `runTddDisciplineStage`.

### Atomicity

Net delta: **154 LOC** (under the 200 hard cap, target was 150).

## Test plan

- [x] `npx vitest run tests/orchestrator/stages/tool-judge-stage.test.js` — 5/5 passing
- [x] Broader suite `tests/orchestrator tests/session tests/roles` — 332/332 passing
- [x] `eslint` clean
- [x] `prettier --check` clean
- [ ] CI green