### PR TITLE
feat(harden): conditional shrink-budget + pack-smoke workflows (H-D.3)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -76,7 +76,9 @@ export async function hardenCommand({
   const withConfig = config && profile !== "minimal";
   const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
   const withCi = ci && profile !== "minimal";
-  const wf = withCi ? installWorkflows({ projectDir, language: roots[0]?.language ?? null, dryRun }) : null;
+  const wf = withCi
+    ? installWorkflows({ projectDir, language: roots[0]?.language ?? null, profile, dryRun })
+    : null;
   const out = { ok: true, ...result, configs: cfg?.configs ?? [], workflows: wf?.workflows ?? [] };
 
   if (json) {

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -10,15 +10,33 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
-import { qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
+import { extraWorkflowsFor, qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
 
 const BLOCK_VERSION = 1;
 const WORKFLOWS_DIR = join(".github", "workflows");
 
-export function installWorkflows({ projectDir = process.cwd(), language = null, dryRun = false } = {}) {
+/** A package.json that ships code (not private, has bin or main) ⇒ publishable. */
+export function isPublishableNpm(projectDir) {
+  const pkgPath = join(projectDir, "package.json");
+  if (!existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    return pkg.private !== true && Boolean(pkg.bin || pkg.main);
+  } catch {
+    return false;
+  }
+}
+
+export function installWorkflows({
+  projectDir = process.cwd(),
+  language = null,
+  profile = "standard",
+  dryRun = false,
+} = {}) {
   const dir = join(projectDir, WORKFLOWS_DIR);
   const quality = qualityWorkflowFor(language);
-  const all = quality ? [...WORKFLOWS, quality] : WORKFLOWS;
+  const extras = extraWorkflowsFor({ profile, publishable: isPublishableNpm(projectDir) });
+  const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras];
   const results = [];
   for (const wf of all) {
     const target = join(dir, wf.file);

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -86,3 +86,67 @@ export function qualityWorkflowFor(language) {
   const body = QUALITY_BY_LANGUAGE[language];
   return body ? { file: "kj-quality.yml", blockId: "wf-quality", body } : null;
 }
+
+// Caps the net LOC delta of a PR (strict profile only — it is opinionated).
+export const SHRINK_BUDGET_WORKFLOW = [
+  "name: Shrink budget",
+  "on:",
+  "  pull_request:",
+  "    branches: [main]",
+  "permissions:",
+  "  contents: read",
+  "jobs:",
+  "  budget:",
+  "    runs-on: ubuntu-latest",
+  '    env: { LOC_LIMIT: "200" }',
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "        with:",
+  "          fetch-depth: 0",
+  "      - name: Net LOC delta within budget",
+  "        env:",
+  "          BASE_REF: ${{ github.base_ref }}",
+  "        run: |",
+  "          d=$(git diff --numstat \"origin/${BASE_REF}...HEAD\" -- . ':!**/*.md' ':!*.lock' ':!package-lock.json' || true)",
+  '          a=$(printf "%s\\n" "$d" | awk \'$1!="-"{s+=$1}END{print s+0}\')',
+  '          r=$(printf "%s\\n" "$d" | awk \'$2!="-"{s+=$2}END{print s+0}\')',
+  '          net=$((a - r)); echo "net=$net (limit=$LOC_LIMIT)"',
+  '          if [ "$net" -gt "$LOC_LIMIT" ]; then echo "::error::PR adds $net net lines (limit $LOC_LIMIT)"; exit 1; fi',
+].join("\n");
+
+// Packs the tarball and installs it clean — only for publishable npm packages.
+export const PACK_SMOKE_WORKFLOW = [
+  "name: Pack smoke",
+  "on:",
+  "  pull_request:",
+  "    branches: [main]",
+  "permissions:",
+  "  contents: read",
+  "jobs:",
+  "  pack-smoke:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - uses: actions/checkout@v4",
+  "      - uses: actions/setup-node@v4",
+  "        with:",
+  "          node-version: 22",
+  "      - run: npm ci",
+  "      - name: Pack and install the tarball clean",
+  "        run: |",
+  "          tgz=$(npm pack --silent)",
+  "          dir=$(mktemp -d)",
+  '          npm install --prefix "$dir" "$PWD/$tgz" --no-audit --no-fund',
+  '          echo "Tarball installs clean: $tgz"',
+].join("\n");
+
+/** Conditional workflows: shrink-budget on strict, pack-smoke when publishable. */
+export function extraWorkflowsFor({ profile = "standard", publishable = false } = {}) {
+  const extras = [];
+  if (profile === "strict") {
+    extras.push({ file: "kj-shrink-budget.yml", blockId: "wf-shrink", body: SHRINK_BUDGET_WORKFLOW });
+  }
+  if (publishable) {
+    extras.push({ file: "kj-pack-smoke.yml", blockId: "wf-pack-smoke", body: PACK_SMOKE_WORKFLOW });
+  }
+  return extras;
+}

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -73,4 +73,30 @@ describe("installWorkflows", () => {
     const res = installWorkflows({ projectDir: dir, language: "ruby" });
     expect(res.workflows.map((w) => w.file)).not.toContain(join(".github", "workflows", "kj-quality.yml"));
   });
+
+  it("adds shrink-budget only on the strict profile", () => {
+    const std = installWorkflows({ projectDir: dir, profile: "standard" });
+    expect(std.workflows.map((w) => w.file)).not.toContain(join(".github", "workflows", "kj-shrink-budget.yml"));
+    const strictDir = mkdtempSync(join(tmpdir(), "kj-wf-strict-"));
+    const strict = installWorkflows({ projectDir: strictDir, profile: "strict" });
+    expect(strict.workflows.map((w) => w.file)).toContain(join(".github", "workflows", "kj-shrink-budget.yml"));
+    expect(yaml.load(readFileSync(join(strictDir, ".github", "workflows", "kj-shrink-budget.yml"), "utf8")).name).toBe(
+      "Shrink budget"
+    );
+    rmSync(strictDir, { recursive: true, force: true });
+  });
+
+  it("adds pack-smoke only for a publishable npm package", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", bin: { x: "cli.js" } }));
+    const res = installWorkflows({ projectDir: dir });
+    expect(res.workflows.map((w) => w.file)).toContain(join(".github", "workflows", "kj-pack-smoke.yml"));
+  });
+
+  it("omits pack-smoke for a private package", () => {
+    const priv = mkdtempSync(join(tmpdir(), "kj-wf-priv-"));
+    writeFileSync(join(priv, "package.json"), JSON.stringify({ name: "x", private: true, main: "i.js" }));
+    const res = installWorkflows({ projectDir: priv });
+    expect(res.workflows.map((w) => w.file)).not.toContain(join(".github", "workflows", "kj-pack-smoke.yml"));
+    rmSync(priv, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## H-D PR3 — KJC-TSK-0557 (épica KJC-PCS-0059), cierra H-D

Workflows condicionales, no impuestos a todos:
- **shrink-budget** (tope de líneas netas por PR): solo en perfil **strict** — es opinable.
- **pack-smoke** (`npm pack` + install limpio del tarball): solo si el repo es un **paquete npm publicable** (`isPublishableNpm`: no `private`, con `bin`/`main`). Es el gate que protege a karajan de publicar paquetes que no arrancan.

4 pruebas (strict añade shrink-budget, standard no; publicable añade pack-smoke, privado no). 110 LOC netas.

**H-D queda cerrada**: `kj harden` siembra anti-atribución IA (universal) + Quality por stack + shrink-budget (strict) + pack-smoke (npm publicable), todo seed-if-absent con managed-markers.