### PR TITLE
feat(doctor): declare the guarantee level per host at runtime (KJC-TSK-0756)

### DIFF
--- a/src/checks/guarantee-level.js
+++ b/src/checks/guarantee-level.js
@@ -1,0 +1,38 @@
+/**
+ * Guarantee level en runtime (KJC-TSK-0756, hallazgo de campo de Pedro):
+ * la doctrina "kj jamás finge una supervisión que no puede aplicar" vivía
+ * solo en el README — ahora kj doctor la DECLARA para el host actual, con
+ * el porqué. El acoplamiento a Claude es UNA capa (tier A: hooks síncronos
+ * bloqueantes, que hoy solo ese harness expone) y es decisión de ADR
+ * (v4.13), no accidente; el tier B (git gates) es el suelo agnóstico.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { detectHostAgent } from "../utils/agent-detect.js";
+
+/** Pure: computes the three tiers from observable facts. */
+export function guaranteeLevel({ host, harnessWired, policyDeclared, policyWorkflow }) {
+  const tierA = host === "claude" && harnessWired
+    ? { active: true, reason: "Claude Code expone hooks síncronos bloqueantes y el harness del Sentinel está instalado (kj harden)" }
+    : host === "claude"
+      ? { active: false, reason: "host Claude sin harness instalado — corre kj harden para activar la supervisión en el turno" }
+      : { active: false, reason: `el host ${host ?? "desconocido"} no expone hooks síncronos bloqueantes — no se finge la supervisión; el tier B sigue siendo el suelo de garantía` };
+  const tierB = { active: true, reason: "los gates viven en el repositorio, no en el harness: cualquier host, el diff violador no entra" };
+  const tierC = policyDeclared && policyWorkflow
+    ? { active: true, reason: "kj-policy.yml re-verifica el PR contra la policy declarada (merge-blocking)" }
+    : policyDeclared
+      ? { active: false, reason: "hay policy declarada pero sin workflow de CI — corre kj harden para sembrar kj-policy.yml" }
+      : { active: false, reason: "sin .karajan/policy.yml declarada — el tier C solo existe donde hay policy que verificar" };
+  return { host: host ?? null, tierA, tierB, tierC };
+}
+
+/** Facts from disk + env; injectable for tests. */
+export function collectGuaranteeFacts({ projectDir = process.cwd(), deps = {} } = {}) {
+  const { detectHost = detectHostAgent, exists = existsSync } = deps;
+  return guaranteeLevel({
+    host: detectHost(),
+    harnessWired: exists(join(projectDir, ".karajan", "harness", "pretooluse-sentinel.mjs")),
+    policyDeclared: exists(join(projectDir, ".karajan", "policy.yml")),
+    policyWorkflow: exists(join(projectDir, ".github", "workflows", "kj-policy.yml")),
+  });
+}

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -13,6 +13,7 @@
 
 import readline from "node:readline";
 import { runChecks as runCheckPipeline, toLegacyShape } from "../checks/runner.js";
+import { collectGuaranteeFacts } from "../checks/guarantee-level.js";
 import { STATUS } from "../checks/types.js";
 import { getSystemChecks } from "../checks/system.js";
 import { getConfigFileChecks } from "../checks/config-files.js";
