### PR TITLE
feat(watch): repo classification and docs sensitivity rules in config KJW-TSK-0037

### DIFF
--- a/packages/watch/src/config.js
+++ b/packages/watch/src/config.js
@@ -112,11 +112,16 @@ const requireOneOf = (value, path, allowed) => {
  * @property {string} name Nombre único del repo (namespace de sus paths en el corpus).
  * @property {string} branch Rama observada cuyos merges disparan la ingesta.
  * @property {Sensitivity} sensitivity Nivel de sensibilidad del repo.
+ * @property {string} [group] Grupo al que pertenece el repo (clasificación libre de la instancia).
+ * @property {{service: string, tier: string}} [dora] Clasificación DORA: servicio y tier del repo.
+ *
+ * @typedef {{prefix: string, level: Sensitivity}} SensitivityRule Sensibilidad por prefijo de ruta.
  *
  * @typedef {Object} CorpusConfig
  * @property {string} store Vector store de karajan-rag.
  * @property {string} embedder Embedder local de karajan-rag.
  * @property {Sensitivity} sensitivity Nivel de sensibilidad del corpus.
+ * @property {SensitivityRule[]} [sensitivityRules] Solo corpus docs: sensibilidad por prefijo de ruta.
  *
  * @typedef {Object} ImpactThresholds
  * @property {number} [minSimilarity] Similitud mínima [0, 1] para considerar un candidato.
@@ -159,7 +164,7 @@ export const announceDefaults = (config, log) => {
  */
 const validateRepo = (value, path, seenNames) => {
   const repo = requireObject(value, path);
-  rejectUnknownKeys(repo, path, ['name', 'branch', 'sensitivity']);
+  rejectUnknownKeys(repo, path, ['name', 'branch', 'sensitivity', 'group', 'dora']);
   const name = requireNonEmptyString(repo.name, `${path}.name`);
   if (seenNames.has(name)) {
     throw new ConfigError(`${path}.name`, `nombre de repo duplicado: "${name}".`);
@@ -171,7 +176,44 @@ const validateRepo = (value, path, seenNames) => {
     repo.sensitivity === undefined
       ? DEFAULT_SENSITIVITY
       : requireOneOf(repo.sensitivity, `${path}.sensitivity`, SENSITIVITY_LEVELS);
-  return { name, branch, sensitivity: /** @type {Sensitivity} */ (sensitivity) };
+  /** @type {RepoConfig} */
+  const result = { name, branch, sensitivity: /** @type {Sensitivity} */ (sensitivity) };
+  if (repo.group !== undefined) {
+    result.group = requireNonEmptyString(repo.group, `${path}.group`);
+  }
+  if (repo.dora !== undefined) {
+    const dora = requireObject(repo.dora, `${path}.dora`);
+    rejectUnknownKeys(dora, `${path}.dora`, ['service', 'tier']);
+    result.dora = {
+      service: requireNonEmptyString(dora.service, `${path}.dora.service`),
+      tier: requireNonEmptyString(dora.tier, `${path}.dora.tier`),
+    };
+  }
+  return result;
+};
+
+/**
+ * Sensibilidad por prefijo del corpus docs; `level` fuera del vocabulario = error de carga.
+ * @param {unknown} value
+ * @param {string} path
+ * @returns {SensitivityRule[]}
+ */
+const validateSensitivityRules = (value, path) => {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new ConfigError(path, 'se esperaba un array no vacío de reglas {prefix, level}.');
+  }
+  const seenPrefixes = new Set();
+  return value.map((rule, i) => {
+    const entry = requireObject(rule, `${path}[${i}]`);
+    rejectUnknownKeys(entry, `${path}[${i}]`, ['prefix', 'level']);
+    const prefix = requireNonEmptyString(entry.prefix, `${path}[${i}].prefix`);
+    if (seenPrefixes.has(prefix)) {
+      throw new ConfigError(`${path}[${i}].prefix`, `prefijo duplicado: "${prefix}".`);
+    }
+    seenPrefixes.add(prefix);
+    const level = requireOneOf(entry.level, `${path}[${i}].level`, SENSITIVITY_LEVELS);
+    return { prefix, level: /** @type {Sensitivity} */ (level) };
+  });
 };
 
 /**
@@ -179,9 +221,12 @@ const validateRepo = (value, path, seenNames) => {
  * @param {string} path
  * @returns {CorpusConfig}
  */
-const validateCorpusEntry = (value, path, defaulted) => {
+const validateCorpusEntry = (value, path, defaulted, { allowSensitivityRules = false } = {}) => {
   const corpus = value === undefined ? {} : requireObject(value, path);
-  rejectUnknownKeys(corpus, path, ['store', 'embedder', 'sensitivity']);
+  const allowedKeys = allowSensitivityRules
+    ? ['store', 'embedder', 'sensitivity', 'sensitivityRules']
+    : ['store', 'embedder', 'sensitivity'];
+  rejectUnknownKeys(corpus, path, allowedKeys);
 
   // Un hueco se rellena; un valor equivocado sigue fallando con su path. La
   // diferencia entre "no lo has dicho" y "lo has dicho mal" es justo lo que
@@ -192,13 +237,22 @@ const validateCorpusEntry = (value, path, defaulted) => {
     return fallback;
   };
 
-  return {
+  /** @type {CorpusConfig} */
+  const result = {
     store: withDefault(corpus.store, 'store', VALID_STORES, DEFAULT_CORPUS.store),
     embedder: withDefault(corpus.embedder, 'embedder', VALID_EMBEDDERS, DEFAULT_CORPUS.embedder),
     sensitivity: /** @type {Sensitivity} */ (
       withDefault(corpus.sensitivity, 'sensitivity', SENSITIVITY_LEVELS, DEFAULT_SENSITIVITY)
     ),
   };
+  // Sin default: la ausencia de reglas no es un valor asumido — nada que anunciar en `defaulted`.
+  if (corpus.sensitivityRules !== undefined) {
+    result.sensitivityRules = validateSensitivityRules(
+      corpus.sensitivityRules,
+      `${path}.sensitivityRules`,
+    );
+  }
+  return result;
 };
 
 /**
@@ -292,7 +346,9 @@ export const validateConfig = (raw) => {
   rejectUnknownKeys(corpusRoot, '$.corpus', ['code', 'docs']);
   const corpus = {
     code: validateCorpusEntry(corpusRoot.code, '$.corpus.code', defaulted),
-    docs: validateCorpusEntry(corpusRoot.docs, '$.corpus.docs', defaulted),
+    docs: validateCorpusEntry(corpusRoot.docs, '$.corpus.docs', defaulted, {
+      allowSensitivityRules: true,
+    }),
   };
 
   /** @type {WatchConfig} */

--- a/packages/watch/tests/config-classification.test.js
+++ b/packages/watch/tests/config-classification.test.js
@@ -1,0 +1,91 @@
+// @ts-check
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ConfigError, validateConfig } from '../src/config.js';
+
+/** Config mínima válida sin defaults pendientes (clonar antes de mutar). */
+const minimalConfig = () => ({
+  repos: [{ name: 'repo-a' }],
+  corpus: {
+    code: { store: 'pgvector', embedder: 'transformers', sensitivity: 'internal' },
+    docs: { store: 'pgvector', embedder: 'transformers', sensitivity: 'internal' },
+  },
+});
+
+const withRepo = (repo) => ({ ...minimalConfig(), repos: [repo] });
+
+const withDocsRules = (sensitivityRules) => {
+  const config = minimalConfig();
+  config.corpus.docs.sensitivityRules = sensitivityRules;
+  return config;
+};
+
+/** Afirma que validateConfig lanza ConfigError con el path exacto. */
+const assertInvalid = (config, expectedPath) => {
+  assert.throws(
+    () => validateConfig(config),
+    (err) =>
+      err instanceof ConfigError &&
+      err.path === expectedPath &&
+      err.message.includes(expectedPath),
+    `esperaba ConfigError en "${expectedPath}"`,
+  );
+};
+
+test('repos[].group y repos[].dora: se aceptan y se tipan', () => {
+  const result = validateConfig(
+    withRepo({ name: 'repo-a', group: 'plataforma', dora: { service: 'atlas', tier: 'tier-1' } }),
+  );
+  assert.equal(result.repos[0].group, 'plataforma');
+  assert.deepEqual(result.repos[0].dora, { service: 'atlas', tier: 'tier-1' });
+});
+
+test('repos[].group y repos[].dora inválidos: ConfigError con path exacto', () => {
+  assertInvalid(withRepo({ name: 'repo-a', group: '' }), '$.repos[0].group');
+  assertInvalid(withRepo({ name: 'repo-a', dora: 'tier-1' }), '$.repos[0].dora');
+  assertInvalid(withRepo({ name: 'repo-a', dora: { tier: 'tier-1' } }), '$.repos[0].dora.service');
+  assertInvalid(withRepo({ name: 'repo-a', dora: { service: 'atlas' } }), '$.repos[0].dora.tier');
+  assertInvalid(
+    withRepo({ name: 'repo-a', dora: { service: 'atlas', tier: 'tier-1', extra: 1 } }),
+    '$.repos[0].dora.extra',
+  );
+});
+
+test('corpus.docs.sensitivityRules: prefijo → nivel, validado y tipado', () => {
+  const rules = [
+    { prefix: 'docs/public/', level: 'public' },
+    { prefix: 'docs/internal/', level: 'confidential' },
+  ];
+  const result = validateConfig(withDocsRules(rules));
+  assert.deepEqual(result.corpus.docs.sensitivityRules, rules);
+});
+
+test('sensitivityRules: level fuera del vocabulario es error de carga', () => {
+  assertInvalid(
+    withDocsRules([{ prefix: 'docs/', level: 'secreto' }]),
+    '$.corpus.docs.sensitivityRules[0].level',
+  );
+});
+
+test('sensitivityRules: forma estricta — array no vacío, prefix no vacío, sin claves extra ni duplicados', () => {
+  const path = '$.corpus.docs.sensitivityRules';
+  assertInvalid(withDocsRules([]), path);
+  assertInvalid(withDocsRules([{ prefix: '', level: 'public' }]), `${path}[0].prefix`);
+  assertInvalid(withDocsRules([{ prefix: 'docs/', level: 'public', extra: 1 }]), `${path}[0].extra`);
+  const dup = { prefix: 'docs/', level: 'public' };
+  assertInvalid(withDocsRules([dup, { ...dup, level: 'confidential' }]), `${path}[1].prefix`);
+});
+
+test('sensitivityRules solo existe en el corpus docs: en code es clave desconocida', () => {
+  const config = minimalConfig();
+  config.corpus.code.sensitivityRules = [{ prefix: 'src/', level: 'public' }];
+  assertInvalid(config, '$.corpus.code.sensitivityRules');
+});
+
+test('sin las secciones nuevas: comportamiento idéntico, sin defaults nuevos anunciados', () => {
+  const result = validateConfig(minimalConfig());
+  assert.equal(result.repos[0].group, undefined);
+  assert.equal(result.repos[0].dora, undefined);
+  assert.equal(result.corpus.docs.sensitivityRules, undefined);
+  assert.deepEqual(result.defaulted, []);
+});


### PR DESCRIPTION
## Qué

Card **KJW-TSK-0037** (Planning Game, Karajan Watch): `karajan-watch.config.json` gana sitio para la clasificación de repos y para reglas de sensibilidad por prefijo del corpus docs, todo validado por `validateConfig` — la fuente de verdad es UN fichero en git, no un `atlas.metadata.json` aparte que nadie valida (gap hallado desplegando tribbu-atlas).

## Cómo

- `repos[].group` (opcional): nombre de grupo, string no vacío.
- `repos[].dora` (opcional): `{service, tier}`, ambos obligatorios, claves extra rechazadas.
- `corpus.docs.sensitivityRules` (opcional): `[{prefix, level}]`; `level` debe pertenecer a `SENSITIVITY_LEVELS` de karajan-rag (fuera del vocabulario = `ConfigError` de carga), prefijos duplicados y claves desconocidas rechazados con el path JSON exacto. Solo en el corpus docs: en `code` es clave desconocida.
- Sin las secciones nuevas el comportamiento es idéntico y `announceDefaults` no anuncia nada nuevo (la ausencia de reglas no es un default).
- La consola (KJC) valida con este mismo `validateConfig` exportado por el paquete.

## Tests

TDD: `tests/config-classification.test.js` (7 tests, node:test) escrito en rojo antes de tocar `src/config.js`. Suite completa de packages/watch: **187/187 verde**. ESLint limpio en los ficheros tocados.

LOC netas: **147** (153+/6−), dentro del presupuesto.

Nota: el pre-gate local de Sonar no pudo ejecutarse en el carril worktree (JGit no resuelve el gitdir de worktrees); el diff lleva review cross-AI aprobada (codex) sellada en el commit.
