### PR TITLE
feat(run): per-iteration gate with report and user directives (--step)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -101,6 +101,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--enable-sonarcloud", "Enable SonarCloud scan (complementary to SonarQube)")
     .option("--no-sonarcloud")
     .option("--checkpoint-interval <n>", "Minutes between interactive checkpoints (default: 5)")
+    .option("--step", "Pause after each iteration with a report and ask before continuing")
     .option("--pg-task <cardId>", "Planning Game card ID (e.g., KJC-TSK-0042)")
     .option("--pg-project <projectId>", "Planning Game project ID")
     .option("--auto-simplify", "Auto-simplify pipeline for simple tasks (disable reviewer/tester)")

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -176,6 +176,9 @@ const DEFAULTS = {
     role_overrides: {}
   },
   session: {
+    // Opt-in per-iteration supervision (KJC-TSK-0628): pause after each
+    // iteration with a report and ask continue / stop / instructions.
+    iteration_gate: false,
     max_iteration_minutes: 30,
     max_total_minutes: 120,
     max_planner_minutes: 60,

--- a/src/config/overrides.js
+++ b/src/config/overrides.js
@@ -147,6 +147,9 @@ function applyMiscOverrides(out, flags) {
   // The flag is still accepted to avoid breaking scripts; it now emits a
   // warning at run start and is otherwise ignored. See preflight-checks.js
   // and flow-runner.js for the actual gate (resolvedPolicies.sonar).
+  // --step: per-iteration supervision gate (KJC-TSK-0628).
+  if (flags.step === true) out.session.iteration_gate = true;
+
   if (flags.noSonar || flags.sonar === false) {
     out._deprecated = out._deprecated || {};
     out._deprecated.noSonarFlag = true;

--- a/src/orchestrator/drivers/iteration-loop.js
+++ b/src/orchestrator/drivers/iteration-loop.js
@@ -27,6 +27,7 @@ import {
   setReviewerFeedback, resetRetryCount,
 } from "../../session/mutators.js";
 import { invokeSolomon } from "../solomon-escalation.js";
+import { buildIterationReport, handleIterationGate } from "../iteration-gate.js";
 import {
   handleCiEarlyPrOrPush, handleCiReviewDispatch,
 } from "../ci-integration.js";
@@ -251,6 +252,21 @@ export async function runIterationLoop(ctx, { task: loopTask, askQuestion, emitt
       return iterResult.result;
     }
     if (iterResult.action === "retry") { i -= 1; }
+    else {
+      // Iteration gate (KJC-TSK-0628): opt-in pause with a report before the
+      // next iteration; free-text answers become directives for the coder.
+      const gate = await handleIterationGate({
+        enabled: ctx.config.session?.iteration_gate === true,
+        askQuestion, session: ctx.session, logger,
+        report: buildIterationReport({
+          i, maxIterations: ctx.config.max_iterations, stageResults: ctx.stageResults,
+          budgetTracker: ctx.budgetTracker, maxBudgetUsd: ctx.config.max_budget_usd,
+        }),
+      });
+      if (gate.action === "stop") {
+        return { approved: false, sessionId: ctx.session.id, reason: "user_stopped_at_gate", iteration: i };
+      }
+    }
   }
 
   // Solomon decides whether to extend iterations or stop
@@ -289,6 +305,20 @@ export async function runIterationLoop(ctx, { task: loopTask, askQuestion, emitt
       const iterResult = await runSingleIteration(ctx);
       if (iterResult.action === "return") return iterResult.result;
       if (iterResult.action === "retry") { i -= 1; }
+      else {
+        // Same iteration gate on Solomon-extended iterations (KJC-TSK-0628).
+        const gate = await handleIterationGate({
+          enabled: ctx.config.session?.iteration_gate === true,
+          askQuestion, session: ctx.session, logger,
+          report: buildIterationReport({
+            i, maxIterations: ctx.config.max_iterations, stageResults: ctx.stageResults,
+            budgetTracker: ctx.budgetTracker, maxBudgetUsd: ctx.config.max_budget_usd,
+          }),
+        });
+        if (gate.action === "stop") {
+          return { approved: false, sessionId: ctx.session.id, reason: "user_stopped_at_gate", iteration: i };
+        }
+      }
     }
 
     // Extended iterations also exhausted — final Solomon call

--- a/src/orchestrator/iteration-gate.js
+++ b/src/orchestrator/iteration-gate.js
@@ -1,0 +1,73 @@
+/**
+ * iteration-gate — opt-in per-iteration supervision (KJC-TSK-0628, épica
+ * KJC-PCS-0062). With `--step` (or session.iteration_gate in config) the
+ * pipeline pauses after EVERY iteration with a compact report — what
+ * happened, what the next iteration will do, spend vs cap — and asks the
+ * user: continue, stop, or continue WITH instructions. Free-text answers
+ * are appended to the reviewer feedback the coder reads next iteration
+ * (same channel Solomon's human guidance uses), never overwriting the
+ * reviewer's own must-fix list.
+ */
+
+import { markSessionStatus } from "../session/store.js";
+import { setReviewerFeedback } from "../session/mutators.js";
+
+const STOP_ANSWERS = new Set(["stop", "parar", "para", "no", "n", "4"]);
+const CONTINUE_ANSWERS = new Set(["", "s", "si", "sí", "y", "yes", "1", "continue", "continuar"]);
+
+/** Compact human report of the iteration that just finished. */
+export function buildIterationReport({ i, maxIterations, stageResults = {}, budgetTracker, maxBudgetUsd, reviewVerdict }) {
+  const lines = [`Iteration ${i}/${maxIterations} finished.`];
+  const stages = Object.keys(stageResults);
+  if (stages.length > 0) lines.push(`Stages so far: ${stages.join(", ")}`);
+
+  const review = reviewVerdict ?? stageResults.reviewer ?? null;
+  const mustFix = review?.must_fix ?? review?.issues ?? [];
+  if (review?.approved === true) {
+    lines.push("Reviewer: APPROVED");
+  } else if (mustFix.length > 0) {
+    const shown = mustFix.slice(0, 3).map((f) => `  • ${typeof f === "string" ? f : f.title || f.description || JSON.stringify(f)}`);
+    lines.push(`Reviewer: rejected with ${mustFix.length} must-fix:`, ...shown);
+    if (mustFix.length > 3) lines.push(`  … and ${mustFix.length - 3} more`);
+    lines.push(`Next iteration: the coder tackles those ${mustFix.length} must-fix.`);
+  } else {
+    lines.push("Next iteration: the coder retries against the pending feedback.");
+  }
+
+  const spent = budgetTracker?.total?.().cost_usd ?? 0;
+  const cap = maxBudgetUsd != null ? ` / cap $${Number(maxBudgetUsd).toFixed(2)}` : "";
+  lines.push(`Spend: $${spent.toFixed(2)}${cap}`);
+  return lines.join("\n");
+}
+
+/** Append a user directive without clobbering the reviewer's feedback. */
+export function appendUserDirective(session, text) {
+  const existing = session.last_reviewer_feedback || "";
+  const block = `## User directive (iteration gate)\n${text}`;
+  setReviewerFeedback(session, existing ? `${existing}\n\n${block}` : block);
+}
+
+/**
+ * Ask the user at the gate. Returns { action: "continue" | "stop",
+ * injected?: string }. Disabled gate, missing askQuestion (nobody to ask)
+ * or unattended autonomous runs pass straight through.
+ */
+export async function handleIterationGate({ enabled, askQuestion, session, logger, report }) {
+  if (!enabled || !askQuestion || askQuestion.unattended === true) return { action: "continue" };
+
+  const answer = await askQuestion(
+    `${report}\n\nContinue? [Enter = yes | "stop" = stop | anything else = instructions for the next iteration]`,
+  );
+  const trimmed = (answer || "").trim();
+  const lower = trimmed.toLowerCase();
+
+  if (STOP_ANSWERS.has(lower)) {
+    await markSessionStatus(session, "stopped");
+    return { action: "stop" };
+  }
+  if (CONTINUE_ANSWERS.has(lower)) return { action: "continue" };
+
+  appendUserDirective(session, trimmed);
+  logger?.info?.("Iteration gate: user directive injected for the next iteration.");
+  return { action: "continue", injected: trimmed };
+}

--- a/tests/iteration-gate.test.js
+++ b/tests/iteration-gate.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildIterationReport, appendUserDirective, handleIterationGate } from "../src/orchestrator/iteration-gate.js";
+
+vi.mock("../src/session/store.js", () => ({ markSessionStatus: vi.fn() }));
+
+const tracker = (usd) => ({ total: () => ({ cost_usd: usd }) });
+
+describe("iteration-gate (KJC-TSK-0628)", () => {
+  it("the report says what happened, what comes next, and the spend vs cap", () => {
+    const report = buildIterationReport({
+      i: 2,
+      maxIterations: 5,
+      stageResults: { coder: {}, reviewer: { approved: false, must_fix: ["fix null check", "add test", "rename var", "split fn"] } },
+      budgetTracker: tracker(1.37),
+      maxBudgetUsd: 5,
+    });
+    expect(report).toContain("Iteration 2/5");
+    expect(report).toContain("4 must-fix");
+    expect(report).toContain("fix null check");
+    expect(report).toContain("… and 1 more");
+    expect(report).toContain("the coder tackles those 4 must-fix");
+    expect(report).toContain("Spend: $1.37 / cap $5.00");
+  });
+
+  it("disabled gate or nobody-to-ask passes straight through", async () => {
+    expect(await handleIterationGate({ enabled: false, askQuestion: vi.fn() })).toEqual({ action: "continue" });
+    expect(await handleIterationGate({ enabled: true, askQuestion: null })).toEqual({ action: "continue" });
+    const unattended = vi.fn();
+    unattended.unattended = true;
+    expect(await handleIterationGate({ enabled: true, askQuestion: unattended })).toEqual({ action: "continue" });
+    expect(unattended).not.toHaveBeenCalled();
+  });
+
+  it("empty answer continues, stop stops and marks the session", async () => {
+    const { markSessionStatus } = await import("../src/session/store.js");
+    const session = {};
+    expect(
+      await handleIterationGate({ enabled: true, askQuestion: async () => "", session, report: "r" }),
+    ).toEqual({ action: "continue" });
+    expect(
+      await handleIterationGate({ enabled: true, askQuestion: async () => "stop", session, report: "r" }),
+    ).toEqual({ action: "stop" });
+    expect(markSessionStatus).toHaveBeenCalledWith(session, "stopped");
+  });
+
+  it("free text becomes a directive appended to the reviewer feedback, never clobbering it", async () => {
+    const session = { last_reviewer_feedback: "must-fix: arregla el parser" };
+    const result = await handleIterationGate({
+      enabled: true,
+      askQuestion: async () => "prioriza el fichero de config y no toques la API pública",
+      session,
+      report: "r",
+      logger: { info: vi.fn() },
+    });
+    expect(result).toEqual({ action: "continue", injected: "prioriza el fichero de config y no toques la API pública" });
+    expect(session.last_reviewer_feedback).toContain("must-fix: arregla el parser");
+    expect(session.last_reviewer_feedback).toContain("## User directive (iteration gate)");
+    expect(session.last_reviewer_feedback).toContain("prioriza el fichero de config");
+  });
+
+  it("appendUserDirective on an empty session starts the block cleanly", () => {
+    const session = {};
+    appendUserDirective(session, "usa el patrón del módulo vecino");
+    expect(session.last_reviewer_feedback).toBe("## User directive (iteration gate)\nusa el patrón del módulo vecino");
+  });
+});


### PR DESCRIPTION
## Qué (KJC-TSK-0628, épica KJC-PCS-0062)

Supervisión opt-in por iteración: con `kj run --step` (o `session.iteration_gate: true`), el pipeline para tras **cada** iteración con un informe compacto — iteración n/max, veredicto del reviewer con sus must-fix, **qué hará la siguiente iteración**, gasto vs techo — y pregunta con tres salidas:

- **Enter** → continúa
- **stop** → para (sesión `stopped`, reanudable con `kj resume`)
- **cualquier otro texto** → se inyecta como directiva en el feedback que el coder lee en la siguiente iteración (el mismo canal que usa la guía humana de Solomon), **anexando sin pisar** los must-fix del reviewer

Los runs desatendidos (autonomous) pasan de largo; el gate aplica en los dos bucles (normal y extendido por Solomon). Default OFF — comportamiento actual intacto.

PR2 de esta card (siguiente): pregunta del wizard de `kj init`.

## Verificación
- 5/5 tests (informe con must-fix truncados y gasto/techo, passthrough desatendido, continuar/parar, inyección sin clobber, directiva sobre sesión vacía) · suite completa verde (exit 0) · `kj run --help` muestra `--step` · ESLint ✓ · Prettier ✓ · privacy ✓

Refs KJC-TSK-0628.