### PR TITLE
fix(harden): ai attribution guarded on every surface

### DIFF
--- a/.github/workflows/kj-no-ai-attribution.yml
+++ b/.github/workflows/kj-no-ai-attribution.yml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - name: Scan commit messages for AI attribution
+      - name: Scan commit messages and PR body for AI attribution
         env:
           BASE_REF: ${{ github.base_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if ! msgs=$(git log --format=%B "origin/${BASE_REF}...HEAD"); then
             echo "::error::cannot resolve origin/${BASE_REF}...HEAD — the scan did not run"; exit 1
@@ -23,6 +25,9 @@ jobs:
           pat="$pat|(generated|written|authored|assisted|powered) (by|with|using) .*(claude|anthropic|openai|copilot|gemini)"
           if printf "%s" "$msgs" | grep -qiE "$pat"; then
             echo "::error::AI attribution detected in commit messages"; exit 1
+          fi
+          if printf "%s\n%s" "$PR_BODY" "$PR_TITLE" | grep -qiE "$pat|generated with \[?claude|🤖"; then
+            echo "::error::AI attribution detected in the PR body or title"; exit 1
           fi
           echo "AI attribution scan: clean"
 

--- a/apps/landing/docs/src/content/docs/guides/sentinel.md
+++ b/apps/landing/docs/src/content/docs/guides/sentinel.md
@@ -51,6 +51,10 @@ The turn cannot end while the method is red: suite failing, unreviewed diffs, pe
 
 Same as the stop gate, at the moment of `git push`: nothing leaves the machine with the method red.
 
+## attribution
+
+AI attribution is forbidden by a deterministic project rule — everywhere, with no escape. Three layers enforce it: the commit-msg hook rejects it in commit messages; the pre-commit hook scans the staged diff's ADDED lines (changelog, docs, code comments — tool *mentions* stay legal, attribution does not); and the Sentinel scans every `gh` command that publishes text (PR/issue/release create, edit, comment, review), including the contents of `--body-file`/`--notes-file` — an unreadable file does not publish either. CI re-checks commits, PR body and title. Born from a real catch: 15 PR bodies shipped an attribution footer because only commit messages were scanned (KJC-BUG-0164).
+
 ## escapes
 
 Every escape, what it skips, and when it is legitimate. All of them: one simple command, one use, recorded in the session state and sealed into the decision log — `kj sentinel status` lists what this session used.

--- a/src/harden/hook-templates.js
+++ b/src/harden/hook-templates.js
@@ -109,6 +109,14 @@ export function hookBody(hook, cmds = {}, { globalHooksDir = null, baseBranch = 
       if (cmds.format) lines.push(`${cmds.format} || { echo 'kj harden: format check failed'; exit 1; }`);
       if (!cmds.lint && !cmds.format) lines.push("# (no lint/format command detected for this stack)");
       lines.push(
+        "# KJC-BUG-0164: attribution is surface EVERYWHERE — the staged diff's",
+        "# ADDED lines (changelog, docs, code comments) are scanned too, with",
+        "# the same precise pattern (tool MENTIONS stay legal; attribution not).",
+        "# The guard's own definition files are excluded by literal path — they",
+        "# CONTAIN the pattern; excluding a path that does not exist is harmless.",
+        `if git diff --cached -- . ':(exclude).github/workflows/kj-no-ai-attribution.yml' ':(exclude)src/harden/hook-templates.js' ':(exclude)src/harden/workflow-templates.js' ':(exclude)src/harden/sentinel-hooks.js' ':(exclude)scripts/ai-attribution-guard.yml' ':(exclude)tests/harden/attribution-guard.test.js' ':(exclude)tests/harden/sentinel-hooks.test.js' | grep '^+' | grep -qiE '${AI_ATTRIBUTION}|generated with \\[?claude'; then`,
+        "  echo 'kj harden: AI attribution is not allowed in committed content'; exit 1",
+        "fi",
         "# v4 review gate (ENV-C1, opt-in via `kj review --install-gate`):",
         "# a staged diff only enters with a recorded cross-AI approved verdict.",
         "if [ -f .karajan/review-gate ]; then",

--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -371,6 +371,32 @@ process.stdin.on("end", () => {
       console.error("karajan sentinel: los ficheros del supervisor no se tocan desde Bash — consultalos con la tool Read/Grep; solo el humano los modifica, fuera de la sesion." + doc("supervisor"));
       process.exit(2);
     }
+    // KJC-BUG-0164: todo gh que PUBLICA texto (pr/issue/release, create/edit/
+    // comment/review) se escanea contra el patron de ATRIBUCION a IA antes de
+    // salir — comando inline Y ficheros --body-file/--notes-file. Regla
+    // determinista del proyecto: prohibido, sin escape. Un fichero ilegible
+    // tampoco publica (fail closed).
+    {
+      // Regex SIN backslashes a proposito (clases de caracteres, emoji
+      // literal): asi la plantilla y el fichero generado son identicos y no
+      // hay doble-escape que leer mal.
+      const ghCmd = String(input.command || "");
+      if (tool === "Bash" && /(^|[^a-zA-Z])gh([^a-zA-Z]|$)/.test(ghCmd) && /(^|[^a-z])(pr|issue|release)([^a-z]|$)/.test(ghCmd) && /(^|[^a-z])(create|edit|comment|review)([^a-z]|$)/.test(ghCmd)) {
+        const attrib = /co-authored-by:.{0,120}(claude|gpt|copilot|gemini)|(generated|written|created) (by|with).{0,120}(claude|gpt|copilot|gemini|codex)|generated with [[]?claude|🤖/is;
+        let corpus = ghCmd;
+        for (const m of ghCmd.matchAll(/--(?:body-file|notes-file|comment-file)[= ]+("([^"]+)"|'([^']+)'|([^ ]+))/g)) {
+          const bodyPath = m[2] || m[3] || m[4];
+          try { corpus += "\\n" + readFileSync(bodyPath, "utf8"); } catch {
+            console.error("karajan sentinel: no puedo leer " + bodyPath + " para el escaneo de atribucion — sin escaneo no se publica." + doc("attribution"));
+            process.exit(2);
+          }
+        }
+        if (attrib.test(corpus)) {
+          console.error("karajan sentinel: atribucion a IA detectada en contenido a PUBLICAR (PR/issue/release) — prohibida por regla determinista del proyecto: limpia el texto." + doc("attribution"));
+          process.exit(2);
+        }
+      }
+    }
     // ADR 0009 (KJC-BUG-0161): kj harden --commit es un ACTO HUMANO — la
     // sesion ni lo intenta. Sin escape (superficie de supervisor). includes()
     // a proposito: cero ambiguedad de escapes en plantilla, y fail-closed

--- a/src/harden/workflow-templates.js
+++ b/src/harden/workflow-templates.js
@@ -36,9 +36,14 @@ export const NO_AI_ATTRIBUTION_WORKFLOW = [
   `      - uses: ${PINNED_ACTIONS.checkout}`,
   "        with:",
   "          fetch-depth: 0",
-  "      - name: Scan commit messages for AI attribution",
+  "      - name: Scan commit messages and PR body for AI attribution",
   "        env:",
   "          BASE_REF: ${{ github.base_ref }}",
+  // KJC-BUG-0164: el cuerpo de la PR tambien es superficie — 15 PRs entraron
+  // con pie de atribucion porque solo se escaneaban commits. Via env, jamas
+  // interpolado en el script (el cuerpo es texto no confiable).
+  "          PR_BODY: ${{ github.event.pull_request.body }}",
+  "          PR_TITLE: ${{ github.event.pull_request.title }}",
   "        run: |",
   '          if ! msgs=$(git log --format=%B "origin/${BASE_REF}...HEAD"); then',
   '            echo "::error::cannot resolve origin/${BASE_REF}...HEAD — the scan did not run"; exit 1',
@@ -47,6 +52,9 @@ export const NO_AI_ATTRIBUTION_WORKFLOW = [
   "          pat=\"$pat|(generated|written|authored|assisted|powered) (by|with|using) .*(claude|anthropic|openai|copilot|gemini)\"",
   '          if printf "%s" "$msgs" | grep -qiE "$pat"; then',
   '            echo "::error::AI attribution detected in commit messages"; exit 1',
+  "          fi",
+  '          if printf "%s\\n%s" "$PR_BODY" "$PR_TITLE" | grep -qiE "$pat|generated with \\[?claude|🤖"; then',
+  '            echo "::error::AI attribution detected in the PR body or title"; exit 1',
   "          fi",
   '          echo "AI attribution scan: clean"',
 ].join("\n");

--- a/tests/harden/attribution-guard.test.js
+++ b/tests/harden/attribution-guard.test.js
@@ -1,0 +1,43 @@
+// KJC-BUG-0164 — la atribución a IA es superficie EN TODAS PARTES, con
+// reglas deterministas: el pre-commit escanea las líneas AÑADIDAS del diff
+// staged (ejecutado de verdad, no leído), y el workflow cubre cuerpo y
+// título de la PR. Las menciones legítimas a herramientas siguen siendo
+// legales; la ATRIBUCIÓN no.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { installHooks } from "../../src/harden/harden-engine.js";
+
+let repo;
+const git = (args, env = {}) =>
+  execFileSync("git", args, { cwd: repo, encoding: "utf8", env: { ...process.env, KJ_ALLOW_IDENTITY: "1", ...env } });
+
+beforeEach(async () => {
+  repo = mkdtempSync(join(tmpdir(), "kj-attrib-"));
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.email", "t@t"]);
+  git(["config", "user.name", "t"]);
+  git(["commit", "-q", "--allow-empty", "-m", "chore: init", "--no-verify"]);
+  git(["checkout", "-q", "-b", "feat/x"]);
+  await installHooks({ projectDir: repo });
+});
+
+afterEach(() => rmSync(repo, { recursive: true, force: true }));
+
+describe("pre-commit scans ADDED content for AI attribution (KJC-BUG-0164)", () => {
+  it("an added line with an attribution footer refuses to commit", () => {
+    writeFileSync(join(repo, "CHANGELOG.md"), "## 1.0\n\n🤖 Generated with [Claude Code](https://x)\n");
+    git(["add", "CHANGELOG.md"]);
+    expect(() => git(["commit", "-q", "-m", "docs: changelog"])).toThrow(/attribution/i);
+  });
+
+  it("a legitimate tool MENTION commits fine", () => {
+    writeFileSync(join(repo, "notes.md"), "El reviewer del metodo es codex y el coder claude.\n");
+    git(["add", "notes.md"]);
+    expect(() => git(["commit", "-q", "-m", "docs: notes"])).not.toThrow();
+  });
+});

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -115,6 +115,26 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
     gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
   });
 
+  it("KJC-BUG-0164: gh que publica con atribucion a IA se deniega — inline, fichero, e ilegible", () => {
+    const bash = (command) => ({ session_id: "s1", tool_name: "Bash", tool_input: { command } });
+    // inline
+    const inline = run(gate, bash('gh pr create --title x --body "Generated with [Claude Code]"'));
+    expect(inline.status).toBe(2);
+    expect(inline.stderr).toMatch(/atribucion/);
+    // fichero sucio
+    const dirty = path.join(dir, "body.md");
+    fs.writeFileSync(dirty, "Todo bien.\n\nCo-Authored-By: Claude <x@y>\n");
+    expect(run(gate, bash(`gh pr create --title x --body-file ${dirty}`)).status).toBe(2);
+    // fichero ilegible: sin escaneo no se publica
+    expect(run(gate, bash("gh pr create --title x --body-file /no/existe.md")).status).toBe(2);
+    // limpio: pasa
+    const clean = path.join(dir, "clean.md");
+    fs.writeFileSync(clean, "Cuerpo normal usando codex como reviewer del metodo.\n");
+    expect(run(gate, bash(`gh pr create --title x --body-file ${clean}`)).status).toBe(0);
+    // gh de lectura: ni se mira
+    expect(run(gate, bash("gh pr view 12 --json state")).status).toBe(0);
+  });
+
   it("ADR 0009: kj harden --commit es acto humano — la sesion lo tiene denegado SIN escape", () => {
     for (const command of ["kj harden --commit", "KJ_ALLOW_CROSS_LANE=1 kj harden --profile strict --commit"]) {
       const blocked = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command } });

--- a/tests/harden/workflow-engine.test.js
+++ b/tests/harden/workflow-engine.test.js
@@ -33,6 +33,10 @@ describe("installWorkflows", () => {
     // FAIL the job — swallowing it would pass the scan on an empty corpus.
     expect(text).not.toContain("|| true");
     expect(text).toContain("cannot resolve origin/");
+    // KJC-BUG-0164: the PR body is attribution surface too — via env (never
+    // interpolated into the script: untrusted text), scanned with the pattern.
+    expect(text).toContain("PR_BODY: ${{ github.event.pull_request.body }}");
+    expect(text).toContain("AI attribution detected in the PR body");
   });
 
   it("is idempotent", () => {


### PR DESCRIPTION
## KJC-BUG-0164 — la atribución a IA, prohibida por reglas DETERMINISTAS en todas las superficies

Orden del usuario tras cazar 15 cuerpos de PR con pie de atribución (aplicado por la IA siguiendo una instrucción por defecto de su harness que la regla del proyecto invalida; el guard existente solo cubría mensajes de commit): «En memoria no me vale. Reglas deterministas. Y si puede ocurrir en más sitios, hay que añadirlo.»

Las superficies, cubiertas:

- **Mensajes de commit**: ya existía (commit-msg + CI) — intacto.
- **Contenido commiteado** (CHANGELOG, docs, comentarios de código): el pre-commit escanea las líneas AÑADIDAS del diff staged con el patrón preciso — las MENCIONES a herramientas siguen siendo legales (el producto integra claude/codex); la ATRIBUCIÓN no. Los ficheros que definen el propio patrón se excluyen por ruta literal (se auto-cazó dos veces durante el desarrollo: la exclusión manta de tests que codex estrechó, y el propio sentinel-hooks.js que faltaba).
- **Todo `gh` que publica texto** (pr/issue/release × create/edit/comment/review): el Sentinel escanea el comando inline Y los `--body-file`/`--notes-file` ANTES de publicar; un fichero ilegible tampoco publica (fail closed). Sin escape. Regex deliberadamente sin backslashes (clases de caracteres, emoji literal) tras el arbitraje: cero ambigüedad de escapes en plantilla.
- **CI**: cuerpo Y título de la PR (vía env, jamás interpolado — texto no confiable), además de los commits.
- Página del Sentinel: ancla `#attribution` nueva que los mensajes enlazan.

Como todo esto vive en las plantillas de kj, **cada proyecto que instale karajan hereda los guards** al hacer harden. Remediación previa: los 15 cuerpos ya limpiados vía REST.

Tests ejecutables (los hooks GENERADOS corriendo de verdad): commit con atribución añadida rechaza; mención legítima pasa; gh con atribución inline/fichero/ilegible deniega; limpio y solo-lectura pasan. Suites del guard: verdes. Review: APPROVED (codex, diff e2ba2e4e43b5) con dos catches suyos absorbidos.
