### PR TITLE
test(harden): isolate the publish fail-open leg from a linked kj (KJC-BUG-0155)

### DIFF
--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -160,7 +160,13 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
     expect(blocked.status).toBe(2);
     expect(blocked.stderr).toMatch(/changelog/);
     expect(run(gate, publish, { PATH: `${bin}:${process.env.PATH}`, KJ_ALLOW_RELEASE: "1" }).status).toBe(0);
-    expect(run(gate, publish, { PATH: path.dirname(process.execPath) }).status).toBe(0);
+    // KJC-BUG-0155: dirname(process.execPath) is node's OWN bin — the same dir
+    // where `npm link` installs the real kj on a dev machine, so the fail-open
+    // leg found kj and blocked. A lonely bin holding ONLY node proves it.
+    const lonely = path.join(dir, "lonelybin");
+    fs.mkdirSync(lonely);
+    fs.symlinkSync(process.execPath, path.join(lonely, "node"));
+    expect(run(gate, publish, { PATH: lonely }).status).toBe(0);
     expect(run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "ls -la" } }).status).toBe(0);
   });
 


### PR DESCRIPTION
## El tramo «fails open without kj» encontraba el kj npm-linkado

Card: KJC-BUG-0155

La aserción de fail-open del test de publish pasaba `PATH: path.dirname(process.execPath)` asumiendo que el bin de node solo contiene node. En una máquina con `npm link karajan-code` ese MISMO directorio contiene el symlink `kj`: el hook lo encontraba, corría `kj release check` en el repo desechable del test (rojo, claro) y bloqueaba — expected 0, received 2. En CI pasaba (sin kj global): un falso rojo solo-local que ensuciaba cada pasada de la suite harden en la máquina de desarrollo.

Fix: un bin solitario dentro del repo del test con un único symlink a `process.execPath` — node resoluble, kj de verdad ausente. Detectado durante KJC-TSK-0803 (fallaba igual con y sin los cambios de esa card).
