### PR TITLE
feat(init): agent-friendly — no-TTY notice and --json machine contract (KJC-TSK-0656)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -32,6 +32,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--no-squeezr", "Skip the Squeezr auto-install (context compression). Karajan still runs but burns more tokens")
     .option("--no-qmd", "Skip the QMD auto-install + collection registration (semantic wiki over docs/, .reviews/ and plans/)")
     .option("--no-harden", "Skip the quality harness (git hooks, lint/commit config, CI gates, agent guidelines)")
+    .option("--json", "Emit a machine-readable summary of what init did (AB-B: for host agents)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "init", flags, async ({ config: _config, logger }) => {
         await initCommand({ logger, flags });

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -736,11 +736,23 @@ export async function resolveConfigScope({ flags, interactive }) {
 }
 
 export async function initCommand({ logger, flags = {} }) {
+  // AB-B (KJC-TSK-0656): with --json, stdout is a machine contract — every
+  // human log moves to stderr so the only stdout line is the summary object.
+  if (flags.json) {
+    const toStderr = (...args) => console.error(...args);
+    logger = { ...logger, info: toStderr, warn: toStderr, error: toStderr };
+  }
   const karajanHome = getKarajanHome();
   await ensureDir(karajanHome);
   logger.info(`Ensured ${karajanHome} exists`);
 
   const interactive = flags.noInteractive !== true && isTTY();
+  // AB-B (KJC-TSK-0656): the agent is the UI. When there is no TTY the
+  // wizard silently used defaults — say so, so a brain (or a CI log
+  // reader) knows WHY nothing was asked and which flags override what.
+  if (!interactive && flags.noInteractive !== true) {
+    logger.info("No TTY detected — running non-interactive with defaults (pass flags to override; see kj init --help)");
+  }
   const { configPath, scope } = await resolveConfigScope({ flags, interactive });
   logger.info(`Config scope: ${scope} → ${configPath}`);
   const karajanDir = path.join(process.cwd(), ".karajan");
@@ -899,6 +911,16 @@ export async function initCommand({ logger, flags = {} }) {
     const version = JSON.parse(readFileSync(pkgPath, "utf8")).version;
     sendTelemetryEvent("install", { version }, config).catch(() => {});
   } catch { /* non-blocking */ }
+
+  // AB-B (KJC-TSK-0656): machine contract for brains — one JSON object with
+  // what init actually did, instead of parsing the human log.
+  if (flags.json) {
+    console.log(JSON.stringify({
+      ok: true, configPath, scope, interactive,
+      skipped: ["ollama", "rtk", "squeezr", "qmd", "harden"].filter((t) => flags[t] === false),
+    }));
+    return;
+  }
 
   // Clear close so a first-time user knows setup finished and what to do next,
   // instead of being left at the end of a wall of detection logs (KJC-BUG-0088).


### PR DESCRIPTION
## AB-B — Any-Agent Brain (épica KJC-PCS-0067)

El agente es la UI; kj nunca puede colgarse esperando a un humano. Auditoría + cierre de huecos:

- **Auditado (ya correcto)**: `init` cae a no-interactive sin TTY (verificado empíricamente: exit 0 con stdin cerrado); `harden` sólo abre wizard con `isTTY && !json` (KJC-TSK-0567); `start` soporta `--json`; `run` guarda la confirmación de cwd tras TTY. Ninguno bloquea.
- **Hueco 1**: al caer a defaults, init no decía POR QUÉ no preguntaba nada — ahora avisa ("No TTY detected — running non-interactive with defaults…"), señal clave para un brain o un log de CI.
- **Hueco 2**: `kj init --json` — stdout pasa a ser contrato de máquina: todos los logs humanos van a stderr desde la primera línea y stdout emite exactamente un objeto `{ok, configPath, scope, interactive, skipped}` (estándar que codex fijó en AB-D). Verificado en vivo: `2>/dev/null` deja una única línea JSON.

Veredicto cross-AI `17ed2de3f4fa`. Con esto, todas las fases funcionales de la épica están entregadas — queda AB-G (doc v4).