### PR TITLE
feat(watch): choose the judge adapter and model from the cli

### DIFF
--- a/packages/watch/bin/karajan-watch.js
+++ b/packages/watch/bin/karajan-watch.js
@@ -5,7 +5,7 @@
  *
  * Uso:
  *   karajan-watch ingest [--config karajan-watch.config.json] [--workspace <dir>] [--corpus code|docs]
- *   karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> [--no-judge] [--no-deliver] [--pr-number N]
+ *   karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> [--adapter X] [--model Y] [--no-judge] [--no-deliver] [--pr-number N]
  *   karajan-watch drift  --workspace <dir> --repo <name> --diff <fichero|-> [--judge] [--no-deliver] [--pr-number N]
  *
  * `ingest` valida el config de despliegue, verifica la convención de
@@ -30,7 +30,7 @@ const printUsage = () => {
     'Uso: karajan-watch ingest [--config karajan-watch.config.json] ' +
       '[--workspace <dir>] [--corpus code|docs]\n' +
       '     karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> ' +
-      '[--config karajan-watch.config.json] [--corpus code|docs] [--no-judge] [--no-deliver] [--pr-number N]\n' +
+      '[--config karajan-watch.config.json] [--corpus code|docs] [--adapter X] [--model Y] [--no-judge] [--no-deliver] [--pr-number N]\n' +
       '     karajan-watch drift  --workspace <dir> --repo <name> --diff <fichero|-> ' +
       '[--config karajan-watch.config.json] [--judge] [--no-deliver] [--pr-number N]\n' +
       '     karajan-watch eval   --workspace <dir> --golden <fichero> ' +
@@ -94,6 +94,8 @@ const main = async () => {
       golden: { type: 'string' },
       judge: { type: 'boolean', default: false },
       'no-judge': { type: 'boolean', default: false },
+      adapter: { type: 'string' },
+      model: { type: 'string' },
       'no-deliver': { type: 'boolean', default: false },
       'pr-number': { type: 'string' },
     },
@@ -163,6 +165,8 @@ const main = async () => {
           ...shared,
           corpusName: /** @type {'code' | 'docs'} */ (values.corpus),
           judge: !values['no-judge'],
+          adapter: values.adapter,
+          model: values.model,
         })
       : await runDriftPipeline({ ...shared, judge: values.judge });
   console.log(result.markdown);

