### PR TITLE
feat(rag): vertex rides the google gen ai sdk with env pinning

### DIFF
--- a/packages/rag/src/ai/adapters/vertex-ai-adapter.js
+++ b/packages/rag/src/ai/adapters/vertex-ai-adapter.js
@@ -7,16 +7,17 @@
 /**
  * @typedef {Object} VertexAIOptions
  * @property {string} [project] GCP project id (default env GOOGLE_CLOUD_PROJECT).
- * @property {string} [location] Region (default 'us-central1').
- * @property {string} [model] Nombre de modelo (default 'gemini-1.5-flash').
- * @property {number} [maxTokens] Default 1024.
- * @property {any} [sdk] Módulo @google-cloud/vertexai inyectable (tests).
+ * @property {string} [location] Region (default env VERTEX_LOCATION, después 'us-central1').
+ * @property {string} [model] Nombre de modelo (default env VERTEX_MODEL, después 'gemini-2.5-flash').
+ * @property {number} [maxTokens] Default 8192.
+ * @property {any} [sdk] Módulo @google/genai inyectable (tests).
  */
 
 /**
- * Adapter Google Vertex AI vía SDK oficial. Credenciales: via
- * GOOGLE_APPLICATION_CREDENTIALS o ADC. @google-cloud/vertexai es
- * peer-dependency opcional.
+ * Adapter Google Vertex AI vía el Google Gen AI SDK (@google/genai en modo
+ * vertexai — KJR-TSK-0159: el SDK anterior, @google-cloud/vertexai, quedó
+ * deprecado con retirada anunciada para jun-2026). Credenciales: via
+ * GOOGLE_APPLICATION_CREDENTIALS o ADC. @google/genai es peer opcional.
  *
  * @param {string} prompt
  * @param {VertexAIOptions} [options]
@@ -24,28 +25,30 @@
  */
 export async function runVertexAi(prompt, options = {}) {
   const project = options.project ?? process.env.GOOGLE_CLOUD_PROJECT;
-  const location = options.location ?? 'us-central1';
+  // options > entorno > default — la instancia fija región y modelo sin
+  // tocar código (KJW-BUG-0011: una instancia europea no debe sacar datos
+  // de la UE por un default).
+  const location = options.location ?? process.env.VERTEX_LOCATION ?? 'us-central1';
   // gemini-1.5/2.0-flash están retirados (404 verificado en campo); los
   // modelos 2.5 gastan tokens de razonamiento que cuentan como salida,
   // así que 1024 dejaba la respuesta VACÍA (KJR-BUG-0011, issue #155).
-  const model = options.model ?? 'gemini-2.5-flash';
+  const model = options.model ?? process.env.VERTEX_MODEL ?? 'gemini-2.5-flash';
   const maxTokens = options.maxTokens ?? 8192;
   if (!project) {
     throw new Error(
       'VertexAI: falta "project" (vía opts o env GOOGLE_CLOUD_PROJECT).',
     );
   }
-  const sdk = options.sdk ?? (await loadVertexSdk());
-  const { VertexAI } = sdk;
-  const vertexAI = new VertexAI({ project, location });
-  const generativeModel = vertexAI.getGenerativeModel({ model });
+  const sdk = options.sdk ?? (await loadGenAiSdk());
+  const { GoogleGenAI } = sdk;
+  const ai = new GoogleGenAI({ vertexai: true, project, location });
 
   const request = {
+    model,
     contents: [{ role: 'user', parts: [{ text: prompt }] }],
-    generationConfig: { maxOutputTokens: maxTokens },
+    config: { maxOutputTokens: maxTokens },
   };
-  const response = await generativeModel.generateContent(request);
-  const raw = response?.response ?? response;
+  const raw = await ai.models.generateContent(request);
   const candidates = raw?.candidates ?? [];
   const text = candidates[0]?.content?.parts?.[0]?.text ?? '';
   // Respuesta vacía por presupuesto agotado: decirlo, no devolver un JSON
@@ -80,12 +83,12 @@ export async function runVertexAi(prompt, options = {}) {
   };
 }
 
-async function loadVertexSdk() {
+async function loadGenAiSdk() {
   try {
-    return await import('@google-cloud/vertexai');
+    return await import('@google/genai');
   } catch (err) {
     throw new Error(
-      "VertexAI adapter requiere '@google-cloud/vertexai'. Instala con: pnpm add @google-cloud/vertexai",
+      "VertexAI adapter requiere '@google/genai'. Instala con: pnpm add @google/genai",
       { cause: err },
     );
   }

--- a/packages/rag/tests/default-registry-policy.test.js
+++ b/packages/rag/tests/default-registry-policy.test.js
@@ -22,15 +22,16 @@ test('todo provider que nombra la política por defecto está registrado en el r
   }
 });
 
