### PR TITLE
feat(watch): the eval is honest with time

### DIFF
--- a/packages/watch/bin/karajan-watch.js
+++ b/packages/watch/bin/karajan-watch.js
@@ -34,7 +34,7 @@ const printUsage = () => {
       '     karajan-watch drift  --workspace <dir> --repo <name> --diff <fichero|-> ' +
       '[--config karajan-watch.config.json] [--judge] [--no-deliver] [--pr-number N]\n' +
       '     karajan-watch eval   --workspace <dir> --golden <fichero> ' +
-      '[--config karajan-watch.config.json]',
+      '[--config karajan-watch.config.json] [--corpus-indexed-at ISO]',
   );
 };
 
@@ -96,6 +96,7 @@ const main = async () => {
       'no-judge': { type: 'boolean', default: false },
       adapter: { type: 'string' },
       model: { type: 'string' },
+      'corpus-indexed-at': { type: 'string' },
       'no-deliver': { type: 'boolean', default: false },
       'pr-number': { type: 'string' },
     },
@@ -126,17 +127,28 @@ const main = async () => {
       golden: await loadGoldenSet(resolve(values.golden)),
       config,
       workspaceDir: resolve(values.workspace),
+      corpusIndexedAt: values['corpus-indexed-at'],
     });
     for (const evalCase of report.cases) {
       const { precision, recall, truePositives } = evalCase.metrics;
+      const repoPart = evalCase.repoMetrics
+        ? ` · repo: precision ${evalCase.repoMetrics.precision.toFixed(2)} recall ${evalCase.repoMetrics.recall.toFixed(2)}`
+        : '';
       console.log(
         `${evalCase.name}: precision ${precision.toFixed(2)} · recall ${recall.toFixed(2)} ` +
-          `· aciertos ${truePositives}`,
+          `· aciertos ${truePositives}${repoPart}`,
       );
     }
+    // KJW-TSK-0042: los avisos ANTES del agregado — un número medido contra
+    // un índice anterior al merge no debe leerse sin su contexto.
+    for (const warning of report.warnings) console.log(`AVISO: ${warning}`);
+    const repoAggregate =
+      report.aggregate.repoRecall !== undefined
+        ? ` · repo: precision ${report.aggregate.repoPrecision?.toFixed(2)} recall ${report.aggregate.repoRecall.toFixed(2)}`
+        : '';
     console.log(
       `agregado: precision ${report.aggregate.precision.toFixed(2)} · ` +
-        `recall ${report.aggregate.recall.toFixed(2)} → ${report.passed ? 'PASSED' : 'FAILED'}`,
+        `recall ${report.aggregate.recall.toFixed(2)}${repoAggregate} → ${report.passed ? 'PASSED' : 'FAILED'}`,
     );
     // Sin esto el número es engañoso: no significa lo mismo medido contra
     // otro store, y estos umbrales acaban copiados a otro despliegue.

