### PR TITLE
fix(install): publish karajan-core to npm, drop bundleDependencies

### DIFF
--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -1,7 +1,7 @@
 # Pack Smoke — installs the REAL published tarball and runs the binary.
 #
 # WHY: the test suite runs against the linked workspace, where
-# @karajan/core and its deps resolve via symlink. A broken PUBLISHED
+# karajan-core and its deps resolve via symlink. A broken PUBLISHED
 # artifact (bundleDependencies dragging in sqlite-vec without its entry
 # point — KJC-BUG-0082 / 0086) passed CI yet crashed on every clean
 # `npm install`. v3.2.0, v3.3.0 and v3.4.1 all shipped unable to run

--- a/docs/audit-false-positives.md
+++ b/docs/audit-false-positives.md
@@ -139,7 +139,7 @@ did. Verified one by one:
 | Dependency | Why it must stay in the root `package.json` |
 | --- | --- |
 | `express`, `express-rate-limit`, `helmet` | Runtime deps of the shipped `packages/hu-board`. Nested workspace `package.json` deps are NOT installed for tarball consumers — `packages/hu-board/src/*` resolves them by walking up to the consumer's top-level `node_modules`, which only contains what the ROOT declares. Removing them breaks `kj board` on every `npm install karajan-code`. |
-| `sqlite-vec` | Runtime dep of `@karajan/core` (vec-store). Core ships via `bundleDependencies` (KJC-BUG-0082), but bundling embeds only the package itself, not its deps — those also resolve against the root install. |
+| `sqlite-vec` | Runtime dep of `karajan-core` (vec-store). Core resolves from the npm registry (KJC-BUG-0103 removed bundling) and declares its runtime deps as peers — those resolve against the root install, so the ROOT must declare them. |
 | `postject` | Already a devDependency (correct placement). Used by `scripts/build-sea.mjs` in the SEA release workflow. |
 | `simple-git-hooks` | Already a devDependency (correct placement). Drives the `pre-commit` hook via the `simple-git-hooks` config block in `package.json`. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "karajan-code",
       "version": "3.12.1",
-      "bundleDependencies": [
-        "@karajan/core"
-      ],
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
@@ -19,7 +16,6 @@
       ],
       "dependencies": {
         "@babel/parser": "^7.29.7",
-        "@karajan/core": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",
@@ -29,6 +25,7 @@
         "express-rate-limit": "^8.5.0",
         "helmet": "^8.1.0",
         "js-yaml": "^4.2.0",
+        "karajan-core": "^1.0.0",
         "knip": "^6.15.0",
         "madge": "^8.0.0",
         "sqlite-vec": "^0.1.9",
@@ -39,7 +36,8 @@
         "karajan-mcp": "bin/karajan-mcp.js",
         "kj": "bin/kj.js",
         "kj-rag-mcp": "bin/kj-rag-mcp.js",
-        "kj-tail": "bin/kj-tail"
+        "kj-tail": "bin/kj-tail",
+        "kj-trash": "packages/ai-trash/bin/kj-trash.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -845,10 +843,6 @@
     },
     "node_modules/@karajan/ai-trash": {
       "resolved": "packages/ai-trash",
-      "link": true
-    },
-    "node_modules/@karajan/core": {
-      "resolved": "packages/core",
       "link": true
     },
     "node_modules/@karajan/hu-board": {
@@ -5052,6 +5046,10 @@
         "node": ">=6"
       }
     },
