### PR TITLE
chore(release): v4.8.0 — the security pass an agent self-invokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.0] - 2026-07-30
+
+Minor. **The security pass an agent self-invokes** — design → scan → remediate in the same session, zero tokens. Closes the trio of controls born from field convergence with how a payments processor operates AI agents.
+
 ### Added
 
 - **`kj audit --security` — the security pass an agent self-invokes** (KJC-TSK-0695): a focused deterministic audit (zero tokens) that runs the prompt-injection scan + OSV + Semgrep + Sonar and skips everything else (basal-cost, webperf, madge, knip, ai-slop, harness, LLM). The injection scan now covers the **agent-context surface** — `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`, `.cursorrules`, `.github/copilot-instructions.md`, `templates/`, `.rulesync/` — on top of `.karajan/**`: whatever lands in the host agent's context every session is the real injection vector. The playbook and `kj brief security` now order the agent to run it and remediate BEFORE requesting review whenever a task touches auth, user input, secrets, network or deps. Closes the Akua trio (self-invocable continuous pentest). Fix ride-along: a bare boolean `--security` no longer collides with the global `--security <provider>` role override (provider overrides must be strings).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Feature ya mergeada y revisada: #1339 (KJC-TSK-0695, kj audit --security + scan de injection sobre la superficie de contexto del agente + orden en playbook/brief). verify-pack verde.