### PR TITLE
feat(agents): aider+opencode cached_tokens via LiteLLM (KJC-TSK-0522)

### DIFF
--- a/src/agents/aider-agent.js
+++ b/src/agents/aider-agent.js
@@ -1,6 +1,46 @@
 import { BaseAgent } from "./base-agent.js";
 import { resolveBin } from "./resolve-bin.js";
 
+/**
+ * Extract token usage from Aider's stdout. Two shapes are supported:
+ *
+ *   1. LiteLLM passthrough — an OpenAI-style JSON `usage` block surfaces
+ *      `prompt_tokens_details.cached_tokens` for prompt-cache hits.
+ *   2. Aider's native footer "Tokens: <sent> sent, <received> received
+ *      [, <cached> cache hit]." (supports comma-separated and `k` suffix).
+ *
+ * Returns `{tokens_in, tokens_out, cached_tokens}` or null when no usage
+ * is found (= unmeasured; callers leave the fields undefined).
+ */
+export function extractAiderUsage(text) {
+  if (!text) return null;
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    const u = obj?.usage ?? (typeof obj?.prompt_tokens === "number" ? obj : null);
+    if (!u || typeof u.prompt_tokens !== "number") continue;
+    return {
+      tokens_in: u.prompt_tokens,
+      tokens_out: u.completion_tokens ?? 0,
+      cached_tokens: u.prompt_tokens_details?.cached_tokens ?? 0
+    };
+  }
+  const m = text.match(/Tokens:\s*([\d.,]+k?)\s*sent,\s*([\d.,]+k?)\s*received(?:,\s*([\d.,]+k?)\s*cache\s*hit)?/i);
+  if (!m) return null;
+  const parse = (s) => {
+    const c = s.replaceAll(",", "");
+    return c.toLowerCase().endsWith("k")
+      ? Math.round(parseFloat(c.slice(0, -1)) * 1000)
+      : Number(c);
+  };
+  const sent = parse(m[1]);
+  const recv = parse(m[2]);
+  if (!Number.isFinite(sent) || !Number.isFinite(recv)) return null;
+  return { tokens_in: sent, tokens_out: recv, cached_tokens: m[3] ? parse(m[3]) : 0 };
+}
+
 export class AiderAgent extends BaseAgent {
   async runTask(task) {
     const role = task.role || "coder";
@@ -32,6 +72,7 @@ export class AiderAgent extends BaseAgent {
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs
     });
-    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+    const usage = extractAiderUsage(res.stdout) ?? extractAiderUsage(res.stderr);
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode, ...usage };
   }
 }

--- a/src/agents/opencode-agent.js
+++ b/src/agents/opencode-agent.js
@@ -1,6 +1,38 @@
 import { BaseAgent } from "./base-agent.js";
 import { resolveBin } from "./resolve-bin.js";
 
+/**
+ * Extract OpenAI-style `usage` from OpenCode stdout. With `--format json`
+ * (used in reviewTask) the CLI emits a JSON document; with LiteLLM-backed
+ * runs that document carries `usage.prompt_tokens_details.cached_tokens`.
+ *
+ * Accepts the whole payload, individual lines, or array elements with a
+ * nested `usage` object. Returns `{tokens_in, tokens_out, cached_tokens}`
+ * or null (= unmeasured).
+ */
+export function extractOpenCodeUsage(text) {
+  if (!text) return null;
+  const candidates = [text.trim()];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (t.startsWith("{") || t.startsWith("[")) candidates.push(t);
+  }
+  for (const candidate of candidates) {
+    let obj;
+    try { obj = JSON.parse(candidate); } catch { continue; }
+    const usage = obj?.usage
+      ?? obj?.result?.usage
+      ?? (Array.isArray(obj) ? obj.find((e) => e?.usage)?.usage : null);
+    if (!usage || typeof usage.prompt_tokens !== "number") continue;
+    return {
+      tokens_in: usage.prompt_tokens,
+      tokens_out: usage.completion_tokens ?? 0,
+      cached_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0
+    };
+  }
+  return null;
+}
+
 export class OpenCodeAgent extends BaseAgent {
   async runTask(task) {
     const role = task.role || "coder";
@@ -34,6 +66,7 @@ export class OpenCodeAgent extends BaseAgent {
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs
     });
-    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+    const usage = extractOpenCodeUsage(res.stdout) ?? extractOpenCodeUsage(res.stderr);
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode, ...usage };
   }
 }

--- a/tests/agents/aider-agent.test.js
+++ b/tests/agents/aider-agent.test.js
@@ -102,4 +102,39 @@ describe("AiderAgent", () => {
     expect(opts.silenceTimeoutMs).toBe(25000);
     expect(opts.timeout).toBe(80000);
   });
