### PR TITLE
feat(autonomy): ArbiterRole — least-bad conflict resolution (AUTO-B)

### DIFF
--- a/src/autonomy/arbiter-role.js
+++ b/src/autonomy/arbiter-role.js
@@ -1,0 +1,71 @@
+/**
+ * ArbiterRole — the autonomous decision authority that resolves agent conflicts
+ * by picking the least-bad verdict (KJC-TSK-0573, épica KJC-PCS-0062).
+ *
+ * Extends AgentRole (so it inherits Brain recovery / standby) following the
+ * TriageRole pattern: a cheap decisor model emits a closed-set verdict, and any
+ * parse failure degrades to BLOCK_AND_CONTINUE — the pipeline never crashes and
+ * never blocks on the Arbiter.
+ */
+
+import { AgentRole } from "../roles/agent-role.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+import { buildArbiterPrompt, VERDICTS } from "../prompts/arbiter.js";
+
+const CONSERVATIVE = "BLOCK_AND_CONTINUE";
+const VERDICT_SET = new Set(VERDICTS);
+
+function clampConfidence(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : 0;
+}
+
+export class ArbiterRole extends AgentRole {
+  constructor(opts) {
+    super({ ...opts, name: "arbiter" });
+  }
+
+  async buildPrompt(input) {
+    return { prompt: buildArbiterPrompt(input) };
+  }
+
+  parseOutput(raw) {
+    return extractFirstJson(raw);
+  }
+
+  buildSuccessResult(parsed, provider) {
+    const verdict = VERDICT_SET.has(parsed?.verdict) ? parsed.verdict : CONSERVATIVE;
+    return {
+      verdict,
+      confidence: clampConfidence(parsed?.confidence),
+      rationale: String(parsed?.rationale || "").trim() || "no rationale",
+      defect: parsed?.defect ? String(parsed.defect).trim() : null,
+      directive: parsed?.directive ? String(parsed.directive).trim() : null,
+      provider,
+    };
+  }
+
+  buildSummary(parsed) {
+    return `Arbiter: ${VERDICT_SET.has(parsed?.verdict) ? parsed.verdict : CONSERVATIVE}`;
+  }
+
+  // Never crash on garbage: degrade to the conservative verdict so the pipeline
+  // moves on instead of aborting (ok:true keeps the run alive).
+  handleParseNull(agentResult, provider) {
+    return this.degraded(agentResult, provider, "unstructured output");
+  }
+
+  handleParseError(err, agentResult, provider) {
+    return this.degraded(agentResult, provider, err?.message || "parse error");
+  }
+
+  degraded(agentResult, provider, why) {
+    this.logger?.warn?.(`[arbiter] ${why} → ${CONSERVATIVE} (conservative)`);
+    return {
+      ok: true,
+      result: { verdict: CONSERVATIVE, confidence: 0, rationale: `degraded: ${why}`, defect: null, directive: null, provider },
+      summary: `Arbiter: ${CONSERVATIVE} (degraded)`,
+      usage: agentResult.usage,
+    };
+  }
+}

--- a/src/autonomy/arbiter.js
+++ b/src/autonomy/arbiter.js
@@ -1,0 +1,22 @@
+/**
+ * createArbiter — adapt ArbiterRole to the function the decision-resolver
+ * injects (KJC-TSK-0573). The resolver calls `arbiter(req)` and expects
+ * `{ choice, rationale, ... }`; here `choice` is the Arbiter's verdict, which
+ * the resolver then validates against the caller's options (AUTO-A).
+ */
+
+import { ArbiterRole } from "./arbiter-role.js";
+
+export function createArbiter({ config = {}, logger = console, createAgentFn = null } = {}) {
+  return async function arbiter(req) {
+    const role = new ArbiterRole({ config, logger, createAgentFn });
+    const { result } = await role.execute(req);
+    return {
+      choice: result.verdict,
+      rationale: result.rationale,
+      confidence: result.confidence,
+      defect: result.defect,
+      directive: result.directive,
+    };
+  };
+}

