### PR TITLE
feat(ai-trash): filesystem snapshotter (KJC-TSK-0388)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -29,3 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `<root>/log.jsonl` with `$HOME` redaction on path-shaped fields,
   `ensureSecureDir` (chmod 0o700), `lockdownFile` (chmod 0o600), and
   `assertOwnedByCurrentUser` to detect a hijacked root directory.
+- Filesystem snapshotter (`src/snapshot.js`, KJC-TSK-0388 commit 4):
+  `snapshotFile` copies the source into `<root>/store/<ulid>/<basename>`
+  with 0o600 mode, returns a manifest-ready entry, and audits the event.
+  `restoreSnapshot` refuses to clobber an existing path. `purgeSnapshot`
+  removes the snapshot dir and audits the eviction. Directories are out
+  of scope for the MVP — file-only.

--- a/packages/ai-trash/src/snapshot.js
+++ b/packages/ai-trash/src/snapshot.js
@@ -1,0 +1,66 @@
+import { promises as fs } from "node:fs";
+import { basename, join } from "node:path";
+import { ulid } from "./ulid.js";
+import { ensureSecureDir, lockdownFile } from "./permissions.js";
+import { appendLogEntry } from "./logger.js";
+
+async function statOrNull(path) {
+  try {
+    return await fs.lstat(path);
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+export async function snapshotFile(rootDir, sourcePath, options = {}) {
+  const stat = await statOrNull(sourcePath);
+  if (!stat) throw new Error(`ai-trash: source not found: ${sourcePath}`);
+  if (stat.isDirectory()) {
+    throw new Error("ai-trash: directory snapshots not implemented in MVP");
+  }
+  const id = ulid();
+  const storeDir = join(rootDir, "store", id);
+  await ensureSecureDir(storeDir);
+  const snapshotPath = join(storeDir, basename(sourcePath));
+  await fs.copyFile(sourcePath, snapshotPath);
+  await lockdownFile(snapshotPath);
+  const entry = {
+    id,
+    createdAt: Date.now(),
+    sourcePath,
+    snapshotPath,
+    sizeBytes: stat.size,
+    command: options.command ?? null,
+    origin: options.origin ?? "unknown",
+  };
+  await appendLogEntry(rootDir, "snapshot.create", {
+    id,
+    sourcePath,
+    snapshotPath,
+    sizeBytes: stat.size,
+  });
+  return entry;
+}
+
+export async function restoreSnapshot(rootDir, entry, targetPath) {
+  const target = targetPath ?? entry.sourcePath;
+  const exists = await statOrNull(target);
+  if (exists) throw new Error(`ai-trash: refusing to overwrite ${target}`);
+  await fs.mkdir(join(target, ".."), { recursive: true });
+  await fs.copyFile(entry.snapshotPath, target);
+  await appendLogEntry(rootDir, "snapshot.restore", {
+    id: entry.id,
+    snapshotPath: entry.snapshotPath,
+    targetPath: target,
+  });
+  return target;
+}
+
+export async function purgeSnapshot(rootDir, entry) {
+  await fs.rm(join(rootDir, "store", entry.id), { recursive: true, force: true });
+  await appendLogEntry(rootDir, "snapshot.purge", {
+    id: entry.id,
+    sizeBytes: entry.sizeBytes,
+  });
+}

--- a/packages/ai-trash/tests/snapshot.test.js
+++ b/packages/ai-trash/tests/snapshot.test.js
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { snapshotFile, restoreSnapshot, purgeSnapshot } from "../src/snapshot.js";
+import { readLog } from "../src/logger.js";
+import { FILE_MODE } from "../src/permissions.js";
+
+async function tmpRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-snap-"));
+}
+
+async function writeSource(content = "hello") {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-src-"));
+  const file = join(dir, "note.txt");
+  await writeFile(file, content);
+  return file;
+}
+
+describe("snapshotFile", () => {
+  it("copies source into <root>/store/<ulid>/ with 0o600 mode and logs the event", async () => {
+    const root = await tmpRoot();
+    const src = await writeSource("contents");
+    const entry = await snapshotFile(root, src, { command: "rm note.txt", origin: "claude" });
+    expect(entry.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(entry.sourcePath).toBe(src);
+    expect(entry.snapshotPath).toBe(join(root, "store", entry.id, "note.txt"));
+    expect(entry.sizeBytes).toBe(8);
+    expect(entry.command).toBe("rm note.txt");
+    expect(entry.origin).toBe("claude");
+    const copy = await readFile(entry.snapshotPath, "utf8");
+    expect(copy).toBe("contents");
+    const info = await stat(entry.snapshotPath);
+    expect(info.mode & 0o777).toBe(FILE_MODE);
+    const log = await readLog(root);
+    expect(log).toHaveLength(1);
+    expect(log[0].event).toBe("snapshot.create");
+    expect(log[0].id).toBe(entry.id);
+  });
+
+  it("rejects when the source is missing", async () => {
+    const root = await tmpRoot();
+    await expect(snapshotFile(root, "/no/such/file")).rejects.toThrow(/source not found/);
+  });
+
+  it("rejects directories in the MVP", async () => {
+    const root = await tmpRoot();
+    const dir = await mkdtemp(join(tmpdir(), "ai-trash-dir-"));
+    await expect(snapshotFile(root, dir)).rejects.toThrow(/directory snapshots/);
+  });
+});
+
+describe("restoreSnapshot", () => {
+  it("restores to the original path and logs the event", async () => {
+    const root = await tmpRoot();
+    const src = await writeSource("payload");
+    const entry = await snapshotFile(root, src);
+    await writeFile(src, "deleted-stub"); // simulate that something else exists
+    await expect(restoreSnapshot(root, entry)).rejects.toThrow(/refusing to overwrite/);
+    const alt = join(dirname(src), "restored.txt");
+    const written = await restoreSnapshot(root, entry, alt);
+    expect(written).toBe(alt);
+    expect(await readFile(alt, "utf8")).toBe("payload");
+    const log = await readLog(root);
+    expect(log.map((l) => l.event)).toEqual(["snapshot.create", "snapshot.restore"]);
+  });
+});
+
+describe("purgeSnapshot", () => {
+  it("removes the store dir and logs the purge", async () => {
+    const root = await tmpRoot();
+    const src = await writeSource("bye");
+    const entry = await snapshotFile(root, src);
+    await purgeSnapshot(root, entry);
+    await expect(stat(entry.snapshotPath)).rejects.toThrow();
+    const log = await readLog(root);
+    expect(log.map((l) => l.event)).toEqual(["snapshot.create", "snapshot.purge"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Commit 4 of KJC-TSK-0388 (ai-trash MVP).
- `src/snapshot.js`: `snapshotFile` copies source into `<root>/store/<ulid>/<basename>` with 0o600 mode and audits `snapshot.create`; `restoreSnapshot` refuses to clobber; `purgeSnapshot` removes the store dir.
- Directory snapshots out of scope for MVP — file-only.
- 5 new tests, 26 total green in the package.

## Test plan
- [x] `npx vitest run` (26/26 passing locally)
- [ ] CI green
- [ ] Net LOC budget under 200