### PR TITLE
feat(qmd): init wiring + per-project collections (KJC-TSK-0506)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -29,6 +29,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--no-ollama", "Skip the RAG embedder bootstrap (Ollama-in-Docker). Useful on modest hardware or when an external embedder will be wired manually")
     .option("--no-rtk", "Skip the RTK auto-install (token savings on Bash outputs). Karajan still runs but burns more tokens")
     .option("--no-squeezr", "Skip the Squeezr auto-install (context compression). Karajan still runs but burns more tokens")
+    .option("--no-qmd", "Skip the QMD auto-install + collection registration (semantic wiki over docs/, .reviews/ and plans/)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,6 +17,9 @@ import { detectRtk } from "../utils/rtk-detect.js";
 import { installRtk } from "../utils/rtk-install.js";
 import { detectSqueezr } from "../utils/squeezr-detect.js";
 import { installSqueezr } from "../utils/squeezr-install.js";
+import { detectQmd } from "../utils/qmd-detect.js";
+import { installQmd } from "../utils/qmd-install.js";
+import { registerQmdCollections } from "../utils/qmd-collection.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { bootstrapSonarToken } from "../sonar/token-bootstrap.js";
 
@@ -787,6 +790,28 @@ export async function initCommand({ logger, flags = {} }) {
         logger.warn("Squeezr install failed — tool outputs will not be compressed.");
         logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
       }
+    }
+  }
+
+  // Check QMD availability — auto-install if missing and register project
+  // collections (docs/, .reviews/, .karajan/plans/). Opt-out: --no-qmd.
+  const skipQmd = flags?.noQmd === true || flags?.qmd === false;
+  if (skipQmd) {
+    logger.info("QMD setup skipped (--no-qmd). Semantic wiki indexing disabled.");
+  } else {
+    const qmd = await detectQmd();
+    if (qmd.available) {
+      logger.info(`QMD ${qmd.version || ""} detected.`);
+    } else {
+      const installResult = await installQmd(logger);
+      if (!installResult.ok) {
+        logger.warn("QMD install failed — semantic wiki unavailable.");
+        logger.warn(`  Manual install: ${getInstallCommand("qmd")}`);
+      }
+    }
+    const recheck = await detectQmd();
+    if (recheck.available) {
+      await registerQmdCollections(process.cwd(), logger);
     }
   }
 

