### PR TITLE
feat(harden): generated hooks chain to the previous global hooks dir (KJC-TSK-0645)

### DIFF
--- a/src/harden/harden-engine.js
+++ b/src/harden/harden-engine.js
@@ -38,6 +38,19 @@ export async function installHooks({
   const hooks = PROFILE_HOOKS[profile];
   if (!hooks) throw new Error(`Unknown harden profile: ${profile}`);
 
+  // KJC-TSK-0645: setting a repo-local hooksPath ECLIPSES the machine's
+  // global hooks dir — personal guards (AI-attribution commit-msg, protected
+  // branch pre-push) would silently stop applying here. Detect the previous
+  // global dir and have every generated hook chain to it. `~` is emitted as
+  // `$HOME` so the committed hook stays portable across machines (the -x
+  // guard silences it where the dir doesn't exist).
+  let globalHooksDir = null;
+  const globalCfg = await runCommand("git", ["config", "--global", "core.hooksPath"], { cwd: projectDir });
+  const rawGlobal = globalCfg.exitCode === 0 ? globalCfg.stdout.trim() : "";
+  if (rawGlobal && rawGlobal !== HOOKS_DIR) {
+    globalHooksDir = rawGlobal.startsWith("~") ? `$HOME${rawGlobal.slice(1)}` : rawGlobal;
+  }
+
   const absHooksDir = join(projectDir, HOOKS_DIR);
   const results = [];
   for (const hook of hooks) {
@@ -47,7 +60,7 @@ export async function installHooks({
       source,
       blockId: `hook:${hook}`,
       version: BLOCK_VERSION,
-      body: hookBody(hook, cmds),
+      body: hookBody(hook, cmds, { globalHooksDir }),
       style: "hash",
     });
     results.push({ hook, target, action });

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -21,7 +21,23 @@ export const PROFILE_HOOKS = {
 };
 
 /** Build the managed body for a single hook. */
-export function hookBody(hook, cmds = {}) {
+// KJC-TSK-0645: `core.hooksPath .karajan/hooks` eclipses the user's global
+// hooks dir, silently disabling personal guards. When a previous global dir
+// is known, every generated hook ends by chaining its namesake there —
+// guarded, so machines without it are unaffected.
+function chainToGlobal(hook, globalHooksDir) {
+  if (!globalHooksDir) return [];
+  return [
+    "# Chain the machine's previous global hook (kj harden keeps it active).",
+    `if [ -x "${globalHooksDir}/${hook}" ]; then`,
+    `  "${globalHooksDir}/${hook}" "$@"; rc=$?`,
+    '  [ "$rc" -eq 0 ] || exit "$rc"',
+    "fi",
+  ];
+}
+
+export function hookBody(hook, cmds = {}, { globalHooksDir = null } = {}) {
+  const chain = chainToGlobal(hook, globalHooksDir);
   switch (hook) {
     case "pre-commit": {
       const lines = ["# Lint + format the working tree with the project's native tools."];
@@ -38,7 +54,7 @@ export function hookBody(hook, cmds = {}) {
         "  kj review --check || { echo 'kj: no approved cross-AI verdict for the staged diff — run `kj review --staged`'; exit 1; }",
         "fi"
       );
-      return lines.join("\n");
+      return [...lines, ...chain].join("\n");
     }
     case "commit-msg":
       // Pure POSIX — Conventional Commits header, length cap, AI-attribution.
@@ -52,6 +68,7 @@ export function hookBody(hook, cmds = {}) {
         `if grep -qiE '${AI_ATTRIBUTION}' "$msg_file"; then`,
         "  echo 'kj harden: AI attribution is not allowed in commit messages'; exit 1",
         "fi",
+        ...chain,
       ].join("\n");
     case "pre-push": {
       const lines = [
@@ -64,7 +81,7 @@ export function hookBody(hook, cmds = {}) {
       ];
       if (cmds.test) lines.push(`${cmds.test} || { echo 'kj harden: tests failed'; exit 1; }`);
       else lines.push("# (no test command detected for this stack)");
-      return lines.join("\n");
+      return [...lines, ...chain].join("\n");
     }
     case "post-merge":
       return [
@@ -72,6 +89,7 @@ export function hookBody(hook, cmds = {}) {
         "if command -v kj >/dev/null 2>&1; then",
         "  kj rag index --since auto >/dev/null 2>&1 || true",
         "fi",
+        ...chain,
       ].join("\n");
     default:
       throw new Error(`Unknown hook: ${hook}`);

--- a/tests/harden/chain-global.test.js
+++ b/tests/harden/chain-global.test.js
@@ -1,0 +1,58 @@
+// KJC-TSK-0645: kj harden points core.hooksPath at .karajan/hooks, which
+// ECLIPSES the user's global hooks dir — silently disabling personal guards
+// (AI-attribution commit-msg, protected-branch pre-push). Reproduced twice
+// in the field. The generated hooks must chain the previous global hook,
+// guarded so machines without one are unaffected.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { hookBody, PROFILE_HOOKS } from "../../src/harden/hook-templates.js";
+import { installHooks } from "../../src/harden/harden-engine.js";
+
+describe("hookBody chain-to-global", () => {
+  it("every profile hook delegates to the global hook when a dir is given", () => {
+    for (const hook of PROFILE_HOOKS.standard) {
+      const body = hookBody(hook, {}, { globalHooksDir: "$HOME/.git-hooks" });
+      expect(body).toContain(`[ -x "$HOME/.git-hooks/${hook}" ]`);
+      expect(body).toContain(`"$HOME/.git-hooks/${hook}" "$@"; rc=$?`);
+      expect(body).toContain('[ "$rc" -eq 0 ] || exit "$rc"');
+    }
+  });
+
+  it("no global dir → no chain block", () => {
+    expect(hookBody("commit-msg", {})).not.toMatch(/Chain the machine/);
+  });
+});
+
+describe("installHooks detects the previous global hooksPath (e2e)", () => {
+  let dir, fakeGitConfig, prevEnv;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-chain-"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+    // Never touch the developer's real ~/.gitconfig: point git at a fake one.
+    fakeGitConfig = path.join(dir, "fake-gitconfig");
+    fs.writeFileSync(fakeGitConfig, "[core]\n\thooksPath = ~/.git-hooks\n");
+    prevEnv = process.env.GIT_CONFIG_GLOBAL;
+    process.env.GIT_CONFIG_GLOBAL = fakeGitConfig;
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+    else process.env.GIT_CONFIG_GLOBAL = prevEnv;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("generated hooks chain to the detected global dir", async () => {
+    await installHooks({ projectDir: dir });
+    const commitMsg = fs.readFileSync(path.join(dir, ".karajan", "hooks", "commit-msg"), "utf8");
+    expect(commitMsg).toContain('[ -x "$HOME/.git-hooks/commit-msg" ]');
+  });
+
+  it("no global hooksPath configured → hooks have no chain block", async () => {
+    fs.writeFileSync(fakeGitConfig, "");
+    await installHooks({ projectDir: dir });
+    const commitMsg = fs.readFileSync(path.join(dir, ".karajan", "hooks", "commit-msg"), "utf8");
+    expect(commitMsg).not.toMatch(/Chain the machine/);
+  });
+});


### PR DESCRIPTION
## Fricción de campo, reproducida dos veces en dos días

`kj harden` fija `core.hooksPath .karajan/hooks` y eso **eclipsa el directorio global de hooks del usuario** — sus guards personales (commit-msg anti-atribución IA, pre-push de ramas protegidas) dejaban de aplicar en silencio. Nos pasó al activar el v4 en karajan-code (codex lo cazó en review) y hoy lo detectó también la primera sesión externa de Claude que instaló el entorno.

Ahora `installHooks` detecta `git config --global core.hooksPath` y **cada hook generado encadena a su homónimo global al final**: guard `-x` (máquinas sin el dir → no-op), args propagados y **exit code real re-emitido** (captura `rc` — exigido por codex en la primera review de este mismo PR, que rechazó el `|| exit 1` por colapsar el código). La tilde se emite como `$HOME` para que el hook commiteado sea portable.

Tests: 4 nuevos — todos los hooks del perfil llevan el chain cuando hay dir global, sin dir no hay bloque, y e2e con `GIT_CONFIG_GLOBAL` falso (jamás toca el gitconfig real del desarrollador) verificando detección y ausencia. Suite harden 96/96.

Commit con veredicto cross-AI `f3086d0619da`.