### PR TITLE
feat(hu-board): wiki panel for qmd search (KJC-TSK-0508)

### DIFF
--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -26,6 +26,7 @@
       <button class="nav-btn" data-view="sessions" title="Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
       <a class="nav-btn" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
       <a class="nav-btn" href="/rag.html" title="RAG retrieval-quality dashboard: chunk counts, embedder provider, db size.">RAG</a>
+      <a class="nav-btn" href="/wiki.html" title="Search the per-project QMD semantic wiki (docs, plans, reviews).">Wiki</a>
       <select class="project-select" id="project-select">
         <option value="">All Projects</option>
       </select>

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -939,3 +939,18 @@ body.scoped-mode .header__nav a[href="/pipeline.html"] {
 .rag-bar__label { color: var(--text-secondary, #cbd5e1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .rag-bar__fill { display: block; height: 14px; background: linear-gradient(90deg, #7c3aed, #a78bfa); border-radius: 3px; }
 .rag-bar__value { text-align: right; color: var(--text-primary, #f8fafc); font-variant-numeric: tabular-nums; }
+
+/* KJC-TSK-0508 — Wiki panel (QMD semantic search) */
+.wiki-search { padding: 1rem; }
+.wiki-form { display: grid; grid-template-columns: 1fr 220px auto auto; gap: .5rem; align-items: center; }
+.wiki-form input[type="search"], .wiki-form input[type="text"] { padding: .5rem .75rem; border-radius: 6px; border: 1px solid var(--border, #334155); background: var(--bg-secondary, #1e1e2e); color: var(--text-primary, #f8fafc); font-size: .9rem; }
+.wiki-fast { display: flex; align-items: center; gap: .35rem; font-size: .85rem; color: var(--text-secondary, #94a3b8); }
+.wiki-hint { margin: .5rem 0 0; font-size: .8rem; color: var(--text-secondary, #94a3b8); font-style: italic; }
+.wiki-results { display: grid; gap: .75rem; padding: 0 1rem 1rem; }
+.wiki-hit { background: var(--bg-secondary, #1e1e2e); border-radius: 8px; padding: .9rem 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.wiki-hit__head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: .4rem; }
+.wiki-hit__src { font-family: ui-monospace, monospace; font-size: .85rem; color: #a78bfa; }
+.wiki-hit__score { font-size: .75rem; color: var(--text-secondary, #94a3b8); font-variant-numeric: tabular-nums; }
+.wiki-hit__snip { margin: 0; font-family: ui-monospace, monospace; font-size: .82rem; line-height: 1.45; color: var(--text-primary, #f8fafc); white-space: pre-wrap; word-break: break-word; }
+.wiki-code { background: #0f172a; color: #e2e8f0; padding: .5rem .75rem; border-radius: 6px; font-family: ui-monospace, monospace; font-size: .85rem; margin: .5rem 0; }
+@media (max-width: 720px) { .wiki-form { grid-template-columns: 1fr; } }

--- a/packages/hu-board/public/wiki.html
+++ b/packages/hu-board/public/wiki.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Karajan Wiki · QMD semantic search</title>
+  <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header__logo"><div><div class="header__title">Karajan Wiki</div><div class="header__subtitle">QMD semantic search</div></div></div>
+    <nav class="header__nav">
+      <a class="nav-btn" href="/">← Board</a>
+      <a class="nav-btn" href="/rag.html">RAG</a>
+      <button class="nav-btn active">Wiki</button>
+    </nav>
+  </header>
+  <main class="main" id="wiki-app">
+    <section class="wiki-search">
+      <form id="wiki-form" class="wiki-form" autocomplete="off">
+        <input id="wiki-q" type="search" placeholder="Search the project wiki…" aria-label="Query" required>
+        <input id="wiki-collection" type="text" placeholder="collection (optional)" aria-label="Collection">
+        <label class="wiki-fast"><input id="wiki-fast" type="checkbox"> fast (no rerank)</label>
+        <button type="submit" class="control-btn" id="wiki-go">Search</button>
+      </form>
+      <p class="wiki-hint">QMD runs locally — 0 tokens, ~60s with rerank, ~5s in fast mode.</p>
+    </section>
+    <section id="wiki-results" class="wiki-results"></section>
+  </main>
+  <script src="/wiki.js"></script>
+</body>
+</html>

--- a/packages/hu-board/public/wiki.js
+++ b/packages/hu-board/public/wiki.js
@@ -1,0 +1,53 @@
+// KJC-TSK-0508 — HU Board Wiki panel frontend. Calls POST /api/wiki/query
+// (server-side spawns `qmd query --format json`) and renders the hits.
+// A 503 with `installable:true` triggers an "Install QMD" CTA instead of
+// a generic error so the user can act on the missing binary.
+const TOKEN = new URLSearchParams(location.search).get("token") || localStorage.getItem("kj_board_token") || "";
+const HEADERS = { "Content-Type": "application/json", ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}) };
+const ESC = (s) => String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
+function renderInstallCTA(root) {
+  root.innerHTML = `<div class="rag-card rag-card--error">
+    <h3>QMD not installed</h3>
+    <p>The semantic wiki engine is not available on this host. Install it once:</p>
+    <pre class="wiki-code">npm install -g @tobilu/qmd</pre>
+    <p class="rag-stat-sub">Then re-run <code>kj init</code> in this project to register the wiki collection.</p>
+  </div>`;
+}
+
+function renderHits(root, results) {
+  if (!Array.isArray(results) || results.length === 0) {
+    root.innerHTML = '<p class="rag-empty">no hits — try a broader query or run <code>qmd update</code>.</p>';
+    return;
+  }
+  root.innerHTML = results.map((r) => {
+    const src = r.source || r.path || r.file || "(unknown source)";
+    const snip = r.snippet || r.text || r.content || "";
+    const score = typeof r.score === "number" ? r.score.toFixed(3) : "";
+    return `<article class="wiki-hit">
+      <header class="wiki-hit__head"><span class="wiki-hit__src">${ESC(src)}</span>${score ? `<span class="wiki-hit__score">${ESC(score)}</span>` : ""}</header>
+      <pre class="wiki-hit__snip">${ESC(snip)}</pre>
+    </article>`;
+  }).join("");
+}
+
+async function runSearch(ev) {
+  ev?.preventDefault();
+  const root = document.getElementById("wiki-results");
+  const query = document.getElementById("wiki-q").value.trim();
+  if (!query) return;
+  const collection = document.getElementById("wiki-collection").value.trim() || undefined;
+  const fast = document.getElementById("wiki-fast").checked;
+  root.innerHTML = '<div class="loading"><div class="loading__spinner"></div><p>Searching the wiki…</p></div>';
+  try {
+    const res = await fetch("/api/wiki/query", { method: "POST", headers: HEADERS, body: JSON.stringify({ query, collection, fast }) });
+    const data = await res.json().catch(() => ({}));
+    if (res.status === 503 && data.installable) { renderInstallCTA(root); return; }
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    renderHits(root, data.results);
+  } catch (err) {
+    root.innerHTML = `<div class="rag-card rag-card--error"><strong>Error:</strong> ${ESC(err.message || String(err))}</div>`;
+  }
+}
+
+document.getElementById("wiki-form").addEventListener("submit", runSearch);


### PR DESCRIPTION
## Resumen

PR2/2 de **KJC-TSK-0508** — Frontend del panel Wiki que consume `POST /api/wiki/query` (servido por PR1 #990, ya en main).

- **Búsqueda** sobre el wiki QMD local del proyecto registrado por `kj init` en KJC-TSK-0506.
- **Formulario**: query (search), colección opcional, toggle `fast` (`--no-rerank` para ~5s en vez de ~60s).
- **Render** de hits: source/path, score (si disponible) y snippet. Output escapado (XSS-safe).
- **CTA "Install QMD"**: cuando el backend responde `503 { installable:true }`, el panel muestra el comando de instalación en lugar de un error genérico.

## Cambios

- `packages/hu-board/public/wiki.html` — nueva página (+32 LOC).
- `packages/hu-board/public/wiki.js` — lógica de búsqueda + render (+53 LOC).
- `packages/hu-board/public/index.html` — botón "Wiki" en la nav junto a "RAG" (+1 LOC).
- `packages/hu-board/public/styles.css` — `.wiki-*` reutilizando el mismo palette dark del panel RAG (+15 LOC).

**Total: 101 LOC añadidas / 0 quitadas.** Sin nuevas deps; puro cliente.

## Verificación local

Server arrancado en `:4000`, navegado a `/wiki.html`, búsqueda contra colección dummy, CTA de instalación visible cuando `qmd` no está en PATH.

## Cierra el epic

Con este PR queda completo **KJC-TSK-0508**. Quedan dos cards del epic **KJC-PCS-0054**:
- KJC-TSK-0509: `kj qmd query` CLI wrapper.
- KJC-TSK-0510: docs README + GETTING-STARTED.