### PR TITLE
feat(tournament): the judge — cross-ai ranking, solomon on dispute (KJC-TSK-0725)

### DIFF
--- a/src/tournament/judge.js
+++ b/src/tournament/judge.js
@@ -1,0 +1,151 @@
+/**
+ * tournament/judge — TOR-C (KJC-TSK-0725, epic KJC-PCS-0073).
+ *
+ * The scoreboard (TOR-B) ELIMINATES; the judge CHOOSES among survivors —
+ * a cross-AI reviewer ranking the finalists with the deterministic table
+ * in sight, so the LLM judges what metrics cannot see (design, readability,
+ * over-engineering) without overruling what they can. Two hard rules:
+ * a participant coder never judges its own tournament (nor does the host),
+ * and a WINNER disagreement with the scoreboard — or a declared tie —
+ * escalates to solomon carrying BOTH positions. Only first place crowns:
+ * lower-order differences are informative and never escalate (the card's
+ * "discrepancia fuerte" — over-escalating would make solomon the judge). Diffs travel WHOLE or the limit is
+ * DECLARED in the prompt (the [TRUNCATED]-blamed-on-the-file lesson,
+ * BUG-0134): the judge must never mistake our clipping for the coder's code.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createAgent } from "../agents/index.js";
+import { resolveRole } from "../config/role-resolver.js";
+import { detectHostAgent } from "../utils/agent-detect.js";
+import { candidateStatus } from "../review/reviewer-fallback.js";
+
+const MAX_DIFF_CHARS = 60_000;
+
+/** The configured reviewer unless it competed or hosts; else the first clean candidate. */
+export function pickJudge({ configured, participants = [], host = null, statuses = [] }) {
+  const dirty = new Set([...participants, host].filter(Boolean));
+  if (configured && !dirty.has(configured)) return configured;
+  const clean = statuses.find((s) => s.installed && s.authenticated && !s.adapterPending && !dirty.has(s.name));
+  return clean ? clean.name : null;
+}
+
+async function defaultJudge({ config, participants }) {
+  const configured = resolveRole(config, "reviewer").provider;
+  const statuses = await candidateStatus();
+  return pickJudge({ configured, participants, host: detectHostAgent(), statuses });
+}
+
+async function defaultAgent({ judge, prompt, config, logger }) {
+  return createAgent(judge, config, logger).reviewTask({ prompt, role: "reviewer" });
+}
+
+function finalistBlock(board, torDir, coder) {
+  const row = board.rows.find((r) => r.coder === coder);
+  let diff = fs.readFileSync(path.join(torDir, coder, "diff.patch"), "utf8");
+  let clipped = false;
+  if (diff.length > MAX_DIFF_CHARS) {
+    diff = diff.slice(0, MAX_DIFF_CHARS);
+    clipped = true;
+  }
+  return [
+    `### Finalista: ${coder}`,
+    `Scoreboard: ${JSON.stringify(row)}`,
+    clipped
+      ? `NOTA DEL SISTEMA: el diff se muestra RECORTADO a ${MAX_DIFF_CHARS} caracteres por límite del prompt — el recorte es NUESTRO, no un defecto del código; júzgalo por lo visible y dilo en tus razones.`
+      : "",
+    "```diff", diff, "```",
+  ].filter(Boolean).join("\n");
+}
+
+/**
+ * Judge a scored tournament: rank finalists, escalate on tie/disagreement.
+ * @returns {Promise<{winner: string, judge: string|null, escalated: boolean, walkover?: boolean}>}
+ */
+export async function judgeTournament({ tournamentDir, config = {}, logger = console, deps = {} }) {
+  const { judgeFn = defaultJudge, agentFn = defaultAgent, solomonFn = null } = deps;
+  const board = JSON.parse(fs.readFileSync(path.join(tournamentDir, "scoreboard.json"), "utf8"));
+  const finalists = board.rows.filter((r) => r.finalist).map((r) => r.coder);
+  const participants = board.rows.map((r) => r.coder);
+
+  if (finalists.length === 0) throw new Error("tournament: sin finalistas (todas las suites rojas) — no hay nada que juzgar");
+  if (finalists.length === 1) {
+    const judgement = { winner: finalists[0], judge: null, escalated: false, walkover: true, board_ranking: board.ranking };
+    fs.writeFileSync(path.join(tournamentDir, "judgement.json"), JSON.stringify(judgement, null, 2));
+    logger?.info?.(`torneo ${board.id}: ganador por walkover — ${finalists[0]} (único finalista)`);
+    return judgement;
+  }
+
+  const judge = await judgeFn({ config, participants });
+  if (!judge) {
+    throw new Error(
+      "tournament: sin juez limpio — todos los agentes disponibles compitieron o son el host. " +
+      "Un participante jamás juzga su propio torneo: quita un coder o añade un agente."
+    );
+  }
+
+  const prompt = [
+    "Eres el JUEZ de un torneo de código: varios coders resolvieron la MISMA tarea de forma independiente.",
+    "La fase determinista ya eliminó a los que suspendieron la suite. Tu trabajo: ordenar a los finalistas",
+    "por calidad de solución (diseño, legibilidad, ausencia de sobre-ingeniería), con el scoreboard a la vista.",
+    `Regla del scoreboard: ${board.rule}`,
+    `Ranking del scoreboard: ${board.ranking.join(" > ")}`,
+    `TAREA ORIGINAL:\n${board.task}`,
+    ...finalists.map((c) => finalistBlock(board, tournamentDir, c)),
+    'Responde SOLO con JSON: {"ranking": ["coder", ...], "reasons": {"coder": "por qué"}, "tie": false}',
+    "Declara tie:true únicamente si de verdad no puedes distinguirlos.",
+  ].join("\n\n");
+
+  logger?.info?.(`torneo ${board.id}: juez=${judge} sobre ${finalists.length} finalistas`);
+  const res = await agentFn({ judge, prompt, config, logger });
+  if (!res?.ok) throw new Error(`tournament: el juez ${judge} falló: ${res?.error || "sin salida"}`);
+  let verdict;
+  try {
+    verdict = JSON.parse(String(res.output).replace(/^[^{]*/, "").replace(/[^}]*$/, ""));
+  } catch {
+    throw new Error(`tournament: el juez ${judge} no devolvió un veredicto parseable`);
+  }
+  // An LLM verdict is untrusted input: the ranking must name FINALISTS and
+  // nobody else — a hallucinated coder must fail loud, never get crowned.
+  const isFinalist = (c) => finalists.includes(c);
+  if (!Array.isArray(verdict.ranking) || verdict.ranking.length === 0 || !verdict.ranking.every(isFinalist)) {
+    throw new Error(`tournament: ranking del juez inválido (${JSON.stringify(verdict.ranking)}) — debe nombrar solo finalistas: ${finalists.join(", ")}`);
+  }
+
+  // Only FIRST place crowns a winner: a judge that reorders lower positions
+  // but agrees on who wins is agreement, not a dispute for solomon.
+  const judgeTop = verdict.ranking?.[0];
+  const boardTop = board.ranking[0];
+  const disagreement = judgeTop !== boardTop;
+  const escalated = Boolean(verdict.tie || disagreement);
+
+  let winner = judgeTop;
+  let solomon = null;
+  if (escalated) {
+    if (!solomonFn) {
+      throw new Error(
+        `tournament: ${verdict.tie ? "empate declarado" : `discrepancia juez(${judgeTop}) vs scoreboard(${boardTop})`} y sin árbitro configurado`
+      );
+    }
+    solomon = await solomonFn({
+      judgeRanking: verdict.ranking,
+      boardRanking: board.ranking,
+      reasons: verdict.reasons,
+      tie: Boolean(verdict.tie),
+    });
+    if (!isFinalist(solomon?.winner)) {
+      throw new Error(`tournament: solomon devolvió un ganador inválido (${solomon?.winner}) — debe ser finalista`);
+    }
+    winner = solomon.winner;
+  }
+
+  const judgement = {
+    winner, judge, escalated,
+    judge_ranking: verdict.ranking, judge_reasons: verdict.reasons || {},
+    board_ranking: board.ranking, solomon,
+    judged_at: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(tournamentDir, "judgement.json"), JSON.stringify(judgement, null, 2));
+  logger?.info?.(`torneo ${board.id}: ganador=${winner}${escalated ? " (vía solomon)" : " (juez y scoreboard de acuerdo)"}`);
+  return judgement;
+}

