### PR TITLE
fix(audit): subsumed-candidate requires it() name overlap, not just imports (KJC-TSK-0345)

### DIFF
--- a/scripts/audit-test-diet.mjs
+++ b/scripts/audit-test-diet.mjs
@@ -53,6 +53,12 @@ export function resolveSrcImport(testFile, specifier, rootDir) {
   return null;
 }
 
+export function extractItNames(source) {
+  const names = new Set();
+  for (const m of source.matchAll(/\b(?:it|test)(?:\.(?:only|skip|todo))?\s*\(\s*['"`]([^'"`]+)['"`]/g)) names.add(m[1]);
+  return names;
+}
+
 export function extractExports(source) {
   const names = new Set();
   for (const m of source.matchAll(/export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g)) names.add(m[1]);
@@ -84,14 +90,14 @@ export function auditFile(testFile, rootDir) {
     }
     srcImports.push({ resolved: relative(rootDir, resolved), named: imp.named });
   }
-  return { path: rel, srcImports, findings };
+  return { path: rel, srcImports, findings, itNames: extractItNames(source) };
 }
 
 export function findSubsumed(perFile) {
   const bySrc = new Map();
   for (const f of perFile) for (const imp of f.srcImports) {
     if (!bySrc.has(imp.resolved)) bySrc.set(imp.resolved, []);
-    bySrc.get(imp.resolved).push({ path: f.path, named: new Set(imp.named) });
+    bySrc.get(imp.resolved).push({ path: f.path, named: new Set(imp.named), itNames: f.itNames });
   }
   const out = [];
   for (const [src, consumers] of bySrc) {
@@ -99,9 +105,14 @@ export function findSubsumed(perFile) {
     const sorted = [...consumers].sort((a, b) => a.named.size - b.named.size);
     const narrow = sorted[0]; const broad = sorted[sorted.length - 1];
     if (narrow.path === broad.path || narrow.named.size === 0 || broad.named.size === 0) continue;
-    if (narrow.named.size < broad.named.size && [...narrow.named].every((n) => broad.named.has(n))) {
-      out.push({ category: "subsumed-candidate", confidence: "low", path: narrow.path, detail: `subset of imports from ${src}, also covered by ${broad.path}` });
-    }
+    if (!(narrow.named.size < broad.named.size && [...narrow.named].every((n) => broad.named.has(n)))) continue;
+    // Require ≥50% of narrow's it() names to also appear in broad's. Imports
+    // alone are a false-positive trap: two tests can share helpers and assert
+    // on disjoint behavior (e.g. tests/budget.test.js vs tests/utils/budget.test.js).
+    if (narrow.itNames.size === 0) continue;
+    const overlap = [...narrow.itNames].filter((n) => broad.itNames.has(n)).length;
+    if (overlap / narrow.itNames.size < 0.5) continue;
+    out.push({ category: "subsumed-candidate", confidence: "low", path: narrow.path, detail: `${overlap}/${narrow.itNames.size} it() names also in ${broad.path}; subset of imports from ${src}` });
   }
   return out;
 }

--- a/tests/scripts/audit-test-diet.test.js
+++ b/tests/scripts/audit-test-diet.test.js
@@ -46,11 +46,17 @@ describe("auditTestDiet — semantic categories", () => {
     expect(dep.confidence).toBe("low");
   });
 
-  it("flags subsumed-candidate when a narrower test imports a subset", async () => {
+  it("flags subsumed-candidate only when it() names actually overlap", async () => {
     await write("src/big.js", `export const a = 1;\nexport const b = 2;\nexport const c = 3;\n`);
-    await write("tests/narrow.test.js", `import { a } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("a", () => { expect(a).toBe(1); });\n`);
-    await write("tests/broad.test.js", `import { a, b, c } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("all", () => { expect(a + b + c).toBe(6); });\n`);
-    const sub = auditTestDiet(root).findings.find((f) => f.category === "subsumed-candidate" && f.path.endsWith("narrow.test.js"));
-    expect(sub.detail).toMatch(/broad\.test\.js/);
+    // Real subsumption: narrow's it() names are a subset of broad's.
+    await write("tests/narrow.test.js", `import { a } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("a is 1", () => { expect(a).toBe(1); });\n`);
+    await write("tests/broad.test.js", `import { a, b, c } from "../src/big.js";\nimport { it, expect } from "vitest";\nit("a is 1", () => { expect(a).toBe(1); });\nit("b is 2", () => { expect(b).toBe(2); });\nit("sum", () => { expect(a+b+c).toBe(6); });\n`);
+    // Same imports, disjoint it() names → must NOT be flagged.
+    await write("src/dual.js", `export const x = 1;\nexport const y = 2;\n`);
+    await write("tests/dual-tracker.test.js", `import { x } from "../src/dual.js";\nimport { it, expect } from "vitest";\nit("tracker records", () => { expect(x).toBe(1); });\n`);
+    await write("tests/dual-helpers.test.js", `import { x, y } from "../src/dual.js";\nimport { it, expect } from "vitest";\nit("helper does math", () => { expect(x+y).toBe(3); });\n`);
+    const findings = auditTestDiet(root).findings.filter((f) => f.category === "subsumed-candidate");
+    expect(findings.find((f) => f.path.endsWith("narrow.test.js"))).toBeTruthy();
+    expect(findings.find((f) => f.path.endsWith("dual-tracker.test.js"))).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Slice 0.1b — fixes a false-positive trap discovered immediately after #968 merged.

When trying to act on the auditor's first run (delete \`tests/budget.test.js\`, allegedly subsumed by \`tests/utils/budget.test.js\`), I compared their bodies:

- \`tests/budget.test.js\` — 7 it() blocks, all about \`BudgetTracker\` behavior (records, totals, summary, pricing).
- \`tests/utils/budget.test.js\` — 17 it() blocks, mostly about \`estimateTokens\` / \`extractUsageMetrics\` (different concern).

Identical imports, disjoint assertions. The auditor's signal was wrong, and following it would have lost real coverage — exactly the failure mode the user wanted prevented.

## Fix

\`findSubsumed\` now requires **both**:
1. Imports of the narrow test are a subset of the broad test (unchanged).
2. ≥50% of the narrow test's \`it()\`/\`test()\` names also appear in the broad test (new).

New helper: \`extractItNames(source)\`.

## Impact

Re-running on the live tree (498 test files): **0 subsumed-candidate findings**. That's the right answer for this repo — no copy-pasted tests waiting to be pruned by import overlap. Other categories (empty-no-expect, skipped-pending, imports-orphan, deprecated-export) also report 0, confirming the suite has good hygiene.

This is signal, not a problem: the 35K-LOC aspirational target from KJC-TSK-0345 cannot be reached by deleting tests-that-lost-meaning alone. Further pruning would require structural refactors (splitting helper-heavy files, deduplicating mocks) rather than blanket deletions.

## Test plan

- [x] New negative-case test: same imports + disjoint it() names → must NOT be flagged
- [x] Existing positive-case test updated to share matching it() names
- [x] \`npx vitest run tests/scripts/audit-test-diet.test.js\` — 4/4 green
- [x] Live audit on this repo — 0 false positives
- [ ] CI green

Net diff: +27 / -10 lines.