### PR TITLE
ci: gate pre-publish — arranca el tarball real antes de subir (KJC-TSK-0553)

### DIFF
--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -1,0 +1,42 @@
+# Pack Smoke — installs the REAL published tarball and runs the binary.
+#
+# WHY: the test suite runs against the linked workspace, where
+# @karajan/core and its deps resolve via symlink. A broken PUBLISHED
+# artifact (bundleDependencies dragging in sqlite-vec without its entry
+# point — KJC-BUG-0082 / 0086) passed CI yet crashed on every clean
+# `npm install`. v3.2.0, v3.3.0 and v3.4.1 all shipped unable to run
+# even `kj --version`. This job packs the tarball, installs it clean and
+# isolated, and asserts the binary starts — catching packaging breakage
+# in the PR instead of after publish. Mirrors the `prepublishOnly` gate
+# so the same check that blocks a publish also blocks the merge.
+# Ref: KJC-TSK-0553.
+name: Pack Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pack-smoke:
+    name: Tarball installs & runs clean
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify the published tarball installs clean and runs
+        run: npm run verify-pack

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -197,6 +197,21 @@ export default [
     },
   },
   {
+    // Scripts block — build/release utilities run under Node directly
+    // (no bundler). Node globals + console allowed; unused-vars soft
+    // (destructuring-rest to drop a key leaves a named binding).
+    files: ["scripts/**/*.js", "scripts/**/*.mjs"],
+    languageOptions: {
+      ecmaVersion: 2024,
+      sourceType: "module",
+      globals: { ...globals.node },
+    },
+    rules: {
+      "no-console": "off",
+      "no-unused-vars": "warn",
+    },
+  },
+  {
     // Tests block — same bug-killer rules, plus vitest globals and
     // relaxed unused-vars (helpers + fixtures legitimately allocate
     // bindings whose value is only their existence).

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "typecheck": "npx -p typescript@5 tsc --noEmit -p tsconfig.json",
     "validate": "npm run lint && npm run lint:syntax && npm test",
     "mcp": "node src/mcp/server.js",
-    "audit:test-diet": "node scripts/audit-test-diet.mjs"
+    "audit:test-diet": "node scripts/audit-test-diet.mjs",
+    "verify-pack": "node scripts/verify-pack.mjs",
+    "prepublishOnly": "node scripts/verify-pack.mjs"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Pre-publish tarball smoke gate (KJC-TSK-0553).
+ *
+ * WHY: the test suite runs against the linked workspace, where
+ * `@karajan/core` and its deps resolve via symlink — so a broken
+ * PUBLISHED artifact (bundleDependencies dragging in sqlite-vec without
+ * its entry point, KJC-BUG-0082 / 0086) passed CI yet failed on every
+ * clean `npm install`. v3.2.0, v3.3.0 and v3.4.1 all shipped unable to
+ * run even `kj --version`.
+ *
+ * WHAT: pack the real tarball, install it into an isolated tmpdir
+ * (outside the repo, with CLAUDECODE stripped), and assert the binary
+ * actually starts and its native-ish deps resolve. Exit non-zero on any
+ * failure so `prepublishOnly` aborts the publish and CI blocks the PR.
+ *
+ * `npm pack` fires prepack/postpack, NOT prepublishOnly — so invoking
+ * this from prepublishOnly does not recurse.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+const expectedVersion = pkg.version;
+
+// Subprocess env: strip CLAUDECODE (Claude Code blocks nested non-interactive
+// runs otherwise) and force a non-interactive, quiet npm.
+const { CLAUDECODE: _omit, ...cleanEnv } = process.env;
+const childEnv = { ...cleanEnv, npm_config_yes: "true", CI: "1" };
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, {
+    encoding: "utf8",
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...opts,
+  });
+}
+
+function fail(msg, detail) {
+  console.error(`\n✗ verify-pack: ${msg}`);
+  if (detail) console.error(String(detail).split("\n").slice(0, 20).join("\n"));
+  process.exit(1);
+}
+
+let tgzPath = null;
+let tmpDir = null;
+try {
+  console.log(`verify-pack: packing karajan-code@${expectedVersion}…`);
+  // --json gives us the exact filename without parsing human output.
+  const packOut = run("npm", ["pack", "--json", "--silent"], { cwd: repoRoot });
+  const filename = JSON.parse(packOut)[0]?.filename;
+  if (!filename) fail("npm pack did not report a filename", packOut);
+  // npm normalizes scoped names in --json but karajan-code is unscoped;
+  // the file lands in cwd under the reported name.
+  tgzPath = path.join(repoRoot, filename);
+  if (!fs.existsSync(tgzPath)) fail(`packed tarball not found at ${tgzPath}`);
+
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verify-pack-"));
+  console.log(`verify-pack: installing the tarball into ${tmpDir} (clean, isolated)…`);
+  run("npm", ["install", tgzPath, "--no-audit", "--no-fund", "--silent", "--prefix", tmpDir], {
+    cwd: tmpDir,
+  });
+
+  const binPath = path.join(tmpDir, "node_modules", ".bin", "kj");
+  if (!fs.existsSync(binPath)) fail(`kj binary missing after install: ${binPath}`);
+
+  // 1. kj --version must start AND report the version we just packed.
+  let versionOut;
+  try {
+    versionOut = run(binPath, ["--version"]).trim();
+  } catch (err) {
+    fail("`kj --version` crashed on a clean install", err.stderr || err.message);
+  }
+  if (!versionOut.includes(expectedVersion)) {
+    fail(`kj --version returned "${versionOut}", expected ${expectedVersion}`);
+  }
+  console.log(`verify-pack: kj --version → ${versionOut} ✓`);
+
+  // 2. kj --help must exit 0 (exercises the command tree wiring).
+  try {
+    run(binPath, ["--help"]);
+  } catch (err) {
+    fail("`kj --help` failed on a clean install", err.stderr || err.message);
+  }
+  console.log("verify-pack: kj --help ✓");
+
+  // 3. The deps that broke before must resolve in the installed tree.
+  const installedRoot = path.join(tmpDir, "node_modules", "karajan-code");
+  const checks = [
+    path.join(tmpDir, "node_modules", "sqlite-vec", "index.mjs"),
+    path.join(installedRoot, "node_modules", "@karajan", "core", "src", "vec-store.js"),
+  ];
+  for (const p of checks) {
+    if (!fs.existsSync(p)) fail(`expected resolved path missing in install: ${p}`);
+  }
+  console.log("verify-pack: sqlite-vec + @karajan/core resolve ✓");
+
+  console.log(`\n✓ verify-pack: karajan-code@${expectedVersion} installs clean and runs.`);
+} finally {
+  if (tgzPath && fs.existsSync(tgzPath)) fs.rmSync(tgzPath, { force: true });
+  if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## El agujero que dejó salir 3.2.0/3.3.0/3.4.1 rotas

El CI prueba el **workspace linkado** (symlinks → todo resuelve). El **tarball publicado** (bundleDependencies, resolución top-level) nunca se instalaba ni se arrancaba. Por eso 3 versiones salieron sin pasar ni `kj --version`.

## Gate (2 capas)
1. **`prepublishOnly` → `scripts/verify-pack.mjs`** (gate duro): `npm pack` → install del tgz en tmpdir aislado sin CLAUDECODE → `kj --version` (debe coincidir con package.json) + `kj --help` (exit 0) + resolución de sqlite-vec/@karajan/core. Exit≠0 ⇒ **el publish se aborta**. Imposible subir un paquete que no arranca.
2. **Workflow `pack-smoke`** en cada PR/push a main: mismo verify-pack en runner limpio ⇒ se detecta en el PR, no al publicar.

Verificado local con 3.4.2: instala limpio y arranca ✓.

## LOC
+~115 (script + workflow + 2 líneas package.json + bloque eslint scripts/).