### PR TITLE
feat(agents): add Copilot and Pi agent support

### DIFF
--- a/src/agents/copilot-agent.js
+++ b/src/agents/copilot-agent.js
@@ -1,0 +1,90 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * Extract usage from Copilot CLI JSONL output.
+ * Copilot CLI with --output-format json emits JSONL (one JSON object per line).
+ * We look for the first message with usage information.
+ */
+function extractCopilotUsage(text) {
+  if (!text) return null;
+  
+  const lines = text.trim().split("\n");
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    try {
+      const obj = JSON.parse(t);
+      // Look for usage in various possible locations
+      const usage = obj?.usage 
+        ?? obj?.data?.usage
+        ?? obj?.result?.usage
+        ?? (obj?.type === "usage" ? obj : null);
+      
+      if (usage && typeof usage.prompt_tokens === "number") {
+        return {
+          tokens_in: usage.prompt_tokens,
+          tokens_out: usage.completion_tokens ?? 0,
+          cached_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export class CopilotAgent extends BaseAgent {
+  async runTask(task) {
+    const role = task.role || "coder";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model, false);
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Copilot model "${model}" not supported — retrying with agent default`);
+      return this._exec(task, null, false);
+    }
+    return result;
+  }
+
+  async reviewTask(task) {
+    const role = task.role || "reviewer";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model, true);
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Copilot model "${model}" not supported — retrying with agent default`);
+      return this._exec(task, null, true);
+    }
+    return result;
+  }
+
+  async _exec(task, model, _jsonFormat) {
+    const args = ["-p", task.prompt];
+    
+    // Use JSON output format for structured parsing
+    args.push("--output-format", "json");
+    
+    // Silent mode to reduce noise
+    args.push("--silent");
+    
+    // Allow all tools for autonomous operation
+    args.push("--allow-all");
+    
+    if (model) args.push("--model", model);
+    
+    const res = await this.runCommand(resolveBin("copilot"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs
+    });
+    
+    const usage = extractCopilotUsage(res.stdout) ?? extractCopilotUsage(res.stderr);
+    return { 
+      ok: res.exitCode === 0, 
+      output: res.stdout, 
+      error: res.stderr, 
+      exitCode: res.exitCode, 
+      ...(usage ?? {})
+    };
+  }
+}

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -3,6 +3,8 @@ import { CodexAgent } from "./codex-agent.js";
 import { GeminiAgent } from "./gemini-agent.js";
 import { AiderAgent } from "./aider-agent.js";
 import { OpenCodeAgent } from "./opencode-agent.js";
+import { CopilotAgent } from "./copilot-agent.js";
+import { PiAgent } from "./pi-agent.js";
 
 const agentRegistry = new Map();
 
@@ -49,3 +51,5 @@ registerAgent("codex", CodexAgent, { bin: "codex", installUrl: "https://develope
 registerAgent("gemini", GeminiAgent, { bin: "gemini", installUrl: "https://github.com/google-gemini/gemini-cli" });
 registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.chat/docs/install.html" });
 registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });
+registerAgent("copilot", CopilotAgent, { bin: "copilot", installUrl: "https://github.com/github/copilot-cli" });
+registerAgent("pi", PiAgent, { bin: "pi", installUrl: "https://pi.dev" });

--- a/src/agents/pi-agent.js
+++ b/src/agents/pi-agent.js
@@ -1,0 +1,116 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * Extract usage from Pi CLI JSONL output.
+ * Pi CLI with --mode json emits JSONL (one JSON object per line).
+ * We look for messages containing token usage information.
+ */
+function extractPiUsage(text) {
+  if (!text) return null;
+  
+  const lines = text.trim().split("\n");
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    
+    try {
+      const obj = JSON.parse(t);
+      
+      // Look for usage in various possible locations
+      const usage = obj?.usage 
+        ?? obj?.data?.usage
+        ?? obj?.result?.usage
+        ?? (obj?.type === "usage" ? obj : null);
+      
+      if (usage && typeof usage.prompt_tokens === "number") {
+        return {
+          tokens_in: usage.prompt_tokens,
+          tokens_out: usage.completion_tokens ?? 0,
+          cached_tokens: usage.prompt_tokens_details?.cached_tokens ?? 0
+        };
+      }
+    } catch {
+      continue;
+    }
+  }
+  
+  return null;
+}
+
+export class PiAgent extends BaseAgent {
+  /**
+   * Run a coding/agentic task through Pi CLI.
+   * @param {Object} task - Task object with prompt, role, timeout, etc.
+   * @returns {Promise<import("../types/agent.js").AgentResult>}
+   */
+  async runTask(task) {
+    const role = task.role || "coder";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model);
+    
+    // Retry with default model if specified model not supported
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Pi model "${model}" not supported — retrying with agent default`);
+      return this._exec(task, null);
+    }
+    
+    return result;
+  }
+
+  /**
+   * Run a review task through Pi CLI.
+   * @param {Object} task - Task object with prompt, role, timeout, etc.
+   * @returns {Promise<import("../types/agent.js").AgentResult>}
+   */
+  async reviewTask(task) {
+    const role = task.role || "reviewer";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model);
+    
+    // Retry with default model if specified model not supported
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Pi model "${model}" not supported — retrying with agent default`);
+      return this._exec(task, null);
+    }
+    
+    return result;
+  }
+
+  /**
+   * Execute a Pi CLI command in print mode.
+   * @param {Object} task - Task object with prompt, timeout, etc.
+   * @param {string|null} model - Model to use (null for default)
+   * @returns {Promise<import("../types/agent.js").AgentResult>}
+   */
+  async _exec(task, model) {
+    // Build arguments for Pi CLI
+    // Reference: https://pi.dev/docs/latest/usage
+    const args = ["-p"]; // Print mode: execute and exit
+    
+    if (model) {
+      args.push("--model", model);
+    }
+    
+    // Use JSON mode for structured output parsing
+    args.push("--mode", "json");
+    
+    const res = await this.runCommand(resolveBin("pi"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs,
+      input: task.prompt
+    });
+    
+    // Extract usage metrics from JSONL output
+    const usage = extractPiUsage(res.stdout) ?? extractPiUsage(res.stderr);
+    
+    return {
+      ok: res.exitCode === 0,
+      output: res.stdout,
+      error: res.stderr,
+      exitCode: res.exitCode,
+      ...(usage ?? {})
+    };
+  }
+}

