### PR TITLE
feat(harden): stack-aware config for python and go (H-C.3)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { installConfigs } from "../harden/config-engine.js";
 import { installHooks } from "../harden/harden-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
+import { detectProjectStack } from "../utils/stack-detect.js";
 
 const TEST_CMD = {
   vitest: "npx vitest run",
@@ -60,9 +61,10 @@ export async function hardenCommand({
     return { ok: false, error: err.message };
   }
 
-  // Config (eslint/prettier/commitlint/.editorconfig) ships with standard+.
+  // Config (lint/format/commit) ships with standard+, adapted to the stack.
   const withConfig = config && profile !== "minimal";
-  const cfg = withConfig ? installConfigs({ projectDir, dryRun }) : null;
+  const { language } = withConfig ? await detectProjectStack(projectDir) : {};
+  const cfg = withConfig ? installConfigs({ projectDir, language, dryRun }) : null;
   const out = { ok: true, ...result, configs: cfg?.configs ?? [] };
 
   if (json) {

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -9,7 +9,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
-import { JS_CONFIGS } from "./config-templates.js";
+import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 
 const BLOCK_VERSION = 1;
 
@@ -19,12 +19,15 @@ function writeFile(target, content) {
 }
 
 /**
- * Install config files for the detected stack (JS/TS for now). Returns a
- * per-file action report. `dryRun` computes actions without touching disk.
+ * Install config files for the detected stack: universal (.editorconfig,
+ * commitlint) plus language-specific lint/format (JS/TS, Python, Go). An
+ * unknown language gets the universal set only — no JS tooling is imposed.
+ * Returns a per-file action report. `dryRun` computes actions without writing.
  */
-export function installConfigs({ projectDir = process.cwd(), dryRun = false } = {}) {
+export function installConfigs({ projectDir = process.cwd(), language = "javascript", dryRun = false } = {}) {
+  const configs = [...UNIVERSAL_CONFIGS, ...(CONFIGS_BY_LANGUAGE[language] ?? [])];
   const results = [];
-  for (const cfg of JS_CONFIGS) {
+  for (const cfg of configs) {
     const target = join(projectDir, cfg.file);
     const exists = existsSync(target);
 

--- a/src/harden/config-templates.js
+++ b/src/harden/config-templates.js
@@ -69,10 +69,44 @@ export const ESLINT_BODY = [
   "];",
 ].join("\n");
 
-/** JS/TS config files harden manages. `json:true` ⇒ seed-only (no marker). */
-export const JS_CONFIGS = [
+// Ruff covers lint + format for Python; `UP` (pyupgrade) is the analogue of
+// the ES2025 deprecated-API ban — it rewrites legacy idioms to modern Python.
+export const RUFF_BODY = [
+  "line-length = 110",
+  'target-version = "py312"',
+  "",
+  "[lint]",
+  'select = ["E", "F", "I", "UP", "B", "SIM"]',
+].join("\n");
+
+export const GOLANGCI_BODY = [
+  "linters:",
+  "  enable:",
+  "    - govet",
+  "    - staticcheck",
+  "    - revive",
+  "    - ineffassign",
+  "    - gofmt",
+].join("\n");
+
+/** Language-agnostic configs (every stack gets these). */
+export const UNIVERSAL_CONFIGS = [
   { file: ".editorconfig", blockId: "editorconfig", style: "hash", body: EDITORCONFIG_BODY },
   { file: "commitlint.config.js", blockId: "commitlint", style: "slash", body: COMMITLINT_BODY },
+];
+
+/** `json:true` ⇒ seed-only (no comment syntax for a marker). */
+export const JS_CONFIGS = [
   { file: "eslint.config.js", blockId: "eslint", style: "slash", body: ESLINT_BODY },
   { file: ".prettierrc.json", json: true, body: PRETTIER_BODY },
 ];
+export const PY_CONFIGS = [{ file: "ruff.toml", blockId: "ruff", style: "hash", body: RUFF_BODY }];
+export const GO_CONFIGS = [{ file: ".golangci.yml", blockId: "golangci", style: "hash", body: GOLANGCI_BODY }];
+
+/** Lint/format configs by detected language. Unknown ⇒ universal only. */
+export const CONFIGS_BY_LANGUAGE = {
+  javascript: JS_CONFIGS,
+  typescript: JS_CONFIGS,
+  python: PY_CONFIGS,
+  go: GO_CONFIGS,
+};

--- a/tests/harden/stack-config.test.js
+++ b/tests/harden/stack-config.test.js
@@ -1,0 +1,50 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installConfigs } from "../../src/harden/config-engine.js";
+
+let dir;
+const has = (f) => existsSync(join(dir, f));
+const read = (f) => readFileSync(join(dir, f), "utf8");
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kj-stack-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("installConfigs is stack-aware", () => {
+  it("python seeds ruff (with pyupgrade) + universal, never JS tooling", () => {
+    installConfigs({ projectDir: dir, language: "python" });
+    expect(has("ruff.toml")).toBe(true);
+    expect(read("ruff.toml")).toContain(">>> kj:managed:ruff v1 >>>");
+    expect(read("ruff.toml")).toContain('"UP"');
+    expect(has(".editorconfig")).toBe(true);
+    expect(has("commitlint.config.js")).toBe(true);
+    expect(has("eslint.config.js")).toBe(false);
+    expect(has(".prettierrc.json")).toBe(false);
+  });
+
+  it("go seeds golangci + universal, no JS tooling", () => {
+    installConfigs({ projectDir: dir, language: "go" });
+    expect(read(".golangci.yml")).toContain("staticcheck");
+    expect(has("eslint.config.js")).toBe(false);
+  });
+
+  it("an unknown language gets only the universal set (no tooling imposed)", () => {
+    const res = installConfigs({ projectDir: dir, language: "ruby" });
+    expect(res.configs.map((c) => c.file).sort()).toEqual([".editorconfig", "commitlint.config.js"]);
+    expect(has("ruff.toml")).toBe(false);
+    expect(has("eslint.config.js")).toBe(false);
+  });
+
+  it("javascript still seeds the full JS set", () => {
+    installConfigs({ projectDir: dir, language: "javascript" });
+    expect(has("eslint.config.js")).toBe(true);
+    expect(has(".prettierrc.json")).toBe(true);
+  });
+});


### PR DESCRIPTION
## H-C PR3 — KJC-TSK-0556 (épica KJC-PCS-0059), cierra H-C

`installConfigs` ahora se adapta al lenguaje detectado en vez de imponer herramientas de JavaScript:

- **Universal** (todo stack): `.editorconfig` + `commitlint.config.js`.
- **JS/TS**: eslint (lista negra ES2025) + prettier.
- **Python**: `ruff.toml` con `UP` (pyupgrade) — el equivalente Python a la lista negra de APIs obsoletas — más `E/F/I/B/SIM`.
- **Go**: `.golangci.yml` (govet, staticcheck, revive, ineffassign, gofmt).
- **Lenguaje desconocido**: solo el conjunto universal. No se impone tooling de JS.

`kj harden` detecta el lenguaje vía `detectProjectStack`. 4 pruebas de variantes (python con pyupgrade, go, desconocido → solo universal, javascript → set completo).

**Con esto H-C queda cerrada**: hooks (H-B) + config de calidad por stack con managed-markers, sin sobrescribir nada del usuario.

89 LOC netas.