### PR TITLE
feat(autonomy): decision resolver + autonomy levels (AUTO-A foundation)

### DIFF
--- a/src/autonomy/decision-resolver.js
+++ b/src/autonomy/decision-resolver.js
@@ -1,0 +1,58 @@
+/**
+ * autonomy/decision-resolver — the single choke point for every pipeline
+ * question (KJC-TSK-0572, design in docs/specs/autonomous-delivery.md §5).
+ *
+ * Today the "ask a human" logic is scattered (spec-review, checkpoint,
+ * reviewer, board-bridge). This unifies it: callers ask `resolveDecision`
+ * instead of prompting directly, and the autonomy level decides who answers —
+ * the human (`ask`) or the Arbiter (`arbiter`, injected by AUTO-B).
+ *
+ * INVARIANT: in `autonomous` mode the resolver NEVER returns a null choice and
+ * NEVER blocks — if the Arbiter can't decide it degrades to the option flagged
+ * `conservative` (or the first option). Decisions are always traced.
+ */
+
+import { RISK, usesArbiter } from "./policy.js";
+
+/** Pick the safe fallback: the option flagged conservative, else the first. */
+function conservativeOf(options) {
+  return options.find((o) => o.conservative) ?? options[0] ?? null;
+}
+
+function decision(choice, rationale, source) {
+  return { choice: choice ?? null, rationale, source };
+}
+
+/**
+ * Build a resolver bound to an autonomy level and its two answer sources.
+ *
+ * @param {object} opts
+ * @param {string} opts.autonomy - interactive | assisted | autonomous
+ * @param {(question: string, context?: object) => Promise<string|null>} [opts.ask] - human prompt
+ * @param {(input: object) => Promise<{choice: string, rationale?: string}>} [opts.arbiter] - AUTO-B
+ * @returns {(req: object) => Promise<{choice, rationale, source}>}
+ */
+export function createDecisionResolver({ autonomy = "interactive", ask = null, arbiter = null, logger = console } = {}) {
+  return async function resolveDecision({ question, options = [], context = null, risk = RISK.LOW } = {}) {
+    const fallback = conservativeOf(options);
+
+    // Human path: interactive, or assisted with a high-risk decision.
+    if (!usesArbiter(autonomy, risk)) {
+      const answer = ask ? await ask(question, context) : null;
+      return decision(answer, "human", "human");
+    }
+
+    // Arbiter path: must always yield a valid choice, never block.
+    if (!arbiter) return decision(fallback?.value, "no arbiter available → conservative", "fallback");
+    let verdict;
+    try {
+      verdict = await arbiter({ question, options, context, risk });
+    } catch (err) {
+      logger.warn?.(`decision-resolver: arbiter failed (${err.message}) → conservative`);
+      return decision(fallback?.value, "arbiter error → conservative", "fallback");
+    }
+    const valid = verdict && options.some((o) => o.value === verdict.choice);
+    if (!valid) return decision(fallback?.value, "arbiter gave no valid choice → conservative", "fallback");
+    return decision(verdict.choice, verdict.rationale ?? "arbiter", "arbiter");
+  };
+}

--- a/src/autonomy/policy.js
+++ b/src/autonomy/policy.js
@@ -1,0 +1,41 @@
+/**
+ * autonomy/policy — autonomy levels for Autonomous Delivery (KJC-TSK-0572,
+ * épica KJC-PCS-0062, design in docs/specs/autonomous-delivery.md §4).
+ *
+ * One configurable axis decides who resolves a pipeline question:
+ *   interactive — the human (current behaviour, default)
+ *   assisted    — the human only for high-risk decisions, the Arbiter otherwise
+ *   autonomous  — always the Arbiter; never asks a human, never blocks
+ *
+ * Precedence (most specific wins): CLI flags → env → config → default.
+ */
+
+export const AUTONOMY_LEVELS = Object.freeze(["interactive", "assisted", "autonomous"]);
+
+/** Risk of a decision — drives whether `assisted` escalates to the human. */
+export const RISK = Object.freeze({ LOW: "low", HIGH: "high" });
+
+const DEFAULT_LEVEL = "interactive";
+
+/**
+ * Resolve the active autonomy level. `--autonomous` is sugar for the
+ * `autonomous` level; `--autonomy <level>` sets it explicitly. An unknown
+ * value degrades to the safe default rather than throwing.
+ */
+export function resolveAutonomy({ config = {}, flags = {}, env = {} } = {}) {
+  const raw =
+    flags.autonomy ??
+    (flags.autonomous ? "autonomous" : null) ??
+    env.KJ_AUTONOMY ??
+    config.autonomy ??
+    DEFAULT_LEVEL;
+  const level = String(raw).toLowerCase();
+  return AUTONOMY_LEVELS.includes(level) ? level : DEFAULT_LEVEL;
+}
+
+/** True when the level should route decisions to the Arbiter for `risk`. */
+export function usesArbiter(level, risk = RISK.LOW) {
+  if (level === "autonomous") return true;
+  if (level === "assisted") return risk !== RISK.HIGH;
+  return false; // interactive
+}

