### PR TITLE
feat(start): start decider role for the Brain (KJC-TSK-0569)

### DIFF
--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -27,7 +27,8 @@ const DEFAULTS = {
     triage: { provider: null, model: null },
     discover: { provider: null, model: null },
     architect: { provider: null, model: null },
-    hu_reviewer: { provider: null, model: null }
+    hu_reviewer: { provider: null, model: null },
+    start: { provider: null, model: "haiku" }
   },
   pipeline: {
     planner: { enabled: false },

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -90,6 +90,7 @@ const RolesMap = v.optional(v.looseObject({
   discover: v.optional(RoleEntry),
   architect: v.optional(RoleEntry),
   hu_reviewer: v.optional(RoleEntry),
+  start: v.optional(RoleEntry),
 }));
 
 const PipelineEntry = v.looseObject({

--- a/src/prompts/start-decision.js
+++ b/src/prompts/start-decision.js
@@ -1,0 +1,52 @@
+// KJC-TSK-0569 (Onboard B) — prompt + intent schema for the StartDecidor.
+//
+// The decider only DECIDES (one intent from a closed set); the safe HOW is
+// deterministic (0570 maps the intent to a saved command). Keep this prompt
+// tight: it routes, it never executes.
+const PREAMBLE = [
+  "IMPORTANT: You are running as a Karajan sub-agent (the `kj start` decider).",
+  "Do NOT mention Karajan, do NOT use MCP tools, do NOT execute anything.",
+  "Your only job: read the project assessment and pick ONE next-step intent.",
+].join(" ");
+
+/** Closed set of intents. Anything else degrades to ASK_USER. */
+export const INTENTS = new Set([
+  "ASSESS_ONLY",
+  "RECOMMEND_HARDEN",
+  "RECOMMEND_INDEX",
+  "START_TASK",
+  "PROPOSE_PLAN",
+  "ASK_USER",
+]);
+
+const INTENT_GUIDE = [
+  "- ASSESS_ONLY: the project is healthy and the user gave no goal — just report.",
+  "- RECOMMEND_HARDEN: quality gaps exist (no tests/CI, drifting checks, missing config).",
+  "- RECOMMEND_INDEX: the codebase has no knowledge index yet.",
+  "- START_TASK: the user stated a concrete thing to build or fix.",
+  "- PROPOSE_PLAN: legacy/large project, or a goal that needs a modernization/feature plan.",
+  "- ASK_USER: intent is unclear — ask ONE open question to disambiguate.",
+].join("\n");
+
+/**
+ * @param {{userMessage?: string, assessment?: string, instructions?: string}} input
+ * @returns {string}
+ */
+export function buildStartDecisionPrompt({ userMessage = "", assessment = "", instructions } = {}) {
+  const sections = [PREAMBLE];
+  if (instructions) sections.push(instructions);
+  sections.push(
+    "You route the next step for a project the user just opened with `kj start`.",
+    "## Project assessment (read-only signals)",
+    assessment || "(no assessment available)",
+    "## User goal",
+    userMessage.trim() || "(none given)",
+    "## Intents",
+    INTENT_GUIDE,
+    "Pick the single best intent. Prefer a concrete next step over ASK_USER when the assessment is clear.",
+    "If you pick ASK_USER, put the open question in questionToAsk.",
+    "Return a single valid JSON object and nothing else.",
+    'JSON schema: {"intent":"ASSESS_ONLY|RECOMMEND_HARDEN|RECOMMEND_INDEX|START_TASK|PROPOSE_PLAN|ASK_USER","rationale":string,"questionToAsk":string}',
+  );
+  return sections.join("\n\n");
+}

--- a/src/start/start-decider-role.js
+++ b/src/start/start-decider-role.js
@@ -1,0 +1,79 @@
+// KJC-TSK-0569 (Onboard B) — the StartDecidor: the only LLM in the Brain's
+// onboarding. Reads the deterministic assessment + user goal, picks ONE intent
+// from a closed set, and never executes (0570 maps the intent to a safe command).
+// Provider falls back to the coder, model defaults to haiku. Unparseable/unknown
+// output degrades to ASK_USER so `kj start` always has a sane next step.
+import { AgentRole } from "../roles/agent-role.js";
+import { extractFirstJson } from "../utils/json-extract.js";
+import { buildStartDecisionPrompt, INTENTS } from "../prompts/start-decision.js";
+
+const FALLBACK_QUESTION = "What would you like to do with this project?";
+
+export class StartDecidorRole extends AgentRole {
+  constructor(opts) {
+    super({ ...opts, name: "start" });
+  }
+
+  extractInput(input) {
+    const src = typeof input === "string" ? { userMessage: input } : input || {};
+    return {
+      userMessage: src.userMessage || "",
+      assessment: src.assessment || "",
+      onOutput: src.onOutput || null,
+      ...src,
+    };
+  }
+
+  async buildPrompt({ userMessage, assessment }) {
+    return {
+      prompt: buildStartDecisionPrompt({ userMessage, assessment, instructions: this.instructions }),
+    };
+  }
+
+  parseOutput(raw) {
+    return extractFirstJson(raw);
+  }
+
+  buildSuccessResult(parsed, provider) {
+    const intent = INTENTS.has(parsed.intent) ? parsed.intent : "ASK_USER";
+    const rationale = String(parsed.rationale || "").trim();
+    const questionToAsk = String(parsed.questionToAsk || "").trim();
+    const degraded = intent !== parsed.intent;
+    return {
+      intent,
+      rationale: rationale || (degraded ? "Unrecognized intent, asking the user." : "No rationale provided."),
+      questionToAsk: intent === "ASK_USER" ? questionToAsk || FALLBACK_QUESTION : "",
+      provider,
+    };
+  }
+
+  buildSummary(parsed) {
+    const intent = INTENTS.has(parsed.intent) ? parsed.intent : "ASK_USER";
+    return `Start decision: ${intent}`;
+  }
+
+  handleParseNull(agentResult, provider) {
+    return this.degradedDecision({ agentResult, provider, reason: "no JSON found" });
+  }
+
+  handleParseError(err, agentResult, provider) {
+    return this.degradedDecision({ agentResult, provider, reason: err?.message || "parse error" });
+  }
+
+  // Never block onboarding: garbage in → ask the user one open question.
+  degradedDecision({ agentResult, provider, reason }) {
+    this.logger?.warn?.(`[start] decider output unusable (${reason}) — asking the user.`);
+    return {
+      ok: true,
+      result: {
+        intent: "ASK_USER",
+        rationale: `Could not read a decision (${reason}).`,
+        questionToAsk: FALLBACK_QUESTION,
+        provider,
+        degraded: true,
+      },
+      summary: "Start decision: ASK_USER (fallback)",
+      usage: agentResult.usage,
+    };
+  }
+}

--- a/tests/start/start-decider-role.test.js
+++ b/tests/start/start-decider-role.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { StartDecidorRole } from "../../src/start/start-decider-role.js";
+
+/**
+ * KJC-TSK-0569 (Onboard B) — the StartDecidor role. The agent is injected
+ * (createAgentFn) so the test never spawns a CLI. Asserts: valid intent passes
+ * through, unknown/unparseable output degrades to ASK_USER, provider resolves.
+ */
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+
+function roleWith(output, { config = {}, ok = true } = {}) {
+  const runTask = vi.fn(async (args) => ({ ok, output, usage: {}, prompt: args.prompt }));
+  const role = new StartDecidorRole({
+    config: { roles: { coder: { provider: "claude" } }, ...config },
+    logger,
+    createAgentFn: () => ({ runTask }),
+  });
+  return { role, runTask };
+}
+
+describe("StartDecidorRole (KJC-TSK-0569)", () => {
+  it("passes a valid intent through with its rationale", async () => {
+    const { role } = roleWith('{"intent":"RECOMMEND_HARDEN","rationale":"no tests"}');
+    const r = await role.execute({ userMessage: "", assessment: "Tests: no" });
+    expect(r.ok).toBe(true);
+    expect(r.result.intent).toBe("RECOMMEND_HARDEN");
+    expect(r.result.rationale).toBe("no tests");
+    expect(r.result.questionToAsk).toBe("");
+  });
+
+  it("keeps the open question when the intent is ASK_USER", async () => {
+    const { role } = roleWith('{"intent":"ASK_USER","questionToAsk":"Build or fix?"}');
+    const r = await role.execute({ assessment: "x" });
+    expect(r.result.intent).toBe("ASK_USER");
+    expect(r.result.questionToAsk).toBe("Build or fix?");
+  });
+
+  it("degrades an unknown intent to ASK_USER with a fallback question", async () => {
+    const { role } = roleWith('{"intent":"LAUNCH_ROCKET"}');
+    const r = await role.execute({ assessment: "x" });
+    expect(r.ok).toBe(true);
+    expect(r.result.intent).toBe("ASK_USER");
+    expect(r.result.questionToAsk).toMatch(/\?$/);
+  });
+
+  it("degrades unparseable output to ASK_USER instead of failing", async () => {
+    const { role } = roleWith("sorry, I cannot help with that");
+    const r = await role.execute({ assessment: "x" });
+    expect(r.ok).toBe(true);
+    expect(r.result.intent).toBe("ASK_USER");
+    expect(r.result.degraded).toBe(true);
+  });
+
+  it("feeds userMessage and assessment into the prompt", async () => {
+    const { role, runTask } = roleWith('{"intent":"START_TASK"}');
+    await role.execute({ userMessage: "add a logout button", assessment: "Maturity: existing" });
+    const prompt = runTask.mock.calls[0][0].prompt;
+    expect(prompt).toContain("add a logout button");
+    expect(prompt).toContain("Maturity: existing");
+  });
+
+  it("resolves the start role to the coder provider when unset", () => {
+    const { role } = roleWith("{}");
+    expect(role.resolveProvider()).toBe("claude");
+  });
+});


### PR DESCRIPTION
## What

PR2 of KJC-TSK-0569 (Onboard B). Adds the **StartDecidor** — the single LLM in the Brain's onboarding flow.

It reads the deterministic assessment (PR1, `buildAssessment`) plus the user goal and returns **one** next-step intent from a closed set. It never executes; KJC-TSK-0570 (Onboard C) maps each intent to a safe saved command.

## Pieces

- `src/prompts/start-decision.js` — prompt + closed `INTENTS` set (`ASSESS_ONLY`, `RECOMMEND_HARDEN`, `RECOMMEND_INDEX`, `START_TASK`, `PROPOSE_PLAN`, `ASK_USER`).
- `src/start/start-decider-role.js` — `StartDecidorRole extends AgentRole` (name `start`). Provider inherits the coder; model defaults to **haiku** (cheap routing). Runs through `withBrainRecovery` automatically via the base `execute()`.
- `src/config/{defaults,schema}.js` — ship `roles.start = { provider: null, model: "haiku" }`.

## Robustness (no over-engineering)

- Unknown intent → degrades to `ASK_USER` with a fallback question.
- Unparseable / null output → `degradedDecision` → `ASK_USER` (never crashes `kj start`).
- haiku is read first by `getRoleModel`; if the coder is codex/gemini and rejects haiku, those agents already retry with their own default model — no latent crash.

The costly strong-model narration was deliberately avoided: synthesis is deterministic (PR1), only the tiny routing call is an LLM, and it runs on haiku.

## Tests

`tests/start/start-decider-role.test.js` — 6 tests, agent injected (no CLI spawned): valid intent pass-through, ASK_USER question preserved, unknown-intent degrade, unparseable degrade, prompt wiring, provider resolution.

Net LOC: 199 (within shrink-budget).