### PR TITLE
feat(install-tools): sudo-capable executor and binary downloader (KJC-TSK-0606)

### DIFF
--- a/src/utils/tool-installer.js
+++ b/src/utils/tool-installer.js
@@ -1,0 +1,93 @@
+// Executor primitives for `kj install-tools` (KJC-TSK-0606).
+//
+// Two ways to run an install step:
+//  · runInstallCommand(cmd)                 — captured: stdout/stderr collected,
+//                                             for non-privileged commands.
+//  · runInstallCommand(cmd, {interactive})  — tty inherited: the child owns the
+//                                             terminal so `sudo` prompts the user
+//                                             directly. kj NEVER sees the password.
+//
+// And a downloader for tools shipped as a single static binary (osv-scanner,
+// semgrep) when no package manager is available: fetch → temp file → chmod +x →
+// atomic rename into ~/.local/bin. On any failure it leaves no partial file.
+
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+const execFileAsync = promisify(execFile);
+
+/** Directory where downloaded standalone binaries are placed. */
+export function binDir() {
+  return path.join(os.homedir(), ".local", "bin");
+}
+
+/**
+ * Run an install command. Commands here are simple (no nested quoting), so we
+ * tokenize on whitespace.
+ *
+ * @param {string} command
+ * @param {{ interactive?: boolean }} [opts]
+ *   interactive → inherit the parent's stdio so sudo can prompt for the password
+ *   on the user's own terminal; kj never captures or logs it.
+ */
+export async function runInstallCommand(command, opts = {}) {
+  const [bin, ...args] = command.split(/\s+/);
+  if (opts.interactive) return runInherited(bin, args);
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, args, {
+      timeout: 300_000,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (err) {
+    return { ok: false, error: err?.shortMessage || err?.message || String(err), stderr: err?.stderr };
+  }
+}
+
+function runInherited(bin, args) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(bin, args, { stdio: "inherit", timeout: 600_000 });
+    } catch (err) {
+      resolve({ ok: false, error: err?.message || String(err) });
+      return;
+    }
+    child.on("error", (err) => resolve({ ok: false, error: err?.message || String(err) }));
+    child.on("close", (code) => resolve({ ok: code === 0, code }));
+  });
+}
+
+/**
+ * Download a single static binary and place it (executable) into `dir`.
+ * Writes to a temp file first and renames atomically; on any failure the temp
+ * file is removed so no partial artifact is left behind.
+ *
+ * @param {{ url: string, name: string, dir?: string }} args
+ */
+export async function downloadBinary({ url, name, dir = binDir() }) {
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    return { ok: false, error: `download failed: ${err?.message || String(err)}` };
+  }
+  if (!res.ok) return { ok: false, error: `download failed: HTTP ${res.status}` };
+
+  await fs.mkdir(dir, { recursive: true });
+  const dest = path.join(dir, name);
+  const tmp = path.join(dir, `.${name}.download`);
+  try {
+    const buf = Buffer.from(await res.arrayBuffer());
+    await fs.writeFile(tmp, buf);
+    await fs.chmod(tmp, 0o755);
+    await fs.rename(tmp, dest);
+    return { ok: true, dest };
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    return { ok: false, error: `install failed: ${err?.message || String(err)}` };
+  }
+}

