### PR TITLE
feat(gates): runtime nudges (KJC-TSK-0688, MG-C)

### DIFF
--- a/src/commands/hu.js
+++ b/src/commands/hu.js
@@ -175,11 +175,13 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
     // silently moving the first hit could move the wrong card.
     const byId = [];
     const byShort = [];
+    const running = [];
     for (const meta of await listPlans(projectDir)) {
       const plan = await loadPlan(projectDir, meta.planId);
       for (const hu of plan.hus || []) {
         if (hu.id === ref) byId.push({ plan, hu });
         else if (hu.short_id === ref) byShort.push({ plan, hu });
+        if (hu.status === "running") running.push(hu);
       }
     }
     const matches = byId.length > 0 ? byId : byShort;
@@ -189,6 +191,16 @@ export async function huCommand({ config = null, action, args = [], flags = {} }
       throw new Error(`"${ref}" is ambiguous (${matches.length} matches: ${ids}) — use the full id`);
     }
     const { plan, hu } = matches[0];
+    // KJC-TSK-0688 (MG-C): the nudge fires AT the deviation — a second
+    // concurrent task belongs in its own lane, not in the shared tree.
+    const others = running.filter((r) => r.id !== hu.id);
+    if (status === "running" && hu.status !== "running" && others.length > 0) {
+      const slug = String(hu.short_id || hu.id).toLowerCase();
+      console.warn(
+        `⚠ ${others.map((r) => r.short_id || r.id).join(", ")} ${others.length === 1 ? "is" : "are"} already running — `
+        + `a second concurrent task should live in its own lane: kj worktree start ${slug}`
+      );
+    }
     updateHuStatus(plan, hu.id, status);
     await savePlan(projectDir, plan);
     return emit({ id: hu.id, status }, `✓ ${hu.short_id || hu.id} → ${status}`);

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -112,6 +112,17 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   // KJC-TSK-0687 (MG-B): the verifiable half of TDD — sources without a
   // single test change warn (block via method_gates.tests_with_code).
   const changedFiles = (await rawDiff(flags.range, ["--name-only"])).split("\n").map((f) => f.trim()).filter(Boolean);
+
+  // KJC-TSK-0688 (MG-C): oversized-diff nudge — informative only; the
+  // project's CI owns any hard budget. Sums additions from --numstat.
+  const sizeWarn = config?.method_gates?.pr_size_warn ?? 150;
+  if (sizeWarn > 0) {
+    const numstat = await rawDiff(flags.range, ["--numstat"]);
+    const added = numstat.split("\n").reduce((acc, l) => acc + (Number(l.split("\t")[0]) || 0), 0);
+    if (added > sizeWarn) {
+      console.log(`⚠ pr-size: ${added} lines added (guideline ~${sizeWarn}) — atomic PRs review better; consider splitting (method_gates.pr_size_warn to tune)`);
+    }
+  }
   const tests = checkTestsWithCode({ config, stagedFiles: changedFiles });
   if (tests.mode === "warn") console.log(`⚠ tests-with-code: ${tests.reason}`);
   if (tests.mode === "exempt") console.log(`⚠ tests-with-code exempt: ${tests.reason}`);

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -75,7 +75,10 @@ const DEFAULTS = {
     card_first: "auto",
     card_first_exempt_branches: ["chore/release-"],
     // MG-B: source changes without a test change — "warn" | "block".
-    tests_with_code: "warn"
+    tests_with_code: "warn",
+    // MG-C: informative nudge when the staged diff exceeds this many
+    // added lines (0 disables). The project's CI owns any hard budget.
+    pr_size_warn: 150
   },
   review_rules: "./.karajan/review-rules.md",
   coder_rules: "./.karajan/coder-rules.md",

--- a/tests/environment/brain-board-adr.test.js
+++ b/tests/environment/brain-board-adr.test.js
@@ -33,6 +33,28 @@ describe("kj hu", () => {
       .rejects.toThrow(/not found/);
   });
 
+  // KJC-TSK-0688 (MG-C): passive playbook orders get ignored — the nudge
+  // fires at the moment of the deviation: a SECOND concurrent task should
+  // live in its own lane.
+  it("moving a second HU to running nudges towards kj worktree start", async () => {
+    await huCommand({ config: cfg(), action: "add", args: ["Primera"], flags: { json: true, id: "T-A" } });
+    await huCommand({ config: cfg(), action: "add", args: ["Segunda"], flags: { json: true, id: "T-B" } });
+    await huCommand({ config: cfg(), action: "move", args: ["T-A", "running"], flags: { json: true } });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await huCommand({ config: cfg(), action: "move", args: ["T-B", "running"], flags: { json: true } });
+      const out = warn.mock.calls.flat().join("\n");
+      expect(out).toMatch(/kj worktree start/);
+      expect(out).toMatch(/T-A/); // names the other running card
+      warn.mockClear();
+      // no-op re-move (already running) must not re-nudge
+      await huCommand({ config: cfg(), action: "move", args: ["T-B", "running"], flags: { json: true } });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("move with an ambiguous ref across plans errors instead of guessing", async () => {
     const { savePlan } = await import("../../src/plan/plan-store.js");
     const { generatePlanId } = await import("../../src/plan/plan-id.js");


### PR DESCRIPTION
Tercera pieza de Method gates (KJC-PCS-0068): las reglas difíciles de gatear ganan fricción en caliente. Mover una SEGUNDA HU a running avisa con el comando exacto (kj worktree start <slug-de-la-nueva>) nombrando la que ya corría — solo en la transición real, los re-moves no-op callan (catch del reviewer). Y el diff staged por encima de method_gates.pr_size_warn (150 líneas añadidas, 0 desactiva) recibe nota informativa en el review — nunca bloquea, el CI del proyecto posee los presupuestos duros.