### PR TITLE
chore(integrations): wire squeezr into kj init + doctor (KJC-TSK-0504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pip install .
 
 Both options expect the `kj` binary to be on your `PATH` (via one of the methods above) — the Python wrapper does not vendor it.
 
-That's it. `kj init` auto-detects your installed agents and installs RTK for token optimization.
+That's it. `kj init` auto-detects your installed agents and installs the bundled integrations (RTK + Squeezr) for token optimization.
 
 ### Optional scanners for `kj audit` + `kj webperf`
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ None of these are required. Karajan runs fine on its own. They're tools that, wh
 | Tool | Invoked by | Why |
 |------|-----------|-----|
 | [**RTK**](https://github.com/rtk-ai/rtk) | Karajan (auto, on Bash outputs) | Reduces token consumption by 60-90% on Bash command outputs |
+| [**Squeezr**](https://www.npmjs.com/package/squeezr-ai) | Karajan (auto, on agent tool outputs) | Compresses verbose tool results before they reach the agent context |
 | [**QMD**](https://github.com/manufosela/qmd) | You (CLI / MCP), complementary to RAG | Semantic search engine over Markdown corpora — works alongside `kj rag query` when you want a richer index over your own docs |
 | [**GitHub MCP**](https://github.com/github/github-mcp-server) | Your AI agent (via MCP) | Create PRs, manage issues directly from the agent |
 | [**Chrome DevTools MCP**](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Your AI agent (via MCP) | Verify UI changes visually after frontend modifications |

--- a/README.md
+++ b/README.md
@@ -366,14 +366,21 @@ Karajan auto-detects and auto-configures everything it can:
 
 No per-project configuration required. If you want to customize, config is layered: session > project > global.
 
+## Bundled integrations
+
+These ship with Karajan and `kj init` installs them as part of setup. They're token-efficiency layers the pipeline depends on — not nice-to-haves.
+
+| Tool | Invoked by | Why |
+|------|-----------|-----|
+| [**RTK**](https://github.com/rtk-ai/rtk) | Karajan (auto, on Bash outputs) | Reduces token consumption by 60-90% on Bash command outputs |
+| [**Squeezr**](https://www.npmjs.com/package/squeezr-ai) | Karajan (auto, on agent tool outputs) | Compresses verbose tool results before they reach the agent context |
+
 ## Recommended companions
 
 None of these are required. Karajan runs fine on its own. They're tools that, when present, Karajan can take advantage of — or that help *you* work better around Karajan.
 
 | Tool | Invoked by | Why |
 |------|-----------|-----|
-| [**RTK**](https://github.com/rtk-ai/rtk) | Karajan (auto, on Bash outputs) | Reduces token consumption by 60-90% on Bash command outputs |
-| [**Squeezr**](https://www.npmjs.com/package/squeezr-ai) | Karajan (auto, on agent tool outputs) | Compresses verbose tool results before they reach the agent context |
 | [**QMD**](https://github.com/manufosela/qmd) | You (CLI / MCP), complementary to RAG | Semantic search engine over Markdown corpora — works alongside `kj rag query` when you want a richer index over your own docs |
 | [**GitHub MCP**](https://github.com/github/github-mcp-server) | Your AI agent (via MCP) | Create PRs, manage issues directly from the agent |
 | [**Chrome DevTools MCP**](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Your AI agent (via MCP) | Verify UI changes visually after frontend modifications |

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -6,7 +6,7 @@
 - Git
 - At least one AI CLI installed: `claude`, `codex`, `gemini`, `aider`, or `opencode`
 - (Optional) Docker for local SonarQube
-- (Optional) RTK for token savings: `cargo install rtk`
+- RTK + Squeezr (token efficiency) — `kj init` installs both automatically. Opt out with `--no-rtk` / `--no-squeezr` if you don't want them.
 
 ### Optional scanners — `kj audit` + `kj webperf`
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -6,7 +6,7 @@
 - Git
 - Al menos una CLI de IA instalada: `claude`, `codex`, `gemini`, `aider` u `opencode`
 - (Opcional) Docker para SonarQube local
-- (Opcional) RTK para ahorro de tokens: `cargo install rtk`
+- RTK + Squeezr (eficiencia de tokens) — `kj init` los instala automáticamente. Para no usarlos, `--no-rtk` / `--no-squeezr`.
 
 ### Scanners opcionales — `kj audit` + `kj webperf`
 

--- a/src/checks/squeezr.js
+++ b/src/checks/squeezr.js
@@ -1,0 +1,36 @@
+/**
+ * Squeezr availability check. Manual strategy — installation
+ * depends on the host platform and is handled by getInstallCommand().
+ */
+
+import { runCommand } from "../utils/process.js";
+import { getInstallCommand } from "../utils/os-detect.js";
+import { withDocLink } from "../utils/doc-links.js";
+import { STRATEGY } from "./types.js";
+
+function createSqueezrCheck() {
+  return {
+    name: "squeezr",
+    label: "Squeezr",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      try {
+        const res = await runCommand("squeezr", ["--version"]);
+        if (res.exitCode === 0) {
+          return { ok: true, severity: "info", detail: `${res.stdout.trim()} — context compression active` };
+        }
+      } catch { /* not installed */ }
+      const installCmd = getInstallCommand("squeezr");
+      return {
+        ok: false,
+        severity: "warn",
+        detail: "Not found — context compression via Squeezr available",
+        fix: withDocLink(`Install: ${installCmd}`, "squeezr_install"),
+      };
+    },
+  };
+}
+
+export function getSqueezrChecks() {
+  return [createSqueezrCheck()];
+}

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -27,6 +27,8 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--global", "Save config to ~/.karajan/kj.config.yml (skip the scope wizard)")
     .option("--local", "Save config to ./.karajan/kj.config.yml (skip the scope wizard)")
     .option("--no-ollama", "Skip the RAG embedder bootstrap (Ollama-in-Docker). Useful on modest hardware or when an external embedder will be wired manually")
+    .option("--no-rtk", "Skip the RTK auto-install (token savings on Bash outputs). Karajan still runs but burns more tokens")
+    .option("--no-squeezr", "Skip the Squeezr auto-install (context compression). Karajan still runs but burns more tokens")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -22,6 +22,7 @@ import { getOllamaChecks } from "../checks/ollama.js";
 import { getHarnessScorecardChecks } from "../checks/harness-scorecard.js";
 import { getCiChecks } from "../checks/ci.js";
 import { getRtkChecks } from "../checks/rtk.js";
+import { getSqueezrChecks } from "../checks/squeezr.js";
 import { getNodeChecks } from "../checks/node.js";
 import { getPortChecks } from "../checks/ports.js";
 import { getTokenChecks } from "../checks/tokens.js";
@@ -64,6 +65,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getSkillsChecks(),
     ...getCiChecks(),
     ...getRtkChecks(),
+    ...getSqueezrChecks(),
     ...getProjectChecks({ projectDir }),
   ];
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -775,7 +775,7 @@ export async function initCommand({ logger, flags = {} }) {
   } else {
     const installResult = await installSqueezr(logger);
     if (!installResult.ok) {
-      logger.warn("Squeezr is optional but recommended for context compression.");
+      logger.warn("Squeezr is required for context compression — install before running kj.");
       logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
     }
   }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -756,27 +756,37 @@ export async function initCommand({ logger, flags = {} }) {
     logger.info("No project stack detected — using default configuration.");
   }
 
-  // Check RTK availability — auto-install if missing
-  const rtk = await detectRtk();
-  if (rtk.available) {
-    logger.info(`RTK ${rtk.version || ""} detected.`);
+  // Check RTK availability — auto-install if missing (opt-out: --no-rtk)
+  const skipRtk = flags?.noRtk === true || flags?.rtk === false;
+  if (skipRtk) {
+    logger.info("RTK setup skipped (--no-rtk). Bash outputs will not be token-optimized.");
   } else {
-    const installResult = await installRtk(logger);
-    if (!installResult.ok) {
-      logger.warn("RTK is optional but recommended for 60-90% token savings.");
-      logger.warn(`  Manual install: ${getInstallCommand("rtk")}`);
+    const rtk = await detectRtk();
+    if (rtk.available) {
+      logger.info(`RTK ${rtk.version || ""} detected.`);
+    } else {
+      const installResult = await installRtk(logger);
+      if (!installResult.ok) {
+        logger.warn("RTK install failed — Bash outputs will not be token-optimized.");
+        logger.warn(`  Manual install: ${getInstallCommand("rtk")}`);
+      }
     }
   }
 
-  // Check Squeezr availability — auto-install if missing
-  const squeezr = await detectSqueezr();
-  if (squeezr.available) {
-    logger.info(`Squeezr ${squeezr.version || ""} detected.`);
+  // Check Squeezr availability — auto-install if missing (opt-out: --no-squeezr)
+  const skipSqueezr = flags?.noSqueezr === true || flags?.squeezr === false;
+  if (skipSqueezr) {
+    logger.info("Squeezr setup skipped (--no-squeezr). Tool outputs will not be compressed.");
   } else {
-    const installResult = await installSqueezr(logger);
-    if (!installResult.ok) {
-      logger.warn("Squeezr is required for context compression — install before running kj.");
-      logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
+    const squeezr = await detectSqueezr();
+    if (squeezr.available) {
+      logger.info(`Squeezr ${squeezr.version || ""} detected.`);
+    } else {
+      const installResult = await installSqueezr(logger);
+      if (!installResult.ok) {
+        logger.warn("Squeezr install failed — tool outputs will not be compressed.");
+        logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
+      }
     }
   }
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -15,6 +15,8 @@ import { detectOsLocale, SUPPORTED_LANGUAGES } from "../utils/locale.js";
 import { buildTelemetryPayload, sendTelemetryEvent } from "../utils/telemetry.js";
 import { detectRtk } from "../utils/rtk-detect.js";
 import { installRtk } from "../utils/rtk-install.js";
+import { detectSqueezr } from "../utils/squeezr-detect.js";
+import { installSqueezr } from "../utils/squeezr-install.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { bootstrapSonarToken } from "../sonar/token-bootstrap.js";
 
@@ -763,6 +765,18 @@ export async function initCommand({ logger, flags = {} }) {
     if (!installResult.ok) {
       logger.warn("RTK is optional but recommended for 60-90% token savings.");
       logger.warn(`  Manual install: ${getInstallCommand("rtk")}`);
+    }
+  }
+
+  // Check Squeezr availability — auto-install if missing
+  const squeezr = await detectSqueezr();
+  if (squeezr.available) {
+    logger.info(`Squeezr ${squeezr.version || ""} detected.`);
+  } else {
+    const installResult = await installSqueezr(logger);
+    if (!installResult.ok) {
+      logger.warn("Squeezr is optional but recommended for context compression.");
+      logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
     }
   }
 

--- a/src/utils/doc-links.js
+++ b/src/utils/doc-links.js
@@ -15,6 +15,7 @@ const ERROR_DOCS = {
   config_missing: `${BASE_URL}/getting-started/quick-start/`,
   branch_error: `${BASE_URL}/guides/pipeline/#git-workflow`,
   rtk_install: `${BASE_URL}/guides/configuration/#rtk`,
+  squeezr_install: `${BASE_URL}/guides/configuration/#squeezr`,
 };
 
 export function docLink(errorType) {

--- a/tests/doctor-squeezr.test.js
+++ b/tests/doctor-squeezr.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/bin/${name}`)
+}));
+
+vi.mock("../src/utils/fs.js", () => ({
+  exists: vi.fn(),
+  ensureDir: vi.fn()
+}));
+
+vi.mock("../src/config.js", () => ({
+  getConfigPath: vi.fn().mockReturnValue("/home/user/.karajan/kj.config.yml"),
+  loadConfig: vi.fn(),
+  applyRunOverrides: vi.fn(),
+  validateConfig: vi.fn(),
+  resolveRole: vi.fn()
+}));
+
+vi.mock("../src/sonar/manager.js", () => ({
+  isSonarReachable: vi.fn()
+}));
+
+vi.mock("../src/roles/base-role.js", () => ({
+  resolveRoleMdPath: vi.fn().mockReturnValue(["/fake/reviewer.md"]),
+  loadFirstExisting: vi.fn()
+}));
+
+vi.mock("../src/utils/git.js", () => ({
+  ensureGitRepo: vi.fn()
+}));
+
+const baseConfig = {
+  review_mode: "standard",
+  sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" }
+};
+
+describe("doctor Squeezr check", () => {
+  let runChecks;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { runCommand } = await import("../src/utils/process.js");
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+
+    const { exists } = await import("../src/utils/fs.js");
+    exists.mockResolvedValue(true);
+
+    const { isSonarReachable } = await import("../src/sonar/manager.js");
+    isSonarReachable.mockResolvedValue(true);
+
+    const { ensureGitRepo } = await import("../src/utils/git.js");
+    ensureGitRepo.mockResolvedValue(true);
+
+    const { loadFirstExisting } = await import("../src/roles/base-role.js");
+    loadFirstExisting.mockResolvedValue("rules content");
+
+    const mod = await import("../src/commands/doctor.js");
+    runChecks = mod.runChecks;
+  });
+
+  it("reports Squeezr version when squeezr is found", async () => {
+    const { runCommand } = await import("../src/utils/process.js");
+    runCommand.mockImplementation((cmd) => {
+      if (cmd.includes("squeezr")) {
+        return Promise.resolve({ exitCode: 0, stdout: "squeezr 1.46.3\n", stderr: "" });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+    });
+
+    const checks = await runChecks({ config: baseConfig });
+    const squeezrCheck = checks.find((c) => c.name === "squeezr");
+
+    expect(squeezrCheck).toBeDefined();
+    expect(squeezrCheck.ok).toBe(true);
+    expect(squeezrCheck.detail).toContain("squeezr 1.46.3");
+    expect(squeezrCheck.detail).toContain("context compression active");
+    expect(squeezrCheck.fix).toBeNull();
+  });
+
+  it("reports MISS with install command when squeezr is not found", async () => {
+    const { runCommand } = await import("../src/utils/process.js");
+    runCommand.mockImplementation((cmd) => {
+      if (cmd.includes("squeezr")) {
+        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "not found" });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+    });
+
+    const checks = await runChecks({ config: baseConfig });
+    const squeezrCheck = checks.find((c) => c.name === "squeezr");
+
+    expect(squeezrCheck).toBeDefined();
+    expect(squeezrCheck.ok).toBe(false);
+    expect(squeezrCheck.detail).toContain("Not found");
+    expect(squeezrCheck.detail).toContain("context compression");
+    expect(squeezrCheck.fix).toContain("Install:");
+  });
+
+  it("reports MISS with install command when squeezr command throws", async () => {
+    const { runCommand } = await import("../src/utils/process.js");
+    runCommand.mockImplementation((cmd) => {
+      if (cmd.includes("squeezr")) {
+        return Promise.reject(new Error("command not found"));
+      }
+      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
+    });
+
+    const checks = await runChecks({ config: baseConfig });
+    const squeezrCheck = checks.find((c) => c.name === "squeezr");
+
+    expect(squeezrCheck).toBeDefined();
+    expect(squeezrCheck.ok).toBe(false);
+    expect(squeezrCheck.detail).toContain("Not found");
+    expect(squeezrCheck.fix).toContain("Install:");
+  });
+});

--- a/tests/doctor-squeezr.test.js
+++ b/tests/doctor-squeezr.test.js
@@ -1,123 +1,35 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-vi.mock("../src/utils/process.js", () => ({
-  runCommand: vi.fn()
-}));
-
-vi.mock("../src/agents/resolve-bin.js", () => ({
-  resolveBin: vi.fn((name) => `/usr/bin/${name}`)
-}));
-
-vi.mock("../src/utils/fs.js", () => ({
-  exists: vi.fn(),
-  ensureDir: vi.fn()
-}));
-
-vi.mock("../src/config.js", () => ({
-  getConfigPath: vi.fn().mockReturnValue("/home/user/.karajan/kj.config.yml"),
-  loadConfig: vi.fn(),
-  applyRunOverrides: vi.fn(),
-  validateConfig: vi.fn(),
-  resolveRole: vi.fn()
-}));
-
-vi.mock("../src/sonar/manager.js", () => ({
-  isSonarReachable: vi.fn()
-}));
-
-vi.mock("../src/roles/base-role.js", () => ({
-  resolveRoleMdPath: vi.fn().mockReturnValue(["/fake/reviewer.md"]),
-  loadFirstExisting: vi.fn()
-}));
-
-vi.mock("../src/utils/git.js", () => ({
-  ensureGitRepo: vi.fn()
-}));
-
-const baseConfig = {
-  review_mode: "standard",
-  sonarqube: { enabled: true, host: "http://localhost:9000", enforcement_profile: "pragmatic" }
-};
+vi.mock("../src/utils/process.js", () => ({ runCommand: vi.fn() }));
 
 describe("doctor Squeezr check", () => {
-  let runChecks;
+  let getSqueezrChecks, runCommand;
 
   beforeEach(async () => {
     vi.resetAllMocks();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const { runCommand } = await import("../src/utils/process.js");
-    runCommand.mockResolvedValue({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
-
-    const { exists } = await import("../src/utils/fs.js");
-    exists.mockResolvedValue(true);
-
-    const { isSonarReachable } = await import("../src/sonar/manager.js");
-    isSonarReachable.mockResolvedValue(true);
-
-    const { ensureGitRepo } = await import("../src/utils/git.js");
-    ensureGitRepo.mockResolvedValue(true);
-
-    const { loadFirstExisting } = await import("../src/roles/base-role.js");
-    loadFirstExisting.mockResolvedValue("rules content");
-
-    const mod = await import("../src/commands/doctor.js");
-    runChecks = mod.runChecks;
+    ({ runCommand } = await import("../src/utils/process.js"));
+    ({ getSqueezrChecks } = await import("../src/checks/squeezr.js"));
   });
 
-  it("reports Squeezr version when squeezr is found", async () => {
-    const { runCommand } = await import("../src/utils/process.js");
-    runCommand.mockImplementation((cmd) => {
-      if (cmd.includes("squeezr")) {
-        return Promise.resolve({ exitCode: 0, stdout: "squeezr 1.46.3\n", stderr: "" });
-      }
-      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
-    });
-
-    const checks = await runChecks({ config: baseConfig });
-    const squeezrCheck = checks.find((c) => c.name === "squeezr");
-
-    expect(squeezrCheck).toBeDefined();
-    expect(squeezrCheck.ok).toBe(true);
-    expect(squeezrCheck.detail).toContain("squeezr 1.46.3");
-    expect(squeezrCheck.detail).toContain("context compression active");
-    expect(squeezrCheck.fix).toBeNull();
+  it("reports OK with version when squeezr is found", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "squeezr 1.46.3\n", stderr: "" });
+    const [check] = getSqueezrChecks();
+    const result = await check.detect();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("squeezr 1.46.3");
+    expect(result.detail).toContain("context compression active");
   });
 
-  it("reports MISS with install command when squeezr is not found", async () => {
-    const { runCommand } = await import("../src/utils/process.js");
-    runCommand.mockImplementation((cmd) => {
-      if (cmd.includes("squeezr")) {
-        return Promise.resolve({ exitCode: 1, stdout: "", stderr: "not found" });
-      }
-      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
-    });
-
-    const checks = await runChecks({ config: baseConfig });
-    const squeezrCheck = checks.find((c) => c.name === "squeezr");
-
-    expect(squeezrCheck).toBeDefined();
-    expect(squeezrCheck.ok).toBe(false);
-    expect(squeezrCheck.detail).toContain("Not found");
-    expect(squeezrCheck.detail).toContain("context compression");
-    expect(squeezrCheck.fix).toContain("Install:");
-  });
-
-  it("reports MISS with install command when squeezr command throws", async () => {
-    const { runCommand } = await import("../src/utils/process.js");
-    runCommand.mockImplementation((cmd) => {
-      if (cmd.includes("squeezr")) {
-        return Promise.reject(new Error("command not found"));
-      }
-      return Promise.resolve({ exitCode: 0, stdout: "v1.0.0\n", stderr: "" });
-    });
-
-    const checks = await runChecks({ config: baseConfig });
-    const squeezrCheck = checks.find((c) => c.name === "squeezr");
-
-    expect(squeezrCheck).toBeDefined();
-    expect(squeezrCheck.ok).toBe(false);
-    expect(squeezrCheck.detail).toContain("Not found");
-    expect(squeezrCheck.fix).toContain("Install:");
+  it.each([
+    ["non-zero exit", { exitCode: 1, stdout: "", stderr: "not found" }, null],
+    ["throws", null, new Error("command not found")],
+  ])("reports MISS with install command when squeezr %s", async (_label, resolveValue, rejectError) => {
+    if (rejectError) runCommand.mockRejectedValue(rejectError);
+    else runCommand.mockResolvedValue(resolveValue);
+    const [check] = getSqueezrChecks();
+    const result = await check.detect();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("Not found");
+    expect(result.fix).toContain("Install:");
   });
 });

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -65,6 +65,14 @@ vi.mock("../src/utils/rtk-install.js", () => ({
   installRtk: vi.fn().mockResolvedValue({ ok: true, version: "rtk 0.31.0", error: null })
 }));
 
+vi.mock("../src/utils/squeezr-detect.js", () => ({
+  detectSqueezr: vi.fn().mockResolvedValue({ available: true, version: "squeezr 1.46.3" })
+}));
+
+vi.mock("../src/utils/squeezr-install.js", () => ({
+  installSqueezr: vi.fn().mockResolvedValue({ ok: true, version: "squeezr 1.46.3", error: null })
+}));
+
 describe("initCommand", () => {
   let initCommand;
   let loadConfig, writeConfig;
@@ -87,6 +95,12 @@ describe("initCommand", () => {
     detectRtk.mockResolvedValue({ available: true, version: "rtk 0.31.0" });
     const { installRtk } = await import("../src/utils/rtk-install.js");
     installRtk.mockResolvedValue({ ok: true, version: "rtk 0.31.0", error: null });
+
+    // Re-set Squeezr mocks after resetAllMocks clears them
+    const { detectSqueezr } = await import("../src/utils/squeezr-detect.js");
+    detectSqueezr.mockResolvedValue({ available: true, version: "squeezr 1.46.3" });
+    const { installSqueezr } = await import("../src/utils/squeezr-install.js");
+    installSqueezr.mockResolvedValue({ ok: true, version: "squeezr 1.46.3", error: null });
   });
 
   it("runs non-interactive mode when --no-interactive is set", async () => {

--- a/tests/os-detect.test.js
+++ b/tests/os-detect.test.js
@@ -65,6 +65,15 @@ describe("os-detect", () => {
       expect(cmd).toBe("npm install -g @anthropic-ai/claude-code");
     });
 
+    it("returns correct squeezr command on every platform", async () => {
+      for (const platform of ["linux", "darwin", "win32"]) {
+        vi.resetModules();
+        os.platform.mockReturnValue(platform);
+        ({ getInstallCommand } = await import("../src/utils/os-detect.js"));
+        expect(getInstallCommand("squeezr")).toBe("npm install -g squeezr-ai");
+      }
+    });
+
     it("returns correct codex command", () => {
       const cmd = getInstallCommand("codex");
       expect(cmd).toBe("npm install -g @openai/codex");


### PR DESCRIPTION
## Summary

- Add Squeezr to the auto-installed integrations list alongside RTK.
- New `src/checks/squeezr.js` mirrors the RTK check (manual strategy, `squeezr --version` probe).
- `kj init` auto-installs Squeezr via `getInstallCommand("squeezr")` if missing — same UX as RTK.
- `kj doctor` surfaces the check in the global list.
- README integrations table grows one row.

Follow-up of #982 (which shipped detect+install utils + os-detect mapping). Both PRs together close KJC-TSK-0504.

## Test plan

- [x] `npx vitest run tests/doctor-squeezr.test.js tests/squeezr-detect.test.js tests/squeezr-install.test.js` — 11/11 green
- [ ] CI passes (Conventional Commits, Coverage v8, Prettier, GitGuardian, ESLint, LOC budget, prompt injection, syntax/test on Node 22 + 24)