### PR TITLE
feat(install-tools): standalone binary route for osv-scanner + semgrep (KJC-TSK-0607)

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -19,6 +19,8 @@ import fs from "node:fs/promises";
 import { checkBinary } from "../utils/agent-detect.js";
 import { getInstallHint, detectPackageManagers, appliesToStack } from "../utils/install-hints.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
+import { resolveStandalone } from "../utils/binary-sources.js";
+import { downloadBinary, binDir } from "../utils/tool-installer.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -118,6 +120,36 @@ function handleDocker(available) {
 }
 
 /**
+ * Standalone route when no package manager matched: download a static binary
+ * (osv-scanner) or surface a concrete command to run (semgrep).
+ */
+async function handleStandalone({ tool, standalone, manualUrl, dryRun, yes, logger }) {
+  if (standalone.kind === "command") {
+    logger.warn?.(`✗ ${tool}: no package manager. Try: ${standalone.command}  (docs: ${manualUrl})`);
+    return { tool, action: "manual", reason: "no package manager — suggested route below", suggested: standalone.command, via: standalone.via, manualUrl };
+  }
+  // kind === "binary"
+  const { url, name } = standalone;
+  if (dryRun) {
+    logger.info?.(`▸ ${tool}: would download ${url} → ${binDir()}`);
+    return { tool, action: "dry-run", command: `download ${url}`, via: "binary" };
+  }
+  const proceed = yes || await promptYesNo(`Download ${tool} from ${url} into ${binDir()}?`);
+  if (!proceed) {
+    logger.info?.(`⊘ ${tool}: declined`);
+    return { tool, action: "declined", command: `download ${url}` };
+  }
+  logger.info?.(`▸ ${tool}: downloading static binary...`);
+  const r = await downloadBinary({ url, name });
+  if (r.ok) {
+    logger.info?.(`✓ ${tool}: installed → ${r.dest} (ensure ${binDir()} is on PATH)`);
+    return { tool, action: "installed", via: "binary", dest: r.dest };
+  }
+  logger.warn?.(`✗ ${tool}: download failed (${r.error})`);
+  return { tool, action: "failed", via: "binary", error: r.error };
+}
+
+/**
  * Plan + (optionally execute) the install of every requested tool.
  *
  * @param {Object} opts
@@ -178,6 +210,14 @@ export async function installToolsCommand(opts = {}) {
     // semgrep / osv-scanner / lighthouse — package-manager driven.
     const hint = await getInstallHint(tool, available);
     if (!hint.command || !hint.manager) {
+      // No package manager matched — try a standalone route (static binary
+      // for osv-scanner, a concrete command for semgrep) before giving up.
+      const standalone = resolveStandalone(tool, available);
+      if (standalone) {
+        const result = await handleStandalone({ tool, standalone, manualUrl: hint.manualUrl, dryRun, yes, logger });
+        results.push(result);
+        continue;
+      }
       results.push({ tool, action: "manual", reason: "no compatible package manager found", manualUrl: hint.manualUrl, suggested: hint.command });
       logger.warn?.(`✗ ${tool}: no compatible package manager. Manual: ${hint.manualUrl}`);
       continue;

--- a/src/utils/binary-sources.js
+++ b/src/utils/binary-sources.js
@@ -1,0 +1,64 @@
+// Standalone install routes for tools with no package manager available
+// (KJC-TSK-0607). On a machine with no pipx/brew/go, `kj install-tools`
+// still needs a way to install osv-scanner and semgrep.
+//
+//  · osv-scanner ships a single static binary per platform on its GitHub
+//    releases — we build the /latest/download URL for the current platform.
+//  · semgrep has no single static binary; we offer the most viable concrete
+//    command (Docker image if docker exists, otherwise bootstrapping pipx).
+
+const OSV_BASE = "https://github.com/google/osv-scanner/releases/latest/download";
+
+function osvOs(platform) {
+  if (platform === "linux") return "linux";
+  if (platform === "darwin") return "darwin";
+  if (platform === "win32") return "windows";
+  return null;
+}
+
+function osvArch(arch) {
+  if (arch === "x64") return "amd64";
+  if (arch === "arm64") return "arm64";
+  return null;
+}
+
+/**
+ * Build the osv-scanner static-binary download source for a platform+arch,
+ * or null when the combination has no published asset.
+ *
+ * @returns {{ url: string, name: string }|null}
+ */
+export function osvScannerSource(platform = process.platform, arch = process.arch) {
+  const os = osvOs(platform);
+  const a = osvArch(arch);
+  if (!os || !a) return null;
+  const ext = os === "windows" ? ".exe" : "";
+  return { url: `${OSV_BASE}/osv-scanner_${os}_${a}${ext}`, name: `osv-scanner${ext}` };
+}
+
+/**
+ * Most viable concrete route to install semgrep without a package manager.
+ * Returns a command the user sees before it runs — never a bare docs URL.
+ *
+ * @returns {{ via: "docker"|"pipx", command: string }}
+ */
+export function semgrepFallback(available = {}) {
+  if (available.docker) return { via: "docker", command: "docker pull semgrep/semgrep" };
+  return { via: "pipx", command: "python3 -m pip install --user pipx && pipx install semgrep" };
+}
+
+/**
+ * Resolve the standalone route for a tool when no package manager matched.
+ *  · binary  → download a static binary into ~/.local/bin.
+ *  · command → run/show a concrete install command.
+ *
+ * @returns {{ kind: "binary", url: string, name: string }|{ kind: "command", via: string, command: string }|null}
+ */
+export function resolveStandalone(tool, available = {}, platform = process.platform, arch = process.arch) {
+  if (tool === "osv-scanner") {
+    const src = osvScannerSource(platform, arch);
+    return src ? { kind: "binary", ...src } : null;
+  }
+  if (tool === "semgrep") return { kind: "command", ...semgrepFallback(available) };
+  return null;
+}

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -28,6 +28,11 @@ vi.mock("../../src/utils/stack-detect.js", () => ({
   detectProjectStack: vi.fn(async () => ({ isBackend: true, isFrontend: false, isFullstack: false })),
 }));
 
