### PR TITLE
fix(harden): CI workflows detect the repo package manager (KJC-BUG-0131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Patch. **Subprocess by right, host by choice** — running kj inside Claude Code
 
 - **CLI providers always spawn as a subprocess** (KJC-BUG-0129, issues #1301/#1303 by @jorgecasar): `isHostAgent()` conflated "running inside agent X" with "the user chose X as provider" — inside Claude Code with `coder: claude`, the pipeline silently delegated to the host via `elicitInput` and hung headless runs. Now every CLI provider spawns its own subprocess even when kj runs inside it; host delegation remains available as an explicit opt-in with `roles.coder.host_delegation: true`.
 - **brace-expansion HIGH advisory resolved** (KJC-BUG-0130, nightly drift #994): GHSA-mh99-v99m-4gvg (DoS via unbounded expansion), transitive through `@modelcontextprotocol/sdk` — lockfile-only `npm audit fix`, non-breaking.
+- **`kj harden` CI workflows respect the repo's package manager** (KJC-BUG-0131, issue #1330): the generated quality/pack-smoke/mutation workflows hardcoded `npm ci`, killing every PR check in pnpm/yarn repos with `EUSAGE: can only install with an existing package-lock.json`. The lockfile now decides — pnpm gets `corepack enable` + `pnpm install --frozen-lockfile` with `--if-present` BEFORE the script name (pnpm forwards trailing flags to the script), yarn gets `yarn install --frozen-lockfile`. Managed workflows refresh on the next `kj harden` run.
 
 ## [4.6.2] - 2026-07-25
 

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -27,6 +27,13 @@ export function isPublishableNpm(projectDir) {
   }
 }
 
+/** Lockfile-detected package manager (KJC-BUG-0131): npm ci kills pnpm/yarn CI. */
+export function detectPackageManager(projectDir) {
+  if (existsSync(join(projectDir, "pnpm-lock.yaml"))) return "pnpm";
+  if (existsSync(join(projectDir, "yarn.lock"))) return "yarn";
+  return "npm";
+}
+
 export function installWorkflows({
   projectDir = process.cwd(),
   language = null,
@@ -35,9 +42,10 @@ export function installWorkflows({
   dryRun = false,
 } = {}) {
   const dir = join(projectDir, WORKFLOWS_DIR);
-  const quality = qualityWorkflowFor(language);
-  const extras = extraWorkflowsFor({ profile, publishable: isPublishableNpm(projectDir) });
-  const mut = mutation ? mutationWorkflowFor(language) : null;
+  const pm = detectPackageManager(projectDir);
+  const quality = qualityWorkflowFor(language, pm);
+  const extras = extraWorkflowsFor({ profile, publishable: isPublishableNpm(projectDir), pm });
+  const mut = mutation ? mutationWorkflowFor(language, pm) : null;
   const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras, ...(mut ? [mut] : [])];
   const results = [];
   for (const wf of all) {

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -54,15 +54,37 @@ const header = (steps) =>
     ...steps,
   ].join("\n");
 
+// Per-package-manager commands (KJC-BUG-0131, issue #1330): `npm ci` in a
+// pnpm/yarn repo dies with EUSAGE (no package-lock.json). corepack ships with
+// Node 22 and resolves the right pnpm/yarn from `packageManager` — no
+// third-party action. pnpm passes flags AFTER the script name to the script
+// itself, so --if-present must go BEFORE it; yarn has no --if-present at all,
+// so lint runs through `npm run` (scripts don't touch the lockfile).
+const PM_COMMANDS = {
+  npm: { setup: [], install: "npm ci", lint: "npm run -s lint --if-present", test: "npm test" },
+  pnpm: {
+    setup: ["      - run: corepack enable"],
+    install: "pnpm install --frozen-lockfile",
+    lint: "pnpm run --if-present -s lint",
+    test: "pnpm test",
+  },
+  yarn: {
+    setup: ["      - run: corepack enable"],
+    install: "yarn install --frozen-lockfile",
+    lint: "npm run -s lint --if-present",
+    test: "yarn test",
+  },
+};
+
+const nodeSetupSteps = (pm) => [
+  "      - uses: actions/setup-node@v4",
+  "        with:",
+  "          node-version: 22",
+  ...(PM_COMMANDS[pm] || PM_COMMANDS.npm).setup,
+  `      - run: ${(PM_COMMANDS[pm] || PM_COMMANDS.npm).install}`,
+];
+
 const QUALITY_BY_LANGUAGE = {
-  javascript: header([
-    "      - uses: actions/setup-node@v4",
-    "        with:",
-    "          node-version: 22",
-    "      - run: npm ci",
-    "      - run: npm run -s lint --if-present",
-    "      - run: npm test",
-  ]),
   python: header([
     "      - uses: actions/setup-python@v5",
     "        with:",
@@ -87,11 +109,13 @@ const QUALITY_BY_LANGUAGE = {
     "      - run: vendor/bin/phpunit",
   ]),
 };
-QUALITY_BY_LANGUAGE.typescript = QUALITY_BY_LANGUAGE.javascript;
-
 /** Stack-aware Quality workflow entry, or null for an unknown language. */
-export function qualityWorkflowFor(language) {
-  const body = QUALITY_BY_LANGUAGE[language];
+export function qualityWorkflowFor(language, pm = "npm") {
+  const c = PM_COMMANDS[pm] || PM_COMMANDS.npm;
+  const body =
+    language === "javascript" || language === "typescript"
+      ? header([...nodeSetupSteps(pm), `      - run: ${c.lint}`, `      - run: ${c.test}`])
+      : QUALITY_BY_LANGUAGE[language];
   return body ? { file: "kj-quality.yml", blockId: "wf-quality", body } : null;
 }
 
@@ -123,29 +147,29 @@ export const SHRINK_BUDGET_WORKFLOW = [
 ].join("\n");
 
 // Packs the tarball and installs it clean — only for publishable npm packages.
-export const PACK_SMOKE_WORKFLOW = [
-  "name: Pack smoke",
-  "on:",
-  "  pull_request:",
-  "    branches: [main]",
-  "permissions:",
-  "  contents: read",
-  "jobs:",
-  "  pack-smoke:",
-  "    runs-on: ubuntu-latest",
-  "    steps:",
-  "      - uses: actions/checkout@v4",
-  "      - uses: actions/setup-node@v4",
-  "        with:",
-  "          node-version: 22",
-  "      - run: npm ci",
-  "      - name: Pack and install the tarball clean",
-  "        run: |",
-  "          tgz=$(npm pack --silent)",
-  "          dir=$(mktemp -d)",
-  '          npm install --prefix "$dir" "$PWD/$tgz" --no-audit --no-fund',
-  '          echo "Tarball installs clean: $tgz"',
-].join("\n");
+// `npm pack`/`npm install <tarball>` need no lockfile, so only the dependency
+// install step is package-manager-aware.
+export const packSmokeWorkflow = (pm = "npm") =>
+  [
+    "name: Pack smoke",
+    "on:",
+    "  pull_request:",
+    "    branches: [main]",
+    "permissions:",
+    "  contents: read",
+    "jobs:",
+    "  pack-smoke:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    ...nodeSetupSteps(pm),
+    "      - name: Pack and install the tarball clean",
+    "        run: |",
+    "          tgz=$(npm pack --silent)",
+    "          dir=$(mktemp -d)",
+    '          npm install --prefix "$dir" "$PWD/$tgz" --no-audit --no-fund',
+    '          echo "Tarball installs clean: $tgz"',
+  ].join("\n");
 
 // Opt-in nightly/manual mutation audit (KJC-TSK-0589). NEVER a PR gate: it runs
 // on a weekly schedule + manual dispatch, and the mutate step is non-blocking
@@ -153,7 +177,7 @@ export const PACK_SMOKE_WORKFLOW = [
 // yields a JSON report (stryker/mutmut/infection) get a workflow — no silent
 // scaffold for tools that can't report yet.
 const MUTATION_TOOLCHAIN = {
-  javascript: ["      - run: npm ci"],
+  javascript: "node", // resolved per package manager in mutationWorkflowFor
   python: [
     "      - uses: actions/setup-python@v5",
     "        with:",
@@ -170,9 +194,11 @@ const MUTATION_TOOLCHAIN = {
 MUTATION_TOOLCHAIN.typescript = MUTATION_TOOLCHAIN.javascript;
 
 /** Opt-in mutation workflow entry, or null for a stack without a JSON report. */
-export function mutationWorkflowFor(language) {
-  const toolchain = MUTATION_TOOLCHAIN[language];
-  if (!toolchain) return null;
+export function mutationWorkflowFor(language, pm = "npm") {
+  const entry = MUTATION_TOOLCHAIN[language];
+  if (!entry) return null;
+  const c = PM_COMMANDS[pm] || PM_COMMANDS.npm;
+  const toolchain = entry === "node" ? [...c.setup, `      - run: ${c.install}`] : entry;
   const body = [
     "name: Mutation (nightly)",
     "on:",
@@ -200,13 +226,13 @@ export function mutationWorkflowFor(language) {
 }
 
 /** Conditional workflows: shrink-budget on strict, pack-smoke when publishable. */
-export function extraWorkflowsFor({ profile = "standard", publishable = false } = {}) {
+export function extraWorkflowsFor({ profile = "standard", publishable = false, pm = "npm" } = {}) {
   const extras = [];
   if (profile === "strict") {
     extras.push({ file: "kj-shrink-budget.yml", blockId: "wf-shrink", body: SHRINK_BUDGET_WORKFLOW });
   }
   if (publishable) {
-    extras.push({ file: "kj-pack-smoke.yml", blockId: "wf-pack-smoke", body: PACK_SMOKE_WORKFLOW });
+    extras.push({ file: "kj-pack-smoke.yml", blockId: "wf-pack-smoke", body: packSmokeWorkflow(pm) });
   }
   return extras;
 }

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -132,6 +132,32 @@ describe("installWorkflows", () => {
     expect(res.workflows.map((w) => w.file)).not.toContain(mutFile);
   });
 
+  // KJC-BUG-0131 (issue #1330): npm ci in a pnpm repo kills every PR check.
+  it("a pnpm repo installs with pnpm and puts --if-present BEFORE the script", () => {
+    writeFileSync(join(dir, "pnpm-lock.yaml"), "");
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", bin: { x: "cli.js" } }));
+    installWorkflows({ projectDir: dir, language: "javascript", mutation: true });
+    const q = read(join(".github", "workflows", "kj-quality.yml"));
+    expect(q).toContain("corepack enable");
+    expect(q).toContain("pnpm install --frozen-lockfile");
+    expect(q).toContain("pnpm run --if-present -s lint");
+    expect(q).not.toContain("npm ci");
+    expect(read(join(".github", "workflows", "kj-pack-smoke.yml"))).not.toContain("npm ci");
+    expect(read(mutFile)).not.toContain("npm ci");
+  });
+
+  it("a yarn repo installs with yarn; no lockfile keeps npm ci", () => {
+    writeFileSync(join(dir, "yarn.lock"), "");
+    installWorkflows({ projectDir: dir, language: "typescript" });
+    const q = read(join(".github", "workflows", "kj-quality.yml"));
+    expect(q).toContain("yarn install --frozen-lockfile");
+    expect(q).not.toContain("npm ci");
+    const plain = mkdtempSync(join(tmpdir(), "kj-wf-npm-"));
+    installWorkflows({ projectDir: plain, language: "javascript" });
+    expect(readFileSync(join(plain, ".github", "workflows", "kj-quality.yml"), "utf8")).toContain("npm ci");
+    rmSync(plain, { recursive: true, force: true });
+  });
+
   it("mutation workflow is idempotent", () => {
     installWorkflows({ projectDir: dir, language: "python", mutation: true });
     const res = installWorkflows({ projectDir: dir, language: "python", mutation: true });


### PR DESCRIPTION
Fixes #1330 (reportado vía kj report-issue desde un repo pnpm). Los workflows generados por kj harden (quality/pack-smoke/mutation) fijaban npm ci y mataban todos los checks de PR en repos pnpm/yarn. Ahora el lockfile decide: pnpm → corepack enable + pnpm install --frozen-lockfile con --if-present ANTES del script (pnpm reenvía flags posteriores al script); yarn → yarn install --frozen-lockfile (lint vía npm run porque yarn no tiene --if-present). Los workflows gestionados se refrescan en el siguiente kj harden. TDD rojo-primero, 118/118 en tests/harden. Sustituye a #1334 (arrastraba ficheros locales ajenos al fix). Entra en la 4.6.3 aún sin publicar.