### PR TITLE
docs: readme section for step mode and parallel lanes + unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Lane worktree bootstrap** (KJC-TSK-0630): each fresh parallel-lane worktree is made operative before the coder lands — submodules initialized, then `session.worktree_setup` (or `npm ci` when a lockfile exists). Best-effort: failures warn and the lane continues.
+- **Per-lane slots and port offsets** (KJC-TSK-0631): every parallel lane acquires a stable numeric slot (`karajan-core/slot-registry`, file-locked, released on cleanup) and its coder + acceptance tests receive `KJ_LANE_SLOT` / `KJ_PORT_OFFSET` so services they start don't collide. Requires `karajan-core >= 1.2.0`.
+
+### Fixed
+
+- **verify-pack pnpm smoke vs release-age quarantine**: modern pnpm silently resolves freshly published dependencies to OLD versions (`minimumReleaseAge` supply-chain protection), failing the tarball gate right after a `karajan-core` publish. The smoke now passes `--config.minimum-release-age=0` — it verifies packaging, not release-age policy.
+
 ## [3.14.1] - 2026-07-17
 
 Patch. **`--parallel` now actually parallelizes — inside real worktree lanes.** The 3.14.0 flag silently degraded to sequential, and lanes shared the main working tree. Everything here came out of a real end-to-end run of the feature (live coder, 4-HU plan, `--parallel 2`).

--- a/README.md
+++ b/README.md
@@ -383,6 +383,16 @@ Each AI role is executed by the agent you choose:
 >
 > Full per-stage reference: [Pipeline roles](https://karajan-code.web.app/docs/handbook/pipeline-roles/) (handbook).
 
+## Step mode and parallel lanes (v3.14+)
+
+Two ways to control how a plan executes:
+
+**`kj run --step`** — supervise the orchestra iteration by iteration. After every iteration the pipeline pauses with a compact report (what happened, the reviewer's must-fix list, what the next iteration will do, spend vs cap) and asks: press Enter to continue, type `stop` to halt (resumable with `kj resume`), or **type instructions** — free text is injected into the feedback the coder reads next iteration, without clobbering the reviewer's own findings. Also offered as a question in the `kj init` wizard (`session.iteration_gate`).
+
+**`kj run --plan <id> --parallel <n>`** — run a plan's independent HUs concurrently, each in its own **git worktree** under `.kj/worktrees/<huId>` on branch `kj-hu-<huId>`. The scheduler walks the `blocked_by` graph and only pairs HUs with disjoint `scope` paths (scopeless HUs run alone); the whole lane — coder, acceptance tests, diffs, sonar, final commit — runs inside its worktree while the main working tree stays parked. Governance is built in: default is `1` (fully sequential), a plan-level budget ceiling (`n × max_budget_usd`) stops the batch loudly when exhausted, and SonarQube serializes across lanes. Each fresh worktree is bootstrapped automatically (submodules + `npm ci`, or your `session.worktree_setup` command) and receives `KJ_LANE_SLOT` / `KJ_PORT_OFFSET` env vars so services started by tests don't collide on ports.
+
+Full guide: [`docs/parallel-hus.md`](docs/parallel-hus.md).
+
 ## 5 AI agents supported
 
 | Agent | CLI | Install |


### PR DESCRIPTION
Gap de doc detectado en auditoría: el README no mencionaba `--step` ni `--parallel` (la feature estrella de la 3.14) y el CHANGELOG [Unreleased] no recogía PAR-G (bootstrap de worktree), PAR-H (slots/env por carril) ni el fix del smoke pnpm de verify-pack. Solo docs — excluido del LOC gate.