### PR TITLE
chore(release): v3.9.0 — standalone binary distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-07-11
+
+Minor. **Distribution as a standalone executable** — install `kj` on a machine with no Node at all, with the release pipeline hardened so a broken binary can never ship (epic KJC-PCS-0006).
+
+### Added
+
+- **Node-free binary installer for Unix** (KJC-TSK-0593): `curl -fsSL https://karajancode.com/install.sh | sh` downloads the prebuilt `kj` for your OS/arch (linux-x64, darwin-arm64), verifies its SHA256 before installing, and drops it in `~/.local/bin` (POSIX `sh`, no bashisms). `KJ_VERSION` / `KJ_INSTALL_DIR` override the defaults.
+- **Node-free binary installer for Windows** (KJC-TSK-0594): `irm https://karajancode.com/install.ps1 | iex` does the same for `kj-win-x64.exe`, verifies the checksum, installs to `%LOCALAPPDATA%\Karajan`, and adds it to the user PATH idempotently (re-running updates in place without duplicating entries).
+- **Channel-aware update notice** (KJC-TSK-0595): the "update available" banner now detects whether `kj` runs as a standalone binary (`node:sea`) or from npm and prints the matching command — re-run the installer for binaries, `npm install -g` for npm — instead of always suggesting npm.
+
+### Changed
+
+- **Binaries clear the OS block on install** (KJC-TSK-0596): the macOS build is ad-hoc signed and the Windows build unsigned (paid notarization/Authenticode remain a deliberate opt-in cost, off by default). The installers now strip the quarantine flag (`xattr` on macOS) and the mark-of-the-web (`Unblock-File` on Windows) on the copy they just checksummed, and the README documents the manual bypass for hand-downloaded binaries.
+
+### CI
+
+- **GitHub Release created from the CHANGELOG before the SEA upload** (KJC-TSK-0591): the `v*` tag triggers the binary build, but the upload needs the Release to already exist — the workflow now creates it from the matching CHANGELOG section first, closing the post-publish "run failed" gap.
+- **SEA binary smoke-tested before its assets are uploaded** (KJC-TSK-0592): each built binary must boot (`--version` / `--help`) before it reaches the Release, so a broken executable is caught in CI rather than by the first user to download it.
+
 ## [3.8.0] - 2026-07-07
 
 Minor. **`kj start`** — one entry point to the autonomous squad: the user states an intent (and at most the project's maturity) and the Brain does the rest, read-only, before proposing anything.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ brew install manufosela/tap/karajan-code
 
 > **Installing with pnpm?** pnpm blocks dependency build scripts by default, so `better-sqlite3`'s native addon won't compile on install and DB-backed commands (`board`, `rag`, cost tracking) will fail. After installing, run `pnpm approve-builds better-sqlite3` — or just use npm. `kj doctor` flags this if it happens.
 
+> **On a bare Linux box, install `curl` first.** The binary and script installers
+> below download with `curl` (or `wget`). macOS already ships `curl` and Windows
+> PowerShell has `irm` built in, but a minimal server or container image often has
+> neither — install it with your package manager, then run the one-liner:
+> - **Debian/Ubuntu**: `sudo apt update && sudo apt install -y curl`
+> - **Fedora/RHEL/CentOS**: `sudo dnf install -y curl`
+> - **Arch**: `sudo pacman -S --noconfirm curl`
+> - **Alpine**: `sudo apk add curl`
+> - **openSUSE**: `sudo zypper install -y curl`
+
 **Standalone binary** (no Node.js needed):
 ```bash
 # macOS (Apple Silicon)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.9.0 (minor)

Ships the executable-distribution work (epic **KJC-PCS-0006**) that landed on `main` above the published `v3.8.0` tag.

### Included cards
- **KJC-TSK-0591** (#1143) — CI: create the GitHub Release from the CHANGELOG before the SEA upload.
- **KJC-TSK-0592** (#1144) — CI: smoke-test each SEA binary before uploading its assets.
- **KJC-TSK-0593** (#1145) — Node-free Unix installer (`curl -fsSL … | sh`).
- **KJC-TSK-0594** (#1146) — Node-free Windows installer (`irm … | iex`).
- **KJC-TSK-0595** (#1147) — channel-aware update notice (SEA binary vs npm).
- **KJC-TSK-0596** (#1148) — installers clear the OS block (Gatekeeper/SmartScreen) + documented manual bypass.

### This PR
- `CHANGELOG.md`: new `3.9.0` section.
- `package.json`: `3.8.0` → `3.9.0`.

`verify-pack` green locally (npm + pnpm) against the `3.9.0` tarball.