### PR TITLE
refactor(tests): sonar-stage fixture (KJC-TSK-0502)

### DIFF
--- a/tests/_fixtures/sonar-stage.js
+++ b/tests/_fixtures/sonar-stage.js
@@ -1,0 +1,29 @@
+// Shared helper for tests that legitimately exercise the Sonar stage
+// (tests/setup.js sets globalThis.__KJ_DISABLE_SONAR_STAGE = true so
+// most non-Sonar tests skip Docker). Five files declared the same
+// save-restore-set dance inline (audit by KJC-TSK-0502).
+//
+// Usage:
+//   import { describe, beforeEach, afterAll } from "vitest";
+//   import { enableSonarStageForSuite } from "../_fixtures/sonar-stage.js";
+//
+//   describe("…", () => {
+//     enableSonarStageForSuite();
+//     // your tests
+//   });
+//
+// The helper registers a beforeEach that flips the flag off and an
+// afterAll that restores the previous value, so the next describe
+// block is unaffected.
+
+import { beforeEach, afterAll } from "vitest";
+
+export function enableSonarStageForSuite() {
+  const prev = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  beforeEach(() => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
+  });
+  afterAll(() => {
+    globalThis.__KJ_DISABLE_SONAR_STAGE = prev;
+  });
+}

--- a/tests/cli/kj-run-smoke.test.js
+++ b/tests/cli/kj-run-smoke.test.js
@@ -1,4 +1,5 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { enableSonarStageForSuite } from "../_fixtures/sonar-stage.js";
 import { EventEmitter } from "node:events";
 
 const REVIEW_OK = JSON.stringify({
@@ -146,16 +147,10 @@ describe("kj_run smoke", () => {
   // This file legitimately exercises the Sonar stage. Opt out of the
   // global test override (tests/setup.js sets __KJ_DISABLE_SONAR_STAGE=true
   // by default so non-sonar tests don't hit the Docker stage).
-  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
+  enableSonarStageForSuite();
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
-    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
-  });
-  // Restore the global default after this describe block finishes so it
-  // doesn't leak to other suites.
-  afterAll(() => {
-    globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled;
   });
 
   it("autostarts SonarQube and scans before review when sonar service is unavailable", async () => {

--- a/tests/preflight-checks.test.js
+++ b/tests/preflight-checks.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { enableSonarStageForSuite } from "./_fixtures/sonar-stage.js";
 
 vi.mock("../src/utils/agent-detect.js", () => ({
   checkBinary: vi.fn()
@@ -82,11 +83,9 @@ describe("preflight-checks", () => {
   // This file legitimately exercises the Sonar preflight (auto-start,
   // reachability, token auth). Opt out of the global test override
   // (tests/setup.js disables sonar by default for non-sonar tests).
-  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
-  afterEach(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
+  enableSonarStageForSuite();
 
   beforeEach(async () => {
-    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
     delete process.env.SONAR_TOKEN;

--- a/tests/runflow-repeat-detection.test.js
+++ b/tests/runflow-repeat-detection.test.js
@@ -1,4 +1,5 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { enableSonarStageForSuite } from "./_fixtures/sonar-stage.js";
 
 const REVIEW_BLOCKING = JSON.stringify({
   approved: false,
@@ -149,12 +150,9 @@ vi.mock("node:fs/promises", () => ({
 describe("orchestrator repeat detection", () => {
   let runFlow;
   // This file exercises the Sonar stage (sonar-issue repeat scenarios).
-  // Opt out of the global test override.
-  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
-  afterAll(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
+  enableSonarStageForSuite();
 
   beforeEach(async () => {
-    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
 
     const { createAgent } = await import("../src/agents/index.js");

--- a/tests/sonar/sonar-token-flow.test.js
+++ b/tests/sonar/sonar-token-flow.test.js
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { enableSonarStageForSuite } from "../_fixtures/sonar-stage.js";
 
 // --- Mocks for preflight-checks ---
 
@@ -39,11 +40,9 @@ describe("[opt-in: sonar] sonar token resolution — preflight", () => {
   let logger, emitter, eventBase;
   // Sonar preflight tests opt out of the global __KJ_DISABLE_SONAR_STAGE
   // (set in tests/setup.js so non-sonar tests don't hit Docker).
-  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
-  afterEach(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
+  enableSonarStageForSuite();
 
   beforeEach(async () => {
-    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
     delete process.env.KJ_SONAR_TOKEN;
     delete process.env.SONAR_TOKEN;

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -1,6 +1,7 @@
-import { afterAll, describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { REVIEW_OK, REVIEW_REJECTED, makeConfig as makeBaseConfig, noopLogger } from "./fixtures/orchestrator-mocks.js";
+import { enableSonarStageForSuite } from "./_fixtures/sonar-stage.js";
 
 function makeConfig(sessionOverrides = {}) {
   return makeBaseConfig({
@@ -146,11 +147,9 @@ describe("configurable sub-loop limits", () => {
   let runFlow;
   // Sonar sub-loop tests genuinely exercise the sonar stage. Opt out of
   // the global test override (tests/setup.js disables it by default).
-  const prevSonarDisabled = globalThis.__KJ_DISABLE_SONAR_STAGE;
-  afterAll(() => { globalThis.__KJ_DISABLE_SONAR_STAGE = prevSonarDisabled; });
+  enableSonarStageForSuite();
 
   beforeEach(async () => {
-    globalThis.__KJ_DISABLE_SONAR_STAGE = false;
     vi.resetAllMocks();
 
     const { createAgent } = await import("../src/agents/index.js");


### PR DESCRIPTION
## Summary

Five test files (`runflow-repeat-detection`, `sonar/sonar-token-flow`, `subloop-limits`, `preflight-checks`, `cli/kj-run-smoke`) each declared the same save/restore dance around `globalThis.__KJ_DISABLE_SONAR_STAGE` to opt out of the global default set in `tests/setup.js`.

Extracted to a single `enableSonarStageForSuite()` helper in `tests/_fixtures/sonar-stage.js`, which registers a `beforeEach` (flag off) and an `afterAll` (restore previous value). Continues the dedupe work of PRs #974–#979 for KJC-TSK-0502.

## Stats
- 6 files changed, +43 / -24, net **+19 LOC** (well under 200 budget)
- New fixture: 29 lines (+ JSDoc)
- 25/25 affected tests green locally

## Test plan
- [x] `npx vitest run tests/runflow-repeat-detection.test.js tests/sonar/sonar-token-flow.test.js tests/subloop-limits.test.js tests/preflight-checks.test.js tests/cli/kj-run-smoke.test.js` — 25/25 pass
- [ ] CI green across Node 22.x / 24.x and Coverage v8