### PR TITLE
feat(orchestrator): pure HU scheduler for parallel execution

### DIFF
--- a/src/orchestrator/hu-scheduler.js
+++ b/src/orchestrator/hu-scheduler.js
@@ -1,0 +1,88 @@
+/**
+ * hu-scheduler — pure scheduling for parallel HU execution (KJC-TSK-0623,
+ * épica KJC-PCS-0065). Decides WHICH HUs may run concurrently; it never
+ * launches anything. Two rules, both conservative by design:
+ *
+ *   1. Dependencies: every blocked_by id must be in completedIds.
+ *   2. Scope isolation: two HUs whose scopes touch the same path prefix are
+ *      never scheduled together — predictable merge conflicts cost more than
+ *      the parallelism they'd buy. An HU with NO scope has an unknown blast
+ *      radius, so it runs alone (exclusive with everything).
+ */
+
+/**
+ * Extract path-like tokens from a free-form scope. The planner writes scope
+ * as prose ("src/auth y tests/auth", "docs/*.md"); we keep anything that
+ * looks like a path or glob, normalized to its base directory.
+ */
+export function scopeTokens(scope) {
+  if (!scope || typeof scope !== "string") return [];
+  const matches = scope.match(/[\w.-]+(?:\/[\w*.{}-]+)+|[\w.-]+\/(?=\s|$|,)/g) || [];
+  return matches
+    .map((raw) => {
+      // Cut the token at its first glob segment: "src/**/*.js" → "src".
+      const segments = raw.replace(/\/+$/, "").split("/");
+      const firstGlob = segments.findIndex((s) => s.includes("*") || s.includes("{"));
+      return (firstGlob === -1 ? segments : segments.slice(0, firstGlob)).join("/");
+    })
+    .filter(Boolean);
+}
+
+/** True when two token lists share a path-prefix relationship. */
+function tokensOverlap(a, b) {
+  for (const ta of a) {
+    for (const tb of b) {
+      if (ta === tb || ta.startsWith(`${tb}/`) || tb.startsWith(`${ta}/`)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * True when two HUs cannot run concurrently: either one has no parseable
+ * scope (unknown blast radius ⇒ exclusive) or their scopes overlap.
+ */
+export function husConflict(huA, huB) {
+  const a = scopeTokens(huA.scope);
+  const b = scopeTokens(huB.scope);
+  if (a.length === 0 || b.length === 0) return true;
+  return tokensOverlap(a, b);
+}
+
+/**
+ * Select the next HUs to launch, order-preserving and greedy.
+ *
+ * @param {object} args
+ * @param {Array<{id: string, blocked_by?: string[], scope?: string|null}>} args.hus - candidates, in plan order
+ * @param {string[]} [args.completedIds] - HUs already done (dependency source)
+ * @param {Array<{id: string, scope?: string|null}>} [args.inFlight] - HUs currently running
+ * @param {number} [args.maxParallel] - total concurrency cap (in-flight included)
+ * @returns {{ selected: object[], blocked: Array<{id: string, reason: string}> }}
+ */
+export function selectRunnableHus({ hus = [], completedIds = [], inFlight = [], maxParallel = 1 } = {}) {
+  const done = new Set(completedIds);
+  const flying = new Set(inFlight.map((h) => h.id));
+  const slots = Math.max(0, maxParallel - inFlight.length);
+  const selected = [];
+  const blocked = [];
+
+  for (const hu of hus) {
+    if (flying.has(hu.id) || done.has(hu.id)) continue;
+    const missing = (hu.blocked_by || []).filter((dep) => !done.has(dep));
+    if (missing.length > 0) {
+      blocked.push({ id: hu.id, reason: `waiting for ${missing.join(", ")}` });
+      continue;
+    }
+    if (selected.length >= slots) {
+      blocked.push({ id: hu.id, reason: "no free slot" });
+      continue;
+    }
+    const rival = [...inFlight, ...selected].find((other) => husConflict(hu, other));
+    if (rival) {
+      blocked.push({ id: hu.id, reason: `scope conflicts with ${rival.id}` });
+      continue;
+    }
+    selected.push(hu);
+  }
+  return { selected, blocked };
+}

--- a/tests/hu-scheduler.test.js
+++ b/tests/hu-scheduler.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { scopeTokens, husConflict, selectRunnableHus } from "../src/orchestrator/hu-scheduler.js";
+
+const hu = (id, scope, blocked_by = []) => ({ id, scope, blocked_by });
+
+describe("hu-scheduler (KJC-TSK-0623)", () => {
+  it("scopeTokens extracts path bases from prose and globs", () => {
+    expect(scopeTokens("src/auth y tests/auth")).toEqual(["src/auth", "tests/auth"]);
+    expect(scopeTokens("docs/**/*.md")).toEqual(["docs"]);
+    expect(scopeTokens("touch src/api/users.js, src/api/roles.js")).toEqual([
+      "src/api/users.js",
+      "src/api/roles.js",
+    ]);
+    expect(scopeTokens(null)).toEqual([]);
+    expect(scopeTokens("mejorar el rendimiento general")).toEqual([]);
+  });
+
+  it("husConflict: prefix overlap conflicts, disjoint trees don't, no scope is exclusive", () => {
+    expect(husConflict(hu("a", "src/auth"), hu("b", "src/auth/login"))).toBe(true);
+    expect(husConflict(hu("a", "src/auth"), hu("b", "src/billing"))).toBe(false);
+    expect(husConflict(hu("a", null), hu("b", "src/billing"))).toBe(true);
+    expect(husConflict(hu("a", "texto sin rutas"), hu("b", "src/billing"))).toBe(true);
+  });
+
+  it("respects the dependency graph", () => {
+    const { selected, blocked } = selectRunnableHus({
+      hus: [hu("A", "src/a"), hu("B", "src/b", ["A"]), hu("C", "src/c", ["A", "B"])],
+      completedIds: ["A"],
+      maxParallel: 3,
+    });
+    expect(selected.map((h) => h.id)).toEqual(["B"]);
+    expect(blocked).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "C", reason: "waiting for B" })]),
+    );
+  });
+
+  it("serializes scope conflicts against in-flight and already-selected HUs", () => {
+    const { selected, blocked } = selectRunnableHus({
+      hus: [hu("B", "src/auth/tokens"), hu("C", "src/billing"), hu("D", "src/billing/invoices")],
+      inFlight: [{ id: "A", scope: "src/auth" }],
+      maxParallel: 3,
+    });
+    expect(selected.map((h) => h.id)).toEqual(["C"]);
+    const reasons = Object.fromEntries(blocked.map((b) => [b.id, b.reason]));
+    expect(reasons.B).toContain("scope conflicts with A");
+    expect(reasons.D).toContain("scope conflicts with C");
+  });
+
+  it("caps at maxParallel counting the in-flight HUs and skips them as candidates", () => {
+    const { selected, blocked } = selectRunnableHus({
+      hus: [hu("A", "src/a"), hu("B", "src/b"), hu("C", "src/c")],
+      inFlight: [{ id: "A", scope: "src/a" }],
+      maxParallel: 2,
+    });
+    expect(selected.map((h) => h.id)).toEqual(["B"]);
+    expect(blocked).toEqual([{ id: "C", reason: "no free slot" }]);
+  });
+
+  it("default maxParallel of 1 reproduces today's sequential behaviour", () => {
+    const { selected } = selectRunnableHus({ hus: [hu("A", "src/a"), hu("B", "src/b")] });
+    expect(selected.map((h) => h.id)).toEqual(["A"]);
+  });
+});


