### PR TITLE
feat(policy): structural supervisor verification by recomputation

### DIFF
--- a/src/harden/harden-engine.js
+++ b/src/harden/harden-engine.js
@@ -23,6 +23,24 @@ export function isGitRepo(projectDir) {
 }
 
 /**
+ * KJC-BUG-0161 / ADR 0009: el contenido CANÓNICO de un hook para una
+ * generación dada — exactamente lo que installHooks escribiría partiendo
+ * de cero. La verificación estructural del supervisor recomputa esto y
+ * compara por hash: un fichero con una sola coma manual ya no coincide.
+ */
+export function renderCanonicalHook(hook, generation = {}) {
+  const { cmds = {}, baseBranch = null, globalHooksDir = null } = generation;
+  const { content } = upsertManagedBlock({
+    source: HOOK_PREAMBLE,
+    blockId: `hook:${hook}`,
+    version: BLOCK_VERSION,
+    body: hookBody(hook, cmds, { globalHooksDir, baseBranch }),
+    style: "hash",
+  });
+  return content;
+}
+
+/**
  * Install (or refresh) the profile's hooks under `.karajan/hooks/` and point
  * `core.hooksPath` there. Idempotent. `dryRun` computes actions without
  * touching disk or git config. `cmds` supplies stack-aware lint/format/test

--- a/src/policy/supervisor-verify.js
+++ b/src/policy/supervisor-verify.js
@@ -1,0 +1,79 @@
+/**
+ * KJC-BUG-0161 / ADR 0009, pieza 3 — exención ESTRUCTURAL del supervisor:
+ * un fichero de .karajan/hooks solo deja de ser violación si su contenido
+ * coincide (sha256) con la provenance sellada Y con el render canónico
+ * recomputado. No confía: recomputa. Una coma manual sigue denegada.
+ */
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync } from "node:fs";
+import { resolve, sep } from "node:path";
+
+import { renderCanonicalHook } from "../harden/harden-engine.js";
+import { PROVENANCE_FILE } from "../harden/supervisor-commit.js";
+
+const HOOKS_PREFIX = ".karajan/hooks/";
+// globalHooksDir es el único texto libre que se interpola en el render:
+// vocabulario cerrado de ruta o la provenance no verifica NADA.
+const SAFE_DIR = /^(\$HOME)?(\/[\w.@%+~-]+)+$/;
+
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
+
+/**
+ * @returns {{files: Set<string>, reason?: string}} rutas repo-relativas de
+ * supervisor cuyo estado actual está respaldado por la provenance sellada.
+ */
+export function verifiedSupervisorFiles({ projectDir }) {
+  let prov;
+  try {
+    prov = JSON.parse(readFileSync(resolve(projectDir, PROVENANCE_FILE), "utf8"));
+  } catch {
+    return { files: new Set(), reason: "sin provenance" };
+  }
+  const gen = prov?.generation ?? {};
+  if (gen.globalHooksDir != null && !SAFE_DIR.test(gen.globalHooksDir)) {
+    return { files: new Set(), reason: "globalHooksDir no verificable en la provenance" };
+  }
+  const ok = new Set();
+  const entries = Array.isArray(prov?.files) ? prov.files : [];
+  const hooksRoot = resolve(projectDir, HOOKS_PREFIX);
+  for (const entry of entries) {
+    if (typeof entry?.file !== "string" || !entry.file.startsWith(HOOKS_PREFIX)) continue;
+    // Contención por resolución, no por prefijo textual (catch de codex).
+    const abs = resolve(projectDir, entry.file);
+    if (!abs.startsWith(hooksRoot + sep)) continue;
+    let st = null;
+    try { st = lstatSync(abs); } catch { /* no hay objeto en la ruta */ }
+    if (entry.deleted === true) {
+      if (st === null) ok.add(entry.file);
+      continue;
+    }
+    if (typeof entry.sha256 !== "string" || !st?.isFile()) continue;
+    if (sha256(readFileSync(abs)) !== entry.sha256) continue;
+    let canonical;
+    try {
+      canonical = renderCanonicalHook(entry.file.slice(HOOKS_PREFIX.length), gen);
+    } catch {
+      continue;
+    }
+    if (sha256(Buffer.from(canonical, "utf8")) === entry.sha256) ok.add(entry.file);
+  }
+  // `complete` = CADA entrada verificó: solo entonces la provenance se
+  // describe con honestidad y su propio diff puede alzarse.
+  const complete = entries.length > 0 && entries.every((e) => typeof e?.file === "string" && ok.has(e.file));
+  return { files: ok, complete };
+}
+
+/** Filtra violaciones de supervisor respaldadas — {violations, lifted}. */
+export function liftSealedSupervisorViolations({ projectDir, violations }) {
+  const RULE = "defaults.supervisor.write";
+  if (!violations.some((v) => v.rule_id === RULE && v.file)) return { violations, lifted: 0 };
+  const sealed = verifiedSupervisorFiles({ projectDir });
+  // La violación sobre la PROPIA provenance solo se alza si la provenance
+  // entera verificó — a medias no describe la verdad y sigue denegada.
+  const liftable = (v) =>
+    v.rule_id === RULE
+    && v.file
+    && (sealed.files.has(v.file) || (v.file === PROVENANCE_FILE && sealed.complete === true));
+  const kept = violations.filter((v) => !liftable(v));
+  return { violations: kept, lifted: violations.length - kept.length };
+}

