### PR TITLE
feat(doctor,init): ai-trash detect + auto-register hook (KJC-TSK-0391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `kj doctor` and `kj init` ai-trash integration (KJC-TSK-0391). Doctor
+  surfaces a WARN when `kj-trash` is missing on PATH (destructive ops
+  unprotected). Init now auto-registers the Claude Code PreToolUse hook via
+  `kj-trash install --claude-code` when the binary is present; opt-out via
+  `--no-ai-trash`. Follows the RTK/Squeezr default-on pattern.
+
 ## [3.1.0] - 2026-06-05
 
 First minor on the v3 line. Bundles five tracks of work landed since v3.0.0:

--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   the `kj-trash hook` command under `hooks.PreToolUse[matcher=Bash]`.
   Preserves unrelated keys and any other PreToolUse matchers / hook
   entries the user already has. Second run is a no-op.
+- `kj doctor` + `kj init` integration (KJC-TSK-0391): doctor surfaces a
+  WARN when `kj-trash` is missing on PATH; init auto-registers the hook
+  via `kj-trash install --claude-code` when the binary is present
+  (opt-out: `--no-ai-trash`). Default-on, paridad RTK/Squeezr.
 - Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
   subcommand, KJC-TSK-0390 commit 2): reads the JSON payload on stdin,
   classifies the Bash command, snapshots existing target paths, and

--- a/src/checks/ai-trash.js
+++ b/src/checks/ai-trash.js
@@ -1,0 +1,34 @@
+/**
+ * ai-trash safety net availability check (KJC-TSK-0391).
+ * Surfaces a WARN in `kj doctor` when the `kj-trash` binary is missing,
+ * since the PreToolUse hook cannot snapshot destructive ops without it.
+ * The remediation is `kj-trash install --claude-code` once the binary is
+ * on PATH (the workspace ships it with karajan-code).
+ */
+
+import { detectAiTrash } from "../utils/ai-trash.js";
+import { STRATEGY } from "./types.js";
+
+function createAiTrashCheck() {
+  return {
+    name: "ai-trash",
+    label: "ai-trash safety net",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      const res = await detectAiTrash();
+      if (res.available) {
+        return { ok: true, severity: "info", detail: "kj-trash present — preventive safety net active" };
+      }
+      return {
+        ok: false,
+        severity: "warn",
+        detail: "kj-trash not found — destructive ops unprotected",
+        fix: "Reinstall karajan-code (kj-trash ships with the workspace) and run `kj-trash install --claude-code`",
+      };
+    },
+  };
+}
+
+export function getAiTrashChecks() {
+  return [createAiTrashCheck()];
+}

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -23,6 +23,7 @@ import { getHarnessScorecardChecks } from "../checks/harness-scorecard.js";
 import { getCiChecks } from "../checks/ci.js";
 import { getRtkChecks } from "../checks/rtk.js";
 import { getSqueezrChecks } from "../checks/squeezr.js";
+import { getAiTrashChecks } from "../checks/ai-trash.js";
 import { getQmdChecks } from "../checks/qmd.js";
 import { getNodeChecks } from "../checks/node.js";
 import { getPortChecks } from "../checks/ports.js";
@@ -67,6 +68,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getCiChecks(),
     ...getRtkChecks(),
     ...getSqueezrChecks(),
+    ...getAiTrashChecks(),
     ...getQmdChecks(),
     ...getProjectChecks({ projectDir }),
   ];

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,6 +17,7 @@ import { detectRtk } from "../utils/rtk-detect.js";
 import { installRtk } from "../utils/rtk-install.js";
 import { detectSqueezr } from "../utils/squeezr-detect.js";
 import { installSqueezr } from "../utils/squeezr-install.js";
+import { detectAiTrash, installAiTrashHook } from "../utils/ai-trash.js";
 import { detectQmd } from "../utils/qmd-detect.js";
 import { installQmd } from "../utils/qmd-install.js";
 import { registerQmdCollections } from "../utils/qmd-collection.js";
@@ -790,6 +791,21 @@ export async function initCommand({ logger, flags = {} }) {
         logger.warn("Squeezr install failed — tool outputs will not be compressed.");
         logger.warn(`  Manual install: ${getInstallCommand("squeezr")}`);
       }
+    }
+  }
+
+  // Check ai-trash availability — register PreToolUse hook if binary present
+  // (opt-out: --no-ai-trash). The binary itself ships with karajan-code.
+  const skipAiTrash = flags?.noAiTrash === true || flags?.aiTrash === false;
+  if (skipAiTrash) {
+    logger.info("ai-trash setup skipped (--no-ai-trash). Destructive ops will run unprotected.");
+  } else {
+    const aiTrash = await detectAiTrash();
+    if (aiTrash.available) {
+      await installAiTrashHook(logger);
+    } else {
+      logger.warn("ai-trash kj-trash binary not found — destructive ops unprotected.");
+      logger.warn("  Reinstall karajan-code so kj-trash is on PATH.");
     }
   }
 

