### PR TITLE
fix(sea): macOS SEA binary boots (--macho-segment-name NODE_SEA) — KJC-BUG-0096

### DIFF
--- a/.github/workflows/sea-smoke.yml
+++ b/.github/workflows/sea-smoke.yml
@@ -1,0 +1,49 @@
+name: SEA macOS smoke
+
+# The macOS SEA binary can only be built and run on macOS, and Node upstream
+# only CI-tests single-executables on Linux. This job builds the darwin-arm64
+# binary and asserts it boots, so a startup segfault (KJC-BUG-0096) is caught
+# on the PR instead of at release time. Runs on demand and whenever the SEA
+# build changes.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "scripts/build-sea.mjs"
+      - "scripts/esbuild-sea.config.mjs"
+      - ".github/workflows/sea-smoke.yml"
+
+jobs:
+  smoke:
+    name: Build + boot darwin-arm64
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build SEA binary
+        run: node scripts/build-sea.mjs
+
+      - name: Boot smoke-test
+        run: |
+          set -euo pipefail
+          ./dist/kj --version
+          ./dist/kj --help >/dev/null
+          ./dist/kj init --help >/dev/null
+          echo "Smoke OK: darwin-arm64 binary boots."
+
+      # If the binary still crashes, surface the Mach-O layout and signature so
+      # the next lead is visible in the run log instead of a bare exit 139.
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "== exit-code probe =="; ./dist/kj --version; echo "exit=$?" || true
+          echo "== NODE_SEA segment =="; otool -l dist/kj | grep -A3 NODE_SEA || echo "NODE_SEA segment NOT found"
+          echo "== codesign verify =="; codesign -vvv --verify dist/kj || true
+          echo "== spctl assess =="; spctl -a -vvv dist/kj || true

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -85,10 +85,16 @@ async function main() {
 
     // ── Step 4: Inject blob with postject ───────────────────────────
     console.log("[4/5] Injecting SEA blob with postject...");
+    // On macOS the blob MUST land as section NODE_SEA_BLOB inside a segment
+    // named NODE_SEA. Without --macho-segment-name postject writes it to a
+    // default segment the SEA loader never inspects, so the binary segfaults
+    // on startup (KJC-BUG-0096, nodejs/postject#76). The flag is Mach-O only —
+    // ELF (Linux) and PE (Windows) don't take it — so add it only on macOS.
     const postjectCmd = [
       `npx postject ${binaryPath}`,
       "NODE_SEA_BLOB dist/sea-prep.blob",
       "--sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2",
+      ...(isMac ? ["--macho-segment-name NODE_SEA"] : []),
     ].join(" ");
     run(postjectCmd);
     console.log("      -> Blob injected.\n");


### PR DESCRIPTION
## Bug
KJC-BUG-0096 — the `darwin-arm64` SEA binary segfaults (exit 139) on startup, so the 0592 smoke gate blocks it and no macOS binary ships. Installers/docs degrade to npm on macOS.

## Root cause
`scripts/build-sea.mjs` runs postject **without** `--macho-segment-name NODE_SEA`. On Mach-O the SEA blob must be a section `NODE_SEA_BLOB` inside a segment named `NODE_SEA`; without the flag postject writes it to a default segment the loader never inspects, and the binary crashes on boot (nodejs/postject#76, nodejs/node#62893). Re-signing was already correct; `useCodeCache`/`useSnapshot` are already off.

## Fix
- `scripts/build-sea.mjs`: append `--macho-segment-name NODE_SEA` to the postject command **on macOS only** (the flag is Mach-O-specific; Linux/Windows commands are byte-for-byte unchanged).
- `.github/workflows/sea-smoke.yml`: new `macos-latest` job (`workflow_dispatch` + PRs touching the SEA build) that builds the binary, boots it (`--version`/`--help`/`init --help`), and on failure dumps the Mach-O `NODE_SEA` segment + codesign/spctl verdicts. Node only CI-tests SEA on Linux, so this is our first macOS reproduction/verification harness.

## Verification
- Linux path unchanged: built + booted locally (`./dist/kj --version` → OK).
- macOS: the new sea-smoke job runs on this PR — **do not merge until it is green** (that green run is the actual segfault fix confirmation).