### PR TITLE
docs(harden): document kj harden + kj check in GETTING-STARTED (H-G)

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -110,6 +110,8 @@ kj audit                     # Audit whole codebase
 kj status                    # Current session
 kj resume <session-id>       # Resume paused
 kj doctor                    # Environment check
+kj harden                    # Install the quality harness (hooks, config, CI, guidelines)
+kj check                     # Verify the harness is present and intact
 
 # Plan management (v2.5+)
 kj plan list                 # List plans for this project
@@ -127,6 +129,49 @@ kj board open                # Start + open in browser
 kj board status              # Check if running
 kj board stop                # Stop the board
 ```
+
+## Quality harness — `kj harden` + `kj check`
+
+`kj harden` brings the guardrails Karajan was built with to **any** repo — new
+or existing — in one command. It is idempotent, stack-aware, and never
+overwrites content you wrote: everything it manages lives inside `kj:managed`
+markers, so re-running only refreshes its own blocks.
+
+```bash
+kj harden                       # Install the standard profile
+kj harden --profile strict      # Add the shrink-budget gate too
+kj harden --dry-run             # Show what would change, write nothing
+kj harden --no-ci --no-guidelines   # Hooks + config only
+```
+
+What it installs (per the detected stack):
+
+- **Git hooks** under `.karajan/hooks/` (via `core.hooksPath`, so it never
+  fights husky): pre-commit lint+format, commit-msg (Conventional Commits +
+  100-char cap + AI-attribution block — pure POSIX, no Node), pre-push tests +
+  git-identity guard, post-merge reindex. **Native commands per language**
+  (`go vet`/`ruff`/`npm`…), so hardening a Go or Python repo never makes Node a
+  commit-time dependency.
+- **Config**: `.editorconfig`, `commitlint.config.js`, and per-language
+  lint/format (`eslint` with the ES2025 deprecated-API blacklist + `prettier`
+  for JS/TS, `ruff.toml` for Python, `.golangci.yml` for Go). In a fullstack
+  monorepo each language gets its config inside its own folder.
+- **CI workflows**: an AI-attribution gate, a stack-aware Quality workflow, and
+  (on `strict`/publishable packages) shrink-budget + pack-smoke.
+- **Agent guidelines**: a distilled rule set seeded into `AGENTS.md` and
+  `CLAUDE.md` (migrating any legacy block cleanly).
+
+`kj init` runs the same engine automatically, so a freshly initialised project
+is hardened out of the box (opt out with `kj init --no-harden`).
+
+```bash
+kj check            # Exit 0 if the harness is intact, non-zero + report on drift
+kj check --json     # Machine-readable, for CI
+```
+
+`kj check` catches drift — a deleted hook, a stripped marker, or a language you
+added after hardening whose config was never seeded — and tells you to re-run
+`kj harden`.
 
 ## Planning workflow (v2.5+)
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -110,6 +110,8 @@ kj audit                      # Auditar toda la base de código
 kj status                     # Estado de la sesión actual
 kj resume <session-id>        # Reanudar sesión pausada
 kj doctor                     # Comprobar entorno
+kj harden                     # Instalar el harness de calidad (hooks, config, CI, guías)
+kj check                      # Verificar que el harness está presente e íntegro
 
 # Gestión de planes (v2.5+)
 kj plan list                  # Listar planes del proyecto actual
@@ -127,6 +129,50 @@ kj board open                 # Iniciar + abrir en el navegador
 kj board status               # Comprobar si está corriendo
 kj board stop                 # Detener el board
 ```
+
+## Harness de calidad — `kj harden` + `kj check`
+
+`kj harden` lleva los guardrails con los que se construyó Karajan a **cualquier**
+repositorio —nuevo o existente— en un solo comando. Es idempotente, consciente
+del stack y nunca sobrescribe lo que tú escribiste: todo lo que gestiona vive
+entre marcadores `kj:managed`, así que al reejecutarlo solo refresca sus propios
+bloques.
+
+```bash
+kj harden                       # Instala el perfil standard
+kj harden --profile strict      # Añade además el gate de shrink-budget
+kj harden --dry-run             # Muestra qué cambiaría, sin escribir
+kj harden --no-ci --no-guidelines   # Solo hooks + config
+```
+
+Qué instala (según el stack detectado):
+
+- **Hooks de git** bajo `.karajan/hooks/` (vía `core.hooksPath`, sin pelear con
+  husky): pre-commit lint+formato, commit-msg (Conventional Commits + tope de
+  100 caracteres + bloqueo de atribución a IA — POSIX puro, sin Node), pre-push
+  tests + guardia de identidad, post-merge reindex. **Comandos nativos por
+  lenguaje** (`go vet`/`ruff`/`npm`…), de modo que endurecer un repo Go o Python
+  nunca convierte a Node en dependencia de commit.
+- **Config**: `.editorconfig`, `commitlint.config.js` y lint/formato por lenguaje
+  (`eslint` con la lista negra de APIs ES2025 obsoletas + `prettier` en JS/TS,
+  `ruff.toml` en Python, `.golangci.yml` en Go). En un monorepo fullstack cada
+  lenguaje recibe su config dentro de su propia carpeta.
+- **Workflows de CI**: gate de atribución a IA, workflow Quality por stack y
+  (en `strict`/paquetes publicables) shrink-budget + pack-smoke.
+- **Guías para agentes**: un conjunto de reglas destilado, sembrado en
+  `AGENTS.md` y `CLAUDE.md` (migrando limpiamente cualquier bloque heredado).
+
+`kj init` ejecuta el mismo motor automáticamente, así que un proyecto recién
+inicializado queda endurecido de serie (desactívalo con `kj init --no-harden`).
+
+```bash
+kj check            # Exit 0 si el harness está íntegro; ≠0 + reporte si hay deriva
+kj check --json     # Salida procesable, para CI
+```
+
+`kj check` detecta deriva —un hook borrado, un marker eliminado, o un lenguaje
+que añadiste después de endurecer y cuya config nunca se sembró— y te dice que
+reejecutes `kj harden`.
 
 ## Flujo de planificación (v2.5+)
 


### PR DESCRIPTION
## H-G docs — KJC-TSK-0560 (épica KJC-PCS-0059)

Segunda parte del AC de H-G: documentar la feature en GETTING-STARTED (EN + ES).

Nueva sección **Quality harness / Harness de calidad** que cubre:
- `kj harden` — perfiles (standard/strict), qué instala por stack, **comandos nativos por lenguaje** y la garantía de **no meter Node como dependencia de commit** en repos no-JS.
- `kj check` — gate de deriva, `--json`.
- Nota de que `kj init` ejecuta el mismo motor (auto-harden, `--no-harden` para desactivar).

Docs-only (`docs/**/*.md` excluidas del shrink-budget). La landing (repo karajan-landing, KJL) va aparte.

Cierra la parte de docs internas de H-G.