### PR TITLE
feat(start): read-only sweep orchestrator for the Brain (KJC-TSK-0568)

### DIFF
--- a/src/start/sweep.js
+++ b/src/start/sweep.js
@@ -1,0 +1,112 @@
+// KJC-TSK-0568 (Onboard A) — read-only sweep orchestrator for the Brain.
+//
+// Runs the READ-ONLY signals fitting the project's maturity and aggregates them
+// into one structured bundle for synthesis (Onboard B, 0569). Writes nothing.
+// No LLM: maturity is deterministic and the costly audit is deferred — legacy
+// only flags `deepHealthRecommended` (0570 decides). Subset by maturity: new =
+// brief+tests; existing/legacy = + drift, harden advisory, rag + qmd status.
+// Collaborators are injected (opts.deps) so it stays trivially testable.
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+import { collectAll } from "../onboarder/collectors/index.js";
+import { checkHarden } from "../harden/check.js";
+import { compareHarden } from "../harden/advisory.js";
+import { detectTestFramework } from "../utils/project-detect.js";
+import { detectQmd } from "../utils/qmd-detect.js";
+import {
+  dbPath, openVecStore, projectSlug, countChunks, getLastIndexedCommit,
+} from "../rag/vec-store.js";
+import { classifyMaturity } from "./maturity.js";
+
+const CODE_EXT = new Set([
+  ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".go",
+  ".rs", ".java", ".php", ".rb", ".c", ".cc", ".cpp", ".cs",
+]);
+const SCAFFOLD_MAX_FILES = 3;
+const CI_MARKERS = [".github/workflows", ".gitlab-ci.yml"];
+
+const safe = async (fn) => { try { return await fn(); } catch { return null; } };
+
+/** Count real source files in a tree bundle, skipping tests. */
+export function countCodeFiles(tree = []) {
+  let n = 0;
+  for (const node of tree) {
+    if (node.kind === "dir") n += countCodeFiles(node.children);
+    else if (node.kind === "file") {
+      const ext = node.path.slice(node.path.lastIndexOf("."));
+      const isTest = /\.(test|spec)\./.test(node.path) || /(^|\/)(test|tests|__tests__)\//.test(node.path);
+      if (CODE_EXT.has(ext) && !isTest) n += 1;
+    }
+  }
+  return n;
+}
+
+/** Age of the last commit in days, or null on non-git / no commits. */
+function lastCommitAgeDays(projectDir) {
+  try {
+    const out = execFileSync("git", ["log", "-1", "--format=%ct"], {
+      cwd: projectDir, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!out) return null;
+    return Math.floor((Date.now() - Number(out) * 1000) / 86_400_000);
+  } catch { return null; }
+}
+
+/** Read-only RAG index status; null when no index file exists yet. */
+function readRagStatus(projectDir) {
+  try {
+    if (!existsSync(dbPath())) return { indexed: false, chunks: 0, lastIndexedCommit: null };
+    const db = openVecStore();
+    return {
+      indexed: true,
+      chunks: countChunks(db, { kind: "code" }),
+      lastIndexedCommit: getLastIndexedCommit(db, projectSlug(projectDir)),
+    };
+  } catch { return null; }
+}
+
+/**
+ * @param {string} projectDir
+ * @param {{declared?: ("new"|"existing"|"legacy"|null), profile?: string, deps?: object}} [opts]
+ *   declared = user-declared maturity; deps = injected collaborators (defaults = real collectors).
+ */
+export async function runReadOnlySweep(projectDir, { declared = null, profile = "standard", deps = {} } = {}) {
+  const d = {
+    collectAll, detectTestFramework, checkHarden, compareHarden,
+    detectQmd, ragStatus: readRagStatus, gitAgeDays: lastCommitAgeDays, ...deps,
+  };
+
+  const brief = await safe(() => d.collectAll(projectDir));
+  const tests = await safe(() => d.detectTestFramework(projectDir));
+
+  const tree = brief?.tree ?? [];
+  const present = brief?.configs?.present ?? [];
+  const codeFiles = countCodeFiles(tree);
+  const commitCount = brief?.git?.commitCount ?? 0;
+
+  const signals = {
+    hasSourceCode: codeFiles > 0,
+    scaffoldingOnly: codeFiles > 0 && codeFiles <= SCAFFOLD_MAX_FILES && commitCount <= 1,
+    hasTests: Boolean(tests?.hasTests),
+    hasCI: CI_MARKERS.some((m) => present.includes(m)),
+    commitCount,
+    staleDays: d.gitAgeDays(projectDir),
+  };
+
+  const maturity = classifyMaturity({ declared, ...signals });
+  const deep = maturity.maturity !== "new";
+
+  return {
+    projectDir,
+    maturity,
+    signals,
+    brief,
+    tests,
+    drift: deep ? await safe(() => d.checkHarden({ projectDir, profile })) : null,
+    improvements: deep ? await safe(() => d.compareHarden({ projectDir, profile })) : null,
+    rag: deep ? await safe(() => d.ragStatus(projectDir)) : null,
+    qmd: deep ? await safe(() => d.detectQmd()) : null,
+    collectedAt: new Date().toISOString(),
+  };
+}

--- a/tests/start/sweep.test.js
+++ b/tests/start/sweep.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { runReadOnlySweep } from "../../src/start/sweep.js";
+
+/**
+ * KJC-TSK-0568 (Onboard A) — read-only sweep orchestrator.
+ *
+ * Deterministic, no LLM. Dependencies are injected so the test never touches
+ * git/fs and stays fast. Asserts: maturity-driven subset (new = minimal;
+ * existing/legacy = + drift/harden/rag/qmd), derived signals, and fail-soft
+ * slots (a throwing collector yields null, never a crash).
+ */
+function fakeDeps(over = {}) {
+  return {
+    collectAll: async () => ({
+      stack: { language: "javascript" },
+      tree: [{ path: "src", kind: "dir", children: ["index", "app", "util", "core"].map(
+        (n) => ({ path: `src/${n}.js`, kind: "file", bytes: 100 })) }],
+      git: { commitCount: 50, headSha: "abc" },
+      configs: { present: ["package.json", ".github/workflows"], scripts: { test: "vitest" } },
+    }),
+    detectTestFramework: async () => ({ hasTests: true, framework: "vitest", language: "javascript" }),
+    checkHarden: async () => ({ ok: true, checks: [] }),
+    compareHarden: () => ({ artifacts: [{ id: "eslint", recommendation: "keep" }] }),
+    detectQmd: async () => ({ available: true, version: "1.0" }),
+    ragStatus: () => ({ indexed: true, chunks: 42, lastIndexedCommit: "abc" }),
+    gitAgeDays: () => 3,
+    ...over,
+  };
+}
+
+describe("runReadOnlySweep (KJC-TSK-0568)", () => {
+  it("infers existing, derives signals, and runs the full subset", async () => {
+    const b = await runReadOnlySweep("/x", { deps: fakeDeps() });
+    expect(b.maturity.maturity).toBe("existing");
+    expect(b.signals).toMatchObject({
+      hasSourceCode: true, scaffoldingOnly: false, hasTests: true,
+      hasCI: true, commitCount: 50, staleDays: 3,
+    });
+    for (const slot of [b.drift, b.improvements, b.rag, b.qmd]) expect(slot).not.toBeNull();
+  });
+
+  it("a declared-new project gets the minimal subset (no drift/harden/rag/qmd)", async () => {
+    const b = await runReadOnlySweep("/x", { declared: "new", deps: fakeDeps() });
+    expect(b.maturity.maturity).toBe("new");
+    expect(b.drift).toBeNull();
+    expect(b.improvements).toBeNull();
+    expect(b.rag).toBeNull();
+    expect(b.qmd).toBeNull();
+    expect(b.brief).not.toBeNull();
+  });
+
+  it("flags legacy (no CI) with deepHealthRecommended", async () => {
+    const deps = fakeDeps({
+      collectAll: async () => ({
+        tree: [{ path: "src/a.js", kind: "file", bytes: 10 }, { path: "src/b.js", kind: "file", bytes: 20 }],
+        git: { commitCount: 30 },
+        configs: { present: ["package.json"], scripts: {} },
+      }),
+    });
+    const b = await runReadOnlySweep("/x", { deps });
+    expect(b.maturity.maturity).toBe("legacy");
+    expect(b.maturity.deepHealthRecommended).toBe(true);
+    expect(b.signals.hasCI).toBe(false);
+  });
+
+  it("treats a freshly-scaffolded repo as new", async () => {
+    const deps = fakeDeps({
+      collectAll: async () => ({
+        tree: [{ path: "index.js", kind: "file", bytes: 10 }],
+        git: { commitCount: 1 },
+        configs: { present: ["package.json"], scripts: {} },
+      }),
+      detectTestFramework: async () => ({ hasTests: false }),
+    });
+    const b = await runReadOnlySweep("/x", { deps });
+    expect(b.maturity.maturity).toBe("new");
+  });
+
+  it("is fail-soft: a throwing collector yields a null slot, not a crash", async () => {
+    const deps = fakeDeps({
+      checkHarden: async () => { throw new Error("boom"); },
+    });
+    const b = await runReadOnlySweep("/x", { deps });
+    expect(b.drift).toBeNull();
+    expect(b.improvements).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Qué

Segunda PR atómica de **KJC-TSK-0568 (Onboard A)** — el orquestador de barrido read-only del Brain (`kj start`).

`runReadOnlySweep(projectDir, opts)` agrega en un único bundle estructurado las señales read-only que correspondan a la madurez del proyecto, listo para la síntesis de Onboard B (0569). No escribe nada y no usa LLM: la madurez es determinista (clasificador de la PR #1128) y la auditoría costosa se difiere mediante el flag `deepHealthRecommended`.

## Subset por madurez

- **new** → `brief` + `tests` (mínimo).
- **existing / legacy** → además `drift` (harden check), `improvements` (harden advisory), `rag` status y `qmd` status.

## Diseño

- **Reutiliza** colectores read-only existentes (`collectAll`, `checkHarden`, `compareHarden`, `detectTestFramework`, `detectQmd`, vec-store). Cero lógica nueva de lectura.
- **Inyección de dependencias** (`opts.deps`) → tests sin tocar git/fs, rápidos y deterministas.
- **Fail-soft**: cada slot va envuelto en `safe()`; un colector que lanza deja `null`, nunca rompe el barrido.

## Tests

5 tests nuevos (16 en total con el clasificador): infiere existing y corre el subset completo, declared-new → subset mínimo, legacy sin CI → `deepHealthRecommended`, repo recién scaffolded → new, y fail-soft con un colector que lanza.

199 insertions (bajo el gate shrink-budget). Lint + prettier limpios.