### PR TITLE
chore(release): v3.7.1 — init fallback fix + pnpm safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-06-22
+
+Patch. Onboarding and package-manager robustness.
+
+### Fixed
+
+- **`kj init` crash configuring Plan B** (KJC-BUG-0091): answering `y` to the fallback-chain prompt threw `wizard.input is not a function`. The interactive wizard never exposed an `input` method; added one (symmetric with `confirm`, with a `[default]` hint). Independent of the package manager.
+- **pnpm installs left karajan unable to open its DB** (KJC-BUG-0092): pnpm blocks dependency build scripts by default, so `better-sqlite3`'s native addon never compiles — `kj --version` works (lazy) but any DB-backed command (`board`, `rag`, cost tracking) crashed with `Cannot find module 'better-sqlite3'`. `kj doctor` now detects the pnpm layout and surfaces the exact remedy (`pnpm approve-builds better-sqlite3`, or install with npm) instead of a cryptic crash.
+
+### Changed
+
+- **Release gate now checks pnpm** (KJC-TSK-0580): `verify-pack` additionally installs the tarball with pnpm and asserts `kj` boots under pnpm's symlinked store, so a pnpm packaging regression is caught every release (CI runs it via `corepack`). The native-build limitation is inherent to pnpm and is surfaced as the doctor warning above.
+
 ## [3.7.0] - 2026-06-21
 
 Minor. **Autonomous delivery** — give Karajan a spec and it runs to completion unattended, resolving agent conflicts itself (epic KJC-PCS-0062).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-> **v3.7.0 released** — Autonomous delivery: `kj autorun <spec>` chains spec → plan → run every user story → outcome in one command, unattended. An **Arbiter** resolves agent conflicts by picking the least-bad call (acceptance tests > must-fix > nice-to-have), no stage blocks for a human, a wall-clock backstop stops runaways, and it ends with an auditable "delivered, with known defects" report. Autonomy is opt-in (`--autonomous` / `--autonomy <level>`); interactive runs are unchanged. Verified live end-to-end. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v3.7.1 released** — Patch: fixes a `kj init` crash when configuring the Plan B fallback, and makes pnpm installs safe — `kj doctor` now flags when pnpm skipped `better-sqlite3`'s native build and tells you exactly how to fix it (`pnpm approve-builds better-sqlite3`). The release gate checks pnpm too. Built on **v3.7.0 — Autonomous delivery**: `kj autorun <spec>` chains spec → plan → run every user story → outcome in one command, unattended, with an **Arbiter** that resolves agent conflicts by picking the least-bad call; autonomy is opt-in, interactive runs are unchanged. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
 
@@ -109,6 +109,8 @@ npm install -g karajan-code
 ```bash
 brew install manufosela/tap/karajan-code
 ```
+
+> **Installing with pnpm?** pnpm blocks dependency build scripts by default, so `better-sqlite3`'s native addon won't compile on install and DB-backed commands (`board`, `rag`, cost tracking) will fail. After installing, run `pnpm approve-builds better-sqlite3` — or just use npm. `kj doctor` flags this if it happens.
 
 **Standalone binary** (no Node.js needed):
 ```bash

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.7.0
+kj --version    # 3.7.1
 kj doctor       # Check environment
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v3.7.1 — patch

Onboarding + package-manager robustness. Groups three already-merged fixes:

- **KJC-BUG-0091** — `kj init` no longer crashes (`wizard.input is not a function`) when configuring the Plan B fallback.
- **KJC-BUG-0092** — `kj doctor` warns when a pnpm install skipped `better-sqlite3`'s native build, with the exact remedy (`pnpm approve-builds better-sqlite3`).
- **KJC-TSK-0580** — `verify-pack` now also smokes a pnpm install so every release is checked against pnpm.

README gains a pnpm install note. verify-pack green at 3.7.1 (npm + pnpm paths).