### PR TITLE
chore(release): v4.1.2 — one pass, fully operational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.2] - 2026-07-21
+
+Patch. **One pass, fully operational.** Direct feedback from a fresh-laptop install: the installer left a minimal setup. No more.
+
+### Added
+
+- **`kj install-tools` covers the full stack** (KJC-TSK-0657): rtk, squeezr and qmd (token/context optimizers, previously init-only) join git, agent CLIs, Semgrep, OSV-Scanner, Lighthouse, Docker and SonarQube in the default tool list — reusing the init installers, asking before each install, planning under `--dry-run`, and reporting failures with their error. A fresh machine ends 100% operational in one pass. The landing's install prompt now recommends npm explicitly (native-module features) and drives `kj install-tools` as part of the setup.
+
 ## [4.1.1] - 2026-07-21
 
 Patch. **Three field frictions closed so a fresh install just works** — all three reported by the environment's first external users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG de la v4.1.2: install-tools con el stack completo (#1248). verify-pack 4.1.2 verde. Veredicto cross-AI `d98a8204cc8b`. Tras el merge: publish (OTP) → tag → GH release → landing.