### PR TITLE
feat(release): dual-publish script for the family scope migration (KJC-TSK-0751)

### DIFF
--- a/.karajan/adrs/0004-migracion-al-scope-karajan-family-dual-publish-y-deprecate.md
+++ b/.karajan/adrs/0004-migracion-al-scope-karajan-family-dual-publish-y-deprecate.md
@@ -1,0 +1,16 @@
+# Migración al scope @karajan-family: dual-publish y deprecate
+
+Status: accepted
+Date: 2026-08-19
+
+## Context
+
+La familia publica con nombres npm dispersos (karajan-code, karajan-core) y el kernel ya nació bajo el scope (@karajan-family/governance). El usuario decidió (PRP-0018, 2026-08-19) que todo pase bajo el paraguas @karajan-family: con la adopción actual el coste de migrar naming es ~cero y solo crece con cada usuario nuevo. Restricción: no romper a NADIE — ni a la base instalada ni al auto-update del nombre viejo.
+
+## Decision
+
+Solo cambian las coordenadas npm: el producto sigue siendo Karajan Code, el binario kj, el repo GitHub el mismo. Mapa: karajan-code → @karajan-family/code; karajan-core → @karajan-family/core; rag/watch/hu-board cuando toque. Mecánica en tres tiempos: (1) DUAL-PUBLISH durante 2-3 minors — la misma release publica ambos nombres con contenido idéntico (scripts/dual-publish.mjs: swap del name EN SITIO con restauración en finally, jamás renombra a ciegas, y verificación con el MISMO verify-pack name-agnóstico); (2) el onboarding público enseña el scoped como primario con nota del legacy; (3) npm deprecate del viejo con mensaje-puntero — decisión explícita del usuario, jamás automática, y el nombre viejo no se borra nunca (npm no permite reutilizarlo y sirve de señal). Prerequisito ejecutado (MIG-A parte 1): ninguna ruta crítica de kj depende del literal de su nombre — update-check, verify-pack y la plantilla del workflow de policy lo resuelven del manifest (URLs del registro codificadas: el scoped lleva @ y /), fijado por test de arquitectura. Identidad: el PRIMER publish de cada nombre nuevo del scope lo hace el usuario (cuenta karajan-family, 2FA security key, desde su terminal) y acto seguido owner add manufosela; el día a día sigue con la cuenta de siempre.
+
+## Consequences
+
+Positivas: la adopción nueva entra por el scope sin que la base instalada note nada; el mismo tarball E2E-verificado para ambos nombres; el patrón queda listo para core y el resto de la familia. Aceptadas: doble publish por release durante la transición (dos OTP-flujos); el bin `kj` colisiona si alguien instala AMBOS nombres en global (documentado: instala uno); alias-package descartado (los alias con bin colisionan y deprecate ya da la señal); renombrar sin dual descartado (rompería el auto-update del nombre viejo). MIG-C (deprecate) queda bloqueada por tiempo: 2-3 minors duales sin incidencias y el OK del usuario.

--- a/scripts/dual-publish.mjs
+++ b/scripts/dual-publish.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * dual-publish (MIG-A, KJC-TSK-0751, épica KJC-PCS-0077, ADR 0004) — el
+ * MISMO contenido sale bajo dos nombres npm durante la migración al scope:
+ * karajan-code (legacy, publish normal) y @karajan-family/code (scoped).
+ *
+ * Uso:
+ *   node scripts/dual-publish.mjs --pack-only          # genera+verifica el tarball scoped
+ *   node scripts/dual-publish.mjs --publish --otp=XXX  # publica el scoped (tras publicar el legacy)
+ *
+ * El swap del name es EN SITIO con restauración en finally: un crash a mitad
+ * no deja el manifest renombrado. La verificación es el MISMO verify-pack
+ * (name-agnóstico desde la parte 1): empaqueta, instala aislado y corre kj.
+ * El PRIMER publish del scoped lo hace el usuario (cuenta karajan-family,
+ * security key); los siguientes van con la sesión normal.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const LEGACY_NAME = "karajan-code";
+export const SCOPED_NAME = "@karajan-family/code";
+
+/**
+ * Ejecuta `fn` con el manifest renombrado al scoped (+ publishConfig public,
+ * obligatorio para scoped) y lo RESTAURA byte a byte pase lo que pase.
+ */
+export async function withScopedName(repoRoot, fn) {
+  const pkgPath = join(repoRoot, "package.json");
+  const original = readFileSync(pkgPath, "utf8");
+  const pkg = JSON.parse(original);
+  if (pkg.name !== LEGACY_NAME) {
+    throw new Error(`dual-publish: el manifest dice "${pkg.name}" y solo se renombra desde ${LEGACY_NAME} — jamás a ciegas`);
+  }
+  // publishConfig se MERGEA, no se pisa (catch de codex): un registry/tag
+  // preexistente debe sobrevivir al publish scoped.
+  writeFileSync(pkgPath, `${JSON.stringify({ ...pkg, name: SCOPED_NAME, publishConfig: { ...pkg.publishConfig, access: "public" } }, null, 2)}\n`, "utf8");
+  try {
+    return await fn();
+  } finally {
+    writeFileSync(pkgPath, original, "utf8");
+  }
+}
+
+// argv[1] normalizado (catch de codex): node lo absolutiza hoy, pero el
+// guard no debe depender de ese detalle de implementación.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const args = process.argv.slice(2);
+  const publish = args.includes("--publish");
+  const otp = args.find((a) => a.startsWith("--otp="))?.slice(6);
+  await withScopedName(repoRoot, async () => {
+    console.log(`dual-publish: manifest → ${SCOPED_NAME} (temporal)`);
+    // La E2E real: empaqueta el scoped, instálalo aislado y corre kj.
+    execFileSync("node", [join(repoRoot, "scripts", "verify-pack.mjs")], { cwd: repoRoot, stdio: "inherit" });
+    if (publish) {
+      const pubArgs = ["publish", "--ignore-scripts", ...(otp ? [`--otp=${otp}`] : [])];
+      console.log(`dual-publish: npm ${pubArgs.join(" ").replace(/--otp=\S+/, "--otp=***")}`);
+      execFileSync("npm", pubArgs, { cwd: repoRoot, stdio: "inherit" });
+    } else {
+      console.log("dual-publish: --pack-only — verificado y SIN publicar (usa --publish en la release)");
+    }
+  });
+  console.log(`dual-publish: manifest restaurado a ${LEGACY_NAME} ✓`);
+}

