### PR TITLE
feat(harden): detect language roots across a monorepo tree (H-C2.1)

### DIFF
--- a/src/harden/stack-roots.js
+++ b/src/harden/stack-roots.js
@@ -1,0 +1,74 @@
+/**
+ * detectStackRoots — find every language root in a (possibly monorepo) tree
+ * for `kj harden` (KJC-TSK-0561).
+ *
+ * Walks the project up to a shallow depth and returns the shallowest
+ * directory where each language appears, e.g. a fullstack repo yields
+ * `[{dir:"frontend",language:"javascript"},{dir:"backend",language:"python"}]`
+ * so lint/format config is seeded on each side. Universal config (handled by
+ * the caller) stays at the project root. Noise dirs are never descended.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  "vendor",
+  "target",
+  "__pycache__",
+  "venv",
+]);
+const DEFAULT_MAX_DEPTH = 2;
+
+/** Identify the language of a single directory by its manifest files. */
+export function languageAt(dir) {
+  if (existsSync(join(dir, "package.json"))) {
+    if (existsSync(join(dir, "tsconfig.json"))) return "typescript";
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+      if (deps.typescript || deps["ts-node"]) return "typescript";
+    } catch {
+      /* unreadable package.json → treat as plain JS */
+    }
+    return "javascript";
+  }
+  if (["pyproject.toml", "requirements.txt", "setup.py"].some((f) => existsSync(join(dir, f)))) return "python";
+  if (existsSync(join(dir, "go.mod"))) return "go";
+  return null;
+}
+
+export function detectStackRoots(projectDir, { maxDepth = DEFAULT_MAX_DEPTH } = {}) {
+  const found = [];
+  function walk(dir, depth) {
+    const language = languageAt(dir);
+    if (language) found.push({ dir: relative(projectDir, dir) || ".", language, depth });
+    if (depth >= maxDepth) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory() && !e.name.startsWith(".") && !IGNORE_DIRS.has(e.name)) {
+        walk(join(dir, e.name), depth + 1);
+      }
+    }
+  }
+  walk(projectDir, 0);
+
+  // Keep only the shallowest directory per language.
+  const byLanguage = new Map();
+  for (const f of found) {
+    const cur = byLanguage.get(f.language);
+    if (!cur || f.depth < cur.depth) byLanguage.set(f.language, f);
+  }
+  return [...byLanguage.values()]
+    .map(({ dir, language }) => ({ dir, language }))
+    .sort((a, b) => a.dir.localeCompare(b.dir));
+}

--- a/tests/harden/stack-roots.test.js
+++ b/tests/harden/stack-roots.test.js
@@ -1,0 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectStackRoots } from "../../src/harden/stack-roots.js";
+
+let root;
+const touch = (rel, content = "") => {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content);
+};
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "kj-roots-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("detectStackRoots", () => {
+  it("returns nothing for an empty project", () => {
+    expect(detectStackRoots(root)).toEqual([]);
+  });
+
+  it("detects a single language at the root", () => {
+    touch("package.json", "{}");
+    expect(detectStackRoots(root)).toEqual([{ dir: ".", language: "javascript" }]);
+  });
+
+  it("flags typescript when tsconfig is present", () => {
+    touch("package.json", "{}");
+    touch("tsconfig.json", "{}");
+    expect(detectStackRoots(root)).toEqual([{ dir: ".", language: "typescript" }]);
+  });
+
+  it("detects each side of a fullstack monorepo", () => {
+    touch("frontend/package.json", "{}");
+    touch("backend/pyproject.toml", "");
+    expect(detectStackRoots(root)).toEqual([
+      { dir: "backend", language: "python" },
+      { dir: "frontend", language: "javascript" },
+    ]);
+  });
+
+  it("handles a root JS workspace plus a python service", () => {
+    touch("package.json", "{}");
+    touch("services/api/go.mod", "module x");
+    expect(detectStackRoots(root)).toEqual([
+      { dir: ".", language: "javascript" },
+      { dir: join("services", "api"), language: "go" },
+    ]);
+  });
+
+  it("keeps only the shallowest dir per language", () => {
+    touch("package.json", "{}");
+    touch("apps/web/package.json", "{}");
+    expect(detectStackRoots(root)).toEqual([{ dir: ".", language: "javascript" }]);
+  });
+
+  it("never descends into noise dirs", () => {
+    touch("node_modules/somepkg/package.json", "{}");
+    touch("dist/package.json", "{}");
+    expect(detectStackRoots(root)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## H-C2 PR1 — KJC-TSK-0561 (épica KJC-PCS-0059)

Resuelve el hueco del caso fullstack que detectamos en H-C: `detectProjectStack` devolvía un único lenguaje y solo sembraba un lado.

`src/harden/stack-roots.js`:
- `detectStackRoots(projectDir)` recorre el árbol a poca profundidad (depth ≤2) y devuelve la carpeta **más superficial por lenguaje**. Un monorepo fullstack da una raíz por lado, p. ej. `[{dir:"backend",language:"python"},{dir:"frontend",language:"javascript"}]`.
- `languageAt(dir)` mapea manifiestos → js/ts/python/go (ts si hay `tsconfig.json` o dependencia typescript).
- Nunca desciende a carpetas de ruido (`node_modules`, `dist`, `build`, `vendor`, `target`, `__pycache__`, `venv`) ni a directorios ocultos.

7 pruebas: vacío, un lenguaje en raíz, ts por tsconfig, fullstack (front+back), workspace JS en raíz + servicio Go, deduplicación por lenguaje (la más superficial gana), ignorar node_modules/dist.

**PR2 (siguiente)**: que `kj harden` siembre la config de cada lenguaje en su carpeta usando estas raíces, y los universales en la raíz.

142 LOC netas.