### PR TITLE
fix(codex): replace removed --full-auto with --sandbox workspace-write (KJC-BUG-0143)

### DIFF
--- a/src/agents/codex-agent.js
+++ b/src/agents/codex-agent.js
@@ -77,9 +77,26 @@ export class CodexAgent extends BaseAgent {
   }
 
   async _exec(task, model, role) {
+    // KJC-BUG-0143 (campo, issue #1471): codex exec >= 0.146 rechaza
+    // --full-auto ("unexpected argument"); el auto-approve moderno para un
+    // coder que escribe es --sandbox workspace-write. Los CLIs antiguos no
+    // conocen --sandbox: si lo rechazan, se reintenta con el flag legacy.
+    const autoApprove = role !== "reviewer" && this.isAutoApproveEnabled(role);
+    const res = await this._execOnce(task, model, role, { autoApprove, legacyAutoFlag: false });
+    if (!res.ok && autoApprove && /unexpected argument '--sandbox'/.test(res.error || "")) {
+      this.logger?.warn("codex CLI sin --sandbox — reintentando con el flag legacy --full-auto");
+      return this._execOnce(task, model, role, { autoApprove, legacyAutoFlag: true });
+    }
+    return res;
+  }
+
+  async _execOnce(task, model, role, { autoApprove, legacyAutoFlag }) {
     const args = ["exec", "--skip-git-repo-check"];
     if (model) args.push("--model", model);
-    if (role !== "reviewer" && this.isAutoApproveEnabled(role)) args.push("--full-auto");
+    if (autoApprove) {
+      if (legacyAutoFlag) args.push("--full-auto");
+      else args.push("--sandbox", "workspace-write");
+    }
     args.push("-");
     const res = await this.runCommand(resolveBin("codex"), args, {
       onOutput: task.onOutput,

--- a/tests/agents/agents-implementations.test.js
+++ b/tests/agents/agents-implementations.test.js
@@ -124,13 +124,16 @@ describe("Agent implementations", () => {
       expect(runCommand.mock.calls[0][2]).toMatchObject({ input: "add tests" });
     });
 
-    it("adds --full-auto when auto_approve is enabled", async () => {
+    it("adds --sandbox workspace-write when auto_approve is enabled (KJC-BUG-0143)", async () => {
       const config = { ...baseConfig, coder_options: { auto_approve: true } };
       const { CodexAgent } = await import("../../src/agents/codex-agent.js");
       const agent = new CodexAgent("codex", config, logger);
       await agent.runTask({ prompt: "test", role: "coder" });
 
-      expect(runCommand.mock.calls[0][1]).toContain("--full-auto");
+      const args = runCommand.mock.calls[0][1];
+      expect(args).toContain("--sandbox");
+      expect(args[args.indexOf("--sandbox") + 1]).toBe("workspace-write");
+      expect(args).not.toContain("--full-auto");
     });
 
     it("does not add --full-auto for reviewer role", async () => {
@@ -140,6 +143,7 @@ describe("Agent implementations", () => {
       await agent.reviewTask({ prompt: "review", role: "reviewer" });
 
       expect(runCommand.mock.calls[0][1]).not.toContain("--full-auto");
+      expect(runCommand.mock.calls[0][1]).not.toContain("--sandbox");
     });
 
     it("adds --model flag when configured", async () => {

--- a/tests/agents/codex-agent.test.js
+++ b/tests/agents/codex-agent.test.js
@@ -34,8 +34,11 @@ describe("CodexAgent", () => {
     });
   });
 
-  // merged-from: 4 --full-auto tests covering coder vs reviewer × on/off/missing.
-  describe("--full-auto flag", () => {
+  // KJC-BUG-0143 (campo, issue #1471): codex exec >= 0.146 no acepta
+  // --full-auto — el flag moderno de auto-aprobación para un coder que
+  // escribe es --sandbox workspace-write; --full-auto queda como retry
+  // para CLIs antiguos.
+  describe("auto-approve flag (--sandbox workspace-write)", () => {
     it.each([
       ["coder, auto_approve=true",  { coder_options: { auto_approve: true } },  "runTask",    true],
       ["coder, auto_approve=false", { coder_options: { auto_approve: false } }, "runTask",    false],
@@ -47,8 +50,43 @@ describe("CodexAgent", () => {
       await agent[method]({ prompt: "t", role: method === "runTask" ? "coder" : "reviewer" });
 
       const args = runCommand.mock.calls[0][1];
-      if (expected) expect(args).toContain("--full-auto");
-      else expect(args).not.toContain("--full-auto");
+      expect(args).not.toContain("--full-auto");
+      if (expected) {
+        expect(args).toContain("--sandbox");
+        expect(args[args.indexOf("--sandbox") + 1]).toBe("workspace-write");
+      } else {
+        expect(args).not.toContain("--sandbox");
+      }
+    });
+
+    it("retries with legacy --full-auto when the CLI rejects --sandbox (codex antiguo)", async () => {
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      runCommand
+        .mockResolvedValueOnce({ exitCode: 2, stdout: "", stderr: "error: unexpected argument '--sandbox' found" })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: "done", stderr: "" });
+
+      const result = await new CodexAgent("codex", config, logger).runTask({ prompt: "t", role: "coder" });
+
+      expect(result.ok).toBe(true);
+      expect(runCommand).toHaveBeenCalledTimes(2);
+      const retryArgs = runCommand.mock.calls[1][1];
+      expect(retryArgs).toContain("--full-auto");
+      expect(retryArgs).not.toContain("--sandbox");
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("--full-auto"));
+    });
+
+    it("does NOT retry on unrelated errors or when the flag was never sent", async () => {
+      const config = { ...baseConfig, coder_options: { auto_approve: true } };
+      runCommand.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "connection timeout" });
+      const unrelated = await new CodexAgent("codex", config, logger).runTask({ prompt: "t", role: "coder" });
+      expect(unrelated.ok).toBe(false);
+      expect(runCommand).toHaveBeenCalledTimes(1);
+
+      runCommand.mockClear();
+      runCommand.mockResolvedValue({ exitCode: 2, stdout: "", stderr: "error: unexpected argument '--sandbox' found" });
+      const noFlag = await new CodexAgent("codex", baseConfig, logger).runTask({ prompt: "t", role: "coder" });
+      expect(noFlag.ok).toBe(false);
+      expect(runCommand).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## KJC-BUG-0143 — codex exec ya no acepta --full-auto (issue #1471, campo)

`codex exec` >= 0.146 rechaza `--full-auto` ("unexpected argument"). kj lo inyectaba como flag de auto-aprobación del coder, así que cualquier `kj start`/`kj run` con codex de coder moría en el arranque. Nunca lo sufrimos en local porque nuestro coder es claude (el reviewer omite el flag).

### Fix
- El auto-approve moderno para un coder que escribe es `--sandbox workspace-write` (verificado contra codex-cli 0.146.1).
- Retry legacy: si el CLI rechaza `--sandbox` con "unexpected argument", se reintenta con `--full-auto` (CLIs antiguos), avisando por log. Sin retry en errores no relacionados ni cuando el flag no se envió.
- El reviewer sigue sin flag de auto-aprobación (ni moderno ni legacy).

### Verificación
TDD en tests/agents/codex-agent.test.js (matriz coder/reviewer × on/off + retry legacy + no-retry) y contrato actualizado en agents-implementations.test.js. Suite completa verde. Review cross-AI APPROVED.

Card: KJC-BUG-0143. Cierra #1471.