+    "node_modules/karajan-core": {
+      "resolved": "packages/core",
+      "link": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8093,8 +8091,9 @@
       }
     },
     "packages/core": {
-      "name": "@karajan/core",
-      "version": "0.1.0",
+      "name": "karajan-core",
+      "version": "1.0.0",
+      "license": "AGPL-3.0",
       "devDependencies": {
         "vitest": "^4.0.0"
       },
@@ -8122,13 +8121,13 @@
       "name": "@karajan/hu-board",
       "version": "1.0.0",
       "dependencies": {
-        "@karajan/core": "*",
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
         "helmet": "^8.1.0",
-        "js-yaml": "^4.2.0"
+        "js-yaml": "^4.2.0",
+        "karajan-core": "*"
       },
       "devDependencies": {
         "supertest": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.7",
-    "@karajan/core": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
@@ -108,15 +107,13 @@
     "express-rate-limit": "^8.5.0",
     "helmet": "^8.1.0",
     "js-yaml": "^4.2.0",
+    "karajan-core": "^1.0.0",
     "knip": "^6.15.0",
     "madge": "^8.0.0",
     "sqlite-vec": "^0.1.9",
     "valibot": "^1.4.1",
     "web-tree-sitter": "^0.26.9"
   },
-  "bundleDependencies": [
-    "@karajan/core"
-  ],
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@vitest/coverage-v8": "^4.1.8",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,11 +1,11 @@
-# @karajan/core
+# karajan-core
 
 Shared modules for the Karajan Code CLI and `@karajan/hu-board`. Private
 workspace package — not published to npm.
 
 ## Scope
 
-`@karajan/core` is the extraction destination for code that both the CLI
+`karajan-core` is the extraction destination for code that both the CLI
 package (`karajan-code`) and the HU Board package (`@karajan/hu-board`)
 need. Today it ships the atomic JSON writer; subsequent commits of
 KJC-TSK-0511 will land the shared paths, port-check, run-registry,
@@ -16,21 +16,21 @@ here.
 
 | Subpath | Module |
 | --- | --- |
-| `@karajan/core/atomic-write` | `writeJsonAtomic`, `writeJsonAtomicSync` |
-| `@karajan/core/shared-paths` | `SHARED_DIR_NAME`, `getSharedRoot`, `getSharedPlansDir`, `getSharedHuStoriesDir`, `isSharedPath` |
-| `@karajan/core/port-check` | `isPortAvailable`, `findAvailablePort` |
-| `@karajan/core/paths` | `resolveHome`, `getKarajanHome`, `getSessionRoot`, `getSonarComposePath`, `getOllamaComposePath`, `getWebperfDir`, `getRunsDir`, `getPromptsDir`, `__resetKjHomeWarningForTests` |
-| `@karajan/core/run-registry` | `runsDir`, `registerRun`, `unregisterRun`, `listActiveRuns` |
-| `@karajan/core/vec-store` | `dbPath`, `openVecStore`, `insertChunk`, `searchSimilar`, `searchBM25`, `projectSlug`, `deleteChunksBySource`, `findChunkByHash`, `getEmbeddingsByIds`, `getLastIndexedCommit`, `setLastIndexedCommit`, `countChunks` |
-| `@karajan/core/plan-id` | `generatePlanId`, `generateHuId`, `normaliseAlias` |
-| `@karajan/core/plan-hu-ops` | `addHu`, `removeHu`, `updateHu`, `updateHuStatus`, `setHuOutcome`, `setPlanOutcome`, `autoCertifyPendingHus`, `assertPlanRunnable`, `computePlanOutcome`, `certifyAllHus`, `reorderHus` |
-| `@karajan/core/plan-validation` | `validateBlockedByChange` |
-| `@karajan/core/process` | `runCommand` (execa wrapper with output streaming, silence/total timeouts, ENOENT enrichment) |
-| `@karajan/core/hu-snapshot` | `snapshotRefForHu`, `createHuSnapshot`, `hasHuSnapshot`, `restoreHuSnapshot`, `removeHuSnapshot` |
-| `@karajan/core/standby-store` | `persistStandby`, `loadStandby`, `listPendingStandby`, `markStandbyDone`, `acquireStandbyLock`, `buildStandbyState`, `standbyDir`, `standbyDoneDir` |
-| `@karajan/core/standby-scheduler` | `scheduleResume`, `cancelScheduled`, `reconcileAll`, `acquireStandbyLock`, `markStandbyDone`, `_resetScheduledForTests` |
+| `karajan-core/atomic-write` | `writeJsonAtomic`, `writeJsonAtomicSync` |
+| `karajan-core/shared-paths` | `SHARED_DIR_NAME`, `getSharedRoot`, `getSharedPlansDir`, `getSharedHuStoriesDir`, `isSharedPath` |
+| `karajan-core/port-check` | `isPortAvailable`, `findAvailablePort` |
+| `karajan-core/paths` | `resolveHome`, `getKarajanHome`, `getSessionRoot`, `getSonarComposePath`, `getOllamaComposePath`, `getWebperfDir`, `getRunsDir`, `getPromptsDir`, `__resetKjHomeWarningForTests` |
+| `karajan-core/run-registry` | `runsDir`, `registerRun`, `unregisterRun`, `listActiveRuns` |
+| `karajan-core/vec-store` | `dbPath`, `openVecStore`, `insertChunk`, `searchSimilar`, `searchBM25`, `projectSlug`, `deleteChunksBySource`, `findChunkByHash`, `getEmbeddingsByIds`, `getLastIndexedCommit`, `setLastIndexedCommit`, `countChunks` |
+| `karajan-core/plan-id` | `generatePlanId`, `generateHuId`, `normaliseAlias` |
+| `karajan-core/plan-hu-ops` | `addHu`, `removeHu`, `updateHu`, `updateHuStatus`, `setHuOutcome`, `setPlanOutcome`, `autoCertifyPendingHus`, `assertPlanRunnable`, `computePlanOutcome`, `certifyAllHus`, `reorderHus` |
+| `karajan-core/plan-validation` | `validateBlockedByChange` |
+| `karajan-core/process` | `runCommand` (execa wrapper with output streaming, silence/total timeouts, ENOENT enrichment) |
+| `karajan-core/hu-snapshot` | `snapshotRefForHu`, `createHuSnapshot`, `hasHuSnapshot`, `restoreHuSnapshot`, `removeHuSnapshot` |
+| `karajan-core/standby-store` | `persistStandby`, `loadStandby`, `listPendingStandby`, `markStandbyDone`, `acquireStandbyLock`, `buildStandbyState`, `standbyDir`, `standbyDoneDir` |
+| `karajan-core/standby-scheduler` | `scheduleResume`, `cancelScheduled`, `reconcileAll`, `acquireStandbyLock`, `markStandbyDone`, `_resetScheduledForTests` |
 
-The root export (`@karajan/core`) re-exports everything via the barrel
+The root export (`karajan-core`) re-exports everything via the barrel
 in `src/index.js`, but prefer the subpath form so the bundler can
 tree-shake unused modules.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,18 @@
 {
-  "name": "@karajan/core",
-  "version": "0.1.0",
+  "name": "karajan-core",
+  "version": "1.0.0",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
-  "private": true,
+  "license": "AGPL-3.0",
+  "author": "manufosela",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manufosela/karajan-code.git",
+    "directory": "packages/core"
+  },
+  "files": [
+    "src/"
+  ],
   "engines": {
     "node": ">=22.22.1"
   },

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,7 +1,7 @@
-// Barrel export for @karajan/core. Subpath imports
-// (e.g. `@karajan/core/atomic-write`) are the preferred shape — this
+// Barrel export for karajan-core. Subpath imports
+// (e.g. `karajan-core/atomic-write`) are the preferred shape — this
 // barrel only exists so a single `import { writeJsonAtomic } from
-// "@karajan/core"` keeps working for callers that want the whole API.
+// "karajan-core"` keeps working for callers that want the whole API.
 
 export * from "./atomic-write.js";
 export * from "./shared-paths.js";

--- a/packages/core/src/run-registry.js
+++ b/packages/core/src/run-registry.js
@@ -13,7 +13,7 @@
  * total terminal ↔ board.
  *
  * Compartido entre el CLI (src/commands/run.js) y el board
- * (packages/hu-board/src/run-tracker.js) vía `@karajan/core/run-registry`.
+ * (packages/hu-board/src/run-tracker.js) vía `karajan-core/run-registry`.
  */
 
 import fs from "node:fs";

--- a/packages/core/tests/atomic-write.test.js
+++ b/packages/core/tests/atomic-write.test.js
@@ -1,4 +1,4 @@
-// Smoke coverage for the @karajan/core/atomic-write extraction
+// Smoke coverage for the karajan-core/atomic-write extraction
 // (KJC-TSK-0511 PR1). The full behavioural matrix already lives next to
 // the CLI; this file just proves the new package entry point works
 // end-to-end so a future regression in workspace wiring fails loudly.
@@ -13,7 +13,7 @@ async function tmpDir() {
   return mkdtemp(join(tmpdir(), "core-atomic-"));
 }
 
-describe("@karajan/core/atomic-write", () => {
+describe("karajan-core/atomic-write", () => {
   it("writeJsonAtomic persists pretty JSON and leaves no .tmp", async () => {
     const dir = await tmpDir();
     const target = join(dir, "plan.json");

--- a/packages/core/tests/hu-snapshot.test.js
+++ b/packages/core/tests/hu-snapshot.test.js
@@ -4,7 +4,7 @@ import {
   restoreHuSnapshot, removeHuSnapshot,
 } from "../src/hu-snapshot.js";
 
-describe("@karajan/core/hu-snapshot", () => {
+describe("karajan-core/hu-snapshot", () => {
   it("snapshotRefForHu sanitises and prefixes", () => {
     expect(snapshotRefForHu("hu_001")).toBe("refs/kj-snapshots/hu_001");
     expect(snapshotRefForHu("hu/with..weird:chars")).toBe("refs/kj-snapshots/hu_with__weird_chars");

--- a/packages/core/tests/paths.test.js
+++ b/packages/core/tests/paths.test.js
@@ -10,7 +10,7 @@ import {
   __resetKjHomeWarningForTests,
 } from "../src/paths.js";
 
-describe("@karajan/core/paths", () => {
+describe("karajan-core/paths", () => {
   let originalKarajanHome;
   let originalKjHome;
 

--- a/packages/core/tests/plan-hu-ops.test.js
+++ b/packages/core/tests/plan-hu-ops.test.js
@@ -11,7 +11,7 @@ import {
 
 const newPlan = () => ({ planId: "plan-T", hus: [], updatedAt: null });
 
-describe("@karajan/core/plan-hu-ops", () => {
+describe("karajan-core/plan-hu-ops", () => {
   it("addHu assigns sequential ID + defaults", () => {
     const plan = newPlan();
     const hu = addHu(plan, { title: "T1" });

--- a/packages/core/tests/plan-id.test.js
+++ b/packages/core/tests/plan-id.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { generatePlanId, generateHuId, normaliseAlias } from "../src/plan-id.js";
 
-describe("@karajan/core/plan-id", () => {
+describe("karajan-core/plan-id", () => {
   it("generatePlanId returns plan-<ts>-<rand>", () => {
     const id = generatePlanId();
     expect(id).toMatch(/^plan-\d{14}-[a-z0-9]{4}$/);

--- a/packages/core/tests/plan-validation.test.js
+++ b/packages/core/tests/plan-validation.test.js
@@ -9,7 +9,7 @@ const plan = () => ({
   ],
 });
 
-describe("@karajan/core/plan-validation", () => {
+describe("karajan-core/plan-validation", () => {
   it("ok when the new blocked_by is a valid subset", () => {
     expect(validateBlockedByChange(plan(), "c", ["a"]).ok).toBe(true);
   });

--- a/packages/core/tests/port-check.test.js
+++ b/packages/core/tests/port-check.test.js
@@ -1,4 +1,4 @@
-// Smoke coverage for the @karajan/core/port-check extraction
+// Smoke coverage for the karajan-core/port-check extraction
 // (KJC-TSK-0511 PR2). Real socket binding — tiny but fast.
 import { createServer } from "node:net";
 import { describe, it, expect } from "vitest";
@@ -12,7 +12,7 @@ function occupy() {
   });
 }
 
-describe("@karajan/core/port-check", () => {
+describe("karajan-core/port-check", () => {
   it("isPortAvailable returns false for a port we already bound", async () => {
     const { srv, port } = await occupy();
     try {

--- a/packages/core/tests/process.test.js
+++ b/packages/core/tests/process.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { runCommand } from "../src/process.js";
 
-describe("@karajan/core/process", () => {
+describe("karajan-core/process", () => {
   it("captures stdout from a real subprocess", async () => {
     const r = await runCommand("node", ["-e", "process.stdout.write('hi')"]);
     expect(r.exitCode).toBe(0);

--- a/packages/core/tests/run-registry.test.js
+++ b/packages/core/tests/run-registry.test.js
@@ -9,7 +9,7 @@ import {
   runsDir,
 } from "../src/run-registry.js";
 
-describe("@karajan/core/run-registry", () => {
+describe("karajan-core/run-registry", () => {
   let tmpHome;
   let originalKarajanHome;
 

--- a/packages/core/tests/shared-paths.test.js
+++ b/packages/core/tests/shared-paths.test.js
@@ -1,4 +1,4 @@
-// Smoke coverage for the @karajan/core/shared-paths extraction
+// Smoke coverage for the karajan-core/shared-paths extraction
 // (KJC-TSK-0511 PR2). Full unit coverage stays next to the CLI;
 // this file proves the new package entry point resolves and returns
 // stable paths so a future workspace-wiring regression fails loudly.
@@ -13,7 +13,7 @@ import {
   isSharedPath,
 } from "../src/shared-paths.js";
 
-describe("@karajan/core/shared-paths", () => {
+describe("karajan-core/shared-paths", () => {
   it("constants and joins land inside the project dir", () => {
     expect(SHARED_DIR_NAME).toBe(".karajan-shared");
     expect(getSharedRoot("/tmp/proj")).toBe(`/tmp/proj${sep}.karajan-shared`);

--- a/packages/core/tests/standby.test.js
+++ b/packages/core/tests/standby.test.js
@@ -21,7 +21,7 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-describe("@karajan/core/standby-store", () => {
+describe("karajan-core/standby-store", () => {
   it("persists + loads + lists pending sessions", () => {
     persistStandby({ sessionId: "s_1", cooldownUntil: "2099-01-01T00:00:00Z", reason: "QUOTA" });
     const loaded = loadStandby("s_1");
@@ -48,7 +48,7 @@ describe("@karajan/core/standby-store", () => {
   });
 });
 
-describe("@karajan/core/standby-scheduler", () => {
+describe("karajan-core/standby-scheduler", () => {
   it("scheduleResume with expired cooldown fires immediate", async () => {
     const cb = vi.fn();
     const r = scheduleResume({ sessionId: "s_4", cooldownUntil: "1990-01-01T00:00:00Z", onResume: cb });

--- a/packages/core/tests/vec-store.test.js
+++ b/packages/core/tests/vec-store.test.js
@@ -15,7 +15,7 @@ import {
   dbPath,
 } from "../src/vec-store.js";
 
-describe("@karajan/core/vec-store", () => {
+describe("karajan-core/vec-store", () => {
   let tmpDir;
   let originalRagDb;
 

--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -1,4 +1,4 @@
-// Local Vitest config for @karajan/core so the workspace package does
+// Local Vitest config for karajan-core so the workspace package does
 // not inherit the root config (which excludes `packages/**` and points
 // at a global setup file outside the workspace).
 

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@karajan/core": "*",
+    "karajan-core": "*",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
     "express": "^5.1.0",

--- a/packages/hu-board/src/plan-mutations.js
+++ b/packages/hu-board/src/plan-mutations.js
@@ -17,13 +17,13 @@
 import { readFileSync, existsSync, readdirSync, mkdirSync, openSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { writeJsonAtomicSync } from '@karajan/core/atomic-write';
+import { writeJsonAtomicSync } from 'karajan-core/atomic-write';
 import { spawn } from 'node:child_process';
 import { trackRun, untrack } from './run-tracker.js';
 import { getHuBoardRunsDir } from './db.js';
 import { fileURLToPath } from 'node:url';
-import { updateHuStatus, certifyAllHus, updateHu } from '@karajan/core/plan-hu-ops';
-import { validateBlockedByChange } from '@karajan/core/plan-validation';
+import { updateHuStatus, certifyAllHus, updateHu } from 'karajan-core/plan-hu-ops';
+import { validateBlockedByChange } from 'karajan-core/plan-validation';
 import { syncPlanFile } from './sync.js';
 import { getDb } from './db.js';
 
@@ -230,7 +230,7 @@ export async function revertHuFromSnapshot({ planId, huId, projectId }) {
   const projectDir = plan.projectDir;
   if (!projectDir) return { ok: false, error: 'plan sin projectDir' };
 
-  const { restoreHuSnapshot } = await import('@karajan/core/hu-snapshot');
+  const { restoreHuSnapshot } = await import('karajan-core/hu-snapshot');
   const restore = await restoreHuSnapshot({ projectDir, huId });
   if (!restore.ok) return { ok: false, error: `restore falló: ${restore.error}` };
 

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1361,7 +1361,7 @@ router.post('/rag/query', async (req, res) => {
     return res.status(400).json({ error: "'text' is required (non-empty string)" });
   }
   try {
-    const { openVecStore, countChunks } = await import('@karajan/core/vec-store');
+    const { openVecStore, countChunks } = await import('karajan-core/vec-store');
     const { makeEmbedder } = await import('../../../../src/rag/embedders/factory.js');
     const { query } = await import('../../../../src/rag/retriever.js');
     const db = openVecStore({ dim: 768 });

--- a/packages/hu-board/src/routes/rag.js
+++ b/packages/hu-board/src/routes/rag.js
@@ -5,7 +5,7 @@
 import { Router } from "express";
 import { existsSync, statSync } from "node:fs";
 import Database from "better-sqlite3";
-import { dbPath } from "@karajan/core/vec-store";
+import { dbPath } from "karajan-core/vec-store";
 import { readConfig } from "../config-yaml.js";
 
 const router = Router();

--- a/packages/hu-board/src/routes/wiki.js
+++ b/packages/hu-board/src/routes/wiki.js
@@ -4,7 +4,7 @@
 // 503 with installable:true so the front renders an "Install QMD" CTA
 // instead of a generic error when the binary is missing.
 import { Router } from "express";
-import { runCommand } from "@karajan/core/process";
+import { runCommand } from "karajan-core/process";
 
 const router = Router();
 const QMD_NOT_INSTALLED = /command not found|ENOENT|not recognized as/i;

--- a/packages/hu-board/src/run-tracker.js
+++ b/packages/hu-board/src/run-tracker.js
@@ -16,7 +16,7 @@
  * se borran como cleanup (responsabilidad de run-registry).
  */
 
-import { listActiveRuns as fsList } from "@karajan/core/run-registry";
+import { listActiveRuns as fsList } from "karajan-core/run-registry";
 
 const runs = new Map();
 let reaperTimer = null;

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -17,7 +17,7 @@ import { reapZombieSessions } from './zombie-reaper.js';
 import { reapZombieHus } from './hu-zombie-reaper.js';
 import { setHuStatus as setHuStatusPlanMutation, setHuFailResult as setHuFailResultPlanMutation } from './plan-mutations.js';
 import { cleanupEphemeralProjects } from './ephemeral-cleaner.js';
-import { findAvailablePort as findAvailablePortBase } from '@karajan/core/port-check';
+import { findAvailablePort as findAvailablePortBase } from 'karajan-core/port-check';
 
 /**
  * Path to the PID file the CLI's `kj board start` / `kj board stop`
@@ -238,7 +238,7 @@ async function main() {
   //   - cooldownUntil > now  → re-programa setTimeout que dispara en cooldown
   // Idempotente (lockfile per session). Cero polling.
   try {
-    const { reconcileAll } = await import('@karajan/core/standby-scheduler');
+    const { reconcileAll } = await import('karajan-core/standby-scheduler');
     const { spawn } = await import('node:child_process');
     const { join, dirname } = await import('node:path');
     const { fileURLToPath } = await import('node:url');

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -14,7 +14,7 @@ import {
   removeTombstone,
 } from './db.js';
 import { publish as publishEvent } from './event-bus.js';
-import { getSharedPlansDir, SHARED_DIR_NAME, isSharedPath } from '@karajan/core/shared-paths';
+import { getSharedPlansDir, SHARED_DIR_NAME, isSharedPath } from 'karajan-core/shared-paths';
 import { readConfig } from './config-yaml.js';
 
 /**

--- a/packages/hu-board/tests/api.test.js
+++ b/packages/hu-board/tests/api.test.js
@@ -350,7 +350,7 @@ describe('GET /api/standby', () => {
   });
 
   it('devuelve las sesiones persistidas', async () => {
-    const { persistStandby } = await import('@karajan/core/standby-store');
+    const { persistStandby } = await import('karajan-core/standby-store');
     persistStandby({
       sessionId: 'test-s1',
       cooldownUntil: '2099-01-01T00:00:00Z',

--- a/packages/hu-board/tests/wiki-route.test.js
+++ b/packages/hu-board/tests/wiki-route.test.js
@@ -4,9 +4,9 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import express from "express";
 import request from "supertest";
 
-vi.mock("@karajan/core/process", () => ({ runCommand: vi.fn() }));
+vi.mock("karajan-core/process", () => ({ runCommand: vi.fn() }));
 
-import { runCommand } from "@karajan/core/process";
+import { runCommand } from "karajan-core/process";
 import wikiRoutes from "../src/routes/wiki.js";
 
 let app;

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -3,7 +3,7 @@
  * Pre-publish tarball smoke gate (KJC-TSK-0553).
  *
  * WHY: the test suite runs against the linked workspace, where
- * `@karajan/core` and its deps resolve via symlink — so a broken
+ * `karajan-core` and its deps resolve via symlink — so a broken
  * PUBLISHED artifact (bundleDependencies dragging in sqlite-vec without
  * its entry point, KJC-BUG-0082 / 0086) passed CI yet failed on every
  * clean `npm install`. v3.2.0, v3.3.0 and v3.4.1 all shipped unable to
@@ -50,6 +50,7 @@ function fail(msg, detail) {
 
 let tgzPath = null;
 let tmpDir = null;
+let gTmp = null;
 let pnpmTmp = null;
 try {
   console.log(`verify-pack: packing karajan-code@${expectedVersion}…`);
@@ -92,15 +93,16 @@ try {
   console.log("verify-pack: kj --help ✓");
 
   // 3. The deps that broke before must resolve in the installed tree.
-  const installedRoot = path.join(tmpDir, "node_modules", "karajan-code");
+  // karajan-core is a registry dep since KJC-BUG-0103 (no bundling), so it
+  // hoists to the consumer's top-level node_modules like everything else.
   const checks = [
     path.join(tmpDir, "node_modules", "sqlite-vec", "index.mjs"),
-    path.join(installedRoot, "node_modules", "@karajan", "core", "src", "vec-store.js"),
+    path.join(tmpDir, "node_modules", "karajan-core", "src", "vec-store.js"),
   ];
   for (const p of checks) {
     if (!fs.existsSync(p)) fail(`expected resolved path missing in install: ${p}`);
   }
-  console.log("verify-pack: sqlite-vec + @karajan/core resolve ✓");
+  console.log("verify-pack: sqlite-vec + karajan-core resolve ✓");
 
   // 4. kj-trash (ai-trash safety binary) must ship + link onto PATH and boot
   // without a module-resolution crash. It was silently absent from the tarball
@@ -115,9 +117,38 @@ try {
   }
   console.log("verify-pack: kj-trash ships + boots ✓");
 
-  // 5. pnpm install smoke (KJC-TSK-0580). pnpm's layout differs from npm's
+  // 5. GLOBAL install smoke (KJC-BUG-0103). `npm install -g` nests every dep
+  // under karajan-code/node_modules; with bundleDependencies present, npm
+  // treated that whole subtree as "already in the tarball" and skipped
+  // fetching better-sqlite3 & friends — EMPTY dirs whose install scripts then
+  // crashed. Local installs hoist and never hit it, which is exactly why the
+  // check above stayed green for ~15 broken releases. A fresh global install
+  // must succeed and kj must boot.
+  gTmp = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verify-g-"));
+  console.log(`verify-pack: installing the tarball GLOBALLY into ${gTmp}…`);
+  try {
+    run("npm", ["install", "-g", tgzPath, "--no-audit", "--no-fund", "--silent", "--prefix", gTmp]);
+  } catch (err) {
+    fail("`npm install -g` of the tarball failed (KJC-BUG-0103 class)", err.stderr || err.message);
+  }
+  const gBin = process.platform === "win32"
+    ? path.join(gTmp, "kj.cmd")
+    : path.join(gTmp, "bin", "kj");
+  if (!fs.existsSync(gBin)) fail(`kj binary missing after global install: ${gBin}`);
+  let gVersion;
+  try {
+    gVersion = run(gBin, ["--version"]).trim();
+  } catch (err) {
+    fail("`kj --version` crashed on a fresh GLOBAL install", err.stderr || err.message);
+  }
+  if (!gVersion.includes(expectedVersion)) {
+    fail(`kj --version (global) returned "${gVersion}", expected ${expectedVersion}`);
+  }
+  console.log(`verify-pack: global install + kj --version → ${gVersion} ✓`);
+
+  // 6. pnpm install smoke (KJC-TSK-0580). pnpm's layout differs from npm's
   // (a symlinked virtual store), so it can break resolution of the bundled
-  // @karajan/core the way npm packaging breakage did before (KJC-BUG-0082/0086).
+  // karajan-core the way npm packaging breakage did before (KJC-BUG-0082/0086).
   // Verify a pnpm install resolves the JS tree and `kj --version` boots — every
   // release catches a pnpm packaging regression. (pnpm also blocks
   // better-sqlite3's native build by default, so DB-backed commands need
@@ -158,5 +189,6 @@ try {
 } finally {
   if (tgzPath && fs.existsSync(tgzPath)) fs.rmSync(tgzPath, { force: true });
   if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+  if (gTmp && fs.existsSync(gTmp)) fs.rmSync(gTmp, { recursive: true, force: true });
   if (pnpmTmp && fs.existsSync(pnpmTmp)) fs.rmSync(pnpmTmp, { recursive: true, force: true });
 }

--- a/src/brain/standby-scheduler.js
+++ b/src/brain/standby-scheduler.js
@@ -1,8 +1,8 @@
-// Shim de compatibilidad: standby-scheduler vive ahora en @karajan/core.
+// Shim de compatibilidad: standby-scheduler vive ahora en karajan-core.
 // Mantiene la ruta para callers internos del CLI.
 export {
   _resetScheduledForTests,
   scheduleResume,
   cancelScheduled,
   reconcileAll,
-} from "@karajan/core/standby-scheduler";
+} from "karajan-core/standby-scheduler";

--- a/src/brain/standby-store.js
+++ b/src/brain/standby-store.js
@@ -1,4 +1,4 @@
-// Shim de compatibilidad: standby-store vive ahora en @karajan/core.
+// Shim de compatibilidad: standby-store vive ahora en karajan-core.
 // Mantiene la ruta para callers internos del CLI.
 export {
   standbyDir,
@@ -9,4 +9,4 @@ export {
   listPendingStandby,
   markStandbyDone,
   acquireStandbyLock,
-} from "@karajan/core/standby-store";
+} from "karajan-core/standby-store";

--- a/src/git/hu-snapshot.js
+++ b/src/git/hu-snapshot.js
@@ -1,4 +1,4 @@
-// Shim de compatibilidad: hu-snapshot vive ahora en @karajan/core.
+// Shim de compatibilidad: hu-snapshot vive ahora en karajan-core.
 // Mantenemos esta ruta para que callers internos del CLI (orchestrator,
 // runners) sigan funcionando sin tocar imports.
 export {
@@ -7,4 +7,4 @@ export {
   hasHuSnapshot,
   restoreHuSnapshot,
   removeHuSnapshot,
-} from "@karajan/core/hu-snapshot";
+} from "karajan-core/hu-snapshot";

--- a/src/plan/plan-hu-ops.js
+++ b/src/plan/plan-hu-ops.js
@@ -1,4 +1,4 @@
-// Shim: plan-hu-ops now lives in @karajan/core/plan-hu-ops so the
+// Shim: plan-hu-ops now lives in karajan-core/plan-hu-ops so the
 // hu-board workspace can consume it without a relative dep on the CLI
 // src tree. KJC-TSK-0511 PR5.
 export {
@@ -13,4 +13,4 @@ export {
   computePlanOutcome,
   certifyAllHus,
   reorderHus,
-} from "@karajan/core/plan-hu-ops";
+} from "karajan-core/plan-hu-ops";

--- a/src/plan/plan-id.js
+++ b/src/plan/plan-id.js
@@ -1,4 +1,4 @@
-// Shim: plan-id primitives now live in @karajan/core/plan-id so the
+// Shim: plan-id primitives now live in karajan-core/plan-id so the
 // hu-board workspace can consume them without a relative dep on the
 // CLI src tree. KJC-TSK-0511 PR5.
-export { generatePlanId, generateHuId, normaliseAlias } from "@karajan/core/plan-id";
+export { generatePlanId, generateHuId, normaliseAlias } from "karajan-core/plan-id";

--- a/src/plan/plan-validation.js
+++ b/src/plan/plan-validation.js
@@ -1,4 +1,4 @@
-// Shim: plan-validation now lives in @karajan/core/plan-validation so
+// Shim: plan-validation now lives in karajan-core/plan-validation so
 // the hu-board workspace can consume it without a relative dep on the
 // CLI src tree. KJC-TSK-0511 PR6.
-export { validateBlockedByChange } from "@karajan/core/plan-validation";
+export { validateBlockedByChange } from "karajan-core/plan-validation";

--- a/src/rag/vec-store.js
+++ b/src/rag/vec-store.js
@@ -1,4 +1,4 @@
-// Shim: vec-store primitives now live in @karajan/core/vec-store so
+// Shim: vec-store primitives now live in karajan-core/vec-store so
 // the hu-board workspace can consume them without a relative dep on the
 // CLI src tree. KJC-TSK-0511 PR4.
 export {
@@ -14,4 +14,4 @@ export {
   findChunkByHash,
   countChunks,
   searchBM25,
-} from "@karajan/core/vec-store";
+} from "karajan-core/vec-store";

--- a/src/utils/atomic-write.js
+++ b/src/utils/atomic-write.js
@@ -1,6 +1,6 @@
-// Shim — the real implementation now lives in @karajan/core/atomic-write.
+// Shim — the real implementation now lives in karajan-core/atomic-write.
 // Kept here so CLI callers (src/**/*.js) keep importing
 // "#utils/atomic-write.js" without churn during KJC-TSK-0511 (decouple
 // @karajan/hu-board). Will be retired once every consumer migrates to
-// the @karajan/core import.
-export { writeJsonAtomic, writeJsonAtomicSync } from "@karajan/core/atomic-write";
+// the karajan-core import.
+export { writeJsonAtomic, writeJsonAtomicSync } from "karajan-core/atomic-write";

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,4 +1,4 @@
-// Shim: paths primitives now live in @karajan/core/paths so the
+// Shim: paths primitives now live in karajan-core/paths so the
 // hu-board workspace can consume them without a relative dep on the
 // CLI src tree. KJC-TSK-0511 PR3.
 export {
@@ -10,4 +10,4 @@ export {
   getOllamaComposePath,
   getWebperfDir,
   getPromptsDir,
-} from "@karajan/core/paths";
+} from "karajan-core/paths";

--- a/src/utils/port-check.js
+++ b/src/utils/port-check.js
@@ -1,6 +1,6 @@
-// Shim — the real implementation now lives in @karajan/core/port-check.
+// Shim — the real implementation now lives in karajan-core/port-check.
 // Kept here so CLI callers (src/**/*.js) keep importing
 // "../utils/port-check.js" without churn during KJC-TSK-0511 (decouple
 // @karajan/hu-board). Will be retired once every consumer migrates to
-// the @karajan/core import.
-export { isPortAvailable, findAvailablePort } from "@karajan/core/port-check";
+// the karajan-core import.
+export { isPortAvailable, findAvailablePort } from "karajan-core/port-check";

--- a/src/utils/process.js
+++ b/src/utils/process.js
@@ -1,4 +1,4 @@
-// Shim: process runner now lives in @karajan/core/process so the
+// Shim: process runner now lives in karajan-core/process so the
 // hu-board workspace can consume it without a relative dep on the CLI
 // src tree. KJC-TSK-0511 PR6.
-export { runCommand } from "@karajan/core/process";
+export { runCommand } from "karajan-core/process";

--- a/src/utils/run-registry.js
+++ b/src/utils/run-registry.js
@@ -1,4 +1,4 @@
-// Shim: run-registry now lives in @karajan/core/run-registry so the
+// Shim: run-registry now lives in karajan-core/run-registry so the
 // hu-board workspace can consume it without a relative dep on the CLI
 // src tree. KJC-TSK-0511 PR3.
 export {
@@ -6,4 +6,4 @@ export {
   registerRun,
   unregisterRun,
   listActiveRuns,
-} from "@karajan/core/run-registry";
+} from "karajan-core/run-registry";

--- a/src/utils/shared-paths.js
+++ b/src/utils/shared-paths.js
@@ -1,12 +1,12 @@
-// Shim — the real implementation now lives in @karajan/core/shared-paths.
+// Shim — the real implementation now lives in karajan-core/shared-paths.
 // Kept here so CLI callers (src/**/*.js) keep importing
 // "../utils/shared-paths.js" without churn during KJC-TSK-0511 (decouple
 // @karajan/hu-board). Will be retired once every consumer migrates to
-// the @karajan/core import.
+// the karajan-core import.
 export {
   SHARED_DIR_NAME,
   getSharedRoot,
   getSharedPlansDir,
   getSharedHuStoriesDir,
   isSharedPath,
-} from "@karajan/core/shared-paths";
+} from "karajan-core/shared-paths";

--- a/tests/architecture/core-no-bundled-deps.test.js
+++ b/tests/architecture/core-no-bundled-deps.test.js
@@ -4,20 +4,22 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * Architecture regression guard — KJC-BUG-0086.
+ * Architecture regression guard — KJC-BUG-0086 + KJC-BUG-0103.
  *
- * @karajan/core ships INSIDE the karajan-code npm tarball via
- * bundleDependencies. If core declares runtime `dependencies`, npm pack
- * bundles them too — and a dep with a broken `files` field (sqlite-vec
- * ships `files: []`) lands without its entry point, so `kj --version`
- * crashes with ERR_MODULE_NOT_FOUND on every clean install.
+ * karajan-core is published to npm and resolved from the registry like any
+ * other dependency. It must NEVER return to `bundleDependencies`: on global
+ * installs npm nests every dep under karajan-code/node_modules, and bundle
+ * semantics mark that whole subtree as "already shipped" — so npm skips
+ * fetching better-sqlite3 & friends, leaving EMPTY directories whose install
+ * scripts then crash (`npm install -g karajan-code` failed on every fresh
+ * machine, KJC-BUG-0103).
  *
  * Contract: core's runtime deps that the host root already provides
  * (better-sqlite3, execa, sqlite-vec) MUST be peerDependencies, never
  * `dependencies`, so they resolve from the consumer's top-level
  * node_modules (complete, and with the right native binary per platform).
  *
- * If you add a NEW runtime dep to @karajan/core, declare it as a
+ * If you add a NEW runtime dep to karajan-core, declare it as a
  * peerDependency AND add it to the root karajan-code dependencies.
  */
 describe("architecture/core-no-bundled-deps (KJC-BUG-0086)", () => {
@@ -29,15 +31,24 @@ describe("architecture/core-no-bundled-deps (KJC-BUG-0086)", () => {
     fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
   );
 
-  it("@karajan/core declares NO runtime dependencies (would be bundled incompletely)", () => {
+  it("karajan-core declares NO runtime dependencies (would be bundled incompletely)", () => {
     expect(corePkg.dependencies ?? {}).toEqual({});
   });
 
-  it("every @karajan/core peerDependency is provided by the root karajan-code dependencies", () => {
+  it("every karajan-core peerDependency is provided by the root karajan-code dependencies", () => {
     const peers = Object.keys(corePkg.peerDependencies ?? {});
     expect(peers.length).toBeGreaterThan(0);
     for (const dep of peers) {
-      expect(rootPkg.dependencies?.[dep], `root must declare ${dep} so the bundled core can resolve it`).toBeTruthy();
+      expect(rootPkg.dependencies?.[dep], `root must declare ${dep} so core can resolve it`).toBeTruthy();
     }
+  });
+
+  it("root declares NO bundleDependencies (breaks fresh global installs, KJC-BUG-0103)", () => {
+    expect(rootPkg.bundleDependencies ?? []).toEqual([]);
+    expect(rootPkg.bundledDependencies ?? []).toEqual([]);
+  });
+
+  it("karajan-core is a registry dependency of the root, pinned to a real range", () => {
+    expect(rootPkg.dependencies?.["karajan-core"]).toMatch(/^\^?\d/);
   });
 });


### PR DESCRIPTION
## Qué (KJC-BUG-0103 — Application Blocker)

`npm install -g karajan-code` **fallaba en toda máquina nueva** desde que existe `bundleDependencies` (~v3.4.2): en installs globales npm anida todas las deps bajo `karajan-code/node_modules`, y la semántica de bundle marca ese subárbol como "ya incluido en el tarball" → npm no descarga `better-sqlite3` y compañía → directorios **vacíos** → su install script revienta → exit 1.

- Reproducido con el tarball publicado 3.12.1 en npm 10.9.4 y npm 11.
- Install **local** hoistea fuera del subárbol y funciona — por eso `verify-pack` estuvo verde durante ~15 releases rotos.
- Los **upgrades** reutilizan el árbol existente y funcionan — por eso nadie lo vio.
- Causalidad probada: el mismo tarball sin `bundleDependencies` instala global OK.

## Cambios

- `@karajan/core` → **`karajan-core@1.0.0`, publicado en npm** (25 kB, solo `src/`, author handle). El root lo declara como dependencia de registry `^1.0.0` y **`bundleDependencies` desaparece**.
- Rename mecánico en 46 ficheros (imports, tests, workflows, docs). CHANGELOG intacto (historia).
- **`verify-pack` gana un smoke de install GLOBAL** — el test de regresión real de esta clase de bug, en el gate pre-publish.
- El guard de arquitectura `core-no-bundled-deps` ahora también prohíbe `bundleDependencies` en el root.

## Verificación

- Suite completa: **6005/6005 tests, 563 ficheros**
- `verify-pack`: npm local ✓, **global ✓ (nuevo)**, pnpm ✓
- Prettier ✓, ESLint ✓, privacy check ✓

## Relación con KJC-BUG-0102 (E2E crónicamente rojo)

La capa 1 del E2E (tarball sin core por falta de `npm ci`) desaparece de raíz: sin bundle, `npm pack` no necesita `node_modules` y el core llega del registry. El E2E debería ponerse verde tras el merge — primera señal real en meses.

Net: +168/−120 (mayoría rename 1:1). Fixes KJC-BUG-0103.