### PR TITLE
fix(review): declare diff clipping as the pipeline's own (KJC-BUG-0134)

### DIFF
--- a/src/prompts/diff-clip.js
+++ b/src/prompts/diff-clip.js
@@ -1,0 +1,27 @@
+/**
+ * diff-clip — KJC-BUG-0134 (issue #1381). A bare [TRUNCATED] marker inside
+ * the diff body reads as file content: reviewers blamed whichever file the
+ * cut landed in and rejected complete, untouched code (each false positive
+ * costs a solomon round). The clip is DECLARED as the pipeline's own, kept
+ * OUTSIDE the diff body, cut on a line boundary, and the reviewer is told
+ * the diff is partial so it never reasons about the completeness of files
+ * it cannot fully see. Shared by every prompt that hands a diff to an AI.
+ */
+
+export const DIFF_CLIP_CHARS = 12000;
+
+/** @returns {{body: string, note: string|null}} note is null when no clip happened. */
+export function clipDiff(diff, limit = DIFF_CLIP_CHARS) {
+  if (!diff) return { body: "", note: null };
+  if (diff.length <= limit) return { body: diff, note: null };
+  const hard = diff.slice(0, limit);
+  const nl = hard.lastIndexOf("\n");
+  const body = nl > 0 ? hard.slice(0, nl) : hard;
+  const omittedLines = diff.slice(body.length).split("\n").filter(Boolean).length;
+  const note = [
+    `NOTE FROM THE KJ PIPELINE (not part of the diff): the diff above was clipped by kj at ~${limit} characters — ${omittedLines} more line(s) exist but are NOT shown.`,
+    "The cut is kj's, not the author's: no file in the working tree is truncated.",
+    "Do not raise issues about incomplete or cut-off content, and do not reason about the completeness of files you cannot fully see. Review only what is visible.",
+  ].join(" ");
+  return { body, note };
+}

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -2,6 +2,7 @@ import { buildRtkInstructions } from "./rtk-snippet.js";
 import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.js";
 import { getLanguageInstruction } from "../utils/locale.js";
 import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "./prompt-layout.js";
+import { clipDiff } from "./diff-clip.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -34,7 +35,7 @@ const SERENA_INSTRUCTIONS = [
  * and always different) goes last.
  */
 export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
-  const truncatedDiff = diff.length > 12000 ? `${diff.slice(0, 12000)}\n\n[TRUNCATED]` : diff;
+  const { body: clippedDiff, note: clipNote } = clipDiff(diff);
 
   const langInstruction = getLanguageInstruction(language);
   const rtkSnippet = buildRtkInstructions({ rtkAvailable });
@@ -60,7 +61,8 @@ export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode,
     section(`Review rules:\n${reviewRules}`, STABLE),
     section(skillSection, STABLE),
     section(`Task context:\n${task}`, VOLATILE),
-    section(`Git diff:\n${truncatedDiff}`, VOLATILE),
+    section(`Git diff:\n${clippedDiff}`, VOLATILE),
+    section(clipNote, VOLATILE),
   ]);
 }
 

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -2,20 +2,14 @@ import { AgentRole } from "./agent-role.js";
 import { buildRtkInstructions } from "../prompts/rtk-snippet.js";
 import { extractFirstJson } from "../utils/json-extract.js";
 import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "../prompts/prompt-layout.js";
+import { clipDiff } from "../prompts/diff-clip.js";
 import { isMutationReviewEnabled, buildReviewerMutationSignal } from "../mutate/reviewer-signal.js";
-
-const MAX_DIFF_LENGTH = 12000;
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
   "Do NOT ask about using Karajan, do NOT mention Karajan, do NOT suggest orchestration.",
   "Do NOT use any MCP tools. Focus only on reviewing the code."
 ].join(" ");
