### PR TITLE
feat(audit): wire ai-slop into kj audit deterministic (KJC-TSK-0503)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -41,9 +41,26 @@ export function formatDeterministicSummary(ctx) {
   if (ctx.circularDeps) lines.push(...formatCircularDepsBlock(ctx.circularDeps));
   if (ctx.deadExports) lines.push(...formatDeadExportsBlock(ctx.deadExports));
   if (ctx.injectionFindings) lines.push(...formatInjectionBlock(ctx.injectionFindings));
+  if (ctx.aiSlop) lines.push(...formatAiSlopBlock(ctx.aiSlop));
   if (ctx.webperf) lines.push(...formatWebperfBlock(ctx.webperf));
 
   return lines.join("\n");
+}
+
+function formatAiSlopBlock(slop) {
+  if (!slop.available) return ["### AI-slop tells (deterministic)", `- Status: not available — ${slop.reason || "scan failed"}`, ""];
+  const lines = ["### AI-slop tells (deterministic)", `- Files scanned: ${slop.filesScanned ?? 0}`, `- Score: ${slop.score}/100 (100 = clean)`, `- Findings: ${slop.total ?? 0}`];
+  if ((slop.total ?? 0) > 0) {
+    for (const [cat, n] of Object.entries(slop.byCategory || {})) {
+      if (n > 0) lines.push(`  - ${cat}: ${n}`);
+    }
+    if (Array.isArray(slop.worst) && slop.worst.length > 0) {
+      lines.push("  - Worst offenders:");
+      for (const f of slop.worst) lines.push(`    - ${f.path}:${f.line} [${f.category}] ${f.snippet}`);
+    }
+  }
+  lines.push("");
+  return lines;
 }
 
 function formatInjectionBlock(inj) {
@@ -278,5 +295,6 @@ export function deterministicContextHasFindings(ctx) {
   if (ctx.circularDeps?.available && (ctx.circularDeps.total ?? 0) > 0) return true;
   if (ctx.deadExports?.available && (ctx.deadExports.total ?? 0) > 0) return true;
   if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;
+  if (ctx.aiSlop?.available && (ctx.aiSlop.total ?? 0) > 0) return true;
   return false;
 }

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -197,6 +197,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-osv", "Skip the OSV-Scanner vulnerability collector. Findings are also skipped automatically when osv-scanner is not installed.")
     .option("--no-semgrep", "Skip the Semgrep SAST collector. Findings are also skipped automatically when semgrep is not installed (install via 'pipx install semgrep' or 'brew install semgrep').")
     .option("--no-harness", "Skip the AI Harness Scorecard stage (Docker one-shot). Auto-skipped when Docker is unavailable. Each run is also persisted to .karajan/audit-history.db (KJC-TSK-0472) for diff/trend tracking.")
+    .option("--no-ai-slop", "Skip the AI-slop tells collector (deterministic regex scan for tautologic comments, banner separators, boilerplate docstrings, magic fallbacks, redundant JSDoc). KJC-TSK-0503.")
     .option("--trend", "Append a sparkline of the harness score across the last 10 runs (uses .karajan/audit-history.db). KJC-TSK-0473.")
     .option("--report-file <path>", "Write the audit report to disk in addition to stdout. <path> may be a file (extension drives format: .md or .json) or a directory (creates audit-<ISO>.<md|json> inside). $KJ_AUDIT_REPORT_DIR env var is used as default directory if no --report-file is given.")
     .option("--deterministic-only", "Skip the LLM analysis entirely. Print/persist only the deterministic findings (basalCost, sonar, stack, growth-delta, webperf). Zero tokens spent. Compatible with --report-file and --json.")
@@ -220,6 +221,7 @@ export function registerMeta(program, { pkgVersion }) {
           noOsv: flags.osv === false,
           noSemgrep: flags.semgrep === false,
           noHarness: flags.harness === false,
+          noAiSlop: flags.aiSlop === false,
           reportFile: flags.reportFile || null,
           deterministicOnly: Boolean(flags.deterministicOnly),
           yes: Boolean(flags.yes),

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -216,7 +216,7 @@ function loadAuditHistoryContext(projectDir, currentHarness, { showTrend = false
   finally { try { db?.close(); } catch { /* noop */ } }
 }
 
-function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }) {
+function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, noAiSlop, json, deterministicOnly, yes }) {
   const parts = ["kj audit"];
   if (task && task !== "Analyze the full codebase") parts.push(JSON.stringify(task));
   if (dimensions && dimensions !== "all") parts.push(`--dimensions=${dimensions}`);
@@ -224,13 +224,14 @@ function describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHar
   if (noOsv) parts.push("--no-osv");
   if (noSemgrep) parts.push("--no-semgrep");
   if (noHarness) parts.push("--no-harness");
+  if (noAiSlop) parts.push("--no-ai-slop");
   if (deterministicOnly) parts.push("--deterministic-only");
   if (yes) parts.push("--yes");
   if (json) parts.push("--json");
   return parts.join(" ");
 }
 
