### PR TITLE
feat(summary): cache hits section per role (KJC-TSK-0524)

### DIFF
--- a/src/session/journal/summary-writer.js
+++ b/src/session/journal/summary-writer.js
@@ -18,7 +18,7 @@ import path from "node:path";
  * @property {"APPROVED"|"REJECTED"|"PAUSED"|"FAILED"|string} result
  * @property {number} iterations
  * @property {number} durationMs
- * @property {{ total_cost_usd?: number, total_tokens?: number, breakdown_by_role?: Object }} [budget]
+ * @property {{ total_cost_usd?: number, total_tokens?: number, total_cached_tokens?: number, breakdown_by_role?: Object }} [budget]
  * @property {Record<string, { ok?: boolean, summary?: string }>} [stages]
  * @property {Array<{ hash?: string, message?: string, date?: string, author?: string }>} [commits]
  * @property {string[]} [files]                    - names of other journal files in the same dir
@@ -108,6 +108,55 @@ function renderBreakdownByRole(breakdown) {
 }
 
 /**
+ * Render the Cache hits section (Φ0-F, KJC-TSK-0524). Shows how many input
+ * tokens were served from provider-side prompt caches, per role, plus a
+ * conservative dollar savings estimate.
+ *
+ * Savings formula: cached tokens are billed at ~10% of the input rate (the
+ * Anthropic/OpenAI convention). Per role:
+ *   savings_usd ≈ cost_usd * (cached_tokens / tokens_in) * 0.9
+ * The estimate is approximate (output tokens also contribute to cost_usd)
+ * and labelled with `~$` so users don't read it as exact.
+ *
+ * Returns:
+ *   - null when no budget data is available
+ *   - "cold run" placeholder when cached == 0 across all roles
+ *   - Markdown table sorted by cached tokens desc when there is cache activity
+ */
+function renderCacheHits(budget) {
+  if (!budget) return null;
+  const totalCached = Number(budget.total_cached_tokens ?? 0);
+  const breakdown = budget.breakdown_by_role || {};
+  const entries = Object.entries(breakdown)
+    .map(([role, m]) => ({
+      role,
+      cached: Number(m?.cached_tokens || 0),
+      tokens_in: Number(m?.tokens_in || 0),
+      cost: Number(m?.total_cost_usd || 0),
+    }))
+    .filter((e) => e.cached > 0);
+
+  if (totalCached === 0 && entries.length === 0) {
+    return "_Cache hits: 0 tokens (cold run)._";
+  }
+
+  const rows = entries
+    .sort((a, b) => b.cached - a.cached)
+    .map((e) => {
+      const ratio = e.tokens_in > 0 ? (e.cached / e.tokens_in) * 100 : 0;
+      const savings = e.tokens_in > 0 ? e.cost * (e.cached / e.tokens_in) * 0.9 : 0;
+      return `| \`${esc(e.role)}\` | ${e.cached.toLocaleString("en-US")} | ${ratio.toFixed(1)}% | ~$${savings.toFixed(4)} |`;
+    });
+  const header = "| Role | Cached tokens | Ratio (cached/in) | Est. savings |\n|---|---|---|---|";
+  return [
+    `**Total cached**: ${totalCached.toLocaleString("en-US")} tokens`,
+    "",
+    header,
+    ...rows,
+  ].join("\n");
+}
+
+/**
  * Render the Skills section: which process skills (addyosmani) were resolved
  * for the task, which OpenSkills were installed, and which skills would have
  * helped but couldn't be installed (graceful-degradation path).
@@ -190,6 +239,11 @@ export function buildSummaryMarkdown(input) {
   const breakdown = renderBreakdownByRole(input.budget?.breakdown_by_role);
   if (breakdown) {
     sections.push("", "## Budget breakdown (by role)", "", breakdown);
+  }
+
+  const cacheHitsSection = renderCacheHits(input.budget);
+  if (cacheHitsSection) {
+    sections.push("", "## Cache hits", "", cacheHitsSection);
   }
 
   const skillsSection = renderSkills(input.skills);

--- a/tests/session/summary-writer.test.js
+++ b/tests/session/summary-writer.test.js
@@ -130,6 +130,54 @@ describe("session/journal/summary-writer — buildSummaryMarkdown", () => {
     expect(md).not.toContain(longSummary);
   });
 
+  // Φ0-F — KJC-TSK-0524. The Cache hits section reads the new
+  // total_cached_tokens / breakdown_by_role.<role>.cached_tokens fields
+  // introduced in Φ0-E (KJC-TSK-0523, BudgetTracker cursor-snapshot).
+  describe("Cache hits section (Φ0-F, KJC-TSK-0524)", () => {
+    it("renders a table with cached tokens, ratio, and estimated savings", () => {
+      const md = buildSummaryMarkdown(sample({
+        budget: {
+          total_cost_usd: 0.42,
+          total_tokens: 54321,
+          total_cached_tokens: 18000,
+          breakdown_by_role: {
+            coder:    { tokens_in: 20000, total_tokens: 30000, cached_tokens: 14000, total_cost_usd: 0.25 },
+            reviewer: { tokens_in: 18000, total_tokens: 24321, cached_tokens: 4000,  total_cost_usd: 0.17 },
+          },
+        },
+      }));
+      expect(md).toContain("## Cache hits");
+      expect(md).toContain("**Total cached**: 18,000 tokens");
+      expect(md).toContain("| Role | Cached tokens | Ratio (cached/in) | Est. savings |");
+      // coder first (more cached); 14000/20000 = 70.0%, savings ≈ 0.25 * 0.7 * 0.9 = 0.1575
+      expect(md).toMatch(/\| `coder` \| 14,000 \| 70\.0% \| ~\$0\.1575 \|/);
+      // reviewer: 4000/18000 ≈ 22.2%, savings ≈ 0.17 * (4000/18000) * 0.9 ≈ 0.034
+      expect(md).toMatch(/\| `reviewer` \| 4,000 \| 22\.2% \| ~\$0\.034\d \|/);
+    });
+
+    it("renders 'cold run' placeholder when no role has cached tokens", () => {
+      const md = buildSummaryMarkdown(sample({
+        budget: {
+          total_cost_usd: 0.42,
+          total_tokens: 54321,
+          total_cached_tokens: 0,
+          breakdown_by_role: {
+            coder:    { tokens_in: 20000, total_tokens: 30000, cached_tokens: 0, total_cost_usd: 0.25 },
+            reviewer: { tokens_in: 18000, total_tokens: 24321, cached_tokens: 0, total_cost_usd: 0.17 },
+          },
+        },
+      }));
+      expect(md).toContain("## Cache hits");
+      expect(md).toContain("_Cache hits: 0 tokens (cold run)._");
+      expect(md).not.toContain("Total cached");
+    });
+
+    it("omits the Cache hits section when budget itself is absent", () => {
+      const md = buildSummaryMarkdown(sample({ budget: undefined }));
+      expect(md).not.toContain("## Cache hits");
+    });
+  });
+
   // regression-for: TSK-0327
   describe("Skills section (KJC-TSK-0327)", () => {
     it("omits the Skills section entirely when no skills activity happened", () => {


### PR DESCRIPTION
## Φ0-F · KJC-PCS-0056

Adds a **Cache hits** section to `summary.md` that surfaces the cross-provider `cached_tokens` metric introduced in Φ0-E (cursor-snapshot, PR #1037).

### What

- New `renderCacheHits(budget)` helper in `summary-writer.js`.
- Inserted into `buildSummaryMarkdown` right after the per-role budget breakdown.
- Reads `budget.total_cached_tokens` and `budget.breakdown_by_role.<role>.cached_tokens`/`tokens_in` (already populated by `BudgetTracker` since Φ0-E).
- Per-role table sorted by cached tokens desc with **cached count**, **ratio (cached/in)**, and an **estimated savings** column using the cached-at-10%-input convention (`cost * ratio * 0.9`).
- Cold-run placeholder (`_Cache hits: 0 tokens (cold run)._`) when no role saw cache hits.
- Section omitted entirely when `budget` is absent.

### Why

Closes the loop on Phase 0: producers (`a`/`b`/`c`/`d`) emit `cached_tokens`, aggregator (`e`) stores them; now the user sees them in the journal entry every run produces.

### Tests

- 3 new cases in `describe(\"Cache hits section (Φ0-F, KJC-TSK-0524)\")`:
  - Table with role/cached/ratio/savings (coder 70.0% / ~\$0.1575, reviewer 22.2% / ~\$0.034x).
  - Cold-run placeholder when all roles have 0 cached.
  - Section omitted when budget itself is undefined.
- Suite total: 27/27 pass.

### LOC budget

103 insertions, 1 deletion — well within the ≤150 target.

### Standing context

- Epic: KJC-PCS-0056 (Phase 0 — cross-provider cache metrics measurement).
- Producers green: Φ0-B (codex), Φ0-C (gemini, unsupported = 0), Φ0-D (aider+opencode via LiteLLM).
- Aggregator green: Φ0-E (BudgetTracker cursor + cached_tokens accumulation).
- Next: Φ0-G (HU Board badge cached %), Φ0-H (telemetry).