### PR TITLE
feat(mutate): diff-scoping util (KJC-TSK-0585)

### DIFF
--- a/src/mutate/diff-scope.js
+++ b/src/mutate/diff-scope.js
@@ -1,0 +1,101 @@
+/**
+ * Diff-scoping for mutation testing. Translates a git range (`--since <ref>`)
+ * into changed source files + line ranges, then into the scope flags of the
+ * tool resolved by the registry (`src/mutate/tool-registry.js`). Mutating only
+ * what the coder just touched is what makes mutation testing cheap and useful.
+ * The git call is injectable so the pure logic is testable without a repo.
+ */
+
+import { runCommand } from "../utils/process.js";
+import { getMutationTool } from "./tool-registry.js";
+
+const SOURCE_EXTENSIONS = {
+  javascript: [".js", ".mjs", ".cjs", ".jsx"],
+  typescript: [".ts", ".tsx"],
+  python: [".py"],
+  php: [".php"],
+  go: [".go"],
+  java: [".java"],
+};
+
+const HUNK = /^@@ -\S+ \+(\d+)(?:,(\d+))?/;
+
+/**
+ * Parse `git diff --unified=0` into new-side line ranges per file. Deleted
+ * files (`+++ /dev/null`) are omitted — there is nothing to mutate.
+ * @returns {Record<string, Array<[number, number]>>}
+ */
+export function parseUnifiedDiff(diffText) {
+  const ranges = {};
+  let current = null;
+  for (const line of String(diffText || "").split("\n")) {
+    if (line.startsWith("+++ ")) {
+      const target = line.slice(4).trim();
+      current = target === "/dev/null" ? null : target.replace(/^b\//, "");
+      if (current) ranges[current] ??= [];
+      continue;
+    }
+    if (!current) continue;
+    const match = HUNK.exec(line);
+    if (!match) continue;
+    const start = Number(match[1]);
+    const count = match[2] === undefined ? 1 : Number(match[2]);
+    if (count > 0) ranges[current].push([start, start + count - 1]);
+  }
+  return ranges;
+}
+
+/** @returns {string[]} source extensions for a language ([] if unsupported) */
+export function sourceExtensions(language) {
+  return SOURCE_EXTENSIONS[language] ?? [];
+}
+
+/** Keep only files whose extension belongs to the language's source set. */
+export function filterSourceFiles(files, language) {
+  const exts = sourceExtensions(language);
+  if (exts.length === 0) return [];
+  return files.filter((file) => exts.some((ext) => file.endsWith(ext)));
+}
+
+/**
+ * Build the tool's scope arguments for the changed source files. `ranges`
+ * (per-file changed line ranges) is only consumed by Stryker (`path:start-end`).
+ * @param {{language: string, files: string[], ranges?: Record<string, Array<[number, number]>>}} params
+ */
+export function buildScope({ language, files, ranges }) {
+  const tool = getMutationTool(language);
+  if (!tool.supported) {
+    return { supported: false, reason: tool.reason, empty: true, args: [] };
+  }
+  const source = filterSourceFiles(files ?? [], language);
+  if (source.length === 0) {
+    return { supported: true, tool: tool.id, empty: true, targets: [], args: [] };
+  }
+  const targets =
+    tool.id === "stryker" && ranges
+      ? source.flatMap((file) =>
+          (ranges[file] ?? [[undefined, undefined]]).map(([start, end]) =>
+            start === undefined ? file : `${file}:${start}-${end}`,
+          ),
+        )
+      : source;
+  const value = targets.join(tool.scope.separator);
+  const args = tool.scope.flag ? [tool.scope.flag, value] : [value];
+  return { supported: true, tool: tool.id, empty: false, targets, args };
+}
+
+/**
+ * Fetch the diff for `since..toRef` and compute the mutation scope. `run` is
+ * the injectable git runner (defaults to `runCommand`).
+ * @param {{since: string, language: string, toRef?: string, run?: Function}} params
+ */
+export async function getDiffScope({ since, language, toRef = "HEAD", run = runCommand }) {
+  const result = await run("git", ["diff", "--unified=0", `${since}..${toRef}`]).catch(
+    () => null,
+  );
+  if (!result || result.exitCode !== 0) {
+    return { supported: true, empty: true, targets: [], args: [] };
+  }
+  const ranges = parseUnifiedDiff(result.stdout);
+  return buildScope({ language, files: Object.keys(ranges), ranges });
+}

--- a/tests/mutate/diff-scope.test.js
+++ b/tests/mutate/diff-scope.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScope,
+  filterSourceFiles,
+  getDiffScope,
+  parseUnifiedDiff,
+} from "../../src/mutate/diff-scope.js";
+
+// Only `+++ ` and `@@ ` lines drive the parser; other diff noise is elided.
+const SAMPLE_DIFF = [
+  "+++ b/src/foo.js",
+  "@@ -10,0 +11,3 @@", // multi-line hunk -> [11,13]
+  "@@ -40,2 +44 @@", // count omitted -> [44,44]
+  "+++ b/README.md",
+  "@@ -1 +1,2 @@",
+  "+++ /dev/null", // deleted file: everything after is skipped
+  "@@ -1,3 +0,0 @@",
+].join("\n");
+
+describe("parseUnifiedDiff", () => {
+  it("extracts new-side ranges per file and skips deleted files", () => {
+    const parsed = parseUnifiedDiff(SAMPLE_DIFF);
+    expect(parsed["src/foo.js"]).toEqual([[11, 13], [44, 44]]);
+    expect(parsed["README.md"]).toEqual([[1, 2]]);
+    expect(parsed["src/gone.js"]).toBeUndefined();
+  });
+
+  it("returns empty object for empty input", () => {
+    expect(parseUnifiedDiff("")).toEqual({});
+  });
+});
+
+describe("filterSourceFiles", () => {
+  it("keeps only files matching the language extensions", () => {
+    const files = ["src/a.js", "src/b.ts", "README.md", "src/c.py"];
+    expect(filterSourceFiles(files, "javascript")).toEqual(["src/a.js"]);
+    expect(filterSourceFiles(files, "python")).toEqual(["src/c.py"]);
+    expect(filterSourceFiles(["a.swift"], "swift")).toEqual([]);
+  });
+});
+
+describe("buildScope", () => {
+  it("appends line ranges to Stryker targets", () => {
+    const scope = buildScope({
+      language: "javascript",
+      files: ["src/foo.js"],
+      ranges: { "src/foo.js": [[11, 13], [44, 44]] },
+    });
+    expect(scope.tool).toBe("stryker");
+    expect(scope.args).toEqual(["--mutate", "src/foo.js:11-13,src/foo.js:44-44"]);
+  });
+
+  it("uses plain paths for tools without line-range scoping (php)", () => {
+    const scope = buildScope({
+      language: "php",
+      files: ["src/A.php", "src/B.php"],
+    });
+    expect(scope.args).toEqual(["--filter", "src/A.php,src/B.php"]);
+  });
+
+  it("returns empty scope when no supported source files changed", () => {
+    const scope = buildScope({ language: "javascript", files: ["README.md"] });
+    expect(scope.empty).toBe(true);
+    expect(scope.args).toEqual([]);
+  });
+
+  it("surfaces unsupported languages explicitly (no silent fallback)", () => {
+    const scope = buildScope({ language: "swift", files: ["App.swift"] });
+    expect(scope.supported).toBe(false);
+    expect(scope.reason.length).toBeGreaterThan(0);
+    expect(scope.args).toEqual([]);
+  });
+});
+
+describe("getDiffScope", () => {
+  it("computes scope from an injected git runner", async () => {
+    const run = async () => ({ exitCode: 0, stdout: SAMPLE_DIFF });
+    const scope = await getDiffScope({ since: "HEAD~1", language: "javascript", run });
+    expect(scope.tool).toBe("stryker");
+    expect(scope.targets).toEqual(["src/foo.js:11-13", "src/foo.js:44-44"]);
+  });
+
+  it("returns empty scope when git diff fails", async () => {
+    const run = async () => ({ exitCode: 128, stdout: "" });
+    const scope = await getDiffScope({ since: "bad", language: "javascript", run });
+    expect(scope.empty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Qué

Segunda pieza de la épica de mutation testing (KJC-PCS-0063). Traduce un rango git (`--since <ref>`) a los ficheros y líneas que el coder acaba de tocar, y de ahí a los flags de scope de la herramienta (registro de M-A).

## API (`src/mutate/diff-scope.js`)

- `parseUnifiedDiff(diff)` → rangos de línea del lado nuevo por fichero (ignora borrados `+++ /dev/null`).
- `filterSourceFiles(files, language)` → solo ficheros de código del lenguaje.
- `buildScope({language, files, ranges})` → `{ tool, targets, args }`. Stryker recibe `path:ini-fin`; el resto, paths.
- `getDiffScope({since, language, run})` → orquesta git + scope; runner git inyectable.

## Decisiones

- **Mutar solo el diff** es lo que hace barato y de alta señal el mutation testing (no toda la base).
- Diff sin ficheros de código soportados → scope vacío (`empty: true`), para que `kj mutate` informe "nada que mutar" sin ejecutar la herramienta.
- Lenguaje no soportado → `{ supported: false, reason }` explícito, sin fallback.

## Tests

9 tests Vitest verdes (parseo de hunks, filtrado, scope stryker con rangos / php sin rangos / vacío / unsupported, runner git inyectado y fallo de git).

Net: 189 LOC (bajo el límite de 200). Bloqueaba a M-D (comando CLI).