### PR TITLE
feat(review): the privacy gate rides the pre-commit (KJC-TSK-0705, PV-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The privacy gate rides the pre-commit** (KJC-TSK-0705, PV-B): `kj review --staged/--check` now scan the ADDED lines of the staged diff — a denylist datum rejects the commit deterministically (masked, with `KJ_ALLOW_PII=1` as the named escape), generic PII warns (`privacy.generic: "block"` hardens). A commit carrying your personal data no longer reaches the repo; existing projects gain the gate on update, no hook regeneration. In the standalone binary (privacy stubbed) the gate degrades with a note instead of crashing.
 - **`kj privacy scan` — the outbound privacy boundary** (KJC-TSK-0704, epic KJC-PCS-0070): audit any outbound surface for personal data before it ships — files/dirs (a build's `dist/`, a docs tree) or the staged diff's ADDED lines (`--staged`). Two layers: your personal denylist from `~/.karajan/privacy.yml` (`personal:`/`allow:` — global, never inside a repo: the list itself is sensitive) **blocks** with exit 1, and generic PII (email, phone, DNI/NIE, IBAN, card — karajan-rag's audited `redactPII`, the family engine, detecting and masking in one pass) **warns**. Findings never echo the datum they flag. Born from a real incident: personal emails published on a landing inside release notes. Gate integration (pre-commit, tarball) lands next (PV-B/PV-C).
 
 ### Fixed

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -15,6 +15,7 @@ import { ensureGateTrackable } from "../review/gate-gitignore.js";
 import { runSonarPregate, formatSonarFinding } from "../review/sonar-pregate.js";
 import { checkCardFirst } from "../review/card-first.js";
 import { checkTestsWithCode } from "../review/tests-with-code.js";
+import { loadPrivacyList, scanText } from "../privacy/scan.js";
 
 // KJC-TSK-0686 (MG-A): card-first is a gate, not a habit. Runs on --staged
 // (before spending sonar/reviewer effort) AND on --check — the pre-commit
@@ -136,6 +137,44 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
       }
     }
   }
+  // KJC-TSK-0705 (PV-B): the outbound privacy boundary at commit time.
+  // Denylist data rejects (KJ_ALLOW_PII=1 is the named escape); generic PII
+  // warns (privacy.generic: "block" hardens). Added lines only — deletions
+  // don't publish. In the SEA binary the privacy module is stubbed and
+  // throws: the gate degrades with a note instead of crashing.
+  try {
+    const added = diff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).map((l) => l.slice(1)).join("\n");
+    const findings = scanText(added, { list: loadPrivacyList(), source: "<staged diff>" });
+    const blocks = findings.filter((f) => f.severity === "block");
+    const warns = findings.filter((f) => f.severity === "warn");
+    for (const f of warns) console.log(`⚠ privacy: [${f.type}] added line ${f.line} → ${f.masked} — personal data? move it out before it ships`);
+    const hardened = config?.privacy?.generic === "block" && warns.length > 0;
+    if (blocks.length > 0 || hardened) {
+      if (process.env.KJ_ALLOW_PII === "1") {
+        console.log(`⚠ privacy exempt: ${blocks.length} denylist hit(s) — KJ_ALLOW_PII=1 (explicit escape hatch)`);
+      } else {
+        for (const f of blocks) console.log(`✗ privacy: denylist hit on added line ${f.line} → ${f.masked}`);
+        const reason = `${blocks.length || warns.length} personal-data finding(s) in the staged diff — this must not reach the repo (KJ_ALLOW_PII=1 to override consciously)`;
+        console.log(`✗ privacy gate: ${reason}`);
+        process.exitCode = 1;
+        return { verdict: "rejected", reviewer: "privacy", issues: [{ severity: "high", description: reason }] };
+      }
+    }
+  } catch (err) {
+    // Known degradation: the SEA stub throws its install-from-npm message.
+    // Anything else fails CLOSED — a silent skip would defeat the guarantee.
+    if (/standalone binary/i.test(err?.message || "")) {
+      console.log("⚠ privacy gate unavailable in this build — skipping");
+    } else if (process.env.KJ_ALLOW_PII === "1") {
+      console.log(`⚠ privacy gate errored (${err.message}) — KJ_ALLOW_PII=1 (explicit escape hatch)`);
+    } else {
+      const reason = `privacy gate error: ${err.message} — refusing to pass the boundary unchecked (KJ_ALLOW_PII=1 to override consciously)`;
+      console.log(`✗ ${reason}`);
+      process.exitCode = 1;
+      return { verdict: "rejected", reviewer: "privacy", issues: [{ severity: "high", description: reason }] };
+    }
+  }
+
   const tests = checkTestsWithCode({ config, stagedFiles: changedFiles });
   if (tests.mode === "warn") console.log(`⚠ tests-with-code: ${tests.reason}`);
   if (tests.mode === "exempt") console.log(`⚠ tests-with-code exempt: ${tests.reason}`);

