### PR TITLE
feat(gates): tests-with-code gate (KJC-TSK-0687, MG-B)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -12,6 +12,7 @@ import { runSolomonArbitration } from "../review/solomon-arbitration.js";
 import { ensureGateTrackable } from "../review/gate-gitignore.js";
 import { runSonarPregate, formatSonarFinding } from "../review/sonar-pregate.js";
 import { checkCardFirst } from "../review/card-first.js";
+import { checkTestsWithCode } from "../review/tests-with-code.js";
 
 // KJC-TSK-0686 (MG-A): card-first is a gate, not a habit. Runs on --staged
 // (before spending sonar/reviewer effort) AND on --check — the pre-commit
@@ -108,6 +109,18 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   const card = await enforceCardFirst({ config, projectDir });
   if (!card.ok) return { verdict: "rejected", reviewer: "card-first", issues: [{ severity: "high", description: card.reason }] };
 
+  // KJC-TSK-0687 (MG-B): the verifiable half of TDD — sources without a
+  // single test change warn (block via method_gates.tests_with_code).
+  const changedFiles = (await rawDiff(flags.range, ["--name-only"])).split("\n").map((f) => f.trim()).filter(Boolean);
+  const tests = checkTestsWithCode({ config, stagedFiles: changedFiles });
+  if (tests.mode === "warn") console.log(`⚠ tests-with-code: ${tests.reason}`);
+  if (tests.mode === "exempt") console.log(`⚠ tests-with-code exempt: ${tests.reason}`);
+  if (!tests.ok) {
+    console.log(`✗ tests-with-code gate: ${tests.reason}`);
+    process.exitCode = 1;
+    return { verdict: "rejected", reviewer: "tests-with-code", issues: [{ severity: "high", description: tests.reason }] };
+  }
+
   if (flags.check) {
     const res = await checkVerdict(projectDir, diff);
     console.log(res.ok
@@ -123,8 +136,7 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   // the cross-AI reviewer weighs them. Unavailable sonar degrades loudly.
   let task = flags.task;
   if (flags.sonar !== false) {
-    const files = (await rawDiff(flags.range, ["--name-only"])).split("\n").map((f) => f.trim()).filter(Boolean);
-    const pre = await runSonarPregate({ config, stagedFiles: files, logger });
+    const pre = await runSonarPregate({ config, stagedFiles: changedFiles, logger });
     if (!pre.available) {
       console.log(`⚠ sonar pre-gate skipped: ${pre.reason}`);
     } else {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -73,7 +73,9 @@ const DEFAULTS = {
   // explicit "warn" | "block" override. Release branches are exempt.
   method_gates: {
     card_first: "auto",
-    card_first_exempt_branches: ["chore/release-"]
+    card_first_exempt_branches: ["chore/release-"],
+    // MG-B: source changes without a test change — "warn" | "block".
+    tests_with_code: "warn"
   },
   review_rules: "./.karajan/review-rules.md",
   coder_rules: "./.karajan/coder-rules.md",

--- a/src/review/tests-with-code.js
+++ b/src/review/tests-with-code.js
@@ -1,0 +1,33 @@
+/**
+ * Tests-with-code gate (KJC-TSK-0687, MG-B of épica KJC-PCS-0068). The
+ * verifiable half of TDD is deterministic: a staged diff that touches
+ * source files without touching a single test warns — or blocks, via
+ * `method_gates.tests_with_code`. Test-FIRST remains the reviewer's
+ * judgment; test-PRESENT belongs to the gate. Patterns come from the
+ * project's own `development.*` config (same ones headless enforces).
+ * KJ_ALLOW_NO_TESTS=1 is the explicit escape hatch.
+ */
+
+const DEFAULT_TEST_PATTERNS = ["/tests/", "/__tests__/", ".test.", ".spec."];
+const DEFAULT_SOURCE_EXTS = [".js", ".jsx", ".ts", ".tsx", ".py", ".go", ".java", ".rb", ".php", ".cs"];
+
+export function checkTestsWithCode({ config = {}, stagedFiles = [], env = process.env }) {
+  if (env.KJ_ALLOW_NO_TESTS === "1") {
+    return { ok: true, mode: "exempt", reason: "KJ_ALLOW_NO_TESTS=1 (explicit escape hatch)" };
+  }
+  const patterns = config.development?.test_file_patterns || DEFAULT_TEST_PATTERNS;
+  const exts = config.development?.source_file_extensions || DEFAULT_SOURCE_EXTS;
+  // Staged paths are repo-relative (no leading slash) — normalize so the
+  // "/tests/" style patterns also match the top-level tests directory.
+  const isTest = (f) => patterns.some((p) => `/${f}`.includes(p));
+  const sources = stagedFiles.filter((f) => !isTest(f) && exts.some((e) => f.endsWith(e)));
+  const hasTests = stagedFiles.some(isTest);
+
+  if (sources.length === 0 || hasTests) return { ok: true, mode: "pass" };
+
+  const policy = config.method_gates?.tests_with_code || "warn";
+  const reason = `source changes without any test change (${sources.slice(0, 5).join(", ")}${sources.length > 5 ? "…" : ""}) — the failing test comes first; add one or KJ_ALLOW_NO_TESTS=1 for a deliberate exception`;
+  return policy === "block"
+    ? { ok: false, mode: "block", sources, reason }
+    : { ok: true, mode: "warn", sources, reason };
+}

--- a/tests/review/tests-with-code.test.js
+++ b/tests/review/tests-with-code.test.js
@@ -1,0 +1,41 @@
+// KJC-TSK-0687 (MG-B, épica KJC-PCS-0068) — the verifiable half of TDD is
+// deterministic: a staged diff that touches source code without touching
+// any test warns (or blocks, by config). Test-FIRST stays with the
+// reviewer; test-PRESENT belongs to the gate.
+
+import { describe, it, expect } from "vitest";
+import { checkTestsWithCode } from "../../src/review/tests-with-code.js";
+
+const run = (files, cfg = {}, env = {}) => checkTestsWithCode({ config: cfg, stagedFiles: files, env });
+
+describe("checkTestsWithCode", () => {
+  it("warns by default when sources change without any test change", () => {
+    const r = run(["src/commands/foo.js", "src/utils/bar.js"]);
+    expect(r).toMatchObject({ ok: true, mode: "warn" });
+    expect(r.sources).toEqual(["src/commands/foo.js", "src/utils/bar.js"]);
+  });
+
+  it("passes when a test accompanies the code (any configured pattern)", () => {
+    for (const test of ["tests/foo.test.js", "src/__tests__/bar.js", "lib/x.spec.ts"]) {
+      expect(run(["src/foo.js", test]).mode).toBe("pass");
+    }
+  });
+
+  it("docs/config-only diffs pass silently — no source extensions touched", () => {
+    expect(run(["README.md", "kj.config.yml", "docs/guide.md"]).mode).toBe("pass");
+  });
+
+  it("block via method_gates.tests_with_code; KJ_ALLOW_NO_TESTS=1 is the escape", () => {
+    const blocked = run(["src/foo.py"], { method_gates: { tests_with_code: "block" } });
+    expect(blocked).toMatchObject({ ok: false, mode: "block" });
+    const escaped = run(["src/foo.py"], { method_gates: { tests_with_code: "block" } }, { KJ_ALLOW_NO_TESTS: "1" });
+    expect(escaped).toMatchObject({ ok: true, mode: "exempt" });
+  });
+
+  it("respects the project's own patterns from development.*", () => {
+    const cfg = { development: { test_file_patterns: ["/checks/"], source_file_extensions: [".go"] } };
+    expect(run(["main.go", "checks/main_check.go"], cfg).mode).toBe("pass");
+    expect(run(["main.go"], cfg).mode).toBe("warn");
+    expect(run(["src/app.js"], cfg).mode).toBe("pass"); // .js not a source ext here
+  });
+});


### PR DESCRIPTION
Segunda pieza de Method gates (KJC-PCS-0068): la mitad verificable del TDD se vuelve determinista. Diff staged con fuentes sin tests -> warn con la lista (block via method_gates.tests_with_code); patrones del propio proyecto; KJ_ALLOW_NO_TESTS=1 como excepcion visible; docs/config pasan en silencio; corre en --staged y --check.