### PR TITLE
chore(release): v4.3.0 — isolation you can prove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-07-23
+
+Minor. **Isolation you can prove.** A field case: the playbook said "one worktree per task" and an agent narrated the isolation while editing the project root. Ordering a practice invites narration; ordering a command gets execution — and now the claim leaves a trail.
+
+### Added
+
+- **`kj worktree start|list|done`** (KJC-TSK-0679): isolated task lanes for the host agent. `start <slug>` creates the worktree in `.kj/worktrees/<slug>` (the same lane dir the headless pipeline uses) with its `feat/<slug>` branch, bootstraps dependencies, and prints the exact `cd`; `done <slug>` removes a merged lane (refusing uncommitted changes without `--force`). The playbook now orders the COMMAND and demands the isolation proof: in a lane, `git rev-parse --git-dir` differs from `--git-common-dir`.
+- **The review verdict stamps its workspace** (KJC-TSK-0680): every `kj review --staged` records where it ran — `✓ APPROVED by codex (diff …) [root]` or `[worktree:<name>]`. Working from the root stays legitimate for single-task work, but if the agent claims isolation and the verdict says `[root]`, the trail talks.
+
 ## [4.2.1] - 2026-07-23
 
 Patch — including the first external contribution of the v4 era.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.2.1",
+      "version": "4.3.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release v4.3.0. Contenido ya mergeado en #1302 y #1304: kj worktree start|list|done (carriles aislados para el agente anfitrión, playbook ordena el comando y exige la prueba) + veredicto del review estampa el workspace (root|worktree). Caso de campo de Jorge: agente narrando aislamiento desde el root.