### PR TITLE
feat(ai-trash): snapshotGitBundle primitive (KJC-TSK-0389)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   WARN when `kj-trash` is missing on PATH; init auto-registers the hook
   via `kj-trash install --claude-code` when the binary is present
   (opt-out: `--no-ai-trash`). Default-on, paridad RTK/Squeezr.
+- `snapshotGitBundle` primitive (`src/git-snapshot.js`, KJC-TSK-0389
+  commit 1): runs `git bundle create --all` against a repo dir, captures
+  refs via `git show-ref --head`, persists the bundle to
+  `<root>/store/<ulid>/repo.bundle` with mode `0o600`, and emits a
+  `snapshot.git-bundle` audit event. The end-to-end test proves a hard
+  reset can recover the lost HEAD via `git fetch <bundle>`. Hook
+  integration lands in commit 2.
 - Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
   subcommand, KJC-TSK-0390 commit 2): reads the JSON payload on stdin,
   classifies the Bash command, snapshots existing target paths, and

--- a/packages/ai-trash/src/git-snapshot.js
+++ b/packages/ai-trash/src/git-snapshot.js
@@ -1,0 +1,87 @@
+// Git snapshot primitive (KJC-TSK-0389 commit 1). Captures the full repo
+// state via `git bundle create --all` before a destructive git op runs so
+// the hook can restore lost commits/refs afterwards. The bundle includes
+// every reachable commit + every ref (branches + tags), letting
+// `git fetch --all <bundle>` rebuild HEAD + ref tips even after a
+// `reset --hard`, `branch -D`, or `push --force`.
+
+import { promises as fs } from "node:fs";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { ulid } from "./ulid.js";
+import { ensureSecureDir, lockdownFile } from "./permissions.js";
+import { appendLogEntry } from "./logger.js";
+
+function runGit(args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b) => (stdout += b.toString("utf8")));
+    child.stderr.on("data", (b) => (stderr += b.toString("utf8")));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function captureRefs(repoDir) {
+  const res = await runGit(["show-ref", "--head"], repoDir);
+  if (res.code !== 0) return [];
+  return res.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, ref] = line.split(/\s+/, 2);
+      return { sha, ref };
+    });
+}
+
+/**
+ * Snapshot the full state of a git repository as a `.bundle` file so the
+ * pre-op refs can be restored after a destructive op. Returns a manifest
+ * entry shaped like `snapshotFile`'s output so the manifest layer can
+ * store both file and git snapshots side by side.
+ *
+ * @param {string} rootDir - ai-trash root (`<root>/store/<id>/repo.bundle`).
+ * @param {string} repoDir - target git repository.
+ * @param {{command?: string, origin?: string, label?: string}} [options]
+ * @returns {Promise<object>} manifest entry with type=`git-bundle`.
+ */
+export async function snapshotGitBundle(rootDir, repoDir, options = {}) {
+  const insideRepo = await runGit(["rev-parse", "--is-inside-work-tree"], repoDir);
+  if (insideRepo.code !== 0 || insideRepo.stdout.trim() !== "true") {
+    throw new Error(`ai-trash: not a git repo: ${repoDir}`);
+  }
+  const id = ulid();
+  const storeDir = join(rootDir, "store", id);
+  await ensureSecureDir(storeDir);
+  const bundlePath = join(storeDir, "repo.bundle");
+  const bundle = await runGit(["bundle", "create", bundlePath, "--all"], repoDir);
+  if (bundle.code !== 0) {
+    throw new Error(`ai-trash: git bundle failed: ${bundle.stderr.trim()}`);
+  }
+  await lockdownFile(bundlePath);
+  const refs = await captureRefs(repoDir);
+  const stat = await fs.stat(bundlePath);
+  const entry = {
+    id,
+    type: "git-bundle",
+    createdAt: Date.now(),
+    sourcePath: repoDir,
+    snapshotPath: bundlePath,
+    sizeBytes: stat.size,
+    refs,
+    command: options.command ?? null,
+    origin: options.origin ?? "unknown",
+    label: options.label ?? null,
+  };
+  await appendLogEntry(rootDir, "snapshot.git-bundle", {
+    id,
+    repoDir,
+    bundlePath,
+    sizeBytes: stat.size,
+    refCount: refs.length,
+  });
+  return entry;
+}

