### PR TITLE
feat(install-tools): install the agent CLI (claude+codex) as required (KJC-TSK-0611)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -226,7 +226,7 @@ export function registerPipeline(program, { pkgVersion }) {
 
   program
     .command("install-tools")
-    .description("Install external audit tools (semgrep, osv-scanner, lighthouse, docker, sonar) using the package manager available on your system")
+    .description("Install the tools kj needs (git, agent CLI: claude+codex) plus the external audit tools (semgrep, osv-scanner, lighthouse, docker, sonar) using the package manager available on your system")
     .option("--only <tools>", "Comma-separated subset (e.g. \"semgrep,osv-scanner\"). Bypasses stack-gating.")
     .option("-y, --yes", "Auto-accept all prompts (non-interactive)")
     .option("--dry-run", "Show what would be installed without running anything")

--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -26,9 +26,17 @@ import { dockerInstallPlan } from "../utils/docker-install.js";
 
 const execFileAsync = promisify(execFile);
 
-// git leads the list: it is a `kj doctor` *required* tool, so a blank machine
-// wants it before the optional audit tools.
-const ALL_TOOLS = ["git", "semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
+// git and the agent CLI lead the list: both are `kj doctor` *required* tools,
+// so a blank machine wants them before the optional audit tools.
+const ALL_TOOLS = ["git", "agent-cli", "semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
+
+// The default pipeline is coder=claude, reviewer=codex, so `agent-cli` installs
+// exactly those two. gemini stays out of the default: it is a supported
+// reviewer, not a required one. Both ship as global npm packages.
+const AGENT_CLIS = [
+  { bin: "claude", pkg: "@anthropic-ai/claude-code", url: "https://docs.anthropic.com/en/docs/claude-code" },
+  { bin: "codex", pkg: "@openai/codex", url: "https://github.com/openai/codex" },
+];
 
 function parseOnlyList(raw) {
   if (!raw) return null;
@@ -58,9 +66,61 @@ async function isInstalled(tool) {
   // sonar is a Docker container, not a binary. We check it separately
   // by looking at running containers via `docker ps`.
   if (tool === "sonar") return checkSonarRunning();
+  // agent-cli is "installed" only when BOTH default-pipeline CLIs are present;
+  // a partial install (one of two) still routes to handleAgentCli.
+  if (tool === "agent-cli") {
+    const present = await Promise.all(AGENT_CLIS.map(async (c) => (await checkBinary(c.bin)).ok));
+    return present.every(Boolean);
+  }
   if (tool === "lighthouse") return (await checkBinary("lighthouse")).ok;
   if (tool === "docker") return (await checkBinary("docker")).ok;
   return (await checkBinary(tool)).ok;
+}
+
+/**
+ * Agent-CLI handler. Installs whichever of the default-pipeline CLIs
+ * (coder=claude, reviewer=codex) are missing, via global npm. Opt-in with the
+ * exact command shown first. When npm itself is absent we surface the manual
+ * commands + URLs rather than failing silently.
+ */
+async function handleAgentCli({ available, dryRun, yes, logger }) {
+  const missing = [];
+  for (const cli of AGENT_CLIS) {
+    if (!(await checkBinary(cli.bin)).ok) missing.push(cli);
+  }
+  if (missing.length === 0) return { tool: "agent-cli", action: "already-installed" };
+
+  if (!available.npm) {
+    const commands = missing.map((c) => `npm install -g ${c.pkg}`);
+    logger.warn?.(`✗ agent-cli: npm not found — install manually: ${commands.join(" ; ")}`);
+    return { tool: "agent-cli", action: "manual", reason: "npm not available", missing: missing.map((c) => c.bin), commands, manualUrls: missing.map((c) => c.url) };
+  }
+
+  const installed = [];
+  for (const cli of missing) {
+    const command = `npm install -g ${cli.pkg}`;
+    if (dryRun) {
+      logger.info?.(`▸ ${cli.bin}: would run \`${command}\``);
+      installed.push({ bin: cli.bin, action: "dry-run", command });
+      continue;
+    }
+    const proceed = yes || await promptYesNo(`Install ${cli.bin} with: ${command}?`);
+    if (!proceed) {
+      logger.info?.(`⊘ ${cli.bin}: declined`);
+      installed.push({ bin: cli.bin, action: "declined", command });
+      continue;
+    }
+    logger.info?.(`▸ ${cli.bin}: running \`${command}\`...`);
+    const r = await runInstallCommand(command, { interactive: false });
+    if (r.ok) { logger.info?.(`✓ ${cli.bin}: installed`); installed.push({ bin: cli.bin, action: "installed", command }); }
+    else { const err = r.error || `exit ${r.code}`; logger.warn?.(`✗ ${cli.bin}: install failed (${err})`); installed.push({ bin: cli.bin, action: "failed", command, error: err }); }
+  }
+
+  const action = dryRun ? "dry-run"
+    : installed.some((r) => r.action === "failed") ? "failed"
+    : installed.some((r) => r.action === "installed") ? "installed"
+    : "declined";
+  return { tool: "agent-cli", action, installed };
 }
 
 /**
@@ -277,6 +337,12 @@ export async function installToolsCommand(opts = {}) {
 
     if (tool === "git") {
       const result = await handleGit({ available, dryRun, yes, logger });
+      results.push(result);
+      continue;
+    }
+
+    if (tool === "agent-cli") {
+      const result = await handleAgentCli({ available, dryRun, yes, logger });
       results.push(result);
       continue;
     }

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -210,6 +210,66 @@ describe("kj install-tools — git (required tool)", () => {
   });
 });
 
+describe("kj install-tools — agent CLI (required tool)", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("plans npm installs for both default CLIs (claude + codex) in dry-run", async () => {
+    // default checkBinary mock → both absent
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "agent-cli", logger: silentLogger });
+    const agent = results.find((r) => r.tool === "agent-cli");
+    expect(agent.action).toBe("dry-run");
+    expect(agent.installed.map((i) => i.command)).toEqual([
+      "npm install -g @anthropic-ai/claude-code",
+      "npm install -g @openai/codex",
+    ]);
+  });
+
+  it("installs both via npm when accepted (yes)", async () => {
+    const { runInstallCommand } = await import("../../src/utils/tool-installer.js");
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ yes: true, only: "agent-cli", logger: silentLogger });
+    expect(runInstallCommand).toHaveBeenCalledWith("npm install -g @anthropic-ai/claude-code", { interactive: false });
+    expect(runInstallCommand).toHaveBeenCalledWith("npm install -g @openai/codex", { interactive: false });
+    expect(results.find((r) => r.tool === "agent-cli").action).toBe("installed");
+  });
+
+  it("reports already-installed when both CLIs are present", async () => {
+    const { checkBinary } = await import("../../src/utils/agent-detect.js");
+    checkBinary.mockResolvedValue({ ok: true, version: "1.0.0", path: "/usr/bin/x" });
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "agent-cli", logger: silentLogger });
+    expect(results.find((r) => r.tool === "agent-cli").action).toBe("already-installed");
+  });
+
+  it("installs only the missing CLI when the other is present", async () => {
+    const { checkBinary } = await import("../../src/utils/agent-detect.js");
+    checkBinary.mockImplementation(async (bin) => ({ ok: bin === "claude", version: null, path: null }));
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "agent-cli", logger: silentLogger });
+    const agent = results.find((r) => r.tool === "agent-cli");
+    expect(agent.installed).toHaveLength(1);
+    expect(agent.installed[0].command).toBe("npm install -g @openai/codex");
+  });
+
+  it("surfaces manual commands (no silent failure) when npm is absent", async () => {
+    const { checkBinary } = await import("../../src/utils/agent-detect.js");
+    checkBinary.mockResolvedValue({ ok: false, version: null, path: null }); // both CLIs absent
+    const { detectPackageManagers } = await import("../../src/utils/install-hints.js");
+    detectPackageManagers.mockResolvedValueOnce({
+      pipx: true, brew: false, go: false, npm: false, pip: false, apt: false, dnf: false, choco: false, scoop: false, docker: true,
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { results } = await installToolsCommand({ dryRun: true, only: "agent-cli", logger });
+    const agent = results.find((r) => r.tool === "agent-cli");
+    expect(agent.action).toBe("manual");
+    expect(agent.commands).toContain("npm install -g @anthropic-ai/claude-code");
+    const warned = logger.warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warned).toMatch(/npm install -g @openai\/codex/);
+  });
+});
+
 describe("kj install-tools — clearer messaging (KJC-TSK-0610)", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 


### PR DESCRIPTION
## Qué

Segunda parte de KJC-TSK-0611. Tras PR #1171 (git), una máquina casi en blanco aún se quedaba sin **agente CLI**, que `kj doctor` marca como **required** (≥1 CLI de agente). Este PR añade un step `agent-cli` a `kj install-tools` que instala los CLIs del pipeline por defecto: **coder=claude, reviewer=codex**.

- `handleAgentCli` detecta cuáles de los dos faltan (`checkBinary`) e instala solo los ausentes vía **npm global** (`npm install -g @anthropic-ai/claude-code`, `npm install -g @openai/codex`), opt-in con el comando exacto mostrado antes.
- Ambos presentes → `already-installed`. Uno presente → instala solo el que falta.
- **gemini queda fuera del default**: es un reviewer soportado, no requerido.
- Sin npm → `action:"manual"` con los comandos + URLs (sin fallo silencioso).
- Descripción del comando `install-tools` actualizada para reflejar git + agent CLI.

## Scope

Cierra KJC-TSK-0611 (parte 2 de 2). Decisión de scope del usuario: "solo claude y codex".

## Tests

- 5 tests de `agent-cli` (dry-run ambos, install ambos, already-installed, install parcial, manual sin npm).
- Suite install-tools: 24/24 verde. Suite completa: 5999/5999. Neto: 126 LOC (< 150).