### PR TITLE
feat(release): self-references resolve the package name from the manifest (KJC-TSK-0751)

### DIFF
--- a/scripts/verify-pack.mjs
+++ b/scripts/verify-pack.mjs
@@ -27,6 +27,9 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
 const expectedVersion = pkg.version;
+// MIG-A (KJC-TSK-0751): el nombre sale del manifest — el MISMO verify-pack
+// valida el tarball unscoped y el @karajan-family/* del dual-publish.
+const pkgName = pkg.name;
 
 // Subprocess env: strip CLAUDECODE (Claude Code blocks nested non-interactive
 // runs otherwise) and force a non-interactive, quiet npm.
@@ -54,13 +57,13 @@ let gTmp = null;
 let pnpmTmp = null;
 let qsTmp = null;
 try {
-  console.log(`verify-pack: packing karajan-code@${expectedVersion}…`);
+  console.log(`verify-pack: packing ${pkgName}@${expectedVersion}…`);
   // --json gives us the exact filename without parsing human output.
   const packOut = run("npm", ["pack", "--json", "--silent"], { cwd: repoRoot });
   const filename = JSON.parse(packOut)[0]?.filename;
   if (!filename) fail("npm pack did not report a filename", packOut);
-  // npm normalizes scoped names in --json but karajan-code is unscoped;
-  // the file lands in cwd under the reported name.
+  // npm --json reports the exact filename (scoped names normalized to
+  // scope-name-x.y.z.tgz); the file lands in cwd under that name.
   tgzPath = path.join(repoRoot, filename);
   if (!fs.existsSync(tgzPath)) fail(`packed tarball not found at ${tgzPath}`);
 
@@ -93,7 +96,7 @@ try {
   const { scanPaths, loadPrivacyList } = await import(
     path.join(repoRoot, "src", "privacy", "scan.js")
   );
-  const shippedDir = path.join(tmpDir, "node_modules", "karajan-code");
+  const shippedDir = path.join(tmpDir, "node_modules", ...pkgName.split("/"));
   const pFindings = scanPaths([shippedDir], { list: loadPrivacyList() });
   const pBlocks = pFindings.filter((f) => f.severity === "block");
   if (pBlocks.length > 0) {
@@ -265,7 +268,7 @@ try {
     );
   }
 
-  console.log(`\n✓ verify-pack: karajan-code@${expectedVersion} installs clean and runs.`);
+  console.log(`\n✓ verify-pack: ${pkgName}@${expectedVersion} installs clean and runs.`);
 } finally {
   if (tgzPath && fs.existsSync(tgzPath)) fs.rmSync(tgzPath, { force: true });
   if (tmpDir && fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -344,7 +344,7 @@ process.stdin.on("end", () => {
       const actorRole = process.env.KJ_POLICY_ROLE || "coder";
       const pres = spawnSync("kj", ["policy", "eval", "--strict", "--role", actorRole, "--tool", tool, "--input", JSON.stringify(input)], { cwd: ROOT, encoding: "utf8" });
       if (pres.error || pres.status === null) {
-        console.error("kj sentinel: .karajan/policy.yml declara enforcement pero kj no es ejecutable — la policy no se puede evaluar; restaura kj en el PATH (npm i -g karajan-code) o retira la policy conscientemente.");
+        console.error("kj sentinel: .karajan/policy.yml declara enforcement pero kj no es ejecutable — la policy no se puede evaluar; restaura kj en el PATH (npm i -g @karajan-family/code, o el nombre legacy karajan-code) o retira la policy conscientemente.");
         process.exit(2);
       }
       if (pres.status === 2) {

--- a/src/harden/workflow-engine.js
+++ b/src/harden/workflow-engine.js
@@ -19,18 +19,18 @@ import { extraWorkflowsFor, mutationWorkflowFor, qualityWorkflowFor, policyWorkf
 // npx del workflow de policy (jamás @latest en CI). Lectura LAZY: en el
 // bundle SEA no hay package.json junto al módulo y una lectura eager a
 // nivel de módulo tumbaba el binario entero al cargar (ENOENT /package.json).
-let _ownVersion;
-function ownVersion() {
-  if (_ownVersion === undefined) {
+let _ownPkg;
+function ownPkg() {
+  if (_ownPkg === undefined) {
     try {
-      _ownVersion = JSON.parse(
+      _ownPkg = JSON.parse(
         readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json"), "utf8"),
-      ).version;
+      );
     } catch {
-      _ownVersion = null;
+      _ownPkg = null;
     }
   }
-  return _ownVersion;
+  return _ownPkg;
 }
 
 const BLOCK_VERSION = 1;
@@ -81,9 +81,9 @@ export function installWorkflows({
   // PL-C: el tier C solo existe donde el proyecto DECLARA policy. Versión a
   // pinear: la plumbeada por el CLI (SEA) o la propia; "latest" es último
   // recurso inalcanzable en los caminos reales.
-  const pinned = kjVersion ?? ownVersion() ?? "latest";
+  const pinned = kjVersion ?? ownPkg()?.version ?? "latest";
   const policy = existsSync(join(projectDir, ".karajan", "policy.yml"))
-    ? { file: "kj-policy.yml", blockId: "wf-policy", body: policyWorkflowFor(pinned) }
+    ? { file: "kj-policy.yml", blockId: "wf-policy", body: policyWorkflowFor(pinned, ownPkg()?.name ?? "karajan-code") }
     : null;
   const all = [...WORKFLOWS, ...(quality ? [quality] : []), ...extras, ...(mut ? [mut] : []), ...(policy ? [policy] : [])];
   const results = [];

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -57,7 +57,7 @@ export const WORKFLOWS = [
 // PL-C (KJC-TSK-0735) — tier C del ADR 0001: re-check merge-blocking en CI
 // (cubre el hook local manipulado). Solo se siembra con policy declarada;
 // npx PINEADO a la versión del kj que corrió harden — jamás @latest en CI.
-export const policyWorkflowFor = (kjVersion) => [
+export const policyWorkflowFor = (kjVersion, kjName = "karajan-code") => [
   "name: Policy",
   "on:",
   "  pull_request:",
@@ -77,7 +77,7 @@ export const policyWorkflowFor = (kjVersion) => [
   "        env:",
   "          BASE_REF: ${{ github.base_ref }}",
   "        run: |",
-  `          if [ -f bin/kj.js ]; then npm ci --ignore-scripts && KJ="node bin/kj.js"; else KJ="npx --yes karajan-code@${kjVersion}"; fi`,
+  `          if [ -f bin/kj.js ]; then npm ci --ignore-scripts && KJ="node bin/kj.js"; else KJ="npx --yes ${kjName}@${kjVersion}"; fi`,
   '          $KJ policy check --range "origin/${BASE_REF}...HEAD" --strict',
   "", // línea en blanco pre-marcador: prettier la exige tras un block scalar
 ].join("\n");

--- a/src/utils/update-check.js
+++ b/src/utils/update-check.js
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isSea } from "node:sea";
@@ -8,7 +9,25 @@ const CACHE_FILE = "update-check.json";
 // KJC-TSK-0690: 6h — kj can ship several releases a day; a session should
 // not work a full day blind. KJ_NO_UPDATE_CHECK=1 opts out (CI).
 const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-const PACKAGE_NAME = "karajan-code";
+// MIG-A (KJC-TSK-0751): el nombre npm se lee del PROPIO manifest — con el
+// dual-publish del scope, el mismo código vive como karajan-code y como
+// @karajan-family/code y cada instalación se auto-actualiza por SU nombre.
+// Lazy + fallback: en el bundle SEA no hay package.json junto al módulo.
+let _pkgName;
+export function packageName() {
+  if (_pkgName) return _pkgName;
+  try {
+    _pkgName = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")).name || "karajan-code";
+  } catch {
+    _pkgName = "karajan-code";
+  }
+  return _pkgName;
+}
+
+// URL del registro con el nombre CODIFICADO — el scoped @karajan-family/code
+// lleva @ y / que rompen la ruta sin encode (catch de codex).
+export const registryLatestUrl = (name = packageName()) =>
+  `https://registry.npmjs.org/${encodeURIComponent(name)}/latest`;
 const CHANGELOG_URL = "https://raw.githubusercontent.com/manufosela/karajan-code/main/CHANGELOG.md";
 const HIGHLIGHT_MAX = 160;
 
@@ -55,10 +74,10 @@ export function updateInstruction({ channel, platform = process.platform }) {
       : `Re-run the installer: curl -fsSL ${INSTALL_SH_URL} | sh`;
   }
   if (channel === "npm") {
-    return `Run: npm install -g ${PACKAGE_NAME}`;
+    return `Run: npm install -g ${packageName()}`;
   }
   // Channel unknown — offer both paths, never silently pick a wrong one.
-  return `Update: npm install -g ${PACKAGE_NAME}  (or re-run the binary installer — see README)`;
+  return `Update: npm install -g ${packageName()}  (or re-run the binary installer — see README)`;
 }
 
 /**
@@ -100,7 +119,7 @@ export async function checkForUpdate(currentVersion) {
     // Fetch from npm (timeout 3s, don't block)
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
+    const res = await fetch(registryLatestUrl(), {
       signal: controller.signal,
       headers: { "Accept": "application/json" },
     });
@@ -174,7 +193,7 @@ export async function performSelfUpdate({ currentVersion, exec, logger = console
   try {
     // Registry over HTTP, not `npm view` — standalone-binary machines may
     // not have npm at all.
-    const res = await fetchFn(`https://registry.npmjs.org/${PACKAGE_NAME}/latest`, {
+    const res = await fetchFn(registryLatestUrl(), {
       headers: { Accept: "application/json" },
     });
     if (!res.ok) throw new Error(`registry responded ${res.status}`);
@@ -213,7 +232,7 @@ export async function performSelfUpdate({ currentVersion, exec, logger = console
       }
     } else {
       // No stdio:inherit — capture and drop npm's warnings on the success path.
-      await run("npm", ["install", "-g", `${PACKAGE_NAME}@latest`]);
+      await run("npm", ["install", "-g", `${packageName()}@latest`]);
     }
   } catch (err) {
     if (err.stdout) logger.error(err.stdout);

--- a/tests/architecture/name-agnostic.test.js
+++ b/tests/architecture/name-agnostic.test.js
@@ -1,0 +1,36 @@
+// MIG-A (KJC-TSK-0751, épica KJC-PCS-0077) — inventario de self-references:
+// con el dual-publish del scope, NINGUNA ruta crítica puede depender del
+// literal "karajan-code" en CÓDIGO (comentarios y URLs de GitHub del REPO,
+// que no cambia, quedan fuera). Este test fija que el literal no vuelve.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { packageName, registryLatestUrl } from "../../src/utils/update-check.js";
+
+const src = (p) => readFileSync(new URL(`../../${p}`, import.meta.url), "utf8");
+// Solo código: fuera comentarios de línea y URLs del repo GitHub.
+const codeLines = (p) =>
+  src(p).split("\n").filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*") && !l.includes("github.com") && !l.includes("githubusercontent.com"));
+
+describe("self-references name-agnósticas (MIG-A)", () => {
+  it("update-check resuelve su nombre del manifest (y cae al legacy si no puede leerlo)", () => {
+    expect(packageName()).toBe(JSON.parse(src("package.json")).name);
+    // El literal solo puede vivir como FALLBACK del resolver (_pkgName);
+    // en registry URLs, mensajes de install o comandos está vetado.
+    const uses = codeLines("src/utils/update-check.js").filter((l) => !l.includes("_pkgName"));
+    expect(uses.join("\n")).not.toMatch(/PACKAGE_NAME|"karajan-code"|karajan-code@/);
+  });
+
+  it("la URL del registro codifica el nombre — el scoped lleva @ y / (catch de codex)", () => {
+    expect(registryLatestUrl("@karajan-family/code")).toBe("https://registry.npmjs.org/%40karajan-family%2Fcode/latest");
+    expect(registryLatestUrl("karajan-code")).toBe("https://registry.npmjs.org/karajan-code/latest");
+  });
+
+  it("verify-pack no hardcodea el nombre — valida el tarball que sea", () => {
+    expect(codeLines("scripts/verify-pack.mjs").join("\n")).not.toMatch(/"karajan-code"|karajan-code@/);
+  });
+
+  it("la plantilla del workflow de policy recibe nombre y versión — jamás el literal", () => {
+    expect(codeLines("src/harden/workflow-templates.js").join("\n")).not.toMatch(/karajan-code@/);
+  });
+});


### PR DESCRIPTION
## MIG-A parte 1 — kj deja de saberse de memoria su nombre npm (KJC-TSK-0751, épica KJC-PCS-0077, PRP-0018)

Preparación del dual-publish `karajan-code` + `@karajan-family/code` (mismo contenido, dos nombres):

- **update-check**: el nombre sale del PROPIO manifest (lazy + fallback al legacy — el bundle SEA no tiene package.json junto al módulo, lección de ayer) — cada instalación se auto-actualiza por SU nombre. Las URLs del registro van **codificadas**: el scoped lleva `@` y `/` que rompían la ruta (catch de codex, con regresión).
- **verify-pack**: nombre del manifest y `node_modules/<scope>/<name>` resuelto por segmentos — el MISMO verificador vale para ambos tarballs.
- **Plantilla del workflow de policy**: `policyWorkflowFor(versión, nombre)` — el fallback npx pinea nombre Y versión del kj que corrió harden.
- Test-inventario de arquitectura: el literal no puede volver a las rutas críticas (fallbacks del resolver exentos, comentarios y URLs del repo GitHub —que no cambia— fuera del veto).

Cero cambio de comportamiento hoy (el manifest sigue diciendo karajan-code). Parte 2: `scripts/dual-publish.mjs` + ADR 0004.