### PR TITLE
fix(plan): preflight hu ships with pending status (KJC-BUG-0108)

### DIFF
--- a/src/plan/preflight-hu.js
+++ b/src/plan/preflight-hu.js
@@ -88,6 +88,9 @@ export async function prependPreflightHu(plan, projectDir) {
     title: "[PREFLIGHT-000] Verificar entorno de desarrollo listo",
     description: "[PREFLIGHT-000] Block functional HUs until the project's environment is reproducible: deps installed, build/test/lint passing, git tree clean, cloud auth ready when applicable.",
     task_type: "infra",
+    // KJC-BUG-0108: without an explicit status, `kj plan ready` rejects the
+    // whole plan with "invalid status undefined".
+    status: "pending",
     blocked_by: [],
     reuse: [],
     acceptance_tests: composePreflightTests(stack, projectDir),

--- a/tests/plan/preflight-hu.test.js
+++ b/tests/plan/preflight-hu.test.js
@@ -55,6 +55,8 @@ describe("preflight-hu — KJC-TSK-0397", () => {
     };
     await prependPreflightHu(plan, root);
     expect(plan.hus[0].id).toBe("PREFLIGHT-000");
+    // KJC-BUG-0108: without it, `kj plan ready` rejects the whole plan
+    expect(plan.hus[0].status).toBe("pending");
     expect(plan.hus[1].id).toBe("HU-A");
     expect(plan.hus[1].blocked_by).toEqual(["PREFLIGHT-000"]);
     expect(plan.hus[2].id).toBe("HU-B");


### PR DESCRIPTION
Encontrado en el e2e de PAR-F: `prependPreflightHu` construye el [PREFLIGHT-000] sin campo `status`, y `kj plan ready` rechaza el plan entero con "HU PREFLIGHT-000: invalid status undefined". Afecta a todos los planes generados desde KJC-TSK-0397.

Fix de una línea: `status: "pending"` en el objeto preflight, igual que el resto de HUs del planner. Test de regresión en el caso C existente.