### PR TITLE
feat(ai-trash): manifest record-keeping (TTL + LRU) (KJC-TSK-0388)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -19,3 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   two back-to-back snapshots keep a stable order. No runtime dep — fewer
   transitive surfaces under the trash store. `decodeTimeFromUlid` rebuilds
   the timestamp for diagnostics.
+- Manifest record-keeping primitives (`src/manifest.js`, KJC-TSK-0388
+  commit 2b): atomic load/save (tmp + rename, `0o600` mode, schemaVersion
+  gate), `addEntry`/`listEntries`/`removeEntry` CRUD, TTL drop via
+  `expireBefore`, and byte-budget LRU eviction via `enforceLruQuota`.
+  Real filesystem snapshots still land in commit 4.

--- a/packages/ai-trash/src/manifest.js
+++ b/packages/ai-trash/src/manifest.js
@@ -1,0 +1,91 @@
+import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
+import { ulid } from "./ulid.js";
+
+export const SCHEMA_VERSION = 1;
+
+export async function loadManifest(rootDir) {
+  const file = join(rootDir, "manifest.json");
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed?.schemaVersion !== SCHEMA_VERSION) {
+      throw new Error(`ai-trash: unsupported manifest schemaVersion ${parsed?.schemaVersion}`);
+    }
+    if (!Array.isArray(parsed.entries)) parsed.entries = [];
+    return parsed;
+  } catch (err) {
+    if (err.code === "ENOENT") return { schemaVersion: SCHEMA_VERSION, entries: [] };
+    throw err;
+  }
+}
+
+export async function saveManifest(rootDir, manifest) {
+  const file = join(rootDir, "manifest.json");
+  await fs.mkdir(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(manifest, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await fs.rename(tmp, file);
+}
+
+export function addEntry(manifest, partial) {
+  if (!partial?.sourcePath) throw new Error("ai-trash: sourcePath required");
+  if (typeof partial.sizeBytes !== "number" || partial.sizeBytes < 0) {
+    throw new Error("ai-trash: sizeBytes must be a non-negative number");
+  }
+  const now = Date.now();
+  const entry = {
+    id: ulid(now),
+    createdAt: now,
+    sourcePath: partial.sourcePath,
+    snapshotPath: partial.snapshotPath ?? null,
+    sizeBytes: partial.sizeBytes,
+    command: partial.command ?? null,
+    origin: partial.origin ?? "unknown",
+  };
+  manifest.entries.push(entry);
+  return entry;
+}
+
+export function listEntries(manifest) {
+  return [...manifest.entries].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function removeEntry(manifest, id) {
+  const idx = manifest.entries.findIndex((e) => e.id === id);
+  if (idx < 0) return null;
+  return manifest.entries.splice(idx, 1)[0];
+}
+
+export function expireBefore(manifest, cutoffMs) {
+  const expired = [];
+  manifest.entries = manifest.entries.filter((e) => {
+    if (e.createdAt < cutoffMs) {
+      expired.push(e);
+      return false;
+    }
+    return true;
+  });
+  return expired;
+}
+
+export function enforceLruQuota(manifest, maxBytes) {
+  if (typeof maxBytes !== "number" || maxBytes < 0) {
+    throw new Error("ai-trash: maxBytes must be a non-negative number");
+  }
+  const sorted = listEntries(manifest);
+  const total = sorted.reduce((sum, e) => sum + e.sizeBytes, 0);
+  const evicted = [];
+  let running = total;
+  for (const entry of sorted) {
+    if (running <= maxBytes) break;
+    evicted.push(entry);
+    running -= entry.sizeBytes;
+  }
+  const evictedIds = new Set(evicted.map((e) => e.id));
+  manifest.entries = manifest.entries.filter((e) => !evictedIds.has(e.id));
+  return evicted;
+}

--- a/packages/ai-trash/tests/manifest.test.js
+++ b/packages/ai-trash/tests/manifest.test.js
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import {
+  loadManifest,
+  saveManifest,
+  addEntry,
+  listEntries,
+  removeEntry,
+  expireBefore,
+  enforceLruQuota,
+  SCHEMA_VERSION,
+} from "../src/manifest.js";
+
+async function tmpRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-"));
+}
+
+describe("manifest persistence", () => {
+  it("returns an empty manifest when the file does not exist", async () => {
+    const root = await tmpRoot();
+    const m = await loadManifest(root);
+    expect(m.schemaVersion).toBe(SCHEMA_VERSION);
+    expect(m.entries).toEqual([]);
+  });
+
+  it("round-trips entries via save + load", async () => {
+    const root = await tmpRoot();
+    const m = await loadManifest(root);
+    addEntry(m, { sourcePath: "/tmp/a.txt", sizeBytes: 12, command: "rm -rf /tmp/a.txt" });
+    addEntry(m, { sourcePath: "/tmp/b.txt", sizeBytes: 8 });
+    await saveManifest(root, m);
+    const reloaded = await loadManifest(root);
+    expect(reloaded.entries).toHaveLength(2);
+    expect(reloaded.entries[0].sourcePath).toBe("/tmp/a.txt");
+    expect(reloaded.entries[0].command).toBe("rm -rf /tmp/a.txt");
+    expect(reloaded.entries[1].origin).toBe("unknown");
+  });
+
+  it("writes the manifest with 0o600 permissions", async () => {
+    const root = await tmpRoot();
+    const m = await loadManifest(root);
+    addEntry(m, { sourcePath: "/tmp/c.txt", sizeBytes: 1 });
+    await saveManifest(root, m);
+    const info = await stat(join(root, "manifest.json"));
+    expect(info.mode & 0o777).toBe(0o600);
+    const raw = await readFile(join(root, "manifest.json"), "utf8");
+    expect(JSON.parse(raw).schemaVersion).toBe(SCHEMA_VERSION);
+  });
+
+  it("rejects invalid entries", () => {
+    const m = { schemaVersion: SCHEMA_VERSION, entries: [] };
+    expect(() => addEntry(m, { sizeBytes: 1 })).toThrow(/sourcePath/);
+    expect(() => addEntry(m, { sourcePath: "/x", sizeBytes: -1 })).toThrow(/sizeBytes/);
+  });
+});
+
+describe("listEntries / removeEntry", () => {
+  it("lists by ulid and removes by id (or returns null)", () => {
+    const m = { schemaVersion: SCHEMA_VERSION, entries: [] };
+    const a = addEntry(m, { sourcePath: "/x/a", sizeBytes: 1 });
+    const b = addEntry(m, { sourcePath: "/x/b", sizeBytes: 1 });
+    expect(listEntries(m).map((e) => e.id)).toEqual([a.id, b.id]);
+    expect(removeEntry(m, a.id).id).toBe(a.id);
+    expect(m.entries).toHaveLength(1);
+    expect(removeEntry(m, "ZZZ")).toBeNull();
+  });
+});
+
+describe("expireBefore", () => {
+  it("drops entries older than the cutoff", () => {
+    const m = { schemaVersion: SCHEMA_VERSION, entries: [] };
+    const old = addEntry(m, { sourcePath: "/x/old", sizeBytes: 1 });
+    old.createdAt = 1_000;
+    const fresh = addEntry(m, { sourcePath: "/x/new", sizeBytes: 1 });
+    fresh.createdAt = 10_000;
+    const expired = expireBefore(m, 5_000);
+    expect(expired.map((e) => e.id)).toEqual([old.id]);
+    expect(m.entries.map((e) => e.id)).toEqual([fresh.id]);
+  });
+});
+
+describe("enforceLruQuota", () => {
+  it("evicts the oldest entries until the byte budget is met", () => {
+    const m = { schemaVersion: SCHEMA_VERSION, entries: [] };
+    const a = addEntry(m, { sourcePath: "/x/a", sizeBytes: 100 });
+    const b = addEntry(m, { sourcePath: "/x/b", sizeBytes: 100 });
+    const c = addEntry(m, { sourcePath: "/x/c", sizeBytes: 100 });
+    expect(enforceLruQuota(m, 150).map((e) => e.id)).toEqual([a.id, b.id]);
+    expect(m.entries.map((e) => e.id)).toEqual([c.id]);
+  });
+
+  it("evicts nothing under quota and rejects negative quota", () => {
+    const m = { schemaVersion: SCHEMA_VERSION, entries: [] };
+    addEntry(m, { sourcePath: "/x/a", sizeBytes: 50 });
+    expect(enforceLruQuota(m, 1000)).toEqual([]);
+    expect(() => enforceLruQuota(m, -1)).toThrow(/maxBytes/);
+  });
+});


### PR DESCRIPTION
## Summary

Commit 2b of **KJC-TSK-0388** (`@karajan/ai-trash` MVP, epic KJC-PCS-0041). Lands the manifest record-keeping layer on top of the ULID generator that shipped in #999. Real filesystem snapshots still land in commit 4.

- `src/manifest.js` — `loadManifest` / `saveManifest` (atomic tmp + rename, mode `0o600`, `schemaVersion` gate), `addEntry` (validates `sourcePath` + non-negative `sizeBytes`, stamps `id` + `createdAt` + `origin`), `listEntries` (sorted by ULID), `removeEntry` (splice by id), `expireBefore` (TTL drop), `enforceLruQuota` (byte-budget LRU eviction).
- `tests/manifest.test.js` — 8 cases covering empty-default load, round-trip persistence, `0o600` file mode, entry validation, CRUD, TTL drop, LRU eviction, and negative-quota rejection.

Net delta: 197 LOC across 3 files (under the 200 budget).

## Test plan

- [x] `cd packages/ai-trash && npx vitest run` — 15/15 green locally (8 manifest + 4 ulid + 3 smoke).
- [ ] CI workspace tests green.
- [ ] Shrink-budget gate green (197 < 200).
- [ ] commitlint green.