### PR TITLE
feat(autonomy): auditable outcome report for autorun (AUTO-F)

### DIFF
--- a/src/autonomy/outcome-report.js
+++ b/src/autonomy/outcome-report.js
@@ -1,0 +1,55 @@
+/**
+ * outcome-report — the auditable "meets the ask, with known defects" report
+ * for an autonomous run (KJC-TSK-0577, design in docs/specs/autonomous-delivery.md §10).
+ *
+ * Pure: builds a serializable outcome from the run results + Arbiter decisions,
+ * and renders it as lines (or the structure is emitted as --json). The point is
+ * that an imperfect-but-delivered result is explicit and auditable: which HUs
+ * met the ask, what the Arbiter decided, and what debt remains.
+ */
+
+/**
+ * @param {object} opts
+ * @param {string} [opts.planRef]
+ * @param {boolean} opts.delivered - the run met the minimum ask
+ * @param {Array<{id, title?, met: boolean, note?}>} [opts.hus]
+ * @param {Array<{verdict, rationale, hu?, defect?}>} [opts.decisions] - Arbiter log
+ */
+export function buildOutcome({ planRef = null, delivered = false, hus = [], decisions = [] } = {}) {
+  const met = hus.filter((h) => h.met).length;
+  const residualDefects = [
+    ...hus.filter((h) => !h.met).map((h) => ({ hu: h.id, detail: h.note || "acceptance criteria not fully met" })),
+    ...decisions.filter((d) => d.defect).map((d) => ({ hu: d.hu ?? null, detail: d.defect })),
+  ];
+  return {
+    verdict: delivered ? "DELIVERED" : "INCOMPLETE",
+    planRef,
+    hus: { total: hus.length, met, unmet: hus.length - met },
+    decisions,
+    residualDefects,
+  };
+}
+
+/** Render an outcome (from buildOutcome) as human-readable lines. */
+export function formatOutcomeReport(outcome) {
+  const lines = [
+    `kj autorun — outcome: ${outcome.verdict}`,
+    `  plan: ${outcome.planRef ?? "?"}`,
+    `  HUs:  ${outcome.hus.met}/${outcome.hus.total} met the ask`,
+  ];
+  if (outcome.decisions?.length) {
+    lines.push("  Decisions (Arbiter — least-bad calls):");
+    for (const d of outcome.decisions) {
+      lines.push(`    • ${d.verdict}${d.hu ? ` [${d.hu}]` : ""} — ${d.rationale}`);
+    }
+  }
+  if (outcome.residualDefects?.length) {
+    lines.push("  Known defects (delivered with debt):");
+    for (const def of outcome.residualDefects) {
+      lines.push(`    • ${def.hu ? `[${def.hu}] ` : ""}${def.detail}`);
+    }
+  } else {
+    lines.push("  No residual defects recorded.");
+  }
+  return lines;
+}

--- a/src/commands/autorun.js
+++ b/src/commands/autorun.js
@@ -10,6 +10,7 @@
 
 import { planGenerateCommand } from "./plan/generate.js";
 import { runCommandHandler } from "./run.js";
