### PR TITLE
feat(harden): kj harden command + CLI wiring (H-B.3)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -14,6 +14,7 @@ import { webperfCommand } from "../commands/webperf.js";
 import { undoCommand } from "../commands/undo.js";
 import { syncCommand } from "../commands/sync.js";
 import { cleanCommand } from "../commands/clean.js";
+import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { withConfig } from "./_shared.js";
 
@@ -394,6 +395,23 @@ export function registerMeta(program, { pkgVersion }) {
         draftDays: flags.draftDays ? Number(flags.draftDays) : undefined,
         sessionDays: flags.sessionDays ? Number(flags.sessionDays) : undefined,
         huDays: flags.huDays ? Number(flags.huDays) : undefined,
+      });
+    });
+
+  program
+    .command("harden")
+    .description("Install the quality harness (git hooks) into this repo — idempotent")
+    .option("--profile <name>", "minimal | standard | strict", "standard")
+    .option("--dry-run", "Show what would change without writing")
+    .option("--json", "Emit machine-readable JSON")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "harden", flags, async ({ logger }) => {
+        await hardenCommand({
+          profile: flags.profile,
+          dryRun: Boolean(flags.dryRun),
+          json: Boolean(flags.json),
+          logger,
+        });
       });
     });
 }

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -1,0 +1,71 @@
+/**
+ * `kj harden` — install the quality harness (git hooks) into any repo.
+ *
+ * Thin CLI layer over harden-engine (KJC-TSK-0555): resolves stack-aware
+ * lint/format/test commands, runs the installer and reports. Config files
+ * (eslint/prettier) and CI gates land in later slices (H-C / H-D).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { installHooks } from "../harden/harden-engine.js";
+import { detectTestFramework } from "../utils/project-detect.js";
+
+const TEST_CMD = {
+  vitest: "npx vitest run",
+  jest: "npx jest",
+  mocha: "npx mocha",
+  pytest: "pytest",
+};
+
+/** Pick lint/format/test commands from package.json scripts, then by framework. */
+export async function resolveCmds(projectDir) {
+  const cmds = {};
+  const pkgPath = join(projectDir, "package.json");
+  if (existsSync(pkgPath)) {
+    try {
+      const scripts = JSON.parse(readFileSync(pkgPath, "utf8")).scripts ?? {};
+      if (scripts.lint) cmds.lint = "npm run -s lint";
+      if (scripts["format:check"]) cmds.format = "npm run -s format:check";
+      else if (scripts.format) cmds.format = "npm run -s format";
+      if (scripts.test) cmds.test = "npm test";
+    } catch {
+      /* unreadable package.json → fall back to framework detection */
+    }
+  }
+  if (!cmds.test) {
+    const { framework } = await detectTestFramework(projectDir);
+    if (framework && TEST_CMD[framework]) cmds.test = TEST_CMD[framework];
+  }
+  return cmds;
+}
+
+export async function hardenCommand({
+  projectDir = process.cwd(),
+  profile = "standard",
+  dryRun = false,
+  json = false,
+  logger = console,
+} = {}) {
+  const cmds = await resolveCmds(projectDir);
+  let result;
+  try {
+    result = await installHooks({ projectDir, profile, cmds, dryRun });
+  } catch (err) {
+    if (json) logger.info?.(JSON.stringify({ ok: false, error: err.message }));
+    else logger.error?.(`kj harden: ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+
+  if (json) {
+    logger.info?.(JSON.stringify({ ok: true, ...result }));
+    return { ok: true, ...result };
+  }
+
+  const verb = dryRun ? "would install" : "installed";
+  logger.info?.(`kj harden (${profile}) — ${verb} ${result.hooks.length} hook(s) → ${result.hooksPath}`);
+  for (const h of result.hooks) logger.info?.(`  • ${h.hook}: ${h.action}`);
+  if (!dryRun) logger.info?.("core.hooksPath set. Verify later with `kj check` (H-E).");
+  return { ok: true, ...result };
+}

--- a/tests/commands/harden.test.js
+++ b/tests/commands/harden.test.js
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hardenCommand, resolveCmds } from "../../src/commands/harden.js";
+
+let repo;
+const logger = { info: vi.fn(), error: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repo = mkdtempSync(join(tmpdir(), "kj-harden-cmd-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("resolveCmds", () => {
+  it("derives commands from package.json scripts", async () => {
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({ scripts: { lint: "eslint .", "format:check": "prettier -c .", test: "vitest run" } })
+    );
+    expect(await resolveCmds(repo)).toEqual({
+      lint: "npm run -s lint",
+      format: "npm run -s format:check",
+      test: "npm test",
+    });
+  });
+
+  it("falls back to framework detection when no test script", async () => {
+    writeFileSync(join(repo, "package.json"), JSON.stringify({ devDependencies: { vitest: "^4" } }));
+    expect((await resolveCmds(repo)).test).toBe("npx vitest run");
+  });
+});
+
+describe("hardenCommand", () => {
+  it("installs hooks and reports ok", async () => {
+    const res = await hardenCommand({ projectDir: repo, profile: "standard", logger });
+    expect(res.ok).toBe(true);
+    expect(res.hooks).toHaveLength(4);
+    expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(true);
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it("dry-run writes nothing and emits JSON when asked", async () => {
+    const res = await hardenCommand({ projectDir: repo, profile: "minimal", dryRun: true, json: true, logger });
+    expect(res.ok).toBe(true);
+    expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(false);
+    const payload = JSON.parse(logger.info.mock.calls.at(-1)[0]);
+    expect(payload).toMatchObject({ ok: true, profile: "minimal", dryRun: true });
+  });
+
+  it("returns ok:false on a non-repo dir without throwing", async () => {
+    const plain = mkdtempSync(join(tmpdir(), "kj-plain-"));
+    const res = await hardenCommand({ projectDir: plain, logger });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/Not a git repository/);
+    rmSync(plain, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## H-B PR3 — KJC-TSK-0555 (épica KJC-PCS-0059)

Cierra H-B: el comando `kj harden` sobre el motor (PR2, #1067) y la primitiva de markers (PR1, #1066).

`src/commands/harden.js`:
- `resolveCmds(projectDir)` — deriva lint/format/test de los `scripts` de package.json y, si no hay test script, del framework detectado (`detectTestFramework` → vitest/jest/mocha/pytest).
- `hardenCommand({profile, dryRun, json, logger})` — corre `installHooks` y reporta (humano o `--json`); **no lanza** en un dir no-repo (devuelve `ok:false`).

`src/cli/register-meta.js`: registra `kj harden --profile <minimal|standard|strict> --dry-run --json`.

`kj harden --help` verificado. 5 tests: resolución de comandos (scripts + fallback framework), instalación, dry-run JSON, no-repo sin throw.

Con esto **H-B queda completa**: managed-markers + motor + CLI. Las siguientes piezas son H-C (config eslint/prettier/commitlint) y H-D (templates de CI).

154 LOC netas.