### PR TITLE
feat(gates): card-first gate (KJC-TSK-0686, MG-A)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -11,6 +11,24 @@ import { runOneShotReview } from "../review/one-shot-review.js";
 import { runSolomonArbitration } from "../review/solomon-arbitration.js";
 import { ensureGateTrackable } from "../review/gate-gitignore.js";
 import { runSonarPregate, formatSonarFinding } from "../review/sonar-pregate.js";
+import { checkCardFirst } from "../review/card-first.js";
+
+// KJC-TSK-0686 (MG-A): card-first is a gate, not a habit. Runs on --staged
+// (before spending sonar/reviewer effort) AND on --check — the pre-commit
+// hook already calls --check, so existing projects gain the gate with a
+// simple package update, no hook regeneration.
+async function enforceCardFirst({ config, projectDir }) {
+  const branchRes = await runCommand("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const branch = branchRes.stdout?.trim() || "HEAD";
+  const card = await checkCardFirst({ config, projectDir, branch });
+  if (card.mode === "warn") console.log(`⚠ card-first: ${card.reason}`);
+  if (card.mode === "exempt" && card.reason.includes("KJ_ALLOW_NO_CARD")) console.log(`⚠ card-first exempt: ${card.reason}`);
+  if (!card.ok) {
+    console.log(`✗ card-first gate: ${card.reason}`);
+    process.exitCode = 1;
+  }
+  return card;
+}
 
 // Raw git always — never a wrapped/compressing runner (KJC-BUG-0115).
 async function rawDiff(range, extraArgs = []) {
@@ -86,6 +104,9 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   }
 
   const diff = await rawDiff(flags.range);
+
+  const card = await enforceCardFirst({ config, projectDir });
+  if (!card.ok) return { verdict: "rejected", reviewer: "card-first", issues: [{ severity: "high", description: card.reason }] };
 
   if (flags.check) {
     const res = await checkVerdict(projectDir, diff);

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -67,6 +67,14 @@ const DEFAULTS = {
   // "none": Karajan does not run without a board.
   state_backend: "hu-board",
   board: { name: null },
+  // Method gates (KJC-PCS-0068): rules climb from playbook text to
+  // deterministic enforcement. card_first: "auto" = block with hu-board
+  // (fully verifiable), warn with planning-game/external (presence only);
+  // explicit "warn" | "block" override. Release branches are exempt.
+  method_gates: {
+    card_first: "auto",
+    card_first_exempt_branches: ["chore/release-"]
+  },
   review_rules: "./.karajan/review-rules.md",
   coder_rules: "./.karajan/coder-rules.md",
   base_branch: "main",

--- a/src/review/card-first.js
+++ b/src/review/card-first.js
@@ -1,0 +1,87 @@
+/**
+ * Card-first gate (KJC-TSK-0686, MG-A of épica KJC-PCS-0068). v3 obeyed
+ * but couldn't think; v4 thinks but narrates — so the rule that every
+ * piece of work starts from a card stops living in playbook text and
+ * moves into the gate. With hu-board the check is fully deterministic:
+ * the branch must reference a LIVE card (block by default). With
+ * planning-game/external boards, liveness can't be verified locally, so
+ * a card-shaped reference is required (warn by default, block via
+ * `method_gates.card_first`). Exemptions are explicit and visible:
+ * configured branch prefixes (releases) and KJ_ALLOW_NO_CARD=1.
+ */
+import { listPlans, loadPlan } from "../plan/plan-store.js";
+import { escapeRegExp } from "../utils/escape-regexp.js";
+
+const LIVE_STATUSES = new Set(["pending", "running", "failed"]);
+// Card-shaped reference: LIN-123, KJC-TSK-0684, bb-002… anchored on a
+// letter, short alnum head, dash, digits — tight enough to skip slugs.
+const CARD_REF_RE = /\b[a-z][a-z0-9]{1,9}-\d{1,6}\b/i;
+const DEFAULT_EXEMPT_PREFIXES = ["chore/release-"];
+
+// Token-boundary match: BB-002 must not satisfy a branch that actually
+// references BB-0022 (reviewer catch — substring matching allowed work
+// onto the wrong card).
+function refInBranch(ref, branchLower) {
+  return new RegExp(`(^|[^a-z0-9])${escapeRegExp(String(ref).toLowerCase())}([^a-z0-9]|$)`).test(branchLower);
+}
+
+async function findLiveCardInBranch(projectDir, branch) {
+  const needle = branch.toLowerCase();
+  // Scan EVERY match before deciding: any live reference satisfies the
+  // gate; a closed one is only reported when no live match exists
+  // (reviewer catch — first-match could reject a branch that also
+  // references a live card, depending on plan iteration order).
+  let closedHit = null;
+  for (const meta of await listPlans(projectDir)) {
+    const plan = await loadPlan(projectDir, meta.planId);
+    for (const h of plan.hus || []) {
+      for (const ref of [h.short_id, h.id]) {
+        if (ref && refInBranch(ref, needle)) {
+          if (LIVE_STATUSES.has(h.status)) return { ref, live: true, status: h.status };
+          closedHit = { ref, live: false, status: h.status };
+        }
+      }
+    }
+  }
+  return closedHit;
+}
+
+export async function checkCardFirst({ config = {}, projectDir = process.cwd(), branch, env = process.env }) {
+  if (env.KJ_ALLOW_NO_CARD === "1") {
+    return { ok: true, mode: "exempt", reason: "KJ_ALLOW_NO_CARD=1 (explicit escape hatch)" };
+  }
+  const exempt = config.method_gates?.card_first_exempt_branches || DEFAULT_EXEMPT_PREFIXES;
+  if (exempt.some((p) => branch.startsWith(p))) {
+    return { ok: true, mode: "exempt", reason: `branch prefix exempt (${branch.split("/")[0]}/…)` };
+  }
+  // The base branch belongs to the branch-first gate — card-first here
+  // would only double-report (and HEAD covers detached checkouts in CI).
+  if ([config.base_branch || "main", "main", "master", "HEAD"].includes(branch)) {
+    return { ok: true, mode: "exempt", reason: "base branch — the branch-first gate owns this case" };
+  }
+
+  const backend = config.state_backend || "hu-board";
+  const policy = config.method_gates?.card_first || "auto";
+
+  if (backend === "hu-board") {
+    const hit = await findLiveCardInBranch(projectDir, branch);
+    if (hit?.live) return { ok: true, mode: "pass", ref: hit.ref };
+    const effective = policy === "auto" ? "block" : policy;
+    const reason = hit
+      ? `branch references ${hit.ref} but its card is "${hit.status}" — card-first needs a live card (reopen it or create one: kj hu add)`
+      : `no live card referenced in branch "${branch}" — create it first (kj hu add "…" --id <REF>) and name the branch after it`;
+    return effective === "block"
+      ? { ok: false, mode: "block", reason }
+      : { ok: true, mode: "warn", reason };
+  }
+
+  // planning-game / external: presence check only — liveness lives in the
+  // project's own board, out of local reach.
+  if (CARD_REF_RE.test(branch)) return { ok: true, mode: "pass", ref: branch.match(CARD_REF_RE)[0] };
+  const effective = policy === "auto" ? "warn" : policy;
+  const boardName = config.board?.name || backend;
+  const reason = `no card reference in branch "${branch}" — card-first on ${boardName}: create the card there and name the branch after it (e.g. feat/ABC-123-summary)`;
+  return effective === "block"
+    ? { ok: false, mode: "block", reason }
+    : { ok: true, mode: "warn", reason };
+}

--- a/src/review/card-first.js
+++ b/src/review/card-first.js
@@ -1,13 +1,10 @@
 /**
- * Card-first gate (KJC-TSK-0686, MG-A of épica KJC-PCS-0068). v3 obeyed
- * but couldn't think; v4 thinks but narrates — so the rule that every
- * piece of work starts from a card stops living in playbook text and
- * moves into the gate. With hu-board the check is fully deterministic:
- * the branch must reference a LIVE card (block by default). With
- * planning-game/external boards, liveness can't be verified locally, so
- * a card-shaped reference is required (warn by default, block via
- * `method_gates.card_first`). Exemptions are explicit and visible:
- * configured branch prefixes (releases) and KJ_ALLOW_NO_CARD=1.
+ * Card-first gate (KJC-TSK-0686, MG-A of épica KJC-PCS-0068): the rule
+ * that work starts from a card moves from playbook text into the gate.
+ * hu-board → the branch must reference a LIVE card (block by default);
+ * planning-game/external → card-shaped reference required (warn default,
+ * block via method_gates.card_first). Exemptions explicit and visible:
+ * base branch, configured prefixes (releases), KJ_ALLOW_NO_CARD=1.
  */
 import { listPlans, loadPlan } from "../plan/plan-store.js";
 import { escapeRegExp } from "../utils/escape-regexp.js";

--- a/tests/review/card-first.test.js
+++ b/tests/review/card-first.test.js
@@ -1,0 +1,89 @@
+// KJC-TSK-0686 (MG-A, épica KJC-PCS-0068) — card-first stops being a
+// narratable habit: with hu-board, the branch must reference a LIVE card
+// or the commit does not enter; external boards get a presence check.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { checkCardFirst } from "../../src/review/card-first.js";
+import { savePlan } from "../../src/plan/plan-store.js";
+import { generatePlanId } from "../../src/plan/plan-id.js";
+
+let dir;
+beforeEach(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-cf-"));
+  await savePlan(dir, {
+    version: 2, planId: generatePlanId(), name: "backlog", task: "t", status: "ready",
+    createdAt: new Date().toISOString(),
+    hus: [
+      { id: "hu_p_001", short_id: "BB-002", title: "Viva", status: "running" },
+      { id: "hu_p_002", short_id: "OLD-9", title: "Cerrada", status: "done" },
+    ],
+  });
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+const hu = (branch, cfg = {}) => checkCardFirst({ config: cfg, projectDir: dir, branch, env: {} });
+
+describe("checkCardFirst — hu-board (verifiable, blocks by default)", () => {
+  it("passes when the branch references a LIVE card", async () => {
+    expect(await hu("feat/BB-002-cosa")).toMatchObject({ ok: true, ref: "BB-002" });
+    expect((await hu("feat/bb-002-cosa")).ok).toBe(true); // case-insensitive
+  });
+
+  it("does not accept a live card as substring of a DIFFERENT reference (BB-002 vs BB-0022)", async () => {
+    expect(await hu("feat/BB-0022-otra-cosa")).toMatchObject({ ok: false, mode: "block" });
+  });
+
+  it("a branch referencing a closed AND a live card passes on the live one", async () => {
+    expect(await hu("feat/OLD-9-continuado-en-BB-002")).toMatchObject({ ok: true, ref: "BB-002" });
+  });
+
+  it("blocks when the branch references nothing, or only a closed card", async () => {
+    expect(await hu("feat/mejora-suelta")).toMatchObject({ ok: false, mode: "block" });
+    const closed = await hu("feat/OLD-9-retomar");
+    expect(closed.ok).toBe(false);
+    expect(closed.reason).toMatch(/OLD-9|live|kj hu/i);
+  });
+
+  it("policy can be relaxed to warn via method_gates.card_first", async () => {
+    const r = await hu("feat/sin-card", { method_gates: { card_first: "warn" } });
+    expect(r).toMatchObject({ ok: true, mode: "warn" });
+  });
+});
+
+describe("checkCardFirst — external / planning-game (presence check, warns by default)", () => {
+  const ext = { state_backend: "external", board: { name: "Linear" } };
+
+  it("passes on a card-shaped reference in the branch", async () => {
+    expect(await checkCardFirst({ config: ext, projectDir: dir, branch: "jorge/lin-123-fix", env: {} }))
+      .toMatchObject({ ok: true });
+  });
+
+  it("warns (not blocks) by default without a reference; block via config", async () => {
+    const w = await checkCardFirst({ config: ext, projectDir: dir, branch: "feat/cosas", env: {} });
+    expect(w).toMatchObject({ ok: true, mode: "warn" });
+    const b = await checkCardFirst({
+      config: { ...ext, method_gates: { card_first: "block" } },
+      projectDir: dir, branch: "feat/cosas", env: {},
+    });
+    expect(b).toMatchObject({ ok: false, mode: "block" });
+  });
+});
+
+describe("checkCardFirst — exemptions", () => {
+  it("release branches are exempt by default, visibly", async () => {
+    expect(await hu("chore/release-v4.6.0")).toMatchObject({ ok: true, mode: "exempt" });
+  });
+
+  it("the base branch is exempt — branch-first owns it", async () => {
+    expect(await hu("main")).toMatchObject({ ok: true, mode: "exempt" });
+    expect(await hu("master")).toMatchObject({ ok: true, mode: "exempt" });
+  });
+
+  it("KJ_ALLOW_NO_CARD=1 is the explicit escape hatch", async () => {
+    const r = await checkCardFirst({ config: {}, projectDir: dir, branch: "feat/sin-card", env: { KJ_ALLOW_NO_CARD: "1" } });
+    expect(r).toMatchObject({ ok: true, mode: "exempt" });
+  });
+});

--- a/tests/review/card-first.test.js
+++ b/tests/review/card-first.test.js
@@ -73,16 +73,10 @@ describe("checkCardFirst — external / planning-game (presence check, warns by 
 });
 
 describe("checkCardFirst — exemptions", () => {
-  it("release branches are exempt by default, visibly", async () => {
-    expect(await hu("chore/release-v4.6.0")).toMatchObject({ ok: true, mode: "exempt" });
-  });
-
-  it("the base branch is exempt — branch-first owns it", async () => {
-    expect(await hu("main")).toMatchObject({ ok: true, mode: "exempt" });
-    expect(await hu("master")).toMatchObject({ ok: true, mode: "exempt" });
-  });
-
-  it("KJ_ALLOW_NO_CARD=1 is the explicit escape hatch", async () => {
+  it("release branches and the base branch are exempt; KJ_ALLOW_NO_CARD=1 is the escape hatch", async () => {
+    for (const branch of ["chore/release-v4.6.0", "main", "master"]) {
+      expect(await hu(branch)).toMatchObject({ ok: true, mode: "exempt" });
+    }
     const r = await checkCardFirst({ config: {}, projectDir: dir, branch: "feat/sin-card", env: { KJ_ALLOW_NO_CARD: "1" } });
     expect(r).toMatchObject({ ok: true, mode: "exempt" });
   });


### PR DESCRIPTION
Primera pieza de la épica **Method gates (KJC-PCS-0068)** — decisión del usuario: v3 mandaba sin inteligencia, v4 piensa pero narra; cada regla del método sube de texto a gate hasta su techo determinista.

**Card-first deja de ser costumbre**:
- **hu-board** (verificable en local): la rama debe referenciar una card VIVA (pending/running/failed) por short_id o id — matching con fronteras de token y escaneo completo prefiriendo vivas (dos catches del reviewer incorporados). Sin card viva → **bloqueo** con el mensaje accionable.
- **planning-game / external**: la vitalidad vive fuera del alcance local — chequeo de presencia de referencia con forma de card en la rama (`abc-123`); **warn** por defecto, `method_gates.card_first: block` lo endurece.
- **Exenciones explícitas y visibles**: rama base (ese caso es del gate branch-first), prefijos configurables (`chore/release-` de serie) y `KJ_ALLOW_NO_CARD=1`.
- **Cableado en `kj review --staged`** (antes del sonar: un bloqueo no gasta ni un token) **y en `--check`** — el hook pre-commit existente ya llama a `--check`, así que **todos los proyectos ganan el gate al actualizar el paquete, sin regenerar hooks**.

Dogfooded: este mismo PR pasó por su propio gate (repo declarado `state_backend: planning-game`, referencia `tsk-0686` en la rama).