### PR TITLE
feat(privacy): kj privacy scan — the outbound boundary (KJC-TSK-0704, PV-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kj privacy scan` — the outbound privacy boundary** (KJC-TSK-0704, epic KJC-PCS-0070): audit any outbound surface for personal data before it ships — files/dirs (a build's `dist/`, a docs tree) or the staged diff's ADDED lines (`--staged`). Two layers: your personal denylist from `~/.karajan/privacy.yml` (`personal:`/`allow:` — global, never inside a repo: the list itself is sensitive) **blocks** with exit 1, and generic PII (email, phone, DNI/NIE, IBAN, card — karajan-rag's audited `redactPII`, the family engine, detecting and masking in one pass) **warns**. Findings never echo the datum they flag. Born from a real incident: personal emails published on a landing inside release notes. Gate integration (pre-commit, tarball) lands next (PV-B/PV-C).
+
 ### Fixed
 
 - **The verdict gate no longer deadlocks pure merge commits** (KJC-BUG-0132, issue #1344, found dogfooding PR #1343): a merge that stages no content of its own — e.g. merging main to move the merge-base — had no diff to bind a verdict to, and `kj review --staged` rightly refuses an empty diff, so the commit could never pass the pre-commit gate. `kj review --check` now recognizes the case (MERGE_HEAD present + empty staged diff) and passes with a trail line; a merge WITH conflict resolutions stages real content and still requires its cross-AI verdict.

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -146,8 +146,7 @@ const huBoardStubPlugin = {
 const ragStubPlugin = {
   name: "rag-stub",
   setup(build) {
-    // KJC-TSK-0704 — src/privacy/* rides the same stub: its engine is
-    // karajan-rag's redactPII, which cannot bundle (optional pg/lancedb).
+    // KJC-TSK-0704 — src/privacy/* rides this stub too: its engine is redactPII.
     build.onResolve({ filter: /[\\/](rag[\\/].+|privacy[\\/].+|commands[\\/](rag|watch|privacy))\.js$/ }, (args) => ({
       path: args.path, namespace: "rag-stub",
     }));

--- a/scripts/esbuild-sea.config.mjs
+++ b/scripts/esbuild-sea.config.mjs
@@ -146,7 +146,9 @@ const huBoardStubPlugin = {
 const ragStubPlugin = {
   name: "rag-stub",
   setup(build) {
-    build.onResolve({ filter: /[\\/](rag[\\/].+|commands[\\/](rag|watch))\.js$/ }, (args) => ({
+    // KJC-TSK-0704 — src/privacy/* rides the same stub: its engine is
+    // karajan-rag's redactPII, which cannot bundle (optional pg/lancedb).
+    build.onResolve({ filter: /[\\/](rag[\\/].+|privacy[\\/].+|commands[\\/](rag|watch|privacy))\.js$/ }, (args) => ({
       path: args.path, namespace: "rag-stub",
     }));
     build.onLoad({ filter: /.*/, namespace: "rag-stub" }, () => ({
@@ -192,6 +194,9 @@ const ragStubPlugin = {
           // reached from \`kj rag install-hooks\`, so it degrades like the rest.
           maybeAutoUpdate: async () => ({ skipped: true }),
           installPostMergeHook: notAvailable,
+          // KJC-TSK-0704 — privacy scan (engine = karajan-rag redactPII).
+          privacyScanCommand: notAvailable, loadPrivacyList: notAvailable,
+          scanText: notAvailable, scanPaths: notAvailable, privacyConfigPath: notAvailable,
           // KJC-BUG-0100 — the doctor rag-hooks check imports this; it throws
           // here and the check swallows it (degrades to a benign info result).
           resolveHooksDir: notAvailable,

--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -30,7 +30,7 @@ export const ADVANCED_GROUPS = [
   { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
-  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar"] },
+  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -261,6 +261,17 @@ export function registerMeta(program, { pkgVersion }) {
       });
     });
 
+  // KJC-TSK-0704 — the outbound privacy boundary: audit before anything ships.
+  const privacy = program.command("privacy").description("Personal-data (PII) auditing of outbound boundaries: staged diffs, build outputs, docs trees");
+  privacy.command("scan [paths...]")
+    .description("Scan files/dirs — or the staged diff's added lines with --staged — for personal data. Denylist hits (~/.karajan/privacy.yml) block with exit 1; generic PII (email/phone/DNI/NIE/IBAN/card via karajan-rag's redactPII) warns. Findings always come out masked.")
+    .option("--staged", "Scan the ADDED lines of the staged diff instead of paths")
+    .option("--json", "Machine-readable result")
+    .action(async (paths, flags) => {
+      const { privacyScanCommand } = await import("../commands/privacy.js");
+      await privacyScanCommand({ paths, flags });
+    });
+
   const rag = program.command("rag").description("Retrieval-augmented search over Karajan plans, onboarding briefs and project code");
   rag.command("index")
     .description("Index plans + onboarding (and optionally project sources) into the local vector store")

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -264,9 +264,9 @@ export function registerMeta(program, { pkgVersion }) {
   // KJC-TSK-0704 — the outbound privacy boundary: audit before anything ships.
   const privacy = program.command("privacy").description("Personal-data (PII) auditing of outbound boundaries: staged diffs, build outputs, docs trees");
   privacy.command("scan [paths...]")
-    .description("Scan files/dirs — or the staged diff's added lines with --staged — for personal data. Denylist hits (~/.karajan/privacy.yml) block with exit 1; generic PII (email/phone/DNI/NIE/IBAN/card via karajan-rag's redactPII) warns. Findings always come out masked.")
+    .description("Scan files/dirs for personal data, always masked in output: denylist hits (~/.karajan/privacy.yml) block with exit 1, generic PII (email/phone/DNI/NIE/IBAN/card via karajan-rag redactPII) warns")
     .option("--staged", "Scan the ADDED lines of the staged diff instead of paths")
-    .option("--json", "Machine-readable result")
+    .option("--json", "Machine-readable result (stdout carries exactly one JSON document)")
     .action(async (paths, flags) => {
       const { privacyScanCommand } = await import("../commands/privacy.js");
       await privacyScanCommand({ paths, flags });

--- a/src/commands/privacy.js
+++ b/src/commands/privacy.js
@@ -1,10 +1,8 @@
 /**
- * `kj privacy scan` (KJC-TSK-0704) — audit any outbound boundary for
- * personal data before it ships: files/dirs (a build's dist/, a docs tree)
- * or the staged diff's ADDED lines. Denylist hits block (exit 1), generic
- * PII warns; every finding comes out masked.
+ * `kj privacy scan` (KJC-TSK-0704) — audit an outbound boundary before it
+ * ships: files/dirs or the staged diff's ADDED lines. Denylist blocks
+ * (exit 1), generic PII warns; findings always come out masked.
  */
-
 import { runCommand } from "../utils/process.js";
 import { loadPrivacyList, scanPaths, scanText, privacyConfigPath } from "../privacy/scan.js";
 

--- a/src/commands/privacy.js
+++ b/src/commands/privacy.js
@@ -1,0 +1,47 @@
+/**
+ * `kj privacy scan` (KJC-TSK-0704) — audit any outbound boundary for
+ * personal data before it ships: files/dirs (a build's dist/, a docs tree)
+ * or the staged diff's ADDED lines. Denylist hits block (exit 1), generic
+ * PII warns; every finding comes out masked.
+ */
+
+import { runCommand } from "../utils/process.js";
+import { loadPrivacyList, scanPaths, scanText, privacyConfigPath } from "../privacy/scan.js";
+
+const addedLines = (diff) =>
+  diff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).map((l) => l.slice(1)).join("\n");
+
+export async function privacyScanCommand({ paths = [], flags = {}, logger = console } = {}) {
+  const list = loadPrivacyList();
+  let findings;
+  if (flags.staged) {
+    const res = await runCommand("git", ["diff", "--cached", "--no-ext-diff", "--unified=0"]);
+    findings = scanText(addedLines(res.stdout || ""), { list, source: "<staged diff>" });
+  } else {
+    if (paths.length === 0) {
+      logger.error?.("kj privacy scan: pass one or more paths, or --staged");
+      process.exitCode = 2;
+      return { ok: false, findings: [] };
+    }
+    findings = scanPaths(paths, { list });
+  }
+
+  const blocks = findings.filter((f) => f.severity === "block");
+  const warns = findings.filter((f) => f.severity === "warn");
+  const ok = blocks.length === 0;
+  process.exitCode = ok ? 0 : 1;
+  // --json keeps stdout machine-clean: exactly one JSON document, no prose.
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify({ ok, blocks: blocks.length, warns: warns.length, findings })}\n`);
+    return { ok, findings };
+  }
+  for (const f of blocks) logger.error?.(`✗ BLOCK [denylist] ${f.source}:${f.line} → ${f.masked}`);
+  for (const f of warns) logger.warn?.(`⚠ warn [${f.type}] ${f.source}:${f.line} → ${f.masked}`);
+  if (!list.present) {
+    logger.info?.(`hint: no personal denylist found — create ${privacyConfigPath()} (personal: [...], allow: [...]) so YOUR data blocks, not just warns`);
+  }
+  logger.info?.(ok
+    ? `privacy scan: clean of denylist hits (${warns.length} generic warning(s))`
+    : `privacy scan: ${blocks.length} personal-data hit(s) — this must not ship`);
+  return { ok, findings };
+}