--- a/tests/tournament/judge.test.js
+++ b/tests/tournament/judge.test.js
@@ -1,0 +1,133 @@
+// KJC-TSK-0725 TOR-C — the judge: a cross-AI reviewer that RANKS the
+// finalists with the scoreboard in sight. The deterministic phase (TOR-B)
+// eliminates; the judge chooses among survivors. Conflict-of-interest rule:
+// a participant coder can never judge its own tournament, and neither can
+// the host. Disagreement with the scoreboard, or a declared tie, escalates
+// to solomon WITH both positions. Full DI.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { judgeTournament, pickJudge } from "../../src/tournament/judge.js";
+
+let dir, torDir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-torc-"));
+  torDir = path.join(dir, ".kj", "tournaments", "tor-x");
+  fs.mkdirSync(torDir, { recursive: true });
+  for (const coder of ["claude", "codex"]) {
+    fs.mkdirSync(path.join(torDir, coder), { recursive: true });
+    fs.writeFileSync(path.join(torDir, coder, "diff.patch"), `diff for ${coder}\n+x\n`);
+  }
+  fs.writeFileSync(
+    path.join(torDir, "scoreboard.json"),
+    JSON.stringify({
+      id: "tor-x", task: "build it",
+      rule: "finalistas = suite verde; orden: LOC neto asc",
+      ranking: ["claude", "codex"],
+      rows: [
+        { coder: "claude", finalist: true, loc: { net: 8, testsTouched: 1 }, mutation: { score: null } },
+        { coder: "codex", finalist: true, loc: { net: 12, testsTouched: 1 }, mutation: { score: null } },
+      ],
+    }),
+  );
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const judgeReply = (ranking, tie = false) => ({
+  ok: true,
+  output: JSON.stringify({ ranking, reasons: { [ranking[0]]: "cleaner" }, tie }),
+});
+
+describe("pickJudge — no conflict of interest", () => {
+  const statuses = [
+    { name: "codex", installed: true, authenticated: true },
+    { name: "copilot", installed: true, authenticated: true },
+    { name: "agy", installed: true, authenticated: true },
+  ];
+  it("keeps the configured reviewer when it did not compete and is not the host", () => {
+    expect(pickJudge({ configured: "agy", participants: ["claude", "codex"], host: "claude", statuses })).toBe("agy");
+  });
+  it("a participant can never judge its own tournament — next clean candidate wins", () => {
+    expect(pickJudge({ configured: "codex", participants: ["claude", "codex"], host: "claude", statuses })).toBe("copilot");
+  });
+  it("returns null when every candidate competed or is the host", () => {
+    expect(pickJudge({ configured: "codex", participants: ["claude", "codex", "copilot", "agy"], host: "claude", statuses })).toBeNull();
+  });
+});
+
+describe("judgeTournament", () => {
+  const base = (agentReply, extra = {}) => ({
+    tournamentDir: torDir,
+    config: {},
+    logger: { info: () => {}, warn: () => {} },
+    deps: {
+      judgeFn: async () => "agy",
+      agentFn: async ({ prompt }) => {
+        base.lastPrompt = prompt;
+        return agentReply;
+      },
+      solomonFn: async (args) => {
+        base.solomonArgs = args;
+        return { winner: "codex", reason: "solomon ruled" };
+      },
+      ...extra,
+    },
+  });
+
+  it("agreement: judge top matches scoreboard top — winner declared, judgement.json persisted with reasons", async () => {
+    const args = base(judgeReply(["claude", "codex"]));
+    const res = await judgeTournament(args);
+    expect(res.winner).toBe("claude");
+    expect(res.escalated).toBe(false);
+    expect(base.lastPrompt).toMatch(/scoreboard|regla/i);
+    expect(base.lastPrompt).toContain("diff for claude");
+    const saved = JSON.parse(fs.readFileSync(path.join(torDir, "judgement.json"), "utf8"));
+    expect(saved.winner).toBe("claude");
+    expect(saved.judge).toBe("agy");
+  });
+
+  it("disagreement with the scoreboard escalates to solomon WITH both positions", async () => {
+    const args = base(judgeReply(["codex", "claude"]));
+    const res = await judgeTournament(args);
+    expect(res.escalated).toBe(true);
+    expect(res.winner).toBe("codex");
+    expect(base.solomonArgs.judgeRanking).toEqual(["codex", "claude"]);
+    expect(base.solomonArgs.boardRanking).toEqual(["claude", "codex"]);
+  });
+
+  it("a declared tie escalates to solomon", async () => {
+    const args = base(judgeReply(["claude", "codex"], true));
+    const res = await judgeTournament(args);
+    expect(res.escalated).toBe(true);
+  });
+
+  it("fewer than two finalists needs no judge — the only finalist wins by walkover", async () => {
+    const board = JSON.parse(fs.readFileSync(path.join(torDir, "scoreboard.json"), "utf8"));
+    board.rows[1].finalist = false;
+    board.ranking = ["claude"];
+    fs.writeFileSync(path.join(torDir, "scoreboard.json"), JSON.stringify(board));
+    const args = base(judgeReply(["claude"]));
+    const res = await judgeTournament(args);
+    expect(res.winner).toBe("claude");
+    expect(res.walkover).toBe(true);
+  });
+
+  it("a hallucinated ranking (non-finalist names, empty, garbage) fails loud — never crowned", async () => {
+    for (const bad of [judgeReply(["gemini-imaginario"]), judgeReply([]), { ok: true, output: "not json at all" }]) {
+      await expect(judgeTournament(base(bad))).rejects.toThrow(/inválido|parseable/i);
+    }
+  });
+
+  it("a solomon winner outside the finalists fails loud too", async () => {
+    const args = base(judgeReply(["codex", "claude"]));
+    args.deps.solomonFn = async () => ({ winner: "intruso" });
+    await expect(judgeTournament(args)).rejects.toThrow(/solomon.*inválido/i);
+  });
+
+  it("no clean judge available is an actionable error, never a participant judging itself", async () => {
+    const args = base(judgeReply(["claude"]), { judgeFn: async () => null });
+    await expect(judgeTournament(args)).rejects.toThrow(/juez|judge/i);
+  });
+});


