### PR TITLE
fix(sentinel): wire posttooluse for bash and mcp update_card (KJC-TSK-0765)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -706,6 +706,11 @@ export function installSentinelHooks({ projectDir = process.cwd(), logger = cons
       { event: "PreToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "pretooluse-sentinel.mjs" },
       { event: "PreToolUse", matcher: "Bash", script: "pretooluse-sentinel.mjs" },
       { event: "PostToolUse", matcher: "Write|Edit|MultiEdit|NotebookEdit", script: "posttooluse.mjs" },
+      // KJC-TSK-0765 board-sync: the merge (Bash) and the tracker move (MCP
+      // update_card) are observed AFTER the fact — found live: with only the
+      // edit matchers wired, the board-sync recorder never ran in production.
+      { event: "PostToolUse", matcher: "Bash", script: "posttooluse.mjs" },
+      { event: "PostToolUse", matcher: "mcp__.*__update_card", script: "posttooluse.mjs" },
       { event: "Stop", script: "stop.mjs" },
     ],
   });

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -475,7 +475,12 @@ describe("installSentinelHooks settings merge", () => {
     const cfg = JSON.parse(fs.readFileSync(settings, "utf8"));
     expect(cfg.model).toBe("opus");
     expect(JSON.stringify(cfg.hooks.PostToolUse)).toContain("echo mine");
-    expect((JSON.stringify(cfg.hooks.PostToolUse).match(/posttooluse\.mjs/g) || []).length).toBe(1);
+    // KJC-TSK-0765: three PostToolUse matchers (edit tools, Bash, MCP update_card),
+    // each wired exactly once across two installs.
+    expect((JSON.stringify(cfg.hooks.PostToolUse).match(/posttooluse\.mjs/g) || []).length).toBe(3);
+    const matchers = cfg.hooks.PostToolUse.map((e) => e.matcher);
+    expect(matchers).toContain("Bash");
+    expect(matchers.some((m) => /update_card/.test(m || ""))).toBe(true);
     expect((JSON.stringify(cfg.hooks.Stop).match(/stop\.mjs/g) || []).length).toBe(1);
   });
 


### PR DESCRIPTION
Segunda causa raíz hallada en vivo (KJC-TSK-0765): el PostToolUse solo estaba cableado para `Write|Edit|MultiEdit|NotebookEdit`, así que ni el merge (Bash) ni la tool call MCP `update_card` llegaban a `posttooluse.mjs` — el board-sync era letra muerta en producción aunque los tests del script pasaran.

Se cablean los matchers `Bash` y `mcp__.*__update_card` (cada uno una sola vez, idempotente a través de reinstalaciones). Test del wiring actualizado (3 entradas de posttooluse, matchers presentes). Suite completa verde. APPROVED agy.

Con #1496 (detección del merge por estado del PR, porque gh es mudo bajo una tool call), el gate queda operativo de verdad en el flujo real de Claude Code.
