### PR TITLE
feat(rag): the library — distilled engineering canon as a RAG collection (KJC-TSK-0697, PR-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
         run: npx vitest run --reporter=default --reporter=github-actions
         working-directory: packages/hu-board
 
+      # Same blind spot, same fix as hu-board above: the root vitest run
+      # excludes packages/**, so karajan-core's own suite must run here.
+      - name: Run karajan-core package tests
+        run: npx vitest run --reporter=default --reporter=github-actions
+        working-directory: packages/core
+
   # Coverage report — generates v8 coverage (text + html + lcov) and uploads
   # the lcov + html as an artifact for download. Added in KJC-TSK-0465 (2026-05-27)
   # to close the ai-harness-scorecard "Code Coverage" FAIL (0/4 → 4/4). Thresholds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The library: distilled engineering canon as a RAG collection** (KJC-TSK-0697, from proposal KJC-PRP-0012): `kj rag query --library "<problem signature>"` serves pattern cards — problem signature, when it beats the default, **when NOT to apply it**, trade-offs and the canonical citation — so the architect can ground the greenfield alternative (the alternatives clause) in citable canon instead of vibes. Cards live in three places: the canon shipped with kj (`library/`), yours (`~/.karajan/library/`) and the project's (`.karajan/library/`); `kj rag index` refreshes them into the global store under their own collection (`project=library`, `kind=library` — invisible to normal project queries). First shipped card: Lamport's logical clocks; the rest of the canon lands next. Underneath, karajan-core 1.4.0 adds the `library` kind with a one-time chunks-table rebuild for older stores (SQLite cannot alter a CHECK) and fixes a real FTS5 subtlety: on external-content tables `COUNT(*)` cannot detect a stale index, so the migration rebuilds it explicitly.
+
+### Added
+
 - **The alternatives clause** (KJC-TSK-0696, from proposal KJC-PRP-0011): on legacy codebases agents optimize for local coherence — improving while following the existing line — even when the canonical solution is better. Nothing in the loop asked for the alternative; now the method does. The playbook orders that a non-trivial plan names at least two approaches — **one as if the codebase didn't exist** — and says why the winner won: following the legacy line is a choice, never a default. `kj brief planner` and `kj brief architect` carry the clause where approaches are chosen. First stone of the excellent-code track (library corpus of distilled engineering canon comes next).
 
 ## [4.8.0] - 2026-07-30

--- a/library/logical-clocks-lamport.md
+++ b/library/logical-clocks-lamport.md
@@ -1,0 +1,40 @@
+# Logical clocks & happened-before (Lamport, 1978)
+
+## Problem signature
+
+Events across processes/services need a consistent order, and wall clocks
+disagree: "last write wins" flip-flops between replicas, audit logs interleave
+impossibly, a consumer sees an update before the create it depends on.
+
+## Reach for it when
+
+- Two or more writers/emitters produce events whose CAUSAL order matters
+  (A caused B must never be observed as B before A).
+- You are tempted to "fix it with NTP" or timestamps — clock skew makes
+  timestamp ordering a race, not an order.
+- You need to detect concurrent (conflicting) updates, not just order them:
+  that is the vector-clock extension (one counter per node; compare
+  component-wise; incomparable = concurrent — see Dynamo's usage).
+
+## Do NOT reach for it when
+
+- A single writer (or a single database) already totally orders the events —
+  its sequence/autoincrement/WAL IS the clock. Most CRUD apps live here.
+- You only need "roughly recent first" for humans (feeds, logs for reading):
+  wall-clock timestamps are fine and far simpler.
+- You need a TOTAL order agreed by all nodes: logical clocks give a partial
+  causal order; total order needs consensus (Raft/Paxos) or a sequencer.
+
+## Trade-offs
+
+- Lamport clocks are one counter: tiny, but they cannot tell concurrent from
+  ordered. Vector clocks can, at O(nodes) metadata per event that must be
+  carried, stored and pruned.
+- Causality tracking pushes conflict RESOLUTION to the reader (semantic
+  merge, CRDTs, or ask-the-user) — ordering was the easy half.
+
+## Canonical source
+
+Leslie Lamport, "Time, Clocks, and the Ordering of Events in a Distributed
+System", Communications of the ACM, 1978. The happened-before relation and
+the clock condition come verbatim from it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7802,7 +7802,7 @@
     },
     "packages/core": {
       "name": "karajan-core",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "vitest": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express-rate-limit": "^8.5.0",
         "helmet": "^8.1.0",
         "js-yaml": "^4.2.0",
-        "karajan-core": "^1.0.0",
+        "karajan-core": "^1.4.0",
         "karajan-rag": "^1.2.0",
         "knip": "^6.15.0",
         "madge": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "files": [
     "src/",
     "bin/",
+    "library/",
     "templates/",
     "scripts/",
     "vendor/tree-sitter-grammars/",
@@ -108,7 +109,7 @@
     "express-rate-limit": "^8.5.0",
     "helmet": "^8.1.0",
     "js-yaml": "^4.2.0",
-    "karajan-core": "^1.0.0",
+    "karajan-core": "^1.4.0",
     "karajan-rag": "^1.2.0",
     "knip": "^6.15.0",
     "madge": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-core",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Shared modules for Karajan Code CLI and @karajan/hu-board (atomic-write, paths, RAG store, plan ops, process runner).",
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/core/src/vec-store.js
+++ b/packages/core/src/vec-store.js
@@ -37,7 +37,7 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
     CREATE TABLE IF NOT EXISTS chunks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       source TEXT NOT NULL,
-      kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding')),
+      kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding', 'library')),
       text TEXT NOT NULL,
       metadata TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -60,6 +60,39 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
   if (!cols.includes("content_hash")) {
     db.exec("ALTER TABLE chunks ADD COLUMN content_hash TEXT;");
     db.exec("CREATE INDEX IF NOT EXISTS chunks_by_hash ON chunks(content_hash, project_slug);");
+  }
+  // KJC-TSK-0697 — the 'library' kind (distilled engineering canon) joins
+  // the store. SQLite cannot alter a CHECK constraint, so stores created
+  // before it rebuild `chunks` once: ids are preserved (the external-content
+  // FTS keeps pointing at the same rowids) and the fts triggers, dropped
+  // with the old table, are recreated by the block below.
+  const chunksDdl = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='chunks'").get()?.sql ?? "";
+  let migratedChunksTable = false;
+  if (chunksDdl.includes("'onboarding'") && !chunksDdl.includes("'library'")) {
+    migratedChunksTable = true;
+    db.exec(`
+      DROP TRIGGER IF EXISTS chunks_ai;
+      DROP TRIGGER IF EXISTS chunks_ad;
+      DROP TRIGGER IF EXISTS chunks_au;
+      CREATE TABLE chunks_migrated (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding', 'library')),
+        text TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        project_slug TEXT,
+        content_hash TEXT
+      );
+      INSERT INTO chunks_migrated (id, source, kind, text, metadata, created_at, project_slug, content_hash)
+        SELECT id, source, kind, text, metadata, created_at, project_slug, content_hash FROM chunks;
+      DROP TABLE chunks;
+      ALTER TABLE chunks_migrated RENAME TO chunks;
+      CREATE INDEX IF NOT EXISTS chunks_by_source ON chunks(source);
+      CREATE INDEX IF NOT EXISTS chunks_by_kind ON chunks(kind);
+      CREATE INDEX IF NOT EXISTS chunks_by_project ON chunks(project_slug);
+      CREATE INDEX IF NOT EXISTS chunks_by_hash ON chunks(content_hash, project_slug);
+    `);
   }
   // KJC-TSK-0455 — Auto-update by commit diff. Per-project metadata tracks
   // the last commit whose changes were reflected in the index, so subsequent
@@ -94,7 +127,10 @@ export function openVecStore({ dim = DEFAULT_DIM, path = dbPath() } = {}) {
   `);
   const ftsCount = db.prepare("SELECT COUNT(*) AS n FROM chunks_fts").get().n;
   const chunksCount = db.prepare("SELECT COUNT(*) AS n FROM chunks").get().n;
-  if (ftsCount === 0 && chunksCount > 0) {
+  // On external-content FTS5, COUNT(*) reads through the content table, so
+  // it cannot detect an empty INDEX — after the chunks-table rebuild the
+  // index is stale by construction and must be rebuilt explicitly.
+  if (migratedChunksTable || (ftsCount === 0 && chunksCount > 0)) {
     db.exec("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild');");
   }
   return db;

--- a/packages/core/tests/vec-store-library-kind.test.js
+++ b/packages/core/tests/vec-store-library-kind.test.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0697 — the 'library' kind joins the store. Fresh stores accept it
+// via the extended CHECK; stores created with the old CHECK rebuild `chunks`
+// once, preserving rows, ids and the FTS wiring.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { openVecStore, insertChunk, countChunks, searchBM25 } from "../src/vec-store.js";
+
+const DIM = 8;
+const vec = (n) => new Array(DIM).fill(n / 10);
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-libkind-"));
+  process.env.KJ_RAG_DB = path.join(tmpDir, "rag.db");
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_RAG_DB;
+});
+
+describe("vec-store library kind", () => {
+  it("a fresh store accepts kind=library", () => {
+    const db = openVecStore({ dim: DIM });
+    insertChunk(db, { source: "library/lamport.md", kind: "library", text: "happened-before ordering", metadata: {}, embedding: vec(1), project: "library" });
+    expect(countChunks(db)).toBe(1);
+    db.close();
+  });
+
+  it("a store with the pre-library CHECK migrates once, keeping rows and FTS", () => {
+    // Hand-build the OLD schema exactly as shipped before this change.
+    const raw = new Database(process.env.KJ_RAG_DB);
+    raw.exec(`
+      CREATE TABLE chunks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK (kind IN ('plan', 'code', 'onboarding')),
+        text TEXT NOT NULL,
+        metadata TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO chunks (source, kind, text, metadata) VALUES ('src/a.js', 'code', 'legacy chunk body', '{}');
+    `);
+    raw.close();
+
+    const db = openVecStore({ dim: DIM });
+    // Old row survived with its id, and the new kind is accepted.
+    expect(db.prepare("SELECT kind, text FROM chunks WHERE id = 1").get()).toMatchObject({ kind: "code", text: "legacy chunk body" });
+    insertChunk(db, { source: "library/dynamo.md", kind: "library", text: "vector clocks resolve concurrent writes", metadata: {}, embedding: vec(2), project: "library" });
+    expect(countChunks(db)).toBe(2);
+    // FTS was rebuilt/rewired: both old and new bodies are searchable.
+    expect(searchBM25(db, "legacy", 5, {}).length).toBeGreaterThan(0);
+    expect(searchBM25(db, "vector clocks", 5, { kind: "library" }).length).toBeGreaterThan(0);
+    // Re-opening does not migrate again (DDL already carries 'library').
+    db.close();
+    const db2 = openVecStore({ dim: DIM });
+    expect(countChunks(db2)).toBe(2);
+    db2.close();
+  });
+});

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -294,6 +294,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--rag-mode <mode>", "hybrid (default) | semantic (cosine only) | keyword (BM25 only)", "hybrid")
     .option("--alpha <n>", "Hybrid weight for semantic component (0..1). Default 0.6", "0.6")
     .option("--where <clause>", "Metadata filter, e.g. 'symbol=loadConfig' or 'hu_id=HU-003 AND kind=plan'")
+    .option("--library", "Query the distilled engineering canon (pattern cards shipped with kj + ~/.karajan/library + project .karajan/library) instead of the project corpus. Cards carry problem signatures, when-NOT-to-apply and canonical citations (KJC-TSK-0697).")
     .option("--rerank", "Apply cross-encoder rerank to top-K (needs @huggingface/transformers, slower but more precise)")
     .option("--rerank-model <name>", "Cross-encoder model id. Default: Xenova/ms-marco-MiniLM-L-6-v2")
     .option("--json", "Output the hits as JSON")

--- a/src/commands/rag.js
+++ b/src/commands/rag.js
@@ -7,6 +7,7 @@ import { makeGovernedEmbedder } from "../rag/governed-embedder.js";
 import { indexProject, indexProjectDelta } from "../rag/indexer.js";
 import { query } from "../rag/retriever.js";
 import { installPostMergeHook, maybeAutoUpdate } from "../rag/auto-update.js";
+import { indexLibrary, LIBRARY_PROJECT } from "../rag/library.js";
 import { loadGoldenQueries, runEval } from "../rag/eval.js";
 import { getKarajanHome } from "../utils/paths.js";
 
@@ -47,6 +48,13 @@ export async function ragIndexCommand({ config, logger, flags = {} }) {
       });
     }
     if (totals.head) setLastIndexedCommit(db, slug, totals.head);
+    // KJC-TSK-0697 — the library corpus refreshes on every index run.
+    // Best-effort and cheap: a handful of cards, content-hash dedup.
+    try {
+      await indexLibrary({ db, embedder, logger, projectDir });
+    } catch (err) {
+      logger.warn?.(`[rag] library index failed: ${err.message}`);
+    }
     if (flags.json) {
       process.stdout.write(`${JSON.stringify(totals)}\n`);
     } else {
@@ -87,7 +95,10 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     // <slug>` overrides. Pre-v2.27 chunks with NULL slug are only visible
     // when no filter is in effect.
     const detected = projectSlug(config?.projectDir || process.cwd());
-    const project = flags.project === "all" ? null : (flags.project || detected || null);
+    // KJC-TSK-0697 — `--library` targets the distilled-canon collection:
+    // its own project namespace plus the kind filter.
+    const library = Boolean(flags.library);
+    const project = library ? LIBRARY_PROJECT : (flags.project === "all" ? null : (flags.project || detected || null));
     // KJC-BUG-0061 follow-up: align the CLI `--json` shape with the MCP
     // handler. The MCP tool responds `{ hits: [], empty: true, topK, scope }`
     // so agents (and the `/kj-rag-query` skill from Camino B) have a
@@ -101,7 +112,12 @@ export async function ragQueryCommand({ text, config, logger, flags = {} }) {
     }
     const mode = flags.mode || "hybrid";
     const alpha = Math.max(0, Math.min(1, Number(flags.alpha) || 0.6));
-    const where = flags.where || null;
+    // Safe by grammar: parseWhere (core where-parser.js) accepts ONLY
+    // AND-joined key=value pairs — an OR or parens never parses, so the
+    // composed clause cannot leak past the kind filter; it fails loudly.
+    const where = library
+      ? (flags.where ? `kind=library AND ${flags.where}` : "kind=library")
+      : (flags.where || null);
     const rerankOpts = flags.rerank ? { model: flags.rerankModel } : null;
     const hits = await query(db, makeGovernedEmbedder(config), text, { topK, scope, project, mode, alpha, where, rerankOpts });
     if (flags.json) {

--- a/src/environment/briefs.js
+++ b/src/environment/briefs.js
@@ -58,6 +58,7 @@ const B = {
         "Check the ADRs before deciding — never against an accepted one.",
         "Prefer the design that deletes code over the one that adds layers.",
         "One alternative answers: what would you build as if the codebase didn't exist? Picking the legacy-shaped path is fine — picking it by inertia is not.",
+        "Ground that alternative in the canon: `kj rag query --library \"<problem signature>\"` serves distilled pattern cards with when-NOT-to-apply and citations.",
       ],
       "chosen design, discarded alternatives with reasons, affected boundaries."),
   },

--- a/src/rag/library.js
+++ b/src/rag/library.js
@@ -1,0 +1,62 @@
+/**
+ * library — the distilled engineering canon as its own RAG collection
+ * (KJC-TSK-0697). Markdown cards from `<pkg>/library/`, `~/.karajan/library/`
+ * and `<project>/.karajan/library/` index into the SAME global rag.db,
+ * isolated by project="library" + kind="library", so `kj rag query --library`
+ * reaches the canon and normal project queries never see it. The architect
+ * consults it to ground the greenfield alternative (KJC-TSK-0696).
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+
+import { chunkMarkdown } from "./chunker.js";
+import { insertChunk, deleteChunksBySource, findChunkByHash } from "./vec-store.js";
+
+export const LIBRARY_PROJECT = "library";
+
+const SHIPPED_LIBRARY_DIR = fileURLToPath(new URL("../../library", import.meta.url));
+
+/** Existing library dirs, shipped canon first. */
+export function libraryDirs({ pkgLibraryDir = SHIPPED_LIBRARY_DIR, home = os.homedir(), projectDir = process.cwd() } = {}) {
+  const candidates = [pkgLibraryDir, join(home, ".karajan", "library"), join(projectDir, ".karajan", "library")];
+  return candidates.filter((d) => existsSync(d));
+}
+
+/**
+ * Index every markdown card found in the library dirs. Idempotent: chunks
+ * re-index per source and identical bodies skip the embedder (content-hash
+ * dedup within the library project).
+ */
+export async function indexLibrary({ db, embedder, logger = console, pkgLibraryDir, home, projectDir } = {}) {
+  let indexed = 0, failed = 0, files = 0;
+  for (const dir of libraryDirs({ pkgLibraryDir, home, projectDir })) {
+    for (const name of readdirSync(dir)) {
+      if (extname(name).toLowerCase() !== ".md") continue;
+      const path = join(dir, name);
+      files += 1;
+      const chunks = chunkMarkdown(readFileSync(path, "utf8"), { path, kind: "library" });
+      const hashed = chunks.map((ch) => ({ ch, contentHash: createHash("sha256").update(ch.text).digest("hex") }));
+      // Unchanged card (every chunk body already known) → skip before the
+      // delete, so idempotent re-runs never touch the embedder.
+      if (hashed.length && hashed.every(({ contentHash }) => findChunkByHash(db, contentHash, LIBRARY_PROJECT))) continue;
+      deleteChunksBySource(db, path);
+      for (const { ch, contentHash } of hashed) {
+        try {
+          if (findChunkByHash(db, contentHash, LIBRARY_PROJECT)) continue;
+          const embedding = await embedder.embed(ch.text);
+          insertChunk(db, { source: path, kind: "library", text: ch.text, metadata: ch.metadata, embedding, project: LIBRARY_PROJECT, contentHash });
+          indexed += 1;
+        } catch (err) {
+          failed += 1;
+          logger.warn?.(`[rag-library] embed failed for ${path}: ${err.message}`);
+        }
+      }
+    }
+  }
+  if (files) logger.info?.(`[rag-library] ${files} card(s) → ${indexed} chunk(s) (${failed} failed)`);
+  return { files, indexed, failed };
+}

--- a/tests/environment/briefs.test.js
+++ b/tests/environment/briefs.test.js
@@ -31,6 +31,8 @@ describe("renderBrief", () => {
     for (const role of ["planner", "architect"]) {
       expect(renderBrief(role, {})).toMatch(/as if the codebase didn'?t exist/i);
     }
+    // KJC-TSK-0697: the architect grounds that alternative in the canon.
+    expect(renderBrief("architect", {})).toMatch(/kj rag query --library/);
   });
 
   for (const role of ["triage", "planner", "researcher", "architect", "tester", "security", "audit"]) {

--- a/tests/rag/library.test.js
+++ b/tests/rag/library.test.js
@@ -1,0 +1,56 @@
+// KJC-TSK-0697 — library corpus: distilled engineering canon as its own RAG
+// collection (project="library", kind="library"), isolated from code chunks
+// by filters the retriever already supports. The architect queries it to
+// ground the greenfield alternative (KJC-TSK-0696) in citable canon.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openVecStore } from "../../src/rag/vec-store.js";
+import { indexLibrary, libraryDirs } from "../../src/rag/library.js";
+import { query } from "../../src/rag/retriever.js";
+
+const embedder = { dim: 8, embed: async (t) => new Array(8).fill(0).map((_, i) => ((t.length + i) % 7) / 7) };
+
+let tmp, db, pkgDir, homeDir, projDir;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "kj-library-"));
+  process.env.KJ_RAG_DB = join(tmp, "rag.db");
+  db = openVecStore({ dim: 8 });
+  pkgDir = join(tmp, "pkg-library");
+  homeDir = join(tmp, "home");
+  projDir = join(tmp, "proj");
+  mkdirSync(pkgDir, { recursive: true });
+  mkdirSync(join(homeDir, ".karajan", "library"), { recursive: true });
+  mkdirSync(join(projDir, ".karajan", "library"), { recursive: true });
+  writeFileSync(join(pkgDir, "lamport.md"), "# Logical clocks\n\nHappened-before ordering without a global clock.\n");
+  writeFileSync(join(homeDir, ".karajan", "library", "user-card.md"), "# Outbox pattern\n\nAtomic DB write plus reliable event publication.\n");
+});
+afterEach(() => {
+  try { db.close(); } catch { /* closed */ }
+  rmSync(tmp, { recursive: true, force: true });
+  delete process.env.KJ_RAG_DB;
+});
+
+describe("rag/library", () => {
+  it("libraryDirs covers shipped, user-home and project dirs that exist", () => {
+    const dirs = libraryDirs({ pkgLibraryDir: pkgDir, home: homeDir, projectDir: projDir });
+    expect(dirs).toContain(pkgDir);
+    expect(dirs).toContain(join(homeDir, ".karajan", "library"));
+    expect(dirs).toContain(join(projDir, ".karajan", "library"));
+    expect(libraryDirs({ pkgLibraryDir: join(tmp, "nope"), home: join(tmp, "nope2"), projectDir: join(tmp, "nope3") })).toEqual([]);
+  });
+
+  it("indexes as kind=library/project=library, idempotent, invisible to project queries", async () => {
+    const opts = { db, embedder, pkgLibraryDir: pkgDir, home: homeDir, projectDir: projDir, logger: { info() {}, warn() {} } };
+    expect((await indexLibrary(opts)).indexed).toBeGreaterThan(0);
+    expect((await indexLibrary(opts)).indexed).toBe(0); // content-hash dedup: nothing re-embedded
+    const hits = await query(db, embedder, "ordering without a global clock", { project: "library", where: "kind=library", topK: 5 });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.every((h) => h.kind === "library")).toBe(true);
+    const proj = await query(db, embedder, "ordering without a global clock", { project: "some-app", topK: 5 });
+    expect(proj.filter((h) => h.kind === "library")).toEqual([]);
+  });
+});


### PR DESCRIPTION
PR-B del library corpus (KJC-PRP-0012). Colección library en el rag.db global (project=library, kind=library — invisible para queries de proyecto): fichas desde library/ del paquete + ~/.karajan/library + .karajan/library, refrescadas en cada kj rag index con idempotencia por hash ANTES del delete. kj rag query --library con aislamiento garantizado por gramática del where-parser (solo-AND). El brief del architect ancla la alternativa greenfield al canon con el comando exacto. Primera ficha: relojes lógicos de Lamport (con su 'cuándo NO aplica', la mitad del valor). Dep karajan-core ^1.4.0 (ya publicado, PR-A #1342). Smoke sobre el store real: migración limpia, firma del problema top-ranked. 188/188 tests.