### PR TITLE
refactor: escapeRegExp compartido en interpolaciones de RegExp (KJC-TSK-0536)

### DIFF
--- a/src/audit/agent-readiness.js
+++ b/src/audit/agent-readiness.js
@@ -16,6 +16,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { escapeRegExp } from "../utils/escape-regexp.js";
 
 const PAGE_BYTE_LIMIT = 32 * 1024; // ≈ 8K tokens, the typical agent budget per fetch
 
@@ -65,7 +66,7 @@ const CHECKS = [
       if (!found) return { ok: false, hint: "Add robots.txt with `User-agent: GPTBot|ClaudeBot|PerplexityBot\\nAllow: /` blocks.", details: {} };
       const text = safeRead(path.join(rootDir, found));
       const aiBots = ["GPTBot", "ClaudeBot", "PerplexityBot", "anthropic-ai", "Google-Extended"];
-      const allowed = aiBots.filter((bot) => new RegExp(`User-agent:\\s*${bot}[\\s\\S]*?Allow:\\s*/`, "i").test(text));
+      const allowed = aiBots.filter((bot) => new RegExp(`User-agent:\\s*${escapeRegExp(bot)}[\\s\\S]*?Allow:\\s*/`, "i").test(text));
       const ok = allowed.length > 0;
       return ok
         ? { ok: true, hint: null, details: { found, allowed } }

--- a/src/audit/issue-filter.js
+++ b/src/audit/issue-filter.js
@@ -16,6 +16,7 @@
 // metadata for auditability — no silent dropping.
 
 import fs from "node:fs";
+import { escapeRegExp } from "../utils/escape-regexp.js";
 
 export const DEFAULT_FALSE_POSITIVES = [
   {
@@ -59,8 +60,8 @@ export function hasInlineIgnore(filePath, line, ruleId, tool = "sonar") {
     const lines = fs.readFileSync(filePath, "utf8").split("\n");
     const idx = line - 1;
     const candidates = [lines[idx], lines[idx - 1]].filter(Boolean);
-    const escapedRule = escapeRegex(ruleId);
-    const escapedTool = escapeRegex(tool);
+    const escapedRule = escapeRegExp(ruleId);
+    const escapedTool = escapeRegExp(tool);
     // New generalised marker + legacy sonar-only marker.
     const reAudit = new RegExp(`karajan-audit-ignore\\s*:\\s*${escapedTool}:${escapedRule}\\b`);
     const reLegacy = tool === "sonar"
@@ -70,10 +71,6 @@ export function hasInlineIgnore(filePath, line, ruleId, tool = "sonar") {
   } catch {
     return false;
   }
-}
-
-function escapeRegex(s) {
-  return String(s).replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/src/audit/plan-adherence.js
+++ b/src/audit/plan-adherence.js
@@ -7,6 +7,8 @@
  * See docs/plan-adherence.md (PR-C) for the full spec.
  */
 
+import { escapeRegExp } from "../utils/escape-regexp.js";
+
 const WEIGHTS = {
   commit_attribution: 40,
   acceptance_tests: 30,
@@ -20,7 +22,7 @@ const WEIGHTS = {
  * appear inside HU ids so we anchor on whole-token rather than \b.
  */
 function huIdMatcher(huId) {
-  const escaped = String(huId).replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  const escaped = escapeRegExp(huId);
   return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, "i");
 }
 

--- a/src/golden/asserter.js
+++ b/src/golden/asserter.js
@@ -10,12 +10,14 @@
  * allowed_loc_range need filesystem access — PR-3a wires those.
  */
 
+import { escapeRegExp } from "../utils/escape-regexp.js";
+
 const COMMIT_LINE = /^- `([^`]+)`\s+(.*)$/;
 const SCORE_LINE = /^\*\*Score\*\*:\s*(\d+)\s*\/\s*100/m;
 const AUDIT_ROW = /^\|\s*`audit`\s*\|\s*([^|]+?)\s*\|/m;
 
 function extractSection(content, heading) {
-  const re = new RegExp(`^## ${heading}\\s*$([\\s\\S]*?)(?=^## |\\Z)`, "m");
+  const re = new RegExp(`^## ${escapeRegExp(heading)}\\s*$([\\s\\S]*?)(?=^## |\\Z)`, "m");
   const m = content.match(re);
   return m ? m[1].trim() : "";
 }

--- a/src/mcp/handlers/management-handlers.js
+++ b/src/mcp/handlers/management-handlers.js
@@ -16,6 +16,7 @@ import {
 } from "../shared-helpers.js";
 import { buildDashboardJson } from "../../utils/status-dashboard.js";
 import { loadMostRecentSession } from "../../session/store.js";
+import { escapeRegExp } from "../../utils/escape-regexp.js";
 
 const AGENT_ROLES = new Set(["coder", "reviewer", "tester", "security", "solomon"]);
 
@@ -72,9 +73,9 @@ export async function handleAgents(a) {
 function parseHumanResponseOverrides(humanResponse, overrides) {
   for (const role of AGENT_ROLES) {
     const patterns = [
-      new RegExp(String.raw`use\s+(\w+)\s+(?:as|for)\s+${role}`, "i"),
-      new RegExp(String.raw`${role}\s*[:=]\s*(\w+)`, "i"),
-      new RegExp(String.raw`set\s+${role}\s+(?:to|=)\s*(\w+)`, "i")
+      new RegExp(String.raw`use\s+(\w+)\s+(?:as|for)\s+${escapeRegExp(role)}`, "i"),
+      new RegExp(String.raw`${escapeRegExp(role)}\s*[:=]\s*(\w+)`, "i"),
+      new RegExp(String.raw`set\s+${escapeRegExp(role)}\s+(?:to|=)\s*(\w+)`, "i")
     ];
     for (const pat of patterns) {
       const m = pat.exec(humanResponse);

--- a/src/sonar/discovery.js
+++ b/src/sonar/discovery.js
@@ -21,6 +21,7 @@
 
 import { runCommand } from "../utils/process.js";
 import { isSonarReachable } from "./manager.js";
+import { escapeRegExp } from "../utils/escape-regexp.js";
 
 /**
  * @typedef {Object} DiscoveredSonar
@@ -48,7 +49,7 @@ import { isSonarReachable } from "./manager.js";
 export function extractHostPort(portsStr, internalPort = 9000) {
   if (!portsStr) return null;
   const re = new RegExp(
-    `(?:0\\.0\\.0\\.0|127\\.0\\.0\\.1|::|\\[::\\]):(\\d+)\\s*->\\s*${internalPort}\\/tcp`,
+    `(?:0\\.0\\.0\\.0|127\\.0\\.0\\.1|::|\\[::\\]):(\\d+)\\s*->\\s*${escapeRegExp(internalPort)}\\/tcp`,
     "g"
   );
   const matches = [...portsStr.matchAll(re)];

--- a/src/utils/escape-regexp.js
+++ b/src/utils/escape-regexp.js
@@ -1,0 +1,15 @@
+/**
+ * Escape regex metacharacters so a value can be interpolated into a
+ * RegExp literally (KJC-TSK-0536 — closes Semgrep's
+ * detect-non-literal-regexp findings in one move).
+ *
+ * Use this EVERY time a variable lands inside `new RegExp(...)`. It is
+ * NOT for config-provided patterns (output-guard/perf-guard policies),
+ * which are regexes by design.
+ *
+ * @param {unknown} value - coerced to string
+ * @returns {string}
+ */
+export function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/utils/port-occupant.js
+++ b/src/utils/port-occupant.js
@@ -9,6 +9,7 @@
  */
 
 import { runCommand } from "./process.js";
+import { escapeRegExp } from "./escape-regexp.js";
 
 /**
  * @typedef {Object} PortOccupant
@@ -74,7 +75,7 @@ async function detectWindows(port) {
     if (netstat.exitCode !== 0) return null;
     const line = netstat.stdout
       .split(/\r?\n/)
-      .find((l) => l.match(new RegExp(`:${port}\\s+.*LISTENING`)));
+      .find((l) => l.match(new RegExp(`:${escapeRegExp(port)}\\s+.*LISTENING`)));
     if (!line) return null;
     const parts = line.trim().split(/\s+/);
     const pid = Number(parts[parts.length - 1]) || null;

--- a/src/utils/project-detect.js
+++ b/src/utils/project-detect.js
@@ -97,7 +97,7 @@ export async function detectTestFramework(cwd = process.cwd()) {
     try {
       if (marker.glob) {
         const entries = await fs.readdir(cwd);
-        const ext = marker.file.replace("*", "");
+        const ext = marker.file.replaceAll("*", "");
         if (entries.some((e) => e.endsWith(ext))) {
           return { hasTests: true, framework: marker.framework, language: marker.language };
         }

--- a/tests/utils/escape-regexp.test.js
+++ b/tests/utils/escape-regexp.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { escapeRegExp } from "../../src/utils/escape-regexp.js";
+
+// KJC-TSK-0536 — shared escape for every variable interpolated into a
+// RegExp. Closes Semgrep's detect-non-literal-regexp findings.
+
+describe("escapeRegExp", () => {
+  it("escapes every regex metacharacter", () => {
+    const meta = ".*+?^${}()|[]\\";
+    const escaped = escapeRegExp(meta);
+    expect(new RegExp(`^${escaped}$`).test(meta)).toBe(true);
+  });
+
+  it("leaves plain identifiers untouched", () => {
+    expect(escapeRegExp("ClaudeBot")).toBe("ClaudeBot");
+    expect(escapeRegExp("HU-001_alpha")).toBe("HU-001_alpha");
+  });
+
+  it("coerces non-string input (ports, ids)", () => {
+    expect(escapeRegExp(9000)).toBe("9000");
+    expect(new RegExp(`:${escapeRegExp(9000)}\\b`).test(":9000 LISTEN")).toBe(true);
+  });
+
+  it("neutralizes a pathological injected pattern", () => {
+    const hostile = "(a+)+$";
+    const re = new RegExp(`^${escapeRegExp(hostile)}$`);
+    expect(re.test("(a+)+$")).toBe(true);
+    expect(re.test("aaaa")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Recomendación 5 del audit v3.4.0 (parte ReDoS)

Nuevo `src/utils/escape-regexp.js` aplicado en todo sitio que interpola una variable en `new RegExp()`:

- `agent-readiness` (nombres de bot), `golden/asserter` (heading), `port-occupant` (puerto), `management-handlers` (rol), `sonar/discovery` (puerto interno).
- Consolida los escapes locales duplicados de `issue-filter` (`escapeRegex`) y `plan-adherence` (inline).
- `project-detect`: `replace('*')` → `replaceAll` (incomplete-sanitization).

**Fuera de scope a propósito**: `output-guard`/`perf-guard` compilan patrones de política que son regex por diseño — escaparlos rompería la feature.

## Tests
4 nuevos del util (metacaracteres, identidad, coerción numérica, patrón hostil neutralizado) + 367/367 en las suites afectadas (audit, golden, mcp, sonar).

## LOC
+62/−13.