### PR TITLE
fix(start): deep source scan counts nested and infra code (KJC-BUG-0141)

### DIFF
--- a/src/start/sweep.js
+++ b/src/start/sweep.js
@@ -7,6 +7,8 @@
 // brief+tests; existing/legacy = + drift, harden advisory, rag + qmd status.
 // Collaborators are injected (opts.deps) so it stays trivially testable.
 import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
 import { execFileSync } from "node:child_process";
 
 import { collectAll } from "../onboarder/collectors/index.js";
@@ -23,10 +25,49 @@ const CODE_EXT = new Set([
   ".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".py", ".go",
   ".rs", ".java", ".php", ".rb", ".c", ".cc", ".cpp", ".cs",
 ]);
+// KJC-BUG-0141 — infra projects (k8s/terraform/shell/Docker) ARE source code,
+// and code nested deeper than the display tree's maxDepth must still count.
+const INFRA_EXT = new Set([".yaml", ".yml", ".tf", ".hcl", ".sh"]);
+const INFRA_NAMES = new Set(["Dockerfile", "Makefile", "Vagrantfile"]);
+const SCAN_IGNORED = new Set([
+  "node_modules", "dist", "build", "out", "vendor", "coverage", "target", "__pycache__",
+]);
+const SCAN_MAX_DEPTH = 6;
 const SCAFFOLD_MAX_FILES = 3;
 const CI_MARKERS = [".github/workflows", ".gitlab-ci.yml"];
 
 const safe = async (fn) => { try { return await fn(); } catch { return null; } };
