### PR TITLE
feat(governance): governed scanners + doctor orphan check (KJC-TSK-0668, 2/2)

### DIFF
--- a/src/audit/osv-findings.js
+++ b/src/audit/osv-findings.js
@@ -19,10 +19,7 @@
  *     out-of-control result list cannot blow the token budget.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { runGoverned } from "../utils/tool-governor.js";
 
 const SCAN_TIMEOUT_MS = 60_000;
 const SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "MODERATE"];
@@ -42,7 +39,10 @@ export async function collectOsvFindings(projectDir, logger = null) {
   }
   let stdout;
   try {
-    const { stdout: out } = await execFileAsync(
+    // KJC-TSK-0668: governed run — single-flight across kj processes and a
+    // timeout that kills the whole process tree (osv-scanner is I/O-bound,
+    // no jobs flag to cap).
+    const { stdout: out } = await runGoverned(
       "osv-scanner",
       ["--format=json", "--recursive", projectDir || "."],
       { cwd: projectDir, timeout: SCAN_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 }

--- a/src/audit/semgrep-findings.js
+++ b/src/audit/semgrep-findings.js
@@ -18,10 +18,7 @@
  *     into the `security` dimension using the rule ID as the rule field.
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { runGoverned, jobsCap } from "../utils/tool-governor.js";
 
 const SCAN_TIMEOUT_MS = 120_000;
 const SEVERITY_ORDER = ["ERROR", "WARNING", "INFO"];
@@ -44,9 +41,12 @@ export async function collectSemgrepFindings(projectDir, logger = null) {
   }
   let stdout;
   try {
-    const { stdout: out } = await execFileAsync(
+    // KJC-TSK-0668: governed run — machine-wide single-flight, --jobs capped
+    // at half the CPUs (semgrep grabs 14 by default), nice +10, and a timeout
+    // that kills the whole process tree (no more orphaned semgrep-core).
+    const { stdout: out } = await runGoverned(
       "semgrep",
-      ["--config", "auto", "--json", "--quiet", `--timeout=${Math.floor(SCAN_TIMEOUT_MS / 1000)}`, projectDir || "."],
+      ["--config", "auto", "--json", "--quiet", `--jobs=${jobsCap()}`, `--timeout=${Math.floor(SCAN_TIMEOUT_MS / 1000)}`, projectDir || "."],
       { cwd: projectDir, timeout: SCAN_TIMEOUT_MS + 5000, maxBuffer: 32 * 1024 * 1024 }
     );
     stdout = out;

--- a/src/checks/orphans.js
+++ b/src/checks/orphans.js
@@ -1,0 +1,77 @@
+/**
+ * Orphaned scanner detection for `kj doctor` (KJC-TSK-0668). After the CPU
+ * storm, timed-out scans left semgrep-core processes reparented to init /
+ * systemd, silently burning cores. This check finds processes of tools kj
+ * governs whose parent is init (pid 1) or a systemd reaper, reports them,
+ * and — strategy "prompt" — offers to kill them.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { STRATEGY } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+const GOVERNED_TOOLS = new Set(["semgrep", "semgrep-core", "osv-scanner", "lighthouse"]);
+
+/**
+ * Scan the process table for governed tools whose parent is init or a
+ * systemd reaper (where the kernel sends orphans). `runPs` injectable.
+ */
+export async function findOrphanToolProcesses(runPs = execFileAsync) {
+  if (process.platform === "win32") return { supported: false, orphans: [] };
+  let stdout;
+  try {
+    ({ stdout } = await runPs("ps", ["-eo", "pid=,ppid=,comm="]));
+  } catch {
+    return { supported: false, orphans: [] };
+  }
+  const rows = [];
+  const commByPid = new Map();
+  for (const line of String(stdout).split("\n")) {
+    const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    if (!m) continue;
+    const row = { pid: Number(m[1]), ppid: Number(m[2]), comm: m[3].trim() };
+    rows.push(row);
+    commByPid.set(row.pid, row.comm);
+  }
+  const orphans = rows.filter((r) =>
+    GOVERNED_TOOLS.has(r.comm) && (r.ppid === 1 || commByPid.get(r.ppid) === "systemd")
+  );
+  return { supported: true, orphans };
+}
+
+function createOrphanCheck() {
+  return {
+    name: "tool-orphans",
+    label: "Orphaned scanner processes",
+    strategy: STRATEGY.PROMPT,
+    describe: "Kill orphaned scanner processes left behind by interrupted runs",
+    async detect({ runPs } = {}) {
+      const { supported, orphans } = await findOrphanToolProcesses(runPs || execFileAsync);
+      if (!supported) return { ok: true, severity: "info", detail: "orphan detection not supported on this platform" };
+      if (orphans.length === 0) return { ok: true, severity: "info", detail: "no orphaned scanner processes" };
+      const list = orphans.map((o) => `${o.comm}(${o.pid})`).join(", ");
+      return {
+        ok: false,
+        severity: "warn",
+        detail: `${orphans.length} orphaned scanner process(es) burning CPU: ${list}`,
+        fix: `kill -9 ${orphans.map((o) => o.pid).join(" ")}`,
+        extra: { orphans },
+      };
+    },
+    async remediate({ extra, kill = process.kill } = {}) {
+      let killed = 0;
+      for (const o of extra?.orphans || []) {
+        try {
+          kill(o.pid, "SIGKILL");
+          killed += 1;
+        } catch { /* already gone */ }
+      }
+      return { fixed: killed > 0, detail: `killed ${killed} orphaned scanner process(es)` };
+    },
+  };
+}
+
+export function getOrphanChecks() {
+  return [createOrphanCheck()];
+}

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -35,6 +35,7 @@ import { getSkillsChecks } from "../checks/skills.js";
 import { getDirSetupChecks } from "../checks/dir-setup.js";
 import { getProjectChecks } from "../checks/project-checks.js";
 import { getHardwareChecks } from "../checks/hardware.js";
+import { getOrphanChecks } from "../checks/orphans.js";
 
 /**
  * Build the list of Check objects applicable to the current config.
@@ -72,6 +73,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getRtkChecks(),
     ...getSqueezrChecks(),
     ...getAiTrashChecks(),
+    ...getOrphanChecks(),
     ...getQmdChecks(),
     ...getRagHooksChecks({ projectDir }),
     ...getProjectChecks({ projectDir }),

--- a/tests/audit/osv-findings.test.js
+++ b/tests/audit/osv-findings.test.js
@@ -1,18 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock execFile + promisify so we can drive collectOsvFindings under
-// controlled conditions. promisify(execFile) resolves to {stdout, stderr}
-// (Node's custom impl). We bypass that nuance by faking promisify too.
+// KJC-TSK-0668: the collector runs through the tool governor now — mock it
+// so tests drive the same {stdout}/rejection contract without real spawns.
 const execFileMock = vi.fn();
 
-vi.mock("node:util", async () => {
-  const actual = await vi.importActual("node:util");
-  return {
-    ...actual,
-    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
-  };
-});
-vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+vi.mock("../../src/utils/tool-governor.js", () => ({
+  runGoverned: (...args) => Promise.resolve(execFileMock(...args)),
+}));
 
 import { collectOsvFindings, parseOsvOutput, groupVulnerabilitiesBySeverity } from "../../src/audit/osv-findings.js";
 import { buildAuditPrompt } from "../../src/prompts/audit.js";

--- a/tests/audit/semgrep-findings.test.js
+++ b/tests/audit/semgrep-findings.test.js
@@ -1,17 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock node:util's promisify to bypass the {stdout, stderr} custom-impl
-// dance (same trick as tests/audit/osv-findings.test.js).
+// KJC-TSK-0668: the collector runs through the tool governor now — mock it
+// so tests drive the same {stdout}/rejection contract without real spawns.
 const execFileMock = vi.fn();
 
-vi.mock("node:util", async () => {
-  const actual = await vi.importActual("node:util");
-  return {
-    ...actual,
-    promisify: () => (...args) => Promise.resolve(execFileMock(...args)),
-  };
-});
-vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+vi.mock("../../src/utils/tool-governor.js", () => ({
+  runGoverned: (...args) => Promise.resolve(execFileMock(...args)),
+  jobsCap: () => 4,
+}));
 
 import { collectSemgrepFindings, parseSemgrepOutput, groupFindingsBySeverity } from "../../src/audit/semgrep-findings.js";
 import { buildAuditPrompt } from "../../src/prompts/audit.js";

--- a/tests/checks/orphans.test.js
+++ b/tests/checks/orphans.test.js
@@ -1,0 +1,51 @@
+// KJC-TSK-0668 — kj doctor detects orphaned scanner processes (the
+// semgrep-core survivors of the CPU storm) and offers to clean them up.
+
+import { describe, it, expect, vi } from "vitest";
+import { findOrphanToolProcesses, getOrphanChecks } from "../../src/checks/orphans.js";
+
+const PS = (rows) => ({ stdout: rows.map((r) => `  ${r.join("  ")}`).join("\n"), stderr: "" });
+
+describe("findOrphanToolProcesses", () => {
+  it("flags governed tools reparented to init or systemd, ignores the rest", async () => {
+    const runPs = vi.fn().mockResolvedValue(PS([
+      [1, 0, "systemd"],
+      [800, 2, "kthreadd-child"],
+      [1200, 1, "semgrep-core"], // orphan: parent is init
+      [1300, 2100, "systemd"], // user session manager
+      [1400, 1300, "semgrep-core"], // orphan: reparented to systemd --user
+      [1500, 900, "semgrep-core"], // NOT orphan: live non-systemd parent
+      [1600, 1, "osv-scanner"], // orphan
+      [1700, 1, "firefox"], // orphan but not ours
+    ]));
+    const { supported, orphans } = await findOrphanToolProcesses(runPs);
+    expect(supported).toBe(true);
+    expect(orphans.map((o) => o.pid)).toEqual([1200, 1400, 1600]);
+  });
+
+  it("reports unsupported instead of throwing when ps fails", async () => {
+    const runPs = vi.fn().mockRejectedValue(new Error("no ps"));
+    await expect(findOrphanToolProcesses(runPs)).resolves.toMatchObject({ supported: false, orphans: [] });
+  });
+});
+
+describe("orphan check for kj doctor", () => {
+  const check = getOrphanChecks()[0];
+
+  it("passes when nothing is orphaned", async () => {
+    const res = await check.detect({ runPs: vi.fn().mockResolvedValue(PS([[900, 500, "node"]])) });
+    expect(res.ok).toBe(true);
+  });
+
+  it("warns with pids and a cleanup fix when orphans exist, and remediates by killing them", async () => {
+    const res = await check.detect({ runPs: vi.fn().mockResolvedValue(PS([[1200, 1, "semgrep-core"]])) });
+    expect(res).toMatchObject({ ok: false, severity: "warn" });
+    expect(res.detail).toContain("semgrep-core");
+    expect(res.fix).toContain("1200");
+
+    const killer = vi.fn();
+    const out = await check.remediate({ extra: res.extra, kill: killer });
+    expect(killer).toHaveBeenCalledWith(1200, "SIGKILL");
+    expect(out.fixed).toBe(true);
+  });
+});


### PR DESCRIPTION
Part 2/2 of KJC-TSK-0668 — closes the semgrep CPU storm end to end (part 1: #1284).

- **semgrep** now runs through the governor: machine-wide single-flight (a second kj waits instead of scanning in parallel), `--jobs` capped at half the CPUs (semgrep defaults to 14), nice +10, and a timeout that kills the whole process tree — no more orphaned semgrep-core.
- **osv-scanner** governed the same way (no jobs flag; it's I/O-bound).
- **`kj doctor`**: new `tool-orphans` check — finds governed tools reparented to init or a systemd reaper, reports pids with the exact cleanup command, and (strategy *prompt*) offers to kill them. Handles both classic init orphans and systemd-user reaper orphans, exactly what the user's `top` showed.

Collector error contracts untouched (rejections mirror execFile: err.code / err.killed / err.stdout); tests drive the governor mock with the same cases. Net delta ~120 lines.