### PR TITLE
feat(hu-board): project total cost chip in board header (KJC-TSK-0518)

### DIFF
--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -244,6 +244,17 @@ a:hover {
   font-family: var(--font-mono);
 }
 
+.section-header__cost {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary, transparent);
+  cursor: help;
+}
+
 /* ---- Kanban Board ---- */
 .kanban {
   display: grid;

--- a/packages/hu-board/public/utils/board-view.js
+++ b/packages/hu-board/public/utils/board-view.js
@@ -35,7 +35,11 @@ async function renderBoard() {
       return;
     }
 
-    const stories = await api(`/api/projects/${encodeURIComponent(selectedProject)}/stories`);
+    const [stories, projectCost] = await Promise.all([
+      api(`/api/projects/${encodeURIComponent(selectedProject)}/stories`),
+      api(`/api/projects/${encodeURIComponent(selectedProject)}/cost`).catch(() => null),
+    ]);
+    const costSummary = projectCost ? formatProjectCostSummary(projectCost) : null;
 
     // Pre-resolve project initials + name for every distinct project_id in
     // the fetched stories so `renderStoryCard` is synchronous and the header
@@ -96,6 +100,7 @@ async function renderBoard() {
                   onclick="event.stopPropagation(); window.renameProjectModal('${esc(selectedProject)}', '${esc(projectDisplayName.replace(/'/g, '&#39;'))}');">✎</button>
         ` : ''}
         <span class="section-header__count">${stories.length} stories</span>
+        ${costSummary ? `<span class="section-header__cost" title="${esc(costSummary.tooltip)}">💵 ${esc(costSummary.label)}</span>` : ''}
         ${isRunning ? `
           <button id="running-badge-btn" class="section-header__badge"
                 style="margin-left:auto;padding:4px 10px;font-size:0.8rem;background:var(--color-yellow,#eab308);color:#000;border-radius:var(--radius-sm);font-weight:600;border:none;cursor:pointer;"

--- a/packages/hu-board/public/utils/formatters.js
+++ b/packages/hu-board/public/utils/formatters.js
@@ -55,6 +55,37 @@ function formatCost(costUsd) {
   };
 }
 
+function formatProjectCostSummary(cost) {
+  if (!cost || typeof cost !== "object") return null;
+  const total = Number(cost.totalUsd);
+  if (!Number.isFinite(total)) return null;
+  const byPlan = Array.isArray(cost.byPlan) ? cost.byPlan : [];
+  if (total === 0 && byPlan.length === 0) return null;
+
+  const lines = [`Total: $${total.toFixed(4)}`];
+  if (byPlan.length > 0) {
+    lines.push("By plan:");
+    for (const p of byPlan) {
+      const planTotal = Number(p?.totalUsd);
+      if (!Number.isFinite(planTotal)) continue;
+      const huCount = Number.isFinite(p?.huCount) ? p.huCount : 0;
+      const planLabel = p?.planId || "unassigned";
+      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})`);
+    }
+  }
+  const unk = cost.unknownModelTokens;
+  if (unk && Number.isFinite(unk.tokensIn) && Number.isFinite(unk.tokensOut)) {
+    const unkTotal = unk.tokensIn + unk.tokensOut;
+    if (unkTotal > 0) {
+      lines.push(`(${unkTotal} tokens with unknown pricing not included)`);
+    }
+  }
+  return {
+    label: `Total: $${total.toFixed(2)}`,
+    tooltip: lines.join("\n"),
+  };
+}
+
 function humaniseProjectName(id) {
   if (!id || typeof id !== 'string') return id || '';
   const tail = id.split(/[/_]/).filter(Boolean).pop() || id;

--- a/packages/hu-board/src/format.js
+++ b/packages/hu-board/src/format.js
@@ -87,6 +87,58 @@ export function formatCost(costUsd) {
   };
 }
 
+/**
+ * Format the aggregated project-level cost chip rendered in the board
+ * header. Cost G (KJC-TSK-0518). Consumes the shape returned by
+ * `GET /api/projects/:id/cost` (Cost E):
+ *   { totalUsd, byPlan: [{planId, totalUsd, huCount}, …],
+ *     unknownModelTokens: { tokensIn, tokensOut, models }, currency }
+ *
+ * Returns `{ label, tooltip }` where:
+ *   - `label` is the compact "Total: $X.XX" shown in the header.
+ *   - `tooltip` is a multi-line string with full precision, the
+ *     per-plan breakdown, and a note when some tokens used a model we
+ *     don't price (they aren't included in the total — surfacing the
+ *     skip is more honest than silently swallowing it).
+ *
+ * Returns `null` when there is nothing to show (no input, or no
+ * measured cost yet and no plans). The chip is then hidden — same
+ * reasoning as `formatCost`: "$0.00" with no data is misleading.
+ *
+ * @param {{totalUsd:number, byPlan?:Array, unknownModelTokens?:object}|null|undefined} cost
+ * @returns {{ label: string, tooltip: string } | null}
+ */
+export function formatProjectCostSummary(cost) {
+  if (!cost || typeof cost !== "object") return null;
+  const total = Number(cost.totalUsd);
+  if (!Number.isFinite(total)) return null;
+  const byPlan = Array.isArray(cost.byPlan) ? cost.byPlan : [];
+  if (total === 0 && byPlan.length === 0) return null;
+
+  const lines = [`Total: $${total.toFixed(4)}`];
+  if (byPlan.length > 0) {
+    lines.push("By plan:");
+    for (const p of byPlan) {
+      const planTotal = Number(p?.totalUsd);
+      if (!Number.isFinite(planTotal)) continue;
+      const huCount = Number.isFinite(p?.huCount) ? p.huCount : 0;
+      const planLabel = p?.planId || "unassigned";
+      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})`);
+    }
+  }
+  const unk = cost.unknownModelTokens;
+  if (unk && Number.isFinite(unk.tokensIn) && Number.isFinite(unk.tokensOut)) {
+    const unkTotal = unk.tokensIn + unk.tokensOut;
+    if (unkTotal > 0) {
+      lines.push(`(${unkTotal} tokens with unknown pricing not included)`);
+    }
+  }
+  return {
+    label: `Total: $${total.toFixed(2)}`,
+    tooltip: lines.join("\n"),
+  };
+}
+
 export function formatSessionLabel(session) {
   if (!session || !session.id) {
     return { title: "(no session)", subtitle: "", idChip: "" };

--- a/packages/hu-board/tests/format.test.js
+++ b/packages/hu-board/tests/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatHHMM, shortTask, formatSessionLabel, formatCost } from "../src/format.js";
+import { formatHHMM, shortTask, formatSessionLabel, formatCost, formatProjectCostSummary } from "../src/format.js";
 
 describe("formatHHMM", () => {
   it("formats an ISO timestamp as HH:MM (24h, server-local)", () => {
@@ -171,5 +171,106 @@ describe("formatCost", () => {
       label: "$0.50",
       tooltip: "Estimated cost: $0.5000",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatProjectCostSummary — Cost G (KJC-TSK-0518)
+//
+// Consumes the shape returned by GET /api/projects/:id/cost (Cost E):
+//   { totalUsd, byPlan: [...], unknownModelTokens: {...}, currency }
+// Returns null when there's nothing to show (no input, or 0 total with no
+// plans). Same "no $0.00 for unmeasured" design as formatCost — rendering
+// a misleading zero is worse than hiding the chip.
+// ---------------------------------------------------------------------------
+describe("formatProjectCostSummary", () => {
+  it("returns label + multi-line tooltip with byPlan breakdown", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 1.5432,
+      byPlan: [
+        { planId: "plan-alpha", totalUsd: 1.0, huCount: 3 },
+        { planId: "plan-beta", totalUsd: 0.5432, huCount: 1 },
+      ],
+    });
+    expect(out.label).toBe("Total: $1.54");
+    expect(out.tooltip).toBe(
+      [
+        "Total: $1.5432",
+        "By plan:",
+        "  plan-alpha: $1.00 (3 HUs)",
+        "  plan-beta: $0.54 (1 HU)",
+      ].join("\n")
+    );
+  });
+
+  it("returns null when input is null/undefined/non-object", () => {
+    expect(formatProjectCostSummary(null)).toBeNull();
+    expect(formatProjectCostSummary(undefined)).toBeNull();
+    expect(formatProjectCostSummary("oops")).toBeNull();
+  });
+
+  it("returns null when totalUsd is not finite", () => {
+    expect(formatProjectCostSummary({ totalUsd: NaN })).toBeNull();
+    expect(formatProjectCostSummary({ totalUsd: "not a number" })).toBeNull();
+  });
+
+  it("returns null when total is 0 and there are no plans (nothing to show)", () => {
+    expect(formatProjectCostSummary({ totalUsd: 0, byPlan: [] })).toBeNull();
+    expect(formatProjectCostSummary({ totalUsd: 0 })).toBeNull();
+  });
+
+  it("renders a tooltip with no breakdown when byPlan is empty but total > 0", () => {
+    const out = formatProjectCostSummary({ totalUsd: 0.25, byPlan: [] });
+    expect(out.label).toBe("Total: $0.25");
+    expect(out.tooltip).toBe("Total: $0.2500");
+  });
+
+  it("appends the 'unknown pricing' note when unknownModelTokens > 0", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 0.5,
+      byPlan: [],
+      unknownModelTokens: { tokensIn: 1200, tokensOut: 800, models: ["mystery-v1"] },
+    });
+    expect(out.tooltip).toBe(
+      ["Total: $0.5000", "(2000 tokens with unknown pricing not included)"].join("\n")
+    );
+  });
+
+  it("skips the unknown-tokens line when the count is 0", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 0.5,
+      byPlan: [],
+      unknownModelTokens: { tokensIn: 0, tokensOut: 0 },
+    });
+    expect(out.tooltip).toBe("Total: $0.5000");
+  });
+
+  it("falls back to 'unassigned' when a plan has no planId", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 0.1,
+      byPlan: [{ planId: null, totalUsd: 0.1, huCount: 1 }],
+    });
+    expect(out.tooltip).toContain("  unassigned: $0.10 (1 HU)");
+  });
+
+  it("uses singular HU when huCount is exactly 1", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 0.1,
+      byPlan: [{ planId: "p1", totalUsd: 0.1, huCount: 1 }],
+    });
+    expect(out.tooltip).toContain("(1 HU)");
+    expect(out.tooltip).not.toContain("(1 HUs)");
+  });
+
+  it("skips per-plan rows whose totalUsd isn't finite", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 0.5,
+      byPlan: [
+        { planId: "ok", totalUsd: 0.5, huCount: 2 },
+        { planId: "broken", totalUsd: "garbage", huCount: 1 },
+      ],
+    });
+    expect(out.tooltip).toContain("  ok: $0.50 (2 HUs)");
+    expect(out.tooltip).not.toContain("broken");
   });
 });


