### PR TITLE
feat(policy): scoped exceptions - project or global store with physical provenance

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -372,6 +372,7 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--rule <rule_id>", "Regla exacta (p.ej. roles.coder.write.deny)")
     .option("--until <iso>", "Caducidad ISO-8601 (p.ej. 2026-09-01T00:00:00Z)")
     .option("--reason <text>", "Justificación escrita en el momento")
+    .option("--global", "Ámbito global (~/.karajan): vale para todos tus proyectos de esta máquina — KJC-TSK-0813")
     .action(async (flags) => {
       await withConfig(pkgVersion, "policy-grant", flags, async ({ config }) => {
         process.exitCode = await policyCommand({ action: "grant", config, flags });

--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -110,12 +110,16 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
       // regla re-concedida N veces es la política real pidiendo que la
       // cambien por su cauce. Se cuenta contra TODAS las permanentes previas
       // (vencidas incluidas: precisamente esas son la sedimentación).
-      const previous = loadStandingExceptions(projectDir).standing.filter((e) => e.rule_id === rule).length;
+      // KJC-TSK-0813: --global escribe en ~/.karajan (todos los proyectos de
+      // la máquina). El contador de renovaciones cuenta sobre la FUSIÓN.
+      const scope = flags.global ? "global" : "project";
+      const previous = loadStandingExceptions(projectDir, { home: deps.home }).standing.filter((e) => e.rule_id === rule).length;
       const rec = recordPolicyException({
-        projectDir,
+        projectDir, scope, deps: { home: deps.home },
         entry: { rule_id: rule, justification: reason.trim(), scopeKind: "permanente", expiresAt: until },
       });
-      logger.info?.(`✓ excepción permanente registrada: [${rec.rule_id}] hasta ${rec.expiresAt} — concedida por ${rec.who?.git ?? "?"} (${rec.who?.grade ?? "?"})`);
+      const ambit = scope === "global" ? " [ámbito global — todos tus proyectos de esta máquina]" : "";
+      logger.info?.(`✓ excepción permanente registrada${ambit}: [${rec.rule_id}] hasta ${rec.expiresAt} — concedida por ${rec.who?.git ?? "?"} (${rec.who?.grade ?? "?"})`);
       if (previous >= 1) {
         logger.warn?.(`⚠ ${previous + 1}ª concesión sobre esta regla — una excepción que se renueva ya no es una excepción: considera cambiar la política por su cauce (PR a .karajan/policy.yml)`);
       }

--- a/src/policy/exceptions.js
+++ b/src/policy/exceptions.js
@@ -6,7 +6,7 @@
  */
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { userInfo } from "node:os";
+import { homedir, userInfo } from "node:os";
 import { spawnSync } from "node:child_process";
 import { recordPolicyException as kernelRecord } from "@karajan-family/governance";
 
@@ -23,20 +23,25 @@ function defaultIdentity(projectDir) {
  * reporta), jamás rompe la evaluación. Las puntuales no dan standing.
  * @returns {{standing: object[], discarded: number}}
  */
-export function loadStandingExceptions(projectDir) {
-  const { records, discarded } = loadExceptionRecords(projectDir);
-  return { standing: records.filter((rec) => rec.scopeKind === "permanente"), discarded };
+export function loadStandingExceptions(projectDir, { home } = {}) {
+  const proj = loadExceptionRecords(projectDir);
+  const glob = loadGlobalExceptionRecords({ home });
+  return {
+    standing: [...proj.records, ...glob.records].filter((rec) => rec.scopeKind === "permanente"),
+    discarded: proj.discarded + glob.discarded,
+  };
 }
 
 /**
- * TODOS los registros del jsonl (permanentes y puntuales) con el mismo parse
- * tolerante — el informe (PL-E) cuenta también las puntuales.
- * @returns {{records: object[], discarded: number}}
+ * Ruta del almacén GLOBAL (~/.karajan): excepciones de la máquina, no de un
+ * proyecto. `home` es inyectable SOLO para tests.
  */
-export function loadExceptionRecords(projectDir) {
+export const globalExceptionsFile = ({ home } = {}) => join(home ?? homedir(), ".karajan", "policy-exceptions.jsonl");
+
+function readRecordsAt(file, origin) {
   let raw;
   try {
-    raw = readFileSync(join(projectDir, ".karajan", "policy-exceptions.jsonl"), "utf8");
+    raw = readFileSync(file, "utf8");
   } catch {
     return { records: [], discarded: 0 };
   }
@@ -49,12 +54,28 @@ export function loadExceptionRecords(projectDir) {
       // JSON válido pero no-objeto (null, número…) es tan corrupto como el
       // que no parsea: se descarta contando (catch de codex, explícito).
       if (typeof rec !== "object" || rec === null) discarded += 1;
-      else records.push(rec);
+      // Procedencia FÍSICA (KJC-TSK-0813): el origin es el almacén del que
+      // se LEYÓ la línea, pisando lo que la línea declare — no se miente.
+      else records.push({ ...rec, origin });
     } catch {
       discarded += 1;
     }
   }
   return { records, discarded };
+}
+
+/**
+ * TODOS los registros del jsonl (permanentes y puntuales) con el mismo parse
+ * tolerante — el informe (PL-E) cuenta también las puntuales.
+ * @returns {{records: object[], discarded: number}}
+ */
+export function loadExceptionRecords(projectDir) {
+  return readRecordsAt(join(projectDir, ".karajan", "policy-exceptions.jsonl"), "project");
+}
+
+/** @returns {{records: object[], discarded: number}} */
+export function loadGlobalExceptionRecords({ home } = {}) {
+  return readRecordsAt(globalExceptionsFile({ home }), "global");
 }
 
 function defaultAppend(projectDir, line) {
@@ -63,8 +84,23 @@ function defaultAppend(projectDir, line) {
   appendFileSync(join(dir, "policy-exceptions.jsonl"), line, "utf8");
 }
 
+const globalAppend = (home) => (_projectDir, line) => {
+  const dir = join(home ?? homedir(), ".karajan");
+  mkdirSync(dir, { recursive: true });
+  appendFileSync(join(dir, "policy-exceptions.jsonl"), line, "utf8");
+};
+
 /** @returns {object} the recorded entry (with ts + who resolved). */
-export function recordPolicyException({ projectDir, entry, deps = {} }) {
-  const { append = defaultAppend, identity = defaultIdentity } = deps;
-  return kernelRecord({ projectDir, entry, deps: { append, identity } });
+export function recordPolicyException({ projectDir, entry, deps = {}, scope = "project" }) {
+  if (scope !== "project" && scope !== "global") {
+    throw new TypeError(`recordPolicyException: scope "${scope}" no existe — solo project o global`);
+  }
+  // Un global puntual NO existe: lo puntual liga al hash de un artefacto de
+  // UN proyecto; el ámbito global solo admite permanentes con caducidad.
+  if (scope === "global" && (entry?.scopeKind !== "permanente" || !entry?.expiresAt)) {
+    throw new TypeError("recordPolicyException: el ámbito global exige scopeKind permanente con expiresAt — un global puntual no existe");
+  }
+  const { home, append = scope === "global" ? globalAppend(home) : defaultAppend, identity = defaultIdentity } = deps;
+  // El origin escrito es informativo: la carga re-estampa el FÍSICO igualmente.
+  return kernelRecord({ projectDir, entry: { ...entry, origin: scope }, deps: { append, identity } });
 }

--- a/tests/policy/scoped-exceptions.test.js
+++ b/tests/policy/scoped-exceptions.test.js
@@ -1,0 +1,97 @@
+// KJC-TSK-0813 PR-1 — excepciones con ámbito: almacén de proyecto
+// (.karajan/ del repo) o GLOBAL (~/.karajan/). La procedencia es FÍSICA:
+// el origin se estampa según el almacén del que se leyó cada línea,
+// ignorando lo que la línea declare — no se puede mentir sobre el origen.
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { evaluateGate } from "@karajan-family/governance";
+import { loadStandingExceptions, recordPolicyException } from "../../src/policy/exceptions.js";
+import { policyCommand } from "../../src/commands/policy.js";
+import { loadPolicy } from "../../src/policy/engine.js";
+
+const DENY_POLICY = "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.secret'], enforcement: deny }\n";
+const SEC_POLICY = "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.secret'], enforcement: deny, class: security }\n";
+const RULE = "roles.coder.write.deny";
+const FAR = "2099-01-01T00:00:00Z";
+const jsonl = (root) => path.join(root, ".karajan", "policy-exceptions.jsonl");
+const writeStore = (root, lines) => {
+  fs.mkdirSync(path.join(root, ".karajan"), { recursive: true });
+  fs.writeFileSync(jsonl(root), `${lines.join("\n")}\n`);
+};
+
+let dir;
+let home;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-scoped-proj-"));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-scoped-home-"));
+});
+
+describe("kj policy grant --global", () => {
+  it("escribe en <home>/.karajan y NO en el proyecto, y el mensaje dice el ámbito", async () => {
+    const logs = [];
+    const code = await policyCommand({
+      action: "grant", config: { projectDir: dir },
+      flags: { rule: RULE, until: FAR, reason: "flota entera de esta máquina", global: true },
+      logger: { info: (m) => logs.push(m), warn: (m) => logs.push(m), error: (m) => logs.push(m) },
+      deps: { readFile: () => DENY_POLICY, home },
+    });
+    expect(code).toBe(0);
+    const rec = JSON.parse(fs.readFileSync(jsonl(home), "utf8").trim());
+    expect(rec).toMatchObject({ rule_id: RULE, scopeKind: "permanente", expiresAt: FAR, origin: "global" });
+    expect(fs.existsSync(jsonl(dir))).toBe(false);
+    expect(logs.join("\n")).toContain("ámbito global — todos tus proyectos de esta máquina");
+  });
+});
+
+describe("loadStandingExceptions fusionada", () => {
+  it("fusiona ambos almacenes con origin FÍSICO (una global que declare project sale global) y suma descartes", () => {
+    writeStore(dir, [JSON.stringify({ rule_id: "p.rule", scopeKind: "permanente", expiresAt: FAR, origin: "global" }), "no-json"]);
+    writeStore(home, [JSON.stringify({ rule_id: "g.rule", scopeKind: "permanente", expiresAt: FAR, origin: "project" }), "null"]);
+    const { standing, discarded } = loadStandingExceptions(dir, { home });
+    expect(standing).toHaveLength(2);
+    expect(standing.find((s) => s.rule_id === "p.rule").origin).toBe("project");
+    expect(standing.find((s) => s.rule_id === "g.rule").origin).toBe("global");
+    expect(discarded).toBe(2);
+  });
+});
+
+describe("recordPolicyException con scope", () => {
+  const deps = () => ({ home, identity: () => ({ grade: "declarada" }), append: () => {} });
+
+  it("global con scopeKind puntual o sin expiresAt es TypeError — un global puntual no existe", () => {
+    expect(() => recordPolicyException({ projectDir: dir, entry: { rule_id: RULE, scopeKind: "puntual" }, deps: deps(), scope: "global" }))
+      .toThrow(/permanente/);
+    expect(() => recordPolicyException({ projectDir: dir, entry: { rule_id: RULE, scopeKind: "permanente" }, deps: deps(), scope: "global" }))
+      .toThrow(TypeError);
+  });
+
+  it("scope desconocido es TypeError", () => {
+    expect(() => recordPolicyException({ projectDir: dir, entry: { rule_id: RULE, scopeKind: "permanente", expiresAt: FAR }, deps: deps(), scope: "machine" }))
+      .toThrow(/project o global/);
+  });
+});
+
+describe("standing global en evaluateGate", () => {
+  const gate = (yaml) => {
+    writeStore(home, [JSON.stringify({ rule_id: RULE, scopeKind: "permanente", expiresAt: FAR, justification: "j" })]);
+    const { policy, errors } = loadPolicy({ projectDir: dir, deps: { readFile: () => yaml } });
+    const { standing } = loadStandingExceptions(dir, { home });
+    return evaluateGate({ policy, errors, files: ["prod.secret"], standingExceptions: standing });
+  };
+
+  it("una permanente global VIVA exime el deny y el exempted lleva la procedencia", () => {
+    const res = gate(DENY_POLICY);
+    expect(res.ok).toBe(true);
+    expect(res.exempted).toHaveLength(1);
+    expect(res.exempted[0].standing.origin).toBe("global");
+  });
+
+  it("lo security sigue sin eximirse aunque haya standing global", () => {
+    const res = gate(SEC_POLICY);
+    expect(res.ok).toBe(false);
+    expect(res.denials[0].class).toBe("security");
+    expect(res.exempted).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
PR-1 de KJC-TSK-0813: excepciones de policy con ámbito — almacén de proyecto (`.karajan/policy-exceptions.jsonl`) o global (`~/.karajan/policy-exceptions.jsonl`).

## Qué cambia

- **El ámbito vive en el adaptador** (`src/policy/exceptions.js`), no en el kernel: `packages/governance` no se toca. El kernel sigue sin saber dónde se persiste ni de dónde se cargó nada.
- **Procedencia física inmentible**: `origin` se estampa según el almacén del que se LEYÓ cada línea (`project` / `global`), pisando cualquier `origin` que la línea declare. Una línea del almacén global que diga `origin: "project"` sale con `origin: "global"` — no se puede mentir sobre el origen.
- **Lo global exige permanente + caducidad**: `recordPolicyException` con `scope: "global"` rechaza con `TypeError` un `scopeKind` puntual o la ausencia de `expiresAt`. Un global puntual no existe: lo puntual liga al hash de un artefacto de UN proyecto. Un `scope` fuera de `project|global` también es `TypeError`.
- **`kj policy grant --global`**: escribe la permanente en `~/.karajan` (mkdir si falta) y el mensaje de éxito nombra el ámbito. El contador de renovaciones (GOV-E) cuenta sobre la fusión de ambos almacenes.
- **Lo inexcepcionable sigue igual en ambos ámbitos**: `defaults.*`, caps `class: security` y policy inválida se rechazan ANTES de mirar el ámbito — `--global` no abre ninguna puerta nueva, y `evaluateGate` sigue denegando security aunque exista standing global viva (test incluido).

## Posición sobre el ADR 0006

`loadStandingExceptions` es el ÚNICO punto de carga y ahora devuelve la fusión proyecto+global con cada record estampado. Los futuros invariantes de composición evalúan la unión de ambos almacenes gratis: nadie tiene que acordarse de consultar dos sitios, y la procedencia viaja en cada record para que quien decida pueda distinguirlas.

## Tests

`tests/policy/scoped-exceptions.test.js` (home SIEMPRE inyectado con mkdtemp, jamás el real): grant global escribe en home y no en el proyecto · fusión con origin físico y suma de descartes · TypeError en global puntual / sin caducidad / scope desconocido · una permanente global viva exime en `evaluateGate` con `standing.origin === "global"` · security sin eximir con standing global. Suites `tests/policy/`, `tests/review/` y `tests/harden/review-gate-hook.test.js` verdes (234 tests).

Ref: KJC-TSK-0813.
