### PR TITLE
fix(ci): the loc gate ignores the built landing docs

### DIFF
--- a/.github/workflows/shrink-budget.yml
+++ b/.github/workflows/shrink-budget.yml
@@ -92,6 +92,7 @@ jobs:
             ":(exclude)**/*.min.js"
             ":(exclude)tests/_diet/**"
             ":(exclude)public/docs/**"
+            ":(exclude)apps/landing/public/docs/**"
             ":(exclude)docs/*.md"
             ":(exclude)docs/**/*.md"
             ":(exclude)docs/*.mdx"


### PR DESCRIPTION
El gate LOC excluye `public/docs/**` anclado a la raíz — herencia de cuando la landing vivía en su propio repo. Desde MONO-3 el build vive en `apps/landing/public/docs/**` y CONTABA: la PR #1620 (669 líneas de build de Starlight) falló el gate por peso que nadie escribió. Una línea: la exclusión equivalente en la ruta del monorepo. KJC-TSK-0818.
