### PR TITLE
docs(cli): kj agents help enumerates subcommands roles and providers (KJC-TSK-0755)

### DIFF
--- a/src/cli/register-roles-skills.js
+++ b/src/cli/register-roles-skills.js
@@ -1,5 +1,5 @@
 import { rolesCommand } from "../commands/roles.js";
-import { agentsCommand } from "../commands/agents.js";
+import { agentsCommand, ASSIGNABLE_ROLES, VALID_PROVIDERS } from "../commands/agents.js";
 import { withConfig } from "./_shared.js";
 
 /**
@@ -30,6 +30,22 @@ export function registerRolesSkills(program, { pkgVersion }) {
     .command("agents [subcommand] [role] [provider]")
     .description("List or change AI agent assignments per role (e.g. kj agents set coder gemini)")
     .option("--global", "Persist change to kj.config.yml (default for CLI)")
+    // KJC-TSK-0755: el --help enumera valores REALES (de las constantes, no
+    // duplicados a mano) — la firma genérica obligaba a preguntar.
+    .addHelpText("after", [
+      "",
+      "Subcommands:",
+      "  list (default)   Show the provider assigned to each role",
+      "  set              Change one: kj agents set <role> <provider>",
+      "",
+      `Roles:     ${ASSIGNABLE_ROLES.join(", ")}`,
+      `Providers: ${VALID_PROVIDERS.join(", ")}  (kj doctor shows which are installed)`,
+      "",
+      "Examples:",
+      "  kj agents                          # current assignments",
+      "  kj agents set reviewer codex",
+      "  kj agents set solomon agy --global",
+    ].join("\n"))
     .action(async (subcommand, role, provider, flags) => {
       await withConfig(pkgVersion, "agents", {}, async ({ config }) => {
         await agentsCommand({ config, subcommand: subcommand || "list", role, provider, global: flags.global });

--- a/src/commands/agents.js
+++ b/src/commands/agents.js
@@ -1,12 +1,14 @@
 import { loadConfig, writeConfig, getConfigPath, getProjectConfigPath, loadProjectConfig, resolveRole } from "../config.js";
 import { checkBinary, KNOWN_AGENTS } from "../utils/agent-detect.js";
 
-const ASSIGNABLE_ROLES = [
+// Exportados para que el --help se autoalimente de las constantes reales
+// (KJC-TSK-0755, hallazgo de campo: la firma genérica obligaba a preguntar).
+export const ASSIGNABLE_ROLES = [
   "coder", "reviewer", "planner", "refactorer", "triage",
   "researcher", "tester", "security", "solomon"
 ];
 
-const VALID_PROVIDERS = KNOWN_AGENTS.map((a) => a.name);
+export const VALID_PROVIDERS = KNOWN_AGENTS.map((a) => a.name);
 
 export function listAgents(config, sessionOverrides = {}, projectConfig = null) {
   return ASSIGNABLE_ROLES.map((role) => {


### PR DESCRIPTION
Field finding (Pedro Amador, testing on his Mac): kj agents --help only showed the generic signature, forcing users to ask what values it accepts. The help now self-feeds from the REAL constants (ASSIGNABLE_ROLES, KNOWN_AGENTS) — list|set explained, 9 roles, 9 providers, examples. Verified live.