### PR TITLE
feat(harden): respect cross-tool alternatives like biome

### DIFF
--- a/src/harden/advisory.js
+++ b/src/harden/advisory.js
@@ -12,6 +12,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { findManagedBlock } from "../utils/managed-markers.js";
+import { findAlternative } from "./alternatives.js";
 import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 import { detectStackRoots } from "./stack-roots.js";
 
@@ -98,6 +99,13 @@ function readArtifactContent(searchDir, foundAt) {
 
 /** Map a classified state to a recommendation + human rationale. */
 function recommend(state) {
+  if (state.status === "SATISFIED_BY_ALTERNATIVE") {
+    return {
+      recommendation: "keep",
+      rationale: `covered by ${state.foundAt} (${state.alternativeTool}) — kj won't add a second linter/formatter`,
+      mergeable: false,
+    };
+  }
   if (state.status === "MISSING") return { recommendation: "install", rationale: `kj would add ${state.file}`, mergeable: true };
   if (state.status === "USER_OWNED") {
     const n = state.improvements?.length ?? 0;
@@ -109,11 +117,20 @@ function recommend(state) {
   return { recommendation: "update", rationale: `kj v${state.currentVersion} available (you have v${state.managedVersion})`, mergeable: true };
 }
 
-/** Classify a single artifact found (or not) under `searchDir`. */
-export function classifyArtifact(searchDir, artifact) {
+/**
+ * Classify a single artifact found (or not) under `searchDir`. `altDirs`
+ * widens the cross-tool alternative lookup (a root-level biome.json covers a
+ * monorepo's language roots); the user's OWN config of the same tool still
+ * wins over an alternative.
+ */
+export function classifyArtifact(searchDir, artifact, altDirs = [searchDir]) {
   const foundAt = findArtifactFile(searchDir, artifact);
   const base = { foundAt, managedVersion: null, upToDate: null, improvements: [] };
   let state = { ...base, status: "MISSING" };
+  if (!foundAt) {
+    const alt = findAlternative(altDirs, artifact.id);
+    if (alt) state = { ...base, status: "SATISFIED_BY_ALTERNATIVE", foundAt: alt.foundAt, alternativeTool: alt.tool };
+  }
   if (foundAt) {
     const content = readArtifactContent(searchDir, foundAt);
     if (artifact.blockId && content.includes(`kj:managed:${artifact.blockId}`)) {
@@ -139,8 +156,10 @@ export function compareHarden({ projectDir = process.cwd(), profile = "standard"
   for (const { dir, language } of detectStackRoots(projectDir, { only, exclude })) {
     const searchDir = dir === "." ? projectDir : join(projectDir, dir);
     for (const cfg of CONFIGS_BY_LANGUAGE[language] ?? []) {
-      const res = classifyArtifact(searchDir, toArtifact(cfg));
-      artifacts.push({ dir, ...res, foundAt: res.foundAt && dir !== "." ? join(dir, res.foundAt) : res.foundAt });
+      const res = classifyArtifact(searchDir, toArtifact(cfg), [searchDir, projectDir]);
+      // Alternative matches may live at the repo root — keep their path unprefixed.
+      const prefix = res.foundAt && dir !== "." && res.status !== "SATISFIED_BY_ALTERNATIVE";
+      artifacts.push({ dir, ...res, foundAt: prefix ? join(dir, res.foundAt) : res.foundAt });
     }
   }
   return { artifacts };

--- a/src/harden/alternatives.js
+++ b/src/harden/alternatives.js
@@ -1,0 +1,50 @@
+/**
+ * Cross-tool alternatives for `kj harden` (KJC-TSK-0614).
+ *
+ * A user's Biome config replaces BOTH eslint and prettier — seeding kj's
+ * configs next to biome.json installs a second, conflicting linter/formatter
+ * that fights the user's own hooks. The advisory's EQUIVALENTS map only
+ * covers same-tool filename variants; this map covers whole-tool
+ * substitutions, and the three surfaces (advisory, config-engine, check)
+ * consult it before treating an artifact as missing.
+ *
+ * Detection is config-file based on purpose: deterministic, and a false
+ * negative just means kj proposes its default (the pre-0614 behaviour),
+ * never that it overwrites the user's tool.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const ALTERNATIVES = {
+  eslint: [{ tool: "biome", files: ["biome.json", "biome.jsonc"] }],
+  prettier: [{ tool: "biome", files: ["biome.json", "biome.jsonc"] }],
+};
+
+/**
+ * First alternative tool that satisfies `artifactId`, searching each dir in
+ * order (a language root first, then the repo root — a root-level biome.json
+ * covers the whole monorepo). Null when none applies.
+ *
+ * @param {string[]} searchDirs
+ * @param {string} artifactId - "eslint" | "prettier" | ...
+ * @returns {{ tool: string, foundAt: string }|null}
+ */
+export function findAlternative(searchDirs, artifactId) {
+  for (const alt of ALTERNATIVES[artifactId] ?? []) {
+    for (const dir of searchDirs) {
+      for (const rel of alt.files) {
+        if (existsSync(join(dir, rel))) return { tool: alt.tool, foundAt: rel };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Artifact id for a config-template entry — same convention as the
+ * advisory's toArtifact: prettier is the only marker-less JSON config.
+ */
+export function artifactIdForConfig(cfg) {
+  return cfg.blockId ?? "prettier";
+}

--- a/src/harden/check.js
+++ b/src/harden/check.js
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { runCommand } from "../utils/process.js";
+import { artifactIdForConfig, findAlternative } from "./alternatives.js";
 import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 import { PROFILE_HOOKS } from "./hook-templates.js";
 import { detectStackRoots } from "./stack-roots.js";
@@ -53,8 +54,18 @@ export async function checkHarden({ projectDir = process.cwd(), profile = "stand
       checks.push(presence(projectDir, cfg.file, `config:${cfg.file}`, "missing — run kj harden"));
     }
     for (const { dir, language } of roots) {
+      const rootDir = dir === "." ? projectDir : join(projectDir, dir);
       for (const cfg of CONFIGS_BY_LANGUAGE[language] ?? []) {
         const rel = dir === "." ? cfg.file : join(dir, cfg.file);
+        // A config covered by the user's own tool (biome.json ⇒ eslint+prettier)
+        // is not drift — kj must not demand a second linter/formatter (KJC-TSK-0614).
+        if (!existsSync(join(projectDir, rel))) {
+          const alt = findAlternative([rootDir, projectDir], artifactIdForConfig(cfg));
+          if (alt) {
+            checks.push({ id: `config:${rel}`, ok: true, detail: `covered by ${alt.foundAt} (${alt.tool})` });
+            continue;
+          }
+        }
         checks.push(presence(projectDir, rel, `config:${rel}`, `missing for ${language} — run kj harden`));
       }
     }

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -9,6 +9,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { artifactIdForConfig, findAlternative } from "./alternatives.js";
 import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 
 const BLOCK_VERSION = 1;
@@ -18,12 +19,25 @@ function writeFile(target, content) {
   writeFileSync(target, content);
 }
 
-/** Seed a list of config entries into `targetDir`, labelling each by `prefix`. */
-function seedInto(targetDir, configs, dryRun, prefix, results) {
+/**
+ * Seed a list of config entries into `targetDir`, labelling each by `prefix`.
+ * `altDirs` widens the cross-tool alternative lookup (KJC-TSK-0614): a config
+ * covered by the user's own tool (biome.json ⇒ eslint+prettier) is never
+ * seeded — kj must not install a second, conflicting linter/formatter.
+ */
+function seedInto(targetDir, configs, dryRun, prefix, results, altDirs = [targetDir]) {
   for (const cfg of configs) {
     const target = join(targetDir, cfg.file);
     const exists = existsSync(target);
     const file = prefix === "." ? cfg.file : join(prefix, cfg.file);
+
+    if (!exists) {
+      const alt = findAlternative(altDirs, artifactIdForConfig(cfg));
+      if (alt) {
+        results.push({ file, action: "covered", by: alt.foundAt });
+        continue;
+      }
+    }
 
     if (cfg.json) {
       const action = exists ? "skipped" : "inserted";
@@ -69,7 +83,9 @@ export function installConfigsForRoots({ projectDir = process.cwd(), roots = [],
   const results = [];
   seedInto(projectDir, UNIVERSAL_CONFIGS, dryRun, ".", results);
   for (const { dir, language } of roots) {
-    seedInto(join(projectDir, dir), CONFIGS_BY_LANGUAGE[language] ?? [], dryRun, dir, results);
+    const rootDir = join(projectDir, dir);
+    // A root-level biome.json covers every language root of the monorepo.
+    seedInto(rootDir, CONFIGS_BY_LANGUAGE[language] ?? [], dryRun, dir, results, [rootDir, projectDir]);
   }
   return { dryRun, configs: results };
 }

--- a/tests/harden/advisory.test.js
+++ b/tests/harden/advisory.test.js
@@ -71,6 +71,40 @@ describe("compareHarden", () => {
     expect(find(artifacts, "ruff", "backend").status).toBe("MISSING");
     expect(() => JSON.stringify(artifacts)).not.toThrow();
   });
+
+  it("classifies eslint+prettier as SATISFIED_BY_ALTERNATIVE when biome.json is present (KJC-TSK-0614)", () => {
+    touch("package.json", "{}");
+    touch("biome.json", '{ "linter": { "enabled": true } }');
+    const artifacts = run();
+    for (const id of ["eslint", "prettier"]) {
+      expect(find(artifacts, id)).toMatchObject({
+        status: "SATISFIED_BY_ALTERNATIVE",
+        foundAt: "biome.json",
+        recommendation: "keep",
+        mergeable: false,
+      });
+      expect(find(artifacts, id).rationale).toContain("biome");
+    }
+    // Biome does not cover commit-message linting — commitlint still proposed.
+    expect(find(artifacts, "commitlint").status).toBe("MISSING");
+  });
+
+  it("the user's OWN eslint config wins over the biome alternative", () => {
+    touch("package.json", "{}");
+    touch("biome.json", "{}");
+    touch(".eslintrc.json", '{ "rules": {} }');
+    expect(find(run(), "eslint").status).toBe("USER_OWNED");
+  });
+
+  it("a root-level biome.json covers a monorepo language root", () => {
+    touch("biome.jsonc", "{}");
+    touch("frontend/package.json", "{}");
+    const artifacts = run();
+    expect(find(artifacts, "eslint", "frontend")).toMatchObject({
+      status: "SATISFIED_BY_ALTERNATIVE",
+      foundAt: "biome.jsonc",
+    });
+  });
 });
 
 describe("formatAdvisoryReport", () => {

--- a/tests/harden/check.test.js
+++ b/tests/harden/check.test.js
@@ -75,4 +75,15 @@ describe("checkCommand", () => {
     expect(code).toBe(1);
     expect(JSON.parse(logger.info.mock.calls.at(-1)[0]).ok).toBe(false);
   });
+
+  it("does not flag eslint/prettier as drift when biome.json covers them (KJC-TSK-0614)", async () => {
+    writeFileSync(join(repo, "package.json"), "{}");
+    writeFileSync(join(repo, "biome.json"), "{}");
+    await harden();
+    const res = await checkHarden({ projectDir: repo, profile: "standard" });
+    const covered = res.checks.filter((c) => c.detail?.startsWith("covered by biome.json"));
+    expect(covered.length).toBeGreaterThanOrEqual(2); // eslint + prettier
+    expect(covered.every((c) => c.ok)).toBe(true);
+    expect(res.ok).toBe(true);
+  });
 });

--- a/tests/harden/config-engine.test.js
+++ b/tests/harden/config-engine.test.js
@@ -57,4 +57,18 @@ describe("installConfigs", () => {
     expect(existsSync(join(dir, ".editorconfig"))).toBe(false);
     expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
   });
+
+  it("never seeds eslint/prettier next to biome.json (KJC-TSK-0614)", () => {
+    writeFileSync(join(dir, "biome.json"), "{}");
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    const byFile = Object.fromEntries(res.configs.map((c) => [c.file, c]));
+    expect(byFile[".prettierrc.json"]).toMatchObject({ action: "covered", by: "biome.json" });
+    expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
+    const eslintEntry = res.configs.find((c) => c.file.includes("eslint"));
+    expect(eslintEntry).toMatchObject({ action: "covered", by: "biome.json" });
+    expect(existsSync(join(dir, eslintEntry.file))).toBe(false);
+    // Biome does not replace editorconfig/commitlint — those still seed.
+    expect(byFile[".editorconfig"].action).toBe("inserted");
+    expect(byFile["commitlint.config.js"].action).toBe("inserted");
+  });
 });


### PR DESCRIPTION
## Qué (KJC-TSK-0614)

Un `biome.json` del usuario sustituye a eslint **y** prettier a la vez, pero harden solo conocía equivalentes de la misma herramienta (`.eslintrc.json` ≈ `eslint.config.mjs`): los clasificaba MISSING, **sembraba los configs de kj al lado de biome** y `kj check` marcaba su ausencia como drift — un segundo linter/formateador en conflicto con el tooling y los hooks propios del usuario.

## Cambios

- **`src/harden/alternatives.js`** (nuevo): mapa de alternativas cross-tool (biome ⇒ eslint+prettier) + `findAlternative()` con búsqueda multi-dir (un biome.json en la raíz cubre los roots del monorepo).
- **Advisory**: estado nuevo `SATISFIED_BY_ALTERNATIVE` → `keep`, nunca mergeable, rationale explícito (*"covered by biome.json (biome) — kj won't add a second linter/formatter"*). El config propio de la misma herramienta sigue ganando (USER_OWNED).
- **config-engine**: no siembra un config cubierto por alternativa (acción `covered`); editorconfig y commitlint (que biome no sustituye) siguen sembrándose.
- **check**: config cubierto = ok ("covered by biome.json (biome)"), no drift.
- `--interactive` no necesita cambios: `keep` ya no pregunta — si Biome está, se respeta sin preguntar.
- Ya cubierto de antes (verificado, sin cambios): hooks pre-commit y workflow Quality delegan en `npm run -s lint`/`format` cuando el proyecto define esos scripts.

## Verificación

- **E2E real**: repo con `biome.json` + scripts lint/format → `kj harden --report` keep×2, `kj harden` no instala eslint/prettier, hook pre-commit invoca `npm run -s lint`, `kj check` → Harness OK.
- Suite completa verde (exit 0) · tests harden 88/88 (6 nuevos: advisory×3, config-engine×1, check×1 + humo) · ESLint ✓ · Prettier ✓ · privacy ✓

Net +162/−7. Refs KJC-TSK-0614.