### PR TITLE
fix(board): a project name is unique - a duplicate registers as a loud error

### DIFF
--- a/packages/hu-board/src/db.js
+++ b/packages/hu-board/src/db.js
@@ -377,6 +377,19 @@ export function ensureDb() {
  * @param {{ id: string, name?: string, first_seen?: string, last_activity?: string, total_stories?: number }} project
  */
 export function upsertProject(project) {
+  // KJC-BUG-0163 — the iron rule: a project NAME is unique on the dashboard.
+  // Two projects with the same visible name are indistinguishable in the
+  // picker; registering the second fails LOUD instead of blending in.
+  if (project.name) {
+    const clash = getDb()
+      .prepare('SELECT id FROM projects WHERE name = ? AND id != ?')
+      .get(project.name, project.id);
+    if (clash) {
+      throw new Error(
+        `board: el nombre "${project.name}" ya pertenece al proyecto "${clash.id}" — dos proyectos no pueden llamarse igual (KJC-BUG-0163); renombra el plan o el directorio de "${project.id}"`,
+      );
+    }
+  }
   // is_shared (KJC-PRP-0002 PR3) is set by sync when a plan came from
   // `.karajan-shared/`. COALESCE with the existing column keeps the badge
   // once it's been promoted — a second non-shared plan won't unset it.

--- a/packages/hu-board/tests/project-name-unique.test.js
+++ b/packages/hu-board/tests/project-name-unique.test.js
@@ -1,0 +1,81 @@
+// KJC-BUG-0163 — the iron rule: a project NAME is unique on the dashboard.
+// Registering a project whose name already belongs to a DIFFERENT id fails
+// LOUD (the conflicting project is not silently registered), and the sync
+// survives: other projects keep syncing. No silent auto-disambiguation —
+// the error IS the signal that something needs a better name.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'hu-board-unique-'));
+  process.env.KJ_HOME = tmpDir;
+  process.env.KJ_PLANS_DIR = join(tmpDir, '_empty_plans_');
+});
+
+afterEach(async () => {
+  const { closeDb } = await import('../src/db.js');
+  closeDb();
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.KJ_HOME;
+  delete process.env.KJ_PLANS_DIR;
+  delete process.env.KJ_SHARED_PROJECT_DIRS;
+});
+
+describe('project name uniqueness (KJC-BUG-0163)', () => {
+  it('upsertProject throws when the name belongs to another project id', async () => {
+    const db = await import('../src/db.js');
+    db.initDb();
+    db.upsertProject({ id: 'proj_a', name: 'Mi Tienda', last_activity: '2026-09-06T00:00:00Z', total_stories: 1 });
+    expect(() =>
+      db.upsertProject({ id: 'proj_b', name: 'Mi Tienda', last_activity: '2026-09-06T00:00:00Z', total_stories: 1 }),
+    ).toThrow(/Mi Tienda/);
+    const names = db.getProjects().map((p) => p.id);
+    expect(names).toContain('proj_a');
+    expect(names).not.toContain('proj_b');
+  });
+
+  it('updating the SAME project id with its own name still works', async () => {
+    const db = await import('../src/db.js');
+    db.initDb();
+    db.upsertProject({ id: 'proj_a', name: 'Mi Tienda', last_activity: '2026-09-06T00:00:00Z', total_stories: 1 });
+    expect(() =>
+      db.upsertProject({ id: 'proj_a', name: 'Mi Tienda', last_activity: '2026-09-06T01:00:00Z', total_stories: 2 }),
+    ).not.toThrow();
+    expect(db.getProjects().length).toBe(1);
+  });
+
+  it('a name collision in one plan does not break the sync of the others', async () => {
+    // Two different dirs with the SAME basename derive the same name — the
+    // exact confusion the rule exists to surface.
+    const dirA = join(tmpDir, 'clones-a', 'mi-app');
+    const dirB = join(tmpDir, 'clones-b', 'mi-app');
+    const dirC = join(tmpDir, 'otra-cosa');
+    for (const [dir, planId] of [[dirA, 'plan-ua'], [dirB, 'plan-ub'], [dirC, 'plan-uc']]) {
+      const plansDir = join(dir, '.karajan-shared', 'plans');
+      mkdirSync(plansDir, { recursive: true });
+      writeFileSync(
+        join(plansDir, `${planId}.json`),
+        JSON.stringify({
+          version: 2, planId, task: 't', projectDir: dir, name: 'brain-backlog',
+          hus: [{ id: 'hu-1', status: 'pending', title: 'x' }],
+          status: 'draft', shared: true, createdAt: '2026-09-06T00:00:00Z',
+        }),
+      );
+    }
+    const db = await import('../src/db.js');
+    db.initDb();
+    const sync = await import('../src/sync.js');
+    // One scan that SEES all three plans (the multi-repo escape hatch) — a
+    // per-cwd sequence would trip orphan pruning instead of the name rule.
+    process.env.KJ_SHARED_PROJECT_DIRS = `${dirA}:${dirB}:${dirC}`;
+    await sync.fullScan();
+    const projects = db.getProjects();
+    // One "Mi App" registered, the clone rejected, "Otra Cosa" untouched.
+    expect(projects.filter((p) => p.name === 'Mi App').length).toBe(1);
+    expect(projects.some((p) => p.name === 'Otra Cosa')).toBe(true);
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0163 — norma a fuego: el nombre de proyecto es ÚNICO en el board

Orden directa del usuario: «JAMÁS poderse llamar igual. JAMÁS. Que dé error». Tras #1625 los nombres derivan del repo, pero dos clones con el mismo basename (o un plan renombrado a mano) podían seguir produciendo gemelos en el dashboard — exactamente la confusión vivida hoy.

- `upsertProject` (db.js): registrar un proyecto cuyo nombre ya pertenece a OTRO id lanza error ALTO nombrando ambos ids y la card de la regla. Actualizar el mismo id con su nombre sigue funcionando.
- El sync ya aísla errores por fichero de plan: el conflictivo se rechaza con log de error y los demás proyectos siguen sincronizando (test con el escape multi-repo KJ_SHARED_PROJECT_DIRS — la secuencia por cwd tropezaba con la poda de huérfanos, no con la regla).
- Sin desambiguación automática silenciosa: el error ES el aviso de que hay que nombrar mejor.

TDD (3 tests, rojo primero). Suite hu-board entera: 461/461. Review: APPROVED (codex, diff bfae2e5d1090).
