### PR TITLE
feat(tournament): fan-out lanes — same task, n coders, isolated evidence (KJC-TSK-0723)

### DIFF
--- a/src/agents/agy-agent.js
+++ b/src/agents/agy-agent.js
@@ -37,6 +37,7 @@ export class AgyAgent extends BaseAgent {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs,
+      cwd: task.cwd,
     });
     const parsed = extractAgyOutput(res.stdout);
     const ok = res.exitCode === 0 && parsed?.status === "SUCCESS";

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -374,7 +374,8 @@ export class ClaudeAgent extends BaseAgent {
         onOutput: streamFilter,
         silenceTimeoutMs: task.silenceTimeoutMs,
         timeout: task.timeoutMs,
-        env: task.env
+        env: task.env,
+        cwd: task.cwd
       }));
       const raw = pickOutput(res);
       const output = extractTextFromStreamJson(raw);
@@ -384,7 +385,7 @@ export class ClaudeAgent extends BaseAgent {
 
     // Without streaming, use json output to get structured response via stderr
     args.push("--output-format", "json");
-    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({ env: task.env }));
+    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({ env: task.env, cwd: task.cwd }));
     const raw = pickOutput(res);
     const output = extractTextFromStreamJson(raw);
     const usage = extractUsageFromStreamJson(raw);

--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -85,7 +85,9 @@ export class CodexAgent extends BaseAgent {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs,
-      input: task.prompt
+      input: task.prompt,
+      // TOR-A (KJC-TSK-0723): tournament lanes run the coder INSIDE the lane.
+      cwd: task.cwd
     });
     const usage = extractCodexTokens(res.stdout);
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode, ...usage };

--- a/src/agents/kimi-agent.js
+++ b/src/agents/kimi-agent.js
@@ -38,6 +38,7 @@ export class KimiAgent extends BaseAgent {
       onOutput: task.onOutput,
       silenceTimeoutMs: task.silenceTimeoutMs,
       timeout: task.timeoutMs,
+      cwd: task.cwd,
     });
     return { ok: res.exitCode === 0, output: res.stdout, error: res.stderr, exitCode: res.exitCode };
   }

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -60,7 +60,7 @@ const header = (steps) =>
 // third-party action. pnpm passes flags AFTER the script name to the script
 // itself, so --if-present must go BEFORE it; yarn has no --if-present at all,
 // so lint runs through `npm run` (scripts don't touch the lockfile).
