### PR TITLE
fix(audit): resilient provider/model fallback for kj audit (KJC-BUG-0094)

### DIFF
--- a/src/agents/availability.js
+++ b/src/agents/availability.js
@@ -29,3 +29,24 @@ export async function assertAgentsAvailable(agentNames = []) {
   }
   throw new Error(lines.join("\n"));
 }
+
+/**
+ * Non-throwing counterpart to assertAgentsAvailable: probe each agent CLI in
+ * parallel and return the subset whose `--version` succeeds. Used by the
+ * audit fallback (KJC-BUG-0094) to skip uninstalled providers instead of
+ * aborting the whole command when any one is missing.
+ * @param {string[]} agentNames
+ * @returns {Promise<string[]>}
+ */
+export async function filterAvailableAgents(agentNames = []) {
+  const unique = [...new Set(agentNames.filter(Boolean))];
+  const probes = await Promise.all(
+    unique.map(async (name) => {
+      const meta = getAgentMeta(name);
+      if (!meta?.bin) return null;
+      const res = await runCommand(resolveBin(meta.bin), ["--version"]);
+      return res.exitCode === 0 ? name : null;
+    })
+  );
+  return probes.filter(Boolean);
+}

--- a/src/audit/audit-fallback.js
+++ b/src/audit/audit-fallback.js
@@ -1,0 +1,66 @@
+// Resilient provider/model fallback for the `kj audit` CLI (KJC-BUG-0094).
+// The CLI audit calls AuditRole.executeWithDeterministic directly, bypassing
+// the orchestrator's recovery paths, so a dead configured model (e.g. an
+// inherited "claude-fable-5") killed the command. The LLM phase now tries:
+// configured provider+model → same provider default model → remaining known
+// providers. First success wins; the deterministic context is reused.
+import { resolveRole } from "../config.js";
+import { AuditRole } from "../roles/audit-role.js";
+
+const KNOWN_PROVIDERS = ["claude", "codex", "gemini"];
+
+/** Ordered, de-duplicated fallback candidates for the audit role. */
+export function buildAuditFallbackCandidates(config) {
+  const effective = resolveRole(config, "audit");
+  const primary = effective.provider || "claude";
+  const candidates = [{ provider: primary, model: effective.model ?? null }];
+  if (effective.model) candidates.push({ provider: primary, model: null });
+  for (const p of KNOWN_PROVIDERS) {
+    if (p !== primary) candidates.push({ provider: p, model: null });
+  }
+  const seen = new Set();
+  return candidates.filter((c) => {
+    const key = `${c.provider}::${c.model ?? ""}`;
+    return seen.has(key) ? false : (seen.add(key), true);
+  });
+}
+
+// Pin the audit role to a provider/model. Sets BOTH the per-role override and
+// `coder_options.model` (the audit role inherits its model from the coder
+// bucket); a null model neutralizes both so the provider default is used.
+export function withAuditProvider(config, provider, model) {
+  return {
+    ...config,
+    roles: { ...(config?.roles || {}), audit: { ...(config?.roles?.audit || {}), provider, model: model ?? undefined } },
+    coder_options: { ...(config?.coder_options || {}), model: model ?? undefined },
+  };
+}
+
+/** Run the audit LLM phase with automatic provider/model fallback. */
+export async function runAuditWithFallback({
+  config, logger, roleInput, deterministicCtx, available, candidates, onFallback, createRole,
+}) {
+  const makeRole = createRole || ((cfg) => new AuditRole({ config: cfg, logger }));
+  const all = candidates || buildAuditFallbackCandidates(config);
+  const usable = available ? all.filter((c) => available.includes(c.provider)) : all;
+  if (usable.length === 0) {
+    throw new Error("No available audit provider — install claude, codex, or gemini, or set roles.audit.provider");
+  }
+
+  let last = null;
+  let attempts = 0;
+  for (const cand of usable) {
+    attempts += 1;
+    if (attempts > 1) onFallback?.(cand, attempts);
+    const role = makeRole(withAuditProvider(config, cand.provider, cand.model));
+    const meta = { provider: cand.provider, model: cand.model ?? null };
+    try {
+      const result = await role.executeWithDeterministic(roleInput, deterministicCtx);
+      if (result?.ok) return { ...result, ...meta, attempts };
+      last = { ...result, ...meta };
+    } catch (err) {
+      last = { ok: false, result: { error: err.message, provider: cand.provider }, summary: `Audit failed: ${err.message}`, ...meta };
+    }
+  }
+  return { ...last, attempts, exhausted: true };
+}

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -3,10 +3,11 @@ import fs from "node:fs/promises";
 import readline from "node:readline";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { assertAgentsAvailable } from "../agents/availability.js";
