### PR TITLE
fix: escribe el session journal en todos los finales de run (KJC-BUG-0084)

### DIFF
--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -34,7 +34,6 @@ import { emitProgress, makeEvent } from "../../utils/events.js";
 import { runTesterStage, runSecurityStage, runFinalAuditStage } from "../post-loop-stages.js";
 import { invokeSolomon } from "../solomon-escalation.js";
 import { tryCiComment } from "../ci-integration.js";
-import { writeIterationsJournal } from "../session-journal.js";
 import { getIntegration } from "../integrations.js";
 
 export async function handlePostLoopStages({ config, session, emitter, eventBase, coderRole, trackBudget, i, task, stageResults, ciEnabled: _ciEnabled, testerEnabled, securityEnabled, askQuestion, logger, brainCtx }) {
@@ -129,103 +128,56 @@ export async function finalizeApprovedSession({ config, gitCtx, task, logger, se
   if (rtkSavings) setRtkSavings(session, rtkSavings);
   await saveSession(session);
 
-  // --- Journal: write final files ---
+  // --- Journal: write final files (shared writer, KJC-BUG-0084) ---
   const journalDir = session._journalDir;
   if (journalDir) {
+    // 2026-05-07 dogfooding: gitResult.commits only carries the post-loop
+    // commit (scaffold). Compute the full range from session_start_sha so
+    // every commit the run produced shows up in execution order.
+    let allCommits;
+    try { allCommits = (await listCommitsBetween(session.head_at_start || session.session_start_sha)) || []; }
+    catch { allCommits = gitResult?.commits || []; }
+    const summaryCommits = allCommits.length > 0 ? allCommits : (gitResult?.commits || []);
+
+    // KJC-TSK-0376 — plan adherence metric (deepeval-inspired). When the
+    // run executed against a known plan (`kj run --plan <id>`), score how
+    // faithfully the coder followed it. Pure offline; safe-by-default
+    // (try/catch swallows missing helper or unreadable plan).
+    let planAdherence = null;
     try {
-      await writeIterationsJournal(journalDir, session._journalIterations || []);
-      // decisions.md: writes only when Solomon was invoked (AC of KJC-TSK-0287).
-      // Pulls structured data from session.solomonRulings + session.brainDecisions.
-      const { writeDecisionsJournal: writeDecisionsJournalV2 } =
-        await import("../../session/journal/decisions-writer.js");
-      const decisionsResult = await writeDecisionsJournalV2(session, { journalDir, logger });
-      // KJC-TSK-0288: use the new tree-writer with directory grouping
-      const { writeTreeJournal: writeTreeJournalV2 } =
-        await import("../../session/journal/tree-writer.js");
-      const treeResult = await writeTreeJournalV2(journalDir, session.session_start_sha, { logger });
-
-      const journalFiles = [...(session._journalFiles || [])];
-      if (session._journalIterations?.length) journalFiles.push("iterations.md");
-      if (decisionsResult.written) journalFiles.push("decisions.md");
-      if (treeResult.written) journalFiles.push("tree.txt");
-
-      // KJC-TSK-0289: use the richer summary writer (stages table, budget
-      // breakdown, brain/solomon counts, typed links to other journal files).
-      const { writeSummaryJournal: writeSummaryJournalV2 } =
-        await import("../../session/journal/summary-writer.js");
-      const startedAt = session._startedAt ? new Date(session._startedAt).toISOString() : undefined;
-      // 2026-05-07 dogfooding: gitResult.commits only carries the post-loop
-      // commit (scaffold), not the coder's own commit. The summary's
-      // "Commits" section was therefore misleading — it claimed the run
-      // produced one chore commit when in fact the coder had also written
-      // a docs/feat commit. Compute the full range from session_start_sha
-      // so every commit between then and HEAD shows up in execution order.
-      // try/catch (instead of `.catch(...)`) so we tolerate both promise
-      // rejection AND a sync return of undefined — the latter happens
-      // when a test mocks listCommitsBetween with a plain vi.fn() that
-      // resetAllMocks has stripped of its mockResolvedValue.
-      let allCommits = [];
-      try { allCommits = (await listCommitsBetween(session.head_at_start || session.session_start_sha)) || []; }
-      catch { allCommits = gitResult?.commits || []; }
-      const summaryCommits = allCommits.length > 0 ? allCommits : (gitResult?.commits || []);
-
-      // KJC-TSK-0376 — plan adherence metric (deepeval-inspired). When the
-      // run executed against a known plan (`kj run --plan <id>`), score how
-      // faithfully the coder followed it. Pure offline; safe-by-default
-      // (try/catch swallows missing helper or unreadable plan).
-      let planAdherence = null;
-      try {
-        const planId = session._planRef?.planId
-          || stageResults?.huReviewer?.planId
-          || null;
-        if (planId) {
-          const projectDir = config?.projectDir
-            || session.config_snapshot?.projectDir
-            || process.cwd();
-          const plan = await loadPlan(projectDir, planId).catch(() => null);
-          if (plan && Array.isArray(plan.hus) && plan.hus.length > 0) {
-            const filesChanged = await listFilesChangedSince(
-              session.head_at_start || session.session_start_sha,
-            ).catch(() => []);
-            planAdherence = computePlanAdherenceScore({
-              commits: summaryCommits,
-              plan,
-              filesChanged,
-            });
-          }
+      const planId = session._planRef?.planId
+        || stageResults?.huReviewer?.planId
+        || null;
+      if (planId) {
+        const projectDir = config?.projectDir
+          || session.config_snapshot?.projectDir
+          || process.cwd();
+        const plan = await loadPlan(projectDir, planId).catch(() => null);
+        if (plan && Array.isArray(plan.hus) && plan.hus.length > 0) {
+          const filesChanged = await listFilesChangedSince(
+            session.head_at_start || session.session_start_sha,
+          ).catch(() => []);
+          planAdherence = computePlanAdherenceScore({
+            commits: summaryCommits,
+            plan,
+            filesChanged,
+          });
         }
-      } catch (err) {
-        logger?.warn?.(`Plan adherence calculation skipped: ${err.message}`);
       }
-
-      await writeSummaryJournalV2(journalDir, {
-        task: session.task,
-        result: "APPROVED",
-        sessionId: session.id,
-        iterations: i,
-        durationMs: Date.now() - (session._startedAt || Date.now()),
-        budget: budgetSummary(),
-        stages: stageResults,
-        commits: summaryCommits,
-        files: journalFiles,
-        startedAt,
-        finishedAt: new Date().toISOString(),
-        brainDecisions: Array.isArray(session.brainDecisions) ? session.brainDecisions.length : 0,
-        solomonInvocations: Array.isArray(session.solomonRulings) ? session.solomonRulings.length : 0,
-        // KJC-TSK-0327: surface skill-source decisions in the summary so the
-        // post-mortem shows which process skills (addyosmani) and stack skills
-        // (OpenSkills) actually shaped the role prompts.
-        skills: {
-          addyosmani: session.addyosmaniSkills,
-          installed: session.autoInstalledSkills,
-          recommended: session.skillsRecommended,
-        },
-        planAdherence,
-      }, { logger });
-      logger.info(`Session journal written to ${journalDir}`);
     } catch (err) {
-      logger.warn(`Journal write failed (non-blocking): ${err.message}`);
+      logger?.warn?.(`Plan adherence calculation skipped: ${err.message}`);
     }
+
+    const { writeSessionJournal } = await import("../../session/journal/write-all.js");
+    await writeSessionJournal({
+      session, logger,
+      result: "APPROVED",
+      iterations: i,
+      budget: budgetSummary(),
+      stages: stageResults,
+      commits: summaryCommits,
+      planAdherence,
+    });
   }
 
   // Mirror the same enriched commit list into the session:end event so the

--- a/src/orchestrator/flow-runner.js
+++ b/src/orchestrator/flow-runner.js
@@ -247,6 +247,31 @@ async function _runFlowInner({ task, config, logger, flags = {}, emitter = null,
     await sealSessionStatusIfStillRunning(ctx.session, result);
     return result;
   } finally {
+    // --- Journal: best-effort write for non-approved endings (KJC-BUG-0084) ---
+    // finalizeApprovedSession writes the journal on the happy path and sets
+    // session._journalWritten. Every other terminal ending (sonar_repeat
+    // stall, stage_error, thrown stage, budget exceeded) used to leave only
+    // triage.md behind — losing the Cache hits table, budget breakdown and
+    // commits exactly on the runs where the post-mortem matters most.
+    // Paused sessions are skipped: they resume later and the eventual
+    // finalize overwrites the journal with the real outcome.
+    try {
+      const s = ctx.session;
+      if (s && s._journalDir && !s._journalWritten && s.status !== "paused") {
+        const { writeSessionJournal } = await import("../session/journal/write-all.js");
+        const badge = s.status && s.status !== "running" ? s.status.toUpperCase() : "FAILED";
+        await writeSessionJournal({
+          session: s, logger,
+          result: badge,
+          iterations: s._journalIterations?.length || 0,
+          budget: typeof ctx.budgetSummary === "function" ? ctx.budgetSummary() : null,
+          stages: ctx.stageResults || {},
+        });
+      }
+    } catch (err) {
+      logger.warn(`Final journal write failed (non-blocking): ${err.message}`);
+    }
+
     // --- Cleanup auto-installed skills ---
     const autoSkills = ctx.session?.autoInstalledSkills;
     if (autoSkills && autoSkills.length > 0) {

--- a/src/session/journal/write-all.js
+++ b/src/session/journal/write-all.js
@@ -14,6 +14,9 @@
 
 import { writeIterationsJournal } from "../../orchestrator/session-journal.js";
 import { listCommitsBetween } from "../../utils/git.js";
+import { writeDecisionsJournal } from "./decisions-writer.js";
+import { writeTreeJournal } from "./tree-writer.js";
+import { writeSummaryJournal } from "./summary-writer.js";
 
 /**
  * Write iterations.md, decisions.md, tree.txt and summary.md for a session.
@@ -36,9 +39,7 @@ export async function writeSessionJournal({ session, logger, result = "APPROVED"
 
   try {
     await writeIterationsJournal(journalDir, session._journalIterations || []);
-    const { writeDecisionsJournal } = await import("./decisions-writer.js");
     const decisionsResult = await writeDecisionsJournal(session, { journalDir, logger });
-    const { writeTreeJournal } = await import("./tree-writer.js");
     const treeResult = await writeTreeJournal(journalDir, session.session_start_sha, { logger });
 
     const journalFiles = [...(session._journalFiles || [])];
@@ -56,7 +57,6 @@ export async function writeSessionJournal({ session, logger, result = "APPROVED"
       catch { summaryCommits = []; }
     }
 
-    const { writeSummaryJournal } = await import("./summary-writer.js");
     const startedAt = session._startedAt ? new Date(session._startedAt).toISOString() : undefined;
     await writeSummaryJournal(journalDir, {
       task: session.task,

--- a/src/session/journal/write-all.js
+++ b/src/session/journal/write-all.js
@@ -1,0 +1,89 @@
+/**
+ * Session-journal writer shared by every terminal path (KJC-BUG-0084).
+ *
+ * Pre-fix, the iterations/decisions/tree/summary block lived inline in
+ * finalizeApprovedSession(), so a run that died on a stage error
+ * (sonar_repeat, gh pr create failure, thrown stage) left only triage.md
+ * behind — the Cache hits table, the budget breakdown and the commit list
+ * vanished exactly on the runs where they matter most. This module is the
+ * single writer; the approved path calls it with its enriched extras and
+ * flow-runner's `finally` calls it best-effort for every other ending.
+ *
+ * Never throws: a journal failure must not mask the run's real result.
+ */
+
+import { writeIterationsJournal } from "../../orchestrator/session-journal.js";
+import { listCommitsBetween } from "../../utils/git.js";
+
+/**
+ * Write iterations.md, decisions.md, tree.txt and summary.md for a session.
+ *
+ * @param {object} args
+ * @param {object} args.session - live session (needs _journalDir to write)
+ * @param {{info?: Function, warn?: Function}} [args.logger]
+ * @param {string} [args.result] - summary badge: APPROVED | FAILED | STOPPED…
+ * @param {number} [args.iterations]
+ * @param {object|null} [args.budget] - budgetSummary() snapshot
+ * @param {object} [args.stages] - stageResults map
+ * @param {Array}  [args.commits] - precomputed commit list; computed from
+ *   session_start_sha when omitted
+ * @param {object|null} [args.planAdherence]
+ * @returns {Promise<{written: boolean, reason?: string}>}
+ */
+export async function writeSessionJournal({ session, logger, result = "APPROVED", iterations = 0, budget = null, stages = {}, commits = null, planAdherence = null }) {
+  const journalDir = session?._journalDir;
+  if (!journalDir) return { written: false, reason: "no journal dir" };
+
+  try {
+    await writeIterationsJournal(journalDir, session._journalIterations || []);
+    const { writeDecisionsJournal } = await import("./decisions-writer.js");
+    const decisionsResult = await writeDecisionsJournal(session, { journalDir, logger });
+    const { writeTreeJournal } = await import("./tree-writer.js");
+    const treeResult = await writeTreeJournal(journalDir, session.session_start_sha, { logger });
+
+    const journalFiles = [...(session._journalFiles || [])];
+    if (session._journalIterations?.length) journalFiles.push("iterations.md");
+    if (decisionsResult.written) journalFiles.push("decisions.md");
+    if (treeResult.written) journalFiles.push("tree.txt");
+
+    // Commit range from session start so the summary shows every commit
+    // the run produced, not just the post-loop scaffold (2026-05-07
+    // dogfooding). try/catch tolerates promise rejection AND a sync
+    // undefined return from a resetAllMocks-stripped test mock.
+    let summaryCommits = Array.isArray(commits) ? commits : null;
+    if (!summaryCommits) {
+      try { summaryCommits = (await listCommitsBetween(session.head_at_start || session.session_start_sha)) || []; }
+      catch { summaryCommits = []; }
+    }
+
+    const { writeSummaryJournal } = await import("./summary-writer.js");
+    const startedAt = session._startedAt ? new Date(session._startedAt).toISOString() : undefined;
+    await writeSummaryJournal(journalDir, {
+      task: session.task,
+      result,
+      sessionId: session.id,
+      iterations,
+      durationMs: Date.now() - (session._startedAt || Date.now()),
+      budget,
+      stages,
+      commits: summaryCommits,
+      files: journalFiles,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      brainDecisions: Array.isArray(session.brainDecisions) ? session.brainDecisions.length : 0,
+      solomonInvocations: Array.isArray(session.solomonRulings) ? session.solomonRulings.length : 0,
+      skills: {
+        addyosmani: session.addyosmaniSkills,
+        installed: session.autoInstalledSkills,
+        recommended: session.skillsRecommended,
+      },
+      planAdherence,
+    }, { logger });
+    session._journalWritten = true;
+    logger?.info?.(`Session journal written to ${journalDir}`);
+    return { written: true };
+  } catch (err) {
+    logger?.warn?.(`Journal write failed (non-blocking): ${err.message}`);
+    return { written: false, reason: err.message };
+  }
+}

--- a/tests/session/write-all.test.js
+++ b/tests/session/write-all.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { writeSessionJournal } from "../../src/session/journal/write-all.js";
+
+// KJC-BUG-0084 — the shared journal writer must produce summary.md for
+// every terminal ending, not just the approved path. Pre-fix, a run that
+// died on sonar_repeat or a gh pr failure left only triage.md behind.
+
+const logger = { info: vi.fn(), warn: vi.fn() };
+
+function makeSession(journalDir) {
+  return {
+    id: "s_test",
+    task: "test task",
+    _journalDir: journalDir,
+    _journalFiles: ["triage.md"],
+    _journalIterations: [],
+    _startedAt: Date.now() - 60_000,
+    session_start_sha: null,
+    head_at_start: null,
+  };
+}
+
+describe("session/journal/write-all (KJC-BUG-0084)", () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-write-all-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes summary.md with the failure badge and the budget breakdown", async () => {
+    const session = makeSession(tmpDir);
+    const res = await writeSessionJournal({
+      session,
+      logger,
+      result: "STOPPED",
+      iterations: 2,
+      budget: {
+        total_cost_usd: 0.53,
+        total_tokens: 11075,
+        breakdown_by_role: { coder: { tokens_in: 4046, tokens_out: 7000, cached_tokens: 1287936, cost_usd: 0.53 } },
+      },
+      stages: { sonar: { ok: false, summary: "quality gate ERROR repeated" } },
+      commits: [],
+    });
+
+    expect(res.written).toBe(true);
+    expect(session._journalWritten).toBe(true);
+    const summary = await fs.readFile(path.join(tmpDir, "summary.md"), "utf8");
+    expect(summary).toContain("STOPPED");
+    expect(summary).toContain("sonar");
+  });
+
+  it("returns written:false without throwing when the session has no journal dir", async () => {
+    const res = await writeSessionJournal({ session: { id: "s" }, logger, result: "FAILED" });
+    expect(res.written).toBe(false);
+    expect(res.reason).toBe("no journal dir");
+  });
+
+  it("never throws when the journal dir is not writable", async () => {
+    // Point _journalDir at a regular FILE so the writes inside fail. The
+    // sub-writers are individually fault-tolerant (they warn and continue),
+    // so the contract asserted here is the one flow-runner's finally relies
+    // on: the call RESOLVES — a journal failure never masks the run result.
+    const fileAsDir = path.join(tmpDir, "not-a-dir");
+    await fs.writeFile(fileAsDir, "plain file");
+    const session = makeSession(fileAsDir);
+    await expect(
+      writeSessionJournal({ session, logger, result: "FAILED" })
+    ).resolves.toBeTruthy();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0084

El bloque de journal (iterations.md, decisions.md, tree.txt, summary.md) vivía inline en `finalizeApprovedSession` — solo el camino feliz lo escribía. Un run terminado por `sonar_repeat`, fallo de `gh pr create` o stage error dejaba **solo triage.md**: se perdían la tabla Cache hits, el budget breakdown y los commits exactamente en los runs donde más falta hace el post-mortem (observado en vivo durante la medición Φ1-G).

### Fix
- Nuevo `src/session/journal/write-all.js` → `writeSessionJournal()`: writer único, never-throws, marca `session._journalWritten`.
- `finalizeApprovedSession` delega en él (mismo contenido enriquecido: commits del rango completo + plan adherence).
- `finally` de `_runFlowInner`: escritura best-effort para todo final **no pausado** que no haya escrito ya — badge del estado real (STOPPED/FAILED/…). Paused se salta: el resume posterior escribe el resultado real (y el approved sobrescribe sin mirar el flag).

### Tests
- 3 nuevos en `tests/session/write-all.test.js` (badge de fallo + budget en summary.md, no-journal-dir, never-throws con dir ilegible).
- Regresión: session (163), runflow-{events,budget,checkpoint,triage}, dry-run, subloop-limits — todos verdes.

## LOC
+186/−112 (neta +74).