### PR TITLE
fix(update): hide npm noise on successful kj update

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -304,26 +304,11 @@ export function registerMeta(program, { pkgVersion }) {
     .command("update")
     .description("Update karajan-code to the latest version from npm")
     .action(async () => {
-      // Audit follow-up: was execaCommand (shell parsing). Inputs are
-      // constants today, but the project standard since #555 is execa
-      // with arg arrays (no shell). Migrated for consistency.
-      const { execa } = await import("execa");
-      console.log(`Current version: ${pkgVersion}`);
-      console.log("Checking for updates...");
-      try {
-        const { stdout } = await execa("npm", ["view", "karajan-code", "version"]);
-        const latest = stdout.trim();
-        if (latest === pkgVersion) {
-          console.log(`Already on the latest version (${pkgVersion}).`);
-          return;
-        }
-        console.log(`Updating ${pkgVersion} → ${latest}...`);
-        await execa("npm", ["install", "-g", "karajan-code@latest"], { stdio: "inherit" });
-        console.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
-      } catch (err) {
-        console.error(`Update failed: ${err.message}`);
-        process.exit(1);
-      }
+      // Output-capturing self-update: npm's deprecation/allow-scripts/funding
+      // warnings are hidden on success and only surfaced when the install fails.
+      const { performSelfUpdate } = await import("../utils/update-check.js");
+      const result = await performSelfUpdate({ currentVersion: pkgVersion });
+      if (!result.ok) process.exit(1);
     });
 
   program

--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -103,6 +103,53 @@ export async function printUpdateNotice(currentVersion) {
   }
 }
 
+/**
+ * Run the npm-channel self-update (`kj update`). Captures npm's output instead
+ * of streaming it: a successful update shows only the progress + result line,
+ * so npm's deprecation / allow-scripts / funding noise — build plumbing, not
+ * actionable for whoever runs the command — never reaches the user. On failure
+ * the captured stdout/stderr IS surfaced, so real errors (native build,
+ * permissions) stay diagnosable — never a silent failure.
+ *
+ * @param {Object} opts
+ * @param {string} opts.currentVersion - version of the running kj
+ * @param {(cmd: string, args: string[]) => Promise<{stdout: string, stderr: string}>} [opts.exec] - injectable runner (defaults to execa)
+ * @param {Console} [opts.logger]
+ * @returns {Promise<{ ok: boolean, alreadyLatest?: boolean, latest?: string }>}
+ */
+export async function performSelfUpdate({ currentVersion, exec, logger = console } = {}) {
+  const run = exec || (async (cmd, args) => (await import("execa")).execa(cmd, args));
+  logger.log(`Current version: ${currentVersion}`);
+  logger.log("Checking for updates...");
+
+  let latest;
+  try {
+    const { stdout } = await run("npm", ["view", PACKAGE_NAME, "version"]);
+    latest = stdout.trim();
+  } catch (err) {
+    logger.error(`Update failed: ${err.shortMessage || err.message}`);
+    return { ok: false };
+  }
+
+  if (latest === currentVersion) {
+    logger.log(`Already on the latest version (${currentVersion}).`);
+    return { ok: true, alreadyLatest: true, latest };
+  }
+
+  logger.log(`Updating ${currentVersion} → ${latest}... (this can take a few minutes)`);
+  try {
+    // No stdio:inherit — capture and drop npm's warnings on the success path.
+    await run("npm", ["install", "-g", `${PACKAGE_NAME}@latest`]);
+    logger.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
+    return { ok: true, latest };
+  } catch (err) {
+    if (err.stdout) logger.error(err.stdout);
+    if (err.stderr) logger.error(err.stderr);
+    logger.error(`Update failed: ${err.shortMessage || err.message}`);
+    return { ok: false };
+  }
+}
+
 /** Simple semver compare: returns >0 if a > b, <0 if a < b, 0 if equal */
 function compareVersions(a, b) {
   const pa = a.split(".").map(Number);

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -100,7 +100,14 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // autorun action lazy-imports the spec resolver and the autorun chain
 // (which pulls in the heavy plan + run pipelines) only when invoked, so a
 // plain `kj` startup never loads them.
-const DYNAMIC_IMPORT_BUDGET = 169;
+//
+// 2026-07-15 (KJC-TSK-0612 clean `kj update` output): bumped 169 → 170 for
+// the lazy `await import("execa")` inside `performSelfUpdate`
+// (src/utils/update-check.js). update-check.js is loaded on EVERY startup
+// (printUpdateNotice in cli.js), but execa is only needed by the `kj update`
+// path — a static import would pull the heavy child-process dep into every
+// plain `kj` invocation. Same feature-gated pattern as the entries above.
+const DYNAMIC_IMPORT_BUDGET = 170;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   checkForUpdate,
   updateInstruction,
+  performSelfUpdate,
   INSTALL_SH_URL,
   INSTALL_PS1_URL,
 } from "../src/utils/update-check.js";
