### PR TITLE
feat(autonomy): wire the autonomy decider into kj run (AUTO-C)

### DIFF
--- a/src/autonomy/decider.js
+++ b/src/autonomy/decider.js
@@ -11,8 +11,8 @@ import { createDecisionResolver } from "./decision-resolver.js";
 import { resolveAutonomy } from "./policy.js";
 import { createArbiter } from "./arbiter.js";
 
-export function buildDecider({ config = {}, flags = {}, ask = null, env = process.env, logger = console } = {}) {
+export function buildDecider({ config = {}, flags = {}, ask = null, env = process.env, logger = console, createAgentFn = null } = {}) {
   const autonomy = resolveAutonomy({ config, flags, env });
-  const arbiter = autonomy === "interactive" ? null : createArbiter({ config, logger });
+  const arbiter = autonomy === "interactive" ? null : createArbiter({ config, logger, createAgentFn });
   return { autonomy, resolve: createDecisionResolver({ autonomy, ask, arbiter, logger }) };
 }

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -114,6 +114,8 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--skip-role <role...>", "Force one or more roles OFF regardless of triage (e.g. --skip-role tester security)")
     .option("--force-role <role...>", "Force one or more roles ON regardless of triage")
     .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
+    .option("--autonomy <level>", "Autonomy level: interactive | assisted | autonomous (default: interactive)")
+    .option("--autonomous", "Shortcut for --autonomy autonomous: the Arbiter resolves every gate, no human prompts")
     .option("--no-rag-update", "Skip the pre-run RAG drift check (KJC-TSK-0455). Same as config.rag.autoUpdate.onRun=false.")
     .option("--dry-run", "Show what would be executed without running anything")
     .option("--json", "Output JSON only (no styled display)")

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,6 +17,7 @@ import { maybeAutoUpdate } from "../rag/auto-update.js";
 // keep working. KJC-BUG-0081 round 2 split the body into utils/ because
 // resume.js also needs the same contract.
 import { createCliAskQuestion } from "../utils/cli-ask-question.js";
+import { buildDecider } from "../autonomy/decider.js";
 export { createCliAskQuestion };
 
 export async function runCommandHandler({ task, config, logger, flags }) {
@@ -129,12 +130,16 @@ export async function runCommandHandler({ task, config, logger, flags }) {
 
     const askQuestion = createCliAskQuestion({ flags });
 
+    // Autonomy (KJC-PCS-0062): wire the level to a resolver. In autonomous mode
+    // every gate is decided by the Arbiter instead of the human; interactive
+    // keeps the human prompts. The decider is threaded into the gates below.
+    const { autonomy, resolve: decide } = buildDecider({ config, flags, ask: askQuestion, logger });
+
     // Spec-reviewer pre-pipeline audit (KJC-PCS-0048). Runs BEFORE
-    // anything else — surfaces ambiguity / missing scope / missing AC
-    // and lets the user bail out cheap, before any tokens burn.
-    // Bypass with --skip-spec-review. Static import — the role runs
-    // on every kj invocation (modulo bypass), no lazy-load benefit.
-    const reviewResult = await runSpecReview({ spec: task, config, logger, askQuestion, flags });
+    // anything else — surfaces ambiguity / missing scope / missing AC.
+    // In autonomous mode the Arbiter decides (never aborts); interactive
+    // lets the user bail. Bypass with --skip-spec-review.
+    const reviewResult = await runSpecReview({ spec: task, config, logger, askQuestion, flags, resolve: decide, autonomy });
     if (!reviewResult.proceed) {
       logger.info("Aborted by user after spec review.");
       cleanupRegistry();

--- a/tests/autonomy/decider.test.js
+++ b/tests/autonomy/decider.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildDecider } from "../../src/autonomy/decider.js";
+
+const agentReturning = (output) => () => ({ async runTask() { return { ok: true, output, usage: {} }; } });
+const OPTIONS = [
+  { value: "PROCEED", conservative: true },
+  { value: "RETRY_DIFFERENT_APPROACH" },
+];
+
+describe("buildDecider", () => {
+  it("interactive: resolves via the human ask, no arbiter", async () => {
+    const ask = vi.fn().mockResolvedValue("PROCEED");
+    const { autonomy, resolve } = buildDecider({ config: {}, flags: {}, ask });
+    expect(autonomy).toBe("interactive");
+    const out = await resolve({ question: "Q?", options: OPTIONS });
+    expect(out.source).toBe("human");
+    expect(ask).toHaveBeenCalled();
+  });
+
+  it("autonomous: resolves via the Arbiter, never touches the human ask", async () => {
+    const ask = vi.fn();
+    const { autonomy, resolve } = buildDecider({
+      config: {},
+      flags: { autonomous: true },
+      ask,
+      createAgentFn: agentReturning(JSON.stringify({ verdict: "PROCEED", confidence: 0.9, rationale: "best reading" })),
+    });
+    expect(autonomy).toBe("autonomous");
+    const out = await resolve({ question: "Q?", options: OPTIONS });
+    expect(out).toMatchObject({ choice: "PROCEED", source: "arbiter" });
+    expect(ask).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Parte de **KJC-TSK-0574** (AUTO-C, épica KJC-PCS-0062) — PR1 de 2.

## Qué
`kj run` ahora entiende la autonomía:
- Nuevos flags **`--autonomy <level>`** (`interactive`|`assisted`|`autonomous`) y **`--autonomous`** (atajo).
- `run.js` construye el resolver con `buildDecider({config, flags, ask})` y lo pasa al gate de spec-review. Así **`kj run --autonomous` ya no aborta** ante una spec ambigua: el Arbiter decide (PROCEED / auto-refinar). Los runs interactivos quedan **idénticos**.
- `buildDecider` gana un `createAgentFn` inyectable (para test sin LLM).

## Tests
`decider.test.js`: interactive→resuelve por el humano (sin arbiter); autonomous→resuelve por el Arbiter, no toca el `ask`. 25/25 en suites autonomy+spec-review; command-run 8/8. Net 41 LOC.

Siguiente (PR2): el comando **`kj autorun <spec>`** que encadena plan→run→informe, reutilizando esto.