### PR TITLE
fix(run): --yes auto-answers questions with a declared default (KJC-BUG-0109)

### DIFF
--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -70,7 +70,11 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
       if (!askQuestion) return { proceed: true, severity, findings, finalSpec: currentSpec };
       const answer = await askQuestion(
         `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
-        { detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 } },
+        {
+          detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 },
+          // KJC-BUG-0109: mirrors the interactive default — --yes presses Enter.
+          defaultAnswer: "continue",
+        },
       );
       if (answer === null) return { proceed: false, cancelled: true, severity, findings };
       const n = String(answer).trim().toLowerCase();

--- a/src/utils/cli-ask-question.js
+++ b/src/utils/cli-ask-question.js
@@ -30,6 +30,15 @@ export function createCliAskQuestion(opts = {}) {
     const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
     if (!isInteractive) {
       if (flags?.yes) {
+        // KJC-BUG-0109: a question that declares a safe default is answered
+        // with it — --yes means "press Enter for me", not "abort on any
+        // gate". Questions without a declared default keep failing loud.
+        const fallback = typeof context?.defaultAnswer === "string" && context.defaultAnswer.trim()
+          ? context.defaultAnswer.trim() : null;
+        if (fallback) {
+          process.stderr.write(`\n[non-interactive --yes] Auto-answering with declared default "${fallback}": ${question}\n`);
+          return fallback;
+        }
         process.stderr.write(
           `\n[non-interactive --yes] Pipeline asked a question that cannot be auto-answered:\n`
           + `  ❓ ${question}\n`

--- a/tests/cli-ask-question-defaults.test.js
+++ b/tests/cli-ask-question-defaults.test.js
@@ -1,0 +1,44 @@
+// KJC-BUG-0109: in non-TTY --yes mode, a question that declares a safe
+// default gets auto-answered with it instead of stopping the session.
+import { describe, expect, it, vi } from "vitest";
+import { createCliAskQuestion } from "../src/utils/cli-ask-question.js";
+
+describe("createCliAskQuestion --yes defaults (KJC-BUG-0109)", () => {
+  function nonTty() {
+    // vitest stdin is not a TTY, so path 2 (no TTY + yes) is exercised
+    // directly; guard the assumption so a TTY-attached runner fails loud.
+    expect(Boolean(process.stdin?.isTTY)).toBe(false);
+  }
+
+  it("auto-answers with the declared default", async () => {
+    nonTty();
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const ask = createCliAskQuestion({ flags: { yes: true } });
+    const answer = await ask("Spec review: 3 findings. [c]/[r]/[x]? (default: continue)", {
+      detail: { severity: "info" },
+      defaultAnswer: "continue",
+    });
+    expect(answer).toBe("continue");
+    expect(write.mock.calls.map(c => c[0]).join("")).toContain("Auto-answering");
+    write.mockRestore();
+  });
+
+  it("still stops loud when no default is declared", async () => {
+    nonTty();
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const ask = createCliAskQuestion({ flags: { yes: true } });
+    const answer = await ask("Irreversible choice?", { detail: { severity: "blocker" } });
+    expect(answer).toBeNull();
+    expect(write.mock.calls.map(c => c[0]).join("")).toContain("cannot be auto-answered");
+    write.mockRestore();
+  });
+
+  it("a blank declared default does not count", async () => {
+    nonTty();
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const ask = createCliAskQuestion({ flags: { yes: true } });
+    const answer = await ask("Question?", { defaultAnswer: "   " });
+    expect(answer).toBeNull();
+    write.mockRestore();
+  });
+});


### PR DESCRIPTION
Encontrado en el e2e de PAR-F: con `--yes` desatendido, el spec review preguntó "[c]ontinue / [r]efine / [x]cancel? (default: continue)" con severidad info y el handler detuvo la sesión entera en vez de tomar el default declarado.

Contrato nuevo, conservador: el caller puede declarar `context.defaultAnswer`; en no-TTY + `--yes`, si existe, se responde con él (equivale a pulsar Enter) dejándolo registrado en stderr. Preguntas sin default declarado siguen parando en alto exactamente como antes (el contrato de KJC-BUG-0081 no cambia). El spec review declara `defaultAnswer: "continue"` — el mismo default que ofrece en interactivo.

Tests: auto-respuesta con default, parada sin default, default en blanco no cuenta. Suites de spec-review (7/7) y resume-yes-no-tty en verde.