### PR TITLE
feat(tournament): kj tournament command — fan out, collect, compare (KJC-TSK-0723)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -27,7 +27,7 @@ export const META_COMMANDS = ["advanced", "help"];
  * so a newly-registered command can never silently vanish from `kj advanced`.
  */
 export const ADVANCED_GROUPS = [
-  { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan"] },
+  { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan", "tournament"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release"] },

--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -3,6 +3,8 @@ import { ollamaStartCommand, ollamaStopCommand, ollamaStatusCommand, ollamaPullC
 import { configCommand } from "../commands/config.js";
 import { codeCommand } from "../commands/code.js";
 import { reviewCommand } from "../commands/review.js";
+import { tournamentCommand } from "../commands/tournament.js";
+import { resolveTaskInput } from "../utils/task-file.js";
 import { reviewGateCommand, solomonCommand } from "../commands/review-gate.js";
 import { scanCommand } from "../commands/scan.js";
 import { installToolsCommand } from "../commands/install-tools.js";
@@ -144,7 +146,6 @@ export function registerPipeline(program, { pkgVersion }) {
             effectiveTask = plan.task;
           }
         }
-        const { resolveTaskInput } = await import("../utils/task-file.js");
         const resolvedTask = await resolveTaskInput({ task: effectiveTask, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         const res = await runCommandHandler({ task: resolvedTask, config, logger, flags });
         // KJC-TSK-0674 (issue #1289): an aborted run (spec-review cancel,
@@ -163,7 +164,6 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--skip-spec-review", "Bypass the spec-reviewer pre-pipeline audit")
     .action(async (task, flags) => {
       const code = await withConfig(pkgVersion, "autorun", flags, async ({ config, logger }) => {
-        const { resolveTaskInput } = await import("../utils/task-file.js");
         const { autorunCommand } = await import("../commands/autorun.js");
         const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         const res = await autorunCommand({ task: resolvedTask, config, logger, flags });
@@ -181,7 +181,6 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--coder-model <name>")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "code", flags, async ({ config, logger }) => {
-        const { resolveTaskInput } = await import("../utils/task-file.js");
         const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         await codeCommand({ task: resolvedTask, config, logger });
       });
@@ -196,6 +195,21 @@ export function registerPipeline(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "solomon", flags, async ({ config, logger }) => {
         await solomonCommand({ config, logger, flags });
+      });
+    });
+
+  // KJC-TSK-0723 (TOR-A) — the governed tournament: same task, N coders,
+  // isolated lanes; the method picks the winner (TOR-B/C), not vibes.
+  program
+    .command("tournament")
+    .description("Fan the SAME task out to N coders in isolated worktree lanes and collect per-lane evidence (diff, suite, log)")
+    .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
+    .option("--task-file <path>", "Read the task from a file (e.g. .md)")
+    .option("--coders <csv>", "Comma-separated coder agents (minimum 2), e.g. claude,codex,agy")
+    .action(async (task, flags) => {
+      await withConfig(pkgVersion, "tournament", flags, async ({ config, logger }) => {
+        const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
+        await tournamentCommand({ task: resolvedTask, config, logger, flags });
       });
     });
 
@@ -220,7 +234,6 @@ export function registerPipeline(program, { pkgVersion }) {
           await reviewGateCommand({ config, logger, flags: { ...flags, task } });
           return;
         }
-        const { resolveTaskInput } = await import("../utils/task-file.js");
         const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         await reviewCommand({ task: resolvedTask, config, logger, baseRef: flags.baseRef });
       });

--- a/src/commands/tournament.js
+++ b/src/commands/tournament.js
@@ -1,0 +1,30 @@
+/**
+ * `kj tournament` (KJC-TSK-0723, TOR-A) — fan the SAME task out to N coders
+ * in N isolated worktree lanes and collect the evidence. The deterministic
+ * scoreboard (TOR-B) and the governed judgement/merge (TOR-C) build on the
+ * artifacts this command leaves under .kj/tournaments/<id>/.
+ */
+import { runTournament } from "../tournament/run.js";
+
+export async function tournamentCommand({ task, config, logger = console, flags = {}, runTournamentFn = runTournament }) {
+  if (!task || !String(task).trim()) {
+    throw new Error("tournament: falta la tarea — kj tournament \"<tarea>\" --coders claude,codex");
+  }
+  const coders = String(flags.coders || "")
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  if (coders.length < 2) {
+    throw new Error("tournament: hacen falta al menos 2 en --coders — p. ej. --coders claude,codex,agy (con uno no hay torneo)");
+  }
+
+  const res = await runTournamentFn({ task, coders, config, logger });
+
+  const completed = res.lanes.filter((l) => l.status === "completed");
+  const green = completed.filter((l) => l.suite?.ok);
+  logger?.info?.("");
+  logger?.info?.(`torneo ${res.id}: ${completed.length}/${res.lanes.length} carriles completados, ${green.length} con suite verde`);
+  logger?.info?.(`  evidencia: ${res.dir}`);
+  logger?.info?.("  siguiente: el scoreboard determinista (TOR-B) puntuará los carriles; de momento compara los diff.patch a mano.");
+  return res;
+}

--- a/src/tournament/run.js
+++ b/src/tournament/run.js
@@ -105,8 +105,14 @@ async function runLane({ coder, task, id, projectDir, resultsRoot, config, logge
   await gitFn(["worktree", "add", "-b", branch, lanePath], projectDir);
   await bootstrapFn({ worktreePath: lanePath, setupCommand: config?.session?.worktree_setup || null });
 
-  // The PAR idiom: the lane IS the project for this agent.
-  const laneConfig = { ...config, projectDir: lanePath };
+  // The PAR idiom: the lane IS the project for this agent. A tournament
+  // coder MUST be able to write files — found live in the first real run:
+  // codex without auto_approve produced an honest but useless EMPTY diff.
+  const laneConfig = {
+    ...config,
+    projectDir: lanePath,
+    coder_options: { ...config?.coder_options, auto_approve: true },
+  };
   const prompt =
     `You are one of ${"several"} coders solving the SAME task independently. ` +
     `Work ONLY inside this directory (your isolated worktree). Implement the task with tests. Do not commit.\n\nTASK:\n${task}`;

--- a/tests/tournament/cli.test.js
+++ b/tests/tournament/cli.test.js
@@ -1,0 +1,46 @@
+// KJC-TSK-0723 TOR-A PR2 — `kj tournament` command wiring: csv parsing,
+// actionable errors, and the human summary with next steps.
+import { describe, it, expect } from "vitest";
+import { tournamentCommand } from "../../src/commands/tournament.js";
+
+const logger = () => {
+  const lines = [];
+  return { lines, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: (m) => lines.push(m) };
+};
+
+describe("tournamentCommand", () => {
+  it("parses --coders csv, trims entries, and passes everything to the runner", async () => {
+    let seen = null;
+    const log = logger();
+    const res = await tournamentCommand({
+      task: "build it",
+      config: { projectDir: "/p" },
+      logger: log,
+      flags: { coders: " claude , codex " },
+      runTournamentFn: async (args) => {
+        seen = args;
+        return { id: "tor-x", dir: "/p/.kj/tournaments/tor-x", lanes: [{ coder: "claude", status: "completed", suite: { ok: true } }] };
+      },
+    });
+    expect(seen.coders).toEqual(["claude", "codex"]);
+    expect(seen.task).toBe("build it");
+    expect(res.id).toBe("tor-x");
+    expect(log.lines.join("\n")).toMatch(/tor-x/);
+    expect(log.lines.join("\n")).toMatch(/scoreboard|TOR-B/i);
+  });
+
+  it("fails actionably without --coders, and with fewer than two coders (the command enforces its own contract)", async () => {
+    await expect(
+      tournamentCommand({ task: "t", config: {}, logger: logger(), flags: {}, runTournamentFn: async () => ({}) }),
+    ).rejects.toThrow(/--coders/);
+    await expect(
+      tournamentCommand({ task: "t", config: {}, logger: logger(), flags: { coders: "claude" }, runTournamentFn: async () => ({}) }),
+    ).rejects.toThrow(/2/);
+  });
+
+  it("fails actionably without a task", async () => {
+    await expect(
+      tournamentCommand({ task: "", config: {}, logger: logger(), flags: { coders: "a,b" }, runTournamentFn: async () => ({}) }),
+    ).rejects.toThrow(/tarea|task/i);
+  });
+});

--- a/tests/tournament/run.test.js
+++ b/tests/tournament/run.test.js
@@ -18,7 +18,10 @@ afterEach(() => fs.rmSync(projectDir, { recursive: true, force: true }));
 
 const okAgent = (marks) => (name, laneConfig) => ({
   runTask: async (task) => {
-    marks.push({ name, cwd: task.cwd, projectDir: laneConfig.projectDir, role: task.role });
+    marks.push({
+      name, cwd: task.cwd, projectDir: laneConfig.projectDir, role: task.role,
+      autoApprove: Boolean(laneConfig?.coder_options?.auto_approve),
+    });
     return { ok: true, output: `${name} did the work` };
   },
 });
@@ -62,6 +65,9 @@ describe("runTournament fan-out", () => {
       expect(m.cwd).toContain(".kj/worktrees/");
       expect(m.projectDir).toBe(m.cwd);
       expect(m.role).toBe("coder");
+      // a coder that cannot write is a rigged tournament (live finding:
+      // codex without auto_approve → honest but useless empty diff)
+      expect(m.autoApprove).toBe(true);
     }
     // two distinct lanes
     expect(new Set(agentMarks.map((m) => m.cwd)).size).toBe(2);


### PR DESCRIPTION
## Qué
PR2 y cierre de TOR-A: el comando `kj tournament "<tarea>" --coders claude,codex,agy` (registrado en pipeline, clasificado en advanced) con parsing de csv, contrato ≥2 coders en la propia capa de comando (catch de codex), `--task-file`, y resumen humano con siguiente paso. Más dos fixes del estreno real: `auto_approve` forzado en el laneConfig (primer torneo vivo: codex produjo un diff VACÍO honesto pero inútil al no poder escribir) y los 4 dynamic imports de task-file del fichero deduplicados a estático (el ratchet de 170 lo exigió — budget liberado).

## El primer torneo real de kj
Proyecto desechable, tarea pequeña, claude vs codex: **claude completed suite verde · codex completed suite ROJA** — árbol principal intacto, carriles aislados, evidencia por carril explicando el rojo (el sandbox bubblewrap de codex no puede anidarse dentro del sandbox de la sesión anfitriona — limitación ambiental, no del torneo; desde terminal del usuario funciona). La evidencia cazando y explicando un fallo real en su primer uso: el producto funcionando.

## Verificación
Suite completa 6486/6486 exit 0 · paridad advanced verde · ratchet de imports verde · APPROVED por codex (diff 00ed536e24ed) tras un rechazo legítimo incorporado.

Card: KJC-TSK-0723 → To Validate al merge · TOR-B (scoreboard) desbloqueada