### PR TITLE
chore(release): v4.10.0 — nothing personal ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.10.0] - 2026-08-01
+
+Minor. **Nothing personal ships** — every outbound boundary (staged diff, npm tarball, any build output) now audits for personal data and hardcoded secrets before it leaves the machine. Born from a real incident: personal emails published on a landing page inside release notes. Epic KJC-PCS-0070.
+
 ### Added
 
 - **Privacy onboarding rides `kj env install`** (KJC-TSK-0707, PV-D): on an interactive install without a denylist, kj ASKS — personal emails, phone/ID, name, public identities — and writes `~/.karajan/privacy.yml` itself (the user never fills YAML by hand; Enter skips any question; answers are never echoed back). Headless installs get a hint, never a block. Protection exists from minute one, not from the day you discover the command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Épica Privacy Gate completa (PRs #1347-#1351: motor+scan, gate pre-commit, secretos hardcodeados, tarball en verify-pack, onboarding en env install) + fix del merge-gate (#1346). verify-pack verde incluyendo su propio scan del tarball.