### PR TITLE
feat(review): card-first verifies liveness against the declared tracker (KJC-TSK-0732)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -26,6 +26,9 @@ async function enforceCardFirst({ config, projectDir }) {
   const branch = branchRes.stdout?.trim() || "HEAD";
   const card = await checkCardFirst({ config, projectDir, branch });
   if (card.mode === "warn") console.log(`⚠ card-first: ${card.reason}`);
+  // KJC-TSK-0732: the verification LEVEL is part of the verdict — a pass on
+  // branch-ref alone must never read as a tracker-verified pass.
+  if (card.note) console.log(`⚠ card-first: ${card.note}`);
   if (card.mode === "exempt" && card.reason.includes("KJ_ALLOW_NO_CARD")) console.log(`⚠ card-first exempt: ${card.reason}`);
   if (!card.ok) {
     console.log(`✗ card-first gate: ${card.reason}`);

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -66,7 +66,9 @@ const DEFAULTS = {
   // through the host agent's MCP/tools, never mirrored by kj. There is NO
   // "none": Karajan does not run without a board.
   state_backend: "hu-board",
-  board: { name: null },
+  // verify_cmd (KJC-TSK-0732): user adapter that checks a card ref against
+  // the real tracker — prints {exists, live, status} JSON; {ref} substituted.
+  board: { name: null, verify_cmd: null },
   // Method gates (KJC-PCS-0068): rules climb from playbook text to
   // deterministic enforcement. card_first: "auto" = block with hu-board
   // (fully verifiable), warn with planning-game/external (presence only);

--- a/src/review/card-first.js
+++ b/src/review/card-first.js
@@ -8,6 +8,7 @@
  */
 import { listPlans, loadPlan } from "../plan/plan-store.js";
 import { escapeRegExp } from "../utils/escape-regexp.js";
+import { verifyCardAlive } from "./card-verify.js";
 
 const LIVE_STATUSES = new Set(["pending", "running", "failed"]);
 // Card-shaped reference: LIN-123, bb-002 and multi-segment ids like
@@ -44,7 +45,7 @@ async function findLiveCardInBranch(projectDir, branch) {
   return closedHit;
 }
 
-export async function checkCardFirst({ config = {}, projectDir = process.cwd(), branch, env = process.env }) {
+export async function checkCardFirst({ config = {}, projectDir = process.cwd(), branch, env = process.env, deps = {} }) {
   if (env.KJ_ALLOW_NO_CARD === "1") {
     return { ok: true, mode: "exempt", reason: "KJ_ALLOW_NO_CARD=1 (explicit escape hatch)" };
   }
@@ -73,11 +74,24 @@ export async function checkCardFirst({ config = {}, projectDir = process.cwd(), 
       : { ok: true, mode: "warn", reason };
   }
 
-  // planning-game / external: presence check only — liveness lives in the
-  // project's own board, out of local reach.
-  if (CARD_REF_RE.test(branch)) return { ok: true, mode: "pass", ref: branch.match(CARD_REF_RE)[0] };
-  const effective = policy === "auto" ? "warn" : policy;
+  // planning-game / external: presence check, upgraded to LIVENESS against
+  // the real tracker when board.verify_cmd declares an adapter
+  // (KJC-TSK-0732, issue #1371). Unverifiable degrades honestly — the
+  // result names its level so nobody mistakes branch-ref for tracker.
   const boardName = config.board?.name || backend;
+  const effective = policy === "auto" ? "warn" : policy;
+  if (CARD_REF_RE.test(branch)) {
+    const ref = branch.match(CARD_REF_RE)[0];
+    const { verifyFn = verifyCardAlive } = deps;
+    const v = await verifyFn({ ref, verifyCmd: config.board?.verify_cmd, projectDir });
+    if (v.verified === false) {
+      const reason = `branch references ${ref} but ${boardName} reports it "${v.status}" — card-first needs a live card in the tracker (create/reopen it there)`;
+      return effective === "block"
+        ? { ok: false, mode: "block", reason, level: v.level }
+        : { ok: true, mode: "warn", reason, level: v.level };
+    }
+    return { ok: true, mode: "pass", ref, level: v.level, ...(v.note ? { note: v.note } : {}) };
+  }
   const reason = `no card reference in branch "${branch}" — card-first on ${boardName}: create the card there and name the branch after it (e.g. feat/ABC-123-summary)`;
   return effective === "block"
     ? { ok: false, mode: "block", reason }

--- a/tests/review/card-first.test.js
+++ b/tests/review/card-first.test.js
@@ -70,6 +70,43 @@ describe("checkCardFirst — external / planning-game (presence check, warns by 
     });
     expect(b).toMatchObject({ ok: false, mode: "block" });
   });
+
+  // KJC-TSK-0732 (issue #1371): with board.verify_cmd the gate checks the
+  // card is ALIVE in the real tracker — a dead/invented ref gets the same
+  // treatment as "no card"; unverifiable degrades to branch-ref, saying so.
+  describe("with board.verify_cmd (tracker verification)", () => {
+    const cfg = { ...ext, board: { name: "Linear", verify_cmd: "adapter {ref}" } };
+    const verify = (result) => ({ verifyFn: async () => result });
+
+    it("a live card passes at tracker level", async () => {
+      const r = await checkCardFirst({
+        config: cfg, projectDir: dir, branch: "jorge/lin-123-fix", env: {},
+        deps: verify({ level: "tracker", verified: true, status: "In Progress" }),
+      });
+      expect(r).toMatchObject({ ok: true, mode: "pass", ref: "lin-123", level: "tracker" });
+    });
+
+    it("a dead or invented ref is treated like 'no card' (warn by default, block via config)", async () => {
+      const dead = verify({ level: "tracker", verified: false, status: "Done" });
+      const w = await checkCardFirst({ config: cfg, projectDir: dir, branch: "jorge/lin-123-fix", env: {}, deps: dead });
+      expect(w).toMatchObject({ ok: true, mode: "warn" });
+      expect(w.reason).toContain("Done");
+      const b = await checkCardFirst({
+        config: { ...cfg, method_gates: { card_first: "block" } },
+        projectDir: dir, branch: "jorge/lin-123-fix", env: {}, deps: dead,
+      });
+      expect(b).toMatchObject({ ok: false, mode: "block" });
+    });
+
+    it("unverifiable passes at branch-ref level WITH the degradation note", async () => {
+      const r = await checkCardFirst({
+        config: cfg, projectDir: dir, branch: "jorge/lin-123-fix", env: {},
+        deps: verify({ level: "branch-ref", verified: null, note: "tracker verification degraded to branch-ref (ETIMEDOUT)" }),
+      });
+      expect(r).toMatchObject({ ok: true, mode: "pass", level: "branch-ref" });
+      expect(r.note).toMatch(/degraded/);
+    });
+  });
 });
 
 describe("checkCardFirst — exemptions", () => {


### PR DESCRIPTION
## Qué (PR 2/2 de la card — issue #1371, cierra la card)
Cablea el módulo del #1402 en `checkCardFirst`: en backends planning-game/external, tras el check de presencia, la referencia de la rama se verifica VIVA contra el tracker declarado.

- Card muerta o inventada → mismo tratamiento que 'sin card' (warn por defecto, block vía `method_gates.card_first`), con el estado del tracker en el mensaje.
- Verificado vivo → pass con `level: tracker`.
- Inverificable → pass con `level: branch-ref` y la nota de degradación IMPRESA por el gate (`review-gate`): un pass por referencia nunca se lee como pass verificado.
- `board.verify_cmd` documentado en defaults; `deps.verifyFn` inyectable para tests.

Con esto 'card-first' significa lo mismo en todos los backends: hoy una rama con referencia inventada pasaba el gate en PG/external.

Fuera de alcance (anotado en el plan de la card): sprint-del-día/TZ y clientes nativos por tracker.

Suite completa verde exit 0 · lint 0 · APPROVED por codex · neto 56.
Card: KJC-TSK-0732 · Issue #1371 (comentar 'Shipped in' al publicar)