### PR TITLE
feat(policy): the report and the gate name each exemption's provenance

### DIFF
--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -12,7 +12,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
-import { loadExceptionRecords, loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
+import { loadExceptionRecords, loadGlobalExceptionRecords, loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
 import { buildPolicyReport } from "../policy/report.js";
 import { policyFileHash, recordGateDecision } from "../policy/decisions.js";
 import { readIdentity } from "../identity/store.js";
@@ -138,7 +138,11 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
     try {
       decisionLines = readFileSync(join(projectDir, ".karajan", "policy-decisions.jsonl"), "utf8").split("\n").filter((l) => l.trim());
     } catch { /* sin decisiones aún: el informe lo dice con ceros */ }
-    const exc = loadExceptionRecords(projectDir);
+    // KJC-TSK-0813 (AC3): el informe cubre TAMBIÉN el almacén global — cada
+    // registro llega con su origin FÍSICO estampado por la carga.
+    const proj = loadExceptionRecords(projectDir);
+    const glob = loadGlobalExceptionRecords({ home: deps.home });
+    const exc = { records: [...proj.records, ...glob.records], discarded: proj.discarded + glob.discarded };
     const soonDays = Number(flags.soon ?? 7);
     const report = buildPolicyReport({ decisionLines, exceptionRecords: exc.records, policy, soonDays: Number.isFinite(soonDays) ? soonDays : 7 });
     if (flags.json) {
@@ -156,8 +160,10 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
       const meta = [r.enforcement && `enforcement=${r.enforcement}`, r.class && `class=${r.class}`].filter(Boolean).join(" ");
       logger.info?.(`  [${r.rule_id}] ${meta} — warn ${r.warns} · deny ${r.denies} · exempt ${r.exempts} · abiertas ${r.open}`);
     }
-    logger.info?.(`concesiones: vivas ${g.alive.length} (próximas a vencer ${g.soon.length}) · vencidas ${g.expired.length} · puntuales ${g.point}`);
-    for (const e of g.alive) logger.info?.(`  [${e.rule_id}] hasta ${e.expiresAt} — ${e.who?.git ?? "?"}: ${e.justification ?? "sin justificación"}`);
+    // Con 0 globales el resumen queda EXACTAMENTE como siempre (hay consumidores de texto).
+    const globals = g.alive.filter((e) => e.origin === "global").length;
+    logger.info?.(`concesiones: vivas ${g.alive.length} (${globals > 0 ? `${globals} globales, ` : ""}próximas a vencer ${g.soon.length}) · vencidas ${g.expired.length} · puntuales ${g.point}`);
+    for (const e of g.alive) logger.info?.(`  [${e.rule_id}] hasta ${e.expiresAt}${e.origin === "global" ? " [global]" : ""} — ${e.who?.git ?? "?"}: ${e.justification ?? "sin justificación"}`);
     logger.info?.(report.signals.length > 0 ? "señales:" : "señales: ninguna");
     for (const s of report.signals) logger.warn?.(`  ⚠ ${s}`);
     return chain.ok ? 0 : 1;

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -52,6 +52,13 @@ async function rawDiff(range, extraArgs = []) {
   return res.stdout;
 }
 
+// KJC-TSK-0813 (AC3): la exención dice su PROCEDENCIA — un standing global
+// (concedido para toda la máquina) no pasa por uno del proyecto. El texto
+// de las de proyecto queda EXACTAMENTE como estaba.
+export const formatExempted = (e) => (e.standing
+  ? `⚠ policy standing [${e.rule_id}] — excepción permanente${e.standing.origin === "global" ? " GLOBAL" : ""} viva hasta ${e.standing.expiresAt} (${e.standing.justification || "sin justificación"})`
+  : `⚠ policy exempt [${e.rule_id}] — excepción registrada en .karajan/policy-exceptions.jsonl (${e.justification})`);
+
 function printVerdict(record) {
   if (record.verdict === "approved") {
     const ws = record.workspace ? ` [${record.workspace}]` : "";
@@ -257,11 +264,7 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
   });
   const at = (v) => (v.file ? ` (${v.file})` : "");
   for (const w of gate.warns) console.log(`⚠ policy [${w.rule_id}] ${w.reason}${at(w)}`);
-  for (const e of gate.exempted) {
-    console.log(e.standing
-      ? `⚠ policy standing [${e.rule_id}] — excepción permanente viva hasta ${e.standing.expiresAt} (${e.standing.justification || "sin justificación"})`
-      : `⚠ policy exempt [${e.rule_id}] — excepción registrada en .karajan/policy-exceptions.jsonl (${e.justification})`);
-  }
+  for (const e of gate.exempted) console.log(formatExempted(e));
   // GOV-C (KJC-TSK-0747): las decisiones de chokepoint dejan rastro
   // hash-encadenado — cada deny, cada excepción, y el allow del commit.
   const chokepoint = flags.check ? "commit" : "review";

--- a/tests/policy/provenance-report.test.js
+++ b/tests/policy/provenance-report.test.js
@@ -1,0 +1,91 @@
+// KJC-TSK-0813 PR-2 — AC3: el informe y el gate dicen la PROCEDENCIA de
+// cada exención aplicada; una decisión influida por un grant global lo dice.
+// Con 0 globales el texto queda EXACTAMENTE como hoy (no romper consumidores).
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { policyCommand } from "../../src/commands/policy.js";
+import { formatExempted } from "../../src/commands/review-gate.js";
+import { evaluatePolicyGate } from "../../src/review/policy-gate.js";
+import { loadStandingExceptions } from "../../src/policy/exceptions.js";
+import { loadPolicy } from "../../src/policy/engine.js";
+
+const FAR = "2099-01-01T00:00:00Z";
+const DENY_POLICY = "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.secret'], enforcement: deny }\n";
+const jsonl = (root) => path.join(root, ".karajan", "policy-exceptions.jsonl");
+const store = (root, lines) => {
+  fs.mkdirSync(path.join(root, ".karajan"), { recursive: true });
+  fs.writeFileSync(jsonl(root), `${lines.join("\n")}\n`);
+};
+const perm = (rule, extra = {}) =>
+  JSON.stringify({ rule_id: rule, scopeKind: "permanente", expiresAt: FAR, justification: "j", who: { git: "t <t@t>" }, ...extra });
+
+let dir;
+let home;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-prov-proj-"));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-prov-home-"));
+  fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
+  fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"), "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.tmp'] }\n");
+});
+
+const logger = () => {
+  const lines = [];
+  return { lines, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: (m) => lines.push(m) };
+};
+const report = (log, flags = {}) => policyCommand({ action: "report", config: { projectDir: dir }, flags, logger: log, deps: { home } });
+
+describe("kj policy report con almacén global", () => {
+  it("--json incluye la global con origin global y la de proyecto con project", async () => {
+    store(dir, [perm("p.rule")]);
+    store(home, [perm("g.rule", { origin: "project" })]); // la línea miente: el FÍSICO manda
+    const log = logger();
+    expect(await report(log, { json: true })).toBe(0);
+    const out = JSON.parse(log.lines.at(-1));
+    expect(out.grants.alive.find((e) => e.rule_id === "p.rule").origin).toBe("project");
+    expect(out.grants.alive.find((e) => e.rule_id === "g.rule").origin).toBe("global");
+  });
+
+  it("el texto marca [global] la concesión global y el resumen desglosa", async () => {
+    store(dir, [perm("p.rule")]);
+    store(home, [perm("g.rule")]);
+    const log = logger();
+    expect(await report(log)).toBe(0);
+    const out = log.lines.join("\n");
+    expect(out).toContain("concesiones: vivas 2 (1 globales, próximas a vencer 0) · vencidas 0 · puntuales 0");
+    expect(out).toContain(`  [g.rule] hasta ${FAR} [global] — t <t@t>: j`);
+    expect(out).toContain(`  [p.rule] hasta ${FAR} — t <t@t>: j`);
+  });
+
+  it("con 0 globales el resumen queda EXACTAMENTE como hoy y los descartes globales cuentan", async () => {
+    store(dir, [perm("p.rule")]);
+    store(home, ["{rota"]);
+    const log = logger();
+    expect(await report(log)).toBe(0);
+    expect(log.lines).toContain("concesiones: vivas 1 (próximas a vencer 0) · vencidas 0 · puntuales 0");
+    expect(log.lines.join("\n")).not.toContain("[global]");
+    expect(log.lines.join("\n")).toContain("0 en decisiones, 1 en excepciones");
+  });
+});
+
+describe("review gate — la exención dice su ámbito", () => {
+  const exempted = (origin) => ({ rule_id: "r", standing: { expiresAt: FAR, justification: "j", origin } });
+
+  it("un standing global lo nombra en la línea", () => {
+    expect(formatExempted(exempted("global"))).toBe(`⚠ policy standing [r] — excepción permanente GLOBAL viva hasta ${FAR} (j)`);
+  });
+
+  it("un standing de proyecto queda EXACTAMENTE como hoy", () => {
+    expect(formatExempted(exempted("project"))).toBe(`⚠ policy standing [r] — excepción permanente viva hasta ${FAR} (j)`);
+  });
+
+  it("el exempted que llega al sello conserva el origin del standing (viene de la fusión)", () => {
+    store(home, [perm("roles.coder.write.deny")]);
+    const { policy, errors } = loadPolicy({ projectDir: dir, deps: { readFile: () => DENY_POLICY } });
+    const std = loadStandingExceptions(dir, { home });
+    const gate = evaluatePolicyGate({ policy, errors, files: ["a.secret"], netLinesAdded: 1, diffHashValue: "x", standingExceptions: std.standing });
+    expect(gate.ok).toBe(true);
+    expect(gate.exempted[0].standing.origin).toBe("global");
+  });
+});

