### PR TITLE
feat(board): check before create — cross-plan title dedup (KJC-TSK-0675)

### DIFF
--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -20,6 +20,29 @@ export function creatorLabel() {
 export const HU_STATUSES = ["pending", "running", "done", "failed", "skipped"];
 const BACKLOG_NAME = "brain-backlog";
 
+// KJC-TSK-0675 (issue #1288): agents that skip `kj hu list` created twins of
+// existing work — sometimes in a DIFFERENT plan. Titles are compared
+// normalized (case/punctuation-insensitive) across every live HU of every
+// plan: identical → refuse; mostly-overlapping tokens → warn with candidates.
+const normTitle = (t) => String(t || "").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim();
+const titleTokens = (t) => new Set(normTitle(t).split(" ").filter((w) => w.length > 2));
+
+export function findTitleMatches(title, allHus) {
+  const norm = normTitle(title);
+  const toks = titleTokens(title);
+  const identical = [];
+  const similar = [];
+  for (const h of allHus) {
+    if (h.status === "skipped") continue; // discarded cards don't reserve titles
+    if (normTitle(h.title) === norm) { identical.push(h); continue; }
+    const other = titleTokens(h.title);
+    const shared = [...toks].filter((w) => other.has(w)).length;
+    const smaller = Math.min(toks.size, other.size);
+    if (smaller > 0 && shared / smaller >= 0.8) similar.push(h);
+  }
+  return { identical, similar };
+}
+
 async function backlogPlan(projectDir) {
   const plans = await listPlans(projectDir);
   const existing = plans.find((p) => p.alias === BACKLOG_NAME || p.name === BACKLOG_NAME);
@@ -65,6 +88,27 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
   if (action === "add") {
     const title = args[0];
     if (!title || !title.trim()) throw new Error("kj hu add requires a title: kj hu add \"<story>\"");
+    // Cross-plan title dedup (KJC-TSK-0675) — check BEFORE creating anything.
+    const allHus = [];
+    for (const meta of await listPlans(projectDir)) {
+      const p = await loadPlan(projectDir, meta.planId);
+      for (const h of p.hus || []) allHus.push({ ...h, plan: p.alias || p.name || p.planId });
+    }
+    const { identical, similar } = findTitleMatches(title, allHus);
+    if (identical.length > 0) {
+      const ref = identical[0];
+      throw new Error(
+        `An HU with this title already exists: ${ref.short_id || ref.id} (status: ${ref.status}, plan: ${ref.plan}). `
+        + `HUs are never duplicated — work that card, move it with: kj hu move ${ref.short_id || ref.id} <status>, `
+        + `or run kj hu list before adding.`
+      );
+    }
+    if (similar.length > 0) {
+      console.warn(
+        `⚠ possible duplicate${similar.length === 1 ? "" : "s"} — check before working it:\n`
+        + similar.map((h) => `  · ${h.short_id || h.id} (${h.status}, plan: ${h.plan}) "${h.title}"`).join("\n")
+      );
+    }
     const plan = await backlogPlan(projectDir);
     // KJC-TSK-0669 (absolute rule): cards are permanent. The delete-and-
     // recreate "fix" an agent improvises loses history and duplicates ids —

--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -24,7 +24,7 @@ const BACKLOG_NAME = "brain-backlog";
 // existing work — sometimes in a DIFFERENT plan. Titles are compared
 // normalized (case/punctuation-insensitive) across every live HU of every
 // plan: identical → refuse; mostly-overlapping tokens → warn with candidates.
-const normTitle = (t) => String(t || "").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim();
+const normTitle = (t) => String(t || "").toLowerCase().replaceAll(/[^\p{L}\p{N}]+/gu, " ").trim();
 const titleTokens = (t) => new Set(normTitle(t).split(" ").filter((w) => w.length > 2));
 
 export function findTitleMatches(title, allHus) {
@@ -104,10 +104,9 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
       );
     }
     if (similar.length > 0) {
-      console.warn(
-        `⚠ possible duplicate${similar.length === 1 ? "" : "s"} — check before working it:\n`
-        + similar.map((h) => `  · ${h.short_id || h.id} (${h.status}, plan: ${h.plan}) "${h.title}"`).join("\n")
-      );
+      const plural = similar.length === 1 ? "" : "s";
+      const candidates = similar.map((h) => `  · ${h.short_id || h.id} (${h.status}, plan: ${h.plan}) "${h.title}"`).join("\n");
+      console.warn(`⚠ possible duplicate${plural} — check before working it:\n${candidates}`);
     }
     const plan = await backlogPlan(projectDir);
     // KJC-TSK-0669 (absolute rule): cards are permanent. The delete-and-

--- a/src/environment/briefs.js
+++ b/src/environment/briefs.js
@@ -87,9 +87,10 @@ const B = {
     render: () => brief("Board",
       "the HU Board is the permanent record of work: every card traces to who created it and what happened to it — a dashboard warning is fixed with the command it names, never by rebuilding the board.",
       [
+        "Before `kj hu add`, ALWAYS run `kj hu list`: if a card already covers the work (same scope, any plan), work THAT card instead of creating a twin.",
         "Cards are NEVER deleted or recreated — not to fix warnings, not to tidy up. Discard = `kj hu move <id> skipped` (archived, history kept).",
         "States move only via `kj hu move <id> <pending|running|done|failed|skipped>`.",
-        "A duplicate short_id means the card already exists: update that card, never add a twin.",
+        "A duplicate short_id or title means the card already exists: update that card, never add a twin.",
         "A warning is information, not damage: run the command it names; if it looks like a kj bug, `kj report-issue` — never work around it by destroying state.",
       ],
       "the board reflects reality: the same cards before and after your action, with truthful states and provenance intact."),

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -29,7 +29,7 @@ const TARGET_FILES = {
 // ENV-D1 (KJC-TSK-0642): the tracking invariant names the CHOSEN state
 // backend — a playbook that says "board or PG" makes the host guess.
 const BACKEND_TRACKING = {
-  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj hu add` / `kj board`) before it starts. Cards are permanent — never delete or recreate one; discard with `kj hu move <id> skipped`. `kj brief board` explains the board.",
+  "hu-board": "Every piece of work has a tracked story/bug in the HU Board (`kj hu add` / `kj board`) before it starts — and `kj hu list` BEFORE `kj hu add`: reuse the existing card if one covers the work. Cards are permanent — never delete or recreate one; discard with `kj hu move <id> skipped`. `kj brief board` explains the board.",
   "planning-game": "Every piece of work has a tracked card in the Planning Game MCP before it starts (In Progress while you work it).",
 };
 

--- a/tests/environment/brain-board-adr.test.js
+++ b/tests/environment/brain-board-adr.test.js
@@ -78,6 +78,40 @@ describe("kj hu", () => {
     expect(rows.filter((r) => r.short_id === "DUP-9")).toHaveLength(1);
   });
 
+  // KJC-TSK-0675 (issue #1288): an agent that skips `kj hu list` must not
+  // be able to create a twin of existing work — not even in ANOTHER plan
+  // (Jorge's case: planner HUs + a second set under brain-backlog).
+  it("add refuses an identical title, even when it lives in another plan", async () => {
+    const { savePlan } = await import("../../src/plan/plan-store.js");
+    const { generatePlanId } = await import("../../src/plan/plan-id.js");
+    await savePlan(dir, {
+      version: 2, planId: generatePlanId(), name: "toolgate-phase-1", task: "t", status: "ready",
+      hus: [{ id: "hu_plan_002", short_id: "BB-002", title: "Wire the toolgate monorepo scanner", status: "pending" }],
+      createdAt: new Date().toISOString(),
+    });
+    await expect(huCommand({ config: cfg(), action: "add", args: ["Wire the toolgate: monorepo scanner!"], flags: {} }))
+      .rejects.toThrow(/already exists.*toolgate-phase-1|toolgate-phase-1.*already exists/s);
+  });
+
+  it("add warns (but creates) on a very similar title, listing the candidates", async () => {
+    await huCommand({ config: cfg(), action: "add", args: ["Add retry logic to the webhook dispatcher"], flags: { json: true, id: "WH-1" } });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const added = await huCommand({ config: cfg(), action: "add", args: ["Add retry logic to webhook dispatcher queue"], flags: { json: true } });
+      expect(added.status).toBe("pending");
+      expect(warn.mock.calls.flat().join("\n")).toMatch(/WH-1/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("a skipped HU does not block reusing its title", async () => {
+    await huCommand({ config: cfg(), action: "add", args: ["Rebuild the login form"], flags: { json: true, id: "L-1" } });
+    await huCommand({ config: cfg(), action: "move", args: ["L-1", "skipped"], flags: { json: true } });
+    const added = await huCommand({ config: cfg(), action: "add", args: ["Rebuild the login form"], flags: { json: true } });
+    expect(added.status).toBe("pending");
+  });
+
   it("second add reuses the same backlog plan", async () => {
     await huCommand({ config: cfg(), action: "add", args: ["A"], flags: { json: true } });
     await huCommand({ config: cfg(), action: "add", args: ["B"], flags: { json: true } });


### PR DESCRIPTION
Fixes #1288.

The agent that skips `kj hu list` can no longer create twins of existing work:

- **`kj hu add` now dedups by TITLE across every plan** (Jorge's case was cross-plan: planner HUs + a second set under brain-backlog). Identical normalized title on any live HU → refused with the existing card's ref, plan and the `kj hu move` hint. ≥80% token overlap → created but with a warning listing the candidates. Skipped HUs don't reserve titles.
- **`kj brief board`** teaches the precondition: "Before `kj hu add`, ALWAYS run `kj hu list`" — reuse the covering card.
- **Playbook** (`hu-board` invariant) carries the same rule into every host agent's CLAUDE.md/AGENTS.md.

This complements the v4.1.8 protections (no deletes, short_id dedup, 405 API) — now the *creation* side is governed too.