### PR TITLE
fix(review): the verdict gate passes pure merge commits (KJC-BUG-0132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The verdict gate no longer deadlocks pure merge commits** (KJC-BUG-0132, issue #1344, found dogfooding PR #1343): a merge that stages no content of its own — e.g. merging main to move the merge-base — had no diff to bind a verdict to, and `kj review --staged` rightly refuses an empty diff, so the commit could never pass the pre-commit gate. `kj review --check` now recognizes the case (MERGE_HEAD present + empty staged diff) and passes with a trail line; a merge WITH conflict resolutions stages real content and still requires its cross-AI verdict.
+
 ## [4.9.0] - 2026-07-31
 
 Minor. **Excellent code is a choice, not inertia** — the method now asks the question legacy codebases suppress ("what would you build if this code didn't exist?") and gives the architect a citable canon to answer it with.

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -5,6 +5,8 @@
  * verdict tied to the exact diff (verdict-store), so the pre-commit hook
  * (ENV-C) can verify it. Exit code 0 = approved, 1 = rejected/stale.
  */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
 import { runCommand } from "../utils/process.js";
 import { checkVerdict } from "../review/verdict-store.js";
 import { runOneShotReview } from "../review/one-shot-review.js";
@@ -145,6 +147,20 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   }
 
   if (flags.check) {
+    // KJC-BUG-0132 (issue #1344): a PURE merge commit stages no content of
+    // its own — everything it brings reached the parent branches already
+    // reviewed, and there is no diff to bind a verdict to, so demanding one
+    // deadlocks the merge. A merge WITH conflict resolutions stages real
+    // content and still requires its verdict below.
+    if (!flags.range && !diff.trim()) {
+      const gitDirRaw = (await runCommand("git", ["rev-parse", "--git-dir"])).stdout?.trim();
+      const gitDir = gitDirRaw && !isAbsolute(gitDirRaw) ? join(projectDir, gitDirRaw) : gitDirRaw;
+      if (gitDir && existsSync(join(gitDir, "MERGE_HEAD"))) {
+        console.log("✓ pure merge commit — empty staged diff, parents already reviewed; gate passes with trail");
+        process.exitCode = 0;
+        return { ok: true, merge: true, reason: "pure merge commit (MERGE_HEAD, empty staged diff)" };
+      }
+    }
     const res = await checkVerdict(projectDir, diff);
     console.log(res.ok
       ? `✓ verdict ok — approved by ${res.verdict.reviewer} (diff ${res.verdict.diffHash.slice(0, 12)})`

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -88,9 +88,8 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
 
   if (flags.installGate) {
     const fs = await import("node:fs/promises");
-    const path = await import("node:path");
-    const marker = path.join(projectDir, ".karajan", "review-gate");
-    await fs.mkdir(path.dirname(marker), { recursive: true });
+    const marker = join(projectDir, ".karajan", "review-gate");
+    await fs.mkdir(join(projectDir, ".karajan"), { recursive: true });
     await fs.writeFile(marker, "# Cross-AI review gate enabled (ENV-C1). Commit this file so the whole team inherits the gate.\n");
     console.log("✓ review gate enabled — commits now require an approved cross-AI verdict (kj review --staged)");
     // KJC-TSK-0646: a `.karajan/` dir-exclude would silently keep the

--- a/tests/review/review-gate.test.js
+++ b/tests/review/review-gate.test.js
@@ -41,6 +41,28 @@ describe("kj review gate", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  // KJC-BUG-0132 (issue #1344): a PURE merge stages nothing of its own —
+  // everything it brings reached the parent branches reviewed. Demanding a
+  // verdict of an empty diff deadlocks the merge.
+  it("--check passes a pure merge commit (MERGE_HEAD present, empty staged diff)", async () => {
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"], { cwd: dir });
+    fs.writeFileSync(path.join(dir, ".git", "MERGE_HEAD"), "deadbeef\n");
+    const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+    expect(res.ok).toBe(true);
+    expect(res.merge).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("--check still demands a verdict when the merge stages conflict resolutions", async () => {
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"], { cwd: dir });
+    fs.writeFileSync(path.join(dir, ".git", "MERGE_HEAD"), "deadbeef\n");
+    fs.writeFileSync(path.join(dir, "a.js"), "const x = 3; // resolved\n");
+    execFileSync("git", ["add", "a.js"], { cwd: dir });
+    const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+    expect(res.ok).toBe(false);
+    expect(process.exitCode).toBe(1);
+  });
+
   it("--check detects a stale verdict after the staged content changes", async () => {
     const staged = execFileSync("git", ["diff", "--cached"], { cwd: dir, encoding: "utf8" });
     await saveVerdict(dir, staged, { verdict: "approved", reviewer: "codex", issues: [] });


### PR DESCRIPTION
Fixes #1344. Un merge puro (MERGE_HEAD + diff staged vacío) no tiene diff al que ligar veredicto — todo lo que trae llegó revisado a las ramas padre — y el gate lo bloqueaba sin escape. kj review --check reconoce el caso y pasa con rastro; un merge CON resoluciones de conflicto stagea contenido real y sigue exigiendo su veredicto cruzado (test propio). Los diffs vacíos no-merge siguen fallando como siempre. Encontrado en dogfooding del PR #1343. TDD rojo-primero sobre el comando real; 81/81.