### PR TITLE
feat(orchestrator): shared parallel limiter with plan budget and cooldown

### DIFF
--- a/src/orchestrator/parallel-limiter.js
+++ b/src/orchestrator/parallel-limiter.js
@@ -1,0 +1,74 @@
+/**
+ * parallel-limiter — shared concurrency coordinator for parallel HU
+ * execution (KJC-TSK-0624, épica KJC-PCS-0065). One instance per plan run,
+ * shared by every HU lane:
+ *
+ *   - Semaphore: at most maxParallel HUs hold a slot (acquire/release).
+ *   - Plan budget: the whole run shares ONE BudgetTracker; the launch gate
+ *     refuses new lanes once aggregated spend reaches the plan ceiling
+ *     (maxParallel × max_budget_usd — parallelism scales the cap, it never
+ *     multiplies it silently).
+ *   - Cooldown: when any lane hits a provider rate limit it calls
+ *     notifyCooldown(ms); NEW launches pause until it expires while lanes
+ *     already flying finish their work — parallel retry stampedes are the
+ *     fastest way to burn a quota.
+ */
+
+export function createParallelLimiter({ maxParallel = 1, budgetTracker = null, planBudgetUsd = null, now = Date.now } = {}) {
+  let inUse = 0;
+  let cooldownUntil = 0;
+  const waiters = [];
+
+  const overPlanBudget = () => {
+    if (planBudgetUsd == null || !budgetTracker) return false;
+    return (budgetTracker.total?.().cost_usd ?? 0) >= Number(planBudgetUsd);
+  };
+
+  const grantNext = () => {
+    while (waiters.length > 0 && inUse < maxParallel) {
+      inUse += 1;
+      waiters.shift()();
+    }
+  };
+
+  return {
+    /** Why a new lane may not launch right now; null = clear to go. */
+    launchBlockReason() {
+      if (overPlanBudget()) {
+        return `plan budget exhausted ($${(budgetTracker.total().cost_usd).toFixed(2)} ≥ $${Number(planBudgetUsd).toFixed(2)})`;
+      }
+      const waitMs = cooldownUntil - now();
+      if (waitMs > 0) return `provider cooldown for ${Math.ceil(waitMs / 1000)}s`;
+      return null;
+    },
+
+    /** Wait for a free slot. Resolves when this lane may run. */
+    acquire() {
+      if (inUse < maxParallel) {
+        inUse += 1;
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => waiters.push(resolve));
+    },
+
+    release() {
+      inUse = Math.max(0, inUse - 1);
+      grantNext();
+    },
+
+    /** A lane hit a rate limit: pause NEW launches until it expires. */
+    notifyCooldown(ms) {
+      cooldownUntil = Math.max(cooldownUntil, now() + Math.max(0, ms));
+    },
+
+    stats() {
+      return { inUse, waiting: waiters.length, maxParallel, cooldownUntil };
+    },
+  };
+}
+
+/** Plan-level ceiling: parallelism scales the per-run cap, explicitly. */
+export function planBudgetUsd({ maxBudgetUsd, maxParallel = 1 }) {
+  if (maxBudgetUsd == null) return null;
+  return Number(maxBudgetUsd) * Math.max(1, maxParallel);
+}

--- a/tests/parallel-limiter.test.js
+++ b/tests/parallel-limiter.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createParallelLimiter, planBudgetUsd } from "../src/orchestrator/parallel-limiter.js";
+
+const tracker = (usd) => ({ total: () => ({ cost_usd: usd }) });
+
+describe("parallel-limiter (KJC-TSK-0624)", () => {
+  it("planBudgetUsd scales the per-run cap by the parallelism, explicitly", () => {
+    expect(planBudgetUsd({ maxBudgetUsd: 5, maxParallel: 3 })).toBe(15);
+    expect(planBudgetUsd({ maxBudgetUsd: 5 })).toBe(5);
+    expect(planBudgetUsd({ maxBudgetUsd: null, maxParallel: 3 })).toBeNull();
+  });
+
+  it("semaphore: grants up to maxParallel and queues the rest until release", async () => {
+    const lim = createParallelLimiter({ maxParallel: 2 });
+    await lim.acquire();
+    await lim.acquire();
+    let third = false;
+    const pending = lim.acquire().then(() => (third = true));
+    await new Promise((r) => setImmediate(r));
+    expect(third).toBe(false);
+    expect(lim.stats()).toMatchObject({ inUse: 2, waiting: 1 });
+
+    lim.release();
+    await pending;
+    expect(third).toBe(true);
+    expect(lim.stats()).toMatchObject({ inUse: 2, waiting: 0 });
+  });
+
+  it("blocks new launches when the shared plan budget is exhausted", () => {
+    const lim = createParallelLimiter({ maxParallel: 2, budgetTracker: tracker(15.2), planBudgetUsd: 15 });
+    expect(lim.launchBlockReason()).toContain("plan budget exhausted");
+    const ok = createParallelLimiter({ maxParallel: 2, budgetTracker: tracker(3), planBudgetUsd: 15 });
+    expect(ok.launchBlockReason()).toBeNull();
+  });
+
+  it("cooldown pauses NEW launches until it expires, without touching in-flight slots", () => {
+    let t = 1000;
+    const lim = createParallelLimiter({ maxParallel: 2, now: () => t });
+    lim.notifyCooldown(30_000);
+    expect(lim.launchBlockReason()).toContain("cooldown for 30s");
+    // A shorter later cooldown never shrinks the pause.
+    lim.notifyCooldown(5_000);
+    expect(lim.launchBlockReason()).toContain("cooldown for 30s");
+    t += 31_000;
+    expect(lim.launchBlockReason()).toBeNull();
+  });
+
+  it("release below zero is clamped and keeps granting correctly", async () => {
+    const lim = createParallelLimiter({ maxParallel: 1 });
+    lim.release(); // spurious release must not corrupt the counter
+    await lim.acquire();
+    expect(lim.stats().inUse).toBe(1);
+    const spy = vi.fn();
+    const pending = lim.acquire().then(spy);
+    lim.release();
+    await pending;
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Qué (KJC-TSK-0624 — PAR-C, épica KJC-PCS-0065)

Coordinador compartido por run de plan, uno para todos los carriles de HU:

- **Semáforo** `acquire()/release()` con tope `maxParallel` (cola FIFO).
- **Techo por plan**: `launchBlockReason()` corta lanzamientos nuevos cuando el **BudgetTracker compartido** alcanza `maxParallel × max_budget_usd` (`planBudgetUsd()`) — el paralelismo escala el techo explícitamente, nunca lo multiplica en silencio. Sinergia directa con el default de 5 (KJC-TSK-0621).
- **Cooldown compartido**: cuando un carril pisa rate limit, `notifyCooldown(ms)` pausa los lanzamientos NUEVOS hasta que expira (nunca se acorta con señales posteriores) sin tocar los carriles en vuelo — la estampida de reintentos paralelos es la forma más rápida de fundir una cuota.

Módulo puro sin consumidores; PAR-E lo cablea al runner.

## Verificación
- 5/5 tests (escala del techo, semáforo con cola, corte por presupuesto, cooldown monotónico con reloj inyectado, release espurio clampado) · ESLint ✓ · Prettier ✓ · privacy ✓ · ~+135 LOC

Refs KJC-TSK-0624.