### PR TITLE
feat(start): maturity classifier for the Brain (KJC-TSK-0568)

### DIFF
--- a/src/start/maturity.js
+++ b/src/start/maturity.js
@@ -1,0 +1,73 @@
+// KJC-TSK-0568 (Onboard A) — maturity classifier for the Brain (`kj start`).
+//
+// Pure and deterministic: given a bundle of read-only signals it labels the
+// project new | existing | legacy. No LLM, no I/O — the sweep (sweep.js) does
+// the reading; this only decides. The label drives which read-only subset the
+// orchestrator runs and, downstream (0570), whether a deep health pass is worth
+// the cost. A user-declared maturity always wins over inference.
+//
+// Acceptance criteria (KJC-TSK-0568):
+//   - empty repo / scaffolding only       -> new
+//   - code + config + tests/CI            -> existing
+//   - code but missing tests/CI, or very stale -> legacy
+
+/** Last-commit age (days) beyond which a repo counts as stalled/neglected. */
+export const STALE_DAYS_THRESHOLD = 365;
+
+const VALID = new Set(["new", "existing", "legacy"]);
+
+/**
+ * @param {object} signals
+ * @param {("new"|"existing"|"legacy"|null)} [signals.declared] user override
+ * @param {boolean} signals.hasSourceCode  real source files present
+ * @param {boolean} signals.scaffoldingOnly only generator boilerplate, no real code
+ * @param {boolean} signals.hasTests        a test suite is present
+ * @param {boolean} signals.hasCI           CI workflows are present
+ * @param {number}  [signals.commitCount]   number of commits (capped upstream)
+ * @param {number|null} [signals.staleDays] age of the last commit in days
+ * @returns {{maturity: "new"|"existing"|"legacy", reasons: string[], deepHealthRecommended: boolean, declared: boolean}}
+ */
+export function classifyMaturity(signals) {
+  if (!signals || typeof signals !== "object") {
+    throw new TypeError("classifyMaturity: signals must be an object");
+  }
+
+  if (VALID.has(signals.declared)) {
+    const maturity = signals.declared;
+    return {
+      maturity,
+      reasons: [`maturity declared by user as "${maturity}"`],
+      deepHealthRecommended: maturity === "legacy",
+      declared: true,
+    };
+  }
+
+  const reasons = [];
+  let maturity;
+
+  if (!signals.hasSourceCode || signals.scaffoldingOnly) {
+    maturity = "new";
+    reasons.push(signals.scaffoldingOnly ? "only scaffolding present, no real code yet" : "no source code found");
+  } else {
+    const stalled = typeof signals.staleDays === "number" && signals.staleDays > STALE_DAYS_THRESHOLD;
+    const gaps = [];
+    if (!signals.hasTests) gaps.push("no tests");
+    if (!signals.hasCI) gaps.push("no CI");
+    if (stalled) gaps.push(`last commit ${signals.staleDays}d old (stalled)`);
+
+    if (gaps.length > 0) {
+      maturity = "legacy";
+      reasons.push(`code present but neglected: ${gaps.join(", ")}`);
+    } else {
+      maturity = "existing";
+      reasons.push("code with tests and CI, actively maintained");
+    }
+  }
+
+  return {
+    maturity,
+    reasons,
+    deepHealthRecommended: maturity === "legacy",
+    declared: false,
+  };
+}

