### PR TITLE
feat(tester): infra suites in test detection and tester brief (KJC-TSK-0759)

### DIFF
--- a/src/roles/tester-role.js
+++ b/src/roles/tester-role.js
@@ -24,7 +24,14 @@ const COVERAGE_COMMANDS = {
   rspec: "bundle exec rspec 2>&1",
   phpunit: "vendor/bin/phpunit --coverage-text 2>&1",
   "dotnet-test": "dotnet test --collect:\"XPlat Code Coverage\" 2>&1",
-  "dart-test": "dart test 2>&1"
+  "dart-test": "dart test 2>&1",
+  // INF-B: the basic suite ALWAYS runs first; checkov is the additive deep
+  // scan. If checkov is missing this chain fails and the brief falls back to
+  // the basic suite alone (declared degradation, never green-by-omission).
+  "terraform-validate": "terraform init -backend=false -input=false 2>&1 && terraform validate 2>&1 && checkov -d . --compact --quiet 2>&1",
+  "helm-lint": "helm lint . 2>&1 && checkov -d . --compact --quiet 2>&1",
+  "kustomize-build": "kustomize build . > /dev/null && checkov -d . --compact --quiet 2>&1",
+  "ansible-lint": "ansible-lint 2>&1 && checkov -d . --compact --quiet 2>&1"
 };
 
 const TEST_COMMANDS = {
@@ -39,7 +46,12 @@ const TEST_COMMANDS = {
   rspec: "bundle exec rspec 2>&1",
   phpunit: "vendor/bin/phpunit 2>&1",
   "dotnet-test": "dotnet test 2>&1",
-  "dart-test": "dart test 2>&1"
+  "dart-test": "dart test 2>&1",
+  // INF-B (KJC-TSK-0759): infra suites — validity IS the test floor.
+  "terraform-validate": "terraform init -backend=false -input=false 2>&1 && terraform validate 2>&1",
+  "helm-lint": "helm lint . 2>&1",
+  "kustomize-build": "kustomize build . > /dev/null && echo kustomize build: OK",
+  "ansible-lint": "ansible-lint 2>&1"
 };
 
 export class TesterRole extends AgentRole {
@@ -82,9 +94,14 @@ export class TesterRole extends AgentRole {
     if (detection.hasTests && detection.framework) {
       const coverageCmd = COVERAGE_COMMANDS[detection.framework];
       const testCmd = TEST_COMMANDS[detection.framework];
+      // INF-B: infra suites have no node_modules — the step-0 contract is
+      // "the tool exists or you SAY which one is missing", never a fake green.
+      const step0 = detection.language === "infra"
+        ? "**Step 0**: Verify the SUITE tool is installed (`which terraform`/`helm`/`kustomize`/`ansible-lint`). If the suite tool is MISSING, do NOT fake a green: report it in `failures` with the exact install command and set tests_pass: false. `checkov` (the deep scan below) is OPTIONAL: if it is missing, run the basic suite as the fallback and SAY the deep scan was skipped (degraded, never green-by-omission)."
+        : "**Step 0**: If node_modules/ does not exist, run `npm install` (or `pnpm install`) first.";
       sections.push(
         `## Detected test framework: ${detection.framework} (${detection.language})`,
-        "**Step 0**: If node_modules/ does not exist, run `npm install` (or `pnpm install`) first.",
+        step0,
         `**Step 1**: Run the test suite with coverage:`,
         "```bash",
         coverageCmd || testCmd,

--- a/src/utils/project-detect.js
+++ b/src/utils/project-detect.js
@@ -42,6 +42,18 @@ const LANGUAGE_MARKERS = [
   { file: "pubspec.yaml", framework: "dart-test", language: "dart" },
 ];
 
+// --- Infra (INF-B, KJC-TSK-0759) ---
+// Checked AFTER app-language markers: a mixed repo keeps its app framework.
+// Only unequivocal markers — a stray .yaml never classifies as infra.
+const INFRA_MARKERS = [
+  { file: "*.tf", glob: true, framework: "terraform-validate", language: "infra" },
+  { file: "terraform", framework: "terraform-validate", language: "infra" },
+  { file: "Chart.yaml", framework: "helm-lint", language: "infra" },
+  { file: "kustomization.yaml", framework: "kustomize-build", language: "infra" },
+  { file: "kustomization.yml", framework: "kustomize-build", language: "infra" },
+  { file: "ansible.cfg", framework: "ansible-lint", language: "infra" },
+];
+
 /** Test file patterns per language (used by TDD policy). */
 export const TEST_PATTERNS_BY_LANGUAGE = {
   javascript: ["/tests/", "/__tests__/", ".test.", ".spec."],
@@ -55,6 +67,7 @@ export const TEST_PATTERNS_BY_LANGUAGE = {
   php:        ["/tests/", "/test/", "Test.php"],
   swift:      ["/Tests/", "Tests.swift"],
   dart:       ["/test/", "_test.dart"],
+  infra:      ["/tests/", "/test/", "_test."],
 };
 
 function frameworkFromConfig(filename) {
@@ -93,7 +106,18 @@ export async function detectTestFramework(cwd = process.cwd()) {
   }
 
   // 3. Multi-language: check project markers
-  for (const marker of LANGUAGE_MARKERS) {
+  const lang = await matchMarkers(cwd, LANGUAGE_MARKERS);
+  if (lang) return lang;
+
+  // 4. Infra (INF-B): terraform/helm/kustomize/ansible have their own suite.
+  const infra = await matchMarkers(cwd, INFRA_MARKERS);
+  if (infra) return infra;
+
+  return { hasTests: false, framework: null, language: null };
+}
+
+async function matchMarkers(cwd, markers) {
+  for (const marker of markers) {
     try {
       if (marker.glob) {
         const entries = await fs.readdir(cwd);
@@ -107,8 +131,7 @@ export async function detectTestFramework(cwd = process.cwd()) {
       }
     } catch { /* not found */ }
   }
-
-  return { hasTests: false, framework: null, language: null };
+  return null;
 }
 
 /**

--- a/tests/utils/project-detect-infra.test.js
+++ b/tests/utils/project-detect-infra.test.js
@@ -1,0 +1,70 @@
+// INF-B (KJC-TSK-0759, épica KJC-PCS-0078) — un proyecto de infra tiene
+// suite propia: terraform validate, helm lint, kustomize build, ansible-lint.
+// Solo marcadores INEQUÍVOCOS (un yaml suelto NO es infra) y siempre DESPUÉS
+// de los frameworks de aplicación (un repo mixto conserva su framework).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { detectTestFramework, TEST_PATTERNS_BY_LANGUAGE } from "../../src/utils/project-detect.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-infra-detect-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("detectTestFramework — markers de infra", () => {
+  it("raiz con *.tf → terraform-validate (language infra)", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    expect(await detectTestFramework(dir)).toEqual({ hasTests: true, framework: "terraform-validate", language: "infra" });
+  });
+
+  it("directorio terraform/ tambien cuenta", async () => {
+    fs.mkdirSync(path.join(dir, "terraform"));
+    fs.writeFileSync(path.join(dir, "terraform", "main.tf"), "resource {}\n");
+    expect((await detectTestFramework(dir)).framework).toBe("terraform-validate");
+  });
+
+  it("Chart.yaml → helm-lint; kustomization.yaml → kustomize-build; ansible.cfg → ansible-lint", async () => {
+    fs.writeFileSync(path.join(dir, "Chart.yaml"), "name: x\n");
+    expect((await detectTestFramework(dir)).framework).toBe("helm-lint");
+    fs.rmSync(path.join(dir, "Chart.yaml"));
+    fs.writeFileSync(path.join(dir, "kustomization.yaml"), "resources: []\n");
+    expect((await detectTestFramework(dir)).framework).toBe("kustomize-build");
+    fs.rmSync(path.join(dir, "kustomization.yaml"));
+    fs.writeFileSync(path.join(dir, "ansible.cfg"), "[defaults]\n");
+    expect((await detectTestFramework(dir)).framework).toBe("ansible-lint");
+  });
+
+  it("un yaml suelto NO clasifica como infra", async () => {
+    fs.writeFileSync(path.join(dir, "config.yaml"), "a: 1\n");
+    expect((await detectTestFramework(dir)).hasTests).toBe(false);
+  });
+
+  it("repo mixto: el framework de aplicación mantiene la precedencia", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    fs.writeFileSync(path.join(dir, "go.mod"), "module x\n");
+    expect((await detectTestFramework(dir)).framework).toBe("go-test");
+  });
+
+  it("infra tiene patterns de test declarados (TDD policy)", () => {
+    expect(TEST_PATTERNS_BY_LANGUAGE.infra).toBeDefined();
+    expect(TEST_PATTERNS_BY_LANGUAGE.infra.length).toBeGreaterThan(0);
+  });
+});
+
+describe("tester brief con proyecto de infra", () => {
+  it("ordena la suite de infra y el fail-loud de tools ausentes (nunca verde vacío)", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    const { TesterRole } = await import("../../src/roles/tester-role.js");
+    const role = new TesterRole({ config: { projectDir: dir, roles: {} }, logger: { warn: () => {} } });
+    const { prompt } = await role.buildPrompt({
+      task: "t", diff: null, sonarIssues: null, pendingGherkinTests: null, shellTestResults: null,
+    });
+    expect(prompt).toContain("terraform-validate (infra)");
+    expect(prompt).toContain("terraform validate");
+    expect(prompt).toContain("checkov");
+    expect(prompt).toContain("MISSING");
+    expect(prompt).not.toContain("npm install");
+  });
+});


### PR DESCRIPTION
INF-B (épica KJC-PCS-0078): `detectTestFramework` gana un tier de markers de infra — DESPUÉS de los frameworks de aplicación (un repo mixto conserva su framework) y solo con marcadores inequívocos (un yaml suelto jamás clasifica): `*.tf` o `terraform/` → terraform-validate, `Chart.yaml` → helm-lint, `kustomization.yaml/.yml` → kustomize-build, `ansible.cfg` → ansible-lint.

El tester conoce las suites: comando primario = suite básica && checkov (el deep scan es aditivo, la suite corre SIEMPRE — catch de codex); si checkov falta, el fallback del brief es la suite básica sola con degradación DECLARADA. El step 0 de infra sustituye el `npm install` (no aplica) por el contrato fail-loud: suite tool ausente = tests_pass false con el comando de instalación; checkov ausente = degradado, nunca verde por omisión (2º catch absorbido). `language=infra` entra en TEST_PATTERNS_BY_LANGUAGE.

TDD: tests/utils/project-detect-infra.test.js (4 markers, precedencia, yaml suelto, brief). Suite completa verde. 2 catches de codex absorbidos, 3ª ronda APPROVED.

Card: KJC-TSK-0759.
