### PR TITLE
feat(review): one-shot cross-AI review runner (KJC-TSK-0637)

### DIFF
--- a/src/review/one-shot-review.js
+++ b/src/review/one-shot-review.js
@@ -1,0 +1,85 @@
+/**
+ * One-shot cross-AI review (ENV-B1, KJC-TSK-0637) — the v4 primitive.
+ *
+ * The HOST agent (Claude Code, Codex) orchestrates the work; Karajan
+ * routes the review to a DIFFERENT AI and records the verdict tied to
+ * the exact diff (verdict-store). No cross-AI reviewer available is an
+ * error, never a silent fallback to the host: without a second pair of
+ * eyes there is no verdict, and without a verdict the pre-commit gate
+ * (ENV-C) keeps the commit out.
+ */
+import { createAgent } from "../agents/index.js";
+import { resolveRole } from "../config/role-resolver.js";
+import { buildReviewerPrompt } from "../prompts/reviewer.js";
+import { resolveReviewProfile } from "./profiles.js";
+import { parseMaybeJsonString } from "./parser.js";
+import { detectAvailableAgents, detectHostAgent } from "../utils/agent-detect.js";
+import { saveVerdict } from "./verdict-store.js";
+
+// Cross-AI preference when the configured reviewer IS the host.
+const CROSS_ORDER = ["codex", "claude", "gemini", "opencode", "aider"];
+
+/**
+ * Pick a reviewer that is NOT the host agent.
+ * @returns {Promise<string|null>} provider name, or null if none exists.
+ */
+export async function pickCrossReviewer({ config, hostAgent, detectAgents = detectAvailableAgents }) {
+  const configured = resolveRole(config, "reviewer").provider;
+  if (configured && configured !== hostAgent) return configured;
+
+  const agents = await detectAgents();
+  const candidates = agents
+    .filter((a) => a.available && a.name !== hostAgent)
+    .map((a) => a.name);
+  return CROSS_ORDER.find((name) => candidates.includes(name)) || candidates[0] || null;
+}
+
+/**
+ * Review a raw diff with a cross-AI reviewer and persist the verdict.
+ * @returns {Promise<object>} the stored verdict record.
+ */
+export async function runOneShotReview({
+  diff, task, config, logger, projectDir,
+  hostAgent = detectHostAgent(),
+  createAgentFn = createAgent,
+  detectAgents = detectAvailableAgents,
+}) {
+  if (!diff || !diff.trim()) {
+    throw new Error("nothing to review — the diff is empty (stage your changes or pass --range)");
+  }
+
+  const reviewer = await pickCrossReviewer({ config, hostAgent, detectAgents });
+  if (!reviewer) {
+    throw new Error(
+      `cross-AI review requires an agent other than the host (${hostAgent || "unknown"}) — install codex, claude or another supported CLI`
+    );
+  }
+
+  const { rules } = await resolveReviewProfile({ mode: "standard", projectDir });
+  const prompt = await buildReviewerPrompt({
+    task: task || "Review the following diff for correctness, security and maintainability.",
+    diff, reviewRules: rules, mode: "standard", provider: reviewer, projectDir,
+  });
+
+  logger?.info?.(`kj review: host=${hostAgent || "none"} → reviewer=${reviewer} (cross-AI)`);
+  const agent = createAgentFn(reviewer, config, logger);
+  const result = await agent.reviewTask({ prompt, role: "reviewer" });
+  if (!result?.ok) {
+    throw new Error(`reviewer ${reviewer} failed: ${result?.error || "no output"}`);
+  }
+
+  const parsed = parseMaybeJsonString(result.output);
+  if (!parsed || typeof parsed.approved !== "boolean") {
+    throw new Error(`reviewer ${reviewer} returned no parseable verdict`);
+  }
+
+  return saveVerdict(projectDir, diff, {
+    verdict: parsed.approved ? "approved" : "rejected",
+    reviewer,
+    host: hostAgent || null,
+    issues: parsed.blocking_issues || [],
+    suggestions: parsed.non_blocking_suggestions || [],
+    summary: parsed.summary || parsed.raw_summary || "",
+    confidence: parsed.confidence ?? null,
+  });
+}

