### PR TITLE
feat(harden): idempotent git-hook installer engine (H-B.2)

### DIFF
--- a/src/harden/harden-engine.js
+++ b/src/harden/harden-engine.js
@@ -1,0 +1,66 @@
+/**
+ * harden-engine — installs kj-managed git hooks idempotently (KJC-TSK-0555).
+ *
+ * Hooks live under `.karajan/hooks/` and are activated via `core.hooksPath`,
+ * so harden never fights husky/simple-git-hooks nor touches `.git/hooks/`.
+ * Each hook is a shebang + a kj:managed block; re-running is a no-op and any
+ * content outside the block is preserved.
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { runCommand } from "../utils/process.js";
+import { hookBody, PROFILE_HOOKS, SHEBANG } from "./hook-templates.js";
+
+const BLOCK_VERSION = 1;
+const HOOKS_DIR = join(".karajan", "hooks");
+const HOOK_PREAMBLE = `${SHEBANG}\nset -e\n`;
+
+export function isGitRepo(projectDir) {
+  return existsSync(join(projectDir, ".git"));
+}
+
+/**
+ * Install (or refresh) the profile's hooks under `.karajan/hooks/` and point
+ * `core.hooksPath` there. Idempotent. `dryRun` computes actions without
+ * touching disk or git config. `cmds` supplies stack-aware lint/format/test
+ * commands (npm-script defaults). Returns a per-hook action report.
+ */
+export async function installHooks({
+  projectDir = process.cwd(),
+  profile = "standard",
+  cmds = {},
+  dryRun = false,
+} = {}) {
+  if (!isGitRepo(projectDir)) throw new Error(`Not a git repository: ${projectDir}`);
+  const hooks = PROFILE_HOOKS[profile];
+  if (!hooks) throw new Error(`Unknown harden profile: ${profile}`);
+
+  const absHooksDir = join(projectDir, HOOKS_DIR);
+  const results = [];
+  for (const hook of hooks) {
+    const target = join(absHooksDir, hook);
+    const source = existsSync(target) ? readFileSync(target, "utf8") : HOOK_PREAMBLE;
+    const { content, action } = upsertManagedBlock({
+      source,
+      blockId: `hook:${hook}`,
+      version: BLOCK_VERSION,
+      body: hookBody(hook, cmds),
+      style: "hash",
+    });
+    results.push({ hook, target, action });
+    if (!dryRun && action !== "unchanged") {
+      mkdirSync(absHooksDir, { recursive: true });
+      writeFileSync(target, content);
+      chmodSync(target, 0o755);
+    }
+  }
+
+  if (!dryRun) {
+    await runCommand("git", ["config", "core.hooksPath", HOOKS_DIR], { cwd: projectDir });
+  }
+
+  return { profile, hooksPath: HOOKS_DIR, dryRun, hooks: results };
+}

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -1,0 +1,56 @@
+/**
+ * Hook bodies + profile→hooks mapping for `kj harden` (KJC-TSK-0555).
+ *
+ * A body is the MANAGED portion only; harden-engine adds the shebang and the
+ * kj:managed markers around it. POSIX sh. `cmds` carries stack-aware commands
+ * (npm-script defaults). See docs/specs/quality-harness.md §5 for profiles.
+ */
+
+export const SHEBANG = "#!/usr/bin/env sh";
+
+/** Hooks enabled per profile. */
+export const PROFILE_HOOKS = {
+  minimal: ["commit-msg"],
+  standard: ["pre-commit", "commit-msg", "pre-push", "post-merge"],
+  strict: ["pre-commit", "commit-msg", "pre-push", "post-merge"],
+};
+
+/** Build the managed body for a single hook. */
+export function hookBody(hook, cmds = {}) {
+  const lint = cmds.lint ?? "npm run -s lint";
+  const format = cmds.format ?? "npm run -s format:check";
+  const test = cmds.test ?? "npm test";
+  switch (hook) {
+    case "pre-commit":
+      return [
+        "# Lint + format the working tree before each commit.",
+        `${lint} || { echo 'kj harden: lint failed'; exit 1; }`,
+        `${format} || { echo 'kj harden: format check failed'; exit 1; }`,
+      ].join("\n");
+    case "commit-msg":
+      return [
+        "# Conventional Commits + block AI self-attribution.",
+        'msg_file="$1"',
+        "if command -v npx >/dev/null 2>&1; then",
+        "  npx --no-install commitlint --edit \"$msg_file\" || { echo 'kj harden: commitlint failed'; exit 1; }",
+        "fi",
+        "if grep -qiE 'co-authored-by:.*(claude|gpt|copilot|gemini)|(generated|written) (by|with) .*(claude|gpt|copilot)' \"$msg_file\"; then",
+        "  echo 'kj harden: AI attribution is not allowed in commit messages'; exit 1",
+        "fi",
+      ].join("\n");
+    case "pre-push":
+      return [
+        "# Run the test suite before pushing.",
+        `${test} || { echo 'kj harden: tests failed'; exit 1; }`,
+      ].join("\n");
+    case "post-merge":
+      return [
+        "# Refresh the local RAG index so retrieval never serves stale code.",
+        "if command -v kj >/dev/null 2>&1; then",
+        "  kj rag index --since auto >/dev/null 2>&1 || true",
+        "fi",
+      ].join("\n");
+    default:
+      throw new Error(`Unknown hook: ${hook}`);
+  }
+}

