### PR TITLE
fix(init): add wizard.input so Plan B fallback prompt works

### DIFF
--- a/src/utils/wizard.js
+++ b/src/utils/wizard.js
@@ -1,7 +1,7 @@
 import readline from "node:readline";
 
-export function createWizard(input = process.stdin, output = process.stdout) {
-  const rl = readline.createInterface({ input, output, terminal: false });
+export function createWizard(inputStream = process.stdin, output = process.stdout) {
+  const rl = readline.createInterface({ input: inputStream, output, terminal: false });
 
   function ask(question) {
     return new Promise((resolve) => {
@@ -14,6 +14,12 @@ export function createWizard(input = process.stdin, output = process.stdout) {
     const answer = await ask(`${question} ${hint} `);
     if (answer === "") return defaultValue;
     return /^y(es)?$/i.test(answer);
+  }
+
+  async function input(question, defaultValue = "") {
+    const hint = defaultValue !== "" ? ` [${defaultValue}]` : "";
+    const answer = await ask(`${question}${hint} `);
+    return answer === "" ? defaultValue : answer;
   }
 
   async function select(question, options) {
@@ -33,7 +39,7 @@ export function createWizard(input = process.stdin, output = process.stdout) {
     rl.close();
   }
 
-  return { ask, confirm, select, close };
+  return { ask, confirm, input, select, close };
 }
 
 export function isTTY() {

--- a/tests/wizard.test.js
+++ b/tests/wizard.test.js
@@ -120,6 +120,36 @@ describe("wizard", () => {
     expect(result).toBe("first");
     wizard.close();
   });
+
+  it("input returns the typed value", async () => {
+    const input = makeInput(["24"]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const answer = await wizard.input("Hours:", "12");
+    expect(answer).toBe("24");
+    wizard.close();
+  });
+
+  it("input falls back to the default on empty input", async () => {
+    const input = makeInput([""]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    const answer = await wizard.input("Hours:", "12");
+    expect(answer).toBe("12");
+    wizard.close();
+  });
+
+  it("input shows the default as a [hint]", async () => {
+    const input = makeInput([""]);
+    const output = makeOutput();
+    const wizard = createWizard(input, output);
+
+    await wizard.input("Hours:", "12");
+    expect(output.getOutput()).toContain("[12]");
+    wizard.close();
+  });
 });
 
 describe("isTTY", () => {


### PR DESCRIPTION
## KJC-BUG-0091 — `kj init` crash: `wizard.input is not a function`

During `kj init`, answering `y` to **"Plan B — Configure a fallback?"** crashed with `wizard.input is not a function`.

### Root cause
`src/commands/init.js:172` calls `await wizard.input("  Max wait before falling back (hours):", "12")`, but `createWizard` (`src/utils/wizard.js`) only exposed `ask`, `confirm`, `select`, `close`. The `input` method never existed; the consumer assumed a `confirm`-style `(question, defaultValue)` API. The branch only runs with ≥2 providers detected **and** answering `y`, so existing tests never hit it.

### Fix
Add `input(question, defaultValue)` to the wizard — symmetric with `confirm`: shows a `[default]` hint and returns the default on empty input. (Also renamed the internal stream param `input` → `inputStream` to avoid shadowing the new method.) No change needed in `init.js`.

### Tests
- 3 new wizard tests (typed value, empty → default, `[hint]` shown). 12/12 wizard green.
- init-wizard + installer-e2e: 32/32 green.
- Smoke: the exact crashing call now returns `"12"` → `12h`.

Note: this is a code bug, independent of the package manager (npm/pnpm/yarn). pnpm support is being tracked separately.