### PR TITLE
feat(board): wire the embedded terminal - ws bridge and xterm statics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2626,6 +2626,15 @@
       "integrity": "sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==",
       "license": "MIT"
     },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -6306,6 +6315,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -6342,6 +6357,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/node-source-walk": {
@@ -8370,6 +8395,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -8495,13 +8541,16 @@
       "name": "@karajan/hu-board",
       "version": "1.1.0",
       "dependencies": {
+        "@xterm/xterm": "^6.0.0",
         "better-sqlite3": "^12.10.0",
         "chokidar": "^5.0.0",
         "express": "^5.1.0",
         "express-rate-limit": "^8.5.0",
         "helmet": "^8.1.0",
         "js-yaml": "^4.2.0",
-        "karajan-core": "*"
+        "karajan-core": "*",
+        "node-pty": "^1.1.0",
+        "ws": "^8.21.3"
       },
       "devDependencies": {
         "supertest": "^7.1.0",

--- a/packages/hu-board/package.json
+++ b/packages/hu-board/package.json
@@ -13,13 +13,16 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "karajan-core": "*",
+    "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.10.0",
     "chokidar": "^5.0.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.5.0",
     "helmet": "^8.1.0",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "karajan-core": "*",
+    "node-pty": "^1.1.0",
+    "ws": "^8.21.3"
   },
   "devDependencies": {
     "supertest": "^7.1.0",

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -13,6 +13,9 @@ import wikiRoutes from './routes/wiki.js';
 import governanceRoutes from './routes/governance.js';
 import { authMiddleware } from './auth.js';
 import { getOrCreateToken, getTokenPath } from './token-store.js';
+import { createRequire } from 'node:module';
+import { createTerminalManager } from './terminal.js';
+import { terminalRouter, attachTerminalWs } from './terminal-wire.js';
 import { reapZombieSessions } from './zombie-reaper.js';
 import { reapZombieHus } from './hu-zombie-reaper.js';
 import { setHuStatus as setHuStatusPlanMutation, setHuFailResult as setHuFailResultPlanMutation } from './plan-mutations.js';
@@ -295,6 +298,8 @@ async function main() {
 
   // Create Express app
   const app = express();
+  // node-pty es CJS nativo y @xterm se localiza por resolve: require clásico.
+  const requireCjs = createRequire(import.meta.url);
   app.use(...buildSecurityMiddleware());
   app.use(express.json());
   app.use(express.static(PUBLIC_DIR, { setHeaders: noStoreHeaders, etag: false, lastModified: false }));
@@ -303,6 +308,20 @@ async function main() {
   app.use('/api/rag', authMiddleware(), ragRoutes);
   app.use('/api/wiki', authMiddleware(), wikiRoutes);
   app.use('/api/governance', authMiddleware(), governanceRoutes);
+
+  // Terminal embebida (KJC-TSK-0816, ADR 0008): la lógica vive en
+  // terminal.js; aquí solo el montaje. El agente arranca en el cwd del
+  // daemon (kj go arranca el board desde el proyecto) u override por env.
+  // xterm se sirve DESDE la dependencia — nada vendorizado al repo.
+  const terminalManager = createTerminalManager({
+    spawnPty: (...args) => requireCjs('node-pty').spawn(...args),
+    cwd: process.env.HU_BOARD_TERMINAL_CWD || process.cwd(),
+  });
+  app.use('/api/terminal', authMiddleware(), terminalRouter(terminalManager));
+  app.use(
+    '/vendor/xterm',
+    express.static(dirname(requireCjs.resolve('@xterm/xterm/package.json'))),
+  );
 
   // SPA fallback: serve index.html for non-API, non-static routes
   app.get('/{*splat}', (_req, res) => {
@@ -318,6 +337,7 @@ async function main() {
   const isLoopback = LOOPBACK_ADDRESSES.has(bindHost);
 
   const server = app.listen(port, bindHost, () => {
+    attachTerminalWs(server, terminalManager);
     // Write the PID file so the CLI's `kj board status / stop` and
     // the next `kj plan`'s startBoard() check find this server. The
     // file used to be written only by `kj board start`'s launcher,

--- a/packages/hu-board/src/terminal-wire.js
+++ b/packages/hu-board/src/terminal-wire.js
@@ -1,0 +1,96 @@
+// KJC-TSK-0816 — pegamento fino de la terminal embebida: rutas REST para
+// arrancar/parar la sesión y el upgrade WebSocket que puentea el pty.
+// La LÓGICA (tokens, catálogo, ciclo de vida) vive en terminal.js y está
+// testeada con dobles; esto es cableado deliberadamente delgado.
+//
+// El token NO viaja en la URL: el cliente lo manda como subprotocolo
+// WebSocket (['kj-terminal', token]) — las URLs acaban en logs; los
+// subprotocolos, no.
+import { Router } from 'express';
+import { WebSocket, WebSocketServer } from 'ws';
+
+const LOOPBACK = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+const WS_PATH = '/api/terminal/ws';
+
+/**
+ * Monta las rutas REST de la terminal sobre un Router de express.
+ * @param {ReturnType<import('./terminal.js').createTerminalManager>} manager
+ */
+export function terminalRouter(manager) {
+  const router = Router();
+  router.post('/start', (req, res) => {
+    try {
+      res.json(manager.start({ agent: req.body?.agent ?? 'claude' }));
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+  router.get('/alive', (_req, res) => res.json({ alive: manager.alive() }));
+  router.post('/stop', (req, res) => {
+    try {
+      manager.stop({ termId: req.body?.termId, token: req.body?.token });
+      res.json({ stopped: true });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+  return router;
+}
+
+/**
+ * Registra el upgrade WS en el servidor http. Entrada del cliente: bytes
+ * crudos = teclado; un mensaje que empiece por \x00 es control JSON
+ * ({type:'resize', cols, rows}) — el prefijo evita confundir un '{'
+ * tecleado con un mensaje de control.
+ *
+ * @param {import('node:http').Server} server
+ * @param {ReturnType<import('./terminal.js').createTerminalManager>} manager
+ */
+export function attachTerminalWs(server, manager) {
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url, 'http://localhost');
+    if (url.pathname !== WS_PATH) return;
+    if (!LOOPBACK.has(req.socket.remoteAddress)) {
+      socket.destroy();
+      return;
+    }
+    const termId = url.searchParams.get('termId');
+    const protocols = String(req.headers['sec-websocket-protocol'] ?? '')
+      .split(',')
+      .map((p) => p.trim());
+    const token = protocols[1] ?? '';
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      let detach;
+      try {
+        detach = manager.attach({
+          termId,
+          token,
+          send: (data) => {
+            if (ws.readyState === WebSocket.OPEN) ws.send(data);
+          },
+        });
+      } catch (err) {
+        ws.close(1008, err.message);
+        return;
+      }
+      ws.on('message', (raw) => {
+        const text = raw.toString('utf8');
+        try {
+          if (text.charCodeAt(0) === 0) {
+            const msg = JSON.parse(text.slice(1));
+            if (msg.type === 'resize') {
+              manager.resize({ termId, token, cols: msg.cols, rows: msg.rows });
+            }
+            return;
+          }
+          manager.write({ termId, token, data: text });
+        } catch {
+          // Una trama malformada no tumba la sesión: se ignora y se sigue.
+        }
+      });
+      ws.on('close', () => detach());
+    });
+  });
+  return wss;
+}


### PR DESCRIPTION
Card KJC-TSK-0816, **PR 2 de 3** (apilada sobre #1608).

El cableado fino: rutas REST `start/alive/stop` tras el auth del board; upgrade WS en `/api/terminal/ws` con doble guarda — loopback + token por **subprotocolo** (las URLs acaban en logs; los subprotocolos, no; la comparación vive en el manager, en tiempo constante); protocolo de entrada bytes-crudos con control JSON prefijado por byte 0 (una llave tecleada no es un mensaje de control); estáticos de `@xterm` servidos **desde node_modules** (cero vendorizado, cero LOC de terceros); deps `node-pty`+`ws`+`@xterm/xterm` probadas en esta máquina (el pty compila y corre).

Catch de codex absorbido: `ws.OPEN` de instancia era `undefined` — ahora `WebSocket.OPEN` de la clase.

Smoke real con el board vivo: `/api/terminal/alive` 200 · `/vendor/xterm/lib/xterm.js` 200 · `/vendor/xterm/css/xterm.css` 200.
