### PR TITLE
feat(review): reviewer candidate registry and quota classifier (KJC-TSK-0730)

### DIFF
--- a/src/review/reviewer-fallback.js
+++ b/src/review/reviewer-fallback.js
@@ -1,0 +1,114 @@
+/**
+ * reviewer-fallback (KJC-TSK-0730) — running out of reviewer quota must
+ * never leave the method without a third party, and must never be silent:
+ * either an authenticated candidate takes over WITH a loud notice, or the
+ * user gets a menu of candidates with their tier and the exact login
+ * command. Born from the real codex weekly-quota outage of 2026-08-06.
+ *
+ * The registry is declarative. `install` is only present when the command
+ * was VERIFIED (never invent package names); auth heuristics are cheap
+ * local file checks — informative for the menu, while the actual failover
+ * only sticks if the candidate answers.
+ */
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { checkBinary } from "../utils/agent-detect.js";
+
+export const REVIEWER_CANDIDATES = [
+  {
+    name: "codex",
+    tier: "suscripción ChatGPT (cuota semanal compartida entre modelos)",
+    login: "codex → Sign in with ChatGPT",
+    install: "npm i -g @openai/codex",
+    authPaths: [".codex/auth.json"],
+  },
+  {
+    name: "copilot",
+    tier: "gratis (tier free de GitHub Copilot; más cuota con suscripción)",
+    login: "copilot → autenticación GitHub",
+    install: "npm i -g @github/copilot",
+    authPaths: [".copilot/config.json"],
+  },
+  {
+    name: "agy",
+    tier: "suscripción Google AI Pro/Ultra (sucesor del gemini CLI, retirado 06-2026)",
+    login: "agy → /login (cuenta Google)",
+    install: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+    authPaths: [".agy", ".config/agy", ".antigravity-cli"],
+    adapterPending: true,
+  },
+  {
+    name: "kimi",
+    tier: "gratis (Kimi Code, Moonshot K2.x)",
+    login: "kimi → /login",
+    install: null,
+    authPaths: [".kimi-code/credentials"],
+    adapterPending: true,
+  },
+  {
+    name: "qwen",
+    tier: "requiere plan o API key (el tier gratis hosted se retiró en 04-2026)",
+    login: "qwen → OAuth o API key OpenAI-compatible",
+    install: "npm i -g @qwen-code/qwen-code",
+    authPaths: [".qwen/oauth_creds.json"],
+  },
+  {
+    name: "opencode",
+    tier: "gratis con modelos locales (LiteLLM/Ollama) o API keys propias",
+    login: "provider en ~/.config/opencode/opencode.json",
+    install: null,
+    authPaths: [".config/opencode/opencode.json"],
+  },
+];
+
+const QUOTA_RE = /usage limit|quota|rate.?limit|credits? (?:exhausted|left: ?0)|hit your .{0,20}limit/i;
+
+/** True when the agent error smells like exhausted quota, not a real failure. */
+export function isQuotaExhausted(text) {
+  return typeof text === "string" && QUOTA_RE.test(text);
+}
+
+/** installed × authenticated for every candidate, from cheap local checks. */
+export async function candidateStatus({ home = os.homedir(), checkBin = checkBinary } = {}) {
+  return Promise.all(
+    REVIEWER_CANDIDATES.map(async (c) => {
+      let installed = false;
+      try {
+        installed = (await checkBin(c.name)).ok;
+      } catch { /* not installed */ }
+      const authenticated = c.authPaths.some((p) => existsSync(path.join(home, p)));
+      return { ...c, installed, authenticated };
+    }),
+  );
+}
+
+/**
+ * First candidate that is installed, authenticated, has a kj adapter and is
+ * not excluded (the exhausted reviewer and the host — the brain NEVER
+ * reviews itself).
+ */
+export function pickQuotaFallback(statuses, { exclude = [] } = {}) {
+  const found = statuses.find(
+    (s) => s.installed && s.authenticated && !s.adapterPending && !exclude.includes(s.name),
+  );
+  return found ? found.name : null;
+}
+
+/** Human/agent-readable menu: tier, state, and the exact command per candidate. */
+export function formatCandidateMenu(statuses, { exclude = [] } = {}) {
+  const lines = statuses
+    .filter((s) => !exclude.includes(s.name))
+    .map((s) => {
+      let state = "no instalado";
+      if (s.authenticated) state = "logado";
+      else if (s.installed) state = "instalado, SIN login";
+      let action = "";
+      if (!s.authenticated) {
+        action = s.installed || !s.install ? ` — login: ${s.login}` : ` — instalar: ${s.install}`;
+      }
+      const pending = s.adapterPending ? " [adaptador kj pendiente: KJC-TSK-0729]" : "";
+      return `  - ${s.name} (${s.tier}) · ${state}${action}${pending}`;
+    });
+  return `Candidatos a reviewer:\n${lines.join("\n")}\nElige uno, haz su login y fija roles.reviewer.provider — o pasa --reviewer <nombre>.`;
+}

