### PR TITLE
feat(board): HU provenance — created_by stamp and list origin (KJC-TSK-0661)

### DIFF
--- a/docs/prompts/install-machine.md
+++ b/docs/prompts/install-machine.md
@@ -21,16 +21,18 @@ LTS into `~/.karajan/node` (checksum-verified, nothing system-wide). Review
 the script first, as you always should. Equivalent: `npm install -g
 karajan-code`.
 
-**Windows:**
+**Windows (PowerShell):**
 
-1. If Node ≥ 22.12 is present: `npm install -g karajan-code` — that's the
-   full product.
-2. If Node is missing: install the official LTS first — `winget install
-   OpenJS.NodeJS.LTS` (needs the user's confirmation/elevation: STOP and
-   wait) — then run the npm install above in a NEW terminal.
-3. `irm https://karajancode.com/install.ps1 | iex` exists but installs the
-   CLI-only standalone binary (no RAG, board or MCP) — use it only if the
-   user explicitly wants no Node.
+```powershell
+irm https://karajancode.com/install.ps1 | iex
+```
+
+Full product, same guarantees as the sh installer: uses the machine's Node
+if ≥ 22.12, or auto-provisions the official Node LTS into `~\.karajan\node`
+(checksum-verified, nothing system-wide). Equivalent with Node already
+present: `npm install -g karajan-code`. CLI-only standalone binary (no RAG,
+board or MCP): set `$env:KJ_STANDALONE = "1"` first — only if the user
+explicitly wants no Node.
 
 ## 2. Diagnose, then complete the stack
 

--- a/scripts/install-binary.ps1
+++ b/scripts/install-binary.ps1
@@ -1,50 +1,158 @@
 <#
 .SYNOPSIS
-  Karajan Code — standalone binary installer for Windows (no Node required).
+  Karajan Code installer for Windows — guarantees a COMPLETE install (KJC-TSK-0667).
 
 .DESCRIPTION
-  Downloads the prebuilt kj.exe for Windows x64 from the GitHub release,
-  verifies its SHA256 checksum, installs it to %LOCALAPPDATA%\Karajan, and
-  adds that folder to the user PATH (idempotently). Re-running updates the
-  binary in place without duplicating PATH entries.
-
   Run it with:
     irm https://karajancode.com/install.ps1 | iex
 
-  Override with env vars: $env:KJ_VERSION (e.g. v3.7.2), $env:KJ_INSTALL_DIR.
+  Default route: npm — the full product (CLI + RAG + HU Board + MCP).
+    1. Node >= 22.12 present  -> npm install -g karajan-code
+    2. No usable Node         -> auto-provision the official Node LTS zip into
+       ~\.karajan\node (checksum-verified, nothing system-wide touched),
+       install karajan-code with it, drop kj/karajan-mcp wrappers into the
+       install dir and add it to the user PATH.
+  Standalone route (CLI only, no native-module features — RAG/board/MCP
+  unavailable): opt-in with $env:KJ_STANDALONE = "1".
 
-  KJC-TSK-0594.
+  Env overrides (irm|iex cannot take parameters): KJ_VERSION, KJ_INSTALL_DIR,
+  KJ_STANDALONE. Windows PowerShell 5.1 compatible.
 #>
 $ErrorActionPreference = "Stop"
 
 $repo = "manufosela/karajan-code"
 $version = if ($env:KJ_VERSION) { $env:KJ_VERSION } else { "latest" }
 $installDir = if ($env:KJ_INSTALL_DIR) { $env:KJ_INSTALL_DIR } else { Join-Path $env:LOCALAPPDATA "Karajan" }
-$asset = "kj-win-x64.exe"
+$mode = if ($env:KJ_STANDALONE -eq "1") { "standalone" } else { "full" }
+$nodeMajor = 22
+$nodeMinMinor = 12
 
