### PR TITLE
feat(prompts): reviewer prompt cache-friendly layout, diff al final (KJC-TSK-0529)

### DIFF
--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -1,6 +1,7 @@
 import { buildRtkInstructions } from "./rtk-snippet.js";
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 import { getLanguageInstruction } from "../utils/locale.js";
+import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "./prompt-layout.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -24,51 +25,45 @@ const SERENA_INSTRUCTIONS = [
   "Fall back to reading files only when Serena tools are not sufficient."
 ].join("\n");
 
-export async function buildReviewerPrompt({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
+/**
+ * Build the reviewer prompt as a { stable, volatile } layout (Φ1,
+ * KJC-PCS-0057). The stable block (preamble, mode, scope rules, JSON
+ * schema, serena/rtk, contexts, review rules, skills) is identical
+ * across reviews of the same project, so prefix-caching providers hit
+ * on it; the per-review content (task context + git diff, up to 12 KB
+ * and always different) goes last.
+ */
+export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
   const truncatedDiff = diff.length > 12000 ? `${diff.slice(0, 12000)}\n\n[TRUNCATED]` : diff;
 
   const langInstruction = getLanguageInstruction(language);
-  const sections = [
-    serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE,
-    ...(langInstruction ? [langInstruction] : []),
-    `You are a code reviewer in ${mode} mode.`,
-    "CRITICAL SCOPE RULE: Only review changes that are part of the diff below. Do NOT flag issues in unchanged code, missing features planned for future tasks, or improvements outside the scope of this task. If the diff is correct for what the task asks, approve it — even if the broader codebase has other issues.",
-    "Only block approval for issues IN THE DIFF that are bugs, security vulnerabilities, or clear violations of the review rules.",
-    "Return only one valid JSON object and nothing else.",
-    "JSON schema:",
-    '{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}'
-  ];
-
-  if (serenaEnabled) {
-    sections.push(SERENA_INSTRUCTIONS);
-  }
-
   const rtkSnippet = buildRtkInstructions({ rtkAvailable });
-  if (rtkSnippet) {
-    sections.push(rtkSnippet);
-  }
-
-  if (productContext) {
-    sections.push(`## Product Context\n${productContext}`);
-  }
-
-  if (domainContext) {
-    sections.push(`## Domain Context\n${domainContext}`);
-  }
-
-  sections.push(
-    `Task context:\n${task}`,
-    `Review rules:\n${reviewRules}`,
-    `Git diff:\n${truncatedDiff}`
-  );
-
+  let skillSection = null;
   if (projectDir) {
     const skills = await loadAvailableSkills(projectDir);
-    const skillSection = buildSkillSection(skills, { provider, role: "reviewer" });
-    if (skillSection) {
-      sections.push(skillSection);
-    }
+    skillSection = buildSkillSection(skills, { provider, role: "reviewer" });
   }
 
-  return sections.join("\n\n");
+  return buildPromptLayout([
+    section(serenaEnabled ? SUBAGENT_PREAMBLE_SERENA : SUBAGENT_PREAMBLE, STABLE),
+    section(langInstruction, STABLE),
+    section(`You are a code reviewer in ${mode} mode.`, STABLE),
+    section("CRITICAL SCOPE RULE: Only review changes that are part of the diff below. Do NOT flag issues in unchanged code, missing features planned for future tasks, or improvements outside the scope of this task. If the diff is correct for what the task asks, approve it — even if the broader codebase has other issues.", STABLE),
+    section("Only block approval for issues IN THE DIFF that are bugs, security vulnerabilities, or clear violations of the review rules.", STABLE),
+    section("Return only one valid JSON object and nothing else.", STABLE),
+    section("JSON schema:", STABLE),
+    section('{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}', STABLE),
+    section(serenaEnabled ? SERENA_INSTRUCTIONS : null, STABLE),
+    section(rtkSnippet, STABLE),
+    section(productContext ? `## Product Context\n${productContext}` : null, STABLE),
+    section(domainContext ? `## Domain Context\n${domainContext}` : null, STABLE),
+    section(`Review rules:\n${reviewRules}`, STABLE),
+    section(skillSection, STABLE),
+    section(`Task context:\n${task}`, VOLATILE),
+    section(`Git diff:\n${truncatedDiff}`, VOLATILE),
+  ]);
+}
+
+export async function buildReviewerPrompt(options) {
+  return joinLayout(await buildReviewerPromptLayout(options));
 }

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -1,5 +1,36 @@
 import { describe, expect, it } from "vitest";
-import { buildReviewerPrompt } from "../src/prompts/reviewer.js";
+import { buildReviewerPrompt, buildReviewerPromptLayout } from "../src/prompts/reviewer.js";
+
+describe("buildReviewerPromptLayout (Φ1 — prefix caching)", () => {
+  const baseArgs = {
+    reviewRules: "Check for security issues",
+    mode: "standard",
+    productContext: "A CLI tool",
+  };
+
+  it("keeps the stable block byte-identical across different task and diff", async () => {
+    const a = await buildReviewerPromptLayout({ ...baseArgs, task: "Add login", diff: "+a" });
+    const b = await buildReviewerPromptLayout({ ...baseArgs, task: "Fix logout", diff: "+b" });
+
+    expect(a.stable).toBe(b.stable);
+    expect(a.volatile).not.toBe(b.volatile);
+  });
+
+  it("puts review rules and contexts in the stable block, task + diff last", async () => {
+    const layout = await buildReviewerPromptLayout({ ...baseArgs, task: "Add login", diff: "+x" });
+
+    expect(layout.stable).toContain("Review rules:\nCheck for security issues");
+    expect(layout.stable).toContain("## Product Context");
+    expect(layout.volatile).toContain("Task context:\nAdd login");
+    expect(layout.volatile).toContain("Git diff:\n+x");
+    expect(layout.volatile.indexOf("Task context:")).toBeLessThan(layout.volatile.indexOf("Git diff:"));
+  });
+
+  it("buildReviewerPrompt renders the git diff as the final section", async () => {
+    const full = await buildReviewerPrompt({ ...baseArgs, task: "Add login", diff: "+final" });
+    expect(full.endsWith("Git diff:\n+final")).toBe(true);
+  });
+});
 
 describe("buildReviewerPrompt", () => {
   const baseArgs = {


### PR DESCRIPTION
## Φ1-C — tercer slice de Phase 1 (KJC-PCS-0057, cache propio)

`buildReviewerPrompt()` migra a `prompt-layout.js` (Φ1-A, #1044):

- Nueva export `buildReviewerPromptLayout()` → `{ stable, volatile }`.
- **Estable** (idéntico entre reviews del mismo proyecto): preámbulo, mode, scope rules, JSON schema, serena/rtk, product/domain context, review rules, skills.
- **Volátil al final**: task context + git diff (hasta 12 KB, distinto en cada review — antes rompía el cache de las skills que iban detrás).

## Tests
- 3 nuevos (stable identity, bucket membership con task→diff order, diff como sección final) + 17 existentes verdes.
- Consumidores: product-context, skill-injection, subloop-limits — 36/36.

## LOC
+66/−40 (neta +26).