### PR TITLE
feat(audit): governed checkov collector wired into the audit (KJC-TSK-0760)

### DIFF
--- a/src/audit/deterministic-summary.js
+++ b/src/audit/deterministic-summary.js
@@ -38,6 +38,7 @@ export function formatDeterministicSummary(ctx) {
   if (ctx.sonarFindings) lines.push(...formatSonarBlock(ctx.sonarFindings));
   if (ctx.osvFindings) lines.push(...formatOsvBlock(ctx.osvFindings));
   if (ctx.semgrepFindings) lines.push(...formatSemgrepBlock(ctx.semgrepFindings));
+  if (ctx.infraFindings) lines.push(...formatInfraBlock(ctx.infraFindings));
   if (ctx.circularDeps) lines.push(...formatCircularDepsBlock(ctx.circularDeps));
   if (ctx.deadExports) lines.push(...formatDeadExportsBlock(ctx.deadExports));
   if (ctx.injectionFindings) lines.push(...formatInjectionBlock(ctx.injectionFindings));
@@ -129,6 +130,25 @@ function formatSemgrepBlock(semgrepFindings) {
       }
     }
   }
+  lines.push("");
+  return lines;
+}
+
+// INF-C (KJC-TSK-0760): checkov misconfigs — same shape as the semgrep
+// block; a not-applicable repo (no infra markers) declares it in one line.
+function formatInfraBlock(infraFindings) {
+  if (!infraFindings.available) {
+    return ["### Infra misconfigurations (checkov)", `- Status: not available — ${infraFindings.reason || "checkov not installed"}`, ""];
+  }
+  const lines = ["### Infra misconfigurations (checkov)"];
+  lines.push(`- Total findings: ${infraFindings.total ?? 0}`);
+  const cap = MAX_SAMPLE_SEMGREP_PER_SEVERITY * 3;
+  for (const f of (infraFindings.findings || []).slice(0, cap)) {
+    const lineSuffix = f.line ? `:${f.line}` : "";
+    lines.push(`  - [${f.severity}] ${f.file}${lineSuffix} [${f.rule}] ${f.message}${f.guideline ? ` (${f.guideline})` : ""}`);
+  }
+  const overflow = (infraFindings.total ?? 0) - cap;
+  if (overflow > 0) lines.push(`  - ... and ${overflow} more`);
   lines.push("");
   return lines;
 }
