### PR TITLE
feat(env): playbook orders git worktrees for parallel work (KJC-TSK-0677)

### DIFF
--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -55,7 +55,9 @@ Invariants (the git gates enforce these — they are not suggestions):
 - Security findings are never overridable — not even by arbitration. You
   absorb the security role: \`kj brief security\` states what must be true.
 - Branch first: never commit on the base branch — every change reaches it
-  through an atomic PR (~150 net lines, Conventional Commits).
+  through an atomic PR (~150 net lines, Conventional Commits). Working on
+  more than one task, or the user needs the base tree untouched? One
+  \`git worktree\` per task — the gates travel with the repo and work there.
 
 Commands: \`kj rag query\` · \`kj brief <role>\` (triage, planner, researcher,
 architect, tester, security, audit, board) · \`kj hu add|move|list\` · \`kj adr add|list\` ·

--- a/tests/environment/playbook.test.js
+++ b/tests/environment/playbook.test.js
@@ -17,6 +17,9 @@ describe("renderPlaybook", () => {
       expect(text).toMatch(/kj review --staged/);
       expect(text).toMatch(/security/i);
       expect(text).toMatch(/conventional commits/i);
+      // KJC-TSK-0677: in v4 the host agent does the work — the playbook is
+      // where it inherits the worktree practice the headless lanes already use.
+      expect(text).toMatch(/git worktree/);
       expect(text.split("\n").length).toBeLessThanOrEqual(60);
     });
   }


### PR DESCRIPTION
En el modo v4 el agente anfitrión hace el trabajo — el playbook es donde hereda la práctica de carriles aislados que el pipeline headless ya usa (KJC-PCS-0065). El invariante de branching ahora añade: más de una tarea a la vez, o el usuario necesita el árbol base intacto → un `git worktree` por tarea; los gates viajan con el repo y funcionan allí. Sigue ≤60 líneas (test).