### PR TITLE
feat(harden): identity lock in pre-commit and pre-push hooks (KJC-TSK-0764)

### DIFF
--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -52,11 +52,49 @@ function baseBranchGuard(baseBranch) {
   ];
 }
 
+// IDN-C (KJC-TSK-0764, ADR 0005): identity lock at tier B — the declared clone
+// identity (.karajan/identity.local.yml) governs authorship on commit and the
+// gh session on push, on ANY host. Undeclared = advisory only (old clones keep
+// working); the fail-closed default is the Sentinel's (IDN-B).
+function identityGuard(hook) {
+  const head = [
+    "# Identity lock (IDN-C, ADR 0005) — this clone's declared identity governs.",
+    'if [ "$KJ_ALLOW_IDENTITY" != "1" ] && [ -f .karajan/identity.local.yml ]; then',
+  ];
+  const tail = [
+    "elif [ ! -f .karajan/identity.local.yml ]; then",
+    "  echo 'kj harden: no identity declared for this clone — run kj identity set (advisory)'",
+    "fi",
+  ];
+  if (hook === "pre-commit") {
+    return [
+      ...head,
+      "  kj_declared_email=$(sed -n 's/^git_email:[[:space:]]*//p' .karajan/identity.local.yml | head -n1)",
+      "  kj_author=$(git var GIT_AUTHOR_IDENT | sed 's/.*<\\(.*\\)>.*/\\1/')",
+      "  kj_committer=$(git var GIT_COMMITTER_IDENT | sed 's/.*<\\(.*\\)>.*/\\1/')",
+      '  if [ -n "$kj_declared_email" ] && { [ "$kj_author" != "$kj_declared_email" ] || [ "$kj_committer" != "$kj_declared_email" ]; }; then',
+      '    echo "kj harden: identity lock — committing as $kj_author / $kj_committer but this clone is declared as $kj_declared_email (kj identity show; KJ_ALLOW_IDENTITY=1 to override)"; exit 1',
+      "  fi",
+      ...tail,
+    ];
+  }
+  return [
+    ...head,
+    "  kj_declared_gh=$(sed -n 's/^gh_user:[[:space:]]*//p' .karajan/identity.local.yml | head -n1)",
+    '  kj_hosts="${GH_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/gh}/hosts.yml"',
+    "  kj_active_gh=$(awk '/^github.com:/{f=1;next} f&&/^[^[:space:]]/{f=0} f&&/^[[:space:]]*user:/{sub(/^[[:space:]]*user:[[:space:]]*/,\"\");print;exit}' \"$kj_hosts\" 2>/dev/null)",
+    '  if [ -n "$kj_declared_gh" ] && [ "$kj_active_gh" != "$kj_declared_gh" ]; then',
+    '    echo "kj harden: identity lock — gh session is ${kj_active_gh:-none} but this clone is declared as $kj_declared_gh — run: gh auth switch --user $kj_declared_gh (KJ_ALLOW_IDENTITY=1 to override)"; exit 1',
+    "  fi",
+    ...tail,
+  ];
+}
+
 export function hookBody(hook, cmds = {}, { globalHooksDir = null, baseBranch = null } = {}) {
   const chain = chainToGlobal(hook, globalHooksDir);
   switch (hook) {
     case "pre-commit": {
-      const lines = [...baseBranchGuard(baseBranch), "# Lint + format the working tree with the project's native tools."];
+      const lines = [...baseBranchGuard(baseBranch), ...identityGuard("pre-commit"), "# Lint + format the working tree with the project's native tools."];
       if (cmds.lint) lines.push(`${cmds.lint} || { echo 'kj harden: lint failed'; exit 1; }`);
       if (cmds.format) lines.push(`${cmds.format} || { echo 'kj harden: format check failed'; exit 1; }`);
       if (!cmds.lint && !cmds.format) lines.push("# (no lint/format command detected for this stack)");
@@ -93,6 +131,7 @@ export function hookBody(hook, cmds = {}, { globalHooksDir = null, baseBranch = 
         "  echo 'kj harden: git user.name/user.email not set — refusing to push'; exit 1",
         "fi",
         'echo "kj harden: pushing as $(git config user.name) <$(git config user.email)>"',
+        ...identityGuard("pre-push"),
         "# Run the test suite before pushing.",
       ];
       if (cmds.test) lines.push(`${cmds.test} || { echo 'kj harden: tests failed'; exit 1; }`);

--- a/tests/harden/identity-hooks.test.js
+++ b/tests/harden/identity-hooks.test.js
@@ -1,0 +1,71 @@
+// IDN-C (KJC-TSK-0764, ADR 0005) — identity lock en los hooks de git (tier B,
+// cualquier host): pre-commit compara autor/committer (git var) con el email
+// declarado del clon; pre-push compara la sesión de gh (hosts.yml) con el
+// gh_user declarado. Sin identidad: aviso, no bloqueo. Real sh + git.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { hookBody, SHEBANG } from "../../src/harden/hook-templates.js";
+
+let dir, ghDir;
+const declare = (gh, email) => {
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".karajan", "identity.local.yml"), `gh_user: ${gh}\ngit_email: ${email}\n`);
+};
+const hosts = (user) => fs.writeFileSync(path.join(ghDir, "hosts.yml"), `github.com:\n    users:\n        ${user}:\n    user: ${user}\n    git_protocol: ssh\n`);
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-idhooks-"));
+  ghDir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-idhooks-gh-"));
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
+  for (const [k, v] of [["user.email", "t@t"], ["user.name", "T"], ["commit.gpgsign", "false"], ["core.hooksPath", ".karajan/hooks"]]) execFileSync("git", ["config", k, v], { cwd: dir });
+  const hooksDir = path.join(dir, ".karajan", "hooks");
+  fs.mkdirSync(hooksDir, { recursive: true });
+  for (const hook of ["pre-commit", "pre-push"]) fs.writeFileSync(path.join(hooksDir, hook), `${SHEBANG}\n${hookBody(hook, {})}\n`, { mode: 0o755 });
+  execFileSync("git", ["checkout", "-q", "-b", "feat/KJC-TSK-0001-x"], { cwd: dir });
+});
+afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); fs.rmSync(ghDir, { recursive: true, force: true }); });
+
+const commit = (env = {}) => {
+  fs.writeFileSync(path.join(dir, "f.js"), `// ${Math.random()}\n`);
+  execFileSync("git", ["add", "f.js"], { cwd: dir });
+  return spawnSync("git", ["commit", "-m", "feat: x"], { cwd: dir, encoding: "utf8", env: { ...process.env, ...env } });
+};
+const push = (env = {}) => spawnSync("sh", [path.join(dir, ".karajan", "hooks", "pre-push")], { cwd: dir, encoding: "utf8", env: { ...process.env, GH_CONFIG_DIR: ghDir, ...env } });
+
+describe("pre-commit identity lock", () => {
+  it("email distinto del declarado: rechaza nombrando ambos; igual: pasa; escape KJ_ALLOW_IDENTITY=1", () => {
+    declare("manufosela", "a@b.c");
+    const denied = commit();
+    expect(denied.status).not.toBe(0);
+    expect(`${denied.stdout}${denied.stderr}`).toMatch(/identity lock.*t@t.*a@b\.c/);
+    expect(commit({ KJ_ALLOW_IDENTITY: "1" }).status).toBe(0);
+    execFileSync("git", ["config", "user.email", "a@b.c"], { cwd: dir });
+    expect(commit().status).toBe(0);
+    expect(commit({ GIT_AUTHOR_EMAIL: "zzz@x.y" }).status).not.toBe(0);
+  });
+
+  it("sin identidad declarada: aviso, no bloqueo", () => {
+    const res = commit();
+    expect(res.status).toBe(0);
+    expect(`${res.stdout}${res.stderr}`).toMatch(/no identity declared/);
+  });
+});
+
+describe("pre-push identity lock", () => {
+  it("sesion gh distinta de la declarada: rechaza con el switch exacto; igual: pasa; sin hosts.yml: rechaza", () => {
+    declare("manufosela", "t@t");
+    hosts("manufosela-tribbu");
+    const denied = push();
+    expect(denied.status).not.toBe(0);
+    expect(denied.stdout).toContain("gh auth switch --user manufosela");
+    hosts("manufosela");
+    expect(push().status).toBe(0);
+    fs.rmSync(path.join(ghDir, "hosts.yml"));
+    expect(push().status).not.toBe(0);
+    expect(push({ KJ_ALLOW_IDENTITY: "1" }).status).toBe(0);
+  });
+});


