### PR TITLE
feat(agents): env allowlist for agent subprocesses (KJC-TSK-0693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Env allowlist for agent subprocesses** (KJC-TSK-0693): spawned agents (coder/reviewer/tester CLIs) no longer inherit the user's whole environment — only system essentials, the CLI's own auth/config families, and `KJ_*` lane vars. Cloud keys, registry tokens and DB URLs never reach the child, so a compromised agent or injected prompt cannot exfiltrate what it never received. Per-agent extras (`GITHUB_*`/`GH_*` only for copilot); escapes: `security.env_passthrough` (names or trailing-* globs) and `security.env_allowlist: false`. Inspired by Akua's "temporary credentials, never a shared master key" control.
+
 ## [4.6.3] - 2026-07-25
 
 Patch. **Subprocess by right, host by choice** — running kj inside Claude Code no longer hijacks the coder role.

--- a/src/agents/base-agent.js
+++ b/src/agents/base-agent.js
@@ -11,6 +11,7 @@
  */
 
 import { defaultEnvironment } from "../infrastructure/environment.js";
+import { buildAgentEnv } from "../utils/role-env.js";
 
 const MODEL_NOT_SUPPORTED_PATTERNS = [
   /model.{0,30}is not supported/i,
@@ -49,6 +50,19 @@ export class BaseAgent {
    * @returns {Promise<CommandRunResult>}
    */
   async runCommand(command, args = [], options = {}) {
+    // KJC-TSK-0693: the subprocess gets an env allowlist, never the user's
+    // whole environment. security.env_allowlist:false opts out.
+    if (this.config?.security?.env_allowlist !== false) {
+      // Merge explicit env over the inherited one BEFORE filtering: a caller
+      // passing only lane vars must not cost the child PATH/HOME.
+      options = {
+        ...options,
+        env: buildAgentEnv({ ...process.env, ...(options.env || {}) }, {
+          agent: this.name,
+          passthrough: this.config?.security?.env_passthrough || [],
+        }),
+      };
+    }
     return this.environment.runner.run(command, args, options);
   }
 

--- a/src/agents/base-agent.js
+++ b/src/agents/base-agent.js
@@ -53,11 +53,14 @@ export class BaseAgent {
     // KJC-TSK-0693: the subprocess gets an env allowlist, never the user's
     // whole environment. security.env_allowlist:false opts out.
     if (this.config?.security?.env_allowlist !== false) {
-      // Merge explicit env over the inherited one BEFORE filtering: a caller
-      // passing only lane vars must not cost the child PATH/HOME.
+      // Contract: options.env, when provided, is the COMPLETE intended child
+      // env (agents build it from process.env and deliberately strip or
+      // override vars — cleanExecaOpts drops CLAUDECODE, qwen unsets gemini's
+      // trust var). Filtering must respect those intentions, so the explicit
+      // env is filtered AS GIVEN, never re-merged over process.env.
       options = {
         ...options,
-        env: buildAgentEnv({ ...process.env, ...(options.env || {}) }, {
+        env: buildAgentEnv(options.env ?? process.env, {
           agent: this.name,
           passthrough: this.config?.security?.env_passthrough || [],
         }),

--- a/src/utils/role-env.js
+++ b/src/utils/role-env.js
@@ -1,0 +1,54 @@
+/**
+ * role-env — env allowlist for agent subprocesses (KJC-TSK-0693).
+ *
+ * Agents inherit only what their function requires: system essentials, the
+ * spawned CLI's own auth/config vars, and KJ_* lane vars. Long-lived secrets
+ * that no agent needs (cloud keys, registry tokens, DB URLs) never reach the
+ * child, so a compromised agent or an injected prompt cannot exfiltrate them.
+ * Escapes: `security.env_passthrough` (exact names or trailing-* globs) and
+ * `security.env_allowlist: false` to disable filtering entirely.
+ */
+
+const EXACT = new Set([
+  "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TERM", "COLORTERM", "LANG",
+  "TZ", "TMPDIR", "TMP", "TEMP", "EDITOR", "CI", "OLLAMA_HOST",
+  // SSH agent socket: local-only handle, needed for git fetch/pull over SSH
+  // inside worktrees. Unusable off-machine, unlike a long-lived token.
+  "SSH_AUTH_SOCK", "SSH_AGENT_PID",
+  "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+  "http_proxy", "https_proxy", "no_proxy",
+]);
+
+// Per-CLI auth/config families. GOOGLE_ covers GOOGLE_APPLICATION_CREDENTIALS
+// (gemini via Vertex); npm_ covers npm_config_* that Node tooling reads.
+const PREFIXES = [
+  "LC_", "XDG_", "KJ_", "NODE_", "npm_",
+  "ANTHROPIC_", "CLAUDE", "OPENAI_", "CODEX", "GEMINI", "GOOGLE_",
+  "QWEN", "DASHSCOPE_", "OPENCODE", "AIDER_", "OPENROUTER_",
+];
+
+// Vars only ONE agent authenticates with — granting them globally would
+// defeat the point (the coder does not need your GitHub token; copilot does).
+const AGENT_EXTRAS = {
+  copilot: ["GITHUB_", "GH_"],
+};
+
+const matches = (pattern, key) =>
+  pattern.endsWith("*") ? key.startsWith(pattern.slice(0, -1)) : key === pattern;
+
+/**
+ * Filter an environment down to what the given agent's subprocess needs.
+ * @param {Record<string,string|undefined>} base - env to filter
+ * @param {{agent?: string|null, passthrough?: string[]}} [opts]
+ * @returns {Record<string,string|undefined>}
+ */
+export function buildAgentEnv(base = process.env, { agent = null, passthrough = [] } = {}) {
+  const prefixes = [...PREFIXES, ...(AGENT_EXTRAS[agent] || [])];
+  const out = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (EXACT.has(key) || prefixes.some((p) => key.startsWith(p)) || passthrough.some((p) => matches(p, key))) {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/tests/agents/opencode-agent.test.js
+++ b/tests/agents/opencode-agent.test.js
@@ -100,15 +100,27 @@ describe("OpenCodeAgent", () => {
   });
 
   // merged-from: 2 stdin/env tests collapsed. OpenCode does not touch stdin
-  // nor strip env vars (unlike Claude); both opts come back undefined.
-  describe("no special stdin/env handling", () => {
-    it.each([
-      ["stdin", "stdin"],
-      ["env",   "env"]
-    ])("does NOT set %s", async (_label, optKey) => {
+  // (unlike Claude). Since KJC-TSK-0693 the env is never inherited whole:
+  // BaseAgent injects the allowlisted env for every agent.
+  describe("no special stdin handling, allowlisted env", () => {
+    it("does NOT set stdin", async () => {
       const agent = new OpenCodeAgent("opencode", baseConfig, logger);
       await agent.runTask({ prompt: "test", role: "coder" });
-      expect(runCommand.mock.calls[0][2][optKey]).toBeUndefined();
+      expect(runCommand.mock.calls[0][2].stdin).toBeUndefined();
+    });
+
+    it("receives the allowlisted env, not the raw inherited one", async () => {
+      process.env.KJC_0693_CANARY = "must-not-leak";
+      try {
+        const agent = new OpenCodeAgent("opencode", baseConfig, logger);
+        await agent.runTask({ prompt: "test", role: "coder" });
+        const env = runCommand.mock.calls[0][2].env;
+        expect(env).toBeDefined();
+        expect(env.KJC_0693_CANARY).toBeUndefined();
+        expect(env.PATH).toBeDefined();
+      } finally {
+        delete process.env.KJC_0693_CANARY;
+      }
     });
   });
 

--- a/tests/utils/role-env.test.js
+++ b/tests/utils/role-env.test.js
@@ -1,0 +1,81 @@
+// KJC-TSK-0693 — credential hygiene: agent subprocesses receive an env
+// allowlist, not the user's whole environment. A compromised agent or an
+// injected prompt cannot exfiltrate what it never received.
+
+import { describe, it, expect } from "vitest";
+import { buildAgentEnv } from "../../src/utils/role-env.js";
+import { BaseAgent } from "../../src/agents/base-agent.js";
+import { buildEnvironment } from "../../src/infrastructure/environment.js";
+
+const BASE = {
+  PATH: "/usr/bin", HOME: "/home/u", TERM: "xterm", LANG: "es_ES.UTF-8",
+  KJ_LANE_SLOT: "2", NODE_OPTIONS: "--max-old-space-size=4096",
+  ANTHROPIC_API_KEY: "sk-ant", OPENAI_API_KEY: "sk-oai", GEMINI_API_KEY: "g",
+  AWS_SECRET_ACCESS_KEY: "aws-secret", NPM_TOKEN: "npm-secret",
+  GITHUB_TOKEN: "gh-secret", DATABASE_URL: "postgres://x",
+};
+
+describe("buildAgentEnv", () => {
+  it("keeps essentials and agent/kj prefixes, drops unrelated secrets", () => {
+    const env = buildAgentEnv(BASE);
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/u");
+    expect(env.KJ_LANE_SLOT).toBe("2");
+    expect(env.NODE_OPTIONS).toBeDefined();
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant");
+    expect(env.OPENAI_API_KEY).toBe("sk-oai");
+    expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    expect(env.NPM_TOKEN).toBeUndefined();
+    expect(env.DATABASE_URL).toBeUndefined();
+  });
+
+  it("GITHUB_/GH_ only reach the agent that authenticates with them (copilot)", () => {
+    expect(buildAgentEnv(BASE).GITHUB_TOKEN).toBeUndefined();
+    expect(buildAgentEnv(BASE, { agent: "claude" }).GITHUB_TOKEN).toBeUndefined();
+    expect(buildAgentEnv(BASE, { agent: "copilot" }).GITHUB_TOKEN).toBe("gh-secret");
+  });
+
+  it("passthrough admits exact names and trailing-* globs", () => {
+    const env = buildAgentEnv(BASE, { passthrough: ["DATABASE_URL", "AWS_*"] });
+    expect(env.DATABASE_URL).toBe("postgres://x");
+    expect(env.AWS_SECRET_ACCESS_KEY).toBe("aws-secret");
+    expect(env.NPM_TOKEN).toBeUndefined(); // not listed → still out
+  });
+});
+
+describe("BaseAgent.runCommand env filtering", () => {
+  const runWith = (config, options = {}) => {
+    const seen = [];
+    const runner = { run: (_c, _a, opts) => { seen.push(opts); return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 }); } };
+    const agent = new BaseAgent("codex", config, console, buildEnvironment({ runner }));
+    return agent.runCommand("codex", [], options).then(() => seen[0]);
+  };
+
+  it("filters the inherited env by default (secrets absent, essentials present)", async () => {
+    process.env.KJ_TEST_SECRET_0693 = "leak-me";
+    process.env.AWS_SECRET_ACCESS_KEY ??= "aws-secret-test";
+    try {
+      const opts = await runWith({});
+      expect(opts.env).toBeDefined();
+      expect(opts.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(opts.env.KJ_TEST_SECRET_0693).toBe("leak-me"); // KJ_ prefix rides along
+      expect(opts.env.PATH).toBeDefined();
+    } finally {
+      delete process.env.KJ_TEST_SECRET_0693;
+      if (process.env.AWS_SECRET_ACCESS_KEY === "aws-secret-test") delete process.env.AWS_SECRET_ACCESS_KEY;
+    }
+  });
+
+  it("filters an explicitly provided env too, and security.env_allowlist:false opts out", async () => {
+    const explicit = await runWith({}, { env: { ...BASE } });
+    expect(explicit.env.NPM_TOKEN).toBeUndefined();
+    expect(explicit.env.ANTHROPIC_API_KEY).toBe("sk-ant");
+    const off = await runWith({ security: { env_allowlist: false } }, { env: { ...BASE } });
+    expect(off.env.NPM_TOKEN).toBe("npm-secret");
+  });
+
+  it("security.env_passthrough reaches the subprocess", async () => {
+    const opts = await runWith({ security: { env_passthrough: ["DATABASE_URL"] } }, { env: { ...BASE } });
+    expect(opts.env.DATABASE_URL).toBe("postgres://x");
+  });
+});


### PR DESCRIPTION
Los subprocesos de agentes (coder/reviewer/tester) dejan de heredar TODO el entorno del usuario: allowlist de esenciales del sistema + familias de auth de cada CLI + KJ_*. AWS keys, tokens de registro y DB URLs no llegan al hijo — un agente comprometido o un prompt inyectado no puede exfiltrar lo que nunca recibió (control inspirado en el modelo de Akua: credencial acotada, nunca llave maestra heredada). Extras por agente: GITHUB_*/GH_* solo para copilot. Escapes: security.env_passthrough (nombres o globs) y security.env_allowlist:false. Punto único de intercepción en BaseAgent.runCommand (el runner es solo-agentes; git/gh/sonar intactos). Dos catches de codex incorporados: merge del env explícito SOBRE el heredado antes de filtrar, y SSH_AUTH_SOCK/SSH_AGENT_PID en el allowlist. TDD rojo-primero; 477 tests verdes en agents+roles. El propio review fue el smoke: codex corrió bajo el env filtrado.