### PR TITLE
chore(release): v4.6.3 — subprocess by right, host by choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.3] - 2026-07-25
+
+Patch. **Subprocess by right, host by choice** — running kj inside Claude Code no longer hijacks the coder role.
+
+### Fixed
+
+- **CLI providers always spawn as a subprocess** (KJC-BUG-0129, issues #1301/#1303 by @jorgecasar): `isHostAgent()` conflated "running inside agent X" with "the user chose X as provider" — inside Claude Code with `coder: claude`, the pipeline silently delegated to the host via `elicitInput` and hung headless runs. Now every CLI provider spawns its own subprocess even when kj runs inside it; host delegation remains available as an explicit opt-in with `roles.coder.host_delegation: true`.
+- **brace-expansion HIGH advisory resolved** (KJC-BUG-0130, nightly drift #994): GHSA-mh99-v99m-4gvg (DoS via unbounded expansion), transitive through `@modelcontextprotocol/sdk` — lockfile-only `npm audit fix`, non-breaking.
+
 ## [4.6.2] - 2026-07-25
 
 Patch. **Warnings stop being negotiable** — a field session rationalized a 522-line PR past the warning, left commits without card refs while asking whether to adopt the convention, and decided a schema unilaterally. Three answers:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.6.2",
+      "version": "4.6.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Fixes ya mergeados y revisados: #1331 (KJC-BUG-0129 host delegation opt-in, issues #1301/#1303 de @jorgecasar) y #1332 (KJC-BUG-0130 brace-expansion HIGH del drift #994). verify-pack verde.