### PR TITLE
fix(git): no-remote runs skip push automation, gemini errors classify as auth

### DIFF
--- a/src/brain/agent-error-classifier.js
+++ b/src/brain/agent-error-classifier.js
@@ -31,7 +31,11 @@ export const ERROR_CLASS = Object.freeze({
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
-const AUTH_PATTERNS = /\b401\b|\b403\b|unauthorized|invalid\s+api\s+key|authentication\s+failed|expired\s+token/i;
+// `error\s+authenticating` + `IneligibleTierError` (KJC-BUG-0113): the
+// retired Gemini Code Assist CLI fails with "Error authenticating:
+// IneligibleTierError … migrate to Antigravity" — it classified as
+// UNKNOWN_FATAL and left the run without the AUTH escalation message.
+const AUTH_PATTERNS = /\b401\b|\b403\b|unauthorized|invalid\s+api\s+key|authentication\s+failed|expired\s+token|error\s+authenticating|IneligibleTierError/i;
 const SILENCED_PATTERNS = /killed\s+after\s+\d+\s*ms|silence\s*timeout|no\s+output\s+for\s+\d+/i;
 // `session\s+limit` / `weekly\s+limit` cover Claude Code's usage caps
 // ("You've hit your session limit · resets 10:10pm"). Without them the

--- a/src/git/automation.js
+++ b/src/git/automation.js
@@ -16,7 +16,8 @@ import {
   commitAll,
   pushBranch,
   createPullRequest,
-  listPendingPaths
+  listPendingPaths,
+  hasRemote
 } from "../utils/git.js";
 
 /**
@@ -276,7 +277,19 @@ export async function finalizeGitAutomation({ config, gitCtx, task, logger, sess
     logger.info(committed ? "Committed changes" : "No changes to commit");
   }
 
-  if (config.git.auto_push || config.git.auto_pr) {
+  // KJC-BUG-0112: without an `origin` remote (the quickstart scenario:
+  // fresh folder + git init) push/PR automation has nothing to talk to —
+  // fetchBase used to throw here and escalate to Solomon on EVERY
+  // iteration, burning the whole budget on an expected condition.
+  const remoteAvailable = (config.git.auto_push || config.git.auto_pr)
+    ? await hasRemote()
+    : false;
+  if ((config.git.auto_push || config.git.auto_pr) && !remoteAvailable) {
+    logger.info("No remote configured — skipping push/PR automation");
+    await addCheckpoint(session, { stage: "git-push", skipped: "no-remote" });
+  }
+
+  if (remoteAvailable && (config.git.auto_push || config.git.auto_pr)) {
     await fetchBase(gitCtx.baseBranch);
     await ensureBranchUpToDateWithBase({
       branch: gitCtx.branch,
@@ -286,14 +299,14 @@ export async function finalizeGitAutomation({ config, gitCtx, task, logger, sess
     await addCheckpoint(session, { stage: "git-rebase-check", branch: gitCtx.branch });
   }
 
-  if (config.git.auto_push || config.git.auto_pr) {
+  if (remoteAvailable && (config.git.auto_push || config.git.auto_pr)) {
     await pushBranch(gitCtx.branch);
     await addCheckpoint(session, { stage: "git-push", branch: gitCtx.branch });
     logger.info(`Pushed branch: ${gitCtx.branch}`);
   }
 
   let prUrl = session.ci_pr_url || null;
-  if (config.git.auto_pr && !prUrl) {
+  if (remoteAvailable && config.git.auto_pr && !prUrl) {
     const body = buildPrBody({ task, stageResults });
     prUrl = await createPullRequest({
       baseBranch: gitCtx.baseBranch,

--- a/src/orchestrator/solomon-escalation.js
+++ b/src/orchestrator/solomon-escalation.js
@@ -123,7 +123,11 @@ export async function invokeSolomon({ config, logger, emitter, eventBase, stage,
     return escalateToHuman({ askQuestion, session, emitter, eventBase, stage, conflict, iteration });
   }
 
-  const solomonProvider = config?.roles?.solomon?.provider || "gemini";
+  // KJC-BUG-0113: the fallback used to be "gemini" — Google retired the
+  // Gemini Code Assist CLI for individuals (IneligibleTierError), so an
+  // unconfigured Solomon died on every escalation. Claude matches the
+  // brain.provider default.
+  const solomonProvider = config?.roles?.solomon?.provider || "claude";
   emitProgress(
     emitter,
     makeEvent("solomon:start", { ...eventBase, stage: "solomon" }, {

--- a/src/roles/commiter-role.js
+++ b/src/roles/commiter-role.js
@@ -8,7 +8,8 @@ import {
   commitAll,
   pushBranch,
   createPullRequest,
-  revParse
+  revParse,
+  hasRemote
 } from "../utils/git.js";
 
 function buildCommitMessage(task) {
@@ -59,7 +60,13 @@ export class CommiterRole extends BaseRole {
     await commitAll(msg);
     const commitHash = await revParse("HEAD");
 
-    if (push) {
+    // KJC-BUG-0112: no `origin` remote (quickstart scenario) → skip
+    // push/PR instead of throwing on fetch.
+    const remoteAvailable = push ? await hasRemote() : false;
+    if (push && !remoteAvailable) {
+      this.logger?.info?.("No remote configured — skipping push/PR");
+    }
+    if (push && remoteAvailable) {
       const baseBranch = this.config.base_branch || "main";
       await fetchBase(baseBranch);
       await ensureBranchUpToDateWithBase({
@@ -71,7 +78,7 @@ export class CommiterRole extends BaseRole {
     }
 
     let prUrl = null;
-    if (push && createPr) {
+    if (push && createPr && remoteAvailable) {
       const baseBranch = this.config.base_branch || "main";
       prUrl = await createPullRequest({
         baseBranch,

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -12,7 +12,10 @@ const KNOWN_AGENTS = [
 
 export async function checkBinary(name, versionArg = "--version") {
   const resolved = resolveBin(name);
-  const res = await runCommand(resolved, [versionArg]);
+  // KJC-BUG-0113: a zombie CLI that hangs on --version (seen with the
+  // retired Gemini Code Assist binary) must not hang init/preflight —
+  // 5s is generous for a version print.
+  const res = await runCommand(resolved, [versionArg], { timeout: 5000 });
   const version = (res.stdout || res.stderr || "").split("\n")[0].trim();
   return { ok: res.exitCode === 0, version, path: resolved };
 }

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -251,6 +251,16 @@ export async function commitAll(message, cwd = null) {
   return { committed: true, commit: { hash, message: commitMessage } };
 }
 
+/**
+ * KJC-BUG-0112: whether the repo has an `origin` remote. The quickstart
+ * scenario (fresh folder + git init) has none — post-approval push/PR
+ * automation must skip instead of failing and escalating to Solomon.
+ */
+export async function hasRemote(cwd = null) {
+  const res = await run("git", ["remote", "get-url", "origin"], cwd ? { cwd } : {});
+  return res.exitCode === 0;
+}
+
 export async function pushBranch(branch, cwd = null) {
   await runGit(["push", "-u", "origin", branch], cwd ? { cwd } : {});
 }

--- a/tests/brain/agent-error-classifier.test.js
+++ b/tests/brain/agent-error-classifier.test.js
@@ -177,3 +177,19 @@ describe("classifyAgentError — Claude Code session limit", () => {
     expect(r.class).not.toBe(ERROR_CLASS.UNKNOWN_FATAL);
   });
 });
