### PR TITLE
feat(review): solomon arbitration core — third-AI rules on rejected verdicts (KJC-TSK-0651, 1/2)

### DIFF
--- a/src/review/solomon-arbitration.js
+++ b/src/review/solomon-arbitration.js
@@ -1,0 +1,102 @@
+/**
+ * Solomon arbitration (AB-E, KJC-TSK-0651) — when the brain (host agent)
+ * disagrees with the reviewer's verdict, a THIRD AI arbitrates and its
+ * ruling is recorded in the verdict store, tied to the exact diff.
+ *
+ * Hard rules:
+ *  - brain ≠ reviewer ≠ solomon. Two-agent machines get an actionable
+ *    error — self-arbitration would void the whole point.
+ *  - Security issues from the reviewer are NEVER overridable (inherited
+ *    from the pipeline's Solomon): the arbiter is not even consulted.
+ *  - An approve ruling writes an approved verdict (`solomon:<agent>`) for
+ *    the same diff hash, so the pre-commit gate opens structurally; a
+ *    reject keeps it closed. Both record the full conflict for audit.
+ */
+import { createAgent } from "../agents/index.js";
+import { parseMaybeJsonString } from "./parser.js";
+import { detectAvailableAgents, detectHostAgent } from "../utils/agent-detect.js";
+import { diffHash, loadVerdict, saveVerdict } from "./verdict-store.js";
+
+const SECURITY_PATTERN = /injection|xss|csrf|secret|credential|password|token leak|auth(entication|orization)?|crypt|session|sanitiz|traversal|rce\b/i;
+
+// Structured signal first (`category: "security"` — part of the reviewer's
+// JSON schema since AB-E); the free-text pattern stays as a fail-closed net
+// for verdicts recorded before the schema carried categories.
+function isSecurityIssue(issue) {
+  return issue.category === "security"
+    || SECURITY_PATTERN.test(`${issue.id || ""} ${issue.description || ""}`);
+}
+
+export async function pickThirdParty({ config, hostAgent, reviewerAgent, detectAgents = detectAvailableAgents }) {
+  const excluded = new Set([hostAgent, reviewerAgent]);
+  const configured = config?.roles?.solomon?.provider;
+  const agents = await detectAgents();
+  const candidates = agents.filter((a) => a.available && !excluded.has(a.name)).map((a) => a.name);
+  if (configured && candidates.includes(configured)) return configured;
+  return candidates[0] || null;
+}
+
+export async function runSolomonArbitration({
+  diff, position, config, logger, projectDir,
+  hostAgent = detectHostAgent(),
+  createAgentFn = createAgent,
+  detectAgents = detectAvailableAgents,
+}) {
+  if (!position || !position.trim()) {
+    throw new Error("kj solomon requires --position \"<why you disagree with the reviewer>\"");
+  }
+  const verdict = await loadVerdict(projectDir, diffHash(diff));
+  if (!verdict || verdict.verdict !== "rejected") {
+    throw new Error("nothing to arbitrate — there is no rejected verdict for the current diff (run `kj review --staged` first)");
+  }
+
+  // ABSOLUTE RULE: security findings are never overridable.
+  const securityIssues = (verdict.issues || []).filter(isSecurityIssue);
+  if (securityIssues.length > 0) {
+    const record = await saveVerdict(projectDir, diff, {
+      ...verdict,
+      arbitration: { position, ruling: "reject", reasoning: "security issues from the reviewer are never overridable", solomon: null },
+    });
+    return { ruling: "reject", reasoning: "security issues are never overridable — fix them", solomon: null, record };
+  }
+
+  const solomon = await pickThirdParty({ config, hostAgent, reviewerAgent: verdict.reviewer, detectAgents });
+  if (!solomon) {
+    throw new Error(
+      `arbitration requires a third AI distinct from the brain (${hostAgent || "unknown"}) and the reviewer (${verdict.reviewer}) — install a third agent CLI`
+    );
+  }
+
+  const prompt = [
+    "You are Solomon, the neutral arbiter between two AIs in a coding workflow.",
+    "The reviewer REJECTED a diff; the orchestrating brain DISAGREES. Decide who is right.",
+    "Never approve to save time or effort — only if the reviewer's objections are genuinely wrong or immaterial for this diff.",
+    'Return only one JSON object: {"ruling":"approve"|"reject","reasoning":string}. "approve" = the brain is right, the diff may ship as-is. "reject" = the reviewer is right, the brain must fix the issues.',
+    "", "## Reviewer's blocking issues",
+    JSON.stringify(verdict.issues || [], null, 2),
+    "", "## Brain's position", position,
+    "", "## The diff under dispute", diff,
+  ].join("\n");
+
+  logger?.info?.(`kj solomon: brain=${hostAgent || "?"} vs reviewer=${verdict.reviewer} → arbiter=${solomon}`);
+  const agent = createAgentFn(solomon, config, logger);
+  const result = await agent.reviewTask({ prompt, role: "solomon" });
+  if (!result?.ok) throw new Error(`solomon ${solomon} failed: ${result?.error || "no output"}`);
+  const parsed = parseMaybeJsonString(result.output);
+  if (!parsed || !["approve", "reject"].includes(parsed.ruling)) {
+    throw new Error(`solomon ${solomon} returned no parseable ruling`);
+  }
+
+  const arbitration = {
+    position, ruling: parsed.ruling, reasoning: parsed.reasoning || "", solomon,
+    originalVerdict: { reviewer: verdict.reviewer, issues: verdict.issues },
+  };
+  const record = parsed.ruling === "approve"
+    ? await saveVerdict(projectDir, diff, {
+      verdict: "approved", reviewer: `solomon:${solomon}`, host: hostAgent || null,
+      issues: [], summary: `Arbitration overrode ${verdict.reviewer}'s rejection: ${parsed.reasoning || ""}`.trim(), arbitration,
+    })
+    : await saveVerdict(projectDir, diff, { ...verdict, arbitration });
+
+  return { ruling: parsed.ruling, reasoning: parsed.reasoning || "", solomon, record };
+}

