### PR TITLE
fix(release): engines floor drops to runtime-real 22.12.0 (KJC-BUG-0111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   # node --check catches parse-time syntax/import bugs. Node 20 was dropped
-  # in v3.0.0 (KJC-TSK-0500, 2026-06-03) when engines.node moved to >=22.22.1
+  # in v3.0.0 (KJC-TSK-0500, 2026-06-03) when engines.node moved to >=22.12.0
   # — Node 20 reaches EOL on 2026-04-30 and three deps (lint-staged 17,
   # commander 15, better-sqlite3 12.10+) required the bump.
   syntax:
@@ -88,7 +88,7 @@ jobs:
         run: npm run format:check
 
   # ESLint runs on the same Node matrix as syntax (22/24). engines.node
-  # is now >=22.22.1 (v3.0.0, KJC-TSK-0500).
+  # is now >=22.12.0 (v3.0.0, KJC-TSK-0500).
   lint:
     name: Lint (ESLint, Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -113,7 +113,7 @@ jobs:
       - name: Lint (ESLint — no-undef + import resolution)
         run: npm run lint
 
-  # Tests run on Node 22/24 — engines.node floor is now >=22.22.1 (v3.0.0).
+  # Tests run on Node 22/24 — engines.node floor is now >=22.12.0 (v3.0.0).
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.15.1] - 2026-07-19
+
+Patch. **`npm install -g karajan-code` no longer silently installs a months-old version on Node 22.0-22.21.**
+
+### Fixed
+
+- **engines.node lowered to the real runtime floor, `>=22.12.0`** (KJC-BUG-0111, caught by following the Quick Start to the letter with a fresh install): every 3.x release declared `>=22.22.1` — a floor inherited from lint-staged 17, a devDependency end users never run. npm resolves the newest version whose engines match your Node, so any install on Node 22.0-22.21 silently received **karajan-code@2.34.0** with zero warnings. The actual runtime floor is commander 15's `>=22.12.0`; all four workspaces now declare it.
+
 ## [3.15.0] - 2026-07-19
 
 Minor. **Parallel lanes ready for real projects, Kimi + DeepSeek as first-class priced models, and a fully decoupled HU Board.**

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Karajan ships as **layers you opt into**. The base CLI is tiny (~5 MB). Heavier 
 - **Pipeline RAM peak**: 1–2 GB per `kj run` (one orchestrator + one coder + one reviewer subprocess at a time).
 - **SQLite is in-process.** No separate DB daemon. `~/.karajan/` is a folder, not a service.
 - **First-run Ollama pull**: ~5 min in the background; you can keep working — `kj` falls back to a cloud embedder if Ollama isn't ready yet.
-- **Runtime**: Node.js ≥ 22.22.1 (Active LTS). v3.0.0 dropped Node 20 support. Use `kj doctor` to verify your environment.
+- **Runtime**: Node.js ≥ 22.12.0 (Active LTS). v3.0.0 dropped Node 20 support. Use `kj doctor` to verify your environment.
 
 ## Two ways to use Karajan
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",
@@ -24,7 +24,7 @@
     "cli"
   ],
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=22.12.0"
   },
   "kj": {
     "harden": {

--- a/packages/ai-trash/package.json
+++ b/packages/ai-trash/package.json
@@ -25,7 +25,7 @@
     "aider"
   ],
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=22.12.0"
   },
   "bin": {
     "kj-trash": "bin/kj-trash.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
   "license": "AGPL-3.0",
@@ -14,7 +14,7 @@
     "src/"
   ],
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=22.12.0"
   },
   "exports": {
     "./atomic-write": "./src/atomic-write.js",

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "start": "node src/server.js",

--- a/src/checks/node.js
+++ b/src/checks/node.js
@@ -2,8 +2,12 @@
  * Node.js runtime version check. Requires Node >= 22 — the Active LTS
  * baseline since Karajan v3.0.0 (KJC-TSK-0500, 2026-06-03). Node 20 was
  * dropped because (a) Node 20 reaches EOL on 2026-04-30 and (b) three
- * dependencies forced the bump: lint-staged 17 needs ≥22.22.1, commander
- * 15 needs ≥22.12.0, and better-sqlite3 v12.10+ dropped Node 20 prebuilds.
+ * dependencies forced the bump: commander 15 needs ≥22.12.0 and
+ * better-sqlite3 v12.10+ dropped Node 20 prebuilds. engines.node is
+ * ">=22.12.0" — the highest RUNTIME floor. KJC-BUG-0111: it briefly sat
+ * at 22.22.1 (lint-staged 17's floor — a devDependency end users never
+ * run) and npm silently served karajan-code@2.34.0 to every Node
+ * 22.0-22.21 install; keep dev-tool floors out of engines.
  * Strategy: manual — we cannot auto-upgrade the runtime. Users on older
  * Node get a clear upgrade instruction with nvm + brew hints instead of a
  * silent runtime crash.


### PR DESCRIPTION
Cazado siguiendo el Quick Start al pie de la letra con la 3.15.0 recién publicada (KJC-TSK-0634): en un Node 22.21.1, `npm install -g karajan-code` instaló **karajan-code@2.34.0 en silencio** — npm resuelve la versión más nueva cuyo engines case, y todas las 3.x exigían `>=22.22.1`… un suelo heredado de lint-staged 17, que es devDependency: el usuario final jamás la ejecuta.

Suelo runtime REAL: commander@15 `>=22.12.0` (better-sqlite3@12 acepta 22.x; el check interno MIN_NODE_MAJOR=22 ya era coherente). Cambios: engines `>=22.12.0` en los 4 workspaces (root, core, hu-board, ai-trash), README y comentarios de workflows alineados, nota de la lección en src/checks/node.js. Bumps: karajan-code 3.15.1 + karajan-core 1.3.1 (secuencia de publish: core primero). verify-pack verde local. CHANGELOG [3.15.1].