--- a/tests/policy/report-command.test.js
+++ b/tests/policy/report-command.test.js
@@ -9,10 +9,12 @@ import { recordGateDecision } from "../../src/policy/decisions.js";
 import { loadExceptionRecords, recordPolicyException } from "../../src/policy/exceptions.js";
 
 let dir;
+let home; // home temporal: el report también lee ~/.karajan (KJC-TSK-0813)
 const cwd0 = process.cwd();
 afterEach(() => { process.chdir(cwd0); });
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), "kj-polreport-"));
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "kj-polreport-home-"));
   fs.mkdirSync(path.join(dir, ".karajan"), { recursive: true });
   fs.writeFileSync(path.join(dir, ".karajan", "policy.yml"), "version: 1\nroles:\n  coder:\n    write: { deny: ['**/*.tmp'] }\n");
   process.chdir(dir);
@@ -21,7 +23,7 @@ const logger = () => {
   const lines = [];
   return { lines, info: (m) => lines.push(m), warn: (m) => lines.push(m), error: (m) => lines.push(m) };
 };
-const run = (log, flags = {}) => policyCommand({ action: "report", config: { projectDir: dir }, flags, logger: log });
+const run = (log, flags = {}) => policyCommand({ action: "report", config: { projectDir: dir }, flags, logger: log, deps: { home } });
 const grant = (until) => recordPolicyException({
   projectDir: dir, entry: { rule_id: "roles.coder.write.deny", justification: "j", scopeKind: "permanente", expiresAt: until },
   deps: { identity: () => ({ git: "t <t@t>", os: "t", grade: "declarada" }) },


### PR DESCRIPTION
## AC3 de KJC-TSK-0813 — la procedencia de cada exención aplicada

PR-2 (última) de la card KJC-TSK-0813. La PR-1 (#1619, mergeada) introdujo los almacenes con ámbito (`project` / `global`) y la fusión que estampa el `origin` FÍSICO de cada registro. Esta PR hace que esa procedencia se VEA en los dos puntos donde una exención influye en una decisión:

### `kj policy report`
- El informe carga TAMBIÉN el almacén global (`loadGlobalExceptionRecords`) y pasa al builder la unión con su `origin` estampado; los descartes de líneas corruptas se suman.
- Texto: cada concesión viva global se marca — `[regla] hasta FECHA [global] — quien: justificación`. Las de proyecto quedan como hoy.
- Resumen: `concesiones: vivas N (M globales, próximas a vencer K) …` solo cuando M > 0; con 0 globales el texto es EXACTAMENTE el de hoy (no rompe consumidores de texto).
- `--json`: cada entrada de `grants.alive` conserva su `origin`.

### Review gate (`kj review --staged` / `--check`)
- La línea de exención por standing nombra el ámbito cuando la concesión es global: `⚠ policy standing [regla] — excepción permanente GLOBAL viva hasta FECHA (…)`. El texto de las de proyecto queda idéntico.
- El formateador se extrae como `formatExempted` (exportado) para testearlo con dobles.

### Sello de decisión
El registro del decision log para `exempt` guarda `rule_ids`, no el objeto exempted — no hay nada que corregir ahí. Se añade un test que prueba que el `exempted` que llega al punto del sello conserva el `origin` del standing (viene de la fusión de PR-1).

### Tests
`tests/policy/provenance-report.test.js` (home SIEMPRE temporal con mkdtemp): json con origin global/project, texto con `[global]` y desglose, texto idéntico al actual con 0 globales, descartes globales contados, formateador del gate en ambos ámbitos. `tests/policy/report-command.test.js` pasa ahora un home temporal (hermético: el report ya lee `~/.karajan`).

Refs: KJC-TSK-0813 · #1619