-if ($version -eq "latest") {
-  $base = "https://github.com/$repo/releases/latest/download"
-} else {
-  $base = "https://github.com/$repo/releases/download/$version"
+function Get-NpmPkg {
+  if ($version -eq "latest") { "karajan-code" } else { "karajan-code@" + $version.TrimStart("v") }
 }
 
-# Download to a temp folder; only install once the checksum matches, so a
-# failure never leaves a half-installed binary behind.
+function Test-NodeOk {
+  $node = Get-Command node -ErrorAction SilentlyContinue
+  if (-not $node) { return $false }
+  $v = (& node --version) 2>$null
+  if (-not $v) { return $false }
+  $parts = $v.TrimStart("v").Split(".")
+  $major = [int]$parts[0]; $minor = [int]$parts[1]
+  return ($major -gt $nodeMajor) -or ($major -eq $nodeMajor -and $minor -ge $nodeMinMinor)
+}
+
+function Add-UserPath([string]$dir) {
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $parts = @()
+  if ($userPath) { $parts = $userPath.Split(";") | Where-Object { $_ -ne "" } }
+  $already = $parts | Where-Object { $_.TrimEnd("\") -ieq $dir.TrimEnd("\") }
+  if (-not $already) {
+    $newPath = if ($userPath) { "$userPath;$dir" } else { $dir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Host "kj-install: added '$dir' to your user PATH. Open a NEW terminal to use 'kj'."
+  }
+}
+
 $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("kj-install-" + [System.Guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $tmp -Force | Out-Null
-try {
-  $binTmp = Join-Path $tmp "kj.exe"
-  $shaTmp = Join-Path $tmp "kj.exe.sha256"
 
-  Write-Host "kj-install: downloading $asset ($version)..."
-  try {
-    Invoke-WebRequest -Uri "$base/$asset" -OutFile $binTmp -UseBasicParsing
-    Invoke-WebRequest -Uri "$base/$asset.sha256" -OutFile $shaTmp -UseBasicParsing
-  } catch {
-    throw "could not download $base/$asset — does that version/asset exist, and is the network reachable? ($_)"
+try {
+  if ($mode -eq "full") {
+    if (Test-NodeOk) {
+      Write-Host "kj-install: Node $(& node --version) found — installing via npm (full product)..."
+      & npm install -g (Get-NpmPkg)
+      if ($LASTEXITCODE -ne 0) { throw "npm install failed (exit $LASTEXITCODE)." }
+      Write-Host "kj-install: installed. Run 'kj doctor' next, then 'kj install-tools' to complete the whole stack."
+      return
+    }
+
+    Write-Host "kj-install: no usable Node (need >= $nodeMajor.$nodeMinMinor) — provisioning official Node LTS into ~\.karajan\node (nothing system-wide)..."
+    $dist = "https://nodejs.org/dist/latest-v$nodeMajor.x"
+    $shaFile = Join-Path $tmp "SHASUMS256.txt"
+    Invoke-WebRequest -Uri "$dist/SHASUMS256.txt" -OutFile $shaFile -UseBasicParsing
+    $shaLines = Get-Content $shaFile
+    $assetLine = $shaLines | Where-Object { $_ -match "node-v[0-9.]+-win-x64\.zip" } | Select-Object -First 1
+    if (-not $assetLine) { throw "no official Node build for win-x64 in $dist" }
+    $nodeAsset = ($assetLine -split "\s+")[1]
+    $expected = ($assetLine -split "\s+")[0].ToLower()
+
+    Write-Host "kj-install: downloading $nodeAsset..."
+    $zip = Join-Path $tmp $nodeAsset
+    Invoke-WebRequest -Uri "$dist/$nodeAsset" -OutFile $zip -UseBasicParsing
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $zip).Hash.ToLower()
+    if ($expected -ne $actual) { throw "Node checksum mismatch — aborting, nothing installed." }
+
+    # Stage everything (extract + npm install) and only swap into place once
+    # EVERYTHING succeeded — a failure must never destroy a previous working
+    # ~\.karajan\node.
+    $nodeHome = Join-Path $env:USERPROFILE ".karajan\node"
+    $staging = "$nodeHome.staging.$PID"
+    $extract = Join-Path $tmp "extract"
+    if (Test-Path $staging) { Remove-Item -Recurse -Force $staging }
+    Expand-Archive -Path $zip -DestinationPath $extract -Force
+    # The zip wraps everything in a node-vX.Y.Z-win-x64\ top folder — unwrap it.
+    $inner = Get-ChildItem -Directory $extract | Select-Object -First 1
+    New-Item -ItemType Directory -Path (Split-Path $staging) -Force | Out-Null
+    Move-Item -Path $inner.FullName -Destination $staging
+
+    Write-Host "kj-install: installing karajan-code with the provisioned Node..."
+    $env:Path = "$staging;$env:Path"
+    # Explicit --prefix: the official Windows npm ships a builtin prefix of
+    # %AppData%\npm — without this the global shims would land OUTSIDE the
+    # self-contained ~\.karajan\node home (on Windows, prefix root IS the
+    # global bin dir, so shims land at $staging\kj.cmd).
+    & (Join-Path $staging "npm.cmd") install -g --prefix "$staging" (Get-NpmPkg)
+    if ($LASTEXITCODE -ne 0) { throw "npm install failed with the provisioned Node (exit $LASTEXITCODE)." }
+    foreach ($bin in @("kj", "karajan-mcp")) {
+      if (-not (Test-Path (Join-Path $staging "$bin.cmd"))) {
+        throw "npm reported success but the $bin shim is missing from the staged prefix — the full product needs both kj and karajan-mcp. Aborting, nothing swapped."
+      }
+    }
+
+    # Swap keeping the previous install recoverable: park it as a backup,
+    # move the staged one in, restore the backup if that move fails.
+    $backup = "$nodeHome.old.$PID"
+    if (Test-Path $nodeHome) { Move-Item -Path $nodeHome -Destination $backup -Force }
+    try {
+      Move-Item -Path $staging -Destination $nodeHome
+    } catch {
+      if (Test-Path $backup) { Move-Item -Path $backup -Destination $nodeHome -Force }
+      throw "could not move the staged install into place (previous install restored). $_"
+    }
+    if (Test-Path $backup) { Remove-Item -Recurse -Force $backup }
+
+    # Wrappers, not copies: npm's own .cmd shims live inside nodeHome and
+    # resolve node via their folder; these put nodeHome on PATH for children
+    # (kj spawns node tooling) and forward every argument.
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    foreach ($bin in @("kj", "karajan-mcp")) {
+      $shim = Join-Path $nodeHome "$bin.cmd"
+      $wrapper = @(
+        "@echo off",
+        "set `"PATH=$nodeHome;%PATH%`"",
+        "`"$shim`" %*"
+      )
+      Set-Content -Path (Join-Path $installDir "$bin.cmd") -Value $wrapper -Encoding ASCII
+    }
+    Add-UserPath $installDir
+    $installed = (& (Join-Path $installDir "kj.cmd") --version) 2>$null
+    Write-Host "kj-install: installed kj $installed (full product) — kj at $(Join-Path $installDir 'kj.cmd')"
+    Write-Host "kj-install: next — run 'kj doctor', then 'kj install-tools' to complete the whole stack."
+    return
   }
 
-  # certutil writes a multi-line file; keep only the hex of the hash line.
+  # --- Standalone route: prebuilt single binary (CLI only). ---
+  Write-Host "kj-install: standalone mode — single binary, NO native-module features (RAG, HU Board and MCP need the npm install)."
+  $asset = "kj-win-x64.exe"
+  $base = if ($version -eq "latest") { "https://github.com/$repo/releases/latest/download" }
+          else { "https://github.com/$repo/releases/download/$version" }
+
+  $binTmp = Join-Path $tmp "kj.exe"
+  $shaTmp = Join-Path $tmp "kj.exe.sha256"
+  Write-Host "kj-install: downloading $asset ($version)..."
+  Invoke-WebRequest -Uri "$base/$asset" -OutFile $binTmp -UseBasicParsing
+  Invoke-WebRequest -Uri "$base/$asset.sha256" -OutFile $shaTmp -UseBasicParsing
+
   $shaLine = (Get-Content $shaTmp | Where-Object { $_ -notmatch "SHA256|CertUtil" } | Select-Object -First 1)
   $expected = ($shaLine -replace "[^0-9A-Fa-f]", "").ToLower()
   $actual = (Get-FileHash -Algorithm SHA256 -Path $binTmp).Hash.ToLower()
@@ -52,38 +160,15 @@ try {
     throw "checksum mismatch (expected '$expected', got '$actual'). Aborting, nothing installed."
   }
 
-  # Install: move into place, replacing any previous install (idempotent).
   New-Item -ItemType Directory -Path $installDir -Force | Out-Null
   $dest = Join-Path $installDir "kj.exe"
   Move-Item -Path $binTmp -Destination $dest -Force
-
-  # The download carries a "mark of the web" (Zone.Identifier) that makes
-  # SmartScreen warn on first run. The binary is not code-signed with a paid
-  # certificate, so clear the mark on the copy we just verified ourselves.
+  # Clear the mark-of-the-web on the copy we just checksum-verified ourselves.
   Unblock-File -Path $dest -ErrorAction SilentlyContinue
-
+  Add-UserPath $installDir
   $installed = (& $dest --version) 2>$null
-  Write-Host "kj-install: installed kj $installed to $dest"
-
-  # Add to the user PATH only if it is not already there (no duplicates).
-  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-  $parts = @()
-  if ($userPath) { $parts = $userPath.Split(";") | Where-Object { $_ -ne "" } }
-  $already = $parts | Where-Object { $_.TrimEnd("\") -ieq $installDir.TrimEnd("\") }
-  if (-not $already) {
-    $newPath = if ($userPath) { "$userPath;$installDir" } else { $installDir }
-    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
-    Write-Host "kj-install: added '$installDir' to your user PATH. Open a new terminal to use 'kj'."
-  } else {
-    Write-Host "kj-install: '$installDir' is already on your user PATH — run 'kj --help' to get started."
-  }
-
-  # The binary bundles no toolchain. kj orchestrates external tools, so name
-  # the hard requirements and let `kj doctor` check them for this machine.
-  Write-Host ""
-  Write-Host "kj-install: next step — run 'kj doctor' to check prerequisites."
-  Write-Host "  Required: git, plus at least one agent CLI (Claude Code, Codex or Gemini)."
-  Write-Host "  Optional: Docker (local models, SonarQube) and Node/npm (helper tools: Squeezr, qmd)."
+  Write-Host "kj-install: installed standalone kj $installed to $dest"
+  Write-Host "kj-install: next — run 'kj doctor'. For the full product later: re-run without KJ_STANDALONE."
 } finally {
   Remove-Item -Path $tmp -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -8,6 +8,14 @@
 import { addHu, updateHuStatus } from "../plan/plan-hu-ops.js";
 import { generatePlanId } from "../plan/plan-id.js";
 import { savePlan, listPlans, loadPlan } from "../plan/plan-store.js";
+import { detectHostAgent } from "../utils/agent-detect.js";
+
+// KJC-TSK-0661 (Jorge's friction): every HU records WHO created it — the
+// board must never show work nobody can trace. Host agent env → that agent;
+// a human typing in a terminal → "human"; anything else headless → "agent".
+export function creatorLabel() {
+  return detectHostAgent() || (process.stdin.isTTY ? "human" : "agent");
+}
 
 export const HU_STATUSES = ["pending", "running", "done", "failed", "skipped"];
 const BACKLOG_NAME = "brain-backlog";
@@ -35,12 +43,22 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
     for (const meta of plans) {
       const plan = await loadPlan(projectDir, meta.planId);
       for (const h of plan.hus || []) {
-        rows.push({ id: h.id, short_id: h.short_id, title: h.title, status: h.status, plan: plan.alias || plan.planId });
+        rows.push({
+          id: h.id, short_id: h.short_id, title: h.title, status: h.status,
+          plan: plan.alias || plan.planId,
+          // KJC-TSK-0661: provenance — where a card came from is part of
+          // the card. Older HUs predate the stamp: shown as "?".
+          created_by: h.created_by || null, created_at: h.createdAt || null,
+        });
       }
     }
     if (flags.json) { console.log(JSON.stringify(rows)); return rows; }
-    for (const r of rows) console.log(`${(r.short_id || r.id).padEnd(28)} ${r.status.padEnd(8)} ${r.title}`);
+    for (const r of rows) {
+      const origin = `${r.plan} · by ${r.created_by || "?"}${r.created_at ? ` · ${r.created_at.slice(0, 10)}` : ""}`;
+      console.log(`${(r.short_id || r.id).padEnd(28)} ${r.status.padEnd(8)} ${r.title}  [${origin}]`);
+    }
     if (rows.length === 0) console.log("no HUs yet — create one with: kj hu add \"<story>\"");
+    else console.log("→ work one: ask your agent, or kj run --plan <plan> · discard one: kj hu move <id> skipped");
     return rows;
   }
 
@@ -53,9 +71,10 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
       short_id: flags.id || null,
       acceptance_criteria: flags.criteria ? [flags.criteria] : [],
     });
+    hu.created_by = creatorLabel();
     await savePlan(projectDir, plan);
-    return emit({ id: hu.id, short_id: hu.short_id, status: hu.status },
-      `✓ HU created: ${hu.short_id || hu.id} (pending) — it shows up in \`kj board\``);
+    return emit({ id: hu.id, short_id: hu.short_id, status: hu.status, created_by: hu.created_by },
+      `✓ HU created: ${hu.short_id || hu.id} (pending, by ${hu.created_by}) — it shows up in \`kj board\``);
   }
 
   if (action === "move") {

--- a/src/commands/plan/add-hu.js
+++ b/src/commands/plan/add-hu.js
@@ -15,6 +15,8 @@ export async function planAddHuCommand({ config, planId, title, type, deps, scop
     scope: scope || null,
     blocked_by: deps ? deps.split(",").map(d => d.trim()) : []
   });
+  const { creatorLabel } = await import("../hu.js");
+  hu.created_by = creatorLabel(); // KJC-TSK-0661: provenance stamp
 
   await savePlan(projectDir, plan);
   console.log(`Added: ${hu.id} — ${hu.title}`);

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -229,6 +229,9 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
       reviewer_model: models.reviewer_model,
       reviewer_provider: models.reviewer_provider,
     });
+    // KJC-TSK-0661: provenance stamp (addHu builds its object explicitly,
+    // so this goes on the returned reference, not in huData).
+    hu.created_by = "planner";
     if (symbolicId) symbolicToHuId.set(symbolicId, hu.id);
     const deps = typeof step === "object" && Array.isArray(step.dependencies) ? step.dependencies : [];
     stepDeps.push(deps);

--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -140,6 +140,7 @@ export function applyFixerPatch(plan, patch) {
       acceptance_tests: a.acceptance_tests,
       reuse: a.reuse || [],
     });
+    hu.created_by = "plan-reviewer"; // KJC-TSK-0661: provenance stamp
     if (symbolicId) symbolicToHuId.set(symbolicId, hu.id);
     const depsSymbolic = Array.isArray(a.dependencies) ? a.dependencies : [];
     addedHus.push({ hu, depsSymbolic });

--- a/tests/environment/brain-board-adr.test.js
+++ b/tests/environment/brain-board-adr.test.js
@@ -1,7 +1,7 @@
 // AB-H (KJC-TSK-0658): the brain can honor "card first" and "check the
 // ADRs" on any backend — HU writes without the subprocess planner, ADRs
 // as numbered git-tracked markdown.
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -47,6 +47,25 @@ describe("kj hu", () => {
     // the full canonical id resolves even when a short_id collides with it
     const moved = await huCommand({ config: cfg(), action: "move", args: ["hu_other_001", "done"], flags: { json: true } });
     expect(moved.id).toBe("hu_other_001");
+  });
+
+  // KJC-TSK-0661 (Jorge's friction): every HU carries provenance — who
+  // created it, when, from which plan — and the list surfaces it.
+  it("add stamps created_by and list exposes provenance + next-action hint", async () => {
+    await huCommand({ config: cfg(), action: "add", args: ["Traced"], flags: { json: true, id: "TR-1" } });
+    const rows = await huCommand({ config: cfg(), action: "list", flags: { json: true } });
+    expect(rows[0].plan).toBe("brain-backlog");
+    expect(typeof rows[0].created_by).toBe("string");
+    expect(rows[0].created_by.length).toBeGreaterThan(0);
+    expect(rows[0].created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const logs = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+    await huCommand({ config: cfg(), action: "list", flags: {} });
+    spy.mockRestore();
+    const out = logs.join("\n");
+    expect(out).toMatch(/brain-backlog · by \S+/);
+    expect(out).toMatch(/kj hu move <id> skipped/);
   });
 
   it("second add reuses the same backlog plan", async () => {

--- a/tests/install-binary-ps1.test.js
+++ b/tests/install-binary-ps1.test.js
@@ -1,0 +1,45 @@
+// KJC-TSK-0667 — the Windows installer must match the sh installer's
+// npm-first contract: full product by default, SEA binary as explicit opt-in.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const script = readFileSync(`${process.cwd()}/scripts/install-binary.ps1`, "utf8");
+
+describe("install-binary.ps1 npm-first parity — KJC-TSK-0667", () => {
+  it("defaults to the npm route (full product)", () => {
+    expect(script).toMatch(/npm install -g/);
+    expect(script).toMatch(/full product/i);
+  });
+
+  it("gates the standalone binary behind KJ_STANDALONE and states its limits", () => {
+    expect(script).toMatch(/KJ_STANDALONE/);
+    expect(script).toMatch(/NO native-module features/i);
+  });
+
+  it("provisions the official Node LTS checksum-verified when Node is missing", () => {
+    expect(script).toMatch(/SHASUMS256\.txt/);
+    expect(script).toMatch(/node-v\[0-9\.\]\+-win-x64\\\.zip/);
+    expect(script).toMatch(/Get-FileHash/);
+    expect(script).toMatch(/checksum mismatch/i);
+  });
+
+  it("stages the install and keeps the previous one recoverable (backup + restore)", () => {
+    expect(script).toMatch(/\.staging\./);
+    expect(script).toMatch(/\.old\./);
+    expect(script).toMatch(/previous install restored/i);
+  });
+
+  it("requires Node >= 22.12, same floor as the sh installer", () => {
+    expect(script).toMatch(/nodeMajor = 22/);
+    expect(script).toMatch(/nodeMinMinor = 12/);
+  });
+
+  it("stays Windows PowerShell 5.1 compatible (no pwsh-7-only ternary)", () => {
+    expect(script).not.toMatch(/\?\s[^:]+\s:/); // `cond ? a : b` is pwsh 7+
+  });
+
+  it("ends pointing at doctor + install-tools, like the sh installer", () => {
+    expect(script).toMatch(/kj doctor/);
+    expect(script).toMatch(/kj install-tools/);
+  });
+});


### PR DESCRIPTION
Fricción de campo de Jorge: 'hay 2 tareas que no sé de dónde salieron'.

- Toda HU registra **quién la creó**: agente anfitrión detectado (claude/codex/…), `human` (TTY), `agent` (headless), `planner` (kj plan) o `plan-reviewer` (fixer). Estampado en los 4 call sites sobre el objeto devuelto — `karajan-core` es paquete publicado y su addHu construye el objeto explícitamente, así que no se toca.
- **`kj hu list`** muestra la procedencia por línea (`[plan · by quien · fecha]`) y cierra con la pista de siguiente acción (trabajar con el agente / `kj run --plan` / descartar con `kj hu move <id> skipped`). `--json` expone `created_by` y `created_at`; el add también devuelve `created_by` (feedback de codex).
- La procedencia viaja en el plan JSON → queda disponible para el panel web del board (render en KJC-PRP-0007, gobierno del board).

Tests: 2 nuevos en brain-board-adr (stamp + list con procedencia y hint).