### PR TITLE
feat(ai-trash): ULID generator (KJC-TSK-0388)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -13,3 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   private bin `kj-trash`), README with roadmap, `bin/kj-trash.js` stub that
   prints a "not implemented yet" banner, `src/index.js` placeholder, smoke
   test confirming the package can be required and lists its `kj-trash` bin.
+- Self-contained Crockford-base32 ULID generator (`src/ulid.js`,
+  KJC-TSK-0388 commit 2a): time-prefix gives lexicographic sortability and
+  the 80-bit random suffix is bumped by one within the same millisecond so
+  two back-to-back snapshots keep a stable order. No runtime dep — fewer
+  transitive surfaces under the trash store. `decodeTimeFromUlid` rebuilds
+  the timestamp for diagnostics.

--- a/packages/ai-trash/src/ulid.js
+++ b/packages/ai-trash/src/ulid.js
@@ -1,0 +1,66 @@
+// Tiny ULID generator (Crockford base32, 26 chars, monotonic within ms).
+// We keep this self-contained to avoid pulling a runtime dep into the
+// safety-net package — fewer transitive deps = fewer supply-chain surfaces
+// that an attacker could pivot through to reach the trash store.
+
+import { randomBytes } from "node:crypto";
+
+const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+let lastMs = 0;
+let lastRandom = new Uint8Array(10);
+
+function encodeTime(ms) {
+  let out = "";
+  for (let i = 9; i >= 0; i--) {
+    out = ENCODING[ms % 32] + out;
+    ms = Math.floor(ms / 32);
+  }
+  return out;
+}
+
+function encodeRandom(bytes) {
+  let out = "";
+  for (let i = 0; i < 16; i++) {
+    const byteIndex = Math.floor((i * 5) / 8);
+    const bitOffset = (i * 5) % 8;
+    const hi = bytes[byteIndex] ?? 0;
+    const lo = bytes[byteIndex + 1] ?? 0;
+    const value = ((hi << 8) | lo) >> (11 - bitOffset);
+    out += ENCODING[value & 31];
+  }
+  return out;
+}
+
+function bumpRandom(buf) {
+  for (let i = buf.length - 1; i >= 0; i--) {
+    if (buf[i] === 0xff) {
+      buf[i] = 0;
+      continue;
+    }
+    buf[i] += 1;
+    return buf;
+  }
+  throw new Error("ulid: random overflow within the same millisecond");
+}
+
+export function ulid(nowMs = Date.now()) {
+  if (nowMs === lastMs) {
+    lastRandom = bumpRandom(lastRandom);
+  } else {
+    lastMs = nowMs;
+    lastRandom = new Uint8Array(randomBytes(10));
+  }
+  return encodeTime(nowMs) + encodeRandom(lastRandom);
+}
+
+export function decodeTimeFromUlid(id) {
+  const slice = id.slice(0, 10);
+  let ms = 0;
+  for (const ch of slice) {
+    const v = ENCODING.indexOf(ch);
+    if (v < 0) throw new Error(`ulid: invalid char ${ch}`);
+    ms = ms * 32 + v;
+  }
+  return ms;
+}

--- a/packages/ai-trash/tests/ulid.test.js
+++ b/packages/ai-trash/tests/ulid.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+
+import { ulid, decodeTimeFromUlid } from "../src/ulid.js";
+
+describe("ulid", () => {
+  it("produces lexicographically ordered ids in time order", () => {
+    const a = ulid(1_000_000);
+    const b = ulid(1_000_000 + 5);
+    expect(b > a).toBe(true);
+    expect(decodeTimeFromUlid(a)).toBe(1_000_000);
+    expect(decodeTimeFromUlid(b)).toBe(1_000_005);
+  });
+
+  it("stays monotonic within the same millisecond", () => {
+    const a = ulid(2_000_000);
+    const b = ulid(2_000_000);
+    expect(b > a).toBe(true);
+  });
+
+  it("emits 26-character Crockford base32 ids", () => {
+    const id = ulid(1_500_000);
+    expect(id).toHaveLength(26);
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it("rejects invalid characters in decodeTimeFromUlid", () => {
+    expect(() => decodeTimeFromUlid("ILOU0000000000000000000000")).toThrow(
+      /invalid char/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Commit 2a of **KJC-TSK-0388** (`@karajan/ai-trash` MVP, epic KJC-PCS-0041). Split from the original commit 2 to fit the 200-LOC per-PR budget — the manifest record-keeping layer lands in commit 2b right after this merges.

- `src/ulid.js` — self-contained Crockford-base32 ULID. Time prefix (10 chars) gives lexicographic sortability; 80-bit random suffix is bumped by one within the same millisecond so two back-to-back snapshots keep a stable order. `decodeTimeFromUlid` rebuilds the timestamp for diagnostics.
- `tests/ulid.test.js` — 4 cases: lexicographic ordering across ms, monotonic-within-ms, 26-char Crockford emit, invalid-char rejection.

Net delta: 103 LOC across 3 files (66 src + 31 tests + 6 changelog).

## Test plan

- [x] `cd packages/ai-trash && npx vitest run` — 7/7 green locally (4 ulid + 3 smoke).
- [ ] CI workspace tests green.
- [ ] Shrink-budget gate green (103 < 200).
- [ ] commitlint green.