### PR TITLE
feat(hu): review and tdd diffs read the lane worktree (KJC-TSK-0629)

### DIFF
--- a/docs/parallel-hus.md
+++ b/docs/parallel-hus.md
@@ -1,0 +1,65 @@
+# Parallel HU execution (worktree lanes)
+
+Since v3.14.0 a plan's independent HUs can run concurrently, each in its own
+git worktree. Epic KJC-PCS-0065 + KJC-TSK-0629.
+
+## Usage
+
+```bash
+kj run --plan <planId> --parallel 2        # up to 2 concurrent HU lanes
+# or persistent:
+# .karajan/kj.config.yml → session.max_parallel_hus: 2
+```
+
+Default is `1` (fully sequential — exactly the pre-3.14 behavior). Parallelism
+is strictly opt-in.
+
+## How a lane works
+
+1. The scheduler (`hu-scheduler.js`) walks the `blocked_by` graph and picks
+   runnable HUs; HUs with overlapping `scope` path prefixes never share a
+   chunk, and a scopeless HU runs alone (`partitionConflictFree`).
+2. Each HU in a multi-lane chunk gets a worktree at
+   `.kj/worktrees/<huId>` on branch `kj-hu-<huId>` (created by
+   `git worktree add -b`, primitive in `karajan-core/worktree`).
+3. The whole lane runs INSIDE that worktree: the coder prompt's project-root
+   rule, the pre-coder snapshot, acceptance tests, TDD/review diffs, sonar
+   (serialized via `withLock("sonar-scan")`) and the final commit/push all use
+   the lane dir (`laneConfig.projectDir`), never the main working tree.
+4. Lane state is isolated: `laneConfig`, `laneFlags`, `laneSession` (cloned),
+   `laneBrain` and `lanePlannedTask` are per-lane copies — per-HU policies
+   (spike/doc/infra) cannot leak into a sibling lane.
+5. Approved lanes merge back sequentially (`mergeWorktree`: merge
+   `kj-hu-<id>` into the main tree's branch, remove worktree, delete branch).
+   Failed lanes get their worktree removed without merging.
+
+## Budget governance
+
+The launch gate (`parallel-limiter.js`) enforces:
+
+- **Plan ceiling**: `max_parallel_hus × max_budget_usd` (default budget cap is
+  5 USD per run, KJC-TSK-0621). When the shared tracker crosses it, no new
+  lane launches and the run stops with `stopReason` — it never drains quota
+  silently (the KJC-BUG-0107 class).
+- **Semaphore**: at most `max_parallel_hus` lanes hold a slot at once.
+- **Cooldown**: provider rate-limit signals pause new launches monotonically.
+
+## Known limits
+
+- `session` disk saves share one session id across lanes (last writer wins);
+  in-memory isolation is what guards correctness. Journal entries may
+  interleave.
+- `ctx.stageResults` on the fallback (no acceptance tests) path is shared;
+  plan-generated HUs always carry acceptance tests, which is the governed
+  path.
+- Recommended `--parallel` is 2–3: subscription rate limits, not CPU, are the
+  real ceiling.
+
+## Iteration gate (`--step`)
+
+Independent of parallelism, `kj run --step` (or `session.iteration_gate:
+true`, asked by `kj init`) pauses after every iteration with a compact report
+(reviewer verdict, must-fix, next step, spend vs cap) and three choices:
+continue, stop, or free text that is injected into the coder's next iteration
+as a user directive (`appendUserDirective`, same channel as Solomon guidance).
+Unattended runs pass through without pausing.

--- a/src/orchestrator/drivers/iteration-phases/guards.js
+++ b/src/orchestrator/drivers/iteration-phases/guards.js
@@ -28,7 +28,7 @@ export async function runGuardStages({ config, logger, emitter, eventBase, sessi
   let diff;
   try {
     const baseRef = await computeBaseRef({ baseBranch });
-    diff = await generateDiff({ baseRef });
+    diff = await generateDiff({ baseRef, projectDir: config?.projectDir || null });
   } catch {
     logger.warn("Guards: could not generate diff, skipping");
     return { action: "ok" };

--- a/src/orchestrator/drivers/iteration-phases/quality-gates.js
+++ b/src/orchestrator/drivers/iteration-phases/quality-gates.js
@@ -77,7 +77,7 @@ export async function runQualityGateStages({ config, logger, emitter, eventBase,
   }
 
   if (pipelineFlags?.impeccableEnabled) {
-    const diff = await generateDiff({ baseRef: session.session_start_sha });
+    const diff = await generateDiff({ baseRef: session.session_start_sha, projectDir: config?.projectDir || null });
     const impeccableMode = pipelineFlags?.impeccableMode || "audit";
     const impeccableResult = await runImpeccableStage({
       config, logger, emitter, eventBase, session, coderRole, trackBudget,

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -432,8 +432,10 @@ export async function runTddCheckStage({ config, logger, emitter, eventBase, ses
   logger.setContext({ iteration, stage: "tdd" });
   let tddDiff, untrackedFiles;
   try {
-    tddDiff = await generateDiff({ baseRef: session.session_start_sha });
-    untrackedFiles = await getUntrackedFiles();
+    // PAR-E2 (KJC-TSK-0629): diff where the coder actually worked — a
+    // worktree lane's changes are invisible from the main tree.
+    tddDiff = await generateDiff({ baseRef: session.session_start_sha, projectDir: config?.projectDir || null });
+    untrackedFiles = await getUntrackedFiles(config?.projectDir || null);
   } catch (err) {
     logger.warn(`TDD diff generation failed: ${err.message}`);
     return { action: "continue", stageResult: { ok: false, summary: `TDD check failed: ${err.message}` } };

--- a/src/orchestrator/stages/reviewer-stage.js
+++ b/src/orchestrator/stages/reviewer-stage.js
@@ -194,14 +194,14 @@ async function handleReviewerRejection({ review, repeatDetector, config, logger,
   });
 }
 
-export async function fetchReviewDiff(session, logger) {
+export async function fetchReviewDiff(session, logger, projectDir = null) {
   let diff;
   if (session.ci_pr_number) {
     const { getPrDiff } = await import("../../ci/pr-diff.js");
     diff = await getPrDiff(session.ci_pr_number);
     logger.info(`Reviewer reading PR diff #${session.ci_pr_number}`);
   } else {
-    diff = await generateDiff({ baseRef: session.session_start_sha, stageNewFiles: true });
+    diff = await generateDiff({ baseRef: session.session_start_sha, stageNewFiles: true, projectDir });
   }
   // Inbound boundary: mask hardcoded secrets before the diff reaches the
   // (possibly cloud) reviewer model. Runs BEFORE the injection guard below so
@@ -221,7 +221,7 @@ export async function runReviewerStage({ reviewerRole, config, logger, emitter, 
 
   let diff;
   try {
-    diff = await fetchReviewDiff(session, logger);
+    diff = await fetchReviewDiff(session, logger, config?.projectDir || null);
   } catch (err) {
     logger.warn(`Review diff generation failed: ${err.message}`);
     return { approved: false, blocking_issues: [{ description: `Diff generation failed: ${err.message}` }], non_blocking_suggestions: [], summary: `Reviewer failed: cannot generate diff — ${err.message}`, confidence: 0 };

--- a/src/review/diff-generator.js
+++ b/src/review/diff-generator.js
@@ -105,8 +105,8 @@ export async function generateDiff({ baseRef, stageNewFiles = false, projectDir 
   return generateSnapshotDiff(emptySnapshot, null, dir);
 }
 
-export async function getUntrackedFiles() {
-  const result = await run("git", ["ls-files", "--others", "--exclude-standard"]);
+export async function getUntrackedFiles(cwd = null) {
+  const result = await run("git", ["ls-files", "--others", "--exclude-standard"], cwd ? { cwd } : {});
   if (result.exitCode !== 0) return [];
   return result.stdout.trim().split("\n").filter(Boolean);
 }

--- a/tests/diff-generator.test.js
+++ b/tests/diff-generator.test.js
@@ -74,7 +74,7 @@ describe("getUntrackedFiles", () => {
 
     const files = await getUntrackedFiles();
 
-    expect(runCommand).toHaveBeenCalledWith("git", ["ls-files", "--others", "--exclude-standard"]);
+    expect(runCommand).toHaveBeenCalledWith("git", ["ls-files", "--others", "--exclude-standard"], {});
     expect(files).toEqual([
       "src/guards/policy-resolver.js",
       "tests/guards/policy-resolver.test.js"


### PR DESCRIPTION
## PAR-E2 PR3 — los diffs miran el worktree del carril + docs

Cierre de la parte de código de KJC-TSK-0629 (tras #1196 y #1197). `generateDiff`/`getUntrackedFiles` corrían siempre en `process.cwd()`: en un carril worktree, el diff TDD, el diff del reviewer, los guards y el gate impeccable veían el árbol principal — cero cambios — y podían rechazar (o aprobar) sobre una foto equivocada.

### Cambios
- `getUntrackedFiles(cwd)` opcional; `generateDiff` ya aceptaba `projectDir`, ahora los call sites del camino del carril lo pasan: TDD check (coder-stage), `fetchReviewDiff` (reviewer-stage), guards y quality-gates (impeccable). Sin `projectDir` el comportamiento es idéntico al actual.
- `docs/parallel-hus.md`: doc de `--parallel` (carriles worktree, scheduler, gobernanza de presupuesto, límites conocidos) y `--step`.

Suite: la completa quedó 6052/6052 tras ajustar la aserción de `getUntrackedFiles` (tercer argumento `{}`).

Queda del card: e2e real 3 HUs `--parallel 2` con coder real (se hará con supervisión del usuario — quema cuota).