### PR TITLE
fix(watch): the verdict declares its scope - repo warnings render as repo

### DIFF
--- a/packages/watch/src/judgment.js
+++ b/packages/watch/src/judgment.js
@@ -60,7 +60,11 @@ export const PROMPT_LIMITS = Object.freeze({
  * @typedef {import('./cochanges.js').CoChangeResult} CoChangeResult
  *
  * @typedef {Object} AffectedEntry
- * @property {string} source Fichero afectado (`repo/path`), uno de los candidatos.
+ * @property {string} source Fichero afectado (`repo/path`) con scope `file`;
+ *   nombre del repo con scope `repo`.
+ * @property {'file' | 'repo'} scope Alcance del aviso (KJW-BUG-0009): `file`
+ *   señala un fichero de las señales; `repo` un repositorio en conjunto —
+ *   colgar un aviso de repo de un fichero es precisión fingida.
  * @property {'low' | 'medium' | 'high'} severity
  * @property {string} reason
  *
@@ -142,8 +146,12 @@ export const buildJudgmentPrompt = ({ candidates, coChanges, diffSummary, contra
         ]
       : []),
     'Responde SOLO con un JSON válido con esta forma exacta:',
-    '{"summary": "<síntesis en una o dos frases>", "affected": [{"source": "<uno de los candidatos>", "severity": "low|medium|high", "reason": "<por qué>"}]}',
+    '{"summary": "<síntesis en una o dos frases>", "affected": [{"source": "<uno de los candidatos>", "scope": "file", "severity": "low|medium|high", "reason": "<por qué>"}]}',
     'Incluye en "affected" únicamente candidatos con impacto plausible; puede ser una lista vacía.',
+    'Si tu conclusión aplica a un REPOSITORIO en su conjunto (p.ej. «los clientes que',
+    'parsean esta respuesta deberán actualizarse») y no a un fichero concreto de las',
+    'señales, usa {"scope": "repo", "source": "<nombre del repo>"} — nunca cuelgues',
+    'un aviso de repo de un fichero que no lo justifica.',
   ].join('\n');
 };
 
@@ -190,7 +198,12 @@ export const parseVerdict = (rawText) => {
     if (typeof entry.reason !== 'string' || entry.reason.length === 0) {
       throw new JudgmentError(`veredicto inválido: affected[${i}].reason requerido.`);
     }
-    return { source: entry.source, severity: entry.severity, reason: entry.reason };
+    // Alcance opcional (KJW-BUG-0009): ausente = file, el contrato de siempre.
+    const scope = entry.scope ?? 'file';
+    if (scope !== 'file' && scope !== 'repo') {
+      throw new JudgmentError(`veredicto inválido: affected[${i}].scope debe ser file | repo.`);
+    }
+    return { source: entry.source, scope, severity: entry.severity, reason: entry.reason };
   });
   return { summary: parsed.summary, affected };
 };
