### PR TITLE
feat(sentinel): stop gate — the turn cannot end with open violations (KJC-TSK-0713)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -31,7 +31,7 @@ export const ADVANCED_GROUPS = [
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release"] },
-  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby"] },
+  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby", "sentinel"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },
 ];

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -28,6 +28,9 @@ import { worktreeCommand } from "../commands/worktree.js";
 import { addAdr, listAdrs } from "../environment/adr.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
 import { withConfig } from "./_shared.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
 
 /**
  * Register the "meta" / single-role / housekeeping commands: pre-pipeline
@@ -278,6 +281,20 @@ export function registerMeta(program, { pkgVersion }) {
         }
         process.exitCode = res.ok ? 0 : 1;
       });
+    });
+
+  // KJC-TSK-0713 — the Sentinel: the method state the harness hooks record.
+  const sentinel = program.command("sentinel").description("Deterministic method supervisor wired into the harness hooks (Claude Code)");
+  sentinel.command("status")
+    .description("Print the per-session method facts (sources/tests edited, escapes used) and any open violation the Stop gate would block on")
+    .action(() => {
+      const script = join(process.cwd(), ".karajan", "harness", "stop.mjs");
+      if (!existsSync(script)) {
+        console.log("sentinel: not installed in this project — run `kj harden` (standard profile or higher)");
+        process.exitCode = 1;
+        return;
+      }
+      process.exitCode = spawnSync("node", [script, "--status"], { stdio: "inherit" }).status ?? 0;
     });
 
   // KJC-TSK-0704 — the outbound privacy boundary: audit before anything ships.

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -19,6 +19,7 @@ import { installGuidelines } from "../harden/guidelines-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
 import { installHooks } from "../harden/harden-engine.js";
 import { installHarnessHooks } from "../harden/harness-hooks.js";
+import { installSentinelHooks } from "../harden/sentinel-hooks.js";
 import { detectStackRoots } from "../harden/stack-roots.js";
 import { installWorkflows } from "../harden/workflow-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
@@ -146,6 +147,10 @@ export async function hardenCommand({
     if (profile !== "minimal" && !dryRun) {
       const hh = installHarnessHooks({ projectDir, logger });
       result.harnessHooks = hh.wired ? "wired" : "script-only";
+      // KJC-TSK-0713 — the Sentinel: method state + Stop gate (turn cannot
+      // end red). Same Claude-only harness surface as the tool gate.
+      const sh = installSentinelHooks({ projectDir, logger });
+      result.sentinelHooks = sh.wired ? "wired" : "script-only";
     }
   } catch (err) {
     if (json) logger.info?.(JSON.stringify({ ok: false, error: err.message }));

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -6,9 +6,9 @@
  * method facts per session, Stop BLOCKS ending the turn while violations are
  * open. Claude Code only: it is the one harness with synchronous blocking
  * hooks, which is why the guaranteed level requires Claude as host (ADR).
- * This module ships the state writer; the Stop gate lands next.
  */
 
+import { CARD_REF_RE } from "../review/card-first.js";
 import { mergeClaudeHooks, writeHarnessScript } from "./harness-hooks.js";
 
 const POST_BODY = `#!/usr/bin/env node
@@ -48,14 +48,85 @@ process.stdin.on("end", () => {
 });
 `;
 
