### PR TITLE
ci(release): smoke-test SEA binary before uploading assets

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -100,6 +100,43 @@ jobs:
         if: runner.os == 'Windows'
         run: mv dist/kj.exe dist/kj-${{ matrix.target }}.exe
 
+      # KJC-TSK-0592: never ship a binary that can't start. The SEA bundle
+      # inlines its version and stubs the native-dep commands (board/rag), so
+      # the gate mirrors verify-pack: assert the binary boots, its version
+      # matches the tag, and the command tree resolves. This catches the
+      # broken-bundle class (ERR_MODULE_NOT_FOUND) that shipped v3.4.1.
+      - name: Smoke-test binary (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN="dist/kj-${{ matrix.target }}"
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          GOT="$("./${BIN}" --version)"
+          if [ "${GOT}" != "${EXPECTED}" ]; then
+            echo "::error::version mismatch: got '${GOT}', expected '${EXPECTED}'"
+            exit 1
+          fi
+          "./${BIN}" --help >/dev/null
+          "./${BIN}" init --help >/dev/null
+          echo "Smoke OK: ${BIN} reports ${GOT} and the command tree resolves."
+
+      - name: Smoke-test binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bin = "dist\kj-${{ matrix.target }}.exe"
+          $expected = $env:GITHUB_REF_NAME.TrimStart("v")
+          $got = (& ".\$bin" --version).Trim()
+          if ($got -ne $expected) {
+            Write-Error "version mismatch: got '$got', expected '$expected'"
+            exit 1
+          }
+          & ".\$bin" --help | Out-Null
+          & ".\$bin" init --help | Out-Null
+          Write-Host "Smoke OK: $bin reports $got and the command tree resolves."
+
       - name: Generate SHA256 checksum (Linux/macOS)
         if: runner.os != 'Windows'
         run: shasum -a 256 dist/kj-${{ matrix.target }} > dist/kj-${{ matrix.target }}.sha256


### PR DESCRIPTION
## KJC-TSK-0592 — Gate SEA smoke-test antes del release

Añade un paso de smoke-test en el job `build` de `release-binaries.yml`, justo tras renombrar el binario y antes de generar el checksum. Se ejecuta en las 3 plataformas (Linux/macOS bash, Windows pwsh).

### Qué valida
El binario SEA inlinea su versión al bundlear y stubbea los comandos con deps nativas (board/rag), así que el gate refleja la filosofía de `verify-pack` para el canal binario:

1. `kj --version` == tag (`${GITHUB_REF_NAME#v}`) — falla el job si no coincide.
2. `kj --help` sale 0 — el árbol de comandos resuelve.
3. `kj init --help` sale 0 — un subcomando resuelve.

### Por qué
Atrapa la clase de fallo de bundle roto (`ERR_MODULE_NOT_FOUND`) que dejó salir el binario de v3.4.1 sin arrancar. Ningún binario que no arranque puede ya subirse como asset del release.

Net: +37 LOC (workflow YAML).