--- a/packages/watch/src/eval.js
+++ b/packages/watch/src/eval.js
@@ -35,6 +35,8 @@ export class GoldenSetError extends Error {
  * @property {string} repoName Repo origen del incidente.
  * @property {string} diff Diff unificado del cambio que causó el incidente.
  * @property {string[]} expectedImpacted Ficheros (`repo/path`) que realmente se vieron afectados.
+ * @property {string} [mergedAt] Fecha ISO del merge del caso (KJW-TSK-0042) — permite avisar cuando el índice es anterior al cambio.
+ * @property {string[]} [expectedRepos] Repos realmente afectados (KJW-TSK-0042) — la métrica que no castiga ficheros creados DESPUÉS de indexar.
  *
  * @typedef {Object} GoldenThresholds
  * @property {number} [precision] Mínimo agregado exigido, en [0, 1].
@@ -51,10 +53,11 @@ export class GoldenSetError extends Error {
  * @property {number} recall
  *
  * @typedef {Object} EvalReport
- * @property {{name: string, metrics: CaseMetrics}[]} cases
- * @property {{precision: number, recall: number}} aggregate Medias sobre los casos.
+ * @property {{name: string, metrics: CaseMetrics, repoMetrics?: CaseMetrics}[]} cases
+ * @property {{precision: number, recall: number, repoPrecision?: number, repoRecall?: number}} aggregate Medias sobre los casos (las de repo, solo sobre los casos que declaran expectedRepos).
  * @property {boolean} passed
- * @property {{store: string, embedder: string}} measuredWith Con qué se obtuvieron estos números: los scores NO son comparables entre backends, así que un umbral calibrado aquí no vale para otro store.
+ * @property {string[]} warnings Avisos de medición (KJW-TSK-0042): p.ej. índice anterior al merge de un caso — el número se da, pero jamás en silencio.
+ * @property {{store: string, embedder: string, corpusIndexedAt?: string}} measuredWith Con qué se obtuvieron estos números: los scores NO son comparables entre backends, así que un umbral calibrado aquí no vale para otro store.
  */
 
 /**
@@ -126,7 +129,7 @@ export const validateGoldenSet = (raw) => {
     const path = `$.cases[${i}]`;
     const goldenCase = requireObject(rawCase, path);
     for (const key of Object.keys(goldenCase)) {
-      if (!['name', 'repoName', 'diff', 'expectedImpacted'].includes(key)) {
+      if (!['name', 'repoName', 'diff', 'expectedImpacted', 'mergedAt', 'expectedRepos'].includes(key)) {
         throw new GoldenSetError(`${path}.${key}`, 'clave desconocida.');
       }
     }
@@ -143,7 +146,26 @@ export const validateGoldenSet = (raw) => {
         'se esperaba un array no vacío de paths `repo/…`.',
       );
     }
-    return { name, repoName, diff, expectedImpacted: goldenCase.expectedImpacted };
+    /** @type {GoldenCase} */
+    const result = { name, repoName, diff, expectedImpacted: goldenCase.expectedImpacted };
+    if (goldenCase.mergedAt !== undefined) {
+      const mergedAt = requireNonEmptyString(goldenCase.mergedAt, `${path}.mergedAt`);
+      if (Number.isNaN(Date.parse(mergedAt))) {
+        throw new GoldenSetError(`${path}.mergedAt`, 'se esperaba una fecha ISO parseable.');
+      }
+      result.mergedAt = mergedAt;
+    }
+    if (goldenCase.expectedRepos !== undefined) {
+      if (
+        !Array.isArray(goldenCase.expectedRepos) ||
+        goldenCase.expectedRepos.length === 0 ||
+        !goldenCase.expectedRepos.every((s) => typeof s === 'string' && s.length > 0)
+      ) {
+        throw new GoldenSetError(`${path}.expectedRepos`, 'se esperaba un array no vacío de repos.');
+      }
+      result.expectedRepos = goldenCase.expectedRepos;
+    }
+    return result;
   });
 
   return { thresholds, cases };
@@ -171,20 +193,45 @@ export const evaluateRanking = (ranking, expectedImpacted, k) => {
 };
 
 /**
+ * Métricas a nivel de REPO (KJW-TSK-0042): ¿acertó QUÉ repos se ven
+ * afectados? Es la métrica que refleja lo que el juicio sabe hacer cuando
+ * los ficheros correctos ni existían al indexar (caso real: repo 2/2 donde
+ * fichero daba 0 — un cero que no era de la herramienta).
+ *
+ * @param {{repo: string}[]} ranking
+ * @param {string[]} expectedRepos
+ * @param {number} k
+ * @returns {CaseMetrics}
+ */
+export const evaluateRepoRanking = (ranking, expectedRepos, k) => {
+  const returned = [...new Set(ranking.slice(0, k).map((entry) => entry.repo))];
+  const expected = new Set(expectedRepos);
+  const truePositives = returned.filter((repo) => expected.has(repo)).length;
+  return {
+    truePositives,
+    precision: returned.length === 0 ? 0 : truePositives / returned.length,
+    recall: truePositives / expected.size,
+  };
+};
+
+/**
  * Ejecuta la eval completa: pipeline por caso (señales puras) + gate.
  *
  * @param {Object} params
  * @param {GoldenSet} params.golden
  * @param {import('./config.js').WatchConfig} params.config
  * @param {string} params.workspaceDir
+ * @param {string} [params.corpusIndexedAt] Fecha ISO en que se indexó el corpus (KJW-TSK-0042): un caso cuyo merge es POSTERIOR se mide contra un mundo que no lo conocía — se avisa, nunca se puntúa en silencio.
  * @param {Record<string, string | undefined>} [params.env]
  * @param {import('./impact.js').ImpactDeps} [params.deps]
  * @returns {Promise<EvalReport>}
  */
