### PR TITLE
feat(harden): ignore demo/fixture dirs + --only/--exclude scope flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
   "engines": {
     "node": ">=22.22.1"
   },
+  "kj": {
+    "harden": {
+      "exclude": [
+        "wrappers",
+        "packages"
+      ]
+    }
+  },
   "workspaces": [
     "packages/ai-trash",
     "packages/core",

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -406,6 +406,8 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-config", "Skip lint/format/commit config files (hooks only)")
     .option("--no-ci", "Skip CI quality workflows")
     .option("--no-guidelines", "Skip AI-agent guideline files (AGENTS.md/CLAUDE.md)")
+    .option("--only <dirs...>", "Harden only these language roots (e.g. frontend backend)")
+    .option("--exclude <globs...>", "Skip language roots matching these globs (e.g. wrappers)")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
     .action(async (flags) => {
@@ -415,6 +417,8 @@ export function registerMeta(program, { pkgVersion }) {
           config: flags.config !== false,
           ci: flags.ci !== false,
           guidelines: flags.guidelines !== false,
+          only: flags.only ?? [],
+          exclude: flags.exclude ?? [],
           dryRun: Boolean(flags.dryRun),
           json: Boolean(flags.json),
           logger,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -24,6 +24,21 @@ const JS_TEST_CMD = {
 };
 
 /**
+ * Per-repo harden scope, persisted in package.json `kj.harden` so a repo with
+ * sub-tools (e.g. a python wrapper) excludes them once instead of on every
+ * invocation (KJC-TSK-0564). CLI flags are merged on top.
+ */
+function readHardenConfig(projectDir) {
+  const pkgPath = join(projectDir, "package.json");
+  if (!existsSync(pkgPath)) return {};
+  try {
+    return JSON.parse(readFileSync(pkgPath, "utf8")).kj?.harden ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Resolve the hook's lint/format/test commands for the primary language.
  * Non-JS stacks use their native toolchain (go/ruff/…); JS/TS is built from
  * the project's own package.json scripts so no npm command is ever assumed.
@@ -60,9 +75,14 @@ export async function hardenCommand({
   guidelines = true,
   dryRun = false,
   json = false,
+  only = [],
+  exclude = [],
   logger = console,
 } = {}) {
-  const roots = detectStackRoots(projectDir);
+  const repoCfg = readHardenConfig(projectDir);
+  const onlyDirs = [...(repoCfg.only ?? []), ...only];
+  const excludeDirs = [...(repoCfg.exclude ?? []), ...exclude];
+  const roots = detectStackRoots(projectDir, { only: onlyDirs, exclude: excludeDirs });
   const cmds = await resolveCmds(projectDir, roots[0]?.language ?? null);
   let result;
   try {

--- a/src/harden/stack-roots.js
+++ b/src/harden/stack-roots.js
@@ -21,8 +21,37 @@ const IGNORE_DIRS = new Set([
   "target",
   "__pycache__",
   "venv",
+  // Auxiliary code that isn't the app to harden (KJC-TSK-0564): demo/fixture
+  // dirs ship their own throwaway manifests and must not seed lint/CI config.
+  "examples",
+  "example",
+  "fixtures",
+  "samples",
+  "third_party",
+  "testdata",
+  "__fixtures__",
 ]);
 const DEFAULT_MAX_DEPTH = 2;
+
+/**
+ * Minimal glob for harden scope flags — no dynamic RegExp (eslint security).
+ * Matches on exact equality, directory prefix (`wrappers` ⊇ `wrappers/python`)
+ * and `*` wildcards anchored at both ends unless the `*` is leading/trailing.
+ */
+export function matchesGlob(value, pattern) {
+  if (value === pattern || value.startsWith(`${pattern}/`)) return true;
+  if (!pattern.includes("*")) return false;
+  const pieces = pattern.split("*");
+  let idx = 0;
+  for (let i = 0; i < pieces.length; i += 1) {
+    const piece = pieces[i];
+    if (!piece) continue;
+    const at = value.indexOf(piece, idx);
+    if (at === -1 || (i === 0 && at !== 0)) return false;
+    idx = at + piece.length;
+  }
+  return pattern.endsWith("*") || value.length === idx;
+}
 
 /** Identify the language of a single directory by its manifest files. */
 export function languageAt(dir) {
@@ -43,7 +72,7 @@ export function languageAt(dir) {
   return null;
 }
 
-export function detectStackRoots(projectDir, { maxDepth = DEFAULT_MAX_DEPTH } = {}) {
+export function detectStackRoots(projectDir, { maxDepth = DEFAULT_MAX_DEPTH, only = [], exclude = [] } = {}) {
   const found = [];
   function walk(dir, depth) {
     const language = languageAt(dir);
@@ -69,7 +98,8 @@ export function detectStackRoots(projectDir, { maxDepth = DEFAULT_MAX_DEPTH } = 
     const cur = byLanguage.get(f.language);
     if (!cur || f.depth < cur.depth) byLanguage.set(f.language, f);
   }
-  return [...byLanguage.values()]
-    .map(({ dir, language }) => ({ dir, language }))
-    .sort((a, b) => a.dir.localeCompare(b.dir));
+  let roots = [...byLanguage.values()].map(({ dir, language }) => ({ dir, language }));
+  if (only.length) roots = roots.filter((r) => only.some((o) => matchesGlob(r.dir, o)));
+  if (exclude.length) roots = roots.filter((r) => !exclude.some((g) => matchesGlob(r.dir, g)));
+  return roots.sort((a, b) => a.dir.localeCompare(b.dir));
 }

--- a/tests/commands/harden.test.js
+++ b/tests/commands/harden.test.js
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -53,6 +53,26 @@ describe("hardenCommand", () => {
     expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(false);
     const payload = JSON.parse(logger.info.mock.calls.at(-1)[0]);
     expect(payload).toMatchObject({ ok: true, profile: "minimal", dryRun: true });
+  });
+
+  const seedPythonWrapper = () => {
+    mkdirSync(join(repo, "wrappers", "python"), { recursive: true });
+    writeFileSync(join(repo, "wrappers", "python", "pyproject.toml"), "");
+  };
+
+  it("honours kj.harden.exclude from package.json (KJC-TSK-0564)", async () => {
+    writeFileSync(join(repo, "package.json"), JSON.stringify({ kj: { harden: { exclude: ["wrappers"] } } }));
+    seedPythonWrapper();
+    const res = await hardenCommand({ projectDir: repo, profile: "standard", json: true, logger });
+    expect(res.ok).toBe(true);
+    expect(res.configs.some((c) => c.file.includes("wrappers"))).toBe(false);
+  });
+
+  it("--exclude flag skips a language root (KJC-TSK-0564)", async () => {
+    writeFileSync(join(repo, "package.json"), "{}");
+    seedPythonWrapper();
+    const res = await hardenCommand({ projectDir: repo, exclude: ["wrappers"], json: true, logger });
+    expect(res.configs.some((c) => c.file.includes("wrappers"))).toBe(false);
   });
 
   it("returns ok:false on a non-repo dir without throwing", async () => {

--- a/tests/harden/stack-roots.test.js
+++ b/tests/harden/stack-roots.test.js
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { detectStackRoots } from "../../src/harden/stack-roots.js";
+import { detectStackRoots, matchesGlob } from "../../src/harden/stack-roots.js";
 
 let root;
 const touch = (rel, content = "") => {
@@ -69,5 +69,46 @@ describe("detectStackRoots", () => {
     touch("node_modules/somepkg/package.json", "{}");
     touch("dist/package.json", "{}");
     expect(detectStackRoots(root)).toEqual([]);
+  });
+
+  it("ignores demo/fixture dirs by default (KJC-TSK-0564)", () => {
+    touch("package.json", "{}");
+    touch("examples/dni-validator/package.json", "{}");
+    touch("wrappers/python/pyproject.toml", "");
+    // examples/* is ignored; wrappers/* is not auto-ignored (needs a flag).
+    expect(detectStackRoots(root)).toEqual([
+      { dir: ".", language: "javascript" },
+      { dir: join("wrappers", "python"), language: "python" },
+    ]);
+  });
+
+  it("--exclude drops a language root by dir prefix", () => {
+    touch("package.json", "{}");
+    touch("wrappers/python/pyproject.toml", "");
+    expect(detectStackRoots(root, { exclude: ["wrappers"] })).toEqual([
+      { dir: ".", language: "javascript" },
+    ]);
+  });
+
+  it("--only restricts to the named roots", () => {
+    touch("frontend/package.json", "{}");
+    touch("backend/pyproject.toml", "");
+    expect(detectStackRoots(root, { only: ["backend"] })).toEqual([
+      { dir: "backend", language: "python" },
+    ]);
+  });
+});
+
+describe("matchesGlob", () => {
+  it("matches exact and directory-prefix", () => {
+    expect(matchesGlob("wrappers", "wrappers")).toBe(true);
+    expect(matchesGlob("wrappers/python", "wrappers")).toBe(true);
+    expect(matchesGlob("wrappersx", "wrappers")).toBe(false);
+  });
+
+  it("honours * wildcards anchored at both ends", () => {
+    expect(matchesGlob("packages/ai-trash", "packages/*")).toBe(true);
+    expect(matchesGlob("apps/web", "packages/*")).toBe(false);
+    expect(matchesGlob("anything", "*")).toBe(true);
   });
 });


### PR DESCRIPTION
Cierra **KJC-TSK-0564**.

## Qué

`kj harden` ya no siembra config en carpetas que no son la app:

- **Ignore por defecto**: `detectStackRoots` salta `examples`, `example`, `fixtures`, `samples`, `third_party`, `testdata`, `__fixtures__` (además de los `node_modules`/`dist`/`vendor`/… que ya saltaba). Estas carpetas traen sus propios manifests de usar y tirar y no deben generar lint/CI.
- **Flags de scope**: `--only <dirs...>` restringe el endurecimiento a esas raíces; `--exclude <globs...>` excluye raíces que casen el glob.
- **Defaults por repo**: `package.json` → `kj.harden.{only,exclude}`, para no teclear los flags en cada invocación. Los flags CLI se fusionan encima.
- **Dogfood karajan-code**: se excluye `wrappers` (wrapper Python) y `packages` (workspaces ya cubiertos por el tooling raíz). `kj harden` pasa de proponer `examples/dni-validator` + `wrappers/python` a un único harness en la raíz.

## Glob

Matcher minimalista sin `RegExp` dinámico (eslint security): igualdad exacta, prefijo de directorio (`wrappers` ⊇ `wrappers/python`) y comodín `*` anclado.

## Tests

- `stack-roots.test.js`: ignore de demo/fixture, `--only`, `--exclude`, y `matchesGlob` (exacto/prefijo/`*`).
- `harden.test.js`: `kj.harden.exclude` desde package.json + flag `--exclude`.

82/82 en suites tocadas. Net ~123 LOC.