### PR TITLE
feat(hu-board): POST /api/wiki/query route for QMD search (KJC-TSK-0508)

### DIFF
--- a/packages/hu-board/src/routes/wiki.js
+++ b/packages/hu-board/src/routes/wiki.js
@@ -1,0 +1,43 @@
+// KJC-TSK-0508 — HU Board Wiki panel route.
+// POST /api/wiki/query → spawns `qmd query --format json` against the local
+// per-project QMD wiki (registered by `kj init` via KJC-TSK-0506). Returns
+// 503 with installable:true so the front renders an "Install QMD" CTA
+// instead of a generic error when the binary is missing.
+import { Router } from "express";
+import { runCommand } from "../../../../src/utils/process.js";
+
+const router = Router();
+const QMD_NOT_INSTALLED = /command not found|ENOENT|not recognized as/i;
+
+router.post("/query", async (req, res) => {
+  const raw = req.body?.query;
+  const query = typeof raw === "string" ? raw.trim() : "";
+  if (!query) return res.status(400).json({ ok: false, error: "query is required" });
+  const limit = Math.min(Math.max(parseInt(req.body?.limit, 10) || 10, 1), 50);
+  const collection = req.body?.collection ? String(req.body.collection).trim() : null;
+  const fast = req.body?.fast === true;
+
+  const args = ["query", query, "--format", "json", "-n", String(limit)];
+  if (collection) args.push("-c", collection);
+  if (fast) args.push("--no-rerank");
+
+  try {
+    const out = await runCommand("qmd", args, { timeout: 120_000 });
+    if (out.exitCode === 127 || QMD_NOT_INSTALLED.test(out.stderr || "")) {
+      return res.status(503).json({ ok: false, error: "qmd not installed", installable: true });
+    }
+    if (out.exitCode !== 0) {
+      const msg = (out.stderr || out.stdout || `qmd exit ${out.exitCode}`).trim();
+      return res.status(500).json({ ok: false, error: msg });
+    }
+    let results;
+    try { results = JSON.parse(out.stdout || "[]"); }
+    catch { return res.status(500).json({ ok: false, error: "qmd output is not valid JSON" }); }
+    res.json({ ok: true, results, count: Array.isArray(results) ? results.length : 0 });
+  } catch (err) {
+    if (err?.code === "ENOENT") return res.status(503).json({ ok: false, error: "qmd not installed", installable: true });
+    res.status(500).json({ ok: false, error: err?.message || String(err) });
+  }
+});
+
+export default router;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -10,6 +10,7 @@ import { fullScan, startWatcher } from './sync.js';
 import apiRoutes from './routes/api.js';
 import pipelineRoutes from './routes/pipeline.js';
 import ragRoutes from './routes/rag.js';
+import wikiRoutes from './routes/wiki.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
 import { reapZombieSessions } from './zombie-reaper.js';
