### PR TITLE
feat(roles): check-alignment micro-gate for moderate/complex tasks (KJC-TSK-0604)

### DIFF
--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -30,6 +30,22 @@ Keep the bar high. Proceed silently when the task is clear and coherent — do N
 object to trivial or stylistic details, and do NOT manufacture doubts to look
 thorough. Relevance is the test: raise only what would derail the result.
 
+## Check alignment (moderate or complex tasks only)
+
+When the task has moderate or high scope — it spans several files, touches
+architecture, security or testing, or leaves any real doubt about the goal —
+state your understanding BEFORE writing code:
+
+- One or two sentences on what you understood the task to be.
+- Any open questions whose answer would change the implementation.
+
+Report this in `result.alignment` (`{ "understood": "…", "open_questions": [] }`).
+Surfacing a misread here is far cheaper than discovering it after the diff.
+
+Do NOT add this step for trivial or small, unambiguous tasks — proceed straight
+to the code. This gate is for tasks big enough that a wrong assumption is costly,
+not a ritual for every change.
+
 ## PR atomicity (hard project rule)
 
 Karajan projects MAY enforce a CI gate that fails any PR whose net delta exceeds **200 lines added** (the karajan-code repo itself enforces this since 2026-05-08). Plan before writing:
@@ -124,7 +140,8 @@ Return a JSON object:
     "files_created": ["path/to/new-file.js"],
     "tests_added": ["path/to/test.js"],
     "approach": "Brief description of what was done",
-    "concerns": []
+    "concerns": [],
+    "alignment": null
   },
   "summary": "Human-readable summary of changes"
 }

--- a/tests/roles/active-partner.test.js
+++ b/tests/roles/active-partner.test.js
@@ -29,3 +29,18 @@ describe("active partner — constructive dissent (KJC-TSK-0603)", () => {
     expect(tpl).toMatch(/never rationalise/i);
   });
 });
+
+describe("check alignment micro-gate (KJC-TSK-0604)", () => {
+  it("coder.md gates the alignment step to moderate/complex tasks", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "coder.md"), "utf8");
+    expect(tpl).toMatch(/Check alignment/i);
+    expect(tpl).toMatch(/moderate or (high|complex)/i);
+    expect(tpl).toContain("result.alignment");
+  });
+
+  it("coder.md skips the alignment step for trivial or small tasks", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "coder.md"), "utf8");
+    expect(tpl).toMatch(/Do NOT add this step for trivial/i);
+    expect(tpl).toMatch(/"alignment":\s*null/);
+  });
+});


### PR DESCRIPTION
## Qué

En tareas de alcance moderado o alto (varios ficheros, arquitectura/seguridad/testing, o duda real sobre el objetivo) el coder declara **antes de codificar**:

- Una o dos frases de qué entendió que es la tarea.
- Preguntas abiertas cuya respuesta cambiaría la implementación.

Se reporta en `result.alignment` (`{ understood, open_questions }`, opcional y advisory — no rompe el parser, igual que `concerns`).

Las tareas triviales o pequeñas y sin ambigüedad **se saltan el paso** y van directas al código: el gate es para tareas donde una suposición equivocada sale cara, no un ritual para cada cambio.

## Por qué

Remedio a Check Alignment: sacar el desalineamiento a la luz antes de implementar en vez de descubrirlo tras el diff.

**Decisión de diseño:** el gate es **autoevaluado por el coder en su prompt**, no cableado desde el nivel de triage. Triage es opcional (default off) y no todos los runs lo ejecutan; el coder siempre lee la descripción de su tarea, así que autoevaluar el alcance es más robusto y no añade plumbing en `src` para devPoints 2. `triage.md` no se toca (ya clasifica; añadirle algo sería cambiar por cambiar).

## Tests

`tests/roles/active-partner.test.js` extendido (2 casos): coder.md acota el paso a moderate/complex y lo salta en trivial/small. Verde.

Net ~33 LOC.