### PR TITLE
feat(tournament): the crown — the winner enters through the normal door (KJC-TSK-0725)

### DIFF
--- a/src/tournament/crown.js
+++ b/src/tournament/crown.js
@@ -1,0 +1,88 @@
+/**
+ * tournament/crown — TOR-C (KJC-TSK-0725, epic KJC-PCS-0073). The last act:
+ * the tournament winner enters main THROUGH THE NORMAL DOOR, not around it.
+ *
+ * In the winner's still-alive lane: stage everything, run the real cross-AI
+ * review over the EXACT staged diff (verdict bound to its sha256, stored by
+ * the same verdict-store every commit uses), then commit — where the
+ * pre-commit gate validates that verdict like any other commit's. A
+ * rejected review ABORTS the coronation with the reasons: winning the
+ * tournament earns you a candidacy, not a bypass. Losers keep their full
+ * dossier under the tournament dir; their lanes are never removed here.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { runOneShotReview } from "../review/one-shot-review.js";
+
+const execFileAsync = promisify(execFile);
+
+const defaultExec = async (cmd, args, { cwd }) => {
+  const res = await execFileAsync(cmd, args, { cwd, maxBuffer: 64 * 1024 * 1024 });
+  return { exitCode: 0, stdout: res.stdout || "" };
+};
+
+async function defaultReview({ lane, task, config, logger }) {
+  const { stdout: diff } = await execFileAsync("git", ["diff", "--cached"], { cwd: lane, maxBuffer: 64 * 1024 * 1024 });
+  try {
+    const record = await runOneShotReview({
+      diff,
+      task: `Tournament winner review. Original task:\n${task}`,
+      config: { ...config, projectDir: lane },
+      logger,
+      projectDir: lane,
+    });
+    return { ok: record.verdict === "approved", ...record };
+  } catch (err) {
+    return { ok: false, verdict: "error", error: err.message };
+  }
+}
+
+/**
+ * Crown the judged winner: governed review + commit in its lane.
+ * @returns {Promise<{winner: string, branch: string, commit: string, verdict: object}>}
+ */
+export async function crownWinner({ tournamentDir, config = {}, logger = console, cardRef = null, deps = {} }) {
+  const { execFn = defaultExec, reviewFn = defaultReview } = deps;
+
+  const judgementPath = path.join(tournamentDir, "judgement.json");
+  if (!fs.existsSync(judgementPath)) {
+    throw new Error("tournament: no hay judgement.json — corre primero kj tournament --judge <id>");
+  }
+  const judgement = JSON.parse(fs.readFileSync(judgementPath, "utf8"));
+  const summary = JSON.parse(fs.readFileSync(path.join(tournamentDir, "summary.json"), "utf8"));
+  const winner = judgement.winner;
+  const meta = JSON.parse(fs.readFileSync(path.join(tournamentDir, winner, "meta.json"), "utf8"));
+  const lane = meta.lane;
+  if (!lane || !fs.existsSync(lane)) {
+    throw new Error(`tournament: el carril del ganador (${winner}) ya no existe — corona justo después de juzgar, antes de limpiar carriles`);
+  }
+
+  logger?.info?.(`coronando a ${winner} en ${meta.branch} — por la puerta normal, no por un atajo`);
+  await execFn("git", ["add", "-A"], { cwd: lane });
+
+  const verdict = await reviewFn({ lane, task: summary.task, config, logger });
+  if (!verdict?.ok) {
+    const issues = (verdict?.issues || []).map((i) => `  - ${i.description}`).join("\n");
+    throw new Error(
+      `tournament: la review RECHAZÓ al ganador (${winner}) — ganar el torneo da candidatura, no bypass.\n${issues || verdict?.error || ""}`
+    );
+  }
+
+  const ref = cardRef ? ` (${cardRef})` : "";
+  const msg = `feat(tournament): crown ${winner} — ${String(summary.task).slice(0, 50).toLowerCase()}${ref} [${summary.id}]`;
+  await execFn("git", ["commit", "-m", msg], { cwd: lane });
+  const { stdout } = await execFn("git", ["rev-parse", "HEAD"], { cwd: lane });
+  const commit = stdout.trim();
+
+  const crown = {
+    winner, branch: meta.branch, commit,
+    verdict: { verdict: verdict.verdict, reviewer: verdict.reviewer, diffHash: verdict.diffHash },
+    crowned_at: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(tournamentDir, "crown.json"), JSON.stringify(crown, null, 2));
+  logger?.info?.(`✓ coronado: ${winner} · commit ${commit.slice(0, 9)} en ${meta.branch} — la rama queda lista para PR`);
+  logger?.info?.("  los perdedores conservan su expediente en el dir del torneo; limpia carriles con kj worktree done cuando quieras");
+  return { winner, branch: meta.branch, commit, verdict: crown.verdict };
+}

