### PR TITLE
feat(governance): tool-governor — single-flight, jobs cap, nice, tree-kill (KJC-TSK-0668, 1/2)

### DIFF
--- a/src/utils/tool-governor.js
+++ b/src/utils/tool-governor.js
@@ -1,0 +1,116 @@
+/**
+ * tool-governor — resource governance for external tools launched by kj
+ * (KJC-TSK-0668), born from a real semgrep CPU storm: single-flight across
+ * processes (pid-stamped lockfile, stale locks stolen), jobs cap (half the
+ * CPUs), nice +10 best-effort, and hard timeouts that kill the PROCESS TREE
+ * (own process group on POSIX). In-process cousin: async-lock.js.
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_LOCKS_DIR = path.join(os.homedir(), ".karajan", "locks");
+const NICENESS = 10;
+
+/** Parallelism cap for scanner `--jobs` flags: half the CPUs, min 1. */
+export function jobsCap(cpuCount = os.cpus().length) {
+  return Math.max(1, Math.floor(cpuCount / 2));
+}
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err.code === "EPERM"; // alive but owned by another user
+  }
+}
+
+/** Machine-wide lock for `tool` → {release}; ELOCKTIMEOUT if the live holder outlasts `timeoutMs`. */
+export async function acquireToolLock(tool, { locksDir = DEFAULT_LOCKS_DIR, timeoutMs = 180_000, pollMs = 500 } = {}) {
+  fs.mkdirSync(locksDir, { recursive: true });
+  const lockPath = path.join(locksDir, `${tool}.lock`);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      // wx = atomic create-or-fail: the filesystem is the arbiter.
+      const fd = fs.openSync(lockPath, "wx");
+      fs.writeSync(fd, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
+      fs.closeSync(fd);
+      return { release: () => fs.rmSync(lockPath, { force: true }) };
+    } catch (err) {
+      if (err.code !== "EEXIST") throw err;
+      let holder = null;
+      try {
+        holder = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+      } catch { /* unreadable → stale */ }
+      if (!holder || !Number.isInteger(holder.pid) || !isPidAlive(holder.pid)) {
+        fs.rmSync(lockPath, { force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        const e = new Error(`${tool} is already running (pid ${holder.pid}, since ${holder.startedAt}) — gave up waiting after ${timeoutMs}ms`);
+        e.code = "ELOCKTIMEOUT";
+        throw e;
+      }
+      await new Promise((r) => setTimeout(r, pollMs));
+    }
+  }
+}
+
+/**
+ * Governed spawn: own process group (POSIX), lowered priority, timeout kills
+ * the whole tree. Rejections mirror execFile's contract (err.code /
+ * err.killed / err.stdout) so scanner collectors keep their error handling.
+ */
+export function governedExecFile(bin, args, { cwd, timeout = 0, maxBuffer = 16 * 1024 * 1024, niceness = NICENESS } = {}) {
+  return new Promise((resolve, reject) => {
+    const posix = process.platform !== "win32";
+    const child = spawn(bin, args, { cwd, detached: posix, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let killedByGovernor = false, timer = null;
+    const killTree = () => {
+      killedByGovernor = true;
+      try {
+        if (posix) process.kill(-child.pid, "SIGKILL");
+        else child.kill("SIGKILL");
+      } catch { /* tree already gone */ }
+    };
+    if (timeout > 0) timer = setTimeout(killTree, timeout);
+    child.on("spawn", () => {
+      try {
+        os.setPriority(child.pid, niceness);
+      } catch { /* best-effort */ }
+    });
+    const bufferBlown = () => stdout.length + stderr.length > maxBuffer;
+    child.stdout.on("data", (d) => { stdout += d; if (bufferBlown()) killTree(); });
+    child.stderr.on("data", (d) => { stderr += d; if (bufferBlown()) killTree(); });
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      reject(Object.assign(err, { stdout, stderr }));
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      if (killedByGovernor) {
+        reject(Object.assign(new Error(`${bin} killed by governor after ${timeout}ms (process tree included)`), { killed: true, stdout, stderr }));
+      } else if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(Object.assign(new Error(`${bin} exited with code ${code}`), { code, stdout, stderr }));
+      }
+    });
+  });
+}
+
+/** Lock + governed exec + guaranteed release. `opts.bin` overrides the executable. */
+export async function runGoverned(tool, args, opts = {}) {
+  const lock = await acquireToolLock(tool, opts.lock);
+  try {
+    return await governedExecFile(opts.bin || tool, args, opts);
+  } finally {
+    lock.release();
+  }
+}

