### PR TITLE
fix(board): probe /api/dashboard before announcing started (KJC-BUG-0080)

### DIFF
--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -122,6 +122,29 @@ export function waitForEarlyExit(child, logPath) {
   });
 }
 
+// KJC-BUG-0080: waitForEarlyExit only catches an exit, not a hung
+// daemon that survived the window without ever bind()ing the port.
+// Poll /api/dashboard until it answers or the readiness budget runs
+// out, so we never announce "HU Board started" for an unreachable
+// server. Overridable with KJ_BOARD_READY_TIMEOUT_MS (tests set it
+// low to stay fast).
+export async function waitForBoardReachable(port, totalTimeoutMs) {
+  const envTimeout = Number(process.env.KJ_BOARD_READY_TIMEOUT_MS);
+  const budget = Number.isFinite(envTimeout) && envTimeout >= 0
+    ? envTimeout
+    : (Number.isFinite(totalTimeoutMs) ? totalTimeoutMs : 5000);
+  const intervalMs = budget <= 200 ? Math.max(10, Math.floor(budget / 5)) : 200;
+  const deadline = Date.now() + budget;
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    const probeTimeout = Math.min(750, Math.max(50, remaining));
+    if (await isBoardReachable(port, probeTimeout)) return true;
+    const wait = Math.min(intervalMs, deadline - Date.now());
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  }
+  return false;
+}
+
 export async function startBoard(desiredPort = 4000, opts = {}) {
   const { projectSlug = null, bind = "127.0.0.1" } = opts;
   const existingPid = readPid();
@@ -198,6 +221,17 @@ export async function startBoard(desiredPort = 4000, opts = {}) {
   const failure = await waitForEarlyExit(child, logPath);
   if (failure) {
     throw new Error(failure);
+  }
+  // KJC-BUG-0080: even after a clean window, the server may have
+  // failed to bind (e.g. port race vs the parent's findAvailablePort)
+  // or be still booting. Probe /api/dashboard before announcing
+  // success — without this the CLI used to print "HU Board started
+  // at http://localhost:4000" while :4000 actually returned nothing.
+  const reachable = await waitForBoardReachable(port);
+  if (!reachable) {
+    throw new Error(
+      `HU Board daemon spawned (PID ${child.pid}) but did not answer on http://localhost:${port} in time. See ${logPath} for the cause.`
+    );
   }
   fs.writeFileSync(PID_FILE, String(child.pid));
   // Detach for real: `detached: true` only sets up the new session;

--- a/tests/board/board-start-detach.test.js
+++ b/tests/board/board-start-detach.test.js
@@ -31,18 +31,29 @@ vi.mock("node:net", () => ({
     }),
   },
 }));
-// startBoard now HTTP-probes the configured port (`isBoardReachable`)
-// before spawning, as a fallback for stale/missing PID files. Stub
-// `node:http` so the probe immediately fails (i.e. "no board there"),
-// letting the spawn path proceed deterministically.
+// startBoard HTTP-probes the configured port twice: once as a
+// pre-spawn fallback (stale PID file) and once as a post-spawn
+// readiness check (KJC-BUG-0080). Mock state lets us simulate
+// "no board there" before spawn and "board answered" after spawn.
+let httpCallIdx = 0;
+let httpAlwaysFail = false;
 vi.mock("node:http", () => {
   return {
     default: {
-      request: () => {
+      request: (_opts, cb) => {
+        const idx = httpCallIdx++;
         const handlers = {};
         return {
-          on: (ev, cb) => { handlers[ev] = cb; },
-          end: () => { setImmediate(() => handlers.error?.(new Error("ECONNREFUSED"))); },
+          on: (ev, h) => { handlers[ev] = h; },
+          end: () => {
+            setImmediate(() => {
+              if (httpAlwaysFail || idx === 0) {
+                handlers.error?.(new Error("ECONNREFUSED"));
+              } else {
+                cb?.({ statusCode: 200, resume() {} });
+              }
+            });
+          },
           destroy: () => {},
         };
       },
@@ -56,6 +67,9 @@ beforeEach(() => {
   tmpHome = mkdtempSync(join(tmpdir(), "kj-board-start-"));
   process.env.KJ_HOME = tmpHome;
   process.env.KJ_BOARD_START_WINDOW_MS = "20";
+  process.env.KJ_BOARD_READY_TIMEOUT_MS = "200";
+  httpCallIdx = 0;
+  httpAlwaysFail = false;
   unref.mockReset();
   child.once.mockReset();
   child.removeListener.mockReset();
@@ -71,6 +85,7 @@ afterEach(() => {
   rmSync(tmpHome, { recursive: true, force: true });
   delete process.env.KJ_HOME;
   delete process.env.KJ_BOARD_START_WINDOW_MS;
+  delete process.env.KJ_BOARD_READY_TIMEOUT_MS;
 });
 
 describe("startBoard — detaches properly", () => {
@@ -105,5 +120,21 @@ describe("startBoard — detaches properly", () => {
     const pidPath = join(tmpHome, "hu-board.pid");
     expect(existsSync(pidPath)).toBe(true);
     expect(readFileSync(pidPath, "utf-8")).toBe("4242");
+  });
+
+  // KJC-BUG-0080 regression: the daemon survives the early-exit
+  // window but never answers HTTP — pre-fix the CLI happily printed
+  // "HU Board started at http://localhost:4000" while the port was
+  // dead. Now startBoard throws and the PID file stays unwritten so
+  // the next kj run knows the previous attempt failed.
+  it("throws when the daemon never answers /api/dashboard within the readiness budget", async () => {
+    httpAlwaysFail = true;
+    process.env.KJ_BOARD_READY_TIMEOUT_MS = "50";
+    const { startBoard } = await import("../../src/commands/board.js");
+    await expect(startBoard(4000)).rejects.toThrow(
+      /did not answer on http:\/\/localhost:4000/
+    );
+    const pidPath = join(tmpHome, "hu-board.pid");
+    expect(existsSync(pidPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `waitForEarlyExit` only catches a crash inside the 1.5 s window — a daemon that survived without ever bind()ing the port (race vs the parent's `findAvailablePort`, slow boot, late crash) made `kj` print "HU Board started at http://localhost:4000" while :4000 returned nothing.
- New `waitForBoardReachable(port)` polls `/api/dashboard` (~200 ms cadence, 5 s budget, overridable via `KJ_BOARD_READY_TIMEOUT_MS`) after the early-exit check. If the budget expires, throw with PID + log path and skip writing the PID file so the next `kj run` starts clean.
- Regression test stays under the existing `tests/board/board-start-detach.test.js` patterns and asserts: rejection message includes `http://localhost:<port>`, no PID file written.

## Test plan
- [x] `npx vitest run tests/board/board-start-detach.test.js` — 4/4 pass (3 existentes + regresión nueva).
- [x] `npx vitest run tests/board tests/orchestrator tests/commands` — 239/239 pass.
- [ ] CI green.