### PR TITLE
feat(review): card-verify module — tracker adapter with honest degradation (KJC-TSK-0732)

### DIFF
--- a/src/review/card-verify.js
+++ b/src/review/card-verify.js
@@ -1,0 +1,83 @@
+/**
+ * card-verify — KJC-TSK-0732 (issue #1371). With a declared tracker,
+ * card-first upgrades "the branch names a card" to "the tracker says that
+ * card is ALIVE". Transport-agnostic: `board.verify_cmd` is the USER'S
+ * adapter (their CLI/MCP wrapper — credentials never enter kj) printing
+ * {exists, live, status?} JSON on stdout. Unverifiable NEVER blocks: it
+ * degrades to branch-ref level SAYING SO — a gate must not claim a check
+ * it didn't make, in either direction. Definitive verdicts are cached
+ * briefly; degradations never are, so recovery is immediate.
+ */
+import { exec } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promisify } from "node:util";
+import fs from "node:fs";
+import path from "node:path";
+import { extractFirstJson } from "../utils/json-extract.js";
+
+const execAsync = promisify(exec);
+export const VERIFY_TIMEOUT_MS = 4000;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+// The ref lands inside a shell command (the user's adapter template), so it
+// must be inert BY CONSTRUCTION — card-ref alphabet only, anchored (codex
+// catch: same injection class as the tournament coder names).
+const SAFE_REF_RE = /^[a-z0-9][a-z0-9-]{0,63}$/i;
+
+const defaultExec = async (cmd, { cwd }) =>
+  execAsync(cmd, { cwd, timeout: VERIFY_TIMEOUT_MS, maxBuffer: 1024 * 1024 });
+
+function cachePath(projectDir) {
+  return path.join(projectDir, ".kj", "cache", "card-verify.json");
+}
+
+/** @returns {Promise<{level: "tracker"|"branch-ref", verified: boolean|null, status?: string|null, note?: string}>}
+ *  verified: true = alive · false = definitively not · null = degraded. */
+export async function verifyCardAlive({ ref, verifyCmd, projectDir = process.cwd(), deps = {} }) {
+  const { execFn = defaultExec, now = Date.now } = deps;
+  if (!verifyCmd) {
+    return {
+      level: "branch-ref", verified: null,
+      note: "card-first checked the branch reference only — set board.verify_cmd to verify the card against your tracker",
+    };
+  }
+
+  if (!SAFE_REF_RE.test(String(ref))) {
+    return {
+      level: "branch-ref", verified: null,
+      note: `tracker verification skipped — ref "${String(ref).slice(0, 30)}" is outside the card-ref alphabet`,
+    };
+  }
+  let cache = {};
+  try {
+    cache = JSON.parse(fs.readFileSync(cachePath(projectDir), "utf8"));
+  } catch { /* no cache yet */ }
+  // Keyed by adapter AND ref (reviewer catch): a verdict from one
+  // verify_cmd must never answer for a different one.
+  const key = `${createHash("sha256").update(verifyCmd).digest("hex").slice(0, 12)}:${ref}`;
+  const hit = cache[key];
+  if (hit && now() - hit.at < CACHE_TTL_MS) return hit.result;
+
+  const cmd = verifyCmd.includes("{ref}") ? verifyCmd.replaceAll("{ref}", ref) : `${verifyCmd} ${ref}`;
+  try {
+    const { stdout } = await execFn(cmd, { cwd: projectDir });
+    const parsed = extractFirstJson(String(stdout));
+    if (!parsed || typeof parsed.exists !== "boolean") {
+      throw new Error("adapter must print JSON {exists, live, status} on stdout");
+    }
+    const alive = parsed.exists && parsed.live !== false;
+    const result = alive
+      ? { level: "tracker", verified: true, status: parsed.status ?? null }
+      : { level: "tracker", verified: false, status: parsed.status ?? (parsed.exists ? "not-live" : "not-found") };
+    try {
+      fs.mkdirSync(path.dirname(cachePath(projectDir)), { recursive: true });
+      fs.writeFileSync(cachePath(projectDir), JSON.stringify({ ...cache, [key]: { at: now(), result } }));
+    } catch { /* cache is best-effort — the verdict stands without it */ }
+    return result;
+  } catch (err) {
+    const why = String(err.message || err).split("\n")[0].slice(0, 120);
+    return {
+      level: "branch-ref", verified: null,
+      note: `tracker verification degraded to branch-ref (${why}) — fix board.verify_cmd or its credentials`,
+    };
+  }
+}

