### PR TITLE
feat(board): two-level nav - generic vs project scope, no project select

### DIFF
--- a/packages/hu-board/public/app.js
+++ b/packages/hu-board/public/app.js
@@ -163,6 +163,9 @@ let lastOpenedLog = null;     // { id, label, tailUrl(offset) }
  */
 function navigate(view) {
   currentView = view;
+  // KJC-TSK-0820: going back to the Dashboard unloads the project — it is
+  // the only place where a (different) project gets picked.
+  if (view === 'dashboard' && !scopedProjectSlug) selectedProject = '';
   window.location.hash = selectedProject ? `${view}/${selectedProject}` : view;
 
   // Update active nav button
@@ -179,14 +182,43 @@ function navigate(view) {
  */
 function selectProject(projectId) {
   selectedProject = projectId;
-  document.getElementById('project-select').value = projectId;
   navigate('board');
+}
+
+/**
+ * KJC-TSK-0820 — two-level nav. Which nav bars are visible: the generic
+ * one always; the project sub-bar only while a project is loaded, and
+ * never on the Dashboard (that's where projects get picked). Pure.
+ * @param {string} view
+ * @param {string} projectId
+ * @returns {{ generic: boolean, project: boolean }}
+ */
+function projectNavVisibility(view, projectId) {
+  return { generic: true, project: Boolean(projectId) && view !== 'dashboard' };
+}
+
+/**
+ * Applies projectNavVisibility() to the DOM and stamps the loaded
+ * project's name on the sub-bar.
+ */
+function updateProjectNav() {
+  const bar = document.getElementById('project-nav');
+  if (!bar) return;
+  const visible = projectNavVisibility(currentView, selectedProject).project;
+  bar.hidden = !visible;
+  if (!visible) return;
+  const nameEl = document.getElementById('project-nav-name');
+  nameEl.textContent = projectNameCache[selectedProject] || humaniseProjectName(selectedProject);
+  resolveProjectMeta(selectedProject).then((meta) => {
+    if (meta.name) nameEl.textContent = meta.name;
+  });
 }
 
 /**
  * Renders the current view.
  */
 function render() {
+  updateProjectNav();
   switch (currentView) {
     case 'dashboard': return renderDashboard();
     case 'board': return renderBoard();
@@ -194,46 +226,6 @@ function render() {
     case 'graph': return renderGraph();
     case 'governance': return renderGovernance();
     default: return renderDashboard();
-  }
-}
-
-/**
- * Populates the project selector dropdown.
- */
-async function populateProjectSelect() {
-  try {
-    const projects = await api('/api/projects');
-    const select = document.getElementById('project-select');
-    // Which project should appear pre-selected? Order:
-    //   1. scopedProjectSlug (URL is /p/<slug>)  — locked, never changes
-    //   2. selectedProject (route state, ej. #board/<slug>)
-    //   3. ""                                    — "All Projects"
-    // PR-D: the previous version cleared innerHTML and never marked
-    // any option as selected, so the dropdown showed "All Projects"
-    // even when scoped to one. handleRoute() set .value separately
-    // BUT the value was lost in the race because the matching option
-    // didn't exist yet when handleRoute ran. Setting .selected on
-    // the option directly avoids the race.
-    const desired = scopedProjectSlug || selectedProject || '';
-    select.innerHTML = '';
-    const all = document.createElement('option');
-    all.value = '';
-    all.textContent = 'All Projects';
-    if (desired === '') all.selected = true;
-    select.appendChild(all);
-    for (const p of projects) {
-      const opt = document.createElement('option');
-      opt.value = p.id;
-      opt.textContent = p.name || p.id;
-      if (p.id === desired) opt.selected = true;
-      select.appendChild(opt);
-    }
-    // Final guard: if `desired` did not match any rendered option
-    // (project not on the board yet), still set the value so
-    // handleRoute's expectation holds.
-    if (desired) select.value = desired;
-  } catch {
-    // Silently fail — project list will be empty
   }
 }
 
@@ -248,13 +240,15 @@ function handleRoute() {
   // In scoped mode the project is locked — the hash controls the view
   // only. `board/<slug>` becomes `board` and the slug stays fixed.
   currentView = parts[0] || 'board';
-  selectedProject = scopedProjectSlug || parts[1] || '';
+  // Dashboard never carries a loaded project (KJC-TSK-0820): it is the
+  // project picker, so a `#dashboard/<slug>` deep-link drops the slug.
+  selectedProject = scopedProjectSlug
+    || (currentView === 'dashboard' ? '' : parts[1] || '');
 
   document.querySelectorAll('.nav-btn').forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.view === currentView);
   });
 
-  document.getElementById('project-select').value = selectedProject;
   render();
 }
 