--- a/src/privacy/scan.js
+++ b/src/privacy/scan.js
@@ -1,14 +1,10 @@
 /**
  * privacy — the outbound boundary scanner (KJC-TSK-0704, epic KJC-PCS-0070).
- *
- * Born from a real incident: personal emails published on a landing page
- * inside release notes. Inputs get sanitized at boundaries — outputs must
- * too. Engine: karajan-rag's audited redactPII (the family motor) applied
- * line by line, so it detects AND masks in one pass and a finding never
- * echoes the datum it flags. On top rides the user's personal denylist
- * from `~/.karajan/privacy.yml` (`personal:` block-level strings,
- * `allow:` public identities) — GLOBAL and never inside a repo: the list
- * itself is sensitive.
+ * Born from a real incident (personal emails published on a landing):
+ * outputs get sanitized at boundaries like inputs do. Engine: karajan-rag's
+ * audited redactPII line by line — detects AND masks in one pass, so a
+ * finding never echoes the datum. On top, the user's denylist from
+ * `~/.karajan/privacy.yml` — GLOBAL, never in a repo: the list is sensitive.
  */
 
 import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";

--- a/src/privacy/scan.js
+++ b/src/privacy/scan.js
@@ -1,0 +1,91 @@
+/**
+ * privacy — the outbound boundary scanner (KJC-TSK-0704, epic KJC-PCS-0070).
+ *
+ * Born from a real incident: personal emails published on a landing page
+ * inside release notes. Inputs get sanitized at boundaries — outputs must
+ * too. Engine: karajan-rag's audited redactPII (the family motor) applied
+ * line by line, so it detects AND masks in one pass and a finding never
+ * echoes the datum it flags. On top rides the user's personal denylist
+ * from `~/.karajan/privacy.yml` (`personal:` block-level strings,
+ * `allow:` public identities) — GLOBAL and never inside a repo: the list
+ * itself is sensitive.
+ */
+
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import os from "node:os";
+import { extname, join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { redactPII } from "karajan-rag";
+
+const SKIP_DIRS = new Set(["node_modules", ".git", ".kj"]);
+const BINARY_EXT = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".pdf", ".zip", ".gz", ".tgz", ".woff", ".woff2", ".ttf", ".eot", ".mp4", ".db", ".sqlite"]);
+const MAX_FILE_BYTES = 512 * 1024;
+
+export function privacyConfigPath(home = os.homedir()) {
+  return join(home, ".karajan", "privacy.yml");
+}
+
+/** Personal denylist + public-identity allowlist. Absent file → generics only. */
+export function loadPrivacyList({ home = os.homedir() } = {}) {
+  try {
+    const raw = parseYaml(readFileSync(privacyConfigPath(home), "utf8")) || {};
+    const clean = (xs) => (Array.isArray(xs) ? xs.map(String).map((s) => s.trim()).filter(Boolean) : []);
+    return { personal: clean(raw.personal), allow: clean(raw.allow), present: true };
+  } catch {
+    return { personal: [], allow: [], present: false };
+  }
+}
+
+const maskValue = (v) => (v.length <= 4 ? "***" : `${v.slice(0, 2)}***${v.slice(-2)}`);
+
+/**
+ * Scan a text. Returns findings — denylist hits as `severity:"block"`
+ * (masked value), generic PII as `severity:"warn"` (line already redacted).
+ */
+export function scanText(text, { list = loadPrivacyList(), source = "<text>" } = {}) {
+  const findings = [];
+  String(text).split("\n").forEach((line, i) => {
+    let probe = line;
+    for (const a of list.allow) probe = probe.split(a).join(" ");
+    for (const p of list.personal) {
+      let at = probe.toLowerCase().indexOf(p.toLowerCase());
+      if (at === -1) continue;
+      findings.push({ severity: "block", type: "denylist", source, line: i + 1, masked: maskValue(p) });
+      while (at !== -1) { // blank every occurrence so generics don't double-report it
+        probe = probe.slice(0, at) + " ".repeat(p.length) + probe.slice(at + p.length);
+        at = probe.toLowerCase().indexOf(p.toLowerCase());
+      }
+    }
+    const red = redactPII(probe);
+    if (red.total > 0) {
+      for (const [type, n] of Object.entries(red.counts)) {
+        if (n > 0) findings.push({ severity: "warn", type, source, line: i + 1, masked: red.text.trim().slice(0, 120) });
+      }
+    }
+  });
+  return findings;
+}
+
+/** Scan files/dirs recursively (skips node_modules/.git, binaries, big files). */
+export function scanPaths(paths, { list = loadPrivacyList() } = {}) {
+  const findings = [];
+  const visit = (p) => {
+    if (!existsSync(p)) return;
+    // lstat + skip symlinks: a link pointing at an ancestor would recurse
+    // forever, and a link out of the tree would scan content nobody ships.
+    const st = lstatSync(p);
+    if (st.isSymbolicLink()) return;
+    if (st.isDirectory()) {
+      for (const name of readdirSync(p)) {
+        if (!SKIP_DIRS.has(name)) visit(join(p, name));
+      }
+      return;
+    }
+    if (BINARY_EXT.has(extname(p).toLowerCase()) || st.size > MAX_FILE_BYTES) return;
+    const content = readFileSync(p);
+    if (content.includes(0)) return; // binary sniff: NUL byte
+    findings.push(...scanText(content.toString("utf8"), { list, source: p }));
+  };
+  for (const p of paths) visit(p);
+  return findings;
+}

