### PR TITLE
feat(agents): gemini cachedContentTokenCount via usageMetadata (KJC-TSK-0521)

### DIFF
--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -1,6 +1,41 @@
 import { BaseAgent } from "./base-agent.js";
 import { resolveBin } from "./resolve-bin.js";
 
+/**
+ * Extract Gemini's `usageMetadata` from stdout, including
+ * `cachedContentTokenCount` (Gemini's context-caching API metric,
+ * https://ai.google.dev/api/caching).
+ *
+ * The gemini CLI emits `usageMetadata` as part of its JSON response
+ * shape (today: only `--output-format json`, used in reviewTask; in
+ * plain runTask mode no usage is surfaced). When absent, returns null
+ * so the caller leaves `cached_tokens` undefined (= unmeasured,
+ * distinct from a measured 0).
+ */
+export function extractGeminiUsage(text) {
+  if (!text) return null;
+  const candidates = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (t.startsWith("{") || t.startsWith("[")) candidates.push(t);
+  }
+  candidates.push(text.trim());
+  for (const candidate of candidates) {
+    let obj;
+    try { obj = JSON.parse(candidate); } catch { continue; }
+    const meta = obj?.usageMetadata
+      ?? obj?.usage_metadata
+      ?? obj?.response?.usageMetadata;
+    if (!meta || typeof meta.promptTokenCount !== "number") continue;
+    return {
+      tokens_in: meta.promptTokenCount,
+      tokens_out: meta.candidatesTokenCount ?? 0,
+      cached_tokens: meta.cachedContentTokenCount ?? 0
+    };
+  }
+  return null;
+}
+
 export class GeminiAgent extends BaseAgent {
   async runTask(task) {
     const role = task.role || "coder";
@@ -33,6 +68,7 @@ export class GeminiAgent extends BaseAgent {
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs
     });
-    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+    const usage = extractGeminiUsage(res.stdout) ?? extractGeminiUsage(res.stderr);
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode, ...usage };
   }
 }

--- a/tests/agents/gemini-agent.test.js
+++ b/tests/agents/gemini-agent.test.js
@@ -118,4 +118,47 @@ describe("GeminiAgent", () => {
     expect(opts.silenceTimeoutMs).toBe(15000);
     expect(opts.timeout).toBe(90000);
   });
+
+  // Φ0-C — Phase 0 cache metrics for Gemini context-caching API.
+  // Gemini surfaces `usageMetadata.cachedContentTokenCount` whenever
+  // the response uses a cached context (https://ai.google.dev/api/caching).
+  // The CLI exposes this via --output-format json (today: reviewTask
+  // only). Plain runTask currently leaves cached_tokens undefined =
+  // unmeasured.
+  describe("cached_tokens extraction from gemini usageMetadata", () => {
+    it.each([
+      ["with cachedContentTokenCount",
+        `{"response":"ok","usageMetadata":{"promptTokenCount":1500,"candidatesTokenCount":400,"cachedContentTokenCount":1200,"totalTokenCount":1900}}`,
+        { tokens_in: 1500, tokens_out: 400, cached_tokens: 1200 }],
+      ["usageMetadata without cachedContentTokenCount",
+        `{"response":"ok","usageMetadata":{"promptTokenCount":800,"candidatesTokenCount":200,"totalTokenCount":1000}}`,
+        { tokens_in: 800, tokens_out: 200, cached_tokens: 0 }],
+      ["snake_case usage_metadata variant",
+        `{"usage_metadata":{"promptTokenCount":300,"candidatesTokenCount":150,"cachedContentTokenCount":250}}`,
+        { tokens_in: 300, tokens_out: 150, cached_tokens: 250 }],
+      ["nested under response wrapper",
+        `{"response":{"usageMetadata":{"promptTokenCount":600,"candidatesTokenCount":120,"cachedContentTokenCount":500}}}`,
+        { tokens_in: 600, tokens_out: 120, cached_tokens: 500 }]
+    ])("%s", async (_n, stdout, expected) => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout, stderr: "" });
+      const result = await new GeminiAgent("gemini", baseConfig, logger).reviewTask({ prompt: "r", role: "reviewer" });
+      expect(result.tokens_in).toBe(expected.tokens_in);
+      expect(result.tokens_out).toBe(expected.tokens_out);
+      expect(result.cached_tokens).toBe(expected.cached_tokens);
+    });
+
+    it("leaves cached_tokens undefined when stdout has no usageMetadata (unmeasured)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "plain response text\n", stderr: "" });
+      const result = await new GeminiAgent("gemini", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.tokens_in).toBeUndefined();
+      expect(result.tokens_out).toBeUndefined();
+      expect(result.cached_tokens).toBeUndefined();
+    });
+
+    it("ignores malformed JSON in stdout and stays unmeasured", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: '{"usageMetadata": not-valid json}', stderr: "" });
+      const result = await new GeminiAgent("gemini", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.cached_tokens).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Φ0-C de Phase 0 (KJC-PCS-0056) — Gemini context-caching API metric.

- Nuevo `extractGeminiUsage()` parsea `usageMetadata` (o `usage_metadata`, o anidado bajo `response.usageMetadata`) y devuelve `{tokens_in, tokens_out, cached_tokens}` extrayendo `promptTokenCount`, `candidatesTokenCount`, `cachedContentTokenCount`.
- Cuando no hay `usageMetadata` (stdout plano de `runTask`), devuelve null → `cached_tokens` queda undefined = unmeasured. Distinto del 0 medido.
- Path activo: `reviewTask` con `--output-format json` ya emite el bloque. `runTask` plain stays unmeasured hasta que el CLI exponga JSON estable en modo run.

## Test plan
- [x] `npx vitest run tests/agents/gemini-agent.test.js` → 17/17 (6 nuevos sub-casos)
- [x] `npx vitest run tests/agents/` → 322/322 (sin regresiones)
- [x] Lint limpio

## Acceptance criteria
- Given gemini stdout con `usageMetadata.cachedContentTokenCount` → returns `{tokens_in, tokens_out, cached_tokens}` ✅
- Given gemini stdout sin caching → `cached_tokens = 0` cuando hay usageMetadata, `undefined` cuando no hay nada ✅
- Tests cover: 4 shapes positivos + 2 negativos (plain output, malformed) ✅