### PR TITLE
feat(cli): trim kj --help to core commands + parity gate (KJC-TSK-0582)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,8 +2,9 @@
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { Command } from "commander";
+import { Command, Help } from "commander";
 import { loadConfig } from "./config.js";
+import { isAdvancedCommand } from "./cli/advanced-commands.js";
 import { registerPipeline } from "./cli/register-pipeline.js";
 import { registerPlan } from "./cli/register-plan.js";
 import { registerRolesSkills } from "./cli/register-roles-skills.js";
@@ -41,8 +42,20 @@ program
   .allowUnknownOption(true)
   .allowExcessArguments(true);
 
-// KJC-TSK-0571: the command list is long (30+). Orient a newcomer to the few
-// commands they actually need; the rest are advanced/internal.
+// KJC-TSK-0582: the flat list had grown to 37 commands. Show only the core
+// basics in `kj --help`; the advanced/specialized ones live under
+// `kj advanced`. The filter applies to the ROOT help only — subcommand help
+// keeps listing its own subcommands untouched.
+program.configureHelp({
+  visibleCommands(cmd) {
+    const cmds = Help.prototype.visibleCommands.call(this, cmd);
+    if (cmd !== program) return cmds;
+    return cmds.filter((c) => !isAdvancedCommand(c.name()));
+  },
+});
+
+// KJC-TSK-0571/0582: orient a newcomer to the few commands they need and
+// point them at `kj advanced` for everything else.
 program.addHelpText(
   "after",
   `
@@ -53,7 +66,7 @@ Getting started (the basics — start here):
   kj doctor           Check your environment is ready
   kj harden           Add quality git hooks + CI to any repo
 
-Everything else is advanced or internal — you rarely call it directly.`
+  kj advanced         List every advanced/specialized command, grouped by area`
 );
 
 registerPipeline(program, { pkgVersion: PKG_VERSION });

--- a/tests/cli/advanced-commands.test.js
+++ b/tests/cli/advanced-commands.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import { registerPipeline } from "../../src/cli/register-pipeline.js";
+import { registerPlan } from "../../src/cli/register-plan.js";
+import { registerRolesSkills } from "../../src/cli/register-roles-skills.js";
+import { registerMeta } from "../../src/cli/register-meta.js";
+import { registerSonar } from "../../src/cli/register-sonar.js";
+import { registerStandby } from "../../src/cli/register-standby.js";
+import {
+  CORE_COMMANDS,
+  ADVANCED_COMMANDS,
+  ADVANCED_GROUPS,
+  META_COMMANDS,
+  classifyCommand,
+  isAdvancedCommand,
+} from "../../src/cli/advanced-commands.js";
+
+/** Build the real CLI command tree exactly as src/cli.js does. */
+function buildProgram() {
+  const program = new Command();
+  const opts = { pkgVersion: "0.0.0-test" };
+  registerPipeline(program, opts);
+  registerPlan(program, opts);
+  registerRolesSkills(program, opts);
+  registerMeta(program, opts);
+  registerSonar(program);
+  registerStandby(program);
+  return program;
+}
+
+describe("advanced-commands registry (KJC-TSK-0582)", () => {
+  it("classifies every registered top-level command (no drift)", () => {
+    const program = buildProgram();
+    const unknown = program.commands
+      .map((c) => c.name())
+      .filter((name) => classifyCommand(name) === "unknown");
+    expect(unknown).toEqual([]);
+  });
+
+  it("every classified command is actually registered", () => {
+    const program = buildProgram();
+    const registered = new Set(program.commands.map((c) => c.name()));
+    registered.add("advanced"); // registered in registerMeta, present above
+    for (const name of [...CORE_COMMANDS, ...ADVANCED_COMMANDS]) {
+      expect(registered.has(name), `'${name}' classified but not registered`).toBe(true);
+    }
+  });
+
+  it("core, advanced and meta sets are disjoint", () => {
+    const overlap = CORE_COMMANDS.filter((n) => ADVANCED_COMMANDS.includes(n) || META_COMMANDS.includes(n));
+    expect(overlap).toEqual([]);
+  });
+
+  it("no advanced command appears in two groups", () => {
+    const seen = new Set();
+    const dupes = [];
+    for (const group of ADVANCED_GROUPS) {
+      for (const name of group.commands) {
+        if (seen.has(name)) dupes.push(name);
+        seen.add(name);
+      }
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("isAdvancedCommand hides advanced, keeps core/meta visible", () => {
+    expect(isAdvancedCommand("audit")).toBe(true);
+    expect(isAdvancedCommand("run")).toBe(false);
+    expect(isAdvancedCommand("advanced")).toBe(false);
+  });
+});

--- a/tests/e2e/01-cli-surface.test.js
+++ b/tests/e2e/01-cli-surface.test.js
@@ -21,14 +21,26 @@ describe("e2e/10 — CLI surface", () => {
     } finally { proj.cleanup(); }
   });
 
-  it("kj --help lists the canonical subcommands and exits 0", () => {
+  it("kj --help lists the core commands + the advanced pointer, exits 0", () => {
     const proj = makeTmpProject();
     try {
       const r = runKj(["--help"], { cwd: proj.projectDir });
       expect(r.exitCode).toBe(0);
-      // Every contract user a power user touches must show up here.
-      for (const cmd of ["plan", "run", "audit", "doctor", "init", "board", "review", "code"]) {
+      // KJC-TSK-0582: --help shows only the core basics + a pointer to
+      // `kj advanced`. The advanced commands no longer clutter this listing.
+      for (const cmd of ["init", "run", "plan", "doctor", "harden", "advanced"]) {
         expect(r.stdout, `'${cmd}' missing from --help`).toContain(cmd);
+      }
+    } finally { proj.cleanup(); }
+  });
+
+  it("kj advanced lists the specialized commands and exits 0", () => {
+    const proj = makeTmpProject();
+    try {
+      const r = runKj(["advanced"], { cwd: proj.projectDir });
+      expect(r.exitCode).toBe(0);
+      for (const cmd of ["audit", "board", "review", "code"]) {
+        expect(r.stdout, `'${cmd}' missing from kj advanced`).toContain(cmd);
       }
     } finally { proj.cleanup(); }
   });


### PR DESCRIPTION
## Qué

PR 2/2 de KJC-TSK-0582. Recorta el listado plano de `kj --help` a los 8 comandos básicos + un puntero a `kj advanced` (introducido en #1126). Antes mostraba 37, ahogando lo que un recién llegado necesita.

## Cómo

- `src/cli.js`: `program.configureHelp({ visibleCommands })` filtra los comandos avanzados **solo en la raíz** (el help de cada subcomando sigue intacto). El bloque "Getting started" ahora apunta a `kj advanced`.
- Ningún comando se oculta ni se desregistra: todos siguen invocables. Solo cambia lo que el listado por defecto surface.

## Gate anti-drift

`tests/cli/advanced-commands.test.js` construye el árbol real de comandos (los 6 `register*`) y **falla si algún comando registrado queda sin clasificar** (core/advanced/meta). Así el listado no puede desincronizarse al añadir comandos nuevos. También verifica disjunción de sets y que ningún avanzado esté en dos grupos.

Net: ~84 LOC.