### PR TITLE
fix(sentinel): parse the escaped mcp response when clearing a pending move (KJC-TSK-0765)

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -117,8 +117,11 @@ process.stdin.on("end", () => {
       if (s.pending_moves.length !== before) save(state);
     };
     if (/__update_card$/.test(String(tool)) && /^mcp__/.test(String(tool))) {
-      const cid = /"cardId"\\s*:\\s*"([A-Za-z0-9-]+)"/.exec(text);
-      const st = /"status"\\s*:\\s*"([^"]+)"/.exec(text);
+      // The MCP response reaches the hook as {content:[{text:"<json>"}]}: once
+      // stringified, the inner quotes are ESCAPED — match both forms (found live:
+      // the first real update_card did not clear its pending entry).
+      const cid = /\\\\?"cardId\\\\?"\\s*:\\s*\\\\?"([A-Za-z0-9-]+)\\\\?"/.exec(text);
+      const st = /\\\\?"status\\\\?"\\s*:\\s*\\\\?"([^"\\\\]+)\\\\?"/.exec(text);
       if (cid && st && CLOSING.includes(st[1].toLowerCase())) clearPending(cid[1].toUpperCase());
       process.exit(0);
     }

--- a/tests/harden/sentinel-board-sync-clear.test.js
+++ b/tests/harden/sentinel-board-sync-clear.test.js
@@ -43,6 +43,13 @@ describe("board-sync — limpieza del pendiente", () => {
     expect(hook(gate, { tool_name: "Bash", tool_input: { command: "git commit -m x" } }).status).toBe(0);
   });
 
+  it("la respuesta MCP real llega como content[].text con el JSON ESCAPADO: tambien limpia (hallado en vivo)", () => {
+    seed("KJC-TSK-0042");
+    const mcpShape = { content: [{ type: "text", text: JSON.stringify({ message: "Card updated successfully", card: { cardId: "KJC-TSK-0042", status: "To Validate" } }) }] };
+    hook(post, { tool_name: "mcp__planning-game-personal__update_card", tool_input: { updates: { status: "To Validate" } }, tool_response: mcpShape });
+    expect(state().sessions.s1.pending_moves).toHaveLength(0);
+  });
+
   it("un update_card que NO cierra (In Progress, sin estado) no limpia nada; otro proyecto/tool tampoco", () => {
     seed("KJC-TSK-0042");
     updateCard("KJC-TSK-0042", "In Progress");


### PR DESCRIPTION
Tercer hallazgo en vivo del board-sync (KJC-TSK-0765): la respuesta MCP llega al hook como `content[].text` con el JSON **escapado**, y el regex de `cardId`/`status` no casaba — el primer `update_card` real no limpió el pendiente.

Regex tolerante a comillas escapadas + test con la forma real de la respuesta.

Verificado en vivo: con este fix, el `update_card` de la card 0765 limpió el pendiente y el commit de este mismo fix pasó el gate. Vuelta completa: merge → pendiente → bloqueo → tool call real del tracker → gate abierto. APPROVED agy.
