### PR TITLE
feat(autonomy): non-blocking stage questions in autonomous mode (AUTO-E)

### DIFF
--- a/src/autonomy/stage-ask.js
+++ b/src/autonomy/stage-ask.js
@@ -1,0 +1,26 @@
+/**
+ * createAutonomyAskQuestion — make the stages' question function non-blocking in
+ * autonomous mode (KJC-TSK-0576, AUTO-E, design in docs/specs/autonomous-delivery.md §9).
+ *
+ * In `autonomous` no stage asks a human or routes to the HU Board: the wrapper
+ * answers in-process with the least-bad "keep going" choice, so the run never
+ * pauses or aborts mid-loop. interactive and assisted keep the human prompts
+ * (baseAsk) unchanged.
+ *
+ * The answer is chosen per stage so the EXISTING branches proceed (verified
+ * against the stage code — no stage logic is touched):
+ *   - architect clarification: null → the stage continues best-effort (a truthy
+ *     answer would force a wasteful architect re-run).
+ *   - everything else (Solomon escalation, checkpoint, …): "continue" → parsed
+ *     as free-text guidance → the stage continues instead of pausing/aborting.
+ */
+export function createAutonomyAskQuestion({ baseAsk = null, autonomy = "interactive", logger = console } = {}) {
+  if (autonomy !== "autonomous") return baseAsk;
+  const auto = async (_question, context = {}) => {
+    const stage = context?.stage ?? null;
+    logger?.info?.(`[autonomy] ${stage ? `${stage}: ` : ""}auto-continue (no human in the loop)`);
+    return stage === "architect" ? null : "continue";
+  };
+  auto.interactive = false;
+  return auto;
+}

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -18,6 +18,7 @@ import { maybeAutoUpdate } from "../rag/auto-update.js";
 // resume.js also needs the same contract.
 import { createCliAskQuestion } from "../utils/cli-ask-question.js";
 import { buildDecider } from "../autonomy/decider.js";
+import { createAutonomyAskQuestion } from "../autonomy/stage-ask.js";
 export { createCliAskQuestion };
 
 export async function runCommandHandler({ task, config, logger, flags }) {
@@ -150,9 +151,14 @@ export async function runCommandHandler({ task, config, logger, flags }) {
     // user actually approved.
     const effectiveTask = reviewResult.refined && reviewResult.finalSpec ? reviewResult.finalSpec : task;
 
+    // AUTO-E: in autonomous mode the stages never ask a human or block on the
+    // board — they auto-continue with the least-bad choice. interactive/assisted
+    // keep the human prompts.
+    const stageAsk = createAutonomyAskQuestion({ baseAsk: askQuestion, autonomy, logger });
+
     let result;
     try {
-      result = await runFlow({ task: effectiveTask, config, logger, flags, emitter, askQuestion, pgTaskId: pgCardId || null, pgProject: pgProject || null });
+      result = await runFlow({ task: effectiveTask, config, logger, flags, emitter, askQuestion: stageAsk, pgTaskId: pgCardId || null, pgProject: pgProject || null });
     } finally {
       // KJC-TSK-0396: limpia el registro pase lo que pase (éxito,
       // throw, o paused). Los handlers de SIGINT/SIGTERM/exit son

--- a/tests/autonomy/stage-ask.test.js
+++ b/tests/autonomy/stage-ask.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAutonomyAskQuestion } from "../../src/autonomy/stage-ask.js";
+
+describe("createAutonomyAskQuestion", () => {
+  it("interactive/assisted return the human ask unchanged", () => {
+    const baseAsk = vi.fn();
+    expect(createAutonomyAskQuestion({ baseAsk, autonomy: "interactive" })).toBe(baseAsk);
+    expect(createAutonomyAskQuestion({ baseAsk, autonomy: "assisted" })).toBe(baseAsk);
+  });
+
+  it("autonomous never calls the human ask and never blocks", async () => {
+    const baseAsk = vi.fn();
+    const auto = createAutonomyAskQuestion({ baseAsk, autonomy: "autonomous", logger: { info: vi.fn() } });
+    expect(auto).not.toBe(baseAsk);
+    expect(auto.interactive).toBe(false);
+    await auto("anything?", { stage: "tdd" });
+    expect(baseAsk).not.toHaveBeenCalled();
+  });
+
+  it("answers per stage so existing branches proceed (architect→null, else→continue)", async () => {
+    const auto = createAutonomyAskQuestion({ baseAsk: vi.fn(), autonomy: "autonomous", logger: { info: vi.fn() } });
+    // architect: a truthy answer would force a wasteful re-run → null keeps it best-effort.
+    expect(await auto("clarify?", { stage: "architect" })).toBeNull();
+    // Solomon escalation / checkpoint: "continue" is parsed as free-text guidance → proceed.
+    expect(await auto("resolve?", { stage: "tdd" })).toBe("continue");
+    expect(await auto("checkpoint?", {})).toBe("continue");
+  });
+});


### PR DESCRIPTION
Cierra **KJC-TSK-0576** (AUTO-E). **Lo que hace que `kj autorun` corra de verdad hasta el final.**

## El problema que cierra
Antes de esto, en modo autónomo los stages internos (architect, coder/TDD→Solomon, checkpoint) seguían preguntando: en no-TTY se **colgaban en el board** o **pausaban la sesión** a mitad del run. Es decir, `kj autorun` se plantaba en la primera pregunta de un stage.

## Qué
`src/autonomy/stage-ask.js` — `createAutonomyAskQuestion(baseAsk, autonomy)` envuelve la función de preguntas de los stages:
- **autonomous**: ningún stage pregunta a un humano ni bloquea en el board; responde en proceso con la opción **menos mala de seguir**, elegida **por stage** para que las ramas existentes continúen (verificado contra el código de cada stage, **sin tocar su lógica**):
  - architect → `null` (continúa best-effort; una respuesta truthy forzaría un re-run inútil).
  - Solomon / checkpoint → `"continue"` (parseado como guía free-text → continúa, no pausa).
- **interactive/assisted** → devuelve `baseAsk` **idéntico** → los runs normales **no cambian nada** (opt-in puro).

## Seguridad
Verifiqué `escalateToHuman` (sin askQuestion → **pausa**), `parseEscalationAnswer("continue")` (→ continue), `parseCheckpointAnswer` (→ continue_loop) y la rama `!askQuestion` del architect (→ best-effort). Por eso el wrapper es context-aware, no un null genérico.

## Tests
`stage-ask.test.js`: identidad en interactive/assisted; autónomo nunca llama a baseAsk; respuestas por stage. 29/29 en suites autonomy+command-run. Net 61 LOC.

Con esto **AUTO-E queda completo**. Falta AUTO-D (backstops) y la verificación live de `kj autorun`.