### PR TITLE
feat(core): workspace skeleton + extract atomic-write (KJC-TSK-0511)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
-        "packages/ai-trash"
+        "packages/ai-trash",
+        "packages/core"
       ],
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -839,6 +840,10 @@
     },
     "node_modules/@karajan/ai-trash": {
       "resolved": "packages/ai-trash",
+      "link": true
+    },
+    "node_modules/@karajan/core": {
+      "resolved": "packages/core",
       "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -7829,6 +7834,16 @@
       "license": "AGPL-3.0",
       "bin": {
         "kj-trash": "bin/kj-trash.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      }
+    },
+    "packages/core": {
+      "name": "@karajan/core",
+      "version": "0.1.0",
+      "devDependencies": {
+        "vitest": "^4.0.0"
       },
       "engines": {
         "node": ">=22.22.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "node": ">=22.22.1"
   },
   "workspaces": [
-    "packages/ai-trash"
+    "packages/ai-trash",
+    "packages/core"
   ],
   "imports": {
     "#utils/*": "./src/utils/*",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,28 @@
+# @karajan/core
+
+Shared modules for the Karajan Code CLI and `@karajan/hu-board`. Private
+workspace package — not published to npm.
+
+## Scope
+
+`@karajan/core` is the extraction destination for code that both the CLI
+package (`karajan-code`) and the HU Board package (`@karajan/hu-board`)
+need. Today it ships the atomic JSON writer; subsequent commits of
+KJC-TSK-0511 will land the shared paths, port-check, run-registry,
+process runner, plan validation, vector store, and plan/HU ops modules
+here.
+
+## Exports
+
+| Subpath | Module |
+| --- | --- |
+| `@karajan/core/atomic-write` | `writeJsonAtomic`, `writeJsonAtomicSync` |
+
+The root export (`@karajan/core`) re-exports everything via the barrel
+in `src/index.js`, but prefer the subpath form so the bundler can
+tree-shake unused modules.
+
+## Status
+
+KJC-TSK-0511 PR1 — skeleton + first extraction (`atomic-write`). See the
+task card for the full roadmap.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@karajan/core",
+  "version": "0.1.0",
+  "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=22.22.1"
+  },
+  "exports": {
+    "./atomic-write": "./src/atomic-write.js"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/core/src/atomic-write.js
+++ b/packages/core/src/atomic-write.js
@@ -1,0 +1,43 @@
+// Atomic JSON writes for persistent state (resilience audit, Phase 2).
+//
+// A plain `writeFile(path, JSON.stringify(...))` truncates the live file
+// before the new content lands. If the process is killed mid-write
+// (SIGKILL, crash, power loss) the file is left truncated and the only
+// good copy is already gone — the plan / session / standby JSON
+// silently corrupts.
+//
+// write-temp + rename fixes it: `rename` is atomic on the same
+// filesystem, so a reader sees either the old file or the complete new
+// one, never a half-written one. The temp file sits next to the target
+// (same dir → same FS) and is uniquely named so concurrent writers do
+// not clobber each other's temp. A crash before the rename leaves an
+// orphan `.tmp` but never a corrupt target.
+
+import { writeFileSync, renameSync } from "node:fs";
+import { writeFile, rename } from "node:fs/promises";
+
+function tempPath(target) {
+  return `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
+}
+
+/**
+ * Atomically write `obj` as pretty JSON to `target` (synchronous).
+ * @param {string} target - destination path; its directory must exist
+ * @param {unknown} obj
+ */
+export function writeJsonAtomicSync(target, obj) {
+  const tmp = tempPath(target);
+  writeFileSync(tmp, JSON.stringify(obj, null, 2), "utf-8");
+  renameSync(tmp, target);
+}
+
+/**
+ * Atomically write `obj` as pretty JSON to `target` (async).
+ * @param {string} target - destination path; its directory must exist
+ * @param {unknown} obj
+ */
+export async function writeJsonAtomic(target, obj) {
+  const tmp = tempPath(target);
+  await writeFile(tmp, JSON.stringify(obj, null, 2), "utf-8");
+  await rename(tmp, target);
+}

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,0 +1,6 @@
+// Barrel export for @karajan/core. Subpath imports
+// (e.g. `@karajan/core/atomic-write`) are the preferred shape — this
+// barrel only exists so a single `import { writeJsonAtomic } from
+// "@karajan/core"` keeps working for callers that want the whole API.
+
+export * from "./atomic-write.js";

--- a/packages/core/tests/atomic-write.test.js
+++ b/packages/core/tests/atomic-write.test.js
@@ -1,0 +1,30 @@
+// Smoke coverage for the @karajan/core/atomic-write extraction
+// (KJC-TSK-0511 PR1). The full behavioural matrix already lives next to
+// the CLI; this file just proves the new package entry point works
+// end-to-end so a future regression in workspace wiring fails loudly.
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+import { writeJsonAtomic, writeJsonAtomicSync } from "../src/atomic-write.js";
+
+async function tmpDir() {
+  return mkdtemp(join(tmpdir(), "core-atomic-"));
+}
+
+describe("@karajan/core/atomic-write", () => {
+  it("writeJsonAtomic persists pretty JSON and leaves no .tmp", async () => {
+    const dir = await tmpDir();
+    const target = join(dir, "plan.json");
+    await writeJsonAtomic(target, { hu: 42 });
+    expect(await readFile(target, "utf-8")).toBe('{\n  "hu": 42\n}');
+  });
+
+  it("writeJsonAtomicSync persists pretty JSON synchronously", async () => {
+    const dir = await tmpDir();
+    const target = join(dir, "state.json");
+    writeJsonAtomicSync(target, { ok: true });
+    expect(await readFile(target, "utf-8")).toBe('{\n  "ok": true\n}');
+  });
+});

--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -1,0 +1,12 @@
+// Local Vitest config for @karajan/core so the workspace package does
+// not inherit the root config (which excludes `packages/**` and points
+// at a global setup file outside the workspace).
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.js"],
+    environment: "node",
+  },
+});

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -17,7 +17,7 @@
 import { readFileSync, existsSync, readdirSync, mkdirSync, openSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { writeJsonAtomicSync } from '../../../src/utils/atomic-write.js';
+import { writeJsonAtomicSync } from '@karajan/core/atomic-write';
 import { spawn } from 'node:child_process';
 import { trackRun, untrack } from './run-tracker.js';
 import { getHuBoardRunsDir } from './db.js';

--- a/src/utils/atomic-write.js
+++ b/src/utils/atomic-write.js
@@ -1,43 +1,6 @@
-// Atomic JSON writes for persistent state (resilience audit, Phase 2).
-//
-// A plain `writeFile(path, JSON.stringify(...))` truncates the live file
-// before the new content lands. If the process is killed mid-write
-// (SIGKILL, crash, power loss) the file is left truncated and the only
-// good copy is already gone — the plan / session / standby JSON
-// silently corrupts.
-//
-// write-temp + rename fixes it: `rename` is atomic on the same
-// filesystem, so a reader sees either the old file or the complete new
-// one, never a half-written one. The temp file sits next to the target
-// (same dir → same FS) and is uniquely named so concurrent writers do
-// not clobber each other's temp. A crash before the rename leaves an
-// orphan `.tmp` but never a corrupt target.
-
-import { writeFileSync, renameSync } from "node:fs";
-import { writeFile, rename } from "node:fs/promises";
-
-function tempPath(target) {
-  return `${target}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}.tmp`;
-}
-
-/**
- * Atomically write `obj` as pretty JSON to `target` (synchronous).
- * @param {string} target - destination path; its directory must exist
- * @param {unknown} obj
- */
-export function writeJsonAtomicSync(target, obj) {
-  const tmp = tempPath(target);
-  writeFileSync(tmp, JSON.stringify(obj, null, 2), "utf-8");
-  renameSync(tmp, target);
-}
-
-/**
- * Atomically write `obj` as pretty JSON to `target` (async).
- * @param {string} target - destination path; its directory must exist
- * @param {unknown} obj
- */
-export async function writeJsonAtomic(target, obj) {
-  const tmp = tempPath(target);
-  await writeFile(tmp, JSON.stringify(obj, null, 2), "utf-8");
-  await rename(tmp, target);
-}
+// Shim — the real implementation now lives in @karajan/core/atomic-write.
+// Kept here so CLI callers (src/**/*.js) keep importing
+// "#utils/atomic-write.js" without churn during KJC-TSK-0511 (decouple
+// @karajan/hu-board). Will be retired once every consumer migrates to
+// the @karajan/core import.
+export { writeJsonAtomic, writeJsonAtomicSync } from "@karajan/core/atomic-write";


### PR DESCRIPTION
## Summary

PR1 of [KJC-TSK-0511](https://github.com/manufosela/karajan-code/issues) — decoupling `@karajan/hu-board` from the CLI by lifting shared modules into a new private workspace package `@karajan/core`.

This first PR establishes the package skeleton and migrates the smallest, most-isolated module (`atomic-write`) end to end. The remaining 7 shared modules (paths, port-check, run-registry, process, plan-validation, vec-store, plan-hu-ops) land in PRs 2–5 of this task.

### What changed

- **New workspace** `packages/core` (`@karajan/core@0.1.0`, private):
  - `src/atomic-write.js` — full implementation (43 LOC).
  - `src/index.js` — barrel export.
  - `package.json` exports `./atomic-write` subpath.
  - `vitest.config.js` mirrors the ai-trash one so the root config (which excludes `packages/**`) doesn't leak in.
  - `tests/atomic-write.test.js` — smoke coverage so a future workspace-wiring regression fails loudly.
  - `README.md` — scope + roadmap.
- **Root `package.json`** — adds `packages/core` to `workspaces[]` next to `packages/ai-trash`.
- **`src/utils/atomic-write.js`** — becomes a shim that re-exports from `@karajan/core/atomic-write`. The five CLI callers stay untouched.
- **`packages/hu-board/src/plan-mutations.js`** — its single cross-package import switches from `../../../src/utils/atomic-write.js` to `@karajan/core/atomic-write`.

Net delta (excluding lockfile): +147 / −45 across 9 files — comfortably under the 200 LOC PR budget.

### Why a shim

Migrating the 5 CLI callers in this PR would push it over the LOC ceiling and dilute the review. The shim is one line plus header and gets retired in a later PR once every consumer migrates.

## Test plan

- [x] `npx vitest run --root packages/core` — 2 / 2 passing.
- [x] `npx vitest run tests/utils/atomic-write.test.js tests/utils/run-registry.test.js tests/brain/standby-store.test.js tests/plan/plan-store-corrupt.test.js tests/plan/plan-store-kj-home-isolation.test.js tests/plan/plan-store-shared-fallback.test.js` — 41 / 41 passing (atomic-write consumers via shim).
- [x] `npx vitest run --root packages/hu-board tests/plan-mutations.test.js tests/run-single-hu.test.js tests/rename-project.test.js` — 60 / 60 passing (hu-board mutation paths via new import).
- [ ] CI green on PR (linter + full suite).