### PR TITLE
feat(start): deterministic synthesis of the read-only sweep (KJC-TSK-0569)

### DIFF
--- a/src/start/assessment.js
+++ b/src/start/assessment.js
@@ -1,0 +1,74 @@
+// KJC-TSK-0569 (Onboard B) — deterministic synthesis of the read-only sweep.
+//
+// Turns the sweep bundle (Onboard A, 0568) into one coherent digest: a
+// human-readable report plus a machine summary the decider (StartDecidorRole)
+// consumes to pick an intent. No LLM here — the costly call is the haiku
+// decider, not a redundant strong-model narration. Reuses the harden advisory
+// formatter so the improvements section reads exactly like `kj harden --report`.
+import { formatAdvisoryReport } from "../harden/advisory.js";
+
+const EMPTY_TALLY = { install: 0, update: 0, review: 0, keep: 0 };
+
+/** Tally harden advisory artifacts by recommendation. */
+function tallyImprovements(improvements) {
+  const tally = { ...EMPTY_TALLY };
+  for (const a of improvements?.artifacts ?? []) {
+    if (a?.recommendation in tally) tally[a.recommendation] += 1;
+  }
+  return tally;
+}
+
+/** Quality/maintenance gaps as short phrases, derived from signals + drift. */
+function collectGaps(signals = {}, drift) {
+  const gaps = [];
+  if (!signals.hasTests) gaps.push("no tests");
+  if (!signals.hasCI) gaps.push("no CI");
+  if (typeof signals.staleDays === "number" && signals.staleDays > 365) {
+    gaps.push(`last commit ${signals.staleDays}d old`);
+  }
+  if (drift && drift.ok === false) {
+    const failed = (drift.checks ?? []).filter((c) => c?.ok === false).length;
+    if (failed > 0) gaps.push(`${failed} harden check(s) drifting`);
+  }
+  return gaps;
+}
+
+/**
+ * @param {object} bundle output of runReadOnlySweep (0568)
+ * @returns {{text: string, summary: object}}
+ */
+export function buildAssessment(bundle) {
+  if (!bundle || typeof bundle !== "object") {
+    throw new TypeError("buildAssessment: bundle must be an object");
+  }
+  const { maturity = {}, signals = {}, drift, improvements, rag, qmd } = bundle;
+  const gaps = collectGaps(signals, drift);
+  const improvementCounts = tallyImprovements(improvements);
+
+  const summary = {
+    maturity: maturity.maturity ?? "unknown",
+    declared: Boolean(maturity.declared),
+    deepHealthRecommended: Boolean(maturity.deepHealthRecommended),
+    gaps,
+    driftOk: drift ? drift.ok !== false : null,
+    improvementCounts,
+    indexed: rag ? Boolean(rag.indexed) : null,
+    qmdAvailable: qmd ? Boolean(qmd.available) : null,
+  };
+
+  const lines = [
+    `Project maturity: ${summary.maturity}${summary.declared ? " (declared)" : " (inferred)"}`,
+    ...(maturity.reasons ?? []).map((r) => `  - ${r}`),
+    "",
+    `Tests: ${signals.hasTests ? "yes" : "no"} · CI: ${signals.hasCI ? "yes" : "no"} · commits: ${signals.commitCount ?? 0}`,
+    `Quality gaps: ${gaps.length ? gaps.join(", ") : "none detected"}`,
+    `Knowledge index: ${summary.indexed === null ? "n/a" : summary.indexed ? "present" : "missing"}` +
+      ` · qmd: ${summary.qmdAvailable === null ? "n/a" : summary.qmdAvailable ? "available" : "absent"}`,
+  ];
+
+  if (improvements) {
+    lines.push("", ...formatAdvisoryReport(improvements));
+  }
+
+  return { text: lines.join("\n"), summary };
+}

