### PR TITLE
fix: board play button should pass HU title as task to kj run

### DIFF
--- a/packages/hu-board/src/routes/api.js
+++ b/packages/hu-board/src/routes/api.js
@@ -1026,7 +1026,18 @@ router.post('/hus/:huId/run', (req, res) => {
     const extraIds = Array.isArray(req.body?.extraHuIds) ? req.body.extraHuIds.map((x) => (x.includes('::') ? x.split('::').pop() : x)) : [];
     const huIds = [planLocalHuId, ...extraIds];
 
-    const result = runPlan({ planId: row.plan_id, projectId: row.project_id, huIds });
+    // Read the HU title from the plan JSON so kj run receives a
+    // meaningful task description instead of the generic plan.task.
+    let taskOverride;
+    try {
+      const planPath = path.join(getHuBoardPlansDir(), row.project_id, `${row.plan_id}.json`);
+      const planRaw = fs.readFileSync(planPath, 'utf8');
+      const planData = JSON.parse(planRaw);
+      const hu = (planData.hus || []).find((h) => h.id === planLocalHuId);
+      if (hu?.title) taskOverride = hu.title;
+    } catch { /* fall through — runPlan will use plan.task */ }
+
+    const result = runPlan({ planId: row.plan_id, projectId: row.project_id, huIds, taskOverride });
     if (!result.ok) return res.status(400).json({ error: result.error });
 
     // Move the launched HU(s) to "coding" in BOTH the SQLite mirror and the


### PR DESCRIPTION
### Problem

When clicking the "play" button on a specific HU from the Board UI, the orchestrator calls `runPlan()` without a `taskOverride`, so `kj run` receives the generic `plan.task` (e.g. "Host-agent tracked work") instead of the actual HU title. The spec review then analyzes this generic description and produces false-positive failures:

- F-001 (missing_scope): "The spec is a single 5-word phrase"
- F-002 (missing_ac): "No acceptance criteria"
- F-003 (ambiguity): "tracked work is undefined"

### Fix

Read the HU title from the plan JSON and pass it as `taskOverride` to `runPlan()`. If the HU or title cannot be resolved (e.g. stale file), it falls through gracefully and `runPlan` uses `plan.task` as before.

### Related

Closes #1297
