### PR TITLE
feat(console): operations and the audit trail in the page (KJC-TSK-0785)

### DIFF
--- a/packages/console/ui/app.js
+++ b/packages/console/ui/app.js
@@ -167,6 +167,87 @@ function memberRow(corpus, email, refresh) {
   return el("li", {}, el("span", {}, email), revoke, confirm);
 }
 
+// Operations: a Run button only when the person's role is one the operation names; the run's
+// status is polled until it settles. The audit trail (admins): the last entries and the chain verdict.
+const RANK = { reader: 1, operator: 2, admin: 3 };
+function renderOperations(cfg) {
+  if (!cfg.operations.length) return;
+  $("#operations-box").hidden = false;
+  $("#operations").replaceChildren(...cfg.operations.map((op) => operationRow(op)));
+}
+
+function operationRow(op) {
+  const status = el(
+    "span",
+    { className: "meta" },
+    op.available ? "" : "not available in this build"
+  );
+  const allowed = op.available && op.roles.some((r) => RANK[state.me.role] >= RANK[r]);
+  const run = el("button", { type: "button", className: "ghost", disabled: !allowed }, "Run");
+  run.addEventListener("click", async () => {
+    run.disabled = true;
+    status.textContent = "starting…";
+    try {
+      const out = await api(`/operations/${encodeURIComponent(op.id)}/dispatch`, {
+        method: "POST",
+        body: JSON.stringify({ inputs: {} }),
+      });
+      await followRun(out, status);
+    } catch (err) {
+      status.textContent = `refused: ${err.message}`;
+    } finally {
+      run.disabled = false;
+    }
+  });
+  return el(
+    "li",
+    {},
+    el("strong", {}, op.id),
+    el("span", { className: "meta" }, `needs ${op.roles.join(" or ")}`),
+    run,
+    status
+  );
+}
+
+async function followRun(out, status) {
+  const link = out.url
+    ? el("a", { href: out.url, target: "_blank", rel: "noopener" }, "open on GitHub")
+    : "";
+  const paint = (text) => status.replaceChildren(`${text} `, link);
+  paint(out.status ?? "dispatched");
+  const settled = (s) => s === "completed" || s === "pending";
+  let current = out;
+  for (let i = 0; i < 60 && !settled(current.status); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    current = await api(`/runs/${encodeURIComponent(out.runRef)}`);
+    paint(current.conclusion ? `${current.status} (${current.conclusion})` : current.status);
+  }
+}
+
+async function renderAudit() {
+  if (state.me.role !== "admin") return;
+  $("#audit-box").hidden = false;
+  const { chain, entries } = await api("/audit?limit=50");
+  $("#audit-chain").textContent = chain.ok
+    ? `Chain verified: ${chain.length} entries, nothing altered.`
+    : `CHAIN BROKEN at entry ${chain.at}: ${chain.reason}`;
+  $("#audit").replaceChildren(
+    ...entries
+      .toReversed()
+      .map((e) =>
+        el(
+          "tr",
+          { className: e.outcome === "ok" ? "" : "bad" },
+          el("td", {}, new Date(e.ts).toLocaleString()),
+          el("td", {}, e.who?.email ?? ""),
+          el("td", {}, e.action),
+          el("td", {}, e.target ?? ""),
+          el("td", {}, e.outcome)
+        )
+      )
+  );
+}
+
 async function signedIn() {
   try {
     const { identity } = await api("/me");
@@ -178,6 +259,10 @@ async function signedIn() {
     // A corpus that cannot be read is shown as such; it never signs the person out.
     await renderCorpora(cfg).catch((err) =>
       notice(`Corpora could not be read: ${err.message}`, "error")
+    );
+    renderOperations(cfg);
+    await renderAudit().catch((err) =>
+      notice(`Audit trail could not be read: ${err.message}`, "error")
     );
   } catch (err) {
     signOut(false);

--- a/packages/console/ui/index.html
+++ b/packages/console/ui/index.html
@@ -41,7 +41,30 @@
           </p>
           <div id="access-lists"></div>
         </section>
-        <p class="hint">Operations and the audit trail open here in the next part.</p>
+        <section id="operations-box" hidden>
+          <h2>Operations</h2>
+          <p class="hint">
+            Each run is a workflow in the deployment repo, fired as the console's GitHub App and
+            sealed with who asked for it.
+          </p>
+          <ul class="cards" id="operations"></ul>
+        </section>
+        <section id="audit-box" hidden>
+          <h2>Audit trail</h2>
+          <p class="hint" id="audit-chain"></p>
+          <table class="trail">
+            <thead>
+              <tr>
+                <th>When</th>
+                <th>Who</th>
+                <th>Action</th>
+                <th>Target</th>
+                <th>Outcome</th>
+              </tr>
+            </thead>
+            <tbody id="audit"></tbody>
+          </table>
+        </section>
       </section>
     </main>
     <script type="module" src="/app.js"></script>

--- a/packages/console/ui/styles.css
+++ b/packages/console/ui/styles.css
@@ -22,6 +22,10 @@
 * {
   box-sizing: border-box;
 }
+/* The hidden attribute must win over any display rule (the who-block is a flex box). */
+[hidden] {
+  display: none !important;
+}
 body {
   margin: 0;
   background: var(--bg);

--- a/packages/console/ui/styles.css
+++ b/packages/console/ui/styles.css
@@ -138,8 +138,29 @@ h2 {
   content: "● ";
   color: var(--bad);
 }
-.danger {
+.danger,
+tr.bad td {
   color: var(--bad);
+}
+.trail {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+.trail th,
+.trail td {
+  text-align: left;
+  padding: 0.4rem 0.5rem;
+  border-top: 1px solid var(--line);
+  vertical-align: top;
+}
+.trail th {
+  color: var(--mute);
+  font-weight: 500;
+}
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 input[type="email"] {
   flex: 1;


### PR DESCRIPTION
## C1-UI (4/4): operations and the audit trail in the page

Card: KJC-TSK-0785 · Epic: KJC-PCS-0080 · ADR 0007 · follows the corpora/access PR

- **Operations**: each operation with the roles it needs; the Run button is enabled only when the person's role is one of them (the server enforces it anyway). A run shows its status as dispatched and is polled every 5 s until it settles (`completed`, or `pending` when GitHub has not shown the run yet), with a link to the run on GitHub. A refusal shows the server's message.
- **Audit trail** (admins): the chain verdict as the kernel answered it (verified, or BROKEN with the entry and reason) and the last 50 entries, newest first.
- Neither section exists in the DOM for roles that cannot use it; nothing in the page decides — it shows what the API answered.

With this the card's acceptance criteria are met: sign in by domain, corpus health for readers, access lists and the trail for admins, operations for operators — without a terminal.
