### PR TITLE
feat(ai-trash): kj-trash install --claude-code (KJC-TSK-0390)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `empty` drops every snapshot by default, with `--older-than-days N`
   (TTL sweep via `expireBefore`) and `--max-bytes N` (LRU eviction via
   `enforceLruQuota`) filters. Each removal is audited.
+- `kj-trash install --claude-code` (`src/install.js`, KJC-TSK-0390
+  commit 3): idempotently patches `~/.claude/settings.json` to register
+  the `kj-trash hook` command under `hooks.PreToolUse[matcher=Bash]`.
+  Preserves unrelated keys and any other PreToolUse matchers / hook
+  entries the user already has. Second run is a no-op.
 - Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
   subcommand, KJC-TSK-0390 commit 2): reads the JSON payload on stdin,
   classifies the Bash command, snapshots existing target paths, and

--- a/packages/ai-trash/src/cli.js
+++ b/packages/ai-trash/src/cli.js
@@ -10,6 +10,7 @@ import {
 import { restoreSnapshot, purgeSnapshot } from "./snapshot.js";
 import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
 import { runHook } from "./hook.js";
+import { installClaudeCodeHook, DEFAULT_SETTINGS_PATH } from "./install.js";
 
 export const DEFAULT_ROOT = process.env.AI_TRASH_ROOT || join(homedir(), ".ai-trash");
 
@@ -130,6 +131,7 @@ const HELP =
   "                             drop all (or filtered) snapshots\n" +
   "  hook                       Claude Code PreToolUse handler (reads JSON\n" +
   "                             on stdin, writes decision JSON on stdout)\n" +
+  "  install --claude-code      patch ~/.claude/settings.json (idempotent)\n" +
   "env: AI_TRASH_ROOT (default ~/.ai-trash)\n";
 
 export async function runCli(argv, io = {}) {
@@ -154,6 +156,13 @@ export async function runCli(argv, io = {}) {
       return cmdEmpty(root, flags, out);
     case "hook":
       return runHook({ root, stdin: io.stdin ?? process.stdin, stdout: out });
+    case "install": {
+      if (!flags["claude-code"]) { err.write("kj-trash: install requires --claude-code\n"); return 2; }
+      const path = typeof flags.settings === "string" ? flags.settings : DEFAULT_SETTINGS_PATH;
+      const res = await installClaudeCodeHook({ path });
+      out.write(`kj-trash: ${res.mutated ? "installed" : "already installed"} -> ${res.path}\n`);
+      return 0;
+    }
     case "help":
     case "--help":
     case undefined:

--- a/packages/ai-trash/src/install.js
+++ b/packages/ai-trash/src/install.js
@@ -1,0 +1,52 @@
+// Claude Code settings patcher (KJC-TSK-0390 commit 3). Idempotently
+// adds a PreToolUse hook entry that pipes Bash commands through
+// `kj-trash hook`. Preserves any unrelated keys and existing hooks so
+// the user's other settings are untouched.
+
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DEFAULT_SETTINGS_PATH = join(homedir(), ".claude", "settings.json");
+export const HOOK_COMMAND = "kj-trash hook";
+const MATCHER = "Bash";
+
+async function readSettings(path) {
+  try {
+    return JSON.parse(await fs.readFile(path, "utf8"));
+  } catch (err) {
+    if (err.code === "ENOENT") return {};
+    throw err;
+  }
+}
+
+function hasHookCommand(matcherEntry, command) {
+  return (matcherEntry.hooks ?? []).some((h) => h.type === "command" && h.command === command);
+}
+
+export function patchSettings(settings, command = HOOK_COMMAND, matcher = MATCHER) {
+  const next = { ...settings };
+  next.hooks = { ...(next.hooks ?? {}) };
+  const preToolUse = Array.isArray(next.hooks.PreToolUse) ? next.hooks.PreToolUse.slice() : [];
+  let entry = preToolUse.find((e) => e.matcher === matcher);
+  let mutated = false;
+  if (!entry) {
+    entry = { matcher, hooks: [{ type: "command", command }] };
+    preToolUse.push(entry);
+    mutated = true;
+  } else if (!hasHookCommand(entry, command)) {
+    entry.hooks = [...(entry.hooks ?? []), { type: "command", command }];
+    mutated = true;
+  }
+  next.hooks.PreToolUse = preToolUse;
+  return { settings: next, mutated };
+}
+
+export async function installClaudeCodeHook({ path = DEFAULT_SETTINGS_PATH, command = HOOK_COMMAND } = {}) {
+  const settings = await readSettings(path);
+  const { settings: next, mutated } = patchSettings(settings, command);
+  if (!mutated) return { path, mutated: false };
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.writeFile(path, JSON.stringify(next, null, 2) + "\n", { encoding: "utf8" });
+  return { path, mutated: true };
+}

--- a/packages/ai-trash/tests/install.test.js
+++ b/packages/ai-trash/tests/install.test.js
@@ -1,0 +1,79 @@
+// install --claude-code tests (KJC-TSK-0390 commit 3).
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { installClaudeCodeHook, patchSettings, HOOK_COMMAND } from "../src/install.js";
+
+async function makeSettings(initial) {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-install-"));
+  const path = join(dir, "settings.json");
+  if (initial !== undefined) await writeFile(path, JSON.stringify(initial, null, 2), "utf8");
+  return path;
+}
+
+describe("patchSettings (pure)", () => {
+  it("adds PreToolUse + Bash matcher when hooks is missing", () => {
+    const { settings, mutated } = patchSettings({ theme: "dark" });
+    expect(mutated).toBe(true);
+    expect(settings.theme).toBe("dark");
+    expect(settings.hooks.PreToolUse).toEqual([
+      { matcher: "Bash", hooks: [{ type: "command", command: HOOK_COMMAND }] },
+    ]);
+  });
+
+  it("appends to existing Bash matcher without dropping siblings", () => {
+    const initial = {
+      hooks: {
+        PreToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: "other-tool" }] },
+          { matcher: "Read", hooks: [{ type: "command", command: "x" }] },
+        ],
+      },
+    };
+    const { settings, mutated } = patchSettings(initial);
+    expect(mutated).toBe(true);
+    const bash = settings.hooks.PreToolUse.find((e) => e.matcher === "Bash");
+    expect(bash.hooks).toHaveLength(2);
+    expect(bash.hooks.at(-1).command).toBe(HOOK_COMMAND);
+    const read = settings.hooks.PreToolUse.find((e) => e.matcher === "Read");
+    expect(read.hooks[0].command).toBe("x");
+  });
+
+  it("is idempotent when the kj-trash hook already exists", () => {
+    const initial = {
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: HOOK_COMMAND }] }],
+      },
+    };
+    const { mutated } = patchSettings(initial);
+    expect(mutated).toBe(false);
+  });
+});
+
+describe("installClaudeCodeHook (filesystem)", () => {
+  it("creates settings.json when missing", async () => {
+    const path = await makeSettings();
+    const res = await installClaudeCodeHook({ path });
+    expect(res.mutated).toBe(true);
+    const written = JSON.parse(await readFile(path, "utf8"));
+    expect(written.hooks.PreToolUse[0].hooks[0].command).toBe(HOOK_COMMAND);
+  });
+
+  it("preserves other top-level keys when patching", async () => {
+    const path = await makeSettings({ theme: "dark", language: "es" });
+    await installClaudeCodeHook({ path });
+    const written = JSON.parse(await readFile(path, "utf8"));
+    expect(written.theme).toBe("dark");
+    expect(written.language).toBe("es");
+    expect(written.hooks.PreToolUse).toHaveLength(1);
+  });
+
+  it("returns mutated:false on second run (idempotent)", async () => {
+    const path = await makeSettings();
+    await installClaudeCodeHook({ path });
+    const second = await installClaudeCodeHook({ path });
+    expect(second.mutated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Idempotent settings patcher closes the loop for KJC-TSK-0390: users can register the PreToolUse hook with one command instead of editing `~/.claude/settings.json` by hand.

```bash
kj-trash install --claude-code
```

- Reads `~/.claude/settings.json` (creates `{}` if missing).
- Inserts `{ matcher: "Bash", hooks: [{ type: "command", command: "kj-trash hook" }] }` under `hooks.PreToolUse`.
- Preserves unrelated top-level keys and any other matchers / hook entries the user already has.
- Second run detects the existing entry and prints `already installed` without rewriting.

## Files
- `packages/ai-trash/src/install.js` — `patchSettings()` (pure) + `installClaudeCodeHook()` (filesystem)
- `packages/ai-trash/src/cli.js` — new `install --claude-code` subcommand and HELP entry
- `packages/ai-trash/tests/install.test.js` — 6 tests covering pure patcher + filesystem round-trip
- `packages/ai-trash/CHANGELOG.md` — Unreleased bullet

## Test plan
- [x] `npx vitest run` in `packages/ai-trash` → 66/66 pass
- [ ] CI green (net delta ~140 LOC, under 200)

## Closes
KJC-TSK-0390 (3-commit series: parser → hook → install).