### PR TITLE
feat(core): the library kind joins the vec store (KJC-TSK-0697, PR-A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
         run: npx vitest run --reporter=default --reporter=github-actions
         working-directory: packages/hu-board
 
+      # Same blind spot, same fix as hu-board above: the root vitest run
+      # excludes packages/**, so karajan-core's own suite must run here.
+      - name: Run karajan-core package tests
+        run: npx vitest run --reporter=default --reporter=github-actions
+        working-directory: packages/core
+
   # Coverage report — generates v8 coverage (text + html + lcov) and uploads
   # the lcov + html as an artifact for download. Added in KJC-TSK-0465 (2026-05-27)
   # to close the ai-harness-scorecard "Code Coverage" FAIL (0/4 → 4/4). Thresholds

--- a/package-lock.json
+++ b/package-lock.json
@@ -7802,7 +7802,7 @@
     },
     "packages/core": {
       "name": "karajan-core",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "vitest": "^4.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-core",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/core/src/vec-store.js
+++ b/packages/core/src/vec-store.js
@@ -37,7 +37,7 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       source TEXT NOT NULL,
-      kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding')),
+      kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding', 'library')),
       text TEXT NOT NULL,
       metadata TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -60,6 +60,39 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
   if (!cols.includes("content_hash")) {
     db.exec("ALTER TABLE chunks ADD COLUMN content_hash TEXT;");
     db.exec("CREATE INDEX IF NOT EXISTS chunks_by_hash ON chunks(content_hash, project_slug);");
+  }
+  // KJC-TSK-0697 — the 'library' kind (distilled engineering canon) joins
+  // the store. SQLite cannot alter a CHECK constraint, so stores created
+  // before it rebuild `chunks` once: ids are preserved (the external-content
+  // FTS keeps pointing at the same rowids) and the fts triggers, dropped
+  // with the old table, are recreated by the block below.
+  const chunksDdl = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='chunks'").get()?.sql ?? "";
+  let migratedChunksTable = false;
+  if (chunksDdl.includes("'onboarding'") && !chunksDdl.includes("'library'")) {
+    migratedChunksTable = true;
+    db.exec(`
+      DROP TRIGGER IF EXISTS chunks_ai;
+      DROP TRIGGER IF EXISTS chunks_ad;
+      DROP TRIGGER IF EXISTS chunks_au;
+      CREATE TABLE chunks_migrated (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding', 'library')),
+        text TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        project_slug TEXT,
+        content_hash TEXT
+      );
+      INSERT INTO chunks_migrated (id, source, kind, text, metadata, created_at, project_slug, content_hash)
+        SELECT id, source, kind, text, metadata, created_at, project_slug, content_hash FROM chunks;
+      DROP TABLE chunks;
+      ALTER TABLE chunks_migrated RENAME TO chunks;
+      CREATE INDEX IF NOT EXISTS chunks_by_source ON chunks(source);
+      CREATE INDEX IF NOT EXISTS chunks_by_kind ON chunks(kind);
+      CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);
+      CREATE INDEX IF NOT EXISTS chunks_by_hash ON chunks(content_hash, project_slug);
+    `);
   }
   // KJC-TSK-0455 — Auto-update by commit diff. Per-project metadata tracks
   // the last commit whose changes were reflected in the index, so subsequent
@@ -94,7 +127,10 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
   `);
   const ftsCount = db.prepare("SELECT COUNT(*) AS n FROM chunks_fts").get().n;
   const chunksCount = db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
-  if (ftsCount === 0 && chunksCount > 0) {
+  // On external-content FTS5, COUNT(*) reads through the content table, so
+  // it cannot detect an empty INDEX — after the chunks-table rebuild the
+  // index is stale by construction and must be rebuilt explicitly.
+  if (migratedChunksTable || (ftsCount === 0 && chunksCount > 0)) {
     db.exec("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild');");
   }
   return db;

--- a/packages/core/tests/vec-store-library-kind.test.js
+++ b/packages/core/tests/vec-store-library-kind.test.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0697 — the 'library' kind joins the store. Fresh stores accept it
+// via the extended CHECK; stores created with the old CHECK rebuild `chunks`
+// once, preserving rows, ids and the FTS wiring.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { openVecStore, insertChunk, countChunks, searchBM25 } from "../src/vec-store.js";
+
+const DIM = 8;
+const vec = (n) => new Array(DIM).fill(n / 10);
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-libkind-"));
+  process.env.KJ_RAG_DB = path.join(tmpDir, "rag.db");
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_RAG_DB;
+});
+
+describe("vec-store library kind", () => {
+  it("a fresh store accepts kind=library", () => {
+    const db = openVecStore({ dim: DIM });
+    insertChunk(db, { source: "library/lamport.md", kind: "library", text: "happened-before ordering", metadata: {}, embedding: vec(1), project: "library" });
+    expect(countChunks(db)).toBe(1);
+    db.close();
+  });
+
+  it("a store with the pre-library CHECK migrates once, keeping rows and FTS", () => {
+    // Hand-build the OLD schema exactly as shipped before this change.
+    const raw = new Database(process.env.KJ_RAG_DB);
+    raw.exec(`
+      CREATE TABLE chunks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding')),
+        text TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO chunks (source, kind, text, metadata) VALUES ('src/a.js', 'code', 'legacy chunk body', '{}');
+    `);
+    raw.close();
+
+    const db = openVecStore({ dim: DIM });
+    // Old row survived with its id, and the new kind is accepted.
+    expect(db.prepare("SELECT kind, text FROM chunks WHERE id = 1").get()).toMatchObject({ kind: "code", text: "legacy chunk body" });
+    insertChunk(db, { source: "library/dynamo.md", kind: "library", text: "vector clocks resolve concurrent writes", metadata: {}, embedding: vec(2), project: "library" });
+    expect(countChunks(db)).toBe(2);
+    // FTS was rebuilt/rewired: both old and new bodies are searchable.
+    expect(searchBM25(db, "legacy", 5, {}).length).toBeGreaterThan(0);
+    expect(searchBM25(db, "vector clocks", 5, { kind: "library" }).length).toBeGreaterThan(0);
+    // Re-opening does not migrate again (DDL already carries 'library').
+    db.close();
+    const db2 = openVecStore({ dim: DIM });
+    expect(countChunks(db2)).toBe(2);
+    db2.close();
+  });
+});


### PR DESCRIPTION
PR-A de 2 del library corpus (KJC-PRP-0012). karajan-core 1.3.1→1.4.0: kind 'library' en el CHECK de chunks + migración de rebuild para stores anteriores (SQLite no altera CHECKs): ids preservados, FTS external-content reconectado con rebuild EXPLÍCITO (bug real cazado: COUNT(*) sobre FTS5 external-content lee la tabla de contenido y no puede detectar índice vacío). Test de migración sobre el schema viejo exacto. Cierra además el punto ciego de CI: la suite de packages/core no corría (mismo fix que hu-board). PR-B (feature en kj + dep bump) llega tras publicar karajan-core@1.4.0.