### PR TITLE
feat(install-tools): install git as a required tool (KJC-TSK-0611)

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -18,7 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { checkBinary } from "../utils/agent-detect.js";
-import { getInstallHint, detectPackageManagers, appliesToStack } from "../utils/install-hints.js";
+import { getInstallHint, detectPackageManagers, appliesToStack, gitInstallPlan } from "../utils/install-hints.js";
 import { detectProjectStack } from "../utils/stack-detect.js";
 import { resolveStandalone } from "../utils/binary-sources.js";
 import { downloadBinary, binDir, runInstallCommand } from "../utils/tool-installer.js";
@@ -26,7 +26,9 @@ import { dockerInstallPlan } from "../utils/docker-install.js";
 
 const execFileAsync = promisify(execFile);
 
-const ALL_TOOLS = ["semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
+// git leads the list: it is a `kj doctor` *required* tool, so a blank machine
+// wants it before the optional audit tools.
+const ALL_TOOLS = ["git", "semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
 
 function parseOnlyList(raw) {
   if (!raw) return null;
@@ -59,6 +61,43 @@ async function isInstalled(tool) {
   if (tool === "lighthouse") return (await checkBinary("lighthouse")).ok;
   if (tool === "docker") return (await checkBinary("docker")).ok;
   return (await checkBinary(tool)).ok;
+}
+
+/**
+ * git handler. git installs through the OS package manager; on Linux that
+ * needs root, so those runs go through the interactive (tty-inherited) path
+ * where sudo prompts the user directly — kj never captures the password. The
+ * exact command is shown first and the install is opt-in, defaulting to NO for
+ * the privileged case. When no package manager matches, we surface the manual
+ * download URL instead of failing silently.
+ */
+async function handleGit({ available, dryRun, yes, logger }) {
+  const plan = gitInstallPlan(available);
+  if (!plan.command) {
+    logger.warn?.(`✗ git: no supported package manager here — install manually: ${plan.manualUrl}`);
+    return { tool: "git", action: "manual", reason: "no supported package manager found", manualUrl: plan.manualUrl };
+  }
+  if (dryRun) {
+    logger.info?.(`▸ git: would run \`${plan.command}\` (manager: ${plan.manager}${plan.needsSudo ? ", needs sudo" : ""})`);
+    return { tool: "git", action: "dry-run", command: plan.command, manager: plan.manager };
+  }
+  if (plan.needsSudo) {
+    logger.warn?.("git: this step needs sudo — you'll be prompted for your password on your own terminal (kj never sees it).");
+  }
+  const proceed = yes || await promptYesNo(`Install git with: ${plan.command}?`, !plan.needsSudo);
+  if (!proceed) {
+    logger.info?.("⊘ git: declined");
+    return { tool: "git", action: "declined", command: plan.command };
+  }
+  logger.info?.(`▸ git: running \`${plan.command}\`...`);
+  const r = await runInstallCommand(plan.command, { interactive: plan.needsSudo });
+  if (r.ok) {
+    logger.info?.(`✓ git: installed via ${plan.manager}`);
+    return { tool: "git", action: "installed", manager: plan.manager };
+  }
+  const err = r.error || `exit ${r.code}`;
+  logger.warn?.(`✗ git: install failed (${err})`);
+  return { tool: "git", action: "failed", command: plan.command, error: err };
 }
 
 async function checkSonarRunning() {
@@ -233,6 +272,12 @@ export async function installToolsCommand(opts = {}) {
           if (!r.ok) result.error = r.error;
         }
       }
+      continue;
+    }
+
+    if (tool === "git") {
+      const result = await handleGit({ available, dryRun, yes, logger });
+      results.push(result);
       continue;
     }
 

--- a/src/utils/install-hints.js
+++ b/src/utils/install-hints.js
@@ -116,7 +116,35 @@ const MANUAL_URLS = {
   "osv-scanner": "https://google.github.io/osv-scanner/installation/",
   lighthouse: "https://github.com/GoogleChrome/lighthouse#using-the-cli",
   docker: "https://docs.docker.com/get-docker/",
+  git: "https://git-scm.com/downloads",
 };
+
+// git is a `kj doctor` *required* tool. Unlike the audit tools it is installed
+// through the OS package manager, and on Linux that needs root — so the plan
+// carries a `needsSudo` flag and the caller runs those through the interactive
+// (tty-inherited) path, where sudo prompts the user directly and kj never sees
+// the password. brew/scoop/choco install at user scope, no sudo.
+const GIT_CANDIDATES = [
+  { manager: "brew", command: "brew install git", needsSudo: false },
+  { manager: "apt", command: "sudo apt-get install -y git", needsSudo: true },
+  { manager: "dnf", command: "sudo dnf install -y git", needsSudo: true },
+  { manager: "choco", command: "choco install git -y", needsSudo: false },
+  { manager: "scoop", command: "scoop install git", needsSudo: false },
+];
+
+/**
+ * Pick a git install plan for the current machine. Returns a manual plan
+ * (command null + URL) when no supported package manager is present.
+ *
+ * @param {Record<PackageManager, boolean>} available
+ * @returns {{ command: string|null, manager: PackageManager|null, needsSudo: boolean, manualUrl: string }}
+ */
+export function gitInstallPlan(available = {}) {
+  for (const { manager, command, needsSudo } of GIT_CANDIDATES) {
+    if (available[manager]) return { command, manager, needsSudo, manualUrl: MANUAL_URLS.git };
+  }
+  return { command: null, manager: null, needsSudo: false, manualUrl: MANUAL_URLS.git };
+}
 
 /**
  * Tools whose hint depends on the project stack. lighthouse is only

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -22,6 +22,12 @@ vi.mock("../../src/utils/install-hints.js", () => ({
     if (tool === "lighthouse") return Boolean(stack?.isFrontend || stack?.isFullstack);
     return true;
   }),
+  gitInstallPlan: vi.fn((available) => {
+    const url = "https://git-scm.com/downloads";
+    if (available?.brew) return { command: "brew install git", manager: "brew", needsSudo: false, manualUrl: url };
+    if (available?.apt) return { command: "sudo apt-get install -y git", manager: "apt", needsSudo: true, manualUrl: url };
+    return { command: null, manager: null, needsSudo: false, manualUrl: url };
+  }),
 }));
 
 vi.mock("../../src/utils/stack-detect.js", () => ({
@@ -157,6 +163,50 @@ describe("kj install-tools — docker on Linux", () => {
     expect(runInstallCommand).toHaveBeenCalledWith(expect.stringMatching(/^sudo sh /), { interactive: true });
     expect(results[0].action).toBe("installed");
     expect(results[0].via).toBe("script");
+  });
+});
+
+describe("kj install-tools — git (required tool)", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("plans the apt install with sudo in dry-run", async () => {
+    const { detectPackageManagers } = await import("../../src/utils/install-hints.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: true, brew: false, go: false, npm: true, pip: false, apt: true, dnf: false, choco: false, scoop: false, docker: true,
+    });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "git", logger: silentLogger });
+    const git = results.find((r) => r.tool === "git");
+    expect(git.action).toBe("dry-run");
+    expect(git.command).toBe("sudo apt-get install -y git");
+    expect(git.manager).toBe("apt");
+  });
+
+  it("runs the apt install through the interactive tty (sudo) when accepted", async () => {
+    const { detectPackageManagers } = await import("../../src/utils/install-hints.js");
+    const { runInstallCommand } = await import("../../src/utils/tool-installer.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: true, brew: false, go: false, npm: true, pip: false, apt: true, dnf: false, choco: false, scoop: false, docker: true,
+    });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ yes: true, only: "git", logger: silentLogger });
+    expect(runInstallCommand).toHaveBeenCalledWith("sudo apt-get install -y git", { interactive: true });
+    expect(results.find((r) => r.tool === "git").action).toBe("installed");
+  });
+
+  it("surfaces a manual route (no silent failure) when no package manager matches", async () => {
+    const { detectPackageManagers } = await import("../../src/utils/install-hints.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: false, brew: false, go: false, npm: false, pip: false, apt: false, dnf: false, choco: false, scoop: false, docker: false,
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "git", logger });
+    const git = results.find((r) => r.tool === "git");
+    expect(git.action).toBe("manual");
+    expect(git.manualUrl).toMatch(/git-scm\.com/);
+    const warned = logger.warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warned).toMatch(/git-scm\.com/);
   });
 });
 

--- a/tests/utils/install-hints.test.js
+++ b/tests/utils/install-hints.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getInstallHint, appliesToStack, resetPackageManagerCache } from "../../src/utils/install-hints.js";
+import { getInstallHint, appliesToStack, gitInstallPlan, resetPackageManagerCache } from "../../src/utils/install-hints.js";
 
 // KJC-TSK v2.18 — platform-aware install hints for external audit tools.
 
@@ -77,5 +77,44 @@ describe("appliesToStack — stack gating", () => {
     expect(appliesToStack("semgrep", null)).toBe(true);
     expect(appliesToStack("osv-scanner", { isBackend: true })).toBe(true);
     expect(appliesToStack("docker", {})).toBe(true);
+  });
+});
+
+describe("gitInstallPlan — package-manager selection", () => {
+  it("prefers brew (user-level, no sudo) on macOS", () => {
+    const plan = gitInstallPlan({ brew: true, apt: true });
+    expect(plan.command).toBe("brew install git");
+    expect(plan.manager).toBe("brew");
+    expect(plan.needsSudo).toBe(false);
+  });
+
+  it("uses apt with sudo when brew is absent", () => {
+    const plan = gitInstallPlan({ brew: false, apt: true });
+    expect(plan.command).toBe("sudo apt-get install -y git");
+    expect(plan.manager).toBe("apt");
+    expect(plan.needsSudo).toBe(true);
+  });
+
+  it("uses dnf with sudo when only dnf is available", () => {
+    const plan = gitInstallPlan({ dnf: true });
+    expect(plan.command).toBe("sudo dnf install -y git");
+    expect(plan.needsSudo).toBe(true);
+  });
+
+  it("uses choco/scoop on Windows (no sudo)", () => {
+    expect(gitInstallPlan({ choco: true }).command).toBe("choco install git -y");
+    expect(gitInstallPlan({ choco: true }).needsSudo).toBe(false);
+    expect(gitInstallPlan({ scoop: true }).command).toBe("scoop install git");
+  });
+
+  it("returns a manual plan with URL when no manager matches", () => {
+    const plan = gitInstallPlan({});
+    expect(plan.command).toBeNull();
+    expect(plan.manager).toBeNull();
+    expect(plan.manualUrl).toMatch(/git-scm\.com/);
+  });
+
+  it("always includes the manual URL", () => {
+    expect(gitInstallPlan({ brew: true }).manualUrl).toMatch(/git-scm\.com/);
   });
 });


### PR DESCRIPTION
## Qué

`kj install-tools` solo cubría las herramientas de auditoría (semgrep, osv-scanner, lighthouse, docker, sonar). Pero `git` es una herramienta **required** según `kj doctor`, así que una máquina casi en blanco seguía sin poder operar tras un `install-tools`.

Este PR añade `git` como primer tool de la lista:

- `gitInstallPlan(available)` en `install-hints.js` — selección por package manager con orden de preferencia **brew > apt > dnf > choco > scoop**, marcando `needsSudo` en apt/dnf (Linux, root).
- `handleGit` en `install-tools.js` — los installs privilegiados (sudo) van por la ruta **interactiva (tty heredada)**: sudo pide la contraseña directamente al usuario y **kj nunca la captura ni la loguea**. Comando exacto mostrado antes, opt-in (default NO en el caso privilegiado).
- Sin fallos silenciosos: si ningún package manager encaja, se muestra la URL manual (git-scm.com).

## Scope

Parte 1 de 2 de KJC-TSK-0611. La parte 2 (agente CLI claude+codex) va en PR aparte para respetar el shrink-budget.

## Tests

- 6 tests de `gitInstallPlan` (selección por manager, sudo, manual).
- 3 tests de `handleGit` (dry-run apt, install interactivo con sudo, ruta manual).
- Suite de ambos ficheros: 38/38 verde. Neto: 162 LOC (< 200).