### PR TITLE
feat(release): quickstart smoke in verify-pack + real-coder gate script (KJC-TSK-0635)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "mcp": "node src/mcp/server.js",
     "audit:test-diet": "node scripts/audit-test-diet.mjs",
     "verify-pack": "node scripts/verify-pack.mjs",
-    "prepublishOnly": "node scripts/verify-pack.mjs"
+    "prepublishOnly": "node scripts/verify-pack.mjs",
+    "verify-quickstart": "node scripts/quickstart-gate.mjs"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"

--- a/scripts/quickstart-gate.mjs
+++ b/scripts/quickstart-gate.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Quickstart gate (KJC-TSK-0635) — the landing's Quick Start, end to end,
+ * against the PACKED tarball, with a REAL coder run.
+ *
+ * Run manually before a release (`npm run verify-quickstart`). Opt-in
+ * because the coder run spends real subscription quota (~$0.5-1.5, 5-8
+ * minutes). What it catches that unit tests and verify-pack cannot:
+ * the exact first-contact sequence a new user follows — install → init →
+ * `kj run` on a no-remote repo → playable artifact (2026-07-19: that
+ * sequence surfaced KJC-BUG-0111/0112/0113 in one afternoon).
+ *
+ * Asserts: run exits 0 · report says approved · index.html exists with
+ * game markers · "skipping push/PR" logged · ZERO Solomon escalations.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const TASK = "Create a tic-tac-toe game in a single self-contained index.html — vanilla HTML, CSS and JavaScript, no server and no build step. The human plays X, the bot plays O and blocks or takes a winning move when it can. Detect wins and draws, and add a New Game button. Opening index.html in a browser must be enough to play.";
+
+function fail(msg, detail) {
+  console.error(`\n✗ quickstart-gate: ${msg}`);
+  if (detail) console.error(String(detail).slice(-1200));
+  process.exitCode = 1;
+  throw new Error(msg);
+}
+
+let work = null;
+try {
+  console.log("quickstart-gate: packing…");
+  const packOut = execFileSync("npm", ["pack", "--json", "--silent"], { cwd: repoRoot, encoding: "utf8" });
+  const tgz = path.join(repoRoot, JSON.parse(packOut)[0].filename);
+
+  work = fs.mkdtempSync(path.join(os.tmpdir(), "kj-qs-gate-"));
+  const prefix = path.join(work, "npm");
+  const project = path.join(work, "project");
+  fs.mkdirSync(project, { recursive: true });
+
+  console.log("quickstart-gate: installing the tarball (isolated prefix)…");
+  execFileSync("npm", ["install", "-g", tgz, "--no-audit", "--no-fund", "--silent", "--prefix", prefix], { encoding: "utf8" });
+  const kj = path.join(prefix, "bin", "kj");
+  fs.rmSync(tgz, { force: true });
+
+  const env = { ...process.env };
+  delete env.CLAUDECODE;
+
+  console.log("quickstart-gate: git init + kj init (unattended)…");
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: project });
+  const init = spawnSync(kj, ["init", "--no-interactive", "--local", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd"], {
+    cwd: project, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 300000,
+  });
+  if (init.status !== 0) fail("kj init failed", init.stderr || init.stdout);
+
+  console.log("quickstart-gate: kj run (REAL coder — this spends quota, ~5-8 min)…");
+  const runRes = spawnSync(kj, ["run", "-y", TASK], {
+    cwd: project, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 20 * 60 * 1000,
+  });
+  const runOut = `${runRes.stdout || ""}${runRes.stderr || ""}`;
+  fs.writeFileSync(path.join(work, "run.log"), runOut);
+
+  if (runRes.status !== 0) fail(`kj run exited ${runRes.status} (log: ${work}/run.log)`, runOut);
+  if (/escalating to Solomon/i.test(runOut)) fail(`Solomon escalation detected — the happy path must not consult Solomon (log: ${work}/run.log)`);
+  if (!/skipping push\/PR/i.test(runOut)) fail("expected the no-remote skip line ('skipping push/PR') in the run output");
+
+  const html = path.join(project, "index.html");
+  if (!fs.existsSync(html)) fail("index.html was not created");
+  const htmlText = fs.readFileSync(html, "utf8");
+  if (!/new game/i.test(htmlText)) fail("index.html has no New Game control — not the requested game");
+
+  const report = spawnSync(kj, ["report"], { cwd: project, env, encoding: "utf8", timeout: 60000 });
+  if (!/approved/i.test(`${report.stdout || ""}`)) fail("kj report does not say approved", report.stdout);
+
+  console.log("\n✓ quickstart-gate: install → init → run → playable index.html → approved. Ship it.");
+} finally {
+  if (work && process.exitCode !== 1 && fs.existsSync(work)) fs.rmSync(work, { recursive: true, force: true });
+  if (work && process.exitCode === 1) console.error(`quickstart-gate: workdir kept for inspection: ${work}`);
+}

