### PR TITLE
feat(core): slot registry for parallel worktree lanes (KJC-TSK-0631)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "./atomic-write": "./src/atomic-write.js",
     "./db": "./src/db.js",
     "./worktree": "./src/worktree.js",
+    "./slot-registry": "./src/slot-registry.js",
     "./shared-paths": "./src/shared-paths.js",
     "./port-check": "./src/port-check.js",
     "./paths": "./src/paths.js",

--- a/packages/core/src/slot-registry.js
+++ b/packages/core/src/slot-registry.js
@@ -1,0 +1,99 @@
+/**
+ * PAR-H (KJC-TSK-0631): stable numeric slots for parallel worktree lanes.
+ *
+ * Each lane gets the lowest free slot, persisted outside the repo so the
+ * same lane id keeps its slot across runs. The slot drives a port offset
+ * (`base + slot × increment`) so concurrent lanes can publish services
+ * without colliding. Design after Jorge del Casar's worktree-docker-envs
+ * skill: the registry is pure logic over a JSON file, guarded by a
+ * mkdir-based lock so concurrent lane starts serialize safely.
+ */
+import { mkdirSync, readFileSync, rmdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 5000;
+const STALE_LOCK_MS = 30_000;
+
+async function withFileLock(registryPath, fn) {
+  const lockDir = `${registryPath}.lock`;
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  for (;;) {
+    try {
+      mkdirSync(lockDir, { recursive: false });
+      break;
+    } catch {
+      // A crashed holder leaves the lock behind — steal it when old enough.
+      try {
+        if (Date.now() - statSync(lockDir).mtimeMs > STALE_LOCK_MS) {
+          rmdirSync(lockDir);
+          continue;
+        }
+      } catch { /* raced with the holder's release — just retry */ }
+      if (Date.now() > deadline) throw new Error(`slot-registry: lock timeout on ${lockDir}`);
+      await new Promise((r) => setTimeout(r, LOCK_RETRY_MS));
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    try { rmdirSync(lockDir); } catch { /* already gone */ }
+  }
+}
+
+function loadRegistry(registryPath) {
+  try {
+    const parsed = JSON.parse(readFileSync(registryPath, "utf-8"));
+    return { slots: parsed?.slots && typeof parsed.slots === "object" ? parsed.slots : {} };
+  } catch {
+    return { slots: {} };
+  }
+}
+
+function saveRegistry(registryPath, reg) {
+  mkdirSync(dirname(registryPath), { recursive: true });
+  writeFileSync(registryPath, JSON.stringify(reg, null, 2));
+}
+
+/** Port offset for a slot. The project applies its own base on top. */
+export function computePortOffset(slot, increment = 100) {
+  return slot * increment;
+}
+
+/**
+ * Assign (or re-find) the slot for a lane id. Lowest free slot wins;
+ * the same id always gets its previous slot back while it holds one.
+ *
+ * @param {object} params
+ * @param {string} params.registryPath  JSON file, e.g. ~/.karajan/worktree-slots.json
+ * @param {string} params.id            Stable lane identifier (projectDir + huId)
+ * @returns {Promise<{slot: number, reused: boolean}>}
+ */
+export async function acquireSlot({ registryPath, id }) {
+  return withFileLock(registryPath, () => {
+    const reg = loadRegistry(registryPath);
+    if (Number.isInteger(reg.slots[id])) return { slot: reg.slots[id], reused: true };
+    const used = new Set(Object.values(reg.slots));
+    let slot = 0;
+    while (used.has(slot)) slot += 1;
+    reg.slots[id] = slot;
+    saveRegistry(registryPath, reg);
+    return { slot, reused: false };
+  });
+}
+
+/**
+ * Free a lane's slot so the next lane can reuse the number.
+ * @returns {Promise<boolean>} true when the id held a slot.
+ */
+export async function releaseSlot({ registryPath, id }) {
+  return withFileLock(registryPath, () => {
+    const reg = loadRegistry(registryPath);
+    if (id in reg.slots) {
+      delete reg.slots[id];
+      saveRegistry(registryPath, reg);
+      return true;
+    }
+    return false;
+  });
+}

--- a/packages/core/tests/slot-registry.test.js
+++ b/packages/core/tests/slot-registry.test.js
@@ -1,0 +1,70 @@
+// PAR-H (KJC-TSK-0631): stable slots per lane, pure over a JSON file.
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireSlot, computePortOffset, releaseSlot } from "../src/slot-registry.js";
+
+const dirs = [];
+function registryPath() {
+  const dir = mkdtempSync(join(tmpdir(), "kj-slots-"));
+  dirs.push(dir);
+  return join(dir, "worktree-slots.json");
+}
+
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("slot-registry (PAR-H)", () => {
+  it("assigns the lowest free slot to new ids", async () => {
+    const reg = registryPath();
+    expect((await acquireSlot({ registryPath: reg, id: "A" })).slot).toBe(0);
+    expect((await acquireSlot({ registryPath: reg, id: "B" })).slot).toBe(1);
+    expect((await acquireSlot({ registryPath: reg, id: "C" })).slot).toBe(2);
+  });
+
+  it("the same id keeps its slot across acquisitions", async () => {
+    const reg = registryPath();
+    await acquireSlot({ registryPath: reg, id: "A" });
+    await acquireSlot({ registryPath: reg, id: "B" });
+    const again = await acquireSlot({ registryPath: reg, id: "A" });
+    expect(again).toEqual({ slot: 0, reused: true });
+  });
+
+  it("released slots are reassigned to the next new id", async () => {
+    const reg = registryPath();
+    await acquireSlot({ registryPath: reg, id: "A" });
+    await acquireSlot({ registryPath: reg, id: "B" });
+    expect(await releaseSlot({ registryPath: reg, id: "A" })).toBe(true);
+    expect((await acquireSlot({ registryPath: reg, id: "C" })).slot).toBe(0);
+  });
+
+  it("releasing an unknown id reports false", async () => {
+    const reg = registryPath();
+    expect(await releaseSlot({ registryPath: reg, id: "ghost" })).toBe(false);
+  });
+
+  it("computePortOffset scales by increment", () => {
+    expect(computePortOffset(0)).toBe(0);
+    expect(computePortOffset(3)).toBe(300);
+    expect(computePortOffset(2, 1000)).toBe(2000);
+  });
+
+  it("concurrent acquisitions never hand out duplicate slots", async () => {
+    const reg = registryPath();
+    const ids = Array.from({ length: 8 }, (_, i) => `lane-${i}`);
+    const results = await Promise.all(ids.map((id) => acquireSlot({ registryPath: reg, id })));
+    const slots = results.map((r) => r.slot).sort((a, b) => a - b);
+    expect(slots).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("a corrupt registry file resets cleanly instead of crashing", async () => {
+    const reg = registryPath();
+    const { writeFileSync, mkdirSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    mkdirSync(dirname(reg), { recursive: true });
+    writeFileSync(reg, "{not json");
+    expect((await acquireSlot({ registryPath: reg, id: "A" })).slot).toBe(0);
+  });
+});


### PR DESCRIPTION
## PAR-H PR1 — registro de slots estable por carril

Primera mitad de KJC-TSK-0631: módulo puro `karajan-core/slot-registry` — cada carril obtiene el slot numérico más bajo libre, estable por id entre runs (persistencia JSON fuera del repo), con lock atómico basado en mkdir (retry + robo de lock stale a 30s) para arranques concurrentes. `computePortOffset(slot, increment)` da el offset de puertos que el proyecto aplica sobre su base. Diseño tomado de la skill worktree-docker-envs de Jorge del Casar.

Tests (7): asignación de slot más bajo, reuso estable por id, liberación/reasignación, release de id desconocido, offsets, 8 adquisiciones concurrentes sin duplicados, y registro corrupto que resetea limpio.

PR2 cableará `KJ_LANE_SLOT`/`KJ_PORT_OFFSET` en el entorno del coder y de los acceptance tests del carril + docs de gotchas.