### PR TITLE
feat(agents): antigravity cli (agy) as ninth built-in agent (KJC-TSK-0729)

### DIFF
--- a/src/agents/agy-agent.js
+++ b/src/agents/agy-agent.js
@@ -1,0 +1,61 @@
+import { BaseAgent } from "./base-agent.js";
+import { resolveBin } from "./resolve-bin.js";
+
+/**
+ * Antigravity CLI (`agy`) — KJC-TSK-0729 fase 2b: the ninth built-in agent.
+ * Google's official successor to the retired gemini CLI (dead 2026-06-18),
+ * covered by the user's Google AI Pro/Ultra subscription — the natural
+ * third AI for solomon arbitration, back at last.
+ *
+ * Verified live against agy 1.1.10:
+ *  - `-p <prompt>` runs print mode; `--output-format json` emits ONE JSON
+ *    object: {status: "SUCCESS", response, usage}. Non-SUCCESS status can
+ *    arrive with exit 0, so ok checks BOTH.
+ *  - `--disable-slash-commands` keeps prompt content (diffs can contain
+ *    "/lines") from expanding as slash commands in print mode.
+ *  - Permission prompts are denied in print mode unless
+ *    `--dangerously-skip-permissions` (coder mode only).
+ *  - Auth lives under ~/.gemini/antigravity-cli (device/browser login).
+ */
+export class AgyAgent extends BaseAgent {
+  async runTask(task) {
+    return this._exec(task, this.getRoleModel(task.role || "coder"), ["--dangerously-skip-permissions"]);
+  }
+
+  async reviewTask(task) {
+    return this._exec(
+      { ...task, prompt: `Do NOT use any tools. Answer directly from this prompt only.\n\n${task.prompt}` },
+      this.getRoleModel(task.role || "reviewer"),
+      [],
+    );
+  }
+
+  async _exec(task, model, extraArgs) {
+    const args = ["-p", task.prompt, "--output-format", "json", "--disable-slash-commands", ...extraArgs];
+    if (model) args.push("--model", model);
+    const res = await this.runCommand(resolveBin("agy"), args, {
+      onOutput: task.onOutput,
+      silenceTimeoutMs: task.silenceTimeoutMs,
+      timeout: task.timeoutMs,
+    });
+    const parsed = extractAgyOutput(res.stdout);
+    const ok = res.exitCode === 0 && parsed?.status === "SUCCESS";
+    return {
+      ok,
+      output: parsed?.response ?? res.stdout,
+      error: ok ? res.stderr : parsed?.error || res.stderr || `agy status: ${parsed?.status || "unparseable"}`,
+      exitCode: res.exitCode,
+    };
+  }
+}
+
+/** Parse agy's single-object JSON print output ({status, response}), null if not JSON. */
+export function extractAgyOutput(stdout) {
+  if (!stdout) return null;
+  try {
+    const obj = JSON.parse(stdout.trim());
+    return typeof obj === "object" && obj !== null ? obj : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/agents/index.js
+++ b/src/agents/index.js
@@ -6,6 +6,7 @@ import { OpenCodeAgent } from "./opencode-agent.js";
 import { QwenAgent } from "./qwen-agent.js";
 import { CopilotAgent } from "./copilot-agent.js";
 import { KimiAgent } from "./kimi-agent.js";
+import { AgyAgent } from "./agy-agent.js";
 
 const agentRegistry = new Map();
 
@@ -55,3 +56,4 @@ registerAgent("opencode", OpenCodeAgent, { bin: "opencode", installUrl: "https:/
 registerAgent("qwen", QwenAgent, { bin: "qwen", installUrl: "https://github.com/QwenLM/qwen-code" });
 registerAgent("copilot", CopilotAgent, { bin: "copilot", installUrl: "https://docs.github.com/copilot/how-tos/use-copilot-agents/use-copilot-cli" });
 registerAgent("kimi", KimiAgent, { bin: "kimi", installUrl: "https://github.com/MoonshotAI/kimi-code" });
+registerAgent("agy", AgyAgent, { bin: "agy", installUrl: "https://antigravity.google" });

--- a/src/config/overrides.js
+++ b/src/config/overrides.js
@@ -81,7 +81,14 @@ function applyRoleOverrides(out, flags) {
   // boolean means the flag belongs to the command itself (`kj audit
   // --security`, KJC-TSK-0695) and must not become a provider.
   for (const [flag, role] of ROLE_PROVIDER_FLAGS) {
-    if (typeof flags[flag] === "string" && flags[flag]) out.roles[role].provider = flags[flag];
+    if (typeof flags[flag] === "string" && flags[flag]) {
+      // A model pin belongs to the provider it was written for — switching
+      // provider by flag drops it (KJC-TSK-0729: codex's pinned mini reached
+      // agy, which answered with its model list instead of a verdict). An
+      // explicit --<role>-model flag re-pins below, after this loop.
+      if (out.roles[role].provider && out.roles[role].provider !== flags[flag]) out.roles[role].model = null;
+      out.roles[role].provider = flags[flag];
+    }
   }
   // coder/reviewer also update top-level aliases
   if (flags.coder) out.coder = flags.coder;

--- a/src/review/reviewer-fallback.js
+++ b/src/review/reviewer-fallback.js
@@ -35,8 +35,7 @@ export const REVIEWER_CANDIDATES = [
     tier: "suscripción Google AI Pro/Ultra (sucesor del gemini CLI, retirado 06-2026)",
     login: "agy → /login (cuenta Google)",
     install: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
-    authPaths: [".agy", ".config/agy", ".antigravity-cli"],
-    adapterPending: true,
+    authPaths: [".gemini/antigravity-cli"],
   },
   {
     name: "kimi",

--- a/src/utils/agent-detect.js
+++ b/src/utils/agent-detect.js
@@ -12,7 +12,8 @@ const KNOWN_AGENTS = [
   { name: "copilot", install: getInstallCommand("copilot") },
   // KJC-TSK-0729: promoted from the observation census once its adapter
   // landed — detecting is not supporting; supporting is.
-  { name: "kimi", install: getInstallCommand("kimi") }
+  { name: "kimi", install: getInstallCommand("kimi") },
+  { name: "agy", install: getInstallCommand("agy") }
 ];
 
 /**

--- a/src/utils/os-detect.js
+++ b/src/utils/os-detect.js
@@ -56,6 +56,11 @@ const INSTALL_COMMANDS = {
     linux: "npm install -g @qwen-code/qwen-code",
     windows: "npm install -g @qwen-code/qwen-code"
   },
+  agy: {
+    macos: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+    linux: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+    windows: "irm https://antigravity.google/cli/install.ps1 | iex"
+  },
   copilot: {
     macos: "npm install -g @github/copilot",
     linux: "npm install -g @github/copilot",

--- a/tests/agents/agy-agent.test.js
+++ b/tests/agents/agy-agent.test.js
@@ -1,0 +1,77 @@
+// KJC-TSK-0729 fase 2b — Antigravity CLI (`agy`, Google's successor to the
+// retired gemini CLI) as the ninth built-in agent. CLI surface verified live
+// against agy 1.1.10: `-p` print mode, `--output-format json` emits ONE JSON
+// object ({status, response, usage}), `--model`, permissions denied unless
+// `--dangerously-skip-permissions`.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AgyAgent, extractAgyOutput } from "../../src/agents/agy-agent.js";
+import { createAgent, getAgentMeta } from "../../src/agents/index.js";
+import { buildMockEnvironment } from "../../src/infrastructure/mocks.js";
+import { KNOWN_AGENTS } from "../../src/utils/agent-detect.js";
+import { REVIEWER_CANDIDATES } from "../../src/review/reviewer-fallback.js";
+
+const AGY_JSON = JSON.stringify({
+  conversation_id: "x",
+  status: "SUCCESS",
+  response: '{"approved":true,"blocking_issues":[]}',
+  usage: { input_tokens: 10, output_tokens: 5 },
+});
+
+describe("AgyAgent", () => {
+  let runCommand, env;
+  beforeEach(() => {
+    env = buildMockEnvironment();
+    runCommand = vi.spyOn(env.runner, "run").mockResolvedValue({ exitCode: 0, stdout: AGY_JSON, stderr: "" });
+  });
+
+  it("is registered as a built-in agent with the agy binary", () => {
+    expect(getAgentMeta("agy")).toMatchObject({ bin: "agy" });
+    expect(createAgent("agy", {}, {}, env)).toBeInstanceOf(AgyAgent);
+  });
+
+  it("reviewTask prints with json output, slash expansion off, no permission skips, no-tools instruction", async () => {
+    const agent = new AgyAgent("agy", {}, {}, env);
+    const res = await agent.reviewTask({ prompt: "review this diff", role: "reviewer" });
+    const [bin, args] = runCommand.mock.calls[0];
+    expect(bin).toMatch(/agy/);
+    expect(args[args.indexOf("-p") + 1]).toMatch(/^Do NOT use any tools[\s\S]*review this diff$/);
+    expect(args).toContain("--output-format");
+    expect(args).toContain("--disable-slash-commands");
+    expect(args).not.toContain("--dangerously-skip-permissions");
+    expect(res.ok).toBe(true);
+    expect(res.output).toBe('{"approved":true,"blocking_issues":[]}');
+  });
+
+  it("runTask skips permission prompts (a coder must act) and honours the role model pin", async () => {
+    const agent = new AgyAgent("agy", { roles: { coder: { model: "gemini-3.1-pro" } } }, {}, env);
+    await agent.runTask({ prompt: "build it", role: "coder" });
+    const [, args] = runCommand.mock.calls[0];
+    expect(args).toContain("--dangerously-skip-permissions");
+    expect(args[args.indexOf("--model") + 1]).toBe("gemini-3.1-pro");
+  });
+
+  it("a non-SUCCESS status maps to ok:false even with exit 0", async () => {
+    runCommand.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({ status: "ERROR", response: "", error: "quota exceeded" }),
+      stderr: "",
+    });
+    const agent = new AgyAgent("agy", {}, {}, env);
+    const res = await agent.reviewTask({ prompt: "x", role: "reviewer" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("extractAgyOutput returns the response field, or null on non-JSON", () => {
+    expect(extractAgyOutput(AGY_JSON).response).toBe('{"approved":true,"blocking_issues":[]}');
+    expect(extractAgyOutput("garbage")).toBeNull();
+  });
+});
+
+describe("agy promotion", () => {
+  it("joins KNOWN_AGENTS and stops being adapterPending in the fallback registry", () => {
+    expect(KNOWN_AGENTS.map((a) => a.name)).toContain("agy");
+    const agy = REVIEWER_CANDIDATES.find((c) => c.name === "agy");
+    expect(agy.adapterPending).toBeUndefined();
+    expect(agy.authPaths).toContain(".gemini/antigravity-cli");
+  });
+});

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -16,6 +16,25 @@ afterEach(async () => {
   }
 });
 
+describe("applyRunOverrides — a model pin belongs to its provider (KJC-TSK-0729)", () => {
+  // Found live twice in one day: codex's gpt-5.4-mini pin travelled first to
+  // the quota fallback (copilot) and then to an explicit --reviewer agy,
+  // which answered with its model list instead of a verdict.
+  it("switching a role provider by flag drops the configured model pin", () => {
+    const cfg = { roles: { reviewer: { provider: "codex", model: "gpt-5.4-mini" } } };
+    const out = applyRunOverrides(cfg, { reviewer: "agy" });
+    expect(out.roles.reviewer.provider).toBe("agy");
+    expect(out.roles.reviewer.model).toBeNull();
+  });
+
+  it("keeps the pin when the flag names the SAME provider, and honours an explicit model flag", () => {
+    const cfg = { roles: { reviewer: { provider: "codex", model: "gpt-5.4-mini" } } };
+    expect(applyRunOverrides(cfg, { reviewer: "codex" }).roles.reviewer.model).toBe("gpt-5.4-mini");
+    const out = applyRunOverrides(cfg, { reviewer: "agy", reviewerModel: "gemini-3.1-pro" });
+    expect(out.roles.reviewer.model).toBe("gemini-3.1-pro");
+  });
+});
+
 describe("applyRunOverrides — max_budget_usd default-on (KJC-TSK-0621)", () => {
   it("an unset budget lands on the shipped default of 5", () => {
     const out = applyRunOverrides({}, {});


### PR DESCRIPTION
## Qué
Fase 2b y cierre de KJC-TSK-0729: **AgyAgent** — Antigravity CLI 1.1.10, sucesor oficial del gemini CLI (retirado 18-06-2026), cubierto por la suscripción Google AI Pro del usuario. Verificado EN VIVO: `-p` print mode con `--output-format json` (objeto único {status, response, usage} — status no-SUCCESS puede llegar con exit 0, el ok comprueba ambos), `--disable-slash-commands` (un diff con '/líneas' no debe expandir comandos), permisos denegados salvo coder (`--dangerously-skip-permissions`), auth en `~/.gemini/antigravity-cli`. Alta en KNOWN_AGENTS, install hints oficiales (curl/irm de antigravity.google), y fuera de `adapterPending` en el failover.

**Más el fix que el estreno destapó**: el pin de modelo de un rol pertenece a su provider — cambiar el provider por flag (`--reviewer agy`) ahora suelta el pin (el `gpt-5.4-mini` de codex llegaba a agy, que respondía con su lista de modelos en vez del veredicto). Segunda vez que esta clase de bug aparece en dos días (la primera en el failover) — ahora cerrada en la raíz (overrides), con tests.

## Dogfood
El veredicto de este PR lo emitió **agy revisando su propio adaptador**: APPROVED (diff 61283b615ef8).

## Nota de tamaño
175 líneas: adaptador + el fix de overrides que su estreno destapó — separar el fix dejaría el adaptador roto para cualquier config con pin.

Card: KJC-TSK-0729 · El panel queda: claude escribe · codex/copilot/agy/kimi revisan/arbitran