### PR TITLE
feat(cli): add kj advanced index command (KJC-TSK-0582)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -1,0 +1,60 @@
+// KJC-TSK-0582: the flat `kj --help` list had grown to 37 commands, which
+// drowns the handful a newcomer actually needs. This module is the single
+// source of truth for which commands are "core" (always shown in `kj --help`)
+// vs "advanced/specialized" (grouped under `kj advanced`). Nothing is hidden
+// or unregistered — every command stays top-level and invokable for
+// back-compat; this only changes what the help listing surfaces by default.
+
+/** The few commands a newcomer needs. Shown in `kj --help`. */
+export const CORE_COMMANDS = [
+  "init",
+  "run",
+  "plan",
+  "status",
+  "doctor",
+  "harden",
+  "config",
+  "update",
+];
+
+/** Navigation/built-ins that are neither core-basics nor advanced. */
+export const META_COMMANDS = ["advanced", "help"];
+
+/**
+ * Advanced commands grouped by area, in display order. Every advanced
+ * command MUST live in exactly one group — the parity test fails otherwise,
+ * so a newly-registered command can never silently vanish from `kj advanced`.
+ */
+export const ADVANCED_GROUPS = [
+  { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "scan"] },
+  { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard"] },
+  { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
+  { title: "Calidad / auditoría", commands: ["audit", "check", "webperf", "sonar"] },
+  { title: "Sesión / board", commands: ["resume", "report", "board", "undo", "standby"] },
+  { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents"] },
+  { title: "Mantenimiento", commands: ["clean", "sync", "telemetry"] },
+];
+
+/** Flat set of every advanced command name (for fast lookup / filtering). */
+export const ADVANCED_COMMANDS = ADVANCED_GROUPS.flatMap((g) => g.commands);
+
+const ADVANCED_SET = new Set(ADVANCED_COMMANDS);
+const CORE_SET = new Set(CORE_COMMANDS);
+const META_SET = new Set(META_COMMANDS);
+
+/**
+ * Classify a command name. Returns "core" | "advanced" | "meta" | "unknown".
+ * "unknown" means the command is registered but not yet placed in this file —
+ * the parity test treats that as a failure so the listing never drifts.
+ */
+export function classifyCommand(name) {
+  if (CORE_SET.has(name)) return "core";
+  if (ADVANCED_SET.has(name)) return "advanced";
+  if (META_SET.has(name)) return "meta";
+  return "unknown";
+}
+
+/** True when the command should be hidden from the flat `kj --help` list. */
+export function isAdvancedCommand(name) {
+  return ADVANCED_SET.has(name);
+}

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -17,6 +17,7 @@ import { cleanCommand } from "../commands/clean.js";
 import { checkCommand } from "../commands/check.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
+import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
 
 /**
@@ -440,5 +441,16 @@ export function registerMeta(program, { pkgVersion }) {
         checkCommand({ profile: flags.profile, json: Boolean(flags.json), logger })
       );
       if (Number.isInteger(code)) process.exit(code);
+    });
+
+  // KJC-TSK-0582: index of the advanced/specialized commands kept out of the
+  // flat `kj --help` list. Descriptions are read from commander itself so they
+  // never drift from each command's own --description.
+  program
+    .command("advanced")
+    .description("List advanced & specialized commands, grouped by area")
+    .action(() => {
+      const descriptions = Object.fromEntries(program.commands.map((c) => [c.name(), c.description()]));
+      console.log(formatAdvancedIndex(descriptions));
     });
 }

--- a/src/commands/advanced.js
+++ b/src/commands/advanced.js
@@ -1,0 +1,31 @@
+// KJC-TSK-0582: `kj advanced` prints every advanced/specialized command,
+// grouped by area, with the one-line description commander already holds for
+// it. Pure formatter (takes a name→description map) so it's trivially
+// testable without spinning up the whole CLI.
+import { ADVANCED_GROUPS } from "../cli/advanced-commands.js";
+
+const NAME_PAD = 14;
+
+/**
+ * Build the `kj advanced` index text.
+ * @param {Record<string,string>|Map<string,string>} descriptions name → one-line description
+ */
+export function formatAdvancedIndex(descriptions) {
+  const lookup = descriptions instanceof Map ? descriptions : new Map(Object.entries(descriptions || {}));
+  const firstLine = (text) => String(text || "").split("\n")[0].trim();
+
+  const lines = [
+    "Comandos avanzados y especializados (agrupados por área).",
+    "Todos siguen siendo invocables directamente: kj <comando>.",
+    "",
+  ];
+  for (const group of ADVANCED_GROUPS) {
+    lines.push(`${group.title}:`);
+    for (const name of group.commands) {
+      lines.push(`  kj ${name.padEnd(NAME_PAD)} ${firstLine(lookup.get(name))}`.trimEnd());
+    }
+    lines.push("");
+  }
+  lines.push("Usa 'kj <comando> --help' para los detalles de cualquiera de ellos.");
+  return lines.join("\n");
+}

--- a/tests/commands/advanced.test.js
+++ b/tests/commands/advanced.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { formatAdvancedIndex } from "../../src/commands/advanced.js";
+import { ADVANCED_GROUPS } from "../../src/cli/advanced-commands.js";
+
+describe("formatAdvancedIndex (KJC-TSK-0582)", () => {
+  const descriptions = {
+    audit: "Analyze codebase health (read-only)",
+    rag: "Retrieval-augmented search\nsecond line ignored",
+  };
+
+  it("renders every group title and command", () => {
+    const text = formatAdvancedIndex(descriptions);
+    for (const group of ADVANCED_GROUPS) {
+      expect(text).toContain(`${group.title}:`);
+      for (const name of group.commands) {
+        expect(text).toContain(`kj ${name}`);
+      }
+    }
+  });
+
+  it("includes the one-line description next to the command", () => {
+    const text = formatAdvancedIndex(descriptions);
+    expect(text).toContain("Analyze codebase health (read-only)");
+  });
+
+  it("uses only the first line of a multi-line description", () => {
+    const text = formatAdvancedIndex(descriptions);
+    expect(text).toContain("Retrieval-augmented search");
+    expect(text).not.toContain("second line ignored");
+  });
+
+  it("tolerates a missing description without crashing", () => {
+    const text = formatAdvancedIndex({});
+    expect(text).toContain("kj audit");
+    expect(text).toContain("Usa 'kj <comando> --help'");
+  });
+
+  it("accepts a Map as well as a plain object", () => {
+    const text = formatAdvancedIndex(new Map([["audit", "Health check"]]));
+    expect(text).toContain("Health check");
+  });
+});


### PR DESCRIPTION
## Qué

`kj --help` había crecido a 37 comandos, ahogando los pocos que un recién llegado necesita. Este PR (1/2) introduce el comando **`kj advanced`**: un índice de los 29 comandos especializados/poco usados, agrupados por área (Pipeline, Análisis pre-run, Búsqueda/RAG, Calidad/auditoría, Sesión/board, Infra/setup, Mantenimiento).

## Cómo

- `src/cli/advanced-commands.js`: única fuente de verdad — set CORE (8 básicos), grupos ADVANCED y `classifyCommand()`.
- `src/commands/advanced.js`: formateador puro; lee la descripción de cada comando del propio commander, así nunca se desincroniza de su `--description`.
- `src/cli/register-meta.js`: registra `kj advanced`.

Ningún comando se oculta ni se desregistra: todos siguen siendo top-level e invocables (`kj <comando>`). El recorte del listado de `kj --help` + el gate de paridad anti-drift llegan en el PR 2/2.

## Tests

`tests/commands/advanced.test.js` (5 casos): títulos de grupo, descripción de una línea, multi-línea recortada, descripción ausente, acepta Map u objeto.

Net: ~145 LOC (bajo el límite de shrink-budget).