### PR TITLE
feat(env): branch-first — playbook step + base-branch guard in pre-commit (KJC-TSK-0648)

### DIFF
--- a/.karajan/hooks/pre-commit
+++ b/.karajan/hooks/pre-commit
@@ -6,6 +6,14 @@ npm run -s lint || { echo 'kj harden: lint failed'; exit 1; }
 npm run -s format:check || { echo 'kj harden: format check failed'; exit 1; }
 # <<< kj:managed:hook:pre-commit <<<
 
+# Branch-first guard (KJC-TSK-0648) — main only moves via PR.
+if [ "$KJ_ALLOW_BASE_COMMIT" != "1" ]; then
+  current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ "$current_branch" = "main" ]; then
+    echo 'kj harden: direct commits on main are not allowed — create a branch and open a PR (KJ_ALLOW_BASE_COMMIT=1 to override)'; exit 1
+  fi
+fi
+
 # v4 review gate (ENV-C1, KJC-TSK-0641): a staged diff only enters with a
 # recorded cross-AI approved verdict. Disable by removing .karajan/review-gate.
 if [ -f .karajan/review-gate ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
 5. **Security checklist** (you absorb the security role): validate all inputs,
    never commit secrets or keys, no deprecated APIs, parameterized queries,
    sanitize anything user-controlled before it reaches HTML/shell/SQL.
-6. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
+6. **Branch first**: never commit on the base branch — create a branch per
+   task/bug and every change reaches the base only through a PR.
+7. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
    compiles and passes tests on its own.
 
 Useful commands: `kj rag query` · `kj review --staged` · `kj review --check` ·

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
 5. **Security checklist** (you absorb the security role): validate all inputs,
    never commit secrets or keys, no deprecated APIs, parameterized queries,
    sanitize anything user-controlled before it reaches HTML/shell/SQL.
-6. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
+6. **Branch first**: never commit on the base branch — create a branch per
+   task/bug and every change reaches the base only through a PR.
+7. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
    compiles and passes tests on its own.
 
 Useful commands: `kj rag query` · `kj review --staged` · `kj review --check` ·

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { loadConfig } from "../config.js";
 import { compareHarden, formatAdvisoryReport } from "../harden/advisory.js";
 import { interactiveHarden } from "../harden/interactive.js";
 import { createWizard, isTTY } from "../utils/wizard.js";
@@ -125,7 +126,6 @@ export async function hardenCommand({
   // harden keeps working on repos that never ran kj init.
   let baseBranch = "main";
   try {
-    const { loadConfig } = await import("../config.js");
     baseBranch = (await loadConfig(projectDir))?.base_branch || "main";
   } catch { /* no kj config — default stands */ }
   let result;

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -120,9 +120,17 @@ export async function hardenCommand({
 
   const roots = detectStackRoots(projectDir, { only: onlyDirs, exclude: excludeDirs });
   const cmds = await resolveCmds(projectDir, roots[0]?.language ?? null);
+  // KJC-TSK-0648: branch-first guard — the base branch only moves via PR.
+  // Resolved from the project's kj config (default "main"); best-effort so
+  // harden keeps working on repos that never ran kj init.
+  let baseBranch = "main";
+  try {
+    const { loadConfig } = await import("../config.js");
+    baseBranch = (await loadConfig(projectDir))?.base_branch || "main";
+  } catch { /* no kj config — default stands */ }
   let result;
   try {
-    result = await installHooks({ projectDir, profile, cmds, dryRun });
+    result = await installHooks({ projectDir, profile, cmds, dryRun, baseBranch });
   } catch (err) {
     if (json) logger.info?.(JSON.stringify({ ok: false, error: err.message }));
     else logger.error?.(`kj harden: ${err.message}`);

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -41,7 +41,9 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
 5. **Security checklist** (you absorb the security role): validate all inputs,
    never commit secrets or keys, no deprecated APIs, parameterized queries,
    sanitize anything user-controlled before it reaches HTML/shell/SQL.
-6. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
+6. **Branch first**: never commit on the base branch — create a branch per
+   task/bug and every change reaches the base only through a PR.
+7. **Ship small**: Conventional Commits, atomic PRs (~150 net lines), each PR
    compiles and passes tests on its own.
 
 Useful commands: \`kj rag query\` · \`kj review --staged\` · \`kj review --check\` ·

--- a/src/harden/harden-engine.js
+++ b/src/harden/harden-engine.js
@@ -33,6 +33,7 @@ export async function installHooks({
   profile = "standard",
   cmds = {},
   dryRun = false,
+  baseBranch = null,
 } = {}) {
   if (!isGitRepo(projectDir)) throw new Error(`Not a git repository: ${projectDir}`);
   const hooks = PROFILE_HOOKS[profile];
@@ -60,7 +61,7 @@ export async function installHooks({
       source,
       blockId: `hook:${hook}`,
       version: BLOCK_VERSION,
-      body: hookBody(hook, cmds, { globalHooksDir }),
+      body: hookBody(hook, cmds, { globalHooksDir, baseBranch }),
       style: "hash",
     });
     results.push({ hook, target, action });

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -36,11 +36,27 @@ function chainToGlobal(hook, globalHooksDir) {
   ];
 }
 
-export function hookBody(hook, cmds = {}, { globalHooksDir = null } = {}) {
+// KJC-TSK-0648: branch-first, enforced. The first external session of the
+// v4 environment committed on local main following literal instructions —
+// the playbook now orders "branch first" and this guard backs it up.
+function baseBranchGuard(baseBranch) {
+  if (!baseBranch) return [];
+  return [
+    "# Branch-first guard — the base branch only moves via PR.",
+    'if [ "$KJ_ALLOW_BASE_COMMIT" != "1" ]; then',
+    '  current_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")',
+    `  if [ "$current_branch" = "${baseBranch}" ]; then`,
+    `    echo 'kj harden: direct commits on ${baseBranch} are not allowed — create a branch and open a PR (KJ_ALLOW_BASE_COMMIT=1 to override)'; exit 1`,
+    "  fi",
+    "fi",
+  ];
+}
+
+export function hookBody(hook, cmds = {}, { globalHooksDir = null, baseBranch = null } = {}) {
   const chain = chainToGlobal(hook, globalHooksDir);
   switch (hook) {
     case "pre-commit": {
-      const lines = ["# Lint + format the working tree with the project's native tools."];
+      const lines = [...baseBranchGuard(baseBranch), "# Lint + format the working tree with the project's native tools."];
       if (cmds.lint) lines.push(`${cmds.lint} || { echo 'kj harden: lint failed'; exit 1; }`);
       if (cmds.format) lines.push(`${cmds.format} || { echo 'kj harden: format check failed'; exit 1; }`);
       if (!cmds.lint && !cmds.format) lines.push("# (no lint/format command detected for this stack)");

--- a/tests/harden/branch-first.test.js
+++ b/tests/harden/branch-first.test.js
@@ -1,0 +1,67 @@
+// KJC-TSK-0648: branch-first in both layers. The playbook must ORDER it
+// (a host following instructions to the letter committed the v4 contract
+// on local main — first external session, 2026-07-20), and the pre-commit
+// must ENFORCE it: commits on the base branch are rejected unless the
+// explicit escape hatch is set.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { renderPlaybook } from "../../src/environment/playbook.js";
+import { hookBody, SHEBANG } from "../../src/harden/hook-templates.js";
+
+describe("playbook orders branch-first", () => {
+  it("contains an explicit branch-first step", () => {
+    const text = renderPlaybook({});
+    expect(text).toMatch(/Branch first/i);
+    expect(text).toMatch(/never commit on the base branch/i);
+  });
+});
+
+describe("pre-commit base-branch guard (real sh + git)", () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-bf-"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: dir });
+    execFileSync("git", ["config", "user.name", "T"], { cwd: dir });
+    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
+    const hooksDir = path.join(dir, ".karajan", "hooks");
+    fs.mkdirSync(hooksDir, { recursive: true });
+    // Guard block only — it is emitted first, so slice up to the lint
+    // section (a line filter would orphan `fi`s from later blocks).
+    const all = hookBody("pre-commit", {}, { baseBranch: "main" }).split("\n");
+    const guard = all.slice(0, all.findIndex((l) => l.startsWith("# Lint")));
+    fs.writeFileSync(path.join(hooksDir, "pre-commit"), `${SHEBANG}\n${guard.join("\n")}\n`, { mode: 0o755 });
+    execFileSync("git", ["config", "core.hooksPath", ".karajan/hooks"], { cwd: dir });
+  });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  function tryCommit(msg, env = {}) {
+    fs.writeFileSync(path.join(dir, "f.js"), `// ${msg}\n`);
+    execFileSync("git", ["add", "f.js"], { cwd: dir });
+    return spawnSync("git", ["commit", "-m", msg], { cwd: dir, encoding: "utf8", env: { ...process.env, ...env } });
+  }
+
+  it("rejects a commit on the base branch with an actionable message", () => {
+    const res = tryCommit("feat: on main");
+    expect(res.status).not.toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/create a branch/i);
+  });
+
+  it("KJ_ALLOW_BASE_COMMIT=1 lets the commit through (explicit escape hatch)", () => {
+    const res = tryCommit("feat: release on main", { KJ_ALLOW_BASE_COMMIT: "1" });
+    expect(res.status).toBe(0);
+  });
+
+  it("does not act on a feature branch", () => {
+    execFileSync("git", ["checkout", "-q", "-b", "feat/x"], { cwd: dir });
+    const res = tryCommit("feat: on branch");
+    expect(res.status).toBe(0);
+  });
+
+  it("no baseBranch option → no guard block generated", () => {
+    expect(hookBody("pre-commit", {})).not.toMatch(/KJ_ALLOW_BASE_COMMIT/);
+  });
+});


### PR DESCRIPTION
## Hueco detectado por la primera sesión externa del entorno v4

Una sesión de Claude siguiendo instrucciones literales commiteó el contrato v4 en su main local: el playbook decía "PRs atómicas" pero nunca **ordenaba la mecánica**, y ningún guard lo impedía. Cerrado en las dos capas de la filosofía v4:

- **Playbook**: paso nuevo "Branch first: never commit on the base branch — create a branch per task/bug and every change reaches the base only through a PR" (los bloques del propio repo regenerados; sigue ≤60 líneas por test).
- **Guard determinista**: el pre-commit de harden rechaza commits en la `base_branch` del config de kj (default main) con mensaje accionable; `KJ_ALLOW_BASE_COMMIT=1` como escotilla explícita (releases/hotfixes); en ramas feature no actúa; detached HEAD (rebase) no bloquea. El hook artesanal de karajan-code gana el mismo guard.
- Wiring: `installHooks({baseBranch})` ← `hardenCommand` lo resuelve del config de kj (best-effort, default main sin kj init).

Tests: 4 nuevos con sh+git reales (rechazo en main con mensaje, escotilla, no-op en feature branch, sin opción no hay bloque). Suites harden+environment 118/118.

Commit con veredicto cross-AI `51405e588459` — codex approved a la primera esta vez.