### PR TITLE
feat(harden): kj harden --report — read-only advisory of gaps

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -408,6 +408,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-guidelines", "Skip AI-agent guideline files (AGENTS.md/CLAUDE.md)")
     .option("--only <dirs...>", "Harden only these language roots (e.g. frontend backend)")
     .option("--exclude <globs...>", "Skip language roots matching these globs (e.g. wrappers)")
+    .option("--report", "Read-only: show what kj would add/improve, change nothing")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
     .action(async (flags) => {
@@ -419,6 +420,7 @@ export function registerMeta(program, { pkgVersion }) {
           guidelines: flags.guidelines !== false,
           only: flags.only ?? [],
           exclude: flags.exclude ?? [],
+          report: Boolean(flags.report),
           dryRun: Boolean(flags.dryRun),
           json: Boolean(flags.json),
           logger,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { compareHarden, formatAdvisoryReport } from "../harden/advisory.js";
 import { installConfigsForRoots } from "../harden/config-engine.js";
 import { installGuidelines } from "../harden/guidelines-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
@@ -75,6 +76,7 @@ export async function hardenCommand({
   guidelines = true,
   dryRun = false,
   json = false,
+  report = false,
   only = [],
   exclude = [],
   logger = console,
@@ -82,6 +84,17 @@ export async function hardenCommand({
   const repoCfg = readHardenConfig(projectDir);
   const onlyDirs = [...(repoCfg.only ?? []), ...only];
   const excludeDirs = [...(repoCfg.exclude ?? []), ...exclude];
+
+  // --report is read-only: compare against the kj standard and print/emit the
+  // advisory (Advisory B, KJC-TSK-0566), honouring the same scope as an install
+  // so it never proposes a root that `kj harden` would skip. Writes nothing.
+  if (report) {
+    const result = compareHarden({ projectDir, profile, only: onlyDirs, exclude: excludeDirs });
+    if (json) logger.info?.(JSON.stringify(result));
+    else for (const line of formatAdvisoryReport(result)) logger.info?.(line);
+    return { ok: true, report: true, ...result };
+  }
+
   const roots = detectStackRoots(projectDir, { only: onlyDirs, exclude: excludeDirs });
   const cmds = await resolveCmds(projectDir, roots[0]?.language ?? null);
   let result;

--- a/src/harden/advisory.js
+++ b/src/harden/advisory.js
@@ -133,10 +133,10 @@ export function classifyArtifact(searchDir, artifact) {
  * own root (monorepo-aware, mirroring installConfigsForRoots). `minimal`
  * profile ships no config, so there is nothing to compare.
  */
-export function compareHarden({ projectDir = process.cwd(), profile = "standard" } = {}) {
+export function compareHarden({ projectDir = process.cwd(), profile = "standard", only = [], exclude = [] } = {}) {
   if (profile === "minimal") return { artifacts: [] };
   const artifacts = UNIVERSAL_CONFIGS.map((cfg) => ({ dir: ".", ...classifyArtifact(projectDir, toArtifact(cfg)) }));
-  for (const { dir, language } of detectStackRoots(projectDir)) {
+  for (const { dir, language } of detectStackRoots(projectDir, { only, exclude })) {
     const searchDir = dir === "." ? projectDir : join(projectDir, dir);
     for (const cfg of CONFIGS_BY_LANGUAGE[language] ?? []) {
       const res = classifyArtifact(searchDir, toArtifact(cfg));
@@ -144,4 +144,25 @@ export function compareHarden({ projectDir = process.cwd(), profile = "standard"
     }
   }
   return { artifacts };
+}
+
+const MARK = { install: "+", update: "↑", review: "~", keep: "✓" };
+
+/**
+ * Render a compareHarden() result as human-readable lines (Advisory B). Pure:
+ * returns an array of strings, prints nothing. One line per artifact, indented
+ * bullets for each improvement, then a one-line tally.
+ */
+export function formatAdvisoryReport({ artifacts = [] } = {}) {
+  if (artifacts.length === 0) return ["kj harden — nothing to compare (minimal profile or empty repo)."];
+  const lines = ["kj harden — advisory report (read-only)", ""];
+  const tally = { install: 0, update: 0, review: 0, keep: 0 };
+  for (const a of artifacts) {
+    tally[a.recommendation] = (tally[a.recommendation] ?? 0) + 1;
+    const path = a.foundAt ?? (a.dir === "." ? a.file : join(a.dir, a.file));
+    lines.push(`  ${MARK[a.recommendation] ?? "·"} ${a.recommendation.padEnd(7)} ${path} — ${a.rationale}`);
+    for (const imp of a.improvements ?? []) lines.push(`      • ${imp.detail}`);
+  }
+  lines.push("", `${artifacts.length} artifact(s) · ${tally.install} missing · ${tally.review} to review · ${tally.update} outdated · ${tally.keep} ok`);
+  return lines;
 }

--- a/tests/commands/harden.test.js
+++ b/tests/commands/harden.test.js
@@ -75,6 +75,22 @@ describe("hardenCommand", () => {
     expect(res.configs.some((c) => c.file.includes("wrappers"))).toBe(false);
   });
 
+  it("--report is read-only and emits the advisory (KJC-TSK-0566)", async () => {
+    writeFileSync(join(repo, "package.json"), "{}");
+    const res = await hardenCommand({ projectDir: repo, report: true, logger });
+    expect(res).toMatchObject({ ok: true, report: true });
+    expect(Array.isArray(res.artifacts)).toBe(true);
+    expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(false);
+    expect(logger.info.mock.calls.flat().join("\n")).toContain("advisory report");
+  });
+
+  it("--report --json emits the structured comparison", async () => {
+    writeFileSync(join(repo, "package.json"), "{}");
+    await hardenCommand({ projectDir: repo, report: true, json: true, logger });
+    const payload = JSON.parse(logger.info.mock.calls.at(-1)[0]);
+    expect(Array.isArray(payload.artifacts)).toBe(true);
+  });
+
   it("returns ok:false on a non-repo dir without throwing", async () => {
     const plain = mkdtempSync(join(tmpdir(), "kj-plain-"));
     const res = await hardenCommand({ projectDir: plain, logger });

--- a/tests/harden/advisory.test.js
+++ b/tests/harden/advisory.test.js
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { buildManagedBlock } from "../../src/utils/managed-markers.js";
-import { compareHarden } from "../../src/harden/advisory.js";
+import { compareHarden, formatAdvisoryReport } from "../../src/harden/advisory.js";
 
 let root;
 const touch = (rel, content = "") => {
@@ -70,5 +70,21 @@ describe("compareHarden", () => {
     expect(find(artifacts, "eslint", "frontend")).toMatchObject({ status: "USER_OWNED", foundAt: join("frontend", "eslint.config.js") });
     expect(find(artifacts, "ruff", "backend").status).toBe("MISSING");
     expect(() => JSON.stringify(artifacts)).not.toThrow();
+  });
+});
+
+describe("formatAdvisoryReport", () => {
+  it("renders a line per artifact, indented improvements, and a tally", () => {
+    touch("commitlint.config.js", "export default { rules: {} };");
+    const lines = formatAdvisoryReport(compareHarden({ projectDir: root }));
+    const text = lines.join("\n");
+    expect(text).toContain("advisory report (read-only)");
+    expect(text).toMatch(/~ review\s+commitlint\.config\.js/);
+    expect(text).toContain("      • caps the commit header at 100 chars");
+    expect(lines.at(-1)).toMatch(/artifact\(s\) ·/);
+  });
+
+  it("handles an empty comparison (minimal profile)", () => {
+    expect(formatAdvisoryReport({ artifacts: [] })[0]).toMatch(/nothing to compare/);
   });
 });


### PR DESCRIPTION
Cierra **KJC-TSK-0566** (Advisory B, épica KJC-PCS-0060). Sobre el motor de Advisory A (#1095/#1096).

## Qué

`kj harden --report`: informe **read-only** que corre el motor de comparación y, por artefacto, dice qué falta, qué tienes y qué aportaría el estándar kj — sin escribir nada, exit 0.

```
kj harden — advisory report (read-only)

  + install .editorconfig — kj would add .editorconfig
  ~ review  .commitlintrc.json — your own config — kj could add 1 improvement(s)
      • enforces a lowercase subject
  ~ review  eslint.config.js — your own config — kj could add 2 improvement(s)
      • bans alert/confirm/prompt, escape/unescape
      • bans document.write, substr
  ✓ keep    .prettierrc.json — your own config — already covers the kj standard

4 artifact(s) · 1 missing · 2 to review · 0 outdated · 1 ok
```

- **`--json`** → emite la estructura `{ artifacts: [...] }` para CI/automatización.
- **Misma scope que un install**: respeta `--only`/`--exclude` y `package.json kj.harden`, así el report nunca propone una raíz que `kj harden` se saltaría (coherencia con KJC-TSK-0564).
- Es la evolución natural de `kj check` (de "¿está el andamiaje?" a "¿qué mejoraría?"), reutilizando el motor de Advisory A sin duplicar.

`formatAdvisoryReport()` es un renderer puro (devuelve líneas, no imprime).

## Tests

`advisory.test.js`: renderer (línea por artefacto, bullets de mejoras, tally) + caso vacío. `harden.test.js`: `--report` no escribe `.karajan/hooks` y emite "advisory report"; `--report --json` emite la estructura. 85/85 en la suite harden. Net 68 LOC.