### PR TITLE
feat(ai-trash): claude code pretooluse hook subcommand (KJC-TSK-0390)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -46,14 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (TTL sweep via `expireBefore`) and `--max-bytes N` (LRU eviction via
   `enforceLruQuota`) filters. Each removal is audited.
 - Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
-  subcommand, KJC-TSK-0390 commit 2): reads the JSON payload Claude
-  Code writes on stdin, classifies the Bash command via the
-  destructive-parser, and snapshots any existing target paths before
-  replying `{ permissionDecision: "allow", permissionDecisionReason }`.
-  Fail-closed: if `snapshotFile` (or root permissions hardening) throws,
-  the hook replies `"deny"` so Claude never runs a destructive op
-  without a recovery copy. Audited via `hook.allow` / `hook.deny`
-  entries in the JSONL log.
+  subcommand, KJC-TSK-0390 commit 2): reads the JSON payload on stdin,
+  classifies the Bash command, snapshots existing target paths, and
+  replies `{ permissionDecision: "allow" | "deny", reason }`. Fail-closed:
+  if snapshotting throws, the hook denies the op so Claude never
+  destroys without a recovery copy. Each decision is audited as
+  `hook.allow` / `hook.deny` in the JSONL log.
 - Destructive-command parser (`src/destructive-parser.js`,
   KJC-TSK-0390 commit 1): pure classifier the upcoming PreToolUse hook
   feeds Bash commands into. Recognises `rm` / `rm -rf`, `truncate`,

--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -45,6 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `empty` drops every snapshot by default, with `--older-than-days N`
   (TTL sweep via `expireBefore`) and `--max-bytes N` (LRU eviction via
   `enforceLruQuota`) filters. Each removal is audited.
+- Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
+  subcommand, KJC-TSK-0390 commit 2): reads the JSON payload Claude
+  Code writes on stdin, classifies the Bash command via the
+  destructive-parser, and snapshots any existing target paths before
+  replying `{ permissionDecision: "allow", permissionDecisionReason }`.
+  Fail-closed: if `snapshotFile` (or root permissions hardening) throws,
+  the hook replies `"deny"` so Claude never runs a destructive op
+  without a recovery copy. Audited via `hook.allow` / `hook.deny`
+  entries in the JSONL log.
 - Destructive-command parser (`src/destructive-parser.js`,
   KJC-TSK-0390 commit 1): pure classifier the upcoming PreToolUse hook
   feeds Bash commands into. Recognises `rm` / `rm -rf`, `truncate`,

--- a/packages/ai-trash/src/cli.js
+++ b/packages/ai-trash/src/cli.js
@@ -9,6 +9,7 @@ import {
 } from "./manifest.js";
 import { restoreSnapshot, purgeSnapshot } from "./snapshot.js";
 import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
+import { runHook } from "./hook.js";
 
 export const DEFAULT_ROOT = process.env.AI_TRASH_ROOT || join(homedir(), ".ai-trash");
 
@@ -127,6 +128,8 @@ const HELP =
   "  purge <id>                 delete a single snapshot\n" +
   "  empty [--older-than-days N | --max-bytes N]\n" +
   "                             drop all (or filtered) snapshots\n" +
