### PR TITLE
feat(update-check): tailor the update notice to the install channel

### DIFF
--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isSea } from "node:sea";
 import { getKarajanHome } from "./paths.js";
 
 const CACHE_FILE = "update-check.json";
@@ -29,16 +30,14 @@ export function updateInstruction({ channel, platform = process.platform }) {
 }
 
 /**
- * Detect how this kj was installed: "sea" (standalone binary), "npm"
- * (global install / source tree), or "unknown" if it can't be told for sure.
+ * Detect how this kj was installed: "sea" (standalone binary) or "npm"
+ * (global install / source tree). Falls back to "npm" if isSea() throws.
  */
-export async function detectInstallChannel() {
+export function detectInstallChannel() {
   try {
-    const sea = await import("node:sea");
-    if (typeof sea.isSea !== "function") return "unknown";
-    return sea.isSea() ? "sea" : "npm";
+    return isSea() ? "sea" : "npm";
   } catch {
-    // node:sea absent ⇒ this cannot be a SEA binary ⇒ npm / source tree.
+    // isSea() unexpectedly threw ⇒ treat as npm / source tree, never block.
     return "npm";
   }
 }
@@ -98,7 +97,7 @@ export async function checkForUpdate(currentVersion) {
 export async function printUpdateNotice(currentVersion) {
   const result = await checkForUpdate(currentVersion);
   if (result?.updateAvailable) {
-    const channel = await detectInstallChannel();
+    const channel = detectInstallChannel();
     console.log(`\n  Update available: v${result.current} → v${result.latest}`);
     console.log(`  ${updateInstruction({ channel })}\n`);
   }

--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -6,6 +6,43 @@ const CACHE_FILE = "update-check.json";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const PACKAGE_NAME = "karajan-code";
 
+const RAW_BASE = "https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts";
+export const INSTALL_SH_URL = `${RAW_BASE}/install-binary.sh`;
+export const INSTALL_PS1_URL = `${RAW_BASE}/install-binary.ps1`;
+
+/**
+ * Build the "how to update" line for the detected install channel.
+ * Pure and testable — no I/O.
+ * @param {{channel: "sea"|"npm"|"unknown", platform?: string}} opts
+ */
+export function updateInstruction({ channel, platform = process.platform }) {
+  if (channel === "sea") {
+    return platform === "win32"
+      ? `Re-run the installer: irm ${INSTALL_PS1_URL} | iex`
+      : `Re-run the installer: curl -fsSL ${INSTALL_SH_URL} | sh`;
+  }
+  if (channel === "npm") {
+    return `Run: npm install -g ${PACKAGE_NAME}`;
+  }
+  // Channel unknown — offer both paths, never silently pick a wrong one.
+  return `Update: npm install -g ${PACKAGE_NAME}  (or re-run the binary installer — see README)`;
+}
+
+/**
+ * Detect how this kj was installed: "sea" (standalone binary), "npm"
+ * (global install / source tree), or "unknown" if it can't be told for sure.
+ */
+export async function detectInstallChannel() {
+  try {
+    const sea = await import("node:sea");
+    if (typeof sea.isSea !== "function") return "unknown";
+    return sea.isSea() ? "sea" : "npm";
+  } catch {
+    // node:sea absent ⇒ this cannot be a SEA binary ⇒ npm / source tree.
+    return "npm";
+  }
+}
+
 /**
  * Check npm for a newer version. Non-blocking, cached for 24h.
  * Returns { updateAvailable, latest, current } or null if check fails/cached.
@@ -61,8 +98,9 @@ export async function checkForUpdate(currentVersion) {
 export async function printUpdateNotice(currentVersion) {
   const result = await checkForUpdate(currentVersion);
   if (result?.updateAvailable) {
+    const channel = await detectInstallChannel();
     console.log(`\n  Update available: v${result.current} → v${result.latest}`);
-    console.log(`  Run: npm install -g ${PACKAGE_NAME}\n`);
+    console.log(`  ${updateInstruction({ channel })}\n`);
   }
 }
 

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { checkForUpdate } from "../src/utils/update-check.js";
+import {
+  checkForUpdate,
+  updateInstruction,
+  INSTALL_SH_URL,
+  INSTALL_PS1_URL,
+} from "../src/utils/update-check.js";
 import fs from "node:fs/promises";
 
 vi.mock("node:fs/promises", () => ({
@@ -98,5 +103,29 @@ describe("update-check", () => {
     const written = JSON.parse(fs.writeFile.mock.calls[0][1]);
     expect(written.latest).toBe("1.39.0");
     expect(written.checkedAt).toBeGreaterThan(0);
+  });
+});
+
+describe("updateInstruction", () => {
+  it("points npm installs at npm install -g", () => {
+    expect(updateInstruction({ channel: "npm" })).toBe("Run: npm install -g karajan-code");
+  });
+
+  it("points SEA binaries on Unix at the shell installer, not npm", () => {
+    const msg = updateInstruction({ channel: "sea", platform: "linux" });
+    expect(msg).toContain(INSTALL_SH_URL);
+    expect(msg).not.toContain("npm install");
+  });
+
+  it("points SEA binaries on Windows at the PowerShell installer", () => {
+    const msg = updateInstruction({ channel: "sea", platform: "win32" });
+    expect(msg).toContain(INSTALL_PS1_URL);
+    expect(msg).toContain("iex");
+  });
+
+  it("offers both paths when the channel is unknown", () => {
+    const msg = updateInstruction({ channel: "unknown" });
+    expect(msg).toContain("npm install -g karajan-code");
+    expect(msg).toContain("binary installer");
   });
 });


### PR DESCRIPTION
## What

The startup "update available" notice always told the user to run `npm install -g karajan-code`. For someone running the standalone SEA binary that command does nothing useful — it does not update the binary they are actually running.

This detects the install channel and prints the right command:

- **SEA binary** → re-run the matching installer (`curl … install-binary.sh | sh` on Unix, `irm … install-binary.ps1 | iex` on Windows).
- **npm / source** → `npm install -g karajan-code`.
- **unknown** → offer both paths, never silently pick a wrong one.

## How

- `detectInstallChannel()` uses `node:sea`'s `isSea()` (dynamic import, try/catch). Absent module ⇒ not a SEA binary ⇒ npm/source.
- `updateInstruction({ channel, platform })` is a pure, testable function that builds the line; `printUpdateNotice` wires it in.

## Tests

Added 4 unit tests covering npm, SEA on Unix, SEA on Windows, and the unknown channel. `vitest run tests/update-check.test.js` → 12 passed.

Closes KJC-TSK-0595.