### PR TITLE
feat(harden): native per-language hook commands, no npm imposed (H-B2.1)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -10,20 +10,27 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { installConfigsForRoots } from "../harden/config-engine.js";
+import { commandsForLanguage } from "../harden/hook-commands.js";
 import { installHooks } from "../harden/harden-engine.js";
 import { detectStackRoots } from "../harden/stack-roots.js";
 import { detectTestFramework } from "../utils/project-detect.js";
 
-const TEST_CMD = {
+const JS_TEST_CMD = {
   vitest: "npx vitest run",
   jest: "npx jest",
   mocha: "npx mocha",
-  pytest: "pytest",
 };
 
-/** Pick lint/format/test commands from package.json scripts, then by framework. */
-export async function resolveCmds(projectDir) {
-  const cmds = {};
+/**
+ * Resolve the hook's lint/format/test commands for the primary language.
+ * Non-JS stacks use their native toolchain (go/ruff/…); JS/TS is built from
+ * the project's own package.json scripts so no npm command is ever assumed.
+ */
+export async function resolveCmds(projectDir, language) {
+  const lang = language ?? detectStackRoots(projectDir)[0]?.language ?? null;
+  const cmds = { ...commandsForLanguage(lang) };
+  if (lang !== "javascript" && lang !== "typescript") return cmds;
+
   const pkgPath = join(projectDir, "package.json");
   if (existsSync(pkgPath)) {
     try {
@@ -38,7 +45,7 @@ export async function resolveCmds(projectDir) {
   }
   if (!cmds.test) {
     const { framework } = await detectTestFramework(projectDir);
-    if (framework && TEST_CMD[framework]) cmds.test = TEST_CMD[framework];
+    if (framework && JS_TEST_CMD[framework]) cmds.test = JS_TEST_CMD[framework];
   }
   return cmds;
 }
@@ -51,7 +58,8 @@ export async function hardenCommand({
   json = false,
   logger = console,
 } = {}) {
-  const cmds = await resolveCmds(projectDir);
+  const roots = detectStackRoots(projectDir);
+  const cmds = await resolveCmds(projectDir, roots[0]?.language ?? null);
   let result;
   try {
     result = await installHooks({ projectDir, profile, cmds, dryRun });
@@ -64,7 +72,6 @@ export async function hardenCommand({
   // Config (lint/format/commit) ships with standard+, per language root so a
   // fullstack monorepo is hardened on every side, not just one.
   const withConfig = config && profile !== "minimal";
-  const roots = withConfig ? detectStackRoots(projectDir) : [];
   const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
   const out = { ok: true, ...result, configs: cfg?.configs ?? [] };
 

--- a/src/harden/hook-commands.js
+++ b/src/harden/hook-commands.js
@@ -1,0 +1,20 @@
+/**
+ * Native lint/format/test commands per language for `kj harden` hooks
+ * (KJC-TSK-0562).
+ *
+ * The installed hooks call the project's OWN toolchain, never npm by default,
+ * so hardening a Go/Python repo never drags Node onto a contributor's machine.
+ * JavaScript/TypeScript is built from package.json scripts by the caller (its
+ * commands depend on what the project defines). Unknown language ⇒ no commands,
+ * leaving only the universal POSIX-shell checks.
+ */
+
+export const COMMANDS_BY_LANGUAGE = {
+  python: { lint: "ruff check .", format: "ruff format --check .", test: "pytest" },
+  go: { lint: "go vet ./...", format: 'test -z "$(gofmt -l .)"', test: "go test ./..." },
+};
+
+/** Native commands for a language, or {} when JS/TS or unknown. */
+export function commandsForLanguage(language) {
+  return COMMANDS_BY_LANGUAGE[language] ?? {};
+}

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -1,10 +1,15 @@
 /**
- * Hook bodies + profile→hooks mapping for `kj harden` (KJC-TSK-0555).
+ * Hook bodies + profile→hooks mapping for `kj harden` (KJC-TSK-0555, 0562).
  *
  * A body is the MANAGED portion only; harden-engine adds the shebang and the
- * kj:managed markers around it. POSIX sh. `cmds` carries stack-aware commands
- * (npm-script defaults). See docs/specs/quality-harness.md §5 for profiles.
+ * kj:managed markers around it. Pure POSIX sh — the universal checks (commit
+ * format, AI-attribution) need no toolchain, and lint/format/test lines call
+ * the project's NATIVE commands (from `cmds`), only when present. No npm/Node
+ * is imposed on non-JS repos. See docs/specs/quality-harness.md §5.
  */
+
+const CONVENTIONAL_TYPES = "feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert";
+const AI_ATTRIBUTION = "co-authored-by:.*(claude|gpt|copilot|gemini)|(generated|written) (by|with) .*(claude|gpt|copilot)";
 
 export const SHEBANG = "#!/usr/bin/env sh";
 
@@ -17,32 +22,33 @@ export const PROFILE_HOOKS = {
 
 /** Build the managed body for a single hook. */
 export function hookBody(hook, cmds = {}) {
-  const lint = cmds.lint ?? "npm run -s lint";
-  const format = cmds.format ?? "npm run -s format:check";
-  const test = cmds.test ?? "npm test";
   switch (hook) {
-    case "pre-commit":
-      return [
-        "# Lint + format the working tree before each commit.",
-        `${lint} || { echo 'kj harden: lint failed'; exit 1; }`,
-        `${format} || { echo 'kj harden: format check failed'; exit 1; }`,
-      ].join("\n");
+    case "pre-commit": {
+      const lines = ["# Lint + format the working tree with the project's native tools."];
+      if (cmds.lint) lines.push(`${cmds.lint} || { echo 'kj harden: lint failed'; exit 1; }`);
+      if (cmds.format) lines.push(`${cmds.format} || { echo 'kj harden: format check failed'; exit 1; }`);
+      if (!cmds.lint && !cmds.format) lines.push("# (no lint/format command detected for this stack)");
+      return lines.join("\n");
+    }
     case "commit-msg":
+      // Pure POSIX — Conventional Commits header, length cap, AI-attribution.
       return [
-        "# Conventional Commits + block AI self-attribution.",
         'msg_file="$1"',
-        "if command -v npx >/dev/null 2>&1; then",
-        "  npx --no-install commitlint --edit \"$msg_file\" || { echo 'kj harden: commitlint failed'; exit 1; }",
+        'header=$(head -n1 "$msg_file")',
+        `if ! printf '%s' "$header" | grep -qE '^(${CONVENTIONAL_TYPES})(\\([a-z0-9._-]+\\))?!?: .+'; then`,
+        "  echo 'kj harden: commit header must follow Conventional Commits (type: subject)'; exit 1",
         "fi",
-        "if grep -qiE 'co-authored-by:.*(claude|gpt|copilot|gemini)|(generated|written) (by|with) .*(claude|gpt|copilot)' \"$msg_file\"; then",
+        'if [ "${#header}" -gt 100 ]; then echo \'kj harden: commit header exceeds 100 chars\'; exit 1; fi',
+        `if grep -qiE '${AI_ATTRIBUTION}' "$msg_file"; then`,
         "  echo 'kj harden: AI attribution is not allowed in commit messages'; exit 1",
         "fi",
       ].join("\n");
-    case "pre-push":
-      return [
-        "# Run the test suite before pushing.",
-        `${test} || { echo 'kj harden: tests failed'; exit 1; }`,
-      ].join("\n");
+    case "pre-push": {
+      const lines = ["# Run the test suite before pushing."];
+      if (cmds.test) lines.push(`${cmds.test} || { echo 'kj harden: tests failed'; exit 1; }`);
+      else lines.push("# (no test command detected for this stack)");
+      return lines.join("\n");
+    }
     case "post-merge":
       return [
         "# Refresh the local RAG index so retrieval never serves stale code.",

--- a/tests/harden/native-hooks.test.js
+++ b/tests/harden/native-hooks.test.js
@@ -1,0 +1,76 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hardenCommand } from "../../src/commands/harden.js";
+import { installHooks } from "../../src/harden/harden-engine.js";
+import { hookBody } from "../../src/harden/hook-templates.js";
+
+let repo;
+const logger = { info: vi.fn(), error: vi.fn() };
+const hook = (name) => readFileSync(join(repo, ".karajan", "hooks", name), "utf8");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repo = mkdtempSync(join(tmpdir(), "kj-native-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("hookBody is pure POSIX (no Node imposed)", () => {
+  it("commit-msg checks Conventional Commits, length and AI attribution without npx", () => {
+    const body = hookBody("commit-msg");
+    expect(body).not.toContain("npx");
+    expect(body).toContain("feat|fix|docs");
+    expect(body).toContain("exceeds 100 chars");
+    expect(body).toContain("AI attribution");
+  });
+
+  it("omits lint/test lines when no native command is available", () => {
+    expect(hookBody("pre-commit")).toContain("no lint/format command detected");
+    expect(hookBody("pre-push")).toContain("no test command detected");
+  });
+
+  it("inlines the native command it is given", () => {
+    expect(hookBody("pre-commit", { lint: "go vet ./..." })).toContain("go vet ./...");
+  });
+
+  it("generates hooks that are valid POSIX shell (sh -n)", async () => {
+    writeFileSync(join(repo, "go.mod"), "module example.com/x\n");
+    await installHooks({ projectDir: repo, profile: "standard", cmds: { lint: "go vet ./...", test: "go test ./..." } });
+    for (const name of ["pre-commit", "commit-msg", "pre-push", "post-merge"]) {
+      expect(() => execFileSync("sh", ["-n", join(repo, ".karajan", "hooks", name)])).not.toThrow();
+    }
+  });
+});
+
+describe("kj harden uses native commands per language, never npm by default", () => {
+  it("a Go repo gets go tooling and no npm", async () => {
+    writeFileSync(join(repo, "go.mod"), "module example.com/x\n");
+    await hardenCommand({ projectDir: repo, logger });
+    expect(hook("pre-commit")).toContain("go vet ./...");
+    expect(hook("pre-push")).toContain("go test ./...");
+    expect(hook("pre-commit")).not.toContain("npm");
+  });
+
+  it("a Python repo gets ruff and pytest", async () => {
+    writeFileSync(join(repo, "pyproject.toml"), "[project]\nname = 'x'\n");
+    await hardenCommand({ projectDir: repo, logger });
+    expect(hook("pre-commit")).toContain("ruff check .");
+    expect(hook("pre-push")).toContain("pytest");
+    expect(hook("pre-commit")).not.toContain("npm");
+  });
+
+  it("an unknown stack gets only universal checks (no tooling, no Node)", async () => {
+    writeFileSync(join(repo, "README.md"), "# x\n");
+    await hardenCommand({ projectDir: repo, logger });
+    expect(hook("pre-commit")).toContain("no lint/format command detected");
+    expect(hook("pre-push")).toContain("no test command detected");
+    expect(hook("commit-msg")).not.toContain("npx");
+  });
+});


### PR DESCRIPTION
## H-B2 PR1 — KJC-TSK-0562 (épica KJC-PCS-0059)

Responde a la duda que planteaste: **endurecer un repo Java/Go/Python no debe convertir Node en dependencia de commit de cada contribuidor.** Mi H-B original metía `npm` por defecto en los hooks aunque el repo no fuera JS — esto lo corrige.

- **Comandos nativos por lenguaje** (`src/harden/hook-commands.js`): Go → `go vet`/`gofmt`/`go test`; Python → `ruff`/`pytest`; JS/TS → scripts de `package.json`. Lenguaje desconocido → sin líneas de lint/test (solo checks universales).
- **`commit-msg` reescrito a POSIX puro**: Conventional Commits + tope de 100 caracteres en el header + bloqueo de atribución a IA, **sin `npx`/commitlint**. Así un repo Go/Python no necesita Node para commitear.
- Detección del lenguaje primario vía `detectStackRoots` (H-C2).

**Dos capas separadas**: ejecutar `kj harden` necesita Node una vez (Karajan es Node); los **hooks instalados** ya no — corren con el toolchain del propio proyecto.

7 pruebas, incluida una verificación `sh -n` de que los hooks generados son shell POSIX válido. 109 LOC netas.

Siguientes en H-B2: guardia de identidad en pre-push (shell puro) y los checks Node de dev-toolkit (strip-comments) **solo en repos JS/TS**.