### PR TITLE
feat(autonomy): kj autorun — unattended spec to delivery chain (AUTO-C)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -146,6 +146,25 @@ export function registerPipeline(program, { pkgVersion }) {
     });
 
   program
+    .command("autorun")
+    .description("Unattended delivery: spec → plan → run all HUs → outcome (defaults to --autonomous)")
+    .argument("[task]", "Spec/task description (or use --task-file)")
+    .option("--task-file <path>", "Read the spec from a file (e.g. spec.md)")
+    .option("--autonomy <level>", "interactive | assisted | autonomous (default: autonomous)")
+    .option("--autonomous", "Shortcut for --autonomy autonomous")
+    .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
+    .action(async (task, flags) => {
+      const code = await withConfig(pkgVersion, "autorun", flags, async ({ config, logger }) => {
+        const { resolveTaskInput } = await import("../utils/task-file.js");
+        const { autorunCommand } = await import("../commands/autorun.js");
+        const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+        const res = await autorunCommand({ task: resolvedTask, config, logger, flags });
+        return res?.ok ? 0 : 1;
+      });
+      if (Number.isInteger(code)) process.exit(code);
+    });
+
+  program
     .command("code")
     .description("Run only coder")
     .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")

--- a/src/commands/autorun.js
+++ b/src/commands/autorun.js
@@ -1,0 +1,39 @@
+/**
+ * `kj autorun <spec>` — the unattended delivery chain (KJC-TSK-0574, épica
+ * KJC-PCS-0062, design in docs/specs/autonomous-delivery.md §7).
+ *
+ * One command: spec → plan → run all HUs → outcome. It reuses `kj plan` and
+ * `kj run --plan` rather than reimplementing them, and defaults to the
+ * `autonomous` level so the Arbiter resolves every gate (no human in the loop).
+ * The rich outcome report lands in AUTO-F; here we chain + propagate exit code.
+ */
+
+import { planGenerateCommand } from "./plan/generate.js";
+import { runCommandHandler } from "./run.js";
+
+export async function autorunCommand({
+  task,
+  config,
+  logger = console,
+  flags = {},
+  planFn = planGenerateCommand,
+  runFn = runCommandHandler,
+} = {}) {
+  // autorun implies unattended: default to autonomous unless the user picked a
+  // level explicitly (so `kj autorun --autonomy assisted` still works).
+  const autoFlags = flags.autonomy || flags.autonomous ? flags : { ...flags, autonomous: true };
+
+  logger.info?.("kj autorun — planning…");
+  const plan = await planFn({ task, config, logger, flags: autoFlags });
+  if (!plan?.ok || !plan.planId) {
+    logger.error?.(`kj autorun: planning failed${plan?.reason ? ` (${plan.reason})` : ""}.`);
+    return { ok: false, stage: "plan", reason: plan?.reason ?? "plan-failed" };
+  }
+
+  logger.info?.(`kj autorun — running plan ${plan.ref ?? plan.planId} (${plan.huCount ?? "?"} HUs)…`);
+  const run = await runFn({ config, logger, flags: { ...autoFlags, plan: plan.planId } });
+
+  const ok = run?.ok === true;
+  logger.info?.(ok ? `✓ autorun complete — plan ${plan.ref ?? plan.planId} delivered.` : `✗ autorun: some HUs did not meet the ask — see the plan board.`);
+  return { ok, stage: ok ? "done" : "run", planId: plan.planId, ref: plan.ref ?? plan.planId };
+}

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -457,7 +457,7 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
 
   if (json) {
     console.log(JSON.stringify(plan, null, 2));
-    return { ok: true };
+    return { ok: true, planId, ref: plan.alias || planId, huCount: plan.hus.length };
   }
 
   if (parsed?.approach) {
@@ -524,5 +524,6 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       console.log(`\nVisualize: kj board start (http://localhost:${config?.hu_board?.port ?? 4000})`);
     }
   }
-  return { ok: true };
+  // KJC-TSK-0574: surface planId/ref so `kj autorun` can chain plan → run.
+  return { ok: true, planId, ref, huCount: plan.hus.length };
 }

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -95,7 +95,12 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // time. Static import is not an option: the binary attaches a
 // StdioServerTransport at top level, so a static import would launch the
 // MCP server on every `kj` invocation, not only `kj rag mcp`.
