### PR TITLE
fix(env): installing IS activating (KJC-BUG-0133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installing IS activating** (KJC-BUG-0133, field case 2026-08-02): a session "installed karajan" and then wrote an entire feature by hand — no `kj run`, no review, rules violated — because the setup flow ordered `kj harden` + the verdict gate as TEXT steps the agent runs (or narrates), and `kj env install` didn't perform them. A decorative method is worse than none. Now `kj env install` does the enforcement itself, idempotently: git hooks, `core.hooksPath`, and the cross-AI verdict gate — *a commit outside the method is rejected, not narrated*. No git repo → the install BLOCKS pending (the guarantees do not exist without git); enforcement failure blocks too; `--no-enforce` is the named escape. And because a mid-session install lands the playbook in a context the session loaded long ago, the install now ends by PRINTING the method into the conversation: in effect from that very message.
+
 ## [4.10.0] - 2026-08-01
 
 Minor. **Nothing personal ships** — every outbound boundary (staged diff, npm tarball, any build output) now audits for personal data and hardcoded secrets before it leaves the machine. Born from a real incident: personal emails published on a landing page inside release notes. Epic KJC-PCS-0070.

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -134,6 +134,7 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Install/refresh the Karajan playbook for any host agent (CLAUDE.md, AGENTS.md, GEMINI.md)")
     .option("--target <target>", "claude | codex | gemini | all", "all")
     .option("--no-rag", "Skip building the RAG index when the project has none (ENV-E1)")
+    .option("--no-enforce", "Skip installing the git hooks + verdict gate (KJC-BUG-0133 — installing IS activating; skipping this leaves the method narratable)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "env-install", flags, async ({ config, logger }) => {
         const r = await envInstallCommand({ config, logger, flags });

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -4,7 +4,7 @@
  * files (CLAUDE.md, AGENTS.md), and make its step 1 real: when the project
  * has no RAG index yet, build it (default ON, `--no-rag` opts out).
  */
-import { installPlaybook } from "../environment/playbook.js";
+import { installPlaybook, renderPlaybook } from "../environment/playbook.js";
 import { renderBrief, listBriefs } from "../environment/briefs.js";
 import { existsSync } from "node:fs";
 import { openVecStore, projectSlug, getLastIndexedCommit, dbPath } from "../rag/vec-store.js";
@@ -14,6 +14,9 @@ import { onnxConfig, persistOnnxChoice, resetEmptyStore } from "../rag/onnx-fall
 import { verifyBoardAccess } from "../environment/board-access.js";
 import { ensurePrivacyList } from "../privacy/onboarding.js";
 import { createWizard } from "../utils/wizard.js";
+import { hardenCommand } from "./harden.js";
+import { reviewGateCommand } from "./review-gate.js";
+import { join } from "node:path";
 
 function hasRagIndex(config, projectDir) {
   // KJC-BUG-0128: probing must never CREATE the store — openVecStore runs
@@ -67,6 +70,35 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
     return result;
   }
   if (access.backend !== "hu-board") console.log(`✓ board access verified: ${access.via}`);
+
+  // KJC-BUG-0133 — installing IS activating. The setup flow used to order
+  // harden + the verdict gate as TEXT steps the agent runs (or narrates);
+  // a session that skipped them got a decorative method — field case
+  // 2026-08-02: installed karajan, then wrote everything by hand with
+  // nothing to stop it. env install now does them itself, idempotently.
+  if (flags.enforce !== false) {
+    if (!existsSync(join(projectDir, ".git"))) {
+      result.exitCode = PENDING_EXIT_CODE;
+      console.log(renderPendingBlock(
+        [{ tool: "git", action: "needs-user", reason: "the enforcement gates live in git hooks — run `git init` (Karajan's guarantees do not exist without git)" }],
+        { retry: "kj env install" },
+      ));
+      return result;
+    }
+    try {
+      const h = await hardenCommand({ projectDir, logger: console });
+      if (h?.ok === false) throw new Error(h.error || "kj harden failed");
+      await reviewGateCommand({ config, flags: { installGate: true } });
+      console.log("✓ enforcement active: git hooks + cross-AI verdict gate — a commit outside the method is rejected, not narrated");
+    } catch (err) {
+      result.exitCode = PENDING_EXIT_CODE;
+      console.log(renderPendingBlock(
+        [{ tool: "enforcement", action: "needs-user", reason: `hooks/gate could not be installed: ${err.message} — without them the method is narratable` }],
+        { retry: "kj env install" },
+      ));
+      return result;
+    }
+  }
 
   // ENV-E1: RAG-first — the playbook orders "query the RAG before coding",
   // so installing the environment guarantees the index exists. KJC-TSK-0659
@@ -138,6 +170,11 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
       wizard?.close();
     } catch { /* privacy onboarding is best-effort */ }
     console.log("  The host agent now follows the method: RAG first, TDD, cross-AI review before commit.");
+    // KJC-BUG-0133 (part 2): a mid-session install lands the playbook in
+    // CLAUDE.md, but the running session loaded its context BEFORE — nobody
+    // re-reads it. Print the method so it enters THIS conversation now.
+    console.log("\n— The Karajan method below is IN EFFECT from this very message. If your session started before this install, apply it from now on:\n");
+    console.log(renderPlaybook({ stateBackend: config?.state_backend || "hu-board", boardName: config?.board?.name || null }));
   }
   return result;
 }

