### PR TITLE
chore(release): v3.7.2 — HU Board deep-link fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.7.2] - 2026-06-22
+
+Patch. HU Board deep-link fix.
+
 ### Fixed
 - **`kj plan` printed a broken HU Board deep-link** (KJC-BUG-0093): the auto-start banner pointed at `http://localhost:4000/p/<slug>`, a path the SPA router doesn't recognise, so the user landed on the global "All projects" dashboard instead of their project. `buildBoardUrl` now emits the canonical hash route `http://localhost:4000/#board/<slug>` used by the frontend router. Fixes the URL for `kj plan`, `kj run` and auto-HU batch alike (single source of truth).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.7.2

Patch. Cierra **KJC-BUG-0093**.

### Fixed
- **`kj plan` mostraba un deep-link roto del HU Board** (KJC-BUG-0093): el banner de auto-start apuntaba a `http://localhost:4000/p/<slug>`, una ruta que el router SPA no reconoce, así que el usuario caía en el dashboard global "All projects" en vez de su proyecto. `buildBoardUrl` ahora emite la ruta hash canónica `http://localhost:4000/#board/<slug>` que usa el router del frontend. Corrige a la vez `kj plan`, `kj run` y el batch auto-HU (fuente única de verdad).

Bump `3.7.1 → 3.7.2`. CHANGELOG actualizado.