--- a/tests/harden/harden-engine.test.js
+++ b/tests/harden/harden-engine.test.js
@@ -1,0 +1,77 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installHooks } from "../../src/harden/harden-engine.js";
+
+let repo;
+
+function git(args) {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim();
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kj-harden-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("installHooks", () => {
+  it("installs the standard profile as executable managed hooks and sets hooksPath", async () => {
+    const res = await installHooks({ projectDir: repo, profile: "standard" });
+    expect(res.hooks.map((h) => h.hook).sort()).toEqual(["commit-msg", "post-merge", "pre-commit", "pre-push"]);
+    for (const { hook } of res.hooks) {
+      const f = join(repo, ".karajan", "hooks", hook);
+      expect(existsSync(f)).toBe(true);
+      expect(statSync(f).mode & 0o100).not.toBe(0);
+      const text = readFileSync(f, "utf8");
+      expect(text).toContain("#!/usr/bin/env sh");
+      expect(text).toContain(`>>> kj:managed:hook:${hook} v1 >>>`);
+    }
+    expect(git(["config", "--local", "core.hooksPath"])).toBe(join(".karajan", "hooks"));
+  });
+
+  it("minimal profile installs only commit-msg", async () => {
+    const res = await installHooks({ projectDir: repo, profile: "minimal" });
+    expect(res.hooks.map((h) => h.hook)).toEqual(["commit-msg"]);
+    expect(existsSync(join(repo, ".karajan", "hooks", "pre-push"))).toBe(false);
+  });
+
+  it("is idempotent: second run reports every hook unchanged with identical bytes", async () => {
+    await installHooks({ projectDir: repo, profile: "standard" });
+    const before = readFileSync(join(repo, ".karajan", "hooks", "commit-msg"), "utf8");
+    const res = await installHooks({ projectDir: repo, profile: "standard" });
+    expect(res.hooks.every((h) => h.action === "unchanged")).toBe(true);
+    expect(readFileSync(join(repo, ".karajan", "hooks", "commit-msg"), "utf8")).toBe(before);
+  });
+
+  it("preserves user content outside the managed block", async () => {
+    const dir = join(repo, ".karajan", "hooks");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "pre-push"), "#!/usr/bin/env sh\necho MY_CUSTOM_GUARD\n");
+    await installHooks({ projectDir: repo, profile: "standard" });
+    const text = readFileSync(join(dir, "pre-push"), "utf8");
+    expect(text).toContain("echo MY_CUSTOM_GUARD");
+    expect(text).toContain(">>> kj:managed:hook:pre-push v1 >>>");
+  });
+
+  it("dry-run touches neither disk nor git config", async () => {
+    const res = await installHooks({ projectDir: repo, profile: "standard", dryRun: true });
+    expect(res.dryRun).toBe(true);
+    expect(res.hooks.every((h) => h.action === "inserted")).toBe(true);
+    expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(false);
+    expect(() => git(["config", "--local", "core.hooksPath"])).toThrow();
+  });
+
+  it("rejects an unknown profile and a non-repo dir", async () => {
+    await expect(installHooks({ projectDir: repo, profile: "nope" })).rejects.toThrow(/profile/);
+    const plain = mkdtempSync(join(tmpdir(), "kj-plain-"));
+    await expect(installHooks({ projectDir: plain })).rejects.toThrow(/Not a git repository/);
+    rmSync(plain, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## H-B PR2 — KJC-TSK-0555 (épica KJC-PCS-0059)

Segunda mitad de H-B: el **motor** que instala los git hooks sobre la primitiva de managed-markers (PR1, #1066).

`src/harden/harden-engine.js` — `installHooks({projectDir, profile, cmds, dryRun})`:
- Escribe cada hook del perfil bajo `.karajan/hooks/` como `shebang + bloque kj:managed` y apunta `core.hooksPath` ahí → **no pelea con husky/simple-git-hooks ni toca `.git/hooks/`**.
- **Idempotente** (segunda ejecución → todo `unchanged`), **dry-run** (no toca disco ni config), preserva contenido del usuario fuera del bloque.
- `isGitRepo()` y validación de perfil/repo.

`src/harden/hook-templates.js` — bodies POSIX sh + mapa perfil→hooks:
- `minimal`: commit-msg (commitlint + anti-atribución-IA).
- `standard`/`strict`: pre-commit (lint+format), commit-msg, pre-push (tests), post-merge (reindex RAG).
- `cmds` stack-aware con defaults de npm-script (el comando `kj harden` de PR3 los resolverá vía stack-detect).

6 tests de integración sobre un repo git temporal real: instalación + ejecutable + markers, perfil minimal, idempotencia byte a byte, preservación de contenido de usuario, dry-run, rechazo de perfil/no-repo desconocidos.

PR3 (siguiente) añade el comando `kj harden` + registro CLI sobre este motor.

199 LOC netas (bajo el gate de 200).