### PR TITLE
feat(installer): curl installs the full product — npm-first with Node auto-provisioning (KJC-TSK-0658)

### DIFF
--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -1,31 +1,36 @@
 #!/bin/sh
-# Karajan Code — standalone binary installer (no Node required).
+# Karajan Code installer — guarantees a COMPLETE install (KJC-TSK-0658).
 #
 #   curl -fsSL https://karajancode.com/install.sh | sh
 #
-# Downloads the prebuilt `kj` binary for your OS/arch from the GitHub
-# release, verifies its SHA256 checksum, and installs it to ~/.local/bin.
-# Override with env vars: KJ_VERSION (e.g. v3.7.2), KJ_INSTALL_DIR.
+# Default route: npm — the full product (CLI + RAG + HU Board + MCP).
+#   1. Node >= 22.12 present  → npm install -g karajan-code
+#   2. No usable Node         → auto-provision official Node LTS into
+#      ~/.karajan/node (checksum-verified, nothing system-wide touched),
+#      install karajan-code with it, symlink kj into ~/.local/bin.
+# Standalone route (CLI only, no native-module features — RAG/board/MCP
+# unavailable): opt-in with `--standalone` or KJ_STANDALONE=1.
 #
-# POSIX sh only — no bashisms, no Node. KJC-TSK-0593.
+# POSIX sh only. Env overrides: KJ_VERSION, KJ_INSTALL_DIR.
 set -eu
 
 REPO="manufosela/karajan-code"
 VERSION="${KJ_VERSION:-latest}"
 INSTALL_DIR="${KJ_INSTALL_DIR:-$HOME/.local/bin}"
+NODE_MAJOR="22"
+NODE_MIN_MINOR="12"
+MODE="full"
+[ "${1:-}" = "--standalone" ] && MODE="standalone"
+[ "${KJ_STANDALONE:-0}" = "1" ] && MODE="standalone"
 
-die() {
-  echo "kj-install: $1" >&2
-  exit 1
-}
+die() { echo "kj-install: $1" >&2; exit 1; }
 
-# --- Detect OS/arch, map to the release asset names we actually build. ---
-os="$(uname -s)"
-arch="$(uname -m)"
+# --- Detect OS/arch (shared by both routes). ---
+os="$(uname -s)"; arch="$(uname -m)"
 case "$os" in
   Linux) os="linux" ;;
   Darwin) os="darwin" ;;
-  *) die "unsupported OS '$os'. Supported: Linux, macOS. Use npm instead: npm install -g karajan-code" ;;
+  *) die "unsupported OS '$os'. Supported: Linux, macOS." ;;
 esac
 case "$arch" in
   x86_64 | amd64) arch="x64" ;;
@@ -33,80 +38,122 @@ case "$arch" in
   *) die "unsupported architecture '$arch'" ;;
 esac
 
-target="${os}-${arch}"
-case "$target" in
-  linux-x64) ;;
-  darwin-arm64) ;;
-  *) die "no prebuilt binary for '$target'. Available: linux-x64, darwin-arm64. Use npm instead: npm install -g karajan-code" ;;
-esac
+# --- Downloader + checksum tool. ---
+if command -v curl >/dev/null 2>&1; then fetch() { curl -fsSL "$1" -o "$2"; }
+elif command -v wget >/dev/null 2>&1; then fetch() { wget -qO "$2" "$1"; }
+else die "need curl or wget"; fi
+if command -v sha256sum >/dev/null 2>&1; then sha256() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else die "need sha256sum or shasum to verify downloads"; fi
 
