### PR TITLE
fix(harden): the relay config leaves the tarball - served by the landing

### DIFF
--- a/apps/landing/public/sign/relay.json
+++ b/apps/landing/public/sign/relay.json
@@ -1,0 +1,5 @@
+{
+  "projectId": "karajan-code",
+  "apiKey": "AIzaSyBEZ7CYkAgs1OQbFHeZIW_VVPAXMiIz1X8",
+  "collection": "kjSupervisorSign"
+}

--- a/src/harden/phone-sign.js
+++ b/src/harden/phone-sign.js
@@ -12,8 +12,24 @@ import { join } from "node:path";
 import qrcode from "qrcode-terminal";
 
 const SPKI_ED25519_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
-const API_KEY = "AIzaSyBEZ7CYkAgs1OQbFHeZIW_VVPAXMiIz1X8"; // clave de cliente Firestore: pública por diseño
-const COLLECTION_URL = "https://firestore.googleapis.com/v1/projects/karajan-code/databases/(default)/documents/kjSupervisorSign";
+// La config del relé (apiKey de cliente Firestore — pública por diseño, la
+// misma que la página firmante lleva incrustada) NO viaja en el tarball: el
+// escáner de privacidad del pack deniega claves google con razón general, y
+// servirla desde la landing la hace además rotable sin release.
+const RELAY_CONFIG_URL = "https://karajancode.com/sign/relay.json";
+let relayCache = null;
+async function relayConfig(fetchFn) {
+  if (relayCache) return relayCache;
+  const res = await fetchFn(RELAY_CONFIG_URL);
+  if (!res.ok) throw new Error(`phone-sign: no pude cargar la config del relé (${res.status}) — revisa la red`);
+  const cfg = await res.json();
+  if (!cfg?.apiKey || !cfg?.projectId || !cfg?.collection) throw new Error("phone-sign: config del relé incompleta");
+  relayCache = {
+    apiKey: cfg.apiKey,
+    url: `https://firestore.googleapis.com/v1/projects/${cfg.projectId}/databases/(default)/documents/${cfg.collection}`,
+  };
+  return relayCache;
+}
 const SIGN_PAGE = "https://karajancode.com/sign";
 const POLL_INTERVAL_MS = 2000;
 const TTL_MS = 120000;
@@ -72,7 +88,8 @@ export async function requestPhoneSignature({ project, files, kjVersion, logger 
       files: { arrayValue: { values: files.map((f) => ({ mapValue: { fields: { file: { stringValue: f.file }, sha256: { stringValue: f.sha256 ?? "" } } } })) } },
     },
   };
-  const created = await fetchFn(`${COLLECTION_URL}?documentId=${cid}&key=${API_KEY}`, {
+  const relay = await relayConfig(fetchFn);
+  const created = await fetchFn(`${relay.url}?documentId=${cid}&key=${relay.apiKey}`, {
     method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
   });
   if (!created.ok) {
@@ -83,7 +100,7 @@ export async function requestPhoneSignature({ project, files, kjVersion, logger 
   logger.info?.(`phone-sign: escanea el QR o abre ${signUrl} y firma en el móvil (caduca en ${TTL_MS / 1000}s)`);
   const deadline = now() + TTL_MS;
   while (now() < deadline) {
-    const res = await fetchFn(`${COLLECTION_URL}/${cid}?key=${API_KEY}`);
+    const res = await fetchFn(`${relay.url}/${cid}?key=${relay.apiKey}`);
     if (!res.ok) throw new Error(`phone-sign: fallo consultando la petición de firma (HTTP ${res.status})`);
     const fields = (await res.json()).fields ?? {};
     if (fields.state?.stringValue === "signed") {

--- a/tests/harden/phone-sign.test.js
+++ b/tests/harden/phone-sign.test.js
@@ -71,6 +71,10 @@ describe("phone-sign core (KJC-TSK-0822)", () => {
 const fakePhone = ({ key = privateKey, pub = rawPub, state = "signed", mangle = (s) => s } = {}) => {
   const seen = {};
   return async (url, opts = {}) => {
+    // La config del relé ya no viaja en el tarball: se sirve desde la landing.
+    if (String(url).endsWith("/sign/relay.json")) {
+      return { ok: true, json: async () => ({ projectId: "karajan-code", apiKey: "test-key", collection: "kjSupervisorSign" }) };
+    }
     if (opts.method === "POST") {
       seen.cid = new URL(url).searchParams.get("documentId");
       seen.nonce = JSON.parse(opts.body).fields.nonce.stringValue;


### PR DESCRIPTION
## KJC-TSK-0822 — la config del relé sale del tarball

El humo del tarball (#1642, check no-required) cayó con razón: el escáner de privacidad del pack deniega claves google, y la apiKey de cliente iba embebida en `src/harden/phone-sign.js`. En vez de agujerear el escáner, la config del relé (apiKey pública + proyecto + colección) se sirve desde la landing (`karajancode.com/sign/relay.json` — la misma fuente de verdad que la página firmante) y kj la carga en runtime con caché: el tarball queda limpio y la clave es rotable sin release. verify-pack local: verde de nuevo.

El override consciente `KJ_ALLOW_PII=1` de esta PR cubre el `relay.json` de la landing (fuera del tarball), donde la clave DEBE estar — es una web API key de cliente, pública por diseño, la misma que ya viaja en la página mergeada en #1639.

Nota operativa del mismo incidente: la dependencia nueva del lockfile tumbó el kj linkado de esta máquina (ERR_MODULE_NOT_FOUND) y afectó a otra sesión — resuelto con npm install; lección para la doctrina de carriles: tras mergear una PR con deps nuevas, npm install inmediato en el clon.

Review: APPROVED (codex, diff 321e4db74919). +30/−4.
