### PR TITLE
feat(sentinel): pretooluse gate — the rule fires before the damage (KJC-TSK-0714)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -130,18 +130,79 @@ process.stdin.on("end", () => {
 });
 `;
 
-/** Write the sentinel scripts (shared lib + state writer + stop gate) and wire them. */
+const PRETOOL_BODY = `#!/usr/bin/env node
+// kj sentinel pretooluse gate (KJC-TSK-0714) — managed by \`kj harden\`.
+// Consults the session method state BEFORE the tool runs: the rule fires
+// before the damage, not in the post-mortem. Exit 2 blocks (stderr says the
+// remediation); read-only tools are never wired here; every honored escape
+// is recorded as an auditable event. Fails OPEN on anything unexpected.
+import { relative } from "node:path";
+import { spawnSync } from "node:child_process";
+import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, load, violations, recordEscape } from "./sentinel-lib.mjs";
+const EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
+const PUBLISH = /\\bnpm\\s+publish\\b|\\bfirebase\\s+deploy\\b|\\bgh\\s+release\\s+create\\b/;
+const PUSH = /\\bgit\\s+push\\b/;
+let raw = "";
+process.stdin.on("data", (d) => { raw += d; });
+process.stdin.on("end", () => {
+  try {
+    if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
+    const { session_id: sid = "default", tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
+    if (EDIT_TOOLS.includes(tool)) {
+      const file = input.file_path || input.notebook_path;
+      const rel = file ? relative(ROOT, String(file)).replaceAll("\\\\", "/") : "";
+      if (rel && CODE.test(rel) && !TESTS.test(rel)) {
+        const branch = branchOf();
+        const why = !branch ? null : BASE_BRANCHES.has(branch) ? "base" : !CARD.test(branch) ? "nocard" : null;
+        if (why) {
+          if (process.env.KJ_ALLOW_NO_CARD === "1") { recordEscape(sid, "KJ_ALLOW_NO_CARD", tool); process.exit(0); }
+          console.error(why === "base"
+            ? "kj sentinel: no se editan fuentes en la rama base '" + branch + "' — crea la card (kj hu add) y la rama: git checkout -b feat/<CARD-ID>-descripcion. (KJ_ALLOW_NO_CARD=1 = excepcion consciente, queda registrada)"
+            : "kj sentinel: la rama '" + branch + "' no referencia ninguna card — crea/mueve la card a running (kj hu add | kj hu move) y usa una rama feat/<CARD-ID>-descripcion. (KJ_ALLOW_NO_CARD=1 = excepcion consciente, queda registrada)");
+          process.exit(2);
+        }
+      }
+    }
+    if (tool === "Bash") {
+      const cmd = String(input.command || "");
+      if (PUBLISH.test(cmd)) {
+        if (process.env.KJ_ALLOW_RELEASE === "1") { recordEscape(sid, "KJ_ALLOW_RELEASE", tool); process.exit(0); }
+        const res = spawnSync("kj", ["release", "check", "--json"], { cwd: ROOT, encoding: "utf8" });
+        if (res.error || res.status === null) process.exit(0);
+        if (res.status !== 0) {
+          let items = "";
+          try { items = (JSON.parse(res.stdout).checks || []).filter((c) => !c.ok).map((c) => "\\n- " + c.name + ": " + c.detail).join(""); } catch { /* raw output */ }
+          console.error("kj sentinel: release check en ROJO — no se publica ni despliega hasta resolverlo:" + (items || "\\n- corre kj release check para el detalle") + "\\n(KJ_ALLOW_RELEASE=1 = excepcion consciente, queda registrada)");
+          process.exit(2);
+        }
+      } else if (PUSH.test(cmd)) {
+        const v = violations(load().sessions?.[sid], branchOf());
+        if (v.length) {
+          console.error("kj sentinel: git push con el metodo en rojo:\\n" + v.map((x) => "- " + x).join("\\n") + "\\nResuelve antes de empujar. Estado: kj sentinel status");
+          process.exit(2);
+        }
+      }
+    }
+  } catch { /* fail open */ }
+  process.exit(0);
+});
+`;
+
+/** Write the sentinel scripts (shared lib + state writer + gates) and wire them. */
 export function installSentinelHooks({ projectDir = process.cwd(), logger = console } = {}) {
   const lib = writeHarnessScript(projectDir, "sentinel-lib.mjs", LIB_BODY);
   const post = writeHarnessScript(projectDir, "posttooluse.mjs", POST_BODY);
   const stop = writeHarnessScript(projectDir, "stop.mjs", STOP_BODY);
+  const pre = writeHarnessScript(projectDir, "pretooluse-sentinel.mjs", PRETOOL_BODY);
   const { wired } = mergeClaudeHooks({
     projectDir,
     logger,
     entries: [
+      { event: "PreToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "pretooluse-sentinel.mjs" },
+      { event: "PreToolUse", matcher: "Bash", script: "pretooluse-sentinel.mjs" },
       { event: "PostToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "posttooluse.mjs" },
       { event: "Stop", script: "stop.mjs" },
     ],
   });
-  return { scripts: [lib, post, stop], wired };
+  return { scripts: [lib, post, stop, pre], wired };
 }

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -96,6 +96,55 @@ describe("stop script (turn cannot end red)", () => {
   });
 });
 
+describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE the damage)", () => {
+  let gate;
+  beforeEach(() => {
+    gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+  });
+
+  it("blocks editing a source on a branch without card ref, with remediation and named escape recorded", () => {
+    execSync("git checkout -q -b sin-card", { cwd: dir });
+    const blocked = run(gate, editTool(path.join(dir, "src", "a.js")));
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/kj hu add|card/i);
+    const escaped = run(gate, editTool(path.join(dir, "src", "a.js")), { KJ_ALLOW_NO_CARD: "1" });
+    expect(escaped.status).toBe(0);
+    expect(state().escape_events.some((e) => e.escape === "KJ_ALLOW_NO_CARD")).toBe(true);
+  });
+
+  it("allows source edits on a card branch, test edits anywhere, and blocks on the base branch", () => {
+    expect(run(gate, editTool(path.join(dir, "src", "a.js"))).status).toBe(0);
+    execSync("git checkout -q main", { cwd: dir });
+    expect(run(gate, editTool(path.join(dir, "tests", "a.test.js"))).status).toBe(0);
+    expect(run(gate, editTool(path.join(dir, "src", "a.js"))).status).toBe(2);
+  });
+
+  it("blocks git push while method violations are open, allows once green", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")));
+    const push = { session_id: "s1", tool_name: "Bash", tool_input: { command: "git push origin HEAD" } };
+    expect(run(gate, push).status).toBe(2);
+    run(postScript, editTool(path.join(dir, "tests", "a.test.js")));
+    expect(run(gate, push).status).toBe(0);
+  });
+
+  it("blocks npm publish when the release check is red, honors the escape, and fails open without kj", () => {
+    const bin = path.join(dir, "fakebin");
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, "kj"),
+      `#!/bin/sh\necho '{"ok":false,"checks":[{"ok":false,"name":"changelog","detail":"missing section"}]}'\nexit 1\n`,
+      { mode: 0o755 },
+    );
+    const publish = { session_id: "s1", tool_name: "Bash", tool_input: { command: "npm publish --otp=123456" } };
+    const blocked = run(gate, publish, { PATH: `${bin}:${process.env.PATH}` });
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/changelog/);
+    expect(run(gate, publish, { PATH: `${bin}:${process.env.PATH}`, KJ_ALLOW_RELEASE: "1" }).status).toBe(0);
+    expect(run(gate, publish, { PATH: path.dirname(process.execPath) }).status).toBe(0);
+    expect(run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "ls -la" } }).status).toBe(0);
+  });
+});
+
 describe("sentinel-lib (shared single source)", () => {
   it("is written by install, and both scripts import it instead of duplicating logic", async () => {
     const lib = path.join(dir, ".karajan", "harness", "sentinel-lib.mjs");


### PR DESCRIPTION
## Qué
Cierre de SEN-B: `.karajan/harness/pretooluse-sentinel.mjs`, el gate PreToolUse CON ESTADO del Sentinel (compone con el tool gate estático de 0710 sin tocarlo — ambos matchean y cualquier exit 2 bloquea). Tres reglas que disparan ANTES del daño: (1) Edit/Write/MultiEdit/NotebookEdit sobre una FUENTE con rama base o sin card-ref → bloqueo con remediación exacta (`kj hu add` / rama `feat/<CARD-ID>`); escape `KJ_ALLOW_NO_CARD=1` honrado y registrado como evento auditable. (2) Bash con `npm publish`/`firebase deploy`/`gh release create` → corre `kj release check --json`; rojo → bloqueo listando los items exactos; `KJ_ALLOW_RELEASE=1` registrado; sin kj en PATH → fail-open. (3) `git push` con violaciones de método abiertas → bloqueo. Solo-lectura (Read/Grep/RAG) jamás se cablea. Todo fail-open ante lo inesperado.

## Por qué
El tool gate de 0710 evoluciona de reglas estáticas a supervisor con estado: la 'card viva' completa la sigue garantizando el gate de commit; el hook aproxima con la señal de rama (coste por tool call ≈ 0, sin acoplar el hook al CLI — alternativa considerada y descartada en el plan de la card).

## Verificación
- 4 tests nuevos ejecutan el script REAL: bloqueo sin card + escape registrado, rama base, push en rojo→verde, publish con release check rojo (kj falso determinista) + escape + fail-open sin kj.
- Suite completa: 6427/6427 × 2 pasadas (una intermedia mostró 7 fallos por contención de recursos tras el audit; irreproducibles en dos pasadas limpias consecutivas). `kj audit --security`: 0 findings.
- Veredicto cross-AI: APPROVED por codex (diff 87675c38e8b7).

Card: KJC-TSK-0714 · Sigue a #1369