### PR TITLE
chore(release): v4.15.0 — winning earns a candidacy, not a bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.15.0] - 2026-08-08
+
 ### Added
 
 - **The governed tournament — `kj tournament` → `--score` → `--judge` → `--crown`** (epic KJC-PCS-0073, KJC-TSK-0723/0724/0725, born from the Orca analysis: "fan one prompt across N agents, compare, merge the winner" — with a human eyeballing diffs; here the method chooses): fan the SAME task out to N coders in N isolated worktree lanes (`task.cwd` forwarded to every adapter; per-lane evidence: diff with intent-to-add, suite result, agent log, metadata; one lane's failure never sinks another) → a **deterministic zero-LLM scoreboard** (red suite eliminates; net LOC and tests parsed with exact-header diff parsing; mutation with honest degradation — a null never becomes a hidden penalty; the ranking rule is lexicographic and PRINTED with the result) → a **cross-AI judge** that chooses among survivors (a participant never judges its own tournament; only first place crowns; tie or winner-disagreement escalates to solomon with both positions; the LLM verdict is untrusted input — hallucinated coders fail loud) → the **crown**: the winner enters through the NORMAL door — real cross-AI review of its exact staged diff, verdict bound to the sha256, commit through the pre-commit gate; a rejected review aborts the coronation, because winning the tournament earns a candidacy, not a bypass. Losers keep their full dossier. The complete cycle ran LIVE on day one, coronation included. Ten legitimate cross-AI review rejections hardened the epic along the way.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (58k LOC, 470 files)
+├── src/              # Source code (67k LOC, 557 files)
 ├── tests/            # Test suite (511 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 3.7.1
+kj --version    # 4.15.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 3.5.1
+kj --version    # 4.15.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.14.0",
+      "version": "4.15.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v4.15.0

**The governed tournament** (épica KJC-PCS-0073, 7 PRs, ciclo completo probado EN VIVO con coronación real) + los **4 fixes del triaje de campo** (#1374 actions por SHA, #1357 lint solo con herramienta, #1381 clipping declarado, #1364 split ≠ borrado).

Bump + CHANGELOG [4.15.0] + GETTING-STARTED EN/ES + stats de ARCHITECTURE regeneradas. verify-pack ✓ (tarball 4.15.0 instala y corre en npm y pnpm). `kj release check`: todo verde salvo landing-current (se pone verde con el deploy post-publish).

Tras el merge: tag v4.15.0 → GH Release + SEA binaries por workflow → npm publish (OTP) → landing + docs → release check final → comentarios 'Shipped in' en las 4 issues.