### PR TITLE
feat(prompts): prompt-layout helper stable/volatile buckets (KJC-TSK-0527)

### DIFF
--- a/docs/phase-1-cache-propio.md
+++ b/docs/phase-1-cache-propio.md
@@ -1,0 +1,151 @@
+# Phase 1 — Cache propio: análisis técnico
+
+> Estado: ANÁLISIS (pre-implementación). Continúa Phase 0 (KJC-PCS-0056, cerrada en v3.3.0).
+> Fecha: 2026-06-11 · Autor: equipo Karajan
+
+## 1. Contexto y objetivo
+
+Phase 0 instrumentó la **medición** del prompt-caching automático de cada provider
+(`cached_tokens` normalizado en `budget.js::computeUsage()`, sección Cache hits en
+`summary.md`, badge 🎯 en HU Board, telemetría `cached_tokens_pct`). El commit
+fundacional (`7bca392d`, KJC-TSK-0519) fijó el siguiente paso: *"medir el
+prompt-caching automático de cada provider **antes de plantear cache propio**"*.
+
+Phase 1 es ese cache propio: **estructurar los prompts que Karajan genera para que
+los mecanismos de caching de cada provider acierten al máximo**, sin tocar el
+transporte (seguimos invocando CLIs, no SDKs).
+
+Objetivo medible: subir el `cache_pct` de runs **fríos** (primera HU de un plan,
+primera iteración) sin regresión en runs calientes ni en calidad de salida.
+
+## 2. Baseline real (v3.3.0, datos 2026-06-09)
+
+| Provider | Cold | Hot | Coste single-HU cold→hot |
+|----------|------|-----|--------------------------|
+| Claude (coder) | 47.2 % | 94.3 % | $0.6141 → $0.1452 (−76.4 %) |
+| Gemini | 87.9 % | 96.8 % | — |
+| Codex | sin medir live (unit tests OK; e2e bloqueado por bwrap del host) | — | — |
+| aider / opencode | passthrough LiteLLM, sin baseline propio | — | — |
+
+Lectura: el margen grande está en **Claude cold (47.2 %)** y en establecer el
+baseline de **Codex**. Gemini ya viene alto de serie (caching implícito agresivo).
+
+## 3. Mecánica de caching por provider (restricción: vamos vía CLI)
+
+| Provider | Mecanismo | Granularidad | Qué controla Karajan vía CLI |
+|----------|-----------|--------------|------------------------------|
+| Anthropic (`claude -p`) | `cache_control` breakpoints (los pone el CLI: system + tools + mensajes) | Bloques con breakpoint; prefix-match exacto | El contenido de `-p` y de `--append-system-prompt`. NO los breakpoints |
+| OpenAI (`codex`) | Prefix caching automático, mínimo 1024 tokens, incrementos ~128 | Prefijo de tokens, sin breakpoints | El orden del prompt completo: prefijo estable = hit directo |
+| Gemini (`gemini`) | Implicit caching (2.5+) automático | Prefijo de tokens | Ídem OpenAI |
+| aider / opencode | LiteLLM normaliza downstream | Según provider subyacente | Ídem: orden del prompt |
+
+Implicación clave por provider:
+
+- **OpenAI/Gemini**: el caching es *token-prefix* puro y automático → basta con que
+  los prompts de llamadas consecutivas **compartan prefijo literal**. Es la palanca
+  más barata y cubre codex, gemini, aider y opencode a la vez.
+- **Anthropic**: el prefix-match opera sobre breakpoints que pone el CLI. Un prefijo
+  estable *dentro* del mensaje de usuario monolítico no genera hit. La palanca es
+  **mover el contenido estable al system block** vía `--append-system-prompt`
+  (el CLI ya cachea system + tools con breakpoints — el 47.2 % cold actual es
+  precisamente eso). El mensaje `-p` queda solo con lo volátil.
+
+## 4. Diagnóstico: por qué los prompts actuales rompen el cache
+
+`buildCoderPrompt()` (src/prompts/coder.js) intercala estable y volátil:
+
+```
+1. SUBAGENT_PREAMBLE          estable
+2. langInstruction            estable
+3. Task: <texto de la HU>     ← VOLÁTIL en posición 3
+4-9. reglas, constraints      estables
+10-13. stack/projectDir/rtk   estables por proyecto
+14. plan                      volátil por run
+15. ADRs                      semiestable por plan
+16-17. specSection/findings   volátiles por HU
+18. acceptanceTests           volátil por HU
+19-20. coderRules, TDD        estables
+21. sonarSummary              volátil
+22. reviewerFeedback          volátil por iteración
+23. skills                    ← ESTABLE en última posición
+```
+
+El prefijo estable compartido entre dos llamadas son ~2 secciones (≪1024 tokens):
+para OpenAI/Gemini el hit sobre la parte que Karajan controla es ~0. Y el bloque
+de skills (estable, potencialmente grande) va al final, detrás de todo lo volátil.
+
+`buildReviewerPrompt()` (src/prompts/reviewer.js) tiene el mismo anti-patrón:
+`Task context` + `Git diff` (hasta 12 KB, cambia siempre) van **antes** de la
+sección de skills.
+
+## 5. Opciones consideradas
+
+| Opción | Decisión | Razón |
+|--------|----------|-------|
+| **A. Reorden prefix-stable** de los prompt builders (estable-primero, volátil-último) | ✅ Hacer | Cubre 4 providers vía CLI, coste bajo, sin tocar transporte |
+| **B. System-prompt split para Anthropic** (`--append-system-prompt` con el bloque estable) | ✅ Hacer | Única forma de que Anthropic cachee el contenido estable de Karajan; el CLI ya pone breakpoints en system |
+| C. Bypass CLI → SDK directo con `cache_control` manual | ❌ Descartar | Perderíamos el agente completo (tools Read/Write/Edit/Bash las da el CLI). Re-implementar el harness no es Phase 1 |
+| D. Gemini explicit context-caching API | ⏸ Posponer | Gemini ya está a 87.9 % cold con implicit; ROI marginal y requiere API directa |
+| E. TTL extendido (1 h) Anthropic | ❌ No accesible | Feature beta de API, no expuesta vía CLI |
+
+## 6. Diseño
+
+Núcleo: un helper `prompt-layout.js` que separa las secciones en dos buckets:
+
+```js
+buildPromptLayout(sections) → { stable: string, volatile: string }
+```
+
+- **stable**: preámbulo, idioma, reglas genéricas, constraints de subproceso,
+  projectDir rule, stack, rtk/serena, coderRules, política TDD, skills,
+  productContext, domainContext. Invariante entre iteraciones de la misma HU
+  y entre HUs del mismo plan/proyecto.
+- **volatile**: plan, task, ADRs, specSection, reviewerFindings, acceptanceTests,
+  sonarSummary, reviewerFeedback, diff. Cambia por HU/iteración.
+
+Consumo por agente:
+
+- `claude-agent`: `--append-system-prompt <stable>` + `-p <volatile>`.
+- `codex/gemini/aider/opencode`: concatenar `stable + "\n\n" + volatile`
+  (prefijo literal estable → prefix caching automático).
+
+Invariantes a proteger con tests:
+
+1. El bloque stable es **byte-idéntico** entre iteración N y N+1 de la misma HU.
+2. El bloque stable es byte-idéntico entre HUs del mismo plan (mismo proyecto,
+   mismas skills, mismas rules).
+3. Ninguna información se pierde: `stable ∪ volatile` ≡ contenido actual
+   (mismas secciones, solo reordenadas).
+
+## 7. Slices propuestos (≤200 LOC netas cada uno, patrón Φ0)
+
+| Slice | Contenido | Ficheros principales |
+|-------|-----------|----------------------|
+| Φ1-A | `prompt-layout.js`: buckets stable/volatile + tests unitarios | src/prompts/prompt-layout.js (nuevo) |
+| Φ1-B | coder.js migra al layout (reorden estable-primero) + snapshot tests | src/prompts/coder.js |
+| Φ1-C | reviewer.js migra al layout (skills antes del diff, diff al final) | src/prompts/reviewer.js |
+| Φ1-D | claude-agent: system-prompt split (`--append-system-prompt`) cuando el rol provee `stablePrompt` | src/agents/claude-agent.js |
+| Φ1-E | planner/architect/hu-reviewer al layout estable | src/prompts/{planner,architect,hu-reviewer}.js |
+| Φ1-F | Test de regresión de estabilidad de prefijo: longest-common-prefix entre prompts consecutivos ≥ 80 % del bloque stable | tests/prompts/prefix-stability.test.js (nuevo) |
+| Φ1-G | Medición real cold/hot post-reorden (Claude+Gemini+Codex) + golden tasks para validar no-regresión de calidad + doc de resultados | docs/, tests/golden |
+| Φ1-H | Release vX.Y.0 + landing | CHANGELOG, landing |
+
+Orden de dependencias: A → (B,C,E en paralelo) → D → F → G → H.
+
+## 8. Riesgos y mitigaciones
+
+| Riesgo | Impacto | Mitigación |
+|--------|---------|------------|
+| Reordenar secciones cambia el comportamiento del LLM (el comentario "order matters" en coder.js es intencional: ADRs → spec → findings → tests) | Regresión de calidad | El orden RELATIVO del bloque volátil se mantiene intacto; solo se extrae lo estable al frente. Golden tasks (Φ1-G) + plan-adherence score como gate |
+| TTL Anthropic 5 min: el gap entre fin de una HU y inicio de la siguiente puede expirar el cache | Hit parcial entre HUs | Aceptado: el win principal es iteración-a-iteración dentro de la HU (gaps de segundos). Documentar |
+| `--append-system-prompt` con bloques grandes (skills) podría cambiar la adherencia a instrucciones | Calidad | Gate con golden tasks; rollback por flag si hace falta |
+| Codex sigue sin baseline live (bwrap) | No podemos verificar el win en OpenAI | Medir en entorno sin sandbox o aceptar verificación via unit tests + datos de terceros |
+
+## 9. Métricas de aceptación
+
+- Claude **cold** `cache_pct` ≥ 65 % (baseline 47.2 %).
+- Claude **hot** sin regresión (≥ 90 %; baseline 94.3 %).
+- Gemini sin regresión (cold ≥ 85 %; baseline 87.9 %).
+- Codex: baseline medido + prefijo estable ≥ 1024 tokens verificado por test.
+- Golden tasks: 3/3 sin regresión estructural.
+- Prefix-stability test: bloque stable byte-idéntico inter-iteración e inter-HU.

