### PR TITLE
fix(installer): let macOS install the darwin-arm64 binary (KJC-BUG-0101)

### DIFF
--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -36,17 +36,8 @@ esac
 target="${os}-${arch}"
 case "$target" in
   linux-x64) ;;
-  darwin-arm64)
-    # The macOS standalone binary is not published yet (tracked in
-    # KJC-BUG-0096: the darwin-arm64 SEA build crashes under smoke-test).
-    # Degrade gracefully to the npm install path instead of trying to
-    # download an asset that does not exist.
-    echo "kj-install: the macOS standalone binary is not available yet." >&2
-    echo "kj-install: install with npm instead (requires Node 18+):" >&2
-    echo "  npm install -g karajan-code" >&2
-    exit 0
-    ;;
-  *) die "no prebuilt binary for '$target'. Available: linux-x64. On macOS use npm instead: npm install -g karajan-code" ;;
+  darwin-arm64) ;;
+  *) die "no prebuilt binary for '$target'. Available: linux-x64, darwin-arm64. Use npm instead: npm install -g karajan-code" ;;
 esac
 
 # --- Resolve the download URL for the requested version (or latest). ---

--- a/tests/install-binary-sh.test.js
+++ b/tests/install-binary-sh.test.js
@@ -1,0 +1,20 @@
+// KJC-BUG-0101 — the standalone installer must let macOS (darwin-arm64)
+// through the normal download flow now that the binary ships in the release.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const script = readFileSync(`${process.cwd()}/scripts/install-binary.sh`, "utf8");
+
+describe("install-binary.sh macOS gating — KJC-BUG-0101", () => {
+  it("no longer degrades macOS to the npm path", () => {
+    expect(script).not.toMatch(/not available yet/i);
+  });
+
+  it("allows darwin-arm64 through the download flow", () => {
+    expect(script).toMatch(/darwin-arm64\)\s*;;/);
+  });
+
+  it("lists darwin-arm64 as an available prebuilt target", () => {
+    expect(script).toMatch(/Available: linux-x64, darwin-arm64/);
+  });
+});


### PR DESCRIPTION
## Bug
`scripts/install-binary.sh` (served at karajancode.com/install.sh via a rewrite to `main`) aborted on macOS with *"the macOS standalone binary is not available yet"* and told users to `npm install -g karajan-code`.

That guard was a leftover from **KJC-BUG-0096**, long resolved: the `kj-darwin-arm64` binary (+ `.sha256`) ships in every GitHub Release since v3.10.0/3.10.1 and is present in **v3.10.2**. The rest of the script (OS/arch detection, download, checksum verification, `xattr` quarantine clear) already supports darwin.

## Fix
- Let `darwin-arm64` fall through to the normal download flow (`darwin-arm64) ;;`).
- Update the `*)` fallback message to list `linux-x64, darwin-arm64` as available targets.
- Add `tests/install-binary-sh.test.js` pinning that macOS is no longer degraded to npm.

## Impact
macOS Apple Silicon users can now install the standalone `kj` binary with the same one-liner as Linux. No release needed — the installer is served from `main`.

Closes KJC-BUG-0101.