### PR TITLE
fix(rag): default registry covers every policy-authorized provider

### DIFF
--- a/packages/rag/src/ai/adapter-registry.js
+++ b/packages/rag/src/ai/adapter-registry.js
@@ -134,19 +134,42 @@ export class AdapterRegistry {
 }
 
 /**
- * Construye un AdapterRegistry con los 3 adapters CLI built-in de KJR:
- * claude, codex, gemini. Los adapters se importan dinámicamente para
- * permitir a los consumidores crear registries vacíos cuando quieran
- * testear con fakes.
+ * Construye un AdapterRegistry con TODOS los adapters built-in de KJR:
+ * los 3 CLI (claude, codex, gemini) y los providers de API que la
+ * política de sensibilidad por defecto puede autorizar (ollama,
+ * azure-openai, bedrock, vertex-ai, openai, anthropic). Un provider
+ * registrado sin configurar falla ALTO en la llamada con el error del
+ * propio adapter (falta project/endpoint/credenciales) — lo que no
+ * puede pasar es que la política autorice un provider y el registry
+ * responda "no registrado" (KJR-BUG-0011, issue #155).
+ *
+ * Los adapters se importan dinámicamente para permitir a los
+ * consumidores crear registries vacíos cuando quieran testear con fakes.
  *
  * @returns {Promise<AdapterRegistry>}
  */
 export async function createDefaultAdapterRegistry() {
   const registry = new AdapterRegistry();
-  const [{ runClaudeCli }, { runCodexCli }, { runGeminiCli }] = await Promise.all([
+  const [
+    { runClaudeCli },
+    { runCodexCli },
+    { runGeminiCli },
+    { runOllamaCli },
+    { runAzureOpenAi },
+    { runBedrock },
+    { runVertexAi },
+    { runOpenAi },
+    { runAnthropic },
+  ] = await Promise.all([
     import('./adapters/claude-cli-adapter.js'),
     import('./adapters/codex-cli-adapter.js'),
     import('./adapters/gemini-cli-adapter.js'),
+    import('./adapters/ollama-cli-adapter.js'),
+    import('./adapters/azure-openai-adapter.js'),
+    import('./adapters/bedrock-adapter.js'),
+    import('./adapters/vertex-ai-adapter.js'),
+    import('./adapters/openai-adapter.js'),
+    import('./adapters/anthropic-adapter.js'),
   ]);
   registry.register('claude', runClaudeCli, {
     bin: 'claude',
@@ -160,5 +183,14 @@ export async function createDefaultAdapterRegistry() {
     bin: 'gemini',
     installUrl: 'https://github.com/google-gemini/gemini-cli',
   });
+  registry.register('ollama', runOllamaCli, {
+    bin: 'ollama',
+    installUrl: 'https://ollama.com/download',
+  });
+  registry.register('azure-openai', runAzureOpenAi, { category: 'private-cloud' });
+  registry.register('bedrock', runBedrock, { category: 'private-cloud' });
+  registry.register('vertex-ai', runVertexAi, { category: 'private-cloud' });
+  registry.register('openai', runOpenAi, { category: 'public-api' });
+  registry.register('anthropic', runAnthropic, { category: 'public-api' });
   return registry;
 }

--- a/packages/rag/src/ai/adapters/vertex-ai-adapter.js
+++ b/packages/rag/src/ai/adapters/vertex-ai-adapter.js
@@ -25,8 +25,11 @@
 export async function runVertexAi(prompt, options = {}) {
   const project = options.project ?? process.env.GOOGLE_CLOUD_PROJECT;
   const location = options.location ?? 'us-central1';
-  const model = options.model ?? 'gemini-1.5-flash';
-  const maxTokens = options.maxTokens ?? 1024;
+  // gemini-1.5/2.0-flash están retirados (404 verificado en campo); los
+  // modelos 2.5 gastan tokens de razonamiento que cuentan como salida,
+  // así que 1024 dejaba la respuesta VACÍA (KJR-BUG-0011, issue #155).
+  const model = options.model ?? 'gemini-2.5-flash';
+  const maxTokens = options.maxTokens ?? 8192;
   if (!project) {
     throw new Error(
       'VertexAI: falta "project" (vía opts o env GOOGLE_CLOUD_PROJECT).',
@@ -45,6 +48,14 @@ export async function runVertexAi(prompt, options = {}) {
   const raw = response?.response ?? response;
   const candidates = raw?.candidates ?? [];
   const text = candidates[0]?.content?.parts?.[0]?.text ?? '';
+  // Respuesta vacía por presupuesto agotado: decirlo, no devolver un JSON
+  // vacío que hace culpar al parseo ("no devolvió ningún objeto JSON").
+  if (text === '' && candidates[0]?.finishReason === 'MAX_TOKENS') {
+    throw new Error(
+      `VertexAI: respuesta vacía con finishReason MAX_TOKENS — el modelo "${model}" agotó ` +
+        `maxTokens (${maxTokens}) pensando antes de emitir salida. Sube "maxTokens" en las opciones.`,
+    );
+  }
 
   return {
     provider: 'vertex-ai',

--- a/packages/rag/tests/coverage-hardening-4.test.js
+++ b/packages/rag/tests/coverage-hardening-4.test.js
@@ -22,14 +22,24 @@ import { saveEasyConfig } from '../src/easy/config.js';
 
 const noopLogger = { info: () => {}, warn: () => {}, error: () => {} };
 
-test('createDefaultAdapterRegistry: registra los tres CLIs con metadata', async () => {
+test('createDefaultAdapterRegistry: registra CLIs con metadata y providers de API (KJR-BUG-0011)', async () => {
   const registry = await createDefaultAdapterRegistry();
-  for (const name of ['claude', 'codex', 'gemini']) {
+  for (const name of ['claude', 'codex', 'gemini', 'ollama']) {
     assert.equal(registry.has(name), true);
     assert.equal(typeof registry.get(name), 'function');
     assert.ok(registry.getMeta(name)?.bin, `meta.bin presente para ${name}`);
   }
-  assert.deepEqual(registry.list().sort(), ['claude', 'codex', 'gemini']);
+  assert.deepEqual(registry.list().sort(), [
+    'anthropic',
+    'azure-openai',
+    'bedrock',
+    'claude',
+    'codex',
+    'gemini',
+    'ollama',
+    'openai',
+    'vertex-ai',
+  ]);
 });
 
 test('createDefaultRoleRegistry: registra roles según las piezas disponibles', async () => {

--- a/packages/rag/tests/default-registry-policy.test.js
+++ b/packages/rag/tests/default-registry-policy.test.js
@@ -1,0 +1,71 @@
+// @ts-check
+// KJR-BUG-0011 (issue #155): el registry por defecto no registraba ningún
+// adapter permitido por la política de sensibilidad por defecto — un índice
+// con DEFAULT_SENSITIVITY=internal se quedaba sin adapter utilizable.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDefaultAdapterRegistry } from '../src/ai/adapter-registry.js';
+import { createDefaultSensitivityPolicy } from '../src/policy/sensitivity-policy.js';
+import { runVertexAi } from '../src/ai/adapters/vertex-ai-adapter.js';
+
+test('todo provider que nombra la política por defecto está registrado en el registry por defecto', async () => {
+  const registry = await createDefaultAdapterRegistry();
+  const policy = createDefaultSensitivityPolicy();
+  for (const [level, providers] of Object.entries(policy)) {
+    for (const provider of providers) {
+      assert.ok(
+        registry.has(provider),
+        `nivel "${level}": provider "${provider}" permitido por la política pero NO registrado`,
+      );
+    }
+    assert.ok(providers.length > 0, `nivel "${level}" sin providers`);
+  }
+});
+
+/** SDK falso de Vertex: captura el request y devuelve una respuesta dada. */
+function makeFakeVertexSdk(response, capture) {
+  return {
+    VertexAI: class {
+      getGenerativeModel() {
+        return {
+          async generateContent(request) {
+            capture.request = request;
+            return { response };
+          },
+        };
+      }
+    },
+  };
+}
+
+test('vertex: el modelo por defecto es gemini-2.5-flash (1.5/2.0 retirados: 404)', async () => {
+  const capture = {};
+  const sdk = makeFakeVertexSdk(
+    { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+    capture,
+  );
+  const result = await runVertexAi('hola', { project: 'p', sdk });
+  assert.equal(result.providerMeta.model, 'gemini-2.5-flash');
+});
+
+test('vertex: maxTokens por defecto 8192 — 1024 deja sin salida a los modelos que razonan', async () => {
+  const capture = {};
+  const sdk = makeFakeVertexSdk(
+    { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+    capture,
+  );
+  await runVertexAi('hola', { project: 'p', sdk });
+  assert.equal(capture.request.generationConfig.maxOutputTokens, 8192);
+});
+
+test('vertex: respuesta vacía con finishReason MAX_TOKENS falla con mensaje explícito, no con JSON vacío', async () => {
+  const capture = {};
+  const sdk = makeFakeVertexSdk(
+    { candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [] } }] },
+    capture,
+  );
+  await assert.rejects(
+    () => runVertexAi('hola', { project: 'p', sdk, maxTokens: 64 }),
+    /MAX_TOKENS.*maxTokens|maxTokens.*MAX_TOKENS/s,
+  );
+});


### PR DESCRIPTION
## El registry por defecto cubre todos los providers que autoriza la política (KJR-BUG-0011)

Card: KJR-BUG-0011 (board Karajan RAG) · Reporte de campo: [manufosela/karajan-rag#155](https://github.com/manufosela/karajan-rag/issues/155) (tribbu, al cablear el juez de impacto de watch)

La política de sensibilidad por defecto autoriza `ollama`, `azure-openai`, `bedrock` y `vertex-ai` para `internal`/`confidential`, pero `createDefaultAdapterRegistry()` solo registraba los 3 CLIs — un índice con la sensibilidad por defecto (`internal`) no tenía **ningún** adapter utilizable. Los 6 adapters de API ya existían y estaban exportados; ahora los 9 quedan registrados. Un provider sin configurar falla ALTO en la llamada con su propio error (falta project/endpoint/credenciales) — lo que ya no puede pasar es «adapter no registrado» para un provider autorizado.

Del mismo reporte, en el adapter de Vertex:
- Modelo por defecto → `gemini-2.5-flash` (1.5/2.0 devuelven 404, verificado por ellos contra la API).
- `maxTokens` por defecto → 8192: los modelos 2.5 gastan tokens de razonamiento que cuentan como salida; con 1024 la respuesta llegaba VACÍA y el error visible culpaba al parseo JSON.
- Respuesta vacía con `finishReason: MAX_TOKENS` → error explícito que nombra la causa y el remedio.

Tests: contrato registry×política (ningún nivel se queda sin adapter registrado) + 3 de vertex con SDK falso. Suite del rag: 560 ✓ / 2 fallos ambientales preexistentes (falta `@lancedb/lancedb` en este árbol, también fallan en la base).

Pendiente en cards aparte: migración del SDK deprecado de Vertex (Gen AI SDK) y la parte de watch (exponer `--adapter`, mensaje de guardia formato-saltado vs inventado).
