### PR TITLE
docs(sentinel): the gate-by-gate page every sentinel message links

### DIFF
--- a/apps/landing/docs/astro.config.mjs
+++ b/apps/landing/docs/astro.config.mjs
@@ -113,6 +113,7 @@ export default defineConfig({
 									{ label: 'Configuration', slug: 'guides/configuration', translations: { es: 'Configuración' } },
 									{ label: 'HU Board', slug: 'guides/hu-board', translations: { es: 'HU Board' } },
 									{ label: 'Hardening Against AI', slug: 'guides/hardening-against-ai', translations: { es: 'Blindar frente a IA' } },
+									{ label: 'The Sentinel', slug: 'guides/sentinel', translations: { es: 'El Sentinel' } },
 									{ label: 'Recommended Setup', slug: 'guides/recommended-setup', translations: { es: 'Configuración Recomendada' } },
 									{ label: 'Troubleshooting', slug: 'guides/troubleshooting', translations: { es: 'Resolución de problemas' } },
 								],

--- a/apps/landing/docs/src/content/docs/guides/sentinel.md
+++ b/apps/landing/docs/src/content/docs/guides/sentinel.md
@@ -1,0 +1,72 @@
+---
+title: The Sentinel, gate by gate
+description: Every message the Karajan Sentinel prints, what it protects, and what each KJ_ALLOW_* escape means.
+---
+
+The Sentinel is the set of synchronous hooks `kj harden` installs in your agent's harness. Every message it prints starts with `karajan sentinel:` and ends with a link to its section on this page. The host harness may wrap it in its own words (Claude Code says "stop says", "PreToolUse hook error") — the body is Karajan's.
+
+Two rules apply to everything below. First: the Sentinel blocks *before* the action runs — nothing is undone, because nothing happened. Second: every escape is an environment variable you prefix to ONE simple command (`KJ_ALLOW_X=1 git …`); it is ignored on command chains (`;`, `|`, `&`, `$( )`, backticks — `2>&1` counts), and every use is recorded in the session state and sealed into the decision log. An escape is a conscious, auditable exception — never a setting.
+
+## card-first
+
+Work needs a tracked card before it starts. Editing sources on the base branch, or on a branch whose name references no card, is blocked. Create the card (`kj hu add`), move it to running, and work on a `feat/<CARD-ID>-description` branch. Escape: `KJ_ALLOW_NO_CARD=1`.
+
+## cross-lane
+
+Since MONO-0, each session mutates only its own worktree lane; reading is free. The guard also refuses mutations it cannot verify: `cd` in a mutator chain, command substitution, shell expansion, or redirections whose target hides behind a variable — use `git -C`, `npm --prefix` and literal paths. Deliberate crossing: `KJ_ALLOW_CROSS_LANE=1` on a simple command.
+
+## identity
+
+The identity lock (ADR 0005): `gh`, `git push` and commit-authoring commands must run under the account this clone declares (`kj identity set`). Born from a real incident — one unswitched `gh` call posted as a client account on a public repo. Escape: `KJ_ALLOW_IDENTITY=1`.
+
+## board-sync
+
+A merged card must be moved in the tracker before anything else advances — commit, push, new PR, another merge, or ending the turn. Clear it with the real tracker call (`update_card` via MCP, or `kj hu move`). Escape: `KJ_ALLOW_BOARD=1`.
+
+## policy
+
+`.karajan/policy.yml` is evaluated on every tool call. A deny names its rule and reason. Security-tagged rules have NO escape and NO arbitration. For the rest: `KJ_ALLOW_POLICY=1` (the commit will also require `KJ_POLICY_REASON`).
+
+## steward
+
+The Steward's sweep can declare the project state bad enough that starting new work is blocked (security invariants, persistently red main — only where the project opted in). Remedy what the report names, or escape for this session: `KJ_ALLOW_STEWARD=1`.
+
+## claims
+
+A hard datum in a PR body or final message that is DENIED by this turn's own outputs is a proven hallucination — the PR is refused before it exists. Verify the datum or mark it unverified. Detail: `kj claims check`.
+
+## release
+
+`kj release check` must be green before anything publishes or deploys. The one legitimate chicken-and-egg: the landing shows the new version only *after* the publish — that step runs under `KJ_ALLOW_RELEASE=1`, recorded like every other escape.
+
+## supervisor
+
+The Sentinel's own files (`.karajan/harness`, hooks) are read-only from inside a session — a supervisor a session can edit is no supervisor. Only the human dismantles or regenerates it (`kj harden`), outside the session. Tampering is detected against what the installed kj itself would write.
+
+## stop-gate
+
+The turn cannot end while the method is red: suite failing, unreviewed diffs, pending board moves, unbacked claims. Resolve the listed violations or ask your user for the applicable escape. State: `kj sentinel status`.
+
+## push-gate
+
+Same as the stop gate, at the moment of `git push`: nothing leaves the machine with the method red.
+
+## escapes
+
+Every escape, what it skips, and when it is legitimate. All of them: one simple command, one use, recorded in the session state and sealed into the decision log — `kj sentinel status` lists what this session used.
+
+| Escape | Skips | Legitimate when |
+| --- | --- | --- |
+| `KJ_ALLOW_NO_CARD=1` | card-first | Emergency fix agreed with your user before the card exists |
+| `KJ_ALLOW_CROSS_LANE=1` | cross-lane / unverifiable-path guards | A deliberate, announced crossing (e.g. publishing from a tag worktree) |
+| `KJ_ALLOW_IDENTITY=1` | identity lock | Test suites exercising other gates; never for real pushes |
+| `KJ_ALLOW_BOARD=1` | board-sync | The tracker itself is down and the move is queued |
+| `KJ_ALLOW_POLICY=1` | non-security policy denies | The rule mis-fires and the fix is agreed; commit also needs `KJ_POLICY_REASON` |
+| `KJ_ALLOW_STEWARD=1` | steward hard block | The break is known, carded, and the user says work continues |
+| `KJ_ALLOW_RELEASE=1` | release check | The publish→landing ordering above |
+| `KJ_ALLOW_NO_TESTS=1` | tests-with-code gate (staged code with no test changes) | The diff genuinely owes no test and it is agreed |
+| `KJ_ALLOW_PII=1` | privacy denylist block at commit time | A confirmed false positive, reviewed by the human |
+| `KJ_ALLOW_REWRITE=1` | the guard against reserializing whole JSON files from Bash | A full-file rewrite IS the agreed change |
+| `KJ_ALLOW_WRITE=1` | the Write-over-existing-file block (use Edit) | A full regeneration is exactly what was asked |
+
+There is no `KJ_ALLOW_*` for security findings. That is the point.

--- a/tests/harden/sentinel-branding.test.js
+++ b/tests/harden/sentinel-branding.test.js
@@ -11,6 +11,10 @@ import path from "node:path";
 import { installSentinelHooks } from "../../src/harden/sentinel-hooks.js";
 
 const DOC_URL = "https://karajancode.com/docs/guides/sentinel/#";
+const DOC_PAGE = new URL(
+  "../../apps/landing/docs/src/content/docs/guides/sentinel.md",
+  import.meta.url,
+);
 
 let dir, scripts;
 
@@ -48,7 +52,29 @@ describe("sentinel branding (KJC-TSK-0814)", () => {
     }
   });
 
