### PR TITLE
chore(release): v4.12.0 — memory is the reminder, the check is the guarantee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.12.0] - 2026-08-03
+
+Minor. **Memory is the reminder; the check is the guarantee** — the release checklist stops depending on anyone (human or AI) remembering it.
+
 ### Added
 
 - **`kj release check` — the release checklist made verifiable** (KJC-TSK-0712, born from the user's critique: *"whatever you note down, you eventually ignore it"* — a note loses salience; a check fails RED with the exact list): generic checks for any karajan project — manifest version vs the CHANGELOG's TOP section (Unreleased promoted?), no tag ahead of the manifest, privacy scan of the exact publishable file set — plus the project's own declarative items in `release_check.items` (`file_contains` with `{version}` interpolation, or any `command` with exit-0 semantics), written once by the agent during setup and evaluated forever after. Completes the per-project triad: commit check (pre-commit gate), PR check (harden CI), release check. First live run caught its first real finding within a minute — a wrong URL in this very repo's landing item.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.11.0",
+      "version": "4.12.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
Bump + CHANGELOG. Feature ya mergeada: #1362 (kj release check). El propio comando corrió como rito de salida: genéricos verdes, item de landing rojo esperado pre-publish (verifica el estado final). verify-pack verde.