### PR TITLE
feat(harden): seed editorconfig/prettier/commitlint config (H-C.1)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -402,12 +402,14 @@ export function registerMeta(program, { pkgVersion }) {
     .command("harden")
     .description("Install the quality harness (git hooks) into this repo — idempotent")
     .option("--profile <name>", "minimal | standard | strict", "standard")
+    .option("--no-config", "Skip lint/format/commit config files (hooks only)")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
     .action(async (flags) => {
       await withConfig(pkgVersion, "harden", flags, async ({ logger }) => {
         await hardenCommand({
           profile: flags.profile,
+          config: flags.config !== false,
           dryRun: Boolean(flags.dryRun),
           json: Boolean(flags.json),
           logger,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { installConfigs } from "../harden/config-engine.js";
 import { installHooks } from "../harden/harden-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
 
@@ -44,6 +45,7 @@ export async function resolveCmds(projectDir) {
 export async function hardenCommand({
   projectDir = process.cwd(),
   profile = "standard",
+  config = true,
   dryRun = false,
   json = false,
   logger = console,
@@ -58,14 +60,20 @@ export async function hardenCommand({
     return { ok: false, error: err.message };
   }
 
+  // Config (eslint/prettier/commitlint/.editorconfig) ships with standard+.
+  const withConfig = config && profile !== "minimal";
+  const cfg = withConfig ? installConfigs({ projectDir, dryRun }) : null;
+  const out = { ok: true, ...result, configs: cfg?.configs ?? [] };
+
   if (json) {
-    logger.info?.(JSON.stringify({ ok: true, ...result }));
-    return { ok: true, ...result };
+    logger.info?.(JSON.stringify(out));
+    return out;
   }
 
   const verb = dryRun ? "would install" : "installed";
   logger.info?.(`kj harden (${profile}) — ${verb} ${result.hooks.length} hook(s) → ${result.hooksPath}`);
   for (const h of result.hooks) logger.info?.(`  • ${h.hook}: ${h.action}`);
+  for (const c of out.configs) logger.info?.(`  • ${c.file}: ${c.action}`);
   if (!dryRun) logger.info?.("core.hooksPath set. Verify later with `kj check` (H-E).");
-  return { ok: true, ...result };
+  return out;
 }

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -1,0 +1,54 @@
+/**
+ * config-engine — seeds/refreshes lint/format/commit config for `kj harden`
+ * (KJC-TSK-0556). Seed-if-absent: a config the user already authored (no
+ * kj:managed marker) is left untouched and reported as "skipped". Markered
+ * files refresh in place; JSON files (no comment syntax) are seed-only.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { JS_CONFIGS } from "./config-templates.js";
+
+const BLOCK_VERSION = 1;
+
+function writeFile(target, content) {
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+/**
+ * Install config files for the detected stack (JS/TS for now). Returns a
+ * per-file action report. `dryRun` computes actions without touching disk.
+ */
+export function installConfigs({ projectDir = process.cwd(), dryRun = false } = {}) {
+  const results = [];
+  for (const cfg of JS_CONFIGS) {
+    const target = join(projectDir, cfg.file);
+    const exists = existsSync(target);
+
+    if (cfg.json) {
+      const action = exists ? "skipped" : "inserted";
+      if (!dryRun && !exists) writeFile(target, `${cfg.body}\n`);
+      results.push({ file: cfg.file, action });
+      continue;
+    }
+
+    const source = exists ? readFileSync(target, "utf8") : "";
+    if (exists && !source.includes(`kj:managed:${cfg.blockId}`)) {
+      results.push({ file: cfg.file, action: "skipped" });
+      continue;
+    }
+    const { content, action } = upsertManagedBlock({
+      source,
+      blockId: cfg.blockId,
+      version: BLOCK_VERSION,
+      body: cfg.body,
+      style: cfg.style,
+    });
+    if (!dryRun && action !== "unchanged") writeFile(target, content);
+    results.push({ file: cfg.file, action });
+  }
+  return { dryRun, configs: results };
+}

--- a/src/harden/config-templates.js
+++ b/src/harden/config-templates.js
@@ -1,0 +1,45 @@
+/**
+ * Config-file templates for `kj harden` (KJC-TSK-0556).
+ *
+ * Each entry is seeded only when absent (project rule: never overwrite an
+ * existing file); on re-run a kj:managed block is refreshed in place. JSON
+ * formats carry no comment syntax, so they are seed-only (no marker).
+ *
+ * The eslint ES2025 deprecated-API blacklist lands in a follow-up slice.
+ */
+
+export const EDITORCONFIG_BODY = [
+  "root = true",
+  "",
+  "[*]",
+  "charset = utf-8",
+  "end_of_line = lf",
+  "insert_final_newline = true",
+  "trim_trailing_whitespace = true",
+  "indent_style = space",
+  "indent_size = 2",
+].join("\n");
+
+export const PRETTIER_BODY = JSON.stringify(
+  { printWidth: 110, singleQuote: false, trailingComma: "es5", semi: true },
+  null,
+  2
+);
+
+export const COMMITLINT_BODY = [
+  "// Conventional Commits — header <=100 chars, lowercase subject.",
+  "export default {",
+  '  extends: ["@commitlint/config-conventional"],',
+  "  rules: {",
+  '    "header-max-length": [2, "always", 100],',
+  '    "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],',
+  "  },",
+  "};",
+].join("\n");
+
+/** JS/TS config files harden manages. `json:true` ⇒ seed-only (no marker). */
+export const JS_CONFIGS = [
+  { file: ".editorconfig", blockId: "editorconfig", style: "hash", body: EDITORCONFIG_BODY },
+  { file: "commitlint.config.js", blockId: "commitlint", style: "slash", body: COMMITLINT_BODY },
+  { file: ".prettierrc.json", json: true, body: PRETTIER_BODY },
+];

--- a/tests/harden/config-engine.test.js
+++ b/tests/harden/config-engine.test.js
@@ -1,0 +1,60 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installConfigs } from "../../src/harden/config-engine.js";
+
+let dir;
+const read = (f) => readFileSync(join(dir, f), "utf8");
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kj-cfg-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("installConfigs", () => {
+  it("seeds editorconfig (markered), commitlint (markered) and prettier (json)", () => {
+    const res = installConfigs({ projectDir: dir });
+    expect(res.configs.every((c) => c.action === "inserted")).toBe(true);
+
+    const ec = read(".editorconfig");
+    expect(ec).toContain(">>> kj:managed:editorconfig v1 >>>");
+    expect(ec).toContain("root = true");
+
+    expect(read("commitlint.config.js")).toContain("config-conventional");
+    expect(JSON.parse(read(".prettierrc.json"))).toMatchObject({ printWidth: 110 });
+  });
+
+  it("is idempotent on the markered files", () => {
+    installConfigs({ projectDir: dir });
+    const res = installConfigs({ projectDir: dir });
+    const ec = res.configs.find((c) => c.file === ".editorconfig");
+    expect(ec.action).toBe("unchanged");
+  });
+
+  it("never overwrites a user-authored config without our marker", () => {
+    writeFileSync(join(dir, ".editorconfig"), "root = true\n[*]\nindent_size = 4\n");
+    const res = installConfigs({ projectDir: dir });
+    expect(res.configs.find((c) => c.file === ".editorconfig").action).toBe("skipped");
+    expect(read(".editorconfig")).toContain("indent_size = 4");
+    expect(read(".editorconfig")).not.toContain("kj:managed");
+  });
+
+  it("leaves a pre-existing prettier json untouched (seed-only)", () => {
+    writeFileSync(join(dir, ".prettierrc.json"), '{"printWidth":80}');
+    const res = installConfigs({ projectDir: dir });
+    expect(res.configs.find((c) => c.file === ".prettierrc.json").action).toBe("skipped");
+    expect(JSON.parse(read(".prettierrc.json")).printWidth).toBe(80);
+  });
+
+  it("dry-run writes nothing", () => {
+    const res = installConfigs({ projectDir: dir, dryRun: true });
+    expect(res.dryRun).toBe(true);
+    expect(existsSync(join(dir, ".editorconfig"))).toBe(false);
+    expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## H-C PR1 — KJC-TSK-0556 (épica KJC-PCS-0059)

`kj harden` ahora siembra config de calidad además de los hooks (H-B).

`src/harden/config-engine.js` + `config-templates.js`:
- **`.editorconfig`** (markered, `#`) y **`commitlint.config.js`** (markered, `//` — header ≤100 + subject-case, pareja del hook commit-msg de H-B) → bloque `kj:managed` refrescable.
- **`.prettierrc.json`** (JSON puro, sin comentarios → seed-only).
- **Seed-if-absent** (regla del usuario "nunca sobrescribir"): un config que el usuario ya escribió sin marker `kj:managed` se deja intacto y se reporta `skipped`.
- Activo en perfiles standard/strict; `--no-config` para solo-hooks.

5 tests: seed markered+json, idempotencia, no-overwrite de config de usuario, prettier json preexistente intacto, dry-run.

**Siguiente (PR2)**: blacklist eslint ES2025 (document.write/alert/escape/substr/var…) con test que verifica que marca `document.write`. **PR3**: variantes Python/Go.

169 LOC netas.