### PR TITLE
fix(board): deep-link HU Board via #board/<slug> hash route (KJC-BUG-0093)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- **`kj plan` printed a broken HU Board deep-link** (KJC-BUG-0093): the auto-start banner pointed at `http://localhost:4000/p/<slug>`, a path the SPA router doesn't recognise, so the user landed on the global "All projects" dashboard instead of their project. `buildBoardUrl` now emits the canonical hash route `http://localhost:4000/#board/<slug>` used by the frontend router. Fixes the URL for `kj plan`, `kj run` and auto-HU batch alike (single source of truth).
 
 ## [3.7.1] - 2026-06-22
 

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -77,15 +77,18 @@ async function findAvailablePort(desiredPort, maxTries = 10) {
 
 /**
  * Build the board URL. When `projectSlug` is provided, the URL points at
- * the per-project view (`/p/<slug>`) so the caller's project shows up
- * pre-filtered instead of "All projects".
+ * the per-project view via the SPA hash route (`#board/<slug>`) so the
+ * caller's project shows up pre-filtered instead of "All projects". The
+ * frontend router is hash-based (see public/utils/init-listeners.js); a
+ * real `/p/<slug>` path is not a route and silently falls back to the
+ * global dashboard. KJC-BUG-0093.
  * @param {number} port
  * @param {string|null} [projectSlug]
  * @returns {string}
  */
-function buildBoardUrl(port, projectSlug) {
+export function buildBoardUrl(port, projectSlug) {
   const base = `http://localhost:${port}`;
-  return projectSlug ? `${base}/p/${projectSlug}` : base;
+  return projectSlug ? `${base}/#board/${projectSlug}` : base;
 }
 
 /**

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -513,8 +513,8 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       const { projectSlug: slugFor } = await import("../../plan/plan-store.js");
       const boardPort = config?.hu_board?.port ?? 4000;
       // `projectSlug` scopes the board URL to this project's view
-      // (`/p/<slug>`) instead of the global "All projects" dashboard. The
-      // board UI hides multi-project chrome when it sees that prefix.
+      // (`#board/<slug>`) instead of the global "All projects" dashboard.
+      // The hash route opens the board pre-filtered to that project.
       const boardResult = await startBoard(boardPort, { projectSlug: slugFor(projectDir) });
       const status = boardResult.alreadyRunning ? "already running" : "started";
       console.log(renderBoardBanner({ url: boardResult.url, status, projectName: plan.name }));

--- a/src/orchestrator/drivers/post-loop.js
+++ b/src/orchestrator/drivers/post-loop.js
@@ -347,8 +347,8 @@ export async function tryAutoStartBoard(config, logger, emitter, eventBase) {
   try {
     const { startBoard, renderBoardBanner } = await import("../../commands/board.js");
     const boardPort = config.hu_board.port || 4000;
-    // Scope the board URL to the current run's project (`/p/<slug>`) so
-    // the user lands on a filtered view, not the global dashboard.
+    // Scope the board URL to the current run's project (`#board/<slug>`)
+    // so the user lands on a filtered view, not the global dashboard.
     const slug = config.projectDir ? slugFor(config.projectDir) : null;
     const boardResult = await startBoard(boardPort, { projectSlug: slug });
     const status = boardResult.alreadyRunning ? "already running" : "started";

--- a/tests/board/board-banner-shape.test.js
+++ b/tests/board/board-banner-shape.test.js
@@ -28,7 +28,7 @@ describe("renderBoardBanner", () => {
   });
 
   it("rules width matches the longest content line (or terminal width, whichever is smaller)", () => {
-    const url = "http://localhost:4000/p/very-long-project-slug-that-might-exceed-old-50-char-box";
+    const url = "http://localhost:4000/#board/very-long-project-slug-that-might-exceed-old-50-char-box";
     const out = renderBoardBanner({ url, status: "started", projectName: "Demo" });
     const lines = out.split("\n").filter(Boolean);
     const maxContentWidth = Math.max(
@@ -50,7 +50,7 @@ describe("renderBoardBanner", () => {
 
   it("never draws a fixed-width 50-char box (the old broken layout)", () => {
     const out = renderBoardBanner({
-      url: "http://localhost:4000/p/home_manu_ws_ai_linux-assistant-orchestrator",
+      url: "http://localhost:4000/#board/home_manu_ws_ai_linux-assistant-orchestrator",
       status: "started",
       projectName: "Linux Assistant Orchestrator",
     });

--- a/tests/board/build-board-url.test.js
+++ b/tests/board/build-board-url.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildBoardUrl } from "../../src/commands/board.js";
+
+// The HU Board frontend is a hash-routed SPA: opening a project
+// pre-filtered means the deep-link must carry `#board/<slug>`, not a
+// real path. `/p/<slug>` is not a router route — the SPA fallback serves
+// index.html with no hash and the user lands on "All projects" instead.
+// KJC-BUG-0093.
+describe("buildBoardUrl", () => {
+  it("deep-links a project via the hash route #board/<slug>", () => {
+    expect(buildBoardUrl(4000, "home_aitor_git_transports_tracker")).toBe(
+      "http://localhost:4000/#board/home_aitor_git_transports_tracker"
+    );
+  });
+
+  it("never emits the broken /p/<slug> path route", () => {
+    expect(buildBoardUrl(4321, "demo")).not.toMatch(/\/p\//);
+  });
+
+  it("returns the bare base URL when no project slug is given", () => {
+    expect(buildBoardUrl(4000)).toBe("http://localhost:4000");
+    expect(buildBoardUrl(4001, null)).toBe("http://localhost:4001");
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0093

`kj plan` (and `kj run` / auto-HU batch) printed a broken HU Board deep-link:

```
HU Board · started → http://localhost:4000/p/<slug>
```

The HU Board frontend is a **hash-routed SPA** (`packages/hu-board/public/utils/init-listeners.js`, `project-picker-view.js`). The canonical route to open a project pre-filtered is `#board/<slug>`. The path `/p/<slug>` is **not** a router route — the SPA fallback serves `index.html` with no hash, so the user lands on the global "All projects" dashboard instead of their project.

### Fix
- `buildBoardUrl(port, slug)` in `src/commands/board.js` now emits `${base}/#board/${slug}` (was `${base}/p/${slug}`). Single source of truth — all three callers (`plan/generate.js`, `post-loop.js`, `auto-hu-batch.js`) read the URL from `startBoard().url`.
- Exported `buildBoardUrl` and added a focused unit test (`tests/board/build-board-url.test.js`).
- Refreshed the doc-by-example URLs in `board-banner-shape.test.js` and the inline comments.

### Expected
```
HU Board · started → http://localhost:4000/#board/<slug>
```

### Tests
- Board suite green (67 tests), new `buildBoardUrl` test (3 cases) green, lint clean.
- Net delta: +3 LOC + new test file (well under the 200-LOC gate).