### PR TITLE
fix(start): resolve project dir to cwd and fail loud on missing root (KJC-BUG-0145)

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -80,7 +80,11 @@ export async function startCommand({ task = "", config, logger, flags = {}, deps
   const spawn = deps.spawnKj || spawnKj;
   const makeWizard = deps.makeWizard || (() => createWizard());
 
-  const bundle = await sweep(config.projectDir, { declared: flags.maturity || null });
+  // KJC-BUG-0145 (campo, #1471): loadConfig never sets projectDir — passing
+  // config.projectDir straight through handed `undefined` to the sweep, every
+  // collector failed silently and the project read as "new, no source code".
+  const projectDir = config.projectDir || process.cwd();
+  const bundle = await sweep(projectDir, { declared: flags.maturity || null });
   const { text, summary } = assess(bundle);
   let result = await decide({ task, text, config, logger, makeDecider });
 
@@ -111,7 +115,7 @@ export async function startCommand({ task = "", config, logger, flags = {}, deps
   // Dispatch the chosen intent to its saved command, confirming first (it writes).
   const toArgs = DISPATCH[result.intent];
   if (interactive && toArgs && (await confirmApply(makeWizard))) {
-    await spawn(toArgs(goal), { cwd: config.projectDir });
+    await spawn(toArgs(goal), { cwd: projectDir });
   }
   return { ok: true, intent: result.intent };
 }

--- a/src/start/sweep.js
+++ b/src/start/sweep.js
@@ -112,6 +112,9 @@ function readRagStatus(projectDir) {
  *   declared = user-declared maturity; deps = injected collaborators (defaults = real collectors).
  */
 export async function runReadOnlySweep(projectDir, { declared = null, profile = "standard", deps = {} } = {}) {
+  // KJC-BUG-0145: a missing projectDir must fail LOUD — every collector is
+  // wrapped in safe(), so an undefined root used to read as an empty project.
+  if (!projectDir) throw new Error("runReadOnlySweep: projectDir is required (got " + String(projectDir) + ")");
   const d = {
     collectAll, detectTestFramework, checkHarden, compareHarden, sourceScan: deepSourceScan,
     detectQmd, ragStatus: readRagStatus, gitAgeDays: lastCommitAgeDays, ...deps,

--- a/tests/start/start-projectdir.test.js
+++ b/tests/start/start-projectdir.test.js
@@ -1,0 +1,63 @@
+// KJC-BUG-0145 (campo, issue #1471 tras la 4.19): `kj start` seguía diciendo
+// "new — no source code found" porque startCommand pasaba config.projectDir
+// (undefined sin config de proyecto) al sweep; readdir(undefined) reventaba,
+// safe() lo tragaba y TODO quedaba a cero. El fix 0141 era correcto y nunca
+// llegó a ejecutarse. Dos capas: start resuelve cwd; el sweep falla en alto.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runReadOnlySweep } from "../../src/start/sweep.js";
+import { startCommand } from "../../src/commands/start.js";
+
+const fakeDecider = (intent = "ASSESS_ONLY") => () => ({
+  execute: async () => ({ result: { intent, rationale: "fake", questionToAsk: "" } }),
+});
+const quiet = { warn: () => {}, info: () => {} };
+
+describe("runReadOnlySweep — projectDir obligatorio (fail-loud, no silent zero)", () => {
+  it("rechaza un projectDir ausente en vez de devolver un proyecto vacío", async () => {
+    await expect(runReadOnlySweep(undefined)).rejects.toThrow(/projectDir/);
+    await expect(runReadOnlySweep("")).rejects.toThrow(/projectDir/);
+  });
+});
+
+describe("startCommand — resuelve el directorio del proyecto", () => {
+  let logSpy;
+  beforeEach(() => { logSpy = vi.spyOn(console, "log").mockImplementation(() => {}); });
+  afterEach(() => logSpy.mockRestore());
+
+  it("sin config.projectDir usa process.cwd() (el caso de Pedro)", async () => {
+    const sweep = vi.fn(async () => ({ maturity: { maturity: "new" }, signals: {}, brief: null, tests: null }));
+    await startCommand({
+      config: {}, logger: quiet, flags: { json: true, yes: true },
+      deps: { runReadOnlySweep: sweep, buildAssessment: () => ({ text: "x", summary: { maturity: "new" } }), makeDecider: fakeDecider(), isTTY: () => false },
+    });
+    expect(sweep).toHaveBeenCalledWith(process.cwd(), expect.anything());
+  });
+
+  it("integración en disco: backend/app.js + Dockerfile → el sweep REAL ve código y no dice new", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-demo-kind-"));
+    try {
+      // Mismo inventario que el demo-kind real: 2 code + 2 infra (> SCAFFOLD_MAX_FILES).
+      fs.mkdirSync(path.join(dir, "backend"));
+      fs.mkdirSync(path.join(dir, "frontend"));
+      fs.writeFileSync(path.join(dir, "backend", "app.js"), "console.log(1)\n");
+      fs.writeFileSync(path.join(dir, "backend", "app.test.js"), "test\n");
+      fs.writeFileSync(path.join(dir, "backend", "eslint.config.js"), "module.exports = {}\n");
+      fs.writeFileSync(path.join(dir, "backend", "Dockerfile"), "FROM node\n");
+      fs.writeFileSync(path.join(dir, "frontend", "Dockerfile"), "FROM nginx\n");
+      fs.writeFileSync(path.join(dir, "frontend", "index.html"), "<html></html>\n");
+      await startCommand({
+        config: { projectDir: dir }, logger: quiet, flags: { json: true, yes: true },
+        deps: { makeDecider: fakeDecider(), isTTY: () => false },
+      });
+      const out = JSON.parse(logSpy.mock.calls.at(-1)[0]);
+      expect(out.maturity).not.toBe("new");
+      expect(out.assessment).not.toMatch(/no source code found/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0145 — `kj start` seguía diciendo "new — no source code found" tras la 4.19 (issue #1471)

Pedro actualizó a 4.19.0 y su demo-kind seguía saliendo como proyecto vacío con `commits: 0`. Reproducido en local con un fixture idéntico.

### Causa raíz
`loadConfig` nunca fija `config.projectDir`, y `startCommand` lo pasaba tal cual al sweep: `runReadOnlySweep(undefined)`. Cada colector está envuelto en `safe()`, así que `readdir(undefined)` reventaba en silencio y TODO quedaba a cero — "no source code found", sin tests, sin CI, 0 commits. El fix del 0141 era correcto y nunca llegó a ejecutarse; sus tests inyectaban deps y jamás pasaron por el camino real de la CLI.

### Fix (dos capas)
- `startCommand` resuelve `config.projectDir || process.cwd()` (el patrón del resto de comandos) para el sweep y para el cwd del dispatch.
- `runReadOnlySweep` falla EN ALTO con un projectDir ausente en vez de devolver un proyecto vacío (no silent fallbacks).

### Verificación
- TDD: guard del sweep; startCommand sin projectDir usa cwd; **integración en disco** con el inventario real de demo-kind (2 code + 2 infra) → el sweep real ve código y no dice "new".
- CLI real sobre el fixture: `Project maturity: legacy — code present but neglected` + advisory de harden. Suite completa verde (un flaky ajeno reconfirmado). APPROVED codex.

Card: KJC-BUG-0145. Sale en v4.20.1.