--- a/tests/environment/install-is-activation.test.js
+++ b/tests/environment/install-is-activation.test.js
@@ -1,0 +1,66 @@
+// KJC-BUG-0133 — installing IS activating. Field case 2026-08-02: a session
+// "installed karajan" (playbook only), skipped the TEXT steps that installed
+// hooks/gate, then wrote everything by hand — nothing stopped it. env install
+// now performs enforcement itself and prints the method into the session.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/rag/vec-store.js", () => ({
+  openVecStore: vi.fn(() => ({ close: vi.fn() })),
+  projectSlug: vi.fn(() => "proj"),
+  getLastIndexedCommit: vi.fn(() => "abc"),
+  setLastIndexedCommit: vi.fn(),
+  countChunks: vi.fn(() => 1),
+  dbPath: vi.fn(() => process.cwd()),
+}));
+vi.mock("../../src/commands/rag.js", () => ({ ragIndexCommand: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock("../../src/environment/playbook.js", () => ({
+  installPlaybook: vi.fn(async () => ({ files: ["CLAUDE.md"], target: "claude" })),
+  renderPlaybook: vi.fn(() => "# Karajan method (v4)\n…"),
+}));
+vi.mock("../../src/environment/board-access.js", () => ({
+  verifyBoardAccess: vi.fn(() => ({ ok: true, backend: "hu-board", via: "bundled HU Board" })),
+}));
+vi.mock("../../src/commands/harden.js", () => ({ hardenCommand: vi.fn(async () => ({ ok: true })) }));
+vi.mock("../../src/commands/review-gate.js", () => ({ reviewGateCommand: vi.fn(async () => ({ installed: true })) }));
+
+import { envInstallCommand } from "../../src/commands/env.js";
+import { hardenCommand } from "../../src/commands/harden.js";
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+import { renderPlaybook } from "../../src/environment/playbook.js";
+
+let dir;
+beforeEach(() => {
+  vi.clearAllMocks();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-envact-"));
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("env install — installing IS activating (KJC-BUG-0133)", () => {
+  it("runs harden + the verdict gate itself and prints the method into the session", async () => {
+    const res = await envInstallCommand({ config: { projectDir: dir, rag: {} }, flags: { rag: false } });
+    expect(hardenCommand).toHaveBeenCalledTimes(1);
+    expect(hardenCommand.mock.calls[0][0].projectDir).toBe(dir);
+    expect(reviewGateCommand.mock.calls[0][0].flags.installGate).toBe(true);
+    expect(renderPlaybook).toHaveBeenCalled(); // the method enters THIS conversation
+    expect(res.exitCode).toBeUndefined();
+  });
+
+  it("without git the install BLOCKS pending — the guarantees do not exist without git", async () => {
+    fs.rmSync(path.join(dir, ".git"), { recursive: true, force: true });
+    const res = await envInstallCommand({ config: { projectDir: dir, rag: {} }, flags: { rag: false } });
+    expect(res.exitCode).toBe(3);
+    expect(hardenCommand).not.toHaveBeenCalled();
+  });
+
+  it("--no-enforce is the named escape and enforcement failure blocks pending", async () => {
+    await envInstallCommand({ config: { projectDir: dir, rag: {} }, flags: { rag: false, enforce: false } });
+    expect(hardenCommand).not.toHaveBeenCalled();
+    hardenCommand.mockResolvedValueOnce({ ok: false, error: "boom" });
+    const res = await envInstallCommand({ config: { projectDir: dir, rag: {} }, flags: { rag: false } });
+    expect(res.exitCode).toBe(3);
+  });
+});

--- a/tests/environment/rag-first.test.js
+++ b/tests/environment/rag-first.test.js
@@ -19,6 +19,7 @@ vi.mock("../../src/commands/rag.js", () => ({
 vi.mock("../../src/environment/playbook.js", () => ({
   // fresh object per call — envInstallCommand mutates its result
   installPlaybook: vi.fn(async () => ({ files: ["CLAUDE.md", "AGENTS.md"], target: "both" })),
+  renderPlaybook: vi.fn(() => "# Karajan method (v4)"),
 }));
 vi.mock("../../src/rag/onnx-fallback.js", async (orig) => ({
   ...(await orig()),
@@ -40,14 +41,14 @@ describe("env install is RAG-first", () => {
 
   it("builds the index with sources when the project has none", async () => {
     getLastIndexedCommit.mockReturnValue(null);
-    await envInstallCommand({ config, flags: {} });
+    await envInstallCommand({ config, flags: { enforce: false } });
     expect(ragIndexCommand).toHaveBeenCalledTimes(1);
     expect(ragIndexCommand.mock.calls[0][0].flags.withSources).toBe(true);
   });
 
   it("does not reindex when an index already exists", async () => {
     getLastIndexedCommit.mockReturnValue("abc123");
-    await envInstallCommand({ config, flags: {} });
+    await envInstallCommand({ config, flags: { enforce: false } });
     expect(ragIndexCommand).not.toHaveBeenCalled();
   });
 
@@ -68,7 +69,7 @@ describe("env install is RAG-first", () => {
     ragIndexCommand.mockRejectedValueOnce(new Error("ollama down"));
     const logs = [];
     const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
-    const res = await envInstallCommand({ config: explicitOllama, flags: {} });
+    const res = await envInstallCommand({ config: explicitOllama, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.files).toContain("CLAUDE.md");
     expect(res.ragError).toMatch(/ollama down/);
@@ -83,7 +84,7 @@ describe("env install is RAG-first", () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockResolvedValueOnce({ indexed: 0, files: 727, failed: 727 });
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config: explicitOllama, flags: {} });
+    const res = await envInstallCommand({ config: explicitOllama, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBe(3);
     expect(res.ragError).toMatch(/0 of 727/);
@@ -98,7 +99,7 @@ describe("env install is RAG-first", () => {
       .mockRejectedValueOnce(new Error("ollama down"))
       .mockResolvedValueOnce({ indexed: 300, files: 400, failed: 0 });
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBeUndefined(); // no block
     expect(ragIndexCommand).toHaveBeenCalledTimes(2);
@@ -115,7 +116,7 @@ describe("env install is RAG-first", () => {
     getLastIndexedCommit.mockReturnValue("abc123"); // would say "present" if consulted
     ragIndexCommand.mockResolvedValueOnce({ indexed: 10, files: 10, failed: 0 });
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    await envInstallCommand({ config, flags: {} });
+    await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(openVecStore).not.toHaveBeenCalled(); // no accidental DDL
     expect(ragIndexCommand).toHaveBeenCalled(); // treated as "no index yet"
@@ -127,7 +128,7 @@ describe("env install is RAG-first", () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockRejectedValueOnce(new Error("ollama down"));
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBe(3); // blocked — never destroys existing data
     expect(ragIndexCommand).toHaveBeenCalledTimes(1); // no second (onnx) attempt
@@ -139,7 +140,7 @@ describe("env install is RAG-first", () => {
       .mockRejectedValueOnce(new Error("ollama down"))
       .mockRejectedValueOnce(new Error("model download failed"));
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBe(3);
     expect(res.ragError).toMatch(/ollama down/);
@@ -152,7 +153,7 @@ describe("env install is RAG-first", () => {
     verifyBoardAccess.mockReturnValueOnce({ ok: false, backend: "external", name: "Linear", needed: ["configure the Linear MCP, or", "export LINEAR_API_KEY"] });
     const logs = [];
     const spy = vi.spyOn(console, "log").mockImplementation((...a) => logs.push(a.join(" ")));
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBe(3);
     expect(res.boardError).toMatch(/Linear|LINEAR/);
@@ -164,7 +165,7 @@ describe("env install is RAG-first", () => {
     getLastIndexedCommit.mockReturnValue(null);
     ragIndexCommand.mockResolvedValueOnce({ indexed: 512, files: 700, failed: 0 });
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const res = await envInstallCommand({ config, flags: {} });
+    const res = await envInstallCommand({ config, flags: { enforce: false } });
     spy.mockRestore();
     expect(res.exitCode).toBeUndefined();
   });


### PR DESCRIPTION
Application Blocker del caso de campo 2026-08-02: una sesión instaló karajan y desarrolló todo a mano — los prompts de setup ordenaban harden/gate/hooksPath como pasos de TEXTO y env install no hacía ninguno: método decorativo, el fallo exacto que v4 existe para impedir, en su propio instalador. Ahora env install ejecuta el enforcement él mismo (hooks + hooksPath + gate, idempotente); sin git = bloqueo pending; fallo de enforcement = bloqueo pending; --no-enforce como escape con nombre. Y como instalar a mitad de sesión aterriza el playbook en un contexto ya cargado, el install termina IMPRIMIENDO el método a la conversación: en vigor desde ese mensaje. PRUEBA en vivo: repo scratch → un solo env install instala todo y un commit manual es RECHAZADO ('no verdict recorded'). 86/86.