### PR TITLE
feat(start): kj start orchestration loop (KJC-TSK-0570)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -7,6 +7,7 @@
 
 /** The few commands a newcomer needs. Shown in `kj --help`. */
 export const CORE_COMMANDS = [
+  "start",
   "init",
   "run",
   "plan",

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -3,6 +3,7 @@ import { triageCommand } from "../commands/triage.js";
 import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
+import { startCommand } from "../commands/start.js";
 import { ragIndexCommand, ragQueryCommand, ragInstallHooksCommand, ragEvalCommand } from "../commands/rag.js";
 import { qmdQueryCommand } from "../commands/qmd.js";
 import { ragMcpCommand } from "../commands/rag-mcp.js";
@@ -103,6 +104,19 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "onboard", flags, async ({ config, logger }) => {
         await onboardCommand({ config, logger, flags });
+      });
+    });
+
+  program
+    .command("start")
+    .description("Single entry point: assess the project and recommend the next step")
+    .argument("[task]", "What you want to do (optional natural-language goal)")
+    .option("--maturity <type>", "Declare project maturity: new|existing|legacy")
+    .option("--yes", "Non-interactive: emit assessment + recommendation, apply nothing")
+    .option("--json", "Output the assessment + decision as JSON")
+    .action(async (task, flags) => {
+      await withConfig(pkgVersion, "start", flags, async ({ config, logger }) => {
+        await startCommand({ task, config, logger, flags });
       });
     });
 

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -1,0 +1,58 @@
+// KJC-TSK-0570 (Onboard C) — `kj start`: the single entry point to the Brain.
+// Wires the read-only sweep (0568) → deterministic assessment (0569) → haiku
+// decider (0569) and reports the recommended next step. This slice WRITES
+// NOTHING: dispatching the chosen intent (harden/index/run/plan) with
+// confirmation lands in the follow-up. --json / --yes / no-TTY emit the
+// assessment + intent and exit. Collaborators are injected for testing.
+import { runReadOnlySweep } from "../start/sweep.js";
+import { buildAssessment } from "../start/assessment.js";
+import { StartDecidorRole } from "../start/start-decider-role.js";
+
+// Each intent maps to the saved command the follow-up will dispatch.
+const NEXT_STEP = {
+  ASSESS_ONLY: "Everything looks healthy — nothing to do.",
+  RECOMMEND_HARDEN: "Suggested: `kj harden --interactive`",
+  RECOMMEND_INDEX: "Suggested: `kj rag index`",
+  START_TASK: 'Suggested: `kj run "<task>"`',
+  PROPOSE_PLAN: 'Suggested: `kj plan "<goal>"`',
+};
+
+const ASK_FALLBACK = "What would you like to do with this project?";
+
+// The decider has its own quota/parse recovery; a spawn-level failure (CLI not
+// installed) still throws, so we degrade here too — `kj start` never crashes.
+async function decide({ task, text, config, logger, makeDecider }) {
+  const decider = makeDecider({ config, logger });
+  try {
+    const decision = await decider.execute({ userMessage: task, assessment: text });
+    return decision.result || {};
+  } catch (err) {
+    logger?.warn?.(`[start] decider unavailable (${err?.message || err}) — asking the user.`);
+    return { intent: "ASK_USER", rationale: "Decider unavailable.", questionToAsk: ASK_FALLBACK, degraded: true };
+  }
+}
+
+export async function startCommand({ task = "", config, logger, flags = {}, deps = {} }) {
+  const sweep = deps.runReadOnlySweep || runReadOnlySweep;
+  const assess = deps.buildAssessment || buildAssessment;
+  const makeDecider = deps.makeDecider || ((opts) => new StartDecidorRole(opts));
+
+  const bundle = await sweep(config.projectDir, { declared: flags.maturity || null });
+  const { text, summary } = assess(bundle);
+  const result = await decide({ task, text, config, logger, makeDecider });
+
+  if (flags.json) {
+    console.log(JSON.stringify({ maturity: summary.maturity, assessment: text, ...result }, null, 2));
+    return { ok: true, intent: result.intent };
+  }
+
+  console.log(`${text}\n`);
+  if (result.intent === "ASK_USER") {
+    console.log(`❓ ${result.questionToAsk || ASK_FALLBACK}`);
+  } else {
+    if (result.rationale) console.log(`→ ${result.rationale}`);
+    const step = NEXT_STEP[result.intent];
+    if (step) console.log(`  ${step}`);
+  }
+  return { ok: true, intent: result.intent };
+}

