### PR TITLE
feat(review): opt-in mutation pre-gate on the staged diff (KJC-TSK-0716)

### DIFF
--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -13,6 +13,7 @@ import { runOneShotReview } from "../review/one-shot-review.js";
 import { runSolomonArbitration } from "../review/solomon-arbitration.js";
 import { ensureGateTrackable } from "../review/gate-gitignore.js";
 import { runSonarPregate, formatSonarFinding } from "../review/sonar-pregate.js";
+import { runMutationPregate, formatSurvivor } from "../review/mutation-pregate.js";
 import { checkCardFirst } from "../review/card-first.js";
 import { checkTestsWithCode } from "../review/tests-with-code.js";
 import { loadPrivacyList, scanText } from "../privacy/scan.js";
@@ -322,6 +323,28 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
           + `Deterministic Sonar findings on these files (fold them into your review):\n`
           + pre.advisory.map((f) => `- ${formatSonarFinding(f)}`).join("\n");
       }
+    }
+  }
+
+  // MUT-A (KJC-TSK-0716): mutation pre-gate — opt-in (method_gates.mutation),
+  // SOLO en --staged (jamás en pre-commit: cuesta minutos; y jamás en --range:
+  // el scope es el ÍNDICE y anotaría trabajo ajeno — catch de codex). block
+  // cierra ANTES de gastar reviewer; warn viaja como advisory en su task.
+  const mut = flags.staged && !flags.range ? await runMutationPregate({ config, projectDir }) : { enabled: false, ok: true };
+  if (mut.enabled) {
+    if (mut.available === false) {
+      console.log(`⚠ mutation pre-gate no disponible: ${mut.reason} — degradado avisando (method_gates.mutation)`);
+    } else if (mut.survived.length > 0) {
+      console.log(`Mutantes supervivientes en el diff — score ${mut.score ?? "n/a"}%:`);
+      for (const m of mut.survived) console.log(`  ✗ ${formatSurvivor(m)}`);
+      if (!mut.ok) {
+        console.log("✗ mutation gate: la suite verde no PRUEBA el cambio — mata los supervivientes antes del review (method_gates.mutation: block).");
+        process.exitCode = 1;
+        return { verdict: "rejected", reviewer: "mutation", issues: mut.survived.map((m) => ({ severity: "high", file: m.file, description: formatSurvivor(m) })) };
+      }
+      task = `${task || "Review the following diff for correctness, security and maintainability."}\n\n`
+        + `Surviving mutants on the changed lines (weak asserts — fold into your review):\n`
+        + mut.survived.map((m) => `- ${formatSurvivor(m)}`).join("\n");
     }
   }
 