--- a/tests/policy/supervisor-verify.test.js
+++ b/tests/policy/supervisor-verify.test.js
@@ -1,0 +1,102 @@
+// KJC-BUG-0161 / ADR 0009 — verifica por RECOMPUTACIÓN, o nada.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { renderCanonicalHook } from "../../src/harden/harden-engine.js";
+import { PROVENANCE_FILE } from "../../src/harden/supervisor-commit.js";
+import { liftSealedSupervisorViolations, verifiedSupervisorFiles } from "../../src/policy/supervisor-verify.js";
+
+let repo;
+const sha = (s) => createHash("sha256").update(Buffer.from(s, "utf8")).digest("hex");
+const generation = { profile: "standard", cmds: {}, baseBranch: "main", globalHooksDir: "$HOME/.git-hooks" };
+
+const writeProvenance = (files, gen = generation) =>
+  writeFileSync(join(repo, PROVENANCE_FILE), JSON.stringify({ kj_version: "9.9.9", generation: gen, files }));
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kj-supverify-"));
+  mkdirSync(join(repo, ".karajan", "hooks"), { recursive: true });
+});
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("verifiedSupervisorFiles (ADR 0009)", () => {
+  it("a pure regeneration verifies: file == provenance == canonical render", () => {
+    const canonical = renderCanonicalHook("pre-commit", generation);
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), canonical);
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(canonical) }]);
+    expect(verifiedSupervisorFiles({ projectDir: repo }).files.has(".karajan/hooks/pre-commit")).toBe(true);
+  });
+
+  it("one manual comma breaks it: hash matches provenance but not the canonical render", () => {
+    const edited = `${renderCanonicalHook("pre-commit", generation)}# manual\n`;
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), edited);
+    // provenance «honesta» con el hash del fichero editado — aun así NO
+    // verifica: el render canónico no coincide.
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(edited) }]);
+    expect(verifiedSupervisorFiles({ projectDir: repo }).files.size).toBe(0);
+  });
+
+  it("a tampered file after sealing does not verify (hash mismatch)", () => {
+    const canonical = renderCanonicalHook("pre-commit", generation);
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), `${canonical}\nrm -rf importante\n`);
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(canonical) }]);
+    expect(verifiedSupervisorFiles({ projectDir: repo }).files.size).toBe(0);
+  });
+
+  it("a hostile globalHooksDir in the provenance verifies NOTHING", () => {
+    const gen = { ...generation, globalHooksDir: '$HOME/x"; rm -rf /; "' };
+    const canonical = renderCanonicalHook("pre-commit", generation);
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), canonical);
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(canonical) }], gen);
+    const res = verifiedSupervisorFiles({ projectDir: repo });
+    expect(res.files.size).toBe(0);
+    expect(res.reason).toMatch(/globalHooksDir/);
+  });
+
+  it("a sealed deletion verifies only while the file stays gone; escapes never verify", () => {
+    writeProvenance([
+      { file: ".karajan/hooks/post-merge", deleted: true },
+      { file: "src/index.js", sha256: sha("x") },
+      { file: ".karajan/hooks/../../evil.sh", sha256: sha("x") },
+    ]);
+    const res = verifiedSupervisorFiles({ projectDir: repo });
+    expect(res.files.has(".karajan/hooks/post-merge")).toBe(true);
+    expect(res.files.has("src/index.js")).toBe(false);
+    expect(res.files.has(".karajan/hooks/../../evil.sh")).toBe(false);
+  });
+});
+
+describe("liftSealedSupervisorViolations", () => {
+  it("lifts only the sealed supervisor violations, keeps the rest", () => {
+    const canonical = renderCanonicalHook("pre-commit", generation);
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), canonical);
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(canonical) }]);
+    const violations = [
+      { rule_id: "defaults.supervisor.write", file: ".karajan/hooks/pre-commit", reason: "x" },
+      { rule_id: "defaults.supervisor.write", file: ".karajan/hooks/pre-push", reason: "x" },
+      { rule_id: "loc-budget", reason: "y" },
+    ];
+    const res = liftSealedSupervisorViolations({ projectDir: repo, violations });
+    expect(res.lifted).toBe(1);
+    expect(res.violations.map((v) => v.file ?? v.rule_id)).toEqual([".karajan/hooks/pre-push", "loc-budget"]);
+  });
+
+  it("the provenance file itself lifts ONLY when the whole provenance verified", () => {
+    const canonical = renderCanonicalHook("pre-commit", generation);
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), canonical);
+    const provViolation = { rule_id: "defaults.supervisor.write", file: PROVENANCE_FILE, reason: "x" };
+    // provenance completa y verificada → su propio diff se alza
+    writeProvenance([{ file: ".karajan/hooks/pre-commit", sha256: sha(canonical) }]);
+    expect(liftSealedSupervisorViolations({ projectDir: repo, violations: [provViolation] }).lifted).toBe(1);
+    // provenance con una entrada que NO verifica → la provenance sigue denegada
+    writeProvenance([
+      { file: ".karajan/hooks/pre-commit", sha256: sha(canonical) },
+      { file: ".karajan/hooks/pre-push", sha256: sha("otra cosa") },
+    ]);
+    expect(liftSealedSupervisorViolations({ projectDir: repo, violations: [provViolation] }).lifted).toBe(0);
+  });
+});


### PR DESCRIPTION
## KJC-BUG-0161 (3a) — la verificación estructural del supervisor: recomputa, no confía

El módulo que hace verdad la exención del ADR 0009: un fichero de `.karajan/hooks` solo se considera respaldado si su contenido coincide (sha256) con la provenance sellada **y** con el render canónico que este kj recompute para esa generación — una coma manual sigue denegada. La propia provenance solo se alza cuando verifica ENTERA.

Tres catches de codex absorbidos en la pasada: path traversal (contención por resolución de rutas, no por prefijo textual), symlinks (lstat + isFile — un enlace no es un hook), y symlink roto que se hacía pasar por borrado (existsSync fuera). `globalHooksDir` con vocabulario cerrado: una provenance hostil no verifica nada y jamás se interpola a ciegas.

Incluye `renderCanonicalHook` exportado del motor. El CABLEADO (review local + policy check de CI + la superficie de la provenance en los defaults del supervisor) va en la 3b, siguiente PR de la serie.

TDD 7 tests. Review: APPROVED (codex, diff c6f4ad65a5f2). +199 netas.