+
+// KJC-BUG-0113: the retired Gemini Code Assist CLI fails with
+// "Error authenticating: IneligibleTierError…" — must classify as
+// AUTH_FAILED (non-recoverable, escalate to user), not UNKNOWN_FATAL.
+describe("retired gemini CLI (KJC-BUG-0113)", () => {
+  it("IneligibleTierError classifies as AUTH_FAILED", () => {
+    const r = classifyAgentError({
+      provider: "gemini",
+      exitCode: 1,
+      stderr: "Error authenticating: IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals.",
+      stdout: "",
+    });
+    expect(r.class).toBe("AUTH_FAILED");
+    expect(r.recoverable).toBe(false);
+  });
+});

--- a/tests/commiter-role.test.js
+++ b/tests/commiter-role.test.js
@@ -15,7 +15,8 @@ vi.mock("../src/utils/git.js", () => ({
   commitAll: vi.fn(),
   pushBranch: vi.fn(),
   createPullRequest: vi.fn(),
-  revParse: vi.fn()
+  revParse: vi.fn(),
+  hasRemote: vi.fn()
 }));
 
 const { CommiterRole } = await import("../src/roles/commiter-role.js");
@@ -36,6 +37,7 @@ describe("CommiterRole", () => {
     git.currentBranch.mockResolvedValue("feat/my-branch");
     git.commitAll.mockResolvedValue({ committed: true });
     git.pushBranch.mockResolvedValue(undefined);
+    git.hasRemote.mockResolvedValue(true);
     git.createPullRequest.mockResolvedValue("https://github.com/org/repo/pull/42");
     git.fetchBase.mockResolvedValue(undefined);
     git.ensureBranchUpToDateWithBase.mockResolvedValue({ upToDate: true, rebased: false });

--- a/tests/git-automation-no-remote.test.js
+++ b/tests/git-automation-no-remote.test.js
@@ -1,0 +1,42 @@
+// KJC-BUG-0112: without an `origin` remote (quickstart: fresh folder +
+// git init), push/PR automation must SKIP with an info line — the old
+// behavior threw on `git fetch origin` and escalated to Solomon on every
+// iteration, burning the run's budget on an expected condition.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/session/store.js", () => ({ addCheckpoint: vi.fn(async () => {}) }));
+
+const { setRunner } = await import("../src/utils/git.js");
+const { finalizeGitAutomation } = await import("../src/git/automation.js");
+
+afterEach(() => setRunner(null));
+
+function noRemoteRunner(calls) {
+  return vi.fn(async (_cmd, args) => {
+    calls.push(args.join(" "));
+    if (args[0] === "remote") return { exitCode: 1, stdout: "", stderr: "fatal: No such remote 'origin'" };
+    if (args[0] === "status") return { exitCode: 0, stdout: "", stderr: "" };
+    return { exitCode: 0, stdout: "", stderr: "" };
+  });
+}
+
+describe("finalizeGitAutomation without a remote (KJC-BUG-0112)", () => {
+  it("skips fetch/push/PR with an info line instead of throwing", async () => {
+    const calls = [];
+    setRunner(noRemoteRunner(calls));
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const result = await finalizeGitAutomation({
+      config: { git: { auto_commit: false, auto_push: true, auto_pr: true } },
+      gitCtx: { enabled: true, branch: "feat/x", baseBranch: "main", autoRebase: true },
+      task: "quickstart tic-tac-toe",
+      logger,
+      session: {},
+    });
+
+    expect(result).toBeDefined();
+    expect(calls.some((c) => c.startsWith("fetch"))).toBe(false);
+    expect(calls.some((c) => c.startsWith("push"))).toBe(false);
+    expect(logger.info.mock.calls.flat().join(" ")).toContain("No remote configured");
+  });
+});


### PR DESCRIPTION
Dos bugs cazados corriendo el Quick Start de la landing al pie de la letra con la 3.15.1 publicada (KJC-TSK-0634):

**KJC-BUG-0112** — en un repo sin remoto (el escenario CANÓNICO del Quick Start: carpeta nueva + git init), el post-loop hacía `git fetch origin main`, reventaba y **escalaba a Solomon en cada iteración** — $2.57 quemados en un run que debía costar ~$0.50, con riesgo de agotar el presupuesto entero. Fix: `hasRemote()` en utils/git y el bloque push/PR entero se salta con "No remote configured — skipping push/PR automation" (patrón del pre-loop), en `finalizeGitAutomation` y en CommiterRole.

**KJC-BUG-0113 (capas 1-3)** — un Gemini CLI obsoleto en el PATH (Google lo retiró para individuals → IneligibleTierError) envenena el run: (1) el error clasificaba UNKNOWN_FATAL → ahora AUTH_FAILED con mensaje accionable; (2) `checkBinary` sin timeout colgaba init/preflight con binarios zombis → timeout 5s; (3) el fallback hardcodeado de Solomon era `"gemini"` → ahora `"claude"`. Queda en la card: probe de auth real en el reparto de roles del init y preflight degradando (no bloqueando) por rol secundario caído.

Tests: no-remote e2e del finalize (sin fetch/push + info), IneligibleTierError→AUTH_FAILED, mock de hasRemote en commiter. Suite completa verde (los 2 últimos rojos eran ambientales: el HU Board del propio QA vivo en :4000).