### PR TITLE
chore(release): v4.6.1 — no session works blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.1] - 2026-07-25
+
+Patch. **No session works blind** — the update notice now tells you what the new version brings, and the agent asks before updating.
+
+### Added
+
+- **Update notice with release highlights** (KJC-TSK-0690): the per-invocation cached version check now fetches the new version's CHANGELOG headline once and prints it — `What it brings: Minor. The method, enforced. …` — alongside the channel-aware update instruction. Check TTL lowered to 6h (several releases can ship in a day); `KJ_NO_UPDATE_CHECK=1` skips it (CI). The notice and the playbook both order the agent: tell your user what it brings and ASK — never run `kj update` on your own. Updating is always a human, informed decision.
+
 ## [4.6.0] - 2026-07-24
 
 Minor. **The method, enforced.** v3 commanded but couldn't think; v4 thinks but narrates — so every method rule climbs from playbook text to its deterministic ceiling: gate, nudge, or trail (épica KJC-PCS-0068).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Release v4.6.1. Contenido ya mergeado en #1325: aviso de versión con el titular del CHANGELOG, TTL 6h, KJ_NO_UPDATE_CHECK=1 y protocolo del agente (informar + preguntar, jamás auto-actualizar).