### PR TITLE
chore(release): v3.12.1 — clean kj update output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.1] - 2026-07-15
+
+Patch. **`kj update` output is clean again.** A successful self-update now shows only the progress and result lines; npm's own noise — deprecation, allow-scripts and funding warnings — is build plumbing the user cannot act on, so it no longer reaches them.
+
+### Fixed
+
+- **`kj update` hides npm's warning noise on success** (KJC-TSK-0612): the command captured npm's output instead of streaming it (`stdio: "inherit"` is gone). On success you see `Current version → Updating → Updated to X`; on failure the captured stdout/stderr IS surfaced so real errors (native build, permissions) stay diagnosable — never a silent failure. Extracted into a testable `performSelfUpdate()` in `src/utils/update-check.js`.
+
 ## [3.12.0] - 2026-07-14
 
 Minor. **`kj install-tools` now installs the tools kj itself needs**, not just the optional audit tools. A near-blank machine becomes operational with a single command — `git` and the default-pipeline agent CLIs (claude + codex) are treated as first-class required tools, exactly as `kj doctor` classifies them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "bundleDependencies": [
         "@karajan/core"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.12.1 (patch)

Publica el fix de **KJC-TSK-0612**: `kj update` deja de mostrar el ruido de npm (deprecation / allow-scripts / funding) en el camino de éxito. Ya está en main; este patch lo lleva a npm para que llegue a quien haga `kj update`.

### Cambios del release
- `package.json` / `package-lock.json`: 3.12.0 → 3.12.1
- `CHANGELOG.md`: entrada [3.12.1]

### Verificación
- `verify-pack` local verde (npm + pnpm, `kj --version` → 3.12.1)

Refs KJC-TSK-0613