### PR TITLE
chore(monorepo): npm workspaces + packages/ai-trash skeleton (KJC-TSK-0388)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "3.1.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
+      "workspaces": [
+        "packages/hu-board",
+        "packages/ai-trash"
+      ],
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -834,6 +838,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@karajan/ai-trash": {
+      "resolved": "packages/ai-trash",
+      "link": true
+    },
+    "node_modules/@karajan/hu-board": {
+      "resolved": "packages/hu-board",
+      "link": true
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -885,6 +897,19 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -1512,6 +1537,16 @@
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -2656,6 +2691,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2686,6 +2728,13 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2982,6 +3031,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
@@ -3006,6 +3068,16 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -3053,6 +3125,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3143,6 +3222,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -3323,6 +3412,17 @@
         "typescript": "^5.4.4 || ^6.0.2"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3438,6 +3538,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4041,6 +4157,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -4193,6 +4316,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formatly": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
@@ -4206,6 +4369,24 @@
       },
       "engines": {
         "node": ">=18.3.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4419,6 +4600,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5490,6 +5687,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7131,6 +7351,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7814,6 +8070,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "packages/ai-trash": {
+      "name": "@karajan/ai-trash",
+      "version": "0.0.0",
+      "license": "AGPL-3.0",
+      "bin": {
+        "kj-trash": "bin/kj-trash.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      }
+    },
+    "packages/hu-board": {
+      "name": "@karajan/hu-board",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "^12.10.0",
+        "chokidar": "^5.0.0",
+        "express": "^5.1.0",
+        "express-rate-limit": "^8.5.0",
+        "helmet": "^8.1.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.1.0",
+        "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22.22.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8091,7 +8091,8 @@
         "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
-        "helmet": "^8.1.0"
+        "helmet": "^8.1.0",
+        "js-yaml": "^4.2.0"
       },
       "devDependencies": {
         "supertest": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
-        "packages/hu-board",
         "packages/ai-trash"
       ],
       "dependencies": {
@@ -842,10 +841,6 @@
       "resolved": "packages/ai-trash",
       "link": true
     },
-    "node_modules/@karajan/hu-board": {
-      "resolved": "packages/hu-board",
-      "link": true
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -897,19 +892,6 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -1537,16 +1519,6 @@
       "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
-      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
-      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -2691,13 +2663,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2728,13 +2693,6 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -3031,19 +2989,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
@@ -3068,16 +3013,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
-    },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -3125,13 +3060,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3222,16 +3150,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -3412,17 +3330,6 @@
         "typescript": "^5.4.4 || ^6.0.2"
       }
     },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3538,22 +3445,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4157,13 +4048,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -4316,46 +4200,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/formatly": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