--- a/src/prompts/arbiter.js
+++ b/src/prompts/arbiter.js
@@ -1,0 +1,38 @@
+/**
+ * Arbiter prompt (KJC-TSK-0573, design in docs/specs/autonomous-delivery.md §6).
+ *
+ * The Arbiter is Karajan's autonomous decision authority: given a conflict, it
+ * picks the LEAST-BAD option from a closed set and moves forward — no human.
+ */
+
+/** The closed set of conflict-resolution verdicts. BLOCK_AND_CONTINUE is safe. */
+export const VERDICTS = Object.freeze([
+  "ACCEPT_WITH_DEFECT",
+  "RETRY_DIFFERENT_APPROACH",
+  "DESCOPE_HU",
+  "BLOCK_AND_CONTINUE",
+  "PROCEED",
+]);
+
+export function buildArbiterPrompt({ question, options = [], context = null } = {}) {
+  const allowed = options.length ? options.map((o) => o.value) : VERDICTS;
+  return [
+    "You are the Arbiter — Karajan's autonomous decision authority. There is no human to ask.",
+    "Resolve the conflict below by choosing the LEAST-BAD option and moving forward.",
+    "",
+    "Ground-truth order (what wins when signals disagree):",
+    "  1. Acceptance tests passing — beats any reviewer opinion.",
+    "  2. Must-fix issues (security, correctness, data) — beat style.",
+    "  3. Nice-to-have (style, optional refactors) — never block; record as a defect if dropped.",
+    "Goal: maximize 'the ask is met', minimize irreversible risk. Imperfect-but-delivered beats blocked.",
+    "",
+    `Conflict: ${question}`,
+    context ? `Context: ${JSON.stringify(context)}` : "",
+    "",
+    `Choose exactly one verdict from: ${allowed.join(", ")}`,
+    "Respond with ONLY this JSON (no prose):",
+    '{"verdict":"<one of the allowed>","confidence":0.0,"rationale":"why it is the least-bad option","defect":"residual debt if any, else null","directive":"instruction to the coder when RETRY_DIFFERENT_APPROACH, else null"}',
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/tests/autonomy/arbiter-role.test.js
+++ b/tests/autonomy/arbiter-role.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ArbiterRole } from "../../src/autonomy/arbiter-role.js";
+import { createArbiter } from "../../src/autonomy/arbiter.js";
+import { buildArbiterPrompt, VERDICTS } from "../../src/prompts/arbiter.js";
+
+const agentReturning = (output) => () => ({ async runTask() { return { ok: true, output, usage: {} }; } });
+const role = (output) => new ArbiterRole({ config: {}, logger: { warn: vi.fn() }, createAgentFn: agentReturning(output) });
+const CONFLICT = { question: "Reviewer rejects but acceptance tests pass", options: VERDICTS.map((v) => ({ value: v })) };
+
+describe("buildArbiterPrompt", () => {
+  it("states the ground-truth order and the allowed verdicts", () => {
+    const p = buildArbiterPrompt(CONFLICT);
+    expect(p).toContain("Acceptance tests passing");
+    expect(p).toContain("least-bad");
+    expect(p).toContain("ACCEPT_WITH_DEFECT");
+  });
+});
+
+describe("ArbiterRole", () => {
+  it("returns a valid verdict and clamps confidence", async () => {
+    const out = await role(JSON.stringify({ verdict: "ACCEPT_WITH_DEFECT", confidence: 5, rationale: "tests pass", defect: "minor style" })).execute(CONFLICT);
+    expect(out.result).toMatchObject({ verdict: "ACCEPT_WITH_DEFECT", confidence: 1, defect: "minor style" });
+  });
+
+  it("coerces an out-of-set verdict to the conservative BLOCK_AND_CONTINUE", async () => {
+    const out = await role(JSON.stringify({ verdict: "DELETE_EVERYTHING", confidence: 0.9 })).execute(CONFLICT);
+    expect(out.result.verdict).toBe("BLOCK_AND_CONTINUE");
+  });
+
+  it("degrades garbage output to BLOCK_AND_CONTINUE without crashing (ok stays true)", async () => {
+    const out = await role("the model rambled with no json").execute(CONFLICT);
+    expect(out.ok).toBe(true);
+    expect(out.result.verdict).toBe("BLOCK_AND_CONTINUE");
+  });
+});
+
+describe("createArbiter adapter", () => {
+  it("maps the verdict to a resolver choice", async () => {
+    const arbiter = createArbiter({ config: {}, createAgentFn: agentReturning(JSON.stringify({ verdict: "RETRY_DIFFERENT_APPROACH", rationale: "try DI", directive: "inject the dep" })) });
+    expect(await arbiter(CONFLICT)).toMatchObject({ choice: "RETRY_DIFFERENT_APPROACH", rationale: "try DI", directive: "inject the dep" });
+  });
+});


### PR DESCRIPTION
Cierra **KJC-TSK-0573** (AUTO-B, épica KJC-PCS-0062). **El corazón de la autonomía.**

## Qué
El **Arbiter** es la autoridad de decisión que resuelve conflictos entre agentes **sin humano**, eligiendo la opción **menos mala**:
- **`src/prompts/arbiter.js`**: `VERDICTS` (set cerrado: `ACCEPT_WITH_DEFECT` / `RETRY_DIFFERENT_APPROACH` / `DESCOPE_HU` / `BLOCK_AND_CONTINUE` / `PROCEED`) + `buildArbiterPrompt` con la **jerarquía de verdad**: tests de aceptación > must-fix > nice-to-have. "Imperfecto-pero-entregado supera a bloqueado".
- **`src/autonomy/arbiter-role.js`**: `ArbiterRole extends AgentRole` (hereda Brain recovery/standby, patrón TriageRole). `parseOutput`=`extractFirstJson`; valida `verdict ∈ VERDICTS` y clampa `confidence`; **toda salida basura o verdict fuera de set degrada a `BLOCK_AND_CONTINUE`** (`ok:true` → el pipeline avanza, nunca crashea ni bloquea).
- **`src/autonomy/arbiter.js`**: `createArbiter` adapta el rol a la función que inyecta el resolver de AUTO-A (`req → {choice, rationale, confidence, defect, directive}`).

## Integración (verificada)
Resolver de AUTO-A en modo `autonomous` + este Arbiter → ante "reviewer vs tests", decide `ACCEPT_WITH_DEFECT` (`source: arbiter`). Sin humano.

## Tests
`arbiter-role.test.js`: prompt con ground-truth, verdict válido + clamp de confidence, verdict fuera-de-set → conservador, basura → `BLOCK_AND_CONTINUE` sin crash, adapter→choice. 12/12 en la suite autonomy. Net 174 LOC.

Siguiente: AUTO-A PR2 (cablear consumidores al resolver con este Arbiter real).