### PR TITLE
feat(review): sonar pre-gate module (KJC-TSK-0676, 1/2)

### DIFF
--- a/src/review/sonar-pregate.js
+++ b/src/review/sonar-pregate.js
@@ -1,0 +1,63 @@
+/**
+ * Sonar pre-gate for `kj review --staged` (KJC-TSK-0676, user request
+ * 2026-07-23). With the brain outside the core (v4), skipping sonar is one
+ * decision away — proven the day the brain itself shipped 3 sonar issues in
+ * new code. Hung off the review gate, it becomes a gate, not discipline:
+ * deterministic findings on the STAGED files come back before any AI
+ * verdict, and BLOCKER/CRITICAL ones reject without spending reviewer
+ * tokens. Unavailable sonar degrades loudly ({available:false, reason}) —
+ * a laptop without Docker still commits.
+ */
+
+import { runSonarScan } from "../sonar/scanner.js";
+import { getOpenIssues } from "../sonar/api.js";
+import { acquireToolLock } from "../utils/tool-governor.js";
+
+const BLOCKING_SEVERITIES = new Set(["BLOCKER", "CRITICAL"]);
+
+/** Repo-relative path of a sonar issue (component is "<projectKey>:<path>"). */
+export function issueFile(issue) {
+  const component = String(issue?.component || "");
+  const idx = component.indexOf(":");
+  return idx === -1 ? component : component.slice(idx + 1);
+}
+
+/** One printable line per finding: (SEVERITY) [file:line] rule — message. */
+export function formatSonarFinding(issue) {
+  const line = issue.line ? `:${issue.line}` : "";
+  return `(${issue.severity}) [${issueFile(issue)}${line}] ${issue.rule} — ${issue.message}`;
+}
+
+/**
+ * Scan the project (single-flight via the tool governor) and return the
+ * open issues that live on the staged files, split by blocking severity.
+ * Every failure path degrades to {available:false, reason} — the pre-gate
+ * never breaks the review, it only refuses to stay silent.
+ */
+export async function runSonarPregate({ config, stagedFiles = [], logger = null }) {
+  if (config?.review_gate?.sonar === false) {
+    return { available: false, reason: "disabled in config (review_gate.sonar: false)" };
+  }
+  let lock = null;
+  try {
+    lock = await acquireToolLock("sonar-scanner", { timeoutMs: 300_000 });
+    const scan = await runSonarScan(config);
+    if (!scan.ok) {
+      return { available: false, reason: (scan.stderr || scan.stdout || "sonar scan failed").trim() };
+    }
+    const res = await getOpenIssues(config, scan.projectKey);
+    const staged = new Set(stagedFiles);
+    const onStaged = (res.issues || []).filter((i) => staged.has(issueFile(i)));
+    return {
+      available: true,
+      blocking: onStaged.filter((i) => BLOCKING_SEVERITIES.has(String(i.severity).toUpperCase())),
+      advisory: onStaged.filter((i) => !BLOCKING_SEVERITIES.has(String(i.severity).toUpperCase())),
+      totalProject: res.total ?? (res.issues || []).length,
+    };
+  } catch (err) {
+    logger?.warn?.(`[sonar-pregate] ${err.message}`);
+    return { available: false, reason: err.message };
+  } finally {
+    lock?.release?.();
+  }
+}

