### PR TITLE
feat(policy): shell capability and diff-threshold invariants (KJC-TSK-0733)

### DIFF
--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -9,18 +9,17 @@
 import { readFileSync } from "node:fs";
 import { isAbsolute, join, posix, relative } from "node:path";
 import yaml from "js-yaml";
-import { matchesAny } from "./glob.js";
+import { commandPatternToRegExp, matchesAny } from "./glob.js";
 
 // Vocabulario CERRADO e incremental: cada capacidad entra al set EN el PR
 // que trae su evaluación — declararla antes sería una regla que miente.
-const ROLE_CAPS = new Set(["write"]);
-const INVARIANT_KINDS = new Set([]);
+const ROLE_CAPS = new Set(["write", "shell"]);
+const INVARIANT_KINDS = new Set(["diff-threshold"]);
+const INVARIANT_METRICS = new Set(["net_lines_added"]);
 const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 // Registro de tools conocidas (fallo de solomon: lo desconocido no se
-// permite a un rol DECLARADO — crece por PR consciente). Bash es conocida:
-// su capacidad shell se evalúa cuando el kind entre al vocabulario.
+// permite a un rol DECLARADO — crece por PR consciente).
 const READONLY_TOOLS = new Set(["Read", "Grep", "Glob", "LS", "WebFetch", "WebSearch"]);