--- a/src/privacy/scan.js
+++ b/src/privacy/scan.js
@@ -18,7 +18,8 @@ const BINARY_EXT = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico", ".
 const MAX_FILE_BYTES = 512 * 1024;
 
 export function privacyConfigPath(home = os.homedir()) {
-  return join(home, ".karajan", "privacy.yml");
+  // KJ_PRIVACY_CONFIG: test/CI override of the global denylist location.
+  return process.env.KJ_PRIVACY_CONFIG || join(home, ".karajan", "privacy.yml");
 }
 
 /** Personal denylist + public-identity allowlist. Absent file → generics only. */

--- a/tests/review/review-gate.test.js
+++ b/tests/review/review-gate.test.js
@@ -41,6 +41,39 @@ describe("kj review gate", () => {
     expect(process.exitCode).toBe(0);
   });
 
+  // KJC-TSK-0705 (PV-B) — the privacy gate: a staged diff ADDING a denylist
+  // datum never becomes a commit; generic PII only warns.
+  describe("privacy gate", () => {
+    let cfgFile;
+    beforeEach(() => {
+      cfgFile = path.join(dir, "privacy.yml");
+      fs.writeFileSync(cfgFile, 'personal:\n  - "secreto.real@example.com"\n');
+      process.env.KJ_PRIVACY_CONFIG = cfgFile;
+    });
+    afterEach(() => { delete process.env.KJ_PRIVACY_CONFIG; delete process.env.KJ_ALLOW_PII; });
+
+    it("rejects when the staged diff adds a denylist datum — masked, never echoed", async () => {
+      fs.writeFileSync(path.join(dir, "a.js"), "const mail = 'secreto.real@example.com';\n");
+      execFileSync("git", ["add", "a.js"], { cwd: dir });
+      const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+      expect(res.verdict).toBe("rejected");
+      expect(res.reviewer).toBe("privacy");
+      expect(JSON.stringify(res)).not.toContain("secreto.real@example.com");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("KJ_ALLOW_PII=1 is the named escape; generic PII alone only warns", async () => {
+      process.env.KJ_ALLOW_PII = "1";
+      const res = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+      expect(res.reviewer).not.toBe("privacy"); // falls through to the verdict check
+      delete process.env.KJ_ALLOW_PII;
+      fs.writeFileSync(path.join(dir, "a.js"), "const mail = 'generico@dominio.com';\n");
+      execFileSync("git", ["add", "a.js"], { cwd: dir });
+      const generic = await reviewGateCommand({ config: { ...config, projectDir: dir }, flags: { check: true } });
+      expect(generic.reviewer).not.toBe("privacy"); // warn, not reject
+    });
+  });
+
   // KJC-BUG-0132 (issue #1344): a PURE merge stages nothing of its own —
   // everything it brings reached the parent branches reviewed. Demanding a
   // verdict of an empty diff deadlocks the merge.


### PR DESCRIPTION
PV-B de la épica Privacy Gate (KJC-PCS-0070). kj review --staged/--check escanean las líneas AÑADIDAS del diff con el motor de PV-A: hit de denylist rechaza el commit (enmascarado; escape con nombre KJ_ALLOW_PII=1), PII genérico avisa (privacy.generic: block endurece). Los proyectos existentes ganan el gate al actualizar sin regenerar hooks. Import estático (presupuesto de dynamic imports en su tope): en el binario SEA el stub lanza y el gate degrada con nota; cualquier otro error FALLA CERRADO (catch de codex — sin fallbacks silenciosos). Smoke real: staging de un fichero con mi email vetado → rechazado como mj***om. El incidente de mayo 2026 ya es imposible en el boundary de commit. TDD rojo-primero; 134/134.