### PR TITLE
feat(orchestrator): persist per-HU cost_usd via setStoryCost (KJC-TSK-0515)

### DIFF
--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -302,10 +302,26 @@ function wirePlanCallbacks({ session, loadedPlan, projectDir, syncResultsToPlan,
   // PR3: per-HU outcome. Stamped once per HU at runSingleHu's exit
   // so the board can show the 📄 indicator as soon as each HU
   // finishes (iterations / duration / commits / blockers / summary).
+  //
+  // Cost D (KJC-TSK-0515): the outcome may carry `cost_usd` (USD
+  // spent on this HU). When present and finite, also persist it to
+  // board.db so the per-card badge (Cost F) and the project total
+  // chip (Cost G) have data to show — without this write, the
+  // `cost_usd` column would always stay NULL and the UI would render
+  // nothing. Lazy-import to keep the pre-loop phase free of board
+  // deps until we actually need them.
   setLiveOutcomeUpdater(session, async (huId, outcome) => {
     try {
       if (!setHuOutcomeFn(loadedPlan, huId, outcome)) return;
       await savePlanToDisk(projectDir, loadedPlan);
+      if (outcome && Number.isFinite(outcome.cost_usd)) {
+        try {
+          const { setStoryCost } = await import("../../../../packages/hu-board/src/db.js");
+          setStoryCost(huId, outcome.cost_usd);
+        } catch (err) {
+          logger?.warn?.(`Cost write failed for ${huId}: ${err.message}`);
+        }
+      }
     } catch (err) {
       logger?.warn?.(`Live outcome update failed for ${huId}: ${err.message}`);
     }

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -360,7 +360,11 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
     onStatusChange: ctx.session?._liveStatusUpdater || null,
     // PR3 (per-HU outcome): same pattern, but for the rich
     // outcome blob written ONCE per HU at the end of runSingleHu.
-    onOutcome: ctx.session?._liveOutcomeUpdater || null
+    onOutcome: ctx.session?._liveOutcomeUpdater || null,
+    // Cost D (KJC-TSK-0515): the sub-pipeline slices BudgetTracker
+    // entries per HU and stamps `outcome.cost_usd` so the board can
+    // show per-HU spend. Without this the tracker is invisible to it.
+    budgetTracker: ctx.budgetTracker || null
   });
 
   emitProgress(emitter, makeEvent("hu:sub-pipeline:end", { ...ctx.eventBase, stage: "hu-sub-pipeline" }, {

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -75,6 +75,37 @@ function buildHuTask(story) {
 }
 
 /**
+ * Sum the cost_usd of a slice of BudgetTracker entries. Returns null
+ * (not 0) when the slice is empty or contains no usable cost data —
+ * the board uses null as "unmeasured" and renders no badge, while 0
+ * means "really free run". Mixing the two would silently hide free
+ * runs and falsely show "$0.00" for runs with no telemetry.
+ *
+ * Cost D (KJC-TSK-0515): the orchestrator calls this once per HU at
+ * runSingleHu exit, passing the slice of entries recorded during that
+ * HU (snapshotted via the entries.length cursor before the iteration
+ * starts). The resulting number flows through buildHuOutcome →
+ * notifyOutcome → setStoryCost in inject-loaded-plan.js.
+ *
+ * @param {Array<{cost_usd?: number}>} entries
+ * @returns {number|null}
+ */
+function sumCostUsd(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+  let total = 0;
+  let hasAny = false;
+  for (const e of entries) {
+    const n = Number(e?.cost_usd);
+    if (Number.isFinite(n)) {
+      total += n;
+      hasAny = true;
+    }
+  }
+  if (!hasAny) return null;
+  return Math.round(total * 1e6) / 1e6;
+}
+
+/**
  * Build the per-HU outcome blob from whatever metadata the iteration
  * loop returned. Tolerant by design — most fields are optional and we
  * default to safe values so the board can render something useful
@@ -90,9 +121,11 @@ function buildHuTask(story) {
  * @param {object} args.iterResult — whatever runIterationFn returned
  * @param {string} args.status — HU_STATUS.* terminal value
  * @param {number} args.startedAt — Date.now() when runSingleHu started
+ * @param {Array} [args.huBudgetEntries] — slice of BudgetTracker
+ *   entries recorded during this HU. Cost D (KJC-TSK-0515).
  * @returns {object}
  */
-function buildHuOutcome({ story: _story, iterResult, status, startedAt }) {
+function buildHuOutcome({ story: _story, iterResult, status, startedAt, huBudgetEntries }) {
   const r = iterResult || {};
   const git = r.git || {};
   // Iterations are tracked in the standard pipeline as
@@ -123,6 +156,7 @@ function buildHuOutcome({ story: _story, iterResult, status, startedAt }) {
     pr_url: r.pr_url || r.prUrl || git.pr_url || null,
     blockers,
     summary,
+    cost_usd: sumCostUsd(huBudgetEntries),
     finishedAt: new Date().toISOString(),
   };
 }
@@ -134,7 +168,7 @@ function buildHuOutcome({ story: _story, iterResult, status, startedAt }) {
  * @param {object} params
  * @returns {Promise<{huId: string, approved: boolean, result?: object, error?: string, blockedDependents?: string[]}>}
  */
-async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null, onOutcome = null }) {
+async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null, onOutcome = null, budgetTracker = null }) {
   // PR1 (live HU status): every saveHuBatch should also notify the
   // plan JSON so the board reflects state in real time. Defined as a
   // local helper so we don't repeat the try/null-check boilerplate.
@@ -157,6 +191,16 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
   // outcome (wall-clock per HU is what the user needs in the board,
   // not internal stage timings).
   const huStartedAt = Date.now();
+  // Cost D (KJC-TSK-0515): snapshot the budget cursor so we can slice
+  // out only the entries this HU produced. BudgetTracker is session-
+  // scoped (it accumulates across all HUs of the run), so without this
+  // cursor every HU after the first would inherit the previous ones'
+  // cost too. Null-safe — older callers without a tracker still work.
+  const huBudgetStartIdx = budgetTracker?.entries?.length ?? 0;
+  const sliceHuBudget = () => {
+    if (!budgetTracker?.entries) return [];
+    return budgetTracker.entries.slice(huBudgetStartIdx);
+  };
   const story = batch.stories.find(s => s.id === storyId);
 
   // --- Lazy refinement ---
@@ -226,7 +270,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
       await saveHuBatch(batchSessionId, batch);
       await notifyStatus(story.id, HU_STATUS.DONE);
       // PR3: build + persist the per-HU outcome.
-      const okOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.DONE, startedAt: huStartedAt });
+      const okOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.DONE, startedAt: huStartedAt, huBudgetEntries: sliceHuBudget() });
       await notifyOutcome(story.id, okOutcome);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → done`,
@@ -242,7 +286,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
       updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
       await saveHuBatch(batchSessionId, batch);
       await notifyStatus(story.id, HU_STATUS.FAILED);
-      const failOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.FAILED, startedAt: huStartedAt });
+      const failOutcome = buildHuOutcome({ story, iterResult, status: HU_STATUS.FAILED, startedAt: huStartedAt, huBudgetEntries: sliceHuBudget() });
       await notifyOutcome(story.id, failOutcome);
       emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
         message: `HU ${story.id} status → failed`,
@@ -259,7 +303,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
     updateStoryStatus(batch, story.id, HU_STATUS.FAILED);
     await saveHuBatch(batchSessionId, batch);
     await notifyStatus(story.id, HU_STATUS.FAILED);
-    const errOutcome = buildHuOutcome({ story, iterResult: { error: err.message }, status: HU_STATUS.FAILED, startedAt: huStartedAt });
+    const errOutcome = buildHuOutcome({ story, iterResult: { error: err.message }, status: HU_STATUS.FAILED, startedAt: huStartedAt, huBudgetEntries: sliceHuBudget() });
     await notifyOutcome(story.id, errOutcome);
     emitProgress(emitter, makeEvent("hu:status-change", { ...eventBase, stage: "hu-sub-pipeline" }, {
       message: `HU ${story.id} status → failed`,
@@ -287,7 +331,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
  * @param {object} params.logger - Logger instance
  * @returns {Promise<{approved: boolean, results: object[], blockedIds: string[]}>}
  */
-export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null, onStatusChange = null, onOutcome = null }) {
+export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitter, eventBase, logger, config = null, onStatusChange = null, onOutcome = null, budgetTracker = null }) {
   const batchSessionId = huReviewerResult.batchSessionId;
   let batch;
   try {
@@ -404,7 +448,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
       // Single HU: run as before, no worktree needed
       const singleResult = await runSingleHu({
         storyId: runnableIds[0], batch, batchSessionId, runIterationFn,
-        emitter, eventBase, logger, config, results, onStatusChange, onOutcome
+        emitter, eventBase, logger, config, results, onStatusChange, onOutcome, budgetTracker
       });
       results.push(singleResult);
       if (!singleResult.approved) {
@@ -443,7 +487,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
           storyId, batch, batchSessionId, runIterationFn,
           emitter, eventBase, logger, config, results,
           worktreePath: worktrees.get(storyId),
-          onStatusChange, onOutcome
+          onStatusChange, onOutcome, budgetTracker
         });
       });
 

--- a/tests/hu/hu-sub-pipeline.test.js
+++ b/tests/hu/hu-sub-pipeline.test.js
@@ -638,4 +638,118 @@ describe("hu-sub-pipeline", () => {
       expect(statusCalls[2][2]).toBe("failed");
     });
   });
+
+  // -------------------------------------------------------------------
+  // Cost D (KJC-TSK-0515): the sub-pipeline must slice BudgetTracker
+  // entries per HU so each card's outcome carries `cost_usd` with the
+  // spend of THAT HU (not the cumulative session total). Without the
+  // per-HU cursor, every HU after the first would inherit prior HUs'
+  // cost — a board-level bug only visible at runtime.
+  // -------------------------------------------------------------------
+  describe("runHuSubPipeline — Cost D: per-HU cost_usd in outcome", () => {
+    it("stamps outcome.cost_usd from the slice of BudgetTracker entries recorded during the HU", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "First" }, original: { text: "First" }, blocked_by: [] },
+        { id: "HU-002", status: "certified", certified: { text: "Second" }, original: { text: "Second" }, blocked_by: ["HU-001"] }
+      ];
+      const batch = { session_id: "hu-s_cost", stories: [...stories] };
+      loadHuBatchMock.mockResolvedValue(batch);
+
+      // Simulated BudgetTracker — its `record` happens inside
+      // runIterationFn (the coder/reviewer push entries during their
+      // calls). We mimic that here so the test mirrors production.
+      const budgetTracker = { entries: [] };
+      let huCounter = 0;
+      const runIterationFn = vi.fn(async () => {
+        huCounter += 1;
+        budgetTracker.entries.push({ role: "coder", cost_usd: huCounter === 1 ? 0.10 : 0.30 });
+        budgetTracker.entries.push({ role: "reviewer", cost_usd: huCounter === 1 ? 0.05 : 0.20 });
+        return { approved: true };
+      });
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_cost" },
+        runIterationFn,
+        emitter, eventBase, logger,
+        onOutcome,
+        budgetTracker
+      });
+
+      expect(outcomes).toHaveLength(2);
+      // First HU billed 0.10 + 0.05 = 0.15.
+      expect(outcomes[0].huId).toBe("HU-001");
+      expect(outcomes[0].outcome.cost_usd).toBeCloseTo(0.15, 6);
+      // Second HU billed only its own slice: 0.30 + 0.20 = 0.50.
+      // If the cursor were missing, this would be 0.65 (accumulated).
+      expect(outcomes[1].huId).toBe("HU-002");
+      expect(outcomes[1].outcome.cost_usd).toBeCloseTo(0.50, 6);
+    });
+
+    it("stamps outcome.cost_usd = null when no tracker entries were produced for the HU", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "x" }, original: { text: "x" }, blocked_by: [] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_no", stories: [...stories] });
+      const budgetTracker = { entries: [] }; // empty, no entries added
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_no" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome, budgetTracker
+      });
+
+      expect(outcomes[0].outcome.cost_usd).toBeNull();
+    });
+
+    it("stamps outcome.cost_usd = null when no tracker is passed (legacy callers)", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "x" }, original: { text: "x" }, blocked_by: [] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_legacy", stories: [...stories] });
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_legacy" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome
+        // no budgetTracker — verifies null-safety
+      });
+
+      expect(outcomes[0].outcome.cost_usd).toBeNull();
+    });
+
+    it("still stamps cost_usd on a failed HU so the board can show 'we spent X before failing'", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "fail" }, original: { text: "fail" }, blocked_by: [] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_fail", stories: [...stories] });
+      const budgetTracker = { entries: [] };
+      const runIterationFn = vi.fn(async () => {
+        budgetTracker.entries.push({ role: "coder", cost_usd: 0.42 });
+        return { approved: false, reason: "review_rejected" };
+      });
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_fail" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome, budgetTracker
+      });
+
+      expect(outcomes[0].outcome.status).toBe("failed");
+      expect(outcomes[0].outcome.cost_usd).toBeCloseTo(0.42, 6);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Cost D closes the loop between `BudgetTracker` and the HU Board UI. Without this PR, `board.db.cost_usd` stayed `NULL` forever and Cost F (per-HU badge) + Cost G (project total chip) had no data to render.

## Changes
- **`hu-sub-pipeline.js`**: per-HU cost slicing via cursor snapshot
  - Capture `budgetTracker.entries.length` at HU start
  - On exit, slice from that index and sum `cost_usd` into `outcome.cost_usd`
  - `sumCostUsd()` returns `null` for empty/unusable arrays — preserves the **null = unmeasured** vs **0 = real free run** semantic
- **`run-hu-batch.js`**: forward `ctx.budgetTracker` into `runHuSubPipeline`
- **`inject-loaded-plan.js`**: `setLiveOutcomeUpdater` now lazy-imports `hu-board/src/db.js` and calls `setStoryCost(huId, outcome.cost_usd)` when finite
- **+4 tests** in `tests/hu/hu-sub-pipeline.test.js`:
  - nominal slice (2 HUs → each gets its own slice, not cumulative)
  - no tracker entries → `null`
  - no tracker passed (legacy callers) → `null`
  - failed HU still stamps cost (board can show "spent X before failing")

## Why null vs 0
`BudgetTracker` records `cost_usd` per entry. An HU with no entries doesn't mean it cost `$0.00` — it means we never measured it. `formatCost()` already hides the badge for `null` cost; rendering `$0.00` for an unmeasured HU would be misleading.

## Why slice instead of total
`BudgetTracker` is session-scoped — it accumulates across all HUs in the run. Without the cursor, every HU would be stamped with the cumulative spend so far. The cursor-snapshot pattern keeps the spend per HU isolated.

## Test plan
- [x] `npx vitest run tests/hu/hu-sub-pipeline.test.js` → 25/25 ✔
- [ ] CI green
- [ ] After merge: `kj run --plan <id>` writes non-NULL `cost_usd` to `board.db` for each finished HU, Cost F badge visible.

Closes KJC-TSK-0515 (Cost D).