### PR TITLE
refactor(tests): shared noop logger fixture (KJC-TSK-0502 PR1)

### DIFF
--- a/tests/_fixtures/loggers.js
+++ b/tests/_fixtures/loggers.js
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+
+// Shared test fixtures for the noop logger pattern. Twenty-plus test
+// files declared the same `{ info, warn, error, debug }` mock inline
+// (audit by KJC-TSK-0502). Importing from here keeps the shape uniform
+// and gives a single point to extend (e.g. add `trace`) without sweeping
+// the test tree.
+
+export const createNoopLogger = () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+});
+
+export const createNoopLoggerWithContext = () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  setContext: vi.fn(),
+});

--- a/tests/agents/agents-base.test.js
+++ b/tests/agents/agents-base.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { BaseAgent } from "../../src/agents/base-agent.js";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 describe("BaseAgent", () => {
   const config = {
@@ -10,7 +11,7 @@ describe("BaseAgent", () => {
     coder_options: { auto_approve: true, model: "fallback-coder-model" },
     reviewer_options: { model: "fallback-reviewer-model" }
   };
-  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const logger = createNoopLogger();
 
   it("stores name, config, and logger", () => {
     const agent = new BaseAgent("test", config, logger);

--- a/tests/agents/agents-index.test.js
+++ b/tests/agents/agents-index.test.js
@@ -5,9 +5,10 @@ import { CodexAgent } from "../../src/agents/codex-agent.js";
 import { GeminiAgent } from "../../src/agents/gemini-agent.js";
 import { AiderAgent } from "../../src/agents/aider-agent.js";
 import { BaseAgent } from "../../src/agents/base-agent.js";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 const config = { session: { max_iteration_minutes: 5 } };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("agents/index createAgent", () => {
   it("creates ClaudeAgent for 'claude'", () => {

--- a/tests/agents/aider-agent.test.js
+++ b/tests/agents/aider-agent.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/utils/process.js", () => ({
   runCommand: vi.fn()
@@ -13,7 +14,7 @@ const baseConfig = {
   coder_options: {},
   reviewer_options: {}
 };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("AiderAgent", () => {
   let runCommand;

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
 vi.mock("../../src/agents/resolve-bin.js", () => ({
@@ -6,7 +7,7 @@ vi.mock("../../src/agents/resolve-bin.js", () => ({
 }));
 
 const baseConfig = { roles: { coder: {}, reviewer: {} }, coder_options: {}, reviewer_options: {} };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("ClaudeAgent", () => {
   let runCommand;

--- a/tests/agents/codex-agent.test.js
+++ b/tests/agents/codex-agent.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
 vi.mock("../../src/agents/resolve-bin.js", () => ({
@@ -6,7 +7,7 @@ vi.mock("../../src/agents/resolve-bin.js", () => ({
 }));
 
 const baseConfig = { roles: { coder: {}, reviewer: {} }, coder_options: {}, reviewer_options: {} };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("CodexAgent", () => {
   let runCommand;

--- a/tests/agents/create-agent.test.js
+++ b/tests/agents/create-agent.test.js
@@ -6,9 +6,10 @@ import { GeminiAgent } from "../../src/agents/gemini-agent.js";
 import { AiderAgent } from "../../src/agents/aider-agent.js";
 import { OpenCodeAgent } from "../../src/agents/opencode-agent.js";
 import { BaseAgent } from "../../src/agents/base-agent.js";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 const config = { roles: {}, coder_options: {}, reviewer_options: {} };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("createAgent factory", () => {
   // merged-from: 5 per-agent instance tests collapsed into a single it.each

--- a/tests/agents/gemini-agent.test.js
+++ b/tests/agents/gemini-agent.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/utils/process.js", () => ({
   runCommand: vi.fn()
@@ -13,7 +14,7 @@ const baseConfig = {
   coder_options: {},
   reviewer_options: {}
 };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("GeminiAgent", () => {
   let runCommand;

--- a/tests/agents/opencode-agent.test.js
+++ b/tests/agents/opencode-agent.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/utils/process.js", () => ({
   runCommand: vi.fn()
@@ -13,7 +14,7 @@ const baseConfig = {
   coder_options: {},
   reviewer_options: {}
 };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("OpenCodeAgent", () => {
   let runCommand;

--- a/tests/integration/agents-index-contract.test.js
+++ b/tests/integration/agents-index-contract.test.js
@@ -22,9 +22,10 @@ import {
   getAgentMeta
 } from "../../src/agents/index.js";
 import { BaseAgent } from "../../src/agents/base-agent.js";
+import { createNoopLogger } from "../_fixtures/loggers.js";
 
 const config = { roles: {}, coder_options: {}, reviewer_options: {} };
-const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const logger = createNoopLogger();
 
 describe("integration: src/agents/index.js external contract", () => {
   it("exposes the documented public functions", () => {


### PR DESCRIPTION
## Summary
- Extracts the duplicated `{ info, warn, error, debug }` mock logger from 9 agent test files into `tests/_fixtures/loggers.js`.
- Two helpers: `createNoopLogger()` (4 methods) and `createNoopLoggerWithContext()` (adds `setContext`).
- Establishes the `tests/_fixtures/` infrastructure for KJC-TSK-0502 follow-ups (more fixtures + heavy-mock splits).

## Test plan
- [x] `npx vitest run tests/agents/ tests/integration/agents-index-contract.test.js` — 311 tests pass.
- [x] LOC delta within budget (+31 net).

Card: KJC-TSK-0502 (epic KJC-PCS-0001).