### PR TITLE
refactor(sentinel): extract shared sentinel-lib for the harness scripts (KJC-TSK-0714)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -11,18 +11,54 @@
 import { CARD_REF_RE } from "../review/card-first.js";
 import { mergeClaudeHooks, writeHarnessScript } from "./harness-hooks.js";
 
+const LIB_BODY = `// kj sentinel shared lib (KJC-TSK-0714) — managed by \`kj harden\`.
+// Single source for every sentinel script: state, branch, classification,
+// violations, and escape recording.
+import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+const here = dirname(fileURLToPath(import.meta.url));
+export const STATE = join(here, "sentinel-state.json");
+export const ROOT = join(here, "..", "..");
+export const TESTS = /(^|\\/)(tests?|__tests__|spec)\\/|\\.(test|spec)\\.[a-z]+$/;
+export const CODE = /\\.(m?[jt]sx?|c[jt]s|py|go|rs|java|rb|php|cs|swift|kt|astro|svelte|vue|c|h|cc|cpp|hpp)$/;
+export const CARD = new RegExp(${JSON.stringify(CARD_REF_RE.source)}, "i");
+export const BASE_BRANCHES = new Set(["main", "master"]);
+export const load = () => { try { return JSON.parse(readFileSync(STATE, "utf8")); } catch { return {}; } };
+export const save = (state) => writeFileSync(STATE, JSON.stringify(state, null, 2));
+export const session = (state, sid) => {
+  state.sessions ||= {};
+  return (state.sessions[sid] ||= { edited_sources: [], edited_tests: [], escapes: [], errors: [], blocks: 0 });
+};
+export const branchOf = () => {
+  try { return execSync("git rev-parse --abbrev-ref HEAD", { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); }
+  catch { return null; }
+};
+export const violations = (s, branch) => {
+  const v = [];
+  if (!s || !(s.edited_sources || []).length) return v;
+  if (BASE_BRANCHES.has(branch)) v.push("Fuentes editadas en la rama base '" + branch + "' — crea una rama: git checkout -b feat/<CARD-ID>-descripcion");
+  else if (branch && !CARD.test(branch)) v.push("La rama '" + branch + "' no referencia ninguna card — usa feat/<CARD-ID>-descripcion (y una card VIVA en el board)");
+  if (!(s.edited_tests || []).length) v.push("Fuentes editadas sin tocar un solo test (" + s.edited_sources.join(", ") + ") — escribe o actualiza el test que prueba el cambio");
+  return v;
+};
+export const recordEscape = (sid, escape, tool) => {
+  const state = load();
+  const s = session(state, sid);
+  s.at = Date.now();
+  if (!s.escapes.includes(escape)) s.escapes.push(escape);
+  (state.escape_events ||= []).push({ escape, tool, sid, ts: Date.now() });
+  save(state);
+};
+`;
+
 const POST_BODY = `#!/usr/bin/env node
 // kj sentinel state writer (KJC-TSK-0713) — managed by \`kj harden\`.
 // Records deterministic method facts per session; never blocks, never fails
 // a tool call (PostToolUse, always exit 0).
-import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
-import { fileURLToPath } from "node:url";
-const here = dirname(fileURLToPath(import.meta.url));
-const STATE = join(here, "sentinel-state.json");
-const ROOT = join(here, "..", "..");
-const TESTS = /(^|\\/)(tests?|__tests__|spec)\\/|\\.(test|spec)\\.[a-z]+$/;
-const CODE = /\\.(m?[jt]sx?|c[jt]s|py|go|rs|java|rb|php|cs|swift|kt|astro|svelte|vue|c|h|cc|cpp|hpp)$/;
+import { relative } from "node:path";
+import { CODE, TESTS, ROOT, load, save, session } from "./sentinel-lib.mjs";
 const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII"];
 let raw = "";
 process.stdin.on("data", (d) => { raw += d; });
@@ -31,10 +67,8 @@ process.stdin.on("end", () => {
     const { session_id: sid = "default", tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
     const file = input.file_path || input.notebook_path;
     if (!["Write", "Edit", "MultiEdit", "NotebookEdit"].includes(tool) || !file) process.exit(0);
-    let state = {};
-    try { state = JSON.parse(readFileSync(STATE, "utf8")); } catch { /* fresh state */ }
-    state.sessions ||= {};
-    const s = (state.sessions[sid] ||= { edited_sources: [], edited_tests: [], escapes: [], errors: [], blocks: 0 });
+    const state = load();
+    const s = session(state, sid);
     s.at = Date.now();
     const rel = relative(ROOT, file).replaceAll("\\\\", "/");
     const bucket = TESTS.test(rel) ? s.edited_tests : CODE.test(rel) ? s.edited_sources : null;
@@ -42,7 +76,7 @@ process.stdin.on("end", () => {
     for (const e of ESCAPES) if (process.env[e] === "1" && !s.escapes.includes(e)) s.escapes.push(e);
     const ids = Object.keys(state.sessions);
     if (ids.length > 5) delete state.sessions[ids.sort((a, b) => (state.sessions[a].at || 0) - (state.sessions[b].at || 0))[0]];
-    writeFileSync(STATE, JSON.stringify(state, null, 2));
+    save(state);
   } catch { /* fail open — the sentinel never breaks a tool call */ }
   process.exit(0);
 });
@@ -54,27 +88,7 @@ const STOP_BODY = `#!/usr/bin/env node
 // one with its remediation). Fails OPEN on corrupt state, git errors, or
 // after 3 unresolved blocks — a sentinel bug never bricks the session — and
 // the fail-open is recorded in the state. \`--status\` prints, never blocks.