+
+const isTestPath = (p) => {
+  const posix = p.replaceAll("\\", "/");
+  return /\.(test|spec)\./.test(posix) || /(^|\/)(test|tests|__tests__)\//.test(posix);
+};
+
+/**
+ * Deep source counter with its own walk: the display tree stops at depth 2,
+ * which made backend/app/… projects look empty (KJC-BUG-0141).
+ * @returns {Promise<{code: number, infra: number}>}
+ */
+export async function deepSourceScan(projectDir, { maxDepth = SCAN_MAX_DEPTH } = {}) {
+  const counts = { code: 0, infra: 0 };
+  const walk = async (dir, depth) => {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const ent of entries) {
+      if (ent.name.startsWith(".") || SCAN_IGNORED.has(ent.name)) continue;
+      const full = join(dir, ent.name);
+      if (ent.isDirectory()) {
+        if (depth < maxDepth) await walk(full, depth + 1);
+        continue;
+      }
+      if (!ent.isFile() || isTestPath(relative(projectDir, full))) continue;
+      const ext = ent.name.slice(ent.name.lastIndexOf("."));
+      if (CODE_EXT.has(ext)) counts.code += 1;
+      else if (INFRA_EXT.has(ext) || INFRA_NAMES.has(ent.name)) counts.infra += 1;
+    }
+  };
+  await walk(projectDir, 0);
+  return counts;
+}
 
 /** Count real source files in a tree bundle, skipping tests. */
 export function countCodeFiles(tree = []) {
@@ -35,8 +76,7 @@ export function countCodeFiles(tree = []) {
     if (node.kind === "dir") n += countCodeFiles(node.children);
     else if (node.kind === "file") {
       const ext = node.path.slice(node.path.lastIndexOf("."));
-      const isTest = /\.(test|spec)\./.test(node.path) || /(^|\/)(test|tests|__tests__)\//.test(node.path);
-      if (CODE_EXT.has(ext) && !isTest) n += 1;
+      if (CODE_EXT.has(ext) && !isTestPath(node.path)) n += 1;
     }
   }
   return n;
@@ -73,20 +113,22 @@ function readRagStatus(projectDir) {
  */
 export async function runReadOnlySweep(projectDir, { declared = null, profile = "standard", deps = {} } = {}) {
   const d = {
-    collectAll, detectTestFramework, checkHarden, compareHarden,
+    collectAll, detectTestFramework, checkHarden, compareHarden, sourceScan: deepSourceScan,
     detectQmd, ragStatus: readRagStatus, gitAgeDays: lastCommitAgeDays, ...deps,
   };
 
   const brief = await safe(() => d.collectAll(projectDir));
   const tests = await safe(() => d.detectTestFramework(projectDir));
+  const scan = await safe(() => d.sourceScan(projectDir));
 
   const tree = brief?.tree ?? [];
   const present = brief?.configs?.present ?? [];
-  const codeFiles = countCodeFiles(tree);
+  const codeFiles = scan ? scan.code + scan.infra : countCodeFiles(tree);
   const commitCount = brief?.git?.commitCount ?? 0;
 
   const signals = {
     hasSourceCode: codeFiles > 0,
+    infraFiles: scan?.infra ?? 0,
     scaffoldingOnly: codeFiles > 0 && codeFiles <= SCAFFOLD_MAX_FILES && commitCount <= 1,
     hasTests: Boolean(tests?.hasTests),
     hasCI: CI_MARKERS.some((m) => present.includes(m)),

--- a/tests/start/deep-source-scan.test.js
+++ b/tests/start/deep-source-scan.test.js
@@ -1,0 +1,66 @@
+// KJC-BUG-0141 (campo: Pedro) — kj start decía "new, no source code found"
+// con el código en backend/app/… (maxDepth=2 del tree lo hacía invisible) y
+// con proyectos de infra (yaml/tf/sh/Dockerfile no contaban como código).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { deepSourceScan, runReadOnlySweep } from "../../src/start/sweep.js";
+
+describe("deepSourceScan", () => {
+  let dir;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-scan-")); });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("ve el código anidado a profundidad backend/app/… (el caso de Pedro)", async () => {
+    fs.mkdirSync(path.join(dir, "backend", "app", "api"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "backend", "app", "api", "main.py"), "print(1)\n");
+    fs.writeFileSync(path.join(dir, "backend", "app", "api", "main.test.py"), "test\n");
+    const scan = await deepSourceScan(dir);
+    expect(scan.code).toBe(1); // el test no cuenta como fuente
+  });
+
+  it("cuenta la infra como fuente: yaml, tf, sh y Dockerfile", async () => {
+    fs.mkdirSync(path.join(dir, "manifests"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "manifests", "deploy.yaml"), "kind: Deployment\n");
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    fs.writeFileSync(path.join(dir, "up.sh"), "#!/bin/sh\n");
+    fs.writeFileSync(path.join(dir, "Dockerfile"), "FROM scratch\n");
+    const scan = await deepSourceScan(dir);
+    expect(scan.code).toBe(0);
+    expect(scan.infra).toBe(4);
+  });
+
+  it("ignora node_modules y ocultos", async () => {
+    fs.mkdirSync(path.join(dir, "node_modules", "x"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "node_modules", "x", "i.js"), "x\n");
+    const scan = await deepSourceScan(dir);
+    expect(scan.code + scan.infra).toBe(0);
+  });
+});
+
+describe("sweep con el escáner inyectado (KJC-BUG-0141)", () => {
+  const base = {
+    collectAll: async () => ({ stack: { language: null }, tree: [], git: { commitCount: 20 }, configs: { present: [] } }),
+    detectTestFramework: async () => ({ hasTests: false }),
+    checkHarden: async () => null, compareHarden: () => null,
+    detectQmd: async () => null, ragStatus: () => null, gitAgeDays: () => 3,
+  };
+
+  it("un proyecto de infra puro deja de ser 'new — no source code found'", async () => {
+    const b = await runReadOnlySweep("/x", { deps: { ...base, sourceScan: async () => ({ code: 0, infra: 12 }) } });
+    expect(b.signals.hasSourceCode).toBe(true);
+    expect(b.maturity.maturity).not.toBe("new");
+  });
+
+  it("código anidado invisible para el tree superficial cuenta igual", async () => {
+    const b = await runReadOnlySweep("/x", { deps: { ...base, sourceScan: async () => ({ code: 7, infra: 0 }) } });
+    expect(b.signals.hasSourceCode).toBe(true);
+  });
+
+  it("si el escáner falla, el conteo del tree sigue siendo el fallback (fail-soft)", async () => {
+    const b = await runReadOnlySweep("/x", { deps: { ...base, sourceScan: async () => { throw new Error("io"); } } });
+    expect(b.signals.hasSourceCode).toBe(false); // tree vacío, sin crash
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0141 — kj start decía "new — no source code found" con código en backend/

Hallazgo de campo (Pedro Amador, proyecto demo-kind de infra): `kj start` clasificaba el proyecto como `new (inferred) - no source code found` teniendo código real.

### Causa raíz (dos huecos)
1. El conteo de fuente se apoyaba en el tree de display (`collectTree`, `maxDepth = 2`): cualquier fichero a profundidad 3+ (`backend/app/api/main.py`) era invisible.
2. `CODE_EXT` solo contenía lenguajes de aplicación: un proyecto de infra (yaml/tf/hcl/sh/Dockerfile) contaba cero fuente.

### Fix
- `deepSourceScan(projectDir)`: walk propio del sweep hasta profundidad 6, ignora ocultos y directorios de build, salta tests, y devuelve `{code, infra}`.
- `INFRA_EXT` (.yaml/.yml/.tf/.hcl/.sh) + `INFRA_NAMES` (Dockerfile/Makefile/Vagrantfile) cuentan como fuente; la señal `infraFiles` queda expuesta en `signals`.
- Fail-soft: si el escáner falla, el conteo del tree sigue siendo el fallback (comportamiento previo intacto).
- Normalización de separadores en `isTestPath` (Windows) — catch de codex.

### Verificación
- TDD: `tests/start/deep-source-scan.test.js` (caso Pedro anidado, infra pura, ignorados, fallback).
- Suite completa: 6684 tests verdes. Review cross-AI: APPROVED by codex.

Card: KJC-BUG-0141.
