### PR TITLE
feat(cli): kj review --staged/--check — cross-AI gate mode (KJC-TSK-0637)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -183,14 +183,24 @@ export function registerPipeline(program, { pkgVersion }) {
 
   program
     .command("review")
-    .description("Run only reviewer")
+    .description("Run only reviewer (--staged/--check: v4 cross-AI gate with recorded verdict)")
     .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--reviewer <name>")
     .option("--reviewer-model <name>")
     .option("--base-ref <ref>")
+    .option("--staged", "Review the staged diff with a cross-AI reviewer and record the verdict")
+    .option("--check", "Verify the recorded verdict matches the staged diff (exit 0/1, hook-friendly)")
+    .option("--range <range>", "Review a git range (e.g. main..HEAD) instead of the staged diff")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "review", flags, async ({ config, logger }) => {
+        // ENV-B1 (KJC-TSK-0637): the gate mode records a verdict tied to
+        // the exact diff so the pre-commit hook can enforce cross-AI review.
+        if (flags.staged || flags.check || flags.range) {
+          const { reviewGateCommand } = await import("../commands/review-gate.js");
+          await reviewGateCommand({ config, logger, flags: { ...flags, task } });
+          return;
+        }
         const { resolveTaskInput } = await import("../utils/task-file.js");
         const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         await reviewCommand({ task: resolvedTask, config, logger, baseRef: flags.baseRef });

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -1,0 +1,54 @@
+/**
+ * `kj review --staged | --check | --range` (ENV-B1, KJC-TSK-0637) — the v4
+ * cross-AI review gate. Unlike the legacy task-review mode, this reviews a
+ * raw git diff with an AI DIFFERENT from the host agent and records the
+ * verdict tied to the exact diff (verdict-store), so the pre-commit hook
+ * (ENV-C) can verify it. Exit code 0 = approved, 1 = rejected/stale.
+ */
+import { runCommand } from "../utils/process.js";
+import { checkVerdict } from "../review/verdict-store.js";
+import { runOneShotReview } from "../review/one-shot-review.js";
+
+// Raw git always — never a wrapped/compressing runner (KJC-BUG-0115).
+async function rawDiff(range) {
+  const args = range ? ["diff", range] : ["diff", "--cached"];
+  const res = await runCommand("git", args);
+  if (res.exitCode !== 0) {
+    throw new Error(res.stderr?.trim() || `git ${args.join(" ")} failed`);
+  }
+  return res.stdout;
+}
+
+function printVerdict(record) {
+  if (record.verdict === "approved") {
+    console.log(`✓ APPROVED by ${record.reviewer} (diff ${record.diffHash.slice(0, 12)})`);
+    if (record.summary) console.log(`  ${record.summary}`);
+    return;
+  }
+  console.log(`✗ REJECTED by ${record.reviewer} — ${record.issues.length} blocking issue(s):`);
+  for (const issue of record.issues) {
+    const where = issue.file ? ` [${issue.file}${issue.line ? `:${issue.line}` : ""}]` : "";
+    console.log(`  - (${issue.severity || "high"})${where} ${issue.description || issue.id}`);
+    if (issue.suggested_fix) console.log(`    fix: ${issue.suggested_fix}`);
+  }
+  console.log("Fix the issues and run `kj review --staged` again — the verdict is tied to the exact diff.");
+}
+
+export async function reviewGateCommand({ config, logger = null, flags = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const diff = await rawDiff(flags.range);
+
+  if (flags.check) {
+    const res = await checkVerdict(projectDir, diff);
+    console.log(res.ok
+      ? `✓ verdict ok — approved by ${res.verdict.reviewer} (diff ${res.verdict.diffHash.slice(0, 12)})`
+      : `✗ ${res.reason}`);
+    process.exitCode = res.ok ? 0 : 1;
+    return res;
+  }
+
+  const record = await runOneShotReview({ diff, task: flags.task, config, logger, projectDir });
+  printVerdict(record);
+  process.exitCode = record.verdict === "approved" ? 0 : 1;
+  return record;
+}

--- a/tests/review/review-gate.test.js
+++ b/tests/review/review-gate.test.js
@@ -1,0 +1,53 @@
+// ENV-B1 (KJC-TSK-0637): the gate command wires raw git diffs to the
+// cross-AI runner and to verdict verification, with hook-friendly exit codes.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+import { saveVerdict } from "../../src/review/verdict-store.js";
+
+let dir, cwd0, exit0;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-gate-"));
+  cwd0 = process.cwd();
+  exit0 = process.exitCode;
+  process.chdir(dir);
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+  fs.writeFileSync(path.join(dir, "a.js"), "const x = 1;\n");
+  execFileSync("git", ["add", "a.js"], { cwd: dir });
+});
+afterEach(() => {
+  process.chdir(cwd0);
+  process.exitCode = exit0;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const config = { projectDir: null, roles: { reviewer: { provider: "codex" } } };
+
+describe("kj review gate", () => {
+  it("--check fails with exit 1 when the staged diff has no verdict", async () => {
+    const res = await reviewGateCommand({ config, flags: { check: true } });
+    expect(res.ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("--check passes with exit 0 when an approved verdict matches the staged diff", async () => {
+    const staged = execFileSync("git", ["diff", "--cached"], { cwd: dir, encoding: "utf8" });
+    await saveVerdict(dir, staged, { verdict: "approved", reviewer: "codex", issues: [] });
+    const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+    expect(res.ok).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("--check detects a stale verdict after the staged content changes", async () => {
+    const staged = execFileSync("git", ["diff", "--cached"], { cwd: dir, encoding: "utf8" });
+    await saveVerdict(dir, staged, { verdict: "approved", reviewer: "codex", issues: [] });
+    fs.writeFileSync(path.join(dir, "a.js"), "const x = 2;\n");
+    execFileSync("git", ["add", "a.js"], { cwd: dir });
+    const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+    expect(res.ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## ENV-B1 parte 3/3 — Karajan Environment v4 (épica KJC-PCS-0066)

Cierra KJC-TSK-0637: el comando `kj review` gana el modo gate v4 sin tocar el modo legacy.

- `kj review --staged`: revisa el diff staged con una IA distinta del anfitrión (runner de #1220) y registra el veredicto ligado al hash (#1219). Exit 0 approved / 1 rejected.
- `kj review --check`: verifica que existe veredicto approved para el diff staged EXACTO — la llamada que hará el hook pre-commit (ENV-C). Exit 0/1.
- `kj review --range main..HEAD`: revisa un rango en vez del staged.
- Diff siempre git crudo vía runCommand directo (lección KJC-BUG-0115).
- Sin flags → comportamiento legacy intacto (`kj review <task>`).

**Probado en vivo con el binario linkado**: ciclo completo divide-by-zero → REJECTED by codex → fix → veredicto stale → re-review APPROVED → `kj review --check` verde.

Tests: 3 del gate (sin veredicto → exit 1; approved que casa → exit 0; stale tras cambiar contenido → exit 1). Con #1219 y #1220, la suite de ENV-B1 suma 15 tests.