### PR TITLE
feat(pricing): static model-pricing registry + getModelPricing (KJC-TSK-0512)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,8 @@
     "./process": "./src/process.js",
     "./hu-snapshot": "./src/hu-snapshot.js",
     "./standby-store": "./src/standby-store.js",
-    "./standby-scheduler": "./src/standby-scheduler.js"
+    "./standby-scheduler": "./src/standby-scheduler.js",
+    "./pricing": "./src/pricing/index.js"
   },
   "scripts": {
     "test": "vitest run"

--- a/packages/core/src/pricing/index.js
+++ b/packages/core/src/pricing/index.js
@@ -1,0 +1,64 @@
+/**
+ * Model pricing registry (Cost A — KJC-TSK-0512).
+ *
+ * Static $-per-1M-tokens lookup. The cost-aggregator (Cost B) turns
+ * `{tokens_in, tokens_out, model}` events from the orchestrator into
+ * USD without calling external pricing APIs at runtime.
+ *
+ * Unknown models return `null` — the aggregator records the run as
+ * `cost: "unknown"` instead of throwing, so a brand-new model id
+ * never blocks a kj run.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY_PATH = join(__dirname, "model-pricing.json");
+
+let _cached = null;
+
+function loadRegistry() {
+  if (_cached) return _cached;
+  const raw = readFileSync(REGISTRY_PATH, "utf8");
+  _cached = JSON.parse(raw);
+  return _cached;
+}
+
+/**
+ * Look up pricing for a model id.
+ *
+ * @param {string} modelId — e.g. "claude-opus-4-7", "gpt-4o".
+ * @returns {{inputPerMTok:number, outputPerMTok:number, currency:string, source:string, updatedAt:string} | null}
+ */
+export function getModelPricing(modelId) {
+  if (typeof modelId !== "string" || modelId.length === 0) return null;
+  const reg = loadRegistry();
+  const entry = reg[modelId];
+  if (!entry || modelId.startsWith("_")) return null;
+  return {
+    inputPerMTok: entry.inputPerMTok,
+    outputPerMTok: entry.outputPerMTok,
+    currency: reg._meta.currency,
+    source: entry.source,
+    updatedAt: reg._meta.updatedAt,
+  };
+}
+
+/**
+ * List every known model id (no metadata). Useful for diagnostics
+ * and future `kj doctor` checks.
+ */
+export function listKnownModels() {
+  const reg = loadRegistry();
+  return Object.keys(reg).filter((k) => !k.startsWith("_"));
+}
+
+/**
+ * Reset the in-memory cache. Tests use this to re-read the JSON
+ * after mutating it; production code never needs to call it.
+ */
+export function _resetCache() {
+  _cached = null;
+}

--- a/packages/core/src/pricing/model-pricing.json
+++ b/packages/core/src/pricing/model-pricing.json
@@ -1,0 +1,28 @@
+{
+  "_meta": {
+    "currency": "USD",
+    "unit": "per 1M tokens",
+    "updatedAt": "2026-06-07",
+    "sources": {
+      "anthropic": "https://www.anthropic.com/pricing",
+      "openai": "https://openai.com/api/pricing/",
+      "google": "https://ai.google.dev/pricing"
+    },
+    "notes": "Static registry. Cache-write/cache-read tiers ignored on purpose: aggregator uses input/output averages. Unknown models return null so the pipeline does not break."
+  },
+  "claude-opus-4-7": { "inputPerMTok": 15.00, "outputPerMTok": 75.00, "source": "anthropic" },
+  "claude-opus-4-6": { "inputPerMTok": 15.00, "outputPerMTok": 75.00, "source": "anthropic" },
+  "claude-sonnet-4-6": { "inputPerMTok": 3.00, "outputPerMTok": 15.00, "source": "anthropic" },
+  "claude-haiku-4-5": { "inputPerMTok": 1.00, "outputPerMTok": 5.00, "source": "anthropic" },
+  "claude-haiku-4-5-20251001": { "inputPerMTok": 1.00, "outputPerMTok": 5.00, "source": "anthropic" },
+  "gpt-4o": { "inputPerMTok": 2.50, "outputPerMTok": 10.00, "source": "openai" },
+  "gpt-4o-mini": { "inputPerMTok": 0.15, "outputPerMTok": 0.60, "source": "openai" },
+  "gpt-4.1": { "inputPerMTok": 2.00, "outputPerMTok": 8.00, "source": "openai" },
+  "gpt-4.1-mini": { "inputPerMTok": 0.40, "outputPerMTok": 1.60, "source": "openai" },
+  "o1": { "inputPerMTok": 15.00, "outputPerMTok": 60.00, "source": "openai" },
+  "o1-mini": { "inputPerMTok": 1.10, "outputPerMTok": 4.40, "source": "openai" },
+  "o3-mini": { "inputPerMTok": 1.10, "outputPerMTok": 4.40, "source": "openai" },
+  "gemini-1.5-pro": { "inputPerMTok": 1.25, "outputPerMTok": 5.00, "source": "google" },
+  "gemini-1.5-flash": { "inputPerMTok": 0.075, "outputPerMTok": 0.30, "source": "google" },
+  "gemini-2.0-flash": { "inputPerMTok": 0.10, "outputPerMTok": 0.40, "source": "google" }
+}

--- a/packages/core/tests/pricing/index.test.js
+++ b/packages/core/tests/pricing/index.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  getModelPricing,
+  listKnownModels,
+  _resetCache,
+} from "../../src/pricing/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY_PATH = join(__dirname, "../../src/pricing/model-pricing.json");
+
+describe("pricing — model-pricing.json structure", () => {
+  it("is valid JSON with a _meta block", () => {
+    const raw = readFileSync(REGISTRY_PATH, "utf8");
+    const data = JSON.parse(raw);
+    expect(data._meta).toBeDefined();
+    expect(data._meta.currency).toBe("USD");
+    expect(data._meta.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(data._meta.unit).toMatch(/1M tokens/);
+  });
+
+  it("every entry (except _meta) has inputPerMTok, outputPerMTok and source", () => {
+    const raw = readFileSync(REGISTRY_PATH, "utf8");
+    const data = JSON.parse(raw);
+    for (const [key, entry] of Object.entries(data)) {
+      if (key.startsWith("_")) continue;
+      expect(typeof entry.inputPerMTok).toBe("number");
+      expect(typeof entry.outputPerMTok).toBe("number");
+      expect(entry.inputPerMTok).toBeGreaterThanOrEqual(0);
+      expect(entry.outputPerMTok).toBeGreaterThanOrEqual(0);
+      expect(typeof entry.source).toBe("string");
+      expect(entry.source.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("pricing — getModelPricing()", () => {
+  beforeEach(() => _resetCache());
+
+  it("returns full pricing for a known Anthropic model", () => {
+    const p = getModelPricing("claude-opus-4-7");
+    expect(p).not.toBeNull();
+    expect(p.inputPerMTok).toBe(15.0);
+    expect(p.outputPerMTok).toBe(75.0);
+    expect(p.currency).toBe("USD");
+    expect(p.source).toBe("anthropic");
+    expect(p.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("returns full pricing for an OpenAI model", () => {
+    const p = getModelPricing("gpt-4o");
+    expect(p).not.toBeNull();
+    expect(p.source).toBe("openai");
+    expect(p.inputPerMTok).toBeGreaterThan(0);
+  });
+
+  it("returns full pricing for a Google model", () => {
+    const p = getModelPricing("gemini-1.5-flash");
+    expect(p).not.toBeNull();
+    expect(p.source).toBe("google");
+  });
+
+  it("returns null for an unknown model", () => {
+    expect(getModelPricing("nonexistent-model-xyz")).toBeNull();
+  });
+
+  it("returns null for the _meta key (does not leak metadata)", () => {
+    expect(getModelPricing("_meta")).toBeNull();
+  });
+
+  it("returns null for empty / non-string inputs", () => {
+    expect(getModelPricing("")).toBeNull();
+    expect(getModelPricing(null)).toBeNull();
+    expect(getModelPricing(undefined)).toBeNull();
+    expect(getModelPricing(42)).toBeNull();
+  });
+});
+
+describe("pricing — listKnownModels()", () => {
+  it("returns a non-empty list and never includes _meta", () => {
+    const models = listKnownModels();
+    expect(Array.isArray(models)).toBe(true);
+    expect(models.length).toBeGreaterThan(5);
+    expect(models).not.toContain("_meta");
+  });
+
+  it("every listed model resolves via getModelPricing", () => {
+    for (const m of listKnownModels()) {
+      expect(getModelPricing(m)).not.toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `@karajan/core/pricing` — static `$`-per-1M-tokens registry + `getModelPricing(modelId)` lookup.
- Cost A pillar of the per-HU cost-tracking feature (epic `KJC-PCS-0055`).
- 10 new unit tests; 59/59 tests across the `@karajan/core` package stay green.

## Why
Cost B (the aggregator) needs a deterministic, offline way to turn `{tokens_in, tokens_out, model}` orchestrator events into USD. A static JSON registry keeps it zero-network, zero-config, and easy to update by hand or via PR. Unknown models return `null` so a brand-new model id never breaks a `kj run`.

## Files
- `packages/core/src/pricing/model-pricing.json` — Anthropic + OpenAI + Google models with `_meta` (currency, unit, updatedAt, sources).
- `packages/core/src/pricing/index.js` — `getModelPricing(id)`, `listKnownModels()`, `_resetCache()`.
- `packages/core/package.json` — adds `./pricing` to `exports`.
- `packages/core/tests/pricing/index.test.js` — 10 tests.

## LOC
189 insertions, 1 deletion (within the 200 budget).

## Test plan
- [x] `cd packages/core && npx vitest run tests/pricing/index.test.js` — 10/10 green
- [x] Full core suite still green (13 files / 59 tests)
- [ ] CI green