### PR TITLE
chore(release): v3.10.1 — SEA `kj run` fix, first usable binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.10.1] - 2026-07-12
+
 ### Fixed
 
 - **Standalone binary crashed on `kj run`** (KJC-BUG-0097): every SEA binary (Linux, Windows, macOS) booted fine (`--version` / `--help` / `init`) but died on the core command with `maybeAutoUpdate is not a function`. The SEA bundler stubs out `src/rag/*` to keep native SQLite deps out of the binary; `src/rag/auto-update.js` was caught by that filter, yet `run.js` calls its `maybeAutoUpdate()` on every run. The stub now re-exports `maybeAutoUpdate` as a silent no-op (RAG auto-update is unavailable in the binary anyway) so the command proceeds. The `sea-smoke` gate and `sea-build` test now exercise `kj run` — booting was never enough to prove the bundle wires up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release **v3.10.1**.

## Why
v3.10.0 built and booted its standalone binaries (`--version` / `--help` / `init`) but crashed on the core command `kj run` with `maybeAutoUpdate is not a function` (KJC-BUG-0097, fixed in #1154). npm never shipped 3.10.0 (still 3.9.0). This is the first standalone binary that runs a task end to end.

## Changes
- Bump `package.json` to 3.10.1.
- CHANGELOG: promote the KJC-BUG-0097 fix under a `[3.10.1]` heading.

## Release steps after merge
- Tag `v3.10.1` → `release-binaries.yml` auto-mints the GitHub release and rebuilds linux/darwin-arm64/win binaries with the fix (sea-smoke now exercises `kj run`).
- Verify the downloaded binary runs `kj run` (not just `--version`) before npm.
- `npm publish` 3.10.1.
- Deploy landing v3.10.1 (EN/ES).