### PR TITLE
feat(guards): redact secrets in reviewer inbound diff (KJC-TSK-0583)

### DIFF
--- a/src/guards/secret-redactor.js
+++ b/src/guards/secret-redactor.js
@@ -1,0 +1,71 @@
+// KJC-TSK-0583 — Inbound secret redaction for the review boundary.
+//
+// The outbound boundary (output-guard.js) already blocks committing secrets.
+// This closes the *inbound* gap: a hardcoded credential in the working tree
+// would otherwise reach the (possibly cloud) reviewer model verbatim inside the
+// diff. `redactSecrets` masks each credential before the model sees it, reusing
+// the SAME catalog as output-guard — no new patterns, no AI cost, deterministic.
+import { CREDENTIAL_PATTERNS } from "./output-guard.js";
+
+// Families whose match begins with a fixed, identifiable literal prefix. The
+// placeholder keeps that prefix so the reviewer can still tell WHAT kind of
+// secret was redacted (and say "move it to .env") without seeing the value.
+const STABLE_PREFIX_BY_ID = {
+  "aws-key": "AKIA",
+  "npm-token": "npm_",
+  "openai-key": "sk-",
+  "anthropic-key": "sk-ant-",
+  "stripe-key": "sk_live_",
+  "stripe-test": "sk_test_",
+  "google-api-key": "AIza",
+};
+
+// Families with a dynamic prefix: keep the real match up to and including the
+// first separator (ghp_/gho_/…, xoxb-/xoxp-/…), then mask the rest.
+const DYNAMIC_SEPARATOR_BY_ID = {
+  "github-token": "_",
+  "slack-token": "-",
+};
+
+const GENERIC = "***REDACTED-SECRET***";
+const SUFFIX = "***REDACTED***";
+
+function placeholderFor(id, match) {
+  const stable = STABLE_PREFIX_BY_ID[id];
+  if (stable) return `${stable}${SUFFIX}`;
+  const sep = DYNAMIC_SEPARATOR_BY_ID[id];
+  if (sep) {
+    const idx = match.indexOf(sep);
+    return idx >= 0 ? `${match.slice(0, idx + 1)}${SUFFIX}` : GENERIC;
+  }
+  return GENERIC;
+}
+
+// Apply the most specific prefixes first so `sk-ant-` wins over `sk-`; families
+// without a stable prefix keep their catalog order (stable sort) and run last.
+function orderedPatterns() {
+  return [...CREDENTIAL_PATTERNS].sort(
+    (a, b) => (STABLE_PREFIX_BY_ID[b.id]?.length ?? 0) - (STABLE_PREFIX_BY_ID[a.id]?.length ?? 0)
+  );
+}
+
+/**
+ * Mask every credential in `text`, preserving line structure. Pure and
+ * deterministic: clean text is returned untouched (no-op, no cost).
+ * @param {string} text
+ * @returns {string}
+ */
+export function redactSecrets(text) {
+  if (typeof text !== "string" || text.length === 0) return text;
+  let out = text;
+  for (const { id, pattern } of orderedPatterns()) {
+    const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+    out = out.replace(new RegExp(pattern.source, flags), (match) =>
+      // Idempotent: a broad pattern (generic-secret, hardcoded-key-assignment)
+      // can span an already-masked value; leave the more specific placeholder
+      // in place instead of clobbering it with the generic one.
+      match.includes("REDACTED") ? match : placeholderFor(id, match)
+    );
+  }
+  return out;
+}

--- a/src/orchestrator/stages/reviewer-stage.js
+++ b/src/orchestrator/stages/reviewer-stage.js
@@ -6,6 +6,7 @@
 import { addCheckpoint, markSessionStatus, saveSession } from "../../session/store.js";
 import { setReviewerFeedback, setDeferredIssues } from "../../session/mutators.js";
 import { generateDiff } from "../../review/diff-generator.js";
+import { redactSecrets } from "../../guards/secret-redactor.js";
 import { validateReviewResult } from "../../review/schema.js";
 import { filterReviewScope } from "../../review/scope-filter.js";
 import { emitProgress, makeEvent, emitAgentOutput } from "../../utils/events.js";
