### PR TITLE
feat(triage): surface per-role activation rationale (KJC-TSK-0601)

### DIFF
--- a/src/orchestrator/stages/triage-stage.js
+++ b/src/orchestrator/stages/triage-stage.js
@@ -11,12 +11,48 @@ import { createStallDetector } from "../../utils/stall-detector.js";
 
 const ROLE_NAMES = ["planner", "researcher", "architect", "refactorer", "reviewer", "tester", "security", "impeccable"];
 
+// What each role is for. Used to explain — deterministically — why triage would
+// or would not turn a role on. These describe the role's trigger, never a claim
+// about the current task, so the rationale is never invented per run.
+const ROLE_PURPOSE = {
+  planner: "planificación multi-fichero",
+  researcher: "investigación de contexto externo",
+  architect: "decisiones de arquitectura",
+  refactorer: "refactor de código existente",
+  reviewer: "revisión de cambios",
+  tester: "cobertura de tests dedicada",
+  security: "auditoría de seguridad",
+  impeccable: "auditoría de diseño"
+};
+
 function buildRoleOverrides(recommendedRoles, pipelineConfig) {
   const overrides = {};
   for (const role of ROLE_NAMES) {
     overrides[`${role}Enabled`] = recommendedRoles.has(role) || Boolean(pipelineConfig[role]?.enabled);
   }
   return overrides;
+}
+
+// Per-role explanation of the activate/skip decision, mirroring buildRoleOverrides.
+// When triage failed, recommendations are unavailable: roles resolve from config
+// alone and skipped ones get a neutral "sin datos de triage" reason.
+function buildRoleRationale(recommendedRoles, pipelineConfig, triageOk) {
+  return ROLE_NAMES.map((role) => {
+    const forced = Boolean(pipelineConfig[role]?.enabled);
+    const recommended = triageOk && recommendedRoles.has(role);
+    const purpose = ROLE_PURPOSE[role];
+
+    if (recommended) {
+      return { role, enabled: true, source: "triage", reason: `recomendado por triage — ${purpose}` };
+    }
+    if (forced) {
+      return { role, enabled: true, source: "config", reason: `forzado por configuración — ${purpose}` };
+    }
+    const reason = triageOk
+      ? `no recomendado — ${purpose} sin aplicar`
+      : `sin datos de triage — ${purpose} sin evaluar`;
+    return { role, enabled: false, source: "none", reason };
+  });
 }
 
 function applyModelSelection(triageOutput, config, emitter, eventBase) {
@@ -104,7 +140,8 @@ export async function runTriageStage({ config, logger, emitter, eventBase, sessi
     taskType: triageOutput.result?.taskType || "sw",
     shouldDecompose,
     subtasks,
-    domainHints
+    domainHints,
+    roleRationale: buildRoleRationale(recommendedRoles, config.pipeline || {}, triageOutput.ok)
   };
 
   const modelSelection = applyModelSelection(triageOutput, config, emitter, eventBase);

--- a/src/utils/display/event-handlers.js
+++ b/src/utils/display/event-handlers.js
@@ -69,6 +69,20 @@ export const EVENT_HANDLERS = {
     console.log(`  \u251c\u2500 ${icon} TDD policy: ${label}${files}${executor}`);
   },
 
+  "triage:end": (event, icon, elapsed, status) => {
+    const detail = event.detail || {};
+    const level = detail.level ? ` ${detail.level}` : "";
+    const onCount = detail.roles?.length || 0;
+    console.log(
+      `  \u251c\u2500 ${icon} ${status} Triage${level}${ANSI.dim} \u2014 ${onCount} role(s) on${ANSI.reset}  ${elapsed}`
+    );
+    // Per-role rationale: why each role was activated or skipped (KJC-TSK-0601).
+    for (const entry of detail.roleRationale || []) {
+      const mark = entry.enabled ? `${ANSI.green}\u2713${ANSI.reset}` : `${ANSI.dim}\u2717${ANSI.reset}`;
+      console.log(`  \u2502    ${mark} ${ANSI.dim}${entry.role}: ${entry.reason}${ANSI.reset}`);
+    }
+  },
+
   "researcher:start": (event, icon) => {
     console.log(`  \u251c\u2500 ${icon} Researcher (${event.detail?.researcher || "?"}) investigating...`);
   },

--- a/tests/triage/triage-stage.test.js
+++ b/tests/triage/triage-stage.test.js
@@ -213,6 +213,78 @@ describe("runTriageStage", () => {
     expect(result.stageResult.taskType).toBe("sw");
   });
 
+  it("emits per-role rationale: triage-recommended, config-forced and off", async () => {
+    triageRunMock.mockResolvedValue({
+      ok: true,
+      result: {
+        level: "medium",
+        roles: ["reviewer", "tester"],
+        reasoning: "Moderate complexity"
+      },
+      usage: { tokens_in: 100, tokens_out: 80 }
+    });
+    config.pipeline = { security: { enabled: true } };
+
+    const result = await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    const rationale = result.stageResult.roleRationale;
+    const byRole = Object.fromEntries(rationale.map((r) => [r.role, r]));
+    // Every known role is covered, deterministically.
+    expect(rationale).toHaveLength(8);
+
+    // Recommended by triage.
+    expect(byRole.reviewer).toMatchObject({ enabled: true, source: "triage" });
+    expect(byRole.reviewer.reason).toMatch(/triage/i);
+    // Forced by config, not recommended by triage.
+    expect(byRole.security).toMatchObject({ enabled: true, source: "config" });
+    expect(byRole.security.reason).toMatch(/configuración/i);
+    // Off: neither recommended nor forced.
+    expect(byRole.planner).toMatchObject({ enabled: false, source: "none" });
+    expect(byRole.planner.reason).toBeTruthy();
+  });
+
+  it("degrades role rationale to a neutral reason when triage fails", async () => {
+    triageRunMock.mockResolvedValue({
+      ok: false,
+      result: { error: "Agent failed" },
+      summary: "Triage failed",
+      usage: { tokens_in: 50, tokens_out: 20 }
+    });
+    config.pipeline = { security: { enabled: true } };
+
+    const result = await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    const byRole = Object.fromEntries(result.stageResult.roleRationale.map((r) => [r.role, r]));
+    // No triage data: non-forced roles get a neutral reason, never an invented one.
+    expect(byRole.planner).toMatchObject({ enabled: false, source: "none" });
+    expect(byRole.planner.reason).toMatch(/sin datos de triage/i);
+    // Config-forced roles still resolve from config alone.
+    expect(byRole.security).toMatchObject({ enabled: true, source: "config" });
+  });
+
+  it("exposes roleRationale in the triage:end event", async () => {
+    const events = [];
+    emitter.on("progress", (event) => events.push(event));
+
+    await runTriageStage({
+      config, logger, emitter, eventBase, session,
+      coderRole: { provider: "codex", model: null },
+      trackBudget
+    });
+
+    const endEvent = events.find((e) => e.type === "triage:end");
+    expect(Array.isArray(endEvent.detail.roleRationale)).toBe(true);
+    expect(endEvent.detail.roleRationale.length).toBe(8);
+  });
+
   it("handles shouldDecompose in stage result", async () => {
     triageRunMock.mockResolvedValue({
       ok: true,

--- a/tests/utils/utils-display.test.js
+++ b/tests/utils/utils-display.test.js
@@ -107,6 +107,28 @@ describe("utils/display", () => {
       expect(output).toContain("OK");
     });
 
+    it("prints triage per-role rationale", () => {
+      printEvent({
+        type: "triage:end",
+        status: "ok",
+        detail: {
+          level: "medium",
+          roles: ["reviewer"],
+          roleRationale: [
+            { role: "reviewer", enabled: true, source: "triage", reason: "recomendado por triage — revisión de cambios" },
+            { role: "planner", enabled: false, source: "none", reason: "no recomendado — planificación multi-fichero sin aplicar" }
+          ]
+        },
+        elapsed: 1000
+      });
+
+      const output = spy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("Triage");
+      expect(output).toContain("1 role(s) on");
+      expect(output).toContain("reviewer: recomendado por triage");
+      expect(output).toContain("planner: no recomendado");
+    });
+
     it("prints question event with pause message", () => {
       printEvent({ type: "question", detail: { question: "Should I proceed?" }, sessionId: "s_123" });
 


### PR DESCRIPTION
## Qué

Triage decidía qué roles activar/saltar pero solo exponía un `reasoning`
global; no había forma de saber **por qué** cada rol concreto (planner,
security, tester…) quedaba activado o desactivado.

Este PR añade un rationale determinista por rol a `stageResult.roleRationale`
y lo renderiza bajo el evento `triage:end`.

## Cómo

- `buildRoleRationale(recommendedRoles, pipelineConfig, triageOk)` en
  `triage-stage.js`, espejo de `buildRoleOverrides`. Cada entrada:
  `{ role, enabled, source, reason }` con `source` ∈ `triage | config | none`.
- `ROLE_PURPOSE` describe el disparador de cada rol (no una afirmación sobre
  la tarea), así el motivo nunca es inventado por ejecución.
- Si triage falla, los roles saltados degradan a un motivo neutro
  ("sin datos de triage — … sin evaluar"); los forzados por config siguen
  resolviéndose desde config.
- Handler `triage:end` en `event-handlers.js` imprime una línea por rol
  (✓/✗ + motivo) bajo la cabecera de triage.

## Tests

- `tests/triage/triage-stage.test.js`: recomendado-por-triage, forzado-por-config,
  saltado, degradación en fallo de triage, y presencia en el evento.
- `tests/utils/utils-display.test.js`: render del rationale por rol.
- 115 tests verdes en el área, lint limpio. Net +145 LOC (bajo shrink-budget).

KJC-TSK-0601