### PR TITLE
feat(policy): enforcement and security class with supervisor defaults (KJC-TSK-0734)

### DIFF
--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -16,6 +16,19 @@ import { commandPatternToRegExp, matchesAny } from "./glob.js";
 const ROLE_CAPS = new Set(["write", "shell"]);
 const INVARIANT_KINDS = new Set(["diff-threshold"]);
 const INVARIANT_METRICS = new Set(["net_lines_added"]);
+// PL-B (KJC-TSK-0734): enforcement por regla y clase. Cerrados como todo lo
+// demás — un valor desconocido es error de carga, nunca un default silencioso.
+const ENFORCEMENTS = new Set(["warn", "deny"]);
+const CLASSES = new Set(["security"]);
+// Defaults embarcados del supervisor (antes hardcodeados en el PRETOOL del
+// Sentinel): se evalúan SIEMPRE, antes que los caps del rol, y ninguna
+// policy de proyecto los debilita. Misma semántica textual que el PRETOOL:
+// nombrar estos ficheros deniega, con o sin root.
+const SUPERVISOR_RE = /\.claude\/settings\.json\b|\.karajan\/(hooks|harness)\//;
+const supervisorDeny = (rule_id, what) => ({
+  decision: "deny", rule_id, enforcement: "deny", class: "security",
+  reason: `${what} nombra ficheros del supervisor — solo el humano los modifica, fuera de la sesión`,
+});
 const WRITE_TOOLS = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 // Registro de tools conocidas (fallo de solomon: lo desconocido no se
 // permite a un rol DECLARADO — crece por PR consciente).
