### PR TITLE
feat(run): non-interactive mode for agents/CI (KJC-TSK-0674)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -403,10 +403,14 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Resume a paused session")
     .argument("<sessionId>")
     .option("--answer <text>", "Answer to the question that caused the pause")
+    .option("--non-interactive", "Agents/CI: auto-answer prompts with their safe defaults; stop when there is none. Also enabled by KJ_NON_INTERACTIVE=1.")
     .option("--json", "Output JSON only")
     .action(async (sessionId, flags) => {
       await withConfig(pkgVersion, "resume", flags, async ({ config, logger }) => {
-        await resumeCommand({ sessionId, answer: flags.answer, config, logger, flags });
+        const res = await resumeCommand({ sessionId, answer: flags.answer, config, logger, flags });
+        // KJC-TSK-0674 (issue #1289): same contract as kj run — an aborted
+        // resume must be observable by CI.
+        if (res?.aborted) process.exitCode = 1;
       });
     });
 

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -54,6 +54,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md). Alternative to the positional task argument.")
     .option("-y, --yes", "Skip the cwd confirmation prompt (CI / scripted runs).")
+    .option("--non-interactive", "Agents/CI: auto-answer prompts with their safe defaults (warn → continue) and stop with exit code 1 when there is none (fail). Also enabled by KJ_NON_INTERACTIVE=1.")
     .option("--planner <name>")
     .option("--coder <name>")
     .option("--reviewer <name>")
@@ -145,7 +146,10 @@ export function registerPipeline(program, { pkgVersion }) {
         }
         const { resolveTaskInput } = await import("../utils/task-file.js");
         const resolvedTask = await resolveTaskInput({ task: effectiveTask, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
-        await runCommandHandler({ task: resolvedTask, config, logger, flags });
+        const res = await runCommandHandler({ task: resolvedTask, config, logger, flags });
+        // KJC-TSK-0674 (issue #1289): an aborted run (spec-review cancel,
+        // unanswerable non-interactive gate) must be observable by CI.
+        if (res?.aborted) process.exitCode = 1;
       });
     });
 

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -93,7 +93,9 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
       );
       if (answer === null) return { proceed: false, cancelled: true, severity, findings };
       const n = String(answer).trim().toLowerCase() || fallback;
