### PR TITLE
fix(board): prompt modals show full spec-review findings (KJC-BUG-0125)

### DIFF
--- a/packages/hu-board/public/utils/modals.js
+++ b/packages/hu-board/public/utils/modals.js
@@ -208,9 +208,27 @@ function showPromptModal(prompt) {
   if (activePromptId === prompt.promptId) return;
   activePromptId = prompt.promptId;
   const dlg = ensureDialog();
+  // KJC-BUG-0125 (issue #1275): findings render as a readable, open list —
+  // "4 findings at severity fail" alone gives the user nothing to act on.
+  // Each finding shows its message and the concrete suggestion.
+  const sevColor = (s) => (s === 'fail' ? '#f87171' : s === 'warn' ? '#fbbf24' : '#60a5fa');
+  const findings = prompt.context?.detail?.findings || prompt.context?.findings;
+  const findingsBlock = Array.isArray(findings) && findings.length
+    ? `<div style="margin-top:10px;display:flex;flex-direction:column;gap:8px;max-height:280px;overflow:auto">`
+      + findings.map((f) => `
+        <div style="border-left:3px solid ${sevColor(f.severity)};padding:6px 10px;background:var(--bg-primary);border-radius:var(--radius-sm)">
+          <div style="font-size:0.78rem;color:var(--text-muted)">
+            <strong style="color:${sevColor(f.severity)}">${esc(String(f.severity || '').toUpperCase())}</strong>
+            · ${esc(f.category || '')}${f.id ? ` · ${esc(f.id)}` : ''}
+          </div>
+          <div style="font-size:0.86rem;line-height:1.45;margin-top:2px">${esc(f.message || '')}</div>
+          ${f.suggestion ? `<div style="font-size:0.8rem;color:var(--text-muted);margin-top:2px">→ ${esc(f.suggestion)}</div>` : ''}
+        </div>`).join('')
+      + `</div>`
+    : '';
   const ctxBlock = prompt.context
     ? `<details style="margin-top:8px">
-         <summary style="cursor:pointer;color:var(--text-muted);font-size:0.85rem">Context</summary>
+         <summary style="cursor:pointer;color:var(--text-muted);font-size:0.85rem">Raw context</summary>
          <pre style="white-space:pre-wrap;font-size:0.78rem;background:var(--bg-primary);padding:8px;border-radius:var(--radius-sm);overflow:auto;max-height:240px">${esc(JSON.stringify(prompt.context, null, 2))}</pre>
        </details>`
     : '';
@@ -221,6 +239,7 @@ function showPromptModal(prompt) {
     </div>
     <div style="padding:14px 18px">
       <div style="white-space:pre-wrap;font-size:0.95rem;line-height:1.55">${esc(prompt.question)}</div>
+      ${findingsBlock}
       ${ctxBlock}
       <textarea id="prompt-answer" rows="3"
                 placeholder="Type your answer (or 'stop' to abort the run)"

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -11,6 +11,16 @@ import { RISK } from "../autonomy/policy.js";
 
 const MAX_REFINE_ITERATIONS = 5;
 
+// KJC-BUG-0125 (issue #1275): the prompt used to carry only counts and
+// categories — the dashboard modal showed "4 findings at severity fail"
+// with nothing to act on. The full findings travel with the prompt now
+// (capped: a runaway reviewer must not blow up the prompt payload).
+const MAX_FINDINGS_IN_PROMPT = 20;
+const findingsForPrompt = (findings) => findings.slice(0, MAX_FINDINGS_IN_PROMPT).map((f) => ({
+  id: f.id, severity: f.severity, category: f.category,
+  message: f.message, suggestion: f.suggestion || null,
+}));
+
 /**
  * Decide the gate action (`continue` | `refine`) autonomously: the Arbiter
  * picks PROCEED (proceed with the best reading) or RETRY_DIFFERENT_APPROACH
@@ -24,7 +34,7 @@ async function decideGateAutonomously(resolve, { severity, findings }) {
       { value: "PROCEED", label: "proceed with the best reading", conservative: true },
       { value: "RETRY_DIFFERENT_APPROACH", label: "auto-refine the spec" },
     ],
-    context: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))] },
+    context: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], findings: findingsForPrompt(findings) },
     risk: severity === "fail" ? RISK.HIGH : RISK.LOW,
   });
   return choice === "RETRY_DIFFERENT_APPROACH" ? "refine" : "continue";
@@ -71,7 +81,7 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
       const answer = await askQuestion(
         `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
         {
-          detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1 },
+          detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1, findings: findingsForPrompt(findings) },
           // KJC-BUG-0109: mirrors the interactive default — --yes presses Enter.
           defaultAnswer: "continue",
         },

--- a/tests/spec-review/run-spec-review.test.js
+++ b/tests/spec-review/run-spec-review.test.js
@@ -79,3 +79,38 @@ describe("runSpecReview", () => {
     expect(noopLog.warn).toHaveBeenCalled();
   });
 });
+
+// KJC-BUG-0125 (issue #1275): the prompt carries the FULL findings so the
+// dashboard modal can show what is wrong and how to fix it — not just a count.
+describe("prompt payload carries full findings", () => {
+  const rich = [
+    { id: "F-001", severity: "fail", category: "missing_ac", message: "no acceptance criteria", suggestion: "add Given/When/Then" },
+    { id: "F-002", severity: "warn", category: "ambiguity", message: "vague scope", suggestion: null },
+  ];
+
+  it("interactive askQuestion detail includes findings with message + suggestion", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: rich } });
+    const askQuestion = vi.fn().mockResolvedValue("continue");
+    await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion, flags: { forceSpecReview: true } });
+    const detail = askQuestion.mock.calls[0][1].detail;
+    expect(detail.findings).toHaveLength(2);
+    expect(detail.findings[0]).toMatchObject({ id: "F-001", severity: "fail", message: "no acceptance criteria", suggestion: "add Given/When/Then" });
+    expect(detail.findings[1].suggestion).toBeNull();
+  });
+
+  it("caps the findings shipped in the prompt", async () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ id: `F-${i}`, severity: "warn", category: "c", message: "m" }));
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "warn", findings: many } });
+    const askQuestion = vi.fn().mockResolvedValue("continue");
+    await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion, flags: { forceSpecReview: true } });
+    expect(askQuestion.mock.calls[0][1].detail.findings).toHaveLength(20);
+    expect(askQuestion.mock.calls[0][1].detail.findingCount).toBe(30); // the real total stays visible
+  });
+
+  it("autonomous resolver context includes findings too", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: rich } });
+    const resolve = vi.fn().mockResolvedValue({ choice: "PROCEED" });
+    await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: vi.fn(), resolve, autonomy: "autonomous", flags: { forceSpecReview: true } });
+    expect(resolve.mock.calls[0][0].context.findings).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #1275 — cuarta issue de campo de Jorge. El modal del dashboard mostraba solo '4 findings at severity fail' sin nada accionable.

- **Emisor** (`run-spec-review`): el prompt viaja con los findings completos (id/severity/category/message/**suggestion**), tanto en el `detail` del askQuestion interactivo como en el `context` del resolver autónomo. Cap a 20 con el total real en `findingCount` (un reviewer desbocado no revienta el payload).
- **Modal del board**: lista legible y abierta por defecto — cada finding con su color de severidad, mensaje y la sugerencia concreta (→). El JSON crudo queda como 'Raw context' colapsado.

hu-board viaja bundled en el tarball → sale en la próxima release sin tren aparte.

Tests: 3 nuevos (payload interactivo con suggestion, cap con total visible, contexto autónomo).