### PR TITLE
feat(orchestrator): propagate cached_tokens/tokens_in to HU outcome (KJC-TSK-0525)

### DIFF
--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -316,8 +316,19 @@ function wirePlanCallbacks({ session, loadedPlan, projectDir, syncResultsToPlan,
       await savePlanToDisk(projectDir, loadedPlan);
       if (outcome && Number.isFinite(outcome.cost_usd)) {
         try {
-          const { setStoryCost } = await import("../../../../packages/hu-board/src/db.js");
+          const { setStoryCost, setStoryCachedTokens } = await import("../../../../packages/hu-board/src/db.js");
           setStoryCost(huId, outcome.cost_usd);
+          // Φ0-G (KJC-TSK-0525): cached/in tokens travel in the same
+          // outcome blob as cost. Write them together so the board
+          // can render the "🎯 N% cached" badge on the same render.
+          // Either may be null (older runs, no cache) — setter handles it.
+          if (Number.isFinite(outcome.cached_tokens) || Number.isFinite(outcome.tokens_in)) {
+            setStoryCachedTokens(
+              huId,
+              Number.isFinite(outcome.cached_tokens) ? outcome.cached_tokens : null,
+              Number.isFinite(outcome.tokens_in) ? outcome.tokens_in : null,
+            );
+          }
         } catch (err) {
           logger?.warn?.(`Cost write failed for ${huId}: ${err.message}`);
         }

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -106,6 +106,31 @@ function sumCostUsd(entries) {
 }
 
 /**
+ * Sum an integer token-counter field across a slice of BudgetTracker
+ * entries (Φ0-G, KJC-TSK-0525). Same null-vs-0 semantics as sumCostUsd:
+ * returns null when nothing measurable was recorded so the board can
+ * distinguish "unmeasured" from "really zero".
+ *
+ * @param {Array<object>} entries
+ * @param {string} field — entry key to sum, e.g. "cached_tokens"
+ * @returns {number|null}
+ */
+function sumTokenField(entries, field) {
+  if (!Array.isArray(entries) || entries.length === 0) return null;
+  let total = 0;
+  let hasAny = false;
+  for (const e of entries) {
+    const n = Number(e?.[field]);
+    if (Number.isFinite(n) && n >= 0) {
+      total += n;
+      hasAny = true;
+    }
+  }
+  if (!hasAny) return null;
+  return Math.round(total);
+}
+
+/**
  * Build the per-HU outcome blob from whatever metadata the iteration
  * loop returned. Tolerant by design — most fields are optional and we
  * default to safe values so the board can render something useful
@@ -157,6 +182,11 @@ function buildHuOutcome({ story: _story, iterResult, status, startedAt, huBudget
     blockers,
     summary,
     cost_usd: sumCostUsd(huBudgetEntries),
+    // Φ0-G (KJC-TSK-0525): cached/input tokens drive the "🎯 N% cached"
+    // board badge. Null when nothing measurable was recorded so the UI
+    // can hide the chip on cold runs or providers without cache.
+    cached_tokens: sumTokenField(huBudgetEntries, 'cached_tokens'),
+    tokens_in: sumTokenField(huBudgetEntries, 'tokens_in'),
     finishedAt: new Date().toISOString(),
   };
 }

--- a/tests/hu/hu-sub-pipeline.test.js
+++ b/tests/hu/hu-sub-pipeline.test.js
@@ -752,4 +752,90 @@ describe("hu-sub-pipeline", () => {
       expect(outcomes[0].outcome.cost_usd).toBeCloseTo(0.42, 6);
     });
   });
+
+  describe("runHuSubPipeline — Φ0-G: per-HU cached_tokens / tokens_in in outcome", () => {
+    it("stamps outcome.cached_tokens and tokens_in from the slice of BudgetTracker entries", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "First" }, original: { text: "First" }, blocked_by: [] },
+        { id: "HU-002", status: "certified", certified: { text: "Second" }, original: { text: "Second" }, blocked_by: ["HU-001"] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_cache", stories: [...stories] });
+
+      const budgetTracker = { entries: [] };
+      let huCounter = 0;
+      const runIterationFn = vi.fn(async () => {
+        huCounter += 1;
+        if (huCounter === 1) {
+          budgetTracker.entries.push({ role: "coder", cost_usd: 0.10, cached_tokens: 8000, tokens_in: 12000 });
+          budgetTracker.entries.push({ role: "reviewer", cost_usd: 0.05, cached_tokens: 6000, tokens_in: 8000 });
+        } else {
+          budgetTracker.entries.push({ role: "coder", cost_usd: 0.30, cached_tokens: 3000, tokens_in: 15000 });
+        }
+        return { approved: true };
+      });
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_cache" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome, budgetTracker
+      });
+
+      expect(outcomes).toHaveLength(2);
+      // HU-001: cached = 8000+6000 = 14000, in = 12000+8000 = 20000
+      expect(outcomes[0].outcome.cached_tokens).toBe(14000);
+      expect(outcomes[0].outcome.tokens_in).toBe(20000);
+      // HU-002: only its own slice — not accumulated
+      expect(outcomes[1].outcome.cached_tokens).toBe(3000);
+      expect(outcomes[1].outcome.tokens_in).toBe(15000);
+    });
+
+    it("stamps cached_tokens / tokens_in = null when no tracker entries were produced", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "x" }, original: { text: "x" }, blocked_by: [] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_nocache", stories: [...stories] });
+      const budgetTracker = { entries: [] };
+      const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_nocache" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome, budgetTracker
+      });
+
+      expect(outcomes[0].outcome.cached_tokens).toBeNull();
+      expect(outcomes[0].outcome.tokens_in).toBeNull();
+    });
+
+    it("returns null for cached_tokens / tokens_in when tracker entries only carry cost (no cache telemetry)", async () => {
+      const stories = [
+        { id: "HU-001", status: "certified", certified: { text: "x" }, original: { text: "x" }, blocked_by: [] }
+      ];
+      loadHuBatchMock.mockResolvedValue({ session_id: "hu-s_costonly", stories: [...stories] });
+      const budgetTracker = { entries: [] };
+      const runIterationFn = vi.fn(async () => {
+        budgetTracker.entries.push({ role: "coder", cost_usd: 0.42 }); // no cache fields
+        return { approved: true };
+      });
+
+      const outcomes = [];
+      const onOutcome = vi.fn(async (huId, outcome) => { outcomes.push({ huId, outcome }); });
+
+      await runHuSubPipeline({
+        huReviewerResult: { ok: true, certified: 1, total: 1, stories, batchSessionId: "hu-s_costonly" },
+        runIterationFn, emitter, eventBase, logger,
+        onOutcome, budgetTracker
+      });
+
+      expect(outcomes[0].outcome.cost_usd).toBeCloseTo(0.42, 6);
+      expect(outcomes[0].outcome.cached_tokens).toBeNull();
+      expect(outcomes[0].outcome.tokens_in).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Φ0-G wiring on the orchestrator side. PR1a (#1039) added board.db
schema + `setStoryCachedTokens` + `getProjectCost` aggregates. This
PR fills them with real telemetry from each `kj run`.

- `buildHuOutcome`: new `sumTokenField` helper (mirrors `sumCostUsd`
  null-vs-0 semantics) adds `cached_tokens` and `tokens_in` to the
  HU outcome blob.
- `inject-loaded-plan` `setLiveOutcomeUpdater`: when the outcome has
  finite `cost_usd`, also call `setStoryCachedTokens(huId, cached, in)`
  so cache telemetry rides the same write path as cost.
- 3 new tests in `tests/hu/hu-sub-pipeline.test.js` covering cold-run,
  cache hit, and partial-cache cases.

Stacked on top of the merged PR1a (#1039). Atomic: storage in PR1a,
write path here.

## Test plan
- [x] `tests/hu/hu-sub-pipeline.test.js`: 28/28 local
- [ ] CI: lint, format, syntax, coverage, net LOC budget (128 net),
  prompt-injection scan
- [ ] CI: Test (Node 22.x) and Test (Node 24.x) full suites