### PR TITLE
feat(env): issue-report core — sanitize, compose, dedup, prefilled URL (KJC-TSK-0655, 1/2)

### DIFF
--- a/src/environment/issue-report.js
+++ b/src/environment/issue-report.js
@@ -1,0 +1,72 @@
+/**
+ * Issue reporting core (AB-F, KJC-TSK-0655) — the self-healing loop: any
+ * user's brain diagnoses a kj friction and reports it to the public repo,
+ * so field feedback reaches the maintainer's board without a human relay.
+ *
+ * A public issue is a privacy boundary. sanitize() strips home paths,
+ * usernames and emails; the composer only ever includes what the brain
+ * explicitly passed (command, error, description) plus kj/node/platform
+ * metadata — never project code.
+ */
+
+export const REPO = "manufosela/karajan-code";
+
+export function sanitize(text) {
+  return String(text || "")
+    // any /home/<user>/ or /Users/<user>/ prefix collapses to ~/
+    .replaceAll(/\/(?:home|Users)\/[^/\s]+/g, "~")
+    // emails never belong in a public issue
+    .replaceAll(/[\w.+-]+@[\w-]+\.[\w.]+/g, "[redacted-email]");
+}
+
+export function composeIssue({ title, description = "", command = "", error = "", env = {} }) {
+  const body = [
+    sanitize(description),
+    command ? `\n**Command:** \`${sanitize(command)}\`` : "",
+    error ? `\n**Error:**\n\`\`\`\n${sanitize(error)}\n\`\`\`` : "",
+    "\n**Environment:**",
+    `- kj ${env.kjVersion || "unknown"}`,
+    `- node ${env.nodeVersion || "unknown"}`,
+    `- ${env.platform || "unknown"}`,
+    "\n---",
+    "_Reported via `kj report-issue` (sanitized: no project code, paths or personal data)._",
+  ].filter(Boolean).join("\n");
+  return { title: sanitize(title), body };
+}
+
+const STOPWORDS = new Set(["the", "a", "an", "is", "are", "from", "with", "for", "and", "not", "kj", "karajan"]);
+
+function meaningfulWords(title) {
+  return title.toLowerCase().split(/[^a-z0-9-]+/)
+    .filter((w) => w.length > 3 && !STOPWORDS.has(w));
+}
+
+/**
+ * Look for open issues that share meaningful title words (≥2 overlaps, or
+ * 1 when the title is short). Read-only public API — no auth needed. Any
+ * failure degrades to [] : dedup must never block reporting.
+ */
+export async function findSimilarIssues(title, { fetchFn = globalThis.fetch } = {}) {
+  try {
+    const res = await fetchFn(`https://api.github.com/repos/${REPO}/issues?state=open&per_page=100`, {
+      headers: { accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) return [];
+    const issues = await res.json();
+    const words = meaningfulWords(title);
+    const needed = Math.min(2, Math.max(1, words.length));
+    return issues.filter((issue) => {
+      const theirs = new Set(meaningfulWords(issue.title || ""));
+      const overlap = words.filter((w) => theirs.has(w)).length;
+      return overlap >= needed;
+    }).map(({ number, title: t, html_url }) => ({ number, title: t, html_url }));
+  } catch {
+    return [];
+  }
+}
+
+/** Prefilled new-issue URL — publishing stays a human click by default. */
+export function newIssueUrl({ title, body }) {
+  const params = new URLSearchParams({ title, body });
+  return `https://github.com/${REPO}/issues/new?${params.toString().replaceAll("+", "%20")}`;
+}

--- a/tests/environment/issue-report.test.js
+++ b/tests/environment/issue-report.test.js
@@ -1,0 +1,73 @@
+// AB-F (KJC-TSK-0655): self-healing by issues. The brain diagnoses; kj
+// composes a SANITIZED report (public output is a privacy boundary: no
+// home paths, no usernames, no emails, never project code) and dedups
+// against the public repo before anything is published.
+import { describe, it, expect, vi } from "vitest";
+import { composeIssue, sanitize, findSimilarIssues, newIssueUrl } from "../../src/environment/issue-report.js";
+
+describe("sanitize", () => {
+  it("redacts home paths, usernames and emails", () => {
+    const dirty = [
+      "Error at /home/manu/ws_npm-packages/karajan-code/src/x.js",
+      "mac path /Users/jcasar/.nvm/versions/node",
+      "contact: someone@example.com",
+    ].join("\n");
+    const clean = sanitize(dirty);
+    expect(clean).not.toMatch(/\/home\/manu|jcasar|someone@example\.com/);
+    expect(clean).toMatch(/~\/ws_npm-packages\/karajan-code\/src\/x\.js/);
+    expect(clean).toMatch(/~\/\.nvm\/versions\/node/);
+    expect(clean).toMatch(/\[redacted-email\]/);
+  });
+
+  it("leaves normal technical content untouched", () => {
+    const text = "better-sqlite3 native addon failed: exit code 1";
+    expect(sanitize(text)).toBe(text);
+  });
+});
+
+describe("composeIssue", () => {
+  it("builds a body with environment metadata and sanitized sections", () => {
+    const { title, body } = composeIssue({
+      title: "MCP fails from SEA binary",
+      command: "kj doctor",
+      error: "better-sqlite3 missing at /home/manu/.local/bin/kj",
+      description: "Installed via curl; doctor FAILs on karajan-mcp.",
+      env: { kjVersion: "4.0.1", nodeVersion: "22.12.0", platform: "darwin-arm64" },
+    });
+    expect(title).toBe("MCP fails from SEA binary");
+    expect(body).toMatch(/kj 4\.0\.1/);
+    expect(body).toMatch(/node 22\.12\.0/);
+    expect(body).toMatch(/darwin-arm64/);
+    expect(body).toMatch(/kj doctor/);
+    expect(body).not.toMatch(/\/home\/manu/);
+    expect(body).toMatch(/reported via `kj report-issue`/i);
+  });
+});
+
+describe("findSimilarIssues", () => {
+  const issues = [
+    { number: 12, title: "SEA binary breaks karajan-mcp (better-sqlite3 missing)", html_url: "https://github.com/manufosela/karajan-code/issues/12" },
+    { number: 9, title: "kj harden overwrites global hooks", html_url: "u9" },
+  ];
+
+  it("matches open issues sharing meaningful title words", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => issues });
+    const hits = await findSimilarIssues("MCP fails: better-sqlite3 missing from SEA binary", { fetchFn });
+    expect(hits.map((h) => h.number)).toEqual([12]);
+    expect(fetchFn.mock.calls[0][0]).toMatch(/repos\/manufosela\/karajan-code\/issues/);
+  });
+
+  it("API failure degrades to empty (reporting must not depend on the dedup)", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("offline"));
+    expect(await findSimilarIssues("anything", { fetchFn })).toEqual([]);
+  });
+});
+
+describe("newIssueUrl", () => {
+  it("prefills title and body, URL-encoded", () => {
+    const url = newIssueUrl({ title: "A & B", body: "line\nline2" });
+    expect(url).toMatch(/^https:\/\/github\.com\/manufosela\/karajan-code\/issues\/new\?/);
+    expect(url).toMatch(/title=A%20%26%20B/);
+    expect(url).toMatch(/body=line%0Aline2/);
+  });
+});


### PR DESCRIPTION
## AB-F parte 1/2 — Any-Agent Brain (épica KJC-PCS-0067)

El núcleo del **bucle de auto-reparación por issues**: el brain de cualquier usuario diagnostica una fricción de kj y la reporta al repo público — el feedback de campo llega solo al board, sin relevo humano (motivación: 3 casos reales llegados por pantallazos de chat, el último KJC-BUG-0118 hoy mismo).

- `sanitize()`: una issue pública es un boundary de privacidad — rutas `/home|/Users/<user>` colapsan a `~`, emails redactados; el composer solo incluye lo que el brain pasó explícitamente + metadatos kj/node/plataforma. **Jamás código del proyecto del usuario.**
- `findSimilarIssues()`: dedup por solape de palabras significativas vía API pública de GitHub (solo lectura, sin auth); cualquier fallo degrada a vacío — el dedup nunca bloquea el reporte.
- `newIssueUrl()`: URL de new-issue prellenada — **publicar sigue siendo un click humano por defecto**.

Parte 2/2: CLI `kj report-issue` + `--publish` vía gh (con la confirmación del usuario ordenada por el playbook).

145 netas · 6 tests. Veredicto cross-AI `cb914aa8a7c3`.