### PR TITLE
fix(update): channel-aware self-update with PATH verification

### DIFF
--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { isSea } from "node:sea";
 import { getKarajanHome } from "./paths.js";
@@ -104,30 +105,46 @@ export async function printUpdateNotice(currentVersion) {
 }
 
 /**
- * Run the npm-channel self-update (`kj update`). Captures npm's output instead
- * of streaming it: a successful update shows only the progress + result line,
- * so npm's deprecation / allow-scripts / funding noise — build plumbing, not
- * actionable for whoever runs the command — never reaches the user. On failure
- * the captured stdout/stderr IS surfaced, so real errors (native build,
- * permissions) stay diagnosable — never a silent failure.
+ * Run the self-update (`kj update`), channel-aware (KJC-BUG-0106).
+ *
+ * npm channel: `npm install -g` with CAPTURED output — success shows only
+ * progress + result; npm's deprecation / allow-scripts / funding noise never
+ * reaches the user. On failure the captured output IS surfaced.
+ *
+ * sea channel (standalone binary): npm-installing would update a copy the
+ * PATH never resolves — the running binary stays old while `kj update`
+ * reports success. Instead the binary installer is re-run (downloaded to a
+ * temp file first, never piped from the network straight into a shell).
+ *
+ * Both channels end with a PATH probe: `kj --version` must report the new
+ * version, otherwise a stale copy shadows the update and the command fails
+ * LOUDLY naming the likely cause — never a silent "updated" that isn't.
  *
  * @param {Object} opts
  * @param {string} opts.currentVersion - version of the running kj
  * @param {(cmd: string, args: string[]) => Promise<{stdout: string, stderr: string}>} [opts.exec] - injectable runner (defaults to execa)
  * @param {Console} [opts.logger]
- * @returns {Promise<{ ok: boolean, alreadyLatest?: boolean, latest?: string }>}
+ * @param {"npm"|"sea"} [opts.channel] - injectable channel (defaults to detectInstallChannel())
+ * @param {typeof fetch} [opts.fetchFn] - injectable fetch (registry lookup + installer download)
+ * @returns {Promise<{ ok: boolean, alreadyLatest?: boolean, latest?: string, manual?: boolean }>}
  */
