### PR TITLE
feat(start): dispatch the chosen intent to its command (KJC-TSK-0570)

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -1,14 +1,17 @@
 // KJC-TSK-0570 (Onboard C) — `kj start`: the single entry point to the Brain.
 // Wires the read-only sweep (0568) → deterministic assessment (0569) → haiku
-// decider (0569) and reports the recommended next step. This slice WRITES
-// NOTHING: dispatching the chosen intent (harden/index/run/plan) with
-// confirmation lands in the follow-up. --json / --yes / no-TTY emit the
-// assessment + intent and exit. Collaborators are injected for testing.
+// decider (0569), reports the recommended next step, and — interactively only —
+// confirms and dispatches the chosen intent to its saved command
+// (harden/rag/run/plan). --json / --yes / no-TTY stay read-only: emit the
+// assessment + intent and apply nothing. Collaborators are injected for testing.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { runReadOnlySweep } from "../start/sweep.js";
 import { buildAssessment } from "../start/assessment.js";
 import { StartDecidorRole } from "../start/start-decider-role.js";
+import { createWizard, isTTY } from "../utils/wizard.js";
 
-// Each intent maps to the saved command the follow-up will dispatch.
+// The recommended next step shown for each intent.
 const NEXT_STEP = {
   ASSESS_ONLY: "Everything looks healthy — nothing to do.",
   RECOMMEND_HARDEN: "Suggested: `kj harden --interactive`",
@@ -17,7 +20,23 @@ const NEXT_STEP = {
   PROPOSE_PLAN: 'Suggested: `kj plan "<goal>"`',
 };
 
+// Each writing intent maps to the saved command + args `kj start` dispatches.
+const DISPATCH = {
+  RECOMMEND_HARDEN: () => ["harden", "--interactive"],
+  RECOMMEND_INDEX: () => ["rag", "index"],
+  START_TASK: (task) => ["run", task],
+  PROPOSE_PLAN: (task) => ["plan", task],
+};
+
 const ASK_FALLBACK = "What would you like to do with this project?";
+const CLI_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "cli.js");
+
+// Run a saved `kj` subcommand as a child, inheriting stdio so its own prompts
+// (e.g. `harden --interactive`) drive the real terminal. Never throws here.
+async function spawnKj(args, { cwd }) {
+  const { execa } = await import("execa");
+  await execa("node", [CLI_PATH, ...args.filter(Boolean)], { cwd, stdio: "inherit", reject: false });
+}
 
 // The decider has its own quota/parse recovery; a spawn-level failure (CLI not
 // installed) still throws, so we degrade here too — `kj start` never crashes.
@@ -32,14 +51,38 @@ async function decide({ task, text, config, logger, makeDecider }) {
   }
 }
 
