### PR TITLE
feat(review): verdict store keyed by raw-diff sha256 (KJC-TSK-0637)

### DIFF
--- a/src/review/verdict-store.js
+++ b/src/review/verdict-store.js
@@ -16,7 +16,9 @@ import path from "node:path";
 const STORE_DIR = path.join(".karajan", "reviews");
 
 export function diffHash(diff) {
-  return crypto.createHash("sha256").update(diff, "utf8").digest("hex");
+  // trimEnd: runners differ on the final newline (execa strips it, raw
+  // git keeps it) — trailing whitespace must not void a verdict.
+  return crypto.createHash("sha256").update(diff.trimEnd(), "utf8").digest("hex");
 }
 
 function verdictPath(projectDir, hash) {

--- a/src/review/verdict-store.js
+++ b/src/review/verdict-store.js
@@ -1,0 +1,60 @@
+/**
+ * Verdict store (ENV-B1, KJC-TSK-0637) — persists cross-AI review verdicts
+ * keyed by the sha256 of the RAW diff they reviewed.
+ *
+ * The hash is the contract: a verdict only counts for byte-identical
+ * content, so any change after the review voids it and forces a new one
+ * (resolve-until-pass by construction). The pre-commit hook (ENV-C)
+ * calls checkVerdict() with the staged diff to decide whether the
+ * commit may enter. Diffs must be raw git output — never rtk-compressed
+ * (KJC-BUG-0115).
+ */
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const STORE_DIR = path.join(".karajan", "reviews");
+
+export function diffHash(diff) {
+  return crypto.createHash("sha256").update(diff, "utf8").digest("hex");
+}
+
+function verdictPath(projectDir, hash) {
+  return path.join(projectDir, STORE_DIR, `${hash}.json`);
+}
+
+export async function saveVerdict(projectDir, diff, verdict) {
+  const hash = diffHash(diff);
+  const record = {
+    ...verdict,
+    diffHash: hash,
+    timestamp: new Date().toISOString(),
+  };
+  const file = verdictPath(projectDir, hash);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, `${JSON.stringify(record, null, 2)}\n`);
+  return record;
+}
+
+export async function loadVerdict(projectDir, hash) {
+  try {
+    return JSON.parse(await fs.readFile(verdictPath(projectDir, hash), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is there an APPROVED verdict for exactly this diff?
+ * @returns {Promise<{ok: boolean, verdict?: object, reason?: string}>}
+ */
+export async function checkVerdict(projectDir, diff) {
+  const verdict = await loadVerdict(projectDir, diffHash(diff));
+  if (!verdict) {
+    return { ok: false, reason: "no verdict recorded for the current diff — run `kj review`" };
+  }
+  if (verdict.verdict !== "approved") {
+    return { ok: false, verdict, reason: `review was rejected by ${verdict.reviewer} — fix the issues and run \`kj review\` again` };
+  }
+  return { ok: true, verdict };
+}

--- a/tests/review/verdict-store.test.js
+++ b/tests/review/verdict-store.test.js
@@ -1,0 +1,54 @@
+// ENV-B1 (KJC-TSK-0637): the verdict store ties a reviewer verdict to the
+// EXACT diff content via sha256. If the code changes after the review, the
+// hash no longer matches and the verdict is void — resolve-until-pass by
+// construction. This is the contract the pre-commit hook (ENV-C) verifies.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { diffHash, saveVerdict, loadVerdict, checkVerdict } from "../../src/review/verdict-store.js";
+
+const DIFF = "diff --git a/a.js b/a.js\n+const x = 1;\n";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verdict-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("verdict store", () => {
+  it("hashes the raw diff deterministically", () => {
+    expect(diffHash(DIFF)).toBe(diffHash(DIFF));
+    expect(diffHash(DIFF)).not.toBe(diffHash(`${DIFF} `));
+    expect(diffHash(DIFF)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("saves and loads a verdict keyed by diff hash", async () => {
+    const verdict = { verdict: "approved", reviewer: "codex", issues: [] };
+    const saved = await saveVerdict(dir, DIFF, verdict);
+    expect(saved.diffHash).toBe(diffHash(DIFF));
+    const loaded = await loadVerdict(dir, saved.diffHash);
+    expect(loaded.verdict).toBe("approved");
+    expect(loaded.reviewer).toBe("codex");
+    expect(loaded.timestamp).toBeTruthy();
+  });
+
+  it("checkVerdict passes only for an approved verdict on the SAME diff", async () => {
+    await saveVerdict(dir, DIFF, { verdict: "approved", reviewer: "codex", issues: [] });
+    expect((await checkVerdict(dir, DIFF)).ok).toBe(true);
+    const changed = await checkVerdict(dir, `${DIFF}+const y = 2;\n`);
+    expect(changed.ok).toBe(false);
+    expect(changed.reason).toMatch(/no verdict/i);
+  });
+
+  it("checkVerdict fails for a rejected verdict even with matching hash", async () => {
+    await saveVerdict(dir, DIFF, { verdict: "rejected", reviewer: "codex", issues: [{ id: "I1" }] });
+    const res = await checkVerdict(dir, DIFF);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/rejected/i);
+    expect(res.verdict.issues).toHaveLength(1);
+  });
+
+  it("checkVerdict fails cleanly when nothing was ever reviewed", async () => {
+    const res = await checkVerdict(dir, DIFF);
+    expect(res.ok).toBe(false);
+  });
+});

--- a/tests/review/verdict-store.test.js
+++ b/tests/review/verdict-store.test.js
@@ -15,9 +15,10 @@ beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-verdict-")); 
 afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
 
 describe("verdict store", () => {
-  it("hashes the raw diff deterministically", () => {
+  it("hashes the raw diff deterministically, ignoring the trailing newline", () => {
     expect(diffHash(DIFF)).toBe(diffHash(DIFF));
-    expect(diffHash(DIFF)).not.toBe(diffHash(`${DIFF} `));
+    expect(diffHash(DIFF)).toBe(diffHash(DIFF.trimEnd()));
+    expect(diffHash(DIFF)).not.toBe(diffHash(`${DIFF}+const y = 2;`));
     expect(diffHash(DIFF)).toMatch(/^[a-f0-9]{64}$/);
   });
 


### PR DESCRIPTION
## ENV-B1 parte 1/3 — Karajan Environment v4 (épica KJC-PCS-0066)

Primer ladrillo de `kj review` cross-AI: el **verdict store** persiste veredictos de review en `.karajan/reviews/<sha256-del-diff>.json`.

El hash del diff CRUDO es el contrato: un veredicto solo vale para contenido byte-idéntico, así que cualquier cambio posterior a la review lo invalida y fuerza una nueva — *resolver-hasta-pass por construcción*. Es la pieza que el hook pre-commit (ENV-C) verificará: sin veredicto approved que case con el diff staged, el commit no entra.

API: `diffHash(diff)`, `saveVerdict(projectDir, diff, verdict)`, `loadVerdict(projectDir, hash)`, `checkVerdict(projectDir, diff)` → `{ok, verdict?, reason?}`.

Siguientes PRs: runner one-shot cross-AI (reusa buildReviewerPrompt + createAgent + detectHostAgent) y CLI `kj review` con `--check`.

Tests: 5 nuevos (hash determinista, save/load, mismatch de contenido, rejected con hash válido, sin review previa).