### PR TITLE
feat(sentinel): identity lock for gh and git push (KJC-TSK-0763)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -90,7 +90,7 @@ const POST_BODY = `#!/usr/bin/env node
 // a tool call (PostToolUse, always exit 0).
 import { relative } from "node:path";
 import { CODE, TESTS, ROOT, load, save, session } from "./sentinel-lib.mjs";
-const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII", "KJ_ALLOW_POLICY"];
+const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII", "KJ_ALLOW_POLICY", "KJ_ALLOW_IDENTITY"];
 let raw = "";
 process.stdin.on("data", (d) => { raw += d; });
 process.stdin.on("end", () => {
@@ -194,9 +194,10 @@ const PRETOOL_BODY = `#!/usr/bin/env node
 // before the damage, not in the post-mortem. Exit 2 blocks (stderr says the
 // remediation); read-only tools are never wired here; every honored escape
 // is recorded as an auditable event. Fails OPEN on anything unexpected.
-import { dirname, relative, resolve } from "node:path";
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
 import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, foreignLane, load, violations, recordEscape } from "./sentinel-lib.mjs";
 const EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
 const PUBLISH = /\\bnpm\\s+publish\\b|\\bfirebase\\s+deploy\\b|\\bgh\\s+release\\s+create\\b/;
@@ -265,6 +266,77 @@ process.stdin.on("end", () => {
       }
       return true;
     };
