### PR TITLE
feat(qmd): detect + install utilities (KJC-TSK-0506)

### DIFF
--- a/src/utils/qmd-detect.js
+++ b/src/utils/qmd-detect.js
@@ -1,0 +1,18 @@
+import { runCommand } from "./process.js";
+
+/**
+ * Detect whether QMD is installed and available.
+ * @returns {Promise<{ available: boolean, version: string|null }>}
+ */
+export async function detectQmd() {
+  try {
+    const result = await runCommand("qmd", ["--version"]);
+    if (result.exitCode === 0) {
+      const version = (result.stdout || "").trim() || null;
+      return { available: true, version };
+    }
+    return { available: false, version: null };
+  } catch { /* qmd binary not found */
+    return { available: false, version: null };
+  }
+}

--- a/src/utils/qmd-install.js
+++ b/src/utils/qmd-install.js
@@ -1,0 +1,37 @@
+import { runCommand } from "./process.js";
+import { getInstallCommand } from "./os-detect.js";
+import { detectQmd } from "./qmd-detect.js";
+
+/**
+ * Install QMD using the OS-appropriate command.
+ * @param {object} logger - Logger with info/warn methods
+ * @returns {Promise<{ ok: boolean, version: string|null, error: string|null }>}
+ */
+export async function installQmd(logger) {
+  const command = getInstallCommand("qmd");
+
+  logger.info("Installing QMD...");
+
+  try {
+    const result = await runCommand("sh", ["-c", command], { timeout: 120_000 });
+
+    if (result.exitCode !== 0) {
+      const error = (result.stderr || "").trim() || `exit code ${result.exitCode}`;
+      logger.warn(`QMD install failed: ${error}`);
+      return { ok: false, version: null, error };
+    }
+
+    const check = await detectQmd();
+    if (check.available) {
+      logger.info(`QMD ${check.version || ""} installed successfully.`);
+      return { ok: true, version: check.version, error: null };
+    }
+
+    logger.warn("QMD install command succeeded but qmd binary not found in PATH.");
+    return { ok: false, version: null, error: "Binary not found after install" };
+  } catch (err) {
+    const error = err.message || String(err);
+    logger.warn(`QMD install failed: ${error}`);
+    return { ok: false, version: null, error };
+  }
+}

--- a/tests/qmd-detect.test.js
+++ b/tests/qmd-detect.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+import { detectQmd } from "../src/utils/qmd-detect.js";
+import { runCommand } from "../src/utils/process.js";
+
+describe("detectQmd", () => {
+  it("returns available:true when qmd --version succeeds", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "qmd 2.5.3" });
+
+    const result = await detectQmd();
+
+    expect(result).toEqual({ available: true, version: "qmd 2.5.3" });
+    expect(runCommand).toHaveBeenCalledWith("qmd", ["--version"]);
+  });
+
+  it("returns available:false when qmd --version fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "" });
+
+    const result = await detectQmd();
+
+    expect(result).toEqual({ available: false, version: null });
+  });
+
+  it("returns available:false when runCommand throws", async () => {
+    runCommand.mockRejectedValue(new Error("ENOENT"));
+
+    const result = await detectQmd();
+
+    expect(result).toEqual({ available: false, version: null });
+  });
+
+  it("handles empty stdout gracefully", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "" });
+
+    const result = await detectQmd();
+
+    expect(result).toEqual({ available: true, version: null });
+  });
+});

--- a/tests/qmd-install.test.js
+++ b/tests/qmd-install.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../src/utils/os-detect.js", () => ({
+  getInstallCommand: vi.fn().mockReturnValue("npm install -g @tobilu/qmd"),
+  getPlatform: vi.fn().mockReturnValue("linux")
+}));
+
+vi.mock("../src/utils/qmd-detect.js", () => ({
+  detectQmd: vi.fn()
+}));
+
+import { installQmd } from "../src/utils/qmd-install.js";
+import { runCommand } from "../src/utils/process.js";
+import { getInstallCommand } from "../src/utils/os-detect.js";
+import { detectQmd } from "../src/utils/qmd-detect.js";
+
+describe("installQmd", () => {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    getInstallCommand.mockReturnValue("npm install -g @tobilu/qmd");
+  });
+
+  it("installs QMD and returns ok:true with version on success", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    detectQmd.mockResolvedValue({ available: true, version: "qmd 2.5.3" });
+
+    const result = await installQmd(logger);
+
+    expect(result).toEqual({ ok: true, version: "qmd 2.5.3", error: null });
+    expect(runCommand).toHaveBeenCalledWith("sh", ["-c", "npm install -g @tobilu/qmd"], { timeout: 120_000 });
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("Installing QMD"));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("installed successfully"));
+  });
+
+  it("returns ok:false with error when install command fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "permission denied" });
+
+    const result = await installQmd(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "permission denied" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("QMD install failed"));
+    expect(detectQmd).not.toHaveBeenCalled();
+  });
+
+  it("returns ok:false when install succeeds but binary not in PATH", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    detectQmd.mockResolvedValue({ available: false, version: null });
+
+    const result = await installQmd(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "Binary not found after install" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("not found in PATH"));
+  });
+
+  it("returns ok:false without throwing when runCommand throws", async () => {
+    runCommand.mockRejectedValue(new Error("ENOENT: sh not found"));
+
+    const result = await installQmd(logger);
+
+    expect(result).toEqual({ ok: false, version: null, error: "ENOENT: sh not found" });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("QMD install failed"));
+  });
+});


### PR DESCRIPTION
## Summary

First slice of KJC-TSK-0506 (QMD per-project wiki integration). Adds two
small utilities that mirror the existing Squeezr / RTK pattern:

- \`src/utils/qmd-detect.js\` — \`detectQmd()\` probes \`qmd --version\`.
- \`src/utils/qmd-install.js\` — \`installQmd()\` runs the OS-appropriate
  install command and re-probes to confirm.

The next PR wires them into \`kj init\` together with the per-project
collection registration (docs/, .reviews/, .karajan/plans/) and the
\`--no-qmd\` opt-out flag.

## Why split

Combined with the collection logic + tests + init wiring the total delta
exceeded the 200 LOC shrink-budget, so QMD lands in two atomic PRs.

## Test plan

- [x] \`tests/qmd-detect.test.js\` (4 cases)
- [x] \`tests/qmd-install.test.js\` (4 cases)
- [x] No behavior change in \`kj init\` yet (utilities not wired)