-import { readFileSync, writeFileSync } from "node:fs";
-import { execSync } from "node:child_process";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-const here = dirname(fileURLToPath(import.meta.url));
-const STATE = join(here, "sentinel-state.json");
-const ROOT = join(here, "..", "..");
-const CARD = new RegExp(${JSON.stringify(CARD_REF_RE.source)}, "i");
-const load = () => { try { return JSON.parse(readFileSync(STATE, "utf8")); } catch { return { sessions: {} }; } };
-const branchOf = () => {
-  try { return execSync("git rev-parse --abbrev-ref HEAD", { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); }
-  catch { return null; }
-};
-const violations = (s, branch) => {
-  const v = [];
-  if (!s || !(s.edited_sources || []).length) return v;
-  if (branch === "main" || branch === "master") v.push("Fuentes editadas en la rama base '" + branch + "' — crea una rama: git checkout -b feat/<CARD-ID>-descripcion");
-  else if (branch && !CARD.test(branch)) v.push("La rama '" + branch + "' no referencia ninguna card — usa feat/<CARD-ID>-descripcion (y una card VIVA en el board)");
-  if (!(s.edited_tests || []).length) v.push("Fuentes editadas sin tocar un solo test (" + s.edited_sources.join(", ") + ") — escribe o actualiza el test que prueba el cambio");
-  return v;
-};
+import { load, save, branchOf, violations } from "./sentinel-lib.mjs";
 if (process.argv.includes("--status")) {
   const st = load();
   const branch = branchOf();
@@ -98,17 +112,17 @@ process.stdin.on("end", () => {
     const v = violations(s, branchOf());
     if (!v.length) {
       s.blocks = 0;
-      writeFileSync(STATE, JSON.stringify(state, null, 2));
+      save(state);
       process.exit(0);
     }
     s.blocks = (s.blocks || 0) + 1;
     if (s.blocks > 3) {
       (s.errors ||= []).push("fail-open: 3 bloqueos consecutivos sin resolver — el sentinel se aparta para no colgar la sesion");
-      writeFileSync(STATE, JSON.stringify(state, null, 2));
+      save(state);
       console.error("kj sentinel: fail-open tras 3 bloqueos sin resolver — revisa kj sentinel status con tu usuario");
       process.exit(0);
     }
-    writeFileSync(STATE, JSON.stringify(state, null, 2));
+    save(state);
     console.error("kj sentinel: el turno NO puede terminar con el metodo en rojo:\\n" + v.map((x) => "- " + x).join("\\n") + "\\nResuelve las violaciones (o pide a tu usuario el escape) y termina de nuevo. Estado: kj sentinel status");
     process.exit(2);
   } catch { /* fail open */ }
@@ -116,8 +130,9 @@ process.stdin.on("end", () => {
 });
 `;
 
-/** Write both sentinel scripts and wire PostToolUse + Stop into .claude/settings.json. */
+/** Write the sentinel scripts (shared lib + state writer + stop gate) and wire them. */
 export function installSentinelHooks({ projectDir = process.cwd(), logger = console } = {}) {
+  const lib = writeHarnessScript(projectDir, "sentinel-lib.mjs", LIB_BODY);
   const post = writeHarnessScript(projectDir, "posttooluse.mjs", POST_BODY);
   const stop = writeHarnessScript(projectDir, "stop.mjs", STOP_BODY);
   const { wired } = mergeClaudeHooks({
@@ -128,5 +143,5 @@ export function installSentinelHooks({ projectDir = process.cwd(), logger = cons
       { event: "Stop", script: "stop.mjs" },
     ],
   });
-  return { scripts: [post, stop], wired };
+  return { scripts: [lib, post, stop], wired };
 }

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -96,6 +96,27 @@ describe("stop script (turn cannot end red)", () => {
   });
 });
 
+describe("sentinel-lib (shared single source)", () => {
+  it("is written by install, and both scripts import it instead of duplicating logic", async () => {
+    const lib = path.join(dir, ".karajan", "harness", "sentinel-lib.mjs");
+    expect(fs.existsSync(lib)).toBe(true);
+    for (const script of [postScript, stopScript]) {
+      expect(fs.readFileSync(script, "utf8")).toContain('from "./sentinel-lib.mjs"');
+    }
+    const mod = await import(`file://${lib}`);
+    expect(mod.violations({ edited_sources: ["src/a.js"], edited_tests: [] }, "main").length).toBe(2);
+    expect(mod.violations({ edited_sources: ["src/a.js"], edited_tests: ["tests/a.test.js"] }, "feat/KJC-TSK-0001-x")).toEqual([]);
+  });
+
+  it("recordEscape appends an auditable escape event to the state", async () => {
+    const mod = await import(`file://${path.join(dir, ".karajan", "harness", "sentinel-lib.mjs")}`);
+    mod.recordEscape("s1", "KJ_ALLOW_NO_CARD", "Edit");
+    expect(state().escape_events).toHaveLength(1);
+    expect(state().escape_events[0]).toMatchObject({ escape: "KJ_ALLOW_NO_CARD", tool: "Edit", sid: "s1" });
+    expect(state().sessions.s1.escapes).toContain("KJ_ALLOW_NO_CARD");
+  });
+});
+
 describe("installSentinelHooks settings merge", () => {
   it("wires PostToolUse and Stop idempotently, preserving the user's entries", () => {
     const settings = path.join(dir, ".claude", "settings.json");


### PR DESCRIPTION
## Qué
Primera pieza de SEN-B: la lógica común de los scripts del Sentinel (estado, rama, regex de card, clasificación fuente/test, violaciones) se extrae a `.karajan/harness/sentinel-lib.mjs` — fuente única importada vía ESM relativo por `posttooluse.mjs` y `stop.mjs`, que adelgazan sin cambio de comportamiento. La lib añade `recordEscape`: cada uso de escape `KJ_ALLOW_*` puede quedar como evento auditable en el estado (`escape_events[]`) — la base sobre la que construyen el PreToolUse con estado (siguiente PR) y la auditoría de SEN-C.

## Verificación
- Tests existentes del ciclo completo (bloqueo/desbloqueo del Stop, clasificación del writer) verdes sin tocar — el comportamiento queda pinnado; tests nuevos de la lib (violations, recordEscape) ejecutan el fichero REAL generado.
- Suite completa: 6423/6423 (una pasada intermedia mostró 2 flakes de runflow-triage por AUTH bajo carga paralela; aislados y en la repetición completa, verdes).
- Veredicto cross-AI: APPROVED por codex (diff 5a6f3dc707c3).

Card: KJC-TSK-0714 (In Progress) · Sigue la serie de KJC-PCS-0071