@@ -140,14 +141,29 @@ export async function runChecks({ config }) {
  */
 export async function doctorCommand({ config, checkOnly = false, yes = false, json = false, verbose = false, projectOnly = false }) {
   const report = await runDoctor({ config, checkOnly, yes, projectOnly });
+  // KJC-TSK-0756 (campo, Pedro): el guarantee level del host actual se
+  // DECLARA en runtime — la doctrina no vive solo en el README.
+  report.guarantee = collectGuaranteeFacts({ projectDir: config?.projectDir || process.cwd() });
 
   if (json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     printHuman(report, { verbose });
+    printGuaranteeLevel(report.guarantee);
   }
 
   return hasBlockingFailure(report) ? 1 : 0;
+}
+
+// KJC-TSK-0756: la seccion de guarantee level — consola es el medio del
+// doctor (excepcion no-console de commands).
+function printGuaranteeLevel(g) {
+  const mark = (t) => (t.active ? "ACTIVE " : "OFF    ");
+  console.log();
+  console.log(`Guarantee level (host: ${g.host ?? "desconocido"}) — kj jamas finge una supervision que no puede aplicar:`);
+  console.log(`  ${mark(g.tierA)} A tool-time (Sentinel en el turno): ${g.tierA.reason}`);
+  console.log(`  ${mark(g.tierB)} B commit-time (git gates, el SUELO): ${g.tierB.reason}`);
+  console.log(`  ${mark(g.tierC)} C merge-time (re-check en CI): ${g.tierC.reason}`);
 }
 
 function hasBlockingFailure(report) {

--- a/tests/checks/guarantee-level.test.js
+++ b/tests/checks/guarantee-level.test.js
@@ -1,0 +1,44 @@
+// KJC-TSK-0756 (campo, Pedro Amador) — el guarantee level se DECLARA en
+// runtime: el acoplamiento a Claude es UNA capa (tier A, hooks síncronos)
+// y decisión de ADR; el tier B es el suelo agnóstico y jamás se finge lo
+// que no se puede aplicar.
+
+import { describe, it, expect } from "vitest";
+import { guaranteeLevel, collectGuaranteeFacts } from "../../src/checks/guarantee-level.js";
+
+describe("guaranteeLevel", () => {
+  it("host claude con harness: los tres tiers activos (con policy y workflow)", () => {
+    const g = guaranteeLevel({ host: "claude", harnessWired: true, policyDeclared: true, policyWorkflow: true });
+    expect(g.tierA.active).toBe(true);
+    expect(g.tierB.active).toBe(true);
+    expect(g.tierC.active).toBe(true);
+  });
+
+  it("host NO claude: tier A OFF con el porqué honesto, tier B sigue siendo el suelo", () => {
+    const g = guaranteeLevel({ host: "codex", harnessWired: false, policyDeclared: false, policyWorkflow: false });
+    expect(g.tierA.active).toBe(false);
+    expect(g.tierA.reason).toMatch(/no expone hooks síncronos/);
+    expect(g.tierA.reason).toMatch(/no se finge/);
+    expect(g.tierB.active).toBe(true);
+  });
+
+  it("claude SIN harness: tier A OFF con remedio (kj harden), no con excusa", () => {
+    const g = guaranteeLevel({ host: "claude", harnessWired: false, policyDeclared: false, policyWorkflow: false });
+    expect(g.tierA.active).toBe(false);
+    expect(g.tierA.reason).toMatch(/kj harden/);
+  });
+
+  it("tier C honesto: policy sin workflow = OFF con remedio; sin policy = OFF explicando que no hay qué verificar", () => {
+    expect(guaranteeLevel({ host: "claude", harnessWired: true, policyDeclared: true, policyWorkflow: false }).tierC).toMatchObject({ active: false });
+    expect(guaranteeLevel({ host: "claude", harnessWired: true, policyDeclared: false, policyWorkflow: false }).tierC.reason).toMatch(/sin .*policy/);
+  });
+
+  it("collectGuaranteeFacts lee los hechos del disco con deps inyectables", () => {
+    const g = collectGuaranteeFacts({
+      projectDir: "/p",
+      deps: { detectHost: () => "gemini", exists: (p) => p.includes(".karajan") && p.endsWith("policy.yml") },
+    });
+    expect(g).toMatchObject({ host: "gemini", tierA: { active: false }, tierC: { active: false } });
+    expect(g.tierC.reason).toMatch(/kj harden/); // declarada sin workflow: remedio, no excusa
+  });
+});


### PR DESCRIPTION
## KJC-TSK-0756 — la doctrina de agnosticismo, declarada en runtime (campo: Pedro Amador)

Percepción de campo: "kj está muy acoplado a claude, debería ser más agnóstico". La respuesta honesta vive en el ADR de la v4.13 y en el README (Guarantee levels): el acoplamiento es UNA capa — el tier A exige hooks síncronos bloqueantes que hoy solo Claude Code expone — y es decisión, no accidente; el tier B (git gates) es el suelo agnóstico para los 9 providers. Pero la doctrina no se VEÍA en runtime — de ahí la percepción.

- **`kj doctor` declara el guarantee level del host actual**, tier a tier, con el porqué y el remedio (no la excusa): host no-claude → "A OFF: este host no expone hooks síncronos — no se finge la supervisión; B sigue siendo el suelo"; claude sin harness → "corre kj harden"; policy declarada sin workflow → "corre kj harden". También en `--json` (`report.guarantee`).
- Función pura testeada (`guaranteeLevel`) + hechos del disco inyectables.
- Auditoría de acoplamientos: las referencias a Claude en src se concentran en las capas DECIDIDAS (claude-agent, harness-hooks, sentinel-hooks — el tier A) y en la detección multi-host; no aflora acoplamiento gratuito en rutas de gates o policy (el playbook escribe CLAUDE.md, AGENTS.md y GEMINI.md desde una fuente).

Dogfood inmediato: en este repo el doctor declara los TRES tiers ACTIVE — es el único repo del mundo con esa línea completa hoy.
