### PR TITLE
feat(watch): warn about inactive observed repos

### DIFF
--- a/packages/watch/src/config.js
+++ b/packages/watch/src/config.js
@@ -121,6 +121,7 @@ const requireOneOf = (value, path, allowed) => {
  * @typedef {Object} ImpactThresholds
  * @property {number} [minSimilarity] Similitud mínima [0, 1] para considerar un candidato.
  * @property {number} [maxCandidates] Máximo de candidatos (entero >= 1).
+ * @property {number} [inactivityDays] Umbral de inactividad de repos observados (entero >= 1, default 90) — KJW-TSK-0043.
  *
  * @typedef {{type: 'pr-comment'} | {type: 'webhook', url: string}} NotifyTarget
  *
@@ -209,7 +210,7 @@ const validateImpact = (value, path) => {
   const impact = requireObject(value, path);
   rejectUnknownKeys(impact, path, ['thresholds']);
   const thresholds = requireObject(impact.thresholds, `${path}.thresholds`);
-  rejectUnknownKeys(thresholds, `${path}.thresholds`, ['minSimilarity', 'maxCandidates']);
+  rejectUnknownKeys(thresholds, `${path}.thresholds`, ['minSimilarity', 'maxCandidates', 'inactivityDays']);
   /** @type {ImpactThresholds} */
   const result = {};
   if (thresholds.minSimilarity !== undefined) {
@@ -225,6 +226,13 @@ const validateImpact = (value, path) => {
       throw new ConfigError(`${path}.thresholds.maxCandidates`, 'se esperaba un entero >= 1.');
     }
     result.maxCandidates = /** @type {number} */ (maxCandidates);
+  }
+  if (thresholds.inactivityDays !== undefined) {
+    const { inactivityDays } = thresholds;
+    if (!Number.isInteger(inactivityDays) || /** @type {number} */ (inactivityDays) < 1) {
+      throw new ConfigError(`${path}.thresholds.inactivityDays`, 'se esperaba un entero >= 1.');
+    }
+    result.inactivityDays = /** @type {number} */ (inactivityDays);
   }
   return { thresholds: result };
 };

--- a/packages/watch/src/impact.js
+++ b/packages/watch/src/impact.js
@@ -25,6 +25,7 @@ import { extractContractTokens, findContractMatches } from './contracts.js';
 import { buildImpactRanking, renderImpactMarkdown, deliverNotifications } from './report.js';
 import { announceDefaults } from './config.js';
 import { appendReport } from './history.js';
+import { findInactiveRepos } from './inactivity.js';
 
 /** Error de orquestación del pipeline de impacto. */
 export class ImpactError extends Error {
@@ -190,6 +191,8 @@ export const runImpactPipeline = async ({
   }
   /** @type {import('./cochanges.js').RepoHistory[]} */
   const targets = [];
+  /** @type {Set<string>} */
+  const unreadableRepos = new Set();
   for (const target of config.repos.filter((r) => r.name !== repoName)) {
     try {
       targets.push({
@@ -199,9 +202,24 @@ export const runImpactPipeline = async ({
     } catch (err) {
       if (!(err instanceof CoChangeError)) throw err;
       targets.push({ name: target.name, commits: [] });
+      unreadableRepos.add(target.name);
     }
   }
   const coChanges = correlateCoChanges({ origin, targets, touchedPaths });
+
+  // KJW-TSK-0043: la config también caduca — un repo observado sin merges en
+  // meses es ruido que nadie señala. El origen no entra: acaba de mergear.
+  const inactivity = {
+    thresholdDays: config.impact?.thresholds?.inactivityDays ?? 90,
+    ...findInactiveRepos({
+      repos: targets.map((t) => ({ ...t, readable: !unreadableRepos.has(t.name) })),
+      thresholdDays: config.impact?.thresholds?.inactivityDays ?? 90,
+      now: new Date().toISOString(),
+    }),
+  };
+  for (const r of inactivity.inactive) {
+    log(`config: repo observado inactivo: ${r.repo} (${r.inactiveDays ?? 'sin actividad conocida'} días) — retíralo o confírmalo`);
+  }
   log(`co-cambios: ${coChanges.byRepo.length} con señal, ${coChanges.noSignal.length} sin ella`);
 
   const diffSummary = `${repoName}: ${touchedPaths.join(', ')} (${chunks.length} chunks)`;
@@ -244,6 +262,7 @@ export const runImpactPipeline = async ({
     ranking,
     diffSummary,
     verdictSummary: verdict.summary,
+    inactivity,
   });
 
   let delivered = 0;

--- a/packages/watch/src/inactivity.js
+++ b/packages/watch/src/inactivity.js
@@ -1,0 +1,58 @@
+// @ts-check
+// KJW-TSK-0043 — la config también caduca: un repo observado sin un solo
+// merge en meses es ruido que nadie señala (caso real: 13 de 29 repos de
+// una instancia, descubierto a mano). Watch lo AVISA: propone retirar o
+// confirmar, nunca decide ni bloquea. Filosofía Steward: la historia que no
+// se puede leer no es «inactiva» — es no observable, y se dice aparte.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * @typedef {Object} InactiveRepo
+ * @property {string} repo
+ * @property {string | null} lastActivity Fecha ISO del último commit conocido; null sin commits.
+ * @property {number | null} inactiveDays Días desde la última actividad; null cuando no consta actividad alguna.
+ *
+ * @typedef {Object} InactivityResult
+ * @property {InactiveRepo[]} inactive Repos legibles cuya última actividad supera el umbral.
+ * @property {string[]} unreadable Repos cuya historia no se pudo leer — no observables, jamás acusados de inactivos.
+ */
+
+/**
+ * Clasifica los repos observados por frescura de su historia.
+ *
+ * @param {Object} params
+ * @param {Array<{name: string, commits: Array<{date: string}>, readable?: boolean}>} params.repos
+ * @param {number} [params.thresholdDays] Umbral de inactividad (default 90).
+ * @param {string} params.now Instante de referencia (ISO) — inyectado para que el resultado sea determinista.
+ * @returns {InactivityResult}
+ */
+export const findInactiveRepos = ({ repos, thresholdDays = 90, now }) => {
+  const nowMs = Date.parse(now);
+  /** @type {InactiveRepo[]} */
+  const inactive = [];
+  /** @type {string[]} */
+  const unreadable = [];
+  for (const repo of repos) {
+    if (repo.readable === false) {
+      unreadable.push(repo.name);
+      continue;
+    }
+    const lastMs = repo.commits.reduce((max, c) => Math.max(max, Date.parse(c.date)), 0);
+    if (lastMs === 0) {
+      // Legible y sin un solo commit conocido: inactivo sin fecha.
+      inactive.push({ repo: repo.name, lastActivity: null, inactiveDays: null });
+      continue;
+    }
+    const inactiveDays = Math.floor((nowMs - lastMs) / MS_PER_DAY);
+    if (inactiveDays > thresholdDays) {
+      inactive.push({
+        repo: repo.name,
+        // La fecha original del commit, no una re-serialización.
+        lastActivity: repo.commits.find((c) => Date.parse(c.date) === lastMs)?.date ?? null,
+        inactiveDays,
+      });
+    }
+  }
+  return { inactive, unreadable };
+};

--- a/packages/watch/src/report.js
+++ b/packages/watch/src/report.js
@@ -154,9 +154,11 @@ export const buildImpactRanking = ({
  * @param {RankingEntry[]} params.ranking
  * @param {string} params.diffSummary
  * @param {string} [params.verdictSummary]
+ * @param {import('./inactivity.js').InactivityResult & {thresholdDays: number}} [params.inactivity]
+ *   Repos observados inactivos (KJW-TSK-0043) — aviso al pie, nunca gate.
  * @returns {string}
  */
-export const renderImpactMarkdown = ({ ranking, diffSummary, verdictSummary }) => {
+export const renderImpactMarkdown = ({ ranking, diffSummary, verdictSummary, inactivity }) => {
   const lines = [
     '## karajan-watch — posible impacto cross-repo',
     '',
@@ -196,6 +198,17 @@ export const renderImpactMarkdown = ({ ranking, diffSummary, verdictSummary }) =
             (ev.line == null ? '' : ` (línea ${ev.line})`),
         );
       }
+    }
+  }
+  // KJW-TSK-0043: la config también caduca. Aviso que propone, no que decide.
+  if (inactivity && (inactivity.inactive.length > 0 || inactivity.unreadable.length > 0)) {
+    lines.push('', `### Repos observados inactivos (umbral: ${inactivity.thresholdDays} días)`, '');
+    for (const r of inactivity.inactive) {
+      const since = r.lastActivity ? `último merge ${r.lastActivity} (${r.inactiveDays} días)` : 'sin actividad conocida';
+      lines.push(`- \`${r.repo}\` — ${since}: retira este repo de la config o confirma que sigue interesando.`);
+    }
+    for (const name of inactivity.unreadable) {
+      lines.push(`- \`${name}\` — historia ilegible: no observable (no se acusa de inactivo lo que no se puede mirar).`);
     }
   }
   return redactPII(lines.join('\n')).text;

--- a/packages/watch/tests/inactivity.test.js
+++ b/packages/watch/tests/inactivity.test.js
@@ -1,0 +1,79 @@
+// @ts-check
+// KJW-TSK-0043: la config también caduca. En una instancia real, 13 de 29
+// repos observados llevaban 3 meses sin un merge y nada lo señalaba — la
+// mitad de la config era ruido silencioso. Watch lo AVISA (nunca gate).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findInactiveRepos } from '../src/inactivity.js';
+import { renderImpactMarkdown } from '../src/report.js';
+import { validateConfig } from '../src/config.js';
+
+const NOW = '2026-09-05T12:00:00Z';
+const history = (name, dates, readable = true) => ({
+  name,
+  readable,
+  commits: dates.map((date, i) => ({ hash: `h${i}`, date, files: ['x'] })),
+});
+
+test('separa activos, inactivos sobre umbral y no-legibles — sin acusar a quien no se puede mirar', () => {
+  const result = findInactiveRepos({
+    repos: [
+      history('vivo', ['2026-09-01T10:00:00Z']),
+      history('dormido', ['2026-04-01T10:00:00Z', '2026-03-01T10:00:00Z']),
+      history('ilegible', [], false),
+      history('vacio-legible', []),
+    ],
+    thresholdDays: 90,
+    now: NOW,
+  });
+  assert.deepEqual(result.inactive.map((r) => r.repo), ['dormido', 'vacio-legible']);
+  const dormido = result.inactive[0];
+  assert.equal(dormido.lastActivity, '2026-04-01T10:00:00Z');
+  assert.ok(dormido.inactiveDays > 150 && dormido.inactiveDays < 160);
+  assert.deepEqual(result.unreadable, ['ilegible']);
+});
+
+test('bajo el umbral nadie es inactivo', () => {
+  const result = findInactiveRepos({
+    repos: [history('a', ['2026-08-01T10:00:00Z'])],
+    thresholdDays: 90,
+    now: NOW,
+  });
+  assert.equal(result.inactive.length, 0);
+});
+
+test('el informe lista los inactivos como aviso que propone, no que decide', () => {
+  const md = renderImpactMarkdown({
+    ranking: [],
+    diffSummary: 'x',
+    inactivity: {
+      thresholdDays: 90,
+      inactive: [{ repo: 'dormido', lastActivity: '2026-04-01T10:00:00Z', inactiveDays: 157 }],
+      unreadable: [],
+    },
+  });
+  assert.match(md, /observados inactivos/i);
+  assert.match(md, /`dormido`/);
+  assert.match(md, /157/);
+  assert.match(md, /retira.*o.*confirma|confirma.*o.*retira/i);
+});
+
+test('el umbral es configurable vía impact.thresholds.inactivityDays', () => {
+  const config = validateConfig({
+    repos: [{ name: 'a' }, { name: 'b' }],
+    corpus: {
+      code: { store: 'in-memory', embedder: 'hash' },
+      docs: { store: 'in-memory', embedder: 'hash' },
+    },
+    impact: { thresholds: { inactivityDays: 30 } },
+  });
+  assert.equal(config.impact?.thresholds.inactivityDays, 30);
+  assert.throws(() => validateConfig({
+    repos: [{ name: 'a' }],
+    corpus: {
+      code: { store: 'in-memory', embedder: 'hash' },
+      docs: { store: 'in-memory', embedder: 'hash' },
+    },
+    impact: { thresholds: { inactivityDays: -1 } },
+  }));
+});


### PR DESCRIPTION
feat(watch): warn about inactive observed repos KJW-TSK-0043

Config decays too: in a real instance 13 of 29 observed repos had not
merged in three months and nothing said so - half the configuration was
silent noise, found by hand. The impact pipeline now classifies observed
repos by history freshness (threshold impact.thresholds.inactivityDays,
default 90), logs each stale one and lists them at the report's foot
proposing to retire or confirm - never a gate. Unreadable history is NOT
accused of inactivity: it is reported apart as not observable.
