### PR TITLE
feat(env): install blocks when the RAG cannot index (KJC-TSK-0659)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -135,7 +135,10 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--no-rag", "Skip building the RAG index when the project has none (ENV-E1)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "env-install", flags, async ({ config, logger }) => {
-        await envInstallCommand({ config, logger, flags });
+        const r = await envInstallCommand({ config, logger, flags });
+        // KJC-TSK-0659: exit 3 = pending user action (RAG cannot index) —
+        // a driving agent must stop and wait, never continue degraded.
+        if (Number.isInteger(r?.exitCode) && r.exitCode !== 0) process.exit(r.exitCode);
       });
     });
 

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -8,6 +8,7 @@ import { installPlaybook } from "../environment/playbook.js";
 import { renderBrief, listBriefs } from "../environment/briefs.js";
 import { openVecStore, projectSlug, getLastIndexedCommit } from "../rag/vec-store.js";
 import { ragIndexCommand } from "./rag.js";
+import { renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-action.js";
 
 function hasRagIndex(config, projectDir) {
   const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
@@ -42,21 +43,38 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
   console.log(`✓ Karajan playbook installed in: ${result.files.join(", ")}`);
 
   // ENV-E1: RAG-first — the playbook orders "query the RAG before coding",
-  // so installing the environment guarantees the index exists. An indexing
-  // failure is reported but never blocks the playbook install.
+  // so installing the environment guarantees the index exists. KJC-TSK-0659
+  // stop-on-sudo: an index that cannot be built is a BLOCKING condition —
+  // "success" with 0 chunks would leave every future session running the
+  // method against an empty RAG (field-reproduced: 0/727 without Ollama).
+  // The playbook stays installed; the command exits 3 so the driving agent
+  // stops, shows the block, and waits for the user.
   if (flags.rag !== false) {
+    const provider = config?.rag?.embedder?.provider || "ollama";
+    const blockRag = (why) => {
+      result.ragError = why;
+      result.exitCode = PENDING_EXIT_CODE;
+      const item = provider === "ollama"
+        ? { tool: "ollama", action: "needs-user", reason: `the RAG cannot index: ${why}` }
+        : { tool: `${provider} embedder`, action: "needs-user", reason: `the RAG cannot index: ${why} — check rag.embedder in kj config`, manualUrl: "kj config" };
+      console.log(renderPendingBlock([item], { retry: "kj rag index --with-sources   (then re-run: kj env install)" }));
+    };
     try {
       if (hasRagIndex(config, projectDir)) {
         console.log("✓ RAG index present");
       } else {
         console.log("⏳ no RAG index for this project — building it (first time only)…");
-        await ragIndexCommand({ config, logger, flags: { withSources: true } });
+        const totals = await ragIndexCommand({ config, logger, flags: { withSources: true } });
+        if ((totals?.indexed ?? 0) === 0 && (totals?.files ?? 0) > 0) {
+          blockRag(`0 of ${totals.files} files indexed — is the embedder running?`);
+        }
       }
     } catch (err) {
-      result.ragError = err.message;
-      console.log(`⚠ RAG index could not be built (${err.message}) — run \`kj rag index --with-sources\` later`);
+      blockRag(err.message);
     }
   }
-  console.log("  The host agent now follows the method: RAG first, TDD, cross-AI review before commit.");
+  if (result.exitCode !== PENDING_EXIT_CODE) {
+    console.log("  The host agent now follows the method: RAG first, TDD, cross-AI review before commit.");
+  }
   return result;
 }

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -29,7 +29,7 @@ const TARGET_FILES = {
 // ENV-D1 (KJC-TSK-0642): the tracking invariant names the CHOSEN state
 // backend — a playbook that says "board or PG" makes the host guess.
 const BACKEND_TRACKING = {
-  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj board`) before it starts.",
+  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj hu add` / `kj board`) before it starts.",
   "planning-game": "Every piece of work has a tracked card in the Planning Game MCP before it starts (In Progress while you work it).",
 };
 
@@ -58,8 +58,9 @@ Invariants (the git gates enforce these — they are not suggestions):
   through an atomic PR (~150 net lines, Conventional Commits).
 
 Commands: \`kj rag query\` · \`kj brief <role>\` (triage, planner, researcher,
-architect, tester, security, audit) · \`kj review --staged\` · \`kj review --check\` ·
-\`kj solomon --position\` · \`kj agent run <agent>\` · \`kj report\` · \`kj check\`
+architect, tester, security, audit) · \`kj hu add|move|list\` · \`kj adr add|list\` ·
+\`kj review --staged\` · \`kj review --check\` · \`kj solomon --position\` ·
+\`kj agent run <agent>\` · \`kj report\` · \`kj check\`
 
 Hit a kj bug or friction? Diagnose it and file it upstream with
 \`kj report-issue\` (sanitized; ask your user before \`--publish\`).

--- a/tests/environment/rag-first.test.js
+++ b/tests/environment/rag-first.test.js
@@ -14,7 +14,8 @@ vi.mock("../../src/commands/rag.js", () => ({
   ragIndexCommand: vi.fn().mockResolvedValue({ ok: true }),
 }));
 vi.mock("../../src/environment/playbook.js", () => ({
-  installPlaybook: vi.fn().mockResolvedValue({ files: ["CLAUDE.md", "AGENTS.md"], target: "both" }),
+  // fresh object per call — envInstallCommand mutates its result
+  installPlaybook: vi.fn(async () => ({ files: ["CLAUDE.md", "AGENTS.md"], target: "both" })),
 }));
 
 import { envInstallCommand } from "../../src/commands/env.js";
@@ -45,11 +46,40 @@ describe("env install is RAG-first", () => {
     expect(ragIndexCommand).not.toHaveBeenCalled();
   });
 
-  it("index failure does not break the playbook install (reported, not thrown)", async () => {
+  // KJC-TSK-0659 stop-on-sudo: a RAG that cannot index BLOCKS (exit 3) —
+  // never "success" with an empty index. The playbook stays installed.
+  it("index failure blocks with pending-user-action (exit 3), playbook still installed", async () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockRejectedValueOnce(new Error("ollama down"));
+    const logs = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
     const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
     expect(res.files).toContain("CLAUDE.md");
     expect(res.ragError).toMatch(/ollama down/);
+    expect(res.exitCode).toBe(3);
+    const out = logs.join("\n");
+    expect(out).toMatch(/PENDING USER ACTION/);
+    expect(out).toMatch(/ollama/);
+    expect(out).toMatch(/kj rag index --with-sources/);
+  });
+
+  it("an index that embeds 0 of N files blocks too — empty is not success", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    ragIndexCommand.mockResolvedValueOnce({ indexed: 0, files: 727, failed: 727 });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
+    expect(res.exitCode).toBe(3);
+    expect(res.ragError).toMatch(/0 of 727/);
+  });
+
+  it("a healthy first index does not block", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    ragIndexCommand.mockResolvedValueOnce({ indexed: 512, files: 700, failed: 0 });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
+    expect(res.exitCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Qué
Parte 2/2 de KJC-TSK-0659 (stop-on-sudo). `kj env install` deja de reportar éxito con un RAG vacío (campo 2026-07-21: 0/727 chunks sin Ollama y la sesión siguió "con criterio"):

- Si el primer indexado termina con **0 chunks sobre N ficheros** o el embedder revienta, el comando emite el bloque `PENDING USER ACTION` (instrucciones de Ollama por OS vía `pending-user-action.js` del #1252, o aviso de config para providers cloud) y **sale con código 3**. El playbook queda instalado; lo que no queda es un éxito falso.
- `register-meta` propaga el exit code.
- Playbook: la invariante hu-board menciona `kj hu add` y la línea de comandos añade `kj hu add|move|list` · `kj adr add|list` (cierre del fleco AB-H).

## Tests
`rag-first.test.js`: bloqueo por excepción del embedder (exit 3 + bloque), bloqueo por 0/N indexados, primer indexado sano no bloquea; mock de `installPlaybook` corregido para devolver objeto fresco por llamada.