### PR TITLE
chore(integrations): squeezr detect+install utils (KJC-TSK-0504)

### DIFF
--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -16,6 +16,11 @@ const INSTALL_COMMANDS = {
     linux: "curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh && rtk init --global",
     windows: "Download from https://github.com/rtk-ai/rtk/releases and add to PATH"
   },
+  squeezr: {
+    macos: "npm install -g squeezr-ai",
+    linux: "npm install -g squeezr-ai",
+    windows: "npm install -g squeezr-ai"
+  },
   claude: {
     macos: "npm install -g @anthropic-ai/claude-code",
     linux: "npm install -g @anthropic-ai/claude-code",

--- a/src/utils/squeezr-detect.js
+++ b/src/utils/squeezr-detect.js
@@ -1,0 +1,18 @@
+import { runCommand } from "./process.js";
+
+/**
+ * Detect whether Squeezr is installed and available.
+ * @returns {Promise<{ available: boolean, version: string|null }>}
+ */
+export async function detectSqueezr() {
+  try {
+    const result = await runCommand("squeezr", ["--version"]);
+    if (result.exitCode === 0) {
+      const version = (result.stdout || "").trim() || null;
+      return { available: true, version };
+    }
+    return { available: false, version: null };
+  } catch { /* squeezr binary not found */
+    return { available: false, version: null };
+  }
+}

--- a/src/utils/squeezr-install.js
+++ b/src/utils/squeezr-install.js
@@ -1,0 +1,37 @@
+import { runCommand } from "./process.js";
+import { getInstallCommand } from "./os-detect.js";
+import { detectSqueezr } from "./squeezr-detect.js";
+
+/**
+ * Install Squeezr using the OS-appropriate command.
+ * @param {object} logger - Logger with info/warn methods
+ * @returns {Promise<{ ok: boolean, version: string|null, error: string|null }>}
+ */
+export async function installSqueezr(logger) {
+  const command = getInstallCommand("squeezr");
+
+  logger.info("Installing Squeezr...");
+
+  try {
+    const result = await runCommand("sh", ["-c", command], { timeout: 120_000 });
+
+    if (result.exitCode !== 0) {
+      const error = (result.stderr || "").trim() || `exit code ${result.exitCode}`;
+      logger.warn(`Squeezr install failed: ${error}`);
+      return { ok: false, version: null, error };
+    }
+
+    const check = await detectSqueezr();
+    if (check.available) {
+      logger.info(`Squeezr ${check.version || ""} installed successfully.`);
+      return { ok: true, version: check.version, error: null };
+    }
+
+    logger.warn("Squeezr install command succeeded but squeezr binary not found in PATH.");
+    return { ok: false, version: null, error: "Binary not found after install" };
+  } catch (err) {
+    const error = err.message || String(err);
+    logger.warn(`Squeezr install failed: ${error}`);
+    return { ok: false, version: null, error };
+  }
+}

--- a/tests/squeezr-detect.test.js
+++ b/tests/squeezr-detect.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+import { detectSqueezr } from "../src/utils/squeezr-detect.js";
+import { runCommand } from "../src/utils/process.js";
+
+describe("detectSqueezr", () => {
+  it("returns available:true when squeezr --version succeeds", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "squeezr 1.46.3" });
+
+    const result = await detectSqueezr();
+
+    expect(result).toEqual({ available: true, version: "squeezr 1.46.3" });
+    expect(runCommand).toHaveBeenCalledWith("squeezr", ["--version"]);
+  });
+
+  it("returns available:false when squeezr --version fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "" });
+
+    const result = await detectSqueezr();
+
+    expect(result).toEqual({ available: false, version: null });
+  });
+
+  it("returns available:false when runCommand throws", async () => {
+    runCommand.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await detectSqueezr();
+
+    expect(result).toEqual({ available: false, version: null });
+  });
+
+  it("handles empty stdout gracefully", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "" });
+
+    const result = await detectSqueezr();
+
+    expect(result).toEqual({ available: true, version: null });
+  });
+});

--- a/tests/squeezr-install.test.js
+++ b/tests/squeezr-install.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/utils/os-detect.js", () => ({
+  getInstallCommand: vi.fn().mockReturnValue("npm install -g squeezr-ai"),
+  getPlatform: vi.fn().mockReturnValue("linux")
+}));
+
+vi.mock("../src/utils/squeezr-detect.js", () => ({
+  detectSqueezr: vi.fn()
+}));
+
+import { installSqueezr } from "../src/utils/squeezr-install.js";
+import { runCommand } from "../src/utils/process.js";
+import { getInstallCommand } from "../src/utils/os-detect.js";
+import { detectSqueezr } from "../src/utils/squeezr-detect.js";
+
+describe("installSqueezr", () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getInstallCommand.mockReturnValue("npm install -g squeezr-ai");
+  });
+
+  it("installs Squeezr and returns ok:true with version on success", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    detectSqueezr.mockResolvedValue({ available: true, version: "squeezr 1.46.3" });
+
+    const result = await installSqueezr(logger);
+
+    expect(result).toEqual({ ok: true, version: "squeezr 1.46.3", error: null });
+    expect(runCommand).toHaveBeenCalledWith("sh", ["-c", "npm install -g squeezr-ai"], { timeout: 120_000 });
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Installing Squeezr"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("installed successfully"));
+  });
+
+  it("returns ok:false with error when install command fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "permission denied" });
+
+    const result = await installSqueezr(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "permission denied" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Squeezr install failed"));
+    expect(detectSqueezr).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false when install succeeds but binary not in PATH", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    detectSqueezr.mockResolvedValue({ available: false, version: null });
+
+    const result = await installSqueezr(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "Binary not found after install" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("not found in PATH"));
+  });
+
+  it("returns ok:false without throwing when runCommand throws", async () => {
+    runCommand.mockRejectedValue(new Error("ENOENT: sh not found"));
+
+    const result = await installSqueezr(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "ENOENT: sh not found" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Squeezr install failed"));
+  });
+});


### PR DESCRIPTION
## Summary

- Mirror RTK detect/install pair for Squeezr (`squeezr-ai` on npm) so the rest of the pipeline can treat it as a first-class integration.
- No wiring into `kj init` or `kj doctor` in this PR — that follows in a separate atomic PR to keep this one under the LOC budget.
- 177 LOC net (well under the 200 cap), 8 new unit tests, all green.

Card: KJC-TSK-0504 (epic KJC-PCS-0018 — Token-savings integrations)

## Test plan

- [x] `npx vitest run tests/squeezr-detect.test.js tests/squeezr-install.test.js` → 8/8 passing locally
- [ ] CI green