### PR TITLE
fix(board): tolerant plan-version sync, stories undeletable via API (KJC-BUG-0124 + KJC-TSK-0671)

### DIFF
--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karajan/hu-board",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "HU Story Board dashboard for Karajan Code",
   "type": "module",
   "private": true,

--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -32,7 +32,6 @@ import {
   getSessionsByProject,
   getSessionDetail,
   deleteProject,
-  deleteStory,
   deleteSession,
   getKjHome,
   getHuBoardRunsDir,
@@ -462,19 +461,15 @@ router.delete('/prompts/:promptId', async (req, res) => {
  * it. Pre-tombstones this endpoint was a DB-only soft hide that the next
  * chokidar event undid silently.
  */
-router.delete('/stories/:id', async (req, res) => {
-  try {
-    const id = req.params.id;
-    const dir = path.join(huStoriesDir(), id);
-    const ok = deleteStory(id);
-    if (!ok) return res.status(404).json({ error: 'Story not found' });
-    addTombstone('story', id, { source: 'api', fsPaths: [dir] });
-    let dirRemoved = false;
-    try { await fsp.rm(dir, { recursive: true, force: true }); dirRemoved = true; } catch { /* */ }
-    res.json({ deleted: true, dirRemoved });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
-  }
+router.delete('/stories/:id', (req, res) => {
+  // KJC-TSK-0671 (absolute product rule): stories are NEVER deleted — the
+  // delete-and-recreate "fix" agents improvise loses history and produced
+  // the field saga this closes. Discard goes through the lifecycle instead.
+  res.status(405).json({
+    error: 'Stories are never deleted. Discard one with: kj hu move <id> skipped '
+      + '(archived, history kept). Dashboard warnings are fixed with the command '
+      + 'they name — see kj brief board.',
+  });
 });
 
 /**

--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -358,7 +358,19 @@ export function syncPlanFile(filePath) {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const data = JSON.parse(raw);
-    if (data.version !== 2 || !Array.isArray(data.hus) || data.hus.length === 0) return;
+    // KJC-BUG-0124 (issue #1277): a strict `version !== 2` silently hid
+    // every plan whose version drifted — the board showed 0 stories with no
+    // trace, and users concluded their work was lost. Tolerant now: any
+    // v2+ plan syncs, with a LOUD warn on version drift (fired before the
+    // empty check so drift is visible even on empty plans). Pre-v2 plans
+    // keep their historical silent skip (they never synced and carry no
+    // hus[]), and an empty v2 plan has nothing to sync — skipping it
+    // loses nothing.
+    if (typeof data.version !== 'number' || data.version < 2) return;
+    if (data.version > 2) {
+      console.warn(`[sync] ${filePath}: plan version ${data.version} (expected 2) — syncing anyway; re-save with current kj to normalize`);
+    }
+    if (!Array.isArray(data.hus) || data.hus.length === 0) return;
 
     // Bug fix: pre-patch, `projectId = data.planId` — every plan was a separate
     // "project" on the board, so 2 464 plans across the same repo produced

--- a/packages/hu-board/tests/tombstones.test.js
+++ b/packages/hu-board/tests/tombstones.test.js
@@ -226,15 +226,18 @@ describe('tombstones — DELETE endpoints', () => {
 
   // ---------- PR B endpoints (story / session / plan / restore / list) ------
 
-  it('DELETE /api/stories/:id tombstones + removes its batch dir', async () => {
+  // KJC-TSK-0671 (absolute product rule): stories are NEVER deleted — the
+  // endpoint refuses with the norm and the lifecycle alternative.
+  it('DELETE /api/stories/:id is refused with 405 and teaches the norm', async () => {
     dbMod.upsertStory({ id: 'st-1', project_id: 'p1', status: 'pending' });
     const dir = join(tmpDir, 'hu-stories', 'st-1');
     mkdirSync(dir, { recursive: true });
 
-    const r = await request(app).delete('/api/stories/st-1').expect(200);
-    expect(r.body).toMatchObject({ deleted: true, dirRemoved: true });
-    expect(dbMod.isTombstoned('story', 'st-1')).toBe(true);
-    expect(existsSync(dir)).toBe(false);
+    const r = await request(app).delete('/api/stories/st-1').expect(405);
+    expect(r.body.error).toMatch(/never deleted/);
+    expect(r.body.error).toMatch(/kj hu move <id> skipped/);
+    expect(dbMod.isTombstoned('story', 'st-1')).toBe(false);
+    expect(existsSync(dir)).toBe(true); // nothing touched
   });
 
   it('DELETE /api/sessions/:id tombstones + removes its session dir', async () => {


### PR DESCRIPTION
Fixes #1277 — tercera issue de campo (Jorge vía kj report-issue). Tren del paquete @karajan/hu-board (1.0.0 → 1.1.0):

1. **Sync tolerante** (KJC-BUG-0124): `syncPlanFile` deja de descartar en silencio los planes con `version !== 2` — la causa raíz de la saga 'me desaparecen tareas'. Checks de versión ANTES del check de vacío (el warn de drift dispara incluso con hus vacías); v2+ sincroniza SIEMPRE; pre-v2 mantiene su skip histórico; un v2 vacío no tiene nada que sincronizar. Partes 2-3 del diagnóstico de la issue no reproducen en main (verificado empíricamente, comentado en la issue con workaround inmediato).
2. **Stories imborrables por API** (KJC-TSK-0671, regla absoluta del producto): `DELETE /api/stories/:id` → **405** con la norma (descartar = `kj hu move <id> skipped`; `kj brief board`). Sin consumidor en la UI — solo agentes podían golpearla. deleteProject/deleteSession (infra) se mantienen.

**Orden de publicación** (regla firme post-v3.15.0): tras mergear, npm publish de @karajan/hu-board@1.1.0 PRIMERO; el bump del dep en karajan-code va con la release v4.1.8 en PR posterior.

Tests: suite completa del paquete 428 passed (tombstones al contrato 405).