### PR TITLE
feat(policy): kj policy report and warn_rule_ids sealed on the commit allow (KJC-TSK-0767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kj policy report` — the data behind "a rule is born warning and gains teeth" and "giving up leaves a trace"** (PL-E, KJC-TSK-0767, epic KJC-PCS-0074): two claims the policy layer made with nothing behind them — warns were never sealed and nobody counted denies, grants or renewals. Now the commit allow seals the rules that WARNED (`warn_rule_ids`), and a deterministic report (no I/O beyond the two jsonl, no LLM — evidence must be reproducible in CI) answers per rule: warns, denies, exempts and OPEN denials (denies after the last allow/exempt — the log ends in rejection; declared heuristic, the log carries no branch or author), with `enforcement`/`class` resolved from the loaded policy; grants alive / expired / expiring (`--soon <days>`), point exceptions, and renewals (≥2 permanents on one rule, expired included — that IS the sediment); and signals: a rule granted N times is the policy asking for change, a warn rule that warned ≥5 times and never blocked asks for a decision (promote or retire), open denials, grants about to expire. `--json` for CI or dashboards; a broken hash chain is exit 1 — a report over a tampered log is not a report.
+
 ## [4.21.0] - 2026-08-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ With a declared `.karajan/policy.yml`, the policy layer enforces at three tiers,
 
 Tier B is the guarantee floor — hosts without hooks lose A, never B; C re-verifies both. Security-class rules and consumer defaults are non-exemptable at every tier: no escape, no arbitration, no grant.
 
+Every chokepoint decision lands in a hash-chained log (`kj policy anchor` seals its head in git), and `kj policy report` turns that log into evidence of process: per rule, how often it warned, denied or was exempted, which denials are still open, which grants are alive, expired or renewed — so a rule "gains teeth" on data, not on a hunch, and a renewed exception is read for what it is: the policy asking to change.
+
 ## Headless mode
 
 The classic multiagent pipeline lives on for CI and automation: `kj run "<task>"` orchestrates coder/reviewer/tester subprocess roles unattended, with the same gates. Agents and CI pass `--non-interactive` (or `KJ_NON_INTERACTIVE=1`): safe gates auto-answer, FAIL findings stop the run with a real exit code. `kj advanced` lists the full surface. [Headless mode docs](https://karajancode.com/docs/v4/headless/).

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -5,6 +5,7 @@ import { architectCommand } from "../commands/architect.js";
 import { onboardCommand } from "../commands/onboard.js";
 import { startCommand } from "../commands/start.js";
 import { identityCommand } from "../commands/identity.js";
+import { policyCommand } from "../commands/policy.js";
 import { ragIndexCommand, ragQueryCommand, ragInstallHooksCommand, ragEvalCommand } from "../commands/rag.js";
 import { qmdQueryCommand } from "../commands/qmd.js";
 import { ragMcpCommand } from "../commands/rag-mcp.js";
@@ -320,7 +321,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--strict", "Exit 2 si deny")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-eval", flags, async ({ config }) => {
-        const { policyCommand } = await import("../commands/policy.js");
         process.exitCode = await policyCommand({ action: "eval", config, flags });
       });
     });
@@ -331,7 +331,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--reason <text>", "Justificación escrita en el momento")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-grant", flags, async ({ config }) => {
-        const { policyCommand } = await import("../commands/policy.js");
         process.exitCode = await policyCommand({ action: "grant", config, flags });
       });
     });
@@ -348,7 +347,6 @@ export function registerMeta(program, { pkgVersion }) {
     .description("Verifica la cadena del decision log y sella su head-hash en .karajan/policy-anchor.json (trackeado) — anclaje temporal en la historia de git, GOV-C2")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-anchor", flags, async ({ config }) => {
-        const { policyCommand } = await import("../commands/policy.js");
         process.exitCode = await policyCommand({ action: "anchor", config, flags });
       });
     });
@@ -358,7 +356,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--json", "Machine-readable")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-report", flags, async ({ config }) => {
-        const { policyCommand } = await import("../commands/policy.js");
         process.exitCode = await policyCommand({ action: "report", config, flags });
       });
     });
@@ -370,7 +367,6 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--json", "Machine-readable")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-check", flags, async ({ config }) => {
-        const { policyCommand } = await import("../commands/policy.js");
         process.exitCode = await policyCommand({ action: "check", config, flags });
       });
     });

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -352,6 +352,16 @@ export function registerMeta(program, { pkgVersion }) {
         process.exitCode = await policyCommand({ action: "anchor", config, flags });
       });
     });
+  policyCmd.command("report")
+    .description("Informe determinista del decision log y las concesiones: avisos/denegaciones/exenciones por regla, denegaciones abiertas, concesiones vivas/vencidas/renovadas y señales — cadena rota = exit 1 (PL-E)")
+    .option("--soon <days>", "Días para considerar una concesión 'próxima a vencer'", "7")
+    .option("--json", "Machine-readable")
+    .action(async (flags) => {
+      await withConfig(pkgVersion, "policy-report", flags, async ({ config }) => {
+        const { policyCommand } = await import("../commands/policy.js");
+        process.exitCode = await policyCommand({ action: "report", config, flags });
+      });
+    });
   policyCmd.command("check")
     .description("Comprueba el diff (staged, o base...head con --range) contra la policy — warn por defecto; --strict devuelve exit 2 si hay violación enforcement=deny (tier C, merge-blocking)")
     .option("--role <role>", "Rol del agente", "coder")

--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -12,7 +12,8 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
-import { loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
+import { loadExceptionRecords, loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
+import { buildPolicyReport } from "../policy/report.js";
 import { verifyDecisionChain } from "@karajan-family/governance";
 
 const execFileAsync = promisify(execFile);
@@ -121,6 +122,39 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
       logger.error?.(`policy grant: ${err.message}`);
       return 1;
     }
+  }
+
+  // PL-E (KJC-TSK-0767): el informe — evidencia de proceso determinista
+  // sobre los dos jsonl. Cadena rota = exit 1: un informe sobre un log
+  // manipulado no es un informe. Todo lo demás es informativo (exit 0).
+  if (action === "report") {
+    let decisionLines = [];
+    try {
+      decisionLines = readFileSync(join(projectDir, ".karajan", "policy-decisions.jsonl"), "utf8").split("\n").filter((l) => l.trim());
+    } catch { /* sin decisiones aún: el informe lo dice con ceros */ }
+    const exc = loadExceptionRecords(projectDir);
+    const soonDays = Number(flags.soon ?? 7);
+    const report = buildPolicyReport({ decisionLines, exceptionRecords: exc.records, policy, soonDays: Number.isFinite(soonDays) ? soonDays : 7 });
+    if (flags.json) {
+      logger.info?.(JSON.stringify({ ...report, exceptions_discarded: exc.discarded }));
+      return report.chain.ok ? 0 : 1;
+    }
+    const { chain, decisions: d, rules, grants: g } = report;
+    if (chain.ok) logger.info?.(`✓ decision log: cadena íntegra (${chain.length} decisiones)`);
+    else logger.error?.(`✗ decision log: cadena rota en la entrada ${chain.at} (${chain.reason}) — el log ha sido manipulado`);
+    if (d.discarded > 0 || exc.discarded > 0) logger.warn?.(`⚠ líneas corruptas descartadas: ${d.discarded} en decisiones, ${exc.discarded} en excepciones`);
+    const cps = Object.entries(d.chokepoints).map(([k, v]) => `${k} ${v}`).join(" · ") || "ninguno";
+    logger.info?.(`decisiones: allow ${d.allow} · deny ${d.deny} · exempt ${d.exempt} · abiertas ${d.open} (chokepoints: ${cps})`);
+    logger.info?.(rules.length > 0 ? "reglas (ordenadas por fricción):" : "reglas: ninguna ha avisado ni denegado todavía");
+    for (const r of rules) {
+      const meta = [r.enforcement && `enforcement=${r.enforcement}`, r.class && `class=${r.class}`].filter(Boolean).join(" ");
+      logger.info?.(`  [${r.rule_id}] ${meta} — warn ${r.warns} · deny ${r.denies} · exempt ${r.exempts} · abiertas ${r.open}`);
+    }
+    logger.info?.(`concesiones: vivas ${g.alive.length} (próximas a vencer ${g.soon.length}) · vencidas ${g.expired.length} · puntuales ${g.point}`);
+    for (const e of g.alive) logger.info?.(`  [${e.rule_id}] hasta ${e.expiresAt} — ${e.who?.git ?? "?"}: ${e.justification ?? "sin justificación"}`);
+    logger.info?.(report.signals.length > 0 ? "señales:" : "señales: ninguna");
+    for (const s of report.signals) logger.warn?.(`  ⚠ ${s}`);
+    return chain.ok ? 0 : 1;
   }
 
   if (action === "eval") {

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -289,8 +289,10 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
     console.log(res.ok
       ? `✓ verdict ok — approved by ${res.verdict.reviewer} (diff ${res.verdict.diffHash.slice(0, 12)})`
       : `✗ ${res.reason}`);
-    // GOV-C: el allow del chokepoint de COMMIT es evidencia — se sella.
-    if (res.ok) seal("allow");
+    // GOV-C: el allow del chokepoint de COMMIT es evidencia — se sella. PL-E
+    // (KJC-TSK-0767): con las reglas que AVISARON, para que "nace avisando y
+    // gana dientes" se decida con datos (kj policy report), no a ciegas.
+    if (res.ok) seal("allow", gate.warns.length > 0 ? { warn_rule_ids: gate.warns.map((w) => w.rule_id) } : {});
     process.exitCode = res.ok ? 0 : 1;
     return res;
   }

--- a/src/policy/exceptions.js
+++ b/src/policy/exceptions.js
@@ -24,13 +24,23 @@ function defaultIdentity(projectDir) {
  * @returns {{standing: object[], discarded: number}}
  */
 export function loadStandingExceptions(projectDir) {
+  const { records, discarded } = loadExceptionRecords(projectDir);
+  return { standing: records.filter((rec) => rec.scopeKind === "permanente"), discarded };
+}
+
+/**
+ * TODOS los registros del jsonl (permanentes y puntuales) con el mismo parse
+ * tolerante — el informe (PL-E) cuenta también las puntuales.
+ * @returns {{records: object[], discarded: number}}
+ */
+export function loadExceptionRecords(projectDir) {
   let raw;
   try {
     raw = readFileSync(join(projectDir, ".karajan", "policy-exceptions.jsonl"), "utf8");
   } catch {
-    return { standing: [], discarded: 0 };
+    return { records: [], discarded: 0 };
   }
-  const standing = [];
+  const records = [];
   let discarded = 0;
   for (const line of raw.split("\n")) {
     if (!line.trim()) continue;
@@ -39,12 +49,12 @@ export function loadStandingExceptions(projectDir) {
       // JSON válido pero no-objeto (null, número…) es tan corrupto como el
       // que no parsea: se descarta contando (catch de codex, explícito).
       if (typeof rec !== "object" || rec === null) discarded += 1;
-      else if (rec.scopeKind === "permanente") standing.push(rec);
+      else records.push(rec);
     } catch {
       discarded += 1;
     }
   }
-  return { standing, discarded };
+  return { records, discarded };
 }
 
 function defaultAppend(projectDir, line) {

--- a/src/policy/report.js
+++ b/src/policy/report.js
@@ -59,8 +59,10 @@ function tallyRules(records, policy, lastResolved) {
 
 function tallyGrants(exceptionRecords, now, soonDays) {
   const perm = exceptionRecords.filter((e) => e?.scopeKind === "permanente");
-  const alive = perm.filter((e) => Date.parse(e.expiresAt) > now.getTime());
-  const expired = perm.filter((e) => !(Date.parse(e.expiresAt) > now.getTime()));
+  // Una caducidad ilegible (NaN) NO está viva: la excepción falla cerrada.
+  const alive = [];
+  const expired = [];
+  for (const e of perm) (Date.parse(e.expiresAt) > now.getTime() ? alive : expired).push(e);
   const soon = alive.filter((e) => Date.parse(e.expiresAt) - now.getTime() <= soonDays * DAY_MS);
   const counts = Map.groupBy(perm, (e) => e.rule_id);
   const renewals = [...counts].filter(([, v]) => v.length >= 2).map(([rule_id, v]) => ({ rule_id, count: v.length }));

--- a/src/policy/report.js
+++ b/src/policy/report.js
@@ -46,10 +46,13 @@ function tallyRules(records, policy, lastResolved) {
     if (!rules.has(id)) rules.set(id, { rule_id: id, ...ruleMeta(policy, id), warns: 0, denies: 0, exempts: 0, open: 0 });
     return rules.get(id);
   };
+  // Un sello lleva un rule_id por FICHERO violador: se cuentan decisiones
+  // por regla, no ficheros — de ahí el Set por entrada.
+  const ids = (list) => new Set(list ?? []);
   records.forEach((rec, i) => {
-    for (const id of rec.warn_rule_ids ?? []) row(id).warns += 1;
-    if (rec.decision === "deny") for (const id of rec.rule_ids ?? []) { row(id).denies += 1; if (i > lastResolved) row(id).open += 1; }
-    if (rec.decision === "exempt") for (const id of rec.rule_ids ?? []) row(id).exempts += 1;
+    for (const id of ids(rec.warn_rule_ids)) row(id).warns += 1;
+    if (rec.decision === "deny") for (const id of ids(rec.rule_ids)) { row(id).denies += 1; if (i > lastResolved) row(id).open += 1; }
+    if (rec.decision === "exempt") for (const id of ids(rec.rule_ids)) row(id).exempts += 1;
   });
   return [...rules.values()].toSorted((a, b) => (b.denies + b.warns) - (a.denies + a.warns));
 }

--- a/tests/architecture/dynamic-imports.test.js
+++ b/tests/architecture/dynamic-imports.test.js
@@ -107,7 +107,10 @@ const SRC_DIR = path.join(REPO_ROOT, "src");
 // (printUpdateNotice in cli.js), but execa is only needed by the `kj update`
 // path — a static import would pull the heavy child-process dep into every
 // plain `kj` invocation. Same feature-gated pattern as the entries above.
-const DYNAMIC_IMPORT_BUDGET = 170;
+// 2026-08-21 (KJC-TSK-0767): ratchet 170 → 166. The five `kj policy`
+// subcommands each re-imported ../commands/policy.js dynamically; one static
+// import serves all of them (the module is light: no agents, no RAG).
+const DYNAMIC_IMPORT_BUDGET = 166;
 
 function listJsFiles(dir, out = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/policy/report-command.test.js
+++ b/tests/policy/report-command.test.js
@@ -1,0 +1,66 @@
+// PL-E (KJC-TSK-0767) — `kj policy report` sobre los ficheros reales:
+// lee los dos jsonl, imprime humano o --json, y una cadena rota es exit 1.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { policyCommand } from "../../src/commands/policy.js";
+import { recordGateDecision } from "../../src/policy/decisions.js";
+import { loadExceptionRecords, recordPolicyException } from "../../src/policy/exceptions.js";
+
+let dir;
+const cwd0 = process.cwd();
+afterEach(() => { process.chdir(cwd0); });
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-polreport-"));
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"), "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.tmp'] }\n");
+  process.chdir(dir);
+});
+const logger = () => {
+  const lines = [];
+  return { lines, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: (m) => lines.push(m) };
+};
+const run = (log, flags = {}) => policyCommand({ action: "report", config: { projectDir: dir }, flags, logger: log });
+const grant = (until) => recordPolicyException({
+  projectDir: dir, entry: { rule_id: "roles.coder.write.deny", justification: "j", scopeKind: "permanente", expiresAt: until },
+  deps: { identity: () => ({ git: "t <t@t>", os: "t", grade: "declarada" }) },
+});
+
+describe("kj policy report", () => {
+  it("sin ficheros: informe en ceros, exit 0, y lo dice", async () => {
+    const log = logger();
+    expect(await run(log)).toBe(0);
+    expect(log.lines.join("\n")).toMatch(/0 decisiones[\s\S]*ninguna ha avisado/);
+  });
+
+  it("lee decisiones y concesiones reales; --json devuelve el objeto con exceptions_discarded", async () => {
+    recordGateDecision(dir, { decision: "allow", chokepoint: "commit", warn_rule_ids: ["roles.coder.write.deny"] });
+    recordGateDecision(dir, { decision: "deny", chokepoint: "commit", rule_ids: ["roles.coder.write.deny"] });
+    grant("2099-01-01T00:00:00Z");
+    grant("2099-06-01T00:00:00Z");
+    fs.appendFileSync(path.join(dir, ".karajan", "policy-exceptions.jsonl"), "{rota\n");
+    expect(loadExceptionRecords(dir)).toMatchObject({ discarded: 1 });
+    const log = logger();
+    expect(await run(log, { json: true })).toBe(0);
+    const out = JSON.parse(log.lines.at(-1));
+    expect(out.decisions).toMatchObject({ total: 2, allow: 1, deny: 1, open: 1 });
+    expect(out.rules[0]).toMatchObject({ rule_id: "roles.coder.write.deny", warns: 1, denies: 1, enforcement: "warn" });
+    expect(out.grants.renewals).toEqual([{ rule_id: "roles.coder.write.deny", count: 2 }]);
+    expect(out.exceptions_discarded).toBe(1);
+    const human = logger();
+    await run(human);
+    expect(human.lines.join("\n")).toMatch(/concedida 2 veces/);
+    expect(human.lines.join("\n")).toMatch(/líneas corruptas descartadas: 0 en decisiones, 1 en excepciones/);
+  });
+
+  it("cadena manipulada = exit 1 gritando, con el informe igualmente impreso", async () => {
+    recordGateDecision(dir, { decision: "deny", rule_ids: ["r1"] });
+    recordGateDecision(dir, { decision: "allow" });
+    const p = path.join(dir, ".karajan", "policy-decisions.jsonl");
+    fs.writeFileSync(p, fs.readFileSync(p, "utf8").replace('"deny"', '"allow"'));
+    const log = logger();
+    expect(await run(log)).toBe(1);
+    expect(log.lines.join("\n")).toMatch(/cadena rota en la entrada 1[\s\S]*decisiones: allow 2/);
+  });
+});

--- a/tests/policy/report.test.js
+++ b/tests/policy/report.test.js
@@ -58,12 +58,12 @@ describe("buildPolicyReport — decisiones", () => {
     expect(by["roles.coder.write.deny"].open).toBe(0);
   });
 
-  it("denegaciones abiertas = denies posteriores al último allow/exempt (el log acaba en rechazo)", () => {
+  it("denegaciones abiertas = denies posteriores al último allow/exempt; un rule_id repetido en la misma entrada (un fichero por violación) cuenta UNA decisión", () => {
     const lines = chain([
       { decision: "deny", rule_ids: ["r1"] },
       { decision: "allow", chokepoint: "commit" },
       { decision: "deny", rule_ids: ["r1"] },
-      { decision: "deny", rule_ids: ["r1", "r2"] },
+      { decision: "deny", rule_ids: ["r1", "r1", "r2"] },
     ]);
     const r = buildPolicyReport({ decisionLines: lines, now: NOW });
     const by = Object.fromEntries(r.rules.map((x) => [x.rule_id, x]));

--- a/tests/policy/report.test.js
+++ b/tests/policy/report.test.js
@@ -76,10 +76,10 @@ describe("buildPolicyReport — decisiones", () => {
 
 describe("buildPolicyReport — concesiones", () => {
   it("separa vivas, vencidas y próximas a vencer; las puntuales solo se cuentan", () => {
-    const recs = [perm("a", 30), perm("b", -1), perm("c", 3), { rule_id: "d", scopeKind: "puntual", diffHash: "h" }, { rule_id: "e" }];
+    const recs = [perm("a", 30), perm("b", -1), perm("c", 3), { rule_id: "d", scopeKind: "puntual", diffHash: "h" }, { rule_id: "e" }, perm("f", 0, { expiresAt: "no-es-fecha" })];
     const r = buildPolicyReport({ exceptionRecords: recs, now: NOW, soonDays: 7 });
     expect(r.grants.alive.map((g) => g.rule_id)).toEqual(["a", "c"]);
-    expect(r.grants.expired.map((g) => g.rule_id)).toEqual(["b"]);
+    expect(r.grants.expired.map((g) => g.rule_id)).toEqual(["b", "f"]);
     expect(r.grants.soon.map((g) => g.rule_id)).toEqual(["c"]);
     expect(r.grants.point).toBe(2);
   });

--- a/tests/review/review-gate-policy.test.js
+++ b/tests/review/review-gate-policy.test.js
@@ -19,6 +19,7 @@ vi.mock("../../src/review/card-first.js", async (orig) => ({
 }));
 
 import { reviewGateCommand } from "../../src/commands/review-gate.js";
+import { saveVerdict } from "../../src/review/verdict-store.js";
 
 let dir;
 const cwd0 = process.cwd();
@@ -92,6 +93,21 @@ describe("policy gate en kj review", () => {
     const r = await reviewGateCommand({ config: { projectDir: dir }, flags: { staged: true } });
     spy.mockRestore();
     expect(r).toMatchObject({ verdict: "rejected", reviewer: "policy" });
+  });
+
+  // PL-E (KJC-TSK-0767): los avisos se sellan en el allow del commit — son el
+  // dato con el que una regla warn gana dientes (kj policy report).
+  it("el allow de --check sella warn_rule_ids con las reglas que avisaron", async () => {
+    fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"), "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.tmp'] }\n");
+    stage("scratch.tmp");
+    const staged = execFileSync("git", ["-C", dir, "diff", "--cached"], { encoding: "utf8" });
+    await saveVerdict(dir, staged, { verdict: "approved", reviewer: "codex", issues: [] });
+    const spy = silence();
+    const r = await reviewGateCommand({ config: { projectDir: dir }, flags: { check: true } });
+    spy.mockRestore();
+    expect(r.ok).toBe(true);
+    const last = fs.readFileSync(path.join(dir, ".karajan", "policy-decisions.jsonl"), "utf8").trim().split("\n").at(-1);
+    expect(JSON.parse(last)).toMatchObject({ decision: "allow", chokepoint: "commit", warn_rule_ids: ["roles.coder.write.deny"] });
   });
 
   it("policy invalida = gate cerrado, jamas un pase silencioso", async () => {


### PR DESCRIPTION
## PL-E (2/2): `kj policy report` + warns sealed on the commit allow

Card: KJC-TSK-0767 · Epic: KJC-PCS-0074 · Stacked on #1501 (pure report module).

- **`kj policy report [--soon <days>] [--json]`**: reads `.karajan/policy-decisions.jsonl` and `.karajan/policy-exceptions.jsonl`, loads the policy for `enforcement`/`class`, and prints: chain integrity, decisions by kind and chokepoint, the per-rule table (warn / deny / exempt / open, sorted by friction), grants alive (with who/until/justification), expired, expiring, point exceptions, and the signals. Corrupt lines are counted and said. **Broken chain = exit 1** — a report over a tampered log is not a report. `--json` adds `exceptions_discarded`.
- **`warn_rule_ids` on the commit allow** (`kj review --check`): the sealed allow now carries the rules that warned. That is the missing datum for "a rule is born warning and gains teeth" — until now warns vanished at the console.
- `loadExceptionRecords` (all records, same tolerant parse); `loadStandingExceptions` is now a filter over it.
- README: one paragraph on the decision log + report. CHANGELOG under Unreleased.

Tests: `kj policy report` on real files (empty, populated + `--json` + human output + renewals + discarded counts, broken chain exit 1) and the gate test proving `warn_rule_ids` lands on the allow record.

Closes the card: both steps of its implementation plan are in. Out of scope (own cards): GOV-F tool-time decisions in the chain (KJC-TSK-0768), policy at the release boundary (KJC-TSK-0769).