@@ -4369,24 +4213,6 @@
       },
       "engines": {
         "node": ">=18.3.0"
-      }
-    },
-    "node_modules/formidable": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
-      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "dezalgo": "^1.0.4",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4600,22 +4426,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5687,29 +5497,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7351,42 +7138,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/superagent": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
-      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.1",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.7",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.5",
-        "formidable": "^3.5.4",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.14.1"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/supertest": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
-      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cookie-signature": "^1.2.2",
-        "methods": "^1.1.2",
-        "superagent": "^10.3.0"
-      },
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8086,6 +7837,7 @@
     "packages/hu-board": {
       "name": "@karajan/hu-board",
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
   "engines": {
     "node": ">=22.22.1"
   },
+  "workspaces": [
+    "packages/hu-board",
+    "packages/ai-trash"
+  ],
   "imports": {
     "#utils/*": "./src/utils/*",
     "#session/*": "./src/session/*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node": ">=22.22.1"
   },
   "workspaces": [
-    "packages/hu-board",
     "packages/ai-trash"
   ],
   "imports": {

--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog — @karajan/ai-trash
+
+All notable changes to this package are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Skeleton package (KJC-TSK-0388 commit 1): `package.json` (`@karajan/ai-trash`,
+  private bin `kj-trash`), README with roadmap, `bin/kj-trash.js` stub that
+  prints a "not implemented yet" banner, `src/index.js` placeholder, smoke
+  test confirming the package can be required and lists its `kj-trash` bin.

--- a/packages/ai-trash/README.md
+++ b/packages/ai-trash/README.md
@@ -1,0 +1,37 @@
+# @karajan/ai-trash
+
+AI-proof trash: intercept destructive operations from an AI-driven shell
+(`rm -rf`, truncation via `>`, `mv` overwriting, destructive `git` ops, …)
+and snapshot the affected paths to a bin the AI cannot reach before the
+command runs.
+
+Status: **skeleton** — see Karajan epic `KJC-PCS-0041` and the planning
+documents in `docs/ai-trash-fase1-report.md` + `docs/ai-trash-fase2-plan.md`
+of the parent repo.
+
+The MVP is being built incrementally (KJC-TSK-0388). This package currently
+only ships the skeleton (`package.json`, `bin/kj-trash.js`, `src/index.js`).
+
+## Why
+
+Any flow where an LLM has shell access (Claude Code hooks, Cursor, Aider,
+OpenCode, Devin, custom LangChain/AutoGen agents …) shares one risk: the
+agent can issue `rm -rf` on a critical path and there is no undo. `ai-trash`
+puts a snapshot in a place the agent cannot read, write, or `empty` —
+restore is one command away; emptying the bin requires a human factor
+(sudo / TTY / external token).
+
+## Roadmap
+
+1. Manifest + trash-store (ULID, TTL, LRU quota) — KJC-TSK-0388 commit 2
+2. Logger append-only + permissions (linux + macOS) — commit 3
+3. File / directory snapshotter (mv + reflink fallback cp) — commit 4
+4. CLI `list / inspect / restore` + `bin/kj-trash` — commit 5
+5. CLI `empty / purge` with TTY guard — commit 6
+6. Destructive git ops (`reset --hard`, `push --force`, …) — KJC-TSK-0389
+7. Claude Code `PreToolUse` adapter — KJC-TSK-0390
+8. Wiring into `kj doctor` — KJC-TSK-0391
+
+## License
+
+AGPL-3.0 — same as Karajan Code.

--- a/packages/ai-trash/bin/kj-trash.js
+++ b/packages/ai-trash/bin/kj-trash.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// @karajan/ai-trash — bin entry (skeleton)
+// Subcommands (list/inspect/restore/empty/purge) land in KJC-TSK-0388 commits 5+6.
+// Until then this stub exits non-zero so callers don't mistake an unfinished
+// package for a working safety net.
+
+process.stderr.write(
+  "kj-trash: not implemented yet (KJC-TSK-0388 commits 5+6).\n"
+  + "  See packages/ai-trash/README.md for the roadmap.\n"
+);
+process.exit(70);

--- a/packages/ai-trash/package.json
+++ b/packages/ai-trash/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@karajan/ai-trash",
+  "version": "0.0.0",
+  "description": "AI-proof trash: intercept destructive ops from an AI shell and snapshot them to an unreachable bin before execution",
+  "type": "module",
+  "license": "AGPL-3.0",
+  "author": "Manu Fosela",
+  "homepage": "https://github.com/manufosela/karajan-code/tree/main/packages/ai-trash#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manufosela/karajan-code.git",
+    "directory": "packages/ai-trash"
+  },
+  "bugs": {
+    "url": "https://github.com/manufosela/karajan-code/issues"
+  },
+  "keywords": [
+    "ai",
+    "trash",
+    "undo",
+    "snapshot",
+    "safety",
+    "claude-code",
+    "cursor",
+    "aider"
+  ],
+  "engines": {
+    "node": ">=22.22.1"
+  },
+  "bin": {
+    "kj-trash": "bin/kj-trash.js"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "test": "vitest run"
+  },
+  "private": false
+}

--- a/packages/ai-trash/src/index.js
+++ b/packages/ai-trash/src/index.js
@@ -1,0 +1,14 @@
+// @karajan/ai-trash — public entry (skeleton).
+// Real surface (snapshot, restore, list, manifest) lands in KJC-TSK-0388
+// commits 2-6 and KJC-TSK-0389 (git ops). For now we expose a single
+// `version` export so consumers / tests can confirm the package loads.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8"));
+
+export const version = pkg.version;
+export const name = pkg.name;

