### PR TITLE
feat(review): aider joins the fallback candidates via env-key auth (KJC-TSK-0729)

### DIFF
--- a/src/review/reviewer-fallback.js
+++ b/src/review/reviewer-fallback.js
@@ -54,6 +54,14 @@ export const REVIEWER_CANDIDATES = [
     authPaths: [".qwen/oauth_creds.json"],
   },
   {
+    name: "aider",
+    tier: "API keys propias (pago por token: OpenAI/Anthropic/OpenRouter…)",
+    login: "exportar OPENAI_API_KEY / ANTHROPIC_API_KEY (o ~/.aider.conf.yml)",
+    install: "pipx install aider-chat || pip3 install aider-chat",
+    authPaths: [".aider.conf.yml"],
+    authEnv: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"],
+  },
+  {
     name: "opencode",
     tier: "gratis con modelos locales (LiteLLM/Ollama) o API keys propias",
     login: "provider en ~/.config/opencode/opencode.json",
@@ -70,14 +78,19 @@ export function isQuotaExhausted(text) {
 }
 
 /** installed × authenticated for every candidate, from cheap local checks. */
-export async function candidateStatus({ home = os.homedir(), checkBin = checkBinary } = {}) {
+export async function candidateStatus({ home = os.homedir(), checkBin = checkBinary, env = process.env } = {}) {
   return Promise.all(
     REVIEWER_CANDIDATES.map(async (c) => {
       let installed = false;
       try {
         installed = (await checkBin(c.name)).ok;
       } catch { /* not installed */ }
-      const authenticated = c.authPaths.some((p) => existsSync(path.join(home, p)));
+      // Session-file heuristics, or env keys for CLIs (aider) that carry
+      // no session file. Key present ≠ credit left — it is menu signal;
+      // the failover only sticks if the candidate actually answers.
+      const authenticated =
+        c.authPaths.some((p) => existsSync(path.join(home, p))) ||
+        (c.authEnv || []).some((name) => Boolean(env[name]));
       return { ...c, installed, authenticated };
     }),
   );

--- a/tests/review/reviewer-fallback.test.js
+++ b/tests/review/reviewer-fallback.test.js
@@ -40,6 +40,19 @@ describe("candidate registry + status", () => {
     }
     expect(REVIEWER_CANDIDATES.map((c) => c.name)).toContain("copilot");
     expect(REVIEWER_CANDIDATES.map((c) => c.name)).toContain("kimi");
+    // "mete también copilot y no sé si alguna más" (2026-08-06): copilot ya
+    // estaba; el hueco real era aider — adaptador kj desde v1, auth por env.
+    expect(REVIEWER_CANDIDATES.map((c) => c.name)).toContain("aider");
+  });
+
+  it("aider authenticates via env keys (no session file), checked against an injected env", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-fb-aider-"));
+    const base = { home, checkBin: async () => ({ ok: true }) };
+    const withKey = await candidateStatus({ ...base, env: { OPENAI_API_KEY: "sk-test" } });
+    expect(withKey.find((s) => s.name === "aider").authenticated).toBe(true);
+    const without = await candidateStatus({ ...base, env: {} });
+    expect(without.find((s) => s.name === "aider").authenticated).toBe(false);
+    fs.rmSync(home, { recursive: true, force: true });
   });
 
   it("reports installed × authenticated from local heuristics (fake home)", async () => {


### PR DESCRIPTION
## Qué
Fase 1 de KJC-TSK-0729, del pedido 'mete también copilot y no sé si alguna más': **copilot ya estaba** en el registro (y es el reviewer activo del día); la auditoría del paisaje encontró el hueco real — **aider**, único CLI con adaptador kj real que faltaba como candidato de failover. Como aider no usa fichero de sesión, `candidateStatus` gana `authEnv[]` (OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY, o `~/.aider.conf.yml`), con env inyectable para tests. Install desde la fuente canónica de kj, no inventado. grok/cursor-agent quedan fuera del menú a propósito (de pago, sin adaptador — el menú propone opciones accionables, no catálogo); siguen en el censo de observación.

## Verificación
Suite completa 6446/6446 exit 0; veredicto APPROVED por copilot (diff 6d7a390a4ff6) vía el failover.

Fase 2 (adaptadores agy + kimi) espera los logins del usuario.
Card: KJC-TSK-0729 (In Progress)