@@ -72,6 +85,8 @@ export function loadPolicy({ projectDir = process.cwd(), deps = {} } = {}) {
         errors.push(`policy.yml: invariant "${inv?.id}" con kind "${inv?.kind}" no existe en el vocabulario v1`);
       } else if (!INVARIANT_METRICS.has(inv?.metric) || !Number.isFinite(inv?.max) || typeof inv?.id !== "string") {
         errors.push(`policy.yml: invariant "${inv?.id}" requiere id string, metric (${[...INVARIANT_METRICS].join(", ")}) y max numérico`);
+      } else if (inv?.enforcement !== undefined && !ENFORCEMENTS.has(inv.enforcement)) {
+        errors.push(`policy.yml: invariant "${inv.id}" enforcement "${inv.enforcement}" no existe en el vocabulario (v1: ${[...ENFORCEMENTS].join(", ")})`);
       }
     }
   } else {
@@ -92,8 +107,8 @@ function validateRoles(roles, errors) {
         continue;
       }
       for (const key of Object.keys(spec)) {
-        if (key !== "allow" && key !== "deny") {
-          errors.push(`policy.yml: roles.${role}.${cap}.${key} no existe en el vocabulario (v1: allow, deny)`);
+        if (!["allow", "deny", "enforcement", "class"].includes(key)) {
+          errors.push(`policy.yml: roles.${role}.${cap}.${key} no existe en el vocabulario (v1: allow, deny, enforcement, class)`);
         }
       }
       for (const list of ["allow", "deny"]) {
@@ -101,6 +116,12 @@ function validateRoles(roles, errors) {
         if (v !== undefined && (!Array.isArray(v) || v.some((g) => typeof g !== "string"))) {
           errors.push(`policy.yml: roles.${role}.${cap}.${list} debe ser una lista de strings (glob)`);
         }
+      }
+      if (spec.enforcement !== undefined && !ENFORCEMENTS.has(spec.enforcement)) {
+        errors.push(`policy.yml: roles.${role}.${cap}.enforcement "${spec.enforcement}" no existe en el vocabulario (v1: ${[...ENFORCEMENTS].join(", ")})`);
+      }
+      if (spec.class !== undefined && !CLASSES.has(spec.class)) {
+        errors.push(`policy.yml: roles.${role}.${cap}.class "${spec.class}" no existe en el vocabulario (v1: ${[...CLASSES].join(", ")})`);
       }
     }
   }
@@ -122,18 +143,26 @@ function normalizeTarget(filePath, root) {
   return p.startsWith("..") || isAbsolute(p) ? null : p;
 }
 
+// enforcement/class del cap viajan en cada deny (default warn = PL-A intacto).
+const capMeta = (spec) => ({ enforcement: spec?.enforcement || "warn", ...(spec?.class ? { class: spec.class } : {}) });
+
 function evalWrite(policy, role, filePath, root) {
+  // Defaults del supervisor primero: sobre el TEXTO del destino (con o sin
+  // root), igual que el PRETOOL que sustituyen — la policy no los debilita.
+  if (filePath && SUPERVISOR_RE.test(String(filePath).replaceAll("\\", "/"))) {
+    return supervisorDeny("defaults.supervisor.write", `el destino "${filePath}"`);
+  }
   const write = policy.roles?.[role]?.write;
   if (!write) return ALLOW;
   // Rol restringido + destino ausente/no-canonizable = no verificable ⇒ deny
   // (reviewer catches: tool call malformado, traversal, absoluta sin root).
   const p = filePath ? normalizeTarget(filePath, root) : null;
-  if (p == null) return deny(`roles.${role}.write`, `destino "${filePath ?? ""}" no verificable contra la policy del rol ${role}`);
+  if (p == null) return { ...deny(`roles.${role}.write`, `destino "${filePath ?? ""}" no verificable contra la policy del rol ${role}`), ...capMeta(write) };
   if (matchesAny(p, write.deny)) {
-    return deny(`roles.${role}.write.deny`, `${p} esta denegado para el rol ${role}`);
+    return { ...deny(`roles.${role}.write.deny`, `${p} esta denegado para el rol ${role}`), ...capMeta(write) };
   }
   if (Array.isArray(write.allow) && !matchesAny(p, write.allow)) {
-    return deny(`roles.${role}.write.allow`, `${p} esta fuera de la allow-list de escritura del rol ${role}`);
+    return { ...deny(`roles.${role}.write.allow`, `${p} esta fuera de la allow-list de escritura del rol ${role}`), ...capMeta(write) };
   }
   return ALLOW;
 }
@@ -225,21 +254,27 @@ const WRAPPER_RE = /^(sh|bash|zsh|dash|ksh)\s+(-\S+\s+)*-\S*c(\s|$)|^eval\b|^xar
 
 // Deny si CUALQUIER segmento casa; con allow-list, CADA segmento debe casar.
 function evalShell(policy, role, command) {
+  // Defaults del supervisor: un Bash que NOMBRA sus ficheros deniega, con o
+  // sin caps del rol (misma semántica textual que el PRETOOL que sustituyen).
+  if (command && SUPERVISOR_RE.test(String(command).replaceAll("\\", "/"))) {
+    return supervisorDeny("defaults.supervisor.shell", "el comando");
+  }
   const shell = policy.roles?.[role]?.shell;
   if (!shell) return ALLOW;
-  if (!command) return deny(`roles.${role}.shell`, `comando ausente — no verificable para el rol ${role}`);
+  const meta = capMeta(shell);
+  if (!command) return { ...deny(`roles.${role}.shell`, `comando ausente — no verificable para el rol ${role}`), ...meta };
   const segs = parseCommand(command);
   if (segs == null) {
-    return deny(`roles.${role}.shell`, "construcciones opacas (escapes, expansión, sustitución, redirecciones, backgrounding o comillas sin cerrar) — no verificable");
+    return { ...deny(`roles.${role}.shell`, "construcciones opacas (escapes, expansión, sustitución, redirecciones, backgrounding o comillas sin cerrar) — no verificable"), ...meta };
   }
   for (const raw of segs) {
     const seg = stripLaunchers(raw);
-    if (seg == null) return deny(`roles.${role}.shell`, `el segmento "${raw}" no es canonicalizable — no verificable`);
-    if (WRAPPER_RE.test(seg)) return deny(`roles.${role}.shell`, `el segmento "${seg}" re-ejecuta texto (envoltura/eval) — no verificable`);
+    if (seg == null) return { ...deny(`roles.${role}.shell`, `el segmento "${raw}" no es canonicalizable — no verificable`), ...meta };
+    if (WRAPPER_RE.test(seg)) return { ...deny(`roles.${role}.shell`, `el segmento "${seg}" re-ejecuta texto (envoltura/eval) — no verificable`), ...meta };
     const hit = Array.isArray(shell.deny) && shell.deny.find((p) => commandPatternToRegExp(p).test(seg));
-    if (hit) return deny(`roles.${role}.shell.deny`, `el segmento "${seg}" casa con el patrón denegado "${hit}"`);
+    if (hit) return { ...deny(`roles.${role}.shell.deny`, `el segmento "${seg}" casa con el patrón denegado "${hit}"`), ...meta };
     if (Array.isArray(shell.allow) && !shell.allow.some((p) => commandPatternToRegExp(p).test(seg))) {
-      return deny(`roles.${role}.shell.allow`, `el segmento "${seg}" está fuera de la allow-list de shell del rol ${role}`);
+      return { ...deny(`roles.${role}.shell.allow`, `el segmento "${seg}" está fuera de la allow-list de shell del rol ${role}`), ...meta };
     }
   }
   return ALLOW;
@@ -260,16 +295,17 @@ export function checkStagedDiff(policy, { role = "coder", files = [], netLinesAd
   const violations = [];
   for (const f of files) {
     const r = evalWrite(policy, role, f);
-    if (r.decision === "deny") violations.push({ rule_id: r.rule_id, reason: r.reason, file: f });
+    if (r.decision === "deny") violations.push({ rule_id: r.rule_id, reason: r.reason, file: f, enforcement: r.enforcement || "warn", ...(r.class ? { class: r.class } : {}) });
   }
   for (const inv of policy.invariants || []) {
     if (inv.kind !== "diff-threshold" || inv.metric !== "net_lines_added") continue;
+    const meta = { enforcement: inv.enforcement || "warn" };
     if (!Number.isFinite(netLinesAdded)) {
       // Métrica ausente con invariante declarado = no verificable, jamás un
       // pase silencioso (reviewer catch).
-      violations.push({ rule_id: inv.id, reason: "net_lines_added no disponible — el invariante no es verificable sin la métrica" });
+      violations.push({ rule_id: inv.id, reason: "net_lines_added no disponible — el invariante no es verificable sin la métrica", ...meta });
     } else if (netLinesAdded > inv.max) {
-      violations.push({ rule_id: inv.id, reason: `net_lines_added=${netLinesAdded} supera el máximo ${inv.max}` });
+      violations.push({ rule_id: inv.id, reason: `net_lines_added=${netLinesAdded} supera el máximo ${inv.max}`, ...meta });
     }
   }
   return violations;

--- a/tests/policy/enforcement.test.js
+++ b/tests/policy/enforcement.test.js
@@ -1,0 +1,146 @@
+// KJC-TSK-0734 PL-B — enforcement por regla (warn→deny), clase security y
+// defaults embarcados del supervisor: las reglas antes hardcodeadas en el
+// PRETOOL viven en el motor y NINGUNA policy de proyecto las debilita.
+
+import { describe, it, expect } from "vitest";
+import { checkStagedDiff, evalToolCall, loadPolicy } from "../../src/policy/engine.js";
+
+const load = (yamlText) =>
+  loadPolicy({ projectDir: "/p", deps: { readFile: () => yamlText } });
+
+const POLICY = `
+version: 1
+roles:
+  coder:
+    write:
+      deny: ["**/*.env*"]
+      enforcement: deny
+    shell:
+      deny: ["git push*"]
+invariants:
+  - id: loc-budget
+    kind: diff-threshold
+    metric: net_lines_added
+    max: 200
+    enforcement: deny
+`;
+
+describe("vocabulario de enforcement (cerrado, fail-loud)", () => {
+  it("acepta enforcement warn|deny en caps e invariants", () => {
+    const { errors } = load(POLICY);
+    expect(errors).toEqual([]);
+  });
+
+  it("un enforcement fuera del vocabulario es error de carga, no un default silencioso", () => {
+    const { errors } = load(`
+version: 1
+roles:
+  coder:
+    write: { deny: ["a"], enforcement: block }
+`);
+    expect(errors.some((e) => e.includes("enforcement"))).toBe(true);
+  });
+
+  it("una class fuera del vocabulario es error de carga", () => {
+    const { errors } = load(`
+version: 1
+roles:
+  coder:
+    write: { deny: ["a"], class: seguridad }
+`);
+    expect(errors.some((e) => e.includes("class"))).toBe(true);
+  });
+
+  it("enforcement invalido en un invariant es error de carga", () => {
+    const { errors } = load(`
+version: 1
+invariants:
+  - { id: x, kind: diff-threshold, metric: net_lines_added, max: 10, enforcement: hard }
+`);
+    expect(errors.some((e) => e.includes("enforcement"))).toBe(true);
+  });
+});
+
+describe("enforcement viaja en el veredicto", () => {
+  it("deny de un cap con enforcement=deny lo dice", () => {
+    const { policy } = load(POLICY);
+    const v = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "prod.env" } });
+    expect(v.decision).toBe("deny");
+    expect(v.enforcement).toBe("deny");
+  });
+
+  it("sin enforcement declarado, el default es warn (PL-A intacto)", () => {
+    const { policy } = load(`
+version: 1
+roles:
+  coder:
+    write: { deny: ["secret/**"] }
+`);
+    const v = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "secret/x.js" } });
+    expect(v.decision).toBe("deny");
+    expect(v.enforcement).toBe("warn");
+  });
+
+  it("checkStagedDiff etiqueta cada violacion con su enforcement", () => {
+    const { policy } = load(POLICY);
+    const vs = checkStagedDiff(policy, { role: "coder", files: ["prod.env"], netLinesAdded: 500 });
+    expect(vs).toHaveLength(2);
+    for (const v of vs) expect(v.enforcement).toBe("deny");
+  });
+
+  it("invariant sin enforcement declara warn en la violacion", () => {
+    const { policy } = load(`
+version: 1
+invariants:
+  - { id: loc, kind: diff-threshold, metric: net_lines_added, max: 10 }
+`);
+    const vs = checkStagedDiff(policy, { files: [], netLinesAdded: 99 });
+    expect(vs[0].enforcement).toBe("warn");
+  });
+});
+
+describe("defaults del supervisor (antes hardcodeados en el PRETOOL)", () => {
+  it("Write sobre los ficheros del supervisor deniega SIN policy de proyecto", () => {
+    const { policy } = load(null);
+    for (const target of [".claude/settings.json", ".karajan/hooks/pre-commit", ".karajan/harness/pretool.mjs"]) {
+      const v = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: target } });
+      expect(v.decision).toBe("deny");
+      expect(v.enforcement).toBe("deny");
+      expect(v.class).toBe("security");
+    }
+  });
+
+  it("Bash que NOMBRA un fichero del supervisor deniega", () => {
+    const { policy } = load(null);
+    const v = evalToolCall(policy, { role: "coder", tool: "Bash", input: { command: "cp x .karajan/hooks/pre-commit" } });
+    expect(v.decision).toBe("deny");
+    expect(v.class).toBe("security");
+  });
+
+  it("la policy del proyecto NO debilita los defaults (deny gana)", () => {
+    const { policy, errors } = load(`
+version: 1
+roles:
+  coder:
+    write: { allow: [".karajan/**", "src/**"] }
+`);
+    expect(errors).toEqual([]);
+    const v = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: ".karajan/hooks/pre-commit" } });
+    expect(v.decision).toBe("deny");
+    expect(v.class).toBe("security");
+  });
+
+  it("checkStagedDiff marca ficheros del supervisor en el diff como security", () => {
+    const { policy } = load(null);
+    const vs = checkStagedDiff(policy, { role: "coder", files: [".karajan/harness/stop.mjs", "src/ok.js"], netLinesAdded: 1 });
+    expect(vs).toHaveLength(1);
+    expect(vs[0].class).toBe("security");
+    expect(vs[0].enforcement).toBe("deny");
+  });
+
+  it("el resto del arbol sigue libre sin policy de proyecto", () => {
+    const { policy } = load(null);
+    const v = evalToolCall(policy, { role: "coder", tool: "Write", input: { file_path: "src/app.js" } });
+    expect(v.decision).toBe("allow");
+  });
+});