+import { assertAgentsAvailable, filterAvailableAgents } from "../agents/availability.js";
 import { resolveRole } from "../config.js";
 import { AUDIT_DIMENSIONS } from "../prompts/audit.js";
 import { AuditRole } from "../roles/audit-role.js";
+import { buildAuditFallbackCandidates, runAuditWithFallback } from "../audit/audit-fallback.js";
 import { withCliRunLog } from "../utils/cli-run-log.js";
 import { createCliProgressReporter } from "../utils/cli-progress.js";
 import { runAgentReadiness, formatAgentReadinessReport } from "../audit/agent-readiness.js";
@@ -260,7 +261,11 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
 
   return withCliRunLog("audit", { projectDir: config?.projectDir, logger }, async ({ runLog }) => {
     const auditRoleConfig = resolveRole(config, "audit");
-    await assertAgentsAvailable([auditRoleConfig.provider]);
+    // KJC-BUG-0094: proceed if any fallback candidate is installed; throw only when NONE are.
+    const fallbackCandidates = buildAuditFallbackCandidates(config);
+    const candidateProviders = [...new Set(fallbackCandidates.map((c) => c.provider))];
+    const available = await filterAvailableAgents(candidateProviders);
+    if (available.length === 0) await assertAgentsAvailable([auditRoleConfig.provider]);
     logger.info(`Audit (${auditRoleConfig.provider}) starting...`);
     runLog.logText(`[audit] provider=${auditRoleConfig.provider} dimensions=${dimensions || "all"} deterministicOnly=${deterministicOnly}`);
 
@@ -347,7 +352,18 @@ export async function auditCommand({ task, config, logger, dimensions, json, age
     const progress = createCliProgressReporter({ role: "auditor" });
     let roleResult;
     try {
-      roleResult = await role.executeWithDeterministic({ ...roleInput, onOutput: progress.onOutput }, deterministicCtx);
+      // KJC-BUG-0094: resilient fallback — if the configured provider/model
+      // is down (e.g. an inherited model like "claude-fable-5" is offline),
+      // degrade to the provider default, then to the next installed provider,
+      // reusing the deterministic context so no static analysis is re-run.
+      roleResult = await runAuditWithFallback({
+        config, logger,
+        roleInput: { ...roleInput, onOutput: progress.onOutput },
+        deterministicCtx,
+        available,
+        candidates: fallbackCandidates,
+        onFallback: (cand) => logger.warn(`Audit provider fallback → ${cand.provider}${cand.model ? ` (${cand.model})` : " (default model)"}`),
+      });
       progress.finish(roleResult.ok ? "done" : "failed");
     } catch (err) { progress.finish("failed"); throw err; }
 

--- a/tests/audit/audit-fallback.test.js
+++ b/tests/audit/audit-fallback.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildAuditFallbackCandidates,
+  withAuditProvider,
+  runAuditWithFallback,
+} from "../../src/audit/audit-fallback.js";
+
+const providersOf = (c) => c.map((x) => x.provider);
+
+describe("buildAuditFallbackCandidates", () => {
+  it("no model: primary then other known providers, all default-model", () => {
+    expect(buildAuditFallbackCandidates({ coder: "claude" })).toEqual([
+      { provider: "claude", model: null },
+      { provider: "codex", model: null },
+      { provider: "gemini", model: null },
+    ]);
+  });
+
+  it("inherited model (fable): keep it, then drop to provider-default, then switch provider", () => {
+    expect(buildAuditFallbackCandidates({ coder: "claude", coder_options: { model: "claude-fable-5" } })).toEqual([
+      { provider: "claude", model: "claude-fable-5" },
+      { provider: "claude", model: null },
+      { provider: "codex", model: null },
+      { provider: "gemini", model: null },
+    ]);
+  });
+
+  it("defaults the primary to claude when config has no provider", () => {
+    expect(providersOf(buildAuditFallbackCandidates({}))).toEqual(["claude", "codex", "gemini"]);
+  });
+});
+
+describe("withAuditProvider", () => {
+  it("neutralizes roles.audit.model and coder_options.model when model is null", () => {
+    const cfg = withAuditProvider({ coder_options: { model: "claude-fable-5" }, roles: { audit: { model: "claude-fable-5" } } }, "codex", null);
+    expect(cfg.roles.audit.provider).toBe("codex");
+    expect(cfg.roles.audit.model).toBeUndefined();
+    expect(cfg.coder_options.model).toBeUndefined();
+  });
+
+  it("pins the model on both buckets when one is given", () => {
+    const cfg = withAuditProvider({}, "claude", "claude-fable-5");
+    expect(cfg.roles.audit).toEqual({ provider: "claude", model: "claude-fable-5" });
+    expect(cfg.coder_options.model).toBe("claude-fable-5");
+  });
+});
+
+describe("runAuditWithFallback", () => {
+  // Fake role factory: each role reads its provider from the overridden
+  // config and returns the scripted result (value or throwing thunk).
+  const factory = (scripts) => (cfg) => ({
+    executeWithDeterministic: async () => {
+      const r = scripts[cfg.roles.audit.provider];
+      return typeof r === "function" ? r() : r;
+    },
+  });
+  const run = (createRole, available, onFallback, config = { coder: "claude" }) =>
+    runAuditWithFallback({ config, roleInput: {}, deterministicCtx: {}, available, onFallback, createRole });
+
+  it("returns the first ok result and counts attempts; thrown errors are just failed candidates", async () => {
+    const onFallback = vi.fn();
+    const res = await run(factory({
+      claude: () => { throw new Error("model claude-fable-5 unavailable"); },
+      codex: { ok: true, result: { summary: { overallHealth: "B" } } },
+    }), ["claude", "codex", "gemini"], onFallback, { coder: "claude", coder_options: { model: "claude-fable-5" } });
+    expect(res.ok).toBe(true);
+    expect(res.provider).toBe("codex"); // claude(fable) throws → claude(default) throws → codex ok
+    expect(res.attempts).toBe(3);
+    expect(onFallback).toHaveBeenCalled();
+  });
+
+  it("marks the run exhausted when every candidate fails", async () => {
+    const res = await run(factory({
+      claude: { ok: false, result: { error: "x" } },
+      codex: { ok: false, result: { error: "y" } },
+      gemini: { ok: false, result: { error: "z" } },
+    }), ["claude", "codex", "gemini"]);
+    expect(res.ok).toBe(false);
+    expect(res.exhausted).toBe(true);
+  });
+
+  it("skips providers that are not installed", async () => {
+    const tried = [];
+    await run((cfg) => ({
+      executeWithDeterministic: async () => { tried.push(cfg.roles.audit.provider); return { ok: true, result: {} }; },
+    }), ["codex"]);
+    expect(tried).toEqual(["codex"]);
+  });
+
+  it("throws when no candidate provider is available", async () => {
+    await expect(run(factory({}), [])).rejects.toThrow(/no available audit provider/i);
+  });
+});

--- a/tests/audit/report-file.test.js
+++ b/tests/audit/report-file.test.js
@@ -21,7 +21,7 @@ vi.mock("../../src/roles/audit-role.js", () => ({
     async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
   },
 }));
-vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn(), filterAvailableAgents: vi.fn(async (names) => names) }));
 vi.mock("../../src/config.js", () => ({
   resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
 }));

