### PR TITLE
feat(agents): kimi and deepseek in the model registry with pricing (KJC-TSK-0633)

### DIFF
--- a/docs/providers-via-opencode.md
+++ b/docs/providers-via-opencode.md
@@ -1,0 +1,74 @@
+# Extra providers via OpenCode (Kimi, DeepSeek, local models…)
+
+Karajan does not need a plugin system for new model providers: **OpenCode is
+the gateway**. Any OpenAI-compatible API becomes a kj coder/reviewer by
+declaring it in `~/.config/opencode/opencode.json` — the same pattern used
+for local models behind a LiteLLM proxy. Cost tracking works out of the box
+for the ids registered in kj's model registry (KJC-TSK-0633: Kimi K2 and
+DeepSeek families).
+
+## 1. Declare the providers
+
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "provider": {
+    "kimi": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "https://api.moonshot.ai/v1",
+        "apiKey": "{env:MOONSHOT_API_KEY}"
+      },
+      "models": {
+        "kimi-k2": {},
+        "kimi-k2-thinking": {}
+      }
+    },
+    "deepseek": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "https://api.deepseek.com",
+        "apiKey": "{env:DEEPSEEK_API_KEY}"
+      },
+      "models": {
+        "deepseek-chat": {},
+        "deepseek-reasoner": {}
+      }
+    }
+  }
+}
+```
+
+Export the keys in your shell profile (`MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`).
+Verify the exact model ids against each provider's catalog — they move fast;
+the ones above are the registered defaults.
+
+## 2. Use them in kj
+
+```bash
+# Kimi as coder
+kj run --coder opencode --coder-model kimi/kimi-k2 "implement the parser"
+
+# DeepSeek as a cheap reviewer while Claude codes
+kj run --reviewer opencode --reviewer-model deepseek/deepseek-chat "fix the race"
+
+# Persistent, in .karajan/kj.config.yml:
+#   roles:
+#     reviewer: { provider: opencode, model: deepseek/deepseek-chat }
+```
+
+## Cost tracking
+
+`kimi-k2`, `kimi-k2-thinking`, `deepseek-chat` and `deepseek-reasoner` (plus
+the `kimi/…` and `deepseek/…` prefixed forms this doc produces) are registered
+with real pricing, so the per-HU $ badge and `max_budget_usd` enforcement work.
+Prices are a static snapshot — check the provider pricing pages linked in
+`src/agents/model-registry.js` before relying on them for billing decisions.
+
+## When would a first-class agent make sense?
+
+Only if a provider ships a mature agent CLI worth wrapping (the PR #75
+OpenCode pattern). Moonshot's `kimi-cli` is a candidate to evaluate;
+DeepSeek has no official agent CLI, so OpenCode/aider remains its natural
+route.

--- a/packages/core/src/pricing/model-pricing.json
+++ b/packages/core/src/pricing/model-pricing.json
@@ -6,23 +6,105 @@
     "sources": {
       "anthropic": "https://www.anthropic.com/pricing",
       "openai": "https://openai.com/api/pricing/",
-      "google": "https://ai.google.dev/pricing"
+      "google": "https://ai.google.dev/pricing",
+      "moonshot": "https://platform.moonshot.ai/docs/pricing",
+      "deepseek": "https://api-docs.deepseek.com/quick_start/pricing"
     },
     "notes": "Static registry. Cache-write/cache-read tiers ignored on purpose: aggregator uses input/output averages. Unknown models return null so the pipeline does not break."
   },
-  "claude-opus-4-7": { "inputPerMTok": 15.00, "outputPerMTok": 75.00, "source": "anthropic" },
-  "claude-opus-4-6": { "inputPerMTok": 15.00, "outputPerMTok": 75.00, "source": "anthropic" },
-  "claude-sonnet-4-6": { "inputPerMTok": 3.00, "outputPerMTok": 15.00, "source": "anthropic" },
-  "claude-haiku-4-5": { "inputPerMTok": 1.00, "outputPerMTok": 5.00, "source": "anthropic" },
-  "claude-haiku-4-5-20251001": { "inputPerMTok": 1.00, "outputPerMTok": 5.00, "source": "anthropic" },
-  "gpt-4o": { "inputPerMTok": 2.50, "outputPerMTok": 10.00, "source": "openai" },
-  "gpt-4o-mini": { "inputPerMTok": 0.15, "outputPerMTok": 0.60, "source": "openai" },
-  "gpt-4.1": { "inputPerMTok": 2.00, "outputPerMTok": 8.00, "source": "openai" },
-  "gpt-4.1-mini": { "inputPerMTok": 0.40, "outputPerMTok": 1.60, "source": "openai" },
-  "o1": { "inputPerMTok": 15.00, "outputPerMTok": 60.00, "source": "openai" },
-  "o1-mini": { "inputPerMTok": 1.10, "outputPerMTok": 4.40, "source": "openai" },
-  "o3-mini": { "inputPerMTok": 1.10, "outputPerMTok": 4.40, "source": "openai" },
-  "gemini-1.5-pro": { "inputPerMTok": 1.25, "outputPerMTok": 5.00, "source": "google" },
-  "gemini-1.5-flash": { "inputPerMTok": 0.075, "outputPerMTok": 0.30, "source": "google" },
-  "gemini-2.0-flash": { "inputPerMTok": 0.10, "outputPerMTok": 0.40, "source": "google" }
+  "claude-opus-4-7": {
+    "inputPerMTok": 15.0,
+    "outputPerMTok": 75.0,
+    "source": "anthropic"
+  },
+  "claude-opus-4-6": {
+    "inputPerMTok": 15.0,
+    "outputPerMTok": 75.0,
+    "source": "anthropic"
+  },
+  "claude-sonnet-4-6": {
+    "inputPerMTok": 3.0,
+    "outputPerMTok": 15.0,
+    "source": "anthropic"
+  },
+  "claude-haiku-4-5": {
+    "inputPerMTok": 1.0,
+    "outputPerMTok": 5.0,
+    "source": "anthropic"
+  },
+  "claude-haiku-4-5-20251001": {
+    "inputPerMTok": 1.0,
+    "outputPerMTok": 5.0,
+    "source": "anthropic"
+  },
+  "gpt-4o": {
+    "inputPerMTok": 2.5,
+    "outputPerMTok": 10.0,
+    "source": "openai"
+  },
+  "gpt-4o-mini": {
+    "inputPerMTok": 0.15,
+    "outputPerMTok": 0.6,
+    "source": "openai"
+  },
+  "gpt-4.1": {
+    "inputPerMTok": 2.0,
+    "outputPerMTok": 8.0,
+    "source": "openai"
+  },
+  "gpt-4.1-mini": {
+    "inputPerMTok": 0.4,
+    "outputPerMTok": 1.6,
+    "source": "openai"
+  },
+  "o1": {
+    "inputPerMTok": 15.0,
+    "outputPerMTok": 60.0,
+    "source": "openai"
+  },
+  "o1-mini": {
+    "inputPerMTok": 1.1,
+    "outputPerMTok": 4.4,
+    "source": "openai"
+  },
+  "o3-mini": {
+    "inputPerMTok": 1.1,
+    "outputPerMTok": 4.4,
+    "source": "openai"
+  },
+  "gemini-1.5-pro": {
+    "inputPerMTok": 1.25,
+    "outputPerMTok": 5.0,
+    "source": "google"
+  },
+  "gemini-1.5-flash": {
+    "inputPerMTok": 0.075,
+    "outputPerMTok": 0.3,
+    "source": "google"
+  },
+  "gemini-2.0-flash": {
+    "inputPerMTok": 0.1,
+    "outputPerMTok": 0.4,
+    "source": "google"
+  },
+  "kimi-k2": {
+    "inputPerMTok": 0.6,
+    "outputPerMTok": 2.5,
+    "source": "moonshot"
+  },
+  "kimi-k2-thinking": {
+    "inputPerMTok": 0.6,
+    "outputPerMTok": 2.5,
+    "source": "moonshot"
+  },
+  "deepseek-chat": {
+    "inputPerMTok": 0.28,
+    "outputPerMTok": 0.42,
+    "source": "deepseek"
+  },
+  "deepseek-reasoner": {
+    "inputPerMTok": 0.28,
+    "outputPerMTok": 0.42,
+    "source": "deepseek"
+  }
 }

--- a/src/agents/model-registry.js
+++ b/src/agents/model-registry.js
@@ -108,6 +108,29 @@ registerModelAlias("gemini", "gemini-2.5-pro");
 registerModel("aider", { provider: "aider", pricing: { input_per_million: 3, output_per_million: 15 } });
 registerModel("opencode", { provider: "opencode", pricing: { input_per_million: 0, output_per_million: 0 } });
 
+/**
+ * Moonshot Kimi Family (KJC-TSK-0633) — consumed through OpenCode as an
+ * OpenAI-compatible provider (docs/providers-via-opencode.md).
+ * Pricing: https://platform.moonshot.ai/docs/pricing — verify before
+ * trusting for billing decisions; ids/prices move fast.
+ */
+registerModel("kimi-k2", { provider: "moonshot", pricing: { input_per_million: 0.6, output_per_million: 2.5 } });
+registerModel("kimi-k2-thinking", { provider: "moonshot", pricing: { input_per_million: 0.6, output_per_million: 2.5 } });
+registerModelAlias("kimi", "kimi-k2");
+// Prefixed ids as the documented opencode.json snippet produces them.
+registerModelAlias("kimi/kimi-k2", "kimi-k2");
+registerModelAlias("kimi/kimi-k2-thinking", "kimi-k2-thinking");
+
+/**
+ * DeepSeek Family (KJC-TSK-0633) — same OpenCode route.
+ * Pricing: https://api-docs.deepseek.com/quick_start/pricing
+ */
+registerModel("deepseek-chat", { provider: "deepseek", pricing: { input_per_million: 0.28, output_per_million: 0.42 } });
+registerModel("deepseek-reasoner", { provider: "deepseek", pricing: { input_per_million: 0.28, output_per_million: 0.42 } });
+registerModelAlias("deepseek", "deepseek-chat");
+registerModelAlias("deepseek/deepseek-chat", "deepseek-chat");
+registerModelAlias("deepseek/deepseek-reasoner", "deepseek-reasoner");
+
 // Common CLI Aliases (with provider overrides)
 registerModelAlias("aider/claude-3-7-sonnet", "claude-sonnet-4.6", { provider: "aider" });
 registerModelAlias("aider/gpt-4o", "gpt-5.4-standard", { provider: "aider" });

--- a/tests/agents/model-registry.test.js
+++ b/tests/agents/model-registry.test.js
@@ -144,3 +144,20 @@ describe("model-registry", () => {
     });
   });
 });
+
+// KJC-TSK-0633: Kimi and DeepSeek ship registered with real pricing so
+// BudgetTracker never sees null for them — including the prefixed ids the
+// documented opencode.json snippet produces.
+describe("kimi + deepseek providers (KJC-TSK-0633)", () => {
+  it.each(["kimi-k2", "kimi", "kimi/kimi-k2", "kimi/kimi-k2-thinking"])("%s has moonshot pricing", (id) => {
+    const p = getModelPricing(id);
+    expect(p).not.toBeNull();
+    expect(p.output_per_million).toBeGreaterThan(0);
+  });
+
+  it.each(["deepseek-chat", "deepseek-reasoner", "deepseek", "deepseek/deepseek-chat", "deepseek/deepseek-reasoner"])("%s has deepseek pricing", (id) => {
+    const p = getModelPricing(id);
+    expect(p).not.toBeNull();
+    expect(p.output_per_million).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Nivel 1 del plan Kimi/DeepSeek: sin plugin y sin adapter — OpenCode ya es la pasarela OpenAI-compatible. Este PR hace que el coste se contabilice bien:

- `model-registry.js`: familias `kimi-k2` (moonshot) y `deepseek-chat`/`deepseek-reasoner` con pricing real, aliases `kimi`/`deepseek` y las variantes prefijadas (`kimi/…`, `deepseek/…`) que produce el snippet documentado — el lookup es por clave exacta.
- `karajan-core/pricing/model-pricing.json`: mismas entradas + sources (viajan al registry npm con el próximo publish de core; hasta entonces un id desconocido devuelve null sin romper, por diseño).
- `docs/providers-via-opencode.md`: opencode.json completo (Moonshot + DeepSeek con API keys por env), comandos de uso y criterio para un futuro agente de primera clase (solo kimi-cli si madura; DeepSeek no tiene CLI de agente oficial).

Tests: 9 asserts nuevos de pricing por id/alias/prefijo (29/29 en agents), core 83/83. Precios son foto estática con URL de verificación, mismo criterio del _meta.updatedAt existente.