### PR TITLE
fix(security): remove personal email from public metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ If you discover a security vulnerability in karajan-code, please report it respo
 
 ### How to Report
 
-1. Email **mjfosela@gmail.com** with the subject line: `[SECURITY] karajan-code vulnerability report`
+1. Open a private report via [GitHub Security Advisories](https://github.com/manufosela/karajan-code/security/advisories/new) (Security → Report a vulnerability)
 2. Include:
    - Description of the vulnerability
    - Steps to reproduce
@@ -41,8 +41,6 @@ The following are out of scope:
 - Vulnerabilities in third-party AI CLIs (claude, codex, gemini, aider)
 - SonarQube Docker container security (report to SonarSource)
 - Denial of service via resource exhaustion (long-running tasks)
-<<<<<<< HEAD
-=======
 
 ---
 
@@ -63,7 +61,7 @@ Si descubres una vulnerabilidad de seguridad en karajan-code, reportala de forma
 
 ### Como Reportar
 
-1. Envia un email a **mjfosela@gmail.com** con el asunto: `[SECURITY] karajan-code vulnerability report`
+1. Abre un reporte privado via [GitHub Security Advisories](https://github.com/manufosela/karajan-code/security/advisories/new) (Security → Report a vulnerability)
 2. Incluye:
    - Descripcion de la vulnerabilidad
    - Pasos para reproducirla
@@ -89,4 +87,3 @@ Fuera del alcance:
 - Vulnerabilidades en CLIs de IA de terceros (claude, codex, gemini, aider)
 - Seguridad del contenedor Docker de SonarQube (reportar a SonarSource)
 - Denegacion de servicio por agotamiento de recursos (tareas de larga duracion)
->>>>>>> 8792e49efcdc75995e024d81339b100c7b253920

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",
-  "author": "Manu Fosela <mjfosela@gmail.com>",
+  "author": "manufosela (https://github.com/manufosela)",
   "homepage": "https://github.com/manufosela/karajan-code#readme",
   "repository": {
     "type": "git",

--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python wrapper for Karajan Code - local multi-agent coding orches
 readme = "README.md"
 license = {text = "AGPL-3.0"}
 requires-python = ">=3.9"
-authors = [{name = "manufosela", email = "manufosela@gmail.com"}]
+authors = [{name = "manufosela"}]
 
 [project.scripts]
 kj = "karajan.__main__:main"


### PR DESCRIPTION
## Qué

Quita el email personal de todos los artefactos públicos del repo y sustituye el canal de reporte de vulnerabilidades por GitHub Security Advisories.

- `package.json` → `author`: nombre + URL de perfil, sin email.
- `wrappers/python/pyproject.toml` → `authors`: solo handle.
- `SECURITY.md` (EN + ES) → reporte vía [GitHub Security Advisories](https://github.com/manufosela/karajan-code/security/advisories/new) en vez de mailto.

## Extra

`SECURITY.md` tenía marcadores de conflicto de merge (`<<<<<<< / ======= / >>>>>>>`) commiteados en main desde el PR #203. Se limpian conservando la sección ES.

## Verificación

- `git grep` del email → 0 coincidencias rastreadas.
- `git grep` de marcadores de conflicto → 0.

Nota: el email persiste en la página de npm de la 3.10.1 ya publicada hasta que salga una versión nueva; no se hace bump automático.

KJC-TSK-0600