### PR TITLE
feat(review): verdict stamps its workspace (KJC-TSK-0680)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -24,7 +24,8 @@ async function rawDiff(range, extraArgs = []) {
 
 function printVerdict(record) {
   if (record.verdict === "approved") {
-    console.log(`✓ APPROVED by ${record.reviewer} (diff ${record.diffHash.slice(0, 12)})`);
+    const ws = record.workspace ? ` [${record.workspace}]` : "";
+    console.log(`✓ APPROVED by ${record.reviewer} (diff ${record.diffHash.slice(0, 12)})${ws}`);
     if (record.summary) console.log(`  ${record.summary}`);
     return;
   }

--- a/src/review/one-shot-review.js
+++ b/src/review/one-shot-review.js
@@ -15,6 +15,7 @@ import { resolveReviewProfile } from "./profiles.js";
 import { parseMaybeJsonString } from "./parser.js";
 import { detectAvailableAgents, detectHostAgent } from "../utils/agent-detect.js";
 import { saveVerdict } from "./verdict-store.js";
+import { detectWorkspace } from "./workspace.js";
 
 // Cross-AI preference when the configured reviewer IS the host.
 const CROSS_ORDER = ["codex", "claude", "gemini", "opencode", "aider"];
@@ -77,6 +78,8 @@ export async function runOneShotReview({
     verdict: parsed.approved ? "approved" : "rejected",
     reviewer,
     host: hostAgent || null,
+    // KJC-TSK-0680: where the review ran — makes any isolation claim auditable.
+    workspace: await detectWorkspace(projectDir),
     issues: parsed.blocking_issues || [],
     suggestions: parsed.non_blocking_suggestions || [],
     summary: parsed.summary || parsed.raw_summary || "",

--- a/src/review/workspace.js
+++ b/src/review/workspace.js
@@ -1,0 +1,21 @@
+/**
+ * Workspace detection for the review gate (KJC-TSK-0680). Field case: an
+ * agent claimed worktree isolation while editing the project root. The
+ * verdict now stamps WHERE the review actually ran, using the same proof
+ * the playbook demands: in a linked worktree, `git rev-parse --git-dir`
+ * differs from `--git-common-dir`. "root" | "worktree:<name>" | null
+ * (not a git repo — the gate itself will fail later with its own error).
+ */
+import path from "node:path";
+import { runCommand } from "../utils/process.js";
+
+export async function detectWorkspace(dir) {
+  const res = await runCommand("git", ["rev-parse", "--git-dir", "--git-common-dir", "--show-toplevel"], { cwd: dir });
+  if (res.exitCode !== 0) return null;
+  const [gitDir, commonDir, toplevel] = String(res.stdout).trim().split("\n").map((l) => l.trim());
+  if (!gitDir || !commonDir) return null;
+  const resolvedGit = path.resolve(dir, gitDir);
+  const resolvedCommon = path.resolve(dir, commonDir);
+  if (resolvedGit === resolvedCommon) return "root";
+  return `worktree:${path.basename(toplevel || dir)}`;
+}

--- a/tests/review/workspace-stamp.test.js
+++ b/tests/review/workspace-stamp.test.js
@@ -1,0 +1,42 @@
+// KJC-TSK-0680 — the isolation claim becomes auditable: the verdict stamps
+// WHERE the review ran (root vs worktree:<name>). If the agent says
+// "isolated" and the verdict says workspace: root, the trail talks.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { detectWorkspace } from "../../src/review/workspace.js";
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-ws-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.writeFileSync(path.join(dir, "a.js"), "x\n");
+  git("add", "a.js"); git("commit", "-qm", "base");
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("detectWorkspace", () => {
+  it("reports root from the main working tree", async () => {
+    expect(await detectWorkspace(dir)).toBe("root");
+  });
+
+  it("reports worktree:<name> from a linked worktree", async () => {
+    const wt = path.join(dir, ".kj", "worktrees", "mi-carril");
+    execFileSync("git", ["-C", dir, "worktree", "add", "-b", "feat/mi-carril", wt]);
+    expect(await detectWorkspace(wt)).toBe("worktree:mi-carril");
+  });
+
+  it("returns null outside a git repo", async () => {
+    const plain = fs.mkdtempSync(path.join(os.tmpdir(), "kj-ws-plain-"));
+    try {
+      expect(await detectWorkspace(plain)).toBeNull();
+    } finally {
+      fs.rmSync(plain, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Parte 2/2 del caso 'mentirijilla del worktree' (parte 1: #1302). La afirmación de aislamiento se vuelve auditable:

- `src/review/workspace.js`: `detectWorkspace(dir)` — la misma prueba que exige el playbook (`git rev-parse --git-dir` ≠ `--git-common-dir`) → `root` | `worktree:<nombre>` | null fuera de un repo.
- El veredicto de `kj review --staged` guarda `workspace` y la línea de aprobación lo muestra: `✓ APPROVED by codex (diff …) [root]`.

No prohíbe trabajar en el root — para tarea única es legítimo — pero si el agente dice "trabajé aislado" y el veredicto dice `[root]`, el rastro habla. Dogfooded en su propio review.