### PR TITLE
feat(env): the board is a question, never a silent default (KJC-TSK-0709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The board is a question, never a silent default** (KJC-TSK-0709, field case 2026-08-02: an install defaulted to hu-board with the user's Planning Game MCP sitting configured and detectable): `kj env install` now detects the boards this machine can reach (Planning Game MCP, external boards by MCP mention or conventional token — `LINEAR_API_KEY`, `JIRA_API_TOKEN`…) BEFORE rendering the playbook. Interactive installs ask and PERSIST the choice in `.karajan/kj.config.yml` (asked once, ever); headless installs keep the default but name the alternatives and the exact line to switch. A backend declared in a config file is never asked again — and "declared" now means *written by you in a file*, because the merged config always carries the default and cannot tell a choice from a fallback. Drift caught along the way: the config schema never learned the `external` backend that shipped in v4.5.0 — a declared `state_backend: external` failed validation ever since. Fixed.
+
 - **The RAG becomes a native tool** (KJC-TSK-0711, field case 2026-08-03: agents in karajan projects grepped code by hand because the RAG was only "a Bash command a text line told them about"): `kj env install` now wires kj's RAG-only MCP server (`kj-rag-mcp`, ships with the package) into the project's `.mcp.json` — merged, idempotent, user entries preserved, invalid JSON untouched. Agents use the tools in their toolbox, so the official path (`kj_rag_query`) is now cheaper than the grep shortcut — the same shadow-AI principle the privacy epic borrowed. The playbook names the native tool alongside `kj rag query`.
 
 ## [4.10.0] - 2026-08-02

--- a/src/commands/env.js
+++ b/src/commands/env.js
@@ -12,6 +12,7 @@ import { ragIndexCommand } from "./rag.js";
 import { renderPendingBlock, PENDING_EXIT_CODE } from "../utils/pending-user-action.js";
 import { onnxConfig, persistOnnxChoice, resetEmptyStore } from "../rag/onnx-fallback.js";
 import { verifyBoardAccess } from "../environment/board-access.js";
+import { pickStateBackend } from "../environment/board-select.js";
 import { ensurePrivacyList } from "../privacy/onboarding.js";
 import { installProjectMcp } from "../environment/mcp-wiring.js";
 import { createWizard } from "../utils/wizard.js";
@@ -49,6 +50,23 @@ export function briefCommand({ config = null, flags = {}, role = null }) {
 
 export async function envInstallCommand({ config = null, logger = null, flags = {} }) {
   const projectDir = config?.projectDir || process.cwd();
+
+  // KJC-TSK-0709 — the board is chosen BEFORE the playbook renders (its
+  // tracking line depends on the backend): interactive installs ask when
+  // alternatives are reachable, headless installs name the default. The
+  // choice persists so it is only ever asked once.
+  try {
+    const wizard = process.stdin.isTTY && process.stdout.isTTY ? createWizard() : null;
+    const sel = await pickStateBackend({ projectDir, wizard, isTTY: Boolean(wizard), logger: console });
+    wizard?.close();
+    // The effective backend feeds the render on EVERY non-error path —
+    // chosen, declared-in-file or default — so the playbook never falls
+    // back to hu-board while the selection said otherwise.
+    config = { ...config, state_backend: sel.backend, board: sel.boardName ? { ...(config?.board || {}), name: sel.boardName } : config?.board };
+  } catch (err) {
+    console.log(`⚠ board selection failed (${err.message}) — continuing with the configured default`);
+  }
+
   const result = await installPlaybook({
     projectDir, target: flags.target || "all",
     stateBackend: config?.state_backend || "hu-board",

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -238,8 +238,10 @@ export const ConfigSchema = v.looseObject({
   // ENV-D1 (KJC-TSK-0642): where work items live — the integrated HU Board
   // or the user's Planning Game. The v4 playbook renders per backend.
   state_backend: v.optional(v.picklist(
-    ["hu-board", "planning-game"],
-    "state_backend must be \"hu-board\" or \"planning-game\""
+    // KJC-TSK-0709 caught the drift: "external" shipped in v4.5.0 (any
+    // board via the agent's own MCP/tools) but this picklist never learned it.
+    ["hu-board", "planning-game", "external"],
+    "state_backend must be \"hu-board\", \"planning-game\" or \"external\""
   )),
   review_rules: v.optional(v.string()),
   coder_rules: v.optional(v.string()),

--- a/src/environment/board-access.js
+++ b/src/environment/board-access.js
@@ -42,6 +42,25 @@ function mcpConfigsMention(slug, projectDir, home) {
   return null;
 }
 
+/**
+ * Boards reachable from this machine (KJC-TSK-0709): the bundled HU Board
+ * always; planning-game / external candidates when their MCP appears in a
+ * host config or a conventional token is exported. Presence-based, like
+ * verifyBoardAccess — an OPTION list, not a connectivity check.
+ */
+export function detectAvailableBoards({ projectDir = process.cwd(), env = process.env, home = os.homedir() } = {}) {
+  const boards = [{ value: "hu-board", label: "HU Board (bundled, zero setup)" }];
+  if (mcpConfigsMention("planning-game", projectDir, home)) {
+    boards.push({ value: "planning-game", label: "Planning Game (MCP detected)" });
+  }
+  for (const [slug, envs] of Object.entries(TOKEN_CONVENTIONS)) {
+    const token = envs.find((k) => env[k]);
+    if (token) boards.push({ value: `external:${slug}`, label: `${slug} (token ${token})` });
+    else if (mcpConfigsMention(slug, projectDir, home)) boards.push({ value: `external:${slug}`, label: `${slug} (MCP detected)` });
+  }
+  return boards;
+}
+
 export function verifyBoardAccess({ config = {}, projectDir = process.cwd(), env = process.env, home = os.homedir() } = {}) {
   const backend = config.state_backend || "hu-board";
 

--- a/src/environment/board-select.js
+++ b/src/environment/board-select.js
@@ -1,0 +1,58 @@
+/**
+ * board-select (KJC-TSK-0709) — never hu-board silently when alternatives
+ * are reachable. Field case 2026-08-02: an install defaulted to hu-board
+ * with the user's Planning Game MCP sitting configured and detectable.
+ * Interactive installs ASK and persist the choice; headless installs name
+ * the default and the exact line to change it. Declared = never asked.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parse as parseYaml, parseDocument } from "yaml";
+import { detectAvailableBoards } from "./board-access.js";
+import { getConfigPath, getProjectConfigPath } from "../config.js";
+
+// "Declared" means the USER wrote state_backend in a config FILE — the
+// merged config object always carries the hu-board default (defaults.js),
+// so it can never tell a choice from a fallback.
+async function declaredStateBackend(projectDir) {
+  for (const p of [getProjectConfigPath(projectDir), getConfigPath()]) {
+    try {
+      const raw = parseYaml(await fs.readFile(p, "utf8")) || {};
+      if (raw.state_backend) return { backend: raw.state_backend, boardName: raw.board?.name || null };
+    } catch { /* missing or unreadable — keep looking */ }
+  }
+  return null;
+}
+
+async function persistStateBackend(projectDir, backend, boardName) {
+  const configPath = getProjectConfigPath(projectDir);
+  let source = "";
+  try { source = await fs.readFile(configPath, "utf8"); } catch { /* no config yet — create it */ }
+  const doc = parseDocument(source || "{}");
+  doc.setIn(["state_backend"], backend);
+  if (boardName) doc.setIn(["board", "name"], boardName);
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, doc.toString(), "utf8");
+  return configPath;
+}
+
+export async function pickStateBackend({ projectDir = process.cwd(), home = os.homedir(), env = process.env, wizard = null, isTTY = false, logger = console } = {}) {
+  const declared = await declaredStateBackend(projectDir);
+  if (declared) return { ...declared, source: "declared" };
+  const boards = detectAvailableBoards({ projectDir, home, env });
+  if (boards.length <= 1) return { backend: "hu-board", boardName: null, source: "default" };
+  if (!wizard || !isTTY) {
+    logger.info?.(`⚠ board: defaulting to the bundled HU Board, but this machine can reach: ${boards.slice(1).map((b) => b.label).join(", ")} — switch with \`state_backend: planning-game\` (or \`external\` + board.name) in .karajan/kj.config.yml and re-run kj env install`);
+    return { backend: "hu-board", boardName: null, source: "default-informed" };
+  }
+  logger.info?.("Karajan needs a board (there is no 'none') — pick where card-first work lives:");
+  const value = await wizard.select("Which board governs this project?", boards);
+  const external = value.startsWith("external:");
+  const backend = external ? "external" : value;
+  const boardName = external ? value.slice("external:".length) : null;
+  await persistStateBackend(projectDir, backend, boardName);
+  logger.info?.(`✓ board: ${backend}${boardName ? ` (${boardName})` : ""} — persisted in .karajan/kj.config.yml`);
+  return { backend, boardName, source: "chosen" };
+}

--- a/tests/environment/board-select.test.js
+++ b/tests/environment/board-select.test.js
@@ -1,0 +1,78 @@
+// KJC-TSK-0709 — never hu-board silently when alternatives are reachable:
+// env install detects boards, asks in interactive installs, PERSISTS the
+// choice, and in headless runs names the default and how to change it.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { detectAvailableBoards } from "../../src/environment/board-access.js";
+import { pickStateBackend } from "../../src/environment/board-select.js";
+
+let dir, home;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-bsel-prj-"));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-bsel-home-"));
+  // Isolate the GLOBAL kj config: the developer's real one may declare a
+  // state_backend, and "declared" must come from files under test only.
+  process.env.KARAJAN_HOME = path.join(home, "karajan-home");
+  fs.writeFileSync(path.join(home, ".claude.json"), JSON.stringify({ mcpServers: { "planning-game-personal": { command: "pg" } } }));
+});
+afterEach(() => {
+  delete process.env.KARAJAN_HOME;
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+const quiet = { info() {} };
+
+describe("detectAvailableBoards", () => {
+  it("always offers hu-board and adds detected MCPs and token boards", () => {
+    const boards = detectAvailableBoards({ projectDir: dir, home, env: { LINEAR_API_KEY: "x" } });
+    const values = boards.map((b) => b.value);
+    expect(values[0]).toBe("hu-board");
+    expect(values).toContain("planning-game");
+    expect(values).toContain("external:linear");
+  });
+});
+
+describe("pickStateBackend", () => {
+  it("a state_backend declared in the project config FILE never asks (the merged default cannot count)", async () => {
+    fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".karajan", "kj.config.yml"), "state_backend: planning-game\n");
+    const res = await pickStateBackend({ projectDir: dir, home, logger: quiet });
+    expect(res).toMatchObject({ backend: "planning-game", source: "declared" });
+  });
+
+  it("interactive: asks, returns the choice and PERSISTS it to kj.config.yml", async () => {
+    const wizard = { select: async (_q, opts) => opts.find((o) => o.value === "planning-game").value };
+    const res = await pickStateBackend({ projectDir: dir, home, env: {}, wizard, isTTY: true, logger: quiet });
+    expect(res).toMatchObject({ backend: "planning-game", source: "chosen" });
+    const yml = fs.readFileSync(path.join(dir, ".karajan", "kj.config.yml"), "utf8");
+    expect(yml).toMatch(/state_backend:\s*planning-game/);
+  });
+
+  it("interactive external choice persists board.name too", async () => {
+    const wizard = { select: async (_q, opts) => opts.find((o) => o.value === "external:linear").value };
+    const res = await pickStateBackend({ projectDir: dir, home, env: { LINEAR_API_KEY: "x" }, wizard, isTTY: true, logger: quiet });
+    expect(res).toMatchObject({ backend: "external", boardName: "linear" });
+    const yml = fs.readFileSync(path.join(dir, ".karajan", "kj.config.yml"), "utf8");
+    expect(yml).toMatch(/state_backend:\s*external/);
+    expect(yml).toMatch(/name:\s*linear/);
+  });
+
+  it("headless with alternatives: defaults to hu-board but SAYS so and how to change", async () => {
+    const lines = [];
+    const res = await pickStateBackend({ projectDir: dir, home, env: {}, wizard: null, isTTY: false, logger: { info: (m) => lines.push(m) } });
+    expect(res).toMatchObject({ backend: "hu-board", source: "default-informed" });
+    expect(lines.join("\n")).toMatch(/state_backend/);
+    expect(lines.join("\n")).toMatch(/planning-game/i);
+  });
+
+  it("nothing else detectable: silent default, no noise", async () => {
+    fs.rmSync(path.join(home, ".claude.json"));
+    const lines = [];
+    const res = await pickStateBackend({ projectDir: dir, home, env: {}, logger: { info: (m) => lines.push(m) } });
+    expect(res).toMatchObject({ backend: "hu-board", source: "default" });
+    expect(lines).toEqual([]);
+  });
+});


### PR DESCRIPTION
Caso de campo 2026-08-02: una instalación asumió hu-board con el PG MCP del usuario configurado y detectable. env install detecta ahora los boards alcanzables (PG por MCP, externos por token o MCP) ANTES de renderizar el playbook: interactivo pregunta y PERSISTE (una vez en la vida); headless mantiene el default pero nombra alternativas y la línea exacta para cambiar; declarado en fichero jamás pregunta ('declarado' = escrito por ti — el config mergeado siempre lleva el default). El backend efectivo alimenta el render en TODAS las rutas (catch de codex). Drift de regalo: el schema nunca aprendió 'external' (v4.5.0) — fallaba validación desde entonces. 137/137, smoke real con home aislado: la línea headless listó Planning Game, linear y github de esta máquina.