### PR TITLE
feat(install-tools): name real deps and point at kj doctor

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -89,7 +89,7 @@ async function handleSonar({ available, dryRun }) {
     return {
       tool: "sonar",
       action: "manual",
-      reason: "docker not available — sonar needs docker. Install docker first.",
+      reason: "SonarQube runs as a Docker container — install Docker first (kj install-tools --only docker), then re-run.",
       manualUrl: "https://docs.docker.com/get-docker/",
     };
   }
@@ -160,7 +160,7 @@ async function handleDocker({ available, dryRun, yes, logger }) {
  */
 async function handleStandalone({ tool, standalone, manualUrl, dryRun, yes, logger }) {
   if (standalone.kind === "command") {
-    logger.warn?.(`✗ ${tool}: no package manager. Try: ${standalone.command}  (docs: ${manualUrl})`);
+    logger.warn?.(`✗ ${tool}: no package manager here. Try: ${standalone.command}  ·  \`kj doctor\` shows what's missing (docs: ${manualUrl})`);
     return { tool, action: "manual", reason: "no package manager — suggested route below", suggested: standalone.command, via: standalone.via, manualUrl };
   }
   // kind === "binary"
@@ -223,7 +223,8 @@ export async function installToolsCommand(opts = {}) {
     if (tool === "sonar") {
       const result = await handleSonar({ available, dryRun });
       results.push(result);
-      logger.info?.(`▸ sonar: ${result.command || result.manualUrl}`);
+      if (result.action === "manual") logger.warn?.(`✗ sonar: ${result.reason}`);
+      else logger.info?.(`▸ sonar: ${result.command}`);
       if (!dryRun && result.action === "ready") {
         const proceed = yes || await promptYesNo(`Start SonarQube with: ${result.command}?`);
         if (proceed) {
@@ -253,7 +254,7 @@ export async function installToolsCommand(opts = {}) {
         continue;
       }
       results.push({ tool, action: "manual", reason: "no compatible package manager found", manualUrl: hint.manualUrl, suggested: hint.command });
-      logger.warn?.(`✗ ${tool}: no compatible package manager. Manual: ${hint.manualUrl}`);
+      logger.warn?.(`✗ ${tool}: no automatic install route here. Run \`kj doctor\` for options, or install manually: ${hint.manualUrl}`);
       continue;
     }
     if (dryRun) {

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -160,6 +160,43 @@ describe("kj install-tools — docker on Linux", () => {
   });
 });
 
+describe("kj install-tools — clearer messaging (KJC-TSK-0610)", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("names the Docker-container dependency for sonar instead of a bare URL", async () => {
+    const { detectPackageManagers } = await import("../../src/utils/install-hints.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: true, brew: false, go: false, npm: true, pip: false, apt: false, dnf: false, choco: false, scoop: false, docker: false,
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "sonar", logger });
+    const sonar = results.find((r) => r.tool === "sonar");
+    expect(sonar.action).toBe("manual");
+    expect(sonar.reason).toMatch(/Docker container/);
+    expect(sonar.reason).toMatch(/install-tools --only docker/);
+    const warned = logger.warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warned).toMatch(/Docker container/);
+  });
+
+  it("names a concrete route for a tool with no package manager, and points at kj doctor", async () => {
+    const { detectPackageManagers, getInstallHint } = await import("../../src/utils/install-hints.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: false, brew: false, go: false, npm: false, pip: false, apt: false, dnf: false, choco: false, scoop: false, docker: true,
+    });
+    getInstallHint.mockResolvedValueOnce({ command: null, manager: null, manualUrl: "https://semgrep.dev" });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "semgrep", logger });
+    const semgrep = results.find((r) => r.tool === "semgrep");
+    expect(semgrep.action).toBe("manual");
+    expect(semgrep.suggested).toMatch(/docker pull semgrep/);
+    const warned = logger.warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warned).toMatch(/docker pull semgrep/);
+    expect(warned).toMatch(/kj doctor/);
+  });
+});
+
 describe("kj install-tools — stack-aware lighthouse", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 


### PR DESCRIPTION
## Qué

Mejora la mensajería de `kj install-tools` para que quede claro que **install-tools instala** y **doctor diagnostica**, sin solapar mensajes (KJC-TSK-0610, épica KJC-PCS-0006).

- **sonar sin Docker**: antes soltaba la URL de get-docker a secas. Ahora dice explícitamente que SonarQube corre como contenedor Docker y da el paso concreto (`kj install-tools --only docker`).
- **herramienta sin gestor de paquetes**: el aviso nombra la vía concreta (ej. `docker pull semgrep`) y apunta a `kj doctor` para ver qué falta, en vez de un genérico "no compatible package manager".

## Criterios de aceptación

- [x] sonar sin Docker: mensaje explícito de dependencia + siguiente paso, no URL a secas.
- [x] tool sin gestor: nombra qué instalar / vía de binario.
- [x] separación clara install-tools (instala) vs doctor (diagnostica).

## Tests

3 tests nuevos en `tests/commands/install-tools.test.js` (16/16 verdes). Net ~38 LOC.