### PR TITLE
feat(check): observation census of agent clis — detect is not support (KJC-TSK-0728)

### DIFF
--- a/src/checks/ai-surface.js
+++ b/src/checks/ai-surface.js
@@ -50,8 +50,11 @@ export function collectAiSurface({ projectDir = process.cwd(), home = os.homedir
  * Diff the current surface against the last-seen snapshot and persist the
  * new state. First run records the baseline silently.
  */
-export function checkAiSurface({ projectDir = process.cwd(), home = os.homedir(), statePath = path.join(os.homedir(), ".karajan", "ai-surface.json") } = {}) {
-  const surface = collectAiSurface({ projectDir, home });
+export function checkAiSurface({ projectDir = process.cwd(), home = os.homedir(), statePath = path.join(os.homedir(), ".karajan", "ai-surface.json"), extraSurface = [] } = {}) {
+  // KJC-TSK-0728: extraSurface carries entries the (async) caller collected
+  // outside config files — e.g. observed agent CLIs as "grok (cli)" — so
+  // they ride the same snapshot and the same "NEW since last check" drift.
+  const surface = [...new Set([...collectAiSurface({ projectDir, home }), ...extraSurface])].sort();
   let state = {};
   try { state = JSON.parse(readFileSync(statePath, "utf8")); } catch { /* first run or corrupt → baseline */ }
   const prev = Array.isArray(state[projectDir]) ? state[projectDir] : null;

--- a/src/checks/binaries.js
+++ b/src/checks/binaries.js
@@ -12,7 +12,7 @@
  * the install command and can offer to run it).
  */
 
-import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
+import { checkBinary, KNOWN_AGENTS, detectObservedAgents } from "../utils/agent-detect.js";
 import { runCommand } from "../utils/process.js";
 import { withDocLink } from "../utils/doc-links.js";
 import { getInstallHint, appliesToStack } from "../utils/install-hints.js";
@@ -33,6 +33,33 @@ function createAgentCheck(agent) {
         severity: "warn", // missing one agent CLI shouldn't block — user may not use it
         detail: result.ok ? `${result.version} (${result.path})` : "Not found",
         fix: result.ok ? undefined : withDocLink(`Install: ${agent.install}`, "agent_not_found"),
+      };
+    },
+  };
+}
+
+/**
+ * KJC-TSK-0728 — ONE aggregate line for the observation census (agent CLIs
+ * kj sees but does not drive). Only FOUND CLIs are listed; the missing ones
+ * make no noise, and the check never fails. `detector` is injectable for
+ * tests.
+ */
+export function createObservedAgentsCheck({ detector = detectObservedAgents } = {}) {
+  return {
+    name: "agents:observed",
+    label: "Agent CLIs observed (not driven)",
+    strategy: STRATEGY.MANUAL,
+    async detect() {
+      let found = [];
+      try {
+        found = (await detector()).filter((a) => a.available);
+      } catch { /* census is best-effort */ }
+      return {
+        ok: true,
+        severity: "info",
+        detail: found.length
+          ? found.map((a) => `${a.name} (${(a.version || "").split(" ").at(-1) || "?"})`).join(", ")
+          : "none detected",
       };
     },
   };
@@ -165,6 +192,7 @@ export function getBinaryChecks() {
   for (const agent of KNOWN_AGENTS) {
     checks.push(createAgentCheck(agent));
   }
+  checks.push(createObservedAgentsCheck());
   for (const bin of ["node", "npm", "git"]) {
     checks.push(createCoreBinaryCheck(bin));
   }

--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -7,6 +7,7 @@
 import { checkHarden } from "../harden/check.js";
 import { collectMethodStats, formatMethodStats } from "../checks/method.js";
 import { checkAiSurface, formatAiSurface } from "../checks/ai-surface.js";
+import { detectObservedAgents } from "../utils/agent-detect.js";
 
 export async function checkCommand({ projectDir = process.cwd(), profile = "standard", json = false, logger = console } = {}) {
   const result = await checkHarden({ projectDir, profile });
@@ -14,8 +15,15 @@ export async function checkCommand({ projectDir = process.cwd(), profile = "stan
   // rides along in check output but never affects the exit code.
   const method = await collectMethodStats({ projectDir }).catch(() => null);
   // KJC-TSK-0694: same deal for the MCP inventory — a nudge, never a gate.
+  // KJC-TSK-0728: observed agent CLIs ride the same snapshot as "(cli)"
+  // entries, so a newly-appeared agent binary trips the same drift question.
   let aiSurface = null;
-  try { aiSurface = checkAiSurface({ projectDir }); } catch { /* inventory is best-effort */ }
+  try {
+    const clis = (await detectObservedAgents().catch(() => []))
+      .filter((a) => a.available)
+      .map((a) => `${a.name} (cli)`);
+    aiSurface = checkAiSurface({ projectDir, extraSurface: clis });
+  } catch { /* inventory is best-effort */ }
 
   if (json) {
     logger.info?.(JSON.stringify({ ...result, method, aiSurface }));

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -12,6 +12,32 @@ const KNOWN_AGENTS = [
   { name: "copilot", install: getInstallCommand("copilot") }
 ];
 
+/**
+ * KJC-TSK-0728 — observation census (from the Orca landscape): agent CLIs kj
+ * can SEE but does not drive. Detecting is not supporting — these never feed
+ * pipeline pickers; they feed the AI-surface inventory and one doctor line.
+ * `bin` differs from `name` when the vendor ships an umbrella binary.
+ */
+const OBSERVED_AGENTS = [
+  { name: "grok", bin: "grok" },
+  { name: "cursor-agent", bin: "cursor-agent" },
+  { name: "pi", bin: "pi" },
+  { name: "kilocode", bin: "kilocode" },
+  { name: "kimi", bin: "kimi" },
+  { name: "vibe", bin: "vibe" },
+  { name: "rovodev", bin: "acli" },
+];
+
+/** Probe the observation census in parallel; callers filter on `available`. */
+export async function detectObservedAgents() {
+  return Promise.all(
+    OBSERVED_AGENTS.map(async (agent) => {
+      const check = await checkBinary(agent.bin);
+      return { name: agent.name, bin: agent.bin, available: check.ok, version: check.ok ? check.version : null };
+    })
+  );
+}
+
 export async function checkBinary(name, versionArg = "--version") {
   const resolved = resolveBin(name);
   // KJC-BUG-0113: a zombie CLI that hangs on --version (seen with the
@@ -61,4 +87,4 @@ export function isHostAgent(provider) {
   return host !== null && host === provider;
 }
 
-export { KNOWN_AGENTS };
+export { KNOWN_AGENTS, OBSERVED_AGENTS };

--- a/tests/installer-e2e.test.js
+++ b/tests/installer-e2e.test.js
@@ -112,6 +112,8 @@ vi.mock("../src/sonar/manager.js", () => ({
 }));
 
 vi.mock("../src/utils/agent-detect.js", () => ({
+  detectObservedAgents: vi.fn().mockResolvedValue([]),
+  OBSERVED_AGENTS: [],
   detectAvailableAgents: vi.fn().mockResolvedValue([
     { name: "claude", available: true, version: "2.0.0", install: "" },
     { name: "codex", available: true, version: "1.0.0", install: "" }

--- a/tests/utils/observed-agents.test.js
+++ b/tests/utils/observed-agents.test.js
@@ -1,0 +1,83 @@
+// KJC-TSK-0728 — the observation census: detecting an agent CLI is NOT
+// supporting it. OBSERVED_AGENTS feeds the AI-surface inventory and a single
+// aggregate doctor line; KNOWN_AGENTS (pipeline) stays untouched.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { OBSERVED_AGENTS, detectObservedAgents, KNOWN_AGENTS } from "../../src/utils/agent-detect.js";
+import { checkAiSurface } from "../../src/checks/ai-surface.js";
+import { createObservedAgentsCheck } from "../../src/checks/binaries.js";
+
+let dir, binDir, statePath, oldPath;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-observed-"));
+  binDir = path.join(dir, "bin");
+  fs.mkdirSync(binDir);
+  statePath = path.join(dir, "ai-surface.json");
+  oldPath = process.env.PATH;
+});
+afterEach(() => {
+  process.env.PATH = oldPath;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const fakeBin = (name) =>
+  fs.writeFileSync(path.join(binDir, name), `#!/bin/sh\necho "${name} 9.9.9"\n`, { mode: 0o755 });
+
+describe("OBSERVED_AGENTS census", () => {
+  it("is observation-only: no overlap with the pipeline KNOWN_AGENTS registry", () => {
+    const known = new Set(KNOWN_AGENTS.map((a) => a.name));
+    for (const agent of OBSERVED_AGENTS) {
+      expect(known.has(agent.name)).toBe(false);
+      expect(agent.bin).toBeTruthy();
+    }
+    expect(OBSERVED_AGENTS.map((a) => a.name)).toContain("grok");
+    expect(OBSERVED_AGENTS.map((a) => a.name)).toContain("rovodev");
+  });
+
+  it("detects an installed CLI with its version and marks unresolvable ones unavailable", async () => {
+    fakeBin("grok");
+    process.env.PATH = `${binDir}:${oldPath}`;
+    const found = await detectObservedAgents();
+    const grok = found.find((a) => a.name === "grok");
+    expect(grok?.available).toBe(true);
+    expect(grok?.version).toContain("9.9.9");
+    // Exhaustive absence is environment-dependent (resolveBin also scans
+    // fixed dirs like ~/.local/bin) — shape and per-entry flags suffice.
+    for (const entry of found) expect(typeof entry.available).toBe("boolean");
+  });
+});
+
+describe("AI surface × observed CLIs", () => {
+  it("extraSurface entries enter the snapshot and the drift report", () => {
+    const first = checkAiSurface({ projectDir: dir, home: dir, statePath, extraSurface: [] });
+    expect(first.first).toBe(true);
+    const second = checkAiSurface({ projectDir: dir, home: dir, statePath, extraSurface: ["grok (cli)"] });
+    expect(second.surface).toContain("grok (cli)");
+    expect(second.added).toEqual(["grok (cli)"]);
+    const third = checkAiSurface({ projectDir: dir, home: dir, statePath, extraSurface: ["grok (cli)"] });
+    expect(third.added).toEqual([]);
+  });
+});
+
+describe("doctor aggregate check", () => {
+  it("lists found CLIs as info and never fails when none are present", async () => {
+    const none = createObservedAgentsCheck({ detector: async () => [{ name: "grok", available: false }] });
+    const emptyRes = await none.detect();
+    expect(emptyRes.ok).toBe(true);
+    expect(emptyRes.detail).toMatch(/none/i);
+    const some = createObservedAgentsCheck({
+      detector: async () => [
+        { name: "grok", available: true, version: "grok 9.9.9" },
+        { name: "kimi", available: false },
+      ],
+    });
+    const res = await some.detect();
+    expect(res.ok).toBe(true);
+    expect(res.detail).toContain("grok");
+    expect(res.detail).not.toContain("kimi");
+  });
+});


### PR DESCRIPTION
## Qué
Del análisis de Orca (su censo de 25+ agentes): registro **OBSERVED_AGENTS** de solo-observación en `agent-detect.js` — grok, cursor-agent, pi, kilocode, kimi, vibe (Mistral), rovodev (`acli`) — separado a propósito de `KNOWN_AGENTS` (detectar ≠ soportar: los pickers del pipeline no cambian). Integración doble: (1) `kj check` mete los CLIs detectados como entradas `(cli)` en el snapshot de superficie IA → el drift '**NEW since last check — approved by you?**' también dispara cuando aparece un binario de agente nuevo en la máquina; (2) `kj doctor` gana UNA línea agregada `agents:observed` que lista solo los encontrados (info, jamás falla, cero ruido de ausentes).

## Estreno en vivo
El primer `kj check` real cazó dos drifts verdaderos en la máquina del mantenedor: un CLI `kimi` instalado y el MCP `planning-game-tribbu` recién aparecido.

## Verificación
- Tests con binarios falsos en PATH + detector inyectable en el check del doctor; suite completa 6436/6436 (exit 0); `kj audit --security` 0 findings.
- Nota pr-size: 155 vs guía 150 — 5 líneas de actualizar un mock existente que no conocía el export nuevo.
- Veredicto cross-AI: APPROVED por codex (diff 3a8265975dd4).

Card: KJC-TSK-0728 (In Progress → To Validate al merge) · Épica KJC-PCS-0003