### PR TITLE
feat(policy): kj policy add — spoken rule to validated yaml with confirmation (KJC-TSK-0735)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -27,6 +27,7 @@ import { huCommand } from "../commands/hu.js";
 import { worktreeCommand } from "../commands/worktree.js";
 import { addAdr, listAdrs } from "../environment/adr.js";
 import { formatAdvancedIndex } from "../commands/advanced.js";
+import { policyAddCommand } from "../policy/add.js";
 import { withConfig } from "./_shared.js";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -315,7 +316,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--yes", "Aplicar el diff propuesto")
     .action(async (textParts, flags) => {
       await withConfig(pkgVersion, "policy-add", flags, async ({ config, logger }) => {
-        const { policyAddCommand } = await import("../policy/add.js");
         process.exitCode = await policyAddCommand({ text: textParts.join(" "), config, flags, logger });
       });
     });

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -309,6 +309,16 @@ export function registerMeta(program, { pkgVersion }) {
         process.exitCode = await policyCommand({ action: "grant", config, flags });
       });
     });
+  policyCmd.command("add")
+    .description("Traduce una regla hablada al vocabulario cerrado de policy.yml — propone el diff y SOLO escribe con --yes (PL-C)")
+    .argument("<text...>", "La regla en lenguaje natural")
+    .option("--yes", "Aplicar el diff propuesto")
+    .action(async (textParts, flags) => {
+      await withConfig(pkgVersion, "policy-add", flags, async ({ config, logger }) => {
+        const { policyAddCommand } = await import("../policy/add.js");
+        process.exitCode = await policyAddCommand({ text: textParts.join(" "), config, flags, logger });
+      });
+    });
   policyCmd.command("anchor")
     .description("Verifica la cadena del decision log y sella su head-hash en .karajan/policy-anchor.json (trackeado) — anclaje temporal en la historia de git, GOV-C2")
     .action(async (flags) => {

--- a/src/policy/add.js
+++ b/src/policy/add.js
@@ -1,0 +1,111 @@
+/**
+ * `kj policy add "<regla hablada>"` (PL-C, KJC-TSK-0735) — el usuario habla,
+ * kj escribe: un agente traduce a UNA regla candidata del vocabulario
+ * CERRADO, parsePolicy valida el merge (lo intraducible se RECHAZA, jamás
+ * se inventa — el YAML es artefacto, no interfaz), se propone el diff y NO
+ * se aplica sin confirmación explícita (--yes).
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { parsePolicy } from "@karajan-family/governance";
+import { createAgent } from "../agents/index.js";
+import { resolveRole } from "../config/role-resolver.js";
+
+const PROMPT = (text) => `Traduce esta regla de proyecto hablada a un FRAGMENTO YAML del vocabulario
+cerrado v1 de policy de Karajan. Vocabulario COMPLETO (nada fuera de esto):
+roles.<rol>.write|shell con allow/deny (listas de globs o patrones de
+comando), enforcement (warn|deny), class (security); invariants con
+{id, kind: diff-threshold, metric: net_lines_added, max, enforcement}.
+Responde SOLO el fragmento YAML (claves raíz: roles y/o invariants), sin
+explicación ni fences. Si la regla NO cabe en el vocabulario, responde
+exactamente: NO_TRADUCIBLE.
+
+Regla: ${text}`;
+
+async function defaultTranslate({ text, config, logger }) {
+  const role = resolveRole(config, "reviewer");
+  const res = await createAgent(role.provider, config, logger).reviewTask({ prompt: PROMPT(text), role: "reviewer" });
+  if (!res?.ok) throw new Error(`el agente traductor (${role.provider}) falló: ${res?.error || "sin salida"}`);
+  return String(res.output || "").replace(/^```[a-z]*\n?|```\s*$/g, "").trim();
+}
+
+// Merge conservador: las listas se CONCATENAN (añadir jamás borra), los
+// escalares nuevos solo entran donde no había valor.
+function mergeFragment(doc, frag) {
+  const out = { version: 1, ...doc };
+  for (const [role, caps] of Object.entries(frag.roles || {})) {
+    out.roles ||= {};
+    out.roles[role] ||= {};
+    for (const [cap, spec] of Object.entries(caps || {})) {
+      const cur = (out.roles[role][cap] ||= {});
+      for (const [k, v] of Object.entries(spec || {})) {
+        cur[k] = Array.isArray(v) ? [...new Set([...(cur[k] || []), ...v])] : (cur[k] ?? v);
+      }
+    }
+  }
+  if (frag.invariants) out.invariants = [...(doc.invariants || []), ...frag.invariants];
+  return out;
+}
+
+const naiveDiff = (oldText, newText) => {
+  const oldLines = new Set(oldText.split("\n"));
+  const newLines = new Set(newText.split("\n"));
+  return [
+    ...[...oldLines].filter((l) => l.trim() && !newLines.has(l)).map((l) => `- ${l}`),
+    ...[...newLines].filter((l) => l.trim() && !oldLines.has(l)).map((l) => `+ ${l}`),
+  ].join("\n");
+};
+
+export async function policyAddCommand({ text, config = {}, flags = {}, logger = console, deps = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  if (!text?.trim()) {
+    logger.error?.('policy add: falta la regla — kj policy add "el coder no toca los workflows"');
+    return 1;
+  }
+  const { translateFn = defaultTranslate } = deps;
+  const raw = await translateFn({ text, config, logger });
+  if (raw.includes("NO_TRADUCIBLE")) {
+    logger.error?.("policy add: la regla no cabe en el vocabulario cerrado v1 — no se inventa nada; exprésala como write/shell/diff-threshold o queda como instrucción de prompt");
+    return 1;
+  }
+  let frag;
+  try {
+    frag = yaml.load(raw);
+  } catch (err) {
+    logger.error?.(`policy add: el agente no devolvió YAML válido (${err.message}) — nada que aplicar`);
+    return 1;
+  }
+  if (typeof frag !== "object" || frag === null || Object.keys(frag).some((k) => !["roles", "invariants"].includes(k))) {
+    logger.error?.("policy add: el fragmento solo puede declarar roles y/o invariants — rechazado (vocabulario cerrado)");
+    return 1;
+  }
+
+  const file = join(projectDir, ".karajan", "policy.yml");
+  let current = "";
+  try {
+    current = readFileSync(file, "utf8");
+  } catch { /* sin policy previa: se propone crearla */ }
+  const merged = mergeFragment(current ? yaml.load(current) || {} : {}, frag);
+  const proposed = yaml.dump(merged, { lineWidth: 100 });
+  const { errors } = parsePolicy(proposed);
+  if (errors.length > 0) {
+    for (const e of errors) logger.error?.(`✗ ${e}`);
+    logger.error?.("policy add: la regla traducida no valida contra el vocabulario del motor — rechazada, no se inventa");
+    return 1;
+  }
+
+  logger.info?.(`policy add — diff propuesto para .karajan/policy.yml:\n${naiveDiff(current, proposed)}`);
+  if (current.includes("#")) {
+    logger.warn?.("⚠ policy add: el fichero actual tiene comentarios y el rewrite NO los preserva — revisa el diff antes de confirmar");
+  }
+  if (!flags.yes) {
+    logger.info?.("policy add: NADA aplicado — re-ejecuta con --yes para escribir (la confirmación es tuya, no del agente)");
+    return 0;
+  }
+  // Primer run sin .karajan/ (catch de codex): crear el padre, no reventar.
+  mkdirSync(join(projectDir, ".karajan"), { recursive: true });
+  writeFileSync(file, proposed, "utf8");
+  logger.info?.("✓ policy add: regla aplicada — los gates (review, pre-commit, tier C) la aplican desde ya");
+  return 0;
+}

