### PR TITLE
feat(board): plain launcher, activity panel and errors with next step

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -327,7 +327,7 @@ export default [
            embedderCard ensureDialog esc escapeHtml fetchPreflight formatCacheRatio formatCost formatDuration formatHHMM
            formatProjectCostSummary formatSessionLabel handleRoute humaniseProjectName isTestIcon isTestTitle
            isMaggleMode lastLaunchedPlanId lastOpenedLog load loadSessions logPollTimer logViewerState maggleText
-           applyMaggleChrome MAGGLE_LABELS MAGGLE_STORE_KEY navigate nextIsTestValue
+           applyMaggleChrome maggleErrorParts MAGGLE_LABELS MAGGLE_STORE_KEY navigate nextIsTestValue
            openCommandLogViewer openGenericLogPanel openLogViewer patchBoardIncremental pollServerVersion pollTimer
            populateProjectSelect preflightCache preflightStatusColor preflightStatusIcon projectInitialsCache
            projectIsSharedCache projectNameCache qualityBar refreshCurrentView refreshInterval refreshOnce refreshStandby

--- a/packages/hu-board/public/utils/command-launcher.js
+++ b/packages/hu-board/public/utils/command-launcher.js
@@ -60,10 +60,25 @@ async function showCommandLauncher() {
     },
   };
 
