### PR TITLE
feat(agents): GitHub Copilot CLI as seventh built-in agent (KJC-TSK-0666)

### DIFF
--- a/src/agents/copilot-agent.js
+++ b/src/agents/copilot-agent.js
@@ -1,0 +1,65 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * GitHub Copilot CLI (@github/copilot, binary `copilot`) — KJC-TSK-0666.
+ * The seventh built-in agent, and the user-chosen third AI for solomon
+ * arbitration (gemini tier retired, Qwen OAuth free tier discontinued).
+ *
+ * Verified live against copilot 1.0.73:
+ *  - `-p <prompt>` runs non-interactive; copilot has NO stdin prompt channel
+ *    (stdin is treated as context, spawning an agentic run) — so the prompt
+ *    travels as an argument. Same documented E2BIG limit as claude-agent
+ *    (KJC-BUG-0121) for multi-hundred-KB diffs.
+ *  - `--output-format json` emits JSONL; the final text lives in the
+ *    `assistant.message` event's `data.content`, run metadata in `result`.
+ *  - Default model routing is automatic and varies per run (haiku, gpt-5-mini
+ *    observed) — pin it per role via `roles.<role>.model` when neutrality
+ *    matters (e.g. a gemini-family model for solomon).
+ */
+export class CopilotAgent extends BaseAgent {
+  async runTask(task) {
+    // Coder mode IS an agentic run: file edits and shell need permissions.
+    return this._exec(task, this.getRoleModel(task.role || "coder"), ["--allow-all-tools"]);
+  }
+
+  async reviewTask(task) {
+    // Review/arbitration answers from the prompt alone — no tool grants, and
+    // an explicit no-tools instruction so copilot never stalls waiting for
+    // an approval that headless mode cannot give.
+    return this._exec(
+      { ...task, prompt: `Do NOT use any tools. Answer directly from this prompt only.\n\n${task.prompt}` },
+      this.getRoleModel(task.role || "reviewer"),
+      [],
+    );
+  }
+
+  async _exec(task, model, extraArgs) {
+    const args = ["-p", task.prompt, "--output-format", "json", "--no-color", ...extraArgs];
+    if (model) args.push("--model", model);
+    const res = await this.runCommand(resolveBin("copilot"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs
+    });
+    const output = extractCopilotOutput(res.stdout);
+    return { ok: res.exitCode === 0, output: output ?? res.stdout, error: res.stderr, exitCode: res.exitCode };
+  }
+}
+
+/** Last `assistant.message` content from copilot's JSONL stream (null if none). */
+export function extractCopilotOutput(stdout) {
+  if (!stdout) return null;
+  let content = null;
+  for (const line of stdout.split("\n")) {
+    const t = line.trim();
+    if (!t.startsWith("{")) continue;
+    try {
+      const obj = JSON.parse(t);
+      if (obj?.type === "assistant.message" && typeof obj?.data?.content === "string") {
+        content = obj.data.content;
+      }
+    } catch { /* non-JSON noise between events */ }
+  }
+  return content;
+}

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -4,6 +4,7 @@ import { GeminiAgent } from "./gemini-agent.js";
 import { AiderAgent } from "./aider-agent.js";
 import { OpenCodeAgent } from "./opencode-agent.js";
 import { QwenAgent } from "./qwen-agent.js";
+import { CopilotAgent } from "./copilot-agent.js";
 
 const agentRegistry = new Map();
 
@@ -51,3 +52,4 @@ registerAgent("gemini", GeminiAgent, { bin: "gemini", installUrl: "https://githu
 registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.chat/docs/install.html" });
 registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });
 registerAgent("qwen", QwenAgent, { bin: "qwen", installUrl: "https://github.com/QwenLM/qwen-code" });
