### PR TITLE
feat(harden): phone-signed supervisor seal - the key never touches this machine (1/3)

### DIFF
--- a/src/cli/register-meta.js
+++ b/src/cli/register-meta.js
@@ -148,6 +148,15 @@ export function registerMeta(program, { pkgVersion }) {
         process.exitCode = await identityCommand({ action: "set", config, flags });
       });
     });
+  identityCmd
+    .command("enroll-phone")
+    .description("Enroll the phone's PUBLIC signing key (base64 of the raw 32-byte ed25519 key) for the supervisor seal")
+    .argument("<publicKeyBase64>", "raw ed25519 public key, base64 (shown by the phone app)")
+    .action(async (publicKeyBase64, flags) => {
+      await withConfig(pkgVersion, "identity-enroll-phone", flags, async ({ config }) => {
+        process.exitCode = await identityCommand({ action: "enroll-phone", config, flags: { ...flags, publicKeyBase64 } });
+      });
+    });
 
   // MGL-A (KJC-TSK-0808): the muggle launcher — one command, at most one
   // question, and the person lands inside a governed conversation.

--- a/src/commands/identity.js
+++ b/src/commands/identity.js
@@ -8,6 +8,7 @@
  *           no session and no flags → exit 1.
  */
 
+import { enrollPhone } from "../harden/phone-sign.js";
 import { readIdentity, writeIdentity } from "../identity/store.js";
 import { activeGhUser, effectiveGitEmail } from "../identity/detect.js";
 import { compareIdentity } from "../identity/compare.js";
