### PR TITLE
perf: hu-board api.js — fs async en handlers + cache de planes (KJC-TSK-0539)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -4,6 +4,23 @@ import fsp from 'node:fs/promises';
 
 /** Async existence probe (KJC-TSK-0539 — no sync fs in handlers). */
 const pathExists = (p) => fsp.access(p).then(() => true, () => false);
+
+/**
+ * mtime-keyed cache for parsed plan JSON (KJC-TSK-0539). The plan scans
+ * used to re-read and re-parse every plan file on EVERY request; with N
+ * plans and the board polling, that was O(N) parses per poll. The cache
+ * serves the parsed object while the file's mtime is unchanged and
+ * re-reads transparently when kj writes the plan.
+ */
+const planFileCache = new Map();
+export async function readPlanCached(p) {
+  const { mtimeMs } = await fsp.stat(p);
+  const hit = planFileCache.get(p);
+  if (hit && hit.mtimeMs === mtimeMs) return hit.plan;
+  const plan = JSON.parse(await fsp.readFile(p, 'utf8'));
+  planFileCache.set(p, { mtimeMs, plan });
+  return plan;
+}
 import os from 'node:os';
 import path from 'node:path';
 import { spawn as spawnChild } from 'node:child_process';
@@ -214,7 +231,7 @@ router.get('/projects/:id/preflight', async (req, res) => {
         if (!(await pathExists(plansDir))) continue;
         for (const f of (await fsp.readdir(plansDir)).filter((x) => x.endsWith('.json'))) {
           try {
-            const plan = JSON.parse(await fsp.readFile(path.join(plansDir, f), 'utf8'));
+            const plan = await readPlanCached(path.join(plansDir, f));
             if (plan?.projectDir) { projectDir = plan.projectDir; break outer; }
           } catch { /* try next file */ }
         }
@@ -246,7 +263,7 @@ router.get('/projects/:id/plans-outcome', async (req, res) => {
       if (!(await pathExists(plansDir))) continue;
       for (const f of (await fsp.readdir(plansDir)).filter(n => n.endsWith('.json'))) {
         try {
-          const plan = JSON.parse(await fsp.readFile(path.join(plansDir, f), 'utf8'));
+          const plan = await readPlanCached(path.join(plansDir, f));
           if (plan?.version !== 2) continue;
           out.push({
           planId: plan.planId,

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1,5 +1,9 @@
 import { Router } from 'express';
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+
+/** Async existence probe (KJC-TSK-0539 — no sync fs in handlers). */
+const pathExists = (p) => fsp.access(p).then(() => true, () => false);
 import os from 'node:os';
 import path from 'node:path';
 import { spawn as spawnChild } from 'node:child_process';
@@ -74,10 +78,10 @@ function huStoriesDir() {
 /**
  * Best-effort removal of the hu-stories/<id>/ directory.
  */
-function removeBatchDir(batchId) {
+async function removeBatchDir(batchId) {
   try {
     const dir = path.join(huStoriesDir(), batchId);
-    fs.rmSync(dir, { recursive: true, force: true });
+    await fsp.rm(dir, { recursive: true, force: true });
     return true;
   } catch {
     return false;
@@ -207,10 +211,10 @@ router.get('/projects/:id/preflight', async (req, res) => {
     try {
       outer: for (const root of getHuBoardPlansDirs()) {
         const plansDir = path.join(root, projectId);
-        if (!fs.existsSync(plansDir)) continue;
-        for (const f of fs.readdirSync(plansDir).filter((x) => x.endsWith('.json'))) {
+        if (!(await pathExists(plansDir))) continue;
+        for (const f of (await fsp.readdir(plansDir)).filter((x) => x.endsWith('.json'))) {
           try {
-            const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
+            const plan = JSON.parse(await fsp.readFile(path.join(plansDir, f), 'utf8'));
             if (plan?.projectDir) { projectDir = plan.projectDir; break outer; }
           } catch { /* try next file */ }
         }
@@ -231,7 +235,7 @@ router.get('/projects/:id/preflight', async (req, res) => {
  * failed · 15 min" banner. Plans that haven't finished yet have a
  * null outcome — the front handles that by hiding the banner.
  */
-router.get('/projects/:id/plans-outcome', (req, res) => {
+router.get('/projects/:id/plans-outcome', async (req, res) => {
   try {
     const projectId = req.params.id;
     // KJC-BUG-0059 (v2.19.3): scan canonical + legacy roots so users
@@ -239,10 +243,10 @@ router.get('/projects/:id/plans-outcome', (req, res) => {
     const out = [];
     for (const root of getHuBoardPlansDirs()) {
       const plansDir = path.join(root, projectId);
-      if (!fs.existsSync(plansDir)) continue;
-      for (const f of fs.readdirSync(plansDir).filter(n => n.endsWith('.json'))) {
+      if (!(await pathExists(plansDir))) continue;
+      for (const f of (await fsp.readdir(plansDir)).filter(n => n.endsWith('.json'))) {
         try {
-          const plan = JSON.parse(fs.readFileSync(path.join(plansDir, f), 'utf8'));
+          const plan = JSON.parse(await fsp.readFile(path.join(plansDir, f), 'utf8'));
           if (plan?.version !== 2) continue;
           out.push({
           planId: plan.planId,
@@ -363,7 +367,7 @@ router.get('/sessions', (_req, res) => {
  * Also removes the hu-stories/<id>/ directory from disk so the next sync
  * does not re-import it.
  */
-router.delete('/projects/:id', (req, res) => {
+router.delete('/projects/:id', async (req, res) => {
   try {
     const id = req.params.id;
     // Gather filesystem paths to remove BEFORE deleting DB rows so we
@@ -397,7 +401,7 @@ router.delete('/projects/:id', (req, res) => {
     // Best-effort fs cleanup; failure does NOT undo the tombstones.
     let pathsRemoved = 0;
     for (const p of fsPaths) {
-      try { fs.rmSync(p, { recursive: true, force: true }); pathsRemoved++; } catch { /* */ }
+      try { await fsp.rm(p, { recursive: true, force: true }); pathsRemoved++; } catch { /* */ }
     }
     res.json({ deleted: true, pathsRemoved, tombstoned: 1 + storyIds.length + sessionIds.length });
   } catch (err) {
@@ -411,7 +415,7 @@ router.delete('/projects/:id', (req, res) => {
  * prompt id so a stale chokidar event can't recreate it, and emits a
  * `prompt:resolved` event so all open boards close the modal.
  */
-router.delete('/prompts/:promptId', (req, res) => {
+router.delete('/prompts/:promptId', async (req, res) => {
   try {
     const promptId = req.params.promptId;
     const dir = promptsDir();
@@ -419,7 +423,7 @@ router.delete('/prompts/:promptId', (req, res) => {
     const answer = path.join(dir, `${promptId}.answer.json`);
     let removed = 0;
     for (const p of [main, answer]) {
-      try { fs.unlinkSync(p); removed++; } catch { /* missing is fine */ }
+      try { await fsp.unlink(p); removed++; } catch { /* missing is fine */ }
     }
     addTombstone('prompt', promptId, { source: 'api', fsPaths: [main, answer] });
     // Re-use the same event the runner emits when answered, so any open
@@ -439,7 +443,7 @@ router.delete('/prompts/:promptId', (req, res) => {
  * it. Pre-tombstones this endpoint was a DB-only soft hide that the next
  * chokidar event undid silently.
  */
-router.delete('/stories/:id', (req, res) => {
+router.delete('/stories/:id', async (req, res) => {
   try {
     const id = req.params.id;
     const dir = path.join(huStoriesDir(), id);
@@ -447,7 +451,7 @@ router.delete('/stories/:id', (req, res) => {
     if (!ok) return res.status(404).json({ error: 'Story not found' });
     addTombstone('story', id, { source: 'api', fsPaths: [dir] });
     let dirRemoved = false;
-    try { fs.rmSync(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
+    try { await fsp.rm(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
     res.json({ deleted: true, dirRemoved });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -459,7 +463,7 @@ router.delete('/stories/:id', (req, res) => {
  *
  * Tombstones + removes `~/.karajan/sessions/<id>/` (KJC-TSK-0380).
  */
-router.delete('/sessions/:id', (req, res) => {
+router.delete('/sessions/:id', async (req, res) => {
   try {
     const id = req.params.id;
     const dir = path.join(getKjHome(), 'sessions', id);
@@ -467,7 +471,7 @@ router.delete('/sessions/:id', (req, res) => {
     if (!ok) return res.status(404).json({ error: 'Session not found' });
     addTombstone('session', id, { source: 'api', fsPaths: [dir] });
     let dirRemoved = false;
-    try { fs.rmSync(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
+    try { await fsp.rm(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
     res.json({ deleted: true, dirRemoved });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -482,7 +486,7 @@ router.delete('/sessions/:id', (req, res) => {
  * delete the project: a project can have multiple plans, deleting one
  * plan only removes that plan's HUs from the board.
  */
-router.delete('/plans/:planId', (req, res) => {
+router.delete('/plans/:planId', async (req, res) => {
   try {
     const planId = req.params.planId;
     // Locate the plan file by scanning both canonical and legacy plans
@@ -492,15 +496,15 @@ router.delete('/plans/:planId', (req, res) => {
     let foundPath = null;
     try {
       outer: for (const plansRoot of getHuBoardPlansDirs()) {
-        if (!fs.existsSync(plansRoot)) continue;
-        for (const projSlug of fs.readdirSync(plansRoot)) {
+        if (!(await pathExists(plansRoot))) continue;
+        for (const projSlug of await fsp.readdir(plansRoot)) {
           const candidate = path.join(plansRoot, projSlug, `plan-${planId}.json`);
-          if (fs.existsSync(candidate)) { foundPath = candidate; break outer; }
+          if (await pathExists(candidate)) { foundPath = candidate; break outer; }
         }
       }
     } catch { /* plansRoot missing */ }
     addTombstone('plan', planId, { source: 'api', fsPaths: foundPath ? [foundPath] : [] });
-    if (foundPath) { try { fs.unlinkSync(foundPath); } catch { /* */ } }
+    if (foundPath) { try { await fsp.unlink(foundPath); } catch { /* */ } }
     res.json({ deleted: true, fileRemoved: !!foundPath });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -770,11 +774,11 @@ function promptsDir() {
 // Solomon escalation; anything older is a crashed runner.
 const PROMPT_ZOMBIE_TTL_MS = 30 * 60 * 1000;
 
-router.get('/prompts', (_req, res) => {
+router.get('/prompts', async (_req, res) => {
   try {
     const dir = promptsDir();
-    if (!fs.existsSync(dir)) return res.json([]);
-    const entries = fs.readdirSync(dir);
+    if (!(await pathExists(dir))) return res.json([]);
+    const entries = await fsp.readdir(dir);
     const result = [];
     const now = Date.now();
     for (const name of entries) {
@@ -784,21 +788,21 @@ router.get('/prompts', (_req, res) => {
       const answerPath = path.join(dir, `${promptId}.answer.json`);
       // KJC-TSK-0380 — skip tombstoned prompts and clean their files.
       if (isTombstonedFn('prompt', promptId)) {
-        try { fs.unlinkSync(mainPath); } catch { /* */ }
-        try { fs.unlinkSync(answerPath); } catch { /* */ }
+        try { await fsp.unlink(mainPath); } catch { /* */ }
+        try { await fsp.unlink(answerPath); } catch { /* */ }
         continue;
       }
       let parsed;
       try {
-        parsed = JSON.parse(fs.readFileSync(mainPath, 'utf-8'));
+        parsed = JSON.parse(await fsp.readFile(mainPath, 'utf-8'));
       } catch { continue; /* malformed — skip */ }
       // KJC-BUG-0038: zombie detection. Prefer parsed.createdAt; fall back
       // to mtime if the runner skipped the timestamp (older formats).
       const createdMs = Date.parse(parsed?.createdAt || '');
-      const ageRef = Number.isFinite(createdMs) ? createdMs : safeMtime(mainPath);
+      const ageRef = Number.isFinite(createdMs) ? createdMs : await safeMtime(mainPath);
       if (ageRef && (now - ageRef) > PROMPT_ZOMBIE_TTL_MS) {
-        try { fs.unlinkSync(mainPath); } catch { /* */ }
-        try { fs.unlinkSync(answerPath); } catch { /* */ }
+        try { await fsp.unlink(mainPath); } catch { /* */ }
+        try { await fsp.unlink(answerPath); } catch { /* */ }
         addTombstone('prompt', promptId, { source: 'zombie-ttl', fsPaths: [mainPath, answerPath] });
         continue;
       }
@@ -811,8 +815,8 @@ router.get('/prompts', (_req, res) => {
   }
 });
 
-function safeMtime(p) {
-  try { return fs.statSync(p).mtimeMs; } catch { return 0; }
+async function safeMtime(p) {
+  try { return (await fsp.stat(p)).mtimeMs; } catch { return 0; }
 }
 
 /**
@@ -821,20 +825,20 @@ function safeMtime(p) {
  * it, deletes both files, and resolves askQuestion. An answer of
  * "stop" tells the runner to abort the session.
  */
-router.post('/prompts/:promptId/answer', (req, res) => {
+router.post('/prompts/:promptId/answer', async (req, res) => {
   try {
     const { answer } = req.body || {};
     if (typeof answer !== 'string') {
       return res.status(400).json({ error: 'Body must contain an "answer" string' });
     }
     const dir = promptsDir();
-    fs.mkdirSync(dir, { recursive: true });
+    await fsp.mkdir(dir, { recursive: true });
     const promptPath = path.join(dir, `${req.params.promptId}.json`);
-    if (!fs.existsSync(promptPath)) {
+    if (!(await pathExists(promptPath))) {
       return res.status(404).json({ error: `Prompt not found: ${req.params.promptId}` });
     }
     const answerPath = path.join(dir, `${req.params.promptId}.answer.json`);
-    fs.writeFileSync(
+    await fsp.writeFile(
       answerPath,
       JSON.stringify({ answer, answeredAt: new Date().toISOString() }, null, 2),
       'utf-8'
@@ -912,14 +916,14 @@ router.get('/events', (req, res) => {
  * Path is the same one that `runPlan` wrote to:
  *   ~/.karajan/hu-board-runs/<planId>.log (honours KJ_HOME in tests).
  */
-router.get('/plans/:planId/log', (req, res) => {
+router.get('/plans/:planId/log', async (req, res) => {
   try {
     const runsDir = getHuBoardRunsDir(); // KJC-TSK-0421
     const logPath = path.join(runsDir, `${req.params.planId}.log`);
-    if (!fs.existsSync(logPath)) {
+    if (!(await pathExists(logPath))) {
       return res.json({ exists: false, size: 0, content: '' });
     }
-    const stat = fs.statSync(logPath);
+    const stat = await fsp.stat(logPath);
     const offset = Math.max(0, Math.min(stat.size, Number(req.query.offset) || 0));
     // Cap per-request read to 1 MiB so a huge log can't blow up the
     // response. The client will keep polling and catch up.
@@ -927,13 +931,13 @@ router.get('/plans/:planId/log', (req, res) => {
     const length = Math.min(MAX_READ, stat.size - offset);
     let content = '';
     if (length > 0) {
-      const fd = fs.openSync(logPath, 'r');
+      const fh = await fsp.open(logPath, 'r');
       try {
         const buf = Buffer.alloc(length);
-        fs.readSync(fd, buf, 0, length, offset);
+        await fh.read(buf, 0, length, offset);
         content = buf.toString('utf-8');
       } finally {
-        fs.closeSync(fd);
+        await fh.close();
       }
     }
     res.json({ exists: true, size: stat.size, content });
@@ -1230,26 +1234,26 @@ router.post('/runs/:planId/stop', async (req, res) => {
   }
 });
 
-router.get('/runs/:commandId/log', (req, res) => {
+router.get('/runs/:commandId/log', async (req, res) => {
   try {
     const runsDir = getHuBoardRunsDir(); // KJC-TSK-0421
     const logPath = path.join(runsDir, `${req.params.commandId}.log`);
-    if (!fs.existsSync(logPath)) {
+    if (!(await pathExists(logPath))) {
       return res.json({ exists: false, size: 0, content: '' });
     }
-    const stat = fs.statSync(logPath);
+    const stat = await fsp.stat(logPath);
     const offset = Math.max(0, Math.min(stat.size, Number(req.query.offset) || 0));
     const MAX_READ = 1024 * 1024;
     const length = Math.min(MAX_READ, stat.size - offset);
     let content = '';
     if (length > 0) {
-      const fd = fs.openSync(logPath, 'r');
+      const fh = await fsp.open(logPath, 'r');
       try {
         const buf = Buffer.alloc(length);
-        fs.readSync(fd, buf, 0, length, offset);
+        await fh.read(buf, 0, length, offset);
         content = buf.toString('utf-8');
       } finally {
-        fs.closeSync(fd);
+        await fh.close();
       }
     }
     res.json({ exists: true, size: stat.size, content });

--- a/tests/board/plan-file-cache.test.js
+++ b/tests/board/plan-file-cache.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { readPlanCached } from "../../packages/hu-board/src/routes/api.js";
+
+// KJC-TSK-0539 — the plan scans must not re-parse unchanged files on
+// every request. readPlanCached serves the parsed object while the
+// file mtime is stable and re-reads transparently after a write.
+
+describe("hu-board readPlanCached", () => {
+  let tmpDir;
+  let planPath;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-plan-cache-"));
+    planPath = path.join(tmpDir, "plan-x.json");
+    await fs.writeFile(planPath, JSON.stringify({ planId: "x", version: 2, name: "one" }));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the same parsed object (cache hit) while mtime is unchanged", async () => {
+    const first = await readPlanCached(planPath);
+    const second = await readPlanCached(planPath);
+    expect(first.name).toBe("one");
+    expect(second).toBe(first);
+  });
+
+  it("re-reads when the file changes (mtime invalidation)", async () => {
+    const first = await readPlanCached(planPath);
+    expect(first.name).toBe("one");
+    // Force a different mtime even on coarse-grained filesystems.
+    await fs.writeFile(planPath, JSON.stringify({ planId: "x", version: 2, name: "two" }));
+    const future = new Date(Date.now() + 5000);
+    await fs.utimes(planPath, future, future);
+
+    const second = await readPlanCached(planPath);
+    expect(second.name).toBe("two");
+    expect(second).not.toBe(first);
+  });
+
+  it("propagates stat errors for missing files (no silent fallback)", async () => {
+    await expect(readPlanCached(path.join(tmpDir, "nope.json"))).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Recomendación 2 del audit v3.4.0

### Commit 1 — 0 fs síncrono en rutas
Las 30 llamadas `*Sync` de los handlers migran a `fs/promises` (handlers async, lectura de logs con `FileHandle`). El event loop del board deja de bloquearse bajo carga.

### Commit 2 — cache mtime de plan JSON
`readPlanCached()`: los dos escaneos de planes (projectDir discovery y `/plans-outcome`) re-leían y re-parseaban TODOS los planes en cada request/poll. Ahora sirven el objeto parseado mientras el mtime no cambie, releyendo transparente cuando `kj` escribe el plan.

## Tests
- 3 nuevos del cache (hit por identidad, invalidación por mtime, error propagado sin fallback).
- Suite del board completa: 64/64.

## LOC
+105/−51 (neta +54).