### PR TITLE
feat(governance): hash-chained chokepoint decision log (KJC-TSK-0747)

### DIFF
--- a/packages/governance/src/decisions.js
+++ b/packages/governance/src/decisions.js
@@ -1,0 +1,42 @@
+/**
+ * Registro de Decisiones de chokepoint (GOV-C, KJC-TSK-0747) — append-only
+ * y hash-encadenado: cada entrada lleva `prev` = sha256 de la LÍNEA
+ * anterior, así que editar o borrar una entrada rompe la cadena de forma
+ * VERIFICABLE sin más infraestructura que el propio fichero. Se registran
+ * deny, excepciones y el allow del chokepoint de commit — nunca los allow
+ * de tool call. El kernel no hace I/O: append/lastLine son del adaptador.
+ */
+import { createHash } from "node:crypto";
+
+const sha256 = (s) => createHash("sha256").update(s, "utf8").digest("hex");
+
+/** @returns {object} the recorded entry (with ts + prev sealed). */
+export function recordDecision({ entry, deps }) {
+  const { append, lastLine } = deps || {};
+  if (typeof append !== "function" || typeof lastLine !== "function") {
+    throw new TypeError("recordDecision: append y lastLine son del adaptador — el kernel no sabe dónde vive el registro");
+  }
+  const last = lastLine();
+  const record = { ts: new Date().toISOString(), ...entry, prev: last == null ? null : sha256(last) };
+  append(JSON.stringify(record));
+  return record;
+}
+
+/** Verifica la cadena completa (lista de líneas jsonl en orden). */
+export function verifyDecisionChain(lines) {
+  let prevLine = null;
+  for (let i = 0; i < lines.length; i++) {
+    let rec;
+    try {
+      rec = JSON.parse(lines[i]);
+    } catch {
+      return { ok: false, at: i, reason: "línea no parseable" };
+    }
+    const expected = prevLine == null ? null : sha256(prevLine);
+    if (rec.prev !== expected) {
+      return { ok: false, at: i, reason: "prev no casa — cadena rota (entrada editada, borrada o reordenada)" };
+    }
+    prevLine = lines[i];
+  }
+  return { ok: true, length: lines.length };
+}

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -14,3 +14,4 @@ export { globToRegExp, matchesAny, commandPatternToRegExp } from "./glob.js";
 export { parsePolicy, evalWrite, evalShell, checkArtifacts, ALLOW_VERDICT, denyVerdict, DEFAULT_POLICY } from "./engine.js";
 export { evaluateGate } from "./gate.js";
 export { recordPolicyException } from "./exceptions.js";
+export { recordDecision, verifyDecisionChain } from "./decisions.js";

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -18,6 +18,7 @@ import { checkTestsWithCode } from "../review/tests-with-code.js";
 import { loadPrivacyList, scanText } from "../privacy/scan.js";
 import { checkStagedDiff, loadPolicy } from "../policy/engine.js";
 import { loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
+import { policyFileHash, recordGateDecision } from "../policy/decisions.js";
 import { evaluatePolicyGate } from "../review/policy-gate.js";
 
 // KJC-TSK-0686 (MG-A): card-first is a gate, not a habit. Runs on --staged
@@ -241,11 +242,18 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
       ? `⚠ policy standing [${e.rule_id}] — excepción permanente viva hasta ${e.standing.expiresAt} (${e.standing.justification || "sin justificación"})`
       : `⚠ policy exempt [${e.rule_id}] — excepción registrada en .karajan/policy-exceptions.jsonl (${e.justification})`);
   }
+  // GOV-C (KJC-TSK-0747): las decisiones de chokepoint dejan rastro
+  // hash-encadenado — cada deny, cada excepción, y el allow del commit.
+  const chokepoint = flags.check ? "commit" : "review";
+  const seal = (decision, extra = {}) =>
+    recordGateDecision(projectDir, { decision, chokepoint, policy_hash: policyFileHash(projectDir), artifact_hash: diffHash(diff), ...extra });
+  if (gate.exempted.length > 0) seal("exempt", { rule_ids: gate.exempted.map((e) => e.rule_id) });
   if (!gate.ok) {
     for (const d of gate.denials) {
       const sec = d.class === "security" ? " [security — sin escape ni arbitraje]" : "";
       console.log(`✗ policy [${d.rule_id}]${sec} ${d.reason}${at(d)}`);
     }
+    seal("deny", { rule_ids: gate.denials.map((d) => d.rule_id) });
     const reason = gate.invalid
       ? "policy.yml inválida — una regla que miente es peor que ninguna: corrígela"
       : `${gate.denials.length} violación(es) de policy con enforcement=deny — el diff no entra`;
@@ -273,6 +281,8 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
     console.log(res.ok
       ? `✓ verdict ok — approved by ${res.verdict.reviewer} (diff ${res.verdict.diffHash.slice(0, 12)})`
       : `✗ ${res.reason}`);
+    // GOV-C: el allow del chokepoint de COMMIT es evidencia — se sella.
+    if (res.ok) seal("allow");
     process.exitCode = res.ok ? 0 : 1;
     return res;
   }

