### PR TITLE
fix(ai-trash): hook line fails closed when the bin is off path (KJC-BUG-0095)

### DIFF
--- a/packages/ai-trash/src/install.js
+++ b/packages/ai-trash/src/install.js
@@ -8,7 +8,14 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 export const DEFAULT_SETTINGS_PATH = join(homedir(), ".claude", "settings.json");
-export const HOOK_COMMAND = "kj-trash hook";
+// KJC-BUG-0095: the bare command fails SILENTLY when the bin drops off PATH
+// (nvm switch, global reinstall) — the anti-delete net goes down without
+// notice. The installed line fails CLOSED: a missing bin blocks the tool
+// call (exit 2) naming the net and the remedy, never a quiet pass-through.
+export const LEGACY_HOOK_COMMAND = "kj-trash hook";
+export const HOOK_COMMAND =
+  "if command -v kj-trash >/dev/null 2>&1; then exec kj-trash hook; fi; " +
+  "echo 'kj-trash: bin not on PATH — the anti-delete net is DOWN. Fix: npm i -g karajan-code (or remove this hook from ~/.claude/settings.json).' >&2; exit 2";
 const MATCHER = "Bash";
 
 async function readSettings(path) {
@@ -33,6 +40,20 @@ export function patchSettings(settings, command = HOOK_COMMAND, matcher = MATCHE
   if (!entry) {
     entry = { matcher, hooks: [{ type: "command", command }] };
     preToolUse.push(entry);
+    mutated = true;
+  } else if (hasHookCommand(entry, LEGACY_HOOK_COMMAND) && command !== LEGACY_HOOK_COMMAND) {
+    // KJC-BUG-0095 migration: upgrade the silent legacy line in place —
+    // deduped (reviewer catch): an entry already carrying the new line
+    // must end up with a single copy, not legacy-turned-duplicate.
+    let seen = false;
+    entry.hooks = entry.hooks
+      .map((h) => (h.type === "command" && h.command === LEGACY_HOOK_COMMAND ? { ...h, command } : h))
+      .filter((h) => {
+        if (!(h.type === "command" && h.command === command)) return true;
+        if (seen) return false;
+        seen = true;
+        return true;
+      });
     mutated = true;
   } else if (!hasHookCommand(entry, command)) {
     entry.hooks = [...(entry.hooks ?? []), { type: "command", command }];

--- a/packages/ai-trash/tests/install.test.js
+++ b/packages/ai-trash/tests/install.test.js
@@ -1,10 +1,12 @@
 // install --claude-code tests (KJC-TSK-0390 commit 3).
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 
-import { installClaudeCodeHook, patchSettings, HOOK_COMMAND } from "../src/install.js";
+import { installClaudeCodeHook, patchSettings, HOOK_COMMAND, LEGACY_HOOK_COMMAND } from "../src/install.js";
 
 async function makeSettings(initial) {
   const dir = await mkdtemp(join(tmpdir(), "ai-trash-install-"));
@@ -75,5 +77,62 @@ describe("installClaudeCodeHook (filesystem)", () => {
     await installClaudeCodeHook({ path });
     const second = await installClaudeCodeHook({ path });
     expect(second.mutated).toBe(false);
+  });
+});
+
+// KJC-BUG-0095: the net must never go down silently. The installed line
+// fails CLOSED when the bin is off PATH, and old installs upgrade in place.
+describe("fail-closed hook line (KJC-BUG-0095)", () => {
+  it("the installed command guards the bin and blocks (exit 2) when missing", () => {
+    expect(HOOK_COMMAND).toContain("command -v kj-trash");
+    expect(HOOK_COMMAND).toContain("exit 2");
+    expect(HOOK_COMMAND).toMatch(/DOWN/);
+  });
+
+  it("upgrades a legacy bare line in place — no duplicates, mutated:true", () => {
+    const initial = {
+      hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: LEGACY_HOOK_COMMAND }] }] },
+    };
+    const { settings, mutated } = patchSettings(initial);
+    expect(mutated).toBe(true);
+    const bash = settings.hooks.PreToolUse.find((e) => e.matcher === "Bash");
+    expect(bash.hooks).toHaveLength(1);
+    expect(bash.hooks[0].command).toBe(HOOK_COMMAND);
+  });
+
+  it("an entry carrying BOTH legacy and new line ends with a single copy (reviewer catch)", () => {
+    const initial = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "command", command: LEGACY_HOOK_COMMAND },
+              { type: "command", command: HOOK_COMMAND },
+            ],
+          },
+        ],
+      },
+    };
+    const { settings } = patchSettings(initial);
+    const bash = settings.hooks.PreToolUse.find((e) => e.matcher === "Bash");
+    expect(bash.hooks.filter((h) => h.command === HOOK_COMMAND)).toHaveLength(1);
+    expect(bash.hooks.some((h) => h.command === LEGACY_HOOK_COMMAND)).toBe(false);
+  });
+
+  it("behaves: blocks with the warning without the bin; delegates when present", () => {
+    const empty = spawnSync("/bin/sh", ["-c", HOOK_COMMAND], { encoding: "utf8", env: { PATH: "/nonexistent" } });
+    expect(empty.status).toBe(2);
+    expect(empty.stderr).toContain("anti-delete net is DOWN");
+
+    const binDir = mkdtempSync(join(tmpdir(), "kj-trash-bin-"));
+    writeFileSync(join(binDir, "kj-trash"), "#!/bin/sh\necho delegated-ok\nexit 0\n", { mode: 0o755 });
+    const ok = spawnSync("/bin/sh", ["-c", HOOK_COMMAND], {
+      encoding: "utf8",
+      env: { PATH: `${binDir}:/usr/bin:/bin` },
+    });
+    expect(ok.status).toBe(0);
+    expect(ok.stdout).toContain("delegated-ok");
+    rmSync(binDir, { recursive: true, force: true });
   });
 });

