### PR TITLE
feat(env): RAG-first — env install builds missing index, query updates on drift (KJC-TSK-0640)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -128,8 +128,11 @@ export function registerMeta(program, { pkgVersion }) {
   env.command("install")
     .description("Install/refresh the Karajan playbook in CLAUDE.md (Claude) and AGENTS.md (Codex)")
     .option("--target <target>", "claude | codex | both", "both")
+    .option("--no-rag", "Skip building the RAG index when the project has none (ENV-E1)")
     .action(async (flags) => {
-      await envInstallCommand({ flags });
+      await withConfig(pkgVersion, "env-install", flags, async ({ config, logger }) => {
+        await envInstallCommand({ config, logger, flags });
+      });
     });
 
   const rag = program.command("rag").description("Retrieval-augmented search over Karajan plans, onboarding briefs and project code");
@@ -153,6 +156,7 @@ export function registerMeta(program, { pkgVersion }) {
     });
   rag.command("query <text>")
     .description("Run a semantic query against the indexed RAG corpus")
+    .option("--no-rag-update", "Skip the pre-query drift delta-update (ENV-E1)")
     .option("--scope <scope>", "plans | code | onboarding | all (default: all)", "all")
     .option("--top-k <n>", "Number of hits to return (default: 5)", "5")
     .option("--project <slug>", "Filter by project slug. Pass 'all' to query across every indexed project. Default: cwd basename")

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -1,14 +1,40 @@
 /**
- * `kj env install` (ENV-A1, KJC-TSK-0639) — install/refresh the Karajan
- * Environment playbook as a managed block in the host agents' rule files:
- * CLAUDE.md (Claude Code) and AGENTS.md (Codex), from one source.
+ * `kj env install` (ENV-A1/E1, KJC-TSK-0639/0640) — install/refresh the
+ * Karajan Environment playbook as a managed block in the host agents' rule
+ * files (CLAUDE.md, AGENTS.md), and make its step 1 real: when the project
+ * has no RAG index yet, build it (default ON, `--no-rag` opts out).
  */
 import { installPlaybook } from "../environment/playbook.js";
+import { openVecStore, projectSlug, getLastIndexedCommit } from "../rag/vec-store.js";
+import { ragIndexCommand } from "./rag.js";
 