--- a/tests/start/start-command.test.js
+++ b/tests/start/start-command.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { startCommand } from "../../src/commands/start.js";
+
+/**
+ * KJC-TSK-0570 (Onboard C) — `kj start` orchestration. Collaborators are
+ * injected (deps) so no sweep runs and no CLI spawns. Asserts the read-only
+ * loop wiring, --json output, the maturity flag, ASK_USER and crash-safety.
+ */
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const config = { projectDir: "/tmp/proj" };
+
+function deps(result, { sweepBundle = {} } = {}) {
+  return {
+    runReadOnlySweep: vi.fn(async () => sweepBundle),
+    buildAssessment: vi.fn(() => ({ text: "ASSESSMENT TEXT", summary: { maturity: "existing" } })),
+    makeDecider: () => ({ execute: vi.fn(async () => ({ result })) }),
+  };
+}
+
+let logs;
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("startCommand (KJC-TSK-0570)", () => {
+  it("runs sweep → assessment → decider and prints the recommended step", async () => {
+    const d = deps({ intent: "RECOMMEND_HARDEN", rationale: "no tests" });
+    const r = await startCommand({ task: "", config, logger, flags: {}, deps: d });
+    expect(r.intent).toBe("RECOMMEND_HARDEN");
+    expect(d.runReadOnlySweep).toHaveBeenCalledWith("/tmp/proj", { declared: null });
+    const out = logs.join("\n");
+    expect(out).toContain("ASSESSMENT TEXT");
+    expect(out).toContain("kj harden");
+  });
+
+  it("emits JSON with maturity + intent under --json, applying nothing", async () => {
+    const d = deps({ intent: "START_TASK", rationale: "go" });
+    await startCommand({ task: "add x", config, logger, flags: { json: true }, deps: d });
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.maturity).toBe("existing");
+    expect(parsed.intent).toBe("START_TASK");
+    expect(parsed.assessment).toBe("ASSESSMENT TEXT");
+  });
+
+  it("passes the declared maturity flag to the sweep", async () => {
+    const d = deps({ intent: "ASSESS_ONLY" });
+    await startCommand({ config, logger, flags: { maturity: "legacy" }, deps: d });
+    expect(d.runReadOnlySweep).toHaveBeenCalledWith("/tmp/proj", { declared: "legacy" });
+  });
+
+  it("prints the open question when the decider returns ASK_USER", async () => {
+    const d = deps({ intent: "ASK_USER", questionToAsk: "Build or fix?" });
+    await startCommand({ config, logger, flags: {}, deps: d });
+    expect(logs.join("\n")).toContain("Build or fix?");
+  });
+
+  it("degrades to ASK_USER instead of crashing when the decider throws", async () => {
+    const d = deps({});
+    d.makeDecider = () => ({ execute: vi.fn(async () => { throw new Error("claude not found"); }) });
+    const r = await startCommand({ config, logger, flags: {}, deps: d });
+    expect(r.intent).toBe("ASK_USER");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("feeds the user task and assessment into the decider", async () => {
+    const execute = vi.fn(async () => ({ result: { intent: "START_TASK" } }));
+    const d = { ...deps({ intent: "START_TASK" }), makeDecider: () => ({ execute }) };
+    await startCommand({ task: "add logout", config, logger, flags: {}, deps: d });
+    expect(execute).toHaveBeenCalledWith({ userMessage: "add logout", assessment: "ASSESSMENT TEXT" });
+  });
+});


### PR DESCRIPTION
## Onboard C (PR1) — `kj start` orchestration loop

Final slice of the Brain epic (KJC-PCS-0061). Wires the pieces from Onboard A/B behind a single command:

```
kj start [task]
  → runReadOnlySweep (0568)      # read-only signals, writes nothing
  → buildAssessment  (0569)      # deterministic digest
  → StartDecidorRole (0569)      # haiku decider → one closed-set intent
  → report the recommended next step
```

### Scope (intentionally small — devPoints 2, split in two)
- **This PR**: orchestration + report + non-interactive modes. Read-only — applies nothing.
- **PR2**: confirm → dispatch the chosen intent to its saved command (`harden --interactive` / `rag index` / `run` / `plan`).

### Behaviour
- Default: prints the assessment, the decider's rationale and the suggested next command.
- `--json` / `--yes` / no-TTY: emit `{maturity, assessment, intent, …}` and exit — no prompts, no writes (CI-friendly).
- `--maturity new|existing|legacy`: declare maturity instead of inferring it.
- Crash-safe: if the decider provider isn't installed, degrades to `ASK_USER` instead of throwing.

### Tests
6 new tests (injected collaborators, no CLI spawned): loop wiring, JSON mode, maturity flag, ASK_USER, crash-safety, decider input. `tests/start` 34/34 green.

Net +145 LOC (within shrink-budget).