### PR TITLE
fix(hu-board): compare the board token in constant time

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@
 
 import js from "@eslint/js";
 import importX from "eslint-plugin-import-x";
+import nodeSecurity from "eslint-plugin-node-security";
 import security from "eslint-plugin-security";
 import globals from "globals";
 
@@ -78,6 +79,7 @@ export default [
       },
     },
     plugins: {
+      "node-security": nodeSecurity,
       "import-x": importX,
       security,
     },
@@ -110,6 +112,14 @@ export default [
       "security/detect-pseudoRandomBytes": "error",
       "security/detect-disable-mustache-escape": "error",
       "security/detect-non-literal-regexp": "warn",
+
+      // `detect-possible-timing-attacks` is one of the noisy members left out
+      // above — it matches on variable NAMES, so every `if (user.token === …)`
+      // in a test fixture reports. This rule asks the same question
+      // structurally: a comparison operator applied to a value that reaches a
+      // credential, which is why the whole repository passes it today and did
+      // not before `packages/hu-board/src/auth.js` was fixed in this PR.
+      "node-security/no-timing-unsafe-compare": "error",
 
       // --- Soft signals (warn, not error) ----------------------------
       // Audit rec #8: ratchet from "warn" to "error" after the

--- a/package-lock.json
+++ b/package-lock.json
@@ -3827,6 +3827,31 @@
         "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/eslint-plugin-node-security/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/eslint-plugin-node-security/node_modules/@interlace/eslint-devkit": {
       "version": "1.17.2",
       "resolved": "https://registry.npmjs.org/@interlace/eslint-devkit/-/eslint-devkit-1.17.2.tgz",
@@ -3856,6 +3881,329 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
       }
     },
     "node_modules/eslint-plugin-security": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.21.0",
+      "version": "4.22.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
@@ -50,12 +50,14 @@
         "esbuild": "^0.28.0",
         "eslint": "^10.4.1",
         "eslint-plugin-import-x": "^4.16.2",
+        "eslint-plugin-node-security": "5.2.2",
         "eslint-plugin-security": "^4.0.0",
         "globals": "^17.6.0",
         "lint-staged": "^17.0.7",
         "postject": "^1.0.0-alpha.6",
         "prettier": "^3.4.2",
         "simple-git-hooks": "^2.13.1",
+        "smol-toml": "^1.7.0",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -3801,6 +3803,57 @@
           "optional": true
         },
         "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-node-security": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node-security/-/eslint-plugin-node-security-5.2.2.tgz",
+      "integrity": "sha512-VETQOmnAKdn0/iY4ct+lxWmCm1YJUl2qL5oXdFTYac0Pgm+YrgOxc7EQslNSN3k60CyiQx6l/XV2EeAXTXAjjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@interlace/eslint-devkit": "^1.17.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "git+https://github.com/ofri-peretz/eslint.git"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-node-security/node_modules/@interlace/eslint-devkit": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@interlace/eslint-devkit/-/eslint-devkit-1.17.2.tgz",
+      "integrity": "sha512-owpOOCCBUeJ+r93Fkb0TzfBOdgDbpptT7FJYR8bWA8PU//8SnTlHOXg7juQl4G9kEvFPoKAVRnNJSQOYryF6Ng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ofri-peretz/eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0",
+        "oxc-resolver": "^11.24.2",
+        "typescript": ">=4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "oxc-resolver": {
+          "optional": true
+        },
+        "typescript": {
           "optional": true
         }
       }