--- a/tests/review/card-verify.test.js
+++ b/tests/review/card-verify.test.js
@@ -1,0 +1,97 @@
+// KJC-TSK-0732 (issue #1371) — card-first against the DECLARED tracker.
+// Rule separable from transport (exec/clock injected); adapter contract:
+// {exists, live, status} JSON. Unverifiable degrades SAYING SO, never blocks.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { verifyCardAlive } from "../../src/review/card-verify.js";
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-cardverify-"));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const okExec = (out) => {
+  const calls = [];
+  const fn = async (cmd) => {
+    calls.push(cmd);
+    return { stdout: typeof out === "string" ? out : JSON.stringify(out) };
+  };
+  fn.calls = calls;
+  return fn;
+};
+
+describe("verifyCardAlive", () => {
+  it("without a verify_cmd it stays at branch-ref level and says how to raise it", async () => {
+    const r = await verifyCardAlive({ ref: "LIN-123", verifyCmd: null, projectDir: dir });
+    expect(r.level).toBe("branch-ref");
+    expect(r.verified).toBeNull();
+    expect(r.note).toContain("board.verify_cmd");
+  });
+
+  it("a live card verifies at tracker level; {ref} substituted, or appended without placeholder", async () => {
+    const exec = okExec({ exists: true, live: true, status: "In Progress" });
+    const r = await verifyCardAlive({ ref: "LIN-123", verifyCmd: "my-adapter --card {ref}", projectDir: dir, deps: { execFn: exec } });
+    expect(r).toMatchObject({ level: "tracker", verified: true, status: "In Progress" });
+    expect(exec.calls[0]).toBe("my-adapter --card LIN-123");
+    await verifyCardAlive({ ref: "LIN-9", verifyCmd: "my-adapter", projectDir: dir, deps: { execFn: exec } });
+    expect(exec.calls[1]).toBe("my-adapter LIN-9");
+  });
+
+  it("not-found and not-live are DEFINITIVE tracker verdicts, not degradations", async () => {
+    const gone = await verifyCardAlive({ ref: "A-1", verifyCmd: "x", projectDir: dir, deps: { execFn: okExec({ exists: false }) } });
+    expect(gone).toMatchObject({ level: "tracker", verified: false, status: "not-found" });
+    const closed = await verifyCardAlive({ ref: "B-2", verifyCmd: "x", projectDir: dir, deps: { execFn: okExec({ exists: true, live: false, status: "Done" }) } });
+    expect(closed).toMatchObject({ level: "tracker", verified: false, status: "Done" });
+  });
+
+  it("a broken adapter degrades to branch-ref with the failure named — it never blocks", async () => {
+    const boom = async () => { throw new Error("ETIMEDOUT talking to tracker"); };
+    const r = await verifyCardAlive({ ref: "C-3", verifyCmd: "x", projectDir: dir, deps: { execFn: boom } });
+    expect(r.level).toBe("branch-ref");
+    expect(r.verified).toBeNull();
+    expect(r.note).toMatch(/degraded/i);
+    expect(r.note).toContain("ETIMEDOUT");
+  });
+
+  it("a ref outside the card-ref alphabet NEVER reaches the shell (injection class)", async () => {
+    const exec = okExec({ exists: true, live: true });
+    const r = await verifyCardAlive({ ref: "x; rm -rf /", verifyCmd: "adapter {ref}", projectDir: dir, deps: { execFn: exec } });
+    expect(exec.calls.length).toBe(0);
+    expect(r).toMatchObject({ level: "branch-ref", verified: null });
+  });
+
+  it("non-JSON adapter output is a degradation, not a verdict", async () => {
+    const r = await verifyCardAlive({ ref: "D-4", verifyCmd: "x", projectDir: dir, deps: { execFn: okExec("everything fine!") } });
+    expect(r.level).toBe("branch-ref");
+    expect(r.verified).toBeNull();
+  });
+
+  it("the cache is keyed by adapter too — one verify_cmd never answers for another", async () => {
+    const now = () => 1_000_000;
+    await verifyCardAlive({ ref: "G-7", verifyCmd: "adapter-a", projectDir: dir, deps: { execFn: okExec({ exists: true, live: true }), now } });
+    const r = await verifyCardAlive({ ref: "G-7", verifyCmd: "adapter-b", projectDir: dir, deps: { execFn: okExec({ exists: false }), now } });
+    expect(r.verified).toBe(false); // adapter-b ran — no stale hit from adapter-a
+  });
+
+  it("definitive results are cached (TTL); degradations are NOT — recovery is immediate", async () => {
+    let t = 1_000_000;
+    const now = () => t;
+    const exec = okExec({ exists: true, live: true });
+    await verifyCardAlive({ ref: "E-5", verifyCmd: "x", projectDir: dir, deps: { execFn: exec, now } });
+    await verifyCardAlive({ ref: "E-5", verifyCmd: "x", projectDir: dir, deps: { execFn: exec, now } });
+    expect(exec.calls.length).toBe(1); // second hit came from cache
+    t += 11 * 60 * 1000; // past the TTL
+    await verifyCardAlive({ ref: "E-5", verifyCmd: "x", projectDir: dir, deps: { execFn: exec, now } });
+    expect(exec.calls.length).toBe(2);
+
+    const boom = async () => { throw new Error("down"); };
+    await verifyCardAlive({ ref: "F-6", verifyCmd: "x", projectDir: dir, deps: { execFn: boom, now } });
+    const exec2 = okExec({ exists: true, live: true });
+    const r = await verifyCardAlive({ ref: "F-6", verifyCmd: "x", projectDir: dir, deps: { execFn: exec2, now } });
+    expect(r.verified).toBe(true); // the degradation was not cached
+  });
+});


