### PR TITLE
fix(doctor): MCP and native-build read as degraded optionals in v4 (KJC-BUG-0118)

### DIFF
--- a/src/checks/mcp-health.js
+++ b/src/checks/mcp-health.js
@@ -102,8 +102,14 @@ export function createKarajanMcpCheck() {
       return {
         ok: result.ok,
         severity: result.ok ? "info" : "warn",
-        detail: result.ok ? result.detail : `karajan-mcp did not respond: ${result.detail}`,
-        fix: result.ok ? undefined : "Re-run karajan-mcp via `node bin/karajan-mcp.js`",
+        // KJC-BUG-0118: the MCP is OPTIONAL in the v4 environment (the host
+        // agent drives kj via CLI) — a dead MCP must read as a degraded
+        // optional, never as a broken install. The standalone (curl) binary
+        // cannot run it at all (no bundled native modules).
+        detail: result.ok
+          ? result.detail
+          : `karajan-mcp did not respond: ${result.detail} — OPTIONAL in v4: your agent runs kj directly; only shell-less hosts need MCP`,
+        fix: result.ok ? undefined : "Only if you need MCP: install via npm (`npm i -g karajan-code`) — the standalone binary does not bundle it",
         extra: { binPath },
       };
     },

--- a/src/checks/native-build.js
+++ b/src/checks/native-build.js
@@ -51,7 +51,10 @@ export function createNativeBuildCheck({ loadDb = defaultLoadDb, isPnpm = isPnpm
         return {
           ok: false,
           severity: "warn",
-          detail: `better-sqlite3 failed to load: ${firstLine}`,
+          // KJC-BUG-0118: the standalone (curl) binary ships without native
+          // modules by design — name the consequence (RAG/board/MCP need the
+          // npm install) instead of implying the install is broken.
+          detail: `better-sqlite3 failed to load: ${firstLine} — DB-backed features (RAG, board, MCP) unavailable; the standalone binary does not bundle native modules`,
           fix: "Reinstall to rebuild native modules: `npm i -g karajan-code`",
         };
       }


### PR DESCRIPTION
Fix corto del bug reportado por Jorge del Casar (Mac arm64, install por curl): el binario SEA no lleva better-sqlite3 y su brain leyó el doctor como instalación rota, reinstalando por npm. Los checks ya eran WARN — el problema era el mensaje: ahora dicen que **el MCP es OPCIONAL en v4** (el anfitrión lanza kj por CLI; solo hosts sin shell lo necesitan), que **el standalone no embebe módulos nativos por diseño**, y qué features exigen la instalación npm (RAG, board, MCP). Encuadre de opcional-degradado, no de instalación rota. La doc v4 Install ya lleva la nota equivalente. Fix de raíz sigue en la épica node:sqlite (KJC-PCS-0064). Suite checks 131/131. Veredicto `329649a8d77d`.