### PR TITLE
feat(tournament): judge and crown flags — the full cycle in the cli (KJC-TSK-0725)

### DIFF
--- a/src/cli/register-pipeline.js
+++ b/src/cli/register-pipeline.js
@@ -207,10 +207,13 @@ export function registerPipeline(program, { pkgVersion }) {
     .option("--task-file <path>", "Read the task from a file (e.g. .md)")
     .option("--coders <csv>", "Comma-separated coder agents (minimum 2), e.g. claude,codex,agy")
     .option("--score <id>", "Score an EXISTING tournament from its artifacts (deterministic, zero LLM)")
-    .option("--json", "With --score: emit the stable scoreboard JSON")
+    .option("--judge <id>", "Cross-AI judge ranks the finalists (scoreboard in sight; solomon on tie/dispute)")
+    .option("--crown <id>", "Commit the judged winner in its lane THROUGH the real review gate")
+    .option("--card <ref>", "With --crown: card reference for the commit message (card-first gates)")
+    .option("--json", "With --score/--judge/--crown: emit stable JSON")
     .action(async (task, flags) => {
       await withConfig(pkgVersion, "tournament", flags, async ({ config, logger }) => {
-        if (flags.score) {
+        if (flags.score || flags.judge || flags.crown) {
           await tournamentCommand({ task: "", config, logger, flags });
           return;
         }

--- a/src/commands/tournament.js
+++ b/src/commands/tournament.js
@@ -7,20 +7,43 @@
 import path from "node:path";
 import { runTournament } from "../tournament/run.js";
 import { scoreTournament } from "../tournament/scoreboard.js";
+import { judgeTournament } from "../tournament/judge.js";
+import { crownWinner } from "../tournament/crown.js";
+
+// The id feeds a path — same traversal class codex caught in TOR-A's coder
+// names: strict slug, no separators, before any filesystem use.
+function tournamentDirFor(config, rawId) {
+  const id = String(rawId);
+  if (!/^[a-z0-9][a-z0-9-]{0,63}$/i.test(id)) {
+    throw new Error(`tournament: id inválido "${id}" — usa el id que imprimió el torneo (p. ej. tor-abc123)`);
+  }
+  return path.join(config?.projectDir || process.cwd(), ".kj", "tournaments", id);
+}
 
 export async function tournamentCommand({
   task, config, logger = console, flags = {},
   runTournamentFn = runTournament, scoreTournamentFn = scoreTournament,
+  judgeTournamentFn = judgeTournament, crownWinnerFn = crownWinner,
 }) {
+  // TOR-C: `--judge <id>` ranks the finalists; `--crown <id>` commits the
+  // winner through the real gate in its lane.
+  if (flags.judge) {
+    const judgement = await judgeTournamentFn({ tournamentDir: tournamentDirFor(config, flags.judge), config, logger });
+    if (flags.json) logger?.info?.(JSON.stringify(judgement));
+    else logger?.info?.(`  siguiente: kj tournament --crown ${flags.judge}${judgement.escalated ? " (ganador vía solomon)" : ""}`);
+    return judgement;
+  }
+  if (flags.crown) {
+    const crown = await crownWinnerFn({
+      tournamentDir: tournamentDirFor(config, flags.crown), config, logger, cardRef: flags.card || null,
+    });
+    if (flags.json) logger?.info?.(JSON.stringify(crown));
+    return crown;
+  }
+
   // TOR-B: `--score <id>` scores an EXISTING tournament from its artifacts.
   if (flags.score) {
-    // The id feeds a path — same traversal class codex caught in TOR-A's
-    // coder names: strict slug, no separators, before any filesystem use.
-    const id = String(flags.score);
-    if (!/^[a-z0-9][a-z0-9-]{0,63}$/i.test(id)) {
-      throw new Error(`tournament: id inválido "${id}" — usa el id que imprimió el torneo (p. ej. tor-abc123)`);
-    }
-    const tournamentDir = path.join(config?.projectDir || process.cwd(), ".kj", "tournaments", id);
+    const tournamentDir = tournamentDirFor(config, flags.score);
     const board = await scoreTournamentFn({ tournamentDir });
     if (flags.json) {
       logger?.info?.(JSON.stringify(board));

--- a/tests/tournament/cli.test.js
+++ b/tests/tournament/cli.test.js
@@ -65,12 +65,41 @@ describe("tournamentCommand", () => {
     expect(out).toMatch(/eliminado|eliminated/i);
   });
 
-  it("--score rejects ids that could traverse paths", async () => {
+  it("--score/--judge/--crown reject ids that could traverse paths", async () => {
     for (const evil of ["../../..", "a/b", ".oculto"]) {
-      await expect(
-        tournamentCommand({ task: "", config: {}, logger: logger(), flags: { score: evil }, scoreTournamentFn: async () => ({}) }),
-      ).rejects.toThrow(/inválido|invalid/i);
+      for (const flag of ["score", "judge", "crown"]) {
+        await expect(
+          tournamentCommand({
+            task: "", config: {}, logger: logger(), flags: { [flag]: evil },
+            scoreTournamentFn: async () => ({}), judgeTournamentFn: async () => ({}), crownWinnerFn: async () => ({}),
+          }),
+        ).rejects.toThrow(/inválido|invalid/i);
+      }
     }
+  });
+
+  it("--judge wires the tournament dir and prints the crown hint; --crown forwards the card ref", async () => {
+    const log = logger();
+    const judgement = await tournamentCommand({
+      task: "", config: { projectDir: "/p" }, logger: log, flags: { judge: "tor-x" },
+      judgeTournamentFn: async ({ tournamentDir }) => {
+        expect(tournamentDir).toBe("/p/.kj/tournaments/tor-x");
+        return { winner: "claude", escalated: false };
+      },
+    });
+    expect(judgement.winner).toBe("claude");
+    expect(log.lines.join("\n")).toMatch(/--crown tor-x/);
+
+    let seen = null;
+    await tournamentCommand({
+      task: "", config: { projectDir: "/p" }, logger: logger(), flags: { crown: "tor-x", card: "KJC-TSK-0999" },
+      crownWinnerFn: async (args) => {
+        seen = args;
+        return { winner: "claude", commit: "abc" };
+      },
+    });
+    expect(seen.cardRef).toBe("KJC-TSK-0999");
+    expect(seen.tournamentDir).toBe("/p/.kj/tournaments/tor-x");
   });
 
   it("--score --json emits the stable board as JSON on the logger", async () => {


### PR DESCRIPTION
## Qué
PR2b y CIERRE de TOR-C (y de la épica KJC-PCS-0073): `kj tournament --judge <id>` y `--crown <id> [--card <ref>]` — ids validados por el helper anti-traversal compartido, `--json` estable, y el hint del siguiente paso en cada fase. El ciclo completo queda en el CLI: **`kj tournament` → `--score` → `--judge` → `--crown`**.

## El ciclo completo, ejecutado EN VIVO
Sobre el torneo real: juicio (walkover — claude único finalista tras la eliminación del scoreboard) y coronación de verdad: stage → **review cross-AI real de codex sobre el diff exacto** → APPROVED → commit conventional `3709232` con el id del torneo → veredicto en el verdict-store del carril (fichero sha256) → rama `tor/...` lista para PR. El 'compare, merge the winner' de Orca, convertido en acto auditado de principio a fin.

Suite completa 6512/6512 exit 0 · 68 líneas · APPROVED por codex (diff c040536efa12).
Card: KJC-TSK-0725 → To Validate al merge · Épica completa