### PR TITLE
feat(agents): Qwen Code as sixth built-in agent (KJC-TSK-0665)

### DIFF
--- a/src/agents/gemini-agent.js
+++ b/src/agents/gemini-agent.js
@@ -37,12 +37,16 @@ function extractGeminiUsage(text) {
 }
 
 export class GeminiAgent extends BaseAgent {
+  // Overridden by forks with the same headless interface (QwenAgent).
+  get cliBin() { return "gemini"; }
+  get spawnEnv() { return { GEMINI_CLI_TRUST_WORKSPACE: "true" }; }
+
   async runTask(task) {
     const role = task.role || "coder";
     const model = this.getRoleModel(role);
     const result = await this._exec(task, model, "run");
     if (!result.ok && model && this.isModelNotSupportedError(result)) {
-      this.logger?.warn(`Gemini model "${model}" not supported — retrying with agent default`);
+      this.logger?.warn(`${this.cliBin} model "${model}" not supported — retrying with agent default`);
       return this._exec(task, null, "run");
     }
     return result;
@@ -53,7 +57,7 @@ export class GeminiAgent extends BaseAgent {
     const model = this.getRoleModel(role);
     const result = await this._exec(task, model, "review");
     if (!result.ok && model && this.isModelNotSupportedError(result)) {
-      this.logger?.warn(`Gemini model "${model}" not supported — retrying with agent default`);
+      this.logger?.warn(`${this.cliBin} model "${model}" not supported — retrying with agent default`);
       return this._exec(task, null, "review");
     }
     return result;
@@ -68,9 +72,9 @@ export class GeminiAgent extends BaseAgent {
     const args = [];
     if (mode === "review") args.push("--output-format", "json");
     if (model) args.push("--model", model);
-    const res = await this.runCommand(resolveBin("gemini"), args, {
+    const res = await this.runCommand(resolveBin(this.cliBin), args, {
       input: task.prompt,
-      env: { GEMINI_CLI_TRUST_WORKSPACE: "true" },
+      env: this.spawnEnv,
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -3,6 +3,7 @@ import { CodexAgent } from "./codex-agent.js";
 import { GeminiAgent } from "./gemini-agent.js";
 import { AiderAgent } from "./aider-agent.js";
 import { OpenCodeAgent } from "./opencode-agent.js";
+import { QwenAgent } from "./qwen-agent.js";
 
 const agentRegistry = new Map();
 
@@ -49,3 +50,4 @@ registerAgent("codex", CodexAgent, { bin: "codex", installUrl: "https://develope
 registerAgent("gemini", GeminiAgent, { bin: "gemini", installUrl: "https://github.com/google-gemini/gemini-cli" });
 registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.chat/docs/install.html" });
 registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });
+registerAgent("qwen", QwenAgent, { bin: "qwen", installUrl: "https://github.com/QwenLM/qwen-code" });

--- a/src/agents/qwen-agent.js
+++ b/src/agents/qwen-agent.js
@@ -1,0 +1,20 @@
+import { GeminiAgent } from "./gemini-agent.js";
+
+/**
+ * Qwen Code (@qwen-code/qwen-code, binary `qwen`) — KJC-TSK-0665.
+ *
+ * A gemini-cli fork with the same headless interface (prompt on stdin,
+ * `--output-format json`, `--model`, identical usageMetadata shape), so it
+ * inherits everything from GeminiAgent including the KJC-BUG-0121 stdin
+ * contract. Cloud-backed and free with a Qwen account: the sixth built-in
+ * agent, and the natural third AI for solomon arbitration now that the
+ * gemini individual tier is retired.
+ */
+export class QwenAgent extends GeminiAgent {
+  get cliBin() { return "qwen"; }
+  // qwen has no workspace-trust gate. execa merges this object over
+  // process.env, so the explicit undefined REMOVES gemini's var from the
+  // child even when the parent shell exported it (manual workarounds) —
+  // returning no env at all would let it leak through inheritance.
+  get spawnEnv() { return { GEMINI_CLI_TRUST_WORKSPACE: undefined }; }
+}

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -7,7 +7,8 @@ const KNOWN_AGENTS = [
   { name: "codex", install: getInstallCommand("codex") },
   { name: "gemini", install: getInstallCommand("gemini") },
   { name: "aider", install: getInstallCommand("aider") },
-  { name: "opencode", install: getInstallCommand("opencode") }
+  { name: "opencode", install: getInstallCommand("opencode") },
+  { name: "qwen", install: getInstallCommand("qwen") }
 ];
 
 export async function checkBinary(name, versionArg = "--version") {

--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -51,6 +51,11 @@ const INSTALL_COMMANDS = {
     linux: "curl -fsSL https://opencode.ai/install | bash",
     windows: "See https://github.com/nicepkg/opencode for Windows install"
   },
+  qwen: {
+    macos: "npm install -g @qwen-code/qwen-code",
+    linux: "npm install -g @qwen-code/qwen-code",
+    windows: "npm install -g @qwen-code/qwen-code"
+  },
   docker: {
     macos: "brew install --cask docker",
     linux: "sudo apt install docker.io docker-compose-v2 (or see https://docs.docker.com/engine/install/)",

--- a/tests/agents/qwen-agent.test.js
+++ b/tests/agents/qwen-agent.test.js
@@ -1,0 +1,45 @@
+// KJC-TSK-0665 — Qwen Code as sixth built-in agent: a gemini-cli fork that
+// inherits the stdin prompt contract (KJC-BUG-0121) with its own binary and
+// no gemini-specific trust env.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QwenAgent } from "../../src/agents/qwen-agent.js";
+import { createAgent, getAgentMeta } from "../../src/agents/index.js";
+import { buildMockEnvironment } from "../../src/infrastructure/mocks.js";
+
+describe("QwenAgent", () => {
+  let runCommand, env;
+  beforeEach(() => {
+    env = buildMockEnvironment();
+    runCommand = vi.spyOn(env.runner, "run").mockResolvedValue({ exitCode: 0, stdout: "{}", stderr: "" });
+  });
+
+  it("is registered as a built-in agent with the qwen binary", () => {
+    expect(getAgentMeta("qwen")).toMatchObject({ bin: "qwen" });
+    expect(createAgent("qwen", {}, {}, env)).toBeInstanceOf(QwenAgent);
+  });
+
+  it("spawns `qwen` with the prompt on stdin, never as an argument", async () => {
+    const agent = new QwenAgent("qwen", {}, {}, env);
+    await agent.reviewTask({ prompt: "arbitrate this diff", role: "solomon" });
+    const [bin, args, opts] = runCommand.mock.calls[0];
+    expect(bin).toMatch(/qwen/);
+    expect(args).toEqual(["--output-format", "json"]);
+    expect(args).not.toContain("arbitrate this diff");
+    expect(opts.input).toBe("arbitrate this diff");
+  });
+
+  it("actively removes gemini's trust env from the qwen spawn (execa merge semantics)", async () => {
+    const agent = new QwenAgent("qwen", {}, {}, env);
+    await agent.runTask({ prompt: "x", role: "coder" });
+    const spawnEnv = runCommand.mock.calls[0][2].env;
+    expect(spawnEnv).toHaveProperty("GEMINI_CLI_TRUST_WORKSPACE", undefined);
+  });
+
+  it("solomon can pick qwen as third party (claude brain, codex reviewer)", async () => {
+    const { pickThirdParty } = await import("../../src/review/solomon-arbitration.js");
+    const detectAgents = async () => [
+      { name: "claude", available: true }, { name: "codex", available: true }, { name: "qwen", available: true },
+    ];
+    expect(await pickThirdParty({ config: {}, hostAgent: "claude", reviewerAgent: "codex", detectAgents })).toBe("qwen");
+  });
+});


### PR DESCRIPTION
El gemini CLI individual está retirado (IneligibleTierError → Antigravity, que es un IDE) — el usuario quiere una tercera IA cloud por CLI, distinta de Claude y Codex, para el arbitraje solomon.

**Qwen Code** (@qwen-code/qwen-code, binario `qwen`): fork de gemini-cli con la misma interfaz headless (prompt por stdin, --output-format json, --model, mismo shape de usageMetadata), cloud y gratuito con cuenta Qwen.

- `QwenAgent extends GeminiAgent` — GeminiAgent parametrizado con getters `cliBin`/`spawnEnv`; qwen hereda el contrato stdin de KJC-BUG-0121 y **elimina activamente** `GEMINI_CLI_TRUST_WORKSPACE` del spawn (undefined explícito por la semántica de merge de execa — feedback de codex).
- Registrado en el agent registry, en la detección (`detectAvailableAgents`) y en los comandos de instalación por OS.
- Verificado contra el CLI real instalado (qwen 0.20.1: mismos flags).
- Config del usuario: `roles.solomon.provider: qwen` (evita que solomon elija el gemini zombi, que va antes en la lista de detección).

Tests: 4 nuevos (registro, stdin, scrub de env, pickThirdParty elige qwen). Suite completa: 6230 passed.