### PR TITLE
feat(board): kj hu add — complete spec in one call (KJC-TSK-0678)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -185,7 +185,11 @@ export function registerMeta(program, { pkgVersion }) {
   const hu = program.command("hu").description("Track work in the HU Board from any host agent (card first)");
   hu.command("add <title>")
     .option("--id <shortId>", "Human-readable short id")
-    .option("--criteria <text>", "Acceptance criteria")
+    .option("--ac <criterion>", "Acceptance criterion (repeatable; multiline strings split per line)", (v, acc) => [...acc, v], [])
+    .option("--tests <test>", "Acceptance test (repeatable; multiline strings split per line)", (v, acc) => [...acc, v], [])
+    .option("--scope <text>", "Scope of the story (files/areas)")
+    .option("--task-type <type>", "sw | infra | doc | add-tests | refactor")
+    .option("--criteria <text>", "Legacy alias for a single acceptance criterion")
     .option("--json", "Machine-readable output")
     .action(async (title, flags) => {
       await withConfig(pkgVersion, "hu", flags, async ({ config }) => {

--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -122,15 +122,36 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
         );
       }
     }
+    // KJC-TSK-0678 (issue #1296): complete HUs in ONE call. --ac / --tests
+    // are repeatable AND accept multiline strings; --criteria stays as the
+    // legacy single-criterion alias.
+    const TASK_TYPES = ["sw", "infra", "doc", "add-tests", "refactor"];
+    if (flags.taskType && !TASK_TYPES.includes(flags.taskType)) {
+      throw new Error(`invalid --task-type "${flags.taskType}" — valid: ${TASK_TYPES.join(", ")}`);
+    }
+    const splitLines = (v) => (Array.isArray(v) ? v : v ? [v] : [])
+      .flatMap((s) => String(s).split("\n")).map((s) => s.trim()).filter(Boolean);
     const hu = addHu(plan, {
       title,
       short_id: flags.id || null,
-      acceptance_criteria: flags.criteria ? [flags.criteria] : [],
+      acceptance_criteria: [...splitLines(flags.ac), ...splitLines(flags.criteria)],
+      acceptance_tests: splitLines(flags.tests),
+      scope: flags.scope || null,
+      task_type: flags.taskType || undefined,
     });
     hu.created_by = creatorLabel();
     await savePlan(projectDir, plan);
-    return emit({ id: hu.id, short_id: hu.short_id, status: hu.status, created_by: hu.created_by },
-      `✓ HU created: ${hu.short_id || hu.id} (pending, by ${hu.created_by}) — it shows up in \`kj board\``);
+    const missing = [];
+    if (hu.acceptance_criteria.length === 0) missing.push("acceptance criteria (--ac \"...\")");
+    if (hu.acceptance_tests.length === 0) missing.push("tests (--tests \"...\")");
+    if (missing.length > 0) {
+      console.warn(`⚠ incomplete spec — kj run's spec review will flag it. Missing: ${missing.join(", ")}`);
+    }
+    return emit({
+      id: hu.id, short_id: hu.short_id, status: hu.status, created_by: hu.created_by,
+      acceptance_criteria: hu.acceptance_criteria, acceptance_tests: hu.acceptance_tests,
+      scope: hu.scope, task_type: hu.task_type,
+    }, `✓ HU created: ${hu.short_id || hu.id} (pending, by ${hu.created_by}) — it shows up in \`kj board\``);
   }
 
   if (action === "move") {

--- a/tests/environment/brain-board-adr.test.js
+++ b/tests/environment/brain-board-adr.test.js
@@ -112,6 +112,36 @@ describe("kj hu", () => {
     expect(added.status).toBe("pending");
   });
 
+  // KJC-TSK-0678 (issue #1296): complete HUs in ONE call — the spec review
+  // gets real material instead of a bare title.
+  it("add accepts --ac (repeatable/multiline), --scope, --tests and --task-type", async () => {
+    const added = await huCommand({ config: cfg(), action: "add", args: ["Full story"], flags: {
+      json: true, id: "FULL-1", ac: ["1. works\n2. survives restart", "3. logs it"],
+      scope: "src/foo.js", tests: ["tests/foo.test.js: validates thing"], taskType: "sw",
+    } });
+    expect(added.acceptance_criteria).toEqual(["1. works", "2. survives restart", "3. logs it"]);
+    expect(added.scope).toBe("src/foo.js");
+    expect(added.acceptance_tests).toEqual(["tests/foo.test.js: validates thing"]);
+    expect(added.task_type).toBe("sw");
+  });
+
+  it("add warns about what is missing for a complete spec", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await huCommand({ config: cfg(), action: "add", args: ["Bare title"], flags: { json: true } });
+      const out = warn.mock.calls.flat().join("\n");
+      expect(out).toMatch(/acceptance criteria/i);
+      expect(out).toMatch(/--ac/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("add rejects an unknown --task-type", async () => {
+    await expect(huCommand({ config: cfg(), action: "add", args: ["X"], flags: { taskType: "banana" } }))
+      .rejects.toThrow(/task-type/);
+  });
+
   it("second add reuses the same backlog plan", async () => {
     await huCommand({ config: cfg(), action: "add", args: ["A"], flags: { json: true } });
     await huCommand({ config: cfg(), action: "add", args: ["B"], flags: { json: true } });


### PR DESCRIPTION
Fixes #1296.

- `kj hu add "Title" --ac "..." --tests "..." --scope "..." --task-type sw`: todos opcionales y retrocompatibles; `--ac`/`--tests` repetibles Y con soporte multilínea (una string con saltos se separa por línea). `--criteria` queda como alias legacy.
- karajan-core `addHu` ya persistía todos los campos (scope, acceptance_criteria, acceptance_tests, task_type) — esto los expone en UNA llamada: se acabó el add + PATCH.
- **Feedback de spec incompleta**: sin AC o sin tests, aviso inmediato con el flag exacto que falta — el mismo material que el spec-review de `kj run` reclamaría después (y que desde #1298 le llega vía taskOverride).
- `--task-type` validado contra los tipos reales (sw|infra|doc|add-tests|refactor).