### PR TITLE
feat(harden): refuse to push without a git identity (H-B2.2)

### DIFF
--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -44,7 +44,14 @@ export function hookBody(hook, cmds = {}) {
         "fi",
       ].join("\n");
     case "pre-push": {
-      const lines = ["# Run the test suite before pushing."];
+      const lines = [
+        "# Identity guard — never push without a configured git identity.",
+        'if [ -z "$(git config user.email)" ] || [ -z "$(git config user.name)" ]; then',
+        "  echo 'kj harden: git user.name/user.email not set — refusing to push'; exit 1",
+        "fi",
+        'echo "kj harden: pushing as $(git config user.name) <$(git config user.email)>"',
+        "# Run the test suite before pushing.",
+      ];
       if (cmds.test) lines.push(`${cmds.test} || { echo 'kj harden: tests failed'; exit 1; }`);
       else lines.push("# (no test command detected for this stack)");
       return lines.join("\n");

--- a/tests/harden/native-hooks.test.js
+++ b/tests/harden/native-hooks.test.js
@@ -40,6 +40,13 @@ describe("hookBody is pure POSIX (no Node imposed)", () => {
     expect(hookBody("pre-commit", { lint: "go vet ./..." })).toContain("go vet ./...");
   });
 
+  it("pre-push refuses to push without a configured git identity", () => {
+    const body = hookBody("pre-push");
+    expect(body).toContain("user.email");
+    expect(body).toContain("refusing to push");
+    expect(body).toContain("pushing as");
+  });
+
   it("generates hooks that are valid POSIX shell (sh -n)", async () => {
     writeFileSync(join(repo, "go.mod"), "module example.com/x\n");
     await installHooks({ projectDir: repo, profile: "standard", cmds: { lint: "go vet ./...", test: "go test ./..." } });


### PR DESCRIPTION
## H-B2 PR2 — KJC-TSK-0562 (épica KJC-PCS-0059)

El hook `pre-push` ahora **bloquea el push si `user.name`/`user.email` no están configurados** y muestra con qué identidad va a empujar (`pushing as Nombre <correo>`), para cazar el caso de identidad personal-vs-trabajo equivocada antes de que salga de la máquina. Implementa tu regla de verificar identidad antes de push.

Shell POSIX puro, cero Node. Cubierto por la verificación `sh -n` existente + test del cuerpo. 14 LOC netas.

Tras esto cierro H-B2; `strip-comments` (modifica ficheros) queda como opt-in para más adelante, no por defecto.