### PR TITLE
feat(rag): sensitivity gate + PII redaction for cloud embedders (KJC-TSK-0682)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "helmet": "^8.1.0",
         "js-yaml": "^4.2.0",
         "karajan-core": "^1.0.0",
+        "karajan-rag": "^1.2.0",
         "knip": "^6.15.0",
         "madge": "^8.0.0",
         "sqlite-vec": "^0.1.9",
@@ -4954,6 +4955,20 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/karajan-rag": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/karajan-rag/-/karajan-rag-1.2.0.tgz",
+      "integrity": "sha512-LjQyON5eca9rTdLIWdS9BhJrBlRM3V6xcTaiBqmrnTRqbLGFkly5PYcTsQjCdYogx6YEW0YPTvyPa5gUJCWdCw==",
+      "license": "AGPL-3.0-or-later",
+      "bin": {
+        "karajan-rag": "bin/karajan-rag.js",
+        "kj-rag": "bin/karajan-rag.js",
+        "kjr": "bin/karajan-rag.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7813,7 +7828,7 @@
     },
     "packages/hu-board": {
       "name": "@karajan/hu-board",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "helmet": "^8.1.0",
     "js-yaml": "^4.2.0",
     "karajan-core": "^1.0.0",
+    "karajan-rag": "^1.2.0",
     "knip": "^6.15.0",
     "madge": "^8.0.0",
     "sqlite-vec": "^0.1.9",

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -3,7 +3,7 @@
 //   kj rag query <text>   [--scope plans|code|onboarding|all] [--top-k N] [--json]
 // Closes the v2.22.0 RAG MVP end-to-end from the terminal.
 import { openVecStore, countChunks, projectSlug, getLastIndexedCommit, setLastIndexedCommit } from "../rag/vec-store.js";
-import { makeEmbedder } from "../rag/embedders/factory.js";
+import { makeGovernedEmbedder } from "../rag/governed-embedder.js";
 import { indexProject, indexProjectDelta } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
 import { installPostMergeHook, maybeAutoUpdate } from "../rag/auto-update.js";
@@ -19,7 +19,7 @@ export async function ragIndexCommand({ config, logger, flags = {} }) {
   const db = openDb(config);
   try {
     const slug = projectSlug(projectDir);
-    const embedder = makeEmbedder(config);
+    const embedder = makeGovernedEmbedder(config);
     const sinceFlag = flags.since;
     // KJC-TSK-0455 — `--since auto` resolves to the last commit we indexed;
     // an explicit ref is honoured as-is. Without a baseline (first-time
@@ -103,7 +103,7 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     const alpha = Math.max(0, Math.min(1, Number(flags.alpha) || 0.6));
     const where = flags.where || null;
     const rerankOpts = flags.rerank ? { model: flags.rerankModel } : null;
-    const hits = await query(db, makeEmbedder(config), text, { topK, scope, project, mode, alpha, where, rerankOpts });
+    const hits = await query(db, makeGovernedEmbedder(config), text, { topK, scope, project, mode, alpha, where, rerankOpts });
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(hits)}\n`);
     } else {
@@ -133,7 +133,7 @@ export async function ragEvalCommand({ config, logger, flags = {} }) {
     const topK = Math.max(1, Number(flags.topK) || 10);
     const detected = projectSlug(config?.projectDir || process.cwd());
     const project = flags.project === "all" ? null : (flags.project || detected || null);
-    const embedder = makeEmbedder(config);
+    const embedder = makeGovernedEmbedder(config);
     const runQuery = async (text, k) => query(db, embedder, text, { topK: k, scope: "all", project });
     const report = await runEval(queries, runQuery, { topK, ks: [5, 10] });
     if (flags.json) {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -216,7 +216,11 @@ const DEFAULTS = {
     // delta re-index before every `kj run`; `onCommit` is consulted by
     // `kj rag install-hooks` to decide whether to install the post-merge
     // hook. Both default ON; flip to false to opt out without uninstalling.
-    autoUpdate: { onCommit: true, onRun: true }
+    autoUpdate: { onCommit: true, onRun: true },
+    // KJC-TSK-0682 — sensitivity of the indexed code. Cloud embedders
+    // (openai/voyage/cohere/mistral) require an explicit "public"; the
+    // safe default blocks them (local ollama/onnx always allowed).
+    sensitivity: "internal"
   },
   // Opt-in. Set by the `kj init` wizard (explicit consent prompt in the OS
   // locale). When the key is absent or false, no events are sent. See

--- a/src/mcp/handlers/rag-handler.js
+++ b/src/mcp/handlers/rag-handler.js
@@ -2,7 +2,7 @@
 // from src/commands/* are forbidden by the layer-boundaries test
 // (MCP and CLI are peer layers); we hit the pure rag/* modules instead.
 import { countChunks, openVecStore } from "../../rag/vec-store.js";
-import { makeEmbedder } from "../../rag/embedders/factory.js";
+import { makeGovernedEmbedder } from "../../rag/governed-embedder.js";
 import { indexProject } from "../../rag/indexer.js";
 import { query } from "../../rag/retriever.js";
 import { getKarajanHome } from "../../utils/paths.js";
@@ -25,7 +25,7 @@ export async function handleRagQuery(args, server) {
     const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
     try {
       if (countChunks(db) === 0) return responseText({ hits: [], empty: true, topK, scope });
-      const hits = await query(db, makeEmbedder(config), text, { topK, scope });
+      const hits = await query(db, makeGovernedEmbedder(config), text, { topK, scope });
       return responseText({ hits, empty: false, topK, scope });
     } finally { db.close(); }
   } catch (err) {
@@ -40,7 +40,7 @@ export async function handleRagIndex(args, server) {
     const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
     try {
       const totals = await indexProject(projectDir, {
-        db, embedder: makeEmbedder(config),
+        db, embedder: makeGovernedEmbedder(config),
         karajanHome: getKarajanHome(), logger: silentLogger,
         withSources: Boolean(args?.withSources),
       });

--- a/src/orchestrator/stages/rag-context-stage.js
+++ b/src/orchestrator/stages/rag-context-stage.js
@@ -6,7 +6,7 @@
 // never sees an exception from this stage.
 import { emitProgress, makeEvent } from "../../utils/events.js";
 import { openVecStore, countChunks } from "../../rag/vec-store.js";
-import { makeEmbedder } from "../../rag/embedders/factory.js";
+import { makeGovernedEmbedder } from "../../rag/governed-embedder.js";
 import { query } from "../../rag/retriever.js";
 
 const DEFAULT_TOP_K = 5;
@@ -52,7 +52,7 @@ export async function runRagContextStage({ config, logger, emitter, eventBase, t
       }
       const topK = preload.topK || DEFAULT_TOP_K;
       const scope = preload.scope || DEFAULT_SCOPE;
-      const embedder = makeEmbedder(config);
+      const embedder = makeGovernedEmbedder(config);
       const searchOpts = resolveSearchOpts(config);
       const hits = await query(db, embedder, task, { topK, scope, ...searchOpts });
       if (hits.length === 0) return { skipped: true, reason: "no-hits" };

--- a/src/rag/auto-update.js
+++ b/src/rag/auto-update.js
@@ -8,7 +8,7 @@ import { execa } from "execa";
 
 import { openVecStore, projectSlug, getLastIndexedCommit, setLastIndexedCommit } from "./vec-store.js";
 import { indexProjectDelta } from "./indexer.js";
-import { makeEmbedder } from "./embedders/factory.js";
+import { makeGovernedEmbedder } from "./governed-embedder.js";
 
 const HOOK_SRC = resolve(fileURLToPath(import.meta.url), "../../../scripts/git-hooks/post-merge");
 
@@ -25,7 +25,7 @@ export async function maybeAutoUpdate({ projectDir, config, logger = console, fl
     const since = getLastIndexedCommit(db, slug);
     if (!since || since === head) return { skipped: true, head };
     logger.info?.(`[rag] drift detected (${since.slice(0, 7)} → ${head.slice(0, 7)}); running delta update`);
-    const totals = await indexProjectDelta(projectDir, { db, embedder: makeEmbedder(config), since, logger });
+    const totals = await indexProjectDelta(projectDir, { db, embedder: makeGovernedEmbedder(config), since, logger });
     if (totals.head) setLastIndexedCommit(db, slug, totals.head);
     return { ran: true, totals };
   } catch (err) {

--- a/src/rag/governed-embedder.js
+++ b/src/rag/governed-embedder.js
@@ -1,0 +1,39 @@
+/**
+ * Governed embedder (KJC-TSK-0682 — card filed by the karajan-rag session
+ * after its independent security audit closed the same risk there, H2).
+ * Chunks of project code must not travel to a cloud embedder without
+ * governance: local providers (ollama/onnx) pass through untouched; cloud
+ * providers (openai/voyage/cohere/mistral) require an EXPLICIT
+ * `rag.sensitivity: public` — the default (`internal`) blocks with an
+ * actionable error, never a silent downgrade. Even when allowed, every
+ * text is PII-redacted (karajan-rag's audited redactPII) before leaving
+ * the machine — defense in depth, not a substitute for the policy.
+ */
+import { redactPII } from "karajan-rag";
+import { makeEmbedder } from "./embedders/factory.js";
+
+const LOCAL_PROVIDERS = new Set(["ollama", "onnx"]);
+const redact = (text) => redactPII(String(text)).text;
+
+class RedactingEmbedder {
+  constructor(inner) { this.inner = inner; }
+  get dim() { return this.inner.dim; }
+  get model() { return this.inner.model; }
+  async embed(text) { return this.inner.embed(redact(text)); }
+  async embedBatch(texts) { return this.inner.embedBatch(texts.map(redact)); }
+}
+
+/** Drop-in replacement for makeEmbedder(config) at every kj call site. */
+export function makeGovernedEmbedder(config) {
+  const provider = config?.rag?.embedder?.provider || "ollama";
+  if (LOCAL_PROVIDERS.has(provider)) return makeEmbedder(config);
+
+  const sensitivity = config?.rag?.sensitivity || "internal";
+  if (sensitivity !== "public") {
+    throw new Error(
+      `embedder "${provider}" sends your code to a cloud provider, but rag.sensitivity is "${sensitivity}". `
+      + `Use a local embedder (rag.embedder.provider: ollama | onnx) or declare rag.sensitivity: public in kj.config.yml.`
+    );
+  }
+  return new RedactingEmbedder(makeEmbedder(config));
+}

--- a/src/rag/watcher.js
+++ b/src/rag/watcher.js
@@ -5,7 +5,7 @@ import { writeFileSync, readFileSync, existsSync, unlinkSync } from "node:fs";
 import { extname, join } from "node:path";
 import chokidar from "chokidar";
 import { openVecStore, deleteChunksBySource, projectSlug } from "./vec-store.js";
-import { makeEmbedder } from "./embedders/factory.js";
+import { makeGovernedEmbedder } from "./governed-embedder.js";
 import { indexFile } from "./indexer.js";
 import { getKarajanHome } from "../utils/paths.js";
 import { getAllCodeExtensions } from "../lang/registry.js";
@@ -27,7 +27,7 @@ export function startWatcher({ projectDir, config, logger = console, debounceMs 
   const slug = projectSlug(projectDir);
   const dim = config?.rag?.embedder?.dim || 768;
   const db = openVecStore({ dim });
-  const embedder = makeEmbedder(config);
+  const embedder = makeGovernedEmbedder(config);
   const paths = [join(getKarajanHome(), "onboarding"), join(getKarajanHome(), "plans")];
   if (withSources) paths.push(projectDir);
   const watcher = chokidar.watch(paths, { ignoreInitial: true, persistent: true });

--- a/tests/rag/governed-embedder.test.js
+++ b/tests/rag/governed-embedder.test.js
@@ -1,0 +1,55 @@
+// KJC-TSK-0682 (card filed by the karajan-rag session) — chunks of private
+// code must pass sensitivity policy + PII redaction before travelling to a
+// cloud embedder. Local providers (ollama/onnx) are always allowed and
+// untouched; cloud requires an EXPLICIT rag.sensitivity: public.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const innerEmbedder = {
+  dim: 1024, model: "test-model",
+  embed: vi.fn().mockResolvedValue(new Float32Array(4)),
+  embedBatch: vi.fn().mockResolvedValue([new Float32Array(4)]),
+};
+const makeEmbedderMock = vi.fn(() => innerEmbedder);
+vi.mock("../../src/rag/embedders/factory.js", () => ({ makeEmbedder: (...a) => makeEmbedderMock(...a) }));
+
+import { makeGovernedEmbedder } from "../../src/rag/governed-embedder.js";
+
+const cfg = (provider, sensitivity) => ({ rag: { embedder: { provider }, ...(sensitivity ? { sensitivity } : {}) } });
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("makeGovernedEmbedder", () => {
+  it("local providers pass through untouched regardless of sensitivity", async () => {
+    for (const provider of ["ollama", "onnx"]) {
+      const e = makeGovernedEmbedder(cfg(provider, "confidential"));
+      expect(e).toBe(innerEmbedder); // no wrapper, no redaction overhead
+    }
+  });
+
+  it("cloud providers are BLOCKED under the default sensitivity (internal)", () => {
+    for (const provider of ["openai", "voyage", "cohere", "mistral"]) {
+      expect(() => makeGovernedEmbedder(cfg(provider)))
+        .toThrow(/sensitivity|public/);
+    }
+    expect(makeEmbedderMock).not.toHaveBeenCalled(); // fails before creating anything
+  });
+
+  it("cloud + explicit public is allowed but PII is redacted before embedding", async () => {
+    const e = makeGovernedEmbedder(cfg("openai", "public"));
+    await e.embed("contact mjx@example.com for access");
+    expect(innerEmbedder.embed.mock.calls[0][0]).not.toContain("mjx@example.com");
+    expect(innerEmbedder.embed.mock.calls[0][0]).toContain("[REDACTED_EMAIL]");
+
+    await e.embedBatch(["a@b.co", "clean text"]);
+    const batch = innerEmbedder.embedBatch.mock.calls[0][0];
+    expect(batch[0]).toContain("[REDACTED_EMAIL]");
+    expect(batch[1]).toBe("clean text");
+    expect(e.dim).toBe(1024); // interface preserved
+    expect(e.model).toBe("test-model");
+  });
+
+  it("cloud + confidential is blocked even if someone sets it explicitly", () => {
+    expect(() => makeGovernedEmbedder(cfg("voyage", "confidential"))).toThrow(/confidential/);
+  });
+});


### PR DESCRIPTION
Card presentada por la sesión de karajan-rag tras cerrar el mismo riesgo (H2) en su auditoría independiente. Hito: **karajan-rag protege ahora a karajan-code** — primera dependencia entre tus dos productos.

- Dependencia `karajan-rag ^1.2.0` (zero-dep; se importan solo `redactPII` y la policy desde la superficie pública auditada en 3 pasadas por Codex).
- `makeGovernedEmbedder(config)` sustituye a `makeEmbedder` en los 8 call sites: **ollama/onnx pasan directo** (nada sale de la máquina); **openai/voyage/cohere/mistral exigen `rag.sensitivity: public` explícito** — el default `internal` bloquea con error accionable, jamás degradación silenciosa.
- Aun permitido el cloud, cada texto pasa por `redactPII` antes de embarcar (emails, teléfonos, NIF/NIE, IBAN, tarjetas) — defensa en profundidad.
- Smoke real verificado: `kj rag query` local intacto a través del camino gobernado.