### PR TITLE
docs(prompts): Windows install route and OS-aware privileges wording

### DIFF
--- a/docs/prompts/install-machine.md
+++ b/docs/prompts/install-machine.md
@@ -2,10 +2,15 @@
 
 Goal: leave this machine FULLY operational for Karajan — not a partial
 install. Ask before each install; never install silently. The HARD RULE from
-[start.md](https://karajancode.com/start.md) applies to every step: sudo, no
-automatic route, or `kj` exit code 3 → STOP, show the commands, WAIT.
+[start.md](https://karajancode.com/start.md) applies to every step: elevated
+privileges (sudo / Administrator), no automatic route, or `kj` exit code 3
+→ STOP, show the commands, WAIT.
 
 ## 1. Install kj (full product)
+
+Pick the route for THIS machine's operating system:
+
+**Linux / macOS:**
 
 ```sh
 curl -fsSL https://karajancode.com/install.sh | sh
@@ -15,6 +20,17 @@ It uses the machine's Node if ≥ 22.12, or auto-provisions the official Node
 LTS into `~/.karajan/node` (checksum-verified, nothing system-wide). Review
 the script first, as you always should. Equivalent: `npm install -g
 karajan-code`.
+
+**Windows:**
+
+1. If Node ≥ 22.12 is present: `npm install -g karajan-code` — that's the
+   full product.
+2. If Node is missing: install the official LTS first — `winget install
+   OpenJS.NodeJS.LTS` (needs the user's confirmation/elevation: STOP and
+   wait) — then run the npm install above in a NEW terminal.
+3. `irm https://karajancode.com/install.ps1 | iex` exists but installs the
+   CLI-only standalone binary (no RAG, board or MCP) — use it only if the
+   user explicitly wants no Node.
 
 ## 2. Diagnose, then complete the stack
 

--- a/docs/prompts/start.md
+++ b/docs/prompts/start.md
@@ -6,12 +6,15 @@ yourself through these steps and report progress in the user's language.
 
 ## 0. HARD RULE — stop and wait
 
-If at ANY point a step needs sudo, has no automatic route on this OS, or any
+If at ANY point a step needs elevated privileges (sudo on Linux/macOS,
+Administrator on Windows), has no automatic route on this OS, or any
 `kj` command exits with code 3 (`PENDING USER ACTION`): **STOP**. Show the
 user the exact commands to run themselves, then **WAIT** until they say
 "done". Never time out into "continuing with my own judgment", never continue
 with a degraded setup. A partial setup (e.g. an empty RAG because
 Docker/Ollama is missing) is a FAILED setup.
+
+Detect the operating system FIRST — every install route below depends on it.
 
 ## 1. Is kj installed on this machine?
 


### PR DESCRIPTION
Feedback del usuario: el prompt en un Cursor de Windows chocaba con `curl … | sh` (unix-only) y hablaba de sudo (que en Windows no existe).

- **start.md**: HARD RULE generalizada a 'elevated privileges (sudo en Linux/macOS, Administrator en Windows)' + orden explícita de detectar el OS ANTES de elegir ruta.
- **install-machine.md**: rutas por OS — Linux/macOS mantienen el curl npm-first; **Windows**: npm install -g con Node ≥22.12, winget del Node LTS si falta (con parada y espera), y el irm|iex del ps1 solo como CLI-only explícito (hoy es el binario standalone degradado — su paridad npm-first es KJC-TSK-0667).

Solo docs (los MDs se sirven del raw de main — efecto inmediato al mergear, sin release).