### PR TITLE
feat(sentinel): board-sync clears the pending move on the real tracker call (KJC-TSK-0765)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -103,8 +103,25 @@ process.stdin.on("end", () => {
     // KJC-TSK-0765 board-sync: a merge that gh CONFIRMS leaves its card pending
     // in the tracker (the PreToolUse gate then refuses to advance until it is
     // moved). Recorded here, after the fact, so a failed merge never blocks.
+    const text = typeof response === "string" ? response : JSON.stringify(response);
+    // Closing states that count as "registered in the tracker" (PG statuses and
+    // HU Board moves). The pending entry is cleared by the REAL tool call that
+    // moved the card — never by a promise in the agent's prose.
+    const CLOSING = ["to validate", "to-validate", "fixed", "verified", "closed", "done", "done&validated", "validated"];
+    const clearPending = (cardId) => {
+      const state = load();
+      const s = session(state, sid);
+      const before = (s.pending_moves || []).length;
+      s.pending_moves = (s.pending_moves || []).filter((p) => p.card !== null && p.card !== cardId);
+      if (s.pending_moves.length !== before) save(state);
+    };
+    if (/__update_card$/.test(String(tool)) && /^mcp__/.test(String(tool))) {
+      const cid = /"cardId"\\s*:\\s*"([A-Za-z0-9-]+)"/.exec(text);
+      const st = /"status"\\s*:\\s*"([^"]+)"/.exec(text);
+      if (cid && st && CLOSING.includes(st[1].toLowerCase())) clearPending(cid[1].toUpperCase());
+      process.exit(0);
+    }
     if (tool === "Bash") {
-      const text = typeof response === "string" ? response : [response.stdout, response.stderr, response.output].filter(Boolean).join(String.fromCharCode(10));
       const merged = /merged pull request #(\\d+)/i.exec(text);
       if (merged) {
         const state = load();
@@ -113,6 +130,8 @@ process.stdin.on("end", () => {
         (s.pending_moves ||= []).push({ card: ref ? ref[0].toUpperCase() : null, pr: Number(merged[1]), at: Date.now() });
         save(state);
       }
+      const moved = /kj\\s+hu\\s+move\\s+([A-Za-z0-9-]+)\\s+([a-z&-]+)/i.exec(String(input.command || ""));
+      if (moved && CLOSING.includes(moved[2].toLowerCase()) && !/error|fail/i.test(text)) clearPending(moved[1].toUpperCase());
       process.exit(0);
     }
     const file = input.file_path || input.notebook_path;

--- a/tests/harden/sentinel-board-sync-clear.test.js
+++ b/tests/harden/sentinel-board-sync-clear.test.js
@@ -1,0 +1,62 @@
+// KJC-TSK-0765 (parte 2) — el pendiente de mover se LIMPIA con el registro
+// real en el tracker, visto por el PostToolUse: la tool call MCP update_card
+// del Planning Game con un estado de cierre para ESA card (el Sentinel ve las
+// tool calls MCP de Claude Code), o `kj hu move` para el HU Board.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync, execSync } from "node:child_process";
+import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
+
+let dir, gate, post, statePath;
+const env = { KJ_ALLOW_IDENTITY: "1" };
+const hook = (script, payload) => spawnSync("node", [script], { input: JSON.stringify({ session_id: "s1", ...payload }), encoding: "utf8", cwd: dir, env: { ...process.env, ...env } });
+const state = () => JSON.parse(fs.readFileSync(statePath, "utf8"));
+const seed = (...cards) => {
+  const st = fs.existsSync(statePath) ? state() : {};
+  st.sessions = { s1: { edited_sources: [], edited_tests: [], escapes: [], errors: [], blocks: 0, pending_moves: cards.map((card, i) => ({ card, pr: 100 + i, at: 1 })) } };
+  fs.writeFileSync(statePath, JSON.stringify(st));
+};
+const updateCard = (cardId, status, tool = "mcp__planning-game-personal__update_card") =>
+  hook(post, { tool_name: tool, tool_input: { updates: { status } }, tool_response: JSON.stringify({ message: "Card updated successfully", card: { cardId, status } }) });
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-board-clear-"));
+  execSync("git init -q -b main && git commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0042-demo", { cwd: dir });
+  installSentinelHooks({ projectDir: dir });
+  gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
+  post = path.join(dir, ".karajan", "harness", "posttooluse.mjs");
+  statePath = path.join(dir, ".karajan", "harness", "sentinel-state.json");
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("board-sync — limpieza del pendiente", () => {
+  it("update_card del PG con estado de cierre para ESA card limpia su pendiente (y solo el suyo)", () => {
+    seed("KJC-TSK-0042", "KJC-BUG-0007");
+    expect(updateCard("KJC-TSK-0042", "To Validate").status).toBe(0);
+    expect(state().sessions.s1.pending_moves.map((p) => p.card)).toEqual(["KJC-BUG-0007"]);
+    expect(updateCard("KJC-BUG-0007", "Fixed").status).toBe(0);
+    expect(state().sessions.s1.pending_moves).toHaveLength(0);
+    expect(hook(gate, { tool_name: "Bash", tool_input: { command: "git commit -m x" } }).status).toBe(0);
+  });
+
+  it("un update_card que NO cierra (In Progress, sin estado) no limpia nada; otro proyecto/tool tampoco", () => {
+    seed("KJC-TSK-0042");
+    updateCard("KJC-TSK-0042", "In Progress");
+    updateCard("KJC-TSK-0042", undefined);
+    hook(post, { tool_name: "mcp__planning-game-personal__get_card", tool_input: {}, tool_response: JSON.stringify({ card: { cardId: "KJC-TSK-0042", status: "To Validate" } }) });
+    expect(state().sessions.s1.pending_moves).toHaveLength(1);
+  });
+
+  it("kj hu move <card> a un estado de cierre limpia el pendiente (HU Board); un pendiente sin card se limpia con cualquier cierre", () => {
+    seed("KJC-TSK-0042", "KJC-TSK-0043");
+    hook(post, { tool_name: "Bash", tool_input: { command: "kj hu move KJC-TSK-0042 to-validate" }, tool_response: { stdout: "moved KJC-TSK-0042 -> to-validate" } });
+    expect(state().sessions.s1.pending_moves.map((p) => p.card)).toEqual(["KJC-TSK-0043"]);
+    // Un pendiente SIN card (rama sin ref) no se puede casar: cualquier cierre lo limpia.
+    seed(null);
+    updateCard("KJC-TSK-0099", "Done&Validated");
+    expect(state().sessions.s1.pending_moves).toHaveLength(0);
+  });
+});

--- a/tests/harden/sentinel-board-sync-clear.test.js
+++ b/tests/harden/sentinel-board-sync-clear.test.js
@@ -24,7 +24,8 @@ const updateCard = (cardId, status, tool = "mcp__planning-game-personal__update_
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-board-clear-"));
-  execSync("git init -q -b main && git commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0042-demo", { cwd: dir });
+  // user.email/name explicitos: el runner de CI no tiene config global de git.
+  execSync("git init -q -b main && git config user.email a@b.c && git config user.name t && git commit -q --allow-empty -m init && git checkout -q -b feat/KJC-TSK-0042-demo", { cwd: dir });
   installSentinelHooks({ projectDir: dir });
   gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
   post = path.join(dir, ".karajan", "harness", "posttooluse.mjs");


### PR DESCRIPTION
Board-sync gate, parte 2 de 2 (KJC-TSK-0765) — cierra la card.

El pendiente de mover se limpia con el REGISTRO REAL en el tracker, visto por el PostToolUse (el Sentinel ve también las tool calls MCP de Claude Code):
- `mcp__planning-game*__update_card` cuya respuesta trae `cardId` + un estado de cierre (To Validate, Fixed, Verified, Closed, Done, Done&Validated) limpia el pendiente de ESA card y solo el suyo; `get_card` o un update sin estado de cierre no limpian nada.
- `kj hu move <card> <estado-de-cierre>` (HU Board) hace lo mismo cuando el comando no falla.
- Un pendiente sin card (rama sin ref) no se puede casar: cualquier cierre lo limpia.

Con la parte 1 (#1494) el ciclo queda cerrado: merge confirmado → pendiente → nada avanza ni el turno cierra → la tool call que mueve la card abre el gate. Nunca por una promesa en la prosa del agente.

Tests contra el hook generado. Suite completa verde (un flaky conocido en subloop-limits, reconfirmado verde). APPROVED codex.
