### PR TITLE
fix(board): the default backlog name never names a project

### DIFF
--- a/packages/hu-board/src/sync.js
+++ b/packages/hu-board/src/sync.js
@@ -456,7 +456,12 @@ export function syncPlanFile(filePath) {
     //      with a SPEC about "Linux Assistant", the basename here would
     //      misleadingly say "Hu Board" — that's why plan.name wins.
     //   3. slugToTitle of the task / projectId as a last resort.
-    const projectName = data.name
+    // KJC-BUG-0162: the default backlog plan is named "brain-backlog" — a
+    // DEFAULT, not a user choice. Every project synced through it ended up
+    // named "brain-backlog", indistinguishable in the picker. Only a real,
+    // user-given plan name may override the repo-derived name.
+    const userGivenName = data.name && data.name !== 'brain-backlog' ? data.name : null;
+    const projectName = userGivenName
       || (canonicalDir ? titleCaseBasename(basename(canonicalDir)) : null)
       || slugToTitle(data.task || '')
       || projectId;

--- a/packages/hu-board/tests/project-name.test.js
+++ b/packages/hu-board/tests/project-name.test.js
@@ -1,0 +1,83 @@
+// KJC-BUG-0162 — every board project showed up as "brain-backlog": the
+// default backlog plan's own name was winning over the project directory.
+// A DEFAULT name is not a user choice — only a real, user-given plan name
+// may override the name derived from the repo.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-name-'));
+  process.env.KJ_HOME = tmpDir;
+  process.env.KJ_PLANS_DIR = join(tmpDir, '_empty_plans_');
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../src/db.js');
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+});
+
+function writeSharedPlan(projectDir, planId, name) {
+  const dir = join(projectDir, '.karajan-shared', 'plans');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${planId}.json`),
+    JSON.stringify({
+      version: 2,
+      planId,
+      task: 'default backlog',
+      projectDir,
+      name,
+      hus: [{ id: 'hu-01', status: 'pending', title: 'Una tarea' }],
+      status: 'draft',
+      shared: true,
+      createdAt: '2026-09-06T00:00:00Z',
+    }),
+  );
+}
+
+describe('board project naming (KJC-BUG-0162)', () => {
+  it('the default backlog name never names the project — the repo directory does', async () => {
+    const projectDir = join(tmpDir, 'mi-tienda');
+    mkdirSync(projectDir, { recursive: true });
+    writeSharedPlan(projectDir, 'plan-0162a', 'brain-backlog');
+    const db = await import('../src/db.js');
+    db.initDb();
+    const sync = await import('../src/sync.js');
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(projectDir);
+      await sync.fullScan();
+    } finally {
+      process.chdir(originalCwd);
+    }
+    const project = db.getProjects().find((p) => p.id.includes('mi-tienda'));
+    expect(project).toBeTruthy();
+    expect(project.name).toBe('Mi Tienda');
+  });
+
+  it('a real, user-given plan name still wins over the directory', async () => {
+    const projectDir = join(tmpDir, 'otro-dir');
+    mkdirSync(projectDir, { recursive: true });
+    writeSharedPlan(projectDir, 'plan-0162b', 'Linux Assistant');
+    const db = await import('../src/db.js');
+    db.initDb();
+    const sync = await import('../src/sync.js');
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(projectDir);
+      await sync.fullScan();
+    } finally {
+      process.chdir(originalCwd);
+    }
+    const project = db.getProjects().find((p) => p.id.includes('otro-dir'));
+    expect(project).toBeTruthy();
+    expect(project.name).toBe('Linux Assistant');
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0162 — todos los proyectos del board se llamaban «brain-backlog»

El plan-backlog por defecto se llama `brain-backlog` y su `name` ganaba al nombre derivado del directorio del repo — resultado: 4+ proyectos reales indistinguibles en el picker (el usuario legítimamente desconfió de la limpieza del board al verlos). Un nombre POR DEFECTO no es una elección del usuario: solo un nombre de plan puesto por el usuario puede pisar el derivado del repo.

- `packages/hu-board/src/sync.js`: el default `brain-backlog` deja de nombrar proyectos; gana `titleCaseBasename` del directorio canónico (con la identidad por repo de KJC-BUG-0160, eso es el root del repo).
- Test nuevo (TDD, rojo primero): el default nunca nombra; un nombre real de usuario sigue ganando.

Suite hu-board entera: 458/458. Review: APPROVED (codex, diff 728bc0db359f). Los nombres existentes en la BD se corrigen solos en el siguiente sync (upsert).
