### PR TITLE
chore(governance): rename kernel to @karajan-family/governance (KJC-TSK-0748)

### DIFF
--- a/.karajan/adrs/0003-governance-kernel-karajan-governance-como-paquete-de-familia.md
+++ b/.karajan/adrs/0003-governance-kernel-karajan-governance-como-paquete-de-familia.md
@@ -1,4 +1,4 @@
-# Governance kernel: @karajan/governance como paquete de familia
+# Governance kernel: @karajan-family/governance como paquete de familia
 
 Status: accepted
 Date: 2026-08-18
@@ -9,7 +9,9 @@ La policy layer (ADR 0001, PL-A/PL-B) construyó un motor de políticas, un gate
 
 ## Decision
 
-El kernel vive en packages/governance (@karajan/governance; patrón hu-board hasta publicarse: workspace npm + imports relativos + whitelist en files del tarball de kj — GOV-D lo convierte en dependencia real). El kernel conoce EXACTAMENTE tres conceptos abstractos: Política (reglas declarativas versionadas, vocabulario CERRADO fail-loud, con subconjunto inexcepcionable), Decisión (evaluación determinista y local de una acción contra una política, sin red ni LLM, con regla citada y enforcement) y Excepción (objeto de primera clase: identidad de quien aprueba, regla exacta, justificación escrita en el momento, alcance con caducidad, hash del artefacto). El kernel NO conoce git, diffs, Sonar, tool calls concretas, agentes ni LLMs: la noción de artefacto es una interfaz (algo con identidad referenciable y hasheable) y cada adaptador la implementa (code: el diff; rag: documento/chunk; watch: evento; radar: informe). Los defaults inexcepcionables son DATOS que cada consumidor inyecta ({id, pattern, message}); en code protegen los ficheros del supervisor del Sentinel. El criterio de frontera: si una constante nombra una tool de harness, una ruta de un proyecto o un comando de git, es del adaptador; si es evaluación de patrones, vocabulario o flujo warn/deny/inexcepcionable/excepción, es del kernel.
+El kernel vive en packages/governance (@karajan-family/governance; patrón hu-board hasta publicarse: workspace npm + imports relativos + whitelist en files del tarball de kj — GOV-D lo convierte en dependencia real). El kernel conoce EXACTAMENTE tres conceptos abstractos: Política (reglas declarativas versionadas, vocabulario CERRADO fail-loud, con subconjunto inexcepcionable), Decisión (evaluación determinista y local de una acción contra una política, sin red ni LLM, con regla citada y enforcement) y Excepción (objeto de primera clase: identidad de quien aprueba, regla exacta, justificación escrita en el momento, alcance con caducidad, hash del artefacto). El kernel NO conoce git, diffs, Sonar, tool calls concretas, agentes ni LLMs: la noción de artefacto es una interfaz (algo con identidad referenciable y hasheable) y cada adaptador la implementa (code: el diff; rag: documento/chunk; watch: evento; radar: informe). Los defaults inexcepcionables son DATOS que cada consumidor inyecta ({id, pattern, message}); en code protegen los ficheros del supervisor del Sentinel. El criterio de frontera: si una constante nombra una tool de harness, una ruta de un proyecto o un comando de git, es del adaptador; si es evaluación de patrones, vocabulario o flujo warn/deny/inexcepcionable/excepción, es del kernel.
+
+Nota de nombre (2026-08-19): el scope npm "karajan" estaba ocupado; el usuario creó la organización "karajan-family" y el paquete queda como @karajan-family/governance — el nombre dice lo que la org ES (una familia de herramientas) y no ata el kernel al dominio código.
 
 ## Consequences
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -844,12 +844,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@karajan/ai-trash": {
-      "resolved": "packages/ai-trash",
+    "node_modules/@karajan-family/governance": {
+      "resolved": "packages/governance",
       "link": true
     },
