### PR TITLE
fix(tests): hook timeout parity — the crack a week of flakes crawled through (KJC-TSK-0545)

### DIFF
--- a/tests/architecture/hook-timeout-parity.test.js
+++ b/tests/architecture/hook-timeout-parity.test.js
@@ -1,0 +1,16 @@
+// KJC-TSK-0545 — the lock on a week of file-hopping flakes: the runflow
+// family cold-imports the orchestrator graph inside beforeEach, and under
+// worker contention that first import blew vitest's DEFAULT 10s hook budget
+// while tests enjoyed 120s. An aborted hook leaves mocks half-wired, which
+// cascaded into missing events, broken mock objects and even real agent
+// spawns. Hooks must share the contention budget the config already grants
+// to tests — this test makes the gap structurally impossible to reopen.
+import { describe, it, expect } from "vitest";
+import config from "../../vitest.config.js";
+
+describe("vitest hook/test timeout parity", () => {
+  it("hookTimeout equals testTimeout — hooks pay the same contention tax as tests", () => {
+    expect(config.test.hookTimeout).toBe(config.test.testTimeout);
+    expect(config.test.hookTimeout).toBeGreaterThanOrEqual(120000);
+  });
+});

--- a/tests/runflow-budget.test.js
+++ b/tests/runflow-budget.test.js
@@ -21,6 +21,22 @@ vi.mock("../src/agents/index.js", () => ({
   createAgent: vi.fn()
 }));
 
+// KJC-TSK-0545: without this mock the orchestrator's preflight probes every
+// KNOWN_AGENTS binary for real (nine 5s-timeout spawns per run) — latency
+// and nondeterminism a budget test must not depend on.
+vi.mock("../src/utils/agent-detect.js", () => ({
+  detectAvailableAgents: vi.fn().mockResolvedValue([
+    { name: "claude", available: true, version: "1.0.0", install: "" },
+    { name: "codex", available: true, version: "1.0.0", install: "" }
+  ]),
+  detectObservedAgents: vi.fn().mockResolvedValue([]),
+  checkBinary: vi.fn().mockResolvedValue({ ok: true, version: "1.0.0", path: "/usr/bin/mock" }),
+  detectHostAgent: vi.fn().mockReturnValue(null),
+  isHostAgent: vi.fn().mockReturnValue(false),
+  KNOWN_AGENTS: [{ name: "claude", install: "" }, { name: "codex", install: "" }],
+  OBSERVED_AGENTS: []
+}));
+
 vi.mock("../src/session/store.js", () => {
   let session = null;
   return {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -28,6 +28,15 @@ export default defineConfig({
     // ~5-15s in isolation. Use forks (not threads) because several config
     // tests call process.chdir(), which throws inside worker_threads.
     testTimeout: 120000,
+    // KJC-TSK-0545: hooks inherit the SAME contention budget. The runflow
+    // family cold-imports the orchestrator graph inside beforeEach (31 test
+    // files, ~90 sites); under parallel workers that first import can exceed
+    // the 10s default, and an aborted hook leaves the module/mock registry
+    // half-wired — the source of a whole week of file-hopping flakes (missing
+    // solomon events, "mockImplementation is not a function", even REAL agent
+    // spawns when the broken mock fell through to the real createAgent). An
+    // architecture test pins hookTimeout === testTimeout.
+    hookTimeout: 120000,
     pool: "forks",
     poolOptions: {
       forks: {


### PR DESCRIPTION
## Diagnóstico (la parte valiosa)
Una semana de flakes que saltaban de fichero — eventos de solomon ausentes, `mockImplementation is not a function`, spawns de claude REAL con AUTH_FAILED — tenían UN mecanismo: la familia runflow (31 ficheros, ~90 sitios) importa el grafo del orquestador dentro de `beforeEach`; `testTimeout` se subió a 120s hace meses por la contención entre workers, pero `hookTimeout` quedó en el default de vitest (10s). Bajo carga, el primer import frío revienta el hook, y un hook abortado deja el registro de módulos/mocks a medias — TODOS los síntomas eran esa cascada (incluidos los spawns reales: el mock roto caía al createAgent de verdad).

## Fix + candado
- `hookTimeout: 120000` — los hooks pagan el mismo impuesto de contención que los tests.
- Test de arquitectura que pinna `hookTimeout === testTimeout` — la grieta no puede reabrirse.
- `runflow-budget` gana el mock de agent-detect que le faltaba (sondaba 9 binarios reales por run).

## Verificación (el AC exigía 3, no 1)
**Tres pasadas completas consecutivas: 633/633 ficheros en verde las tres** — primera vez en la semana. De regalo, dos hallazgos colaterales cazados y anotados: bindings nativos borrados y node_modules convertido a layout pnpm por el paso pnpm del verify-pack (candidata a issue).

Card: KJC-TSK-0545 (reenfocada con OK del usuario) · Veredicto: APPROVED por agy (diff c78dbe8de148)