### PR TITLE
chore(release): v4.1.9 — warnings you can act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.9] - 2026-07-22
+
+Patch. **Warnings you can act on** — the fourth field issue filed by a user's Karajan, fixed and auto-closed within hours.
+
+### Fixed
+
+- **Dashboard prompt modals show the FULL spec-review findings** (KJC-BUG-0125, issue #1275 — fourth self-healing cycle): each finding renders as a readable severity-colored entry with its message and the concrete suggestion, instead of "4 findings at severity fail" and a collapsed JSON blob. The full findings travel with the prompt in both the interactive and the autonomous paths (capped at 20, real total always visible).
+- **`kj-run-smoke` no longer flakes on Node 24 CI** (KJC-BUG-0126): the positional `mockResolvedValueOnce` chains — misaligned by any order shift in the orchestrator's probes — are replaced by command-keyed mocks that describe the world, not a fragile sequence.
+
 ## [4.1.8] - 2026-07-22
 
 Patch. **The board becomes ungameable** — the dashboard-vs-agent fights reported from the field (an agent "fixing" warnings by deleting and recreating tasks) end here, the Planning Game way: the code forbids it AND the agent is taught why.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.1.8",
+      "version": "4.1.9",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release v4.1.9. Contenido ya mergeado en #1281 y #1282: modal del dashboard con findings completos (issue #1275 de Jorge — cuarto ciclo self-healing) y fix estructural del flaky de kj-run-smoke en Node 24.