### PR TITLE
feat(sentinel): lane boundary — each session mutates only its worktree (KJC-TSK-0737)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -49,6 +49,21 @@ export const branchOf = () => {
   try { return execSync("git rev-parse --abbrev-ref HEAD", { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); }
   catch { return null; }
 };
+const _git = (args, cwd) => {
+  try { return execSync("git " + args, { cwd, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); } catch { return ""; }
+};
+let _home;
+// MONO-0 (ADR 0002): lane identity = worktree toplevel; repo identity =
+// git-common-dir. Same repo but another toplevel than OUR root => foreign
+// lane (returns its toplevel); anything else => null.
+export const foreignLane = (targetDir) => {
+  const top = _git("rev-parse --show-toplevel", targetDir);
+  if (!top) return null;
+  _home ||= { top: _git("rev-parse --show-toplevel", ROOT), common: _git("rev-parse --path-format=absolute --git-common-dir", ROOT) };
+  if (!_home.top || top === _home.top) return null;
+  const common = _git("rev-parse --path-format=absolute --git-common-dir", targetDir);
+  return common && common === _home.common ? top : null;
+};
 export const violations = (s, branch) => {
   const v = [];
   if (!s || !(s.edited_sources || []).length) return v;
@@ -177,9 +192,10 @@ const PRETOOL_BODY = `#!/usr/bin/env node
 // before the damage, not in the post-mortem. Exit 2 blocks (stderr says the
 // remediation); read-only tools are never wired here; every honored escape
 // is recorded as an auditable event. Fails OPEN on anything unexpected.
-import { relative } from "node:path";
+import { dirname, relative, resolve } from "node:path";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, load, violations, recordEscape } from "./sentinel-lib.mjs";
+import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, foreignLane, load, violations, recordEscape } from "./sentinel-lib.mjs";
 const EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
 const PUBLISH = /\\bnpm\\s+publish\\b|\\bfirebase\\s+deploy\\b|\\bgh\\s+release\\s+create\\b/;
 const PUSH = /\\bgit\\s+push\\b/;
@@ -210,6 +226,109 @@ process.stdin.on("end", () => {
       process.exit(2);
     }
     if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
+    // MONO-0 (KJC-TSK-0737, ADR 0002): cada sesion muta solo SU worktree;
+    // otro carril del MISMO repo se deniega ANTES del dano. Lectura libre.
+    const laneOf = (p) => {
+      // Sube al primer ancestro EXISTENTE (un subdir aun no creado escapaba).
+      let d = String(p);
+      if (!(existsSync(d) && statSync(d).isDirectory())) d = dirname(d);
+      while (d && !existsSync(d)) {
+        const up = dirname(d);
+        if (up === d) return null;
+        d = up;
+      }
+      // Canonicaliza (reviewer catch: un symlink local hacia otro carril
+      // esquivaba la clasificacion por ruta literal).
+      try { d = realpathSync(d); } catch { /* se clasifica tal cual */ }
+      return d ? foreignLane(d) : null;
+    };
+    const laneDeny = (what, lane) => {
+      if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); return false; }
+      console.error("kj sentinel: " + what + " vive en otro carril (" + lane + ") de este repo — cada sesion muta solo SU worktree (MONO-0). Cruce deliberado: KJ_ALLOW_CROSS_LANE=1, queda registrado.");
+      return true;
+    };
+    if (EDIT_TOOLS.includes(tool)) {
+      const target = input.file_path || input.notebook_path;
+      const lane = target ? laneOf(target) : null;
+      if (lane && laneDeny(String(target), lane)) process.exit(2);
+    }
+    if (tool === "Bash") {
+      const cmd = String(input.command || "");
+      // Deny-unless-known-read-only: un allowlist de verbos mutadores era
+      // esquivable (dd, interpretes). Solo un comando SIMPLE de lectura (sin
+      // encadenar ni redirigir) puede nombrar otro carril; leer carriles es
+      // trabajo de las tools Read/Grep, como con los ficheros del supervisor.
+      // Solo LITERALES: expansión/sustitución en un comando "de lectura"
+      // puede ejecutar cualquier cosa (reviewer catch: grep foo $(rm ...)).
+      // (find fuera: -delete/-exec mutan — reviewer catch; sus tokens de
+      // carril los caza el escaner de abajo.)
+      const READONLY = /^[ \\t]*(grep|rg|cat|head|tail|less|ls|wc|diff|stat|file|du|tree|git (log|show|diff|status|blame))\\b[^;|&<>$\`(){}\\n\\r]*$/;
+      if (!READONLY.test(cmd)) {
+        // cd/pushd invalida TODO razonamiento textual de rutas posteriores
+        // (carrera de bypasses confirmada en review: destino bare, con $,
+        // relativas post-cd...): en un comando NO-read-only, cambiar de
+        // directorio se deniega conservadoramente — el remedio es no
+        // necesitarlo (git -C, npm --prefix, rutas absolutas).
+        if (/(^|[;&|(\\s])(cd|pushd)([ \\t]|$)/.test(cmd)) {
+          if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); }
+          else {
+            console.error("kj sentinel: cd/pushd en un comando mutador — las rutas posteriores no son verificables por el guard de carriles (MONO-0); usa git -C / npm --prefix / rutas ABSOLUTAS sin cd (o KJ_ALLOW_CROSS_LANE=1, queda registrado).");
+            process.exit(2);
+          }
+        }
+        // Absolute AND dot-relative tokens (../lane escapaba al primer scan —
+        // reviewer catch); relative se resuelve contra el cwd de la sesion.
+        // EVERY token (un tope seria un bypass); dedup acota el coste git.
+        // Fallo de solomon (seguridad no arbitrable) + carrera de bypasses:
+        // la expansion ($, backtick) solo se tolera en segmentos que son
+        // asignaciones puras o runners del toolchain propio (npm/pnpm/yarn/
+        // vitest/jest/kj/gh/echo/printf, git sin -C/--git-dir/--work-tree) —
+        // sus argumentos son datos. En herramientas genericas de fichero o
+        // interpretes el objetivo queda oculto al texto => deny. Los paths
+        // LITERALES (tambien dentro de sustituciones) los escanea el bucle
+        // de tokens de abajo; el residuo (expansion anidada en segmentos
+        // runner) queda documentado como en la regla de ficheros PROTECTED.
+        if (/>{1,2}[ \\t]*["']?[\\$\`]/.test(cmd)) {
+          if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); }
+          else {
+            console.error("kj sentinel: redireccion con destino tras variable/sustitucion — el guard de carriles no puede verificarlo (MONO-0); usa una ruta LITERAL (o KJ_ALLOW_CROSS_LANE=1, queda registrado).");
+            process.exit(2);
+          }
+        }
+        // Sustitucion de comandos ($(...) o backticks) EJECUTA su contenido
+        // en cualquier posicion, y una ruta entrecomillada con espacios es
+        // invisible al tokenizador: ambas => deny conservador (endpoint
+        // pedido por el reviewer; friccion asumida, el remedio es literal).
+        if (/\\$\\(|\`/.test(cmd) || /["'][^"'\\n]*\\/[^"'\\n]* [^"'\\n]*["']/.test(cmd)) {
+          if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); }
+          else {
+            console.error("kj sentinel: sustitucion de comandos o ruta entrecomillada con espacios en un comando mutador — no verificable por el guard de carriles (MONO-0); usa valores/rutas LITERALES sin sustitucion (o KJ_ALLOW_CROSS_LANE=1, queda registrado).");
+            process.exit(2);
+          }
+        }
+        const SAFE_EXP_SEG = /^([A-Za-z_][A-Za-z0-9_]*=[^ \\t]*[ \\t]*)*((npm|pnpm|yarn|vitest|jest|kj|gh|echo|printf|true|test)\\b|git[ \\t](?![^\\n]*(-C[ \\t]|--git-dir|--work-tree)))[^;|&\\n]*$|^[A-Za-z_][A-Za-z0-9_]*=[^;|&\\n]*$/;
+        const segs = cmd.split(/&&|\\|\\||[;|\\n]/).map((s) => s.trim()).filter(Boolean);
+        if (!segs.every((s) => !/[\\$]/.test(s) || SAFE_EXP_SEG.test(s))) {
+          if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); }
+          else {
+            console.error("kj sentinel: expansion de shell en una herramienta generica de fichero/interprete — el objetivo no es verificable por el guard de carriles (MONO-0); usa rutas LITERALES o un runner del toolchain (o KJ_ALLOW_CROSS_LANE=1, queda registrado).");
+            process.exit(2);
+          }
+        }
+        // ...incluidas relativas A PELO (los carriles kj viven en
+        // .kj/worktrees/). Un falso token (s/a/b/) resuelve al arbol propio
+        // y foreignLane da null — solo deniega lo que CAE en otro carril.
+        const seen = new Set();
+        for (const m of cmd.matchAll(/(?:^|[\\s"'=;(><])((?:\\.\\.?\\/)[^\\s"'\`;|&)]*|\\/[^\\s"'\`;|&)]+|~\\/[^\\s"'\`;|&)]+|[A-Za-z0-9_.@-]+\\/[^\\s"'\`;|&)]+)/g)) {
+          const t = m[1].startsWith("~/") ? (process.env.HOME || "~") + m[1].slice(1) : m[1];
+          const abs = resolve(t);
+          if (seen.has(abs)) continue;
+          seen.add(abs);
+          const lane = laneOf(abs);
+          if (lane && laneDeny(m[1], lane)) process.exit(2);
+        }
+      }
+    }
     if (EDIT_TOOLS.includes(tool)) {
       const file = input.file_path || input.notebook_path;
       const rel = file ? relative(ROOT, String(file)).replaceAll("\\\\", "/") : "";

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -232,6 +232,145 @@ describe("sentinel-lib (shared single source)", () => {
   });
 });
 
+// MONO-0 (KJC-TSK-0737, ADR 0002) — lane boundary: a session mutates only
+// ITS worktree. Same repo (git-common-dir) + another toplevel ⇒ deny BEFORE
+// the damage; reads and non-repo paths untouched; the escape is audited.
+describe("pretooluse-sentinel lane boundary (MONO-0)", () => {
+  let gate, lane;
+  beforeEach(() => {
+    gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+    lane = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "kj-lane-")), "wt");
+    execSync(`git worktree add --detach ${lane}`, { cwd: dir });
+    fs.mkdirSync(path.join(lane, "src"), { recursive: true });
+    fs.writeFileSync(path.join(lane, "src", "x.js"), "x");
+  });
+  afterEach(() => {
+    execSync(`git worktree remove --force ${lane}`, { cwd: dir });
+  });
+  const laneEdit = () => ({ session_id: "s1", tool_name: "Edit", tool_input: { file_path: path.join(lane, "src", "x.js") } });
+
+  it("denies an Edit into a sibling worktree of the same repo, naming the lane", () => {
+    const res = run(gate, laneEdit());
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("carril");
+    expect(res.stderr).toContain(lane);
+  });
+
+  it("KJ_ALLOW_CROSS_LANE=1 passes AND records the auditable escape", () => {
+    const res = run(gate, laneEdit(), { KJ_ALLOW_CROSS_LANE: "1" });
+    expect(res.status).toBe(0);
+    expect(state().escape_events.some((e) => e.escape === "KJ_ALLOW_CROSS_LANE")).toBe(true);
+  });
+
+  it("denies Bash that mutates a sibling-lane path; read-only Bash passes", () => {
+    const mut = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `sed -i s/a/b/ ${path.join(lane, "src", "x.js")}` } });
+    expect(mut.status).toBe(2);
+    expect(mut.stderr).toContain("carril");
+    const wipe = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `rm -rf ${lane}` } });
+    expect(wipe.status).toBe(2);
+    const ro = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `grep -rn foo ${path.join(lane, "src")}` } });
+    expect(ro.status).toBe(0);
+  });
+
+  it("expansion hiding a destructive target is denied; benign $ usage passes (solomon ruling)", () => {
+    const bash = (command, env = {}) => run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command } }, env);
+    expect(bash("rm -rf $LANE").status).toBe(2);
+    expect(bash("echo hi > $OUT").status).toBe(2);
+    expect(bash("tee `cat target`").status).toBe(2);
+    expect(bash("rm -rf $LANE", { KJ_ALLOW_CROSS_LANE: "1" }).status).toBe(0);
+    // Multilinea nunca es "lectura simple" (reviewer catch): la 2a linea muta.
+    expect(bash(`git status\nsed -i s/a/b/ ${path.join(lane, "src", "x.js")}`).status).toBe(2);
+    // Expansion en herramienta generica (chmod/touch/interprete): deny.
+    expect(bash("chmod 755 $F").status).toBe(2);
+    expect(bash('python -c "open(\'$F\')"').status).toBe(2);
+    // find muta con -delete/-exec: no es read-only y sus paths se escanean.
+    expect(bash(`find ${path.join(lane, "src")} -delete`).status).toBe(2);
+    // A "read-only" verb with substitution is NOT read-only (reviewer catch).
+    expect(bash(`grep foo $(true) ${path.join(lane, "src")}`.replace("$(true)", "$(rm -rf $L)")).status).toBe(2);
+    // Command substitution EXECUTES anywhere — denied even in runner args;
+    // plain $VARs in toolchain-runner segments stay allowed.
+    expect(bash('git commit -m "release $(date +%F)"').status).toBe(2);
+    expect(bash("FOO=$BAR npm test").status).toBe(0);
+    expect(bash("git commit -m $MSG").status).toBe(0);
+  });
+
+  it("bare relative paths into an in-tree lane (.kj/worktrees/…) are denied; sed patterns never false-positive (reviewer catch)", () => {
+    const inTree = path.join(dir, ".kj", "worktrees", "wt2");
+    execSync(`git worktree add --detach ${inTree}`, { cwd: dir });
+    fs.mkdirSync(path.join(inTree, "src"), { recursive: true });
+    fs.writeFileSync(path.join(inTree, "src", "x.js"), "x");
+    const spawn = (command) => spawnSync("node", [gate], {
+      input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command } }),
+      encoding: "utf8", cwd: dir, env: { ...process.env },
+    });
+    const bare = spawn("sed -i s/a/b/ .kj/worktrees/wt2/src/x.js");
+    expect(bare.status).toBe(2);
+    expect(bare.stderr).toContain("carril");
+    const sedOnly = spawn("sed -i s/a/b/ notas.txt");
+    expect(sedOnly.status).toBe(0);
+    // cd/pushd en comando mutador: deny conservador SIEMPRE — bare, con $,
+    // o relativas post-cd, todas las variantes de la carrera de bypasses.
+    for (const evil of ["cd .kj/worktrees/wt2 && rm x.js", "cd $L && rm x.js", "cd .kj/worktrees && rm -rf wt2"]) {
+      const res = spawn(evil);
+      expect(res.status).toBe(2);
+      expect(res.stderr).toContain("cd");
+    }
+    execSync(`git worktree remove --force ${inTree}`, { cwd: dir });
+  });
+
+  it("a local symlink into a foreign lane is canonicalized and denied (reviewer catch)", () => {
+    fs.symlinkSync(path.join(lane, "src"), path.join(dir, "sneaky"));
+    const res = run(gate, { session_id: "s1", tool_name: "Edit", tool_input: { file_path: path.join(dir, "sneaky", "x.js") } });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("carril");
+  });
+
+  it("cd/pushd in any mutating command is denied conservatively; mutating without cd in own tree passes", () => {
+    const res = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "cd /tmp && rm -rf ../whatever" } });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("cd");
+    const own = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `rm -f ${path.join(dir, "notas.txt")}` } });
+    expect(own.status).toBe(0);
+  });
+
+  it("a write under a NOT-yet-existing lane subdir is denied — walks up to an existing ancestor (reviewer catch)", () => {
+    const res = run(gate, { session_id: "s1", tool_name: "Write", tool_input: { file_path: path.join(lane, "newdir", "deep", "file.js") } });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("carril");
+  });
+
+  it("unlisted mutators and cd-chains into a lane are denied — deny-unless-read-only (reviewer catch)", () => {
+    const dd = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `dd if=/dev/zero of=${path.join(lane, "src", "img")} count=1` } });
+    expect(dd.status).toBe(2);
+    const cdChain = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `cd ${lane} && make build` } });
+    expect(cdChain.status).toBe(2);
+  });
+
+  it("a redirection glued to the path (>/lane/file) is denied too (reviewer catch)", () => {
+    const res = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: `echo x >${path.join(lane, "src", "out.txt")}` } });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("carril");
+  });
+
+  it("relative ../ paths into a sibling lane are resolved and denied too (reviewer catch)", () => {
+    const rel = path.relative(dir, path.join(lane, "src", "x.js"));
+    const res = spawnSync("node", [gate], {
+      input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command: `sed -i s/a/b/ ${rel}` } }),
+      encoding: "utf8",
+      cwd: dir,
+      env: { ...process.env },
+    });
+    expect(res.status).toBe(2);
+    expect(res.stderr).toContain("carril");
+  });
+
+  it("same-tree edits and non-repo paths stay untouched", () => {
+    expect(run(gate, editTool(path.join(dir, "src", "ok.js"))).status).toBe(0);
+    const outside = path.join(os.tmpdir(), "kj-nolane-note.md");
+    expect(run(gate, { session_id: "s1", tool_name: "Write", tool_input: { file_path: outside } }).status).toBe(0);
+  });
+});
+
 describe("installSentinelHooks settings merge", () => {
   it("wires PostToolUse and Stop idempotently, preserving the user's entries", () => {
     const settings = path.join(dir, ".claude", "settings.json");


### PR DESCRIPTION
## Qué (MONO-0, épica KJC-PCS-0075, ADR 0002)
El PreToolUse del Sentinel gana la frontera de carril: **cada sesión muta solo SU worktree** — otro carril del MISMO repo (identidad: toplevel; repo: git-common-dir) se deniega ANTES del daño, con lectura libre (tools Read/Grep) y escape auditado `KJ_ALLOW_CROSS_LANE=1` (recordEscape → systemMessage/report). Prerequisito de seguridad de la fusión monorepo: la colisión de dos sesiones sobre un árbol fue real (2026-08-08).

**Forjado por 12 rondas de review cruzada + 2 arbitrajes de solomon** (la razón del tamaño — ver etiqueta):
- Edit/Write: clasificación canonicalizada (symlinks), ancestro existente para subdirs aún no creados.
- Bash: deny-unless-read-only con lecturas SOLO literales y monolinea; escáner de tokens absolutos/dot-relativos/bare/~ (sin tope — un cap era bypass; dedup acota coste); redirecciones pegadas; cd/pushd en comando mutador = deny conservador (el razonamiento textual post-cd es insostenible — remedio: git -C / npm --prefix / rutas absolutas); sustitución de comandos y rutas entrecomilladas con espacios = deny; $VAR solo tolerado en segmentos de runners del toolchain (npm/yarn/git-sin-C/gh/kj…).
- Arbitraje 1 (agy→falló a reviewer): seguridad no arbitrable → indirección cerrada. Arbitraje 2 (copilot→falló a brain): re-ampliar la lista read-only reabría los bypasses de las rondas 3-8 — la frontera estricta se queda.
- Complementa el hook global del usuario (MONO-0a, ya desplegado) — misma semántica en las dos capas.

Suite completa verde exit 0 · lint 0 · 32 tests del sentinel (todos los bypasses cazados tienen su regresión) · gate abierto por veredicto de arbitraje.

**LOC 258 > 200 — `large-pr-justified`**: es UNA frontera de seguridad indivisible; partirla desacoplaría los veredictos (atados al sha256 del diff exacto) de la lógica endurecida ronda a ronda, y cada mitad sería insegura por separado.
Card: KJC-TSK-0737