### PR DESCRIPTION
## Summary

Closes the **Cost epic (KJC-PCS-0055)** by surfacing the per-project cost the API already exposes via Cost E (`GET /api/projects/:id/cost`, PR #1028). The kanban header now shows a "💵 Total: \$X.XX" chip next to the story count; hovering reveals the 4-decimal total, per-plan breakdown, and a note when unpriced tokens were skipped.

Same null-instead-of-\$0.00 design as Cost F (per-HU badge): if nothing has been measured yet — endpoint missing, broken, or all zeros with no plans — the chip is hidden. Rendering "Total: \$0.00" with no data is misleading; the absence of a chip is honest.

## Changes

- **`src/format.js`** + **`public/utils/formatters.js`** — new `formatProjectCostSummary(cost)` helper. ES module for unit tests, classic-script mirror for the browser (same load pattern as Cost F).
  - `label`: compact `"Total: \$X.XX"`.
  - `tooltip`: multi-line — 4-decimal total, optional per-plan rows (`planId: \$X.XX (N HUs)` with singular/plural and an `unassigned` fallback), optional `(N tokens with unknown pricing not included)` note.
- **`public/utils/board-view.js`** `renderBoard()` — parallel-fetch stories + cost endpoint with `Promise.all`; cost fetch is `.catch(() => null)` so a missing endpoint hides the chip without breaking the board.
- **`public/styles.css`** — `.section-header__cost` pill matching the existing count style (mono font, muted color, subtle border + bg, `cursor: help`).
- **`tests/format.test.js`** — 10 new tests for `formatProjectCostSummary` (nominal byPlan breakdown, null/non-object inputs, non-finite total, total=0+empty=null, missing planId → `unassigned`, singular vs plural HU, unknown-tokens note, skips per-plan rows with non-finite totalUsd). 32/32 passing locally.

LOC delta: +202 / -2 (within budget).

## Test plan

- [x] `npx vitest run packages/hu-board/tests/format.test.js` → 32/32 green.
- [ ] CI: full suite + lint + coverage.
- [ ] Smoke: open the board with a project that has at least one HU with `cost_usd` set; verify chip shows + tooltip renders multi-line. Open a project with no cost data; verify chip is hidden.