--- a/src/utils/ai-trash.js
+++ b/src/utils/ai-trash.js
@@ -1,0 +1,48 @@
+// ai-trash detection + Claude Code hook install (KJC-TSK-0391).
+// `kj-trash` is the binary shipped by the @karajan/ai-trash workspace.
+// detectAiTrash() probes the binary; installAiTrashHook() invokes
+// `kj-trash install --claude-code`, which idempotently patches
+// ~/.claude/settings.json to register the PreToolUse hook.
+
+import { runCommand } from "./process.js";
+
+/**
+ * @returns {Promise<{ available: boolean, version: string|null }>}
+ */
+export async function detectAiTrash() {
+  try {
+    const res = await runCommand("kj-trash", ["--help"]);
+    if (res.exitCode === 0 || res.exitCode === 2) {
+      return { available: true, version: "0.0.0" };
+    }
+    return { available: false, version: null };
+  } catch {
+    return { available: false, version: null };
+  }
+}
+
+/**
+ * Register the kj-trash PreToolUse hook in ~/.claude/settings.json.
+ * Idempotent: second run reports "already installed" without rewriting.
+ *
+ * @param {object} logger - logger with info/warn methods
+ * @returns {Promise<{ ok: boolean, mutated: boolean, error: string|null }>}
+ */
+export async function installAiTrashHook(logger) {
+  logger.info("Registering ai-trash Claude Code hook...");
+  try {
+    const res = await runCommand("kj-trash", ["install", "--claude-code"], { timeout: 30_000 });
+    if (res.exitCode !== 0) {
+      const error = (res.stderr || "").trim() || `exit code ${res.exitCode}`;
+      logger.warn(`ai-trash hook install failed: ${error}`);
+      return { ok: false, mutated: false, error };
+    }
+    const mutated = !(res.stdout || "").includes("already installed");
+    logger.info(mutated ? "ai-trash hook installed." : "ai-trash hook already installed.");
+    return { ok: true, mutated, error: null };
+  } catch (err) {
+    const error = err.message || String(err);
+    logger.warn(`ai-trash hook install failed: ${error}`);
+    return { ok: false, mutated: false, error };
+  }
+}

--- a/tests/utils/ai-trash.test.js
+++ b/tests/utils/ai-trash.test.js
@@ -1,0 +1,66 @@
+// detectAiTrash + installAiTrashHook tests (KJC-TSK-0391).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/utils/process.js", () => ({ runCommand: vi.fn() }));
+
+import { runCommand } from "../../src/utils/process.js";
+import { detectAiTrash, installAiTrashHook } from "../../src/utils/ai-trash.js";
+
+function silentLogger() {
+  return { info: vi.fn(), warn: vi.fn() };
+}
+
+describe("detectAiTrash", () => {
+  beforeEach(() => runCommand.mockReset());
+
+  it("returns available when kj-trash --help exits 0", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "usage: kj-trash ...", stderr: "" });
+    const res = await detectAiTrash();
+    expect(res.available).toBe(true);
+  });
+
+  it("returns available when kj-trash --help exits 2 (help-as-error idiom)", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 2, stdout: "", stderr: "" });
+    const res = await detectAiTrash();
+    expect(res.available).toBe(true);
+  });
+
+  it("returns unavailable when runCommand rejects (binary not on PATH)", async () => {
+    runCommand.mockRejectedValueOnce(new Error("ENOENT"));
+    const res = await detectAiTrash();
+    expect(res.available).toBe(false);
+    expect(res.version).toBeNull();
+  });
+});
+
+describe("installAiTrashHook", () => {
+  beforeEach(() => runCommand.mockReset());
+
+  it("reports ok+mutated when stdout indicates fresh install", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "kj-trash: installed -> /home/u/.claude/settings.json\n", stderr: "" });
+    const res = await installAiTrashHook(silentLogger());
+    expect(res.ok).toBe(true);
+    expect(res.mutated).toBe(true);
+  });
+
+  it("reports ok+not-mutated when hook already present (idempotent)", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 0, stdout: "kj-trash: already installed -> /home/u/.claude/settings.json\n", stderr: "" });
+    const res = await installAiTrashHook(silentLogger());
+    expect(res.ok).toBe(true);
+    expect(res.mutated).toBe(false);
+  });
+
+  it("reports failure when kj-trash exits non-zero", async () => {
+    runCommand.mockResolvedValueOnce({ exitCode: 2, stdout: "", stderr: "kj-trash: install requires --claude-code\n" });
+    const res = await installAiTrashHook(silentLogger());
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("--claude-code");
+  });
+
+  it("reports failure when runCommand throws (binary missing mid-install)", async () => {
+    runCommand.mockRejectedValueOnce(new Error("ENOENT: kj-trash"));
+    const res = await installAiTrashHook(silentLogger());
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/ENOENT/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes KJC-TSK-0391. Wires the ai-trash safety net into Karajan's onboarding
(`kj init`) and self-check (`kj doctor`) using the same default-on pattern as
RTK and Squeezr.

- `kj doctor` lists a new "ai-trash safety net" check. WARN when `kj-trash` is
  missing on PATH (destructive ops unprotected). INFO with "preventive safety
  net active" when present.
- `kj init` auto-invokes `kj-trash install --claude-code` when the binary is
  present. Idempotent (no-op on subsequent runs). Opt-out via `--no-ai-trash`.
- Combined detect/install utility (`src/utils/ai-trash.js`) so both commands
  share probing logic.

## Files

- `src/utils/ai-trash.js` (new) — detect + installHook helpers.
- `src/checks/ai-trash.js` (new) — doctor check.
- `src/commands/doctor.js` — register check in the buildChecks list.
- `src/commands/init.js` — auto-install branch after the Squeezr block.
- `tests/utils/ai-trash.test.js` (new) — 7 unit tests across all branches.
- `CHANGELOG.md` + `packages/ai-trash/CHANGELOG.md` — Unreleased entry.

## Test plan

- [x] 7/7 new unit tests green (`tests/utils/ai-trash.test.js`).
- [x] Sibling smokes green: `tests/doctor.test.js`,
      `tests/doctor-rtk.test.js`, `tests/doctor-squeezr.test.js`,
      `tests/doctor-qmd.test.js` — 33/33 total.
- [x] `npx eslint` clean on touched files.
- [x] `npx prettier --check` clean.
- [x] Net delta: 178 LOC (under shrink-budget 200).