### PR TITLE
feat(review): sonar pre-gate wired into the review gate (KJC-TSK-0676, 2/2)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -211,6 +211,7 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--check", "Verify the recorded verdict matches the staged diff (exit 0/1, hook-friendly)")
     .option("--range <range>", "Review a git range (e.g. main..HEAD) instead of the staged diff")
     .option("--install-gate", "Enable the pre-commit review gate for this project (creates .karajan/review-gate)")
+    .option("--no-sonar", "Skip the deterministic Sonar pre-gate that runs before the cross-AI verdict")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "review", flags, async ({ config, logger }) => {
         // ENV-B1 (KJC-TSK-0637): the gate mode records a verdict tied to

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -10,10 +10,11 @@ import { checkVerdict } from "../review/verdict-store.js";
 import { runOneShotReview } from "../review/one-shot-review.js";
 import { runSolomonArbitration } from "../review/solomon-arbitration.js";
 import { ensureGateTrackable } from "../review/gate-gitignore.js";
+import { runSonarPregate, formatSonarFinding } from "../review/sonar-pregate.js";
 
 // Raw git always — never a wrapped/compressing runner (KJC-BUG-0115).
-async function rawDiff(range) {
-  const args = range ? ["diff", range] : ["diff", "--cached"];
+async function rawDiff(range, extraArgs = []) {
+  const args = range ? ["diff", range, ...extraArgs] : ["diff", "--cached", ...extraArgs];
   const res = await runCommand("git", args);
   if (res.exitCode !== 0) {
     throw new Error(res.stderr?.trim() || `git ${args.join(" ")} failed`);
@@ -29,7 +30,11 @@ function printVerdict(record) {
   }
   console.log(`✗ REJECTED by ${record.reviewer} — ${record.issues.length} blocking issue(s):`);
   for (const issue of record.issues) {
-    const where = issue.file ? ` [${issue.file}${issue.line ? `:${issue.line}` : ""}]` : "";
+    let where = "";
+    if (issue.file) {
+      const line = issue.line ? `:${issue.line}` : "";
+      where = ` [${issue.file}${line}]`;
+    }
     console.log(`  - (${issue.severity || "high"})${where} ${issue.description || issue.id}`);
     if (issue.suggested_fix) console.log(`    fix: ${issue.suggested_fix}`);
   }
@@ -48,7 +53,8 @@ export async function solomonCommand({ config, logger = null, flags = {} }) {
   if (res.ruling === "approve") {
     console.log(`⚖ Solomon (${res.solomon}) rules for the brain — verdict recorded, the gate is open.`);
   } else {
-    console.log(`⚖ Solomon${res.solomon ? ` (${res.solomon})` : ""} rules for the reviewer — obey and fix:`);
+    const who = res.solomon ? ` (${res.solomon})` : "";
+    console.log(`⚖ Solomon${who} rules for the reviewer — obey and fix:`);
   }
   if (res.reasoning) console.log(`  ${res.reasoning}`);
   process.exitCode = res.ruling === "approve" ? 0 : 1;
@@ -89,7 +95,39 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
     return res;
   }
 
-  const record = await runOneShotReview({ diff, task: flags.task, config, logger, projectDir });
+  // KJC-TSK-0676: deterministic pre-gate — sonar findings on the changed
+  // files come back BEFORE any AI opinion. Blocking severities reject
+  // without spending reviewer tokens; the rest travel with the task so
+  // the cross-AI reviewer weighs them. Unavailable sonar degrades loudly.
+  let task = flags.task;
+  if (flags.sonar !== false) {
+    const files = (await rawDiff(flags.range, ["--name-only"])).split("\n").map((f) => f.trim()).filter(Boolean);
+    const pre = await runSonarPregate({ config, stagedFiles: files, logger });
+    if (!pre.available) {
+      console.log(`⚠ sonar pre-gate skipped: ${pre.reason}`);
+    } else {
+      const found = [...pre.blocking, ...pre.advisory];
+      if (found.length > 0) {
+        console.log(`Sonar on the changed files — ${pre.blocking.length} blocking, ${pre.advisory.length} advisory (project total: ${pre.totalProject}):`);
+        for (const f of found) console.log(`  - ${formatSonarFinding(f)}`);
+      }
+      if (pre.blocking.length > 0) {
+        console.log("✗ REJECTED by sonar (deterministic) — fix the blocking findings; the cross-AI reviewer was not invoked.");
+        process.exitCode = 1;
+        return {
+          verdict: "rejected", reviewer: "sonar",
+          issues: pre.blocking.map((i) => ({ severity: i.severity, file: undefined, description: formatSonarFinding(i) })),
+        };
+      }
+      if (pre.advisory.length > 0) {
+        task = `${task || "Review the following diff for correctness, security and maintainability."}\n\n`
+          + `Deterministic Sonar findings on these files (fold them into your review):\n`
+          + pre.advisory.map((f) => `- ${formatSonarFinding(f)}`).join("\n");
+      }
+    }
+  }
+
+  const record = await runOneShotReview({ diff, task, config, logger, projectDir });
   printVerdict(record);
   process.exitCode = record.verdict === "approved" ? 0 : 1;
   return record;

--- a/tests/review/review-gate-sonar.test.js
+++ b/tests/review/review-gate-sonar.test.js
@@ -1,0 +1,73 @@
+// KJC-TSK-0676 part 2 — the review gate runs the sonar pre-gate BEFORE the
+// cross-AI verdict: blocking findings reject without spending reviewer
+// tokens; advisory ones travel inside the reviewer's task.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const pregateMock = vi.fn();
+const reviewMock = vi.fn();
+
+vi.mock("../../src/review/sonar-pregate.js", async (orig) => ({
+  ...(await orig()), runSonarPregate: (...a) => pregateMock(...a),
+}));
+vi.mock("../../src/review/one-shot-review.js", () => ({ runOneShotReview: (...a) => reviewMock(...a) }));
+
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); });
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-gate-sonar-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.writeFileSync(path.join(dir, "a.js"), "x\n");
+  git("add", "a.js"); git("commit", "-qm", "base");
+  fs.writeFileSync(path.join(dir, "a.js"), "y\n");
+  git("add", "a.js");
+  process.chdir(dir); // rawDiff runs git in the process cwd
+  reviewMock.mockResolvedValue({ verdict: "approved", reviewer: "codex", diffHash: "abc123456789", summary: "" });
+});
+
+const cfg = () => ({ projectDir: dir });
+const finding = (severity) => ({ component: `k:a.js`, severity, rule: "js:S1", line: 1, message: "boom" });
+
+describe("review gate × sonar pre-gate", () => {
+  it("blocking findings reject WITHOUT invoking the cross-AI reviewer", async () => {
+    pregateMock.mockResolvedValue({ available: true, blocking: [finding("CRITICAL")], advisory: [], totalProject: 1 });
+    const r = await reviewGateCommand({ config: cfg(), flags: { staged: true } });
+    expect(r.verdict).toBe("rejected");
+    expect(r.reviewer).toBe("sonar");
+    expect(reviewMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("advisory findings travel inside the reviewer task and pass staged files to the pre-gate", async () => {
+    pregateMock.mockResolvedValue({ available: true, blocking: [], advisory: [finding("MINOR")], totalProject: 1 });
+    const r = await reviewGateCommand({ config: cfg(), flags: { staged: true, task: "my intent" } });
+    expect(r.verdict).toBe("approved");
+    expect(pregateMock.mock.calls[0][0].stagedFiles).toEqual(["a.js"]);
+    expect(reviewMock.mock.calls[0][0].task).toContain("my intent");
+    expect(reviewMock.mock.calls[0][0].task).toContain("boom");
+  });
+
+  it("unavailable sonar warns and continues to the cross-AI review", async () => {
+    pregateMock.mockResolvedValue({ available: false, reason: "server down" });
+    const r = await reviewGateCommand({ config: cfg(), flags: { staged: true } });
+    expect(r.verdict).toBe("approved");
+    expect(reviewMock).toHaveBeenCalled();
+  });
+
+  it("--no-sonar skips the pre-gate entirely", async () => {
+    const r = await reviewGateCommand({ config: cfg(), flags: { staged: true, sonar: false } });
+    expect(pregateMock).not.toHaveBeenCalled();
+    expect(r.verdict).toBe("approved");
+  });
+});


### PR DESCRIPTION
Part 2/2 of KJC-TSK-0676 (part 1: #1293). Sonar becomes unskippable the v4 way — a gate, not discipline.

`kj review --staged` (and `--range`) now:
1. Runs the sonar pre-gate FIRST (single-flight via tool-governor) and prints the findings on the changed files before any AI opinion.
2. **BLOCKER/CRITICAL on changed files → REJECTED by sonar, exit 1, cross-AI reviewer NOT invoked** (deterministic fail-fast, zero reviewer tokens).
3. Advisory findings travel inside the reviewer's task so codex weighs them.
4. Sonar down / no Docker → `⚠ sonar pre-gate skipped: <reason>` and the review continues. `--no-sonar` (or `review_gate.sonar: false`) opts out explicitly.

Dogfooded live on its own diff: the pre-gate surfaced 3 pre-existing MAJORs in `review-gate.js`, which this PR also fixes (nested ternary/templates in `printVerdict`/`solomonCommand`).

Known caveat for a follow-up: the issues API can serve the PREVIOUS analysis for a few seconds after a scan (SonarQube processes reports in a background CE task) — a future improvement is polling the CE task before reading issues.