### PR TITLE
feat(autonomy): route the spec-review gate through the resolver (AUTO-A)

### DIFF
--- a/src/autonomy/decider.js
+++ b/src/autonomy/decider.js
@@ -1,0 +1,18 @@
+/**
+ * buildDecider — wire the active autonomy level to a ready decision resolver
+ * (KJC-TSK-0572, design in docs/specs/autonomous-delivery.md §5).
+ *
+ * interactive → the human `ask`; assisted/autonomous → the Arbiter (AUTO-B).
+ * Consumers (spec-review, reviewer, checkpoint…) call `resolve(...)` instead of
+ * prompting directly, so the autonomy level decides who answers in one place.
+ */
+
+import { createDecisionResolver } from "./decision-resolver.js";
+import { resolveAutonomy } from "./policy.js";
+import { createArbiter } from "./arbiter.js";
+
+export function buildDecider({ config = {}, flags = {}, ask = null, env = process.env, logger = console } = {}) {
+  const autonomy = resolveAutonomy({ config, flags, env });
+  const arbiter = autonomy === "interactive" ? null : createArbiter({ config, logger });
+  return { autonomy, resolve: createDecisionResolver({ autonomy, ask, arbiter, logger }) };
+}

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -7,10 +7,30 @@
 import { SpecReviewerRole } from "../roles/spec-reviewer-role.js";
 import { printFindings } from "../utils/display/spec-findings.js";
 import { runRefinePass } from "./refine-loop.js";
+import { RISK } from "../autonomy/policy.js";
 
 const MAX_REFINE_ITERATIONS = 5;
 
-export async function runSpecReview({ spec, config, logger, askQuestion, flags = {} }) {
+/**
+ * Decide the gate action (`continue` | `refine`) autonomously: the Arbiter
+ * picks PROCEED (proceed with the best reading) or RETRY_DIFFERENT_APPROACH
+ * (auto-refine). It is never offered `cancel`, so an autonomous run never
+ * aborts on spec ambiguity (KJC-TSK-0572, closes gap G1).
+ */
+async function decideGateAutonomously(resolve, { severity, findings }) {
+  const { choice } = await resolve({
+    question: `Spec has ${findings.length} finding(s) at severity ${severity}: proceed with the best reading, or auto-refine?`,
+    options: [
+      { value: "PROCEED", label: "proceed with the best reading", conservative: true },
+      { value: "RETRY_DIFFERENT_APPROACH", label: "auto-refine the spec" },
+    ],
+    context: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))] },
+    risk: severity === "fail" ? RISK.HIGH : RISK.LOW,
+  });
+  return choice === "RETRY_DIFFERENT_APPROACH" ? "refine" : "continue";
+}
+
+export async function runSpecReview({ spec, config, logger, askQuestion, flags = {}, resolve = null, autonomy = "interactive" }) {
   // VITEST guard — pre-existing test suites (e.g. tests/commands/command-run.test.js)
   // mock `runFlow` + `assertAgentsAvailable` but predate this role and have
   // no need to exercise it. Auto-skip in vitest unless the test passes
@@ -40,16 +60,24 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
       return { proceed: true, severity: "ok", findings: [], finalSpec: currentSpec, refined: iter > 0 };
     }
     printFindings(findings, severity);
-    if (!askQuestion) return { proceed: true, severity, findings, finalSpec: currentSpec };
 
-    const answer = await askQuestion(
-      `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
-      { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 } },
-    );
-    if (answer === null) return { proceed: false, cancelled: true, severity, findings };
-    const n = String(answer).trim().toLowerCase();
-    if (n.startsWith("x") || n === "cancel") return { proceed: false, cancelled: true, severity, findings };
-    if (n.startsWith("r") || n === "refine") {
+    // Autonomous/assisted: the Arbiter decides (continue|refine), never cancels.
+    // Interactive (no resolver): the human answers [c]/[r]/[x] as before.
+    let action;
+    if (resolve && autonomy !== "interactive") {
+      action = await decideGateAutonomously(resolve, { severity, findings });
+    } else {
+      if (!askQuestion) return { proceed: true, severity, findings, finalSpec: currentSpec };
+      const answer = await askQuestion(
+        `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
+        { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 } },
+      );
+      if (answer === null) return { proceed: false, cancelled: true, severity, findings };
+      const n = String(answer).trim().toLowerCase();
+      action = n.startsWith("x") || n === "cancel" ? "cancel" : n.startsWith("r") || n === "refine" ? "refine" : "continue";
+    }
+    if (action === "cancel") return { proceed: false, cancelled: true, severity, findings };
+    if (action === "refine") {
       const refine = await runRefinePass({
         spec: currentSpec, findings, role,
         projectDir: config?.projectDir, taskFile: flags.taskFile, logger,

--- a/tests/spec-review/run-spec-review.test.js
+++ b/tests/spec-review/run-spec-review.test.js
@@ -58,6 +58,20 @@ describe("runSpecReview", () => {
     }
   });
 
+  it("autonomous: the resolver decides, never asks the human, never cancels (gap G1)", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: findingsFail } });
+    const resolve = vi.fn().mockResolvedValue({ choice: "PROCEED", source: "arbiter" });
+    const askQuestion = vi.fn();
+    const r = await runSpecReview({
+      spec: "x", config: {}, logger: noopLog, askQuestion, resolve, autonomy: "autonomous",
+      flags: { forceSpecReview: true },
+    });
+    expect(r).toMatchObject({ proceed: true });
+    expect(r.cancelled).toBeUndefined();
+    expect(askQuestion).not.toHaveBeenCalled(); // no human in the loop
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
   it("never blocks when the reviewer itself failed (proceed=true + warn log)", async () => {
     const { runSpecReview } = await loadWith({ ok: false, summary: "agent crashed", result: { error: "boom" } });
     const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, flags: { forceSpecReview: true } });


### PR DESCRIPTION
Completa **KJC-TSK-0572** (AUTO-A) — PR2 de 2 (sobre #1103 y el Arbiter #1105).

## Qué
- **`src/autonomy/decider.js`** — `buildDecider({config, flags, ask})` cablea el nivel de autonomía a un resolver listo: `interactive`→pregunta al humano (`ask`), `assisted`/`autonomous`→Arbiter (AUTO-B). Un solo sitio donde se decide quién responde.
- **`run-spec-review.js`** — el gate de findings pasa por el resolver. En modo autónomo el Arbiter elige `PROCEED` (seguir con la mejor lectura) o `RETRY_DIFFERENT_APPROACH` (auto-refinar), y **nunca se le ofrece cancelar** → un run autónomo **no aborta nunca por spec ambigua** (cierra el hueco **G1**). Los callers interactivos quedan **intactos** (sin resolver → el prompt `[c]/[r]/[x]` de siempre).

## Tests
`run-spec-review.test.js`: caso autónomo — el resolver decide, no se llama a `askQuestion`, `proceed:true` sin `cancelled` aun con severidad `fail`. 19/19. Net 60 LOC.

Con esto **AUTO-A queda completo**. El cableado en `kj run`/`kj plan` (construir el decider desde la config) llega con AUTO-C (`kj autorun`).