### PR TITLE
feat(sentinel): board-sync gate — merged cards must be moved before advancing (KJC-TSK-0765)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -66,8 +66,12 @@ export const foreignLane = (targetDir) => {
   const common = _git("rev-parse --path-format=absolute --git-common-dir", targetDir);
   return common && common === _home.common ? top : null;
 };
+// KJC-TSK-0765 board-sync: cards merged in this session but not yet moved in
+// the tracker. The method does not advance until the board is true.
+export const pendingMoves = (s) => (s && Array.isArray(s.pending_moves) ? s.pending_moves : []);
+export const pendingText = (p) => (p.card ? p.card : "card sin identificar") + " (PR #" + p.pr + ") mergeada sin mover en el tracker — muevela a To Validate / Fixed con sus commits (update_card del PG o kj hu move)";
 export const violations = (s, branch) => {
-  const v = [];
+  const v = pendingMoves(s).map(pendingText);
   if (!s || !(s.edited_sources || []).length) return v;
   if (BASE_BRANCHES.has(branch)) v.push("Fuentes editadas en la rama base '" + branch + "' — crea una rama: git checkout -b feat/<CARD-ID>-descripcion");
   else if (branch && !CARD.test(branch)) v.push("La rama '" + branch + "' no referencia ninguna card — usa feat/<CARD-ID>-descripcion (y una card VIVA en el board)");
@@ -89,13 +93,28 @@ const POST_BODY = `#!/usr/bin/env node
 // Records deterministic method facts per session; never blocks, never fails
 // a tool call (PostToolUse, always exit 0).
 import { relative } from "node:path";
-import { CODE, TESTS, ROOT, load, save, session } from "./sentinel-lib.mjs";
-const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII", "KJ_ALLOW_POLICY", "KJ_ALLOW_IDENTITY"];
+import { CODE, TESTS, ROOT, CARD, branchOf, load, save, session } from "./sentinel-lib.mjs";
+const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII", "KJ_ALLOW_POLICY", "KJ_ALLOW_IDENTITY", "KJ_ALLOW_BOARD"];
 let raw = "";
 process.stdin.on("data", (d) => { raw += d; });
 process.stdin.on("end", () => {
   try {
-    const { session_id: sid = "default", tool_name: tool, tool_input: input = {} } = JSON.parse(raw);
+    const { session_id: sid = "default", tool_name: tool, tool_input: input = {}, tool_response: response = {} } = JSON.parse(raw);
+    // KJC-TSK-0765 board-sync: a merge that gh CONFIRMS leaves its card pending
+    // in the tracker (the PreToolUse gate then refuses to advance until it is
+    // moved). Recorded here, after the fact, so a failed merge never blocks.
+    if (tool === "Bash") {
+      const text = typeof response === "string" ? response : [response.stdout, response.stderr, response.output].filter(Boolean).join(String.fromCharCode(10));
+      const merged = /merged pull request #(\\d+)/i.exec(text);
+      if (merged) {
+        const state = load();
+        const s = session(state, sid);
+        const ref = CARD.exec(branchOf() || "");
+        (s.pending_moves ||= []).push({ card: ref ? ref[0].toUpperCase() : null, pr: Number(merged[1]), at: Date.now() });
+        save(state);
+      }
+      process.exit(0);
+    }
     const file = input.file_path || input.notebook_path;
     if (!["Write", "Edit", "MultiEdit", "NotebookEdit"].includes(tool) || !file) process.exit(0);
     const state = load();
@@ -198,7 +217,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
-import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, foreignLane, load, violations, recordEscape } from "./sentinel-lib.mjs";
+import { CODE, TESTS, ROOT, BASE_BRANCHES, CARD, branchOf, foreignLane, load, violations, recordEscape, pendingMoves, pendingText } from "./sentinel-lib.mjs";
 const EDIT_TOOLS = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
 const PUBLISH = /\\bnpm\\s+publish\\b|\\bfirebase\\s+deploy\\b|\\bgh\\s+release\\s+create\\b/;
 const PUSH = /\\bgit\\s+push\\b/;
@@ -578,6 +597,23 @@ process.stdin.on("end", () => {
     }
     if (tool === "Bash") {
       const cmd = String(input.command || "");
+      // KJC-TSK-0765 board-sync: a merge leaves its card PENDING in the tracker
+      // and nothing advances (commit, new PR, another merge; push and the end of
+      // the turn go through violations()) until the card is moved. The board is
+      // true at all times or the method stops — never a rule in the agent's memory.
+      const MERGE = /\\bgh\\s+pr\\s+merge(\\s+(\\d+))?/;
+      const ADVANCE = /\\bgit\\s+commit\\b|\\bgit\\s+push\\b|\\bgh\\s+pr\\s+create\\b/; // push also falls under violations() — explicit here too (review catch)
+      const mergeM = cmd.match(MERGE);
+      const pend = pendingMoves(load().sessions?.[sid]);
+      if (pend.length > 0 && (mergeM || ADVANCE.test(cmd))) {
+        if (escOn("KJ_ALLOW_BOARD")) { recordEscape(sid, "KJ_ALLOW_BOARD", tool); }
+        else {
+          console.error("kj sentinel: board-sync — el metodo no avanza con cards mergeadas sin mover:\\n" + pend.map((p) => "- " + pendingText(p)).join("\\n") + "\\n(KJ_ALLOW_BOARD=1 = excepcion consciente, queda registrada)");
+          process.exit(2);
+        }
+      }
+      // (the pending entry itself is recorded by the PostToolUse hook, only once
+      // gh confirms "merged pull request #N" — a failed merge never blocks)
       if (PUBLISH.test(cmd)) {
         if (escOn("KJ_ALLOW_RELEASE")) { recordEscape(sid, "KJ_ALLOW_RELEASE", tool); process.exit(0); }
         const res = spawnSync("kj", ["release", "check", "--json"], { cwd: ROOT, encoding: "utf8" });

--- a/tests/harden/sentinel-board-sync.test.js
+++ b/tests/harden/sentinel-board-sync.test.js
@@ -1,0 +1,87 @@
+// KJC-TSK-0765 — board-sync gate: tras `gh pr merge` la card de la rama queda
+// PENDIENTE DE MOVER en el tracker; mientras haya pendientes, el método no
+// avanza (commit, push, nuevo PR, cierre de turno). Regla del usuario: NO
+// PUEDE AVANZAR SI NO SE REGISTRA. Tests contra los hooks generados.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync, execSync } from "node:child_process";
+import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
+
+let dir, gate, stop, post, statePath;
+const env = { KJ_ALLOW_IDENTITY: "1" }; // el identity lock tiene su propia suite
+const bash = (command, extra = {}) =>
+  spawnSync("node", [gate], {
+    input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command } }),
+    encoding: "utf8", cwd: dir, env: { ...process.env, ...env, ...extra },
+  });
+// El registro del merge lo hace el PostToolUse, SOLO cuando gh confirma el merge.
+const merged = (pr, ok = true) =>
+  spawnSync("node", [post], {
+    input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command: `gh pr merge ${pr} --squash` }, tool_response: { stdout: ok ? `✓ Squashed and merged pull request #${pr}` : "", stderr: ok ? "" : "GraphQL: Pull request is not mergeable" } }),
+    encoding: "utf8", cwd: dir, env: { ...process.env, ...env },
+  });
+const endTurn = () => spawnSync("node", [stop], { input: JSON.stringify({ session_id: "s1" }), encoding: "utf8", cwd: dir, env: { ...process.env, ...env } });
+const state = () => JSON.parse(fs.readFileSync(statePath, "utf8"));
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-board-sync-"));
+  execSync(
+    "git init -q -b main && git config user.email a@b.c && git config user.name t && git commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0042-demo",
+    { cwd: dir },
+  );
+  installSentinelHooks({ projectDir: dir });
+  gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+  stop = path.join(dir, ".karajan", "harness", "stop.mjs");
+  post = path.join(dir, ".karajan", "harness", "posttooluse.mjs");
+  statePath = path.join(dir, ".karajan", "harness", "sentinel-state.json");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("board-sync gate", () => {
+  it("un merge CONFIRMADO por gh registra la card de la rama como pendiente de mover; un merge fallido no", () => {
+    expect(bash("gh auth switch --user x && gh pr merge 12 --squash").status).toBe(0); // el gate deja pasar el merge
+    expect(merged(12, false).status).toBe(0);
+    expect(fs.existsSync(statePath) ? (state().sessions?.s1?.pending_moves ?? []) : []).toHaveLength(0);
+    expect(merged(12).status).toBe(0);
+    const pending = state().sessions.s1.pending_moves;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ card: "KJC-TSK-0042", pr: 12 });
+  });
+
+  it("con una card pendiente: commit, push, nuevo PR y cierre de turno se deniegan nombrando card+PR y el remedio", () => {
+    merged(12);
+    for (const cmd of ["git commit -m x", "git push origin feat/x", "gh pr create --title t", "gh pr merge 13"]) {
+      const r = bash(cmd);
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain("KJC-TSK-0042");
+      expect(r.stderr).toContain("12");
+      expect(r.stderr).toMatch(/To Validate|Fixed|kj hu move/);
+    }
+    const turn = endTurn();
+    expect(turn.status).toBe(2);
+    expect(turn.stderr).toContain("KJC-TSK-0042");
+    // Lectura y edicion siguen libres: el bloqueo es sobre AVANZAR.
+    expect(bash("git status").status).toBe(0);
+  });
+
+  it("KJ_ALLOW_BOARD=1 es el escape auditado; y al desaparecer el pendiente todo vuelve a pasar", () => {
+    merged(12);
+    expect(bash("KJ_ALLOW_BOARD=1 git commit -m x").status).toBe(0);
+    expect(state().escape_events.some((e) => e.escape === "KJ_ALLOW_BOARD")).toBe(true);
+    const st = state();
+    st.sessions.s1.pending_moves = [];
+    fs.writeFileSync(statePath, JSON.stringify(st));
+    expect(bash("git commit -m x").status).toBe(0);
+    expect(endTurn().status).toBe(0);
+  });
+
+  it("sin card en la rama, el merge registra el PR y el remedio pide identificar la card", () => {
+    execSync("git checkout -q -b sin-card", { cwd: dir });
+    merged(7);
+    expect(state().sessions.s1.pending_moves[0]).toMatchObject({ card: null, pr: 7 });
+    expect(bash("git commit -m x").stderr).toMatch(/PR #7/);
+  });
+});


