### PR TITLE
feat(cli): kj report-issue — self-healing loop, sanitized and human-gated (KJC-TSK-0655, 2/2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,9 @@ Invariants (the git gates enforce these — they are not suggestions):
 
 Commands: `kj rag query` · `kj brief <role>` (triage, planner, researcher,
 architect, tester, security, audit) · `kj review --staged` · `kj review --check` ·
-`kj solomon --position` · `kj report` · `kj check`
+`kj solomon --position` · `kj agent run <agent>` · `kj report` · `kj check`
+
+Hit a kj bug or friction? Diagnose it and file it upstream with
+`kj report-issue` (sanitized; ask your user before `--publish`).
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,9 @@ Invariants (the git gates enforce these — they are not suggestions):
 
 Commands: `kj rag query` · `kj brief <role>` (triage, planner, researcher,
 architect, tester, security, audit) · `kj review --staged` · `kj review --check` ·
-`kj solomon --position` · `kj report` · `kj check`
+`kj solomon --position` · `kj agent run <agent>` · `kj report` · `kj check`
+
+Hit a kj bug or friction? Diagnose it and file it upstream with
+`kj report-issue` (sanitized; ask your user before `--publish`).
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,9 @@ Invariants (the git gates enforce these — they are not suggestions):
 
 Commands: `kj rag query` · `kj brief <role>` (triage, planner, researcher,
 architect, tester, security, audit) · `kj review --staged` · `kj review --check` ·
-`kj solomon --position` · `kj report` · `kj check`
+`kj solomon --position` · `kj agent run <agent>` · `kj report` · `kj check`
+
+Hit a kj bug or friction? Diagnose it and file it upstream with
+`kj report-issue` (sanitized; ask your user before `--publish`).
 
 <!-- <<< kj:managed:playbook <<< -->

--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -33,7 +33,7 @@ export const ADVANCED_GROUPS = [
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "undo", "standby"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
-  { title: "Mantenimiento", commands: ["clean", "sync", "telemetry"] },
+  { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },
 ];
 
 /** Flat set of every advanced command name (for fast lookup / filtering). */

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -21,6 +21,7 @@ import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { envInstallCommand, briefCommand } from "../commands/env.js";
 import { agentRunCommand } from "../commands/agent-run.js";
+import { reportIssueCommand } from "../commands/report-issue.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
 
@@ -146,6 +147,21 @@ export function registerMeta(program, { pkgVersion }) {
       await withConfig(pkgVersion, "agent-run", flags, async ({ config, logger }) => {
         await agentRunCommand({ agent, task, config, logger, flags });
       });
+    });
+
+  // AB-F (KJC-TSK-0655): self-healing — the brain files kj frictions upstream.
+  program
+    .command("report-issue")
+    .description("Report a kj bug/friction to the public repo (sanitized; publishing needs --publish)")
+    .requiredOption("--title <text>", "One-line summary")
+    .option("--description <text>", "What happened and what you expected")
+    .option("--command <cmd>", "The kj command involved")
+    .option("--error <text>", "The error output (it will be sanitized)")
+    .option("--publish", "Create the issue via the gh CLI (confirm with your user first)")
+    .option("--force", "Skip the similar-issues check")
+    .option("--json", "Machine-readable output")
+    .action(async (flags) => {
+      await reportIssueCommand({ logger: console, flags });
     });
 
   // AB-C (KJC-TSK-0652): role briefs for the brain (any host agent).

