### PR TITLE
feat(harden): seed eslint config banning deprecated ES2025 APIs (H-C.2)

### DIFF
--- a/src/harden/config-templates.js
+++ b/src/harden/config-templates.js
@@ -37,9 +37,42 @@ export const COMMITLINT_BODY = [
   "};",
 ].join("\n");
 
+// Self-contained flat config (no plugin deps) banning APIs deprecated under
+// an ES2025 target — mirrors the Karajan standard. Seeded only when the
+// project has no eslint config of its own.
+export const ESLINT_BODY = [
+  "export default [",
+  "  {",
+  '    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],',
+  '    languageOptions: { ecmaVersion: 2025, sourceType: "module" },',
+  "    rules: {",
+  '      "no-var": "error",',
+  '      "no-eval": "error",',
+  '      "no-new-func": "error",',
+  '      "no-restricted-globals": [',
+  '        "error",',
+  '        { name: "alert", message: "Use the app modal, not alert()." },',
+  '        { name: "confirm", message: "Use the app modal, not confirm()." },',
+  '        { name: "prompt", message: "Use the app modal, not prompt()." },',
+  '        { name: "escape", message: "Use encodeURIComponent()." },',
+  '        { name: "unescape", message: "Use decodeURIComponent()." },',
+  '        { name: "event", message: "Use the handler parameter, not window.event." },',
+  "      ],",
+  '      "no-restricted-properties": [',
+  '        "error",',
+  '        { object: "document", property: "write", message: "Use DOM nodes / Blob URLs, not document.write." },',
+  '        { object: "document", property: "writeln", message: "Use DOM nodes, not document.writeln." },',
+  '        { property: "substr", message: "Use slice() or substring(), not substr()." },',
+  "      ],",
+  "    },",
+  "  },",
+  "];",
+].join("\n");
+
 /** JS/TS config files harden manages. `json:true` ⇒ seed-only (no marker). */
 export const JS_CONFIGS = [
   { file: ".editorconfig", blockId: "editorconfig", style: "hash", body: EDITORCONFIG_BODY },
   { file: "commitlint.config.js", blockId: "commitlint", style: "slash", body: COMMITLINT_BODY },
+  { file: "eslint.config.js", blockId: "eslint", style: "slash", body: ESLINT_BODY },
   { file: ".prettierrc.json", json: true, body: PRETTIER_BODY },
 ];

--- a/tests/harden/eslint-es2025.test.js
+++ b/tests/harden/eslint-es2025.test.js
@@ -1,0 +1,45 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ESLint } from "eslint";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installConfigs } from "../../src/harden/config-engine.js";
+
+let dir;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kj-eslint-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function lint(code) {
+  installConfigs({ projectDir: dir });
+  const eslint = new ESLint({ overrideConfigFile: join(dir, "eslint.config.js"), cwd: dir });
+  const [result] = await eslint.lintText(code, { filePath: join(dir, "sample.js") });
+  return result;
+}
+
+describe("seeded eslint.config.js (ES2025 deprecated-API blacklist)", () => {
+  it("is seeded with a managed marker", () => {
+    installConfigs({ projectDir: dir });
+    expect(readFileSync(join(dir, "eslint.config.js"), "utf8")).toContain(">>> kj:managed:eslint v1 >>>");
+  });
+
+  it("flags document.write, escape, substr and var", async () => {
+    const result = await lint("document.write('x'); var y = escape('z'); 'a'.substr(1);");
+    const rules = result.messages.map((m) => m.ruleId);
+    expect(rules).toContain("no-restricted-properties"); // document.write + substr
+    expect(rules).toContain("no-restricted-globals"); // escape
+    expect(rules).toContain("no-var");
+    expect(result.errorCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("passes clean modern code with zero errors", async () => {
+    const result = await lint("const url = encodeURIComponent('z');\ndocument.body.append(url);\n");
+    expect(result.errorCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## H-C PR2 — KJC-TSK-0556 (épica KJC-PCS-0059)

`kj harden` ahora genera también un `eslint.config.js` autónomo (sin dependencias de plugins) que prohíbe las APIs obsoletas bajo un objetivo ES2025, reflejando el estándar Karajan:

- `var`, `eval`, `new Function`
- `alert` / `confirm` / `prompt` → modales de la app
- `escape` / `unescape` → `encodeURIComponent` / `decodeURIComponent`
- `window.event` → parámetro del manejador
- `document.write` / `document.writeln` → nodos del DOM / Blob URLs
- `String.prototype.substr` → `slice` / `substring`

Se genera solo si el proyecto no tiene ya configuración de eslint (regla de no sobrescribir). Bloque `kj:managed` refrescable.

**Prueba de comportamiento**: carga la configuración generada a través de la API de ESLint y confirma que marca `document.write`, `escape`, `substr` y `var`, y que deja pasar código moderno limpio con cero errores.

Falta **PR3** para cerrar H-C: variantes de otros lenguajes (Python ruff/black, Go golangci-lint).

78 LOC netas.