--- a/tests/start/assessment.test.js
+++ b/tests/start/assessment.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { buildAssessment } from "../../src/start/assessment.js";
+
+/**
+ * KJC-TSK-0569 (Onboard B) — deterministic synthesis.
+ *
+ * buildAssessment reduces the 0568 sweep bundle to a digest + machine summary.
+ * Pure, no LLM. Asserts: gap derivation, improvement tally, null-safe optional
+ * slots (new project has no drift/rag/qmd), and the advisory section is folded
+ * in when present.
+ */
+function bundle(over = {}) {
+  return {
+    projectDir: "/x",
+    maturity: { maturity: "existing", reasons: ["code with tests and CI"], deepHealthRecommended: false, declared: false },
+    signals: { hasSourceCode: true, scaffoldingOnly: false, hasTests: true, hasCI: true, commitCount: 40, staleDays: 5 },
+    drift: { ok: true, checks: [] },
+    improvements: { artifacts: [{ recommendation: "install", dir: ".", file: "eslint.config.js", foundAt: "eslint.config.js", rationale: "missing", improvements: [] }] },
+    rag: { indexed: true, chunks: 10 },
+    qmd: { available: true },
+    ...over,
+  };
+}
+
+describe("buildAssessment (KJC-TSK-0569)", () => {
+  it("summarizes a healthy existing project with no gaps", () => {
+    const { text, summary } = buildAssessment(bundle());
+    expect(summary.maturity).toBe("existing");
+    expect(summary.gaps).toEqual([]);
+    expect(summary.improvementCounts.install).toBe(1);
+    expect(summary.indexed).toBe(true);
+    expect(text).toMatch(/maturity: existing \(inferred\)/);
+  });
+
+  it("derives gaps from missing tests/CI and stale commits", () => {
+    const { summary } = buildAssessment(bundle({
+      signals: { hasTests: false, hasCI: false, commitCount: 3, staleDays: 540 },
+      maturity: { maturity: "legacy", reasons: ["neglected"], deepHealthRecommended: true, declared: false },
+    }));
+    expect(summary.gaps).toContain("no tests");
+    expect(summary.gaps).toContain("no CI");
+    expect(summary.gaps.some((g) => /540d old/.test(g))).toBe(true);
+    expect(summary.deepHealthRecommended).toBe(true);
+  });
+
+  it("counts drifting harden checks as a gap", () => {
+    const { summary } = buildAssessment(bundle({
+      drift: { ok: false, checks: [{ id: "a", ok: false }, { id: "b", ok: true }] },
+    }));
+    expect(summary.driftOk).toBe(false);
+    expect(summary.gaps.some((g) => /1 harden check/.test(g))).toBe(true);
+  });
+
+  it("is null-safe for a new project with no deep signals", () => {
+    const { text, summary } = buildAssessment(bundle({
+      maturity: { maturity: "new", reasons: ["no source code found"], deepHealthRecommended: false, declared: false },
+      drift: null, improvements: null, rag: null, qmd: null,
+    }));
+    expect(summary.indexed).toBeNull();
+    expect(summary.qmdAvailable).toBeNull();
+    expect(summary.improvementCounts).toEqual({ install: 0, update: 0, review: 0, keep: 0 });
+    expect(text).toMatch(/maturity: new/);
+  });
+
+  it("folds in the harden advisory report when improvements are present", () => {
+    const { text } = buildAssessment(bundle());
+    expect(text).toMatch(/kj harden — advisory report/);
+  });
+
+  it("throws on a missing or non-object bundle", () => {
+    expect(() => buildAssessment(null)).toThrow(TypeError);
+    expect(() => buildAssessment("nope")).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Qué

Primera PR atómica de **KJC-TSK-0569 (Onboard B)** — la síntesis del Brain.

`buildAssessment(bundle)` reduce el bundle read-only de Onboard A (#1129) a un **informe único coherente**: un digest legible + un `summary` machine-readable que el decisor haiku (PR2) consumirá para elegir un intent.

## Decisión de diseño (anti-sobreingeniería)

La spec planteaba Fase 2 (síntesis con modelo fuerte) **+** Fase 3 (decisor haiku) = dos llamadas LLM. La pieza genuinamente IA es **solo el decisor**. Aquí la síntesis es **determinista**: deriva madurez, gaps (tests/CI/staleness/drift), tally de mejoras y estado de índice/qmd directamente del bundle, **reutilizando `formatAdvisoryReport`** para que la sección de mejoras se lea idéntica a `kj harden --report`. Más simple, más barato y testeable, sin una segunda llamada LLM cara redundante.

## API

- `buildAssessment(bundle)` → `{ text, summary }`. Puro, sin I/O ni LLM.
- `summary`: `{ maturity, declared, deepHealthRecommended, gaps[], driftOk, improvementCounts, indexed, qmdAvailable }` — null-safe para proyectos nuevos sin señales profundas.

## Tests

6 tests: proyecto existente sano sin gaps, derivación de gaps (tests/CI/staleness), drift de harden como gap, null-safety para proyecto nuevo, fold-in del advisory report, y TypeError ante bundle inválido.

148 insertions (bajo el gate). Lint + prettier limpios.