### PR TITLE
feat(board): HUs are never deleted — fixer archives, add refuses recreation (KJC-TSK-0669)

### DIFF
--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -66,6 +66,19 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
     const title = args[0];
     if (!title || !title.trim()) throw new Error("kj hu add requires a title: kj hu add \"<story>\"");
     const plan = await backlogPlan(projectDir);
+    // KJC-TSK-0669 (absolute rule): cards are permanent. The delete-and-
+    // recreate "fix" an agent improvises loses history and duplicates ids —
+    // refuse it with the norm spelled out.
+    if (flags.id) {
+      const dup = (plan.hus || []).find((h) => h.short_id === flags.id);
+      if (dup) {
+        throw new Error(
+          `HU "${flags.id}" already exists (status: ${dup.status}). HUs are never deleted or recreated — `
+          + `update its state with: kj hu move ${flags.id} <pending|running|done|failed|skipped>, `
+          + `or discard it with: kj hu move ${flags.id} skipped`
+        );
+      }
+    }
     const hu = addHu(plan, {
       title,
       short_id: flags.id || null,

--- a/src/commands/plan/fix.js
+++ b/src/commands/plan/fix.js
@@ -60,7 +60,7 @@ export async function planFixCommand({ config, planId, prompt, logger, json }) {
     });
     if (!fix.ok) { fixProgress.finish("failed"); break; }
     const ops = applyFixerPatch(plan, fix.patch);
-    if (ops.added + ops.depsAdded + ops.deleted === 0) { fixProgress.finish("done"); break; }
+    if (ops.added + ops.depsAdded + ops.archived === 0) { fixProgress.finish("done"); break; }
     const review2 = await reviewPlan({
       agent: planner, task: enrichedTask, hus: plan.hus,
       onOutput: fixProgress.onOutput, silenceTimeoutMs, timeoutMs,

--- a/src/commands/plan/generate.js
+++ b/src/commands/plan/generate.js
@@ -370,8 +370,8 @@ async function planGenerateImpl({ task, config, logger, json, context, runLog, f
             break;
           }
           const ops = applyFixerPatch(plan, fix.patch);
-          runLog.logText(`[planner] self-fix iter ${i} applied: +${ops.added} HU, +${ops.depsAdded} dep, -${ops.deleted} HU`);
-          if (ops.added + ops.depsAdded + ops.deleted === 0) {
+          runLog.logText(`[planner] self-fix iter ${i} applied: +${ops.added} HU, +${ops.depsAdded} dep, ${ops.archived} archived`);
+          if (ops.added + ops.depsAdded + ops.archived === 0) {
             fixProgress.finish("done");
             runLog.logText(`[planner] self-fix iter ${i} empty patch — stopping`);
             break;

--- a/src/plan/plan-fixer.js
+++ b/src/plan/plan-fixer.js
@@ -10,7 +10,7 @@
  */
 
 import { extractFirstJson } from "../utils/json-extract.js";
-import { addHu, removeHu } from "./plan-hu-ops.js";
+import { addHu } from "./plan-hu-ops.js";
 import { normaliseAcceptanceTests } from "./plan-schema.js";
 import { withBrainRecovery } from "../brain/with-brain-recovery.js";
 
@@ -111,9 +111,31 @@ export async function applyReviewerFeedback({ agent, task, hus, findings, onOutp
 }
 
 export function applyFixerPatch(plan, patch) {
-  const counts = { added: 0, depsAdded: 0, deleted: 0 };
+  const counts = { added: 0, depsAdded: 0, archived: 0 };
+  // KJC-TSK-0669 (absolute rule): HUs are NEVER deleted — not even by the
+  // fix loop. Overlap resolutions ARCHIVE in place (status skipped +
+  // provenance), so history survives and ids stay referenceable. The
+  // references are cleaned exactly like removeHu used to, because a
+  // skipped dependency never satisfies the scheduler (deadlock otherwise).
   for (const huId of patch.deletions || []) {
-    if (removeHu(plan, huId)) counts.deleted += 1;
+    const hu = plan.hus.find(h => h.id === huId);
+    if (!hu) continue;
+    if (hu.status !== "skipped") {
+      hu.status = "skipped";
+      hu.archived_by = "plan-reviewer";
+      hu.archive_reason = "scope overlap resolved by the plan-review fix loop";
+      hu.updatedAt = new Date().toISOString();
+      counts.archived += 1;
+    }
+    for (const other of plan.hus) {
+      if (other.id === huId) continue;
+      if (Array.isArray(other.blocked_by) && other.blocked_by.includes(huId)) {
+        other.blocked_by = other.blocked_by.filter(d => d !== huId);
+      }
+      if (Array.isArray(other.reuse) && other.reuse.includes(huId)) {
+        other.reuse = other.reuse.filter(d => d !== huId);
+      }
+    }
   }
   // KJC-BUG-0053: las HUs añadidas por el fixer dejaban `short_id` y
   // `blocked_by` vacíos porque addHu no recibía esos campos. Resultado:
@@ -163,7 +185,7 @@ export function applyFixerPatch(plan, patch) {
     hu.blocked_by = [...blocked, on];
     counts.depsAdded += 1;
   }
-  if (counts.added + counts.depsAdded + counts.deleted > 0) {
+  if (counts.added + counts.depsAdded + counts.archived > 0) {
     plan.updatedAt = new Date().toISOString();
   }
   return counts;

--- a/tests/environment/brain-board-adr.test.js
+++ b/tests/environment/brain-board-adr.test.js
@@ -68,6 +68,16 @@ describe("kj hu", () => {
     expect(out).toMatch(/kj hu move <id> skipped/);
   });
 
+  // KJC-TSK-0669 (Jorge's dashboard fights): cards are permanent — the
+  // delete-and-recreate "fix" is refused with the norm spelled out.
+  it("add with an existing short_id refuses and teaches the norm", async () => {
+    await huCommand({ config: cfg(), action: "add", args: ["First"], flags: { json: true, id: "DUP-9" } });
+    await expect(huCommand({ config: cfg(), action: "add", args: ["Again"], flags: { json: true, id: "DUP-9" } }))
+      .rejects.toThrow(/never deleted or recreated[\s\S]*kj hu move DUP-9/);
+    const rows = await huCommand({ config: cfg(), action: "list", flags: { json: true } });
+    expect(rows.filter((r) => r.short_id === "DUP-9")).toHaveLength(1);
+  });
+
   it("second add reuses the same backlog plan", async () => {
     await huCommand({ config: cfg(), action: "add", args: ["A"], flags: { json: true } });
     await huCommand({ config: cfg(), action: "add", args: ["B"], flags: { json: true } });

--- a/tests/plan/plan-fixer.test.js
+++ b/tests/plan/plan-fixer.test.js
@@ -85,7 +85,9 @@ describe("applyFixerPatch", () => {
     updatedAt: "2026-05-11T00:00:00Z",
   });
 
-  it("adds new HUs, declares deps without duplicating, deletes HUs and cleans dangling refs", () => {
+  // KJC-TSK-0669 (absolute rule): the fix loop ARCHIVES, it never deletes —
+  // history survives, refs are cleaned so nothing deadlocks on a skipped HU.
+  it("adds new HUs, declares deps without duplicating, archives 'deleted' HUs and cleans refs", () => {
     const plan = makePlan();
     plan.hus.push({ id: "hu_003", title: "C", task_type: "sw", status: "pending", blocked_by: [], reuse: [], scope: "c", acceptance_criteria: [], acceptance_tests: [] });
     const r = applyFixerPatch(plan, {
@@ -97,17 +99,22 @@ describe("applyFixerPatch", () => {
       ],
       deletions: ["hu_002"],
     });
-    expect(r).toEqual({ added: 1, depsAdded: 1, deleted: 1 });
-    expect(plan.hus).toHaveLength(3); // 3 original - 1 deleted + 1 added
+    expect(r).toEqual({ added: 1, depsAdded: 1, archived: 1 });
+    expect(plan.hus).toHaveLength(4); // nothing is ever removed
+    const archived = plan.hus.find(h => h.id === "hu_002");
+    expect(archived.status).toBe("skipped");
+    expect(archived.archived_by).toBe("plan-reviewer");
+    expect(archived.archive_reason).toMatch(/overlap/);
     expect(plan.hus.find(h => h.id === "hu_001").blocked_by).toEqual(["hu_003"]);
     expect(plan.hus.find(h => h.scope === "Audit log")?.spec_section).toBe("5.3");
   });
 
-  it("removeHu cleans dangling blocked_by refs from other HUs", () => {
+  it("archiving cleans dangling blocked_by refs so dependents never deadlock", () => {
     const plan = makePlan();
     applyFixerPatch(plan, { additions: [], deps_to_add: [], deletions: ["hu_001"] });
-    expect(plan.hus).toHaveLength(1);
-    expect(plan.hus[0].blocked_by).toEqual([]);
+    expect(plan.hus).toHaveLength(2); // archived, not removed
+    expect(plan.hus.find(h => h.id === "hu_001").status).toBe("skipped");
+    expect(plan.hus.find(h => h.id === "hu_002").blocked_by).toEqual([]);
   });
 
   // KJC-BUG-0053: HUs añadidas por fixer deben llevar short_id y blocked_by


### PR DESCRIPTION
Regla absoluta del product owner (fricción de campo de Jorge: su agente 'arreglaba' warnings del dashboard borrando y recreando tareas): **borrar tareas NO PUEDE HACERLO EL AGENTE**.

- **plan-fixer**: las `deletions` del patch del plan-reviewer ARCHIVAN en sitio (status `skipped` + `archived_by: plan-reviewer` + `archive_reason`) — `removeHu` fuera del camino. Las referencias `blocked_by`/`reuse` se limpian igual que hacía removeHu, porque una dependencia `skipped` no satisface al scheduler (deadlock si no). La historia sobrevive y los ids siguen siendo referenciables.
- **`kj hu add`** con un `short_id` existente: error pedagógico con la norma — *las HUs nunca se borran ni se recrean; muévela con `kj hu move`, descártala con `kj hu move <id> skipped`*.
- `counts.deleted` → `archived` en todos los consumidores.

Parte 1/2 de la respuesta a la fricción (paraguas KJC-PRP-0007). La 2/2 es `kj brief board` + invariante del playbook (KJC-TSK-0670); el blindaje de la API REST del board (405 en DELETE de stories) queda en KJC-TSK-0671 (requiere publish de @karajan/hu-board).

Tests: fixer archiva y limpia refs (2 reescritos), churn guard (1 nuevo); 500 en plan/commands/orchestrator.