### PR TITLE
feat(identity): compare and kj identity show|set (KJC-TSK-0762)

### DIFF
--- a/src/commands/identity.js
+++ b/src/commands/identity.js
@@ -1,0 +1,60 @@
+/**
+ * `kj identity show|set` (IDN-A, KJC-TSK-0762, epic KJC-PCS-0079).
+ *
+ *   show  — declared identity vs what is ACTIVE now; exit 2 on mismatch or
+ *           when nothing is declared (scriptable: the gate and hooks reuse it).
+ *   set   — capture the effective gh account + git email (or --gh/--email),
+ *           confirm on a TTY, write .karajan/identity.local.yml. Never invents:
+ *           no session and no flags → exit 1.
+ */
+
+import { readIdentity, writeIdentity } from "../identity/store.js";
+import { activeGhUser, effectiveGitEmail } from "../identity/detect.js";
+import { compareIdentity } from "../identity/compare.js";
+import { createWizard, isTTY } from "../utils/wizard.js";
+
+export async function identityCommand({ action = "show", config, flags = {}, deps = {} }) {
+  const projectDir = config?.projectDir || process.cwd();
+  const log = deps.log || console.log;
+  const tty = deps.isTTY || isTTY;
+  const detectOpts = { hostsPath: deps.hostsPath, gitFn: deps.gitFn };
+  const effective = {
+    gh_user: activeGhUser(detectOpts.hostsPath ? { hostsPath: detectOpts.hostsPath } : {}),
+    git_email: effectiveGitEmail(projectDir, detectOpts.gitFn ? { gitFn: detectOpts.gitFn } : {}),
+  };
+
+  if (action === "set") {
+    const candidate = { gh_user: flags.gh || effective.gh_user, git_email: flags.email || effective.git_email };
+    if (!candidate.gh_user || !candidate.git_email) {
+      log(`kj identity: cannot declare — gh account: ${candidate.gh_user ?? "no session"}, git email: ${candidate.git_email ?? "none"}. Log in / set git config, or pass --gh <user> --email <email>.`);
+      return 1;
+    }
+    if (tty() && !flags.yes) {
+      const wizard = (deps.makeWizard || createWizard)();
+      try {
+        const ok = await wizard.confirm(`Bind this clone to gh ${candidate.gh_user} / git ${candidate.git_email}?`, true);
+        if (!ok) { log("kj identity: not declared."); return 1; }
+      } finally { wizard.close(); }
+    } else if (!flags.gh || !flags.email) {
+      // Proven live on day one: the active gh session had been flipped by
+      // ANOTHER session, and --yes bound the clone to the wrong account.
+      // Binding without confirmation is allowed, but never silent.
+      log("kj identity: WARNING — binding the ACTIVE session as-is without confirmation (another session may have switched it); prefer --gh/--email explicitly and verify with `kj identity show`.");
+    }
+    writeIdentity(projectDir, candidate);
+    log(`kj identity: declared gh ${candidate.gh_user} / git ${candidate.git_email} → .karajan/identity.local.yml (ignored by git).`);
+    return 0;
+  }
+
+  const declared = readIdentity(projectDir);
+  const result = compareIdentity(declared, effective);
+  if (!declared) {
+    log("kj identity: no identity declared for this clone — run `kj identity set`.");
+    return 2;
+  }
+  const mark = (field) => (result.mismatches.some((m) => m.field === field) ? "DISTINTA" : "ACTIVA");
+  log(`gh_user    ${declared.gh_user}  [${mark("gh_user")}: ${effective.gh_user ?? "no session"}]`);
+  log(`git_email  ${declared.git_email}  [${mark("git_email")}: ${effective.git_email ?? "none"}]`);
+  for (const m of result.mismatches) log(`  → ${m.remedy}`);
+  return result.ok ? 0 : 2;
+}

--- a/src/identity/compare.js
+++ b/src/identity/compare.js
@@ -1,0 +1,38 @@
+/**
+ * Identity lock — compare (IDN-A, KJC-TSK-0762). Pure: declared vs effective
+ * → {ok, mismatches}. Every mismatch carries the LITERAL remedy, because the
+ * gate (IDN-B) and the hooks (IDN-C) print it instead of auto-switching —
+ * changing the user's keyring is the user's act, never the agent's.
+ */
+
+/**
+ * @param {{gh_user: string, git_email: string}|null} declared
+ * @param {{gh_user: string|null, git_email: string|null}} effective
+ * @returns {{ok: boolean, mismatches: Array<{field: string, declared: string|null, effective: string|null, remedy: string}>}}
+ */
+export function compareIdentity(declared, effective) {
+  if (!declared) {
+    return {
+      ok: false,
+      mismatches: [{ field: "identity", declared: null, effective: null, remedy: "kj identity set — this clone has no declared identity yet" }],
+    };
+  }
+  const mismatches = [];
+  if (effective.gh_user !== declared.gh_user) {
+    mismatches.push({
+      field: "gh_user",
+      declared: declared.gh_user,
+      effective: effective.gh_user ?? null,
+      remedy: effective.gh_user ? `gh auth switch --user ${declared.gh_user}` : `gh auth login (as ${declared.gh_user}) or gh auth switch --user ${declared.gh_user}`,
+    });
+  }
+  if (effective.git_email !== declared.git_email) {
+    mismatches.push({
+      field: "git_email",
+      declared: declared.git_email,
+      effective: effective.git_email ?? null,
+      remedy: `git config user.email ${declared.git_email} (or -c user.email=${declared.git_email} on the command)`,
+    });
+  }
+  return { ok: mismatches.length === 0, mismatches };
+}

