### PR TITLE
refactor(tests): noop logger fixture batch 4 (KJC-TSK-0502)

### DIFF
--- a/tests/commands/command-architect.test.js
+++ b/tests/commands/command-architect.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -30,9 +31,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/architect", () => {
   let createAgent, assertAgentsAvailable, buildArchitectPrompt;

--- a/tests/commands/command-code.test.js
+++ b/tests/commands/command-code.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -33,9 +34,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/code", () => {
   let createAgent, assertAgentsAvailable, buildCoderPrompt;

--- a/tests/commands/command-triage.test.js
+++ b/tests/commands/command-triage.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/agents/index.js", () => ({
   createAgent: vi.fn()
@@ -34,9 +35,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn()
-};
+const noopLogger = createNoopLoggerWithContext();
 
 describe("commands/triage", () => {
   let createAgent, assertAgentsAvailable;

--- a/tests/roles/base-role-provider.test.js
+++ b/tests/roles/base-role-provider.test.js
@@ -4,8 +4,9 @@ import path from "node:path";
 import os from "node:os";
 import { BaseRole } from "../../src/roles/base-role.js";
 import { AgentRole } from "../../src/roles/agent-role.js";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
-const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+const silentLogger = createNoopLoggerWithContext();
 
 async function mkTmpProject() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-role-prov-"));
@@ -66,7 +67,7 @@ describe("Role instantiation resolves per-provider templates", () => {
     await fs.mkdir(roleDir, { recursive: true });
     await fs.writeFile(path.join(roleDir, "default.md"), "DEFAULT");
 
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), setContext: vi.fn() };
+    const logger = createNoopLoggerWithContext();
     const role = new AgentRole({
       name: "coder",
       config: { projectDir: dir, roles: { coder: { provider: "gemini" } } },


### PR DESCRIPTION
## Summary
- Apply `createNoopLoggerWithContext()` fixture to 4 more non-agent test files
- Net delta: -2 lines (9 insertions, 11 deletions)
- Zero behaviour change

## Files refactored
- `tests/commands/command-architect.test.js`
- `tests/commands/command-code.test.js`
- `tests/commands/command-triage.test.js`
- `tests/roles/base-role-provider.test.js` (2 occurrences inside same file)

Continues the inline-mock cleanup from PR #974, #975, #976, #977.

## Test plan
- [x] Local: `npx vitest run` on the 4 files → 19/19 passing
- [ ] CI: all checks green