### PR TITLE
feat(console): corpora health and access lists in the page (KJC-TSK-0785)

### DIFF
--- a/packages/console/ui/app.js
+++ b/packages/console/ui/app.js
@@ -6,7 +6,11 @@ const state = { token: sessionStorage.getItem(TOKEN_KEY), status: null, me: null
 const $ = (selector) => document.querySelector(selector);
 
 const el = (tag, attrs = {}, ...children) => {
-  const node = Object.assign(document.createElement(tag), attrs);
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key.includes("-")) node.setAttribute(key, value);
+    else node[key] = value;
+  }
   for (const child of children) node.append(child);
   return node;
 };
@@ -67,13 +71,114 @@ function renderHome(identity, cfg) {
   $("#facts").replaceChildren(...facts.flatMap(([k, v]) => [el("dt", {}, k), el("dd", {}, v)]));
 }
 
+// Corpora health for everyone; access lists for admins, with an inline confirmation before a revoke
+// (no native dialogs) and the server's answer shown as it came.
+async function renderCorpora(cfg) {
+  const { corpora } = await api("/corpora");
+  $("#corpora").replaceChildren(
+    ...corpora.map((c) =>
+      el(
+        "li",
+        { className: c.ok ? "ok" : "bad" },
+        el("strong", {}, c.name),
+        el(
+          "span",
+          { className: "meta" },
+          c.ok
+            ? `${c.files ?? "?"} files · ${c.chunks ?? "?"} chunks · ${c.fingerprint ?? ""}`
+            : `unavailable — ${c.error}`
+        )
+      )
+    )
+  );
+  if (state.me.role !== "admin") return;
+  $("#access").hidden = false;
+  const domain = cfg.instance.allowedDomains[0];
+  $("#access-lists").replaceChildren(
+    ...(await Promise.all(cfg.corpora.map((corpus) => renderAccess(corpus, domain))))
+  );
+}
+
+async function renderAccess(corpus, domain) {
+  const box = el("div", { className: "access" }, el("h3", {}, corpus.name));
+  const refresh = async () => {
+    try {
+      const { members } = await api(`/corpora/${encodeURIComponent(corpus.id)}/access`);
+      list.replaceChildren(...members.map((m) => memberRow(corpus, m, refresh)));
+      if (!members.length) list.append(el("li", { className: "hint" }, "nobody yet"));
+    } catch (err) {
+      list.replaceChildren(el("li", { className: "bad" }, `cannot read access: ${err.message}`));
+    }
+  };
+  const list = el("ul", { className: "members" });
+  const input = el("input", {
+    type: "email",
+    placeholder: `someone@${domain}`,
+    required: true,
+    "aria-label": `email to grant on ${corpus.name}`,
+  });
+  const form = el(
+    "form",
+    {},
+    input,
+    el("button", { type: "submit", className: "ghost" }, "Grant access")
+  );
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    try {
+      await api(`/corpora/${encodeURIComponent(corpus.id)}/access`, {
+        method: "POST",
+        body: JSON.stringify({ email: input.value }),
+      });
+      input.value = "";
+      notice(`Access granted on ${corpus.name}.`);
+      await refresh();
+    } catch (err) {
+      notice(`Grant refused: ${err.message}`, "error");
+    }
+  });
+  box.append(list, form);
+  await refresh();
+  return box;
+}
+
+function memberRow(corpus, email, refresh) {
+  const revoke = el("button", { type: "button", className: "ghost" }, "Remove");
+  const confirm = el(
+    "button",
+    { type: "button", className: "ghost danger", hidden: true },
+    `Confirm: remove ${email}`
+  );
+  revoke.addEventListener("click", () => {
+    confirm.hidden = false;
+    revoke.hidden = true;
+  });
+  confirm.addEventListener("click", async () => {
+    try {
+      await api(`/corpora/${encodeURIComponent(corpus.id)}/access/${encodeURIComponent(email)}`, {
+        method: "DELETE",
+      });
+      notice(`Access removed on ${corpus.name}.`);
+      await refresh();
+    } catch (err) {
+      notice(`Remove refused: ${err.message}`, "error");
+    }
+  });
+  return el("li", {}, el("span", {}, email), revoke, confirm);
+}
+
 async function signedIn() {
   try {
     const { identity } = await api("/me");
     state.me = identity;
-    renderHome(identity, await api("/config"));
+    const cfg = await api("/config");
+    renderHome(identity, cfg);
     notice("");
     show("home");
+    // A corpus that cannot be read is shown as such; it never signs the person out.
+    await renderCorpora(cfg).catch((err) =>
+      notice(`Corpora could not be read: ${err.message}`, "error")
+    );
   } catch (err) {
     signOut(false);
     notice(

--- a/packages/console/ui/index.html
+++ b/packages/console/ui/index.html
@@ -31,10 +31,17 @@
       <section data-view="home" hidden>
         <h1>Your access</h1>
         <dl class="facts" id="facts"></dl>
-        <p class="hint">
-          Corpora, access, operations and the audit trail open here in the next releases of the
-          console.
-        </p>
+        <h2>Corpora</h2>
+        <ul class="cards" id="corpora" aria-live="polite"></ul>
+        <section id="access" hidden>
+          <h2>Who can query</h2>
+          <p class="hint">
+            People of the organisation with access to a corpus. Removing someone takes effect on the
+            service at once; every change is sealed in the audit trail.
+          </p>
+          <div id="access-lists"></div>
+        </section>
+        <p class="hint">Operations and the audit trail open here in the next part.</p>
       </section>
     </main>
     <script type="module" src="/app.js"></script>

--- a/packages/console/ui/styles.css
+++ b/packages/console/ui/styles.css
@@ -109,3 +109,44 @@ button.ghost:focus-visible {
   border-color: var(--accent);
   outline: none;
 }
+h2 {
+  font-size: 1.1rem;
+  margin: 2rem 0 0.75rem;
+}
+.cards,
+.members {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.cards li,
+.members li,
+.access form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-top: 1px solid var(--line);
+}
+.meta,
+.bad .meta {
+  color: var(--mute);
+  font-size: 0.9rem;
+}
+.bad strong::before {
+  content: "● ";
+  color: var(--bad);
+}
+.danger {
+  color: var(--bad);
+}
+input[type="email"] {
+  flex: 1;
+  min-width: 12rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: var(--bg);
+  color: inherit;
+}


### PR DESCRIPTION
## C1-UI (3/4): corpora health and access in the page

Card: KJC-TSK-0785 · Epic: KJC-PCS-0080 · ADR 0007 · follows the script PR

- **Corpora** (everyone): each corpus with its health as the API answered — files, chunks, fingerprint — or "unavailable" with the server's reason.
- **Who can query** (admins only, the section does not exist for other roles): per corpus, the people on the service's invoker binding; grant by email (the server enforces the domain and seals it); remove with an **inline confirmation** — the Remove button turns into "Confirm: remove <email>" — no native dialogs.
- Everything rendered from the API's answers with `textContent`/`append`; every refusal shows the server's message.
- Styles for the lists, the form and the unavailable marker.

Part 4 brings operations (run + status) and the audit trail.
