### PR TITLE
feat(mutate): reviewer opt-in mutation signal (KJC-TSK-0588)

### DIFF
--- a/src/mutate/reviewer-signal.js
+++ b/src/mutate/reviewer-signal.js
@@ -1,0 +1,76 @@
+/**
+ * Reviewer opt-in mutation signal (KJC-TSK-0588). OFF by default: only when
+ * `KJ_REVIEW_MUTATION` is set does the reviewer run `kj mutate` scoped to the
+ * diff and fold surviving mutants into its verdict as a weak-test signal.
+ * A null return means "add nothing" → the default-off prompt stays identical.
+ */
+
+import { mutateCommand } from "../commands/mutate.js";
+
+const DEFAULT_SINCE = "HEAD~1";
+const ENABLED = /^(1|true|yes|on)$/i;
+
+/** True when the reviewer mutation opt-in is switched on via env. */
+export function isMutationReviewEnabled(env = process.env) {
+  return ENABLED.test(String(env?.KJ_REVIEW_MUTATION ?? "").trim());
+}
+
+// Drives `kj mutate --json` over the diff, capturing its output instead of
+// printing it, and returns {code, result} where result is the normalized JSON.
+async function defaultRun({ since, projectDir }) {
+  const lines = [];
+  const code = await mutateCommand({
+    since,
+    projectDir,
+    json: true,
+    maxSurvivors: Number.POSITIVE_INFINITY,
+    logger: { info: (m) => lines.push(String(m)) },
+  });
+  const jsonLine = [...lines].reverse().find((l) => l.trim().startsWith("{"));
+  return { code, result: jsonLine ? JSON.parse(jsonLine) : null };
+}
+
+function unavailableNote() {
+  return [
+    "## Mutation testing (advisory)",
+    "Mutation testing was requested but could not run on this diff (unsupported",
+    "stack or tool unavailable). Treat it as unavailable — do not infer test",
+    "quality from its absence.",
+  ].join("\n");
+}
+
+function survivorSection(survivors) {
+  const lines = survivors.map((s) => `- ${s.file}:${s.line ?? "?"} (${s.mutator ?? s.status})`);
+  return [
+    "## Mutation testing (advisory signal)",
+    "The following mutants survived over the changed lines — the tests did not",
+    "catch these deliberate defects, so the covering tests are weak. Weigh this",
+    "as a signal about test quality, not as a hard blocker on its own:",
+    ...lines,
+  ].join("\n");
+}
+
+/**
+ * Build the reviewer's mutation-signal prompt section, or null to add nothing.
+ * `run` ({since, projectDir}) → {code, result} is injectable for tests.
+ * @returns {Promise<string|null>}
+ */
+export async function buildReviewerMutationSignal({
+  enabled,
+  since = DEFAULT_SINCE,
+  projectDir = process.cwd(),
+  run = defaultRun,
+} = {}) {
+  if (!enabled) return null;
+  let outcome;
+  try {
+    outcome = await run({ since, projectDir });
+  } catch {
+    return unavailableNote();
+  }
+  const { code, result } = outcome ?? {};
+  if (code === 1 || code === 2) return unavailableNote();
+  const survivors = result?.survived ?? [];
+  if (survivors.length === 0) return null;
+  return survivorSection(survivors);
+}

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -2,6 +2,7 @@ import { AgentRole } from "./agent-role.js";
 import { buildRtkInstructions } from "../prompts/rtk-snippet.js";
 import { extractFirstJson } from "../utils/json-extract.js";
 import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "../prompts/prompt-layout.js";
+import { isMutationReviewEnabled, buildReviewerMutationSignal } from "../mutate/reviewer-signal.js";
 
 const MAX_DIFF_LENGTH = 12000;
 
