### PR TITLE
chore: release v3.5.1 — first-class PHP in the quality harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-06-14
+
+Patch. PHP becomes a first-class language in the quality harness.
+
+### Added
+
+- **PHP support in `kj harden`** (KJC-TSK-0563): `detectStackRoots` now recognises `composer.json` → `php` (aligning the harden detector with `detectProjectStack`, which already knew it), and the harden maps gain PHP — native hook commands (`vendor/bin/phpstan analyse`, `php-cs-fixer fix --dry-run`, `vendor/bin/phpunit`), a `phpstan.neon` config (level 6) seeded as a `kj:managed` block, and a `setup-php` Quality CI workflow. A PHP repo is now hardened like JS/Python/Go — native tooling, no npm/Node imposed at commit time — and `kj check` inherits the PHP config drift checks automatically. The PHP RAG AST grammar (tree-sitter) is intentionally out of scope.
+
 ## [3.5.0] - 2026-06-14
 
 Minor. **Quality harness** — `kj harden` + `kj check` (epic KJC-PCS-0059): the guardrails Karajan was built with, installable into any repo (new or existing) in one command, then verifiable as a CI drift gate.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.5.0 released** — Quality harness: `kj harden` brings the guardrails Karajan was built with to any repo in one command — idempotent git hooks, lint/format/commit config, CI quality gates and agent guidelines, all stack-aware and behind `kj:managed` markers that never overwrite your content. Native per-language hook commands mean hardening a Go/Python/Java repo never makes Node a commit-time dependency. `kj check` verifies the harness as a CI drift gate, and `kj init` installs it out of the box. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.5.1 released** — PHP joins the quality harness as a first-class language: `kj harden` now detects `composer.json`, installs PHP-native hooks (`phpstan` / `php-cs-fixer` / `phpunit`), a `phpstan.neon` config and a `setup-php` CI workflow — same as JS/Python/Go, no npm/Node imposed at commit time. Builds on v3.5.0's quality harness (`kj harden` + `kj check`): idempotent git hooks, config, CI gates and agent guidelines for any repo, behind `kj:managed` markers. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.5.0
+kj --version    # 3.5.1
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.5.0
+kj --version    # 3.5.1
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.5.1 (patch)

PHP se suma a JS/Python/Go como lenguaje de primera en `kj harden` (KJC-TSK-0563, ya en main vía #1088): detección de `composer.json`, hooks nativos (`phpstan`/`php-cs-fixer`/`phpunit`), config `phpstan.neon`, workflow Quality `setup-php`.

### Checklist
- `package.json` 3.5.0 → **3.5.1** + lock
- `CHANGELOG.md` entrada 3.5.1
- `README.md` banner v3.5.1
- `docs/GETTING-STARTED.md` + `es/` versión
- arch stats regeneradas

### Verificación
- Suite completa verde (local).
- **`verify-pack` verde**: tarball 3.5.1 instala limpio + `kj --version`.

Tras merge: tag v3.5.1 + GH release + npm publish (OTP) + landing (con reorden descendente de Recent releases + PHP).