### PR TITLE
fix: @karajan/core deps a peerDependencies — hotfix install roto v3.4.1 (KJC-BUG-0086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.2] - 2026-06-13
+
+Hotfix: `npm install karajan-code@3.4.1` rompía en `kj --version`.
+
+### Fixed
+
+- **Install roto en 3.4.1 (Application Blocker)**: `@karajan/core/src/vec-store.js` importa `sqlite-vec`, que declara `files: []` en su package.json; al re-empaquetar `@karajan/core` vía `bundleDependencies` (fix de KJC-BUG-0082), npm arrastraba sqlite-vec respetando ese `files: []` y lo copiaba sin `index.mjs` → `ERR_MODULE_NOT_FOUND` en el arranque. Fix: las deps de runtime de `@karajan/core` (better-sqlite3, execa, sqlite-vec) pasan a `peerDependencies` — nunca se bundlean y resuelven desde el top-level del consumidor, completas y con el binario nativo correcto por plataforma. Las tres ya están declaradas en las dependencies raíz de karajan-code (KJC-BUG-0086). Test de regresión `tests/architecture/core-no-bundled-deps.test.js` lo congela.
+
 ## [3.4.1] - 2026-06-12
 
 Hardening post-v3.4.0: los 3 bugs de observabilidad detectados durante la medición de Phase 1 + el top accionable del `kj audit` ejecutado con claude-fable-5.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.4.1 released** — Post-Phase-1 hardening. The session journal (Cache hits, budget, commits) is now written on EVERY run ending — not just approved ones; the audit role reports its cached tokens (it was the most expensive role and reported 0); and a new preflight check fails fast with an actionable message when Sonar cannot derive a project key, instead of burning coder iterations and dying in `sonar_repeat`. Plus the top of the v3.4.0 self-audit: shared `escapeRegExp()`, 23 dead exports pruned, 4 complex regexes decomposed, and the HU Board API with zero sync fs calls + mtime-cached plan scans. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.4.2 released** — Hotfix: `npm install karajan-code@3.4.1` crashed at `kj --version` because the bundled `@karajan/core` dragged in `sqlite-vec` (which ships `files: []`) without its entry point. `@karajan/core`'s runtime deps are now `peerDependencies`, so they resolve complete from the consumer's top-level install. Clean install verified end-to-end. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.4.1
+kj --version    # 3.4.2
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.4.1
+kj --version    # 3.4.2
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "bundleDependencies": [
         "@karajan/core"
       ],
@@ -8095,16 +8095,27 @@
     "packages/core": {
       "name": "@karajan/core",
       "version": "0.1.0",
-      "dependencies": {
-        "better-sqlite3": "^12.10.0",
-        "execa": "^9.6.0",
-        "sqlite-vec": "^0.1.9"
-      },
       "devDependencies": {
         "vitest": "^4.0.0"
       },
       "engines": {
         "node": ">=22.22.1"
+      },
+      "peerDependencies": {
+        "better-sqlite3": "^12.10.0",
+        "execa": "^9.6.0",
+        "sqlite-vec": "^0.1.9"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "execa": {
+          "optional": true
+        },
+        "sqlite-vec": {
+          "optional": true
+        }
       }
     },
     "packages/hu-board": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,10 +27,15 @@
   "scripts": {
     "test": "vitest run"
   },
-  "dependencies": {
+  "peerDependencies": {
     "better-sqlite3": "^12.10.0",
     "execa": "^9.6.0",
     "sqlite-vec": "^0.1.9"
+  },
+  "peerDependenciesMeta": {
+    "better-sqlite3": { "optional": true },
+    "execa": { "optional": true },
+    "sqlite-vec": { "optional": true }
   },
   "devDependencies": {
     "vitest": "^4.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,9 +33,15 @@
     "sqlite-vec": "^0.1.9"
   },
   "peerDependenciesMeta": {
-    "better-sqlite3": { "optional": true },
-    "execa": { "optional": true },
-    "sqlite-vec": { "optional": true }
+    "better-sqlite3": {
+      "optional": true
+    },
+    "execa": {
+      "optional": true
+    },
+    "sqlite-vec": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "vitest": "^4.0.0"

--- a/tests/architecture/core-no-bundled-deps.test.js
+++ b/tests/architecture/core-no-bundled-deps.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Architecture regression guard — KJC-BUG-0086.
+ *
+ * @karajan/core ships INSIDE the karajan-code npm tarball via
+ * bundleDependencies. If core declares runtime `dependencies`, npm pack
+ * bundles them too — and a dep with a broken `files` field (sqlite-vec
+ * ships `files: []`) lands without its entry point, so `kj --version`
+ * crashes with ERR_MODULE_NOT_FOUND on every clean install.
+ *
+ * Contract: core's runtime deps that the host root already provides
+ * (better-sqlite3, execa, sqlite-vec) MUST be peerDependencies, never
+ * `dependencies`, so they resolve from the consumer's top-level
+ * node_modules (complete, and with the right native binary per platform).
+ *
+ * If you add a NEW runtime dep to @karajan/core, declare it as a
+ * peerDependency AND add it to the root karajan-code dependencies.
+ */
+describe("architecture/core-no-bundled-deps (KJC-BUG-0086)", () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+  const corePkg = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "packages/core/package.json"), "utf8"),
+  );
+  const rootPkg = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  );
+
+  it("@karajan/core declares NO runtime dependencies (would be bundled incompletely)", () => {
+    expect(corePkg.dependencies ?? {}).toEqual({});
+  });
+
+  it("every @karajan/core peerDependency is provided by the root karajan-code dependencies", () => {
+    const peers = Object.keys(corePkg.peerDependencies ?? {});
+    expect(peers.length).toBeGreaterThan(0);
+    for (const dep of peers) {
+      expect(rootPkg.dependencies?.[dep], `root must declare ${dep} so the bundled core can resolve it`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0086 — Application Blocker (hotfix v3.4.2)

`npm install karajan-code@3.4.1` crasheaba en `kj --version` con `ERR_MODULE_NOT_FOUND: sqlite-vec/index.mjs`.

### Causa raíz
`sqlite-vec` declara `files: []` en su package.json. Al re-empaquetar `@karajan/core` vía `bundleDependencies` (el fix de KJC-BUG-0082), npm arrastraba sqlite-vec como dep transitiva y respetaba ese `files: []`, copiándolo **sin index.mjs** (solo package.json + README). better-sqlite3 se bundleó OK en v3.4.0 (no tiene ese bug), por eso solo se detectó ahora que la cadena de `kj --version` carga `vec-store.js`.

### Fix
Las 3 deps de runtime de `@karajan/core` (better-sqlite3, execa, sqlite-vec) pasan a **peerDependencies (optional)**: las peerDeps nunca se bundlean, así que resuelven desde el top-level del consumidor — completas y con el binario nativo correcto por plataforma. Las tres ya están en las dependencies raíz de karajan-code.

### Verificado
- Tarball ya NO bundlea sqlite-vec; conserva `@karajan/core/src/vec-store.js`.
- Install limpio del tgz → `kj --version` = 3.4.2, sqlite-vec completo en top-level.
- tests board/rag/agents: 560/560.
- Test de regresión `tests/architecture/core-no-bundled-deps.test.js` prohíbe `dependencies` de runtime en core y exige que cada peerDep esté en la raíz.

## LOC
+79/−15 (test + package.json + docs de release).