### PR TITLE
feat(hu): lane slot env vars for parallel services (KJC-TSK-0631)

### DIFF
--- a/docs/parallel-hus.md
+++ b/docs/parallel-hus.md
@@ -57,6 +57,30 @@ The launch gate (`parallel-limiter.js`) enforces:
 - **Semaphore**: at most `max_parallel_hus` lanes hold a slot at once.
 - **Cooldown**: provider rate-limit signals pause new launches monotonically.
 
+## Services per lane (ports, docker)
+
+Each parallel lane gets a stable numeric slot (KJC-TSK-0631, registry at
+`~/.karajan/worktree-slots.json`, released when the lane finishes). The
+coder subprocess and the acceptance tests receive:
+
+- `KJ_LANE_SLOT` — the lane's slot number (0, 1, …)
+- `KJ_PORT_OFFSET` — `slot × 100`; apply it over your project's base port
+  (e.g. `PORT=$((3000 + KJ_PORT_OFFSET))`)
+
+Gotchas when your tests start real services (credit: Jorge del Casar's
+worktree-docker-envs skill):
+
+- **Dev-server client port**: Vite/webpack HMR announces the container's
+  INTERNAL port to the browser. Pass the offset host port explicitly as an
+  `environment:` variable and use it to override the dev server's client
+  port — variables used only in `ports:` interpolation never reach the
+  process inside the container.
+- **Docker namespacing**: `docker compose -p "lane-$KJ_LANE_SLOT"` already
+  namespaces containers/networks/volumes — no per-service renaming needed.
+- **One-shot jobs vs `--wait`**: `docker compose up --wait` treats
+  successfully-exited one-shot jobs (migrations, seeders) as failures.
+  Use `up -d` plus polling the main service's healthcheck instead.
+
 ## Known limits
 
 - `session` disk saves share one session id across lanes (last writer wins);

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -300,7 +300,10 @@ export function createStreamJsonFilter(onOutput) {
  */
 function cleanExecaOpts(extra = {}) {
   const { CLAUDECODE: _CLAUDECODE, ...env } = process.env;
-  return { env, stdin: "ignore", ...extra };
+  // PAR-H (KJC-TSK-0631): extra.env ADDS to the inherited env (lane slot
+  // vars) instead of replacing it wholesale.
+  const { env: extraEnv, ...rest } = extra;
+  return { env: extraEnv ? { ...env, ...extraEnv } : env, stdin: "ignore", ...rest };
 }
 
 /**
@@ -370,7 +373,8 @@ export class ClaudeAgent extends BaseAgent {
       const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({
         onOutput: streamFilter,
         silenceTimeoutMs: task.silenceTimeoutMs,
-        timeout: task.timeoutMs
+        timeout: task.timeoutMs,
+        env: task.env
       }));
       const raw = pickOutput(res);
       const output = extractTextFromStreamJson(raw);
@@ -380,7 +384,7 @@ export class ClaudeAgent extends BaseAgent {
 
     // Without streaming, use json output to get structured response via stderr
     args.push("--output-format", "json");
-    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts());
+    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({ env: task.env }));
     const raw = pickOutput(res);
     const output = extractTextFromStreamJson(raw);
     const usage = extractUsageFromStreamJson(raw);
@@ -393,7 +397,8 @@ export class ClaudeAgent extends BaseAgent {
     const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
-      timeout: task.timeoutMs
+      timeout: task.timeoutMs,
+      env: task.env
     }));
     const raw = pickOutput(res);
     const usage = extractUsageFromStreamJson(raw);

--- a/src/hu/acceptance-runner.js
+++ b/src/hu/acceptance-runner.js
@@ -12,11 +12,15 @@ import { runCommand } from "../utils/process.js";
  * @param {number} [timeoutMs=30000] - Timeout per test
  * @returns {Promise<{cmd: string, passed: boolean, output: string, exitCode: number}>}
  */
-async function runSingleTest(cmd, cwd, timeoutMs = 30000) {
+async function runSingleTest(cmd, cwd, timeoutMs = 30000, env = null) {
   try {
     const result = await runCommand("bash", ["-c", cmd], {
       timeout: timeoutMs,
-      cwd
+      cwd,
+      // PAR-H (KJC-TSK-0631): lane env (KJ_LANE_SLOT / KJ_PORT_OFFSET) so
+      // tests that start services can offset their ports. execa merges
+      // this on top of process.env.
+      ...(env ? { env } : {})
     });
     const output = (result.stdout || "") + (result.stderr || "");
     return {
@@ -51,7 +55,7 @@ async function runSingleTest(cmd, cwd, timeoutMs = 30000) {
  * @param {string} cwd - Working directory
  * @returns {Promise<{allPassed: boolean, results: object[], summary: string, diagnostics: string|null, pending: number}>}
  */
-export async function runAcceptanceTests(tests, cwd) {
+export async function runAcceptanceTests(tests, cwd, { env = null } = {}) {
   if (!tests || tests.length === 0) {
     return { allPassed: false, results: [], summary: "No acceptance tests defined", diagnostics: null, pending: 0 };
   }
@@ -86,7 +90,7 @@ export async function runAcceptanceTests(tests, cwd) {
       });
       continue;
     }
-    const result = await runSingleTest(cmd, cwd);
+    const result = await runSingleTest(cmd, cwd, 30000, env);
     results.push({ ...result, type: "shell" });
   }
 

--- a/src/orchestrator/drivers/run-hu-batch.js
+++ b/src/orchestrator/drivers/run-hu-batch.js
@@ -104,7 +104,13 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
       // left it clamped to hu_max_iterations for the rest of the run.
       const worktreePath = laneOpts?.worktreePath || null;
       const projectDir = worktreePath || ctx.config.projectDir || process.cwd();
-      const laneConfig = { ...ctx.config, projectDir, max_iterations: huMaxIterations };
+      // PAR-H (KJC-TSK-0631): the lane's slot travels as env vars so any
+      // service the coder or the acceptance tests start can offset its
+      // ports (offset = slot × 100; the project applies its own base).
+      const laneEnv = Number.isInteger(laneOpts?.laneSlot)
+        ? { KJ_LANE_SLOT: String(laneOpts.laneSlot), KJ_PORT_OFFSET: String(laneOpts.laneSlot * 100) }
+        : null;
+      const laneConfig = { ...ctx.config, projectDir, max_iterations: huMaxIterations, lane_env: laneEnv };
       if (!huPolicies.tdd) laneConfig.development = { ...laneConfig.development, methodology: "standard", require_test_changes: false };
       if (!huPolicies.sonar) laneConfig.sonarqube = { ...laneConfig.sonarqube, enabled: false };
       const laneFlags = { ...ctx.pipelineFlags };
@@ -233,7 +239,7 @@ export async function runHuBatch({ ctx, task, askQuestion, emitter, logger }) {
             detail: { huId: story.id, testCount: story.acceptance_tests.length }
           }));
 
-          const testResult = await runAcceptanceTests(story.acceptance_tests, projectDir);
+          const testResult = await runAcceptanceTests(story.acceptance_tests, projectDir, { env: laneEnv });
           emitProgress(emitter, makeEvent("hu:acceptance-end", { ...ctx.eventBase, stage: "acceptance" }, {
             status: testResult.allPassed ? "ok" : "fail",
             message: testResult.summary,

--- a/src/orchestrator/hu-sub-pipeline.js
+++ b/src/orchestrator/hu-sub-pipeline.js
@@ -6,6 +6,9 @@ import { topologicalSort } from "../hu/graph.js";
 import { updateStoryStatus, loadHuBatch, saveHuBatch, HU_STATUS } from "../hu/store.js";
 import { emitProgress, makeEvent } from "../utils/events.js";
 import { refineHuWithContext } from "../hu/lazy-planner.js";
+import { join } from "node:path";
+import { acquireSlot, releaseSlot } from "karajan-core/slot-registry";
+import { getKarajanHome } from "karajan-core/paths";
 import { findParallelGroups, createWorktree, mergeWorktree, removeWorktree } from "../hu/parallel-executor.js";
 import { bootstrapWorktree } from "../hu/worktree-bootstrap.js";
 import { partitionConflictFree } from "./hu-scheduler.js";
@@ -201,7 +204,7 @@ function buildHuOutcome({ story: _story, iterResult, status, startedAt, huBudget
  * @param {object} params
  * @returns {Promise<{huId: string, approved: boolean, result?: object, error?: string, blockedDependents?: string[]}>}
  */
-async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, onStatusChange = null, onOutcome = null, budgetTracker = null }) {
+async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emitter, eventBase, logger, config, results, worktreePath, laneSlot = null, onStatusChange = null, onOutcome = null, budgetTracker = null }) {
   // PR1 (live HU status): every saveHuBatch should also notify the
   // plan JSON so the board reflects state in real time. Defined as a
   // local helper so we don't repeat the try/null-check boilerplate.
@@ -288,7 +291,7 @@ async function runSingleHu({ storyId, batch, batchSessionId, runIterationFn, emi
   try {
     // PAR-E2 (KJC-TSK-0629): lanes handed a worktree must aim every git and
     // filesystem touchpoint at it — laneOpts carries that path to the runner.
-    const iterResult = await runIterationFn(huTask, story, { worktreePath: worktreePath || null });
+    const iterResult = await runIterationFn(huTask, story, { worktreePath: worktreePath || null, laneSlot });
     const approved = Boolean(iterResult?.approved);
 
     // --- Transition to reviewing (post-coder, pre-reviewer evaluation) ---
@@ -528,6 +531,11 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
       // Multiple HUs: create worktrees, run in parallel
       const projectDir = config?.projectDir || process.cwd();
       const worktrees = new Map();
+      // PAR-H (KJC-TSK-0631): every lane gets a stable numeric slot so
+      // services it starts can offset their ports (KJ_LANE_SLOT /
+      // KJ_PORT_OFFSET reach the coder and the acceptance tests).
+      const slotRegistryPath = join(getKarajanHome(), "worktree-slots.json");
+      const laneSlots = new Map();
 
       // Create worktrees for each HU in the batch
       for (const id of runnableIds) {
@@ -538,6 +546,12 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
           // no initialized submodules — make the lane operative before the
           // coder lands. Best-effort: warnings never block the lane.
           await bootstrapWorktree({ worktreePath: wtPath, setupCommand: config?.session?.worktree_setup || null, logger });
+          try {
+            const { slot } = await acquireSlot({ registryPath: slotRegistryPath, id: `${projectDir}::${id}` });
+            laneSlots.set(id, slot);
+          } catch (err) {
+            logger.warn(`Failed to acquire lane slot for HU ${id}: ${err.message} — lane runs without port offset`);
+          }
         } catch (err) {
           logger.warn(`Failed to create worktree for HU ${id}: ${err.message} — will run sequentially`);
         }
@@ -552,6 +566,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
             storyId, batch, batchSessionId, runIterationFn,
             emitter, eventBase, logger, config, results,
             worktreePath: worktrees.get(storyId),
+            laneSlot: laneSlots.get(storyId) ?? null,
             onStatusChange, onOutcome, budgetTracker
           });
         } finally {
@@ -567,6 +582,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
         if (res.approved && worktrees.has(res.huId)) {
           try {
             await mergeWorktree(projectDir, res.huId);
+            await releaseSlot({ registryPath: slotRegistryPath, id: `${projectDir}::${res.huId}` }).catch(() => {});
           } catch (err) {
             logger.warn(`Failed to merge worktree for HU ${res.huId}: ${err.message}`);
           }
@@ -586,6 +602,7 @@ export async function runHuSubPipeline({ huReviewerResult, runIterationFn, emitt
           // Clean up failed worktree
           if (worktrees.has(res.huId)) {
             try { await removeWorktree(projectDir, res.huId); } catch { /* ignore */ }
+            await releaseSlot({ registryPath: slotRegistryPath, id: `${projectDir}::${res.huId}` }).catch(() => {});
           }
         }
       }

--- a/src/orchestrator/stages/coder-stage.js
+++ b/src/orchestrator/stages/coder-stage.js
@@ -71,6 +71,9 @@ export async function runCoderStage({ coderRoleInstance, coderRole, config, logg
       // PAR-E2 (KJC-TSK-0629): the stage's config wins over the role's own —
       // worktree lanes pass a laneConfig whose projectDir is the worktree.
       projectDir: config?.projectDir || null,
+      // PAR-H (KJC-TSK-0631): lane env (KJ_LANE_SLOT / KJ_PORT_OFFSET)
+      // reaches the coder subprocess so services it starts don't collide.
+      env: config?.lane_env || null,
       onOutput: coderStall.onOutput,
       // Lets Brain Recovery persist a standby snapshot if the coder's
       // provider hits a quota cap mid-run (KJC hibernation wiring).

--- a/src/roles/agent-role.js
+++ b/src/roles/agent-role.js
@@ -129,6 +129,10 @@ export class AgentRole extends BaseRole {
 
     const runArgs = { prompt, role: this.name };
     if (onOutput) runArgs.onOutput = onOutput;
+    // PAR-H (KJC-TSK-0631): per-call env additions for the agent
+    // subprocess (lane slot vars). Agents that ignore task.env simply
+    // run without them.
+    if (extracted.env) runArgs.env = extracted.env;
     // Φ1-D (KJC-PCS-0057): roles that build their prompt as a
     // stable/volatile layout forward both buckets so cache-aware agents
     // (ClaudeAgent) can ship the stable block as system prompt. Agents

--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -56,6 +56,8 @@ export class CoderRole extends AgentRole {
       // PAR-E2 (KJC-TSK-0629): per-call project root. Worktree lanes pass
       // their lane dir here; the shared role instance keeps its own config.
       projectDir: input?.projectDir || null,
+      // PAR-H (KJC-TSK-0631): per-call subprocess env (lane slot vars).
+      env: input?.env || null,
       onOutput: input?.onOutput || null
     };
   }

--- a/tests/acceptance-runner-env.test.js
+++ b/tests/acceptance-runner-env.test.js
@@ -1,0 +1,24 @@
+// PAR-H (KJC-TSK-0631): lane env vars reach the acceptance-test subprocesses.
+import { describe, expect, it, vi } from "vitest";
+
+const runCommandMock = vi.fn(async () => ({ exitCode: 0, stdout: "ok", stderr: "" }));
+vi.mock("../src/utils/process.js", () => ({ runCommand: (...args) => runCommandMock(...args) }));
+
+const { runAcceptanceTests } = await import("../src/hu/acceptance-runner.js");
+
+describe("runAcceptanceTests lane env (PAR-H)", () => {
+  it("forwards env to the shell subprocess", async () => {
+    await runAcceptanceTests(["echo hi"], "/proj", { env: { KJ_LANE_SLOT: "2", KJ_PORT_OFFSET: "200" } });
+    expect(runCommandMock).toHaveBeenCalledWith("bash", ["-c", "echo hi"], expect.objectContaining({
+      cwd: "/proj",
+      env: { KJ_LANE_SLOT: "2", KJ_PORT_OFFSET: "200" }
+    }));
+  });
+
+  it("omits env entirely when no lane env is given (legacy behavior)", async () => {
+    runCommandMock.mockClear();
+    await runAcceptanceTests(["echo hi"], "/proj");
+    const opts = runCommandMock.mock.calls[0][2];
+    expect("env" in opts).toBe(false);
+  });
+});

--- a/tests/hu-lane-state.test.js
+++ b/tests/hu-lane-state.test.js
@@ -15,7 +15,7 @@ vi.mock("../src/orchestrator/hu-sub-pipeline.js", () => ({
       id: "HU-1", task_type: "sw", status: "certified",
       certified: { title: "T" }, acceptance_tests: ["test -f x"]
     };
-    const res = await runIterationFn("do x", story, { worktreePath: "/proj/.kj/worktrees/HU-1" });
+    const res = await runIterationFn("do x", story, { worktreePath: "/proj/.kj/worktrees/HU-1", laneSlot: 3 });
     return { approved: res.approved, results: [res], blockedIds: [] };
   })
 }));
@@ -85,6 +85,8 @@ describe("HU lane state isolation (PAR-E2 PR2)", () => {
     expect(coderArgs.config.projectDir).toBe("/proj/.kj/worktrees/HU-1");
     expect(coderArgs.config.max_iterations).toBe(3);
     expect(coderArgs.config.sonarqube.enabled).toBe(false);
+    // PAR-H: the lane's slot travels to the coder as env vars
+    expect(coderArgs.config.lane_env).toEqual({ KJ_LANE_SLOT: "3", KJ_PORT_OFFSET: "300" });
     expect(coderArgs.session).not.toBe(ctx.session);
     expect(coderArgs.session.id).toBe("s_1");
 

--- a/tests/parallel-hu.test.js
+++ b/tests/parallel-hu.test.js
@@ -320,9 +320,10 @@ describe("parallel HU execution in sub-pipeline", () => {
     expect(parallelEvents).toHaveLength(2);
     expect(parallelEvents.every(e => e.detail.parallel === false)).toBe(true);
 
-    // PAR-E2: sequential lanes carry no worktree — main-tree behavior intact
+    // PAR-E2/PAR-H: sequential lanes carry no worktree and no slot —
+    // main-tree behavior intact
     for (const call of runIterationFn.mock.calls) {
-      expect(call[2]).toEqual({ worktreePath: null });
+      expect(call[2]).toEqual({ worktreePath: null, laneSlot: null });
     }
   });
 
@@ -355,6 +356,10 @@ describe("parallel HU execution in sub-pipeline", () => {
       "/project/.kj/worktrees/HU-001",
       "/project/.kj/worktrees/HU-002"
     ]);
+
+    // PAR-H: each lane gets a distinct numeric slot for port offsets
+    const laneSlots = runIterationFn.mock.calls.map(call => call[2]?.laneSlot).sort();
+    expect(laneSlots).toEqual([0, 1]);
   });
 
   it("diamond dependency produces correct parallel batches", async () => {


### PR DESCRIPTION
## PAR-H PR2 — KJ_LANE_SLOT / KJ_PORT_OFFSET en el entorno del carril

Cierra KJC-TSK-0631 (sobre el slot registry de #1204). Cada carril worktree adquiere su slot (`~/.karajan/worktree-slots.json`, id = projectDir::huId) tras crear el worktree y lo libera en el cleanup post-batch (merge y fallo). El slot viaja como `KJ_LANE_SLOT` y `KJ_PORT_OFFSET` (slot×100) al entorno de:

- los **acceptance tests** (`runAcceptanceTests` gana opción `env`, mergeada sobre process.env por execa), y
- el **subproceso del coder** (`task.env` enhebrado por coder-stage → CoderRole → AgentRole → ClaudeAgent, cuyo `cleanExecaOpts` ahora AÑADE en vez de reemplazar el env). Agentes que ignoran `task.env` simplemente corren sin las variables.

Secuencial (sin worktree): `laneSlot` null ⇒ sin env inyectado, comportamiento intacto.

Docs: sección "Services per lane" con los gotchas de la skill worktree-docker-envs de Jorge del Casar (client port del dev server, `docker compose -p`, `up -d` + polling vs `--wait`).

Tests: passthrough de env en el runner (y ausencia total sin lane env), `lane_env` llegando al coder con slot 3 → offset 300, slots [0,1] asignados en el batch paralelo real, secuencial sin slot. Suite completa 6066/6066.