### PR TITLE
chore(release): v4.9.0 — excellent code is a choice, not inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.0] - 2026-07-31
+
+Minor. **Excellent code is a choice, not inertia** — the method now asks the question legacy codebases suppress ("what would you build if this code didn't exist?") and gives the architect a citable canon to answer it with.
+
 ### Added
 
-- **The library: distilled engineering canon as a RAG collection** (KJC-TSK-0697, from proposal KJC-PRP-0012): `kj rag query --library "<problem signature>"` serves pattern cards — problem signature, when it beats the default, **when NOT to apply it**, trade-offs and the canonical citation — so the architect can ground the greenfield alternative (the alternatives clause) in citable canon instead of vibes. Cards live in three places: the canon shipped with kj (`library/`), yours (`~/.karajan/library/`) and the project's (`.karajan/library/`); `kj rag index` refreshes them into the global store under their own collection (`project=library`, `kind=library` — invisible to normal project queries). First shipped card: Lamport's logical clocks; the rest of the canon lands next. Underneath, karajan-core 1.4.0 adds the `library` kind with a one-time chunks-table rebuild for older stores (SQLite cannot alter a CHECK) and fixes a real FTS5 subtlety: on external-content tables `COUNT(*)` cannot detect a stale index, so the migration rebuilds it explicitly.
-
-### Added
-
-- **The alternatives clause** (KJC-TSK-0696, from proposal KJC-PRP-0011): on legacy codebases agents optimize for local coherence — improving while following the existing line — even when the canonical solution is better. Nothing in the loop asked for the alternative; now the method does. The playbook orders that a non-trivial plan names at least two approaches — **one as if the codebase didn't exist** — and says why the winner won: following the legacy line is a choice, never a default. `kj brief planner` and `kj brief architect` carry the clause where approaches are chosen. First stone of the excellent-code track (library corpus of distilled engineering canon comes next).
+- **The alternatives clause** (KJC-TSK-0696, from proposal KJC-PRP-0011): on legacy codebases agents optimize for local coherence — improving while following the existing line — even when the canonical solution is better. Nothing in the loop asked for the alternative; now the method does. The playbook orders that a non-trivial plan names at least two approaches — **one as if the codebase didn't exist** — and says why the winner won: following the legacy line is a choice, never a default. `kj brief planner` and `kj brief architect` carry the clause where approaches are chosen.
+- **The library: distilled engineering canon as a RAG collection** (KJC-TSK-0697, from proposal KJC-PRP-0012): `kj rag query --library "<problem signature>"` serves pattern cards — problem signature, when it beats the default, **when NOT to apply it**, trade-offs and the canonical citation — so the architect can ground the greenfield alternative in citable canon instead of vibes. Cards live in three places: the canon shipped with kj (`library/`), yours (`~/.karajan/library/`) and the project's (`.karajan/library/`); `kj rag index` refreshes them into the global store under their own collection (`project=library`, `kind=library` — invisible to normal project queries). First shipped card: Lamport's logical clocks; the rest of the canon lands next. Underneath, karajan-core 1.4.0 adds the `library` kind with a one-time chunks-table rebuild for older stores (SQLite cannot alter a CHECK) and fixes a real FTS5 subtlety: on external-content tables `COUNT(*)` cannot detect a stale index, so the migration rebuilds it explicitly.
 
 ## [4.8.0] - 2026-07-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Features ya mergeadas y revisadas: #1341 (KJC-TSK-0696 alternatives clause) y #1342/#1343 (KJC-TSK-0697 library corpus, karajan-core@1.4.0 ya publicado). verify-pack verde con el core del registro.