--- a/tests/autonomy/decision-resolver.test.js
+++ b/tests/autonomy/decision-resolver.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AUTONOMY_LEVELS, RISK, resolveAutonomy, usesArbiter } from "../../src/autonomy/policy.js";
+import { createDecisionResolver } from "../../src/autonomy/decision-resolver.js";
+
+const OPTIONS = [
+  { value: "proceed", label: "Proceed" },
+  { value: "block", label: "Block", conservative: true },
+];
+
+describe("resolveAutonomy", () => {
+  it("defaults to interactive and honours flag > env > config precedence", () => {
+    expect(resolveAutonomy()).toBe("interactive");
+    expect(resolveAutonomy({ config: { autonomy: "assisted" } })).toBe("assisted");
+    expect(resolveAutonomy({ config: { autonomy: "assisted" }, env: { KJ_AUTONOMY: "autonomous" } })).toBe("autonomous");
+    expect(resolveAutonomy({ flags: { autonomy: "interactive" }, env: { KJ_AUTONOMY: "autonomous" } })).toBe("interactive");
+    expect(resolveAutonomy({ flags: { autonomous: true } })).toBe("autonomous");
+  });
+
+  it("degrades an unknown level to the safe default", () => {
+    expect(resolveAutonomy({ flags: { autonomy: "yolo" } })).toBe("interactive");
+    expect(AUTONOMY_LEVELS).toContain("autonomous");
+  });
+});
+
+describe("usesArbiter", () => {
+  it("routes by level and risk", () => {
+    expect(usesArbiter("interactive", RISK.LOW)).toBe(false);
+    expect(usesArbiter("autonomous", RISK.HIGH)).toBe(true);
+    expect(usesArbiter("assisted", RISK.LOW)).toBe(true);
+    expect(usesArbiter("assisted", RISK.HIGH)).toBe(false); // high-risk → human
+  });
+});
+
+describe("createDecisionResolver", () => {
+  it("interactive asks the human and returns their answer", async () => {
+    const ask = vi.fn().mockResolvedValue("proceed");
+    const resolve = createDecisionResolver({ autonomy: "interactive", ask });
+    expect(await resolve({ question: "Q?", options: OPTIONS })).toEqual({ choice: "proceed", rationale: "human", source: "human" });
+    expect(ask).toHaveBeenCalledWith("Q?", null);
+  });
+
+  it("autonomous uses the arbiter's valid choice", async () => {
+    const arbiter = vi.fn().mockResolvedValue({ choice: "proceed", rationale: "tests pass" });
+    const resolve = createDecisionResolver({ autonomy: "autonomous", arbiter });
+    expect(await resolve({ question: "Q?", options: OPTIONS })).toEqual({ choice: "proceed", rationale: "tests pass", source: "arbiter" });
+  });
+
+  it("autonomous degrades to the conservative option when the arbiter throws, returns garbage, or is absent", async () => {
+    const throwing = createDecisionResolver({ autonomy: "autonomous", arbiter: vi.fn().mockRejectedValue(new Error("boom")), logger: { warn: vi.fn() } });
+    expect((await throwing({ question: "Q?", options: OPTIONS })).choice).toBe("block");
+
+    const garbage = createDecisionResolver({ autonomy: "autonomous", arbiter: vi.fn().mockResolvedValue({ choice: "nope" }) });
+    expect((await garbage({ question: "Q?", options: OPTIONS })).source).toBe("fallback");
+
+    const none = createDecisionResolver({ autonomy: "autonomous" });
+    expect((await none({ question: "Q?", options: OPTIONS })).choice).toBe("block");
+  });
+
+  it("assisted escalates high-risk to the human but lets the arbiter take low-risk", async () => {
+    const ask = vi.fn().mockResolvedValue("proceed");
+    const arbiter = vi.fn().mockResolvedValue({ choice: "block" });
+    const resolve = createDecisionResolver({ autonomy: "assisted", ask, arbiter });
+    expect((await resolve({ question: "Q?", options: OPTIONS, risk: RISK.HIGH })).source).toBe("human");
+    expect((await resolve({ question: "Q?", options: OPTIONS, risk: RISK.LOW })).source).toBe("arbiter");
+  });
+});


### PR DESCRIPTION
Parte de **KJC-TSK-0572** (AUTO-A, épica KJC-PCS-0062 Autonomous Delivery) — PR1 de 2.

## Qué
`src/autonomy/` — la fundación de la autonomía, autocontenida:
- **`policy.js`**: niveles `interactive` | `assisted` | `autonomous` + `RISK`. `resolveAutonomy` con precedencia flag (`--autonomy`/`--autonomous`) > env (`KJ_AUTONOMY`) > config > default `interactive`; nivel desconocido → default seguro. `usesArbiter(level, risk)`.
- **`decision-resolver.js`**: `createDecisionResolver` = el **choke point único** por el que pasarán todos los gates. `interactive`→pregunta al humano (`ask`); `assisted`→humano solo si `risk` alto, si no Arbiter; `autonomous`→**siempre** Arbiter, **nunca null, nunca bloqueo**, degrada a la opción `conservative` si el Arbiter falla/da basura/no existe.

El **Arbiter es dependencia inyectada** (lo provee AUTO-B) → todo testeable sin LLM.

## Alcance
PR1 = contrato del resolver + niveles. **PR2** (mismo card) cablea los consumidores existentes (spec-review, checkpoint, reviewer, board-bridge) a `resolveDecision` sin romper el flujo interactivo.

## Tests
`decision-resolver.test.js`: precedencia de `resolveAutonomy`, routing de `usesArbiter`, y el resolver en las 4 rutas (human, arbiter-válido, degradación a conservadora ×3, assisted high/low risk). 7/7. Net 166 LOC.