### PR TITLE
fix(init): scope-aware config-exists check + no cold scope question

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -686,16 +686,24 @@ export async function resolveConfigScope({ flags, interactive }) {
   if (flags?.global) return { configPath: getConfigPath(), scope: "global" };
   if (flags?.local) return { configPath: getProjectConfigPath(process.cwd()), scope: "local" };
   if (interactive) {
+    const globalPath = getConfigPath();
+    // KJC-BUG-0087: on a true first run (no global config yet) there is no
+    // meaningful choice — set up the global config and skip a cold question a
+    // newcomer has no context to answer. Only when a global already exists is
+    // "override just for this project?" an actual decision worth asking.
+    if (!(await exists(globalPath))) {
+      return { configPath: globalPath, scope: "global" };
+    }
     const wizard = createWizard();
     try {
       const choice = await wizard.select(
-        "Where do you want to save the config? (default: global)",
+        "You already have a global Karajan config. For this project, do you want to…",
         [
-          { value: "global", label: `Global (${getConfigPath()} — applies to all projects)` },
-          { value: "local",  label: `Local  (${getProjectConfigPath(process.cwd())} — overrides global for this project only)` },
+          { value: "global", label: "Use the global config (your default for every project)" },
+          { value: "local", label: `Override it just for this project (${getProjectConfigPath(process.cwd())})` },
         ]
       );
-      return { configPath: choice === "local" ? getProjectConfigPath(process.cwd()) : getConfigPath(), scope: choice };
+      return { configPath: choice === "local" ? getProjectConfigPath(process.cwd()) : globalPath, scope: choice };
     } finally {
       wizard.close();
     }
@@ -717,7 +725,11 @@ export async function initCommand({ logger, flags = {} }) {
   const reviewRulesPath = path.resolve(karajanDir, "review-rules.md");
   const coderRulesPath = path.resolve(karajanDir, "coder-rules.md");
 
-  const { config, exists: configExists } = await loadConfig();
+  const { config } = await loadConfig();
+  // KJC-BUG-0087: ask "reconfigure?" only when a config exists AT THE CHOSEN
+  // scope path — not when the global cascade has one. Picking local scope in a
+  // fresh dir must not report the unrelated global config as "already exists".
+  const configExists = await exists(configPath);
 
   // Auto-detect language from OS locale for non-interactive mode
   if (!interactive && !configExists) {

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -192,7 +192,7 @@ describe("initCommand", () => {
       ask: vi.fn().mockResolvedValue(""),  // branch_prefix only asked if auto_commit
       confirm: vi.fn().mockResolvedValue(false),
       select: vi.fn()
-        .mockResolvedValueOnce("global")       // KJC-TSK-0395: config scope
+        // KJC-BUG-0087: first run (no global config) no longer asks scope.
         .mockResolvedValueOnce("codex")        // coder
         .mockResolvedValueOnce("claude")       // reviewer
         // KJC-TSK-0367: 10 per-role selects (planner, researcher,
@@ -219,8 +219,9 @@ describe("initCommand", () => {
     await initCommand({ logger, flags: {} });
 
     expect(detectAvailableAgents).toHaveBeenCalled();
-    // 1 (KJC-TSK-0395 scope) + 2 (agents) + 10 (per-role) + 3 (methodology/pipelineLang/huLang) = 16
-    expect(mockWizard.select).toHaveBeenCalledTimes(16);
+    // KJC-BUG-0087: no scope question on first run. 2 (agents) + 10 (per-role)
+    // + 3 (methodology/pipelineLang/huLang) = 15
+    expect(mockWizard.select).toHaveBeenCalledTimes(15);
     expect(writeConfig).toHaveBeenCalled();
     const writtenConfig = writeConfig.mock.calls[0][1];
     expect(writtenConfig.coder).toBe("codex");
@@ -237,8 +238,13 @@ describe("initCommand", () => {
     mockWizard.close();
   });
 
-  it("asks to reconfigure when config already exists", async () => {
+  it("asks to reconfigure when a config exists at the chosen scope path", async () => {
     isTTY.mockReturnValue(true);
+    // KJC-BUG-0087: the prompt now keys off existence AT THE CHOSEN PATH.
+    // exists() true means the config file at configPath is present. --global
+    // pins the scope so no scope question is asked.
+    const { exists } = await import("../src/utils/fs.js");
+    exists.mockResolvedValue(true);
     loadConfig.mockResolvedValue({
       config: {
         coder: "claude",
@@ -259,7 +265,7 @@ describe("initCommand", () => {
     };
     createWizard.mockReturnValue(mockWizard);
 
-    await initCommand({ logger, flags: {} });
+    await initCommand({ logger, flags: { global: true } });
 
     expect(mockWizard.confirm).toHaveBeenCalledWith(
       expect.stringContaining("Reconfigure"),
@@ -558,5 +564,38 @@ describe("writeInitConfig — delegates to writeConfig (KJC-BUG-0034 / 0036)", (
     await writeInitConfig("/tmp/kj.config.yml", config);
     expect(config.sonarqube.enabled).toBe(false);
     expect(config.sonarqube.host).toBe("http://localhost:9000");
+  });
+});
+
+describe("resolveConfigScope (KJC-BUG-0087)", () => {
+  let resolveConfigScope, exists, createWizard;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ resolveConfigScope } = await import("../src/commands/init.js"));
+    ({ exists } = await import("../src/utils/fs.js"));
+    ({ createWizard } = await import("../src/utils/wizard.js"));
+  });
+
+  it("honours explicit --global / --local without asking", async () => {
+    expect((await resolveConfigScope({ flags: { global: true }, interactive: true })).scope).toBe("global");
+    expect((await resolveConfigScope({ flags: { local: true }, interactive: true })).scope).toBe("local");
+    expect(createWizard).not.toHaveBeenCalled();
+  });
+
+  it("on a true first run (no global config) defaults to global WITHOUT a cold question", async () => {
+    exists.mockResolvedValue(false); // no global config yet
+    const res = await resolveConfigScope({ flags: {}, interactive: true });
+    expect(res.scope).toBe("global");
+    expect(createWizard).not.toHaveBeenCalled();
+  });
+
+  it("only asks the scope question when a global config already exists", async () => {
+    exists.mockResolvedValue(true); // global exists → override-for-this-project is a real choice
+    const select = vi.fn().mockResolvedValue("local");
+    createWizard.mockReturnValue({ select, close: vi.fn() });
+    const res = await resolveConfigScope({ flags: {}, interactive: true });
+    expect(createWizard).toHaveBeenCalled();
+    expect(res.scope).toBe("local");
   });
 });


### PR DESCRIPTION
## KJC-BUG-0087 — el "Config already exists" falso de `kj init`

**Repro**: `kj init` en un dir recién creado → elegir scope **local** → *"Config already exists. Reconfigure?"* aunque el config local NO existe.

**Causa raíz**: `loadConfig()` devuelve `exists = globalExists` (`src/config/loader.js:164`). `initCommand` usaba ese flag como `configExists`, así que si había un `~/.karajan/kj.config.yml` global de usos previos, la comprobación daba `true` **sea cual sea el scope elegido**. La pregunta miraba el sitio equivocado.

**Fix**:
1. `configExists = await exists(configPath)` — comprueba el **path del scope elegido**, no el global.
2. **UX**: en un primer arranque real (sin global) ya **no se pregunta** global/local en frío (un usuario nuevo no tiene contexto) → default global. La pregunta de scope solo aparece cuando ya hay un global, y **reformulada a la decisión real** ("usar el global / sobreescribir solo para este proyecto").

**Tests**: 4 de regresión de `resolveConfigScope` (flags, primer arranque sin pregunta, pregunta solo si hay global) + actualizadas las dos pruebas de init al nuevo mecanismo. 30/30 verde.

Lo básico, bien.