### PR TITLE
feat(policy): engine — fail-loud load and write-capability evaluation (KJC-TSK-0733)

### DIFF
--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -1,0 +1,146 @@
+/**
+ * policy engine — PL-A (KJC-TSK-0733, épica KJC-PCS-0074, ADR 0001).
+ * Policy as DATA (`.karajan/policy.yml`, vocabulario CERRADO), engine as
+ * code: módulo puro, determinista, sin red ni LLM. Una regla que el motor
+ * no puede aplicar falla FUERTE al cargar — jamás se ignora en silencio.
+ * Deny gana a allow; una allow-list convierte el exterior en denegación.
+ * Consumidores: kj policy (PL-A) → gates PL-B → CI PL-C → middleware PL-D.
+ */
+import { readFileSync } from "node:fs";
+import { isAbsolute, join, posix, relative } from "node:path";
+import yaml from "js-yaml";
+import { matchesAny } from "./glob.js";
+
+// Vocabulario CERRADO e incremental: cada capacidad entra al set EN el PR
+// que trae su evaluación — declararla antes sería una regla que miente.
+const ROLE_CAPS = new Set(["write"]);
+const INVARIANT_KINDS = new Set([]);
+const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+// Registro de tools conocidas (fallo de solomon: lo desconocido no se
+// permite a un rol DECLARADO — crece por PR consciente). Bash es conocida:
+// su capacidad shell se evalúa cuando el kind entre al vocabulario.
+const READONLY_TOOLS = new Set(["Read", "Grep", "Glob", "LS", "WebFetch", "WebSearch"]);
+const KNOWN_PENDING_TOOLS = new Set(["Bash"]);
+export const DEFAULT_POLICY = Object.freeze({ version: 1, roles: {}, invariants: [] });
+
+function defaultReadFile(projectDir) {
+  try {
+    return readFileSync(join(projectDir, ".karajan", "policy.yml"), "utf8");
+  } catch (err) {
+    // Solo ENOENT es "sin policy"; EACCES/EIO seria un fallback silencioso.
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * @returns {{policy: object, errors: string[]}} errors non-empty ⇒ the file
+ * declares something this engine cannot enforce — callers must surface it.
+ */
+export function loadPolicy({ projectDir = process.cwd(), deps = {} } = {}) {
+  const { readFile = defaultReadFile } = deps;
+  let raw;
+  try {
+    raw = readFile(projectDir);
+  } catch (err) {
+    return { policy: DEFAULT_POLICY, errors: [`policy.yml: ilegible (${err.code || err.message}) — presente pero no leible NO es "sin policy"`] };
+  }
+  if (raw == null) return { policy: DEFAULT_POLICY, errors: [] };
+
+  const errors = [];
+  let doc;
+  try {
+    doc = yaml.load(raw) || {};
+  } catch (err) {
+    return { policy: DEFAULT_POLICY, errors: [`policy.yml: YAML invalido — ${err.message}`] };
+  }
+  if (typeof doc !== "object" || Array.isArray(doc)) {
+    return { policy: DEFAULT_POLICY, errors: ["policy.yml: la raiz debe ser un objeto"] };
+  }
+  if (doc.version !== 1) {
+    errors.push(`policy.yml: version "${doc.version}" no soportada — este motor habla version 1`);
+  }
+  const roles = doc.roles ?? {};
+  if (typeof roles !== "object" || roles === null || Array.isArray(roles)) {
+    errors.push("policy.yml: roles debe ser un objeto");
+  } else {
+    validateRoles(roles, errors);
+  }
+  const invs = doc.invariants ?? [];
+  if (!Array.isArray(invs)) errors.push("policy.yml: invariants debe ser una lista");
+  else {
+    for (const inv of invs) {
+      if (!INVARIANT_KINDS.has(inv?.kind)) {
+        errors.push(`policy.yml: invariant "${inv?.id}" con kind "${inv?.kind}" no existe en el vocabulario v1`);
+      }
+    }
+  }
+  return { policy: { roles: {}, invariants: [], ...doc }, errors };
+}
+
+function validateRoles(roles, errors) {
+  for (const [role, caps] of Object.entries(roles)) {
+    for (const [cap, spec] of Object.entries(caps || {})) {
+      if (!ROLE_CAPS.has(cap)) {
+        errors.push(`policy.yml: roles.${role}.${cap} no existe en el vocabulario (v1: ${[...ROLE_CAPS].join(", ")})`);
+        continue;
+      }
+      if (typeof spec !== "object" || spec === null || Array.isArray(spec)) {
+        errors.push(`policy.yml: roles.${role}.${cap} debe ser un objeto {allow, deny}`);
+        continue;
+      }
+      for (const key of Object.keys(spec)) {
+        if (key !== "allow" && key !== "deny") {
+          errors.push(`policy.yml: roles.${role}.${cap}.${key} no existe en el vocabulario (v1: allow, deny)`);
+        }
+      }
+      for (const list of ["allow", "deny"]) {
+        const v = spec?.[list];
+        if (v !== undefined && (!Array.isArray(v) || v.some((g) => typeof g !== "string"))) {
+          errors.push(`policy.yml: roles.${role}.${cap}.${list} debe ser una lista de strings (glob)`);
+        }
+      }
+    }
+  }
+}
+
+const deny = (rule_id, reason) => ({ decision: "deny", rule_id, reason });
+const ALLOW = Object.freeze({ decision: "allow" });
+
+// Normaliza el destino a ruta RELATIVA canónica: absolutas se relativizan
+// contra root (sin root ⇒ null), y `..`/escapes ⇒ null (reviewer catch:
+// src/../.env no puede esquivar los globs, ni una absoluta salirse del root).
+function normalizeTarget(filePath, root) {
+  let p = String(filePath).replaceAll("\\", "/");
+  if (isAbsolute(p)) {
+    if (!root) return null;
+    p = relative(root, p).replaceAll("\\", "/");
+  }
+  p = posix.normalize(p).replace(/^\.\//, "");
+  return p.startsWith("..") || isAbsolute(p) ? null : p;
+}
+
+function evalWrite(policy, role, filePath, root) {
+  const write = policy.roles?.[role]?.write;
+  if (!write) return ALLOW;
+  // Rol restringido + destino ausente/no-canonizable = no verificable ⇒ deny
+  // (reviewer catches: tool call malformado, traversal, absoluta sin root).
+  const p = filePath ? normalizeTarget(filePath, root) : null;
+  if (p == null) return deny(`roles.${role}.write`, `destino "${filePath ?? ""}" no verificable contra la policy del rol ${role}`);
+  if (matchesAny(p, write.deny)) {
+    return deny(`roles.${role}.write.deny`, `${p} esta denegado para el rol ${role}`);
+  }
+  if (Array.isArray(write.allow) && !matchesAny(p, write.allow)) {
+    return deny(`roles.${role}.write.allow`, `${p} esta fuera de la allow-list de escritura del rol ${role}`);
+  }
+  return ALLOW;
+}
+
+/** One tool call against the policy. `root` permite evaluar file_path
+ *  absolutos. Un rol DECLARADO solo usa tools del registro: lo desconocido
+ *  es no-verificable ⇒ deny (roles sin declarar quedan como hoy). */
+export function evalToolCall(policy, { role = "coder", tool, input = {}, root = null }) {
+  if (WRITE_TOOLS.has(tool)) return evalWrite(policy, role, input.file_path || input.notebook_path, root);
+  if (READONLY_TOOLS.has(tool) || KNOWN_PENDING_TOOLS.has(tool) || !policy.roles?.[role]) return ALLOW;
+  return deny(`roles.${role}.tools`, `tool "${tool}" fuera del registro de la policy — no verificable para el rol declarado ${role}`);
+}

--- a/tests/policy/engine.test.js
+++ b/tests/policy/engine.test.js
@@ -1,0 +1,101 @@
+// KJC-TSK-0733 PL-A — policy as DATA (vocabulario cerrado, fail-loud al
+// cargar), engine as code (puro, fs inyectado, deny-wins).
+
+import { describe, it, expect } from "vitest";
+import { loadPolicy, evalToolCall } from "../../src/policy/engine.js";
+
+const load = (yamlText) =>
+  loadPolicy({ projectDir: "/p", deps: { readFile: () => yamlText } });
+
+const POLICY = `
+version: 1
+roles:
+  coder:
+    write:
+      allow: ["src/**", "tests/**"]
+      deny: ["**/*.env*", ".github/workflows/**"]
+  reviewer:
+    write: { allow: [] }
+`;
+
+describe("loadPolicy", () => {
+  it("no policy file ⇒ embedded defaults — today's behavior, zero constraints", () => {
+    const { policy, errors } = loadPolicy({ projectDir: "/p", deps: { readFile: () => null } });
+    expect(errors).toEqual([]);
+    expect(policy.version).toBe(1);
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "anything.js" } }).decision).toBe("allow");
+  });
+
+  it("everything undeclarable fails LOUD at load — closed vocabulary, strict shapes, one version", () => {
+    expect(load("version: 1\ninvariants:\n  - id: x\n    kind: quantum-vibes\n").errors.some((e) => e.includes("quantum-vibes"))).toBe(true);
+    expect(load("version: 1\nroles:\n  coder:\n    teleport: {}\n").errors.some((e) => e.includes("teleport"))).toBe(true);
+    // shell entra en la parte 2 CON su evaluación — hoy declararlo es error.
+    expect(load("version: 1\nroles:\n  coder:\n    shell: {deny: ['curl *']}\n").errors.some((e) => e.includes("shell"))).toBe(true);
+    expect(load("version: 7\n").errors.some((e) => e.includes("version"))).toBe(true);
+    expect(load("version: 1\ninvariants: nope\n").errors.some((e) => e.includes("lista"))).toBe(true);
+    expect(load('version: 1\nroles:\n  coder:\n    write: si\n').errors.some((e) => e.includes("objeto"))).toBe(true);
+    expect(load("version: 1\nroles:\n  coder:\n    write: {allw: ['src/**']}\n").errors.some((e) => e.includes("allw"))).toBe(true);
+  });
+
+  it("an unreadable policy file is an ERROR, never silently 'no policy' (reviewer catch)", () => {
+    const boom = () => { const e = new Error("denied"); e.code = "EACCES"; throw e; };
+    const { errors } = loadPolicy({ projectDir: "/p", deps: { readFile: boom } });
+    expect(errors.some((e) => e.includes("EACCES"))).toBe(true);
+  });
+
+  it("malformed shapes surface the error and never crash evaluation (reviewer catches)", () => {
+    const { policy, errors } = load('version: 1\nroles:\n  coder:\n    write: {deny: "src/**"}\n');
+    expect(errors.some((e) => e.includes("lista de strings"))).toBe(true);
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "src/a.js" } }).decision).toBe("allow");
+  });
+});
+
+describe("evalToolCall — write", () => {
+  const { policy } = load(POLICY);
+
+  it("deny WINS over allow (src/** allowed, .env denied inside it)", () => {
+    const r = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "src/.env.local" } });
+    expect(r.decision).toBe("deny");
+    expect(r.rule_id).toBe("roles.coder.write.deny");
+    expect(r.reason).toContain("src/.env.local");
+  });
+
+  it("an allow-list makes everything OUTSIDE it a denial", () => {
+    const r = evalToolCall(policy, { role: "coder", tool: "Edit", input: { file_path: "package.json" } });
+    expect(r).toMatchObject({ decision: "deny", rule_id: "roles.coder.write.allow" });
+    expect(evalToolCall(policy, { role: "coder", tool: "Edit", input: { file_path: "tests/a.test.js" } }).decision).toBe("allow");
+  });
+
+  it("an empty allow-list is a read-only role", () => {
+    const r = evalToolCall(policy, { role: "reviewer", tool: "Write", input: { file_path: "src/a.js" } });
+    expect(r.decision).toBe("deny");
+  });
+
+  it("unverifiable targets deny for constrained roles: missing, traversal, absolute-without-root (reviewer catches)", () => {
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: {} })).toMatchObject({ decision: "deny", rule_id: "roles.coder.write" });
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "src/../.env" } }).decision).toBe("deny");
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "../fuera/x.js" } }).decision).toBe("deny");
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "/abs/x.js" } }).decision).toBe("deny");
+    expect(evalToolCall(policy, { role: "tester", tool: "Write", input: {} }).decision).toBe("allow");
+  });
+
+  it("absolute paths WITH root are relativized and evaluated normally", () => {
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "/repo/src/a.js" }, root: "/repo" }).decision).toBe("allow");
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "/repo/src/.env" }, root: "/repo" }).decision).toBe("deny");
+    expect(evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "/otro/src/a.js" }, root: "/repo" }).decision).toBe("deny");
+  });
+
+  it("undeclared roles stay unconstrained; read-only tools are never writes", () => {
+    expect(evalToolCall(policy, { role: "tester", tool: "Write", input: { file_path: "x" } }).decision).toBe("allow");
+    expect(evalToolCall(policy, { role: "reviewer", tool: "Read", input: { file_path: "src/a.js" } }).decision).toBe("allow");
+  });
+
+  it("a DECLARED role using a tool outside the registry is denied — unknown is unverifiable (solomon ruling)", () => {
+    expect(evalToolCall(policy, { role: "coder", tool: "TeleportFiles", input: {} })).toMatchObject({ decision: "deny", rule_id: "roles.coder.tools" });
+    expect(evalToolCall(policy, { role: "tester", tool: "TeleportFiles", input: {} }).decision).toBe("allow");
+    // Bash es conocida (su kind shell llega en la parte 2) — no se deniega.
+    expect(evalToolCall(policy, { role: "coder", tool: "Bash", input: { command: "ls" } }).decision).toBe("allow");
+  });
+});
+
+// (globToRegExp/matchesAny se prueban en tests/policy/glob.test.js — #1429.)


