### PR TITLE
feat(update): version notice with highlights + agent protocol (KJC-TSK-0690)

### DIFF
--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -81,6 +81,8 @@ architect, tester, security, audit, board) · \`kj hu add|move|list\` ·
 
 Hit a kj bug or friction? Diagnose it and file it upstream with
 \`kj report-issue\` (sanitized; ask your user before \`--publish\`).
+kj announces a newer version? Tell your user what it brings and ask —
+never run \`kj update\` on your own.
 `;
 
 export function renderPlaybook({ stateBackend = "hu-board", boardName = null } = {}) {

--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -5,8 +5,38 @@ import { isSea } from "node:sea";
 import { getKarajanHome } from "./paths.js";
 
 const CACHE_FILE = "update-check.json";
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+// KJC-TSK-0690: 6h — kj can ship several releases a day; a session should
+// not work a full day blind. KJ_NO_UPDATE_CHECK=1 opts out (CI).
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 const PACKAGE_NAME = "karajan-code";
+const CHANGELOG_URL = "https://raw.githubusercontent.com/manufosela/karajan-code/main/CHANGELOG.md";
+const HIGHLIGHT_MAX = 160;
+
+/**
+ * First paragraph of a version's CHANGELOG section — the release headline
+ * ("Minor. **The method, enforced.** …"), bold stripped, truncated. Pure.
+ */
+export function parseChangelogHighlight(markdown, version) {
+  const section = String(markdown).split(new RegExp(`^## \\[${version.replaceAll(".", "\\.")}\\][^\\n]*$`, "m"))[1];
+  if (!section) return null;
+  const firstLine = section.split(/^##|^###/m)[0].split("\n").map((l) => l.trim()).find(Boolean);
+  if (!firstLine) return null;
+  const clean = firstLine.replaceAll("**", "");
+  return clean.length > HIGHLIGHT_MAX ? `${clean.slice(0, HIGHLIGHT_MAX - 1)}…` : clean;
+}
+
+async function fetchHighlight(version) {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const res = await fetch(CHANGELOG_URL, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    return parseChangelogHighlight(await res.text(), version);
+  } catch {
+    return null;
+  }
+}
 
 const RAW_BASE = "https://raw.githubusercontent.com/manufosela/karajan-code/main/scripts";
 export const INSTALL_SH_URL = `${RAW_BASE}/install-binary.sh`;
@@ -48,6 +78,7 @@ export function detectInstallChannel() {
  * Returns { updateAvailable, latest, current } or null if check fails/cached.
  */
 export async function checkForUpdate(currentVersion) {
+  if (process.env.KJ_NO_UPDATE_CHECK === "1") return null;
   try {
     const cachePath = path.join(getKarajanHome(), CACHE_FILE);
 
@@ -59,7 +90,7 @@ export async function checkForUpdate(currentVersion) {
         if (!cache.latest || cache.latest === currentVersion) return null;
         // Only show update if latest is actually NEWER than current
         if (compareVersions(cache.latest, currentVersion) > 0) {
-          return { updateAvailable: true, latest: cache.latest, current: currentVersion };
+          return { updateAvailable: true, latest: cache.latest, current: currentVersion, highlight: cache.highlight || null };
         }
         return null;
       }
@@ -78,14 +109,16 @@ export async function checkForUpdate(currentVersion) {
     const data = await res.json();
     const latest = data.version;
 
+    // KJC-TSK-0690: a NEWER version also fetches its headline once — the
+    // notice tells the user what it brings, not just that it exists.
+    const newer = latest !== currentVersion && compareVersions(latest, currentVersion) > 0;
+    const highlight = newer ? await fetchHighlight(latest) : null;
+
     // Save cache
     await fs.mkdir(getKarajanHome(), { recursive: true });
-    await fs.writeFile(cachePath, JSON.stringify({ latest, checkedAt: Date.now() }), "utf8");
+    await fs.writeFile(cachePath, JSON.stringify({ latest, checkedAt: Date.now(), highlight }), "utf8");
 
-    if (latest === currentVersion) return null;
-    if (compareVersions(latest, currentVersion) > 0) {
-      return { updateAvailable: true, latest, current: currentVersion };
-    }
+    if (newer) return { updateAvailable: true, latest, current: currentVersion, highlight };
     return null;
   } catch {
     return null; // Network error, offline, etc. Never block.
@@ -100,7 +133,9 @@ export async function printUpdateNotice(currentVersion) {
   if (result?.updateAvailable) {
     const channel = detectInstallChannel();
     console.log(`\n  Update available: v${result.current} → v${result.latest}`);
-    console.log(`  ${updateInstruction({ channel })}\n`);
+    if (result.highlight) console.log(`  What it brings: ${result.highlight}`);
+    console.log(`  ${updateInstruction({ channel })}`);
+    console.log("  Agent: tell your user and ask before updating — never update on your own.\n");
   }
 }
 

--- a/tests/update-check.test.js
+++ b/tests/update-check.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   checkForUpdate,
   updateInstruction,
+  parseChangelogHighlight,
   performSelfUpdate,
   INSTALL_SH_URL,
   INSTALL_PS1_URL,
@@ -35,6 +36,35 @@ describe("update-check", () => {
     expect(result).toBeNull();
   });
 
+  // KJC-TSK-0690: the notice tells the user WHAT the new version brings —
+  // the headline is the first paragraph of the version's CHANGELOG section.
+  it("parses the version headline from the changelog (bold stripped, truncated)", () => {
+    const md = "# Changelog\n\n## [Unreleased]\n\n## [4.6.0] - 2026-07-24\n\nMinor. **The method, enforced.** Rules climb to gates.\n\n### Added\n- stuff\n\n## [4.5.0] - 2026-07-24\n\nOther.\n";
+    expect(parseChangelogHighlight(md, "4.6.0")).toBe("Minor. The method, enforced. Rules climb to gates.");
+    expect(parseChangelogHighlight(md, "9.9.9")).toBeNull();
+    expect(parseChangelogHighlight("x".repeat(10), "4.6.0")).toBeNull();
+  });
+
+  it("KJ_NO_UPDATE_CHECK=1 skips everything, including the fetch", async () => {
+    process.env.KJ_NO_UPDATE_CHECK = "1";
+    try {
+      expect(await checkForUpdate("1.0.0")).toBeNull();
+      expect(global.fetch).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.KJ_NO_UPDATE_CHECK;
+    }
+  });
+
+  it("a fresh newer version carries the changelog highlight into result and cache", async () => {
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ version: "2.0.0" }) })
+      .mockResolvedValueOnce({ ok: true, text: async () => "## [2.0.0] - 2026-07-25\n\nMinor. **Big thing.** Details.\n" });
+    const r = await checkForUpdate("1.0.0");
+    expect(r).toMatchObject({ updateAvailable: true, latest: "2.0.0", highlight: "Minor. Big thing. Details." });
+    const cached = JSON.parse(fs.writeFile.mock.calls[0][1]);
+    expect(cached.highlight).toBe("Minor. Big thing. Details.");
+  });
+
   it("returns update info when npm has newer version", async () => {
     global.fetch.mockResolvedValue({
       ok: true,
@@ -45,6 +75,7 @@ describe("update-check", () => {
       updateAvailable: true,
       latest: "1.39.0",
       current: "1.38.2",
+      highlight: null,
     });
   });
 
@@ -78,6 +109,7 @@ describe("update-check", () => {
       updateAvailable: true,
       latest: "1.40.0",
       current: "1.38.2",
+      highlight: null,
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Preocupación del usuario: sesiones activas o nuevas con kj viejo trabajando a ciegas.

Lo que ya existía: cada invocación de kj hace un chequeo no bloqueante cacheado y avisa "Update available" con la instrucción por canal. Lo que faltaba:

- **Novedades**: al detectar versión nueva se trae UNA vez el titular de su sección del CHANGELOG (`parseChangelogHighlight`, negritas fuera, truncado a 160) y el aviso lo muestra: *What it brings: Minor. The method, enforced. …*
- **TTL 6h** (antes 24h — kj puede publicar varias veces al día; una sesión no debe pasar el día entero a ciegas). `KJ_NO_UPDATE_CHECK=1` lo omite (CI).
- **Protocolo del agente**, en el propio aviso Y en el playbook: *cuéntale a tu usuario qué trae y PREGUNTA — jamás `kj update` por tu cuenta.* La decisión de actualizar es siempre humana e informada.