### PR TITLE
feat(identity): clone identity store and detection (KJC-TSK-0762)

### DIFF
--- a/src/identity/detect.js
+++ b/src/identity/detect.js
@@ -1,0 +1,51 @@
+/**
+ * Identity lock — detect (IDN-A, KJC-TSK-0762). What is EFFECTIVE right now,
+ * with no network and no spawned `gh`: the active gh account is read from
+ * gh's own hosts.yml (the file `gh auth switch` mutates), the git email from
+ * `git config user.email`. Both return null when unknown — never a guess.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import yaml from "js-yaml";
+
+export function defaultHostsPath() {
+  const base = process.env.GH_CONFIG_DIR || join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "gh");
+  return join(base, "hosts.yml");
+}
+
+/**
+ * @param {{hostsPath?: string, host?: string}} [opts]
+ * @returns {string|null} active gh login for the host, null without a session
+ */
+export function activeGhUser({ hostsPath = defaultHostsPath(), host = "github.com" } = {}) {
+  if (!existsSync(hostsPath)) return null;
+  try {
+    const parsed = yaml.load(readFileSync(hostsPath, "utf8"));
+    const user = parsed?.[host]?.user;
+    return typeof user === "string" && user.length > 0 ? user : null;
+  } catch {
+    return null;
+  }
+}
+
+const defaultGitFn = (projectDir) =>
+  execFileSync("git", ["config", "--get", "user.email"], { cwd: projectDir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+
+/**
+ * @param {string} projectDir
+ * @param {{gitFn?: (projectDir: string) => string}} [opts]
+ * @returns {string|null}
+ */
+export function effectiveGitEmail(projectDir, { gitFn = defaultGitFn } = {}) {
+  try {
+    // --get yields the single effective value; keep the last line anyway so a
+    // multi-line answer from an odd config can never leak a newline into it.
+    const out = String(gitFn(projectDir) || "").trim().split("\n").at(-1).trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/identity/store.js
+++ b/src/identity/store.js
@@ -1,0 +1,66 @@
+/**
+ * Identity lock — store (IDN-A, KJC-TSK-0762, epic KJC-PCS-0079).
+ *
+ * Each CLONE declares the identity it is worked with: the gh account and the
+ * git email. It is per developer, not per project, so it lives in
+ * `.karajan/identity.local.yml`, never tracked (this module keeps it in the
+ * .gitignore). Born from the 2026-08-20 incident: one `gh` call without an
+ * explicit account switch posted as a client account on a public repo.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+export const IDENTITY_FILE = ".karajan/identity.local.yml";
+
+/** @param {string} projectDir */
+export function identityPath(projectDir) {
+  return join(projectDir, ".karajan", "identity.local.yml");
+}
+
+/**
+ * @param {string} projectDir
+ * @returns {{gh_user: string, git_email: string, declared_at: string}|null}
+ */
+export function readIdentity(projectDir) {
+  const p = identityPath(projectDir);
+  if (!existsSync(p)) return null;
+  let parsed;
+  try {
+    parsed = yaml.load(readFileSync(p, "utf8"));
+  } catch {
+    return null; // corrupt or half-written file = no identity (review catch)
+  }
+  if (!parsed || typeof parsed !== "object" || !parsed.gh_user || !parsed.git_email) return null;
+  return { gh_user: String(parsed.gh_user), git_email: String(parsed.git_email), declared_at: String(parsed.declared_at || "") };
+}
+
+/**
+ * Write the declaration and make sure it never gets tracked. Fails loud on
+ * an incomplete identity — a half-declared lock is no lock.
+ * @param {string} projectDir
+ * @param {{gh_user: string, git_email: string}} identity
+ */
+export function writeIdentity(projectDir, identity) {
+  for (const field of ["gh_user", "git_email"]) {
+    if (!identity?.[field] || typeof identity[field] !== "string") {
+      throw new Error(`identity: "${field}" is required (got ${JSON.stringify(identity?.[field])})`);
+    }
+  }
+  // Ignore FIRST, write SECOND (review catch): if the ignore step fails, no
+  // unignored identity file is ever left on disk for git to pick up.
+  ensureIgnored(projectDir);
+  mkdirSync(join(projectDir, ".karajan"), { recursive: true });
+  const record = { gh_user: identity.gh_user, git_email: identity.git_email, declared_at: new Date().toISOString() };
+  writeFileSync(identityPath(projectDir), yaml.dump(record, { lineWidth: 120 }), "utf8");
+  return record;
+}
+
+function ensureIgnored(projectDir) {
+  const ignorePath = join(projectDir, ".gitignore");
+  const current = existsSync(ignorePath) ? readFileSync(ignorePath, "utf8") : "";
+  if (current.split("\n").some((line) => line.trim() === IDENTITY_FILE)) return;
+  const sep = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+  writeFileSync(ignorePath, `${current}${sep}${IDENTITY_FILE}\n`, "utf8");
+}

--- a/tests/identity/store-detect.test.js
+++ b/tests/identity/store-detect.test.js
@@ -1,0 +1,66 @@
+// IDN-A (KJC-TSK-0762, épica KJC-PCS-0079 Identity lock) — cada clon declara
+// con qué cuenta de gh y qué email de git se trabaja. Origen: incidente
+// 2026-08-20, un gh sin switch salió como la cuenta de cliente. Aquí las dos
+// piezas de base: store (fichero local sin trackear) y detect (hosts.yml de
+// gh + git config, sin red, nunca inventa).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { identityPath, readIdentity, writeIdentity } from "../../src/identity/store.js";
+import { activeGhUser, effectiveGitEmail } from "../../src/identity/detect.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-identity-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const hostsYml = (user) => {
+  const p = path.join(dir, "hosts.yml");
+  fs.writeFileSync(p, `github.com:\n    users:\n        ${user}:\n        otra:\n    user: ${user}\n    git_protocol: ssh\n`);
+  return p;
+};
+
+describe("store — .karajan/identity.local.yml, por clon y sin trackear", () => {
+  it("escribe, lee y añade el fichero al .gitignore (sin duplicar)", () => {
+    fs.writeFileSync(path.join(dir, ".gitignore"), "node_modules\n");
+    expect(readIdentity(dir)).toBeNull();
+    writeIdentity(dir, { gh_user: "manufosela", git_email: "a@b.c" });
+    const id = readIdentity(dir);
+    expect(id).toMatchObject({ gh_user: "manufosela", git_email: "a@b.c" });
+    expect(id.declared_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(identityPath(dir)).toBe(path.join(dir, ".karajan", "identity.local.yml"));
+    writeIdentity(dir, { gh_user: "manufosela", git_email: "a@b.c" });
+    const ignore = fs.readFileSync(path.join(dir, ".gitignore"), "utf8");
+    expect(ignore.split("\n").filter((l) => l === ".karajan/identity.local.yml")).toHaveLength(1);
+  });
+
+  it("crea el .gitignore si no existe y falla en alto con una identidad incompleta", () => {
+    expect(() => writeIdentity(dir, { gh_user: "x" })).toThrow(/git_email/);
+    writeIdentity(dir, { gh_user: "x", git_email: "y@z" });
+    expect(fs.readFileSync(path.join(dir, ".gitignore"), "utf8")).toContain(".karajan/identity.local.yml");
+  });
+
+  it("un fichero corrupto o incompleto se lee como 'sin identidad'", () => {
+    fs.mkdirSync(path.join(dir, ".karajan"));
+    fs.writeFileSync(identityPath(dir), "gh_user: solo-esto\n");
+    expect(readIdentity(dir)).toBeNull();
+    fs.writeFileSync(identityPath(dir), "gh_user: [sin cerrar\n  :: yaml roto");
+    expect(readIdentity(dir)).toBeNull();
+  });
+});
+
+describe("detect — sin red: hosts.yml de gh y git config", () => {
+  it("lee la cuenta activa de gh del hosts.yml y null si no hay sesión", () => {
+    expect(activeGhUser({ hostsPath: hostsYml("manufosela-tribbu") })).toBe("manufosela-tribbu");
+    expect(activeGhUser({ hostsPath: path.join(dir, "no-existe.yml") })).toBeNull();
+    fs.writeFileSync(path.join(dir, "sin-user.yml"), "github.com:\n    git_protocol: ssh\n");
+    expect(activeGhUser({ hostsPath: path.join(dir, "sin-user.yml") })).toBeNull();
+  });
+
+  it("email efectivo de git vía función inyectada; null si git falla o está vacío", () => {
+    expect(effectiveGitEmail(dir, { gitFn: () => " a@b.c \n" })).toBe("a@b.c");
+    expect(effectiveGitEmail(dir, { gitFn: () => "\n" })).toBeNull();
+    expect(effectiveGitEmail(dir, { gitFn: () => { throw new Error("no git"); } })).toBeNull();
+  });
+});


### PR DESCRIPTION
IDN-A parte 1 de 3 (épica KJC-PCS-0079 Identity lock — nacida del incidente de hoy: un `gh` sin switch explícito salió como la cuenta de cliente en este repo público).

Las dos piezas de base, puras e inyectables:
- `src/identity/store.js`: `.karajan/identity.local.yml` por CLON (es por desarrollador, no por proyecto), jamás trackeado — el store lo añade al `.gitignore` ANTES de escribir (catch de codex: sin ventana en la que el fichero exista sin ignorar). Lectura tolerante: corrupto o incompleto = sin identidad (catch de codex).
- `src/identity/detect.js`: cuenta activa de gh leyendo el `hosts.yml` de gh (el fichero que muta `gh auth switch` — sin spawn, sin red) y email efectivo con `git config --get user.email` (catch de codex). Ambos devuelven null cuando no saben: nunca se inventa.

Partes 2 y 3: compare + `kj identity show|set`, y registro CLI + ADR + captura al arrancar. TDD; 3 catches absorbidos; APPROVED codex.

Card: KJC-TSK-0762.