@@ -300,6 +301,7 @@ async function main() {
   app.use('/api', buildRateLimiter(), authMiddleware(), apiRoutes);
   app.use('/api/pipeline', authMiddleware(), pipelineRoutes);
   app.use('/api/rag', authMiddleware(), ragRoutes);
+  app.use('/api/wiki', authMiddleware(), wikiRoutes);
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {

--- a/packages/hu-board/tests/wiki-route.test.js
+++ b/packages/hu-board/tests/wiki-route.test.js
@@ -1,0 +1,74 @@
+// KJC-TSK-0508 — Tests for POST /api/wiki/query. Mocks runCommand so the
+// handler logic stays hermetic; no real qmd binary is required.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+
+import { runCommand } from "../../../src/utils/process.js";
+import wikiRoutes from "../src/routes/wiki.js";
+
+let app;
+beforeEach(() => {
+  vi.resetAllMocks();
+  app = express();
+  app.use(express.json());
+  app.use("/api/wiki", wikiRoutes);
+});
+
+describe("POST /api/wiki/query", () => {
+  it("returns 400 when query is missing or blank", async () => {
+    const res = await request(app).post("/api/wiki/query").send({ query: "   " });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: "query is required" });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("spawns qmd query with format json and parsed results on success", async () => {
+    const hits = [{ source: "docs/spec.md", snippet: "hello" }];
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: JSON.stringify(hits), stderr: "" });
+    const res = await request(app).post("/api/wiki/query").send({ query: "auth flow" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, results: hits, count: 1 });
+    const args = runCommand.mock.calls[0][1];
+    expect(args.slice(0, 6)).toEqual(["query", "auth flow", "--format", "json", "-n", "10"]);
+  });
+
+  it("clamps limit and forwards collection + --no-rerank when fast=true", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "[]", stderr: "" });
+    await request(app).post("/api/wiki/query").send({ query: "x", limit: 999, collection: "karajan-docs", fast: true });
+    const args = runCommand.mock.calls[0][1];
+    expect(args).toContain("-c"); expect(args).toContain("karajan-docs");
+    expect(args).toContain("--no-rerank");
+    expect(args[args.indexOf("-n") + 1]).toBe("50");
+  });
+
+  it("returns 503 installable:true when qmd binary is missing (ENOENT)", async () => {
+    runCommand.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const res = await request(app).post("/api/wiki/query").send({ query: "x" });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ ok: false, error: "qmd not installed", installable: true });
+  });
+
+  it("returns 503 when exitCode=127 (shell not-found fallback)", async () => {
+    runCommand.mockResolvedValue({ exitCode: 127, stdout: "", stderr: "qmd: command not found" });
+    const res = await request(app).post("/api/wiki/query").send({ query: "x" });
+    expect(res.status).toBe(503);
+    expect(res.body.installable).toBe(true);
+  });
+
+  it("returns 500 with qmd stderr when query fails", async () => {
+    runCommand.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "boom: index empty" });
+    const res = await request(app).post("/api/wiki/query").send({ query: "x" });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ ok: false, error: "boom: index empty" });
+  });
+
+  it("returns 500 when qmd stdout is not valid JSON", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "not-json", stderr: "" });
+    const res = await request(app).post("/api/wiki/query").send({ query: "x" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/not valid JSON/);
+  });
+});


### PR DESCRIPTION
## Resumen

Primera mitad de **KJC-TSK-0508** (épica `KJC-PCS-0054` — QMD per-project wiki). Añade el endpoint backend del panel Wiki del HU Board para que el front-end (próximo PR) tenga sobre qué hablar.

La tarea original tiene `devPoints=4` y tocaba 4 ficheros nuevos (route + tests + html + js + css + viewer). Para respetar el budget de ~200 LOC por PR, se entrega en dos PRs:

1. **(este)** Backend route + tests — ~119 LOC.
2. (siguiente) Frontend `wiki.html` + `wiki.js` + `wiki.css` + integración en `index.html`.

Ambos siguen referenciando `KJC-TSK-0508` en commit; la card pasa a `To Validate` cuando se mergee el segundo PR.

## Cambios

- **`packages/hu-board/src/routes/wiki.js`** — nuevo. `POST /api/wiki/query` con body `{ query, limit?, collection?, fast? }`. Internamente lanza `runCommand("qmd", ["query", <text>, "--format", "json", "-n", <limit>, ...])` con timeout de 120 s para cubrir el rerank LLM en CPU. Casos especiales:
  - Sin `query` → `400 { ok: false, error: "query is required" }`.
  - `qmd` no instalado (`ENOENT` o `exitCode=127`) → `503 { ok: false, error: "qmd not installed", installable: true }` para que el front-end pinte un CTA "Install QMD" en vez de error genérico.
  - `stdout` no parseable como JSON → `500 { ok: false, error: "qmd output is not valid JSON" }`.
  - `exitCode != 0` → `500` con `stderr` del binario.
  - Éxito → `200 { ok: true, results, count }`.
- **`packages/hu-board/src/server.js`** — monta la route bajo `/api/wiki` detrás de `authMiddleware()` (mismo patrón que `/api/rag`).
- **`packages/hu-board/tests/wiki-route.test.js`** — 7 cases con `runCommand` mockeado via `vi.mock`. Cubre los 5 paths de error + el happy path + la combinación `limit` clamping + `collection` + `--no-rerank`.

## Test plan

- [x] `cd packages/hu-board && npx vitest run tests/wiki-route.test.js` — 7/7 verde.
- [ ] CI: syntax + lint + tests + budget + commitlint + scan.

## Notas

- Net delta: **+119 LOC**. Bajo el límite de 200.
- No requiere cambios en `kj init` ni en docs (eso ya se entregó en TSK-0506 y se cerrará en TSK-0510 respectivamente).
- La route es agnóstica de la colección: el frontend del próximo PR podrá ofrecer un selector entre `<slug>-docs`, `<slug>-reviews` y `<slug>-karajan-plans`, o dejarlo en blanco para buscar en las tres.