### PR TITLE
feat(prompts): architect, hu-reviewer y reviewer-role al layout estable (KJC-TSK-0531)

### DIFF
--- a/src/prompts/architect.js
+++ b/src/prompts/architect.js
@@ -1,5 +1,6 @@
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 import { getLanguageInstruction } from "../utils/locale.js";
+import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "./prompt-layout.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -9,19 +10,28 @@ const SUBAGENT_PREAMBLE = [
 
 export const VALID_VERDICTS = new Set(["ready", "needs_clarification"]);
 
-export async function buildArchitectPrompt({ task, instructions, researchContext = null, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
+/**
+ * Build the architect prompt as a { stable, volatile } layout (Φ1,
+ * KJC-PCS-0057): instructions, guidelines, schema, contexts and skills
+ * are identical across invocations on the same project; research
+ * context and the task itself go last.
+ */
+export async function buildArchitectPromptLayout({ task, instructions, researchContext = null, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
   const langInstruction = getLanguageInstruction(language);
-  const sections = [SUBAGENT_PREAMBLE, ...(langInstruction ? [langInstruction] : [])];
-
-  if (instructions) {
-    sections.push(instructions);
+  let skillSection = null;
+  if (projectDir) {
+    const skills = await loadAvailableSkills(projectDir);
+    skillSection = buildSkillSection(skills, { provider, role: "architect" });
   }
 
-  sections.push(
-    "You are the architect in a multi-role AI pipeline.",
-    "Analyze the task and produce a concrete architecture design including layers, patterns, data model, API contracts, dependencies, and tradeoffs.",
-    "## Architecture Guidelines",
-    [
+  return buildPromptLayout([
+    section(SUBAGENT_PREAMBLE, STABLE),
+    section(langInstruction, STABLE),
+    section(instructions, STABLE),
+    section("You are the architect in a multi-role AI pipeline.", STABLE),
+    section("Analyze the task and produce a concrete architecture design including layers, patterns, data model, API contracts, dependencies, and tradeoffs.", STABLE),
+    section("## Architecture Guidelines", STABLE),
+    section([
       "- Identify the architecture type (layered, microservices, event-driven, etc.)",
       "- Define the layers and their responsibilities",
       "- Identify design patterns to apply",
@@ -30,34 +40,19 @@ export async function buildArchitectPrompt({ task, instructions, researchContext
       "- List external and internal dependencies",
       "- Document tradeoffs and their rationale",
       "- If critical decisions cannot be made without more information, list clarifying questions"
-    ].join("\n"),
-    "Return a single valid JSON object and nothing else.",
-    'JSON schema: {"verdict":"ready|needs_clarification","architecture":{"type":string,"layers":[string],"patterns":[string],"dataModel":{"entities":[string]},"apiContracts":[string],"dependencies":[string],"tradeoffs":[string]},"questions":[string],"summary":string}'
-  );
+    ].join("\n"), STABLE),
+    section("Return a single valid JSON object and nothing else.", STABLE),
+    section('JSON schema: {"verdict":"ready|needs_clarification","architecture":{"type":string,"layers":[string],"patterns":[string],"dataModel":{"entities":[string]},"apiContracts":[string],"dependencies":[string],"tradeoffs":[string]},"questions":[string],"summary":string}', STABLE),
+    section(productContext ? `## Product Context\n${productContext}` : null, STABLE),
+    section(domainContext ? `## Domain Context\n${domainContext}` : null, STABLE),
+    section(skillSection, STABLE),
+    section(researchContext ? `## Research Context\n${researchContext}` : null, VOLATILE),
+    section(`## Task\n${task}`, VOLATILE),
+  ]);
+}
 
-  if (productContext) {
-    sections.push(`## Product Context\n${productContext}`);
-  }
-
-  if (domainContext) {
-    sections.push(`## Domain Context\n${domainContext}`);
-  }
-
-  if (researchContext) {
-    sections.push(`## Research Context\n${researchContext}`);
-  }
-
-  sections.push(`## Task\n${task}`);
-
-  if (projectDir) {
-    const skills = await loadAvailableSkills(projectDir);
-    const skillSection = buildSkillSection(skills, { provider, role: "architect" });
-    if (skillSection) {
-      sections.push(skillSection);
-    }
-  }
-
-  return sections.join("\n\n");
+export async function buildArchitectPrompt(options) {
+  return joinLayout(await buildArchitectPromptLayout(options));
 }
 
 function filterStrings(arr) {

--- a/src/prompts/hu-reviewer.js
+++ b/src/prompts/hu-reviewer.js
@@ -1,5 +1,6 @@
 import { extractFirstJson } from "../utils/json-extract.js";
 import { getLanguageInstruction } from "../utils/locale.js";
+import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "./prompt-layout.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -22,38 +23,31 @@ const DIMENSION_KEYS = [
  * @param {{stories: Array<{id: string, text: string}>, instructions: string|null, context?: string|null}} params
  * @returns {string} The assembled prompt.
  */
-export function buildHuReviewerPrompt({ stories, instructions, context = null, productContext = null, domainContext = null, hu_language = "en" }) {
+/**
+ * Build the HU-reviewer prompt as a { stable, volatile } layout (Φ1,
+ * KJC-PCS-0057): preamble, instructions, JSON schema and contexts are
+ * identical across batches on the same project; the stories under
+ * evaluation and the per-batch additional context go last.
+ */
+export function buildHuReviewerPromptLayout({ stories, instructions, context = null, productContext = null, domainContext = null, hu_language = "en" }) {
   const langInstruction = getLanguageInstruction(hu_language);
-  const sections = [SUBAGENT_PREAMBLE, ...(langInstruction ? [langInstruction] : [])];
 
-  if (instructions) {
-    sections.push(instructions);
-  }
+  return buildPromptLayout([
+    section(SUBAGENT_PREAMBLE, STABLE),
+    section(langInstruction, STABLE),
+    section(instructions, STABLE),
+    section("Return a single valid JSON object and nothing else.", STABLE),
+    section(`JSON schema: {"evaluations":[{"story_id":string,"scores":{"D1_jtbd_context":number,"D2_user_specificity":number,"D3_behavior_change":number,"D4_control_zone":number,"D5_time_constraints":number,"D6_survivable_experiment":number},"total":number,"antipatterns_detected":[string],"verdict":"certified|needs_rewrite|needs_context","evaluation_notes":string,"rewritten":object|null,"certified_hu":object|null,"context_needed":object|null}],"batch_summary":{"total":number,"certified":number,"needs_rewrite":number,"needs_context":number,"consolidated_questions":string}}`, STABLE),
+    section(productContext ? `## Product Context\n${productContext}` : null, STABLE),
+    section(domainContext ? `## Domain Context\n${domainContext}` : null, STABLE),
+    section("## Stories to Evaluate", VOLATILE),
+    ...stories.map((story) => section(`### ${story.id}\n${story.text}`, VOLATILE)),
+    section(context ? `## Additional Context\n${context}` : null, VOLATILE),
+  ]);
+}
 
-  sections.push("## Stories to Evaluate");
-
-  for (const story of stories) {
-    sections.push(`### ${story.id}\n${story.text}`);
-  }
-
-  sections.push(
-    "Return a single valid JSON object and nothing else.",
-    `JSON schema: {"evaluations":[{"story_id":string,"scores":{"D1_jtbd_context":number,"D2_user_specificity":number,"D3_behavior_change":number,"D4_control_zone":number,"D5_time_constraints":number,"D6_survivable_experiment":number},"total":number,"antipatterns_detected":[string],"verdict":"certified|needs_rewrite|needs_context","evaluation_notes":string,"rewritten":object|null,"certified_hu":object|null,"context_needed":object|null}],"batch_summary":{"total":number,"certified":number,"needs_rewrite":number,"needs_context":number,"consolidated_questions":string}}`
-  );
-
-  if (productContext) {
-    sections.push(`## Product Context\n${productContext}`);
-  }
-
-  if (domainContext) {
-    sections.push(`## Domain Context\n${domainContext}`);
-  }
-
-  if (context) {
-    sections.push(`## Additional Context\n${context}`);
-  }
-
-  return sections.join("\n\n");
+export function buildHuReviewerPrompt(options) {
+  return joinLayout(buildHuReviewerPromptLayout(options));
 }
 
 /**

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -1,6 +1,7 @@
 import { AgentRole } from "./agent-role.js";
 import { buildRtkInstructions } from "../prompts/rtk-snippet.js";
 import { extractFirstJson } from "../utils/json-extract.js";
+import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "../prompts/prompt-layout.js";
 
 const MAX_DIFF_LENGTH = 12000;
 
@@ -32,30 +33,26 @@ export class ReviewerRole extends AgentRole {
     };
   }
 
+  // Φ1-E (KJC-PCS-0057): stable block (preamble, instructions, mode,
+  // schema, contexts, rtk, review rules) first; task + diff — different
+  // on every review — last. The buckets ride along so ClaudeAgent can
+  // ship the stable block via --append-system-prompt (Φ1-D).
   async buildPrompt({ task, diff, reviewRules }) {
-    const sections = [SUBAGENT_PREAMBLE];
-    if (this.instructions) sections.push(this.instructions);
-    sections.push(
-      `You are a code reviewer in ${this.config?.review_mode || "standard"} mode.`,
-      "Return only one valid JSON object and nothing else.",
-      "JSON schema:",
-      '{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}',
-      `Task context:\n${task}`
-    );
-
-    const pc = this.config?.productContext;
-    if (pc) sections.push(`## Product Context\n${pc}`);
-    const dc = this.config?.domainContext;
-    if (dc) sections.push(`## Domain Context\n${dc}`);
-
-    const rtkSnippet = buildRtkInstructions({
-      rtkAvailable: Boolean(this.config?.rtk?.available)
-    });
-    if (rtkSnippet) sections.push(rtkSnippet);
-    if (reviewRules) sections.push(`Review rules:\n${reviewRules}`);
-    sections.push(`Git diff:\n${truncateDiff(diff)}`);
-
-    return { prompt: sections.join("\n\n") };
+    const layout = buildPromptLayout([
+      section(SUBAGENT_PREAMBLE, STABLE),
+      section(this.instructions, STABLE),
+      section(`You are a code reviewer in ${this.config?.review_mode || "standard"} mode.`, STABLE),
+      section("Return only one valid JSON object and nothing else.", STABLE),
+      section("JSON schema:", STABLE),
+      section('{"approved":boolean,"blocking_issues":[{"id":string,"severity":"critical|high|medium|low","file":string,"line":number,"description":string,"suggested_fix":string}],"non_blocking_suggestions":[string],"summary":string,"confidence":number}', STABLE),
+      section(this.config?.productContext ? `## Product Context\n${this.config.productContext}` : null, STABLE),
+      section(this.config?.domainContext ? `## Domain Context\n${this.config.domainContext}` : null, STABLE),
+      section(buildRtkInstructions({ rtkAvailable: Boolean(this.config?.rtk?.available) }), STABLE),
+      section(reviewRules ? `Review rules:\n${reviewRules}` : null, STABLE),
+      section(`Task context:\n${task}`, VOLATILE),
+      section(`Git diff:\n${truncateDiff(diff)}`, VOLATILE),
+    ]);
+    return { prompt: joinLayout(layout), stablePrompt: layout.stable, volatilePrompt: layout.volatile };
   }
 
   parseOutput(raw) {

--- a/tests/prompt-architect.test.js
+++ b/tests/prompt-architect.test.js
@@ -1,5 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { buildArchitectPrompt, parseArchitectOutput, VALID_VERDICTS } from "../src/prompts/architect.js";
+import { buildArchitectPrompt, buildArchitectPromptLayout, parseArchitectOutput, VALID_VERDICTS } from "../src/prompts/architect.js";
+
+describe("buildArchitectPromptLayout (Φ1 — prefix caching)", () => {
+  it("keeps the stable block byte-identical across different tasks", async () => {
+    const base = { instructions: "Arch rules", productContext: "A CLI tool" };
+    const a = await buildArchitectPromptLayout({ ...base, task: "Design auth" });
+    const b = await buildArchitectPromptLayout({ ...base, task: "Design billing", researchContext: "notes" });
+
+    expect(a.stable).toBe(b.stable);
+    expect(a.volatile).not.toBe(b.volatile);
+  });
+
+  it("renders the task as the final volatile section", async () => {
+    const prompt = await buildArchitectPrompt({ task: "Design auth", researchContext: "prior findings" });
+    expect(prompt.endsWith("## Task\nDesign auth")).toBe(true);
+    expect(prompt.indexOf("## Research Context")).toBeLessThan(prompt.indexOf("## Task"));
+  });
+});
 
 describe("buildArchitectPrompt", () => {
   it("returns a string containing the task", async () => {

--- a/tests/reviewer/reviewer-role.test.js
+++ b/tests/reviewer/reviewer-role.test.js
@@ -112,6 +112,34 @@ describe("ReviewerRole", () => {
     expect(prompt).toContain("No console.log");
   });
 
+  // Φ1-E (KJC-PCS-0057): the inline builder forwards stable/volatile
+  // buckets so ClaudeAgent can system-split them (Φ1-D); the diff is
+  // the final volatile section so it never breaks the stable prefix.
+  it("forwards stable/volatile buckets with task+diff last", async () => {
+    const fakeAgent = {
+      reviewTask: vi.fn().mockResolvedValue({
+        ok: true,
+        output: JSON.stringify({ approved: true, blocking_issues: [], summary: "OK", confidence: 1 })
+      })
+    };
+    const role = new ReviewerRole({
+      config: {},
+      logger,
+      createAgentFn: vi.fn().mockReturnValue(fakeAgent)
+    });
+    await role.init({ task: "Task" });
+    await role.run({ task: "Task A", diff: "+line1", reviewRules: "No console.log" });
+    await role.run({ task: "Task B", diff: "+line2", reviewRules: "No console.log" });
+
+    const first = fakeAgent.reviewTask.mock.calls[0][0];
+    const second = fakeAgent.reviewTask.mock.calls[1][0];
+    expect(first.stablePrompt).toContain("Review rules:\nNo console.log");
+    expect(first.stablePrompt).toBe(second.stablePrompt);
+    expect(first.volatilePrompt).toContain("Task context:\nTask A");
+    expect(first.volatilePrompt.endsWith("Git diff:\n+line1")).toBe(true);
+    expect(first.prompt).toBe(`${first.stablePrompt}\n\n${first.volatilePrompt}`);
+  });
+
   it("emits role:start and role:end events", async () => {
     const events = [];
     emitter.on(ROLE_EVENTS.START, (e) => events.push({ type: "start", ...e }));


### PR DESCRIPTION
## Φ1-E — quinto slice de Phase 1 (KJC-PCS-0057, cache propio)

Tres builders más migran a `prompt-layout.js`:

- `buildArchitectPromptLayout()`: instrucciones, guidelines, JSON schema, contexts y skills estables; research context + task al final.
- `buildHuReviewerPromptLayout()`: preámbulo, instrucciones, schema y contexts estables; stories del batch + additional context al final.
- **ReviewerRole builder inline** (el camino real del pipeline — `runReviewerWithFallback` usa ReviewerRole, no `prompts/reviewer.js`): migrado igual y además devuelve `stablePrompt`/`volatilePrompt`, con lo que el system-split de Claude (#1047) aplica también a TODAS las reviews del loop.

**Planner excluido a propósito**: se invoca una vez por plan (win de cache marginal), une con `\n` en vez de `\n\n`, y sus reglas `spec_section` derivan de la task (contenido task-dependent incrustado en el bloque de formato). Documentado en la card.

## Tests
- 4 nuevos (architect stable identity + task final; reviewer-role buckets byte-idénticos entre reviews + diff como sección final).
- Suite afectada: 191/191 (reviewer, architect, coder, agents, multiformat-ac).

## LOC
+121/−90 (neta +31).