### PR TITLE
chore(release): v4.1.11 — unattended runs and a board that refuses twins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.11] - 2026-07-23
+
+Patch. **Agents can run kj unattended, and the board refuses twins** — both requested from the field (issues #1288 and #1289).
+
+### Added
+
+- **Non-interactive mode for `kj run` / `kj resume`** (KJC-TSK-0674, issue #1289): `--non-interactive` flag or `KJ_NON_INTERACTIVE=1` env force auto-answering even under a pseudo-TTY, instead of blocking forever on a board modal nobody watches. The spec-review gate is now severity-aware: warn findings auto-continue (decision streamed to stderr); FAIL findings stop the run with **exit code 1** — and interactively, Enter at FAIL now defaults to cancel. An aborted run/resume is finally observable by CI.
+- **Cross-plan title dedup on `kj hu add`** (KJC-TSK-0675, issue #1288): an identical normalized title on any live HU of any plan is refused with the existing card's ref; heavily-overlapping titles warn with the candidates. `kj brief board` and the playbook now order the precondition: `kj hu list` BEFORE `kj hu add` — reuse the covering card.
+
 ## [4.1.10] - 2026-07-22
 
 Patch. **Karajan governs its tools' resources, not just your code** — born from a real CPU storm (concurrent scans, semgrep taking 14 cores each, orphaned semgrep-core processes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.1.10",
+      "version": "4.1.11",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release v4.1.11. Contenido ya mergeado en #1290 y #1291: modo no interactivo para agentes/CI (issue #1289) y dedup de títulos cross-plan en el board (issue #1288).