### PR TITLE
feat(install-tools): stop-on-sudo — pending-user-action block, exit 3 (KJC-TSK-0659)

### DIFF
--- a/src/commands/install-tools.js
+++ b/src/commands/install-tools.js
@@ -23,6 +23,7 @@ import { detectProjectStack } from "../utils/stack-detect.js";
 import { resolveStandalone } from "../utils/binary-sources.js";
 import { downloadBinary, binDir, runInstallCommand } from "../utils/tool-installer.js";
 import { dockerInstallPlan } from "../utils/docker-install.js";
+import { collectPending, renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-action.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -416,8 +417,16 @@ export async function installToolsCommand(opts = {}) {
     }
   }
 
+  // KJC-TSK-0659 stop-on-sudo: anything that still needs the user's hands
+  // becomes ONE block with the exact per-OS commands, and a distinctive exit
+  // code so a driving agent stops and waits instead of continuing degraded.
+  const pending = dryRun ? [] : collectPending(results, { yes });
+  if (pending.length > 0) {
+    logger.warn?.(renderPendingBlock(pending));
+    return { results, pending, exitCode: PENDING_EXIT_CODE };
+  }
   const failures = results.filter((r) => r.action === "failed").length;
-  return { results, exitCode: failures > 0 ? 1 : 0 };
+  return { results, pending, exitCode: failures > 0 ? 1 : 0 };
 }
 
 export const __test = { parseOnlyList, isInstalled, ALL_TOOLS };

--- a/src/utils/pending-user-action.js
+++ b/src/utils/pending-user-action.js
@@ -1,0 +1,92 @@
+/**
+ * Stop-on-sudo policy (KJC-TSK-0659). When a tool cannot be installed
+ * automatically (sudo needed, no package-manager route, or the attempt
+ * failed), kj must NOT continue degraded — a RAG with 0 chunks because
+ * Docker was missing helps nobody. Instead: emit ONE block with the exact
+ * commands for this machine's OS and exit with a distinctive code so a
+ * driving agent stops, shows the block, and waits for the user.
+ */
+
+export const PENDING_EXIT_CODE = 3;
+
+const PENDING = new Set(["manual", "failed", "needs-user"]);
+
+// Exact per-OS commands for the tools kj cannot install unattended.
+// Multiple lines when the route depends on the distro/package manager.
+const OS_COMMANDS = {
+  docker: {
+    linux: ["sudo apt-get install -y docker.io   # Debian/Ubuntu", "sudo dnf install -y docker          # Fedora/RHEL"],
+    darwin: ["brew install --cask docker   # Docker Desktop, then open it once"],
+    win32: ["winget install Docker.DockerDesktop", "wsl --install   # if WSL2 is not set up yet"],
+  },
+  git: {
+    linux: ["sudo apt-get install -y git   # Debian/Ubuntu", "sudo dnf install -y git        # Fedora/RHEL"],
+    darwin: ["brew install git   # or: xcode-select --install"],
+    win32: ["winget install Git.Git"],
+  },
+  semgrep: {
+    linux: ["python3 -m pip install --user semgrep   # or: pipx install semgrep"],
+    darwin: ["brew install semgrep"],
+    win32: ["python -m pip install --user semgrep"],
+  },
+  "osv-scanner": {
+    linux: ["go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2   # or download from GitHub releases"],
+    darwin: ["brew install osv-scanner"],
+    win32: ["winget install Google.OSVScanner   # or download from GitHub releases"],
+  },
+  lighthouse: {
+    linux: ["npm install -g lighthouse"],
+    darwin: ["npm install -g lighthouse"],
+    win32: ["npm install -g lighthouse"],
+  },
+  ollama: {
+    linux: ["curl -fsSL https://ollama.com/install.sh | sh   # official installer (uses sudo)", "ollama pull nomic-embed-text"],
+    darwin: ["brew install ollama && brew services start ollama", "ollama pull nomic-embed-text"],
+    win32: ["winget install Ollama.Ollama", "ollama pull nomic-embed-text"],
+  },
+};
+
+/** Exact commands to install `tool` on `platform` (empty when unknown). */
+export function osCommandsFor(tool, platform = process.platform) {
+  return OS_COMMANDS[tool]?.[platform] ?? [];
+}
+
+/**
+ * Results that require the USER's hands. `manual`/`failed`/`needs-user`
+ * always qualify; `declined` only when nobody actually declined — a non-TTY
+ * run without --yes auto-answers the default, which for sudo installs is
+ * "no". A real interactive decline stays the user's own decision.
+ */
+export function collectPending(results, { tty = Boolean(process.stdin.isTTY), yes = false } = {}) {
+  return results.filter((r) => PENDING.has(r.action) || (r.action === "declined" && !tty && !yes));
+}
+
+/** The PENDING USER ACTION block: exact commands for THIS OS, then wait. */
+export function renderPendingBlock(pending, { platform = process.platform, retry = "kj install-tools" } = {}) {
+  const lines = [
+    "════ PENDING USER ACTION ════════════════════════════════════════",
+    "kj could not finish this install by itself (sudo or a platform",
+    "installer is required). Karajan needs a COMPLETE environment —",
+    "do not continue degraded.",
+    "",
+    "Run in YOUR terminal:",
+    "",
+  ];
+  for (const r of pending) {
+    const why = r.error ? `install failed: ${r.error}` : r.reason || "no automatic route on this machine";
+    lines.push(`  ▸ ${r.tool}  (${why})`);
+    const commands = r.commands
+      ?? (r.command ? [r.command] : null)
+      ?? (r.suggested ? [r.suggested] : null)
+      ?? (osCommandsFor(r.tool, platform).length > 0 ? osCommandsFor(r.tool, platform) : null)
+      ?? [`see ${r.manualUrl || "the tool's install docs"}`];
+    for (const c of commands) lines.push(`      ${c}`);
+    lines.push("");
+  }
+  lines.push(
+    `When done, re-run: ${retry}`,
+    "Agents: STOP here, show this block to your user, and WAIT for their",
+    `go-ahead. Exit code ${PENDING_EXIT_CODE} means "pending user action" — never proceed past it.`,
+  );
+  return lines.join("\n");
+}