+vi.mock("../../src/utils/tool-installer.js", () => ({
+  downloadBinary: vi.fn(async ({ name }) => ({ ok: true, dest: `/home/u/.local/bin/${name}` })),
+  binDir: vi.fn(() => "/home/u/.local/bin"),
+}));
+
 // Skip child_process exec entirely for these tests — we never want to
 // actually install anything during the test run.
 vi.mock("node:child_process", async (orig) => {
@@ -55,7 +60,8 @@ describe("kj install-tools — dry-run", () => {
     expect(exitCode).toBe(0);
     expect(results.find((r) => r.tool === "semgrep").action).toBe("dry-run");
     expect(results.find((r) => r.tool === "semgrep").command).toBe("pipx install semgrep");
-    expect(results.find((r) => r.tool === "osv-scanner").action).toBe("manual");
+    // osv-scanner has no package manager here, but a static-binary route exists.
+    expect(results.find((r) => r.tool === "osv-scanner").action).toBe("dry-run");
     expect(results.find((r) => r.tool === "lighthouse").action).toBe("skipped");
     expect(results.find((r) => r.tool === "docker").action).toBe("manual");
     expect(results.find((r) => r.tool === "sonar").action).toBe("dry-run");
@@ -90,11 +96,21 @@ describe("kj install-tools — dry-run", () => {
     expect(results[0].action).toBe("already-installed");
   });
 
-  it("flags osv-scanner as manual when no compatible package manager is available", async () => {
+  it("offers osv-scanner via static binary when no package manager is available", async () => {
     const { installToolsCommand } = await import("../../src/commands/install-tools.js");
     const { results } = await installToolsCommand({ dryRun: true, only: "osv-scanner", logger: silentLogger });
-    expect(results[0].action).toBe("manual");
-    expect(results[0].suggested).toBeNull();
+    expect(results[0].action).toBe("dry-run");
+    expect(results[0].via).toBe("binary");
+    expect(results[0].command).toMatch(/osv-scanner_/);
+  });
+
+  it("downloads the osv-scanner binary when accepted (yes)", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { downloadBinary } = await import("../../src/utils/tool-installer.js");
+    const { results } = await installToolsCommand({ yes: true, only: "osv-scanner", logger: silentLogger });
+    expect(downloadBinary).toHaveBeenCalledOnce();
+    expect(results[0].action).toBe("installed");
+    expect(results[0].via).toBe("binary");
   });
 });
 

--- a/tests/utils/binary-sources.test.js
+++ b/tests/utils/binary-sources.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { osvScannerSource, semgrepFallback, resolveStandalone } from "../../src/utils/binary-sources.js";
+
+// KJC-TSK-0607 — standalone routes for tools with no package manager:
+//  · osv-scanner ships a static per-platform binary on its GitHub releases.
+//  · semgrep has no single binary — offer a concrete command (docker / pipx).
+
+describe("osvScannerSource", () => {
+  it("maps linux x64 to the amd64 release asset", () => {
+    const s = osvScannerSource("linux", "x64");
+    expect(s.url).toBe("https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_linux_amd64");
+    expect(s.name).toBe("osv-scanner");
+  });
+
+  it("maps darwin arm64 to the darwin_arm64 asset", () => {
+    const s = osvScannerSource("darwin", "arm64");
+    expect(s.url).toMatch(/osv-scanner_darwin_arm64$/);
+    expect(s.name).toBe("osv-scanner");
+  });
+
+  it("appends .exe on windows", () => {
+    const s = osvScannerSource("win32", "x64");
+    expect(s.url).toMatch(/osv-scanner_windows_amd64\.exe$/);
+    expect(s.name).toBe("osv-scanner.exe");
+  });
+
+  it("returns null for unsupported architecture", () => {
+    expect(osvScannerSource("linux", "ia32")).toBeNull();
+  });
+
+  it("returns null for unsupported platform", () => {
+    expect(osvScannerSource("freebsd", "x64")).toBeNull();
+  });
+});
+
+describe("semgrepFallback", () => {
+  it("prefers the docker image when docker is available", () => {
+    const f = semgrepFallback({ docker: true });
+    expect(f.via).toBe("docker");
+    expect(f.command).toMatch(/semgrep\/semgrep/);
+  });
+
+  it("bootstraps pipx when docker is absent", () => {
+    const f = semgrepFallback({});
+    expect(f.via).toBe("pipx");
+    expect(f.command).toMatch(/pipx install semgrep/);
+  });
+});
+
+describe("resolveStandalone", () => {
+  it("gives osv-scanner a binary route", () => {
+    const r = resolveStandalone("osv-scanner", {}, "linux", "x64");
+    expect(r.kind).toBe("binary");
+    expect(r.url).toMatch(/osv-scanner_linux_amd64$/);
+  });
+
+  it("gives semgrep a command route", () => {
+    const r = resolveStandalone("semgrep", { docker: true });
+    expect(r.kind).toBe("command");
+    expect(r.command).toMatch(/semgrep/);
+  });
+
+  it("returns null for tools with no standalone route", () => {
+    expect(resolveStandalone("lighthouse", {})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Qué

En un equipo sin ningún gestor de paquetes, `kj install-tools` ahora **instala de verdad** osv-scanner y da una vía concreta para semgrep, en vez de un simple enlace a docs.

- **osv-scanner**: descarga el binario estático de la release oficial de GitHub (`osv-scanner_<os>_<arch>`, +`.exe` en Windows) a `~/.local/bin` vía `downloadBinary` (HU A). Avisa de asegurar que `~/.local/bin` esté en el PATH.
- **semgrep**: no tiene binario único; se ofrece la ruta más viable — imagen Docker si docker está disponible, si no bootstrap de pipx — mostrando el comando exacto.
- La **ruta del gestor de paquetes sigue teniendo prioridad**; el binario/comando es el fallback cuando no hay ninguno.

Nuevo `src/utils/binary-sources.js` resuelve la ruta por herramienta (`resolveStandalone`); `install-tools.js` la cablea a través del flujo existente de prompt/dry-run (`handleStandalone`).

## Tests

- `tests/utils/binary-sources.test.js` (10): mapeo os/arch de osv-scanner, `.exe` en Windows, combinaciones no soportadas → null, fallback de semgrep docker/pipx, `resolveStandalone`.
- `tests/commands/install-tools.test.js`: actualizados los casos de osv-scanner (antes "manual", ahora ruta de binario) + nuevo test de descarga real con `tool-installer` mockeado.
- 30 tests verdes en los 3 ficheros afectados.

## Presupuesto

186 LOC netas, bajo el límite de 200.

Segundo de 5 HUs (KJC-TSK-0606..0610). Depende de 0606 (ya en To Validate).