--- a/packages/ai-trash/tests/git-snapshot.test.js
+++ b/packages/ai-trash/tests/git-snapshot.test.js
@@ -1,0 +1,80 @@
+// snapshotGitBundle tests (KJC-TSK-0389 commit 1). Uses a real git repo
+// in a tmpdir to exercise `git bundle create --all` end-to-end.
+import { mkdtemp, writeFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, it, expect } from "vitest";
+
+import { snapshotGitBundle } from "../src/git-snapshot.js";
+import { readLog } from "../src/logger.js";
+import { FILE_MODE } from "../src/permissions.js";
+
+function git(args, cwd) {
+  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (res.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  return res.stdout.trim();
+}
+
+async function tmpRoot() {
+  return mkdtemp(join(tmpdir(), "ai-trash-gitsnap-"));
+}
+
+async function makeRepo() {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-repo-"));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.invalid"], dir);
+  git(["config", "user.name", "Test"], dir);
+  await writeFile(join(dir, "README"), "v1");
+  git(["add", "README"], dir);
+  git(["commit", "-q", "-m", "initial"], dir);
+  return dir;
+}
+
+describe("snapshotGitBundle", () => {
+  it("creates a bundle that re-fetches the original HEAD after a hard reset", async () => {
+    const root = await tmpRoot();
+    const repo = await makeRepo();
+    const headBefore = git(["rev-parse", "HEAD"], repo);
+
+    const entry = await snapshotGitBundle(root, repo, {
+      command: "git reset --hard HEAD~1",
+      origin: "claude",
+    });
+    expect(entry.type).toBe("git-bundle");
+    expect(entry.snapshotPath).toBe(join(root, "store", entry.id, "repo.bundle"));
+    expect(entry.refs.some((r) => r.sha === headBefore)).toBe(true);
+    expect(entry.command).toBe("git reset --hard HEAD~1");
+
+    const info = await stat(entry.snapshotPath);
+    expect(info.mode & 0o777).toBe(FILE_MODE);
+    expect(info.size).toBeGreaterThan(0);
+
+    await writeFile(join(repo, "README"), "v2");
+    git(["add", "README"], repo);
+    git(["commit", "-q", "-m", "second"], repo);
+    git(["reset", "--hard", "HEAD~1"], repo);
+    expect(git(["rev-parse", "HEAD"], repo)).toBe(headBefore);
+
+    const fetched = spawnSync(
+      "git",
+      ["fetch", entry.snapshotPath, "+refs/heads/*:refs/remotes/restore/*"],
+      { cwd: repo, encoding: "utf8" }
+    );
+    expect(fetched.status).toBe(0);
+    const restored = git(["rev-parse", "refs/remotes/restore/main"], repo);
+    expect(restored).toBe(headBefore);
+
+    const log = await readLog(root);
+    expect(log).toHaveLength(1);
+    expect(log[0].event).toBe("snapshot.git-bundle");
+    expect(log[0].id).toBe(entry.id);
+    expect(log[0].refCount).toBe(entry.refs.length);
+  });
+
+  it("rejects when the directory is not a git repo", async () => {
+    const root = await tmpRoot();
+    const notRepo = await mkdtemp(join(tmpdir(), "ai-trash-notrepo-"));
+    await expect(snapshotGitBundle(root, notRepo)).rejects.toThrow(/not a git repo/);
+  });
+});


### PR DESCRIPTION
## Summary

Commit 1/3 of KJC-TSK-0389 (git-destructive ops snapshotter).

Adds `snapshotGitBundle(rootDir, repoDir, options)` to `@karajan/ai-trash`. Before a destructive git op runs, the hook can call this to capture the full repo state as a portable `.bundle` file containing every reachable commit + every ref. After a `reset --hard`, `branch -D`, `clean -f`, or `push --force`, the user can `git fetch <bundle> +refs/heads/*:refs/remotes/restore/*` and rebuild the pre-op state.

The entry uses the same manifest shape as `snapshotFile` (with `type=git-bundle`), so the manifest layer stores file and git snapshots side by side. The bundle file is mode 0o600 and the event is audited as `snapshot.git-bundle` in the JSONL log.

Hook integration lands in commit 2; `kj-trash restore` for bundles lands in commit 3.

## Test plan

- [x] Unit + e2e test in `packages/ai-trash/tests/git-snapshot.test.js`
  - Round-trip: snapshot → second commit → `git reset --hard HEAD~1` → `git fetch <bundle>` recovers the pre-reset HEAD
  - Asserts bundle mode is `0o600` and audit log captured `snapshot.git-bundle`
  - Rejects non-git directories with a clear error
- [x] `npx vitest run tests/git-snapshot.test.js` → 2/2 verdes
- [x] Prettier + ESLint clean