### PR TITLE
docs(changelog): drop wrong issue refs from rag 1.7.0 and watch 0.8.0 notes

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -12,7 +12,7 @@ este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **`easy.exclude`: globs que mantienen secretos fuera del corpus**
-  (KJR-TSK-0153, [issue #156](https://github.com/manufosela/karajan-rag/issues/156)):
+  (KJR-TSK-0153):
   patrones glob en `karajan.config.json` que filtran ficheros durante el
   walk — ANTES de leerlos o chunkearlos — con `path.matchesGlob` (cero
   dependencias nuevas). El resultado del indexado registra qué se excluyó

--- a/packages/watch/CHANGELOG.md
+++ b/packages/watch/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.0 — 2026-09-06
 
-Minor porque la CONFIG crece (issue [#24](https://github.com/manufosela/karajan-watch/issues/24)):
+Minor porque la CONFIG crece:
 
 ### Nuevo
 


### PR DESCRIPTION
Las notas de rag 1.7.0 y watch 0.8.0 citaban las issues rag#156 y watch#24 (guardarraíles de arranque, aún pendientes) como origen de exclude globs y config classification — atribución incorrecta. Se retiran las referencias. Los tarballs publicados viajan con la referencia errónea (no se puede reeditar un publish); el repo queda corregido para la siguiente versión. KJC-TSK-0817