@@ -38,6 +39,11 @@ export class ReviewerRole extends AgentRole {
   // on every review — last. The buckets ride along so ClaudeAgent can
   // ship the stable block via --append-system-prompt (Φ1-D).
   async buildPrompt({ task, diff, reviewRules }) {
+    // Opt-in (KJ_REVIEW_MUTATION): null when off/clean → prompt stays identical.
+    const mutationSignal = await buildReviewerMutationSignal({
+      enabled: isMutationReviewEnabled(),
+      projectDir: this.config?.projectDir,
+    });
     const layout = buildPromptLayout([
       section(SUBAGENT_PREAMBLE, STABLE),
       section(this.instructions, STABLE),
@@ -51,6 +57,7 @@ export class ReviewerRole extends AgentRole {
       section(reviewRules ? `Review rules:\n${reviewRules}` : null, STABLE),
       section(`Task context:\n${task}`, VOLATILE),
       section(`Git diff:\n${truncateDiff(diff)}`, VOLATILE),
+      section(mutationSignal, VOLATILE),
     ]);
     return { prompt: joinLayout(layout), stablePrompt: layout.stable, volatilePrompt: layout.volatile };
   }

--- a/tests/mutate/reviewer-signal.test.js
+++ b/tests/mutate/reviewer-signal.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isMutationReviewEnabled, buildReviewerMutationSignal } from "../../src/mutate/reviewer-signal.js";
+
+const withSurvivors = { code: 0, result: { score: 50, killed: 1, total: 2, survived: [{ file: "src/foo.js", line: 8, mutator: "Arithmetic", status: "Survived" }] } };
+const clean = { code: 0, result: { score: 100, killed: 2, total: 2, survived: [] } };
+
+describe("isMutationReviewEnabled", () => {
+  it("is off by default (no env var)", () => {
+    expect(isMutationReviewEnabled({})).toBe(false);
+  });
+
+  it("accepts the usual truthy spellings", () => {
+    for (const v of ["1", "true", "TRUE", "yes", "on"]) {
+      expect(isMutationReviewEnabled({ KJ_REVIEW_MUTATION: v })).toBe(true);
+    }
+  });
+
+  it("rejects anything else", () => {
+    for (const v of ["0", "false", "off", "no", "", "maybe"]) {
+      expect(isMutationReviewEnabled({ KJ_REVIEW_MUTATION: v })).toBe(false);
+    }
+  });
+});
+
+describe("buildReviewerMutationSignal", () => {
+  it("returns null when disabled (default off → byte-identical prompt)", async () => {
+    const run = async () => withSurvivors;
+    expect(await buildReviewerMutationSignal({ enabled: false, run })).toBeNull();
+  });
+
+  it("returns null on a clean run (nothing to flag)", async () => {
+    const run = async () => clean;
+    expect(await buildReviewerMutationSignal({ enabled: true, run })).toBeNull();
+  });
+
+  it("returns null when there is nothing to mutate", async () => {
+    const run = async () => ({ code: 0, result: null });
+    expect(await buildReviewerMutationSignal({ enabled: true, run })).toBeNull();
+  });
+
+  it("lists survivors as file:line when there are undetected mutants", async () => {
+    const run = async () => withSurvivors;
+    const signal = await buildReviewerMutationSignal({ enabled: true, run });
+    expect(signal).toContain("src/foo.js:8");
+    expect(signal).toMatch(/mutation/i);
+  });
+
+  it("notes unavailability on an unsupported language (exit 2) — no silent drop", async () => {
+    const run = async () => ({ code: 2, result: null });
+    const signal = await buildReviewerMutationSignal({ enabled: true, run });
+    expect(signal).toMatch(/unavailable|could not/i);
+  });
+
+  it("notes unavailability when the tool produced no report (exit 1)", async () => {
+    const run = async () => ({ code: 1, result: null });
+    const signal = await buildReviewerMutationSignal({ enabled: true, run });
+    expect(signal).toMatch(/unavailable|could not/i);
+  });
+
+  it("notes unavailability when the run throws", async () => {
+    const run = async () => { throw new Error("boom"); };
+    const signal = await buildReviewerMutationSignal({ enabled: true, run });
+    expect(signal).toMatch(/unavailable|could not/i);
+  });
+});


### PR DESCRIPTION
## Qué

M-E de la épica de mutation testing (KJC-PCS-0063). El reviewer puede, **opt-in**, correr `kj mutate` sobre el diff y usar los mutantes supervivientes como señal de tests débiles.

- **Default OFF** vía env `KJ_REVIEW_MUTATION` (`1|true|yes|on`). Con el flag apagado el prompt del reviewer es **byte-idéntico** al actual → coste cero en runs normales.
- Con el flag encendido: `kj mutate --json` scoped al diff (reusa M-D, sin refactor), y los supervivientes se añaden como sección advisory del prompt (señal, no bloqueo duro).
- **Sin fallback silencioso**: stack no soportado (exit 2) o herramienta no disponible (exit 1) → nota explícita de 'unavailable'.

## Cómo

- `src/mutate/reviewer-signal.js`: `isMutationReviewEnabled(env)` + `buildReviewerMutationSignal({enabled, since, projectDir, run})` (helper puro, `run` inyectable).
- `src/roles/reviewer-role.js`: sección VOLATILE tras el diff; null cuando off/clean → dropped.

## Tests

- `tests/mutate/reviewer-signal.test.js` (10) + reviewer-role sin regresión. 54/54 verde.

Net ~148 LOC (dentro del shrink-budget).