@@ -300,10 +313,20 @@ export const judgeImpact = async ({
   // contador; las fundadas sobreviven. Abortar el juicio entero por una
   // entrada convertía un veredicto casi íntegro en ningún informe
   // (KJW-BUG-0010 — antes tiraba el merge completo).
+  // Una entrada de alcance repo se valida contra los REPOS de las señales
+  // (KJW-BUG-0009) — incluidos los que aparecen sin señal de co-cambios,
+  // que también estuvieron delante del juez.
+  const knownRepos = new Set([
+    ...candidates.map((c) => c.repo),
+    ...contracts.map((c) => c.repo),
+    ...coChanges.byRepo.map((r) => r.repo),
+    ...coChanges.noSignal.map((r) => r.repo),
+  ]);
   const backed = [];
   let discardedEntries = 0;
   for (const entry of verdict.affected) {
-    if (knownSources.has(entry.source)) backed.push(entry);
+    const known = entry.scope === 'repo' ? knownRepos : knownSources;
+    if (known.has(entry.source)) backed.push(entry);
     else discardedEntries += 1;
   }
 

--- a/packages/watch/src/report.js
+++ b/packages/watch/src/report.js
@@ -42,6 +42,8 @@ const SEVERITY_RANK = { high: 3, medium: 2, low: 1 };
  * @property {{count: number, lastDate: string} | null} coChange Señal de co-cambios para este path, si existe.
  * @property {{severity: 'low' | 'medium' | 'high', reason: string} | null} judged Juicio LLM, si lo hay.
  * @property {import('./contracts.js').ContractMatch | null} contract Contrato compartido con el diff, si lo hay.
+ * @property {'file' | 'repo'} [scope] `repo` cuando la fila es un veredicto de
+ *   alcance repositorio (KJW-BUG-0009) — `source` es entonces el nombre del repo.
  */
 
 /**
@@ -62,8 +64,12 @@ export const buildImpactRanking = ({
   contracts = [],
   thresholds = {},
 }) => {
+  // Los veredictos de alcance repo NO se cuelgan de un fichero (KJW-BUG-0009):
+  // entran al ranking como filas propias, más abajo.
+  const fileVerdicts = verdict.affected.filter((a) => a.scope !== 'repo');
+  const repoVerdicts = verdict.affected.filter((a) => a.scope === 'repo');
   const judgedBySource = new Map(
-    verdict.affected.map((a) => [a.source, { severity: a.severity, reason: a.reason }]),
+    fileVerdicts.map((a) => [a.source, { severity: a.severity, reason: a.reason }]),
   );
   /** @type {Map<string, {count: number, lastDate: string}>} */
   const coChangeBySource = new Map();
@@ -106,6 +112,19 @@ export const buildImpactRanking = ({
       coChange: coChangeBySource.get(match.source) ?? null,
       judged: judgedBySource.get(match.source) ?? null,
       contract: match,
+    });
+  }
+
+  for (const entry of repoVerdicts) {
+    entries.push({
+      source: entry.source,
+      repo: entry.source,
+      score: 0,
+      evidence: [],
+      coChange: null,
+      judged: { severity: entry.severity, reason: entry.reason },
+      contract: null,
+      scope: 'repo',
     });
   }
 
@@ -167,7 +186,10 @@ export const renderImpactMarkdown = ({ ranking, diffSummary, verdictSummary }) =
       if (entry.judged) {
         parts.push(`juicio: **${entry.judged.severity}** — ${entry.judged.reason}`);
       }
-      lines.push(`- \`${entry.source}\` · ${parts.join(' · ')}`);
+      // Un veredicto de alcance repo se presenta COMO repo — fingir la
+      // precisión de un fichero hace que el aviso se descarte por ruido.
+      const label = entry.scope === 'repo' ? `repo \`${entry.source}\`` : `\`${entry.source}\``;
+      lines.push(`- ${label} · ${parts.join(' · ')}`);
       for (const ev of entry.evidence) {
         lines.push(
           `  - visto desde \`${ev.fromChunk.path}@${ev.fromChunk.newStart}\`` +

--- a/packages/watch/tests/judgment-scope.test.js
+++ b/packages/watch/tests/judgment-scope.test.js
@@ -1,0 +1,94 @@
+// @ts-check
+// KJW-BUG-0009: el juez razona a veces a nivel de REPO («la app tendrá que
+// actualizarse») y el informe colgaba ese razonamiento de un fichero
+// concreto — precisión fingida que hace descartar avisos correctos. El
+// veredicto declara su alcance y todo el camino lo respeta.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { judgeImpact, parseVerdict, buildJudgmentPrompt } from '../src/judgment.js';
+import { buildImpactRanking, renderImpactMarkdown } from '../src/report.js';
+
+const policy = { confidential: ['ollama'], internal: ['ollama'], public: ['claude'] };
+const candidates = [
+  {
+    source: 'new-app-android/src/sso/WebClientAuthenticator.kt',
+    repo: 'new-app-android',
+    score: 0.61,
+    evidence: [{ fromChunk: { path: 'src/api.php', newStart: 1 }, line: 4, score: 0.61 }],
+  },
+];
+const coChanges = { byRepo: [], noSignal: [{ repo: 'new-app-ios', reason: 'sin historia' }] };
+const params = (affected) => ({
+  candidates,
+  coChanges,
+  diffSummary: 'api: src/api.php',
+  sensitivity: 'public',
+  policy,
+  runAdapter: async () => JSON.stringify({ summary: 'ok', affected }),
+});
+
+test('parseVerdict acepta scope repo y da file por defecto', () => {
+  const v = parseVerdict(
+    JSON.stringify({
+      summary: 'ok',
+      affected: [
+        { source: 'new-app-android', scope: 'repo', severity: 'high', reason: 'parsea la respuesta' },
+        { source: 'repo-b/src/x.js', severity: 'low', reason: 'y' },
+      ],
+    }),
+  );
+  assert.equal(v.affected[0].scope, 'repo');
+  assert.equal(v.affected[1].scope, 'file');
+  assert.throws(() => parseVerdict('{"summary":"ok","affected":[{"source":"x","scope":"galaxy","severity":"low","reason":"y"}]}'));
+});
+
+test('el prompt ofrece el alcance repo al juez', () => {
+  const prompt = buildJudgmentPrompt({ candidates, coChanges, diffSummary: 'x', contracts: [] });
+  assert.match(prompt, /"scope"/);
+  assert.match(prompt, /repo/i);
+});
+
+test('una entrada repo se valida contra los REPOS de las señales, no contra sources', async () => {
+  const result = await judgeImpact(
+    params([
+      { source: 'new-app-android', scope: 'repo', severity: 'high', reason: 'los clientes que parsean esta respuesta deberán actualizarse' },
+      { source: 'new-app-ios', scope: 'repo', severity: 'medium', reason: 'ídem — repo con señal de co-cambios vacía pero presente' },
+    ]),
+  );
+  assert.equal(result.verdict.affected.length, 2);
+  assert.equal(result.discardedEntries, 0);
+});
+
+test('una entrada repo con repo desconocido se descarta con contador, como las de fichero', async () => {
+  const result = await judgeImpact(
+    params([{ source: 'repo-inventado', scope: 'repo', severity: 'low', reason: 'x' }]),
+  );
+  assert.equal(result.verdict.affected.length, 0);
+  assert.equal(result.discardedEntries, 1);
+});
+
+test('el ranking y el render presentan la entrada repo COMO repo, sin fingir fichero', () => {
+  const verdict = {
+    summary: 'la forma del JSON cambia',
+    affected: [
+      { source: 'new-app-android', scope: 'repo', severity: 'high', reason: 'los clientes que parsean esta respuesta' },
+    ],
+  };
+  const ranking = buildImpactRanking({ candidates, coChanges, verdict, contracts: [] });
+  const repoEntry = ranking.find((e) => e.scope === 'repo');
+  assert.ok(repoEntry, 'la entrada repo entra al ranking');
+  assert.equal(repoEntry.source, 'new-app-android');
+  assert.equal(repoEntry.judged.severity, 'high');
+  const md = renderImpactMarkdown({ ranking, diffSummary: 'x' });
+  assert.match(md, /repo `new-app-android`/);
+  assert.doesNotMatch(md, /repo `new-app-android`\S*\.kt/);
+});
+
+test('la entrada repo pesa por severidad: high de repo por delante de un candidato sin juicio', () => {
+  const verdict = {
+    summary: 'x',
+    affected: [{ source: 'new-app-android', scope: 'repo', severity: 'high', reason: 'r' }],
+  };
+  const ranking = buildImpactRanking({ candidates, coChanges, verdict, contracts: [] });
+  assert.equal(ranking[0].scope, 'repo');
+});


### PR DESCRIPTION
fix(watch): the verdict declares its scope - repo warnings render as repo KJW-BUG-0009

Field pattern (tribbu's golden, both real-impact cases): the judge
reasons at repo level ("the Android app will need updating") and the
report hung that reasoning off whatever file retrieval pulled from that
repo - a correct warning attributed to an unrelated SSO file gets
dismissed as noise. Now the verdict carries scope (file default, repo
allowed), repo entries validate against the repos the judge actually
saw, ranking gives them their own row weighted by severity, and the
report says "repo x" instead of faking file precision. With a repo-level
metric their case reads 2/2 where file-level read 0/2.
