### PR TITLE
fix(install): degrade to npm on macOS while darwin binary is unavailable

### DIFF
--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -35,8 +35,18 @@ esac
 
 target="${os}-${arch}"
 case "$target" in
-  linux-x64 | darwin-arm64) ;;
-  *) die "no prebuilt binary for '$target'. Available: linux-x64, darwin-arm64. Use npm instead: npm install -g karajan-code" ;;
+  linux-x64) ;;
+  darwin-arm64)
+    # The macOS standalone binary is not published yet (tracked in
+    # KJC-BUG-0096: the darwin-arm64 SEA build crashes under smoke-test).
+    # Degrade gracefully to the npm install path instead of trying to
+    # download an asset that does not exist.
+    echo "kj-install: the macOS standalone binary is not available yet." >&2
+    echo "kj-install: install with npm instead (requires Node 18+):" >&2
+    echo "  npm install -g karajan-code" >&2
+    exit 0
+    ;;
+  *) die "no prebuilt binary for '$target'. Available: linux-x64. On macOS use npm instead: npm install -g karajan-code" ;;
 esac
 
 # --- Resolve the download URL for the requested version (or latest). ---


### PR DESCRIPTION
## Qué

El instalador de binarios (`scripts/install-binary.sh`) listaba `darwin-arm64` como target descargable, pero el binario SEA de macOS **no está publicado todavía** (KJC-BUG-0096: el build darwin-arm64 crashea bajo el gate de smoke-test). Al ejecutarlo en un Mac, el script intentaba descargar un asset inexistente y fallaba con un error de red confuso.

## Cambio

- `darwin-arm64` ahora degrada de forma limpia: imprime que el binario standalone de macOS aún no está disponible e indica la vía npm (`npm install -g karajan-code`), saliendo con código 0.
- `linux-x64` sin cambios (sigue descargando + verificando checksum).
- Mensaje de arquitectura no soportada actualizado (macOS → npm).

## Verificación

- `sh -n` OK (POSIX sh válido).
- Simulación de la rama darwin-arm64: degrada a npm sin intentar descarga.

KJC-TSK-0598