### PR TITLE
feat(mutate): mutation-tool registry (KJC-TSK-0584)

### DIFF
--- a/src/mutate/tool-registry.js
+++ b/src/mutate/tool-registry.js
@@ -1,0 +1,90 @@
+/**
+ * Mutation-tool registry.
+ *
+ * Maps a detected stack language (see `src/harden/stack-roots.js`) to the
+ * mutation-testing runner Karajan drives for it. Unknown or native-mobile
+ * languages resolve to an explicit `{ supported: false, reason }` object —
+ * never a silent fallback to another tool.
+ *
+ * `scope` describes how the runner limits mutation to a subset of files, so
+ * diff-scoped runs (`kj mutate --since <ref>`) can pass only the changed paths:
+ *   - flag:      the CLI flag that accepts the file list
+ *   - separator: how multiple paths are joined for that flag
+ */
+
+const TOOLS_BY_LANGUAGE = {
+  javascript: {
+    id: "stryker",
+    binary: "stryker",
+    installHint: "npm install --save-dev @stryker-mutator/core",
+    scope: { flag: "--mutate", separator: "," },
+    reportFormat: "json",
+  },
+  typescript: {
+    id: "stryker",
+    binary: "stryker",
+    installHint: "npm install --save-dev @stryker-mutator/core",
+    scope: { flag: "--mutate", separator: "," },
+    reportFormat: "json",
+  },
+  python: {
+    id: "mutmut",
+    binary: "mutmut",
+    installHint: "pip install mutmut",
+    scope: { flag: "--paths-to-mutate", separator: "," },
+    reportFormat: "json",
+  },
+  php: {
+    id: "infection",
+    binary: "infection",
+    installHint: "composer require --dev infection/infection",
+    scope: { flag: "--filter", separator: "," },
+    reportFormat: "json",
+  },
+  go: {
+    id: "go-mutesting",
+    binary: "go-mutesting",
+    installHint: "go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest",
+    scope: { flag: "", separator: " " },
+    reportFormat: "json",
+  },
+  java: {
+    id: "pitest",
+    binary: "pitest",
+    installHint: "add org.pitest:pitest-maven (Maven) or gradle-pitest-plugin",
+    scope: { flag: "targetClasses", separator: "," },
+    reportFormat: "json",
+  },
+};
+
+const UNSUPPORTED_REASONS = {
+  swift: "Swift (iOS) has no mutation runner wired into Karajan",
+  kotlin: "Kotlin (Android) has no mutation runner wired into Karajan",
+};
+
+function normalize(language) {
+  if (typeof language !== "string") return "";
+  return language.trim().toLowerCase();
+}
+
+/**
+ * @param {string} language - language id from `detectStackRoots`
+ * @returns {{supported: true, id, binary, language, installHint, scope, reportFormat}
+ *          | {supported: false, language, reason: string}}
+ */
+export function getMutationTool(language) {
+  const key = normalize(language);
+  const tool = TOOLS_BY_LANGUAGE[key];
+  if (tool) {
+    return { supported: true, language: key, ...tool };
+  }
+  const reason =
+    UNSUPPORTED_REASONS[key] ??
+    `no mutation-testing tool is registered for language "${key || "(none)"}"`;
+  return { supported: false, language: key, reason };
+}
+
+/** @returns {string[]} languages with a registered mutation tool */
+export function listSupportedLanguages() {
+  return Object.keys(TOOLS_BY_LANGUAGE);
+}

--- a/tests/mutate/tool-registry.test.js
+++ b/tests/mutate/tool-registry.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMutationTool,
+  listSupportedLanguages,
+} from "../../src/mutate/tool-registry.js";
+
+describe("getMutationTool", () => {
+  it("maps javascript and typescript to Stryker", () => {
+    const js = getMutationTool("javascript");
+    const ts = getMutationTool("typescript");
+    expect(js.supported).toBe(true);
+    expect(js.id).toBe("stryker");
+    expect(ts.id).toBe("stryker");
+    expect(js.binary).toBe("stryker");
+  });
+
+  it("maps python to mutmut", () => {
+    const tool = getMutationTool("python");
+    expect(tool.supported).toBe(true);
+    expect(tool.id).toBe("mutmut");
+    expect(tool.installHint).toContain("mutmut");
+  });
+
+  it("maps php to Infection", () => {
+    const tool = getMutationTool("php");
+    expect(tool.supported).toBe(true);
+    expect(tool.id).toBe("infection");
+    expect(tool.installHint).toContain("infection");
+  });
+
+  it("maps go to go-mutesting", () => {
+    const tool = getMutationTool("go");
+    expect(tool.supported).toBe(true);
+    expect(tool.id).toBe("go-mutesting");
+  });
+
+  it("maps java to PIT", () => {
+    const tool = getMutationTool("java");
+    expect(tool.supported).toBe(true);
+    expect(tool.id).toBe("pitest");
+  });
+
+  it("every supported tool exposes a scope and json report format", () => {
+    for (const language of listSupportedLanguages()) {
+      const tool = getMutationTool(language);
+      expect(tool.scope).toBeTypeOf("object");
+      expect(tool.scope.flag).toBeTypeOf("string");
+      expect(tool.reportFormat).toBe("json");
+      expect(tool.installHint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns explicit unsupported for native mobile languages", () => {
+    for (const language of ["swift", "kotlin"]) {
+      const tool = getMutationTool(language);
+      expect(tool.supported).toBe(false);
+      expect(tool.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns explicit unsupported (never a silent fallback) for unknown languages", () => {
+    const tool = getMutationTool("cobol");
+    expect(tool.supported).toBe(false);
+    expect(tool.reason.length).toBeGreaterThan(0);
+  });
+
+  it("normalizes casing and whitespace", () => {
+    expect(getMutationTool("  JavaScript ").id).toBe("stryker");
+  });
+
+  it("returns unsupported for empty or non-string input", () => {
+    expect(getMutationTool("").supported).toBe(false);
+    expect(getMutationTool(null).supported).toBe(false);
+    expect(getMutationTool(undefined).supported).toBe(false);
+  });
+});


### PR DESCRIPTION
## Qué

Primera pieza de la épica de mutation testing (KJC-PCS-0063): un registro que mapea el lenguaje detectado por `detectStackRoots` al runner de mutation testing correspondiente.

| Lenguaje | Herramienta |
|----------|-------------|
| JS / TS | Stryker |
| Python | mutmut |
| PHP | Infection |
| Go | go-mutesting |
| Java | PIT |

## Decisiones

- **Sin fallback silencioso**: lenguajes desconocidos y móvil nativo (Swift/Kotlin) devuelven `{ supported: false, reason }` explícito, nunca otra herramienta por defecto.
- Cada tool lleva un `scope` (flag + separador) para que los runs diff-scoped (`kj mutate --since`) puedan pasar solo los paths cambiados. Lo consumirán M-B/M-C.
- `reportFormat: json` uniforme para el parser posterior.

## Tests

10 tests Vitest verdes (mapeos, normalización de casing/espacios, unsupported explícito, entrada vacía/no-string).

## Alcance

Solo el registro puro. Detección de diff, ejecución y parseo van en cards siguientes de la épica (M-B..M-D).

Net: 145 LOC (bajo el límite de 200).