### PR TITLE
feat(sentinel): infra files count as sources (KJC-TSK-0758)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -35,8 +35,10 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 export const STATE = join(here, "sentinel-state.json");
 export const ROOT = join(here, "..", "..");
-export const TESTS = /(^|\\/)(tests?|__tests__|spec)\\/|\\.(test|spec)\\.[a-z]+$/;
-export const CODE = /\\.(m?[jt]sx?|c[jt]s|py|go|rs|java|rb|php|cs|swift|kt|astro|svelte|vue|c|h|cc|cpp|hpp)$/;
+// INF-A (KJC-TSK-0758): infra IS source — terraform/k8s/shell/Docker edits
+// engage the method like app code; *_test.* files (terratest) are tests.
+export const TESTS = /(^|\\/)(tests?|__tests__|spec)\\/|\\.(test|spec)\\.[a-z]+$|_test\\.[a-z]+$/;
+export const CODE = /\\.(m?[jt]sx?|c[jt]s|py|go|rs|java|rb|php|cs|swift|kt|astro|svelte|vue|c|h|cc|cpp|hpp|tf|hcl|ya?ml|sh)$|(^|\\/)(Dockerfile|Makefile|Vagrantfile)$/;
 export const CARD = new RegExp(${JSON.stringify(CARD_REF_RE.source)}, "i");
 export const BASE_BRANCHES = new Set(["main", "master"]);
 export const load = () => { try { return JSON.parse(readFileSync(STATE, "utf8")); } catch { return {}; } };

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -43,6 +43,17 @@ describe("posttooluse script (state writer)", () => {
     expect(s.edited_tests).toEqual(["tests/a.test.js"]);
   });
 
+  it("INF-A (KJC-TSK-0758): la infra ES fuente — .tf/.yaml/.sh/Dockerfile van al bucket de sources y *_test.* al de tests", () => {
+    run(postScript, editTool(path.join(dir, "main.tf")));
+    run(postScript, editTool(path.join(dir, "k8s", "deploy.yaml")));
+    run(postScript, editTool(path.join(dir, "up.sh")));
+    run(postScript, editTool(path.join(dir, "Dockerfile")));
+    run(postScript, editTool(path.join(dir, "modules", "vpc_test.go")));
+    const s = state().sessions.s1;
+    expect(s.edited_sources).toEqual(["main.tf", "k8s/deploy.yaml", "up.sh", "Dockerfile"]);
+    expect(s.edited_tests).toEqual(["modules/vpc_test.go"]);
+  });
+
   it("records used KJ_ALLOW_* escapes and never crashes on garbage input", () => {
     run(postScript, editTool(path.join(dir, "src", "a.js")), { KJ_ALLOW_NO_CARD: "1" });
     expect(state().sessions.s1.escapes).toContain("KJ_ALLOW_NO_CARD");
@@ -100,6 +111,13 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
   let gate;
   beforeEach(() => {
     gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+  });
+
+  it("INF-A: editar un .tf en rama sin card se deniega igual que un .js", () => {
+    execSync("git checkout -q -b sin-card", { cwd: dir });
+    const blocked = run(gate, editTool(path.join(dir, "main.tf")));
+    expect(blocked.status).toBe(2);
+    expect(blocked.stderr).toMatch(/card/i);
   });
 
   it("blocks editing a source on a branch without card ref, with remediation and named escape recorded", () => {


### PR DESCRIPTION
INF-A (épica KJC-PCS-0078, caso de campo demo-kind): el CODE regex de sentinel-lib incorpora `.tf/.hcl/.yaml/.yml/.sh` y los basenames Dockerfile/Makefile/Vagrantfile — editar infra dispara card-first, Stop gate y push gate igual que un `.js`. Los `*_test.*` (terratest) clasifican como tests, no como fuentes.

TDD sobre el hook generado (bucket de sources/tests + deny en rama sin card); suite completa verde; review cross-AI APPROVED.

Card: KJC-TSK-0758.
