### PR TITLE
fix(init): gitignore gets the karajan contract block, never a bare exclude (KJC-BUG-0123)

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -672,6 +672,7 @@ const GITIGNORE_ENTRIES = [
   { pattern: ".kj/", comment: "Karajan runtime (logs, worktrees)" },
   { pattern: ".agent/", comment: "Agent skills (OpenSkills)" },
   { pattern: ".scannerwork/", comment: "SonarQube scanner temp" },
+  { pattern: ".reviews/", comment: "Legacy review artifacts" },
 ];
 
 async function ensureGitignoreEntries(projectDir, logger) {
@@ -685,16 +686,23 @@ async function ensureGitignoreEntries(projectDir, logger) {
   if (!content) content = "";
 
   const missing = GITIGNORE_ENTRIES.filter(e => !content.includes(e.pattern));
-  if (missing.length === 0) return;
+  if (missing.length > 0) {
+    const block = [
+      "",
+      "# Karajan Code",
+      ...missing.map(e => e.pattern)
+    ].join("\n") + "\n";
+    await fs.appendFile(gitignorePath, block, "utf8");
+    logger.info(`Added to .gitignore: ${missing.map(e => e.pattern).join(", ")}`);
+  }
 
-  const block = [
-    "",
-    "# Karajan Code",
-    ...missing.map(e => e.pattern)
-  ].join("\n") + "\n";
-
-  await fs.appendFile(gitignorePath, block, "utf8");
-  logger.info(`Added to .gitignore: ${missing.map(e => e.pattern).join(", ")}`);
+  // KJC-BUG-0123 (issue #1268): the .karajan entries were missing entirely —
+  // and they must land as the CONTRACT BLOCK (`.karajan/*` + re-includes),
+  // never a bare `.karajan/` dir-exclude, or git cannot re-include the
+  // review-gate/hooks/adrs the whole team inherits (KJC-TSK-0646).
+  const { ensureContractBlockPresent } = await import("../review/gate-gitignore.js");
+  const res = await ensureContractBlockPresent(projectDir);
+  if (res.changed) logger.info("Added the .karajan contract block to .gitignore (verdicts stay local; gate/hooks/adrs tracked)");
 }
 
 /**

--- a/src/orchestrator/config-init.js
+++ b/src/orchestrator/config-init.js
@@ -55,8 +55,11 @@ export async function autoInit(projectDir, logger) {
   }
 
   // Ensure .gitignore exists with universal entries only (stack-specific added after planner)
+  // KJC-BUG-0123: `.karajan/` is NOT in this list on purpose — a bare
+  // dir-exclude breaks the gate contract (git cannot re-include children);
+  // the canonical block is appended below from its single source.
   const gitignorePath = path.join(projectDir, ".gitignore");
-  const universalIgnores = [".env", "*.log", ".DS_Store", ".karajan/", ".reviews/"];
+  const universalIgnores = [".env", "*.log", ".DS_Store", ".reviews/"];
   try {
     let content = "";
     if (await exists(gitignorePath)) {
@@ -68,6 +71,8 @@ export async function autoInit(projectDir, logger) {
       await fs.appendFile(gitignorePath, append, "utf8");
       logger.info(`Created .gitignore with universal entries`);
     }
+    const { ensureContractBlockPresent } = await import("../review/gate-gitignore.js");
+    await ensureContractBlockPresent(projectDir);
   } catch (err) {
     logger.warn(`Failed to create .gitignore: ${err.message}`);
   }

--- a/src/review/gate-gitignore.js
+++ b/src/review/gate-gitignore.js
@@ -12,7 +12,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const CONTRACT_BLOCK = [
+// KJC-BUG-0123 (issue #1268): exported as the SINGLE source of truth — kj
+// init and the orchestrator's autoInit write this same block instead of a
+// bare `.karajan/` exclude (which git cannot re-include children of).
+export const CONTRACT_BLOCK = [
   ".karajan/*",
   "# …except the v4 environment contract, which the whole team inherits:",
   "!.karajan/review-gate",
@@ -24,6 +27,22 @@ const CONTRACT_BLOCK = [
   "!.karajan/hooks/post-merge",
   "!.karajan/adrs/",
 ];
+
+/**
+ * KJC-BUG-0123: append the canonical contract block to .gitignore when the
+ * file has no `.karajan` mention at all (fresh projects — `kj init` path).
+ * Files that already mention .karajan are left to ensureGateTrackable,
+ * which rewrites legacy root excludes without touching anything else.
+ */
+export async function ensureContractBlockPresent(projectDir) {
+  const file = path.join(projectDir, ".gitignore");
+  let text = "";
+  try { text = await fs.readFile(file, "utf8"); } catch { /* no .gitignore yet */ }
+  if (text.includes(".karajan")) return { changed: false };
+  const sep = text && !text.endsWith("\n") ? "\n" : "";
+  await fs.writeFile(file, `${text}${sep}# Karajan environment (verdicts stay local; the contract is tracked)\n${CONTRACT_BLOCK.join("\n")}\n`);
+  return { changed: true };
+}
 
 export async function ensureGateTrackable(projectDir) {
   const file = path.join(projectDir, ".gitignore");

--- a/tests/review/gate-gitignore.test.js
+++ b/tests/review/gate-gitignore.test.js
@@ -77,3 +77,39 @@ describe("ensureGateTrackable", () => {
     expect(text.match(/!\.karajan\/review-gate/g)).toHaveLength(1);
   });
 });
