### PR TITLE
fix(doctor): warn when pnpm skipped the better-sqlite3 native build

### DIFF
--- a/src/checks/native-build.js
+++ b/src/checks/native-build.js
@@ -1,0 +1,64 @@
+/**
+ * Native build availability check (KJC-BUG-0092).
+ *
+ * better-sqlite3 ships a native addon compiled in a postinstall step. pnpm
+ * blocks dependency build scripts by default (ERR_PNPM_IGNORED_BUILDS), so a
+ * `pnpm add -g karajan-code` leaves the addon uncompiled: `kj --version` still
+ * works (it never opens a DB) but any DB-backed command (board, rag, cost
+ * tracking) crashes with "Cannot find module 'better-sqlite3'". This surfaces a
+ * WARN in `kj doctor` with the exact remedy instead of a cryptic runtime crash.
+ */
+
+import { STRATEGY } from "./types.js";
+
+/** pnpm lays packages out under a `.pnpm` virtual store and symlinks them in. */
+function isPnpmInstall() {
+  return (
+    import.meta.url.includes("/.pnpm/") ||
+    (process.env.npm_config_user_agent || "").includes("pnpm")
+  );
+}
+
+/** Force the native binding to load by opening an in-memory database. */
+async function defaultLoadDb() {
+  const Database = (await import("better-sqlite3")).default;
+  new Database(":memory:").close();
+}
+
+export function createNativeBuildCheck({ loadDb = defaultLoadDb, isPnpm = isPnpmInstall } = {}) {
+  return {
+    name: "native-build",
+    label: "native modules (better-sqlite3)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      try {
+        await loadDb();
+        return {
+          ok: true,
+          severity: "info",
+          detail: "better-sqlite3 native addon loads — DB-backed commands available",
+        };
+      } catch (err) {
+        const firstLine = String(err?.message || err).split("\n")[0];
+        if (isPnpm()) {
+          return {
+            ok: false,
+            severity: "warn",
+            detail: "better-sqlite3 native build was skipped — pnpm blocks dependency build scripts by default",
+            fix: "Approve the build then reinstall: `pnpm approve-builds better-sqlite3` — or install with npm: `npm i -g karajan-code`",
+          };
+        }
+        return {
+          ok: false,
+          severity: "warn",
+          detail: `better-sqlite3 failed to load: ${firstLine}`,
+          fix: "Reinstall to rebuild native modules: `npm i -g karajan-code`",
+        };
+      }
+    },
+  };
+}
+
+export function getNativeBuildChecks() {
+  return [createNativeBuildCheck()];
+}

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -26,6 +26,7 @@ import { getSqueezrChecks } from "../checks/squeezr.js";
 import { getAiTrashChecks } from "../checks/ai-trash.js";
 import { getQmdChecks } from "../checks/qmd.js";
 import { getNodeChecks } from "../checks/node.js";
+import { getNativeBuildChecks } from "../checks/native-build.js";
 import { getPortChecks } from "../checks/ports.js";
 import { getTokenChecks } from "../checks/tokens.js";
 import { getMcpHealthChecks } from "../checks/mcp-health.js";
@@ -54,6 +55,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
   return [
     ...getSystemChecks(),
     ...getNodeChecks(),
+    ...getNativeBuildChecks(),
     ...getHardwareChecks(),
     ...getDirSetupChecks(),
     ...getConfigFileChecks(),

--- a/tests/checks/native-build.test.js
+++ b/tests/checks/native-build.test.js
@@ -1,0 +1,38 @@
+// KJC-BUG-0092 — `kj doctor` native-build (better-sqlite3) check.
+import { describe, expect, it } from "vitest";
+import { createNativeBuildCheck } from "../../src/checks/native-build.js";
+
+describe("checks/native-build — KJC-BUG-0092", () => {
+  it("ok when the native addon loads", async () => {
+    const check = createNativeBuildCheck({ loadDb: async () => {}, isPnpm: () => false });
+    const r = await check.detect();
+    expect(r).toMatchObject({ ok: true, severity: "info" });
+    expect(r.detail).toMatch(/better-sqlite3/);
+  });
+
+  it("warns with the pnpm remedy when the build was skipped under pnpm", async () => {
+    const check = createNativeBuildCheck({
+      loadDb: async () => {
+        throw new Error("Cannot find module 'better-sqlite3'");
+      },
+      isPnpm: () => true,
+    });
+    const r = await check.detect();
+    expect(r).toMatchObject({ ok: false, severity: "warn" });
+    expect(r.detail).toMatch(/pnpm/i);
+    expect(r.fix).toMatch(/approve-builds/);
+  });
+
+  it("warns with a reinstall remedy when it fails outside pnpm", async () => {
+    const check = createNativeBuildCheck({
+      loadDb: async () => {
+        throw new Error("boom");
+      },
+      isPnpm: () => false,
+    });
+    const r = await check.detect();
+    expect(r).toMatchObject({ ok: false, severity: "warn" });
+    expect(r.fix).toMatch(/npm i -g karajan-code/);
+    expect(r.fix).not.toMatch(/approve-builds/);
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0092 — pnpm install leaves karajan unable to open its DB

Verified live (pnpm 11.5.2, 3.7.0 tarball): `pnpm add -g karajan-code` installs, but pnpm **blocks dependency build scripts by default** (`ERR_PNPM_IGNORED_BUILDS`), so `better-sqlite3` never compiles its native addon. `kj --version` still works (it never opens a DB), but `kj board` / `kj rag` / cost-tracking crash with `Cannot find module 'better-sqlite3'`. npm doesn't hit this because it runs postinstall.

### This PR (the warning — part 1 of 2)
New `kj doctor` check `native-build`: opens an in-memory `better-sqlite3` DB; on failure it detects a pnpm layout (`/.pnpm/` in the module path or the pnpm user-agent) and surfaces the exact remedy instead of a cryptic crash.

```
⚠ native modules (better-sqlite3): build was skipped — pnpm blocks dependency build scripts by default
  → pnpm approve-builds better-sqlite3  (then reinstall) — or: npm i -g karajan-code
```

Outside pnpm the same failure points at a plain reinstall.

### Tests
3 new check tests (ok / pnpm-warn / non-pnpm-warn), injectable `loadDb`+`isPnpm`. Real detect smoke returns `ok` on this npm-built tree.

Part 2 (KJC-TSK-0580): a pnpm smoke in `verify-pack` so every release catches this automatically. Ships together in v3.7.1.