### PR TITLE
fix(watch): the judge location is pinnable - eu data stays in the eu

### DIFF
--- a/packages/watch/bin/karajan-watch.js
+++ b/packages/watch/bin/karajan-watch.js
@@ -5,7 +5,7 @@
  *
  * Uso:
  *   karajan-watch ingest [--config karajan-watch.config.json] [--workspace <dir>] [--corpus code|docs]
- *   karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> [--adapter X] [--model Y] [--no-judge] [--no-deliver] [--pr-number N]
+ *   karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> [--adapter X] [--model Y] [--location Z] [--no-judge] [--no-deliver] [--pr-number N]
  *   karajan-watch drift  --workspace <dir> --repo <name> --diff <fichero|-> [--judge] [--no-deliver] [--pr-number N]
  *
  * `ingest` valida el config de despliegue, verifica la convención de
@@ -30,7 +30,7 @@ const printUsage = () => {
     'Uso: karajan-watch ingest [--config karajan-watch.config.json] ' +
       '[--workspace <dir>] [--corpus code|docs]\n' +
       '     karajan-watch impact --workspace <dir> --repo <name> --diff <fichero|-> ' +
-      '[--config karajan-watch.config.json] [--corpus code|docs] [--adapter X] [--model Y] [--no-judge] [--no-deliver] [--pr-number N]\n' +
+      '[--config karajan-watch.config.json] [--corpus code|docs] [--adapter X] [--model Y] [--location Z] [--no-judge] [--no-deliver] [--pr-number N]\n' +
       '     karajan-watch drift  --workspace <dir> --repo <name> --diff <fichero|-> ' +
       '[--config karajan-watch.config.json] [--judge] [--no-deliver] [--pr-number N]\n' +
       '     karajan-watch eval   --workspace <dir> --golden <fichero> ' +
@@ -96,6 +96,7 @@ const main = async () => {
       'no-judge': { type: 'boolean', default: false },
       adapter: { type: 'string' },
       model: { type: 'string' },
+      location: { type: 'string' },
       'corpus-indexed-at': { type: 'string' },
       'no-deliver': { type: 'boolean', default: false },
       'pr-number': { type: 'string' },
@@ -179,6 +180,7 @@ const main = async () => {
           judge: !values['no-judge'],
           adapter: values.adapter,
           model: values.model,
+          location: values.location,
         })
       : await runDriftPipeline({ ...shared, judge: values.judge });
   console.log(result.markdown);

--- a/packages/watch/src/impact.js
+++ b/packages/watch/src/impact.js
@@ -67,16 +67,21 @@ export const extractAdapterText = (result) => {
  *
  * @returns {(adapterName: string, prompt: string) => Promise<string>}
  */
-export const createDefaultRunAdapter = ({ model, registryFactory = createDefaultAdapterRegistry } = {}) => {
+export const createDefaultRunAdapter = ({ model, location, registryFactory = createDefaultAdapterRegistry } = {}) => {
   /** @type {import('karajan-rag').AdapterRegistry | null} */
   let registry = null;
   return async (adapterName, prompt) => {
     registry ??= await registryFactory();
     const adapterFn = registry.get(adapterName);
-    // El modelo del juez es elegible desde el binario (KJW-TSK-0040): en
-    // campo, el default del adapter puede no respetar el formato del
-    // veredicto y no había vía para fijar otro sin script propio.
-    return extractAdapterText(await adapterFn(prompt, model ? { model } : {}));
+    // Modelo y región del juez son elegibles desde el binario (KJW-TSK-0040,
+    // KJW-BUG-0011): en campo, el modelo por defecto se saltaba el formato
+    // del veredicto y la región fija en us-central1 sacaba los datos de la
+    // UE — y no había vía para fijar ninguno sin script propio.
+    const options = {
+      ...(model ? { model } : {}),
+      ...(location ? { location } : {}),
+    };
+    return extractAdapterText(await adapterFn(prompt, options));
   };
 };
 
@@ -109,6 +114,7 @@ export const createDefaultRunAdapter = ({ model, registryFactory = createDefault
  * @param {boolean} [params.judge] Ejecutar el juicio LLM (default true). Con false el veredicto queda vacío y no se toca ningún adapter — señales puras (eval, despliegues sin LLM).
  * @param {string} [params.adapter] Adapter del juez (KJW-TSK-0040); debe estar permitido por la policy — no se degrada a otro.
  * @param {string} [params.model] Modelo del adapter del juez (KJW-TSK-0040); solo aplica al runAdapter por defecto.
+ * @param {string} [params.location] Región del adapter del juez (KJW-BUG-0011, p.ej. europe-west1); solo aplica al runAdapter por defecto.
  * @param {boolean} [params.deliver] Entregar a notify.targets (default true).
  * @param {{repoSlug: string, prNumber: number, token: string}} [params.prContext]
  * @param {Record<string, string | undefined>} [params.env]
@@ -125,6 +131,7 @@ export const runImpactPipeline = async ({
   judge = true,
   adapter,
   model,
+  location,
   deliver = true,
   prContext,
   env = process.env,
@@ -233,7 +240,7 @@ export const runImpactPipeline = async ({
         policy: config.policy ?? createDefaultSensitivityPolicy(),
         contracts,
         adapter,
-        runAdapter: deps.runAdapter ?? createDefaultRunAdapter({ model }),
+        runAdapter: deps.runAdapter ?? createDefaultRunAdapter({ model, location }),
       })
     : { verdict: { summary: '', affected: [] }, discardedEntries: 0 };
   const { verdict } = judgment;

--- a/packages/watch/tests/judgment-adapter-model.test.js
+++ b/packages/watch/tests/judgment-adapter-model.test.js
@@ -55,7 +55,9 @@ test('el adapter elegido llega al juez a través del pipeline (--adapter)', asyn
   assert.equal(captured, 'vertex-ai');
 });
 
-test('createDefaultRunAdapter({model}) pasa el modelo como opción del adapter', async () => {
+test('createDefaultRunAdapter pasa modelo Y región como opciones del adapter', async () => {
+  // KJW-BUG-0011: sin location fijable, el juicio salía de us-central1 sí o
+  // sí — datos fuera de la UE para una instancia europea.
   let seen = null;
   const registryFactory = async () => ({
     get: () => async (prompt, options) => {
@@ -63,9 +65,12 @@ test('createDefaultRunAdapter({model}) pasa el modelo como opción del adapter',
       return { parsedOutput: { text: VERDICT } };
     },
   });
-  const run = createDefaultRunAdapter({ model: 'gemini-2.5-pro', registryFactory });
+  const run = createDefaultRunAdapter({ model: 'gemini-2.5-pro', location: 'europe-west1', registryFactory });
   await run('vertex-ai', 'hola');
-  assert.deepEqual(seen, { model: 'gemini-2.5-pro' });
+  assert.deepEqual(seen, { model: 'gemini-2.5-pro', location: 'europe-west1' });
+  seen = null;
+  await createDefaultRunAdapter({ registryFactory })('vertex-ai', 'hola');
+  assert.deepEqual(seen, {});
 });
 
 test('la guardia clasifica el descarte: formato saltado vs inventado', async () => {


### PR DESCRIPTION
Card KJW-BUG-0011 (reporte de tribbu tras 0.7.0): runVertexAi acepta options.location pero nada la propagaba - el juicio salía de us-central1 sí o sí, sacando datos de la UE en instancias europeas, y era LO ÚLTIMO que forzaba su deps.runAdapter propio. --location en el binario, runImpactPipeline la acepta y createDefaultRunAdapter la pasa como opción junto a model. Tests actualizados; suite 180.