### PR TITLE
feat(cli): kj agent run — the brain's inter-agent bus (KJC-TSK-0654)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -27,7 +27,7 @@ export const META_COMMANDS = ["advanced", "help"];
  * so a newly-registered command can never silently vanish from `kj advanced`.
  */
 export const ADVANCED_GROUPS = [
-  { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "scan"] },
+  { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -20,6 +20,7 @@ import { mutateCommand } from "../commands/mutate.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { envInstallCommand, briefCommand } from "../commands/env.js";
+import { agentRunCommand } from "../commands/agent-run.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
 
@@ -132,6 +133,18 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "env-install", flags, async ({ config, logger }) => {
         await envInstallCommand({ config, logger, flags });
+      });
+    });
+
+  // AB-D (KJC-TSK-0654): the brain's inter-agent bus.
+  const agentCmd = program.command("agent").description("Delegate work to another AI agent (the brain's bus)");
+  agentCmd.command("run <agent> <task>")
+    .description("Run a task on the named agent and print its output (exit 0/1)")
+    .option("--json", "Machine-readable output: {ok, agent, output, usage}")
+    .option("--timeout-minutes <n>", "Hard timeout for the delegated task")
+    .action(async (agent, task, flags) => {
+      await withConfig(pkgVersion, "agent-run", flags, async ({ config, logger }) => {
+        await agentRunCommand({ agent, task, config, logger, flags });
       });
     });
 

--- a/src/commands/agent-run.js
+++ b/src/commands/agent-run.js
@@ -1,0 +1,63 @@
+/**
+ * `kj agent run <agent> "<task>"` (AB-D, KJC-TSK-0654) — the brain's
+ * inter-agent bus. The host agent decides WHO does WHAT; kj provides the
+ * plumbing it shouldn't have to fight: binary detection, subprocess
+ * workarounds (CLAUDECODE strip, stdin, silence timeouts), usage capture.
+ * The brain reads the output and decides — kj never interprets it.
+ */
+import { createAgent, getAvailableAgents } from "../agents/index.js";
+import { detectAvailableAgents } from "../utils/agent-detect.js";
+
+export async function agentRunCommand({ agent, task, config = {}, logger = null, flags = {} }) {
+  if (!task || !task.trim()) {
+    throw new Error("kj agent run requires a task: kj agent run <agent> \"<task>\"");
+  }
+  const known = getAvailableAgents().map((a) => a.name);
+  const detected = await detectAvailableAgents();
+  const up = detected.filter((a) => a.available).map((a) => a.name).join(", ") || "none";
+  if (!known.includes(agent)) {
+    throw new Error(`unknown agent "${agent}" — supported: ${known.join(", ")}; available on this machine: ${up}`);
+  }
+  const entry = detected.find((a) => a.name === agent);
+  if (!entry?.available) {
+    throw new Error(`agent "${agent}" is not available on this machine (available: ${up}) — install its CLI or pick another`);
+  }
+
+  let timeoutMs;
+  if (flags.timeoutMinutes !== undefined) {
+    const minutes = Number(flags.timeoutMinutes);
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      throw new Error(`--timeout-minutes must be a positive number, got "${flags.timeoutMinutes}"`);
+    }
+    timeoutMs = minutes * 60000;
+  }
+
+  // --json must emit ONLY the serialized result — no informational lines,
+  // and a crash of the delegated subprocess still yields one JSON payload.
+  if (!flags.json) logger?.info?.(`kj agent run: delegating to ${agent}`);
+  const instance = createAgent(agent, config, logger);
+  let result;
+  try {
+    result = await instance.runTask({ prompt: task, role: "delegate", timeoutMs });
+  } catch (err) {
+    result = { ok: false, output: "", error: err.message };
+  }
+
+  const res = {
+    ok: Boolean(result?.ok),
+    agent,
+    output: result?.output || "",
+    error: result?.error || null,
+    usage: result?.tokens_out != null
+      ? { tokens_in: result.tokens_in ?? null, tokens_out: result.tokens_out, cached_tokens: result.cached_tokens ?? null }
+      : null,
+  };
+  if (flags.json) {
+    console.log(JSON.stringify(res));
+  } else {
+    if (res.output) console.log(res.output);
+    if (!res.ok && res.error) console.error(res.error);
+  }
+  process.exitCode = res.ok ? 0 : 1;
+  return res;
+}

