### PR TITLE
feat(autonomy): enforce the wall-clock in autonomous runs (AUTO-D)

### DIFF
--- a/src/autonomy/stage-ask.js
+++ b/src/autonomy/stage-ask.js
@@ -22,5 +22,9 @@ export function createAutonomyAskQuestion({ baseAsk = null, autonomy = "interact
     return stage === "architect" ? null : "continue";
   };
   auto.interactive = false;
+  // Marker so the orchestrator can tell an autonomous (unattended) run from an
+  // interactive one even though both carry a truthy askQuestion — the wall-clock
+  // backstop relies on it (KJC-TSK-0575, AUTO-D).
+  auto.unattended = true;
   return auto;
 }

--- a/src/orchestrator/flow-control.js
+++ b/src/orchestrator/flow-control.js
@@ -128,7 +128,13 @@ export function parseCheckpointAnswer({ trimmedAnswer, checkpointDisabled, confi
 }
 
 export async function checkSessionTimeout({ askQuestion, elapsedMinutes, config, session, emitter, eventBase, i, budgetSummary }) {
-  if (askQuestion || elapsedMinutes <= config.session.max_total_minutes) return;
+  // Enforce the wall-clock when no human is watching the checkpoint: either a
+  // non-interactive run (no askQuestion) OR an autonomous one — where askQuestion
+  // is the auto-continue wrapper (truthy) but nobody is there to stop a runaway.
+  // Interactive runs keep skipping it (the human decides at the checkpoint).
+  // KJC-TSK-0575 (AUTO-D): without this, autonomous runs had NO wall-clock cap.
+  const unattended = !askQuestion || askQuestion.unattended === true;
+  if (!unattended || elapsedMinutes <= config.session.max_total_minutes) return;
 
   await markSessionStatus(session, "failed");
   emitProgress(

--- a/tests/orchestrator/session-timeout.test.js
+++ b/tests/orchestrator/session-timeout.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/session/store.js", () => ({ markSessionStatus: vi.fn() }));
+
+import { checkSessionTimeout } from "../../src/orchestrator/flow-control.js";
+
+const base = {
+  config: { session: { max_total_minutes: 120 } },
+  session: {},
+  emitter: null,
+  eventBase: {},
+  i: 1,
+  budgetSummary: () => ({}),
+};
+
+describe("checkSessionTimeout (AUTO-D wall-clock)", () => {
+  it("never fires within the time budget", async () => {
+    await expect(checkSessionTimeout({ ...base, askQuestion: null, elapsedMinutes: 10 })).resolves.toBeUndefined();
+  });
+
+  it("interactive runs skip the wall-clock even past the budget (the human decides)", async () => {
+    const interactiveAsk = () => {}; // truthy, no `unattended` marker
+    await expect(checkSessionTimeout({ ...base, askQuestion: interactiveAsk, elapsedMinutes: 999 })).resolves.toBeUndefined();
+  });
+
+  it("autonomous runs ENFORCE the wall-clock past the budget — closes the runaway gap", async () => {
+    const autonomousAsk = Object.assign(() => {}, { unattended: true });
+    await expect(checkSessionTimeout({ ...base, askQuestion: autonomousAsk, elapsedMinutes: 999 })).rejects.toThrow(/timed out/i);
+  });
+
+  it("non-interactive runs still enforce it (unchanged behaviour)", async () => {
+    await expect(checkSessionTimeout({ ...base, askQuestion: null, elapsedMinutes: 999 })).rejects.toThrow(/timed out/i);
+  });
+});


### PR DESCRIPTION
Avanza **KJC-TSK-0575** (AUTO-D backstops). El trozo crítico.

## El hueco real que cierra
`checkSessionTimeout` se saltaba el wall-clock **siempre que `askQuestion` fuera truthy** (`if (askQuestion || elapsed <= max) return`). Tras AUTO-E, en modo autónomo `askQuestion` es el wrapper auto-continue (truthy) → **el run desatendido se quedaba sin tope de tiempo**. Justo el modo que más lo necesita.

## Qué
- El wrapper autónomo (AUTO-E) ahora lleva un marcador `unattended = true`.
- `checkSessionTimeout` calcula `unattended = !askQuestion || askQuestion.unattended` y **aplica `max_total_minutes` cuando es unattended** (no hay humano mirando). Los runs **interactive siguen saltándoselo** (el humano decide en el checkpoint). Sin cambios para no-TTY.

## Lo que ya existía (no reinvento)
- **Board-prompt timeout** (30 min) — ya estaba.
- **Exit code** — ya hecho en AUTO-C (`kj autorun` propaga ≠0).
- **Auto-resume programado tras cuota** — pieza mayor (necesita scheduler/daemon), va como **follow-up** aparte.

## Tests
`session-timeout.test.js`: dentro de presupuesto no dispara; interactive se lo salta aun pasado el tope; **autónomo lo aplica** (runaway cerrado); no-TTY igual que antes. 28/28 en flow-control+command-run. Net 44 LOC.