### PR TITLE
chore(integrations): qmd doctor check + install hint (KJC-TSK-0505)

### DIFF
--- a/src/checks/qmd.js
+++ b/src/checks/qmd.js
@@ -1,0 +1,41 @@
+/**
+ * QMD availability check. Manual strategy — installation
+ * depends on the host platform and is handled by getInstallCommand().
+ *
+ * QMD (Quick Markdown Search) provides semantic search over the
+ * user's wiki / docs / notes collections. Karajan ships it as a
+ * default integration (mirror of Squeezr): kj init installs it,
+ * kj doctor reports its presence.
+ */
+
+import { runCommand } from "../utils/process.js";
+import { getInstallCommand } from "../utils/os-detect.js";
+import { withDocLink } from "../utils/doc-links.js";
+import { STRATEGY } from "./types.js";
+
+function createQmdCheck() {
+  return {
+    name: "qmd",
+    label: "QMD",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      try {
+        const res = await runCommand("qmd", ["--version"]);
+        if (res.exitCode === 0) {
+          return { ok: true, severity: "info", detail: `${res.stdout.trim()} — semantic wiki active` };
+        }
+      } catch { /* not installed */ }
+      const installCmd = getInstallCommand("qmd");
+      return {
+        ok: false,
+        severity: "warn",
+        detail: "Not found — semantic wiki via QMD available",
+        fix: withDocLink(`Install: ${installCmd}`, "qmd_install"),
+      };
+    },
+  };
+}
+
+export function getQmdChecks() {
+  return [createQmdCheck()];
+}

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -23,6 +23,7 @@ import { getHarnessScorecardChecks } from "../checks/harness-scorecard.js";
 import { getCiChecks } from "../checks/ci.js";
 import { getRtkChecks } from "../checks/rtk.js";
 import { getSqueezrChecks } from "../checks/squeezr.js";
+import { getQmdChecks } from "../checks/qmd.js";
 import { getNodeChecks } from "../checks/node.js";
 import { getPortChecks } from "../checks/ports.js";
 import { getTokenChecks } from "../checks/tokens.js";
@@ -66,6 +67,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getCiChecks(),
     ...getRtkChecks(),
     ...getSqueezrChecks(),
+    ...getQmdChecks(),
     ...getProjectChecks({ projectDir }),
   ];
 }

--- a/src/utils/doc-links.js
+++ b/src/utils/doc-links.js
@@ -16,6 +16,7 @@ const ERROR_DOCS = {
   branch_error: `${BASE_URL}/guides/pipeline/#git-workflow`,
   rtk_install: `${BASE_URL}/guides/configuration/#rtk`,
   squeezr_install: `${BASE_URL}/guides/configuration/#squeezr`,
+  qmd_install: `${BASE_URL}/guides/configuration/#qmd`,
 };
 
 export function docLink(errorType) {

--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -21,6 +21,11 @@ const INSTALL_COMMANDS = {
     linux: "npm install -g squeezr-ai",
     windows: "npm install -g squeezr-ai"
   },
+  qmd: {
+    macos: "npm install -g @tobilu/qmd",
+    linux: "npm install -g @tobilu/qmd",
+    windows: "npm install -g @tobilu/qmd"
+  },
   claude: {
     macos: "npm install -g @anthropic-ai/claude-code",
     linux: "npm install -g @anthropic-ai/claude-code",

--- a/tests/doctor-qmd.test.js
+++ b/tests/doctor-qmd.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+
+describe("doctor QMD check", () => {
+  let getQmdChecks, runCommand;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ runCommand } = await import("../src/utils/process.js"));
+    ({ getQmdChecks } = await import("../src/checks/qmd.js"));
+  });
+
+  it("reports OK with version when qmd is found", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "qmd 2.5.3\n", stderr: "" });
+    const [check] = getQmdChecks();
+    const result = await check.detect();
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("qmd 2.5.3");
+    expect(result.detail).toContain("semantic wiki active");
+  });
+
+  it.each([
+    ["non-zero exit", { exitCode: 1, stdout: "", stderr: "not found" }, null],
+    ["throws", null, new Error("command not found")],
+  ])("reports MISS with install command when qmd %s", async (_label, resolveValue, rejectError) => {
+    if (rejectError) runCommand.mockRejectedValue(rejectError);
+    else runCommand.mockResolvedValue(resolveValue);
+    const [check] = getQmdChecks();
+    const result = await check.detect();
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("Not found");
+    expect(result.fix).toContain("Install:");
+  });
+});


### PR DESCRIPTION
## Summary

QMD (Quick Markdown Search) becomes a first-class default integration on the same tier as Squeezr and RTK:

- `kj doctor` reports QMD presence with detected version (OK) or install hint (MISS).
- New `src/checks/qmd.js` mirrors the Squeezr pattern.
- New tests in `tests/doctor-qmd.test.js` (3 cases, full mock).
- Install hint: `npm install -g @tobilu/qmd` (cross-platform).

Card 1 of 6 in the QMD epic (KJC-PCS-0054). Subsequent cards wire `kj init` install, post-merge reindex hook, HU Board panel, `kj qmd query` CLI wrapper and docs.

Recreated from PR #984 (closed) with commit body wrapped to commitlint's 100-char/line rule.

## Test plan
- [x] `npx vitest run tests/doctor-qmd.test.js` → 3/3 passing
- [x] `npx vitest run tests/doctor-squeezr.test.js` (regression) → 3/3 passing
- [ ] CI green on push