### PR TITLE
feat(roles): active partner — relevance-gated constructive dissent (KJC-TSK-0603)

### DIFF
--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -12,6 +12,24 @@ You are the **Coder** in a multi-role AI pipeline. Your job is to write code and
 - Before creating a new utility or helper, check if a similar one already exists in the codebase. Reuse existing code over creating duplicates.
 - Follow existing code conventions and patterns in the repository.
 
+## Constructive dissent (raise real blockers before you code)
+
+You are an Active Partner, not a silent contractor. Before implementing, if you
+detect a genuine problem with the task, surface it FIRST instead of quietly
+coding around it:
+
+- A contradiction between two requirements that cannot both hold.
+- A false or impossible premise — the task assumes a fact, file, or API that
+  does not exist, or forces an outcome that cannot be correct.
+- A concrete security or maintainability risk in what is being asked.
+
+Report it concisely in `result.concerns` (an array of short strings). When a
+blocker makes the task unworkable as stated, stop and report instead of guessing.
+
+Keep the bar high. Proceed silently when the task is clear and coherent — do NOT
+object to trivial or stylistic details, and do NOT manufacture doubts to look
+thorough. Relevance is the test: raise only what would derail the result.
+
 ## PR atomicity (hard project rule)
 
 Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan before writing:
@@ -105,7 +123,8 @@ Return a JSON object:
     "files_modified": ["path/to/file.js"],
     "files_created": ["path/to/new-file.js"],
     "tests_added": ["path/to/test.js"],
-    "approach": "Brief description of what was done"
+    "approach": "Brief description of what was done",
+    "concerns": []
   },
   "summary": "Human-readable summary of changes"
 }

--- a/templates/roles/spec-reviewer.md
+++ b/templates/roles/spec-reviewer.md
@@ -11,6 +11,11 @@ user's spec (prompt or `.md`) for deficiencies. You do NOT execute or plan.
 - **assumptions** — depends on unstated context.
 - **out_of_scope** — asks for things outside what Karajan can do.
 
+A spec can also carry a **false premise**: it forces an answer that cannot be
+correct (asks for N options when only one is valid, assumes a fact/API that does
+not exist). Surface these as `contradiction` or `out_of_scope` — never rationalise
+them into a plausible-looking answer.
+
 ## Severity
 
 `info` (nuance), `warn` (real gap), `fail` (unworkable). Top-level `severity`

--- a/tests/roles/active-partner.test.js
+++ b/tests/roles/active-partner.test.js
@@ -1,0 +1,31 @@
+// Tests for the Active Partner / constructive dissent guidance (KJC-TSK-0603).
+// The coder and spec-reviewer role prompts must give relevance-gated permission
+// to surface real blockers WITHOUT manufacturing trivial objections.
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const ROLES = path.resolve(import.meta.dirname, "..", "..", "templates", "roles");
+
+describe("active partner — constructive dissent (KJC-TSK-0603)", () => {
+  it("coder.md lets the coder raise real blockers before coding", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "coder.md"), "utf8");
+    expect(tpl).toMatch(/Active Partner/);
+    expect(tpl).toMatch(/false or impossible premise/i);
+    expect(tpl).toContain("result.concerns");
+  });
+
+  it("coder.md keeps the bar high — no manufactured or trivial dissent", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "coder.md"), "utf8");
+    expect(tpl).toMatch(/do NOT manufacture doubts/i);
+    expect(tpl).toMatch(/Relevance is the test/i);
+    expect(tpl).toMatch(/"concerns":\s*\[\]/);
+  });
+
+  it("spec-reviewer.md flags false premises instead of rationalising them", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "spec-reviewer.md"), "utf8");
+    expect(tpl).toMatch(/false premise/i);
+    expect(tpl).toMatch(/never rationalise/i);
+  });
+});


### PR DESCRIPTION
## Qué

Da al coder permiso explícito y **acotado por relevancia** para plantear bloqueos reales antes de codificar, sin fabricar objeciones triviales:

- Contradicciones entre requisitos que no pueden cumplirse a la vez.
- Premisa falsa o imposible (asume un hecho/fichero/API inexistente, o fuerza un resultado que no puede ser correcto).
- Riesgo concreto de seguridad o mantenibilidad en lo que se pide.

Se reporta en `result.concerns` (array opcional en el output del coder — advisory, no rompe el parser). El listón se mantiene alto: si la tarea es clara y coherente, procede en silencio; nada de discrepar por detalles de estilo ni de inventar dudas para parecer minucioso.

El **spec-reviewer** ahora marca premisas falsas como `contradiction`/`out_of_scope` (categorías existentes, sin tocar el enum) en vez de racionalizarlas hacia una respuesta plausible.

## Por qué

Remedio a Silent Misalignment / Compliance Bias / Obedient Contractor: el agente tendía a codificar alrededor de un problema en vez de señalarlo. La clave del diseño es que sea **relevance-gated**, no obligatorio — obligar a discrepar es tan dañino como el silencio.

## Tests

Nuevo `tests/roles/active-partner.test.js` (3 casos): coder.md permite plantear bloqueos reales y mantiene el listón alto (no dudas fabricadas), spec-reviewer.md marca premisas falsas sin racionalizarlas. Verde junto a la suite de spec-reviewer.

Net ~55 LOC.