### PR TITLE
feat(cli): kj brief command + playbook names briefs and solomon (KJC-TSK-0652, 2/2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
    compiles and passes tests on its own.
 
 Useful commands: `kj rag query` · `kj review --staged` · `kj review --check` ·
-`kj report` · `kj check`
+`kj brief <role>` (the method of each role you absorb: triage, planner,
+researcher, architect, tester, security, audit) · `kj solomon --position`
+(third-AI arbitration when you disagree with a rejected verdict) · `kj report` · `kj check`
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
    compiles and passes tests on its own.
 
 Useful commands: `kj rag query` · `kj review --staged` · `kj review --check` ·
-`kj report` · `kj check`
+`kj brief <role>` (the method of each role you absorb: triage, planner,
+researcher, architect, tester, security, audit) · `kj solomon --position`
+(third-AI arbitration when you disagree with a rejected verdict) · `kj report` · `kj check`
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,8 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
    compiles and passes tests on its own.
 
 Useful commands: `kj rag query` · `kj review --staged` · `kj review --check` ·
-`kj report` · `kj check`
+`kj brief <role>` (the method of each role you absorb: triage, planner,
+researcher, architect, tester, security, audit) · `kj solomon --position`
+(third-AI arbitration when you disagree with a rejected verdict) · `kj report` · `kj check`
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -28,7 +28,7 @@ export const META_COMMANDS = ["advanced", "help"];
  */
 export const ADVANCED_GROUPS = [
   { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "scan"] },
-  { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard"] },
+  { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "undo", "standby"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -19,7 +19,7 @@ import { checkCommand } from "../commands/check.js";
 import { mutateCommand } from "../commands/mutate.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
-import { envInstallCommand } from "../commands/env.js";
+import { envInstallCommand, briefCommand } from "../commands/env.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
 
@@ -132,6 +132,18 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "env-install", flags, async ({ config, logger }) => {
         await envInstallCommand({ config, logger, flags });
+      });
+    });
+
+  // AB-C (KJC-TSK-0652): role briefs for the brain (any host agent).
+  program
+    .command("brief")
+    .description("Show the distilled method of a pipeline role (for the host agent to execute)")
+    .argument("[role]", "triage | planner | researcher | architect | tester | security | audit")
+    .option("--json", "Machine-readable output")
+    .action(async (role, flags) => {
+      await withConfig(pkgVersion, "brief", flags, async ({ config }) => {
+        briefCommand({ config, flags, role });
       });
     });
 

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -5,6 +5,7 @@
  * has no RAG index yet, build it (default ON, `--no-rag` opts out).
  */
 import { installPlaybook } from "../environment/playbook.js";
+import { renderBrief, listBriefs } from "../environment/briefs.js";
 import { openVecStore, projectSlug, getLastIndexedCommit } from "../rag/vec-store.js";
 import { ragIndexCommand } from "./rag.js";
 
@@ -12,6 +13,24 @@ function hasRagIndex(config, projectDir) {
   const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
   try { return Boolean(getLastIndexedCommit(db, projectSlug(projectDir))); }
   finally { db.close(); }
+}
+
+/**
+ * `kj brief [role]` (AB-C, KJC-TSK-0652) — the distilled method of a role,
+ * for the brain to execute or delegate. No role → list them.
+ */
+export function briefCommand({ config = null, flags = {}, role = null }) {
+  if (!role) {
+    const list = listBriefs();
+    if (flags.json) { console.log(JSON.stringify(list, null, 2)); return list; }
+    console.log("Available role briefs (kj brief <role>):");
+    for (const { role: r, purpose } of list) console.log(`  ${r.padEnd(11)} ${purpose}`);
+    return list;
+  }
+  const text = renderBrief(role, config || {});
+  if (flags.json) { console.log(JSON.stringify({ role, brief: text })); return { role, brief: text }; }
+  console.log(text);
+  return { role, brief: text };
 }
 
 export async function envInstallCommand({ config = null, logger = null, flags = {} }) {

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -56,7 +56,9 @@ You are the orchestrator; Karajan governs the method. Follow this on every task:
    compiles and passes tests on its own.
 
 Useful commands: \`kj rag query\` · \`kj review --staged\` · \`kj review --check\` ·
-\`kj report\` · \`kj check\`
+\`kj brief <role>\` (the method of each role you absorb: triage, planner,
+researcher, architect, tester, security, audit) · \`kj solomon --position\`
+(third-AI arbitration when you disagree with a rejected verdict) · \`kj report\` · \`kj check\`
 `;
 
 export function renderPlaybook({ stateBackend = "hu-board" } = {}) {


### PR DESCRIPTION
## AB-C parte 2/2 — cierra KJC-TSK-0652 (épica KJC-PCS-0067)

Sobre los briefs mergeados en #1236: CLI `kj brief [rol]` (sin argumento lista los 7 roles con su propósito; `--json` disponible), imports estáticos, registro advanced, y la línea de comandos útiles del playbook nombra `kj brief` y `kj solomon` — sin eso, ningún brain los descubriría. Bloques regenerados en los tres anfitriones del repo.

39 netas. Probado en vivo. Veredicto cross-AI `75f4203b29ca`.

**Nota de diseño (decidida con el usuario, para AB-C2 y la doc de AB-G)**: los modelos frontier actuales rinden mejor con objetivo+invariantes+criterio de éxito que con guiones paso a paso. Playbook y briefs evolucionarán a formato **misión + invariantes + entregable** (AB-C2), manteniendo explícitos los contratos del sistema (gates, seguridad innegociable, branch-first) y soltando la microgestión cognitiva.