### PR TITLE
refactor: barrido Sonar — CRITICALs S2871 + regex S5843 + ternarios S3358/S4624 (KJC-TSK-0538)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -71,7 +71,8 @@ function formatInjectionBlock(inj) {
       if (items.length === 0) continue;
       lines.push(`  - ${severity} (${items.length}):`);
       for (const f of items.slice(0, MAX_SAMPLE_INJECTION_PER_SEVERITY)) {
-        lines.push(`    - ${f.file || "(unknown)"}${f.line ? `:${f.line}` : ""} [${f.type}] ${f.pattern}`);
+        const lineSuffix = f.line ? `:${f.line}` : "";
+        lines.push(`    - ${f.file || "(unknown)"}${lineSuffix} [${f.type}] ${f.pattern}`);
       }
       if (items.length > MAX_SAMPLE_INJECTION_PER_SEVERITY) lines.push(`    - ... and ${items.length - MAX_SAMPLE_INJECTION_PER_SEVERITY} more in ${severity}`);
     }
@@ -85,7 +86,8 @@ function formatCircularDepsBlock(circularDeps) {
     return ["### Circular Dependencies (architecture)", `- Status: not available — ${circularDeps.reason || "madge not available"}`, ""];
   }
   const lines = ["### Circular Dependencies (architecture)"];
