### PR TITLE
feat(policy): single threshold source — pr-size and ci read the policy file (KJC-TSK-0735)

### DIFF
--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -25,10 +25,11 @@ permissions:
   pull-requests: read
 
 env:
-  # Net LOC limit per PR before the budget check fails. Tune carefully —
-  # tightened from 500 → 200 (2026-05-08) — atomic PRs are the rule, not the exception. Use the `large-pr-justified` label
-  # for one-off exceptions instead.
-  LOC_LIMIT: "200"
+  # PL-C (KJC-TSK-0735): the limit's SINGLE SOURCE is .karajan/policy.yml
+  # (invariant loc-budget). The step below extracts it fail-loud — a gate
+  # that cannot find its threshold must not guess. `large-pr-justified`
+  # label remains the one-off escape.
+  KJ_POLICY_FILE: ".karajan/policy.yml"
 
 jobs:
   loc-budget:
@@ -37,8 +38,8 @@ jobs:
     # allowed there — see actionlint expression rules). The original
     # PR carried the same bug, which silently disabled the entire
     # workflow file with a 0s "validation failure" run on every push.
-    # Hard-coded number here; the real limit lives in `env.LOC_LIMIT`
-    # below and the steps still read that — name is purely cosmetic.
+    # The real limit lives in .karajan/policy.yml (single source, PL-C)
+    # and is extracted fail-loud in the compute step — name is cosmetic.
     name: Net LOC delta within budget
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'large-pr-justified') }}
@@ -56,6 +57,16 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+
+          # Single source of thresholds (PL-C): read the loc-budget max from
+          # the policy file — the same number kj review and kj policy check use.
+          LOC_LIMIT=$(awk '/id: loc-budget/{f=1} f && /max:/{print $2; exit}' "$KJ_POLICY_FILE")
+          case "$LOC_LIMIT" in (''|*[!0-9]*)
+            echo "::error::loc-budget max not found in $KJ_POLICY_FILE — the gate refuses to guess"; exit 1;;
+          esac
+          echo "LOC_LIMIT=$LOC_LIMIT (source: $KJ_POLICY_FILE)"
+          # Exportado a los steps posteriores (Enforce) — el env de un run no cruza steps.
+          echo "LOC_LIMIT=$LOC_LIMIT" >> "$GITHUB_ENV"
 
           # Excluded paths: lockfiles, snapshots, build output, vendored
           # third-party, minified bundles, generated diet baselines,

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -148,7 +148,15 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   // Field case: a 522-line PR sailed past the warning with a
   // rationalization — where the project wants teeth, pr_size: "block"
   // rejects deterministically with a NAMED escape. Default stays warn.
-  const sizeWarn = config?.method_gates?.pr_size_warn ?? 150;
+  // PL-C (KJC-TSK-0735), fuente única de umbrales: si la policy declara el
+  // invariante net_lines_added, SU max es el umbral — el mismo número que
+  // aplican kj policy check y el tier C de CI; method_gates queda de fallback.
+  const pol = loadPolicy({ projectDir });
+  const locInv = pol.errors.length === 0
+    ? (pol.policy.invariants || []).find((i) => i.kind === "diff-threshold" && i.metric === "net_lines_added")
+    : null;
+  const sizeWarn = locInv?.max ?? config?.method_gates?.pr_size_warn ?? 150;
+  const sizeSource = locInv ? `policy [${locInv.id}]` : "method_gates";
   if (sizeWarn > 0) {
     const numstat = await rawDiff(flags.range, ["--numstat"]);
     const added = numstat.split("\n").reduce((acc, l) => acc + (Number(l.split("\t")[0]) || 0), 0);
@@ -157,12 +165,12 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
       if (process.env.KJ_ALLOW_LARGE_PR === "1") {
         console.log(`⚠ pr-size exempt: ${added} lines added — KJ_ALLOW_LARGE_PR=1 (explicit escape hatch)`);
       } else if (sizePolicy === "block") {
-        const reason = `${added} lines added exceeds the ${sizeWarn}-line budget (method_gates.pr_size: block) — partition the work, or get your user's explicit OK and re-run with KJ_ALLOW_LARGE_PR=1`;
+        const reason = `${added} lines added exceeds the ${sizeWarn}-line budget (${sizeSource}; method_gates.pr_size: block) — partition the work, or get your user's explicit OK and re-run with KJ_ALLOW_LARGE_PR=1`;
         console.log(`✗ pr-size gate: ${reason}`);
         process.exitCode = 1;
         return { verdict: "rejected", reviewer: "pr-size", issues: [{ severity: "high", description: reason }] };
       } else {
-        console.log(`⚠ pr-size: ${added} lines added (guideline ~${sizeWarn}) — an oversized warning is not an opinion: partition, or ask your user (method_gates.pr_size: block to harden)`);
+        console.log(`⚠ pr-size: ${added} lines added (guideline ~${sizeWarn}, source: ${sizeSource}) — an oversized warning is not an opinion: partition, or ask your user (method_gates.pr_size: block to harden)`);
       }
     }
   }
