### PR TITLE
feat(ai-trash): hook snapshots git bundle on destructive git ops (KJC-TSK-0389)

### DIFF
--- a/packages/ai-trash/CHANGELOG.md
+++ b/packages/ai-trash/CHANGELOG.md
@@ -61,6 +61,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `snapshot.git-bundle` audit event. The end-to-end test proves a hard
   reset can recover the lost HEAD via `git fetch <bundle>`. Hook
   integration lands in commit 2.
+- Hook wires git destructive ops to `snapshotGitBundle` (KJC-TSK-0389
+  commit 2, `src/hook.js`): when the destructive-parser flags a
+  `git-*` kind (`reset --hard`, `clean -f`, `branch -D`,
+  `push --force`, `checkout -- .`), the PreToolUse hook now captures a
+  full bundle of the cwd repo before letting the op run. If the cwd is
+  not a git repo, the hook allows with a no-op audit entry (the git
+  command would fail anyway). All other bundle errors keep fail-closed
+  behaviour so Claude never destroys refs without a recovery copy.
 - Claude Code PreToolUse hook (`src/hook.js` + `kj-trash hook`
   subcommand, KJC-TSK-0390 commit 2): reads the JSON payload on stdin,
   classifies the Bash command, snapshots existing target paths, and

--- a/packages/ai-trash/src/hook.js
+++ b/packages/ai-trash/src/hook.js
@@ -5,14 +5,22 @@
 
 import { promises as fs } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
+import process from "node:process";
 import { classifyCommand } from "./destructive-parser.js";
 import { loadManifest, saveManifest } from "./manifest.js";
 import { snapshotFile } from "./snapshot.js";
