### PR TITLE
feat(harden): phone-sign request - firestore doc, qr and poll (2/3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karajan-code",
-  "version": "4.24.0",
+  "version": "4.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karajan-code",
-      "version": "4.24.0",
+      "version": "4.27.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "workspaces": [
@@ -32,6 +32,7 @@
         "karajan-rag": "^1.2.0",
         "knip": "^6.15.0",
         "madge": "^8.0.0",
+        "qrcode-terminal": "0.12.0",
         "sqlite-vec": "^0.1.9",
         "valibot": "^1.4.1",
         "web-tree-sitter": "^0.26.9",
@@ -6939,6 +6940,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "karajan-rag": "^1.2.0",
     "knip": "^6.15.0",
     "madge": "^8.0.0",
+    "qrcode-terminal": "0.12.0",
     "sqlite-vec": "^0.1.9",
     "valibot": "^1.4.1",
     "web-tree-sitter": "^0.26.9",

--- a/src/harden/phone-sign.js
+++ b/src/harden/phone-sign.js
@@ -4,12 +4,19 @@
  * clave PÚBLICA (~/.karajan/supervisor-phone.json) y se verifica ed25519
  * contra ella — el transporte (Firestore, PR siguiente) nunca es la verdad.
  */
-import { createHash, createPublicKey, verify } from "node:crypto";
+import { createHash, createPublicKey, randomBytes, verify } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import qrcode from "qrcode-terminal";
+
 const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const API_KEY = "AIzaSyBEZ7CYkAgs1OQbFHeZIW_VVPAXMiIz1X8"; // clave de cliente Firestore: pública por diseño
+const COLLECTION_URL = "https://firestore.googleapis.com/v1/projects/karajan-code/databases/(default)/documents/kjSupervisorSign";
+const SIGN_PAGE = "https://karajancode.com/sign";
+const POLL_INTERVAL_MS = 2000;
+const TTL_MS = 120000;
 
 const phoneKeyPath = (home) => join(home ?? homedir(), ".karajan", "supervisor-phone.json");
 
@@ -40,4 +47,56 @@ export function verifyPhoneSignature({ payload, signature, publicKey }) {
   const der = Buffer.concat([SPKI_ED25519_PREFIX, Buffer.from(publicKey, "base64")]);
   const key = createPublicKey({ key: der, format: "der", type: "spki" });
   return verify(null, Buffer.from(payload, "utf8"), key, Buffer.from(signature, "base64"));
+}
+
+/**
+ * Publica la petición en Firestore, enseña QR + URL, pollea el doc y verifica
+ * la firma. Sin fallbacks silenciosos: red caída o HTTP no-ok ⇒ throw. Firma
+ * mala / clave ajena / TTL vencido ⇒ {ok:false, reason}.
+ * @returns {Promise<{ok: boolean, reason?: string}>}
+ */
+export async function requestPhoneSignature({ project, files, kjVersion, logger = console, deps = {} }) {
+  const fetchFn = deps.fetch ?? fetch;
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const drawQr = deps.qr ?? ((url) => qrcode.generate(url, { small: true }));
+  const cid = randomBytes(16).toString("hex");
+  const nonce = randomBytes(16).toString("hex");
+  const body = {
+    fields: {
+      nonce: { stringValue: nonce },
+      project: { stringValue: project },
+      kj_version: { stringValue: kjVersion },
+      state: { stringValue: "pending" },
+      createdAt: { timestampValue: new Date().toISOString() },
+      files: { arrayValue: { values: files.map((f) => ({ mapValue: { fields: { file: { stringValue: f.file }, sha256: { stringValue: f.sha256 ?? "" } } } })) } },
+    },
+  };
+  const created = await fetchFn(`${COLLECTION_URL}?documentId=${cid}&key=${API_KEY}`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+  if (!created.ok) {
+    throw new Error(`phone-sign: no se pudo publicar la petición de firma (HTTP ${created.status}) — sin red no hay sello, no se degrada`);
+  }
+  const signUrl = `${SIGN_PAGE}?c=${cid}`;
+  drawQr(signUrl);
+  logger.info?.(`phone-sign: escanea el QR o abre ${signUrl} y firma en el móvil (caduca en ${TTL_MS / 1000}s)`);
+  const deadline = now() + TTL_MS;
+  while (now() < deadline) {
+    const res = await fetchFn(`${COLLECTION_URL}/${cid}?key=${API_KEY}`);
+    if (!res.ok) throw new Error(`phone-sign: fallo consultando la petición de firma (HTTP ${res.status})`);
+    const fields = (await res.json()).fields ?? {};
+    if (fields.state?.stringValue === "signed") {
+      const enrolled = readEnrolledKey({ home: deps.home });
+      if (fields.publicKey?.stringValue !== enrolled) {
+        return { ok: false, reason: "la publicKey del doc no coincide con la enrolada — el doc es transporte, la verdad es la enrolada" };
+      }
+      const payload = canonicalPayload({ cid, nonce, project, files });
+      const good = verifyPhoneSignature({ payload, signature: fields.signature?.stringValue ?? "", publicKey: enrolled });
+      return good ? { ok: true } : { ok: false, reason: "firma ed25519 inválida para el payload canónico" };
+    }
+    logger.info?.("phone-sign: esperando la firma del móvil…");
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return { ok: false, reason: "caducado" };
 }

--- a/tests/harden/phone-sign.test.js
+++ b/tests/harden/phone-sign.test.js
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-  canonicalPayload, enrollPhone, isPhoneEnrolled, readEnrolledKey, verifyPhoneSignature,
+  canonicalPayload, enrollPhone, isPhoneEnrolled, readEnrolledKey, requestPhoneSignature, verifyPhoneSignature,
 } from "../../src/harden/phone-sign.js";
 
 const FILES = [
@@ -64,5 +64,64 @@ describe("phone-sign core (KJC-TSK-0822)", () => {
     const reordered = canonicalPayload({ cid: CID, nonce: "cafebabe", project: "karajan-code", files: FILES.toReversed() });
     expect(reordered).not.toBe(payload);
     expect(verifyPhoneSignature({ payload: reordered, signature: signPayload(payload), publicKey: rawPub })).toBe(false);
+  });
+});
+
+// Móvil falso: captura cid+nonce de la petición publicada y firma como la app.
+const fakePhone = ({ key = privateKey, pub = rawPub, state = "signed", mangle = (s) => s } = {}) => {
+  const seen = {};
+  return async (url, opts = {}) => {
+    if (opts.method === "POST") {
+      seen.cid = new URL(url).searchParams.get("documentId");
+      seen.nonce = JSON.parse(opts.body).fields.nonce.stringValue;
+      return { ok: true, json: async () => ({}) };
+    }
+    const payload = canonicalPayload({ cid: seen.cid, nonce: seen.nonce, project: "karajan-code", files: FILES });
+    const fields = state === "signed"
+      ? { state: { stringValue: "signed" }, signature: { stringValue: mangle(signPayload(payload, key)) }, publicKey: { stringValue: pub } }
+      : { state: { stringValue: state } };
+    return { ok: true, json: async () => ({ fields }) };
+  };
+};
+
+describe("requestPhoneSignature (KJC-TSK-0822)", () => {
+  let t;
+  beforeEach(() => { t = 0; });
+  const request = (fetchFn) => requestPhoneSignature({
+    project: "karajan-code", files: FILES, kjVersion: "9.9.9", logger: { info: () => {} },
+    deps: { fetch: fetchFn, home, now: () => t, sleep: async (ms) => { t += ms; }, qr: () => {} },
+  });
+
+  it("accepts a REAL signature from the enrolled key over the published cid+nonce", async () => {
+    enrollPhone(rawPub, { home });
+    await expect(request(fakePhone())).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects a tampered signature", async () => {
+    enrollPhone(rawPub, { home });
+    const mangle = (s) => { const b = Buffer.from(s, "base64"); b[0] ^= 1; return b.toString("base64"); };
+    const res = await request(fakePhone({ mangle }));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/firma/);
+  });
+
+  it("rejects a doc publicKey that is not the ENROLLED one — even with a valid signature", async () => {
+    enrollPhone(rawPub, { home });
+    const other = generateKeyPairSync("ed25519");
+    const otherPub = other.publicKey.export({ type: "spki", format: "der" }).subarray(-32).toString("base64");
+    const res = await request(fakePhone({ key: other.privateKey, pub: otherPub }));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/enrolada/);
+  });
+
+  it("expires after 120s of pending state", async () => {
+    enrollPhone(rawPub, { home });
+    await expect(request(fakePhone({ state: "pending" }))).resolves.toEqual({ ok: false, reason: "caducado" });
+    expect(t).toBeGreaterThanOrEqual(120000);
+  });
+
+  it("a dead network fails loudly — no silent fallback", async () => {
+    enrollPhone(rawPub, { home });
+    await expect(request(async () => ({ ok: false, status: 503 }))).rejects.toThrow(/503/);
   });
 });