-export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, noHarness = false, reportFile = null, deterministicOnly = false, yes = false, trend = false, promptFn = null }) {
+export async function auditCommand({ task, config, logger, dimensions, json, agentReadiness, path: pathArg, noSonar = false, noOsv = false, noSemgrep = false, noHarness = false, noAiSlop = false, reportFile = null, deterministicOnly = false, yes = false, trend = false, promptFn = null }) {
   // --agent-readiness is a STANDALONE, deterministic, LLM-free audit
   // dimension. It scores any third-party repo for AI-agent readability
   // (llms.txt presence, page token budgets, robots allowlist, etc.).
@@ -269,6 +270,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
       noSonar,
       noOsv,
       noSemgrep,
+      noAiSlop,
     };
     const deterministicCtx = await role.collectDeterministic(roleInput);
     const deterministicMd = formatDeterministicSummary(deterministicCtx);
@@ -324,7 +326,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
         if (reportPath.endsWith(".json")) {
           payload = JSON.stringify({ deterministic: deterministicCtx, harnessScore: harnessJson, harnessScoreDiff: history.diff, mode: "deterministic-only" }, null, 2);
         } else {
-          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));
+          const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, noAiSlop, json, deterministicOnly, yes }));
           payload = `${header}${deterministicMd}\n${harnessMd}${historyMd}`;
         }
         await fs.writeFile(reportPath, payload, "utf8");
@@ -385,7 +387,7 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
           : { ...roleResult, harnessScore: harnessJson, harnessScoreDiff: history.diff, usage: usage || undefined };
         payload = JSON.stringify(jsonPayload, null, 2);
       } else {
-        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, json, deterministicOnly, yes }));
+        const header = await buildReportHeader(config?.projectDir, describeInvocation({ task, dimensions, noSonar, noOsv, noSemgrep, noHarness, noAiSlop, json, deterministicOnly, yes }));
         payload = header + stdoutContent + "\n";
       }
       await fs.writeFile(reportPath, payload, "utf8");

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -9,6 +9,7 @@ import { collectSemgrepFindings } from "../audit/semgrep-findings.js";
 import { collectCircularDeps } from "../audit/circular-deps.js";
 import { collectDeadExports } from "../audit/dead-exports.js";
 import { collectInjectionFindings } from "../audit/injection-findings.js";
