### PR TITLE
feat(ai-trash): kj-trash list/inspect/restore cli (KJC-TSK-0388)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -35,3 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `restoreSnapshot` refuses to clobber an existing path. `purgeSnapshot`
   removes the snapshot dir and audits the eviction. Directories are out
   of scope for the MVP — file-only.
+- `kj-trash` CLI surface (`src/cli.js` + bin, KJC-TSK-0388 commit 5):
+  subcommands `list` (id/age/bytes/source table), `inspect <id>` (JSON
+  payload), and `restore <id> [--to PATH]` (atomic restore + manifest
+  drop). Root defaults to `~/.ai-trash` (override via `AI_TRASH_ROOT`)
+  and is hardened with `ensureSecureDir` + `assertOwnedByCurrentUser`.
+  `empty`/`purge` land in commit 6.

--- a/packages/ai-trash/bin/kj-trash.js
+++ b/packages/ai-trash/bin/kj-trash.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
-// @karajan/ai-trash — bin entry (skeleton)
-// Subcommands (list/inspect/restore/empty/purge) land in KJC-TSK-0388 commits 5+6.
-// Until then this stub exits non-zero so callers don't mistake an unfinished
-// package for a working safety net.
+import { runCli } from "../src/cli.js";
 
-process.stderr.write(
-  "kj-trash: not implemented yet (KJC-TSK-0388 commits 5+6).\n"
-  + "  See packages/ai-trash/README.md for the roadmap.\n"
+runCli(process.argv.slice(2)).then(
+  (code) => process.exit(code ?? 0),
+  (err) => {
+    process.stderr.write(`kj-trash: ${err?.message ?? err}\n`);
+    process.exit(1);
+  }
 );
-process.exit(70);

--- a/packages/ai-trash/src/cli.js
+++ b/packages/ai-trash/src/cli.js
@@ -1,0 +1,110 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { loadManifest, saveManifest, removeEntry } from "./manifest.js";
+import { restoreSnapshot } from "./snapshot.js";
+import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
+
+export const DEFAULT_ROOT = process.env.AI_TRASH_ROOT || join(homedir(), ".ai-trash");
+
+function parseFlags(argv) {
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const tok = argv[i];
+    if (tok.startsWith("--")) {
+      const eq = tok.indexOf("=");
+      if (eq > -1) flags[tok.slice(2, eq)] = tok.slice(eq + 1);
+      else if (argv[i + 1] && !argv[i + 1].startsWith("--")) flags[tok.slice(2)] = argv[++i];
+      else flags[tok.slice(2)] = true;
+    } else positional.push(tok);
+  }
+  return { positional, flags };
+}
+
+function shortAge(ms) {
+  const sec = Math.max(1, Math.floor(ms / 1000));
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h`;
+  return `${Math.floor(sec / 86400)}d`;
+}
+
+async function ensureRoot(root) {
+  await ensureSecureDir(root);
+  await assertOwnedByCurrentUser(root);
+}
+
+async function cmdList(root, out) {
+  await ensureRoot(root);
+  const m = await loadManifest(root);
+  if (!m.entries.length) {
+    out.write("kj-trash: (empty)\n");
+    return 0;
+  }
+  const now = Date.now();
+  out.write("ID                          AGE   BYTES  SOURCE\n");
+  for (const e of m.entries) {
+    out.write(`${e.id}  ${shortAge(now - e.createdAt).padStart(4)}  ${String(e.sizeBytes).padStart(5)}  ${e.sourcePath}\n`);
+  }
+  return 0;
+}
+
+async function cmdInspect(root, id, out, err) {
+  await ensureRoot(root);
+  const m = await loadManifest(root);
+  const entry = m.entries.find((e) => e.id === id);
+  if (!entry) {
+    err.write(`kj-trash: no entry with id ${id}\n`);
+    return 1;
+  }
+  out.write(`${JSON.stringify(entry, null, 2)}\n`);
+  return 0;
+}
+
+async function cmdRestore(root, id, target, out, err) {
+  await ensureRoot(root);
+  const m = await loadManifest(root);
+  const entry = m.entries.find((e) => e.id === id);
+  if (!entry) {
+    err.write(`kj-trash: no entry with id ${id}\n`);
+    return 1;
+  }
+  const written = await restoreSnapshot(root, entry, target);
+  removeEntry(m, id);
+  await saveManifest(root, m);
+  out.write(`kj-trash: restored ${id} -> ${written}\n`);
+  return 0;
+}
+
+const HELP =
+  "usage: kj-trash <command> [args]\n" +
+  "  list                       list snapshots oldest-first\n" +
+  "  inspect <id>               print snapshot metadata as JSON\n" +
+  "  restore <id> [--to PATH]   restore a snapshot (default: original path)\n" +
+  "env: AI_TRASH_ROOT (default ~/.ai-trash)\n";
+
+export async function runCli(argv, io = {}) {
+  const out = io.out ?? process.stdout;
+  const err = io.err ?? process.stderr;
+  const root = io.root ?? DEFAULT_ROOT;
+  const { positional, flags } = parseFlags(argv);
+  const [cmd, arg1] = positional;
+  switch (cmd) {
+    case "list":
+      return cmdList(root, out);
+    case "inspect":
+      if (!arg1) { err.write("kj-trash: inspect requires <id>\n"); return 2; }
+      return cmdInspect(root, arg1, out, err);
+    case "restore":
+      if (!arg1) { err.write("kj-trash: restore requires <id>\n"); return 2; }
+      return cmdRestore(root, arg1, typeof flags.to === "string" ? flags.to : undefined, out, err);
+    case "help":
+    case "--help":
+    case undefined:
+      out.write(HELP);
+      return cmd ? 0 : 2;
+    default:
+      err.write(`kj-trash: unknown command '${cmd}'\n${HELP}`);
+      return 2;
+  }
+}

--- a/packages/ai-trash/tests/cli.test.js
+++ b/packages/ai-trash/tests/cli.test.js
@@ -1,0 +1,81 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { runCli } from "../src/cli.js";
+import { loadManifest, saveManifest } from "../src/manifest.js";
+import { snapshotFile } from "../src/snapshot.js";
+
+class StringSink {
+  constructor() { this.text = ""; }
+  write(chunk) { this.text += chunk; return true; }
+}
+
+async function makeRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-cli-"));
+}
+
+async function makeSnapshot(root, contents = "data") {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-cli-src-"));
+  const src = join(dir, "file.txt");
+  await writeFile(src, contents);
+  const entry = await snapshotFile(root, src);
+  const m = await loadManifest(root);
+  m.entries.push(entry);
+  await saveManifest(root, m);
+  return { entry, src };
+}
+
+describe("kj-trash CLI", () => {
+  it("list reports (empty) when nothing is stored", async () => {
+    const root = await makeRoot();
+    const out = new StringSink();
+    const code = await runCli(["list"], { out, err: new StringSink(), root });
+    expect(code).toBe(0);
+    expect(out.text).toContain("(empty)");
+  });
+
+  it("list prints stored entries with id and source", async () => {
+    const root = await makeRoot();
+    const { entry, src } = await makeSnapshot(root);
+    const out = new StringSink();
+    const code = await runCli(["list"], { out, err: new StringSink(), root });
+    expect(code).toBe(0);
+    expect(out.text).toContain(entry.id);
+    expect(out.text).toContain(src);
+  });
+
+  it("inspect prints JSON for a known id and 1 for unknown", async () => {
+    const root = await makeRoot();
+    const { entry } = await makeSnapshot(root);
+    const out = new StringSink();
+    const err = new StringSink();
+    expect(await runCli(["inspect", entry.id], { out, err, root })).toBe(0);
+    expect(JSON.parse(out.text).id).toBe(entry.id);
+    out.text = "";
+    expect(await runCli(["inspect", "ZZZ"], { out, err, root })).toBe(1);
+    expect(err.text).toMatch(/no entry/);
+  });
+
+  it("restore drops the entry from the manifest and writes the file", async () => {
+    const root = await makeRoot();
+    const { entry, src } = await makeSnapshot(root);
+    const target = join(dirname(src), "restored.txt");
+    const out = new StringSink();
+    const code = await runCli(["restore", entry.id, "--to", target], {
+      out, err: new StringSink(), root,
+    });
+    expect(code).toBe(0);
+    expect(await readFile(target, "utf8")).toBe("data");
+    const m = await loadManifest(root);
+    expect(m.entries.find((e) => e.id === entry.id)).toBeUndefined();
+  });
+
+  it("no args prints usage with non-zero exit", async () => {
+    const root = await makeRoot();
+    const out = new StringSink();
+    expect(await runCli([], { out, err: new StringSink(), root })).toBe(2);
+    expect(out.text).toContain("usage: kj-trash");
+  });
+});


### PR DESCRIPTION
## Summary
- Commit 5 of KJC-TSK-0388 (ai-trash MVP).
- `src/cli.js` dispatcher + bin: `list`, `inspect <id>`, `restore <id> [--to PATH]`.
- Default root `~/.ai-trash` (override via `AI_TRASH_ROOT`); hardened with `ensureSecureDir` + `assertOwnedByCurrentUser`.
- `empty` / `purge` land in commit 6.
- 5 new tests, 31 total green in the package.

## Test plan
- [x] `npx vitest run` (31/31 passing locally)
- [ ] CI green
- [ ] Net LOC budget under 200