### PR TITLE
feat(policy): pure policy report — warns, open denies, grants, renewals (KJC-TSK-0767)

### DIFF
--- a/src/policy/report.js
+++ b/src/policy/report.js
@@ -1,0 +1,94 @@
+/**
+ * PL-E (KJC-TSK-0767) — el informe de policy, PURO (líneas del decision log +
+ * excepciones + policy + reloj ⇒ objeto determinista; cero I/O, cero LLM).
+ * Responde: ¿qué reglas avisan y cuánto (gana dientes con datos)?, ¿qué
+ * denegaciones siguen abiertas (la renuncia deja rastro)?, ¿qué concesiones
+ * viven, vencen o se renuevan (la renovación es señal)?
+ */
+import { verifyDecisionChain } from "@karajan-family/governance";
+
+const DAY_MS = 86_400_000;
+const WARN_SIGNAL_MIN = 5;
+
+/** enforcement/class de una regla según la policy cargada (null si no se sabe). */
+function ruleMeta(policy, ruleId) {
+  if (!policy) return {};
+  if (ruleId.startsWith("defaults.")) return { enforcement: "deny", class: "security" };
+  const m = /^roles\.([^.]+)\.([^.]+)/.exec(ruleId);
+  const spec = m ? policy.roles?.[m[1]]?.[m[2]] : policy.invariants?.find((i) => i.id === ruleId);
+  if (!spec) return {};
+  return { enforcement: spec.enforcement || "warn", ...(spec.class ? { class: spec.class } : {}) };
+}
+
+function parseDecisions(lines) {
+  const records = [];
+  let discarded = 0;
+  for (const line of lines) {
+    try {
+      const rec = JSON.parse(line);
+      if (typeof rec === "object" && rec !== null) records.push(rec);
+      else discarded += 1;
+    } catch {
+      discarded += 1;
+    }
+  }
+  return { records, discarded };
+}
+
+// Abiertas = denies posteriores al último allow/exempt: el log acaba en
+// rechazo sin que nada haya pasado después. Heurística declarada — el log
+// no lleva rama ni autor, así que no distingue "arreglado" de "abandonado".
+const lastResolvedIndex = (records) => records.findLastIndex((r) => r.decision === "allow" || r.decision === "exempt");
+
+function tallyRules(records, policy, lastResolved) {
+  const rules = new Map();
+  const row = (id) => {
+    if (!rules.has(id)) rules.set(id, { rule_id: id, ...ruleMeta(policy, id), warns: 0, denies: 0, exempts: 0, open: 0 });
+    return rules.get(id);
+  };
+  records.forEach((rec, i) => {
+    for (const id of rec.warn_rule_ids ?? []) row(id).warns += 1;
+    if (rec.decision === "deny") for (const id of rec.rule_ids ?? []) { row(id).denies += 1; if (i > lastResolved) row(id).open += 1; }
+    if (rec.decision === "exempt") for (const id of rec.rule_ids ?? []) row(id).exempts += 1;
+  });
+  return [...rules.values()].toSorted((a, b) => (b.denies + b.warns) - (a.denies + a.warns));
+}
+
+function tallyGrants(exceptionRecords, now, soonDays) {
+  const perm = exceptionRecords.filter((e) => e?.scopeKind === "permanente");
+  const alive = perm.filter((e) => Date.parse(e.expiresAt) > now.getTime());
+  const expired = perm.filter((e) => !(Date.parse(e.expiresAt) > now.getTime()));
+  const soon = alive.filter((e) => Date.parse(e.expiresAt) - now.getTime() <= soonDays * DAY_MS);
+  const counts = Map.groupBy(perm, (e) => e.rule_id);
+  const renewals = [...counts].filter(([, v]) => v.length >= 2).map(([rule_id, v]) => ({ rule_id, count: v.length }));
+  return { alive, expired, soon, renewals, point: exceptionRecords.length - perm.length };
+}
+
+function signalsFor(rules, grants) {
+  const out = [];
+  for (const g of grants.renewals) out.push(`[${g.rule_id}] concedida ${g.count} veces — una excepción que se renueva ya no es una excepción: es la política pidiendo cambio (PR a .karajan/policy.yml)`);
+  for (const r of rules) {
+    if (r.warns >= WARN_SIGNAL_MIN && r.denies === 0 && r.enforcement !== "deny") out.push(`[${r.rule_id}] ha avisado ${r.warns} veces y nunca ha bloqueado — decide: promover a enforcement=deny o retirarla; un aviso perpetuo es ruido`);
+    if (r.open > 0) out.push(`[${r.rule_id}] ${r.open} denegación(es) abierta(s) — el log acaba en rechazo: ¿arreglo pendiente, excepción por pedir, o renuncia?`);
+  }
+  for (const g of grants.soon) out.push(`[${g.rule_id}] vence ${g.expiresAt} — al vencer vuelve a bloquear sola; renueva por su cauce o deja que caduque`);
+  return out;
+}
+
+/**
+ * @returns {{chain: object, decisions: object, rules: object[], grants: object, signals: string[]}}
+ */
+export function buildPolicyReport({ decisionLines = [], exceptionRecords = [], policy = null, now = new Date(), soonDays = 7 } = {}) {
+  const chain = decisionLines.length ? verifyDecisionChain(decisionLines) : { ok: true, length: 0 };
+  const { records, discarded } = parseDecisions(decisionLines);
+  const count = (d) => records.filter((r) => r.decision === d).length;
+  const chokepoints = Object.fromEntries([...Map.groupBy(records, (r) => r.chokepoint ?? "unknown")].map(([k, v]) => [k, v.length]));
+  const lastResolved = lastResolvedIndex(records);
+  const rules = tallyRules(records, policy, lastResolved);
+  const grants = tallyGrants(exceptionRecords, now, soonDays);
+  const decisions = {
+    total: records.length, discarded, allow: count("allow"), deny: count("deny"), exempt: count("exempt"),
+    open: records.filter((r, i) => r.decision === "deny" && i > lastResolved).length, chokepoints,
+  };
+  return { chain, decisions, rules, grants, signals: signalsFor(rules, grants) };
+}

