### PR TITLE
feat(board): cached % badge on HU cards and project header (KJC-TSK-0525)

### DIFF
--- a/packages/hu-board/public/utils/board-view.js
+++ b/packages/hu-board/public/utils/board-view.js
@@ -40,6 +40,9 @@ async function renderBoard() {
       api(`/api/projects/${encodeURIComponent(selectedProject)}/cost`).catch(() => null),
     ]);
     const costSummary = projectCost ? formatProjectCostSummary(projectCost) : null;
+    // Φ0-G (KJC-TSK-0525): aggregated cache-hit badge at the project
+    // header, rendered alongside the project cost chip.
+    const cacheSummary = projectCost ? formatCacheRatio(projectCost.cachedTokens, projectCost.tokensIn) : null;
 
     // Pre-resolve project initials + name for every distinct project_id in
     // the fetched stories so `renderStoryCard` is synchronous and the header
@@ -101,6 +104,7 @@ async function renderBoard() {
         ` : ''}
         <span class="section-header__count">${stories.length} stories</span>
         ${costSummary ? `<span class="section-header__cost" title="${esc(costSummary.tooltip)}">💵 ${esc(costSummary.label)}</span>` : ''}
+        ${cacheSummary ? `<span class="section-header__cache" title="${esc(cacheSummary.tooltip)}">${esc(cacheSummary.label)}</span>` : ''}
         ${isRunning ? `
           <button id="running-badge-btn" class="section-header__badge"
                 style="margin-left:auto;padding:4px 10px;font-size:0.8rem;background:var(--color-yellow,#eab308);color:#000;border-radius:var(--radius-sm);font-weight:600;border:none;cursor:pointer;"
@@ -380,6 +384,13 @@ function renderStoryCard(story) {
         ${(() => {
           const c = formatCost(story.cost_usd);
           return c ? `<span class="story-card__cost" title="${esc(c.tooltip)}">💵 ${esc(c.label)}</span>` : '';
+        })()}
+        ${(() => {
+          // Φ0-G (KJC-TSK-0525): per-HU cache hit badge. Rendered next to
+          // the cost so users can correlate "this run cost $X and 73% of
+          // input was served from cache" in one glance.
+          const r = formatCacheRatio(story.cached_tokens, story.tokens_in);
+          return r ? `<span class="story-card__cache" title="${esc(r.tooltip)}">${esc(r.label)}</span>` : '';
         })()}
       </div>
       ${missingTestContract ? `

--- a/packages/hu-board/public/utils/formatters.js
+++ b/packages/hu-board/public/utils/formatters.js
@@ -55,6 +55,26 @@ function formatCost(costUsd) {
   };
 }
 
+// Φ0-G (KJC-TSK-0525): mirror of formatCacheRatio in src/format.js.
+// Kept duplicated because this file is a classic script loaded into
+// the browser, while src/format.js uses ES modules and is consumed by
+// Node tests. See KJC-TSK-0501 header notes above.
+function formatCacheRatio(cachedTokens, tokensIn) {
+  if (cachedTokens === null || cachedTokens === undefined) return null;
+  if (tokensIn === null || tokensIn === undefined) return null;
+  const c = Number(cachedTokens);
+  const t = Number(tokensIn);
+  if (!Number.isFinite(c) || !Number.isFinite(t)) return null;
+  if (t <= 0 || c < 0) return null;
+  const pct = Math.round((c / t) * 1000) / 10;
+  const num = c.toLocaleString("en-US");
+  const den = t.toLocaleString("en-US");
+  return {
+    label: `🎯 ${pct}%`,
+    tooltip: `Cache hits: ${num} / ${den} input tokens (${pct}%)`,
+  };
+}
+
 function formatProjectCostSummary(cost) {
   if (!cost || typeof cost !== "object") return null;
   const total = Number(cost.totalUsd);
@@ -63,6 +83,9 @@ function formatProjectCostSummary(cost) {
   if (total === 0 && byPlan.length === 0) return null;
 
   const lines = [`Total: $${total.toFixed(4)}`];
+  // Φ0-G (KJC-TSK-0525): aggregate cache hits line + per-plan suffix.
+  const projCache = formatCacheRatio(cost.cachedTokens, cost.tokensIn);
+  if (projCache) lines.push(`Cache: ${projCache.tooltip.split(": ")[1]}`);
   if (byPlan.length > 0) {
     lines.push("By plan:");
     for (const p of byPlan) {
@@ -70,7 +93,11 @@ function formatProjectCostSummary(cost) {
       if (!Number.isFinite(planTotal)) continue;
       const huCount = Number.isFinite(p?.huCount) ? p.huCount : 0;
       const planLabel = p?.planId || "unassigned";
-      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})`);
+      const cachePct = p?.cachedRatioPct;
+      const cacheSuffix = (cachePct !== null && cachePct !== undefined && Number.isFinite(Number(cachePct)))
+        ? ` 🎯 ${cachePct}%`
+        : "";
+      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})${cacheSuffix}`);
     }
   }
   const unk = cost.unknownModelTokens;

--- a/packages/hu-board/src/format.js
+++ b/packages/hu-board/src/format.js
@@ -88,6 +88,42 @@ export function formatCost(costUsd) {
 }
 
 /**
+ * Φ0-G (KJC-TSK-0525): per-HU and per-plan cached-tokens badge.
+ *
+ * Returns `{ label, tooltip }` for "🎯 23%" with a tooltip showing the
+ * exact numerator/denominator. Same "don't render 0% when there is no
+ * data" stance as formatCost — returns null when:
+ *   - either arg is null/undefined/non-finite,
+ *   - tokens_in is 0 (no input → ratio undefined, not zero),
+ *   - cached is negative (would only happen from corrupted telemetry).
+ *
+ * The badge intentionally shows 1 decimal to keep narrow runs (e.g.
+ * a 73-token cache out of 1 200) readable without rounding to 0%.
+ *
+ * @param {number|null|undefined} cachedTokens
+ * @param {number|null|undefined} tokensIn
+ * @returns {{ label: string, tooltip: string } | null}
+ */
+export function formatCacheRatio(cachedTokens, tokensIn) {
+  // Reject null/undefined explicitly — Number(null) coerces to 0,
+  // which would otherwise render an honest-looking "🎯 0%" badge for
+  // runs where we simply have no telemetry. Same stance as formatCost.
+  if (cachedTokens === null || cachedTokens === undefined) return null;
+  if (tokensIn === null || tokensIn === undefined) return null;
+  const c = Number(cachedTokens);
+  const t = Number(tokensIn);
+  if (!Number.isFinite(c) || !Number.isFinite(t)) return null;
+  if (t <= 0 || c < 0) return null;
+  const pct = Math.round((c / t) * 1000) / 10;
+  const num = c.toLocaleString("en-US");
+  const den = t.toLocaleString("en-US");
+  return {
+    label: `🎯 ${pct}%`,
+    tooltip: `Cache hits: ${num} / ${den} input tokens (${pct}%)`,
+  };
+}
+
+/**
  * Format the aggregated project-level cost chip rendered in the board
  * header. Cost G (KJC-TSK-0518). Consumes the shape returned by
  * `GET /api/projects/:id/cost` (Cost E):
@@ -116,6 +152,11 @@ export function formatProjectCostSummary(cost) {
   if (total === 0 && byPlan.length === 0) return null;
 
   const lines = [`Total: $${total.toFixed(4)}`];
+  // Φ0-G (KJC-TSK-0525): when the API includes project-level cache
+  // counters, show the aggregate cached% line right under the total
+  // so users can see at a glance how much was served from cache.
+  const projCache = formatCacheRatio(cost.cachedTokens, cost.tokensIn);
+  if (projCache) lines.push(`Cache: ${projCache.tooltip.split(": ")[1]}`);
   if (byPlan.length > 0) {
     lines.push("By plan:");
     for (const p of byPlan) {
@@ -123,7 +164,11 @@ export function formatProjectCostSummary(cost) {
       if (!Number.isFinite(planTotal)) continue;
       const huCount = Number.isFinite(p?.huCount) ? p.huCount : 0;
       const planLabel = p?.planId || "unassigned";
-      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})`);
+      const cachePct = p?.cachedRatioPct;
+      const cacheSuffix = (cachePct !== null && cachePct !== undefined && Number.isFinite(Number(cachePct)))
+        ? ` 🎯 ${cachePct}%`
+        : "";
+      lines.push(`  ${planLabel}: $${planTotal.toFixed(2)} (${huCount} HU${huCount === 1 ? "" : "s"})${cacheSuffix}`);
     }
   }
   const unk = cost.unknownModelTokens;

