### PR TITLE
fix(harden): seed-if-absent checks every same-tool config variant (KJC-BUG-0119)

### DIFF
--- a/src/harden/advisory.js
+++ b/src/harden/advisory.js
@@ -21,10 +21,37 @@ const BLOCK_VERSION = 1; // current version every markered config ships at
 // Other filenames/formats for the same artifact, so kj never reports a false
 // "missing". `pkgKey` is a package.json field that can hold inline config.
 const EQUIVALENTS = {
-  commitlint: { files: [".commitlintrc", ".commitlintrc.js", ".commitlintrc.json", ".commitlintrc.yaml"], pkgKey: "commitlint" },
-  eslint: { files: ["eslint.config.mjs", ".eslintrc.js", ".eslintrc.cjs", ".eslintrc.json", ".eslintrc.yaml"], pkgKey: "eslintConfig" },
-  prettier: { files: [".prettierrc", ".prettierrc.js", ".prettierrc.yaml", "prettier.config.js"], pkgKey: "prettier" },
+  commitlint: { files: [".commitlintrc", ".commitlintrc.js", ".commitlintrc.cjs", ".commitlintrc.mjs", ".commitlintrc.json", ".commitlintrc.yaml", ".commitlintrc.yml", "commitlint.config.mjs", "commitlint.config.cjs", "commitlint.config.ts"], pkgKey: "commitlint" },
+  eslint: { files: ["eslint.config.mjs", "eslint.config.cjs", "eslint.config.ts", "eslint.config.mts", "eslint.config.cts", ".eslintrc.js", ".eslintrc.cjs", ".eslintrc.json", ".eslintrc.yaml", ".eslintrc.yml"], pkgKey: "eslintConfig" },
+  prettier: { files: [".prettierrc", ".prettierrc.js", ".prettierrc.yaml", ".prettierrc.yml", ".prettierrc.json5", ".prettierrc.toml", "prettier.config.js", "prettier.config.mjs", "prettier.config.cjs", "prettier.config.ts"], pkgKey: "prettier" },
 };
+
+/**
+ * KJC-BUG-0119 — same-tool filename variant for `artifactId` in any of
+ * `searchDirs` (file or inline package.json config); null when none exists.
+ * Seeding kj's default filename NEXT TO a variant eclipses the user's real
+ * config (eslint resolves eslint.config.js before .mjs), so config-engine
+ * must consult this before treating an artifact as absent.
+ */
+export function findEquivalentIn(searchDirs, artifactId) {
+  const spec = EQUIVALENTS[artifactId];
+  if (!spec) return null;
+  for (const dir of searchDirs) {
+    for (const rel of spec.files) {
+      if (existsSync(join(dir, rel))) return rel;
+    }
+    if (spec.pkgKey && existsSync(join(dir, "package.json"))) {
+      try {
+        if (JSON.parse(readFileSync(join(dir, "package.json"), "utf8"))[spec.pkgKey] != null) {
+          return `package.json#${spec.pkgKey}`;
+        }
+      } catch {
+        /* unreadable package.json → not a match */
+      }
+    }
+  }
+  return null;
+}
 
 // Concrete gains kj's standard would add to a USER_OWNED config, detected by
 // substring probes (no AST parse): each probe absent from the user's content
