### PR TITLE
feat(method): the alternatives clause (KJC-TSK-0696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The alternatives clause** (KJC-TSK-0696, from proposal KJC-PRP-0011): on legacy codebases agents optimize for local coherence — improving while following the existing line — even when the canonical solution is better. Nothing in the loop asked for the alternative; now the method does. The playbook orders that a non-trivial plan names at least two approaches — **one as if the codebase didn't exist** — and says why the winner won: following the legacy line is a choice, never a default. `kj brief planner` and `kj brief architect` carry the clause where approaches are chosen. First stone of the excellent-code track (library corpus of distilled engineering canon comes next).
+
 ## [4.8.0] - 2026-07-30
 
 Minor. **The security pass an agent self-invokes** — design → scan → remediate in the same session, zero tokens. Closes the trio of controls born from field convergence with how a payments processor operates AI agents.

--- a/src/environment/briefs.js
+++ b/src/environment/briefs.js
@@ -36,6 +36,7 @@ const B = {
         "Behavior changes carry their test in the same step.",
         "Data-model or API changes never share a step with anything else.",
         "No PR beyond ~150 net lines — partition upfront, not at the gate.",
+        "Non-trivial task? Name at least two approaches — one as if the codebase didn't exist — and say why the winner won.",
       ],
       "numbered-free plan: steps {description, files}, risks, out-of-scope."),
   },
@@ -56,6 +57,7 @@ const B = {
       [
         "Check the ADRs before deciding — never against an accepted one.",
         "Prefer the design that deletes code over the one that adds layers.",
+        "One alternative answers: what would you build as if the codebase didn't exist? Picking the legacy-shaped path is fine — picking it by inertia is not.",
       ],
       "chosen design, discarded alternatives with reasons, affected boundaries."),
   },

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -72,6 +72,9 @@ Invariants (the git gates enforce these — they are not suggestions):
   it as a proposed ADR (\`kj adr add\`) and ask — never bury it in a PR
   bullet. An oversized-diff warning is not an opinion either: partition,
   or get an explicit OK.
+- A non-trivial plan names at least two approaches — one as if the
+  codebase didn't exist — and says why the winner won. Following the
+  legacy line is a choice, never a default.
 - Branch first: never commit on the base branch — every change reaches it
   through an atomic PR (~150 net lines, Conventional Commits). More than one
   task, or the base tree must stay untouched? \`kj worktree start <slug>\`

--- a/tests/environment/briefs.test.js
+++ b/tests/environment/briefs.test.js
@@ -26,6 +26,13 @@ describe("renderBrief", () => {
   // be true), Invariants (hard limits) and Deliverable. Never step lists:
   // frontier models pick better paths than a script; what they need
   // explicit are the limits.
+  // KJC-TSK-0696: the alternatives clause lives where approaches are chosen.
+  it("planner and architect carry the greenfield-alternative clause", () => {
+    for (const role of ["planner", "architect"]) {
+      expect(renderBrief(role, {})).toMatch(/as if the codebase didn'?t exist/i);
+    }
+  });
+
   for (const role of ["triage", "planner", "researcher", "architect", "tester", "security", "audit"]) {
     it(`${role}: mission + invariants + deliverable, concise`, () => {
       const text = renderBrief(role, {});

--- a/tests/environment/playbook.test.js
+++ b/tests/environment/playbook.test.js
@@ -26,6 +26,8 @@ describe("renderPlaybook", () => {
       expect(text).toMatch(/proposed ADR/);
       // KJC-TSK-0695: sensitive-surface tasks self-invoke the security pass.
       expect(text).toMatch(/kj audit --security/);
+      // KJC-TSK-0696: the alternatives clause — legacy-following is a choice.
+      expect(text).toMatch(/as if the\s+codebase didn'?t exist/i);
       expect(text.split("\n").length).toBeLessThanOrEqual(60);
     });
   }


### PR DESCRIPTION
Implementa la proposal KJC-PRP-0011 (escalón texto+rastro de la vía 'código excelente'). El playbook ordena que todo plan no trivial nombre >=2 enfoques — uno como si el codebase no existiera — y justifique la elección: seguir la línea del legacy es una elección, nunca un default. Los briefs de planner y architect llevan la cláusula donde se eligen los enfoques. 45/60 líneas de playbook (cap intacto y ahora asertando la cláusula), TDD rojo-primero, 83/83 tests de environment. La escalada a empujón/gate queda diferida a que el rastro muestre que se ignora, según la escalera del método.