### PR TITLE
fix(resume): honour --yes in no-TTY mode (KJC-BUG-0081 reopen)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,6 +175,11 @@ export default [
       "src/utils/update-check.js",
       "src/utils/display/**/*.js",
       "src/utils/logger.js",
+      // Shared CLI prompt helper used by run.js + resume.js (KJC-BUG-0081
+      // round 2). Same UX surface as src/commands/**/*.js — was inlined
+      // there until the duplicate copy in resume.js shipped without the
+      // --yes guard. Lives in utils/ now for DRY, keeps the same allow.
+      "src/utils/cli-ask-question.js",
       // The orchestrator drivers below print user-facing run banners
       // (board URL, plan summary). They're terminal output, not log
       // lines that would benefit from a structured logger.

--- a/src/commands/resume.js
+++ b/src/commands/resume.js
@@ -1,53 +1,10 @@
 import { EventEmitter } from "node:events";
-import readline from "node:readline";
 import { resumeFlow } from "../orchestrator.js";
 import { createActivityLog } from "../activity-log.js";
 import { printEvent } from "../utils/display/event-handlers.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { registerRun, unregisterRun } from "../utils/run-registry.js";
-
-function createCliAskQuestion(opts = {}) {
-  const { sessionId = null } = opts;
-  return async (question, context) => {
-    // Mirror the run.js logic: route to the board via the file-based
-    // bridge when there's no TTY; otherwise prompt the local terminal.
-    const stdinReadable = process.stdin && process.stdin.readable !== false;
-    const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
-    if (!isInteractive) {
-      const { askThroughBoard } = await import("../utils/board-prompt-bridge.js");
-      console.log(`\n\u2753 ${question}`);
-      if (context?.detail) {
-        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
-      }
-      console.log(
-        "\n[non-interactive] Routing the prompt to the HU Board.\n"
-        + "  Open http://localhost:4000 \u2014 a modal will appear asking for your answer."
-      );
-      try {
-        return await askThroughBoard({ sessionId, question, context });
-      } catch (err) {
-        console.log(`\n[prompt-bridge] ${err.message} \u2014 stopping the session.`);
-        return null;
-      }
-    }
-
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    return new Promise((resolve) => {
-      console.log(`\n\u2753 ${question}`);
-      if (context?.detail) {
-        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
-      }
-      rl.question("\n> Your response (or 'stop' to exit): ", (answer) => {
-        rl.close();
-        if (answer.trim().toLowerCase() === "stop") {
-          resolve(null);
-        } else {
-          resolve(answer.trim());
-        }
-      });
-    });
-  };
-}
+import { createCliAskQuestion } from "../utils/cli-ask-question.js";
 
 export async function resumeCommand({ sessionId, answer, config, logger, flags }) {
   const jsonMode = flags?.json;
@@ -88,7 +45,11 @@ export async function resumeCommand({ sessionId, answer, config, logger, flags }
       }
     });
 
