### PR TITLE
feat(agents): kimi code as eighth built-in agent — free-tier reviewer reserve (KJC-TSK-0729)

### DIFF
--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -5,6 +5,7 @@ import { AiderAgent } from "./aider-agent.js";
 import { OpenCodeAgent } from "./opencode-agent.js";
 import { QwenAgent } from "./qwen-agent.js";
 import { CopilotAgent } from "./copilot-agent.js";
+import { KimiAgent } from "./kimi-agent.js";
 
 const agentRegistry = new Map();
 
@@ -53,3 +54,4 @@ registerAgent("aider", AiderAgent, { bin: "aider", installUrl: "https://aider.ch
 registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https://opencode.ai" });
 registerAgent("qwen", QwenAgent, { bin: "qwen", installUrl: "https://github.com/QwenLM/qwen-code" });
 registerAgent("copilot", CopilotAgent, { bin: "copilot", installUrl: "https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli" });
+registerAgent("kimi", KimiAgent, { bin: "kimi", installUrl: "https://github.com/MoonshotAI/kimi-code" });

--- a/src/agents/kimi-agent.js
+++ b/src/agents/kimi-agent.js
@@ -1,0 +1,44 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * Kimi Code (Moonshot, binary `kimi`) — KJC-TSK-0729 fase 2: the eighth
+ * built-in agent and the free-tier reserve of the reviewer/solomon panel.
+ *
+ * Verified live against kimi-code 0.27.0:
+ *  - `-p <prompt>` runs one prompt non-interactively and prints the
+ *    response (text output by default) — the prompt travels as an argument,
+ *    same E2BIG caveat as claude/copilot (KJC-BUG-0121) for huge diffs.
+ *  - `-m <model>` picks a model alias; `-y` auto-approves actions.
+ *  - Auth is the device-code login (`kimi login`), no env keys involved;
+ *    "No model configured" on a logged machine means the login did not
+ *    populate the managed provider (re-run `kimi login`).
+ */
+export class KimiAgent extends BaseAgent {
+  async runTask(task) {
+    // Coder mode IS an agentic run: file edits and shell need approval.
+    return this._exec(task, this.getRoleModel(task.role || "coder"), ["-y"]);
+  }
+
+  async reviewTask(task) {
+    // Review/arbitration answers from the prompt alone — no auto-approval,
+    // and an explicit no-tools instruction so a headless run never stalls
+    // waiting for a permission prompt nobody can answer.
+    return this._exec(
+      { ...task, prompt: `Do NOT use any tools. Answer directly from this prompt only.\n\n${task.prompt}` },
+      this.getRoleModel(task.role || "reviewer"),
+      [],
+    );
+  }
+
+  async _exec(task, model, extraArgs) {
+    const args = ["-p", task.prompt, ...extraArgs];
+    if (model) args.push("-m", model);
+    const res = await this.runCommand(resolveBin("kimi"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs,
+    });
+    return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
+  }
+}

--- a/src/review/reviewer-fallback.js
+++ b/src/review/reviewer-fallback.js
@@ -41,10 +41,9 @@ export const REVIEWER_CANDIDATES = [
   {
     name: "kimi",
     tier: "gratis (Kimi Code, Moonshot K2.x)",
-    login: "kimi → /login",
+    login: "kimi login (device-code; si dice 'No model configured', repítelo)",
     install: null,
     authPaths: [".kimi-code/credentials"],
-    adapterPending: true,
   },
   {
     name: "qwen",

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -9,7 +9,10 @@ const KNOWN_AGENTS = [
   { name: "aider", install: getInstallCommand("aider") },
   { name: "opencode", install: getInstallCommand("opencode") },
   { name: "qwen", install: getInstallCommand("qwen") },
-  { name: "copilot", install: getInstallCommand("copilot") }
+  { name: "copilot", install: getInstallCommand("copilot") },
+  // KJC-TSK-0729: promoted from the observation census once its adapter
+  // landed — detecting is not supporting; supporting is.
+  { name: "kimi", install: getInstallCommand("kimi") }
 ];
 
 /**
@@ -23,7 +26,6 @@ const OBSERVED_AGENTS = [
   { name: "cursor-agent", bin: "cursor-agent" },
   { name: "pi", bin: "pi" },
   { name: "kilocode", bin: "kilocode" },
-  { name: "kimi", bin: "kimi" },
   { name: "vibe", bin: "vibe" },
   { name: "rovodev", bin: "acli" },
 ];

--- a/src/utils/role-env.js
+++ b/src/utils/role-env.js
@@ -32,8 +32,9 @@ const PREFIXES = [
 
 // Vars only ONE agent authenticates with — granting them globally would
 // defeat the point (the coder does not need your GitHub token; copilot does).
-const AGENT_EXTRAS = {
+export const AGENT_EXTRAS = {
   copilot: ["GITHUB_", "GH_"],
+  kimi: ["KIMI_", "MOONSHOT_"],
 };
 
 const matches = (pattern, key) =>

--- a/tests/agents/kimi-agent.test.js
+++ b/tests/agents/kimi-agent.test.js
@@ -1,0 +1,70 @@
+// KJC-TSK-0729 fase 2 — Kimi Code (Moonshot, binary `kimi`) as the eighth
+// built-in agent: the free-tier reserve of the reviewer/solomon panel.
+// CLI surface verified live against kimi-code 0.27.0: `-p <prompt>` prints
+// the response (text by default), `-m <model>`, `-y` auto-approves actions.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { KimiAgent } from "../../src/agents/kimi-agent.js";
+import { createAgent, getAgentMeta } from "../../src/agents/index.js";
+import { buildMockEnvironment } from "../../src/infrastructure/mocks.js";
+import { KNOWN_AGENTS, OBSERVED_AGENTS } from "../../src/utils/agent-detect.js";
+import { REVIEWER_CANDIDATES } from "../../src/review/reviewer-fallback.js";
+import { AGENT_EXTRAS } from "../../src/utils/role-env.js";
+
+describe("KimiAgent", () => {
+  let runCommand, env;
+  beforeEach(() => {
+    env = buildMockEnvironment();
+    runCommand = vi.spyOn(env.runner, "run").mockResolvedValue({ exitCode: 0, stdout: '{"approved":true}', stderr: "" });
+  });
+
+  it("is registered as a built-in agent with the kimi binary", () => {
+    expect(getAgentMeta("kimi")).toMatchObject({ bin: "kimi" });
+    expect(createAgent("kimi", {}, {}, env)).toBeInstanceOf(KimiAgent);
+  });
+
+  it("reviewTask runs -p with a no-tools instruction and NO auto-approval flags", async () => {
+    const agent = new KimiAgent("kimi", {}, {}, env);
+    const res = await agent.reviewTask({ prompt: "review this diff", role: "reviewer" });
+    const [bin, args] = runCommand.mock.calls[0];
+    expect(bin).toMatch(/kimi/);
+    expect(args).toContain("-p");
+    expect(args[args.indexOf("-p") + 1]).toMatch(/^Do NOT use any tools[\s\S]*review this diff$/);
+    expect(args).not.toContain("-y");
+    expect(args).not.toContain("--auto");
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe('{"approved":true}');
+  });
+
+  it("runTask auto-approves actions (a coder must act) and honours the role model pin", async () => {
+    const agent = new KimiAgent("kimi", { roles: { coder: { model: "k2.6" } } }, {}, env);
+    await agent.runTask({ prompt: "build it", role: "coder" });
+    const [, args] = runCommand.mock.calls[0];
+    expect(args).toContain("-y");
+    expect(args).toContain("-m");
+    expect(args[args.indexOf("-m") + 1]).toBe("k2.6");
+  });
+
+  it("maps non-zero exit to ok:false with stderr as the error", async () => {
+    runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error: failed to run prompt" });
+    const agent = new KimiAgent("kimi", {}, {}, env);
+    const res = await agent.reviewTask({ prompt: "x", role: "reviewer" });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("failed to run prompt");
+  });
+});
+
+describe("kimi promotion: supported, not merely observed", () => {
+  it("moves from the observation census into KNOWN_AGENTS (detecting is not supporting — supporting is)", () => {
+    expect(KNOWN_AGENTS.map((a) => a.name)).toContain("kimi");
+    expect(OBSERVED_AGENTS.map((a) => a.name)).not.toContain("kimi");
+  });
+
+  it("stops being adapterPending in the reviewer-fallback registry", () => {
+    const kimi = REVIEWER_CANDIDATES.find((c) => c.name === "kimi");
+    expect(kimi.adapterPending).toBeUndefined();
+  });
+
+  it("gets only its own auth env prefixes in the allowlist", () => {
+    expect(AGENT_EXTRAS.kimi).toEqual(["KIMI_", "MOONSHOT_"]);
+  });
+});


### PR DESCRIPTION
## Qué
Fase 2a de KJC-TSK-0729 (activada por el login del usuario): **KimiAgent** — Kimi Code (Moonshot, binario `kimi`, verificado en vivo contra 0.27.0: `-p` no interactivo con el prompt como argumento, `-m` modelo, `-y` auto-aprobación). Review/arbitraje sin auto-aprobación y con instrucción no-tools (patrón copilot); coder con `-y`. Promociones coherentes con el principio 'detectar no es soportar': entra en KNOWN_AGENTS y SALE del censo de observación (el test de no-solape lo exige); deja de ser `adapterPending` en el registro de failover; env allowlist con extras propios (`KIMI_`/`MOONSHOT_`).

## Nota de campo
En la máquina del mantenedor el `/login` dejó credenciales pero no pobló el provider ('No model configured') — el registro de failover ya recoge la remediación (`kimi login` de nuevo). El smoke en vivo del review con kimi queda pendiente de ese re-login.

## Verificación
Suite completa 6460/6460 exit 0 · `kj audit --security` 0 findings · APPROVED por copilot (diff 95e0ee8cc245) vía el failover de 0730.

Card: KJC-TSK-0729 (In Progress — fase 2b: adaptador agy tras su login)