--- a/src/utils/qmd-collection.js
+++ b/src/utils/qmd-collection.js
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { existsSync, statSync } from "node:fs";
+import { runCommand } from "./process.js";
+
+export const QMD_DEFAULT_PATHS = ["docs", ".reviews", ".karajan/plans"];
+
+export function projectSlug(projectDir) {
+  const base = path.basename(path.resolve(projectDir));
+  return base.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "project";
+}
+
+export function planQmdCollections(projectDir) {
+  const slug = projectSlug(projectDir);
+  const result = [];
+  for (const rel of QMD_DEFAULT_PATHS) {
+    const abs = path.join(projectDir, rel);
+    if (!existsSync(abs)) continue;
+    try { if (!statSync(abs).isDirectory()) continue; } catch { continue; }
+    const suffix = rel.replace(/^\./, "").replace(/[/\\]+/g, "-");
+    result.push({ name: `${slug}-${suffix}`, path: abs });
+  }
+  return result;
+}
+
+async function listExistingCollections() {
+  try {
+    const res = await runCommand("qmd", ["collection", "list"]);
+    if (res.exitCode !== 0) return new Set();
+    const names = new Set();
+    for (const line of (res.stdout || "").split("\n")) {
+      const m = line.match(/^([\w.-]+)\s+\(qmd:\/\//);
+      if (m) names.add(m[1]);
+    }
+    return names;
+  } catch { return new Set(); }
+}
+
+/**
+ * Register all default QMD collections for the project. Idempotent: skips
+ * collections already present in `qmd collection list`. qmd's CLI only
+ * accepts one path per `collection add`, so we register up to 3 sibling
+ * collections (`<slug>-docs`, `<slug>-reviews`, `<slug>-karajan-plans`).
+ */
+export async function registerQmdCollections(projectDir, logger) {
+  const planned = planQmdCollections(projectDir);
+  const result = { ok: true, added: [], skipped: [], errors: [] };
+  if (planned.length === 0) {
+    logger.info("QMD: no indexable folders yet (docs/, .reviews/, .karajan/plans/ all missing).");
+    return result;
+  }
+  const existing = await listExistingCollections();
+  for (const { name, path: abs } of planned) {
+    if (existing.has(name)) { result.skipped.push(name); continue; }
+    try {
+      const res = await runCommand("qmd", ["collection", "add", abs, "--name", name], { timeout: 60_000 });
+      if (res.exitCode === 0) {
+        result.added.push(name);
+      } else {
+        const err = (res.stderr || res.stdout || "").trim() || `exit code ${res.exitCode}`;
+        result.errors.push(`${name}: ${err}`);
+        result.ok = false;
+      }
+    } catch (err) {
+      result.errors.push(`${name}: ${err.message || String(err)}`);
+      result.ok = false;
+    }
+  }
+  if (result.added.length) logger.info(`QMD: registered ${result.added.length} collection(s): ${result.added.join(", ")}.`);
+  if (result.skipped.length) logger.info(`QMD: ${result.skipped.length} collection(s) already present, skipped.`);
+  for (const err of result.errors) logger.warn(`QMD: collection registration failed — ${err}`);
+  return result;
+}

--- a/tests/qmd-collection.test.js
+++ b/tests/qmd-collection.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+vi.mock("../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+
+import { runCommand } from "../src/utils/process.js";
+import {
+  projectSlug, planQmdCollections, registerQmdCollections, QMD_DEFAULT_PATHS
+} from "../src/utils/qmd-collection.js";
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+let tmpRoot, projectDir;
+function setupProject(name) {
+  tmpRoot = mkdtempSync(path.join(tmpdir(), "qmd-coll-"));
+  projectDir = path.join(tmpRoot, name);
+  mkdirSync(projectDir, { recursive: true });
+}
+beforeEach(() => vi.resetAllMocks());
+afterEach(() => { if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true }); });
+
+describe("projectSlug", () => {
+  it("lowercases, sanitises and trims dashes", () => {
+    expect(projectSlug("/tmp/MyProject")).toBe("myproject");
+    expect(projectSlug("/tmp/My Cool Project!")).toBe("my-cool-project");
+    expect(projectSlug("/tmp/---Edge---")).toBe("edge");
+    expect(projectSlug("/tmp/!!!")).toBe("project");
+  });
+});
+
+describe("planQmdCollections", () => {
+  it("exposes the default paths", () => {
+    expect(QMD_DEFAULT_PATHS).toEqual(["docs", ".reviews", ".karajan/plans"]);
+  });
+
+  it("returns only existing directories", () => {
+    setupProject("Karajan");
+    mkdirSync(path.join(projectDir, "docs"));
+    mkdirSync(path.join(projectDir, ".reviews"));
+    const names = planQmdCollections(projectDir).map((r) => r.name).sort();
+    expect(names).toEqual(["karajan-docs", "karajan-reviews"]);
+  });
+
+  it("returns [] when nothing indexable exists", () => {
+    setupProject("Empty");
+    expect(planQmdCollections(projectDir)).toEqual([]);
+  });
+
+  it("skips entries that exist as files, not directories", () => {
+    setupProject("Mixed");
+    writeFileSync(path.join(projectDir, "docs"), "i am a file");
+    expect(planQmdCollections(projectDir)).toEqual([]);
+  });
+});
+
+describe("registerQmdCollections", () => {
+  it("no-ops when no indexable folder exists", async () => {
+    setupProject("Empty");
+    const result = await registerQmdCollections(projectDir, logger);
+    expect(result).toMatchObject({ ok: true, added: [], skipped: [], errors: [] });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("registers new collections", async () => {
+    setupProject("Alpha");
+    mkdirSync(path.join(projectDir, "docs"));
+    mkdirSync(path.join(projectDir, ".reviews"));
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })
+      .mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const result = await registerQmdCollections(projectDir, logger);
+    expect(result.ok).toBe(true);
+    expect(result.added.sort()).toEqual(["alpha-docs", "alpha-reviews"]);
+  });
+
+  it("skips collections already present (idempotent)", async () => {
+    setupProject("Beta");
+    mkdirSync(path.join(projectDir, "docs"));
+    runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "beta-docs (qmd://abc)\n", stderr: "" });
+    const result = await registerQmdCollections(projectDir, logger);
+    expect(result).toMatchObject({ ok: true, added: [], skipped: ["beta-docs"] });
+    expect(runCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("flips ok:false when qmd add fails", async () => {
+    setupProject("Gamma");
+    mkdirSync(path.join(projectDir, "docs"));
+    runCommand
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "boom" });
+    const result = await registerQmdCollections(projectDir, logger);
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("gamma-docs");
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of KJC-TSK-0506 (builds on #986). Wires \`detectQmd\` /
\`installQmd\` into \`kj init\` and adds per-project collection
registration over \`docs/\`, \`.reviews/\` and \`.karajan/plans/\`.

- New util \`src/utils/qmd-collection.js\` (\`projectSlug\`,
  \`planQmdCollections\`, \`registerQmdCollections\`) with 9 tests.
- \`kj init\` flow: detect → install if missing → register collections.
- New flag \`--no-qmd\` mirrors \`--no-rtk\` / \`--no-squeezr\`.

## Idempotency

\`registerQmdCollections\` parses \`qmd collection list\` and skips any
name already present, so re-running \`kj init\` does nothing if the
project is already indexed.

## qmd CLI quirk

\`qmd collection add\` only takes one path, so we end up with up to 3
sibling collections per project (\`<slug>-docs\`, \`<slug>-reviews\`,
\`<slug>-karajan-plans\`). The task spec implied a single multi-path
collection, but that's not how qmd's CLI works today.

## Budget

195 LOC net delta — first slice (#986) carried the detect/install
utilities + tests separately to keep both PRs under the 200 LOC gate.

## Test plan

- [x] \`tests/qmd-collection.test.js\` (9 cases)
- [x] Slug sanitisation, missing folders, file-vs-dir, idempotency, error.
- [x] \`--no-qmd\` short-circuits both install and registration.