### PR TITLE
feat(mutate): add kj mutate diff-scoped CLI command (KJC-TSK-0587)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -30,7 +30,7 @@ export const ADVANCED_GROUPS = [
   { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "scan"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
-  { title: "Calidad / auditoría", commands: ["audit", "check", "webperf", "sonar"] },
+  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "undo", "standby"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -16,6 +16,7 @@ import { undoCommand } from "../commands/undo.js";
 import { syncCommand } from "../commands/sync.js";
 import { cleanCommand } from "../commands/clean.js";
 import { checkCommand } from "../commands/check.js";
+import { mutateCommand } from "../commands/mutate.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
@@ -453,6 +454,26 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       const code = await withConfig(pkgVersion, "check", flags, async ({ logger }) =>
         checkCommand({ profile: flags.profile, json: Boolean(flags.json), logger })
+      );
+      if (Number.isInteger(code)) process.exit(code);
+    });
+
+  program
+    .command("mutate")
+    .description("Diff-scoped mutation testing (¿cazan tus tests los mutantes de tu cambio?)")
+    .argument("[path]", "Target explícito a mutar (omite el diff)")
+    .option("--since <ref>", "Ref git contra la que sacar el diff", "HEAD~1")
+    .option("--max-survivors <n>", "Supervivientes tolerados antes de exit 1", "0")
+    .option("--json", "Emitir el resultado normalizado como JSON")
+    .action(async (pathArg, flags) => {
+      const code = await withConfig(pkgVersion, "mutate", flags, async ({ logger }) =>
+        mutateCommand({
+          path: pathArg,
+          since: flags.since,
+          maxSurvivors: Number(flags.maxSurvivors),
+          json: Boolean(flags.json),
+          logger,
+        })
       );
       if (Number.isInteger(code)) process.exit(code);
     });

--- a/src/commands/mutate.js
+++ b/src/commands/mutate.js
@@ -1,0 +1,94 @@
+/**
+ * `kj mutate` (KJC-TSK-0587) — diff-scoped mutation testing. Detects language
+ * (M-A registry) → changed lines (M-B diff-scope) → runs the tool (M-C runner)
+ * only over what you just touched. `--json` + exit code make it a gate. No
+ * silent fallback: unsupported language / unreadable report exit non-zero.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { detectProjectStack } from "../utils/stack-detect.js";
+import { getMutationTool } from "../mutate/tool-registry.js";
+import { getDiffScope } from "../mutate/diff-scope.js";
+import { runMutation } from "../mutate/runner.js";
+
+// Per-tool launch detail: subcommand + JSON report path. Tools without a JSON
+// report leave `report` empty → the run surfaces the tool's own output.
+const INVOCATION = {
+  stryker: { base: ["run"], report: "reports/mutation/mutation.json" },
+  mutmut: { base: ["run"], report: "mutmut-report.json" },
+  infection: { base: [], report: "infection.json" },
+  "go-mutesting": { base: [], report: "" },
+  pitest: { base: [], report: "" },
+};
+
+const DEFAULT_SINCE = "HEAD~1";
+
+function makeReadReport(reportFile) {
+  if (!reportFile) return undefined;
+  return async () => JSON.parse(await fs.readFile(reportFile, "utf8"));
+}
+
+/**
+ * `deps` ({detectStack, diffScope, run}) is injectable so tests stay pure.
+ * `since` diffs against a git ref (default HEAD~1); `path` bypasses the diff.
+ * @returns {Promise<number>} process exit code
+ */
+export async function mutateCommand({
+  projectDir = process.cwd(),
+  since,
+  path: pathArg,
+  json = false,
+  maxSurvivors = 0,
+  logger = console,
+  deps = {},
+} = {}) {
+  const detectStack = deps.detectStack ?? detectProjectStack;
+  const diffScope = deps.diffScope ?? getDiffScope;
+  const run = deps.run ?? runMutation;
+  const say = (msg) => logger.info?.(msg);
+
+  const { language } = await detectStack(projectDir);
+  const tool = getMutationTool(language);
+  if (!tool.supported) {
+    say(`kj mutate: lenguaje no soportado (${language ?? "desconocido"}) — ${tool.reason}`);
+    return 2;
+  }
+
+  let scope;
+  if (pathArg) {
+    const args = tool.scope.flag ? [tool.scope.flag, pathArg] : [pathArg];
+    scope = { supported: true, empty: false, args };
+  } else {
+    scope = await diffScope({ since: since ?? DEFAULT_SINCE, language, projectDir });
+  }
+  if (scope.empty) {
+    say("kj mutate: nada que mutar en el diff.");
+    return 0;
+  }
+
+  const invocation = INVOCATION[tool.id] ?? { base: [], report: "" };
+  const reportFile = invocation.report ? path.join(projectDir, invocation.report) : "";
+  const outcome = await run({
+    binary: tool.binary,
+    args: [...invocation.base, ...scope.args],
+    cwd: projectDir,
+    readReport: makeReadReport(reportFile),
+  });
+
+  if (!outcome.result) {
+    say(`kj mutate: la herramienta ${tool.id} no produjo un informe legible.`);
+    if (outcome.stderr) say(outcome.stderr.trim());
+    return 1;
+  }
+
+  const { score, killed, total, survived } = outcome.result;
+  if (json) {
+    say(JSON.stringify(outcome.result));
+  } else {
+    say(`kj mutate (${tool.id}): score ${score ?? "n/a"}% — ${killed}/${total} mutantes cazados`);
+    for (const s of survived) say(`  ✗ superviviente ${s.file}:${s.line} (${s.mutator ?? s.status})`);
+    if (survived.length === 0) say("  ✓ sin supervivientes");
+  }
+  return survived.length > maxSurvivors ? 1 : 0;
+}

