### PR TITLE
feat(env): env install guarantees an operational board (KJC-TSK-0685, 2/2)

### DIFF
--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -11,6 +11,7 @@ import { openVecStore, projectSlug, getLastIndexedCommit, dbPath } from "../rag/
 import { ragIndexCommand } from "./rag.js";
 import { renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-action.js";
 import { onnxConfig, persistOnnxChoice, resetEmptyStore } from "../rag/onnx-fallback.js";
+import { verifyBoardAccess } from "../environment/board-access.js";
 
 function hasRagIndex(config, projectDir) {
   // KJC-BUG-0128: probing must never CREATE the store — openVecStore runs
@@ -48,6 +49,22 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
     boardName: config?.board?.name || null,
   });
   console.log(`✓ Karajan playbook installed in: ${result.files.join(", ")}`);
+
+  // KJC-TSK-0685 (user rule): Karajan does not run without a board — it is
+  // what guarantees ordered, card-first work. Verify an OPERATIONAL access
+  // path to the declared backend BEFORE anything else; no path → block
+  // (exit 3) with the exact steps. The playbook stays installed.
+  const access = verifyBoardAccess({ config, projectDir });
+  if (!access.ok) {
+    result.boardError = access.needed.join(" | ");
+    result.exitCode = PENDING_EXIT_CODE;
+    console.log(renderPendingBlock(
+      [{ tool: `${access.name || access.backend} board`, action: "needs-user", reason: `Karajan does not run without a board. To use ${access.name || access.backend}: ${access.needed.join(" ")}` }],
+      { retry: "kj env install" },
+    ));
+    return result;
+  }
+  if (access.backend !== "hu-board") console.log(`✓ board access verified: ${access.via}`);
 
   // ENV-E1: RAG-first — the playbook orders "query the RAG before coding",
   // so installing the environment guarantees the index exists. KJC-TSK-0659

--- a/src/environment/board-access.js
+++ b/src/environment/board-access.js
@@ -1,0 +1,78 @@
+/**
+ * Board access verification (KJC-TSK-0685). User rule: Karajan does not
+ * run without a board — it is what guarantees ordered, card-first work and
+ * meaningful lanes. There is NO "none". init/env-install verify an
+ * OPERATIONAL access path to the declared backend:
+ *   - hu-board       → always ok (ships inside the kj tarball).
+ *   - planning-game  → its MCP appears in a host agent config.
+ *   - external       → the named board's MCP appears in a host agent
+ *                      config, OR an API token is exported (conventional
+ *                      env var, or the one declared in board.token_env).
+ * Detection is presence-based and format-agnostic (the MCP config files
+ * are scanned as text) — v1 verifies a path exists, not connectivity.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TOKEN_CONVENTIONS = {
+  linear: ["LINEAR_API_KEY"],
+  trello: ["TRELLO_TOKEN", "TRELLO_API_KEY"],
+  jira: ["JIRA_API_TOKEN"],
+  github: ["GITHUB_TOKEN", "GH_TOKEN"],
+  asana: ["ASANA_ACCESS_TOKEN"],
+};
+
+function mcpConfigPaths(projectDir, home) {
+  return [
+    path.join(projectDir, ".mcp.json"),
+    path.join(home, ".claude.json"),
+    path.join(home, ".codex", "config.toml"),
+    path.join(home, ".gemini", "settings.json"),
+  ];
+}
+
+function mcpConfigsMention(slug, projectDir, home) {
+  const needle = slug.toLowerCase();
+  for (const p of mcpConfigPaths(projectDir, home)) {
+    try {
+      if (existsSync(p) && readFileSync(p, "utf8").toLowerCase().includes(needle)) return p;
+    } catch { /* unreadable config — keep looking */ }
+  }
+  return null;
+}
+
+export function verifyBoardAccess({ config = {}, projectDir = process.cwd(), env = process.env, home = os.homedir() } = {}) {
+  const backend = config.state_backend || "hu-board";
+
+  if (backend === "planning-game") {
+    const hit = mcpConfigsMention("planning-game", projectDir, home);
+    if (hit) return { ok: true, backend, via: `planning-game MCP (${hit})` };
+    return {
+      ok: false, backend,
+      needed: ["configure the planning-game MCP in your host agent (project .mcp.json or the agent's global config)"],
+    };
+  }
+
+  if (backend === "external") {
+    const name = String(config.board?.name || "").trim();
+    if (!name) return { ok: false, backend, needed: ["declare board.name in kj.config.yml (e.g. Linear, Trello, Jira, GitHub Issues)"] };
+    const slug = name.toLowerCase().split(/\s+/)[0];
+    const hit = mcpConfigsMention(slug, projectDir, home);
+    if (hit) return { ok: true, backend, via: `${name} MCP detected (${hit})` };
+    const tokenEnvs = config.board?.token_env ? [config.board.token_env] : (TOKEN_CONVENTIONS[slug] || []);
+    const found = tokenEnvs.find((k) => env[k]);
+    if (found) return { ok: true, backend, via: `API token ${found}` };
+    return {
+      ok: false, backend, name,
+      needed: [
+        `configure the ${name} MCP in your host agent (project .mcp.json or the agent's global config), or`,
+        tokenEnvs.length > 0
+          ? `export an API token: ${tokenEnvs.join(" or ")}`
+          : "declare board.token_env in kj.config.yml and export that variable",
+      ],
+    };
+  }
+
+  return { ok: true, backend: "hu-board", via: "bundled HU Board" };
+}

