### PR TITLE
feat(board): the embedded terminal session manager

### DIFF
--- a/packages/hu-board/src/terminal.js
+++ b/packages/hu-board/src/terminal.js
@@ -1,0 +1,119 @@
+// KJC-TSK-0816 (MGL-E, ADR 0008) — la ventana única: la terminal REAL del
+// agente embebida en el board; el proceso es el agente interactivo de
+// siempre, con los hooks del Sentinel intactos. Seguridad de la superficie:
+// server solo en loopback, token aleatorio de 128 bits entregado tras el
+// auth del board y comparado en tiempo constante, y catálogo de agentes
+// CERRADO — por la red viaja qué agente, jamás un comando arbitrario.
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Catálogo cerrado: los mismos agentes que kj go sabe lanzar. */
+export const TERMINAL_AGENTS = Object.freeze({
+  claude: { command: 'claude', args: [] },
+  codex: { command: 'codex', args: [] },
+});
+
+const tokenMatches = (expected, given) => {
+  const a = Buffer.from(String(expected));
+  const b = Buffer.from(String(given ?? ''));
+  return a.length === b.length && timingSafeEqual(a, b);
+};
+
+/**
+ * Gestor de LA sesión de terminal del board (singleton por diseño: una
+ * conversación por board acota la superficie; multi-terminal queda fuera
+ * del alcance del ADR).
+ *
+ * @param {Object} deps
+ * @param {(command: string, args: string[], opts: object) => object} deps.spawnPty
+ *   Factoría del pty (node-pty.spawn en producción; fake en tests).
+ * @param {string} deps.cwd Directorio del proyecto donde vive el agente.
+ * @param {Record<string, string|undefined>} [deps.env]
+ */
+export function createTerminalManager({ spawnPty, cwd, env = process.env }) {
+  /** @type {{termId: string, token: string, pty: object, subscribers: Set<Function>, buffer: string[]} | null} */
+  let session = null;
+
+  const requireSession = (termId, token) => {
+    if (!session || session.termId !== termId) {
+      throw new Error('terminal: no hay sesión viva con ese id.');
+    }
+    if (!tokenMatches(session.token, token)) {
+      throw new Error('terminal: token inválido.');
+    }
+    return session;
+  };
+
+  return {
+    /** Arranca (o devuelve) LA sesión — reutilizar la viva evita que cada
+     *  recarga multiplique agentes. @param {{agent: string}} params */
+    start({ agent }) {
+      if (session) return { termId: session.termId, token: session.token, reused: true };
+      // hasOwn: sin él, "constructor"/"__proto__" indexarían el prototipo.
+      const spec = Object.hasOwn(TERMINAL_AGENTS, agent) ? TERMINAL_AGENTS[agent] : null;
+      if (!spec) {
+        throw new Error(
+          `terminal: agente "${agent}" fuera del catálogo (${Object.keys(TERMINAL_AGENTS).join(', ')}).`,
+        );
+      }
+      // CLAUDECODE fuera: un Claude anidado se niega a arrancar con ella
+      // (la misma peculiaridad que ya maneja kj go).
+      const { CLAUDECODE: _omit, ...cleanEnv } = env;
+      const pty = spawnPty(spec.command, spec.args, {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 32,
+        cwd,
+        env: cleanEnv,
+      });
+      const current = {
+        termId: `term-${randomBytes(8).toString('hex')}`,
+        token: randomBytes(16).toString('hex'),
+        pty,
+        subscribers: new Set(),
+        buffer: [],
+      };
+      pty.onData((data) => {
+        // Búfer corto para que una reconexión no arranque en negro.
+        current.buffer.push(data);
+        if (current.buffer.length > 200) current.buffer.shift();
+        for (const send of current.subscribers) send(data);
+      });
+      pty.onExit(() => {
+        for (const send of current.subscribers) send('\r\n[la sesión del agente terminó]\r\n');
+        // El exit tardío de un pty viejo no debe anular una sesión nueva.
+        if (session === current) session = null;
+      });
+      session = current;
+      return { termId: current.termId, token: current.token, reused: false };
+    },
+
+    /**
+     * Conecta un receptor de salida. Devuelve el detach; soltar la
+     * conexión NO mata el pty — el agente sigue y se puede volver.
+     */
+    attach({ termId, token, send }) {
+      const s = requireSession(termId, token);
+      for (const chunk of s.buffer) send(chunk);
+      s.subscribers.add(send);
+      return () => s.subscribers.delete(send);
+    },
+
+    write({ termId, token, data }) {
+      requireSession(termId, token).pty.write(data);
+    },
+
+    resize({ termId, token, cols, rows }) {
+      requireSession(termId, token).pty.resize(cols, rows);
+    },
+
+    stop({ termId, token }) {
+      const s = requireSession(termId, token);
+      s.pty.kill();
+      session = null;
+    },
+
+    alive() {
+      return session ? { termId: session.termId } : null;
+    },
+  };
+}

