### PR TITLE
feat(policy): glob primitive — anchored, tiny, dependency-free (KJC-TSK-0733)

### DIFF
--- a/src/policy/glob.js
+++ b/src/policy/glob.js
@@ -1,0 +1,35 @@
+// glob → RegExp anclada — primitivo de la policy layer (PL-A, KJC-TSK-0733).
+// Semántica: doble asterisco cruza directorios; doble asterisco + barra es
+// prefijo de directorio OPCIONAL (así "**" "/*.env*" casa también con .env
+// en la raíz); "*" no sale de su segmento; "?" es un carácter. Sin
+// dependencias: el vocabulario es pequeño a propósito — una lib general
+// traería semánticas que la policy no declara.
+export function globToRegExp(glob) {
+  let re = "";
+  const s = String(glob);
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "*") {
+      if (s[i + 1] === "*") {
+        if (s[i + 2] === "/") {
+          re += "(?:.*/)?";
+          i += 2;
+        } else {
+          re += ".*";
+          i++;
+        }
+      } else {
+        re += "[^/]*";
+      }
+    } else if (c === "?") {
+      re += "[^/]";
+    } else {
+      re += c.replaceAll(/[.+^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** true si `value` casa con ALGUNO de los globs (lista no-array ⇒ false). */
+export const matchesAny = (value, globs) =>
+  Array.isArray(globs) && globs.some((g) => globToRegExp(g).test(value));

--- a/tests/policy/glob.test.js
+++ b/tests/policy/glob.test.js
@@ -1,0 +1,34 @@
+// PL-A (KJC-TSK-0733) — el primitivo glob de la policy: semántica pequeña,
+// anclada y SIN sorpresas de lib general.
+import { describe, it, expect } from "vitest";
+import { globToRegExp, matchesAny } from "../../src/policy/glob.js";
+
+describe("globToRegExp", () => {
+  it("** cruza directorios, * no sale de su segmento, ? es un carácter", () => {
+    expect(globToRegExp("src/**").test("src/a/b/c.js")).toBe(true);
+    expect(globToRegExp("src/*.js").test("src/a.js")).toBe(true);
+    expect(globToRegExp("src/*.js").test("src/a/b.js")).toBe(false);
+    expect(globToRegExp("src/?.js").test("src/a.js")).toBe(true);
+    expect(globToRegExp("src/?.js").test("src/ab.js")).toBe(false);
+    expect(globToRegExp("src/**").test("srcx/a.js")).toBe(false);
+  });
+
+  it("**/ es prefijo de directorio OPCIONAL — casa en la raíz (reviewer catch)", () => {
+    expect(globToRegExp("**/*.env*").test("deep/dir/.env.local")).toBe(true);
+    expect(globToRegExp("**/*.env*").test(".env.local")).toBe(true);
+  });
+
+  it("los metacaracteres de regex del glob quedan inertes", () => {
+    expect(globToRegExp("a+b(c).js").test("a+b(c).js")).toBe(true);
+    expect(globToRegExp("a+b.js").test("aab.js")).toBe(false);
+  });
+});
+
+describe("matchesAny", () => {
+  it("lista válida casa; lista malformada (no-array) es false, nunca crash", () => {
+    expect(matchesAny("src/a.js", ["docs/**", "src/**"])).toBe(true);
+    expect(matchesAny("src/a.js", ["docs/**"])).toBe(false);
+    expect(matchesAny("src/a.js", "src/**")).toBe(false);
+    expect(matchesAny("src/a.js", undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Qué (PL-A parte 1 de 3, épica KJC-PCS-0074, ADR 0001)
El primitivo de matching de la policy layer: `globToRegExp` anclada (`**` cruza directorios; `**/` es prefijo OPCIONAL — catch del reviewer: `**/*.env*` debe casar también con `.env` en raíz; `*` no sale de su segmento) y `matchesAny` que jamás revienta con listas malformadas. Sin dependencia nueva: el vocabulario es pequeño a propósito — una lib general traería semánticas que la policy no declara. Partido del motor para respetar el gate LOC (el conjunto medía 214+).
Siguiente: parte 2 = motor (load fail-loud + eval de write); parte 3 = shell + gate de resultado + CLI.
Suite verde · lint 0 · APPROVED por codex · neto 71.
Card: KJC-TSK-0733