@@ -70,19 +97,8 @@ function toArtifact(cfg) {
 
 /** Locate the user's file for an artifact under `searchDir`; null if absent. */
 function findArtifactFile(searchDir, artifact) {
-  for (const rel of [artifact.file, ...artifact.equivalents]) {
-    if (existsSync(join(searchDir, rel))) return rel;
-  }
-  if (artifact.pkgKey && existsSync(join(searchDir, "package.json"))) {
-    try {
-      if (JSON.parse(readFileSync(join(searchDir, "package.json"), "utf8"))[artifact.pkgKey] != null) {
-        return `package.json#${artifact.pkgKey}`;
-      }
-    } catch {
-      /* unreadable package.json → not a match */
-    }
-  }
-  return null;
+  if (existsSync(join(searchDir, artifact.file))) return artifact.file;
+  return findEquivalentIn([searchDir], artifact.id);
 }
 
 /** Read the artifact body, or the JSON of an inline package.json key. */

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -9,6 +9,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import { upsertManagedBlock } from "../utils/managed-markers.js";
+import { findEquivalentIn } from "./advisory.js";
 import { artifactIdForConfig, findAlternative } from "./alternatives.js";
 import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 
@@ -35,6 +36,15 @@ function seedInto(targetDir, configs, dryRun, prefix, results, altDirs = [target
       const alt = findAlternative(altDirs, artifactIdForConfig(cfg));
       if (alt) {
         results.push({ file, action: "covered", by: alt.foundAt });
+        continue;
+      }
+      // KJC-BUG-0119: a same-tool variant (eslint.config.mjs, .eslintrc.json,
+      // package.json#eslintConfig…) means the config already EXISTS — seeding
+      // kj's default filename next to it would silently ECLIPSE the user's
+      // real config (eslint resolves eslint.config.js before .mjs).
+      const variant = findEquivalentIn(altDirs, artifactIdForConfig(cfg));
+      if (variant) {
+        results.push({ file, action: "covered", by: variant });
         continue;
       }
     }

--- a/tests/harden/config-engine.test.js
+++ b/tests/harden/config-engine.test.js
@@ -58,6 +58,44 @@ describe("installConfigs", () => {
     expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
   });
 
+  // KJC-BUG-0119 (field, 2026-07-21): harden created eslint.config.js in a
+  // Next.js repo that already had eslint.config.mjs — ESLint resolves .js
+  // BEFORE .mjs, so the generated file silently eclipsed the project's real
+  // linting. Any same-tool variant must count as "the config exists".
+  it("never seeds eslint.config.js next to eslint.config.mjs (KJC-BUG-0119)", () => {
+    writeFileSync(join(dir, "eslint.config.mjs"), "export default [];\n");
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    const eslintEntry = res.configs.find((c) => c.file === "eslint.config.js");
+    expect(eslintEntry).toMatchObject({ action: "covered", by: "eslint.config.mjs" });
+    expect(existsSync(join(dir, "eslint.config.js"))).toBe(false);
+  });
+
+  it("covers legacy .eslintrc.json and inline package.json config too", () => {
+    writeFileSync(join(dir, ".eslintrc.json"), "{}");
+    writeFileSync(join(dir, "package.json"), '{"prettier":{"printWidth":80}}');
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    const byFile = Object.fromEntries(res.configs.map((c) => [c.file, c]));
+    expect(byFile["eslint.config.js"]).toMatchObject({ action: "covered", by: ".eslintrc.json" });
+    expect(byFile[".prettierrc.json"]).toMatchObject({ action: "covered", by: "package.json#prettier" });
+    expect(existsSync(join(dir, "eslint.config.js"))).toBe(false);
+    expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
+  });
+
+  it("covers a YAML commitlint config (.commitlintrc.yml) instead of seeding", () => {
+    writeFileSync(join(dir, ".commitlintrc.yml"), "extends: ['@commitlint/config-conventional']\n");
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    const byFile = Object.fromEntries(res.configs.map((c) => [c.file, c]));
+    expect(byFile["commitlint.config.js"]).toMatchObject({ action: "covered", by: ".commitlintrc.yml" });
+    expect(existsSync(join(dir, "commitlint.config.js"))).toBe(false);
+  });
+
+  it("still seeds when no variant of the tool exists", () => {
+    writeFileSync(join(dir, "eslint.config.mjs"), "export default [];\n");
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    // prettier has no variant here → seeds normally alongside the mjs eslint.
+    expect(res.configs.find((c) => c.file === ".prettierrc.json").action).toBe("inserted");
+  });
+
   it("never seeds eslint/prettier next to biome.json (KJC-TSK-0614)", () => {
     writeFileSync(join(dir, "biome.json"), "{}");
     const res = installConfigs({ projectDir: dir, language: "javascript" });


### PR DESCRIPTION
## Bug (campo, 2026-07-21)
`kj harden` creó `eslint.config.js` en un repo Next.js que YA tenía `eslint.config.mjs`. ESLint resuelve `.js` antes que `.mjs`, así que el fichero generado **eclipsó en silencio el linting real del proyecto**.

## Causa raíz
`seedInto` (config-engine) solo comprobaba el nombre canónico exacto y las alternativas cross-tool (Biome). Las variantes del MISMO tool (`eslint.config.mjs`, `.eslintrc.*`, `package.json#eslintConfig`…) viven en `EQUIVALENTS` del advisory, que el config-engine no consultaba.

## Fix
- Nuevo export `findEquivalentIn(searchDirs, artifactId)` en advisory.js (ficheros + config inline en package.json); `findArtifactFile` refactorizado sobre él (DRY).
- `seedInto` lo consulta antes de sembrar: cualquier variante ⇒ `covered`, nunca se crea el fichero.
- `EQUIVALENTS` completado: eslint (`.cjs/.ts/.mts/.cts/.yml`), commitlint (`.cjs/.mjs/.yml`, `commitlint.config.{mjs,cjs,ts}`), prettier (`.yml/.json5/.toml`, `prettier.config.{mjs,cjs,ts}`).

## Tests
5 regresiones nuevas (mjs eclipse, .eslintrc.json, package.json inline, .commitlintrc.yml, seed normal sin variante). tests/harden completo: 110 passed.