### PR TITLE
chore(release): v4.1.10 — karajan governs its tools' resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.10] - 2026-07-22
+
+Patch. **Karajan governs its tools' resources, not just your code** — born from a real CPU storm (concurrent scans, semgrep taking 14 cores each, orphaned semgrep-core processes).
+
+### Added
+
+- **Tool governor** (KJC-TSK-0668): every external scanner kj launches now runs governed — machine-wide single-flight (a second kj needing the same tool waits instead of scanning in parallel; locks from dead processes are stolen), `--jobs` capped at half the CPUs for semgrep, reduced priority (nice +10), and hard timeouts that kill the whole process tree, so an interrupted scan can never leave orphans burning CPU.
+- **`kj doctor` orphan check**: detects scanner processes reparented to init or a systemd reaper, reports them with the exact cleanup command, and offers to kill them.
+
 ## [4.1.9] - 2026-07-22
 
 Patch. **Warnings you can act on** — the fourth field issue filed by a user's Karajan, fixed and auto-closed within hours.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.1.9",
+      "version": "4.1.10",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release v4.1.10. Contenido ya mergeado en #1284 y #1285: tool-governor (single-flight, jobs cap, nice, tree-kill) + check de escáneres huérfanos en kj doctor. Cierra la clase de bug de la tormenta de CPU de semgrep.