### PR TITLE
chore(core): karajan-core 1.2.0 ships slot-registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8092,7 +8092,7 @@
     },
     "packages/core": {
       "name": "karajan-core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "vitest": "^4.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
   "license": "AGPL-3.0",

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -166,7 +166,11 @@ try {
     console.log(`verify-pack: installing the tarball with pnpm into ${pnpmTmp}…`);
     // pnpm exits non-zero on ERR_PNPM_IGNORED_BUILDS (it skips native build
     // scripts by default) — expected here, so don't treat the exit as failure.
-    spawnSync("pnpm", ["add", tgzPath, "--store-dir", path.join(pnpmTmp, ".store")], {
+    // minimum-release-age=0: modern pnpm quarantines freshly published
+    // versions (supply-chain protection), so right after publishing
+    // karajan-core it silently resolves an OLD one and this smoke fails on
+    // missing subpaths. The gate verifies packaging, not release-age policy.
+    spawnSync("pnpm", ["add", tgzPath, "--store-dir", path.join(pnpmTmp, ".store"), "--config.minimum-release-age=0"], {
       encoding: "utf8",
       env: childEnv,
       cwd: pnpmTmp,


### PR DESCRIPTION
Fix-forward del gate rojo "Tarball installs & runs clean" en #1205: `hu-sub-pipeline` importa `karajan-core/slot-registry`, pero el karajan-core@1.1.0 del registry no lo lleva (solo existía en el workspace) — `ERR_PACKAGE_PATH_NOT_EXPORTED` al instalar el tarball. Misma clase que KJC-BUG-0082; error de secuencia: el core debía publicarse ANTES de mergear al consumidor.

Este PR sube el workspace a 1.2.0; la publicación en npm (que es lo que pone verde el gate) va justo después — el rango `^1.0.0` de karajan-code la recoge sola. Nota: el check de tarball de ESTE PR seguirá rojo hasta que 1.2.0 esté en el registry; se re-ejecuta tras publicar.