### PR TITLE
feat(governance): exception scopes with strict expiry and standing exemptions (KJC-TSK-0746)

### DIFF
--- a/packages/governance/src/exceptions.js
+++ b/packages/governance/src/exceptions.js
@@ -11,13 +11,34 @@
  * venderse como más evidencia de la que es (GOV-B trae el grado explícito).
  */
 
+// GOV-B (KJC-TSK-0746): alcance con vocabulario CERRADO. `puntual` liga la
+// excepción a un artefacto exacto (caducidad implícita: cambia el artefacto
+// y muere sola); `permanente` exige caducidad EXPLÍCITA — sin expiresAt no
+// hay excepción permanente válida, jamás un "para siempre" silencioso.
+const SCOPE_KINDS = new Set(["puntual", "permanente"]);
+
 /** @returns {object} the recorded entry (with ts + who resolved). */
 export function recordPolicyException({ projectDir, entry, deps }) {
   const { append, identity } = deps || {};
   if (typeof append !== "function" || typeof identity !== "function") {
     throw new TypeError("recordPolicyException: identity y append son del adaptador — el kernel no sabe quién eres ni dónde persistir");
   }
-  const record = { ts: new Date().toISOString(), who: identity(projectDir), ...entry };
+  const scopeKind = entry.scopeKind ?? "puntual";
+  if (!SCOPE_KINDS.has(scopeKind)) {
+    throw new TypeError(`recordPolicyException: scopeKind "${entry.scopeKind}" no existe en el vocabulario (${[...SCOPE_KINDS].join(", ")})`);
+  }
+  // ISO-8601 ESTRICTO (catch de codex: Date.parse traga fechas locales y
+  // ambiguas — una caducidad ambigua evaluaría mal el standing después).
+  const strictIso = (s) =>
+    typeof s === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/.test(s) &&
+    !Number.isNaN(Date.parse(s));
+  if (scopeKind === "permanente" && !strictIso(entry.expiresAt)) {
+    throw new TypeError("recordPolicyException: una excepción permanente exige caducidad — expiresAt en ISO-8601 estricto (p.ej. 2026-09-01T00:00:00Z)");
+  }
+  // El scopeKind NORMALIZADO va el último: un entry con scopeKind undefined
+  // pisaría el valor canónico en el registro (catch de codex).
+  const record = { ts: new Date().toISOString(), who: identity(projectDir), ...entry, scopeKind };
   append(projectDir, `${JSON.stringify(record)}\n`);
   return record;
 }

