### PR TITLE
chore(release): v3.7.0 — autonomous delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-06-21
+
+Minor. **Autonomous delivery** — give Karajan a spec and it runs to completion unattended, resolving agent conflicts itself (epic KJC-PCS-0062).
+
+### Added
+
+- **`kj autorun <spec>`** — one command chains spec → plan → run every HU → outcome, defaulting to the autonomous level so no human is in the loop. Reuses `kj plan` and `kj run --plan`; propagates a non-zero exit code when HUs don't meet the ask (KJC-TSK-0574).
+- **Autonomy levels** `interactive | assisted | autonomous` (`--autonomy <level>` / `--autonomous`, also on `kj run`). A single decision resolver routes every gate to the human or to the Arbiter depending on the level (KJC-TSK-0572).
+- **The Arbiter** — an autonomous decision authority that resolves agent conflicts (reviewer vs coder, failing acceptance tests, ambiguous spec) by picking the **least-bad** verdict from a closed set (`ACCEPT_WITH_DEFECT` / `RETRY_DIFFERENT_APPROACH` / `DESCOPE_HU` / `BLOCK_AND_CONTINUE` / `PROCEED`), with the ground-truth order *acceptance tests > must-fix > nice-to-have*. Any parse failure degrades to the conservative verdict — it never crashes or blocks (KJC-TSK-0573).
+- **Outcome report** — `kj autorun` ends with an auditable "meets the ask, with known defects" summary: DELIVERED/INCOMPLETE, which HUs met the ask, the Arbiter's decisions, and residual defects (KJC-TSK-0577).
+
+### Changed
+
+- In autonomous mode the spec-review gate and every pipeline stage no longer ask a human or block on the board — they auto-continue with the least-bad choice, and the wall-clock backstop is enforced for unattended runs so a run can't pause or run away (KJC-TSK-0572, 0576, 0575).
+
+### Fixed
+
+- `kj autorun` cost writes no longer fail with "Database not initialized", and the outcome report shows the real per-HU count instead of `0/0` — both found by live end-to-end runs (KJC-BUG-0090).
+
+Verified live: `kj autorun spec.md --autonomous` plans, builds and tests a module with no human, ending DELIVERED. Scheduled auto-resume after a quota reset is a follow-up (KJC-TSK-0578).
+
 ## [3.6.0] - 2026-06-19
 
 Minor. **Advisory harden** — `kj harden` learns to compare instead of just install, plus a rounder first-run and the ai-trash safety net actually reaching npm users.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.6.0 released** — Advisory harden: `kj harden --report` shows what the kj standard would add to an existing repo (per artifact: missing / yours / kj-managed, plus the concrete improvements), and `kj harden --interactive` lets you adopt it piece by piece, default-safe. Plus scope control (`--only`/`--exclude`, demo/fixture dirs ignored), a rounder `kj init` first run (consistent English, glossed terms, clean close), and the `kj-trash` safety net now actually ships to npm installs. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.7.0 released** — Autonomous delivery: `kj autorun <spec>` chains spec → plan → run every user story → outcome in one command, unattended. An **Arbiter** resolves agent conflicts by picking the least-bad call (acceptance tests > must-fix > nice-to-have), no stage blocks for a human, a wall-clock backstop stops runaways, and it ends with an auditable "delivered, with known defects" report. Autonomy is opt-in (`--autonomous` / `--autonomy <level>`); interactive runs are unchanged. Verified live end-to-end. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.6.0
+kj --version    # 3.7.0
 kj doctor       # Check environment
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v3.7.0 — Autonomous Delivery

Release of the **Autonomous Delivery** epic (KJC-PCS-0062): given a spec, Karajan plans, creates HUs, and runs to completion unattended — resolving agent conflicts by picking the least-bad answer and delivering a result that meets the ask even with residual defects.

### Highlights
- **Autonomy axis** `interactive | assisted | autonomous` (`--autonomy`/`--autonomous`, `KJ_AUTONOMY`, config; default `interactive` — normal runs unchanged).
- **The Arbiter** — resolves agent conflicts with a closed verdict set, ground-truth order: acceptance tests > must-fix > nice-to-have.
- **`kj autorun <spec>`** — chains plan → run → outcome report atomically, with exit-code propagation.
- **Non-blocking autonomous stages** + **wall-clock backstop** so unattended runs never hang.
- **Outcome report** — DELIVERED / INCOMPLETE with residual defects listed.

Live-verified end-to-end on real specs (real claude coder + codex reviewer, `node --test` passing, no human). Verification surfaced and fixed KJC-BUG-0090.

Verify-pack green at 3.7.0.

Closes the v3.7.0 release.