+
+// KJC-BUG-0123 (issue #1268, Jorge via kj report-issue): kj init wrote no
+// .karajan entries at all; autoInit wrote a bare `.karajan/` dir-exclude
+// that breaks gate trackability. Both now share this single source.
+describe("ensureContractBlockPresent", () => {
+  it("appends the canonical block to a gitignore with no .karajan mention", async () => {
+    const { ensureContractBlockPresent } = await import("../../src/review/gate-gitignore.js");
+    fs.writeFileSync(path.join(dir, ".gitignore"), "node_modules/\n");
+    const res = await ensureContractBlockPresent(dir);
+    expect(res.changed).toBe(true);
+    // verdicts stay local; the contract stays trackable
+    fs.mkdirSync(path.join(dir, ".karajan", "hooks"), { recursive: true });
+    fs.mkdirSync(path.join(dir, ".karajan", "reviews"), { recursive: true });
+    expect(ignored(".karajan/reviews/abc.json")).toBe(true);
+    expect(ignored(".karajan/review-gate")).toBe(false);
+    expect(ignored(".karajan/hooks/pre-commit")).toBe(false);
+    expect(ignored(".karajan/adrs/0001-x.md")).toBe(false);
+    expect(ignored("node_modules/x.js")).toBe(true); // untouched
+  });
+
+  it("creates the gitignore when none exists", async () => {
+    const { ensureContractBlockPresent } = await import("../../src/review/gate-gitignore.js");
+    const res = await ensureContractBlockPresent(dir);
+    expect(res.changed).toBe(true);
+    expect(fs.readFileSync(path.join(dir, ".gitignore"), "utf8")).toMatch(/\.karajan\/\*/);
+  });
+
+  it("is a no-op when .karajan is already mentioned (legacy files go through ensureGateTrackable)", async () => {
+    const { ensureContractBlockPresent } = await import("../../src/review/gate-gitignore.js");
+    fs.writeFileSync(path.join(dir, ".gitignore"), ".karajan/\n");
+    expect((await ensureContractBlockPresent(dir)).changed).toBe(false);
+    // ...and ensureGateTrackable is the one that repairs that legacy exclude
+    expect((await ensureGateTrackable(dir)).changed).toBe(true);
+    expect(ignored(".karajan/review-gate")).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #1268 — segunda issue de campo del ciclo self-healing (Jorge, kj 4.1.5, darwin-arm64). 🎉

## Bug (con doble fondo)
1. GITIGNORE_ENTRIES de `kj init` no traía ninguna entrada de .karajan → los veredictos de `.karajan/reviews/` acababan commiteables.
2. El `autoInit` del orquestador SÍ añadía `.karajan/`… **pelado** — exactamente el patrón que KJC-TSK-0646 tiene que reescribir (git no re-incluye hijos de un directorio excluido → el contrato del gate no se heredaba).

## Fix
- `CONTRACT_BLOCK` exportado desde `gate-gitignore.js` como **fuente única**; nueva `ensureContractBlockPresent()` lo añade cuando el gitignore no menciona .karajan (los legacy los repara ensureGateTrackable como siempre).
- `kj init` y el autoInit del orquestador la usan; init gana además `.reviews/` (legacy).
- Tests con `git check-ignore` real: los veredictos quedan ignorados, gate/hooks/adrs quedan trackeables.

Suite completa local: verde (con el kill-switch de KJC-BUG-0122 validado en la misma pasada — PR aparte).