+import { snapshotGitBundle } from "./git-snapshot.js";
 import { ensureSecureDir, assertOwnedByCurrentUser } from "./permissions.js";
 import { appendLogEntry } from "./logger.js";
 
 function reply(decision, reason) {
-  return { hookSpecificOutput: { hookEventName: "PreToolUse", permissionDecision: decision, permissionDecisionReason: reason } };
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: decision,
+      permissionDecisionReason: reason,
+    },
+  };
 }
 
 async function readJsonStdin(stdin) {
@@ -39,13 +47,31 @@ async function snapshotExistingPaths(root, paths, cwd, command) {
   return snapshots;
 }
 
-export async function handleHookPayload(payload, { root, stdin, stdout }) {
+async function snapshotGitRepo(root, cwd, command, kind) {
+  if (!cwd) return { snapshots: [], skipped: "no cwd" };
+  try {
+    const entry = await snapshotGitBundle(root, cwd, {
+      command,
+      origin: "claude-code",
+      label: kind,
+    });
+    return { snapshots: [entry], skipped: null };
+  } catch (err) {
+    if (/not a git repo/.test(err.message)) {
+      return { snapshots: [], skipped: "cwd is not a git repo" };
+    }
+    throw err;
+  }
+}
+
+export async function handleHookPayload(payload, { root, stdin }) {
   const data = payload ?? (await readJsonStdin(stdin));
   if (!data) return reply("allow", "ai-trash: empty payload, deferring");
   if (data.hook_event_name !== "PreToolUse") {
     return reply("allow", `ai-trash: not PreToolUse (${data.hook_event_name})`);
   }
-  if (data.tool_name !== "Bash") return reply("allow", `ai-trash: tool '${data.tool_name}' not handled`);
+  if (data.tool_name !== "Bash")
+    return reply("allow", `ai-trash: tool '${data.tool_name}' not handled`);
 
   const command = data.tool_input?.command;
   if (typeof command !== "string" || !command.trim()) {
@@ -58,19 +84,48 @@ export async function handleHookPayload(payload, { root, stdin, stdout }) {
   try {
     await ensureSecureDir(root);
     await assertOwnedByCurrentUser(root);
-    const snapshots = await snapshotExistingPaths(root, verdict.paths, data.cwd, command);
+    let snapshots = [];
+    let skipped = null;
+    if (verdict.kind.startsWith("git-")) {
+      ({ snapshots, skipped } = await snapshotGitRepo(root, data.cwd, command, verdict.kind));
+    } else {
+      snapshots = await snapshotExistingPaths(root, verdict.paths, data.cwd, command);
+    }
     if (snapshots.length) {
       const m = await loadManifest(root);
       for (const s of snapshots) m.entries.push(s);
       await saveManifest(root, m);
     }
-    await appendLogEntry(root, "hook.allow", { kind: verdict.kind, command, cwd: data.cwd ?? null, snapshotCount: snapshots.length, sessionId: data.session_id ?? null });
-    return reply("allow", snapshots.length
-      ? `ai-trash: snapshotted ${snapshots.length} path(s) before ${verdict.kind}`
-      : `ai-trash: ${verdict.kind} (no existing paths to snapshot)`);
+    await appendLogEntry(root, "hook.allow", {
+      kind: verdict.kind,
+      command,
+      cwd: data.cwd ?? null,
+      snapshotCount: snapshots.length,
+      sessionId: data.session_id ?? null,
+    });
+    if (snapshots.length) {
+      return reply(
+        "allow",
+        `ai-trash: snapshotted ${snapshots.length} ${verdict.kind.startsWith("git-") ? "git bundle" : "path(s)"} before ${verdict.kind}`
+      );
+    }
+    return reply(
+      "allow",
+      skipped
+        ? `ai-trash: ${verdict.kind} (${skipped})`
+        : `ai-trash: ${verdict.kind} (no existing paths to snapshot)`
+    );
   } catch (err) {
-    try { await appendLogEntry(root, "hook.deny", { kind: verdict.kind, command, error: err.message, sessionId: data.session_id ?? null }); }
-    catch { /* root unwritable; deny is still the right answer */ }
+    try {
+      await appendLogEntry(root, "hook.deny", {
+        kind: verdict.kind,
+        command,
+        error: err.message,
+        sessionId: data.session_id ?? null,
+      });
+    } catch {
+      /* root unwritable; deny is still the right answer */
+    }
     return reply("deny", `ai-trash: snapshot failed (${err.message}); blocking ${verdict.kind}`);
   }
 }

--- a/packages/ai-trash/tests/hook.test.js
+++ b/packages/ai-trash/tests/hook.test.js
@@ -1,12 +1,31 @@
 // PreToolUse hook handler tests (KJC-TSK-0390 commit 2).
-import { mkdtemp, readFile, writeFile, lstat } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, lstat, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import process from "node:process";
 import { describe, it, expect } from "vitest";
 
 import { handleHookPayload } from "../src/hook.js";
 import { loadManifest } from "../src/manifest.js";
 import { readLog } from "../src/logger.js";
+
+function git(args, cwd) {
+  const res = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (res.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  return res.stdout.trim();
+}
+
+async function makeGitRepo() {
+  const dir = await mkdtemp(join(tmpdir(), "ai-trash-hook-repo-"));
+  git(["init", "-q", "-b", "main"], dir);
+  git(["config", "user.email", "test@example.invalid"], dir);
+  git(["config", "user.name", "Test"], dir);
+  await writeFile(join(dir, "README"), "v1");
+  git(["add", "README"], dir);
+  git(["commit", "-q", "-m", "initial"], dir);
+  return dir;
+}
 
 async function makeRoot() {
   return mkdtemp(join(tmpdir(), "ai-trash-hook-"));
@@ -26,15 +45,22 @@ function payload(command, extras = {}) {
 describe("PreToolUse hook — pass-through cases", () => {
   it("allows non-PreToolUse events untouched", async () => {
     const root = await makeRoot();
-    const res = await handleHookPayload(payload("rm a", { hook_event_name: "PostToolUse" }), { root });
+    const res = await handleHookPayload(payload("rm a", { hook_event_name: "PostToolUse" }), {
+      root,
+    });
     expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
   });
 
   it("allows non-Bash tools untouched", async () => {
     const root = await makeRoot();
-    const res = await handleHookPayload({
-      hook_event_name: "PreToolUse", tool_name: "Read", tool_input: { file_path: "x" },
-    }, { root });
+    const res = await handleHookPayload(
+      {
+        hook_event_name: "PreToolUse",
+        tool_name: "Read",
+        tool_input: { file_path: "x" },
+      },
+      { root }
+    );
     expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
     expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/not handled/);
   });
@@ -63,14 +89,35 @@ describe("PreToolUse hook — destructive snapshotting", () => {
     expect(await readFile(m.entries[0].snapshotPath, "utf8")).toBe("irreplaceable");
   });
 
-  it("allows the op even when the destructive command has no paths to snapshot (git reset --hard)", async () => {
+  it("allows git destructive ops when cwd is not a git repo (no bundle taken)", async () => {
     const root = await makeRoot();
-    const res = await handleHookPayload(payload("git reset --hard HEAD~3"), { root });
+    const notRepo = await mkdtemp(join(tmpdir(), "ai-trash-hook-notrepo-"));
+    const res = await handleHookPayload(payload("git reset --hard HEAD~3", { cwd: notRepo }), {
+      root,
+    });
     expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
-    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/no existing paths/);
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/not a git repo/);
     const log = await readLog(root);
     expect(log.at(-1).event).toBe("hook.allow");
     expect(log.at(-1).kind).toBe("git-reset-hard");
+    expect(log.at(-1).snapshotCount).toBe(0);
+  });
+
+  it("snapshots a git bundle before git reset --hard when cwd is a repo", async () => {
+    const root = await makeRoot();
+    const repo = await makeGitRepo();
+    const res = await handleHookPayload(payload("git reset --hard HEAD~1", { cwd: repo }), {
+      root,
+    });
+    expect(res.hookSpecificOutput.permissionDecision).toBe("allow");
+    expect(res.hookSpecificOutput.permissionDecisionReason).toMatch(/git bundle/);
+    const m = await loadManifest(root);
+    expect(m.entries).toHaveLength(1);
+    expect(m.entries[0].type).toBe("git-bundle");
+    const info = await stat(m.entries[0].snapshotPath);
+    expect(info.size).toBeGreaterThan(0);
+    const log = await readLog(root);
+    expect(log.some((e) => e.event === "snapshot.git-bundle")).toBe(true);
   });
 
   it("skips non-existent paths without failing the hook", async () => {


### PR DESCRIPTION
## Summary

Commit 2/3 of KJC-TSK-0389. The PreToolUse hook now wires the destructive-parser's `git-*` kinds (`git reset --hard`, `git clean -f`, `git branch -D`, `git push --force`, `git checkout -- .`) to `snapshotGitBundle`, so Claude never loses refs without a recovery copy on disk.

- When `verdict.kind.startsWith("git-")`, the hook bundles the cwd repo via `git bundle create --all` before allowing the op.
- If cwd is not a git repo, the hook allows with a no-op audit entry (the git command would fail anyway).
- Any other bundle failure keeps the existing fail-closed behaviour: deny + audit.

Builds on PR #1011 (commit 1 — `snapshotGitBundle` primitive). Commit 3 (CLI `kj-trash restore` dispatch for git-bundle entries) follows.

## Test plan

- [x] `tests/hook.test.js` updated: non-git cwd → allow + audit "cwd is not a git repo"; real git repo → allow + snapshot.git-bundle entry recorded.
- [x] Full ai-trash suite passes locally (`npm test -w @karajan/ai-trash`).
- [ ] CI green on Node 22.x + 24.x.