### PR TITLE
feat(install-tools): full stack coverage — rtk, squeezr and qmd (KJC-TSK-0657)

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -28,7 +28,17 @@ const execFileAsync = promisify(execFile);
 
 // git and the agent CLI lead the list: both are `kj doctor` *required* tools,
 // so a blank machine wants them before the optional audit tools.
-const ALL_TOOLS = ["git", "agent-cli", "semgrep", "osv-scanner", "lighthouse", "docker", "sonar"];
+// KJC-TSK-0657: rtk/squeezr/qmd (token+context optimizers, previously
+// init-only) complete the list — one pass leaves the machine 100%
+// operational, per the quality-default-on product rule.
+const ALL_TOOLS = ["git", "agent-cli", "semgrep", "osv-scanner", "lighthouse", "docker", "sonar", "rtk", "squeezr", "qmd"];
+
+// Optimizer tools reuse the init installers (same {ok, version, error} contract).
+const OPTIMIZER_INSTALLERS = {
+  rtk: () => import("../utils/rtk-install.js").then((m) => m.installRtk),
+  squeezr: () => import("../utils/squeezr-install.js").then((m) => m.installSqueezr),
+  qmd: () => import("../utils/qmd-install.js").then((m) => m.installQmd),
+};
 
 // The default pipeline is coder=claude, reviewer=codex, so `agent-cli` installs
 // exactly those two. gemini stays out of the default: it is a supported
@@ -332,6 +342,22 @@ export async function installToolsCommand(opts = {}) {
           if (!r.ok) result.error = r.error;
         }
       }
+      continue;
+    }
+
+    if (OPTIMIZER_INSTALLERS[tool]) {
+      if (dryRun) {
+        results.push({ tool, action: "planned", command: `kj install-tools --only ${tool}` });
+        logger.info?.(`▸ ${tool}: would install (init installer)`);
+        continue;
+      }
+      const proceed = yes || await promptYesNo(`Install ${tool}?`);
+      if (!proceed) { results.push({ tool, action: "declined" }); continue; }
+      const install = await OPTIMIZER_INSTALLERS[tool]();
+      const r = await install(logger);
+      results.push(r.ok
+        ? { tool, action: "installed", version: r.version }
+        : { tool, action: "failed", error: r.error });
       continue;
     }
 

--- a/tests/install-tools-full-stack.test.js
+++ b/tests/install-tools-full-stack.test.js
@@ -1,0 +1,57 @@
+// KJC-TSK-0657: `kj install-tools` covers the FULL stack — a fresh machine
+// must end 100% operational in one pass. rtk, squeezr and qmd (previously
+// init-only) join the tool list, reusing the init installers.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../src/utils/rtk-install.js", () => ({ installRtk: vi.fn() }));
+vi.mock("../src/utils/squeezr-install.js", () => ({ installSqueezr: vi.fn() }));
+vi.mock("../src/utils/qmd-install.js", () => ({ installQmd: vi.fn() }));
+vi.mock("../src/utils/agent-detect.js", async (importOriginal) => ({
+  ...(await importOriginal()),
+  checkBinary: vi.fn(async () => ({ ok: false })),
+}));
+
+import { installToolsCommand, __test } from "../src/commands/install-tools.js";
+import { installRtk } from "../src/utils/rtk-install.js";
+import { installSqueezr } from "../src/utils/squeezr-install.js";
+import { installQmd } from "../src/utils/qmd-install.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe("full-stack tool list", () => {
+  it("ALL_TOOLS includes rtk, squeezr and qmd", () => {
+    expect(__test.ALL_TOOLS).toEqual(expect.arrayContaining(["rtk", "squeezr", "qmd"]));
+  });
+
+  it("--only accepts the three new names", () => {
+    expect(__test.parseOnlyList("rtk,squeezr,qmd")).toEqual(["rtk", "squeezr", "qmd"]);
+  });
+});
+
+describe("optimizer installs via the init installers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("installs rtk/squeezr/qmd with --only and --yes", async () => {
+    installRtk.mockResolvedValue({ ok: true, version: "1.0", error: null });
+    installSqueezr.mockResolvedValue({ ok: true, version: "1.0", error: null });
+    installQmd.mockResolvedValue({ ok: true, version: "1.0", error: null });
+    const { results } = await installToolsCommand({ only: "rtk,squeezr,qmd", yes: true, logger });
+    expect(installRtk).toHaveBeenCalledOnce();
+    expect(installSqueezr).toHaveBeenCalledOnce();
+    expect(installQmd).toHaveBeenCalledOnce();
+    expect(results.map((r) => r.action)).toEqual(["installed", "installed", "installed"]);
+  });
+
+  it("a failing installer reports failed with the error, not a crash", async () => {
+    installRtk.mockResolvedValue({ ok: false, version: null, error: "cargo missing" });
+    const { results } = await installToolsCommand({ only: "rtk", yes: true, logger });
+    expect(results[0]).toMatchObject({ tool: "rtk", action: "failed", error: "cargo missing" });
+  });
+
+  it("dry-run plans without invoking installers", async () => {
+    const { results } = await installToolsCommand({ only: "rtk,squeezr", dryRun: true, logger });
+    expect(installRtk).not.toHaveBeenCalled();
+    expect(installSqueezr).not.toHaveBeenCalled();
+    expect(results.every((r) => r.action === "planned")).toBe(true);
+  });
+});


### PR DESCRIPTION
Feedback directo del usuario probando en un portátil virgen: *«no puede ser que el instalador de karajan instale una mínima parte»*. `kj install-tools` (sin `--only`) ahora deja el stack COMPLETO: a git, agent-cli, semgrep, osv-scanner, lighthouse, docker y sonar se suman **rtk, squeezr y qmd** — reutilizando los instaladores del init (contrato uniforme `{ok, version, error}`), con gating yes/prompt, plan en dry-run y fallos reportados con su error. Una pasada = máquina 100% operativa (regla de producto: calidad default-ON). El prompt de instalación de la landing se actualiza en el repo de la landing para ejecutarlo. 5 tests. Veredicto `99e4c808dea2`.