### PR TITLE
feat(tournament): --score command — the board on demand (KJC-TSK-0724)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -206,8 +206,14 @@ export function registerPipeline(program, { pkgVersion }) {
     .argument("[task]", "Task description (REQUIRED — provide as argument or via --task-file)")
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--coders <csv>", "Comma-separated coder agents (minimum 2), e.g. claude,codex,agy")
+    .option("--score <id>", "Score an EXISTING tournament from its artifacts (deterministic, zero LLM)")
+    .option("--json", "With --score: emit the stable scoreboard JSON")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "tournament", flags, async ({ config, logger }) => {
+        if (flags.score) {
+          await tournamentCommand({ task: "", config, logger, flags });
+          return;
+        }
         const resolvedTask = await resolveTaskInput({ task, taskFile: flags.taskFile, projectDir: config.projectDir, logger });
         await tournamentCommand({ task: resolvedTask, config, logger, flags });
       });

--- a/src/commands/tournament.js
+++ b/src/commands/tournament.js
@@ -4,9 +4,41 @@
  * scoreboard (TOR-B) and the governed judgement/merge (TOR-C) build on the
  * artifacts this command leaves under .kj/tournaments/<id>/.
  */
+import path from "node:path";
 import { runTournament } from "../tournament/run.js";
+import { scoreTournament } from "../tournament/scoreboard.js";
 
-export async function tournamentCommand({ task, config, logger = console, flags = {}, runTournamentFn = runTournament }) {
+export async function tournamentCommand({
+  task, config, logger = console, flags = {},
+  runTournamentFn = runTournament, scoreTournamentFn = scoreTournament,
+}) {
+  // TOR-B: `--score <id>` scores an EXISTING tournament from its artifacts.
+  if (flags.score) {
+    // The id feeds a path — same traversal class codex caught in TOR-A's
+    // coder names: strict slug, no separators, before any filesystem use.
+    const id = String(flags.score);
+    if (!/^[a-z0-9][a-z0-9-]{0,63}$/i.test(id)) {
+      throw new Error(`tournament: id inválido "${id}" — usa el id que imprimió el torneo (p. ej. tor-abc123)`);
+    }
+    const tournamentDir = path.join(config?.projectDir || process.cwd(), ".kj", "tournaments", id);
+    const board = await scoreTournamentFn({ tournamentDir });
+    if (flags.json) {
+      logger?.info?.(JSON.stringify(board));
+      return board;
+    }
+    logger?.info?.(`scoreboard ${board.id} — regla: ${board.rule}`);
+    for (const r of board.rows) {
+      if (!r.finalist) {
+        logger?.info?.(`  ${r.coder.padEnd(10)} eliminado (${r.eliminated_by})`);
+        continue;
+      }
+      const mut = typeof r.mutation?.score === "number" ? `${r.mutation.score}%` : "n/a";
+      logger?.info?.(`  ${r.coder.padEnd(10)} FINALISTA  loc:${String(r.loc.net).padStart(5)}  tests:${r.loc.testsTouched}  mutation:${mut}`);
+    }
+    logger?.info?.(`  ranking: ${board.ranking.join(" > ") || "(sin finalistas)"}`);
+    return board;
+  }
+
   if (!task || !String(task).trim()) {
     throw new Error("tournament: falta la tarea — kj tournament \"<tarea>\" --coders claude,codex");
   }

--- a/tests/tournament/cli.test.js
+++ b/tests/tournament/cli.test.js
@@ -38,6 +38,51 @@ describe("tournamentCommand", () => {
     ).rejects.toThrow(/2/);
   });
 
+  it("--score <id> scores an existing tournament and prints rule, ranking and per-lane rows", async () => {
+    const log = logger();
+    const res = await tournamentCommand({
+      task: "",
+      config: { projectDir: "/p" },
+      logger: log,
+      flags: { score: "tor-x", json: false },
+      scoreTournamentFn: async ({ tournamentDir }) => {
+        expect(tournamentDir).toBe("/p/.kj/tournaments/tor-x");
+        return {
+          id: "tor-x",
+          rule: "finalistas = suite verde; orden: LOC neto asc",
+          ranking: ["claude"],
+          rows: [
+            { coder: "claude", finalist: true, suite: { ok: true }, loc: { net: 8, testsTouched: 1 }, mutation: { score: null, note: "not available" }, sonar: null },
+            { coder: "codex", finalist: false, eliminated_by: "suite" },
+          ],
+        };
+      },
+    });
+    expect(res.ranking).toEqual(["claude"]);
+    const out = log.lines.join("\n");
+    expect(out).toMatch(/regla|rule/i);
+    expect(out).toMatch(/claude/);
+    expect(out).toMatch(/eliminado|eliminated/i);
+  });
+
+  it("--score rejects ids that could traverse paths", async () => {
+    for (const evil of ["../../..", "a/b", ".oculto"]) {
+      await expect(
+        tournamentCommand({ task: "", config: {}, logger: logger(), flags: { score: evil }, scoreTournamentFn: async () => ({}) }),
+      ).rejects.toThrow(/inválido|invalid/i);
+    }
+  });
+
+  it("--score --json emits the stable board as JSON on the logger", async () => {
+    const log = logger();
+    await tournamentCommand({
+      task: "", config: { projectDir: "/p" }, logger: log,
+      flags: { score: "tor-x", json: true },
+      scoreTournamentFn: async () => ({ id: "tor-x", rule: "r", ranking: [], rows: [] }),
+    });
+    expect(() => JSON.parse(log.lines.at(-1))).not.toThrow();
+  });
+
   it("fails actionably without a task", async () => {
     await expect(
       tournamentCommand({ task: "", config: {}, logger: logger(), flags: { coders: "a,b" }, runTournamentFn: async () => ({}) }),


### PR DESCRIPTION
## Qué
PR2 y cierre de TOR-B: `kj tournament --score <id>` puntúa un torneo EXISTENTE desde sus artefactos — tabla humana (regla declarada, finalistas con loc/tests/mutation, eliminados con causa, ranking) y `--json` estable para telemetría. Id validado con slug estricto antes de tocar el filesystem (misma clase de traversal que codex cazó en TOR-A — esta vez el catch fue en review, incorporado con test).

## Smoke real
`kj tournament --score tor-mska1po4` sobre el torneo vivo: *claude FINALISTA loc:8 tests:1 mutation:n/a · codex eliminado (suite) · ranking: claude* — regla impresa sin fingir precisión.

Suite completa 6496/6496 exit 0 · APPROVED por codex (diff 3a04369066c7) tras 1 rechazo legítimo.
Card: KJC-TSK-0724 → To Validate al merge · TOR-C (juicio + merge gobernado) desbloqueada