### PR TITLE
fix(sea): embed templates as SEA assets so the binary finds them

### DIFF
--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -19,7 +19,7 @@
  */
 
 import { execSync } from "node:child_process";
-import { cpSync, mkdirSync, writeFileSync, statSync } from "node:fs";
+import { cpSync, mkdirSync, writeFileSync, statSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -59,10 +59,32 @@ async function main() {
 
     // ── Step 2: Generate SEA blob ───────────────────────────────────
     console.log("[2/5] Generating SEA preparation blob...");
+    // Templates travel as SEA assets (KJC-BUG-0104): the binary ships no
+    // templates/ directory, so kj init / role prompts / onboard resolved
+    // paths like $HOME/templates/skills and hit ENOENT. The runtime
+    // (src/utils/templates-root.js) reads the index asset and extracts
+    // the files to ~/.karajan/embedded-templates/<version>/ on first use.
+    const { collectTemplateFiles } = await import("./esbuild-sea.config.mjs");
+    const pkgVersion = JSON.parse(
+      readFileSync(path.join(ROOT, "package.json"), "utf8"),
+    ).version;
+    const templateFiles = collectTemplateFiles();
+    writeFileSync(
+      path.join(DIST, "templates-index.json"),
+      JSON.stringify({ version: pkgVersion, files: templateFiles }),
+    );
+    // Absolute paths: node resolves asset paths against the CWD (not the
+    // config file), so anything relative is ambiguous.
+    const assets = { "templates-index.json": path.join(DIST, "templates-index.json") };
+    for (const rel of templateFiles) {
+      assets[`templates/${rel}`] = path.join(ROOT, "templates", rel);
+    }
+    console.log(`      -> ${templateFiles.length} template assets embedded.`);
     const seaConfig = {
       main: "dist/kj-bundle.cjs",
       output: "dist/sea-prep.blob",
       disableExperimentalSEAWarning: true,
+      assets,
     };
     writeFileSync(
       path.join(DIST, "sea-config.json"),

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -10,7 +10,7 @@
 
 import path from "node:path";
 import fs from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -213,6 +213,27 @@ const auditHistoryStubPlugin = {
 };
 
 /** @type {import('esbuild').BuildOptions} */
+/**
+ * List every built-in template file, as paths relative to templates/
+ * (KJC-BUG-0104). The SEA binary ships them as SEA assets — build-sea.mjs
+ * turns this list into the sea-config `assets` map plus an index the
+ * runtime (src/utils/templates-root.js) uses to extract them on first use.
+ * Exported (instead of living in build-sea.mjs, which runs main() on
+ * import) so tests can exercise it.
+ */
+export function collectTemplateFiles(rootDir = path.join(ROOT, "templates")) {
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else files.push(path.relative(rootDir, p));
+    }
+  };
+  walk(rootDir);
+  return files.sort();
+}
+
 export const seaBuildOptions = {
   entryPoints: ["src/cli.js"],
   outfile: "dist/kj-bundle.cjs",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -7,6 +7,7 @@ import { ollamaUp, waitForOllamaReady, normalizeOllamaConfig } from "../rag/olla
 import { checkOllamaCapability, pullOllamaModel } from "../rag/ollama-capability.js";
 import { exists, ensureDir } from "../utils/fs.js";
 import { getKarajanHome } from "../utils/paths.js";
+import { getTemplatesRoot } from "../utils/templates-root.js";
 import { detectAvailableAgents } from "../utils/agent-detect.js";
 import { createWizard, isTTY } from "../utils/wizard.js";
 import { runCommand } from "../utils/process.js";
@@ -441,7 +442,7 @@ async function ensureReviewRules(reviewRulesPath, logger) {
 
 async function ensureCoderRules(coderRulesPath, logger) {
   if (await exists(coderRulesPath)) return;
-  const templatePath = path.resolve(import.meta.dirname, "../../templates/coder-rules.md");
+  const templatePath = path.join(getTemplatesRoot(), "coder-rules.md");
   let content;
   try {
     content = await fs.readFile(templatePath, "utf8");
@@ -537,7 +538,7 @@ async function scaffoldCiGateway(config, flags, logger) {
   const workflowDir = path.join(projectDir, ".github", "workflows");
   await ensureDir(workflowDir);
 
-  const templatesDir = path.resolve(import.meta.dirname, "../../templates/workflows");
+  const templatesDir = path.join(getTemplatesRoot(), "workflows");
   const workflows = ["kj-ci-gateway.yml", "automerge.yml", "houston-override.yml"];
 
   for (const wf of workflows) {
@@ -611,7 +612,7 @@ async function bootstrapOllama({ flags, config, logger, interactive }) {
 async function installSkills(logger, interactive) {
   const projectDir = process.cwd();
   const commandsDir = path.join(projectDir, ".claude", "commands");
-  const skillsTemplateDir = path.resolve(import.meta.dirname, "../../templates/skills");
+  const skillsTemplateDir = path.join(getTemplatesRoot(), "skills");
 
   let doInstall = true;
   if (interactive) {

--- a/src/commands/onboard.js
+++ b/src/commands/onboard.js
@@ -6,6 +6,7 @@ import { collectAll } from "../onboarder/collectors/index.js";
 import { OnboarderRole } from "../roles/onboarder-role.js";
 import { resolveRole } from "../config.js";
 import { getKarajanHome } from "../utils/paths.js";
+import { getTemplatesRoot } from "../utils/templates-root.js";
 
 export function briefPath(projectDir) {
   const slug = path.basename(projectDir).replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
@@ -28,7 +29,7 @@ export async function onboardCommand({ config, logger, flags = {} }) {
     return { path: out, bundle, brief: null };
   }
   const roleCfg = resolveRole(config, "onboarder") || resolveRole(config, "architect");
-  const templatePath = new URL("../../templates/roles/onboarder.md", import.meta.url).pathname;
+  const templatePath = path.join(getTemplatesRoot(), "roles", "onboarder.md");
   const instructions = existsSync(templatePath) ? await readFile(templatePath, "utf8") : "";
   const role = new OnboarderRole({ instructions, config, ...roleCfg });
   // KJC-BUG-0061 Bug B: BaseRole.run() refuses to execute unless init()

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -10,6 +10,7 @@ import { buildCoderPrompt } from "../prompts/coder.js";
 import { buildReviewerPrompt } from "../prompts/reviewer.js";
 import { resolveRole } from "../config.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
+import { getTemplatesRoot } from "../utils/templates-root.js";
 import { BudgetTracker, extractUsageMetrics } from "../utils/budget.js";
 import { computeKjComparison } from "../budget/comparison.js";
 import { resolveRoleMdPath, loadFirstExisting } from "../roles/base-role.js";
@@ -76,7 +77,7 @@ export async function autoInit(projectDir, logger) {
   logger.info("No .karajan/ found — auto-initializing project scaffolding");
   await ensureDir(karajanDir);
 
-  const templatesDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "templates");
+  const templatesDir = getTemplatesRoot();
 
   const filesToCopy = [
     { src: "coder-rules.md", dest: "coder-rules.md" },

--- a/src/prompts/prompt-resolver.js
+++ b/src/prompts/prompt-resolver.js
@@ -26,8 +26,8 @@
 
 import fs from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { getKarajanHome } from "../utils/paths.js";
+import { getTemplatesRoot } from "../utils/templates-root.js";
 import { normalizeProvider } from "../utils/provider-env.js";
 
 /**
@@ -50,14 +50,7 @@ export function resolveRolePromptPaths(role, provider, projectDir) {
   if (projectDir) homes.push(path.join(projectDir, ".karajan", "roles"));
   homes.push(path.join(getKarajanHome(), "roles"));
 
-  const builtInRoot = path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "..",
-    "..",
-    "templates",
-    "roles"
-  );
-  homes.push(builtInRoot);
+  homes.push(path.join(getTemplatesRoot(), "roles"));
 
   const perProvider = [];
   const defaults = [];

--- a/src/utils/templates-root.js
+++ b/src/utils/templates-root.js
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isSea, getAsset } from "node:sea";
+import { getKarajanHome } from "./paths.js";
+
+// npm install / source tree: the real templates/ directory next to src/.
+const SOURCE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "templates",
+);
+
+const INDEX_ASSET = "templates-index.json";
+
+/**
+ * Root directory of the built-in templates (KJC-BUG-0104).
+ *
+ * The SEA binary ships only the JS bundle — templates/ never travels as
+ * files, and `import.meta.dirname`-relative resolution lands on the
+ * binary's own directory (e.g. `$HOME/templates/skills` → ENOENT). In SEA
+ * builds the templates travel as SEA assets (see scripts/build-sea.mjs);
+ * they are extracted once per version into ~/.karajan/embedded-templates/
+ * and served from there, so every fs-based consumer keeps working.
+ */
+export function getTemplatesRoot() {
+  if (!isSeaRuntime()) return SOURCE_ROOT;
+  const index = JSON.parse(getAsset(INDEX_ASSET, "utf8"));
+  const destRoot = path.join(getKarajanHome(), "embedded-templates", index.version);
+  return extractEmbeddedTemplates({
+    destRoot,
+    files: index.files,
+    readAsset: (rel) => getAsset(`templates/${rel}`, "utf8"),
+  });
+}
+
+function isSeaRuntime() {
+  try {
+    return isSea();
+  } catch {
+    // isSea() unexpectedly threw ⇒ treat as npm / source tree, never block.
+    return false;
+  }
+}
+
+/**
+ * Extract the embedded template files into destRoot (idempotent: a
+ * .complete marker skips re-extraction). Exported for unit testing.
+ */
+export function extractEmbeddedTemplates({ destRoot, files, readAsset }) {
+  const marker = path.join(destRoot, ".complete");
+  if (fs.existsSync(marker)) return destRoot;
+  for (const rel of files) {
+    const dest = path.join(destRoot, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, readAsset(rel));
+  }
+  fs.writeFileSync(marker, "");
+  return destRoot;
+}

--- a/tests/sea-templates.test.js
+++ b/tests/sea-templates.test.js
@@ -1,0 +1,72 @@
+/**
+ * KJC-BUG-0104 — the SEA binary shipped NO templates/: esbuild rewrites
+ * import.meta.dirname to the binary's own directory, so `kj init` resolved
+ * `$HOME/templates/skills` and warned ENOENT, and built-in role prompts /
+ * config-init / onboard templates were unreachable on a fresh machine.
+ *
+ * Fix: templates travel as SEA assets (scripts/build-sea.mjs) and
+ * src/utils/templates-root.js extracts them once per version. These tests
+ * cover the two halves that run outside a real SEA binary:
+ *  - the build-side asset collection (every template file is listed)
+ *  - the runtime extraction (idempotent, faithful contents)
+ *  - the non-SEA path (source tree resolves to the real templates/)
+ */
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectTemplateFiles } from "../scripts/esbuild-sea.config.mjs";
+import { getTemplatesRoot, extractEmbeddedTemplates } from "../src/utils/templates-root.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("SEA templates (KJC-BUG-0104)", () => {
+  it("collectTemplateFiles lists every built-in template the runtime depends on", () => {
+    const files = collectTemplateFiles();
+    // The exact files each consumer needs: skills (init), built-in role
+    // prompts (prompt-resolver), coder-rules + workflows (init/config-init).
+    expect(files).toContain("coder-rules.md");
+    expect(files).toContain("review-rules.md");
+    expect(files.some((f) => f.startsWith(path.join("skills", "")))).toBe(true);
+    expect(files.some((f) => f.startsWith(path.join("roles", "")))).toBe(true);
+    expect(files.some((f) => f.startsWith(path.join("workflows", "")))).toBe(true);
+    // Sanity: matches what actually lives on disk.
+    expect(files.length).toBeGreaterThanOrEqual(70);
+    for (const rel of files) {
+      expect(fs.existsSync(path.join(REPO_ROOT, "templates", rel))).toBe(true);
+    }
+  });
+
+  it("getTemplatesRoot resolves the real templates/ dir outside a SEA binary", () => {
+    const root = getTemplatesRoot();
+    expect(root).toBe(path.join(REPO_ROOT, "templates"));
+    expect(fs.existsSync(path.join(root, "skills"))).toBe(true);
+  });
+
+  it("extractEmbeddedTemplates writes every file faithfully and is idempotent", () => {
+    const destRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kj-tpl-extract-"));
+    try {
+      const files = ["coder-rules.md", path.join("skills", "kj-run.md")];
+      const contents = { "coder-rules.md": "# rules", [path.join("skills", "kj-run.md")]: "# skill" };
+      let reads = 0;
+      const readAsset = (rel) => {
+        reads += 1;
+        return contents[rel];
+      };
+
+      const first = extractEmbeddedTemplates({ destRoot, files, readAsset });
+      expect(first).toBe(destRoot);
+      expect(fs.readFileSync(path.join(destRoot, "coder-rules.md"), "utf8")).toBe("# rules");
+      expect(fs.readFileSync(path.join(destRoot, "skills", "kj-run.md"), "utf8")).toBe("# skill");
+      expect(reads).toBe(2);
+
+      // Second call sees the .complete marker and never re-reads assets.
+      extractEmbeddedTemplates({ destRoot, files, readAsset });
+      expect(reads).toBe(2);
+    } finally {
+      fs.rmSync(destRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Qué (KJC-BUG-0104)

Reporte real de un usuario de Mac con el binario standalone:
```
[warn] Could not install skills: ENOENT: no such file or directory, scandir '/Users/jcasar/templates/skills'
```

**El binario SEA no llevaba `templates/`** (solo embebe el bundle JS) y esbuild reescribe `import.meta.dirname` → `__dirname` = directorio del propio binario → `../../templates/skills` = `$HOME/templates/skills` → ENOENT. Afectaba a los 6 consumidores: skills (`kj init`), coder-rules, workflows, role prompts built-in (`prompt-resolver`), `config-init` y `onboard`.

## Cambios

- **Los templates viajan como SEA assets** (`scripts/build-sea.mjs` genera el mapa de 72 assets + índice; `collectTemplateFiles()` exportado en `esbuild-sea.config.mjs` para poder testearlo).
- **`src/utils/templates-root.js`** — resolver único: en npm/source devuelve el `templates/` real; en SEA extrae los assets una vez por versión a `~/.karajan/embedded-templates/<versión>/` (idempotente vía marker) y todos los consumidores fs siguen funcionando sin cambios de lógica.
- Los 6 puntos de consumo pasan a `getTemplatesRoot()` (de paso elimina el bug latente de `new URL().pathname` en Windows en onboard/config-init).
- 3 tests nuevos (`tests/sea-templates.test.js`): colección de assets completa y fiel al disco, resolución non-SEA, extracción fiel + idempotente.

## Verificación

- **E2E real con binario SEA construido en local** (120 MB, 72 assets): `kj init --no-interactive` en proyecto limpio con HOME aislado → `Installed 14 Karajan skill(s)` ✓, templates extraídos a `~/.karajan/embedded-templates/3.12.2/` ✓, **sin ENOENT** — el escenario exacto del reporte.
- Suite completa: 6008/6008 · ESLint ✓ · Prettier ✓ · privacy ✓

Net ~+178 LOC (fix + tests). Fixes KJC-BUG-0104.