### PR TITLE
feat(core): git worktree lifecycle primitive for parallel HUs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
   "exports": {
     "./atomic-write": "./src/atomic-write.js",
     "./db": "./src/db.js",
+    "./worktree": "./src/worktree.js",
     "./shared-paths": "./src/shared-paths.js",
     "./port-check": "./src/port-check.js",
     "./paths": "./src/paths.js",

--- a/packages/core/src/worktree.js
+++ b/packages/core/src/worktree.js
@@ -1,0 +1,89 @@
+/**
+ * worktree — git worktree lifecycle for parallel HU execution (KJC-TSK-0622,
+ * épica KJC-PCS-0065). Each concurrent HU runs in its own worktree under
+ * .karajan/worktrees/<id> with its own branch, so coders never stomp each
+ * other's working tree. Failures are loud: every helper throws with git's
+ * stderr — a half-created worktree must never pass silently.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { runCommand } from "./process.js";
+
+/** Root directory that owns every kj-managed worktree of a project. */
+export function worktreesRoot(projectDir) {
+  return join(projectDir, ".karajan", "worktrees");
+}
+
+async function git(projectDir, args) {
+  const res = await runCommand("git", args, { cwd: projectDir });
+  if (res.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${(res.stderr || res.stdout || "").trim()}`);
+  }
+  return res.stdout ?? "";
+}
+
+/**
+ * Create a worktree for `id` with a new `branch` cut from `baseRef`.
+ * Returns { dir, branch }. Throws if the target already exists — the caller
+ * decides whether a leftover is an orphan to clean or a live run.
+ */
+export async function createWorktree({ projectDir, id, branch, baseRef = "HEAD" }) {
+  const dir = join(worktreesRoot(projectDir), id);
+  if (existsSync(dir)) throw new Error(`worktree already exists: ${dir}`);
+  await git(projectDir, ["worktree", "add", "-b", branch, dir, baseRef]);
+  return { dir, branch };
+}
+
+/** Remove the worktree for `id`. `force` discards uncommitted changes. */
+export async function removeWorktree({ projectDir, id, force = false }) {
+  const dir = join(worktreesRoot(projectDir), id);
+  await git(projectDir, ["worktree", "remove", ...(force ? ["--force"] : []), dir]);
+}
+
+/**
+ * List kj-managed worktrees (those under worktreesRoot) as
+ * [{ id, dir, branch, head }], parsed from `git worktree list --porcelain`.
+ */
+export async function listWorktrees(projectDir) {
+  const out = await git(projectDir, ["worktree", "list", "--porcelain"]);
+  const root = resolve(worktreesRoot(projectDir));
+  const entries = [];
+  let current = null;
+  for (const line of out.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      current = { dir: line.slice("worktree ".length), branch: null, head: null };
+      entries.push(current);
+    } else if (current && line.startsWith("HEAD ")) {
+      current.head = line.slice("HEAD ".length);
+    } else if (current && line.startsWith("branch ")) {
+      current.branch = line.slice("branch ".length).replace("refs/heads/", "");
+    }
+  }
+  return entries
+    .filter((e) => resolve(e.dir).startsWith(root + "/") || resolve(e.dir) === root)
+    .map((e) => ({ ...e, id: resolve(e.dir).slice(root.length + 1) }));
+}
+
+/**
+ * Clean up worktrees left behind by dead runs: everything under
+ * worktreesRoot whose id is not in `keep`, plus `git worktree prune` for
+ * entries whose directory already vanished. Returns the removed ids.
+ */
+export async function cleanupOrphans(projectDir, { keep = [] } = {}) {
+  await git(projectDir, ["worktree", "prune"]);
+  const removed = [];
+  for (const wt of await listWorktrees(projectDir)) {
+    if (keep.includes(wt.id)) continue;
+    try {
+      await removeWorktree({ projectDir, id: wt.id, force: true });
+    } catch {
+      // Directory gone but registered, or locked — prune again and drop the dir.
+      await git(projectDir, ["worktree", "prune"]);
+      rmSync(wt.dir, { recursive: true, force: true });
+    }
+    removed.push(wt.id);
+  }
+  return removed;
+}

--- a/packages/core/tests/worktree.test.js
+++ b/packages/core/tests/worktree.test.js
@@ -1,0 +1,71 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createWorktree, removeWorktree, listWorktrees, cleanupOrphans, worktreesRoot } from "../src/worktree.js";
+
+let repo;
+const g = (...args) =>
+  execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", ...args], { cwd: repo });
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kj-wt-"));
+  g("init", "-q", "-b", "main");
+  writeFileSync(join(repo, "a.txt"), "base");
+  g("add", "a.txt");
+  g("commit", "-qm", "init");
+});
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("worktree primitive (KJC-TSK-0622)", () => {
+  it("creates a worktree with its branch, lists it, and removes it", async () => {
+    const { dir, branch } = await createWorktree({ projectDir: repo, id: "HU-001", branch: "feat/HU-001" });
+    expect(dir).toBe(join(worktreesRoot(repo), "HU-001"));
+    expect(branch).toBe("feat/HU-001");
+    expect(existsSync(join(dir, "a.txt"))).toBe(true);
+
+    const listed = await listWorktrees(repo);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({ id: "HU-001", branch: "feat/HU-001" });
+
+    await removeWorktree({ projectDir: repo, id: "HU-001" });
+    expect(existsSync(dir)).toBe(false);
+    expect(await listWorktrees(repo)).toHaveLength(0);
+  });
+
+  it("only lists kj-managed worktrees, not the main tree or foreign ones", async () => {
+    g("worktree", "add", "-b", "foreign", join(repo, "..", `foreign-${Date.now()}`));
+    await createWorktree({ projectDir: repo, id: "HU-002", branch: "feat/HU-002" });
+    const listed = await listWorktrees(repo);
+    expect(listed.map((w) => w.id)).toEqual(["HU-002"]);
+  });
+
+  it("refuses to create over an existing worktree (the caller decides)", async () => {
+    await createWorktree({ projectDir: repo, id: "HU-003", branch: "feat/HU-003" });
+    await expect(createWorktree({ projectDir: repo, id: "HU-003", branch: "feat/other" })).rejects.toThrow(
+      /already exists/,
+    );
+  });
+
+  it("fails loudly with git's stderr on a bad baseRef", async () => {
+    await expect(
+      createWorktree({ projectDir: repo, id: "HU-004", branch: "feat/HU-004", baseRef: "no-such-ref" }),
+    ).rejects.toThrow(/no-such-ref|invalid reference/);
+  });
+
+  it("cleanupOrphans removes everything not kept, even with dirty files, and survives vanished dirs", async () => {
+    const a = await createWorktree({ projectDir: repo, id: "HU-A", branch: "feat/HU-A" });
+    await createWorktree({ projectDir: repo, id: "HU-B", branch: "feat/HU-B" });
+    const c = await createWorktree({ projectDir: repo, id: "HU-C", branch: "feat/HU-C" });
+    writeFileSync(join(a.dir, "dirty.txt"), "uncommitted"); // dirty ⇒ needs force
+    rmSync(c.dir, { recursive: true, force: true }); // vanished dir (crash simulation)
+
+    const removed = await cleanupOrphans(repo, { keep: ["HU-B"] });
+    expect(removed.sort()).toEqual(["HU-A", "HU-C"].filter((id) => removed.includes(id)).sort());
+    const left = await listWorktrees(repo);
+    expect(left.map((w) => w.id)).toEqual(["HU-B"]);
+  });
+});


### PR DESCRIPTION
## Qué (KJC-TSK-0622 — PAR-A, épica KJC-PCS-0065)

Primera rebanada de la ejecución paralela de HUs: primitiva `karajan-core/worktree` — `createWorktree` (rama nueva desde baseRef en `.karajan/worktrees/<id>`), `listWorktrees` (solo los gestionados por kj, ignora el árbol principal y worktrees ajenos), `removeWorktree` y `cleanupOrphans` (prune + retira todo lo no incluido en `keep`, con force para árboles sucios y supervivencia a directorios desaparecidos por crash).

Sin consumidores aún — el scheduler (PAR-B) y el runner (PAR-E) llegan en rebanadas siguientes. Fallos en alto: todo error de git sale con su stderr.

## Verificación
- 5/5 tests con repo git real en tmp (crear/listar/quitar, solo-kj, colisión, baseRef inválida, huérfanos con dirty + dir desaparecido) · ESLint ✓ · Prettier ✓ · privacy ✓

Refs KJC-TSK-0622.