-# --- Resolve the download URL for the requested version (or latest). ---
-asset="kj-${target}"
-if [ "$VERSION" = "latest" ]; then
-  base="https://github.com/${REPO}/releases/latest/download"
-else
-  base="https://github.com/${REPO}/releases/download/${VERSION}"
-fi
-
-# --- Pick a downloader. ---
-if command -v curl >/dev/null 2>&1; then
-  fetch() { curl -fsSL "$1" -o "$2"; }
-elif command -v wget >/dev/null 2>&1; then
-  fetch() { wget -qO "$2" "$1"; }
-else
-  die "need curl or wget to download the binary"
-fi
-
-# --- Pick a checksum tool. ---
-if command -v sha256sum >/dev/null 2>&1; then
-  sha256() { sha256sum "$1" | cut -d' ' -f1; }
-elif command -v shasum >/dev/null 2>&1; then
-  sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
-else
-  die "need sha256sum or shasum to verify the download"
-fi
-
-# --- Download to a temp dir; only install after the checksum matches. ---
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/kj-install.XXXXXX")"
 trap 'rm -rf "$tmp"' EXIT INT TERM
 
-echo "kj-install: downloading ${asset} (${VERSION})..."
-fetch "${base}/${asset}" "${tmp}/kj" || die "could not download ${base}/${asset} — does that version/asset exist?"
-fetch "${base}/${asset}.sha256" "${tmp}/kj.sha256" || die "could not download the checksum for ${asset}"
+path_hint() {
+  case ":${PATH}:" in
+    *":$1:"*) ;;
+    *) echo "kj-install: add '$1' to your PATH:  export PATH=\"$1:\$PATH\"  (persist it in ~/.bashrc / ~/.zshrc)" ;;
+  esac
+}
 
