### PR TITLE
feat(harden): the tool gate — PreToolUse hooks (KJC-TSK-0710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The tool gate: rules imposed at tool time** (KJC-TSK-0710, from proposal KJC-PRP-0013 — suggested by the offending agent itself: *"instructions weren't enough; the environment must impose them"*): `kj harden` (standard+) now writes a PreToolUse hook script and wires it into the project's `.claude/settings.json` (merged, never clobbering the user's own settings). `Write` over an EXISTING file blocks with "use Edit" (`KJ_ALLOW_WRITE=1` escapes); a Bash command that reserializes whole JSON files to disk (`json.dump` + write signal) blocks with "make targeted edits" (`KJ_ALLOW_REWRITE=1`). A new rung under the commit gate: the rule fires when the tool is invoked, not when the agent remembers it. Fails open on garbage input — a gate bug never bricks a session. Claude-only v1; the abstraction arrives with the second host that supports tool hooks.
+
 ## [4.10.0] - 2026-08-02
 
 Minor. **Nothing personal ships** — every outbound boundary (staged diff, npm tarball, any build output) now audits for personal data and hardcoded secrets before it leaves the machine. Born from a real incident: personal emails published on a landing page inside release notes. Epic KJC-PCS-0070.

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -18,6 +18,7 @@ import { installConfigsForRoots } from "../harden/config-engine.js";
 import { installGuidelines } from "../harden/guidelines-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
 import { installHooks } from "../harden/harden-engine.js";
+import { installHarnessHooks } from "../harden/harness-hooks.js";
 import { detectStackRoots } from "../harden/stack-roots.js";
 import { installWorkflows } from "../harden/workflow-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