--- a/tests/mutate/mutate.test.js
+++ b/tests/mutate/mutate.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { mutateCommand } from "../../src/commands/mutate.js";
+
+const line = () => {
+  const out = [];
+  return { logger: { info: (m) => out.push(m) }, out };
+};
+
+// Run results as returned by runMutation/M-C (survivor-carrying vs clean).
+const base = { exitCode: 0, stdout: "", stderr: "" };
+const survivor = { file: "src/foo.js", line: 8, mutator: "Arithmetic", status: "Survived" };
+const withSurvivor = { ...base, result: { score: 50, killed: 1, total: 2, excluded: 0, survived: [survivor] } };
+const clean = { ...base, result: { score: 100, killed: 2, total: 2, excluded: 0, survived: [] } };
+
+const deps = (over = {}) => ({
+  detectStack: async () => ({ language: "javascript" }),
+  diffScope: async () => ({ supported: true, empty: false, tool: "stryker", targets: ["src/foo.js"], args: ["--mutate", "src/foo.js"] }),
+  run: async () => withSurvivor,
+  ...over,
+});
+
+describe("mutateCommand", () => {
+  it("reports unsupported languages explicitly (no silent fallback)", async () => {
+    const { logger, out } = line();
+    const code = await mutateCommand({ logger, deps: deps({ detectStack: async () => ({ language: "swift" }) }) });
+    expect(code).toBe(2);
+    expect(out.join("\n")).toMatch(/swift/i);
+  });
+
+  it("exits 0 with nothing to mutate when the scope is empty", async () => {
+    const { logger, out } = line();
+    const code = await mutateCommand({ logger, deps: deps({ diffScope: async () => ({ supported: true, empty: true, args: [] }) }) });
+    expect(code).toBe(0);
+    expect(out.join("\n")).toMatch(/nada que mutar/i);
+  });
+
+  it("exits 1 and lists survivors as file:line above the threshold", async () => {
+    const { logger, out } = line();
+    const code = await mutateCommand({ logger, deps: deps() });
+    expect(code).toBe(1);
+    expect(out.join("\n")).toContain("src/foo.js:8");
+  });
+
+  it("exits 0 when survivors are within the threshold", async () => {
+    const code = await mutateCommand({ logger: line().logger, maxSurvivors: 1, deps: deps() });
+    expect(code).toBe(0);
+  });
+
+  it("exits 0 on a clean run", async () => {
+    const code = await mutateCommand({ logger: line().logger, deps: deps({ run: async () => clean }) });
+    expect(code).toBe(0);
+  });
+
+  it("emits normalized JSON with --json", async () => {
+    const { logger, out } = line();
+    const code = await mutateCommand({ logger, json: true, deps: deps() });
+    expect(code).toBe(1);
+    expect(JSON.parse(out[0]).survived[0].file).toBe("src/foo.js");
+  });
+
+  it("passes an explicit path straight to the tool, bypassing the diff", async () => {
+    const calls = [];
+    const code = await mutateCommand({
+      logger: line().logger,
+      path: "src/pkg",
+      deps: deps({ run: async (opts) => (calls.push(opts), clean) }),
+    });
+    expect(code).toBe(0);
+    expect(calls[0].args).toEqual(["run", "--mutate", "src/pkg"]);
+  });
+
+  it("exits 1 and surfaces stderr when the tool produced no report", async () => {
+    const { logger, out } = line();
+    const code = await mutateCommand({
+      logger,
+      deps: deps({ run: async () => ({ exitCode: 1, stdout: "", stderr: "stryker not found", result: null }) }),
+    });
+    expect(code).toBe(1);
+    expect(out.join("\n")).toMatch(/stryker not found/);
+  });
+});