--- a/tests/commands/install-tools.test.js
+++ b/tests/commands/install-tools.test.js
@@ -321,6 +321,28 @@ describe("kj install-tools — stack-aware lighthouse", () => {
   });
 });
 
+describe("kj install-tools — stop-on-sudo (KJC-TSK-0659)", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("exits with the distinctive pending code and emits the block when a tool needs the user", async () => {
+    // default docker mock → "manual" route (platform installer required)
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { exitCode, pending } = await installToolsCommand({ only: "docker", yes: true, logger });
+    expect(pending.map((r) => r.tool)).toEqual(["docker"]);
+    expect(exitCode).toBe(3);
+    const warned = logger.warn.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(warned).toMatch(/PENDING USER ACTION/);
+    expect(warned).toMatch(/WAIT/);
+  });
+
+  it("keeps exit 0 in dry-run even when routes are manual (planning is not degradation)", async () => {
+    const { installToolsCommand } = await import("../../src/commands/install-tools.js");
+    const { exitCode } = await installToolsCommand({ only: "docker", dryRun: true, logger: silentLogger });
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("parseOnlyList", () => {
   beforeEach(() => { vi.clearAllMocks(); });
 

--- a/tests/utils/pending-user-action.test.js
+++ b/tests/utils/pending-user-action.test.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0659 — stop-on-sudo: pending-user-action classification + block.
+import { describe, it, expect } from "vitest";
+import { collectPending, renderPendingBlock, osCommandsFor, PENDING_EXIT_CODE } from "../../src/utils/pending-user-action.js";
+
+describe("collectPending", () => {
+  it("keeps manual/failed/needs-user, drops installed and skipped", () => {
+    const results = [
+      { tool: "semgrep", action: "installed" },
+      { tool: "docker", action: "manual", manualUrl: "https://docs.docker.com" },
+      { tool: "git", action: "failed", error: "exit 100" },
+      { tool: "lighthouse", action: "skipped" },
+      { tool: "sonar", action: "needs-user" },
+    ];
+    expect(collectPending(results, { tty: true }).map((r) => r.tool)).toEqual(["docker", "git", "sonar"]);
+  });
+
+  it("treats a non-TTY auto-decline as pending (nobody actually declined)", () => {
+    const results = [{ tool: "docker", action: "declined", command: "sudo apt-get install -y docker.io" }];
+    expect(collectPending(results, { tty: false, yes: false })).toHaveLength(1);
+    // A real interactive decline is the user's own decision — not pending.
+    expect(collectPending(results, { tty: true, yes: false })).toHaveLength(0);
+    // With --yes the decline was explicit input upstream — not reclassified.
+    expect(collectPending(results, { tty: false, yes: true })).toHaveLength(0);
+  });
+});
+
+describe("renderPendingBlock", () => {
+  it("emits exact per-OS commands for the detected platform and orders agents to wait", () => {
+    const block = renderPendingBlock(
+      [{ tool: "docker", action: "manual", reason: "platform installer required" }],
+      { platform: "linux" },
+    );
+    expect(block).toMatch(/PENDING USER ACTION/);
+    expect(block).toMatch(/sudo apt-get install -y docker\.io/);
+    expect(block).toMatch(/sudo dnf install -y docker/);
+    expect(block).toMatch(/STOP here/);
+    expect(block).toMatch(new RegExp(`Exit code ${PENDING_EXIT_CODE}`));
+    expect(block).not.toMatch(/winget/); // only THIS OS's commands
+  });
+
+  it("prefers the exact command the run already computed over the generic table", () => {
+    const block = renderPendingBlock(
+      [{ tool: "git", action: "declined", command: "sudo dnf install -y git" }],
+      { platform: "linux" },
+    );
+    expect(block).toMatch(/sudo dnf install -y git/);
+    expect(block).not.toMatch(/apt-get install -y git/);
+  });
+
+  it("falls back to the manual URL when no command is known", () => {
+    const block = renderPendingBlock([{ tool: "weird", action: "manual", manualUrl: "https://x.dev" }], { platform: "linux" });
+    expect(block).toMatch(/see https:\/\/x\.dev/);
+  });
+});
+
+describe("osCommandsFor", () => {
+  it("covers ollama per OS (reused by kj env install when the RAG cannot index)", () => {
+    expect(osCommandsFor("ollama", "darwin").join(" ")).toMatch(/brew install ollama/);
+    expect(osCommandsFor("ollama", "linux").join(" ")).toMatch(/ollama\.com\/install\.sh/);
+    expect(osCommandsFor("ollama", "win32").join(" ")).toMatch(/winget/);
+    expect(osCommandsFor("nope", "linux")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Qué
Política stop-on-sudo (KJC-TSK-0659, feedback de campo 2026-07-21): cuando una herramienta no se puede instalar de forma automática (sudo necesario, sin ruta en este OS, o el intento falló), `kj install-tools` deja de continuar degradado:

- Nuevo `src/utils/pending-user-action.js`: clasifica resultados pendientes, tabla de comandos exactos por OS (Linux apt/dnf, macOS brew, Windows winget/WSL — incluye ollama para reutilización desde `env install`) y renderiza UN bloque `PENDING USER ACTION` que ordena al agente PARAR y ESPERAR.
- Exit code distintivo **3** = pending user action.
- Un "declined" automático en no-TTY sin `--yes` se reclasifica como pendiente (nadie declinó de verdad); un decline interactivo real se respeta.
- `--dry-run` mantiene exit 0 (planificar no es degradación).

## Tests
- 32 tests en `pending-user-action.test.js` + `install-tools.test.js` (clasificación, render por OS, preferencia por el comando ya computado, exit 3, dry-run).
- Suite completa: 6205 passed.

Parte 1/2 de KJC-TSK-0659 — la parte 2 hace que `kj env install` bloquee cuando el RAG no puede indexar.