+    // IDN-B (KJC-TSK-0763, ADR 0005): identity lock — gh and mutating git never
+    // run under an account other than the one THIS CLONE declared (the incident:
+    // a gh comment without switch went out as the client account). Deny BEFORE
+    // the damage with the literal remedy; never auto-switch; undeclared = closed.
+    if (tool === "Bash" && CMD_TEXT.length > 0) {
+      const idFile = join(ROOT, ".karajan", "identity.local.yml");
+      const idLine = (key) => {
+        if (!existsSync(idFile)) return null;
+        const line = readFileSync(idFile, "utf8").split(ESC_NL).find((l) => l.startsWith(key + ":"));
+        const v = line ? line.slice(key.length + 1).trim() : "";
+        return v.length > 0 ? v : null;
+      };
+      const declaredGh = idLine("gh_user");
+      const ghHostsPath = join(process.env.GH_CONFIG_DIR || join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "gh"), "hosts.yml");
+      const activeGh = () => {
+        if (!existsSync(ghHostsPath)) return null;
+        const lines = readFileSync(ghHostsPath, "utf8").split(ESC_NL);
+        const start = lines.findIndex((l) => l.startsWith("github.com:"));
+        if (start < 0) return null;
+        for (let k = start + 1; k < lines.length; k += 1) {
+          if (lines[k].length > 0 && lines[k][0] !== " " && lines[k][0] !== ESC_TAB) break;
+          const t = lines[k].trim();
+          if (t.startsWith("user:")) { const u = t.slice(5).trim(); return u.length > 0 ? u : null; }
+        }
+        return null;
+      };
+      const words = (seg) => seg.trim().split(" ").filter((w) => w.length > 0 && w !== ESC_TAB);
+      const headOf = (ws) => { let k = 0; while (k < ws.length && ws[k].indexOf("=") > 0 && ws[k].indexOf("=") < ws[k].length) k += 1; return ws.slice(k); };
+      // Wrapper shells hide the payload in a string (review catch): scan inside.
+      const WRAPPERS =["sh", "bash", "zsh", "dash", "eval", "env", "xargs", "sudo", "nohup", "time", "exec"];
+      let switchedTo = null;
+      const problems = [];
+      // $( and backticks are separators too (review catch): their payload is its own segment.
+      const SEPS = [";", "&&", "||", "|", "$(", String.fromCharCode(96), "(", ")"];
+      const bare = (w) => w.replaceAll(String.fromCharCode(39), "").replaceAll(String.fromCharCode(34), "");
+      const scan = (text, depth) => { if (depth > 3) return; for (const seg of SEPS.reduce((acc, s) => acc.flatMap((l) => l.split(s)), text.split(ESC_NL))) checkSeg(headOf(words(seg)), depth, words(seg)); };
+      const checkSeg = (ws, depth, raw) => {
+        if (ws.length === 0) return;
+        if (WRAPPERS.includes(ws[0])) { // wrapper args have arity (sudo -u bob): scan from the first gh/git/wrapper token (review catch)
+          const j = ws.findIndex((w, i) => i > 0 && ["gh", "git", ...WRAPPERS].includes(bare(w)));
+          if (j > 0) scan(ws.slice(j).map(bare).join(" "), depth + 1);
+          return;
+        }
+        if (ws[0] === "gh") {
+          if (ws[1] === "auth") {
+            if (ws[2] === "switch") { const u = ws.indexOf("--user"); if (u > 0 && ws[u + 1]) switchedTo = ws[u + 1]; }
+            return; // session commands ARE the remedy — never blocked
+          }
+          if (!declaredGh) { problems.push("gh without a declared identity for this clone — run: kj identity set"); return; }
+          const eff = switchedTo || activeGh();
+          if (eff !== declaredGh) problems.push("gh as '" + (eff || "no session") + "' but this clone is declared as '" + declaredGh + "' — prefix the command: gh auth switch --user " + declaredGh + " && ...");
+          return;
+        }
+        if (ws[0] === "git") { // git push authenticates with the gh session (review catch); commit authorship = IDN-B2
+          let k = 1;
+          while (k < ws.length && ws[k].startsWith("-")) k += (ws[k] === "-c" || ws[k] === "-C") && ws[k + 1] ? 2 : 1;
+          if (ws[k] !== "push") return;
+          if (!declaredGh) { problems.push("git push without a declared identity for this clone — run: kj identity set"); return; }
+          const eff = switchedTo || activeGh();
+          if (eff !== declaredGh) problems.push("git push with gh session '" + (eff || "no session") + "' but this clone is declared as '" + declaredGh + "' — prefix: gh auth switch --user " + declaredGh + " && ...");
+        }
+      };
+      scan(CMD_TEXT, 0);
+      if (problems.length > 0) {
+        if (escOn("KJ_ALLOW_IDENTITY")) { recordEscape(sid, "KJ_ALLOW_IDENTITY", tool); }
+        else {
+          console.error("kj sentinel: identity lock (ADR 0005) —" + problems.map((p) => ESC_NL + "- " + p).join("") + ESC_NL + "(KJ_ALLOW_IDENTITY=1 = excepcion consciente, queda registrada)");
+          process.exit(2);
+        }
+      }
+    }
     // MONO-0 (KJC-TSK-0737, ADR 0002): cada sesion muta solo SU worktree;
     // otro carril del MISMO repo se deniega ANTES del dano. Lectura libre.
     const laneOf = (p) => {

--- a/tests/harden/harness-hooks.test.js
+++ b/tests/harden/harness-hooks.test.js
@@ -12,7 +12,7 @@ import { installHarnessHooks } from "../../src/harden/harness-hooks.js";
 
 let dir, script;
 const runHook = (payload, env = {}) =>
-  spawnSync("node", [script], { input: JSON.stringify(payload), encoding: "utf8", env: { ...process.env, ...env } });
+  spawnSync("node", [script], { input: JSON.stringify(payload), encoding: "utf8", env: { ...process.env, KJ_ALLOW_IDENTITY: "1", ...env } });
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-toolgate-"));

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -15,7 +15,9 @@ const run = (script, payload, env = {}) =>
   spawnSync("node", [script], {
     input: typeof payload === "string" ? payload : JSON.stringify(payload),
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    // IDN-B: these suites exercise the OTHER gates; the identity lock has its
+    // own suite (sentinel-identity.test.js), so it is escaped here (env route).
+    env: { ...process.env, KJ_ALLOW_IDENTITY: "1", ...env },
   });
 const editTool = (file, session = "s1") => ({ session_id: session, tool_name: "Edit", tool_input: { file_path: file } });
 const state = () => JSON.parse(fs.readFileSync(statePath, "utf8"));
@@ -363,7 +365,7 @@ describe("pretooluse-sentinel lane boundary (MONO-0)", () => {
     fs.writeFileSync(path.join(inTree, "src", "x.js"), "x");
     const spawn = (command) => spawnSync("node", [gate], {
       input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command } }),
-      encoding: "utf8", cwd: dir, env: { ...process.env },
+      encoding: "utf8", cwd: dir, env: { ...process.env, KJ_ALLOW_IDENTITY: "1" },
     });
     const bare = spawn("sed -i s/a/b/ .kj/worktrees/wt2/src/x.js");
     expect(bare.status).toBe(2);
