### PR TITLE
fix(plan): batch stories keep the plan scope field (KJC-BUG-0110)

### DIFF
--- a/src/plan/plan-executor.js
+++ b/src/plan/plan-executor.js
@@ -24,6 +24,10 @@ export function planToHuBatch(plan) {
     task_type: hu.task_type || "sw",
     status: hu.status === "certified" ? "certified" : hu.status,
     blocked_by: hu.blocked_by || [],
+    // KJC-BUG-0110: scope must survive as its own field — the parallel
+    // scheduler treats a scopeless story as exclusive, so dropping it
+    // silently degrades --parallel N to sequential.
+    scope: hu.scope || null,
     certified: { text: hu.scope || hu.title },
     acceptance_criteria: hu.acceptance_criteria || [],
     acceptance_tests: hu.acceptance_tests || [],

--- a/tests/plan-executor.test.js
+++ b/tests/plan-executor.test.js
@@ -1,0 +1,37 @@
+// KJC-BUG-0110: planToHuBatch must carry `scope` into the batch stories —
+// the parallel scheduler treats scopeless stories as exclusive, so losing
+// it silently turns --parallel N into a sequential run.
+import { describe, expect, it } from "vitest";
+import { planToHuBatch } from "../src/plan/plan-executor.js";
+import { partitionConflictFree } from "../src/orchestrator/hu-scheduler.js";
+
+const PLAN = {
+  version: 2,
+  planId: "plan-test",
+  hus: [
+    { id: "A", title: "A", status: "certified", blocked_by: [], scope: "Implementar src/sum/sum.js y tests/sum.test.js" },
+    { id: "B", title: "B", status: "certified", blocked_by: [], scope: "Implementar src/mult/mult.js y tests/mult.test.js" },
+    { id: "C", title: "C", status: "certified", blocked_by: [], scope: "Implementar src/greet/greet.js y tests/greet.test.js" }
+  ]
+};
+
+describe("planToHuBatch scope passthrough (KJC-BUG-0110)", () => {
+  it("stories keep the plan's scope as their own field", () => {
+    const batch = planToHuBatch(PLAN);
+    expect(batch.ok).toBe(true);
+    for (const [i, hu] of PLAN.hus.entries()) {
+      expect(batch.stories[i].scope).toBe(hu.scope);
+    }
+  });
+
+  it("converted stories with disjoint scopes still pair under --parallel 2", () => {
+    const { stories } = planToHuBatch(PLAN);
+    const chunks = partitionConflictFree(stories, ["A", "B", "C"], 2);
+    expect(chunks).toEqual([["A", "B"], ["C"]]);
+  });
+
+  it("a plan HU without scope converts to scope null (exclusive lane)", () => {
+    const { stories } = planToHuBatch({ version: 2, planId: "p", hus: [{ id: "X", title: "X", status: "certified", blocked_by: [] }] });
+    expect(stories[0].scope).toBeNull();
+  });
+});


### PR DESCRIPTION
Encontrado en el e2e de PAR-F: `planToHuBatch` usa `hu.scope` como texto de certified/original pero no lo copia como campo propio de la story. El batch persiste con `scope: null`, el scheduler (por diseño seguro: sin scope ⇒ exclusiva) parte en singletons, y `kj run --plan X --parallel 2` ejecuta **secuencial en silencio**. El reconcile de PR #544 tampoco lo repone porque salta campos ausentes en la conversión (`field in fromPlan`).

Fix de una línea en la raíz: `scope: hu.scope || null` — cubre la conversión inicial Y el reconcile.

Tests: passthrough del scope, partición real [[A,B],[C]] con las stories convertidas bajo maxParallel=2, y scope ausente ⇒ null (carril exclusivo). Evidencia e2e con coder real en curso — se añade como comentario al PR.