--- a/packages/watch/src/impact.js
+++ b/packages/watch/src/impact.js
@@ -66,13 +66,16 @@ export const extractAdapterText = (result) => {
  *
  * @returns {(adapterName: string, prompt: string) => Promise<string>}
  */
-export const createDefaultRunAdapter = () => {
+export const createDefaultRunAdapter = ({ model, registryFactory = createDefaultAdapterRegistry } = {}) => {
   /** @type {import('karajan-rag').AdapterRegistry | null} */
   let registry = null;
   return async (adapterName, prompt) => {
-    registry ??= await createDefaultAdapterRegistry();
+    registry ??= await registryFactory();
     const adapterFn = registry.get(adapterName);
-    return extractAdapterText(await adapterFn(prompt));
+    // El modelo del juez es elegible desde el binario (KJW-TSK-0040): en
+    // campo, el default del adapter puede no respetar el formato del
+    // veredicto y no había vía para fijar otro sin script propio.
+    return extractAdapterText(await adapterFn(prompt, model ? { model } : {}));
   };
 };
 
@@ -103,6 +106,8 @@ export const createDefaultRunAdapter = () => {
  * @param {string} params.diffText Diff unificado del merge.
  * @param {'code' | 'docs'} [params.corpusName]
  * @param {boolean} [params.judge] Ejecutar el juicio LLM (default true). Con false el veredicto queda vacío y no se toca ningún adapter — señales puras (eval, despliegues sin LLM).
+ * @param {string} [params.adapter] Adapter del juez (KJW-TSK-0040); debe estar permitido por la policy — no se degrada a otro.
+ * @param {string} [params.model] Modelo del adapter del juez (KJW-TSK-0040); solo aplica al runAdapter por defecto.
  * @param {boolean} [params.deliver] Entregar a notify.targets (default true).
  * @param {{repoSlug: string, prNumber: number, token: string}} [params.prContext]
  * @param {Record<string, string | undefined>} [params.env]
@@ -117,6 +122,8 @@ export const runImpactPipeline = async ({
   diffText,
   corpusName = 'code',
   judge = true,
+  adapter,
+  model,
   deliver = true,
   prContext,
   env = process.env,
@@ -207,7 +214,8 @@ export const runImpactPipeline = async ({
         sensitivity: corpus.sensitivity,
         policy: config.policy ?? createDefaultSensitivityPolicy(),
         contracts,
-        runAdapter: deps.runAdapter ?? createDefaultRunAdapter(),
+        adapter,
+        runAdapter: deps.runAdapter ?? createDefaultRunAdapter({ model }),
       })
     : { verdict: { summary: '', affected: [] }, discardedEntries: 0 };
   const { verdict } = judgment;
@@ -216,6 +224,13 @@ export const runImpactPipeline = async ({
   if (judgment.insufficientSignal) log('juicio: sin señal suficiente — veredicto no pedido');
   if (judgment.discardedEntries > 0) {
     log(`juicio: ${judgment.discardedEntries} entrada(s) sin respaldo descartada(s)`);
+    for (const d of judgment.discarded ?? []) {
+      log(
+        d.kind === 'format'
+          ? `juicio: descartada por FORMATO (señal conocida escrita de otra forma): ${d.source}`
+          : `juicio: descartada por fuente DESCONOCIDA (posible invención): ${d.source}`,
+      );
+    }
   }
 
   const ranking = buildImpactRanking({

--- a/packages/watch/src/judgment.js
+++ b/packages/watch/src/judgment.js
@@ -77,6 +77,10 @@ export const PROMPT_LIMITS = Object.freeze({
  * @property {Verdict} verdict Veredicto validado y con PII redactada.
  * @property {number} discardedEntries Entradas del veredicto descartadas por
  *   citar fuentes fuera de las señales (0 = veredicto íntegro).
+ * @property {Array<{source: string, kind: 'format' | 'unknown'}>} [discarded]
+ *   Detalle del descarte (KJW-TSK-0040): `format` = la fuente se corresponde
+ *   con una señal conocida escrita de otra forma (el adapter se saltó el
+ *   formato, no inventó); `unknown` = no aparece en ninguna señal.
  * @property {boolean} [insufficientSignal] true cuando las tres señales
  *   llegaron vacías y NO se pidió veredicto al adapter (KJW-BUG-0010).
  */
@@ -322,12 +326,24 @@ export const judgeImpact = async ({
     ...coChanges.byRepo.map((r) => r.repo),
     ...coChanges.noSignal.map((r) => r.repo),
   ]);
+  // «Formato saltado» ≠ «inventado» (KJW-TSK-0040): si la fuente devuelta se
+  // corresponde con una señal conocida escrita de otra forma («repo: ruta»,
+  // solo el prefijo), el adapter no alucinó — incumplió el formato. Ambos se
+  // descartan, pero decirlos distinto evita despistar sobre la causa.
+  const looksLikeKnown = (value) => {
+    const normalized = value.replace(/:\s*/g, '/');
+    for (const known of knownSources) {
+      if (known === normalized || known.startsWith(value) || value.startsWith(known)) return true;
+    }
+    return knownRepos.has(value.split(/[/:]/)[0]);
+  };
   const backed = [];
-  let discardedEntries = 0;
+  /** @type {Array<{source: string, kind: 'format' | 'unknown'}>} */
+  const discarded = [];
   for (const entry of verdict.affected) {
     const known = entry.scope === 'repo' ? knownRepos : knownSources;
     if (known.has(entry.source)) backed.push(entry);
-    else discardedEntries += 1;
+    else discarded.push({ source: entry.source, kind: looksLikeKnown(entry.source) ? 'format' : 'unknown' });
   }
 
   return {
@@ -339,6 +355,7 @@ export const judgeImpact = async ({
         reason: redact(entry.reason).text,
       })),
     },
-    discardedEntries,
+    discardedEntries: discarded.length,
+    discarded,
   };
 };

--- a/packages/watch/tests/judgment-adapter-model.test.js
+++ b/packages/watch/tests/judgment-adapter-model.test.js
@@ -1,0 +1,99 @@
+// @ts-check
+// KJW-TSK-0040: el operador elige adapter y modelo del juez desde el binario
+// (sin scripts propios), y la guardia distingue «formato saltado» (la fuente
+// devuelta se corresponde con una señal conocida escrita de otra forma) de
+// «inventado» (no aparece por ningún lado). En ambos casos se descarta.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateConfig } from '../src/config.js';
+import { createDefaultRunAdapter, runImpactPipeline } from '../src/impact.js';
+import { judgeImpact } from '../src/judgment.js';
+
+const config = () =>
+  validateConfig({
+    repos: [{ name: 'repo-a' }, { name: 'repo-b' }],
+    corpus: {
+      code: { store: 'in-memory', embedder: 'hash' },
+      docs: { store: 'in-memory', embedder: 'hash' },
+    },
+  });
+
+const DIFF = [
+  'diff --git a/src/api.js b/src/api.js',
+  'index 1111111..2222222 100644',
+  '--- a/src/api.js',
+  '+++ b/src/api.js',
+  '@@ -1,2 +1,2 @@',
+  '-const TIMEOUT_MS = 1000;',
+  '+const TIMEOUT_MS = 5000;',
+  '',
+].join('\n');
+
+const VERDICT = JSON.stringify({ summary: 'ok', affected: [] });
+
+test('el adapter elegido llega al juez a través del pipeline (--adapter)', async () => {
+  let captured = null;
+  const result = await runImpactPipeline({
+    config: config(),
+    workspaceDir: '/ws',
+    repoName: 'repo-a',
+    diffText: DIFF,
+    adapter: 'vertex-ai',
+    deps: {
+      query: async () => ({
+        hits: [{ source: 'repo-b/src/x.js', line: 1, score: 0.8, content: 'x', sensitivity: 'internal' }],
+        candidates: 1,
+      }),
+      runAdapter: async (name) => {
+        captured = name;
+        return VERDICT;
+      },
+      readHistory: async () => [],
+    },
+  });
+  assert.ok(result);
+  assert.equal(captured, 'vertex-ai');
+});
+
+test('createDefaultRunAdapter({model}) pasa el modelo como opción del adapter', async () => {
+  let seen = null;
+  const registryFactory = async () => ({
+    get: () => async (prompt, options) => {
+      seen = options;
+      return { parsedOutput: { text: VERDICT } };
+    },
+  });
+  const run = createDefaultRunAdapter({ model: 'gemini-2.5-pro', registryFactory });
+  await run('vertex-ai', 'hola');
+  assert.deepEqual(seen, { model: 'gemini-2.5-pro' });
+});
+
+test('la guardia clasifica el descarte: formato saltado vs inventado', async () => {
+  const result = await judgeImpact({
+    candidates: [
+      {
+        source: 'hoop-api/openapi/openapi.json',
+        repo: 'hoop-api',
+        score: 0.7,
+        evidence: [{ fromChunk: { path: 'src/api.php', newStart: 1 }, line: 2, score: 0.7 }],
+      },
+    ],
+    coChanges: { byRepo: [], noSignal: [] },
+    diffSummary: 'x',
+    sensitivity: 'public',
+    policy: { confidential: ['ollama'], internal: ['ollama'], public: ['claude'] },
+    runAdapter: async () =>
+      JSON.stringify({
+        summary: 'ok',
+        affected: [
+          { source: 'hoop-api: openapi/openapi.json', severity: 'low', reason: 'formato con dos puntos' },
+          { source: 'zzz/inventado.js', severity: 'low', reason: 'no existe' },
+        ],
+      }),
+  });
+  assert.equal(result.verdict.affected.length, 0);
+  assert.equal(result.discardedEntries, 2);
+  const kinds = Object.fromEntries(result.discarded.map((d) => [d.source, d.kind]));
+  assert.equal(kinds['hoop-api: openapi/openapi.json'], 'format');
+  assert.equal(kinds['zzz/inventado.js'], 'unknown');
+});


### PR DESCRIPTION
feat(watch): choose the judge adapter and model from the cli KJW-TSK-0040

--adapter reaches judgeImpact as the explicit choice the policy already
validates (no silent degradation), and --model travels as adapter
options through the default runAdapter - in the field the adapter's
default model skipped the verdict format and there was no way to pin
another without a custom script. The discard log now tells format-skip
(a known signal written differently) apart from invention: both are
rejected, but blaming hallucination for a formatting miss misleads.
