### PR TITLE
feat(agents): land GitHub Copilot CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ While Genkit, Mastra, LangChain and Vercel AI SDK call `/v1/messages`, Karajan o
 | Axis | Karajan | Genkit / Mastra / LangChain / Vercel AI SDK |
 |------|---------|---------------------------------------------|
 | Calls provider HTTP API (`/v1/messages`, etc.) | ❌ Delegates to CLIs | ✅ |
-| Orchestrates existing AI CLIs (claude, codex, gemini, aider, opencode) as subprocesses | ✅ | ❌ |
+| Orchestrates existing AI CLIs (claude, codex, gemini, aider, opencode, copilot) as subprocesses | ✅ | ❌ |
 | Depends on cloud infrastructure | ❌ Fully local | ⚠️ Varies |
 | Token billing | **Uses your existing CLI subscriptions** | Pay per API call |
 
@@ -338,7 +338,7 @@ Each AI role is executed by the agent you choose:
 >
 > Full per-stage reference: [Pipeline roles](https://karajan-code.web.app/docs/handbook/pipeline-roles/) (handbook).
 
-## 5 AI agents supported
+## 6 AI agents supported
 
 | Agent | CLI | Install |
 |-------|-----|---------|
@@ -347,6 +347,7 @@ Each AI role is executed by the agent you choose:
 | **Gemini** | `gemini` | See [Gemini CLI docs](https://github.com/google-gemini/gemini-cli) |
 | **Aider** | `aider` | `pipx install aider-chat` (or `pip3 install aider-chat`) |
 | **OpenCode** | `opencode` | See [OpenCode docs](https://github.com/nicepkg/opencode) |
+| **Copilot** | `copilot` | `npm install -g @github/copilot` |
 
 Mix and match. Use Claude as coder and Codex as reviewer. Karajan auto-detects installed agents during `kj init`.
 

--- a/src/agents/copilot-agent.js
+++ b/src/agents/copilot-agent.js
@@ -1,0 +1,83 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * Extract usage from the Copilot CLI JSONL stream (--output-format json,
+ * reviewTask). Copilot reports per-message `outputTokens` on each
+ * `assistant.message` and a final `result` line with `usage.premiumRequests`
+ * (billing units, not tokens). No prompt-token count exists, so tokens_in and
+ * cached_tokens stay 0 and tokens_out sums the outputs. Returns null when no
+ * token count is present (= unmeasured).
+ */
+function extractCopilotUsage(text) {
+  if (!text) return null;
+  let tokens_out = 0;
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    if (obj?.type === "assistant.message" && typeof obj.data?.outputTokens === "number") {
+      tokens_out += obj.data.outputTokens;
+    }
+  }
+  if (tokens_out <= 0) return null;
+  return { tokens_in: 0, tokens_out, cached_tokens: 0 };
+}
+
+/**
+ * Extract the final assistant text from a Copilot JSONL stream: the answer is
+ * the last `assistant.message` content; fall back to raw text when none parse.
+ */
+function extractCopilotText(text) {
+  if (!text) return "";
+  const messages = [];
+  for (const line of text.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    let obj;
+    try { obj = JSON.parse(t); } catch { continue; }
+    if (obj?.type === "assistant.message" && typeof obj.data?.content === "string") {
+      messages.push(obj.data.content);
+    }
+  }
+  return messages.length ? messages.join("") : text;
+}
+
+export class CopilotAgent extends BaseAgent {
+  async runTask(task) {
+    const role = task.role || "coder";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model, false);
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Copilot model "${model}" not supported - retrying with agent default`);
+      return this._exec(task, null, false);
+    }
+    return result;
+  }
+
+  async reviewTask(task) {
+    const role = task.role || "reviewer";
+    const model = this.getRoleModel(role);
+    const result = await this._exec(task, model, true);
+    if (!result.ok && model && this.isModelNotSupportedError(result)) {
+      this.logger?.warn(`Copilot model "${model}" not supported - retrying with agent default`);
+      return this._exec(task, null, true);
+    }
+    return result;
+  }
+
+  async _exec(task, model, jsonFormat) {
+    const args = ["-p", task.prompt, "-s", "--allow-all-tools", "--no-ask-user"];
+    if (jsonFormat) args.push("--output-format", "json");
+    if (model) args.push("--model", model);
+    const res = await this.runCommand(resolveBin("copilot"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs
+    });
+    const output = jsonFormat ? extractCopilotText(res.stdout) : res.stdout;
+    const usage = extractCopilotUsage(res.stdout) ?? extractCopilotUsage(res.stderr);
+    return { ok: res.exitCode === 0, output, error: res.stderr, exitCode: res.exitCode, ...usage };
+  }
+}

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -3,6 +3,7 @@ import { CodexAgent } from "./codex-agent.js";
 import { GeminiAgent } from "./gemini-agent.js";
 import { AiderAgent } from "./aider-agent.js";
 import { OpenCodeAgent } from "./opencode-agent.js";
+import { CopilotAgent } from "./copilot-agent.js";
 
 const agentRegistry = new Map();
 
@@ -49,3 +50,4 @@ registerAgent("codex", CodexAgent, { bin: "codex", installUrl: "https://develope
 registerAgent("gemini", GeminiAgent, { bin: "gemini", installUrl: "https://github.com/google-gemini/gemini-cli" });
 registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.chat/docs/install.html" });
 registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });
+registerAgent("copilot", CopilotAgent, { bin: "copilot", installUrl: "https://github.com/github/copilot-cli" });

--- a/src/agents/model-registry.js
+++ b/src/agents/model-registry.js
@@ -107,6 +107,7 @@ registerModelAlias("gemini", "gemini-2.5-pro");
  */
 registerModel("aider", { provider: "aider", pricing: { input_per_million: 3, output_per_million: 15 } });
 registerModel("opencode", { provider: "opencode", pricing: { input_per_million: 0, output_per_million: 0 } });
+registerModel("copilot", { provider: "copilot", pricing: { input_per_million: 0, output_per_million: 0 } });
 
 // Common CLI Aliases (with provider overrides)
 registerModelAlias("aider/claude-3-7-sonnet", "claude-sonnet-4.6", { provider: "aider" });

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -59,7 +59,7 @@ const Methodology = v.picklist(
  * Recursivo — el fallback puede tener su propio fallback.
  */
 const RoleFallback = v.looseObject({
-  provider: v.string("fallback.provider required (claude|codex|gemini|opencode|aider)"),
+  provider: v.string("fallback.provider required (claude|codex|gemini|opencode|aider|copilot)"),
   model: v.optional(v.nullable(v.string())),
   max_wait_hours: v.optional(v.pipe(v.number(), v.minValue(0)), 12),
   // Recursivo. Schema permite cualquier shape compatible con RoleFallback.

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -7,7 +7,8 @@ const KNOWN_AGENTS = [
   { name: "codex", install: getInstallCommand("codex") },
   { name: "gemini", install: getInstallCommand("gemini") },
   { name: "aider", install: getInstallCommand("aider") },
-  { name: "opencode", install: getInstallCommand("opencode") }
+  { name: "opencode", install: getInstallCommand("opencode") },
+  { name: "copilot", install: getInstallCommand("copilot") }
 ];
 
 export async function checkBinary(name, versionArg = "--version") {
@@ -44,6 +45,7 @@ export function detectHostAgent() {
   if (process.env.CODEX_CLI === "1" || process.env.CODEX === "1") return "codex";
   if (process.env.GEMINI_CLI === "1") return "gemini";
   if (process.env.OPENCODE === "1") return "opencode";
+  if (process.env.COPILOT_CLI === "1") return "copilot";
   return null;
 }
 

--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -51,6 +51,11 @@ const INSTALL_COMMANDS = {
     linux: "curl -fsSL https://opencode.ai/install | bash",
     windows: "See https://github.com/nicepkg/opencode for Windows install"
   },
+  copilot: {
+    macos: "npm install -g @github/copilot",
+    linux: "npm install -g @github/copilot",
+    windows: "npm install -g @github/copilot"
+  },
   docker: {
     macos: "brew install --cask docker",
     linux: "sudo apt install docker.io docker-compose-v2 (or see https://docs.docker.com/engine/install/)",

--- a/tests/agents/agent-detect.test.js
+++ b/tests/agents/agent-detect.test.js
@@ -52,11 +52,13 @@ describe("agent-detect", () => {
     expect(gemini.version).toBeNull();
   });
 
-  it("KNOWN_AGENTS contains claude, codex, gemini, aider", () => {
+  it("KNOWN_AGENTS contains claude, codex, gemini, aider, opencode, copilot", () => {
     const names = KNOWN_AGENTS.map((a) => a.name);
     expect(names).toContain("claude");
     expect(names).toContain("codex");
     expect(names).toContain("gemini");
     expect(names).toContain("aider");
+    expect(names).toContain("opencode");
+    expect(names).toContain("copilot");
   });
 });

--- a/tests/agents/copilot-agent.test.js
+++ b/tests/agents/copilot-agent.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createNoopLogger } from "../_fixtures/loggers.js";
+import { baseAgentConfig } from "../_fixtures/agents.js";
+
+vi.mock("../../src/utils/process.js", () => ({
+  runCommand: vi.fn()
+}));
+
+vi.mock("../../src/agents/resolve-bin.js", () => ({
+  resolveBin: vi.fn((name) => `/usr/local/bin/${name}`)
+}));
+
+const baseConfig = baseAgentConfig();
+const logger = createNoopLogger();
+
+describe("CopilotAgent", () => {
+  let runCommand;
+  let CopilotAgent;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const proc = await import("../../src/utils/process.js");
+    runCommand = proc.runCommand;
+    runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+    const mod = await import("../../src/agents/copilot-agent.js");
+    CopilotAgent = mod.CopilotAgent;
+  });
+
+  describe("non-interactive surface (runTask & reviewTask)", () => {
+    it.each([
+      ["runTask",    "coder",    "fix bug",     false],
+      ["reviewTask", "reviewer", "review code", true]
+    ])("%s: passes -p prompt, -s, --allow-all-tools, --no-ask-user, json=%s", async (method, role, prompt, expectsJson) => {
+      const agent = new CopilotAgent("copilot", baseConfig, logger);
+      await agent[method]({ prompt, role });
+
+      const [, args, opts] = runCommand.mock.calls[0];
+      expect(args[0]).toBe("-p");
+      expect(args[1]).toBe(prompt);
+      expect(args).toContain("-s");
+      expect(args).toContain("--allow-all-tools");
+      expect(args).toContain("--no-ask-user");
+      expect(opts.input).toBeUndefined();
+      if (expectsJson) {
+        expect(args).toContain("--output-format");
+        expect(args).toContain("json");
+      } else {
+        expect(args).not.toContain("--output-format");
+      }
+    });
+  });
+
+  describe("model configuration", () => {
+    const cfg = (role, model) => ({ ...baseConfig, roles: { coder: {}, reviewer: {}, [role]: { model } } });
+    it("adds --model when configured, omits it otherwise", async () => {
+      await new CopilotAgent("copilot", cfg("coder", "claude-sonnet-4.5"), logger).runTask({ prompt: "p", role: "coder" });
+      expect(runCommand.mock.calls[0][1]).toContain("--model");
+      expect(runCommand.mock.calls[0][1]).toContain("claude-sonnet-4.5");
+      vi.resetAllMocks();
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "done", stderr: "" });
+      await new CopilotAgent("copilot", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(runCommand.mock.calls[0][1]).not.toContain("--model");
+    });
+  });
+
+  describe("exit code handling", () => {
+    it.each([
+      [0, "success", "",      { ok: true,  output: "success", error: "",      exitCode: 0 }],
+      [1, "",        "error", { ok: false, output: "",        error: "error", exitCode: 1 }]
+    ])("exit=%i reflects ok+output+error", async (exitCode, stdout, stderr, expected) => {
+      runCommand.mockResolvedValue({ exitCode, stdout, stderr });
+      const result = await new CopilotAgent("copilot", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result).toEqual(expected);
+    });
+  });
+
+  // JSONL: the final answer is the last assistant.message content; outputTokens
+  // sum to tokens_out (Copilot reports no prompt tokens, so tokens_in stays 0).
+  describe("JSON output parsing (reviewTask)", () => {
+    it("extracts assistant.message content and outputTokens", async () => {
+      const stdout = [
+        '{"type":"user.message","data":{"content":"r"}}',
+        '{"type":"assistant.message","data":{"content":"looks good","outputTokens":33}}',
+        '{"type":"result","sessionId":"abc","exitCode":0,"usage":{"premiumRequests":1}}'
+      ].join("\n");
+      runCommand.mockResolvedValue({ exitCode: 0, stdout, stderr: "" });
+      const result = await new CopilotAgent("copilot", baseConfig, logger).reviewTask({ prompt: "r", role: "reviewer" });
+      expect(result.output).toBe("looks good");
+      expect(result.tokens_out).toBe(33);
+      expect(result.tokens_in).toBe(0);
+    });
+
+    it("leaves usage undefined on plain runTask output", async () => {
+      runCommand.mockResolvedValue({ exitCode: 0, stdout: "plain\n", stderr: "" });
+      const result = await new CopilotAgent("copilot", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(result.tokens_out).toBeUndefined();
+    });
+  });
+});

--- a/tests/integration/agents-index-contract.test.js
+++ b/tests/integration/agents-index-contract.test.js
@@ -36,7 +36,7 @@ describe("integration: src/agents/index.js external contract", () => {
   });
 
   it("createAgent returns a BaseAgent subclass for every built-in provider", () => {
-    for (const name of ["claude", "codex", "gemini", "aider", "opencode"]) {
+    for (const name of ["claude", "codex", "gemini", "aider", "opencode", "copilot"]) {
       const agent = createAgent(name, config, logger);
       expect(agent).toBeInstanceOf(BaseAgent);
       expect(agent.name).toBe(name);


### PR DESCRIPTION
## What this PR solves

Lands GitHub Copilot CLI as a first-class provider, sitting next to claude, codex, gemini, aider, and opencode. `CopilotAgent` mirrors the Gemini/OpenCode adapters and drives the verified copilot v1.0.65 non-interactive surface:

- `copilot -p "<prompt>" -s --allow-all-tools --no-ask-user [--model]` so it never blocks on a permission or ask-user prompt.
- `reviewTask` adds `--output-format json` and parses the JSONL stream: the answer is the last `assistant.message` content, `tokens_out` sums per-message `outputTokens`, and the final `result` line carries `sessionId`/`exitCode`. Copilot exposes no prompt tokens, so `tokens_in`/`cached_tokens` stay 0 (unmeasured) instead of being faked.
- Wires copilot into the registry, `KNOWN_AGENTS`, host detection (`COPILOT_CLI`), model registry, install hints, and the fallback-provider message.

This supersedes #1085, which used wrong flags (`--allow-all`, `--silent`) and a guessed OpenAI `prompt_tokens` schema that never matched copilot output. Pi is intentionally left out to keep this PR atomic.

## How to test it

- `npm install`
- `npm run lint` (0 errors), `npm run lint:syntax`, `npx prettier --check` on changed files (clean)
- `npx vitest run tests/agents tests/config tests/brain tests/commands tests/integration` (all pass)
- Real CLI smoke (copilot v1.0.65 authed): `reviewTask` returned `ok=true exit=0 output="smoke-ok" tokens_out=36`, confirming the JSONL `assistant.message`/`result` parsing.

## Tests added or modified

- `tests/agents/copilot-agent.test.js` (new): surface flags, `--model`, exit codes, JSONL content + token parsing.
- `tests/agents/agent-detect.test.js`, `tests/integration/agents-index-contract.test.js`: extend coverage to copilot.

## Notes for the reviewer

Net source delta stays under the 200-LOC shrink budget (~194). README and docs are excluded by the gate.

---

## Qué resuelve este PR

Incorpora la CLI de GitHub Copilot como proveedor de primera clase. `CopilotAgent` replica los adaptadores Gemini/OpenCode y usa la superficie verificada de copilot v1.0.65: `-p` con `-s --allow-all-tools --no-ask-user [--model]`, y en `reviewTask` añade `--output-format json` para parsear el JSONL (contenido de `assistant.message`, `outputTokens`, y la línea `result` con `sessionId`/`exitCode`). Reemplaza los flags y el esquema JSON incorrectos de #1085. Pi se deja fuera para mantener el PR atómico.

## Cómo probarlo

`npm install`, `npm run lint`, tests de agentes/config/brain/commands/integration, y smoke real con la CLI.

## Tests añadidos o modificados

`copilot-agent.test.js` nuevo, mas extensiones en agent-detect e index-contract.

## Notas para el revisor

Delta neto por debajo del presupuesto de 200 LOC.
