### PR TITLE
feat(budget): cursor-snapshot + cached_tokens (KJC-TSK-0523)

### DIFF
--- a/src/utils/budget.js
+++ b/src/utils/budget.js
@@ -26,6 +26,13 @@ export function extractUsageMetrics(result, defaultModel = null) {
     usage?.output_tokens ??
     usage?.completion_tokens ??
     0;
+  const cached_tokens =
+    result?.cached_tokens ??
+    usage?.cached_tokens ??
+    usage?.cache_read_input_tokens ??
+    usage?.prompt_tokens_details?.cached_tokens ??
+    usage?.cachedContentTokenCount ??
+    0;
   const cost_usd =
     result?.cost_usd ??
     usage?.cost_usd ??
@@ -58,7 +65,7 @@ export function extractUsageMetrics(result, defaultModel = null) {
     }
   }
 
-  return { tokens_in: finalTokensIn, tokens_out: finalTokensOut, cost_usd, model, estimated };
+  return { tokens_in: finalTokensIn, tokens_out: finalTokensOut, cached_tokens, cost_usd, model, estimated };
 }
 
 function toSafeNumber(value) {
@@ -79,9 +86,10 @@ function normalizeLimit(limit) {
 }
 
 function addToBreakdown(map, key, entry) {
-  const current = map[key] || { tokens_in: 0, tokens_out: 0, total_tokens: 0, total_cost_usd: 0, count: 0 };
+  const current = map[key] || { tokens_in: 0, tokens_out: 0, cached_tokens: 0, total_tokens: 0, total_cost_usd: 0, count: 0 };
   current.tokens_in += entry.tokens_in;
   current.tokens_out += entry.tokens_out;
+  current.cached_tokens += entry.cached_tokens || 0;
   current.total_tokens += entry.tokens_in + entry.tokens_out;
   current.total_cost_usd = roundUsd(current.total_cost_usd + entry.cost_usd);
   current.count += 1;
@@ -94,9 +102,10 @@ export class BudgetTracker {
     this.pricing = mergePricing(DEFAULT_MODEL_PRICING, options.pricing || {});
   }
 
-  record({ role, provider, model, tokens_in, tokens_out, cost_usd, duration_ms, stage_index, estimated } = {}) {
+  record({ role, provider, model, tokens_in, tokens_out, cached_tokens, cost_usd, duration_ms, stage_index, estimated } = {}) {
     const safeTokensIn = toSafeNumber(tokens_in);
     const safeTokensOut = toSafeNumber(tokens_out);
+    const safeCached = toSafeNumber(cached_tokens);
     const hasExplicitCost = cost_usd !== undefined && cost_usd !== null && cost_usd !== "";
     const modelName = model || provider || null;
     const computedCost = calculateUsageCostUsd({
@@ -113,6 +122,7 @@ export class BudgetTracker {
       timestamp: new Date().toISOString(),
       tokens_in: safeTokensIn,
       tokens_out: safeTokensOut,
+      cached_tokens: safeCached,
       cost_usd: roundUsd(hasExplicitCost ? cost_usd : computedCost)
     };
     if (duration_ms !== undefined && duration_ms !== null) {
@@ -129,19 +139,36 @@ export class BudgetTracker {
   }
 
   total() {
+    return this._aggregate(this.entries);
+  }
+
+  _aggregate(entries) {
     let tokensIn = 0;
     let tokensOut = 0;
+    let cached = 0;
     let totalCost = 0;
-    for (const entry of this.entries) {
+    for (const entry of entries) {
       tokensIn += entry.tokens_in;
       tokensOut += entry.tokens_out;
+      cached += entry.cached_tokens || 0;
       totalCost = roundUsd(totalCost + entry.cost_usd);
     }
-    return {
-      tokens_in: tokensIn,
-      tokens_out: tokensOut,
-      cost_usd: totalCost
-    };
+    return { tokens_in: tokensIn, tokens_out: tokensOut, cached_tokens: cached, cost_usd: totalCost };
+  }
+
+  /**
+   * Snapshot cursor (Φ0-E). Returns an opaque marker pointing at the current
+   * end of the entries log. Pair with `since(cursor)` to compute per-HU deltas
+   * without resetting global accumulators (per-HU isolation).
+   */
+  cursor() {
+    return this.entries.length;
+  }
+
+  since(cursor = 0) {
+    const start = Number.isFinite(cursor) && cursor >= 0 ? Math.min(cursor, this.entries.length) : 0;
+    const slice = this.entries.slice(start);
+    return { ...this._aggregate(slice), count: slice.length };
   }
 
   remaining(limit) {
@@ -171,6 +198,7 @@ export class BudgetTracker {
     const hasEstimates = this.entries.some(e => e.estimated);
     const result = {
       total_tokens: totals.tokens_in + totals.tokens_out,
+      total_cached_tokens: totals.cached_tokens,
       total_cost_usd: totals.cost_usd,
       breakdown_by_role: byRole,
       entries: [...this.entries],
@@ -191,6 +219,7 @@ export class BudgetTracker {
         duration_ms: entry.duration_ms ?? null,
         tokens_in: entry.tokens_in,
         tokens_out: entry.tokens_out,
+        cached_tokens: entry.cached_tokens || 0,
         cost_usd: entry.cost_usd
       };
       if (entry.estimated) item.estimated = true;

--- a/tests/budget.test.js
+++ b/tests/budget.test.js
@@ -10,6 +10,7 @@ describe("BudgetTracker", () => {
     expect(tracker.total()).toEqual({
       tokens_in: 140,
       tokens_out: 310,
+      cached_tokens: 0,
       cost_usd: 0.6
     });
   });
@@ -21,6 +22,7 @@ describe("BudgetTracker", () => {
     expect(tracker.total()).toEqual({
       tokens_in: 0,
       tokens_out: 0,
+      cached_tokens: 0,
       cost_usd: 0
     });
     expect(tracker.summary().entries).toHaveLength(1);
@@ -57,6 +59,7 @@ describe("BudgetTracker", () => {
     expect(tracker.total()).toEqual({
       tokens_in: 2000000,
       tokens_out: 1000000,
+      cached_tokens: 0,
       cost_usd: 7
     });
   });

--- a/tests/report-trace.test.js
+++ b/tests/report-trace.test.js
@@ -20,6 +20,7 @@ describe("BudgetTracker trace()", () => {
       duration_ms: 1200,
       tokens_in: 100,
       tokens_out: 50,
+      cached_tokens: 0,
       cost_usd: 0.1
     });
     expect(trace[1].index).toBe(1);

--- a/tests/utils/budget.test.js
+++ b/tests/utils/budget.test.js
@@ -124,6 +124,78 @@ describe("extractUsageMetrics", () => {
   });
 });
 
+// Φ0-E — `cached_tokens` is the cross-provider normalized metric. The agent
+// extractors (claude/codex/gemini/aider/opencode) already surface a top-level
+// `result.cached_tokens`, but extractUsageMetrics also accepts the raw shapes
+// from each provider (Anthropic `cache_read_input_tokens`, OpenAI
+// `prompt_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`).
+describe("extractUsageMetrics — cached_tokens (Φ0-E)", () => {
+  it.each([
+    ["top-level result.cached_tokens",        { tokens_in: 1, tokens_out: 1, cached_tokens: 1200 }, 1200],
+    ["nested usage.cached_tokens",            { usage: { input_tokens: 1, output_tokens: 1, cached_tokens: 800 } }, 800],
+    ["Anthropic cache_read_input_tokens",     { usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 600 } }, 600],
+    ["OpenAI prompt_tokens_details.cached",   { usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 400 } } }, 400],
+    ["Gemini cachedContentTokenCount",        { usage: { input_tokens: 1, output_tokens: 1, cachedContentTokenCount: 250 } }, 250],
+    ["missing → 0 (measured zero, not undefined)", { tokens_in: 1, tokens_out: 1 }, 0]
+  ])("%s", (_n, result, expected) => {
+    expect(extractUsageMetrics(result).cached_tokens).toBe(expected);
+  });
+});
+
+describe("BudgetTracker — cached_tokens accumulation (Φ0-E)", () => {
+  it("totals + summary surface cached_tokens across entries", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder",    provider: "claude", tokens_in: 1000, tokens_out: 200, cached_tokens: 700, cost_usd: 0.01 });
+    tracker.record({ role: "reviewer", provider: "codex",  tokens_in: 500,  tokens_out: 100, cached_tokens: 300, cost_usd: 0.02 });
+
+    expect(tracker.total().cached_tokens).toBe(1000);
+    const s = tracker.summary();
+    expect(s.total_cached_tokens).toBe(1000);
+    expect(s.breakdown_by_role.coder.cached_tokens).toBe(700);
+    expect(s.breakdown_by_role.reviewer.cached_tokens).toBe(300);
+    expect(tracker.trace()[0].cached_tokens).toBe(700);
+  });
+
+  it("treats undefined cached_tokens as 0 (preserves unmeasured semantics)", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "claude", tokens_in: 100, tokens_out: 50 });
+    expect(tracker.total().cached_tokens).toBe(0);
+    expect(tracker.entries[0].cached_tokens).toBe(0);
+  });
+});
+
+describe("BudgetTracker.cursor() + since() — per-HU isolation (Φ0-E)", () => {
+  it("cursor()=0 on empty tracker, since(0) returns zeroed delta", () => {
+    const tracker = new BudgetTracker();
+    expect(tracker.cursor()).toBe(0);
+    expect(tracker.since(0)).toEqual({ tokens_in: 0, tokens_out: 0, cached_tokens: 0, cost_usd: 0, count: 0 });
+  });
+
+  it("isolates per-HU deltas: cursor at HU2 start, since() returns only HU2 entries", () => {
+    const tracker = new BudgetTracker();
+    // HU1
+    tracker.record({ role: "coder", provider: "claude", tokens_in: 100, tokens_out: 50, cached_tokens: 70, cost_usd: 0.01 });
+    tracker.record({ role: "reviewer", provider: "codex", tokens_in: 80, tokens_out: 20, cached_tokens: 40, cost_usd: 0.02 });
+    const hu2Start = tracker.cursor();
+    expect(hu2Start).toBe(2);
+    // HU2
+    tracker.record({ role: "coder", provider: "claude", tokens_in: 200, tokens_out: 100, cached_tokens: 150, cost_usd: 0.03 });
+    tracker.record({ role: "reviewer", provider: "codex", tokens_in: 60, tokens_out: 30, cached_tokens: 50, cost_usd: 0.04 });
+
+    const delta = tracker.since(hu2Start);
+    expect(delta).toEqual({ tokens_in: 260, tokens_out: 130, cached_tokens: 200, cost_usd: 0.07, count: 2 });
+    // Global totals remain accumulated across both HUs.
+    expect(tracker.total().cached_tokens).toBe(310);
+  });
+
+  it("clamps out-of-range cursor (>length) and rejects negatives", () => {
+    const tracker = new BudgetTracker();
+    tracker.record({ role: "coder", provider: "claude", tokens_in: 10, tokens_out: 5, cached_tokens: 3 });
+    expect(tracker.since(99).count).toBe(0);
+    expect(tracker.since(-1).count).toBe(1);
+  });
+});
+
 describe("BudgetTracker with estimated data", () => {
   it("marks entries as estimated when estimation is used", () => {
     const tracker = new BudgetTracker();


### PR DESCRIPTION
## Resumen

Φ0-E del epic **KJC-PCS-0056** (Phase 0 — Cross-provider cache metrics).

Cierra el bucle entre los extractores per-agent (Φ0-A..D, ya en main) y los consumidores aguas abajo (summary.md / board / telemetría):

- **`extractUsageMetrics()`** lee `cached_tokens` del result top-level (lo que los agentes ya normalizan) y, defensivamente, también de los shapes raw de cada provider: Anthropic `cache_read_input_tokens`, OpenAI `prompt_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`.
- **`BudgetTracker.record()`** acepta `cached_tokens`; `total()`, `summary()` (con `total_cached_tokens` global + `breakdown_by_role.<role>.cached_tokens`) y `trace()` lo propagan sin romper los consumers existentes (todos los campos previos siguen).
- **Patrón cursor-snapshot**: `cursor()` devuelve una marca opaca (longitud actual del log) y `since(cursor)` devuelve el delta agregado `{tokens_in, tokens_out, cached_tokens, cost_usd, count}` desde esa marca. Permite aislar el gasto por HU sin resetear los acumuladores globales.

## Test plan

- [x] `npx vitest run tests/utils/budget.test.js tests/budget.test.js` — 34/34
- [x] Suite de regresión cruzada (agents + runflow-budget + report-trace + rtk-savings + budget): **394/394 ✅**
- [x] LOC: +114 / −9 (dentro del target 150 LOC)
- [x] 3 tests existentes con `toEqual` exacto contra `total()`/`trace()` ajustados con `cached_tokens: 0`.

## Refs

- Epic: KJC-PCS-0056
- Task: KJC-TSK-0523
- Sigue de: #1036 (Φ0-D, mergeado)
- Prepara: Φ0-F (summary.md cache hits), Φ0-G (board badge %), Φ0-H (telemetría pct)