### PR TITLE
fix(brain): direct-action installs skip lifecycle scripts (KJC-BUG-0099)

### DIFF
--- a/src/orchestrator/direct-actions.js
+++ b/src/orchestrator/direct-actions.js
@@ -26,6 +26,17 @@ const ALLOWED_COMMANDS = [
   "bundle install", "composer install", "dotnet restore"
 ];
 
+// KJC-BUG-0099: a dependency install must not be arbitrary code execution —
+// lifecycle hooks (postinstall & friends) run whatever the dependency ships.
+// The allow-list above names the INTENT; execution appends the ecosystem's
+// script-skipping flag. Ecosystems without package hooks run untouched.
+const HARDEN_FLAGS = {
+  npm: ["--ignore-scripts"],
+  pnpm: ["--ignore-scripts"],
+  yarn: ["--ignore-scripts"],
+  composer: ["--no-scripts", "--no-plugins"],
+};
+
 /**
  * True when `target` resolves to a path inside `base` (or is `base` itself).
  * Uses path.relative instead of a string prefix check: a naive
@@ -64,7 +75,7 @@ async function runCommand({ cmd, cwd }) {
     // Even though `cmd` is allow-listed, defense-in-depth: switched to
     // execFileSync with a tokenised arg array so no shell expansion at all.
     const [program, ...args] = cmd.trim().split(/\s+/);
-    const output = execFileSync(program, args, {
+    const output = execFileSync(program, [...args, ...(HARDEN_FLAGS[program] ?? [])], {
       cwd: cwd || process.cwd(),
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],

--- a/tests/direct-actions.test.js
+++ b/tests/direct-actions.test.js
@@ -52,8 +52,29 @@ describe("direct-actions", () => {
       });
       expect(result.ok).toBe(true);
       expect(result.output).toContain("42 packages");
-      // Tokenised arg array, no shell expansion.
-      expect(execFileSync).toHaveBeenCalledWith("npm", ["install"], expect.any(Object));
+      // Tokenised arg array, no shell expansion — and hardened (KJC-BUG-0099):
+      // a dependency install must never run arbitrary lifecycle scripts.
+      expect(execFileSync).toHaveBeenCalledWith("npm", ["install", "--ignore-scripts"], expect.any(Object));
+    });
+
+    // KJC-BUG-0099: every ecosystem with lifecycle hooks gets its skip flag
+    // appended at EXECUTION time — the allow-list stays as the user-visible
+    // intent. Ecosystems without package hooks run untouched.
+    it("appends script-skipping flags per ecosystem (KJC-BUG-0099)", async () => {
+      execFileSync.mockReturnValue("");
+      const expected = [
+        ["npm ci", "npm", ["ci", "--ignore-scripts"]],
+        ["pnpm install", "pnpm", ["install", "--ignore-scripts"]],
+        ["yarn install", "yarn", ["install", "--ignore-scripts"]],
+        ["composer install", "composer", ["install", "--no-scripts", "--no-plugins"]],
+        ["go mod download", "go", ["mod", "download"]],
+        ["cargo fetch", "cargo", ["fetch"]],
+      ];
+      for (const [cmd, program, args] of expected) {
+        execFileSync.mockClear();
+        await executeAction({ type: "run_command", params: { cmd } });
+        expect(execFileSync).toHaveBeenCalledWith(program, args, expect.any(Object));
+      }
     });
 
     it("rejects disallowed command", async () => {


### PR DESCRIPTION
## Qué
Cierra KJC-BUG-0099: el direct-action `run_command` del Brain instalaba dependencias sin bloquear los lifecycle scripts — un `npm install` autónomo era ejecución arbitraria de código vía postinstall de cualquier dependencia comprometida (la clase exacta del ataque de cadena de suministro de npm auditado el 8-ago).

Diseño: la allow-list sigue nombrando la INTENCIÓN (`npm install`); la ejecución la endurece añadiendo el flag anti-scripts del ecosistema: npm/pnpm/yarn `--ignore-scripts`, composer `--no-scripts --no-plugins`. Los ecosistemas sin hooks de paquete (go, cargo, pip, dotnet…) corren intactos. Test que fija el mapeo completo.

Suite completa verde exit 0 · lint 0 · `kj audit --security` limpio · APPROVED por codex · 35 ins / 3 del.
Card: KJC-BUG-0099