### PR TITLE
feat(hu): worktree lanes aim coder and git at their lane dir (KJC-TSK-0629)

### DIFF
--- a/src/git/hu-automation.js
+++ b/src/git/hu-automation.js
@@ -113,11 +113,11 @@ export async function prepareHuBranch({ story, huBranches, config, logger }) {
  * @param {object} params.logger
  * @returns {Promise<{committed: boolean, pushed: boolean, prUrl: string|null}>}
  */
-export async function finalizeHuCommit({ story, branchName, config, logger }) {
+export async function finalizeHuCommit({ story, branchName, config, logger, cwd = null }) {
   const result = { committed: false, pushed: false, prUrl: null };
   if (!branchName) return result;
 
-  const changed = await hasChanges();
+  const changed = await hasChanges(cwd);
   if (!changed) {
     logger.info(`HU ${story.id}: no changes to commit`);
     return result;
@@ -126,7 +126,7 @@ export async function finalizeHuCommit({ story, branchName, config, logger }) {
   const title = story.title || story.id;
   const commitMsg = `feat(${story.id}): ${title}`;
   if (config.git?.auto_commit) {
-    const commitRes = await commitAll(commitMsg);
+    const commitRes = await commitAll(commitMsg, cwd);
     if (commitRes) {
       result.committed = true;
       logger.info(`HU ${story.id}: committed on '${branchName}'`);
@@ -135,7 +135,7 @@ export async function finalizeHuCommit({ story, branchName, config, logger }) {
 
   if (config.git?.auto_push && result.committed) {
     try {
-      await pushBranch(branchName);
+      await pushBranch(branchName, cwd);
       result.pushed = true;
       logger.info(`HU ${story.id}: pushed '${branchName}'`);
     } catch (err) {
@@ -157,7 +157,8 @@ export async function finalizeHuCommit({ story, branchName, config, logger }) {
         baseBranch: config.base_branch || "main",
         branch: branchName,
         title: commitMsg,
-        body: prBody
+        body: prBody,
+        cwd
       });
       result.prUrl = url;
       logger.info(`HU ${story.id}: PR created ${url}`);

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -83,7 +83,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
 
   const subPipelineResult = await runHuSubPipeline({
     huReviewerResult: ctx.stageResults.huReviewer,
-    runIterationFn: async (huTask, story) => {
+    runIterationFn: async (huTask, story, laneOpts = {}) => {
       ctx.config.max_iterations = huMaxIterations;
       if (ctx.brainCtx?.enabled) {
         ctx.brainCtx.extensionCount = 0;
@@ -110,8 +110,20 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       if (!huPolicies.testsRequired) ctx.pipelineFlags.testerEnabled = false;
       logger.info(`HU ${story.id} (${resolvedTaskType}): policies → reviewer=${huPolicies.reviewer}, tdd=${huPolicies.tdd}, sonar=${huPolicies.sonar}, tests=${huPolicies.testsRequired}`);
 
-      const branchName = await prepareHuBranch({ story, huBranches, config: ctx.config, logger });
-      const projectDir = ctx.config.projectDir || process.cwd();
+      // PAR-E2 (KJC-TSK-0629): a lane handed a worktree aims every git and
+      // filesystem touchpoint at it. `git worktree add -b` already left the
+      // worktree checked out on kj-hu-<id>, so the main-tree checkout is
+      // skipped — concurrent lanes must never move the main working tree.
+      const worktreePath = laneOpts?.worktreePath || null;
+      const projectDir = worktreePath || ctx.config.projectDir || process.cwd();
+      const laneConfig = worktreePath ? { ...ctx.config, projectDir } : ctx.config;
+      let branchName;
+      if (worktreePath) {
+        branchName = `kj-hu-${story.id}`;
+        huBranches.set(story.id, branchName);
+      } else {
+        branchName = await prepareHuBranch({ story, huBranches, config: ctx.config, logger });
+      }
 
       // KJC-TSK-0408 step 2: snapshot del workspace ANTES de invocar al
       // coder. Si el usuario hace Undo después, restaura este SHA. El
@@ -155,7 +167,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
           // not only after the first failed run.
           const coderResult = await runCoderStage({
             coderRoleInstance: ctx.coderRoleInstance, coderRole: ctx.coderRole,
-            config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
+            config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
             session: ctx.session, plannedTask: ctx.plannedTask,
             trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: ctx.brainCtx,
             acceptanceTests: story.acceptance_tests,
@@ -176,7 +188,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
           if (huPolicies.sonar && ctx.config.sonarqube?.enabled) {
             try {
               const sonarResult = await runSonarStage({
-                config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
+                config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
                 session: ctx.session, trackBudget: ctx.trackBudget, iteration: attempt,
                 // sonarState is required: runSonarStage reads/writes
                 // .issuesInitial / .issuesFinal on it. Forgetting this
@@ -225,7 +237,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             );
             if (pendingGherkinTests.length === 0) {
               logger.info(`HU ${story.id}: all shell acceptance tests PASSED, no Gherkin to translate — approved`);
-              await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
+              await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
               return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
             }
 
@@ -236,7 +248,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             const { runTesterStage } = await import("../post-loop-stages.js");
             const shellResults = testResult.results.filter((r) => r.type !== "gherkin");
             const testerOutcome = await runTesterStage({
-              config: ctx.config, logger, emitter, eventBase: ctx.eventBase,
+              config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
               session: ctx.session, coderRole: ctx.coderRole, trackBudget: ctx.trackBudget,
               iteration: attempt, task: huTask, diff: null, askQuestion,
               pendingGherkinTests, shellTestResults: shellResults,
@@ -244,7 +256,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             const testerStage = testerOutcome?.stageResult;
             if (testerOutcome?.action !== "continue" && testerStage?.verdict === "pass") {
               logger.info(`HU ${story.id}: tester translated Gherkin and verdict=pass — approved`);
-              await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
+              await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
               return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
             }
 
@@ -341,7 +353,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       try {
         const result = await runIterationLoop(ctx, { task: huTask, askQuestion, emitter, logger });
         if (result?.approved) {
-          await finalizeHuCommit({ story, branchName, config: ctx.config, logger });
+          await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
         }
         return result;
       } finally {

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -285,7 +285,9 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
   }));
 
   try {
-    const iterResult = await runIterationFn(huTask, story);
+    // PAR-E2 (KJC-TSK-0629): lanes handed a worktree must aim every git and
+    // filesystem touchpoint at it — laneOpts carries that path to the runner.
+    const iterResult = await runIterationFn(huTask, story, { worktreePath: worktreePath || null });
     const approved = Boolean(iterResult?.approved);
 
     // --- Transition to reviewing (post-coder, pre-reviewer evaluation) ---

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -68,6 +68,9 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       // the plan, the rest are scoped to this HU. All four pass through
       // untouched when the caller omits them (legacy single-task runs).
       adrs, specSection, reviewerFindings, huId,
+      // PAR-E2 (KJC-TSK-0629): the stage's config wins over the role's own —
+      // worktree lanes pass a laneConfig whose projectDir is the worktree.
+      projectDir: config?.projectDir || null,
       onOutput: coderStall.onOutput,
       // Lets Brain Recovery persist a standby snapshot if the coder's
       // provider hits a quota cap mid-run (KJC hibernation wiring).

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -31,6 +31,7 @@ export class CoderRole extends AgentRole {
         reviewerFeedback: null, sonarSummary: null, deferredContext: null,
         acceptanceTests: null,
         adrs: null, specSection: null, reviewerFindings: null, huId: null,
+        projectDir: null,
         onOutput: null
       };
     }
@@ -52,12 +53,15 @@ export class CoderRole extends AgentRole {
       specSection: input?.specSection || null,
       reviewerFindings: input?.reviewerFindings || null,
       huId: input?.huId || null,
+      // PAR-E2 (KJC-TSK-0629): per-call project root. Worktree lanes pass
+      // their lane dir here; the shared role instance keeps its own config.
+      projectDir: input?.projectDir || null,
       onOutput: input?.onOutput || null
     };
   }
 
-  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests, adrs, specSection, reviewerFindings, huId }) {
-    const projectDir = this.config?.projectDir || null;
+  async buildPrompt({ task, reviewerFeedback, sonarSummary, deferredContext, acceptanceTests, adrs, specSection, reviewerFindings, huId, projectDir: laneProjectDir }) {
+    const projectDir = laneProjectDir || this.config?.projectDir || null;
     // KJC sesgo-de-stack: pasar stack/testFramework al prompt para que
     // el coder no asuma JS/vitest en proyectos Python / Go / Rust /
     // Ruby. audit-role.js y tester-role.js ya lo hacen así.

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -167,8 +167,8 @@ export function buildBranchName(prefix, task) {
   return `${prefix}${slugifyTask(task) || "task"}-${stamp}`;
 }
 
-export async function hasChanges() {
-  const status = await runGit(["status", "--porcelain"]);
+export async function hasChanges(cwd = null) {
+  const status = await runGit(["status", "--porcelain"], cwd ? { cwd } : {});
   return status.length > 0;
 }
 
@@ -229,12 +229,13 @@ function isNothingToCommit(message) {
   return NOTHING_TO_COMMIT_PATTERNS.some((re) => re.test(m));
 }
 
-export async function commitAll(message) {
-  await runGit(["add", "-A"]);
-  const changed = await hasChanges();
+export async function commitAll(message, cwd = null) {
+  const opts = cwd ? { cwd } : {};
+  await runGit(["add", "-A"], opts);
+  const changed = await hasChanges(cwd);
   if (!changed) return { committed: false };
   try {
-    await runGit(["commit", "-m", message]);
+    await runGit(["commit", "-m", message], opts);
   } catch (err) {
     // `git status --porcelain` and `git commit` disagreed about whether
     // there was anything to commit. Don't escalate — the only outcome
@@ -245,18 +246,18 @@ export async function commitAll(message) {
     }
     throw err;
   }
-  const raw = await runGit(["log", "-1", "--pretty=format:%H%x1f%s"]);
+  const raw = await runGit(["log", "-1", "--pretty=format:%H%x1f%s"], opts);
   const [hash, commitMessage] = raw.split("\x1f");
   return { committed: true, commit: { hash, message: commitMessage } };
 }
 
-export async function pushBranch(branch) {
-  await runGit(["push", "-u", "origin", branch]);
+export async function pushBranch(branch, cwd = null) {
+  await runGit(["push", "-u", "origin", branch], cwd ? { cwd } : {});
 }
 
-export async function createPullRequest({ baseBranch, branch, title, body }) {
+export async function createPullRequest({ baseBranch, branch, title, body, cwd = null }) {
   const args = ["pr", "create", "--base", baseBranch, "--head", branch, "--title", title, "--body", body];
-  const res = await runCommand("gh", args);
+  const res = await runCommand("gh", args, cwd ? { cwd } : {});
   if (res.exitCode !== 0) {
     throw new Error(`gh ${args.join(" ")} failed: ${res.stderr || res.stdout}`);
   }

--- a/tests/hu-lane-worktree.test.js
+++ b/tests/hu-lane-worktree.test.js
@@ -1,0 +1,67 @@
+// PAR-E2 (KJC-TSK-0629) PR1: worktree lanes aim git + coder prompt at the
+// lane directory. Covers the cwd plumbing in utils/git and the per-call
+// projectDir override in CoderRole.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { commitAll, hasChanges, pushBranch, setRunner } from "../src/utils/git.js";
+import { CoderRole } from "../src/roles/coder-role.js";
+
+describe("utils/git cwd plumbing (PAR-E2)", () => {
+  afterEach(() => setRunner(null));
+
+  function captureRunner() {
+    return vi.fn(async (_cmd, args) => {
+      if (args[0] === "status") return { exitCode: 0, stdout: " M file.js", stderr: "" };
+      if (args[0] === "log") return { exitCode: 0, stdout: "abc123\x1ffeat: x", stderr: "" };
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+  }
+
+  it("hasChanges runs git in the given cwd", async () => {
+    const runner = captureRunner();
+    setRunner(runner);
+    await hasChanges("/wt/HU-001");
+    expect(runner).toHaveBeenCalledWith("git", ["status", "--porcelain"], { cwd: "/wt/HU-001" });
+  });
+
+  it("commitAll threads cwd through add, status, commit and log", async () => {
+    const runner = captureRunner();
+    setRunner(runner);
+    const res = await commitAll("feat: x", "/wt/HU-001");
+    expect(res.committed).toBe(true);
+    for (const call of runner.mock.calls) {
+      expect(call[2]).toEqual({ cwd: "/wt/HU-001" });
+    }
+  });
+
+  it("pushBranch runs git push in the given cwd", async () => {
+    const runner = captureRunner();
+    setRunner(runner);
+    await pushBranch("kj-hu-HU-001", "/wt/HU-001");
+    expect(runner).toHaveBeenCalledWith("git", ["push", "-u", "origin", "kj-hu-HU-001"], { cwd: "/wt/HU-001" });
+  });
+
+  it("omitting cwd keeps the legacy behavior (no cwd option)", async () => {
+    const runner = captureRunner();
+    setRunner(runner);
+    await hasChanges();
+    expect(runner.mock.calls[0][2]).toEqual({});
+  });
+});
+
+describe("CoderRole per-call projectDir override (PAR-E2)", () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  it("worktree lane dir wins over the role's own config", async () => {
+    const role = new CoderRole({ config: { projectDir: "/main/root" }, logger });
+    const input = role.extractInput({ task: "do x", projectDir: "/main/root/.kj/worktrees/HU-001" });
+    const { prompt } = await role.buildPrompt(input);
+    expect(prompt).toContain("/main/root/.kj/worktrees/HU-001");
+    expect(prompt).not.toContain("The project root is **/main/root**");
+  });
+
+  it("without an override the role's config.projectDir still applies", async () => {
+    const role = new CoderRole({ config: { projectDir: "/main/root" }, logger });
+    const { prompt } = await role.buildPrompt(role.extractInput({ task: "do x" }));
+    expect(prompt).toContain("The project root is **/main/root**");
+  });
+});

--- a/tests/parallel-hu.test.js
+++ b/tests/parallel-hu.test.js
@@ -319,6 +319,11 @@ describe("parallel HU execution in sub-pipeline", () => {
     const parallelEvents = events.filter(e => e.type === "hu:parallel-start");
     expect(parallelEvents).toHaveLength(2);
     expect(parallelEvents.every(e => e.detail.parallel === false)).toBe(true);
+
+    // PAR-E2: sequential lanes carry no worktree — main-tree behavior intact
+    for (const call of runIterationFn.mock.calls) {
+      expect(call[2]).toEqual({ worktreePath: null });
+    }
   });
 
   it("emits hu:parallel-start with batch info when parallelism is opted in and scopes are disjoint", async () => {
@@ -342,6 +347,14 @@ describe("parallel HU execution in sub-pipeline", () => {
     expect(parallelEvents).toHaveLength(1);
     expect(parallelEvents[0].detail.batchIds).toEqual(expect.arrayContaining(["HU-001", "HU-002"]));
     expect(parallelEvents[0].detail.parallel).toBe(true);
+
+    // PAR-E2: each parallel lane receives ITS worktree path so the whole
+    // iteration (coder, git, acceptance tests) runs inside it
+    const lanePaths = runIterationFn.mock.calls.map(call => call[2]?.worktreePath).sort();
+    expect(lanePaths).toEqual([
+      "/project/.kj/worktrees/HU-001",
+      "/project/.kj/worktrees/HU-002"
+    ]);
   });
 
   it("diamond dependency produces correct parallel batches", async () => {

--- a/tests/utils/utils-git.test.js
+++ b/tests/utils/utils-git.test.js
@@ -184,7 +184,8 @@ describe("utils/git", () => {
       expect(url).toBe("https://github.com/repo/pull/1");
       expect(runCommand).toHaveBeenCalledWith(
         "gh",
-        ["pr", "create", "--base", "main", "--head", "feat/test", "--title", "Test PR", "--body", "Description"]
+        ["pr", "create", "--base", "main", "--head", "feat/test", "--title", "Test PR", "--body", "Description"],
+        {}
       );
     });
 


### PR DESCRIPTION
## PAR-E2 PR1 — el carril trabaja DENTRO de su worktree

Hallazgo post-PAR-E (KJC-TSK-0629): el sub-pipeline creaba worktrees para HUs concurrentes pero **nadie trabajaba en ellos** — `runIterationFn(huTask, story)` no recibía `worktreePath`, `prepareHuBranch` hacía `git checkout -B` sobre el árbol principal y el prompt del coder apuntaba al projectDir compartido. Con `--parallel 2` real, dos carriles habrían movido el árbol principal a la vez.

### Cambios
- `hu-sub-pipeline`: `runIterationFn` recibe `{ worktreePath }` como tercer argumento.
- `run-hu-batch`: el carril con worktree usa `laneConfig` (`projectDir` = worktree, sin mutar `ctx.config`), salta el checkout del árbol principal (el worktree ya está en `kj-hu-<id>`), y snapshot/acceptance-tests/coder/sonar/tester/finalize apuntan al worktree.
- `hu-automation` + `utils/git`: `cwd` opcional enhebrado (`hasChanges`, `commitAll`, `pushBranch`, `createPullRequest`).
- `CoderRole`: override de `projectDir` por llamada — la regla dura del prompt ("project root is X") apunta al worktree del carril sin clonar la instancia del rol.

### Garantía de no-regresión
Con `max_parallel_hus: 1` (default) `worktreePath` es `null` y todo el camino queda byte a byte como antes (test de regresión incluido).

### Pendiente en PRs siguientes (misma card)
PR2: estado por carril (pipelineFlags/session/brainCtx). PR3: merge-back + e2e real `--parallel 2`.