### PR TITLE
feat(roles): point the target — affirmative high-impact instructions (KJC-TSK-0605)

### DIFF
--- a/templates/roles/coder.md
+++ b/templates/roles/coder.md
@@ -8,7 +8,7 @@ You are the **Coder** in a multi-role AI pipeline. Your job is to write code and
 - Write tests BEFORE implementation when using TDD.
 - Keep changes minimal and focused on the task.
 - "Minimal" means no unnecessary changes — it does NOT mean avoiding new files. If the task requires creating new files (pages, components, modules, tests), you MUST create them. Updating references/links without creating the actual files is an incomplete implementation.
-- Do not modify code unrelated to the task.
+- Change only the code the task requires; leave everything else as it is.
 - Before creating a new utility or helper, check if a similar one already exists in the codebase. Reuse existing code over creating duplicates.
 - Follow existing code conventions and patterns in the repository.
 
@@ -69,7 +69,7 @@ Before reporting done, verify that ALL parts of the task are addressed:
 - If the task says "create X", create the complete working implementation, not a skeleton.
 - If tests exist, the implementation MUST make all tests pass.
 - If you write tests first (TDD), the implementation MUST make those tests pass.
-- Do NOT commit code that doesn't compile or doesn't pass tests.
+- Commit only code that compiles and passes the full test suite.
 
 ## Test file location (MANDATORY convention)
 

--- a/templates/roles/reviewer.md
+++ b/templates/roles/reviewer.md
@@ -4,7 +4,7 @@ You are the **Reviewer** in a multi-role AI pipeline. Your job is to review code
 
 ## Scope constraint
 
-- **ONLY review files present in the diff.** Do not flag issues in files that were not changed.
+- **Review only the files present in the diff.** Keep every finding scoped to what this change touched.
 - If you notice problems in untouched files, mention them as `non_blocking_suggestions` with a note that they are outside the current scope — never as `blocking_issues`.
 - Your job is to review THIS change, not audit the entire codebase.
 
@@ -21,7 +21,7 @@ You are the **Reviewer** in a multi-role AI pipeline. Your job is to review code
 - Focus on security, correctness, and tests first.
 - Only raise blocking issues for concrete production risks in the changed files.
 - Keep non-blocking suggestions separate.
-- Style preferences NEVER block approval.
+- Let style preferences pass; reserve blocking for concrete production risks.
 - Confidence threshold: reject only if < 0.70.
 
 ## File overwrite detection (BLOCKING)

--- a/tests/roles/point-the-target.test.js
+++ b/tests/roles/point-the-target.test.js
@@ -1,0 +1,24 @@
+// Tests for Point the Target (KJC-TSK-0605): the highest-impact instructions in
+// the coder and reviewer role prompts state what TO do, not only what to avoid.
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const ROLES = path.resolve(import.meta.dirname, "..", "..", "templates", "roles");
+
+describe("point the target — affirmative high-impact instructions (KJC-TSK-0605)", () => {
+  it("coder.md states scope and commit gate affirmatively", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "coder.md"), "utf8");
+    expect(tpl).toMatch(/Change only the code the task requires/);
+    expect(tpl).toMatch(/Commit only code that compiles and passes/);
+    expect(tpl).not.toMatch(/Do not modify code unrelated to the task/);
+  });
+
+  it("reviewer.md states scope and blocking policy affirmatively", async () => {
+    const tpl = await fs.readFile(path.join(ROLES, "reviewer.md"), "utf8");
+    expect(tpl).toMatch(/Review only the files present in the diff/);
+    expect(tpl).toMatch(/Let style preferences pass; reserve blocking/);
+    expect(tpl).not.toMatch(/Style preferences NEVER block approval/);
+  });
+});


### PR DESCRIPTION
## Qué

Reformula las **cuatro instrucciones negativas de mayor impacto** de `coder.md` y `reviewer.md` para expresar qué hacer en positivo, sin perder la restricción original:

| Antes | Ahora |
|-------|-------|
| Do not modify code unrelated to the task | Change only the code the task requires; leave everything else as it is |
| Do NOT commit code that doesn't compile or doesn't pass tests | Commit only code that compiles and passes the full test suite |
| ONLY review files present in the diff. Do not flag issues in files that were not changed | Review only the files present in the diff. Keep every finding scoped to what this change touched |
| Style preferences NEVER block approval | Let style preferences pass; reserve blocking for concrete production risks |

## Por qué

Point the Target: un objetivo afirmativo evita el *negative bleedthrough* (la instrucción "no hagas X" mantiene X activo en el contexto del modelo). Se tocan solo las de más impacto — scope, commit gate, alcance de review y política de bloqueo — **no** una reescritura masiva de todas las negaciones (eso sería cambiar por cambiar).

## Tests

Nuevo `tests/roles/point-the-target.test.js`: fija las formas afirmativas y verifica que las negativas de más impacto ya no reaparecen. Suite de roles completa verde (98 tests).

Net ~28 LOC.