--- a/tests/environment/agent-run.test.js
+++ b/tests/environment/agent-run.test.js
@@ -1,0 +1,80 @@
+// AB-D (KJC-TSK-0654): kj agent run is the brain's inter-agent bus — kj
+// provides the plumbing (availability, subprocess workarounds, usage),
+// the brain reads the output and decides.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mirror the REAL registry shape ({name, AgentClass, ...meta} objects) —
+// a string[] mock hid an .includes() bug on first write.
+vi.mock("../../src/agents/index.js", () => ({
+  createAgent: vi.fn(),
+  getAvailableAgents: vi.fn(() =>
+    ["claude", "codex", "gemini", "aider", "opencode"].map((name) => ({ name, AgentClass: class {} }))),
+}));
+vi.mock("../../src/utils/agent-detect.js", () => ({
+  detectAvailableAgents: vi.fn(async () => [
+    { name: "claude", available: true },
+    { name: "codex", available: true },
+    { name: "gemini", available: false },
+  ]),
+}));
+
+import { agentRunCommand } from "../../src/commands/agent-run.js";
+import { createAgent } from "../../src/agents/index.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("kj agent run", () => {
+  beforeEach(() => { vi.clearAllMocks(); process.exitCode = 0; });
+
+  it("runs the task on the requested agent and returns its output", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: true, output: "analysis done", tokens_out: 42 }),
+    });
+    const res = await agentRunCommand({ agent: "codex", task: "analyze X", config: {}, logger, flags: { json: true } });
+    expect(res.ok).toBe(true);
+    expect(res.agent).toBe("codex");
+    expect(res.output).toBe("analysis done");
+    expect(process.exitCode).toBe(0);
+    // --json is a machine contract: nothing but the payload may be logged
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("agent failure → ok:false and exit 1", async () => {
+    createAgent.mockReturnValue({
+      runTask: vi.fn().mockResolvedValue({ ok: false, output: "", error: "boom", exitCode: 2 }),
+    });
+    const res = await agentRunCommand({ agent: "codex", task: "t", config: {}, logger, flags: {} });
+    expect(res.ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("unknown agent → actionable error naming the machine's available agents", async () => {
+    await expect(agentRunCommand({ agent: "cursor", task: "t", config: {}, logger, flags: {} }))
+      .rejects.toThrow(/claude.*codex|available/i);
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("known but unavailable agent → actionable error", async () => {
+    await expect(agentRunCommand({ agent: "gemini", task: "t", config: {}, logger, flags: {} }))
+      .rejects.toThrow(/not available|no está/i);
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("empty task → error", async () => {
+    await expect(agentRunCommand({ agent: "codex", task: "  ", config: {}, logger, flags: {} }))
+      .rejects.toThrow(/task/i);
+  });
+
+  it("a crashing delegate still yields one JSON payload (never a raw exception)", async () => {
+    createAgent.mockReturnValue({ runTask: vi.fn().mockRejectedValue(new Error("spawn failed")) });
+    const res = await agentRunCommand({ agent: "codex", task: "t", config: {}, logger, flags: { json: true } });
+    expect(res).toMatchObject({ ok: false, agent: "codex", error: "spawn failed", usage: null });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("non-numeric --timeout-minutes → actionable error, agent never invoked", async () => {
+    await expect(agentRunCommand({ agent: "codex", task: "t", config: {}, logger, flags: { timeoutMinutes: "foo" } }))
+      .rejects.toThrow(/timeout-minutes must be a positive number/);
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## AB-D — Any-Agent Brain (épica KJC-PCS-0067)

`kj agent run <agente> "<tarea>"`: el brain delega trabajo a otra IA; kj pone la fontanería (registro+disponibilidad con errores que nombran lo instalable Y lo disponible, workarounds de subprocess, timeout validado, usage) y el brain procesa la salida y decide. `--json` es contrato de máquina: SOLO el payload, incluso si el subprocess delegado revienta (try/catch → un único `{ok:false, error}`).

**Probado en vivo**: `kj agent run codex "Reply with exactly PONG"` → PONG.

Ciclo de review notable: codex encadenó **4 rechazos legítimos** (error de agente desconocido sin lista de disponibles → timeout sin validar → --json contaminado por logs → excepción del delegado rompiendo el contrato JSON) — cada uno con test que lo pina. El bus salió endurecido por la IA que viajará en él. Veredicto final `e7da1018a6e7`.

129 netas · 7 tests (mock espejando la forma real del registro — un mock de strings ocultó un bug de .includes() en la primera pasada).