@@ -450,7 +452,7 @@ describe("pretooluse-sentinel lane boundary (MONO-0)", () => {
       input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command: `sed -i s/a/b/ ${rel}` } }),
       encoding: "utf8",
       cwd: dir,
-      env: { ...process.env },
+      env: { ...process.env, KJ_ALLOW_IDENTITY: "1" },
     });
     expect(res.status).toBe(2);
     expect(res.stderr).toContain("carril");

--- a/tests/harden/sentinel-identity.test.js
+++ b/tests/harden/sentinel-identity.test.js
@@ -1,0 +1,95 @@
+// IDN-B (KJC-TSK-0763, ADR 0005) — identity lock en el Sentinel, contra el
+// hook GENERADO (hosts.yml falso vía GH_CONFIG_DIR, git config real).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync, execSync } from "node:child_process";
+import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
+
+let dir, gate, ghDir;
+const run = (command, env = {}) =>
+  spawnSync("node", [gate], {
+    input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command } }),
+    encoding: "utf8", cwd: dir, env: { ...process.env, GH_CONFIG_DIR: ghDir, ...env },
+  });
+const activeGh = (user) => fs.writeFileSync(path.join(ghDir, "hosts.yml"), `github.com:\n    users:\n        ${user}:\n    user: ${user}\n    git_protocol: ssh\n`);
+const declare = (gh, email) => {
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".karajan", "identity.local.yml"), `gh_user: ${gh}\ngit_email: ${email}\ndeclared_at: 2026-08-20T00:00:00.000Z\n`);
+};
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-sentinel-id-"));
+  ghDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-gh-"));
+  execSync(
+    "git init -q -b main && git config user.email a@b.c && git config user.name t && git commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0001-demo",
+    { cwd: dir },
+  );
+  installSentinelHooks({ projectDir: dir });
+  gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(ghDir, { recursive: true, force: true });
+});
+
+describe("identity lock — gh", () => {
+  it("cuenta activa distinta de la declarada: deny nombrando ambas y el switch exacto; con el switch como prefijo pasa", () => {
+    declare("manufosela", "a@b.c");
+    activeGh("manufosela-tribbu");
+    const denied = run("gh issue comment 1 --body hola");
+    expect(denied.status).toBe(2);
+    expect(denied.stderr).toContain("manufosela-tribbu");
+    expect(denied.stderr).toContain("gh auth switch --user manufosela");
+    expect(run("gh auth switch --user manufosela && gh issue comment 1 --body hola").status).toBe(0);
+    // Los comandos de sesion de gh son el remedio: nunca se bloquean.
+    expect(run("gh auth switch --user manufosela").status).toBe(0);
+    expect(run("gh auth status").status).toBe(0);
+    // Una mencion textual de gh no es un comando gh; con la cuenta correcta, pasa.
+    expect(run("grep -n gh notas.txt").status).toBe(0);
+    activeGh("manufosela");
+    expect(run("gh pr list --limit 3").status).toBe(0);
+  });
+
+  it("sin identidad declarada: fail-closed para gh y git mutador, pidiendo kj identity set; escape KJ_ALLOW_IDENTITY=1 por prefijo", () => {
+    activeGh("manufosela");
+    const gh = run("gh issue list");
+    expect(gh.status).toBe(2);
+    expect(gh.stderr).toContain("kj identity set");
+    expect(run("git push origin x").status).toBe(2);
+    expect(run("git status").status).toBe(0);
+    expect(run("KJ_ALLOW_IDENTITY=1 gh issue list").status).toBe(0);
+    const st = JSON.parse(fs.readFileSync(path.join(dir, ".karajan", "harness", "sentinel-state.json"), "utf8"));
+    expect(st.escape_events.some((e) => e.escape === "KJ_ALLOW_IDENTITY")).toBe(true);
+    // Sin sesion gh (hosts.yml ausente) tampoco se adivina: deny.
+    declare("manufosela", "a@b.c");
+    fs.rmSync(path.join(ghDir, "hosts.yml"));
+    expect(run("gh issue list").stderr).toMatch(/no session/);
+  });
+
+  it("un shell envoltorio no esconde el payload (catch de codex): bash -c / eval / env se escanean por dentro", () => {
+    declare("manufosela", "a@b.c");
+    activeGh("manufosela-tribbu");
+    expect(run("bash -lc 'gh issue comment 1 --body hola'").status).toBe(2);
+    expect(run("bash -lc 'echo $(git push origin main)'").status).toBe(2);
+    expect(run("sudo -u bob gh pr merge 3").status).toBe(2);
+    const wrapped = run("bash -lc 'gh auth switch --user manufosela && gh pr list'");
+    expect(wrapped.stderr).toBe("");
+    expect(wrapped.status).toBe(0);
+  });
+});
+
+describe("identity lock — git push", () => {
+  it("push autentica con la sesion de gh, no con user.email (catch de codex): cuenta distinta deny, switch como prefijo pasa; lectura libre", () => {
+    declare("manufosela", "a@b.c");
+    activeGh("manufosela-tribbu");
+    const denied = run("git push -u origin feat/x");
+    expect(denied.status).toBe(2);
+    expect(denied.stderr).toContain("gh auth switch --user manufosela");
+    expect(run("gh auth switch --user manufosela && git push -u origin feat/x").status).toBe(0);
+    expect(run("git -C sub -c core.x=1 push origin x").status).toBe(2);
+    expect(run("git log --oneline -1").status).toBe(0);
+  });
+});

