### PR TITLE
feat(sentinel): per-session method state via posttooluse hook (KJC-TSK-0713)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -1,0 +1,61 @@
+/**
+ * sentinel-hooks — SEN-A (KJC-TSK-0713, epic KJC-PCS-0071 Karajan Sentinel).
+ * v3 had authority without intelligence; v4 intelligence without authority.
+ * The Sentinel separates them: a deterministic PROGRAM (zero LLM) supervises
+ * the agent through the harness's synchronous hooks — PostToolUse records
+ * method facts per session, Stop BLOCKS ending the turn while violations are
+ * open. Claude Code only: it is the one harness with synchronous blocking
+ * hooks, which is why the guaranteed level requires Claude as host (ADR).
+ * This module ships the state writer; the Stop gate lands next.
+ */
+
+import { mergeClaudeHooks, writeHarnessScript } from "./harness-hooks.js";
+
+const POST_BODY = `#!/usr/bin/env node
+// kj sentinel state writer (KJC-TSK-0713) — managed by \`kj harden\`.
+// Records deterministic method facts per session; never blocks, never fails
+// a tool call (PostToolUse, always exit 0).
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+const here = dirname(fileURLToPath(import.meta.url));
+const STATE = join(here, "sentinel-state.json");
+const ROOT = join(here, "..", "..");
+const TESTS = /(^|\\/)(tests?|__tests__|spec)\\/|\\.(test|spec)\\.[a-z]+$/;
+const CODE = /\\.(m?[jt]sx?|c[jt]s|py|go|rs|java|rb|php|cs|swift|kt|astro|svelte|vue|c|h|cc|cpp|hpp)$/;
+const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII"];
+let raw = "";
+process.stdin.on("data", (d) => { raw += d; });
+process.stdin.on("end", () => {
+  try {
+    const { session_id: sid = "default", tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
+    const file = input.file_path || input.notebook_path;
+    if (!["Write", "Edit", "MultiEdit", "NotebookEdit"].includes(tool) || !file) process.exit(0);
+    let state = {};
+    try { state = JSON.parse(readFileSync(STATE, "utf8")); } catch { /* fresh state */ }
+    state.sessions ||= {};
+    const s = (state.sessions[sid] ||= { edited_sources: [], edited_tests: [], escapes: [], errors: [], blocks: 0 });
+    s.at = Date.now();
+    const rel = relative(ROOT, file).replaceAll("\\\\", "/");
+    const bucket = TESTS.test(rel) ? s.edited_tests : CODE.test(rel) ? s.edited_sources : null;
+    if (bucket && !bucket.includes(rel)) bucket.push(rel);
+    for (const e of ESCAPES) if (process.env[e] === "1" && !s.escapes.includes(e)) s.escapes.push(e);
+    const ids = Object.keys(state.sessions);
+    if (ids.length > 5) delete state.sessions[ids.sort((a, b) => (state.sessions[a].at || 0) - (state.sessions[b].at || 0))[0]];
+    writeFileSync(STATE, JSON.stringify(state, null, 2));
+  } catch { /* fail open — the sentinel never breaks a tool call */ }
+  process.exit(0);
+});
+`;
+
+
+/** Write the state-writer script and wire PostToolUse into .claude/settings.json. */
+export function installSentinelHooks({ projectDir = process.cwd(), logger = console } = {}) {
+  const post = writeHarnessScript(projectDir, "posttooluse.mjs", POST_BODY);
+  const { wired } = mergeClaudeHooks({
+    projectDir,
+    logger,
+    entries: [{ event: "PostToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "posttooluse.mjs" }],
+  });
+  return { scripts: [post], wired };
+}

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -1,0 +1,72 @@
+// KJC-TSK-0713 SEN-A — the Sentinel: per-session method state (PostToolUse).
+// Tests run the REAL script through the hooks protocol (JSON on stdin),
+// inside a throwaway git repo. The Stop gate that consumes this state is the
+// next slice of the card.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync, execSync } from "node:child_process";
+import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
+
+let dir, postScript, statePath;
+const run = (script, payload, env = {}) =>
+  spawnSync("node", [script], {
+    input: typeof payload === "string" ? payload : JSON.stringify(payload),
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+const editTool = (file, session = "s1") => ({ session_id: session, tool_name: "Edit", tool_input: { file_path: file } });
+const state = () => JSON.parse(fs.readFileSync(statePath, "utf8"));
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-sentinel-"));
+  execSync(
+    "git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0001-demo",
+    { cwd: dir },
+  );
+  installSentinelHooks({ projectDir: dir });
+  postScript = path.join(dir, ".karajan", "harness", "posttooluse.mjs");
+  statePath = path.join(dir, ".karajan", "harness", "sentinel-state.json");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("posttooluse script (state writer)", () => {
+  it("records source edits and test edits separately, per session", () => {
+    expect(run(postScript, editTool(path.join(dir, "src", "a.js"))).status).toBe(0);
+    expect(run(postScript, editTool(path.join(dir, "tests", "a.test.js"))).status).toBe(0);
+    expect(run(postScript, editTool(path.join(dir, "README.md"))).status).toBe(0);
+    const s = state().sessions.s1;
+    expect(s.edited_sources).toEqual(["src/a.js"]);
+    expect(s.edited_tests).toEqual(["tests/a.test.js"]);
+  });
+
+  it("records used KJ_ALLOW_* escapes and never crashes on garbage input", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")), { KJ_ALLOW_NO_CARD: "1" });
+    expect(state().sessions.s1.escapes).toContain("KJ_ALLOW_NO_CARD");
+    expect(run(postScript, "not-json").status).toBe(0);
+  });
+});
+
+describe("installSentinelHooks settings merge", () => {
+  it("wires PostToolUse idempotently, preserving the user's entries", () => {
+    const settings = path.join(dir, ".claude", "settings.json");
+    const mine = { matcher: "Grep", hooks: [{ type: "command", command: "echo mine" }] };
+    fs.writeFileSync(settings, JSON.stringify({ model: "opus", hooks: { PostToolUse: [mine] } }));
+    installSentinelHooks({ projectDir: dir });
+    installSentinelHooks({ projectDir: dir });
+    const cfg = JSON.parse(fs.readFileSync(settings, "utf8"));
+    expect(cfg.model).toBe("opus");
+    expect(JSON.stringify(cfg.hooks.PostToolUse)).toContain("echo mine");
+    expect((JSON.stringify(cfg.hooks.PostToolUse).match(/posttooluse\.mjs/g) || []).length).toBe(1);
+  });
+
+  it("leaves a non-array hook event untouched and reports script-only", () => {
+    const settings = path.join(dir, ".claude", "settings.json");
+    fs.writeFileSync(settings, JSON.stringify({ hooks: { PostToolUse: { weird: true } } }));
+    const res = installSentinelHooks({ projectDir: dir });
+    expect(res.wired).toBe(false);
+    expect(JSON.parse(fs.readFileSync(settings, "utf8")).hooks.PostToolUse).toEqual({ weird: true });
+  });
+});


### PR DESCRIPTION
## Qué
Primera pieza de la épica **Karajan Sentinel** (KJC-PCS-0071): `src/harden/sentinel-hooks.js` escribe `.karajan/harness/posttooluse.mjs`, un hook PostToolUse determinista (cero LLM) que registra hechos de método por sesión en `sentinel-state.json`: fuentes editadas vs tests editados (clasificación por ruta/extensión), escapes `KJ_ALLOW_*` usados, y poda a las últimas 5 sesiones. Nunca bloquea, nunca rompe una tool call (fail-open con registro). El cableado usa `mergeClaudeHooks` (#1365): merge en `.claude/settings.json` preservando siempre lo del usuario.

## Por qué
v3 tenía autoridad sin inteligencia; v4 inteligencia sin autoridad. El Sentinel las separa: el programa manda, el agente piensa. Este estado es lo que consumirá el **Stop gate** (siguiente PR de la card): el turno no podrá terminar con violaciones abiertas. Claude-only por diseño (ADR aceptado: el harness garantizado exige Claude Code como anfitrión — es el único con hooks síncronos bloqueantes).

## Verificación
- Tests nuevos ejecutan el script REAL vía protocolo de hooks (JSON por stdin) en un repo git desechable.
- Suite completa: 6416/6416 en verde. `kj audit --security`: 0 findings.
- Veredicto cross-AI: APPROVED por codex (diff 00bc69bb8720).

Card: KJC-TSK-0713 (In Progress) · Sigue a #1365