-  lines.push(`- Total cycles: ${circularDeps.total ?? 0}${circularDeps.suppressedCount ? ` (+${circularDeps.suppressedCount} suppressed)` : ""}`);
+  const suppressedSuffix = circularDeps.suppressedCount ? ` (+${circularDeps.suppressedCount} suppressed)` : "";
+  lines.push(`- Total cycles: ${circularDeps.total ?? 0}${suppressedSuffix}`);
   if ((circularDeps.total ?? 0) > 0) {
     const groups = groupCyclesBySeverity(circularDeps.cycles || []);
     for (const [severity, cycles] of Object.entries(groups)) {
@@ -118,7 +120,8 @@ function formatSemgrepBlock(semgrepFindings) {
       if (findings.length === 0) continue;
       lines.push(`  - ${severity} (${findings.length}):`);
       for (const f of findings.slice(0, MAX_SAMPLE_SEMGREP_PER_SEVERITY)) {
-        const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
+        const lineSuffix = f.line ? `:${f.line}` : "";
+        const loc = f.file ? `${f.file}${lineSuffix}` : "";
         lines.push(`    - ${loc} [${f.rule}]`);
       }
       if (findings.length > MAX_SAMPLE_SEMGREP_PER_SEVERITY) {
@@ -172,7 +175,9 @@ function formatDeadExportsBlock(deadExports) {
       if (items.length === 0) continue;
       lines.push(`  - ${severity} (${items.length}):`);
       for (const item of items.slice(0, MAX_SAMPLE_KNIP_PER_SEVERITY)) {
-        lines.push(`    - ${item.path}${item.line ? `:${item.line}` : ""} [${item.rule}]${item.name ? ` \`${item.name}\`` : ""}`);
+        const lineSuffix = item.line ? `:${item.line}` : "";
+        const nameSuffix = item.name ? ` \`${item.name}\`` : "";
+        lines.push(`    - ${item.path}${lineSuffix} [${item.rule}]${nameSuffix}`);
       }
       if (items.length > MAX_SAMPLE_KNIP_PER_SEVERITY) {
         lines.push(`    - ... and ${items.length - MAX_SAMPLE_KNIP_PER_SEVERITY} more in ${severity}`);
@@ -246,7 +251,8 @@ function formatSonarBlock(sonarFindings) {
       if (issues.length === 0) continue;
       lines.push(`  - ${severity} (${issues.length}):`);
       for (const issue of issues.slice(0, MAX_SAMPLE_SONAR_PER_SEVERITY)) {
-        const loc = issue.component ? `${issue.component}${issue.line ? `:${issue.line}` : ""}` : "";
+        const lineSuffix = issue.line ? `:${issue.line}` : "";
+        const loc = issue.component ? `${issue.component}${lineSuffix}` : "";
         const rule = issue.rule ? ` [${issue.rule}]` : "";
         lines.push(`    - ${loc}${rule} ${issue.message || ""}`.trim());
       }

--- a/src/audit/semgrep-findings.js
+++ b/src/audit/semgrep-findings.js
@@ -72,6 +72,10 @@ export async function collectSemgrepFindings(projectDir, logger = null) {
   return { available: true, ...parseSemgrepOutput(parsed, projectDir) };
 }
 
+function relativizeSemgrepPath(p, projectDir) {
+  return p.startsWith(projectDir + "/") ? p.slice(projectDir.length + 1) : p;
+}
+
 /**
  * Convert semgrep's JSON shape into the flat findings list the prompt
  * builder consumes. Semgrep emits results[] with rule id, severity,
@@ -86,7 +90,7 @@ export function parseSemgrepOutput(raw, projectDir = "") {
   const findings = [];
   for (const r of results) {
     const file = r.path && projectDir
-      ? r.path.startsWith(projectDir + "/") ? r.path.slice(projectDir.length + 1) : r.path
+      ? relativizeSemgrepPath(r.path, projectDir)
       : r.path || "";
     findings.push({
       rule: r.check_id || "(unknown)",

--- a/src/brain/agent-error-classifier.js
+++ b/src/brain/agent-error-classifier.js
@@ -37,7 +37,14 @@ const SILENCED_PATTERNS = /killed\s+after\s+\d+\s*ms|silence\s*timeout|no\s+outp
 // ("You've hit your session limit · resets 10:10pm"). Without them the
 // message fell through to UNKNOWN_FATAL and the run aborted instead of
 // hibernating until the reset.
-const RATE_LIMIT_PATTERNS = /usage\s+limit|rate\s*limit|too\s+many\s+requests|\b429\b|throttl|exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached|monthly\s+limit|weekly\s+limit|daily\s+limit|session\s+limit/i;
+// Decomposed by family (S5843, complexity 36 → 3 named groups). The
+// union of tokens is identical to the original single alternation.
+const RATE_LIMIT_GROUPS = [
+  /rate\s*limit|too\s+many\s+requests|\b429\b|throttl/i,
+  /exceeded\s+your\s+current\s+quota|resource\s+exhausted|quota\s+exceeded|token\s+limit\s+reached/i,
+  /usage\s+limit|monthly\s+limit|weekly\s+limit|daily\s+limit|session\s+limit/i,
+];
+const RATE_LIMIT_PATTERNS = { test: (text) => RATE_LIMIT_GROUPS.some((re) => re.test(text)) };
 const API_DOWN_PATTERNS = /\b50[0-4]\b|bad\s+gateway|service\s+unavailable|gateway\s+timeout|overloaded|internal\s+server\s+error/i;
 const NETWORK_PATTERNS = /ECONNREFUSED|ECONNRESET|ETIMEDOUT|socket\s+hang\s+up|fetch\s+failed|network\s+error/i;
 

--- a/src/brain/decisor.js
+++ b/src/brain/decisor.js
@@ -179,8 +179,8 @@ export function buildDecision({ triage, task: _task, config = {}, overrides = {}
     solomonReason = "triage returned no level";
   }
 
-  const rolesOn = Array.from(roles).sort();
-  const rolesOff = Array.from(VALID_ROLES).filter((r) => !roles.has(r)).sort();
+  const rolesOn = Array.from(roles).sort((a, b) => a.localeCompare(b));
+  const rolesOff = Array.from(VALID_ROLES).filter((r) => !roles.has(r)).sort((a, b) => a.localeCompare(b));
 
   const rationale = buildRationale({ level, taskType, rolesOn, appliedOverrides, triage });
 

--- a/src/brain/solomon-consult.js
+++ b/src/brain/solomon-consult.js
@@ -161,8 +161,8 @@ export function applyRulingToDecision(decision, ruling, logger) {
 
   return {
     ...decision,
-    rolesOn: Array.from(rolesOn).sort(),
-    rolesOff: Array.from(rolesOff).sort(),
+    rolesOn: Array.from(rolesOn).sort((a, b) => a.localeCompare(b)),
+    rolesOff: Array.from(rolesOff).sort((a, b) => a.localeCompare(b)),
     appliedOverrides: [...decision.appliedOverrides, ...applied],
     confidence: applied.length > 0 ? "high" : decision.confidence,
     consultSolomon: false,

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -38,7 +38,8 @@ function promptContinueWithLlm({ promptFn = null } = {}) {
 function formatFindings(findings) {
   const lines = [];
   for (const f of findings) {
-    const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
+    const lineSuffix = f.line ? `:${f.line}` : "";
+    const loc = f.file ? `${f.file}${lineSuffix}` : "";
     const rule = f.rule ? ` [${f.rule}]` : "";
     lines.push(`  - [${f.severity.toUpperCase()}] ${loc}${rule}`);
     lines.push(`    ${f.description}`);
@@ -116,7 +117,8 @@ function formatAudit(parsed, usage = null) {
 function formatUsageSummary(usage) {
   if (!usage) return null;
   const lines = ["## LLM Usage"];
-  lines.push(`- Provider: ${usage.provider}${usage.model ? ` (${usage.model})` : ""}`);
+  const modelSuffix = usage.model ? ` (${usage.model})` : "";
+  lines.push(`- Provider: ${usage.provider}${modelSuffix}`);
   if (typeof usage.durationMs === "number") {
     lines.push(`- Duration: ${(usage.durationMs / 1000).toFixed(1)}s`);
   }

--- a/src/commands/standby.js
+++ b/src/commands/standby.js
@@ -49,7 +49,10 @@ export async function standbyListCommand({ json } = {}) {
     const ms = new Date(s.cooldownUntil).getTime() - now;
     const status = ms <= 0 ? "✓ lista para resume" : `⏳ resume en ${formatCountdown(ms)}`;
     console.log(`  ${s.sessionId}  · ${s.reason || "?"}  · ${status}`);
-    if (s.planId) console.log(`    plan: ${s.planId}${s.huId ? `, HU: ${s.huId}` : ""}`);
+    if (s.planId) {
+      const huSuffix = s.huId ? `, HU: ${s.huId}` : "";
+      console.log(`    plan: ${s.planId}${huSuffix}`);
+    }
   }
 }
 

--- a/src/orchestrator/fs-leak-detector.js
+++ b/src/orchestrator/fs-leak-detector.js
@@ -156,11 +156,16 @@ export function detectTranscriptCdLeaks(transcript, projectDir) {
   const projectDirAbs = projectDir ? path.resolve(projectDir) : null;
   const homeDir = os.homedir();
   // Capture cd target + the next ~200 chars of the same line for write-cmd lookup.
-  const cdRegex = /\bcd\s+(~\/[^\s&|;`'"\n]+|\$HOME\/[^\s&|;`'"\n]+|\/[^\s&|;`'"\n]+)([^\n]{0,200})/g;
+  // Two-step (S5843, complexity 31): capture ANY cd target with one simple
+  // class, then filter to the absolute/home-rooted shapes the original
+  // single alternation required (~/, $HOME/, /).
+  const cdRegex = /\bcd\s+([^\s&|;`'"\n]+)([^\n]{0,200})/g;
+  const absoluteTargetRe = /^(?:~\/|\$HOME\/|\/)/;
   const writeCmdRegex = /\b(mkdir|touch|cp|mv|git\s+init|(?:pnpm|npm|yarn)\s+(?:init|create)|npx\s+create|cat\s*>|echo\s+[^|]*>|>>?\s*\S)/i;
   const leaks = new Set();
   let match;
   while ((match = cdRegex.exec(transcript)) !== null) {
+    if (!absoluteTargetRe.test(match[1])) continue;
     const original = match[1];
     let target = original;
     const rest = match[2] || "";

--- a/src/orchestrator/solomon-rules.js
+++ b/src/orchestrator/solomon-rules.js
@@ -70,7 +70,18 @@ export function evaluateRules(context, rulesConfig = {}) {
     const styleKeywords = /\b(naming|name|rename|style|format|formatting|indent|spacing|camelCase|snake_case|convention|cosmetic|readability|comment|jsdoc|documentation|whitespace|semicolon|quotes|trailing)\b/i;
     // Anti-style: if any of these match, the issue is NOT style — it's a real correctness/security concern.
     // Fixes KJC-BUG-0026 (Solomon approving legitimate security blockers misclassified as "style").
-    const securityKeywords = /\b(sql\s*injection|xss|csrf|ssrf|rce|injection|vulnerab|exploit|sanitiz|escape\b|encod\b|cors|auth|authn|authz|password|secret|credential|token|api[-_\s]*key|private[-_\s]*key|hash|cipher|crypto|encrypt|decrypt|tls|ssl|certificate|leak|sensitive|pii|privacy|insecure|unsafe|race[-_\s]*condition|deadlock|memory[-_\s]*leak|null[-_\s]*deref|uaf|overflow|traversal|prototype[-_\s]*pollution|deserializ|eval\b|exec\b|spawn|shell|command[-_\s]*injection)\b/i;
+    // Decomposed by concern (S5843, complexity 71 → 7 named groups).
+    // The union of tokens is byte-identical to the original alternation.
+    const SECURITY_KEYWORD_GROUPS = [
+      /\b(sql\s*injection|xss|csrf|ssrf|rce|injection|vulnerab|exploit)\b/i,
+      /\b(sanitiz|escape\b|encod\b|cors|traversal|prototype[-_\s]*pollution|deserializ)\b/i,
+      /\b(auth|authn|authz|password|secret|credential|token|api[-_\s]*key|private[-_\s]*key)\b/i,
+      /\b(hash|cipher|crypto|encrypt|decrypt|tls|ssl|certificate)\b/i,
+      /\b(leak|sensitive|pii|privacy|insecure|unsafe)\b/i,
+      /\b(race[-_\s]*condition|deadlock|memory[-_\s]*leak|null[-_\s]*deref|uaf|overflow)\b/i,
+      /\b(eval\b|exec\b|spawn|shell|command[-_\s]*injection)\b/i,
+    ];
+    const securityKeywords = { test: (text) => SECURITY_KEYWORD_GROUPS.some((re) => re.test(text)) };
     const securityCategories = new Set(["security", "correctness", "bug", "vulnerability"]);
     const styleSeverities = new Set(["low", "minor"]);
     const blockingSeverities = new Set(["critical", "high", "blocker", "major"]);

--- a/src/prompts/audit.js
+++ b/src/prompts/audit.js
@@ -49,13 +49,10 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     const stackLines = ["## Project Stack"];
     if (stack.language) stackLines.push(`- Language: ${stack.language}`);
     if (stack.frameworks?.length) stackLines.push(`- Frameworks: ${stack.frameworks.join(", ")}`);
-    const tier = stack.isFullstack
-      ? "fullstack (frontend + backend)"
-      : stack.isFrontend
-        ? "frontend-only"
-        : stack.isBackend
-          ? "backend-only"
-          : "unknown";
+    let tier = "unknown";
+    if (stack.isFullstack) tier = "fullstack (frontend + backend)";
+    else if (stack.isFrontend) tier = "frontend-only";
+    else if (stack.isBackend) tier = "backend-only";
     stackLines.push(`- Tier: ${tier}`);
     if (stack.isFullstack) {
       stackLines.push("Apply BOTH backend heuristics (queries, sync I/O, caching) AND frontend heuristics (bundle size, lazy loading, render-blocking) where each layer applies.");
@@ -241,7 +238,8 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
         lines.push(`### ${severity} (${issues.length})`);
         const slice = issues.slice(0, Math.max(0, remaining));
         for (const issue of slice) {
-          const loc = issue.component ? `${issue.component}${issue.line ? `:${issue.line}` : ""}` : "";
+          const lineSuffix = issue.line ? `:${issue.line}` : "";
+          const loc = issue.component ? `${issue.component}${lineSuffix}` : "";
           const rule = issue.rule ? ` [${issue.rule}]` : "";
           lines.push(`  - ${loc}${rule} ${issue.message || ""}`.trim());
         }
@@ -332,8 +330,10 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
       lines.push(`### ${severity} (${findings.length})`);
       const slice = findings.slice(0, Math.max(0, remaining));
       for (const f of slice) {
-        const loc = f.file ? `${f.file}${f.line ? `:${f.line}` : ""}` : "";
-        const cwe = f.cwe ? ` (${Array.isArray(f.cwe) ? f.cwe.join(", ") : f.cwe})` : "";
+        const lineSuffix = f.line ? `:${f.line}` : "";
+        const loc = f.file ? `${f.file}${lineSuffix}` : "";
+        const cweText = Array.isArray(f.cwe) ? f.cwe.join(", ") : f.cwe;
+        const cwe = f.cwe ? ` (${cweText})` : "";
         lines.push(`  - ${loc} [${f.rule}]${cwe}: ${f.message || ""}`.trim());
       }
       if (findings.length > slice.length) {
@@ -355,7 +355,8 @@ export function buildAuditPrompt({ task, instructions, dimensions = null, contex
     lines.push(`- Unused files: ${(deadExports.files || []).length}`);
     const allItems = [...(deadExports.exports || []), ...(deadExports.files || [])].slice(0, 40);
     for (const item of allItems) {
-      const loc = `${item.path}${item.line ? `:${item.line}` : ""}`;
+      const lineSuffix = item.line ? `:${item.line}` : "";
+      const loc = `${item.path}${lineSuffix}`;
       const name = item.name ? ` \`${item.name}\`` : "";
       lines.push(`  - [${item.severity}] ${loc} [${item.rule}]${name}`);
     }

--- a/src/utils/cli-progress.js
+++ b/src/utils/cli-progress.js
@@ -157,8 +157,10 @@ export function createCliProgressReporter(opts = {}) {
   //   - `  "foo": 123`           propiedad numérica
   //   - `  "foo": {`             apertura de objeto en valor
   //   - `  },` / `  ],` / `  }` / `  ]`  cierre con o sin coma
-  const JSON_SCRAP_RE =
-    /^\s*(?:"[^"\\]*(?:\\.[^"\\]*)*"\s*:\s*.+|[}\]][,]?)\s*$/;
+  // Split in two named patterns (S5843): property line vs closer line.
+  const JSON_PROP_LINE_RE = /^\s*"[^"\\]*(?:\\.[^"\\]*)*"\s*:\s*.+$/;
+  const JSON_CLOSER_LINE_RE = /^\s*[}\]],?\s*$/;
+  const JSON_SCRAP_RE = { test: (l) => JSON_PROP_LINE_RE.test(l) || JSON_CLOSER_LINE_RE.test(l) };
   const onOutput = (event) => {
     if (!event || typeof event !== "object") return;
     const raw = typeof event.line === "string" ? event.line : "";


### PR DESCRIPTION
## Barrido del audit v3.4.0 sobre el quality gate

### CRITICALs (S2871) — 4 resueltos
`sort()` sin comparador en `brain/decisor.js` y `brain/solomon-consult.js` → `localeCompare` explícito.

### MAJOR S5843 — los 4 regex complejos descompuestos
- `solomon-rules` securityKeywords (c71) → 7 grupos nombrados por concern + `some()`; unión de tokens idéntica.
- `agent-error-classifier` RATE_LIMIT (c36) → 3 familias.
- `fs-leak-detector` cdRegex (c31) → captura simple + filtro de target absoluto en dos pasos.
- `cli-progress` JSON_SCRAP (c22) → patrón de propiedad + patrón de cierre.

### MAJOR S3358/S4624 — cluster citado por el audit
Ternarios anidados y templates anidados extraídos a variables nombradas/helpers en `prompts/audit.js`, `commands/audit.js`, `audit/deterministic-summary.js`, `commands/standby.js` y `audit/semgrep-findings.js`.

### Nota sobre el quality gate (hallazgo del scan fresco)
El gate NO se gobierna por estos MAJORs viejos: falla por condiciones de **new code** (`new_coverage` 65.4 % < 80, `new_violations` 224, hotspots sin revisar). Recuperarlo es un trabajo distinto (cobertura del código nuevo + revisión de hotspots) que queda documentado en la card — este PR reduce deuda real pero no voltea el gate por sí solo.

## Tests
545+ en suites afectadas (brain, fs-leak, cli-progress, audit, commands) — todas verdes.

## LOC
2 commits, neta ~+50.