### PR TITLE
docs(prompts): versioned bootstrap prompts + start.md router (KJC-TSK-0663)

### DIFF
--- a/docs/prompts/install-machine.md
+++ b/docs/prompts/install-machine.md
@@ -1,0 +1,37 @@
+# Karajan — machine install (agent instructions)
+
+Goal: leave this machine FULLY operational for Karajan — not a partial
+install. Ask before each install; never install silently. The HARD RULE from
+[start.md](https://karajancode.com/start.md) applies to every step: sudo, no
+automatic route, or `kj` exit code 3 → STOP, show the commands, WAIT.
+
+## 1. Install kj (full product)
+
+```sh
+curl -fsSL https://karajancode.com/install.sh | sh
+```
+
+It uses the machine's Node if ≥ 22.12, or auto-provisions the official Node
+LTS into `~/.karajan/node` (checksum-verified, nothing system-wide). Review
+the script first, as you always should. Equivalent: `npm install -g
+karajan-code`.
+
+## 2. Diagnose, then complete the stack
+
+Run `kj doctor` and explain every issue to the user. Then run
+`kj install-tools` to complete the whole stack: git, agent CLIs, Docker +
+SonarQube, Semgrep, OSV-Scanner, Lighthouse, RTK, Squeezr, QMD — asking the
+user before each install.
+
+When `kj install-tools` exits with code 3 it prints a `PENDING USER ACTION`
+block with the exact per-OS commands: show it, wait for the user, then re-run
+`kj install-tools` until nothing is pending.
+
+## 3. Verify
+
+Run `kj doctor` again. Done means: no pending tools, and you can tell the
+user exactly what (if anything) still limits Karajan here — e.g. no third
+agent CLI for arbitration — and how to lift it.
+
+Then go back to [start.md](https://karajancode.com/start.md) step 2 to
+activate the project.

--- a/docs/prompts/project-legacy.md
+++ b/docs/prompts/project-legacy.md
@@ -1,0 +1,49 @@
+# Karajan — adopt Karajan in an EXISTING project (agent instructions)
+
+Goal: this codebase keeps its history, tooling and conventions — Karajan
+governs from here on without breaking anything that already works. Requires
+kj on the machine
+([install-machine.md](https://karajancode.com/install-machine.md) if not).
+The HARD RULE from [start.md](https://karajancode.com/start.md) applies.
+
+## 1. Respect what exists
+
+- Work on a branch, never directly on the default branch.
+- kj seeds configs only when NO variant exists (an `eslint.config.mjs`, a
+  `.prettierrc`, a biome.json… all count as "exists"). If `kj harden`
+  reports something as `covered` or `skipped`, that is correct behavior —
+  do not force kj's defaults over the project's own.
+
+## 2. Understand the codebase
+
+```sh
+kj onboard        # brownfield analysis → Architecture Brief
+```
+
+Read the brief before proposing anything.
+
+## 3. Activate the environment
+
+```sh
+kj init                    # detects the stack; respects existing config
+kj env install             # method into the rules files + RAG over the EXISTING code
+kj harden                  # hooks; seed-if-absent, never eclipses real configs
+kj review --install-gate   # commits now REQUIRE a cross-AI verdict
+git config core.hooksPath .karajan/hooks
+```
+
+The RAG index over the existing code is the main prize: from now on you query
+it (`kj rag query`) instead of guessing what the codebase does.
+
+## 4. Contract via the project's own flow
+
+Commit `.karajan/review-gate`, `.karajan/hooks/`, `.karajan/adrs/` and the
+rules files through the project's normal flow (branch + PR if that is how
+this repo works). Every teammate who pulls inherits the environment.
+
+## 5. Hand over
+
+Run `kj doctor`, summarize the Architecture Brief to the user, and ask what
+to develop next. Track it with `kj hu add "<story>"` (card first) and work
+under the method: RAG before assuming, tests first, cross-AI review before
+every commit, atomic branch + PR.

--- a/docs/prompts/project-new.md
+++ b/docs/prompts/project-new.md
@@ -1,0 +1,38 @@
+# Karajan — activate a NEW project (agent instructions)
+
+Goal: this empty (or nearly empty) directory becomes a Karajan-governed
+project. Requires kj on the machine
+([install-machine.md](https://karajancode.com/install-machine.md) if not).
+The HARD RULE from [start.md](https://karajancode.com/start.md) applies.
+
+## 1. Repository first
+
+If there is no git repo yet: `git init` (ask the user about remote/hosting —
+do not create a public repo without their explicit OK).
+
+## 2. Activate the environment
+
+```sh
+kj init                    # config, rules, quality tooling (agent-safe without a TTY)
+kj env install             # method into the rules files + builds the RAG index
+kj harden                  # git hooks: lint, commit policy, review-gate runner
+kj review --install-gate   # commits now REQUIRE a cross-AI verdict
+git config core.hooksPath .karajan/hooks
+```
+
+`kj env install` exits 3 if the RAG cannot index (missing embedder) — stop
+and wait, as always.
+
+## 3. Commit the contract
+
+Commit the generated contract files — `.karajan/review-gate`,
+`.karajan/hooks/`, `.karajan/adrs/`, the agent rules files — so anyone who
+clones inherits the environment (each clone repeats the `core.hooksPath`
+config once).
+
+## 4. Hand over
+
+Run `kj doctor`, then ask the user what to build. Their answer becomes the
+first tracked work: create it with `kj hu add "<story>"` (card first), and
+develop it under the method — RAG before assuming, tests first, cross-AI
+review before every commit, atomic branch + PR.

--- a/docs/prompts/start.md
+++ b/docs/prompts/start.md
@@ -1,0 +1,43 @@
+# Karajan — start here (agent instructions)
+
+You are an AI agent (Claude Code, Codex, Gemini CLI, Cursor…). Your user wants
+to use Karajan Code (`kj`, karajancode.com) in the current project. Route
+yourself through these steps and report progress in the user's language.
+
+## 0. HARD RULE — stop and wait
+
+If at ANY point a step needs sudo, has no automatic route on this OS, or any
+`kj` command exits with code 3 (`PENDING USER ACTION`): **STOP**. Show the
+user the exact commands to run themselves, then **WAIT** until they say
+"done". Never time out into "continuing with my own judgment", never continue
+with a degraded setup. A partial setup (e.g. an empty RAG because
+Docker/Ollama is missing) is a FAILED setup.
+
+## 1. Is kj installed on this machine?
+
+Run `kj --version`.
+
+- **Not installed** → follow <https://karajancode.com/install-machine.md>
+  first, then come back to step 2.
+- **Installed** → continue.
+
+## 2. What kind of project is this directory?
+
+Check in order:
+
+- **Already active** — `.karajan/review-gate` exists, or the rules file
+  (CLAUDE.md / AGENTS.md / GEMINI.md) contains a "Karajan method (v4)" block
+  → nothing to set up. Read the block, follow the method from now on, and ask
+  the user what to work on next. You are done here.
+- **New / empty** — no meaningful codebase yet
+  → follow <https://karajancode.com/project-new.md>
+- **Existing codebase** to keep developing, now with Karajan
+  → follow <https://karajancode.com/project-legacy.md>
+
+## 3. When setup finishes
+
+Run `kj doctor`. Report to the user: what got installed or activated, anything
+still limiting Karajan on this machine (and the exact way to lift each limit),
+and the first thing they can ask you to build. From now on you operate under
+the "Karajan method (v4)" block in this project's rules file: RAG before
+assuming, card first, tests first, cross-AI review before every commit.


### PR DESCRIPTION
Los prompts de arranque dejan de vivir solo en la landing y pasan a estar versionados en `docs/prompts/`:

- **start.md** — enrutador: HARD RULE parar-y-esperar → ¿kj instalado? → ¿proyecto activo / nuevo / legacy? → prompt correspondiente → doctor final + handover.
- **install-machine.md** — instalación de máquina completa (curl installer, doctor, install-tools con ask-first y exit 3).
- **project-new.md** — activar proyecto de cero (git init, init/env/harden/gate, commit del contrato, primera HU).
- **project-legacy.md** — adoptar Karajan en código existente (branch-first, onboard → Architecture Brief, respeto a configs existentes, RAG sobre el código como premio principal, contrato vía PR).

El usuario solo dirá: *'Quiero usar Karajan en este proyecto: lee karajancode.com/start.md y haz lo que dice'*. La landing (KJL-TSK-0080) añade los redirects 302 a estos raw (mismo patrón que install.sh) y separa la página de instalación en los 3 flujos.

Solo docs — exento del gate LOC (cohort human-facing).