### PR DESCRIPTION
## Qué

Cuarta pieza (M-D) de la épica de mutation testing (KJC-PCS-0063) y **cierre del MVP**: el comando `kj mutate`, que orquesta las piezas ya mergeadas.

- Detecta el lenguaje del repo (`detectProjectStack`) → resuelve la herramienta (M-A `getMutationTool`) → calcula el scope del **diff** (M-B `getDiffScope`, por defecto `HEAD~1`) o de un `path` explícito → ejecuta (M-C `runMutation`) → imprime **score + supervivientes** como `fichero:línea`.
- `--since <ref>`: ref git contra la que sacar el diff.
- `[path]`: target explícito, omite el diff.
- `--json`: emite el resultado normalizado.
- `--max-survivors <n>` (default **0**): supervivientes tolerados antes de `exit 1`.
- Registrado en `kj advanced` → grupo *Calidad / auditoría*.

### Exit codes (usable como gate)
- `0` — sin supervivientes por encima del umbral, o nada que mutar en el diff.
- `1` — supervivientes por encima del umbral, o la herramienta no produjo un informe legible (se muestra su `stderr`).
- `2` — lenguaje no soportado (mensaje explícito, **sin fallback silencioso**).

## Por qué

Es el 80/20: mutar solo lo que acabas de tocar responde "¿mis tests nuevos cazan los mutantes de mi cambio?" en segundos, en el día a día. La lógica pura queda testeable con dependencias inyectables; el único requisito en runtime es tener la herramienta del stack instalada.

## Decisión de producto (por defecto, ajustable)

El umbral por defecto es **0 supervivientes** (`--max-survivors 0`): en código recién cambiado, cualquier mutante superviviente es señal. Se relaja con `--max-survivors <n>`. Un umbral por *mutation score* se puede añadir después si hace falta.

## Tests

8/8 Vitest (`tests/mutate/mutate.test.js`): lenguaje no soportado (exit 2), scope vacío (exit 0), supervivientes sobre umbral (exit 1, `fichero:línea`), dentro de umbral (exit 0), run limpio, `--json`, modo `path` (bypass del diff), e informe ilegible (exit 1 + stderr). Paridad de `kj advanced` verde.