### PR TITLE
fix(sentinel): a board pending clears by its PR, not only by card id (KJC-BUG-0157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A board-sync pending can now be cleared by its PR, not only by its card id** (KJC-BUG-0157, found live minutes after cutting 4.23.0): when the tracker's `create_card` timed out, the release branch was named with the ASSUMED next id, and the merged PR's pending got anchored to a card that never existed — uncleanable by any verified route, a deadlock only the human's kill-switch could break. The pending's TRUE identity is its PR: a CONFIRMED closing `update_card` whose request names that PR (`pipelineStatus.prCreated.prNumber`) clears it even when the card id differs — still a real tracker call seen by the hook, never a promise in prose; pendings of other PRs stay untouched.
+
 ## [4.23.0] - 2026-08-29
 
 ### Security

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -151,7 +151,21 @@ process.stdin.on("end", () => {
       // the first real update_card did not clear its pending entry).
       const cid = /\\\\?"cardId\\\\?"\\s*:\\s*\\\\?"([A-Za-z0-9-]+)\\\\?"/.exec(text);
       const st = /\\\\?"status\\\\?"\\s*:\\s*\\\\?"([^"\\\\]+)\\\\?"/.exec(text);
-      if (cid && st && CLOSING.includes(st[1].toLowerCase())) clearPending(cid[1].toUpperCase());
+      if (cid && st && CLOSING.includes(st[1].toLowerCase())) {
+        clearPending(cid[1].toUpperCase());
+        // KJC-BUG-0157: a pending whose card-id NEVER existed (branch named
+        // before the tracker confirmed the create) could not be cleared by any
+        // verified route. The pending's TRUE identity is its PR: a CONFIRMED
+        // closing update whose request names that PR clears it too — still a
+        // real tracker call seen by this hook, never a promise in prose.
+        const prIn = Number(input?.updates?.pipelineStatus?.prCreated?.prNumber);
+        if (Number.isFinite(prIn) && prIn > 0) {
+          const state = load();
+          const s = session(state, sid);
+          s.pending_moves = (s.pending_moves || []).filter((p) => Number(p.pr) !== prIn);
+          save(state);
+        }
+      }
       process.exit(0);
     }
     if (tool === "Bash") {

--- a/tests/harden/sentinel-board-sync-clear.test.js
+++ b/tests/harden/sentinel-board-sync-clear.test.js
@@ -50,6 +50,40 @@ describe("board-sync — limpieza del pendiente", () => {
     expect(state().sessions.s1.pending_moves).toHaveLength(0);
   });
 
+  // KJC-BUG-0157 (caso real, 29-ago): el create_card hizo timeout, la rama se
+  // bautizó con el ID siguiente ASUMIDO, y el pending quedó anclado a una card
+  // que jamás existió — imposible de limpiar por cardId. La identidad VERDADERA
+  // de un pending es su PR: un cierre confirmado cuyo request nombra ese PR lo
+  // limpia — sigue siendo una llamada real al tracker, jamás prosa.
+  it("un pending huérfano (card inexistente) se limpia por su PR cuando un cierre confirmado lo nombra en pipelineStatus", () => {
+    seed("KJC-TSK-0805");
+    const st0 = state();
+    st0.sessions.s1.pending_moves[0].pr = 1577;
+    fs.writeFileSync(statePath, JSON.stringify(st0));
+    hook(post, {
+      tool_name: "mcp__planning-game-personal__update_card",
+      tool_input: { updates: { status: "To Validate", pipelineStatus: { prCreated: { prNumber: 1577 } } } },
+      tool_response: JSON.stringify({ message: "Card updated successfully", card: { cardId: "KJC-TSK-0806", status: "To Validate" } }),
+    });
+    expect(state().sessions.s1.pending_moves).toHaveLength(0);
+  });
+
+  it("el clear por PR no toca pendings de OTROS PRs, y sin prNumber en el request no limpia nada ajeno", () => {
+    seed("KJC-TSK-0805", "KJC-TSK-0099");
+    const st0 = state();
+    st0.sessions.s1.pending_moves[0].pr = 1577;
+    st0.sessions.s1.pending_moves[1].pr = 1600;
+    fs.writeFileSync(statePath, JSON.stringify(st0));
+    hook(post, {
+      tool_name: "mcp__planning-game-personal__update_card",
+      tool_input: { updates: { status: "Fixed", pipelineStatus: { prCreated: { prNumber: 1577 } } } },
+      tool_response: JSON.stringify({ message: "Card updated successfully", card: { cardId: "KJC-TSK-0777", status: "Fixed" } }),
+    });
+    expect(state().sessions.s1.pending_moves.map((p) => p.card)).toEqual(["KJC-TSK-0099"]);
+    updateCard("KJC-TSK-0123", "To Validate");
+    expect(state().sessions.s1.pending_moves.map((p) => p.card)).toEqual(["KJC-TSK-0099"]);
+  });
+
   it("un update_card que NO cierra (In Progress, sin estado) no limpia nada; otro proyecto/tool tampoco", () => {
     seed("KJC-TSK-0042");
     updateCard("KJC-TSK-0042", "In Progress");


### PR DESCRIPTION
## Board-sync: un pending se limpia por su PR, no solo por su card-id

Card: KJC-BUG-0157 · Encontrado en vivo minutos después de cortar la 4.23.0

El `create_card` del tracker hizo timeout de 30 minutos sin devolver ID; la rama de release se bautizó con el ID siguiente ASUMIDO (`KJC-TSK-0805`); al reintentar, el tracker creó `KJC-TSK-0806`. El PR se mergeó y el pending del board-sync quedó anclado a una card que JAMÁS existió — imposible de limpiar por ninguna vía verificada (el `kj hu move` de una card inexistente ya no limpia desde la 0154, correctamente): deadlock que solo el kill-switch del humano podía romper.

- **La identidad VERDADERA de un pending es su PR, no el ref textual de la rama**: un `update_card` de CIERRE confirmado cuyo request nombra ese PR (`pipelineStatus.prCreated.prNumber`) lo limpia aunque el cardId difiera — sigue siendo una llamada real al tracker vista por el hook, jamás una promesa en prosa.
- Los pendings de OTROS PRs no se tocan, y un request sin prNumber no limpia nada ajeno (con test).
- Probado en vivo antes de esta PR: con el harness regenerado, mover la card real (0806, PR #1577) limpió el pending huérfano y el método volvió a verde sin escape.