@@ -22,6 +23,18 @@ export async function identityCommand({ action = "show", config, flags = {}, dep
     gh_user: activeGhUser(detectOpts.hostsPath ? { hostsPath: detectOpts.hostsPath } : {}),
     git_email: effectiveGitEmail(projectDir, detectOpts.gitFn ? { gitFn: detectOpts.gitFn } : {}),
   };
+
+  // KJC-TSK-0822: enrola la clave PÚBLICA del móvil (la privada nunca toca esta máquina).
+  if (action === "enroll-phone") {
+    try {
+      enrollPhone(flags.publicKeyBase64, { home: deps.home });
+    } catch (err) {
+      log(`kj identity enroll-phone: ${err.message}`);
+      return 1;
+    }
+    log("Móvil enrolado: la clave pública quedó en ~/.karajan/supervisor-phone.json. A partir de ahora, sellar el supervisor pedirá la firma de tu móvil.");
+    return 0;
+  }
 
   if (action === "set") {
     const candidate = { gh_user: flags.gh || effective.gh_user, git_email: flags.email || effective.git_email };

--- a/src/harden/phone-sign.js
+++ b/src/harden/phone-sign.js
@@ -1,0 +1,43 @@
+/**
+ * KJC-TSK-0822 (PRP-0023) — capa 5 del sello del supervisor: firma asimétrica
+ * desde el móvil. La clave privada vive SOLO en el teléfono; aquí se enrola su
+ * clave PÚBLICA (~/.karajan/supervisor-phone.json) y se verifica ed25519
+ * contra ella — el transporte (Firestore, PR siguiente) nunca es la verdad.
+ */
+import { createHash, createPublicKey, verify } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+const phoneKeyPath = (home) => join(home ?? homedir(), ".karajan", "supervisor-phone.json");
+
+export const isPhoneEnrolled = ({ home } = {}) => existsSync(phoneKeyPath(home));
+
+export const readEnrolledKey = ({ home } = {}) =>
+  JSON.parse(readFileSync(phoneKeyPath(home), "utf8")).publicKey;
+
+/** Valida y persiste la clave pública del móvil (base64 del raw de 32 bytes). */
+export function enrollPhone(publicKeyBase64, { home } = {}) {
+  const raw = Buffer.from(publicKeyBase64 ?? "", "base64");
+  if (raw.length !== 32 || raw.toString("base64") !== publicKeyBase64) {
+    throw new Error("la clave debe ser base64 canónico de EXACTAMENTE 32 bytes (ed25519 raw)");
+  }
+  mkdirSync(join(phoneKeyPath(home), ".."), { recursive: true });
+  const record = { publicKey: publicKeyBase64, enrolledAt: new Date().toISOString() };
+  writeFileSync(phoneKeyPath(home), `${JSON.stringify(record, null, 2)}\n`, "utf8");
+}
+
+/** Payload canónico firmado: files EXACTAMENTE como se enviaron, JSON sin espacios. */
+export function canonicalPayload({ cid, nonce, project, files }) {
+  const filesHash = createHash("sha256").update(JSON.stringify(files)).digest("hex");
+  return `kj-supervisor-sign:v1:${cid}:${nonce}:${project}:${filesHash}`;
+}
+
+/** Verifica la firma (base64) del payload contra la clave pública raw (base64). */
+export function verifyPhoneSignature({ payload, signature, publicKey }) {
+  const der = Buffer.concat([SPKI_ED25519_PREFIX, Buffer.from(publicKey, "base64")]);
+  const key = createPublicKey({ key: der, format: "der", type: "spki" });
+  return verify(null, Buffer.from(payload, "utf8"), key, Buffer.from(signature, "base64"));
+}

--- a/tests/harden/phone-sign.test.js
+++ b/tests/harden/phone-sign.test.js
@@ -1,0 +1,68 @@
+// KJC-TSK-0822 (PRP-0023) — capa 5 del sello del supervisor: firma ed25519
+// desde el móvil. La clave privada JAMÁS toca esta máquina: aquí se prueba el
+// núcleo — payload canónico byte-estable, enrolamiento validado y verificación
+// contra una firma REAL generada con node:crypto.
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  canonicalPayload, enrollPhone, isPhoneEnrolled, readEnrolledKey, verifyPhoneSignature,
+} from "../../src/harden/phone-sign.js";
+
+const FILES = [
+  { file: ".karajan/hooks/pre-commit", sha256: "ab".repeat(32) },
+  { file: ".karajan/hooks/pre-push", sha256: "cd".repeat(32) },
+];
+const CID = "00112233445566778899aabbccddeeff";
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const rawPub = publicKey.export({ type: "spki", format: "der" }).subarray(-32).toString("base64");
+const signPayload = (payload, key = privateKey) => cryptoSign(null, Buffer.from(payload, "utf8"), key).toString("base64");
+
+let home;
+beforeEach(() => { home = mkdtempSync(join(tmpdir(), "kj-phone-")); });
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+describe("phone-sign core (KJC-TSK-0822)", () => {
+  it("canonical payload is byte-stable for a fixed case", () => {
+    expect(canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES })).toBe(
+      `kj-supervisor-sign:v1:${CID}:cafebabe:karajan-code:e9c991f428490467c3e17bd131444bc350f49957e7ca24c16ac2b9bdfe0c159d`,
+    );
+  });
+
+  it("enroll validates base64 of EXACTLY 32 bytes and persists the key", () => {
+    for (const bad of ["", "no es base64!!", Buffer.alloc(31).toString("base64"), Buffer.alloc(33).toString("base64")]) {
+      expect(() => enrollPhone(bad, { home })).toThrow(/32 bytes/);
+    }
+    expect(isPhoneEnrolled({ home })).toBe(false);
+    enrollPhone(rawPub, { home });
+    expect(isPhoneEnrolled({ home })).toBe(true);
+    expect(readEnrolledKey({ home })).toBe(rawPub);
+    expect(JSON.parse(readFileSync(join(home, ".karajan", "supervisor-phone.json"), "utf8")).enrolledAt).toBeTruthy();
+  });
+
+  it("accepts a REAL ed25519 signature over the canonical payload", () => {
+    const payload = canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES });
+    expect(verifyPhoneSignature({ payload, signature: signPayload(payload), publicKey: rawPub })).toBe(true);
+  });
+
+  it("rejects a tampered signature and a signature from another key", () => {
+    const payload = canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES });
+    const sig = Buffer.from(signPayload(payload), "base64");
+    sig[0] ^= 1;
+    expect(verifyPhoneSignature({ payload, signature: sig.toString("base64"), publicKey: rawPub })).toBe(false);
+    const other = generateKeyPairSync("ed25519");
+    expect(verifyPhoneSignature({ payload, signature: signPayload(payload, other.privateKey), publicKey: rawPub })).toBe(false);
+  });
+
+  it("rejects a valid signature over a DIFFERENT payload (files reordered)", () => {
+    const payload = canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES });
+    const reordered = canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES.toReversed() });
+    expect(reordered).not.toBe(payload);
+    expect(verifyPhoneSignature({ payload: reordered, signature: signPayload(payload), publicKey: rawPub })).toBe(false);
+  });
+});

