### PR TITLE
ci(release): ensure GitHub Release from CHANGELOG before SEA upload (KJC-TSK-0591)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,8 +19,50 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # KJC-TSK-0591: make the SEA release self-sufficient. Pushing a `v*` tag
+  # must never leave an orphan release or depend on a human remembering to
+  # run `gh release create`. This job runs first (build `needs` it): if the
+  # release already exists (created by hand) it is a no-op; otherwise it mints
+  # the release from the CHANGELOG section for this version. Because the
+  # release is guaranteed to exist before any matrix job uploads assets, this
+  # also closes the KJC-BUG-0040 race (human create vs softprops).
+  ensure-release:
+    name: Ensure GitHub Release exists
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Ensure release from CHANGELOG
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" --json id >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists — nothing to do."
+            exit 0
+          fi
+          VERSION="${TAG#v}"
+          awk -v ver="${VERSION}" '
+            $0 ~ "^## \\[" ver "\\]" { f=1; next }
+            f && /^## \[/ { exit }
+            f { print }
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::No CHANGELOG section found for ${VERSION}. Add a '## [${VERSION}]' entry before tagging."
+            exit 1
+          fi
+          gh release create "${TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${TAG}" \
+            --notes-file release-notes.md
+          echo "Created release ${TAG} from CHANGELOG."
+
   build:
     name: Build ${{ matrix.target }}
+    needs: ensure-release
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Qué

Añade un job `ensure-release` al workflow **Release SEA Binaries** que corre **antes** de la matriz `build` (vía `needs: ensure-release`).

- **Idempotente**: si el GitHub Release ya existe (creado a mano), es un no-op.
- Si falta, lo crea a partir de la sección del `CHANGELOG.md` correspondiente al tag pusheado (`## [X.Y.Z]`).
- **Guardarail secundario**: si no hay sección en el CHANGELOG para esa versión, el job falla con un error explícito en vez de crear un release con notas vacías.

## Por qué

Pushear un tag `v*` no debe poder dejar el release huérfano ni depender de que un humano recuerde ejecutar `gh release create`. Con `needs`, el release está garantizado antes de que cualquier job de la matriz suba binarios, lo que además cierra la carrera de **KJC-BUG-0040** (creación humana vs softprops) de forma determinista.

## Verificación

- YAML válido (`jobs: [ensure-release, build]`, `build.needs: ensure-release`).
- Extracción awk probada contra el CHANGELOG real: v3.8.0 extrae la sección; una versión inexistente sale vacía (dispararía el guardarail).

Incidente que lo motiva: v3.8.0 se publicó, se pusheó el tag, pero se olvidó `gh release create` → el workflow SEA falló en las 3 plataformas esperando un release inexistente.