### PR TITLE
feat(rag): ONNX fallback when Ollama is unavailable (KJC-TSK-0683)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "madge": "^8.0.0",
         "sqlite-vec": "^0.1.9",
         "valibot": "^1.4.1",
-        "web-tree-sitter": "^0.26.9"
+        "web-tree-sitter": "^0.26.9",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "karajan-mcp": "bin/karajan-mcp.js",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "madge": "^8.0.0",
     "sqlite-vec": "^0.1.9",
     "valibot": "^1.4.1",
-    "web-tree-sitter": "^0.26.9"
+    "web-tree-sitter": "^0.26.9",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -9,6 +9,7 @@ import { renderBrief, listBriefs } from "../environment/briefs.js";
 import { openVecStore, projectSlug, getLastIndexedCommit } from "../rag/vec-store.js";
 import { ragIndexCommand } from "./rag.js";
 import { renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-action.js";
+import { onnxConfig, persistOnnxChoice } from "../rag/onnx-fallback.js";
 
 function hasRagIndex(config, projectDir) {
   const db = openVecStore({ dim: config?.rag?.embedder?.dim || 768 });
@@ -59,6 +60,27 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
         : { tool: `${provider} embedder`, action: "needs-user", reason: `the RAG cannot index: ${why} — check rag.embedder in kj config`, manualUrl: "kj config" };
       console.log(renderPendingBlock([item], { retry: "kj rag index --with-sources   (then re-run: kj env install)" }));
     };
+    // KJC-TSK-0683: on limited machines (no Ollama, no Docker) the DEFAULT
+    // provider falls back to the built-in ONNX embedder instead of blocking.
+    // Only for the first index and only when the user didn't pick a provider
+    // explicitly — the election is persisted (dims differ, it must stick).
+    const explicitProvider = Boolean(config?.rag?.embedder?.provider);
+    const tryOnnxFallback = async (why) => {
+      if (explicitProvider) return false;
+      console.log(`⚠ default embedder unavailable (${why}) — trying the built-in ONNX embedder (no install needed)…`);
+      try {
+        const totals = await ragIndexCommand({ config: onnxConfig(config), logger, flags: { withSources: true } });
+        if ((totals?.indexed ?? 0) > 0) {
+          const p = await persistOnnxChoice(projectDir);
+          console.log(`✓ RAG indexed with the built-in ONNX embedder — persisted in ${p}`);
+          console.log("  For higher-quality embeddings later: install Ollama and run `kj rag index --rebuild`.");
+          return true;
+        }
+      } catch (fallbackErr) {
+        console.log(`  ONNX fallback also failed: ${fallbackErr.message}`);
+      }
+      return false;
+    };
     try {
       if (hasRagIndex(config, projectDir)) {
         console.log("✓ RAG index present");
@@ -66,11 +88,12 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
         console.log("⏳ no RAG index for this project — building it (first time only)…");
         const totals = await ragIndexCommand({ config, logger, flags: { withSources: true } });
         if ((totals?.indexed ?? 0) === 0 && (totals?.files ?? 0) > 0) {
-          blockRag(`0 of ${totals.files} files indexed — is the embedder running?`);
+          const why = `0 of ${totals.files} files indexed — is the embedder running?`;
+          if (!(await tryOnnxFallback(why))) blockRag(why);
         }
       }
     } catch (err) {
-      blockRag(err.message);
+      if (!(await tryOnnxFallback(err.message))) blockRag(err.message);
     }
   }
   if (result.exitCode !== PENDING_EXIT_CODE) {

--- a/src/rag/onnx-fallback.js
+++ b/src/rag/onnx-fallback.js
@@ -1,0 +1,42 @@
+/**
+ * ONNX embedder fallback (KJC-TSK-0683) — limited machines where installing
+ * Ollama/Docker is not viable still get a working RAG: the built-in ONNX
+ * embedder (all-MiniLM via @huggingface/transformers, in-process, CPU).
+ * The choice is PERSISTED in the project config: onnx (384) and ollama
+ * (768) have different vector dims, so the election must be sticky —
+ * an index can never be written by one and queried by the other.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parseDocument } from "yaml";
+import { getProjectConfigPath } from "../config/loader.js";
+
+const ONNX_EMBEDDER = { provider: "onnx", dim: 384 };
+
+/** The same config, with the embedder swapped to the built-in ONNX. */
+export function onnxConfig(config) {
+  return {
+    ...config,
+    rag: { ...(config?.rag || {}), embedder: { ...(config?.rag?.embedder || {}), ...ONNX_EMBEDDER } },
+  };
+}
+
+/**
+ * Persist the ONNX election in the PROJECT config file. Surgical edit via
+ * the yaml Document API: only rag.embedder.{provider,dim} change — the
+ * user's comments, ordering and every other key survive untouched.
+ */
+export async function persistOnnxChoice(projectDir) {
+  const configPath = getProjectConfigPath(projectDir);
+  let source = "";
+  try {
+    source = await fs.readFile(configPath, "utf8");
+  } catch { /* no project config yet — create it */ }
+  const doc = parseDocument(source || "{}");
+  for (const [key, value] of Object.entries(ONNX_EMBEDDER)) {
+    doc.setIn(["rag", "embedder", key], value);
+  }
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, doc.toString(), "utf8");
+  return configPath;
+}

