### PR TITLE
fix(install-tools): point osv-scanner go install at the v2 cmd path

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ None of these are required. Karajan auto-skips any scanner that isn't installed,
 | Tool | Scope | Install | Installable from `kj init`? | What you get |
 |------|-------|---------|-----------------------------|--------------|
 | **SonarQube** | Any stack | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | ✅ Yes (wizard configures Docker container + token) | Code quality + security rules with line-precision in `kj audit` |
-| **OSV-Scanner** | Any stack | `go install github.com/google/osv-scanner@latest` | ❌ No (install manually) | Dependency CVE coverage broader than `npm audit` |
+| **OSV-Scanner** | Any stack | `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` | ❌ No (install manually) | Dependency CVE coverage broader than `npm audit` |
 | **Semgrep** | Any stack | `pipx install semgrep` | ❌ No (install manually) | SAST: XSS, SQLi, taint flow, secrets — equivalent to `snyk code`, free for OSS |
 | **Lighthouse** | **Frontend only** | `npm install -g lighthouse` | ❌ No (install manually) | Core Web Vitals + opportunities for `kj webperf` (auto-feeds `kj audit`) |
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -16,7 +16,7 @@ Karajan's audit pipeline runs deterministic scanners in parallel and feeds their
 | Tool | Install | Used by | Gives you |
 |------|---------|---------|-----------|
 | **SonarQube** | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | `kj audit`, `kj run` | Code quality + security rules with line-precision; `kj audit` cross-references the LLM's findings against Sonar rule IDs |
-| **OSV-Scanner** | `go install github.com/google/osv-scanner@latest` | `kj audit` | Dependency CVE coverage broader than `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + others). No account, no upload |
+| **OSV-Scanner** | `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` | `kj audit` | Dependency CVE coverage broader than `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + others). No account, no upload |
 | **Semgrep** | `pipx install semgrep` (or `brew install semgrep`) | `kj audit` | SAST: XSS, SQLi, taint flow, hardcoded secrets, language-specific anti-patterns. Equivalent to `snyk code` but free for OSS. `--config auto` ships 2 000+ rules |
 | **Lighthouse** | `npm install -g lighthouse` | `kj webperf`, `kj audit` (when scan exists) | Core Web Vitals (LCP, CLS, INP) + opportunity audits (render-blocking, unused CSS, image format, font-display) for frontend projects. `kj webperf` writes the result to `~/.karajan/webperf/<slug>/last.json` and `kj audit` reads it automatically |
 
@@ -37,7 +37,7 @@ kj install-tools --only semgrep,osv-scanner      # Subset
 Behaviour per tool:
 
 - **Semgrep**: picks `pipx install semgrep` if pipx is available, falls back to `brew install semgrep`, then `pip install semgrep`.
-- **OSV-Scanner**: picks `go install github.com/google/osv-scanner@latest` if Go is available, falls back to `brew install osv-scanner`.
+- **OSV-Scanner**: picks `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` if Go is available, falls back to `brew install osv-scanner`.
 - **Lighthouse**: `npm install -g lighthouse`. **Only suggested on frontend / fullstack projects** — backend-only projects don't see lighthouse noise. Use `--only lighthouse` to force.
 - **Docker**: never auto-installed (platform-specific). Prints docs URL and, on macOS, the `brew install --cask docker` hint.
 - **Sonar**: requires Docker. If a `docker-compose.yml` exists in the cwd, suggests `docker compose up -d`; otherwise a one-shot `docker run` with the official SonarQube image.

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -16,7 +16,7 @@ El pipeline de audit de Karajan corre scanners deterministas en paralelo y mete 
 | Tool | Instalación | Usado por | Te da |
 |------|-------------|-----------|-------|
 | **SonarQube** | `docker compose -f ~/sonarqube/docker-compose.yml up -d` | `kj audit`, `kj run` | Code quality + security rules con line-precision; `kj audit` cruza los hallazgos del LLM con los rule IDs de Sonar |
