### PR TITLE
feat(gates): pr-size block policy + out-of-AC decisions rule (KJC-TSK-0691, MG-E/G)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -113,14 +113,26 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   // single test change warn (block via method_gates.tests_with_code).
   const changedFiles = (await rawDiff(flags.range, ["--name-only"])).split("\n").map((f) => f.trim()).filter(Boolean);
 
-  // KJC-TSK-0688 (MG-C): oversized-diff nudge — informative only; the
-  // project's CI owns any hard budget. Sums additions from --numstat.
+  // KJC-TSK-0688 (MG-C) + KJC-TSK-0691 (MG-E): oversized-diff policy.
+  // Field case: a 522-line PR sailed past the warning with a
+  // rationalization — where the project wants teeth, pr_size: "block"
+  // rejects deterministically with a NAMED escape. Default stays warn.
   const sizeWarn = config?.method_gates?.pr_size_warn ?? 150;
   if (sizeWarn > 0) {
     const numstat = await rawDiff(flags.range, ["--numstat"]);
     const added = numstat.split("\n").reduce((acc, l) => acc + (Number(l.split("\t")[0]) || 0), 0);
     if (added > sizeWarn) {
-      console.log(`⚠ pr-size: ${added} lines added (guideline ~${sizeWarn}) — atomic PRs review better; consider splitting (method_gates.pr_size_warn to tune)`);
+      const sizePolicy = config?.method_gates?.pr_size || "warn";
+      if (process.env.KJ_ALLOW_LARGE_PR === "1") {
+        console.log(`⚠ pr-size exempt: ${added} lines added — KJ_ALLOW_LARGE_PR=1 (explicit escape hatch)`);
+      } else if (sizePolicy === "block") {
+        const reason = `${added} lines added exceeds the ${sizeWarn}-line budget (method_gates.pr_size: block) — partition the work, or get your user's explicit OK and re-run with KJ_ALLOW_LARGE_PR=1`;
+        console.log(`✗ pr-size gate: ${reason}`);
+        process.exitCode = 1;
+        return { verdict: "rejected", reviewer: "pr-size", issues: [{ severity: "high", description: reason }] };
+      } else {
+        console.log(`⚠ pr-size: ${added} lines added (guideline ~${sizeWarn}) — an oversized warning is not an opinion: partition, or ask your user (method_gates.pr_size: block to harden)`);
+      }
     }
   }
   const tests = checkTestsWithCode({ config, stagedFiles: changedFiles });

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -66,6 +66,10 @@ Invariants (the git gates enforce these — they are not suggestions):
   and it must be reviewed again. Disagree with a rejection? \`kj solomon\`.
 - Security findings are never overridable — not even by arbitration. You
   absorb the security role: \`kj brief security\` states what must be true.
+- A design decision the card's AC don't cover belongs to the USER: record
+  it as a proposed ADR (\`kj adr add\`) and ask — never bury it in a PR
+  bullet. An oversized-diff warning is not an opinion either: partition,
+  or get an explicit OK.
 - Branch first: never commit on the base branch — every change reaches it
   through an atomic PR (~150 net lines, Conventional Commits). More than one
   task, or the base tree must stay untouched? \`kj worktree start <slug>\`

--- a/tests/environment/playbook.test.js
+++ b/tests/environment/playbook.test.js
@@ -22,6 +22,8 @@ describe("renderPlaybook", () => {
       // get run) and demands the isolation proof.
       expect(text).toMatch(/kj worktree start/);
       expect(text).toMatch(/--git-common-dir/);
+      // KJC-TSK-0691 (MG-G): out-of-AC decisions go back to the user.
+      expect(text).toMatch(/proposed ADR/);
       expect(text.split("\n").length).toBeLessThanOrEqual(60);
     });
   }

--- a/tests/review/pr-size.test.js
+++ b/tests/review/pr-size.test.js
@@ -1,0 +1,70 @@
+// KJC-TSK-0691 (MG-E) — field case: a 522-line PR sailed past the warning
+// with a rationalization. Where the project wants teeth, pr_size becomes a
+// block with a NAMED escape; the default stays warn.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const reviewMock = vi.fn();
+vi.mock("../../src/review/one-shot-review.js", () => ({ runOneShotReview: (...a) => reviewMock(...a) }));
+vi.mock("../../src/review/sonar-pregate.js", async (orig) => ({
+  ...(await orig()), runSonarPregate: vi.fn().mockResolvedValue({ available: false, reason: "test" }),
+}));
+vi.mock("../../src/review/card-first.js", async (orig) => ({
+  ...(await orig()), checkCardFirst: vi.fn().mockResolvedValue({ ok: true, mode: "pass" }),
+}));
+
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); delete process.env.KJ_ALLOW_LARGE_PR; });
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-prsize-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.writeFileSync(path.join(dir, "a.js"), "base\n");
+  git("add", "a.js"); git("commit", "-qm", "base");
+  fs.writeFileSync(path.join(dir, "a.js"), Array.from({ length: 300 }, (_, i) => `line ${i}`).join("\n"));
+  fs.writeFileSync(path.join(dir, "tests.test.js"), "test\n");
+  git("add", "-A");
+  process.chdir(dir);
+  reviewMock.mockResolvedValue({ verdict: "approved", reviewer: "codex", diffHash: "abc123456789" });
+});
+
+const cfg = (pr_size) => ({ projectDir: dir, method_gates: { pr_size, pr_size_warn: 150 } });
+
+describe("pr-size policy", () => {
+  it("block rejects an oversized diff WITHOUT invoking the reviewer, naming the escape", async () => {
+    const logs = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+    const r = await reviewGateCommand({ config: cfg("block"), flags: { staged: true } });
+    spy.mockRestore();
+    expect(r).toMatchObject({ verdict: "rejected", reviewer: "pr-size" });
+    expect(reviewMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(logs.join("\n")).toMatch(/KJ_ALLOW_LARGE_PR/);
+  });
+
+  it("KJ_ALLOW_LARGE_PR=1 is the explicit, visible escape", async () => {
+    process.env.KJ_ALLOW_LARGE_PR = "1";
+    const logs = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
+    const r = await reviewGateCommand({ config: cfg("block"), flags: { staged: true } });
+    spy.mockRestore();
+    expect(r.verdict).toBe("approved");
+    expect(logs.join("\n")).toMatch(/pr-size exempt/i);
+  });
+
+  it("default policy stays warn — review proceeds", async () => {
+    const r = await reviewGateCommand({ config: cfg(undefined), flags: { staged: true } });
+    expect(r.verdict).toBe("approved");
+    expect(reviewMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Caso de campo del usuario: otro agente racionalizó una PR de 522 líneas ('es la unidad mínima de la card') y decidió un esquema unilateralmente ('decisión que tomé'). Donde solo hay warning, el agente negocia.

- **MG-E**: `method_gates.pr_size: block` — el review rechaza determinísticamente por encima del umbral SIN invocar al reviewer, nombrando el escape (`KJ_ALLOW_LARGE_PR=1`, visible y deliberado). El default sigue `warn`, ahora con lenguaje sin ambigüedad: *an oversized warning is not an opinion*.
- **MG-G**: el playbook ordena que toda decisión de diseño no cubierta por los AC de la card se registre como **ADR propuesto** (`kj adr add`) y se PREGUNTE al usuario — jamás enterrada en un bullet del PR.