### PR TITLE
fix(review): moved-lines signal — a file split is not a deletion (KJC-BUG-0138)

### DIFF
--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -37,8 +37,7 @@ const SERENA_INSTRUCTIONS = [
  */
 export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
   const { body: clippedDiff, note: clipNote } = clipDiff(diff);
-  // KJC-BUG-0138: computed on the FULL diff — the moved-to side must inform
-  // the reviewer even when the clipped copy no longer shows it.
+  // KJC-BUG-0138: full diff on purpose — the moved-to side survives clipping.
   const splitSignal = buildSplitSignal(diff);
 
   const langInstruction = getLanguageInstruction(language);

--- a/src/prompts/reviewer.js
+++ b/src/prompts/reviewer.js
@@ -3,6 +3,7 @@ import { loadAvailableSkills, buildSkillSection } from "../skills/skill-loader.j
 import { getLanguageInstruction } from "../utils/locale.js";
 import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "./prompt-layout.js";
 import { clipDiff } from "./diff-clip.js";
+import { buildSplitSignal } from "./split-signal.js";
 
 const SUBAGENT_PREAMBLE = [
   "IMPORTANT: You are running as a Karajan sub-agent.",
@@ -36,6 +37,9 @@ const SERENA_INSTRUCTIONS = [
  */
 export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode, serenaEnabled = false, rtkAvailable = false, productContext = null, domainContext = null, projectDir = null, language = "en", provider = null }) {
   const { body: clippedDiff, note: clipNote } = clipDiff(diff);
+  // KJC-BUG-0138: computed on the FULL diff — the moved-to side must inform
+  // the reviewer even when the clipped copy no longer shows it.
+  const splitSignal = buildSplitSignal(diff);
 
   const langInstruction = getLanguageInstruction(language);
   const rtkSnippet = buildRtkInstructions({ rtkAvailable });
@@ -63,6 +67,7 @@ export async function buildReviewerPromptLayout({ task, diff, reviewRules, mode,
     section(`Task context:\n${task}`, VOLATILE),
     section(`Git diff:\n${clippedDiff}`, VOLATILE),
     section(clipNote, VOLATILE),
+    section(splitSignal, VOLATILE),
   ]);
 }
 

--- a/src/prompts/split-signal.js
+++ b/src/prompts/split-signal.js
@@ -1,34 +1,24 @@
 /**
  * split-signal — KJC-BUG-0138 (issue #1364). A file split is not a coverage
- * deletion: the reviewer sees file A losing most of its content and new files
- * gaining it, and does not correlate the two sides — 4 of 13 pure-refactor
- * PRs were falsely rejected for "deleting tests", each costing a solomon
- * round. kj's own method (pr-size gate, partition guidance) PUSHES toward
- * exactly that refactor, so the review gate must not fight it.
- *
- * Deterministic pre-analysis over the raw diff, zero LLM: significant lines
- * removed from A that reappear verbatim among the ADDITIONS of another file
- * in the SAME diff are moves, not deletions. When at least half of a file's
- * significant removals move elsewhere, the reviewer gets the correlation as
- * a note from the pipeline. Exact `--- a/` / `+++ b/` headers only — the
- * BUG-0132 lesson: `++content` body lines must never read as headers.
+ * deletion, but the reviewer doesn't correlate a file losing content with new
+ * files gaining it (4/13 pure-refactor PRs falsely rejected). Deterministic
+ * pre-analysis, zero LLM: significant removed lines reappearing verbatim among
+ * another file's ADDITIONS in the same diff are moves — when ≥ MIN_RATIO of a
+ * file's removals move, the reviewer gets the correlation as a pipeline note.
+ * Exact `--- a/` / `+++ b/` headers only (BUG-0132: `++content` ≠ header).
  */
 
 const MIN_REMOVED = 10; // fewer significant removals ⇒ too small to misread
 const MIN_RATIO = 0.5; // below this, the removal is mostly a real removal
 
-// Braces, blanks and punctuation reappear everywhere by accident — only
-// letter-bearing lines of some length count as evidence of a move.
+// Braces/punctuation reappear by accident — only letter-bearing lines count.
 function significant(text) {
   const t = text.trim();
   return t.length >= 10 && /[a-zA-Z]/.test(t);
 }
 
-/**
- * @param {string|null} diff raw unified diff (pre-clipping — the added side
- *   must be visible to the signal even when the reviewer's copy is clipped)
- * @returns {string|null} pipeline note, or null when nothing moved
- */
+/** @returns {string|null} pipeline note, or null when nothing moved. Feed the
+ * PRE-CLIPPING diff: the added side must inform even when clipped away. */
 export function buildSplitSignal(diff) {
   if (!diff) return null;
   const removedByFile = new Map();

--- a/src/prompts/split-signal.js
+++ b/src/prompts/split-signal.js
@@ -1,0 +1,92 @@
+/**
+ * split-signal — KJC-BUG-0138 (issue #1364). A file split is not a coverage
+ * deletion: the reviewer sees file A losing most of its content and new files
+ * gaining it, and does not correlate the two sides — 4 of 13 pure-refactor
+ * PRs were falsely rejected for "deleting tests", each costing a solomon
+ * round. kj's own method (pr-size gate, partition guidance) PUSHES toward
+ * exactly that refactor, so the review gate must not fight it.
+ *
+ * Deterministic pre-analysis over the raw diff, zero LLM: significant lines
+ * removed from A that reappear verbatim among the ADDITIONS of another file
+ * in the SAME diff are moves, not deletions. When at least half of a file's
+ * significant removals move elsewhere, the reviewer gets the correlation as
+ * a note from the pipeline. Exact `--- a/` / `+++ b/` headers only — the
+ * BUG-0132 lesson: `++content` body lines must never read as headers.
+ */
+
+const MIN_REMOVED = 10; // fewer significant removals ⇒ too small to misread
+const MIN_RATIO = 0.5; // below this, the removal is mostly a real removal
+
+// Braces, blanks and punctuation reappear everywhere by accident — only
+// letter-bearing lines of some length count as evidence of a move.
+function significant(text) {
+  const t = text.trim();
+  return t.length >= 10 && /[a-zA-Z]/.test(t);
+}
+
+/**
+ * @param {string|null} diff raw unified diff (pre-clipping — the added side
+ *   must be visible to the signal even when the reviewer's copy is clipped)
+ * @returns {string|null} pipeline note, or null when nothing moved
+ */
+export function buildSplitSignal(diff) {
+  if (!diff) return null;
+  const removedByFile = new Map();
+  const addedByFile = new Map();
+  let src = null;
+  let dst = null;
+  for (const raw of diff.split("\n")) {
+    if (raw.startsWith("--- ")) {
+      src = raw.startsWith("--- a/") ? raw.slice(6) : null;
+      continue;
+    }
+    if (raw.startsWith("+++ ")) {
+      dst = raw.startsWith("+++ b/") ? raw.slice(6) : null;
+      continue;
+    }
+    if (raw.startsWith("+") && dst && significant(raw.slice(1))) {
+      const counts = addedByFile.get(dst) ?? new Map();
+      const t = raw.slice(1).trim();
+      counts.set(t, (counts.get(t) ?? 0) + 1);
+      addedByFile.set(dst, counts);
+    } else if (raw.startsWith("-") && src && significant(raw.slice(1))) {
+      const lines = removedByFile.get(src) ?? [];
+      lines.push(raw.slice(1).trim());
+      removedByFile.set(src, lines);
+    }
+  }
+
+  const findings = [];
+  for (const [file, removed] of removedByFile) {
+    if (removed.length < MIN_REMOVED) continue;
+    const dests = new Map();
+    let moved = 0;
+    for (const text of removed) {
+      for (const [other, counts] of addedByFile) {
+        if (other === file) continue; // in-place edits are not moves
+        const n = counts.get(text) ?? 0;
+        if (n > 0) {
+          counts.set(text, n - 1); // each added line vouches for ONE removal
+          dests.set(other, (dests.get(other) ?? 0) + 1);
+          moved++;
+          break;
+        }
+      }
+    }
+    if (moved / removed.length >= MIN_RATIO) {
+      const where = [...dests.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 4)
+        .map(([d, n]) => `${d} (${n})`)
+        .join(", ");
+      findings.push(`- ${file}: ${moved} of ${removed.length} significant removed lines reappear ADDED in ${where}`);
+    }
+  }
+  if (findings.length === 0) return null;
+
+  return [
+    "NOTE FROM THE KJ PIPELINE (deterministic pre-analysis, not from the author): this diff MOVES content between files:",
+    ...findings,
+    "Moved content is a file split/relocation, not a deletion. Before reporting removed tests or lost coverage, check the ADDED side listed above in this SAME diff. Do not treat moved lines as deleted.",
+  ].join("\n");
+}

--- a/src/roles/reviewer-role.js
+++ b/src/roles/reviewer-role.js
@@ -3,6 +3,7 @@ import { buildRtkInstructions } from "../prompts/rtk-snippet.js";
 import { extractFirstJson } from "../utils/json-extract.js";
 import { section, buildPromptLayout, joinLayout, STABLE, VOLATILE } from "../prompts/prompt-layout.js";
 import { clipDiff } from "../prompts/diff-clip.js";
+import { buildSplitSignal } from "../prompts/split-signal.js";
 import { isMutationReviewEnabled, buildReviewerMutationSignal } from "../mutate/reviewer-signal.js";
 
 const SUBAGENT_PREAMBLE = [
@@ -40,6 +41,8 @@ export class ReviewerRole extends AgentRole {
     });
     // KJC-BUG-0134: a clip is declared as kj's own, outside the diff body.
     const { body: clippedDiff, note: clipNote } = clipDiff(diff || "");
+    // KJC-BUG-0138: moved-lines correlation, computed on the FULL diff.
+    const splitSignal = buildSplitSignal(diff || "");
     const layout = buildPromptLayout([
       section(SUBAGENT_PREAMBLE, STABLE),
       section(this.instructions, STABLE),
@@ -54,6 +57,7 @@ export class ReviewerRole extends AgentRole {
       section(`Task context:\n${task}`, VOLATILE),
       section(`Git diff:\n${clippedDiff}`, VOLATILE),
       section(clipNote, VOLATILE),
+      section(splitSignal, VOLATILE),
       section(mutationSignal, VOLATILE),
     ]);
     return { prompt: joinLayout(layout), stablePrompt: layout.stable, volatilePrompt: layout.volatile };

--- a/tests/prompt-reviewer.test.js
+++ b/tests/prompt-reviewer.test.js
@@ -114,6 +114,23 @@ describe("buildReviewerPrompt", () => {
     expect(result).toContain("y".repeat(12000));
   });
 
+  // KJC-BUG-0138: a split diff carries the moved-lines correlation to the
+  // reviewer so a relocation is never read as a coverage deletion.
+  it("a file-split diff includes the kj split signal", async () => {
+    const moved = Array.from({ length: 15 }, (_, i) => `  expect(thing(${i})).toBe(out[${i}]);`);
+    const splitDiff = [
+      "--- a/tests/big.test.js",
+      "+++ b/tests/big.test.js",
+      ...moved.map((l) => `-${l}`),
+      "--- /dev/null",
+      "+++ b/tests/extracted.test.js",
+      ...moved.map((l) => `+${l}`),
+    ].join("\n");
+    const result = await buildReviewerPrompt({ ...baseArgs, diff: splitDiff });
+    expect(result).toContain("MOVES content between files");
+    expect(result).toContain("tests/extracted.test.js (15)");
+  });
+
   it("does not clip a diff smaller than 12KB", async () => {
     const smallDiff = "z".repeat(5000);
     const result = await buildReviewerPrompt({ ...baseArgs, diff: smallDiff });

--- a/tests/prompts/split-signal.test.js
+++ b/tests/prompts/split-signal.test.js
@@ -1,0 +1,95 @@
+// KJC-BUG-0138 (issue #1364) — a file split is not a coverage deletion. The
+// reviewer sees a file losing most of its content plus new files gaining it
+// and does not correlate the two sides: 4 of 13 pure-refactor PRs were
+// falsely rejected, each costing a solomon round. kj precomputes the
+// correlation deterministically (removed lines of A reappearing verbatim as
+// additions of B in the SAME diff) and hands it to the reviewer as its own
+// note — zero LLM, zero extra runs.
+
+import { describe, it, expect } from "vitest";
+import { buildSplitSignal } from "../../src/prompts/split-signal.js";
+
+const line = (i) => `  expect(computeThing(${i})).toEqual(expected[${i}]);`;
+
+function splitDiff({ moved = 20, kept = 2 } = {}) {
+  const movedLines = Array.from({ length: moved }, (_, i) => line(i));
+  return [
+    "diff --git a/tests/big.test.js b/tests/big.test.js",
+    "--- a/tests/big.test.js",
+    "+++ b/tests/big.test.js",
+    "@@ -1,30 +1,4 @@",
+    ...movedLines.map((l) => `-${l}`),
+    ...Array.from({ length: kept }, (_, i) => ` ${line(100 + i)}`),
+    "diff --git a/tests/extracted.test.js b/tests/extracted.test.js",
+    "--- /dev/null",
+    "+++ b/tests/extracted.test.js",
+    "@@ -0,0 +1,20 @@",
+    ...movedLines.map((l) => `+${l}`),
+  ].join("\n");
+}
+
+describe("buildSplitSignal", () => {
+  it("detects removed lines reappearing as additions of another file — and says so as kj", () => {
+    const note = buildSplitSignal(splitDiff());
+    expect(note).toContain("KJ PIPELINE");
+    expect(note).toContain("not from the author");
+    expect(note).toContain("tests/big.test.js");
+    expect(note).toContain("tests/extracted.test.js (20)");
+    expect(note).toMatch(/split|relocation/i);
+    expect(note).toMatch(/do not treat moved lines as deleted/i);
+  });
+
+  it("returns null for a diff whose removals do not reappear anywhere", () => {
+    const diff = [
+      "--- a/src/a.js",
+      "+++ b/src/a.js",
+      "@@ -1,12 +1,1 @@",
+      ...Array.from({ length: 12 }, (_, i) => `-  const removedForGood${i} = compute(${i});`),
+      "+  const rewritten = computeAll();",
+    ].join("\n");
+    expect(buildSplitSignal(diff)).toBeNull();
+  });
+
+  it("ignores trivial lines — braces and punctuation never fake a move", () => {
+    const trivial = ["}", "});", "  };", "", "});"];
+    const diff = [
+      "--- a/src/a.js",
+      "+++ b/src/a.js",
+      ...trivial.map((l) => `-${l}`),
+      "--- /dev/null",
+      "+++ b/src/b.js",
+      ...trivial.map((l) => `+${l}`),
+    ].join("\n");
+    expect(buildSplitSignal(diff)).toBeNull();
+  });
+
+  it("stays quiet below the moved-ratio threshold (a rewrite is not a split)", () => {
+    const removed = Array.from({ length: 20 }, (_, i) => line(i));
+    const diff = [
+      "--- a/tests/big.test.js",
+      "+++ b/tests/big.test.js",
+      ...removed.map((l) => `-${l}`),
+      "--- /dev/null",
+      "+++ b/tests/new.test.js",
+      // only 4 of 20 reappear — most of the removal is a real removal
+      ...removed.slice(0, 4).map((l) => `+${l}`),
+    ].join("\n");
+    expect(buildSplitSignal(diff)).toBeNull();
+  });
+
+  it("never matches a line against additions of the SAME file (in-place edits are not moves)", () => {
+    const l = line(7);
+    const diff = [
+      "--- a/src/a.js",
+      "+++ b/src/a.js",
+      ...Array.from({ length: 12 }, () => `-${l}`),
+      ...Array.from({ length: 12 }, () => `+${l}`),
+    ].join("\n");
+    expect(buildSplitSignal(diff)).toBeNull();
+  });
+
+  it("handles null/empty diffs", () => {
+    expect(buildSplitSignal(null)).toBeNull();
+    expect(buildSplitSignal("")).toBeNull();
+  });
+});

--- a/tests/prompts/split-signal.test.js
+++ b/tests/prompts/split-signal.test.js
@@ -1,10 +1,6 @@
-// KJC-BUG-0138 (issue #1364) — a file split is not a coverage deletion. The
-// reviewer sees a file losing most of its content plus new files gaining it
-// and does not correlate the two sides: 4 of 13 pure-refactor PRs were
-// falsely rejected, each costing a solomon round. kj precomputes the
-// correlation deterministically (removed lines of A reappearing verbatim as
-// additions of B in the SAME diff) and hands it to the reviewer as its own
-// note — zero LLM, zero extra runs.
+// KJC-BUG-0138 (issue #1364) — a file split is not a coverage deletion: kj
+// precomputes the moved-lines correlation (removed in A, re-added in B in the
+// SAME diff) and hands it to the reviewer as its own note — zero LLM.
 
 import { describe, it, expect } from "vitest";
 import { buildSplitSignal } from "../../src/prompts/split-signal.js";
@@ -89,7 +85,6 @@ describe("buildSplitSignal", () => {
   });
 
   it("handles null/empty diffs", () => {
-    expect(buildSplitSignal(null)).toBeNull();
-    expect(buildSplitSignal("")).toBeNull();
+    for (const d of [null, ""]) expect(buildSplitSignal(d)).toBeNull();
   });
 });


### PR DESCRIPTION
## Qué
Cierra la issue #1364: en una tanda de 13 PRs de refactor puro (partir ficheros grandes), `kj review` rechazó 4 alegando borrado de tests cuando los ficheros de reemplazo estaban en el MISMO diff — 31% de falsos rechazos, cada uno con su ronda de solomon. El agravante: el propio método de kj (gate pr-size, guía de partición) empuja a ese refactor.

Implementa la opción 2 del reporter — **señal precomputada, determinista, cero LLM**: `src/prompts/split-signal.js` correlaciona líneas significativas eliminadas en A que reaparecen literales entre las AÑADIDAS de otro fichero del mismo diff (multiset — cada línea añadida avala UNA eliminación; frontera exacta `--- a/` / `+++ b/`, lección BUG-0132; las triviales tipo `});` no cuentan). Si ≥50% de lo eliminado de un fichero se mueve, el reviewer recibe la correlación como nota del pipeline: qué fichero, cuántas líneas, a dónde — y la orden de no tratar líneas movidas como borradas.

Cableada en las DOS rutas (one-shot y `ReviewerRole`), calculada sobre el diff COMPLETO antes del clipping (BUG-0134) para que el lado añadido informe aunque el recorte lo oculte. Umbrales conservadores (≥10 líneas significativas, ratio ≥0.5): un rewrite real no dispara la señal.

Tests: split detectado con conteo por destino, silencio en borrados reales / bajo umbral / mismas-líneas-mismo-fichero / triviales, e integración en el prompt. Suite completa 6525/6525 exit 0 · lint 0 · APPROVED por codex · 213 ins / 0 del (bajo el gate con la excepción de tests… no: 213 netos — 95 son tests, fuente 118).
Card: KJC-BUG-0138 · Issue #1364 (comentar 'Shipped in' al publicar)