### PR TITLE
refactor(tests): noop logger fixture for command-run (KJC-TSK-0502)

### DIFF
--- a/tests/commands/command-run.test.js
+++ b/tests/commands/command-run.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLoggerWithContext } from "../_fixtures/loggers.js";
 
 vi.mock("../../src/orchestrator.js", () => ({
   runFlow: vi.fn()
@@ -43,10 +44,7 @@ function makeConfig(overrides = {}) {
   };
 }
 
-const noopLogger = {
-  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
-  setContext: vi.fn(), onLog: vi.fn()
-};
+const noopLogger = { ...createNoopLoggerWithContext(), onLog: vi.fn() };
 
 describe("commands/run", () => {
   let runFlow, assertAgentsAvailable, printHeader, printEvent;


### PR DESCRIPTION
## Summary
- Apply `createNoopLoggerWithContext()` to `tests/commands/command-run.test.js`
- This file has the same shape **plus** `onLog: vi.fn()`, so compose:
  `const noopLogger = { ...createNoopLoggerWithContext(), onLog: vi.fn() };`
- Net delta: -3 lines

Continues the inline-mock cleanup from PR #974, #975, #976, #977, #978.

## Test plan
- [x] Local: 8/8 tests green
- [ ] CI: all checks green