### PR TITLE
feat(install): Node-free binary installer for Unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,13 @@ curl -L https://github.com/manufosela/karajan-code/releases/latest/download/kj-l
 curl -L https://github.com/manufosela/karajan-code/releases/latest/download/kj-win-x64.exe -o kj.exe
 ```
 
-**One-liner** (detects OS, installs via npm):
+**One-liner, binary** (no Node — detects OS/arch, verifies the checksum, installs to `~/.local/bin`):
+```bash
+curl -fsSL https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts/install-binary.sh | sh
+```
+Pin a version or install dir with env vars: `KJ_VERSION=v3.7.2 KJ_INSTALL_DIR=/usr/local/bin`.
+
+**One-liner, npm** (detects OS, installs via npm — needs Node ≥ 18):
 ```bash
 curl -fsSL https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts/install-kj.sh | sh
 ```

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Karajan Code — standalone binary installer (no Node required).
+#
+#   curl -fsSL https://karajancode.com/install.sh | sh
+#
+# Downloads the prebuilt `kj` binary for your OS/arch from the GitHub
+# release, verifies its SHA256 checksum, and installs it to ~/.local/bin.
+# Override with env vars: KJ_VERSION (e.g. v3.7.2), KJ_INSTALL_DIR.
+#
+# POSIX sh only — no bashisms, no Node. KJC-TSK-0593.
+set -eu
+
+REPO="manufosela/karajan-code"
+VERSION="${KJ_VERSION:-latest}"
+INSTALL_DIR="${KJ_INSTALL_DIR:-$HOME/.local/bin}"
+
+die() {
+  echo "kj-install: $1" >&2
+  exit 1
+}
+
+# --- Detect OS/arch, map to the release asset names we actually build. ---
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+  Linux) os="linux" ;;
+  Darwin) os="darwin" ;;
+  *) die "unsupported OS '$os'. Supported: Linux, macOS. Use npm instead: npm install -g karajan-code" ;;
+esac
+case "$arch" in
+  x86_64 | amd64) arch="x64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *) die "unsupported architecture '$arch'" ;;
+esac
+
+target="${os}-${arch}"
+case "$target" in
+  linux-x64 | darwin-arm64) ;;
+  *) die "no prebuilt binary for '$target'. Available: linux-x64, darwin-arm64. Use npm instead: npm install -g karajan-code" ;;
+esac
+
+# --- Resolve the download URL for the requested version (or latest). ---
+asset="kj-${target}"
+if [ "$VERSION" = "latest" ]; then
+  base="https://github.com/${REPO}/releases/latest/download"
+else
+  base="https://github.com/${REPO}/releases/download/${VERSION}"
+fi
+
+# --- Pick a downloader. ---
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -qO "$2" "$1"; }
+else
+  die "need curl or wget to download the binary"
+fi
+
+# --- Pick a checksum tool. ---
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+  die "need sha256sum or shasum to verify the download"
+fi
+
+# --- Download to a temp dir; only install after the checksum matches. ---
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/kj-install.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "kj-install: downloading ${asset} (${VERSION})..."
+fetch "${base}/${asset}" "${tmp}/kj" || die "could not download ${base}/${asset} — does that version/asset exist?"
+fetch "${base}/${asset}.sha256" "${tmp}/kj.sha256" || die "could not download the checksum for ${asset}"
+
+expected="$(cut -d' ' -f1 <"${tmp}/kj.sha256")"
+actual="$(sha256 "${tmp}/kj")"
+[ "$expected" = "$actual" ] || die "checksum mismatch (expected ${expected}, got ${actual}). Aborting, nothing installed."
+
+# --- Install atomically: chmod on the temp file, then move into place. ---
+chmod +x "${tmp}/kj"
+mkdir -p "$INSTALL_DIR"
+mv -f "${tmp}/kj" "${INSTALL_DIR}/kj"
+
+installed="$("${INSTALL_DIR}/kj" --version 2>/dev/null || echo '?')"
+echo "kj-install: installed kj ${installed} to ${INSTALL_DIR}/kj"
+
+# --- Tell the user how to reach it if the dir is not on PATH. ---
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) echo "kj-install: '${INSTALL_DIR}' is on your PATH — run 'kj --help' to get started." ;;
+  *)
+    echo "kj-install: '${INSTALL_DIR}' is not on your PATH. Add it with:"
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo "  (add that line to ~/.bashrc, ~/.zshrc or ~/.profile to make it permanent)"
+    ;;
+esac


### PR DESCRIPTION
## KJC-TSK-0593 — Install script Unix (curl | sh)

Nuevo `scripts/install-binary.sh`: instala el binario standalone `kj` sin Node, sin npm, sin compilar.

### Qué hace
1. Detecta OS/arch (`uname`) y lo mapea a los assets que realmente compilamos: `linux-x64`, `darwin-arm64`.
2. Descarga el binario del release (versión de `KJ_VERSION` o `latest`) con curl o wget.
3. Descarga el `.sha256` y **verifica el checksum** antes de instalar nada.
4. `chmod +x` + instala en `~/.local/bin/kj` (override con `KJ_INSTALL_DIR`).
5. Si el dir no está en el PATH, imprime la línea exacta para añadirlo.

### Robustez
- POSIX `sh` puro, sin bashisms.
- Arch/OS no soportado → error claro apuntando a npm, **no instala un binario equivocado**.
- Descarga a un tmp dir con `trap` de limpieza; solo mueve al destino **tras** validar el checksum → nunca deja una instalación a medias.

README documenta el one-liner binario (y mantiene el one-liner npm existente). Net: +96 LOC (script; README excluido del budget).