--- a/scripts/quickstart-gate.mjs
+++ b/scripts/quickstart-gate.mjs
@@ -44,12 +44,14 @@ try {
   const kj = path.join(prefix, "bin", "kj");
   fs.rmSync(tgz, { force: true });
 
-  const env = { ...process.env };
+  // Isolated KARAJAN_HOME: faithful to a brand-new user (no global
+  // config) and never touches the maintainer's real ~/.karajan.
+  const env = { ...process.env, KARAJAN_HOME: path.join(work, "karajan-home") };
   delete env.CLAUDECODE;
 
   console.log("quickstart-gate: git init + kj init (unattended)…");
   execFileSync("git", ["init", "-q", "-b", "main"], { cwd: project });
-  const init = spawnSync(kj, ["init", "--no-interactive", "--local", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd"], {
+  const init = spawnSync(kj, ["init", "--no-interactive", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd"], {
     cwd: project, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 300000,
   });
   if (init.status !== 0) fail("kj init failed", init.stderr || init.stdout);

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -157,15 +157,21 @@ try {
   qsTmp = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verify-qs-"));
   console.log(`verify-pack: quickstart smoke (init on a no-remote repo) in ${qsTmp}…`);
   run("git", ["init", "-q", "-b", "main"], { cwd: qsTmp });
-  const qsEnv = { ...childEnv };
+  // KARAJAN_HOME points at an isolated dir: faithful to a brand-new user
+  // (no pre-existing global config — `--local` without one is rejected by
+  // design, which is exactly what this smoke caught on its first CI run)
+  // AND hermetic (never touches the real ~/.karajan).
+  const qsEnv = { ...childEnv, KARAJAN_HOME: path.join(qsTmp, "karajan-home") };
   delete qsEnv.CLAUDECODE;
-  const initRes = spawnSync(gBin, ["init", "--no-interactive", "--local", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd", "--no-harden"], {
+  const initRes = spawnSync(gBin, ["init", "--no-interactive", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd", "--no-harden"], {
     encoding: "utf8", cwd: qsTmp, env: qsEnv, timeout: 180000,
   });
   if (initRes.status !== 0) {
-    fail("`kj init --no-interactive --local` failed on a fresh no-remote repo", (initRes.stderr || initRes.stdout || "").slice(-800));
+    fail("`kj init --no-interactive` failed on a fresh no-remote repo", (initRes.stderr || initRes.stdout || "").slice(-800));
   }
-  const qsCfg = path.join(qsTmp, ".karajan", "kj.config.yml");
+  const qsCfgLocal = path.join(qsTmp, ".karajan", "kj.config.yml");
+  const qsCfgGlobal = path.join(qsTmp, "karajan-home", "kj.config.yml");
+  const qsCfg = fs.existsSync(qsCfgLocal) ? qsCfgLocal : qsCfgGlobal;
   if (!fs.existsSync(qsCfg)) fail(`kj init did not write ${qsCfg}`);
   if (!/coder:\s*\S+/.test(fs.readFileSync(qsCfg, "utf8"))) {
     fail("generated kj.config.yml has no coder assignment");

--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -52,6 +52,7 @@ let tgzPath = null;
 let tmpDir = null;
 let gTmp = null;
 let pnpmTmp = null;
+let qsTmp = null;
 try {
   console.log(`verify-pack: packing karajan-code@${expectedVersion}…`);
   // --json gives us the exact filename without parsing human output.
@@ -146,6 +147,36 @@ try {
   }
   console.log(`verify-pack: global install + kj --version → ${gVersion} ✓`);
 
+  // 5.5 Quickstart smoke (KJC-TSK-0635) — the landing's Getting Started
+  // sequence against the INSTALLED tarball, no LLM involved. Born from
+  // 2026-07-19: following the docs to the letter caught 3 field bugs
+  // (silent 2.34.0 install, Solomon loop on no-remote repos, retired
+  // gemini CLI) that 6000 unit tests never saw. Aux bootstraps (ollama,
+  // rtk, squeezr, qmd, harden) are skipped — this validates kj's own
+  // init + config on the canonical no-remote scenario, not the network.
+  qsTmp = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verify-qs-"));
+  console.log(`verify-pack: quickstart smoke (init on a no-remote repo) in ${qsTmp}…`);
+  run("git", ["init", "-q", "-b", "main"], { cwd: qsTmp });
+  const qsEnv = { ...childEnv };
+  delete qsEnv.CLAUDECODE;
+  const initRes = spawnSync(gBin, ["init", "--no-interactive", "--local", "--no-ollama", "--no-rtk", "--no-squeezr", "--no-qmd", "--no-harden"], {
+    encoding: "utf8", cwd: qsTmp, env: qsEnv, timeout: 180000,
+  });
+  if (initRes.status !== 0) {
+    fail("`kj init --no-interactive --local` failed on a fresh no-remote repo", (initRes.stderr || initRes.stdout || "").slice(-800));
+  }
+  const qsCfg = path.join(qsTmp, ".karajan", "kj.config.yml");
+  if (!fs.existsSync(qsCfg)) fail(`kj init did not write ${qsCfg}`);
+  if (!/coder:\s*\S+/.test(fs.readFileSync(qsCfg, "utf8"))) {
+    fail("generated kj.config.yml has no coder assignment");
+  }
+  const reportRes = spawnSync(gBin, ["report"], { encoding: "utf8", cwd: qsTmp, env: qsEnv, timeout: 60000 });
+  const reportOut = `${reportRes.stdout || ""}${reportRes.stderr || ""}`;
+  if (reportRes.status !== 0 && !/no session|sin sesi|not found/i.test(reportOut)) {
+    fail("`kj report` crashed on a project with no sessions", reportOut.slice(-400));
+  }
+  console.log("verify-pack: quickstart smoke (init + report, no-remote repo) ✓");
+
   // 6. pnpm install smoke (KJC-TSK-0580). pnpm's layout differs from npm's
   // (a symlinked virtual store), so it can break resolution of the bundled
   // karajan-core the way npm packaging breakage did before (KJC-BUG-0082/0086).
@@ -195,4 +226,5 @@ try {
   if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
   if (gTmp && fs.existsSync(gTmp)) fs.rmSync(gTmp, { recursive: true, force: true });
   if (pnpmTmp && fs.existsSync(pnpmTmp)) fs.rmSync(pnpmTmp, { recursive: true, force: true });
+  if (qsTmp && fs.existsSync(qsTmp)) fs.rmSync(qsTmp, { recursive: true, force: true });
 }


### PR DESCRIPTION
Automatiza como gate pre-release lo que el QA manual del 19-07 demostró: seguir el Quick Start al pie de la letra caza bugs que 6000 tests unitarios no ven (2.34.0 silenciosa, bucle de Solomon sin remoto, gemini retirado).

**Nivel CI (gratis, cada PR + prepublishOnly)**: verify-pack gana la fase "quickstart smoke" — con el binario del install global aislado del TARBALL: `git init` sin remoto → `kj init --no-interactive --local` (bootstraps auxiliares saltados; valida el init de kj, no la red) → exit 0 + `kj.config.yml` con coder asignado + `kj report` sin sesión sale limpio.

**Nivel local (opt-in, `npm run verify-quickstart`)**: `scripts/quickstart-gate.mjs` — pack → install en prefix aislado → init → el `kj run` EXACTO del tic-tac-toe con coder real (~$0.5-1.5, 5-8 min) → aserciones: exit 0, CERO "escalating to Solomon", línea "skipping push/PR" presente, `index.html` con New Game, report "approved". En fallo conserva el workdir con el run.log para inspección.

verify-pack completo verde en local con la fase nueva incluida.