-export async function performSelfUpdate({ currentVersion, exec, logger = console } = {}) {
+export async function performSelfUpdate({ currentVersion, exec, logger = console, channel, fetchFn = fetch } = {}) {
   const run = exec || (async (cmd, args) => (await import("execa")).execa(cmd, args));
+  const ch = channel || detectInstallChannel();
   logger.log(`Current version: ${currentVersion}`);
   logger.log("Checking for updates...");
 
   let latest;
   try {
-    const { stdout } = await run("npm", ["view", PACKAGE_NAME, "version"]);
-    latest = stdout.trim();
+    // Registry over HTTP, not `npm view` — standalone-binary machines may
+    // not have npm at all.
+    const res = await fetchFn(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) throw new Error(`registry responded ${res.status}`);
+    latest = (await res.json()).version;
   } catch (err) {
-    logger.error(`Update failed: ${err.shortMessage || err.message}`);
+    logger.error(`Update failed: could not check the registry (${err.message})`);
     return { ok: false };
   }
 
@@ -136,18 +153,64 @@ export async function performSelfUpdate({ currentVersion, exec, logger = console
     return { ok: true, alreadyLatest: true, latest };
   }
 
+  if (ch === "sea" && process.platform === "win32") {
+    // Executing a downloaded .ps1 from inside the binary is not supported
+    // yet — hand the user the exact command instead of half-updating.
+    logger.log(`Update available: ${currentVersion} → ${latest} (standalone binary).`);
+    logger.log(`${updateInstruction({ channel: "sea" })}`);
+    return { ok: true, latest, manual: true };
+  }
+
   logger.log(`Updating ${currentVersion} → ${latest}... (this can take a few minutes)`);
   try {
-    // No stdio:inherit — capture and drop npm's warnings on the success path.
-    await run("npm", ["install", "-g", `${PACKAGE_NAME}@latest`]);
-    logger.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
-    return { ok: true, latest };
+    if (ch === "sea") {
+      // Re-run the binary installer: download to a temp file, then execute —
+      // never pipe the network straight into a shell.
+      const res = await fetchFn(INSTALL_SH_URL);
+      if (!res.ok) throw new Error(`installer download failed (${res.status})`);
+      const tmpScript = path.join(os.tmpdir(), `kj-install-${process.pid}.sh`);
+      await fs.writeFile(tmpScript, await res.text(), { mode: 0o700 });
+      try {
+        await run("sh", [tmpScript]);
+      } finally {
+        await fs.rm(tmpScript, { force: true });
+      }
+    } else {
+      // No stdio:inherit — capture and drop npm's warnings on the success path.
+      await run("npm", ["install", "-g", `${PACKAGE_NAME}@latest`]);
+    }
   } catch (err) {
     if (err.stdout) logger.error(err.stdout);
     if (err.stderr) logger.error(err.stderr);
     logger.error(`Update failed: ${err.shortMessage || err.message}`);
     return { ok: false };
   }
+
+  // The install succeeded — but is the kj the USER runs actually the new one?
+  const onPath = await verifyKjOnPath({ run, latest, logger });
+  if (!onPath) return { ok: false };
+  logger.log(`Updated to ${latest}. Restart Claude to pick up the new MCP server.`);
+  return { ok: true, latest };
+}
+
+/**
+ * Probe `kj --version` through the PATH and confirm it reports `latest`.
+ * A mismatch means a stale copy shadows the freshly installed one (e.g. a
+ * standalone binary in ~/.local/bin in front of the npm global prefix).
+ */
+async function verifyKjOnPath({ run, latest, logger }) {
+  let reported;
+  try {
+    const { stdout } = await run("kj", ["--version"]);
+    reported = String(stdout).trim();
+  } catch (err) {
+    logger.error(`Update installed ${latest}, but running \`kj --version\` failed: ${err.shortMessage || err.message}`);
+    return false;
+  }
+  if (reported.includes(latest)) return true;
+  logger.error(`Update installed ${latest}, but the \`kj\` on your PATH still reports ${reported}.`);
+  logger.error("A stale copy is shadowing the update. Check `which -a kj` and remove the old one, or update through the channel that owns the first entry.");
+  return false;
 }
 
 /** Simple semver compare: returns >0 if a > b, <0 if a < b, 0 if equal */

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -13,6 +13,7 @@ vi.mock("node:fs/promises", () => ({
     readFile: vi.fn(),
     writeFile: vi.fn(),
     mkdir: vi.fn(),
+    rm: vi.fn(),
   },
 }));
 
@@ -135,29 +136,66 @@ describe("performSelfUpdate", () => {
   const makeLogger = () => ({ log: vi.fn(), error: vi.fn() });
   const logged = (logger) => logger.log.mock.calls.map((c) => c.join(" ")).join("\n");
   const errored = (logger) => logger.error.mock.calls.map((c) => c.join(" ")).join("\n");
+  const registry = (version) =>
+    vi.fn(async () => ({ ok: true, json: async () => ({ version }), text: async () => "#!/bin/sh\n" }));
 
   it("reports already-latest and never runs the install", async () => {
-    const exec = vi.fn(async () => ({ stdout: "3.12.0", stderr: "" }));
+    const exec = vi.fn();
     const logger = makeLogger();
-    const result = await performSelfUpdate({ currentVersion: "3.12.0", exec, logger });
+    const result = await performSelfUpdate({
+      currentVersion: "3.12.0", exec, logger, channel: "npm", fetchFn: registry("3.12.0"),
+    });
     expect(result).toEqual({ ok: true, alreadyLatest: true, latest: "3.12.0" });
-    expect(exec).toHaveBeenCalledTimes(1); // only `npm view`, no install
+    expect(exec).not.toHaveBeenCalled();
     expect(logged(logger)).toMatch(/Already on the latest/);
   });
 
-  it("installs the latest and hides npm's noise on success", async () => {
+  it("installs the latest, hides npm's noise, and verifies the kj on PATH", async () => {
     const noisy = "npm warn deprecated prebuild-install@7\nnpm warn allow-scripts\n100 packages are looking for funding";
-    const exec = vi.fn(async (_cmd, args) =>
-      args[0] === "view" ? { stdout: "3.12.0", stderr: "" } : { stdout: noisy, stderr: noisy });
+    const exec = vi.fn(async (cmd) =>
+      cmd === "kj" ? { stdout: "3.12.0", stderr: "" } : { stdout: noisy, stderr: noisy });
     const logger = makeLogger();
-    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    const result = await performSelfUpdate({
+      currentVersion: "3.10.2", exec, logger, channel: "npm", fetchFn: registry("3.12.0"),
+    });
     expect(result).toEqual({ ok: true, latest: "3.12.0" });
     expect(exec).toHaveBeenCalledWith("npm", ["install", "-g", "karajan-code@latest"]);
+    expect(exec).toHaveBeenCalledWith("kj", ["--version"]);
     const out = logged(logger);
-    expect(out).toMatch(/Updating 3\.10\.2 → 3\.12\.0/);
     expect(out).toMatch(/Updated to 3\.12\.0/);
     // The whole point: none of npm's plumbing reaches the user on success.
     expect(out).not.toMatch(/npm warn|deprecated|allow-scripts|funding/);
+  });
+
+  it("fails LOUDLY when the kj on PATH still reports the old version (KJC-BUG-0106)", async () => {
+    // The user's laptop: npm installs 3.12.2 into its prefix, but the SEA
+    // binary earlier on PATH keeps answering 3.10.2.
+    const exec = vi.fn(async (cmd) =>
+      cmd === "kj" ? { stdout: "3.10.2", stderr: "" } : { stdout: "", stderr: "" });
+    const logger = makeLogger();
+    const result = await performSelfUpdate({
+      currentVersion: "3.10.2", exec, logger, channel: "npm", fetchFn: registry("3.12.2"),
+    });
+    expect(result).toEqual({ ok: false });
+    const out = errored(logger);
+    expect(out).toMatch(/still reports 3\.10\.2/);
+    expect(out).toMatch(/which -a kj/);
+    expect(logged(logger)).not.toMatch(/Updated to/); // no false success line
+  });
+
+  it("sea channel re-runs the downloaded installer instead of npm (KJC-BUG-0106)", async () => {
+    const exec = vi.fn(async (cmd) =>
+      cmd === "kj" ? { stdout: "3.12.2", stderr: "" } : { stdout: "", stderr: "" });
+    const logger = makeLogger();
+    const result = await performSelfUpdate({
+      currentVersion: "3.10.2", exec, logger, channel: "sea", fetchFn: registry("3.12.2"),
+    });
+    expect(result).toEqual({ ok: true, latest: "3.12.2" });
+    // Installer executed from a temp file via sh — npm never invoked.
+    const cmds = exec.mock.calls.map((c) => c[0]);
+    expect(cmds).toContain("sh");
+    expect(cmds).not.toContain("npm");
+    expect(exec).toHaveBeenCalledWith("kj", ["--version"]);
   });
 
   it("surfaces the captured npm output and fails loudly when install errors", async () => {
@@ -166,12 +204,11 @@ describe("performSelfUpdate", () => {
       stdout: "gyp ERR! build error",
       stderr: "node-gyp rebuild failed",
     });
-    const exec = vi.fn(async (_cmd, args) => {
-      if (args[0] === "view") return { stdout: "3.12.0", stderr: "" };
-      throw err;
-    });
+    const exec = vi.fn(async () => { throw err; });
     const logger = makeLogger();
-    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    const result = await performSelfUpdate({
+      currentVersion: "3.10.2", exec, logger, channel: "npm", fetchFn: registry("3.12.0"),
+    });
     expect(result).toEqual({ ok: false });
     const out = errored(logger);
     expect(out).toMatch(/gyp ERR! build error/);
@@ -179,10 +216,12 @@ describe("performSelfUpdate", () => {
     expect(out).toMatch(/Update failed/);
   });
 
-  it("fails cleanly when the version lookup itself errors", async () => {
-    const exec = vi.fn(async () => { throw new Error("network down"); });
+  it("fails cleanly when the registry lookup itself errors", async () => {
+    const fetchFn = vi.fn(async () => { throw new Error("network down"); });
     const logger = makeLogger();
-    const result = await performSelfUpdate({ currentVersion: "3.10.2", exec, logger });
+    const result = await performSelfUpdate({
+      currentVersion: "3.10.2", exec: vi.fn(), logger, channel: "npm", fetchFn,
+    });
     expect(result).toEqual({ ok: false });
     expect(errored(logger)).toMatch(/Update failed/);
   });


### PR DESCRIPTION
## Qué (KJC-BUG-0106, Individual Blocker)

Reporte real (portátil del usuario, kj 3.10.2 standalone): dos `kj update` "exitosos" (`Updated to 3.12.1`, `Updated to 3.12.2`) y `kj` sigue en 3.10.2. **`kj update` hacía `npm install -g` SIEMPRE, sin mirar el canal**: npm actualiza su copia en el prefix global pero el PATH sigue resolviendo el binario SEA viejo → éxito falso, fallo silencioso.

## Cambios

- **Canal sea**: re-ejecuta el instalador de binarios (descargado a fichero temporal y ejecutado — nunca red→shell directo). En Windows entrega el comando exacto en vez de medio-actualizar.
- **Lookup del registry por HTTP** en vez de `npm view` — una máquina con solo el binario puede no tener npm.
- **Verificación post-update en AMBOS canales**: sonda `kj --version` a través del PATH; si no reporta la versión objetivo, el comando **falla en alto** señalando la copia que hace sombra (`which -a kj`) — se acabó el "Updated to X" mentiroso.
- 6 tests (2 nuevos: shadow-detection con el escenario exacto del reporte, y canal sea ejecutando el instalador sin tocar npm).

## Verificación
- Suite completa: 6008/6008 · update-check 20/20 · ratchet dynamic-imports intacto (node:os estático) · ESLint ✓ · Prettier ✓ · privacy ✓

Net +102 LOC. Fixes KJC-BUG-0106.