### PR TITLE
feat(ai-trash): kj-trash empty + purge subcommands (KJC-TSK-0388)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -40,4 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   payload), and `restore <id> [--to PATH]` (atomic restore + manifest
   drop). Root defaults to `~/.ai-trash` (override via `AI_TRASH_ROOT`)
   and is hardened with `ensureSecureDir` + `assertOwnedByCurrentUser`.
-  `empty`/`purge` land in commit 6.
+- `kj-trash empty` and `kj-trash purge <id>` (KJC-TSK-0388 commit 6):
+  `purge` removes a single snapshot (store dir + manifest entry);
+  `empty` drops every snapshot by default, with `--older-than-days N`
+  (TTL sweep via `expireBefore`) and `--max-bytes N` (LRU eviction via
+  `enforceLruQuota`) filters. Each removal is audited.

--- a/packages/ai-trash/src/cli.js
+++ b/packages/ai-trash/src/cli.js
@@ -1,7 +1,13 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { loadManifest, saveManifest, removeEntry } from "./manifest.js";
-import { restoreSnapshot } from "./snapshot.js";
+import {
+  loadManifest,
+  saveManifest,
+  removeEntry,
+  expireBefore,
+  enforceLruQuota,
+} from "./manifest.js";
+import { restoreSnapshot, purgeSnapshot } from "./snapshot.js";
 import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
 
 export const DEFAULT_ROOT = process.env.AI_TRASH_ROOT || join(homedir(), ".ai-trash");
@@ -76,11 +82,51 @@ async function cmdRestore(root, id, target, out, err) {
   return 0;
 }
 
+async function cmdPurge(root, id, out, err) {
+  await ensureRoot(root);
+  const m = await loadManifest(root);
+  const entry = m.entries.find((e) => e.id === id);
+  if (!entry) {
+    err.write(`kj-trash: no entry with id ${id}\n`);
+    return 1;
+  }
+  await purgeSnapshot(root, entry);
+  removeEntry(m, id);
+  await saveManifest(root, m);
+  out.write(`kj-trash: purged ${id}\n`);
+  return 0;
+}
+
+async function cmdEmpty(root, flags, out) {
+  await ensureRoot(root);
+  const m = await loadManifest(root);
+  let dropped = [];
+  if (flags["older-than-days"]) {
+    const days = Number(flags["older-than-days"]);
+    if (!Number.isFinite(days) || days < 0) throw new Error("--older-than-days must be >= 0");
+    dropped = expireBefore(m, Date.now() - days * 86400 * 1000);
+  } else if (flags["max-bytes"]) {
+    const max = Number(flags["max-bytes"]);
+    if (!Number.isFinite(max) || max < 0) throw new Error("--max-bytes must be >= 0");
+    dropped = enforceLruQuota(m, max);
+  } else {
+    dropped = m.entries.slice();
+    m.entries = [];
+  }
+  for (const e of dropped) await purgeSnapshot(root, e);
+  await saveManifest(root, m);
+  out.write(`kj-trash: emptied ${dropped.length} snapshot(s)\n`);
+  return 0;
+}
+
 const HELP =
   "usage: kj-trash <command> [args]\n" +
   "  list                       list snapshots oldest-first\n" +
   "  inspect <id>               print snapshot metadata as JSON\n" +
   "  restore <id> [--to PATH]   restore a snapshot (default: original path)\n" +