@@ -127,5 +128,62 @@ describe("updateInstruction", () => {
     const msg = updateInstruction({ channel: "unknown" });
     expect(msg).toContain("npm install -g karajan-code");
     expect(msg).toContain("binary installer");
+  });
+});
+
+describe("performSelfUpdate", () => {
+  const makeLogger = () => ({ log: vi.fn(), error: vi.fn() });
+  const logged = (logger) => logger.log.mock.calls.map((c) => c.join(" ")).join("\n");
+  const errored = (logger) => logger.error.mock.calls.map((c) => c.join(" ")).join("\n");
+
+  it("reports already-latest and never runs the install", async () => {
+    const exec = vi.fn(async () => ({ stdout: "3.12.0", stderr: "" }));
+    const logger = makeLogger();
+    const result = await performSelfUpdate({ currentVersion: "3.12.0", exec, logger });
+    expect(result).toEqual({ ok: true, alreadyLatest: true, latest: "3.12.0" });
+    expect(exec).toHaveBeenCalledTimes(1); // only `npm view`, no install
+    expect(logged(logger)).toMatch(/Already on the latest/);
+  });
+
+  it("installs the latest and hides npm's noise on success", async () => {
+    const noisy = "npm warn deprecated prebuild-install@7\nnpm warn allow-scripts\n100 packages are looking for funding";
+    const exec = vi.fn(async (_cmd, args) =>
+      args[0] === "view" ? { stdout: "3.12.0", stderr: "" } : { stdout: noisy, stderr: noisy });
+    const logger = makeLogger();
+    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    expect(result).toEqual({ ok: true, latest: "3.12.0" });
+    expect(exec).toHaveBeenCalledWith("npm", ["install", "-g", "karajan-code@latest"]);
+    const out = logged(logger);
+    expect(out).toMatch(/Updating 3\.10\.2 → 3\.12\.0/);
+    expect(out).toMatch(/Updated to 3\.12\.0/);
+    // The whole point: none of npm's plumbing reaches the user on success.
+    expect(out).not.toMatch(/npm warn|deprecated|allow-scripts|funding/);
+  });
+
+  it("surfaces the captured npm output and fails loudly when install errors", async () => {
+    const err = Object.assign(new Error("Command failed with exit code 1"), {
+      shortMessage: "npm install failed",
+      stdout: "gyp ERR! build error",
+      stderr: "node-gyp rebuild failed",
+    });
+    const exec = vi.fn(async (_cmd, args) => {
+      if (args[0] === "view") return { stdout: "3.12.0", stderr: "" };
+      throw err;
+    });
+    const logger = makeLogger();
+    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    expect(result).toEqual({ ok: false });
+    const out = errored(logger);
+    expect(out).toMatch(/gyp ERR! build error/);
+    expect(out).toMatch(/node-gyp rebuild failed/);
+    expect(out).toMatch(/Update failed/);
+  });
+
+  it("fails cleanly when the version lookup itself errors", async () => {
+    const exec = vi.fn(async () => { throw new Error("network down"); });
+    const logger = makeLogger();
+    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    expect(result).toEqual({ ok: false });
+    expect(errored(logger)).toMatch(/Update failed/);
   });
 });


### PR DESCRIPTION
## Qué

`kj update` mostraba la salida cruda de `npm install -g` (`stdio: "inherit"`), inundando al usuario con warnings de npm que son fontanería del build y sobre los que no tiene que actuar:

```
npm warn deprecated prebuild-install@7.1.3...
npm warn allow-scripts 2 packages have install scripts...
100 packages are looking for funding
```

## Cambios

- Nueva función `performSelfUpdate()` en `src/utils/update-check.js`: captura la salida de npm en vez de streamearla. En éxito solo muestra progreso + resultado; en fallo **sí** vuelca stdout/stderr capturados para que los errores reales (build nativo, permisos) sigan siendo diagnosticables — nunca un fallo silencioso.
- `src/cli/register-meta.js`: el comando `update` delega en la nueva función (fuera el `stdio: "inherit"`).
- 4 tests nuevos en `tests/update-check.test.js` (already-latest, éxito ocultando ruido, fallo de install vuelca salida, fallo de lookup).

## Verificación

- `vitest run tests/update-check.test.js` → 16 passed
- eslint limpio, net +90 LOC (bajo el límite de 150)

Refs KJC-TSK-0612