### PR TITLE
refactor: elimina void _drop en stripRuntimeOnlyKeys (KJC-TSK-0535)

### DIFF
--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -187,8 +187,8 @@ function stripRuntimeOnlyKeys(config) {
   // warning on every subsequent kj run.
   if (out.sonarqube && typeof out.sonarqube === "object"
       && Object.prototype.hasOwnProperty.call(out.sonarqube, "enabled")) {
-    const { enabled: _drop, ...rest } = out.sonarqube;
-    void _drop;
+    const rest = { ...out.sonarqube };
+    delete rest.enabled;
     out.sonarqube = rest;
   }
   return out;


### PR DESCRIPTION
Único CRITICAL del quality gate de Sonar (detectado por el `kj audit` post-v3.4.0 con claude-fable-5): `config/loader.js:191` usaba destructuring + `void _drop` para descartar `sonarqube.enabled` (regla S3735). Sustituido por copia superficial + `delete` — mismo comportamiento, sin variable sin uso ni `void`.

Tests de config: 66/66.

## LOC
+2/−2.