### PR TITLE
feat(policy): kj policy anchor seals the decision log head in git (KJC-TSK-0749)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist/
 # …the v4 contract the whole team inherits (KJC-TSK-0641):
 !.karajan/adrs/
 !.karajan/review-gate
+# GOV-C2: el sello del decision log SE COMMITEA — es el anclaje temporal.
+!.karajan/policy-anchor.json
 !.karajan/hooks/
 .karajan/hooks/*
 !.karajan/hooks/pre-commit

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -309,6 +309,14 @@ export function registerMeta(program, { pkgVersion }) {
         process.exitCode = await policyCommand({ action: "grant", config, flags });
       });
     });
+  policyCmd.command("anchor")
+    .description("Verifica la cadena del decision log y sella su head-hash en .karajan/policy-anchor.json (trackeado) — anclaje temporal en la historia de git, GOV-C2")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "policy-anchor", flags, async ({ config }) => {
+        const { policyCommand } = await import("../commands/policy.js");
+        process.exitCode = await policyCommand({ action: "anchor", config, flags });
+      });
+    });
   policyCmd.command("check")
     .description("Comprueba el diff STAGED contra la policy (write-deny + invariantes) — siempre warn en PL-A; exit 1 solo si policy.yml es inválido")
     .option("--role <role>", "Rol del agente", "coder")

--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -8,8 +8,12 @@
  */
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
 import { recordPolicyException } from "../policy/exceptions.js";
+import { verifyDecisionChain } from "../../packages/governance/src/decisions.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -37,6 +41,44 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
     for (const e of errors) logger.error?.(`✗ ${e}`);
     logger.error?.("policy: el fichero declara lo que el motor no puede aplicar — corrígelo (una regla que miente es peor que ninguna)");
     return 1;
+  }
+
+  // GOV-C2 (KJC-TSK-0749): anclaje temporal sin blockchain — verificar la
+  // cadena ENTERA y sellar su head-hash en un fichero TRACKEADO por git:
+  // reescribir el log de ayer exige reescribir el repo de ayer. Un anchor
+  // previo con más entradas que el log actual = truncado ⇒ no se re-sella.
+  if (action === "anchor") {
+    let raw;
+    try {
+      raw = readFileSync(join(projectDir, ".karajan", "policy-decisions.jsonl"), "utf8");
+    } catch {
+      logger.info?.("policy anchor: sin decisiones que anclar — el log nace con el primer deny/excepción/commit-allow");
+      return 0;
+    }
+    const lines = raw.split("\n").filter((l) => l.trim());
+    // Fichero vacío o solo whitespace = sin decisiones (catch de codex:
+    // lines.at(-1) undefined reventaba el hash en vez de salir limpio).
+    if (lines.length === 0) {
+      logger.info?.("policy anchor: sin decisiones que anclar — el log nace con el primer deny/excepción/commit-allow");
+      return 0;
+    }
+    const chain = verifyDecisionChain(lines);
+    if (!chain.ok) {
+      logger.error?.(`✗ policy anchor: cadena rota en la entrada ${chain.at} (${chain.reason}) — el log ha sido manipulado; NO se sella`);
+      return 1;
+    }
+    const anchorFile = join(projectDir, ".karajan", "policy-anchor.json");
+    try {
+      const prev = JSON.parse(readFileSync(anchorFile, "utf8"));
+      if (Number.isFinite(prev.length) && prev.length > chain.length) {
+        logger.error?.(`✗ policy anchor: el log retrocede (anchor previo=${prev.length} entradas, actual=${chain.length}) — truncado tras el último sello; NO se re-sella`);
+        return 1;
+      }
+    } catch { /* sin anchor previo (o ilegible): primer sello */ }
+    const head = createHash("sha256").update(lines.at(-1), "utf8").digest("hex");
+    writeFileSync(anchorFile, `${JSON.stringify({ head, length: chain.length, ts: new Date().toISOString() }, null, 2)}\n`, "utf8");
+    logger.info?.(`✓ policy anchor: cadena íntegra (${chain.length} decisiones) — head ${head.slice(0, 12)} sellado en .karajan/policy-anchor.json; committéalo para anclarlo en la historia de git`);
+    return 0;
   }
 
   // GOV-B (KJC-TSK-0746): conceder una excepción PERMANENTE con el modelo