--- a/tests/policy/add.test.js
+++ b/tests/policy/add.test.js
@@ -1,0 +1,78 @@
+// PL-C (KJC-TSK-0735) — kj policy add: el usuario habla, un agente traduce
+// a una regla candidata, parsePolicy la VALIDA (vocabulario cerrado: lo
+// intraducible se RECHAZA, jamás se inventa), se propone el diff del YAML
+// y NO se escribe nada sin confirmación explícita (--yes).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { policyAddCommand } from "../../src/policy/add.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); });
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-poladd-"));
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"), "version: 1\ninvariants:\n  - { id: loc, kind: diff-threshold, metric: net_lines_added, max: 200 }\n");
+  process.chdir(dir);
+});
+
+const policyPath = () => path.join(dir, ".karajan", "policy.yml");
+const run = ({ text = "el coder no toca los workflows", yes = false, fragment, logs = [] }) =>
+  policyAddCommand({
+    text,
+    config: { projectDir: dir },
+    flags: { yes },
+    logger: { info: (m) => logs.push(m), warn: (m) => logs.push(m), error: (m) => logs.push(m) },
+    deps: { translateFn: async () => fragment },
+  });
+
+const GOOD_FRAGMENT = 'roles:\n  coder:\n    write:\n      deny: [".github/workflows/**"]\n      enforcement: deny\n';
+
+describe("kj policy add", () => {
+  it("propone el diff y NO escribe sin --yes", async () => {
+    const logs = [];
+    expect(await run({ fragment: GOOD_FRAGMENT, logs })).toBe(0);
+    expect(fs.readFileSync(policyPath(), "utf8")).not.toContain("workflows");
+    const out = logs.join("\n");
+    expect(out).toMatch(/\+.*workflows/);
+    expect(out).toMatch(/--yes/);
+  });
+
+  it("con --yes escribe el merge y el resultado valida contra el motor", async () => {
+    expect(await run({ fragment: GOOD_FRAGMENT, yes: true })).toBe(0);
+    const written = fs.readFileSync(policyPath(), "utf8");
+    expect(written).toContain(".github/workflows/**");
+    expect(written).toContain("loc"); // el invariante previo sobrevive al merge
+  });
+
+  it("una regla fuera del vocabulario se RECHAZA nombrando el error, no se inventa", async () => {
+    const logs = [];
+    expect(await run({ fragment: "roles:\n  coder:\n    network: { deny: ['*'] }\n", yes: true, logs })).toBe(1);
+    expect(fs.readFileSync(policyPath(), "utf8")).not.toContain("network");
+    expect(logs.join("\n")).toMatch(/vocabulario/);
+  });
+
+  it("salida no-YAML del agente = rechazo limpio", async () => {
+    expect(await run({ fragment: "esto no es: [yaml valido", yes: true })).toBe(1);
+  });
+
+  it("claves de nivel raiz fuera de roles/invariants se rechazan", async () => {
+    expect(await run({ fragment: "hooks:\n  pre: rm -rf\n", yes: true })).toBe(1);
+  });
+
+  it("primer run sin .karajan/ crea el directorio y la policy (catch de codex)", async () => {
+    fs.rmSync(path.join(dir, ".karajan"), { recursive: true, force: true });
+    expect(await run({ fragment: GOOD_FRAGMENT, yes: true })).toBe(0);
+    expect(fs.readFileSync(policyPath(), "utf8")).toContain(".github/workflows/**");
+  });
+
+  it("avisa cuando el rewrite perderia comentarios del YAML original", async () => {
+    fs.writeFileSync(policyPath(), "# comentario importante\nversion: 1\n");
+    const logs = [];
+    await run({ fragment: GOOD_FRAGMENT, logs });
+    expect(logs.join("\n")).toMatch(/comentario/i);
+  });
+});


### PR DESCRIPTION
## PL-C parte 3 — el usuario habla, kj escribe (KJC-TSK-0735)

`kj policy add "el coder no toca los workflows"`:

- Un agente (el reviewer configurado) traduce la regla hablada a un FRAGMENTO del vocabulario cerrado v1 — el prompt enumera el vocabulario completo y exige `NO_TRADUCIBLE` cuando la regla no cabe: **lo intraducible se rechaza, jamás se inventa**.
- El fragmento se valida DOS veces: forma (solo `roles`/`invariants` en la raíz) y fondo (`parsePolicy` del kernel sobre el merge — cualquier error de vocabulario rechaza).
- Merge conservador: las listas se CONCATENAN (añadir jamás borra) y los escalares nuevos solo entran donde no había valor.
- **Propone el diff y NO escribe sin `--yes`** — la confirmación es del usuario, no del agente. Avisa cuando el rewrite perdería comentarios del YAML original.
- Primer run sin `.karajan/`: crea el directorio en vez de reventar (catch de codex, con regresión).

TDD: 7 tests con traductor inyectado. Suite completa verde. 199 net.