### PR TITLE
feat(init): ask for step mode in the interactive wizard

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -371,6 +371,15 @@ async function runWizard(config, logger) {
     logger.info("Git automation:");
     await askGitAutomation(wizard, config, logger);
 
+    // Iteration gate (KJC-TSK-0628): opt-in step mode, default no.
+    config.session = config.session || {};
+    const stepMode = await wizard.confirm(
+      "Pause after each iteration with a report and ask before continuing (step mode)?",
+      false,
+    );
+    config.session.iteration_gate = stepMode;
+    logger.info(`  -> iteration_gate: ${stepMode}`);
+
     if (enableHuBoard) {
       logger.info("");
       logger.info("HU Board security:");


### PR DESCRIPTION
## Qué (KJC-TSK-0628 — PR2/2)

El wizard interactivo de `kj init` pregunta si activar el **modo paso a paso** (default no) y guarda `session.iteration_gate` en la config del proyecto — el usuario elige supervisión sin tocar YAML, como manda la regla. El init no-interactivo no cambia.

Completa la card junto a #1190 (`--step` + gate + directivas).

## Verificación
- init-wizard + installer-e2e: 32/32 · ESLint ✓ · Prettier ✓ · privacy ✓ · +9 LOC

Refs KJC-TSK-0628.