### PR TITLE
feat(cli): add kj qmd query command wrapper (KJC-TSK-0509)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -4,6 +4,7 @@ import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
 import { ragIndexCommand, ragQueryCommand, ragInstallHooksCommand, ragEvalCommand } from "../commands/rag.js";
+import { qmdQueryCommand } from "../commands/qmd.js";
 import { ragMcpCommand } from "../commands/rag-mcp.js";
 import { watchStartCommand, watchStopCommand, watchStatusCommand } from "../commands/watch.js";
 import { auditCommand } from "../commands/audit.js";
@@ -170,6 +171,24 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Start the standalone RAG MCP server (kj_rag_query + kj_rag_index only). Same as running `kj-rag-mcp` directly")
     .action(async () => {
       await ragMcpCommand();
+    });
+
+  // KJC-TSK-0509 — `kj qmd query` is a thin wrapper around the upstream
+  // `qmd` binary that auto-resolves the project's collection (rag = agent
+  // context; qmd = human wiki). One subcommand for now; index/add live in
+  // `kj init` and `kj rag install-hooks` (post-merge reindex).
+  const qmd = program.command("qmd").description("Semantic search over the per-project QMD wiki (docs/, .reviews/, .karajan/plans/)");
+  qmd.command("query <text>")
+    .description("Run a qmd query against the wiki collection of the current project")
+    .option("--collection <name>", "Override the auto-resolved <slug>-<suffix> collection name")
+    .option("--scope <name>", "docs (default) | reviews | plans", "docs")
+    .option("--top-k <n>", "Number of hits to return (1..50, default 10)", "10")
+    .option("--fast", "Skip the LLM reranker (faster, slightly noisier hits)")
+    .option("--json", "Emit the raw JSON array for piping to jq")
+    .action(async (text, flags) => {
+      await withConfig(pkgVersion, "qmd-query", flags, async ({ config, logger }) => {
+        await qmdQueryCommand({ text, config, logger, flags });
+      });
     });
 
   // KJC-TSK-0441 — `kj watch [start|stop|status]` for live RAG re-index.

