### PR TITLE
feat(install-tools): install Docker on Linux via apt/dnf or official script

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -14,13 +14,15 @@
 import readline from "node:readline";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { checkBinary } from "../utils/agent-detect.js";
 import { getInstallHint, detectPackageManagers, appliesToStack } from "../utils/install-hints.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { resolveStandalone } from "../utils/binary-sources.js";
-import { downloadBinary, binDir } from "../utils/tool-installer.js";
+import { downloadBinary, binDir, runInstallCommand } from "../utils/tool-installer.js";
+import { dockerInstallPlan } from "../utils/docker-install.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -106,17 +108,50 @@ async function handleSonar({ available, dryRun }) {
 }
 
 /**
- * Docker handler: never auto-install (platform-specific, invasive).
- * Always point at the official docs.
+ * Docker handler. On macOS/Windows we never auto-install — point at the docs.
+ * On Linux we offer the distro package manager (apt/dnf) or, failing that, the
+ * official convenience script downloaded to a file. The install runs through
+ * `sudo` on the user's own tty (kj never sees the password) and is opt-in,
+ * defaulting to NO, with the exact command shown first.
  */
-function handleDocker(available) {
-  return {
-    tool: "docker",
-    action: "manual",
-    reason: "Docker install is platform-specific — see official docs.",
-    manualUrl: "https://docs.docker.com/get-docker/",
-    suggested: available.brew ? "brew install --cask docker" : null,
-  };
+async function handleDocker({ available, dryRun, yes, logger }) {
+  const plan = dockerInstallPlan(process.platform, available);
+  if (plan.kind === "manual") {
+    logger.info?.(`▸ docker: ${plan.suggested || plan.manualUrl}`);
+    return { tool: "docker", action: "manual", reason: "Docker install is platform-specific — see official docs.", manualUrl: plan.manualUrl, suggested: plan.suggested };
+  }
+
+  const shownCommand = plan.kind === "package" ? plan.command : `sudo sh <get-docker.sh from ${plan.url}>`;
+  if (dryRun) {
+    logger.info?.(`▸ docker: would run \`${shownCommand}\` (invasive, needs sudo)`);
+    return { tool: "docker", action: "dry-run", command: shownCommand, via: plan.kind };
+  }
+
+  logger.warn?.("docker: this step is invasive and needs sudo — you'll be prompted for your password on your own terminal (kj never sees it).");
+  const proceed = yes || await promptYesNo(`Install Docker with: ${shownCommand}?`, false);
+  if (!proceed) {
+    logger.info?.("⊘ docker: declined");
+    return { tool: "docker", action: "declined", command: shownCommand };
+  }
+
+  if (plan.kind === "package") {
+    logger.info?.(`▸ docker: running \`${plan.command}\`...`);
+    const r = await runInstallCommand(plan.command, { interactive: true });
+    if (r.ok) { logger.info?.(`✓ docker: installed via ${plan.manager}`); return { tool: "docker", action: "installed", via: "package", manager: plan.manager }; }
+    const err = r.error || `exit ${r.code}`;
+    logger.warn?.(`✗ docker: install failed (${err})`);
+    return { tool: "docker", action: "failed", via: "package", error: err };
+  }
+
+  // script route: download to a temp file, then run with sudo — never `curl | sh`.
+  const dl = await downloadBinary({ url: plan.url, name: "get-docker.sh", dir: os.tmpdir() });
+  if (!dl.ok) { logger.warn?.(`✗ docker: script download failed (${dl.error})`); return { tool: "docker", action: "failed", via: "script", error: dl.error }; }
+  logger.info?.(`▸ docker: running \`sudo sh ${dl.dest}\`...`);
+  const r = await runInstallCommand(`sudo sh ${dl.dest}`, { interactive: true });
+  if (r.ok) { logger.info?.("✓ docker: installed via get.docker.com"); return { tool: "docker", action: "installed", via: "script", dest: dl.dest }; }
+  const err = r.error || `exit ${r.code}`;
+  logger.warn?.(`✗ docker: install failed (${err})`);
+  return { tool: "docker", action: "failed", via: "script", error: err };
 }
 
 /**
@@ -201,9 +236,8 @@ export async function installToolsCommand(opts = {}) {
     }
 
     if (tool === "docker") {
-      const result = handleDocker(available);
+      const result = await handleDocker({ available, dryRun, yes, logger });
       results.push(result);
-      logger.info?.(`▸ docker: ${result.suggested || result.manualUrl}`);
       continue;
     }
 

--- a/src/utils/docker-install.js
+++ b/src/utils/docker-install.js
@@ -1,0 +1,34 @@
+// How `kj install-tools` installs Docker, resolved per platform (KJC-TSK-0609,
+// absorbing the sudo+apt/dnf primitive of KJC-TSK-0608).
+//
+//  · Linux: prefer the distro package manager (apt → docker.io, dnf → docker)
+//    run through `sudo` on the user's own tty — kj never sees the password.
+//    When neither is present, fall back to Docker's official convenience
+//    script, which the caller downloads to a file and runs (never `curl | sh`).
+//  · macOS / Windows: never auto-install (platform-specific, invasive) — point
+//    at the official docs, suggesting the brew cask on macOS.
+
+const GET_DOCKER_URL = "https://get.docker.com";
+const DOCKER_DOCS_URL = "https://docs.docker.com/get-docker/";
+
+/**
+ * Resolve the Docker install plan for a platform + available managers.
+ *
+ * @param {string} platform - process.platform value (linux/darwin/win32).
+ * @param {Record<string, boolean>} available - detected package managers.
+ * @returns {{ kind: "package", manager: string, command: string }
+ *          | { kind: "script", url: string }
+ *          | { kind: "manual", manualUrl: string, suggested: string|null }}
+ */
+export function dockerInstallPlan(platform = process.platform, available = {}) {
+  if (platform !== "linux") {
+    return {
+      kind: "manual",
+      manualUrl: DOCKER_DOCS_URL,
+      suggested: available.brew ? "brew install --cask docker" : null,
+    };
+  }
+  if (available.apt) return { kind: "package", manager: "apt", command: "sudo apt-get install -y docker.io" };
+  if (available.dnf) return { kind: "package", manager: "dnf", command: "sudo dnf install -y docker" };
+  return { kind: "script", url: GET_DOCKER_URL };
+}

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -31,6 +31,14 @@ vi.mock("../../src/utils/stack-detect.js", () => ({
 vi.mock("../../src/utils/tool-installer.js", () => ({
   downloadBinary: vi.fn(async ({ name }) => ({ ok: true, dest: `/home/u/.local/bin/${name}` })),
   binDir: vi.fn(() => "/home/u/.local/bin"),
+  runInstallCommand: vi.fn(async () => ({ ok: true })),
+}));
+
+// Docker install plan is platform-dependent; mock it so these tests are
+// deterministic regardless of the host OS. Default: macOS-style manual route.
+// The per-platform logic itself is covered in docker-install.test.js.
+vi.mock("../../src/utils/docker-install.js", () => ({
+  dockerInstallPlan: vi.fn(() => ({ kind: "manual", manualUrl: "https://docs.docker.com/get-docker/", suggested: null })),
 }));
 
 // Skip child_process exec entirely for these tests — we never want to
@@ -111,6 +119,44 @@ describe("kj install-tools — dry-run", () => {
     expect(downloadBinary).toHaveBeenCalledOnce();
     expect(results[0].action).toBe("installed");
     expect(results[0].via).toBe("binary");
+  });
+});
+
+describe("kj install-tools — docker on Linux", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("plans the apt package command in dry-run (invasive, sudo)", async () => {
+    const { dockerInstallPlan } = await import("../../src/utils/docker-install.js");
+    dockerInstallPlan.mockReturnValueOnce({ kind: "package", manager: "apt", command: "sudo apt-get install -y docker.io" });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "docker", logger: silentLogger });
+    expect(results[0].action).toBe("dry-run");
+    expect(results[0].via).toBe("package");
+    expect(results[0].command).toBe("sudo apt-get install -y docker.io");
+  });
+
+  it("runs the apt install with sudo (interactive tty) when accepted", async () => {
+    const { dockerInstallPlan } = await import("../../src/utils/docker-install.js");
+    const { runInstallCommand } = await import("../../src/utils/tool-installer.js");
+    dockerInstallPlan.mockReturnValueOnce({ kind: "package", manager: "apt", command: "sudo apt-get install -y docker.io" });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ yes: true, only: "docker", logger: silentLogger });
+    expect(runInstallCommand).toHaveBeenCalledWith("sudo apt-get install -y docker.io", { interactive: true });
+    expect(results[0].action).toBe("installed");
+    expect(results[0].via).toBe("package");
+  });
+
+  it("downloads the official script to a file and runs it with sudo (never curl|sh)", async () => {
+    const { dockerInstallPlan } = await import("../../src/utils/docker-install.js");
+    const { downloadBinary, runInstallCommand } = await import("../../src/utils/tool-installer.js");
+    dockerInstallPlan.mockReturnValueOnce({ kind: "script", url: "https://get.docker.com" });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ yes: true, only: "docker", logger: silentLogger });
+    expect(downloadBinary).toHaveBeenCalledOnce();
+    expect(downloadBinary.mock.calls[0][0].name).toBe("get-docker.sh");
+    expect(runInstallCommand).toHaveBeenCalledWith(expect.stringMatching(/^sudo sh /), { interactive: true });
+    expect(results[0].action).toBe("installed");
+    expect(results[0].via).toBe("script");
   });
 });
 