+  "  hook                       Claude Code PreToolUse handler (reads JSON\n" +
+  "                             on stdin, writes decision JSON on stdout)\n" +
   "env: AI_TRASH_ROOT (default ~/.ai-trash)\n";
 
 export async function runCli(argv, io = {}) {
@@ -149,6 +152,8 @@ export async function runCli(argv, io = {}) {
       return cmdPurge(root, arg1, out, err);
     case "empty":
       return cmdEmpty(root, flags, out);
+    case "hook":
+      return runHook({ root, stdin: io.stdin ?? process.stdin, stdout: out });
     case "help":
     case "--help":
     case undefined:

--- a/packages/ai-trash/src/hook.js
+++ b/packages/ai-trash/src/hook.js
@@ -12,13 +12,7 @@ import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
 import { appendLogEntry } from "./logger.js";
 
 function reply(decision, reason) {
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: decision,
-      permissionDecisionReason: reason,
-    },
-  };
+  return { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: decision, permissionDecisionReason: reason } };
 }
 
 async function readJsonStdin(stdin) {
@@ -70,22 +64,13 @@ export async function handleHookPayload(payload, { root, stdin, stdout }) {
       for (const s of snapshots) m.entries.push(s);
       await saveManifest(root, m);
     }
-    await appendLogEntry(root, "hook.allow", {
-      kind: verdict.kind, command, cwd: data.cwd ?? null,
-      snapshotCount: snapshots.length,
-      sessionId: data.session_id ?? null,
-    });
-    const reason = snapshots.length
+    await appendLogEntry(root, "hook.allow", { kind: verdict.kind, command, cwd: data.cwd ?? null, snapshotCount: snapshots.length, sessionId: data.session_id ?? null });
+    return reply("allow", snapshots.length
       ? `ai-trash: snapshotted ${snapshots.length} path(s) before ${verdict.kind}`
-      : `ai-trash: ${verdict.kind} (no existing paths to snapshot)`;
-    return reply("allow", reason);
+      : `ai-trash: ${verdict.kind} (no existing paths to snapshot)`);
   } catch (err) {
-    try {
-      await appendLogEntry(root, "hook.deny", {
-        kind: verdict.kind, command, error: err.message,
-        sessionId: data.session_id ?? null,
-      });
-    } catch { /* root unwritable; deny is still the right answer */ }
+    try { await appendLogEntry(root, "hook.deny", { kind: verdict.kind, command, error: err.message, sessionId: data.session_id ?? null }); }
+    catch { /* root unwritable; deny is still the right answer */ }
     return reply("deny", `ai-trash: snapshot failed (${err.message}); blocking ${verdict.kind}`);
   }
 }