@@ -298,6 +318,7 @@ export function deterministicContextHasFindings(ctx) {
   if (ctx.sonarFindings?.qualityGate?.status === "ERROR") return true;
   if (ctx.osvFindings?.available && (ctx.osvFindings.total ?? 0) > 0) return true;
   if (ctx.semgrepFindings?.available && (ctx.semgrepFindings.total ?? 0) > 0) return true;
+  if (ctx.infraFindings?.available && (ctx.infraFindings.total ?? 0) > 0) return true;
   if (ctx.circularDeps?.available && (ctx.circularDeps.total ?? 0) > 0) return true;
   if (ctx.deadExports?.available && (ctx.deadExports.total ?? 0) > 0) return true;
   if (ctx.growthDelta && (Math.abs(ctx.growthDelta.lines || 0) > 100 || Math.abs(ctx.growthDelta.deps || 0) > 0)) return true;

--- a/src/audit/infra-findings.js
+++ b/src/audit/infra-findings.js
@@ -5,10 +5,70 @@
  * One tool covers the whole infra surface — terraform, kubernetes, helm,
  * kustomize, ansible, dockerfiles — so checkov is THE infra scanner (tfsec
  * and tflint stay out of scope: single dependency to learn and install).
- * This module ships the PURE half (parser + marker gate); the governed
- * collector that runs checkov and wires the audit lands in the follow-up
- * PR — same best-effort channel as semgrep-findings (KJC-TSK-0366).
+ * Findings enter the audit through the SAME best-effort channel as
+ * semgrep-findings (KJC-TSK-0366): no infra markers → not-applicable (zero
+ * noise, checkov never runs); missing binary → declared with the install
+ * command; non-zero exit with JSON on stdout (checkov's failed-checks
+ * behavior) rescued; unparseable output degrades SAYING so.
  */
+
+import { runGoverned, jobsCap } from "../utils/tool-governor.js";
+import { detectInfraMarkers } from "../utils/project-detect.js";
+
+const SCAN_TIMEOUT_MS = 120_000;
+const INSTALL_HINT = "install via 'pipx install checkov' or 'pip install checkov'";
+
+/**
+ * Run checkov on the project and return a structured result.
+ *
+ * @param {string} projectDir - absolute path to the project root
+ * @param {object} [logger]
+ * @returns {Promise<{available: boolean, reason?: string, total?: number, findings?: object[]}>}
+ */
+export async function collectInfraFindings(projectDir, logger = null) {
+  // KJC-BUG-0122 doctrine: external scanners never fire from the unit suite.
+  if (process.env.VITEST && process.env.KJ_ALLOW_REAL_SCANS !== "1") {
+    return { available: false, reason: "real scans disabled under the test runner (set KJ_ALLOW_REAL_SCANS=1 to opt in)" };
+  }
+  if (!(await detectInfraMarkers(projectDir))) {
+    return { available: false, reason: "no infra markers (terraform/helm/kustomize/ansible) — not applicable" };
+  }
+  let stdout;
+  try {
+    const { stdout: out } = await runGoverned(
+      "checkov",
+      ["-d", projectDir || ".", "--output", "json", "--quiet", "--compact", `--parallel-runner-count=${jobsCap()}`],
+      { cwd: projectDir, timeout: SCAN_TIMEOUT_MS + 5000, maxBuffer: 32 * 1024 * 1024 }
+    );
+    stdout = out;
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      if (logger?.warn) logger.warn(`checkov not found in PATH — ${INSTALL_HINT}`);
+      return { available: false, reason: `checkov not installed — ${INSTALL_HINT}` };
+    }
+    if (err.killed) {
+      if (logger?.warn) logger.warn(`checkov timed out after ${SCAN_TIMEOUT_MS}ms`);
+      return { available: false, reason: `checkov timed out after ${SCAN_TIMEOUT_MS}ms` };
+    }
+    // checkov exits non-zero when checks fail, but still emits the report.
+    if (typeof err.stdout === "string" && err.stdout.trim().length > 0) {
+      stdout = err.stdout;
+    } else {
+      if (logger?.warn) logger.warn(`checkov failed: ${err.message}`);
+      return { available: false, reason: `checkov failed: ${err.message}` };
+    }
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    if (logger?.warn) logger.warn(`checkov output not parseable: ${err.message}`);
+    return { available: false, reason: "checkov output not parseable as JSON" };
+  }
+
+  return { available: true, ...parseCheckovOutput(parsed) };
+}
 
 /**
  * Convert checkov's JSON (object for one framework, array for several)

--- a/src/roles/audit-role.js
+++ b/src/roles/audit-role.js
@@ -6,6 +6,7 @@ import { collectSonarFindings } from "../audit/sonar-findings.js";
 import { collectWebPerfInput } from "../audit/webperf-input.js";
 import { collectOsvFindings } from "../audit/osv-findings.js";
 import { collectSemgrepFindings } from "../audit/semgrep-findings.js";
+import { collectInfraFindings } from "../audit/infra-findings.js";
 import { collectCircularDeps } from "../audit/circular-deps.js";
 import { collectDeadExports } from "../audit/dead-exports.js";
 import { collectInjectionFindings } from "../audit/injection-findings.js";
@@ -58,6 +59,7 @@ export class AuditRole extends AgentRole {
     const noMadge = (typeof input === "object" ? Boolean(input?.noMadge) : false) || securityOnly;
     const noKnip = (typeof input === "object" ? Boolean(input?.noKnip) : false) || securityOnly;
     const noInjectionScan = typeof input === "object" ? Boolean(input?.noInjectionScan) : false;
+    const noInfraScan = typeof input === "object" ? Boolean(input?.noInfraScan) : false;
     const noAiSlop = (typeof input === "object" ? Boolean(input?.noAiSlop) : false) || securityOnly;
     const projectDir = this.config?.projectDir || process.cwd();
     let basalCost = null;
@@ -70,6 +72,7 @@ export class AuditRole extends AgentRole {
     let circularDeps = null;
     let deadExports = null;
     let injectionFindings = null;
+    let infraFindings = null;
     let aiSlop = null;
     if (!securityOnly) {
       try {
@@ -127,6 +130,14 @@ export class AuditRole extends AgentRole {
         injectionFindings = await collectInjectionFindings(projectDir, this.logger);
       } catch { /* injection scan is best-effort (KJC-TSK-0498) */ }
     }
