### PR TITLE
fix(steward): phantom-E2E sees interpolated labels by static-chunk prefix (KJC-BUG-0158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The phantom-E2E detector now sees interpolated labels** (KJC-BUG-0158, from GREBLA's field validation of 4.23.0): the phantom that MOTIVATED the detector was invisible to it — the code produces the label interpolated (`aria-label="Head al que reporta ${name}"`) and the test looks for the RESOLVED string, so no exact literal matched; in Lit that is the usual case, not the exception. The crossing now also matches by static-chunk prefix: the longest SUFFIX of a template chunk that is a PREFIX of the test's literal (threshold 8 chars contains false positives), and a LIVE chunk producing at least the same start absolves — covering interpolation must never accuse a test that points at live UI, which is exactly GREBLA's acceptance criterion (their cleaned main must keep reporting zero). Their numbers on member-reachability, for the record: 31/31 exact at the known-truth commit, 0 on main.
+
 ## [4.23.0] - 2026-08-30
 
 ### Fixed

--- a/src/steward/phantom-coverage.js
+++ b/src/steward/phantom-coverage.js
@@ -75,10 +75,25 @@ export function detectPhantomUnit({ sourceAnalysis, testSource, file = "<test>" 
 const literalsOf = (tree, minLength) => {
   const out = [];
   walk(tree, (n) => {
-    if (n.type === "StringLiteral" && n.value.trim().length >= minLength) out.push({ value: n.value, line: n.loc.start.line });
-    if (n.type === "TemplateElement" && n.value.cooked && n.value.cooked.trim().length >= minLength) out.push({ value: n.value.cooked, line: n.loc.start.line });
+    if (n.type === "StringLiteral" && n.value.trim().length >= minLength) out.push({ value: n.value, line: n.loc.start.line, template: false });
+    if (n.type === "TemplateElement" && n.value.cooked && n.value.cooked.trim().length >= minLength) out.push({ value: n.value.cooked, line: n.loc.start.line, template: true });
   });
   return out;
+};
+
+// KJC-BUG-0158 (GREBLA's field validation): an interpolated label —
+// aria-label="Head al que reporta ${name}" — never matches the RESOLVED
+// string a test looks for, and in Lit that is the usual case, not the
+// exception. The static chunk carries markup before the label, so the right
+// crossing is: the longest SUFFIX of a template chunk that is a PREFIX of the
+// test's literal. Threshold contains false positives; a LIVE chunk producing
+// the same start absolves — covering interpolation must never accuse live UI.
+const PREFIX_MIN = 8;
+const overlap = (chunk, wanted) => {
+  for (let k = Math.min(chunk.length, wanted.length); k >= PREFIX_MIN; k--) {
+    if (chunk.endsWith(wanted.slice(0, k))) return k;
+  }
+  return 0;
 };
 
 /**
@@ -99,8 +114,9 @@ export function detectPhantomE2E({ sourceText, sourceAnalysis, testSource, file 
   }
   const deadSpans = observableClasses(sourceAnalysis).flatMap((c) => c.unreachable.map((u) => [u.line, u.endLine]));
   const inDead = (line) => deadSpans.some(([a, b]) => line >= a && line <= b);
+  const sourceLits = literalsOf(sourceTree, minLength);
   const onlyInDead = new Map(); // literal → line where it lives
-  for (const lit of literalsOf(sourceTree, minLength)) {
+  for (const lit of sourceLits) {
     if (inDead(lit.line)) { if (!onlyInDead.has(lit.value)) onlyInDead.set(lit.value, lit.line); }
     else onlyInDead.set(lit.value, -1); // seen reachable — poisoned, never reportable
   }
@@ -108,6 +124,23 @@ export function detectPhantomE2E({ sourceText, sourceAnalysis, testSource, file 
   const phantoms = [...wanted]
     .filter((v) => onlyInDead.get(v) !== undefined && onlyInDead.get(v) !== -1)
     .map((v) => ({ literal: v, line: onlyInDead.get(v), file }));
+  // KJC-BUG-0158: interpolated labels match by static-chunk prefix. Dead wins
+  // only when NO live chunk produces at least the same start.
+  const chunks = sourceLits.filter((l) => l.template);
+  for (const v of wanted) {
+    if (phantoms.some((p) => p.literal === v)) continue;
+    // the exact literal living in REACHABLE code absolves here too (codex's
+    // catch): that test does point at something alive.
+    if (onlyInDead.get(v) === -1) continue;
+    let kDead = 0, kLive = 0, deadLine = 0;
+    for (const c of chunks) {
+      // a chunk CONTAINING the whole literal is the strongest match either way
+      const k = c.value.includes(v) ? v.length : overlap(c.value, v);
+      if (inDead(c.line)) { if (k > kDead) { kDead = k; deadLine = c.line; } }
+      else if (k > kLive) kLive = k;
+    }
+    if (kDead >= PREFIX_MIN && kDead > kLive) phantoms.push({ literal: v, line: deadLine, file });
+  }
   return { observable: true, phantoms };
 }
 

--- a/tests/steward/phantom-coverage.test.js
+++ b/tests/steward/phantom-coverage.test.js
@@ -55,6 +55,42 @@ describe("detectPhantomE2E — literal crossing (the case the call graph cannot 
     });
     expect(r.phantoms).toEqual([]);
   });
+  // KJC-BUG-0158 (GREBLA's field validation, 31-aug): the phantom that
+  // MOTIVATED the detector was invisible to it — the code produces the label
+  // interpolated (aria-label="Head al que reporta ${name}") and the test looks
+  // for the RESOLVED string, so no exact literal matches. In Lit that is the
+  // usual case, not the exception. A test literal that STARTS with a static
+  // template chunk living only in unreachable code is a phantom.
+  it("an interpolated label in dead code is caught by its static prefix — GREBLA's real case", () => {
+    const src = "class Panel extends LitElement {\n  render() { return this._rows(); }\n  _rows() { return 1; }\n  _renderReportsTo(l) { return `<button aria-label=\"Head al que reporta ${l.displayName}\">x</button>`; }\n}";
+    const a = analyzeMemberReachability(src, { file: "panel.js" });
+    const r = detectPhantomE2E({
+      sourceText: src, sourceAnalysis: a,
+      testSource: `test("hierarchy", async ({ page }) => { await page.getByLabel("Head al que reporta Sin Head E2E").click(); });`,
+      file: "hierarchy.spec.js",
+    });
+    expect(r.observable).toBe(true);
+    expect(r.phantoms).toEqual([expect.objectContaining({ literal: "Head al que reporta Sin Head E2E" })]);
+    expect(r.phantoms[0].line).toBeGreaterThan(0);
+  });
+  it("the same interpolated chunk ALSO in live code reports nothing — covering interpolation must not accuse live UI (GREBLA's acceptance)", () => {
+    const src = "class Panel extends LitElement {\n  render() { return `<b aria-label=\"Head al que reporta ${this.x}\">y</b>`; }\n  _renderReportsTo(l) { return `<button aria-label=\"Head al que reporta ${l.displayName}\">x</button>`; }\n}";
+    const a = analyzeMemberReachability(src, { file: "panel.js" });
+    const r = detectPhantomE2E({ sourceText: src, sourceAnalysis: a, testSource: `t("x", () => page.getByLabel("Head al que reporta Sin Head E2E"));`, file: "s.spec.js" });
+    expect(r.phantoms).toEqual([]);
+  });
+  it("the exact literal living in REACHABLE code absolves the prefix pass too — that test points at something alive", () => {
+    const src = "class Panel extends LitElement {\n  render() { return `<b aria-label=\"Head al que reporta Sin Head E2E\">y</b>`; }\n  _renderReportsTo(l) { return `<button aria-label=\"Head al que reporta ${l.displayName}\">x</button>`; }\n}";
+    const a = analyzeMemberReachability(src, { file: "panel.js" });
+    const r = detectPhantomE2E({ sourceText: src, sourceAnalysis: a, testSource: `t("x", () => page.getByLabel("Head al que reporta Sin Head E2E"));`, file: "s.spec.js" });
+    expect(r.phantoms).toEqual([]);
+  });
+  it("a short static chunk never matches by prefix — the threshold contains false positives", () => {
+    const src = "class Panel extends LitElement {\n  render() {}\n  _dead() { return `<i title=\"Ver: ${this.x}\">z</i>`; }\n}";
+    const a = analyzeMemberReachability(src, { file: "panel.js" });
+    const r = detectPhantomE2E({ sourceText: src, sourceAnalysis: a, testSource: `t("x", () => page.getByTitle("Ver: algo concreto"));`, file: "s.spec.js" });
+    expect(r.phantoms).toEqual([]);
+  });
   it("inherits not-observable from the analysis", () => {
     const src = "class A extends Unknown { m() { return 'Etiqueta rara'; } }";
     const na = analyzeMemberReachability(src, { file: "a.js" });


### PR DESCRIPTION
## El detector de fantasmas E2E ve las etiquetas interpoladas

Card: KJC-BUG-0158 · De la validación en campo de GREBLA (4.23.0 desde npm, verdad conocida en 7ab330b^) · Relacionada: KJC-TSK-0807

El fantasma que MOTIVÓ el detector era invisible para él: el código produce la etiqueta interpolada (`aria-label="Head al que reporta ${name}"`) y el test busca la cadena RESUELTA — sin literal exacto que casar. En Lit es el caso habitual, no la excepción.

- **Cruce por prefijo de tramo estático**: el mayor SUFIJO de un tramo de template que sea PREFIJO del literal del test (el tramo lleva el markup delante — por eso sufijo, no arranque). Umbral de 8 caracteres para contener falsos positivos.
- **Tres absoluciones** (el criterio de aceptación de GREBLA: su main limpio debe seguir dando cero): un tramo VIVO que produzca al menos el mismo arranque; el literal exacto presente en código alcanzable (catch de codex); y un tramo vivo que CONTENGA el literal completo (caso hallado por el propio test del fix, más duro que el del reviewer).
- El fixture del test es el caso real: `Head al que reporta ${l.displayName}` en `_renderReportsTo` inalcanzable, spec buscando `Head al que reporta Sin Head E2E` → fantasma con su línea.

Nota para el registro: member-reachability validado por GREBLA con 31/31 exactos en dd5a91a y 0 en su main — la diferencia de denominador (140 vs 139) es el slot static del catálogo v2, no un hallazgo.
