### PR TITLE
feat(worktree): kj worktree start|list|done — lanes for the host agent (KJC-TSK-0679)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -31,7 +31,7 @@ export const ADVANCED_GROUPS = [
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },
-  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "undo", "standby"] },
+  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },
 ];

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -23,6 +23,7 @@ import { envInstallCommand, briefCommand } from "../commands/env.js";
 import { agentRunCommand } from "../commands/agent-run.js";
 import { reportIssueCommand } from "../commands/report-issue.js";
 import { huCommand } from "../commands/hu.js";
+import { worktreeCommand } from "../commands/worktree.js";
 import { addAdr, listAdrs } from "../environment/adr.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
@@ -155,6 +156,32 @@ export function registerMeta(program, { pkgVersion }) {
     });
 
   // AB-H (KJC-TSK-0658): board writes + repo ADRs for the brain.
+  // KJC-TSK-0679: isolated lanes for the host agent — ordering a command
+  // beats ordering a practice an agent can narrate without doing.
+  const wt = program.command("worktree").description("Isolated task lanes (git worktrees) for the host agent");
+  wt.command("start <slug>")
+    .description("Create a lane: worktree + feat/<slug> branch + dependency bootstrap")
+    .action(async (slug, flags) => {
+      await withConfig(pkgVersion, "worktree", flags, async ({ config }) => {
+        await worktreeCommand({ config, action: "start", args: [slug], flags });
+      });
+    });
+  wt.command("list")
+    .description("List the active lanes")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "worktree", flags, async ({ config }) => {
+        await worktreeCommand({ config, action: "list", flags });
+      });
+    });
+  wt.command("done <slug>")
+    .option("--force", "Remove the lane even with uncommitted changes")
+    .description("Remove a merged lane (refuses uncommitted changes without --force)")
+    .action(async (slug, flags) => {
+      await withConfig(pkgVersion, "worktree", flags, async ({ config }) => {
+        await worktreeCommand({ config, action: "done", args: [slug], flags });
+      });
+    });
+
   const hu = program.command("hu").description("Track work in the HU Board from any host agent (card first)");
   hu.command("add <title>")
     .option("--id <shortId>", "Human-readable short id")