### PR DESCRIPTION
## KJC-TSK-0822 · carril B · PR 2/3 — petición Firestore + QR + poll

Segunda PR de la serie (PRP-0023), cortada de main tras mergear #1641. `requestPhoneSignature`:

- Publica la petición en `kjSupervisorSign/{cid}` vía Firestore REST (cid = 32 hex de `crypto.randomBytes`), con nonce, project, kj_version, state `pending`, createdAt y los files `{file, sha256}`.
- Pinta el QR en terminal (dep nueva `qrcode-terminal`, **versión fijada 0.12.0**) y la URL `https://karajancode.com/sign?c=<cid>`.
- Pollea cada 2s con TTL de 120s → `{ok:false, reason:'caducado'}`; red caída o HTTP no-ok ⇒ throw alto, jamás silencioso.
- Al llegar `state=signed`: la `publicKey` del doc debe COINCIDIR con la ENROLADA (`~/.karajan/supervisor-phone.json`) — el doc es transporte, la verdad es la enrolada — y la firma ed25519 debe validar el payload canónico.

Tests: móvil falso que firma DE VERDAD (node:crypto) el cid+nonce capturados de la petición publicada; firma alterada, clave no enrolada, pending hasta TTL y red caída.

**Privacy gate — override consciente `KJ_ALLOW_PII=1`**: el gate bloqueó la constante `API_KEY`. Es la apiKey **de cliente** de Firestore (pública por diseño; PRP-0023 manda incrustarla — solo permite hablar con la colección del protocolo, la seguridad real es la verificación contra la clave enrolada). No hay ningún secreto en el diff.

Review: APPROVED by codex (diff b09f19f5dabd); el rebase sobre main no cambió el diff. Sigue: PR 3/3, integración obligatoria en el sello del supervisor.
