### PR TITLE
feat(harden): advisory comparison engine (artifact classification)

### DIFF
--- a/src/harden/advisory.js
+++ b/src/harden/advisory.js
@@ -1,0 +1,113 @@
+/**
+ * advisory — per-artifact comparison engine for `kj harden` advisory mode
+ * (KJC-TSK-0565, épica KJC-PCS-0060). For each artifact harden manages it
+ * classifies the repo state: MISSING (no file nor equivalent), KJ_MANAGED (a
+ * kj:managed block, up to date or outdated vN) or USER_OWNED (the user's own,
+ * possibly in another format). Read-only; never writes or prints. The result
+ * feeds `--report` (Advisory B) / `--interactive` (Advisory C). Per-type
+ * improvement heuristics for USER_OWNED land in the follow-up slice (PR2).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { findManagedBlock } from "../utils/managed-markers.js";
+import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
+import { detectStackRoots } from "./stack-roots.js";
+
+const BLOCK_VERSION = 1; // current version every markered config ships at
+
+// Other filenames/formats for the same artifact, so kj never reports a false
+// "missing". `pkgKey` is a package.json field that can hold inline config.
+const EQUIVALENTS = {
+  commitlint: { files: [".commitlintrc", ".commitlintrc.js", ".commitlintrc.json", ".commitlintrc.yaml"], pkgKey: "commitlint" },
+  eslint: { files: ["eslint.config.mjs", ".eslintrc.js", ".eslintrc.cjs", ".eslintrc.json", ".eslintrc.yaml"], pkgKey: "eslintConfig" },
+  prettier: { files: [".prettierrc", ".prettierrc.js", ".prettierrc.yaml", "prettier.config.js"], pkgKey: "prettier" },
+};
+
+/** Build an artifact descriptor from a config-template entry. */
+function toArtifact(cfg) {
+  const id = cfg.blockId ?? "prettier"; // the only marker-less JSON config is prettier
+  return {
+    id,
+    file: cfg.file,
+    blockId: cfg.blockId ?? null,
+    currentVersion: cfg.blockId ? BLOCK_VERSION : null,
+    equivalents: EQUIVALENTS[id]?.files ?? [],
+    pkgKey: EQUIVALENTS[id]?.pkgKey ?? null,
+  };
+}
+
+/** Locate the user's file for an artifact under `searchDir`; null if absent. */
+function findArtifactFile(searchDir, artifact) {
+  for (const rel of [artifact.file, ...artifact.equivalents]) {
+    if (existsSync(join(searchDir, rel))) return rel;
+  }
+  if (artifact.pkgKey && existsSync(join(searchDir, "package.json"))) {
+    try {
+      if (JSON.parse(readFileSync(join(searchDir, "package.json"), "utf8"))[artifact.pkgKey] != null) {
+        return `package.json#${artifact.pkgKey}`;
+      }
+    } catch {
+      /* unreadable package.json → not a match */
+    }
+  }
+  return null;
+}
+
+/** Read the artifact body, or the JSON of an inline package.json key. */
+function readArtifactContent(searchDir, foundAt) {
+  const [file, key] = foundAt.split("#");
+  const raw = readFileSync(join(searchDir, file), "utf8");
+  if (!key) return raw;
+  try {
+    return JSON.stringify(JSON.parse(raw)[key] ?? null);
+  } catch {
+    return raw;
+  }
+}
+
+/** Map a classified state to a recommendation + human rationale. */
+function recommend(state) {
+  if (state.status === "MISSING") return { recommendation: "install", rationale: `kj would add ${state.file}`, mergeable: true };
+  if (state.status === "USER_OWNED") return { recommendation: "keep", rationale: "your own config — kept by default", mergeable: false };
+  if (state.upToDate) return { recommendation: "keep", rationale: `managed by kj (v${state.managedVersion}), up to date`, mergeable: false };
+  return { recommendation: "update", rationale: `kj v${state.currentVersion} available (you have v${state.managedVersion})`, mergeable: true };
+}
+
+/** Classify a single artifact found (or not) under `searchDir`. */
+export function classifyArtifact(searchDir, artifact) {
+  const foundAt = findArtifactFile(searchDir, artifact);
+  const base = { foundAt, managedVersion: null, upToDate: null, improvements: [] };
+  let state = { ...base, status: "MISSING" };
+  if (foundAt) {
+    const content = readArtifactContent(searchDir, foundAt);
+    if (artifact.blockId && content.includes(`kj:managed:${artifact.blockId}`)) {
+      const { version } = findManagedBlock(content, artifact.blockId);
+      state = { ...base, status: "KJ_MANAGED", managedVersion: version, upToDate: version != null && version >= artifact.currentVersion };
+    } else {
+      state = { ...base, status: "USER_OWNED" };
+    }
+  }
+  const head = { id: artifact.id, file: artifact.file, currentVersion: artifact.currentVersion };
+  return { ...head, ...state, ...recommend({ ...state, ...head }) };
+}
+
+/**
+ * Compare the whole repo against the kj standard, artifact by artifact:
+ * universal configs at the root, then each language's lint config inside its
+ * own root (monorepo-aware, mirroring installConfigsForRoots). `minimal`
+ * profile ships no config, so there is nothing to compare.
+ */
+export function compareHarden({ projectDir = process.cwd(), profile = "standard" } = {}) {
+  if (profile === "minimal") return { artifacts: [] };
+  const artifacts = UNIVERSAL_CONFIGS.map((cfg) => ({ dir: ".", ...classifyArtifact(projectDir, toArtifact(cfg)) }));
+  for (const { dir, language } of detectStackRoots(projectDir)) {
+    const searchDir = dir === "." ? projectDir : join(projectDir, dir);
+    for (const cfg of CONFIGS_BY_LANGUAGE[language] ?? []) {
+      const res = classifyArtifact(searchDir, toArtifact(cfg));
+      artifacts.push({ dir, ...res, foundAt: res.foundAt && dir !== "." ? join(dir, res.foundAt) : res.foundAt });
+    }
+  }
+  return { artifacts };
+}