--- a/tests/policy/report.test.js
+++ b/tests/policy/report.test.js
@@ -1,0 +1,100 @@
+// PL-E (KJC-TSK-0767) — kj policy report: el dato que falta para que "una
+// regla nace avisando y gana dientes" y "la renuncia deja rastro" sean
+// afirmaciones comprobables, no frases. Módulo PURO: líneas del decision
+// log + registros de excepciones + policy + reloj ⇒ informe determinista.
+
+import { describe, it, expect } from "vitest";
+import { createHash } from "node:crypto";
+import { buildPolicyReport } from "../../src/policy/report.js";
+
+const sha = (s) => createHash("sha256").update(s, "utf8").digest("hex");
+/** Encadena entradas como lo haría recordDecision (prev = sha256 de la línea previa). */
+const chain = (entries) => {
+  const lines = [];
+  for (const e of entries) lines.push(JSON.stringify({ ts: "2026-08-21T00:00:00Z", ...e, prev: lines.length ? sha(lines.at(-1)) : null }));
+  return lines;
+};
+const NOW = new Date("2026-08-21T12:00:00Z");
+const day = (n) => new Date(NOW.getTime() + n * 86_400_000).toISOString();
+const perm = (rule_id, days, extra = {}) => ({ rule_id, scopeKind: "permanente", expiresAt: day(days), justification: "x", ...extra });
+const policy = {
+  roles: { coder: { write: { enforcement: "deny", class: "security" }, shell: { enforcement: "warn" } } },
+  invariants: [{ id: "loc.max", enforcement: "warn" }],
+};
+
+describe("buildPolicyReport — decisiones", () => {
+  it("cuenta por decisión y por chokepoint y verifica la cadena", () => {
+    const lines = chain([
+      { decision: "deny", chokepoint: "commit", rule_ids: ["roles.coder.write.deny"] },
+      { decision: "exempt", chokepoint: "review", rule_ids: ["roles.coder.shell.deny"] },
+      { decision: "allow", chokepoint: "commit" },
+    ]);
+    const r = buildPolicyReport({ decisionLines: lines, now: NOW });
+    expect(r.chain).toEqual({ ok: true, length: 3 });
+    expect(r.decisions).toMatchObject({ total: 3, allow: 1, deny: 1, exempt: 1, chokepoints: { commit: 2, review: 1 } });
+  });
+
+  it("cadena rota se dice (ok=false, at) y el informe sigue contando; líneas no parseables se cuentan como discarded", () => {
+    const lines = chain([{ decision: "deny", rule_ids: ["a"] }, { decision: "allow" }]);
+    lines[0] = lines[0].replace('"deny"', '"allow"');
+    const r = buildPolicyReport({ decisionLines: [...lines, "{nope"], now: NOW });
+    expect(r.chain).toMatchObject({ ok: false, at: 1 });
+    expect(r.decisions).toMatchObject({ total: 2, discarded: 1 });
+  });
+
+  it("tabla por regla: warn_rule_ids cuenta avisos; deny/exempt por rule_ids; enforcement y clase salen de la policy", () => {
+    const lines = chain([
+      { decision: "allow", chokepoint: "commit", warn_rule_ids: ["roles.coder.shell.deny", "loc.max"] },
+      { decision: "allow", chokepoint: "commit", warn_rule_ids: ["loc.max"] },
+      { decision: "deny", chokepoint: "commit", rule_ids: ["roles.coder.write.deny"] },
+      { decision: "exempt", chokepoint: "commit", rule_ids: ["roles.coder.shell.deny"] },
+      { decision: "allow", chokepoint: "commit" },
+    ]);
+    const r = buildPolicyReport({ decisionLines: lines, policy, now: NOW });
+    const by = Object.fromEntries(r.rules.map((x) => [x.rule_id, x]));
+    expect(by["loc.max"]).toMatchObject({ warns: 2, denies: 0, exempts: 0, enforcement: "warn" });
+    expect(by["roles.coder.shell.deny"]).toMatchObject({ warns: 1, exempts: 1, enforcement: "warn" });
+    expect(by["roles.coder.write.deny"]).toMatchObject({ denies: 1, enforcement: "deny", class: "security" });
+    expect(by["roles.coder.write.deny"].open).toBe(0);
+  });
+
+  it("denegaciones abiertas = denies posteriores al último allow/exempt (el log acaba en rechazo)", () => {
+    const lines = chain([
+      { decision: "deny", rule_ids: ["r1"] },
+      { decision: "allow", chokepoint: "commit" },
+      { decision: "deny", rule_ids: ["r1"] },
+      { decision: "deny", rule_ids: ["r1", "r2"] },
+    ]);
+    const r = buildPolicyReport({ decisionLines: lines, now: NOW });
+    const by = Object.fromEntries(r.rules.map((x) => [x.rule_id, x]));
+    expect(by.r1).toMatchObject({ denies: 3, open: 2 });
+    expect(by.r2).toMatchObject({ denies: 1, open: 1 });
+    expect(r.decisions.open).toBe(2);
+  });
+
+});
+
+describe("buildPolicyReport — concesiones", () => {
+  it("separa vivas, vencidas y próximas a vencer; las puntuales solo se cuentan", () => {
+    const recs = [perm("a", 30), perm("b", -1), perm("c", 3), { rule_id: "d", scopeKind: "puntual", diffHash: "h" }, { rule_id: "e" }];
+    const r = buildPolicyReport({ exceptionRecords: recs, now: NOW, soonDays: 7 });
+    expect(r.grants.alive.map((g) => g.rule_id)).toEqual(["a", "c"]);
+    expect(r.grants.expired.map((g) => g.rule_id)).toEqual(["b"]);
+    expect(r.grants.soon.map((g) => g.rule_id)).toEqual(["c"]);
+    expect(r.grants.point).toBe(2);
+  });
+
+  it("renovaciones: ≥2 permanentes sobre la misma regla (vencidas incluidas) son señal de política pidiendo cambio", () => {
+    const recs = [perm("a", -30), perm("a", -1), perm("a", 20), perm("b", 10)];
+    const r = buildPolicyReport({ exceptionRecords: recs, now: NOW });
+    expect(r.grants.renewals).toEqual([{ rule_id: "a", count: 3 }]);
+    expect(r.signals.some((s) => /a.*3/.test(s))).toBe(true);
+  });
+
+  it("señales: regla warn con avisos repetidos y sin deny pide decisión (promover o retirar); sin datos no hay señales", () => {
+    const lines = chain(Array.from({ length: 5 }, () => ({ decision: "allow", chokepoint: "commit", warn_rule_ids: ["loc.max"] })));
+    const r = buildPolicyReport({ decisionLines: lines, policy, now: NOW });
+    expect(r.signals.some((s) => /loc\.max/.test(s) && /5/.test(s))).toBe(true);
+    expect(buildPolicyReport({ now: NOW }).signals).toEqual([]);
+  });
+});


