### PR TITLE
fix(autorun): real per-HU outcome report + cost DB init (KJC-BUG-0090)

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -362,6 +362,17 @@ export function getDb() {
 }
 
 /**
+ * Lazily initialise the DB if it isn't open yet (KJC-BUG-0090). The cost
+ * writers run from `kj run`/`kj autorun` paths that may never start the board
+ * (which is what normally calls initDb), so cost writes failed with
+ * "Database not initialized". This makes those writers self-sufficient.
+ */
+export function ensureDb() {
+  if (!db) initDb();
+  return db;
+}
+
+/**
  * Inserts or updates a project record.
  * @param {{ id: string, name?: string, first_seen?: string, last_activity?: string, total_stories?: number }} project
  */

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -174,6 +174,12 @@ export async function runCommandHandler({ task, config, logger, flags }) {
       // failed), tell the user the exact command to resume it.
       printResumeHint(result);
     }
-    return { ok: !result?.paused && result?.approved !== false };
+    // Surface per-HU results so `kj autorun` can build a real outcome report
+    // (KJC-BUG-0090: it showed "0/0 met the ask" because only { ok } came back).
+    // The plan run returns them as `huResults` (run-hu-batch finalResult).
+    const hus = Array.isArray(result?.huResults)
+      ? result.huResults.map((r) => ({ id: r.huId, met: r.approved === true }))
+      : [];
+    return { ok: !result?.paused && result?.approved !== false, hus };
   });
 }

--- a/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
+++ b/src/orchestrator/drivers/pre-loop-phases/inject-loaded-plan.js
@@ -316,7 +316,8 @@ function wirePlanCallbacks({ session, loadedPlan, projectDir, syncResultsToPlan,
       await savePlanToDisk(projectDir, loadedPlan);
       if (outcome && Number.isFinite(outcome.cost_usd)) {
         try {
-          const { setStoryCost, setStoryCachedTokens } = await import("../../../../packages/hu-board/src/db.js");
+          const { ensureDb, setStoryCost, setStoryCachedTokens } = await import("../../../../packages/hu-board/src/db.js");
+          ensureDb(); // KJC-BUG-0090: autorun/run may not have started the board
           setStoryCost(huId, outcome.cost_usd);
           // Φ0-G (KJC-TSK-0525): cached/in tokens travel in the same
           // outcome blob as cost. Write them together so the board

--- a/tests/commands/autorun.test.js
+++ b/tests/commands/autorun.test.js
@@ -30,6 +30,14 @@ describe("autorunCommand", () => {
     expect(await autorunCommand({ task: "x", config: {}, logger, flags: {}, planFn, runFn })).toMatchObject({ ok: false, stage: "run" });
   });
 
+  it("builds a real outcome from the run's per-HU results (KJC-BUG-0090)", async () => {
+    const planFn = vi.fn().mockResolvedValue({ ok: true, planId: "p", ref: "p", huCount: 2 });
+    const runFn = vi.fn().mockResolvedValue({ ok: false, hus: [{ id: "h1", met: true }, { id: "h2", met: false }] });
+    const res = await autorunCommand({ task: "x", config: {}, logger, flags: {}, planFn, runFn });
+    expect(res.outcome).toMatchObject({ verdict: "INCOMPLETE", hus: { total: 2, met: 1, unmet: 1 } });
+    expect(res.outcome.residualDefects).toHaveLength(1);
+  });
+
   it("respects an explicit --autonomy level instead of forcing autonomous", async () => {
     const planFn = vi.fn().mockResolvedValue({ ok: true, planId: "p", ref: "p", huCount: 1 });
     const runFn = vi.fn().mockResolvedValue({ ok: true });


### PR DESCRIPTION
Cierra **KJC-BUG-0090**. Dos defectos que **destapó un `kj autorun` real** (los tests unitarios no los veían — el valor de verificar en vivo).

## Contexto
La verificación live de `kj autorun` confirmó que la cadena **entrega software funcionando** (DELIVERED, `node --test` pasa, sin humano). Pero el run real mostró 2 fallos:

## Fix 1 — cost DB not initialized
`Cost write failed: Database not initialized` (recurrente): `initDb()` solo se llama al arrancar el board, y autorun/run no lo arrancan. → Añado **`ensureDb()`** (init-si-falta) en `packages/hu-board/src/db.js` y lo llamo antes del cost-write por HU en `inject-loaded-plan.js`.

## Fix 2 — informe 0/0
El informe decía `HUs: 0/0 met the ask` aunque entregaba HUs. `runCommandHandler` devolvía solo `{ ok }`. → Surfaceo los resultados por-HU. **Clave**: el primer intento leía `result.results` (vacío); el campo correcto es **`result.huResults`** (lo expone `run-hu-batch` como `finalResult.huResults`) — **esto solo se vio en el run live**, no en unit tests.

## Verificado en vivo (3 runs reales)
```
kj autorun spec.md --autonomous
→ DELIVERED · HUs: 2/2 met the ask · 0 cost warnings · node --test 6 pass
```

## Tests
`autorun.test.js`: nuevo caso — runFn con `hus` → outcome real (met/unmet + defectos). 13/13 en autorun+command-run. Net ~25 LOC (`src/` lint limpio; los `console` de db.js son pre-existentes y CI no lintea packages/).