### PR TITLE
feat(board): plain-language maggle mode opened by kj go

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -326,7 +326,8 @@ export default [
            confirmRunWithPreflight cssEscape currentSessionId currentView deriveInitialsFromName deriveRoleStatus els
            embedderCard ensureDialog esc escapeHtml fetchPreflight formatCacheRatio formatCost formatDuration formatHHMM
            formatProjectCostSummary formatSessionLabel handleRoute humaniseProjectName isTestIcon isTestTitle
-           lastLaunchedPlanId lastOpenedLog load loadSessions logPollTimer logViewerState navigate nextIsTestValue
+           isMaggleMode lastLaunchedPlanId lastOpenedLog load loadSessions logPollTimer logViewerState maggleText
+           applyMaggleChrome MAGGLE_LABELS MAGGLE_STORE_KEY navigate nextIsTestValue
            openCommandLogViewer openGenericLogPanel openLogViewer patchBoardIncremental pollServerVersion pollTimer
            populateProjectSelect preflightCache preflightStatusColor preflightStatusIcon projectInitialsCache
            projectIsSharedCache projectNameCache qualityBar refreshCurrentView refreshInterval refreshOnce refreshStandby

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -53,6 +53,7 @@
     <div class="modal" id="modal-content"></div>
   </div>
 
+  <script src="/utils/maggle-mode.js"></script>
   <script src="/utils/formatters.js"></script>
   <script src="/utils/modals.js"></script>
   <script src="/utils/api.js"></script>

--- a/packages/hu-board/public/utils/board-view.js
+++ b/packages/hu-board/public/utils/board-view.js
@@ -87,48 +87,49 @@ async function renderBoard() {
 
     // KJC-TSK-0403: 3 canonical lanes. Failed eliminado — HUs con
     // result=fail aparecen en Pending con badge ✗.
+    // Maggle mode (KJC-TSK-0810): plain label first, jargon as tooltip.
     const visibleColumns = [
-      { title: 'Pending', cls: 'pending', rows: columns.pending },
-      { title: 'Running', cls: 'running', rows: columns.running },
-      { title: 'Done', cls: 'done', rows: columns.done },
+      { title: maggleText('column.pending', 'Pending'), cls: 'pending', rows: columns.pending },
+      { title: maggleText('column.running', 'Running'), cls: 'running', rows: columns.running },
+      { title: maggleText('column.done', 'Done'), cls: 'done', rows: columns.done },
     ];
 
     app.innerHTML = `
       <div class="section-header">
-        <span class="section-header__title" title="${selectedProject ? esc(selectedProject) : ''}">Story Board${selectedProject ? ` - ${esc(projectDisplayName)}` : ''}</span>
+        <span class="section-header__title" title="${selectedProject ? esc(selectedProject) : ''}">${maggleText('board.title', 'Story Board')}${selectedProject ? ` - ${esc(projectDisplayName)}` : ''}</span>
         ${selectedProject ? `
           <button class="control-btn project-rename-btn"
                   style="background:transparent;border:none;color:var(--text-muted);cursor:pointer;font-size:0.9rem;padding:2px 6px;"
                   title="Renombrar este proyecto"
                   onclick="event.stopPropagation(); window.renameProjectModal('${esc(selectedProject)}', '${esc(projectDisplayName.replace(/'/g, '&#39;'))}');">✎</button>
         ` : ''}
-        <span class="section-header__count">${stories.length} stories</span>
+        <span class="section-header__count" title="stories">${stories.length} ${maggleText('board.stories', 'stories')}</span>
         ${costSummary ? `<span class="section-header__cost" title="${esc(costSummary.tooltip)}">💵 ${esc(costSummary.label)}</span>` : ''}
         ${cacheSummary ? `<span class="section-header__cache" title="${esc(cacheSummary.tooltip)}">${esc(cacheSummary.label)}</span>` : ''}
         ${isRunning ? `
           <button id="running-badge-btn" class="section-header__badge"
                 style="margin-left:auto;padding:4px 10px;font-size:0.8rem;background:var(--color-yellow,#eab308);color:#000;border-radius:var(--radius-sm);font-weight:600;border:none;cursor:pointer;"
                 title="Abrir el log de la HU en marcha">
-            ⚙ ${runningCount} running…
+            ⚙ ${runningCount} ${maggleText('board.running', 'running')}…
           </button>
           <button id="stop-run-btn" class="control-btn"
                 style="padding:4px 10px;font-size:0.8rem;background:var(--color-red,#ef4444);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;"
-                title="Abortar todos los kj run en marcha de este proyecto (SIGTERM con escalado a SIGKILL tras 5s)">
-            ⏹ Stop
+                title="${maggleText('board.stopTitle', 'Abortar todos los kj run en marcha de este proyecto (SIGTERM con escalado a SIGKILL tras 5s)')}">
+            ${maggleText('board.stop', '⏹ Stop')}
           </button>
         ` : ''}
         ${lastOpenedLog ? `
           <button class="control-btn" id="view-log-btn"
                   style="${isRunning ? '' : 'margin-left:auto;'}padding:6px 12px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);cursor:pointer;"
                   title="Re-open the log of the most recent run/command">
-            📜 View log
+            ${maggleText('board.viewLog', '📜 View log')}
           </button>
         ` : ''}
         ${canRun ? `
           <button class="control-btn" id="run-plan-btn"
                   style="margin-left:auto;padding:6px 14px;font-size:0.9rem;background:var(--color-green);color:#fff;border:none;border-radius:var(--radius-sm);cursor:pointer;font-weight:600;"
-                  title="Launch kj run --plan over every plan in this project">
-            ▶ Run plan (${awaitingCount} HU${awaitingCount === 1 ? '' : 's'})
+                  title="${maggleText('board.runTitle', 'Launch kj run --plan over every plan in this project')}">
+            ${maggleText('board.run', '▶ Run plan')} (${awaitingCount} ${maggleText('board.story', 'HU')}${awaitingCount === 1 ? '' : 's'})
           </button>
         ` : ''}
       </div>
@@ -138,7 +139,7 @@ async function renderBoard() {
         </div>
       </div>
       <div id="rag-panel" class="rag-panel" style="margin:8px 0;display:flex;gap:8px;align-items:flex-start;flex-wrap:wrap;">
-        <input id="rag-query" type="text" placeholder="🔍 RAG search: ask anything about this project's plans / onboarding / code…"
+        <input id="rag-query" type="text" placeholder="${maggleText('board.ragPlaceholder', "🔍 RAG search: ask anything about this project's plans / onboarding / code…")}"
                style="flex:1;min-width:260px;padding:6px 10px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);" />
         <select id="rag-scope" style="padding:6px 10px;font-size:0.85rem;background:var(--bg-primary);border:1px solid var(--border);color:var(--text);border-radius:var(--radius-sm);">
           <option value="all">All</option><option value="plans">Plans</option><option value="onboarding">Onboarding</option><option value="code">Code</option>
@@ -305,7 +306,7 @@ function renderKanbanColumn(title, cssClass, stories) {
   return `
     <div class="kanban__column kanban__column--${cssClass}" data-column="${cssClass}"${stories.length === 0 ? ' style="opacity:0.55"' : ''}>
       <div class="kanban__column-header">
-        <span class="kanban__column-title">${title}</span>
+        <span class="kanban__column-title" title="${cssClass}">${title}</span>
         <span class="kanban__column-count" data-column-count>${stories.length}</span>
       </div>
       ${stories.map(renderStoryCard).join('')}

--- a/packages/hu-board/public/utils/maggle-mode.js
+++ b/packages/hu-board/public/utils/maggle-mode.js
@@ -1,0 +1,63 @@
+// KJC-TSK-0810 (MGL-C) — maggle mode: the board in plain language.
+//
+// Classic script (no exports), loaded FIRST among the utils so the other
+// scripts can call maggleText() at render time. `kj go` opens the board at
+// /?maggle=1; the choice persists in localStorage so reloads keep the
+// plain-language UI, and ?maggle=0 (the "modo experto" link) clears it.
+// A dev opening the board directly sees no change. If storage is
+// unavailable the mode degrades to the technical UI — it never breaks.
+
+const MAGGLE_STORE_KEY = 'kj-maggle-mode';
+
+// Plain label first; the technical term survives as tooltip/secondary
+// detail where each call site renders it (AC1: llano delante, jerga detrás).
+const MAGGLE_LABELS = {
+  'column.pending': 'Por hacer',
+  'column.running': 'En marcha',
+  'column.done': 'Hecho',
+  'board.title': 'Tu trabajo',
+  'board.stories': 'tareas',
+  'board.story': 'tarea',
+  'board.run': '▶ Continuar con lo pendiente',
+  'board.runTitle': 'Karajan seguirá con las tareas que faltan, una a una. Podrás ver la actividad aquí.',
+  'board.stop': '⏹ Parar',
+  'board.stopTitle': 'Detiene el trabajo en marcha. Lo ya terminado se conserva.',
+  'board.viewLog': '📜 Ver actividad',
+  'board.running': 'en marcha',
+  'board.ragPlaceholder': '🔍 Pregunta lo que quieras sobre este proyecto…',
+  'header.subtitle': 'tu tablero de trabajo',
+  'nav.board': 'Tablero',
+  'nav.dashboard': 'Proyectos',
+  'nav.more': 'Más',
+};
+
+function isMaggleMode() {
+  try {
+    const flag = new URLSearchParams(location.search || '').get('maggle');
+    if (flag === '1') { localStorage.setItem(MAGGLE_STORE_KEY, '1'); return true; }
+    if (flag === '0') { localStorage.removeItem(MAGGLE_STORE_KEY); return false; }
+    return localStorage.getItem(MAGGLE_STORE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Plain label when maggle mode is on; the technical one otherwise. */
+function maggleText(key, technical) {
+  if (!isMaggleMode()) return technical;
+  return MAGGLE_LABELS[key] || technical;
+}
+
+// Minimal chrome for this step: mark the body (CSS hook) and put the
+// subtitle in plain language. Folding the advanced nav behind "Más" is
+// AC2 and ships with the launcher step (PR-C2 of KJC-TSK-0810).
+function applyMaggleChrome() {
+  if (!isMaggleMode()) return;
+  document.body.classList.add('maggle-mode');
+  const subtitle = document.querySelector('.header__subtitle');
+  if (subtitle) subtitle.textContent = MAGGLE_LABELS['header.subtitle'];
+}
+
+if (typeof document !== 'undefined' && document.addEventListener) {
+  document.addEventListener('DOMContentLoaded', applyMaggleChrome);
+}

--- a/packages/hu-board/tests/maggle-mode.test.js
+++ b/packages/hu-board/tests/maggle-mode.test.js
@@ -1,0 +1,75 @@
+// KJC-TSK-0810 (MGL-C) — maggle mode: the board in plain language.
+//
+// maggle-mode.js is a classic browser script (no exports), so the test
+// loads it into a node:vm context with a fake location/localStorage and
+// asserts against the hoisted function declarations.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+
+const src = readFileSync(
+  fileURLToPath(new URL('../public/utils/maggle-mode.js', import.meta.url)),
+  'utf8'
+);
+
+function loadMaggle({ search = '', stored = null, brokenStorage = false } = {}) {
+  const store = new Map();
+  if (stored !== null) store.set('kj-maggle-mode', stored);
+  const localStorage = brokenStorage
+    ? { getItem() { throw new Error('denied'); }, setItem() { throw new Error('denied'); }, removeItem() { throw new Error('denied'); } }
+    : {
+        getItem: (k) => (store.has(k) ? store.get(k) : null),
+        setItem: (k, v) => store.set(k, String(v)),
+        removeItem: (k) => store.delete(k),
+      };
+  const ctx = { location: { search }, localStorage, URLSearchParams };
+  vm.createContext(ctx);
+  vm.runInContext(src, ctx);
+  return { ctx, store };
+}
+
+describe('maggle mode (KJC-TSK-0810)', () => {
+  it('?maggle=1 turns the mode on and persists it for reloads', () => {
+    const { ctx, store } = loadMaggle({ search: '?maggle=1' });
+    expect(ctx.isMaggleMode()).toBe(true);
+    expect(store.get('kj-maggle-mode')).toBe('1');
+  });
+
+  it('without the flag or persistence the board stays technical', () => {
+    const { ctx } = loadMaggle();
+    expect(ctx.isMaggleMode()).toBe(false);
+    expect(ctx.maggleText('column.pending', 'Pending')).toBe('Pending');
+  });
+
+  it('a persisted choice survives a reload without the query string', () => {
+    const { ctx } = loadMaggle({ stored: '1' });
+    expect(ctx.isMaggleMode()).toBe(true);
+    expect(ctx.maggleText('column.pending', 'Pending')).toBe('Por hacer');
+  });
+
+  it('?maggle=0 turns the mode off and clears the persistence', () => {
+    const { ctx, store } = loadMaggle({ stored: '1', search: '?maggle=0' });
+    expect(ctx.isMaggleMode()).toBe(false);
+    expect(store.has('kj-maggle-mode')).toBe(false);
+  });
+
+  it('covers the three kanban columns with plain labels distinct from the jargon', () => {
+    const { ctx } = loadMaggle({ stored: '1' });
+    for (const [key, jargon] of [
+      ['column.pending', 'Pending'],
+      ['column.running', 'Running'],
+      ['column.done', 'Done'],
+    ]) {
+      const plain = ctx.maggleText(key, jargon);
+      expect(plain).toBeTruthy();
+      expect(plain).not.toBe(jargon);
+    }
+  });
+
+  it('degrades to the technical UI when localStorage is unavailable, never breaks', () => {
+    const { ctx } = loadMaggle({ search: '?maggle=1', brokenStorage: true });
+    expect(ctx.isMaggleMode()).toBe(false);
+    expect(ctx.maggleText('column.done', 'Done')).toBe('Done');
+  });
+});

--- a/src/commands/board.js
+++ b/src/commands/board.js
@@ -87,8 +87,23 @@ async function findAvailablePort(desiredPort, maxTries = 10) {
  * @returns {string}
  */
 export function buildBoardUrl(port, projectSlug) {
-  const base = `http://localhost:${port}`;
-  return projectSlug ? `${base}/#board/${projectSlug}` : base;
+  return projectSlug ? boardUrl(port, `/#board/${projectSlug}`) : boardUrl(port);
+}
+
+/**
+ * Base board URL plus an optional absolute path (query and/or hash) —
+ * `kj go` opens `/?maggle=1` so the frontend renders in plain language
+ * (KJC-TSK-0810). A relative path is a caller bug, not something to fix
+ * up silently.
+ * @param {number} port
+ * @param {string} [path]
+ * @returns {string}
+ */
+export function boardUrl(port, path = "") {
+  if (path && !path.startsWith("/")) {
+    throw new Error(`board path must start with "/": ${path}`);
+  }
+  return `http://localhost:${port}${path}`;
 }
 
 /**
@@ -368,7 +383,7 @@ export function renderBoardBanner({ url, status, projectName }) {
   return ["", rule, ...content, rule, ""].join("\n");
 }
 
-export async function boardCommand({ action = "start", port = 4000, bind = "127.0.0.1", logger }) {
+export async function boardCommand({ action = "start", port = 4000, bind = "127.0.0.1", logger, path }) {
   switch (action) {
     case "start": {
       let result;
@@ -422,7 +437,7 @@ export async function boardCommand({ action = "start", port = 4000, bind = "127.
         logger.info("HU Board is not running. Starting it first...");
         await startBoard(port);
       }
-      const url = `http://localhost:${port}`;
+      const url = boardUrl(port, path);
       // eslint-disable-next-line import-x/no-unresolved -- optional peer; the .catch handles its absence
       const { default: open } = await import("open").catch(() => ({ default: null }));
       if (open) {

--- a/src/commands/go.js
+++ b/src/commands/go.js
@@ -46,10 +46,12 @@ export function buildGoPrompt() {
 async function defaultPrepare({ config, logger }) {
   await envInstallCommand({ config, logger, flags: { yes: true } });
 }
-async function defaultBoard({ config, logger }) {
+export async function defaultBoard({ config, logger, runBoard = boardCommand }) {
   const port = config.hu_board?.port || 4000;
-  await boardCommand({ action: "start", port, bind: "127.0.0.1", logger });
-  await boardCommand({ action: "open", port, bind: "127.0.0.1", logger });
+  await runBoard({ action: "start", port, bind: "127.0.0.1", logger });
+  // /?maggle=1 switches the frontend to plain language (KJC-TSK-0810) —
+  // the muggle's window opens already speaking their language.
+  await runBoard({ action: "open", port, bind: "127.0.0.1", path: "/?maggle=1", logger });
 }
 function defaultLaunch(agent, prompt) {
   // Interactive session: the muggle LIVES here. CLAUDECODE is stripped so a

--- a/tests/commands/command-go.test.js
+++ b/tests/commands/command-go.test.js
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { goCommand, detectMaggleAgents } from "../../src/commands/go.js";
+import { goCommand, detectMaggleAgents, defaultBoard } from "../../src/commands/go.js";
+import { boardUrl } from "../../src/commands/board.js";
 
 describe("detectMaggleAgents", () => {
   it("installed × authenticated from cheap local checks — no process is spawned for auth", async () => {
@@ -96,5 +97,18 @@ describe("kj go", () => {
     expect(code).toBe(0);
     expect(deps.launch).toHaveBeenCalledOnce();
     expect(log.all()).toMatch(/port busy/);
+  });
+  // MGL-C (KJC-TSK-0810): the board kj go opens speaks plain language —
+  // the open action carries /?maggle=1 so the frontend switches vocabulary.
+  it("the board opens in maggle mode: the open action carries /?maggle=1", async () => {
+    const calls = [];
+    await defaultBoard({ config: {}, logger: logger(), runBoard: async (opts) => { calls.push(opts); } });
+    const open = calls.find((c) => c.action === "open");
+    expect(open.path).toBe("/?maggle=1");
+  });
+  it("boardUrl appends the path and rejects one that does not start with /", () => {
+    expect(boardUrl(4000, "/?maggle=1")).toBe("http://localhost:4000/?maggle=1");
+    expect(boardUrl(4000)).toBe("http://localhost:4000");
+    expect(() => boardUrl(4000, "maggle=1")).toThrow(/must start/);
   });
 });


### PR DESCRIPTION
## El board en llano — modo maggle abierto por kj go (PR 1 de 2)

Card: KJC-TSK-0810 (MGL-C) · Épica: KJC-PCS-0084

`kj go` abre ahora el board en `/?maggle=1` y el frontend cambia de vocabulario: columnas **Por hacer / En marcha / Hecho**, cabecera **Tu trabajo**, contador en **tareas**, «⏹ Parar», «📜 Ver actividad», «▶ Continuar con lo pendiente» con confirmación en el tooltip de qué va a pasar, y el buscador RAG en llano. El término técnico sobrevive como tooltip (AC1: llano delante, jerga detrás).

- El modo persiste en `localStorage`; `?maggle=0` devuelve la UI experta. Quien abre `localhost:4000` directamente no nota ningún cambio (verificado con captura en ambos modos).
- `maggle-mode.js` es un script clásico testeado vía `node:vm` (6 tests): activación, persistencia, apagado, diccionario de las 3 columnas y degradación sin romper cuando `localStorage` no está.
- `boardUrl(port, path)` nueva primitiva en `board.js` (path absoluto o error — sin arreglos silenciosos); `buildBoardUrl` la reutiliza; la acción `open` la honra; `defaultBoard` de `kj go` pasa `/?maggle=1` (inyectable, 2 tests nuevos).

La segunda PR de la card trae el AC2-4: launcher en llano con confirmación, nav avanzada tras «Más», actividad legible y errores con paso siguiente.

Suites: hu-board 444 ✓ · command-go 10 ✓. Sin errores de consola en ninguno de los dos modos.