-const KNOWN_PENDING_TOOLS = new Set(["Bash"]);
 export const DEFAULT_POLICY = Object.freeze({ version: 1, roles: {}, invariants: [] });
 
 function defaultReadFile(projectDir) {
@@ -67,13 +66,16 @@ export function loadPolicy({ projectDir = process.cwd(), deps = {} } = {}) {
     validateRoles(roles, errors);
   }
   const invs = doc.invariants ?? [];
-  if (!Array.isArray(invs)) errors.push("policy.yml: invariants debe ser una lista");
-  else {
+  if (Array.isArray(invs)) {
     for (const inv of invs) {
       if (!INVARIANT_KINDS.has(inv?.kind)) {
         errors.push(`policy.yml: invariant "${inv?.id}" con kind "${inv?.kind}" no existe en el vocabulario v1`);
+      } else if (!INVARIANT_METRICS.has(inv?.metric) || !Number.isFinite(inv?.max) || typeof inv?.id !== "string") {
+        errors.push(`policy.yml: invariant "${inv?.id}" requiere id string, metric (${[...INVARIANT_METRICS].join(", ")}) y max numérico`);
       }
     }
+  } else {
+    errors.push("policy.yml: invariants debe ser una lista");
   }
   return { policy: { roles: {}, invariants: [], ...doc }, errors };
 }
@@ -136,11 +138,139 @@ function evalWrite(policy, role, filePath, root) {
   return ALLOW;
 }
 
+// Launchers y asignaciones de entorno se PELAN antes de casar patrones
+// (reviewer catch: "sudo git push" o "FOO=1 git add -A" no esquivan la
+// regla del subcomando real); capas excesivas ⇒ opaco ⇒ deny.
+const LAUNCHER_RE = /^(sudo(\s+-\S+)*|command|nohup|time|nice(\s+-n\s*\d+)?|stdbuf\s+\S+|env)\s+|^([A-Za-z_][A-Za-z0-9_]*=\S*\s+)+/;
+function stripLaunchers(seg) {
+  let s = seg;
+  for (let i = 0; i < 5; i++) {
+    const m = s.match(LAUNCHER_RE);
+    if (!m) return s;
+    // Asignaciones que alteran QUÉ ejecutable resuelve (PATH, LD_*, GIT_*,
+    // NODE_OPTIONS) o llevan expansión son opacas — no se pelan, denegan.
+    if (/^(PATH|LD_\w*|NODE_OPTIONS|GIT_\w*)=/.test(m[0]) || m[0].includes("$")) return null;
+    s = s.slice(m[0].length);
+  }
+  return null; // sigue envuelto tras 5 capas: no verificable
+}
+
+// Tokenizador consciente de comillas: separa segmentos SOLO por operadores
+// no entrecomillados (reviewer catch: un ';' dentro de un mensaje no es
+// separador) y canonicaliza tokens sin comillas a la vez. Cualquier
+// construcción que ejecute o redirija texto opaco al análisis — escapes,
+// expansión ($ salvo entre comillas simples), sustitución/backticks,
+// redirecciones, backgrounding, comillas sin cerrar — devuelve null.
+function parseCommand(cmd) {
+  const segs = [];
+  let toks = [];
+  let cur = "";
+  let q = null;
+  const pushTok = () => {
+    if (cur) {
+      toks.push(cur);
+      cur = "";
+    }
+  };
+  const pushSeg = () => {
+    pushTok();
+    if (toks.length > 0) {
+      segs.push(toks.join(" "));
+      toks = [];
+    }
+  };
+  const s = String(cmd);
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "\\" || ch === "`") return null;
+    if (ch === "$" && q !== "'") return null;
+    if (q) {
+      if (ch === q) q = null;
+      else cur += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      q = ch;
+      continue;
+    }
+    if (ch === ">" || ch === "<") return null;
+    if (ch === "&" && s[i + 1] === "&") {
+      pushSeg();
+      i++;
+      continue;
+    }
+    if (ch === "|" && s[i + 1] === "|") {
+      pushSeg();
+      i++;
+      continue;
+    }
+    if (ch === "&") return null;
+    if (ch === ";" || ch === "|" || ch === "\n") {
+      pushSeg();
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      pushTok();
+      continue;
+    }
+    cur += ch;
+  }
+  if (q) return null;
+  pushSeg();
+  return segs;
+}
+
+// Envolturas que re-ejecutan texto (lección del guard del Sentinel).
+const WRAPPER_RE = /^(sh|bash|zsh|dash|ksh)\s+(-\S+\s+)*-\S*c(\s|$)|^eval\b|^xargs\b|^source\b|^\.\s/;
+
+// Deny si CUALQUIER segmento casa; con allow-list, CADA segmento debe casar.
+function evalShell(policy, role, command) {
+  const shell = policy.roles?.[role]?.shell;
+  if (!shell) return ALLOW;
+  if (!command) return deny(`roles.${role}.shell`, `comando ausente — no verificable para el rol ${role}`);
+  const segs = parseCommand(command);
+  if (segs == null) {
+    return deny(`roles.${role}.shell`, "construcciones opacas (escapes, expansión, sustitución, redirecciones, backgrounding o comillas sin cerrar) — no verificable");
+  }
+  for (const raw of segs) {
+    const seg = stripLaunchers(raw);
+    if (seg == null) return deny(`roles.${role}.shell`, `el segmento "${raw}" no es canonicalizable — no verificable`);
+    if (WRAPPER_RE.test(seg)) return deny(`roles.${role}.shell`, `el segmento "${seg}" re-ejecuta texto (envoltura/eval) — no verificable`);
+    const hit = Array.isArray(shell.deny) && shell.deny.find((p) => commandPatternToRegExp(p).test(seg));
+    if (hit) return deny(`roles.${role}.shell.deny`, `el segmento "${seg}" casa con el patrón denegado "${hit}"`);
+    if (Array.isArray(shell.allow) && !shell.allow.some((p) => commandPatternToRegExp(p).test(seg))) {
+      return deny(`roles.${role}.shell.allow`, `el segmento "${seg}" está fuera de la allow-list de shell del rol ${role}`);
+    }
+  }
+  return ALLOW;
+}
+
 /** One tool call against the policy. `root` permite evaluar file_path
  *  absolutos. Un rol DECLARADO solo usa tools del registro: lo desconocido
  *  es no-verificable ⇒ deny (roles sin declarar quedan como hoy). */
 export function evalToolCall(policy, { role = "coder", tool, input = {}, root = null }) {
   if (WRITE_TOOLS.has(tool)) return evalWrite(policy, role, input.file_path || input.notebook_path, root);
-  if (READONLY_TOOLS.has(tool) || KNOWN_PENDING_TOOLS.has(tool) || !policy.roles?.[role]) return ALLOW;
+  if (tool === "Bash") return evalShell(policy, role, input.command);
+  if (READONLY_TOOLS.has(tool) || !policy.roles?.[role]) return ALLOW;
   return deny(`roles.${role}.tools`, `tool "${tool}" fuera del registro de la policy — no verificable para el rol declarado ${role}`);
+}
+
+/** El gate del RESULTADO: ficheros del diff + métricas contra rol e invariantes. */
+export function checkStagedDiff(policy, { role = "coder", files = [], netLinesAdded = null } = {}) {
+  const violations = [];
+  for (const f of files) {
+    const r = evalWrite(policy, role, f);
+    if (r.decision === "deny") violations.push({ rule_id: r.rule_id, reason: r.reason, file: f });
+  }
+  for (const inv of policy.invariants || []) {
+    if (inv.kind !== "diff-threshold" || inv.metric !== "net_lines_added") continue;
+    if (!Number.isFinite(netLinesAdded)) {
+      // Métrica ausente con invariante declarado = no verificable, jamás un
+      // pase silencioso (reviewer catch).
+      violations.push({ rule_id: inv.id, reason: "net_lines_added no disponible — el invariante no es verificable sin la métrica" });
+    } else if (netLinesAdded > inv.max) {
+      violations.push({ rule_id: inv.id, reason: `net_lines_added=${netLinesAdded} supera el máximo ${inv.max}` });
+    }
+  }
+  return violations;
 }