--- a/packages/ai-trash/tests/smoke.test.js
+++ b/packages/ai-trash/tests/smoke.test.js
@@ -25,8 +25,10 @@ describe("@karajan/ai-trash skeleton", () => {
     expect(pkg.bin["kj-trash"]).toBe("bin/kj-trash.js");
   });
 
-  it("declares AGPL-3.0 license and node >=22.22.1", () => {
+  // Floor aligned with KJC-BUG-0111 (#1213): 22.12.0 is the runtime-real
+  // minimum — the old >=22.22.1 silently pushed installers to an ancient kj.
+  it("declares AGPL-3.0 license and the runtime-real node floor", () => {
     expect(pkg.license).toBe("AGPL-3.0");
-    expect(pkg.engines?.node).toBe(">=22.22.1");
+    expect(pkg.engines?.node).toBe(">=22.12.0");
   });
 });


### PR DESCRIPTION
## Qué
Cierra KJC-BUG-0095: el instalador escribía la línea desnuda `kj-trash hook` en el PreToolUse global — si el bin cae del PATH (cambio de versión de nvm, reinstalación global), el hook falla con exit 127 que Claude Code no bloquea: **la red anti-borrados se cae sin ningún aviso**.

- La línea instalada ahora **falla CERRADA**: sin bin resoluble, bloquea la tool call (exit 2) nombrando la red caída y el remedio (`npm i -g karajan-code` o quitar el hook) — nunca un pass-through silencioso.
- **Migración in situ**: el instalador reemplaza la línea vieja al reinstalar, deduplicada (catch de codex: una entrada con línea vieja Y nueva acaba con UNA copia).
- Test de comportamiento real: `/bin/sh -c` sin bin → exit 2 con el aviso; con bin en PATH → delega intacto.
- De paso: rojo PREEXISTENTE en la suite de ai-trash (invisible porque no corre en el CI raíz): su smoke aseguraba engines `>=22.22.1` cuando el suelo real es `>=22.12.0` desde KJC-BUG-0111 (#1213). Alineado.

Suites verdes: ai-trash 76/76 · raíz completa exit 0 · lint 0 · APPROVED por codex · 86 ins / 4 del.
Card: KJC-BUG-0095