@@ -218,7 +226,6 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   // hooks. enforcement=warn avisa; deny cierra salvo excepción probatoria
   // (KJ_ALLOW_POLICY=1 + KJ_POLICY_REASON, registrada con identidad y hash
   // del diff); class=security cierra sin escape y sin arbitraje.
-  const pol = loadPolicy({ projectDir });
   let net = 0;
   for (const l of (await rawDiff(flags.range, ["--numstat"])).split("\n")) {
     const [a, r] = l.trim().split(/\s+/);

--- a/tests/review/pr-size-policy-source.test.js
+++ b/tests/review/pr-size-policy-source.test.js
@@ -1,0 +1,81 @@
+// PL-C (KJC-TSK-0735) — fuente única de umbrales: cuando la policy declara
+// el invariante net_lines_added, el aviso/gate pr-size del review LEE ESE
+// max (el policy file GANA a method_gates); sin invariante, todo sigue como
+// siempre. Un solo número para el aviso local y el gate de CI.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const reviewMock = vi.fn();
+vi.mock("../../src/review/one-shot-review.js", () => ({ runOneShotReview: (...a) => reviewMock(...a) }));
+vi.mock("../../src/review/sonar-pregate.js", async (orig) => ({
+  ...(await orig()), runSonarPregate: vi.fn().mockResolvedValue({ available: false, reason: "test" }),
+}));
+vi.mock("../../src/review/card-first.js", async (orig) => ({
+  ...(await orig()), checkCardFirst: vi.fn().mockResolvedValue({ ok: true, mode: "pass" }),
+}));
+
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); });
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = 0;
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-prsrc-"));
+  const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+  git("init", "-q");
+  git("config", "user.email", "t@t"); git("config", "user.name", "t");
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "a.js"), "base\n");
+  git("add", "a.js"); git("commit", "-qm", "base");
+  // 30 líneas añadidas + un test para no disparar tests-with-code.
+  fs.writeFileSync(path.join(dir, "a.js"), Array.from({ length: 30 }, (_, i) => `l${i}`).join("\n"));
+  fs.writeFileSync(path.join(dir, "a.test.js"), "t\n");
+  git("add", "-A");
+  process.chdir(dir);
+  reviewMock.mockResolvedValue({ verdict: "approved", reviewer: "codex", diffHash: "abc123456789" });
+});
+
+const withPolicyMax = (max) =>
+  fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"),
+    `version: 1\ninvariants:\n  - { id: loc-budget, kind: diff-threshold, metric: net_lines_added, max: ${max} }\n`);
+const logs = () => {
+  const out = [];
+  const spy = vi.spyOn(console, "log").mockImplementation((...a) => out.push(a.join(" ")));
+  return { out, spy };
+};
+
+describe("pr-size con la policy como fuente unica", () => {
+  it("el invariante de la policy GANA a method_gates.pr_size_warn", async () => {
+    withPolicyMax(10);
+    const { out, spy } = logs();
+    await reviewGateCommand({ config: { projectDir: dir, method_gates: { pr_size_warn: 500 } }, flags: { staged: true } });
+    spy.mockRestore();
+    expect(out.join("\n")).toMatch(/pr-size.*(policy|loc-budget)/);
+  });
+
+  it("pr_size block usa el max de la policy y lo nombra", async () => {
+    withPolicyMax(10);
+    const { out, spy } = logs();
+    const r = await reviewGateCommand({
+      config: { projectDir: dir, method_gates: { pr_size: "block", pr_size_warn: 500 } },
+      flags: { staged: true },
+    });
+    spy.mockRestore();
+    expect(r).toMatchObject({ verdict: "rejected", reviewer: "pr-size" });
+    expect(out.join("\n")).toMatch(/10/);
+  });
+
+  it("sin invariante declarado, method_gates sigue mandando (sin policy no cambia nada)", async () => {
+    const { out, spy } = logs();
+    const r = await reviewGateCommand({ config: { projectDir: dir, method_gates: { pr_size_warn: 10, pr_size: "block" } }, flags: { staged: true } });
+    spy.mockRestore();
+    expect(r).toMatchObject({ verdict: "rejected", reviewer: "pr-size" });
+    expect(out.join("\n")).not.toMatch(/policy file/);
+  });
+});