--- a/tests/policy/anchor.test.js
+++ b/tests/policy/anchor.test.js
@@ -1,0 +1,73 @@
+// GOV-C2 (KJC-TSK-0749) — anclaje temporal sin blockchain: kj policy anchor
+// verifica la cadena ENTERA y sella su head-hash en un fichero trackeable
+// por git — reescribir el log de ayer exige reescribir el repo de ayer.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { policyCommand } from "../../src/commands/policy.js";
+import { recordGateDecision } from "../../src/policy/decisions.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); });
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-anchor-"));
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  process.chdir(dir);
+});
+
+const logger = () => {
+  const out = { info: [], error: [] };
+  return { out, log: { info: (m) => out.info.push(m), error: (m) => out.error.push(m) } };
+};
+const anchorPath = () => path.join(dir, ".karajan", "policy-anchor.json");
+const run = (log) => policyCommand({ action: "anchor", config: { projectDir: dir }, flags: {}, logger: log });
+
+describe("kj policy anchor", () => {
+  it("verifica la cadena y sella head, length y ts en un json trackeable", async () => {
+    recordGateDecision(dir, { decision: "deny", rule_ids: ["r1"] });
+    recordGateDecision(dir, { decision: "allow", chokepoint: "commit" });
+    const { out, log } = logger();
+    expect(await run(log)).toBe(0);
+    const anchor = JSON.parse(fs.readFileSync(anchorPath(), "utf8"));
+    expect(anchor.length).toBe(2);
+    expect(anchor.head).toHaveLength(64);
+    expect(anchor.ts).toBeTruthy();
+    expect(out.info.join("\n")).toMatch(/commit/i);
+  });
+
+  it("cadena manipulada = exit 1 gritando y SIN sellar", async () => {
+    recordGateDecision(dir, { decision: "deny", rule_ids: ["r1"] });
+    recordGateDecision(dir, { decision: "allow" });
+    const p = path.join(dir, ".karajan", "policy-decisions.jsonl");
+    fs.writeFileSync(p, fs.readFileSync(p, "utf8").replace('"deny"', '"allow"'));
+    const { out, log } = logger();
+    expect(await run(log)).toBe(1);
+    expect(fs.existsSync(anchorPath())).toBe(false);
+    expect(out.error.join("\n")).toMatch(/cadena|rota/i);
+  });
+
+  it("log truncado tras un anchor previo se detecta (length retrocede) y no se re-sella", async () => {
+    recordGateDecision(dir, { decision: "deny", rule_ids: ["r1"] });
+    recordGateDecision(dir, { decision: "allow" });
+    expect(await run(logger().log)).toBe(0);
+    const p = path.join(dir, ".karajan", "policy-decisions.jsonl");
+    const first = fs.readFileSync(p, "utf8").split("\n")[0];
+    fs.writeFileSync(p, `${first}\n`); // borra la segunda entrada: cadena VÁLIDA pero más corta
+    const { out, log } = logger();
+    expect(await run(log)).toBe(1);
+    expect(out.error.join("\n")).toMatch(/retroced|anchor/i);
+  });
+
+  it("sin log que anclar (ausente o vacio) lo dice y no inventa un anchor", async () => {
+    const { out, log } = logger();
+    expect(await run(log)).toBe(0);
+    expect(fs.existsSync(anchorPath())).toBe(false);
+    expect(out.info.join("\n")).toMatch(/sin decisiones/i);
+    fs.writeFileSync(path.join(dir, ".karajan", "policy-decisions.jsonl"), "\n  \n"); // vacio = lo mismo (catch de codex)
+    expect(await run(logger().log)).toBe(0);
+    expect(fs.existsSync(anchorPath())).toBe(false);
+  });
+});


### PR DESCRIPTION
## GOV-C2 — anclaje temporal sin blockchain (KJC-TSK-0749, épica KJC-PCS-0076)

Nace de la discusión "¿qué bases de blockchain tienen cabida?": la respuesta fue tomar la criptografía de integridad y dejar fuera la descentralización adversarial. Esta es la última pieza accionable de esa criba:

- **`kj policy anchor`** verifica la cadena ENTERA del decision log (rota = exit 1 gritando, sin sellar) y escribe `.karajan/policy-anchor.json` `{head, length, ts}` — un fichero TRACKEADO (gitignore lo permite explícitamente): al committearlo, reescribir el log de ayer exige reescribir el repo de ayer.
- **Truncado detectado**: si el log actual tiene MENOS entradas que el último sello, es que alguien recortó tras anclar — no se re-sella.
- Log ausente o vacío = "sin decisiones que anclar", salida limpia (catch de codex: el hash sobre `undefined` reventaba — con regresión).

TDD: 4 tests. Suite completa 6.640 ✓. 125 net.