### PR TITLE
fix(sonar): declare multicriteria once — last-wins un-ignored rules (KJC-BUG-0139)

### DIFF
--- a/src/sonar/scanner.js
+++ b/src/sonar/scanner.js
@@ -47,13 +47,17 @@ export function buildScannerOpts(projectKey, scanner = {}) {
     opts.push(`-Dsonar.javascript.lcov.reportPaths=${scanner.javascript_lcov_report_paths}`);
   }
   const rules = scanner.disabled_rules || [];
-  rules.forEach((rule, i) => {
-    opts.push(
-      `-Dsonar.issue.ignore.multicriteria=e${i + 1}`,
-      `-Dsonar.issue.ignore.multicriteria.e${i + 1}.ruleKey=${rule}`,
-      `-Dsonar.issue.ignore.multicriteria.e${i + 1}.resourceKey=**/*`
-    );
-  });
+  if (rules.length > 0) {
+    // KJC-BUG-0139: the list property is declared ONCE — one `multicriteria=`
+    // per rule was last-wins, silently un-ignoring every rule but the final one.
+    opts.push(`-Dsonar.issue.ignore.multicriteria=${rules.map((_, i) => `e${i + 1}`).join(",")}`);
+    rules.forEach((rule, i) => {
+      opts.push(
+        `-Dsonar.issue.ignore.multicriteria.e${i + 1}.ruleKey=${rule}`,
+        `-Dsonar.issue.ignore.multicriteria.e${i + 1}.resourceKey=**/*`
+      );
+    });
+  }
   return opts.join(" ");
 }
 

--- a/tests/sonar/sonar-scanner.test.js
+++ b/tests/sonar/sonar-scanner.test.js
@@ -24,17 +24,26 @@ describe("[opt-in: sonar] buildScannerOpts", () => {
     expect(result).toContain("-Dsonar.javascript.lcov.reportPaths=coverage/lcov.info");
   });
 
-  it("generates disabled_rules with multicriteria syntax", () => {
+  // KJC-BUG-0139: one `multicriteria=` property PER RULE meant last-wins —
+  // with [S1116, S3776] only S3776 was really ignored. The property must be
+  // declared ONCE with the full entry list; sub-properties stay per rule.
+  it("declares multicriteria ONCE with the full entry list (KJC-BUG-0139)", () => {
     const scanner = {
       disabled_rules: ["javascript:S1116", "javascript:S3776"]
     };
     const result = buildScannerOpts("proj", scanner);
-    expect(result).toContain("-Dsonar.issue.ignore.multicriteria=e1");
+    expect(result).toContain("-Dsonar.issue.ignore.multicriteria=e1,e2");
+    expect(result.match(/-Dsonar\.issue\.ignore\.multicriteria=/g)).toHaveLength(1);
     expect(result).toContain("-Dsonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S1116");
     expect(result).toContain("-Dsonar.issue.ignore.multicriteria.e1.resourceKey=**/*");
-    expect(result).toContain("-Dsonar.issue.ignore.multicriteria=e2");
     expect(result).toContain("-Dsonar.issue.ignore.multicriteria.e2.ruleKey=javascript:S3776");
     expect(result).toContain("-Dsonar.issue.ignore.multicriteria.e2.resourceKey=**/*");
+  });
+
+  it("a single disabled rule still declares the list form", () => {
+    const result = buildScannerOpts("proj", { disabled_rules: ["javascript:S1116"] });
+    expect(result).toContain("-Dsonar.issue.ignore.multicriteria=e1");
+    expect(result).toContain("-Dsonar.issue.ignore.multicriteria.e1.ruleKey=javascript:S1116");
   });
 
   it("works without scanner config (backward compatible)", () => {


### PR DESCRIPTION
## Qué
Cierra KJC-BUG-0139 (hallado durante la 0540): `buildScannerOpts` declaraba `sonar.issue.ignore.multicriteria` UNA VEZ POR REGLA — la última definición pisa a las anteriores, así que con los defaults `[S1116, S3776]` solo S3776 quedaba ignorada de verdad: S1116 llevaba reportándose en todos los scans de kj pese a estar 'deshabilitada'.

Fix: la propiedad-lista se declara UNA vez con todas las entradas (`=e1,e2,…`) y las sub-propiedades siguen por regla. El test viejo fijaba justo el formato roto — reescrito al contrato correcto (propiedad única, aserción de que solo aparece una vez) + caso de regla única. cloud-scanner no emite multicriteria (sin cambio).

Suite completa verde exit 0 · lint 0 · APPROVED por codex · 23 ins / 10 del.
Card: KJC-BUG-0139