### PR TITLE
feat(harden): kj harden --interactive — adopt the standard piece by piece

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -409,6 +409,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--only <dirs...>", "Harden only these language roots (e.g. frontend backend)")
     .option("--exclude <globs...>", "Skip language roots matching these globs (e.g. wrappers)")
     .option("--report", "Read-only: show what kj would add/improve, change nothing")
+    .option("--interactive", "Adopt the kj standard piece by piece (default keeps yours)")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
     .action(async (flags) => {
@@ -421,6 +422,7 @@ export function registerMeta(program, { pkgVersion }) {
           only: flags.only ?? [],
           exclude: flags.exclude ?? [],
           report: Boolean(flags.report),
+          interactive: Boolean(flags.interactive),
           dryRun: Boolean(flags.dryRun),
           json: Boolean(flags.json),
           logger,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -10,6 +10,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { compareHarden, formatAdvisoryReport } from "../harden/advisory.js";
+import { interactiveHarden } from "../harden/interactive.js";
+import { createWizard, isTTY } from "../utils/wizard.js";
 import { installConfigsForRoots } from "../harden/config-engine.js";
 import { installGuidelines } from "../harden/guidelines-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
@@ -77,6 +79,7 @@ export async function hardenCommand({
   dryRun = false,
   json = false,
   report = false,
+  interactive = false,
   only = [],
   exclude = [],
   logger = console,
@@ -93,6 +96,25 @@ export async function hardenCommand({
     if (json) logger.info?.(JSON.stringify(result));
     else for (const line of formatAdvisoryReport(result)) logger.info?.(line);
     return { ok: true, report: true, ...result };
+  }
+
+  // --interactive: adopt the kj standard piece by piece, default-safe (keep the
+  // user's own). Only meaningful with a TTY — without one (CI, --json) we fall
+  // through to the normal seed-if-absent install so nothing breaks (KJC-TSK-0567).
+  if (interactive && isTTY() && !json) {
+    const wizard = createWizard();
+    try {
+      return await interactiveHarden({
+        projectDir,
+        profile,
+        only: onlyDirs,
+        exclude: excludeDirs,
+        ask: (prompt, def) => wizard.confirm(prompt, def),
+        logger,
+      });
+    } finally {
+      wizard.close();
+    }
   }
 
   const roots = detectStackRoots(projectDir, { only: onlyDirs, exclude: excludeDirs });

--- a/src/harden/interactive.js
+++ b/src/harden/interactive.js
@@ -1,0 +1,76 @@
+/**
+ * interactive — `kj harden --interactive` (KJC-TSK-0567, épica KJC-PCS-0060).
+ *
+ * Walks the advisory comparison (Advisory A/B) and asks, artifact by artifact,
+ * whether to apply the kj standard — with a safe default of leaving the user's
+ * own config untouched. Only the pieces the user says yes to are written:
+ *
+ *   MISSING                  → add it?      (default yes — same as seed-if-absent)
+ *   KJ_MANAGED outdated      → update it?   (default yes)
+ *   USER_OWNED w/ gaps       → adopt kj's?  (default NO — keep yours)
+ *
+ * The full merge (user's config + kj rules) is out of scope here (v2): adopt
+ * replaces the file with kj's standard. `ask` is injected so the flow is
+ * testable without a TTY; the CLI passes a readline-backed confirm.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { compareHarden } from "./advisory.js";
+import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
+
+const BLOCK_VERSION = 1; // mirrors config-engine.js
+
+// Artifact id (blockId, or "prettier" for the marker-less JSON) → its template.
+const TEMPLATE_BY_ID = new Map();
+for (const cfg of [...UNIVERSAL_CONFIGS, ...Object.values(CONFIGS_BY_LANGUAGE).flat()]) {
+  TEMPLATE_BY_ID.set(cfg.blockId ?? "prettier", cfg);
+}
+
+/** What to ask (and do) for one classified artifact; null = nothing to offer. */
+export function decideAction(a) {
+  if (a.recommendation === "install") return { action: "add", defaultYes: true, prompt: `Add ${a.file}? (${a.rationale})` };
+  if (a.recommendation === "update") return { action: "update", defaultYes: true, prompt: `Update ${a.file} to kj v${a.currentVersion}?` };
+  if (a.recommendation === "review") {
+    return { action: "adopt", defaultYes: false, prompt: `Adopt kj's ${a.file}? Replaces yours, adds ${a.improvements.length} improvement(s). Default keeps yours.` };
+  }
+  return null; // keep / up-to-date — nothing to ask
+}
+
+/** Write an artifact's kj body. `overwrite` discards the user's file (adopt). */
+function applyArtifact(projectDir, dir, cfg, { overwrite }) {
+  const target = join(projectDir, dir === "." ? "" : dir, cfg.file);
+  mkdirSync(dirname(target), { recursive: true });
+  if (cfg.json) {
+    writeFileSync(target, `${cfg.body}\n`);
+    return;
+  }
+  const source = !overwrite && existsSync(target) ? readFileSync(target, "utf8") : "";
+  const { content } = upsertManagedBlock({ source, blockId: cfg.blockId, version: BLOCK_VERSION, body: cfg.body, style: cfg.style });
+  writeFileSync(target, content);
+}
+
+/**
+ * Run the interactive adoption flow. `ask(prompt, defaultYes) → Promise<bool>`.
+ * Returns the list of applied artifacts. Writes nothing the user declines.
+ */
+export async function interactiveHarden({ projectDir = process.cwd(), profile = "standard", only = [], exclude = [], ask, logger = console } = {}) {
+  const { artifacts } = compareHarden({ projectDir, profile, only, exclude });
+  const applied = [];
+  for (const a of artifacts) {
+    const plan = decideAction(a);
+    if (!plan) continue;
+    const yes = await ask(plan.prompt, plan.defaultYes);
+    if (!yes) continue;
+    const cfg = TEMPLATE_BY_ID.get(a.id);
+    if (!cfg) continue;
+    applyArtifact(projectDir, a.dir, cfg, { overwrite: plan.action === "adopt" });
+    const where = a.dir === "." ? a.file : join(a.dir, a.file);
+    applied.push({ file: where, action: plan.action });
+    logger.info?.(`  ✓ ${plan.action} ${where}`);
+  }
+  if (applied.length === 0) logger.info?.("kj harden — nothing applied (kept everything as-is).");
+  return { ok: true, interactive: true, applied };
+}

--- a/tests/commands/harden.test.js
+++ b/tests/commands/harden.test.js
@@ -91,6 +91,13 @@ describe("hardenCommand", () => {
     expect(Array.isArray(payload.artifacts)).toBe(true);
   });
 
+  it("--interactive without a TTY falls back to a normal install (KJC-TSK-0567)", async () => {
+    // vitest has no TTY, so the interactive branch is skipped and seed-if-absent runs.
+    const res = await hardenCommand({ projectDir: repo, interactive: true, logger });
+    expect(res.ok).toBe(true);
+    expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(true);
+  });
+
   it("returns ok:false on a non-repo dir without throwing", async () => {
     const plain = mkdtempSync(join(tmpdir(), "kj-plain-"));
     const res = await hardenCommand({ projectDir: plain, logger });

--- a/tests/harden/interactive.test.js
+++ b/tests/harden/interactive.test.js
@@ -1,0 +1,48 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { decideAction, interactiveHarden } from "../../src/harden/interactive.js";
+
+let root;
+const logger = { info: vi.fn() };
+const read = (rel) => readFileSync(join(root, rel), "utf8");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  root = mkdtempSync(join(tmpdir(), "kj-interactive-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("decideAction", () => {
+  it("defaults to adding a missing artifact and to keeping a user's own", () => {
+    expect(decideAction({ recommendation: "install", file: "x", rationale: "r" })).toMatchObject({ action: "add", defaultYes: true });
+    expect(decideAction({ recommendation: "review", file: "x", improvements: [{}, {}] })).toMatchObject({ action: "adopt", defaultYes: false });
+    expect(decideAction({ recommendation: "keep" })).toBeNull();
+  });
+});
+
+describe("interactiveHarden", () => {
+  it("adds missing configs and adopts a thin user config when the user says yes", async () => {
+    writeFileSync(join(root, "commitlint.config.js"), "export default { rules: {} };"); // thin USER_OWNED
+    const ask = vi.fn().mockResolvedValue(true);
+    const res = await interactiveHarden({ projectDir: root, ask, logger });
+    expect(res.applied.some((a) => a.file === ".editorconfig" && a.action === "add")).toBe(true);
+    expect(res.applied.some((a) => a.file === "commitlint.config.js" && a.action === "adopt")).toBe(true);
+    expect(read("commitlint.config.js")).toContain("kj:managed:commitlint");
+    expect(read("commitlint.config.js")).toContain("header-max-length");
+  });
+
+  it("writes nothing the user declines (safe default)", async () => {
+    writeFileSync(join(root, "commitlint.config.js"), "export default { rules: {} };");
+    const ask = vi.fn().mockResolvedValue(false);
+    const res = await interactiveHarden({ projectDir: root, ask, logger });
+    expect(res.applied).toEqual([]);
+    expect(existsSync(join(root, ".editorconfig"))).toBe(false);
+    expect(read("commitlint.config.js")).toBe("export default { rules: {} };"); // untouched
+  });
+});


### PR DESCRIPTION
Cierra **KJC-TSK-0567** (Advisory C, épica KJC-PCS-0060). Completa el epic advisory sobre el motor (#1095/#1096) y el report (#1097).

## Qué

`kj harden --interactive`: recorre la comparación (Advisory A/B) y pregunta **pieza a pieza** si adoptar el estándar kj, con **default seguro = dejar lo del usuario**. Solo escribe lo que el usuario acepta:

| Estado | Pregunta | Default | Acción al "sí" |
|---|---|---|---|
| `MISSING` | Add `<file>`? | **sí** | seed (igual que seed-if-absent) |
| `KJ_MANAGED` desactualizado | Update to kj vN? | **sí** | refresca el bloque managed |
| `USER_OWNED` con mejoras | Adopt kj's `<file>`? | **no** | reemplaza por el estándar kj |
| `keep` / al día | — | — | no pregunta |

- **Sin TTY (CI, `--json`)**: cae al comportamiento actual seed-if-absent → no rompe nada.
- El **merge** config-del-usuario + reglas-kj queda explícitamente **fuera de alcance** (v2): adoptar = escribir el estándar kj.
- `ask(prompt, default) → Promise<bool>` es **inyectable** → el flujo se testea sin TTY; la CLI pasa un `confirm` de readline (`createWizard`).

## Tests

`interactive.test.js`: `decideAction` (defaults add/keep), flujo con `ask=yes` (añade `.editorconfig`, adopta commitlint con bloque `kj:managed` + `header-max-length`), flujo con `ask=no` (no escribe nada, config intacta). `harden.test.js`: `--interactive` sin TTY instala normal. 89/89 en la suite harden. Net 155 LOC.

> Nota UX: el texto de las preguntas es fácil de pulir; el comportamiento (default-keep, sin sobrescrituras no consentidas) es el contrato.