-    "node_modules/@karajan/governance": {
-      "resolved": "packages/governance",
+    "node_modules/@karajan/ai-trash": {
+      "resolved": "packages/ai-trash",
       "link": true
     },
     "node_modules/@karajan/hu-board": {
@@ -7833,7 +7833,7 @@
       }
     },
     "packages/governance": {
-      "name": "@karajan/governance",
+      "name": "@karajan-family/governance",
       "version": "0.1.0",
       "license": "MIT"
     },

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@karajan/governance",
+  "name": "@karajan-family/governance",
   "version": "0.1.0",
   "description": "Governance kernel for agent actions — Policy, Decision and Exception as first-class objects. Deterministic, local, domain-agnostic: adapters map each domain's actions and artifacts (karajan-code is the first consumer, not the owner).",
   "type": "module",

--- a/packages/governance/src/engine.js
+++ b/packages/governance/src/engine.js
@@ -1,7 +1,7 @@
 /**
  * governance kernel engine — nacido como policy engine de karajan-code
  * (PL-A KJC-TSK-0733, PL-B KJC-TSK-0734, ADR 0001) y extraído a
- * @karajan/governance en GOV-A (KJC-TSK-0745, ADR 0003). Policy as DATA
+ * @karajan-family/governance en GOV-A (KJC-TSK-0745, ADR 0003). Policy as DATA
  * (vocabulario CERRADO), engine as code: módulo puro, determinista, sin
  * red ni LLM. Una regla que el motor no puede aplicar falla FUERTE al
  * cargar — jamás se ignora en silencio. Deny gana a allow; una allow-list

--- a/packages/governance/src/index.js
+++ b/packages/governance/src/index.js
@@ -1,5 +1,5 @@
 /**
- * @karajan/governance — governance kernel for agent actions (ADR 0003,
+ * @karajan-family/governance — governance kernel for agent actions (ADR 0003,
  * epic KJC-PCS-0076). The kernel knows exactly three concepts, all
  * abstract: Policy (declarative, versioned, closed fail-loud vocabulary,
  * with a non-exemptable subset), Decision (deterministic evaluation of an

--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -1,6 +1,6 @@
 /**
  * karajan-code policy ADAPTER (GOV-A, KJC-TSK-0745, ADR 0003). El motor
- * vive en @karajan/governance (packages/governance): aquí queda SOLO lo
+ * vive en @karajan-family/governance (packages/governance): aquí queda SOLO lo
  * que es de este dominio — dónde vive el fichero de policy, los defaults
  * inexcepcionables del supervisor del Sentinel, y el mapeo de tools del
  * harness (Write/Edit/Bash…) a capabilities del kernel. La superficie

--- a/src/policy/exceptions.js
+++ b/src/policy/exceptions.js
@@ -1,6 +1,6 @@
 /**
  * Adaptador de excepciones de karajan-code (GOV-A, KJC-TSK-0745). El
- * registro vive en el kernel (@karajan/governance); aquí solo lo que es de
+ * registro vive en el kernel (@karajan-family/governance); aquí solo lo que es de
  * este dominio: la identidad (git user + usuario del SO — DECLARADA, no
  * autenticada) y el destino append-only `.karajan/policy-exceptions.jsonl`.
  */

--- a/src/review/policy-gate.js
+++ b/src/review/policy-gate.js
@@ -1,7 +1,7 @@
 /**
  * Adaptador del gate de policy en el flujo de review de karajan-code
  * (GOV-A, KJC-TSK-0745). La decisión warn/deny/inexcepcionable/excepción
- * vive en el kernel (@karajan/governance); aquí solo el dominio: la
+ * vive en el kernel (@karajan-family/governance); aquí solo el dominio: la
  * excepción se pide con KJ_ALLOW_POLICY=1 + KJ_POLICY_REASON, y el
  * artefacto de este dominio es el diff staged — por eso el alcance
  * registrado dice "este diff exacto".


### PR DESCRIPTION
GOV-D paso 1: el scope npm karajan estaba ocupado; la org karajan-family existe desde hoy (creada por el usuario). Rename del paquete + nota de nombre final en el ADR 0003 + lock regenerado. Whitelist e imports relativos intactos hasta publicar (paso 2) — el switch a dependencia real es el paso 3.