+// Ask one yes/no, always closing the readline interface afterwards.
+async function confirmApply(makeWizard) {
+  const wizard = makeWizard();
+  try {
+    return await wizard.confirm("Apply this?", true);
+  } finally {
+    wizard.close();
+  }
+}
+
+// Print the rationale + recommended step, or the open question for ASK_USER.
+function render(result) {
+  if (result.intent === "ASK_USER") {
+    console.log(`❓ ${result.questionToAsk || ASK_FALLBACK}`);
+    return;
+  }
+  if (result.rationale) console.log(`→ ${result.rationale}`);
+  const step = NEXT_STEP[result.intent];
+  if (step) console.log(`  ${step}`);
+}
+
 export async function startCommand({ task = "", config, logger, flags = {}, deps = {} }) {
   const sweep = deps.runReadOnlySweep || runReadOnlySweep;
   const assess = deps.buildAssessment || buildAssessment;
   const makeDecider = deps.makeDecider || ((opts) => new StartDecidorRole(opts));
+  const tty = deps.isTTY || isTTY;
+  const spawn = deps.spawnKj || spawnKj;
+  const makeWizard = deps.makeWizard || (() => createWizard());
 
   const bundle = await sweep(config.projectDir, { declared: flags.maturity || null });
   const { text, summary } = assess(bundle);
-  const result = await decide({ task, text, config, logger, makeDecider });
+  let result = await decide({ task, text, config, logger, makeDecider });
 
   if (flags.json) {
     console.log(JSON.stringify({ maturity: summary.maturity, assessment: text, ...result }, null, 2));
@@ -47,12 +90,24 @@ export async function startCommand({ task = "", config, logger, flags = {}, deps
   }
 
   console.log(`${text}\n`);
-  if (result.intent === "ASK_USER") {
-    console.log(`❓ ${result.questionToAsk || ASK_FALLBACK}`);
-  } else {
-    if (result.rationale) console.log(`→ ${result.rationale}`);
-    const step = NEXT_STEP[result.intent];
-    if (step) console.log(`  ${step}`);
+  const interactive = tty() && !flags.yes;
+
+  // ASK_USER: one interactive re-route — the open answer becomes the goal.
+  if (result.intent === "ASK_USER" && interactive) {
+    const wizard = makeWizard();
+    try {
+      const answer = await wizard.input(`❓ ${result.questionToAsk || ASK_FALLBACK}`);
+      if (answer) result = await decide({ task: answer, text, config, logger, makeDecider });
+    } finally {
+      wizard.close();
+    }
+  }
+  render(result);
+
+  // Dispatch the chosen intent to its saved command, confirming first (it writes).
+  const toArgs = DISPATCH[result.intent];
+  if (interactive && toArgs && (await confirmApply(makeWizard))) {
+    await spawn(toArgs(task), { cwd: config.projectDir });
   }
   return { ok: true, intent: result.intent };
 }

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -6,6 +6,7 @@
 // assessment + intent and apply nothing. Collaborators are injected for testing.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { execa } from "execa";
 import { runReadOnlySweep } from "../start/sweep.js";
 import { buildAssessment } from "../start/assessment.js";
 import { StartDecidorRole } from "../start/start-decider-role.js";
@@ -34,7 +35,6 @@ const CLI_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 // Run a saved `kj` subcommand as a child, inheriting stdio so its own prompts
 // (e.g. `harden --interactive`) drive the real terminal. Never throws here.
 async function spawnKj(args, { cwd }) {
-  const { execa } = await import("execa");
   await execa("node", [CLI_PATH, ...args.filter(Boolean)], { cwd, stdio: "inherit", reject: false });
 }
 

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -91,13 +91,17 @@ export async function startCommand({ task = "", config, logger, flags = {}, deps
 
   console.log(`${text}\n`);
   const interactive = tty() && !flags.yes;
+  let goal = task;
 
   // ASK_USER: one interactive re-route — the open answer becomes the goal.
   if (result.intent === "ASK_USER" && interactive) {
     const wizard = makeWizard();
     try {
       const answer = await wizard.input(`❓ ${result.questionToAsk || ASK_FALLBACK}`);
-      if (answer) result = await decide({ task: answer, text, config, logger, makeDecider });
+      if (answer) {
+        goal = answer;
+        result = await decide({ task: answer, text, config, logger, makeDecider });
+      }
     } finally {
       wizard.close();
     }
@@ -107,7 +111,7 @@ export async function startCommand({ task = "", config, logger, flags = {}, deps
   // Dispatch the chosen intent to its saved command, confirming first (it writes).
   const toArgs = DISPATCH[result.intent];
   if (interactive && toArgs && (await confirmApply(makeWizard))) {
-    await spawn(toArgs(task), { cwd: config.projectDir });
+    await spawn(toArgs(goal), { cwd: config.projectDir });
   }
   return { ok: true, intent: result.intent };
 }

--- a/tests/start/start-command.test.js
+++ b/tests/start/start-command.test.js
@@ -71,3 +71,57 @@ describe("startCommand (KJC-TSK-0570)", () => {
     expect(execute).toHaveBeenCalledWith({ userMessage: "add logout", assessment: "ASSESSMENT TEXT" });
   });
 });
+
+/** Interactive dispatch (PR2): TTY on, wizard + spawn injected. */
+function interactiveDeps(result, { confirm = true, answer = "" } = {}) {
+  const spawnKj = vi.fn(async () => {});
+  const wizard = { confirm: vi.fn(async () => confirm), input: vi.fn(async () => answer), close: vi.fn() };
+  return { ...deps(result), isTTY: () => true, spawnKj, makeWizard: () => wizard, _spawnKj: spawnKj, _wizard: wizard };
+}
+
+describe("startCommand dispatch (KJC-TSK-0570 PR2)", () => {
+  it("confirms and dispatches the intent to its saved command", async () => {
+    const d = interactiveDeps({ intent: "RECOMMEND_HARDEN" });
+    await startCommand({ config, logger, flags: {}, deps: d });
+    expect(d._wizard.confirm).toHaveBeenCalled();
+    expect(d._spawnKj).toHaveBeenCalledWith(["harden", "--interactive"], { cwd: "/tmp/proj" });
+  });
+
+  it("passes the task as the run argument for START_TASK", async () => {
+    const d = interactiveDeps({ intent: "START_TASK" });
+    await startCommand({ task: "add logout", config, logger, flags: {}, deps: d });
+    expect(d._spawnKj).toHaveBeenCalledWith(["run", "add logout"], { cwd: "/tmp/proj" });
+  });
+
+  it("does not dispatch when the user declines the confirmation", async () => {
+    const d = interactiveDeps({ intent: "RECOMMEND_INDEX" }, { confirm: false });
+    await startCommand({ config, logger, flags: {}, deps: d });
+    expect(d._spawnKj).not.toHaveBeenCalled();
+  });
+
+  it("re-routes ASK_USER: the open answer becomes the next decision input", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({ result: { intent: "ASK_USER", questionToAsk: "Build or fix?" } })
+      .mockResolvedValueOnce({ result: { intent: "PROPOSE_PLAN" } });
+    const wizard = { confirm: vi.fn(async () => true), input: vi.fn(async () => "modernize it"), close: vi.fn() };
+    const spawnKj = vi.fn(async () => {});
+    const d = { ...deps({}), makeDecider: () => ({ execute }), isTTY: () => true, makeWizard: () => wizard, spawnKj };
+    const r = await startCommand({ config, logger, flags: {}, deps: d });
+    expect(execute).toHaveBeenNthCalledWith(2, { userMessage: "modernize it", assessment: "ASSESSMENT TEXT" });
+    expect(r.intent).toBe("PROPOSE_PLAN");
+    expect(spawnKj).toHaveBeenCalledWith(["plan", ""], { cwd: "/tmp/proj" });
+  });
+
+  it("never dispatches without a TTY (read-only by default)", async () => {
+    const d = { ...interactiveDeps({ intent: "RECOMMEND_HARDEN" }), isTTY: () => false };
+    await startCommand({ config, logger, flags: {}, deps: d });
+    expect(d._spawnKj).not.toHaveBeenCalled();
+  });
+
+  it("--yes stays read-only even on a TTY", async () => {
+    const d = interactiveDeps({ intent: "RECOMMEND_HARDEN" });
+    await startCommand({ config, logger, flags: { yes: true }, deps: d });
+    expect(d._spawnKj).not.toHaveBeenCalled();
+  });
+});

--- a/tests/start/start-command.test.js
+++ b/tests/start/start-command.test.js
@@ -110,7 +110,7 @@ describe("startCommand dispatch (KJC-TSK-0570 PR2)", () => {
     const r = await startCommand({ config, logger, flags: {}, deps: d });
     expect(execute).toHaveBeenNthCalledWith(2, { userMessage: "modernize it", assessment: "ASSESSMENT TEXT" });
     expect(r.intent).toBe("PROPOSE_PLAN");
-    expect(spawnKj).toHaveBeenCalledWith(["plan", ""], { cwd: "/tmp/proj" });
+    expect(spawnKj).toHaveBeenCalledWith(["plan", "modernize it"], { cwd: "/tmp/proj" });
   });
 
   it("never dispatches without a TTY (read-only by default)", async () => {


### PR DESCRIPTION
## KJC-TSK-0570 PR2 (Onboard C) — `kj start` intent dispatch

Completes the final slice of the Brain epic (KJC-PCS-0061). PR1 wired the
read-only sweep → assessment → haiku decider and reported the next step. This PR
closes the loop: in **interactive mode only**, `kj start` confirms and dispatches
the chosen intent to its existing saved command.

### What it does
- `DISPATCH` table maps each writing intent to a `kj` subcommand:
  - `RECOMMEND_HARDEN` → `kj harden --interactive`
  - `RECOMMEND_INDEX` → `kj rag index`
  - `START_TASK` → `kj run "<task>"`
  - `PROPOSE_PLAN` → `kj plan "<goal>"`
- Confirms before anything that writes (`Apply this?` [Y/n]); spawns the child with
  `stdio: "inherit"` so the target command's own prompts drive the terminal.
- `ASK_USER` re-routes once: the open answer becomes the next decision input.
- **Read-only modes unchanged**: `--json`, `--yes`, and no-TTY never dispatch.

### Safety
- The decider still only emits an intent from a closed set; every destination is a
  guarded command. Phase 1 stays read-only by construction.
- Collaborators (`spawnKj`, `makeWizard`, `isTTY`) are injected so tests never spawn.

### Tests
- 40/40 green in `tests/start/`; 6 new dispatch tests (confirm, decline, task
  passthrough, ASK_USER re-route, no-TTY, `--yes`).
- Net +109 LOC (within the 200 gate). eslint + prettier clean.