### PR TITLE
chore(core): karajan-core 1.1.0 — db and worktree modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8092,7 +8092,7 @@
     },
     "packages/core": {
       "name": "karajan-core",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "vitest": "^4.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump de `karajan-core` 1.0.0 → 1.1.0 para publicar en npm los dos módulos que ya viven en main sin publicar: `./db` (adaptador node:sqlite, SQL-A #1184) y `./worktree` (primitiva de worktrees, PAR-A #1187). Sin esto el registry y el workspace divergen y la próxima rebanada que los importe rompe verify-pack.

karajan-code NO se re-publica: nada de cara al usuario desde 3.13.1 (el scheduler PAR-B es código durmiente sin consumidores).

Refs KJC-PCS-0064, KJC-PCS-0065