### PR TITLE
feat(hu-board): GET /api/projects/:id/cost endpoint (KJC-TSK-0516)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -630,6 +630,53 @@ export function getStoriesByProject(projectId) {
 }
 
 /**
+ * Aggregate $ cost for a project (KJC-TSK-0516, Cost E).
+ * Sums stories.cost_usd, groups by plan_id ('unassigned' for NULL).
+ * Returns null if project does not exist; otherwise an object with
+ * totalUsd=0 and byPlan=[] when no stories carry cost_usd yet.
+ * @param {string} projectId
+ * @returns {{ totalUsd:number, byPlan:Array<{planId:string,totalUsd:number,huCount:number}>, unknownModelTokens:object, currency:string } | null}
+ */
+export function getProjectCost(projectId) {
+  const project = getDb()
+    .prepare('SELECT id FROM projects WHERE id = ?')
+    .get(projectId);
+  if (!project) return null;
+
+  const rows = getDb()
+    .prepare(
+      `SELECT plan_id, cost_usd FROM stories
+       WHERE project_id = ? AND cost_usd IS NOT NULL`
+    )
+    .all(projectId);
+
+  const round4 = (n) => Math.round(n * 10000) / 10000;
+  const byPlanMap = new Map();
+  let totalUsd = 0;
+  for (const r of rows) {
+    const planId = r.plan_id || 'unassigned';
+    const cost = Number(r.cost_usd);
+    if (!Number.isFinite(cost)) continue;
+    totalUsd += cost;
+    const cur = byPlanMap.get(planId) || { planId, totalUsd: 0, huCount: 0 };
+    cur.totalUsd += cost;
+    cur.huCount += 1;
+    byPlanMap.set(planId, cur);
+  }
+
+  const byPlan = Array.from(byPlanMap.values())
+    .map((p) => ({ planId: p.planId, totalUsd: round4(p.totalUsd), huCount: p.huCount }))
+    .sort((a, b) => b.totalUsd - a.totalUsd);
+
+  return {
+    totalUsd: round4(totalUsd),
+    byPlan,
+    unknownModelTokens: { tokensIn: 0, tokensOut: 0, models: [] },
+    currency: 'USD',
+  };
+}
+
+/**
  * Returns full story detail including context requests.
  * @param {string} storyId
  * @returns {object | null}

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -22,6 +22,7 @@ import {
   listPlanIdsForProject,
   updateStoryStatus,
   setProjectIsTest,
+  getProjectCost,
 } from '../db.js';
 import { fullScan } from '../sync.js';
 import { setHuStatus, setHuFields, markPlanReady, runPlan, renameProject, revertHuFromSnapshot } from '../plan-mutations.js';
@@ -280,6 +281,20 @@ router.get('/stories/:id', (req, res) => {
     const story = getStoryDetail(req.params.id);
     if (!story) return res.status(404).json({ error: 'Story not found' });
     res.json(story);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * GET /api/projects/:id/cost - Aggregated $ cost for a project (KJC-TSK-0516).
+ * Sums stories.cost_usd, groups by plan_id, returns 404 if project missing.
+ */
+router.get('/projects/:id/cost', (req, res) => {
+  try {
+    const cost = getProjectCost(req.params.id);
+    if (!cost) return res.status(404).json({ error: 'Project not found' });
+    res.json(cost);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -365,3 +365,55 @@ describe('GET /api/standby', () => {
     expect(res.body.sessions[0].planId).toBe('p1');
   });
 });
+
+// ---------------------------------------------------------------------------
+// GET /api/projects/:id/cost (KJC-TSK-0516, Cost E)
+// ---------------------------------------------------------------------------
+describe('GET /api/projects/:id/cost', () => {
+  it('aggregates totalUsd and groups by plan_id', async () => {
+    dbMod.upsertProject({ id: 'proj-cost', name: 'Cost Project' });
+    dbMod.upsertStory({ id: 'st-c1', project_id: 'proj-cost', plan_id: 'plan-A' });
+    dbMod.upsertStory({ id: 'st-c2', project_id: 'proj-cost', plan_id: 'plan-A' });
+    dbMod.upsertStory({ id: 'st-c3', project_id: 'proj-cost', plan_id: 'plan-B' });
+    dbMod.setStoryCost('st-c1', 1.25);
+    dbMod.setStoryCost('st-c2', 0.75);
+    dbMod.setStoryCost('st-c3', 0.5);
+
+    const res = await request(app).get('/api/projects/proj-cost/cost');
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('USD');
+    expect(res.body.totalUsd).toBe(2.5);
+    expect(res.body.byPlan).toHaveLength(2);
+    // sorted by totalUsd desc → plan-A (2.0) before plan-B (0.5)
+    expect(res.body.byPlan[0]).toEqual({ planId: 'plan-A', totalUsd: 2, huCount: 2 });
+    expect(res.body.byPlan[1]).toEqual({ planId: 'plan-B', totalUsd: 0.5, huCount: 1 });
+    expect(res.body.unknownModelTokens).toEqual({ tokensIn: 0, tokensOut: 0, models: [] });
+  });
+
+  it('returns totalUsd=0 and empty byPlan when no story has cost', async () => {
+    dbMod.upsertProject({ id: 'proj-cost-empty', name: 'Empty' });
+    dbMod.upsertStory({ id: 'st-e1', project_id: 'proj-cost-empty', plan_id: 'plan-X' });
+
+    const res = await request(app).get('/api/projects/proj-cost-empty/cost');
+    expect(res.status).toBe(200);
+    expect(res.body.totalUsd).toBe(0);
+    expect(res.body.byPlan).toEqual([]);
+  });
+
+  it('groups stories with NULL plan_id under "unassigned"', async () => {
+    dbMod.upsertProject({ id: 'proj-cost-na', name: 'NoPlan' });
+    dbMod.upsertStory({ id: 'st-na1', project_id: 'proj-cost-na' });
+    dbMod.setStoryCost('st-na1', 0.1);
+
+    const res = await request(app).get('/api/projects/proj-cost-na/cost');
+    expect(res.status).toBe(200);
+    expect(res.body.byPlan[0].planId).toBe('unassigned');
+    expect(res.body.byPlan[0].huCount).toBe(1);
+  });
+
+  it('returns 404 for unknown project', async () => {
+    const res = await request(app).get('/api/projects/nonexistent/cost');
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
Cost E of KJC-PCS-0055 (cost $ tracking per HU/project in HU Board).

Wires the `cost_usd` column added by Cost C (#1026) into an API that the HU Board UI (Cost F/G) can consume.

- `db.js` → `getProjectCost(projectId)`:
  - Groups `stories.cost_usd` by `plan_id` ("unassigned" for NULL).
  - 4-decimal rounding, sorted desc by `totalUsd`.
  - Returns `null` if project does not exist.
  - Shape: `{ totalUsd, byPlan: [{planId, totalUsd, huCount}], unknownModelTokens, currency: "USD" }`.
- `api.js` → `GET /api/projects/:id/cost`:
  - Wires the helper, 404 on missing project.
- 4 new test cases in `api.test.js`:
  1. Aggregate + group by plan_id.
  2. Empty project (no `cost_usd` yet).
  3. NULL plan_id grouped under `"unassigned"`.
  4. Nonexistent project → 404.

## Test plan
- [x] `npx vitest run tests/api.test.js` → 33/33 passing.
- [x] `npx vitest run tests/db.test.js` → 29/29 passing.
- [x] Net LOC: 114 insertions, well within the 200 budget.

## Card
KJC-TSK-0516 (Cost E) — In Progress, will move to To Validate on merge.