--- a/tests/shrink-budget-workflow.test.js
+++ b/tests/shrink-budget-workflow.test.js
@@ -39,11 +39,16 @@ describe("shrink-budget workflow", () => {
     expect(trigger?.pull_request?.branches).toContain("main");
   });
 
-  it("declares LOC_LIMIT at env level (default 200)", async () => {
+  it("reads LOC_LIMIT from the policy file, fail-loud, and exports it across steps (PL-C)", async () => {
     const wf = await loadWorkflow();
-    expect(wf.env?.LOC_LIMIT).toBeDefined();
-    // Allow string or number; YAML coerces depending on quoting.
-    expect(String(wf.env.LOC_LIMIT)).toBe("200");
+    // Single source of thresholds: the limit lives in .karajan/policy.yml,
+    // not in a workflow env — the gate extracts it and refuses to guess.
+    expect(wf.env?.KJ_POLICY_FILE).toBe(".karajan/policy.yml");
+    expect(wf.env?.LOC_LIMIT).toBeUndefined();
+    const run = wf.jobs["loc-budget"].steps.find((s) => s.id === "loc").run;
+    expect(run).toContain("loc-budget");
+    expect(run).toMatch(/refuses to guess.*exit 1/s);
+    expect(run).toContain('echo "LOC_LIMIT=$LOC_LIMIT" >> "$GITHUB_ENV"');
   });
 
   it("defines exactly the two expected jobs", async () => {


### PR DESCRIPTION
## PL-C parte 2 — un solo número (KJC-TSK-0735)

El umbral de tamaño de PR vivía duplicado: 150 en `method_gates.pr_size_warn`, 200 en el env del workflow shrink-budget. Ahora la fuente única es el invariante `loc-budget` de `.karajan/policy.yml`:

- **`kj review` (aviso y block de pr-size)** lee `max` del invariante cuando está declarado — el MISMO número que aplican `kj policy check` y el tier C; `method_gates` queda de fallback para proyectos sin policy, y el mensaje nombra la fuente.
- **shrink-budget (CI de este repo)** extrae `LOC_LIMIT` del policy.yml **fail-loud**: un gate que no encuentra su umbral no adivina — falla nombrando el fichero. Exportado vía `$GITHUB_ENV` al step de enforce (el env de un run no cruza steps).

TDD: 3 tests (la policy GANA a method_gates; block usa y nombra el max de la policy; sin invariante nada cambia). Suite completa verde. 99 net.