### PR TITLE
feat(audit): checkov parser and infra-marker gate (KJC-TSK-0760)

### DIFF
--- a/src/audit/infra-findings.js
+++ b/src/audit/infra-findings.js
@@ -1,0 +1,40 @@
+/**
+ * Checkov infra-misconfiguration collector for `kj audit` (INF-C,
+ * KJC-TSK-0760, epic KJC-PCS-0078).
+ *
+ * One tool covers the whole infra surface — terraform, kubernetes, helm,
+ * kustomize, ansible, dockerfiles — so checkov is THE infra scanner (tfsec
+ * and tflint stay out of scope: single dependency to learn and install).
+ * This module ships the PURE half (parser + marker gate); the governed
+ * collector that runs checkov and wires the audit lands in the follow-up
+ * PR — same best-effort channel as semgrep-findings (KJC-TSK-0366).
+ */
+
+/**
+ * Convert checkov's JSON (object for one framework, array for several)
+ * into the flat findings list the audit prompt consumes. Checkov OSS may
+ * omit severity — WARNING is the honest default.
+ *
+ * @param {object|object[]} raw
+ * @returns {{total: number, findings: object[]}}
+ */
+export function parseCheckovOutput(raw) {
+  const reports = Array.isArray(raw) ? raw : [raw];
+  const findings = [];
+  for (const report of reports) {
+    const failed = report?.results?.failed_checks;
+    if (!Array.isArray(failed)) continue;
+    for (const c of failed) {
+      findings.push({
+        rule: c.check_id || "(unknown)",
+        severity: String(c.severity || "WARNING").toUpperCase(),
+        framework: report.check_type || "infra",
+        file: String(c.file_path || "").replace(/^\//, ""),
+        line: Array.isArray(c.file_line_range) ? (c.file_line_range[0] ?? 0) : 0,
+        message: c.check_name || "",
+        guideline: c.guideline || null,
+      });
+    }
+  }
+  return { total: findings.length, findings };
+}

--- a/src/utils/project-detect.js
+++ b/src/utils/project-detect.js
@@ -116,6 +116,17 @@ export async function detectTestFramework(cwd = process.cwd()) {
   return { hasTests: false, framework: null, language: null };
 }
 
+/**
+ * True when the project carries unequivocal infra markers (terraform, helm,
+ * kustomize, ansible) — regardless of the app framework the repo may also
+ * have. Used by INF-C's audit collector to gate the checkov scan.
+ * @param {string} cwd
+ * @returns {Promise<boolean>}
+ */
+export async function detectInfraMarkers(cwd = process.cwd()) {
+  return Boolean(await matchMarkers(cwd, INFRA_MARKERS));
+}
+
 async function matchMarkers(cwd, markers) {
   for (const marker of markers) {
     try {

--- a/tests/audit/infra-findings.test.js
+++ b/tests/audit/infra-findings.test.js
@@ -1,0 +1,68 @@
+// INF-C (KJC-TSK-0760, épica KJC-PCS-0078) — parser de checkov: los
+// misconfigs de infra entrarán por el mismo canal best-effort que semgrep.
+// Aquí la mitad PURA: parser tolerante a los dos shapes de checkov (objeto
+// single-framework / array multi-framework) y el gate por markers.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseCheckovOutput } from "../../src/audit/infra-findings.js";
+import { detectInfraMarkers } from "../../src/utils/project-detect.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-infra-audit-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const CHECKOV_SINGLE = {
+  check_type: "terraform",
+  results: {
+    failed_checks: [
+      { check_id: "CKV_AWS_20", check_name: "S3 bucket has public READ", file_path: "/main.tf", file_line_range: [1, 8], severity: null, guideline: "https://docs.example/ckv-aws-20" },
+    ],
+  },
+  summary: { failed: 1, passed: 4 },
+};
+
+const CHECKOV_MULTI = [
+  CHECKOV_SINGLE,
+  { check_type: "kubernetes", results: { failed_checks: [
+    { check_id: "CKV_K8S_21", check_name: "default namespace used", file_path: "/k8s/deploy.yaml", file_line_range: [3, 3], severity: "HIGH" },
+  ] }, summary: { failed: 1, passed: 0 } },
+];
+
+describe("parseCheckovOutput", () => {
+  it("shape objeto single-framework (sin severity → WARNING honesto)", () => {
+    const out = parseCheckovOutput(CHECKOV_SINGLE);
+    expect(out.total).toBe(1);
+    expect(out.findings[0]).toMatchObject({ rule: "CKV_AWS_20", file: "main.tf", line: 1, severity: "WARNING", framework: "terraform" });
+    expect(out.findings[0].guideline).toContain("ckv-aws-20");
+  });
+
+  it("shape array multi-framework, con severidad propia cuando existe", () => {
+    const out = parseCheckovOutput(CHECKOV_MULTI);
+    expect(out.total).toBe(2);
+    expect(out.findings[1]).toMatchObject({ rule: "CKV_K8S_21", severity: "HIGH", framework: "kubernetes" });
+  });
+
+  it("shape malformado no revienta: cero findings", () => {
+    expect(parseCheckovOutput({}).total).toBe(0);
+    expect(parseCheckovOutput([{ results: "garbage" }]).total).toBe(0);
+  });
+});
+
+describe("detectInfraMarkers (gate del scanner)", () => {
+  it("true con markers inequívocos, false sin ellos (un yaml suelto no cuenta)", async () => {
+    expect(await detectInfraMarkers(dir)).toBe(false);
+    fs.writeFileSync(path.join(dir, "config.yaml"), "a: 1\n");
+    expect(await detectInfraMarkers(dir)).toBe(false);
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    expect(await detectInfraMarkers(dir)).toBe(true);
+  });
+
+  it("detecta infra AUNQUE el repo tenga framework de aplicación (a diferencia de detectTestFramework)", async () => {
+    fs.writeFileSync(path.join(dir, "go.mod"), "module x\n");
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    expect(await detectInfraMarkers(dir)).toBe(true);
+  });
+});


### PR DESCRIPTION
INF-C parte 1 de 2 (particionado por el presupuesto LOC): la mitad PURA — parseCheckovOutput tolerante a los dos shapes de checkov (objeto single-framework y array multi-framework, severity ausente = WARNING honesto) y detectInfraMarkers como gate (markers inequívocos; detecta infra aunque el repo tenga framework de app). El colector governed + wiring del audit van en la parte 2. TDD, suite verde, APPROVED codex.