--- a/tests/environment/rag-first.test.js
+++ b/tests/environment/rag-first.test.js
@@ -17,6 +17,9 @@ vi.mock("../../src/environment/playbook.js", () => ({
   // fresh object per call — envInstallCommand mutates its result
   installPlaybook: vi.fn(async () => ({ files: ["CLAUDE.md", "AGENTS.md"], target: "both" })),
 }));
+vi.mock("../../src/rag/onnx-fallback.js", async (orig) => ({
+  ...(await orig()), persistOnnxChoice: vi.fn().mockResolvedValue("/tmp/proj/.karajan/kj.config.yml"),
+}));
 
 import { envInstallCommand } from "../../src/commands/env.js";
 import { getLastIndexedCommit } from "../../src/rag/vec-store.js";
@@ -48,12 +51,16 @@ describe("env install is RAG-first", () => {
 
   // KJC-TSK-0659 stop-on-sudo: a RAG that cannot index BLOCKS (exit 3) —
   // never "success" with an empty index. The playbook stays installed.
+  // KJC-TSK-0683: with an EXPLICIT provider the user's choice is respected —
+  // no ONNX fallback, straight to the block.
+  const explicitOllama = { projectDir: "/tmp/proj", rag: { embedder: { provider: "ollama" } } };
+
   it("index failure blocks with pending-user-action (exit 3), playbook still installed", async () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockRejectedValueOnce(new Error("ollama down"));
     const logs = [];
     const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config: explicitOllama, flags: {} });
     spy.mockRestore();
     expect(res.files).toContain("CLAUDE.md");
     expect(res.ragError).toMatch(/ollama down/);
@@ -68,10 +75,40 @@ describe("env install is RAG-first", () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockResolvedValueOnce({ indexed: 0, files: 727, failed: 727 });
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config: explicitOllama, flags: {} });
     spy.mockRestore();
     expect(res.exitCode).toBe(3);
     expect(res.ragError).toMatch(/0 of 727/);