-const PM_COMMANDS = {
+export const PM_COMMANDS = {
   npm: { setup: [], install: "npm ci", lint: "npm run -s lint --if-present", test: "npm test" },
   pnpm: {
     setup: ["      - run: corepack enable"],

--- a/src/tournament/run.js
+++ b/src/tournament/run.js
@@ -1,0 +1,136 @@
+/**
+ * tournament/run — TOR-A (KJC-TSK-0723, epic KJC-PCS-0073).
+ *
+ * Orca's pitch is "fan one prompt across N agents, compare, merge the
+ * winner" — with a human eyeballing diffs. Karajan's tournament keeps the
+ * fan-out and replaces the eyeballing with the method: this module runs the
+ * SAME task through N coders, each in its own isolated worktree lane (the
+ * PAR machinery), and collects per-lane evidence (diff, suite result, agent
+ * log, metadata) for the deterministic scoreboard (TOR-B) and the governed
+ * judgement/merge (TOR-C). No commits here: lanes stay as working trees.
+ *
+ * A COMPOSER, not a new pipeline: lanes = `git worktree` under
+ * .kj/worktrees (same dir as kj worktree / headless lanes); agents = the
+ * registered adapters with the PAR idiom (laneConfig.projectDir = lane,
+ * task.cwd = lane); suite = the package manager the repo actually uses.
+ * Every dependency is injectable; one lane's failure never sinks another.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createAgent } from "../agents/index.js";
+import { bootstrapWorktree } from "../hu/worktree-bootstrap.js";
+import { detectPackageManager } from "../harden/workflow-engine.js";
+import { PM_COMMANDS } from "../harden/workflow-templates.js";
+
+const execFileAsync = promisify(execFile);
+const WORKTREE_DIR = ".kj/worktrees"; // shared with kj worktree + headless lanes
+const TOURNAMENT_DIR = ".kj/tournaments";
+const SUITE_TIMEOUT_MS = 15 * 60 * 1000;
+
+const defaultGit = (args, cwd) => execFileAsync("git", args, { cwd, maxBuffer: 64 * 1024 * 1024 });
+
+async function defaultRunSuite({ lanePath }) {
+  const pm = detectPackageManager(lanePath);
+  const testCmd = (PM_COMMANDS[pm] || PM_COMMANDS.npm).test.split(" ");
+  try {
+    const res = await execFileAsync(testCmd[0], testCmd.slice(1), {
+      cwd: lanePath, timeout: SUITE_TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024,
+    });
+    return { ok: true, exitCode: 0, output: res.stdout || "" };
+  } catch (err) {
+    return { ok: false, exitCode: err.code ?? 1, output: `${err.stdout || ""}\n${err.stderr || ""}` };
+  }
+}
+
+/**
+ * Fan the task out to every coder and collect per-lane results.
+ * @returns {Promise<{id: string, dir: string, lanes: Array<object>}>}
+ */
+export async function runTournament({ task, coders = [], config = {}, logger = console, deps = {} }) {
+  const {
+    createAgentFn = createAgent,
+    gitFn = defaultGit,
+    bootstrapFn = bootstrapWorktree,
+    runSuiteFn = defaultRunSuite,
+  } = deps;
+  if (!task || !String(task).trim()) throw new Error("tournament: falta la tarea");
+  if (!Array.isArray(coders) || coders.length < 2) {
+    throw new Error("tournament: hacen falta al menos 2 coders (--coders a,b) — con uno no hay torneo");
+  }
+  // Coder names feed lane/result PATHS: a strict slug (no separators, no
+  // leading dot, no traversal) before any filesystem use — codex's catch.
+  const CODER_RE = /^[a-z0-9][a-z0-9_-]{0,23}$/i;
+  for (const c of coders) {
+    if (!CODER_RE.test(String(c))) {
+      throw new Error(`tournament: nombre de coder inválido "${c}" — solo letras, dígitos, guiones (sin rutas)`);
+    }
+  }
+
+  const projectDir = config.projectDir || process.cwd();
+  const id = `tor-${Date.now().toString(36)}`;
+  const resultsRoot = path.join(projectDir, TOURNAMENT_DIR, id);
+  fs.mkdirSync(resultsRoot, { recursive: true });
+  logger?.info?.(`kj tournament ${id}: ${coders.length} coders → ${coders.join(", ")}`);
+
+  const settled = await Promise.allSettled(coders.map((coder) => runLane({
+    coder, task, id, projectDir, resultsRoot, config, logger,
+    createAgentFn, gitFn, bootstrapFn, runSuiteFn,
+  })));
+
+  const lanes = settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : { coder: coders[i], status: "failed", error: String(s.reason?.message || s.reason), dir: path.join(resultsRoot, coders[i]) },
+  );
+
+  const summary = { id, task: String(task), created_at: new Date().toISOString(), lanes };
+  fs.writeFileSync(path.join(resultsRoot, "summary.json"), JSON.stringify(summary, null, 2));
+  for (const lane of lanes) {
+    let state = `FAILED: ${lane.error}`;
+    if (lane.status === "completed") state = lane.suite?.ok ? "suite verde" : "suite ROJA";
+    logger?.info?.(`  ${lane.coder.padEnd(10)} ${lane.status.padEnd(10)} ${state}`);
+  }
+  return { id, dir: resultsRoot, lanes };
+}
+
+async function runLane({ coder, task, id, projectDir, resultsRoot, config, logger, createAgentFn, gitFn, bootstrapFn, runSuiteFn }) {
+  const slug = `${id}-${coder}`;
+  const lanePath = path.join(projectDir, WORKTREE_DIR, slug);
+  const branch = `tor/${slug}`;
+  const laneDir = path.join(resultsRoot, coder);
+  fs.mkdirSync(laneDir, { recursive: true });
+
+  await gitFn(["worktree", "add", "-b", branch, lanePath], projectDir);
+  await bootstrapFn({ worktreePath: lanePath, setupCommand: config?.session?.worktree_setup || null });
+
+  // The PAR idiom: the lane IS the project for this agent.
+  const laneConfig = { ...config, projectDir: lanePath };
+  const prompt =
+    `You are one of ${"several"} coders solving the SAME task independently. ` +
+    `Work ONLY inside this directory (your isolated worktree). Implement the task with tests. Do not commit.\n\nTASK:\n${task}`;
+  const started = Date.now();
+  const result = await createAgentFn(coder, laneConfig, logger).runTask({ prompt, role: "coder", cwd: lanePath });
+  fs.writeFileSync(path.join(laneDir, "agent.log"), String(result?.output ?? ""));
+  if (!result?.ok) throw new Error(`coder ${coder} failed: ${result?.error || "no output"}`);
+
+  // Intent-to-add first: plain `git diff` is blind to UNTRACKED files, and
+  // new files are the most common coder output — codex's catch.
+  await gitFn(["add", "-N", "."], lanePath);
+  const diff = await gitFn(["diff"], lanePath);
+  fs.writeFileSync(path.join(laneDir, "diff.patch"), diff.stdout || "");
+
+  const suite = await runSuiteFn({ lanePath });
+  fs.writeFileSync(path.join(laneDir, "suite.log"), suite.output || "");
+
+  const meta = {
+    coder, branch, lane: lanePath, tournament: id,
+    duration_ms: Date.now() - started,
+    diff_bytes: (diff.stdout || "").length,
+    suite: { ok: suite.ok, exitCode: suite.exitCode },
+  };
+  fs.writeFileSync(path.join(laneDir, "meta.json"), JSON.stringify(meta, null, 2));
+
+  return { coder, status: "completed", branch, lane: lanePath, dir: laneDir, suite: { ok: suite.ok, exitCode: suite.exitCode } };
+}

--- a/tests/agents/kimi-agent.test.js
+++ b/tests/agents/kimi-agent.test.js
@@ -44,6 +44,13 @@ describe("KimiAgent", () => {
     expect(args[args.indexOf("-m") + 1]).toBe("k2.6");
   });
 
+  it("forwards task.cwd to the spawn — tournament lanes run the coder INSIDE the lane (TOR-A)", async () => {
+    const agent = new KimiAgent("kimi", {}, {}, env);
+    await agent.runTask({ prompt: "x", role: "coder", cwd: "/tmp/lane-1" });
+    const [, , options] = runCommand.mock.calls[0];
+    expect(options.cwd).toBe("/tmp/lane-1");
+  });
+
   it("maps non-zero exit to ok:false with stderr as the error", async () => {
     runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "error: failed to run prompt" });
     const agent = new KimiAgent("kimi", {}, {}, env);

--- a/tests/tournament/run.test.js
+++ b/tests/tournament/run.test.js
@@ -1,0 +1,119 @@
+// KJC-TSK-0723 TOR-A — the tournament fan-out: the SAME task to N coders in
+// N isolated worktree lanes, results collected per lane, one lane's failure
+// never sinking the others. Orca's "fan out and compare" — but the compare
+// will be the method's (TOR-B/C), not vibes. Full DI: no real git, agents
+// or package managers in these tests.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runTournament } from "../../src/tournament/run.js";
+
+let projectDir;
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-tor-"));
+});
+afterEach(() => fs.rmSync(projectDir, { recursive: true, force: true }));
+
+const okAgent = (marks) => (name, laneConfig) => ({
+  runTask: async (task) => {
+    marks.push({ name, cwd: task.cwd, projectDir: laneConfig.projectDir, role: task.role });
+    return { ok: true, output: `${name} did the work` };
+  },
+});
+
+const baseDeps = (marks, overrides = {}) => ({
+  createAgentFn: okAgent(marks),
+  gitFn: async (args, cwd) => {
+    marks.push({ git: args[0], cwd });
+    if (args[0] === "diff") return { stdout: `diff --git a/x.js b/x.js\n+by lane ${cwd}\n` };
+    return { stdout: "" };
+  },
+  bootstrapFn: async () => ({ ok: true }),
+  runSuiteFn: async () => ({ ok: true, exitCode: 0, output: "633 passed" }),
+  ...overrides,
+});
+
+describe("runTournament fan-out", () => {
+  it("creates one isolated lane per coder, runs each agent with the lane as cwd, and collects results", async () => {
+    const marks = [];
+    const res = await runTournament({
+      task: "build the rate limiter",
+      coders: ["claude", "codex"],
+      config: { projectDir },
+      logger: { info: () => {}, warn: () => {} },
+      deps: baseDeps(marks),
+    });
+
+    expect(res.lanes).toHaveLength(2);
+    for (const lane of res.lanes) {
+      expect(lane.status).toBe("completed");
+      expect(lane.suite.ok).toBe(true);
+      expect(fs.readFileSync(path.join(lane.dir, "diff.patch"), "utf8")).toContain("by lane");
+      const meta = JSON.parse(fs.readFileSync(path.join(lane.dir, "meta.json"), "utf8"));
+      expect(meta.coder).toBe(lane.coder);
+      expect(meta.branch).toMatch(/^tor\//);
+    }
+    // each agent ran with ITS lane as cwd and laneConfig.projectDir
+    const agentMarks = marks.filter((m) => m.name);
+    expect(agentMarks).toHaveLength(2);
+    for (const m of agentMarks) {
+      expect(m.cwd).toContain(".kj/worktrees/");
+      expect(m.projectDir).toBe(m.cwd);
+      expect(m.role).toBe("coder");
+    }
+    // two distinct lanes
+    expect(new Set(agentMarks.map((m) => m.cwd)).size).toBe(2);
+    // untracked files enter the evidence: intent-to-add precedes every diff
+    const gitOps = marks.filter((m) => m.git).map((m) => m.git);
+    expect(gitOps.filter((g) => g === "add")).toHaveLength(2);
+    expect(gitOps.indexOf("add")).toBeLessThan(gitOps.indexOf("diff"));
+  });
+
+  it("a failing lane reports status failed with its cause and does not sink the others", async () => {
+    const marks = [];
+    const deps = baseDeps(marks, {
+      createAgentFn: (name, laneConfig) =>
+        name === "codex"
+          ? { runTask: async () => { throw new Error("codex exploded"); } }
+          : okAgent(marks)(name, laneConfig),
+    });
+    const res = await runTournament({
+      task: "t", coders: ["claude", "codex"], config: { projectDir },
+      logger: { info: () => {}, warn: () => {} }, deps,
+    });
+    const failed = res.lanes.find((l) => l.coder === "codex");
+    const alive = res.lanes.find((l) => l.coder === "claude");
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toContain("codex exploded");
+    expect(alive.status).toBe("completed");
+  });
+
+  it("a red suite is a completed lane with suite.ok false — elimination is TOR-B's job, not an error", async () => {
+    const marks = [];
+    const deps = baseDeps(marks, { runSuiteFn: async () => ({ ok: false, exitCode: 1, output: "2 failed" }) });
+    const res = await runTournament({
+      task: "t", coders: ["claude", "codex"], config: { projectDir },
+      logger: { info: () => {}, warn: () => {} }, deps,
+    });
+    for (const lane of res.lanes) {
+      expect(lane.status).toBe("completed");
+      expect(lane.suite.ok).toBe(false);
+    }
+  });
+
+  it("rejects coder names that could traverse paths — lanes and results derive dirs from them", async () => {
+    for (const evil of ["../evil", "a/b", ".hidden", "x".repeat(40)]) {
+      await expect(
+        runTournament({ task: "t", coders: [evil, "claude"], config: { projectDir }, logger: {}, deps: baseDeps([]) }),
+      ).rejects.toThrow(/inválido|invalid/i);
+    }
+  });
+
+  it("rejects fewer than two coders — one coder is not a tournament", async () => {
+    await expect(
+      runTournament({ task: "t", coders: ["claude"], config: { projectDir }, logger: {}, deps: baseDeps([]) }),
+    ).rejects.toThrow(/2|dos/);
+  });
+});


### PR DESCRIPTION
## Qué
PR1 de TOR-A (épica **Torneo gobernado** KJC-PCS-0073, arrancada con el '¡arrancamos!' del usuario): `src/tournament/run.js` — la MISMA tarea a N coders, cada uno en su carril worktree aislado (`tor/<id>-<coder>` bajo `.kj/worktrees`, misma maquinaria que kj worktree/PAR + bootstrap), con el idioma del PAR (`laneConfig.projectDir` = carril) y `task.cwd` reenviado al spawn en los 4 adaptadores (claude ×3 sitios, codex, agy, kimi — contrato pinnado por test). Por carril queda la evidencia para TOR-B/C: `diff.patch` (con **intent-to-add** primero — `git diff` es ciego a ficheros nuevos, caza de codex), `suite.log` (detectPackageManager reutilizado del fix pnpm), `agent.log` y `meta.json`. `Promise.allSettled`: un carril caído = `failed` con causa, jamás tumba a los demás; suite roja = carril completado con `suite.ok:false` (eliminar es trabajo del scoreboard, no un error). Sin commits en carriles: el merge gobernado es TOR-C.

## Review (codex de vuelta, estrenando cuota)
Dos rechazos LEGÍTIMOS incorporados: (1) nombres de coder sin sanear alimentaban rutas — path traversal posible, ahora slug estricto validado antes de cualquier uso; (2) `git diff` perdía los ficheros nuevos — intent-to-add. Más un MAJOR de sonar (ternario anidado) extraído.

## Verificación
DI total en tests (sin git/agentes/PMs reales): fan-out con carriles distintos y cwd correcto, aislamiento de fallo, suite roja no-error, traversal rechazado, add-antes-de-diff. Suite completa 6482/6482 exit 0 · audit 0 findings · APPROVED por codex (diff 0c0995fc3eeb).

PR2: CLI `kj tournament` + smoke con coders reales.
Card: KJC-TSK-0723 (In Progress)