### PR TITLE
feat(harden): kj check verifies config + workflows + language gap (H-E.2)

### DIFF
--- a/src/harden/check.js
+++ b/src/harden/check.js
@@ -11,9 +11,19 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { runCommand } from "../utils/process.js";
+import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 import { PROFILE_HOOKS } from "./hook-templates.js";
+import { detectStackRoots } from "./stack-roots.js";
+import { qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
 
 const HOOKS_DIR = join(".karajan", "hooks");
+const WORKFLOWS_DIR = join(".github", "workflows");
+
+/** A config/workflow file just needs to be present (it may be user-owned). */
+function presence(projectDir, rel, id, miss) {
+  const ok = existsSync(join(projectDir, rel));
+  return { id, ok, detail: ok ? "ok" : miss };
+}
 
 export async function checkHarden({ projectDir = process.cwd(), profile = "standard" } = {}) {
   const checks = [];
@@ -33,6 +43,27 @@ export async function checkHarden({ projectDir = process.cwd(), profile = "stand
     const marked = exists && readFileSync(target, "utf8").includes(`kj:managed:hook:${hook}`);
     const detail = !exists ? "missing" : !executable ? "not executable" : !marked ? "no kj marker" : "ok";
     checks.push({ id: `hook:${hook}`, ok: exists && executable && marked, detail });
+  }
+
+  // Config + workflows ship with standard+ — and surface the greenfield gap:
+  // a language now present but never hardened ⇒ its config shows as missing.
+  if (profile !== "minimal") {
+    const roots = detectStackRoots(projectDir);
+    for (const cfg of UNIVERSAL_CONFIGS) {
+      checks.push(presence(projectDir, cfg.file, `config:${cfg.file}`, "missing — run kj harden"));
+    }
+    for (const { dir, language } of roots) {
+      for (const cfg of CONFIGS_BY_LANGUAGE[language] ?? []) {
+        const rel = dir === "." ? cfg.file : join(dir, cfg.file);
+        checks.push(presence(projectDir, rel, `config:${rel}`, `missing for ${language} — run kj harden`));
+      }
+    }
+    const expectedWf = [...WORKFLOWS];
+    const quality = qualityWorkflowFor(roots[0]?.language ?? null);
+    if (quality) expectedWf.push(quality);
+    for (const wf of expectedWf) {
+      checks.push(presence(projectDir, join(WORKFLOWS_DIR, wf.file), `workflow:${wf.file}`, "missing — run kj harden"));
+    }
   }
 
   return { ok: checks.every((c) => c.ok), checks };

--- a/tests/harden/check.test.js
+++ b/tests/harden/check.test.js
@@ -6,12 +6,15 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { checkCommand } from "../../src/commands/check.js";
+import { hardenCommand } from "../../src/commands/harden.js";
 import { checkHarden } from "../../src/harden/check.js";
-import { installHooks } from "../../src/harden/harden-engine.js";
 
 let repo;
+const logger = { info: vi.fn(), error: vi.fn() };
+const harden = () => hardenCommand({ projectDir: repo, logger });
 
 beforeEach(() => {
+  vi.clearAllMocks();
   repo = mkdtempSync(join(tmpdir(), "kj-check-"));
   execFileSync("git", ["init", "-q"], { cwd: repo });
 });
@@ -21,10 +24,11 @@ afterEach(() => {
 
 describe("checkHarden", () => {
   it("passes on a freshly hardened repo", async () => {
-    await installHooks({ projectDir: repo, profile: "standard" });
+    await harden();
     const res = await checkHarden({ projectDir: repo, profile: "standard" });
     expect(res.ok).toBe(true);
-    expect(res.checks.find((c) => c.id === "core.hooksPath").ok).toBe(true);
+    expect(res.checks.find((c) => c.id === "config:.editorconfig").ok).toBe(true);
+    expect(res.checks.find((c) => c.id === "workflow:kj-no-ai-attribution.yml").ok).toBe(true);
   });
 
   it("fails when the harness is absent", async () => {
@@ -34,32 +38,39 @@ describe("checkHarden", () => {
   });
 
   it("detects a deleted hook as drift", async () => {
-    await installHooks({ projectDir: repo, profile: "standard" });
+    await harden();
     rmSync(join(repo, ".karajan", "hooks", "pre-push"));
     const res = await checkHarden({ projectDir: repo, profile: "standard" });
-    expect(res.ok).toBe(false);
     expect(res.checks.find((c) => c.id === "hook:pre-push")).toMatchObject({ ok: false, detail: "missing" });
   });
 
   it("flags a hook that lost its kj marker", async () => {
-    await installHooks({ projectDir: repo, profile: "standard" });
+    await harden();
     writeFileSync(join(repo, ".karajan", "hooks", "commit-msg"), "#!/usr/bin/env sh\necho hi\n");
     execFileSync("chmod", ["+x", join(repo, ".karajan", "hooks", "commit-msg")]);
     const res = await checkHarden({ projectDir: repo, profile: "standard" });
     expect(res.checks.find((c) => c.id === "hook:commit-msg")).toMatchObject({ ok: false, detail: "no kj marker" });
   });
+
+  it("surfaces a newly added language whose config was never seeded (greenfield gap)", async () => {
+    await harden(); // empty repo → only universal config
+    writeFileSync(join(repo, "go.mod"), "module example.com/x\n");
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    expect(res.ok).toBe(false);
+    const goCfg = res.checks.find((c) => c.id === "config:.golangci.yml");
+    expect(goCfg).toMatchObject({ ok: false });
+    expect(goCfg.detail).toContain("go");
+  });
 });
 
 describe("checkCommand", () => {
   it("returns 0 and prints OK when clean", async () => {
-    await installHooks({ projectDir: repo, profile: "standard" });
-    const logger = { info: vi.fn() };
+    await harden();
     expect(await checkCommand({ projectDir: repo, logger })).toBe(0);
     expect(logger.info).toHaveBeenCalledWith("Harness OK.");
   });
 
   it("returns 1 on drift and emits JSON when asked", async () => {
-    const logger = { info: vi.fn() };
     const code = await checkCommand({ projectDir: repo, json: true, logger });
     expect(code).toBe(1);
     expect(JSON.parse(logger.info.mock.calls.at(-1)[0]).ok).toBe(false);


### PR DESCRIPTION
## H-E PR2 — KJC-TSK-0558 (épica KJC-PCS-0059), cierra H-E

`kj check` ahora verifica también (en perfil standard+):
- **Config universal** presente: `.editorconfig`, `commitlint.config.js`.
- **Config de cada lenguaje** detectado, dentro de su carpeta (eslint/prettier, ruff, golangci).
- **Workflows de CI** presentes: `kj-no-ai-attribution.yml` + `kj-quality.yml` del lenguaje primario.

**Cierra el hueco del greenfield** que comentamos: si endureces un repo vacío y luego añades código Go, `kj check` ve la raíz Go pero su `.golangci.yml` falta → falla con `missing for go — run kj harden`. Ese es justo el aviso de re-ejecutar que faltaba.

Presencia basta (un config puede ser del usuario, no se exige marker). 58 pruebas verdes; las de check ahora ejercitan el `hardenCommand` completo. 42 LOC netas.

**H-E queda cerrada.**