### PR TITLE
fix(harden): enrolling the phone key is a human act too

### DIFF
--- a/src/harden/sentinel-hooks.js
+++ b/src/harden/sentinel-hooks.js
@@ -371,6 +371,18 @@ process.stdin.on("end", () => {
       console.error("karajan sentinel: los ficheros del supervisor no se tocan desde Bash — consultalos con la tool Read/Grep; solo el humano los modifica, fuera de la sesion." + doc("supervisor"));
       process.exit(2);
     }
+    // KJC-TSK-0822 v1.1: enrolar (o pisar) la clave del movil es acto humano
+    // — si un agente pudiera enrolar una clave SUYA, contestaria la capa 5 el
+    // solo. Ni el comando ni el fichero de enrolamiento desde la sesion.
+    {
+      const enrollCmd = String(input.command || "");
+      const namesEnroll = (enrollCmd.includes("identity") && enrollCmd.includes("enroll-phone")) || enrollCmd.includes("supervisor-phone.json");
+      const writesEnroll = EDIT_TOOLS.includes(tool) && String(input.file_path || "").includes("supervisor-phone.json");
+      if ((tool === "Bash" && namesEnroll) || writesEnroll) {
+        console.error("karajan sentinel: el enrolamiento del movil (capa 5) es un acto humano — pideselo a tu usuario; supervisor-phone.json no se toca desde la sesion." + doc("supervisor"));
+        process.exit(2);
+      }
+    }
     // ADR 0009 (KJC-BUG-0161): kj harden --commit es un ACTO HUMANO — la
     // sesion ni lo intenta. Sin escape (superficie de supervisor). includes()
     // a proposito: cero ambiguedad de escapes en plantilla, y fail-closed

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -115,6 +115,17 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
     gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
   });
 
+  it("KJC-TSK-0822 v1.1: enrolar la clave del movil es acto humano — comando y fichero denegados", () => {
+    const bash = (command) => ({ session_id: "s1", tool_name: "Bash", tool_input: { command } });
+    expect(run(gate, bash("kj identity enroll-phone QUJDRA==")).status).toBe(2);
+    expect(run(gate, bash("cat /home/x/.karajan/supervisor-phone.json")).status).toBe(2);
+    const w = run(gate, { session_id: "s1", tool_name: "Write", tool_input: { file_path: "/home/x/.karajan/supervisor-phone.json", content: "{}" } });
+    expect(w.status).toBe(2);
+    expect(w.stderr).toMatch(/acto humano/);
+    // kj identity show sigue permitido
+    expect(run(gate, bash("kj identity show")).status).toBe(0);
+  });
+
   it("ADR 0009: kj harden --commit es acto humano — la sesion lo tiene denegado SIN escape", () => {
     for (const command of ["kj harden --commit", "KJ_ALLOW_CROSS_LANE=1 kj harden --profile strict --commit"]) {
       const blocked = run(gate, { session_id: "s1", tool_name: "Bash", tool_input: { command } });

--- a/tests/harden/sentinel-hooks.test.js
+++ b/tests/harden/sentinel-hooks.test.js
@@ -115,6 +115,7 @@ describe("pretooluse-sentinel script (stateful gate — the rule fires BEFORE th
     gate = path.join(dir, ".karajan", "harness", "pretooluse-sentinel.mjs");
   });
 
+  // (sha refrescado el 6-sep: Actions no entregó el evento del push original)
   it("KJC-TSK-0822 v1.1: enrolar la clave del movil es acto humano — comando y fichero denegados", () => {
     const bash = (command) => ({ session_id: "s1", tool_name: "Bash", tool_input: { command } });
     expect(run(gate, bash("kj identity enroll-phone QUJDRA==")).status).toBe(2);


### PR DESCRIPTION
KJC-TSK-0822 v1.1 — cierra el residual v1 documentado en la card: un agente podía borrar o PISAR el enrolamiento con una clave suya y contestar la capa 5 él solo (ventana usada conscientemente esta noche para el E2E técnico, con Chrome de escritorio como sustituto del móvil — resultado `ok:true` por el circuito real desplegado: desafío en Firestore → página real → firma Ed25519 en el navegador → relé → verificación en kj contra la clave enrolada).

Ahora el Sentinel deniega en sesión el comando de enrolamiento y cualquier Bash/Write que nombre el fichero de la clave; `kj identity show` sigue libre. Autoprobado en vivo: bloqueó el comando que intentaba crear esta misma PR por citar el nombre del fichero.

Tests ejecutables sobre el hook generado. Review: APPROVED (codex, diff c38e984f1628). +23 netas.
