### PR TITLE
refactor(hu-board): standby route resolves karajan-core directly (KJC-TSK-0632)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -76,7 +76,9 @@ router.get('/version', (_req, res) => {
  */
 router.get('/standby', async (_req, res) => {
   try {
-    const { listPendingStandby } = await import('../../../../src/brain/standby-store.js');
+    // KJC-TSK-0632: resolve from karajan-core directly — the CLI's
+    // src/brain/standby-store.js is just a re-export shim of this.
+    const { listPendingStandby } = await import('karajan-core/standby-store');
     const sessions = listPendingStandby();
     res.set('Cache-Control', 'no-store');
     res.json({ sessions });


### PR DESCRIPTION
PR1 del desacople de hu-board (KJC-TSK-0632): el endpoint /api/standby importaba src/brain/standby-store.js del CLI, que es un shim re-export de karajan-core/standby-store desde KJC-TSK-0511 PR8 — ahora resuelve el paquete directamente. Quedan 2 imports relativos (rag), que van en PR2-PR5. Suite del board 427/427.