### PR TITLE
feat(sentinel): identity lock for git authorship via git var (KJC-TSK-0763)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -279,6 +279,7 @@ process.stdin.on("end", () => {
         return v.length > 0 ? v : null;
       };
       const declaredGh = idLine("gh_user");
+      const declaredEmail = idLine("git_email");
       const ghHostsPath = join(process.env.GH_CONFIG_DIR || join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "gh"), "hosts.yml");
       const activeGh = () => {
         if (!existsSync(ghHostsPath)) return null;
@@ -319,13 +320,43 @@ process.stdin.on("end", () => {
           if (eff !== declaredGh) problems.push("gh as '" + (eff || "no session") + "' but this clone is declared as '" + declaredGh + "' — prefix the command: gh auth switch --user " + declaredGh + " && ...");
           return;
         }
-        if (ws[0] === "git") { // git push authenticates with the gh session (review catch); commit authorship = IDN-B2
+        if (ws[0] === "git") {
+          // Global options (-C, -c, --git-dir, --work-tree...) are NOT re-implemented: they
+          // are forwarded verbatim to git var, so git resolves identity exactly as the real
+          // command would (review catches: -C cumulative, --git-dir, --opt=value forms).
+          const TWO = ["-c", "-C", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path", "--config-env"];
           let k = 1;
-          while (k < ws.length && ws[k].startsWith("-")) k += (ws[k] === "-c" || ws[k] === "-C") && ws[k + 1] ? 2 : 1;
-          if (ws[k] !== "push") return;
-          if (!declaredGh) { problems.push("git push without a declared identity for this clone — run: kj identity set"); return; }
-          const eff = switchedTo || activeGh();
-          if (eff !== declaredGh) problems.push("git push with gh session '" + (eff || "no session") + "' but this clone is declared as '" + declaredGh + "' — prefix: gh auth switch --user " + declaredGh + " && ...");
+          while (k < ws.length && ws[k].startsWith("-")) k += TWO.includes(ws[k]) && ws[k + 1] ? 2 : 1;
+          const globals = ws.slice(1, k).map(bare);
+          const sub = ws[k];
+          if (sub === "push") { // push authenticates with the gh session, not user.email (review catch)
+            if (!declaredGh) { problems.push("git push without a declared identity for this clone — run: kj identity set"); return; }
+            const eff = switchedTo || activeGh();
+            if (eff !== declaredGh) problems.push("git push with gh session '" + (eff || "no session") + "' but this clone is declared as '" + declaredGh + "' — prefix: gh auth switch --user " + declaredGh + " && ...");
+            return;
+          }
+          // IDN-B2: anything that authors or rewrites commits carries an identity (review catch).
+          if (!["commit", "tag", "merge", "rebase", "cherry-pick", "am", "revert"].includes(sub)) return; // am: the COMMITTER is still this user
+          if (!declaredEmail) { problems.push("git " + sub + " without a declared identity for this clone — run: kj identity set"); return; }
+          // Let GIT resolve author and committer under the command's own environment
+          // (review catch: user.email, -c, GIT_*_EMAIL, EMAIL, GIT_CONFIG_*, includeIf are
+          // its business): git var is the single source of truth.
+          const assigns = raw.slice(0, raw.length - ws.length).filter((w) => w.indexOf("=") > 0);
+          const env = Object.assign({}, process.env);
+          for (const w of assigns) env[w.slice(0, w.indexOf("="))] = bare(w.slice(w.indexOf("=") + 1));
+          const ident = (v) => {
+            const r = spawnSync("git", [...globals, "var", v], { cwd: ROOT, encoding: "utf8", env });
+            const s = r.status === 0 ? String(r.stdout) : "";
+            const a = s.indexOf("<");
+            const b = s.indexOf(">");
+            return a >= 0 && b > a ? s.slice(a + 1, b) : null;
+          };
+          const ai = ws.findIndex((w) => w.startsWith("--author"));
+          const authorRaw = ai < 0 ? null : ws[ai].includes("=") ? ws[ai].slice(ws[ai].indexOf("=") + 1) : ws.slice(ai + 1).join(" ");
+          const authorMail = authorRaw === null ? null : bare(authorRaw.includes("<") ? authorRaw.slice(authorRaw.indexOf("<") + 1, authorRaw.indexOf(">")) : authorRaw.trim());
+          const mails = [authorMail ?? ident("GIT_AUTHOR_IDENT"), ident("GIT_COMMITTER_IDENT")]; // --author overrides the author (review catch); the committer is always git's
+          const offender = mails.find((m) => m !== null && m !== declaredEmail) ?? (mails[0] === null ? "none" : null);
+          if (offender !== null) problems.push("git " + sub + " as '" + offender + "' but this clone is declared as '" + declaredEmail + "' — use: git -c user.email=" + declaredEmail + " " + sub + " ... (or git config user.email " + declaredEmail + ")");
         }
       };
       scan(CMD_TEXT, 0);

--- a/tests/harden/sentinel-identity.test.js
+++ b/tests/harden/sentinel-identity.test.js
@@ -105,7 +105,8 @@ describe("identity lock — autoria git (IDN-B2)", () => {
     // (EMAIL no: git solo lo usa como fallback cuando no hay user.email configurado).
     expect(run("GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.email GIT_CONFIG_VALUE_0=zzz@x.y git commit -m x").status).toBe(2);
     const other = path.join(dir, "otro");
-    execSync(`git init -q ${other} && git -C ${other} config user.email zzz@other.x`, { cwd: dir });
+    // user.name tambien: sin el, git var falla (CI no tiene config global) y el gate deniega por "none".
+    execSync(`git init -q ${other} && git -C ${other} config user.email zzz@other.x && git -C ${other} config user.name z`, { cwd: dir });
     expect(run(`git -C ${other} commit -m x`).status).toBe(2);
     expect(run(`git -C ${other} -c user.email=a@b.c commit -m x`).status).toBe(0);
   });

--- a/tests/harden/sentinel-identity.test.js
+++ b/tests/harden/sentinel-identity.test.js
@@ -81,6 +81,36 @@ describe("identity lock — gh", () => {
   });
 });
 
+describe("identity lock — autoria git (IDN-B2)", () => {
+  it("commit/tag/merge/rebase/cherry-pick con email efectivo distinto: deny; con -c user.email= del declarado pasa", () => {
+    declare("manufosela", "otro@mail.x");
+    activeGh("manufosela");
+    const denied = run('git commit -m "feat: x"');
+    expect(denied.status).toBe(2);
+    expect(denied.stderr).toContain("otro@mail.x");
+    expect(denied.stderr).toContain("a@b.c");
+    expect(run('git -c user.email=otro@mail.x commit -m "feat: x"').status).toBe(0);
+    for (const m of ["git tag v1", "git merge feat/y", "git cherry-pick abc", "git rebase main", "git --git-dir .git commit -m x", "git --work-tree . am p.patch"]) expect(run(m).status).toBe(2);
+    declare("manufosela", "a@b.c");
+    expect(run('git commit -m "feat: x"').status).toBe(0);
+  });
+
+  it("todas las fuentes que git honra (catch de codex): env en el comando o en la sesion, --author, y -C otro-repo", () => {
+    declare("manufosela", "a@b.c");
+    activeGh("manufosela");
+    expect(run("GIT_AUTHOR_EMAIL=zzz@x.y git commit -m x").status).toBe(2);
+    expect(run('git commit --author="Z <zzz@x.y>" -m x').status).toBe(2);
+    expect(run("git commit -m x", { GIT_COMMITTER_EMAIL: "zzz@x.y" }).status).toBe(2);
+    // git resuelve la identidad (catch de codex): GIT_CONFIG_* inyectado tambien cuenta
+    // (EMAIL no: git solo lo usa como fallback cuando no hay user.email configurado).
+    expect(run("GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.email GIT_CONFIG_VALUE_0=zzz@x.y git commit -m x").status).toBe(2);
+    const other = path.join(dir, "otro");
+    execSync(`git init -q ${other} && git -C ${other} config user.email zzz@other.x`, { cwd: dir });
+    expect(run(`git -C ${other} commit -m x`).status).toBe(2);
+    expect(run(`git -C ${other} -c user.email=a@b.c commit -m x`).status).toBe(0);
+  });
+});
+
 describe("identity lock — git push", () => {
   it("push autentica con la sesion de gh, no con user.email (catch de codex): cuenta distinta deny, switch como prefijo pasa; lectura libre", () => {
     declare("manufosela", "a@b.c");


### PR DESCRIPTION
IDN-B parte 2 de 2 (épica KJC-PCS-0079 Identity lock, ADR 0005) — cierra la card KJC-TSK-0763.

Identidad de AUTORÍA en git: `commit`, `tag`, `merge`, `rebase`, `cherry-pick`, `am`, `revert` se deniegan antes de ejecutarse si el autor o el committer efectivos no son el email que este clon declaró.

La clave del diseño tras 7 rondas de codex: **no reimplementamos la resolución de identidad de git — se la preguntamos a git**. El gate reenvía verbatim las opciones globales del comando (`-C` acumulativo, `-c user.email=…`, `--git-dir`, `--work-tree`, formas `--opt=valor`…) a `git var GIT_AUTHOR_IDENT` / `GIT_COMMITTER_IDENT`, ejecutado con el entorno del comando (asignaciones de prefijo como `GIT_AUTHOR_EMAIL=`, `GIT_CONFIG_COUNT/KEY/VALUE`, más el entorno de la sesión). `--author` manda sobre el autor; el committer es siempre el que git diga. `am` cuenta porque su committer es este usuario. Sin identidad declarada: fail-closed. Escape auditado `KJ_ALLOW_IDENTITY=1` por prefijo.

Incidente de desarrollo digno de nota: dos veces un backtick dentro de un COMENTARIO del template cerró el template literal y dejó el `kj` linkado sin cargar — policy eval en deny total; la salida fue `KJ_ALLOW_POLICY=1 git checkout` (el fix del 0142 pagándose solo otra vez).

Tests contra el hook generado: email distinto por config, `-c`, `-C otro-repo`, `--git-dir`, `--work-tree … am`, env en el comando y en la sesión, `GIT_CONFIG_*`, `--author`. Suite completa verde. APPROVED codex.