--- a/src/prompts/prompt-layout.js
+++ b/src/prompts/prompt-layout.js
@@ -1,0 +1,80 @@
+/**
+ * Prompt layout helper — Phase 1 (KJC-PCS-0057, cache propio).
+ *
+ * Separates prompt sections into two buckets so every prompt builder can
+ * emit a cache-friendly shape:
+ *
+ *   - stable:   identical across iterations of the same HU and across HUs
+ *               of the same plan (preamble, rules, constraints, skills,
+ *               product/domain context). Goes FIRST in the rendered prompt
+ *               so providers with automatic prefix caching (OpenAI, Gemini,
+ *               LiteLLM-routed) hit on the literal prefix. For Anthropic,
+ *               agents can send this bucket via --append-system-prompt
+ *               where the CLI already places cache breakpoints.
+ *   - volatile: changes per HU/iteration (task, plan, acceptance tests,
+ *               reviewer feedback, diff). Goes LAST, preserving the
+ *               relative order the builder pushed it in — the semantic
+ *               ordering inside the bucket ("order matters" in coder.js)
+ *               is untouched.
+ *
+ * Tagging is explicit on purpose: an untagged section throws instead of
+ * silently landing in one bucket (a misclassified volatile section would
+ * silently break the byte-identical invariant the prefix cache relies on).
+ */
+
+export const STABLE = "stable";
+export const VOLATILE = "volatile";
+
+const SEPARATOR = "\n\n";
+
+/**
+ * Tag a section for buildPromptLayout. Returns null for empty/non-string
+ * content so builders can push conditional sections without guards.
+ *
+ * @param {string|null|undefined} content
+ * @param {"stable"|"volatile"} [stability]
+ * @returns {{content: string, stability: string}|null}
+ */
+export function section(content, stability = VOLATILE) {
+  if (typeof content !== "string" || content.length === 0) return null;
+  return { content, stability };
+}
+
+/**
+ * Split tagged sections into { stable, volatile } blocks. Insertion order
+ * is preserved within each bucket. Null/undefined entries are skipped.
+ *
+ * @param {Array<{content: string, stability: string}|null|undefined>} sections
+ * @returns {{stable: string, volatile: string}}
+ */
+export function buildPromptLayout(sections) {
+  const stable = [];
+  const volatile = [];
+  for (const entry of sections) {
+    if (entry == null) continue;
+    if (entry.stability === STABLE) {
+      stable.push(entry.content);
+    } else if (entry.stability === VOLATILE) {
+      volatile.push(entry.content);
+    } else {
+      throw new Error(
+        `prompt-layout: section has invalid stability tag "${entry?.stability}" — use section(content, STABLE|VOLATILE)`
+      );
+    }
+  }
+  return { stable: stable.join(SEPARATOR), volatile: volatile.join(SEPARATOR) };
+}
+
+/**
+ * Render a layout as a single prompt string: stable prefix first, volatile
+ * tail last. Used by agents whose provider caches on the literal token
+ * prefix (codex, gemini, aider, opencode).
+ *
+ * @param {{stable: string, volatile: string}} layout
+ * @returns {string}
+ */
+export function joinLayout({ stable, volatile }) {
+  if (!stable) return volatile;
+  if (!volatile) return stable;
+  return `${stable}${SEPARATOR}${volatile}`;
+}