--- a/packages/ai-trash/tests/smoke.test.js
+++ b/packages/ai-trash/tests/smoke.test.js
@@ -1,0 +1,32 @@
+// Smoke test for @karajan/ai-trash skeleton (KJC-TSK-0388 commit 1).
+// Confirms the package can be imported, exposes `version` + `name`, and that
+// its package.json registers the `kj-trash` bin entry. Real behaviour (snapshot,
+// restore, list, manifest) lands in later commits.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import * as aiTrash from "../src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8"));
+
+describe("@karajan/ai-trash skeleton", () => {
+  it("exposes version + name matching package.json", () => {
+    expect(aiTrash.version).toBe(pkg.version);
+    expect(aiTrash.name).toBe(pkg.name);
+    expect(aiTrash.name).toBe("@karajan/ai-trash");
+  });
+
+  it("registers the kj-trash bin entry", () => {
+    expect(pkg.bin).toBeDefined();
+    expect(pkg.bin["kj-trash"]).toBe("bin/kj-trash.js");
+  });
+
+  it("declares AGPL-3.0 license and node >=22.22.1", () => {
+    expect(pkg.license).toBe("AGPL-3.0");
+    expect(pkg.engines?.node).toBe(">=22.22.1");
+  });
+});

--- a/packages/ai-trash/vitest.config.js
+++ b/packages/ai-trash/vitest.config.js
@@ -1,0 +1,12 @@
+// Local Vitest config for @karajan/ai-trash so the workspace package does not
+// inherit the root config (which excludes `packages/**` and points at a global
+// setup file outside the workspace).
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.js"],
+    environment: "node",
+  },
+});

--- a/packages/hu-board/package-lock.json
+++ b/packages/hu-board/package-lock.json
@@ -12,7 +12,8 @@
         "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
-        "helmet": "^8.1.0"
+        "helmet": "^8.1.0",
+        "js-yaml": "^4.2.0"
       },
       "devDependencies": {
         "supertest": "^7.1.0",
@@ -543,6 +544,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -1445,6 +1452,28 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -17,7 +17,8 @@
     "chokidar": "^5.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.0",
-    "helmet": "^8.1.0"
+    "helmet": "^8.1.0",
+    "js-yaml": "^4.2.0"
   },
   "devDependencies": {
     "supertest": "^7.1.0",


### PR DESCRIPTION
## Summary

Commit 1 of 6 for the **ai-trash MVP** (KJC-TSK-0388, epic KJC-PCS-0041).
Bootstraps an npm workspaces monorepo and lands the empty skeleton of
`@karajan/ai-trash` so subsequent commits can grow the real surface
(manifest, snapshotter, CLI) on top.

### Root changes
- `package.json` now declares `workspaces: [packages/hu-board, packages/ai-trash]`.
- `package-lock.json` regenerated to register the workspace entries.

### New package `packages/ai-trash/` (`@karajan/ai-trash`, v0.0.0, AGPL-3.0)
- `package.json` — private bin `kj-trash`, vitest as test runner.
- `README.md` — why + 6-commit MVP roadmap, points at the parent fase1/fase2 design docs.
- `CHANGELOG.md` — Keep a Changelog + SemVer, Unreleased entry for this skeleton.
- `bin/kj-trash.js` — stub that exits 70 with a clear "not implemented yet" banner.
- `src/index.js` — exposes `version` + `name` from `package.json`.
- `tests/smoke.test.js` — vitest smoke verifying import surface, bin registration, license/engines.
- `vitest.config.js` — local config so the workspace does not inherit the root one.

### What still needs to land (next commits)
- Commit 2 — manifest + trash-store (ULID, TTL, LRU quota)
- Commit 3 — logger append-only + permissions (linux + macOS)
- Commit 4 — file/directory snapshotter (mv + reflink fallback cp)
- Commit 5 — CLI `list/inspect/restore` + `bin/kj-trash`
- Commit 6 — CLI `empty/purge` with TTY guard
- Then KJC-TSK-0389 (destructive git ops), 0390 (Claude Code adapter), 0391 (kj doctor wiring).

## Test plan
- [x] `npx vitest run` from `packages/ai-trash/` (3 tests pass: import surface, bin entry, license/engines)
- [x] `bin/kj-trash.js` is executable and exits 70 with the "not implemented" banner
- [x] Root commitlint + pre-commit hooks pass
- [ ] CI green