### PR TITLE
feat(harden): advisory improvement heuristics for user-owned configs

### DIFF
--- a/src/harden/advisory.js
+++ b/src/harden/advisory.js
@@ -25,6 +25,35 @@ const EQUIVALENTS = {
   prettier: { files: [".prettierrc", ".prettierrc.js", ".prettierrc.yaml", "prettier.config.js"], pkgKey: "prettier" },
 };
 
+// Concrete gains kj's standard would add to a USER_OWNED config, detected by
+// substring probes (no AST parse): each probe absent from the user's content
+// becomes one improvement. Heuristic by design — conservative, never a false
+// "you're missing this" when the signal is clearly present.
+const IMPROVEMENTS = {
+  eslint: [
+    { needle: "no-var", id: "no-var", detail: "bans var (ES2025: const/let)" },
+    { needle: "no-restricted-globals", id: "no-legacy-globals", detail: "bans alert/confirm/prompt, escape/unescape" },
+    { needle: "no-restricted-properties", id: "no-legacy-apis", detail: "bans document.write, substr" },
+  ],
+  commitlint: [
+    { needle: "header-max-length", id: "header-max-length", detail: "caps the commit header at 100 chars" },
+    { needle: "subject-case", id: "subject-case", detail: "enforces a lowercase subject" },
+  ],
+  prettier: [{ needle: "printWidth", id: "print-width", detail: "pins printWidth (consistent wrapping)" }],
+  editorconfig: [
+    { needle: "insert_final_newline", id: "final-newline", detail: "enforces a final newline" },
+    { needle: "charset", id: "charset", detail: "pins charset = utf-8" },
+    { needle: "trim_trailing_whitespace", id: "trim-trailing", detail: "trims trailing whitespace" },
+  ],
+};
+
+/** Improvements kj would add to the user's own config for `artifactId`. */
+function improvementsFor(artifactId, content) {
+  return (IMPROVEMENTS[artifactId] ?? [])
+    .filter((probe) => !content.includes(probe.needle))
+    .map(({ id, detail }) => ({ id, detail }));
+}
+
 /** Build an artifact descriptor from a config-template entry. */
 function toArtifact(cfg) {
   const id = cfg.blockId ?? "prettier"; // the only marker-less JSON config is prettier
@@ -70,7 +99,12 @@ function readArtifactContent(searchDir, foundAt) {
 /** Map a classified state to a recommendation + human rationale. */
 function recommend(state) {
   if (state.status === "MISSING") return { recommendation: "install", rationale: `kj would add ${state.file}`, mergeable: true };
-  if (state.status === "USER_OWNED") return { recommendation: "keep", rationale: "your own config — kept by default", mergeable: false };
+  if (state.status === "USER_OWNED") {
+    const n = state.improvements?.length ?? 0;
+    return n === 0
+      ? { recommendation: "keep", rationale: "your own config — already covers the kj standard", mergeable: false }
+      : { recommendation: "review", rationale: `your own config — kj could add ${n} improvement(s)`, mergeable: true };
+  }
   if (state.upToDate) return { recommendation: "keep", rationale: `managed by kj (v${state.managedVersion}), up to date`, mergeable: false };
   return { recommendation: "update", rationale: `kj v${state.currentVersion} available (you have v${state.managedVersion})`, mergeable: true };
 }
@@ -86,7 +120,7 @@ export function classifyArtifact(searchDir, artifact) {
       const { version } = findManagedBlock(content, artifact.blockId);
       state = { ...base, status: "KJ_MANAGED", managedVersion: version, upToDate: version != null && version >= artifact.currentVersion };
     } else {
-      state = { ...base, status: "USER_OWNED" };
+      state = { ...base, status: "USER_OWNED", improvements: improvementsFor(artifact.id, content) };
     }
   }
   const head = { id: artifact.id, file: artifact.file, currentVersion: artifact.currentVersion };

--- a/tests/harden/advisory.test.js
+++ b/tests/harden/advisory.test.js
@@ -38,9 +38,21 @@ describe("compareHarden", () => {
     expect(find(run(), "commitlint")).toMatchObject({ upToDate: false, recommendation: "update" });
   });
 
-  it("treats a user's own config as USER_OWNED, kept by default", () => {
+  it("lists concrete improvements for a thin USER_OWNED config", () => {
     touch("commitlint.config.js", "export default { rules: {} };");
-    expect(find(run(), "commitlint")).toMatchObject({ status: "USER_OWNED", recommendation: "keep" });
+    const commitlint = find(run(), "commitlint");
+    expect(commitlint).toMatchObject({ status: "USER_OWNED", recommendation: "review", mergeable: true });
+    expect(commitlint.improvements.map((i) => i.id)).toEqual(["header-max-length", "subject-case"]);
+  });
+
+  it("keeps a USER_OWNED config that already covers the kj standard", () => {
+    touch("commitlint.config.js", 'rules: { "header-max-length": 1, "subject-case": 2 }');
+    expect(find(run(), "commitlint")).toMatchObject({
+      status: "USER_OWNED",
+      recommendation: "keep",
+      improvements: [],
+      mergeable: false,
+    });
   });
 
   it("recognizes equivalent formats (legacy eslintrc, package.json key) — no false MISSING", () => {


### PR DESCRIPTION
Completa **KJC-TSK-0565** (Advisory A, épica KJC-PCS-0060) — PR2 de 2 (sobre #1095).

## Qué

Para los artefactos `USER_OWNED`, el motor ahora lista las **mejoras concretas** que aportaría el estándar kj, pieza a pieza (no un "lo machaco"):

- **eslint** → ¿prohíbe APIs obsoletas ES2025? (`no-var`, globals legacy `alert`/`escape`, props `document.write`/`substr`)
- **commitlint** → `header-max-length` (≤100) + `subject-case` (lowercase)
- **prettier** → `printWidth`
- **editorconfig** → `insert_final_newline`, `charset`, `trim_trailing_whitespace`

Detección por **sondas de substring** (sin parseo AST): cada sonda ausente del config del usuario se convierte en una mejora. Conservador por diseño — si la señal está claramente presente, no la marca como falta.

`recommend()` para `USER_OWNED`:
- con mejoras → `review` (`mergeable: true`) + rationale con el conteo
- ya cubre el estándar → `keep` (`mergeable: false`)

## Tests

`advisory.test.js`: config flaco lista `["header-max-length","subject-case"]` y recomienda `review`; config que ya cubre el estándar queda `keep`/`improvements: []`. 74/74 en la suite harden. Net 46 LOC.

Con esto el card cierra: el motor produce la estructura completa `{ status, recommendation, rationale, mergeable, improvements }` que consumirán Advisory B (`--report`) y C (`--interactive`).