--- a/tests/harden/advisory.test.js
+++ b/tests/harden/advisory.test.js
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildManagedBlock } from "../../src/utils/managed-markers.js";
+import { compareHarden } from "../../src/harden/advisory.js";
+
+let root;
+const touch = (rel, content = "") => {
+  const abs = join(root, rel);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content);
+};
+const run = () => compareHarden({ projectDir: root }).artifacts;
+const find = (artifacts, id, dir = ".") => artifacts.find((a) => a.id === id && a.dir === dir);
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "kj-advisory-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("compareHarden", () => {
+  it("reports MISSING for absent configs; JS configs need a package.json to be in scope", () => {
+    expect(find(run(), "commitlint")).toMatchObject({ status: "MISSING", recommendation: "install" });
+    expect(find(run(), "eslint")).toBeUndefined();
+    touch("package.json", "{}");
+    expect(find(run(), "eslint").status).toBe("MISSING");
+  });
+
+  it("flags a kj:managed config as up to date, an old one for update", () => {
+    touch("commitlint.config.js", buildManagedBlock({ blockId: "commitlint", version: 1, body: "export default {};", style: "slash" }));
+    expect(find(run(), "commitlint")).toMatchObject({ status: "KJ_MANAGED", managedVersion: 1, upToDate: true, recommendation: "keep" });
+    touch("commitlint.config.js", buildManagedBlock({ blockId: "commitlint", version: 0, body: "export default {};", style: "slash" }));
+    expect(find(run(), "commitlint")).toMatchObject({ upToDate: false, recommendation: "update" });
+  });
+
+  it("treats a user's own config as USER_OWNED, kept by default", () => {
+    touch("commitlint.config.js", "export default { rules: {} };");
+    expect(find(run(), "commitlint")).toMatchObject({ status: "USER_OWNED", recommendation: "keep" });
+  });
+
+  it("recognizes equivalent formats (legacy eslintrc, package.json key) — no false MISSING", () => {
+    touch("package.json", JSON.stringify({ prettier: { printWidth: 80 } }));
+    touch(".eslintrc.json", '{ "rules": {} }');
+    expect(find(run(), "eslint")).toMatchObject({ status: "USER_OWNED", foundAt: ".eslintrc.json" });
+    expect(find(run(), "prettier")).toMatchObject({ status: "USER_OWNED", foundAt: "package.json#prettier" });
+  });
+
+  it("classifies each language root with a dir-prefixed path; output is serializable", () => {
+    touch("frontend/package.json", "{}");
+    touch("frontend/eslint.config.js", "export default [];");
+    touch("backend/pyproject.toml", "");
+    const artifacts = run();
+    expect(find(artifacts, "eslint", "frontend")).toMatchObject({ status: "USER_OWNED", foundAt: join("frontend", "eslint.config.js") });
+    expect(find(artifacts, "ruff", "backend").status).toBe("MISSING");
+    expect(() => JSON.stringify(artifacts)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Parte de **KJC-TSK-0565** (Advisory A, épica KJC-PCS-0060) — PR1 de 2.

## Qué

Motor puro y read-only `src/harden/advisory.js` que clasifica, artefacto por artefacto, el estado del repo frente al estándar kj:

- **`MISSING`** — no hay fichero ni equivalente → recomienda `install`.
- **`KJ_MANAGED`** — hay un bloque `kj:managed`; distingue **al día** (`keep`) vs **desactualizado vN** (`update`), leyendo la versión con `findManagedBlock`.
- **`USER_OWNED`** — config propia del usuario → `keep` por defecto (advisory; default = no tocar lo del usuario).

**Reconoce formatos equivalentes** para no dar falsos *missing*: eslint flat vs legacy (`.eslintrc.*`), `.commitlintrc.{js,json,yaml}`, y config inline en keys de `package.json` (`prettier`/`eslintConfig`/`commitlint`).

**Monorepo-aware**: universal en la raíz, configs de lenguaje en su propia raíz (vía `detectStackRoots`), con `foundAt` prefijado por dir.

Salida serializable `{ id, file, dir, status, managedVersion, upToDate, currentVersion, foundAt, improvements, recommendation, rationale, mergeable }` — reutilizable por `kj harden --report` (Advisory B) y `--interactive` (Advisory C). No imprime ni escribe nada.

## Alcance

PR1 = clasificación + recomendación. **PR2** (mismo card) añade las **heurísticas de mejoras** por tipo para `USER_OWNED` (eslint ES2025, commitlint header/subject, prettier printWidth, editorconfig) — por eso `improvements: []` aquí.

## Tests

`tests/harden/advisory.test.js`: MISSING + scope JS, KJ_MANAGED al día/desactualizado, USER_OWNED, formatos equivalentes, monorepo + serializable. 73/73 en la suite harden. Net 175 LOC.