### PR TITLE
chore(release): v4.0.0 — Karajan Environment (KJC-TSK-0644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-07-20
+
+Major. **Karajan v4 is an ENVIRONMENT: the host agent orchestrates, Karajan governs.** Born from a real-world demo where the subprocess loop produced an integral false green (5 "approved" iterations with zero reviewer passes — fixed in 3.15.3) while three days of the inverse model (a human tasking a host agent under deterministic gates) never let a single error through. v4 makes that inverse model the product: you work with Claude Code or Codex as the orchestrator, and Karajan installs the method, the tools and the git gates that make a false green structurally impossible. Everything ships additively — the subprocess runtime continues as the headless mode with the same gates, and no existing config breaks.
+
+### Added
+
+- **`kj env install`** — installs the Karajan playbook as a managed block in the host agents' rule files (CLAUDE.md for Claude Code, AGENTS.md for Codex) from ONE source: RAG before coding, card first, TDD, cross-AI review before committing, security checklist, atomic PRs. Under 60 lines by test; user content outside the block is never touched; re-running is idempotent. It is also RAG-first: when the project has no index, it builds one (`--no-rag` opts out).
+- **`kj review --staged`** — reviews the staged diff with an AI **different from the host** (host detected via environment; a configured reviewer that matches the host is overridden; no cross reviewer available is an error, never a silent same-AI fallback) and records the verdict in `.karajan/reviews/<sha256-of-the-raw-diff>.json`. The hash ties the verdict to byte-exact content: change the code and the verdict is void — resolve-until-pass by construction. `--check` verifies the staged diff has an approved verdict (exit 0/1, hook-friendly), `--range` reviews a git range, `--install-gate` enables the gate.
+- **Pre-commit review gate** (opt-in via `kj review --install-gate`, marker tracked in git so the whole team inherits it): without an approved cross-AI verdict matching the staged diff, **the commit does not enter**. Fails closed when kj is missing.
+- **`state_backend`** (`hu-board` | `planning-game`, default `hu-board`) — where work items live; the playbook's "card first" step names the chosen backend.
+- **`kj rag query` drift update** — before searching, the index delta-updates from the last indexed commit, so retrieval never serves stale code (`--no-rag-update` opts out). Full indexing now stamps the HEAD commit — previously the FIRST full index never armed the drift check.
+- **Headless verdict stamping** — `kj run` sessions record their internal reviewer's verdict for the staged diff before committing, so pipeline commits pass the v4 gate in gated repos.
+
+### Changed
+
+- **karajan-code itself now runs under the v4 environment**: every commit to this repo requires an approved cross-AI verdict. The activation commit was the first one governed — codex rejected the initial version with two legitimate issues before approving.
+- RTK is never used for internal git/diff plumbing (see 3.15.3); detection remains so agents can use it in their own shell.
+
 ## [3.15.3] - 2026-07-19
 
 Patch. **The integral false green found by the complex real demo is fixed — the last 3.x release before v4.** A 5-iteration run that ended "approved" with zero reviewer passes, zero post-loop stages and zero push can no longer happen: every layer of that chain is closed.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@
 
 ---
 
-> **v3.7.1 released** — Patch: fixes a `kj init` crash when configuring the Plan B fallback, and makes pnpm installs safe — `kj doctor` now flags when pnpm skipped `better-sqlite3`'s native build and tells you exactly how to fix it (`pnpm approve-builds better-sqlite3`). The release gate checks pnpm too. Built on **v3.7.0 — Autonomous delivery**: `kj autorun <spec>` chains spec → plan → run every user story → outcome in one command, unattended, with an **Arbiter** that resolves agent conflicts by picking the least-bad call; autonomy is opt-in, interactive runs are unchanged. Full notes in [CHANGELOG.md](CHANGELOG.md).
+> **v4.0.0 released — Karajan Environment.** The host agent orchestrates, Karajan governs. Work with Claude Code or Codex as your orchestrator; Karajan installs the method (`kj env install`), routes every diff through a review by a DIFFERENT AI (`kj review --staged`), and enforces it with a git pre-commit gate: without an approved cross-AI verdict tied to the exact staged diff, **the commit does not enter**. A false green becomes structurally impossible. The classic subprocess pipeline continues as the headless mode with the same gates. Full notes in [CHANGELOG.md](CHANGELOG.md).
 
 You describe what you want to build. Karajan orchestrates multiple AI agents to plan it, implement it, test it, review it with SonarQube, and iterate. No babysitting required.
+
+## v4: the Karajan Environment
+
+Since v4, Karajan attaches to the agent you already work with instead of driving everything by subprocess:
+
+1. **`kj env install`** — writes the Karajan method into your agent's rule file (CLAUDE.md for Claude Code, AGENTS.md for Codex, same single source): query the project RAG before coding, card first, TDD, cross-AI review before committing, security checklist. It also builds the project's RAG index if missing.
+2. **`kj review --staged`** — your diff is reviewed by an AI **different from your orchestrator** (Claude orchestrates → Codex reviews, and vice versa). The verdict is recorded, tied to the sha256 of the exact diff: change the code and it must be reviewed again.
+3. **`kj review --install-gate`** — enables the pre-commit gate. From then on, commits without an approved cross-AI verdict are rejected by git itself. The marker is tracked, so the whole team inherits the contract.
+
+This repo runs under its own environment: every commit to karajan-code carries a cross-AI verdict.
 
 ## What is Karajan?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "3.15.3",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "3.15.3",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "3.15.3",
+  "version": "4.0.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Release v4.0.0 — cierre de la épica KJC-PCS-0066

Bump a 4.0.0 + CHANGELOG major + README con el banner v4 y la sección "v4: the Karajan Environment" (sustituye el banner obsoleto de v3.7.1).

**La narrativa**: el anfitrión orquesta, Karajan gobierna. Playbook desde fuente única (`kj env install`), review cross-AI con veredicto ligado al sha256 del diff (`kj review --staged`), gate pre-commit opt-in que hace el falso verde estructuralmente imposible, RAG-first con drift-update, `state_backend` y headless estampando veredictos. Todo aditivo — cero breaking en configs existentes; el subprocess sigue como modo headless.

Gates pre-release: **verify-pack 4.0.0 verde** (npm/global/pnpm/smoke); quickstart gate con coder real en curso. Este commit de release entró con veredicto cross-AI `ed3f522d042e` (codex), como todos los del repo desde #1225.

Tras el merge: npm publish (OTP) → tag v4.0.0 → GH Release + binarios SEA → deploy de la landing (PR #120 lista) → cards PG → memoria.