### PR DESCRIPTION
Board-sync gate, parte 1 de 2 (KJC-TSK-0765, épica Sentinel KJC-PCS-0071). Regla del usuario: **tras mergear una task o un bug, la card DEBE quedar movida en el tracker — NO PUEDE AVANZAR SI NO SE REGISTRA.** Nació de cuatro cards que se quedaron In Progress ya mergeadas: una regla en la memoria del agente se salta; un gate no.

- **PostToolUse** registra la card de la rama como `pending_moves` SOLO cuando gh confirma el merge ("merged pull request #N" en la respuesta del comando) — un merge fallido nunca bloquea (catch de codex).
- **PreToolUse** deniega `git commit`, `git push`, `gh pr create` y otro `gh pr merge` mientras haya pendientes, nombrando card + PR y el remedio (mover a To Validate/Fixed con sus commits: `update_card` del PG o `kj hu move`). `git push` y el **Stop gate** caen además por `violations()` de la lib compartida: el turno no puede cerrar con una card mergeada sin mover. Lectura y edición siguen libres — se bloquea AVANZAR.
- `KJ_ALLOW_BOARD=1` escape auditado por prefijo. Sin card en la rama, registra el PR y el remedio pide identificar la card.

Parte 2: limpiar el pendiente al ver la tool call MCP `update_card` con estado To Validate/Fixed/Done (el Sentinel ve las tool calls MCP) y `kj hu move` para HU Board; `board.status_cmd` para verificar contra el tracker real.

Tests contra los hooks generados (registro solo con merge confirmado, deny de avance + Stop, escape, rama sin card). Suite completa verde.