### PR DESCRIPTION
## Qué (PL-A parte 2 de 3, épica KJC-PCS-0074, ADR 0001)
El motor de la policy layer: `src/policy/engine.js`, puro (fs inyectado, sin red, sin LLM), evaluando `.karajan/policy.yml` con vocabulario CERRADO v1 (`roles.<rol>.write` con allow/deny de globs). Sin fichero ⇒ defaults = comportamiento de hoy.

**Doctrina fail-loud forjada en 7 catches de codex + 2 fallos de solomon (seguridad no arbitrable), todos con regresión en tests:**
- Todo lo indeclarable falla FUERTE al cargar: kinds/capacidades/claves desconocidas (un typo `allw:` sería regla muerta), formas malformadas en cada nivel (raíz, roles, spec, listas), versión no hablada, y fichero ILEGIBLE ≠ 'sin policy' (solo ENOENT es ausencia).
- Destinos no-verificables ⇒ deny para roles restringidos: sin `file_path`, traversal (`src/../.env` no esquiva globs), absolutas sin `root` (con `root` se relativizan y evalúan).
- Fallo de solomon: un rol DECLARADO solo usa tools del registro — lo desconocido es no-verificable ⇒ deny; roles sin declarar quedan intactos. Bash es conocida (su kind `shell` entra en la parte 3 CON su evaluación — declararlo hoy es error de carga, no regla inerte).
- deny gana a allow; allow-list ⇒ el exterior deniega; `{decision, rule_id, reason}` estructurado (el gancho de evidencia del diagnóstico de auditabilidad).

Se apoya en el primitivo glob (#1429). Parte 3: `shell` + gate de resultado + CLI `kj policy` en warn.

**LOC 247 — `large-pr-justified`**: núcleo de seguridad endurecido ronda a ronda; cada catch vive con su test en el mismo diff al que se ata el veredicto.
Suite completa verde exit 0 · lint 0 · APPROVED por codex.
Card: KJC-TSK-0733