### PR TITLE
chore(release): v3.13.1 — default spend ceiling per run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.13.1] - 2026-07-16
+
+Patch. **Every run now ships with a spend ceiling.** A stuck or runaway pipeline can no longer drain a subscription quota unattended.
+
+### Fixed
+
+- **`max_budget_usd` defaults to 5** (KJC-TSK-0621, from a field report of a stuck run burning a user's whole quota): the per-iteration budget enforcement existed but the default was `null` — opt-in safety. Exceeding the cap stops the run with the spend, the limit, how to raise it and how to continue (`kj resume` opens a fresh window). Explicit `null` opts out; the legacy `session.max_budget_usd` location keeps working.
+
 ## [3.13.0] - 2026-07-16
 
 Minor. **`kj harden` respects your own tooling.** A repo that formats and lints with Biome no longer gets kj's eslint + prettier planted next to it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.13.0",
+      "version": "3.13.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v3.13.1 (patch)

Publica **KJC-TSK-0621** (#1185): `max_budget_usd` default 5 — ningún run puede fundir una cuota desatendido (origen: KJC-BUG-0107, reporte de campo).

### Verificación
- verify-pack verde (npm local + global + pnpm → 3.13.1)

Refs KJC-TSK-0621