### PR TITLE
feat(audit): semantic test-diet auditor for loss-of-meaning detection (KJC-TSK-0345 slice 0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ review-rules.md
 tests/e2e/karajan-code.tgz
 .env
 audits/
+audit/
 
 # AI Engineering runtime state (events ndjson, lock files) — local only
 .ai-engineering/

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "format:fix": "prettier --write .",
     "typecheck": "npx -p typescript@5 tsc --noEmit -p tsconfig.json",
     "validate": "npm run lint && npm run lint:syntax && npm test",
-    "mcp": "node src/mcp/server.js"
+    "mcp": "node src/mcp/server.js",
+    "audit:test-diet": "node scripts/audit-test-diet.mjs"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/scripts/audit-test-diet.mjs
+++ b/scripts/audit-test-diet.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * scripts/audit-test-diet.mjs — semantic loss-of-meaning auditor (KJC-TSK-0345).
+ * Categories: empty-no-expect, skipped-pending, imports-orphan, deprecated-export,
+ * subsumed-candidate. Each finding carries confidence (high|low). Complements
+ * tests/_diet/audit.mjs (which classifies by LOC bucket only).
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = resolve(HERE, "..");
+const SKIP_DIRS = new Set(["_diet", "fixtures", "node_modules"]);
+
+export function walkTests(rootDir, testsSubdir = "tests") {
+  const out = [];
+  const base = join(rootDir, testsSubdir);
+  if (!existsSync(base)) return out;
+  const stack = [base];
+  while (stack.length) {
+    for (const e of readdirSync(stack.pop(), { withFileTypes: true })) {
+      const p = join(e.parentPath ?? base, e.name);
+      if (e.isDirectory() && !SKIP_DIRS.has(e.name)) stack.push(p);
+      else if (e.isFile() && /\.test\.(m?js|ts)$/.test(e.name)) out.push(p);
+    }
+  }
+  return out;
+}
+
+export function parseImports(source) {
+  const imports = [];
+  const re = /^[ \t]*import\s+(?:([\w*\s{},]+?)\s+from\s+)?['"]([^'"]+)['"]/gm;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const named = [];
+    const braced = (m[1] || "").match(/\{([^}]+)\}/);
+    if (braced) for (const part of braced[1].split(",")) {
+      const name = part.trim().split(/\s+as\s+/)[0].trim();
+      if (name) named.push(name);
+    }
+    imports.push({ specifier: m[2], named });
+  }
+  return imports;
+}
+
+export function resolveSrcImport(testFile, specifier, rootDir) {
+  if (!specifier.startsWith(".") && !specifier.startsWith("#")) return null;
+  const base = specifier.startsWith("#") ? resolve(rootDir, specifier.replace(/^#/, "src/")) : resolve(dirname(testFile), specifier);
+  for (const c of [base, `${base}.js`, `${base}.mjs`, join(base, "index.js")]) {
+    if (existsSync(c) && statSync(c).isFile()) return c;
+  }
+  return null;
+}
+
+export function extractExports(source) {
+  const names = new Set();
+  for (const m of source.matchAll(/export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g)) names.add(m[1]);
+  for (const m of source.matchAll(/export\s*\{([^}]+)\}/g)) for (const part of m[1].split(",")) {
+    const name = part.trim().split(/\s+as\s+/).pop().trim();
+    if (name) names.add(name);
+  }
+  if (/export\s+default\b/.test(source)) names.add("default");
+  return names;
+}
+
+export function auditFile(testFile, rootDir) {
+  const source = readFileSync(testFile, "utf-8");
+  const rel = relative(rootDir, testFile);
+  const findings = [];
+  const hasIt = /\b(?:it|test)\s*\(/.test(source);
+  if (hasIt && !/\bexpect\s*\(/.test(source)) findings.push({ category: "empty-no-expect", confidence: "high", detail: "it()/test() blocks with no expect()" });
+  if (/\b(?:it|test|describe)\.skip\s*\(|\bxit\s*\(|\bxtest\s*\(|\b(?:it|test)\.todo\s*\(/.test(source)) {
+    findings.push({ category: "skipped-pending", confidence: "high", detail: "uses .skip / xit / xtest / .todo" });
+  }
+  const srcImports = [];
+  for (const imp of parseImports(source)) {
+    if (!imp.specifier.startsWith(".") && !imp.specifier.startsWith("#")) continue;
+    const resolved = resolveSrcImport(testFile, imp.specifier, rootDir);
+    if (!resolved) { findings.push({ category: "imports-orphan", confidence: "high", detail: `cannot resolve '${imp.specifier}'` }); continue; }
+    if (imp.named.length) {
+      const missing = imp.named.filter((n) => !extractExports(readFileSync(resolved, "utf-8")).has(n));
+      if (missing.length) findings.push({ category: "deprecated-export", confidence: "low", detail: `${imp.specifier} no longer exports: ${missing.join(", ")}` });
+    }
+    srcImports.push({ resolved: relative(rootDir, resolved), named: imp.named });
+  }
+  return { path: rel, srcImports, findings };
+}
+
+export function findSubsumed(perFile) {
+  const bySrc = new Map();
+  for (const f of perFile) for (const imp of f.srcImports) {
+    if (!bySrc.has(imp.resolved)) bySrc.set(imp.resolved, []);
+    bySrc.get(imp.resolved).push({ path: f.path, named: new Set(imp.named) });
+  }
+  const out = [];
+  for (const [src, consumers] of bySrc) {
+    if (consumers.length < 2) continue;
+    const sorted = [...consumers].sort((a, b) => a.named.size - b.named.size);
+    const narrow = sorted[0]; const broad = sorted[sorted.length - 1];
+    if (narrow.path === broad.path || narrow.named.size === 0 || broad.named.size === 0) continue;
+    if (narrow.named.size < broad.named.size && [...narrow.named].every((n) => broad.named.has(n))) {
+      out.push({ category: "subsumed-candidate", confidence: "low", path: narrow.path, detail: `subset of imports from ${src}, also covered by ${broad.path}` });
+    }
+  }
+  return out;
+}
+
+export function auditTestDiet(rootDir = DEFAULT_ROOT) {
+  const files = walkTests(rootDir);
+  const perFile = files.map((f) => auditFile(f, rootDir));
+  const findings = [];
+  for (const f of perFile) for (const x of f.findings) findings.push({ path: f.path, ...x });
+  for (const s of findSubsumed(perFile)) findings.push(s);
+  return { generatedAt: new Date().toISOString(), rootDir, totals: { filesAudited: files.length, findings: findings.length }, findings };
+}
+
+export function renderMarkdown(report) {
+  const byCat = new Map();
+  for (const f of report.findings) {
+    if (!byCat.has(f.category)) byCat.set(f.category, []);
+    byCat.get(f.category).push(f);
+  }
+  const lines = [`# Semantic test-diet audit`, ``, `Generated: ${report.generatedAt}`, `Files audited: ${report.totals.filesAudited}`, `Findings: ${report.totals.findings}`, ``];
+  for (const [cat, items] of byCat) {
+    lines.push(`## ${cat} (${items.length})`, ``);
+    for (const it of items) lines.push(`- \`${it.path}\` — ${it.detail} (confidence: ${it.confidence})`);
+    lines.push(``);
+  }
+  return lines.join("\n");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const report = auditTestDiet(DEFAULT_ROOT);
+  const outDir = join(DEFAULT_ROOT, "audit");
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, "test-diet-semantic.json"), JSON.stringify(report, null, 2));
+  writeFileSync(join(outDir, "test-diet-semantic.md"), renderMarkdown(report));
+  console.log(`audit: ${report.totals.filesAudited} files, ${report.totals.findings} findings -> audit/test-diet-semantic.{json,md}`);
+}

--- a/tests/scripts/audit-test-diet.test.js
+++ b/tests/scripts/audit-test-diet.test.js
@@ -1,0 +1,56 @@
+// KJC-TSK-0345 slice 0.1 — semantic auditor smoke tests with synthetic fixtures.
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { auditTestDiet, parseImports, extractExports, renderMarkdown } from "../../scripts/audit-test-diet.mjs";
+
+let root;
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "kj-audit-diet-"));
+  await fs.mkdir(path.join(root, "src"), { recursive: true });
+  await fs.mkdir(path.join(root, "tests"), { recursive: true });
+});
+afterEach(async () => { await fs.rm(root, { recursive: true, force: true }); });
+
+async function write(rel, content) {
+  const p = path.join(root, rel);
+  await fs.mkdir(path.dirname(p), { recursive: true });
+  await fs.writeFile(p, content, "utf-8");
+}
+
+describe("auditTestDiet — semantic categories", () => {
+  it("parses imports/exports correctly (helpers)", () => {
+    expect(parseImports(`import { a, b as bb } from "./x.js";\n`)[0].named).toEqual(["a", "b"]);
+    expect(extractExports(`export function a(){}\nexport const b=1;\nexport default c;\n`)).toEqual(new Set(["a", "b", "default"]));
+  });
+
+  it("flags empty-no-expect, skipped-pending, imports-orphan and renders markdown", async () => {
+    await write("tests/empty.test.js", `import { it } from "vitest";\nit("noop", () => { const x = 1; });\n`);
+    await write("tests/skipped.test.js", `import { it, expect } from "vitest";\nit.skip("parked", () => { expect(1).toBe(1); });\n`);
+    await write("tests/orphan.test.js", `import { gone } from "../src/gone.js";\nimport { it, expect } from "vitest";\nit("g", () => { expect(gone()).toBe(1); });\n`);
+    const report = auditTestDiet(root);
+    const cats = new Set(report.findings.map((f) => f.category));
+    expect(cats.has("empty-no-expect")).toBe(true);
+    expect(cats.has("skipped-pending")).toBe(true);
+    const orphan = report.findings.find((f) => f.category === "imports-orphan");
+    expect(orphan.detail).toMatch(/gone\.js/);
+    expect(renderMarkdown(report)).toMatch(/## empty-no-expect/);
+  });
+
+  it("flags deprecated-export when a named import is no longer exported", async () => {
+    await write("src/mod.js", `export function alive() { return 1; }\n`);
+    await write("tests/dep.test.js", `import { alive, removed } from "../src/mod.js";\nimport { it, expect } from "vitest";\nit("x", () => { expect(alive()).toBe(1); expect(removed).toBeUndefined(); });\n`);
+    const dep = auditTestDiet(root).findings.find((f) => f.category === "deprecated-export");
+    expect(dep.detail).toMatch(/removed/);
+    expect(dep.confidence).toBe("low");
+  });
+
+  it("flags subsumed-candidate when a narrower test imports a subset", async () => {
+    await write("src/big.js", `export const a = 1;\nexport const b = 2;\nexport const c = 3;\n`);
+    await write("tests/narrow.test.js", `import { a } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("a", () => { expect(a).toBe(1); });\n`);
+    await write("tests/broad.test.js", `import { a, b, c } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("all", () => { expect(a + b + c).toBe(6); });\n`);
+    const sub = auditTestDiet(root).findings.find((f) => f.category === "subsumed-candidate" && f.path.endsWith("narrow.test.js"));
+    expect(sub.detail).toMatch(/broad\.test\.js/);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 0.1 of KJC-TSK-0345 (test-diet FASE 2). Adds a semantic auditor that surfaces tests that have *lost their reason to exist*, complementing `tests/_diet/audit.mjs` (which only buckets by LOC).

Five categories with confidence:

| Category | Confidence | Meaning |
|----------|-----------|---------|
| `empty-no-expect` | high | `it()`/`test()` blocks with no `expect()` |
| `skipped-pending` | high | `.skip` / `xit` / `xtest` / `.todo` |
| `imports-orphan` | high | imports a `src/` module that no longer exists |
| `deprecated-export` | low | named import no longer exported |
| `subsumed-candidate` | low | narrower test imports a subset of another's surface |

**High** = safe to delete. **Low** = needs justification per the rule that tests are pruned when they lose meaning, not to hit a LOC target.

Live run against this repo (498 test files): 38 `subsumed-candidate` findings — including the next slice target, `tests/budget.test.js` (subsumed by `tests/utils/budget.test.js`).

## What changed

- `scripts/audit-test-diet.mjs` — 140 LOC, exports `auditTestDiet`, `parseImports`, `extractExports`, `renderMarkdown` plus helpers.
- `tests/scripts/audit-test-diet.test.js` — 56 LOC, 4 tests covering all 5 categories with synthetic fixtures in `os.tmpdir()`.
- `package.json` — `npm run audit:test-diet`.
- `.gitignore` — ignores generated `audit/` outputs.

Total: **199 lines added**, within the 200-LOC PR budget.

## Test plan

- [x] `npx vitest run tests/scripts/audit-test-diet.test.js` — 4/4 green
- [x] Full suite: 5468/5469 (1 flake in `tests/board/board.test.js` unrelated, passes in isolation)
- [x] `node scripts/audit-test-diet.mjs` on real tree — produces useful, non-noisy findings
- [ ] CI green