### PR TITLE
feat(rag): config exclude globs keep secrets out of the corpus KJR-TSK-0153

### DIFF
--- a/packages/rag/src/easy/cli.js
+++ b/packages/rag/src/easy/cli.js
@@ -653,6 +653,8 @@ export async function runIndexCommand(argv, io = {}) {
     // KJR-BUG-0006: el nivel de sensibilidad declarado en la config se
     // estampa por documento; sin config aplica el default seguro.
     sensitivityFor: (relPath) => resolveDocumentSensitivity(relPath, config),
+    // KJR-TSK-0153: los globs de easy.exclude nunca entran al corpus.
+    exclude: config?.exclude,
   });
   log(
     `hecho: ${result.indexedFiles} indexados, ${result.unchangedFiles} sin cambios, ` +
@@ -660,7 +662,10 @@ export async function runIndexCommand(argv, io = {}) {
       (result.fullReindex ? ' (reindex completo por cambio de fingerprint)' : ''),
   );
   if (result.excluded.length > 0) {
-    log(`excluidos: ${result.excluded.map((e) => `${e.path} (${e.reason})`).join(', ')}`);
+    log(
+      `excluidos (${result.excluded.length}): ` +
+        `${result.excluded.map((e) => `${e.path} (${e.reason})`).join(', ')}`,
+    );
   }
   return result;
 }

--- a/packages/rag/src/easy/config.js
+++ b/packages/rag/src/easy/config.js
@@ -28,10 +28,12 @@ export const CONFIG_FILE = 'karajan.config.json';
  * @property {string} [adapter]
  * @property {Sensitivity} [sensitivity] Nivel del corpus completo (default seguro: internal).
  * @property {SensitivityRule[]} [sensitivityRules] Excepciones por prefijo; gana la primera que matchea.
+ * @property {string[]} [exclude] Globs de ficheros que NUNCA entran al corpus (KJR-TSK-0153).
  */
 
 const VALID_KEYS = Object.freeze([
   'store', 'embedder', 'dimensions', 'topK', 'adapter', 'sensitivity', 'sensitivityRules',
+  'exclude',
 ]);
 const VALID_STORES = Object.freeze(['lancedb', 'pgvector', 'in-memory']);
 const VALID_EMBEDDERS = Object.freeze(['hash', 'transformers']);
@@ -45,6 +47,26 @@ export const DEFAULT_EASY_CONFIG = Object.freeze({
   adapter: 'claude',
   sensitivity: DEFAULT_SENSITIVITY,
 });