--- a/src/orchestrator/post-loop-stages.js
+++ b/src/orchestrator/post-loop-stages.js
@@ -7,7 +7,7 @@ import { resetRetryCount } from "../session/mutators.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { invokeSolomon } from "./solomon-escalation.js";
 
-const KNOWN_AGENTS = ["claude", "codex", "gemini"];
+const KNOWN_AGENTS = ["claude", "codex", "gemini", "copilot", "pi"];
 
 /**
  * Build an ordered fallback chain for a role.

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -7,7 +7,9 @@ const KNOWN_AGENTS = [
   { name: "codex", install: getInstallCommand("codex") },
   { name: "gemini", install: getInstallCommand("gemini") },
   { name: "aider", install: getInstallCommand("aider") },
-  { name: "opencode", install: getInstallCommand("opencode") }
+  { name: "opencode", install: getInstallCommand("opencode") },
+  { name: "copilot", install: getInstallCommand("copilot") },
+  { name: "pi", install: getInstallCommand("pi") }
 ];
 
 export async function checkBinary(name, versionArg = "--version") {
@@ -18,10 +20,10 @@ export async function checkBinary(name, versionArg = "--version") {
 }
 
 export async function detectAvailableAgents() {
-  // PR-J (audit quick win): probe the 5 agent binaries in parallel
+  // PR-J (audit quick win): probe the agent binaries in parallel
   // via Promise.all instead of awaiting in a for-of. checkBinary is
   // a pure shell-out (no shared state), so serialising them was
-  // wasted latency. With 5 agents at ~80ms each: O(n) → O(1).
+  // wasted latency. With N agents at ~80ms each: O(n) → O(1).
   return Promise.all(
     KNOWN_AGENTS.map(async (agent) => {
       const check = await checkBinary(agent.name);
@@ -44,6 +46,8 @@ export function detectHostAgent() {
   if (process.env.CODEX_CLI === "1" || process.env.CODEX === "1") return "codex";
   if (process.env.GEMINI_CLI === "1") return "gemini";
   if (process.env.OPENCODE === "1") return "opencode";
+  if (process.env.COPILOT_CLI === "1") return "copilot";
+  if (process.env.PI_CLI === "1") return "pi";
   return null;
 }
 

--- a/tests/agents/agent-detect.test.js
+++ b/tests/agents/agent-detect.test.js
@@ -52,11 +52,14 @@ describe("agent-detect", () => {
     expect(gemini.version).toBeNull();
   });
 
-  it("KNOWN_AGENTS contains claude, codex, gemini, aider", () => {
+  it("KNOWN_AGENTS contains claude, codex, gemini, aider, copilot, pi", () => {
     const names = KNOWN_AGENTS.map((a) => a.name);
     expect(names).toContain("claude");
     expect(names).toContain("codex");
     expect(names).toContain("gemini");
     expect(names).toContain("aider");
+    expect(names).toContain("opencode");
+    expect(names).toContain("copilot");
+    expect(names).toContain("pi");
   });
 });


### PR DESCRIPTION
## Summary

- Add `CopilotAgent` class with JSONL usage parsing for Copilot CLI
- Add `PiAgent` class for pi.dev agent
- Register both agents in the agent registry

## Related

- PR-J (audit quick win)