### PR TITLE
fix(harden): lint configs and ci gate only when the tool exists (KJC-BUG-0137)

### DIFF
--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -184,7 +184,7 @@ export async function hardenCommand({
   const verb = dryRun ? "would install" : "installed";
   logger.info?.(`kj harden (${profile}) — ${verb} ${result.hooks.length} hook(s) → ${result.hooksPath}`);
   for (const h of result.hooks) logger.info?.(`  • ${h.hook}: ${h.action}`);
-  for (const c of out.configs) logger.info?.(`  • ${c.file}: ${c.action}`);
+  for (const c of out.configs) logger.info?.(`  • ${c.file}: ${c.action}${c.note ? ` (${c.note})` : ""}`);
   for (const w of out.workflows) logger.info?.(`  • ${w.file}: ${w.action}`);
   for (const g of out.guidelines) logger.info?.(`  • ${g.file}: ${g.action}`);
   if (!dryRun) logger.info?.("core.hooksPath set. Verify later with `kj check`.");

--- a/src/harden/config-engine.js
+++ b/src/harden/config-engine.js
@@ -15,6 +15,24 @@ import { CONFIGS_BY_LANGUAGE, UNIVERSAL_CONFIGS } from "./config-templates.js";
 
 const BLOCK_VERSION = 1;
 
+// KJC-BUG-0137 (issue #1357): is the tool a config demands actually installed?
+// Declared dependency or a resolvable bin both count; an unreadable
+// package.json is no evidence of the tool.
+function hasTool(dirs, tool) {
+  for (const d of dirs) {
+    if (existsSync(join(d, "node_modules", ".bin", tool))) return true;
+    const pkgPath = join(d, "package.json");
+    if (!existsSync(pkgPath)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      if (pkg.devDependencies?.[tool] || pkg.dependencies?.[tool]) return true;
+    } catch {
+      /* unreadable ⇒ keep looking */
+    }
+  }
+  return false;
+}
+
 function writeFile(target, content) {
   mkdirSync(dirname(target), { recursive: true });
   writeFileSync(target, content);
@@ -45,6 +63,15 @@ function seedInto(targetDir, configs, dryRun, prefix, results, altDirs = [target
       const variant = findEquivalentIn(altDirs, artifactIdForConfig(cfg));
       if (variant) {
         results.push({ file, action: "covered", by: variant });
+        continue;
+      }
+      // KJC-BUG-0137: no tool ⇒ no config — report the actionable gap instead.
+      if (cfg.requires && !hasTool(altDirs, cfg.requires)) {
+        results.push({
+          file,
+          action: "omitted",
+          note: `${cfg.requires} is not installed — npm i -D ${cfg.requires}, then re-run kj harden`,
+        });
         continue;
       }
     }

--- a/src/harden/config-templates.js
+++ b/src/harden/config-templates.js
@@ -95,10 +95,15 @@ export const UNIVERSAL_CONFIGS = [
   { file: "commitlint.config.js", blockId: "commitlint", style: "slash", body: COMMITLINT_BODY },
 ];
 
-/** `json:true` ⇒ seed-only (no comment syntax for a marker). */
+/**
+ * `json:true` ⇒ seed-only (no comment syntax for a marker). `requires` names
+ * the tool the config is for: absent from the project ⇒ the config is omitted
+ * with the install command in the report (KJC-BUG-0137) — a config without its
+ * tool is decorative, and kj never generates a demand it didn't satisfy.
+ */
 export const JS_CONFIGS = [
-  { file: "eslint.config.js", blockId: "eslint", style: "slash", body: ESLINT_BODY },
-  { file: ".prettierrc.json", json: true, body: PRETTIER_BODY },
+  { file: "eslint.config.js", blockId: "eslint", style: "slash", body: ESLINT_BODY, requires: "eslint" },
+  { file: ".prettierrc.json", json: true, body: PRETTIER_BODY, requires: "prettier" },
 ];
 export const PY_CONFIGS = [{ file: "ruff.toml", blockId: "ruff", style: "hash", body: RUFF_BODY }];
 export const GO_CONFIGS = [{ file: ".golangci.yml", blockId: "golangci", style: "hash", body: GOLANGCI_BODY }];

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -34,6 +34,16 @@ export function detectPackageManager(projectDir) {
   return "npm";
 }
 
+// KJC-BUG-0137: the JS quality workflow only carries a lint step when the
+// project HAS a lint script — and then it enforces (no --if-present).
+function hasLintScript(projectDir) {
+  try {
+    return Boolean(JSON.parse(readFileSync(join(projectDir, "package.json"), "utf8")).scripts?.lint);
+  } catch {
+    return false;
+  }
+}
+
 export function installWorkflows({
   projectDir = process.cwd(),
   language = null,
@@ -43,7 +53,7 @@ export function installWorkflows({
 } = {}) {
   const dir = join(projectDir, WORKFLOWS_DIR);
   const pm = detectPackageManager(projectDir);
-  const quality = qualityWorkflowFor(language, pm);
+  const quality = qualityWorkflowFor(language, pm, hasLintScript(projectDir));
   const extras = extraWorkflowsFor({ profile, publishable: isPublishableNpm(projectDir), pm });
   const mut = mutation ? mutationWorkflowFor(language, pm) : null;
   const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras, ...(mut ? [mut] : [])];

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -71,21 +71,22 @@ const header = (steps) =>
 // Per-package-manager commands (KJC-BUG-0131, issue #1330): `npm ci` in a
 // pnpm/yarn repo dies with EUSAGE (no package-lock.json). corepack ships with
 // Node 22 and resolves the right pnpm/yarn from `packageManager` — no
-// third-party action. pnpm passes flags AFTER the script name to the script
-// itself, so --if-present must go BEFORE it; yarn has no --if-present at all,
-// so lint runs through `npm run` (scripts don't touch the lockfile).
+// third-party action. Yarn scripts run through `npm run` (scripts don't touch
+// the lockfile). Lint ENFORCES — never --if-present: a step that passes when
+// its script is missing protects nothing (KJC-BUG-0137, issue #1357); the
+// engine omits the step instead when the project has no lint script.
 export const PM_COMMANDS = {
-  npm: { setup: [], install: "npm ci", lint: "npm run -s lint --if-present", test: "npm test" },
+  npm: { setup: [], install: "npm ci", lint: "npm run -s lint", test: "npm test" },
   pnpm: {
     setup: ["      - run: corepack enable"],
     install: "pnpm install --frozen-lockfile",
-    lint: "pnpm run --if-present -s lint",
+    lint: "pnpm run -s lint",
     test: "pnpm test",
   },
   yarn: {
     setup: ["      - run: corepack enable"],
     install: "yarn install --frozen-lockfile",
-    lint: "npm run -s lint --if-present",
+    lint: "npm run -s lint",
     test: "yarn test",
   },
 };
@@ -123,12 +124,16 @@ const QUALITY_BY_LANGUAGE = {
     "      - run: vendor/bin/phpunit",
   ]),
 };
-/** Stack-aware Quality workflow entry, or null for an unknown language. */
-export function qualityWorkflowFor(language, pm = "npm") {
+/**
+ * Stack-aware Quality workflow entry, or null for an unknown language.
+ * `lint:false` drops the JS lint step entirely (project has no lint script,
+ * KJC-BUG-0137) — mirroring the local hook, which also omits it.
+ */
+export function qualityWorkflowFor(language, pm = "npm", lint = true) {
   const c = PM_COMMANDS[pm] || PM_COMMANDS.npm;
   const body =
     language === "javascript" || language === "typescript"
-      ? header([...nodeSetupSteps(pm), `      - run: ${c.lint}`, `      - run: ${c.test}`])
+      ? header([...nodeSetupSteps(pm), ...(lint ? [`      - run: ${c.lint}`] : []), `      - run: ${c.test}`])
       : QUALITY_BY_LANGUAGE[language];
   return body ? { file: "kj-quality.yml", blockId: "wf-quality", body } : null;
 }

--- a/tests/harden/config-engine.test.js
+++ b/tests/harden/config-engine.test.js
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,8 +9,17 @@ import { installConfigs } from "../../src/harden/config-engine.js";
 let dir;
 const read = (f) => readFileSync(join(dir, f), "utf8");
 
+// KJC-BUG-0137: eslint/prettier configs only seed when their tool is actually
+// installed — most fixtures here declare both so the classic behavior holds.
+const withTools = (extra = {}) =>
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "x", devDependencies: { eslint: "^9", prettier: "^3" }, ...extra }),
+  );
+
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "kj-cfg-"));
+  withTools();
 });
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
@@ -72,7 +81,7 @@ describe("installConfigs", () => {
 
   it("covers legacy .eslintrc.json and inline package.json config too", () => {
     writeFileSync(join(dir, ".eslintrc.json"), "{}");
-    writeFileSync(join(dir, "package.json"), '{"prettier":{"printWidth":80}}');
+    withTools({ prettier: { printWidth: 80 } });
     const res = installConfigs({ projectDir: dir, language: "javascript" });
     const byFile = Object.fromEntries(res.configs.map((c) => [c.file, c]));
     expect(byFile["eslint.config.js"]).toMatchObject({ action: "covered", by: ".eslintrc.json" });
@@ -94,6 +103,32 @@ describe("installConfigs", () => {
     const res = installConfigs({ projectDir: dir, language: "javascript" });
     // prettier has no variant here → seeds normally alongside the mjs eslint.
     expect(res.configs.find((c) => c.file === ".prettierrc.json").action).toBe("inserted");
+  });
+
+  // KJC-BUG-0137 (issue #1357): a lint/format config whose tool isn't even
+  // installed is decorative at best — and pairs with a hook/workflow demand
+  // the project can't satisfy. kj never generates a demand it didn't leave
+  // satisfied: no eslint/prettier in the project ⇒ no config, with the
+  // actionable install command in the report instead.
+  it("omits eslint/prettier configs when the tool is not installed (KJC-BUG-0137)", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    const byFile = Object.fromEntries(res.configs.map((c) => [c.file, c]));
+    expect(byFile["eslint.config.js"].action).toBe("omitted");
+    expect(byFile["eslint.config.js"].note).toContain("npm i -D eslint");
+    expect(byFile[".prettierrc.json"].action).toBe("omitted");
+    expect(existsSync(join(dir, "eslint.config.js"))).toBe(false);
+    expect(existsSync(join(dir, ".prettierrc.json"))).toBe(false);
+    // Tool-independent configs are untouched by the gate.
+    expect(byFile[".editorconfig"].action).toBe("inserted");
+  });
+
+  it("a tool present only via node_modules/.bin still counts as installed", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+    mkdirSync(join(dir, "node_modules", ".bin"), { recursive: true });
+    writeFileSync(join(dir, "node_modules", ".bin", "eslint"), "");
+    const res = installConfigs({ projectDir: dir, language: "javascript" });
+    expect(res.configs.find((c) => c.file === "eslint.config.js").action).toBe("inserted");
   });
 
   it("never seeds eslint/prettier next to biome.json (KJC-TSK-0614)", () => {

--- a/tests/harden/config-roots.test.js
+++ b/tests/harden/config-roots.test.js
@@ -23,7 +23,7 @@ afterEach(() => {
 
 describe("installConfigsForRoots (monorepo)", () => {
   it("seeds universal at root and each language inside its own root", () => {
-    seed("frontend/package.json", "{}");
+    seed("frontend/package.json", '{"devDependencies":{"eslint":"^9","prettier":"^3"}}');
     seed("backend/pyproject.toml", "");
     const roots = detectStackRoots(root);
     const res = installConfigsForRoots({ projectDir: root, roots });
@@ -51,7 +51,7 @@ describe("installConfigsForRoots (monorepo)", () => {
   });
 
   it("dry-run writes nothing", () => {
-    seed("frontend/package.json", "{}");
+    seed("frontend/package.json", '{"devDependencies":{"eslint":"^9","prettier":"^3"}}');
     const roots = detectStackRoots(root);
     installConfigsForRoots({ projectDir: root, roots, dryRun: true });
     expect(has(".editorconfig")).toBe(false);

--- a/tests/harden/eslint-es2025.test.js
+++ b/tests/harden/eslint-es2025.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,6 +11,8 @@ let dir;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "kj-eslint-"));
+  // KJC-BUG-0137: the seeded eslint config demands the tool be present.
+  writeFileSync(join(dir, "package.json"), '{"devDependencies":{"eslint":"^9","prettier":"^3"}}');
 });
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });

--- a/tests/harden/stack-config.test.js
+++ b/tests/harden/stack-config.test.js
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +12,8 @@ const read = (f) => readFileSync(join(dir, f), "utf8");
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "kj-stack-"));
+  // KJC-BUG-0137: JS configs only seed when their tool is installed.
+  writeFileSync(join(dir, "package.json"), '{"devDependencies":{"eslint":"^9","prettier":"^3"}}');
 });
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -133,17 +133,37 @@ describe("installWorkflows", () => {
   });
 
   // KJC-BUG-0131 (issue #1330): npm ci in a pnpm repo kills every PR check.
-  it("a pnpm repo installs with pnpm and puts --if-present BEFORE the script", () => {
+  it("a pnpm repo installs with pnpm and lints through pnpm", () => {
     writeFileSync(join(dir, "pnpm-lock.yaml"), "");
-    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", bin: { x: "cli.js" } }));
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", bin: { x: "cli.js" }, scripts: { lint: "eslint ." } }));
     installWorkflows({ projectDir: dir, language: "javascript", mutation: true });
     const q = read(join(".github", "workflows", "kj-quality.yml"));
     expect(q).toContain("corepack enable");
     expect(q).toContain("pnpm install --frozen-lockfile");
-    expect(q).toContain("pnpm run --if-present -s lint");
+    expect(q).toContain("pnpm run -s lint");
     expect(q).not.toContain("npm ci");
     expect(read(join(".github", "workflows", "kj-pack-smoke.yml"))).not.toContain("npm ci");
     expect(read(mutFile)).not.toContain("npm ci");
+  });
+
+  // KJC-BUG-0137 (issue #1357): `--if-present` let the gate disarm itself when
+  // the script was missing — silently green, the opposite of the local hook.
+  // Now the lint step only exists when the project HAS a lint script at harden
+  // time, and when it exists it ENFORCES.
+  it("a repo with a lint script gets an enforcing lint step — never --if-present (KJC-BUG-0137)", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x", scripts: { lint: "eslint ." } }));
+    installWorkflows({ projectDir: dir, language: "javascript" });
+    const q = read(join(".github", "workflows", "kj-quality.yml"));
+    expect(q).toContain("- run: npm run -s lint");
+    expect(q).not.toContain("--if-present");
+  });
+
+  it("a repo without a lint script gets NO lint step — a gate that exists always enforces", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "x" }));
+    installWorkflows({ projectDir: dir, language: "javascript" });
+    const q = read(join(".github", "workflows", "kj-quality.yml"));
+    expect(q).not.toContain("lint");
+    expect(q).toContain("npm test");
   });
 
   it("a yarn repo installs with yarn; no lockfile keeps npm ci", () => {


### PR DESCRIPTION
## Qué
Cierra la issue #1357 — sus dos mitades caen con un solo principio: **kj no genera exigencias que él mismo no dejó satisfechas**.

1. **Config sin herramienta** — `eslint.config.js` / `.prettierrc.json` solo se siembran si la herramienta está realmente presente (dependencia declarada o bin resoluble en `node_modules/.bin`, monorepo-aware vía `altDirs`). Si falta: acción `omitted` con el comando accionable en el informe (`npm i -D eslint, then re-run kj harden`) — nunca una config decorativa que empuja al primer commit roto.
2. **Gate que se desarma solo** — fuera `--if-present` del workflow `kj-quality.yml`: si el proyecto tiene script `lint`, el paso EXIGE (`npm run -s lint` / `pnpm run -s lint`); si no lo tiene, el paso no se genera — el mismo contrato que el hook local, que también lo omite. Un gate presente siempre hace cumplir; el que pasa en silencio cuando falta su script no protege nada.

Al ser ficheros `kj:managed`, el siguiente `kj harden` de cada proyecto recoge ambas correcciones solo — se acaba el ciclo perverso que describía el reporter (corregirlo a mano se pierde, dejarlo lo rechaza `kj review`, y solomon falla en contra).

Tests: gate de omisión + presencia por bin + workflow con/sin script en npm y pnpm; fixtures existentes declaran ahora la herramienta donde se espera inserción. Suite completa 6517/6517 exit 0 · APPROVED por codex · 129 ins / 23 del (neto ~106, bajo el gate).
Card: KJC-BUG-0137 · Issue #1357 (comentar 'Shipped in' al publicar)