### PR TITLE
feat(hu-board): stories.cost_usd column + setStoryCost (KJC-TSK-0514)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -323,6 +323,11 @@ export function initDb() {
   // unconditionally so solo devs who later promote a plan don't lose
   // values they typed pre-share.
   try { db.exec('ALTER TABLE stories ADD COLUMN assignee TEXT'); } catch { /* already migrated */ }
+  // KJC-TSK-0514 (Cost C): persisted USD cost of running this HU. NULL
+  // until the orchestrator (Cost D) calls setStoryCost on HU close. UI
+  // renders "—" while NULL. Stored as REAL so the SQL aggregations in
+  // Cost E (/api/projects/:id/cost) can SUM directly without parsing.
+  try { db.exec('ALTER TABLE stories ADD COLUMN cost_usd REAL'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
@@ -496,6 +501,32 @@ export function updateStoryStatus(storyId, status) {
   const res = getDb()
     .prepare('UPDATE stories SET status = ?, updated_at = ? WHERE id = ?')
     .run(status, new Date().toISOString(), storyId);
+  return res.changes > 0;
+}
+
+/**
+ * Persist the USD cost of a HU. Called by the orchestrator (Cost D) once
+ * the HU finishes — the value comes from `aggregateRunCost(events).totalUsd`
+ * (Cost B). `null` clears the cell so the UI renders "—" again. Other
+ * numeric inputs are coerced via `Number`; non-finite values reject with
+ * an explicit throw so callers don't silently NULL-out real cost rows.
+ *
+ * @param {string} storyId
+ * @param {number|null} costUsd
+ * @returns {boolean} true when the row existed and was updated
+ */
+export function setStoryCost(storyId, costUsd) {
+  let value = null;
+  if (costUsd !== null && costUsd !== undefined) {
+    const n = Number(costUsd);
+    if (!Number.isFinite(n)) {
+      throw new Error(`setStoryCost: costUsd must be a finite number or null (got ${costUsd})`);
+    }
+    value = n;
+  }
+  const res = getDb()
+    .prepare('UPDATE stories SET cost_usd = ?, updated_at = ? WHERE id = ?')
+    .run(value, new Date().toISOString(), storyId);
   return res.changes > 0;
 }
 

--- a/packages/hu-board/tests/db.test.js
+++ b/packages/hu-board/tests/db.test.js
@@ -329,3 +329,53 @@ describe('getDashboardStats', () => {
     expect(stats.total_projects).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cost_usd column + setStoryCost (KJC-TSK-0514 — Cost C)
+// ---------------------------------------------------------------------------
+describe('cost_usd persistence', () => {
+  it('migrates stories table with a nullable cost_usd column', async () => {
+    const { getDb } = await freshDb();
+    const cols = getDb().prepare("PRAGMA table_info(stories)").all();
+    const costCol = cols.find((c) => c.name === 'cost_usd');
+    expect(costCol).toBeTruthy();
+    expect(costCol.type.toUpperCase()).toBe('REAL');
+    expect(costCol.notnull).toBe(0);
+  });
+
+  it('defaults cost_usd to NULL on insert', async () => {
+    const { getDb, upsertStory } = await freshDb();
+    upsertStory({ id: 's-new', project_id: 'p1' });
+    const row = getDb().prepare('SELECT cost_usd FROM stories WHERE id = ?').get('s-new');
+    expect(row.cost_usd).toBeNull();
+  });
+
+  it('setStoryCost writes a finite USD value and round-trips', async () => {
+    const { getDb, upsertStory, setStoryCost } = await freshDb();
+    upsertStory({ id: 's-cost', project_id: 'p1' });
+    expect(setStoryCost('s-cost', 22.5)).toBe(true);
+    const row = getDb().prepare('SELECT cost_usd FROM stories WHERE id = ?').get('s-cost');
+    expect(row.cost_usd).toBe(22.5);
+  });
+
+  it('setStoryCost(null) clears the cell back to NULL', async () => {
+    const { getDb, upsertStory, setStoryCost } = await freshDb();
+    upsertStory({ id: 's-clear', project_id: 'p1' });
+    setStoryCost('s-clear', 1.23);
+    setStoryCost('s-clear', null);
+    const row = getDb().prepare('SELECT cost_usd FROM stories WHERE id = ?').get('s-clear');
+    expect(row.cost_usd).toBeNull();
+  });
+
+  it('setStoryCost rejects NaN/Infinity instead of silently NULL-ing', async () => {
+    const { upsertStory, setStoryCost } = await freshDb();
+    upsertStory({ id: 's-bad', project_id: 'p1' });
+    expect(() => setStoryCost('s-bad', NaN)).toThrow(/finite number/);
+    expect(() => setStoryCost('s-bad', Infinity)).toThrow(/finite number/);
+  });
+
+  it('setStoryCost returns false when the story does not exist', async () => {
+    const { setStoryCost } = await freshDb();
+    expect(setStoryCost('does-not-exist', 5)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Cost C of KJC-PCS-0055 (HU/project \$ tracking epic).

- Adds nullable `cost_usd REAL` column to `stories` via the existing idempotent ALTER pattern.
- Adds `setStoryCost(storyId, costUsd)` helper that round-trips finite numbers and rejects NaN/Infinity instead of silently NULL-ing real cost rows.
- NULL until the orchestrator (Cost D, KJC-TSK-0515) calls `setStoryCost` on HU close. UI renders "—" while NULL. REAL storage lets Cost E (`/api/projects/:id/cost`) SUM directly without parsing.

## LOC
81 net (29 src / 50 tests). Well under the 200-LOC budget.

## Test plan
- [x] 6 new tests in `packages/hu-board/tests/db.test.js`: migration shape, NULL default, set+round-trip, null clears, NaN/Infinity rejection, missing-row returns false.
- [x] `npx vitest run tests/db.test.js` → 29/29 green locally.
- [ ] CI green (waiting).

Stack: Cost A (#1024 merged), Cost B (#1025 in CI), Cost C (this PR).