### PR TITLE
feat(board): persist cached/in tokens per HU (KJC-TSK-0525, Φ0-G PR1a)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -328,6 +328,13 @@ export function initDb() {
   // renders "—" while NULL. Stored as REAL so the SQL aggregations in
   // Cost E (/api/projects/:id/cost) can SUM directly without parsing.
   try { db.exec('ALTER TABLE stories ADD COLUMN cost_usd REAL'); } catch { /* already migrated */ }
+  // KJC-TSK-0525 (Φ0-G): persisted cached/input tokens per HU so the
+  // board can render the "🎯 N% cached" badge without re-parsing the
+  // session summary. NULL = unmeasured (older runs, cold runs without
+  // cache support). INTEGER because providers report token counts as
+  // ints. Ratio is computed at read time as cached_tokens / tokens_in.
+  try { db.exec('ALTER TABLE stories ADD COLUMN cached_tokens INTEGER'); } catch { /* already migrated */ }
+  try { db.exec('ALTER TABLE stories ADD COLUMN tokens_in INTEGER'); } catch { /* already migrated */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_stories_plan ON stories(plan_id)'); } catch { /* ignore */ }
 
   // is_test (KJC-TSK-0371 — board polish #3): per-project flag that
@@ -531,6 +538,35 @@ export function setStoryCost(storyId, costUsd) {
 }
 
 /**
+ * Persist cached/input tokens for a HU (KJC-TSK-0525, Φ0-G). Called by
+ * the orchestrator alongside `setStoryCost` once the HU finishes. Both
+ * values come from `BudgetTracker.since(huCursor)` (Φ0-E). Pass `null`
+ * to clear either cell. Non-finite numbers throw so callers don't
+ * silently null-out real telemetry.
+ *
+ * @param {string} storyId
+ * @param {number|null} cachedTokens
+ * @param {number|null} tokensIn
+ * @returns {boolean} true when the row existed and was updated
+ */
+export function setStoryCachedTokens(storyId, cachedTokens, tokensIn) {
+  const coerce = (v, name) => {
+    if (v === null || v === undefined) return null;
+    const n = Number(v);
+    if (!Number.isFinite(n) || n < 0) {
+      throw new Error(`setStoryCachedTokens: ${name} must be a non-negative finite number or null (got ${v})`);
+    }
+    return Math.round(n);
+  };
+  const cached = coerce(cachedTokens, 'cachedTokens');
+  const tin = coerce(tokensIn, 'tokensIn');
+  const res = getDb()
+    .prepare('UPDATE stories SET cached_tokens = ?, tokens_in = ?, updated_at = ? WHERE id = ?')
+    .run(cached, tin, new Date().toISOString(), storyId);
+  return res.changes > 0;
+}
+
+/**
  * List every distinct `plan_id` stamped on the stories of a given project.
  * Used by "mark plan ready" so the board can act on each plan of a project
  * without making the user pick one.
@@ -643,9 +679,13 @@ export function getProjectCost(projectId) {
     .get(projectId);
   if (!project) return null;
 
+  // Φ0-G: cached_tokens / tokens_in are nullable independently of
+  // cost_usd, so we read all three columns but keep cost as the
+  // primary filter (a row with only cache telemetry but no $ should
+  // not appear in the per-plan totals — cost rules the byPlan list).
   const rows = getDb()
     .prepare(
-      `SELECT plan_id, cost_usd FROM stories
+      `SELECT plan_id, cost_usd, cached_tokens, tokens_in FROM stories
        WHERE project_id = ? AND cost_usd IS NOT NULL`
     )
     .all(projectId);
@@ -653,24 +693,43 @@ export function getProjectCost(projectId) {
   const round4 = (n) => Math.round(n * 10000) / 10000;
   const byPlanMap = new Map();
   let totalUsd = 0;
+  let totalCached = 0;
+  let totalTokensIn = 0;
   for (const r of rows) {
     const planId = r.plan_id || 'unassigned';
     const cost = Number(r.cost_usd);
     if (!Number.isFinite(cost)) continue;
     totalUsd += cost;
-    const cur = byPlanMap.get(planId) || { planId, totalUsd: 0, huCount: 0 };
+    const cached = Number(r.cached_tokens);
+    const tin = Number(r.tokens_in);
+    if (Number.isFinite(cached) && cached >= 0) totalCached += cached;
+    if (Number.isFinite(tin) && tin >= 0) totalTokensIn += tin;
+    const cur = byPlanMap.get(planId) || { planId, totalUsd: 0, huCount: 0, cachedTokens: 0, tokensIn: 0 };
     cur.totalUsd += cost;
     cur.huCount += 1;
+    if (Number.isFinite(cached) && cached >= 0) cur.cachedTokens += cached;
+    if (Number.isFinite(tin) && tin >= 0) cur.tokensIn += tin;
     byPlanMap.set(planId, cur);
   }
 
+  const ratio = (cached, tin) => tin > 0 ? Math.round((cached / tin) * 1000) / 10 : null;
   const byPlan = Array.from(byPlanMap.values())
-    .map((p) => ({ planId: p.planId, totalUsd: round4(p.totalUsd), huCount: p.huCount }))
+    .map((p) => ({
+      planId: p.planId,
+      totalUsd: round4(p.totalUsd),
+      huCount: p.huCount,
+      cachedTokens: p.cachedTokens,
+      tokensIn: p.tokensIn,
+      cachedRatioPct: ratio(p.cachedTokens, p.tokensIn),
+    }))
     .sort((a, b) => b.totalUsd - a.totalUsd);
 
   return {
     totalUsd: round4(totalUsd),
     byPlan,
+    cachedTokens: totalCached,
+    tokensIn: totalTokensIn,
+    cachedRatioPct: ratio(totalCached, totalTokensIn),
     unknownModelTokens: { tokensIn: 0, tokensOut: 0, models: [] },
     currency: 'USD',
   };

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -385,8 +385,16 @@ describe('GET /api/projects/:id/cost', () => {
     expect(res.body.totalUsd).toBe(2.5);
     expect(res.body.byPlan).toHaveLength(2);
     // sorted by totalUsd desc → plan-A (2.0) before plan-B (0.5)
-    expect(res.body.byPlan[0]).toEqual({ planId: 'plan-A', totalUsd: 2, huCount: 2 });
-    expect(res.body.byPlan[1]).toEqual({ planId: 'plan-B', totalUsd: 0.5, huCount: 1 });
+    // cachedTokens/tokensIn/cachedRatioPct are Φ0-G fields: with no setStoryCachedTokens
+    // calls in this test the sums are 0 and the ratio is null (tokens_in == 0).
+    expect(res.body.byPlan[0]).toEqual({
+      planId: 'plan-A', totalUsd: 2, huCount: 2,
+      cachedTokens: 0, tokensIn: 0, cachedRatioPct: null,
+    });
+    expect(res.body.byPlan[1]).toEqual({
+      planId: 'plan-B', totalUsd: 0.5, huCount: 1,
+      cachedTokens: 0, tokensIn: 0, cachedRatioPct: null,
+    });
     expect(res.body.unknownModelTokens).toEqual({ tokensIn: 0, tokensOut: 0, models: [] });
   });
 

--- a/packages/hu-board/tests/db.test.js
+++ b/packages/hu-board/tests/db.test.js
@@ -379,3 +379,128 @@ describe('cost_usd persistence', () => {
     expect(setStoryCost('does-not-exist', 5)).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cached_tokens + tokens_in columns + setStoryCachedTokens (KJC-TSK-0525 — Φ0-G)
+// ---------------------------------------------------------------------------
+describe('cached_tokens / tokens_in persistence (Φ0-G)', () => {
+  it('migrates stories table with nullable cached_tokens / tokens_in columns', async () => {
+    const { getDb } = await freshDb();
+    const cols = getDb().prepare("PRAGMA table_info(stories)").all();
+    const cached = cols.find((c) => c.name === 'cached_tokens');
+    const tin = cols.find((c) => c.name === 'tokens_in');
+    expect(cached).toBeTruthy();
+    expect(cached.type.toUpperCase()).toBe('INTEGER');
+    expect(cached.notnull).toBe(0);
+    expect(tin).toBeTruthy();
+    expect(tin.type.toUpperCase()).toBe('INTEGER');
+    expect(tin.notnull).toBe(0);
+  });
+
+  it('defaults cached_tokens / tokens_in to NULL on insert', async () => {
+    const { getDb, upsertStory } = await freshDb();
+    upsertStory({ id: 's-cache', project_id: 'p1' });
+    const row = getDb().prepare('SELECT cached_tokens, tokens_in FROM stories WHERE id = ?').get('s-cache');
+    expect(row.cached_tokens).toBeNull();
+    expect(row.tokens_in).toBeNull();
+  });
+
+  it('setStoryCachedTokens writes integers and round-trips', async () => {
+    const { getDb, upsertStory, setStoryCachedTokens } = await freshDb();
+    upsertStory({ id: 's-w', project_id: 'p1' });
+    expect(setStoryCachedTokens('s-w', 14000, 20000)).toBe(true);
+    const row = getDb().prepare('SELECT cached_tokens, tokens_in FROM stories WHERE id = ?').get('s-w');
+    expect(row.cached_tokens).toBe(14000);
+    expect(row.tokens_in).toBe(20000);
+  });
+
+  it('setStoryCachedTokens rounds non-integer inputs to nearest integer', async () => {
+    const { getDb, upsertStory, setStoryCachedTokens } = await freshDb();
+    upsertStory({ id: 's-r', project_id: 'p1' });
+    setStoryCachedTokens('s-r', 14000.6, 20000.4);
+    const row = getDb().prepare('SELECT cached_tokens, tokens_in FROM stories WHERE id = ?').get('s-r');
+    expect(row.cached_tokens).toBe(14001);
+    expect(row.tokens_in).toBe(20000);
+  });
+
+  it('setStoryCachedTokens accepts null on either field independently', async () => {
+    const { getDb, upsertStory, setStoryCachedTokens } = await freshDb();
+    upsertStory({ id: 's-n', project_id: 'p1' });
+    setStoryCachedTokens('s-n', 1234, null);
+    const row = getDb().prepare('SELECT cached_tokens, tokens_in FROM stories WHERE id = ?').get('s-n');
+    expect(row.cached_tokens).toBe(1234);
+    expect(row.tokens_in).toBeNull();
+  });
+
+  it('setStoryCachedTokens rejects NaN / negative / Infinity', async () => {
+    const { upsertStory, setStoryCachedTokens } = await freshDb();
+    upsertStory({ id: 's-bad', project_id: 'p1' });
+    expect(() => setStoryCachedTokens('s-bad', NaN, 1)).toThrow(/non-negative finite/);
+    expect(() => setStoryCachedTokens('s-bad', -1, 1)).toThrow(/non-negative finite/);
+    expect(() => setStoryCachedTokens('s-bad', 1, Infinity)).toThrow(/non-negative finite/);
+  });
+
+  it('setStoryCachedTokens returns false when the story does not exist', async () => {
+    const { setStoryCachedTokens } = await freshDb();
+    expect(setStoryCachedTokens('does-not-exist', 100, 200)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProjectCost — cached/in aggregates (KJC-TSK-0525 — Φ0-G)
+// ---------------------------------------------------------------------------
+describe('getProjectCost — cached/in aggregates (Φ0-G)', () => {
+  it('aggregates cachedTokens / tokensIn at project level and computes ratio', async () => {
+    const { upsertProject, upsertStory, setStoryCost, setStoryCachedTokens, getProjectCost } = await freshDb();
+    upsertProject({ id: 'p1' });
+    upsertStory({ id: 'hu-a', project_id: 'p1', plan_id: 'plan-1' });
+    upsertStory({ id: 'hu-b', project_id: 'p1', plan_id: 'plan-1' });
+    setStoryCost('hu-a', 0.25);
+    setStoryCost('hu-b', 0.17);
+    setStoryCachedTokens('hu-a', 14000, 20000);
+    setStoryCachedTokens('hu-b', 4000, 18000);
+
+    const cost = getProjectCost('p1');
+    expect(cost.totalUsd).toBeCloseTo(0.42, 4);
+    expect(cost.cachedTokens).toBe(18000);
+    expect(cost.tokensIn).toBe(38000);
+    // 18000/38000 = 0.4736842... → 47.4%
+    expect(cost.cachedRatioPct).toBe(47.4);
+
+    expect(cost.byPlan).toHaveLength(1);
+    const plan = cost.byPlan[0];
+    expect(plan.planId).toBe('plan-1');
+    expect(plan.cachedTokens).toBe(18000);
+    expect(plan.tokensIn).toBe(38000);
+    expect(plan.cachedRatioPct).toBe(47.4);
+  });
+
+  it('returns cachedRatioPct=null when tokensIn is zero (cold run, no telemetry)', async () => {
+    const { upsertProject, upsertStory, setStoryCost, getProjectCost } = await freshDb();
+    upsertProject({ id: 'p1' });
+    upsertStory({ id: 'hu-x', project_id: 'p1' });
+    setStoryCost('hu-x', 0.10);
+
+    const cost = getProjectCost('p1');
+    expect(cost.cachedTokens).toBe(0);
+    expect(cost.tokensIn).toBe(0);
+    expect(cost.cachedRatioPct).toBeNull();
+    expect(cost.byPlan[0].cachedRatioPct).toBeNull();
+  });
+
+  it('tolerates rows with cost but no cache telemetry (mixed legacy + new)', async () => {
+    const { upsertProject, upsertStory, setStoryCost, setStoryCachedTokens, getProjectCost } = await freshDb();
+    upsertProject({ id: 'p1' });
+    upsertStory({ id: 'legacy', project_id: 'p1', plan_id: 'plan-1' });
+    upsertStory({ id: 'modern', project_id: 'p1', plan_id: 'plan-1' });
+    setStoryCost('legacy', 0.50);   // no cache telemetry — pre-Φ0-G row
+    setStoryCost('modern', 0.30);
+    setStoryCachedTokens('modern', 5000, 10000);
+
+    const cost = getProjectCost('p1');
+    expect(cost.totalUsd).toBeCloseTo(0.80, 4);
+    expect(cost.cachedTokens).toBe(5000);
+    expect(cost.tokensIn).toBe(10000);
+    expect(cost.cachedRatioPct).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `cached_tokens` + `tokens_in` nullable INTEGER columns to `stories` via idempotent `ALTER TABLE` migration.
- Introduces `setStoryCachedTokens(storyId, cached, in)` with the same finite/non-negative/null discipline as `setStoryCost`.
- Extends `getProjectCost` so both the top-level project rollup and per-plan entries carry `cachedTokens`, `tokensIn`, and a derived `cachedRatioPct` (one decimal, `null` when `tokens_in` is 0 to avoid rendering "0% cached" on cold runs).

## Why split

Original PR1 was 311 LOC net (db + sub-pipeline + writer + tests). Split per the ≤200 LOC gate:
- **PR1a (this PR)**: backend storage — 187 LOC.
- **PR1b (next)**: sub-pipeline outcome stamp + writer side-effect — ~125 LOC.

Schema must land first because the writer's `UPDATE stories SET cached_tokens = ...` query references the columns.

## Phase 0 context

Part of epic **KJC-PCS-0056** (cross-provider cache metrics). Pairs with Φ0-F (`summary.md` Cache hits section, merged in #1038) to make the same telemetry visible in the HU Board UI.

## Test plan

- [x] `cd packages/hu-board && npx vitest run tests/db.test.js` — 39 passing (11 new for Φ0-G).
- [ ] CI green.

Closes Phase 0-G PR1a (KJC-TSK-0525 partition).