+
+  // Φ0-D — Aider passes through to providers via LiteLLM; when the
+  // underlying API returns OpenAI-style `usage` with `prompt_tokens_details
+  // .cached_tokens`, we surface it. We also parse aider's native footer
+  // (`Tokens: <sent> sent, <received> received[, <cached> cache hit]`).
+  describe("cached_tokens extraction (LiteLLM passthrough + native footer)", () => {
+    it.each([
+      ["OpenAI usage JSON with cached_tokens",
+        `pre\n{"usage":{"prompt_tokens":1800,"completion_tokens":420,"prompt_tokens_details":{"cached_tokens":1200}}}\n`,
+        { tokens_in: 1800, tokens_out: 420, cached_tokens: 1200 }],
+      ["native footer with commas + cache hit",
+        `Tokens: 4,096 sent, 1,234 received, 2,048 cache hit.\nCost: $0.05\n`,
+        { tokens_in: 4096, tokens_out: 1234, cached_tokens: 2048 }],
+      ["native footer with k suffix, no cache",
+        `Tokens: 4.2k sent, 1.0k received.\n`,
+        { tokens_in: 4200, tokens_out: 1000, cached_tokens: 0 }],
+      ["JSON malformed → fallback to native footer",
+        `not-json {usage: broken\nTokens: 500 sent, 200 received\n`,
+        { tokens_in: 500, tokens_out: 200, cached_tokens: 0 }]
+    ])("%s", async (_n, stdout, expected) => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout, stderr: "" });
+      const result = await new AiderAgent("aider", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.tokens_in).toBe(expected.tokens_in);
+      expect(result.tokens_out).toBe(expected.tokens_out);
+      expect(result.cached_tokens).toBe(expected.cached_tokens);
+    });
+
+    it("leaves usage fields undefined when no footer/JSON present (unmeasured)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "changes applied\n", stderr: "" });
+      const result = await new AiderAgent("aider", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.tokens_in).toBeUndefined();
+      expect(result.tokens_out).toBeUndefined();
+      expect(result.cached_tokens).toBeUndefined();
+    });
+  });
 });

--- a/tests/agents/opencode-agent.test.js
+++ b/tests/agents/opencode-agent.test.js
@@ -130,4 +130,43 @@ describe("OpenCodeAgent", () => {
       expect(opts.timeout).toBe(50000);
     });
   });
+
+  // Φ0-D — OpenCode often runs against LiteLLM-backed providers; when
+  // `--format json` (reviewTask) is on, the CLI emits a JSON document
+  // whose `usage` block carries `prompt_tokens_details.cached_tokens`.
+  describe("cached_tokens extraction (LiteLLM passthrough via --format json)", () => {
+    it.each([
+      ["root usage with cached_tokens",
+        `{"result":"ok","usage":{"prompt_tokens":2200,"completion_tokens":380,"prompt_tokens_details":{"cached_tokens":1700}}}`,
+        { tokens_in: 2200, tokens_out: 380, cached_tokens: 1700 }],
+      ["nested under result wrapper",
+        `{"result":{"text":"done","usage":{"prompt_tokens":900,"completion_tokens":150,"prompt_tokens_details":{"cached_tokens":600}}}}`,
+        { tokens_in: 900, tokens_out: 150, cached_tokens: 600 }],
+      ["array payload — usage on one element",
+        `[{"type":"chunk"},{"type":"final","usage":{"prompt_tokens":400,"completion_tokens":80}}]`,
+        { tokens_in: 400, tokens_out: 80, cached_tokens: 0 }],
+      ["line-delimited JSON in mixed output",
+        `pre\n{"usage":{"prompt_tokens":300,"completion_tokens":60,"prompt_tokens_details":{"cached_tokens":250}}}\npost`,
+        { tokens_in: 300, tokens_out: 60, cached_tokens: 250 }]
+    ])("%s", async (_n, stdout, expected) => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout, stderr: "" });
+      const result = await new OpenCodeAgent("opencode", baseConfig, logger).reviewTask({ prompt: "r", role: "reviewer" });
+      expect(result.tokens_in).toBe(expected.tokens_in);
+      expect(result.tokens_out).toBe(expected.tokens_out);
+      expect(result.cached_tokens).toBe(expected.cached_tokens);
+    });
+
+    it("leaves usage fields undefined when stdout is plain text (unmeasured)", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "plain output\n", stderr: "" });
+      const result = await new OpenCodeAgent("opencode", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.tokens_in).toBeUndefined();
+      expect(result.cached_tokens).toBeUndefined();
+    });
+
+    it("ignores malformed JSON and stays unmeasured", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: '{"usage": not-valid}', stderr: "" });
+      const result = await new OpenCodeAgent("opencode", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.cached_tokens).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 0-D — extracción de `cached_tokens` para los dos agentes que pasan por LiteLLM (aider, opencode). Cierra la cobertura cross-provider iniciada en Φ0-A (Anthropic), Φ0-B (OpenAI/Codex) y Φ0-C (Gemini).

- **aider-agent**: `extractAiderUsage` admite dos formas — JSON `usage` estilo OpenAI (passthrough LiteLLM con `prompt_tokens_details.cached_tokens`) y el footer nativo `Tokens: N sent, M received[, K cache hit]`. Soporta números con coma y sufijo `k`.
- **opencode-agent**: `extractOpenCodeUsage` parsea el documento JSON que emite `--format json` (usado por `reviewTask`) y busca `usage` en raíz, dentro de `result`, o en un elemento de array.

Contrato `null = unmeasured` idéntico al de los otros 3 extractores: `cached_tokens` queda `undefined` cuando el agente o el proveedor no emite información.

## Test plan
- [x] `npx vitest run tests/agents/aider-agent.test.js tests/agents/opencode-agent.test.js` → 32/32
- [ ] CI completo verde
- [ ] Sin regresiones en suites colindantes

Card: KJC-TSK-0522 (épica KJC-PCS-0056)