### PR TITLE
fix(harden): pin workflow actions to commit shas — no mutable tags (KJC-BUG-0136)

### DIFF
--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -8,6 +8,20 @@
 
 // Blocks AI self-attribution in PR commit messages. Pure bash + grep, no Node.
 // Pins github.base_ref to an env var (never interpolated into the run block).
+// KJC-BUG-0136 (issue #1374): actions pinned to full commit SHAs — a
+// mutable tag lets its owner run arbitrary code inside EVERY hardened
+// repo's CI, with access to the workflow's secrets; 5 of this project's 7
+// audit findings came from files kj itself generated. The version rides in
+// a comment (the practice kj audit demands). To bump one:
+//   gh api repos/<owner>/<repo>/commits/<tag> --jq .sha
+export const PINNED_ACTIONS = {
+  checkout: "actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4",
+  setupNode: "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4",
+  setupPython: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5",
+  setupGo: "actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5",
+  setupPhp: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2",
+};
+
 export const NO_AI_ATTRIBUTION_WORKFLOW = [
   "name: Block AI attribution",
   "on:",
@@ -19,7 +33,7 @@ export const NO_AI_ATTRIBUTION_WORKFLOW = [
   "  scan:",
   "    runs-on: ubuntu-latest",
   "    steps:",
-  "      - uses: actions/checkout@v4",
+  `      - uses: ${PINNED_ACTIONS.checkout}`,
   "        with:",
   "          fetch-depth: 0",
   "      - name: Scan commit messages for AI attribution",
@@ -50,7 +64,7 @@ const header = (steps) =>
     "  quality:",
     "    runs-on: ubuntu-latest",
     "    steps:",
-    "      - uses: actions/checkout@v4",
+    `      - uses: ${PINNED_ACTIONS.checkout}`,
     ...steps,
   ].join("\n");
 
@@ -77,7 +91,7 @@ export const PM_COMMANDS = {
 };
 
 const nodeSetupSteps = (pm) => [
-  "      - uses: actions/setup-node@v4",
+  `      - uses: ${PINNED_ACTIONS.setupNode}`,
   "        with:",
   "          node-version: 22",
   ...(PM_COMMANDS[pm] || PM_COMMANDS.npm).setup,
@@ -86,7 +100,7 @@ const nodeSetupSteps = (pm) => [
 
 const QUALITY_BY_LANGUAGE = {
   python: header([
-    "      - uses: actions/setup-python@v5",
+    `      - uses: ${PINNED_ACTIONS.setupPython}`,
     "        with:",
     "          python-version: '3.12'",
     "      - run: pip install ruff pytest",
@@ -94,14 +108,14 @@ const QUALITY_BY_LANGUAGE = {
     "      - run: pytest",
   ]),
   go: header([
-    "      - uses: actions/setup-go@v5",
+    `      - uses: ${PINNED_ACTIONS.setupGo}`,
     "        with:",
     "          go-version: stable",
     "      - run: go vet ./...",
     "      - run: go test ./...",
   ]),
   php: header([
-    "      - uses: shivammathur/setup-php@v2",
+    `      - uses: ${PINNED_ACTIONS.setupPhp}`,
     "        with:",
     "          php-version: '8.3'",
     "      - run: composer install --no-interaction --no-progress",
@@ -132,7 +146,7 @@ export const SHRINK_BUDGET_WORKFLOW = [
   "    runs-on: ubuntu-latest",
   '    env: { LOC_LIMIT: "200" }',
   "    steps:",
-  "      - uses: actions/checkout@v4",
+  `      - uses: ${PINNED_ACTIONS.checkout}`,
   "        with:",
   "          fetch-depth: 0",
   "      - name: Net LOC delta within budget",
@@ -161,7 +175,7 @@ export const packSmokeWorkflow = (pm = "npm") =>
     "  pack-smoke:",
     "    runs-on: ubuntu-latest",
     "    steps:",
-    "      - uses: actions/checkout@v4",
+    `      - uses: ${PINNED_ACTIONS.checkout}`,
     ...nodeSetupSteps(pm),
     "      - name: Pack and install the tarball clean",
     "        run: |",
@@ -179,13 +193,13 @@ export const packSmokeWorkflow = (pm = "npm") =>
 const MUTATION_TOOLCHAIN = {
   javascript: "node", // resolved per package manager in mutationWorkflowFor
   python: [
-    "      - uses: actions/setup-python@v5",
+    `      - uses: ${PINNED_ACTIONS.setupPython}`,
     "        with:",
     "          python-version: '3.12'",
     "      - run: pip install mutmut pytest",
   ],
   php: [
-    "      - uses: shivammathur/setup-php@v2",
+    `      - uses: ${PINNED_ACTIONS.setupPhp}`,
     "        with:",
     "          php-version: '8.3'",
     "      - run: composer install --no-interaction --no-progress",
@@ -211,10 +225,10 @@ export function mutationWorkflowFor(language, pm = "npm") {
     "  mutation:",
     "    runs-on: ubuntu-latest",
     "    steps:",
-    "      - uses: actions/checkout@v4",
+    `      - uses: ${PINNED_ACTIONS.checkout}`,
     "        with:",
     "          fetch-depth: 0",
-    "      - uses: actions/setup-node@v4",
+    `      - uses: ${PINNED_ACTIONS.setupNode}`,
     "        with:",
     "          node-version: 22",
     ...toolchain,

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -55,7 +55,7 @@ describe("installWorkflows", () => {
     const res = installWorkflows({ projectDir: dir, language: "go" });
     expect(res.workflows.map((w) => w.file)).toContain(join(".github", "workflows", "kj-quality.yml"));
     const text = read(join(".github", "workflows", "kj-quality.yml"));
-    expect(text).toContain("actions/setup-go@v5");
+    expect(text).toContain("actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5");
     expect(text).toContain("go test ./...");
     expect(yaml.load(text).jobs.quality["runs-on"]).toBe("ubuntu-latest");
   });
@@ -63,7 +63,7 @@ describe("installWorkflows", () => {
   it("php gets a setup-php Quality workflow", () => {
     installWorkflows({ projectDir: dir, language: "php" });
     const text = read(join(".github", "workflows", "kj-quality.yml"));
-    expect(text).toContain("shivammathur/setup-php@v2");
+    expect(text).toContain("shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2");
     expect(text).toContain("vendor/bin/phpunit");
   });
 
@@ -162,5 +162,33 @@ describe("installWorkflows", () => {
     installWorkflows({ projectDir: dir, language: "python", mutation: true });
     const res = installWorkflows({ projectDir: dir, language: "python", mutation: true });
     expect(res.workflows.find((w) => w.file === mutFile).action).toBe("unchanged");
+  });
+});
+
+// KJC-BUG-0136 (issue #1374) — a mutable action tag lets its owner run
+// arbitrary code inside every hardened repo's CI. Every generated workflow
+// pins actions to a full commit SHA with the version in a comment — the
+// practice kj audit itself demands (semgrep github-actions-mutable-action-tag).
+describe("pinned actions — no mutable tags in generated workflows (KJC-BUG-0136)", () => {
+  it("every `uses:` in every template is pinned to a 40-hex SHA with a version comment", async () => {
+    const t = await import("../../src/harden/workflow-templates.js");
+    const flat = (w) => {
+      if (!w) return "";
+      return typeof w === "string" ? w : (w.content ?? Object.values(w).join("\n"));
+    };
+    const corpora = [
+      t.NO_AI_ATTRIBUTION_WORKFLOW,
+      t.SHRINK_BUDGET_WORKFLOW,
+      t.packSmokeWorkflow("npm"),
+      t.packSmokeWorkflow("pnpm"),
+      ...["node", "python", "go", "php"].map((lang) => flat(t.qualityWorkflowFor(lang))),
+      ...["node", "python"].map((lang) => flat(t.mutationWorkflowFor(lang))),
+    ].join("\n");
+    const uses = corpora.split("\n").filter((l) => l.includes("uses:"));
+    expect(uses.length).toBeGreaterThan(0);
+    for (const line of uses) {
+      expect(line).toMatch(/uses: [\w.-]+\/[\w.-]+@[0-9a-f]{40} # v/);
+      expect(line).not.toMatch(/@v\d/);
+    }
   });
 });


### PR DESCRIPTION
## Qué
Cierra la issue #1374: las 5 actions de las plantillas de `kj harden` (checkout, setup-node, setup-python, setup-go, setup-php) quedan **fijadas a SHA de commit completo con la versión en comentario** — `PINNED_ACTIONS` como fuente única con la receta de actualización (`gh api repos/<o>/<r>/commits/<tag> --jq .sha`). Un tag móvil deja a su dueño ejecutar código en el CI de TODOS los repos hardenizados con acceso a sus secretos; 5 de los 7 avisos de `kj audit --security` de un proyecto recién hardenizado salían de ficheros que kj mismo escribía. Los workflows `kj:managed` se refrescan solos al siguiente `kj harden` de cada proyecto — la corrección ya no se pierde al regenerar. SHAs verificados contra los repos reales (el ejemplo del reporter coincide byte a byte con checkout@v4). Test candado: toda línea `uses:` de todo template debe llevar SHA de 40 hex + comentario de versión; los tags `@vN` quedan estructuralmente prohibidos.

Suite completa 6513/6513 exit 0 · APPROVED por codex.
Card: KJC-BUG-0135→no, KJC-BUG-0136 · Issue #1374 (comentar 'Shipped in' al publicar)