-export async function envInstallCommand({ config = null, flags = {} }) {
+function hasRagIndex(config, projectDir) {
+  const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
+  try { return Boolean(getLastIndexedCommit(db, projectSlug(projectDir))); }
+  finally { db.close(); }
+}
+
+export async function envInstallCommand({ config = null, logger = null, flags = {} }) {
   const projectDir = config?.projectDir || process.cwd();
   const result = await installPlaybook({ projectDir, target: flags.target || "both" });
   console.log(`✓ Karajan playbook installed in: ${result.files.join(", ")}`);
+
+  // ENV-E1: RAG-first — the playbook orders "query the RAG before coding",
+  // so installing the environment guarantees the index exists. An indexing
+  // failure is reported but never blocks the playbook install.
+  if (flags.rag !== false) {
+    try {
+      if (hasRagIndex(config, projectDir)) {
+        console.log("✓ RAG index present");
+      } else {
+        console.log("⏳ no RAG index for this project — building it (first time only)…");
+        await ragIndexCommand({ config, logger, flags: { withSources: true } });
+      }
+    } catch (err) {
+      result.ragError = err.message;
+      console.log(`⚠ RAG index could not be built (${err.message}) — run \`kj rag index --with-sources\` later`);
+    }
+  }
   console.log("  The host agent now follows the method: RAG first, TDD, cross-AI review before commit.");
   return result;
 }

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -6,7 +6,7 @@ import { openVecStore, countChunks, projectSlug, getLastIndexedCommit, setLastIn
 import { makeEmbedder } from "../rag/embedders/factory.js";
 import { indexProject, indexProjectDelta } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
-import { installPostMergeHook } from "../rag/auto-update.js";
+import { installPostMergeHook, maybeAutoUpdate } from "../rag/auto-update.js";
 import { loadGoldenQueries, runEval } from "../rag/eval.js";
 import { getKarajanHome } from "../utils/paths.js";
 
@@ -73,6 +73,11 @@ export async function ragInstallHooksCommand({ config, logger, flags = {} }) {
 
 export async function ragQueryCommand({ text, config, logger, flags = {} }) {
   if (!text) throw new Error("kj rag query: text argument required");
+  // ENV-E1 (KJC-TSK-0640): never serve stale code — delta-update on drift
+  // before searching. Same escape hatches as the pre-run check
+  // (--no-rag-update / config.rag.autoUpdate); failures degrade to a warn
+  // inside maybeAutoUpdate and the query proceeds with the current index.
+  await maybeAutoUpdate({ projectDir: config?.projectDir || process.cwd(), config, logger, flags });
   const db = openDb(config);
   try {
     const topK = Math.max(1, Number(flags.topK) || 5);

--- a/src/rag/indexer.js
+++ b/src/rag/indexer.js
@@ -119,7 +119,14 @@ async function listFiles(dir, predicate) {
  * it as `--with-sources`.
  */
 export async function indexProject(projectDir, { db, embedder, karajanHome, logger = console, withSources = false } = {}) {
-  const totals = { indexed: 0, failed: 0, files: 0 };
+  // KJC-TSK-0640: a full index must stamp HEAD too — without it,
+  // last_indexed_commit stayed null after the FIRST index, so the drift
+  // delta-update (maybeAutoUpdate) never engaged until a manual --since.
+  const totals = { indexed: 0, failed: 0, files: 0, head: null };
+  try {
+    const { stdout } = await execa("git", ["-C", projectDir, "rev-parse", "HEAD"]);
+    totals.head = stdout.trim();
+  } catch { /* not a git repo (or zero commits) — nothing to stamp */ }
   const slug = projectDir.split("/").pop()?.replace(/[^a-zA-Z0-9._-]/g, "-").toLowerCase() || "project";
   await prepareAdapters(detectAdaptersForProject(projectDir), { logger });
   const planRoot = join(karajanHome, PLANS_DIR, slug);

--- a/tests/environment/rag-first.test.js
+++ b/tests/environment/rag-first.test.js
@@ -1,0 +1,55 @@
+// ENV-E1 (KJC-TSK-0640): the playbook's step 1 ("query the RAG before
+// coding") must never point at a missing or stale index — env install
+// builds it when absent, rag query delta-updates on drift before serving.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/rag/vec-store.js", () => ({
+  openVecStore: vi.fn(() => ({ close: vi.fn() })),
+  projectSlug: vi.fn(() => "proj"),
+  getLastIndexedCommit: vi.fn(),
+  setLastIndexedCommit: vi.fn(),
+  countChunks: vi.fn(() => 0),
+}));
+vi.mock("../../src/commands/rag.js", () => ({
+  ragIndexCommand: vi.fn().mockResolvedValue({ ok: true }),
+}));
+vi.mock("../../src/environment/playbook.js", () => ({
+  installPlaybook: vi.fn().mockResolvedValue({ files: ["CLAUDE.md", "AGENTS.md"], target: "both" }),
+}));
+
+import { envInstallCommand } from "../../src/commands/env.js";
+import { getLastIndexedCommit } from "../../src/rag/vec-store.js";
+import { ragIndexCommand } from "../../src/commands/rag.js";
+
+const config = { projectDir: "/tmp/proj", rag: {} };
+
+describe("env install is RAG-first", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("builds the index with sources when the project has none", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    await envInstallCommand({ config, flags: {} });
+    expect(ragIndexCommand).toHaveBeenCalledTimes(1);
+    expect(ragIndexCommand.mock.calls[0][0].flags.withSources).toBe(true);
+  });
+
+  it("does not reindex when an index already exists", async () => {
+    getLastIndexedCommit.mockReturnValue("abc123");
+    await envInstallCommand({ config, flags: {} });
+    expect(ragIndexCommand).not.toHaveBeenCalled();
+  });
+
+  it("--no-rag opts out of index creation", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    await envInstallCommand({ config, flags: { rag: false } });
+    expect(ragIndexCommand).not.toHaveBeenCalled();
+  });
+
+  it("index failure does not break the playbook install (reported, not thrown)", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    ragIndexCommand.mockRejectedValueOnce(new Error("ollama down"));
+    const res = await envInstallCommand({ config, flags: {} });
+    expect(res.files).toContain("CLAUDE.md");
+    expect(res.ragError).toMatch(/ollama down/);
+  });
+});