--- a/tests/utils/docker-install.test.js
+++ b/tests/utils/docker-install.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { dockerInstallPlan } from "../../src/utils/docker-install.js";
+
+// KJC-TSK-0609 — how `kj install-tools` installs Docker per platform.
+//  · Linux: prefer the distro package manager (apt/dnf), else the official
+//    convenience script — downloaded to a file, never piped blindly into sh.
+//  · macOS/Windows: never auto-install; point at the official docs.
+
+describe("dockerInstallPlan — Linux", () => {
+  it("prefers apt (docker.io) with sudo when apt is available", () => {
+    const p = dockerInstallPlan("linux", { apt: true, dnf: false });
+    expect(p.kind).toBe("package");
+    expect(p.manager).toBe("apt");
+    expect(p.command).toBe("sudo apt-get install -y docker.io");
+  });
+
+  it("uses dnf (docker) with sudo when only dnf is available", () => {
+    const p = dockerInstallPlan("linux", { apt: false, dnf: true });
+    expect(p.kind).toBe("package");
+    expect(p.manager).toBe("dnf");
+    expect(p.command).toBe("sudo dnf install -y docker");
+  });
+
+  it("prefers apt over dnf when both are present", () => {
+    const p = dockerInstallPlan("linux", { apt: true, dnf: true });
+    expect(p.manager).toBe("apt");
+  });
+
+  it("falls back to the official script when no package manager matches", () => {
+    const p = dockerInstallPlan("linux", { apt: false, dnf: false });
+    expect(p.kind).toBe("script");
+    expect(p.url).toBe("https://get.docker.com");
+  });
+});
+
+describe("dockerInstallPlan — macOS / Windows", () => {
+  it("never auto-installs on macOS; suggests brew cask when present", () => {
+    const p = dockerInstallPlan("darwin", { brew: true });
+    expect(p.kind).toBe("manual");
+    expect(p.suggested).toBe("brew install --cask docker");
+    expect(p.manualUrl).toMatch(/get-docker/);
+  });
+
+  it("never auto-installs on Windows; no brew suggestion", () => {
+    const p = dockerInstallPlan("win32", {});
+    expect(p.kind).toBe("manual");
+    expect(p.suggested).toBeNull();
+    expect(p.manualUrl).toMatch(/get-docker/);
+  });
+});