--- a/src/commands/worktree.js
+++ b/src/commands/worktree.js
@@ -1,0 +1,76 @@
+/**
+ * `kj worktree start|list|done` (KJC-TSK-0679) — isolated lanes for the
+ * host agent. Field case: the playbook said "one worktree per task" and an
+ * agent NARRATED the isolation while editing the project root. Ordering a
+ * command beats ordering a practice: start = worktree + feat/ branch +
+ * dependency bootstrap + the exact cd printed; done = remove after merge.
+ * Same lane dir (.kj/worktrees) and bootstrap the headless pipeline uses.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { bootstrapWorktree } from "../hu/worktree-bootstrap.js";
+
+const execFileAsync = promisify(execFile);
+const WORKTREE_DIR = ".kj/worktrees"; // shared with the headless lanes
+
+const SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export async function worktreeCommand({ config = null, action, args = [], flags = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const git = (gitArgs, cwd = projectDir) => execFileAsync("git", gitArgs, { cwd });
+  const lanePath = (slug) => path.join(projectDir, WORKTREE_DIR, slug);
+
+  if (action === "start") {
+    const slug = String(args[0] || "").trim();
+    if (!SLUG_RE.test(slug)) {
+      throw new Error("invalid slug — use letters, digits, dots, dashes (no slashes): kj worktree start <slug>");
+    }
+    const wtPath = lanePath(slug);
+    if (fs.existsSync(wtPath)) {
+      throw new Error(`lane "${slug}" already exists — cd ${wtPath}, or finish it with: kj worktree done ${slug}`);
+    }
+    const branch = `feat/${slug}`;
+    await git(["worktree", "add", "-b", branch, wtPath]);
+    const boot = await bootstrapWorktree({ worktreePath: wtPath, setupCommand: config?.session?.worktree_setup || null });
+    console.log(`✓ lane ready: ${branch}`);
+    console.log(`  cd ${wtPath}`);
+    console.log("  The gates travel with the repo — kj review --staged works there. When merged: kj worktree done " + slug);
+    return { path: wtPath, branch, bootstrap: boot };
+  }
+
+  if (action === "list") {
+    const laneRoot = path.join(projectDir, WORKTREE_DIR) + path.sep;
+    const { stdout } = await git(["worktree", "list", "--porcelain"]);
+    const rows = [];
+    let current = null;
+    for (const line of stdout.split("\n")) {
+      if (line.startsWith("worktree ")) current = { path: line.slice(9).trim() };
+      else if (line.startsWith("branch ") && current) {
+        current.branch = line.slice(7).trim().replace("refs/heads/", "");
+        if (current.path.startsWith(laneRoot)) {
+          rows.push({ slug: path.basename(current.path), branch: current.branch, path: current.path });
+        }
+      }
+    }
+    if (rows.length === 0) console.log("no lanes — create one with: kj worktree start <slug>");
+    for (const r of rows) console.log(`${r.slug.padEnd(24)} ${r.branch.padEnd(30)} ${r.path}`);
+    return rows;
+  }
+
+  if (action === "done") {
+    const slug = String(args[0] || "").trim();
+    const wtPath = lanePath(slug);
+    if (!fs.existsSync(wtPath)) throw new Error(`lane "${slug}" not found — see kj worktree list`);
+    const { stdout: dirty } = await git(["status", "--porcelain"], wtPath);
+    if (dirty.trim() && !flags.force) {
+      throw new Error(`lane "${slug}" has uncommitted changes — commit them (through the gate) or discard with --force`);
+    }
+    await git(["worktree", "remove", ...(flags.force ? ["--force"] : []), wtPath]);
+    console.log(`✓ lane "${slug}" removed — its branch survives; delete it after merge if you want`);
+    return { removed: true, slug };
+  }
+
+  throw new Error(`unknown action "${action}" — use: start | list | done`);
+}

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -55,12 +55,15 @@ Invariants (the git gates enforce these — they are not suggestions):
 - Security findings are never overridable — not even by arbitration. You
   absorb the security role: \`kj brief security\` states what must be true.
 - Branch first: never commit on the base branch — every change reaches it
-  through an atomic PR (~150 net lines, Conventional Commits). Working on
-  more than one task, or the user needs the base tree untouched? One
-  \`git worktree\` per task — the gates travel with the repo and work there.
+  through an atomic PR (~150 net lines, Conventional Commits). More than one
+  task, or the base tree must stay untouched? \`kj worktree start <slug>\`
+  (one lane per task; \`kj worktree done <slug>\` after merge). Never CLAIM
+  isolation without proof: in a lane, \`git rev-parse --git-dir\` differs
+  from \`--git-common-dir\`.
 
 Commands: \`kj rag query\` · \`kj brief <role>\` (triage, planner, researcher,
-architect, tester, security, audit, board) · \`kj hu add|move|list\` · \`kj adr add|list\` ·
+architect, tester, security, audit, board) · \`kj hu add|move|list\` ·
+\`kj worktree start|list|done\` · \`kj adr add|list\` ·
 \`kj review --staged\` · \`kj review --check\` · \`kj solomon --position\` ·
 \`kj agent run <agent>\` · \`kj report\` · \`kj check\`
 

--- a/tests/commands/worktree.test.js
+++ b/tests/commands/worktree.test.js
@@ -1,0 +1,64 @@
+// KJC-TSK-0679 — `kj worktree start|list|done`: the host agent's isolated
+// lanes. Born from a field case: an agent NARRATED worktree isolation while
+// editing the project root. The compliant path must be the easy one.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { worktreeCommand } from "../../src/commands/worktree.js";
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-wt-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.writeFileSync(path.join(dir, "a.js"), "x\n");
+  git("add", "a.js"); git("commit", "-qm", "base");
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+const cfg = () => ({ projectDir: dir });
+
+describe("kj worktree", () => {
+  it("start creates the worktree with its feat/ branch and prints the cd", async () => {
+    const r = await worktreeCommand({ config: cfg(), action: "start", args: ["mi-tarea"], flags: {} });
+    expect(fs.existsSync(r.path)).toBe(true);
+    expect(r.branch).toBe("feat/mi-tarea");
+    const branches = execFileSync("git", ["-C", r.path, "rev-parse", "--abbrev-ref", "HEAD"]).toString().trim();
+    expect(branches).toBe("feat/mi-tarea");
+    // the proof the playbook demands: git-dir differs from common-dir in a worktree
+    const gitDir = execFileSync("git", ["-C", r.path, "rev-parse", "--git-dir"]).toString().trim();
+    const commonDir = execFileSync("git", ["-C", r.path, "rev-parse", "--git-common-dir"]).toString().trim();
+    expect(gitDir).not.toBe(commonDir);
+  });
+
+  it("start refuses a duplicate slug and path-escaping slugs", async () => {
+    await worktreeCommand({ config: cfg(), action: "start", args: ["dup"], flags: {} });
+    await expect(worktreeCommand({ config: cfg(), action: "start", args: ["dup"], flags: {} }))
+      .rejects.toThrow(/already exists/);
+    for (const bad of ["../evil", "a/b", "", "  "]) {
+      await expect(worktreeCommand({ config: cfg(), action: "start", args: [bad], flags: {} }))
+        .rejects.toThrow(/slug/i);
+    }
+  });
+
+  it("list shows the lanes", async () => {
+    await worktreeCommand({ config: cfg(), action: "start", args: ["uno"], flags: {} });
+    await worktreeCommand({ config: cfg(), action: "start", args: ["dos"], flags: {} });
+    const rows = await worktreeCommand({ config: cfg(), action: "list", flags: {} });
+    expect(rows.map((r) => r.slug).sort()).toEqual(["dos", "uno"]);
+  });
+
+  it("done refuses a dirty lane without --force and removes a clean one", async () => {
+    const { path: wt } = await worktreeCommand({ config: cfg(), action: "start", args: ["sucia"], flags: {} });
+    fs.writeFileSync(path.join(wt, "a.js"), "changed\n");
+    await expect(worktreeCommand({ config: cfg(), action: "done", args: ["sucia"], flags: {} }))
+      .rejects.toThrow(/uncommitted/);
+    const r = await worktreeCommand({ config: cfg(), action: "done", args: ["sucia"], flags: { force: true } });
+    expect(r.removed).toBe(true);
+    expect(fs.existsSync(wt)).toBe(false);
+  });
+});

--- a/tests/environment/playbook.test.js
+++ b/tests/environment/playbook.test.js
@@ -17,9 +17,11 @@ describe("renderPlaybook", () => {
       expect(text).toMatch(/kj review --staged/);
       expect(text).toMatch(/security/i);
       expect(text).toMatch(/conventional commits/i);
-      // KJC-TSK-0677: in v4 the host agent does the work — the playbook is
-      // where it inherits the worktree practice the headless lanes already use.
-      expect(text).toMatch(/git worktree/);
+      // KJC-TSK-0677/0679: in v4 the host agent does the work — the playbook
+      // orders the lane COMMAND (narratable practices get narrated, commands
+      // get run) and demands the isolation proof.
+      expect(text).toMatch(/kj worktree start/);
+      expect(text).toMatch(/--git-common-dir/);
       expect(text.split("\n").length).toBeLessThanOrEqual(60);
     });
   }


### PR DESCRIPTION
Caso de campo: el playbook decía "un worktree por tarea" y un agente NARRÓ el aislamiento mientras editaba el root del proyecto. Ordenar una práctica narrable no funciona; ordenar un comando sí.

- `kj worktree start <slug>`: worktree en `.kj/worktrees/<slug>` (mismo carril que el pipeline headless) + rama `feat/<slug>` + bootstrap de dependencias (reutiliza `worktree-bootstrap`) + el `cd` exacto impreso.
- `kj worktree list`: carriles activos.
- `kj worktree done <slug>`: desmonta tras el merge; rechaza cambios sin commitear salvo `--force`.
- Playbook: el invariante de branching ordena ahora el COMANDO y exige la prueba de aislamiento (`git rev-parse --git-dir` ≠ `--git-common-dir`) antes de afirmarlo. El test lo pina.
- Slugs validados (sin barras ni traversal).

Parte 1 de 2 del caso: la parte 2 (KJC-TSK-0680) estampa el workspace (root|worktree) en el veredicto del review para que la afirmación sea auditable.