-  // The doc-page side of the contract (each linked anchor exists as a literal
-  // heading; every KJ_ALLOW_* escape documented) ships with the page itself
-  // in the follow-up PR — same card, atomicity partition.
+  it("every linked anchor exists as a literal heading in the doc page", () => {
+    const page = fs.readFileSync(DOC_PAGE, "utf8");
+    const all = scripts.map((s) => s.body).join("\n");
+    const linked = new Set(
+      [...all.matchAll(/doc\("([a-z-]+)"\)/g)].map((m) => m[1]),
+    );
+    expect(linked.size).toBeGreaterThanOrEqual(12);
+    for (const anchor of linked) {
+      expect(page, `doc page misses heading for #${anchor}`).toMatch(
+        new RegExp(`^##\\s+${anchor}\\s*$`, "m"),
+      );
+    }
+  });
+
+  it("the doc page names every real escape", () => {
+    const page = fs.readFileSync(DOC_PAGE, "utf8");
+    const all = scripts.map((s) => s.body).join("\n");
+    const escapes = new Set([...all.matchAll(/KJ_ALLOW_[A-Z_]+/g)].map((m) => m[0]))
+      // KJ_ALLOW_X is the generic placeholder in the simple-command rule text.
+      .difference(new Set(["KJ_ALLOW_X"]));
+    expect(escapes.size).toBeGreaterThanOrEqual(8);
+    for (const esc of escapes) {
+      expect(page, `doc page misses ${esc}`).toContain(esc);
+    }
+  });
 });


### PR DESCRIPTION
## KJC-TSK-0814 (2/2) — la página que enlazan todos los mensajes del Sentinel

- `guides/sentinel.md`: un heading literal por ancla (card-first, cross-lane, identity, board-sync, policy, steward, claims, release, supervisor, stop-gate, push-gate, escapes) — heading = slug = ancla estable.
- Tabla de los escapes KJ_ALLOW_* con semántica VERIFICADA contra el código (WRITE = Write sobre fichero existente; REWRITE = reserializar JSON desde Bash; NO_TESTS = código staged sin tests; PII = denylist de privacidad en commit…), regla de comando simple, y que todo uso queda registrado y sellado.
- Entrada del sidebar (astro.config.mjs) tras «Hardening Against AI».
- Tests de contrato plantillas↔página: cada ancla enlazada existe como heading; cada escape real aparece documentado.

Review: APPROVED (codex, diff d9b859beec1f + fix de `__dirname`→`import.meta.url` que él mismo cazó). Tras el merge: rebuild + deploy de docs para que los enlaces de los mensajes no den 404.