### PR DESCRIPTION
## PL-B parte 1 — enforcement por regla + defaults del supervisor (KJC-TSK-0734, épica KJC-PCS-0074, ADR 0001)

El vocabulario CERRADO v1 gana dos campos por regla, ambos fail-loud:

- **`enforcement: warn | deny`** en caps (`roles.*.write/shell`) e invariants — default `warn` (PL-A intacto). Un valor desconocido es error de carga, nunca un default silencioso. El campo viaja en cada veredicto deny y en cada violación de `checkStagedDiff`: es lo que el gate de commit (parte 2) leerá para decidir avisar o rechazar.
- **`class: security`** — la marca que las partes 2 y 3 usan para "sin escape y sin arbitraje".

**Defaults embarcados del supervisor**: las reglas hardcodeadas del PRETOOL del Sentinel (`.claude/settings.json`, `.karajan/hooks/**`, `.karajan/harness/**`) viven ahora en el motor como defaults `class: security` + `enforcement: deny`, evaluados ANTES que los caps del rol y con la misma semántica textual que el PRETOOL que sustituyen (nombrar el fichero deniega, en Write y en Bash, con o sin root). Ninguna policy de proyecto los debilita — deny gana.

TDD: 13 tests nuevos (rojo primero), los 29 de PL-A intactos. Suite completa 6592 ✓.

Parte 2: gate determinista en `kj review --staged/--check` + excepción auditada. Parte 3: el PRETOOL delega en `kj policy eval --strict`.