--- a/src/policy/decisions.js
+++ b/src/policy/decisions.js
@@ -1,0 +1,42 @@
+/**
+ * Adaptador del registro de decisiones para karajan-code (GOV-C,
+ * KJC-TSK-0747): almacén `.karajan/policy-decisions.jsonl`; policy_hash =
+ * sha256 del policy.yml CRUDO (null sin policy — la decisión lo dice, no
+ * lo inventa). Append no atómico entre procesos: aceptado, el chokepoint
+ * de commit es secuencial.
+ */
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { recordDecision } from "../../packages/governance/src/decisions.js";
+
+const filePath = (projectDir) => join(projectDir, ".karajan", "policy-decisions.jsonl");
+
+export function policyFileHash(projectDir) {
+  try {
+    return createHash("sha256").update(readFileSync(join(projectDir, ".karajan", "policy.yml"), "utf8"), "utf8").digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+/** @returns {object} the sealed record. */
+export function recordGateDecision(projectDir, entry) {
+  return recordDecision({
+    entry,
+    deps: {
+      lastLine: () => {
+        try {
+          const lines = readFileSync(filePath(projectDir), "utf8").split("\n").filter((l) => l.trim());
+          return lines.at(-1) ?? null;
+        } catch {
+          return null;
+        }
+      },
+      append: (line) => {
+        mkdirSync(join(projectDir, ".karajan"), { recursive: true });
+        appendFileSync(filePath(projectDir), `${line}\n`, "utf8");
+      },
+    },
+  });
+}

--- a/tests/governance/decision-log.test.js
+++ b/tests/governance/decision-log.test.js
@@ -1,0 +1,104 @@
+// GOV-C (KJC-TSK-0747) — decisiones de chokepoint append-only y
+// hash-encadenadas: cada entrada referencia la anterior; editar o borrar
+// una rompe la cadena de forma VERIFICABLE. El kernel no hace I/O.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { recordDecision, verifyDecisionChain } from "../../packages/governance/src/decisions.js";
+import { recordGateDecision, policyFileHash } from "../../src/policy/decisions.js";
+
+const reviewMock = vi.fn();
+vi.mock("../../src/review/one-shot-review.js", () => ({ runOneShotReview: (...a) => reviewMock(...a) }));
+vi.mock("../../src/review/sonar-pregate.js", async (orig) => ({
+  ...(await orig()), runSonarPregate: vi.fn().mockResolvedValue({ available: false, reason: "test" }),
+}));
+vi.mock("../../src/review/card-first.js", async (orig) => ({
+  ...(await orig()), checkCardFirst: vi.fn().mockResolvedValue({ ok: true, mode: "pass" }),
+}));
+vi.mock("../../src/review/verdict-store.js", async (orig) => ({
+  ...(await orig()), checkVerdict: vi.fn().mockResolvedValue({ ok: true, verdict: { reviewer: "codex", diffHash: "abc123456789" } }),
+}));
+
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+
+describe("kernel: recordDecision + verifyDecisionChain", () => {
+  it("encadena por hash y la verificacion detecta manipulacion", () => {
+    const lines = [];
+    const deps = { append: (l) => lines.push(l), lastLine: () => lines.at(-1) ?? null };
+    recordDecision({ entry: { decision: "deny", rule_ids: ["r1"] }, deps });
+    recordDecision({ entry: { decision: "allow", artifact_hash: "abc" }, deps });
+    expect(JSON.parse(lines[0]).prev).toBeNull();
+    expect(JSON.parse(lines[1]).prev).toHaveLength(64);
+    expect(verifyDecisionChain(lines)).toEqual({ ok: true, length: 2 });
+    const tampered = [lines[0].replace("deny", "allow"), lines[1]];
+    expect(verifyDecisionChain(tampered).ok).toBe(false);
+    expect(verifyDecisionChain([lines[1]]).ok).toBe(false); // borrar la primera rompe
+  });
+
+  it("el kernel exige el almacen inyectado", () => {
+    expect(() => recordDecision({ entry: { decision: "deny" } })).toThrow(/adaptador/);
+  });
+});
+
+describe("adaptador + chokepoints", () => {
+  let dir;
+  const cwd0 = process.cwd();
+  afterEach(() => { process.chdir(cwd0); });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-decis-"));
+    const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+    git("init", "-q");
+    git("config", "user.email", "t@t"); git("config", "user.name", "t");
+    fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "base.js"), "base\n");
+    git("add", "base.js"); git("commit", "-qm", "base");
+    fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"),
+      "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.secret'], enforcement: deny }\n");
+    process.chdir(dir);
+    reviewMock.mockResolvedValue({ verdict: "approved", reviewer: "codex", diffHash: "abc123456789" });
+  });
+
+  const stage = (name) => {
+    fs.writeFileSync(path.join(dir, name), "x\n");
+    execFileSync("git", ["-C", dir, "add", name]);
+  };
+  const log = () => fs.readFileSync(path.join(dir, ".karajan", "policy-decisions.jsonl"), "utf8").trim().split("\n").map((l) => JSON.parse(l));
+  const silence = () => vi.spyOn(console, "log").mockImplementation(() => {});
+
+  it("un deny en el gate queda registrado con policy_hash y artefacto (y sin policy el hash es null)", async () => {
+    expect(policyFileHash(fs.mkdtempSync(path.join(os.tmpdir(), "kj-nopol-")))).toBeNull();
+    stage("prod.secret");
+    const spy = silence();
+    await reviewGateCommand({ config: { projectDir: dir }, flags: { staged: true } });
+    spy.mockRestore();
+    const [rec] = log();
+    expect(rec).toMatchObject({ decision: "deny", chokepoint: "review" });
+    expect(rec.rule_ids).toContain("roles.coder.write.deny");
+    expect(rec.policy_hash).toHaveLength(64);
+    expect(rec.artifact_hash).toHaveLength(64);
+  });
+
+  it("el allow del chokepoint de COMMIT (--check) se registra; el de --staged no", async () => {
+    stage("src-ok.js");
+    const spy = silence();
+    await reviewGateCommand({ config: { projectDir: dir }, flags: { staged: true } });
+    expect(fs.existsSync(path.join(dir, ".karajan", "policy-decisions.jsonl"))).toBe(false);
+    await reviewGateCommand({ config: { projectDir: dir }, flags: { check: true } });
+    spy.mockRestore();
+    const recs = log();
+    expect(recs).toHaveLength(1);
+    expect(recs[0]).toMatchObject({ decision: "allow", chokepoint: "commit" });
+  });
+
+  it("recordGateDecision encadena en disco", () => {
+    recordGateDecision(dir, { decision: "deny", rule_ids: ["x"] });
+    recordGateDecision(dir, { decision: "allow" });
+    const recs = log();
+    expect(recs[1].prev).toHaveLength(64);
+  });
+});


