### PR TITLE
fix(audit): scanners never fire from the unit suite — vitest kill-switch (KJC-BUG-0122)

### DIFF
--- a/src/audit/osv-findings.js
+++ b/src/audit/osv-findings.js
@@ -35,6 +35,11 @@ const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE"];
  * @returns {Promise<{available: boolean, reason?: string, total?: number, vulnerabilities?: object[]}>}
  */
 export async function collectOsvFindings(projectDir, logger = null) {
+  // KJC-BUG-0122: same kill-switch as semgrep — external scanners never
+  // fire from the unit suite; e2e opts in with KJ_ALLOW_REAL_SCANS=1.
+  if (process.env.VITEST && process.env.KJ_ALLOW_REAL_SCANS !== "1") {
+    return { available: false, reason: "real scans disabled under the test runner (set KJ_ALLOW_REAL_SCANS=1 to opt in)" };
+  }
   let stdout;
   try {
     const { stdout: out } = await execFileAsync(

--- a/src/audit/semgrep-findings.js
+++ b/src/audit/semgrep-findings.js
@@ -34,6 +34,14 @@ const SEVERITY_ORDER = ["ERROR", "WARNING", "INFO"];
  * @returns {Promise<{available: boolean, reason?: string, total?: number, findings?: object[]}>}
  */
 export async function collectSemgrepFindings(projectDir, logger = null) {
+  // KJC-BUG-0122: a full `--config auto` scan must NEVER fire from the unit
+  // suite — on machines with the complete stack installed (the product
+  // default since v4.1.2) parallel vitest workers each launched a real
+  // whole-repo scan: load average 50, orphaned semgrep-core processes.
+  // E2E tests that genuinely want the real scan opt in explicitly.
+  if (process.env.VITEST && process.env.KJ_ALLOW_REAL_SCANS !== "1") {
+    return { available: false, reason: "real scans disabled under the test runner (set KJ_ALLOW_REAL_SCANS=1 to opt in)" };
+  }
   let stdout;
   try {
     const { stdout: out } = await execFileAsync(

--- a/tests/audit/osv-findings.test.js
+++ b/tests/audit/osv-findings.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock execFile + promisify so we can drive collectOsvFindings under
 // controlled conditions. promisify(execFile) resolves to {stdout, stderr}
@@ -20,7 +20,19 @@ import { buildAuditPrompt } from "../../src/prompts/audit.js";
 const noopLogger = { warn: vi.fn(), info: vi.fn() };
 
 describe("collectOsvFindings (KJC-TSK-0365)", () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => { vi.resetAllMocks(); process.env.KJ_ALLOW_REAL_SCANS = "1"; });
+  afterEach(() => { delete process.env.KJ_ALLOW_REAL_SCANS; });
+
+  // KJC-BUG-0122: the kill-switch — under the test runner, without the
+  // explicit opt-in, the collector never spawns anything.
+  it("refuses to scan under VITEST without KJ_ALLOW_REAL_SCANS", async () => {
+    delete process.env.KJ_ALLOW_REAL_SCANS;
+    const r = await collectOsvFindings(".", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/disabled under the test runner/);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
 
   it("returns available=false when osv-scanner is not installed (ENOENT)", async () => {
     const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });

--- a/tests/audit/semgrep-findings.test.js
+++ b/tests/audit/semgrep-findings.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock node:util's promisify to bypass the {stdout, stderr} custom-impl
 // dance (same trick as tests/audit/osv-findings.test.js).
@@ -19,7 +19,19 @@ import { buildAuditPrompt } from "../../src/prompts/audit.js";
 const noopLogger = { warn: vi.fn(), info: vi.fn() };
 
 describe("collectSemgrepFindings (KJC-TSK-0366)", () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => { vi.resetAllMocks(); process.env.KJ_ALLOW_REAL_SCANS = "1"; });
+  afterEach(() => { delete process.env.KJ_ALLOW_REAL_SCANS; });
+
+  // KJC-BUG-0122: the kill-switch — under the test runner, without the
+  // explicit opt-in, the collector never spawns anything.
+  it("refuses to scan under VITEST without KJ_ALLOW_REAL_SCANS", async () => {
+    delete process.env.KJ_ALLOW_REAL_SCANS;
+    const r = await collectSemgrepFindings(".", noopLogger);
+    expect(r.available).toBe(false);
+    expect(r.reason).toMatch(/disabled under the test runner/);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
 
   it("returns available=false when semgrep is not installed (ENOENT)", async () => {
     const enoErr = Object.assign(new Error("not found"), { code: "ENOENT" });


### PR DESCRIPTION
Tormenta de CPU en la máquina del usuario (load average 50): pysemgrep --config auto en paralelo lanzados por workers de vitest — tests de runflow/post-loop que llegan al AuditRole real sin mockear los colectores. En CI nunca se vio (semgrep ausente → available:false); en máquinas con el stack COMPLETO (default del producto desde v4.1.2) el escaneo real del repo entero se disparaba por worker.

## Fix
Kill-switch en `collectSemgrepFindings` y `collectOsvFindings`: bajo `VITEST` devuelven `available:false` salvo opt-in explícito `KJ_ALLOW_REAL_SCANS=1` (e2e). Mata la clase entera — ningún test presente o futuro puede relanzar un escaneo real por accidente.

## Verificación empírica
Shim espía de semgrep en el PATH registrando cada invocación con su cadena de padres: **24 llamadas antes → 0 escaneos `--config auto` después**, suite completa verde en la misma pasada.

Relacionado (no incluido): KJC-TSK-0668 — gobierno de recursos de herramientas lanzadas por el propio kj.