--- a/packages/hu-board/tests/terminal.test.js
+++ b/packages/hu-board/tests/terminal.test.js
@@ -1,0 +1,81 @@
+// KJC-TSK-0816 (MGL-E, ADR 0008) — la terminal embebida: un pty del agente
+// puenteado por WebSocket, SOLO en loopback y SOLO con el token de la
+// sesión. Todo inyectable: cero procesos y cero sockets reales aquí.
+import { describe, it, expect, vi } from 'vitest';
+import { createTerminalManager } from '../src/terminal.js';
+
+const fakePty = () => {
+  const listeners = { data: [], exit: [] };
+  return {
+    written: [],
+    killed: false,
+    onData(cb) { listeners.data.push(cb); },
+    onExit(cb) { listeners.exit.push(cb); },
+    write(d) { this.written.push(d); },
+    resize: vi.fn(),
+    kill() { this.killed = true; listeners.exit.forEach((cb) => cb({ exitCode: 0 })); },
+    emitData(d) { listeners.data.forEach((cb) => cb(d)); },
+  };
+};
+
+const manager = (pty = fakePty()) =>
+  createTerminalManager({ spawnPty: vi.fn(() => pty), cwd: '/proyecto' });
+
+describe('terminal embebida (KJC-TSK-0816)', () => {
+  it('start crea UN pty con token aleatorio; un segundo start reutiliza la sesión viva', () => {
+    const spawnPty = vi.fn(() => fakePty());
+    const m = createTerminalManager({ spawnPty, cwd: '/proyecto' });
+    const a = m.start({ agent: 'claude' });
+    expect(a.token).toMatch(/^[a-f0-9]{32,}$/);
+    const b = m.start({ agent: 'claude' });
+    expect(b.termId).toBe(a.termId);
+    expect(spawnPty).toHaveBeenCalledOnce();
+  });
+
+  it('el agente arranca en el cwd del proyecto y SIN la variable CLAUDECODE heredada', () => {
+    const spawnPty = vi.fn(() => fakePty());
+    const m = createTerminalManager({ spawnPty, cwd: '/proyecto', env: { CLAUDECODE: '1', PATH: '/bin' } });
+    m.start({ agent: 'claude' });
+    const [cmd, , opts] = spawnPty.mock.calls[0];
+    expect(cmd).toBe('claude');
+    expect(opts.cwd).toBe('/proyecto');
+    expect(opts.env.CLAUDECODE).toBeUndefined();
+    expect(opts.env.PATH).toBe('/bin');
+  });
+
+  it('solo acepta agentes del catálogo — ni comandos arbitrarios ni claves del prototipo', () => {
+    const m = manager();
+    expect(() => m.start({ agent: 'rm -rf /' })).toThrow(/agente/i);
+    expect(() => m.start({ agent: 'constructor' })).toThrow(/agente/i);
+  });
+
+  it('attach exige token; el detach NO mata el pty y se puede reconectar', () => {
+    const pty = fakePty();
+    const m = manager(pty);
+    const { termId, token } = m.start({ agent: 'claude' });
+    expect(() => m.attach({ termId, token: 'malo', send: () => {} })).toThrow(/token/i);
+    const socket = { sent: [] };
+    const detach = m.attach({ termId, token, send: (d) => socket.sent.push(d) });
+    pty.emitData('hola');
+    expect(socket.sent).toContain('hola');
+    detach();
+    pty.emitData('adios');
+    expect(socket.sent).not.toContain('adios');
+    expect(pty.killed).toBe(false);
+    const sent = [];
+    m.attach({ termId, token, send: (d) => sent.push(d) });
+    pty.emitData('sigo vivo');
+    expect(sent).toContain('sigo vivo');
+  });
+
+  it('write llega al pty y stop lo mata y limpia la sesión', () => {
+    const pty = fakePty();
+    const m = manager(pty);
+    const { termId, token } = m.start({ agent: 'claude' });
+    m.write({ termId, token, data: 'ls\r' });
+    expect(pty.written).toContain('ls\r');
+    m.stop({ termId, token });
+    expect(pty.killed).toBe(true);
+    expect(() => m.write({ termId, token, data: 'x' })).toThrow(/sesión|session/i);
+  });
+});


### PR DESCRIPTION
Card KJC-TSK-0816 (MGL-E, ADR 0008 aceptado) — **PR 1 de 3**.

El gestor de LA sesión de terminal embebida: pty del agente con catálogo CERRADO (claude/codex — `hasOwn` contra claves del prototipo, catch de codex en review), token aleatorio de 128 bits comparado en tiempo constante, `CLAUDECODE` fuera del env heredado, búfer de reconexión (cerrar el panel NO mata al agente), y el exit tardío de un pty viejo no anula una sesión nueva (segundo catch de codex). Todo inyectable: 5 tests, cero procesos reales. `kj audit --security`: 0 hallazgos.

PR 2: cableado WS + rutas + estáticos de xterm desde node_modules. PR 3: panel «Conversación» del board.
