### PR TITLE
chore: release v3.3.0 — Phase 0 epic complete (KJC-PCS-0056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-06-09
+
+Cross-provider cache observability (epic KJC-PCS-0056 / Phase 0 closed).
+Karajan now measures, persists and surfaces provider-level prompt-cache hits
+end-to-end across Anthropic, OpenAI/Codex, Gemini, aider and opencode. The
+same `cached_tokens` field flows from agent → BudgetTracker → summary.md →
+`board.db` → HU Board UI badge `🎯 N%` → telemetry `pipeline_complete`.
+**No breaking changes** — every new field is null-safe (badge hides when
+unmeasured rather than showing a misleading `🎯 0%`).
+
+### Added
+
+- **Φ0-A — claude cache_read/creation tokens passthrough** (KJC-TSK-0519,
+  v3.2.x backport on main) — extracts `usage.cache_read_input_tokens` and
+  `usage.cache_creation_input_tokens` from the Anthropic response into the
+  unified BudgetTracker `cached_tokens` slot.
+- **Φ0-B — codex cache_tokens passthrough** (KJC-TSK-0520) — reads
+  `usage.prompt_tokens_details.cached_tokens` from the OpenAI/Codex wire
+  format. Covered by `tests/agents/codex-cache-passthrough.test.js`.
+- **Φ0-C — gemini cachedContentTokenCount via usageMetadata** (KJC-TSK-0521)
+  — extracts Google's native cache field. Project-level system-prompt cache
+  is already warm in cold runs, observed at 87.9% on real data.
+- **Φ0-D — aider+opencode passthrough via LiteLLM** (KJC-TSK-0522) — both
+  CLIs route through LiteLLM, which normalises `usage.cached_tokens` so
+  Karajan reads a single shape regardless of upstream provider.
+- **Φ0-E — BudgetTracker cursor-snapshot cached accumulation** (KJC-TSK-0523)
+  — `computeUsage()` collapses all five provider fields into one
+  `cached_tokens` value and `summary()` exposes per-role `cached_tokens` /
+  `tokens_in` in `breakdown_by_role`.
+- **Φ0-F — summary.md `## Cache hits` section** (KJC-TSK-0524) — per-role
+  table with cached tokens, ratio, and estimated savings. Renders
+  `_Cache hits: 0 tokens (cold run)._` instead of an empty table when no
+  cache fired.
+- **Φ0-G — HU Board cached % badge** (KJC-TSK-0525) — three PRs:
+  `cached_tokens`/`tokens_in` columns on `stories` (board.db migration),
+  orchestrator propagation to HU outcome, and `formatCacheRatio()` rendering
+  `🎯 N%` on card + project header with hover tooltip. Hidden when no
+  signal (same stance as Cost F).
+- **Φ0-H — telemetry `cached_pct_{coder,reviewer,total}`** (KJC-TSK-0526) —
+  `computeCachedPct(summary)` aggregates from `BudgetTracker.summary()` and
+  is folded into the opt-in `pipeline_complete` event. Per-role nulls
+  preserved so the backend can distinguish "no cache" from "no signal".
+
+### Notes
+
+- **Real data collected** (2026-06-09, local sandbox):
+  - Claude cold→hot: 47.2% → 94.3% cache_pct ($0.6141 → $0.1452,
+    **76.4% cost savings** on a single HU).
+  - Gemini cold→hot: 87.9% → 96.8% cache_pct.
+  - Codex: shape verified via unit tests; live E2E blocked by its own
+    bubblewrap kernel-namespace permission on this host (OS issue, not
+    Karajan).
+- Provider-agnostic by design: `BudgetTracker` never branches on which
+  provider produced the run; the 5 paths converge on one normalised field.
+- Telemetry remains opt-in (`telemetry: true` in `.karajanrc`); the new
+  cache fields ride the existing endpoint.
+
 ## [3.2.0] - 2026-06-07
 
 Cost tracking end-to-end (epic KJC-PCS-0055 closed). Every HU run now

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.2.0 released** — Cost tracking end-to-end (epic KJC-PCS-0055 closed). Every `kj run` now records per-HU USD spend via the `BudgetTracker` cursor-snapshot pattern, persists it to `board.db.cost_usd`, and the HU Board surfaces both a per-card badge (`$0.02`) and a project-wide chip with per-plan breakdown. Null-safe: unmeasured HUs hide the badge instead of misleading "$0.00". Drop-in upgrade from v3.1.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.3.0 released** — Cross-provider cache observability (epic KJC-PCS-0056 / Phase 0 closed). Every `kj run` now measures provider-level prompt-cache hits end-to-end across Anthropic, OpenAI/Codex, Gemini, aider and opencode — same `cached_tokens` field flows from agent → BudgetTracker → `summary.md` → `board.db` → HU Board badge `🎯 N%` → telemetry `pipeline_complete`. Real data: Claude cold→hot 47.2% → 94.3% cache_pct (**76.4% cost savings on a single HU**), Gemini 87.9% → 96.8%. Null-safe: badge hides when unmeasured. Drop-in upgrade from v3.2.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,8 +41,8 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (57k LOC, 441 files)
-├── tests/            # Test suite (291 test files)
+├── src/              # Source code (57k LOC, 453 files)
+├── tests/            # Test suite (511 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)
 ├── scripts/          # Install, release scripts

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.2.0
+kj --version    # 3.3.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.2.0
+kj --version    # 3.3.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary

- v3.2.0 → **v3.3.0** — Phase 0 epic (KJC-PCS-0056) closed: cross-provider cache observability end-to-end.
- The `cached_tokens` field flows from agent (Anthropic / OpenAI-Codex / Gemini / aider / opencode) through `BudgetTracker` into `summary.md`, `board.db`, the HU Board `🎯 N%` badge and the `pipeline_complete` telemetry event.
- Drop-in upgrade from v3.2.0. Null-safe — badge hides instead of showing a misleading `🎯 0%` when unmeasured.

## Real data measured (2026-06-09, local sandbox)

| Provider | Cold cache_pct | Hot cache_pct | Cold cost | Hot cost | Savings |
|---|---|---|---|---|---|
| Claude (Anthropic) | 47.2% | 94.3% | $0.6141 | $0.1452 | **76.4%** |
| Gemini (Google) | 87.9% | 96.8% | n/d (free tier) | n/d | — |
| Codex (OpenAI) | — | — | — | — | sandbox bwrap on host |

Codex shape is verified by unit tests in `tests/agents/codex-cache-passthrough.test.js` (Φ0-B). The live E2E was blocked by codex-cli's own bubblewrap kernel-namespace permission on this host — OS issue, not Karajan.

## Files

- `package.json` / `package-lock.json` — version bump.
- `CHANGELOG.md` — `## [3.3.0] - 2026-06-09` with Added/Notes.
- `README.md` — banner.
- `docs/GETTING-STARTED.md` + `docs/es/GETTING-STARTED.md` — `kj --version` comment.
- `docs/ARCHITECTURE.md` — regenerated arch stats (453 src files, 511 test files).

## Test plan

- [x] `npx vitest run tests/telemetry.test.js tests/utils/budget.test.js tests/session/journal/summary-writer.test.js` → 53/53 ✅
- [ ] CI green
- [ ] Tag `v3.3.0` + `gh release create` after merge
- [ ] `npm publish --otp=<code>`
- [ ] Landing update (karajan-landing repo)