### PR TITLE
fix(install): distro-aware semgrep guidance — PEP 668 safe (KJC-BUG-0120)

### DIFF
--- a/src/utils/binary-sources.js
+++ b/src/utils/binary-sources.js
@@ -44,6 +44,12 @@ export function osvScannerSource(platform = process.platform, arch = process.arc
  */
 export function semgrepFallback(available = {}) {
   if (available.docker) return { via: "docker", command: "docker pull semgrep/semgrep" };
+  // KJC-BUG-0120 (issue #1256): on Debian/Ubuntu-like systems the system
+  // Python is externally managed (PEP 668) and often ships without pip at
+  // all — `python3 -m pip install --user` is guaranteed to fail there.
+  // pipx must come from the distro's own package manager.
+  if (available.apt) return { via: "apt", command: "sudo apt update && sudo apt install -y pipx && pipx install semgrep" };
+  if (available.dnf) return { via: "dnf", command: "sudo dnf install -y pipx && pipx install semgrep" };
   return { via: "pipx", command: "python3 -m pip install --user pipx && pipx install semgrep" };
 }
 

--- a/src/utils/install-hints.js
+++ b/src/utils/install-hints.js
@@ -80,8 +80,13 @@ export async function getInstallHint(tool, available = null) {
   for (const { manager, command } of candidates) {
     if (avail[manager]) return { command, manager, manualUrl: MANUAL_URLS[tool] };
   }
-  // Nothing matched — fall back to the first candidate's command as a
-  // suggestion, so the user at least sees a working recipe.
+  // Nothing matched — suggest a recipe that actually works on this system.
+  // KJC-BUG-0120 (issue #1256): distro-aware fallbacks first (PEP 668 makes
+  // the generic pip bootstrap fail on Debian/Ubuntu); these are display-only
+  // (manager: null), never auto-run — sudo stays in the user's hands.
+  for (const { when, command } of DISTRO_FALLBACKS[tool] || []) {
+    if (avail[when]) return { command, manager: null, manualUrl: MANUAL_URLS[tool] };
+  }
   const first = candidates[0];
   return {
     command: first ? first.command : null,
@@ -89,6 +94,13 @@ export async function getInstallHint(tool, available = null) {
     manualUrl: MANUAL_URLS[tool],
   };
 }
+
+const DISTRO_FALLBACKS = {
+  semgrep: [
+    { when: "apt", command: "sudo apt update && sudo apt install -y pipx && pipx install semgrep" },
+    { when: "dnf", command: "sudo dnf install -y pipx && pipx install semgrep" },
+  ],
+};
 
 const INSTALL_CANDIDATES = {
   semgrep: [

--- a/src/utils/pending-user-action.js
+++ b/src/utils/pending-user-action.js
@@ -25,7 +25,9 @@ const OS_COMMANDS = {
     win32: ["winget install Git.Git"],
   },
   semgrep: {
-    linux: ["python3 -m pip install --user semgrep   # or: pipx install semgrep"],
+    // PEP 668 (#1256): system Python is externally managed on modern
+    // distros — pipx comes from the distro package manager, never from pip.
+    linux: ["sudo apt update && sudo apt install -y pipx && pipx install semgrep   # Debian/Ubuntu", "sudo dnf install -y pipx && pipx install semgrep   # Fedora/RHEL"],
     darwin: ["brew install semgrep"],
     win32: ["python -m pip install --user semgrep"],
   },
@@ -75,10 +77,11 @@ export function renderPendingBlock(pending, { platform = process.platform, retry
   for (const r of pending) {
     const why = r.error ? `install failed: ${r.error}` : r.reason || "no automatic route on this machine";
     lines.push(`  ▸ ${r.tool}  (${why})`);
-    const commands = r.commands
-      ?? (r.command ? [r.command] : null)
-      ?? (r.suggested ? [r.suggested] : null)
-      ?? (osCommandsFor(r.tool, platform).length > 0 ? osCommandsFor(r.tool, platform) : null)
+    const os = osCommandsFor(r.tool, platform);
+    const own = r.commands ?? (r.command ? [r.command] : null) ?? (r.suggested ? [r.suggested] : null);
+    // A FAILED install must not be re-suggested verbatim (#1256: the pip
+    // route that just broke) — the curated per-OS route goes first there.
+    const commands = (r.action === "failed" ? (os.length > 0 ? os : own) : (own ?? (os.length > 0 ? os : null)))
       ?? [`see ${r.manualUrl || "the tool's install docs"}`];
     for (const c of commands) lines.push(`      ${c}`);
     lines.push("");

--- a/tests/utils/binary-sources.test.js
+++ b/tests/utils/binary-sources.test.js
@@ -45,6 +45,26 @@ describe("semgrepFallback", () => {
     expect(f.via).toBe("pipx");
     expect(f.command).toMatch(/pipx install semgrep/);
   });
+
+  // KJC-BUG-0120 (issue #1256): PEP 668 — on apt/dnf systems pipx must come
+  // from the distro, never from `python3 -m pip install --user` (which fails
+  // outright when the system Python ships without pip).
+  it("routes through apt on Debian/Ubuntu (PEP 668 safe, apt update first)", () => {
+    const f = semgrepFallback({ apt: true });
+    expect(f.via).toBe("apt");
+    expect(f.command).toMatch(/^sudo apt update && sudo apt install -y pipx/);
+    expect(f.command).not.toMatch(/pip install --user/);
+  });
+
+  it("routes through dnf on Fedora/RHEL", () => {
+    const f = semgrepFallback({ dnf: true });
+    expect(f.via).toBe("dnf");
+    expect(f.command).toMatch(/sudo dnf install -y pipx && pipx install semgrep/);
+  });
+
+  it("still prefers docker over the distro routes", () => {
+    expect(semgrepFallback({ docker: true, apt: true }).via).toBe("docker");
+  });
 });
 
 describe("resolveStandalone", () => {

--- a/tests/utils/install-hints.test.js
+++ b/tests/utils/install-hints.test.js
@@ -49,6 +49,26 @@ describe("getInstallHint — manager prioritization", () => {
     expect(hint.command).toBe("pipx install semgrep");
   });
 
+  // KJC-BUG-0120 (issue #1256): the no-match fallback must be distro-aware —
+  // PEP 668 makes the generic pip/pipx bootstrap fail on Debian/Ubuntu.
+  it("suggests the apt pipx route on Debian when no runnable manager matches", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: false, brew: false, pip: false, apt: true });
+    expect(hint.manager).toBeNull(); // display-only: sudo never auto-runs
+    expect(hint.command).toBe("sudo apt update && sudo apt install -y pipx && pipx install semgrep");
+  });
+
+  it("suggests the dnf pipx route on Fedora when no runnable manager matches", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: false, brew: false, pip: false, dnf: true });
+    expect(hint.manager).toBeNull();
+    expect(hint.command).toMatch(/^sudo dnf install -y pipx/);
+  });
+
+  it("a runnable manager (pipx) still wins over the distro fallback", async () => {
+    const hint = await getInstallHint("semgrep", { pipx: true, apt: true });
+    expect(hint.manager).toBe("pipx");
+    expect(hint.command).toBe("pipx install semgrep");
+  });
+
   it("always includes the manual URL", async () => {
     const hint = await getInstallHint("semgrep", { pipx: true });
     expect(hint.manualUrl).toMatch(/semgrep\.dev/);

--- a/tests/utils/pending-user-action.test.js
+++ b/tests/utils/pending-user-action.test.js
@@ -47,6 +47,16 @@ describe("renderPendingBlock", () => {
     expect(block).not.toMatch(/apt-get install -y git/);
   });
 
+  it("a FAILED install prefers the curated per-OS route over re-suggesting the broken command", () => {
+    const block = renderPendingBlock(
+      [{ tool: "semgrep", action: "failed", command: "pip install semgrep", error: "externally-managed-environment" }],
+      { platform: "linux" },
+    );
+    expect(block).toMatch(/sudo apt update && sudo apt install -y pipx/);
+    expect(block).not.toMatch(/ {6}pip install semgrep/); // the broken route is not the instruction
+    expect(block).toMatch(/externally-managed-environment/); // the error still explains WHY
+  });
+
   it("falls back to the manual URL when no command is known", () => {
     const block = renderPendingBlock([{ tool: "weird", action: "manual", manualUrl: "https://x.dev" }], { platform: "linux" });
     expect(block).toMatch(/see https:\/\/x\.dev/);


### PR DESCRIPTION
Fixes #1256 — primera issue de campo del ciclo self-healing (abierta vía `kj report-issue` desde el portátil del usuario). 🎉

## Bug
En Debian 12+/13 la guía de semgrep (`python3 -m pip install --user pipx && pipx install semgrep`) falla dos veces: el Python del sistema no trae pip, y con pip instalado PEP 668 (externally-managed-environment) bloquea `pip install --user`.

## Fix
- `semgrepFallback`: rutas distro (apt con `apt update` previo / dnf → `pipx` del sistema) antes del bootstrap genérico; docker sigue primero.
- `getInstallHint`: fallback sin manager ejecutable ahora es distro-aware (`DISTRO_FALLBACKS`, display-only — sudo jamás se auto-ejecuta, entra por el flujo stop-on-sudo).
- `PENDING USER ACTION`: un install FALLIDO ya no re-sugiere el comando roto — prioriza la ruta curada por OS; el error sigue visible como explicación. Tabla semgrep/linux actualizada a las rutas distro.

## Tests
8 nuevos (fallback apt/dnf, precedencia docker/pipx, render de fallos). 68 en los 4 ficheros afectados.