+const STOP_BODY = `#!/usr/bin/env node
+// kj sentinel stop gate (KJC-TSK-0713) — managed by \`kj harden\`. Exit 2
+// BLOCKS ending the turn while method violations are open (stderr lists each
+// one with its remediation). Fails OPEN on corrupt state, git errors, or
+// after 3 unresolved blocks — a sentinel bug never bricks the session — and
+// the fail-open is recorded in the state. \`--status\` prints, never blocks.
+import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const here = dirname(fileURLToPath(import.meta.url));
+const STATE = join(here, "sentinel-state.json");
+const ROOT = join(here, "..", "..");
+const CARD = new RegExp(${JSON.stringify(CARD_REF_RE.source)}, "i");
+const load = () => { try { return JSON.parse(readFileSync(STATE, "utf8")); } catch { return { sessions: {} }; } };
+const branchOf = () => {
+  try { return execSync("git rev-parse --abbrev-ref HEAD", { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); }
+  catch { return null; }
+};
+const violations = (s, branch) => {
+  const v = [];
+  if (!s || !(s.edited_sources || []).length) return v;
+  if (branch === "main" || branch === "master") v.push("Fuentes editadas en la rama base '" + branch + "' — crea una rama: git checkout -b feat/<CARD-ID>-descripcion");
+  else if (branch && !CARD.test(branch)) v.push("La rama '" + branch + "' no referencia ninguna card — usa feat/<CARD-ID>-descripcion (y una card VIVA en el board)");
+  if (!(s.edited_tests || []).length) v.push("Fuentes editadas sin tocar un solo test (" + s.edited_sources.join(", ") + ") — escribe o actualiza el test que prueba el cambio");
+  return v;
+};
+if (process.argv.includes("--status")) {
+  const st = load();
+  const branch = branchOf();
+  const sessions = Object.entries(st.sessions || {});
+  if (!sessions.length) console.log("sentinel: sin actividad registrada en esta sesion");
+  for (const [sid, s] of sessions) {
+    console.log("session " + sid + ": sources=[" + (s.edited_sources || []).join(", ") + "] tests=[" + (s.edited_tests || []).join(", ") + "] escapes=[" + (s.escapes || []).join(", ") + "] blocks=" + (s.blocks || 0) + ((s.errors || []).length ? " errors=" + s.errors.length : ""));
+    for (const x of violations(s, branch)) console.log("  ROJO: " + x);
+  }
+  process.exit(0);
+}
+let raw = "";
+process.stdin.on("data", (d) => { raw += d; });
+process.stdin.on("end", () => {
+  try {
+    if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
+    const { session_id: sid = "default" } = JSON.parse(raw);
+    const state = load();
+    const s = state.sessions?.[sid];
+    if (!s) process.exit(0);
+    const v = violations(s, branchOf());
+    if (!v.length) {
+      s.blocks = 0;
+      writeFileSync(STATE, JSON.stringify(state, null, 2));
+      process.exit(0);
+    }
+    s.blocks = (s.blocks || 0) + 1;
+    if (s.blocks > 3) {
+      (s.errors ||= []).push("fail-open: 3 bloqueos consecutivos sin resolver — el sentinel se aparta para no colgar la sesion");
+      writeFileSync(STATE, JSON.stringify(state, null, 2));
+      console.error("kj sentinel: fail-open tras 3 bloqueos sin resolver — revisa kj sentinel status con tu usuario");
+      process.exit(0);
+    }
+    writeFileSync(STATE, JSON.stringify(state, null, 2));
+    console.error("kj sentinel: el turno NO puede terminar con el metodo en rojo:\\n" + v.map((x) => "- " + x).join("\\n") + "\\nResuelve las violaciones (o pide a tu usuario el escape) y termina de nuevo. Estado: kj sentinel status");
+    process.exit(2);
+  } catch { /* fail open */ }
+  process.exit(0);
+});
+`;
 
