### PR TITLE
fix(direct-actions): guard paths by containment not string prefix (KJC-BUG-0098)

### DIFF
--- a/src/orchestrator/direct-actions.js
+++ b/src/orchestrator/direct-actions.js
@@ -27,6 +27,18 @@ const ALLOWED_COMMANDS = [
 ];
 
 /**
+ * True when `target` resolves to a path inside `base` (or is `base` itself).
+ * Uses path.relative instead of a string prefix check: a naive
+ * `resolved.startsWith(base)` lets a sibling with a shared prefix slip through
+ * (base `/repo/app` would accept `/repo/app2`). Also rejects absolute paths
+ * pointing outside the project.
+ */
+function isInsideBase(target, base) {
+  const rel = path.relative(base, target);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/**
  * Validate that a shell command is in the allow-list.
  * Prevents arbitrary command execution.
  */
@@ -74,7 +86,7 @@ async function createFile({ filePath, content, cwd, overwrite = false }) {
     // Path traversal guard
     const resolved = path.resolve(fullPath);
     const base = path.resolve(cwd || process.cwd());
-    if (!resolved.startsWith(base)) {
+    if (!isInsideBase(resolved, base)) {
       return { ok: false, error: "Path traversal denied", action: "create_file" };
     }
 
@@ -130,9 +142,10 @@ async function gitAdd({ files, cwd }) {
   }
 
   try {
-    // Only allow relative paths (no absolute paths, no shell metacharacters)
+    // Reject shell metacharacters and anything that resolves outside the project.
+    const base = path.resolve(cwd || process.cwd());
     for (const f of files) {
-      if (typeof f !== "string" || f.includes("..") || /[;&|`$]/.test(f)) {
+      if (typeof f !== "string" || /[;&|`$]/.test(f) || !isInsideBase(path.resolve(base, f), base)) {
         return { ok: false, error: `Invalid file path: ${f}`, action: "git_add" };
       }
     }

--- a/tests/direct-actions.test.js
+++ b/tests/direct-actions.test.js
@@ -106,6 +106,16 @@ describe("direct-actions", () => {
       expect(result.error).toContain("traversal");
     });
 
+    it("rejects a sibling directory that shares a path prefix", async () => {
+      // /tmp/kj-test-XXX vs /tmp/kj-test-XXX2 — a naive startsWith(base) lets this slip.
+      const result = await executeAction({
+        type: "create_file",
+        params: { filePath: path.join(`${tmpDir}2`, "leak.txt"), content: "x", cwd: tmpDir }
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("traversal");
+    });
+
     it("creates parent directories", async () => {
       const result = await executeAction({
         type: "create_file",
@@ -182,6 +192,16 @@ describe("direct-actions", () => {
         params: { files: ["file; rm -rf /"], cwd: tmpDir }
       });
       expect(result.ok).toBe(false);
+    });
+
+    it("rejects absolute paths outside the project", async () => {
+      // No "..", no metacharacters — only a containment check catches this.
+      const result = await executeAction({
+        type: "git_add",
+        params: { files: ["/etc/passwd"], cwd: tmpDir }
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("Invalid file path");
     });
   });
 


### PR DESCRIPTION
## Bug (KJC-BUG-0098)

The path-traversal guard in `src/orchestrator/direct-actions.js` gave a false sense of security:

- **createFile** checked containment with `resolved.startsWith(base)`. A sibling directory sharing a prefix slips through — base `/repo/app` accepts `/repo/app2`.
- **gitAdd** rejected `..` by substring but let absolute paths outside the repo (e.g. `/etc/passwd`) reach `git add`.

Surfaced by an external review and verified against the code.

## Fix

Shared `isInsideBase(target, base)` helper using `path.relative` (rejects when the relative path escapes with `..` or is absolute). Applied to both `createFile` and `gitAdd`; the `gitAdd` shell-metacharacter check is preserved.

## Tests

Two regression tests added (both red before the fix, green after):
- createFile rejects a sibling directory sharing a path prefix.
- gitAdd rejects absolute paths outside the project.

`tests/direct-actions.test.js` → 26/26 passing. Net +36 LOC (under the shrink-budget gate).