+# --- Is there a usable Node (>= NODE_MAJOR.NODE_MIN_MINOR)? ---
+node_ok() {
+  command -v node >/dev/null 2>&1 || return 1
+  v="$(node --version 2>/dev/null | sed 's/^v//')"
+  major="${v%%.*}"; rest="${v#*.}"; minor="${rest%%.*}"
+  [ "$major" -gt "$NODE_MAJOR" ] 2>/dev/null && return 0
+  [ "$major" -eq "$NODE_MAJOR" ] 2>/dev/null && [ "$minor" -ge "$NODE_MIN_MINOR" ] 2>/dev/null
+}
+
+npm_pkg() { if [ "$VERSION" = "latest" ]; then echo "karajan-code"; else echo "karajan-code@${VERSION#v}"; fi; }
+
+if [ "$MODE" = "full" ]; then
+  if node_ok; then
+    echo "kj-install: Node $(node --version) found — installing via npm (full product)..."
+    npm install -g "$(npm_pkg)" || die "npm install failed. If it was a permissions error, set a user prefix (npm config set prefix ~/.local) and re-run."
+    echo "kj-install: installed $(kj --version 2>/dev/null || echo karajan-code). Run 'kj doctor' next."
+    exit 0
+  fi
+
+  echo "kj-install: no usable Node (need >= ${NODE_MAJOR}.${NODE_MIN_MINOR}) — provisioning official Node LTS into ~/.karajan/node (nothing system-wide)..."
+  dist="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
+  fetch "${dist}/SHASUMS256.txt" "${tmp}/SHASUMS256.txt" || die "could not fetch the Node checksum list"
+  node_asset="$(grep -o "node-v[0-9.]*-${os}-${arch}\.tar\.gz" "${tmp}/SHASUMS256.txt" | head -1)"
+  [ -n "$node_asset" ] || die "no official Node build for ${os}-${arch}"
+  echo "kj-install: downloading ${node_asset}..."
+  fetch "${dist}/${node_asset}" "${tmp}/${node_asset}" || die "could not download Node"
+  expected="$(grep "${node_asset}\$" "${tmp}/SHASUMS256.txt" | head -1 | cut -d' ' -f1)"
+  actual="$(sha256 "${tmp}/${node_asset}")"
+  [ "$expected" = "$actual" ] || die "Node checksum mismatch — aborting, nothing installed"
+
+  # Stage the whole install (extract + npm install) in a sibling dir and only
+  # swap it into place once EVERYTHING succeeded — a failed download/extract/
+  # install must never destroy a previous working ~/.karajan/node.
+  node_home="$HOME/.karajan/node"
+  staging="${node_home}.staging.$$"
+  rm -rf "$staging"; mkdir -p "$staging"
+  trap 'rm -rf "$tmp" "$staging"' EXIT INT TERM
+  tar -xzf "${tmp}/${node_asset}" -C "$staging" --strip-components=1 || die "could not extract Node"
+
+  echo "kj-install: installing karajan-code with the provisioned Node..."
+  PATH="${staging}/bin:$PATH" "${staging}/bin/npm" install -g "$(npm_pkg)" || die "npm install failed with the provisioned Node"
+
+  # Swap keeping the previous install recoverable at EVERY instant: park it
+  # as a backup, arm a trap that restores it on any exit (signal included),
+  # move the staged one in, and only then disarm the trap and drop the
+  # backup — the user can never end up without a working install.
+  backup="${node_home}.old.$$"
+  if [ -e "$node_home" ]; then
+    mv "$node_home" "$backup" || die "could not park the previous install"
+    trap '[ -e "$node_home" ] || mv "$backup" "$node_home" 2>/dev/null; rm -rf "$tmp" "$staging"' EXIT INT TERM
+  fi
+  mv "$staging" "$node_home" || die "could not move the staged install into place (previous install restored)"
+  trap 'rm -rf "$tmp"' EXIT INT TERM
+  rm -rf "$backup"
+  mkdir -p "$INSTALL_DIR"
+  # Wrappers, not symlinks: the shebang (#!/usr/bin/env node) must find the
+  # provisioned Node even though it is not on the user's PATH.
+  for bin in kj karajan-mcp; do
+    [ -e "${node_home}/bin/${bin}" ] || continue
+    {
+      echo '#!/bin/sh'
+      echo "export PATH=\"${node_home}/bin:\$PATH\""
+      echo "exec \"${node_home}/bin/${bin}\" \"\$@\""
+    } >"${INSTALL_DIR}/${bin}"
+    chmod +x "${INSTALL_DIR}/${bin}"
+  done
+  installed="$("${INSTALL_DIR}/kj" --version 2>/dev/null || echo '?')"
+  echo "kj-install: installed kj ${installed} (full product) — kj at ${INSTALL_DIR}/kj"
+  path_hint "$INSTALL_DIR"
+  echo "kj-install: next — run 'kj doctor', then 'kj install-tools' to complete the whole stack."
+  exit 0
+fi
+
+# --- Standalone route: prebuilt single binary (CLI only). ---
+echo "kj-install: standalone mode — single binary, NO native-module features (RAG, HU Board and MCP need the npm install)."
+target="${os}-${arch}"
+case "$target" in
+  linux-x64 | darwin-arm64) ;;
+  *) die "no prebuilt binary for '$target' (available: linux-x64, darwin-arm64) — run without --standalone for the npm route" ;;
+esac
+asset="kj-${target}"
+if [ "$VERSION" = "latest" ]; then base="https://github.com/${REPO}/releases/latest/download"
+else base="https://github.com/${REPO}/releases/download/${VERSION}"; fi
+
+echo "kj-install: downloading ${asset} (${VERSION})..."
+fetch "${base}/${asset}" "${tmp}/kj" || die "could not download ${base}/${asset}"
+fetch "${base}/${asset}.sha256" "${tmp}/kj.sha256" || die "could not download the checksum for ${asset}"
 expected="$(cut -d' ' -f1 <"${tmp}/kj.sha256")"
 actual="$(sha256 "${tmp}/kj")"
-[ "$expected" = "$actual" ] || die "checksum mismatch (expected ${expected}, got ${actual}). Aborting, nothing installed."
+[ "$expected" = "$actual" ] || die "checksum mismatch — aborting, nothing installed"
 
-# --- Install atomically: chmod on the temp file, then move into place. ---
 chmod +x "${tmp}/kj"
 mkdir -p "$INSTALL_DIR"
 mv -f "${tmp}/kj" "${INSTALL_DIR}/kj"