--- a/src/commands/qmd.js
+++ b/src/commands/qmd.js
@@ -1,0 +1,86 @@
+// KJC-TSK-0509 — `kj qmd query` CLI wrapper. Auto-resolves the project's QMD
+// collection (`<projectSlug>-<suffix>`) so users do not have to remember it.
+// Mirrors `kj rag query`'s friendly-error shape on missing binary/collection.
+// Distinction: rag = agent context (code+plans); qmd = human wiki (docs/*.md).
+import { runCommand } from "../utils/process.js";
+import { projectSlug } from "../utils/qmd-collection.js";
+
+const QMD_NOT_INSTALLED = /command not found|ENOENT|not recognized as/i;
+const COLLECTION_MISSING = /no such collection|collection .* not found|unknown collection/i;
+const INSTALL_HINT = "qmd not installed. Install it with: npm install -g @tobilu/qmd";
+const INIT_HINT = "Collection not registered for this project. Run `kj init` to register the wiki collection.";
+
+function suffixFor(scope) {
+  if (!scope || scope === "docs") return "docs";
+  if (scope === "reviews" || scope === ".reviews") return "reviews";
+  if (scope === "plans" || scope === ".karajan/plans" || scope === "karajan-plans") return "karajan-plans";
+  return scope;
+}
+
+function resolveCollection({ flags, projectDir }) {
+  if (flags.collection) return String(flags.collection).trim();
+  return `${projectSlug(projectDir)}-${suffixFor(flags.scope)}`;
+}
+
+function notInstalled(logger) {
+  logger.error?.(`[qmd] ${INSTALL_HINT}`);
+  process.exitCode = 127;
+  return { ok: false, error: "qmd not installed", installable: true };
+}
+
+export async function qmdQueryCommand({ text, config, logger, flags = {} }) {
+  if (!text || !String(text).trim()) throw new Error("kj qmd query: text argument required");
+  const projectDir = config?.projectDir || process.cwd();
+  const collection = resolveCollection({ flags, projectDir });
+  const limit = Math.min(Math.max(Number(flags.topK) || 10, 1), 50);
+  const args = ["query", String(text), "--format", "json", "-c", collection, "-n", String(limit)];
+  if (flags.fast) args.push("--no-rerank");
+
+  let out;
+  try {
+    out = await runCommand("qmd", args, { timeout: 120_000 });
+  } catch (err) {
+    if (err?.code === "ENOENT") return notInstalled(logger);
+    throw err;
+  }
+
+  const stderr = out.stderr || "";
+  if (out.exitCode === 127 || QMD_NOT_INSTALLED.test(stderr)) return notInstalled(logger);
+  if (COLLECTION_MISSING.test(stderr)) {
+    logger.error?.(`[qmd] ${INIT_HINT}`);
+    process.exitCode = 1;
+    return { ok: false, error: "collection not registered", collection };
+  }
+  if (out.exitCode !== 0) {
+    const msg = (stderr || out.stdout || `qmd exit ${out.exitCode}`).trim();
+    logger.error?.(`[qmd] ${msg}`);
+    process.exitCode = out.exitCode || 1;
+    return { ok: false, error: msg };
+  }
+
+  let results;
+  try { results = JSON.parse(out.stdout || "[]"); }
+  catch {
+    logger.error?.("[qmd] qmd output is not valid JSON");
+    process.exitCode = 1;
+    return { ok: false, error: "qmd output is not valid JSON" };
+  }
+
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify(results)}\n`);
+    return { ok: true, results };
+  }
+  if (!Array.isArray(results) || results.length === 0) {
+    logger.info(`[qmd] no hits for "${text}" in collection ${collection}`);
+    return { ok: true, results: [] };
+  }
+  logger.info(`[qmd] ${results.length} hit(s) in ${collection}:`);
+  for (const h of results) {
+    const src = h.source || h.path || h.file || "?";
+    const score = typeof h.score === "number" ? ` · score=${h.score.toFixed(4)}` : "";
+    const snippet = h.snippet || h.text || h.body || "";
+    logger.info(`  - ${src}${score}`);
+    if (snippet) logger.info(`    ${snippet.length > 200 ? `${snippet.slice(0, 200)}…` : snippet}`);
+  }
+  return { ok: true, results };
+}

--- a/tests/commands/command-qmd.test.js
+++ b/tests/commands/command-qmd.test.js
@@ -1,0 +1,91 @@
+// KJC-TSK-0509 — kj qmd query CLI wrapper. Mocks runCommand so the handler
+// stays hermetic; no real qmd binary required.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+
+import { runCommand } from "../../src/utils/process.js";
+import { qmdQueryCommand } from "../../src/commands/qmd.js";
+
+const noopLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  for (const k of ["info", "warn", "error"]) noopLogger[k].mockClear();
+  process.exitCode = undefined;
+});
+
+describe("qmdQueryCommand — KJC-TSK-0509", () => {
+  it("throws when text is blank", async () => {
+    await expect(
+      qmdQueryCommand({ text: "   ", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: {} })
+    ).rejects.toThrow(/text argument required/);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it("auto-resolves <slug>-docs, supports overrides, scope mapping, clamp, fast", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "[]", stderr: "" });
+    // default → my-repo-docs
+    await qmdQueryCommand({ text: "auth flow", config: { projectDir: "/tmp/My-Repo" }, logger: noopLogger, flags: {} });
+    expect(runCommand.mock.calls[0][1].slice(0, 8))
+      .toEqual(["query", "auth flow", "--format", "json", "-c", "my-repo-docs", "-n", "10"]);
+    // --collection wins, --top-k clamps to 50, --fast adds --no-rerank
+    await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: { collection: "custom", topK: 999, fast: true } });
+    const a2 = runCommand.mock.calls[1][1];
+    expect(a2[a2.indexOf("-c") + 1]).toBe("custom");
+    expect(a2[a2.indexOf("-n") + 1]).toBe("50");
+    expect(a2).toContain("--no-rerank");
+    // --scope=plans → <slug>-karajan-plans
+    await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: { scope: "plans" } });
+    expect(runCommand.mock.calls[2][1]).toContain("p-karajan-plans");
+  });
+
+  it("returns installable error and exitCode=127 on ENOENT or shell-not-found", async () => {
+    // ENOENT path
+    runCommand.mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const r1 = await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: {} });
+    expect(r1).toEqual({ ok: false, error: "qmd not installed", installable: true });
+    expect(process.exitCode).toBe(127);
+    expect(noopLogger.error).toHaveBeenCalledWith(expect.stringMatching(/npm install -g @tobilu\/qmd/));
+    // exitCode=127 fallback
+    process.exitCode = undefined;
+    runCommand.mockResolvedValueOnce({ exitCode: 127, stdout: "", stderr: "qmd: command not found" });
+    const r2 = await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: {} });
+    expect(r2.installable).toBe(true);
+    expect(process.exitCode).toBe(127);
+  });
+
+  it("suggests `kj init` when collection is missing", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "Error: no such collection 'my-repo-docs'" });
+    const res = await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/My-Repo" }, logger: noopLogger, flags: {} });
+    expect(res).toEqual({ ok: false, error: "collection not registered", collection: "my-repo-docs" });
+    expect(noopLogger.error).toHaveBeenCalledWith(expect.stringMatching(/kj init/));
+  });
+
+  it("prints raw JSON when --json, friendly hits otherwise", async () => {
+    const hits = [{ source: "docs/a.md", score: 0.91, snippet: "alpha" }];
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: JSON.stringify(hits), stderr: "" });
+    // --json → raw
+    const chunks = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (s) => { chunks.push(String(s)); return true; };
+    try {
+      await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: { json: true } });
+    } finally { process.stdout.write = orig; }
+    expect(JSON.parse(chunks.join("").trim())).toEqual(hits);
+    expect(noopLogger.info).not.toHaveBeenCalled();
+    // no --json → friendly
+    await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/My-Repo" }, logger: noopLogger, flags: {} });
+    const lines = noopLogger.info.mock.calls.map((c) => c[0]).join("\n");
+    expect(lines).toMatch(/1 hit\(s\) in my-repo-docs/);
+    expect(lines).toMatch(/docs\/a\.md.*score=0\.9100/);
+    expect(lines).toMatch(/alpha/);
+  });
+
+  it("returns malformed-JSON error when qmd stdout is not valid JSON", async () => {
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "not-json", stderr: "" });
+    const res = await qmdQueryCommand({ text: "x", config: { projectDir: "/tmp/p" }, logger: noopLogger, flags: {} });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not valid JSON/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes [KJC-TSK-0509](https://planning-game-xp.web.app/?project=Karajan%20Code&card=KJC-TSK-0509). Part of the QMD per-project wiki epic ([KJC-PCS-0054](https://planning-game-xp.web.app/?project=Karajan%20Code&card=KJC-PCS-0054)).

Adds `kj qmd query <text>` — a thin CLI wrapper over the upstream `qmd` binary that auto-resolves the project's QMD collection (`<projectSlug>-docs|reviews|karajan-plans`) so the user does not have to remember the exact name. Same friendly-error UX as `kj rag query` when Ollama is missing.

### Flags

| Flag | Default | Meaning |
|---|---|---|
| `--collection <name>` | `<slug>-docs` (auto) | Override the auto-resolved collection name |
| `--scope <name>` | `docs` | `docs` \| `reviews` \| `plans` → maps to `<slug>-{docs,reviews,karajan-plans}` |
| `--top-k <n>` | `10` | Clamped to `[1, 50]` |
| `--fast` | off | Skip the LLM reranker (faster, slightly noisier) |
| `--json` | off | Emit the raw qmd JSON for piping to `jq` |

### Error UX (acceptance criteria)

- `qmd` binary missing (`ENOENT` or `exit 127` or `command not found` in stderr) → prints `qmd not installed. Install it with: npm install -g @tobilu/qmd` and `process.exitCode = 127`.
- Collection not registered (`no such collection ...` in stderr) → prints `Collection not registered for this project. Run kj init to register the wiki collection.`
- `--json` returns the raw array unchanged for pipe-to-jq workflows.

### Distinction (also documented in next card TSK-0510)

- `kj rag query`  → vector search over **agent-facing** context (code + plans).
- `kj qmd query`  → semantic search over the **human-facing** wiki (docs/, reviews/, plan markdowns).

## Files

- `src/commands/qmd.js` (new, 86 LOC) — exports `qmdQueryCommand({ text, config, logger, flags })`.
- `src/cli/register-meta.js` (+19 LOC) — wires `program.command('qmd').command('query <text>')`.
- `tests/commands/command-qmd.test.js` (new, 91 LOC) — 6 cases.

Net delta: **196 LOC** (under the 200 LOC budget).

## Test plan

- [x] `npx vitest run tests/commands/command-qmd.test.js` — 6/6 green
- [x] `npx vitest run tests/commands/` — 105/105 green
- [x] `node src/cli.js qmd query --help` — renders correctly
- [ ] CI green