### PR TITLE
feat(harden): the human channel enforced end to end

### DIFF
--- a/src/commands/policy.js
+++ b/src/commands/policy.js
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { checkStagedDiff, evalToolCall, loadPolicy } from "../policy/engine.js";
+import { liftSealedSupervisorViolations } from "../policy/supervisor-verify.js";
 import { loadExceptionRecords, loadGlobalExceptionRecords, loadStandingExceptions, recordPolicyException } from "../policy/exceptions.js";
 import { buildPolicyReport } from "../policy/report.js";
 import { policyFileHash, recordGateDecision } from "../policy/decisions.js";
@@ -231,7 +232,14 @@ export async function policyCommand({ action, config = {}, flags = {}, logger = 
   // --strict (PL-C): con --strict, una violación enforcement=deny devuelve
   // exit 2 nombrando la regla — el contrato merge-blocking del tier C.
   const facts = await stagedFacts(projectDir, deps.gitFn, flags.range || null);
-  const violations = checkStagedDiff(policy, { role: flags.role || "coder", ...facts });
+  let violations = checkStagedDiff(policy, { role: flags.role || "coder", ...facts });
+  // ADR 0009 (KJC-BUG-0161): en CI la misma exención estructural que en la
+  // review — supervisor respaldado por provenance sellada + render canónico.
+  const sup = liftSealedSupervisorViolations({ projectDir, violations });
+  if (sup.lifted > 0) {
+    logger.info?.(`✓ policy: ${sup.lifted} fichero(s) de supervisor verificados contra la provenance sellada (ADR 0009)`);
+    violations = sup.violations;
+  }
   const hard = flags.strict ? violations.filter((v) => v.enforcement === "deny") : [];
   if (flags.json) {
     logger.info?.(JSON.stringify({ mode: flags.strict ? "strict" : "warn", violations }));

--- a/src/commands/review-gate.js
+++ b/src/commands/review-gate.js
@@ -15,6 +15,7 @@ import { ensureGateTrackable } from "../review/gate-gitignore.js";
 import { runSonarPregate, formatSonarFinding, addedLinesByFile } from "../review/sonar-pregate.js";
 import { runMutationPregate, formatSurvivor } from "../review/mutation-pregate.js";
 import { checkCardFirst } from "../review/card-first.js";
+import { liftSealedSupervisorViolations } from "../policy/supervisor-verify.js";
 import { checkTestsWithCode } from "../review/tests-with-code.js";
 import { loadPrivacyList, scanText } from "../privacy/scan.js";
 import { checkStagedDiff, loadPolicy } from "../policy/engine.js";
@@ -262,6 +263,17 @@ export async function reviewGateCommand({ config, logger = null, flags = {} }) {
     recordException: (entry) => recordPolicyException({ projectDir, entry }),
     standingExceptions: std.standing,
   });
+  // ADR 0009 (KJC-BUG-0161): la exención ESTRUCTURAL del supervisor — un
+  // diff de .karajan/hooks respaldado por la provenance sellada Y el render
+  // canónico no es una edición: es la regeneración de kj harden --commit.
+  {
+    const res = liftSealedSupervisorViolations({ projectDir, violations: gate.denials });
+    if (res.lifted > 0) {
+      console.log(`✓ policy: ${res.lifted} fichero(s) de supervisor verificados contra la provenance sellada (ADR 0009) — regeneración, no edición`);
+      gate.denials = res.violations;
+      gate.ok = gate.denials.length === 0 && !gate.invalid;
+    }
+  }
   const at = (v) => (v.file ? ` (${v.file})` : "");
   for (const w of gate.warns) console.log(`⚠ policy [${w.rule_id}] ${w.reason}${at(w)}`);
   for (const e of gate.exempted) console.log(formatExempted(e));

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -371,6 +371,20 @@ process.stdin.on("end", () => {
       console.error("karajan sentinel: los ficheros del supervisor no se tocan desde Bash — consultalos con la tool Read/Grep; solo el humano los modifica, fuera de la sesion." + doc("supervisor"));
       process.exit(2);
     }
+    // ADR 0009 (KJC-BUG-0161): kj harden --commit es un ACTO HUMANO — la
+    // sesion ni lo intenta. Sin escape (superficie de supervisor). includes()
+    // a proposito: cero ambiguedad de escapes en plantilla, y fail-closed
+    // (mencionarlo en un argumento tambien bloquea: preferible a un hueco).
+    // ANTES de KJ_SENTINEL_OFF a proposito, como el guard PROTECTED de
+    // arriba: un env var lo pone tambien un agente — el supervisor no se
+    // apaga con interruptores al alcance del supervisado.
+    {
+      const kjCmd = String(input.command || "");
+      if (tool === "Bash" && kjCmd.includes("harden") && kjCmd.includes("--commit")) {
+        console.error("karajan sentinel: kj harden --commit es un acto humano (ADR 0009) — pideselo a tu usuario; ninguna sesion de agente lo ejecuta." + doc("supervisor"));
+        process.exit(2);
+      }
+    }
     if (process.env.KJ_SENTINEL_OFF === "1") process.exit(0);
     // KJC-BUG-0142: cada deny anuncia su escape como prefijo del comando
     // (KJ_ALLOW_X=1 cmd), pero el hook corre con el env del HOST — el

--- a/src/harden/supervisor-commit.js
+++ b/src/harden/supervisor-commit.js
@@ -18,6 +18,29 @@ const HOOKS_PREFIX = ".karajan/hooks/";
 
 const sha256 = (abs) => createHash("sha256").update(readFileSync(abs)).digest("hex");
 
+// Capa 3 del acto humano (test adversarial del 6-sep): un pty falso engaña a
+// isTTY y `env -u` borra CLAUDECODE, pero el kj que lanza un agente DESCIENDE
+// de su proceso — y eso está en /proc lo falsifique quien lo falsifique.
+const AGENT_PROC = /claude|codex|copilot|gemini|opencode|\bagy\b/i;
+export function agentAncestry({ pid = process.pid, readProc = null, maxDepth = 40 } = {}) {
+  const read = readProc || ((p) => {
+    const stat = readFileSync(`/proc/${p}/stat`, "utf8");
+    const ppid = Number(stat.slice(stat.lastIndexOf(")") + 2).split(" ")[1]);
+    let cmd = "";
+    try { cmd = readFileSync(`/proc/${p}/cmdline`).toString("utf8").replaceAll("\0", " "); } catch { /* gone */ }
+    return { ppid, cmd };
+  });
+  let cur = pid;
+  for (let i = 0; i < maxDepth && cur > 1; i += 1) {
+    let info;
+    try { info = read(cur); } catch { return { agent: false, unknown: true }; }
+    if (info?.cmd && AGENT_PROC.test(info.cmd)) return { agent: true, match: info.cmd.slice(0, 80) };
+    if (!Number.isFinite(info?.ppid) || info.ppid === cur) break;
+    cur = info.ppid;
+  }
+  return { agent: false };
+}
+
 /** Ficheros de supervisor TRACKEADOS con cambios (staged o no). */
 export function supervisorDrift({ projectDir, gitFn }) {
   const run = gitFn || ((args) => execFileSync("git", args, { cwd: projectDir, encoding: "utf8" }));
@@ -40,11 +63,18 @@ export function commitSupervisorRegeneration({
   gitFn = null,
   env = process.env,
   tty = process.stdout.isTTY,
+  deps = {},
 }) {
   // El cauce es humano por diseño (ADR 0009): una sesión de agente no lo usa.
   if (env.CLAUDECODE || env.KJ_NON_INTERACTIVE === "1" || !tty) {
     throw new Error(
       "harden --commit es un acto humano: córrelo desde TU terminal, fuera de una sesión de agente (ADR 0009)",
+    );
+  }
+  const anc = agentAncestry(deps.ancestry ?? {});
+  if (anc.agent) {
+    throw new Error(
+      `harden --commit es un acto humano y este proceso desciende de un agente (${anc.match}) — ni con pty falso ni con el entorno limpio (ADR 0009)`,
     );
   }
   const run = gitFn || ((args) => execFileSync("git", args, { cwd: projectDir, encoding: "utf8" }));

--- a/src/policy/engine.js
+++ b/src/policy/engine.js
@@ -25,7 +25,9 @@ import {
 export const SUPERVISOR_DEFAULTS = [
   {
     id: "defaults.supervisor.write",
-    pattern: /\.claude\/settings\.json\b|\.karajan\/(hooks|harness)\//,
+    // ADR 0009: la provenance del supervisor es superficie de supervisor —
+    // un agente no la escribe; solo kj harden --commit (humano) la produce.
+    pattern: /\.claude\/settings\.json\b|\.karajan\/(hooks|harness)\/|\.karajan\/supervisor-provenance\.json\b/,
     message: "nombra ficheros del supervisor — solo el humano los modifica, fuera de la sesión",
   },
 ];

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -115,6 +115,16 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
     gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
   });
 
+  it("ADR 0009: kj harden --commit es acto humano — la sesion lo tiene denegado SIN escape", () => {
+    for (const command of ["kj harden --commit", "KJ_ALLOW_CROSS_LANE=1 kj harden --profile strict --commit"]) {
+      const blocked = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command } });
+      expect(blocked.status).toBe(2);
+      expect(blocked.stderr).toMatch(/acto humano/);
+    }
+    // harden a secas sigue permitido (la regeneracion local es legitima).
+    expect(run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command: "kj harden --report" } }).status).toBe(0);
+  });
+
   it("INF-A: editar un .tf en rama sin card se deniega igual que un .js", () => {
     execSync("git checkout -q -b sin-card", { cwd: dir });
     const blocked = run(gate, editTool(path.join(dir, "main.tf")));

--- a/tests/harden/supervisor-commit.test.js
+++ b/tests/harden/supervisor-commit.test.js
@@ -15,7 +15,11 @@ import { commitSupervisorRegeneration, PROVENANCE_FILE } from "../../src/harden/
 let repo;
 const git = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" });
 
-const HUMAN = { env: {}, tty: true };
+// Cadena de procesos HUMANA inyectada: bash ← sshd ← init. Sin inyectar, la
+// ascendencia REAL de la suite (que corre bajo un agente) rechazaría — que es
+// exactamente lo que la capa debe hacer.
+const humanChain = { 100: { ppid: 50, cmd: "bash" }, 50: { ppid: 1, cmd: "sshd: manu@pts/0" } };
+const HUMAN = { env: {}, tty: true, deps: { ancestry: { pid: 100, readProc: (p) => humanChain[p] ?? { ppid: 1, cmd: "init" } } } };
 const generation = { profile: "standard", cmds: { lint: "x" }, baseBranch: "main", globalHooksDir: "$HOME/.git-hooks" };
 
 beforeEach(() => {
@@ -47,6 +51,20 @@ describe("kj harden --commit (KJC-BUG-0161)", () => {
     expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
   });
 
+  it("a faked pty with a clean env still refuses: the process DESCENDS from an agent", () => {
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nnew\n");
+    // script(1) + env -u: tty=true y env limpio — pero la cadena de procesos
+    // delata al agente: script ← sh ← node(claude).
+    const chain = { 200: { ppid: 150, cmd: "script -qec kj harden --commit" }, 150: { ppid: 120, cmd: "sh" }, 120: { ppid: 1, cmd: "node /usr/lib/claude-code/cli.js" } };
+    expect(() =>
+      commitSupervisorRegeneration({
+        projectDir: repo, kjVersion: "9.9.9", generation, env: {}, tty: true,
+        deps: { ancestry: { pid: 200, readProc: (p) => chain[p] ?? { ppid: 1, cmd: "init" } } },
+      }),
+    ).toThrow(/desciende de un agente/);
+    expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
+  });
+
   it("with drift: writes provenance, seals the acta, and commits ONLY supervisor+provenance", () => {
     writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nnew\n");
     writeFileSync(join(repo, "other.txt"), "dirty working tree survives\n");
@@ -66,8 +84,23 @@ describe("kj harden --commit (KJC-BUG-0161)", () => {
     expect(shown).not.toContain("other.txt");
   });
 
-  // Los casos de borrado y renombrado (catches de codex ya absorbidos en el
-  // código) viajan en la PR de la pieza 3 — presupuesto LOC de esta PR.
+  it("a DELETED hook is drift too — recorded as deleted, committed (codex catch)", () => {
+    rmSync(join(repo, ".karajan", "hooks", "pre-commit"));
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(true);
+    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
+    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
+    expect(git(["show", "--name-status", "--format=", "HEAD"])).toContain("D\t.karajan/hooks/pre-commit");
+  });
+
+  it("a RENAMED hook yields both paths — old as deleted, new hashed (codex catch)", () => {
+    git(["mv", ".karajan/hooks/pre-commit", ".karajan/hooks/pre-commit-new"]);
+    const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });
+    expect(res.committed).toBe(true);
+    const prov = JSON.parse(readFileSync(join(repo, PROVENANCE_FILE), "utf8"));
+    expect(prov.files).toContainEqual({ file: ".karajan/hooks/pre-commit", deleted: true });
+    expect(prov.files.some((f) => f.file === ".karajan/hooks/pre-commit-new" && f.sha256)).toBe(true);
+  });
 
   it("without drift: commits nothing and says so", () => {
     const res = commitSupervisorRegeneration({ projectDir: repo, kjVersion: "9.9.9", generation, ...HUMAN });


### PR DESCRIPTION
## KJC-BUG-0161 (final) — el cauce humano, aplicado de punta a punta

Cierra la serie del ADR 0009 con el enforcement y las capas nacidas del test adversarial que ordenó el usuario («quiero probar que no puedes, ni aunque yo te lo ordene»):

- **Cableado de la exención estructural** en los tres puntos: review local, `kj policy check` de CI, y la provenance añadida a la superficie del supervisor (un agente tampoco puede escribirla; su violación solo se alza cuando la provenance verifica ENTERA).
- **Capa de ascendencia de procesos**: un pty falso engaña a isTTY y `env -u` borra la variable, pero el kj lanzado por un agente DESCIENDE de su proceso y /proc lo cuenta — rechazo con el nombre del ancestro delator. Con test de la cadena `script ← sh ← node(claude)`.
- **Bloqueo en la puerta del Sentinel**: la sesión ni siquiera ejecuta el comando (`includes()` sin ambigüedad de escapes, fail-closed — mencionarlo en un argumento también bloquea, y así se AUTOPROBÓ en vivo: bloqueó un comando legítimo de esta misma sesión que citaba la frase). Deliberadamente ANTES del kill-switch de entorno, como el guard vecino: el supervisor no se apaga con interruptores al alcance del supervisado.
- Dos hallazgos de codex en la pasada: uno absorbido (orden respecto al kill-switch, hecho intención explícita) y uno resuelto eliminando la ambigüedad de raíz (regex→includes) tras un arbitraje donde Solomon se puso del lado del revisor — como debe ser en sabor seguridad.

Suites harden+policy: 318/318. `kj audit --security` limpio. +114 netas.

Con esto merged: re-ataque completo al sandbox y, verificado el rechazo total, release y primer `kj harden --commit` del usuario.