-/** SDK falso de Vertex: captura el request y devuelve una respuesta dada. */
+/** SDK falso (Google Gen AI, KJR-TSK-0159): captura init y request. */
 function makeFakeVertexSdk(response, capture) {
   return {
-    VertexAI: class {
-      getGenerativeModel() {
-        return {
-          async generateContent(request) {
+    GoogleGenAI: class {
+      constructor(init) {
+        capture.init = init;
+        this.models = {
+          generateContent: async (request) => {
             capture.request = request;
-            return { response };
+            return response;
           },
         };
       }
@@ -55,7 +56,40 @@ test('vertex: maxTokens por defecto 8192 — 1024 deja sin salida a los modelos 
     capture,
   );
   await runVertexAi('hola', { project: 'p', sdk });
-  assert.equal(capture.request.generationConfig.maxOutputTokens, 8192);
+  assert.equal(capture.request.config.maxOutputTokens, 8192);
+});
+
+test('vertex: el Gen AI SDK arranca en modo vertexai con project y location', async () => {
+  const capture = {};
+  const sdk = makeFakeVertexSdk(
+    { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+    capture,
+  );
+  await runVertexAi('hola', { project: 'p', location: 'europe-west1', sdk });
+  assert.equal(capture.init.vertexai, true);
+  assert.equal(capture.init.project, 'p');
+  assert.equal(capture.init.location, 'europe-west1');
+});
+
+test('vertex: VERTEX_MODEL y VERTEX_LOCATION del entorno como fallback — options gana, env después, default al final', async () => {
+  const capture = {};
+  const sdk = makeFakeVertexSdk(
+    { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+    capture,
+  );
+  process.env.VERTEX_MODEL = 'gemini-2.5-pro';
+  process.env.VERTEX_LOCATION = 'europe-west4';
+  try {
+    const viaEnv = await runVertexAi('hola', { project: 'p', sdk });
+    assert.equal(viaEnv.providerMeta.model, 'gemini-2.5-pro');
+    assert.equal(viaEnv.providerMeta.location, 'europe-west4');
+    const viaOptions = await runVertexAi('hola', { project: 'p', model: 'otro', location: 'us-east1', sdk });
+    assert.equal(viaOptions.providerMeta.model, 'otro');
+    assert.equal(viaOptions.providerMeta.location, 'us-east1');
+  } finally {
+    delete process.env.VERTEX_MODEL;
+    delete process.env.VERTEX_LOCATION;
+  }
 });
 
 test('vertex: respuesta vacía con finishReason MAX_TOKENS falla con mensaje explícito, no con JSON vacío', async () => {

--- a/packages/rag/tests/private-cloud-adapters.test.js
+++ b/packages/rag/tests/private-cloud-adapters.test.js
@@ -118,19 +118,19 @@ test('runBedrock: sin SDK instalado lanza con instrucción', async () => {
 });
 
 test('runVertexAi: usa SDK mock y extrae text de Gemini response', async () => {
+  // Contrato del Google Gen AI SDK (KJR-TSK-0159) — los asertos de
+  // comportamiento son los mismos que con el SDK anterior.
   const sdk = {
-    VertexAI: function VertexMock(cfg) {
+    GoogleGenAI: function GenAiMock(cfg) {
       this.cfg = cfg;
-      this.getGenerativeModel = () => ({
+      this.models = {
         async generateContent(_req) {
           return {
-            response: {
-              candidates: [{ content: { parts: [{ text: 'hola desde Vertex' }] } }],
-              usageMetadata: { totalTokenCount: 12 },
-            },
+            candidates: [{ content: { parts: [{ text: 'hola desde Vertex' }] } }],
+            usageMetadata: { totalTokenCount: 12 },
           };
         },
-      });
+      };
     },
   };
   const res = await runVertexAi('hola', {


### PR DESCRIPTION
Card KJR-TSK-0159. `runVertexAi` migra del SDK deprecado `@google-cloud/vertexai` (retirada anunciada jun-2026, ya vencida, avisaba en cada carga) al Google Gen AI SDK (`@google/genai` en modo vertexai), manteniendo firma AdapterFunction y shape AdapterResult; los asertos de comportamiento de KJR-BUG-0011 (modelo default, maxTokens 8192, error explícito en MAX_TOKENS vacío) siguen intactos con el fake reformado al contrato nuevo.

BONUS pedido en campo (KJW-TSK-0040/KJW-BUG-0011): `VERTEX_MODEL` y `VERTEX_LOCATION` del entorno como fallback (`options > env > default`) — una instancia europea fija región y modelo sin tocar código.

Suite rag 562 ✓ (2 fallos ambientales LanceDB preexistentes). **PENDIENTE HUMANO antes de publicar**: prueba contra la API real (necesita `GOOGLE_CLOUD_PROJECT`).