-const DYNAMIC_IMPORT_BUDGET = 167;
+//
+// 2026-06-20 (KJC-TSK-0574 `kj autorun` command): bumped 167 → 169. The
+// autorun action lazy-imports the spec resolver and the autorun chain
+// (which pulls in the heavy plan + run pipelines) only when invoked, so a
+// plain `kj` startup never loads them.
+const DYNAMIC_IMPORT_BUDGET = 169;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/commands/autorun.test.js
+++ b/tests/commands/autorun.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { autorunCommand } from "../../src/commands/autorun.js";
+
+const logger = { info: vi.fn(), error: vi.fn() };
+
+describe("autorunCommand", () => {
+  it("chains plan → run and defaults to autonomous, propagating ok", async () => {
+    const planFn = vi.fn().mockResolvedValue({ ok: true, planId: "plan_x", ref: "FEAT-1", huCount: 3 });
+    const runFn = vi.fn().mockResolvedValue({ ok: true });
+    const res = await autorunCommand({ task: "build X", config: {}, logger, flags: {}, planFn, runFn });
+
+    expect(res).toMatchObject({ ok: true, stage: "done", planId: "plan_x" });
+    expect(planFn.mock.calls[0][0].flags.autonomous).toBe(true); // implied autonomous
+    expect(runFn.mock.calls[0][0].flags.plan).toBe("plan_x"); // planId threaded into run
+  });
+
+  it("stops at the plan stage when planning fails (never runs)", async () => {
+    const planFn = vi.fn().mockResolvedValue({ ok: false, reason: "spec-review-cancelled" });
+    const runFn = vi.fn();
+    const res = await autorunCommand({ task: "x", config: {}, logger, flags: {}, planFn, runFn });
+
+    expect(res).toMatchObject({ ok: false, stage: "plan" });
+    expect(runFn).not.toHaveBeenCalled();
+  });
+
+  it("reports ok:false when some HUs did not meet the ask", async () => {
+    const planFn = vi.fn().mockResolvedValue({ ok: true, planId: "p", ref: "p", huCount: 2 });
+    const runFn = vi.fn().mockResolvedValue({ ok: false });
+    expect(await autorunCommand({ task: "x", config: {}, logger, flags: {}, planFn, runFn })).toMatchObject({ ok: false, stage: "run" });
+  });
+
+  it("respects an explicit --autonomy level instead of forcing autonomous", async () => {
+    const planFn = vi.fn().mockResolvedValue({ ok: true, planId: "p", ref: "p", huCount: 1 });
+    const runFn = vi.fn().mockResolvedValue({ ok: true });
+    await autorunCommand({ task: "x", config: {}, logger, flags: { autonomy: "assisted" }, planFn, runFn });
+    expect(planFn.mock.calls[0][0].flags.autonomy).toBe("assisted");
+    expect(planFn.mock.calls[0][0].flags.autonomous).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Completa **KJC-TSK-0574** (AUTO-C) — PR2 de 2. **La cadena desatendida.**

## Qué
`kj autorun <spec>` — un solo comando: **spec → plan → run de todas las HUs → resultado**. Por defecto en nivel **autonomous** (el Arbiter resuelve cada gate, sin humano):
- Reutiliza `kj plan` y `kj run --plan` (no los reimplementa). `planGenerateCommand` ahora **devuelve el `planId`** para poder encadenar.
- Si la planificación falla, **para en la fase plan** (no ejecuta).
- Propaga **exit code ≠ 0** cuando alguna HU no cumple el encargo.
- `--autonomy <level>` respeta un nivel explícito (`assisted`/`interactive`); `--task-file` para spec en fichero.

```
$ kj autorun spec.md
kj autorun — planning…
kj autorun — running plan FEAT-1 (3 HUs)…
✓ autorun complete — plan FEAT-1 delivered.
```

## Tests
`autorun.test.js` (planFn/runFn inyectados): encadena y fuerza autonomous + threadea planId; para en plan si falla (no corre); ok:false si HUs incumplen; respeta `--autonomy assisted`. 4/4. Net 99 LOC.

Con esto **AUTO-C queda completo**. El informe rico de resultado es AUTO-F; los backstops, AUTO-D.