### PR TITLE
feat(agents): claude cache tokens en usage (KJC-TSK-0519)

### DIFF
--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -68,8 +68,16 @@ function collectAssistantText(obj) {
 /**
  * Extract usage metrics from stream-json/json NDJSON output.
  * Looks for the "result" line which contains total_cost_usd,
- * usage.input_tokens/output_tokens, and modelUsage.
- * Returns an object with tokens_in, tokens_out, cost_usd, model or null if not found.
+ * usage.input_tokens/output_tokens, cache_read_input_tokens,
+ * cache_creation_input_tokens, and modelUsage.
+ *
+ * `cached_tokens` aggregates both cache_read_input_tokens (tokens served
+ * from Anthropic's automatic prompt cache) and cache_creation_input_tokens
+ * (tokens just written to the cache during this call). The sum represents
+ * the total volume of input that benefited from prompt-caching machinery.
+ *
+ * Returns an object with tokens_in, tokens_out, cached_tokens, cost_usd,
+ * model or null if not found.
  */
 function extractUsageFromStreamJson(raw) {
   const events = parseClaudeEvents(raw);
@@ -79,11 +87,14 @@ function extractUsageFromStreamJson(raw) {
 
     const tokens_in = obj.usage?.input_tokens ?? 0;
     const tokens_out = obj.usage?.output_tokens ?? 0;
+    const cache_read = obj.usage?.cache_read_input_tokens ?? 0;
+    const cache_creation = obj.usage?.cache_creation_input_tokens ?? 0;
+    const cached_tokens = cache_read + cache_creation;
     const cost_usd = obj.total_cost_usd ?? undefined;
     const modelUsage = obj.modelUsage;
     const model = modelUsage ? Object.keys(modelUsage)[0] || null : null;
 
-    return { tokens_in, tokens_out, cost_usd, model };
+    return { tokens_in, tokens_out, cached_tokens, cost_usd, model };
   }
   return null;
 }

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -213,12 +213,12 @@ describe("ClaudeAgent", () => {
     it.each([
       ["runTask", "coder", { type: "result", result: "done", total_cost_usd: 0.117, usage: usage(3000, 4000),
         modelUsage: { "claude-opus-4-6[1m]": { inputTokens: 3000, outputTokens: 4000, costUSD: 0.117 } } },
-        { tokens_in: 3000, tokens_out: 4000, cost_usd: 0.117, model: "claude-opus-4-6[1m]" }],
+        { tokens_in: 3000, tokens_out: 4000, cost_usd: 0.117, model: "claude-opus-4-6[1m]", cached_tokens: 0 }],
       ["reviewTask", "reviewer", { type: "result", result: "review", total_cost_usd: 0.03, usage: usage(500, 800),
         modelUsage: { haiku: { inputTokens: 500, outputTokens: 800, costUSD: 0.03 } } },
-        { tokens_in: 500, tokens_out: 800, cost_usd: 0.03, model: "haiku" }],
+        { tokens_in: 500, tokens_out: 800, cost_usd: 0.03, model: "haiku", cached_tokens: 0 }],
       ["runTask", "coder", { type: "result", result: "done", total_cost_usd: 0.01, usage: usage(100, 200) },
-        { tokens_in: 100, tokens_out: 200, cost_usd: 0.01, model: null }]
+        { tokens_in: 100, tokens_out: 200, cost_usd: 0.01, model: null, cached_tokens: 0 }]
     ])("%s extracts tokens/cost/model", async (method, role, ndjson, exp) => {
       runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: JSON.stringify(ndjson) });
       const result = await new ClaudeAgent("claude", baseConfig, logger)[method]({ prompt: "t", role });
@@ -226,6 +226,27 @@ describe("ClaudeAgent", () => {
       expect(result.tokens_out).toBe(exp.tokens_out);
       expect(result.cost_usd).toBe(exp.cost_usd);
       expect(result.model).toBe(exp.model);
+      expect(result.cached_tokens).toBe(exp.cached_tokens);
+    });
+
+    // Φ0-A — Phase 0 cache metrics: Anthropic exposes both cache_read_input_tokens
+    // (served from automatic prompt cache) and cache_creation_input_tokens (just
+    // written to cache). cached_tokens aggregates both — the total volume of
+    // input that touched the caching machinery this call.
+    it.each([
+      ["cache read only", { input_tokens: 200, output_tokens: 100, cache_read_input_tokens: 1500 }, 1500],
+      ["cache creation only", { input_tokens: 200, output_tokens: 100, cache_creation_input_tokens: 800 }, 800],
+      ["read + creation mixed", {
+        input_tokens: 200, output_tokens: 100,
+        cache_read_input_tokens: 1500, cache_creation_input_tokens: 800
+      }, 2300]
+    ])("extracts cached_tokens: %s", async (_name, usageObj, expectedCached) => {
+      const ndjson = { type: "result", result: "ok", total_cost_usd: 0.05, usage: usageObj };
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: JSON.stringify(ndjson) });
+      const result = await new ClaudeAgent("claude", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.cached_tokens).toBe(expectedCached);
+      expect(result.tokens_in).toBe(200);
+      expect(result.tokens_out).toBe(100);
     });
   });
 


### PR DESCRIPTION
## Summary

Primer paso de **Phase 0 — Cross-provider cache metrics** (epic KJC-PCS-0056). Extrae `cache_read_input_tokens` + `cache_creation_input_tokens` del stream-json/json de Claude y los expone como `cached_tokens` en el `AgentUsage` devuelto por `ClaudeAgent.runTask`/`reviewTask`.

Sin Φ0-A, el caching automático de Anthropic no se mide en ningún sitio: los tokens cacheados ya se ahorran (Anthropic los factura a 10%), pero Karajan no lo sabe ni lo muestra.

## Cambios

- `src/agents/claude-agent.js`: `extractUsageFromStreamJson` añade `cached_tokens = cache_read_input_tokens + cache_creation_input_tokens` (default 0).
- `tests/agents/claude-agent.test.js`: 3 casos nuevos (solo read, solo creation, mixto) + baseline `cached_tokens: 0` en los 3 existentes.

## Test plan

- [x] `npx vitest run tests/agents/claude-agent.test.js` → 37/37 green
- [x] `npx vitest run tests/agents` → 311/311 green
- [ ] Verificar en CI

## Atomicidad

38 LOC añadidas / 6 eliminadas (44 LOC delta) — dentro del presupuesto de 200.

## Próximos pasos (Phase 0)

- Φ0-B (KJC-TSK-0520): Codex/OpenAI `prompt_tokens_details.cached_tokens`
- Φ0-C (KJC-TSK-0521): Gemini context-caching
- Φ0-D (KJC-TSK-0522): Aider y OpenCode vía LiteLLM
- Φ0-E..H: BudgetTracker, summary.md, HU Board, telemetría