### PR TITLE
feat(hu): bootstrap lane worktrees — submodules + deps (KJC-TSK-0630)

### DIFF
--- a/docs/parallel-hus.md
+++ b/docs/parallel-hus.md
@@ -33,6 +33,19 @@ is strictly opt-in.
    `kj-hu-<id>` into the main tree's branch, remove worktree, delete branch).
    Failed lanes get their worktree removed without merging.
 
+## Lane bootstrap
+
+A fresh worktree is a clean checkout — no `node_modules`, no initialized
+submodules. Before the coder starts, each lane runs (KJC-TSK-0630):
+
+1. `git submodule update --init --recursive` when `.gitmodules` exists.
+2. `session.worktree_setup` if configured (any shell command, cwd = the
+   worktree); otherwise `npm ci` when `package-lock.json` exists.
+
+Bootstrap is best-effort: failures warn and the lane continues — the
+acceptance tests deliver the real verdict. Each lane keeps its own
+`node_modules` (that IS the isolation; disk is the price).
+
 ## Budget governance
 
 The launch gate (`parallel-limiter.js`) enforces:

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -182,6 +182,10 @@ const DEFAULTS = {
     // Concurrent HU lanes per plan run (KJC-TSK-0626). 1 = sequential.
     // Raising it multiplies token burn rate — the plan budget scales with it.
     max_parallel_hus: 1,
+    // Command run inside each fresh lane worktree before the coder starts
+    // (KJC-TSK-0630). null = auto-detect: `npm ci` when package-lock.json
+    // exists, nothing otherwise. Submodules are always initialized first.
+    worktree_setup: null,
     max_iteration_minutes: 30,
     max_total_minutes: 120,
     max_planner_minutes: 60,

--- a/src/hu/worktree-bootstrap.js
+++ b/src/hu/worktree-bootstrap.js
@@ -1,0 +1,59 @@
+/**
+ * PAR-G (KJC-TSK-0630): make a freshly created lane worktree operative.
+ *
+ * `git worktree add` produces a clean checkout: no node_modules, no
+ * initialized submodules — and a container/bind-mounted process cannot
+ * init them itself because the worktree's real .git lives in the parent
+ * repo (gotcha reported by Jorge del Casar's worktree-docker-envs skill).
+ * Without this step, --parallel lanes die on the first `npm test` in any
+ * real project.
+ *
+ * Best-effort by contract: a failed or slow bootstrap warns and the lane
+ * continues — the acceptance tests deliver the real verdict.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { runCommand } from "../utils/process.js";
+
+const STEP_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * @param {object} params
+ * @param {string} params.worktreePath  Absolute path of the lane worktree.
+ * @param {string|null} [params.setupCommand]  session.worktree_setup — wins over auto-detect.
+ * @param {object|null} [params.logger]
+ * @param {number} [params.timeoutMs]
+ * @param {Function} [params.run]  Injectable runner (tests).
+ * @returns {Promise<{ok: boolean, steps: string[], warnings: string[]}>}
+ */
+export async function bootstrapWorktree({ worktreePath, setupCommand = null, logger = null, timeoutMs = STEP_TIMEOUT_MS, run = runCommand }) {
+  const warnings = [];
+  const steps = [];
+
+  if (existsSync(join(worktreePath, ".gitmodules"))) {
+    steps.push({ name: "submodules", cmd: "git", args: ["submodule", "update", "--init", "--recursive"] });
+  }
+
+  const explicit = typeof setupCommand === "string" && setupCommand.trim() ? setupCommand.trim() : null;
+  if (explicit) {
+    steps.push({ name: "setup", cmd: "sh", args: ["-c", explicit] });
+  } else if (existsSync(join(worktreePath, "package-lock.json"))) {
+    steps.push({ name: "deps", cmd: "npm", args: ["ci", "--no-audit", "--no-fund"] });
+  }
+
+  for (const step of steps) {
+    try {
+      const res = await run(step.cmd, step.args, { cwd: worktreePath, timeout: timeoutMs });
+      if (res.exitCode !== 0) {
+        warnings.push(`${step.name} failed (exit ${res.exitCode}): ${String(res.stderr || res.stdout || "").slice(0, 200)}`);
+      } else {
+        logger?.info?.(`worktree bootstrap: ${step.name} ok`);
+      }
+    } catch (err) {
+      warnings.push(`${step.name} threw: ${err.message}`);
+    }
+  }
+
+  for (const w of warnings) logger?.warn?.(`worktree bootstrap: ${w} — lane continues`);
+  return { ok: warnings.length === 0, steps: steps.map((s) => s.name), warnings };
+}

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -7,6 +7,7 @@ import { updateStoryStatus, loadHuBatch, saveHuBatch, HU_STATUS } from "../hu/st
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { refineHuWithContext } from "../hu/lazy-planner.js";
 import { findParallelGroups, createWorktree, mergeWorktree, removeWorktree } from "../hu/parallel-executor.js";
+import { bootstrapWorktree } from "../hu/worktree-bootstrap.js";
 import { partitionConflictFree } from "./hu-scheduler.js";
 import { createParallelLimiter, planBudgetUsd } from "./parallel-limiter.js";
 
@@ -533,6 +534,10 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
         try {
           const wtPath = await createWorktree(projectDir, id);
           worktrees.set(id, wtPath);
+          // PAR-G (KJC-TSK-0630): a fresh worktree has no node_modules and
+          // no initialized submodules — make the lane operative before the
+          // coder lands. Best-effort: warnings never block the lane.
+          await bootstrapWorktree({ worktreePath: wtPath, setupCommand: config?.session?.worktree_setup || null, logger });
         } catch (err) {
           logger.warn(`Failed to create worktree for HU ${id}: ${err.message} — will run sequentially`);
         }

--- a/tests/worktree-bootstrap.test.js
+++ b/tests/worktree-bootstrap.test.js
@@ -1,0 +1,75 @@
+// PAR-G (KJC-TSK-0630): a fresh lane worktree gets submodules initialized
+// and dependencies installed — best-effort, never blocking the lane.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { bootstrapWorktree } from "../src/hu/worktree-bootstrap.js";
+
+const dirs = [];
+function makeWorktree(files = []) {
+  const dir = mkdtempSync(join(tmpdir(), "kj-wt-boot-"));
+  dirs.push(dir);
+  for (const f of files) writeFileSync(join(dir, f), "{}");
+  return dir;
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+const okRun = () => vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+
+describe("bootstrapWorktree (PAR-G)", () => {
+  it("initializes submodules when .gitmodules exists, with cwd=worktree", async () => {
+    const wt = makeWorktree([".gitmodules"]);
+    const run = okRun();
+    const res = await bootstrapWorktree({ worktreePath: wt, run });
+    expect(res.ok).toBe(true);
+    expect(res.steps).toEqual(["submodules"]);
+    expect(run).toHaveBeenCalledWith("git", ["submodule", "update", "--init", "--recursive"], expect.objectContaining({ cwd: wt }));
+  });
+
+  it("runs npm ci when package-lock.json exists and no explicit setup", async () => {
+    const wt = makeWorktree(["package-lock.json"]);
+    const run = okRun();
+    const res = await bootstrapWorktree({ worktreePath: wt, run });
+    expect(res.steps).toEqual(["deps"]);
+    expect(run).toHaveBeenCalledWith("npm", ["ci", "--no-audit", "--no-fund"], expect.objectContaining({ cwd: wt }));
+  });
+
+  it("an explicit setup command wins over auto-detect", async () => {
+    const wt = makeWorktree(["package-lock.json"]);
+    const run = okRun();
+    const res = await bootstrapWorktree({ worktreePath: wt, setupCommand: "pnpm install --frozen-lockfile", run });
+    expect(res.steps).toEqual(["setup"]);
+    expect(run).toHaveBeenCalledWith("sh", ["-c", "pnpm install --frozen-lockfile"], expect.objectContaining({ cwd: wt }));
+  });
+
+  it("a failing step warns but never throws — the lane continues", async () => {
+    const wt = makeWorktree(["package-lock.json"]);
+    const logger = { warn: vi.fn(), info: vi.fn() };
+    const run = vi.fn(async () => ({ exitCode: 1, stdout: "", stderr: "EACCES" }));
+    const res = await bootstrapWorktree({ worktreePath: wt, logger, run });
+    expect(res.ok).toBe(false);
+    expect(res.warnings[0]).toContain("deps failed");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("a throwing runner is contained too", async () => {
+    const wt = makeWorktree([".gitmodules"]);
+    const run = vi.fn(async () => { throw new Error("spawn ENOENT"); });
+    const res = await bootstrapWorktree({ worktreePath: wt, run });
+    expect(res.ok).toBe(false);
+    expect(res.warnings[0]).toContain("spawn ENOENT");
+  });
+
+  it("no lockfile, no submodules, no setup → no-op", async () => {
+    const wt = makeWorktree();
+    const run = okRun();
+    const res = await bootstrapWorktree({ worktreePath: wt, run });
+    expect(res.ok).toBe(true);
+    expect(res.steps).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PAR-G — el worktree del carril queda operativo antes de que aterrice el coder

`git worktree add` produce un checkout limpio: sin `node_modules` y sin submodules inicializados (y el worktree no puede inicializarlos desde dentro — gotcha aportado por la skill worktree-docker-envs de Jorge del Casar). El e2e de PAR-F coló porque `node:test` no necesita deps; en cualquier proyecto real, los carriles de `--parallel` morirían al primer `npm test`.

### Cambios
- `src/hu/worktree-bootstrap.js`: `bootstrapWorktree` — (1) `git submodule update --init --recursive` si hay `.gitmodules`; (2) `session.worktree_setup` explícito gana; sin él, `npm ci` cuando hay `package-lock.json`; (3) **best-effort**: fallo o timeout → warn y el carril continúa (los acceptance tests dan el veredicto real). Runner inyectable.
- Cableado en `hu-sub-pipeline` justo tras `createWorktree` — solo toca el camino multi-HU opt-in; el secuencial no cambia.
- `session.worktree_setup: null` en defaults + sección "Lane bootstrap" en `docs/parallel-hus.md`.

### Tests
6 casos con runner mock y worktrees temporales reales: submodules con cwd correcto, npm ci por lockfile, comando explícito gana, fallo no bloquea, excepción contenida, no-op limpio. Suite completa verde (el único fallo fue ambiental: el HU Board del e2e seguía vivo y un test de board asume puerto libre).