### PR TITLE
feat(harden): seed CI quality workflows — no-AI-attribution (H-D.1)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -403,6 +403,7 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Install the quality harness (git hooks) into this repo — idempotent")
     .option("--profile <name>", "minimal | standard | strict", "standard")
     .option("--no-config", "Skip lint/format/commit config files (hooks only)")
+    .option("--no-ci", "Skip CI quality workflows")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
     .action(async (flags) => {
@@ -410,6 +411,7 @@ export function registerMeta(program, { pkgVersion }) {
         await hardenCommand({
           profile: flags.profile,
           config: flags.config !== false,
+          ci: flags.ci !== false,
           dryRun: Boolean(flags.dryRun),
           json: Boolean(flags.json),
           logger,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -13,6 +13,7 @@ import { installConfigsForRoots } from "../harden/config-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
 import { installHooks } from "../harden/harden-engine.js";
 import { detectStackRoots } from "../harden/stack-roots.js";
+import { installWorkflows } from "../harden/workflow-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
 
 const JS_TEST_CMD = {
@@ -54,6 +55,7 @@ export async function hardenCommand({
   projectDir = process.cwd(),
   profile = "standard",
   config = true,
+  ci = true,
   dryRun = false,
   json = false,
   logger = console,
@@ -73,7 +75,9 @@ export async function hardenCommand({
   // fullstack monorepo is hardened on every side, not just one.
   const withConfig = config && profile !== "minimal";
   const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
-  const out = { ok: true, ...result, configs: cfg?.configs ?? [] };
+  const withCi = ci && profile !== "minimal";
+  const wf = withCi ? installWorkflows({ projectDir, dryRun }) : null;
+  const out = { ok: true, ...result, configs: cfg?.configs ?? [], workflows: wf?.workflows ?? [] };
 
   if (json) {
     logger.info?.(JSON.stringify(out));
@@ -84,6 +88,7 @@ export async function hardenCommand({
   logger.info?.(`kj harden (${profile}) — ${verb} ${result.hooks.length} hook(s) → ${result.hooksPath}`);
   for (const h of result.hooks) logger.info?.(`  • ${h.hook}: ${h.action}`);
   for (const c of out.configs) logger.info?.(`  • ${c.file}: ${c.action}`);
+  for (const w of out.workflows) logger.info?.(`  • ${w.file}: ${w.action}`);
   if (!dryRun) logger.info?.("core.hooksPath set. Verify later with `kj check` (H-E).");
   return out;
 }

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -1,0 +1,44 @@
+/**
+ * workflow-engine — seeds CI quality workflows for `kj harden` (KJC-TSK-0557).
+ *
+ * Seed-if-absent into `.github/workflows/`: a workflow the user already wrote
+ * (no kj:managed marker) is left untouched and reported "skipped". kj-managed
+ * workflows refresh in place. Markers ride in YAML `#` comments.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { WORKFLOWS } from "./workflow-templates.js";
+
+const BLOCK_VERSION = 1;
+const WORKFLOWS_DIR = join(".github", "workflows");
+
+export function installWorkflows({ projectDir = process.cwd(), dryRun = false } = {}) {
+  const dir = join(projectDir, WORKFLOWS_DIR);
+  const results = [];
+  for (const wf of WORKFLOWS) {
+    const target = join(dir, wf.file);
+    const label = join(WORKFLOWS_DIR, wf.file);
+    const exists = existsSync(target);
+    const source = exists ? readFileSync(target, "utf8") : "";
+    if (exists && !source.includes(`kj:managed:${wf.blockId}`)) {
+      results.push({ file: label, action: "skipped" });
+      continue;
+    }
+    const { content, action } = upsertManagedBlock({
+      source,
+      blockId: wf.blockId,
+      version: BLOCK_VERSION,
+      body: wf.body,
+      style: "hash",
+    });
+    if (!dryRun && action !== "unchanged") {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(target, content);
+    }
+    results.push({ file: label, action });
+  }
+  return { dryRun, workflows: results };
+}

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -1,0 +1,41 @@
+/**
+ * CI workflow templates for `kj harden` (KJC-TSK-0557).
+ *
+ * Generic, language-agnostic GitHub Actions that `kj harden` seeds into a
+ * target repo's `.github/workflows/`. Bodies are plain strings (NOT template
+ * literals) so the `${{ … }}` GitHub expressions survive verbatim.
+ */
+
+// Blocks AI self-attribution in PR commit messages. Pure bash + grep, no Node.
+// Pins github.base_ref to an env var (never interpolated into the run block).
+export const NO_AI_ATTRIBUTION_WORKFLOW = [
+  "name: Block AI attribution",
+  "on:",
+  "  pull_request:",
+  "    branches: [main]",
+  "permissions:",
+  "  contents: read",
+  "jobs:",
+  "  scan:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "        with:",
+  "          fetch-depth: 0",
+  "      - name: Scan commit messages for AI attribution",
+  "        env:",
+  "          BASE_REF: ${{ github.base_ref }}",
+  "        run: |",
+  '          msgs=$(git log --format=%B "origin/${BASE_REF}...HEAD" || true)',
+  "          pat='co-authored-by:.*(claude|anthropic|openai|chatgpt|gpt-[0-9]|copilot|gemini|cursor|windsurf|codeium|deepseek)'",
+  "          pat=\"$pat|(generated|written|authored|assisted|powered) (by|with|using) .*(claude|anthropic|openai|copilot|gemini)\"",
+  '          if printf "%s" "$msgs" | grep -qiE "$pat"; then',
+  '            echo "::error::AI attribution detected in commit messages"; exit 1',
+  "          fi",
+  '          echo "AI attribution scan: clean"',
+].join("\n");
+
+/** Workflows harden seeds. style:hash ⇒ kj:managed block in YAML comments. */
+export const WORKFLOWS = [
+  { file: "kj-no-ai-attribution.yml", blockId: "wf-no-ai", body: NO_AI_ATTRIBUTION_WORKFLOW },
+];

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -1,0 +1,53 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import yaml from "js-yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { installWorkflows } from "../../src/harden/workflow-engine.js";
+
+let dir;
+const wfPath = join(".github", "workflows", "kj-no-ai-attribution.yml");
+const read = (rel) => readFileSync(join(dir, rel), "utf8");
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kj-wf-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("installWorkflows", () => {
+  it("seeds a marked, valid-YAML no-AI-attribution workflow", () => {
+    const res = installWorkflows({ projectDir: dir });
+    expect(res.workflows[0]).toMatchObject({ file: wfPath, action: "inserted" });
+    const text = read(wfPath);
+    expect(text).toContain(">>> kj:managed:wf-no-ai v1 >>>");
+    // GitHub expressions survive verbatim (not interpolated by JS).
+    expect(text).toContain("${{ github.base_ref }}");
+    const parsed = yaml.load(text);
+    expect(parsed.name).toBe("Block AI attribution");
+    expect(parsed.jobs.scan["runs-on"]).toBe("ubuntu-latest");
+  });
+
+  it("is idempotent", () => {
+    installWorkflows({ projectDir: dir });
+    const res = installWorkflows({ projectDir: dir });
+    expect(res.workflows[0].action).toBe("unchanged");
+  });
+
+  it("never overwrites a user workflow without our marker", () => {
+    const abs = join(dir, ".github", "workflows");
+    mkdirSync(abs, { recursive: true });
+    writeFileSync(join(abs, "kj-no-ai-attribution.yml"), "name: mine\n");
+    const res = installWorkflows({ projectDir: dir });
+    expect(res.workflows[0].action).toBe("skipped");
+    expect(read(wfPath)).toBe("name: mine\n");
+  });
+
+  it("dry-run writes nothing", () => {
+    installWorkflows({ projectDir: dir, dryRun: true });
+    expect(existsSync(join(dir, wfPath))).toBe(false);
+  });
+});


### PR DESCRIPTION
## H-D PR1 — KJC-TSK-0557 (épica KJC-PCS-0059)

`kj harden` ahora siembra workflows de CI en `.github/workflows/`. Primera pieza: el workflow **Block AI attribution** (portado y saneado de `dev-toolkit`, sin tokens personales): bash + grep, escanea los mensajes de commit de la PR; `base_ref` fijado a variable de entorno (patrón anti shell-injection de KJC-BUG-0072). Sin Node.

- `src/harden/workflow-templates.js` + `workflow-engine.js` (`installWorkflows`): seed-if-absent en `.github/workflows/`, bloque `kj:managed` en comentarios YAML, no pisa workflows del usuario.
- Nuevo `--no-ci` para desactivar.
- Validado como YAML con `js-yaml`; las expresiones `${{ … }}` sobreviven literales.

5 pruebas. 145 LOC netas. **Siguiente PR**: gates de calidad por stack (lint/tests/shrink-budget/pack-smoke condicional).