### PR TITLE
feat(policy): kj policy eval and check — the engine speaks cli, warn mode (KJC-TSK-0733)

### DIFF
--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -30,7 +30,7 @@ export const ADVANCED_GROUPS = [
   { title: "Pipeline (piezas sueltas)", commands: ["autorun", "code", "review", "solomon", "agent", "scan", "tournament"] },
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
-  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release"] },
+  { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release", "policy"] },
   { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby", "sentinel"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -284,6 +284,31 @@ export function registerMeta(program, { pkgVersion }) {
       });
     });
 
+  // KJC-TSK-0733 PL-A — policy as code: motor determinista en modo warn.
+  const policyCmd = program.command("policy").description("Policy as code (.karajan/policy.yml, vocabulario cerrado) — PL-A: modo warn");
+  policyCmd.command("eval")
+    .description("Evalúa UNA tool call: imprime {decision, rule_id, reason}; --strict devuelve exit 2 en deny (contrato para adaptadores de hooks)")
+    .option("--role <role>", "Rol del agente", "coder")
+    .option("--tool <tool>", "Tool (Write, Edit, Bash…)")
+    .option("--input <json>", "tool_input en JSON")
+    .option("--strict", "Exit 2 si deny")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "policy-eval", flags, async ({ config }) => {
+        const { policyCommand } = await import("../commands/policy.js");
+        process.exitCode = await policyCommand({ action: "eval", config, flags });
+      });
+    });
+  policyCmd.command("check")
+    .description("Comprueba el diff STAGED contra la policy (write-deny + invariantes) — siempre warn en PL-A; exit 1 solo si policy.yml es inválido")
+    .option("--role <role>", "Rol del agente", "coder")
+    .option("--json", "Machine-readable")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "policy-check", flags, async ({ config }) => {
+        const { policyCommand } = await import("../commands/policy.js");
+        process.exitCode = await policyCommand({ action: "check", config, flags });
+      });
+    });
+
   // KJC-TSK-0713 — the Sentinel: the method state the harness hooks record.
   const sentinel = program.command("sentinel").description("Deterministic method supervisor wired into the harness hooks (Claude Code)");
   sentinel.command("status")

