### PR TITLE
refactor(hu-board): zero cli imports — rag resolves karajan-core (KJC-TSK-0632)

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1364,8 +1364,10 @@ router.post('/rag/query', async (req, res) => {
   }
   try {
     const { openVecStore, countChunks } = await import('karajan-core/vec-store');
-    const { makeEmbedder } = await import('../../../../src/rag/embedders/factory.js');
-    const { query } = await import('../../../../src/rag/retriever.js');
+    // KJC-TSK-0632: resolved from karajan-core — the board carries zero
+    // relative imports into the CLI src tree (see no-cli-imports test).
+    const { makeEmbedder } = await import('karajan-core/rag/embedders/factory');
+    const { query } = await import('karajan-core/rag/retriever');
     const db = openVecStore({ dim: 768 });
     try {
       if (countChunks(db) === 0) return res.json({ hits: [], empty: true, topK, scope });

--- a/packages/hu-board/tests/no-cli-imports.test.js
+++ b/packages/hu-board/tests/no-cli-imports.test.js
@@ -1,0 +1,27 @@
+// KJC-TSK-0632: @karajan/hu-board is decoupled from the CLI src tree —
+// everything it shares with kj resolves through the karajan-core package.
+// A relative import climbing into <repo>/src reintroduces the coupling
+// this epic removed, so this test rejects it.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+const CLI_IMPORT = /import\s*\(?\s*['"](?:\.\.\/)+src\//;
+
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+describe("hu-board decoupling (KJC-TSK-0632)", () => {
+  it("no source file imports the CLI src tree", () => {
+    const offenders = walk(SRC).filter((f) => CLI_IMPORT.test(readFileSync(f, "utf8")));
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
PR5 y último del desacople de hu-board: los 2 imports rag de routes/api.js resuelven `karajan-core/rag/*` (registry ya en 1.3.0 desde #1209), con lo que **el board deja de tener imports relativos hacia el src del CLI** — cero acoplamiento.

Anti-regresión: test nuevo `no-cli-imports.test.js` que escanea packages/hu-board/src y rechaza cualquier import que trepe a `<repo>/src`.

Suite del board 428/428 (incluye el test nuevo). Cierra el pendiente de la extracción karajan-core (KJC-TSK-0511) y la card KJC-TSK-0632.