--- a/tests/harden/sentinel-policy-delegation.test.js
+++ b/tests/harden/sentinel-policy-delegation.test.js
@@ -16,7 +16,7 @@ const run = (script, payload, env = {}) =>
   spawnSync("node", [script], {
     input: JSON.stringify(payload),
     encoding: "utf8",
-    env: { ...process.env, ...env },
+    env: { ...process.env, KJ_ALLOW_IDENTITY: "1", ...env },
   });
 const editTool = (file) => ({ session_id: "s1", tool_name: "Edit", tool_input: { file_path: file } });
 const state = () => JSON.parse(fs.readFileSync(statePath, "utf8"));


### PR DESCRIPTION
IDN-B parte 1 de 2 (épica KJC-PCS-0079 Identity lock, ADR 0005) — el gate tool-time de SESIÓN.

El Sentinel deniega ANTES de ejecutar cualquier Bash en el que `gh` (salvo `gh auth …`, que es el remedio) o `git push` vayan a correr con una cuenta de gh distinta de la que este clon declaró en `.karajan/identity.local.yml` — nombrando ambas cuentas y el remedio literal (`gh auth switch --user X && …`). Sin identidad declarada: fail-closed pidiendo `kj identity set`. `KJ_ALLOW_IDENTITY=1` como escape auditado por prefijo. Nunca auto-switch.

Detección sin red: cuenta activa leída del `hosts.yml` de gh (respeta `GH_CONFIG_DIR`). Un `gh auth switch --user X` que precede al comando en la misma línea cuenta como sesión efectiva.

Catches de codex absorbidos (4 rondas): `git push` autentica con la sesión gh y no con user.email; shells envoltorio (`bash -c`, `sh -c`, `eval`, `sudo -u bob …`) se escanean por dentro con su aridad; `$(...)` y backticks son separadores (su payload se comprueba); una mención textual de gh no es un comando gh.

Parte 2 (IDN-B2): identidad de AUTORÍA en git commit/tag/merge/rebase/cherry-pick/am/revert — user.email, `-c`, `-C otro-repo`, `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL`, `--author` (ya escrita, particionada por el presupuesto LOC).

Los demás tests del harness escapan este gate con `KJ_ALLOW_IDENTITY=1` por env (tienen su propia suite). El incidente que lo motiva: un `gh issue comment` sin switch salió como la cuenta de cliente en este repo público.

Card: KJC-TSK-0763.