+  // Maggle mode (KJC-TSK-0810 AC2): the frequent action leads in plain
+  // language — one textarea, clear promise of what will happen. The full
+  // technical launcher (file paths, architect, clean) stays one click
+  // away behind "Más opciones…".
+  const maggle = isMaggleMode();
+  let advancedVisible = !maggle;
+  if (maggle) {
+    SCHEMAS.plan.label = maggleText('launcher.planLabel', SCHEMAS.plan.label);
+    SCHEMAS.plan.help = maggleText('launcher.planHelp', SCHEMAS.plan.help);
+    SCHEMAS.plan.simpleFields = [
+      { name: 'task', label: maggleText('launcher.taskLabel', 'Task'), type: 'textarea', rows: 6 },
+    ];
+  }
+
   let active = 'plan';
   const renderForm = () => {
     const s = SCHEMAS[active];
-    const fields = s.fields.map((f) => {
+    const visibleFields = (!advancedVisible && s.simpleFields) ? s.simpleFields : s.fields;
+    const fields = visibleFields.map((f) => {
       const id = `cmd-field-${f.name}`;
       if (f.type === 'textarea') {
         return `
@@ -90,14 +105,14 @@ async function showCommandLauncher() {
 
     dlg.innerHTML = `
       <div style="padding:14px 18px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;justify-content:space-between;gap:10px">
-        <span>⚡ Run a Karajan command</span>
+        <span>${esc(maggleText('launcher.title', '⚡ Run a Karajan command'))}</span>
         <button id="cmd-close" type="button" class="control-btn"
                 style="padding:4px 10px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
           ✕
         </button>
       </div>
       <div style="padding:12px 18px;display:flex;gap:8px;border-bottom:1px solid var(--border)">
-        ${Object.entries(SCHEMAS).map(([key, s]) => `
+        ${Object.entries(SCHEMAS).filter(([key]) => advancedVisible || key === 'plan').map(([key, s]) => `
           <button type="button" data-cmd="${key}"
                   style="padding:6px 12px;border:1px solid var(--border);
                          background:${key === active ? 'var(--color-green)' : 'var(--bg-primary)'};
@@ -106,6 +121,13 @@ async function showCommandLauncher() {
             ${esc(s.label)}
           </button>
         `).join('')}
+        ${maggle && !advancedVisible ? `
+          <button type="button" id="cmd-more"
+                  style="margin-left:auto;padding:6px 12px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text-muted);border-radius:var(--radius-sm);cursor:pointer;font-size:0.85rem"
+                  title="Comandos técnicos: kj plan con ficheros, kj architect, kj clean">
+            ${esc(maggleText('launcher.more', 'More…'))}
+          </button>
+        ` : ''}
       </div>
       <form id="cmd-form" onsubmit="return false"
             style="padding:14px 18px;display:flex;flex-direction:column;gap:12px;width:min(640px, 88vw);box-sizing:border-box">
@@ -114,11 +136,11 @@ async function showCommandLauncher() {
         <div style="display:flex;justify-content:flex-end;gap:8px;padding-top:8px;border-top:1px solid var(--border)">
           <button type="button" id="cmd-cancel" class="control-btn"
                   style="padding:6px 14px;border:1px solid var(--border);background:var(--bg-primary);color:var(--text);border-radius:var(--radius-sm);cursor:pointer">
-            Cancel
+            ${esc(maggleText('launcher.cancel', 'Cancel'))}
           </button>
           <button type="button" id="cmd-submit" class="control-btn"
                   style="padding:6px 14px;border:none;background:var(--color-green);color:#fff;border-radius:var(--radius-sm);cursor:pointer;font-weight:600">
-            Run
+            ${esc(maggleText('launcher.submit', 'Run'))}
           </button>
         </div>
       </form>
@@ -127,6 +149,8 @@ async function showCommandLauncher() {
     dlg.querySelectorAll('[data-cmd]').forEach((btn) => {
       btn.addEventListener('click', () => { active = btn.dataset.cmd; renderForm(); });
     });
+    const moreBtn = dlg.querySelector('#cmd-more');
+    if (moreBtn) moreBtn.addEventListener('click', () => { advancedVisible = true; renderForm(); });
     dlg.querySelector('#cmd-close').addEventListener('click', () => dlg.close());
     dlg.querySelector('#cmd-cancel').addEventListener('click', () => dlg.close());
     dlg.querySelector('#cmd-submit').addEventListener('click', () => submitCommand(active));
@@ -146,8 +170,20 @@ async function showCommandLauncher() {
     }
     // plan / architect: at least one of taskFile or task is required.
     if ((command === 'plan' || command === 'architect') && !body.taskFile && !body.task) {
-      await showError('Provide either a SPEC file path or paste the task text.', { title: 'Missing input' });
+      await showError(
+        maggle ? 'Escribe primero qué quieres pedir — con tus palabras vale.' : 'Provide either a SPEC file path or paste the task text.',
+        { title: 'Missing input' }
+      );
       return;
+    }
+    // AC2: before launching, the maggle confirms knowing exactly what
+    // will happen — in their language, never a command name alone.
+    if (maggle && command === 'plan') {
+      const ok = await showConfirm(maggleText('launcher.confirm', ''), {
+        title: SCHEMAS.plan.label,
+        okLabel: maggleText('launcher.submit', 'Run'),
+      });
+      if (!ok) return;
     }
     if (command === 'clean' && body.nuke) {
       const ok = await showConfirm(

--- a/packages/hu-board/public/utils/log-panel.js
+++ b/packages/hu-board/public/utils/log-panel.js
@@ -79,13 +79,13 @@ function openGenericLogPanel({ id, label, tailUrl }) {
                    border-bottom:1px solid var(--border);
                    user-select:none;flex-shrink:0">
       <div style="display:flex;align-items:baseline;gap:10px;min-width:0">
-        <strong style="color:var(--text)">${esc(label)}</strong>
+        <strong style="color:var(--text)" title="${esc(label)}">${esc(maggleText('log.label', label))}</strong>
         <span style="font-family:var(--font-mono, monospace);font-size:0.78rem;
                      color:var(--text-muted);overflow:hidden;text-overflow:ellipsis;
                      white-space:nowrap">${esc(id)}</span>
       </div>
       <div style="display:flex;align-items:center;gap:6px;flex-shrink:0">
-        <span id="log-status" style="font-size:0.75rem;color:var(--text-muted);margin-right:8px">connecting…</span>
+        <span id="log-status" style="font-size:0.75rem;color:var(--text-muted);margin-right:8px">${maggleText('log.connecting', 'connecting…')}</span>
         <button id="log-min" type="button" title="Minimize (run keeps going)"
                 style="${winBtnStyle('#facc15')}">_</button>
         <button id="log-max" type="button" title="Maximize / Restore"
@@ -101,8 +101,8 @@ function openGenericLogPanel({ id, label, tailUrl }) {
                 white-space:pre-wrap;word-break:break-word"></pre>
     <footer style="padding:6px 12px;border-top:1px solid var(--border);
                    font-size:0.7rem;color:var(--text-muted);flex-shrink:0">
-      Closing this panel does NOT stop the run. It keeps going in the background;
-      reopen with the 📜 View log button on the board.
+      ${maggleText('log.footer', `Closing this panel does NOT stop the run. It keeps going in the background;
+      reopen with the 📜 View log button on the board.`)}
     </footer>
   `;
 

--- a/packages/hu-board/public/utils/maggle-mode.js
+++ b/packages/hu-board/public/utils/maggle-mode.js
@@ -29,6 +29,19 @@ const MAGGLE_LABELS = {
   'nav.board': 'Tablero',
   'nav.dashboard': 'Proyectos',
   'nav.more': 'Más',
+  'picker.hint': 'Elige un proyecto para ver su tablero. Puedes cambiar de proyecto arriba a la derecha.',
+  'picker.project': 'proyecto',
+  'launcher.title': '📝 Pedir trabajo a Karajan',
+  'launcher.planLabel': '📝 Pedir trabajo nuevo',
+  'launcher.planHelp': 'Cuéntale a Karajan qué quieres construir o cambiar, con tus palabras. Lo convertirá en tareas que verás en el tablero — todavía no toca tu código.',
+  'launcher.taskLabel': 'Qué quieres pedir',
+  'launcher.submit': 'Pedir',
+  'launcher.cancel': 'Cancelar',
+  'launcher.more': 'Más opciones…',
+  'launcher.confirm': 'Voy a convertir tu petición en tareas del tablero. Tardará unos minutos y podrás seguir la actividad en esta ventana. ¿Sigo?',
+  'log.label': 'Actividad',
+  'log.connecting': 'conectando…',
+  'log.footer': 'Cerrar esta ventana NO detiene el trabajo: sigue en marcha. Vuelve a abrirla con el botón «📜 Ver actividad» del tablero.',
 };
 
 function isMaggleMode() {
@@ -48,14 +61,62 @@ function maggleText(key, technical) {
   return MAGGLE_LABELS[key] || technical;
 }
 
-// Minimal chrome for this step: mark the body (CSS hook) and put the
-// subtitle in plain language. Folding the advanced nav behind "Más" is
-// AC2 and ships with the launcher step (PR-C2 of KJC-TSK-0810).
+// AC4: an error shown to a maggle is never a stacktrace alone. Pure —
+// the caller (showError) decides by mode and renders the HTML.
+function maggleErrorParts(rawMessage) {
+  return {
+    headline: 'Algo no ha salido como se esperaba',
+    next: 'No has roto nada. Vuelve a intentarlo; si se repite, cuéntaselo a tu agente en la conversación — este detalle le sirve para arreglarlo.',
+    detail: rawMessage,
+  };
+}
+
+// AC2 (nav half): the header keeps Tablero + Proyectos in plain Spanish
+// and folds every advanced view behind one "Más" toggle, which also
+// reveals the way back to the expert UI.
 function applyMaggleChrome() {
   if (!isMaggleMode()) return;
   document.body.classList.add('maggle-mode');
   const subtitle = document.querySelector('.header__subtitle');
   if (subtitle) subtitle.textContent = MAGGLE_LABELS['header.subtitle'];
+  const nav = document.querySelector('.header__nav');
+  if (!nav) return;
+  const KEEP = { board: MAGGLE_LABELS['nav.board'], dashboard: MAGGLE_LABELS['nav.dashboard'] };
+  const advanced = [];
+  for (const btn of nav.querySelectorAll('.nav-btn')) {
+    const view = btn.dataset.view;
+    if (view && KEEP[view]) {
+      btn.title = `${btn.textContent.trim()} — ${btn.title}`;
+      btn.textContent = KEEP[view];
+    } else {
+      btn.style.display = 'none';
+      advanced.push(btn);
+    }
+  }
+  if (advanced.length === 0) return;
+  const more = document.createElement('button');
+  more.className = 'nav-btn';
+  more.textContent = `${MAGGLE_LABELS['nav.more']} ▾`;
+  more.title = 'Vistas avanzadas y volver al modo experto';
+  more.addEventListener('click', () => {
+    const hidden = advanced[0].style.display === 'none';
+    for (const btn of advanced) btn.style.display = hidden ? '' : 'none';
+    more.textContent = `${MAGGLE_LABELS['nav.more']} ${hidden ? '▴' : '▾'}`;
+    let expert = document.getElementById('maggle-expert-link');
+    if (hidden && !expert) {
+      expert = document.createElement('a');
+      expert.id = 'maggle-expert-link';
+      expert.className = 'nav-btn';
+      expert.href = '/?maggle=0';
+      expert.textContent = 'Modo experto';
+      expert.title = 'Vuelve a la interfaz técnica (Pending/Running/Done, comandos kj)';
+      more.after(expert);
+    } else if (!hidden && expert) {
+      expert.remove();
+    }
+  });
+  // After the LAST nav button, so the plain row reads Tablero | Proyectos | Más.
+  advanced.at(-1).after(more);
 }
 
 if (typeof document !== 'undefined' && document.addEventListener) {

--- a/packages/hu-board/public/utils/modals.js
+++ b/packages/hu-board/public/utils/modals.js
@@ -74,14 +74,23 @@ function ensureDialog() {
 function showError(message, opts = {}) {
   return new Promise((resolve) => {
     const dlg = ensureDialog();
-    const title = opts.title || 'Error';
+    // Maggle mode (KJC-TSK-0810 AC4): plain headline + next step, the raw
+    // message demoted to a collapsed technical detail — never alone.
+    const maggle = isMaggleMode() ? maggleErrorParts(message) : null;
+    const title = maggle ? maggle.headline : (opts.title || 'Error');
+    const body = maggle
+      ? `${esc(maggle.next)}
+         <details style="margin-top:10px"><summary style="cursor:pointer;color:var(--text-muted)">Detalle técnico${opts.title ? ` — ${esc(opts.title)}` : ''}</summary>
+           <pre style="white-space:pre-wrap;font-size:0.8rem;color:var(--text-muted);margin:8px 0 0">${esc(maggle.detail)}</pre>
+         </details>`
+      : esc(message);
     dlg.innerHTML = `
       <div style="padding:14px 18px;border-bottom:1px solid var(--border);
                   font-weight:600;color:var(--color-red,#ef4444)">
         ${esc(title)}
       </div>
       <div style="padding:16px 18px;font-size:0.9rem;line-height:1.5;
-                  white-space:pre-wrap">${esc(message)}</div>
+                  white-space:pre-wrap">${body}</div>
       <div style="padding:12px 18px;border-top:1px solid var(--border);
                   text-align:right">
         <button id="app-dialog-ok" class="control-btn"

--- a/packages/hu-board/public/utils/project-picker-view.js
+++ b/packages/hu-board/public/utils/project-picker-view.js
@@ -70,11 +70,11 @@ async function renderProjectPicker() {
 
   app.innerHTML = `
     <div class="section-header">
-      <span class="section-header__title">Story Board</span>
-      <span class="section-header__count">${sorted.length} project${sorted.length === 1 ? '' : 's'}</span>
+      <span class="section-header__title">${maggleText('board.title', 'Story Board')}</span>
+      <span class="section-header__count">${sorted.length} ${maggleText('picker.project', 'project')}${sorted.length === 1 ? '' : 's'}</span>
     </div>
     <p style="padding:8px 4px 16px;color:var(--text-muted);font-size:0.9rem">
-      Pick a project to see its kanban. Use the project selector in the header to switch later.
+      ${maggleText('picker.hint', 'Pick a project to see its kanban. Use the project selector in the header to switch later.')}
     </p>
     <div style="display:grid;grid-template-columns:repeat(auto-fill, minmax(320px, 1fr));gap:14px">
       ${sorted.map((p) => {

--- a/packages/hu-board/tests/maggle-mode.test.js
+++ b/packages/hu-board/tests/maggle-mode.test.js
@@ -72,4 +72,32 @@ describe('maggle mode (KJC-TSK-0810)', () => {
     expect(ctx.isMaggleMode()).toBe(false);
     expect(ctx.maggleText('column.done', 'Done')).toBe('Done');
   });
+
+  // PR-C2 (AC4): an error is never a stacktrace alone — plain headline,
+  // a next step, and the raw message demoted to collapsible detail.
+  it('maggleErrorParts wraps any raw message in headline + next step + detail', () => {
+    const raw = 'TypeError: cannot read properties of undefined\n  at tick (log-panel.js:120)';
+    const { ctx } = loadMaggle({ stored: '1' });
+    const parts = ctx.maggleErrorParts(raw);
+    expect(parts.headline).toBeTruthy();
+    expect(parts.headline).not.toMatch(/TypeError/);
+    expect(parts.next).toMatch(/agente|intentar/i);
+    expect(parts.detail).toBe(raw);
+  });
+
+  // PR-C2 (AC2/AC3): the launcher and the activity panel have plain labels
+  // distinct from the technical ones.
+  it('covers launcher and activity labels with plain text distinct from the jargon', () => {
+    const { ctx } = loadMaggle({ stored: '1' });
+    for (const [key, jargon] of [
+      ['launcher.title', '⚡ Run a Karajan command'],
+      ['launcher.submit', 'Run'],
+      ['launcher.cancel', 'Cancel'],
+      ['log.label', 'Run log'],
+    ]) {
+      const plain = ctx.maggleText(key, jargon);
+      expect(plain).toBeTruthy();
+      expect(plain).not.toBe(jargon);
+    }
+  });
 });


### PR DESCRIPTION
## Launcher en llano, actividad visible y errores con paso siguiente (PR 2 de 2)

Card: KJC-TSK-0810 (MGL-C) · Épica: KJC-PCS-0084 · Apilada sobre #1586

Cierra los AC2–AC4 del board como ventana del maggle:

- **Nav plegada (AC2)**: en modo maggle la cabecera se queda en **Tablero | Proyectos | Más ▾**; «Más» despliega las vistas avanzadas (Graph, Sessions, Governance, Pipeline, RAG, Wiki) y el enlace **Modo experto** que devuelve la UI técnica.
- **Launcher en llano (AC2)**: el diálogo ⚡ abre como **«📝 Pedir trabajo a Karajan»** con una sola acción delante — un textarea «Qué quieres pedir» y la promesa clara de qué va a pasar («lo convertirá en tareas… todavía no toca tu código»). Antes de lanzar, confirmación en llano. El launcher técnico completo (ficheros SPEC, architect, clean) queda a un clic tras «Más opciones…».
- **Actividad (AC3)**: el panel de log flotante se presenta como **«Actividad»** (técnico en tooltip), «conectando…» y pie en llano: cerrar la ventana no detiene el trabajo.
- **Errores (AC4)**: `showError` en modo maggle nunca muestra un stacktrace a secas — titular «Algo no ha salido como se esperaba», paso siguiente accionable («cuéntaselo a tu agente — este detalle le sirve para arreglarlo») y el mensaje crudo plegado como «Detalle técnico». `maggleErrorParts` es pura y está testeada.
- El picker de proyectos también habla llano (título, hint y contador).

2 tests nuevos vía `node:vm` (partes del error; labels de launcher y actividad ≠ jerga). Suite hu-board 446 ✓. Verificado con captura: nav plegada, launcher, y el modal de error con el detalle desplegado. El modo experto queda intacto.