@@ -8040,7 +8093,7 @@
     },
     "packages/console": {
       "name": "@karajan-family/console",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@karajan-family/governance": "*",

--- a/package.json
+++ b/package.json
@@ -123,17 +123,18 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "smol-toml": "^1.7.0",
     "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.28.0",
     "eslint": "^10.4.1",
     "eslint-plugin-import-x": "^4.16.2",
+    "eslint-plugin-node-security": "5.2.2",
     "eslint-plugin-security": "^4.0.0",
     "globals": "^17.6.0",
     "lint-staged": "^17.0.7",
     "postject": "^1.0.0-alpha.6",
     "prettier": "^3.4.2",
     "simple-git-hooks": "^2.13.1",
+    "smol-toml": "^1.7.0",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/hu-board/src/auth.js
+++ b/packages/hu-board/src/auth.js
@@ -20,6 +20,8 @@
  *     legacy callers keep working.
  */
 
+import { timingSafeEqual } from "node:crypto";
+
 /** Loopback addresses we trust without auth, regardless of token state. */
 const LOOPBACK_ADDRESSES = new Set([
   "127.0.0.1",
@@ -41,7 +43,7 @@ export function authMiddleware() {
     if (isLoopback(req)) return next();
 
     const token = extractToken(req);
-    if (token === expected) return next();
+    if (tokensMatch(token, expected)) return next();
 
     return res.status(401).json({
       error: "Unauthorized",
@@ -51,6 +53,32 @@ export function authMiddleware() {
         "?token=<token>, or the kj_board_token cookie.",
     });
   };
+}
+
+/**
+ * Constant-time comparison of a presented token against the expected one.
+ *
+ * `===` on strings stops at the first differing byte, so the time it takes to
+ * reject a token leaks how much of a correct prefix was supplied. Over the
+ * loopback interface that is noise — but this middleware exists precisely for
+ * the case the header above describes, where the board is bound beyond
+ * loopback and the peer is on the LAN. There the difference is measurable, and
+ * the token can be recovered a byte at a time.
+ *
+ * `timingSafeEqual` throws when the buffers differ in length, so the length is
+ * checked first. That is not a leak worth closing: the length of the expected
+ * token is fixed by whatever wrote `~/.karajan/hu-board/token`, and a token of
+ * the wrong length is wrong regardless of its contents.
+ *
+ * @param {string|undefined} presented
+ * @param {string} expected
+ * @returns {boolean}
+ */
+function tokensMatch(presented, expected) {
+  if (typeof presented !== "string") return false;
+  const left = Buffer.from(presented, "utf8");
+  const right = Buffer.from(expected, "utf8");
+  return left.length === right.length && timingSafeEqual(left, right);
 }
 
 /**

--- a/packages/hu-board/tests/auth.test.js
+++ b/packages/hu-board/tests/auth.test.js
@@ -142,4 +142,33 @@ describe('auth enabled, simulated non-loopback peer', () => {
     expect(res.status).toBe(401);
     expect(res.body.error).toBe('Unauthorized');
   });
+
+  // The comparison is length-checked before timingSafeEqual, which throws on
+  // a length mismatch. These are the shapes that would surface that.
+  it('rejects a token that shares a prefix with the expected one', async () => {
+    process.env.HU_BOARD_TOKEN = TOKEN;
+    const app = await buildAppFromLan();
+    const res = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${TOKEN.slice(0, -1)}X`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token shorter than the expected one', async () => {
+    process.env.HU_BOARD_TOKEN = TOKEN;
+    const app = await buildAppFromLan();
+    const res = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', `Bearer ${TOKEN.slice(0, 4)}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an empty Bearer token', async () => {
+    process.env.HU_BOARD_TOKEN = TOKEN;
+    const app = await buildAppFromLan();
+    const res = await request(app)
+      .get('/api/dashboard')
+      .set('Authorization', 'Bearer ');
+    expect(res.status).toBe(401);
+  });
 });


### PR DESCRIPTION
## What

`packages/hu-board/src/auth.js` compares the presented bearer token to `HU_BOARD_TOKEN` with `===`:

```js
const token = extractToken(req);
if (token === expected) return next();
```

String comparison stops at the first differing byte, so the time taken to reject a token leaks how long a correct prefix was supplied, and the token can be recovered a byte at a time.

The module's own header is what makes this worth fixing rather than theoretical:

> The "shared dev machine" risk only kicks in when the server binds beyond loopback (e.g. `--bind 0.0.0.0` to access from another laptop on LAN).

That is exactly the deployment this middleware exists for. On loopback the timing difference is drowned in noise; across a LAN it is measurable.

## The fix

`crypto.timingSafeEqual`, with a length check first because it throws on a length mismatch:

```js
function tokensMatch(presented, expected) {
  if (typeof presented !== "string") return false;
  const left = Buffer.from(presented, "utf8");
  const right = Buffer.from(expected, "utf8");
  return left.length === right.length && timingSafeEqual(left, right);
}
```

The length is not a leak worth closing — it is fixed by whatever wrote `~/.karajan/hu-board/token`, and a token of the wrong length is wrong whatever it contains.

## The rule, and why not `detect-possible-timing-attacks`

`eslint.config.js` says it deliberately leaves out the noisy members of `eslint-plugin-security`'s preset. `detect-possible-timing-attacks` is one of them: it matches on variable **names**, so every `if (user.token === expected)` in a fixture reports. Leaving it off is the right call, and it is why this bug was not caught.

This PR enables `node-security/no-timing-unsafe-compare` instead, which asks the question structurally rather than by name. Two measurements:

- On the code as it stands today, before this fix: **1 error**, at `auth.js:44`.
- On `packages/` and `src/` after the fix: **0 errors** — so the rule can be repository-wide rather than scoped, and it goes red only on a new one.

`eslint-plugin-node-security@5.2.2`, pinned exactly rather than as a range so you are approving the version this was measured against.

## Test plan

- [x] Three tests added to `packages/hu-board/tests/auth.test.js`: a token sharing a prefix with the expected one, a shorter token, and an empty `Bearer` — the shapes that would surface `timingSafeEqual`'s length throw. The existing valid-token and wrong-token tests are unchanged and still pass.
- [x] Comparison semantics checked directly against six cases: exact match, differing byte, short, `undefined`, empty, and multi-byte UTF-8.
- [ ] I did not run the full suite locally — `npm install` registers `karajan-mcp` into local Claude/Codex config via a postinstall, and I did not want to leave that on a machine that is not mine to configure. Happy to run it if you would rather I did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)