-/** Write the state-writer script and wire PostToolUse into .claude/settings.json. */
+/** Write both sentinel scripts and wire PostToolUse + Stop into .claude/settings.json. */
 export function installSentinelHooks({ projectDir = process.cwd(), logger = console } = {}) {
   const post = writeHarnessScript(projectDir, "posttooluse.mjs", POST_BODY);
+  const stop = writeHarnessScript(projectDir, "stop.mjs", STOP_BODY);
   const { wired } = mergeClaudeHooks({
     projectDir,
     logger,
-    entries: [{ event: "PostToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "posttooluse.mjs" }],
+    entries: [
+      { event: "PostToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "posttooluse.mjs" },
+      { event: "Stop", script: "stop.mjs" },
+    ],
   });
-  return { scripts: [post], wired };
+  return { scripts: [post, stop], wired };
 }

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -1,7 +1,7 @@
-// KJC-TSK-0713 SEN-A — the Sentinel: per-session method state (PostToolUse).
-// Tests run the REAL script through the hooks protocol (JSON on stdin),
-// inside a throwaway git repo. The Stop gate that consumes this state is the
-// next slice of the card.
+// KJC-TSK-0713 SEN-A — the Sentinel: per-session method state (PostToolUse)
+// plus a Stop hook that BLOCKS ending the turn while violations are open.
+// Tests run the REAL scripts through the hooks protocol (JSON on stdin,
+// exit 2 = block), inside a throwaway git repo.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
@@ -10,7 +10,7 @@ import path from "node:path";
 import { spawnSync, execSync } from "node:child_process";
 import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
 
-let dir, postScript, statePath;
+let dir, postScript, stopScript, statePath;
 const run = (script, payload, env = {}) =>
   spawnSync("node", [script], {
     input: typeof payload === "string" ? payload : JSON.stringify(payload),
@@ -28,6 +28,7 @@ beforeEach(() => {
   );
   installSentinelHooks({ projectDir: dir });
   postScript = path.join(dir, ".karajan", "harness", "posttooluse.mjs");
+  stopScript = path.join(dir, ".karajan", "harness", "stop.mjs");
   statePath = path.join(dir, ".karajan", "harness", "sentinel-state.json");
 });
 afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
@@ -49,8 +50,54 @@ describe("posttooluse script (state writer)", () => {
   });
 });
 
+describe("stop script (turn cannot end red)", () => {
+  it("blocks when sources were edited without touching a single test, then passes once a test is touched", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    const blocked = run(stopScript, { session_id: "s1" });
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/test/i);
+    run(postScript, editTool(path.join(dir, "tests", "a.test.js")));
+    expect(run(stopScript, { session_id: "s1" }).status).toBe(0);
+  });
+
+  it("blocks on the base branch and on a branch without a card ref, with remediation in the message", () => {
+    execSync("git checkout -q main", { cwd: dir });
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    run(postScript, editTool(path.join(dir, "tests", "a.test.js")));
+    const onMain = run(stopScript, { session_id: "s1" });
+    expect(onMain.status).toBe(2);
+    expect(onMain.stderr).toMatch(/rama base|base branch/i);
+    execSync("git checkout -q -b sin-card", { cwd: dir });
+    const noCard = run(stopScript, { session_id: "s1" });
+    expect(noCard.status).toBe(2);
+    expect(noCard.stderr).toMatch(/card/i);
+  });
+
+  it("ends the turn normally when nothing was edited, on escape, and on garbage input", () => {
+    expect(run(stopScript, { session_id: "empty" }).status).toBe(0);
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    expect(run(stopScript, { session_id: "s1" }, { KJ_SENTINEL_OFF: "1" }).status).toBe(0);
+    expect(run(stopScript, "not-json").status).toBe(0);
+  });
+
+  it("fails OPEN after 3 consecutive blocks (a sentinel bug never bricks the session) and records it", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    for (let i = 0; i < 3; i++) expect(run(stopScript, { session_id: "s1" }).status).toBe(2);
+    const open = run(stopScript, { session_id: "s1" });
+    expect(open.status).toBe(0);
+    expect(state().sessions.s1.errors.join(" ")).toMatch(/fail-open/);
+  });
+
+  it("--status prints the state without blocking", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    const res = spawnSync("node", [stopScript, "--status"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/src\/a\.js/);
+  });
+});
+
 describe("installSentinelHooks settings merge", () => {
-  it("wires PostToolUse idempotently, preserving the user's entries", () => {
+  it("wires PostToolUse and Stop idempotently, preserving the user's entries", () => {
     const settings = path.join(dir, ".claude", "settings.json");
     const mine = { matcher: "Grep", hooks: [{ type: "command", command: "echo mine" }] };
     fs.writeFileSync(settings, JSON.stringify({ model: "opus", hooks: { PostToolUse: [mine] } }));
@@ -60,13 +107,14 @@ describe("installSentinelHooks settings merge", () => {
     expect(cfg.model).toBe("opus");
     expect(JSON.stringify(cfg.hooks.PostToolUse)).toContain("echo mine");
     expect((JSON.stringify(cfg.hooks.PostToolUse).match(/posttooluse\.mjs/g) || []).length).toBe(1);
+    expect((JSON.stringify(cfg.hooks.Stop).match(/stop\.mjs/g) || []).length).toBe(1);
   });
 
   it("leaves a non-array hook event untouched and reports script-only", () => {
     const settings = path.join(dir, ".claude", "settings.json");
-    fs.writeFileSync(settings, JSON.stringify({ hooks: { PostToolUse: { weird: true } } }));
+    fs.writeFileSync(settings, JSON.stringify({ hooks: { Stop: { weird: true } } }));
     const res = installSentinelHooks({ projectDir: dir });
     expect(res.wired).toBe(false);
-    expect(JSON.parse(fs.readFileSync(settings, "utf8")).hooks.PostToolUse).toEqual({ weird: true });
+    expect(JSON.parse(fs.readFileSync(settings, "utf8")).hooks.Stop).toEqual({ weird: true });
   });
 });


### PR DESCRIPTION
## Qué
Cierre de SEN-A (épica **Karajan Sentinel** KJC-PCS-0071). `.karajan/harness/stop.mjs`: hook **Stop** determinista que evalúa el estado de método de la sesión (#1366) y BLOQUEA el fin de turno (exit 2) mientras haya violaciones abiertas — cada una con su remediación en el mensaje: fuentes editadas en la rama base, rama sin card, fuentes sin tocar un solo test. Fail-open registrado ante estado corrupto, error de git o 3 bloqueos sin resolver (un bug del sentinel jamás cuelga la sesión). Escape: `KJ_SENTINEL_OFF=1`. `kj harden` (standard+) instala y cablea ambos hooks; `kj sentinel status` inspecciona el estado y las violaciones sin bloquear (mismo evaluador: `stop.mjs --status`). El regex de card se interpola desde `CARD_REF_RE` (fuente única, #card-first).

## Por qué
'Que no pueda seguir sin solventarlo' pasa de petición a estructura: el programa manda, el agente piensa. v3 = autoridad sin inteligencia; v4 = inteligencia sin autoridad; el Sentinel las separa. Claude-only por diseño (ADR aceptado): el harness garantizado exige Claude Code como anfitrión — Claude codifica, codex revisa, gemini retirado.

## Verificación
- Tests ejecutan el script REAL vía protocolo de hooks en un repo git desechable: bloqueo y desbloqueo al tocar test, rama base, rama sin card, escape, basura en stdin, fail-open a los 3 bloqueos, `--status`.
- Suite completa: 6421/6421 en verde. `kj audit --security`: 75 ficheros, 0 findings.
- Veredicto cross-AI: APPROVED por codex (diff 32a302d389fc).

Card: KJC-TSK-0713 · Cierra la terna #1365 → #1366 → este