### PR TITLE
feat(installer): guide binary users to kj doctor for prerequisites

### DIFF
--- a/scripts/install-binary.ps1
+++ b/scripts/install-binary.ps1
@@ -77,6 +77,13 @@ try {
   } else {
     Write-Host "kj-install: '$installDir' is already on your user PATH — run 'kj --help' to get started."
   }
+
+  # The binary bundles no toolchain. kj orchestrates external tools, so name
+  # the hard requirements and let `kj doctor` check them for this machine.
+  Write-Host ""
+  Write-Host "kj-install: next step — run 'kj doctor' to check prerequisites."
+  Write-Host "  Required: git, plus at least one agent CLI (Claude Code, Codex or Gemini)."
+  Write-Host "  Optional: Docker (local models, SonarQube) and Node/npm (helper tools: Squeezr, qmd)."
 } finally {
   Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -111,3 +111,11 @@ case ":${PATH}:" in
     echo "  (add that line to ~/.bashrc, ~/.zshrc or ~/.profile to make it permanent)"
     ;;
 esac
+
+# --- Prerequisites: the binary bundles no toolchain. kj orchestrates ---
+# --- external tools, so name the hard requirements and let `kj doctor` ---
+# --- check them precisely for this machine.
+echo ""
+echo "kj-install: next step — run 'kj doctor' to check prerequisites."
+echo "  Required: git, plus at least one agent CLI (Claude Code, Codex or Gemini)."
+echo "  Optional: Docker (local models, SonarQube) and Node/npm (helper tools: Squeezr, qmd)."

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -160,6 +160,28 @@ function statusIcon(status) {
   }
 }
 
+// The `kj` binary bundles no toolchain: it orchestrates external tools. So
+// beyond the per-check wall, spell out what is *required* to run kj at all
+// (git + at least one agent CLI) versus what is *optional* (enables extra
+// features). We derive the verdict from the checks already collected rather
+// than re-probing, so it always agrees with the lines printed above.
+function printPrerequisites(report) {
+  const git = report.checks.find((c) => c.name === "git");
+  const agents = report.checks.filter((c) => c.name?.startsWith("agent:"));
+  const okAgent = agents.find((c) => c.status === STATUS.OK);
+  const mark = (ok) => (ok ? "OK" : "MISSING");
+
+  const gitOk = git?.status === STATUS.OK;
+  const agentLabel = okAgent
+    ? `OK (${okAgent.label.replace(/^Agent:\s*/, "")})`
+    : "MISSING — install Claude Code, Codex or Gemini";
+
+  console.log();
+  console.log("Prerequisites (kj orchestrates external tools, it bundles none):");
+  console.log(`  Required: git ${mark(gitOk)}; agent CLI ${agentLabel}`);
+  console.log("  Optional: Docker (local models, SonarQube); Node/npm (helper tools: Squeezr, qmd)");
+}
+
 function printHuman(report, { verbose }) {
   for (const check of report.checks) {
     console.log(`${statusIcon(check.status)} ${check.label}: ${check.detail}`);
@@ -186,6 +208,8 @@ function printHuman(report, { verbose }) {
     console.log(`Runtime overrides applied: ${JSON.stringify(report.overrides)}`);
   }
 
+  printPrerequisites(report);
+
   // KJC-TSK v2.18 — if any external audit tool (semgrep, osv-scanner,
   // lighthouse) reported missing, surface the one-line remediation so
   // the user doesn't have to dig the fix lines out of the wall of
@@ -202,4 +226,4 @@ function printHuman(report, { verbose }) {
   }
 }
 
-export const __test = { printHuman };
+export const __test = { printHuman, printPrerequisites };

--- a/tests/doctor-prerequisites.test.js
+++ b/tests/doctor-prerequisites.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { STATUS, STRATEGY } from "../src/checks/types.js";
+import { __test } from "../src/commands/doctor.js";
+
+// KJC-TSK-0599 — the binary bundles no toolchain, so `kj doctor` prints a
+// Prerequisites block that separates what is required to run kj at all
+// (git + at least one agent CLI) from what is optional. The verdict is
+// derived from the checks already collected, not re-probed.
+
+const { printPrerequisites } = __test;
+
+function makeReport(checks) {
+  return { checks, overrides: {}, summary: {}, totalMs: 1 };
+}
+
+let logs;
+
+beforeEach(() => {
+  logs = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => { logs.push(args.join(" ")); });
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("printPrerequisites", () => {
+  it("marks required OK when git and at least one agent are present", () => {
+    printPrerequisites(makeReport([
+      { name: "git", label: "git", status: STATUS.OK, strategy: STRATEGY.MANUAL, detail: "git 2.45", runMs: 1 },
+      { name: "agent:codex", label: "Agent: codex", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not found", runMs: 1 },
+      { name: "agent:claude", label: "Agent: claude", status: STATUS.OK, strategy: STRATEGY.MANUAL, detail: "2.0", runMs: 1 },
+    ]));
+    const out = logs.join("\n");
+    expect(out).toContain("Required: git OK");
+    expect(out).toContain("agent CLI OK (claude)");
+    expect(out).toContain("Optional: Docker");
+  });
+
+  it("flags git and agent as MISSING when neither is present", () => {
+    printPrerequisites(makeReport([
+      { name: "git", label: "git", status: STATUS.FAIL, strategy: STRATEGY.MANUAL, detail: "Not found", runMs: 1 },
+      { name: "agent:claude", label: "Agent: claude", status: STATUS.WARN, strategy: STRATEGY.MANUAL, detail: "Not found", runMs: 1 },
+    ]));
+    const out = logs.join("\n");
+    expect(out).toContain("git MISSING");
+    expect(out).toContain("agent CLI MISSING — install Claude Code, Codex or Gemini");
+  });
+});


### PR DESCRIPTION
## Qué

El binario standalone no empaqueta ningún toolchain: `kj` orquesta herramientas externas (git, CLIs de agentes, Docker, helpers npm). Hasta ahora ni el instalador ni `kj doctor` dejaban claro qué hace falta tener instalado, así que quien se baja el ejecutable se encuentra con comandos que fallan sin explicación.

## Cambios

- **`scripts/install-binary.sh` / `.ps1`**: al terminar la instalación apuntan a `kj doctor` y nombran los requisitos duros (git + al menos un CLI de agente: Claude Code / Codex / Gemini) frente a los opcionales (Docker, Node/npm para helpers).
- **`kj doctor`**: nuevo bloque *Prerequisites* que separa requerido de opcional, con veredicto real derivado de los checks ya recogidos (no vuelve a sondear).
- Test `tests/doctor-prerequisites.test.js`.

## Fuera de alcance

No se auto-instala Docker/Node/CLIs: es invasivo y dependiente de plataforma. Enfoque acordado: documentar + guiar.

KJC-TSK-0599