+
+/**
+ * Valida una lista `exclude` de globs (KJR-TSK-0153): array de strings no
+ * vacíos; el error señala el path exacto del item inválido.
+ *
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {string[]}
+ */
+export function validateExcludeGlobs(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} debe ser un array de globs (strings).`);
+  }
+  value.forEach((glob, i) => {
+    if (typeof glob !== 'string' || glob.length === 0) {
+      throw new Error(`${label}[${i}] debe ser un glob (string no vacío).`);
+    }
+  });
+  return /** @type {string[]} */ (value);
+}
 
 /**
  * Valida la sección `easy` de una config deserializada.
@@ -91,6 +113,9 @@ export function validateEasyConfig(value) {
     throw new Error(
       `karajan.config.json: easy.sensitivity debe ser uno de ${SENSITIVITY_LEVELS.join(', ')}.`,
     );
+  }
+  if (config.exclude !== undefined) {
+    validateExcludeGlobs(config.exclude, `${CONFIG_FILE}: easy.exclude`);
   }
   if (config.sensitivityRules !== undefined) {
     if (!Array.isArray(config.sensitivityRules)) {

--- a/packages/rag/src/easy/indexer.js
+++ b/packages/rag/src/easy/indexer.js
@@ -23,6 +23,7 @@ import {
 } from './manifest.js';
 import { ensureIndexFingerprint } from '../vector-store/fingerprint-guard.js';
 import { DEFAULT_SENSITIVITY } from '../domain/document.js';
+import { validateExcludeGlobs } from './config.js';
 
 /**
  * @typedef {import('./manifest.js').IndexManifest} IndexManifest
@@ -47,7 +48,7 @@ import { DEFAULT_SENSITIVITY } from '../domain/document.js';
  * @property {number} unchangedFiles Ficheros saltados por hash idéntico.
  * @property {number} chunksUpserted
  * @property {boolean} fullReindex true si el fingerprint cambió y se reconstruyó todo.
- * @property {{ path: string, reason: 'binary' | 'unknown' }[]} excluded
+ * @property {{ path: string, reason: 'binary' | 'unknown' | 'config' }[]} excluded
  */
 
 /** Directorios que nunca se indexan. */
@@ -56,12 +57,19 @@ const EXCLUDED_DIRS = new Set([
 ]);
 
 /**
- * Recorre el directorio y clasifica cada fichero por preset.
+ * Recorre el directorio y clasifica cada fichero por preset. KJR-TSK-0153:
+ * los globs de `exclude` se aplican sobre la ruta relativa ANTES de leer o
+ * chunkear nada — lo que casa jamás entra al corpus ni al manifest.
  *
  * @param {string} rootDir
- * @returns {Promise<{ groups: ReturnType<typeof classifySources>, relPaths: string[] }>}
+ * @param {{ exclude?: string[] }} [options]
+ * @returns {Promise<{ groups: ReturnType<typeof classifySources>, relPaths: string[], excludedByGlob: string[] }>}
  */
-export async function collectIndexableFiles(rootDir) {
+export async function collectIndexableFiles(rootDir, options = {}) {
+  const exclude =
+    options.exclude === undefined
+      ? []
+      : validateExcludeGlobs(options.exclude, 'collectIndexableFiles: "exclude"');
   let rootStat;
   try {
     rootStat = await stat(rootDir);
@@ -74,6 +82,8 @@ export async function collectIndexableFiles(rootDir) {
 
   /** @type {string[]} */
   const relPaths = [];
+  /** @type {string[]} */
+  const excludedByGlob = [];
 
   /** @param {string} current */
   async function walk(current) {
@@ -85,14 +95,20 @@ export async function collectIndexableFiles(rootDir) {
         continue;
       }
       if (entry.isFile() && !entry.name.startsWith('.')) {
-        relPaths.push(path.relative(rootDir, full));
+        const relPath = path.relative(rootDir, full);
+        if (exclude.some((glob) => path.matchesGlob(relPath, glob))) {
+          excludedByGlob.push(relPath);
+        } else {
+          relPaths.push(relPath);
+        }
       }
     }
   }
 
   await walk(rootDir);
   relPaths.sort();
-  return { groups: classifySources(relPaths), relPaths };
+  excludedByGlob.sort();
+  return { groups: classifySources(relPaths), relPaths, excludedByGlob };
 }
 
 /**
@@ -121,7 +137,7 @@ export const DEFAULT_INGEST_BATCH_SIZE = 64;
  * Indexa (o reindexa incrementalmente) un directorio.
  *
  * @param {string} rootDir
- * @param {{ store: EasyVectorStore, embedder: EasyEmbedder, onEvent?: (msg: string) => void, batchSize?: number, sensitivityFor?: (relPath: string) => import('../domain/document.js').Sensitivity }} deps
+ * @param {{ store: EasyVectorStore, embedder: EasyEmbedder, onEvent?: (msg: string) => void, batchSize?: number, sensitivityFor?: (relPath: string) => import('../domain/document.js').Sensitivity, exclude?: string[] }} deps
  * @returns {Promise<IndexResult>}
  */
 export async function indexDirectory(rootDir, deps) {
@@ -132,7 +148,9 @@ export async function indexDirectory(rootDir, deps) {
     throw new Error('indexDirectory: "batchSize" debe ser entero positivo.');
   }
 
-  const { groups } = await collectIndexableFiles(rootDir);
+  const { groups, excludedByGlob } = await collectIndexableFiles(rootDir, {
+    exclude: deps.exclude,
+  });
   const fingerprint = computeIndexFingerprint({
     embedderName: embedder.name ?? 'hash',
     dimensions: embedder.dimensions,
@@ -268,6 +286,9 @@ export async function indexDirectory(rootDir, deps) {
     unchangedFiles: unchanged.length,
     chunksUpserted,
     fullReindex,
-    excluded: groups.excluded,
+    excluded: [
+      ...groups.excluded,
+      ...excludedByGlob.map((relPath) => ({ path: relPath, reason: /** @type {const} */ ('config') })),
+    ],
   };
 }

--- a/packages/rag/tests/easy-exclude.test.js
+++ b/packages/rag/tests/easy-exclude.test.js
@@ -1,0 +1,99 @@
+// @ts-check
+// KJR-TSK-0153 — easy.exclude (globs): lo que casa nunca se chunkea ni entra al manifest.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { InMemoryVectorStore } from '../src/vector-store/in-memory-vector-store.js';
+import { createHashEmbedder } from '../src/embedding/embedder.js';
+import { validateEasyConfig } from '../src/easy/config.js';
+import { loadManifest } from '../src/easy/manifest.js';
+import { indexDirectory } from '../src/easy/indexer.js';
+
+const makeDeps = () => ({
+  store: new InMemoryVectorStore({ dimensions: 16 }),
+  embedder: createHashEmbedder({ dimensions: 16 }),
+});
+
+/** @param {Record<string, string>} files */
+async function makeProject(files) {
+  const root = await mkdtemp(path.join(tmpdir(), 'kjr-exclude-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    await mkdir(path.dirname(full), { recursive: true });
+    await writeFile(full, content, 'utf8');
+  }
+  return root;
+}
+
+const PROJECT_FILES = {
+  'src/app.js': 'export const a = 1;\n',
+  'certs/server.pem': '-----BEGIN FAKE KEY-----\nno-soy-una-clave\n',
+  'secrets/token.json': '{ "token": "fake" }\n',
+};
+
+test('validateEasyConfig: acepta exclude como array de globs', () => {
+  const config = validateEasyConfig({ exclude: ['**/*.pem', 'secrets/**'] });
+  assert.deepEqual(config.exclude, ['**/*.pem', 'secrets/**']);
+});
+
+test('validateEasyConfig: rechaza exclude que no es array', () => {
+  assert.throws(() => validateEasyConfig({ exclude: '**/*.pem' }), /easy\.exclude/);
+});
+
+test('validateEasyConfig: rechaza items no-string o vacíos con el path exacto', () => {
+  assert.throws(() => validateEasyConfig({ exclude: ['ok', 42] }), /easy\.exclude\[1\]/);
+  assert.throws(() => validateEasyConfig({ exclude: [''] }), /easy\.exclude\[0\]/);
+});
+
+test('indexDirectory: exclude deja los globs fuera del índice y del manifest', async () => {
+  const root = await makeProject(PROJECT_FILES);
+  const { store, embedder } = makeDeps();
+  try {
+    const result = await indexDirectory(root, {
+      store,
+      embedder,
+      exclude: ['**/*.pem', 'secrets/**'],
+    });
+    assert.equal(result.indexedFiles, 1);
+    assert.deepEqual(
+      result.excluded.filter((e) => e.reason === 'config').map((e) => e.path).sort(),
+      ['certs/server.pem', 'secrets/token.json'],
+    );
+    const manifest = await loadManifest(root);
+    assert.ok(manifest);
+    assert.deepEqual(Object.keys(manifest.files), ['src/app.js']);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('indexDirectory: sin exclude el comportamiento no cambia', async () => {
+  const root = await makeProject(PROJECT_FILES);
+  const { store, embedder } = makeDeps();
+  try {
+    const result = await indexDirectory(root, { store, embedder });
+    // Sin exclude: token.json SÍ entra al corpus; el .pem cae por preset ('unknown').
+    assert.equal(result.indexedFiles, 2);
+    assert.deepEqual(result.excluded, [{ path: 'certs/server.pem', reason: 'unknown' }]);
+    const manifest = await loadManifest(root);
+    assert.ok(manifest?.files['secrets/token.json']);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('indexDirectory: exclude inválido falla alto, nunca indexa en silencio', async () => {
+  const root = await makeProject(PROJECT_FILES);
+  const { store, embedder } = makeDeps();
+  try {
+    await assert.rejects(
+      indexDirectory(root, { store, embedder, exclude: /** @type {never} */ (['ok', 3]) }),
+      /exclude/,
+    );
+    assert.equal(await loadManifest(root), null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## KJR-TSK-0153 — easy.exclude globs in karajan.config.json

Credentials or sensitive files committed in an indexed workspace could enter the RAG corpus: the reusable ingest.yml workflow cannot prune the workspace beforehand.

- `easy.exclude` accepts a list of globs (`**/*.pem`, `secrets/**`, ...), validated strictly: array of non-empty strings, error names the exact invalid item (`easy.exclude[1]`).
- Matching files are filtered in `collectIndexableFiles` during the walk, before any read/chunk/embed — they never reach the store nor the manifest (so `/health` never sees them).
- `IndexResult.excluded` carries them with reason `config` and the CLI summary reports the excluded count.
- No `exclude` -> behavior identical to today. No new dependencies (`path.matchesGlob`, Node 22).

TDD: 6 new tests in `packages/rag/tests/easy-exclude.test.js` (red first). Full rag suite green except the 2 preexisting environmental LanceDB failures in `e2e-answer-routing.test.js`. Cross-AI review: approved by codex (diff 97a010b1099b). Net delta +150.
