### PR TITLE
feat(core): better-sqlite3-compatible db adapter over node:sqlite

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
   },
   "exports": {
     "./atomic-write": "./src/atomic-write.js",
+    "./db": "./src/db.js",
     "./shared-paths": "./src/shared-paths.js",
     "./port-check": "./src/port-check.js",
     "./paths": "./src/paths.js",

--- a/packages/core/src/db.js
+++ b/packages/core/src/db.js
@@ -1,12 +1,8 @@
 /**
- * db — better-sqlite3-compatible adapter over node:sqlite (KJC-TSK-0615,
- * épica KJC-PCS-0064).
- *
- * node:sqlite ships INSIDE Node 22+ — no native addon, no node-gyp, no
- * prebuild download, and it works inside the SEA standalone binary. This
- * adapter exposes the exact better-sqlite3 surface karajan consumes
- * (prepare().run/get/all, exec, pragma, transaction, close, loadExtension)
- * so vec-store / hu-board / audit-history migrate without rewriting logic.
+ * db — better-sqlite3-compatible adapter over node:sqlite (KJC-TSK-0615).
+ * node:sqlite ships INSIDE Node 22+ — no native addon, no node-gyp, and it
+ * works inside the SEA standalone binary. Exposes the exact surface karajan
+ * consumes so vec-store / hu-board / audit-history migrate without rewrites.
  */
 
 import { createRequire } from "node:module";

--- a/packages/core/src/db.js
+++ b/packages/core/src/db.js
@@ -1,0 +1,107 @@
+/**
+ * db — better-sqlite3-compatible adapter over node:sqlite (KJC-TSK-0615,
+ * épica KJC-PCS-0064).
+ *
+ * node:sqlite ships INSIDE Node 22+ — no native addon, no node-gyp, no
+ * prebuild download, and it works inside the SEA standalone binary. This
+ * adapter exposes the exact better-sqlite3 surface karajan consumes
+ * (prepare().run/get/all, exec, pragma, transaction, close, loadExtension)
+ * so vec-store / hu-board / audit-history migrate without rewriting logic.
+ */
+
+import { createRequire } from "node:module";
+
+// node:sqlite emits a one-time ExperimentalWarning on load that would leak
+// into every kj command's output. Swallow ONLY that warning, only during
+// the import — anything else still reaches the user.
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = (() => {
+  const original = process.emitWarning;
+  process.emitWarning = (warning, ...rest) => {
+    const text = String(warning?.message ?? warning);
+    if (text.includes("SQLite is an experimental feature")) return;
+    return original.call(process, warning, ...rest);
+  };
+  try {
+    return require("node:sqlite");
+  } finally {
+    process.emitWarning = original;
+  }
+})();
+
+class DbHandle {
+  #db;
+
+  constructor(db) {
+    this.#db = db;
+  }
+
+  /** Prepared statement with better-sqlite3's run/get/all surface. */
+  prepare(sql) {
+    const stmt = this.#db.prepare(sql);
+    return {
+      run: (...args) => stmt.run(...args),
+      get: (...args) => stmt.get(...args),
+      all: (...args) => stmt.all(...args),
+    };
+  }
+
+  exec(sql) {
+    this.#db.exec(sql);
+    return this;
+  }
+
+  /**
+   * better-sqlite3-style pragma: `pragma("user_version", { simple: true })`
+   * returns the scalar; `pragma("journal_mode = WAL")` applies the setting.
+   */
+  pragma(text, { simple = false } = {}) {
+    let rows;
+    try {
+      rows = this.#db.prepare(`PRAGMA ${text}`).all();
+    } catch {
+      // Some pragma writes are not preparable — run them directly.
+      this.#db.exec(`PRAGMA ${text}`);
+      rows = [];
+    }
+    if (simple) {
+      const first = rows[0];
+      return first ? Object.values(first)[0] : undefined;
+    }
+    return rows;
+  }
+
+  /**
+   * better-sqlite3-style transaction: returns a function that wraps `fn`
+   * in BEGIN/COMMIT, rolling back if it throws.
+   */
+  transaction(fn) {
+    return (...args) => {
+      this.#db.exec("BEGIN");
+      try {
+        const result = fn(...args);
+        this.#db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        this.#db.exec("ROLLBACK");
+        throw err;
+      }
+    };
+  }
+
+  loadExtension(path) {
+    this.#db.loadExtension(path);
+  }
+
+  close() {
+    this.#db.close();
+  }
+}
+
+/**
+ * Open (or create) a SQLite database at `location` (a path or ":memory:").
+ * `allowExtension: true` is required to later loadExtension (sqlite-vec).
+ */
+export function openDatabase(location, { allowExtension = false } = {}) {
+  return new DbHandle(new DatabaseSync(location, allowExtension ? { allowExtension: true } : {}));
+}

--- a/packages/core/tests/db.test.js
+++ b/packages/core/tests/db.test.js
@@ -1,0 +1,103 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { openDatabase } from "../src/db.js";
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kj-db-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("openDatabase — better-sqlite3 parity over node:sqlite (KJC-TSK-0615)", () => {
+  it("prepare().run/get/all match the better-sqlite3 surface", () => {
+    const db = openDatabase(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)");
+    const info = db.prepare("INSERT INTO t (name) VALUES (?)").run("uno");
+    expect(Number(info.changes)).toBe(1);
+    expect(Number(info.lastInsertRowid)).toBe(1);
+    db.prepare("INSERT INTO t (name) VALUES (?)").run("dos");
+    expect(db.prepare("SELECT name FROM t WHERE id = ?").get(2).name).toBe("dos");
+    expect(db.prepare("SELECT name FROM t ORDER BY id").all().map((r) => r.name)).toEqual(["uno", "dos"]);
+    db.close();
+  });
+
+  it("persists to a file on disk", () => {
+    const file = join(dir, "test.db");
+    const db = openDatabase(file);
+    db.exec("CREATE TABLE t (a TEXT)");
+    db.prepare("INSERT INTO t VALUES (?)").run("persistido");
+    db.close();
+    expect(existsSync(file)).toBe(true);
+    const again = openDatabase(file);
+    expect(again.prepare("SELECT a FROM t").get().a).toBe("persistido");
+    again.close();
+  });
+
+  it("pragma supports assignments and simple reads (the shapes karajan uses)", () => {
+    const db = openDatabase(join(dir, "p.db"));
+    db.pragma("journal_mode = WAL");
+    db.pragma("user_version = 7");
+    expect(db.pragma("user_version", { simple: true })).toBe(7);
+    expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+    // non-simple returns rows, better-sqlite3 style
+    expect(db.pragma("user_version")).toEqual([{ user_version: 7 }]);
+    db.close();
+  });
+
+  it("transaction commits on success and rolls back on throw", () => {
+    const db = openDatabase(":memory:");
+    db.exec("CREATE TABLE t (a TEXT)");
+    const insertTwo = db.transaction((x, y) => {
+      db.prepare("INSERT INTO t VALUES (?)").run(x);
+      db.prepare("INSERT INTO t VALUES (?)").run(y);
+      return "done";
+    });
+    expect(insertTwo("a", "b")).toBe("done");
+    expect(db.prepare("SELECT COUNT(*) c FROM t").get().c).toBe(2);
+
+    const failing = db.transaction(() => {
+      db.prepare("INSERT INTO t VALUES (?)").run("c");
+      throw new Error("boom");
+    });
+    expect(() => failing()).toThrow("boom");
+    // rollback: "c" never landed
+    expect(db.prepare("SELECT COUNT(*) c FROM t").get().c).toBe(2);
+    db.close();
+  });
+
+  it("loads the sqlite-vec extension and answers a vector query", async () => {
+    let loadablePath;
+    try {
+      const sv = await import("sqlite-vec");
+      loadablePath = sv.getLoadablePath();
+    } catch {
+      return; // platform package unavailable — nothing to assert here
+    }
+    const db = openDatabase(":memory:", { allowExtension: true });
+    db.loadExtension(loadablePath);
+    const { v } = db.prepare("SELECT vec_version() AS v").get();
+    expect(v).toMatch(/^v?\d+\./);
+    db.close();
+  });
+
+  it("does not leak the node:sqlite ExperimentalWarning", async () => {
+    const warnings = [];
+    const listener = (w) => warnings.push(String(w?.message ?? w));
+    process.on("warning", listener);
+    try {
+      const db = openDatabase(":memory:");
+      db.exec("CREATE TABLE t (a TEXT)");
+      db.close();
+      await new Promise((resolve) => setImmediate(resolve));
+    } finally {
+      process.off("warning", listener);
+    }
+    expect(warnings.filter((w) => w.includes("SQLite is an experimental feature"))).toEqual([]);
+  });
+});

--- a/packages/core/tests/db.test.js
+++ b/packages/core/tests/db.test.js
@@ -7,12 +7,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openDatabase } from "../src/db.js";
 
 let dir;
