### PR TITLE
feat(policy): renewal count surfaces as a signal on repeated grants (KJC-TSK-0750)

### DIFF
--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -12,7 +12,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
-import { recordPolicyException } from "../policy/exceptions.js";
+import { loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
 import { verifyDecisionChain } from "@karajan-family/governance";
 
 const execFileAsync = promisify(execFile);
@@ -103,11 +103,19 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
       return 1;
     }
     try {
+      // GOV-E (KJC-TSK-0750, idea del lector): la renovación es SEÑAL — una
+      // regla re-concedida N veces es la política real pidiendo que la
+      // cambien por su cauce. Se cuenta contra TODAS las permanentes previas
+      // (vencidas incluidas: precisamente esas son la sedimentación).
+      const previous = loadStandingExceptions(projectDir).standing.filter((e) => e.rule_id === rule).length;
       const rec = recordPolicyException({
         projectDir,
         entry: { rule_id: rule, justification: reason.trim(), scopeKind: "permanente", expiresAt: until },
       });
       logger.info?.(`✓ excepción permanente registrada: [${rec.rule_id}] hasta ${rec.expiresAt} — concedida por ${rec.who?.git ?? "?"} (${rec.who?.grade ?? "?"})`);
+      if (previous >= 1) {
+        logger.warn?.(`⚠ ${previous + 1}ª concesión sobre esta regla — una excepción que se renueva ya no es una excepción: considera cambiar la política por su cauce (PR a .karajan/policy.yml)`);
+      }
       return 0;
     } catch (err) {
       logger.error?.(`policy grant: ${err.message}`);

--- a/tests/review/standing-adapter.test.js
+++ b/tests/review/standing-adapter.test.js
@@ -79,6 +79,20 @@ describe("kj policy grant", () => {
     expect(rec.who.grade).toBe("declarada"); // git+os es atribucion, no autenticacion
   });
 
+  it("la renovacion como señal (GOV-E): la 3ª concesion sobre la MISMA regla lo dice y sugiere cambiar la politica", async () => {
+    const logs = [];
+    const logger = { info: (m) => logs.push(m), warn: (m) => logs.push(m), error: (m) => logs.push(m) };
+    const grant = (rule, until) => policyCommand({ action: "grant", config: { projectDir: dir }, flags: { rule, until, reason: "r" }, logger });
+    expect(await grant("roles.coder.write.deny", "2026-01-01T00:00:00Z")).toBe(0);
+    expect(await grant("roles.coder.shell.deny", "2026-02-01T00:00:00Z")).toBe(0); // otra regla: no cuenta
+    expect(logs.join("\n")).not.toMatch(/concesión/);
+    expect(await grant("roles.coder.write.deny", "2026-03-01T00:00:00Z")).toBe(0);
+    expect(await grant("roles.coder.write.deny", "2027-01-01T00:00:00Z")).toBe(0); // 3ª de write.deny
+    const out = logs.join("\n");
+    expect(out).toMatch(/3ª concesión sobre esta regla/);
+    expect(out).toMatch(/cambiar la política|PR/);
+  });
+
   it("se niega sobre defaults.*, sobre caps class=security (catch de codex) y sin reason/until", async () => {
     const err = [];
     const logger = { info: () => {}, error: (m) => err.push(m) };


### PR DESCRIPTION
## GOV-E — la renovación como señal (KJC-TSK-0750, épica KJC-PCS-0076)

Nace del lector de LinkedIn: "la excepción aprobada hace 3 años con alcance temporal que nadie cerró, en auditoría aparece impecable — y para entonces ya es el proceso". En Karajan la caducidad ya la ejecuta el sistema (GOV-B: vencida = el gate cierra solo); esta pieza hace visible la otra mitad:

- `kj policy grant` cuenta las concesiones PREVIAS sobre la misma regla — **vencidas incluidas: precisamente esas son la sedimentación** — y a partir de la 2ª lo dice en la cara: "Nª concesión sobre esta regla — una excepción que se renueva ya no es una excepción: considera cambiar la política por su cauce (PR)".
- Informativo, jamás bloquea; reglas distintas no se cuentan entre sí.

TDD: 1 test (3ª concesión avisa y sugiere; otras reglas no contaminan). Suite completa verde. 22 net.