### PR TITLE
fix(verify-pack): isolate the pnpm smoke from the host repo (KJC-BUG-0135)

### DIFF
--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -208,7 +208,17 @@ try {
   // better-sqlite3's native build by default, so DB-backed commands need
   // `pnpm approve-builds`; that's surfaced as a doctor warning, KJC-BUG-0092 —
   // not a gate failure, since it's inherent to pnpm.) Auto-skips without pnpm.
-  const hasPnpm = spawnSync("pnpm", ["--version"], { encoding: "utf8", env: childEnv }).status === 0;
+  // KJC-BUG-0135: `npm run` leaks npm_config_* into the child env, and pnpm
+  // maps those variables onto its own config — which can re-anchor it to THIS
+  // repo (7-aug incident: the repo's node_modules converted to pnpm layout,
+  // native bindings wiped, and simple-git-hooks' hook overwrote
+  // .karajan/hooks). The smoke runs with a scrubbed env and a pinned --dir,
+  // and the tripwire below turns any host contamination into a loud gate
+  // failure instead of a silent green.
+  const pnpmEnv = Object.fromEntries(Object.entries(childEnv).filter(([k]) => !/^npm_config_/i.test(k)));
+  const HOST_MARKERS = ["pnpm-lock.yaml", "pnpm-workspace.yaml", path.join("node_modules", ".pnpm")];
+  const hostMarkersBefore = new Set(HOST_MARKERS.filter((m) => fs.existsSync(path.join(repoRoot, m))));
+  const hasPnpm = spawnSync("pnpm", ["--version"], { encoding: "utf8", env: pnpmEnv }).status === 0;
   if (!hasPnpm) {
     console.log("verify-pack: pnpm not installed — skipping pnpm smoke (npm path covered above) ⚠");
   } else {
@@ -224,11 +234,11 @@ try {
     // versions (supply-chain protection), so right after publishing
     // karajan-core it silently resolves an OLD one and this smoke fails on
     // missing subpaths. The gate verifies packaging, not release-age policy.
-    spawnSync("pnpm", ["add", tgzPath, "--store-dir", path.join(pnpmTmp, ".store"), "--config.minimum-release-age=0"], {
-      encoding: "utf8",
-      env: childEnv,
-      cwd: pnpmTmp,
-    });
+    spawnSync(
+      "pnpm",
+      ["add", tgzPath, "--dir", pnpmTmp, "--ignore-workspace", "--store-dir", path.join(pnpmTmp, ".store"), "--config.minimum-release-age=0"],
+      { encoding: "utf8", env: pnpmEnv, cwd: pnpmTmp },
+    );
     const pnpmBin = path.join(pnpmTmp, "node_modules", ".bin", "kj");
     if (!fs.existsSync(pnpmBin)) fail(`kj binary missing after pnpm install: ${pnpmBin}`);
     let pnpmVersion;
@@ -241,6 +251,18 @@ try {
       fail(`kj --version under pnpm returned "${pnpmVersion}", expected ${expectedVersion}`);
     }
     console.log(`verify-pack: pnpm install + kj --version → ${pnpmVersion} ✓ (DB build needs \`pnpm approve-builds\`)`);
+  }
+  // Tripwire (KJC-BUG-0135): the smoke must NEVER touch the host repo. If a
+  // pnpm artifact appeared at the repo root during this run, the gate fails
+  // naming it — never a green over a contaminated tree.
+  const contaminated = HOST_MARKERS.filter(
+    (m) => !hostMarkersBefore.has(m) && fs.existsSync(path.join(repoRoot, m)),
+  );
+  if (contaminated.length > 0) {
+    fail(
+      `pnpm smoke contaminated the host repo: ${contaminated.join(", ")} appeared at the repo root`,
+      "remove the listed files and run `npm ci` to restore the npm layout; then verify .karajan/hooks with `git status`",
+    );
   }
 
   console.log(`\n✓ verify-pack: karajan-code@${expectedVersion} installs clean and runs.`);


### PR DESCRIPTION
## Qué
Cierra KJC-BUG-0135: el 7-ago el paso pnpm de verify-pack convirtió el node_modules del PROPIO repo a layout pnpm (bindings nativos borrados) y de propina el hook de simple-git-hooks sobrescribió `.karajan/hooks` — el review-gate local quedó desactivado en el working tree sin aviso. El `pnpm-workspace.yaml` residual en la raíz (con allowBuilds de las deps del repo) confirma que un pnpm se ancló a la raíz; el vector plausible: `npm run` filtra `npm_config_*` al entorno hijo y pnpm mapea esas variables a su propia config.

Tres capas, sin sobreingeniería:
1. **Entorno depurado**: el smoke pnpm corre sin `npm_config_*` heredadas.
2. **Anclaje explícito**: `--dir <tmp>` + `--ignore-workspace` — el proyecto del smoke es el tmp, digan lo que digan env o árbol.
3. **Tripwire honesto**: snapshot de marcadores pnpm en la raíz antes del paso; si tras el paso apareció alguno (`pnpm-lock.yaml`, `pnpm-workspace.yaml`, `node_modules/.pnpm`), el gate FALLA nombrándolo con la receta de restauración — nunca un verde sobre un árbol contaminado.

Validación: `npm run verify-pack` completo en verde con el paso endurecido y la raíz limpia después. Residuos del incidente (pnpm-lock/workspace.yaml en raíz, untracked) eliminados.

Suite completa verde exit 0 · APPROVED por codex · 28 ins / 6 del.
Card: KJC-BUG-0135