### PR TITLE
feat(identity): kj identity in the cli, capture at harden, adr 0005 (KJC-TSK-0762)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ PERSONAL/
 undefined/
 ai-trash-prompt.md
 .scratch-test-autoinit/
+.karajan/identity.local.yml

--- a/.karajan/adrs/0005-identity-lock-identidad-por-clon-local-y-sin-trackear-fail-c.md
+++ b/.karajan/adrs/0005-identity-lock-identidad-por-clon-local-y-sin-trackear-fail-c.md
@@ -1,0 +1,16 @@
+# Identity lock: identidad por clon, local y sin trackear, fail-closed en los gates, sin auto-switch
+
+Status: accepted
+Date: 2026-08-20
+
+## Context
+
+Incidente 2026-08-20: un gh issue comment sin switch explicito salio como la cuenta de cliente en el repo publico de karajan; la regla del switch vivia en la memoria del agente y una regla en memoria se salta y cuesta tokens. Ademas el keyring de gh lo cambian otras sesiones por debajo: el primer kj identity set --yes ato el clon a la cuenta equivocada.
+
+## Decision
+
+Cada CLON declara su identidad (gh_user y git_email) en .karajan identity.local.yml, por desarrollador y nunca trackeado; se captura al arrancar SOLO con confirmacion humana (en no-TTY se declara pendiente, jamas se ata a ciegas) o con flags explicitos. Los gates (Sentinel tool-time, hooks commit-time) comparan lo declarado con lo efectivo y DENIEGAN con el remedio literal; nunca auto-switch: cambiar el keyring es acto del usuario. Sin identidad declarada el Sentinel es fail-closed para gh y git mutadores.
+
+## Consequences
+
+Un clon nuevo no puede escribir en el repo ni en el tracker hasta declarar identidad (friccion asumida, una vez por clon). La deteccion lee el hosts.yml de gh sin red: si gh cambia el formato, el detector devuelve null y el gate deniega pidiendo kj identity set (fail-closed, nunca adivina). Identidades de npm y firebase quedan fuera hasta que se pidan.

--- a/src/cli/advanced-commands.js
+++ b/src/cli/advanced-commands.js
@@ -31,7 +31,7 @@ export const ADVANCED_GROUPS = [
   { title: "Análisis pre-run", commands: ["discover", "triage", "researcher", "architect", "onboard", "brief"] },
   { title: "Búsqueda / RAG", commands: ["rag", "qmd", "watch"] },
   { title: "Calidad / auditoría", commands: ["audit", "check", "mutate", "webperf", "sonar", "privacy", "release", "policy"] },
-  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby", "sentinel"] },
+  { title: "Sesión / board", commands: ["resume", "report", "board", "hu", "adr", "worktree", "undo", "standby", "sentinel", "identity"] },
   { title: "Infra / setup", commands: ["install-tools", "ollama", "skills", "roles", "agents", "env"] },
   { title: "Mantenimiento", commands: ["clean", "sync", "telemetry", "report-issue"] },
 ];

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -4,6 +4,7 @@ import { researcherCommand } from "../commands/researcher.js";
 import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
 import { startCommand } from "../commands/start.js";
+import { identityCommand } from "../commands/identity.js";
 import { ragIndexCommand, ragQueryCommand, ragInstallHooksCommand, ragEvalCommand } from "../commands/rag.js";
 import { qmdQueryCommand } from "../commands/qmd.js";
 import { ragMcpCommand } from "../commands/rag-mcp.js";
@@ -117,6 +118,30 @@ export function registerMeta(program, { pkgVersion }) {
     .action(async (flags) => {
       await withConfig(pkgVersion, "onboard", flags, async ({ config, logger }) => {
         await onboardCommand({ config, logger, flags });
+      });
+    });
+
+  // IDN-A (KJC-TSK-0762, epic KJC-PCS-0079): identity lock per clone.
+  const identityCmd = program
+    .command("identity")
+    .description("Identity lock: which gh account and git email this clone is worked with (.karajan/identity.local.yml, never tracked)");
+  identityCmd
+    .command("show", { isDefault: true })
+    .description("Declared identity vs the active one (exit 2 on mismatch or when undeclared)")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "identity-show", flags, async ({ config }) => {
+        process.exitCode = await identityCommand({ action: "show", config, flags });
+      });
+    });
+  identityCmd
+    .command("set")
+    .description("Declare this clone's identity from the active gh session and git config (or --gh/--email)")
+    .option("--gh <user>", "gh account to bind")
+    .option("--email <email>", "git email to bind")
+    .option("--yes", "Do not ask for confirmation")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "identity-set", flags, async ({ config }) => {
+        process.exitCode = await identityCommand({ action: "set", config, flags });
       });
     });
 

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -23,6 +23,7 @@ import { installSentinelHooks } from "../harden/sentinel-hooks.js";
 import { detectStackRoots } from "../harden/stack-roots.js";
 import { installWorkflows } from "../harden/workflow-engine.js";
 import { detectTestFramework } from "../utils/project-detect.js";