--- a/tests/start/maturity.test.js
+++ b/tests/start/maturity.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { classifyMaturity } from "../../src/start/maturity.js";
+
+/**
+ * KJC-TSK-0568 (Onboard A) — maturity classifier.
+ *
+ * Pure, deterministic, no LLM. Maps a bundle of read-only signals to one
+ * of new | existing | legacy, mirroring the card's acceptance criteria:
+ *   - empty repo / scaffolding only        -> new
+ *   - code + config + tests/CI             -> existing
+ *   - code but no tests/CI, or stalled     -> legacy
+ * A user-declared maturity always wins over inference.
+ */
+describe("classifyMaturity (KJC-TSK-0568)", () => {
+  const healthy = {
+    declared: null,
+    hasSourceCode: true,
+    scaffoldingOnly: false,
+    hasTests: true,
+    hasCI: true,
+    commitCount: 120,
+    staleDays: 5,
+  };
+
+  it("respects a user-declared maturity over the signals", () => {
+    const r = classifyMaturity({ ...healthy, declared: "legacy" });
+    expect(r.maturity).toBe("legacy");
+    expect(r.declared).toBe(true);
+    expect(r.reasons.join(" ")).toMatch(/declared/i);
+  });
+
+  it("ignores an invalid declared value and falls back to inference", () => {
+    const r = classifyMaturity({ ...healthy, declared: "ancient" });
+    expect(r.maturity).toBe("existing");
+    expect(r.declared).toBe(false);
+  });
+
+  it("classifies an empty repo as new", () => {
+    const r = classifyMaturity({
+      declared: null,
+      hasSourceCode: false,
+      scaffoldingOnly: false,
+      hasTests: false,
+      hasCI: false,
+      commitCount: 0,
+      staleDays: null,
+    });
+    expect(r.maturity).toBe("new");
+  });
+
+  it("classifies a scaffolding-only repo as new", () => {
+    const r = classifyMaturity({ ...healthy, hasSourceCode: true, scaffoldingOnly: true });
+    expect(r.maturity).toBe("new");
+  });
+
+  it("classifies code + tests + CI as existing", () => {
+    expect(classifyMaturity(healthy).maturity).toBe("existing");
+  });
+
+  it("classifies code without tests as legacy", () => {
+    expect(classifyMaturity({ ...healthy, hasTests: false }).maturity).toBe("legacy");
+  });
+
+  it("classifies code without CI as legacy", () => {
+    expect(classifyMaturity({ ...healthy, hasCI: false }).maturity).toBe("legacy");
+  });
+
+  it("classifies a healthy-but-stalled repo as legacy", () => {
+    const r = classifyMaturity({ ...healthy, staleDays: 540 });
+    expect(r.maturity).toBe("legacy");
+    expect(r.reasons.join(" ")).toMatch(/stall|old|inactiv/i);
+  });
+
+  it("recommends a deep health pass only for legacy", () => {
+    expect(classifyMaturity(healthy).deepHealthRecommended).toBe(false);
+    expect(classifyMaturity({ ...healthy, hasCI: false }).deepHealthRecommended).toBe(true);
+    expect(classifyMaturity({ declared: null, hasSourceCode: false, scaffoldingOnly: false, hasTests: false, hasCI: false, commitCount: 0, staleDays: null }).deepHealthRecommended).toBe(false);
+  });
+
+  it("always returns at least one reason", () => {
+    for (const m of [healthy, { ...healthy, hasTests: false }, { ...healthy, hasSourceCode: false }]) {
+      expect(classifyMaturity(m).reasons.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("throws on a missing or non-object signal bundle", () => {
+    expect(() => classifyMaturity(null)).toThrow(TypeError);
+    expect(() => classifyMaturity("nope")).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Qué

Primer slice de la épica **Brain** (KJC-PCS-0061, `kj start`): un clasificador de madurez **puro y determinista**, sin LLM.

`classifyMaturity(signals)` mapea un bundle de señales read-only a `new | existing | legacy`:
- repo vacío / solo scaffolding → `new`
- código + tests + CI, mantenido → `existing`
- código pero sin tests/CI, o último commit muy antiguo (>365d) → `legacy`

Una madurez **declarada por el usuario** gana siempre sobre la inferencia. `legacy` marca `deepHealthRecommended:true` como flag para que la decisión de correr el audit caro la tome 0570 (no aquí).

## Por qué

KJC-TSK-0568 (Onboard A). El Brain decide qué señales lanzar según la madurez; esta función es el clasificador. Sin I/O para mantenerlo trivialmente testeable — el barrido lo aporta sweep.js (PR2).

## Alcance

- `src/start/maturity.js` — `classifyMaturity` + `STALE_DAYS_THRESHOLD`
- `tests/start/maturity.test.js` — 11 casos (declared gana, scaffolding=new, gaps=legacy, stalled=legacy, deepHealth solo legacy, input defensivo)

Fuera de alcance: `kj start` CLI (0570), síntesis LLM (0569), orquestador del barrido (PR2). Net +163 LOC (bajo el gate de 200).