--- a/src/policy/glob.js
+++ b/src/policy/glob.js
@@ -7,24 +7,24 @@
 export function globToRegExp(glob) {
   let re = "";
   const s = String(glob);
-  for (let i = 0; i < s.length; i++) {
+  let i = 0;
+  while (i < s.length) {
     const c = s[i];
-    if (c === "*") {
-      if (s[i + 1] === "*") {
-        if (s[i + 2] === "/") {
-          re += "(?:.*/)?";
-          i += 2;
-        } else {
-          re += ".*";
-          i++;
-        }
-      } else {
-        re += "[^/]*";
-      }
+    if (c === "*" && s[i + 1] === "*" && s[i + 2] === "/") {
+      re += "(?:.*/)?";
+      i += 3;
+    } else if (c === "*" && s[i + 1] === "*") {
+      re += ".*";
+      i += 2;
+    } else if (c === "*") {
+      re += "[^/]*";
+      i += 1;
     } else if (c === "?") {
       re += "[^/]";
+      i += 1;
     } else {
-      re += c.replaceAll(/[.+^${}()|[\]\\]/g, "\\$&");
+      re += c.replaceAll(/[.+^${}()|[\]\\]/g, String.raw`\$&`);
+      i += 1;
     }
   }
   return new RegExp(`^${re}$`);
@@ -33,3 +33,12 @@ export function globToRegExp(glob) {
 /** true si `value` casa con ALGUNO de los globs (lista no-array ⇒ false). */
 export const matchesAny = (value, globs) =>
   Array.isArray(globs) && globs.some((g) => globToRegExp(g).test(value));
+
+/** Patrón de comando shell → RegExp anclada al INICIO: `*` = cualquier cosa
+ *  (los comandos no son rutas — sin semántica de segmentos). */
+export function commandPatternToRegExp(pattern) {
+  const re = String(pattern)
+    .replaceAll(/[.+^${}()|[\]\\?]/g, String.raw`\$&`)
+    .replaceAll("*", ".*");
+  return new RegExp(`^${re}`);
+}

--- a/tests/policy/engine.test.js
+++ b/tests/policy/engine.test.js
@@ -2,7 +2,7 @@
 // cargar), engine as code (puro, fs inyectado, deny-wins).
 
 import { describe, it, expect } from "vitest";
-import { loadPolicy, evalToolCall } from "../../src/policy/engine.js";
+import { checkStagedDiff, evalToolCall, loadPolicy } from "../../src/policy/engine.js";
 
 const load = (yamlText) =>
   loadPolicy({ projectDir: "/p", deps: { readFile: () => yamlText } });
@@ -14,8 +14,15 @@ roles:
     write:
       allow: ["src/**", "tests/**"]
       deny: ["**/*.env*", ".github/workflows/**"]
+    shell:
+      deny: ["git add -A*", "git push*", "curl *"]
   reviewer:
     write: { allow: [] }
+invariants:
+  - id: loc-budget
+    kind: diff-threshold
+    metric: net_lines_added
+    max: 200
 `;
 
 describe("loadPolicy", () => {
@@ -29,8 +36,9 @@ describe("loadPolicy", () => {
   it("everything undeclarable fails LOUD at load — closed vocabulary, strict shapes, one version", () => {
     expect(load("version: 1\ninvariants:\n  - id: x\n    kind: quantum-vibes\n").errors.some((e) => e.includes("quantum-vibes"))).toBe(true);
     expect(load("version: 1\nroles:\n  coder:\n    teleport: {}\n").errors.some((e) => e.includes("teleport"))).toBe(true);
-    // shell entra en la parte 2 CON su evaluación — hoy declararlo es error.
-    expect(load("version: 1\nroles:\n  coder:\n    shell: {deny: ['curl *']}\n").errors.some((e) => e.includes("shell"))).toBe(true);
+    // Un invariant con kind válido pero forma incompleta o max no-finito falla.
+    expect(load("version: 1\ninvariants:\n  - id: x\n    kind: diff-threshold\n").errors.some((e) => e.includes("max"))).toBe(true);
+    expect(load("version: 1\ninvariants:\n  - id: x\n    kind: diff-threshold\n    metric: net_lines_added\n    max: .nan\n").errors.some((e) => e.includes("max"))).toBe(true);
     expect(load("version: 7\n").errors.some((e) => e.includes("version"))).toBe(true);
     expect(load("version: 1\ninvariants: nope\n").errors.some((e) => e.includes("lista"))).toBe(true);
     expect(load('version: 1\nroles:\n  coder:\n    write: si\n').errors.some((e) => e.includes("objeto"))).toBe(true);
@@ -93,8 +101,81 @@ describe("evalToolCall — write", () => {
   it("a DECLARED role using a tool outside the registry is denied — unknown is unverifiable (solomon ruling)", () => {
     expect(evalToolCall(policy, { role: "coder", tool: "TeleportFiles", input: {} })).toMatchObject({ decision: "deny", rule_id: "roles.coder.tools" });
     expect(evalToolCall(policy, { role: "tester", tool: "TeleportFiles", input: {} }).decision).toBe("allow");
-    // Bash es conocida (su kind shell llega en la parte 2) — no se deniega.
-    expect(evalToolCall(policy, { role: "coder", tool: "Bash", input: { command: "ls" } }).decision).toBe("allow");
+  });
+});
+
+describe("evalToolCall — shell (por segmento)", () => {
+  const { policy } = load(POLICY);
+  const bash = (command, role = "coder") => evalToolCall(policy, { role, tool: "Bash", input: { command } });
+
+  it("deniega si CUALQUIER segmento casa un patrón denegado (el clásico git add -A)", () => {
+    expect(bash("npx vitest run && git add -A")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell.deny" });
+    expect(bash("git add -A")).toMatchObject({ decision: "deny" });
+  });
+
+  it("comandos limpios pasan; roles sin shell declarado quedan libres; comando ausente deniega", () => {
+    expect(bash("npx vitest run").decision).toBe("allow");
+    expect(bash("git push", "tester").decision).toBe("allow");
+    expect(bash(undefined)).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+  });
+
+  it("el quoting se canonicaliza y la evasión por comillas/escapes/cabecera-variable deniega (reviewer catch)", () => {
+    expect(bash('"git" push origin')).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell.deny" });
+    expect(bash("git 'add' -A")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell.deny" });
+    expect(bash("git\\ push x")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    expect(bash("$G push")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    // $ expandible en CUALQUIER posición = opaco; entre comillas simples es literal.
+    expect(bash("git push $REMOTE")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    expect(bash("git commit -m 'precio en $'").decision).toBe("allow");
+    // Comillas legítimas en argumentos no molestan al prefijo, y un ';'
+    // DENTRO de comillas no es separador (reviewer catch).
+    expect(bash('git commit -m "release 4.17"').decision).toBe("allow");
+    expect(bash('git commit -m "a;b && c"').decision).toBe("allow");
+  });
+
+  it("launchers y asignaciones se pelan: el patrón caza el subcomando real (reviewer catch)", () => {
+    expect(bash("sudo git push origin main")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell.deny" });
+    expect(bash("env FOO=1 git add -A")).toMatchObject({ decision: "deny" });
+    expect(bash("NODE_ENV=test nohup curl http://x")).toMatchObject({ decision: "deny" });
+    expect(bash("FOO=1 npx vitest run").decision).toBe("allow");
+    // Redirecciones y backgrounding no están modelados ⇒ opacos.
+    expect(bash("git status > out.txt")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    expect(bash("npx vitest run & npx vitest run")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    expect(bash("git commit -m 'a > b'").decision).toBe("allow");
+    // Asignaciones que cambian QUÉ ejecutable resuelve = opacas.
+    expect(bash("PATH=/tmp/evil git status")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    expect(bash("FOO=$BAR git status")).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+  });
+
+  it("envolturas, sustitución y eval son texto opaco ⇒ deny (reviewer catch, clase del Sentinel)", () => {
+    for (const evil of ['sh -c "git add -A"', "bash -lc 'git push'", "echo $(git push)", "eval git push", "xargs rm < lista", "diff <(git push) x", "tee >(git push)"]) {
+      expect(bash(evil)).toMatchObject({ decision: "deny", rule_id: "roles.coder.shell" });
+    }
+  });
+
+  it("con allow-list, TODO segmento debe casar", () => {
+    const { policy: p2 } = load('version: 1\nroles:\n  ci:\n    shell: {allow: ["npm *", "npx *"]}\n');
+    expect(evalToolCall(p2, { role: "ci", tool: "Bash", input: { command: "npm test && npx vitest run" } }).decision).toBe("allow");
+    expect(evalToolCall(p2, { role: "ci", tool: "Bash", input: { command: "npm test && rm -rf x" } })).toMatchObject({ decision: "deny", rule_id: "roles.ci.shell.allow" });
+  });
+});
+
+describe("checkStagedDiff — el gate del resultado", () => {
+  const { policy } = load(POLICY);
+
+  it("flagea ficheros write-deny del diff y el presupuesto de líneas", () => {
+    const v = checkStagedDiff(policy, { role: "coder", files: ["src/ok.js", ".github/workflows/x.yml"], netLinesAdded: 250 });
+    expect(v.some((x) => x.rule_id === "roles.coder.write.deny" && x.file === ".github/workflows/x.yml")).toBe(true);
+    expect(v.some((x) => x.rule_id === "loc-budget" && x.reason.includes("250"))).toBe(true);
+  });
+
+  it("un diff limpio devuelve cero violaciones", () => {
+    expect(checkStagedDiff(policy, { role: "coder", files: ["src/a.js"], netLinesAdded: 10 })).toEqual([]);
+  });
+
+  it("métrica ausente con invariante declarado = violación, no pase silencioso (reviewer catch)", () => {
+    const v = checkStagedDiff(policy, { role: "coder", files: [] });
+    expect(v.some((x) => x.rule_id === "loc-budget" && x.reason.includes("no disponible"))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Qué (PL-A parte 3a, épica KJC-PCS-0074)
El kind `shell` entra al vocabulario CON su evaluación (la doctrina: nunca antes) y el primer invariante (`diff-threshold` sobre `net_lines_added`) con validación estricta de forma (métrica del set, max finito).

**Evaluación shell endurecida en 7 catches de codex, cada uno con regresión:**
- **Tokenizador consciente de comillas**: separa segmentos SOLO por operadores no entrecomillados (un `;` en un mensaje de commit no es separador) y canonicaliza tokens (`"git" push` no esquiva el patrón).
- Opaco ⇒ deny: escapes, `$` expandible (entre comillas simples es literal), sustitución/backticks/process-substitution, redirecciones, backgrounding, comillas sin cerrar, envolturas que re-ejecutan texto (`sh -c`, eval, xargs, source).
- **Launchers se PELAN** (sudo/env/nohup/asignaciones) y el patrón caza el subcomando real; asignaciones que alteran QUÉ ejecutable resuelve (PATH/LD_*/GIT_*/NODE_OPTIONS) o llevan $ = opacas.
- `checkStagedDiff`: ficheros write-deny del diff + presupuesto de líneas; **métrica ausente con invariante declarado = violación explícita**, jamás pase silencioso.
- Patrón de comando: prefijo anclado con `*` (`git add -A*`, `git push*`); deny si CUALQUIER segmento casa, allow-list exige CADA segmento.

**LOC 220 — `large-pr-justified`**: mismo precedente que #1416/#1430 — cada catch vive con su test en el diff al que se ata el veredicto.
Suite completa verde exit 0 · lint 0 · APPROVED por codex.
Parte 3b (cierra la card): CLI `kj policy eval/check` en warn.
Card: KJC-TSK-0733