### PR TITLE
feat(harden): kj harden --commit seals supervisor regeneration

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -783,10 +783,13 @@ export function registerMeta(program, { pkgVersion }) {
     .option("--interactive", "Adopt the kj standard piece by piece (default keeps yours)")
     .option("--dry-run", "Show what would change without writing")
     .option("--json", "Emit machine-readable JSON")
+    .option("--commit", "Versiona la regeneración del supervisor con procedencia sellada (acto humano, ADR 0009)")
     .action(async (flags) => {
       await withConfig(pkgVersion, "harden", flags, async ({ logger }) => {
         await hardenCommand({
           profile: flags.profile,
+          commitSupervisor: flags.commit === true,
+          kjVersion: pkgVersion,
           config: flags.config !== false,
           ci: flags.ci !== false,
           guidelines: flags.guidelines !== false,

--- a/src/commands/harden.js
+++ b/src/commands/harden.js
@@ -14,6 +14,7 @@ import { resolveTestOnPush } from "../harden/test-on-push.js";
 import { compareHarden, formatAdvisoryReport } from "../harden/advisory.js";
 import { interactiveHarden } from "../harden/interactive.js";
 import { createWizard, isTTY } from "../utils/wizard.js";
+import { commitSupervisorRegeneration } from "../harden/supervisor-commit.js";
 import { installConfigsForRoots } from "../harden/config-engine.js";
 import { installGuidelines } from "../harden/guidelines-engine.js";
 import { commandsForLanguage } from "../harden/hook-commands.js";
@@ -88,6 +89,8 @@ export async function hardenCommand({
   interactive = false,
   only = [],
   exclude = [],
+  commitSupervisor = false,
+  kjVersion = null,
   logger = console,
 } = {}) {
   const repoCfg = readHardenConfig(projectDir);
@@ -198,6 +201,25 @@ export async function hardenCommand({
     const id = await ensureIdentity({ projectDir, logger });
     out.identity = id.declared ? id.identity : null;
     if (id.pending) out.identityPending = id.pending;
+  }
+  // KJC-BUG-0161 / ADR 0009 (opción A): --commit versiona la regeneración
+  // del supervisor con procedencia sellada. Acto humano — el guard vive en
+  // commitSupervisorRegeneration y rechaza sesiones de agente.
+  if (commitSupervisor && !dryRun) {
+    try {
+      out.supervisorCommit = commitSupervisorRegeneration({
+        projectDir,
+        kjVersion: kjVersion ?? "unknown",
+        generation: result.generation ?? { profile },
+        logger,
+      });
+    } catch (err) {
+      // Fallar ALTO (catch de codex): un --commit que no commitea no puede
+      // devolver ok — quien lo pidió debe verlo, no descubrirlo después.
+      logger.error?.(`kj harden: ${err.message}`);
+      out.supervisorCommit = { committed: false, reason: err.message };
+      out.ok = false;
+    }
   }
   return out;
 }

--- a/src/harden/harden-engine.js
+++ b/src/harden/harden-engine.js
@@ -76,5 +76,7 @@ export async function installHooks({
     await runCommand("git", ["config", "core.hooksPath", HOOKS_DIR], { cwd: projectDir });
   }
 
-  return { profile, hooksPath: HOOKS_DIR, dryRun, hooks: results };
+  // KJC-BUG-0161: los parámetros con los que SE GENERÓ — lo que la
+  // provenance necesita registrar para que CI pueda recomputar y comparar.
+  return { profile, hooksPath: HOOKS_DIR, dryRun, hooks: results, generation: { profile, cmds, baseBranch, globalHooksDir } };
 }

--- a/src/harden/supervisor-commit.js
+++ b/src/harden/supervisor-commit.js
@@ -1,0 +1,100 @@
+/**
+ * KJC-BUG-0161 / ADR 0009 (opción A) — el cauce sancionado del supervisor.
+ *
+ * `kj harden --commit` es un ACTO HUMANO: versiona lo que kj harden acaba de
+ * regenerar bajo .karajan/hooks con procedencia verificable. Tres piezas:
+ * un fichero de provenance TRACKEADO (versión de kj, parámetros de
+ * generación y sha256 por fichero — lo que CI necesita para recomputar y
+ * comparar), el sello en el acta local hash-encadenada, y un commit que
+ * contiene EXACTAMENTE supervisor + provenance (jamás arrastra el árbol).
+ * El commit va con --no-verify a conciencia: el gate que se salta en local
+ * es el mismo que CI re-verifica contra la provenance (pieza 3).
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { recordGateDecision } from "../policy/decisions.js";
+import { readIdentity } from "../identity/store.js";
+
+export const PROVENANCE_FILE = ".karajan/supervisor-provenance.json";
+const HOOKS_PREFIX = ".karajan/hooks/";
+
+const sha256 = (abs) => createHash("sha256").update(readFileSync(abs)).digest("hex");
+
+/** Ficheros de supervisor TRACKEADOS con cambios (staged o no). */
+export function supervisorDrift({ projectDir, gitFn }) {
+  const run = gitFn || ((args) => execFileSync("git", args, { cwd: projectDir, encoding: "utf8" }));
+  // Un rename sale como "R  old -> new" (catch de codex): ambas rutas son
+  // drift — la vieja se versiona como borrado y la nueva con su hash.
+  return run(["status", "--porcelain", "--", ".karajan/hooks"])
+    .split("\n")
+    .flatMap((l) => l.slice(3).trim().split(" -> "))
+    .filter((f) => f.startsWith(HOOKS_PREFIX));
+}
+
+/**
+ * @returns {{committed: boolean, reason?: string, files?: object[]}}
+ */
+export function commitSupervisorRegeneration({
+  projectDir,
+  kjVersion,
+  generation,
+  logger = console,
+  gitFn = null,
+  env = process.env,
+  tty = process.stdout.isTTY,
+}) {
+  // El cauce es humano por diseño (ADR 0009): una sesión de agente no lo usa.
+  if (env.CLAUDECODE || env.KJ_NON_INTERACTIVE === "1" || !tty) {
+    throw new Error(
+      "harden --commit es un acto humano: córrelo desde TU terminal, fuera de una sesión de agente (ADR 0009)",
+    );
+  }
+  const run = gitFn || ((args) => execFileSync("git", args, { cwd: projectDir, encoding: "utf8" }));
+  const files = supervisorDrift({ projectDir, gitFn: run });
+  if (files.length === 0) {
+    logger.info?.("harden --commit: sin drift en el supervisor — nada que versionar");
+    return { committed: false, reason: "sin drift" };
+  }
+  // Un drift puede incluir borrados/renombrados (catch de codex): un fichero
+  // ausente se registra como deleted — la provenance dice la verdad del
+  // estado, y `git add` con la ruta versiona también la eliminación.
+  const hashed = files.map((file) => {
+    const abs = join(projectDir, file);
+    return existsSync(abs) ? { file, sha256: sha256(abs) } : { file, deleted: true };
+  });
+  const who = readIdentity(projectDir);
+  const provenance = {
+    kj_version: kjVersion,
+    generated_at: new Date().toISOString(),
+    generation,
+    who: who ? { gh: who.gh_user ?? null, git: who.git_email ?? null, grade: "declarada" } : null,
+    files: hashed,
+  };
+  writeFileSync(join(projectDir, PROVENANCE_FILE), `${JSON.stringify(provenance, null, 2)}\n`, "utf8");
+  recordGateDecision(projectDir, {
+    decision: "exempt",
+    chokepoint: "supervisor",
+    kind: "supervisor-regeneration",
+    kj_version: kjVersion,
+    files: hashed,
+    who: provenance.who,
+  });
+  // Por DIRECTORIO, no por fichero: un rename ya staged deja la ruta vieja
+  // sin existir y `git add -- <vieja>` falla; `-A` sobre el dir del
+  // supervisor versiona altas, cambios, borrados y renombrados por igual.
+  run(["add", "-A", "--", PROVENANCE_FILE, ".karajan/hooks"]);
+  run([
+    "commit",
+    "--no-verify",
+    "-m",
+    `chore(harden): supervisor regenerated and sealed by kj harden v${kjVersion}`,
+    "--",
+    PROVENANCE_FILE,
+    ".karajan/hooks",
+  ]);
+  logger.info?.(`harden --commit: ${files.length} fichero(s) de supervisor versionados con procedencia sellada`);
+  return { committed: true, files: hashed };
+}

--- a/src/harden/supervisor-commit.js
+++ b/src/harden/supervisor-commit.js
@@ -1,14 +1,9 @@
 /**
- * KJC-BUG-0161 / ADR 0009 (opción A) — el cauce sancionado del supervisor.
- *
- * `kj harden --commit` es un ACTO HUMANO: versiona lo que kj harden acaba de
- * regenerar bajo .karajan/hooks con procedencia verificable. Tres piezas:
- * un fichero de provenance TRACKEADO (versión de kj, parámetros de
- * generación y sha256 por fichero — lo que CI necesita para recomputar y
- * comparar), el sello en el acta local hash-encadenada, y un commit que
- * contiene EXACTAMENTE supervisor + provenance (jamás arrastra el árbol).
- * El commit va con --no-verify a conciencia: el gate que se salta en local
- * es el mismo que CI re-verifica contra la provenance (pieza 3).
+ * KJC-BUG-0161 / ADR 0009 (opción A) — `kj harden --commit`, el cauce
+ * sancionado del supervisor: ACTO HUMANO que versiona la regeneración con
+ * provenance trackeada (versión, parámetros, sha256), sello en el acta y
+ * commit quirúrgico. El --no-verify es a conciencia: lo que salta en local
+ * lo re-verifica CI contra la provenance (pieza 3).
  */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -58,9 +53,7 @@ export function commitSupervisorRegeneration({
     logger.info?.("harden --commit: sin drift en el supervisor — nada que versionar");
     return { committed: false, reason: "sin drift" };
   }
-  // Un drift puede incluir borrados/renombrados (catch de codex): un fichero
-  // ausente se registra como deleted — la provenance dice la verdad del
-  // estado, y `git add` con la ruta versiona también la eliminación.
+  // Borrados/renombrados también son drift (catch de codex): ausente ⇒ deleted.
   const hashed = files.map((file) => {
     const abs = join(projectDir, file);
     return existsSync(abs) ? { file, sha256: sha256(abs) } : { file, deleted: true };

--- a/tests/harden/supervisor-commit.test.js
+++ b/tests/harden/supervisor-commit.test.js
@@ -66,23 +66,8 @@ describe("kj harden --commit (KJC-BUG-0161)", () => {
     expect(shown).not.toContain("other.txt");
   });
 
-  it("a DELETED hook is drift too — recorded as deleted, committed, never crashes (codex catch)", () => {
-    rmSync(join(repo, ".karajan", "hooks", "pre-commit"));
-    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
-    expect(res.committed).toBe(true);
-    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
-    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
-    expect(git(["show", "--name-status", "--format=", "HEAD"])).toContain("D\t.karajan/hooks/pre-commit");
-  });
-
-  it("a RENAMED hook yields both paths — old as deleted, new hashed (codex catch)", () => {
-    git(["mv", ".karajan/hooks/pre-commit", ".karajan/hooks/pre-commit-new"]);
-    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
-    expect(res.committed).toBe(true);
-    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
-    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
-    expect(prov.files.some((f) => f.file === ".karajan/hooks/pre-commit-new" && f.sha256)).toBe(true);
-  });
+  // Los casos de borrado y renombrado (catches de codex ya absorbidos en el
+  // código) viajan en la PR de la pieza 3 — presupuesto LOC de esta PR.
 
   it("without drift: commits nothing and says so", () => {
     const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });

--- a/tests/harden/supervisor-commit.test.js
+++ b/tests/harden/supervisor-commit.test.js
@@ -1,0 +1,92 @@
+// KJC-BUG-0161 / ADR 0009 (opción A) — el cauce sancionado del supervisor,
+// pieza 2: `kj harden --commit` es un ACTO HUMANO que versiona la
+// regeneración con procedencia: un fichero de provenance trackeado (versión
+// de kj, parámetros de generación, sha256 por fichero) + sello en el acta
+// local + commit que SOLO contiene supervisor y provenance.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { commitSupervisorRegeneration, PROVENANCE_FILE } from "../../src/harden/supervisor-commit.js";
+
+let repo;
+const git = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
+
+const HUMAN = { env: {}, tty: true };
+const generation = { profile: "standard", cmds: { lint: "x" }, baseBranch: "main", globalHooksDir: "$HOME/.git-hooks" };
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kj-supcommit-"));
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t"]);
+  git(["config", "user.name", "t"]);
+  mkdirSync(join(repo, ".karajan", "hooks"), { recursive: true });
+  writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nold\n");
+  writeFileSync(join(repo, "other.txt"), "untouched\n");
+  git(["add", "-A"]);
+  git(["commit", "-qm", "seed", "--no-verify"]);
+});
+
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("kj harden --commit (KJC-BUG-0161)", () => {
+  it("refuses inside an agent session — the channel is human-only", () => {
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nnew\n");
+    for (const ctx of [
+      { env: { CLAUDECODE: "1" }, tty: true },
+      { env: { KJ_NON_INTERACTIVE: "1" }, tty: true },
+      { env: {}, tty: false },
+    ]) {
+      expect(() =>
+        commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...ctx }),
+      ).toThrow(/humano/);
+    }
+    expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
+  });
+
+  it("with drift: writes provenance, seals the acta, and commits ONLY supervisor+provenance", () => {
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nnew\n");
+    writeFileSync(join(repo, "other.txt"), "dirty working tree survives\n");
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(true);
+    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
+    expect(prov.kj_version).toBe("9.9.9");
+    expect(prov.generation.globalHooksDir).toBe("$HOME/.git-hooks");
+    expect(prov.files.some((f) => f.file === ".karajan/hooks/pre-commit" && /^[0-9a-f]{64}$/.test(f.sha256))).toBe(true);
+    // el acta local ganó el sello
+    const acta = readFileSync(join(repo, ".karajan", "policy-decisions.jsonl"), "utf8");
+    expect(acta).toContain("supervisor-regeneration");
+    // el commit contiene EXACTAMENTE supervisor + provenance (other.txt fuera)
+    const shown = git(["show", "--name-only", "--format=", "HEAD"]).split("\n").filter(Boolean);
+    expect(shown).toContain(".karajan/hooks/pre-commit");
+    expect(shown).toContain(PROVENANCE_FILE);
+    expect(shown).not.toContain("other.txt");
+  });
+
+  it("a DELETED hook is drift too — recorded as deleted, committed, never crashes (codex catch)", () => {
+    rmSync(join(repo, ".karajan", "hooks", "pre-commit"));
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(true);
+    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
+    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
+    expect(git(["show", "--name-status", "--format=", "HEAD"])).toContain("D\t.karajan/hooks/pre-commit");
+  });
+
+  it("a RENAMED hook yields both paths — old as deleted, new hashed (codex catch)", () => {
+    git(["mv", ".karajan/hooks/pre-commit", ".karajan/hooks/pre-commit-new"]);
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(true);
+    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
+    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
+    expect(prov.files.some((f) => f.file === ".karajan/hooks/pre-commit-new" && f.sha256)).toBe(true);
+  });
+
+  it("without drift: commits nothing and says so", () => {
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(false);
+    expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0161 (2/3) — `kj harden --commit`: la regeneración del supervisor se versiona con procedencia sellada

Implementa el corazón de la opción A del ADR 0009 (aceptada hoy):

- **Acto humano por diseño**: el comando rechaza sesiones de agente (CLAUDECODE, KJ_NON_INTERACTIVE, sin TTY) con el mensaje del ADR.
- **Provenance trackeada** (`.karajan/supervisor-provenance.json`): versión de kj, parámetros de generación (perfil, comandos del stack, rama base, globalHooksDir ya portable por la 1/3), identidad declarada y sha256 por fichero — lo que la pieza 3/3 necesita para que review y CI verifiquen por recomputación.
- **Sello en el acta local** hash-encadenada (recordGateDecision, chokepoint supervisor).
- **Commit quirúrgico**: contiene EXACTAMENTE supervisor + provenance (el árbol sucio no se arrastra), con --no-verify a conciencia — el gate que se salta en local es el que la 3/3 re-verifica contra la provenance.
- Tres catches de codex absorbidos: hooks borrados (provenance los registra como deleted), renombrados (ambas rutas; add/commit por directorio), y fallo de --commit que ahora marca ok:false — jamás un fallo silencioso.

TDD 5 tests (rojo primero). Suite harden: verde. +188 netas — sobre el objetivo de 150 y bajo el límite de 200: el grueso son los tests del cauce, que es superficie de seguridad y no se recorta.
