### PR TITLE
feat(gates): method adherence report (KJC-TSK-0689, MG-D)

### DIFF
--- a/src/checks/method.js
+++ b/src/checks/method.js
@@ -1,0 +1,73 @@
+/**
+ * Method report (KJC-TSK-0689, MG-D of épica KJC-PCS-0068). Individual
+ * deviations can each be legitimate — the AGGREGATE trail is the drift
+ * detector. Three measurable signals over the recent history: commit
+ * subjects without a card reference, review verdicts by workspace
+ * ([root] vs lanes), and source commits without a single test change.
+ * Informative by design; only a card-ref drought turns it into a warn.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { runCommand } from "../utils/process.js";
+import { checkTestsWithCode } from "../review/tests-with-code.js";
+import { CARD_REF_RE } from "../review/card-first.js";
+import { STRATEGY } from "./types.js";
+
+function recentVerdicts(projectDir, sample) {
+  try {
+    const dir = path.join(projectDir, ".karajan", "reviews");
+    return readdirSync(dir).filter((f) => f.endsWith(".json"))
+      .map((f) => JSON.parse(readFileSync(path.join(dir, f), "utf8")))
+      .sort((a, b) => String(b.timestamp).localeCompare(String(a.timestamp)))
+      .slice(0, sample);
+  } catch {
+    return [];
+  }
+}
+
+export async function collectMethodStats({ projectDir, run = runCommand, sample = 20 } = {}) {
+  const subjectsRes = await run("git", ["log", `-${sample}`, "--no-merges", "--format=%s"], { cwd: projectDir });
+  const subjects = subjectsRes.exitCode === 0 ? subjectsRes.stdout.split("\n").filter(Boolean) : [];
+
+  // "@%h" carries a % so git treats it as a literal format string — a bare
+  // "@" is rejected as an unknown pretty alias (caught in a live smoke).
+  const blocksRes = await run("git", ["log", `-${Math.min(sample, 10)}`, "--no-merges", "--name-only", "--format=@%h"], { cwd: projectDir });
+  const blocks = blocksRes.exitCode === 0
+    ? blocksRes.stdout.split(/^@.*$/m).map((b) => b.split("\n").map((l) => l.trim()).filter(Boolean)).filter((b) => b.length > 0)
+    : [];
+  const offenders = blocks.filter((files) => checkTestsWithCode({ config: {}, stagedFiles: files, env: {} }).mode !== "pass").length;
+
+  const verdicts = recentVerdicts(projectDir, sample);
+  const stamped = verdicts.filter((v) => v.workspace);
+
+  return {
+    commits: { total: subjects.length, withCard: subjects.filter((s) => CARD_REF_RE.test(s)).length },
+    verdicts: { total: verdicts.length, stamped: stamped.length, root: stamped.filter((v) => v.workspace === "root").length },
+    testless: { sampled: blocks.length, offenders },
+  };
+}
+
+export function formatMethodStats(s) {
+  return `commits with card ref ${s.commits.withCard}/${s.commits.total} · verdict workspaces root ${s.verdicts.root}/${s.verdicts.stamped || 0} stamped (${s.verdicts.total} total) · source commits without tests ${s.testless.offenders}/${s.testless.sampled}`;
+}
+
+function createMethodCheck() {
+  return {
+    name: "method",
+    label: "Method adherence (recent history)",
+    strategy: STRATEGY.NONE,
+    async detect({ config = {}, projectDir = process.cwd(), run = runCommand } = {}) {
+      const stats = await collectMethodStats({ projectDir, run, sample: config.method_gates?.report_sample || 20 });
+      const detail = formatMethodStats(stats);
+      const drought = stats.commits.total >= 5 && stats.commits.withCard / stats.commits.total < 0.5;
+      if (drought) {
+        return { ok: false, severity: "warn", detail: `most recent commits carry no card reference — ${detail}` };
+      }
+      return { ok: true, severity: "info", detail };
+    },
+  };
+}
+
+export function getMethodChecks() {
+  return [createMethodCheck()];
+}

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -5,17 +5,22 @@
  */
 
 import { checkHarden } from "../harden/check.js";
