### PR TITLE
feat(release): kj release check — the checklist made verifiable (KJC-TSK-0712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kj release check` — the release checklist made verifiable** (KJC-TSK-0712, born from the user's critique: *"whatever you note down, you eventually ignore it"* — a note loses salience; a check fails RED with the exact list): generic checks for any karajan project — manifest version vs the CHANGELOG's TOP section (Unreleased promoted?), no tag ahead of the manifest, privacy scan of the exact publishable file set — plus the project's own declarative items in `release_check.items` (`file_contains` with `{version}` interpolation, or any `command` with exit-0 semantics), written once by the agent during setup and evaluated forever after. Completes the per-project triad: commit check (pre-commit gate), PR check (harden CI), release check. First live run caught its first real finding within a minute — a wrong URL in this very repo's landing item.
+
 ## [4.11.0] - 2026-08-03
 
 Minor. **The toolbox decides** — agents use what is in front of them, so the RAG becomes a native MCP tool and the board becomes a question. Two installs-that-listen born from the same field week.

--- a/src/checks/release-check.js
+++ b/src/checks/release-check.js
@@ -1,11 +1,8 @@
 /**
- * release-check (KJC-TSK-0712) — the release checklist made verifiable.
- * Born from the user's critique: "whatever you note down, you eventually
- * ignore it" — a note loses salience; a check fails RED with the exact
- * list. Generic checks work for any karajan project; each project extends
- * with declarative items in `release_check.items` (file_contains with
- * {version} interpolation, or command with exit-0 semantics) — written by
- * the agent during setup, evaluated forever after.
+ * release-check (KJC-TSK-0712) — the release checklist made verifiable:
+ * a note loses salience; a check fails RED with the exact list. Generics
+ * fit any karajan project; each project extends via `release_check.items`
+ * (file_contains with {version}, or command with exit-0 semantics).
  */
 
 import { existsSync, readFileSync } from "node:fs";

--- a/src/checks/release-check.js
+++ b/src/checks/release-check.js
@@ -1,0 +1,112 @@
+/**
+ * release-check (KJC-TSK-0712) — the release checklist made verifiable.
+ * Born from the user's critique: "whatever you note down, you eventually
+ * ignore it" — a note loses salience; a check fails RED with the exact
+ * list. Generic checks work for any karajan project; each project extends
+ * with declarative items in `release_check.items` (file_contains with
+ * {version} interpolation, or command with exit-0 semantics) — written by
+ * the agent during setup, evaluated forever after.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { runCommand } from "../utils/process.js";
+import { loadPrivacyList, scanPaths } from "../privacy/scan.js";
+
+const semverCmp = (a, b) => {
+  const pa = a.split(".").map(Number), pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+  return 0;
+};
+
+async function genericChecks(projectDir) {
+  const checks = [];
+  const pkgPath = join(projectDir, "package.json");
+  if (!existsSync(pkgPath)) {
+    checks.push({ name: "manifest", ok: true, detail: "no package.json — generic version checks skipped (declared items still run)" });
+    return { checks, version: null, pkg: null };
+  }
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const version = pkg.version;
+  checks.push({ name: "manifest", ok: Boolean(version), detail: version ? `version ${version}` : "package.json has no version" });
+
+  const clPath = join(projectDir, "CHANGELOG.md");
+  if (!existsSync(clPath)) {
+    checks.push({ name: "changelog-current", ok: false, detail: "no CHANGELOG.md — the release story must exist before the release" });
+  } else {
+    const cl = readFileSync(clPath, "utf8");
+    const topVersioned = (cl.match(/^## \[(\d+\.\d+\.\d+)\]/m) || [])[1] || null;
+    // Content still sitting under [Unreleased] means unpromoted entries —
+    // the tarball would ship changes its release notes do not tell.
+    const afterUnreleased = cl.split(/^## \[Unreleased\]\s*$/m)[1] ?? "";
+    const unreleasedBody = afterUnreleased.split(/^## \[/m)[0] ?? "";
+    const pending = /\S/.test(unreleasedBody);
+    const ok = topVersioned === version && !pending;
+    checks.push({
+      name: "changelog-current",
+      ok,
+      detail: ok
+        ? `top section is [${version}], Unreleased empty`
+        : pending
+          ? `[Unreleased] still carries content — promote it into [${version}] before releasing`
+          : `top CHANGELOG section is [${topVersioned ?? "none"}] but the manifest says ${version} — promote Unreleased before releasing`,
+    });
+  }
+
+  const tagsOut = await runCommand("git", ["-C", projectDir, "tag", "--list", "v[0-9]*"]);
+  const tags = (tagsOut.stdout || "").split("\n").map((t) => t.trim().replace(/^v/, "")).filter((t) => /^\d+\.\d+\.\d+$/.test(t));
+  const ahead = version ? tags.filter((t) => semverCmp(t, version) > 0) : [];
+  checks.push({
+    name: "tags",
+    ok: ahead.length === 0,
+    detail: ahead.length ? `tag(s) ahead of the manifest exist: v${ahead.join(", v")}` : (tags.includes(version) ? `v${version} already tagged` : `tag v${version} pending (created after publish)`),
+  });
+  return { checks, version, pkg };
+}
+
+async function packPrivacyCheck(projectDir, pkg) {
+  // Every non-private named package is publishable (exports/files-based
+  // packages carry no main/bin) — they all get the scan.
+  if (!pkg || pkg.private === true || !pkg.name || !pkg.version) return null;
+  try {
+    const out = await runCommand("npm", ["pack", "--dry-run", "--json", "--silent"], { cwd: projectDir });
+    const files = (JSON.parse(out.stdout || "[]")[0]?.files || []).map((f) => join(projectDir, f.path));
+    const blocks = scanPaths(files, { list: loadPrivacyList() }).filter((f) => f.severity === "block");
+    return { name: "pack-privacy", ok: blocks.length === 0, detail: blocks.length ? `${blocks.length} personal-data/secret hit(s) in the publishable files` : `${files.length} publishable file(s) clean` };
+  } catch (err) {
+    return { name: "pack-privacy", ok: false, detail: `npm pack --dry-run failed: ${err.message}` };
+  }
+}
+
+async function declaredItems(projectDir, config, version) {
+  const items = config?.release_check?.items;
+  if (!Array.isArray(items)) return [];
+  const checks = [];
+  for (const item of items) {
+    const name = item?.name || "unnamed item";
+    if (item?.file_contains?.path && item.file_contains.pattern != null) {
+      const p = isAbsolute(item.file_contains.path) ? item.file_contains.path : join(projectDir, item.file_contains.path);
+      const needle = String(item.file_contains.pattern).replaceAll("{version}", version ?? "");
+      const ok = existsSync(p) && readFileSync(p, "utf8").includes(needle);
+      checks.push({ name, ok, detail: ok ? `"${needle}" found in ${item.file_contains.path}` : `"${needle}" NOT found in ${item.file_contains.path}` });
+    } else if (item?.command) {
+      try {
+        const res = await runCommand("sh", ["-c", String(item.command).replaceAll("{version}", version ?? "")], { cwd: projectDir });
+        checks.push({ name, ok: res.exitCode === 0, detail: res.exitCode === 0 ? "command exited 0" : `command exited ${res.exitCode}` });
+      } catch (err) {
+        checks.push({ name, ok: false, detail: `command failed to run: ${err.message}` });
+      }
+    } else {
+      checks.push({ name, ok: false, detail: "unknown item shape — use file_contains {path, pattern} or command" });
+    }
+  }
+  return checks;
+}
+
+export async function runReleaseCheck({ projectDir = process.cwd(), config = {} } = {}) {
+  const { checks, version, pkg } = await genericChecks(projectDir);
+  const pack = await packPrivacyCheck(projectDir, pkg);
+  if (pack) checks.push(pack);
+  checks.push(...await declaredItems(projectDir, config, version));
+  return { ok: checks.every((c) => c.ok), version, checks };
+}

--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -30,7 +30,7 @@ export const ADVANCED_GROUPS = [
   { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
-  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy"] },
+  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -262,6 +262,25 @@ export function registerMeta(program, { pkgVersion }) {
       });
     });
 
+  // KJC-TSK-0712 — the release checklist made verifiable: memory is the
+  // reminder, the check is the guarantee.
+  const release = program.command("release").description("Release ceremony helpers");
+  release.command("check")
+    .description("Verify the release checklist deterministically: manifest vs CHANGELOG top section vs tags, privacy scan of the publishable files, plus the project's own release_check.items (file_contains with {version} / command). Exit 1 lists exactly what is missing.")
+    .option("--json", "Machine-readable result")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "release-check", flags, async ({ config }) => {
+        const { runReleaseCheck } = await import("../checks/release-check.js");
+        const res = await runReleaseCheck({ projectDir: config?.projectDir || process.cwd(), config });
+        if (flags.json) process.stdout.write(`${JSON.stringify(res)}\n`);
+        else {
+          for (const c of res.checks) console.log(`  ${c.ok ? "✓" : "✗"} ${c.name}: ${c.detail}`);
+          console.log(res.ok ? `release check: ready to release ${res.version ?? ""}`.trim() : "release check: NOT ready — fix the red items first");
+        }
+        process.exitCode = res.ok ? 0 : 1;
+      });
+    });
+
   // KJC-TSK-0704 — the outbound privacy boundary: audit before anything ships.
   const privacy = program.command("privacy").description("Personal-data (PII) auditing of outbound boundaries: staged diffs, build outputs, docs trees");
   privacy.command("scan [paths...]")

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -20,6 +20,7 @@ import { mutateCommand } from "../commands/mutate.js";
 import { hardenCommand } from "../commands/harden.js";
 import { telemetryPreviewCommand, telemetryStatusCommand } from "../commands/telemetry.js";
 import { envInstallCommand, briefCommand } from "../commands/env.js";
+import { runReleaseCheck } from "../checks/release-check.js";
 import { agentRunCommand } from "../commands/agent-run.js";
 import { reportIssueCommand } from "../commands/report-issue.js";
 import { huCommand } from "../commands/hu.js";
@@ -262,15 +263,13 @@ export function registerMeta(program, { pkgVersion }) {
       });
     });
 
-  // KJC-TSK-0712 — the release checklist made verifiable: memory is the
-  // reminder, the check is the guarantee.
+  // KJC-TSK-0712 — memory is the reminder, the check is the guarantee.
   const release = program.command("release").description("Release ceremony helpers");
   release.command("check")
-    .description("Verify the release checklist deterministically: manifest vs CHANGELOG top section vs tags, privacy scan of the publishable files, plus the project's own release_check.items (file_contains with {version} / command). Exit 1 lists exactly what is missing.")
+    .description("Verify the release checklist deterministically (manifest vs CHANGELOG vs tags, privacy scan of publishable files, plus the project's release_check.items); exit 1 lists exactly what is missing")
     .option("--json", "Machine-readable result")
     .action(async (flags) => {
       await withConfig(pkgVersion, "release-check", flags, async ({ config }) => {
-        const { runReleaseCheck } = await import("../checks/release-check.js");
         const res = await runReleaseCheck({ projectDir: config?.projectDir || process.cwd(), config });
         if (flags.json) process.stdout.write(`${JSON.stringify(res)}\n`);
         else {

--- a/tests/checks/release-check.test.js
+++ b/tests/checks/release-check.test.js
@@ -1,6 +1,4 @@
-// KJC-TSK-0712 — the release checklist made verifiable. Born from the
-// user's critique: "whatever you note down, you eventually ignore it".
-// Memory is the reminder; the check is the guarantee.
+// KJC-TSK-0712 — memory is the reminder; the check is the guarantee.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
@@ -63,17 +61,13 @@ describe("runReleaseCheck — declared items", () => {
       { name: "footer shows version", file_contains: { path: "footer.html", pattern: "v{version}" } },
       { name: "always ok", command: "true" },
       { name: "always fails", command: "false" },
+      { name: "ghost", file_contains: { path: "nope.txt", pattern: "x" } }, // missing file = red, not crash
     ] } };
     const res = await runReleaseCheck({ projectDir: dir, config });
     expect(byName(res, "footer shows version").ok).toBe(true);
     expect(byName(res, "always ok").ok).toBe(true);
     expect(byName(res, "always fails").ok).toBe(false);
-    expect(res.ok).toBe(false);
-  });
-
-  it("a missing file in file_contains is a red check, not a crash", async () => {
-    const config = { release_check: { items: [{ name: "ghost", file_contains: { path: "nope.txt", pattern: "x" } }] } };
-    const res = await runReleaseCheck({ projectDir: dir, config });
     expect(byName(res, "ghost").ok).toBe(false);
+    expect(res.ok).toBe(false);
   });
 });

--- a/tests/checks/release-check.test.js
+++ b/tests/checks/release-check.test.js
@@ -1,0 +1,79 @@
+// KJC-TSK-0712 — the release checklist made verifiable. Born from the
+// user's critique: "whatever you note down, you eventually ignore it".
+// Memory is the reminder; the check is the guarantee.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { runReleaseCheck } from "../../src/checks/release-check.js";
+
+let dir;
+const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+const write = (rel, text) => fs.writeFileSync(path.join(dir, rel), text);
+const byName = (res, name) => res.checks.find((c) => c.name === name);
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-relcheck-"));
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  write("package.json", JSON.stringify({ name: "demo", version: "1.2.0", private: true }));
+  write("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n## [1.2.0] - 2026-08-03\n\n- stuff\n\n## [1.1.0] - 2026-08-01\n");
+  write("a.txt", "x"); git("add", "-A"); git("commit", "-qm", "base");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("runReleaseCheck — generics", () => {
+  it("passes when manifest, top CHANGELOG section and tags agree", async () => {
+    const res = await runReleaseCheck({ projectDir: dir, config: {} });
+    expect(res.ok).toBe(true);
+    expect(byName(res, "changelog-current").ok).toBe(true);
+  });
+
+  it("fails RED when the CHANGELOG top section is not the manifest version", async () => {
+    write("package.json", JSON.stringify({ name: "demo", version: "1.3.0", private: true }));
+    const res = await runReleaseCheck({ projectDir: dir, config: {} });
+    expect(res.ok).toBe(false);
+    const c = byName(res, "changelog-current");
+    expect(c.ok).toBe(false);
+    expect(c.detail).toContain("1.3.0");
+  });
+
+  it("fails when [Unreleased] still carries unpromoted content", async () => {
+    write("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- forgotten entry\n\n## [1.2.0] - 2026-08-03\n\n- stuff\n");
+    const res = await runReleaseCheck({ projectDir: dir, config: {} });
+    expect(byName(res, "changelog-current").ok).toBe(false);
+    expect(byName(res, "changelog-current").detail).toMatch(/Unreleased/);
+  });
+
+  it("fails when a tag AHEAD of the manifest exists; same-version tag is only info", async () => {
+    git("tag", "v1.2.0");
+    expect((await runReleaseCheck({ projectDir: dir, config: {} })).ok).toBe(true);
+    git("tag", "v1.4.0");
+    const res = await runReleaseCheck({ projectDir: dir, config: {} });
+    expect(res.ok).toBe(false);
+    expect(byName(res, "tags").detail).toContain("1.4.0");
+  });
+});
+
+describe("runReleaseCheck — declared items", () => {
+  it("file_contains interpolates {version}; command passes on exit 0 and fails otherwise", async () => {
+    write("footer.html", "<span>v1.2.0</span>");
+    const config = { release_check: { items: [
+      { name: "footer shows version", file_contains: { path: "footer.html", pattern: "v{version}" } },
+      { name: "always ok", command: "true" },
+      { name: "always fails", command: "false" },
+    ] } };
+    const res = await runReleaseCheck({ projectDir: dir, config });
+    expect(byName(res, "footer shows version").ok).toBe(true);
+    expect(byName(res, "always ok").ok).toBe(true);
+    expect(byName(res, "always fails").ok).toBe(false);
+    expect(res.ok).toBe(false);
+  });
+
+  it("a missing file in file_contains is a red check, not a crash", async () => {
+    const config = { release_check: { items: [{ name: "ghost", file_contains: { path: "nope.txt", pattern: "x" } }] } };
+    const res = await runReleaseCheck({ projectDir: dir, config });
+    expect(byName(res, "ghost").ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Nace de la crítica del usuario: 'da igual lo que apuntes, pasado un tiempo lo ignoras'. La memoria como recordatorio; el check como garantía. Genéricos (manifest vs sección TOP del CHANGELOG con Unreleased VACÍO, tags no adelantados, privacy scan del set publicable de todo paquete no-privado) + items declarativos (file_contains con {version} | command, fail-red sin crash). Tríada completa: commit/PR/release. Dos hallazgos reales el primer día: la URL del item de landing, y el Unreleased de este repo en rojo hasta la próxima release. Cuatro rondas de codex incorporadas. TDD, 6/6.