### PR TITLE
feat(env): board brief and permanence invariant in the playbook (KJC-TSK-0670)

### DIFF
--- a/src/environment/briefs.js
+++ b/src/environment/briefs.js
@@ -82,6 +82,18 @@ const B = {
       ],
       "findings with severity, category and file:line — or an explicit 'no security surface touched'."),
   },
+  board: {
+    purpose: "What the HU Board is and how to act on it without breaking it",
+    render: () => brief("Board",
+      "the HU Board is the permanent record of work: every card traces to who created it and what happened to it — a dashboard warning is fixed with the command it names, never by rebuilding the board.",
+      [
+        "Cards are NEVER deleted or recreated — not to fix warnings, not to tidy up. Discard = `kj hu move <id> skipped` (archived, history kept).",
+        "States move only via `kj hu move <id> <pending|running|done|failed|skipped>`.",
+        "A duplicate short_id means the card already exists: update that card, never add a twin.",
+        "A warning is information, not damage: run the command it names; if it looks like a kj bug, `kj report-issue` — never work around it by destroying state.",
+      ],
+      "the board reflects reality: the same cards before and after your action, with truthful states and provenance intact."),
+  },
   audit: {
     purpose: "Final look before shipping — does the whole thing hold?",
     render: () => brief("Audit",

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -29,7 +29,7 @@ const TARGET_FILES = {
 // ENV-D1 (KJC-TSK-0642): the tracking invariant names the CHOSEN state
 // backend — a playbook that says "board or PG" makes the host guess.
 const BACKEND_TRACKING = {
-  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj hu add` / `kj board`) before it starts.",
+  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj hu add` / `kj board`) before it starts. Cards are permanent — never delete or recreate one; discard with `kj hu move <id> skipped`. `kj brief board` explains the board.",
   "planning-game": "Every piece of work has a tracked card in the Planning Game MCP before it starts (In Progress while you work it).",
 };
 
@@ -58,7 +58,7 @@ Invariants (the git gates enforce these — they are not suggestions):
   through an atomic PR (~150 net lines, Conventional Commits).
 
 Commands: \`kj rag query\` · \`kj brief <role>\` (triage, planner, researcher,
-architect, tester, security, audit) · \`kj hu add|move|list\` · \`kj adr add|list\` ·
+architect, tester, security, audit, board) · \`kj hu add|move|list\` · \`kj adr add|list\` ·
 \`kj review --staged\` · \`kj review --check\` · \`kj solomon --position\` ·
 \`kj agent run <agent>\` · \`kj report\` · \`kj check\`
 

--- a/tests/environment/briefs.test.js
+++ b/tests/environment/briefs.test.js
@@ -8,8 +8,18 @@ import { BRIEF_ROLES, renderBrief, listBriefs } from "../../src/environment/brie
 describe("renderBrief", () => {
   it("covers the roles the brain absorbs", () => {
     expect(BRIEF_ROLES).toEqual(
-      expect.arrayContaining(["triage", "planner", "researcher", "architect", "tester", "security", "audit"])
+      expect.arrayContaining(["triage", "planner", "researcher", "architect", "tester", "security", "audit", "board"])
     );
+  });
+
+  // KJC-TSK-0670 (Jorge's dashboard fights): the board brief gives any
+  // brain the board's model and its hard rule — cards are never deleted.
+  it("board brief teaches permanence and the warning protocol", () => {
+    const text = renderBrief("board", {});
+    expect(text).toMatch(/NEVER deleted or recreated/);
+    expect(text).toMatch(/kj hu move <id> skipped/);
+    expect(text).toMatch(/kj report-issue/);
+    expect(text).toMatch(/provenance intact/);
   });
 
   // AB-C2 (KJC-TSK-0653): outcome-first — briefs state Mission (what must


### PR DESCRIPTION
Parte 2/2 de la respuesta a las peleas dashboard↔agente de Jorge (paraguas KJC-PRP-0007):

- **`kj brief board`**: el modelo del board para cualquier brain — el board es el registro permanente del trabajo; cards jamás se borran ni recrean (descartar = `kj hu move <id> skipped`); estados solo vía `kj hu move`; short_id duplicado = actualiza la existente; un warning se arregla con el comando que nombra o se reporta con `kj report-issue`, nunca destruyendo estado. Deliverable: mismo board antes y después, con estados veraces y procedencia intacta.
- **Playbook**: la invariante hu-board declara la permanencia de las cards y apunta al brief; `board` entra en el catálogo de `kj brief`.

Con el PR #1276 (fixer archiva + add rechaza recreación), la norma queda enforced en código Y explicada al agente — el mismo doble mecanismo que hace que el Planning Game no sufra estas peleas.