### PR DESCRIPTION
## Qué
PR1 de TOR-C: `src/tournament/judge.js` — el juez cross-AI que ELIGE entre los finalistas que el scoreboard no eliminó. Reglas duras: **un participante jamás juzga su propio torneo** (ni el host) — `pickJudge` sobre el registro de candidatos con exclusión, error accionable si no queda juez limpio; el prompt lleva la tarea + fila de scoreboard + **diff íntegro** por finalista (si excede el límite se DECLARA como recorte nuestro — lección de BUG-0134, jamás culpar al código); **solo la posición 1 corona**: discrepancia de ganador con el scoreboard o empate declarado → solomon con AMBAS posiciones; walkover con un solo finalista; **el veredicto LLM es input no confiable** — ranking validado como permutación de finalistas y ganador de solomon también (un coder alucinado falla en alto, jamás se corona). `judgement.json` persistido.

## Review — 2 rechazos incorporados + 1 alineamiento
(1) Semántica de escalada alineada: el comentario prometía 'cualquier discrepancia' — solo el ganador corona, el orden inferior es informativo ('discrepancia fuerte' de la card). (2) Validación de forma del veredicto y del ganador de solomon, con tests de alucinación.

## Nota de tamaño (revisada ANTES del merge esta vez)
284 líneas: módulo + tests inseparables (tests-con-código), crecimiento por los endurecimientos del review. Label `large-pr-justified` aplicada pre-merge por el flujo sancionado.

Suite completa 6506/6506 exit 0 · audit 0 findings · APPROVED por codex (diff 95843b7198af).
PR2: crown (merge gobernado del ganador) + flags CLI.
Card: KJC-TSK-0725 (In Progress)