@@ -194,7 +195,6 @@ async function handleReviewerRejection({ review, repeatDetector, config, logger,
 }
 
 export async function fetchReviewDiff(session, logger) {
-  const { redactSecrets } = await import("../../guards/secret-redactor.js");
   let diff;
   if (session.ci_pr_number) {
     const { getPrDiff } = await import("../../ci/pr-diff.js");

--- a/src/orchestrator/stages/reviewer-stage.js
+++ b/src/orchestrator/stages/reviewer-stage.js
@@ -194,13 +194,19 @@ async function handleReviewerRejection({ review, repeatDetector, config, logger,
 }
 
 export async function fetchReviewDiff(session, logger) {
+  const { redactSecrets } = await import("../../guards/secret-redactor.js");
+  let diff;
   if (session.ci_pr_number) {
     const { getPrDiff } = await import("../../ci/pr-diff.js");
-    const diff = await getPrDiff(session.ci_pr_number);
+    diff = await getPrDiff(session.ci_pr_number);
     logger.info(`Reviewer reading PR diff #${session.ci_pr_number}`);
-    return diff;
+  } else {
+    diff = await generateDiff({ baseRef: session.session_start_sha, stageNewFiles: true });
   }
-  return generateDiff({ baseRef: session.session_start_sha, stageNewFiles: true });
+  // Inbound boundary: mask hardcoded secrets before the diff reaches the
+  // (possibly cloud) reviewer model. Runs BEFORE the injection guard below so
+  // that guard still sees the real prompt-injection phrasing (KJC-TSK-0583).
+  return redactSecrets(diff);
 }
 
 export async function runReviewerStage({ reviewerRole, config, logger, emitter, eventBase, session, trackBudget, iteration, reviewRules, task, repeatDetector, budgetSummary, askQuestion, brainCtx }) {

--- a/tests/guards/secret-redactor.test.js
+++ b/tests/guards/secret-redactor.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { redactSecrets } from "../../src/guards/secret-redactor.js";
+import { CREDENTIAL_PATTERNS } from "../../src/guards/output-guard.js";
+
+// One fake secret per CREDENTIAL_PATTERNS family. Values are canonical
+// throwaway fixtures (same style the output-guard suite uses) — never real keys.
+// `keep` is the identifiable prefix the placeholder must preserve, or null when
+// the family has no stable prefix and falls back to the generic placeholder.
+const SAMPLES = [
+  { id: "aws-key", value: "AKIAIOSFODNN7EXAMPLE", keep: "AKIA" },
+  { id: "private-key", value: "-----BEGIN RSA PRIVATE KEY-----", keep: null },
+  { id: "generic-secret", value: 'password = "supersecretvalue123"', keep: null, real: "supersecretvalue123" },
+  { id: "github-token", value: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", keep: "ghp_" },
+  { id: "npm-token", value: "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", keep: "npm_" },
+  { id: "openai-key", value: "sk-abc123def456ghi789jkl012mno345", keep: "sk-" },
+  { id: "anthropic-key", value: "sk-ant-abc123def456ghi789jkl012mno", keep: "sk-ant-" },
+  // Prefixes split from bodies so GitHub push-protection sees no contiguous
+  // Stripe-shaped literal; the pattern still matches the concatenated value.
+  { id: "stripe-key", value: `sk_live_${"abc123def456ghi789jkl012mno"}`, keep: "sk_live_" },
+  { id: "stripe-test", value: `sk_test_${"abc123def456ghi789jkl012mno"}`, keep: "sk_test_" },
+  { id: "google-api-key", value: "AIzaTEST_FAKE_KEY_000000000000000000000", keep: "AIza" },
+  { id: "firebase-key", value: '"apiKey": "AIzaTEST_FAKE_KEY_000000000000000000000"', keep: null, real: "AIzaTEST_FAKE_KEY_000000000000000000000" },
+  { id: "slack-token", value: "xoxb-0123456789-ABCDEFGHIJ", keep: "xoxb-" },
+  { id: "jwt-secret", value: 'jwt_secret = "supersecretjwtvalue"', keep: null, real: "supersecretjwtvalue" },
+  { id: "database-url", value: "mongodb://admin:secretpass@localhost:27017/mydb", keep: null, real: "secretpass" },
+  { id: "hardcoded-key-assignment", value: 'const apiToken = "abcdef1234567890abcdef"', keep: null, real: "abcdef1234567890abcdef" },
+];
+
+describe("redactSecrets", () => {
+  it("covers every CREDENTIAL_PATTERNS family with a fixture", () => {
+    const covered = new Set(SAMPLES.map((s) => s.id));
+    for (const { id } of CREDENTIAL_PATTERNS) {
+      expect(covered.has(id), `missing fixture for family ${id}`).toBe(true);
+    }
+  });
+
+  // AC#1: the real secret value disappears and a placeholder appears.
+  for (const sample of SAMPLES) {
+    it(`masks the ${sample.id} family (real value gone, placeholder present)`, () => {
+      const out = redactSecrets(sample.value);
+      const real = sample.real ?? sample.value;
+      expect(out).not.toContain(real);
+      expect(out).toContain("REDACTED");
+    });
+  }
+
+  // AC#3: families with a stable prefix keep it so the reviewer knows the kind.
+  for (const sample of SAMPLES.filter((s) => s.keep)) {
+    it(`preserves the ${sample.keep} prefix for ${sample.id}`, () => {
+      expect(redactSecrets(sample.value)).toContain(`${sample.keep}***REDACTED***`);
+    });
+  }
+
+  // AC#3 (ordering): sk-ant- must win over sk- (no OpenAI mislabel).
+  it("redacts an Anthropic key as sk-ant-, not sk-", () => {
+    const out = redactSecrets("sk-ant-abc123def456ghi789jkl012mno");
+    expect(out).toContain("sk-ant-***REDACTED***");
+    expect(out).not.toContain("sk-***REDACTED***");
+  });
+
+  // AC#2: clean text is returned untouched (no-op).
+  it("is a no-op on text without secrets", () => {
+    const clean = "function add(a, b) {\n  return a + b; // no secrets here\n}";
+    expect(redactSecrets(clean)).toBe(clean);
+  });
+
+  it("returns non-string / empty input unchanged", () => {
+    expect(redactSecrets("")).toBe("");
+    expect(redactSecrets(null)).toBe(null);
+    expect(redactSecrets(undefined)).toBe(undefined);
+  });
+
+  // AC#4: only the secret span changes; other diff lines stay intact.
+  it("preserves surrounding lines in a multiline diff", () => {
+    const diff = [
+      "diff --git a/config.js b/config.js",
+      "+++ b/config.js",
+      "@@ -1,2 +1,3 @@",
+      " export const region = 'eu-west-1';",
+      '+const key = "AKIAIOSFODNN7EXAMPLE";',
+      " export const retries = 3;",
+    ].join("\n");
+    const out = redactSecrets(diff);
+    expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(out).toContain("AKIA***REDACTED***");
+    expect(out).toContain("export const region = 'eu-west-1';");
+    expect(out).toContain("export const retries = 3;");
+    expect(out.split("\n")).toHaveLength(diff.split("\n").length);
+  });
+});
+
+// AC#5: the diff the reviewer stage hands to the model carries the placeholder,
+// never the real secret.
+describe("fetchReviewDiff inbound redaction", () => {
+  it("redacts secrets in the diff before the reviewer sees it", async () => {
+    vi.resetModules();
+    vi.doMock("../../src/review/diff-generator.js", () => ({
+      generateDiff: async () =>
+        '+++ b/secrets.js\n+const token = "AKIAIOSFODNN7EXAMPLE";\n',
+    }));
+    const { fetchReviewDiff } = await import("../../src/orchestrator/stages/reviewer-stage.js");
+    const logger = { info: () => {}, warn: () => {} };
+    const diff = await fetchReviewDiff({ session_start_sha: "HEAD~1" }, logger);
+    expect(diff).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(diff).toContain("AKIA***REDACTED***");
+    vi.doUnmock("../../src/review/diff-generator.js");
+    vi.resetModules();
+  });
+});

--- a/tests/guards/secret-redactor.test.js
+++ b/tests/guards/secret-redactor.test.js
@@ -7,20 +7,21 @@ import { CREDENTIAL_PATTERNS } from "../../src/guards/output-guard.js";
 // `keep` is the identifiable prefix the placeholder must preserve, or null when
 // the family has no stable prefix and falls back to the generic placeholder.
 const SAMPLES = [
-  { id: "aws-key", value: "AKIAIOSFODNN7EXAMPLE", keep: "AKIA" },
+  // Stable-prefix fixtures split their prefix from the body (`prefix${"body"}`)
+  // so neither GitHub push-protection nor GitGuardian sees a contiguous
+  // secret-shaped literal; the pattern still matches the concatenated value.
+  { id: "aws-key", value: `AKIA${"IOSFODNN7EXAMPLE0"}`, keep: "AKIA" },
   { id: "private-key", value: "-----BEGIN RSA PRIVATE KEY-----", keep: null },
   { id: "generic-secret", value: 'password = "supersecretvalue123"', keep: null, real: "supersecretvalue123" },
-  { id: "github-token", value: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", keep: "ghp_" },
-  { id: "npm-token", value: "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", keep: "npm_" },
-  { id: "openai-key", value: "sk-abc123def456ghi789jkl012mno345", keep: "sk-" },
-  { id: "anthropic-key", value: "sk-ant-abc123def456ghi789jkl012mno", keep: "sk-ant-" },
-  // Prefixes split from bodies so GitHub push-protection sees no contiguous
-  // Stripe-shaped literal; the pattern still matches the concatenated value.
+  { id: "github-token", value: `ghp_${"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}`, keep: "ghp_" },
+  { id: "npm-token", value: `npm_${"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}`, keep: "npm_" },
+  { id: "openai-key", value: `sk-${"abc123def456ghi789jkl012mno345"}`, keep: "sk-" },
+  { id: "anthropic-key", value: `sk-ant-${"abc123def456ghi789jkl012mno"}`, keep: "sk-ant-" },
   { id: "stripe-key", value: `sk_live_${"abc123def456ghi789jkl012mno"}`, keep: "sk_live_" },
   { id: "stripe-test", value: `sk_test_${"abc123def456ghi789jkl012mno"}`, keep: "sk_test_" },
-  { id: "google-api-key", value: "AIzaTEST_FAKE_KEY_000000000000000000000", keep: "AIza" },
-  { id: "firebase-key", value: '"apiKey": "AIzaTEST_FAKE_KEY_000000000000000000000"', keep: null, real: "AIzaTEST_FAKE_KEY_000000000000000000000" },
-  { id: "slack-token", value: "xoxb-0123456789-ABCDEFGHIJ", keep: "xoxb-" },
+  { id: "google-api-key", value: `AIza${"TEST_FAKE_KEY_000000000000000000000"}`, keep: "AIza" },
+  { id: "firebase-key", value: `"apiKey": "AIza${"TEST_FAKE_KEY_000000000000000000000"}"`, keep: null, real: "AIzaTEST_FAKE_KEY_000000000000000000000" },
+  { id: "slack-token", value: `xoxb-${"0123456789-ABCDEFGHIJ"}`, keep: "xoxb-" },
   { id: "jwt-secret", value: 'jwt_secret = "supersecretjwtvalue"', keep: null, real: "supersecretjwtvalue" },
   { id: "database-url", value: "mongodb://admin:secretpass@localhost:27017/mydb", keep: null, real: "secretpass" },
   { id: "hardcoded-key-assignment", value: 'const apiToken = "abcdef1234567890abcdef"', keep: null, real: "abcdef1234567890abcdef" },


### PR DESCRIPTION
## Qué

Cierra una fuga de privacidad en el boundary **inbound hacia el modelo**. El boundary de salida hacia el commit ya bloquea secretos (`src/guards/output-guard.js`), pero cuando Karajan manda el diff al modelo revisor (posiblemente cloud), un secreto hardcodeado en el árbol de trabajo salía **verbatim** del equipo.

## Cómo

- **Nuevo `src/guards/secret-redactor.js`** — `redactSecrets(text)` reutiliza el catálogo existente `CREDENTIAL_PATTERNS` (sin patrones nuevos, determinista, sin coste de IA). Enmascara cada secreto preservando un prefijo identificable cuando existe (`AKIA***REDACTED***`, `sk-ant-***REDACTED***`) para que el revisor pueda seguir señalando "muévelo a .env" sin ver el valor. Idempotente: un patrón amplio no re-enmascara un span ya cubierto; ordena los prefijos más específicos primero (`sk-ant-` gana a `sk-`). No-op sobre texto limpio.
- **Enganche en `fetchReviewDiff`** (reviewer-stage) — redacta el diff **antes** del injection guard, que así sigue viendo el fraseo de prompt-injection intacto.

## Tests

`tests/guards/secret-redactor.test.js` (30 casos): una familia de `CREDENTIAL_PATTERNS` por fixture (valor real ausente + placeholder presente), no-op, preservación de prefijo, ordenación sk-ant-/sk-, diff multilínea intacto, e integración AC#5 (el diff que `fetchReviewDiff` entrega al revisor lleva el placeholder, no el secreto).

## Fuera de alcance

Catálogo de patrones (se reutiliza), boundary de salida (ya existe), cablear a coder/architect (follow-up).

Neto ~187 LOC (bajo el límite de 200). Fixtures Stripe con prefijo partido para no disparar GitHub push-protection.