### PR TITLE
chore(release): v3.8.0 — kj start + inbound secret redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-07-07
+
+Minor. **`kj start`** — one entry point to the autonomous squad: the user states an intent (and at most the project's maturity) and the Brain does the rest, read-only, before proposing anything.
+
+### Added
+
+- **`kj start [intent]`** — the single door to the Brain (epic KJC-PCS-0061). The user never learns or invokes `doctor`/`check`/`harden`/`onboard`/`rag`/`qmd`; the Brain orchestrates them. A cheap AI layer **decides the WHAT** (a structured intent from a closed set) and KJ maps it to an existing saved command with **confirmation for anything that writes** — the model never runs commands on its own.
+  - **Maturity classifier** (`src/start/maturity.js`, KJC-TSK-0568): infers `new | existing | legacy` from deterministic signals (scaffolding only, real code + tests + CI, or neglected health) to shape what gets proposed; the guess is confirmed with the user, never asked cold.
+  - **Read-only sweep** (`src/start/sweep.js`, KJC-TSK-0568): runs the assessment commands without touching the user's code (init only ever writes `.karajan/`).
+  - **Deterministic synthesis + decider role** (`src/start/assessment.js`, `src/start/start-decider-role.js`, KJC-TSK-0569): condenses the sweep into a stable report and asks the decider for the next intent.
+  - **Orchestration loop + dispatch** (`src/commands/start.js`, KJC-TSK-0570): each writing intent maps to a saved command + args; degrades gracefully so `kj start` never crashes.
+- **`kj advanced` command namespace** (KJC-TSK-0582): `kj --help` is trimmed to the core commands, with the full surface indexed under `kj advanced` and guarded by a help-parity gate.
+
+### Security
+
+- **Inbound secret redaction at the review boundary** (KJC-TSK-0583): a hardcoded credential in the working tree used to reach the (possibly cloud) reviewer model verbatim inside the diff. `src/guards/secret-redactor.js` now masks every secret before the model sees it, reusing the existing `CREDENTIAL_PATTERNS` catalog (deterministic, no AI cost, no-op on clean text). It preserves an identifiable prefix (`AKIA***REDACTED***`, `sk-ant-***REDACTED***`) so the reviewer can still flag "move this to .env" without seeing the value. Closes the inbound counterpart to the existing outbound (commit) secret guard.
+
 ## [3.7.2] - 2026-06-23
 
 Patch. HU Board deep-link fix + resilient `kj audit` provider fallback.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.8.0 (minor)

Agrupa el trabajo mergeado a main desde v3.7.2. Solo bump de versión + CHANGELOG; el código ya está en main vía sus PRs.

### Highlights

- **`kj start`** — entrada única al squad autónomo (épica **KJC-PCS-0061**). El usuario expresa intención + madurez; el Brain orquesta doctor/check/harden/onboard/rag/qmd en read-only y propone el siguiente paso con una capa IA barata que **decide el QUÉ** (intent de conjunto cerrado) mapeado a comandos guardados, con confirmación para todo lo que escribe.
  - Clasificador de madurez `new | existing | legacy` (KJC-TSK-0568)
  - Sweep read-only + síntesis determinista + decider role (KJC-TSK-0568/0569)
  - Orchestration loop + dispatch intent→comando (KJC-TSK-0570)
- **`kj advanced`** namespace + `kj --help` recortado a comandos core, con gate de paridad (KJC-TSK-0582)
- **Redacción de secretos inbound** en el boundary del revisor (KJC-TSK-0583) — cierra la contraparte inbound del guard de salida

### Verificación

- `verify-pack` verde en **npm y pnpm**: `karajan-code@3.8.0` instala limpio y `kj --version` arranca en aislamiento.
- Sin emails personales ni atribución IA en el diff.

### Pendiente (manual, con el usuario)

`npm publish` requiere `npm login` + OTP del usuario. Tras publicar: tag `v3.8.0` a main, y deploy atómico de la landing (EN/ES current + nueva Phase).