@@ -140,6 +141,12 @@ export async function hardenCommand({
   let result;
   try {
     result = await installHooks({ projectDir, profile, cmds, dryRun, baseBranch });
+    // KJC-TSK-0710 — the TOOL gate: rules imposed at tool time (Claude Code
+    // PreToolUse). Standard+ only; minimal stays hooks-lite.
+    if (profile !== "minimal" && !dryRun) {
+      const hh = installHarnessHooks({ projectDir, logger });
+      result.harnessHooks = hh.wired ? "wired" : "script-only";
+    }
   } catch (err) {
     if (json) logger.info?.(JSON.stringify({ ok: false, error: err.message }));
     else logger.error?.(`kj harden: ${err.message}`);

--- a/src/harden/harness-hooks.js
+++ b/src/harden/harness-hooks.js
@@ -1,0 +1,80 @@
+/**
+ * harness-hooks — the TOOL gate (KJC-TSK-0710, from proposal KJC-PRP-0013).
+ * Field case 2026-08-02: text rules were not enough — the environment must
+ * impose them AT TOOL TIME. `kj harden` writes a PreToolUse script and wires
+ * it into the project's `.claude/settings.json` (merged, never clobbered):
+ * Write over an existing file blocks ("use Edit", KJ_ALLOW_WRITE=1 escapes);
+ * Bash that reserializes whole JSON files blocks (KJ_ALLOW_REWRITE=1).
+ * Claude-only v1 — the abstraction arrives with the second host that
+ * supports tool hooks.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT_REL = join(".karajan", "harness", "pretooluse.mjs");
+
+const SCRIPT_BODY = `#!/usr/bin/env node
+// kj tool gate (KJC-TSK-0710) — managed by \`kj harden\`. Exit 2 blocks the
+// tool call (stderr explains why); anything unexpected fails OPEN (exit 0)
+// so a gate bug never bricks the session.
+import { existsSync } from "node:fs";
+let raw = "";
+process.stdin.on("data", (d) => { raw += d; });
+process.stdin.on("end", () => {
+  try {
+    const { tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
+    if (tool === "Write" && process.env.KJ_ALLOW_WRITE !== "1") {
+      if (input.file_path && existsSync(input.file_path)) {
+        console.error("kj tool gate: Write over an EXISTING file destroys unseen changes — use Edit for targeted changes (KJ_ALLOW_WRITE=1 to override consciously).");
+        process.exit(2);
+      }
+    }
+    if (tool === "Bash" && process.env.KJ_ALLOW_REWRITE !== "1") {
+      const cmd = String(input.command || "");
+      const writes = /open\\s*\\([^)]*["'][wa]["']|>\\s*\\S+\\.json\\b/.test(cmd);
+      if (/json\\.dumps?\\s*\\(/.test(cmd) && writes) {
+        console.error("kj tool gate: reserializing a whole JSON file makes the diff unreviewable — make targeted edits instead (KJ_ALLOW_REWRITE=1 to override consciously).");
+        process.exit(2);
+      }
+    }
+  } catch { /* fail open */ }
+  process.exit(0);
+});
+`;
+
+const hookEntry = (matcher) => ({ matcher, hooks: [{ type: "command", command: `node ${SCRIPT_REL}` }] });
+
+/** Write the script and merge the PreToolUse entries into .claude/settings.json. */
+export function installHarnessHooks({ projectDir = process.cwd(), logger = console } = {}) {
+  const scriptAbs = join(projectDir, SCRIPT_REL);
+  mkdirSync(join(projectDir, ".karajan", "harness"), { recursive: true });
+  writeFileSync(scriptAbs, SCRIPT_BODY, { mode: 0o755 });
+
+  const settingsPath = join(projectDir, ".claude", "settings.json");
+  let settings = {};
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    } catch {
+      logger.warn?.(`kj harden: ${settingsPath} is not valid JSON — leaving it untouched (tool gate script written, wire it manually)`);
+      return { script: scriptAbs, wired: false };
+    }
+  }
+  settings.hooks = settings.hooks || {};
+  // Preserve, never clobber: an existing PreToolUse with an unexpected shape
+  // is the user's business — leave the file alone (same as invalid JSON).
+  if ("PreToolUse" in settings.hooks && !Array.isArray(settings.hooks.PreToolUse)) {
+    logger.warn?.(`kj harden: ${settingsPath} has a non-array hooks.PreToolUse — leaving it untouched (tool gate script written, wire it manually)`);
+    return { script: scriptAbs, wired: false };
+  }
+  const pre = Array.isArray(settings.hooks.PreToolUse) ? settings.hooks.PreToolUse : [];
+  for (const matcher of ["Write", "Bash"]) {
+    const present = pre.some((e) => e?.matcher === matcher && JSON.stringify(e).includes("pretooluse.mjs"));
+    if (!present) pre.push(hookEntry(matcher));
+  }
+  settings.hooks.PreToolUse = pre;
+  mkdirSync(join(projectDir, ".claude"), { recursive: true });
+  writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+  return { script: scriptAbs, wired: true };
+}

--- a/tests/harden/harness-hooks.test.js
+++ b/tests/harden/harness-hooks.test.js
@@ -1,0 +1,62 @@
+// KJC-TSK-0710 — the TOOL gate: rules imposed at tool time, not remembered.
+// Field case 2026-08-02: "instructions weren't enough — the environment must
+// impose them" (the offending agent's own advice). Tests run the REAL script
+// through the hooks protocol (JSON on stdin, exit 2 = block).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { installHarnessHooks } from "../../src/harden/harness-hooks.js";
+
+let dir, script;
+const runHook = (payload, env = {}) =>
+  spawnSync("node", [script], { input: JSON.stringify(payload), encoding: "utf8", env: { ...process.env, ...env } });
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-toolgate-"));
+  installHarnessHooks({ projectDir: dir });
+  script = path.join(dir, ".karajan", "harness", "pretooluse.mjs");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("pretooluse script", () => {
+  it("blocks Write over an EXISTING file (use Edit), allows new files and the named escape", () => {
+    const existing = path.join(dir, "a.js");
+    fs.writeFileSync(existing, "x");
+    const blocked = runHook({ tool_name: "Write", tool_input: { file_path: existing } });
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/Edit/);
+    expect(runHook({ tool_name: "Write", tool_input: { file_path: path.join(dir, "new.js") } }).status).toBe(0);
+    expect(runHook({ tool_name: "Write", tool_input: { file_path: existing } }, { KJ_ALLOW_WRITE: "1" }).status).toBe(0);
+  });
+
+  it("blocks Bash that reserializes JSON to disk, allows benign bash and the escape", () => {
+    const cmd = { tool_name: "Bash", tool_input: { command: "python3 -c 'import json; json.dump(d, open(\"cfg.json\",\"w\"))'" } };
+    const blocked = runHook(cmd);
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/rewrit|puntuales|Edit/i);
+    expect(runHook({ tool_name: "Bash", tool_input: { command: "python3 -c 'import json; print(json.dumps(d))'" } }).status).toBe(0);
+    expect(runHook({ tool_name: "Bash", tool_input: { command: "ls -la" } }).status).toBe(0);
+    expect(runHook(cmd, { KJ_ALLOW_REWRITE: "1" }).status).toBe(0);
+  });
+
+  it("never crashes the tool flow on garbage input (fail open with exit 0)", () => {
+    expect(spawnSync("node", [script], { input: "not-json", encoding: "utf8" }).status).toBe(0);
+  });
+});
+
+describe("installHarnessHooks settings merge", () => {
+  it("is idempotent and preserves the user's existing settings", () => {
+    const settings = path.join(dir, ".claude", "settings.json");
+    fs.writeFileSync(settings, JSON.stringify({ model: "opus", hooks: { PreToolUse: [{ matcher: "Grep", hooks: [{ type: "command", command: "echo mine" }] }] } }));
+    installHarnessHooks({ projectDir: dir });
+    installHarnessHooks({ projectDir: dir });
+    const cfg = JSON.parse(fs.readFileSync(settings, "utf8"));
+    expect(cfg.model).toBe("opus");
+    const all = JSON.stringify(cfg.hooks.PreToolUse);
+    expect(all).toContain("echo mine");
+    expect((all.match(/pretooluse\.mjs/g) || []).length).toBe(2); // Write + Bash, once each
+  });
+});


### PR DESCRIPTION
Implementa KJC-PRP-0013 — el consejo del propio agente infractor del caso 2026-08-02: 'que el entorno las imponga'. kj harden (standard+) escribe .karajan/harness/pretooluse.mjs y lo cablea en .claude/settings.json del proyecto (merge que preserva lo del usuario, idempotente; forma inesperada o JSON inválido = no tocar). Reglas v1: Write sobre fichero EXISTENTE bloquea con 'usa Edit' (KJ_ALLOW_WRITE=1); Bash que reserializa JSON a disco bloquea con 'ediciones puntuales' (KJ_ALLOW_REWRITE=1). Escalón nuevo bajo el gate de commit: la regla dispara al invocar la herramienta, no cuando el agente se acuerda. Fail-open ante entrada basura — un bug del gate jamás rompe la sesión. Solo Claude v1. TDD sobre el script real vía protocolo stdin; 132/132.