### PR TITLE
feat(harden): kj init installs the harness via the shared engine (H-G)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -30,6 +30,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--no-rtk", "Skip the RTK auto-install (token savings on Bash outputs). Karajan still runs but burns more tokens")
     .option("--no-squeezr", "Skip the Squeezr auto-install (context compression). Karajan still runs but burns more tokens")
     .option("--no-qmd", "Skip the QMD auto-install + collection registration (semantic wiki over docs/, .reviews/ and plans/)")
+    .option("--no-harden", "Skip the quality harness (git hooks, lint/commit config, CI gates, agent guidelines)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -21,6 +21,8 @@ import { detectAiTrash, installAiTrashHook } from "../utils/ai-trash.js";
 import { detectQmd } from "../utils/qmd-detect.js";
 import { installQmd } from "../utils/qmd-install.js";
 import { registerQmdCollections } from "../utils/qmd-collection.js";
+import { isGitRepo } from "../harden/harden-engine.js";
+import { hardenCommand } from "./harden.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { bootstrapSonarToken } from "../sonar/token-bootstrap.js";
 
@@ -833,6 +835,19 @@ export async function initCommand({ logger, flags = {} }) {
 
   await setupSonarQube(config, logger, { interactive });
   await scaffoldCiGateway(config, flags, logger);
+
+  // Install the quality harness (git hooks, lint/format/commit config, CI
+  // quality gates, agent guidelines) through the SAME engine as `kj harden`,
+  // so init and harden never drift. Opt-out: --no-harden. Needs a git repo.
+  const skipHarden = flags?.noHarden === true || flags?.harden === false;
+  if (skipHarden) {
+    logger.info("Quality harness skipped (--no-harden).");
+  } else if (isGitRepo(process.cwd())) {
+    logger.info("Installing quality harness (kj harden)...");
+    await hardenCommand({ projectDir: process.cwd(), logger });
+  } else {
+    logger.info("Not a git repository — run `kj harden` after `git init` to add the quality harness.");
+  }
 
   // Persist any changes setupSonarQube made (token, etc.) back to disk.
   // Use writeInitConfig so the deprecated `sonarqube.enabled` key —

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -73,6 +73,12 @@ vi.mock("../src/utils/squeezr-install.js", () => ({
   installSqueezr: vi.fn().mockResolvedValue({ ok: true, version: "squeezr 1.46.3", error: null })
 }));
 
+// initCommand runs in the test process cwd (the repo). Mock the harness so it
+// never hardens the real working tree during unit tests.
+vi.mock("../src/commands/harden.js", () => ({
+  hardenCommand: vi.fn().mockResolvedValue({ ok: true })
+}));
+
 describe("initCommand", () => {
   let initCommand;
   let loadConfig, writeConfig;
@@ -141,6 +147,28 @@ describe("initCommand", () => {
 
     expect(writeConfig).toHaveBeenCalled();
     expect(createWizard).not.toHaveBeenCalled();
+  });
+
+  it("installs the quality harness via the shared harden engine", async () => {
+    isTTY.mockReturnValue(true);
+    loadConfig.mockResolvedValue({
+      config: { coder: "claude", reviewer: "codex", roles: { coder: {}, reviewer: {} }, pipeline: {}, sonarqube: { enabled: false }, development: { methodology: "tdd" } },
+      exists: false
+    });
+    const { hardenCommand } = await import("../src/commands/harden.js");
+    await initCommand({ logger, flags: { noInteractive: true } });
+    expect(hardenCommand).toHaveBeenCalled();
+  });
+
+  it("skips the harness with --no-harden", async () => {
+    isTTY.mockReturnValue(true);
+    loadConfig.mockResolvedValue({
+      config: { coder: "claude", reviewer: "codex", roles: { coder: {}, reviewer: {} }, pipeline: {}, sonarqube: { enabled: false }, development: { methodology: "tdd" } },
+      exists: false
+    });
+    const { hardenCommand } = await import("../src/commands/harden.js");
+    await initCommand({ logger, flags: { noInteractive: true, harden: false } });
+    expect(hardenCommand).not.toHaveBeenCalled();
   });
 
   it("runs wizard when interactive and config does not exist", async () => {

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -145,6 +145,11 @@ vi.mock("../src/utils/git.js", () => ({
   ensureGitRepo: vi.fn().mockResolvedValue(true)
 }));
 
+// init runs in the repo cwd; mock the harness so it never hardens the tree.
+vi.mock("../src/commands/harden.js", () => ({
+  hardenCommand: vi.fn().mockResolvedValue({ ok: true })
+}));
+
 describe("installer E2E: init → doctor", () => {
   const logger = {
     debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn()


### PR DESCRIPTION
## H-G — KJC-TSK-0560 (épica KJC-PCS-0059)

`kj init` ahora ejecuta el **mismo motor** que `kj harden` tras el scaffolding, de modo que init y harden comparten una única fuente de verdad para hooks, config, gates de CI y guías de agentes — sin duplicar lógica ni divergir.

- Tras `scaffoldCiGateway`, init llama a `hardenCommand({projectDir})`, guardado por `isGitRepo` (si no es repo git, avisa de ejecutar `kj harden` tras `git init`).
- Nuevo `--no-harden` para desactivar.

**Fix de seguridad de tests**: `initCommand` corre en el cwd del proceso (la raíz del repo en los unit tests). Los tests de init ahora **mockean `hardenCommand`** para no endurecer el árbol real durante los tests (verificado: el repo queda limpio tras correrlos). Dos pruebas nuevas afirman el cableado (se llama por defecto; se omite con `--no-harden`).

49 LOC netas.

**Con esto la épica KJC-PCS-0059 queda completa** (H-A..H-G + H-B2 + H-C2). Pendiente solo: docs/landing (repo karajan-landing, aparte).