+  "  purge <id>                 delete a single snapshot\n" +
+  "  empty [--older-than-days N | --max-bytes N]\n" +
+  "                             drop all (or filtered) snapshots\n" +
   "env: AI_TRASH_ROOT (default ~/.ai-trash)\n";
 
 export async function runCli(argv, io = {}) {
@@ -98,6 +144,11 @@ export async function runCli(argv, io = {}) {
     case "restore":
       if (!arg1) { err.write("kj-trash: restore requires <id>\n"); return 2; }
       return cmdRestore(root, arg1, typeof flags.to === "string" ? flags.to : undefined, out, err);
+    case "purge":
+      if (!arg1) { err.write("kj-trash: purge requires <id>\n"); return 2; }
+      return cmdPurge(root, arg1, out, err);
+    case "empty":
+      return cmdEmpty(root, flags, out);
     case "help":
     case "--help":
     case undefined:

--- a/packages/ai-trash/tests/cli-empty-purge.test.js
+++ b/packages/ai-trash/tests/cli-empty-purge.test.js
@@ -1,0 +1,77 @@
+import { mkdtemp, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { runCli } from "../src/cli.js";
+import { loadManifest, saveManifest } from "../src/manifest.js";
+import { snapshotFile } from "../src/snapshot.js";
+
+class StringSink {
+  constructor() { this.text = ""; }
+  write(chunk) { this.text += chunk; return true; }
+}
+
+async function makeRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-cli2-"));
+}
+
+async function recordSnapshot(root, contents = "x") {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-cli2-src-"));
+  const src = join(dir, "f.txt");
+  await writeFile(src, contents);
+  const entry = await snapshotFile(root, src);
+  const m = await loadManifest(root);
+  m.entries.push(entry);
+  await saveManifest(root, m);
+  return entry;
+}
+
+describe("kj-trash purge", () => {
+  it("removes a single entry + its store dir", async () => {
+    const root = await makeRoot();
+    const entry = await recordSnapshot(root);
+    const out = new StringSink();
+    expect(await runCli(["purge", entry.id], { out, err: new StringSink(), root })).toBe(0);
+    expect(out.text).toMatch(/purged/);
+    await expect(stat(entry.snapshotPath)).rejects.toThrow();
+    const m = await loadManifest(root);
+    expect(m.entries).toHaveLength(0);
+  });
+
+  it("returns 1 when the id is unknown", async () => {
+    const root = await makeRoot();
+    const err = new StringSink();
+    expect(await runCli(["purge", "ZZZ"], { out: new StringSink(), err, root })).toBe(1);
+    expect(err.text).toMatch(/no entry/);
+  });
+});
+
+describe("kj-trash empty", () => {
+  it("drops every snapshot when called without filters", async () => {
+    const root = await makeRoot();
+    const a = await recordSnapshot(root, "a");
+    const b = await recordSnapshot(root, "bb");
+    const out = new StringSink();
+    expect(await runCli(["empty"], { out, err: new StringSink(), root })).toBe(0);
+    expect(out.text).toMatch(/emptied 2/);
+    const m = await loadManifest(root);
+    expect(m.entries).toHaveLength(0);
+    await expect(stat(a.snapshotPath)).rejects.toThrow();
+    await expect(stat(b.snapshotPath)).rejects.toThrow();
+  });
+
+  it("respects --max-bytes by evicting oldest until the budget fits", async () => {
+    const root = await makeRoot();
+    const a = await recordSnapshot(root, "x".repeat(100));
+    await recordSnapshot(root, "y".repeat(100));
+    const out = new StringSink();
+    expect(await runCli(["empty", "--max-bytes", "150"], {
+      out, err: new StringSink(), root,
+    })).toBe(0);
+    expect(out.text).toMatch(/emptied 1/);
+    const m = await loadManifest(root);
+    expect(m.entries.find((e) => e.id === a.id)).toBeUndefined();
+    expect(m.entries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Commit 6 of KJC-TSK-0388 (ai-trash MVP) — closes the CLI surface.
- `purge <id>`: drops a single snapshot's store dir + manifest entry.
- `empty`: removes everything by default; `--older-than-days N` runs a TTL sweep (`expireBefore`); `--max-bytes N` enforces LRU eviction (`enforceLruQuota`).
- Each removal is audited via the JSONL log.
- 4 new tests, 35 total green in the package.

## Test plan
- [x] `npx vitest run` (35/35 passing locally)
- [ ] CI green
- [ ] Net LOC budget under 200