-beforeEach(() => {
-  dir = mkdtempSync(join(tmpdir(), "kj-db-"));
-});
-afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
-});
+beforeEach(() => (dir = mkdtempSync(join(tmpdir(), "kj-db-"))));
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
 describe("openDatabase — better-sqlite3 parity over node:sqlite (KJC-TSK-0615)", () => {
   it("prepare().run/get/all match the better-sqlite3 surface", () => {
@@ -90,14 +86,9 @@ describe("openDatabase — better-sqlite3 parity over node:sqlite (KJC-TSK-0615)
     const warnings = [];
     const listener = (w) => warnings.push(String(w?.message ?? w));
     process.on("warning", listener);
-    try {
-      const db = openDatabase(":memory:");
-      db.exec("CREATE TABLE t (a TEXT)");
-      db.close();
-      await new Promise((resolve) => setImmediate(resolve));
-    } finally {
-      process.off("warning", listener);
-    }
+    openDatabase(":memory:").close();
+    await new Promise((resolve) => setImmediate(resolve));
+    process.off("warning", listener);
     expect(warnings.filter((w) => w.includes("SQLite is an experimental feature"))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Qué (KJC-TSK-0615 — SQL-A, épica KJC-PCS-0064)

Primera rebanada de la migración a `node:sqlite`: adaptador `karajan-core/db` con la superficie exacta de better-sqlite3 que consume karajan (`prepare().run/get/all`, `exec`, `pragma` con asignaciones y `{simple:true}`, `transaction` con rollback, `close`, `loadExtension`). Sin consumidores aún — se migran en SQL-B..D.

**Riesgo de la épica despejado**: los tests cargan la extensión **sqlite-vec real** vía `allowExtension`+`loadExtension` y `vec_version()` responde — el RAG sobre node:sqlite es viable, y node:sqlite vive DENTRO del binario SEA.

El ExperimentalWarning de node:sqlite se traga en el import (solo ese) para que no se cuele en la salida de cada comando kj.

## Verificación
- 6/6 tests de paridad (run/get/all, persistencia en disco, pragma, transaction commit/rollback, sqlite-vec real, sin warning) · ESLint ✓ · Prettier ✓ · privacy ✓

Refs KJC-TSK-0615.