--- a/tests/review/solomon-arbitration.test.js
+++ b/tests/review/solomon-arbitration.test.js
@@ -1,0 +1,93 @@
+// AB-E (KJC-TSK-0651): when brain and reviewer clash, a THIRD AI arbitrates.
+// Hard rules under test: the arbiter is never the brain nor the reviewer
+// (2-agent machines get an actionable error, never self-arbitration), an
+// approve ruling opens the gate for the exact diff, and security issues
+// are NEVER overridable — the agent is not even consulted.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pickThirdParty, runSolomonArbitration } from "../../src/review/solomon-arbitration.js";
+import { saveVerdict, checkVerdict } from "../../src/review/verdict-store.js";
+
+const DIFF = "diff --git a/x.js b/x.js\n+const ok = true;\n";
+const agentsUp = (...names) => async () => names.map((name) => ({ name, available: true }));
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-sol-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("pickThirdParty", () => {
+  it("prefers the configured solomon when it differs from brain AND reviewer", async () => {
+    const config = { roles: { solomon: { provider: "gemini" } } };
+    expect(await pickThirdParty({ config, hostAgent: "claude", reviewerAgent: "codex", detectAgents: agentsUp("claude", "codex", "gemini") })).toBe("gemini");
+  });
+
+  it("overrides a configured solomon that matches brain or reviewer", async () => {
+    const config = { roles: { solomon: { provider: "codex" } } };
+    expect(await pickThirdParty({ config, hostAgent: "claude", reviewerAgent: "codex", detectAgents: agentsUp("claude", "codex", "gemini") })).toBe("gemini");
+  });
+
+  it("returns null with only two agents", async () => {
+    expect(await pickThirdParty({ config: {}, hostAgent: "claude", reviewerAgent: "codex", detectAgents: agentsUp("claude", "codex") })).toBeNull();
+  });
+});
+
+describe("runSolomonArbitration", () => {
+  const config = { roles: { solomon: { provider: "gemini" } } };
+  const base = { config, projectDir: null, hostAgent: "claude", detectAgents: agentsUp("claude", "codex", "gemini") };
+  const ruling = (r) => ({ reviewTask: vi.fn().mockResolvedValue({ ok: true, output: JSON.stringify({ ruling: r, reasoning: "because" }) }) });
+
+  async function seedRejected(issues) {
+    await saveVerdict(dir, DIFF, { verdict: "rejected", reviewer: "codex", issues });
+  }
+
+  it("approve ruling records a verdict that opens the gate", async () => {
+    await seedRejected([{ id: "I1", severity: "medium", description: "naming could be better" }]);
+    const agent = ruling("approve");
+    const res = await runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "style-only, tests green", createAgentFn: () => agent });
+    expect(res.ruling).toBe("approve");
+    expect(res.solomon).toBe("gemini");
+    const check = await checkVerdict(dir, DIFF);
+    expect(check.ok).toBe(true);
+    expect(check.verdict.reviewer).toBe("solomon:gemini");
+    expect(check.verdict.arbitration.position).toMatch(/style-only/);
+  });
+
+  it("reject ruling keeps the gate closed and records the arbitration", async () => {
+    await seedRejected([{ id: "I1", severity: "high", description: "off-by-one in loop" }]);
+    const res = await runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "I disagree", createAgentFn: () => ruling("reject") });
+    expect(res.ruling).toBe("reject");
+    expect((await checkVerdict(dir, DIFF)).ok).toBe(false);
+  });
+
+  it("security issues are never overridable — the arbiter is not even consulted", async () => {
+    await seedRejected([{ id: "S1", severity: "critical", description: "SQL injection via unsanitized user input" }]);
+    const agent = ruling("approve");
+    const res = await runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "it is fine", createAgentFn: () => agent });
+    expect(res.ruling).toBe("reject");
+    expect(res.reasoning).toMatch(/security/i);
+    expect(agent.reviewTask).not.toHaveBeenCalled();
+    expect((await checkVerdict(dir, DIFF)).ok).toBe(false);
+  });
+
+  it("structured category blocks arbitration even with neutral wording", async () => {
+    await seedRejected([{ id: "I9", severity: "high", category: "security", description: "input handling could be improved" }]);
+    const agent = ruling("approve");
+    const res = await runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "cosmetic", createAgentFn: () => agent });
+    expect(res.ruling).toBe("reject");
+    expect(agent.reviewTask).not.toHaveBeenCalled();
+  });
+
+  it("errors without a prior rejected verdict (nothing to arbitrate)", async () => {
+    await expect(runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "p" }))
+      .rejects.toThrow(/nothing to arbitrate/i);
+  });
+
+  it("errors with only two agents — never self-arbitration", async () => {
+    await seedRejected([{ id: "I1", severity: "low", description: "minor" }]);
+    await expect(runSolomonArbitration({
+      ...base, projectDir: dir, diff: DIFF, position: "p", detectAgents: agentsUp("claude", "codex"),
+    })).rejects.toThrow(/third/i);
+  });
+});


### PR DESCRIPTION
## AB-E parte 1/2 — Any-Agent Brain (épica KJC-PCS-0067)

*(El PR #1233 original superaba el gate de 200 LOC netas (227); partido en dos — esta parte: 195 netas. #1233 queda cerrado.)*

Núcleo del arbitraje a tres bandas: cuando el brain discrepa de un veredicto rejected, una TERCERA IA falla.

- `pickThirdParty`: brain ≠ reviewer ≠ solomon; el configurado se honra solo si es distinto de ambos; con 2 agentes → null (error accionable en el runner — jamás autoarbitraje).
- `runSolomonArbitration`: exige veredicto rejected previo; **seguridad jamás anulable** — bloquea sobre `category === "security"` estructurada o patrón fail-closed, sin consultar siquiera al árbitro (diseño exigido por codex en la review); approve → veredicto `solomon:<agente>` para el mismo diffHash (el gate abre estructuralmente); reject → cerrado. Conflicto completo auditado.

Parte 2/2 (siguiente PR): CLI `kj solomon --position`, registro advanced y `category` en el schema del reviewer.

Tests: 9. Veredicto cross-AI `cac4ea83e6c4`.