-    const askQuestion = createCliAskQuestion();
+    // KJC-BUG-0081 round 2 — propagate `flags` so the helper honours
+    // `--yes` here too. Before this fix, `kj resume <id> --yes` in
+    // non-TTY mode still routed every prompt to the HU Board bridge
+    // and hung, exactly the bug the original PR #995 fixed for `kj run`.
+    const askQuestion = createCliAskQuestion({ sessionId, flags });
     const result = await resumeFlow({
       sessionId,
       answer: answer || null,

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,5 +1,4 @@
 import { EventEmitter } from "node:events";
-import readline from "node:readline";
 import { runFlow } from "../orchestrator.js";
 import { assertAgentsAvailable } from "../agents/availability.js";
 import { createActivityLog } from "../activity-log.js";
@@ -14,68 +13,11 @@ import { confirmCwd } from "../utils/cwd-confirm.js";
 import { runSpecReview } from "../spec-review/run-spec-review.js";
 import { maybeAutoUpdate } from "../rag/auto-update.js";
 
-export function createCliAskQuestion(opts = {}) {
-  const { sessionId = null, flags = {} } = opts;
-  return async (question, context) => {
-    // Three paths:
-    //   - Interactive TTY: prompt via readline (the developer's terminal).
-    //   - No TTY + --yes (CI / scripted / desatendido): KJC-BUG-0081 \u2014 never
-    //     route to the HU Board bridge in this case; the caller explicitly
-    //     asked NOT to be prompted. Print the unanswered question + context
-    //     to stderr and stop the session so the run fails fast and loud
-    //     instead of hanging on a modal nobody is watching.
-    //   - No TTY without --yes (board's \u25b6 Run plan with stdio=ignore): publish
-    //     the prompt through the file-based bridge so the HU Board can
-    //     surface it as a modal. The runner blocks on the bridge until
-    //     the user answers (or times out / kills the run).
-    const stdinReadable = process.stdin && process.stdin.readable !== false;
-    const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
-    if (!isInteractive) {
-      if (flags?.yes) {
-        process.stderr.write(
-          `\n[non-interactive --yes] Pipeline asked a question that cannot be auto-answered:\n`
-          + `  \u2753 ${question}\n`
-          + (context?.detail ? `  Context: ${JSON.stringify(context.detail)}\n` : "")
-          + `  Stopping the session. Re-run without --yes (TTY or HU Board) to answer it,\n`
-          + `  or pass --skip-spec-review / a more complete spec so the question never appears.\n`
-        );
-        return null;
-      }
-      const { askThroughBoard } = await import("../utils/board-prompt-bridge.js");
-      console.log(`\n\u2753 ${question}`);
-      if (context?.detail) {
-        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
-      }
-      console.log(
-        "\n[non-interactive] Routing the prompt to the HU Board.\n"
-        + "  Open http://localhost:4000 \u2014 a modal will appear asking for your answer.\n"
-        + "  This process is now waiting; closing the board does NOT cancel the run."
-      );
-      try {
-        return await askThroughBoard({ sessionId, question, context });
-      } catch (err) {
-        console.log(`\n[prompt-bridge] ${err.message} \u2014 stopping the session.`);
-        return null;
-      }
-    }
-
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    return new Promise((resolve) => {
-      console.log(`\n\u2753 ${question}`);
-      if (context?.detail) {
-        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
-      }
-      rl.question("\n> Your response (or 'stop' to exit): ", (answer) => {
-        rl.close();
-        if (answer.trim().toLowerCase() === "stop") {
-          resolve(null);
-        } else {
-          resolve(answer.trim());
-        }
-      });
-    });
-  };
-}
+// Re-export the shared helper so existing imports (tests, MCP wrappers)
+// keep working. KJC-BUG-0081 round 2 split the body into utils/ because
+// resume.js also needs the same contract.
+import { createCliAskQuestion } from "../utils/cli-ask-question.js";
+export { createCliAskQuestion };
 
 export async function runCommandHandler({ task, config, logger, flags }) {
   // PR-F (cwd confirmation): when launching from an interactive

--- a/src/utils/cli-ask-question.js
+++ b/src/utils/cli-ask-question.js
@@ -1,0 +1,76 @@
+import readline from "node:readline";
+
+/**
+ * Shared askQuestion factory used by `kj run` and `kj resume`.
+ *
+ * Pre-fix (KJC-BUG-0081 round 1), `src/commands/run.js` got the guard
+ * but `src/commands/resume.js` kept its own copy without the guard, so
+ * `kj resume --yes` in non-TTY mode still hung on the HU Board bridge.
+ * Centralising the three paths here means both commands honour the
+ * same contract and a future fix only needs to land in one place.
+ *
+ * Three paths:
+ *   1. Interactive TTY: prompt via readline (developer terminal).
+ *   2. No TTY + `flags.yes`: caller asked NOT to be prompted → write
+ *      question + context to stderr, return null so the run aborts
+ *      fast and loud (CI / scripted / `kj audit --yes` desatendido).
+ *   3. No TTY without `flags.yes` (HU Board ▶ Run plan with
+ *      `stdio=ignore`): publish through the file-based bridge so the
+ *      board can surface a modal; block until the user answers.
+ *
+ * @param {object} [opts]
+ * @param {string|null} [opts.sessionId]
+ * @param {object} [opts.flags]
+ * @returns {(question: string, context?: object) => Promise<string|null>}
+ */
+export function createCliAskQuestion(opts = {}) {
+  const { sessionId = null, flags = {} } = opts;
+  return async (question, context) => {
+    const stdinReadable = process.stdin && process.stdin.readable !== false;
+    const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
+    if (!isInteractive) {
+      if (flags?.yes) {
+        process.stderr.write(
+          `\n[non-interactive --yes] Pipeline asked a question that cannot be auto-answered:\n`
+          + `  ❓ ${question}\n`
+          + (context?.detail ? `  Context: ${JSON.stringify(context.detail)}\n` : "")
+          + `  Stopping the session. Re-run without --yes (TTY or HU Board) to answer it,\n`
+          + `  or pass --skip-spec-review / a more complete spec so the question never appears.\n`
+        );
+        return null;
+      }
+      const { askThroughBoard } = await import("./board-prompt-bridge.js");
+      console.log(`\n❓ ${question}`);
+      if (context?.detail) {
+        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
+      }
+      console.log(
+        "\n[non-interactive] Routing the prompt to the HU Board.\n"
+        + "  Open http://localhost:4000 — a modal will appear asking for your answer.\n"
+        + "  This process is now waiting; closing the board does NOT cancel the run."
+      );
+      try {
+        return await askThroughBoard({ sessionId, question, context });
+      } catch (err) {
+        console.log(`\n[prompt-bridge] ${err.message} — stopping the session.`);
+        return null;
+      }
+    }
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => {
+      console.log(`\n❓ ${question}`);
+      if (context?.detail) {
+        console.log(`   Context: ${JSON.stringify(context.detail, null, 2)}`);
+      }
+      rl.question("\n> Your response (or 'stop' to exit): ", (answer) => {
+        rl.close();
+        if (answer.trim().toLowerCase() === "stop") {
+          resolve(null);
+        } else {
+          resolve(answer.trim());
+        }
+      });
+    });
+  };
+}

--- a/tests/commands/command-resume-yes-no-tty.test.js
+++ b/tests/commands/command-resume-yes-no-tty.test.js
@@ -1,0 +1,64 @@
+// KJC-BUG-0081 round 2 — `kj resume <id> --yes` también debe abortar
+// sin TTY en lugar de colgarse en el bridge del HU Board.
+//
+// Round 1 (PR #995) arregló `src/commands/run.js` pero olvidó la copia
+// duplicada de `createCliAskQuestion` en `src/commands/resume.js`, así
+// que `kj resume <sid> --yes` desde un Cron / CI seguía colgándose en
+// el primer `elicitInput`. Round 2 extrae el helper a
+// `src/utils/cli-ask-question.js` y este test confirma que la nueva
+// importación de resume.js propaga `flags` correctamente.
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Importamos el helper compartido — resume.js no exporta nada al respecto
+// (lo usa internamente) y el contrato canónico vive en utils/.
+import { createCliAskQuestion } from "../../src/utils/cli-ask-question.js";
+
+describe("resume.js askQuestion contract — KJC-BUG-0081 round 2", () => {
+  const origIsTTY = process.stdin.isTTY;
+  let stderrWrites;
+  let stderrSpy;
+
+  beforeEach(() => {
+    stderrWrites = [];
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
+  });
+
+  it("returns null without invoking the HU Board bridge when --yes and no TTY", async () => {
+    const bridge = await import("../../src/utils/board-prompt-bridge.js");
+    const askSpy = vi.spyOn(bridge, "askThroughBoard").mockResolvedValue("should-not-be-called");
+
+    const ask = createCliAskQuestion({ sessionId: "sess_abc", flags: { yes: true } });
+    const answer = await ask("¿Reanudar?", { detail: { reason: "checkpoint" } });
+
+    expect(answer).toBeNull();
+    expect(askSpy).not.toHaveBeenCalled();
+    const all = stderrWrites.join("");
+    expect(all).toMatch(/non-interactive --yes/);
+    expect(all).toMatch(/checkpoint/);
+    askSpy.mockRestore();
+  });
+
+  it("falls back to the HU Board bridge when no TTY and --yes is not set", async () => {
+    const bridge = await import("../../src/utils/board-prompt-bridge.js");
+    const askSpy = vi.spyOn(bridge, "askThroughBoard").mockResolvedValue("from-board");
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const ask = createCliAskQuestion({ sessionId: "sess_abc", flags: {} });
+    const answer = await ask("¿Reanudar?", {});
+
+    expect(answer).toBe("from-board");
+    expect(askSpy).toHaveBeenCalledOnce();
+    expect(askSpy.mock.calls[0][0]).toMatchObject({ sessionId: "sess_abc" });
+    askSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- Causa raíz: `src/commands/resume.js` tenía una copia local de `createCliAskQuestion` SIN el guard `flags?.yes` que PR #995 introdujo en `run.js`. `kj resume <sid> --yes` desde CI/Cron seguía colgándose en el HU Board bridge.
- Fix: extraer el helper a `src/utils/cli-ask-question.js` y que `run.js` + `resume.js` importen de ahí. Una única copia, un único contrato.
- `run.js` re-exporta el símbolo para preservar el import path del test existente.

## Test plan

- [x] `tests/commands/command-run-yes-no-tty.test.js` (existente) — sigue verde con el re-export.
- [x] `tests/commands/command-resume-yes-no-tty.test.js` (nuevo) — verifica que `kj resume --yes` no-TTY aborta sin tocar el bridge.
- [x] `npx vitest run tests/commands/` → 17 files, 104/104.

Refs: KJC-BUG-0081