### PR TITLE
feat(env): the RAG becomes a native tool (KJC-TSK-0711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The RAG becomes a native tool** (KJC-TSK-0711, field case 2026-08-03: agents in karajan projects grepped code by hand because the RAG was only "a Bash command a text line told them about"): `kj env install` now wires kj's RAG-only MCP server (`kj-rag-mcp`, ships with the package) into the project's `.mcp.json` — merged, idempotent, user entries preserved, invalid JSON untouched. Agents use the tools in their toolbox, so the official path (`kj_rag_query`) is now cheaper than the grep shortcut — the same shadow-AI principle the privacy epic borrowed. The playbook names the native tool alongside `kj rag query`.
+
 ## [4.10.0] - 2026-08-02
 
 Minor. **Nothing personal ships** — every outbound boundary (staged diff, npm tarball, any build output) now audits for personal data and hardcoded secrets before it leaves the machine. Born from a real incident: personal emails published on a landing page inside release notes. Epic KJC-PCS-0070.

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -13,6 +13,7 @@ import { renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-act
 import { onnxConfig, persistOnnxChoice, resetEmptyStore } from "../rag/onnx-fallback.js";
 import { verifyBoardAccess } from "../environment/board-access.js";
 import { ensurePrivacyList } from "../privacy/onboarding.js";
+import { installProjectMcp } from "../environment/mcp-wiring.js";
 import { createWizard } from "../utils/wizard.js";
 import { hardenCommand } from "./harden.js";
 import { reviewGateCommand } from "./review-gate.js";
@@ -54,6 +55,14 @@ export async function envInstallCommand({ config = null, logger = null, flags = 
     boardName: config?.board?.name || null,
   });
   console.log(`✓ Karajan playbook installed in: ${result.files.join(", ")}`);
+
+  // KJC-TSK-0711 — RAG as a native tool: agents use what is in their
+  // toolbox, so the official path must be cheaper than the grep shortcut.
+  try {
+    installProjectMcp({ projectDir, logger: console });
+  } catch (err) {
+    console.log(`⚠ could not wire kj-rag-mcp into .mcp.json: ${err.message}`);
+  }
 
   // KJC-TSK-0685 (user rule): Karajan does not run without a board — it is
   // what guarantees ordered, card-first work. Verify an OPERATIONAL access

--- a/src/environment/mcp-wiring.js
+++ b/src/environment/mcp-wiring.js
@@ -1,0 +1,44 @@
+/**
+ * mcp-wiring — RAG as a NATIVE tool (KJC-TSK-0711). Field case 2026-08-03:
+ * agents in karajan projects grep code by hand because the RAG is only "a
+ * Bash command a text line told them about". Agents use the tools in their
+ * toolbox, so env install wires kj's RAG-only MCP server (`kj-rag-mcp`,
+ * ships with the package) into the project's `.mcp.json` — the official
+ * path must be cheaper than the shortcut. Merge preserves the user's
+ * entries; invalid JSON is left untouched (preserve, never clobber).
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export function installProjectMcp({ projectDir = process.cwd(), logger = console } = {}) {
+  const mcpPath = join(projectDir, ".mcp.json");
+  let cfg = {};
+  if (existsSync(mcpPath)) {
+    try {
+      cfg = JSON.parse(readFileSync(mcpPath, "utf8"));
+    } catch {
+      logger.warn?.(`kj env: ${mcpPath} is not valid JSON — leaving it untouched (wire kj-rag-mcp manually for native RAG queries)`);
+      return { wired: false, reason: "invalid-json" };
+    }
+  }
+  if (cfg.mcpServers && typeof cfg.mcpServers !== "object") {
+    logger.warn?.(`kj env: ${mcpPath} has a non-object mcpServers — leaving it untouched`);
+    return { wired: false, reason: "unexpected-shape" };
+  }
+  cfg.mcpServers = cfg.mcpServers || {};
+  // Wired = the LAUNCH SPEC runs kj-rag-mcp (command or an arg, so `npx
+  // kj-rag-mcp` and absolute paths count) — never env/description fields.
+  const launchesRagMcp = (s) =>
+    Boolean(s) && typeof s === "object" && (
+      (typeof s.command === "string" && s.command.includes("kj-rag-mcp")) ||
+      (Array.isArray(s.args) && s.args.some((a) => typeof a === "string" && a.includes("kj-rag-mcp")))
+    );
+  const present = Object.values(cfg.mcpServers).some(launchesRagMcp);
+  if (!present) {
+    cfg.mcpServers["kj-rag"] = { command: "kj-rag-mcp", args: [] };
+    writeFileSync(mcpPath, `${JSON.stringify(cfg, null, 2)}\n`);
+    logger.info?.("✓ kj_rag_query wired as a NATIVE tool (.mcp.json → kj-rag-mcp): querying the RAG is now the agent's cheapest path");
+  }
+  return { wired: true, added: !present };
+}

--- a/src/environment/playbook.js
+++ b/src/environment/playbook.js
@@ -57,7 +57,8 @@ carries a cross-AI verdict.
 Invariants (the git gates enforce these — they are not suggestions):
 
 - The project RAG answers before you assume: \`kj rag query\` — never guess
-  what the codebase does.
+  what the codebase does. In MCP hosts the same index is the native
+  \`kj_rag_query\` tool: reach for it before grepping by hand.
 - ${trackingLine(stateBackend, boardName)}
 - Tests prove behavior: the failing test exists first (TDD), and the suite
   is never left red.

--- a/tests/environment/mcp-wiring.test.js
+++ b/tests/environment/mcp-wiring.test.js
@@ -1,0 +1,46 @@
+// KJC-TSK-0711 — RAG as a NATIVE tool: env install wires kj-rag-mcp into the
+// project's .mcp.json so agents query the RAG because it is their cheapest
+// path, not because a text line asked them to.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { installProjectMcp } from "../../src/environment/mcp-wiring.js";
+
+let dir;
+const mcpPath = () => path.join(dir, ".mcp.json");
+const read = () => JSON.parse(fs.readFileSync(mcpPath(), "utf8"));
+
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-mcpwire-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("installProjectMcp", () => {
+  it("creates .mcp.json with the kj-rag server when absent", () => {
+    const res = installProjectMcp({ projectDir: dir, logger: { info() {}, warn() {} } });
+    expect(res.wired).toBe(true);
+    expect(read().mcpServers["kj-rag"].command).toBe("kj-rag-mcp");
+  });
+
+  it("preserves existing servers and is idempotent", () => {
+    fs.writeFileSync(mcpPath(), JSON.stringify({ mcpServers: { mine: { command: "my-server" } } }));
+    installProjectMcp({ projectDir: dir, logger: { info() {}, warn() {} } });
+    installProjectMcp({ projectDir: dir, logger: { info() {}, warn() {} } });
+    const cfg = read();
+    expect(cfg.mcpServers.mine.command).toBe("my-server");
+    expect(Object.keys(cfg.mcpServers).filter((k) => JSON.stringify(cfg.mcpServers[k]).includes("kj-rag-mcp"))).toHaveLength(1);
+  });
+
+  it("a user entry already pointing at kj-rag-mcp counts as wired — no duplicate key added", () => {
+    fs.writeFileSync(mcpPath(), JSON.stringify({ mcpServers: { "my-kj": { command: "kj-rag-mcp" } } }));
+    const res = installProjectMcp({ projectDir: dir, logger: { info() {}, warn() {} } });
+    expect(res.wired).toBe(true);
+    expect(read().mcpServers["kj-rag"]).toBeUndefined();
+  });
+
+  it("invalid JSON is left untouched (preserve, never clobber)", () => {
+    fs.writeFileSync(mcpPath(), "{ not json");
+    const res = installProjectMcp({ projectDir: dir, logger: { info() {}, warn() {} } });
+    expect(res.wired).toBe(false);
+    expect(fs.readFileSync(mcpPath(), "utf8")).toBe("{ not json");
+  });
+});

--- a/tests/environment/playbook.test.js
+++ b/tests/environment/playbook.test.js
@@ -30,6 +30,8 @@ describe("renderPlaybook", () => {
       expect(text).toMatch(/as if the\s+codebase didn'?t exist/i);
       // KJC-TSK-0706: the outbound privacy boundary before publishing.
       expect(text).toMatch(/kj privacy scan/);
+      // KJC-TSK-0711: the RAG is a native MCP tool, not just a Bash command.
+      expect(text).toMatch(/kj_rag_query/);
       expect(text.split("\n").length).toBeLessThanOrEqual(60);
     });
   }


### PR DESCRIPTION
Caso de campo 2026-08-03: los agentes en proyectos karajan analizan código a mano porque el RAG solo existía como comando Bash mencionado en texto — los agentes usan las herramientas de su caja. env install cablea kj-rag-mcp (server RAG-only del paquete) en el .mcp.json del proyecto: merge idempotente por spec de lanzamiento (catch de codex refinado: command o args, jamás env/description), preserva entradas del usuario, JSON inválido intacto. kj_rag_query pasa a ser el camino más barato — el principio shadow-AI de la épica de privacidad. El playbook nombra la tool nativa (asertado). TDD, 90/90, smoke real.