-
-function truncateDiff(diff) {
-  if (!diff) return "";
-  return diff.length > MAX_DIFF_LENGTH ? `${diff.slice(0, MAX_DIFF_LENGTH)}\n\n[TRUNCATED]` : diff;
-}
 
 export class ReviewerRole extends AgentRole {
   constructor(opts) {
@@ -44,6 +38,8 @@ export class ReviewerRole extends AgentRole {
       enabled: isMutationReviewEnabled(),
       projectDir: this.config?.projectDir,
     });
+    // KJC-BUG-0134: a clip is declared as kj's own, outside the diff body.
+    const { body: clippedDiff, note: clipNote } = clipDiff(diff || "");
     const layout = buildPromptLayout([
       section(SUBAGENT_PREAMBLE, STABLE),
       section(this.instructions, STABLE),
@@ -56,7 +52,8 @@ export class ReviewerRole extends AgentRole {
       section(buildRtkInstructions({ rtkAvailable: Boolean(this.config?.rtk?.available) }), STABLE),
       section(reviewRules ? `Review rules:\n${reviewRules}` : null, STABLE),
       section(`Task context:\n${task}`, VOLATILE),
-      section(`Git diff:\n${truncateDiff(diff)}`, VOLATILE),
+      section(`Git diff:\n${clippedDiff}`, VOLATILE),
+      section(clipNote, VOLATILE),
       section(mutationSignal, VOLATILE),
     ]);
     return { prompt: joinLayout(layout), stablePrompt: layout.stable, volatilePrompt: layout.volatile };

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -82,30 +82,43 @@ describe("buildReviewerPrompt", () => {
     expect(result).toContain("Git diff:\ndiff --git a/src/auth.js");
   });
 
-  it("truncates diff larger than 12KB", async () => {
-    const largeDiff = "x".repeat(15000);
+  // KJC-BUG-0134 (issue #1381): a bare [TRUNCATED] inside the diff body reads
+  // as file content — reviewers blamed whichever file the cut landed in and
+  // rejected complete, untouched code. The clip is DECLARED as kj's own,
+  // outside the diff, with the order not to reason about completeness.
+  it("clips diffs larger than 12KB with a note attributed to kj — never a bare marker", async () => {
+    const line = "+a changed line of code xxxx\n";
+    const largeDiff = line.repeat(600); // ~17KB of newline-terminated lines
     const result = await buildReviewerPrompt({ ...baseArgs, diff: largeDiff });
 
-    expect(result).toContain("[TRUNCATED]");
-    expect(result).not.toContain("x".repeat(15000));
-    // Truncated portion should be 12000 chars
-    const diffSection = result.split("Git diff:\n")[1];
-    expect(diffSection).toContain("x".repeat(12000));
+    expect(result).not.toContain("[TRUNCATED]");
+    expect(result).toContain("clipped by kj");
+    expect(result).toContain("not part of the diff");
+    expect(result).toMatch(/\d+ more line/);
+    // The cut lands on a line boundary — no half-line artifacts to misread.
+    const diffSection = result.split("Git diff:\n")[1].split("\n\nNOTE FROM")[0];
+    expect(diffSection.endsWith(line.trimEnd())).toBe(true);
   });
 
-  it("does not truncate diff at exactly 12KB", async () => {
+  it("a diff with no newlines still clips hard at the limit", async () => {
+    const result = await buildReviewerPrompt({ ...baseArgs, diff: "x".repeat(15000) });
+    expect(result).toContain("clipped by kj");
+    expect(result).not.toContain("x".repeat(12001));
+  });
+
+  it("does not clip a diff at exactly 12KB", async () => {
     const exactDiff = "y".repeat(12000);
     const result = await buildReviewerPrompt({ ...baseArgs, diff: exactDiff });
 
-    expect(result).not.toContain("[TRUNCATED]");
+    expect(result).not.toContain("clipped by kj");
     expect(result).toContain("y".repeat(12000));
   });
 
-  it("does not truncate diff smaller than 12KB", async () => {
+  it("does not clip a diff smaller than 12KB", async () => {
     const smallDiff = "z".repeat(5000);
     const result = await buildReviewerPrompt({ ...baseArgs, diff: smallDiff });
 
-    expect(result).not.toContain("[TRUNCATED]");
+    expect(result).not.toContain("clipped by kj");
     expect(result).toContain("z".repeat(5000));
   });
 

--- a/tests/reviewer/reviewer-role.test.js
+++ b/tests/reviewer/reviewer-role.test.js
@@ -214,6 +214,8 @@ describe("ReviewerRole", () => {
     await role.run({ task: "Task", diff: largeDiff });
 
     const prompt = fakeAgent.reviewTask.mock.calls[0][0].prompt;
-    expect(prompt).toContain("[TRUNCATED]");
+    // KJC-BUG-0134: the clip is declared as kj's own, never a bare marker.
+    expect(prompt).toContain("clipped by kj");
+    expect(prompt).not.toContain("[TRUNCATED]");
   });
 });


### PR DESCRIPTION
## Qué
Cierra la issue #1381: el recorte de diffs sobredimensionados metía un `[TRUNCATED]` desnudo DENTRO del cuerpo del diff, y el reviewer culpaba al fichero donde caía el corte — rechazos falsos contra código completo e intacto, cada uno con su ronda de solomon (en la sesión del reporter, 2 de 3 rechazos del mismo diff eran falsos positivos).

Fix — el mismo patrón ya validado en el judge del torneo: módulo compartido `src/prompts/diff-clip.js` usado por las DOS rutas que recortaban (`kj review` one-shot y `ReviewerRole` del pipeline):
- El corte cae en frontera de línea — sin artefactos de media línea que parezcan corrupción.
- La omisión se declara FUERA del diff como nota del pipeline: cuántas líneas existen y no se muestran, que el corte es de kj y no del autor, y la orden de no razonar sobre completitud de ficheros que no puede ver enteros.
- El marcador `[TRUNCATED]` queda estructuralmente prohibido por test en ambas rutas.

Suite completa 6518/6518 exit 0 · lint 0 · APPROVED por codex · 63 ins / 22 del (neto ~41).
Card: KJC-BUG-0134 · Issue #1381 (comentar 'Shipped in' al publicar)