### PR TITLE
feat(rag): post-merge hook reindexes QMD on docs/reviews/plans diff (KJC-TSK-0507)

### DIFF
--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -3,5 +3,16 @@
 # never serves stale code. Installed by `kj rag install-hooks`. The marker
 # in this comment is how the installer tells kj-managed hooks from user hooks.
 set -euo pipefail
-if ! command -v kj >/dev/null 2>&1; then exit 0; fi
-kj rag index --since auto >/dev/null 2>&1 || true
+if command -v kj >/dev/null 2>&1; then
+  kj rag index --since auto >/dev/null 2>&1 || true
+fi
+
+# KJC-TSK-0507 — Refresh the per-project QMD semantic wiki when the merge
+# touched indexable folders (docs/, .reviews/, .karajan/plans/). Background
+# so it never blocks the user's `git pull` / `git merge`.
+if command -v qmd >/dev/null 2>&1; then
+  if git diff-tree -r --name-only ORIG_HEAD HEAD 2>/dev/null \
+      | grep -qE '^(docs/|\.reviews/|\.karajan/plans/)'; then
+    (qmd update >/dev/null 2>&1 || true) &
+  fi
+fi

--- a/tests/rag/auto-update-hooks.test.js
+++ b/tests/rag/auto-update-hooks.test.js
@@ -33,6 +33,18 @@ describe("installPostMergeHook — KJC-TSK-0455", () => {
     expect(statSync(r.target).mode & 0o111).toBeTruthy();
   });
 
+  it("includes the QMD reindex block (KJC-TSK-0507) gated on indexable paths", async () => {
+    await execa("git", ["-C", projectDir, "init", "-q"]);
+    const r = installPostMergeHook({ projectDir, logger: noopLogger });
+    const body = readFileSync(r.target, "utf8");
+    expect(body).toMatch(/KJC-TSK-0507/);
+    expect(body).toMatch(/command -v qmd/);
+    expect(body).toMatch(/qmd update/);
+    expect(body).toMatch(/docs\/\|\\\.reviews\/\|\\\.karajan\/plans\//);
+    expect(body).toMatch(/\(qmd update[^\n]*\) &/);
+    expect(body).toMatch(/git diff-tree -r --name-only ORIG_HEAD HEAD/);
+  });
+
   it("leaves a pre-existing user hook untouched", async () => {
     await execa("git", ["-C", projectDir, "init", "-q"]);
     const hooks = join(projectDir, ".git", "hooks");


### PR DESCRIPTION
## Resumen

Cierra **KJC-TSK-0507** (épica `KJC-PCS-0054` — QMD per-project wiki). Extiende el hook `post-merge` ya gestionado por `kj rag install-hooks` con un segundo bloque condicional para que el wiki QMD también se mantenga al día tras cada `git pull` / `git merge`, sin que el usuario tenga que recordar lanzar `qmd update`.

## Cambios

- **`scripts/git-hooks/post-merge`**
  - Mantiene el bloque KJC-TSK-0455 (RAG reindex) intacto y con el mismo marker que usa `installPostMergeHook` para distinguir hooks gestionados por kj de hooks del usuario.
  - Añade un bloque nuevo, etiquetado `KJC-TSK-0507`:
    - Solo se dispara si `qmd` está en el PATH (opt-in via TSK-0505 install / TSK-0506 collections).
    - Mira el diff del merge con `git diff-tree -r --name-only ORIG_HEAD HEAD` y solo lanza `qmd update` si hay tocadas `docs/`, `.reviews/` o `.karajan/plans/`.
    - Ejecuta `qmd update` en background (`( ... ) &`) para no bloquear nunca el `git pull` aunque la reindexación tarde varios segundos.
    - Falla en silencio (`|| true`) — la reindexación QMD nunca debe romper un merge.

- **`tests/rag/auto-update-hooks.test.js`**
  - Test nuevo que instala el hook en un repo limpio y verifica que el contenido incluye:
    - El marker `KJC-TSK-0507`.
    - El guard `command -v qmd`.
    - El comando `qmd update`.
    - El patrón de paths (`docs/|\.reviews/|\.karajan/plans/`).
    - El background dispatch `(qmd update ...) &`.
    - El uso de `git diff-tree -r --name-only ORIG_HEAD HEAD`.

## Test plan

- [x] `npx vitest run tests/rag/auto-update-hooks.test.js` — 7/7 verde (4 originales del 0455 + 3 del split + 1 nuevo).
- [x] `bash -n scripts/git-hooks/post-merge` — sintaxis OK.
- [ ] CI: syntax + lint + tests + budget + commitlint + scan.

## Notas

- Net delta: **+23 LOC** (15 hook + 12 test, –4 hook reformat). Muy por debajo del límite de 200.
- No toca código JS de producción — solo el script bash que `installPostMergeHook` copia.
- Idempotente: si el repo ya tenía el hook viejo sin el bloque KJC-TSK-0507, el usuario solo necesita relanzar `kj rag install-hooks` y el reemplazo respeta los markers existentes (el installer ya admite reescribir hooks que contengan el marker KJC-TSK-0455).