### PR TITLE
fix(sentinel): quote-pair aware lane guard kills the quoted-spaces illusion (KJC-BUG-0140)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -299,7 +299,62 @@ process.stdin.on("end", () => {
         // en cualquier posicion, y una ruta entrecomillada con espacios es
         // invisible al tokenizador: ambas => deny conservador (endpoint
         // pedido por el reviewer; friccion asumida, el remedio es literal).
-        if (/\\$\\(|\`/.test(cmd) || /["'][^"'\\n]*\\/[^"'\\n]* [^"'\\n]*["']/.test(cmd)) {
+        // KJC-BUG-0140: pares de comillas REALES, no regex sobre el texto —
+        // la comilla de CIERRE de un string + un redirect literal + la de
+        // apertura del siguiente creaban la ilusion de ruta con espacios y
+        // denegaban el flujo estandar commit -m "..." > log && echo "ok".
+        // Se recorre alternando estado (doctrina del parseCommand del motor):
+        // solo el CONTENIDO realmente entrecomillado con slash y espacio
+        // deniega — incluidas comillas a mitad de token (scp host:"/a b/x")
+        // y la comilla sin cerrar (no verificable).
+        // ...y por TOKEN completo, no por span: spans adyacentes concatenan
+        // ("dir with"" spaces/file" es UNA ruta) — catch de codex.
+        const quotedPathWithSpaces = (s) => {
+          // Un backslash pegado a comilla o blanco (comilla escapada,
+          // espacio escapado) altera donde CIERRA el string o esconde
+          // espacios: opaco => deny (doctrina del motor) — catch de codex.
+          // Caracteres construidos con fromCharCode: CERO escaping en este
+          // template — fuente y artefacto identicos, nada que malinterpretar
+          // (el doble-escaping confundio cuatro reviews; solomon desestimo
+          // la primera y las demas se volvieron ilegibles igual).
+          // El punto escapado de un sed y similares siguen libres.
+          const BS = String.fromCharCode(92);
+          const TAB = String.fromCharCode(9);
+          const NL = String.fromCharCode(10);
+          for (let i = s.indexOf(BS); i !== -1; i = s.indexOf(BS, i + 1)) {
+            const n = s[i + 1] || "";
+            if (n === '"' || n === "'" || n === " " || n === TAB) return true;
+          }
+          let q = null;
+          let tok = "";
+          let hadQuote = false;
+          const flush = () => {
+            const bad = hadQuote && tok.includes("/") && tok.includes(" ");
+            tok = "";
+            hadQuote = false;
+            return bad;
+          };
+          for (const ch of s) {
+            if (q) {
+              if (ch === q) q = null;
+              else tok += ch;
+              continue;
+            }
+            if (ch === '"' || ch === "'") {
+              q = ch;
+              hadQuote = true;
+              continue;
+            }
+            if (ch === " " || ch === TAB || ch === NL || ch === ";" || ch === "|" || ch === "&" || ch === "<" || ch === ">" || ch === "(" || ch === ")") {
+              if (flush()) return true;
+              continue;
+            }
+            tok += ch;
+          }
+          if (q !== null) return true; // comilla sin cerrar: no verificable
+          return flush();
+        };
+        if (/\\$\\(|\`/.test(cmd) || quotedPathWithSpaces(cmd)) {
           if (process.env.KJ_ALLOW_CROSS_LANE === "1") { recordEscape(sid, "KJ_ALLOW_CROSS_LANE", tool); }
           else {
             console.error("kj sentinel: sustitucion de comandos o ruta entrecomillada con espacios en un comando mutador — no verificable por el guard de carriles (MONO-0); usa valores/rutas LITERALES sin sustitucion (o KJ_ALLOW_CROSS_LANE=1, queda registrado).");

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -325,6 +325,36 @@ describe("pretooluse-sentinel lane boundary (MONO-0)", () => {
     expect(res.stderr).toContain("carril");
   });
 
+  it("KJC-BUG-0140: un redirect literal ENTRE dos strings entrecomillados no es una ruta con espacios — el flujo estándar commit+log pasa; la ruta REAL entrecomillada con espacios sigue denegando", () => {
+    const standard = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: {
+      command: 'git commit -m "feat(x): mensaje con espacios" > /tmp/kj-log.txt 2>&1 && echo "ok" && git push -u origin rama',
+    } });
+    expect(standard.status).toBe(0);
+    const realQuoted = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: {
+      command: 'cp "/otro carril/con espacios/x.js" destino.js',
+    } });
+    expect(realQuoted.status).toBe(2);
+    const afterEq = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: {
+      command: 'rsync --exclude="/un dir/con espacios" a b',
+    } });
+    expect(afterEq.status).toBe(2);
+    // Pares reales, no contexto (catch de codex): la comilla a mitad de
+    // token (scp host:"...") o pegada a un redirect sigue siendo ruta real.
+    for (const evil of ['tee >"/un dir/con espacios/x.log" archivo', 'scp host:"/path with spaces/file" .', 'touch foo"/path with spaces"', 'touch "dir with"" spaces/file"']) {
+      const res = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: evil } });
+      expect(res.status).toBe(2);
+    }
+    // Escapes que tocan comilla o blanco son opacos (catch de codex): la
+    // comilla escapada moveria el cierre y esconderia el espacio.
+    const escaped = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: 'cp "dir\\" with spaces/file" dest' } });
+    expect(escaped.status).toBe(2);
+    const sedFree = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "sed -i s/a\\.b/c/ notas.txt" } });
+    expect(sedFree.status).toBe(0);
+    // Comilla sin cerrar en mutador = no verificable.
+    const unclosed = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: 'git commit -m "a medias' } });
+    expect(unclosed.status).toBe(2);
+  });
+
   it("cd/pushd in any mutating command is denied conservatively; mutating without cd in own tree passes", () => {
     const res = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "cd /tmp && rm -rf ../whatever" } });
     expect(res.status).toBe(2);


### PR DESCRIPTION
## KJC-BUG-0140 — el guard de carriles ya distingue comillas de verdad

Encontrado en carne propia: al instalarse el Sentinel en este repo (dogfood del `kj env install`), su PreToolUse denegó el flujo estándar del método — `git commit -m "..." > log && echo "ok" && git push` — porque el regex de "ruta entrecomillada con espacios" casaba una ILUSIÓN: comilla de cierre del mensaje + redirect literal + comilla de apertura del siguiente string.

El fix sigue la doctrina del parseCommand del kernel — pares reales, no regex sobre texto plano:

- Escáner de comillas con estado que evalúa por **TOKEN completo del shell** (spans adyacentes concatenan: `"dir with"" spaces/file"` es UNA ruta — catch de codex) con frontera solo en separadores no entrecomillados.
- Comillas a mitad de token (`scp host:"/a b/x"`) y tras redirecciones siguen denegando (catch de codex).
- **Escapes que tocan comilla o blanco son opacos** ⇒ deny (`\"` movería el cierre y escondería el espacio — catch de codex); el `\.` de un sed sigue libre.
- Comilla sin cerrar en mutador = no verificable ⇒ deny.

**La sub-historia del template escaping**: CUATRO findings consecutivos de codex leyeron el doble-escaping del template como si fuera el artefacto (el guard generado siempre tuvo el backslash y el whitespace correctos — verificado leyendo el script que `installSentinelHooks` escribe). Solomon (copilot de árbitro) desestimó el primero; el segundo llegó etiquetado security (no arbitrable por doctrina) y en vez de pelear la etiqueta, la solución estructural: **cero escaping en el template** — backslash/tab/newline construidos con `fromCharCode` y separadores por comparación explícita de caracteres. Fuente y artefacto idénticos: no queda nada que malinterpretar, y la quinta review aprobó.

La cadena de fricción quedó en la card: 6 comandos míos denegados por el guard viejo mientras lo arreglaba — incluido el `kj solomon` sobre este mismo fix.
