### PR TITLE
feat(review): quota failover hook — loud switch or actionable menu (KJC-TSK-0730)

### DIFF
--- a/src/review/one-shot-review.js
+++ b/src/review/one-shot-review.js
@@ -16,6 +16,7 @@ import { parseMaybeJsonString } from "./parser.js";
 import { detectAvailableAgents, detectHostAgent } from "../utils/agent-detect.js";
 import { saveVerdict } from "./verdict-store.js";
 import { detectWorkspace } from "./workspace.js";
+import { isQuotaExhausted, candidateStatus, pickQuotaFallback, formatCandidateMenu } from "./reviewer-fallback.js";
 
 // Cross-AI preference when the configured reviewer IS the host.
 const CROSS_ORDER = ["codex", "claude", "gemini", "opencode", "aider"];
@@ -44,6 +45,7 @@ export async function runOneShotReview({
   hostAgent = detectHostAgent(),
   createAgentFn = createAgent,
   detectAgents = detectAvailableAgents,
+  candidateStatusFn = candidateStatus,
 }) {
   if (!diff || !diff.trim()) {
     throw new Error("nothing to review — the diff is empty (stage your changes or pass --range)");
@@ -57,26 +59,58 @@ export async function runOneShotReview({
   }
 
   const { rules } = await resolveReviewProfile({ mode: "standard", projectDir });
-  const prompt = await buildReviewerPrompt({
-    task: task || "Review the following diff for correctness, security and maintainability.",
-    diff, reviewRules: rules, mode: "standard", provider: reviewer, projectDir,
-  });
+  const attempt = async (who, cfg = config) => {
+    const prompt = await buildReviewerPrompt({
+      task: task || "Review the following diff for correctness, security and maintainability.",
+      diff, reviewRules: rules, mode: "standard", provider: who, projectDir,
+    });
+    logger?.info?.(`kj review: host=${hostAgent || "none"} → reviewer=${who} (cross-AI)`);
+    return createAgentFn(who, cfg, logger).reviewTask({ prompt, role: "reviewer" });
+  };
 
-  logger?.info?.(`kj review: host=${hostAgent || "none"} → reviewer=${reviewer} (cross-AI)`);
-  const agent = createAgentFn(reviewer, config, logger);
-  const result = await agent.reviewTask({ prompt, role: "reviewer" });
+  let activeReviewer = reviewer;
+  let result = await attempt(activeReviewer);
+
+  // KJC-TSK-0730 — quota failover: exhausted quota is not a review failure,
+  // it is a provider outage. One retry with an authenticated candidate
+  // (loud notice, never silent), or an actionable menu. Never the host:
+  // the brain does not review itself.
+  if (!result?.ok && isQuotaExhausted(result?.error) && (config?.reviewer_options?.auto_fallback ?? true)) {
+    const statuses = await candidateStatusFn();
+    const fallback = pickQuotaFallback(statuses, { exclude: [activeReviewer, hostAgent].filter(Boolean) });
+    if (fallback) {
+      logger?.warn?.(
+        `⚠ reviewer ${activeReviewer} sin cuota → usando ${fallback} SOLO en esta invocación. ` +
+        `Para fijarlo: roles.reviewer.provider: ${fallback} (avisando, nunca en silencio — KJC-TSK-0730).`
+      );
+      activeReviewer = fallback;
+      // The role's model pin belongs to the exhausted provider (a codex
+      // model name means nothing to copilot) — the candidate runs on its
+      // own default model.
+      result = await attempt(activeReviewer, {
+        ...config,
+        roles: { ...config?.roles, reviewer: { ...config?.roles?.reviewer, model: null } },
+      });
+    } else {
+      throw new Error(
+        `reviewer ${activeReviewer} sin cuota y ningún candidato autenticado con adaptador.\n` +
+        formatCandidateMenu(statuses, { exclude: [hostAgent].filter(Boolean) })
+      );
+    }
+  }
+
   if (!result?.ok) {
-    throw new Error(`reviewer ${reviewer} failed: ${result?.error || "no output"}`);
+    throw new Error(`reviewer ${activeReviewer} failed: ${result?.error || "no output"}`);
   }
 
   const parsed = parseMaybeJsonString(result.output);
   if (!parsed || typeof parsed.approved !== "boolean") {
-    throw new Error(`reviewer ${reviewer} returned no parseable verdict`);
+    throw new Error(`reviewer ${activeReviewer} returned no parseable verdict`);
   }
 
   return saveVerdict(projectDir, diff, {
     verdict: parsed.approved ? "approved" : "rejected",
-    reviewer,
+    reviewer: activeReviewer,
     host: hostAgent || null,
     // KJC-TSK-0680: where the review ran — makes any isolation claim auditable.
     workspace: await detectWorkspace(projectDir),

--- a/tests/review/reviewer-fallback.test.js
+++ b/tests/review/reviewer-fallback.test.js
@@ -14,6 +14,7 @@ import {
   pickQuotaFallback,
   formatCandidateMenu,
 } from "../../src/review/reviewer-fallback.js";
+import { runOneShotReview } from "../../src/review/one-shot-review.js";
 
 const CODEX_REAL_ERROR =
   "ERROR: You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Aug 8th, 2026 6:55 AM.";
@@ -68,6 +69,69 @@ describe("pickQuotaFallback", () => {
   it("returns null when nothing valid remains (never the host, never unauthenticated)", () => {
     const statuses = [mk("codex", true, true), mk("claude", true, true), mk("kimi", true, false)];
     expect(pickQuotaFallback(statuses, { exclude: ["codex", "claude"] })).toBeNull();
+  });
+});
+
+describe("runOneShotReview quota failover", () => {
+  const baseArgs = (agents) => ({
+    diff: "diff --git a/x.js b/x.js\n+1\n",
+    task: "review",
+    config: {},
+    logger: { info: () => {}, warn: () => {} },
+    projectDir: fs.mkdtempSync(path.join(os.tmpdir(), "kj-fb-proj-")),
+    hostAgent: "claude",
+    detectAgents: async () => [{ name: "codex", available: true }, { name: "copilot", available: true }],
+    createAgentFn: (name) => agents[name],
+  });
+
+  it("retries ONCE with the fallback, warns loudly, and the verdict records the real reviewer", async () => {
+    const warns = [];
+    const seenConfigs = {};
+    const agents = {
+      codex: { reviewTask: async () => ({ ok: false, error: CODEX_REAL_ERROR }) },
+      copilot: {
+        reviewTask: async () => ({ ok: true, output: JSON.stringify({ approved: true, blocking_issues: [], summary: "ok" }) }),
+      },
+    };
+    const args = baseArgs(agents);
+    // The role's model pin belongs to the ORIGINAL provider (found live:
+    // codex's gpt-5.4-mini reached copilot and broke it) — the fallback
+    // attempt must drop it and use the candidate's default model.
+    args.config = { roles: { reviewer: { provider: "codex", model: "gpt-5.4-mini" } } };
+    args.createAgentFn = (name, cfg) => {
+      seenConfigs[name] = cfg;
+      return agents[name];
+    };
+    args.logger.warn = (m) => warns.push(m);
+    args.candidateStatusFn = async () => [
+      { name: "codex", installed: true, authenticated: true },
+      { name: "copilot", installed: true, authenticated: true },
+    ];
+    const record = await runOneShotReview(args);
+    expect(record.verdict).toBe("approved");
+    expect(record.reviewer).toBe("copilot");
+    expect(warns.join(" ")).toMatch(/sin cuota|quota/i);
+    expect(warns.join(" ")).toMatch(/roles\.reviewer\.provider/);
+    expect(seenConfigs.codex.roles.reviewer.model).toBe("gpt-5.4-mini");
+    expect(seenConfigs.copilot.roles.reviewer.model).toBeNull();
+  });
+
+  it("prints the candidate menu when no candidate is authenticated", async () => {
+    const agents = { codex: { reviewTask: async () => ({ ok: false, error: CODEX_REAL_ERROR }) } };
+    const args = baseArgs(agents);
+    args.candidateStatusFn = async () => [
+      { name: "codex", installed: true, authenticated: true },
+      { name: "copilot", installed: true, authenticated: false, tier: "gratis", login: "copilot login" },
+      { name: "kimi", installed: false, authenticated: false, tier: "gratis", login: "kimi /login" },
+    ];
+    await expect(runOneShotReview(args)).rejects.toThrow(/candidato|login/i);
+  });
+
+  it("does not fall back on non-quota errors", async () => {
+    const agents = { codex: { reviewTask: async () => ({ ok: false, error: "boom" }) } };
+    const args = baseArgs(agents);
+    args.candidateStatusFn = async () => [{ name: "copilot", installed: true, authenticated: true }];
+    await expect(runOneShotReview(args)).rejects.toThrow(/boom/);
   });
 });
 


### PR DESCRIPTION
## Qué
Segunda mitad del failover (cierra la card): `runOneShotReview` detecta agotamiento de cuota del reviewer (clasificador de #1378) y hace **UN reintento** con el primer candidato instalado+autenticado+con-adaptador que no sea ni el reviewer agotado ni el host — avisando en alto ('usando X SOLO en esta invocación; fija roles.reviewer.provider') — o, si no hay candidato, falla con el **menú accionable** (tier, estado, comando de login por candidato). El pin de modelo del proveedor agotado NO viaja al fallback (bug real cazado en el primer dogfood: el gpt-5.4-mini de codex rompía a copilot); el veredicto registra el reviewer que de verdad revisó. `reviewer_options.auto_fallback` (default ON) lo desactiva.

## Dogfood
Los CUATRO veredictos de esta tarde (incluido el de este PR) se emitieron a través de este mismo failover en el kj linkado: codex sin cuota → aviso → copilot.

## Verificación
- Tests de integración con agentes stub: reintento único con veredicto del fallback, menú sin candidatos, errores no-cuota NO disparan fallback, pin de modelo limpiado (config del fallback capturada). Suite completa 6445/6445 exit 0.
- Veredicto: APPROVED por copilot (diff 0565ea7c7943), vía el propio failover.

Card: KJC-TSK-0730 · Sigue a #1378