--- a/tests/audit/two-phase.test.js
+++ b/tests/audit/two-phase.test.js
@@ -18,7 +18,10 @@ vi.mock("../../src/roles/audit-role.js", () => ({
     async execute(input) { const ctx = await this.collectDeterministic(input); return this.executeWithDeterministic(input, ctx); }
   },
 }));
-vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/agents/availability.js", () => ({
+  assertAgentsAvailable: vi.fn(),
+  filterAvailableAgents: vi.fn(async (names) => names),
+}));
 vi.mock("../../src/config.js", () => ({
   resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
 }));

--- a/tests/audit/usage-summary.test.js
+++ b/tests/audit/usage-summary.test.js
@@ -19,7 +19,7 @@ vi.mock("../../src/roles/audit-role.js", () => ({
     async executeWithDeterministic(input, ctx) { return executeWithDetMock(input, ctx); }
   },
 }));
-vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn() }));
+vi.mock("../../src/agents/availability.js", () => ({ assertAgentsAvailable: vi.fn(), filterAvailableAgents: vi.fn(async (names) => names) }));
 vi.mock("../../src/config.js", () => ({
   resolveRole: vi.fn((config, role) => ({ provider: config.roles?.[role]?.provider || role })),
 }));

--- a/tests/commands/command-audit.test.js
+++ b/tests/commands/command-audit.test.js
@@ -21,6 +21,7 @@ vi.mock("../../src/roles/audit-role.js", () => ({
 
 vi.mock("../../src/agents/availability.js", () => ({
   assertAgentsAvailable: vi.fn(),
+  filterAvailableAgents: vi.fn(async (names) => names),
 }));
 
 vi.mock("../../src/config.js", () => ({
@@ -78,7 +79,7 @@ const successResult = {
 };
 
 describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
-  let assertAgentsAvailable;
+  let filterAvailableAgents;
 
   beforeEach(async () => {
     vi.resetAllMocks();
@@ -87,14 +88,14 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
     executeWithDetMock.mockResolvedValue(successResult);
 
     const avail = await import("../../src/agents/availability.js");
-    assertAgentsAvailable = avail.assertAgentsAvailable;
+    filterAvailableAgents = avail.filterAvailableAgents;
   });
 
-  it("asserts audit provider is available before invoking the role", async () => {
+  it("checks audit provider availability before invoking the role", async () => {
     const { auditCommand } = await import("../../src/commands/audit.js");
     await auditCommand({ task: "audit codebase", config: makeConfig(), logger: noopLogger });
 
-    expect(assertAgentsAvailable).toHaveBeenCalledWith(["claude"]);
+    expect(filterAvailableAgents).toHaveBeenCalledWith(["claude", "codex", "gemini"]);
   });
 
   it("invokes AuditRole.executeWithDeterministic with the task verbatim", async () => {
@@ -127,8 +128,8 @@ describe("commands/audit (post KJC-TSK-0357 — uses AuditRole)", () => {
     );
   });
 
-  it("throws when AuditRole returns ok=false", async () => {
-    executeWithDetMock.mockResolvedValueOnce({
+  it("throws when every audit provider returns ok=false", async () => {
+    executeWithDetMock.mockResolvedValue({
       ok: false,
       result: { error: "agent error", provider: "claude" },
       summary: "Audit failed: agent error",


### PR DESCRIPTION
## Problem

`kj audit` ran the LLM phase by calling `AuditRole.executeWithDeterministic`
directly, bypassing the orchestrator's recovery paths (`runRoleWithFallback`,
`withBrainRecovery`). When the configured provider/model was offline — in the
field, an inherited `claude-fable-5` was down — the command failed outright
instead of degrading. The audit must be resilient and work even with no
explicit config or when the configured model fails.

## Fix

New `src/audit/audit-fallback.js` adds an ordered, de-duplicated candidate
chain and a runner:

1. configured provider + model
2. same provider at its **default** model (neutralizes both `roles.audit.model`
   and the inherited `coder_options.model`)
3. the remaining known providers (claude → codex → gemini) at default model

First success wins. The deterministic context is collected **once** and reused
across attempts, so no static analysis is re-run. Preflight no longer
hard-requires the configured provider: it proceeds when any candidate CLI is
installed (non-throwing `filterAvailableAgents` probe) and only aborts when
none are.

## Tests

- `tests/audit/audit-fallback.test.js` (new): candidate ordering, config
  pinning, runner success/exhaustion/skip-uninstalled/none-available.
- Existing two-phase / report-file / usage-summary mocks updated for the new
  export. Full `tests/audit/` suite green (253 passed).