### PR TITLE
fix(init): gate per-role agent routing behind one advanced question

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -91,16 +91,28 @@ async function askAgents(wizard, available, config, logger) {
  * `available.length === 1` short-circuits: every role uses the only CLI
  * available, no point asking.
  */
-async function askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger) {
+async function askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger, ask = true) {
   if (available.length <= 1) return;
-
-  logger.info("");
-  logger.info("Configure provider per role (Enter accepts the default):");
 
   // Make sure containers exist for every role/pipeline key we touch —
   // older configs may have a sparser shape than DEFAULTS.
   config.roles = config.roles || {};
   config.pipeline = config.pipeline || {};
+
+  // KJC-TSK-0571: per-role provider selection is advanced. By default every
+  // role inherits its provider from coder/reviewer — a newcomer has no context
+  // to pick an agent for "refactorer" or "perf". Only init the containers.
+  if (!ask) {
+    for (const role of PER_ROLE_QUESTIONS) {
+      config.roles[role.key] = config.roles[role.key] || { provider: null, model: null };
+      if (role.pipelineKey) config.pipeline[role.pipelineKey] = config.pipeline[role.pipelineKey] || { enabled: false };
+    }
+    logger.info("  Agent routing: every role inherits from your coder/reviewer (default).");
+    return;
+  }
+
+  logger.info("");
+  logger.info("Configure provider per role (Enter accepts the default):");
 
   for (const role of PER_ROLE_QUESTIONS) {
     config.roles[role.key] = config.roles[role.key] || { provider: null, model: null };
@@ -348,8 +360,19 @@ async function runWizard(config, logger) {
     }
     logger.info(`  -> HU Board: ${enableHuBoard ? "enabled (auto-start on kj run)" : "disabled"}`);
 
-    await askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger);
-    await askFallbackChain(wizard, available, config, { coder, reviewer }, logger);
+    // KJC-TSK-0571: per-role providers + fallback chains are advanced and
+    // collapse a newcomer's first run by ~12 questions. Ask one gate; default
+    // off → every role inherits from coder/reviewer.
+    const advancedRouting =
+      available.length > 1 &&
+      (await wizard.confirm(
+        "Configure advanced agent routing (a different AI per role + fallback chains)? Most users don't need this.",
+        false
+      ));
+    await askPerRoleProviders(wizard, available, config, { coder, reviewer }, logger, advancedRouting);
+    if (advancedRouting) {
+      await askFallbackChain(wizard, available, config, { coder, reviewer }, logger);
+    }
     await askMethodology(wizard, config, logger);
     await askLanguages(wizard, config, logger);
 

--- a/tests/init-wizard.test.js
+++ b/tests/init-wizard.test.js
@@ -193,22 +193,10 @@ describe("initCommand", () => {
       confirm: vi.fn().mockResolvedValue(false),
       select: vi.fn()
         // KJC-BUG-0087: first run (no global config) no longer asks scope.
+        // KJC-TSK-0571: advanced agent routing is off by default (confirm→false),
+        // so the 10 per-role provider questions are skipped on a first run.
         .mockResolvedValueOnce("codex")        // coder
         .mockResolvedValueOnce("claude")       // reviewer
-        // KJC-TSK-0367: 10 per-role selects (planner, researcher,
-        // architect, tester, security, solomon, refactorer,
-        // impeccable, perf, hu_reviewer). Sentinel "__default__"
-        // means "inherit from coder/reviewer".
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
-        .mockResolvedValueOnce("__default__")
         .mockResolvedValueOnce("tdd")          // methodology
         .mockResolvedValueOnce("en")           // pipeline language
         .mockResolvedValueOnce("en"),          // HU language
@@ -219,9 +207,11 @@ describe("initCommand", () => {
     await initCommand({ logger, flags: {} });
 
     expect(detectAvailableAgents).toHaveBeenCalled();
-    // KJC-BUG-0087: no scope question on first run. 2 (agents) + 10 (per-role)
-    // + 3 (methodology/pipelineLang/huLang) = 15
-    expect(mockWizard.select).toHaveBeenCalledTimes(15);
+    // KJC-BUG-0087 + KJC-TSK-0571: no scope question, no per-role questions by
+    // default. 2 (agents) + 3 (methodology/pipelineLang/huLang) = 5
+    expect(mockWizard.select).toHaveBeenCalledTimes(5);
+    // per-role providers stay null (inherit) when advanced routing is declined
+    expect(writeConfig.mock.calls[0][1].roles.tester.provider).toBeNull();
     expect(writeConfig).toHaveBeenCalled();
     const writtenConfig = writeConfig.mock.calls[0][1];
     expect(writtenConfig.coder).toBe("codex");
@@ -597,5 +587,35 @@ describe("resolveConfigScope (KJC-BUG-0087)", () => {
     const res = await resolveConfigScope({ flags: {}, interactive: true });
     expect(createWizard).toHaveBeenCalled();
     expect(res.scope).toBe("local");
+  });
+});
+
+describe("askPerRoleProviders advanced gate (KJC-TSK-0571)", () => {
+  let askPerRoleProviders;
+  const logger = { info: vi.fn() };
+  const available = [
+    { name: "claude", available: true },
+    { name: "codex", available: true },
+  ];
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    ({ askPerRoleProviders } = (await import("../src/commands/init.js")).__test__);
+  });
+
+  it("ask=false initialises roles to inherit (provider null) WITHOUT asking", async () => {
+    const wizard = { select: vi.fn() };
+    const config = {};
+    await askPerRoleProviders(wizard, available, config, { coder: "claude", reviewer: "codex" }, logger, false);
+    expect(wizard.select).not.toHaveBeenCalled();
+    expect(config.roles.tester.provider).toBeNull();
+    expect(config.roles.architect.provider).toBeNull();
+  });
+
+  it("ask=true asks one question per role", async () => {
+    const wizard = { select: vi.fn().mockResolvedValue("__default__") };
+    const config = {};
+    await askPerRoleProviders(wizard, available, config, { coder: "claude", reviewer: "codex" }, logger, true);
+    expect(wizard.select).toHaveBeenCalledTimes(10);
   });
 });


### PR DESCRIPTION
## KJC-TSK-0571 — pase de UX de primer arranque (parte 1)

**Papercut (con evidencia)**: un primer `kj init` interactivo dispara ~20 interacciones, entre ellas **un proveedor por cada uno de 10 roles** (planner, researcher, architect, tester, security, solomon, refactorer, impeccable, perf, hu_reviewer) + cadena de fallback — **preguntas que un usuario nuevo no tiene contexto para responder**, y que por defecto solo "heredan de coder".

**Fix**: una sola pregunta gate — *"Configure advanced agent routing? Most users don't need this"* (default **off**). Apagado → cada rol hereda de coder/reviewer (provider null), sin preguntar; encendido → el flujo completo de antes. El primer arranque baja de ~20 interacciones a un puñado.

Alineado con la visión de autonomía y con feedback_defaults_over_per_project_config.

3 tests (gate off → 0 preguntas por rol + providers null; gate on → 10 preguntas) + actualizados los del wizard. 30/30 init verde.

Pendiente del pase: papercut #1 (`kj --help` con 36 comandos sin jerarquía) → PR aparte.