--- a/packages/hu-board/tests/format.test.js
+++ b/packages/hu-board/tests/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatHHMM, shortTask, formatSessionLabel, formatCost, formatProjectCostSummary } from "../src/format.js";
+import { formatHHMM, shortTask, formatSessionLabel, formatCost, formatProjectCostSummary, formatCacheRatio } from "../src/format.js";
 
 describe("formatHHMM", () => {
   it("formats an ISO timestamp as HH:MM (24h, server-local)", () => {
@@ -272,5 +272,74 @@ describe("formatProjectCostSummary", () => {
     });
     expect(out.tooltip).toContain("  ok: $0.50 (2 HUs)");
     expect(out.tooltip).not.toContain("broken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCacheRatio — Φ0-G (KJC-TSK-0525)
+// ---------------------------------------------------------------------------
+// Per-HU and per-plan cache-hit ratio badge. Returns null when there is
+// no signal to show (so the UI hides the badge instead of rendering
+// "0%" with no data — same stance as formatCost).
+describe("formatCacheRatio", () => {
+  it("returns a 1-decimal % label and full-numerator tooltip", () => {
+    expect(formatCacheRatio(234, 1000)).toEqual({
+      label: "🎯 23.4%",
+      tooltip: "Cache hits: 234 / 1,000 input tokens (23.4%)",
+    });
+  });
+
+  it("rounds to 1 decimal so narrow runs do not appear as 0%", () => {
+    expect(formatCacheRatio(7, 1200).label).toBe("🎯 0.6%");
+  });
+
+  it("returns null when tokens_in is 0 (ratio is undefined, not zero)", () => {
+    expect(formatCacheRatio(0, 0)).toBeNull();
+    expect(formatCacheRatio(50, 0)).toBeNull();
+  });
+
+  it("returns null on null/undefined/non-finite inputs", () => {
+    expect(formatCacheRatio(null, 100)).toBeNull();
+    expect(formatCacheRatio(100, null)).toBeNull();
+    expect(formatCacheRatio(undefined, undefined)).toBeNull();
+    expect(formatCacheRatio(NaN, 100)).toBeNull();
+    expect(formatCacheRatio(100, Infinity)).toBeNull();
+  });
+
+  it("returns null on negative cached counter (corrupted telemetry)", () => {
+    expect(formatCacheRatio(-1, 100)).toBeNull();
+  });
+
+  it("renders 100% when every input token was cached", () => {
+    expect(formatCacheRatio(500, 500)).toEqual({
+      label: "🎯 100%",
+      tooltip: "Cache hits: 500 / 500 input tokens (100%)",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatProjectCostSummary — Φ0-G additions
+// ---------------------------------------------------------------------------
+describe("formatProjectCostSummary — Φ0-G cache lines", () => {
+  it("appends a Cache line when the project carries cached/in counters", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 1, byPlan: [],
+      cachedTokens: 350, tokensIn: 1000,
+    });
+    expect(out.tooltip).toContain("Cache: 350 / 1,000 input tokens (35%)");
+  });
+
+  it("appends 🎯 N% suffix to each plan that carries a cachedRatioPct", () => {
+    const out = formatProjectCostSummary({
+      totalUsd: 2,
+      byPlan: [
+        { planId: "p1", totalUsd: 1.5, huCount: 2, cachedRatioPct: 42 },
+        { planId: "p2", totalUsd: 0.5, huCount: 1, cachedRatioPct: null },
+      ],
+    });
+    expect(out.tooltip).toContain("  p1: $1.50 (2 HUs) 🎯 42%");
+    expect(out.tooltip).toContain("  p2: $0.50 (1 HU)");
+    expect(out.tooltip).not.toContain("p2: $0.50 (1 HU) 🎯");
   });
 });


### PR DESCRIPTION
## Summary
PR1c (final piece) of Φ0-G — surface the per-HU and per-plan cache hit ratio captured by PR1a (#1039, storage) and PR1b (#1040, orchestrator wiring) as a visible `🎯 N%` badge in the HU Board.

- New `formatCacheRatio(cached, in)` helper in `src/format.js` (ES module, tested) plus mirrored copy in `public/utils/formatters.js` (classic script, browser). Returns `{ label: "🎯 N%", tooltip }` or `null` when telemetry is missing — same "no fake 0%" stance as `formatCost`.
- `formatProjectCostSummary` now appends a `Cache: …` line in the tooltip when the project carries `cachedTokens` / `tokensIn`, plus a `🎯 N%` suffix on each plan row that provides `cachedRatioPct`.
- `board-view.js` renders the badge on every story card (next to the cost badge) and a `cacheSummary` span in the section header.
- Explicit `null` / `undefined` guard **before** `Number()` coercion to avoid the `Number(null) === 0` trap rendering a misleading `🎯 0%` for plans/HUs with no telemetry.

Net delta: **152 LOC** (within the 200 budget, 4 files).

## Test plan
- [x] `format.test.js` 40/40 — 6 new tests for `formatCacheRatio` + 2 for `formatProjectCostSummary` Φ0-G cache lines
- [x] Full hu-board suite 427/427
- [x] Visual check: badge renders only when telemetry is present; tooltip shows numerator / denominator

Closes the visible-UI side of KJC-TSK-0525. Telemetry follow-up tracked in KJC-TSK-0526 (Φ0-H).