### PR TITLE
feat(orchestrator): govern parallel HU execution (--parallel, default 1)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -102,6 +102,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--no-sonarcloud")
     .option("--checkpoint-interval <n>", "Minutes between interactive checkpoints (default: 5)")
     .option("--step", "Pause after each iteration with a report and ask before continuing")
+    .option("--parallel <n>", "Concurrent HU lanes for plan runs (default: 1, sequential)")
     .option("--pg-task <cardId>", "Planning Game card ID (e.g., KJC-TSK-0042)")
     .option("--pg-project <projectId>", "Planning Game project ID")
     .option("--auto-simplify", "Auto-simplify pipeline for simple tasks (disable reviewer/tester)")

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -179,6 +179,9 @@ const DEFAULTS = {
     // Opt-in per-iteration supervision (KJC-TSK-0628): pause after each
     // iteration with a report and ask continue / stop / instructions.
     iteration_gate: false,
+    // Concurrent HU lanes per plan run (KJC-TSK-0626). 1 = sequential.
+    // Raising it multiplies token burn rate — the plan budget scales with it.
+    max_parallel_hus: 1,
     max_iteration_minutes: 30,
     max_total_minutes: 120,
     max_planner_minutes: 60,

--- a/src/config/overrides.js
+++ b/src/config/overrides.js
@@ -55,6 +55,7 @@ const SCALAR_FLAGS = [
   ["maxIterationMinutes", (out, v) => { out.session.max_iteration_minutes = Number(v); }],
   ["maxTotalMinutes", (out, v) => { out.session.max_total_minutes = Number(v); }],
   ["checkpointInterval", (out, v) => { out.session.checkpoint_interval_minutes = Number(v); }],
+  ["parallel", (out, v) => { out.session.max_parallel_hus = Number(v); }],
   ["baseBranch", (out, v) => { out.base_branch = v; }],
   ["coderFallback", (out, v) => { out.coder_options.fallback_coder = v; }],
   ["reviewerFallback", (out, v) => { out.reviewer_options.fallback_reviewer = v; }],

--- a/src/orchestrator/hu-scheduler.js
+++ b/src/orchestrator/hu-scheduler.js
@@ -50,6 +50,32 @@ export function husConflict(huA, huB) {
 }
 
 /**
+ * Split one dependency-level group into conflict-free chunks of at most
+ * `maxParallel` HUs (KJC-TSK-0626). Every chunk runs concurrently; chunks
+ * run one after another. maxParallel 1 ⇒ singletons (fully sequential).
+ * Same conservative rules as husConflict: no parseable scope ⇒ runs alone.
+ *
+ * @param {Array<{id: string, scope?: string|null}>} stories - full story list
+ * @param {string[]} groupIds - ids of one dependency-level group, in order
+ * @param {number} maxParallel
+ * @returns {string[][]} chunks of ids
+ */
+export function partitionConflictFree(stories, groupIds, maxParallel = 1) {
+  if (maxParallel <= 1) return groupIds.map((id) => [id]);
+  const byId = new Map(stories.map((s) => [s.id, s]));
+  const chunks = [];
+  for (const id of groupIds) {
+    const story = byId.get(id) ?? { id };
+    const fit = chunks.find(
+      (chunk) => chunk.length < maxParallel && !chunk.some((otherId) => husConflict(story, byId.get(otherId) ?? { id: otherId })),
+    );
+    if (fit) fit.push(id);
+    else chunks.push([id]);
+  }
+  return chunks;
+}
+
+/**
  * Select the next HUs to launch, order-preserving and greedy.
  *
  * @param {object} args

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -7,6 +7,8 @@ import { updateStoryStatus, loadHuBatch, saveHuBatch, HU_STATUS } from "../hu/st
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { refineHuWithContext } from "../hu/lazy-planner.js";
 import { findParallelGroups, createWorktree, mergeWorktree, removeWorktree } from "../hu/parallel-executor.js";
+import { partitionConflictFree } from "./hu-scheduler.js";
+import { createParallelLimiter, planBudgetUsd } from "./parallel-limiter.js";
 
 /**
  * Determine whether the HU reviewer result needs the sub-pipeline path.
@@ -459,14 +461,37 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
   // --- Group HUs into parallel batches ---
   const parallelBatches = findParallelGroups(certifiedStories, orderedIds);
 
-  for (const group of parallelBatches) {
+  // Governance (KJC-TSK-0626): the dependency groups above used to launch
+  // UNBOUNDED via Promise.all — a plan with N independent HUs ran N full
+  // pipelines at once, with no cap, no shared budget and no scope checks.
+  // Now each group is partitioned into conflict-free chunks of at most
+  // max_parallel_hus (default 1 = fully sequential, today's safe path) and
+  // a shared limiter gates every launch against the PLAN budget.
+  const maxParallel = Math.max(1, Number(config?.session?.max_parallel_hus ?? 1));
+  const limiter = createParallelLimiter({
+    maxParallel,
+    budgetTracker,
+    planBudgetUsd: planBudgetUsd({ maxBudgetUsd: config?.max_budget_usd, maxParallel }),
+  });
+  let stopReason = null;
+
+  outer: for (const group of parallelBatches) {
+    for (const chunk of partitionConflictFree(batch.stories, group, maxParallel)) {
     // Filter out HUs that were blocked by a failed dependency in a previous batch
-    const runnableIds = group.filter(id => {
+    const runnableIds = chunk.filter(id => {
       const story = batch.stories.find(s => s.id === id);
       return story && story.status !== HU_STATUS.BLOCKED;
     });
 
     if (runnableIds.length === 0) continue;
+
+    const blockReason = limiter.launchBlockReason();
+    if (blockReason) {
+      stopReason = blockReason;
+      allApproved = false;
+      logger.warn(`HU sub-pipeline stopped before launching ${runnableIds.join(", ")}: ${blockReason}`);
+      break outer;
+    }
 
     // Emit parallel batch start event
     emitProgress(emitter, makeEvent("hu:parallel-start", { ...eventBase, stage: "hu-sub-pipeline" }, {
@@ -511,14 +536,20 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
         }
       }
 
-      // Run all HUs in the batch concurrently
+      // Run all HUs in the batch concurrently, each holding a limiter slot
+      // (belt-and-braces: chunks are already ≤ maxParallel).
       const batchPromises = runnableIds.map(async (storyId) => {
-        return runSingleHu({
-          storyId, batch, batchSessionId, runIterationFn,
-          emitter, eventBase, logger, config, results,
-          worktreePath: worktrees.get(storyId),
-          onStatusChange, onOutcome, budgetTracker
-        });
+        await limiter.acquire();
+        try {
+          return await runSingleHu({
+            storyId, batch, batchSessionId, runIterationFn,
+            emitter, eventBase, logger, config, results,
+            worktreePath: worktrees.get(storyId),
+            onStatusChange, onOutcome, budgetTracker
+          });
+        } finally {
+          limiter.release();
+        }
       });
 
       const batchResults = await Promise.all(batchPromises);
@@ -554,7 +585,8 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
 
       await saveHuBatch(batchSessionId, batch);
     }
+    }
   }
 
-  return { approved: allApproved, results, blockedIds };
+  return { approved: allApproved, results, blockedIds, ...(stopReason ? { stopReason } : {}) };
 }

--- a/tests/hu-scheduler.test.js
+++ b/tests/hu-scheduler.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { scopeTokens, husConflict, selectRunnableHus } from "../src/orchestrator/hu-scheduler.js";
+import { scopeTokens, husConflict, selectRunnableHus, partitionConflictFree } from "../src/orchestrator/hu-scheduler.js";
 
 const hu = (id, scope, blocked_by = []) => ({ id, scope, blocked_by });
 
@@ -60,5 +60,29 @@ describe("hu-scheduler (KJC-TSK-0623)", () => {
   it("default maxParallel of 1 reproduces today's sequential behaviour", () => {
     const { selected } = selectRunnableHus({ hus: [hu("A", "src/a"), hu("B", "src/b")] });
     expect(selected.map((h) => h.id)).toEqual(["A"]);
+  });
+
+  describe("partitionConflictFree (KJC-TSK-0626)", () => {
+    const stories = [hu("A", "src/a"), hu("B", "src/b"), hu("C", "src/a/deep"), hu("D", "src/d"), hu("E", null)];
+
+    it("maxParallel 1 yields singletons — fully sequential", () => {
+      expect(partitionConflictFree(stories, ["A", "B", "C"], 1)).toEqual([["A"], ["B"], ["C"]]);
+    });
+
+    it("packs conflict-free HUs together and isolates overlapping or scopeless ones", () => {
+      // A/B/D are disjoint; C overlaps A (src/a prefix); E has no scope ⇒ alone.
+      expect(partitionConflictFree(stories, ["A", "B", "C", "D", "E"], 3)).toEqual([
+        ["A", "B", "D"],
+        ["C"],
+        ["E"],
+      ]);
+    });
+
+    it("never exceeds maxParallel per chunk", () => {
+      const many = [hu("1", "a1"), hu("2", "a2"), hu("3", "a3"), hu("4", "a4")].map((h, i) => ({ ...h, scope: `src/x${i}` }));
+      const chunks = partitionConflictFree(many, ["1", "2", "3", "4"], 2);
+      expect(chunks.every((c) => c.length <= 2)).toBe(true);
+      expect(chunks.flat().sort()).toEqual(["1", "2", "3", "4"]);
+    });
   });
 });

--- a/tests/parallel-hu.test.js
+++ b/tests/parallel-hu.test.js
@@ -297,7 +297,7 @@ describe("parallel HU execution in sub-pipeline", () => {
     expect(runIterationFn).toHaveBeenCalledTimes(1);
   });
 
-  it("emits hu:parallel-start event with batch info", async () => {
+  it("default governance (KJC-TSK-0626): independent HUs run SEQUENTIALLY, one lane at a time", async () => {
     const stories = [
       { id: "HU-001", status: "certified", certified: { text: "A" }, original: { text: "A" }, blocked_by: [] },
       { id: "HU-002", status: "certified", certified: { text: "B" }, original: { text: "B" }, blocked_by: [] }
@@ -312,6 +312,30 @@ describe("parallel HU execution in sub-pipeline", () => {
       huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_parallel" },
       runIterationFn, emitter, eventBase, logger,
       config: { projectDir: "/project" }
+    });
+
+    // Pre-governance this launched ONE unbounded parallel batch of 2 —
+    // no cap, no shared budget. Default max_parallel_hus is now 1.
+    const parallelEvents = events.filter(e => e.type === "hu:parallel-start");
+    expect(parallelEvents).toHaveLength(2);
+    expect(parallelEvents.every(e => e.detail.parallel === false)).toBe(true);
+  });
+
+  it("emits hu:parallel-start with batch info when parallelism is opted in and scopes are disjoint", async () => {
+    const stories = [
+      { id: "HU-001", status: "certified", certified: { text: "A" }, original: { text: "A" }, blocked_by: [], scope: "src/a" },
+      { id: "HU-002", status: "certified", certified: { text: "B" }, original: { text: "B" }, blocked_by: [], scope: "src/b" }
+    ];
+    const batch = { session_id: "hu-s_parallel", stories: [...stories] };
+    loadHuBatchMock.mockResolvedValue(batch);
+    execFileAsyncMock.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const runIterationFn = vi.fn(async () => ({ approved: true }));
+
+    await runHuSubPipeline({
+      huReviewerResult: { ok: true, certified: 2, total: 2, stories, batchSessionId: "hu-s_parallel" },
+      runIterationFn, emitter, eventBase, logger,
+      config: { projectDir: "/project", session: { max_parallel_hus: 2 } }
     });
 
     const parallelEvents = events.filter(e => e.type === "hu:parallel-start");


### PR DESCRIPTION
## Qué (KJC-TSK-0626 — PAR-E, épica KJC-PCS-0065) + fix de seguridad

**Hallazgo**: el sub-pipeline ya paralelizaba — `findParallelGroups` + `Promise.all` **sin límite alguno**. Un plan/triage con N HUs independientes lanzaba N pipelines completos a la vez, sin tope, sin presupuesto compartido y sin comprobar scopes. Es el candidato más fuerte a la quema de cuota del reporte de campo (KJC-BUG-0107, actualizada).

## Cambios

- **Cada grupo de dependencias se particiona** en trozos libres de conflicto de como mucho `session.max_parallel_hus` (`partitionConflictFree`, reusa `husConflict` de PAR-B: sin scope parseable = corre sola).
- **Default 1 = totalmente secuencial** — el comportamiento seguro pasa a ser el de serie; el paralelismo es opt-in con `--parallel <n>` (flag nuevo) o config.
- **Limiter compartido (PAR-C) cableado**: techo por plan (`maxParallel × max_budget_usd`); presupuesto agotado → el lote **para en alto** con `stopReason` en el resultado; cada carril sostiene un slot del semáforo (cinturón: los trozos ya son ≤ maxParallel).
- Test actualizado al contrato nuevo (default secuencial documentando el porqué) + test del paralelo opt-in con scopes disjuntos + 3 tests del particionador.

## Verificación
- Suite completa verde (exit 0) · parallel-hu 14/14 · scheduler 9/9 · ESLint ✓ · Prettier ✓ · privacy ✓ · +123/−12

Refs KJC-TSK-0626, KJC-BUG-0107.