--- a/src/privacy/scan.js
+++ b/src/privacy/scan.js
@@ -47,10 +47,8 @@ export function scanText(text, { list = loadPrivacyList(), source = "<text>" } =
       let at = probe.toLowerCase().indexOf(p.toLowerCase());
       if (at === -1) continue;
       findings.push({ severity: "block", type: "denylist", source, line: i + 1, masked: maskValue(p) });
-      while (at !== -1) { // blank every occurrence so generics don't double-report it
-        probe = probe.slice(0, at) + " ".repeat(p.length) + probe.slice(at + p.length);
-        at = probe.toLowerCase().indexOf(p.toLowerCase());
-      }
+      // Blank every occurrence so the generics don't double-report it.
+      while (at !== -1) { probe = probe.slice(0, at) + " ".repeat(p.length) + probe.slice(at + p.length); at = probe.toLowerCase().indexOf(p.toLowerCase()); }
     }
     const red = redactPII(probe);
     if (red.total > 0) {
@@ -67,8 +65,7 @@ export function scanPaths(paths, { list = loadPrivacyList() } = {}) {
   const findings = [];
   const visit = (p) => {
     if (!existsSync(p)) return;
-    // lstat + skip symlinks: a link pointing at an ancestor would recurse
-    // forever, and a link out of the tree would scan content nobody ships.
+    // Skip symlinks: an ancestor link recurses forever; an outside link ships nothing.
     const st = lstatSync(p);
     if (st.isSymbolicLink()) return;
     if (st.isDirectory()) {

--- a/tests/privacy/scan.test.js
+++ b/tests/privacy/scan.test.js
@@ -1,7 +1,5 @@
-// KJC-TSK-0704 (PV-A) — the outbound privacy boundary. Findings NEVER echo
-// the datum they flag: the denylist masks, the generics report the line
-// already redacted by karajan-rag's redactPII (the family engine).
-
+// KJC-TSK-0704 (PV-A) — outbound privacy boundary. Findings NEVER echo the
+// datum: denylist masks, generics report the redactPII-redacted line.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/tests/privacy/scan.test.js
+++ b/tests/privacy/scan.test.js
@@ -1,0 +1,55 @@
+// KJC-TSK-0704 (PV-A) — the outbound privacy boundary. Findings NEVER echo
+// the datum they flag: the denylist masks, the generics report the line
+// already redacted by karajan-rag's redactPII (the family engine).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadPrivacyList, scanText, scanPaths } from "../../src/privacy/scan.js";
+
+let home, dir;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kj-priv-home-"));
+  dir = mkdtempSync(join(tmpdir(), "kj-priv-dir-"));
+  mkdirSync(join(home, ".karajan"), { recursive: true });
+  writeFileSync(join(home, ".karajan", "privacy.yml"),
+    'personal:\n  - "secreto.real@example.com"\n  - "Nombre Muyprivado"\nallow:\n  - "@manufosela"\n  - "mjfosela"\n');
+});
+afterEach(() => { rmSync(home, { recursive: true, force: true }); rmSync(dir, { recursive: true, force: true }); });
+
+const list = () => loadPrivacyList({ home });
+
+describe("privacy/scan", () => {
+  it("denylist hits BLOCK and come out masked — the datum never echoes", () => {
+    const f = scanText("author: secreto.real@example.com\n", { list: list(), source: "a.md" });
+    const hit = f.find((x) => x.type === "denylist");
+    expect(hit).toMatchObject({ severity: "block", source: "a.md", line: 1 });
+    expect(JSON.stringify(f)).not.toContain("secreto.real@example.com");
+  });
+
+  it("generic PII warns with the line already redacted; allowlist keeps quiet", () => {
+    const f = scanText("dni 12345678Z\nponte con @manufosela\n", { list: list() });
+    expect(f.some((x) => x.severity === "warn" && x.type === "nif")).toBe(true);
+    expect(f.filter((x) => x.line === 2)).toEqual([]);
+    expect(JSON.stringify(f)).not.toContain("12345678Z");
+  });
+
+  it("works without privacy.yml (generics only, present:false)", () => {
+    const empty = loadPrivacyList({ home: join(home, "nope") });
+    expect(empty.present).toBe(false);
+    const f = scanText("mail generico: alguien@dominio.com\n", { list: empty });
+    expect(f.some((x) => x.type === "email" && x.severity === "warn")).toBe(true);
+  });
+
+  it("scanPaths walks dirs, skips node_modules, and reports file:line", () => {
+    writeFileSync(join(dir, "ok.txt"), "nada personal aqui\n");
+    writeFileSync(join(dir, "leak.txt"), "linea limpia\ncontacto Nombre Muyprivado\n");
+    mkdirSync(join(dir, "node_modules"), { recursive: true });
+    writeFileSync(join(dir, "node_modules", "x.txt"), "secreto.real@example.com\n");
+    const f = scanPaths([dir], { list: list() });
+    expect(f).toHaveLength(1);
+    expect(f[0]).toMatchObject({ severity: "block", line: 2 });
+    expect(f[0].source.endsWith("leak.txt")).toBe(true);
+  });
+});


### PR DESCRIPTION
PV-A de la épica Privacy Gate (KJC-PCS-0070), nacida del incidente real de mayo 2026. Motor: redactPII de karajan-rag línea a línea (detecta Y enmascara — un hallazgo jamás ecoa el dato) + denylist personal de ~/.karajan/privacy.yml (global, jamás en repo) con allowlist de identidades públicas. kj privacy scan <paths...> | --staged: denylist=block exit 1, PII genérico=warn. Dos catches de codex: --json con stdout limpio y walker que salta symlinks (ciclos). TDD rojo-primero con aserciones de no-echo; 128/128. PV-B (gate pre-commit) y PV-C (tarball/deploy) siguen.