+import { collectMethodStats, formatMethodStats } from "../checks/method.js";
 
 export async function checkCommand({ projectDir = process.cwd(), profile = "standard", json = false, logger = console } = {}) {
   const result = await checkHarden({ projectDir, profile });
+  // KJC-TSK-0689 (MG-D): method adherence is VISIBILITY, not a gate — it
+  // rides along in check output but never affects the exit code.
+  const method = await collectMethodStats({ projectDir }).catch(() => null);
 
   if (json) {
-    logger.info?.(JSON.stringify(result));
+    logger.info?.(JSON.stringify({ ...result, method }));
     return result.ok ? 0 : 1;
   }
 
   logger.info?.(`kj check (${profile})`);
   for (const c of result.checks) logger.info?.(`  ${c.ok ? "✓" : "✗"} ${c.id}: ${c.detail}`);
+  if (method) logger.info?.(`  method: ${formatMethodStats(method)}`);
   if (!result.ok) logger.info?.("Harness drift detected — run `kj harden` to repair.");
   else logger.info?.("Harness OK.");
   return result.ok ? 0 : 1;

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -36,6 +36,7 @@ import { getDirSetupChecks } from "../checks/dir-setup.js";
 import { getProjectChecks } from "../checks/project-checks.js";
 import { getHardwareChecks } from "../checks/hardware.js";
 import { getOrphanChecks } from "../checks/orphans.js";
+import { getMethodChecks } from "../checks/method.js";
 
 /**
  * Build the list of Check objects applicable to the current config.
@@ -74,6 +75,7 @@ function buildChecks(config, { projectOnly = false } = {}) {
     ...getSqueezrChecks(),
     ...getAiTrashChecks(),
     ...getOrphanChecks(),
+    ...getMethodChecks(),
     ...getQmdChecks(),
     ...getRagHooksChecks({ projectDir }),
     ...getProjectChecks({ projectDir }),

--- a/src/review/card-first.js
+++ b/src/review/card-first.js
@@ -10,9 +10,10 @@ import { listPlans, loadPlan } from "../plan/plan-store.js";
 import { escapeRegExp } from "../utils/escape-regexp.js";
 
 const LIVE_STATUSES = new Set(["pending", "running", "failed"]);
-// Card-shaped reference: LIN-123, KJC-TSK-0684, bb-002… anchored on a
-// letter, short alnum head, dash, digits — tight enough to skip slugs.
-const CARD_REF_RE = /\b[a-z][a-z0-9]{1,9}-\d{1,6}\b/i;
+// Card-shaped reference: LIN-123, bb-002 and multi-segment ids like
+// KJC-TSK-0684 (optional middle segments) — tight enough to skip slugs.
+// Shared with the method report (MG-D): one pattern, one truth.
+export const CARD_REF_RE = /\b[a-z][a-z0-9]{1,9}(?:-[a-z][a-z0-9]{1,9})*-\d{1,6}\b/i;
 const DEFAULT_EXEMPT_PREFIXES = ["chore/release-"];
 
 // Token-boundary match: BB-002 must not satisfy a branch that actually

--- a/tests/checks/method.test.js
+++ b/tests/checks/method.test.js
@@ -1,0 +1,65 @@
+// KJC-TSK-0689 (MG-D) — the aggregate trail is the drift detector: the
+// human sees at a glance where the agent deviates (commits without card,
+// [root] reviews, source commits without tests), even when each single
+// case was legitimate.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { collectMethodStats, getMethodChecks } from "../../src/checks/method.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-mth-")); });
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+const gitRuns = ({ subjects, blocks }) => vi.fn(async (cmd, args) => {
+  if (args.includes("--format=%s")) return { exitCode: 0, stdout: subjects.join("\n") };
+  if (args.includes("--name-only")) return { exitCode: 0, stdout: blocks };
+  return { exitCode: 0, stdout: "" };
+});
+
+describe("collectMethodStats", () => {
+  it("counts card refs in subjects, verdict workspaces and testless source commits", async () => {
+    const reviews = path.join(dir, ".karajan", "reviews");
+    fs.mkdirSync(reviews, { recursive: true });
+    fs.writeFileSync(path.join(reviews, "a.json"), JSON.stringify({ verdict: "approved", workspace: "root", timestamp: "2026-07-24T10:00:00Z" }));
+    fs.writeFileSync(path.join(reviews, "b.json"), JSON.stringify({ verdict: "approved", workspace: "worktree:x", timestamp: "2026-07-24T11:00:00Z" }));
+    fs.writeFileSync(path.join(reviews, "c.json"), JSON.stringify({ verdict: "approved", timestamp: "2026-07-23T09:00:00Z" })); // pre-stamp era
+
+    const run = gitRuns({
+      subjects: ["feat: add gate (KJC-TSK-0686)", "fix: quick patch", "docs: readme"],
+      blocks: "@abc123\nsrc/a.js\ntests/a.test.js\n\n@def456\nsrc/b.js\n\n@0f9e8d\nREADME.md\n",
+    });
+    const s = await collectMethodStats({ projectDir: dir, run });
+    expect(s.commits).toMatchObject({ total: 3, withCard: 1 }); // multi-segment KJC-TSK-0686 counts
+    expect(s.verdicts).toMatchObject({ total: 3, stamped: 2, root: 1 });
+    expect(s.testless).toMatchObject({ sampled: 3, offenders: 1 }); // src/b.js alone
+  });
+
+  it("degrades to zeros outside a repo or without verdicts", async () => {
+    const run = vi.fn(async () => ({ exitCode: 128, stdout: "" }));
+    const s = await collectMethodStats({ projectDir: dir, run });
+    expect(s.commits.total).toBe(0);
+    expect(s.verdicts.total).toBe(0);
+  });
+});
+
+describe("card reference pattern (shared with card-first)", () => {
+  it("counts multi-segment ids like KJC-TSK-0686 as a single valid reference", async () => {
+    const run = gitRuns({ subjects: ["feat(gates): card-first gate (KJC-TSK-0686, MG-A)"], blocks: "" });
+    const s = await collectMethodStats({ projectDir: dir, run });
+    expect(s.commits).toMatchObject({ total: 1, withCard: 1 });
+  });
+});
+
+describe("method check for kj doctor", () => {
+  it("reports info normally and warn when most commits lack a card ref", async () => {
+    const check = getMethodChecks()[0];
+    const ok = await check.detect({ config: {}, projectDir: dir, run: gitRuns({ subjects: ["feat: x (ABC-1)", "fix: y (ABC-2)"], blocks: "" }) });
+    expect(ok.ok).toBe(true);
+    const bad = await check.detect({ config: {}, projectDir: dir, run: gitRuns({ subjects: ["a", "b", "c", "d", "e", "f"], blocks: "" }) });
+    expect(bad.severity).toBe("warn");
+    expect(bad.detail).toMatch(/card/i);
+  });
+});


### PR DESCRIPTION
Cuarta y última pieza de Method gates (KJC-PCS-0068): el rastro agregado es el detector de deriva. collectMethodStats sobre el histórico reciente — commits con referencia de card (patrón multi-segmento compartido con card-first, fuente única), workspaces de los veredictos (root vs carriles), commits con fuentes sin tests (un solo git log --name-only; formato @%h literal tras cazar en smoke real que @ pelado es inválido). Viaja en la salida de kj check sin tocar su exit code y como check del registro del doctor (warn solo con sequía de referencias <50%). Datos reales de este repo en el estreno: 13/20 con card, 19/19 veredictos estampados, 0/10 sin tests.