### PR TITLE
feat(sentinel): self-protection and audited escapes (KJC-TSK-0715)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -31,6 +31,7 @@ import { withConfig } from "./_shared.js";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { verifySentinelScripts, resolveSentinelRoot } from "../harden/sentinel-hooks.js";
 
 /**
  * Register the "meta" / single-role / housekeeping commands: pre-pipeline
@@ -288,13 +289,22 @@ export function registerMeta(program, { pkgVersion }) {
   sentinel.command("status")
     .description("Print the per-session method facts (sources/tests edited, escapes used) and any open violation the Stop gate would block on")
     .action(() => {
-      const script = join(process.cwd(), ".karajan", "harness", "stop.mjs");
+      const script = join(resolveSentinelRoot(), ".karajan", "harness", "stop.mjs");
       if (!existsSync(script)) {
         console.log("sentinel: not installed in this project — run `kj harden` (standard profile or higher)");
         process.exitCode = 1;
         return;
       }
       process.exitCode = spawnSync("node", [script, "--status"], { stdio: "inherit" }).status ?? 0;
+    });
+  sentinel.command("verify")
+    .description("Verify the harness scripts match this kj install — the root of trust is the installed package, not the project tree; exit 1 lists what was modified")
+    .option("--json", "Machine-readable result")
+    .action((flags) => {
+      const res = verifySentinelScripts();
+      if (flags.json) process.stdout.write(`${JSON.stringify(res)}\n`);
+      else console.log(res.ok ? "sentinel verify: scripts intactos" : `sentinel verify: modificados fuera de kj harden: ${res.mismatched.join(", ")} — restaura con kj harden`);
+      process.exitCode = res.ok ? 0 : 1;
     });
 
   // KJC-TSK-0704 — the outbound privacy boundary: audit before anything ships.

--- a/src/commands/report.js
+++ b/src/commands/report.js
@@ -162,6 +162,9 @@ async function buildReport(dir, sessionId) {
   if (session.pg_task_id) report.pg_task_id = session.pg_task_id;
   if (session.pg_project_id) report.pg_project_id = session.pg_project_id;
   if (session.rtk_savings) report.rtk_savings = session.rtk_savings;
+  // The session may belong to another workspace: its snapshot knows the
+  // project dir the sentinel state lives in (same source solomon-rules uses).
+  if (session.config_snapshot?.projectDir) report.project_dir = session.config_snapshot.projectDir;
   return report;
 }
 
@@ -208,6 +211,36 @@ function printTextReport(report) {
   console.log(formatBudgetText(report.budget_consumed));
   console.log("Commits Generated:");
   console.log(formatCommitsText(report.commits_generated));
+}
+
+/**
+ * KJC-TSK-0715 — escapes are the user's decisions, never the agent's silent
+ * shortcuts: every KJ_ALLOW_* the sentinel honored surfaces in the report.
+ */
+export function formatSentinelEscapes(state) {
+  const events = Array.isArray(state?.escape_events) ? state.escape_events : [];
+  if (events.length === 0) return null;
+  const lines = events.map(
+    (e) => `  ${e.ts ? new Date(e.ts).toISOString() : "?"} ${e.escape} (tool: ${e.tool || "?"}, session: ${e.sid || "?"})`
+  );
+  return `Sentinel escapes used (${events.length}):\n${lines.join("\n")}`;
+}
+
+// The sentinel state is a PROJECT artifact (<project>/.karajan/harness), not
+// a session artifact: the `dir` the report handlers receive is the GLOBAL
+// sessions root (~/.karajan/sessions) and never contains it. `kj report` is
+// run from inside the project, so the project dir is the cwd — overridable
+// for callers reporting on another workspace.
+async function printSentinelEscapes({ projectDir = process.cwd(), format } = {}) {
+  if (format === "json") return;
+  try {
+    const raw = await fs.readFile(path.join(projectDir, ".karajan", "harness", "sentinel-state.json"), "utf8");
+    const text = formatSentinelEscapes(JSON.parse(raw));
+    if (text) {
+      console.log("");
+      console.log(text);
+    }
+  } catch { /* no sentinel state in this project — nothing to report */ }
 }
 
 function formatDuration(ms) {
@@ -384,6 +417,7 @@ async function handlePgTaskReport({ dir, pgTask, list, sessionId, format, trace,
   } else {
     printTextReport(report);
   }
+  await printSentinelEscapes({ projectDir: report.project_dir, format });
 }
 
 async function handleSingleSessionReport({ dir, entries, sessionId, format, trace, currency }) {
@@ -405,9 +439,10 @@ async function handleSingleSessionReport({ dir, entries, sessionId, format, trac
   if (trace) {
     const { cur, rate } = await resolveTraceOptions(currency);
     printTraceReport(report, cur, rate);
-    return;
+  } else {
+    printTextReport(report);
   }
-  printTextReport(report);
+  await printSentinelEscapes({ projectDir: report.project_dir, format });
 }
 
 export async function reportCommand({ list = false, sessionId = null, format = "text", trace = false, currency = "usd", pgTask = null }) {

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -8,8 +8,22 @@
  * hooks, which is why the guaranteed level requires Claude as host (ADR).
  */
 
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
 import { CARD_REF_RE } from "../review/card-first.js";
 import { mergeClaudeHooks, writeHarnessScript } from "./harness-hooks.js";
+
+/** The harness lives at the PROJECT root — resolve it even from a subdir. */
+export function resolveSentinelRoot(dir = process.cwd()) {
+  try {
+    return (
+      execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim() || dir
+    );
+  } catch {
+    return dir;
+  }
+}
 
 const LIB_BODY = `// kj sentinel shared lib (KJC-TSK-0714) — managed by \`kj harden\`.
 // Single source for every sentinel script: state, branch, classification,
@@ -73,7 +87,11 @@ process.stdin.on("end", () => {
     const rel = relative(ROOT, file).replaceAll("\\\\", "/");
     const bucket = TESTS.test(rel) ? s.edited_tests : CODE.test(rel) ? s.edited_sources : null;
     if (bucket && !bucket.includes(rel)) bucket.push(rel);
-    for (const e of ESCAPES) if (process.env[e] === "1" && !s.escapes.includes(e)) s.escapes.push(e);
+    for (const e of ESCAPES)
+      if (process.env[e] === "1" && !s.escapes.includes(e)) {
+        s.escapes.push(e);
+        (state.escape_events ||= []).push({ escape: e, tool, sid, ts: Date.now() });
+      }
     const ids = Object.keys(state.sessions);
     if (ids.length > 5) delete state.sessions[ids.sort((a, b) => (state.sessions[a].at || 0) - (state.sessions[b].at || 0))[0]];
     save(state);
@@ -88,7 +106,8 @@ const STOP_BODY = `#!/usr/bin/env node
 // one with its remediation). Fails OPEN on corrupt state, git errors, or
 // after 3 unresolved blocks — a sentinel bug never bricks the session — and
 // the fail-open is recorded in the state. \`--status\` prints, never blocks.
-import { load, save, branchOf, violations } from "./sentinel-lib.mjs";
+import { spawnSync } from "node:child_process";
+import { load, save, branchOf, violations, ROOT } from "./sentinel-lib.mjs";
 if (process.argv.includes("--status")) {
   const st = load();
   const branch = branchOf();
@@ -107,12 +126,34 @@ process.stdin.on("end", () => {
     if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
     const { session_id: sid = "default" } = JSON.parse(raw);
     const state = load();
+    // Tamper check runs regardless of session state: shell indirection leaves
+    // no edit-tool record, but it cannot survive \`kj sentinel verify\`, whose
+    // root of trust is the INSTALLED kj package (outside this project tree) —
+    // nothing under .karajan can vouch for itself. No kj on PATH → fail open.
+    const ver = spawnSync("kj", ["sentinel", "verify", "--json"], { cwd: ROOT, encoding: "utf8" });
+    let tampered = [];
+    if (!ver.error && ver.status !== null && ver.status !== 0) {
+      try { tampered = JSON.parse(ver.stdout).mismatched || ["unknown"]; } catch { tampered = ["unknown"]; }
+    }
+    if (tampered.length) {
+      state.tamper_blocks = (state.tamper_blocks || 0) + 1;
+      save(state);
+      if (state.tamper_blocks > 3) {
+        console.error("kj sentinel: fail-open tras 3 bloqueos por manipulacion sin restaurar — corre kj harden y avisa a tu usuario");
+        process.exit(0);
+      }
+      console.error("kj sentinel: scripts del supervisor modificados fuera de kj harden (" + tampered.join(", ") + ") — restaura con kj harden antes de terminar; si lo cambiaste tu (humano), reinstalar lo deja en verde.");
+      process.exit(2);
+    }
+    state.tamper_blocks = 0;
     const s = state.sessions?.[sid];
     if (!s) process.exit(0);
     const v = violations(s, branchOf());
     if (!v.length) {
       s.blocks = 0;
       save(state);
+      if ((s.escapes || []).length)
+        console.log(JSON.stringify({ systemMessage: "kj sentinel: esta sesion uso " + s.escapes.length + " escape(s): " + s.escapes.join(", ") + " — decision registrada; detalle en kj sentinel status." }));
       process.exit(0);
     }
     s.blocks = (s.blocks || 0) + 1;
@@ -142,12 +183,33 @@ import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, load, violations, rec
 const EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
 const PUBLISH = /\\bnpm\\s+publish\\b|\\bfirebase\\s+deploy\\b|\\bgh\\s+release\\s+create\\b/;
 const PUSH = /\\bgit\\s+push\\b/;
+const PROTECTED = /\\.claude\\/settings\\.json\\b|\\.karajan\\/(hooks|harness)\\//;
 let raw = "";
 process.stdin.on("data", (d) => { raw += d; });
 process.stdin.on("end", () => {
   try {
-    if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
     const { session_id: sid = "default", tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
+    // Self-protection (KJC-TSK-0715) rules run BEFORE any escape, including
+    // KJ_SENTINEL_OFF: the sentinel is not dismantled from inside a session —
+    // only the human, editing outside it.
+    if (EDIT_TOOLS.includes(tool)) {
+      const target = input.file_path || input.notebook_path;
+      const relT = target ? relative(ROOT, String(target)).replaceAll("\\\\", "/") : "";
+      if (relT && PROTECTED.test(relT)) {
+        console.error("kj sentinel: ese fichero es parte del supervisor (" + relT + ") — solo el humano desmonta el sentinel, editalo fuera de la sesion.");
+        process.exit(2);
+      }
+    }
+    // Any Bash that NAMES the supervisor's files is denied — a write-verb
+    // blocklist is bypassable (cp, dd, one-liners), and reading them is what
+    // the Read/Grep tools are for. Shell indirection (variables, globs,
+    // substitution) cannot be resolved from command text: that vector is
+    // caught by the Stop gate's checksum verification, which blocks the turn.
+    if (tool === "Bash" && PROTECTED.test(String(input.command || "").replaceAll("\\\\", "/"))) {
+      console.error("kj sentinel: los ficheros del supervisor no se tocan desde Bash — consultalos con la tool Read/Grep; solo el humano los modifica, fuera de la sesion.");
+      process.exit(2);
+    }
+    if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
     if (EDIT_TOOLS.includes(tool)) {
       const file = input.file_path || input.notebook_path;
       const rel = file ? relative(ROOT, String(file)).replaceAll("\\\\", "/") : "";
@@ -188,12 +250,37 @@ process.stdin.on("end", () => {
 });
 `;
 
+const SCRIPT_BODIES = {
+  "sentinel-lib.mjs": LIB_BODY,
+  "posttooluse.mjs": POST_BODY,
+  "stop.mjs": STOP_BODY,
+  "pretooluse-sentinel.mjs": PRETOOL_BODY,
+};
+
+/**
+ * Tamper detection (KJC-TSK-0715): compare the on-disk harness scripts with
+ * what THIS kj install would write. The root of trust is the installed kj
+ * package — outside the project tree, beyond the session's tool reach —
+ * because nothing under .karajan can vouch for itself.
+ */
+export function verifySentinelScripts({ projectDir } = {}) {
+  const dir = join(projectDir || resolveSentinelRoot(), ".karajan", "harness");
+  const mismatched = [];
+  for (const [name, body] of Object.entries(SCRIPT_BODIES)) {
+    try {
+      if (readFileSync(join(dir, name), "utf8") !== body) mismatched.push(name);
+    } catch {
+      mismatched.push(name);
+    }
+  }
+  return { ok: mismatched.length === 0, mismatched };
+}
+
 /** Write the sentinel scripts (shared lib + state writer + gates) and wire them. */
 export function installSentinelHooks({ projectDir = process.cwd(), logger = console } = {}) {
-  const lib = writeHarnessScript(projectDir, "sentinel-lib.mjs", LIB_BODY);
-  const post = writeHarnessScript(projectDir, "posttooluse.mjs", POST_BODY);
-  const stop = writeHarnessScript(projectDir, "stop.mjs", STOP_BODY);
-  const pre = writeHarnessScript(projectDir, "pretooluse-sentinel.mjs", PRETOOL_BODY);
+  const [lib, post, stop, pre] = Object.entries(SCRIPT_BODIES).map(([name, body]) =>
+    writeHarnessScript(projectDir, name, body),
+  );
   const { wired } = mergeClaudeHooks({
     projectDir,
     logger,

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -145,6 +145,72 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
   });
 });
 
+describe("self-protection + audited escapes (SEN-C)", () => {
+  let gate;
+  beforeEach(() => {
+    gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+  });
+
+  it("blocks the agent editing settings.json or the harness/hooks, with NO agent escape honored", () => {
+    for (const target of [
+      path.join(dir, ".claude", "settings.json"),
+      path.join(dir, ".karajan", "hooks", "pre-commit"),
+      path.join(dir, ".karajan", "harness", "stop.mjs"),
+    ]) {
+      const blocked = run(gate, editTool(target), { KJ_ALLOW_WRITE: "1", KJ_ALLOW_NO_CARD: "1", KJ_SENTINEL_OFF: "1" });
+      expect(blocked.status).toBe(2);
+      expect(blocked.stderr).toMatch(/humano|sentinel/i);
+    }
+  });
+
+  it("denies ANY Bash mentioning protected paths (write blocklists are bypassable), leaves other Bash alone", () => {
+    const bash = (command) => run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command } });
+    expect(bash("sed -i 's/x/y/' .karajan/harness/stop.mjs").status).toBe(2);
+    expect(bash("echo '{}' > .claude/settings.json").status).toBe(2);
+    expect(bash("cp evil.mjs .karajan/harness/stop.mjs").status).toBe(2);
+    expect(bash("cat .claude/settings.json").status).toBe(2);
+    expect(bash("ls -la src/").status).toBe(0);
+  });
+
+  it("kj report formats the audited escape events (timestamp + escape + tool)", async () => {
+    const { formatSentinelEscapes } = await import("../../src/commands/report.js");
+    expect(formatSentinelEscapes({})).toBeNull();
+    const text = formatSentinelEscapes({ escape_events: [{ escape: "KJ_ALLOW_PII", tool: "Bash", sid: "s1", ts: Date.UTC(2026, 7, 4, 12) }] });
+    expect(text).toMatch(/Sentinel escapes used \(1\)/);
+    expect(text).toMatch(/KJ_ALLOW_PII/);
+    expect(text).toMatch(/2026-08-04T12/);
+  });
+
+  it("stop BLOCKS the turn on tampered scripts (root of trust: the installed kj, never the project tree)", async () => {
+    const { verifySentinelScripts } = await import("../../src/harden/sentinel-hooks.js");
+    fs.appendFileSync(postScript, "// tampered via indirection\n");
+    expect(verifySentinelScripts({ projectDir: dir }).mismatched).toEqual(["posttooluse.mjs"]);
+    const bin = path.join(dir, "verifybin");
+    fs.mkdirSync(bin);
+    fs.writeFileSync(
+      path.join(bin, "kj"),
+      `#!/bin/sh\necho '{"ok":false,"mismatched":["posttooluse.mjs"]}'\nexit 1\n`,
+      { mode: 0o755 },
+    );
+    const blocked = run(stopScript, { session_id: "empty" }, { PATH: `${bin}:${process.env.PATH}` });
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/kj harden/);
+    installSentinelHooks({ projectDir: dir });
+    expect(verifySentinelScripts({ projectDir: dir }).ok).toBe(true);
+    expect(run(stopScript, { session_id: "empty" }, { PATH: path.dirname(process.execPath) }).status).toBe(0);
+  });
+
+  it("stop emits a user-visible summary of used escapes when the turn ends green", () => {
+    run(postScript, editTool(path.join(dir, "src", "a.js")), { KJ_ALLOW_NO_CARD: "1" });
+    run(postScript, editTool(path.join(dir, "tests", "a.test.js")));
+    const res = run(stopScript, { session_id: "s1" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/systemMessage/);
+    expect(res.stdout).toMatch(/KJ_ALLOW_NO_CARD/);
+    expect(state().escape_events.some((e) => e.escape === "KJ_ALLOW_NO_CARD")).toBe(true);
+  });
+});
+
 describe("sentinel-lib (shared single source)", () => {
   it("is written by install, and both scripts import it instead of duplicating logic", async () => {
     const lib = path.join(dir, ".karajan", "harness", "sentinel-lib.mjs");


### PR DESCRIPTION
## Qué
Cierre de la épica **Karajan Sentinel** (KJC-PCS-0071). SEN-C: el supervisor no se desmonta en silencio y todo escape es una decisión visible del usuario.

- **Autoprotección en capas** (modelo honesto, forjado en 4 rondas de review con codex):
  1. Tools de edición sobre `.claude/settings.json` / `.karajan/hooks` / `.karajan/harness` → bloqueo SIN escape de agente (evaluado antes incluso de `KJ_SENTINEL_OFF`).
  2. Bash que NOMBRA esas rutas → denegado por completo (una blocklist de verbos de escritura es evadible con cp/dd/one-liners; para consultar están Read/Grep, nunca cableadas).
  3. La indirección de shell (variables, globs, sustitución) no se resuelve del texto — la caza **`kj sentinel verify`**: compara los scripts en disco con lo que ESTE kj instalaría. Raíz de confianza = el paquete instalado, fuera del árbol del proyecto (nada bajo `.karajan` se avala a sí mismo). El Stop lo invoca en cada cierre: manipulación → el turno NO termina; `kj harden` restaura; anti-brick a los 3 bloqueos.
- **Escapes auditados**: cada `KJ_ALLOW_*` honrado queda como evento (`escape_events[]`: escape+tool+sesión+timestamp) desde ambos hooks; al cerrar en verde el Stop emite `systemMessage` — *'esta sesión usó N escape(s): …'* — y `kj report` imprime la sección de escapes del proyecto (projectDir derivado del snapshot de la sesión cuando existe). `kj sentinel status|verify` resuelven la raíz del proyecto desde cualquier subdirectorio.

## Nota de tamaño
Net 198 líneas: el diff creció 4 veces por findings LEGÍTIMOS de codex (deny-all en Bash, raíz de confianza fuera del proyecto, projectDir de sesión, resolución desde subdirs) — partir los fixes de seguridad de un mismo gate dejaría PRs intermedias con garantías falsas.

## Verificación
- Tests ejecutan los scripts reales: rutas protegidas con todos los escapes activos → bloqueo; Bash cp/cat sobre protegidas → bloqueo; manipulación → Stop bloquea y reinstalar restaura verde; fail-open sin kj; systemMessage con los escapes; formato del report.
- Suite completa: 6432/6432. `kj audit --security`: 0 findings. Veredicto: APPROVED por codex (diff 4b7c68201fc0) tras 4 rechazos incorporados.

Card: KJC-TSK-0715 · Cierra KJC-PCS-0071 (SEN-A #1365-#1368 · SEN-B #1369-#1370)