+registerAgent("copilot", CopilotAgent, { bin: "copilot", installUrl: "https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli" });

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -8,7 +8,8 @@ const KNOWN_AGENTS = [
   { name: "gemini", install: getInstallCommand("gemini") },
   { name: "aider", install: getInstallCommand("aider") },
   { name: "opencode", install: getInstallCommand("opencode") },
-  { name: "qwen", install: getInstallCommand("qwen") }
+  { name: "qwen", install: getInstallCommand("qwen") },
+  { name: "copilot", install: getInstallCommand("copilot") }
 ];
 
 export async function checkBinary(name, versionArg = "--version") {

--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -56,6 +56,11 @@ const INSTALL_COMMANDS = {
     linux: "npm install -g @qwen-code/qwen-code",
     windows: "npm install -g @qwen-code/qwen-code"
   },
+  copilot: {
+    macos: "npm install -g @github/copilot",
+    linux: "npm install -g @github/copilot",
+    windows: "npm install -g @github/copilot"
+  },
   docker: {
     macos: "brew install --cask docker",
     linux: "sudo apt install docker.io docker-compose-v2 (or see https://docs.docker.com/engine/install/)",

--- a/tests/agents/copilot-agent.test.js
+++ b/tests/agents/copilot-agent.test.js
@@ -1,0 +1,69 @@
+// KJC-TSK-0666 — GitHub Copilot CLI as seventh built-in agent. Contract
+// verified live against copilot 1.0.73 (JSONL events, -p prompt, no stdin
+// channel).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CopilotAgent, extractCopilotOutput } from "../../src/agents/copilot-agent.js";
+import { createAgent, getAgentMeta } from "../../src/agents/index.js";
+import { buildMockEnvironment } from "../../src/infrastructure/mocks.js";
+
+const JSONL = [
+  '{"type":"user.message","data":{"content":"x"}}',
+  "log noise that is not json",
+  '{"type":"assistant.message_delta","data":{"content":"{"}}',
+  '{"type":"assistant.message","data":{"content":"{\\"ruling\\":\\"approve\\",\\"reasoning\\":\\"ok\\"}","model":"gpt-5-mini"}}',
+  '{"type":"result","exitCode":0,"usage":{"premiumRequests":0.33}}',
+].join("\n");
+
+describe("CopilotAgent", () => {
+  let runCommand, env;
+  beforeEach(() => {
+    env = buildMockEnvironment();
+    runCommand = vi.spyOn(env.runner, "run").mockResolvedValue({ exitCode: 0, stdout: JSONL, stderr: "" });
+  });
+
+  it("is registered as a built-in agent with the copilot binary", () => {
+    expect(getAgentMeta("copilot")).toMatchObject({ bin: "copilot" });
+    expect(createAgent("copilot", {}, {}, env)).toBeInstanceOf(CopilotAgent);
+  });
+
+  it("reviewTask runs -p with JSONL output, no tool grants, and a no-tools instruction", async () => {
+    const agent = new CopilotAgent("copilot", {}, {}, env);
+    const res = await agent.reviewTask({ prompt: "arbitrate this", role: "solomon" });
+    const [bin, args] = runCommand.mock.calls[0];
+    expect(bin).toMatch(/copilot/);
+    expect(args).toContain("-p");
+    expect(args[args.indexOf("-p") + 1]).toMatch(/^Do NOT use any tools[\s\S]*arbitrate this$/);
+    expect(args).toContain("--output-format");
+    expect(args).not.toContain("--allow-all-tools");
+    // the parsed assistant.message content is the agent output
+    expect(res.output).toBe('{"ruling":"approve","reasoning":"ok"}');
+    expect(res.ok).toBe(true);
+  });
+
+  it("runTask grants tools (a coder must edit files) and honours the role model", async () => {
+    const agent = new CopilotAgent("copilot", { roles: { coder: { model: "gpt-5.1-codex" } } }, {}, env);
+    await agent.runTask({ prompt: "build it", role: "coder" });
+    const args = runCommand.mock.calls[0][1];
+    expect(args).toContain("--allow-all-tools");
+    expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.1-codex");
+  });
+
+  it("solomon can pick copilot as third party (claude brain, codex reviewer)", async () => {
+    const { pickThirdParty } = await import("../../src/review/solomon-arbitration.js");
+    const detectAgents = async () => [
+      { name: "claude", available: true }, { name: "codex", available: true }, { name: "copilot", available: true },
+    ];
+    expect(await pickThirdParty({ config: {}, hostAgent: "claude", reviewerAgent: "codex", detectAgents })).toBe("copilot");
+  });
+});
+
+describe("extractCopilotOutput", () => {
+  it("returns the LAST assistant.message content, ignoring deltas and noise", () => {
+    expect(extractCopilotOutput(JSONL)).toBe('{"ruling":"approve","reasoning":"ok"}');
+  });
+
+  it("returns null when no assistant.message exists (caller falls back to raw stdout)", () => {
+    expect(extractCopilotOutput('{"type":"result","exitCode":1}')).toBeNull();
+    expect(extractCopilotOutput("")).toBeNull();
+  });
+});


### PR DESCRIPTION
El usuario eligió Copilot CLI como tercera IA para arbitraje (tiene tier operativo; verificado en vivo: el CLI responde autenticado en su máquina, ~0.33 premium requests por arbitraje).

- **CopilotAgent**: `-p` no interactivo + `--output-format json` (JSONL); `extractCopilotOutput` extrae el content del último `assistant.message`. reviewTask SIN permisos de tools + instrucción no-tools (evita stalls de aprobación en headless); runTask con `--allow-all-tools` (un coder debe editar). Modelo fijable por rol (`roles.solomon.model` — el routing automático varía por run: haiku y gpt-5-mini observados).
- Registrado en registry, detección e install commands (`npm install -g @github/copilot`).
- **Limitación documentada**: copilot no tiene canal stdin para el prompt (stdin dispara un run agéntico) → prompt vía `-p`, mismo límite E2BIG que claude-agent (KJC-BUG-0121).
- **Verificado e2e real** contra copilot 1.0.73: reviewTask devuelve el JSON del veredicto limpio.
- Config del usuario: `roles.solomon.provider: copilot`.

Tests: 6 nuevos. Suite completa: 6236 passed.