### PR TITLE
fix: bundle @karajan/core en el tarball npm (KJC-BUG-0082)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "karajan-code",
       "version": "3.4.0",
+      "bundleDependencies": [
+        "@karajan/core"
+      ],
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
@@ -16,6 +19,7 @@
       ],
       "dependencies": {
         "@babel/parser": "^7.29.7",
+        "@karajan/core": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.7",
+    "@karajan/core": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
@@ -99,6 +100,9 @@
     "valibot": "^1.4.1",
     "web-tree-sitter": "^0.26.9"
   },
+  "bundleDependencies": [
+    "@karajan/core"
+  ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "^4.1.8",


### PR DESCRIPTION
## KJC-BUG-0082 — Application Blocker

`npm install karajan-code` rompía en `kj --version` con `ERR_MODULE_NOT_FOUND: Cannot find package '@karajan/core'`: el tarball publicado no incluye `packages/core` ni declara la dependencia (13 módulos de `src/` y todo `packages/hu-board` la importan). **Afecta a v3.3.0 publicada** y habría afectado a v3.4.0.

### Fix
- `dependencies`: `"@karajan/core": "*"` (resuelve al workspace en dev).
- `bundleDependencies: ["@karajan/core"]` → `npm pack` incluye `node_modules/@karajan/core/**` en el tarball.

### Verificación
- `npm pack` → el tgz contiene `node_modules/@karajan/core/src/*`.
- Install limpio del tgz en prefix vacío → `kj --version` = **3.4.0** ✅
- `packages/hu-board/src/db.js` resuelve `@karajan/core` desde el árbol instalado ✅

## LOC
+8 (package.json + lockfile).