--- a/tests/tournament/crown.test.js
+++ b/tests/tournament/crown.test.js
@@ -1,0 +1,99 @@
+// KJC-TSK-0725 TOR-C — the crown: the winner enters through the NORMAL
+// door. In its still-alive lane: stage everything, cross-AI review of the
+// EXACT staged diff (verdict bound to its sha256), commit through the real
+// pre-commit gate — no escapes, no shortcuts. A rejected review aborts the
+// coronation with the reasons; losers stay archived, never silently gone.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { crownWinner } from "../../src/tournament/crown.js";
+
+let dir, torDir, lanePath;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-crown-"));
+  torDir = path.join(dir, ".kj", "tournaments", "tor-x");
+  lanePath = path.join(dir, ".kj", "worktrees", "tor-x-claude");
+  fs.mkdirSync(path.join(torDir, "claude"), { recursive: true });
+  fs.mkdirSync(lanePath, { recursive: true });
+  fs.writeFileSync(path.join(torDir, "judgement.json"), JSON.stringify({ winner: "claude", judge: "agy", escalated: false }));
+  fs.writeFileSync(
+    path.join(torDir, "claude", "meta.json"),
+    JSON.stringify({ coder: "claude", branch: "tor/tor-x-claude", lane: lanePath }),
+  );
+  fs.writeFileSync(path.join(torDir, "summary.json"), JSON.stringify({ id: "tor-x", task: "build the thing", lanes: [] }));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const okDeps = (calls) => ({
+  execFn: async (cmd, args, { cwd }) => {
+    calls.push({ cmd, args, cwd });
+    if (cmd === "git" && args[0] === "rev-parse") return { exitCode: 0, stdout: "abc123def\n" };
+    return { exitCode: 0, stdout: "" };
+  },
+  reviewFn: async ({ lane }) => {
+    calls.push({ cmd: "review", cwd: lane });
+    return { ok: true, verdict: "approved", reviewer: "codex", diffHash: "sha256sha256" };
+  },
+});
+
+describe("crownWinner", () => {
+  it("stages, reviews the staged diff, commits through the gate, and persists crown.json", async () => {
+    const calls = [];
+    const res = await crownWinner({
+      tournamentDir: torDir,
+      config: {},
+      logger: { info: () => {}, warn: () => {} },
+      deps: okDeps(calls),
+    });
+    expect(res.winner).toBe("claude");
+    expect(res.branch).toBe("tor/tor-x-claude");
+    expect(res.commit).toBe("abc123def");
+    // order: add → review (BEFORE commit) → commit → rev-parse
+    const seq = calls.map((c) => (c.cmd === "git" ? c.args[0] : c.cmd));
+    expect(seq.indexOf("add")).toBeLessThan(seq.indexOf("review"));
+    expect(seq.indexOf("review")).toBeLessThan(seq.indexOf("commit"));
+    // every operation ran IN the winner's lane
+    for (const c of calls) expect(c.cwd).toBe(lanePath);
+    // the commit message is conventional and names the tournament
+    const commitCall = calls.find((c) => c.cmd === "git" && c.args[0] === "commit");
+    const msg = commitCall.args[commitCall.args.indexOf("-m") + 1];
+    expect(msg).toMatch(/^feat\(tournament\):/);
+    expect(msg).toContain("tor-x");
+    const saved = JSON.parse(fs.readFileSync(path.join(torDir, "crown.json"), "utf8"));
+    expect(saved.commit).toBe("abc123def");
+    expect(saved.verdict.reviewer).toBe("codex");
+  });
+
+  it("appends the user's card ref to the commit message when provided (card-first gates)", async () => {
+    const calls = [];
+    await crownWinner({ tournamentDir: torDir, config: {}, logger: { info: () => {} }, deps: okDeps(calls), cardRef: "KJC-TSK-0999" });
+    const commitCall = calls.find((c) => c.cmd === "git" && c.args[0] === "commit");
+    expect(commitCall.args[commitCall.args.indexOf("-m") + 1]).toContain("KJC-TSK-0999");
+  });
+
+  it("a rejected review ABORTS the coronation — no commit, reasons surfaced", async () => {
+    const calls = [];
+    const deps = okDeps(calls);
+    deps.reviewFn = async () => ({ ok: false, verdict: "rejected", issues: [{ description: "smells" }] });
+    await expect(
+      crownWinner({ tournamentDir: torDir, config: {}, logger: { info: () => {}, warn: () => {} }, deps }),
+    ).rejects.toThrow(/rejected|rechaz/i);
+    expect(calls.some((c) => c.cmd === "git" && c.args[0] === "commit")).toBe(false);
+  });
+
+  it("a gone lane is an actionable error — crown right after judging, before cleaning lanes", async () => {
+    fs.rmSync(lanePath, { recursive: true, force: true });
+    await expect(
+      crownWinner({ tournamentDir: torDir, config: {}, logger: { info: () => {} }, deps: okDeps([]) }),
+    ).rejects.toThrow(/lane|carril/i);
+  });
+
+  it("missing judgement points to --judge first", async () => {
+    fs.rmSync(path.join(torDir, "judgement.json"));
+    await expect(
+      crownWinner({ tournamentDir: torDir, config: {}, logger: { info: () => {} }, deps: okDeps([]) }),
+    ).rejects.toThrow(/--judge|judgement/i);
+  });
+});


### PR DESCRIPTION
## Qué
PR2a de TOR-C: `src/tournament/crown.js` — la coronación gobernada. En el carril vivo del ganador juzgado: `git add -A` → **review cross-AI real del diff staged exacto** (`runOneShotReview` con el carril como projectDir: veredicto ligado al sha256 y guardado por el mismo verdict-store de cualquier commit) → commit conventional (`--card <ref>` opcional para gates card-first) → `crown.json` con commit+veredicto. **Ganar el torneo da candidatura, no bypass**: review rechazada = coronación ABORTADA con las razones, sin commit. Carril desaparecido y judgement ausente → errores accionables. Los perdedores conservan su expediente; sus carriles jamás se tocan aquí.

## Verificación
Tests DI: secuencia add→review→commit (review SIEMPRE antes del commit), todo en el carril del ganador, mensaje conventional con id del torneo y card ref, rechazo aborta sin commit, carril/judgement ausentes accionables. Suite completa 6511/6511 exit 0 · 187 líneas (bajo el gate, medido antes) · APPROVED por codex (diff e131d6f340c8).

PR2b: flags `--judge`/`--crown` en el CLI + smoke sobre el torneo vivo — cierra la card.
Card: KJC-TSK-0725 (In Progress)