### PR TITLE
feat(hu-board): cost badge on hu cards via formatCost helper (KJC-TSK-0517)

### DIFF
--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -341,6 +341,12 @@ a:hover {
 .story-card__score--ok { color: var(--color-yellow); }
 .story-card__score--bad { color: var(--color-red); }
 
+.story-card__cost {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 .quality-bar {
   display: inline-flex;
   gap: 1px;

--- a/packages/hu-board/public/utils/board-view.js
+++ b/packages/hu-board/public/utils/board-view.js
@@ -372,6 +372,10 @@ function renderStoryCard(story) {
             ${story.quality_total}/60 ${qualityBar(story.quality_total)}
           </span>
         ` : ''}
+        ${(() => {
+          const c = formatCost(story.cost_usd);
+          return c ? `<span class="story-card__cost" title="${esc(c.tooltip)}">💵 ${esc(c.label)}</span>` : '';
+        })()}
       </div>
       ${missingTestContract ? `
         <div class="story-card__meta" style="margin-top:4px;font-size:0.75rem;color:var(--color-yellow,#eab308);font-weight:600" title="This HU has no acceptance_tests declared — Run plan will reject it until you add at least one.">

--- a/packages/hu-board/public/utils/formatters.js
+++ b/packages/hu-board/public/utils/formatters.js
@@ -45,6 +45,16 @@ function formatSessionLabel(session) {
   };
 }
 
+function formatCost(costUsd) {
+  if (costUsd === null || costUsd === undefined) return null;
+  const n = Number(costUsd);
+  if (!Number.isFinite(n)) return null;
+  return {
+    label: `$${n.toFixed(2)}`,
+    tooltip: `Estimated cost: $${n.toFixed(4)}`,
+  };
+}
+
 function humaniseProjectName(id) {
   if (!id || typeof id !== 'string') return id || '';
   const tail = id.split(/[/_]/).filter(Boolean).pop() || id;

--- a/packages/hu-board/src/format.js
+++ b/packages/hu-board/src/format.js
@@ -60,6 +60,33 @@ export function shortTask(text, max = MAX_TASK_CHARS) {
  *           created_at?: string|null }} session
  * @returns {{ title: string, subtitle: string, idChip: string }}
  */
+/**
+ * Format a per-HU cost (USD) for the card badge. Cost F (KJC-TSK-0517).
+ *
+ * Two outputs in one call so the UI can render both at once:
+ *   - `label`: 2-decimal "$X.XX" shown on the card (compact).
+ *   - `tooltip`: 4-decimal "Estimated cost: $X.XXXX" shown on hover
+ *     (matches the precision aggregated by Cost B/C/D, see
+ *     `packages/core/src/cost/index.js`).
+ *
+ * Returns `null` for null/undefined/non-finite inputs so the caller
+ * skips the badge entirely (rendering "$0.00" for an unknown cost
+ * would be misleading — there is a real difference between "we know it
+ * was free" and "we haven't measured it yet").
+ *
+ * @param {number|null|undefined} costUsd
+ * @returns {{ label: string, tooltip: string } | null}
+ */
+export function formatCost(costUsd) {
+  if (costUsd === null || costUsd === undefined) return null;
+  const n = Number(costUsd);
+  if (!Number.isFinite(n)) return null;
+  return {
+    label: `$${n.toFixed(2)}`,
+    tooltip: `Estimated cost: $${n.toFixed(4)}`,
+  };
+}
+
 export function formatSessionLabel(session) {
   if (!session || !session.id) {
     return { title: "(no session)", subtitle: "", idChip: "" };

--- a/packages/hu-board/tests/format.test.js
+++ b/packages/hu-board/tests/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatHHMM, shortTask, formatSessionLabel } from "../src/format.js";
+import { formatHHMM, shortTask, formatSessionLabel, formatCost } from "../src/format.js";
 
 describe("formatHHMM", () => {
   it("formats an ISO timestamp as HH:MM (24h, server-local)", () => {
@@ -118,5 +118,58 @@ describe("formatSessionLabel", () => {
   it("idChip always preserves the raw session id (kj resume needs it)", () => {
     const id = "s_2026-05-07T08-35-58-010Z";
     expect(formatSessionLabel({ id, project_name: "p", task: "t", created_at: "2026-05-07T08:35:00Z" }).idChip).toBe(id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCost — Cost F (KJC-TSK-0517)
+//
+// The HU card shows two precisions for the same cost: a compact "$X.XX"
+// label and a 4-decimal tooltip. The helper returns both atomically so
+// the rendering code can't accidentally show one without the other.
+// Null/undefined/NaN must return null so the badge is hidden — rendering
+// "$0.00" for an unmeasured HU would be misleading.
+// ---------------------------------------------------------------------------
+describe("formatCost", () => {
+  it("returns 2-decimal label and 4-decimal tooltip for a valid cost", () => {
+    expect(formatCost(0.0234)).toEqual({
+      label: "$0.02",
+      tooltip: "Estimated cost: $0.0234",
+    });
+  });
+
+  it("rounds the visible label but keeps full precision in tooltip", () => {
+    expect(formatCost(1.2356)).toEqual({
+      label: "$1.24",
+      tooltip: "Estimated cost: $1.2356",
+    });
+  });
+
+  it("returns null when cost is null (no badge → no false $0.00)", () => {
+    expect(formatCost(null)).toBeNull();
+  });
+
+  it("returns null when cost is undefined", () => {
+    expect(formatCost(undefined)).toBeNull();
+  });
+
+  it("returns null for NaN / Infinity", () => {
+    expect(formatCost(NaN)).toBeNull();
+    expect(formatCost(Infinity)).toBeNull();
+    expect(formatCost(-Infinity)).toBeNull();
+  });
+
+  it("renders $0.00 / $0.0000 only when cost is genuinely 0 (free run)", () => {
+    expect(formatCost(0)).toEqual({
+      label: "$0.00",
+      tooltip: "Estimated cost: $0.0000",
+    });
+  });
+
+  it("accepts numeric strings (SQLite REAL → JS sometimes ships as string)", () => {
+    expect(formatCost("0.5")).toEqual({
+      label: "$0.50",
+      tooltip: "Estimated cost: $0.5000",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Cost F (sixth of seven, KJC-PCS-0055 epic). Renders a compact `$X.XX` badge on every HU card whose `cost_usd` is set, with a 4-decimal tooltip "Estimated cost: $X.XXXX" so the user sees both views without clicking.

- New pure helper `formatCost` in `src/format.js` (testable) + a parallel copy in `public/utils/formatters.js` (classic script consumed by `board-view.js`, same pattern as the existing `formatHHMM` / `shortTask` / `formatSessionLabel` pair).
- Returns `null` for `null` / `undefined` / `NaN` / `±Infinity` so the badge is skipped entirely. Rendering `$0.00` for an unmeasured HU would be misleading — `$0.00` only shows when the cost is genuinely zero.
- Badge sits inside the existing `.story-card__meta` row, immediately after the INVEST score. CSS uses the existing mono font + muted color so the row stays visually balanced.
- 7 new tests in `tests/format.test.js`: 2/4-decimal split, label rounding, `null` / `undefined` → no badge, non-finite → no badge, genuine zero, numeric-string input.

## Test plan

- [x] `npx vitest run tests/format.test.js` — 22/22 green (15 previous + 7 new).
- [x] Lint + Prettier clean (pre-commit hooks pass).
- [x] LOC delta `+101 / -1` (well below the 200-LOC PR atomicity gate).
- [ ] Manual: open HU Board → project page, confirm cards with `cost_usd != NULL` show `💵 $X.XX` and tooltip on hover; cards with `cost_usd = NULL` show no badge.

Part of KJC-PCS-0055. Unblocks Cost G (project-level total).