+import { ensureIdentity } from "../identity/bootstrap.js";
 
 const JS_TEST_CMD = {
   vitest: "npx vitest run",
@@ -191,5 +192,12 @@ export async function hardenCommand({
   for (const w of out.workflows) logger.info?.(`  • ${w.file}: ${w.action}`);
   for (const g of out.guidelines) logger.info?.(`  • ${g.file}: ${g.action}`);
   if (!dryRun) logger.info?.("core.hooksPath set. Verify later with `kj check`.");
+  // IDN-A (KJC-TSK-0762): a hardened clone declares who works it. Captured
+  // only with a human confirming; headless runs get the pending command.
+  if (!dryRun) {
+    const id = await ensureIdentity({ projectDir, logger });
+    out.identity = id.declared ? id.identity : null;
+    if (id.pending) out.identityPending = id.pending;
+  }
   return out;
 }

--- a/src/identity/bootstrap.js
+++ b/src/identity/bootstrap.js
@@ -1,0 +1,48 @@
+/**
+ * Identity lock — bootstrap (IDN-A, KJC-TSK-0762). Runs at the end of
+ * `kj harden` (and therefore `kj env install`): if this clone has no declared
+ * identity, capture it — but ONLY with a human confirming on a TTY. Headless
+ * runs never bind blindly (the first real `set --yes` bound a clone to an
+ * account another session had switched to); they report the pending step
+ * with the exact command instead. Fail-loud, never a guess.
+ */
+
+import { readIdentity, writeIdentity } from "./store.js";
+import { activeGhUser, effectiveGitEmail } from "./detect.js";
+import { createWizard, isTTY } from "../utils/wizard.js";
+
+/**
+ * @param {{projectDir: string, logger?: object, deps?: object}} args
+ * @returns {Promise<{declared: boolean, identity: object|null, pending: string|null}>}
+ */
+export async function ensureIdentity({ projectDir, logger = null, deps = {} }) {
+  const existing = readIdentity(projectDir);
+  if (existing) return { declared: true, identity: existing, pending: null };
+
+  const gh = activeGhUser(deps.hostsPath ? { hostsPath: deps.hostsPath } : {});
+  const email = effectiveGitEmail(projectDir, deps.gitFn ? { gitFn: deps.gitFn } : {});
+  const hint = `kj identity set --gh ${gh ?? "<user>"} --email ${email ?? "<email>"}`;
+  const tty = (deps.isTTY || isTTY)();
+
+  if (!tty || !gh || !email) {
+    const why = !gh || !email ? "no active gh session or git email" : "non-interactive run";
+    const pending = `identity not declared for this clone (${why}) — run: ${hint}`;
+    logger?.warn?.(`kj identity: ${pending}`);
+    return { declared: false, identity: null, pending };
+  }
+
+  const wizard = (deps.makeWizard || createWizard)();
+  try {
+    const ok = await wizard.confirm(`Bind this clone to gh ${gh} / git ${email}? (other sessions may switch gh accounts — verify)`, true);
+    if (!ok) {
+      const pending = `identity not declared (declined) — run: ${hint}`;
+      logger?.warn?.(`kj identity: ${pending}`);
+      return { declared: false, identity: null, pending };
+    }
+  } finally {
+    wizard.close();
+  }
+  const identity = writeIdentity(projectDir, { gh_user: gh, git_email: email });
+  logger?.info?.(`kj identity: declared gh ${gh} / git ${email} → .karajan/identity.local.yml (ignored by git)`);
+  return { declared: true, identity, pending: null };
+}

--- a/tests/identity/bootstrap.test.js
+++ b/tests/identity/bootstrap.test.js
@@ -1,0 +1,57 @@
+// IDN-A (KJC-TSK-0762) — captura al arrancar: solo con humano confirmando en
+// TTY; en headless NUNCA se ata a ciegas (el primer set --yes real ató el
+// clon a la cuenta que otra sesión había dejado activa) — se declara pendiente
+// con el comando exacto.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ensureIdentity } from "../../src/identity/bootstrap.js";
+import { readIdentity, writeIdentity } from "../../src/identity/store.js";
+
+let dir;
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-identity-boot-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const hosts = (user) => {
+  const p = path.join(dir, "hosts.yml");
+  fs.writeFileSync(p, `github.com:\n    user: ${user}\n`);
+  return p;
+};
+const logger = () => ({ warn: vi.fn(), info: vi.fn() });
+
+describe("ensureIdentity", () => {
+  it("ya declarada → no toca nada", async () => {
+    writeIdentity(dir, { gh_user: "manufosela", git_email: "a@b.c" });
+    const r = await ensureIdentity({ projectDir: dir, logger: logger(), deps: { isTTY: () => true } });
+    expect(r.declared).toBe(true);
+    expect(r.identity.gh_user).toBe("manufosela");
+  });
+
+  it("headless: NO ata a ciegas — pendiente con el comando exacto", async () => {
+    const log = logger();
+    const r = await ensureIdentity({ projectDir: dir, logger: log, deps: { isTTY: () => false, hostsPath: hosts("manufosela-tribbu"), gitFn: () => "a@b.c" } });
+    expect(r.declared).toBe(false);
+    expect(r.pending).toContain("kj identity set --gh manufosela-tribbu --email a@b.c");
+    expect(readIdentity(dir)).toBeNull();
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it("TTY con confirmación → declara; TTY rechazando → pendiente", async () => {
+    const wiz = (answer) => () => ({ confirm: async () => answer, close: () => {} });
+    const yes = await ensureIdentity({ projectDir: dir, logger: logger(), deps: { isTTY: () => true, hostsPath: hosts("manufosela"), gitFn: () => "a@b.c", makeWizard: wiz(true) } });
+    expect(yes.declared).toBe(true);
+    expect(readIdentity(dir)).toMatchObject({ gh_user: "manufosela", git_email: "a@b.c" });
+    fs.rmSync(path.join(dir, ".karajan"), { recursive: true, force: true });
+    const no = await ensureIdentity({ projectDir: dir, logger: logger(), deps: { isTTY: () => true, hostsPath: hosts("manufosela"), gitFn: () => "a@b.c", makeWizard: wiz(false) } });
+    expect(no.declared).toBe(false);
+    expect(no.pending).toMatch(/declined/);
+  });
+
+  it("sin sesión gh: pendiente aunque haya TTY (nunca inventa)", async () => {
+    const r = await ensureIdentity({ projectDir: dir, logger: logger(), deps: { isTTY: () => true, hostsPath: path.join(dir, "none.yml"), gitFn: () => "a@b.c" } });
+    expect(r.declared).toBe(false);
+    expect(r.pending).toMatch(/no active gh session/);
+  });
+});


### PR DESCRIPTION
IDN-A parte 3 de 3 (épica KJC-PCS-0079 Identity lock) — cierra la card KJC-TSK-0762.

- `kj identity show|set` registrado en la CLI (import estático por el presupuesto de imports dinámicos; grupo "Sesión / board" del registro de comandos).
- **Captura al arrancar**: `kj harden` (y por tanto `kj env install`) termina con `ensureIdentity` — si el clon no tiene identidad la captura SOLO con un humano confirmando en TTY; en headless NUNCA ata a ciegas (el primer `set --yes` real ató este clon a la cuenta que otra sesión había dejado activa): declara el paso pendiente con el comando exacto `kj identity set --gh … --email …`.
- **ADR 0005**: identidad por clon, local y sin trackear, fail-closed en los gates, sin auto-switch.
- `.gitignore`: `.karajan/identity.local.yml`.

TDD (bootstrap: ya declarada / headless pendiente / TTY confirma o rechaza / sin sesión nunca inventa). Suite completa verde. APPROVED codex.

Siguiente: IDN-B (gate del Sentinel) e IDN-C (hooks).
