### PR TITLE
feat(mutate): add runner + report normalizer (KJC-TSK-0586)

### DIFF
--- a/src/mutate/runner.js
+++ b/src/mutate/runner.js
@@ -1,0 +1,72 @@
+/**
+ * Mutation runner + report normalizer. Executes a mutation tool and parses its
+ * report (the shared mutation-testing-report-schema, `files[].mutants[]`) into a
+ * tool-agnostic result the CLI, reviewer and CI can all consume the same way.
+ * `exec` and `readReport` are injectable so the logic is testable without a
+ * real mutation tool installed.
+ */
+
+import { runCommand } from "../utils/process.js";
+
+// A mutant the test suite detected (killed or forced to time out).
+const KILLED = new Set(["Killed", "Timeout"]);
+// A real survivor: the mutation went undetected (or no test covered it).
+const SURVIVED = new Set(["Survived", "NoCoverage"]);
+// Not a real result: equivalent, config-ignored, or uncompilable mutants.
+const EXCLUDED = new Set(["Ignored", "CompileError", "RuntimeError"]);
+
+/**
+ * Normalize a standard-schema report into `{score, killed, survived, total, excluded}`.
+ * `score` is the covered mutation score `killed / (killed + survived) * 100`, or
+ * null when there is nothing to mutate. Excluded mutants never count as survivors.
+ * @param {{files?: Record<string, {mutants?: Array<object>}>}} report
+ */
+export function parseStandardReport(report) {
+  const files = report?.files ?? {};
+  let killed = 0;
+  let excluded = 0;
+  const survived = [];
+  for (const [file, entry] of Object.entries(files)) {
+    for (const mutant of entry?.mutants ?? []) {
+      const { status } = mutant;
+      if (EXCLUDED.has(status)) {
+        excluded += 1;
+      } else if (KILLED.has(status)) {
+        killed += 1;
+      } else if (SURVIVED.has(status)) {
+        survived.push({
+          file,
+          line: mutant.location?.start?.line ?? null,
+          mutator: mutant.mutatorName ?? null,
+          status,
+        });
+      }
+    }
+  }
+  const total = killed + survived.length;
+  const score = total === 0 ? null : Number(((killed / total) * 100).toFixed(2));
+  return { score, killed, survived, total, excluded };
+}
+
+/**
+ * Run a mutation tool and normalize the report it produced.
+ * @param {object} params
+ * @param {string} params.binary
+ * @param {string[]} [params.args]
+ * @param {string} [params.cwd]
+ * @param {Function} [params.exec] - injectable command runner (default runCommand)
+ * @param {() => Promise<object>} [params.readReport] - reads/parses the tool's report file
+ */
+export async function runMutation({ binary, args = [], cwd, exec = runCommand, readReport }) {
+  const run = await exec(binary, args, { cwd }).catch((err) => ({
+    exitCode: 1,
+    stdout: "",
+    stderr: String(err?.message ?? err),
+  }));
+  let result = null;
+  if (readReport) {
+    const report = await readReport().catch(() => null);
+    if (report) result = parseStandardReport(report);
+  }
+  return { exitCode: run.exitCode, result, stdout: run.stdout, stderr: run.stderr };
+}

--- a/tests/mutate/runner.test.js
+++ b/tests/mutate/runner.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { parseStandardReport, runMutation } from "../../src/mutate/runner.js";
+
+const REPORT = {
+  files: {
+    "src/foo.js": {
+      mutants: [
+        { status: "Killed", location: { start: { line: 3 } } },
+        { status: "Timeout", location: { start: { line: 5 } } },
+        {
+          status: "Survived",
+          mutatorName: "ArithmeticOperator",
+          location: { start: { line: 8 } },
+        },
+        { status: "Ignored", location: { start: { line: 9 } } },
+      ],
+    },
+    "src/bar.js": {
+      mutants: [{ status: "NoCoverage", location: { start: { line: 2 } } }],
+    },
+  },
+};
+
+describe("parseStandardReport", () => {
+  it("normalizes a mixed report to score/killed/survived/total", () => {
+    const result = parseStandardReport(REPORT);
+    expect(result.killed).toBe(2); // Killed + Timeout
+    expect(result.total).toBe(4); // 2 killed + 2 survived
+    expect(result.excluded).toBe(1); // Ignored
+    expect(result.score).toBe(50);
+  });
+
+  it("carries file, line and mutator for each survivor (incl. NoCoverage)", () => {
+    const { survived } = parseStandardReport(REPORT);
+    expect(survived).toEqual([
+      { file: "src/foo.js", line: 8, mutator: "ArithmeticOperator", status: "Survived" },
+      { file: "src/bar.js", line: 2, mutator: null, status: "NoCoverage" },
+    ]);
+  });
+
+  it("does not count ignored/equivalent mutants as survivors", () => {
+    const report = { files: { a: { mutants: [{ status: "Ignored" }] } } };
+    const result = parseStandardReport(report);
+    expect(result.survived).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+
+  it("returns null score when there is nothing to mutate", () => {
+    expect(parseStandardReport({ files: {} }).score).toBeNull();
+    expect(parseStandardReport(null).score).toBeNull();
+  });
+});
+
+describe("runMutation", () => {
+  it("executes the binary and parses the report it produced", async () => {
+    const calls = [];
+    const exec = async (binary, args) => {
+      calls.push({ binary, args });
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const readReport = async () => REPORT;
+    const out = await runMutation({
+      binary: "stryker",
+      args: ["run", "--mutate", "src/foo.js"],
+      exec,
+      readReport,
+    });
+    expect(calls[0].binary).toBe("stryker");
+    expect(out.exitCode).toBe(0);
+    expect(out.result.score).toBe(50);
+  });
+
+  it("returns a null result when the report cannot be read", async () => {
+    const exec = async () => ({ exitCode: 0 });
+    const readReport = async () => {
+      throw new Error("no report");
+    };
+    const out = await runMutation({ binary: "mutmut", exec, readReport });
+    expect(out.result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Qué

Tercera pieza (M-C) de la épica de mutation testing (KJC-PCS-0063): el **ejecutor** de la herramienta de mutación y el **normalizador de informe**.

- `parseStandardReport(report)` — convierte el informe del esquema compartido (`files[].mutants[]`) en un resultado agnóstico de herramienta: `{score, killed, survived, total, excluded}`.
  - `killed` = `Killed` + `Timeout`.
  - `survived` = `Survived` + `NoCoverage`, cada uno con `{file, line, mutator, status}`.
  - `excluded` = `Ignored` + `CompileError` + `RuntimeError` (mutantes equivalentes/no compilables); **nunca** cuentan como supervivientes.
  - `score` = `killed / (killed + survived) * 100`, o `null` cuando no hay nada que mutar.
- `runMutation({binary, args, cwd, exec, readReport})` — ejecuta la herramienta y normaliza el informe. `exec` y `readReport` son inyectables, así que la lógica se testea sin herramienta real instalada.

## Por qué

El CLI (M-D), el reviewer (M-E) y el job de CI (M-F) consumen todos el mismo resultado normalizado. Aislar aquí el parseo mantiene esas piezas triviales y las herramientas por stack (Stryker/mutmut/Infection/…) intercambiables.

## Tests

6/6 Vitest verdes (`tests/mutate/runner.test.js`): informe mixto, supervivientes con línea/mutator (incl. `NoCoverage`), exclusión de equivalentes, `score` null sin mutantes, ejecución+parseo end-to-end, y resultado `null` cuando el informe no se puede leer.