### PR DESCRIPTION
## Qué (KJC-TSK-0623 — PAR-B, épica KJC-PCS-0065)

Segunda rebanada del paralelismo: `selectRunnableHus` — función **pura** (decide, no lanza) que calcula el siguiente lote de HUs:

- **Grafo**: solo HUs con `blocked_by` satisfechos contra `completedIds`; completadas y en vuelo jamás se re-seleccionan (el test lo cazó — filtro defensivo).
- **Aislamiento de scope conservador**: solape por prefijos de ruta extraídos del scope en prosa del planner (`scopeTokens`: rutas y globs recortados a su base); HU **sin scope parseable = radio de explosión desconocido = corre sola**. Un conflicto de merge previsible cuesta más que el paralelismo que compraría.
- **Greedy con orden del plan** hasta `maxParallel` contando las en vuelo; cada descarte sale en `blocked` con su motivo (observabilidad para el Board en PAR-E).
- **`maxParallel: 1` (default) reproduce el comportamiento secuencial actual** — cero riesgo al mergear sin consumidores.

## Verificación
- 6/6 tests (tokens de prosa/globs, conflictos, grafo, serialización contra en-vuelo y seleccionadas, tope con en-vuelo, default secuencial) · suite completa verde (exit 0) · ESLint ✓ · Prettier ✓ · privacy ✓

Refs KJC-TSK-0623.