+import { collectAiSlop } from "../audit/ai-slop-findings.js";
 
 function parseDimensions(dimensionsStr) {
   if (!dimensionsStr || dimensionsStr === "all") return null;
@@ -53,6 +54,7 @@ export class AuditRole extends AgentRole {
     const noMadge = typeof input === "object" ? Boolean(input?.noMadge) : false;
     const noKnip = typeof input === "object" ? Boolean(input?.noKnip) : false;
     const noInjectionScan = typeof input === "object" ? Boolean(input?.noInjectionScan) : false;
+    const noAiSlop = typeof input === "object" ? Boolean(input?.noAiSlop) : false;
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
     let growthDelta = null;
@@ -64,6 +66,7 @@ export class AuditRole extends AgentRole {
     let circularDeps = null;
     let deadExports = null;
     let injectionFindings = null;
+    let aiSlop = null;
     try {
       basalCost = await measureBasalCost(projectDir);
       const previous = await loadPreviousAudit(projectDir);
@@ -116,7 +119,14 @@ export class AuditRole extends AgentRole {
         injectionFindings = await collectInjectionFindings(projectDir, this.logger);
       } catch { /* injection scan is best-effort (KJC-TSK-0498) */ }
     }
-    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings, circularDeps, deadExports, injectionFindings };
+    // AI-slop tells (KJC-TSK-0503). Deterministic, offline, regex-based.
+    // Local equivalent of Deslopify-style review. Best-effort.
+    if (!noAiSlop) {
+      try {
+        aiSlop = await collectAiSlop(projectDir);
+      } catch { /* ai-slop scan is best-effort */ }
+    }
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings, circularDeps, deadExports, injectionFindings, aiSlop };
   }
 
   /**

--- a/tests/audit/ai-slop-integration.test.js
+++ b/tests/audit/ai-slop-integration.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { formatDeterministicSummary, deterministicContextHasFindings } from "../../src/audit/deterministic-summary.js";
+
+// PR 2/2 for KJC-TSK-0503 — verifies that AI-slop findings render
+// inside the deterministic summary and unlock the "Continue with LLM?"
+// gate when present.
+
+describe("formatDeterministicSummary — AI-slop block", () => {
+  it("renders the block with score and category breakdown when findings exist", () => {
+    const md = formatDeterministicSummary({
+      aiSlop: {
+        available: true,
+        filesScanned: 12,
+        totalLOC: 1234,
+        total: 4,
+        score: 60,
+        byCategory: {
+          "tautologic-comments": 2,
+          "banner-separators": 1,
+          "boilerplate-docstrings": 0,
+          "magic-fallbacks": 1,
+          "redundant-jsdoc": 0,
+        },
+        worst: [
+          { path: "src/a.js", line: 3, category: "tautologic-comments", snippet: "// returns the user" },
+          { path: "src/b.js", line: 9, category: "magic-fallbacks", snippet: "const x = a || null;" },
+        ],
+      },
+    });
+    expect(md).toContain("### AI-slop tells (deterministic)");
+    expect(md).toContain("Files scanned: 12");
+    expect(md).toContain("Score: 60/100");
+    expect(md).toContain("Findings: 4");
+    expect(md).toContain("tautologic-comments: 2");
+    expect(md).toContain("magic-fallbacks: 1");
+    expect(md).not.toContain("boilerplate-docstrings: 0");
+    expect(md).toContain("src/a.js:3");
+    expect(md).toContain("src/b.js:9");
+  });
+
+  it("renders a 'not available' line when the scan failed", () => {
+    const md = formatDeterministicSummary({
+      aiSlop: { available: false, reason: "ENOENT" },
+    });
+    expect(md).toContain("### AI-slop tells (deterministic)");
+    expect(md).toContain("not available — ENOENT");
+  });
+
+  it("does not render any block when ctx.aiSlop is absent", () => {
+    const md = formatDeterministicSummary({});
+    expect(md).not.toContain("### AI-slop tells");
+  });
+});
+
+describe("deterministicContextHasFindings — AI-slop signal", () => {
+  it("returns true when AI-slop has at least one finding", () => {
+    expect(deterministicContextHasFindings({
+      aiSlop: { available: true, total: 1, score: 95, byCategory: {} },
+    })).toBe(true);
+  });
+
+  it("returns false when AI-slop is clean (total=0)", () => {
+    expect(deterministicContextHasFindings({
+      aiSlop: { available: true, total: 0, score: 100, byCategory: {} },
+    })).toBe(false);
+  });
+
+  it("returns false when AI-slop is unavailable", () => {
+    expect(deterministicContextHasFindings({
+      aiSlop: { available: false, reason: "x" },
+    })).toBe(false);
+  });
+});

--- a/tests/commands/command-audit.test.js
+++ b/tests/commands/command-audit.test.js
@@ -217,8 +217,8 @@ describe("commands/audit — CLI/MCP parity (KJC-TSK-0357)", () => {
     // (MCP clients toggle the same control via the AuditRole input
     // directly when they want it). Strip both before comparing the
     // structural shape that drives the prompt.
-    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, noSemgrep: _cliNoSemgrep, ...cliCore } = cliArgs;
-    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, noSemgrep: _mcpNoSemgrep, ...mcpCore } = mcpArgs;
+    const { onOutput: _cliOnOutput, noSonar: _cliNoSonar, noOsv: _cliNoOsv, noSemgrep: _cliNoSemgrep, noAiSlop: _cliNoAiSlop, ...cliCore } = cliArgs;
+    const { onOutput: _mcpOnOutput, noSonar: _mcpNoSonar, noOsv: _mcpNoOsv, noSemgrep: _mcpNoSemgrep, noAiSlop: _mcpNoAiSlop, ...mcpCore } = mcpArgs;
     expect(cliCore).toEqual(mcpCore);
   });
 });


### PR DESCRIPTION
## Summary

PR 2/2 for KJC-TSK-0503 — wires the deterministic AI-slop scanner shipped in #972 into `kj audit`.

- `AuditRole.collectDeterministic()` calls `collectAiSlop(projectDir)` unless `--no-ai-slop` is set. Best-effort: a scan failure returns `available:false` without breaking the audit.
- `deterministic-summary.js` renders a new **AI-slop tells (deterministic)** block: files scanned, score (0-100, 100 = clean), per-category breakdown, and the worst offenders (`path:line` + snippet).
- `deterministicContextHasFindings` now returns true when AI-slop has findings, so the *Continue with LLM?* gate fires for slop-heavy repos even when every other collector comes back clean.
- New CLI flag `--no-ai-slop` (commander negation), threaded through `auditCommand` and into `describeInvocation` so the report header reflects the invocation.

## Test plan

- [x] 6 new tests in `tests/audit/ai-slop-integration.test.js` (3 for `formatDeterministicSummary`, 3 for `deterministicContextHasFindings`)
- [x] `tests/audit/two-phase.test.js` still passes after the new block lands
- [x] 345/345 tests across `tests/audit` + `tests/roles` pass locally
- [x] `eslint` + `prettier --check` clean
- [x] Net LOC delta = 105