--- a/packages/governance/src/gate.js
+++ b/packages/governance/src/gate.js
@@ -17,6 +17,7 @@ import { checkArtifacts } from "./engine.js";
 export function evaluateGate({
   policy, errors = [], role = "coder", files = [], netLinesAdded = null,
   artifactHash = null, exemption = {}, recordException = () => {},
+  standingExceptions = [], now = new Date(),
 }) {
   if (errors.length > 0) {
     return { ok: false, invalid: true, warns: [], denials: errors.map((e) => ({ rule_id: "policy.load", reason: e })), exempted: [] };
@@ -26,9 +27,22 @@ export function evaluateGate({
   const hard = violations.filter((v) => v.enforcement === "deny");
   const denials = [];
   const exempted = [];
+  // GOV-B (KJC-TSK-0746): standing exceptions — permanentes YA concedidas
+  // (cargadas por el adaptador de su almacén; el kernel no hace I/O) que
+  // eximen la regla exacta mientras VIVEN. `now` lo pone quien evalúa:
+  // la caducidad es la regla, no una sugerencia.
+  // Registros legacy (PL-B, sin scopeKind) se normalizan a `puntual` — su
+  // tipo efectivo de siempre: eximieron EN su momento ligados a un diff y
+  // jamás se re-consultaron. Solo una permanente explícita y VIVA da standing.
+  const alive = (s) => (s.scopeKind ?? "puntual") === "permanente" && Date.parse(s.expiresAt) > now.getTime();
   for (const v of hard) {
     if (v.class === "security") {
-      denials.push(v); // inexcepcionable: sin escape y sin arbitraje — no negociable
+      denials.push(v); // inexcepcionable: sin escape, sin arbitraje, sin standing
+      continue;
+    }
+    const st = standingExceptions.find((s) => s.rule_id === v.rule_id && alive(s));
+    if (st) {
+      exempted.push({ ...v, standing: st });
       continue;
     }
     if (exemption.requested) {

--- a/tests/governance/standing-exceptions.test.js
+++ b/tests/governance/standing-exceptions.test.js
@@ -1,0 +1,103 @@
+// GOV-B (KJC-TSK-0746) — la excepción con forma completa: scopeKind
+// puntual|permanente (cerrado, fail-loud), expiresAt OBLIGATORIO en la
+// permanente, grade en la identidad, y evaluateGate honrando standing
+// exceptions VIVAS con un `now` explícito (determinismo: el reloj lo pone
+// quien evalúa, no el kernel).
+
+import { describe, it, expect, vi } from "vitest";
+import { recordPolicyException } from "../../packages/governance/src/exceptions.js";
+import { evaluateGate } from "../../packages/governance/src/gate.js";
+import { parsePolicy } from "../../packages/governance/src/engine.js";
+
+const deps = () => {
+  const lines = [];
+  return { lines, deps: { append: (_d, l) => lines.push(l), identity: () => ({ git: "manu <m@x>", os: "manu", grade: "declarada" }) } };
+};
+
+describe("recordPolicyException con alcance", () => {
+  it("una permanente sin caducidad es invalida — sin expiresAt no hay excepcion permanente", () => {
+    const { deps: d } = deps();
+    expect(() => recordPolicyException({ projectDir: "/p", entry: { rule_id: "r", scopeKind: "permanente" }, deps: d })).toThrow(/expiresAt|caducidad/);
+  });
+
+  it("una caducidad ambigua (no ISO estricto) es invalida — Date.parse tragaba fechas locales (catch de codex)", () => {
+    const { deps: d } = deps();
+    for (const bad of ["next friday", "2026-9-1", "01/09/2026", "2026-09-01"]) {
+      expect(() => recordPolicyException({ projectDir: "/p", entry: { rule_id: "r", scopeKind: "permanente", expiresAt: bad }, deps: d })).toThrow(/ISO/);
+    }
+  });
+
+  it("un scopeKind fuera del vocabulario es invalido, no un default silencioso", () => {
+    const { deps: d } = deps();
+    expect(() => recordPolicyException({ projectDir: "/p", entry: { rule_id: "r", scopeKind: "eterna" }, deps: d })).toThrow(/scopeKind/);
+  });
+
+  it("un scopeKind undefined explicito no pisa el valor normalizado del registro (catch de codex)", () => {
+    const { lines, deps: d } = deps();
+    recordPolicyException({ projectDir: "/p", entry: { rule_id: "r", scopeKind: undefined }, deps: d });
+    expect(JSON.parse(lines[0]).scopeKind).toBe("puntual");
+  });
+
+  it("la permanente valida registra scopeKind, expiresAt y el grade de la identidad", () => {
+    const { lines, deps: d } = deps();
+    const rec = recordPolicyException({
+      projectDir: "/p",
+      entry: { rule_id: "r", justification: "j", scopeKind: "permanente", expiresAt: "2026-09-01T00:00:00Z" },
+      deps: d,
+    });
+    expect(rec.scopeKind).toBe("permanente");
+    expect(JSON.parse(lines[0]).who.grade).toBe("declarada");
+  });
+});
+
+const POLICY = `
+version: 1
+roles:
+  coder:
+    write: { deny: ["**/*.secret"], enforcement: deny }
+`;
+
+const standing = (expiresAt) => [{ rule_id: "roles.coder.write.deny", scopeKind: "permanente", expiresAt, justification: "campaña Q3" }];
+const gate = ({ exceptions = [], now }) => {
+  const { policy, errors } = parsePolicy(POLICY);
+  return evaluateGate({ policy, errors, files: ["x.secret"], netLinesAdded: 1, standingExceptions: exceptions, now });
+};
+
+describe("evaluateGate con standing exceptions", () => {
+  it("una permanente VIVA exime el deny de su regla referenciandola", () => {
+    const res = gate({ exceptions: standing("2026-09-01T00:00:00Z"), now: new Date("2026-08-18T00:00:00Z") });
+    expect(res.ok).toBe(true);
+    expect(res.exempted[0]).toMatchObject({ rule_id: "roles.coder.write.deny", standing: expect.objectContaining({ expiresAt: "2026-09-01T00:00:00Z" }) });
+  });
+
+  it("caducada = deny de nuevo — la caducidad es la regla, no una sugerencia", () => {
+    const res = gate({ exceptions: standing("2026-08-01T00:00:00Z"), now: new Date("2026-08-18T00:00:00Z") });
+    expect(res.ok).toBe(false);
+  });
+
+  it("los registros legacy (PL-B, sin scopeKind) NO dan standing — su tipo efectivo era puntual (catch de codex)", () => {
+    const res = gate({
+      exceptions: [{ rule_id: "roles.coder.write.deny", justification: "legacy", diffHash: "abc", expiresAt: "2027-01-01T00:00:00Z" }],
+      now: new Date("2026-08-18T00:00:00Z"),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("una standing de OTRA regla no exime nada", () => {
+    const res = gate({
+      exceptions: [{ rule_id: "roles.coder.shell.deny", scopeKind: "permanente", expiresAt: "2026-09-01T00:00:00Z" }],
+      now: new Date("2026-08-18T00:00:00Z"),
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("las inexcepcionables (security) NO se eximen ni con standing viva", () => {
+    const { policy, errors } = parsePolicy(null, { defaults: [{ id: "defaults.x", pattern: /sealed\//, message: "sellado" }] });
+    const res = evaluateGate({
+      policy, errors, files: ["sealed/a"], netLinesAdded: 1,
+      standingExceptions: [{ rule_id: "defaults.x", scopeKind: "permanente", expiresAt: "2027-01-01T00:00:00Z" }],
+      now: new Date("2026-08-18T00:00:00Z"),
+    });
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## GOV-B parte 1 — la excepción con forma completa (KJC-TSK-0746, épica KJC-PCS-0076)

El objeto Excepción del kernel gana su alcance con vocabulario CERRADO:

- **`scopeKind: puntual | permanente`** — puntual (default, y tipo efectivo de todos los registros legacy de PL-B) liga la excepción al hash del artefacto: caducidad implícita. **permanente exige `expiresAt` en ISO-8601 ESTRICTO** — sin caducidad no hay excepción permanente válida, y `Date.parse` a secas no vale (tragaba fechas locales/ambiguas — catch de codex).
- **`evaluateGate` consulta standing exceptions**: permanentes YA concedidas (las carga el adaptador de su almacén — el kernel no hace I/O) eximen su regla exacta mientras VIVEN, con `now` explícito de quien evalúa: la caducidad es la regla, no una sugerencia. Caducada = deny de nuevo; otra regla = deny; `class: security` = jamás, ni con standing viva.
- La identidad de los registros lleva `grade` (el adaptador de code declara `declarada` en la parte 2 — atribución, no autenticación).

3 catches de codex absorbidos con regresión: legacy sin scopeKind normalizado a puntual (su comportamiento de siempre, ahora explícito), ISO estricto, y el spread que pisaba el scopeKind normalizado.

Parte 2: el adaptador — carga del jsonl, `grade` en la identidad y `kj policy grant`.