--- a/src/commands/report-issue.js
+++ b/src/commands/report-issue.js
@@ -1,0 +1,77 @@
+/**
+ * `kj report-issue` (AB-F 2/2, KJC-TSK-0655) — the brain files kj
+ * frictions to the public repo. Default output is a sanitized preview
+ * plus a prefilled new-issue URL: publishing stays a human decision.
+ * `--publish` uses the gh CLI; the playbook orders the brain to confirm
+ * with its user before passing it.
+ */
+import os from "node:os";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { runCommand } from "../utils/process.js";
+import { composeIssue, findSimilarIssues, newIssueUrl, REPO } from "../environment/issue-report.js";
+
+function kjVersion() {
+  try {
+    const pkg = resolve(fileURLToPath(import.meta.url), "../../../package.json");
+    return JSON.parse(readFileSync(pkg, "utf8")).version;
+  } catch { return "unknown"; }
+}
+
+export async function reportIssueCommand({ logger: _logger = null, flags = {}, deps = {} }) {
+  if (!flags.title || !flags.title.trim()) {
+    throw new Error("kj report-issue requires --title \"<one-line summary>\"");
+  }
+  const { fetchFn = globalThis.fetch, runCmd = runCommand } = deps;
+
+  const { title, body } = composeIssue({
+    title: flags.title,
+    description: flags.description || "",
+    command: flags.command || "",
+    error: flags.error || "",
+    env: { kjVersion: kjVersion(), nodeVersion: process.version, platform: `${os.platform()}-${os.arch()}` },
+  });
+  const url = newIssueUrl({ title, body });
+
+  const similar = await findSimilarIssues(title, { fetchFn });
+  if (similar.length > 0 && !flags.force) {
+    const res = { published: false, title, body, similar, url };
+    if (flags.json) console.log(JSON.stringify(res));
+    else {
+      console.log(`✗ ${similar.length} similar open issue(s) — comment there instead of duplicating (or re-run with --force):`);
+      for (const s of similar) console.log(`  #${s.number} ${s.title}\n     ${s.html_url}`);
+    }
+    process.exitCode = 1;
+    return res;
+  }
+
+  if (flags.publish) {
+    try {
+      const gh = await runCmd("gh", ["issue", "create", "--repo", REPO, "--title", title, "--body", body]);
+      if (gh.exitCode !== 0) throw new Error(gh.stderr?.trim() || `gh exited ${gh.exitCode}`);
+      const issueUrl = gh.stdout.trim().split("\n").pop();
+      const res = { published: true, title, url: issueUrl, similar };
+      if (flags.json) console.log(JSON.stringify(res));
+      else console.log(`✓ issue published: ${issueUrl}`);
+      process.exitCode = 0;
+      return res;
+    } catch (err) {
+      const res = { published: false, title, body, similar, url, error: err.message };
+      if (flags.json) console.log(JSON.stringify(res));
+      else console.log(`✗ could not publish via gh (${err.message}) — open it manually:\n${url}`);
+      process.exitCode = 1;
+      return res;
+    }
+  }
+
+  const res = { published: false, title, body, similar, url };
+  if (flags.json) console.log(JSON.stringify(res));
+  else {
+    console.log(`--- issue preview (sanitized) ---\n# ${title}\n\n${body}\n---`);
+    console.log(`Open (and edit) it here:\n${url}`);
+    console.log("Or publish directly with --publish (requires gh; confirm with your user first).");
+  }
+  process.exitCode = 0;
+  return res;
+}

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -59,7 +59,10 @@ Invariants (the git gates enforce these — they are not suggestions):
 
 Commands: \`kj rag query\` · \`kj brief <role>\` (triage, planner, researcher,
 architect, tester, security, audit) · \`kj review --staged\` · \`kj review --check\` ·
-\`kj solomon --position\` · \`kj report\` · \`kj check\`
+\`kj solomon --position\` · \`kj agent run <agent>\` · \`kj report\` · \`kj check\`
+
+Hit a kj bug or friction? Diagnose it and file it upstream with
+\`kj report-issue\` (sanitized; ask your user before \`--publish\`).
 `;
 
 export function renderPlaybook({ stateBackend = "hu-board" } = {}) {

--- a/tests/environment/report-issue-cli.test.js
+++ b/tests/environment/report-issue-cli.test.js
@@ -1,0 +1,76 @@
+// AB-F 2/2 (KJC-TSK-0655): the CLI. Default NEVER publishes (preview +
+// prefilled URL); similar issues block unless --force; --publish requires
+// gh and fails actionably without it.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { reportIssueCommand } from "../../src/commands/report-issue.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+const fetchNone = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+const fetchSimilar = vi.fn().mockResolvedValue({
+  ok: true,
+  json: async () => [{ number: 12, title: "SEA binary breaks karajan-mcp better-sqlite3", html_url: "u12" }],
+});
+
+describe("kj report-issue", () => {
+  beforeEach(() => { vi.clearAllMocks(); process.exitCode = 0; });
+
+  it("default: preview + prefilled URL, nothing published", async () => {
+    const runCmd = vi.fn();
+    const res = await reportIssueCommand({
+      logger, flags: { title: "Something broke badly", error: "boom at /home/manu/x" },
+      deps: { fetchFn: fetchNone, runCmd },
+    });
+    expect(res.published).toBe(false);
+    expect(res.url).toMatch(/issues\/new\?/);
+    expect(res.body).not.toMatch(/\/home\/manu/);
+    expect(runCmd).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("similar issues found → blocks with the list (exit 1) unless --force", async () => {
+    const res = await reportIssueCommand({
+      logger, flags: { title: "SEA binary better-sqlite3 missing karajan-mcp" },
+      deps: { fetchFn: fetchSimilar, runCmd: vi.fn() },
+    });
+    expect(res.published).toBe(false);
+    expect(res.similar).toHaveLength(1);
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = 0;
+    const forced = await reportIssueCommand({
+      logger, flags: { title: "SEA binary better-sqlite3 missing karajan-mcp", force: true },
+      deps: { fetchFn: fetchSimilar, runCmd: vi.fn() },
+    });
+    expect(process.exitCode).toBe(0);
+    expect(forced.url).toMatch(/issues\/new/);
+  });
+
+  it("--publish creates the issue via gh and returns its URL", async () => {
+    const runCmd = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "https://github.com/manufosela/karajan-code/issues/99\n" });
+    const res = await reportIssueCommand({
+      logger, flags: { title: "Broken thing entirely", publish: true },
+      deps: { fetchFn: fetchNone, runCmd },
+    });
+    expect(res.published).toBe(true);
+    expect(res.url).toMatch(/issues\/99/);
+    const [bin, args] = runCmd.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(args).toEqual(expect.arrayContaining(["issue", "create"]));
+  });
+
+  it("--publish without a working gh → actionable error including the manual URL", async () => {
+    const runCmd = vi.fn().mockRejectedValue(new Error("gh: not found"));
+    const res = await reportIssueCommand({
+      logger, flags: { title: "Broken thing entirely", publish: true },
+      deps: { fetchFn: fetchNone, runCmd },
+    });
+    expect(res.published).toBe(false);
+    expect(res.url).toMatch(/issues\/new\?/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("missing title → error", async () => {
+    await expect(reportIssueCommand({ logger, flags: {}, deps: { fetchFn: fetchNone, runCmd: vi.fn() } }))
+      .rejects.toThrow(/--title/);
+  });
+});


### PR DESCRIPTION
## AB-F parte 2/2 — cierra KJC-TSK-0655 (épica KJC-PCS-0067)

El sistema agente/humano múltiple queda operativo: el brain de cualquier usuario diagnostica una fricción de kj y la reporta al repo — el caso KJC-BUG-0118 de esta mañana (pantallazos por chat) es de los últimos que llegan por mensajería.

- **Default nunca publica**: preview sanitizado + URL de new-issue prellenada — publicar es un click humano.
- **Dedup bloquea** con la lista de issues similares (comentar > duplicar; `--force` salta; exit 1).
- **`--publish`** vía gh, con degradación a la URL manual si gh falta; `--json` contrato de máquina.
- **El playbook lo ordena**: "Hit a kj bug or friction? Diagnose it and file it upstream with kj report-issue (sanitized; ask your user before --publish)" — regenerado en los 3 anfitriones.
- Humo en vivo: `/home/manu/...` salió como `~/...` en preview y URL. (El propio pre-commit del repo rechazó mi primer intento por un unused-param de eslint — gates gobernando al que los construye.)

181 netas · 5 tests. Veredicto cross-AI `abc2081ac3c7`.