--- a/tests/scripts/dual-publish.test.js
+++ b/tests/scripts/dual-publish.test.js
@@ -1,0 +1,52 @@
+// MIG-A parte 2 (KJC-TSK-0751) — dual-publish: el MISMO contenido sale como
+// karajan-code y como @karajan-family/code. El swap del name es EN SITIO con
+// restauración garantizada (try/finally): un crash a mitad no puede dejar el
+// manifest renombrado. En MIG-A solo --pack-only; --publish llega con la
+// release v4.19.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { withScopedName, SCOPED_NAME } from "../../scripts/dual-publish.mjs";
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-dual-"));
+  fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "karajan-code", version: "9.9.9", bin: { kj: "bin/kj.js" } }, null, 2) + "\n");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const readPkg = () => JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
+
+describe("withScopedName", () => {
+  it("dentro del bloque el manifest es @karajan-family/code con publishConfig public; fuera, restaurado BYTE a byte", async () => {
+    const before = fs.readFileSync(path.join(dir, "package.json"), "utf8");
+    await withScopedName(dir, async () => {
+      const pkg = readPkg();
+      expect(pkg.name).toBe(SCOPED_NAME);
+      expect(pkg.version).toBe("9.9.9");
+      expect(pkg.publishConfig).toEqual({ access: "public" });
+      expect(pkg.bin).toEqual({ kj: "bin/kj.js" }); // el binario no cambia
+    });
+    expect(fs.readFileSync(path.join(dir, "package.json"), "utf8")).toBe(before);
+  });
+
+  it("un publishConfig preexistente se MERGEA, no se pisa (catch de codex)", async () => {
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "karajan-code", version: "1.0.0", publishConfig: { tag: "next" } }) + "\n");
+    await withScopedName(dir, async () => {
+      expect(readPkg().publishConfig).toEqual({ tag: "next", access: "public" });
+    });
+  });
+
+  it("si el bloque revienta, el manifest queda restaurado igualmente y el error sube", async () => {
+    const before = fs.readFileSync(path.join(dir, "package.json"), "utf8");
+    await expect(withScopedName(dir, async () => { throw new Error("boom"); })).rejects.toThrow("boom");
+    expect(fs.readFileSync(path.join(dir, "package.json"), "utf8")).toBe(before);
+  });
+
+  it("se niega a hacer swap sobre un manifest que NO es el legacy esperado — jamás renombra a ciegas", async () => {
+    fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "otra-cosa", version: "1.0.0" }) + "\n");
+    await expect(withScopedName(dir, async () => {})).rejects.toThrow(/karajan-code/);
+  });
+});


### PR DESCRIPTION
## MIG-A parte 2 (final) — dual-publish + ADR 0004 (KJC-TSK-0751, épica KJC-PCS-0077)

- **`scripts/dual-publish.mjs`**: el MISMO contenido sale como `karajan-code` y `@karajan-family/code`. Swap del name EN SITIO con restauración en `finally` (byte a byte, también si el bloque revienta — con test), se niega a renombrar desde un manifest que no sea el legacy esperado, `publishConfig` se MERGEA en vez de pisarse (catch de codex), y la verificación es el MISMO verify-pack name-agnóstico de la parte 1.
- **Probado en vivo**: `--pack-only` → `✓ verify-pack: @karajan-family/code@4.18.0 installs clean and runs` y el manifest restaurado sin rastro en git. `--publish` queda para la release v4.19 (el PRIMER publish del scoped lo hará el usuario con su security key).
- **ADR 0004** (accepted): la mecánica completa — dual-publish 2-3 minors → scoped como primario → deprecate con decisión explícita del usuario; alias-package y rename-sin-dual descartados con razón.

Con esto **MIG-A queda completa**. 2 catches de codex absorbidos con regresión. TDD: 4 tests. Suite completa verde.