### PR TITLE
refactor(tests): noop logger fixture for non-agent tests (KJC-TSK-0502 PR3)

### DIFF
--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 // Reuse the same AuditRole mocking strategy as tests/command-audit.test.js
 // so this file can drive auditCommand through the report-file branch
@@ -39,7 +40,7 @@ vi.mock("../../src/audit/harness-section.js", () => ({
   harnessSummaryForJson: vi.fn(() => null),
 }));
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 
 const successResult = {
   ok: true,

--- a/tests/audit/two-phase.test.js
+++ b/tests/audit/two-phase.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { formatDeterministicSummary, deterministicContextHasFindings } from "../../src/audit/deterministic-summary.js";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 // Two-phase audit (deterministic first, ask before LLM) — KJC-TSK-0364.
 
@@ -57,7 +58,7 @@ const successResult = {
   usage: { available: true, provider: "claude", model: "claude-sonnet-4-6", tokens_in: 1000, tokens_out: 200, total_tokens: 1200, cost_usd: 0.005, durationMs: 4500 },
 };
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 
 let tmpDir;
 let consoleSpy;

--- a/tests/audit/usage-summary.test.js
+++ b/tests/audit/usage-summary.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 // Mocks must be declared before imports of code-under-test that triggers
 // the mocked modules. We import formatAudit/formatUsageSummary lazily
@@ -140,7 +141,7 @@ describe("formatAudit appends LLM Usage section when usage is provided", () => {
 // Integration via auditCommand path: confirm the section lands in stdout
 // + the JSON output + the markdown report-file. AuditRole is mocked at
 // the top of the file so this section just exercises auditCommand.
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 const exampleUsage = {
   available: true, provider: "claude", model: "claude-sonnet-4-6",
   tokens_in: 1234, tokens_out: 567, total_tokens: 1801, cost_usd: 0.0123, durationMs: 5500,

--- a/tests/commands/command-researcher.test.js
+++ b/tests/commands/command-researcher.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -21,9 +22,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/researcher", () => {
   let createAgent, assertAgentsAvailable;

--- a/tests/commands/command-review.test.js
+++ b/tests/commands/command-review.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -40,9 +41,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/review", () => {
   let createAgent, assertAgentsAvailable, computeBaseRef, generateDiff, buildReviewerPrompt;

--- a/tests/discover-role.test.js
+++ b/tests/discover-role.test.js
@@ -1,9 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DiscoverRole } from "../src/roles/discover-role.js";
-
-function makeLogger() {
-  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
-}
+import { createNoopLoggerWithContext as makeLogger } from "./_fixtures/loggers.js";
 
 function makeConfig(overrides = {}) {
   return {

--- a/tests/onboarder/onboard-command.test.js
+++ b/tests/onboarder/onboard-command.test.js
@@ -5,8 +5,9 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OnboarderRole } from "../../src/roles/onboarder-role.js";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 
 describe("OnboarderRole — KJC-TSK-0384 PR 2", () => {
   const role = new OnboarderRole({});


### PR DESCRIPTION
## Summary
- Seven more test files declared the same setContext-bearing noop logger shape inline.
- Swap each for `createNoopLoggerWithContext()` from `tests/_fixtures/loggers.js` (already created in #974).
- Files: `tests/audit/{usage-summary,two-phase,report-file}.test.js`, `tests/commands/{command-researcher,command-review}.test.js`, `tests/discover-role.test.js`, `tests/onboarder/onboard-command.test.js`.
- Net delta: +13 / -14.

## Test plan
- [x] \`npx vitest run\` over the 7 touched files → 79/79 passing locally
- [ ] CI green