### PR TITLE
feat(git): headless sessions stamp reviewer verdict for the v4 gate (KJC-TSK-0643)

### DIFF
--- a/src/git/automation.js
+++ b/src/git/automation.js
@@ -4,6 +4,7 @@
  */
 
 import { addCheckpoint } from "../session/store.js";
+import { stampStagedVerdict } from "../review/verdict-store.js";
 import {
   ensureGitRepo,
   currentBranch,
@@ -271,7 +272,6 @@ export async function finalizeGitAutomation({ config, gitCtx, task, logger, sess
     // ENV-F1: this path only runs after the pipeline's reviewer approved,
     // so stamp that verdict for the staged diff — the v4 pre-commit gate
     // (when the repo opted in) accepts the pipeline's own commit.
-    const { stampStagedVerdict } = await import("../review/verdict-store.js");
     const commitResult = await commitAll(commitMsg, null, {
       beforeCommit: () => stampStagedVerdict({
         projectDir: config?.projectDir || process.cwd(),

--- a/src/git/automation.js
+++ b/src/git/automation.js
@@ -268,7 +268,17 @@ export async function finalizeGitAutomation({ config, gitCtx, task, logger, sess
   let committed = false;
   const commits = [];
   if (config.git.auto_commit) {
-    const commitResult = await commitAll(commitMsg);
+    // ENV-F1: this path only runs after the pipeline's reviewer approved,
+    // so stamp that verdict for the staged diff — the v4 pre-commit gate
+    // (when the repo opted in) accepts the pipeline's own commit.
+    const { stampStagedVerdict } = await import("../review/verdict-store.js");
+    const commitResult = await commitAll(commitMsg, null, {
+      beforeCommit: () => stampStagedVerdict({
+        projectDir: config?.projectDir || process.cwd(),
+        reviewer: config?.reviewer || "pipeline-reviewer",
+        summary: `kj run session ${session?.id || ""}: reviewer approved`.trim(),
+      }),
+    });
     committed = commitResult.committed;
     if (commitResult.commit) {
       commits.push(commitResult.commit);

--- a/src/review/verdict-store.js
+++ b/src/review/verdict-store.js
@@ -12,6 +12,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { runCommand } from "../utils/process.js";
 
 const STORE_DIR = path.join(".karajan", "reviews");
 
@@ -44,6 +45,30 @@ export async function loadVerdict(projectDir, hash) {
   } catch {
     return null;
   }
+}
+
+/**
+ * ENV-F1 (KJC-TSK-0643): headless pipeline sessions call this after staging
+ * and before committing. Their reviewer ALREADY cross-AI-reviewed the work,
+ * so the verdict is recorded for the staged diff and the v4 pre-commit gate
+ * accepts the pipeline's commit. No gate marker → no-op (zero overhead for
+ * repos that never opted in). Raw git only — never a wrapped runner
+ * (KJC-BUG-0115).
+ * @returns {Promise<{stamped: boolean}>}
+ */
+export async function stampStagedVerdict({ projectDir, reviewer, summary = "" }) {
+  const dir = projectDir || process.cwd();
+  try {
+    await fs.access(path.join(dir, ".karajan", "review-gate"));
+  } catch {
+    return { stamped: false };
+  }
+  const res = await runCommand("git", ["diff", "--cached"], { cwd: dir });
+  if (res.exitCode !== 0 || !res.stdout?.trim()) return { stamped: false };
+  await saveVerdict(dir, res.stdout, {
+    verdict: "approved", reviewer, host: "kj-pipeline", issues: [], summary,
+  });
+  return { stamped: true };
 }
 
 /**

--- a/src/roles/commiter-role.js
+++ b/src/roles/commiter-role.js
@@ -57,7 +57,16 @@ export class CommiterRole extends BaseRole {
     }
 
     const msg = commitMessage || buildCommitMessage(task);
-    await commitAll(msg);
+    // ENV-F1 (KJC-TSK-0643): CommiterRole runs after the HU review passed —
+    // stamp the pipeline's verdict so the v4 gate accepts this commit.
+    const { stampStagedVerdict } = await import("../review/verdict-store.js");
+    await commitAll(msg, null, {
+      beforeCommit: () => stampStagedVerdict({
+        projectDir: this.config?.projectDir || process.cwd(),
+        reviewer: this.config?.reviewer || "pipeline-reviewer",
+        summary: "kj pipeline (commiter role): review passed",
+      }),
+    });
     const commitHash = await revParse("HEAD");
 
     // KJC-BUG-0112: no `origin` remote (quickstart scenario) → skip

--- a/src/roles/commiter-role.js
+++ b/src/roles/commiter-role.js
@@ -1,4 +1,5 @@
 import { BaseRole } from "./base-role.js";
+import { stampStagedVerdict } from "../review/verdict-store.js";
 import {
   ensureGitRepo,
   currentBranch,
@@ -59,7 +60,6 @@ export class CommiterRole extends BaseRole {
     const msg = commitMessage || buildCommitMessage(task);
     // ENV-F1 (KJC-TSK-0643): CommiterRole runs after the HU review passed —
     // stamp the pipeline's verdict so the v4 gate accepts this commit.
-    const { stampStagedVerdict } = await import("../review/verdict-store.js");
     await commitAll(msg, null, {
       beforeCommit: () => stampStagedVerdict({
         projectDir: this.config?.projectDir || process.cwd(),

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -229,11 +229,15 @@ function isNothingToCommit(message) {
   return NOTHING_TO_COMMIT_PATTERNS.some((re) => re.test(m));
 }
 
-export async function commitAll(message, cwd = null) {
+export async function commitAll(message, cwd = null, { beforeCommit = null } = {}) {
   const opts = cwd ? { cwd } : {};
   await runGit(["add", "-A"], opts);
   const changed = await hasChanges(cwd);
   if (!changed) return { committed: false };
+  // ENV-F1 (KJC-TSK-0643): runs between staging and committing — the only
+  // window where the staged diff is exactly what the commit will contain
+  // (used to stamp the pipeline's review verdict for the v4 gate).
+  if (beforeCommit) await beforeCommit();
   try {
     await runGit(["commit", "-m", message], opts);
   } catch (err) {

--- a/tests/commiter-role.test.js
+++ b/tests/commiter-role.test.js
@@ -70,7 +70,11 @@ describe("CommiterRole", () => {
     await role.init({ task: "Fix login" });
     await role.run({ task: "Fix login", commitMessage: "fix: resolve login null pointer" });
 
-    expect(git.commitAll).toHaveBeenCalledWith("fix: resolve login null pointer");
+    expect(git.commitAll).toHaveBeenCalledWith(
+      "fix: resolve login null pointer",
+      null,
+      expect.objectContaining({ beforeCommit: expect.any(Function) })
+    );
   });
 
   it("generates commit message from task when not provided", async () => {

--- a/tests/review/stamp-staged-verdict.test.js
+++ b/tests/review/stamp-staged-verdict.test.js
@@ -1,0 +1,46 @@
+// ENV-F1 (KJC-TSK-0643): headless pipeline sessions stamp their (already
+// cross-AI-reviewed) verdict for the staged diff so the v4 pre-commit gate
+// lets the pipeline's own commits through. Gate absent → zero side effects.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { stampStagedVerdict, checkVerdict } from "../../src/review/verdict-store.js";
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-stamp-"));
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+  fs.writeFileSync(path.join(dir, "a.js"), "const x = 1;\n");
+  execFileSync("git", ["add", "-A"], { cwd: dir });
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("stampStagedVerdict", () => {
+  it("no gate marker → does nothing", async () => {
+    const res = await stampStagedVerdict({ projectDir: dir, reviewer: "codex" });
+    expect(res.stamped).toBe(false);
+    expect(fs.existsSync(path.join(dir, ".karajan", "reviews"))).toBe(false);
+  });
+
+  it("gate marker + staged changes → approved verdict the gate accepts", async () => {
+    fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".karajan", "review-gate"), "");
+    const res = await stampStagedVerdict({ projectDir: dir, reviewer: "codex", summary: "pipeline reviewer approved" });
+    expect(res.stamped).toBe(true);
+    const staged = execFileSync("git", ["diff", "--cached"], { cwd: dir, encoding: "utf8" });
+    const check = await checkVerdict(dir, staged);
+    expect(check.ok).toBe(true);
+    expect(check.verdict.reviewer).toBe("codex");
+    expect(check.verdict.host).toBe("kj-pipeline");
+  });
+
+  it("gate marker but empty staged diff → does not stamp", async () => {
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false", "commit", "-qm", "seed"], { cwd: dir });
+    fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".karajan", "review-gate"), "");
+    const res = await stampStagedVerdict({ projectDir: dir, reviewer: "codex" });
+    expect(res.stamped).toBe(false);
+  });
+});


### PR DESCRIPTION
## ENV-F1 — Karajan Environment v4 (épica KJC-PCS-0066)

Cierra el conflicto headless↔gate: en un repo con `.karajan/review-gate`, los commits de `kj run` eran rechazados por el pre-commit aunque el reviewer interno del pipeline YA hubiera aprobado cruzado. Ahora el pipeline **registra su veredicto** para el diff staged exacto antes de commitear:

- `stampStagedVerdict({projectDir, reviewer, summary})` en verdict-store: no-op sin el marcador del gate (cero overhead); con marcador, persiste approved con `host: "kj-pipeline"` y el hash del staged crudo.
- `commitAll` gana un hook `beforeCommit` — la única ventana donde el diff staged es exactamente lo que contendrá el commit.
- Cableado en los DOS caminos post-review: `finalizeGitAutomation` (auto_commit tras aprobación) y `CommiterRole`. Los caminos ci-early (push ANTES del reviewer, opt-in minoritario) quedan fuera a propósito: estampar ahí sería mentir — limitación documentada.

Desarrollado bajo el entorno v4 (este commit entró con veredicto codex `46c4e22cc3d5`). Tests: 3 nuevos del stamp (no-op sin marcador, approved que el gate acepta, staged vacío) + assert de commiter-role actualizado. Suites review+git+commiter 108/108.