### PR TITLE
chore(release): v4.16.0 — no gate goes down silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.16.0] - 2026-08-10
+
 ### Fixed
 
 - **Disabled sonar rules are ALL ignored now** (KJC-BUG-0139, PR #1411): `buildScannerOpts` declared `sonar.issue.ignore.multicriteria` once per rule — last definition wins, so with the default `[S1116, S3776]` only S3776 was really ignored and S1116 kept reporting on every kj scan despite being "disabled". The list property is now declared once with every entry; the old test locked the broken shape and was rewritten to the real contract.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ From v2.0, Karajan introduces the **Karajan Brain** layer: an AI-powered orchest
 
 ```
 karajan-code/
-├── src/              # Source code (67k LOC, 557 files)
+├── src/              # Source code (67k LOC, 558 files)
 ├── tests/            # Test suite (511 test files)
 ├── templates/        # Role definitions (MD) + skill docs + workflows
 ├── docs/             # Documentation (you are here)

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verify:
 ```bash
-kj --version    # 4.15.0
+kj --version    # 4.16.0
 kj doctor       # Check environment
 ```
 

--- a/docs/es/GETTING-STARTED.md
+++ b/docs/es/GETTING-STARTED.md
@@ -58,7 +58,7 @@ npm install -g karajan-code
 
 Verifica:
 ```bash
-kj --version    # 4.15.0
+kj --version    # 4.16.0
 kj doctor       # Comprobar entorno
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karajan-code",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Local multi-agent coding orchestrator with TDD, SonarQube, and code review pipeline",
   "type": "module",
   "license": "AGPL-3.0",


### PR DESCRIPTION
## v4.16.0

Tema: ningún guardarraíl se cae en silencio — cada gate o verifica de verdad, o dice a qué nivel está verificando.

- **card-first contra el tracker declarado** (KJC-TSK-0732, issue #1371): con `board.verify_cmd`, la card de la rama se verifica VIVA en el tracker real; inverificable degrada DICIÉNDOLO.
- **Installs del Brain sin lifecycle scripts** (KJC-BUG-0099): un npm install autónomo ya no es ejecución arbitraria de código.
- **verify-pack aislado del repo anfitrión + tripwire** (KJC-BUG-0135): el smoke pnpm no puede volver a tocar el árbol del host, y si lo hiciera el gate falla nombrándolo.
- **kj-trash falla cerrado** (KJC-BUG-0095): bin fuera del PATH ⇒ bloqueo con remedio, nunca red caída sin aviso.
- **multicriteria se declara una vez** (KJC-BUG-0139): TODAS las disabled_rules se ignoran de verdad (S1116 llevaba reportándose).
- **Gate Sonar del proyecto en OK** (KJC-TSK-0540): periodo 30 días, cobertura real 83.8%, hotspots revisados con justificación, 15 violations arregladas.

Bump + CHANGELOG [4.16.0] + GETTING-STARTED EN/ES + stats. verify-pack ✓ (con su propio aislamiento nuevo). Release check verde salvo landing-current (post-publish).

Tras el merge: tag → GH Release + SEA → npm publish (OTP) → card KJL + issue de landing → 'Shipped in' en #1371.