### PR TITLE
feat(governance): kj consumes the published kernel as a real dependency (KJC-TSK-0748)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       ],
       "dependencies": {
         "@babel/parser": "^7.29.7",
+        "@karajan-family/governance": "^0.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
     "templates/",
     "scripts/",
     "vendor/tree-sitter-grammars/",
-    "packages/governance/src/",
-    "packages/governance/package.json",
     "packages/hu-board/src/",
     "packages/hu-board/public/",
     "packages/hu-board/package.json",
@@ -103,6 +101,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.7",
+    "@karajan-family/governance": "^0.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",

--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -13,7 +13,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
 import { recordPolicyException } from "../policy/exceptions.js";
-import { verifyDecisionChain } from "../../packages/governance/src/decisions.js";
+import { verifyDecisionChain } from "@karajan-family/governance";
 
 const execFileAsync = promisify(execFile);
 

--- a/src/policy/decisions.js
+++ b/src/policy/decisions.js
@@ -8,7 +8,7 @@
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
-import { recordDecision } from "../../packages/governance/src/decisions.js";
+import { recordDecision } from "@karajan-family/governance";
 
 const filePath = (projectDir) => join(projectDir, ".karajan", "policy-decisions.jsonl");
 

--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -17,7 +17,7 @@ import {
   evalWrite,
   parsePolicy,
   DEFAULT_POLICY as KERNEL_DEFAULT_POLICY,
-} from "../../packages/governance/src/engine.js";
+} from "@karajan-family/governance";
 
 // Defaults inexcepcionables de karajan-code: los ficheros del supervisor
 // (antes hardcodeados en el PRETOOL del Sentinel — PL-B). Misma semántica

--- a/src/policy/exceptions.js
+++ b/src/policy/exceptions.js
@@ -8,7 +8,7 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { userInfo } from "node:os";
 import { spawnSync } from "node:child_process";
-import { recordPolicyException as kernelRecord } from "../../packages/governance/src/exceptions.js";
+import { recordPolicyException as kernelRecord } from "@karajan-family/governance";
 
 function defaultIdentity(projectDir) {
   const git = (args) => spawnSync("git", ["-C", projectDir, "config", ...args], { encoding: "utf8" }).stdout?.trim() || null;

--- a/src/review/policy-gate.js
+++ b/src/review/policy-gate.js
@@ -6,7 +6,7 @@
  * artefacto de este dominio es el diff staged — por eso el alcance
  * registrado dice "este diff exacto".
  */
-import { evaluateGate } from "../../packages/governance/src/gate.js";
+import { evaluateGate } from "@karajan-family/governance";
 
 /**
  * @returns {{ok: boolean, invalid?: boolean, warns: object[], denials: object[], exempted: object[]}}

--- a/tests/governance/decision-log.test.js
+++ b/tests/governance/decision-log.test.js
@@ -7,7 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
-import { recordDecision, verifyDecisionChain } from "../../packages/governance/src/decisions.js";
+import { recordDecision, verifyDecisionChain } from "@karajan-family/governance";
 import { recordGateDecision, policyFileHash } from "../../src/policy/decisions.js";
 
 const reviewMock = vi.fn();

--- a/tests/governance/engine-kernel.test.js
+++ b/tests/governance/engine-kernel.test.js
@@ -3,8 +3,7 @@
 // expedientes), no hay tools de harness ni rutas .karajan en el motor.
 
 import { describe, it, expect } from "vitest";
-import { parsePolicy, evalWrite, evalShell, checkArtifacts } from "../../packages/governance/src/engine.js";
-import { recordPolicyException } from "../../packages/governance/src/exceptions.js";
+import { parsePolicy, evalWrite, evalShell, checkArtifacts, recordPolicyException } from "@karajan-family/governance";
 
 const LEDGER_DEFAULTS = [
   { id: "defaults.ledger.sealed", pattern: /sealed\//, message: "toca expedientes sellados — solo el registrador los modifica" },

--- a/tests/governance/glob.test.js
+++ b/tests/governance/glob.test.js
@@ -1,7 +1,7 @@
 // PL-A (KJC-TSK-0733) — el primitivo glob de la policy: semántica pequeña,
 // anclada y SIN sorpresas de lib general.
 import { describe, it, expect } from "vitest";
-import { globToRegExp, matchesAny } from "../../packages/governance/src/glob.js";
+import { globToRegExp, matchesAny } from "@karajan-family/governance";
 
 describe("globToRegExp", () => {
   it("** cruza directorios, * no sale de su segmento, ? es un carácter", () => {

--- a/tests/governance/standing-exceptions.test.js
+++ b/tests/governance/standing-exceptions.test.js
@@ -5,9 +5,7 @@
 // quien evalúa, no el kernel).
 
 import { describe, it, expect, vi } from "vitest";
-import { recordPolicyException } from "../../packages/governance/src/exceptions.js";
-import { evaluateGate } from "../../packages/governance/src/gate.js";
-import { parsePolicy } from "../../packages/governance/src/engine.js";
+import { evaluateGate, parsePolicy, recordPolicyException } from "@karajan-family/governance";
 
 const deps = () => {
   const lines = [];


### PR DESCRIPTION
## GOV-D paso 3 — el kernel ya no viaja de polizón (KJC-TSK-0748; @karajan-family/governance@0.1.0 publicado hoy)

- kj depende de `@karajan-family/governance ^0.1.0` (patrón karajan-core: workspace local en dev, registro npm en el tarball publicado).
- Todos los imports pasan de rutas relativas al índice público del paquete — src y tests: los tests del kernel ejercitan ahora el export map real.
- La whitelist del tarball (`packages/governance/*` en `files`) se retira: **verify-pack verde probando que el tarball de kj resuelve el kernel DESDE EL REGISTRO** — el patrón hu-board cumplió su función de puente y se va.

Nota de la publicación: el scope acabó siendo la CUENTA `karajan-family` (npm no permite convertirla en org sin crear otro usuario); `manufosela` es owner del paquete, así que las versiones futuras se publican desde la cuenta de siempre. Con esto **la épica KJC-PCS-0076 queda completa**: GOV-A extracción, GOV-B excepciones con caducidad, GOV-C decision log encadenado + C2 anclaje, GOV-D publicación y consumo real.