### PR TITLE
chore(release): v4.7.0 — least privilege for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-07-29
+
+Minor. **Least privilege for agents** — a subprocess gets what its function requires and nothing more, and every new tool is a conscious access. Two controls born from convergence with how a payments processor operates AI agents safely.
+
 ### Added
 
 - **Env allowlist for agent subprocesses** (KJC-TSK-0693): spawned agents (coder/reviewer/tester CLIs) no longer inherit the user's whole environment — only system essentials, the CLI's own auth/config families, and `KJ_*` lane vars. Cloud keys, registry tokens and DB URLs never reach the child, so a compromised agent or injected prompt cannot exfiltrate what it never received. Per-agent extras (`GITHUB_*`/`GH_*` only for copilot); escapes: `security.env_passthrough` (names or trailing-* globs) and `security.env_allowlist: false`. Inspired by Akua's "temporary credentials, never a shared master key" control.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.6.3",
+  "version": "4.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.6.3",
+      "version": "4.7.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.6.3",
+  "version": "4.7.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Features ya mergeadas y revisadas: #1336 (KJC-TSK-0693 env allowlist para subprocesos, con contrato arbitrado por solomon) y #1337 (KJC-TSK-0694 inventario de superficie IA en kj check). verify-pack verde.