--- a/tests/identity/compare-command.test.js
+++ b/tests/identity/compare-command.test.js
@@ -50,6 +50,19 @@ describe("kj identity show|set", () => {
   });
   beforeEach(() => { lines = []; });
 
+  // KJC-TSK-0822: enroll-phone valida y confirma en llano; clave mala ⇒ exit 1.
+  it("enroll-phone guarda la clave del móvil y rechaza una que no sea 32 bytes", async () => {
+    const good = Buffer.alloc(32, 7).toString("base64");
+    const run = (publicKeyBase64) =>
+      identityCommand({ action: "enroll-phone", config: { projectDir: dir }, flags: { publicKeyBase64 }, deps: { ...deps(), home: dir } });
+    expect(await run("corta")).toBe(1);
+    expect(lines.join("\n")).toMatch(/32 bytes/);
+    expect(await run(good)).toBe(0);
+    const saved = JSON.parse(fs.readFileSync(path.join(dir, ".karajan", "supervisor-phone.json"), "utf8"));
+    expect(saved.publicKey).toBe(good);
+    expect(lines.join("\n")).toMatch(/enrolado/i);
+  });
+
   it("set --yes ata lo efectivo AVISANDO y show lo marca ACTIVA", async () => {
     expect(await identityCommand({ action: "set", config: { projectDir: dir }, flags: { yes: true }, deps: deps() })).toBe(0);
     expect(readIdentity(dir)).toMatchObject({ gh_user: "manufosela", git_email: "a@b.c" });


### PR DESCRIPTION
## KJC-TSK-0822 · carril B · PR 1/3 — phone-sign core

Capa 5 del sello del supervisor (PRP-0023): firma asimétrica desde el móvil — **la clave privada jamás toca esta máquina**. Esta primera PR de la serie trae el núcleo sin red:

- `src/harden/phone-sign.js`: payload canónico `kj-supervisor-sign:v1:<cid>:<nonce>:<project>:<sha256(files JSON)>` byte-estable; enrolamiento de la clave pública del móvil en `~/.karajan/supervisor-phone.json` validando base64 canónico de EXACTAMENTE 32 bytes (ed25519 raw); verificación ed25519 convirtiendo el raw a SPKI DER con el prefijo fijo `302a300506032b6570032100`.
- `kj identity enroll-phone <publicKeyBase64>`: registra la clave y confirma en llano.
- Tests: snapshot del payload para un caso fijo; firma REAL generada con `node:crypto` aceptada; firma alterada, de otra clave y sobre payload distinto (files reordenados) rechazadas; validación base64/longitud del enroll (módulo y comando).

Serie (jamás apiladas — cada una se corta de main tras mergear la anterior):
1. **Esta**: núcleo + enroll (146 netas).
2. Petición Firestore + QR + poll + TTL (`requestPhoneSignature`, dep `qrcode-terminal`).
3. Integración obligatoria en el sello del supervisor cuando hay móvil enrolado.

Review: APPROVED by codex (diff e5dfc0f4d1b2). Los avisos de privacy son falsos positivos sobre constantes hex (prefijo SPKI y cid de fixture).
