### PR TITLE
fix(packaging): ship kj-trash so npm installs get the ai-trash safety net

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "packages/hu-board/src/",
     "packages/hu-board/public/",
     "packages/hu-board/package.json",
+    "packages/ai-trash/src/",
+    "packages/ai-trash/bin/",
+    "packages/ai-trash/package.json",
     "docs/karajan-code-logo-small.png",
     "docs/README.es.md",
     "LICENSE",
@@ -62,6 +65,7 @@
   "bin": {
     "kj": "bin/kj.js",
     "kj-tail": "bin/kj-tail",
+    "kj-trash": "packages/ai-trash/bin/kj-trash.js",
     "karajan-mcp": "bin/karajan-mcp.js",
     "kj-rag-mcp": "bin/kj-rag-mcp.js"
   },

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -18,7 +18,7 @@
  * this from prepublishOnly does not recurse.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -100,6 +100,19 @@ try {
     if (!fs.existsSync(p)) fail(`expected resolved path missing in install: ${p}`);
   }
   console.log("verify-pack: sqlite-vec + @karajan/core resolve ✓");
+
+  // 4. kj-trash (ai-trash safety binary) must ship + link onto PATH and boot
+  // without a module-resolution crash. It was silently absent from the tarball
+  // until KJC-BUG-0089 — every npm user got "kj-trash not found".
+  const trashBin = path.join(tmpDir, "node_modules", ".bin", "kj-trash");
+  if (!fs.existsSync(trashBin)) fail(`kj-trash binary missing after install: ${trashBin}`);
+  const trash = spawnSync(trashBin, ["--help"], { encoding: "utf8", env: childEnv });
+  // The CLI exits 2 on --help (usage); only a real crash (module not found, or
+  // an unexpected non-0/2 exit) is a failure.
+  if (![0, 2].includes(trash.status) || /ERR_MODULE_NOT_FOUND|Cannot find/.test(trash.stderr || "")) {
+    fail("`kj-trash --help` crashed on a clean install", trash.stderr || `exit ${trash.status}`);
+  }
+  console.log("verify-pack: kj-trash ships + boots ✓");
 
   console.log(`\n✓ verify-pack: karajan-code@${expectedVersion} installs clean and runs.`);
 } finally {

--- a/src/checks/ai-trash.js
+++ b/src/checks/ai-trash.js
@@ -23,7 +23,7 @@ function createAiTrashCheck() {
         ok: false,
         severity: "warn",
         detail: "kj-trash not found — destructive ops unprotected",
-        fix: "Reinstall karajan-code (kj-trash ships with the workspace) and run `kj-trash install --claude-code`",
+        fix: "Install karajan-code globally (npm i -g karajan-code) so kj-trash is on PATH, then run `kj-trash install --claude-code`",
       };
     },
   };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -832,7 +832,7 @@ export async function initCommand({ logger, flags = {} }) {
       await installAiTrashHook(logger);
     } else {
       logger.warn("ai-trash kj-trash binary not found — destructive ops unprotected.");
-      logger.warn("  Reinstall karajan-code so kj-trash is on PATH.");
+      logger.warn("  Install karajan-code globally (npm i -g karajan-code) so kj-trash is on PATH.");
     }
   }
 


### PR DESCRIPTION
Cierra **KJC-BUG-0089**. Investigación de la opción A (warning de ai-trash en primer uso).

## Confirmado: hueco de packaging real (no kj-link)

El binario `kj-trash` (paquete `@karajan/ai-trash` — snapshots de operaciones destructivas, la red de seguridad) **nunca se publicaba**:
- **NO** estaba en `files` del `package.json` raíz (sí `packages/hu-board/`).
- **NO** era bin raíz.
- **NO** era dependencia ni `bundleDependency` (solo `@karajan/core`).

Verificado con `npm pack --dry-run`: nada de ai-trash en el tarball. Resultado: **todo usuario de `npm i -g karajan-code`** veía `kj-trash not found — destructive ops unprotected` en `kj init`/`kj doctor`, y la remediación *"Reinstall karajan-code (ships with the workspace)"* era **falsa** (reinstalar no lo trae).

## Fix

`@karajan/ai-trash` es **autocontenido** (0 deps, `type: module`, imports relativos, sin `@karajan/core`) → shippearlo es limpio:
1. `files`: + `packages/ai-trash/{src,bin,package.json}`.
2. `bin`: + `"kj-trash": "packages/ai-trash/bin/kj-trash.js"` → npm lo enlaza al PATH en install global.
3. Remediación honesta en `init.js` + `checks/ai-trash.js` (`npm i -g karajan-code`, no "reinstala").
4. **Gate verify-pack** ampliado: asserta que `.bin/kj-trash` se enlaza y arranca sin crash de módulo → no recae (es justo el gate que lo habría pillado).

## Verificado

`node scripts/verify-pack.mjs` (npm pack + install aislado real):
```
verify-pack: kj --version → 3.5.1 ✓
verify-pack: kj-trash ships + boots ✓
✓ installs clean and runs.
```

Net +17 LOC. Se publicará con la próxima v3.5.2.