### PR DESCRIPTION
## Qué (PR 1/2 de la card — issue #1371)
Módulo puro `src/review/card-verify.js`: verifica que una card referenciada está VIVA contra el tracker real vía adaptador del usuario (`board.verify_cmd`, plantilla con `{ref}` o append) — contrato JSON `{exists, live, status}` en stdout. Cero credenciales en kj: el adaptador llama a la CLI/MCP donde ya viven.

Decisiones (regla separable del transporte — punto 5 del reporter):
- **Degradación honesta** (AC de la card): inverificable — sin cmd, timeout 4s, salida inválida — NUNCA bloquea; cae a nivel `branch-ref` DICIÉNDOLO. Un gate no reclama una comprobación que no hizo, en ningún sentido.
- **Caché corta** (10 min, solo veredictos definitivos; las degradaciones no se cachean — la recuperación es inmediata) con clave **adaptador+ref** (catch de codex: un verify_cmd nunca responde por otro).
- **Ref inerte por construcción** (catch de codex, clase inyección del torneo): alfabeto card-ref anclado o no se toca la shell.

El cableado en `checkCardFirst` (planning-game/external) + `board.verify_cmd` en defaults llega en el PR 2/2 — partido ANTES de crear el PR para respetar el gate LOC (el conjunto medía 219).

Suite 6536 verde exit 0 · lint 0 · APPROVED por codex · 180 ins / 0 del.
Card: KJC-TSK-0732 · Issue #1371