### PR TITLE
fix(roles): CLI providers spawn as subprocess even inside themselves (KJC-BUG-0129)

### DIFF
--- a/src/roles/coder-role.js
+++ b/src/roles/coder-role.js
@@ -17,9 +17,17 @@ export class CoderRole extends AgentRole {
   }
 
   createAgentInstance(provider) {
+    // KJC-BUG-0129 (issues #1301/#1303): running INSIDE an agent does not
+    // make it "the host executor" — delegating sent the full instruction
+    // prompt through elicitInput as a hanging board "question". A CLI
+    // provider spawns as a subprocess ALWAYS; host delegation is explicit
+    // opt-in (roles.coder.host_delegation: true) for MCP-only setups.
     if (this._askHost && isHostAgent(provider)) {
-      this.logger.info(`Host-as-coder: delegating to host AI (skipping ${provider} subprocess)`);
-      return new HostAgent(this.config, this.logger, { askHost: this._askHost });
+      if (this.config?.roles?.coder?.host_delegation === true) {
+        this.logger.info(`Host-as-coder: delegating to host AI (roles.coder.host_delegation, skipping ${provider} subprocess)`);
+        return new HostAgent(this.config, this.logger, { askHost: this._askHost });
+      }
+      this.logger.info(`Running inside ${provider} — spawning it as a subprocess anyway (set roles.coder.host_delegation: true to delegate to the host)`);
     }
     return this._createAgent(provider, this.config, this.logger);
   }

--- a/tests/roles/host-delegation.test.js
+++ b/tests/roles/host-delegation.test.js
@@ -1,0 +1,51 @@
+// KJC-BUG-0129 (issues #1301/#1303) — running INSIDE an agent does not
+// make that agent "the host executor": a CLI-spawnable provider goes
+// through a subprocess ALWAYS, or the instruction prompt lands on the
+// board as a hanging "question". Host delegation is explicit opt-in.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CoderRole } from "../../src/roles/coder-role.js";
+import { HostAgent } from "../../src/agents/host-agent.js";
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), setContext: vi.fn() };
+const subprocessAgent = { name: "opencode-subprocess" };
+
+function role(config) {
+  const r = new CoderRole({ config, logger, askHost: vi.fn() });
+  r._createAgent = vi.fn(() => subprocessAgent);
+  return r;
+}
+
+const HOST_ENVS = ["CLAUDECODE", "CLAUDE_CODE", "CODEX_CLI", "CODEX", "GEMINI_CLI", "OPENCODE"];
+const saved = {};
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of HOST_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+  process.env.OPENCODE = "1"; // the test runner itself runs inside Claude Code
+});
+afterEach(() => {
+  for (const k of HOST_ENVS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("coder host delegation (KJC-BUG-0129)", () => {
+  it("running inside opencode with provider opencode spawns the SUBPROCESS by default", () => {
+    const agent = role({ roles: { coder: { provider: "opencode" } } }).createAgentInstance("opencode");
+    expect(agent).toBe(subprocessAgent);
+    expect(logger.info.mock.calls.flat().join("\n")).toMatch(/subprocess/i);
+  });
+
+  it("host delegation remains available as explicit opt-in", () => {
+    const agent = role({ roles: { coder: { provider: "opencode", host_delegation: true } } })
+      .createAgentInstance("opencode");
+    expect(agent).toBeInstanceOf(HostAgent);
+  });
+
+  it("outside any host, the provider spawns normally (no change)", () => {
+    delete process.env.OPENCODE;
+    const agent = role({}).createAgentInstance("opencode");
+    expect(agent).toBe(subprocessAgent);
+  });
+});


### PR DESCRIPTION
Fixes #1301. Fixes #1303.

Análisis de @jorgecasar, impecable en ambas issues: `isHostAgent` confundía dos estados independientes — *correr DENTRO de X* y *X es el provider configurado* — y los roles caían a `HostAgent`, que manda el prompt COMPLETO de instrucciones por `elicitInput`: cientos de líneas presentadas como "pregunta" en el board, pipeline colgado esperando que un humano responda a un banner unidireccional.

- **Un provider con CLI spawneable va SIEMPRE por subprocess**, también cuando kj corre dentro de él (con log informativo del porqué).
- **La delegación al host queda como opt-in explícito** (`roles.coder.host_delegation: true`) para setups puramente MCP donde el spawn anidado no sea viable — la optimización original sobrevive, pero ya no es una emboscada.
- Dos canales, dos mecanismos, como señala la issue: decisión → `elicitInput`; instrucción → subprocess.