### PR TITLE
feat(harden): opt-in cross-AI review gate in pre-commit (KJC-TSK-0638)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -192,11 +192,12 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--staged", "Review the staged diff with a cross-AI reviewer and record the verdict")
     .option("--check", "Verify the recorded verdict matches the staged diff (exit 0/1, hook-friendly)")
     .option("--range <range>", "Review a git range (e.g. main..HEAD) instead of the staged diff")
+    .option("--install-gate", "Enable the pre-commit review gate for this project (creates .karajan/review-gate)")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "review", flags, async ({ config, logger }) => {
         // ENV-B1 (KJC-TSK-0637): the gate mode records a verdict tied to
         // the exact diff so the pre-commit hook can enforce cross-AI review.
-        if (flags.staged || flags.check || flags.range) {
+        if (flags.staged || flags.check || flags.range || flags.installGate) {
           const { reviewGateCommand } = await import("../commands/review-gate.js");
           await reviewGateCommand({ config, logger, flags: { ...flags, task } });
           return;

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -36,6 +36,21 @@ function printVerdict(record) {
 
 export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   const projectDir = config?.projectDir || process.cwd();
+
+  if (flags.installGate) {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const marker = path.join(projectDir, ".karajan", "review-gate");
+    await fs.mkdir(path.dirname(marker), { recursive: true });
+    await fs.writeFile(marker, "# Cross-AI review gate enabled (ENV-C1). Commit this file so the whole team inherits the gate.\n");
+    console.log("✓ review gate enabled — commits now require an approved cross-AI verdict (kj review --staged)");
+    const hookProbe = await runCommand("git", ["config", "core.hooksPath"]);
+    if (!hookProbe.stdout?.trim()) {
+      console.log("⚠ no core.hooksPath configured — run `kj harden` so the pre-commit hook enforces the gate");
+    }
+    return { installed: true };
+  }
+
   const diff = await rawDiff(flags.range);
 
   if (flags.check) {

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -28,6 +28,16 @@ export function hookBody(hook, cmds = {}) {
       if (cmds.lint) lines.push(`${cmds.lint} || { echo 'kj harden: lint failed'; exit 1; }`);
       if (cmds.format) lines.push(`${cmds.format} || { echo 'kj harden: format check failed'; exit 1; }`);
       if (!cmds.lint && !cmds.format) lines.push("# (no lint/format command detected for this stack)");
+      lines.push(
+        "# v4 review gate (ENV-C1, opt-in via `kj review --install-gate`):",
+        "# a staged diff only enters with a recorded cross-AI approved verdict.",
+        "if [ -f .karajan/review-gate ]; then",
+        "  if ! command -v kj >/dev/null 2>&1; then",
+        "    echo 'kj: review gate is enabled but kj is not installed — see karajancode.com/docs/getting-started/installation'; exit 1",
+        "  fi",
+        "  kj review --check || { echo 'kj: no approved cross-AI verdict for the staged diff — run `kj review --staged`'; exit 1; }",
+        "fi"
+      );
       return lines.join("\n");
     }
     case "commit-msg":

--- a/tests/harden/review-gate-hook.test.js
+++ b/tests/harden/review-gate-hook.test.js
@@ -1,0 +1,77 @@
+// ENV-C1 (KJC-TSK-0638): the pre-commit hook enforces the cross-AI review
+// gate — but ONLY when the project opts in via the .karajan/review-gate
+// marker. The e2e test runs the real generated hook under sh against a
+// real git repo: no marker → commit passes; marker + no verdict → commit
+// rejected; marker + matching approved verdict → commit passes.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { hookBody, SHEBANG } from "../../src/harden/hook-templates.js";
+import { saveVerdict } from "../../src/review/verdict-store.js";
+
+describe("pre-commit template includes the opt-in review gate", () => {
+  it("guards on the .karajan/review-gate marker and calls kj review --check", () => {
+    const body = hookBody("pre-commit", {});
+    expect(body).toMatch(/\.karajan\/review-gate/);
+    expect(body).toMatch(/kj review --check/);
+    expect(body).toMatch(/kj review --staged/); // actionable message
+  });
+});
+
+describe("review gate e2e (real sh + git)", () => {
+  const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+  let dir, env;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-gate-e2e-"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    const hooksDir = path.join(dir, ".karajan", "hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    // Only the gate block: isolate the behavior under test from lint/format.
+    const gateBlock = hookBody("pre-commit", {}).split("\n")
+      .filter((l) => !l.includes("lint") && !l.includes("format"));
+    fs.writeFileSync(path.join(hooksDir, "pre-commit"), `${SHEBANG}\n${gateBlock.join("\n")}\n`, { mode: 0o755 });
+    execFileSync("git", ["config", "core.hooksPath", ".karajan/hooks"], { cwd: dir });
+    // CI has no global kj install: shim `kj` onto this repo's bin, with an
+    // isolated KARAJAN_HOME so the maintainer's real config never leaks in.
+    const shimDir = path.join(dir, "bin-shim");
+    fs.mkdirSync(shimDir, { recursive: true });
+    fs.writeFileSync(path.join(shimDir, "kj"),
+      `${SHEBANG}\nexec node "${path.join(repoRoot, "bin", "kj.js")}" "$@"\n`, { mode: 0o755 });
+    env = { ...process.env, PATH: `${shimDir}:${process.env.PATH}`, KARAJAN_HOME: path.join(dir, "kj-home") };
+    delete env.CLAUDECODE;
+  });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  function tryCommit(msg) {
+    fs.writeFileSync(path.join(dir, "f.js"), `// ${msg}\n`);
+    execFileSync("git", ["add", "f.js"], { cwd: dir });
+    return spawnSync("git", ["commit", "-m", msg], { cwd: dir, encoding: "utf8", env });
+  }
+
+  it("no marker → commit passes (opt-in only)", () => {
+    const res = tryCommit("feat: no gate");
+    expect(res.status).toBe(0);
+  });
+
+  it("marker + no verdict → commit rejected with actionable message", () => {
+    fs.writeFileSync(path.join(dir, ".karajan", "review-gate"), "");
+    const res = tryCommit("feat: gated");
+    expect(res.status).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/kj review --staged/);
+  });
+
+  it("marker + approved verdict matching the staged diff → commit passes", async () => {
+    fs.writeFileSync(path.join(dir, ".karajan", "review-gate"), "");
+    fs.writeFileSync(path.join(dir, "f.js"), "// approved change\n");
+    execFileSync("git", ["add", "f.js"], { cwd: dir });
+    const staged = execFileSync("git", ["diff", "--cached"], { cwd: dir, encoding: "utf8" });
+    await saveVerdict(dir, staged, { verdict: "approved", reviewer: "codex", issues: [] });
+    const res = spawnSync("git", ["commit", "-m", "feat: approved change"], { cwd: dir, encoding: "utf8", env });
+    expect(`${res.stdout}${res.stderr}`).not.toMatch(/kj review --staged/);
+    expect(res.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## ENV-C1 — Karajan Environment v4 (épica KJC-PCS-0066)

El hook pre-commit de `kj harden` gana el **review gate v4**, condicionado al marcador `.karajan/review-gate`:

- **Con marcador**: el commit solo entra si `kj review --check` encuentra un veredicto cross-AI approved que casa con el diff staged EXACTO (#1219-#1221). Sin kj instalado → falla cerrado con puntero a la instalación (sin sugerir npm — contrato native-tools de Go/Python/PHP intacto).
- **Sin marcador**: el gate no actúa — opt-in explícito, cero fricción para repos hardened existentes.
- `kj review --install-gate`: crea el marcador (git-trackeable — commitéalo y todo el equipo hereda el gate) y avisa si `core.hooksPath` no está configurado.

Con esto el falso verde es **estructuralmente imposible** en repos con el gate: sin review de otra IA, el commit no entra.

Tests: 4 — template contiene el bloque, y e2e con sh+git reales (shim de kj + KARAJAN_HOME aislado, CI-proof): sin marcador pasa, con marcador y sin veredicto rechaza con mensaje accionable, con veredicto que casa entra. Suites harden+review completas: 176/176.