### PR TITLE
feat(harden): adr 0009 accepted - portable hook chaining via HOME

### DIFF
--- a/.karajan/adrs/0009-el-cauce-sancionado-del-supervisor-como-se-versiona-lo-que-kj-harden-regenera.md
+++ b/.karajan/adrs/0009-el-cauce-sancionado-del-supervisor-como-se-versiona-lo-que-kj-harden-regenera.md
@@ -1,7 +1,8 @@
 # El cauce sancionado del supervisor: como se versiona lo que kj harden regenera
 
-Status: proposed
+Status: accepted
 Date: 2026-09-06
+Accepted: 2026-09-06 (dev_001) — opcion A
 
 ## Context
 
@@ -25,5 +26,7 @@ C) Status quo documentado: aceptar el drift permanente y documentar que la copia
 A. La copia versionada tiene valor real (gates activos en cada clon desde el segundo cero — exactamente la promesa del harden) y la exencion estructural de A es deterministica y estrecha: no confia en nadie, recomputa. B queda como simplificacion futura si la familia decide que kj harden post-clone es contrato suficiente.
 
 ## Consequences
+
+Precision de implementacion (al aceptar): la recomputacion byte a byte solo es posible EN LA MAQUINA que corre kj harden — la generacion esta parametrizada (comandos nativos del stack, rama base, chaining del hook global). Por eso el contrato es: en local, kj harden --commit recomputa (trivial: lo que acaba de escribir ES lo canonico) y sella en el decision log la version de kj y el hash sha256 de cada fichero; los gates (review local y CI) verifican que cada fichero de supervisor tocado coincide con un hash sellado en el log Y que la cadena del log esta integra. La confianza se apoya en la raiz que ya existe (el acta hash-encadenada), no en poder regenerar en CI. Requisito previo: las plantillas no hornean rutas de maquina (chaining via $HOME — mismo contenido en todas partes).
 
 kj harden gana --commit (solo con TTY humano, jamas desde una sesion con CLAUDECODE/agente detectado); el decision log gana el sello de procedencia del supervisor; review-gate y kj-policy CI ganan la verificacion por recomputacion; KJC-BUG-0161 se implementa sobre esta decision. Los 3 ficheros hoy en drift serian el primer uso real del cauce.

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -8,6 +8,8 @@
  * is imposed on non-JS repos. See docs/specs/quality-harness.md §5.
  */
 
+import { homedir } from "node:os";
+
 const CONVENTIONAL_TYPES = "feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert";
 const AI_ATTRIBUTION = "co-authored-by:.*(claude|gpt|copilot|gemini)|(generated|written) (by|with) .*(claude|gpt|copilot)";
 
@@ -27,10 +29,18 @@ export const PROFILE_HOOKS = {
 // guarded, so machines without it are unaffected.
 function chainToGlobal(hook, globalHooksDir) {
   if (!globalHooksDir) return [];
+  // KJC-BUG-0161 (ADR 0009): a committed hook must not bake a machine's
+  // absolute home path — resolve through $HOME at runtime so the same
+  // generated content is valid on every machine and its provenance stays
+  // verifiable (and no local filesystem layout leaks into a public repo).
+  const home = homedir();
+  const dir = globalHooksDir === home || globalHooksDir.startsWith(`${home}/`)
+    ? `$HOME${globalHooksDir.slice(home.length)}`
+    : globalHooksDir;
   return [
     "# Chain the machine's previous global hook (kj harden keeps it active).",
-    `if [ -x "${globalHooksDir}/${hook}" ]; then`,
-    `  "${globalHooksDir}/${hook}" "$@"; rc=$?`,
+    `if [ -x "${dir}/${hook}" ]; then`,
+    `  "${dir}/${hook}" "$@"; rc=$?`,
     '  [ "$rc" -eq 0 ] || exit "$rc"',
     "fi",
   ];

--- a/tests/harden/hook-portability.test.js
+++ b/tests/harden/hook-portability.test.js
@@ -1,0 +1,32 @@
+// KJC-BUG-0161 / ADR 0009 — the committed hook must not bake a machine's
+// absolute home path: the chain to the user's previous global hooks resolves
+// through $HOME at runtime, so the SAME generated content is valid (and its
+// provenance verifiable) on every machine — and no local filesystem layout
+// leaks into a public repo.
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { hookBody } from "../../src/harden/hook-templates.js";
+
+describe("hook chaining is machine-portable (KJC-BUG-0161)", () => {
+  it("a global hooks dir under the home resolves through $HOME, never the literal path", () => {
+    const globalHooksDir = join(homedir(), ".git-hooks");
+    for (const hook of ["pre-commit", "commit-msg", "pre-push", "post-merge"]) {
+      const body = hookBody(hook, {}, { globalHooksDir });
+      expect(body, `${hook} bakes the literal home path`).not.toContain(homedir());
+      expect(body).toContain(`"$HOME/.git-hooks/${hook}"`);
+    }
+  });
+
+  it("a global hooks dir OUTSIDE the home stays literal — there is nothing to normalize", () => {
+    const body = hookBody("pre-commit", {}, { globalHooksDir: "/opt/git-hooks" });
+    expect(body).toContain('"/opt/git-hooks/pre-commit"');
+  });
+
+  it("no global dir, no chain — unchanged behavior", () => {
+    const body = hookBody("pre-commit", {}, {});
+    expect(body).not.toContain(".git-hooks");
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0161 (1/3) — ADR 0009 aceptado (opción A) + plantillas portables

El usuario aceptó el ADR 0009 con la opción A: `kj harden --commit` humano con sello de procedencia en el acta encadenada, y gates que verifican hash-contra-sello (la precisión de implementación queda registrada en el propio ADR: la recomputación es local; CI confía en la raíz de confianza que ya existe — el decision log hash-encadenado).

Esta pieza trae el requisito previo: **las plantillas de hooks dejan de hornear rutas de máquina**. El chaining al hook global del usuario resolvía con la ruta absoluta (`/home/<usuario>/.git-hooks/...`) — mismo contenido inválido en otra máquina, procedencia inverificable, y el layout local filtrado a un repo público. Ahora resuelve vía `$HOME` en runtime (solo cuando el dir está bajo el home; fuera del home queda literal).

Piezas 2/3 (sello + --commit) y 3/3 (exención estructural en gates local y CI) en PRs serie.

TDD (3 tests, rojo primero); suites de hooks afectadas verdes (26/26). Review: APPROVED (codex, diff ccc3c2c9ed0c).