--- a/tests/prompts/prompt-layout.test.js
+++ b/tests/prompts/prompt-layout.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  STABLE,
+  VOLATILE,
+  section,
+  buildPromptLayout,
+  joinLayout,
+} from "../../src/prompts/prompt-layout.js";
+
+describe("prompts/prompt-layout", () => {
+  describe("section", () => {
+    it("tags content with the given stability", () => {
+      expect(section("rules", STABLE)).toEqual({ content: "rules", stability: STABLE });
+      expect(section("task", VOLATILE)).toEqual({ content: "task", stability: VOLATILE });
+    });
+
+    it("defaults to volatile when stability is omitted", () => {
+      expect(section("diff")).toEqual({ content: "diff", stability: VOLATILE });
+    });
+
+    it("returns null for empty or non-string content", () => {
+      expect(section("")).toBeNull();
+      expect(section(null)).toBeNull();
+      expect(section(undefined)).toBeNull();
+    });
+  });
+
+  describe("buildPromptLayout", () => {
+    it("separates buckets preserving insertion order within each", () => {
+      const layout = buildPromptLayout([
+        section("preamble", STABLE),
+        section("task body", VOLATILE),
+        section("coder rules", STABLE),
+        section("reviewer feedback", VOLATILE),
+        section("skills", STABLE),
+      ]);
+      expect(layout.stable).toBe("preamble\n\ncoder rules\n\nskills");
+      expect(layout.volatile).toBe("task body\n\nreviewer feedback");
+    });
+
+    it("produces a byte-identical stable block across calls with different volatile content", () => {
+      const stableSections = () => [
+        section("preamble", STABLE),
+        section("rules", STABLE),
+        section("skills", STABLE),
+      ];
+      const a = buildPromptLayout([...stableSections(), section("task A", VOLATILE)]);
+      const b = buildPromptLayout([section("task B", VOLATILE), ...stableSections()]);
+      expect(a.stable).toBe(b.stable);
+      expect(a.volatile).not.toBe(b.volatile);
+    });
+
+    it("loses no content: every section appears exactly once across both buckets", () => {
+      const contents = ["alpha", "beta", "gamma", "delta"];
+      const layout = buildPromptLayout([
+        section("alpha", STABLE),
+        section("beta", VOLATILE),
+        section("gamma", STABLE),
+        section("delta", VOLATILE),
+      ]);
+      const full = joinLayout(layout);
+      for (const c of contents) {
+        expect(full.split(c).length - 1).toBe(1);
+      }
+    });
+
+    it("skips null and undefined entries (pattern: conditional sections)", () => {
+      const layout = buildPromptLayout([
+        section("preamble", STABLE),
+        null,
+        undefined,
+        section("", STABLE),
+        section("task", VOLATILE),
+      ]);
+      expect(layout.stable).toBe("preamble");
+      expect(layout.volatile).toBe("task");
+    });
+
+    it("throws on entries without a valid stability tag (no silent fallback)", () => {
+      expect(() => buildPromptLayout([{ content: "x", stability: "sometimes" }])).toThrow(/stability/);
+      expect(() => buildPromptLayout(["bare string"])).toThrow(/stability/);
+    });
+
+    it("returns empty strings for empty buckets", () => {
+      expect(buildPromptLayout([section("only stable", STABLE)])).toEqual({
+        stable: "only stable",
+        volatile: "",
+      });
+      expect(buildPromptLayout([])).toEqual({ stable: "", volatile: "" });
+    });
+  });
+
+  describe("joinLayout", () => {
+    it("joins stable before volatile with a blank-line separator", () => {
+      expect(joinLayout({ stable: "A\n\nB", volatile: "C" })).toBe("A\n\nB\n\nC");
+    });
+
+    it("omits the separator when a bucket is empty", () => {
+      expect(joinLayout({ stable: "A", volatile: "" })).toBe("A");
+      expect(joinLayout({ stable: "", volatile: "C" })).toBe("C");
+      expect(joinLayout({ stable: "", volatile: "" })).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Φ1-A — primer slice de Phase 1 (KJC-PCS-0057, cache propio)

Helper `prompt-layout.js` que separa secciones de prompt en dos buckets:

- **stable**: idéntico entre iteraciones de la misma HU y entre HUs del mismo plan. Va PRIMERO → providers con prefix caching automático (OpenAI/Gemini/LiteLLM) aciertan sobre el prefijo literal. Para Anthropic, los agentes lo enviarán vía `--append-system-prompt` (Φ1-D).
- **volatile**: cambia por HU/iteración. Va al final, preservando su orden relativo actual (el "order matters" de coder.js intacto).

Etiquetado explícito: sección sin tag → throw (sin fallback silencioso; una sección volátil mal clasificada rompería el invariante byte-idéntico).

Incluye `docs/phase-1-cache-propio.md` con el análisis completo de la fase (baseline v3.3.0, mecánica por provider, slices Φ1-A..H, riesgos, métricas).

## Tests
- 11/11 nuevos en `tests/prompts/prompt-layout.test.js`: orden determinista, identidad byte-a-byte inter-llamada, no-pérdida de contenido, secciones condicionales null, throw en tags inválidos, joinLayout sin separadores espurios.

## LOC
184 netas (src 80 + tests 104); el doc está excluido del gate.