### PR TITLE
fix(test): root vitest excludes apps and nested node_modules (monorepo fallout)

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,7 +16,10 @@ export default defineConfig({
     },
   },
   test: {
-    exclude: ["node_modules/**", "packages/**", ".claude/**", ".kj/**", "demo/**"],
+    // apps/** y **/node_modules/**: los paquetes fusionados (ADR 0002) traen
+    // sus propias suites y, tras un deploy local de la landing, node_modules
+    // anidados que el patrón de primer nivel no cubría.
+    exclude: ["**/node_modules/**", "packages/**", "apps/**", ".claude/**", ".kj/**", "demo/**"],
     setupFiles: ["./tests/setup.js"],
     // KJC-BUG-0075: mtime-based purge of stale `karajan-vitest-*` tmp dirs
     // (>24 h) as a safety net for SIGKILL'd / crashed forks that miss the


### PR DESCRIPTION
El vitest raíz descubría los tests de node_modules anidados (apps/landing/functions tras un deploy local) porque el patrón de primer nivel no cubre profundidad, y apps/** no existía cuando se escribió el exclude. Una línea; suite raíz de vuelta a 6540 verdes.