--- a/tests/environment/rag-query-drift.test.js
+++ b/tests/environment/rag-query-drift.test.js
@@ -1,0 +1,43 @@
+// ENV-E1 (KJC-TSK-0640): rag query must delta-update the index on drift
+// BEFORE searching, passing the caller's flags through so --no-rag-update
+// and config.rag.autoUpdate keep working as escape hatches.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/rag/auto-update.js", () => ({
+  maybeAutoUpdate: vi.fn().mockResolvedValue({ ran: true }),
+  installPostMergeHook: vi.fn(),
+}));
+vi.mock("../../src/rag/vec-store.js", () => ({
+  openVecStore: vi.fn(() => ({ close: vi.fn() })),
+  projectSlug: vi.fn(() => "proj"),
+  getLastIndexedCommit: vi.fn(),
+  setLastIndexedCommit: vi.fn(),
+  countChunks: vi.fn(() => 0),
+}));
+vi.mock("../../src/rag/embedders/factory.js", () => ({ makeEmbedder: vi.fn(() => ({})) }));
+vi.mock("../../src/rag/indexer.js", () => ({ indexProject: vi.fn(), indexProjectDelta: vi.fn() }));
+vi.mock("../../src/rag/retriever.js", () => ({ query: vi.fn().mockResolvedValue([]) }));
+vi.mock("../../src/rag/eval.js", () => ({ loadGoldenQueries: vi.fn(), runEval: vi.fn() }));
+
+import { ragQueryCommand } from "../../src/commands/rag.js";
+import { maybeAutoUpdate } from "../../src/rag/auto-update.js";
+import { openVecStore } from "../../src/rag/vec-store.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("rag query drift check", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("delta-updates before opening the store, passing flags through", async () => {
+    const config = { projectDir: "/tmp/p", rag: {} };
+    const flags = { ragUpdate: false };
+    await ragQueryCommand({ text: "q", config, logger, flags });
+    expect(maybeAutoUpdate).toHaveBeenCalledTimes(1);
+    const call = maybeAutoUpdate.mock.calls[0][0];
+    expect(call.projectDir).toBe("/tmp/p");
+    expect(call.flags).toBe(flags);
+    // ordering: the update ran before the store was opened for the search
+    expect(maybeAutoUpdate.mock.invocationCallOrder[0])
+      .toBeLessThan(openVecStore.mock.invocationCallOrder[0]);
+  });
+});


### PR DESCRIPTION
## ENV-E1 — Karajan Environment v4 (épica KJC-PCS-0066)

El paso 1 del playbook ("consulta el RAG antes de codificar") nunca puede apuntar al vacío ni servir código viejo:

- **`kj env install` es RAG-first**: si el proyecto no tiene índice (`getLastIndexedCommit` null), lo construye con fuentes (default ON, `--no-rag` opt-out). Un fallo de indexado se reporta pero jamás bloquea la instalación del playbook. El comando ahora corre bajo `withConfig` (config+logger reales).
- **`kj rag query` se auto-actualiza por drift**: ejecuta `maybeAutoUpdate` (delta desde last_indexed_commit) ANTES de buscar, con las mismas escotillas del pre-run (`--no-rag-update` / `config.rag.autoUpdate`).
- **Fix de raíz descubierto en el camino**: `indexProject` (índice completo) no devolvía `head`, así que el PRIMER index nunca estampaba `last_indexed_commit` y el drift-check quedaba inerte hasta un `--since` manual. Ahora estampa HEAD (try/catch para repos sin git/commits).

**Probado en vivo**: primera pasada construye el índice y estampa; segunda dice "RAG index present"; `kj rag query` en este repo sirve el código de ENV-B1 recién mergeado con el drift-check silencioso delante.

Tests: 5 nuevos (construye si falta, no reindexa si existe, --no-rag, fallo degradado sin romper install, drift antes de abrir el store con flags pass-through).