### PR TITLE
fix: audit propaga cached_tokens al budget y al informe (KJC-BUG-0085)

### DIFF
--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -130,6 +130,9 @@ function formatUsageSummary(usage) {
   // locale-less Node and "1,234" on a US-locale workstation).
   const fmt = (n) => n.toLocaleString("en-US");
   lines.push(`- Tokens: ${fmt(usage.total_tokens)} total (${fmt(usage.tokens_in)} in, ${fmt(usage.tokens_out)} out)`);
+  if (typeof usage.cached_tokens === "number" && usage.cached_tokens > 0) {
+    lines.push(`- Cached tokens: ${fmt(usage.cached_tokens)} (prompt-cache hits)`);
+  }
   if (typeof usage.cost_usd === "number") {
     lines.push(`- Estimated cost: $${usage.cost_usd.toFixed(4)} USD`);
   }

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -207,9 +207,9 @@ export class AuditRole extends AgentRole {
  *
  * @param {object} result - raw agent.runTask() return
  * @param {{provider: string, durationMs: number}} ctx
- * @returns {{available: boolean, provider: string, model?: string, tokens_in?: number, tokens_out?: number, total_tokens?: number, cost_usd?: number, durationMs: number, reason?: string}}
+ * @returns {{available: boolean, provider: string, model?: string, tokens_in?: number, tokens_out?: number, cached_tokens?: number, total_tokens?: number, cost_usd?: number, durationMs: number, reason?: string}}
  */
-function extractUsage(result, { provider, durationMs }) {
+export function extractUsage(result, { provider, durationMs }) {
   if (!result || typeof result !== "object") {
     return { available: false, provider, durationMs, reason: "no agent result" };
   }
@@ -218,12 +218,18 @@ function extractUsage(result, { provider, durationMs }) {
   if (tokens_in === null && tokens_out === null) {
     return { available: false, provider, model: result.model, durationMs, reason: `provider "${provider}" did not report token usage` };
   }
+  // KJC-BUG-0085: cached_tokens must survive this consolidation — the
+  // budget chain (computeUsage → BudgetTracker → summary.md Cache hits →
+  // telemetry) reads it from `usage` and the audit is the most expensive
+  // role of the session.
+  const cached_tokens = Number.isFinite(result.cached_tokens) ? result.cached_tokens : 0;
   return {
     available: true,
     provider,
     model: result.model,
     tokens_in: tokens_in ?? 0,
     tokens_out: tokens_out ?? 0,
+    cached_tokens,
     total_tokens: (tokens_in ?? 0) + (tokens_out ?? 0),
     cost_usd: typeof result.cost_usd === "number" ? result.cost_usd : null,
     durationMs,

--- a/tests/audit/usage-summary.test.js
+++ b/tests/audit/usage-summary.test.js
@@ -87,6 +87,50 @@ describe("formatUsageSummary (KJC-TSK-0363)", () => {
     expect(text).toContain("Tokens: 150 total");
     expect(text).not.toContain("Estimated cost");
   });
+
+  // KJC-BUG-0085: extractUsage must propagate cached_tokens so the
+  // budget chain (computeUsage → BudgetTracker → Cache hits) sees it.
+  it("extractUsage propagates cached_tokens from the agent result", async () => {
+    const { extractUsage } = await vi.importActual("../../src/roles/audit-role.js");
+    const usage = extractUsage(
+      { ok: true, tokens_in: 3795, tokens_out: 11989, cached_tokens: 1058694, cost_usd: 3.84, model: "claude-fable-5" },
+      { provider: "claude", durationMs: 1000 }
+    );
+    expect(usage.cached_tokens).toBe(1058694);
+
+    const noCache = extractUsage(
+      { ok: true, tokens_in: 100, tokens_out: 50 },
+      { provider: "claude", durationMs: 1000 }
+    );
+    expect(noCache.cached_tokens).toBe(0);
+  });
+
+  // KJC-BUG-0085: the audit usage must surface prompt-cache hits.
+  it("renders cached tokens line when cached_tokens > 0 and hides it at 0", () => {
+    const withCache = formatUsageSummary({
+      available: true,
+      provider: "claude",
+      tokens_in: 3795,
+      tokens_out: 11989,
+      total_tokens: 15784,
+      cached_tokens: 1058694,
+      cost_usd: 3.84,
+      durationMs: 174600,
+    });
+    expect(withCache).toContain("Cached tokens: 1,058,694 (prompt-cache hits)");
+
+    const noCache = formatUsageSummary({
+      available: true,
+      provider: "claude",
+      tokens_in: 100,
+      tokens_out: 50,
+      total_tokens: 150,
+      cached_tokens: 0,
+      cost_usd: null,
+      durationMs: 1000,
+    });
+    expect(noCache).not.toContain("Cached tokens");
+  });
 });
 
 describe("formatAudit appends LLM Usage section when usage is provided", () => {


### PR DESCRIPTION
## KJC-BUG-0085

`extractUsage()` de audit-role consolidaba el usage del agente descartando `cached_tokens`. Como `computeUsage()` lee `result.usage.cached_tokens` (budget.js:30-34), el rol audit — el más caro de la sesión (~10k tokens y $1.30+/run) — registraba 0 cached en BudgetTracker, en la tabla Cache hits de summary.md y en la telemetría.

### Fix
- `extractUsage()` propaga `cached_tokens` (0 si el provider no lo reporta) — exportado para test directo.
- El informe de `kj audit` muestra `- Cached tokens: N (prompt-cache hits)` cuando hay hits (oculto a 0, null-safety de siempre).

### Tests
- 2 nuevos (propagación en extractUsage con/sin cache; render condicional en formatUsageSummary). Suite audit completa: 273/273.

## LOC
+38/−4.