### PR DESCRIPTION
## GOV-C — el registro de decisiones de chokepoint (KJC-TSK-0747, épica KJC-PCS-0076)

Cierra el gap de evidencia de PROCESO que salió del diagnóstico de auditabilidad: hasta hoy solo los resultados (veredictos) y las excepciones dejaban rastro — las DECISIONES del gate, no.

- **Kernel `decisions.js`** — `recordDecision` sella cada entrada con `prev` = sha256 de la línea anterior: append-only y **hash-encadenado** — editar, borrar o reordenar una entrada rompe la cadena de forma verificable (`verifyDecisionChain`), sin más infraestructura que el propio fichero. El kernel no hace I/O: append/lastLine inyectados.
- **Adaptador** — `.karajan/policy-decisions.jsonl`; `policy_hash` = sha256 del policy.yml crudo (null sin policy: la decisión lo dice, no lo inventa); `artifact_hash` = hash del diff.
- **Qué se sella y qué no**: cada deny (con sus rule_ids), cada excepción, y el **allow del chokepoint de COMMIT** (`--check`, lo que llama el pre-commit). Los allow de `--staged` y de tool calls NO se registran — volumen y ruido no son evidencia (decisión de la épica, con test que lo fija).

TDD: 5 tests (cadena manipulada detectada, deny sellado, allow solo en commit, encadenado en disco). Suite completa 6.635 ✓. 199 net.