### PR TITLE
fix(sentinel): detect a merge by PR state, gh is silent under tool calls (KJC-TSK-0765)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -93,6 +93,7 @@ const POST_BODY = `#!/usr/bin/env node
 // Records deterministic method facts per session; never blocks, never fails
 // a tool call (PostToolUse, always exit 0).
 import { relative } from "node:path";
+import { spawnSync } from "node:child_process";
 import { CODE, TESTS, ROOT, CARD, branchOf, load, save, session } from "./sentinel-lib.mjs";
 const ESCAPES = ["KJ_ALLOW_WRITE", "KJ_ALLOW_REWRITE", "KJ_ALLOW_NO_CARD", "KJ_ALLOW_NO_TESTS", "KJ_ALLOW_PII", "KJ_ALLOW_POLICY", "KJ_ALLOW_IDENTITY", "KJ_ALLOW_BOARD"];
 let raw = "";
@@ -122,12 +123,23 @@ process.stdin.on("end", () => {
       process.exit(0);
     }
     if (tool === "Bash") {
-      const merged = /merged pull request #(\\d+)/i.exec(text);
-      if (merged) {
+      const cmdText = String(input.command || "");
+      // gh prints "merged pull request #N" only on a TTY: under a tool call the
+      // success line is ABSENT (found live on the first dogfood merge). The
+      // authoritative signal is the PR state itself: one gh pr view per merge.
+      const mergeCmd = /\\bgh\\s+pr\\s+merge(\\s+(\\d+))?/.exec(cmdText);
+      const said = /merged pull request #(\\d+)/i.exec(text);
+      let mergedPr = said ? Number(said[1]) : null;
+      if (mergedPr === null && mergeCmd) {
+        const args = ["pr", "view", ...(mergeCmd[2] ? [mergeCmd[2]] : []), "--json", "number,state"];
+        const r = spawnSync("gh", args, { cwd: ROOT, encoding: "utf8" });
+        try { const v = JSON.parse(r.status === 0 ? r.stdout : "null"); if (v && v.state === "MERGED") mergedPr = Number(v.number); } catch { /* unknown = not confirmed */ }
+      }
+      if (mergedPr !== null) {
         const state = load();
         const s = session(state, sid);
         const ref = CARD.exec(branchOf() || "");
-        (s.pending_moves ||= []).push({ card: ref ? ref[0].toUpperCase() : null, pr: Number(merged[1]), at: Date.now() });
+        (s.pending_moves ||= []).push({ card: ref ? ref[0].toUpperCase() : null, pr: mergedPr, at: Date.now() });
         save(state);
       }
       const moved = /kj\\s+hu\\s+move\\s+([A-Za-z0-9-]+)\\s+([a-z&-]+)/i.exec(String(input.command || ""));

--- a/tests/harden/sentinel-board-sync.test.js
+++ b/tests/harden/sentinel-board-sync.test.js
@@ -51,6 +51,23 @@ describe("board-sync gate", () => {
     expect(pending[0]).toMatchObject({ card: "KJC-TSK-0042", pr: 12 });
   });
 
+  it("bajo una tool call gh NO imprime el mensaje de exito: el estado del PR (gh pr view) es la señal autoritativa", () => {
+    // Hallado en vivo en el primer merge con el gate activo: salida vacia, pendiente sin registrar.
+    const bin = path.join(dir, "fakebin");
+    fs.mkdirSync(bin);
+    const fakeGh = (st) => fs.writeFileSync(path.join(bin, "gh"), `#!/bin/sh\necho '{"number":21,"state":"${st}"}'\n`, { mode: 0o755 });
+    const silentMerge = (pr) => spawnSync("node", [post], {
+      input: JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command: `gh auth switch --user x && gh pr merge ${pr} --squash` }, tool_response: { stdout: "", stderr: "" } }),
+      encoding: "utf8", cwd: dir, env: { ...process.env, ...env, PATH: `${bin}:${process.env.PATH}` },
+    });
+    fakeGh("OPEN");
+    expect(silentMerge(21).status).toBe(0);
+    expect(fs.existsSync(statePath) ? (state().sessions?.s1?.pending_moves ?? []) : []).toHaveLength(0);
+    fakeGh("MERGED");
+    expect(silentMerge(21).status).toBe(0);
+    expect(state().sessions.s1.pending_moves[0]).toMatchObject({ card: "KJC-TSK-0042", pr: 21 });
+  });
+
   it("con una card pendiente: commit, push, nuevo PR y cierre de turno se deniegan nombrando card+PR y el remedio", () => {
     merged(12);
     for (const cmd of ["git commit -m x", "git push origin feat/x", "gh pr create --title t", "gh pr merge 13"]) {


### PR DESCRIPTION
Hallado en vivo en el primer merge con el board-sync gate activo: bajo una tool call gh no imprime el mensaje de exito (solo en TTY), asi que el PostToolUse no registraba el pendiente. Ahora, si el comando es gh pr merge y no hay mensaje, consulta gh pr view --json number,state y registra solo con state MERGED (un merge fallido sigue sin bloquear). Test con gh falso en PATH: OPEN no registra, MERGED registra. APPROVED agy.