-export const runGoldenEval = async ({ golden, config, workspaceDir, env, deps }) => {
+export const runGoldenEval = async ({ golden, config, workspaceDir, corpusIndexedAt, env, deps }) => {
   const k = golden.thresholds.k ?? 10;
   /** @type {EvalReport['cases']} */
   const cases = [];
+  /** @type {string[]} */
+  const warnings = [];
   for (const goldenCase of golden.cases) {
     const { ranking } = await runImpactPipeline({
       config,
@@ -196,18 +243,42 @@ export const runGoldenEval = async ({ golden, config, workspaceDir, env, deps })
       env,
       deps,
     });
-    cases.push({
+    /** @type {EvalReport['cases'][0]} */
+    const entry = {
       name: goldenCase.name,
       metrics: evaluateRanking(ranking, goldenCase.expectedImpacted, k),
-    });
+    };
+    if (goldenCase.expectedRepos) {
+      entry.repoMetrics = evaluateRepoRanking(ranking, goldenCase.expectedRepos, k);
+    }
+    if (
+      corpusIndexedAt &&
+      goldenCase.mergedAt &&
+      Date.parse(corpusIndexedAt) < Date.parse(goldenCase.mergedAt)
+    ) {
+      warnings.push(
+        `caso "${goldenCase.name}": el índice (${corpusIndexedAt}) es anterior al merge ` +
+          `(${goldenCase.mergedAt}) — la métrica de fichero castiga ficheros que no existían al indexar; ` +
+          'mira la métrica de repo.',
+      );
+    }
+    cases.push(entry);
   }
 
   const mean = (/** @type {(c: EvalReport['cases'][0]) => number} */ pick) =>
     cases.reduce((sum, c) => sum + pick(c), 0) / cases.length;
+  /** @type {EvalReport['aggregate']} */
   const aggregate = {
     precision: mean((c) => c.metrics.precision),
     recall: mean((c) => c.metrics.recall),
   };
+  const withRepos = cases.filter((c) => c.repoMetrics);
+  if (withRepos.length > 0) {
+    aggregate.repoPrecision =
+      withRepos.reduce((s, c) => s + (c.repoMetrics?.precision ?? 0), 0) / withRepos.length;
+    aggregate.repoRecall =
+      withRepos.reduce((s, c) => s + (c.repoMetrics?.recall ?? 0), 0) / withRepos.length;
+  }
 
   const { precision, recall } = golden.thresholds;
   const passed =
@@ -218,7 +289,10 @@ export const runGoldenEval = async ({ golden, config, workspaceDir, env, deps })
   // umbrales calibrados con un store y un embedder no significan lo mismo
   // con otros. El informe lo deja registrado en vez de dar un número suelto.
   const { store, embedder } = config.corpus.code;
-  return { cases, aggregate, passed, measuredWith: { store, embedder } };
+  /** @type {EvalReport['measuredWith']} */
+  const measuredWith = { store, embedder };
+  if (corpusIndexedAt) measuredWith.corpusIndexedAt = corpusIndexedAt;
+  return { cases, aggregate, passed, warnings, measuredWith };
 };
 
 /**

--- a/packages/watch/tests/eval-honest-time.test.js
+++ b/packages/watch/tests/eval-honest-time.test.js
@@ -1,10 +1,7 @@
 // @ts-check
-// KJW-TSK-0042: el eval honesto con el tiempo. Caso real de campo: el juez
-// acertó a nivel repo (2/2, confirmado por merges posteriores) y la métrica
-// de fichero daba 0 — porque los ficheros correctos se crearon DESPUÉS de
-// indexar el corpus. Un número que castiga eso es engañoso: el caso declara
-// cuándo fue el merge, el eval avisa si el índice es anterior, y existe
-// métrica a nivel repo además de la de fichero.
+// KJW-TSK-0042: el eval honesto con el tiempo — el caso declara cuándo fue
+// su merge, el eval avisa si el índice es anterior (jamás puntúa en
+// silencio), y hay métrica a nivel repo además de la de fichero.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { validateGoldenSet, runGoldenEval, evaluateRepoRanking, GoldenSetError } from '../src/eval.js';
@@ -88,34 +85,22 @@ test('métrica de repo en el informe cuando el caso declara expectedRepos', asyn
   assert.equal(report.aggregate.repoRecall, 1);
 });
 
-test('índice anterior al merge = AVISO explícito, nunca un número en silencio', async () => {
-  const report = await runGoldenEval({
-    golden: validateGoldenSet(golden({ mergedAt: '2026-08-31T10:00:00Z' })),
-    config: config(),
-    workspaceDir: '/ws',
-    corpusIndexedAt: '2026-08-21T00:00:00Z',
-    deps: deps(),
-  });
-  assert.equal(report.warnings.length, 1);
-  assert.match(report.warnings[0], /invitaciones/);
-  assert.match(report.warnings[0], /anterior al merge/i);
-  assert.equal(report.measuredWith.corpusIndexedAt, '2026-08-21T00:00:00Z');
-});
-
-test('sin fechas o con índice fresco no hay aviso', async () => {
-  const fresh = await runGoldenEval({
-    golden: validateGoldenSet(golden({ mergedAt: '2026-08-01T10:00:00Z' })),
-    config: config(),
-    workspaceDir: '/ws',
-    corpusIndexedAt: '2026-08-21T00:00:00Z',
-    deps: deps(),
-  });
+test('índice anterior al merge = AVISO explícito; con índice fresco o sin fechas, ninguno', async () => {
+  const run = (caseOverrides, corpusIndexedAt) =>
+    runGoldenEval({
+      golden: validateGoldenSet(golden(caseOverrides)),
+      config: config(),
+      workspaceDir: '/ws',
+      corpusIndexedAt,
+      deps: deps(),
+    });
+  const stale = await run({ mergedAt: '2026-08-31T10:00:00Z' }, '2026-08-21T00:00:00Z');
+  assert.equal(stale.warnings.length, 1);
+  assert.match(stale.warnings[0], /invitaciones/);
+  assert.match(stale.warnings[0], /anterior al merge/i);
+  assert.equal(stale.measuredWith.corpusIndexedAt, '2026-08-21T00:00:00Z');
+  const fresh = await run({ mergedAt: '2026-08-01T10:00:00Z' }, '2026-08-21T00:00:00Z');
   assert.equal(fresh.warnings.length, 0);
-  const undated = await runGoldenEval({
-    golden: validateGoldenSet(golden()),
-    config: config(),
-    workspaceDir: '/ws',
-    deps: deps(),
-  });
+  const undated = await run({}, undefined);
   assert.equal(undated.warnings.length, 0);
 });

--- a/packages/watch/tests/eval-honest-time.test.js
+++ b/packages/watch/tests/eval-honest-time.test.js
@@ -1,0 +1,121 @@
+// @ts-check
+// KJW-TSK-0042: el eval honesto con el tiempo. Caso real de campo: el juez
+// acertó a nivel repo (2/2, confirmado por merges posteriores) y la métrica
+// de fichero daba 0 — porque los ficheros correctos se crearon DESPUÉS de
+// indexar el corpus. Un número que castiga eso es engañoso: el caso declara
+// cuándo fue el merge, el eval avisa si el índice es anterior, y existe
+// métrica a nivel repo además de la de fichero.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateGoldenSet, runGoldenEval, evaluateRepoRanking, GoldenSetError } from '../src/eval.js';
+import { validateConfig } from '../src/config.js';
+
+const config = () =>
+  validateConfig({
+    repos: [{ name: 'repo-a' }, { name: 'repo-b' }],
+    corpus: {
+      code: { store: 'in-memory', embedder: 'hash' },
+      docs: { store: 'in-memory', embedder: 'hash' },
+    },
+  });
+
+const DIFF = [
+  'diff --git a/src/api.js b/src/api.js',
+  'index 1111111..2222222 100644',
+  '--- a/src/api.js',
+  '+++ b/src/api.js',
+  '@@ -1,1 +1,1 @@',
+  '-const A = 1;',
+  '+const A = 2;',
+  '',
+].join('\n');
+
+const golden = (caseOverrides = {}) => ({
+  thresholds: { k: 5 },
+  cases: [
+    {
+      name: 'invitaciones',
+      repoName: 'repo-a',
+      diff: DIFF,
+      expectedImpacted: ['repo-b/src/consumer.js'],
+      ...caseOverrides,
+    },
+  ],
+});
+
+const deps = () => ({
+  query: async () => ({
+    hits: [{ source: 'repo-b/src/consumer.js', line: 3, score: 0.9, content: 'x', sensitivity: 'internal' }],
+    candidates: 7,
+  }),
+});
+
+test('el caso declara mergedAt y expectedRepos; lo inválido se rechaza con path', () => {
+  const ok = validateGoldenSet(
+    golden({ mergedAt: '2026-08-31T10:00:00Z', expectedRepos: ['repo-b'] }),
+  );
+  assert.equal(ok.cases[0].mergedAt, '2026-08-31T10:00:00Z');
+  assert.deepEqual(ok.cases[0].expectedRepos, ['repo-b']);
+  assert.throws(
+    () => validateGoldenSet(golden({ mergedAt: 'ayer' })),
+    (err) => err instanceof GoldenSetError && err.path === '$.cases[0].mergedAt',
+  );
+  assert.throws(
+    () => validateGoldenSet(golden({ expectedRepos: [] })),
+    (err) => err instanceof GoldenSetError && err.path === '$.cases[0].expectedRepos',
+  );
+});
+
+test('evaluateRepoRanking: acierto por repo aunque el fichero exacto no exista en el corpus', () => {
+  const ranking = [
+    { source: 'new-app-android/src/sso/Auth.kt', repo: 'new-app-android' },
+    { source: 'repo-c/x.js', repo: 'repo-c' },
+  ];
+  const m = evaluateRepoRanking(ranking, ['new-app-android', 'new-app-ios'], 5);
+  assert.equal(m.truePositives, 1);
+  assert.equal(m.precision, 0.5);
+  assert.equal(m.recall, 0.5);
+});
+
+test('métrica de repo en el informe cuando el caso declara expectedRepos', async () => {
+  const report = await runGoldenEval({
+    golden: validateGoldenSet(golden({ expectedRepos: ['repo-b'] })),
+    config: config(),
+    workspaceDir: '/ws',
+    deps: deps(),
+  });
+  assert.equal(report.cases[0].repoMetrics?.recall, 1);
+  assert.equal(report.aggregate.repoRecall, 1);
+});
+
+test('índice anterior al merge = AVISO explícito, nunca un número en silencio', async () => {
+  const report = await runGoldenEval({
+    golden: validateGoldenSet(golden({ mergedAt: '2026-08-31T10:00:00Z' })),
+    config: config(),
+    workspaceDir: '/ws',
+    corpusIndexedAt: '2026-08-21T00:00:00Z',
+    deps: deps(),
+  });
+  assert.equal(report.warnings.length, 1);
+  assert.match(report.warnings[0], /invitaciones/);
+  assert.match(report.warnings[0], /anterior al merge/i);
+  assert.equal(report.measuredWith.corpusIndexedAt, '2026-08-21T00:00:00Z');
+});
+
+test('sin fechas o con índice fresco no hay aviso', async () => {
+  const fresh = await runGoldenEval({
+    golden: validateGoldenSet(golden({ mergedAt: '2026-08-01T10:00:00Z' })),
+    config: config(),
+    workspaceDir: '/ws',
+    corpusIndexedAt: '2026-08-21T00:00:00Z',
+    deps: deps(),
+  });
+  assert.equal(fresh.warnings.length, 0);
+  const undated = await runGoldenEval({
+    golden: validateGoldenSet(golden()),
+    config: config(),
+    workspaceDir: '/ws',
+    deps: deps(),
+  });
+  assert.equal(undated.warnings.length, 0);
+});


### PR DESCRIPTION
feat(watch): the eval is honest with time KJW-TSK-0042

Field case: the judge was right at repo level (2/2, proven by later
merges) and the file metric read 0 - the correct files were created
AFTER the corpus was indexed. Now a golden case can declare mergedAt and
expectedRepos, the eval warns explicitly when the index predates the
merge instead of scoring in silence, a repo-level metric rides next to
the file one (per case and aggregated), and measuredWith records the
corpus timestamp. CLI: --corpus-indexed-at.
