### PR TITLE
refactor(tests): noop logger fixture batch 3 (KJC-TSK-0502)

### DIFF
--- a/tests/commands/command-audit.test.js
+++ b/tests/commands/command-audit.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 // AuditRole.collectDeterministic() + executeWithDeterministic() drive
 // auditCommand post KJC-TSK-0364 (two-phase). The legacy execute()
@@ -56,9 +57,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn(),
-};
+const noopLogger = createNoopLoggerWithContext();
 
 const successResult = {
   ok: true,

--- a/tests/commands/command-discover.test.js
+++ b/tests/commands/command-discover.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -30,9 +31,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/discover", () => {
   let createAgent, assertAgentsAvailable, buildDiscoverPrompt;

--- a/tests/commands/command-plan.test.js
+++ b/tests/commands/command-plan.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -26,9 +27,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 const validPlan = JSON.stringify({
   approach: "Use modular design",

--- a/tests/plan/plan-generate-no-chain.test.js
+++ b/tests/plan/plan-generate-no-chain.test.js
@@ -14,6 +14,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { tmpdir } from "node:os";
 import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 function loadOnlyPlan() {
   const root = join(process.env.KJ_HOME, "plans");
@@ -37,9 +38,7 @@ vi.mock("../../src/prompts/planner.js", () => ({
   buildPlannerPrompt: vi.fn().mockReturnValue("planner prompt"),
 }));
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn(),
-};
+const noopLogger = createNoopLoggerWithContext();
 
 const sixSteps = JSON.stringify({
   approach: "Build the foundation in six independent slices",

--- a/tests/webperf/command-webperf.test.js
+++ b/tests/webperf/command-webperf.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 const scanMock = vi.fn();
 
@@ -13,7 +14,7 @@ vi.mock("../../src/utils/cli-run-log.js", () => ({
   }),
 }));
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 
 const passingScan = {
   ok: true,

--- a/tests/webperf/perf-role.test.js
+++ b/tests/webperf/perf-role.test.js
@@ -3,8 +3,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { PerfRole } from "../../src/roles/perf-role.js";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 
 const passingScan = {
   ok: true,

--- a/tests/webperf/perf-stage.test.js
+++ b/tests/webperf/perf-stage.test.js
@@ -2,8 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
-const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const noopLogger = createNoopLoggerWithContext();
 const emitter = { emit: vi.fn() };
 
 let tmpHome, tmpProject, originalHome;


### PR DESCRIPTION
## Summary
- Apply `createNoopLoggerWithContext()` fixture to 7 more non-agent test files
- Net delta: -1 line (14 insertions, 15 deletions)
- Zero behaviour change

## Files refactored
- `tests/commands/command-audit.test.js`
- `tests/commands/command-discover.test.js`
- `tests/commands/command-plan.test.js`
- `tests/plan/plan-generate-no-chain.test.js`
- `tests/webperf/command-webperf.test.js`
- `tests/webperf/perf-role.test.js`
- `tests/webperf/perf-stage.test.js`

Continues the inline-mock cleanup from PR #974, #975, #976.

## Test plan
- [x] Local: `npx vitest run` on the 7 files → 47/47 passing
- [ ] CI: all checks green