### PR TITLE
feat(tournament): deterministic scoreboard — declared rule, honest nulls (KJC-TSK-0724)

### DIFF
--- a/src/tournament/scoreboard.js
+++ b/src/tournament/scoreboard.js
@@ -1,0 +1,124 @@
+/**
+ * tournament/scoreboard — TOR-B (KJC-TSK-0724, epic KJC-PCS-0073).
+ *
+ * The deterministic half of "merge the winner": pure metrics computed from
+ * the artifacts TOR-A leaves under .kj/tournaments/<id>/ (suite verdict,
+ * net LOC, tests touched — parsed from diff.patch), plus injectable
+ * external metrics (mutation via `kj mutate` in the still-alive lane;
+ * sonar reserved) that degrade HONESTLY to null-with-note when their tool
+ * is unavailable — a fake zero would poison the ranking. Red suites are
+ * eliminated, never finalists. The ranking rule is lexicographic and
+ * PRINTED with the result: no opaque composite scores, no hidden weights.
+ * Zero LLM in this whole phase.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TESTS_RE = /(^|\/)(tests?|__tests__|spec)\/|\.(test|spec)\.[a-z]+$/;
+const MUTATE_TIMEOUT_MS = 10 * 60 * 1000;
+
+// EXACT unified-diff header forms — an added line whose content starts with
+// "++" produces "+++<content>" and must still COUNT (codex's catch): only
+// `+++ b/…`, `+++ /dev/null`, `--- a/…`, `--- /dev/null` are headers.
+const ADD_HEADER_RE = /^\+\+\+ (b\/|\/dev\/null)/;
+const DEL_HEADER_RE = /^--- (a\/|\/dev\/null)/;
+
+/** Pure unified-diff stats: files, additions/deletions/net, tests touched. */
+export function parseDiffStats(patch) {
+  const files = [];
+  let additions = 0;
+  let deletions = 0;
+  for (const line of String(patch || "").split("\n")) {
+    if (ADD_HEADER_RE.test(line)) {
+      if (line.startsWith("+++ b/")) files.push(line.slice(6).trim());
+    } else if (DEL_HEADER_RE.test(line)) {
+      // deletion-side header — never a counted line
+    } else if (line.startsWith("+")) additions++;
+    else if (line.startsWith("-")) deletions++;
+  }
+  const testsTouched = files.filter((f) => TESTS_RE.test(f)).length;
+  return { files, additions, deletions, net: additions - deletions, testsTouched };
+}
+
+export async function defaultMutate({ lane }) {
+  // Mutation runs IN the live worktree lane — codex's catch: guard the path
+  // explicitly so a gone/relative lane yields a DISTINCT note instead of
+  // silently degrading the ranking.
+  if (!lane || !path.isAbsolute(lane) || !fs.existsSync(lane)) {
+    return { score: null, note: "lane no longer exists — score after the fan-out, before cleaning lanes" };
+  }
+  try {
+    const res = await execFileAsync("kj", ["mutate", "--json"], { cwd: lane, timeout: MUTATE_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+    const parsed = JSON.parse(res.stdout);
+    return { score: parsed.score ?? null, killed: parsed.killed ?? null, survived: parsed.survived ?? null };
+  } catch {
+    return null; // kj unavailable / no mutants / timeout — honest n/a
+  }
+}
+
+// Sonar-per-lane needs the running-server collector; reserved as a future
+// step (see card). Injectable so TOR-C or tests can supply real findings.
+const defaultSonar = async () => null;
+
+/**
+ * Score every lane of a tournament from its artifacts.
+ * @returns {Promise<{id: string, rows: Array<object>, ranking: string[], rule: string}>}
+ */
+export async function scoreTournament({ tournamentDir, deps = {} }) {
+  const { mutateFn = defaultMutate, sonarFn = defaultSonar } = deps;
+  const summary = JSON.parse(fs.readFileSync(path.join(tournamentDir, "summary.json"), "utf8"));
+
+  const rows = [];
+  for (const lane of summary.lanes) {
+    if (lane.status !== "completed") {
+      rows.push({ coder: lane.coder, finalist: false, eliminated_by: "failed", error: lane.error || null });
+      continue;
+    }
+    const laneDir = lane.dir || path.join(tournamentDir, lane.coder);
+    const meta = JSON.parse(fs.readFileSync(path.join(laneDir, "meta.json"), "utf8"));
+    const loc = parseDiffStats(fs.readFileSync(path.join(laneDir, "diff.patch"), "utf8"));
+
+    let mutation = { score: null, note: "not available" };
+    try {
+      const m = await mutateFn({ coder: lane.coder, lane: meta.lane, laneDir });
+      if (m && typeof m.score === "number") mutation = { ...m, note: null };
+      else if (m?.note) mutation = { score: null, note: m.note };
+    } catch { /* honest n/a — never a fake zero */ }
+    const sonar = await sonarFn({ coder: lane.coder, lane: meta.lane, files: loc.files }).catch(() => null);
+
+    const suiteOk = Boolean(meta.suite?.ok);
+    rows.push({
+      coder: lane.coder,
+      finalist: suiteOk,
+      eliminated_by: suiteOk ? null : "suite",
+      suite: meta.suite,
+      loc,
+      mutation,
+      sonar,
+    });
+  }
+
+  const anyMutation = rows.some((r) => typeof r.mutation?.score === "number");
+  const rule = anyMutation
+    ? "finalistas = suite verde; orden: mutation desc SOLO entre carriles que la tienen (null jamás penaliza — codex's catch), luego LOC neto asc"
+    : "finalistas = suite verde; orden: LOC neto asc (mutation no disponible)";
+
+  const ranking = rows
+    .filter((r) => r.finalist)
+    .sort((a, b) => {
+      const ma = a.mutation?.score;
+      const mb = b.mutation?.score;
+      // Mutation only compares when BOTH lanes have a real score — a null
+      // (tool unavailable) must stay a note, never become a hidden penalty.
+      if (typeof ma === "number" && typeof mb === "number" && mb !== ma) return mb - ma;
+      return a.loc.net - b.loc.net;
+    })
+    .map((r) => r.coder);
+
+  const board = { id: summary.id, task: summary.task, rule, ranking, rows, scored_at: new Date().toISOString() };
+  fs.writeFileSync(path.join(tournamentDir, "scoreboard.json"), JSON.stringify(board, null, 2));
+  return board;
+}

--- a/tests/tournament/scoreboard.test.js
+++ b/tests/tournament/scoreboard.test.js
@@ -1,0 +1,146 @@
+// KJC-TSK-0724 TOR-B — the deterministic scoreboard: pure metrics from the
+// artifacts TOR-A leaves behind, injectable external metrics with HONEST
+// degradation (n/a, never fake numbers), red suites eliminated, and a
+// declared lexicographic ranking — no opaque composite scores. Zero LLM.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { scoreTournament, parseDiffStats, defaultMutate } from "../../src/tournament/scoreboard.js";
+
+const DIFF_TWO_FILES = [
+  "diff --git a/src/a.js b/src/a.js",
+  "+++ b/src/a.js",
+  "+line one",
+  "+line two",
+  "-old line",
+  "diff --git a/tests/a.test.js b/tests/a.test.js",
+  "+++ b/tests/a.test.js",
+  "+assert something",
+  "",
+].join("\n");
+
+let dir, torDir;
+const mkLane = (coder, { suiteOk = true, diff = DIFF_TWO_FILES, status = "completed" } = {}) => {
+  const laneDir = path.join(torDir, coder);
+  fs.mkdirSync(laneDir, { recursive: true });
+  fs.writeFileSync(path.join(laneDir, "diff.patch"), diff);
+  fs.writeFileSync(
+    path.join(laneDir, "meta.json"),
+    JSON.stringify({ coder, branch: `tor/x-${coder}`, lane: `/lanes/${coder}`, suite: { ok: suiteOk, exitCode: suiteOk ? 0 : 1 } }),
+  );
+  return { coder, status, dir: laneDir, lane: `/lanes/${coder}`, suite: { ok: suiteOk } };
+};
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-torb-"));
+  torDir = path.join(dir, ".kj", "tournaments", "tor-x");
+  fs.mkdirSync(torDir, { recursive: true });
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const writeSummary = (lanes) =>
+  fs.writeFileSync(path.join(torDir, "summary.json"), JSON.stringify({ id: "tor-x", task: "t", lanes }));
+
+describe("parseDiffStats", () => {
+  it("counts additions, deletions, files and tests touched from a unified diff", () => {
+    const stats = parseDiffStats(DIFF_TWO_FILES);
+    expect(stats.files).toEqual(["src/a.js", "tests/a.test.js"]);
+    expect(stats.additions).toBe(3);
+    expect(stats.deletions).toBe(1);
+    expect(stats.net).toBe(2);
+    expect(stats.testsTouched).toBe(1);
+  });
+  it("counts added/deleted lines whose CONTENT starts with ++ or -- (only exact headers are excluded)", () => {
+    const tricky = [
+      "diff --git a/src/inc.js b/src/inc.js",
+      "--- a/src/inc.js",
+      "+++ b/src/inc.js",
+      "+++counter;", // added line with content "++counter;"
+      "---counter;", // deleted line with content "--counter;"
+      "+normal",
+      "--- /dev/null", // deletion header of a new file — not a count
+      "+++ /dev/null", // addition header of a deleted file — not a count
+    ].join("\n");
+    const stats = parseDiffStats(tricky);
+    expect(stats.additions).toBe(2);
+    expect(stats.deletions).toBe(1);
+    expect(stats.files).toEqual(["src/inc.js"]);
+  });
+
+  it("handles an empty diff as zeroes", () => {
+    expect(parseDiffStats("")).toMatchObject({ files: [], additions: 0, deletions: 0, net: 0, testsTouched: 0 });
+  });
+});
+
+describe("defaultMutate lane guard", () => {
+  it("a gone or relative lane yields a DISTINCT note, never a silent degradation", async () => {
+    for (const lane of ["/does/not/exist", "relative/path", null]) {
+      const res = await defaultMutate({ lane });
+      expect(res.score).toBeNull();
+      expect(res.note).toMatch(/lane/i);
+    }
+  });
+});
+
+describe("scoreTournament", () => {
+  it("scores completed lanes, eliminates red suites from finalists, and persists scoreboard.json", async () => {
+    writeSummary([mkLane("claude"), mkLane("codex", { suiteOk: false }), { coder: "agy", status: "failed", error: "boom" }]);
+    const board = await scoreTournament({
+      tournamentDir: torDir,
+      deps: { mutateFn: async () => ({ score: 80, killed: 8, survived: 2 }), sonarFn: async () => null },
+    });
+    const claude = board.rows.find((r) => r.coder === "claude");
+    const codex = board.rows.find((r) => r.coder === "codex");
+    const agy = board.rows.find((r) => r.coder === "agy");
+    expect(claude.finalist).toBe(true);
+    expect(claude.mutation.score).toBe(80);
+    expect(claude.loc.net).toBe(2);
+    expect(codex.finalist).toBe(false);
+    expect(codex.eliminated_by).toBe("suite");
+    expect(agy.finalist).toBe(false);
+    expect(agy.eliminated_by).toBe("failed");
+    expect(board.ranking[0]).toBe("claude");
+    expect(JSON.parse(fs.readFileSync(path.join(torDir, "scoreboard.json"), "utf8")).rows).toHaveLength(3);
+  });
+
+  it("ranks finalists by declared rule: mutation desc, then net LOC asc — and states the rule", async () => {
+    writeSummary([mkLane("claude"), mkLane("codex"), mkLane("agy")]);
+    const mutation = { claude: { score: 60 }, codex: { score: 90 }, agy: { score: 90 } };
+    const diffs = { agy: DIFF_TWO_FILES, codex: `${DIFF_TWO_FILES}\n+++ b/src/extra.js\n+x\n+y\n+z\n` };
+    for (const [coder, d] of Object.entries(diffs)) fs.writeFileSync(path.join(torDir, coder, "diff.patch"), d);
+    const board = await scoreTournament({
+      tournamentDir: torDir,
+      deps: { mutateFn: async ({ coder }) => mutation[coder], sonarFn: async () => null },
+    });
+    // codex y agy empatan en mutation (90); agy gana por menos LOC neto
+    expect(board.ranking).toEqual(["agy", "codex", "claude"]);
+    expect(board.rule).toMatch(/mutation/i);
+  });
+
+  it("a null mutation is never a hidden penalty: partial availability falls back to LOC between those pairs", async () => {
+    writeSummary([mkLane("claude"), mkLane("codex")]);
+    // codex tiene score real 50; claude no tiene mutation pero MENOS LOC
+    fs.writeFileSync(path.join(torDir, "codex", "diff.patch"), `${DIFF_TWO_FILES}\n+++ b/src/extra.js\n+a\n+b\n+c\n+d\n`);
+    const board = await scoreTournament({
+      tournamentDir: torDir,
+      deps: { mutateFn: async ({ coder }) => (coder === "codex" ? { score: 50 } : null), sonarFn: async () => null },
+    });
+    // con -1 implícito claude habría quedado último; con la regla honesta gana por LOC
+    expect(board.ranking).toEqual(["claude", "codex"]);
+  });
+
+  it("degrades honestly: unavailable mutation/sonar become null with a note, never zeros", async () => {
+    writeSummary([mkLane("claude")]);
+    const board = await scoreTournament({
+      tournamentDir: torDir,
+      deps: { mutateFn: async () => { throw new Error("mutate not available"); }, sonarFn: async () => null },
+    });
+    const row = board.rows[0];
+    expect(row.mutation.score).toBeNull();
+    expect(row.mutation.note).toMatch(/available|disponible/i);
+    expect(row.sonar).toBeNull();
+    expect(board.rule).toMatch(/LOC/);
+  });
+});


### PR DESCRIPTION
## Qué
PR1 de TOR-B: `src/tournament/scoreboard.js` — el scoreboard determinista (cero LLM) sobre los artefactos de TOR-A. Métricas puras de fichero: veredicto de suite (roja = **eliminado**, jamás finalista), LOC neto y tests tocados vía `parseDiffStats` (parser de cabeceras EXACTAS); métricas externas inyectables con **degradación honesta**: mutation vía `kj mutate --json` en el carril vivo (guard explícito de carril desaparecido con nota distinta) y sonar reservado. **Regla de ranking lexicográfica y DECLARADA en la salida** — nada de scores compuestos con pesos opacos: mutation desc solo entre carriles que la tienen (un null jamás penaliza), luego LOC asc. `scoreboard.json` persistido (contrato estable para la telemetría de Model Routing).

## Review — codex en modo francotirador (3 rechazos, los 3 incorporados)
1. Guard del carril en `defaultMutate` (fallo silencioso → nota distinta).
2. El `?? -1` convertía el null honesto en **penalización oculta** del ranking — mutation solo compara cuando ambos la tienen, con test del caso parcial.
3. `parseDiffStats` trataba como cabecera una línea añadida cuyo contenido empieza por `++` — cabeceras exactas (`+++ b/`, `/dev/null`) con test de los casos retorcidos.

## Smoke real
Sobre el torneo vivo de TOR-A: *claude FINALISTA (8 LOC, 1 test) · codex eliminado(suite) · regla: LOC asc (mutation no disponible)* — el ranking correcto con la precisión declarada, no fingida.

Suite completa 6493/6493 exit 0 · APPROVED por codex (diff 076c597bb2b4).
PR2: `kj tournament --score <id>` + salida humana.
Card: KJC-TSK-0724 (In Progress)