+    // Checkov infra misconfigs — INF-C (KJC-TSK-0760). Security surface, so
+    // it ALSO runs in securityOnly. Best-effort: no infra markers or missing
+    // checkov return available:false declaring why.
+    if (!noInfraScan) {
+      try {
+        infraFindings = await collectInfraFindings(projectDir, this.logger);
+      } catch { /* checkov is best-effort */ }
+    }
     // AI-slop tells (KJC-TSK-0503). Deterministic, offline, regex-based.
     // Local equivalent of Deslopify-style review. Best-effort.
     if (!noAiSlop) {
@@ -134,7 +145,7 @@ export class AuditRole extends AgentRole {
         aiSlop = await collectAiSlop(projectDir);
       } catch { /* ai-slop scan is best-effort */ }
     }
-    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings, circularDeps, deadExports, injectionFindings, aiSlop };
+    return { projectDir, basalCost, growthDelta, stack, sonarFindings, webperf, osvFindings, semgrepFindings, circularDeps, deadExports, injectionFindings, infraFindings, aiSlop };
   }
 
   /**

--- a/tests/audit/infra-collector.test.js
+++ b/tests/audit/infra-collector.test.js
@@ -1,0 +1,77 @@
+// INF-C parte 2 (KJC-TSK-0760) — el colector governed de checkov: gate por
+// markers sin ejecutar nada, ENOENT declarado con comando de instalación,
+// rescate del exit!=0 con JSON (checkov sale non-zero con failed checks),
+// y degradación declarada en salida no parseable.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/utils/tool-governor.js", () => ({
+  runGoverned: vi.fn(),
+  jobsCap: () => 2,
+}));
+
+const { runGoverned } = await import("../../src/utils/tool-governor.js");
+const { collectInfraFindings } = await import("../../src/audit/infra-findings.js");
+
+const CHECKOV_JSON = JSON.stringify({
+  check_type: "terraform",
+  results: { failed_checks: [{ check_id: "CKV_AWS_20", check_name: "S3 public READ", file_path: "/main.tf", file_line_range: [1, 8] }] },
+});
+
+let dir;
+beforeEach(() => {
+  vi.clearAllMocks();
+  // runGoverned está mockeado — el kill-switch VITEST (KJC-BUG-0122) puede
+  // abrirse sin riesgo de scan real.
+  process.env.KJ_ALLOW_REAL_SCANS = "1";
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-infra-collect-"));
+});
+afterEach(() => {
+  delete process.env.KJ_ALLOW_REAL_SCANS;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("collectInfraFindings", () => {
+  it("sin markers de infra → not applicable, sin ejecutar checkov", async () => {
+    const res = await collectInfraFindings(dir, null);
+    expect(res.available).toBe(false);
+    expect(res.reason).toMatch(/no infra/i);
+    expect(runGoverned).not.toHaveBeenCalled();
+  });
+
+  it("con infra y checkov instalado → findings disponibles", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    runGoverned.mockResolvedValue({ stdout: CHECKOV_JSON });
+    const res = await collectInfraFindings(dir, null);
+    expect(res.available).toBe(true);
+    expect(res.total).toBe(1);
+  });
+
+  it("checkov NO instalado → red caída DECLARADA con comando de instalación", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    runGoverned.mockRejectedValue(Object.assign(new Error("spawn checkov ENOENT"), { code: "ENOENT" }));
+    const res = await collectInfraFindings(dir, null);
+    expect(res.available).toBe(false);
+    expect(res.reason).toMatch(/checkov not installed/);
+    expect(res.reason).toMatch(/pipx install checkov/);
+  });
+
+  it("exit!=0 con JSON en stdout se rescata", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    runGoverned.mockRejectedValue(Object.assign(new Error("exit 1"), { stdout: CHECKOV_JSON }));
+    const res = await collectInfraFindings(dir, null);
+    expect(res.available).toBe(true);
+    expect(res.total).toBe(1);
+  });
+
+  it("salida no parseable degrada declarándolo", async () => {
+    fs.writeFileSync(path.join(dir, "main.tf"), "resource {}\n");
+    runGoverned.mockResolvedValue({ stdout: "not json" });
+    const res = await collectInfraFindings(dir, null);
+    expect(res.available).toBe(false);
+    expect(res.reason).toMatch(/parseable/);
+  });
+});


### PR DESCRIPTION
INF-C parte 2 de 2: colector governed de checkov (kill-switch VITEST, gate por markers sin ejecutar nada, ENOENT declarado con pipx install checkov, rescate del exit!=0 con JSON, degradación declarada) + wiring: bloque en el summary determinista, señal en hasDeterministicSignal, y collectDeterministic lo corre TAMBIÉN en securityOnly (es superficie de seguridad; flag noInfraScan para excluir). TDD del colector con runGoverned mockeado. Suite completa 6726 verde. APPROVED codex. Cierra la card KJC-TSK-0760.