--- a/tests/utils/tool-governor.test.js
+++ b/tests/utils/tool-governor.test.js
@@ -1,0 +1,80 @@
+// KJC-TSK-0668 — resource governance for external tools launched by kj.
+// The semgrep CPU storm happened because nothing serialized concurrent
+// scans, capped their parallelism, or killed their process tree on timeout.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { jobsCap, acquireToolLock, governedExecFile, runGoverned } from "../../src/utils/tool-governor.js";
+
+let locksDir;
+beforeEach(() => { locksDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-locks-")); });
+afterEach(() => { fs.rmSync(locksDir, { recursive: true, force: true }); });
+
+describe("jobsCap", () => {
+  it("uses half the CPUs, never less than 1", () => {
+    expect(jobsCap(20)).toBe(10);
+    expect(jobsCap(3)).toBe(1);
+    expect(jobsCap(1)).toBe(1);
+  });
+});
+
+describe("acquireToolLock", () => {
+  it("acquires, blocks a second caller, and frees on release", async () => {
+    const lock = await acquireToolLock("semgrep", { locksDir });
+    await expect(acquireToolLock("semgrep", { locksDir, timeoutMs: 300, pollMs: 50 }))
+      .rejects.toMatchObject({ code: "ELOCKTIMEOUT" });
+    const other = await acquireToolLock("osv-scanner", { locksDir, timeoutMs: 300 }); // per-tool
+    other.release();
+    lock.release();
+    expect(fs.existsSync(path.join(locksDir, "semgrep.lock"))).toBe(false);
+  });
+
+  it("steals a lock whose holder pid is dead", async () => {
+    const lockPath = path.join(locksDir, "semgrep.lock");
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 999999999, startedAt: "x" }));
+    const lock = await acquireToolLock("semgrep", { locksDir, timeoutMs: 2000 });
+    expect(JSON.parse(fs.readFileSync(lockPath, "utf8")).pid).toBe(process.pid);
+    lock.release();
+  });
+});
+
+describe("governedExecFile", () => {
+  it("resolves stdout on success; rejects with exit code and rescued stdout on failure", async () => {
+    const { stdout } = await governedExecFile(process.execPath, ["-e", "console.log('ok')"]);
+    expect(stdout.trim()).toBe("ok");
+    await expect(governedExecFile(process.execPath, ["-e", "console.log('partial'); process.exit(2)"]))
+      .rejects.toMatchObject({ code: 2, stdout: expect.stringContaining("partial") });
+  });
+
+  it("rejects with ENOENT for a missing binary", async () => {
+    await expect(governedExecFile("definitely-not-a-real-binary-kj", []))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("kills the whole process tree on timeout", async () => {
+    // The child spawns a grandchild that would outlive it if only the
+    // direct child were killed — exactly the orphaned semgrep-core case.
+    const script = "const{spawn}=require('node:child_process');const g=spawn(process.execPath,['-e','setInterval(()=>{},1e3)']);console.log('grandchild:'+g.pid);setInterval(()=>{},1e3);";
+    const err = await governedExecFile(process.execPath, ["-e", script], { timeout: 1500 }).catch((e) => e);
+    expect(err.killed).toBe(true);
+    const grandchildPid = Number(String(err.stdout).match(/grandchild:(\d+)/)?.[1]);
+    expect(grandchildPid).toBeGreaterThan(0);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(() => process.kill(grandchildPid, 0)).toThrow(); // dead → ESRCH
+  });
+});
+
+describe("runGoverned", () => {
+  it("serializes concurrent runs of the same tool", async () => {
+    const marker = path.join(locksDir, "overlap.txt");
+    const script = `const fs=require('node:fs');fs.appendFileSync(${JSON.stringify(marker)},'start\\n');const t=Date.now();while(Date.now()-t<150){}fs.appendFileSync(${JSON.stringify(marker)},'end\\n');`;
+    await Promise.all([
+      runGoverned("node-tool", ["-e", script], { bin: process.execPath, lock: { locksDir } }),
+      runGoverned("node-tool", ["-e", script], { bin: process.execPath, lock: { locksDir } }),
+    ]);
+    // Serialized ⇒ strict start,end,start,end — never two starts in a row.
+    expect(fs.readFileSync(marker, "utf8").trim().split("\n")).toEqual(["start", "end", "start", "end"]);
+  });
+});


### PR DESCRIPTION
Part 1/2 of KJC-TSK-0668 (the semgrep CPU storm, user request 2026-07-22).

New `src/utils/tool-governor.js`:
- **Single-flight across processes**: pid-stamped lockfile in `~/.karajan/locks/<tool>.lock` — a second kj needing the same tool waits (poll + ELOCKTIMEOUT); locks from dead pids are stolen.
- **jobsCap()**: half the CPUs, min 1 — for scanner `--jobs` flags.
- **Reduced priority**: `os.setPriority(+10)` best-effort on spawn.
- **Tree-kill timeouts**: children spawn detached in their own process group (POSIX); timeout (or blown stdout+stderr budget) kills the whole group — no more orphaned semgrep-core.

Rejections mirror execFile's contract (err.code / err.killed / err.stdout) so collectors keep their error handling. Test proves the grandchild dies (the exact orphan case).

Part 2/2 wires semgrep (with `--jobs`) and osv-scanner through the governor and adds the `kj doctor` orphan check.