### PR TITLE
feat(go): kj go --window - the conversation lives inside the board

### DIFF
--- a/packages/hu-board/public/utils/terminal-panel.js
+++ b/packages/hu-board/public/utils/terminal-panel.js
@@ -26,7 +26,9 @@ async function openConversationPanel() {
     const res = await fetch('/api/terminal/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agent: 'claude' }),
+      // Sin agente en el body: decide el servidor (kj go --window fija el
+      // elegido por env; sin él, claude).
+      body: JSON.stringify({}),
     });
     started = await res.json();
     if (!res.ok) throw new Error(started.error || `HTTP ${res.status}`);

--- a/packages/hu-board/src/server.js
+++ b/packages/hu-board/src/server.js
@@ -316,8 +316,13 @@ async function main() {
   const terminalManager = createTerminalManager({
     spawnPty: (...args) => requireCjs('node-pty').spawn(...args),
     cwd: process.env.HU_BOARD_TERMINAL_CWD || process.cwd(),
+    promptArg: process.env.HU_BOARD_TERMINAL_PROMPT,
   });
-  app.use('/api/terminal', authMiddleware(), terminalRouter(terminalManager));
+  app.use(
+    '/api/terminal',
+    authMiddleware(),
+    terminalRouter(terminalManager, { defaultAgent: process.env.HU_BOARD_TERMINAL_AGENT || 'claude' }),
+  );
   app.use(
     '/vendor/xterm',
     express.static(dirname(requireCjs.resolve('@xterm/xterm/package.json'))),

--- a/packages/hu-board/src/terminal-wire.js
+++ b/packages/hu-board/src/terminal-wire.js
@@ -16,11 +16,11 @@ const WS_PATH = '/api/terminal/ws';
  * Monta las rutas REST de la terminal sobre un Router de express.
  * @param {ReturnType<import('./terminal.js').createTerminalManager>} manager
  */
-export function terminalRouter(manager) {
+export function terminalRouter(manager, { defaultAgent = 'claude' } = {}) {
   const router = Router();
   router.post('/start', (req, res) => {
     try {
-      res.json(manager.start({ agent: req.body?.agent ?? 'claude' }));
+      res.json(manager.start({ agent: req.body?.agent ?? defaultAgent }));
     } catch (err) {
       res.status(400).json({ error: err.message });
     }

--- a/packages/hu-board/src/terminal.js
+++ b/packages/hu-board/src/terminal.js
@@ -28,8 +28,10 @@ const tokenMatches = (expected, given) => {
  *   Factoría del pty (node-pty.spawn en producción; fake en tests).
  * @param {string} deps.cwd Directorio del proyecto donde vive el agente.
  * @param {Record<string, string|undefined>} [deps.env]
+ * @param {string} [deps.promptArg] Prompt inicial del agente (kj go --window
+ *   lo pasa por env al daemon) — SIEMPRE del lado servidor, jamás de la red.
  */
-export function createTerminalManager({ spawnPty, cwd, env = process.env }) {
+export function createTerminalManager({ spawnPty, cwd, env = process.env, promptArg }) {
   /** @type {{termId: string, token: string, pty: object, subscribers: Set<Function>, buffer: string[]} | null} */
   let session = null;
 
@@ -58,7 +60,8 @@ export function createTerminalManager({ spawnPty, cwd, env = process.env }) {
       // CLAUDECODE fuera: un Claude anidado se niega a arrancar con ella
       // (la misma peculiaridad que ya maneja kj go).
       const { CLAUDECODE: _omit, ...cleanEnv } = env;
-      const pty = spawnPty(spec.command, spec.args, {
+      const args = promptArg ? [...spec.args, promptArg] : spec.args;
+      const pty = spawnPty(spec.command, args, {
         name: 'xterm-256color',
         cols: 120,
         rows: 32,

--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -154,6 +154,7 @@ export function registerMeta(program, { pkgVersion }) {
   program
     .command("go")
     .description("Arranca Karajan sin saber nada: detecta tu agente, prepara el proyecto, abre el tablero y te deja en la conversación")
+    .option("--window", "La ventana única (ADR 0008): la conversación vive DENTRO del tablero del navegador")
     .action(async (flags) => {
       await withConfig(pkgVersion, "go", flags, async ({ config, logger }) => {
         await goCommand({ config, logger, flags });

--- a/src/commands/go.js
+++ b/src/commands/go.js
@@ -46,12 +46,13 @@ export function buildGoPrompt() {
 async function defaultPrepare({ config, logger }) {
   await envInstallCommand({ config, logger, flags: { yes: true } });
 }
-export async function defaultBoard({ config, logger, runBoard = boardCommand }) {
+export async function defaultBoard({ config, logger, runBoard = boardCommand, openPath = "/?maggle=1" }) {
   const port = config.hu_board?.port || 4000;
   await runBoard({ action: "start", port, bind: "127.0.0.1", logger });
   // /?maggle=1 switches the frontend to plain language (KJC-TSK-0810) —
-  // the muggle's window opens already speaking their language.
-  await runBoard({ action: "open", port, bind: "127.0.0.1", path: "/?maggle=1", logger });
+  // the muggle's window opens already speaking their language. With
+  // &window=1 (KJC-TSK-0816) the conversation itself lives IN the board.
+  await runBoard({ action: "open", port, bind: "127.0.0.1", path: openPath, logger });
 }
 function defaultLaunch(agent, prompt) {
   // Interactive session: the muggle LIVES here. CLAUDECODE is stripped so a
@@ -96,13 +97,40 @@ export async function goCommand({ config = {}, logger = console, flags = {}, dep
     logger.info?.("Preparando tu proyecto (solo la primera vez)…");
     await (deps.prepare ?? defaultPrepare)({ config, logger });
   }
+  const prompt = (deps.prompt ?? buildGoPrompt)();
+  // --window (MGL-E, ADR 0008): la conversación vive DENTRO del board — el
+  // daemon hereda por env el cwd, el agente elegido y el prompt inicial, y
+  // el pty arranca el agente REAL (harness intacto). La fase 1 sigue siendo
+  // el default: sin el flag, nada cambia.
+  const windowMode = Boolean(flags.window);
+  if (windowMode) {
+    process.env.HU_BOARD_TERMINAL_CWD = projectDir;
+    process.env.HU_BOARD_TERMINAL_AGENT = chosen.name;
+    process.env.HU_BOARD_TERMINAL_PROMPT = prompt;
+  }
   // The board is the muggle's window — unless the project turned it off
   // (hu_board.enabled false is respected: KJC-BUG-0152). A board failure is
   // said and never stops the conversation from starting.
+  let boardOpened = false;
   if (config.hu_board?.enabled !== false) {
-    try { await (deps.board ?? defaultBoard)({ config, logger }); } catch (err) { logger.warn?.(`El tablero no pudo abrirse (${err.message}) — la conversación arranca igual.`); }
+    const openPath = windowMode ? "/?maggle=1&window=1" : "/?maggle=1";
+    try {
+      await (deps.board ?? defaultBoard)({ config, logger, openPath });
+      boardOpened = true;
+    } catch (err) {
+      logger.warn?.(`El tablero no pudo abrirse (${err.message}) — la conversación arranca igual.`);
+    }
   }
-  const prompt = (deps.prompt ?? buildGoPrompt)();
+  if (windowMode && boardOpened) {
+    logger.info?.("Tu conversación vive en la ventana del navegador que se acaba de abrir. Si el tablero ya estaba arrancado de antes, reinícialo con kj board stop && kj go --window para que recoja este proyecto.");
+    process.exitCode = 0;
+    return 0;
+  }
+  if (windowMode) {
+    // Sin board no hay ventana: se dice y la conversación arranca en la
+    // terminal — el maggle nunca se queda sin sesión (catch de codex).
+    logger.warn?.("Sin tablero no hay ventana única: abro la conversación aquí mismo.");
+  }
   logger.info?.("Abriendo tu conversación… (escribe ahí lo que necesites, en tu idioma)");
   const code = await (deps.launch ?? defaultLaunch)(chosen, prompt);
   process.exitCode = code;

--- a/src/commands/go.js
+++ b/src/commands/go.js
@@ -99,9 +99,10 @@ export async function goCommand({ config = {}, logger = console, flags = {}, dep
   }
   const prompt = (deps.prompt ?? buildGoPrompt)();
   // --window (MGL-E, ADR 0008): la conversación vive DENTRO del board — el
-  // daemon hereda por env el cwd, el agente elegido y el prompt inicial, y
-  // el pty arranca el agente REAL (harness intacto). La fase 1 sigue siendo
-  // el default: sin el flag, nada cambia.
+  // daemon hereda por env (HU_BOARD_TERMINAL_CWD/AGENT/PROMPT) el cwd, el
+  // agente elegido y el prompt inicial, y el pty arranca el agente REAL
+  // (harness intacto). La fase 1 sigue siendo el default: sin el flag,
+  // nada cambia.
   const windowMode = Boolean(flags.window);
   if (windowMode) {
     process.env.HU_BOARD_TERMINAL_CWD = projectDir;

--- a/tests/commands/command-go.test.js
+++ b/tests/commands/command-go.test.js
@@ -38,7 +38,7 @@ const run = (over = {}) => {
     launch: vi.fn(async () => 0),
     ...over.deps,
   };
-  return goCommand({ config: { projectDir: dir, ...over.config }, logger: over.logger ?? logger(), flags: {}, deps }).then((code) => ({ code, deps }));
+  return goCommand({ config: { projectDir: dir, ...over.config }, logger: over.logger ?? logger(), flags: over.flags ?? {}, deps }).then((code) => ({ code, deps }));
 };
 
 beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-go-")); });
@@ -110,5 +110,31 @@ describe("kj go", () => {
     expect(boardUrl(4000, "/?maggle=1")).toBe("http://localhost:4000/?maggle=1");
     expect(boardUrl(4000)).toBe("http://localhost:4000");
     expect(() => boardUrl(4000, "maggle=1")).toThrow(/must start/);
+  });
+  // MGL-E (KJC-TSK-0816, ADR 0008): --window = la conversación vive EN el
+  // board; la fase 1 (terminal + board) sigue siendo el default.
+  it("--window: no se lanza terminal, el board abre con window=1 y el pty hereda cwd, agente y prompt por env", async () => {
+    const calls = [];
+    const { deps } = await run({
+      flags: { window: true },
+      deps: {
+        detect: async () => [agent("claude")],
+        board: vi.fn(async ({ openPath }) => { calls.push(openPath); }),
+      },
+    });
+    expect(deps.launch).not.toHaveBeenCalled();
+    expect(calls[0]).toContain("window=1");
+    expect(process.env.HU_BOARD_TERMINAL_CWD).toBe(dir);
+    expect(process.env.HU_BOARD_TERMINAL_AGENT).toBe("claude");
+    expect(process.env.HU_BOARD_TERMINAL_PROMPT).toMatch(/llano/i);
+    delete process.env.HU_BOARD_TERMINAL_CWD;
+    delete process.env.HU_BOARD_TERMINAL_AGENT;
+    delete process.env.HU_BOARD_TERMINAL_PROMPT;
+  });
+  it("defaultBoard honra openPath", async () => {
+    const calls = [];
+    await defaultBoard({ config: {}, logger: logger(), runBoard: async (opts) => { calls.push(opts); }, openPath: "/?maggle=1&window=1" });
+    const open = calls.find((c) => c.action === "open");
+    expect(open.path).toBe("/?maggle=1&window=1");
   });
 });


### PR DESCRIPTION
## KJC-TSK-0816 — MGL-E (pieza 3/3): kj go --window

Cierra la serie de la ventana única (ADR 0008). Con --window, kj go configura la terminal embebida del board (env trío HU_BOARD_TERMINAL_CWD/AGENT/PROMPT), abre /?maggle=1&window=1 y la conversación vive dentro del board. Sin la flag, nada cambia (fase 1 sigue siendo el default). Si el board falla en modo --window, fallback honesto a la terminal.

- src/commands/go.js: windowMode + boardOpened + fallback.
- src/cli/register-meta.js: opción --window.
- Tests de kj go cubren la rama nueva (12/12).

Serie: #1608 (manager) → #1612 (wire) → #1613 (panel) → esta.
