### PR TITLE
chore: release v3.4.1 — hardening post-Phase-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-06-12
+
+Hardening post-v3.4.0: los 3 bugs de observabilidad detectados durante la medición de Phase 1 + el top accionable del `kj audit` ejecutado con claude-fable-5.
+
+### Fixed
+
+- El session journal (summary.md con Cache hits, budget y commits) se escribe en TODOS los finales de run — sonar_repeat, stage error, throw — vía el writer único `session/journal/write-all.js` llamado desde el `finally` del flow-runner; antes solo el camino aprobado lo escribía y los runs fallidos perdían el post-mortem (KJC-BUG-0084, #1055).
+- El rol audit propaga `cached_tokens` al BudgetTracker, a la tabla Cache hits y al informe de `kj audit` (línea "Cached tokens"); era el rol más caro de la sesión y reportaba 0 (KJC-BUG-0085, #1054).
+- Preflight fail-fast `sonar-project-key`: cuando el remote git no es parseable y no hay `sonarqube.project_key`, el run aborta ANTES de la primera iteración con mensaje accionable en vez de quemar tokens y morir en `sonar_repeat`. Sonar sigue siendo obligatorio para tareas de código — contrato v2.7.4 intacto (KJC-BUG-0083, #1056).
+
+### Changed
+
+- `stripRuntimeOnlyKeys` sin `void _drop` — único CRITICAL S3735 del quality gate fuera (KJC-TSK-0535, #1053).
+- Util compartido `escapeRegExp()` aplicado en toda interpolación de variables en `new RegExp()` — cierra los hallazgos detect-non-literal-regexp de Semgrep (KJC-TSK-0536, #1057).
+- 23 dead exports podados (knip a 0) + `docs/audit-false-positives.md` documenta por qué las 6 deps raíz marcadas como "no usadas" son imprescindibles para el tarball npm (KJC-TSK-0537, #1058).
+- 4 CRITICALs S2871 (sorts sin comparador) + 4 regex S5843 descompuestos (c71/c36/c31/c22) + cluster de ternarios/templates anidados extraído (KJC-TSK-0538, #1059).
+- HU Board `api.js`: 0 llamadas fs síncronas en handlers (fs/promises + FileHandle) y cache mtime de plan JSON en los escaneos — el event loop deja de bloquearse y los polls no re-parsean todos los planes (KJC-TSK-0539, #1060).
+
+5 638 tests en 517 ficheros.
+
 ## [3.4.0] - 2026-06-11
 
 Cache propio cross-provider (epic KJC-PCS-0057 / Phase 1 closed). Los prompts de Karajan se reestructuran para maximizar el prompt-caching automático de cada provider: la medición real con Claude pasa de 47.2 % a 99.6 % de cache_pct en frío y el coste del coder cae un 76 %.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.4.0 released** — Cache-friendly prompts (epic KJC-PCS-0057 / Phase 1 closed). Every Karajan prompt is now split into a stable block (identical across iterations and HUs, rendered first so automatic prefix caching hits on it) and a volatile tail; on Claude the stable block ships via `--append-system-prompt` so the CLI's cache breakpoints serve it from cache on every call. Real data: cold-run cache_pct jumps **47.2% → 99.6%** and coder cost drops **76%** ($0.61 → $0.14 per HU). A prefix-stability regression suite freezes the contract in CI. Drop-in upgrade from v3.3.0. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.4.1 released** — Post-Phase-1 hardening. The session journal (Cache hits, budget, commits) is now written on EVERY run ending — not just approved ones; the audit role reports its cached tokens (it was the most expensive role and reported 0); and a new preflight check fails fast with an actionable message when Sonar cannot derive a project key, instead of burning coder iterations and dying in `sonar_repeat`. Plus the top of the v3.4.0 self-audit: shared `escapeRegExp()`, 23 dead exports pruned, 4 complex regexes decomposed, and the HU Board API with zero sync fs calls + mtime-cached plan scans. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (57k LOC, 454 files)
+├── src/              # Source code (57k LOC, 456 files)
 ├── tests/            # Test suite (511 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.4.0
+kj --version    # 3.4.1
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.4.0
+kj --version    # 3.4.1
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.4.1 (patch)

3 fixes de observabilidad detectados durante la medición Φ1-G + el top accionable del self-audit v3.4.0:

### Fixed
- Journal escrito en TODOS los finales de run (KJC-BUG-0084, #1055)
- Audit propaga cached_tokens (KJC-BUG-0085, #1054)
- Preflight fail-fast sonar-project-key (KJC-BUG-0083, #1056)

### Changed
- CRITICAL `void _drop` fuera (#1053) · `escapeRegExp()` compartido (#1057) · 23 dead exports podados + doc de falsos positivos (#1058) · 4 CRITICALs S2871 + 4 regex S5843 + cluster de ternarios (#1059) · api.js fs async + cache de planes (#1060)

5 638 tests / 517 ficheros. Sin breaking changes.