+import { buildOutcome, formatOutcomeReport } from "../autonomy/outcome-report.js";
 
 export async function autorunCommand({
   task,
@@ -34,6 +35,15 @@ export async function autorunCommand({
   const run = await runFn({ config, logger, flags: { ...autoFlags, plan: plan.planId } });
 
   const ok = run?.ok === true;
-  logger.info?.(ok ? `✓ autorun complete — plan ${plan.ref ?? plan.planId} delivered.` : `✗ autorun: some HUs did not meet the ask — see the plan board.`);
-  return { ok, stage: ok ? "done" : "run", planId: plan.planId, ref: plan.ref ?? plan.planId };
+  // AUTO-F: emit the auditable outcome — delivered/incomplete, HUs that met the
+  // ask, Arbiter decisions and residual defects (enriched as the run surfaces
+  // them; baseline today is delivered + plan ref).
+  const outcome = buildOutcome({
+    planRef: plan.ref ?? plan.planId,
+    delivered: ok,
+    hus: run?.hus ?? [],
+    decisions: run?.decisions ?? [],
+  });
+  for (const line of formatOutcomeReport(outcome)) logger.info?.(line);
+  return { ok, stage: ok ? "done" : "run", planId: plan.planId, ref: plan.ref ?? plan.planId, outcome };
 }

--- a/tests/autonomy/outcome-report.test.js
+++ b/tests/autonomy/outcome-report.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOutcome, formatOutcomeReport } from "../../src/autonomy/outcome-report.js";
+
+describe("buildOutcome", () => {
+  it("marks DELIVERED with met counts and no defects when all HUs met the ask", () => {
+    const o = buildOutcome({ planRef: "FEAT-1", delivered: true, hus: [{ id: "h1", met: true }, { id: "h2", met: true }] });
+    expect(o).toMatchObject({ verdict: "DELIVERED", planRef: "FEAT-1", hus: { total: 2, met: 2, unmet: 0 }, residualDefects: [] });
+  });
+
+  it("marks INCOMPLETE and records residual defects from unmet HUs and decision defects", () => {
+    const o = buildOutcome({
+      planRef: "FEAT-2",
+      delivered: false,
+      hus: [{ id: "h1", met: true }, { id: "h2", met: false, note: "edge case unhandled" }],
+      decisions: [{ verdict: "ACCEPT_WITH_DEFECT", rationale: "tests pass", hu: "h1", defect: "no retry on 5xx" }],
+    });
+    expect(o.verdict).toBe("INCOMPLETE");
+    expect(o.hus).toMatchObject({ total: 2, met: 1, unmet: 1 });
+    expect(o.residualDefects).toEqual([
+      { hu: "h2", detail: "edge case unhandled" },
+      { hu: "h1", detail: "no retry on 5xx" },
+    ]);
+  });
+});
+
+describe("formatOutcomeReport", () => {
+  it("renders the verdict, HU tally, Arbiter decisions and known defects", () => {
+    const o = buildOutcome({
+      planRef: "FEAT-2",
+      delivered: true,
+      hus: [{ id: "h1", met: true }],
+      decisions: [{ verdict: "ACCEPT_WITH_DEFECT", rationale: "tests pass", hu: "h1", defect: "no retry on 5xx" }],
+    });
+    const text = formatOutcomeReport(o).join("\n");
+    expect(text).toContain("outcome: DELIVERED");
+    expect(text).toContain("1/1 met the ask");
+    expect(text).toContain("ACCEPT_WITH_DEFECT [h1] — tests pass");
+    expect(text).toContain("[h1] no retry on 5xx");
+  });
+
+  it("states there are no residual defects when clean", () => {
+    const text = formatOutcomeReport(buildOutcome({ planRef: "p", delivered: true, hus: [{ id: "h1", met: true }] })).join("\n");
+    expect(text).toContain("No residual defects recorded.");
+  });
+});


### PR DESCRIPTION
Cierra **KJC-TSK-0577** (AUTO-F, épica KJC-PCS-0062).

## Qué
`src/autonomy/outcome-report.js` — el informe **"cumple lo pedido, con defectos conocidos"** que hace **auditable** una entrega autónoma imperfecta:
- **`buildOutcome`** → estructura serializable: `verdict` (`DELIVERED`/`INCOMPLETE`), `hus` (met/unmet), `decisions` (log del Arbiter), `residualDefects` (de HUs no cumplidas + defectos de decisiones).
- **`formatOutcomeReport`** → líneas legibles: veredicto, recuento de HUs, **decisiones del Arbiter (las llamadas menos-malas)** y **defectos conocidos** (o "no residual defects").
- **`kj autorun`** lo emite al terminar.

```
kj autorun — outcome: DELIVERED
  plan: FEAT-2
  HUs:  1/1 met the ask
  Decisions (Arbiter — least-bad calls):
    • ACCEPT_WITH_DEFECT [h1] — tests pass
  Known defects (delivered with debt):
    • [h1] no retry on 5xx
```

Módulo puro y testeado (8/8). El detalle por-HU/decisión se enriquece según el run lo exponga (AUTO-E). Net 111 LOC.