### PR DESCRIPTION
## KJC-TSK-0609 — Docker install on Linux (opt-in, absorbs KJC-TSK-0608)

`kj install-tools` can now actually install Docker on Linux instead of just linking the docs:

- **apt** → `sudo apt-get install -y docker.io`; **dnf** → `sudo dnf install -y docker`.
- No package manager → the official `get.docker.com` script **downloaded to a file** and run with sudo — never `curl | sh`.
- **Opt-in**, defaults to **NO**, warns it is invasive. sudo runs on the user's own tty, so **kj never sees the password**.
- **macOS/Windows** keep the docs pointer (brew cask suggestion on macOS).

### Why it absorbs 0608
The generic sudo+apt/dnf primitive was going to be HU C on its own, but semgrep/osv-scanner/lighthouse aren't packaged in apt/dnf (osv-scanner already ships as a static binary from HU B). Docker is the primitive's only reliable consumer in the current tool set, so building it here avoids dead scaffolding (YAGNI).

### Tests
- `docker-install.test.js`: per-platform plan (apt/dnf/script/manual) — 6 cases.
- `install-tools.test.js`: dry-run plan, sudo interactive run, script download-to-file — mocks `dockerInstallPlan` so it's OS-independent.
- 160 tests green across commands + related utils. Net +164 LOC (under the 200 gate).

Board: KJC-TSK-0609 (epic KJC-PCS-0006). KJC-TSK-0608 absorbed.