--- a/tests/environment/board-access.test.js
+++ b/tests/environment/board-access.test.js
@@ -1,0 +1,72 @@
+// KJC-TSK-0685 — Karajan does not run without a board (user rule, no
+// "none"): init/env-install verify there is an OPERATIONAL access path to
+// the declared board — bundled hu-board, a configured MCP, or an API token.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { verifyBoardAccess } from "../../src/environment/board-access.js";
+
+let dir, home;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-board-p-"));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-board-h-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("verifyBoardAccess", () => {
+  it("hu-board is always operational — it ships with kj", () => {
+    expect(verifyBoardAccess({ config: {}, projectDir: dir, home, env: {} }))
+      .toMatchObject({ ok: true });
+  });
+
+  it("planning-game requires its MCP in a host agent config", () => {
+    const missing = verifyBoardAccess({ config: { state_backend: "planning-game" }, projectDir: dir, home, env: {} });
+    expect(missing.ok).toBe(false);
+    expect(missing.needed.join(" ")).toMatch(/planning-game/);
+
+    fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({ mcpServers: { "planning-game-personal": { command: "x" } } }));
+    expect(verifyBoardAccess({ config: { state_backend: "planning-game" }, projectDir: dir, home, env: {} }).ok).toBe(true);
+  });
+
+  it("external + MCP of the named board in the project .mcp.json passes", () => {
+    fs.writeFileSync(path.join(dir, ".mcp.json"), JSON.stringify({ mcpServers: { linear: { url: "https://mcp.linear.app" } } }));
+    const r = verifyBoardAccess({ config: { state_backend: "external", board: { name: "Linear" } }, projectDir: dir, home, env: {} });
+    expect(r.ok).toBe(true);
+    expect(r.via).toMatch(/MCP/);
+  });
+
+  it("external + conventional API token env passes", () => {
+    const r = verifyBoardAccess({
+      config: { state_backend: "external", board: { name: "Linear" } },
+      projectDir: dir, home, env: { LINEAR_API_KEY: "lin_xxx" },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.via).toMatch(/LINEAR_API_KEY/);
+  });
+
+  it("external + declared board.token_env passes when exported", () => {
+    const r = verifyBoardAccess({
+      config: { state_backend: "external", board: { name: "MiBoard", token_env: "MIBOARD_TOKEN" } },
+      projectDir: dir, home, env: { MIBOARD_TOKEN: "t" },
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("external with NO access path fails with the exact steps", () => {
+    const r = verifyBoardAccess({ config: { state_backend: "external", board: { name: "Trello" } }, projectDir: dir, home, env: {} });
+    expect(r.ok).toBe(false);
+    expect(r.needed.join("\n")).toMatch(/Trello MCP/i);
+    expect(r.needed.join("\n")).toMatch(/TRELLO/);
+  });
+
+  it("external without a board.name fails asking for it", () => {
+    const r = verifyBoardAccess({ config: { state_backend: "external" }, projectDir: dir, home, env: {} });
+    expect(r.ok).toBe(false);
+    expect(r.needed.join(" ")).toMatch(/board.name/);
+  });
+});

--- a/tests/environment/rag-first.test.js
+++ b/tests/environment/rag-first.test.js
@@ -25,6 +25,9 @@ vi.mock("../../src/rag/onnx-fallback.js", async (orig) => ({
   persistOnnxChoice: vi.fn().mockResolvedValue("/tmp/proj/.karajan/kj.config.yml"),
   resetEmptyStore: vi.fn(() => true),
 }));
+vi.mock("../../src/environment/board-access.js", () => ({
+  verifyBoardAccess: vi.fn(() => ({ ok: true, backend: "hu-board", via: "bundled HU Board" })),
+}));
 
 import { envInstallCommand } from "../../src/commands/env.js";
 import { getLastIndexedCommit } from "../../src/rag/vec-store.js";
@@ -140,6 +143,21 @@ describe("env install is RAG-first", () => {
     spy.mockRestore();
     expect(res.exitCode).toBe(3);
     expect(res.ragError).toMatch(/ollama down/);
+  });
+
+  // KJC-TSK-0685: no board access → block BEFORE the RAG even runs. The
+  // playbook stays installed; exit 3 carries the exact steps.
+  it("blocks with exit 3 when the declared board has no access path — before touching the RAG", async () => {
+    const { verifyBoardAccess } = await import("../../src/environment/board-access.js");
+    verifyBoardAccess.mockReturnValueOnce({ ok: false, backend: "external", name: "Linear", needed: ["configure the Linear MCP, or", "export LINEAR_API_KEY"] });
+    const logs = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+    const res = await envInstallCommand({ config, flags: {} });
+    spy.mockRestore();
+    expect(res.exitCode).toBe(3);
+    expect(res.boardError).toMatch(/Linear|LINEAR/);
+    expect(ragIndexCommand).not.toHaveBeenCalled(); // board first, RAG later
+    expect(logs.join("\n")).toMatch(/PENDING USER ACTION/);
   });
 
   it("a healthy first index does not block", async () => {


### PR DESCRIPTION
Parte 2/2 del cierre de #1287, con la regla del usuario: **sin board no hay Karajan** — el board garantiza que el código se desarrolle bien, en orden y con worktrees con sentido. No existe `none`.

- `verifyBoardAccess`: **hu-board** OK por construcción (viaja en el tarball); **planning-game** exige su MCP en alguna config del agente anfitrión (`.mcp.json` del proyecto, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`); **external** exige el MCP del board nombrado O un token de API (convención por board — LINEAR_API_KEY, TRELLO_TOKEN, JIRA_API_TOKEN, GITHUB_TOKEN, ASANA_ACCESS_TOKEN — o el `board.token_env` que declare el config).
- Sin vía de acceso → **bloqueo PENDING-USER-ACTION (exit 3)** con los pasos exactos, ANTES incluso del paso del RAG — el board es más fundamental. El playbook queda instalado.
- Detección por presencia y agnóstica de formato (las configs se escanean como texto); v1 verifica que existe la vía, no la conectividad.

Fixes #1287.