-
-# On macOS the binary is ad-hoc signed, not notarized with a paid Apple
-# certificate, so Gatekeeper can quarantine it. Clear the flag on the copy
-# we just checksummed ourselves (no-op on Linux / if the flag is absent).
 if [ "$os" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
   xattr -d com.apple.quarantine "${INSTALL_DIR}/kj" 2>/dev/null || true
 fi
-
 installed="$("${INSTALL_DIR}/kj" --version 2>/dev/null || echo '?')"
-echo "kj-install: installed kj ${installed} to ${INSTALL_DIR}/kj"
-
-# --- Tell the user how to reach it if the dir is not on PATH. ---
-case ":${PATH}:" in
-  *":${INSTALL_DIR}:"*) echo "kj-install: '${INSTALL_DIR}' is on your PATH — run 'kj --help' to get started." ;;
-  *)
-    echo "kj-install: '${INSTALL_DIR}' is not on your PATH. Add it with:"
-    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
-    echo "  (add that line to ~/.bashrc, ~/.zshrc or ~/.profile to make it permanent)"
-    ;;
-esac
-
-# --- Prerequisites: the binary bundles no toolchain. kj orchestrates ---
-# --- external tools, so name the hard requirements and let `kj doctor` ---
-# --- check them precisely for this machine.
-echo ""
-echo "kj-install: next step — run 'kj doctor' to check prerequisites."
-echo "  Required: git, plus at least one agent CLI (Claude Code, Codex or Gemini)."
-echo "  Optional: Docker (local models, SonarQube) and Node/npm (helper tools: Squeezr, qmd)."
+echo "kj-install: installed standalone kj ${installed} to ${INSTALL_DIR}/kj"
+path_hint "$INSTALL_DIR"
+echo "kj-install: next — run 'kj doctor'. For the full product later: re-run this installer without --standalone."

--- a/tests/install-binary-sh.test.js
+++ b/tests/install-binary-sh.test.js
@@ -15,6 +15,14 @@ describe("install-binary.sh macOS gating — KJC-BUG-0101", () => {
   });
 
   it("lists darwin-arm64 as an available prebuilt target", () => {
-    expect(script).toMatch(/Available: linux-x64, darwin-arm64/);
+    expect(script).toMatch(/available: linux-x64, darwin-arm64/i);
+  });
+
+  // KJC-TSK-0658: the default route is npm-first (full product); the SEA
+  // binary is an explicit opt-in that states its limitations.
+  it("defaults to the npm route and gates the binary behind --standalone", () => {
+    expect(script).toMatch(/npm install -g/);
+    expect(script).toMatch(/--standalone/);
+    expect(script).toMatch(/SHASUMS256\.txt/); // provisioned Node is checksum-verified
   });
 });


### PR DESCRIPTION
Feedback directo del usuario: *«¿para qué tengo el curl en la landing si no va a funcionar bien?»*. El instalador de `karajancode.com/install.sh` ahora **garantiza el producto completo**:

- **Con Node ≥ 22.12** → `npm install -g karajan-code` y listo.
- **Sin Node** → autoprovisiona el Node LTS oficial (checksum verificado contra SHASUMS256 de nodejs.org) en `~/.karajan/node` — sin tocar nada del sistema — instala karajan-code con él, y expone `kj`/`karajan-mcp` vía **wrappers independientes del PATH** (los symlinks fallaban sin Node: el shebang no encontraba node — cazado en prueba real).
- **`--standalone` / KJ_STANDALONE=1** → el binario SEA de antes, ahora opt-in explícito que declara sus limitaciones de entrada.

**Robustez forjada por codex en 3 rechazos legítimos encadenados**: staging del install completo antes de tocar nada → backup del install previo antes del swap → trap de rollback que cubre CUALQUIER salida o señal en la ventana del swap.

**Probado en vivo 4 veces** en entorno aislado sin Node: desde cero (kj full respondiendo sin Node en PATH), upgrade sobre existente, cero restos. Al mergear, `karajancode.com/install.sh` (redirect a raw de main) sirve el nuevo instalador al instante. Veredicto `a1f837c2cdef`.