### PR TITLE
feat(install): unblock the binary on install and document the manual bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ Pin a version or install dir with env vars: `KJ_VERSION=v3.7.2 KJ_INSTALL_DIR=/u
 irm https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts/install-binary.ps1 | iex
 ```
 
+> **If your OS blocks the binary.** The macOS build is ad-hoc signed and the
+> Windows build is unsigned — neither carries a paid certificate, so a manually
+> downloaded binary may be blocked on first run. The install scripts above clear
+> the flag for you. If you download the binary by hand instead:
+> - **macOS** — Gatekeeper says the binary "cannot be opened": `xattr -d com.apple.quarantine ./kj`, or Control-click the file → **Open**.
+> - **Windows** — SmartScreen shows "Windows protected your PC": click **More info → Run anyway**, or run `Unblock-File .\kj.exe`.
+>
+> Paid notarization (Apple) and Authenticode signing (Windows) are optional and
+> not enabled by default — this is a deliberate cost decision, not an oversight.
+
 **One-liner, npm** (detects OS, installs via npm — needs Node ≥ 18):
 ```bash
 curl -fsSL https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts/install-kj.sh | sh

--- a/scripts/install-binary.ps1
+++ b/scripts/install-binary.ps1
@@ -57,6 +57,11 @@ try {
   $dest = Join-Path $installDir "kj.exe"
   Move-Item -Path $binTmp -Destination $dest -Force
 
+  # The download carries a "mark of the web" (Zone.Identifier) that makes
+  # SmartScreen warn on first run. The binary is not code-signed with a paid
+  # certificate, so clear the mark on the copy we just verified ourselves.
+  Unblock-File -Path $dest -ErrorAction SilentlyContinue
+
   $installed = (& $dest --version) 2>$null
   Write-Host "kj-install: installed kj $installed to $dest"
 

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -82,6 +82,13 @@ chmod +x "${tmp}/kj"
 mkdir -p "$INSTALL_DIR"
 mv -f "${tmp}/kj" "${INSTALL_DIR}/kj"
 
+# On macOS the binary is ad-hoc signed, not notarized with a paid Apple
+# certificate, so Gatekeeper can quarantine it. Clear the flag on the copy
+# we just checksummed ourselves (no-op on Linux / if the flag is absent).
+if [ "$os" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "${INSTALL_DIR}/kj" 2>/dev/null || true
+fi
+
 installed="$("${INSTALL_DIR}/kj" --version 2>/dev/null || echo '?')"
 echo "kj-install: installed kj ${installed} to ${INSTALL_DIR}/kj"
 


### PR DESCRIPTION
## What

Closes the code-signing card for the executable distribution (KJC-TSK-0596).

The macOS build is ad-hoc signed and the Windows build is unsigned. Paid notarization (Apple, 99 USD/year) and Authenticode signing (Windows) are a deliberate cost decision — off by default, not an oversight. Without them, Gatekeeper and SmartScreen can block a freshly downloaded binary on first run.

## How

- **install-binary.sh** — on macOS, `xattr -d com.apple.quarantine` on the installed binary (no-op on Linux or if the flag is absent).
- **install-binary.ps1** — `Unblock-File` on the installed `kj.exe` to strip the mark-of-the-web that `Invoke-WebRequest` attaches, so SmartScreen does not warn on the copy we just verified.
- **README** — a short "If your OS blocks the binary" note covering the manual bypass (`xattr` / Control-click → Open on macOS; *More info → Run anyway* / `Unblock-File` on Windows) and stating the signing posture plainly.

Both installers only clear the flag on a binary whose SHA256 they already verified, so this does not weaken the checksum guarantee.

## Acceptance criteria

- macOS binary ad-hoc signed + quarantine bypass documented and auto-applied; paid notarization left optional. ✅
- Windows binary: no paid cert → SmartScreen bypass documented and mark-of-the-web cleared on install. ✅
- Paid signing not approved → binaries ship without it, bypass documented, other distribution work unblocked. ✅