--- a/packages/hu-board/public/index.html
+++ b/packages/hu-board/public/index.html
@@ -21,17 +21,7 @@
       </div>
     </div>
     <nav class="header__nav">
-      <button class="nav-btn active" data-view="board" title="Kanban board: every HU of the selected project, grouped by status (Pending → Certified → Done). Click an HU card to expand the detail panel.">Board</button>
-      <button class="nav-btn" data-view="graph" title="Dependency graph of the selected project's HUs — who blocks whom. Useful before scheduling work.">Graph</button>
-      <button class="nav-btn" data-view="dashboard" title="Per-project landing: stats grid + project list. Click a project card to focus the kanban / graph on that project.">Dashboard</button>
-      <button class="nav-btn" data-view="sessions" title="Every kj run that has touched the board, newest first. Filter by project; click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
-      <button class="nav-btn" data-view="governance" title="The acta: policy rules by friction, the hash-chained decision log and its anchor, standing exceptions with owner and expiry, renewals and signals.">Governance</button>
-      <a class="nav-btn" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
-      <a class="nav-btn" href="/rag.html" title="RAG retrieval-quality dashboard: chunk counts, embedder provider, db size.">RAG</a>
-      <a class="nav-btn" href="/wiki.html" title="Search the per-project QMD semantic wiki (docs, plans, reviews).">Wiki</a>
-      <select class="project-select" id="project-select">
-        <option value="">All Projects</option>
-      </select>
+      <button class="nav-btn active" data-view="dashboard" title="Per-project landing: stats grid + project list. Click a project card to load that project — its views appear in the project bar below.">Dashboard</button>
       <div class="header__controls">
         <button class="control-btn" id="help-btn" title="What does each view do? Quick reference for Board / Graph / Dashboard / Sessions / Pipeline.">?</button>
         <button class="control-btn" id="config-btn" title="Configurar Karajan (modelos, agentes, tope de iteraciones, …)">⚙</button>
@@ -43,6 +33,20 @@
       </div>
     </nav>
   </header>
+
+  <!-- KJC-TSK-0820: project sub-bar. Hidden until a project is loaded from
+       the dashboard; every entry here shows data of THAT project. Switching
+       projects = back to Dashboard (the select is gone on purpose). -->
+  <nav class="project-nav" id="project-nav" hidden>
+    <span class="project-nav__name" id="project-nav-name"></span>
+    <button class="nav-btn nav-btn--project" data-view="board" title="Kanban board: every HU of the loaded project, grouped by status (Pending → Certified → Done). Click an HU card to expand the detail panel.">Board</button>
+    <button class="nav-btn nav-btn--project" data-view="graph" title="Dependency graph of the loaded project's HUs — who blocks whom. Useful before scheduling work.">Graph</button>
+    <button class="nav-btn nav-btn--project" data-view="sessions" title="Every kj run of the loaded project, newest first. Click a session to inspect its iterations, commits and checkpoints.">Sessions</button>
+    <button class="nav-btn nav-btn--project" data-view="governance" title="The acta: policy rules by friction, the hash-chained decision log and its anchor, standing exceptions with owner and expiry, renewals and signals.">Governance</button>
+    <a class="nav-btn nav-btn--project" href="/pipeline.html" title="Live observability of pipeline runs (Karajan v2.7+): stage timings, agent calls, decision logs.">Pipeline</a>
+    <a class="nav-btn nav-btn--project" href="/rag.html" title="RAG retrieval-quality dashboard: chunk counts, embedder provider, db size.">RAG</a>
+    <a class="nav-btn nav-btn--project" href="/wiki.html" title="Search the per-project QMD semantic wiki (docs, plans, reviews).">Wiki</a>
+  </nav>
 
   <main class="main" id="app">
     <div class="loading">