--- a/src/mutate/diff-scope.js
+++ b/src/mutate/diff-scope.js
@@ -89,8 +89,12 @@ export function buildScope({ language, files, ranges }) {
  * the injectable git runner (defaults to `runCommand`).
  * @param {{since: string, language: string, toRef?: string, run?: Function}} params
  */
-export async function getDiffScope({ since, language, toRef = "HEAD", run = runCommand }) {
-  const result = await run("git", ["diff", "--unified=0", `${since}..${toRef}`]).catch(
+export async function getDiffScope({ since, language, toRef = "HEAD", staged = false, run = runCommand }) {
+  // MUT-A (KJC-TSK-0716): staged=true scopea al ÍNDICE (git diff --cached) —
+  // lo que el review gate evalúa. since..HEAD con since=HEAD sería un diff
+  // VACÍO y el pre-gate no mutaría nada (catch de codex, agravado).
+  const args = staged ? ["diff", "--unified=0", "--cached"] : ["diff", "--unified=0", `${since}..${toRef}`];
+  const result = await run("git", args).catch(
     () => null,
   );
   if (!result || result.exitCode !== 0) {

--- a/src/review/mutation-pregate.js
+++ b/src/review/mutation-pregate.js
@@ -1,0 +1,51 @@
+/**
+ * Mutation pre-gate (MUT-A, KJC-TSK-0716, épica KJC-PCS-0072) — el auditor
+ * del invariante "tests prove behavior": un test con asserts flojos deja
+ * mutantes vivos aunque la suite esté verde. OPT-IN (method_gates.mutation:
+ * warn|block — la mutación cuesta minutos, jamás corre sin declararla) y
+ * SOLO en --staged, donde ya se va a gastar reviewer: los supervivientes
+ * viajan como advisory en su task, y en block cierran el gate ANTES con la
+ * lista exacta. Indisponible = degrada avisando, nunca en silencio.
+ */
+import { runMutation } from "../mutate/runner.js";
+import { getDiffScope } from "../mutate/diff-scope.js";
+import { detectProjectStack } from "../utils/stack-detect.js";
+import { getMutationTool } from "../mutate/tool-registry.js";
+
+export const formatSurvivor = (s) =>
+  `${s.file}:${s.line} (${s.mutator ?? s.status ?? "?"}) — mátalo con un assert que distinga el cambio`;
+
+async function defaultMutate({ projectDir }) {
+  const { language } = await detectProjectStack(projectDir);
+  const tool = getMutationTool(language);
+  if (!tool.supported) throw new Error(`lenguaje no soportado (${language ?? "desconocido"}) — ${tool.reason}`);
+  const scope = await getDiffScope({ staged: true, language });
+  if (scope.empty) return { result: { score: 100, killed: 0, total: 0, survived: [] } };
+  const outcome = await runMutation({ binary: tool.binary, args: scope.args, cwd: projectDir });
+  if (!outcome.result) throw new Error(`la herramienta ${tool.id} no produjo un informe legible`);
+  return outcome;
+}
+
+/**
+ * @returns {Promise<{enabled: boolean, ok: boolean, available?: boolean, mode?: string, survived?: object[], score?: number, reason?: string}>}
+ */
+export async function runMutationPregate({ config = {}, projectDir = process.cwd(), deps = {} } = {}) {
+  const mode = config?.method_gates?.mutation;
+  if (mode !== "warn" && mode !== "block") return { enabled: false, ok: true };
+  const { mutateFn = defaultMutate } = deps;
+  let outcome;
+  try {
+    outcome = await mutateFn({ projectDir });
+  } catch (err) {
+    // Sin herramienta no hay medición: cerrar sería castigar sin juicio y
+    // callar sería un pase falso — se degrada DICIENDO qué red está caída.
+    return { enabled: true, ok: true, available: false, mode, reason: err.message };
+  }
+  // Payload malformado del runner = misma degradación que el error (catch
+  // de codex): jamás crashear el review gate por un informe roto.
+  if (!outcome?.result || !Array.isArray(outcome.result.survived ?? [])) {
+    return { enabled: true, ok: true, available: false, mode, reason: "el runner de mutación devolvió un informe ilegible" };
+  }
+  const { survived = [], score } = outcome.result;
+  return { enabled: true, available: true, mode, survived, score, ok: mode === "warn" || survived.length === 0 };
+}

--- a/src/review/mutation-pregate.js
+++ b/src/review/mutation-pregate.js
@@ -1,10 +1,8 @@
 /**
- * Mutation pre-gate (MUT-A, KJC-TSK-0716, épica KJC-PCS-0072) — el auditor
- * del invariante "tests prove behavior": un test con asserts flojos deja
- * mutantes vivos aunque la suite esté verde. OPT-IN (method_gates.mutation:
- * warn|block — la mutación cuesta minutos, jamás corre sin declararla) y
- * SOLO en --staged, donde ya se va a gastar reviewer: los supervivientes
- * viajan como advisory en su task, y en block cierran el gate ANTES con la
+ * Mutation pre-gate (MUT-A, KJC-TSK-0716) — audita "tests prove behavior":
+ * asserts flojos dejan mutantes vivos con la suite verde. OPT-IN
+ * (method_gates.mutation: warn|block — cuesta minutos) y SOLO en --staged:
+ * supervivientes como advisory al reviewer; block cierra ANTES con la
  * lista exacta. Indisponible = degrada avisando, nunca en silencio.
  */
 import { runMutation } from "../mutate/runner.js";
@@ -37,8 +35,7 @@ export async function runMutationPregate({ config = {}, projectDir = process.cwd
   try {
     outcome = await mutateFn({ projectDir });
   } catch (err) {
-    // Sin herramienta no hay medición: cerrar sería castigar sin juicio y
-    // callar sería un pase falso — se degrada DICIENDO qué red está caída.
+    // Sin herramienta no hay medición: se degrada DICIENDO qué red cayó.
     return { enabled: true, ok: true, available: false, mode, reason: err.message };
   }
   // Payload malformado del runner = misma degradación que el error (catch

--- a/tests/mutate/diff-scope.test.js
+++ b/tests/mutate/diff-scope.test.js
@@ -80,6 +80,14 @@ describe("getDiffScope", () => {
     expect(scope.targets).toEqual(["src/foo.js:11-13", "src/foo.js:44-44"]);
   });
 
+  it("staged=true scopea al índice (--cached), jamás un rango vacío HEAD..HEAD (MUT-A, catch de codex)", async () => {
+    const calls = [];
+    const run = async (_cmd, args) => { calls.push(args); return { exitCode: 0, stdout: SAMPLE_DIFF }; };
+    const scope = await getDiffScope({ staged: true, language: "javascript", run });
+    expect(calls[0]).toEqual(["diff", "--unified=0", "--cached"]);
+    expect(scope.empty).toBe(false);
+  });
+
   it("returns empty scope when git diff fails", async () => {
     const run = async () => ({ exitCode: 128, stdout: "" });
     const scope = await getDiffScope({ since: "bad", language: "javascript", run });

--- a/tests/review/mutation-pregate.test.js
+++ b/tests/review/mutation-pregate.test.js
@@ -1,0 +1,116 @@
+// MUT-A (KJC-TSK-0716, épica KJC-PCS-0072) — el mutation pre-gate: opt-in
+// (mutation es cara), solo en --staged, supervivientes como advisory al
+// reviewer, y con block la lista exacta con remediación ANTES de gastar
+// reviewer. Indisponible = degrada AVISANDO, jamás en silencio.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { runMutationPregate, formatSurvivor } from "../../src/review/mutation-pregate.js";
+
+const reviewMock = vi.fn();
+vi.mock("../../src/review/one-shot-review.js", () => ({ runOneShotReview: (...a) => reviewMock(...a) }));
+vi.mock("../../src/review/sonar-pregate.js", async (orig) => ({
+  ...(await orig()), runSonarPregate: vi.fn().mockResolvedValue({ available: false, reason: "test" }),
+}));
+vi.mock("../../src/review/card-first.js", async (orig) => ({
+  ...(await orig()), checkCardFirst: vi.fn().mockResolvedValue({ ok: true, mode: "pass" }),
+}));
+vi.mock("../../src/review/mutation-pregate.js", async (orig) => {
+  const real = await orig();
+  return { ...real, runMutationPregate: vi.fn(real.runMutationPregate) };
+});
+import { reviewGateCommand } from "../../src/commands/review-gate.js";
+
+const outcome = (survived, extra = {}) => ({
+  result: { score: 80, killed: 8, total: 10, survived, ...extra },
+});
+
+describe("wiring en review-gate: --range NUNCA consulta el indice (catch de codex)", () => {
+  let dir;
+  const cwd0 = process.cwd();
+  afterEach(() => { process.chdir(cwd0); });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.exitCode = 0;
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-mutrange-"));
+    const git = (...args) => execFileSync("git", ["-C", dir, ...args]);
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "t@t"); git("config", "user.name", "t");
+    fs.writeFileSync(path.join(dir, "a.js"), "base\n");
+    git("add", "a.js"); git("commit", "-qm", "base");
+    fs.writeFileSync(path.join(dir, "a.js"), "cambio\n");
+    fs.writeFileSync(path.join(dir, "a.test.js"), "t\n");
+    git("add", "-A"); git("commit", "-qm", "cambio");
+    process.chdir(dir);
+    reviewMock.mockResolvedValue({ verdict: "approved", reviewer: "codex", diffHash: "abc123456789" });
+  });
+
+  it("con --range el pregate ni se invoca aunque method_gates.mutation este activo", async () => {
+    const { runMutationPregate: spy } = await import("../../src/review/mutation-pregate.js");
+    const spy2 = vi.spyOn(console, "log").mockImplementation(() => {});
+    const r = await reviewGateCommand({ config: { projectDir: dir, method_gates: { mutation: "block" } }, flags: { range: "HEAD~1...HEAD" } });
+    spy2.mockRestore();
+    expect(spy).not.toHaveBeenCalled();
+    expect(r.verdict).toBe("approved");
+  });
+});
+
+describe("runMutationPregate", () => {
+  it("sin method_gates.mutation NO corre — la mutación es opt-in", async () => {
+    const mutate = vi.fn();
+    const res = await runMutationPregate({ config: {}, deps: { mutateFn: mutate } });
+    expect(res.enabled).toBe(false);
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it("warn: supervivientes viajan como advisory, el gate no cierra", async () => {
+    const survived = [{ file: "src/a.js", line: 12, mutator: "ArithmeticOperator" }];
+    const res = await runMutationPregate({
+      config: { method_gates: { mutation: "warn" } },
+      deps: { mutateFn: async () => outcome(survived) },
+    });
+    expect(res).toMatchObject({ enabled: true, ok: true });
+    expect(res.survived).toHaveLength(1);
+  });
+
+  it("block: cierra con la lista exacta y remediación, sin tocar al reviewer", async () => {
+    const survived = [
+      { file: "src/a.js", line: 12, mutator: "ArithmeticOperator" },
+      { file: "src/b.js", line: 3, mutator: "ConditionalExpression" },
+    ];
+    const res = await runMutationPregate({
+      config: { method_gates: { mutation: "block" } },
+      deps: { mutateFn: async () => outcome(survived) },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.survived).toHaveLength(2);
+    expect(formatSurvivor(survived[0])).toMatch(/src\/a\.js:12.*ArithmeticOperator/);
+  });
+
+  it("cero supervivientes = gate abierto en block", async () => {
+    const res = await runMutationPregate({
+      config: { method_gates: { mutation: "block" } },
+      deps: { mutateFn: async () => outcome([]) },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("payload malformado del runner degrada igual que el error — jamas crashea el gate (catch de codex)", async () => {
+    for (const bad of [{}, { result: null }, { result: { survived: "no-array" } }]) {
+      const res = await runMutationPregate({ config: { method_gates: { mutation: "block" } }, deps: { mutateFn: async () => bad } });
+      expect(res).toMatchObject({ enabled: true, ok: true, available: false });
+    }
+  });
+
+  it("herramienta/lenguaje indisponible degrada AVISANDO — nunca un pase silencioso ni un cierre injusto", async () => {
+    const res = await runMutationPregate({
+      config: { method_gates: { mutation: "block" } },
+      deps: { mutateFn: async () => { throw new Error("stryker no instalado"); } },
+    });
+    expect(res).toMatchObject({ enabled: true, ok: true, available: false });
+    expect(res.reason).toMatch(/stryker/);
+  });
+});


### PR DESCRIPTION
## MUT-A parte 1 — el auditor del "tests prove behavior" (KJC-TSK-0716, épica KJC-PCS-0072)

Un test con asserts flojos deja la suite verde y los mutantes vivos. El mutation pre-gate cablea `kj mutate` (M-A..C, ya existente) al flujo de review con el patrón sonar-pregate:

- **Opt-in** (`method_gates.mutation: warn|block`) — la mutación cuesta minutos: jamás corre sin declararla, jamás en `--check`/pre-commit, y **solo con `--staged`** (ni siquiera en `--range`: el scope es el ÍNDICE y anotaría trabajo ajeno — catch de codex, con test de integración que fija que con range el pregate NI SE INVOCA).
- **`getDiffScope` gana modo `staged`** (`git diff --cached`): el `since: HEAD` inicial habría producido un rango `HEAD..HEAD` VACÍO — el pregate no habría mutado nada (catch de codex, agravado al verificarlo).
- **warn**: los supervivientes viajan como advisory dentro del task del reviewer (mismo canal que sonar). **block**: cierra ANTES de gastar reviewer con la lista exacta `fichero:línea (mutator)` y remediación.
- Indisponible (sin herramienta, informe ilegible o payload malformado — tercer catch de codex): degrada AVISANDO qué red está caída — ni pase silencioso ni castigo sin juicio.

TDD: 8 tests (7 unit con runner inyectado + 1 integración en repo git real). Suite completa verde. Parte 2: el playbook y el brief tester ORDENAN mutate post-verde pre-review.