--- a/tests/review/one-shot-review.test.js
+++ b/tests/review/one-shot-review.test.js
@@ -1,0 +1,79 @@
+// ENV-B1 (KJC-TSK-0637): the cross-AI rule is the core of the v4 review —
+// the reviewer must NEVER be the host agent, and no cross reviewer means
+// error (a silent same-AI fallback would defeat the whole gate).
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pickCrossReviewer, runOneShotReview } from "../../src/review/one-shot-review.js";
+import { loadVerdict, diffHash } from "../../src/review/verdict-store.js";
+
+const DIFF = "diff --git a/x.js b/x.js\n+const ok = true;\n";
+const agentsUp = (...names) => async () => names.map((name) => ({ name, available: true }));
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-osr-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("pickCrossReviewer", () => {
+  it("keeps the configured reviewer when it differs from the host", async () => {
+    const config = { roles: { reviewer: { provider: "codex" } } };
+    expect(await pickCrossReviewer({ config, hostAgent: "claude" })).toBe("codex");
+  });
+
+  it("overrides a configured reviewer that IS the host", async () => {
+    const config = { roles: { reviewer: { provider: "claude" } } };
+    const picked = await pickCrossReviewer({ config, hostAgent: "claude", detectAgents: agentsUp("claude", "codex") });
+    expect(picked).toBe("codex");
+  });
+
+  it("returns null when only the host agent exists", async () => {
+    const config = { roles: {} };
+    expect(await pickCrossReviewer({ config, hostAgent: "claude", detectAgents: agentsUp("claude") })).toBeNull();
+  });
+});
+
+describe("runOneShotReview", () => {
+  const config = { roles: { reviewer: { provider: "codex" } } };
+  const reviewOutput = (approved, issues = []) => JSON.stringify({
+    approved, blocking_issues: issues, non_blocking_suggestions: [], summary: "s", confidence: 0.9,
+  });
+
+  function fakeAgent(output) {
+    return { reviewTask: vi.fn().mockResolvedValue({ ok: true, output }) };
+  }
+
+  it("stores an approved verdict tied to the diff hash", async () => {
+    const agent = fakeAgent(reviewOutput(true));
+    const record = await runOneShotReview({
+      diff: DIFF, config, projectDir: dir, hostAgent: "claude",
+      createAgentFn: () => agent, detectAgents: agentsUp("claude", "codex"),
+    });
+    expect(record.verdict).toBe("approved");
+    expect(record.reviewer).toBe("codex");
+    expect(record.diffHash).toBe(diffHash(DIFF));
+    expect(await loadVerdict(dir, record.diffHash)).toBeTruthy();
+    expect(agent.reviewTask).toHaveBeenCalledOnce();
+  });
+
+  it("stores a rejected verdict with the blocking issues", async () => {
+    const record = await runOneShotReview({
+      diff: DIFF, config, projectDir: dir, hostAgent: "claude",
+      createAgentFn: () => fakeAgent(reviewOutput(false, [{ id: "I1", severity: "high" }])),
+    });
+    expect(record.verdict).toBe("rejected");
+    expect(record.issues).toHaveLength(1);
+  });
+
+  it("throws (never silently falls back) when no cross-AI reviewer exists", async () => {
+    await expect(runOneShotReview({
+      diff: DIFF, config: { roles: {} }, projectDir: dir, hostAgent: "claude",
+      detectAgents: agentsUp("claude"),
+    })).rejects.toThrow(/cross-AI review requires an agent other than the host/);
+  });
+
+  it("throws on an empty diff", async () => {
+    await expect(runOneShotReview({ diff: "", config, projectDir: dir, hostAgent: "claude" }))
+      .rejects.toThrow(/nothing to review/);
+  });
+});


### PR DESCRIPTION
## ENV-B1 parte 2/3 — Karajan Environment v4 (épica KJC-PCS-0066)

`runOneShotReview`: revisa un diff crudo con una IA **DISTINTA del anfitrión** y persiste el veredicto en el verdict store (#1219).

- **Cross-AI forzado**: `pickCrossReviewer` respeta `roles.reviewer.provider` solo si ≠ anfitrión (detectado vía `detectHostAgent`: CLAUDECODE⇒claude, CODEX_CLI⇒codex); si coincide, elige otro agente disponible (orden codex > claude > gemini > opencode > aider). Sin reviewer cruzado disponible → **error accionable, nunca fallback silencioso al mismo anfitrión**.
- Reutiliza `buildReviewerPrompt` + `resolveReviewProfile` + `createAgent` + `parseMaybeJsonString` del pipeline.
- El diff debe ser git crudo (lección KJC-BUG-0115 — jamás vía rtk).

**Validado en vivo** con codex real: rechazó un `divide(a,b)` sin guard de división por cero (issue accionable), el veredicto quedó stale al arreglar el código, y la re-review aprobó — ciclo resolver-hasta-pass completo.

Tests: 7 (cross-AI con configured≠host, override cuando configured==host, null sin candidatos, approved/rejected persistidos con hash, error sin cross reviewer, error con diff vacío).

Siguiente PR: CLI `kj review --staged/--check/--range`.