### PR TITLE
fix(sea): re-export maybeAutoUpdate so `kj run` works in the binary

### DIFF
--- a/.github/workflows/sea-smoke.yml
+++ b/.github/workflows/sea-smoke.yml
@@ -38,6 +38,29 @@ jobs:
           ./dist/kj init --help >/dev/null
           echo "Smoke OK: darwin-arm64 binary boots."
 
+      # KJC-BUG-0097 — booting is not enough: the SEA bundler once stubbed out
+      # src/rag/auto-update.js and `kj run` crashed with "maybeAutoUpdate is not
+      # a function" while --version/--help/init stayed green. Exercise the run
+      # dispatch far enough to prove the bundle wires up. No agent is installed
+      # here, so the command is expected to FAIL later — we only assert it does
+      # NOT die with a missing-symbol error. perl's alarm guards against a hang.
+      - name: Run-dispatch smoke-test
+        run: |
+          set -uo pipefail
+          kj_bin="$PWD/dist/kj"
+          repo="$(mktemp -d)"
+          git -C "$repo" init -q
+          git -C "$repo" -c user.email=kj@test.local -c user.name=kj \
+            commit -q --allow-empty -m "seed"
+          out="$(cd "$repo" && perl -e 'alarm 30; exec @ARGV' \
+            "$kj_bin" run "smoke probe" </dev/null 2>&1 || true)"
+          echo "$out"
+          if echo "$out" | grep -Eq "is not a function|is not defined"; then
+            echo "FAIL: kj run crashed on a missing bundled symbol." >&2
+            exit 1
+          fi
+          echo "Run-dispatch OK: no missing-symbol crash."
+
       # If the binary still crashes, surface the Mach-O layout and signature so
       # the next lead is visible in the run log instead of a bare exit 139.
       - name: Diagnostics on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Standalone binary crashed on `kj run`** (KJC-BUG-0097): every SEA binary (Linux, Windows, macOS) booted fine (`--version` / `--help` / `init`) but died on the core command with `maybeAutoUpdate is not a function`. The SEA bundler stubs out `src/rag/*` to keep native SQLite deps out of the binary; `src/rag/auto-update.js` was caught by that filter, yet `run.js` calls its `maybeAutoUpdate()` on every run. The stub now re-exports `maybeAutoUpdate` as a silent no-op (RAG auto-update is unavailable in the binary anyway) so the command proceeds. The `sea-smoke` gate and `sea-build` test now exercise `kj run` — booting was never enough to prove the bundle wires up.
+
 ## [3.10.0] - 2026-07-12
 
 Minor. **The macOS standalone binary now boots** — the first release to ship a working `darwin-arm64` executable, plus installer guidance for binary users (epic KJC-PCS-0006).

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -183,6 +183,15 @@ const ragStubPlugin = {
           parseWhere: notAvailable, buildWhereSql: notAvailable,
           // KJC-TSK-0449 — RAG cross-encoder rerank.
           rerank: notAvailable, RerankError: notAvailable, _resetPipeline: notAvailable,
+          // KJC-BUG-0097 — src/rag/auto-update.js lives under src/rag/ so it is
+          // caught by this stub, but its exports are called on the hot path.
+          // maybeAutoUpdate() runs on EVERY \`kj run\` (run.js): it must be a
+          // silent no-op here (RAG index is unavailable in SEA anyway), NOT an
+          // absent symbol — otherwise the whole command crashes with
+          // "maybeAutoUpdate is not a function". installPostMergeHook() is only
+          // reached from \`kj rag install-hooks\`, so it degrades like the rest.
+          maybeAutoUpdate: async () => ({ skipped: true }),
+          installPostMergeHook: notAvailable,
           default: notAvailable,
         };
       `,

--- a/tests/sea-build.test.js
+++ b/tests/sea-build.test.js
@@ -53,6 +53,35 @@ describe("SEA bundle (KJC-BUG-0040)", () => {
     expect(out).toMatch(/^\d+\.\d+\.\d+/);
   });
 
+  it("dispatches `kj run` without a missing-symbol crash (KJC-BUG-0097)", () => {
+    // src/rag/auto-update.js lives under src/rag/ so the rag stub swallows it,
+    // yet run.js calls maybeAutoUpdate() on every `kj run`. If the stub omits
+    // that export the whole command dies with "maybeAutoUpdate is not a
+    // function" — while --version/--help stay green. No agent is configured
+    // here, so the command is expected to fail LATER; we only assert it does
+    // not die on a missing bundled symbol.
+    const repo = mkdtempSync(join(tmpdir(), "kj-sea-run-"));
+    // CI runners have no global git identity, so pin one per-invocation
+    // (-c) — otherwise the seed commit dies with "Author identity unknown".
+    execFileSync("git", ["-C", repo, "init", "-q"]);
+    execFileSync("git", [
+      "-C", repo,
+      "-c", "user.email=kj@test.local",
+      "-c", "user.name=kj",
+      "commit", "-q", "--allow-empty", "-m", "seed",
+    ]);
+    let combined = "";
+    try {
+      combined = execFileSync("node", [bundlePath, "run", "smoke probe"], {
+        encoding: "utf8", cwd: repo, input: "", timeout: 30_000,
+      });
+    } catch (err) {
+      combined = `${String(err.stdout || "")}\n${String(err.stderr || "")}`;
+    }
+    rmSync(repo, { recursive: true, force: true });
+    expect(combined).not.toMatch(/is not a function|is not defined/);
+  });
+
   it("emits the stub message (not a stack trace) when `board cleanup` is invoked", () => {
     // The child node process inherits process.env.VITEST, which routes
     // KARAJAN_HOME to a fresh tmp dir without a global kj.config.yml. The


### PR DESCRIPTION
## KJC-BUG-0097 — Application Blocker

The standalone SEA binary (Linux, Windows, **macOS**) booted fine (`--version` / `--help` / `init`) but **crashed on `kj run`**, the core command:

```
(0 , import_auto_update.maybeAutoUpdate) is not a function
```

### Root cause
`scripts/esbuild-sea.config.mjs` → `ragStubPlugin` replaces everything under `src/rag/` with a stub to keep native SQLite deps (`better-sqlite3`/`sqlite-vec`) out of the binary. `src/rag/auto-update.js` lives in that folder so it got stubbed too — but `src/commands/run.js:51` calls its `maybeAutoUpdate()` on **every** `kj run`. The stub didn't re-export that symbol → `undefined` → crash before the pipeline starts.

Latent since KJC-TSK-0455 placed `maybeAutoUpdate` under `src/rag/`. `sea-smoke` never caught it because it only tested `--version`/`--help`/`init`. npm is unaffected (the tarball ships the real source), which is why `verify-pack` stayed green.

### Fix
- `ragStubPlugin` re-exports `maybeAutoUpdate` as a silent no-op (`async () => ({ skipped: true })`) — RAG auto-update is unavailable in the binary anyway, so skipping is correct — and `installPostMergeHook` as the standard "install via npm" thrower.
- **`sea-smoke.yml`** gains a run-dispatch probe: seeds a throwaway git repo and asserts `kj run` does **not** die with `is not a function` (no agent installed, so it's expected to fail later).
- **`tests/sea-build.test.js`** gains the same assertion on the freshly built bundle (fast, runs on every `npm test`).

Booting was never enough to prove the bundle wires up; both gates now exercise the run path.

### Verification
- Rebuilt binary: `kj run` now reaches the pipeline (preflight) instead of crashing.
- `sea-build.test.js` 5/5 green.
- Net +53 LOC (under the 200 shrink-budget).