--- a/packages/ai-trash/src/hook.js
+++ b/packages/ai-trash/src/hook.js
@@ -1,0 +1,97 @@
+// Claude Code PreToolUse hook (KJC-TSK-0390 commit 2). Reads the JSON
+// payload from stdin, classifies the Bash command, snapshots target
+// paths, prints the decision JSON on stdout. Fail-closed: if snapshot
+// throws, deny the op so Claude never destroys without a recovery copy.
+
+import { promises as fs } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { classifyCommand } from "./destructive-parser.js";
+import { loadManifest, saveManifest } from "./manifest.js";
+import { snapshotFile } from "./snapshot.js";
+import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
+import { appendLogEntry } from "./logger.js";
+
+function reply(decision, reason) {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+async function readJsonStdin(stdin) {
+  let raw = "";
+  for await (const chunk of stdin) raw += chunk;
+  if (!raw.trim()) return null;
+  return JSON.parse(raw);
+}
+
+async function snapshotExistingPaths(root, paths, cwd, command) {
+  const snapshots = [];
+  for (const p of paths) {
+    const abs = isAbsolute(p) ? p : resolve(cwd ?? process.cwd(), p);
+    try {
+      const stat = await fs.lstat(abs);
+      if (stat.isDirectory()) continue;
+      const entry = await snapshotFile(root, abs, { command, origin: "claude-code" });
+      snapshots.push(entry);
+    } catch (err) {
+      if (err.code === "ENOENT") continue;
+      throw err;
+    }
+  }
+  return snapshots;
+}
+
+export async function handleHookPayload(payload, { root, stdin, stdout }) {
+  const data = payload ?? (await readJsonStdin(stdin));
+  if (!data) return reply("allow", "ai-trash: empty payload, deferring");
+  if (data.hook_event_name !== "PreToolUse") {
+    return reply("allow", `ai-trash: not PreToolUse (${data.hook_event_name})`);
+  }
+  if (data.tool_name !== "Bash") return reply("allow", `ai-trash: tool '${data.tool_name}' not handled`);
+
+  const command = data.tool_input?.command;
+  if (typeof command !== "string" || !command.trim()) {
+    return reply("allow", "ai-trash: empty Bash command");
+  }
+
+  const verdict = classifyCommand(command);
+  if (!verdict.destructive) return reply("allow", `ai-trash: ${verdict.kind} (${verdict.reason})`);
+
+  try {
+    await ensureSecureDir(root);
+    await assertOwnedByCurrentUser(root);
+    const snapshots = await snapshotExistingPaths(root, verdict.paths, data.cwd, command);
+    if (snapshots.length) {
+      const m = await loadManifest(root);
+      for (const s of snapshots) m.entries.push(s);
+      await saveManifest(root, m);
+    }
+    await appendLogEntry(root, "hook.allow", {
+      kind: verdict.kind, command, cwd: data.cwd ?? null,
+      snapshotCount: snapshots.length,
+      sessionId: data.session_id ?? null,
+    });
+    const reason = snapshots.length
+      ? `ai-trash: snapshotted ${snapshots.length} path(s) before ${verdict.kind}`
+      : `ai-trash: ${verdict.kind} (no existing paths to snapshot)`;
+    return reply("allow", reason);
+  } catch (err) {
+    try {
+      await appendLogEntry(root, "hook.deny", {
+        kind: verdict.kind, command, error: err.message,
+        sessionId: data.session_id ?? null,
+      });
+    } catch { /* root unwritable; deny is still the right answer */ }
+    return reply("deny", `ai-trash: snapshot failed (${err.message}); blocking ${verdict.kind}`);
+  }
+}
+
+export async function runHook({ root, stdin = process.stdin, stdout = process.stdout }) {
+  const response = await handleHookPayload(null, { root, stdin, stdout });
+  stdout.write(JSON.stringify(response) + "\n");
+  return 0;
+}

--- a/packages/ai-trash/tests/hook.test.js
+++ b/packages/ai-trash/tests/hook.test.js
@@ -1,7 +1,4 @@
-// PreToolUse hook handler tests (KJC-TSK-0390 commit 2). Drives
-// handleHookPayload with synthetic payloads and asserts the response
-// shape, snapshot side-effects, audit entries, and fail-closed behaviour.
-
+// PreToolUse hook handler tests (KJC-TSK-0390 commit 2).
 import { mkdtemp, readFile, writeFile, lstat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -90,9 +87,7 @@ describe("PreToolUse hook — fail-closed", () => {
     const dir = await mkdtemp(join(tmpdir(), "ai-trash-hook-src-"));
     const file = join(dir, "x.txt");
     await writeFile(file, "data");
-    // Point root at a path that ensureSecureDir cannot create (parent does not exist
-    // and the file segment in the middle of the path makes mkdir -p fail).
-    const bogusRoot = join(file, "nested", "root");
+    const bogusRoot = join(file, "nested", "root"); // file-as-dir → mkdir -p fails
     const res = await handleHookPayload(payload(`rm ${file}`), { root: bogusRoot });
     expect(res.hookSpecificOutput.permissionDecision).toBe("deny");
     expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/snapshot failed/);

--- a/packages/ai-trash/tests/hook.test.js
+++ b/packages/ai-trash/tests/hook.test.js
@@ -1,0 +1,101 @@
+// PreToolUse hook handler tests (KJC-TSK-0390 commit 2). Drives
+// handleHookPayload with synthetic payloads and asserts the response
+// shape, snapshot side-effects, audit entries, and fail-closed behaviour.
+
+import { mkdtemp, readFile, writeFile, lstat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { handleHookPayload } from "../src/hook.js";
+import { loadManifest } from "../src/manifest.js";
+import { readLog } from "../src/logger.js";
+
+async function makeRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-hook-"));
+}
+
+function payload(command, extras = {}) {
+  return {
+    session_id: "sess_test",
+    cwd: extras.cwd ?? process.cwd(),
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command },
+    ...extras,
+  };
+}
+
+describe("PreToolUse hook — pass-through cases", () => {
+  it("allows non-PreToolUse events untouched", async () => {
+    const root = await makeRoot();
+    const res = await handleHookPayload(payload("rm a", { hook_event_name: "PostToolUse" }), { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+  });
+
+  it("allows non-Bash tools untouched", async () => {
+    const root = await makeRoot();
+    const res = await handleHookPayload({
+      hook_event_name: "PreToolUse", tool_name: "Read", tool_input: { file_path: "x" },
+    }, { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/not handled/);
+  });
+
+  it("allows safe Bash commands (ls, npm install)", async () => {
+    const root = await makeRoot();
+    const res = await handleHookPayload(payload("ls -la"), { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+  });
+});
+
+describe("PreToolUse hook — destructive snapshotting", () => {
+  it("snapshots an existing file before rm and registers it in the manifest", async () => {
+    const root = await makeRoot();
+    const dir = await mkdtemp(join(tmpdir(), "ai-trash-hook-src-"));
+    const file = join(dir, "doomed.txt");
+    await writeFile(file, "irreplaceable");
+
+    const res = await handleHookPayload(payload(`rm ${file}`, { cwd: dir }), { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/snapshotted 1 path/);
+
+    const m = await loadManifest(root);
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].sourcePath).toBe(file);
+    expect(await readFile(m.entries[0].snapshotPath, "utf8")).toBe("irreplaceable");
+  });
+
+  it("allows the op even when the destructive command has no paths to snapshot (git reset --hard)", async () => {
+    const root = await makeRoot();
+    const res = await handleHookPayload(payload("git reset --hard HEAD~3"), { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/no existing paths/);
+    const log = await readLog(root);
+    expect(log.at(-1).event).toBe("hook.allow");
+    expect(log.at(-1).kind).toBe("git-reset-hard");
+  });
+
+  it("skips non-existent paths without failing the hook", async () => {
+    const root = await makeRoot();
+    const res = await handleHookPayload(payload("rm -f /tmp/does/not/exist.txt"), { root });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+    const m = await loadManifest(root);
+    expect(m.entries).toHaveLength(0);
+  });
+});
+
+describe("PreToolUse hook — fail-closed", () => {
+  it("denies the op when snapshotting throws (e.g. root not writable)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ai-trash-hook-src-"));
+    const file = join(dir, "x.txt");
+    await writeFile(file, "data");
+    // Point root at a path that ensureSecureDir cannot create (parent does not exist
+    // and the file segment in the middle of the path makes mkdir -p fail).
+    const bogusRoot = join(file, "nested", "root");
+    const res = await handleHookPayload(payload(`rm ${file}`), { root: bogusRoot });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/snapshot failed/);
+    await expect(lstat(file)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- New `kj-trash hook` subcommand implementing the Claude Code PreToolUse contract: reads JSON from stdin, classifies the Bash command, snapshots existing target paths, replies with `{ permissionDecision, permissionDecisionReason }`.
- Fail-closed: if root hardening or `snapshotFile` throws, the hook denies the op so Claude never destroys without a recovery copy.
- Pass-through for safe commands, non-Bash tools, non-PreToolUse events.
- Audit log entries `hook.allow` / `hook.deny` capture kind, command, cwd, snapshot count, session id.

## Files
- `packages/ai-trash/src/hook.js` — `handleHookPayload` + `runHook`
- `packages/ai-trash/src/cli.js` — wires `hook` subcommand
- `packages/ai-trash/tests/hook.test.js` — 7 cases (pass-through, snapshotting, fail-closed)
- `packages/ai-trash/CHANGELOG.md` — Unreleased bullet

## Test plan
- [x] `npx vitest run` in `packages/ai-trash` → 60/60 pass
- [ ] CI green
- [ ] Net delta within shrink-budget (≤200 LOC excluding CHANGELOG)

## Next
Commit 3 of KJC-TSK-0390: `kj-trash install --claude-code` to idempotently patch `~/.claude/settings.json` so adoption is one command.