+  });
+
+  // KJC-TSK-0683: limited machines — default provider + Ollama down falls
+  // back to the built-in ONNX embedder and PERSISTS the choice (dims differ:
+  // the election must be sticky, never oscillate per run).
+  it("default provider + failed first index falls back to ONNX and persists it", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    ragIndexCommand
+      .mockRejectedValueOnce(new Error("ollama down"))
+      .mockResolvedValueOnce({ indexed: 300, files: 400, failed: 0 });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
+    expect(res.exitCode).toBeUndefined(); // no block
+    expect(ragIndexCommand).toHaveBeenCalledTimes(2);
+    expect(ragIndexCommand.mock.calls[1][0].config.rag.embedder.provider).toBe("onnx");
+    const { persistOnnxChoice } = await import("../../src/rag/onnx-fallback.js");
+    expect(persistOnnxChoice).toHaveBeenCalledWith("/tmp/proj");
+  });
+
+  it("blocks as before when the ONNX fallback also fails", async () => {
+    getLastIndexedCommit.mockReturnValue(null);
+    ragIndexCommand
+      .mockRejectedValueOnce(new Error("ollama down"))
+      .mockRejectedValueOnce(new Error("model download failed"));
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
+    expect(res.exitCode).toBe(3);
+    expect(res.ragError).toMatch(/ollama down/);
   });
 
   it("a healthy first index does not block", async () => {

--- a/tests/rag/onnx-fallback.test.js
+++ b/tests/rag/onnx-fallback.test.js
@@ -1,0 +1,43 @@
+// KJC-TSK-0683 — the ONNX election must merge into the project config
+// surgically (never a full-config dump) and survive an existing file.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import yaml from "js-yaml";
+import { onnxConfig, persistOnnxChoice } from "../../src/rag/onnx-fallback.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-onnx-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+describe("onnxConfig", () => {
+  it("swaps provider and dim without touching the rest", () => {
+    const cfg = onnxConfig({ projectDir: "/p", rag: { autoUpdate: { onRun: true }, embedder: { model: "x" } } });
+    expect(cfg.rag.embedder).toMatchObject({ provider: "onnx", dim: 384, model: "x" });
+    expect(cfg.rag.autoUpdate.onRun).toBe(true);
+    expect(cfg.projectDir).toBe("/p");
+  });
+});
+
+describe("persistOnnxChoice", () => {
+  it("creates the project config when none exists", async () => {
+    const p = await persistOnnxChoice(dir);
+    const written = yaml.load(fs.readFileSync(p, "utf8"));
+    expect(written.rag.embedder).toEqual({ provider: "onnx", dim: 384 });
+  });
+
+  it("merges into an existing config preserving user keys AND comments", async () => {
+    const configPath = path.join(dir, ".karajan", "kj.config.yml");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, "# my precious comment\ncoder: claude\nrag:\n  autoUpdate:\n    onRun: false\n");
+    await persistOnnxChoice(dir);
+    const raw = fs.readFileSync(configPath, "utf8");
+    expect(raw).toContain("# my precious comment"); // comments survive
+    const written = yaml.load(raw);
+    expect(written.coder).toBe("claude"); // untouched
+    expect(written.rag.autoUpdate.onRun).toBe(false); // untouched
+    expect(written.rag.embedder).toEqual({ provider: "onnx", dim: 384 });
+  });
+});


### PR DESCRIPTION
Petición del usuario: equipos limitados donde instalar Ollama/Docker no es viable.

- Primera indexación con provider POR DEFECTO y Ollama caído → `kj env install` cae al **embedder ONNX integrado** (all-MiniLM en proceso, ~80MB, CPU, cero instalaciones) y **persiste la elección** en el config del proyecto — las dimensiones difieren (384 vs 768), la elección debe ser pegajosa, jamás oscilar por run.
- La persistencia usa la Document API de `yaml` (`setIn`): los comentarios, el orden y las claves del usuario sobreviven intactos (feedback del reviewer aplicado; `yaml` promovido a dependencia directa).
- **Provider explícito → se respeta**: bloqueo PENDING-USER-ACTION como hasta ahora, sin fallback.
- ONNX también falla (p. ej. sin red para bajar el modelo) → bloqueo como siempre.
- Mensaje de vuelta: instalar Ollama + `kj rag index --rebuild` para calidad superior.