--- a/tests/review/sonar-pregate.test.js
+++ b/tests/review/sonar-pregate.test.js
@@ -1,0 +1,68 @@
+// KJC-TSK-0676 — Sonar as deterministic pre-gate of `kj review --staged`.
+// With the brain outside the core (v4), skipping sonar is one decision away;
+// hanging it off the review gate makes it a gate, not discipline.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const scanMock = vi.fn();
+const issuesMock = vi.fn();
+const lockMock = vi.fn();
+
+vi.mock("../../src/sonar/scanner.js", () => ({ runSonarScan: (...a) => scanMock(...a) }));
+vi.mock("../../src/sonar/api.js", () => ({ getOpenIssues: (...a) => issuesMock(...a) }));
+vi.mock("../../src/utils/tool-governor.js", () => ({ acquireToolLock: (...a) => lockMock(...a) }));
+
+import { runSonarPregate } from "../../src/review/sonar-pregate.js";
+
+const release = vi.fn();
+beforeEach(() => {
+  vi.clearAllMocks();
+  lockMock.mockResolvedValue({ release });
+  scanMock.mockResolvedValue({ ok: true, projectKey: "kj-test" });
+});
+
+const issue = (file, severity, extra = {}) => ({
+  component: `kj-test:${file}`, severity, rule: "js:S000", line: 7, message: "m", ...extra,
+});
+
+describe("runSonarPregate", () => {
+  it("filters to staged files and splits blocking from advisory", async () => {
+    issuesMock.mockResolvedValue({ total: 4, issues: [
+      issue("src/a.js", "CRITICAL"),
+      issue("src/a.js", "MINOR"),
+      issue("src/untouched.js", "BLOCKER"),
+      issue("src/b.js", "MAJOR"),
+    ] });
+    const r = await runSonarPregate({ config: {}, stagedFiles: ["src/a.js", "src/b.js"] });
+    expect(r.available).toBe(true);
+    expect(r.blocking.map((i) => i.severity)).toEqual(["CRITICAL"]);
+    expect(r.advisory.map((i) => i.severity)).toEqual(["MINOR", "MAJOR"]);
+    expect(r.totalProject).toBe(4);
+    expect(release).toHaveBeenCalled(); // lock always released
+  });
+
+  it("degrades gracefully when the scan fails or the server is down", async () => {
+    scanMock.mockResolvedValue({ ok: false, stderr: "connect ECONNREFUSED" });
+    const r = await runSonarPregate({ config: {}, stagedFiles: ["src/a.js"] });
+    expect(r).toMatchObject({ available: false, reason: expect.stringContaining("ECONNREFUSED") });
+
+    issuesMock.mockRejectedValue(new Error("401 auth"));
+    scanMock.mockResolvedValue({ ok: true, projectKey: "kj-test" });
+    const r2 = await runSonarPregate({ config: {}, stagedFiles: ["src/a.js"] });
+    expect(r2.available).toBe(false);
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("is disabled by config without touching sonar", async () => {
+    const r = await runSonarPregate({ config: { review_gate: { sonar: false } }, stagedFiles: ["src/a.js"] });
+    expect(r.available).toBe(false);
+    expect(scanMock).not.toHaveBeenCalled();
+  });
+
+  it("never runs two scans at once — waits on the governor lock", async () => {
+    issuesMock.mockResolvedValue({ total: 0, issues: [] });
+    await runSonarPregate({ config: {}, stagedFiles: [] });
+    expect(lockMock).toHaveBeenCalledWith("sonar-scanner", expect.anything());
+    expect(lockMock.mock.invocationCallOrder[0]).toBeLessThan(scanMock.mock.invocationCallOrder[0]);
+  });
+});


### PR DESCRIPTION
Part 1/2 of KJC-TSK-0676 (user proposal: sonar must be unskippable — hang it off the review gate).

New `src/review/sonar-pregate.js`: `runSonarPregate({config, stagedFiles})` takes the `sonar-scanner` lock from the tool governor (single-flight), runs the scan, fetches open issues, filters them to the STAGED files and splits **blocking** (BLOCKER/CRITICAL) from **advisory**. Every failure path — server down, no Docker, config `review_gate.sonar: false` — degrades to `{available:false, reason}`: the pre-gate never breaks the review, it only refuses to stay silent.

Part 2/2 wires it into `reviewGateCommand` (findings printed FIRST, blocking rejects without spending reviewer tokens, advisory travels in the reviewer's task) and adds `--no-sonar` to `kj review`.