### PR TITLE
feat(orchestrator): serialize sonar across lanes, prove worktree guard safety

### DIFF
--- a/src/orchestrator/drivers/iteration-phases/quality-gates.js
+++ b/src/orchestrator/drivers/iteration-phases/quality-gates.js
@@ -14,6 +14,7 @@
  */
 
 import { generateDiff } from "../../../review/diff-generator.js";
+import { withLock } from "../../../utils/async-lock.js";
 import {
   runTddCheckStage, runSonarStage, runSonarCloudStage,
 } from "../../iteration-stages.js";
@@ -52,10 +53,12 @@ export async function runQualityGateStages({ config, logger, emitter, eventBase,
   // that one file.
   const sonarStageDisabledForTest = config?.testHarness?.disableSonarStage === true;
   if (!sonarStageDisabledForTest && session.resolved_policies?.sonar !== false) {
-    const sonarResult = await runSonarStage({
+    // Serialize across parallel HU lanes (KJC-TSK-0625): the SonarQube
+    // server scans one project key at a time. No-op on sequential runs.
+    const sonarResult = await withLock("sonar-scan", () => runSonarStage({
       config, logger, emitter, eventBase, session, trackBudget, iteration: i,
       repeatDetector, budgetSummary, sonarState, askQuestion, task, brainCtx
-    });
+    }));
     if (sonarResult.action === "stalled" || sonarResult.action === "pause") return { action: "return", result: sonarResult.result };
     if (sonarResult.action === "continue") return { action: "continue" };
     if (sonarResult.stageResult) {

--- a/src/utils/async-lock.js
+++ b/src/utils/async-lock.js
@@ -1,0 +1,31 @@
+/**
+ * async-lock — named in-process mutex (KJC-TSK-0625, épica KJC-PCS-0065).
+ * Parallel HU lanes run inside ONE kj process; shared single-instance
+ * resources (the SonarQube server scans one project key at a time) must
+ * serialize across lanes. `withLock` chains callers per name in FIFO
+ * order; sequential runs pay nothing (the chain is always settled).
+ */
+
+const locks = new Map(); // name -> { tail: Promise, holders: number }
+
+/** Run `fn` exclusively among every caller sharing `name`. */
+export async function withLock(name, fn) {
+  const entry = locks.get(name) ?? { tail: Promise.resolve(), holders: 0 };
+  entry.holders += 1;
+  locks.set(name, entry);
+
+  const previous = entry.tail;
+  let release;
+  entry.tail = new Promise((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+    entry.holders -= 1;
+    if (entry.holders === 0) locks.delete(name);
+  }
+}

--- a/tests/async-lock.test.js
+++ b/tests/async-lock.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { withLock } from "../src/utils/async-lock.js";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe("async-lock (KJC-TSK-0625)", () => {
+  it("serializes same-name sections in FIFO order", async () => {
+    const order = [];
+    await Promise.all([
+      withLock("sonar", async () => {
+        order.push("a-in");
+        await sleep(20);
+        order.push("a-out");
+      }),
+      withLock("sonar", async () => {
+        order.push("b-in");
+        await sleep(5);
+        order.push("b-out");
+      }),
+      withLock("sonar", async () => order.push("c")),
+    ]);
+    expect(order).toEqual(["a-in", "a-out", "b-in", "b-out", "c"]);
+  });
+
+  it("different names run concurrently", async () => {
+    const order = [];
+    await Promise.all([
+      withLock("x", async () => {
+        order.push("x-in");
+        await sleep(20);
+        order.push("x-out");
+      }),
+      withLock("y", async () => order.push("y")),
+    ]);
+    expect(order).toEqual(["x-in", "y", "x-out"]);
+  });
+
+  it("a throwing section releases the lock for the next caller", async () => {
+    await expect(withLock("boom", async () => {
+      throw new Error("kaput");
+    })).rejects.toThrow("kaput");
+    const result = await withLock("boom", async () => "recovered");
+    expect(result).toBe("recovered");
+  });
+
+  it("returns the section's value", async () => {
+    expect(await withLock("v", async () => 42)).toBe(42);
+  });
+});

--- a/tests/fs-leak-detector.test.js
+++ b/tests/fs-leak-detector.test.js
@@ -270,3 +270,21 @@ describe("detectTranscriptCdLeaks (BUG-0032 layer 2 — cd-then-write outside pr
     expect(Array.isArray(leaks)).toBe(true);
   });
 });
+
+describe("worktree safety (KJC-TSK-0625, épica KJC-PCS-0065)", () => {
+  it("parallel worktrees under projectDir/.karajan/worktrees never register as leaks", () => {
+    // projectDir under $HOME, snapshotted BEFORE the run — the real layout.
+    const projectDir = path.join(tmpHome, "myproj");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const before = snapshotHomeTopLevel();
+
+    // A parallel run creates worktrees INSIDE the project: no new $HOME entry.
+    fs.mkdirSync(path.join(projectDir, ".karajan", "worktrees", "HU-001"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, ".karajan", "worktrees", "HU-001", "a.js"), "x");
+    expect(detectNewHomeEntries(before, projectDir)).toEqual([]);
+
+    // Control: a genuine stray $HOME entry still trips the detector.
+    fs.writeFileSync(path.join(tmpHome, "stray.md"), "leak");
+    expect(detectNewHomeEntries(before, projectDir)).toEqual([path.join(tmpHome, "stray.md")]);
+  });
+});


### PR DESCRIPTION
## Qué (KJC-TSK-0625 — PAR-D, épica KJC-PCS-0065)

Contención de recursos compartidos para el paralelismo:

- **`withLock` (`src/utils/async-lock.js`)**: mutex nombrado en proceso — FIFO, libera ante throw, se auto-limpia del mapa. Los carriles paralelos viven en UN proceso kj, así que basta con esto.
- **Stage sonar serializada**: `withLock("sonar-scan", …)` alrededor de `runSonarStage` — el servidor SonarQube escanea un project key a la vez. **No-op en runs secuenciales.**
- **Guard de leaks: cero cambios, un test**. Hallazgo del análisis: el fs-leak-detector vigila entradas nuevas de $HOME y los worktrees viven DENTRO de `projectDir/.karajan/worktrees/` — nunca lo disparan. Test de regresión con control positivo (un fichero suelto en $HOME sí salta).
- **Reindex RAG**: los merges de PAR-E serán secuenciales → los hooks post-merge serializan solos (documentado en la card).

## Verificación
- async-lock 4/4 + fs-leak 35/35 (incl. el nuevo de worktrees) · ESLint ✓ · Prettier ✓ · privacy ✓ · ~+95 LOC

Refs KJC-TSK-0625.