### PR TITLE
fix(solomon): operational arbitration — stdin prompt, trust env, actionable errors (KJC-BUG-0121)

### DIFF
--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -60,10 +60,17 @@ export class GeminiAgent extends BaseAgent {
   }
 
   async _exec(task, model, mode) {
-    const args = ["-p", task.prompt];
+    // KJC-BUG-0121: the prompt NEVER travels as a CLI argument — a solomon
+    // prompt embeds the full diff, and large diffs blow past the kernel's
+    // per-argument limit (E2BIG). gemini reads the prompt from stdin in
+    // headless mode. Same bug's layer 2: headless gemini refuses untrusted
+    // workspaces unless GEMINI_CLI_TRUST_WORKSPACE is set.
+    const args = [];
     if (mode === "review") args.push("--output-format", "json");
     if (model) args.push("--model", model);
     const res = await this.runCommand(resolveBin("gemini"), args, {
+      input: task.prompt,
+      env: { GEMINI_CLI_TRUST_WORKSPACE: "true" },
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/review/solomon-arbitration.js
+++ b/src/review/solomon-arbitration.js
@@ -81,7 +81,18 @@ export async function runSolomonArbitration({
   logger?.info?.(`kj solomon: brain=${hostAgent || "?"} vs reviewer=${verdict.reviewer} → arbiter=${solomon}`);
   const agent = createAgentFn(solomon, config, logger);
   const result = await agent.reviewTask({ prompt, role: "solomon" });
-  if (!result?.ok) throw new Error(`solomon ${solomon} failed: ${result?.error || "no output"}`);
+  if (!result?.ok) {
+    // KJC-BUG-0121 layer 3: a binary on PATH is not an OPERATIONAL arbiter
+    // (dead account tier, auth, trust). Fail with the way out, not just the
+    // wreckage: name the other agents that could arbitrate instead.
+    const others = (await detectAgents())
+      .filter((a) => a.available && a.name !== solomon && a.name !== hostAgent && a.name !== verdict.reviewer)
+      .map((a) => a.name);
+    const hint = others.length > 0
+      ? `If ${solomon} is not operational on this machine (account tier, auth, workspace trust), set roles.solomon.provider in your kj config to another agent: ${others.join(", ")}.`
+      : `No other agent CLI on this machine can arbitrate (needs one distinct from brain "${hostAgent}" and reviewer "${verdict.reviewer}") — install a third agent CLI or fix ${solomon}.`;
+    throw new Error(`solomon ${solomon} failed: ${String(result?.error || "no output").slice(0, 400)}\n${hint}`);
+  }
   const parsed = parseMaybeJsonString(result.output);
   if (!parsed || !["approve", "reject"].includes(parsed.ruling)) {
     throw new Error(`solomon ${solomon} returned no parseable ruling`);

--- a/tests/agents/agents-implementations.test.js
+++ b/tests/agents/agents-implementations.test.js
@@ -165,14 +165,15 @@ describe("Agent implementations", () => {
   });
 
   describe("GeminiAgent", () => {
-    it("runs task with gemini -p and prompt", async () => {
+    it("runs task with the prompt on stdin, never as an argument (KJC-BUG-0121)", async () => {
       const { GeminiAgent } = await import("../../src/agents/gemini-agent.js");
       const agent = new GeminiAgent("gemini", baseConfig, logger);
       await agent.runTask({ prompt: "build feature", role: "coder" });
 
       const args = runCommand.mock.calls[0][1];
-      expect(args).toContain("-p");
-      expect(args).toContain("build feature");
+      expect(args).not.toContain("-p");
+      expect(args).not.toContain("build feature");
+      expect(runCommand.mock.calls[0][2].input).toBe("build feature");
     });
 
     it("reviews with --output-format json", async () => {

--- a/tests/agents/agents-role-model.test.js
+++ b/tests/agents/agents-role-model.test.js
@@ -31,17 +31,18 @@ describe("agents role model handling", () => {
     await agent.runTask({ prompt: "plan", role: "planner" });
     await agent.reviewTask({ prompt: "review", role: "reviewer" });
 
+    // KJC-BUG-0121: the prompt travels via stdin, never as an argument.
     expect(runCommand).toHaveBeenNthCalledWith(
       1,
       "gemini",
-      ["-p", "plan", "--model", "gemini-plan-model"],
-      expect.any(Object)
+      ["--model", "gemini-plan-model"],
+      expect.objectContaining({ input: "plan" })
     );
     expect(runCommand).toHaveBeenNthCalledWith(
       2,
       "gemini",
-      ["-p", "review", "--output-format", "json", "--model", "gemini-review-model"],
-      expect.any(Object)
+      ["--output-format", "json", "--model", "gemini-review-model"],
+      expect.objectContaining({ input: "review" })
     );
   });
 

--- a/tests/agents/gemini-agent.test.js
+++ b/tests/agents/gemini-agent.test.js
@@ -26,20 +26,21 @@ describe("GeminiAgent", () => {
     GeminiAgent = mod.GeminiAgent;
   });
 
-  // merged-from: 4 -p flag + output-format tests collapsed. Both methods pass
-  // -p <prompt>; only reviewTask appends `--output-format json`.
-  describe("-p flag and output format", () => {
+  // KJC-BUG-0121: the prompt travels via stdin (`input`), NEVER as a CLI
+  // argument — solomon prompts embed whole diffs and E2BIG kills the spawn.
+  // Only reviewTask appends `--output-format json`.
+  describe("stdin prompt and output format", () => {
     it.each([
       ["runTask",    "coder",    "build feature", false],
       ["reviewTask", "reviewer", "review code",   true]
-    ])("%s emits -p <prompt>; --output-format json=%s", async (method, role, prompt, expectsJson) => {
+    ])("%s sends the prompt via stdin; --output-format json=%s", async (method, role, prompt, expectsJson) => {
       const agent = new GeminiAgent("gemini", baseConfig, logger);
       await agent[method]({ prompt, role });
 
       const args = runCommand.mock.calls[0][1];
-      const pIdx = args.indexOf("-p");
-      expect(pIdx).toBeGreaterThanOrEqual(0);
-      expect(args[pIdx + 1]).toBe(prompt);
+      expect(args).not.toContain("-p");
+      expect(args).not.toContain(prompt);
+      expect(runCommand.mock.calls[0][2].input).toBe(prompt);
       if (expectsJson) {
         const fmtIdx = args.indexOf("--output-format");
         expect(fmtIdx).toBeGreaterThanOrEqual(0);
@@ -87,16 +88,15 @@ describe("GeminiAgent", () => {
     });
   });
 
-  // merged-from: 2 stdin/env tests collapsed. Gemini, like OpenCode, never
-  // touches either option (unlike Claude which sets stdin=ignore + strips env).
-  describe("no special stdin/env handling (unlike Claude)", () => {
-    it.each([
-      ["stdin", "stdin"],
-      ["env",   "env"]
-    ])("does NOT set %s", async (_label, optKey) => {
+  // KJC-BUG-0121 layer 2: headless gemini refuses untrusted workspaces —
+  // every spawn declares GEMINI_CLI_TRUST_WORKSPACE. stdin stays unset
+  // (the runner wires `input` itself; no Claude-style stdin=ignore).
+  describe("workspace trust env", () => {
+    it("sets GEMINI_CLI_TRUST_WORKSPACE=true and no stdin override", async () => {
       const agent = new GeminiAgent("gemini", baseConfig, logger);
       await agent.runTask({ prompt: "test", role: "coder" });
-      expect(runCommand.mock.calls[0][2][optKey]).toBeUndefined();
+      expect(runCommand.mock.calls[0][2].env).toEqual({ GEMINI_CLI_TRUST_WORKSPACE: "true" });
+      expect(runCommand.mock.calls[0][2].stdin).toBeUndefined();
     });
   });
 

--- a/tests/review/solomon-arbitration.test.js
+++ b/tests/review/solomon-arbitration.test.js
@@ -54,6 +54,25 @@ describe("runSolomonArbitration", () => {
     expect(check.verdict.arbitration.position).toMatch(/style-only/);
   });
 
+  // KJC-BUG-0121 layer 3: a binary on PATH is not an operational arbiter
+  // (dead tier, auth, trust). The failure must carry the way out.
+  it("an arbiter that fails at runtime produces an actionable error naming alternatives", async () => {
+    await seedRejected([{ id: "I1", severity: "medium", description: "naming" }]);
+    const dead = { reviewTask: vi.fn().mockResolvedValue({ ok: false, error: "IneligibleTierError: migrate to Antigravity" }) };
+    await expect(runSolomonArbitration({
+      ...base, detectAgents: agentsUp("claude", "codex", "gemini", "opencode"),
+      projectDir: dir, diff: DIFF, position: "disagree", createAgentFn: () => dead,
+    })).rejects.toThrow(/IneligibleTierError[\s\S]*roles\.solomon\.provider[\s\S]*opencode/);
+  });
+
+  it("when no alternative arbiter exists, the error says install-or-fix", async () => {
+    await seedRejected([{ id: "I1", severity: "medium", description: "naming" }]);
+    const dead = { reviewTask: vi.fn().mockResolvedValue({ ok: false, error: "not trusted" }) };
+    await expect(runSolomonArbitration({
+      ...base, projectDir: dir, diff: DIFF, position: "disagree", createAgentFn: () => dead,
+    })).rejects.toThrow(/install a third agent CLI or fix gemini/);
+  });
+
   it("reject ruling keeps the gate closed and records the arbitration", async () => {
     await seedRejected([{ id: "I1", severity: "high", description: "off-by-one in loop" }]);
     const res = await runSolomonArbitration({ ...base, projectDir: dir, diff: DIFF, position: "I disagree", createAgentFn: () => ruling("reject") });


### PR DESCRIPTION
Bug de dogfooding (arbitraje del README v4, #1261): kj solomon falló en CASCADA de tres capas. Fix de las tres:

1. **E2BIG**: el prompt de gemini (con el diff completo embebido) viajaba como argumento CLI → supera MAX_ARG_STRLEN en diffs grandes. Ahora va por **stdin** (`input` del runner, como ya hacía codex).
2. **Workspace trust**: gemini headless rechaza directorios no confiados — cada spawn declara `GEMINI_CLI_TRUST_WORKSPACE=true`.
3. **Árbitro muerto ≠ binario presente**: si el árbitro falla en runtime (tier retirado, auth), el error ahora nombra los agentes alternativos disponibles para `roles.solomon.provider`, o pide instalar/arreglar si no hay ninguno. Payload de error coercionado a string (feedback de codex).

Limitación conocida documentada en la card: claude-agent sigue pasando el prompt como argumento (su workaround stdin-ignore de Claude Code 2.x impide moverlo a stdin sin riesgo); opencode/aider igual — fuera del camino por defecto de solomon.

Tests: 27 en gemini-agent + solomon-arbitration (2 nuevos de errores accionables; contrato stdin/env pineado).