-      action = n.startsWith("x") || n === "cancel" ? "cancel" : n.startsWith("r") || n === "refine" ? "refine" : "continue";
+      if (n.startsWith("x") || n === "cancel") action = "cancel";
+      else if (n.startsWith("r") || n === "refine") action = "refine";
+      else action = "continue";
     }
     if (action === "cancel") return { proceed: false, cancelled: true, severity, findings };
     if (action === "refine") {

--- a/src/spec-review/run-spec-review.js
+++ b/src/spec-review/run-spec-review.js
@@ -78,16 +78,21 @@ export async function runSpecReview({ spec, config, logger, askQuestion, flags =
       action = await decideGateAutonomously(resolve, { severity, findings });
     } else {
       if (!askQuestion) return { proceed: true, severity, findings, finalSpec: currentSpec };
+      // KJC-TSK-0674 (issue #1289): at severity FAIL the default flips to
+      // cancel — continuing past fails requires an explicit answer, both
+      // interactively (Enter cancels) and unattended (no declared default,
+      // so --yes / KJ_NON_INTERACTIVE stops with exit ≠ 0). warn/info keep
+      // the KJC-BUG-0109 contract: --yes presses Enter → continue.
+      const fallback = severity === "fail" ? "cancel" : "continue";
       const answer = await askQuestion(
-        `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: continue)`,
+        `Spec review: ${findings.length} finding${findings.length === 1 ? "" : "s"} at severity ${severity}. [c]ontinue / [r]efine / [x]cancel? (default: ${fallback})`,
         {
           detail: { severity, findingCount: findings.length, categories: [...new Set(findings.map((f) => f.category))], iteration: iter + 1, findings: findingsForPrompt(findings) },
-          // KJC-BUG-0109: mirrors the interactive default — --yes presses Enter.
-          defaultAnswer: "continue",
+          defaultAnswer: severity === "fail" ? undefined : "continue",
         },
       );
       if (answer === null) return { proceed: false, cancelled: true, severity, findings };
-      const n = String(answer).trim().toLowerCase();
+      const n = String(answer).trim().toLowerCase() || fallback;
       action = n.startsWith("x") || n === "cancel" ? "cancel" : n.startsWith("r") || n === "refine" ? "refine" : "continue";
     }
     if (action === "cancel") return { proceed: false, cancelled: true, severity, findings };

--- a/src/utils/cli-ask-question.js
+++ b/src/utils/cli-ask-question.js
@@ -28,22 +28,28 @@ export function createCliAskQuestion(opts = {}) {
   return async (question, context) => {
     const stdinReadable = process.stdin && process.stdin.readable !== false;
     const isInteractive = Boolean(process.stdin?.isTTY) && stdinReadable;
-    if (!isInteractive) {
-      if (flags?.yes) {
+    // KJC-TSK-0674 (issue #1289): agents and CI enable the same contract
+    // as --yes explicitly, via --non-interactive or KJ_NON_INTERACTIVE=1,
+    // instead of blocking forever on a board modal nobody is watching.
+    // Explicit mode wins even when a (pseudo-)TTY is attached.
+    const forcedNonInteractive = flags?.nonInteractive || process.env.KJ_NON_INTERACTIVE === "1";
+    if (!isInteractive || forcedNonInteractive) {
+      const nonInteractive = forcedNonInteractive || flags?.yes;
+      if (nonInteractive) {
         // KJC-BUG-0109: a question that declares a safe default is answered
         // with it — --yes means "press Enter for me", not "abort on any
         // gate". Questions without a declared default keep failing loud.
         const fallback = typeof context?.defaultAnswer === "string" && context.defaultAnswer.trim()
           ? context.defaultAnswer.trim() : null;
         if (fallback) {
-          process.stderr.write(`\n[non-interactive --yes] Auto-answering with declared default "${fallback}": ${question}\n`);
+          process.stderr.write(`\n[non-interactive] Auto-answering with declared default "${fallback}": ${question}\n`);
           return fallback;
         }
         process.stderr.write(
-          `\n[non-interactive --yes] Pipeline asked a question that cannot be auto-answered:\n`
+          `\n[non-interactive] Pipeline asked a question that cannot be auto-answered:\n`
           + `  ❓ ${question}\n`
           + (context?.detail ? `  Context: ${JSON.stringify(context.detail)}\n` : "")
-          + `  Stopping the session. Re-run without --yes (TTY or HU Board) to answer it,\n`
+          + `  Stopping the session. Re-run interactively (TTY or HU Board) to answer it,\n`
           + `  or pass --skip-spec-review / a more complete spec so the question never appears.\n`
         );
         return null;
@@ -56,7 +62,9 @@ export function createCliAskQuestion(opts = {}) {
       console.log(
         "\n[non-interactive] Routing the prompt to the HU Board.\n"
         + "  Open http://localhost:4000 — a modal will appear asking for your answer.\n"
-        + "  This process is now waiting; closing the board does NOT cancel the run."
+        + "  This process is now waiting; closing the board does NOT cancel the run.\n"
+        + "  Running from an agent or CI with nobody watching the board? Re-run with\n"
+        + "  --non-interactive (or KJ_NON_INTERACTIVE=1) to auto-answer safe defaults instead."
       );
       try {
         return await askThroughBoard({ sessionId, question, context });

--- a/tests/cli-ask-question-defaults.test.js
+++ b/tests/cli-ask-question-defaults.test.js
@@ -41,4 +41,42 @@ describe("createCliAskQuestion --yes defaults (KJC-BUG-0109)", () => {
     expect(answer).toBeNull();
     write.mockRestore();
   });
+
+  // KJC-TSK-0674 (issue #1289): agents/CI can enable the same contract
+  // without --yes, via env var or the --non-interactive flag.
+  it("KJ_NON_INTERACTIVE=1 enables auto-answering without --yes", async () => {
+    nonTty();
+    process.env.KJ_NON_INTERACTIVE = "1";
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const ask = createCliAskQuestion({ flags: {} });
+      const answer = await ask("Gate?", { defaultAnswer: "continue" });
+      expect(answer).toBe("continue");
+    } finally {
+      delete process.env.KJ_NON_INTERACTIVE;
+      write.mockRestore();
+    }
+  });
+
+  it("--non-interactive flag enables auto-answering and stops loud without a default", async () => {
+    nonTty();
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const ask = createCliAskQuestion({ flags: { nonInteractive: true } });
+    expect(await ask("Gate?", { defaultAnswer: "continue" })).toBe("continue");
+    expect(await ask("Hard question?", {})).toBeNull();
+    write.mockRestore();
+  });
+
+  it("explicit non-interactive mode wins even with a (pseudo-)TTY attached", async () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const hadTty = process.stdin.isTTY;
+    process.stdin.isTTY = true; // a readline fallback would hang this test
+    try {
+      const ask = createCliAskQuestion({ flags: { nonInteractive: true } });
+      expect(await ask("Gate?", { defaultAnswer: "continue" })).toBe("continue");
+    } finally {
+      process.stdin.isTTY = hadTty;
+      write.mockRestore();
+    }
+  });
 });

--- a/tests/commands/command-resume-yes-no-tty.test.js
+++ b/tests/commands/command-resume-yes-no-tty.test.js
@@ -42,7 +42,7 @@ describe("resume.js askQuestion contract — KJC-BUG-0081 round 2", () => {
     expect(answer).toBeNull();
     expect(askSpy).not.toHaveBeenCalled();
     const all = stderrWrites.join("");
-    expect(all).toMatch(/non-interactive --yes/);
+    expect(all).toMatch(/non-interactive/);
     expect(all).toMatch(/checkpoint/);
     askSpy.mockRestore();
   });

--- a/tests/commands/command-run-yes-no-tty.test.js
+++ b/tests/commands/command-run-yes-no-tty.test.js
@@ -36,7 +36,7 @@ describe("createCliAskQuestion — KJC-BUG-0081", () => {
     expect(answer).toBeNull();
     expect(askSpy).not.toHaveBeenCalled();
     const all = stderrWrites.join("");
-    expect(all).toMatch(/non-interactive --yes/);
+    expect(all).toMatch(/non-interactive/);
     expect(all).toMatch(/Stopping the session/);
     expect(all).toMatch(/missing-ac/);
     askSpy.mockRestore();

--- a/tests/spec-review/run-spec-review.test.js
+++ b/tests/spec-review/run-spec-review.test.js
@@ -49,6 +49,24 @@ describe("runSpecReview", () => {
     }
   });
 
+  // KJC-TSK-0674 (issue #1289): unattended runs must never silently
+  // continue past FAIL findings — only warn/info declare the safe default
+  // that --yes / KJ_NON_INTERACTIVE auto-answer.
+  it("declares defaultAnswer 'continue' for warn but NOT for fail", async () => {
+    for (const [findings, expected] of [[findingsWarn, "continue"], [findingsFail, undefined]]) {
+      const ask = vi.fn().mockResolvedValue("continue");
+      const { runSpecReview } = await loadWith({ ok: true, result: { severity: findings[0].severity, findings } });
+      await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: ask, flags: { forceSpecReview: true } });
+      expect(ask.mock.calls[0][1].defaultAnswer).toBe(expected);
+    }
+  });
+
+  it("empty answer (Enter) cancels at severity fail instead of continuing", async () => {
+    const { runSpecReview } = await loadWith({ ok: true, result: { severity: "fail", findings: findingsFail } });
+    const r = await runSpecReview({ spec: "x", config: {}, logger: noopLog, askQuestion: vi.fn().mockResolvedValue(""), flags: { forceSpecReview: true } });
+    expect(r).toMatchObject({ proceed: false, cancelled: true });
+  });
+
   it("treats empty / 'c' / 'continue' / unknown as continue", async () => {
     for (const answer of ["", "c", "continue", "yes"]) {
       const { runSpecReview } = await loadWith({ ok: true, result: { severity: "warn", findings: findingsWarn } });


### PR DESCRIPTION
Fixes #1289.

Agent/CI runs of `kj run` no longer block forever on the HU Board modal:

- **`--non-interactive` flag** on `kj run` and `kj resume`, plus **`KJ_NON_INTERACTIVE=1`** env — both force the auto-answer path even when a pseudo-TTY is attached.
- **Severity-aware spec-review gate**: warn/info findings auto-answer `continue` (decision streamed to stderr, as requested); FAIL findings declare no auto-answer → the run stops, and `aborted` now maps to **exit code 1** on both `kj run` and `kj resume` so the caller observes it. Interactively, FAIL flips the Enter default to cancel — continuing past fails requires typing it.
- The board-routing message now hints the mode, so the next agent that lands there knows the way out.

`--yes` keeps its KJC-BUG-0109 contract (presses Enter on declared defaults) — except it no longer silently continues past FAILs, which was unsafe unattended.