### PR TITLE
fix(agents): drop cross-family role models per provider (KJC-BUG-0144)

### DIFF
--- a/src/agents/base-agent.js
+++ b/src/agents/base-agent.js
@@ -12,6 +12,7 @@
 
 import { defaultEnvironment } from "../infrastructure/environment.js";
 import { buildAgentEnv } from "../utils/role-env.js";
+import { isModelCompatible } from "../config/role-resolver.js";
 
 const MODEL_NOT_SUPPORTED_PATTERNS = [
   /model.{0,30}is not supported/i,
@@ -95,10 +96,19 @@ export class BaseAgent {
    * @returns {string|null}
    */
   getRoleModel(role) {
-    const roleModel = this.config?.roles?.[role]?.model;
-    if (roleModel) return roleModel;
-    if (role === "reviewer") return this.config?.reviewer_options?.model || null;
-    return this.config?.coder_options?.model || null;
+    const roleModel =
+      this.config?.roles?.[role]?.model ||
+      (role === "reviewer" ? this.config?.reviewer_options?.model : this.config?.coder_options?.model) ||
+    null;
+    // KJC-BUG-0144 (campo, issue #1465): un default por-rol (start: haiku)
+    // puede caer sobre un provider de OTRA familia (agy, codex...) — el
+    // modelo se descarta con aviso y el agente usa su propio default,
+    // nunca se le pasa un --model ajeno.
+    if (roleModel && !isModelCompatible(this.name, roleModel)) {
+      this.logger?.warn?.(`model "${roleModel}" belongs to another family — dropping it for ${this.name} (role ${role})`);
+      return null;
+    }
+    return roleModel;
   }
 
   /**

--- a/src/config/role-resolver.js
+++ b/src/config/role-resolver.js
@@ -20,8 +20,13 @@
 
 /**
  * Check if a model string is compatible with an agent provider.
- * Only returns false when the model clearly belongs to a DIFFERENT provider.
+ * Only returns false when the model clearly belongs to a DIFFERENT family.
  * Returns true if we can't determine or if the model is ambiguous.
+ *
+ * KJC-BUG-0144: exported and family-based — an agent may serve another
+ * family's models (agy is Google's Antigravity, gemini family), and the
+ * same check now guards BaseAgent.getRoleModel so per-role defaults
+ * (e.g. start's haiku) never reach a provider from another family.
  */
 const AGENT_MODEL_SIGNATURES = {
   claude: ["claude", "sonnet", "opus", "haiku"],
@@ -29,21 +34,26 @@ const AGENT_MODEL_SIGNATURES = {
   gemini: ["gemini", "flash-"]
 };
 
-function isModelCompatible(agent, model) {
-  if (!model || !agent) return true;
+// Single-family CLIs: they only serve their own vendor's models. Agents NOT
+// in this map (aider, opencode, copilot, kimi...) are multi-model hosts —
+// they route to arbitrary models, so any model name is allowed there.
+const AGENT_FAMILY = { claude: "claude", codex: "codex", gemini: "gemini", agy: "gemini" };
+
+function modelFamily(model) {
   const lower = model.toLowerCase();
-
-  // Check if model clearly belongs to a different provider
-  for (const [provider, signatures] of Object.entries(AGENT_MODEL_SIGNATURES)) {
-    if (provider === agent) continue;
-    if (signatures.some(s => lower.includes(s))) {
-      // Model belongs to a different provider — incompatible
-      return false;
-    }
+  for (const [family, signatures] of Object.entries(AGENT_MODEL_SIGNATURES)) {
+    if (signatures.some(s => lower.includes(s))) return family;
   }
+  return null;
+}
 
-  // Model doesn't clearly belong to any other provider — allow it
-  return true;
+export function isModelCompatible(agent, model) {
+  if (!model || !agent) return true;
+  const agentFamily = AGENT_FAMILY[agent];
+  if (!agentFamily) return true; // multi-model host — bring your own model
+  const family = modelFamily(model);
+  if (!family) return true; // ambiguous/custom/local — allow it
+  return family === agentFamily;
 }
 
 // Roles that inherit provider/model from the coder when not explicitly configured

--- a/tests/agents/model-family-filter.test.js
+++ b/tests/agents/model-family-filter.test.js
@@ -1,0 +1,56 @@
+// KJC-BUG-0144 (campo, issue #1465): kj start pasaba el modelo "haiku"
+// (familia Claude) a agy — el default del rol start es haiku pero el
+// provider cae al coder, y getRoleModel devolvía el modelo crudo sin
+// comprobar a qué familia pertenece. El modelo por defecto se resuelve
+// POR PROVIDER: un modelo de otra familia se descarta (con aviso) y el
+// agente usa su default.
+
+import { describe, it, expect, vi } from "vitest";
+import { BaseAgent } from "../../src/agents/base-agent.js";
+import { isModelCompatible } from "../../src/config/role-resolver.js";
+
+const mkLogger = () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() });
+const agentWith = (name, config, logger = mkLogger()) => new BaseAgent(name, config, logger);
+
+describe("isModelCompatible — familias por provider", () => {
+  it.each([
+    ["agy", "haiku", false],
+    ["agy", "claude-haiku-4.5", false],
+    ["agy", "gemini-2.5-pro", true], // agy = Antigravity, familia gemini
+    ["codex", "haiku", false],
+    ["codex", "gpt-5-mini", true],
+    ["claude", "haiku", true],
+    ["claude", "gemini-2.5-pro", false],
+    // Hosts multi-modelo (BYOM): enrutan a modelos de cualquier familia.
+    ["aider", "gpt-4o", true],
+    ["copilot", "haiku", true],
+    ["opencode", "gemma-local/coder", true],
+  ])("%s + %s → %s", (agent, model, expected) => {
+    expect(isModelCompatible(agent, model)).toBe(expected);
+  });
+});
+
+describe("BaseAgent.getRoleModel — el caso de Pedro (start con haiku sobre agy)", () => {
+  it("descarta el modelo de otra familia y avisa (agy + haiku → null)", () => {
+    const logger = mkLogger();
+    const agent = agentWith("agy", { roles: { start: { model: "haiku" } } }, logger);
+    expect(agent.getRoleModel("start")).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("haiku"));
+  });
+
+  it("mantiene el modelo cuando la familia coincide (claude + haiku)", () => {
+    const agent = agentWith("claude", { roles: { start: { model: "haiku" } } });
+    expect(agent.getRoleModel("start")).toBe("haiku");
+  });
+
+  it("mantiene modelos de familia indeterminada (local/custom)", () => {
+    const agent = agentWith("opencode", { roles: { coder: { model: "coder" } } });
+    expect(agent.getRoleModel("coder")).toBe("coder");
+  });
+
+  it("tambien filtra los modelos heredados de coder_options", () => {
+    const logger = mkLogger();
+    const agent = agentWith("codex", { coder_options: { model: "sonnet" } }, logger);
+    expect(agent.getRoleModel("coder")).toBeNull();
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0144 — kj start pasa el modelo haiku (solo Claude) a agy (issue #1465, campo)

El rol `start` tiene `model: "haiku"` por defecto y su provider cae al coder. Con coder=agy (o codex), kj lanzaba el agente con `--model haiku`: un modelo de otra familia. `resolveRole` ya filtraba incompatibilidades, pero el rol start (y cualquier ruta que use `BaseAgent.getRoleModel` directo) lo esquivaba.

### Fix
- `isModelCompatible` (role-resolver) se exporta y pasa a ser por FAMILIA: los CLIs de familia única (claude, codex, gemini, y **agy = familia gemini**) solo aceptan modelos de su vendor; los hosts multi-modelo (aider, opencode, copilot…) enrutan a cualquier modelo — BYOM, sin filtro.
- `BaseAgent.getRoleModel` aplica el filtro en el chokepoint: un modelo de otra familia se descarta con aviso y el agente usa su propio default — nunca se le pasa un `--model` ajeno. Cubre defaults por-rol (start), overrides y herencias de coder_options.

### Verificación
TDD en tests/agents/model-family-filter.test.js (matriz de familias + los 4 caminos de getRoleModel). La primera versión del filtro rompió 8 tests legítimos de hosts BYOM (aider con gpt-4o, copilot con haiku) — el matiz multi-modelo salió de ahí y quedó fijado con tests. Suite completa 6705 verde. Review cross-AI APPROVED.

Card: KJC-BUG-0144. Cierra #1465.