-| **OSV-Scanner** | `go install github.com/google/osv-scanner@latest` | `kj audit` | Cobertura CVE de dependencias más amplia que `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + otros). Sin cuenta, sin upload |
+| **OSV-Scanner** | `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` | `kj audit` | Cobertura CVE de dependencias más amplia que `npm audit` (GitHub Advisory DB + GLSA + Go vuln DB + otros). Sin cuenta, sin upload |
 | **Semgrep** | `pipx install semgrep` (o `brew install semgrep`) | `kj audit` | SAST: XSS, SQLi, taint flow, secrets hardcodeados, anti-patrones específicos por lenguaje. Equivalente a `snyk code` pero gratis para OSS. `--config auto` trae 2 000+ reglas |
 | **Lighthouse** | `npm install -g lighthouse` | `kj webperf`, `kj audit` (cuando hay scan) | Core Web Vitals (LCP, CLS, INP) + audits de oportunidades (render-blocking, CSS sin uso, formato de imagen, font-display) para proyectos frontend. `kj webperf` escribe el resultado en `~/.karajan/webperf/<slug>/last.json` y `kj audit` lo lee automáticamente |
 
@@ -37,7 +37,7 @@ kj install-tools --only semgrep,osv-scanner      # Subset
 Comportamiento por herramienta:
 
 - **Semgrep**: usa `pipx install semgrep` si pipx está disponible, cae a `brew install semgrep`, luego `pip install semgrep`.
-- **OSV-Scanner**: usa `go install github.com/google/osv-scanner@latest` si Go está disponible, cae a `brew install osv-scanner`.
+- **OSV-Scanner**: usa `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest` si Go está disponible, cae a `brew install osv-scanner`.
 - **Lighthouse**: `npm install -g lighthouse`. **Solo se sugiere en proyectos frontend / fullstack** — proyectos backend-only no ven ruido de lighthouse. Usa `--only lighthouse` para forzar.
 - **Docker**: nunca se auto-instala (depende de plataforma). Imprime URL de docs y, en macOS, el hint `brew install --cask docker`.
 - **Sonar**: necesita Docker. Si hay un `docker-compose.yml` en el cwd, sugiere `docker compose up -d`; si no, un `docker run` puntual con la imagen oficial de SonarQube.

--- a/src/audit/osv-findings.js
+++ b/src/audit/osv-findings.js
@@ -48,7 +48,7 @@ export async function collectOsvFindings(projectDir, logger = null) {
     // err.code 1 is NORMAL — we still want the stdout. Real failures are
     // ENOENT (binary missing) or stdout empty.
     if (err.code === "ENOENT") {
-      if (logger?.warn) logger.warn("osv-scanner not found in PATH — install via 'go install github.com/google/osv-scanner@latest'");
+      if (logger?.warn) logger.warn("osv-scanner not found in PATH — install via 'go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest'");
       return { available: false, reason: "osv-scanner not installed" };
     }
     if (err.killed) {

--- a/src/utils/install-hints.js
+++ b/src/utils/install-hints.js
@@ -97,7 +97,11 @@ const INSTALL_CANDIDATES = {
     { manager: "pip", command: "pip install semgrep" },
   ],
   "osv-scanner": [
-    { manager: "go", command: "go install github.com/google/osv-scanner@latest" },
+    // The module root has no main package — the binary lives in the cmd/
+    // subpackage, and since v2 the module path carries the /v2 suffix.
+    // `go install github.com/google/osv-scanner@latest` resolves the module
+    // (v1.x) but fails with "does not contain package" (KJC-BUG-0105).
+    { manager: "go", command: "go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest" },
     { manager: "brew", command: "brew install osv-scanner" },
   ],
   lighthouse: [

--- a/tests/utils/install-hints.test.js
+++ b/tests/utils/install-hints.test.js
@@ -23,9 +23,12 @@ describe("getInstallHint — manager prioritization", () => {
     expect(hint.command).toBe("pip install semgrep");
   });
 
-  it("prefers go install for osv-scanner", async () => {
+  it("prefers go install for osv-scanner, targeting the cmd/ subpackage (KJC-BUG-0105)", async () => {
     const hint = await getInstallHint("osv-scanner", { go: true, brew: true });
-    expect(hint.command).toMatch(/go install.*osv-scanner/);
+    // The module root has no main package: installing
+    // github.com/google/osv-scanner@latest resolves the module but fails
+    // with "does not contain package". The binary lives in /v2/cmd/.
+    expect(hint.command).toBe("go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest");
     expect(hint.manager).toBe("go");
   });
 


### PR DESCRIPTION
## Qué (KJC-BUG-0105)

Reporte de usuario:
```
✗ osv-scanner: install failed (... module github.com/google/osv-scanner@latest found (v1.9.2),
  but does not contain package github.com/google/osv-scanner
```

La raíz del módulo no tiene paquete main: el binario vive en el subpaquete `cmd/` y desde v2 el module path lleva `/v2`. Ruta correcta: `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest`.

## Cambios
- `src/utils/install-hints.js`: candidato go de install-tools corregido (con comentario del porqué).
- `src/audit/osv-findings.js`: hint del warn de `kj audit` corregido.
- Test endurecido: fija la ruta completa (el anterior `/go install.*osv-scanner/` pasaba con ambas).
- Docs: GETTING-STARTED EN/ES + README con el comando correcto (5 ocurrencias).

## Verificación
- tests install-hints + doctor-install-tip: 23/23 ✓ · Prettier ✓ · privacy ✓

Net +7 LOC en código. Fixes KJC-BUG-0105.