--- a/tests/review/reviewer-fallback.test.js
+++ b/tests/review/reviewer-fallback.test.js
@@ -1,0 +1,84 @@
+// KJC-TSK-0730 — quota failover: running out of reviewer quota either
+// continues with a LOUD notice (an authenticated candidate exists) or prints
+// an actionable menu — never a silent failure, never brain self-review.
+// Born from the real codex weekly-quota outage of 2026-08-06.
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  REVIEWER_CANDIDATES,
+  isQuotaExhausted,
+  candidateStatus,
+  pickQuotaFallback,
+  formatCandidateMenu,
+} from "../../src/review/reviewer-fallback.js";
+
+const CODEX_REAL_ERROR =
+  "ERROR: You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 6:55 AM.";
+
+describe("isQuotaExhausted", () => {
+  it("classifies the real codex message plus generic quota/rate-limit shapes, and nothing else", () => {
+    expect(isQuotaExhausted(CODEX_REAL_ERROR)).toBe(true);
+    expect(isQuotaExhausted("Quota exceeded for this billing period")).toBe(true);
+    expect(isQuotaExhausted("429 rate limited, retry later")).toBe(true);
+    expect(isQuotaExhausted("SyntaxError: unexpected token")).toBe(false);
+    expect(isQuotaExhausted("")).toBe(false);
+    expect(isQuotaExhausted(undefined)).toBe(false);
+  });
+});
+
+describe("candidate registry + status", () => {
+  it("every candidate declares name, tier and a login hint; install only when verified", () => {
+    for (const c of REVIEWER_CANDIDATES) {
+      expect(c.name).toBeTruthy();
+      expect(c.tier).toBeTruthy();
+      expect(c.login).toBeTruthy();
+      expect(Array.isArray(c.authPaths)).toBe(true);
+    }
+    expect(REVIEWER_CANDIDATES.map((c) => c.name)).toContain("copilot");
+    expect(REVIEWER_CANDIDATES.map((c) => c.name)).toContain("kimi");
+  });
+
+  it("reports installed × authenticated from local heuristics (fake home)", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-fb-home-"));
+    fs.mkdirSync(path.join(home, ".copilot"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".copilot", "config.json"), "{}");
+    const statuses = await candidateStatus({
+      home,
+      checkBin: async (name) => ({ ok: name === "copilot" }),
+    });
+    const copilot = statuses.find((s) => s.name === "copilot");
+    expect(copilot.installed).toBe(true);
+    expect(copilot.authenticated).toBe(true);
+    const kimi = statuses.find((s) => s.name === "kimi");
+    expect(kimi.installed).toBe(false);
+    expect(kimi.authenticated).toBe(false);
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+});
+
+describe("pickQuotaFallback", () => {
+  const mk = (name, installed, authenticated) => ({ name, installed, authenticated });
+  it("picks the first installed+authenticated candidate excluding reviewer and host", () => {
+    const statuses = [mk("codex", true, true), mk("copilot", true, true), mk("kimi", true, false)];
+    expect(pickQuotaFallback(statuses, { exclude: ["codex", "claude"] })).toBe("copilot");
+  });
+  it("returns null when nothing valid remains (never the host, never unauthenticated)", () => {
+    const statuses = [mk("codex", true, true), mk("claude", true, true), mk("kimi", true, false)];
+    expect(pickQuotaFallback(statuses, { exclude: ["codex", "claude"] })).toBeNull();
+  });
+});
+
+describe("formatCandidateMenu", () => {
+  it("lists tier, install/login state and the command for each candidate", () => {
+    const menu = formatCandidateMenu([
+      { name: "copilot", tier: "gratis", installed: true, authenticated: false, login: "copilot (auth GitHub)" },
+      { name: "kimi", tier: "gratis", installed: false, authenticated: false, login: "kimi → /login", install: null },
+    ]);
+    expect(menu).toContain("copilot");
+    expect(menu).toContain("gratis");
+    expect(menu).toMatch(/login/i);
+  });
+});


### PR DESCRIPTION
## Qué
Primera mitad del failover de reviewer (nacido del apagón real de codex de hoy): `src/review/reviewer-fallback.js` — registro declarativo de CLIs candidatos a reviewer (codex, copilot, agy, kimi, qwen, opencode) con tier (gratis/suscripción/local), comando de login, install SOLO cuando está verificado (jamás inventar nombres npm — lección del día), y heurísticas de auth por ficheros locales verificadas en máquina real; `isQuotaExhausted` (clasificador con el mensaje literal de codex + formas genéricas); `candidateStatus` (instalado × autenticado); `pickQuotaFallback` (excluye reviewer agotado y host — el brain jamás se revisa a sí mismo; los candidatos sin adaptador kj quedan fuera hasta KJC-TSK-0729); `formatCandidateMenu` para el humano/agente.

## Verificación
- Tests unitarios con el error real de codex y homes falsos. Suite de review 92/92; lint 0.
- Veredicto: APPROVED por copilot — emitido, con toda la poesía, A TRAVÉS del propio failover en el kj linkado (codex sin cuota → aviso → copilot).

El enganche en `runOneShotReview` (reintento único + menú) llega en el PR siguiente — partido por el gate de 200 LOC.
Card: KJC-TSK-0730 (In Progress) · Relacionada: KJC-TSK-0729