### PR TITLE
feat(harden): seed lint config per language root in monorepos (H-C2.2)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -9,10 +9,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { installConfigs } from "../harden/config-engine.js";
+import { installConfigsForRoots } from "../harden/config-engine.js";
 import { installHooks } from "../harden/harden-engine.js";
+import { detectStackRoots } from "../harden/stack-roots.js";
 import { detectTestFramework } from "../utils/project-detect.js";
-import { detectProjectStack } from "../utils/stack-detect.js";
 
 const TEST_CMD = {
   vitest: "npx vitest run",
@@ -61,10 +61,11 @@ export async function hardenCommand({
     return { ok: false, error: err.message };
   }
 
-  // Config (lint/format/commit) ships with standard+, adapted to the stack.
+  // Config (lint/format/commit) ships with standard+, per language root so a
+  // fullstack monorepo is hardened on every side, not just one.
   const withConfig = config && profile !== "minimal";
-  const { language } = withConfig ? await detectProjectStack(projectDir) : {};
-  const cfg = withConfig ? installConfigs({ projectDir, language, dryRun }) : null;
+  const roots = withConfig ? detectStackRoots(projectDir) : [];
+  const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
   const out = { ok: true, ...result, configs: cfg?.configs ?? [] };
 
   if (json) {

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -18,29 +18,23 @@ function writeFile(target, content) {
   writeFileSync(target, content);
 }
 
-/**
- * Install config files for the detected stack: universal (.editorconfig,
- * commitlint) plus language-specific lint/format (JS/TS, Python, Go). An
- * unknown language gets the universal set only — no JS tooling is imposed.
- * Returns a per-file action report. `dryRun` computes actions without writing.
- */
-export function installConfigs({ projectDir = process.cwd(), language = "javascript", dryRun = false } = {}) {
-  const configs = [...UNIVERSAL_CONFIGS, ...(CONFIGS_BY_LANGUAGE[language] ?? [])];
-  const results = [];
+/** Seed a list of config entries into `targetDir`, labelling each by `prefix`. */
+function seedInto(targetDir, configs, dryRun, prefix, results) {
   for (const cfg of configs) {
-    const target = join(projectDir, cfg.file);
+    const target = join(targetDir, cfg.file);
     const exists = existsSync(target);
+    const file = prefix === "." ? cfg.file : join(prefix, cfg.file);
 
     if (cfg.json) {
       const action = exists ? "skipped" : "inserted";
       if (!dryRun && !exists) writeFile(target, `${cfg.body}\n`);
-      results.push({ file: cfg.file, action });
+      results.push({ file, action });
       continue;
     }
 
     const source = exists ? readFileSync(target, "utf8") : "";
     if (exists && !source.includes(`kj:managed:${cfg.blockId}`)) {
-      results.push({ file: cfg.file, action: "skipped" });
+      results.push({ file, action: "skipped" });
       continue;
     }
     const { content, action } = upsertManagedBlock({
@@ -51,7 +45,31 @@ export function installConfigs({ projectDir = process.cwd(), language = "javascr
       style: cfg.style,
     });
     if (!dryRun && action !== "unchanged") writeFile(target, content);
-    results.push({ file: cfg.file, action });
+    results.push({ file, action });
+  }
+}
+
+/**
+ * Single-directory seed: universal (.editorconfig, commitlint) plus the
+ * language's lint/format config, all at `projectDir`. Unknown language ⇒
+ * universal only. `dryRun` computes actions without writing.
+ */
+export function installConfigs({ projectDir = process.cwd(), language = "javascript", dryRun = false } = {}) {
+  const results = [];
+  seedInto(projectDir, [...UNIVERSAL_CONFIGS, ...(CONFIGS_BY_LANGUAGE[language] ?? [])], dryRun, ".", results);
+  return { dryRun, configs: results };
+}
+
+/**
+ * Monorepo seed: universal config once at the root, then each language's
+ * lint/format config inside its own root (from detectStackRoots). A fullstack
+ * repo gets eslint in frontend/, ruff in backend/, etc.
+ */
+export function installConfigsForRoots({ projectDir = process.cwd(), roots = [], dryRun = false } = {}) {
+  const results = [];
+  seedInto(projectDir, UNIVERSAL_CONFIGS, dryRun, ".", results);
+  for (const { dir, language } of roots) {
+    seedInto(join(projectDir, dir), CONFIGS_BY_LANGUAGE[language] ?? [], dryRun, dir, results);
   }
   return { dryRun, configs: results };
 }

--- a/tests/harden/config-roots.test.js
+++ b/tests/harden/config-roots.test.js
@@ -1,0 +1,60 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installConfigsForRoots } from "../../src/harden/config-engine.js";
+import { detectStackRoots } from "../../src/harden/stack-roots.js";
+
+let root;
+const has = (rel) => existsSync(join(root, rel));
+const seed = (rel, content = "") => {
+  mkdirSync(join(root, rel, ".."), { recursive: true });
+  writeFileSync(join(root, rel), content);
+};
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "kj-cfgroots-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("installConfigsForRoots (monorepo)", () => {
+  it("seeds universal at root and each language inside its own root", () => {
+    seed("frontend/package.json", "{}");
+    seed("backend/pyproject.toml", "");
+    const roots = detectStackRoots(root);
+    const res = installConfigsForRoots({ projectDir: root, roots });
+
+    // Universal at the repo root, once.
+    expect(has(".editorconfig")).toBe(true);
+    expect(has("commitlint.config.js")).toBe(true);
+
+    // JS tooling only in frontend/, Python tooling only in backend/.
+    expect(has(join("frontend", "eslint.config.js"))).toBe(true);
+    expect(has(join("frontend", ".prettierrc.json"))).toBe(true);
+    expect(has(join("backend", "ruff.toml"))).toBe(true);
+    expect(has("eslint.config.js")).toBe(false);
+    expect(has("ruff.toml")).toBe(false);
+    expect(has(join("backend", "eslint.config.js"))).toBe(false);
+
+    const files = res.configs.map((c) => c.file);
+    expect(files).toContain(join("frontend", "eslint.config.js"));
+    expect(files).toContain(join("backend", "ruff.toml"));
+  });
+
+  it("with no roots seeds only the universal set", () => {
+    const res = installConfigsForRoots({ projectDir: root, roots: [] });
+    expect(res.configs.map((c) => c.file).sort()).toEqual([".editorconfig", "commitlint.config.js"]);
+  });
+
+  it("dry-run writes nothing", () => {
+    seed("frontend/package.json", "{}");
+    const roots = detectStackRoots(root);
+    installConfigsForRoots({ projectDir: root, roots, dryRun: true });
+    expect(has(".editorconfig")).toBe(false);
+    expect(has(join("frontend", "eslint.config.js"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## H-C2 PR2 — KJC-TSK-0561 (épica KJC-PCS-0059), cierra H-C2

Cierra el caso fullstack: `kj harden` ahora siembra la configuración de cada lenguaje **en su propia carpeta**.

`installConfigsForRoots({projectDir, roots})`:
- Universal (`.editorconfig`, `commitlint`) una sola vez en la raíz.
- Por cada raíz de `detectStackRoots` (PR1): la config de lint/formato de ese lenguaje dentro de su carpeta.
- Un monorepo con React delante y Python detrás → eslint+prettier en `frontend/`, ruff en `backend/`. Nunca al revés ni duplicado.

`kj harden` reemplaza la detección de un solo lenguaje por `detectStackRoots` + `installConfigsForRoots`. Helper `seedInto` compartido; `installConfigs` de un directorio se mantiene por compatibilidad.

3 pruebas de monorepo: universal en raíz + JS en frontend + Python en backend (y nada cruzado), sin raíces → solo universal, dry-run no escribe.

**Con esto H-C2 queda cerrada**: el endurecimiento de configuración cubre proyectos de un lenguaje y monorepos fullstack.

79 LOC netas.