### PR TITLE
chore: release v3.4.0 — Phase 1 cache propio (KJC-PCS-0057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-06-11
+
+Cache propio cross-provider (epic KJC-PCS-0057 / Phase 1 closed). Los prompts de Karajan se reestructuran para maximizar el prompt-caching automático de cada provider: la medición real con Claude pasa de 47.2 % a 99.6 % de cache_pct en frío y el coste del coder cae un 76 %.
+
+### Added
+
+- `src/prompts/prompt-layout.js`: helper `buildPromptLayout`/`section`/`joinLayout` que separa cada prompt en bloque estable (idéntico entre iteraciones y HUs) y bloque volátil, con etiquetado explícito y sin fallbacks silenciosos (KJC-TSK-0527, #1044).
+- Coder prompt cache-friendly: `buildCoderPromptLayout()` con secciones estables delante y volátiles al final preservando el orden relativo legacy (KJC-TSK-0528, #1045).
+- Reviewer prompt cache-friendly: review rules y skills en el bloque estable; task + git diff (hasta 12 KB) como cola volátil (KJC-TSK-0529, #1046).
+- Claude system-prompt split: con `stablePrompt`/`volatilePrompt` el agente envía `-p <volatile> --append-system-prompt <stable>` — el CLI cachea el system block con breakpoints y Anthropic sirve el contenido estable desde cache en cada iteración (KJC-TSK-0530, #1047).
+- Architect, HU-reviewer y el builder inline de ReviewerRole migrados al layout estable; el split de Claude aplica también a todas las reviews del loop (KJC-TSK-0531, #1048).
+- Suite de regresión prefix-stability: LCP inter-iteración e inter-HU = 100 % del bloque estable, mínimo de 1024 tokens del prefix caching de OpenAI verificado, y marcadores volátiles que nunca se cuelan en el bloque estable (KJC-TSK-0532, #1049).
+- `docs/phase-1-cache-propio.md`: análisis completo de la fase + resultados de la medición real (KJC-TSK-0533, #1050).
+
+### Measured
+
+- Claude coder cold: cache_pct 47.2 % → **99.60 %**; coste $0.6141 → **$0.1447** (−76 %). Hot: 94.3 % → 99.69 %. Ambos runs APPROVED + audit CERTIFIED (2026-06-11).
+- Incidencias de entorno registradas durante la medición: KJC-BUG-0083 (sonar no desactivable por config/flag), KJC-BUG-0084 (summary.md no se escribe en runs fallidos), KJC-BUG-0085 (rol audit sin cached_tokens).
+
+5 624 tests en 514 ficheros.
+
 ## [3.3.0] - 2026-06-09
 
 Cross-provider cache observability (epic KJC-PCS-0056 / Phase 0 closed).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.3.0 released** — Cross-provider cache observability (epic KJC-PCS-0056 / Phase 0 closed). Every `kj run` now measures provider-level prompt-cache hits end-to-end across Anthropic, OpenAI/Codex, Gemini, aider and opencode — same `cached_tokens` field flows from agent → BudgetTracker → `summary.md` → `board.db` → HU Board badge `🎯 N%` → telemetry `pipeline_complete`. Real data: Claude cold→hot 47.2% → 94.3% cache_pct (**76.4% cost savings on a single HU**), Gemini 87.9% → 96.8%. Null-safe: badge hides when unmeasured. Drop-in upgrade from v3.2.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.4.0 released** — Cache-friendly prompts (epic KJC-PCS-0057 / Phase 1 closed). Every Karajan prompt is now split into a stable block (identical across iterations and HUs, rendered first so automatic prefix caching hits on it) and a volatile tail; on Claude the stable block ships via `--append-system-prompt` so the CLI's cache breakpoints serve it from cache on every call. Real data: cold-run cache_pct jumps **47.2% → 99.6%** and coder cost drops **76%** ($0.61 → $0.14 per HU). A prefix-stability regression suite freezes the contract in CI. Drop-in upgrade from v3.3.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (57k LOC, 453 files)
+├── src/              # Source code (57k LOC, 454 files)
 ├── tests/            # Test suite (511 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.3.0
+kj --version    # 3.4.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.3.0
+kj --version    # 3.4.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.4.0

Cierra la épica **KJC-PCS-0057 — Phase 1 cache propio** (slices Φ1-A..H, PRs #1044–#1050).

### Highlights
- Prompts cache-friendly: bloque estable primero (prefix caching automático de OpenAI/Gemini/LiteLLM) + system-split de Claude vía `--append-system-prompt`.
- **Medición real**: Claude cold cache_pct 47.2 % → 99.60 %, coste coder −76 % ($0.61 → $0.14/HU). Hot 94.3 % → 99.69 %.
- Suite prefix-stability congelando el contrato en CI.

### Ficheros
package.json + lockfile (3.4.0), CHANGELOG, README banner, GETTING-STARTED EN/ES, ARCHITECTURE stats regen.

5 624 tests / 514 ficheros.