### PR TITLE
feat(agents): claude system-prompt split vía --append-system-prompt (KJC-TSK-0530)

### DIFF
--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -321,6 +321,21 @@ const ALLOWED_TOOLS = [
   "Read", "Write", "Edit", "Bash", "Glob", "Grep"
 ];
 
+/**
+ * Base CLI args for a task (Φ1-D, KJC-PCS-0057). When the role provides the
+ * prompt split in stable/volatile buckets, the stable block travels via
+ * --append-system-prompt — the CLI places cache breakpoints on the system
+ * block, so Anthropic's prompt cache hits on it across iterations — and only
+ * the volatile block goes in the -p message. Without the split, legacy
+ * single-prompt behavior is unchanged.
+ */
+function buildPromptArgs(task) {
+  if (task.stablePrompt && task.volatilePrompt) {
+    return ["-p", task.volatilePrompt, "--append-system-prompt", task.stablePrompt, "--allowedTools", ...ALLOWED_TOOLS];
+  }
+  return ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS];
+}
+
 export class ClaudeAgent extends BaseAgent {
   async runTask(task) {
     const role = task.role || "coder";
@@ -345,7 +360,7 @@ export class ClaudeAgent extends BaseAgent {
   }
 
   async _runTaskExec(task, model, _role) {
-    const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS];
+    const args = buildPromptArgs(task);
     if (model) args.push("--model", model);
 
     // Use stream-json when onOutput is provided to get real-time feedback
@@ -373,7 +388,7 @@ export class ClaudeAgent extends BaseAgent {
   }
 
   async _reviewTaskExec(task, model) {
-    const args = ["-p", task.prompt, "--allowedTools", ...ALLOWED_TOOLS, "--output-format", "stream-json", "--verbose"];
+    const args = [...buildPromptArgs(task), "--output-format", "stream-json", "--verbose"];
     if (model) args.push("--model", model);
     const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({
       onOutput: task.onOutput,

--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -123,12 +123,20 @@ export class AgentRole extends BaseRole {
     const agent = this.createAgentInstance(provider);
 
     const promptResult = await this.buildPrompt(extracted);
-    const { prompt, onOutput } = typeof promptResult === "string"
+    const { prompt, onOutput, stablePrompt, volatilePrompt } = typeof promptResult === "string"
       ? { prompt: promptResult, onOutput: extracted.onOutput }
       : { onOutput: extracted.onOutput, ...promptResult };
 
     const runArgs = { prompt, role: this.name };
     if (onOutput) runArgs.onOutput = onOutput;
+    // Φ1-D (KJC-PCS-0057): roles that build their prompt as a
+    // stable/volatile layout forward both buckets so cache-aware agents
+    // (ClaudeAgent) can ship the stable block as system prompt. Agents
+    // that don't know the fields keep reading `prompt` as before.
+    if (stablePrompt && volatilePrompt) {
+      runArgs.stablePrompt = stablePrompt;
+      runArgs.volatilePrompt = volatilePrompt;
+    }
     // Kill a hung agent: without a silence timeout a coder / reviewer
     // that stalls with no output left `kj run` waiting indefinitely.
     // PlannerRole set this itself; every other role was unprotected.

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -1,5 +1,6 @@
 import { AgentRole } from "./agent-role.js";
-import { buildCoderPrompt } from "../prompts/coder.js";
+import { buildCoderPromptLayout } from "../prompts/coder.js";
+import { joinLayout } from "../prompts/prompt-layout.js";
 import { isHostAgent } from "../utils/agent-detect.js";
 import { HostAgent } from "../agents/host-agent.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
@@ -66,7 +67,7 @@ export class CoderRole extends AgentRole {
       try { stack = await detectProjectStack(projectDir); } catch { /* best-effort */ }
       try { testFramework = await detectTestFramework(projectDir); } catch { /* best-effort */ }
     }
-    const prompt = await buildCoderPrompt({
+    const layout = await buildCoderPromptLayout({
       task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests,
       adrs, specSection, reviewerFindings, huId,
       coderRules: this.instructions,
@@ -79,7 +80,9 @@ export class CoderRole extends AgentRole {
       stack, testFramework,
       provider: this._resolvedProvider || (typeof this.resolveProvider === "function" ? this.resolveProvider() : null)
     });
-    return { prompt };
+    // Φ1-D: prompt is the joined layout (identical for every agent);
+    // the buckets ride along so ClaudeAgent can system-split them.
+    return { prompt: joinLayout(layout), stablePrompt: layout.stable, volatilePrompt: layout.volatile };
   }
 
   buildSuccessResult(parsed, provider, agentResult) {

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -83,6 +83,37 @@ describe("ClaudeAgent", () => {
     });
   });
 
+  // Φ1-D (KJC-PCS-0057): stable/volatile system-prompt split.
+  describe("buildPromptArgs — system-prompt split", () => {
+    it.each([
+      ["runTask",    (a, t) => a.runTask({ ...t, role: "coder" })],
+      ["reviewTask", (a, t) => a.reviewTask({ ...t, role: "reviewer" })]
+    ])("%s with stablePrompt+volatilePrompt sends -p volatile and --append-system-prompt stable", async (_n, call) => {
+      await call(new ClaudeAgent("claude", baseConfig, logger), {
+        prompt: "joined full prompt",
+        stablePrompt: "STABLE RULES",
+        volatilePrompt: "VOLATILE TASK"
+      });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[args.indexOf("-p") + 1]).toBe("VOLATILE TASK");
+      expect(args[args.indexOf("--append-system-prompt") + 1]).toBe("STABLE RULES");
+      expect(args).not.toContain("joined full prompt");
+    });
+
+    it.each([
+      ["only stablePrompt",   { prompt: "full", stablePrompt: "S" }],
+      ["only volatilePrompt", { prompt: "full", volatilePrompt: "V" }],
+      ["neither",             { prompt: "full" }]
+    ])("falls back to -p prompt when %s is provided", async (_n, task) => {
+      await new ClaudeAgent("claude", baseConfig, logger).runTask({ ...task, role: "coder" });
+
+      const args = runCommand.mock.calls[0][1];
+      expect(args[args.indexOf("-p") + 1]).toBe("full");
+      expect(args).not.toContain("--append-system-prompt");
+    });
+  });
+
   // merged-from: 4 buildArgs tests (-p prompt, json default, stream-json+verbose).
   describe("buildArgs — -p flag and output format", () => {
     it("includes -p with the task prompt", async () => {

--- a/tests/cli/kj-run-smoke.test.js
+++ b/tests/cli/kj-run-smoke.test.js
@@ -66,7 +66,8 @@ vi.mock("../../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../../src/prompts/reviewer.js", () => ({

--- a/tests/coder/coder-role.test.js
+++ b/tests/coder/coder-role.test.js
@@ -59,6 +59,34 @@ describe("CoderRole", () => {
     expect(callArgs.role).toBe("coder");
   });
 
+  // Φ1-D (KJC-PCS-0057): the role forwards the stable/volatile buckets so
+  // ClaudeAgent can ship the stable block via --append-system-prompt; the
+  // joined prompt stays identical for every other agent.
+  it("forwards stablePrompt and volatilePrompt buckets alongside the joined prompt", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add login feature" });
+
+    const callArgs = mockRunTask.mock.calls[0][0];
+    expect(callArgs.stablePrompt).toBeTruthy();
+    expect(callArgs.volatilePrompt).toBeTruthy();
+    expect(callArgs.stablePrompt).toContain("Karajan sub-agent");
+    expect(callArgs.volatilePrompt).toContain("Task:\nAdd login feature");
+    expect(callArgs.prompt).toBe(`${callArgs.stablePrompt}\n\n${callArgs.volatilePrompt}`);
+  });
+
+  it("keeps the stable bucket byte-identical across iterations with different feedback", async () => {
+    const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
+    await role.init({});
+    await role.run({ task: "Add login feature" });
+    await role.run({ task: "Add login feature", reviewerFeedback: "fix the null check" });
+
+    const first = mockRunTask.mock.calls[0][0];
+    const second = mockRunTask.mock.calls[1][0];
+    expect(first.stablePrompt).toBe(second.stablePrompt);
+    expect(first.volatilePrompt).not.toBe(second.volatilePrompt);
+  });
+
   it("includes reviewer feedback in prompt when provided", async () => {
     const role = new CoderRole({ config, logger, createAgentFn: mockCreateAgent });
     await role.init({});

--- a/tests/commands/command-code.test.js
+++ b/tests/commands/command-code.test.js
@@ -16,7 +16,8 @@ vi.mock("../../src/config.js", () => ({
 }));
 
 vi.mock("../../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("node:fs/promises", () => ({

--- a/tests/dry-run.test.js
+++ b/tests/dry-run.test.js
@@ -34,7 +34,8 @@ vi.mock("../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt content")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt content"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt content", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({

--- a/tests/mcp/mcp-direct-handlers.test.js
+++ b/tests/mcp/mcp-direct-handlers.test.js
@@ -31,7 +31,8 @@ vi.mock("../../src/prompts/planner.js", () => ({
 }));
 
 vi.mock("../../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn(async () => "code prompt")
+  buildCoderPrompt: vi.fn(async () => "code prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "code prompt", volatile: "" })
 }));
 
 vi.mock("../../src/prompts/reviewer.js", () => ({

--- a/tests/mcp/mcp-server-handlers.test.js
+++ b/tests/mcp/mcp-server-handlers.test.js
@@ -73,7 +73,8 @@ vi.mock("../../src/prompts/planner.js", () => ({
 }));
 
 vi.mock("../../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn(() => "coder prompt")
+  buildCoderPrompt: vi.fn(() => "coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../../src/prompts/reviewer.js", () => ({

--- a/tests/reviewer/reviewer-parse-resilience.test.js
+++ b/tests/reviewer/reviewer-parse-resilience.test.js
@@ -54,7 +54,8 @@ vi.mock("../../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../../src/prompts/reviewer.js", () => ({

--- a/tests/runflow-budget.test.js
+++ b/tests/runflow-budget.test.js
@@ -72,7 +72,8 @@ vi.mock("../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({

--- a/tests/runflow-events.test.js
+++ b/tests/runflow-events.test.js
@@ -88,7 +88,8 @@ vi.mock("../src/sonar/credentials.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({

--- a/tests/runflow-repeat-detection.test.js
+++ b/tests/runflow-repeat-detection.test.js
@@ -65,7 +65,8 @@ vi.mock("../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({

--- a/tests/runflow-triage.test.js
+++ b/tests/runflow-triage.test.js
@@ -130,7 +130,8 @@ vi.mock("../src/review/parser.js", () => ({ parseJsonOutput: vi.fn((s) => JSON.p
 vi.mock("../src/review/tdd-policy.js", () => ({
   evaluateTddPolicy: vi.fn().mockReturnValue({ ok: true, reason: "pass", sourceFiles: ["a.js"], testFiles: ["a.test.js"], message: "OK" })
 }));
-vi.mock("../src/prompts/coder.js", () => ({ buildCoderPrompt: vi.fn().mockReturnValue("coder prompt") }));
+vi.mock("../src/prompts/coder.js", () => ({ buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" }) }));
 vi.mock("../src/prompts/reviewer.js", () => ({ buildReviewerPrompt: vi.fn().mockReturnValue("reviewer prompt") }));
 vi.mock("../src/review/profiles.js", () => ({ resolveReviewProfile: vi.fn().mockResolvedValue({ rules: "rules" }) }));
 vi.mock("../src/git/automation.js", () => ({

--- a/tests/server-handlers-unit.test.js
+++ b/tests/server-handlers-unit.test.js
@@ -72,7 +72,8 @@ vi.mock("../src/prompts/planner.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn(async () => "coder prompt")
+  buildCoderPrompt: vi.fn(async () => "coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({

--- a/tests/subloop-limits.test.js
+++ b/tests/subloop-limits.test.js
@@ -55,7 +55,8 @@ vi.mock("../src/review/tdd-policy.js", () => ({
 }));
 
 vi.mock("../src/prompts/coder.js", () => ({
-  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt")
+  buildCoderPrompt: vi.fn().mockReturnValue("coder prompt"),
+  buildCoderPromptLayout: async () => ({ stable: "coder prompt", volatile: "" })
 }));
 
 vi.mock("../src/prompts/reviewer.js", () => ({


### PR DESCRIPTION
## Φ1-D — cuarto slice de Phase 1 (KJC-PCS-0057, cache propio)

La palanca específica de Anthropic: su prompt cache opera sobre breakpoints que el CLI coloca en el system block — un prefijo estable *dentro* del mensaje de usuario no genera hit. Este slice mueve el bloque estable al system prompt:

- `claude-agent.js`: nuevo `buildPromptArgs(task)` — con `stablePrompt`+`volatilePrompt` construye `-p <volatile> --append-system-prompt <stable>`; sin ellos, comportamiento legacy byte-idéntico. Aplica a `runTask` y `reviewTask`.
- `coder-role.js`: construye con `buildCoderPromptLayout()` (Φ1-B) y devuelve `{ prompt: joinLayout, stablePrompt, volatilePrompt }`.
- `agent-role.js`: propaga ambos buckets a `runArgs` — codex/gemini/aider/opencode los ignoran y siguen leyendo `prompt` (prefijo literal estable vía Φ1-B).

Rollback implícito: si el rol no provee los buckets no hay split.

## Tests
- claude-agent: 5 nuevos (split en runTask/reviewTask, fallbacks con solo-stable/solo-volatile/ninguno).
- coder-role: 2 nuevos (buckets presentes y `prompt === stable+\n\n+volatile`; stable byte-idéntico entre iteraciones con feedback distinto).
- Suite agents+coder+roles: 422/422.

## LOC
+91/−6 (neta +85).