--- a/tests/utils/tool-installer.test.js
+++ b/tests/utils/tool-installer.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runInstallCommand, downloadBinary, binDir } from "../../src/utils/tool-installer.js";
+
+// KJC-TSK-0606 — install-tools executor primitives:
+//  · runInstallCommand: captured (non-interactive) vs tty-inherited (sudo) execution.
+//  · downloadBinary: fetch → temp file → chmod +x → atomic rename into ~/.local/bin.
+
+const NODE = process.execPath;
+
+describe("runInstallCommand — non-interactive (captured)", () => {
+  it("runs a command and captures stdout on success", async () => {
+    const r = await runInstallCommand(`${NODE} -e console.log('ready')`);
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toMatch(/ready/);
+  });
+
+  it("reports failure for a non-existent binary", async () => {
+    const r = await runInstallCommand("kj-nonexistent-binary-xyz --version");
+    expect(r.ok).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+});
+
+describe("runInstallCommand — interactive (tty inherited, for sudo)", () => {
+  it("resolves ok when the child exits 0", async () => {
+    const r = await runInstallCommand(`${NODE} -e process.exit(0)`, { interactive: true });
+    expect(r.ok).toBe(true);
+    expect(r.code).toBe(0);
+  });
+
+  it("resolves not-ok with the exit code when the child fails", async () => {
+    const r = await runInstallCommand(`${NODE} -e process.exit(3)`, { interactive: true });
+    expect(r.ok).toBe(false);
+    expect(r.code).toBe(3);
+  });
+
+  it("reports an error when the binary cannot be spawned", async () => {
+    const r = await runInstallCommand("kj-nonexistent-binary-xyz", { interactive: true });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+});
+
+describe("binDir", () => {
+  it("points at ~/.local/bin", () => {
+    expect(binDir()).toBe(path.join(os.homedir(), ".local", "bin"));
+  });
+});
+
+describe("downloadBinary", () => {
+  let tmpDir;
+  const realFetch = globalThis.fetch;
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (tmpDir) { await fs.rm(tmpDir, { recursive: true, force: true }); tmpDir = null; }
+  });
+
+  it("downloads, makes executable and places the binary", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-tool-"));
+    const body = "#!/bin/sh\necho hi\n";
+    globalThis.fetch = async () => ({ ok: true, status: 200, arrayBuffer: async () => new TextEncoder().encode(body).buffer });
+
+    const r = await downloadBinary({ url: "https://example.test/osv-scanner", name: "osv-scanner", dir: tmpDir });
+    expect(r.ok).toBe(true);
+    expect(r.dest).toBe(path.join(tmpDir, "osv-scanner"));
+
+    const content = await fs.readFile(r.dest, "utf8");
+    expect(content).toBe(body);
+    const mode = (await fs.stat(r.dest)).mode;
+    expect(mode & 0o111).toBeTruthy(); // executable bits set
+  });
+
+  it("reports failure on a non-2xx response", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-tool-"));
+    globalThis.fetch = async () => ({ ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0) });
+
+    const r = await downloadBinary({ url: "https://example.test/missing", name: "missing", dir: tmpDir });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/404/);
+  });
+
+  it("leaves no partial file behind when the download fails", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "kj-tool-"));
+    globalThis.fetch = async () => ({ ok: false, status: 500, arrayBuffer: async () => new ArrayBuffer(0) });
+
+    await downloadBinary({ url: "https://example.test/x", name: "x", dir: tmpDir });
+    const entries = await fs.readdir(tmpDir);
+    expect(entries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Qué

Primitivas de ejecución para que `kj install-tools` **instale de verdad** en una máquina sin ningún gestor de paquetes (no solo diga qué instalar — eso es `kj doctor`).

- `runInstallCommand(cmd)` — ejecución capturada (stdout/stderr) para comandos no privilegiados.
- `runInstallCommand(cmd, { interactive: true })` — hereda el tty del padre con `stdio: "inherit"`, de modo que **sudo pide la contraseña directamente al usuario en su propia terminal**. kj nunca captura ni registra la contraseña.
- `downloadBinary({ url, name, dir })` — descarga un binario estático (osv-scanner, semgrep) a `~/.local/bin` vía fichero temporal → `chmod +x` → rename atómico. Si falla, no deja fichero parcial.
- `binDir()` → `~/.local/bin`.

Es la primera de 5 HUs (KJC-TSK-0606..0610). Esta entrega **solo las primitivas testeables**; el cableado en `install-tools.js` (rutas de binario standalone, apt/dnf con sudo, docker en Linux) va en las HUs siguientes.

## Tests

9 tests nuevos (`tests/utils/tool-installer.test.js`), TDD-first. Cubren éxito/fallo capturado, éxito/fallo/spawn-error interactivo, ruta de `binDir`, y descarga con éxito / 404 / limpieza sin fichero parcial en fallo.

## Presupuesto

187 LOC netas (src 93 + tests 94), bajo el límite de 200 del shrink-budget.