### PR TITLE
feat(harden): prepare-commit-msg card stamp (KJC-TSK-0692, MG-F)

### DIFF
--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -16,8 +16,8 @@ export const SHEBANG = "#!/usr/bin/env sh";
 /** Hooks enabled per profile. */
 export const PROFILE_HOOKS = {
   minimal: ["commit-msg"],
-  standard: ["pre-commit", "commit-msg", "pre-push", "post-merge"],
-  strict: ["pre-commit", "commit-msg", "pre-push", "post-merge"],
+  standard: ["pre-commit", "prepare-commit-msg", "commit-msg", "pre-push", "post-merge"],
+  strict: ["pre-commit", "prepare-commit-msg", "commit-msg", "pre-push", "post-merge"],
 };
 
 /** Build the managed body for a single hook. */
@@ -99,6 +99,37 @@ export function hookBody(hook, cmds = {}, { globalHooksDir = null, baseBranch = 
       else lines.push("# (no test command detected for this stack)");
       return [...lines, ...chain].join("\n");
     }
+    case "prepare-commit-msg":
+      // KJC-TSK-0692 (MG-F): the branch already carries the card ref
+      // (validated by the card-first gate) — the subject inherits it
+      // automatically. A convention that enforces itself needs no adoption.
+      return [
+        'msg_file="$1"',
+        'branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")',
+        "# POSIX-safe extraction (no grep -o): the ref is the leading",
+        "# card-shaped token of the branch's last segment (feat/REF-desc).",
+        "seg=$(printf '%s' \"$branch\" | tr '[:upper:]' '[:lower:]'); seg=\"${seg##*/}\"",
+        "ref=$(printf '%s' \"$seg\" | sed -nE 's/^([a-z][a-z0-9]{1,9}(-[a-z][a-z0-9]{1,9})*-[0-9]{1,6})(-.*)?$/\\1/p')",
+        'header=$(head -n1 "$msg_file")',
+        'if [ -n "$ref" ] && [ -n "$header" ]; then',
+        '  case "$header" in',
+        "    Merge*|fixup!*|squash!*) ;;",
+        "    *)",
+        "      # Boundary match — a header mentioning KJW-TSK-00011 must not",
+        "      # suppress the KJW-TSK-0001 stamp. $ref is [a-z0-9-] only by",
+        "      # construction (sed extraction above), safe inside the ERE.",
+        '      if ! printf \'%s\' "$header" | grep -qiE "(^|[^a-zA-Z0-9-])$ref([^a-zA-Z0-9-]|$)"; then',
+        "        stamp=$(printf '%s' \"$ref\" | tr '[:lower:]' '[:upper:]')",
+        '        new_header="$header ($stamp)"',
+        '        if [ "${#new_header}" -le 100 ]; then',
+        "          { printf '%s\\n' \"$new_header\"; tail -n +2 \"$msg_file\"; } > \"$msg_file.kjtmp\" && mv \"$msg_file.kjtmp\" \"$msg_file\"",
+        "        fi",
+        "      fi",
+        "      ;;",
+        "  esac",
+        "fi",
+        ...chain,
+      ].join("\n");
     case "post-merge":
       return [
         "# Refresh the local RAG index so retrieval never serves stale code.",

--- a/tests/commands/harden.test.js
+++ b/tests/commands/harden.test.js
@@ -42,7 +42,7 @@ describe("hardenCommand", () => {
   it("installs hooks and reports ok", async () => {
     const res = await hardenCommand({ projectDir: repo, profile: "standard", logger });
     expect(res.ok).toBe(true);
-    expect(res.hooks).toHaveLength(4);
+    expect(res.hooks).toHaveLength(5);
     expect(existsSync(join(repo, ".karajan", "hooks", "commit-msg"))).toBe(true);
     expect(logger.info).toHaveBeenCalled();
   });

--- a/tests/harden/commit-stamp.test.js
+++ b/tests/harden/commit-stamp.test.js
@@ -1,0 +1,74 @@
+// KJC-TSK-0692 (MG-F) — field case: "commits with card ref 0/4" while the
+// agent asked whether to adopt the convention. A convention that enforces
+// itself needs no adoption: prepare-commit-msg stamps the branch's card
+// ref into the subject. Functional tests run the REAL generated script.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { hookBody, PROFILE_HOOKS } from "../../src/harden/hook-templates.js";
+
+let dir, script;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-stamp-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.writeFileSync(path.join(dir, "a"), "x");
+  git("add", "a"); git("commit", "-qm", "base");
+  script = path.join(dir, "prepare-commit-msg.sh");
+  fs.writeFileSync(script, `#!/bin/sh\n${hookBody("prepare-commit-msg", {}, {})}\n`);
+  fs.chmodSync(script, 0o755);
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+const onBranch = (name) => execFileSync("git", ["-C", dir, "checkout", "-qb", name]);
+const runHook = (message) => {
+  const msgFile = path.join(dir, "MSG");
+  fs.writeFileSync(msgFile, message);
+  execFileSync("sh", [script, msgFile], { cwd: dir });
+  return fs.readFileSync(msgFile, "utf8");
+};
+
+describe("prepare-commit-msg card stamp", () => {
+  it("stamps the branch's card ref into a bare subject (uppercased)", () => {
+    onBranch("feat/kjw-tsk-0001-validator");
+    expect(runHook("feat: add validator\n")).toBe("feat: add validator (KJW-TSK-0001)\n");
+  });
+
+  it("does not duplicate when the subject already carries the ref (any case)", () => {
+    onBranch("feat/KJW-TSK-0001-validator");
+    expect(runHook("feat: add validator (kjw-tsk-0001)\n")).toBe("feat: add validator (kjw-tsk-0001)\n");
+  });
+
+  it("leaves merges, refless branches and over-limit headers untouched", () => {
+    onBranch("feat/KJW-TSK-0001-x");
+    expect(runHook("Merge branch 'main'\n")).toBe("Merge branch 'main'\n");
+    const long = `feat: ${"x".repeat(90)}`;
+    expect(runHook(`${long}\n`)).toBe(`${long}\n`); // stamping would exceed 100
+    onBranch("feat/sin-referencia");
+    expect(runHook("feat: cosa\n")).toBe("feat: cosa\n");
+    // the numeric suffix needs a real delimiter — kjc-tsk-0692x is NOT
+    // a reference to kjc-tsk-0692 (reviewer catch)
+    onBranch("feat/kjc-tsk-0692x");
+    expect(runHook("feat: cosa\n")).toBe("feat: cosa\n");
+  });
+
+  it("a header mentioning a LONGER id still gets the branch's stamp (boundary match)", () => {
+    onBranch("feat/KJW-TSK-0001-x");
+    expect(runHook("feat: relates to KJW-TSK-00011\n")).toBe("feat: relates to KJW-TSK-00011 (KJW-TSK-0001)\n");
+  });
+
+  it("preserves the message body below the subject", () => {
+    onBranch("feat/KJW-TSK-0002-y");
+    expect(runHook("fix: y\n\nbody line\n")).toBe("fix: y (KJW-TSK-0002)\n\nbody line\n");
+  });
+
+  it("ships in the standard and strict profiles", () => {
+    expect(PROFILE_HOOKS.standard).toContain("prepare-commit-msg");
+    expect(PROFILE_HOOKS.strict).toContain("prepare-commit-msg");
+    expect(PROFILE_HOOKS.minimal).not.toContain("prepare-commit-msg");
+  });
+});

--- a/tests/harden/harden-engine.test.js
+++ b/tests/harden/harden-engine.test.js
@@ -24,7 +24,7 @@ afterEach(() => {
 describe("installHooks", () => {
   it("installs the standard profile as executable managed hooks and sets hooksPath", async () => {
     const res = await installHooks({ projectDir: repo, profile: "standard" });
-    expect(res.hooks.map((h) => h.hook).sort()).toEqual(["commit-msg", "post-merge", "pre-commit", "pre-push"]);
+    expect(res.hooks.map((h) => h.hook).sort()).toEqual(["commit-msg", "post-merge", "pre-commit", "pre-push", "prepare-commit-msg"]);
     for (const { hook } of res.hooks) {
       const f = join(repo, ".karajan", "hooks", hook);
       expect(existsSync(f)).toBe(true);


### PR DESCRIPTION
Caso de campo: 'commits with card ref 0/4' mientras el agente preguntaba si adoptar la convención. Una convención que se cumple sola no necesita adopción: hook prepare-commit-msg que estampa el ref de la rama (validado por card-first) en el subject — extracción POSIX-safe anclada al último segmento, delimitador obligatorio tras los dígitos y detección de duplicado con fronteras (TRES catches del reviewer incorporados con sus tests), mayúsculas, tope 100 chars, merges/fixups/refless intactos, cuerpo preservado, hook global encadenado. Perfiles standard/strict. Tests funcionales sobre el script real.