### PR TITLE
refactor: poda 23 dead exports + doc falsos positivos deps (KJC-TSK-0537)

### DIFF
--- a/docs/audit-false-positives.md
+++ b/docs/audit-false-positives.md
@@ -128,3 +128,22 @@ All five flow through the FP filter above. CLI flags `--no-sonar`,
 `--no-osv`, `--no-semgrep`, `--no-madge`, `--no-knip` disable each one
 independently. `--deterministic-only` runs the collectors but skips the
 LLM phase entirely (zero tokens).
+
+## Root dependencies flagged "unused" by knip (audit v3.4.0, 2026-06-12)
+
+The v3.4.0 post-release audit recommended removing 6 "unused" root
+dependencies. **All six are required** — applying that recommendation
+would have broken the published npm package the same way KJC-BUG-0082
+did. Verified one by one:
+
+| Dependency | Why it must stay in the root `package.json` |
+| --- | --- |
+| `express`, `express-rate-limit`, `helmet` | Runtime deps of the shipped `packages/hu-board`. Nested workspace `package.json` deps are NOT installed for tarball consumers — `packages/hu-board/src/*` resolves them by walking up to the consumer's top-level `node_modules`, which only contains what the ROOT declares. Removing them breaks `kj board` on every `npm install karajan-code`. |
+| `sqlite-vec` | Runtime dep of `@karajan/core` (vec-store). Core ships via `bundleDependencies` (KJC-BUG-0082), but bundling embeds only the package itself, not its deps — those also resolve against the root install. |
+| `postject` | Already a devDependency (correct placement). Used by `scripts/build-sea.mjs` in the SEA release workflow. |
+| `simple-git-hooks` | Already a devDependency (correct placement). Drives the `pre-commit` hook via the `simple-git-hooks` config block in `package.json`. |
+
+Rule of thumb: anything imported by `packages/hu-board/src` or
+`packages/core/src` must ALSO be declared in the root `dependencies`,
+because that is the only `node_modules` that exists after
+`npm install karajan-code`.

