### PR TITLE
fix(watch): the hallucination guard scopes to the entry, not the merge

### DIFF
--- a/packages/watch/src/impact.js
+++ b/packages/watch/src/impact.js
@@ -199,7 +199,7 @@ export const runImpactPipeline = async ({
 
   const diffSummary = `${repoName}: ${touchedPaths.join(', ')} (${chunks.length} chunks)`;
   if (judge) log('juicio: pidiendo veredicto al adapter…');
-  const { verdict } = judge
+  const judgment = judge
     ? await judgeImpact({
         candidates,
         coChanges,
@@ -209,7 +209,14 @@ export const runImpactPipeline = async ({
         contracts,
         runAdapter: deps.runAdapter ?? createDefaultRunAdapter(),
       })
-    : { verdict: { summary: '', affected: [] } };
+    : { verdict: { summary: '', affected: [] }, discardedEntries: 0 };
+  const { verdict } = judgment;
+  // KJW-BUG-0010: lo descartado y lo no-juzgado se DICE — es la diferencia
+  // entre medir la guarda y que sus efectos pasen en silencio.
+  if (judgment.insufficientSignal) log('juicio: sin señal suficiente — veredicto no pedido');
+  if (judgment.discardedEntries > 0) {
+    log(`juicio: ${judgment.discardedEntries} entrada(s) sin respaldo descartada(s)`);
+  }
 
   const ranking = buildImpactRanking({
     candidates,

--- a/packages/watch/src/judgment.js
+++ b/packages/watch/src/judgment.js
@@ -71,6 +71,10 @@ export const PROMPT_LIMITS = Object.freeze({
  * @typedef {Object} JudgmentResult
  * @property {string} adapter Adapter usado.
  * @property {Verdict} verdict Veredicto validado y con PII redactada.
+ * @property {number} discardedEntries Entradas del veredicto descartadas por
+ *   citar fuentes fuera de las señales (0 = veredicto íntegro).
+ * @property {boolean} [insufficientSignal] true cuando las tres señales
+ *   llegaron vacías y NO se pidió veredicto al adapter (KJW-BUG-0010).
  */
 
 /**
@@ -236,6 +240,33 @@ export const judgeImpact = async ({
   }
   const adapterName = adapter ?? allowed[0];
 
+  // El prompt muestra TRES señales, así que el veredicto puede apoyarse en
+  // cualquiera de ellas: validar solo contra el retrieval convertía en
+  // "alucinación" un juicio legítimo basado en co-cambios (KJW-BUG-0005).
+  const knownSources = new Set([
+    ...candidates.map((c) => c.source),
+    ...contracts.map((c) => c.source),
+    ...coChanges.byRepo.flatMap((r) => r.coChanges.map((c) => `${r.repo}/${c.path}`)),
+  ]);
+
+  // Tres señales vacías = nada contra lo que validar: pedir veredicto
+  // garantizaba el aborto (en campo, 8/8 merges sin retrieval — y eran los
+  // diffs quirúrgicos, KJW-BUG-0010). No se llama al adapter y el informe
+  // lo dice, en vez de castigar una recuperación vacía como alucinación.
+  if (knownSources.size === 0) {
+    return {
+      adapter: adapterName,
+      verdict: {
+        summary:
+          'sin señal suficiente para juzgar: retrieval, co-cambios y contratos ' +
+          'llegaron vacíos — no se pidió veredicto al adapter.',
+        affected: [],
+      },
+      discardedEntries: 0,
+      insufficientSignal: true,
+    };
+  }
+
   const prompt = buildJudgmentPrompt({ candidates, coChanges, diffSummary, contracts });
   let raw;
   /** @type {ReturnType<typeof setTimeout> | undefined} */
@@ -265,31 +296,26 @@ export const judgeImpact = async ({
   }
 
   const verdict = parseVerdict(raw);
-  // El prompt muestra TRES señales, así que el veredicto puede apoyarse en
-  // cualquiera de ellas: validar solo contra el retrieval convertía en
-  // "alucinación" un juicio legítimo basado en co-cambios (KJW-BUG-0005).
-  const knownSources = new Set([
-    ...candidates.map((c) => c.source),
-    ...contracts.map((c) => c.source),
-    ...coChanges.byRepo.flatMap((r) => r.coChanges.map((c) => `${r.repo}/${c.path}`)),
-  ]);
+  // Una entrada que cita una fuente fuera de las señales se DESCARTA con
+  // contador; las fundadas sobreviven. Abortar el juicio entero por una
+  // entrada convertía un veredicto casi íntegro en ningún informe
+  // (KJW-BUG-0010 — antes tiraba el merge completo).
+  const backed = [];
+  let discardedEntries = 0;
   for (const entry of verdict.affected) {
-    if (!knownSources.has(entry.source)) {
-      throw new JudgmentError(
-        `el veredicto menciona "${entry.source}", que no aparece en ninguna señal ` +
-          '(retrieval, co-cambios ni contratos): alucinación del adapter.',
-      );
-    }
+    if (knownSources.has(entry.source)) backed.push(entry);
+    else discardedEntries += 1;
   }
 
   return {
     adapter: adapterName,
     verdict: {
       summary: redact(verdict.summary).text,
-      affected: verdict.affected.map((entry) => ({
+      affected: backed.map((entry) => ({
         ...entry,
         reason: redact(entry.reason).text,
       })),
     },
+    discardedEntries,
   };
 };

--- a/packages/watch/tests/judgment-sources.test.js
+++ b/packages/watch/tests/judgment-sources.test.js
@@ -59,12 +59,48 @@ test('acepta un veredicto que cita un CONTRATO', async () => {
   assert.equal(verdict.affected[0].source, 'repo-d/src/client.js');
 });
 
-test('sigue rechazando una fuente que no apareció en ninguna señal', async () => {
-  await assert.rejects(
-    () =>
-      judgeImpact(
-        base([{ source: 'repo-z/inventado.js', severity: 'low', reason: 'me lo he inventado' }]),
-      ),
-    (err) => err instanceof JudgmentError && err.message.includes('repo-z/inventado.js'),
+test('una fuente sin respaldo se DESCARTA con contador — el resto del veredicto sobrevive (KJW-BUG-0010)', async () => {
+  // Antes: un solo source inventado tiraba el juicio ENTERO del merge
+  // (4/70 abortados en campo). La entrada sin respaldo se descarta y se
+  // cuenta; las fundadas se conservan.
+  const result = await judgeImpact(
+    base([
+      { source: 'repo-d/src/client.js', severity: 'high', reason: 'usa el endpoint eliminado' },
+      { source: 'repo-z/inventado.js', severity: 'low', reason: 'me lo he inventado' },
+    ]),
   );
+  assert.equal(result.verdict.affected.length, 1);
+  assert.equal(result.verdict.affected[0].source, 'repo-d/src/client.js');
+  assert.equal(result.discardedEntries, 1);
+});
+
+test('con TODAS las entradas sin respaldo el veredicto queda vacío con contador, nunca error', async () => {
+  const result = await judgeImpact(
+    base([{ source: 'repo-z/inventado.js', severity: 'low', reason: 'me lo he inventado' }]),
+  );
+  assert.equal(result.verdict.affected.length, 0);
+  assert.equal(result.discardedEntries, 1);
+});
+
+test('con las TRES señales vacías no se pide veredicto: informe «sin señal suficiente» (KJW-BUG-0010)', async () => {
+  // En campo: 8/8 merges sin retrieval abortaban — y eran los diffs
+  // quirúrgicos (1-9 chunks). Sin nada contra lo que validar no hay
+  // alucinación que detectar: no se llama al adapter y el informe lo dice.
+  let adapterCalled = false;
+  const result = await judgeImpact({
+    candidates: [],
+    coChanges: { byRepo: [], noSignal: [] },
+    contracts: [],
+    diffSummary: 'repo-a: src/api.js',
+    sensitivity: 'public',
+    policy,
+    runAdapter: async () => {
+      adapterCalled = true;
+      return JSON.stringify({ summary: 'no debería llegar', affected: [] });
+    },
+  });
+  assert.equal(adapterCalled, false);
+  assert.equal(result.insufficientSignal, true);
+  assert.equal(result.verdict.affected.length, 0);
+  assert.match(result.verdict.summary, /sin señal suficiente/i);
 });

--- a/packages/watch/tests/judgment-timeout.test.js
+++ b/packages/watch/tests/judgment-timeout.test.js
@@ -3,8 +3,18 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { JudgmentError, JUDGMENT_TIMEOUT_MS, judgeImpact } from '../src/judgment.js';
 
+// Con las tres señales vacías judgeImpact ya NO llama al adapter
+// (KJW-BUG-0010), así que estos tests necesitan al menos un candidato
+// para seguir ejercitando el camino del timeout que dicen probar.
 const params = (runAdapter, extra = {}) => ({
-  candidates: [],
+  candidates: [
+    {
+      source: 'repo-b/src/consumer.js',
+      repo: 'repo-b',
+      score: 0.7,
+      evidence: [{ fromChunk: { path: 'src/api.js', newStart: 1 }, line: 2, score: 0.7 }],
+    },
+  ],
   coChanges: { byRepo: [], noSignal: [] },
   diffSummary: 'repo-a: src/api.js',
   sensitivity: 'public',

--- a/packages/watch/tests/judgment.test.js
+++ b/packages/watch/tests/judgment.test.js
@@ -109,15 +109,16 @@ test('parseVerdict: JSON inválido o esquema roto = JudgmentError', () => {
   );
 });
 
-test('source alucinado (no está entre los candidatos): JudgmentError', async () => {
+test('source alucinado (no está entre los candidatos): se descarta con contador, sin abortar', async () => {
+  // KJW-BUG-0010: antes esto lanzaba JudgmentError y tiraba el juicio
+  // entero del merge. La entrada sin respaldo se descarta y se cuenta.
   const hallucinated = JSON.stringify({
     summary: 'ok',
     affected: [{ source: 'repo-z/invento.js', severity: 'low', reason: 'x' }],
   });
-  await assert.rejects(
-    () => judgeImpact(baseParams({ runAdapter: async () => hallucinated })),
-    (err) => err instanceof JudgmentError && err.message.includes('repo-z/invento.js'),
-  );
+  const result = await judgeImpact(baseParams({ runAdapter: async () => hallucinated }));
+  assert.equal(result.verdict.affected.length, 0);
+  assert.equal(result.discardedEntries, 1);
 });
 
 test('redactPII aplicado a summary y reasons', async () => {


### PR DESCRIPTION
## La guarda anti-alucinación puntúa a la entrada, no al merge (KJW-BUG-0010)

Card: KJW-BUG-0010 · Reporte de campo: [manufosela/karajan-watch#23](https://github.com/manufosela/karajan-watch/issues/23) (tribbu, 80 merges medidos en 11 días)

Lo medido: una sola entrada del veredicto con fuente sin respaldo abortaba el juicio **entero** del merge (4/70 con retrieval); y con las tres señales vacías el aborto era **garantizado** (8/8) — castigando al adapter por una recuperación vacía, justo en los diffs quirúrgicos (1–9 chunks) que más interesa vigilar.

Las dos mitades del fix, como propuso la issue:

- **Entrada sin respaldo → se descarta, el resto sobrevive**, con `discardedEntries` medible en el resultado y logueado por el pipeline. Con todas descartadas: veredicto vacío con contador, nunca error.
- **Tres señales vacías → no se pide veredicto** (nada contra lo que validar ≠ alucinación): retorno temprano con `insufficientSignal: true` y el informe diciendo «sin señal suficiente», sin llamar al adapter.

Es la segunda mitad del camino de KJW-BUG-0005 (validar contra las tres señales): qué hacer cuando las tres están vacías.

Tests: 3 nuevos (descarte con superviviente, todas descartadas, señales vacías sin llamada al adapter) + 3 actualizados al contrato nuevo — los de timeout ganan un candidato para seguir ejercitando el camino que dicen probar (con señales vacías ya no se llama al adapter). Suite watch 163 ✓.

Cierra karajan-watch#23 al publicarse (les llega como release dual de `karajan-watch` — no esperan a la 1.0).
