### PR TITLE
docs(readme): promote QMD to bundled integrations (KJC-TSK-0510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pip install .
 
 Both options expect the `kj` binary to be on your `PATH` (via one of the methods above) — the Python wrapper does not vendor it.
 
-That's it. `kj init` auto-detects your installed agents and installs the bundled integrations (RTK + Squeezr) for token optimization.
+That's it. `kj init` auto-detects your installed agents and installs the bundled integrations (RTK + Squeezr for token optimization; QMD for the per-project semantic wiki).
 
 ### Optional scanners for `kj audit` + `kj webperf`
 
@@ -374,6 +374,7 @@ These ship with Karajan and `kj init` installs them as part of setup. They're to
 |------|-----------|-----|
 | [**RTK**](https://github.com/rtk-ai/rtk) | Karajan (auto, on Bash outputs) | Reduces token consumption by 60-90% on Bash command outputs |
 | [**Squeezr**](https://www.npmjs.com/package/squeezr-ai) | Karajan (auto, on agent tool outputs) | Compresses verbose tool results before they reach the agent context |
+| [**QMD**](https://github.com/manufosela/qmd) | Karajan (`kj init` auto-registers `docs/`, `.reviews/`, `.karajan/plans/`); you (via `kj qmd query`) | Per-project semantic wiki for **humans**. Complements the **agent-facing** RAG index — `kj rag query` is what the pipeline reads; `kj qmd query` is what you read |
 
 ## Recommended companions
 
@@ -381,7 +382,6 @@ None of these are required. Karajan runs fine on its own. They're tools that, wh
 
 | Tool | Invoked by | Why |
 |------|-----------|-----|
-| [**QMD**](https://github.com/manufosela/qmd) | You (CLI / MCP), complementary to RAG | Semantic search engine over Markdown corpora — works alongside `kj rag query` when you want a richer index over your own docs |
 | [**GitHub MCP**](https://github.com/github/github-mcp-server) | Your AI agent (via MCP) | Create PRs, manage issues directly from the agent |
 | [**Chrome DevTools MCP**](https://github.com/ChromeDevTools/chrome-devtools-mcp) | Your AI agent (via MCP) | Verify UI changes visually after frontend modifications |
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -7,6 +7,7 @@
 - At least one AI CLI installed: `claude`, `codex`, `gemini`, `aider`, or `opencode`
 - (Optional) Docker for local SonarQube
 - RTK + Squeezr (token efficiency) — `kj init` installs both automatically. Opt out with `--no-rtk` / `--no-squeezr` if you don't want them.
+- QMD (per-project semantic wiki) — `kj init` registers `docs/`, `.reviews/` and `.karajan/plans/` as searchable collections, and `kj qmd query "..."` runs against the active project. The RAG index serves the **agent**; QMD serves **you**. Opt out with `--no-qmd`.
 
 ### Optional scanners — `kj audit` + `kj webperf`
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -7,6 +7,7 @@
 - Al menos una CLI de IA instalada: `claude`, `codex`, `gemini`, `aider` u `opencode`
 - (Opcional) Docker para SonarQube local
 - RTK + Squeezr (eficiencia de tokens) — `kj init` los instala automáticamente. Para no usarlos, `--no-rtk` / `--no-squeezr`.
+- QMD (wiki semántica por proyecto) — `kj init` registra `docs/`, `.reviews/` y `.karajan/plans/` como colecciones indexadas, y `kj qmd query "..."` consulta contra el proyecto activo. El índice RAG sirve al **agente**; QMD te sirve a **ti**. Para no usarlo, `--no-qmd`.
 
 ### Scanners opcionales — `kj audit` + `kj webperf`
 


### PR DESCRIPTION
## Summary
- Promote QMD from "Recommended companions" to "Bundled integrations" in `README.md` alongside RTK and Squeezr.
- Add a single-line QMD entry to `docs/GETTING-STARTED.md` and `docs/es/GETTING-STARTED.md` right after the existing RTK + Squeezr line, with the `--no-qmd` opt-out flag.
- Make the **agent (RAG) vs human (QMD)** distinction explicit so users do not conflate the two semantic-search surfaces.

Silent integration per the [[squeezr-integrate-silently]] feedback: no CHANGELOG entry, no landing card, no release notes — QMD reads as if it were bundled since day one.

## Test plan
- [x] Diff stays inside the docs-only allowlist (3 MD files, +4/-2 net).
- [ ] `prettier --check`, `lint`, `markdown-link` and the rest of the CI pipeline pass.

Closes KJC-TSK-0510 (part of QMD epic KJC-PCS-0054).