### PR TITLE
fix(run): abort cleanly when --yes + no TTY (KJC-BUG-0081)

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -14,19 +14,33 @@ import { confirmCwd } from "../utils/cwd-confirm.js";
 import { runSpecReview } from "../spec-review/run-spec-review.js";
 import { maybeAutoUpdate } from "../rag/auto-update.js";
 
-function createCliAskQuestion(opts = {}) {
-  const { sessionId = null } = opts;
+export function createCliAskQuestion(opts = {}) {
+  const { sessionId = null, flags = {} } = opts;
   return async (question, context) => {
-    // Two paths:
+    // Three paths:
     //   - Interactive TTY: prompt via readline (the developer's terminal).
-    //   - No TTY (board's \u25b6 Run plan with stdio=ignore, CI, etc.): publish
+    //   - No TTY + --yes (CI / scripted / desatendido): KJC-BUG-0081 \u2014 never
+    //     route to the HU Board bridge in this case; the caller explicitly
+    //     asked NOT to be prompted. Print the unanswered question + context
+    //     to stderr and stop the session so the run fails fast and loud
+    //     instead of hanging on a modal nobody is watching.
+    //   - No TTY without --yes (board's \u25b6 Run plan with stdio=ignore): publish
     //     the prompt through the file-based bridge so the HU Board can
     //     surface it as a modal. The runner blocks on the bridge until
-    //     the user answers (or times out / kills the run). Pre-v2.7.5
-    //     this path just bailed; now the question actually gets answered.
+    //     the user answers (or times out / kills the run).
     const stdinReadable = process.stdin && process.stdin.readable !== false;
     const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
     if (!isInteractive) {
+      if (flags?.yes) {
+        process.stderr.write(
+          `\n[non-interactive --yes] Pipeline asked a question that cannot be auto-answered:\n`
+          + `  \u2753 ${question}\n`
+          + (context?.detail ? `  Context: ${JSON.stringify(context.detail)}\n` : "")
+          + `  Stopping the session. Re-run without --yes (TTY or HU Board) to answer it,\n`
+          + `  or pass --skip-spec-review / a more complete spec so the question never appears.\n`
+        );
+        return null;
+      }
       const { askThroughBoard } = await import("../utils/board-prompt-bridge.js");
       console.log(`\n\u2753 ${question}`);
       if (context?.detail) {
@@ -171,7 +185,7 @@ export async function runCommandHandler({ task, config, logger, flags }) {
       printHeader({ task: task, config });
     }
 
-    const askQuestion = createCliAskQuestion();
+    const askQuestion = createCliAskQuestion({ flags });
 
     // Spec-reviewer pre-pipeline audit (KJC-PCS-0048). Runs BEFORE
     // anything else — surfaces ambiguity / missing scope / missing AC

--- a/tests/commands/command-run-yes-no-tty.test.js
+++ b/tests/commands/command-run-yes-no-tty.test.js
@@ -1,0 +1,58 @@
+// KJC-BUG-0081 — kj run no debe colgarse en modo --yes sin TTY.
+// El bridge de HU Board solo aplica cuando NO hay --yes; con --yes el caller
+// pidió explícitamente "no me preguntes nada", así que la sesión debe abortar
+// limpio con un mensaje en stderr en vez de quedarse esperando un modal que
+// nadie va a ver (CI, scripted runs, kj audit --yes desatendido, etc.).
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { createCliAskQuestion } from "../../src/commands/run.js";
+
+describe("createCliAskQuestion — KJC-BUG-0081", () => {
+  const origIsTTY = process.stdin.isTTY;
+  let stderrWrites;
+  let stderrSpy;
+
+  beforeEach(() => {
+    stderrWrites = [];
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+  });
+
+  it("returns null without invoking the HU Board bridge when --yes and no TTY", async () => {
+    const bridge = await import("../../src/utils/board-prompt-bridge.js");
+    const askSpy = vi.spyOn(bridge, "askThroughBoard").mockResolvedValue("should-not-be-called");
+
+    const ask = createCliAskQuestion({ flags: { yes: true } });
+    const answer = await ask("¿Confirma la spec?", { detail: { reason: "missing-ac" } });
+
+    expect(answer).toBeNull();
+    expect(askSpy).not.toHaveBeenCalled();
+    const all = stderrWrites.join("");
+    expect(all).toMatch(/non-interactive --yes/);
+    expect(all).toMatch(/Stopping the session/);
+    expect(all).toMatch(/missing-ac/);
+    askSpy.mockRestore();
+  });
+
+  it("falls back to the HU Board bridge when no TTY and --yes is not set", async () => {
+    const bridge = await import("../../src/utils/board-prompt-bridge.js");
+    const askSpy = vi.spyOn(bridge, "askThroughBoard").mockResolvedValue("from-board");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const ask = createCliAskQuestion({ flags: {} });
+    const answer = await ask("¿Confirma?", {});
+
+    expect(answer).toBe("from-board");
+    expect(askSpy).toHaveBeenCalledOnce();
+    askSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

`kj run --yes` se colgaba indefinidamente cuando se ejecutaba sin TTY (CI, scripted, `kj audit --yes` desatendido). `createCliAskQuestion` enrutaba todos los prompts no-TTY al puente del HU Board — sin importar que el caller hubiera dicho explícitamente "no me preguntes nada" con `--yes`. Sin board escuchando, el modal nunca se respondía y la sesión quedaba viva esperando.

Ahora la rama no-TTY chequea `flags.yes` primero: si está, escribe la pregunta + contexto a stderr con un hint (`--skip-spec-review` o quitar `--yes`) y devuelve `null` para parar la sesión rápido y ruidoso. El path del board sigue intacto para no-TTY **sin** `--yes` (Run plan desde el board con `stdio=ignore`).

`createCliAskQuestion` queda exportada para test unitario directo.

Card: KJC-BUG-0081 (Application Blocker).

## Test plan

- [x] `npx vitest run tests/commands/command-run-yes-no-tty.test.js` — nuevo test: 2/2 verde (rama `--yes` no toca el bridge, rama sin `--yes` sí cae en el bridge).
- [x] `npx vitest run tests/commands/command-run.test.js` — regresión: 8/8 verde.
- [x] Diff: 21+ / 7- en `src/commands/run.js`, sin tocar paths externos. Cabecera 58 chars (≤100).