### PR TITLE
feat(templates): environment isolation for parallel lanes (KJC-TSK-0681)

### DIFF
--- a/templates/coder-rules.md
+++ b/templates/coder-rules.md
@@ -23,6 +23,14 @@
 - Do not modify code unrelated to the task.
 - Follow existing code conventions and patterns in the repository.
 
+## Environment isolation (parallel runs)
+
+- Never hardcode ports, DB names, or docker project names — read them from env
+  vars, documenting each one in `.env.example`. When `KJ_LANE_SLOT` /
+  `KJ_PORT_OFFSET` exist in the env, derive per-task values from them so
+  parallel lanes never collide.
+- Never commit a real `.env` — only `.env.example` is versioned.
+
 ## Tests location (MANDATORY)
 
 - Tests live in a top-level `tests/` directory mirroring `src/` (e.g. a function in

--- a/templates/kj.config.yml
+++ b/templates/kj.config.yml
@@ -118,3 +118,11 @@ session:
   # when exceeded; resume with `kj resume`. Set to null to remove the cap.
   max_budget_usd: 5
   fail_fast_repeats: 2
+  # Per-lane setup for parallel runs (worktrees). Runs INSIDE the fresh
+  # worktree instead of the default `npm ci`. Each lane receives
+  # KJ_LANE_SLOT (0,1,2…) and KJ_PORT_OFFSET (slot-derived) in its env —
+  # derive ports, DB names and docker project names from them so lanes
+  # never collide. The coder never orchestrates git; isolation is declared
+  # here. Example:
+  #   worktree_setup: "npm ci && docker compose -p app_lane_$KJ_LANE_SLOT up -d db"
+  worktree_setup: null

--- a/templates/review-rules.md
+++ b/templates/review-rules.md
@@ -4,6 +4,12 @@
 - Only raise blocking issues for concrete production risks.
 - Keep non-blocking suggestions separate.
 
+## Environment isolation
+
+- Reject changes that hardcode ports, DB names or service hostnames instead of
+  reading them from env vars, and any diff that adds a real `.env` (only
+  `.env.example` is versioned).
+
 ## File overwrite detection (BLOCKING)
 
 - If the diff shows an entire file was replaced (massive deletions + additions instead of targeted edits), flag it as BLOCKING.

--- a/tests/templates/env-isolation.test.js
+++ b/tests/templates/env-isolation.test.js
@@ -1,0 +1,32 @@
+// KJC-TSK-0681 (issue #1306) — the generated rules teach environment
+// isolation for parallel lanes, and worktree_setup is documented where it
+// is declared. Pins the templates so a future rewrite can't drop them.
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const read = (f) => fs.readFileSync(path.join(root, "templates", f), "utf8");
+
+describe("environment isolation templates (KJC-TSK-0681)", () => {
+  it("coder-rules teach lane isolation via KJ_LANE_SLOT/KJ_PORT_OFFSET", () => {
+    const text = read("coder-rules.md");
+    expect(text).toMatch(/Environment isolation/);
+    expect(text).toMatch(/KJ_LANE_SLOT/);
+    expect(text).toMatch(/\.env\.example/);
+  });
+
+  it("review-rules reject hardcoded resources and committed .env", () => {
+    const text = read("review-rules.md");
+    expect(text).toMatch(/Environment isolation/);
+    expect(text).toMatch(/hardcode ports/i);
+  });
+
+  it("worktree_setup is documented inline in the example config", () => {
+    const text = read("kj.config.yml");
+    expect(text).toMatch(/worktree_setup: null/);
+    expect(text).toMatch(/KJ_LANE_SLOT/);
+  });
+});


### PR DESCRIPTION
Fixes #1306 (points 1-3).

- **`session.worktree_setup` documented inline** in the example config, with a lane-aware example — it now feeds BOTH the headless lanes and `kj worktree start` (both go through `bootstrapWorktree`).
- **`coder-rules.md`** gains the environment-isolation section: env vars over hardcoded ports/DB/docker names, deriving per-task values from the `KJ_LANE_SLOT` / `KJ_PORT_OFFSET` the slot registry already injects (v3.15.0), `.env` never committed.
- **`review-rules.md`** gains the mirror reject rule.
- Templates pinned by test so a future rewrite can't drop the sections.

Point 4 (deterministic detection of hardcoded ports): partially covered today by the sonar pre-gate (v4.2.0) — sonar flags hardcoded IPs (S1313) and secrets, but not bare port literals; the cross-AI reviewer now carries the reject rule, which covers the practical gap without new machinery. Detailed in an issue comment on close.