--- a/packages/hu-board/src/zombie-reaper.js
+++ b/packages/hu-board/src/zombie-reaper.js
@@ -130,7 +130,7 @@ export function appendZombieCheckpoint(existingJson, reason, isoTimestamp) {
  * @returns {string}
  */
 import { getKjHome } from "./db.js";
-export function getSessionsDir() {
+function getSessionsDir() {
   return path.join(getKjHome(), "sessions");
 }
 

--- a/src/agents/aider-agent.js
+++ b/src/agents/aider-agent.js
@@ -12,7 +12,7 @@ import { resolveBin } from "./resolve-bin.js";
  * Returns `{tokens_in, tokens_out, cached_tokens}` or null when no usage
  * is found (= unmeasured; callers leave the fields undefined).
  */
-export function extractAiderUsage(text) {
+function extractAiderUsage(text) {
   if (!text) return null;
   for (const line of text.split("\n")) {
     const t = line.trim();

--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -12,7 +12,7 @@ import { resolveBin } from "./resolve-bin.js";
  * so the caller leaves `cached_tokens` undefined (= unmeasured,
  * distinct from a measured 0).
  */
-export function extractGeminiUsage(text) {
+function extractGeminiUsage(text) {
   if (!text) return null;
   const candidates = [];
   for (const line of text.split("\n")) {

--- a/src/agents/opencode-agent.js
+++ b/src/agents/opencode-agent.js
@@ -10,7 +10,7 @@ import { resolveBin } from "./resolve-bin.js";
  * nested `usage` object. Returns `{tokens_in, tokens_out, cached_tokens}`
  * or null (= unmeasured).
  */
-export function extractOpenCodeUsage(text) {
+function extractOpenCodeUsage(text) {
   if (!text) return null;
   const candidates = [text.trim()];
   for (const line of text.split("\n")) {

--- a/src/brain/standby-scheduler.js
+++ b/src/brain/standby-scheduler.js
@@ -5,6 +5,4 @@ export {
   scheduleResume,
   cancelScheduled,
   reconcileAll,
-  acquireStandbyLock,
-  markStandbyDone,
 } from "@karajan/core/standby-scheduler";

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -405,4 +405,4 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
 }
 
 // Exposed for tests — kept module-private otherwise.
-export { formatAudit, formatUsageSummary, AUDIT_DIMENSIONS };
+export { formatAudit, formatUsageSummary };

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -128,7 +128,7 @@ export function waitForEarlyExit(child, logPath) {
 // out, so we never announce "HU Board started" for an unreachable
 // server. Overridable with KJ_BOARD_READY_TIMEOUT_MS (tests set it
 // low to stay fast).
-export async function waitForBoardReachable(port, totalTimeoutMs) {
+async function waitForBoardReachable(port, totalTimeoutMs) {
   const envTimeout = Number(process.env.KJ_BOARD_READY_TIMEOUT_MS);
   const budget = Number.isFinite(envTimeout) && envTimeout >= 0
     ? envTimeout

--- a/src/golden/schema.js
+++ b/src/golden/schema.js
@@ -12,7 +12,7 @@ const NonNegInt = v.pipe(v.number(), v.integer(), v.minValue(0));
 const LocRangeSchema = v.pipe(v.array(NonNegInt), v.length(2),
   v.check((arr) => arr[0] <= arr[1], "allowed_loc_range: min must be <= max"));
 
-export const GoldenTaskSchema = v.looseObject({
+const GoldenTaskSchema = v.looseObject({
   id: v.pipe(NonEmptyString, v.regex(/^[a-z0-9_-]+$/, "id must be lowercase a-z0-9_-")),
   title: NonEmptyString,
   prompt: NonEmptyString,

--- a/src/hu/auto-generator.js
+++ b/src/hu/auto-generator.js
@@ -106,7 +106,7 @@ function filterConflictingHints(hints) {
  * @param {string[]} hints
  * @returns {"python"|"go"|"rust"|"javascript"}
  */
-export function resolveLanguageFromHints(hints) {
+function resolveLanguageFromHints(hints) {
   if (!hints || hints.length === 0) return "javascript";
   if (hints.some((h) => HINT_PYTHON.has(h))) return "python";
   if (hints.some((h) => HINT_GO.has(h))) return "go";

--- a/src/lang/tree-sitter-loader.js
+++ b/src/lang/tree-sitter-loader.js
@@ -24,7 +24,7 @@ async function initRuntime() {
   return runtimePromise;
 }
 
-export function grammarPath(id) {
+function grammarPath(id) {
   return resolve(GRAMMAR_DIR, `${id}.wasm`);
 }
 
@@ -43,7 +43,3 @@ export function getLoaded(id) {
   return cache.get(id) || null;
 }
 
-export function resetForTests() {
-  cache.clear();
-  runtimePromise = null;
-}

--- a/src/prompts/hu-reviewer.js
+++ b/src/prompts/hu-reviewer.js
@@ -29,7 +29,7 @@ const DIMENSION_KEYS = [
  * identical across batches on the same project; the stories under
  * evaluation and the per-batch additional context go last.
  */
-export function buildHuReviewerPromptLayout({ stories, instructions, context = null, productContext = null, domainContext = null, hu_language = "en" }) {
+function buildHuReviewerPromptLayout({ stories, instructions, context = null, productContext = null, domainContext = null, hu_language = "en" }) {
   const langInstruction = getLanguageInstruction(hu_language);
 
   return buildPromptLayout([

--- a/src/prompts/planner.js
+++ b/src/prompts/planner.js
@@ -70,7 +70,7 @@ export function parsePlannerOutput(output) {
  * @param {string} task
  * @returns {string[]} deduplicated trimmed exclusion items
  */
-export function extractScopeExclusions(task) {
+function extractScopeExclusions(task) {
   if (!task || typeof task !== "string") return [];
   const patterns = [
     /\bNO\s+incluye[^:\n]{0,60}:\s*([^.\n]+)/gi,

--- a/src/rag/embedders/factory.js
+++ b/src/rag/embedders/factory.js
@@ -27,4 +27,3 @@ export function makeEmbedder(config = {}) {
   return new spec.cls({ url: cfg.url, apiKey: cfg.api_key, model: cfg.model, dim, timeoutMs: cfg.timeout_ms });
 }
 
-export { PROVIDERS };

--- a/src/rag/retriever.js
+++ b/src/rag/retriever.js
@@ -124,4 +124,4 @@ export async function query(db, embedder, text, { topK = 5, scope = "all", kindB
   return reranked;
 }
 
-export { shouldBoostSources, isTestPath, fuseHits, cosineSim };
+export { fuseHits, cosineSim };

--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -25,7 +25,7 @@ import { withBrainRecovery } from "../brain/with-brain-recovery.js";
  * @param {object} config
  * @returns {number|null}
  */
-export function resolveAgentSilenceTimeoutMs(config) {
+function resolveAgentSilenceTimeoutMs(config) {
   const minutes = Number(config?.session?.max_agent_silence_minutes);
   return Number.isFinite(minutes) && minutes > 0 ? Math.round(minutes * 60 * 1000) : null;
 }

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -205,6 +205,8 @@ export class AuditRole extends AgentRole {
  * result fields. Returns a single object so consumers (CLI formatter,
  * report-file writer, MCP) don't need to know about the spread shape.
  *
+ * Consumed by tests via vi.importActual (knip blind spot) — keep exported.
+ * @public
  * @param {object} result - raw agent.runTask() return
  * @param {{provider: string, durationMs: number}} ctx
  * @returns {{available: boolean, provider: string, model?: string, tokens_in?: number, tokens_out?: number, cached_tokens?: number, total_tokens?: number, cost_usd?: number, durationMs: number, reason?: string}}

--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -11,7 +11,7 @@ import {
   resolveSonarCredentials,
 } from "./config-resolver.js";
 
-export async function findNativeSonarScanner() {
+async function findNativeSonarScanner() {
   const which = await runCommand("sh", ["-c", "command -v sonar-scanner"]);
   if (which.exitCode === 0) {
     const bin = String(which.stdout || "").trim();

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -9,6 +9,5 @@ export {
   getSonarComposePath,
   getOllamaComposePath,
   getWebperfDir,
-  getRunsDir,
   getPromptsDir,
 } from "@karajan/core/paths";

--- a/tests/fixtures/orchestrator-mocks.js
+++ b/tests/fixtures/orchestrator-mocks.js
@@ -18,26 +18,7 @@ export const REVIEW_REJECTED = JSON.stringify({
   confidence: 0.9,
 });
 
-export const REVIEW_BLOCKING = JSON.stringify({
-  approved: false,
-  blocking_issues: [{ id: "B1", severity: "high", file: "a.js", line: 10, description: "Bug found", suggested_fix: "Fix it" }],
-  non_blocking_suggestions: [],
-  summary: "Blocking issues found",
-  confidence: 0.85,
-});
-
 // --- Logger factories ---
-
-export function createLogger() {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    setContext: vi.fn(),
-    resetContext: vi.fn(),
-  };
-}
 
 export const noopLogger = {
   info: vi.fn(),
@@ -91,15 +72,6 @@ export function makeConfig(overrides = {}) {
 }
 
 // --- Mock setup helpers ---
-
-export function mockCreateAgent(reviewOutput = REVIEW_OK) {
-  return {
-    createAgent: vi.fn(() => ({
-      runTask: vi.fn().mockResolvedValue({ ok: true, output: "" }),
-      reviewTask: vi.fn().mockResolvedValue({ ok: true, output: reviewOutput }),
-    })),
-  };
-}
 
 // --- Convenience: apply all standard mocks after vi.resetAllMocks() ---
 


### PR DESCRIPTION
## Recomendación 5 (parte dead exports) + recomendación 3 (corregida) del audit v3.4.0

### Poda (knip pasa de 24 a **0** unused exports)
- **Un-export** de símbolos solo usados internamente: usage extractors de gemini/aider/opencode, `buildHuReviewerPromptLayout`, `extractScopeExclusions`, retriever helpers, `GoldenTaskSchema`, `waitForBoardReachable`, `findNativeSonarScanner`, `grammarPath`, `getSessionsDir`, `resolveLanguageFromHints`, `resolveAgentSilenceTimeoutMs`, `PROVIDERS`, `AUDIT_DIMENSIONS` (re-export redundante).
- **Limpieza de barrels**: `getRunsDir` (paths) y `acquireStandbyLock`/`markStandbyDone` (standby-scheduler) — nadie los consumía vía el shim.
- **Borrados**: `resetForTests` (tree-sitter) y los 3 helpers huérfanos de `orchestrator-mocks` (REVIEW_BLOCKING, createLogger, mockCreateAgent).
- **`@public`** en `extractUsage` de audit-role: lo consumen los tests vía `vi.importActual` (punto ciego de knip) — knip respeta el tag.

### Recomendación 3 del audit era un falso positivo COMPLETO
Documentado en `docs/audit-false-positives.md`: las 6 deps raíz "no usadas" son imprescindibles (express/rate-limit/helmet las resuelve el hu-board shipped contra el node_modules raíz; sqlite-vec la usa el core bundled; postject/simple-git-hooks ya son devDeps en uso). Aplicar la recomendación habría repetido el patrón de KJC-BUG-0082.

## Tests
Suite completa local: **5 635/5 635** (516 ficheros).

## LOC
+35/−50 (neta **−15**).