### PR TITLE
feat(hu): per-lane config, flags, session and brain state (KJC-TSK-0629)

### DIFF
--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -55,7 +55,6 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
   }));
 
   // Per-HU pipeline: focused max_iterations, fresh Brain state, own git branch.
-  const originalMaxIterations = ctx.config.max_iterations;
   const huMaxIterations = ctx.config.hu_max_iterations ?? 3;
   const huBranches = new Map();
   const { prepareHuBranch, finalizeHuCommit } = await import("../../git/hu-automation.js");
@@ -84,14 +83,6 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
   const subPipelineResult = await runHuSubPipeline({
     huReviewerResult: ctx.stageResults.huReviewer,
     runIterationFn: async (huTask, story, laneOpts = {}) => {
-      ctx.config.max_iterations = huMaxIterations;
-      if (ctx.brainCtx?.enabled) {
-        ctx.brainCtx.extensionCount = 0;
-        const { createBrainContext } = await import("../brain-coordinator.js");
-        const fresh = createBrainContext({ enabled: true });
-        ctx.brainCtx.feedbackQueue = fresh.feedbackQueue;
-        ctx.brainCtx.verificationTracker = fresh.verificationTracker;
-      }
       // Apply per-HU policies based on task_type (infra skips reviewer/sonar/tdd).
       // KJC-TSK-0400: `effectiveTaskType` mira primero story.task_type y, si
       // no es válido, infiere del prefijo del title ([SPIKE], [DOC]…). Así
@@ -103,26 +94,49 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
         logger.info(`HU ${story.id}: task_type inferido del title → ${resolvedTaskType} (era ${story.task_type || "null"})`);
       }
       const huPolicies = applyPolicies({ taskType: resolvedTaskType, policies: ctx.config.policies });
-      const savedFlags = { ...ctx.pipelineFlags };
-      if (!huPolicies.reviewer) ctx.pipelineFlags.reviewerEnabled = false;
-      if (!huPolicies.tdd) ctx.config.development = { ...ctx.config.development, methodology: "standard", require_test_changes: false };
-      if (!huPolicies.sonar) ctx.config.sonarqube = { ...ctx.config.sonarqube, enabled: false };
-      if (!huPolicies.testsRequired) ctx.pipelineFlags.testerEnabled = false;
       logger.info(`HU ${story.id} (${resolvedTaskType}): policies → reviewer=${huPolicies.reviewer}, tdd=${huPolicies.tdd}, sonar=${huPolicies.sonar}, tests=${huPolicies.testsRequired}`);
 
-      // PAR-E2 (KJC-TSK-0629): a lane handed a worktree aims every git and
-      // filesystem touchpoint at it. `git worktree add -b` already left the
-      // worktree checked out on kj-hu-<id>, so the main-tree checkout is
-      // skipped — concurrent lanes must never move the main working tree.
+      // PAR-E2 PR2 (KJC-TSK-0629): every per-HU adjustment lands on LANE
+      // copies. ctx.config/pipelineFlags/session/brainCtx are shared by all
+      // lanes, so concurrent lanes must never mutate them. This also fixes a
+      // latent leak: max_iterations was mutated on ctx.config and only the
+      // fallback path restored it — the acceptance path returned early and
+      // left it clamped to hu_max_iterations for the rest of the run.
       const worktreePath = laneOpts?.worktreePath || null;
       const projectDir = worktreePath || ctx.config.projectDir || process.cwd();
-      const laneConfig = worktreePath ? { ...ctx.config, projectDir } : ctx.config;
+      const laneConfig = { ...ctx.config, projectDir, max_iterations: huMaxIterations };
+      if (!huPolicies.tdd) laneConfig.development = { ...laneConfig.development, methodology: "standard", require_test_changes: false };
+      if (!huPolicies.sonar) laneConfig.sonarqube = { ...laneConfig.sonarqube, enabled: false };
+      const laneFlags = { ...ctx.pipelineFlags };
+      if (!huPolicies.reviewer) laneFlags.reviewerEnabled = false;
+      if (!huPolicies.testsRequired) laneFlags.testerEnabled = false;
+      // Worktree lanes clone the session so reviewer feedback never leaks
+      // across concurrent HUs. Disk saves still share the session id (last
+      // writer wins) — journal noise at most; in-memory isolation is what
+      // guards correctness.
+      const laneSession = worktreePath ? { ...ctx.session } : ctx.session;
+      let laneBrain = ctx.brainCtx;
+      if (ctx.brainCtx?.enabled) {
+        const { createBrainContext } = await import("../brain-coordinator.js");
+        const fresh = createBrainContext({ enabled: true });
+        if (worktreePath) {
+          laneBrain = { ...ctx.brainCtx, extensionCount: 0, feedbackQueue: fresh.feedbackQueue, verificationTracker: fresh.verificationTracker };
+        } else {
+          ctx.brainCtx.extensionCount = 0;
+          ctx.brainCtx.feedbackQueue = fresh.feedbackQueue;
+          ctx.brainCtx.verificationTracker = fresh.verificationTracker;
+        }
+      }
+      let lanePlannedTask = ctx.plannedTask;
+
+      // A worktree lane skips the main-tree checkout: `git worktree add -b`
+      // already left the worktree checked out on kj-hu-<id>.
       let branchName;
       if (worktreePath) {
         branchName = `kj-hu-${story.id}`;
         huBranches.set(story.id, branchName);
       } else {
-        branchName = await prepareHuBranch({ story, huBranches, config: ctx.config, logger });
+        branchName = await prepareHuBranch({ story, huBranches, config: laneConfig, logger });
       }
 
       // KJC-TSK-0408 step 2: snapshot del workspace ANTES de invocar al
@@ -154,11 +168,11 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
         // iterations against an irreparable test (the 2026-04-29 bug).
         const failureTracker = createFailureTracker();
 
-        for (let attempt = 1; attempt <= ctx.config.max_iterations; attempt++) {
-          logger.info(`HU ${story.id}: coder iteration ${attempt}/${ctx.config.max_iterations}`);
+        for (let attempt = 1; attempt <= laneConfig.max_iterations; attempt++) {
+          logger.info(`HU ${story.id}: coder iteration ${attempt}/${laneConfig.max_iterations}`);
           emitProgress(emitter, makeEvent("iteration:start", { ...ctx.eventBase, stage: "iteration" }, {
-            message: `Iteration ${attempt}/${ctx.config.max_iterations}`,
-            detail: { iteration: attempt, maxIterations: ctx.config.max_iterations }
+            message: `Iteration ${attempt}/${laneConfig.max_iterations}`,
+            detail: { iteration: attempt, maxIterations: laneConfig.max_iterations }
           }));
 
           // Coder runs with the HU task + any diagnostic feedback from previous attempt.
@@ -168,8 +182,8 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
           const coderResult = await runCoderStage({
             coderRoleInstance: ctx.coderRoleInstance, coderRole: ctx.coderRole,
             config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
-            session: ctx.session, plannedTask: ctx.plannedTask,
-            trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: ctx.brainCtx,
+            session: laneSession, plannedTask: lanePlannedTask,
+            trackBudget: ctx.trackBudget, iteration: attempt, brainCtx: laneBrain,
             acceptanceTests: story.acceptance_tests,
             // PR F (v2.7.5): plan-aware coder context. ADRs are
             // shared across the plan, the rest are scoped to this
@@ -185,11 +199,11 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
           }
 
           // Sonar quality gate (sw task_type only, when policies say sonar=true)
-          if (huPolicies.sonar && ctx.config.sonarqube?.enabled) {
+          if (huPolicies.sonar && laneConfig.sonarqube?.enabled) {
             try {
               const sonarResult = await runSonarStage({
                 config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
-                session: ctx.session, trackBudget: ctx.trackBudget, iteration: attempt,
+                session: laneSession, trackBudget: ctx.trackBudget, iteration: attempt,
                 // sonarState is required: runSonarStage reads/writes
                 // .issuesInitial / .issuesFinal on it. Forgetting this
                 // surfaces as `Cannot read properties of undefined
@@ -200,11 +214,11 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
                 sonarState: ctx.sonarState,
                 repeatDetector: ctx.repeatDetector,
                 budgetSummary: ctx.budgetSummary,
-                askQuestion, brainCtx: ctx.brainCtx
+                askQuestion, brainCtx: laneBrain
               });
               if (sonarResult?.action === "continue") {
                 // Sonar failed — add to feedback for next coder attempt
-                ctx.plannedTask = `${huTask}\n\n--- SONAR FAILURE ---\n${ctx.session.last_reviewer_feedback}`;
+                lanePlannedTask = `${huTask}\n\n--- SONAR FAILURE ---\n${laneSession.last_reviewer_feedback}`;
                 continue;
               }
             } catch (err) {
@@ -238,7 +252,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             if (pendingGherkinTests.length === 0) {
               logger.info(`HU ${story.id}: all shell acceptance tests PASSED, no Gherkin to translate — approved`);
               await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
-              return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
+              return { approved: true, sessionId: laneSession.id, reason: "acceptance_tests_passed" };
             }
 
             // Shell tests passed; Gherkin needs translation. Invoke the
@@ -249,7 +263,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             const shellResults = testResult.results.filter((r) => r.type !== "gherkin");
             const testerOutcome = await runTesterStage({
               config: laneConfig, logger, emitter, eventBase: ctx.eventBase,
-              session: ctx.session, coderRole: ctx.coderRole, trackBudget: ctx.trackBudget,
+              session: laneSession, coderRole: ctx.coderRole, trackBudget: ctx.trackBudget,
               iteration: attempt, task: huTask, diff: null, askQuestion,
               pendingGherkinTests, shellTestResults: shellResults,
             });
@@ -257,7 +271,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             if (testerOutcome?.action !== "continue" && testerStage?.verdict === "pass") {
               logger.info(`HU ${story.id}: tester translated Gherkin and verdict=pass — approved`);
               await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
-              return { approved: true, sessionId: ctx.session.id, reason: "acceptance_tests_passed" };
+              return { approved: true, sessionId: laneSession.id, reason: "acceptance_tests_passed" };
             }
 
             // Tester rejected (translated tests failed or coverage
@@ -271,8 +285,8 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
               "Fix the implementation so every scenario passes. Do NOT soften the scenarios.",
             ].filter(Boolean).join("\n");
             logger.warn(`HU ${story.id}: tester verdict=fail after Gherkin translation — sending back to coder`);
-            setReviewerFeedback(ctx.session, diagnostic);
-            ctx.plannedTask = `${huTask}\n\n--- GHERKIN TRANSLATION FAILURES ---\n${diagnostic}`;
+            setReviewerFeedback(laneSession, diagnostic);
+            lanePlannedTask = `${huTask}\n\n--- GHERKIN TRANSLATION FAILURES ---\n${diagnostic}`;
             continue;
           }
 
@@ -326,7 +340,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
 
           if (repairEscalate) {
             logger.warn(`HU ${story.id}: Repairer escalated — ${repairEscalate}`);
-            return { approved: false, sessionId: ctx.session.id, reason: "repair_escalated" };
+            return { approved: false, sessionId: laneSession.id, reason: "repair_escalated" };
           }
           if (repairedAny) {
             // Tests were rewritten — restart iteration with the fixed
@@ -340,26 +354,24 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
           // No repair happened — normal coder feedback path.
           const diagnostic = buildDiagnosticPrompt(failed);
           logger.warn(`HU ${story.id}: ${failed.length} acceptance test(s) FAILED — sending diagnostic to coder`);
-          setReviewerFeedback(ctx.session, diagnostic);
-          ctx.plannedTask = `${huTask}\n\n--- ACCEPTANCE TEST FAILURES ---\n${diagnostic}`;
+          setReviewerFeedback(laneSession, diagnostic);
+          lanePlannedTask = `${huTask}\n\n--- ACCEPTANCE TEST FAILURES ---\n${diagnostic}`;
         }
 
         // All iterations exhausted
         logger.warn(`HU ${story.id}: max iterations reached with acceptance tests still failing`);
-        return { approved: false, sessionId: ctx.session.id, reason: "acceptance_tests_failed" };
+        return { approved: false, sessionId: laneSession.id, reason: "acceptance_tests_failed" };
       }
 
-      // Fallback: no acceptance_tests → standard pipeline (reviewer/tester)
-      try {
-        const result = await runIterationLoop(ctx, { task: huTask, askQuestion, emitter, logger });
-        if (result?.approved) {
-          await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
-        }
-        return result;
-      } finally {
-        ctx.config.max_iterations = originalMaxIterations;
-        Object.assign(ctx.pipelineFlags, savedFlags);
+      // Fallback: no acceptance_tests → standard pipeline (reviewer/tester).
+      // The loop reads everything through ctx.* — handing it a lane view
+      // keeps the shared ctx untouched (no more mutate-and-restore dance).
+      const laneCtx = { ...ctx, config: laneConfig, pipelineFlags: laneFlags, session: laneSession, brainCtx: laneBrain, plannedTask: lanePlannedTask };
+      const result = await runIterationLoop(laneCtx, { task: huTask, askQuestion, emitter, logger });
+      if (result?.approved) {
+        await finalizeHuCommit({ story, branchName, config: laneConfig, logger, cwd: worktreePath });
       }
+      return result;
     },
     emitter,
     eventBase: ctx.eventBase,

--- a/tests/hu-lane-state.test.js
+++ b/tests/hu-lane-state.test.js
@@ -1,0 +1,97 @@
+// PAR-E2 (KJC-TSK-0629) PR2: per-HU adjustments live on LANE copies —
+// the shared ctx (config, pipelineFlags, session, brainCtx) must come out
+// of a lane byte-identical, and worktree lanes must hand the coder a
+// lane-scoped config + cloned session.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCoderStageMock = vi.fn(async () => ({ ok: true }));
+const prepareHuBranchMock = vi.fn(async () => "feat/branch");
+const finalizeHuCommitMock = vi.fn(async () => ({ committed: true, pushed: false, prUrl: null }));
+
+vi.mock("../src/orchestrator/hu-sub-pipeline.js", () => ({
+  needsSubPipeline: () => true,
+  runHuSubPipeline: vi.fn(async ({ runIterationFn }) => {
+    const story = {
+      id: "HU-1", task_type: "sw", status: "certified",
+      certified: { title: "T" }, acceptance_tests: ["test -f x"]
+    };
+    const res = await runIterationFn("do x", story, { worktreePath: "/proj/.kj/worktrees/HU-1" });
+    return { approved: res.approved, results: [res], blockedIds: [] };
+  })
+}));
+vi.mock("../src/orchestrator/stages/coder-stage.js", () => ({
+  runCoderStage: (...args) => runCoderStageMock(...args)
+}));
+vi.mock("../src/orchestrator/stages/sonar-stage.js", () => ({ runSonarStage: vi.fn() }));
+vi.mock("../src/orchestrator/drivers/iteration-loop.js", () => ({ runIterationLoop: vi.fn() }));
+vi.mock("../src/orchestrator/drivers/post-loop.js", () => ({ writeHistoryRecord: vi.fn() }));
+vi.mock("../src/git/hu-snapshot.js", () => ({ createHuSnapshot: vi.fn(async () => ({ ok: false, error: "skip" })) }));
+vi.mock("../src/git/hu-automation.js", () => ({
+  prepareHuBranch: (...args) => prepareHuBranchMock(...args),
+  finalizeHuCommit: (...args) => finalizeHuCommitMock(...args)
+}));
+vi.mock("../src/guards/policy-resolver.js", () => ({
+  effectiveTaskType: () => "sw",
+  applyPolicies: () => ({ reviewer: false, tdd: false, sonar: false, testsRequired: false })
+}));
+vi.mock("../src/plan/adr-loader.js", () => ({ loadActiveAdrs: vi.fn(async () => []) }));
+vi.mock("../src/hu/acceptance-runner.js", () => ({
+  runAcceptanceTests: vi.fn(async () => ({ allPassed: true, summary: "ok", results: [] })),
+  buildDiagnosticPrompt: vi.fn(() => "")
+}));
+
+const { runHuBatch } = await import("../src/orchestrator/drivers/run-hu-batch.js");
+
+function buildCtx() {
+  return {
+    config: {
+      projectDir: "/proj", max_iterations: 5, hu_max_iterations: 3,
+      development: { methodology: "tdd", require_test_changes: true },
+      sonarqube: { enabled: true }, policies: {}, git: { auto_commit: true }
+    },
+    pipelineFlags: { reviewerEnabled: true, testerEnabled: true },
+    session: { id: "s_1", last_reviewer_feedback: null },
+    brainCtx: { enabled: false },
+    stageResults: { huReviewer: { certified: 1, total: 1, planId: null, review: null } },
+    eventBase: { sessionId: "s_1", iteration: 0, stage: null, startedAt: 1 },
+    coderRoleInstance: {}, coderRole: { provider: "claude" },
+    trackBudget: vi.fn(), budgetTracker: null, plannedTask: "do x"
+  };
+}
+
+describe("HU lane state isolation (PAR-E2 PR2)", () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+  const emitter = { emit: vi.fn() };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shared ctx comes out untouched even when policies disable everything", async () => {
+    const ctx = buildCtx();
+    const configBefore = JSON.stringify(ctx.config);
+    const flagsBefore = JSON.stringify(ctx.pipelineFlags);
+
+    const { result } = await runHuBatch({ ctx, task: "t", askQuestion: vi.fn(), emitter, logger });
+
+    expect(result.approved).toBe(true);
+    expect(JSON.stringify(ctx.config)).toBe(configBefore);
+    expect(JSON.stringify(ctx.pipelineFlags)).toBe(flagsBefore);
+  });
+
+  it("worktree lane hands the coder a lane config and a cloned session", async () => {
+    const ctx = buildCtx();
+    await runHuBatch({ ctx, task: "t", askQuestion: vi.fn(), emitter, logger });
+
+    const coderArgs = runCoderStageMock.mock.calls[0][0];
+    expect(coderArgs.config.projectDir).toBe("/proj/.kj/worktrees/HU-1");
+    expect(coderArgs.config.max_iterations).toBe(3);
+    expect(coderArgs.config.sonarqube.enabled).toBe(false);
+    expect(coderArgs.session).not.toBe(ctx.session);
+    expect(coderArgs.session.id).toBe("s_1");
+
+    // Worktree lane never checks out the main tree; commit runs in the lane
+    expect(prepareHuBranchMock).not.toHaveBeenCalled();
+    expect(finalizeHuCommitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/proj/.kj/worktrees/HU-1", branchName: "kj-hu-HU-1" })
+    );
+  });
+});


### PR DESCRIPTION
## PAR-E2 PR2 — estado por carril

Segunda rebanada de KJC-TSK-0629. PR1 (#1196) apuntó git y coder al worktree; este PR elimina las **46 referencias mutantes a `ctx` compartido** dentro del carril:

- `laneConfig` absorbe `max_iterations` y los ajustes de policies (tdd/sonar) — `ctx.config` ya no se muta nunca.
- `laneFlags` absorbe reviewer/tester por policy — `ctx.pipelineFlags` intacto (adiós al mutate-and-restore del `finally`).
- `laneSession` (clon superficial en carriles worktree): el feedback del reviewer no se filtra entre HUs concurrentes. Los saves a disco comparten id (last-writer-wins, solo ruido de journal).
- `laneBrain`: cada carril worktree recibe su feedbackQueue/verificationTracker; el camino secuencial mantiene el reset compartido de siempre.
- `lanePlannedTask` local en vez de `ctx.plannedTask`.
- Fallback sin acceptance tests: `runIterationLoop(laneCtx)` con vista de carril.

### Bug latente arreglado
`ctx.config.max_iterations` se clampaba a `hu_max_iterations` y **solo el camino fallback lo restauraba** — el camino de acceptance tests (el habitual en planes) retornaba antes y lo dejaba mutado para el resto del run.

### Tests
`tests/hu-lane-state.test.js`: (1) el ctx compartido sale byte a byte idéntico aunque las policies desactiven todo; (2) el coder recibe config del carril (projectDir=worktree, max_iterations=3, sonar off) y sesión clonada; prepareHuBranch no se llama en carril worktree y el commit corre con cwd del worktree. Verificado que ambos tests FALLAN contra main sin este cambio. Suite completa 6052/6052.

Queda PR3: e2e real `--parallel 2` + docs.