### PR TITLE
feat(harden): opt-in nightly mutation CI workflow (KJC-TSK-0589)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -422,6 +422,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-config", "Skip lint/format/commit config files (hooks only)")
     .option("--no-ci", "Skip CI quality workflows")
     .option("--no-guidelines", "Skip AI-agent guideline files (AGENTS.md/CLAUDE.md)")
+    .option("--mutation", "Also seed an opt-in nightly/manual mutation CI job (never a PR gate)")
     .option("--only <dirs...>", "Harden only these language roots (e.g. frontend backend)")
     .option("--exclude <globs...>", "Skip language roots matching these globs (e.g. wrappers)")
     .option("--report", "Read-only: show what kj would add/improve, change nothing")
@@ -435,6 +436,7 @@ export function registerMeta(program, { pkgVersion }) {
           config: flags.config !== false,
           ci: flags.ci !== false,
           guidelines: flags.guidelines !== false,
+          mutation: Boolean(flags.mutation),
           only: flags.only ?? [],
           exclude: flags.exclude ?? [],
           report: Boolean(flags.report),

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -76,6 +76,7 @@ export async function hardenCommand({
   config = true,
   ci = true,
   guidelines = true,
+  mutation = false,
   dryRun = false,
   json = false,
   report = false,
@@ -134,7 +135,7 @@ export async function hardenCommand({
   const cfg = withConfig ? installConfigsForRoots({ projectDir, roots, dryRun }) : null;
   const withCi = ci && profile !== "minimal";
   const wf = withCi
-    ? installWorkflows({ projectDir, language: roots[0]?.language ?? null, profile, dryRun })
+    ? installWorkflows({ projectDir, language: roots[0]?.language ?? null, profile, mutation, dryRun })
     : null;
   const withGuidelines = guidelines && profile !== "minimal";
   const gl = withGuidelines ? installGuidelines({ projectDir, dryRun }) : null;

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -10,7 +10,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
-import { extraWorkflowsFor, qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
+import { extraWorkflowsFor, mutationWorkflowFor, qualityWorkflowFor, WORKFLOWS } from "./workflow-templates.js";
 
 const BLOCK_VERSION = 1;
 const WORKFLOWS_DIR = join(".github", "workflows");
@@ -31,12 +31,14 @@ export function installWorkflows({
   projectDir = process.cwd(),
   language = null,
   profile = "standard",
+  mutation = false,
   dryRun = false,
 } = {}) {
   const dir = join(projectDir, WORKFLOWS_DIR);
   const quality = qualityWorkflowFor(language);
   const extras = extraWorkflowsFor({ profile, publishable: isPublishableNpm(projectDir) });
-  const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras];
+  const mut = mutation ? mutationWorkflowFor(language) : null;
+  const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras, ...(mut ? [mut] : [])];
   const results = [];
   for (const wf of all) {
     const target = join(dir, wf.file);

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -147,6 +147,58 @@ export const PACK_SMOKE_WORKFLOW = [
   '          echo "Tarball installs clean: $tgz"',
 ].join("\n");
 
+// Opt-in nightly/manual mutation audit (KJC-TSK-0589). NEVER a PR gate: it runs
+// on a weekly schedule + manual dispatch, and the mutate step is non-blocking
+// (continue-on-error) so a red run never nags. Only stacks whose `kj mutate`
+// yields a JSON report (stryker/mutmut/infection) get a workflow — no silent
+// scaffold for tools that can't report yet.
+const MUTATION_TOOLCHAIN = {
+  javascript: ["      - run: npm ci"],
+  python: [
+    "      - uses: actions/setup-python@v5",
+    "        with:",
+    "          python-version: '3.12'",
+    "      - run: pip install mutmut pytest",
+  ],
+  php: [
+    "      - uses: shivammathur/setup-php@v2",
+    "        with:",
+    "          php-version: '8.3'",
+    "      - run: composer install --no-interaction --no-progress",
+  ],
+};
+MUTATION_TOOLCHAIN.typescript = MUTATION_TOOLCHAIN.javascript;
+
+/** Opt-in mutation workflow entry, or null for a stack without a JSON report. */
+export function mutationWorkflowFor(language) {
+  const toolchain = MUTATION_TOOLCHAIN[language];
+  if (!toolchain) return null;
+  const body = [
+    "name: Mutation (nightly)",
+    "on:",
+    "  schedule:",
+    "    - cron: '0 4 * * 1'",
+    "  workflow_dispatch:",
+    "permissions:",
+    "  contents: read",
+    "jobs:",
+    "  mutation:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          fetch-depth: 0",
+    "      - uses: actions/setup-node@v4",
+    "        with:",
+    "          node-version: 22",
+    ...toolchain,
+    "      - name: Mutation testing (advisory, never blocks a PR)",
+    "        continue-on-error: true",
+    "        run: npx --yes --package karajan-code kj mutate --since HEAD~1",
+  ].join("\n");
+  return { file: "kj-mutation.yml", blockId: "wf-mutation", body };
+}
+
 /** Conditional workflows: shrink-budget on strict, pack-smoke when publishable. */
 export function extraWorkflowsFor({ profile = "standard", publishable = false } = {}) {
   const extras = [];

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -106,4 +106,35 @@ describe("installWorkflows", () => {
     expect(res.workflows.map((w) => w.file)).not.toContain(join(".github", "workflows", "kj-pack-smoke.yml"));
     rmSync(priv, { recursive: true, force: true });
   });
+
+  const mutFile = join(".github", "workflows", "kj-mutation.yml");
+
+  it("omits the mutation workflow unless it is opted into", () => {
+    const res = installWorkflows({ projectDir: dir, language: "javascript" });
+    expect(res.workflows.map((w) => w.file)).not.toContain(mutFile);
+  });
+
+  it("seeds a nightly/manual, non-blocking mutation workflow when opted in", () => {
+    const res = installWorkflows({ projectDir: dir, language: "javascript", mutation: true });
+    expect(res.workflows.map((w) => w.file)).toContain(mutFile);
+    const parsed = yaml.load(read(mutFile));
+    // Never a PR gate: only schedule + manual dispatch.
+    expect(parsed.on.schedule).toBeTruthy();
+    expect(parsed.on).toHaveProperty("workflow_dispatch");
+    expect(parsed.on).not.toHaveProperty("pull_request");
+    const step = parsed.jobs.mutation.steps.find((s) => s["continue-on-error"]);
+    expect(step["continue-on-error"]).toBe(true);
+    expect(read(mutFile)).toContain("kj mutate");
+  });
+
+  it("omits the mutation workflow for a stack without a JSON report (go)", () => {
+    const res = installWorkflows({ projectDir: dir, language: "go", mutation: true });
+    expect(res.workflows.map((w) => w.file)).not.toContain(mutFile);
+  });
+
+  it("mutation workflow is idempotent", () => {
+    installWorkflows({ projectDir: dir, language: "python", mutation: true });
+    const res = installWorkflows({ projectDir: dir, language: "python", mutation: true });
+    expect(res.workflows.find((w) => w.file === mutFile).action).toBe("unchanged");
+  });
 });


### PR DESCRIPTION
## Qué

`kj harden --mutation` siembra un workflow de mutation testing **opt-in**, nunca un gate de PR.

- **Schedule semanal + `workflow_dispatch`** — jamás `pull_request`, así nunca bloquea un merge.
- Step de `kj mutate --since HEAD~1` con **`continue-on-error: true`**: una corrida roja avisa, no molesta.
- Solo para stacks cuyo `kj mutate` produce un informe JSON (**js/ts/python/php**). Go/Java se omiten — nada de scaffold silencioso para herramientas que aún no reportan.
- Idempotente vía managed-markers; **off por defecto** (`--mutation` para activarlo).

Cierra la capa 3 del diseño de mutation testing (épica KJC-PCS-0063): el job de CI nightly/manual, separado del primitive `kj mutate` (M-D) y de la señal del reviewer (M-E).

## Test
- 4 tests nuevos en `tests/harden/workflow-engine.test.js` (omit sin opt-in, seed non-blocking, omit go, idempotente).
- Suite harden+mutate: 126/126 verde.
- Net LOC: +88.