### PR TITLE
feat(agents): codex extract prompt_tokens_details.cached_tokens (KJC-TSK-0520)

### DIFF
--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -2,18 +2,55 @@ import { BaseAgent } from "./base-agent.js";
 import { resolveBin } from "./resolve-bin.js";
 
 /**
- * Extract token usage from Codex CLI stdout.
- * Codex prints "tokens used\n<number>" at the end, where number may have comma separators.
- * Returns { tokens_out } with the total token count, or null if not found.
- * Since Codex doesn't split input/output, we assign the total to tokens_out
- * as a conservative estimate for cost calculation.
+ * Try to extract an OpenAI-style `usage` JSON block from codex stdout.
+ *
+ * OpenAI's Chat Completions API exposes prompt-cache hits via
+ * `usage.prompt_tokens_details.cached_tokens` (since Aug 2024). Codex
+ * CLI doesn't surface this in its default footer, but newer flags or a
+ * wrapper may emit a JSON `usage` line. We scan stdout line-by-line and
+ * accept the first parseable object that carries `prompt_tokens`.
+ *
+ * Returns `{tokens_in, tokens_out, cached_tokens}` or null when absent.
+ */
+function extractJsonUsage(stdout) {
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let obj;
+    try { obj = JSON.parse(trimmed); } catch { continue; }
+    const usage = obj?.usage ?? (typeof obj?.prompt_tokens === "number" ? obj : null);
+    if (!usage || typeof usage.prompt_tokens !== "number") continue;
+    return {
+      tokens_in: usage.prompt_tokens,
+      tokens_out: usage.completion_tokens ?? 0,
+      cached_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0
+    };
+  }
+  return null;
+}
+
+/**
+ * Extract token usage from Codex CLI stdout. Two shapes are supported:
+ *
+ *   1. OpenAI-style JSON `usage` block (preferred):
+ *      `{"usage":{"prompt_tokens":N,"completion_tokens":M,
+ *                 "prompt_tokens_details":{"cached_tokens":C}}}`
+ *      → `{tokens_in:N, tokens_out:M, cached_tokens:C}`.
+ *
+ *   2. Legacy "tokens used\n<number>" footer (codex's default total,
+ *      no cache visibility) → `{tokens_in:0, tokens_out, cached_tokens:0}`.
+ *
+ * Returns null when neither shape is found.
  */
 function extractCodexTokens(stdout) {
-  const match = (stdout || "").match(/tokens?\s+used\s*\n\s*([\d,]+)/i);
+  if (!stdout) return null;
+  const json = extractJsonUsage(stdout);
+  if (json) return json;
+  const match = stdout.match(/tokens?\s+used\s*\n\s*([\d,]+)/i);
   if (!match) return null;
   const total = Number(match[1].replaceAll(/,/g, ""));
   if (!Number.isFinite(total) || total <= 0) return null;
-  return { tokens_in: 0, tokens_out: total };
+  return { tokens_in: 0, tokens_out: total, cached_tokens: 0 };
 }
 
 export class CodexAgent extends BaseAgent {

--- a/tests/agents/codex-agent.test.js
+++ b/tests/agents/codex-agent.test.js
@@ -181,4 +181,36 @@ describe("CodexAgent", () => {
       expect(result.tokens_out).toBe(expected.tokens_out);
     });
   });
+
+  // Φ0-B — Phase 0 cache metrics: OpenAI Chat Completions API exposes
+  // `usage.prompt_tokens_details.cached_tokens` for prompt-cache hits.
+  // We parse this when present, fall back to 0 when missing, and stay
+  // robust against malformed JSON lines mixed in stdout.
+  describe("cached_tokens extraction from OpenAI usage JSON", () => {
+    it.each([
+      ["with cached_tokens", `pre\n{"usage":{"prompt_tokens":2000,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":1500}}}\npost`,
+        { tokens_in: 2000, tokens_out: 300, cached_tokens: 1500 }],
+      ["usage without prompt_tokens_details", `{"usage":{"prompt_tokens":500,"completion_tokens":120}}`,
+        { tokens_in: 500, tokens_out: 120, cached_tokens: 0 }],
+      ["bare object (no `usage` wrapper)", `{"prompt_tokens":100,"completion_tokens":50,"prompt_tokens_details":{"cached_tokens":40}}`,
+        { tokens_in: 100, tokens_out: 50, cached_tokens: 40 }],
+      ["malformed JSON falls back to legacy regex",
+        `not-json {"usage": broken\ntokens used\n4,096\n`,
+        { tokens_in: 0, tokens_out: 4096, cached_tokens: 0 }]
+    ])("%s", async (_n, stdout, expected) => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout, stderr: "" });
+      const result = await new CodexAgent("codex", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(result.tokens_in).toBe(expected.tokens_in);
+      expect(result.tokens_out).toBe(expected.tokens_out);
+      expect(result.cached_tokens).toBe(expected.cached_tokens);
+    });
+
+    it("returns undefined cached_tokens when no usage data at all", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "just regular output", stderr: "" });
+      const result = await new CodexAgent("codex", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.cached_tokens).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Φ0-B de Phase 0 (KJC-PCS-0056) — instrumenta el Codex/OpenAI agent para extraer `usage.prompt_tokens_details.cached_tokens` (shape OpenAI Chat Completions, vigente desde ago-2024).

- `extractCodexTokens` ahora intenta primero parsear un bloque JSON `usage` en stdout (`prompt_tokens` + `completion_tokens` + `prompt_tokens_details.cached_tokens`).
- Si no aparece, fallback al footer legacy `tokens used\n<N>` con `cached_tokens = 0`.
- El campo `cached_tokens` se propaga automáticamente al resultado vía el spread `...usage` existente.
- Sin breaking changes: stdout sin tokens sigue devolviendo `tokens_in/tokens_out/cached_tokens` undefined.

## Test plan
- [x] `npx vitest run tests/agents/codex-agent.test.js` → 27/27 (5 nuevos sub-casos en `it.each` + 1 ungated)
- [x] `npx vitest run tests/agents/` → 316/316 (sin regresiones en otros agentes)
- [x] Lint limpio

## Acceptance criteria
- Given stdout with usage JSON containing `prompt_tokens_details.cached_tokens` → returns `{tokens_in, tokens_out, cached_tokens}` ✅
- Given stdout without `prompt_tokens_details` → `cached_tokens = 0` ✅
- Tests cover: with caching, without caching, malformed response ✅