### PR TITLE
feat(sync): kj sync --apply writes canvas drift patch with backup (KJC-TSK-0348)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -313,12 +313,13 @@ export function registerMeta(program, { pkgVersion }) {
 
   program
     .command("sync")
-    .description("Detect drift between code and the latest plan. Read-only report (issue #540 MVP).")
+    .description("Detect drift between code and the latest plan. Read-only by default; --apply writes a patch back to the Canvas.")
     .option("--plan <planId>", "Sync against a specific plan instead of the latest")
     .option("--json", "Emit machine-readable JSON instead of human output")
+    .option("--apply", "Write the drift report into the source Canvas (creates a .bak backup)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "sync", flags, async ({ config, logger }) => {
-        await syncCommand({ config, logger, planId: flags.plan, json: flags.json });
+        await syncCommand({ config, logger, planId: flags.plan, json: flags.json, apply: Boolean(flags.apply) });
       });
     });
 

--- a/src/cli/register-plan.js
+++ b/src/cli/register-plan.js
@@ -93,7 +93,16 @@ export function registerPlan(program, { pkgVersion }) {
           // Norms + Safeguards ride along under explicit headings the
           // coder prompt can grep for.
           const taskFromCanvas = canvasToTask(validation.canvas);
-          await planGenerateCommand({ task: taskFromCanvas, config, logger, flags });
+          // KJC-TSK-0348: remember WHERE the Canvas lived on disk so
+          // `kj sync --apply` later knows which file to patch.
+          let sourceCanvasPath = null;
+          if (typeof flags?.taskFile === "string" && flags.taskFile.length > 0) {
+            const path = await import("node:path");
+            sourceCanvasPath = path.isAbsolute(flags.taskFile)
+              ? flags.taskFile
+              : path.resolve(config.projectDir || process.cwd(), flags.taskFile);
+          }
+          await planGenerateCommand({ task: taskFromCanvas, config, logger, flags, sourceCanvasPath });
           return;
         }
         await planGenerateCommand({

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -21,14 +21,14 @@ import { formatPlan, formatHuTable } from "./_shared.js";
 /**
  * kj plan "task" — generate plan + HUs
  */
-export async function planGenerateCommand({ task, config, logger, json, context, flags = {} }) {
+export async function planGenerateCommand({ task, config, logger, json, context, flags = {}, sourceCanvasPath = null }) {
   const { withCliRunLog } = await import("../../utils/cli-run-log.js");
   return withCliRunLog("plan", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
-    return planGenerateImpl({ task, config, logger, json, context, runLog, flags });
+    return planGenerateImpl({ task, config, logger, json, context, runLog, flags, sourceCanvasPath });
   });
 }
 
-async function planGenerateImpl({ task, config, logger, json, context, runLog, flags = {} }) {
+async function planGenerateImpl({ task, config, logger, json, context, runLog, flags = {}, sourceCanvasPath = null }) {
   // Auto-GC: prune orphan plans (project dir gone) + old finalised plans/
   // sessions/HU batches before we start. Silent unless something was
   // removed; one-liner summary on stderr in that case so --json stays
@@ -164,6 +164,12 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
   plan.approach = parsed?.approach || (typeof parsed === "string" ? parsed : (typeof result.output === "string" ? result.output : null));
   plan.risks = parsed?.risks || [];
   plan.outOfScope = parsed?.outOfScope || [];
+  // KJC-TSK-0348: persist the SPEC.canvas.md path so `kj sync --apply`
+  // can later locate it and append drift notes. Only set when the plan
+  // actually came from a Canvas SPEC; flat-task plans stay unstamped.
+  if (typeof sourceCanvasPath === "string" && sourceCanvasPath.length > 0) {
+    plan.sourceCanvasPath = sourceCanvasPath;
+  }
 
   // Convert planner steps → HUs, carrying the structured acceptance_tests
   // the LLM was asked to emit. If the LLM fell back to legacy behaviour

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -1,12 +1,15 @@
 /**
  * `kj sync` — closed-loop drift detection between code and Canvas/plan.
- * Issue #540 MVP: detection + report only. No --apply yet.
+ * Issue #540 MVP: detection + report.
+ * KJC-TSK-0348: `--apply` writes drift notes back into the source Canvas
+ * markdown (with `.bak` backup) so the user can review + commit.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { listPlans, loadPlan } from "../plan/plan-store.js";
 import { classifyDrift, formatDriftReport } from "../sync/detect-drift.js";
+import { applyCanvasPatch } from "../sync/apply-canvas-patch.js";
 
 const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".karajan", ".kj", "tmp", ".cache", ".astro", ".next"]);
 
@@ -36,8 +39,11 @@ function listSourceFiles(rootDir, out = []) {
  * @param {object} args.logger
  * @param {string} [args.planId] — when set, sync against this plan; else use the latest
  * @param {boolean} [args.json]
+ * @param {boolean} [args.apply] — when true, write a drift patch back into
+ *                                 the Canvas markdown the plan came from
+ *                                 (with `.bak` backup).
  */
-export async function syncCommand({ config, logger, planId, json }) {
+export async function syncCommand({ config, logger, planId, json, apply }) {
   const projectDir = config?.projectDir || process.cwd();
 
   // Resolve which plan to sync against.
@@ -60,14 +66,36 @@ export async function syncCommand({ config, logger, planId, json }) {
   const files = listSourceFiles(projectDir);
   const report = classifyDrift(plan, files);
 
+  let applyResult = null;
+  if (apply) {
+    if (!plan.sourceCanvasPath) {
+      throw new Error(
+        "kj sync --apply: this plan has no sourceCanvasPath — it was not generated from a SPEC.canvas.md. "
+        + "Re-run `kj plan generate --task-file SPEC.canvas.md` so the plan remembers the Canvas it came from."
+      );
+    }
+    applyResult = await applyCanvasPatch({ canvasPath: plan.sourceCanvasPath, report });
+  }
+
   if (json) {
     console.log(JSON.stringify({
       planId: plan.planId,
       projectDir,
       ...report,
+      apply: applyResult,
     }, null, 2));
   } else {
     console.log(formatDriftReport(report, plan));
+    if (applyResult) {
+      if (applyResult.skipped) {
+        console.log("\nkj sync --apply: no actionable drift, Canvas left untouched.");
+      } else {
+        console.log(
+          `\nkj sync --apply: wrote ${applyResult.mutations} drift note(s) to ${applyResult.patchedPath} `
+          + `(backup at ${applyResult.backupPath}).`
+        );
+      }
+    }
   }
 
   // Exit 0 always — drift is informational, not an error. CI users

--- a/src/sync/apply-canvas-patch.js
+++ b/src/sync/apply-canvas-patch.js
@@ -1,0 +1,55 @@
+/**
+ * kj sync --apply — append a drift patch to the Canvas markdown.
+ *
+ * KJC-TSK-0348. Pure data + I/O: reads the Canvas at `canvasPath`, drops a
+ * `.bak` snapshot alongside it, appends an HTML-comment block describing
+ * untracked / missing / covered files, and atomically renames a `.tmp`
+ * over the target. Comments are inert for the Canvas parser, so the
+ * patched file stays structurally valid — the user converts the TODOs
+ * into Operations by hand.
+ */
+
+import { promises as fs } from "node:fs";
+
+function tempPath(target) {
+  return `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+}
+
+export function renderDriftComment(report) {
+  const lines = ["", `<!-- kj sync --apply (${new Date().toISOString()}) — review and convert into Operations as needed. -->`];
+  let mutations = 0;
+  if (report.untracked?.length) {
+    lines.push("<!-- Untracked files (modified, no Operation references them — add one): -->");
+    for (const u of report.untracked) { lines.push(`<!-- + ${u.path} -->`); mutations += 1; }
+  }
+  if (report.missing?.length) {
+    lines.push("<!-- Missing files (Operation file_hint points at a file that does not exist): -->");
+    for (const m of report.missing) { lines.push(`<!-- ! ${m.path}  [op #${(m.operationIndex ?? 0) + 1}] -->`); mutations += 1; }
+  }
+  if (report.covered?.length) {
+    lines.push("<!-- Covered (referenced and modified — consider extending the Approach): -->");
+    for (const c of report.covered) lines.push(`<!-- ~ ${c.path}  [op #${(c.operationIndex ?? 0) + 1}] -->`);
+  }
+  lines.push("<!-- /kj sync -->", "");
+  return { block: lines.join("\n"), mutations };
+}
+
+export async function applyCanvasPatch({ canvasPath, report }) {
+  if (!canvasPath || typeof canvasPath !== "string") throw new Error("applyCanvasPatch: canvasPath is required");
+  if (!report || typeof report !== "object") throw new Error("applyCanvasPatch: report is required");
+  const hasDrift = (report.untracked?.length || 0) + (report.missing?.length || 0) > 0;
+  if (!hasDrift) return { patchedPath: canvasPath, backupPath: null, mutations: 0, skipped: true };
+
+  let original;
+  try { original = await fs.readFile(canvasPath, "utf-8"); }
+  catch (err) { throw new Error(`applyCanvasPatch: cannot read canvas ${canvasPath}: ${err.message}`, { cause: err }); }
+
+  const backupPath = `${canvasPath}.bak`;
+  await fs.writeFile(backupPath, original, "utf-8");
+  const { block, mutations } = renderDriftComment(report);
+  const trimmed = original.endsWith("\n") ? original : `${original}\n`;
+  const tmp = tempPath(canvasPath);
+  await fs.writeFile(tmp, `${trimmed}${block}\n`, "utf-8");
+  await fs.rename(tmp, canvasPath);
+  return { patchedPath: canvasPath, backupPath, mutations };
+}

--- a/tests/sync/apply-canvas-patch.test.js
+++ b/tests/sync/apply-canvas-patch.test.js
@@ -1,0 +1,72 @@
+// KJC-TSK-0348 — Tests for kj sync --apply (apply-canvas-patch module).
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyCanvasPatch, renderDriftComment } from "../../src/sync/apply-canvas-patch.js";
+
+const BASE_CANVAS = `# Test Spec\n\n## REASONS:Requirements\nDo a thing.\n\n## REASONS:Approach\nDo it well.\n\n## REASONS:Structure\n- touches: src/foo.js\n\n## REASONS:Operations\n1. Add foo\n   Acceptance:\n   - shell: node -e "1"\n`;
+
+let tmpDir;
+beforeEach(async () => { tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-sync-apply-")); });
+afterEach(async () => { await fs.rm(tmpDir, { recursive: true, force: true }); });
+
+async function seedCanvas() {
+  const p = path.join(tmpDir, "SPEC.canvas.md");
+  await fs.writeFile(p, BASE_CANVAS, "utf-8");
+  return p;
+}
+
+describe("renderDriftComment", () => {
+  it("counts untracked + missing as mutations and ignores covered for the counter", () => {
+    const { block, mutations } = renderDriftComment({
+      untracked: [{ path: "src/new.js" }],
+      missing: [{ path: "src/gone.js", operationIndex: 0 }],
+      covered: [{ path: "src/foo.js", operationIndex: 0 }],
+    });
+    expect(mutations).toBe(2);
+    expect(block).toMatch(/<!-- \+ src\/new\.js -->/);
+    expect(block).toMatch(/<!-- ! src\/gone\.js {2}\[op #1\] -->/);
+    expect(block).toMatch(/<!-- ~ src\/foo\.js/);
+    expect(block.startsWith("\n<!-- kj sync --apply")).toBe(true);
+    expect(block.endsWith("<!-- /kj sync -->\n")).toBe(true);
+  });
+});
+
+describe("applyCanvasPatch", () => {
+  it("writes a .bak backup with the ORIGINAL content and patches the Canvas atomically", async () => {
+    const canvasPath = await seedCanvas();
+    const out = await applyCanvasPatch({
+      canvasPath,
+      report: { untracked: [{ path: "src/new.js" }], missing: [], covered: [], clean: [] },
+    });
+    expect(out.mutations).toBe(1);
+    expect(out.backupPath).toBe(`${canvasPath}.bak`);
+    expect(await fs.readFile(out.backupPath, "utf-8")).toBe(BASE_CANVAS);
+    const patched = await fs.readFile(canvasPath, "utf-8");
+    expect(patched.startsWith(BASE_CANVAS.replace(/\n+$/, "\n"))).toBe(true);
+    expect(patched).toMatch(/<!-- \+ src\/new\.js -->/);
+    expect(patched).toMatch(/<!-- \/kj sync -->/);
+  });
+
+  it("is a no-op when there's no actionable drift (no .bak, Canvas untouched)", async () => {
+    const canvasPath = await seedCanvas();
+    const out = await applyCanvasPatch({
+      canvasPath, report: { untracked: [], missing: [], covered: [], clean: [] },
+    });
+    expect(out.skipped).toBe(true);
+    expect(out.mutations).toBe(0);
+    expect(out.backupPath).toBeNull();
+    expect(await fs.readFile(canvasPath, "utf-8")).toBe(BASE_CANVAS);
+    await expect(fs.access(`${canvasPath}.bak`)).rejects.toThrow();
+  });
+
+  it("rejects missing canvasPath / report and surfaces read errors clearly", async () => {
+    await expect(applyCanvasPatch({})).rejects.toThrow(/canvasPath is required/);
+    await expect(applyCanvasPatch({ canvasPath: "x" })).rejects.toThrow(/report is required/);
+    await expect(applyCanvasPatch({
+      canvasPath: path.join(tmpDir, "missing.canvas.md"),
+      report: { untracked: [{ path: "x" }], missing: [], covered: [] },
+    })).rejects.toThrow(/cannot read canvas/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the loop on `kj sync` so the user can write detected drift back into the source Canvas.

- Plans generated from a `SPEC.canvas.md` now persist `sourceCanvasPath` (absolute) on the saved plan. Flat-task plans stay unstamped.
- New `src/sync/apply-canvas-patch.js`: reads the Canvas, drops a `.bak` snapshot next to it, appends an HTML-comment drift block (untracked / missing / covered), and atomically renames a `.tmp` over the target. Comments are inert for the Canvas parser, so the file stays structurally valid.
- `kj sync --apply` errors out clearly when the plan has no `sourceCanvasPath` (legacy plan or flat-task SPEC).

Net delta ~170 LOC (under the 200 budget).

## Why HTML comments and not real Operations

Auto-synthesising acceptance tests for an untracked file would be making semantic decisions for the user. The drift block is a TODO marker — the user converts it into Operations by hand.

## Test plan

- [x] `npx vitest run tests/sync/` (13 passing — 4 new for `applyCanvasPatch`/`renderDriftComment`)
- [x] `npx vitest run tests/canvas/ tests/commands/command-plan.test.js` (60 passing — no regressions)
- [x] ESLint clean on touched files
- [x] LOC budget: 179 added / 8 removed = 171 net (under 200)