--- a/tests/identity/compare-command.test.js
+++ b/tests/identity/compare-command.test.js
@@ -1,0 +1,77 @@
+// IDN-A (KJC-TSK-0762) — compare (declarado vs efectivo → remedio literal) y
+// el comando kj identity show|set. Probado en vivo el primer día: la sesión
+// activa de gh la había cambiado OTRA sesión y `set --yes` ató el clon a la
+// cuenta equivocada — por eso atar sin confirmar nunca es silencioso.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readIdentity } from "../../src/identity/store.js";
+import { compareIdentity } from "../../src/identity/compare.js";
+import { identityCommand } from "../../src/commands/identity.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-identity-cmd-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const hostsYml = (user) => {
+  const p = path.join(dir, `hosts-${user}.yml`);
+  fs.writeFileSync(p, `github.com:\n    user: ${user}\n`);
+  return p;
+};
+
+describe("compare — declarado vs efectivo, con el remedio literal", () => {
+  it("ok cuando coincide; mismatch nombra ambos y el switch exacto", () => {
+    const declared = { gh_user: "manufosela", git_email: "a@b.c" };
+    expect(compareIdentity(declared, { gh_user: "manufosela", git_email: "a@b.c" }).ok).toBe(true);
+    const r = compareIdentity(declared, { gh_user: "manufosela-tribbu", git_email: "a@b.c" });
+    expect(r.ok).toBe(false);
+    expect(r.mismatches).toHaveLength(1);
+    expect(r.mismatches[0]).toMatchObject({ field: "gh_user", declared: "manufosela", effective: "manufosela-tribbu" });
+    expect(r.mismatches[0].remedy).toBe("gh auth switch --user manufosela");
+  });
+
+  it("sin identidad declarada no es ok (remedio kj identity set); sin sesión gh se dice", () => {
+    const none = compareIdentity(null, { gh_user: "x", git_email: "y" });
+    expect(none.ok).toBe(false);
+    expect(none.mismatches[0].remedy).toMatch(/kj identity set/);
+    const noGh = compareIdentity({ gh_user: "manufosela", git_email: "a@b.c" }, { gh_user: null, git_email: "a@b.c" });
+    expect(noGh.mismatches[0].effective).toBeNull();
+    expect(noGh.mismatches[0].remedy).toMatch(/gh auth switch --user manufosela/);
+  });
+});
+
+describe("kj identity show|set", () => {
+  let lines;
+  const deps = (user = "manufosela") => ({
+    log: (l) => lines.push(l), isTTY: () => false,
+    hostsPath: hostsYml(user), gitFn: () => "a@b.c\n",
+  });
+  beforeEach(() => { lines = []; });
+
+  it("set --yes ata lo efectivo AVISANDO y show lo marca ACTIVA", async () => {
+    expect(await identityCommand({ action: "set", config: { projectDir: dir }, flags: { yes: true }, deps: deps() })).toBe(0);
+    expect(readIdentity(dir)).toMatchObject({ gh_user: "manufosela", git_email: "a@b.c" });
+    expect(lines.join("\n")).toMatch(/WARNING/);
+    expect(await identityCommand({ action: "show", config: { projectDir: dir }, flags: {}, deps: deps() })).toBe(0);
+    expect(lines.join("\n")).toMatch(/gh_user\s+manufosela.*ACTIVA/);
+  });
+
+  it("set con --gh/--email explícitos no avisa; show marca DISTINTA, da el switch y sale 2", async () => {
+    await identityCommand({ action: "set", config: { projectDir: dir }, flags: { gh: "manufosela", email: "a@b.c", yes: true }, deps: deps() });
+    expect(lines.join("\n")).not.toMatch(/WARNING/);
+    const code = await identityCommand({ action: "show", config: { projectDir: dir }, flags: {}, deps: deps("manufosela-tribbu") });
+    expect(code).toBe(2);
+    expect(lines.join("\n")).toMatch(/DISTINTA.*manufosela-tribbu/);
+    expect(lines.join("\n")).toContain("gh auth switch --user manufosela");
+  });
+
+  it("show sin identidad sale 2 pidiendo set; set sin sesión ni flags falla en alto (nunca inventa)", async () => {
+    expect(await identityCommand({ action: "show", config: { projectDir: dir }, flags: {}, deps: deps() })).toBe(2);
+    expect(lines.join("\n")).toMatch(/kj identity set/);
+    const d = { ...deps(), hostsPath: path.join(dir, "nope.yml"), gitFn: () => { throw new Error("x"); } };
+    expect(await identityCommand({ action: "set", config: { projectDir: dir }, flags: {}, deps: d })).toBe(1);
+    expect(readIdentity(dir)).toBeNull();
+  });
+});


### PR DESCRIPTION
IDN-A parte 2 de 3 (épica KJC-PCS-0079 Identity lock).

- `src/identity/compare.js`: declarado vs efectivo → `{ok, mismatches[]}` con el remedio LITERAL por campo (`gh auth switch --user X`, `git config user.email E`); sin identidad declarada → remedio `kj identity set`. Puro: lo reutilizarán el Sentinel (IDN-B) y los hooks (IDN-C). Nunca auto-switch: cambiar el keyring del usuario es acto del usuario.
- `src/commands/identity.js`: `show` (declarado vs ACTIVA/DISTINTA, exit 2 en mismatch o sin declarar — scriptable) y `set` (captura sesión gh + git config o `--gh/--email`, confirma en TTY; `--yes` ata pero AVISA con WARNING). Ese aviso nació en vivo: el primer `set --yes` real ató el clon a la cuenta equivocada porque otra sesión había cambiado la cuenta activa de gh — exactamente el agujero que esta épica cierra.

Registro en la CLI + ADR + captura al arrancar: parte 3. TDD; APPROVED codex.

Card: KJC-TSK-0762.
