### PR TITLE
feat(harden): pre-push drops tests when CI runs the suite (KJC-TSK-0647)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -10,6 +10,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { loadConfig } from "../config.js";
+import { resolveTestOnPush } from "../harden/test-on-push.js";
 import { compareHarden, formatAdvisoryReport } from "../harden/advisory.js";
 import { interactiveHarden } from "../harden/interactive.js";
 import { createWizard, isTTY } from "../utils/wizard.js";
@@ -121,6 +122,14 @@ export async function hardenCommand({
 
   const roots = detectStackRoots(projectDir, { only: onlyDirs, exclude: excludeDirs });
   const cmds = await resolveCmds(projectDir, roots[0]?.language ?? null);
+  // KJC-TSK-0647: CI already running the suite per PR ⇒ pre-push drops its
+  // test command (false-red source under local parallelism); opt back in
+  // via package.json kj.harden.test_on_push.
+  const top = resolveTestOnPush({ projectDir, repoCfg, testCmd: cmds.test });
+  if (top.reason) {
+    logger.info?.(`kj harden: ${top.reason}`);
+    cmds.test = undefined;
+  }
   // KJC-TSK-0648: branch-first guard — the base branch only moves via PR.
   // Resolved from the project's kj config (default "main"); best-effort so
   // harden keeps working on repos that never ran kj init.

--- a/src/harden/test-on-push.js
+++ b/src/harden/test-on-push.js
@@ -1,0 +1,38 @@
+/**
+ * Test-on-push policy (KJC-TSK-0647) — the full suite on every push is
+ * redundant when CI already runs it per PR, and a source of false reds
+ * (suites unstable under local parallelism). Field-reproduced.
+ *
+ * Policy: a CI workflow that runs tests ⇒ pre-push drops its test command
+ * (identity guard and chaining stay). Repos can force it back with
+ * `"kj": { "harden": { "test_on_push": true } }` in package.json. Repos
+ * without CI keep tests on push — there it IS the last safety net.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_STEP = /\b(npm (run )?test|vitest|jest|pytest|go test|phpunit|cargo test)\b/;
+
+export function ciRunsTests(projectDir) {
+  const dir = join(projectDir, ".github", "workflows");
+  if (!existsSync(dir)) return false;
+  try {
+    return readdirSync(dir)
+      .filter((f) => /\.ya?ml$/.test(f))
+      .some((f) => TEST_STEP.test(readFileSync(join(dir, f), "utf8")));
+  } catch {
+    return false;
+  }
+}
+
+export function resolveTestOnPush({ projectDir, repoCfg = {}, testCmd = null }) {
+  if (!testCmd) return { testCmd: null, reason: null };
+  if (repoCfg.test_on_push === true) return { testCmd, reason: null };
+  if (ciRunsTests(projectDir)) {
+    return {
+      testCmd: null,
+      reason: "CI already runs the suite per PR — pre-push keeps only the identity guard (opt back in with kj.harden.test_on_push: true in package.json)",
+    };
+  }
+  return { testCmd, reason: null };
+}

--- a/tests/harden/test-on-push.test.js
+++ b/tests/harden/test-on-push.test.js
@@ -1,0 +1,52 @@
+// KJC-TSK-0647: running the FULL suite on every push is redundant when CI
+// already runs it per PR, and a source of false reds (suites unstable under
+// local parallelism — reproduced in the field). When a CI workflow runs
+// tests, harden drops the test command from pre-push unless the repo opts
+// back in via package.json `kj.harden.test_on_push: true`.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ciRunsTests, resolveTestOnPush } from "../../src/harden/test-on-push.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-top-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+function writeWorkflow(content) {
+  fs.mkdirSync(path.join(dir, ".github", "workflows"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".github", "workflows", "ci.yml"), content);
+}
+
+describe("ciRunsTests", () => {
+  it("true when a workflow runs a test command", () => {
+    writeWorkflow("jobs:\n  test:\n    steps:\n      - run: npm test\n");
+    expect(ciRunsTests(dir)).toBe(true);
+  });
+
+  it("false without workflows or without test steps", () => {
+    expect(ciRunsTests(dir)).toBe(false);
+    writeWorkflow("jobs:\n  lint:\n    steps:\n      - run: npm run lint\n");
+    expect(ciRunsTests(dir)).toBe(false);
+  });
+});
+
+describe("resolveTestOnPush", () => {
+  it("CI runs tests → pre-push drops the test command (with reason)", () => {
+    writeWorkflow("jobs:\n  t:\n    steps:\n      - run: vitest run\n");
+    const res = resolveTestOnPush({ projectDir: dir, repoCfg: {}, testCmd: "npm test" });
+    expect(res.testCmd).toBeNull();
+    expect(res.reason).toMatch(/CI/);
+  });
+
+  it("explicit opt-in keeps tests on push even with CI", () => {
+    writeWorkflow("jobs:\n  t:\n    steps:\n      - run: vitest run\n");
+    const res = resolveTestOnPush({ projectDir: dir, repoCfg: { test_on_push: true }, testCmd: "npm test" });
+    expect(res.testCmd).toBe("npm test");
+  });
+
+  it("no CI → tests stay on push (last safety net)", () => {
+    const res = resolveTestOnPush({ projectDir: dir, repoCfg: {}, testCmd: "npm test" });
+    expect(res.testCmd).toBe("npm test");
+  });
+});


### PR DESCRIPTION
Fricción de campo cerrada (suites inestables con paralelismo local → falsos rojos en cada push; reproducida en la primera sesión externa del entorno): cuando un workflow de CI ya ejecuta tests, el pre-push generado por harden pierde su comando de test (quedan identity guard y chain-to-global), con el motivo logueado y la vuelta atrás documentada (`kj.harden.test_on_push: true` en package.json). Repos sin CI mantienen el test en push — ahí SÍ es la última red. 5 tests. Veredicto `f4543a35ecaf`.