### PR TITLE
fix(sentinel): a version tail is not a card, and a phantom hu move clears nothing (KJC-BUG-0154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A release branch no longer manufactures a phantom card the gate then demands you move** (KJC-BUG-0154, lived through while merging 4.22.0's own release PR): `CARD_REF_RE` matched "release-4" inside `chore/release-4.22.0` at the dot's word boundary, so the board-sync gate recorded a pending move for the card "RELEASE-4" — which exists on no tracker — and the Stop gate blocked the turn demanding the impossible. A negative lookahead keeps any version tail from reading as a card. And the second half is worse than the first: `kj hu move RELEASE-4 done` answered `HU "RELEASE-4" not found` and STILL cleared the pending, because the clear only rejected outputs containing error/fail — a move that moved nothing could discard a legitimate pending without touching the tracker. "not found" now counts as failure. Both halves proven red before the fix; an unmakeable violation is exactly what teaches escapes (KJC-PCS-0082).
+
 ## [4.22.0] - 2026-08-25
 
 ### Added

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -168,7 +168,9 @@ process.stdin.on("end", () => {
         save(state);
       }
       const moved = /kj\\s+hu\\s+move\\s+([A-Za-z0-9-]+)\\s+([a-z&-]+)/i.exec(String(input.command || ""));
-      if (moved && CLOSING.includes(moved[2].toLowerCase()) && !/error|fail/i.test(text)) clearPending(moved[1].toUpperCase());
+      // "not found" counts as failure (KJC-BUG-0154): a move that moved nothing must not
+      // clear a pending — that would discard a LEGITIMATE one without touching the tracker.
+      if (moved && CLOSING.includes(moved[2].toLowerCase()) && !/error|fail|not found/i.test(text)) clearPending(moved[1].toUpperCase());
       process.exit(0);
     }
     const file = input.file_path || input.notebook_path;

--- a/src/review/card-first.js
+++ b/src/review/card-first.js
@@ -14,7 +14,10 @@ const LIVE_STATUSES = new Set(["pending", "running", "failed"]);
 // Card-shaped reference: LIN-123, bb-002 and multi-segment ids like
 // KJC-TSK-0684 (optional middle segments) — tight enough to skip slugs.
 // Shared with the method report (MG-D): one pattern, one truth.
-export const CARD_REF_RE = /\b[a-z][a-z0-9]{1,9}(?:-[a-z][a-z0-9]{1,9})*-\d{1,6}\b/i;
+// The lookahead keeps a version tail from reading as a card (KJC-BUG-0154):
+// `chore/release-4.22.0` matched "release-4" at the dot's word boundary, and
+// the board-sync gate then demanded moving a card that exists nowhere.
+export const CARD_REF_RE = /\b[a-z][a-z0-9]{1,9}(?:-[a-z][a-z0-9]{1,9})*-\d{1,6}\b(?!\.\d)/i;
 const DEFAULT_EXEMPT_PREFIXES = ["chore/release-"];
 
 // Token-boundary match: BB-002 must not satisfy a branch that actually

--- a/tests/harden/sentinel-board-sync-clear.test.js
+++ b/tests/harden/sentinel-board-sync-clear.test.js
@@ -67,4 +67,13 @@ describe("board-sync — limpieza del pendiente", () => {
     updateCard("KJC-TSK-0099", "Done&Validated");
     expect(state().sessions.s1.pending_moves).toHaveLength(0);
   });
+
+  // KJC-BUG-0154, mitad (2): «HU "X" not found» no contiene error ni fail, así que un move
+  // que no movió NADA limpiaba el pendiente — vía válida para descartar uno legítimo sin
+  // tocar el tracker. Un movimiento fantasma no limpia.
+  it("kj hu move de una HU inexistente NO limpia el pendiente", () => {
+    seed("KJC-TSK-0042");
+    hook(post, { tool_name: "Bash", tool_input: { command: "kj hu move KJC-TSK-0042 done" }, tool_response: { stdout: 'HU "KJC-TSK-0042" not found — see kj hu list' } });
+    expect(state().sessions.s1.pending_moves).toHaveLength(1);
+  });
 });

--- a/tests/review/card-first.test.js
+++ b/tests/review/card-first.test.js
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { checkCardFirst } from "../../src/review/card-first.js";
+import { checkCardFirst, CARD_REF_RE } from "../../src/review/card-first.js";
 import { savePlan } from "../../src/plan/plan-store.js";
 import { generatePlanId } from "../../src/plan/plan-id.js";
 
@@ -106,6 +106,18 @@ describe("checkCardFirst — external / planning-game (presence check, warns by 
       expect(r).toMatchObject({ ok: true, mode: "pass", level: "branch-ref" });
       expect(r.note).toMatch(/degraded/);
     });
+  });
+});
+
+describe("CARD_REF_RE — a version tail is not a card (KJC-BUG-0154)", () => {
+  // `chore/release-4.22.0` matched "release-4" at the dot's word boundary, and the
+  // board-sync gate then demanded moving a card that exists nowhere. Lived through it.
+  it("does not read release-4.22.0 as the card RELEASE-4, and still reads real cards", () => {
+    expect(CARD_REF_RE.test("chore/release-4.22.0")).toBe(false);
+    expect(CARD_REF_RE.test("release-10.0.1")).toBe(false);
+    expect("feat/KJC-TSK-0778-console-c2".match(CARD_REF_RE)[0]).toBe("KJC-TSK-0778");
+    expect("fix/bb-002-thing".match(CARD_REF_RE)[0]).toBe("bb-002");
+    expect("lin-123".match(CARD_REF_RE)[0]).toBe("lin-123");
   });
 });
 


### PR DESCRIPTION
## Una rama de release fabricaba una card fantasma, y un movimiento fantasma la limpiaba

Bug: KJC-BUG-0154 · Épica: KJC-PCS-0082 (credibilidad de los gates) · vivido al mergear la propia PR de release de la 4.22.0

**Mitad 1 — el falso positivo.** `CARD_REF_RE` casaba «release-4» dentro de `chore/release-4.22.0` (el punto de la versión es límite de palabra), así que el gate de board-sync registró una pendiente para la card **RELEASE-4** — que no existe en ningún tracker — y el Stop gate bloqueó el turno exigiendo mover lo imposible. Una violación infabricable es exactamente lo que enseña a usar escapes. Arreglo: lookahead negativo — una cola de versión nunca es una card. `card-first` ya eximía `chore/release-`; el registrador de pendientes no pasaba por esa exención.

**Mitad 2 — y es la peor.** Al intentar limpiarla con `kj hu move RELEASE-4 done`, la respuesta fue `HU "RELEASE-4" not found`… **y limpió la pendiente igualmente**, porque el clear solo rechazaba salidas con `error` o `fail`. Es decir: un movimiento que no movió nada podía descartar una pendiente **legítima** sin tocar el tracker — un agujero en el propio gate que existe para impedir eso. Ahora `not found` cuenta como fallo.

Las dos mitades comprobadas en rojo sin el arreglo (2/2 fallan) y en verde con él. Hooks regenerados con `kj harden`; la deriva trackeada revertida — los hooks los commitea el humano.
