### PR TITLE
chore: release v3.2.0 — Cost epic complete (KJC-PCS-0055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-07
+
+Cost tracking end-to-end (epic KJC-PCS-0055 closed). Every HU run now
+records its USD spend; the HU Board surfaces it as a per-card badge and a
+project total chip. **No breaking changes** — `cost_usd` is additive and
+null-safe (badge hides when unmeasured, never "$0.00" by mistake).
+
 ### Added
 
+- **Cost A — model pricing registry** (KJC-TSK-0512) — `model-pricing.json`
+  with input/output USD-per-token for Claude, GPT, Gemini, local models.
+  Versioned, lookup is exact-match then prefix fallback.
+- **Cost B — cost aggregator** (KJC-TSK-0513) — `aggregateRunCost()` reduces
+  a list of `BudgetTracker` entries into `{totalUsd, byModel, byProvider,
+  unknownModelTokens}`. Unknown models surface their token counts so the
+  user knows what's missing pricing.
+- **Cost C — board.db schema** (KJC-TSK-0514) — idempotent migration adds
+  `cost_usd REAL` column on `stories`. NULL = unmeasured, 0 = free run.
+- **Cost D — orchestrator → board write** (KJC-TSK-0515) — per-HU cost is
+  sliced from the session `BudgetTracker` via cursor snapshot (entries at
+  HU-start vs at HU-end) and persisted to `board.db` through
+  `setLiveOutcomeUpdater`. Lazy import of hu-board keeps the pre-loop free
+  of board deps until needed.
+- **Cost E — `/api/projects/:id/cost`** (KJC-TSK-0516) — returns `{totalUsd,
+  byPlan, unknownModelTokens, currency}` for a project. Aggregates across
+  all plans, isolates unknown-model token leakage.
+- **Cost F — HU card badge** (KJC-TSK-0517) — `formatCost(cost_usd)` renders
+  `$0.02` label + `Estimated cost: $0.0234` tooltip. Hidden when null.
+- **Cost G — project total chip** (KJC-TSK-0518) — `formatProjectCostSummary`
+  builds a header chip with per-plan breakdown. Hidden when nothing to show.
 - `kj doctor` and `kj init` ai-trash integration (KJC-TSK-0391). Doctor
   surfaces a WARN when `kj-trash` is missing on PATH (destructive ops
   unprotected). Init now auto-registers the Claude Code PreToolUse hook via
   `kj-trash install --claude-code` when the binary is present; opt-out via
   `--no-ai-trash`. Follows the RTK/Squeezr default-on pattern.
+
+### Notes
+
+- Null vs 0 semantic preserved end-to-end: `BudgetTracker` empty → outcome
+  null → board.db NULL → UI hides badge. A measured free run still renders
+  `$0.00`.
+- `BudgetTracker` is session-scoped; the cursor-snapshot pattern
+  (`entries.slice(huBudgetStartIdx)`) isolates per-HU spend without losing
+  cumulative totals.
 
 ## [3.1.0] - 2026-06-05
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.1.0 released** — first minor on v3. Bundles tool-correctness judge and TDD-discipline as new quality gates, `kj clean --all/--vector-stores/--repo` for housekeeping, `kj sync --apply` closing the SPDD loop, semantic test-diet auditor (498 test files, 0 loss-of-meaning findings), HU Board structural refactor (17 PRs), and a batch of security + flake fixes. No breaking changes; drop-in upgrade from v3.0.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.2.0 released** — Cost tracking end-to-end (epic KJC-PCS-0055 closed). Every `kj run` now records per-HU USD spend via the `BudgetTracker` cursor-snapshot pattern, persists it to `board.db.cost_usd`, and the HU Board surfaces both a per-card badge (`$0.02`) and a project-wide chip with per-plan breakdown. Null-safe: unmeasured HUs hide the badge instead of misleading "$0.00". Drop-in upgrade from v3.1.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.1.0
+kj --version    # 3.2.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.1.0
+kj --version    # 3.2.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
Releases v3.2.0. Closes the **Cost** epic (KJC-PCS-0055): Cost A through G now ship together.

- Cost A — model-pricing.json registry (KJC-TSK-0512)
- Cost B — cost-aggregator util (KJC-TSK-0513)
- Cost C — board.db schema migration (KJC-TSK-0514)
- Cost D — orchestrator → board write (KJC-TSK-0515, #1031)
- Cost E — \`/api/projects/:id/cost\` (KJC-TSK-0516)
- Cost F — HU card badge (KJC-TSK-0517)
- Cost G — project total chip (KJC-TSK-0518, #1030)

Result: every \`kj run\` now records per-HU USD spend via the BudgetTracker cursor-snapshot pattern, persists to \`board.db.cost_usd\`, and the HU Board surfaces both a per-card badge and a project total chip with per-plan breakdown. Null-safe end-to-end.

## Changes
- \`package.json\` + \`package-lock.json\`: 3.1.0 → 3.2.0
- \`CHANGELOG.md\`: [3.2.0] entry with Added + Notes sections
- \`README.md\`: banner refreshed
- \`docs/GETTING-STARTED.md\` + \`docs/es/GETTING-STARTED.md\`: version hint

## Test plan
- [x] Local tests on cost-related files passing
- [ ] CI green
- [ ] After merge: tag v3.2.0, gh release, npm publish, landing update