### PR TITLE
feat(telemetry): add cached_pct_{coder,reviewer,total} to pipeline_complete (KJC-TSK-0526)

### DIFF
--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -263,15 +263,23 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
 
     // --- Telemetry: anonymous pipeline_complete event (non-blocking) ---
     try {
-      const { sendTelemetryEvent } = await import("../utils/telemetry.js");
+      const { sendTelemetryEvent, computeCachedPct } = await import("../utils/telemetry.js");
       const durationS = Math.round((Date.now() - ctx.startedAt) / 1000);
       const sessionStatus = ctx.session?.status || "unknown";
+      // Φ0-H (KJC-TSK-0526): aggregate cache-hit ratios per role so we
+      // can see on the fleet how much each provider's cache is buying.
+      let cachedPct = { cached_pct_coder: null, cached_pct_reviewer: null, cached_pct_total: null };
+      try {
+        const budgetSummary = ctx.budgetTracker?.summary?.();
+        if (budgetSummary) cachedPct = computeCachedPct(budgetSummary);
+      } catch { /* non-blocking — telemetry must never break runs */ }
       sendTelemetryEvent("pipeline_complete", {
         mode: config.review_mode,
         agent: ctx.coderRole?.provider || config.coder,
         duration_s: durationS,
         success: sessionStatus === "approved",
-        taskType: ctx.session?.resolved_policies?.taskType || null
+        taskType: ctx.session?.resolved_policies?.taskType || null,
+        ...cachedPct
       }, config).catch(() => {});
     } catch { /* non-blocking */ }
   }

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -27,6 +27,49 @@ export function buildTelemetryPayload(eventName, data = {}) {
 }
 
 /**
+ * Φ0-H (KJC-TSK-0526): aggregate cache-hit ratio per role from the budget
+ * summary the orchestrator already builds. Returns `{ cached_pct_coder,
+ * cached_pct_reviewer, cached_pct_total }` with values rounded to one
+ * decimal, or `null` per slot when there is no measurable input (rather
+ * than `0`, so the backend can distinguish "no cache" from "no signal").
+ *
+ * Provider-agnostic by design: the BudgetTracker entries already
+ * normalise `cached_tokens` for Anthropic (`cache_read_input_tokens`),
+ * OpenAI / Codex (`prompt_tokens_details.cached_tokens`), Gemini
+ * (`cachedContentTokenCount`) and the LiteLLM-routed providers
+ * (aider, opencode), so this helper does not need to know which
+ * provider produced the run.
+ *
+ * @param {{ breakdown_by_role?: object, total_cached_tokens?: number } | null | undefined} summary
+ * @returns {{ cached_pct_coder: number|null, cached_pct_reviewer: number|null, cached_pct_total: number|null }}
+ */
+export function computeCachedPct(summary) {
+  const empty = { cached_pct_coder: null, cached_pct_reviewer: null, cached_pct_total: null };
+  if (!summary || typeof summary !== "object") return empty;
+  const ratio = (cached, tokensIn) => {
+    const c = Number(cached);
+    const t = Number(tokensIn);
+    if (!Number.isFinite(c) || !Number.isFinite(t) || t <= 0 || c < 0) return null;
+    return Math.round((c / t) * 1000) / 10;
+  };
+  const byRole = summary.breakdown_by_role || {};
+  const coder = byRole.coder || null;
+  const reviewer = byRole.reviewer || null;
+  let totalCached = 0;
+  let totalIn = 0;
+  for (const role of Object.keys(byRole)) {
+    const r = byRole[role];
+    totalCached += Number(r?.cached_tokens || 0);
+    totalIn += Number(r?.tokens_in || 0);
+  }
+  return {
+    cached_pct_coder: coder ? ratio(coder.cached_tokens, coder.tokens_in) : null,
+    cached_pct_reviewer: reviewer ? ratio(reviewer.cached_tokens, reviewer.tokens_in) : null,
+    cached_pct_total: ratio(totalCached, totalIn)
+  };
+}
+
+/**
  * Send an anonymous telemetry event. Non-blocking, fire-and-forget.
  * Never throws, never blocks the pipeline.
  *

--- a/tests/telemetry.test.js
+++ b/tests/telemetry.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { sendTelemetryEvent, isTelemetryEnabled, buildTelemetryPayload, TELEMETRY_ENDPOINT } from "../src/utils/telemetry.js";
+import { sendTelemetryEvent, isTelemetryEnabled, buildTelemetryPayload, TELEMETRY_ENDPOINT, computeCachedPct } from "../src/utils/telemetry.js";
 
 describe("telemetry", () => {
   let originalFetch;
@@ -163,6 +163,92 @@ describe("telemetry", () => {
       const body = JSON.parse(global.fetch.mock.calls[0][1].body);
       // ts will differ by a few ms; everything else must be identical.
       expect({ ...preview, ts: 0 }).toEqual({ ...body, ts: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Φ0-H (KJC-TSK-0526): cached_pct_{coder,reviewer,total} aggregator.
+  // The fleet's pipeline_complete event needs per-role cache-hit ratios so we
+  // can see how much the provider-level caches are buying in real runs, not
+  // just locally. Provider-agnostic — works whether the run used Anthropic,
+  // OpenAI/Codex, Gemini, aider or opencode (BudgetTracker normalises).
+  // -------------------------------------------------------------------------
+  describe("computeCachedPct (KJC-TSK-0526)", () => {
+    it("returns nulls when summary is missing/invalid (no signal)", () => {
+      expect(computeCachedPct(null)).toEqual({
+        cached_pct_coder: null, cached_pct_reviewer: null, cached_pct_total: null,
+      });
+      expect(computeCachedPct(undefined)).toEqual({
+        cached_pct_coder: null, cached_pct_reviewer: null, cached_pct_total: null,
+      });
+      expect(computeCachedPct("nope")).toEqual({
+        cached_pct_coder: null, cached_pct_reviewer: null, cached_pct_total: null,
+      });
+    });
+
+    it("computes per-role 1-decimal ratios and total", () => {
+      const out = computeCachedPct({
+        breakdown_by_role: {
+          coder: { tokens_in: 1000, cached_tokens: 350 },
+          reviewer: { tokens_in: 500, cached_tokens: 50 },
+        },
+      });
+      expect(out.cached_pct_coder).toBe(35);
+      expect(out.cached_pct_reviewer).toBe(10);
+      // total = (350+50) / (1000+500) = 400/1500 ≈ 26.7
+      expect(out.cached_pct_total).toBe(26.7);
+    });
+
+    it("returns null for a role with tokens_in=0 (ratio undefined, not 0)", () => {
+      const out = computeCachedPct({
+        breakdown_by_role: {
+          coder: { tokens_in: 0, cached_tokens: 0 },
+          reviewer: { tokens_in: 200, cached_tokens: 50 },
+        },
+      });
+      expect(out.cached_pct_coder).toBeNull();
+      expect(out.cached_pct_reviewer).toBe(25);
+      expect(out.cached_pct_total).toBe(25);
+    });
+
+    it("returns null per absent role rather than 0", () => {
+      const out = computeCachedPct({
+        breakdown_by_role: {
+          coder: { tokens_in: 100, cached_tokens: 30 },
+        },
+      });
+      expect(out.cached_pct_coder).toBe(30);
+      expect(out.cached_pct_reviewer).toBeNull();
+      expect(out.cached_pct_total).toBe(30);
+    });
+
+    it("does not send when telemetry is off (caller is responsible — no payload by side effect)", async () => {
+      // The function itself is pure; verify the gating happens upstream
+      // via sendTelemetryEvent with telemetry=false (existing pattern).
+      await sendTelemetryEvent("pipeline_complete", {
+        version: "1.0.0",
+        cached_pct_coder: 35,
+        cached_pct_reviewer: 10,
+        cached_pct_total: 26.7,
+      }, { telemetry: false });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("includes the three cached_pct_* fields in the wire payload when present", async () => {
+      await sendTelemetryEvent("pipeline_complete", {
+        version: "1.0.0",
+        mode: "standard",
+        agent: "claude",
+        duration_s: 42,
+        success: true,
+        cached_pct_coder: 35,
+        cached_pct_reviewer: 10,
+        cached_pct_total: 26.7,
+      }, { telemetry: true });
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.cached_pct_coder).toBe(35);
+      expect(body.cached_pct_reviewer).toBe(10);
+      expect(body.cached_pct_total).toBe(26.7);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Φ0-H (last sub-task of **Phase 0 — cross-provider cache metrics**, epic KJC-PCS-0056).
- New `computeCachedPct(summary)` helper in `src/utils/telemetry.js`: reads `breakdown_by_role` from the BudgetTracker summary and returns `{ cached_pct_coder, cached_pct_reviewer, cached_pct_total }` rounded to 1 decimal.
- `flow-runner.js` folds these three fields into the existing `pipeline_complete` event (opt-in telemetry, fire-and-forget, never blocks the run).
- **Provider-agnostic by design**: `BudgetTracker.extractUsageMetrics` already normalises `cached_tokens` for Anthropic (`cache_read_input_tokens`), OpenAI / Codex (`prompt_tokens_details.cached_tokens`), Gemini (`cachedContentTokenCount`) and the LiteLLM-routed providers (aider, opencode). No provider switch needed here.
- **Null per slot when no signal** (not `0`): when `tokens_in <= 0` or the role is absent we return `null`, so the backend can distinguish "no cache hits" from "no measurable input". Same stance as Φ0-G's `formatCacheRatio`.

## Why this matters
Phase 0 was about *measuring* cross-provider cache hit ratios on real fleet runs before we tune anything. Φ0-G surfaces it per-HU on the Board; Φ0-H surfaces it on the fleet via telemetry so we can see how much each provider's cache is actually buying.

## Test plan
- [x] `tests/telemetry.test.js`: 5 new unit tests under `describe("computeCachedPct (KJC-TSK-0526)")` — null/undefined/invalid summary, per-role ratios + total, null when `tokens_in=0`, null per absent role, wire payload shape includes the three new fields.
- [x] 26/26 telemetry suite passes locally.
- [x] CI to confirm full repo still green.

Closes part of KJC-PCS-0056 (Phase 0).