### PR DESCRIPTION
## PL-E (1/2): `buildPolicyReport` — the data behind two claims

Card: KJC-TSK-0767 · Epic: KJC-PCS-0074 (policy as code)

Two sentences we state about the policy layer have no data behind them today: *"a rule is born warning and gains teeth once the false positives have been seen"* and *"if asking for an exception is cheaper than giving up, giving up leaves a trace"*. Warns are never sealed, nobody counts denies, grants or renewals.

This PR adds the PURE report module (no I/O, no LLM — evidence must be reproducible in CI):

- `buildPolicyReport({ decisionLines, exceptionRecords, policy, now, soonDays })`
- **chain**: integrity of the hash-chained decision log (`verifyDecisionChain`), reported — never hidden — while the counts still run.
- **decisions**: totals by decision and by chokepoint, discarded lines, and **open** denials (denies after the last allow/exempt — the log ends in rejection). Declared heuristic: the log carries no branch/author, so it cannot tell "fixed" from "abandoned"; it says so.
- **rules**: per rule — warns (from `warn_rule_ids`), denies, exempts, open; `enforcement`/`class` resolved from the loaded policy (roles, invariants, `defaults.*` = security).
- **grants**: permanent exceptions alive / expired / expiring within `soonDays`; **renewals** (≥2 permanents on the same rule, expired included — that IS the sediment); point exceptions counted.
- **signals**: human hints — a rule granted N times is the policy asking for change; a warn rule that warned ≥5 times and never blocked asks for a decision (promote or retire); open denials; grants about to expire.

Part 2 wires `kj policy report` (human + `--json`) and seals `warn_rule_ids` on the commit allow so warns become countable.

Tests: 7 pure cases (chain ok/broken, per-rule table, open denials, grants partition, renewals, signals, empty input).
