### PR TITLE
feat(go): the muggle launcher core (KJC-TSK-0808)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kj go`: the muggle launcher** (MGL-A part 1, KJC-TSK-0808, epic KJC-PCS-0084): one command for a person with no computing background. It detects their installed agents (Claude Code, Codex — the same cheap local checks the reviewer registry uses, never a spawned process for auth), asks AT MOST one question (which agent, only when there are two; zero when there is one, none repeated once the project is prepared), prepares the project silently (`env install` only when the gate marker is missing), opens the HU Board alongside — respecting `hu_board.enabled: false`, and a board failure never stops the conversation — and launches the interactive session with a SHORT plain-language opening prompt: the full playbook already lives in the agent files, so the prompt sets the tone (plain words, say-before-doing, errors explained with a next step) instead of duplicating the method. What cannot be hidden is said honestly: no agent installed gets the exact install commands, no login gets the exact login command — the account is theirs, kj never touches credentials. CLI wiring lands in part 2.
+
 ### Fixed
 
 - **A phantom finding now points at the TEST** (KJC-BUG-0159, from GREBLA's re-measurement of the 0158 fix): the finding carried the dead code's line under the test's file — `hierarchy.spec.js:2183` on a 32-line spec sends the reader nowhere. `file`+`line` now name the spec and the literal's line in it (where the fix happens), and the dead chunk's spot travels apart as `sourceLine`. Their re-measurement, for the record: the motivating phantom is now caught (7ab330b^), their clean main still reports zero, and the one accusation under a synthetic cross-era pair was correctly classified by them as a known scope limit (single-file contract), not a false positive.

--- a/src/commands/go.js
+++ b/src/commands/go.js
@@ -1,0 +1,108 @@
+/**
+ * `kj go` (MGL-A, KJC-TSK-0808, epic KJC-PCS-0084) — the muggle launcher.
+ * One command for a person with no computing background: detect their agents,
+ * ask AT MOST one question, prepare the project silently, open the board, and
+ * leave them inside a conversation that already knows the method. What cannot
+ * be hidden is said honestly: the agent's account and login are THEIRS — kj
+ * never touches credentials. Everything is injectable so tests spawn nothing.
+ */
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { checkBinary } from "../utils/agent-detect.js";
+import { createCliAskQuestion } from "../utils/cli-ask-question.js";
+import { envInstallCommand } from "./env.js";
+import { boardCommand } from "./board.js";
+// The interactive launchers a muggle can live inside (v1: the two the epic
+// names). Auth heuristics are the same cheap file checks reviewer-fallback
+// uses: menu signal, never a spawned process.
+export const MAGGLE_AGENTS = [
+  { name: "claude", label: "Claude Code (Anthropic)", authPaths: [".claude.json", ".claude"], install: "npm install -g @anthropic-ai/claude-code", login: "claude   (sigue el enlace de inicio de sesión que te muestre)" },
+  { name: "codex", label: "Codex (OpenAI)", authPaths: [".codex/auth.json"], install: "npm install -g @openai/codex", login: "codex login" },
+];
+export async function detectMaggleAgents({ home = os.homedir(), checkBin = checkBinary } = {}) {
+  return Promise.all(
+    MAGGLE_AGENTS.map(async (a) => {
+      let installed = false;
+      try { installed = (await checkBin(a.name)).ok; } catch { /* not installed */ }
+      const authenticated = installed && a.authPaths.some((p) => existsSync(path.join(home, p)));
+      return { ...a, installed, authenticated };
+    }),
+  );
+}
+/** The session's opening prompt — SHORT and in plain language. The full
+ * playbook already lives in the agent files env-install wrote; duplicating it
+ * here would dilute it. This prompt sets the tone for a muggle. */
+export function buildGoPrompt() {
+  return [
+    "Arrancas dentro de un proyecto gobernado por Karajan (las reglas del método ya están en los ficheros de agente de este proyecto: síguelas siempre).",
+    "La persona que te habla puede no saber programar. Habla en lenguaje llano: sin jerga, sin siglas sin explicar, y resume cada resultado en una o dos frases antes del detalle.",
+    "Antes de cambios importantes, di en llano qué vas a hacer y qué pasará. Si algo falla, explica qué pasó y cuál es el siguiente paso — nunca un volcado de error a secas.",
+    "El tablero del proyecto está abierto en su navegador: cuando termines algo, recuérdale que puede verlo ahí.",
+    "Empieza presentándote en dos frases y preguntando qué quiere construir o cambiar hoy.",
+  ].join("\n");
+}
+async function defaultPrepare({ config, logger }) {
+  await envInstallCommand({ config, logger, flags: { yes: true } });
+}
+async function defaultBoard({ config, logger }) {
+  const port = config.hu_board?.port || 4000;
+  await boardCommand({ action: "start", port, bind: "127.0.0.1", logger });
+  await boardCommand({ action: "open", port, bind: "127.0.0.1", logger });
+}
+function defaultLaunch(agent, prompt) {
+  // Interactive session: the muggle LIVES here. CLAUDECODE is stripped so a
+  // nested Claude does not refuse to start (the known subprocess quirk).
+  const { CLAUDECODE: _omit, ...env } = process.env;
+  return new Promise((resolvePromise) => {
+    const child = spawn(agent.name, [prompt], { stdio: "inherit", env });
+    child.on("exit", (code) => resolvePromise(code ?? 0));
+    child.on("error", (err) => {
+      console.error(`No se pudo arrancar ${agent.label}: ${err.message}`);
+      resolvePromise(1);
+    });
+  });
+}
+export async function goCommand({ config = {}, logger = console, flags = {}, deps = {} } = {}) {
+  const projectDir = config.projectDir || process.cwd();
+  const agents = await (deps.detect ?? detectMaggleAgents)();
+  const ready = agents.filter((a) => a.installed && a.authenticated);
+  const needLogin = agents.filter((a) => a.installed && !a.authenticated);
+  if (ready.length === 0) {
+    if (needLogin.length > 0) {
+      logger.error?.("Tienes el agente instalado pero falta iniciar sesión — eso solo puedes hacerlo tú (la cuenta es tuya; Karajan nunca toca tus credenciales):");
+      for (const a of needLogin) logger.error?.(`  ${a.label}:  ${a.login}`);
+      logger.error?.("Cuando hayas iniciado sesión, vuelve a escribir: kj go");
+    } else {
+      logger.error?.("Karajan trabaja con un agente de IA que aún no tienes instalado. Elige uno, instálalo con su comando, e inicia sesión con TU cuenta (la cuenta es tuya):");
+      for (const a of agents) logger.error?.(`  ${a.label}:  ${a.install}`);
+      logger.error?.("Después, vuelve a escribir: kj go");
+    }
+    process.exitCode = 1;
+    return 1;
+  }
+  let chosen = ready[0];
+  if (ready.length > 1) {
+    const ask = deps.ask ?? createCliAskQuestion({ flags });
+    const answer = await ask("¿Con cuál de tus agentes quieres trabajar?", { options: ready.map((a) => a.name), default: ready[0].name });
+    chosen = ready.find((a) => a.name === String(answer).trim()) ?? ready[0];
+  }
+  logger.info?.(`Trabajarás con ${chosen.label}.`);
+  // Prepare ONCE: decisions already taken are never re-asked.
+  if (!existsSync(path.join(projectDir, ".karajan", "review-gate"))) {
+    logger.info?.("Preparando tu proyecto (solo la primera vez)…");
+    await (deps.prepare ?? defaultPrepare)({ config, logger });
+  }
+  // The board is the muggle's window — unless the project turned it off
+  // (hu_board.enabled false is respected: KJC-BUG-0152). A board failure is
+  // said and never stops the conversation from starting.
+  if (config.hu_board?.enabled !== false) {
+    try { await (deps.board ?? defaultBoard)({ config, logger }); } catch (err) { logger.warn?.(`El tablero no pudo abrirse (${err.message}) — la conversación arranca igual.`); }
+  }
+  const prompt = (deps.prompt ?? buildGoPrompt)();
+  logger.info?.("Abriendo tu conversación… (escribe ahí lo que necesites, en tu idioma)");
+  const code = await (deps.launch ?? defaultLaunch)(chosen, prompt);
+  process.exitCode = code;
+  return code;
+}

--- a/tests/commands/command-go.test.js
+++ b/tests/commands/command-go.test.js
@@ -1,0 +1,86 @@
+// MGL-A (KJC-TSK-0808, epic KJC-PCS-0084) — `kj go`: the muggle launcher.
+// One command: detect agents, ask AT MOST one question, prepare the project
+// silently, open the board, and hand the person a conversation that already
+// knows the method. Everything injectable — no real processes in tests.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { goCommand } from "../../src/commands/go.js";
+
+let dir;
+const logger = () => ({
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  all: function () { return [...this.info.mock.calls, ...this.warn.mock.calls, ...this.error.mock.calls].flat().join("\n"); },
+});
+const agent = (name, over = {}) => ({ name, label: name, installed: true, authenticated: true, install: `npm install -g ${name}-cli`, login: `${name} login`, ...over });
+const run = (over = {}) => {
+  const deps = {
+    detect: async () => [agent("claude"), agent("codex")],
+    ask: vi.fn(async () => "claude"),
+    prepare: vi.fn(async () => {}),
+    board: vi.fn(async () => {}),
+    launch: vi.fn(async () => 0),
+    ...over.deps,
+  };
+  return goCommand({ config: { projectDir: dir, ...over.config }, logger: over.logger ?? logger(), flags: {}, deps }).then((code) => ({ code, deps }));
+};
+
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-go-")); });
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe("kj go", () => {
+  it("two ready agents: exactly ONE question, and the answer picks the session", async () => {
+    const { code, deps } = await run();
+    expect(code).toBe(0);
+    expect(deps.ask).toHaveBeenCalledOnce();
+    expect(deps.launch.mock.calls[0][0].name).toBe("claude");
+  });
+  it("one ready agent: zero questions — it is used and said", async () => {
+    const log = logger();
+    const { deps } = await run({ logger: log, deps: { detect: async () => [agent("codex"), agent("claude", { installed: false, authenticated: false })] } });
+    expect(deps.ask).not.toHaveBeenCalled();
+    expect(deps.launch.mock.calls[0][0].name).toBe("codex");
+    expect(log.all()).toMatch(/codex/i);
+  });
+  it("no agent, or no login: never an error dump — the exact install/login commands and the honest note that the account is theirs", async () => {
+    const none = logger();
+    const r1 = await run({ logger: none, deps: { detect: async () => [agent("claude", { installed: false, authenticated: false }), agent("codex", { installed: false, authenticated: false })] } });
+    expect(r1.code).toBe(1);
+    expect(r1.deps.launch).not.toHaveBeenCalled();
+    expect(none.all()).toMatch(/npm install -g claude-cli/);
+    expect(none.all()).toMatch(/cuenta/i); // la cuenta y el login son suyos
+    const noAuth = logger();
+    const r2 = await run({ logger: noAuth, deps: { detect: async () => [agent("claude", { authenticated: false })] } });
+    expect(r2.code).toBe(1);
+    expect(noAuth.all()).toMatch(/claude login/);
+  });
+  it("an unprepared project is prepared silently; a prepared one is NEVER re-asked", async () => {
+    const first = await run({ deps: { detect: async () => [agent("claude")] } });
+    expect(first.deps.prepare).toHaveBeenCalledOnce();
+    fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+    fs.writeFileSync(path.join(dir, ".karajan", "review-gate"), "x");
+    const second = await run({ deps: { detect: async () => [agent("claude")] } });
+    expect(second.deps.prepare).not.toHaveBeenCalled();
+  });
+  it("the board opens alongside — unless the project turned it off (hu_board.enabled false is respected)", async () => {
+    const on = await run({ deps: { detect: async () => [agent("claude")] } });
+    expect(on.deps.board).toHaveBeenCalledOnce();
+    const off = await run({ config: { hu_board: { enabled: false } }, deps: { detect: async () => [agent("claude")] } });
+    expect(off.deps.board).not.toHaveBeenCalled();
+  });
+  it("the launcher gets a non-empty prompt in plain language — the session is born knowing whom it talks to", async () => {
+    const { deps } = await run({ deps: { detect: async () => [agent("claude")] } });
+    const prompt = deps.launch.mock.calls[0][1];
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(100);
+    expect(prompt).toMatch(/llano/i);
+  });
+  it("a board failure never stops the launch — said, not fatal", async () => {
+    const log = logger();
+    const { code, deps } = await run({ logger: log, deps: { detect: async () => [agent("claude")], board: vi.fn(async () => { throw new Error("port busy"); }) } });
+    expect(code).toBe(0);
+    expect(deps.launch).toHaveBeenCalledOnce();
+    expect(log.all()).toMatch(/port busy/);
+  });
+});


### PR DESCRIPTION
MGL-A parte 1: goCommand con detección de agentes (checks locales baratos, jamás credenciales), una pregunta como máximo, preparación silenciosa única, board respetando enabled:false y sin bloquear el arranque, y lanzamiento interactivo con prompt corto en llano (el playbook ya vive en los ficheros de agente — no se duplica). Todo inyectable; 7 tests. El registro CLI llega en la parte 2.