### PR TITLE
feat(budget): default max_budget_usd to 5 with honest cutoff

### DIFF
--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -55,7 +55,10 @@ const DEFAULTS = {
   review_mode: "standard",
   max_iterations: 5,
   hu_max_iterations: 3,
-  max_budget_usd: null,
+  // Hard per-run spend ceiling, ON by default (KJC-TSK-0621): a stuck or
+  // runaway run must never drain a subscription quota unattended. Explicit
+  // null in the user's config opts out (no cap).
+  max_budget_usd: 5,
   review_rules: "./.karajan/review-rules.md",
   coder_rules: "./.karajan/coder-rules.md",
   base_branch: "main",

--- a/src/config/overrides.js
+++ b/src/config/overrides.js
@@ -172,8 +172,14 @@ export function applyRunOverrides(config, flags) {
   out.git = out.git || {};
   out.development = out.development || {};
   out.sonarqube = out.sonarqube || {};
-  if (out.max_budget_usd === undefined || out.max_budget_usd === null) {
-    out.max_budget_usd = out.session.max_budget_usd ?? null;
+  // Precedence: explicit top-level value (including null = opt-out) wins;
+  // the legacy session.max_budget_usd location next; the shipped default
+  // (KJC-TSK-0621: 5) last. When top-level still carries the default, a
+  // session-level value — including an explicit null — takes over.
+  if (out.max_budget_usd === undefined) {
+    out.max_budget_usd = out.session.max_budget_usd !== undefined ? out.session.max_budget_usd : DEFAULTS.max_budget_usd;
+  } else if (out.max_budget_usd === DEFAULTS.max_budget_usd && out.session.max_budget_usd !== undefined) {
+    out.max_budget_usd = out.session.max_budget_usd;
   }
   out.budget = mergeDeep(DEFAULTS.budget, out.budget || {});
   out.roles = mergeDeep(DEFAULTS.roles, out.roles || {});

--- a/src/orchestrator/flow-control.js
+++ b/src/orchestrator/flow-control.js
@@ -153,7 +153,11 @@ export async function checkBudgetExceeded({ budgetTracker, config, session, emit
 
   await markSessionStatus(session, "failed");
   const totalCost = budgetTracker.total().cost_usd;
-  const message = `Budget exceeded: $${totalCost.toFixed(2)} > $${budgetLimit.toFixed(2)}`;
+  const limit = Number(budgetLimit ?? config?.max_budget_usd);
+  const message =
+    `Budget exceeded: $${totalCost.toFixed(2)} > $${limit.toFixed(2)}. ` +
+    `Continue consciously with \`kj resume ${session.id}\`, or raise the cap ` +
+    `(max_budget_usd in .karajan/kj.config.yml; null removes it).`;
   emitProgress(
     emitter,
     makeEvent("session:end", { ...eventBase, iteration: i, stage: "budget" }, {

--- a/templates/kj.config.yml
+++ b/templates/kj.config.yml
@@ -114,5 +114,7 @@ output:
 session:
   max_iteration_minutes: 15
   max_total_minutes: 120
-  max_budget_usd: null
+  # Hard per-run spend ceiling (USD-equivalent). The run stops with a summary
+  # when exceeded; resume with `kj resume`. Set to null to remove the cap.
+  max_budget_usd: 5
   fail_fast_repeats: 2

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -16,6 +16,28 @@ afterEach(async () => {
   }
 });
 
+describe("applyRunOverrides — max_budget_usd default-on (KJC-TSK-0621)", () => {
+  it("an unset budget lands on the shipped default of 5", () => {
+    const out = applyRunOverrides({}, {});
+    expect(out.max_budget_usd).toBe(5);
+  });
+
+  it("an explicit top-level null opts out (no cap)", () => {
+    const out = applyRunOverrides({ max_budget_usd: null }, {});
+    expect(out.max_budget_usd).toBeNull();
+  });
+
+  it("the legacy session location wins over the shipped default, including null", () => {
+    expect(applyRunOverrides({ session: { max_budget_usd: 12 } }, {}).max_budget_usd).toBe(12);
+    expect(applyRunOverrides({ session: { max_budget_usd: null } }, {}).max_budget_usd).toBeNull();
+  });
+
+  it("an explicit top-level value beats the session location", () => {
+    const out = applyRunOverrides({ max_budget_usd: 20, session: { max_budget_usd: 12 } }, {});
+    expect(out.max_budget_usd).toBe(20);
+  });
+});
+
 describe("applyRunOverrides", () => {
   it("overrides review mode and base branch", () => {
     const base = {


### PR DESCRIPTION
## Qué (KJC-TSK-0621 — origen: KJC-BUG-0107, reporte de campo)

Un run sin presupuesto configurado **no tenía techo de gasto**: un pipeline atascado o desbocado podía fundir la cuota de una suscripción sin nadie mirando (le pasó a un usuario real con la orquesta completa). El enforcement existía (`checkBudgetExceeded`, por iteración) pero el default era `null` — safety opt-in, contra la regla del proyecto (default ON con opt-out).

## Cambios

- `max_budget_usd` **default 5** (valor aprobado por el usuario) en defaults + plantilla de config.
- Al superarse: el run **para** con mensaje honesto — gasto, límite, cómo subir el techo y cómo continuar (`kj resume <id>` da una ventana fresca: el tracker se construye por run).
- **Opt-out explícito**: `max_budget_usd: null` = sin techo. La ubicación legacy `session.max_budget_usd` sigue funcionando (incluido null), con precedencia: top-level explícito > session > default.
- 4 tests de precedencia nuevos.

## Verificación
- Suite completa verde (exit 0) · config 32/32 · ESLint ✓ · Prettier ✓ · privacy ✓

Net +42/−5. Refs KJC-TSK-0621, KJC-BUG-0107.