### PR DESCRIPTION
IDN-C (épica KJC-PCS-0079 Identity lock, ADR 0005) — el suelo del método, tier B, cualquier host.

La misma verdad que el Sentinel (la identidad declarada del clon en `.karajan/identity.local.yml`) en los hooks de git que `kj harden` instala:
- **pre-commit**: autor y committer efectivos (`git var GIT_AUTHOR_IDENT` / `GIT_COMMITTER_IDENT` — git resuelve config, `-c`, env…) deben ser el `git_email` declarado; si no, rechaza nombrando ambos.
- **pre-push**: la sesión activa de gh (leída del `hosts.yml` de gh, respetando `GH_CONFIG_DIR`) debe ser el `gh_user` declarado; si no, rechaza con el `gh auth switch --user …` exacto. Sin `hosts.yml` (sin sesión) rechaza: nunca se adivina.
- **Sin identidad declarada: aviso, no bloqueo** — los clones antiguos siguen funcionando; el fail-closed vive en el Sentinel (IDN-B). `KJ_ALLOW_IDENTITY=1` como escape explícito.

POSIX sh puro (sed/awk), sin dependencias. Tests con sh + git reales en un repo temporal: rechazo por email, escape, paso con email correcto, `GIT_AUTHOR_EMAIL` ajeno, aviso sin identidad, pre-push con sesión distinta/igual/ausente.

Cierra la card KJC-TSK-0764 y, con IDN-A/B, la épica: el incidente de hoy (un gh como la cuenta de cliente) ya es imposible en las tres capas.
