### PR TITLE
feat(harden): stack-aware Quality CI workflow (H-D.2)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -76,7 +76,7 @@ export async function hardenCommand({
   const withConfig = config && profile !== "minimal";
   const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
   const withCi = ci && profile !== "minimal";
-  const wf = withCi ? installWorkflows({ projectDir, dryRun }) : null;
+  const wf = withCi ? installWorkflows({ projectDir, language: roots[0]?.language ?? null, dryRun }) : null;
   const out = { ok: true, ...result, configs: cfg?.configs ?? [], workflows: wf?.workflows ?? [] };
 
   if (json) {

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -10,15 +10,17 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
-import { WORKFLOWS } from "./workflow-templates.js";
+import { qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
 
 const BLOCK_VERSION = 1;
 const WORKFLOWS_DIR = join(".github", "workflows");
 
-export function installWorkflows({ projectDir = process.cwd(), dryRun = false } = {}) {
+export function installWorkflows({ projectDir = process.cwd(), language = null, dryRun = false } = {}) {
   const dir = join(projectDir, WORKFLOWS_DIR);
+  const quality = qualityWorkflowFor(language);
+  const all = quality ? [...WORKFLOWS, quality] : WORKFLOWS;
   const results = [];
-  for (const wf of WORKFLOWS) {
+  for (const wf of all) {
     const target = join(dir, wf.file);
     const label = join(WORKFLOWS_DIR, wf.file);
     const exists = existsSync(target);

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -35,7 +35,54 @@ export const NO_AI_ATTRIBUTION_WORKFLOW = [
   '          echo "AI attribution scan: clean"',
 ].join("\n");
 
-/** Workflows harden seeds. style:hash ⇒ kj:managed block in YAML comments. */
+/** Universal workflows (every stack). style:hash ⇒ marker in YAML comments. */
 export const WORKFLOWS = [
   { file: "kj-no-ai-attribution.yml", blockId: "wf-no-ai", body: NO_AI_ATTRIBUTION_WORKFLOW },
 ];
+
+const header = (steps) =>
+  [
+    "name: Quality",
+    "on:",
+    "  pull_request:",
+    "    branches: [main]",
+    "jobs:",
+    "  quality:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    ...steps,
+  ].join("\n");
+
+const QUALITY_BY_LANGUAGE = {
+  javascript: header([
+    "      - uses: actions/setup-node@v4",
+    "        with:",
+    "          node-version: 22",
+    "      - run: npm ci",
+    "      - run: npm run -s lint --if-present",
+    "      - run: npm test",
+  ]),
+  python: header([
+    "      - uses: actions/setup-python@v5",
+    "        with:",
+    "          python-version: '3.12'",
+    "      - run: pip install ruff pytest",
+    "      - run: ruff check .",
+    "      - run: pytest",
+  ]),
+  go: header([
+    "      - uses: actions/setup-go@v5",
+    "        with:",
+    "          go-version: stable",
+    "      - run: go vet ./...",
+    "      - run: go test ./...",
+  ]),
+};
+QUALITY_BY_LANGUAGE.typescript = QUALITY_BY_LANGUAGE.javascript;
+
+/** Stack-aware Quality workflow entry, or null for an unknown language. */
+export function qualityWorkflowFor(language) {
+  const body = QUALITY_BY_LANGUAGE[language];
+  return body ? { file: "kj-quality.yml", blockId: "wf-quality", body } : null;
+}

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -50,4 +50,27 @@ describe("installWorkflows", () => {
     installWorkflows({ projectDir: dir, dryRun: true });
     expect(existsSync(join(dir, wfPath))).toBe(false);
   });
+
+  it("adds a stack-aware Quality workflow for a known language", () => {
+    const res = installWorkflows({ projectDir: dir, language: "go" });
+    expect(res.workflows.map((w) => w.file)).toContain(join(".github", "workflows", "kj-quality.yml"));
+    const text = read(join(".github", "workflows", "kj-quality.yml"));
+    expect(text).toContain("actions/setup-go@v5");
+    expect(text).toContain("go test ./...");
+    expect(yaml.load(text).jobs.quality["runs-on"]).toBe("ubuntu-latest");
+  });
+
+  it("python gets ruff + pytest, javascript gets npm", () => {
+    const py = mkdtempSync(join(tmpdir(), "kj-wf-py-"));
+    installWorkflows({ projectDir: py, language: "python" });
+    expect(readFileSync(join(py, ".github", "workflows", "kj-quality.yml"), "utf8")).toContain("ruff check .");
+    rmSync(py, { recursive: true, force: true });
+    installWorkflows({ projectDir: dir, language: "typescript" });
+    expect(read(join(".github", "workflows", "kj-quality.yml"))).toContain("npm test");
+  });
+
+  it("omits the Quality workflow for an unknown language", () => {
+    const res = installWorkflows({ projectDir: dir, language: "ruby" });
+    expect(res.workflows.map((w) => w.file)).not.toContain(join(".github", "workflows", "kj-quality.yml"));
+  });
 });


### PR DESCRIPTION
## H-D PR2 — KJC-TSK-0557 (épica KJC-PCS-0059)

`kj harden` añade ahora un workflow **Quality** adaptado al lenguaje, junto al universal anti-atribución (PR1):
- **JS/TS**: setup-node + `npm ci` + lint + `npm test`.
- **Python**: setup-python + `ruff check` + `pytest`.
- **Go**: setup-go + `go vet` + `go test`.
- Lenguaje desconocido → se omite (solo el universal).

`installWorkflows({language})` lo compone; `kj harden` pasa el lenguaje primario detectado. 4 pruebas, validadas como YAML con `js-yaml`. 72 LOC netas.

**Siguiente (PR3, cierra H-D)**: shrink-budget genérico + pack-smoke condicional para paquetes npm publicables.