### PR TITLE
fix(harden): layer 4 - a random nonce typed back on the real tty

### DIFF
--- a/src/harden/supervisor-commit.js
+++ b/src/harden/supervisor-commit.js
@@ -7,7 +7,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { recordGateDecision } from "../policy/decisions.js";
@@ -39,6 +39,21 @@ export function agentAncestry({ pid = process.pid, readProc = null, maxDepth = 4
     cur = info.ppid;
   }
   return { agent: false };
+}
+
+// Lee la respuesta del nonce de la TTY REAL del proceso (no de stdin, que un
+// atacante alimenta por pipe): /dev/tty solo existe con terminal de control.
+function defaultConfirm(nonce) {
+  process.stdout.write(`harden --commit: teclea "${nonce}" para confirmar que eres humano: `);
+  try {
+    const buf = Buffer.alloc(64);
+    const fd = openSync("/dev/tty", "r");
+    const n = readSync(fd, buf, 0, 64);
+    closeSync(fd);
+    return buf.toString("utf8", 0, n).trim();
+  } catch {
+    return null;
+  }
 }
 
 /** Ficheros de supervisor TRACKEADOS con cambios (staged o no). */
@@ -76,6 +91,15 @@ export function commitSupervisorRegeneration({
     throw new Error(
       `harden --commit es un acto humano y este proceso desciende de un agente (${anc.match}) — ni con pty falso ni con el entorno limpio (ADR 0009)`,
     );
+  }
+  // Capa 4 (test adversarial 6-sep: un huérfano a init con pty falso y
+  // prompts a ciegas llegó hasta aquí): nonce aleatorio tecleado de vuelta.
+  // Un alimentador ciego no conoce el código; automatizar su lectura exige
+  // un driver expect — premeditación inequívoca, no un descuido.
+  const nonce = createHash("sha256").update(String(Math.random())).digest("hex").slice(0, 6);
+  const answer = (deps.confirm ?? defaultConfirm)(nonce);
+  if (answer !== nonce) {
+    throw new Error(`harden --commit: confirmación humana fallida (esperaba "${nonce}") — ADR 0009`);
   }
   const run = gitFn || ((args) => execFileSync("git", args, { cwd: projectDir, encoding: "utf8" }));
   const files = supervisorDrift({ projectDir, gitFn: run });

--- a/tests/harden/supervisor-commit.test.js
+++ b/tests/harden/supervisor-commit.test.js
@@ -19,7 +19,7 @@ const git = (args) => execFileSync("git", args, { cwd: repo, encoding: "utf8" })
 // ascendencia REAL de la suite (que corre bajo un agente) rechazaría — que es
 // exactamente lo que la capa debe hacer.
 const humanChain = { 100: { ppid: 50, cmd: "bash" }, 50: { ppid: 1, cmd: "sshd: manu@pts/0" } };
-const HUMAN = { env: {}, tty: true, deps: { ancestry: { pid: 100, readProc: (p) => humanChain[p] ?? { ppid: 1, cmd: "init" } } } };
+const HUMAN = { env: {}, tty: true, deps: { confirm: (n) => n, ancestry: { pid: 100, readProc: (p) => humanChain[p] ?? { ppid: 1, cmd: "init" } } } };
 const generation = { profile: "standard", cmds: { lint: "x" }, baseBranch: "main", globalHooksDir: "$HOME/.git-hooks" };
 
 beforeEach(() => {
@@ -62,6 +62,16 @@ describe("kj harden --commit (KJC-BUG-0161)", () => {
         deps: { ancestry: { pid: 200, readProc: (p) => chain[p] ?? { ppid: 1, cmd: "init" } } },
       }),
     ).toThrow(/desciende de un agente/);
+    expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
+  });
+
+  it("a blind prompt-feeder fails the nonce: layer 4 refuses (adversarial catch, 6-sep)", () => {
+    writeFileSync(join(repo, ".karajan", "hooks", "pre-commit"), "#!/bin/sh\nnew\n");
+    for (const confirm of [() => "\n", () => "yes", () => null]) {
+      expect(() =>
+        commitSupervisorRegeneration({ ...HUMAN, projectDir: repo, kjVersion: "9.9.9", generation, deps: { ...HUMAN.deps, confirm } }),
+      ).toThrow(/confirmación humana fallida/);
+    }
     expect(git(["log", "--oneline"]).split("\n").filter(Boolean).length).toBe(1);
   });
 


### PR DESCRIPTION
## KJC-BUG-0161 — capa 4: nonce aleatorio tecleado en la TTY real

Del re-ataque adversarial ordenado por el usuario: un proceso HUÉRFANO (doble fork a init) con pty falso, entorno limpio y prompts alimentados a ciegas atravesó las capas 1-3 y commiteó en el sandbox. Capa 4: nonce aleatorio de 6 caracteres que debe teclearse de vuelta, leído de `/dev/tty` (la TTY REAL del proceso de control, no stdin — el pipe de un alimentador no la tiene). Un feeder ciego no conoce el código; automatizar su lectura exige un driver expect — premeditación inequívoca, no un descuido. Test con los tres feeders ciegos típicos.

KJC-BUG-0161 / ADR 0009. Review: APPROVED (codex, diff c02d14bb064e). +36 netas. Tras el merge: batería adversarial completa re-ejecutada y documento final.
