### PR TITLE
feat(policy): acting role travels to tier a and guarantee tiers documented (KJC-TSK-0735)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Karajan **governs** any agent with git gates — the false green is structurally
 
 Synchronous blocking hooks exist today only in Claude Code. That makes the supported setup explicit: **to guarantee a harness that controls the LLM, use Claude Code as the host** — Claude writes, Codex reviews (a review subprocess needs no hooks), and a third CLI arbitrates when available. On any other host Karajan still governs at the full git-gate level and tells you which level is active — it never pretends a supervision it cannot enforce.
 
+With a declared `.karajan/policy.yml`, the policy layer enforces at three tiers, and which tier applies depends on the host:
+
+| Tier | Where | Requires | What it guarantees |
+|---|---|---|---|
+| **A — tool time** | Sentinel PreToolUse → `kj policy eval --strict` | Claude Code as host (synchronous hooks) | The rule fires BEFORE the damage; the acting agent's role travels in `KJ_POLICY_ROLE` |
+| **B — commit time** | `kj review --staged` / pre-commit → deny + evidentiary exceptions | Any host (the gate lives in git) | The violating diff never enters, no matter who wrote it or what host ran it |
+| **C — merge time** | `kj-policy.yml` CI workflow → `kj policy check --range --strict` | GitHub Actions (seeded by `kj harden`) | Covers a tampered local hook: the PR diff is re-checked against the same policy, merge-blocking |
+
+Tier B is the guarantee floor — hosts without hooks lose A, never B; C re-verifies both. Security-class rules and consumer defaults are non-exemptable at every tier: no escape, no arbitration, no grant.
+
 ## Headless mode
 
 The classic multiagent pipeline lives on for CI and automation: `kj run "<task>"` orchestrates coder/reviewer/tester subprocess roles unattended, with the same gates. Agents and CI pass `--non-interactive` (or `KJ_NON_INTERACTIVE=1`): safe gates auto-answer, FAIL findings stop the run with a real exit code. `kj advanced` lists the full surface. [Headless mode docs](https://karajancode.com/docs/v4/headless/).

--- a/src/agents/claude-agent.js
+++ b/src/agents/claude-agent.js
@@ -365,6 +365,11 @@ export class ClaudeAgent extends BaseAgent {
   async _runTaskExec(task, model, _role) {
     const args = buildPromptArgs(task);
     if (model) args.push("--model", model);
+    // PL-C (KJC-TSK-0735): el rol del subproceso viaja en KJ_POLICY_ROLE —
+    // si su harness corre hooks (claude -p), el tier A evalúa la policy con
+    // el rol que ACTÚA. El rol del ORQUESTADOR es autoritativo: task.env no
+    // puede spoofearlo (catch de codex: sería un bypass de reglas por rol).
+    const roleEnv = task.role ? { ...task.env, KJ_POLICY_ROLE: task.role } : task.env;
 
     // Use stream-json when onOutput is provided to get real-time feedback
     if (task.onOutput) {
@@ -374,7 +379,7 @@ export class ClaudeAgent extends BaseAgent {
         onOutput: streamFilter,
         silenceTimeoutMs: task.silenceTimeoutMs,
         timeout: task.timeoutMs,
-        env: task.env,
+        env: roleEnv,
         cwd: task.cwd
       }));
       const raw = pickOutput(res);
@@ -385,7 +390,7 @@ export class ClaudeAgent extends BaseAgent {
 
     // Without streaming, use json output to get structured response via stderr
     args.push("--output-format", "json");
-    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({ env: task.env, cwd: task.cwd }));
+    const res = await this.runCommand(resolveBin("claude"), args, cleanExecaOpts({ env: roleEnv, cwd: task.cwd }));
     const raw = pickOutput(res);
     const output = extractTextFromStreamJson(raw);
     const usage = extractUsageFromStreamJson(raw);

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -339,7 +339,10 @@ process.stdin.on("end", () => {
     // evaluacion = deny con escape humano registrable — la sesion no queda
     // presa de un typo de YAML, pero abrirla es decision del usuario.
     if ((EDIT_TOOLS.includes(tool) || tool === "Bash") && existsSync(resolve(ROOT, ".karajan", "policy.yml"))) {
-      const pres = spawnSync("kj", ["policy", "eval", "--strict", "--role", "coder", "--tool", tool, "--input", JSON.stringify(input)], { cwd: ROOT, encoding: "utf8" });
+      // PL-C: el rol que ACTÚA (KJ_POLICY_ROLE, sembrado por los runners de
+      // kj run en los subprocesos) — el anfitrión-brain evalúa como coder.
+      const actorRole = process.env.KJ_POLICY_ROLE || "coder";
+      const pres = spawnSync("kj", ["policy", "eval", "--strict", "--role", actorRole, "--tool", tool, "--input", JSON.stringify(input)], { cwd: ROOT, encoding: "utf8" });
       if (pres.error || pres.status === null) {
         console.error("kj sentinel: .karajan/policy.yml declara enforcement pero kj no es ejecutable — la policy no se puede evaluar; restaura kj en el PATH (npm i -g karajan-code) o retira la policy conscientemente.");
         process.exit(2);

--- a/tests/agents/claude-agent.test.js
+++ b/tests/agents/claude-agent.test.js
@@ -39,6 +39,15 @@ describe("ClaudeAgent", () => {
       expect(opts.stdin).toBe("ignore");
     });
 
+    it("propaga el rol del task como KJ_POLICY_ROLE al subproceso (PL-C, KJC-TSK-0735)", async () => {
+      await new ClaudeAgent("claude", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(runCommand.mock.calls[0][2].env.KJ_POLICY_ROLE).toBe("coder");
+      // El rol del ORQUESTADOR es autoritativo: task.env no lo spoofea
+      // (catch de codex — un env manipulado seria un bypass de reglas por rol).
+      await new ClaudeAgent("claude", baseConfig, logger).runTask({ prompt: "t", role: "coder", env: { ...process.env, KJ_POLICY_ROLE: "tester" } });
+      expect(runCommand.mock.calls[1][2].env.KJ_POLICY_ROLE).toBe("coder");
+    });
+
     it("does not crash when CLAUDECODE is unset", async () => {
       delete process.env.CLAUDECODE;
       await new ClaudeAgent("claude", baseConfig, logger).runTask({ prompt: "t", role: "coder" });

--- a/tests/harden/sentinel-policy-delegation.test.js
+++ b/tests/harden/sentinel-policy-delegation.test.js
@@ -90,6 +90,13 @@ describe("pretooluse delega en kj policy eval --strict (PL-B)", () => {
     expect(state().escape_events.some((e) => e.escape === "KJ_ALLOW_POLICY")).toBe(true);
   });
 
+  it("el rol que actua viaja: KJ_POLICY_ROLE=reviewer llega como --role reviewer (PL-C)", () => {
+    const argsFile = path.join(dir, "kj-args.txt");
+    const env = fakeKj(`echo "$@" > ${argsFile}; exit 0`);
+    run(gate, editTool(path.join(dir, "src", "a.js")), { ...env, KJ_POLICY_ROLE: "reviewer" });
+    expect(fs.readFileSync(argsFile, "utf8")).toContain("--role reviewer");
+  });
+
   it("sin policy.yml no se consulta el motor (cero spawn, cero coste)", () => {
     fs.rmSync(path.join(dir, ".karajan", "policy.yml"));
     const env = fakeKj(`echo '${DENY}'; exit 2`);


### PR DESCRIPTION
## PL-C parte 4 (final) — el rol que actúa, y los tiers escritos (KJC-TSK-0735)

- **Scoping por rol en el tier A**: el PRETOOL evalúa con `KJ_POLICY_ROLE` (default coder = el anfitrión-brain), y claude-agent siembra `KJ_POLICY_ROLE=task.role` en el env de sus subprocesos — si el harness del subproceso corre hooks, la policy se evalúa con el rol que ACTÚA. **El rol del orquestador es autoritativo**: `task.env` no puede spoofearlo (catch de codex — un env manipulado sería un bypass de reglas por rol; con regresión que fija la precedencia).
- **README Guarantee levels**: tabla de los tres tiers (A tool-time / B commit-time / C merge-time), qué exige cada uno por anfitrión, y la doctrina: el tier B es el suelo de garantía, y lo inexcepcionable no se negocia en ninguno.

Con esto **KJC-TSK-0735 (PL-C) queda completa**: tier C merge-blocking (#1454), fuente única de umbrales (#1455), `kj policy add` conversacional (#1456), y scoping por rol + docs (este). 22 net sin docs.