--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -1,0 +1,70 @@
+/**
+ * `kj policy` — PL-A parte 3b (KJC-TSK-0733, épica KJC-PCS-0074). El motor
+ * en modo WARN: eval de una tool call y check del diff staged contra
+ * `.karajan/policy.yml`. En PL-A nada bloquea salvo un fichero de policy
+ * inválido (exit 1: declarar lo inaplicable es error del fichero, no aviso).
+ * `eval --strict` devuelve exit 2 en deny — el contrato para los adaptadores
+ * de hooks de PL-B. Los dientes de check llegan en PL-B/PL-C.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
+
+const execFileAsync = promisify(execFile);
+
+async function stagedFacts(projectDir, gitFn) {
+  const run =
+    gitFn ||
+    (async (args) => (await execFileAsync("git", args, { cwd: projectDir, maxBuffer: 16 * 1024 * 1024 })).stdout);
+  const files = (await run(["diff", "--cached", "--name-only"]))
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  let net = 0;
+  for (const line of (await run(["diff", "--cached", "--numstat"])).split("\n")) {
+    const [a, r] = line.trim().split(/\s+/);
+    if (a && a !== "-") net += Number(a) || 0;
+    if (r && r !== "-") net -= Number(r) || 0;
+  }
+  return { files, netLinesAdded: net };
+}
+
+export async function policyCommand({ action, config = {}, flags = {}, logger = console, deps = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const { policy, errors } = loadPolicy({ projectDir, deps });
+  if (errors.length > 0) {
+    for (const e of errors) logger.error?.(`✗ ${e}`);
+    logger.error?.("policy: el fichero declara lo que el motor no puede aplicar — corrígelo (una regla que miente es peor que ninguna)");
+    return 1;
+  }
+
+  if (action === "eval") {
+    let input;
+    try {
+      input = flags.input ? JSON.parse(flags.input) : {};
+    } catch {
+      logger.error?.("policy eval: --input debe ser JSON válido");
+      return 1;
+    }
+    const verdict = evalToolCall(policy, { role: flags.role || "coder", tool: flags.tool, input, root: projectDir });
+    logger.info?.(JSON.stringify(verdict));
+    return verdict.decision === "deny" && flags.strict ? 2 : 0;
+  }
+
+  // check — sobre el diff staged (único modo en PL-A), SIEMPRE warn.
+  const facts = await stagedFacts(projectDir, deps.gitFn);
+  const violations = checkStagedDiff(policy, { role: flags.role || "coder", ...facts });
+  if (flags.json) {
+    logger.info?.(JSON.stringify({ mode: "warn", violations }));
+    return 0;
+  }
+  if (violations.length === 0) {
+    logger.info?.("policy check: limpio");
+    return 0;
+  }
+  for (const v of violations) {
+    logger.warn?.(`⚠ policy [${v.rule_id}] ${v.reason}${v.file ? ` (${v.file})` : ""}`);
+  }
+  logger.warn?.(`policy check: ${violations.length} aviso(s) — modo warn (PL-A): no bloquea; PL-B le dará dientes`);
+  return 0;
+}

--- a/tests/policy/command.test.js
+++ b/tests/policy/command.test.js
@@ -1,0 +1,81 @@
+// PL-A 3b (KJC-TSK-0733) — `kj policy` en modo warn: eval con contrato de
+// adaptador (--strict ⇒ exit 2 en deny) y check del staged que AVISA sin
+// bloquear; un policy.yml inválido es exit 1, nunca un pase.
+import { describe, it, expect } from "vitest";
+import { policyCommand } from "../../src/commands/policy.js";
+
+const logger = () => {
+  const lines = [];
+  return { lines, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: (m) => lines.push(m) };
+};
+
+const POLICY = `
+version: 1
+roles:
+  coder:
+    write: { deny: ["**/*.env*"] }
+invariants:
+  - id: loc-budget
+    kind: diff-threshold
+    metric: net_lines_added
+    max: 200
+`;
+const deps = (extra = {}) => ({ readFile: () => POLICY, ...extra });
+
+describe("kj policy eval", () => {
+  it("imprime el veredicto estructurado; --strict convierte deny en exit 2", async () => {
+    const log = logger();
+    const code = await policyCommand({
+      action: "eval", config: { projectDir: "/p" }, logger: log,
+      flags: { role: "coder", tool: "Write", input: '{"file_path":"src/.env"}', strict: true },
+      deps: deps(),
+    });
+    expect(code).toBe(2);
+    expect(JSON.parse(log.lines.at(-1))).toMatchObject({ decision: "deny", rule_id: "roles.coder.write.deny" });
+    expect(await policyCommand({
+      action: "eval", config: { projectDir: "/p" }, logger: logger(),
+      flags: { role: "coder", tool: "Write", input: '{"file_path":"src/a.js"}', strict: true },
+      deps: deps(),
+    })).toBe(0);
+  });
+
+  it("--input no-JSON es exit 1 con motivo", async () => {
+    const log = logger();
+    expect(await policyCommand({ action: "eval", logger: log, flags: { tool: "Write", input: "{rota" }, deps: deps() })).toBe(1);
+    expect(log.lines.join("\n")).toContain("JSON");
+  });
+});
+
+describe("kj policy check --staged (warn)", () => {
+  const gitFn = async (args) =>
+    args.includes("--name-only") ? "src/ok.js\nsrc/.env.local\n" : "250\t0\tsrc/ok.js\n";
+
+  it("avisa las violaciones con rule_id y NUNCA bloquea en PL-A", async () => {
+    const log = logger();
+    const code = await policyCommand({ action: "check", config: { projectDir: "/p" }, logger: log, flags: {}, deps: deps({ gitFn }) });
+    expect(code).toBe(0);
+    const out = log.lines.join("\n");
+    expect(out).toContain("roles.coder.write.deny");
+    expect(out).toContain("loc-budget");
+    expect(out).toContain("warn");
+  });
+
+  it("--json emite {mode, violations} parseable; limpio dice limpio", async () => {
+    const log = logger();
+    await policyCommand({ action: "check", config: { projectDir: "/p" }, logger: log, flags: { json: true }, deps: deps({ gitFn }) });
+    const parsed = JSON.parse(log.lines.at(-1));
+    expect(parsed.mode).toBe("warn");
+    expect(parsed.violations.length).toBeGreaterThan(0);
+
+    const clean = logger();
+    await policyCommand({ action: "check", config: { projectDir: "/p" }, logger: clean, flags: {}, deps: deps({ gitFn: async (a) => (a.includes("--name-only") ? "src/a.js\n" : "5\t0\tsrc/a.js\n") }) });
+    expect(clean.lines.join("\n")).toContain("limpio");
+  });
+
+  it("un policy.yml inválido es exit 1 — jamás un pase silencioso", async () => {
+    const log = logger();
+    const code = await policyCommand({ action: "check", logger: log, flags: {}, deps: { readFile: () => "version: 9\n" } });
+    expect(code).toBe(1);
+    expect(log.lines.join("\n")).toContain("version");
+  });
+});


### PR DESCRIPTION
## Qué (PL-A parte 3b — CIERRA la card 0733)
El motor gana voz: `kj policy eval --role --tool --input` imprime `{decision, rule_id, reason}` (`--strict` ⇒ exit 2 en deny — el contrato para los adaptadores de hooks de PL-B) y `kj policy check` evalúa el diff STAGED (ficheros write-deny + invariantes con métrica real de numstat) SIEMPRE en warn — el único exit 1 es un policy.yml inválido: declarar lo inaplicable es error del fichero, jamás un pase silencioso. Registrado en el grupo Calidad/auditoría (el candado anti-drift de comandos lo exigió, bien por él). Probado en vivo sobre este repo.
Con esto **PL-A está completa**: glob #1429 + motor #1430 + shell/invariantes #1431 + CLI. Siguiente de la épica: PL-B (deny en pre-commit/review + el PRETOOL del Sentinel delega en `kj policy eval --strict`).
Suite completa verde exit 0 · lint 0 · APPROVED por codex · neto 176.
Card: KJC-TSK-0733