### PR TITLE
feat(harden): kj check verifies the hook harness (H-E.1)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -14,6 +14,7 @@ import { webperfCommand } from "../commands/webperf.js";
 import { undoCommand } from "../commands/undo.js";
 import { syncCommand } from "../commands/sync.js";
 import { cleanCommand } from "../commands/clean.js";
+import { checkCommand } from "../commands/check.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { withConfig } from "./_shared.js";
@@ -417,5 +418,17 @@ export function registerMeta(program, { pkgVersion }) {
           logger,
         });
       });
+    });
+
+  program
+    .command("check")
+    .description("Verify the quality harness installed by kj harden (drift gate)")
+    .option("--profile <name>", "minimal | standard | strict", "standard")
+    .option("--json", "Emit machine-readable JSON")
+    .action(async (flags) => {
+      const code = await withConfig(pkgVersion, "check", flags, async ({ logger }) =>
+        checkCommand({ profile: flags.profile, json: Boolean(flags.json), logger })
+      );
+      if (Number.isInteger(code)) process.exit(code);
     });
 }

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -1,0 +1,22 @@
+/**
+ * `kj check` — verify the quality harness installed by `kj harden`
+ * (KJC-TSK-0558). Prints a per-category table and returns an exit code so it
+ * works both locally and as a CI drift gate. `--json` for machine output.
+ */
+
+import { checkHarden } from "../harden/check.js";
+
+export async function checkCommand({ projectDir = process.cwd(), profile = "standard", json = false, logger = console } = {}) {
+  const result = await checkHarden({ projectDir, profile });
+
+  if (json) {
+    logger.info?.(JSON.stringify(result));
+    return result.ok ? 0 : 1;
+  }
+
+  logger.info?.(`kj check (${profile})`);
+  for (const c of result.checks) logger.info?.(`  ${c.ok ? "✓" : "✗"} ${c.id}: ${c.detail}`);
+  if (!result.ok) logger.info?.("Harness drift detected — run `kj harden` to repair.");
+  else logger.info?.("Harness OK.");
+  return result.ok ? 0 : 1;
+}

--- a/src/harden/check.js
+++ b/src/harden/check.js
@@ -1,0 +1,39 @@
+/**
+ * checkHarden — verify the quality harness installed by `kj harden`
+ * (KJC-TSK-0558). Detects drift: a deleted hook, a hook that lost its kj
+ * marker or its executable bit, or a core.hooksPath that no longer points at
+ * `.karajan/hooks`. Returns a per-check report; the CLI maps it to exit 0/≠0.
+ *
+ * Config, workflow and language-advisory checks land in the next slice.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { runCommand } from "../utils/process.js";
+import { PROFILE_HOOKS } from "./hook-templates.js";
+
+const HOOKS_DIR = join(".karajan", "hooks");
+
+export async function checkHarden({ projectDir = process.cwd(), profile = "standard" } = {}) {
+  const checks = [];
+
+  const res = await runCommand("git", ["config", "--local", "core.hooksPath"], { cwd: projectDir });
+  const hooksPath = (res.stdout ?? "").trim();
+  checks.push({
+    id: "core.hooksPath",
+    ok: hooksPath === HOOKS_DIR,
+    detail: hooksPath === HOOKS_DIR ? "ok" : hooksPath || "(unset) — run kj harden",
+  });
+
+  for (const hook of PROFILE_HOOKS[profile] ?? []) {
+    const target = join(projectDir, HOOKS_DIR, hook);
+    const exists = existsSync(target);
+    const executable = exists && (statSync(target).mode & 0o100) !== 0;
+    const marked = exists && readFileSync(target, "utf8").includes(`kj:managed:hook:${hook}`);
+    const detail = !exists ? "missing" : !executable ? "not executable" : !marked ? "no kj marker" : "ok";
+    checks.push({ id: `hook:${hook}`, ok: exists && executable && marked, detail });
+  }
+
+  return { ok: checks.every((c) => c.ok), checks };
+}

--- a/tests/harden/check.test.js
+++ b/tests/harden/check.test.js
@@ -1,0 +1,67 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkCommand } from "../../src/commands/check.js";
+import { checkHarden } from "../../src/harden/check.js";
+import { installHooks } from "../../src/harden/harden-engine.js";
+
+let repo;
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kj-check-"));
+  execFileSync("git", ["init", "-q"], { cwd: repo });
+});
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("checkHarden", () => {
+  it("passes on a freshly hardened repo", async () => {
+    await installHooks({ projectDir: repo, profile: "standard" });
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    expect(res.ok).toBe(true);
+    expect(res.checks.find((c) => c.id === "core.hooksPath").ok).toBe(true);
+  });
+
+  it("fails when the harness is absent", async () => {
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    expect(res.ok).toBe(false);
+    expect(res.checks.find((c) => c.id === "core.hooksPath").detail).toContain("run kj harden");
+  });
+
+  it("detects a deleted hook as drift", async () => {
+    await installHooks({ projectDir: repo, profile: "standard" });
+    rmSync(join(repo, ".karajan", "hooks", "pre-push"));
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    expect(res.ok).toBe(false);
+    expect(res.checks.find((c) => c.id === "hook:pre-push")).toMatchObject({ ok: false, detail: "missing" });
+  });
+
+  it("flags a hook that lost its kj marker", async () => {
+    await installHooks({ projectDir: repo, profile: "standard" });
+    writeFileSync(join(repo, ".karajan", "hooks", "commit-msg"), "#!/usr/bin/env sh\necho hi\n");
+    execFileSync("chmod", ["+x", join(repo, ".karajan", "hooks", "commit-msg")]);
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    expect(res.checks.find((c) => c.id === "hook:commit-msg")).toMatchObject({ ok: false, detail: "no kj marker" });
+  });
+});
+
+describe("checkCommand", () => {
+  it("returns 0 and prints OK when clean", async () => {
+    await installHooks({ projectDir: repo, profile: "standard" });
+    const logger = { info: vi.fn() };
+    expect(await checkCommand({ projectDir: repo, logger })).toBe(0);
+    expect(logger.info).toHaveBeenCalledWith("Harness OK.");
+  });
+
+  it("returns 1 on drift and emits JSON when asked", async () => {
+    const logger = { info: vi.fn() };
+    const code = await checkCommand({ projectDir: repo, json: true, logger });
+    expect(code).toBe(1);
+    expect(JSON.parse(logger.info.mock.calls.at(-1)[0]).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## H-E PR1 — KJC-TSK-0558 (épica KJC-PCS-0059)

`kj check` — verifica que el andamiaje que instaló `kj harden` sigue presente. Detecta deriva (alguien borró un hook, le quitó el marker, o cambió `core.hooksPath`).

- `src/harden/check.js` `checkHarden({projectDir, profile})`: comprueba que `core.hooksPath` apunta a `.karajan/hooks` y que cada hook del perfil existe, es ejecutable y conserva su marker `kj:managed`.
- `kj check` (`src/commands/check.js` + registro): tabla por check, **exit 0/1**, `--json` para CI.

6 pruebas: repo recién endurecido pasa; sin andamiaje falla con pista `run kj harden`; hook borrado → `missing`; hook sin marker → `no kj marker`; command devuelve 0/1 + JSON.

**Siguiente (PR2)**: checks de config + workflows + el aviso "hay lenguaje pero falta su config" (cierra el hueco del greenfield que comentamos). 141 LOC netas.