--- a/packages/hu-board/public/styles.css
+++ b/packages/hu-board/public/styles.css
@@ -124,20 +124,36 @@ a:hover {
   border-color: var(--accent-purple);
 }
 
-.project-select {
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  color: var(--text-primary);
-  padding: 6px 12px;
-  border-radius: var(--radius-sm);
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  cursor: pointer;
+/* ---- Project sub-bar (KJC-TSK-0820) ----
+ * Second nav level, only visible while a project is loaded. Teal, not
+ * purple: project-scoped actions must read as a different tier from the
+ * generic header. */
+.project-nav {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 8px 24px;
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border);
 }
 
-.project-select:focus {
-  outline: none;
-  border-color: var(--accent-purple);
+.project-nav[hidden] {
+  display: none;
+}
+
+.project-nav__name {
+  color: var(--accent-teal);
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin-right: 8px;
+}
+
+.nav-btn--project:hover,
+.nav-btn--project.active {
+  background: var(--accent-teal-dim);
+  color: var(--bg-primary);
+  border-color: var(--accent-teal-dim);
 }
 
 .header__controls {
@@ -955,13 +971,12 @@ a:hover {
 /* ---- Scoped-project mode (URL: /p/<slug>) ---- */
 /* Hide multi-project affordances when the board is scoped to a single
  * project — the page only makes sense as "this project's Kanban".
- * Multi-project UX (the All Projects selector, the Sessions tab, the
+ * Multi-project UX (the Dashboard picker, the Sessions tab, the
  * Pipeline page link) adds noise and broke the user's mental model
  * during dogfooding. */
-body.scoped-mode .project-select,
 body.scoped-mode .nav-btn[data-view="sessions"],
 body.scoped-mode .nav-btn[data-view="dashboard"],
-body.scoped-mode .header__nav a[href="/pipeline.html"] {
+body.scoped-mode a[href="/pipeline.html"] {
   display: none;
 }
 

--- a/packages/hu-board/public/utils/graph-view.js
+++ b/packages/hu-board/public/utils/graph-view.js
@@ -99,7 +99,7 @@ async function renderGraph() {
   if (!selectedProject) {
     app.innerHTML = renderEmptyState(
       'Pick a project first',
-      'The dependency graph is per-project. Choose one in the dropdown above and I will draw its HU DAG.'
+      'The dependency graph is per-project. Pick one on the Dashboard and I will draw its HU DAG.'
     );
     return;
   }

--- a/packages/hu-board/public/utils/init-listeners.js
+++ b/packages/hu-board/public/utils/init-listeners.js
@@ -6,8 +6,7 @@
 // the boot block run.
 //
 // Globals consumed from earlier scripts / app.js:
-//   - navigate(), render(), handleRoute(),
-//     populateProjectSelect()         (app.js)
+//   - navigate(), render(), handleRoute() (app.js)
 //   - showCommandLauncher(),
 //     nextIsTestValue()               (utils/command-launcher.js)
 //   - showHelp(), showConfirm(),
@@ -32,13 +31,6 @@ document.querySelectorAll('.nav-btn').forEach((btn) => {
   btn.addEventListener('click', () => navigate(btn.dataset.view));
 });
 
-// Project selector
-document.getElementById('project-select').addEventListener('change', (e) => {
-  selectedProject = e.target.value;
-  window.location.hash = selectedProject ? `${currentView}/${selectedProject}` : currentView;
-  render();
-});
-
 // Sync button — re-scan disk for new batches
 document.getElementById('sync-btn').addEventListener('click', async () => {
   const btn = document.getElementById('sync-btn');
@@ -46,7 +38,6 @@ document.getElementById('sync-btn').addEventListener('click', async () => {
   btn.textContent = '⏳';
   try {
     await fetch('/api/sync', { method: 'POST' });
-    await populateProjectSelect();
     render();
   } catch { /* ignore */ }
   btn.textContent = '🔄';
@@ -106,7 +97,6 @@ document.addEventListener('click', async (e) => {
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     // Re-render the project list so the badge reflects the new value.
-    await populateProjectSelect();
     render();
   } catch (err) {
     await showError(err.message, { title: 'Failed to update is_test' });
@@ -130,7 +120,6 @@ document.addEventListener('click', async (e) => {
   try {
     const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: 'DELETE' });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    await populateProjectSelect();
     render();
   } catch (err) {
     await showError(err.message, { title: 'Failed to delete project' });
@@ -161,7 +150,6 @@ startStandbyPolling();
 
 // Initial load — sync disk data first so new batches are visible
 triggerSync().then(() => {
-  populateProjectSelect();
   handleRoute();
   subscribeToServerEvents();
 });
@@ -174,7 +162,6 @@ triggerSync().then(() => {
 refreshInterval = setInterval(async () => {
   if (document.getElementById('modal-backdrop').classList.contains('hidden')) {
     await triggerSync();
-    await populateProjectSelect();
     await smartRefresh(null);
   }
 }, 60_000);

--- a/packages/hu-board/public/utils/maggle-mode.js
+++ b/packages/hu-board/public/utils/maggle-mode.js
@@ -29,7 +29,7 @@ const MAGGLE_LABELS = {
   'nav.board': 'Tablero',
   'nav.dashboard': 'Proyectos',
   'nav.more': 'Más',
-  'picker.hint': 'Elige un proyecto para ver su tablero. Puedes cambiar de proyecto arriba a la derecha.',
+  'picker.hint': 'Elige un proyecto para ver su tablero. Para cambiar de proyecto, vuelve a «Proyectos».',
   'picker.project': 'proyecto',
   'launcher.title': '📝 Pedir trabajo a Karajan',
   'launcher.planLabel': '📝 Pedir trabajo nuevo',
@@ -86,7 +86,10 @@ function applyMaggleChrome() {
   if (!nav) return;
   const KEEP = { board: MAGGLE_LABELS['nav.board'], dashboard: MAGGLE_LABELS['nav.dashboard'] };
   const advanced = [];
-  for (const btn of nav.querySelectorAll('.nav-btn')) {
+  // KJC-TSK-0820: nav buttons live in TWO bars now — the generic header
+  // and the project sub-bar (#project-nav). Fold both; Tablero stays in
+  // the sub-bar so it only shows once a project is loaded.
+  for (const btn of document.querySelectorAll('.header__nav .nav-btn, .project-nav .nav-btn')) {
     const view = btn.dataset.view;
     if (view && KEEP[view]) {
       btn.title = `${btn.textContent.trim()} — ${btn.title}`;
@@ -118,8 +121,11 @@ function applyMaggleChrome() {
       expert.remove();
     }
   });
-  // After the LAST nav button, so the plain row reads Tablero | Proyectos | Más.
-  advanced.at(-1).after(more);
+  // In the GENERIC bar (before the control buttons), so the plain header
+  // reads Proyectos | Más and the sub-bar keeps only Tablero.
+  const controls = nav.querySelector('.header__controls');
+  if (controls) controls.before(more);
+  else nav.append(more);
 }
 
 if (typeof document !== 'undefined' && document.addEventListener) {

--- a/packages/hu-board/public/utils/project-actions.js
+++ b/packages/hu-board/public/utils/project-actions.js
@@ -11,8 +11,7 @@
 //   - formatDuration()            (utils/formatters.js)
 //   - projectNameCache            (mutable in app.js — assignment crosses
 //                                  scripts transparently)
-//   - populateProjectSelect()     (app.js)
-//   - renderBoard()               (app.js)
+//   - render()                    (app.js)
 
 /**
  * PR-G: rename a project from the header ✎ button. Opens a small
@@ -67,11 +66,11 @@ window.renameProjectModal = function renameProjectModal(projectId, currentName) 
         return;
       }
       // Update the cached display name + refresh the board so the
-      // header, dropdown and project picker all show the new value.
+      // header, project bar and project picker all show the new value.
       projectNameCache[projectId] = newName;
       try { dlg.close(); } catch { /* ignore */ }
-      await populateProjectSelect();
-      await renderBoard();
+      // render() (not renderBoard()) so the project bar name refreshes too.
+      await render();
     } catch (err) {
       errorEl.style.display = 'block';
       errorEl.textContent = err.message || String(err);

--- a/packages/hu-board/public/utils/project-picker-view.js
+++ b/packages/hu-board/public/utils/project-picker-view.js
@@ -74,7 +74,7 @@ async function renderProjectPicker() {
       <span class="section-header__count">${sorted.length} ${maggleText('picker.project', 'project')}${sorted.length === 1 ? '' : 's'}</span>
     </div>
     <p style="padding:8px 4px 16px;color:var(--text-muted);font-size:0.9rem">
-      ${maggleText('picker.hint', 'Pick a project to see its kanban. Use the project selector in the header to switch later.')}
+      ${maggleText('picker.hint', 'Pick a project to see its kanban. To switch later, go back to the Dashboard.')}
     </p>
     <div style="display:grid;grid-template-columns:repeat(auto-fill, minmax(320px, 1fr));gap:14px">
       ${sorted.map((p) => {

--- a/packages/hu-board/tests/two-level-nav.test.js
+++ b/packages/hu-board/tests/two-level-nav.test.js
@@ -1,0 +1,86 @@
+// KJC-TSK-0820 — two-level nav: generic top bar vs project sub-bar.
+//
+// The user's order: generic buttons (Dashboard) can never share a bar with
+// project-scoped ones (Board, Governance, …) — it made Governance look
+// global. The project sub-bar (#project-nav) appears only once a project
+// is loaded from the dashboard, and the confusing project <select> is gone:
+// the ONLY way to switch project is going back to the dashboard.
+//
+// index.html is a static file, so the contract is asserted structurally;
+// the visibility rule is a pure function in app.js, loaded via node:vm
+// (same pattern as maggle-mode.test.js — classic scripts, no exports).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const html = readFileSync(new URL('../public/index.html', import.meta.url), 'utf8');
+const appSrc = readFileSync(new URL('../public/app.js', import.meta.url), 'utf8');
+
+const headerNav = html.slice(
+  html.indexOf('<nav class="header__nav">'),
+  html.indexOf('</header>')
+);
+const projectNavStart = html.indexOf('id="project-nav"');
+const projectNav = projectNavStart === -1
+  ? ''
+  : html.slice(projectNavStart, html.indexOf('</nav>', projectNavStart));
+
+function loadApp() {
+  const ctx = { window: { location: { pathname: '/', hash: '' } } };
+  vm.createContext(ctx);
+  vm.runInContext(appSrc, ctx);
+  return ctx;
+}
+
+describe('two-level nav (KJC-TSK-0820)', () => {
+  it('the project <select> is gone — switching projects happens on the dashboard only', () => {
+    expect(html).not.toContain('project-select');
+  });
+
+  it('the generic top bar holds only entries not tied to one project', () => {
+    expect(headerNav).toContain('data-view="dashboard"');
+    for (const scoped of ['data-view="board"', 'data-view="graph"', 'data-view="sessions"', 'data-view="governance"', '/pipeline.html', '/rag.html', '/wiki.html']) {
+      expect(headerNav).not.toContain(scoped);
+    }
+  });
+
+  it('the project sub-bar holds every project-scoped entry plus the project name slot', () => {
+    expect(projectNav).not.toBe('');
+    expect(projectNav).toContain('id="project-nav-name"');
+    for (const scoped of ['data-view="board"', 'data-view="graph"', 'data-view="sessions"', 'data-view="governance"', '/pipeline.html', '/rag.html', '/wiki.html']) {
+      expect(projectNav).toContain(scoped);
+    }
+  });
+
+  it('project-scoped buttons carry their own visual level (nav-btn--project)', () => {
+    expect(projectNav).toContain('nav-btn--project');
+    expect(headerNav).not.toContain('nav-btn--project');
+  });
+
+  describe('projectNavVisibility (pure)', () => {
+    it('shows the project bar only when a project is loaded', () => {
+      const app = loadApp();
+      expect(app.projectNavVisibility('board', 'my-project')).toEqual({ generic: true, project: true });
+      expect(app.projectNavVisibility('board', '')).toEqual({ generic: true, project: false });
+    });
+
+    it('hides the project bar on the dashboard even with a project in the route', () => {
+      const app = loadApp();
+      expect(app.projectNavVisibility('dashboard', 'my-project')).toEqual({ generic: true, project: false });
+    });
+
+    it('the generic bar is always visible', () => {
+      const app = loadApp();
+      for (const view of ['board', 'dashboard', 'sessions', 'governance']) {
+        expect(app.projectNavVisibility(view, '').generic).toBe(true);
+      }
+    });
+  });
+
+  it('no orphan references to the removed select survive in the frontend scripts', () => {
+    for (const file of ['app.js', 'utils/init-listeners.js', 'utils/project-actions.js']) {
+      const src = readFileSync(new URL(`../public/${file}`, import.meta.url), 'utf8');
+      expect(src, `${file} still references the removed project select`).not.toMatch(/populateProjectSelect|project-select/);
+    }
+  });
+});


### PR DESCRIPTION
## KJC-TSK-0820 — two-level nav on the HU Board

User's order (verbatim):

> «En el menú no puede haber botones genéricos (como mostrar los proyectos) mezclados con específicos de proyecto (como governance), porque parece que governance es genérico. Primero, solo se muestren botones genéricos. Si selecciono en el dashboard un proyecto, cargas ese proyecto y aparecen, en otro color/nivel, los botones de cosas asociadas a ese proyecto. Solo se cambia de proyecto desde el dashboard: elimina el select que confunde.»

### What changed

- **Generic top bar**: only `Dashboard` (plus the control buttons). Nothing project-scoped lives there any more.
- **New project sub-bar** (`#project-nav`): `Board · Graph · Sessions · Governance · Pipeline · RAG · Wiki`, preceded by the loaded project's **name**. Hidden until a project is loaded from the dashboard; teal accent (`--accent-teal`) so it reads as a different tier from the purple header.
- **Project `<select>` removed**, along with all its JS (`populateProjectSelect`, the change listener, every call site). Switching projects = back to Dashboard, pick another. `navigate('dashboard')` and a `#dashboard/<slug>` deep-link both unload the project.
- **Maggle mode** (`/?maggle=1`) keeps its contract: folded header reads `Proyectos | Más`, and `Tablero` appears in the sub-bar only once a project is loaded. Verified live with Chrome DevTools (no console errors; Más toggle and expert link intact).
- Stale copy that pointed at the removed dropdown updated (picker hint EN/ES, graph empty state).

### Tests (TDD — red first)

`tests/two-level-nav.test.js` (9 tests): structural contract over `index.html` (select gone, generic vs project containers, `nav-btn--project` tier), pure `projectNavVisibility()` via `node:vm`, and a no-orphan-references sweep over the touched scripts. Full package suite: 465 passing; the single failure (`version.test.js` SPA fallback 404) is pre-existing on clean `main` in this environment.

Net delta: **+91 LOC** (184 insertions, 93 deletions). Cross-AI verdict: APPROVED by codex (diff `1bfe222755e4`).
