### PR TITLE
ci(policy): pin kj to 4.27.0 so the supervisor exemption runs in ci

### DIFF
--- a/.github/workflows/kj-policy.yml
+++ b/.github/workflows/kj-policy.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ -f bin/kj.js ]; then npm ci --ignore-scripts && KJ="node bin/kj.js"; else KJ="npx --yes karajan-code@4.25.0"; fi
+          if [ -f bin/kj.js ]; then npm ci --ignore-scripts && KJ="node bin/kj.js"; else KJ="npx --yes karajan-code@4.27.0"; fi
           $KJ policy check --range "origin/${BASE_REF}...HEAD" --strict
 
 # <<< kj:managed:wf-policy <<<


### PR DESCRIPTION
El estreno de la pieza 3 en CI (#1637) falló policy-check: el workflow corre npx pineado a 4.26.0, que no lleva la exención estructural (salió en 4.27.0). El harden del usuario actualizó el pin en el árbol, pero el cauce del supervisor solo versiona supervisor+provenance — el pin quedó sin subir. Una línea. KJC-BUG-0161.

Nota aparte para el usuario: policy-check no es required en branch protection (por eso #1637 mergeó pese al rojo) — decidir si debe serlo.
